### PR TITLE
fix(examples/_shared): scope websocket text-input rule so it no longer blows out the Cells grid (rf2-gv5xd)

### DIFF
--- a/examples/_shared/css/structure.css
+++ b/examples/_shared/css/structure.css
@@ -152,7 +152,7 @@ dl.boot-summary dd { margin: 0; }
   align-items: center;
 }
 
-input[type="text"] {
+.send-form input[type="text"] {
   padding: 8px 12px;
   flex: 1;
   min-width: 240px;

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -368,6 +368,39 @@ function checkSharedTree(io, opts = {}) {
       );
     }
   }
+
+  // CSS-cascade contract (rf2-gv5xd): the WebSocket send-form text-input
+  // baseline (padding/flex/min-width:240px) MUST stay scoped to the
+  // `.send-form` so it cannot leak into other examples. Component-specific
+  // sizing lives behind a component selector, never as a global element rule.
+  // The 7GUIs Cells example renders each inline editor as a text input inside
+  // `.cells-grid`; a bare global `input[type="text"] { min-width: 240px }`
+  // would override the intended compact `.cells-grid input { width: 56px }`
+  // and blow the spreadsheet grid out to >=240px columns. A static cascade
+  // check, since the asset gate cannot observe layout.
+  const structurePath = path.join(sharedRoot, 'css', 'structure.css');
+  const structure = readFileSafe(io, structurePath);
+  if (structure != null) {
+    // A bare `input[type="text"]` selector (no class/id/attribute qualifier
+    // to its LEFT) is global; the send-form baseline must be qualified.
+    if (/(^|[},;])\s*input\[type=(["'])text\2\]\s*\{/m.test(structure)) {
+      errors.push(
+        `examples/_shared/css/structure.css: the WebSocket text-input ` +
+          `baseline is a GLOBAL 'input[type="text"]' rule. It sets ` +
+          `min-width:240px on EVERY text input in EVERY example and blows ` +
+          `out the 7GUIs Cells grid (whose inline editors are text inputs ` +
+          `inside .cells-grid intended at width:56px). Scope it to the send ` +
+          `form (e.g. '.send-form input[type="text"]') — see rf2-gv5xd.`,
+      );
+    }
+    // The Cells grid editor must keep its compact width.
+    if (!/\.cells-grid\s+input\s*\{[^}]*width:\s*56px/m.test(structure)) {
+      errors.push(
+        `examples/_shared/css/structure.css: the '.cells-grid input' rule ` +
+          `must pin the compact 'width: 56px' cell-editor size (rf2-gv5xd).`,
+      );
+    }
+  }
   return errors;
 }
 

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -91,6 +91,18 @@ it('LIVE: the real _shared source tree is intact (style.css -> structure.css)', 
   );
 });
 
+it('LIVE: the send-form text-input baseline is scoped, not a global input[type=text] (rf2-gv5xd)', () => {
+  // The real structure.css must NOT carry a bare global `input[type="text"]`
+  // rule (it leaks min-width:240px into the 7GUIs Cells inline editors and
+  // blows the grid out), and `.cells-grid input` must keep width:56px.
+  const errors = checkSharedTree(require('fs'));
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `_shared CSS-cascade contract errors:\n` + errors.map((e) => `    - ${e}`).join('\n'),
+  );
+});
+
 it('LIVE: TodoMVC is the encoded style.css opt-out (allowlist, not a regression)', () => {
   const key = 'examples/reagent/todomvc/index.html';
   const entry = ALLOWLIST[key];
@@ -382,6 +394,60 @@ it('TEETH: a stale exemption (page DOES reference the exempt asset) is flagged',
   assert.ok(
     errors.some((e) => e.includes('stale exemption')),
     `expected a stale-exemption error, got: ${errors.join(' | ')}`,
+  );
+});
+
+// ---- TEETH: CSS-cascade contract (rf2-gv5xd) ----------------------------
+
+// A minimal _shared/css io: style.css @imports structure.css; structure.css
+// contents are supplied per-test so we can pin the cascade check both ways.
+const SHARED_ROOT = path.join(EXAMPLES_ROOT, '_shared');
+function sharedCssIo(structureCss) {
+  return makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: "@import url('structure.css');",
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]: structureCss,
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
+  });
+}
+const SCOPED_SENDFORM =
+  '.send-form input[type="text"] { padding: 8px 12px; flex: 1; min-width: 240px; }';
+const CELLS_INPUT = '.cells-grid input { width: 56px; box-sizing: border-box; }';
+
+it('TEETH: a bare global input[type="text"] rule is flagged (Cells blowout)', () => {
+  const bad = 'input[type="text"] { min-width: 240px; }\n' + CELLS_INPUT;
+  const errors = checkSharedTree(sharedCssIo(bad), { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('GLOBAL') && e.includes('input[type="text"]')),
+    `expected a global-text-input error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: the scoped .send-form input[type="text"] form scans clean', () => {
+  const good = SCOPED_SENDFORM + '\n' + CELLS_INPUT;
+  const errors = checkSharedTree(sharedCssIo(good), { sharedRoot: SHARED_ROOT });
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `scoped send-form CSS should scan clean, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: a single-quoted bare global input[type=text] is also flagged', () => {
+  const bad = "input[type='text'] { min-width: 240px; }\n" + CELLS_INPUT;
+  const errors = checkSharedTree(sharedCssIo(bad), { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('GLOBAL')),
+    `single-quoted bare rule must also be flagged, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: dropping the compact .cells-grid input width:56px is flagged', () => {
+  const bad = SCOPED_SENDFORM + '\n.cells-grid input { box-sizing: border-box; }';
+  const errors = checkSharedTree(sharedCssIo(bad), { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('width: 56px')),
+    `expected a missing-cells-width error, got: ${errors.join(' | ')}`,
   );
 });
 


### PR DESCRIPTION
## Summary

`examples/_shared/css/structure.css:155` defined the WebSocket send-form text-input baseline as a **global** `input[type="text"]` rule (`padding: 8px 12px; flex: 1; min-width: 240px`). Despite living under the `/* WebSocket example specifics */` section, the selector was unscoped, so it styled **every** text input in **every** example.

The 7GUIs Cells example renders each inline cell editor as a text input (`examples/reagent/seven_guis/cells/core.cljs:288`) inside `.cells-grid`. The shared CSS intends those at `width: 56px` (`structure.css:211`), but `.cells-grid input` never reset `min-width`, so the global `min-width: 240px` won the cascade — opening any cell editor expanded that cell/column to >=240px and blew out the compact A1..Z100 spreadsheet grid.

## Fix

Scope the rule to `.send-form input[type="text"]` — it now applies only to the WebSocket send form, exactly where its surrounding comment already says it belongs, and can no longer leak into Cells or any other example. No `.cells-grid` override needed once the global rule is gone; the compact `width: 56px` cell editor wins on its own.

Verified no other example relied on the global rule for required sizing: login uses scoped `.login-form input`; all other text inputs (crud, flight_booker, temperature, todomvc, nine_states, realworld) only ever needed the typography baseline from `style.css`'s `input, textarea, select` rule, which is untouched.

## Regression guard (static, no browser)

Extended the existing examples asset gate (`examples/scripts/check-examples-assets.cjs` `checkSharedTree`) with a static CSS-cascade assertion: it flags any bare global `input[type="text"]` rule in `structure.css` and requires `.cells-grid input` to keep `width: 56px`. Added LIVE + UNIT-TEETH coverage in `implementation/scripts/check-examples-assets.test.cjs` (proves the bad global form is flagged, the scoped form is clean, single-quoted variant is caught, and dropping the 56px width is caught). This is NOT a `*.spec.cjs` — examples stay test-free (rf2-8cevm).

## Quality gates

- `npm run test:examples-compile` (from `implementation/`): **39 example builds compiled, 0 warnings, exit 0**.
- `npm run test:script-policy` (wires the asset gate into always-run CI): **all suites pass, exit 0** — including `check-examples-assets` (26 tests: 22 prior + 4 new TEETH + 1 new LIVE cascade assertion).