### PR TITLE
ci: gate README inventories via check_readme_inventories.py (rf2-fvv9c)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,6 +190,19 @@ jobs:
       - name: Validate README links (targets + MkDocs-rule anchor slugs)
         run: python scripts/check_readme_links.py --ci
 
+      # README inventory drift-ratchet gate (rf2-fvv9c, follows rf2-198k3).
+      # check_readme_inventories.py asserts the layout-map <-> disk bijection
+      # and the "N <noun>" count-numeral claims in the pair-mcp / story-mcp
+      # READMEs. It was wired into the local pre-checkin spine
+      # (scripts/test-fast-pr.sh) but did not gate CI, so a contributor who
+      # skipped the local spine could land README inventory drift unchecked.
+      # Pure Python stdlib — no extra deps over the slugifier install above.
+      - name: Self-test the README inventory validator
+        run: python scripts/check_readme_inventories.py --self-test --verbose
+
+      - name: Validate README inventories (layout-map <-> disk + count claims)
+        run: python scripts/check_readme_inventories.py --verbose
+
   jvm-core:
     name: JVM core (clojure -M:test)
     # rf2-f79t8 — job-level gating (NOT a workflow-trigger path filter:


### PR DESCRIPTION
## Summary

`scripts/check_readme_inventories.py` (added in rf2-198k3 — README layout-map ↔ disk bijection + "N <noun>" count-numeral drift ratchet for the pair-mcp / story-mcp READMEs) was wired into the local pre-checkin spine (`scripts/test-fast-pr.sh`) but **did not gate CI**. A contributor who skipped the local spine could land README inventory drift without turning CI red.

This wires it in by adding two steps to the existing `verify-readme-links` job in `test.yml`, mirroring the adjacent `check_readme_links.py` step pattern:

- `python scripts/check_readme_inventories.py --self-test --verbose`
- `python scripts/check_readme_inventories.py --verbose`

The `verify-readme-links` job already has Python set up and is already listed in the `all-required-passed` aggregator's `needs:`, so the new gate rolls into the required check set with no further wiring. Pure Python stdlib — no extra deps over the slugifier install already in the job. No new job is created (per the bead's "don't duplicate a job; add a step to the right existing one").

Follows rf2-198k3; cross-ref rf2-27ptt.

## Quality gates

Run from the worktree against the wired script:

- `python scripts/check_readme_inventories.py` → exit 0 (green on current main — what's being wired)
- `python scripts/check_readme_inventories.py --self-test --verbose` → exit 0 (all self-tests passed)
- `python scripts/check_readme_inventories.py --verbose` → exit 0 (no README inventory violations)
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` → `YAML_OK` (workflow parses well-formed)
- New steps mirror the indentation + `--self-test`/main split of the adjacent `check_readme_links.py` steps.

HOT-ZONE: `.github/workflows/test.yml` only — sole toucher this run.
