### PR TITLE
fix(story): thread :run-args through canvas decorator plan recompile (rf2-eyrpr)

### DIFF
--- a/tools/story/spec/008-Docs-Mode.md
+++ b/tools/story/spec/008-Docs-Mode.md
@@ -64,7 +64,7 @@ The pane renders six sections, top-to-bottom:
 | 1 | Header      | variant id, parent-story id, tags, variant `:doc` (or parent `:doc` fallback)   | always                                         |
 | 2 | Prose       | `:body` strings from `:layout :prose` workspaces that reference this variant   | at least one prose block found                 |
 | 3 | Args        | `(args/resolve-args variant-id {:cell-overrides nil})` × variant `:argtypes`    | always (renders "no args resolved" if empty)   |
-| 4 | Decorators  | `(decorators/resolve-decorators variant-id)`                                    | always (renders "no decorators" if empty)      |
+| 4 | Decorators  | `(decorators/resolve-decorators variant-id {:active-modes … :cell-overrides nil})` | always (renders "no decorators" if empty)      |
 | 5 | Parameters  | variant body's `:modes` / `:substrates` / `:platforms` slots (story fallback)  | always (renders "no … declared" if all empty) |
 | 6 | Tags        | sorted variant tags (parent-story fallback)                                     | always (renders "no tags" if empty)            |
 

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -470,6 +470,20 @@ so those plays carry the resolved placeholders, not the raw `[:arg …]` forms.
 `:control-overrides` on top of the plan-time effective args and re-resolves
 sub-overrides, because rendering does not execute setup/script/db-seed.)
 
+The canvas/controls/docs **decorator-resolution** front door
+(`decorators/resolve-decorators`) likewise threads the per-run layers into the
+plan it recompiles to read `[:world :decorators]` (rf2-eyrpr). That recompile
+substitutes every `[:arg key]` in the variant body, so a key resolvable ONLY
+through a mode / cell / global / story layer (never the variant chain) must be
+supplied via the same `{:active-modes :cell-overrides}` opts — otherwise the
+decorator recompile fails `:rf.error/story-missing-arg` even though the runner
+compile (with run opts) substitutes it cleanly. The common case (every
+`[:arg]` key declared on the variant or its `:extends` chain) is unaffected;
+the threading is purely additive. The hot-reload fingerprint poll
+(`resolution-fingerprints`) threads the same opts for the same reason — the
+fingerprints are body-derived and run-layer-invariant, the opts only let the
+ref-collection compile succeed.
+
 `:effective-args` (the args after control-panel overrides) is a
 first-class plan field, and `(story/render-variant target opts)` renders
 the workshop view from the **same plan** the runner consumes. The live

--- a/tools/story/src/re_frame/story/decorators.cljc
+++ b/tools/story/src/re_frame/story/decorators.cljc
@@ -36,7 +36,8 @@
   Unknown decorator-ids surface as an entry in the returned `:errors`
   vector; the runtime then projects those into the variant's
   `:assertions` (per IMPL-SPEC §5.5)."
-  (:require [re-frame.story.plan      :as plan]
+  (:require [re-frame.story.args      :as args]
+            [re-frame.story.plan      :as plan]
             [re-frame.story.registrar :as registrar]))
 
 ;; ---- collection -----------------------------------------------------------
@@ -68,9 +69,24 @@
 
   `decorators → plan` is acyclic (plan does NOT require decorators). The
   per-variant cost is one plan compile per resolution, which the single-
-  source invariant pays for (no second merge engine to diverge)."
-  [variant-id]
-  (or (get-in (plan/variant-plan variant-id) [:world :decorators]) []))
+  source invariant pays for (no second merge engine to diverge).
+
+  `run-args` (rf2-eyrpr) — the ambient + per-run arg layers
+  (`args/run-arg-layers`'s `{:pre … :post …}` shape) threaded into the
+  plan compile so a `[:arg key]` resolvable ONLY through a mode / cell /
+  global / story layer (never the variant chain) substitutes cleanly
+  rather than throwing `:rf.error/story-missing-arg`. The runtime's
+  `prepare-context` already compiles WITH `:run-args` and reads
+  `[:world :decorators]` off that plan; the canvas/controls/docs paths
+  flow through `resolve-decorators` → here, so they must pass the SAME
+  run layers to recompile the identical plan. Absent (a bare front-door
+  call) ⇒ the variant arg layer alone, exactly as before."
+  ([variant-id] (collect-decorator-refs variant-id nil))
+  ([variant-id run-args]
+   (or (get-in (plan/variant-plan variant-id
+                                  (when run-args {:run-args run-args}))
+               [:world :decorators])
+       [])))
 
 ;; ---- resolution -----------------------------------------------------------
 
@@ -165,15 +181,25 @@
   "Return `{decorator-id → fingerprint}` for every decorator the variant
   will use. Stage 4 caches the resolved decorator stack alongside this
   map and re-resolves if any fingerprint diverges from the registry's
-  current value."
-  [variant-id]
-  (let [refs (collect-decorator-refs variant-id)]
-    (into {}
-          (keep (fn [ref]
-                  (let [id (first ref)]
-                    (when (keyword? id)
-                      [id (decorator-fingerprint id)]))))
-          refs)))
+  current value.
+
+  `opts` (rf2-eyrpr) — the per-run `{:active-modes … :cell-overrides …}`
+  (same shape `resolve-decorators` takes), folded into the plan compile
+  that yields the decorator REF list so a `[:arg key]` resolvable only
+  through a mode / cell layer does not throw `:rf.error/story-missing-arg`
+  during the hot-reload poll. The fingerprints themselves depend only on
+  the decorator BODIES (registry), invariant under run layers; `opts`
+  serves solely to let the ref collection's plan compile succeed."
+  ([variant-id] (resolution-fingerprints variant-id nil))
+  ([variant-id opts]
+   (let [run-args (when opts (args/run-arg-layers variant-id opts))
+         refs     (collect-decorator-refs variant-id run-args)]
+     (into {}
+           (keep (fn [ref]
+                   (let [id (first ref)]
+                     (when (keyword? id)
+                       [id (decorator-fingerprint id)]))))
+           refs))))
 
 ;; ---- public surface -------------------------------------------------------
 
@@ -216,13 +242,20 @@
     variant).
   - `:fx-override` — declared order; last-wins on a key collision.
 
-  `opts` accepts `:active-modes` for forward compatibility — v1 modes
-  carry no decorators, but the slot exists for v2 (per IMPL-SPEC
-  §13.2)."
+  `opts` accepts `:active-modes` + `:cell-overrides` — the SAME per-run
+  shape `args/resolve-args` takes. v1 modes carry no decorators (per
+  IMPL-SPEC §3.1 modes are `:args`-only, so the active modes never
+  perturb the decorator REFS), but the run layers must still be threaded
+  into the plan compile (rf2-eyrpr): a `[:arg key]` resolvable ONLY
+  through a mode / cell / global / story layer would otherwise throw
+  `:rf.error/story-missing-arg` when this front-door recompiles the plan
+  WITHOUT `:run-args` — the gap rf2-2cpoo (#3248) closed for the runtime
+  `prepare-context` path but not this canvas/controls/docs path."
   ([variant-id]
    (resolve-decorators variant-id nil))
-  ([variant-id _opts]
-   (resolve-decorator-refs (collect-decorator-refs variant-id))))
+  ([variant-id opts]
+   (let [run-args (when opts (args/run-arg-layers variant-id opts))]
+     (resolve-decorator-refs (collect-decorator-refs variant-id run-args)))))
 
 (defn resolve-decorator-refs
   "Resolve, classify, and order a supplied vector of `[decorator-id & args]`

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -494,14 +494,21 @@
   [variant-id]
   (let [view-id        (variant-component variant-id)
         variant-body   (registrar/handler-meta :variant variant-id)
-        decorator-pack (decorators/resolve-decorators variant-id)
-        eff-args       (args/resolve-args
-                         variant-id
-                         {:active-modes
-                          (:active-modes @state/shell-state-atom)
-                          :cell-overrides
-                          (get-in @state/shell-state-atom
-                                  [:cell-overrides variant-id])})
+        ;; rf2-eyrpr — the SAME per-run opts the `eff-args` resolve below
+        ;; uses, threaded into `resolve-decorators` so the plan it
+        ;; recompiles to read `[:world :decorators]` substitutes `[:arg]`
+        ;; keys with the mode/cell-aware args. Without this an `[:arg key]`
+        ;; resolvable ONLY through an active-mode / cell-override layer
+        ;; (never the variant chain) throws `:rf.error/story-missing-arg`
+        ;; here even though the runtime's plan compile (rf2-2cpoo) handled
+        ;; it — the canvas decorator recompile was the remaining gap.
+        run-opts       {:active-modes
+                        (:active-modes @state/shell-state-atom)
+                        :cell-overrides
+                        (get-in @state/shell-state-atom
+                                [:cell-overrides variant-id])}
+        decorator-pack (decorators/resolve-decorators variant-id run-opts)
+        eff-args       (args/resolve-args variant-id run-opts)
         assertions     (runtime/read-assertions variant-id)
         ;; rf2-5x1wt.13 — resolve the variant's view-state subscription
         ;; overrides (arg-substituted) for the render-path binding below.

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -966,7 +966,14 @@
   unique `key`s in a sibling list, so the row key is the `[index id]`
   tuple rather than the bare id."
   [variant-id]
-  (let [pack  (decorators/resolve-decorators variant-id)
+  (let [shell (deref state/shell-state-atom)
+        ;; rf2-eyrpr — thread the per-run opts into `resolve-decorators` so
+        ;; the plan recompile substitutes `[:arg]` keys resolvable only
+        ;; through a mode / cell layer (mirrors the args panel's resolve).
+        pack  (decorators/resolve-decorators
+                variant-id
+                {:active-modes   (:active-modes shell)
+                 :cell-overrides (get-in shell [:cell-overrides variant-id])})
         all   (concat (:hiccup pack) (:frame-setup pack) (:fx-override pack))]
     [:div {:style (:section styles)}
      [:div {:style (:section-h styles)} "Decorators"]

--- a/tools/story/src/re_frame/story/ui/docs.cljc
+++ b/tools/story/src/re_frame/story/ui/docs.cljc
@@ -657,7 +657,15 @@
      in apply-order. Story-level decorators come first per
      `resolve-decorators` semantics."
      [variant-id]
-     (let [pack (decorators/resolve-decorators variant-id)
+     (let [shell @state/shell-state-atom
+           ;; rf2-eyrpr — thread the active-modes into `resolve-decorators`
+           ;; so the plan recompile substitutes `[:arg]` keys resolvable
+           ;; only through a mode layer. Mirrors `args-section` (docs is
+           ;; read-only — overrides deliberately excluded; the variant's
+           ;; declared shape, mode-aware, is what the docs surface shows).
+           pack (decorators/resolve-decorators
+                  variant-id
+                  {:active-modes (:active-modes shell) :cell-overrides nil})
            rows (decorator-rows pack)]
        [:div {:style     (:section styles)
               :data-test "story-docs-decorators-section"}

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -107,11 +107,24 @@
 
 (defn- compute-fingerprint-snapshot
   "Walk every running variant frame and capture its current decorator
-  fingerprint map. Pure data → data."
+  fingerprint map. Pure data → data.
+
+  rf2-eyrpr — thread each frame's per-run opts (`:active-modes` +
+  per-variant `:cell-overrides`) into `resolution-fingerprints` so the
+  plan compile that yields the decorator ref list substitutes `[:arg]`
+  keys resolvable only through a mode / cell layer rather than throwing
+  on the 500ms hot-reload poll. Fingerprints are body-derived and run-
+  layer-invariant; the opts only let the ref collection's compile succeed."
   []
-  (into {}
-        (map (fn [vid] [vid (decorators/resolution-fingerprints vid)]))
-        (frames/variant-frames)))
+  (let [shell        (state/get-state)
+        active-modes (:active-modes shell)]
+    (into {}
+          (map (fn [vid]
+                 [vid (decorators/resolution-fingerprints
+                        vid
+                        {:active-modes   active-modes
+                         :cell-overrides (get-in shell [:cell-overrides vid])})]))
+          (frames/variant-frames))))
 
 (defn- existing-frame-fingerprint-drift?
   "True when a frame that was present on the previous poll now reports

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -350,13 +350,16 @@
      [variant-id]
      (let [view-id        (variant-component-id variant-id)
            shell          @state/shell-state-atom
-           decorator-pack (decorators/resolve-decorators variant-id)
-           eff-args       (args/resolve-args
-                            variant-id
-                            {:active-modes   (:active-modes shell)
-                             :cell-overrides (get-in shell
-                                                     [:cell-overrides
-                                                      variant-id])})
+           ;; rf2-eyrpr — thread the per-run opts into `resolve-decorators`
+           ;; (mirrors `canvas/canvas-inner`) so the plan it recompiles to
+           ;; read `[:world :decorators]` substitutes `[:arg]` keys that
+           ;; resolve only through a mode / cell layer instead of throwing.
+           run-opts       {:active-modes   (:active-modes shell)
+                           :cell-overrides (get-in shell
+                                                   [:cell-overrides
+                                                    variant-id])}
+           decorator-pack (decorators/resolve-decorators variant-id run-opts)
+           eff-args       (args/resolve-args variant-id run-opts)
            assertions     (runtime/read-assertions variant-id)
            errors         (:errors decorator-pack)]
        ;; Per rf2-9la06: stamp `data-test-variant` on each cell so

--- a/tools/story/test/re_frame/story/canvas_plan_resolution_test.cljc
+++ b/tools/story/test/re_frame/story/canvas_plan_resolution_test.cljc
@@ -286,3 +286,136 @@
       (is (= :cannot-run (:status r)))
       (is (= :no-render-host (:reason r)))
       (is (= :story.norender/v (:frame r))))))
+
+;; ===========================================================================
+;; rf2-eyrpr — the canvas decorator path threads :run-args into the plan it
+;; recompiles to read [:world :decorators].
+;;
+;; rf2-2cpoo (#3248) threaded run opts into the RUNTIME plan compile
+;; (`prepare-context`), but the CANVAS decorator path
+;; (`decorators/resolve-decorators`, the front door the live canvas /
+;; controls / docs panes call) still recompiled the plan WITHOUT them. That
+;; recompile substitutes EVERY `[:arg key]` in the variant body (db-seed /
+;; sub-overrides / setup / script) against the arg-map — so a key resolvable
+;; ONLY through a mode / cell / global / story layer (never the variant
+;; chain) threw `:rf.error/story-missing-arg` at decorator-resolution time,
+;; even though the runtime compile (with run opts) substituted it cleanly.
+;; The fix threads the SAME `{:active-modes :cell-overrides}` opts the canvas
+;; already builds for `resolve-args` through `resolve-decorators` →
+;; `collect-decorator-refs` → `variant-plan {:run-args …}`.
+;;
+;; These tests register on the DEFAULT side-table and call
+;; `decorators/resolve-decorators` (the production front door) — proving the
+;; new capability resolves AND, critically, that the no-opts path STILL
+;; throws (so the test would catch a regression / proves the gap was real).
+;; ===========================================================================
+
+(defn- missing-arg-throw?
+  "True iff `thunk` throws the plan-compile `:rf.error/story-missing-arg`."
+  [thunk]
+  (try (thunk) false
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+         (= :rf.error/story-missing-arg (:rf.error/id (ex-data e))))))
+
+(deftest canvas-decorator-resolution-threads-active-mode-arg
+  (testing "a variant whose body carries `[:arg :only-in-mode]` for a key the
+            variant chain NEVER declares (supplied ONLY by an active mode)
+            resolves its decorator stack through the canvas front door when the
+            active mode is threaded — the recompile no longer throws
+            `:rf.error/story-missing-arg` (rf2-eyrpr)"
+    (registrar/reg-decorator* :deco/mode-wrap
+                              {:kind :hiccup :wrap (fn [body _] [:div.mode body])})
+    ;; the mode supplies :only-in-mode; the variant declares NO :args, so the
+    ;; key is reachable ONLY through the mode layer (the rf2-2cpoo new
+    ;; capability — `mode < variant`, mode fills the arg the variant omits).
+    (registrar/reg-mode* :Mode.canvas/big {:args {:only-in-mode "from-mode"}})
+    (registrar/reg-variant* :story.canvas.modearg/v
+                            {:component  :views/widget
+                             :decorators [[:deco/mode-wrap]]
+                             ;; `[:arg :only-in-mode]` substitutes at PLAN
+                             ;; compile, inside the `variant-plan` the canvas
+                             ;; recompiles to read `[:world :decorators]`.
+                             :db-seed    {:seeded [:arg :only-in-mode]}
+                             :events     []})
+    (testing "the OLD no-opts front door throws — the gap rf2-2cpoo left
+              (proves the test exercises the actual failing path)"
+      (is (missing-arg-throw?
+            #(decorators/resolve-decorators :story.canvas.modearg/v))
+          "without :run-args the recompile cannot substitute the mode-only arg"))
+    (testing "threading the active mode resolves the decorator stack cleanly"
+      (let [pack (decorators/resolve-decorators
+                   :story.canvas.modearg/v
+                   {:active-modes [:Mode.canvas/big]})]
+        (is (= [:deco/mode-wrap] (mapv :id (:hiccup pack)))
+            "the variant's :hiccup decorator resolves (no throw)")
+        (is (empty? (:errors pack))
+            "no resolution errors — the mode-only [:arg] substituted")))))
+
+(deftest canvas-decorator-resolution-threads-cell-override-arg
+  (testing "a `:cell-override` supplies the SOLE source of an `[:arg key]` in
+            the variant body; the canvas front door resolves the decorator
+            stack when the override is threaded (rf2-eyrpr — the highest run
+            layer, same as a mode at `cell-override > variant`)"
+    (registrar/reg-decorator* :deco/cell-wrap
+                              {:kind :hiccup :wrap (fn [body _] [:div.cell body])})
+    (registrar/reg-variant* :story.canvas.cellarg/v
+                            {:component  :views/widget
+                             :decorators [[:deco/cell-wrap]]
+                             :db-seed    {:seeded [:arg :only-in-cell]}
+                             :events     []})
+    (testing "the no-opts front door throws (the cell key is variant-absent)"
+      (is (missing-arg-throw?
+            #(decorators/resolve-decorators :story.canvas.cellarg/v))))
+    (testing "threading the cell-override resolves the stack cleanly"
+      (let [pack (decorators/resolve-decorators
+                   :story.canvas.cellarg/v
+                   {:cell-overrides {:only-in-cell "from-cell"}})]
+        (is (= [:deco/cell-wrap] (mapv :id (:hiccup pack))))
+        (is (empty? (:errors pack)))))))
+
+(deftest canvas-decorator-resolution-unaffected-when-arg-in-variant-chain
+  (testing "the COMMON case is unchanged: when every `[:arg key]` is declared
+            on the variant itself, the no-opts front door resolves fine — the
+            run-args threading is purely ADDITIVE (rf2-eyrpr regression guard)"
+    (registrar/reg-decorator* :deco/plain-wrap
+                              {:kind :hiccup :wrap (fn [body _] [:div.plain body])})
+    (registrar/reg-variant* :story.canvas.ownarg/v
+                            {:component  :views/widget
+                             :decorators [[:deco/plain-wrap]]
+                             :args       {:in-variant "static"}
+                             :db-seed    {:seeded [:arg :in-variant]}
+                             :events     []})
+    (testing "no-opts resolves (the variant declares the key)"
+      (is (= [:deco/plain-wrap]
+             (mapv :id (:hiccup (decorators/resolve-decorators
+                                  :story.canvas.ownarg/v))))))
+    (testing "and threading run opts resolves the IDENTICAL stack"
+      (is (= (mapv :id (:hiccup (decorators/resolve-decorators
+                                  :story.canvas.ownarg/v)))
+             (mapv :id (:hiccup (decorators/resolve-decorators
+                                  :story.canvas.ownarg/v
+                                  {:active-modes [] :cell-overrides {}}))))))))
+
+(deftest resolution-fingerprints-threads-run-args-without-throwing
+  (testing "the hot-reload fingerprint poll (`resolution-fingerprints`) threads
+            the per-run opts too, so a mode-only `[:arg]` variant does not
+            throw on the 500ms poll — fingerprints are body-derived + run-layer
+            invariant, the opts only let the ref-collection compile succeed
+            (rf2-eyrpr)"
+    (registrar/reg-decorator* :deco/fp-wrap
+                              {:kind :hiccup :wrap (fn [body _] [:div.fp body])})
+    (registrar/reg-mode* :Mode.fp/on {:args {:only-in-mode "x"}})
+    (registrar/reg-variant* :story.canvas.fp/v
+                            {:component  :views/widget
+                             :decorators [[:deco/fp-wrap]]
+                             :db-seed    {:seeded [:arg :only-in-mode]}
+                             :events     []})
+    (testing "the no-opts poll throws (the gap)"
+      (is (missing-arg-throw?
+            #(decorators/resolution-fingerprints :story.canvas.fp/v))))
+    (testing "threading the active mode lets the poll capture the fingerprint"
+      (let [fps (decorators/resolution-fingerprints
+                  :story.canvas.fp/v
+                  {:active-modes [:Mode.fp/on]})]
+        (is (contains? fps :deco/fp-wrap)
+            "the decorator's fingerprint is captured (no throw)")))))


### PR DESCRIPTION
## The gap

rf2-2cpoo (#3248) threaded the per-run arg layers (`:active-modes` / `:cell-overrides`) into the **runtime** plan compile (`prepare-context`), so an `[:arg key]` resolvable ONLY through a mode / cell / global / story layer (never the variant chain) substitutes cleanly. But the **canvas decorator front door** — `decorators/resolve-decorators`, which the live canvas, controls panel, docs-mode pane, and hot-reload fingerprint poll all call — still recompiled the plan (to read `[:world :decorators]`) **without** those layers.

That recompile runs `substitute-args` over the whole variant body, so a mode/cell-only `[:arg key]` threw `:rf.error/story-missing-arg` at decorator-resolution time even though the runner compile (with run opts) handled it. This is a NEW-capability completeness follow-up: the common case (every `[:arg]` key declared on the variant or its `:extends` chain) was always fine.

## The fix

Mirror #3248's threading on the decorator path:

- `collect-decorator-refs` takes an optional `run-args` → passes it to `variant-plan {:run-args …}`.
- `resolve-decorators`'s 2-arity builds run-args from the `{:active-modes :cell-overrides}` opts via `args/run-arg-layers` (the SAME shape `resolve-args` takes). `decorators` now `:requires args` — acyclic (`args` pulls only `config`/`predicates`/`registrar`; `plan` does not require `decorators`).
- `resolution-fingerprints` gains the same opts arity — fingerprints are body-derived and run-layer-invariant; the opts only let the ref-collection compile succeed on the 500ms poll.
- Call sites thread the SAME opts they already build for `resolve-args`: `canvas-inner`, workspace `variant-cell-inner`, docs `decorators-section` (`:cell-overrides nil`, mirroring its own args-section), controls `decorator-list`, and the shell fingerprint snapshot (per-variant `:cell-overrides`).
- The bare **1-arity** front door keeps the pre-fix variant-only behaviour (backward-compatible). The `frames/destroy!` teardown call (try/catch-wrapped, no run-opts source, run-invariant refs) is intentionally unchanged.

## The gate

`tools/story/test/re_frame/story/canvas_plan_resolution_test.cljc` (JVM + CLJS, DEFAULT side-table = the production path):

- **`canvas-decorator-resolution-threads-active-mode-arg`** — a variant whose `:db-seed` carries `[:arg :only-in-mode]` (a key supplied ONLY by an active mode): the old no-opts front door THROWS `:rf.error/story-missing-arg` (proves the test hits the actual failing path), and threading `{:active-modes […]}` resolves the `:hiccup` decorator stack cleanly.
- **`canvas-decorator-resolution-threads-cell-override-arg`** — same for a cell-override-only key.
- **`canvas-decorator-resolution-unaffected-when-arg-in-variant-chain`** — regression guard: the common case (variant declares the key) resolves with no opts, and threading opts yields the IDENTICAL stack (additive).
- **`resolution-fingerprints-threads-run-args-without-throwing`** — the hot-reload poll gets the same coverage.

Full story JVM suite green: **1638 tests / 6098 assertions, 0 failures, 0 errors** (incl. the #3248 runtime-runpath tests + the 4 new ones).

Scope: `tools/story/**` only. Specs `017-Testing-Story.md` (§Args) + `008-Docs-Mode.md` (decorators-section data source) updated to document the decorator-path threading.

> CLJS-only UI namespaces (canvas/controls/docs/shell/workspace) are pure-data threading changes; full CLJS browser compile deferred to CI (no `node_modules` in this fresh worktree). The `.cljc` gate runs under both JVM and the story CLJS build.