### PR TITLE
fix(examples/reagent+skills): :rf/start → :rf.machine/start so the boot machine actually fires (rf2-5nzih)

### DIFF
--- a/examples/reagent/boot/README.md
+++ b/examples/reagent/boot/README.md
@@ -30,8 +30,10 @@ initialisation graph. The boot sequence is:
 - `:ready` — terminal. The main view only mounts after the boot
   machine reaches this state.
 - `:failed` — terminal. The view renders an error screen with a
-  retry button; the retry dispatches `[:app/boot [:rf/start]]`
-  back into the boot machine.
+  retry button; the retry dispatches `[:app/boot [:boot/restart]]`
+  back into the boot machine (a real re-entry event — the
+  `:rf.machine/start` creation marker is inert once the machine
+  exists).
 
 ## Key Pattern-Boot decisions
 

--- a/examples/reagent/boot/boot.cljs
+++ b/examples/reagent/boot/boot.cljs
@@ -64,8 +64,8 @@
    the `:promote-staged` action reads it from there to thread the
    `:api-base` into the next phase (mechanism 3 → mechanism 2 above).
 
-   Trigger boot once at app start via `[:app/boot [:rf/start]]`. The
-   machine self-initialises (per Spec 005 §Restore semantics): the
+   Trigger boot once at app start via `[:app/boot [:rf.machine/start]]`.
+   The machine self-initialises (per Spec 005 §Restore semantics): the
    `:initial` state and `:data` seed `[:rf/runtime :machines :snapshots :app/boot]` when
    the dispatch lands."
   (:require [re-frame.core :as rf]
@@ -204,8 +204,8 @@
 ;; ============================================================================
 
 (rf/reg-machine :app/boot
-  {:initial :idle
-   :data    {:phase  :idle
+  {:initial :configuring
+   :data    {:phase  :configuring
              :config nil
              :flags  nil
              :user   nil
@@ -245,16 +245,14 @@
        :fx   [[:dispatch [:boot/apply-hydration]]]})}
 
    :states
-   {;; ---- :idle — the parking spot before the boot kicks off -------------
-    ;; Per the standard re-frame2 state-machine convention (see the
-    ;; `:spawn-all` conformance fixtures), a machine's initial state
-    ;; is `:idle` and the first work-event transitions it onward. Here
-    ;; the `:rf/start` event the dispatched-on-app-boot fires moves
-    ;; :idle → :configuring, which fires the :spawn entry-cascade.
-    :idle
-    {:on {:rf/start :configuring}}
-
-    ;; ---- :configuring — a single :spawn fetches /config -----------------
+   {;; ---- :configuring — the :initial state; a single :spawn fetches /config
+    ;; Per Pattern-Boot the boot machine is BORN directly into its first
+    ;; work state. The init-kick `[:app/boot [:rf.machine/start]]` is a
+    ;; PURE creation marker (Spec 005 §F‴ / transition/start-marker): it
+    ;; runs the initial-entry cascade — here `:configuring`'s `:spawn` —
+    ;; and STOPS; it is NEVER fed into an `:on` map as a trigger. So there
+    ;; is no `:idle` parking spot and no start-marker transition: the
+    ;; machine starts working the moment it is kicked.
     :configuring
     {:spawn {:machine-id :boot/loader
               ;; Per Spec 005 §Spec-spec keys, `:data` admits a
@@ -332,16 +330,20 @@
     ;; ---- :ready / :failed — terminal -------------------------------------
     :ready  {:meta {:terminal? true}}
     :failed {;; Per Pattern-Boot §Re-boot semantics, :failed is
-             ;; re-entrant — dispatching `[:app/boot [:rf/start]]`
-             ;; from the failure screen re-runs the boot from
-             ;; :configuring. The terminal? meta is still true so
+             ;; re-entrant — dispatching the explicit re-entry event
+             ;; `[:app/boot [:boot/restart]]` from the failure screen
+             ;; re-runs the boot from :configuring. Re-boot uses a REAL
+             ;; event, NOT the `:rf.machine/start` creation marker: the
+             ;; marker is a pure init-kick that is never fed into an `:on`
+             ;; map (Spec 005 §F‴), so once the machine exists a start
+             ;; marker is inert. The terminal? meta is still true so
              ;; visualisers / conformance harnesses see :failed as a
-             ;; terminal state; the re-entry transition is the
-             ;; explicit re-boot, not the default end of the flow.
+             ;; terminal state; the re-entry transition is the explicit
+             ;; re-boot, not the default end of the flow.
              :meta {:terminal? true}
-             :on   {:rf/start {:target :configuring
-                               :action (fn [{data :data}]
-                                         {:data (assoc data :error nil)})}}}}})
+             :on   {:boot/restart {:target :configuring
+                                   :action (fn [{data :data}]
+                                             {:data (assoc data :error nil)})}}}}})
 
 ;; ============================================================================
 ;; HYDRATION PROMOTION
@@ -381,11 +383,13 @@
 ;; ============================================================================
 
 (rf/reg-event-fx :boot/initialise
-  {:doc "Top-level app boot. Fires the :app/boot machine's :rf/start
-         event to kick the boot sequence off. The frame's :on-create
-         points at this event (see core.cljs)."}
+  {:doc "Top-level app boot. Fires the :app/boot machine's
+         `:rf.machine/start` creation marker to kick the boot sequence
+         off — the machine is born directly into `:configuring` and runs
+         its `:spawn` entry-cascade. The frame's :on-create points at
+         this event (see core.cljs)."}
   (fn handler-app-initialise [_ _]
-    {:fx [[:dispatch [:app/boot [:rf/start]]]]}))
+    {:fx [[:dispatch [:app/boot [:rf.machine/start]]]]}))
 
 ;; ============================================================================
 ;; SUBS — boot-state slots the views read

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -151,8 +151,9 @@
   ;; Kick the boot. The `:app/boot` machine's :initial state and
   ;; :data seed `[:rf/runtime :machines :snapshots :app/boot]` on first dispatch (per
   ;; Spec 005 §Restore semantics); :boot/initialise fires
-  ;; `[:app/boot [:rf/start]]`, which transitions :configuring's
-  ;; :spawn spawn-fx and starts the boot sequence.
+  ;; `[:app/boot [:rf.machine/start]]`, the creation marker that births
+  ;; the machine directly into :configuring and runs its :spawn
+  ;; entry-cascade, starting the boot sequence.
   (rf/dispatch-sync [:boot/initialise])
 
   (when (exists? js/document)

--- a/examples/reagent/boot/views.cljs
+++ b/examples/reagent/boot/views.cljs
@@ -16,10 +16,13 @@
 
    The failure path renders `[boot-failed]` (terminal `:failed`),
    which surfaces the error and offers a retry button. The retry
-   dispatches `[:app/boot [:rf/start]]` directly back into the boot
+   dispatches `[:app/boot [:boot/restart]]` directly back into the boot
    machine — re-running the boot from `:configuring` is supported
    per Pattern-Boot §Re-boot semantics (the example treats `:failed`
-   as a re-entrant target rather than terminal-with-reload).
+   as a re-entrant target rather than terminal-with-reload). Re-boot
+   uses a REAL re-entry event, not the `:rf.machine/start` creation
+   marker — the marker is a pure init-kick and is inert once the
+   machine already exists.
 
    Why split the views by boot state: the alternative — mount the
    main app and let each sub-view render a per-phase loading
@@ -65,7 +68,7 @@
         (str "Reason: " msg)
         "An unexpected error occurred during application boot.")]
      [:button {:data-testid "boot-retry"
-               :on-click    #(dispatch [:app/boot [:rf/start]])}
+               :on-click    #(dispatch [:app/boot [:boot/restart]])}
       "Retry boot"]]))
 
 (reg-view ^{:doc "Post-ready screen — the main app. By the time this

--- a/skills/re-frame2/patterns/boot.md
+++ b/skills/re-frame2/patterns/boot.md
@@ -16,7 +16,7 @@ For trivial boots (≤3 steps, no error states, no progress UI), use the chained
 
 | Feature | Role |
 |---|---|
-| `reg-frame` `:on-create` | Atomic entry point — fires `[:app/boot [:rf/start]]` exactly once per frame creation; survives hot-reload. |
+| `reg-frame` `:on-create` | Atomic entry point — fires `[:app/boot [:rf.machine/start]]` exactly once per frame creation; survives hot-reload. |
 | `:spawn` per phase | Each phase spawns its async work (`:rf.http/managed` or a domain child like `:auth/restore-session`) and transitions on `:succeeded` / `:failed`. |
 | Consolidated `:entry` action | Per Spec 005, `:entry` is one fn or one registered id — never a vector. To update `:data` AND dispatch, write one action returning `{:data ..., :fx ...}`. |
 | `:after` (numeric delay) | Retry-with-backoff between failed phase and re-attempt. |
@@ -89,7 +89,7 @@ For trivial boots (≤3 steps, no error states, no progress UI), use the chained
       :fatal-error    {:meta {:terminal? true}}}}))
 ```
 
-The frame's `:on-create` dispatches `[:app/boot [:rf/start]]`; the machine self-initialises.
+The frame's `:on-create` dispatches `[:app/boot [:rf.machine/start]]` — the reserved creation marker that births the machine directly into its `:initial` state (`:configuring`) and runs that state's entry-cascade. The marker is a pure init-kick (it is never fed into an `:on` map as a trigger), so the machine self-initialises and starts working at birth — there is no idle parking spot waiting on the marker.
 
 ## Simple form — chained events
 


### PR DESCRIPTION
Sibling-lane fix to rf2-cd8vz (Pattern-Boot.md). The non-existent creation marker `:rf/start` (the real marker is `:rf.machine/start` = `transition/start-marker`, rf2-gl588) had drifted into the `examples/reagent/boot/**` example and the `skills/re-frame2/patterns/boot.md` skill — including **live transition keys**, so the boot machine never fired at runtime.

## What was broken

The `:app/boot` machine had a dead `:idle` parking spot whose only exit was `:on {:rf/start :configuring}`. Two compounding defects:

1. `:rf/start` is recognised by nothing — the runtime marker is `:rf.machine/start`.
2. Even renamed, `:rf.machine/start` is a **pure init-kick**: per `machines/.../lifecycle_fx/registration.cljc` it runs the initial-entry cascade and **STOPS**, and is **never fed into an `:on` map** as a trigger (regardless of whether the snapshot pre-exists). So `:on {:rf.machine/start :configuring}` could never fire.

A literal `:rf/start → :rf.machine/start` swap on the transition keys would therefore still leave the machine stuck in `:idle`. The state schema (`schema.cljs` enum: `:configuring … :ready :failed`) and the views already assumed the canonical Pattern-Boot `:initial :configuring` shape — `:idle` was never even a valid state.

## Fix (idiomatic Pattern-Boot)

- `:app/boot` is now born directly into `:configuring` (`:initial :configuring`); the dead `:idle` state + its start-marker transition are removed. The init-kick `[:app/boot [:rf.machine/start]]` runs `:configuring`'s `:spawn` entry-cascade — the machine actually boots.
- `:failed` re-boot now uses a **real** re-entry event `[:boot/restart]`, not the inert creation marker (a start marker is a no-op once the snapshot exists).
- All remaining `:rf/start` prose/dispatch sites across `boot.cljs`, `core.cljs`, `views.cljs`, `README.md`, and `skills/re-frame2/patterns/boot.md` updated to `:rf.machine/start` (init-kick) or `:boot/restart` (re-boot).
- The loader-child machine's legitimate `:idle` (exits on the real `:rf.machine.spawn/spawned` event) is untouched.

The skill's own example machine was already `:initial :configuring`; only its two prose `:rf/start` mentions were drift.

## Quality gates

- `cd implementation && npm run test:examples-compile` → **all 39 example builds compiled, 0 warnings** (`[:examples/boot] Build completed … 0 warnings`).
- Skill / doc gates (run from repo root) all exit 0: `check_skill_redirect_anchors.py`, `check_skill_migration_cites.py`, `check_skill_package_refs.py`, `check_doc_slugs.py`, `check_skill_mcp_drift.py`.
- `git grep :rf/start` over the lane → **no matches remain**.
- Firing-correctness proof: the compile gate plus the runtime init-kick semantics confirmed against `transition.cljc` (start-marker) + `registration.cljc` (STOP branch) + the `singleton-initial-entry-fires-on-first-dispatch` machines test, which together establish that birthing into `:configuring` runs the `:spawn` entry-cascade while a dispatched start-marker into an `:on` map would not. (Examples are test-free per rf2-8cevm — no example test added.)

Closes rf2-5nzih.

## Note for the mayor (out of lane — not touched here)

`spec/Pattern-Boot.md` still contains three `:rf/start` references (lines ~197, ~324, ~366) — the rf2-cd8vz "all fixed" claim was stale for the spec too, not only the examples. Those are outside this worker's lane; flagging for a follow-up bead.
