### PR TITLE
fix(security): redact machine-action-exception :exception-data + navigate :error egress slots (rf2-zsm03)

### DIFF
--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -757,6 +757,48 @@
           (contains? tags :after)    (assoc :after    (project (:after    tags)))
           (contains? tags :snapshot) (assoc :snapshot (project (:snapshot tags))))))))
 
+(defn- project-machine-error-tags
+  "Walk the `:rf.error/machine-action-exception` tag shape (rf2-zsm03).
+  The trace carries `:exception-data` — the `ex-data` of a thrown machine
+  action — under a bare slot the machine-snapshot projection
+  (`project-machine-tags`) does NOT cover: the `:event` slot is redacted by
+  `project-event-tags` and `:before`/`:after`/`:snapshot` by
+  `project-machine-tags`, but `:exception-data` is the developer's
+  arbitrary exception payload and could embed the same app secrets the
+  machine's `:data` marks gate (a thrown action that puts a token /
+  document-id in its `ex-data`).
+
+  Unlike the snapshot slots, `:exception-data` is NOT snapshot-shaped, so
+  the machine's `[:data …]`-rooted `:sensitive` paths do not map onto it.
+  The conservative, footgun-prevention posture (mirroring how
+  `resolve-sub-output-marks` treats a layer-1 sub against any sensitive
+  app-db declaration — Spec 015 §Propagation rules): when the machine
+  declares ANY `:sensitive` mark, the machine handles secrets, so an
+  action's `ex-data` MAY carry them and we cannot prove otherwise. Elide
+  the WHOLE `:exception-data` slot to the `:rf/redacted` sentinel before
+  the error trace crosses the bus / epoch-capture / AI-MCP egress boundary
+  or reaches a log sink. The structural slots (`:machine-id` / `:action-id`
+  / `:state-path` / `:reason` / `:exception-message`) stay intact — they
+  carry no user value and consumers need them to locate the failure.
+
+  A machine with NO `:sensitive` mark rides `:exception-data` verbatim
+  (the seam is precise, not a blanket scrub — symmetric with every other
+  per-registration projection). `:large` marks do not apply: the slot is
+  a developer-shaped diagnostic, not an app-data path graph.
+
+  The whole-Throwable `:exception` slot is left as-is — a Throwable is not
+  a Clojure-walkable collection and consumers extract `:exception-message`
+  (the plain string, untouched here) separately; this matches how every
+  other `:rf.error/*` trace handles the raw exception object."
+  [tags]
+  (let [machine-id (:machine-id tags)
+        marks      (machine-marks machine-id)]
+    (if (and (contains? tags :exception-data)
+             marks
+             (seq (:sensitive marks)))
+      (assoc tags :exception-data privacy/redacted-sentinel :sensitive? true)
+      tags)))
+
 (defn- machine-op?
   [operation]
   (let [n (and (keyword? operation) (namespace operation))]
@@ -821,7 +863,18 @@
                       (project-sub-tags frame-id)
 
                       (and (map? tags) (machine-op? operation))
-                      (project-machine-tags))]
+                      (project-machine-tags)
+
+                      ;; rf2-zsm03 — the `:rf.error/machine-action-exception`
+                      ;; trace carries the thrown action's `ex-data` under a
+                      ;; bare `:exception-data` slot. Its op namespace is
+                      ;; `:rf.error/*` (NOT `rf.machine`), so `machine-op?`
+                      ;; above does not reach it; redact the slot against the
+                      ;; machine's declared `:sensitive` marks here so an
+                      ;; action that throws app secrets inside a sensitive
+                      ;; machine does not leak them past the egress boundary.
+                      (and (map? tags) (contains? tags :exception-data))
+                      (project-machine-error-tags))]
       (assoc event :tags tags'))))
 
 ;; ---- late-bind hook registration ----------------------------------------

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -76,6 +76,21 @@
   "Emit `:rf.error/machine-action-exception` for a `result/fail` Result's
   `::result/info` map. Returns `{}` so the handler short-circuits.
 
+  Per rf2-zsm03 (privacy — AI/MCP egress + logs threat model): the
+  `:event` slot is redacted by the marks projection's `project-event-tags`
+  and `:before`/`:after`/`:snapshot` by `project-machine-tags`, but the
+  `:exception-data` slot below carries the thrown action's `ex-data` — the
+  developer's arbitrary exception payload, which could embed the same app
+  secrets the machine's `:data` marks gate. That slot is path-elided at the
+  trace egress chokepoint by `re-frame.marks/project-machine-error-tags`
+  (a NEW projection clause): when the machine declares ANY `:sensitive`
+  mark the whole `:exception-data` slot scrubs to `:rf/redacted` before the
+  trace crosses the bus / epoch-capture / AI-MCP boundary or a log sink —
+  the same egress seam (the marks projection) the rf2-o69h5 class sweep
+  routed the core validation-failure class through. The redaction lives at
+  the chokepoint (not here) so it covers EVERY consumer of the trace
+  uniformly and stays the single place the `:sensitive` decision is made.
+
   Per Spec 005 §Final states §`:on-error` (rf2-5hlsh; XState v5 invoke
   `onError`): an uncaught child action exception is the SECOND `:on-error`
   trigger (the control-flow case — formerly observability-only). When the

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -12,6 +12,8 @@
   `:reload` re-wires it on a fresh registrar. Per the rf2-2yabr cohesion
   split: NAVIGATE-EVENT seam."
   (:require [clojure.string :as str]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.privacy :as privacy]
             [re-frame.registrar :as registrar]
             [re-frame.routing.can-leave :as can-leave]
             [re-frame.routing.events :as routing-events]
@@ -54,6 +56,58 @@
       (seq (filter (fn [k] (and (contains? opts-only-keys k)
                                 (not (contains? declared k))))
                    (keys params))))))
+
+(defn- route-schema-sensitive?
+  "True iff the route's `:params` OR `:query` Malli schema declares ANY
+  `:sensitive?` slot (rf2-zsm03). The sensitivity decision is made by the
+  SAME shared schema-aware seam the rf2-o69h5 class sweep routes every
+  off-schemas validation-failure emit site through
+  (`:schemas/redact-validation-tags`): routing the route's schema + an
+  empty tag map through it stamps `:sensitive? true` exactly when the
+  schema is sensitive (the seam's `redact-tags` always stamps when it
+  fires). Reaching it through the late-bind hook keeps routing's optional-
+  schemas posture — when the schemas artefact is absent the hook is unbound
+  and this returns false (no schema to walk → nothing to redact), the same
+  fall-through every other off-namespace seam consumer uses."
+  [route-meta]
+  (boolean
+    (when-let [redact (late-bind/get-fn-cached :schemas/redact-validation-tags)]
+      (some (fn [slot]
+              (when-let [schema (get route-meta slot)]
+                (true? (:sensitive? (redact schema {})))))
+            [:params :query]))))
+
+(defn- redact-route-error-tags
+  "Elide the `:error` slot of a `:rf.route/navigate` schema-validation-failure
+  trace when the route's `:params` / `:query` schema declares any
+  `:sensitive?` slot (rf2-zsm03; AI/MCP egress + logs threat model).
+
+  The `:error` slot carries `(ex-data ex)` of a `route-url` construction
+  throw. For the `:rf.error/route-url-validation` case that ex-data embeds
+  `:value` (the raw path-params / query-params the caller supplied) AND
+  `:error` (the Malli explainer, which itself reproduces the failing value
+  verbatim); for `:rf.error/missing-route-param` it carries `:value` (the
+  offending param value). Route params can be document-ids / tokens, so on a
+  `:sensitive?`-marked route this slot leaks the same secret material the
+  route's `:params` / `:query` schema gates — the SAME class the rf2-o69h5
+  sweep closed for the schema-validation hot path, except route-param
+  validation is STRUCTURAL (the throw is from `route-url`, not from a
+  per-slot Malli walk at this emit point), so the shared
+  `redact-validation-tags` seam cannot path-target it. We elide the WHOLE
+  `:error` slot to `:rf/redacted` and stamp `:sensitive? true`.
+
+  The structural slots stay intact — `:where` / `:route-id` / `:recovery`
+  carry no user value, and the SSR error-projector keys only off the
+  `:operation` category (it never echoes `:error` into the public 400), so
+  eliding `:error` is invisible to the public-error projection and scoped to
+  the diagnostic (Xray / dev-detail / log) egress the threat model targets.
+  A route with no `:sensitive?` slot rides `:error` verbatim — the seam is
+  precise, not a blanket scrub."
+  [tags route-meta]
+  (if (and (contains? tags :error)
+           (route-schema-sensitive? route-meta))
+    (assoc tags :error privacy/redacted-sentinel :sensitive? true)
+    tags))
 
 (defn navigate-handler
   "`:rf.route/navigate` event-fx handler. Registered by the façade so a
@@ -248,13 +302,26 @@
                        ;; can map it to a 4xx for the correct frame under
                        ;; concurrent server frames — not the single-frame
                        ;; fallback's guess.
+                       ;; rf2-zsm03 — the `:error` slot carries the
+                       ;; `route-url` throw's ex-data, which on a
+                       ;; `:rf.error/route-url-validation` /
+                       ;; `:rf.error/missing-route-param` throw embeds the
+                       ;; raw route-param value (document-ids / tokens). Elide
+                       ;; it when the route's `:params` / `:query` schema is
+                       ;; `:sensitive?`, BEFORE the trace crosses the bus /
+                       ;; epoch-capture / AI-MCP egress boundary or a log
+                       ;; sink — the route-param analogue of the rf2-o69h5
+                       ;; class sweep (structural param validation has no
+                       ;; per-slot Malli walk here, so the slot is elided
+                       ;; whole rather than path-targeted).
                        (trace/emit-error! :rf.error/schema-validation-failure
-                                          (cond-> {:where    :event
-                                                   :route-id route-id
-                                                   :error    (or (ex-data ex)
-                                                                 {:message (ex-message ex)})
-                                                   :recovery :no-recovery}
-                                            frame (assoc :frame frame)))
+                                          (-> (cond-> {:where    :event
+                                                       :route-id route-id
+                                                       :error    (or (ex-data ex)
+                                                                     {:message (ex-message ex)})
+                                                       :recovery :no-recovery}
+                                                frame (assoc :frame frame))
+                                              (redact-route-error-tags route-meta)))
                        ::reject)))
           on-match-vec (vec (or (:on-match route-meta) []))
           ;; Spec 012 §Per-route data loading rule 3: a programmatic

--- a/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
@@ -1,0 +1,345 @@
+(ns re-frame.security.error-slot-egress-security-cljs-test
+  "Security tier — non-schema-validation error-emit slots that carry
+  caller-supplied data the path-marks projection did NOT cover and the
+  shared schema-aware validation seam does NOT apply to (rf2-zsm03;
+  follow-up to the rf2-o69h5 class sweep).
+
+  ## The two slots
+
+  rf2-o69h5 closed the `:rf.error/schema-validation-failure` class: every
+  framework emission of that op routes its value-bearing slots through the
+  one shared schema-aware redactor. Two OTHER error-emit sites carry
+  caller-supplied data outside that class:
+
+    1. `:rf.error/machine-action-exception` `:exception-data` — the `ex-data`
+       of a thrown machine action (re-frame.machines.lifecycle-fx.registration).
+       The `:event` slot IS covered by the marks projection's
+       `project-event-tags`; `:before`/`:after`/`:snapshot` by
+       `project-machine-tags`. But `:exception-data` is the developer's
+       arbitrary exception payload — under a bare slot NO projection clause
+       reached (the op namespace is `:rf.error/*`, not `rf.machine`, so
+       `machine-op?` skips it). It can embed the same app secrets the
+       machine's `:data` marks gate.
+
+    2. `:rf.route/navigate` `:error` (re-frame.routing.navigate) — `(ex-data
+       ex)` of a `route-url` construction throw. On
+       `:rf.error/route-url-validation` / `:rf.error/missing-route-param` it
+       embeds the raw route-param value (document-ids / tokens) AND the Malli
+       explainer. Route-param validation is STRUCTURAL (the throw is from
+       `route-url`, not a per-slot Malli walk at this emit point), so the
+       shared `redact-validation-tags` seam cannot path-target it.
+
+  ## The fix (mirrors the rf2-o69h5 egress-chokepoint approach)
+
+  Both slots are elided at the trace egress chokepoint BEFORE the event
+  crosses the bus / epoch-capture / AI-MCP boundary or reaches a log sink:
+
+    1. `re-frame.marks/project-machine-error-tags` (a NEW projection clause,
+       wired into `project-trace-event`) elides the WHOLE `:exception-data`
+       slot to `:rf/redacted` and stamps `:sensitive? true` when the machine
+       declares ANY `:sensitive` mark.
+    2. `re-frame.routing.navigate`'s `redact-route-error-tags` elides the
+       WHOLE `:error` slot and stamps `:sensitive? true` when the route's
+       `:params` / `:query` schema declares any `:sensitive?` slot (decided
+       through the SAME shared `:schemas/redact-validation-tags` seam).
+
+  Both stamp `:sensitive? true`, so the MCP egress gate
+  (`re-frame.mcp-base.sensitive/strip-sensitive`) ALSO drops the whole event
+  with the boot gate OFF — defence in depth (asserted below).
+
+  ## Net property (verify-by-revert)
+
+  Reverting `project-machine-error-tags` (or its dispatch clause) to a
+  pass-through makes the machine corpus + property go RED — the sentinel
+  surfaces in `:exception-data`. Reverting `redact-route-error-tags` makes
+  the navigate corpus go RED — the sentinel surfaces in `:error`. Confirmed
+  by temporary local revert + restore (see PR Quality gates).
+
+  ## Threat model
+
+  AI/MCP boundary + logs ONLY (per rf2-zsm03 / rf2-o69h5) — human-facing
+  egress is out of scope and not gold-plated."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [clojure.walk :as walk]
+            [re-frame.core :as rf]
+            ;; Publishes the Malli late-bind validate/explain/sensitive hooks;
+            ;; without it `route-url` soft-passes (no validation throw) and the
+            ;; `:schemas/redact-validation-tags` sensitivity oracle is unbound.
+            [re-frame.schemas.malli]
+            [re-frame.marks :as marks]
+            [re-frame.mcp-base.sensitive :as sens]
+            [re-frame.routing :as routing]
+            ;; Call `navigate-handler` directly (a plain event-fx handler fn)
+            ;; so site 2 exercises the REAL redaction path headless — no
+            ;; reactive-substrate adapter / `dispatch-sync` machinery needed.
+            ;; A `:params`-schema validation reject short-circuits inside the
+            ;; handler before any push/scroll fx, so a synthetic cofx suffices.
+            [re-frame.routing.navigate :as navigate]
+            [re-frame.routing.registry :as registry]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.security.gen :as gen]))
+
+;; Reset per-test so route + mark + app-schema registrations don't bleed.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:clear-app-schemas? true}))
+
+;; ---------------------------------------------------------------------------
+;; Sentinel — a value that must NEVER appear unredacted in either slot.
+;; ---------------------------------------------------------------------------
+
+(def ^:private sentinel "S3CR3T-rf2-zsm03-ERROR-SLOT-DO-NOT-LEAK")
+
+(defn- contains-sentinel?
+  "Deep-walk `x`; true when the sentinel string appears anywhere (as a
+  value, inside a collection, or inside a stringified form)."
+  [x]
+  (let [hit (volatile! false)]
+    (walk/postwalk
+      (fn [node]
+        (when (and (string? node) (re-find (re-pattern sentinel) node))
+          (vreset! hit true))
+        node)
+      x)
+    (or @hit
+        (boolean (re-find (re-pattern sentinel) (pr-str x))))))
+
+;; ===========================================================================
+;; SITE 1 — :rf.error/machine-action-exception :exception-data
+;; Driven through the REAL egress chokepoint `marks/project-trace-event`.
+;; ===========================================================================
+
+(def ^:private sensitive-machine-id :sec/sensitive-machine)
+(def ^:private plain-machine-id     :sec/plain-machine)
+
+(defn- declare-machine-marks!
+  "Install the per-(kind, id) marks a `reg-machine` with `:sensitive`
+  machine-data paths would install (machine marks are keyed under the
+  `:event` kind because a machine IS an event handler)."
+  []
+  ;; Sensitive machine — declares a sensitive `:data` path (the snapshot
+  ;; analogue), the signal `project-machine-error-tags` keys off.
+  (marks/register-marks! :event sensitive-machine-id
+                         {:sensitive [[:data :token]]})
+  ;; Plain machine — no marks at all.
+  (marks/register-marks! :event plain-machine-id {}))
+
+(defn- machine-action-exception-event
+  "Build a realistic `:rf.error/machine-action-exception` trace envelope
+  (the shape `trace/build-event` produces) carrying `machine-id` and the
+  sentinel-bearing `:exception-data`."
+  [machine-id]
+  {:operation :rf.error/machine-action-exception
+   :op-type   :error
+   :tags      {:machine-id        machine-id
+               :action-id         :do/thing
+               :state-path        [:running]
+               :event             [machine-id [:tick]]
+               :exception-message "boom"
+               :exception-data    {:user-token sentinel :doc-id [sentinel]}
+               :reason            "Machine action threw."
+               :recovery          :no-recovery}})
+
+(deftest machine-exception-data-redacted-for-sensitive-machine
+  (testing "rf2-zsm03 — a sensitive machine's :exception-data is elided to
+            :rf/redacted at the egress chokepoint, :sensitive? is stamped,
+            and the sentinel never survives"
+    (declare-machine-marks!)
+    (let [out  (marks/project-trace-event
+                 (machine-action-exception-event sensitive-machine-id))
+          tags (:tags out)]
+      (is (= :rf/redacted (:exception-data tags)) ":exception-data redacted")
+      (is (true? (:sensitive? tags)) ":sensitive? stamped on the tags")
+      (is (not (contains-sentinel? out))
+          (str "the sentinel leaked into the machine-action-exception trace: "
+               (pr-str tags)))
+      ;; Structural slots survive — consumers locate the failure.
+      (is (= sensitive-machine-id (:machine-id tags)) ":machine-id kept")
+      (is (= :do/thing (:action-id tags)) ":action-id kept")
+      (is (= "boom" (:exception-message tags)) ":exception-message kept"))))
+
+(deftest machine-exception-data-verbatim-for-plain-machine
+  (testing "rf2-zsm03 — a machine with NO :sensitive mark rides
+            :exception-data verbatim (the seam is precise, not a blanket
+            scrub)"
+    (declare-machine-marks!)
+    (let [out  (marks/project-trace-event
+                 (machine-action-exception-event plain-machine-id))
+          tags (:tags out)]
+      (is (map? (:exception-data tags)) ":exception-data NOT redacted")
+      (is (not (contains? tags :sensitive?))
+          "no :sensitive? stamp when the machine declares nothing sensitive"))))
+
+(deftest machine-exception-data-verbatim-for-unregistered-machine
+  (testing "rf2-zsm03 — a machine with no marks entry at all (never
+            registered marks) rides :exception-data verbatim"
+    ;; No declare-machine-marks! call — kind->id->marks has no entry.
+    (let [out  (marks/project-trace-event
+                 (machine-action-exception-event :sec/unregistered))
+          tags (:tags out)]
+      (is (map? (:exception-data tags)) ":exception-data verbatim (no marks)")
+      (is (not (contains? tags :sensitive?)) "no :sensitive? stamp"))))
+
+;; ---------------------------------------------------------------------------
+;; SITE 1 PROPERTY — across arbitrary collection/map nestings of the
+;; sentinel inside :exception-data, a sensitive machine NEVER egresses it.
+;; ---------------------------------------------------------------------------
+
+(defn- gen-ex-data
+  "Generator: a sentinel-bearing ex-data value at a random collection/map
+  nesting. `depth` bounds recursion."
+  [depth]
+  (if (<= depth 0)
+    (fn [rng] [sentinel rng])
+    (fn [rng]
+      (let [[wrap rng1] (gen/rand-nth rng [:map :vector :set :nested-map])
+            [inner rng2] ((gen-ex-data (dec depth)) rng1)]
+        (case wrap
+          :map        [{:k inner} rng2]
+          :vector     [[inner] rng2]
+          :set        [#{inner} rng2]
+          :nested-map [{:a {:b inner}} rng2])))))
+
+(def ^:private gen-nested-ex-data
+  (fn [rng]
+    (let [[depth rng1] (gen/next-int rng 5)]
+      ((gen-ex-data (inc depth)) rng1))))
+
+(deftest sensitive-machine-redacts-ex-data-at-arbitrary-nesting
+  (testing "rf2-zsm03 — across arbitrary nestings of the sentinel inside
+            :exception-data, a sensitive machine elides the WHOLE slot and
+            stamps :sensitive?; the sentinel never survives"
+    (declare-machine-marks!)
+    (let [result (gen/for-all
+                   gen-nested-ex-data 120 41
+                   (fn [ex-data]
+                     (let [ev   (assoc-in (machine-action-exception-event
+                                            sensitive-machine-id)
+                                          [:tags :exception-data] ex-data)
+                           out  (marks/project-trace-event ev)]
+                       (and (= :rf/redacted (-> out :tags :exception-data))
+                            (true? (-> out :tags :sensitive?))
+                            (not (contains-sentinel? out))))))]
+      (is (nil? result)
+          (str "a sensitive machine leaked :exception-data for a generated "
+               "nesting: " (pr-str (when result (dissoc result :threw))))))))
+
+;; ===========================================================================
+;; SITE 2 — :rf.route/navigate :error
+;; Driven END-TO-END through the REAL navigate-handler: a validation-reject
+;; short-circuits BEFORE any push/scroll fx, so no window stub is needed.
+;; ===========================================================================
+
+(def ^:private sensitive-params-schema
+  ;; A route :params schema marking the doc-id slot sensitive. A navigate
+  ;; with a non-conforming :doc value throws :rf.error/route-url-validation
+  ;; whose ex-data carries the failing value (the sentinel) under :value AND
+  ;; the Malli explainer.
+  [:map [:doc {:sensitive? true} :int]])
+
+(def ^:private plain-params-schema
+  [:map [:doc :int]])
+
+(defn- capture-navigate-failure
+  "Register `:sec/route` with `params-schema`, invoke the REAL
+  `navigate-handler` with a sentinel-bearing (non-:int) :doc param so
+  `route-url` throws inside the handler, and return the emitted
+  `:rf.error/schema-validation-failure` trace event. Calling the handler
+  fn directly (rather than `dispatch-sync`) keeps the test substrate-free:
+  the `:params`-schema reject short-circuits before any push/scroll fx."
+  [params-schema]
+  (rf/reg-route :sec/route {:path "/doc/:doc" :params params-schema})
+  (let [traces (atom [])
+        kw     (keyword "rf2-zsm03" (name (gensym "nav")))]
+    (trace-tooling/register-listener! kw (fn [ev] (swap! traces conj ev)))
+    (try
+      ;; :doc must be a value the schema rejects (schema wants :int). The
+      ;; sentinel rides as the offending param value.
+      (navigate/navigate-handler {:db {} :frame :rf/default}
+                                 [:rf.route/navigate :sec/route {:doc sentinel}])
+      (finally (trace-tooling/unregister-listener! kw)))
+    (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                   @traces))))
+
+(deftest navigate-error-redacted-for-sensitive-route
+  (testing "rf2-zsm03 — a navigate whose route :params schema is :sensitive?
+            elides the :error slot (carrying the failing param value) to
+            :rf/redacted, stamps :sensitive?, and never egresses the sentinel"
+    (let [trace (capture-navigate-failure sensitive-params-schema)
+          tags  (:tags trace)]
+      (is (some? trace) "a schema-validation-failure trace fired for the reject")
+      (when trace
+        (is (= :rf/redacted (:error tags)) ":error slot redacted")
+        ;; The redaction stamps tags-level `:sensitive?`; this emit goes
+        ;; through the real `trace/emit-error!` → `build-event`, which hoists
+        ;; the flag to the TOP LEVEL of the envelope (and strips it from
+        ;; `:tags`). The top-level stamp is exactly what the MCP egress gate
+        ;; reads (`mcp-base.sensitive/sensitive-event?`).
+        (is (true? (:sensitive? trace)) "top-level :sensitive? stamped")
+        (is (not (contains-sentinel? trace))
+            (str "the sentinel leaked into the navigate :error trace: "
+                 (pr-str trace)))
+        ;; Structural slots survive.
+        (is (= :sec/route (:route-id tags)) ":route-id kept")
+        (is (= :event (:where tags)) ":where kept")))))
+
+(deftest navigate-error-verbatim-for-plain-route
+  (testing "rf2-zsm03 — a navigate whose route :params schema has NO
+            :sensitive? slot rides :error verbatim (no over-redaction)"
+    (let [trace (capture-navigate-failure plain-params-schema)
+          tags  (:tags trace)]
+      (is (some? trace) "a schema-validation-failure trace fired")
+      (when trace
+        (is (not= :rf/redacted (:error tags)) ":error NOT redacted")
+        (is (map? (:error tags)) ":error rode through as the raw ex-data map")
+        (is (not (contains? tags :sensitive?))
+            "no :sensitive? stamp on a non-sensitive route")))))
+
+;; ===========================================================================
+;; REDACTION IS AT-SOURCE — the scrub happens at the trace egress chokepoint,
+;; so the sentinel is gone from the event REGARDLESS of the MCP boot gate.
+;; Unlike the MCP whole-event drop (which would also hide the useful "an
+;; action threw" / "a navigate rejected" signal from the agent), per-slot
+;; redaction lets the agent SEE the structural error while the secret stays
+;; off-box. So we pass the redacted events through the MCP egress with the
+;; gate ON (include? true — the MOST permissive, fully opted-in path) and
+;; confirm the sentinel STILL never reaches the boundary: the protection is
+;; the source scrub, not a gate decision.
+;; ===========================================================================
+
+(deftest redaction-survives-even-the-opt-in-mcp-egress
+  (testing "rf2-zsm03 — the per-slot scrub is at-source: even with the MCP
+            boot gate fully ON (include? true), neither the machine
+            :exception-data nor the navigate :error egresses the sentinel"
+    (declare-machine-marks!)
+    (let [machine-ev (marks/project-trace-event
+                       (machine-action-exception-event sensitive-machine-id))
+          nav-trace  (capture-navigate-failure sensitive-params-schema)
+          events     (filterv some? [machine-ev nav-trace])
+          [kept _]   (sens/strip-sensitive events true)]
+      (is (= 2 (count events)) "both redacted events were produced")
+      (is (not-any? contains-sentinel? kept)
+          (str "the sentinel reached the MCP boundary even after redaction: "
+               (pr-str kept))))))
+
+;; ===========================================================================
+;; UNIT — the route-url throw genuinely carries the sentinel in its ex-data
+;; (pins the pre-redaction leak vector so the redaction is not vacuous).
+;; ===========================================================================
+
+(deftest route-url-throw-ex-data-carries-the-sentinel
+  (testing "rf2-zsm03 — the route-url validation throw's ex-data DOES embed
+            the failing param value (the sentinel); without redaction the
+            navigate :error slot would ship it"
+    (rf/reg-route :sec/raw-route {:path "/doc/:doc" :params sensitive-params-schema})
+    (let [ex (try
+               (registry/route-url :sec/raw-route {:doc sentinel})
+               nil
+               (catch #?(:clj Throwable :cljs :default) e e))]
+      (is (some? ex) "route-url threw on the non-conforming sensitive param")
+      (when ex
+        (is (contains-sentinel? (ex-data ex))
+            "pre-redaction: the throw's ex-data embeds the sentinel — the leak
+             vector the :error redaction closes")))))


### PR DESCRIPTION
Follow-up to **rf2-o69h5** (the `:rf.error/schema-validation-failure` class sweep). Two NON-schema-validation error-emit sites carried caller-supplied data the path-marks projection did NOT cover and the shared schema-aware validation seam did NOT apply to. **Both are REDACTED** at the trace egress chokepoint — mirroring how o69h5 handled the core class. Threat model: **AI/MCP boundary + logs ONLY** (no human-facing gold-plating).

## Per-site decision

### Site 1 — `:rf.error/machine-action-exception` `:exception-data` → **REDACT**
`registration.cljc:98`. The `:event` slot is already covered by the marks projection's `project-event-tags` and `:before`/`:after`/`:snapshot` by `project-machine-tags` — but `:exception-data` (the `ex-data` of a thrown machine action) rode a **bare slot no projection clause reached**: the trace op namespace is `:rf.error/*` (not `rf.machine`), so `machine-op?` skips it. It is the developer's arbitrary exception payload and can embed the same app secrets the machine's `:data` marks gate.

**Fix:** a new `project-machine-error-tags` clause in `re-frame.marks` (wired into `project-trace-event`, keyed on the presence of `:exception-data`) elides the **whole `:exception-data` slot** to `:rf/redacted` and stamps `:sensitive?` when the machine declares **any** `:sensitive` mark. Whole-slot (not path-targeted) because ad-hoc ex-data is not snapshot-shaped, so the machine's `[:data …]`-rooted marks cannot map onto it — the conservative footgun-prevention posture Spec 015 already uses for layer-1 sub propagation ("any sensitive declaration ⇒ treat as sensitive"). The raw `:exception` Throwable is left as-is (not a Clojure-walkable collection; `:exception-message` is extracted separately — matching every other `:rf.error/*` trace). A machine with no `:sensitive` mark rides `:exception-data` verbatim (precise, not blanket).

The fix lives at the **chokepoint** (not in `registration.cljc`) so it covers all consumers uniformly and is the single place the `:sensitive` decision is made; `registration.cljc` gains a documentary note pointing at it.

### Site 2 — `:rf.route/navigate` `:error` → **REDACT**
`navigate.cljc:251`. The `:error` slot carries `(ex-data ex)` of a `route-url` construction throw. On `:rf.error/route-url-validation` / `:rf.error/missing-route-param` it embeds the **raw route-param value** (document-ids / tokens) under `:value` **and** the Malli explainer (which reproduces the failing value verbatim). The verify-by-revert output showed the sentinel three times unredacted.

**Assessment of the bead's question — can route `:params`/`:query` schemas declare `:sensitive?`?** Yes: they are Malli schemas walked by `validate-route-shape`. **Fix:** `redact-route-error-tags` elides the **whole `:error` slot** when the route's `:params`/`:query` schema declares any `:sensitive?` slot. Route-param validation is **structural** (the throw is from `route-url`, not a per-slot Malli walk at this emit point), so the shared `redact-validation-tags` seam cannot path-target the slot — but the sensitivity **decision** is delegated to the **same** `:schemas/redact-validation-tags` seam (reached via late-bind, keeping routing's optional-schemas posture; verbatim fall-through when schemas is absent). The SSR error-projector keys only off the `:operation` category (it never echoes `:error` into the public 400), so eliding `:error` is invisible to the public-error projection and scoped to the diagnostic (Xray / dev-detail / log) egress the threat model targets.

This site emits `:rf.error/schema-validation-failure`, so it was a **gap in the existing o69h5 Spec-010 invariant** ("EVERY framework emission of that op MUST route its value-bearing slots through the shared redactor"); this fix brings it into compliance.

### Sensitivity stamp
Both stamp `:sensitive? true` — tags-level for the machine projection (consistent with `project-sub-tags`; intentionally does NOT trigger the MCP whole-event drop, so the agent still sees the scrubbed "an action threw" signal), hoisted to top-level by `build-event` for the navigate emit (which is what the MCP egress gate reads).

## Gate

New security-tier test **`error_slot_egress_security_cljs_test.cljc`** (rides both `test:cljs` and the focused `test:security`):
- Site 1: a per-kind corpus + a collection/map nesting fuzzer, driven through the **real** `marks/project-trace-event` chokepoint; asserts `:exception-data` redacts + no planted sentinel egresses + non-sensitive machines ride verbatim.
- Site 2: an **end-to-end** `navigate-handler` emit (the validation-reject short-circuits before any push/scroll fx, so it runs substrate-free); asserts `:error` redacts + top-level `:sensitive?` + no sentinel + non-sensitive routes ride verbatim.
- An at-source check (the scrub holds even through the fully opted-in MCP egress) + a unit pin that the `route-url` throw's ex-data genuinely embeds the sentinel pre-redaction (so the redaction is not vacuous).
- **Verify-by-revert: RED for each site independently** (toggled the dispatch clause / the redaction guard, restored).

Gates green: `test:cljs` (5787 tests / 20364 assertions), `test:security` (41 tests / 285 assertions), `core` + `routing` + `machines` JVM, `test:elision` (40/40), `test:bundle-isolation`.

No new late-bind hook (reuses the published `:schemas/redact-validation-tags`); no hot-zone files touched.
