### PR TITLE
fix(skills/implementor): correct issue-body mechanism to --body-file in design.md (rf2-vntn3)

### DIFF
--- a/skills/re-frame2-implementor/spec/authoring-prompt.md
+++ b/skills/re-frame2-implementor/spec/authoring-prompt.md
@@ -48,7 +48,7 @@ A self-contained prompt that re-authors the `re-frame2-implementor` skill from t
 > *5. No core.async. Async fx via host primitives; cross-frame work serialised per frame.*
 > *6. JVM-runnability for the test surface (pure functions stay callable from non-substrate harness).*
 > *7. Conformance corpus is the acceptance test. `passed / claimed-applicable`.*
-> *8. Spec gaps file GitHub issues against `day8/re-frame2` (never `bd`, which is monorepo-internal — see L6 lock and `skills/README.md` baseline). Bodies pass via stdin/here-doc, never inline interpolation. Cross-repo filings are announced first (cardinal rule 9). Never silent extrapolation from the reference.*
+> *8. Spec gaps file GitHub issues against `day8/re-frame2` (never `bd`, which is monorepo-internal — see L6 lock and `skills/README.md` baseline). Bodies pass via `--body-file` (the body is written to a file first), never inline interpolation. Cross-repo filings are announced first (cardinal rule 9). Never silent extrapolation from the reference.*
 >
 > *Locks to preserve verbatim (from `spec/design.md`):*
 >

--- a/skills/re-frame2-implementor/spec/design.md
+++ b/skills/re-frame2-implementor/spec/design.md
@@ -59,7 +59,7 @@ The skill frames `spec/conformance/` consistently as the **objective measure of 
 
 When implementing surfaces a spec gap — a missing surface, an inconsistency, an undocumented decision — the agent files a GitHub issue against `day8/re-frame2`. Does not silently invent an answer; does not extrapolate from the reference.
 
-**Tracker boundary**: `bd` (beads) is the re-frame2 monorepo's internal tracker. Published skills run in *consumer* repos (an engineer's port repo, in this skill's case) and must never invoke `bd` — cross-repo side effects target the *target* repo's GitHub issues. The published skill announces the cross-repo filing before it lands (cardinal rule 9), and passes the body via stdin / here-doc, never inline interpolation (shell-safety baseline in `skills/README.md`).
+**Tracker boundary**: `bd` (beads) is the re-frame2 monorepo's internal tracker. Published skills run in *consumer* repos (an engineer's port repo, in this skill's case) and must never invoke `bd` — cross-repo side effects target the *target* repo's GitHub issues. The published skill announces the cross-repo filing before it lands (cardinal rule 9), and passes the body via `gh`'s native `--body-file` flag (the body is `Write`-ten to a file first), never inline interpolation (shell-safety baseline in `skills/README.md`).
 
 **Why**: spec gaps are findings. The reference's prior solution to a spec gap was *one engineer's call at one moment*. Treating it as the contract retroactively conflates worked-example and contract — undercutting L1.
 


### PR DESCRIPTION
@
## Summary

`skills/re-frame2-implementor/spec/design.md` (L6 "Tracker boundary") and `spec/authoring-prompt.md` (lock 8) described the `gh issue` body as passed via **stdin / here-doc**. The skills actual recipe — `references/cardinal-rules.md` §8 and `references/kickoff-prompt.md` — uses **`--body-file`**, matching the shell-safety baseline in `skills/README.md`.

That baseline explicitly forbids a `cat > file` here-doc or a `--body "$(cat …)"` subshell under the `Bash(gh issue *)` permission these skills declare, so the design-doc phrasing did not merely diverge from the recipe — it contradicted the documented mechanism. Corrected both spec references to the `--body-file` mechanism (body `Write`-ten to a file first, then a bare `gh issue create --body-file …`).

Verified before editing: the recipe leaf (`cardinal-rules.md` §8 lines 60-70) and `kickoff-prompt.md` line 34 already use `--body-file`; the canonical baseline in `skills/README.md` §Published-skill `allowed-tools` baseline (lines 246-265) is `--body-file`. A grep across the implementor skill confirms no remaining `stdin`/`here-doc` references after the fix.

Scope: `skills/re-frame2-implementor/**` only (2 files, 2 lines).

## Quality gates

- `python scripts/check_skill_mcp_drift.py` — pass (exit 0)
- `python scripts/check_skill_migration_cites.py` — pass (exit 0)
- `python scripts/check_skill_package_refs.py` — pass (exit 0)
- `python scripts/check_skill_redirect_anchors.py` — pass (exit 0)
- `python scripts/check_doc_slugs.py` — pass (exit 0)
@