### PR TITLE
docs(skills/migration): drop the obsolete breaking-changes 'this section governs' stopgap (rf2-ufy9a)

### DIFF
--- a/skills/re-frame-migration/references/breaking-changes.md
+++ b/skills/re-frame-migration/references/breaking-changes.md
@@ -113,8 +113,6 @@ Confirmed-broken v1 add-ons (each references the removed `re-frame.core/console`
 
 This surface is keyed off application-/dep-level triggers (Maven coords + fx ids), so it pairs with the O-16 / O-17 detection but is **not** gated behind the opt-in question — the removal/replacement is required.
 
-> **Note on the corpus.** Older MIGRATION.md O-16 / O-17 prose says the v1 add-on "continues to work against v2." That line predates the `re-frame.core/console` removal and is **superseded by this section** — the add-on does not compile on v2. Where the corpus and this section disagree on the add-on "keeps working" point, **this section governs** until the corpus prose is corrected.
-
 ## Opt-in modernisations (O-rules) by trigger surface
 
 The author **must** ask for these. They are never auto-applied as part of a routine v1→v2 migration.


### PR DESCRIPTION
@
## What

Drops the now-obsolete "Note on the corpus" stopgap in `skills/re-frame-migration/references/breaking-changes.md` (~L116). It declared **"this section governs until the corpus prose is corrected,"** asserting that older MIGRATION.md O-16/O-17 prose still said the v1 add-on "continues to work against v2."

## Why

rf2-r6377 (#3227) corrected the corpus. The current MIGRATION.md (`migration/from-re-frame-v1/README.md`) O-16 (line ~2827) and O-17 (line ~2839) now explicitly state the broken add-ons **"do not keep working against v2"** — they fail to compile on the removed `re-frame.core/console`. The premise of the stopgap is gone, so the note is dead weight (CLARITY). Surrounding content left intact.

## Verification

- Confirmed the corpus is corrected: O-16/O-17 both carry "Acting is forced; the conversion path is the opt-in part … It does **not** keep working against v2."
- Confirmed no surviving "continues to work against v2" claim is tied to the broken add-ons.

## Quality gates

| Gate | Result |
|---|---|
| `python scripts/check_skill_migration_cites.py` | PASS (exit 0) |
| `python scripts/check_doc_slugs.py` | PASS (exit 0) |
| `python scripts/check_skill_redirect_anchors.py` | PASS (exit 0) |

Closes rf2-ufy9a.
@