### PR TITLE
chore(shadow-cljs): refresh stale :examples/machine-epochs build comment (rf2-nl1lj)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -298,16 +298,17 @@
             ;; slot (machine_epochs takes 8033).
             8032 ["../tools/xray/testbeds/routes_epochs"
                   "out/examples/routes-epochs"]
-            ;; Single-frame machine-epochs testbed (rf2-w06op) — the
-            ;; STATE-MACHINE sibling of standard-epochs: a tall column of
-            ;; numbered buttons, each bumping a shared baseline counter +
-            ;; sending one machine event exercising one more machine
-            ;; feature, so clicking top-to-bottom completely exercises the
-            ;; Xray Machine Inspector (rf-xray-machine-inspector). Same
-            ;; source-dir-first cascade as 8031/8032; compiled main.js
-            ;; falls through to out/examples/machine-epochs. Port 8033 is
-            ;; the trio's machine slot (standard-epochs 8031, routes-epochs
-            ;; 8032).
+            ;; machine-epochs testbed (rf2-w06op; reworked to a
+            ;; multi-machine frame-isolated stepper per rf2-q3lfm) — the
+            ;; STATE-MACHINE Xray driver. A left machine-picker rail; each
+            ;; of the 8 machine domains runs in its OWN frame and owns its
+            ;; OWN epoch ring, and selecting one re-points Xray at that
+            ;; frame so every observation panel (Epoch cascade, scrubber,
+            ;; App-db, Machine Inspector) shows ONLY that machine's
+            ;; isolated arc. Same source-dir-first cascade as 8031/8032;
+            ;; compiled main.js falls through to out/examples/machine-epochs.
+            ;; Port 8033 is the machine slot of the _epochs port trio
+            ;; (standard-epochs 8031, routes-epochs 8032).
             8033 ["../tools/xray/testbeds/machine_epochs"
                   "out/examples/machine-epochs"]
             ;; Single-frame edn-inspector testbed (rf2-74u2s) — the
@@ -825,27 +826,30 @@
    :devtools         {:preloads [re-frame2-pair.runtime
                                  day8.re-frame2-xray.preload]}}
 
-  ;; Single-frame machine-epochs testbed (rf2-w06op) — the STATE-MACHINE
-  ;; sibling of standard-epochs. Same shape (a tall column of numbered
-  ;; buttons in ONE plainly-mounted frame, each button bumping a shared
-  ;; baseline counter + sending one machine event exercising one more
-  ;; machine feature), aimed squarely at the Xray Machine Inspector
-  ;; (rf-xray-machine-inspector): click top-to-bottom and the Inspector's
-  ;; surfaces (topology highlight · focused-transition lens · guards /
-  ;; actions · snapshot drill-in · transition history · parallel regions)
-  ;; are completely exercised. A TEST surface — no deliberate bugs, no
-  ;; teaching layers (feedback_testbeds_are_test_surfaces).
+  ;; machine-epochs testbed (rf2-w06op; reworked to a multi-machine
+  ;; frame-isolated stepper per rf2-q3lfm) — the STATE-MACHINE Xray
+  ;; driver. A left machine-picker rail over the shared queued-step
+  ;; runner, re-expressed as a multi-track picker: each of the 8 machine
+  ;; domains (door · traffic · quiz · brew · session · fuse · hvac ·
+  ;; media) runs in its OWN frame and owns its OWN epoch ring. Selecting
+  ;; a track boots its machine(s) and re-points Xray
+  ;; (:rf.xray/select-frame) at that frame, so every observation panel
+  ;; (the Epoch cascade, the time-travel scrubber, the App-db panel, the
+  ;; Machine Inspector — topology highlight · focused-transition lens ·
+  ;; guards / actions · snapshot drill-in · transition history · parallel
+  ;; regions) shows ONLY that machine's isolated arc. A TEST surface — no
+  ;; deliberate bugs, no teaching layers (feedback_testbeds_are_test_surfaces).
   ;;
   ;; The machines / events / subs / views are OWNED in
   ;; machine_epochs/core.cljs — it boots the machines artefact
   ;; (`[re-frame.machines]`) and uses the real `reg-machine` + machine-
-  ;; event-routing surface; it does NOT reuse the deleted testdeck.*
-  ;; modules, and the deep_machine framework testbed stays the gate's
-  ;; deterministic machine substrate (this deck does not touch it).
+  ;; event-routing surface; the machine specs are shared with the
+  ;; assertion harness via the sibling ns machine_epochs/machines.cljs.
   ;; Sources live under tools/xray/testbeds/machine_epochs/; the Xray
-  ;; preload auto-mounts inline so every lens reads the single frame.
+  ;; preload auto-mounts inline, and the picker re-points it per-frame so
+  ;; every lens reads exactly the selected machine's frame.
   ;; Served at http://localhost:8033 via the top-level `:dev-http` map
-  ;; (the machine slot of the _epochs trio — standard-epochs 8031,
+  ;; (the machine slot of the _epochs port trio — standard-epochs 8031,
   ;; routes-epochs 8032 mirror this build-id scheme).
   :examples/machine-epochs
   {:target           :browser


### PR DESCRIPTION
## What

Refresh the stale `:examples/machine-epochs` comments in `implementation/shadow-cljs.edn` (rf2-nl1lj).

q3lfm (#3223) reworked the machine-epochs testbed into a **multi-machine, frame-isolated Xray stepper**, but the shadow-cljs.edn comments still described the OLD **single-frame "baseline counter / numbered buttons"** shape. q3lfm left them untouched because shadow-cljs.edn is hot-zone. This rides the comment fix on a (now sole-toucher) hot-zone pass per the bead.

Two comment blocks refreshed to match the source at `tools/xray/testbeds/machine_epochs/core.cljs`:
- the `:dev-http` port-8033 block
- the `:examples/machine-epochs` build-definition block

New description: a left machine-picker rail where each of 8 machine domains (door · traffic · quiz · brew · session · fuse · hvac · media) runs in its own frame with its own epoch ring; selecting a track boots its machine(s) and re-points Xray (`:rf.xray/select-frame`) so every observation panel shows only that machine's isolated arc.

## Scope discipline

Comment-only. **No** build-id, source-path, port (8033), output-dir, init-fn, or compiler-option changed. Sibling testbed comments (standard-epochs, routes-epochs, edn-inspector) — genuinely single-frame — were left untouched. The port-trio facts (8031/8032/8033) are preserved.

## Quality gates

- **Comment-only proof**: `git diff origin/main` filtered to non-comment, non-blank changed lines returns EMPTY — every added/removed line is a `;;` comment.
- **EDN structural parse**: `clojure.tools.reader` (shadow-cljs's reader) parses the file as exactly **1 top-level form, PARSE-OK**. (Note: `clojure.edn/read-string` reports "EOF while reading character" on both this and the pristine origin/main version — a pre-existing `clojure.edn` char-literal limitation, not introduced here.)
- Worker worktree guard passed (`WORKTREE_ROOT=...re-frame2-worktrees/shadow-cljs-comment-nl1lj`).

Closes rf2-nl1lj.