### PR TITLE
ci(api-manifest): wire :test alias regression tests into the lint job (rf2-4v79f)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -341,6 +341,18 @@ jobs:
         working-directory: implementation/scripts/api-manifest
         run: clojure -M -m re-frame.api-manifest.doc-guide-check
 
+      # Pure-reconciler regression contracts (rf2-4v79f). The `:test` alias
+      # carries the unit tests that lock the reconcilers the check-mains
+      # above drive: the api-md-check qualifier-resolution contract
+      # (rf2-41j0a — a fully-qualified symbol must match its EXACT [ns var],
+      # never merely share a bare var name) and the xray-spec-check contract
+      # (rf2-0u8kz). The check-mains go RED on real drift, but these unit
+      # contracts pin the reconciler logic itself; gating them here closes
+      # the local-only-dev-net hole.
+      - name: Run api-manifest reconciler regression tests
+        working-directory: implementation/scripts/api-manifest
+        run: clojure -M:test
+
   # ---------------------------------------------------------------------------
   # Required-checks aggregator (rf2-aemyt).
   #


### PR DESCRIPTION
Wires the api-manifest artefact's `:test` alias regression tests into CI (bead rf2-4v79f).

## Problem

The `:test` alias of `implementation/scripts/api-manifest/deps.edn` carries pure-reconciler unit contracts that were **not run by any CI workflow** — a local-only dev net:

- `test/re_frame/api_manifest/api_md_check_test.clj` — rf2-41j0a qualifier-resolution contract (a fully-qualified panel symbol must match its EXACT `[ns var]`, never merely share a bare var name)
- `test/re_frame/api_manifest/xray_spec_check_test.clj` — rf2-0u8kz contract

The `lint.yml` `api-manifest` job ran only the `-m ...` check-mains (`gen --check`, `api-md-check`, `story/xray/skills/doc-guide-check`). Those go RED correctly on real manifest drift, but the **reconciler logic itself** — the resolution semantics these tests pin — was ungated in CI.

## Change

Add one step, `Run api-manifest reconciler regression tests`, after the existing check-main steps in the `api-manifest` job, running `clojure -M:test` with `working-directory: implementation/scripts/api-manifest`. It mirrors the adjacent steps' shape exactly. The step rolls up into the existing `Lint required` aggregator, so a regression now blocks the merge.

Minimal workflow edit (+12 lines), no back-compat shims. The `:test` alias content is unchanged — this only wires it into CI.

## Quality gates

- `cd implementation/scripts/api-manifest && clojure -M:test` — green locally: **14 tests, 30 assertions, 0 failures, 0 errors** (this is exactly what the new step runs).
- `lint.yml` YAML validated well-formed (`yaml.safe_load` parses clean).
- Edited step mirrors the adjacent check-main steps (`name:` / `working-directory:` / `run:`).
- Diff is exactly one file, +12 lines.

Bead: rf2-4v79f. Surfaced by rf2-41j0a (PR #3271).