### PR TITLE
docs(Spec-Schemas): document :rf.fx.server/safe-redirect-args row (rf2-k29bq)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2411,6 +2411,17 @@ The `:rf/effect-map`'s `:fx` is `[[fx-id args] ...]`. Each *standard* `fx-id` (t
   [:map
    [:status   {:optional true} :int]                                       ;; default 302
    [:location :string]])
+
+;; :rf.server/safe-redirect — caller-UNtrusted redirect (open-redirect mitigation);
+;; :location is the validation target and so is REQUIRED here (unlike :rf.server/redirect,
+;; which has a documented no-target graceful path). The scheme / relative-only? / allowlist
+;; gate lives in re-frame.ssr.response/safe-redirect-fx; this is the structural shape check.
+(def SafeRedirectFxArgs
+  [:map
+   [:location       :string]
+   [:status         {:optional true} :int]                                 ;; default 302
+   [:relative-only? {:optional true} :boolean]
+   [:allow          {:optional true} [:sequential :string]]])              ;; allowlisted hosts
 ```
 
 These are registered under spec ids:
@@ -2432,6 +2443,7 @@ These are registered under spec ids:
 | `:rf.fx.server/set-cookie-args` | `:rf.server/set-cookie` (the `:rf.server/cookie` shape) |
 | `:rf.fx.server/delete-cookie-args` | `:rf.server/delete-cookie` |
 | `:rf.fx.server/redirect-args` | `:rf.server/redirect` |
+| `:rf.fx.server/safe-redirect-args` | `:rf.server/safe-redirect` (caller-untrusted redirect; `:location` required) |
 
 The `:http` schema is **user-owned, not framework-owned** — projects that ship their own HTTP integration register their own `:schema` on their own `:http` `reg-fx`. The schema here is a reasonable starting point (the conformance corpus uses it) but is not part of the locked pattern contract.
 


### PR DESCRIPTION
@
Documents the `:rf.fx.server/safe-redirect-args` schema in `spec/Spec-Schemas.md`, the deferred follow-up row from rf2-wtd8z (which added the schema to `implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc`). Was sequenced after z522n (now merged) to avoid a hot-zone collision in Spec-Schemas.

Two minimal additions mirroring the sibling six `:rf.server/*` fx-args rows:

1. A `SafeRedirectFxArgs` def in the standard-fx-args clojure block, after `RedirectFxArgs`.
2. A table row mapping `:rf.fx.server/safe-redirect-args` to `:rf.server/safe-redirect`.

The documented shape matches the impl `safe-redirect-args` def exactly:
- `:location` — REQUIRED `:string` (the validation target; unlike caller-trusted `:rf.server/redirect`, safe-redirect has no no-target graceful path)
- `:status` — optional `:int` (default 302)
- `:relative-only?` — optional `:boolean`
- `:allow` — optional `[:sequential :string]` (allowlisted hosts)

## Quality gates

- `python scripts/check_doc_slugs.py` — PASS (exit 0)
- `python scripts/check_doc_slugs.py --self-test --verbose` — PASS (all 11 self-tests)
- `python scripts/check_doc_slugs.py --verbose` — PASS (396 files scanned, no broken links)
- `mkdocs build --strict` — not runnable locally (mkdocs not installed); CI `docs.yml` covers it

Closes rf2-k29bq.
@