### PR TITLE
fix(api-manifest): resolve namespace qualifiers in API.md drift check (no false-green on duplicate bare vars) (rf2-41j0a)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -19,12 +19,35 @@
   Keyword rows (`:rf.http/managed`, `:rf/route`, …) and prose-celled rows
   are skipped — they are not vars and carry no Tier-for-a-var.
 
-  NAME NORMALISATION. API.md writes some var names namespace-qualified
-  (`helix-adapter/adapter`, `re-frame.http/get`, `re-frame.interop/...`).
-  We normalise to the bare var name and resolve it against the manifest by
-  var-name (the manifest is keyed by namespace+var, but a bare API.md row
-  is unambiguous in practice — and where a name is genuinely ambiguous we
-  match if ANY manifest row with that var-name carries the stated tier).
+  QUALIFIER RESOLUTION (rf2-41j0a). API.md writes some var names
+  namespace-qualified (`helix-adapter/adapter`, `re-frame.http/get`,
+  `re-frame.interop/debug-enabled?`) and others bare (`reg-event-db`). The
+  two SHAPES resolve against DIFFERENT manifest indexes, because they carry
+  different identity — exactly the rf2-0u8kz lesson the Xray-spec check
+  already pins:
+
+    - A QUALIFIED row names BOTH a namespace (or its documented `:as`
+      alias) AND a var. It resolves STRICTLY against the `[namespace var]`
+      index — resolving by bare var alone is unsound, because the manifest
+      carries the SAME `:var \"adapter\"` for FOUR distinct namespaces
+      (`re-frame.adapter.{reagent,uix,helix}` at tier `:adapter`, plus
+      `re-frame.ssr` at `:internal-public`). A bare-`:var` match would let
+      a qualified row drift to a stale/wrong/unknown qualifier
+      (`uix-adapter/adapter` → `bogus-adapter/adapter`) and still pass the
+      moment ANY manifest row with bare name `adapter` carried the stated
+      tier — a false-green drift gate. The qualifier is first resolved to
+      an EXACT manifest namespace: a documented adapter `:as` alias via
+      `adapter-aliases`, otherwise the qualifier verbatim (the
+      full-namespace rows `re-frame.http/...`, `re-frame.interop/...`,
+      `re-frame.performance/...` ARE literal manifest namespaces). A
+      qualifier that resolves to neither a known alias nor a manifest
+      namespace+var pair fails as a wrong/unknown qualifier.
+
+    - A BARE row names only a var. It keeps the original name-resolution
+      latitude: it resolves if ANY manifest row with that var-name carries
+      the stated tier (a bare API.md row is unambiguous in practice), and
+      its knowingly-unmanifested allowlist (`:api-md-known-unmanifested`)
+      is keyed by bare var-name.
 
   TIER ALIASES. A handful of API.md rows state a tier in the Tier cell as
   prose-with-the-tier-word (e.g. `— (fx-id; follows the advanced HTTP
@@ -57,15 +80,34 @@
   [cell]
   (boolean (re-find #"^(Fn|M|Var|Component)\b" (str/trim cell))))
 
-(defn- bare-var-name
-  "Normalise an API.md first-cell identifier to its bare var name:
-   `helix-adapter/adapter` -> `adapter`, `re-frame.http/get` -> `get`,
-   `reg-event-db` -> `reg-event-db`."
+(def adapter-aliases
+  "The documented `:require [<ns> :as <alias>]` adapter aliases API.md uses
+   to qualify the substrate-adapter surfaces (spec/API.md §UIx adapter /
+   §Helix adapter prose). A qualified API.md row written with one of these
+   aliases resolves to the EXACT manifest namespace named here — never by
+   bare var name (the `adapter` / `flush-views!` / … vars are carried for
+   all three adapter namespaces, so a bare match would not distinguish
+   them). The alias→namespace shape is regular (`<x>-adapter` ->
+   `re-frame.adapter.<x>`); it is spelled out so the contract is explicit
+   and a new adapter alias is an intentional one-line addition."
+  {"reagent-adapter" "re-frame.adapter.reagent"
+   "uix-adapter"     "re-frame.adapter.uix"
+   "helix-adapter"   "re-frame.adapter.helix"})
+
+(defn- parse-first-cell-ident
+  "Split an API.md first-cell identifier into `[qualifier bare-var]`. For a
+   QUALIFIED ident the qualifier is everything before the last `/`
+   (`helix-adapter/adapter` -> `[\"helix-adapter\" \"adapter\"]`,
+   `re-frame.http/get` -> `[\"re-frame.http\" \"get\"]`); for a BARE ident
+   the qualifier is nil (`reg-event-db` -> `[nil \"reg-event-db\"]`). The
+   qualifier is PRESERVED (not stripped) so a qualified row can be resolved
+   strictly against the manifest's `[namespace var]` index — see the ns
+   docstring's QUALIFIER RESOLUTION note (rf2-41j0a)."
   [ident]
   (let [s (str/trim ident)]
     (if-let [i (str/last-index-of s "/")]
-      (subs s (inc i))
-      s)))
+      [(subs s 0 i) (subs s (inc i))]
+      [nil s])))
 
 (defn- table-row-cells
   "Split a markdown `| a | b | c |` row into trimmed cell strings, or nil
@@ -91,9 +133,13 @@
   (first (keep-indexed (fn [i c] (when (= "Tier" (str/trim c)) i)) cells)))
 
 (defn parse-api-md-var-rows
-  "Parse spec/API.md and return `[{:var <bare-name> :tier <kw> :line <n>
-   :raw <first-cell>} ...]` for every VAR-row found in any table that has
-   a `Tier` column.
+  "Parse spec/API.md and return `[{:var <bare-name> :qualifier <ns-or-alias
+   or nil> :tier <kw> :line <n> :raw <first-cell>} ...]` for every VAR-row
+   found in any table that has a `Tier` column. `:qualifier` is the
+   namespace/alias prefix for a qualified row (`helix-adapter`,
+   `re-frame.http`) or nil for a bare row — preserved so qualified rows can
+   resolve strictly against the manifest `[namespace var]` index
+   (rf2-41j0a).
 
    We track the CURRENT table's `Tier` column index (from its header row)
    and read the tier from EXACTLY that cell — not by scanning every cell,
@@ -126,14 +172,71 @@
               (if (and tier-idx m (var-kind-marker? kind-cell)
                        (< tier-idx (count cells)))
                 (if-let [tier (first-tier-token (nth cells tier-idx))]
-                  (recur more tier-idx
-                         (conj! acc {:var  (bare-var-name (second m))
-                                     :tier tier
-                                     :line n
-                                     :raw  (second m)}))
+                  (let [[qualifier bare] (parse-first-cell-ident (second m))]
+                    (recur more tier-idx
+                           (conj! acc {:var       bare
+                                       :qualifier qualifier
+                                       :tier      tier
+                                       :line      n
+                                       :raw       (second m)})))
                   (recur more tier-idx acc))
                 (recur more tier-idx acc)))))
         (persistent! acc)))))
+
+(defn reconcile
+  "Pure reconciler (rf2-41j0a — extracted so the qualifier-resolution
+   contract is unit-testable with synthetic inputs). Returns the seq of
+   problem maps for the supplied API.md var-rows.
+
+   `rows`               — manifest rows (each `{:namespace :var :tier ...}`).
+   `api-rows`           — parsed API.md var-rows `{:var :qualifier :tier
+                          :line :raw}` (`:qualifier` nil for a bare row).
+   `known-unmanifested` — set of bare var-name strings knowingly
+                          unmanifested (the `:api-md-known-unmanifested`
+                          allowlist; bare rows only).
+   `aliases`            — `{alias -> namespace}` for documented adapter
+                          `:as` aliases (`adapter-aliases`).
+
+   QUALIFIED rows resolve STRICTLY against the `[namespace var] -> #{tiers}`
+   index after mapping the qualifier through `aliases` (else verbatim) — a
+   qualifier that does not resolve to a manifest `[namespace var]` pair is
+   `:missing` (this is what catches a stale/wrong/unknown qualifier on a
+   duplicate bare var). BARE rows keep the name-resolution latitude: any
+   manifest row with the bare name carrying the tier satisfies them, and
+   the bare-name allowlist applies."
+  [{:keys [rows api-rows known-unmanifested aliases]}]
+  (let [;; bare var-name -> set of tiers the manifest carries for that name
+        by-name (reduce (fn [acc {:keys [var tier]}]
+                          (update acc var (fnil conj #{}) tier))
+                        {} rows)
+        ;; strict [namespace var] -> set of tiers (a [ns var] pair is unique
+        ;; in the manifest, so each set is a singleton — but a set keeps the
+        ;; not-contains? tier check uniform with the bare path).
+        by-ns+var (reduce (fn [acc {:keys [namespace var tier]}]
+                            (update acc [namespace var] (fnil conj #{}) tier))
+                          {} rows)]
+    (keep (fn [{:keys [var qualifier tier line raw]}]
+            (if qualifier
+              ;; QUALIFIED: resolve the qualifier to an exact namespace,
+              ;; then require an exact [namespace var] manifest pair.
+              (let [ns'   (get aliases qualifier qualifier)
+                    tiers (get by-ns+var [ns' var])]
+                (cond
+                  (nil? tiers)
+                  {:kind :missing :var var :raw raw :line line :api-tier tier}
+                  (not (contains? tiers tier))
+                  {:kind :tier-mismatch :var var :raw raw :line line
+                   :api-tier tier :manifest-tiers tiers}))
+              ;; BARE: original by-name latitude + bare-name allowlist.
+              (let [tiers (get by-name var)]
+                (cond
+                  (contains? known-unmanifested var) nil
+                  (nil? tiers)
+                  {:kind :missing :var var :raw raw :line line :api-tier tier}
+                  (not (contains? tiers tier))
+                  {:kind :tier-mismatch :var var :raw raw :line line
+                   :api-tier tier :manifest-tiers tiers}))))
+          api-rows)))
 
 (defn check!
   "Validate spec/API.md var-rows against the manifest. Returns true when
@@ -142,25 +245,14 @@
   []
   (let [manifest   (gen/read-committed-manifest)
         rows       (:vars manifest)
-        ;; var-name -> set of tiers the manifest carries for that name
-        by-name    (reduce (fn [acc {:keys [var tier]}]
-                             (update acc var (fnil conj #{}) tier))
-                           {} rows)
         ;; API.md var-rows the sidecar marks as knowingly-unmanifested
         ;; (post-v1-lib surfaces the reference impl does not yet ship).
         known-unmanifested (set (:api-md-known-unmanifested (gen/read-sidecar)))
         api-rows   (parse-api-md-var-rows)
-        problems
-        (keep (fn [{:keys [var tier line raw]}]
-                (let [tiers (get by-name var)]
-                  (cond
-                    (contains? known-unmanifested var) nil
-                    (nil? tiers)
-                    {:kind :missing :var var :raw raw :line line :api-tier tier}
-                    (not (contains? tiers tier))
-                    {:kind :tier-mismatch :var var :raw raw :line line
-                     :api-tier tier :manifest-tiers tiers})))
-              api-rows)]
+        problems   (reconcile {:rows               rows
+                               :api-rows           api-rows
+                               :known-unmanifested known-unmanifested
+                               :aliases            adapter-aliases})]
     (if (empty? problems)
       (do (println (format "OK: spec/API.md projection in sync (%d var-rows checked against the manifest)."
                            (count api-rows)))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -1,0 +1,158 @@
+(ns re-frame.api-manifest.api-md-check-test
+  "Regression tests for the spec/API.md projection check's qualifier
+  resolution (rf2-41j0a).
+
+  THE BUG. The API.md var-row validator stripped any namespace/alias
+  qualifier from the documented var name and matched by BARE var name only;
+  the manifest lookup was also keyed by bare var. The manifest carries the
+  SAME bare var `adapter` for FOUR distinct namespaces
+  (`re-frame.adapter.{reagent,uix,helix}` at tier `:adapter`, plus
+  `re-frame.ssr` at `:internal-public`). So a QUALIFIED row such as
+  `uix-adapter/adapter` could drift to a stale / wrong / unknown qualifier
+  (`bogus-adapter/adapter`) and STILL pass, because some other manifest
+  entry with bare name `adapter` carried the expected tier — a false-green
+  drift gate.
+
+  THE FIX. Qualified rows resolve STRICTLY against the manifest
+  `[namespace var]` index: the qualifier is mapped through the documented
+  adapter `:as` aliases (`adapter-aliases`) else taken verbatim (the
+  full-namespace `re-frame.http/...` rows ARE literal manifest
+  namespaces), and the resolved `[namespace var]` pair must exist with a
+  matching tier. Bare rows keep the original by-bare-name latitude + the
+  bare-name allowlist. These tests pin that contract through the pure
+  `reconcile` reconciler with synthetic inputs, plus a live smoke that the
+  committed spec/API.md + manifest still reconcile clean."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.api-manifest.api-md-check :as c]))
+
+;; A minimal synthetic manifest reproducing the EXACT ambiguity the real
+;; manifest has: the bare var `adapter` carried for four namespaces, three
+;; of them at tier :adapter and one (SSR) at :internal-public. Plus an
+;; intentionally-bare var (`reg-event-db`) for the bare-row path.
+(def ^:private synthetic-rows
+  [{:namespace "re-frame.adapter.reagent" :var "adapter" :tier :adapter}
+   {:namespace "re-frame.adapter.uix"     :var "adapter" :tier :adapter}
+   {:namespace "re-frame.adapter.helix"   :var "adapter" :tier :adapter}
+   {:namespace "re-frame.ssr"             :var "adapter" :tier :internal-public}
+   {:namespace "re-frame.http"            :var "get"     :tier :advanced}
+   {:namespace "re-frame.core"            :var "reg-event-db" :tier :front-porch}])
+
+(defn- problems-for
+  "Run `reconcile` over `api-rows` against the synthetic manifest, with the
+   real `adapter-aliases` and an optional bare-name allowlist."
+  [api-rows & {:keys [known-unmanifested]
+               :or   {known-unmanifested #{}}}]
+  (c/reconcile {:rows               synthetic-rows
+                :api-rows           api-rows
+                :known-unmanifested known-unmanifested
+                :aliases            c/adapter-aliases}))
+
+;; ---------------------------------------------------------------------------
+;; Qualified-row resolution.
+;; ---------------------------------------------------------------------------
+
+(deftest qualified-alias-row-resolves-by-exact-ns+var
+  (testing "a live aliased adapter row resolves clean against its EXACT
+            [namespace var] manifest pair"
+    (is (empty? (problems-for
+                  [{:var "adapter" :qualifier "uix-adapter" :tier :adapter
+                    :line 185 :raw "uix-adapter/adapter"}]))
+        "uix-adapter -> re-frame.adapter.uix; [re-frame.adapter.uix adapter]
+         carries :adapter — must pass")))
+
+(deftest qualified-full-namespace-row-resolves-verbatim
+  (testing "a full-namespace qualifier (not an alias) resolves verbatim"
+    (is (empty? (problems-for
+                  [{:var "get" :qualifier "re-frame.http" :tier :advanced
+                    :line 349 :raw "re-frame.http/get"}]))
+        "re-frame.http is a literal manifest namespace — [re-frame.http get]
+         carries :advanced")))
+
+(deftest unknown-qualifier-on-duplicate-bare-var-fails
+  (testing "THE BUG (rf2-41j0a): a qualified duplicate bare var changed to an
+            UNKNOWN/WRONG qualifier FAILS, even though another adapter var
+            with the same bare name and tier still exists"
+    ;; `uix-adapter/adapter` mutated to `bogus-adapter/adapter`. `bogus-adapter`
+    ;; is neither a documented alias nor a manifest namespace, so
+    ;; [<bogus> adapter] is absent — even though re-frame.adapter.{reagent,
+    ;; uix,helix}/adapter all still carry :adapter. The OLD bare-name match
+    ;; would have PASSED this (some `adapter` row carries :adapter).
+    (let [problems (problems-for
+                     [{:var "adapter" :qualifier "bogus-adapter" :tier :adapter
+                       :line 185 :raw "bogus-adapter/adapter"}])]
+      (is (= 1 (count problems))
+          "the wrong/unknown qualifier must be flagged despite the bare var
+           `adapter` carrying :adapter on three real namespaces")
+      (is (= :missing (:kind (first problems))))
+      (is (= "bogus-adapter/adapter" (:raw (first problems))))
+      (is (= 185 (:line (first problems)))))))
+
+(deftest wrong-but-real-namespace-qualifier-with-mismatched-tier-fails
+  (testing "a qualifier that resolves to a REAL [ns var] pair whose tier
+            disagrees with the API.md tier is a tier-mismatch, not a pass"
+    ;; re-frame.ssr/adapter exists but at :internal-public, not :adapter.
+    ;; A qualified row claiming :adapter for it must fail on tier even
+    ;; though the [ns var] pair resolves.
+    (let [problems (problems-for
+                     [{:var "adapter" :qualifier "re-frame.ssr" :tier :adapter
+                       :line 314 :raw "re-frame.ssr/adapter"}])]
+      (is (= 1 (count problems)))
+      (is (= :tier-mismatch (:kind (first problems))))
+      (is (= #{:internal-public} (:manifest-tiers (first problems)))))))
+
+(deftest qualifier-does-not-mask-via-bare-name
+  (testing "the qualified path NEVER falls back to bare-name latitude: a
+            qualified row whose [ns var] is absent fails even when the bare
+            name is in the bare-name allowlist (the allowlist is bare-only)"
+    ;; Even if `adapter` were on the bare allowlist, a qualified row with a
+    ;; non-resolving qualifier still fails — the allowlist only silences
+    ;; BARE rows.
+    (is (= 1 (count (problems-for
+                      [{:var "adapter" :qualifier "bogus-adapter" :tier :adapter
+                        :line 1 :raw "bogus-adapter/adapter"}]
+                      :known-unmanifested #{"adapter"})))
+        "a bare-name allowlist entry must not silence a qualified row")))
+
+;; ---------------------------------------------------------------------------
+;; Bare-row resolution (unchanged latitude).
+;; ---------------------------------------------------------------------------
+
+(deftest bare-row-resolves-by-bare-name
+  (testing "a bare row resolves if ANY manifest row with that bare name
+            carries the stated tier"
+    (is (empty? (problems-for
+                  [{:var "reg-event-db" :qualifier nil :tier :front-porch
+                    :line 1 :raw "reg-event-db"}])))
+    (testing "and an unmanifested bare name is flagged unless allowlisted"
+      (is (= 1 (count (problems-for
+                        [{:var "story-view" :qualifier nil :tier :tooling
+                          :line 1 :raw "story-view"}]))))
+      (is (empty? (problems-for
+                    [{:var "story-view" :qualifier nil :tier :tooling
+                      :line 1 :raw "story-view"}]
+                    :known-unmanifested #{"story-view"}))))))
+
+(deftest bare-row-tier-mismatch-flagged
+  (testing "a bare row whose stated tier no manifest row with that name
+            carries is a tier-mismatch"
+    (let [problems (problems-for
+                     [{:var "reg-event-db" :qualifier nil :tier :tooling
+                       :line 1 :raw "reg-event-db"}])]
+      (is (= 1 (count problems)))
+      (is (= :tier-mismatch (:kind (first problems))))
+      (is (= #{:front-porch} (:manifest-tiers (first problems)))))))
+
+;; ---------------------------------------------------------------------------
+;; Live smoke: the committed spec/API.md + manifest reconcile clean.
+;; ---------------------------------------------------------------------------
+
+(deftest live-api-md-and-manifest-reconcile-clean
+  (testing "the committed spec/API.md projection reconciles against the
+            committed manifest with zero problems (the CI contract), and it
+            actually exercises qualified rows"
+    (let [api-rows (c/parse-api-md-var-rows)]
+      (is (pos? (count (filter :qualifier api-rows)))
+          "spec/API.md must actually name namespace/alias-qualified var-rows
+           (otherwise this regression would be vacuous)")
+      (is (true? (c/check!))
+          "live drift: spec/API.md var-rows disagree with the manifest"))))


### PR DESCRIPTION
@-