### PR TITLE
docs(Spec-Schemas): widen redirect (two spots, no-target) + cookie ingress to match the live fx-args contract (rf2-cwfy2)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc
+++ b/implementation/ssr/src/re_frame/ssr/server_fx_schemas.cljc
@@ -60,19 +60,15 @@
   `:rf.server/set-cookie` / `:rf.server/delete-cookie` produce. Per
   Spec 011 §Cookie shape / [Spec-Schemas §`:rf.server/cookie`].
 
-  KNOWN DIVERGENCE from [Spec-Schemas §`:rf.server/cookie`] (filed for
-  Mike's ruling — rf2-kjf3m.2 follow-up). Spec-Schemas declares the
-  canonical types strictly:
-
-      :max-age   :int
-      :expires   :int                         ;; ms-since-epoch
-      :same-site [:enum :strict :lax :none]
-
-  …but `re-frame.ssr.response/validate-cookie!` (rf2-kjf3m.1 / rf2-z7gor)
-  DELIBERATELY accepts and `str`-coerces non-canonical scalar forms for
-  these three attrs — a string `:max-age`, a string/instant `:expires`,
-  a string `:same-site` (\"Strict\"/\"Lax\") — because apps build cookie
-  attrs from host-data that often arrives as strings, and the
+  Ingress tolerance vs canonical shape (rf2-cwfy2, ruled by Mike
+  2026-06-05 — Spec-Schemas widened to match this contract; no divergence
+  remains). The `:max-age`, `:expires`, and `:same-site` attrs carry a
+  `[:or <canonical-type> :string]` shape rather than the bare canonical
+  type, because `re-frame.ssr.response/validate-cookie!` (rf2-kjf3m.1 /
+  rf2-z7gor) DELIBERATELY accepts and `str`-coerces non-canonical scalar
+  forms for these three attrs — a string `:max-age`, a string/instant
+  `:expires`, a string `:same-site` (\"Strict\"/\"Lax\") — because apps
+  build cookie attrs from host-data that often arrives as strings, and the
   per-attribute CRLF gate must SEE those strings to reject a forged
   `\"3600\\r\\nSet-Cookie: admin=1\"` payload at the fx boundary. The
   ssr CRLF tests (`ssr-set-cookie-crlf-checks-every-attribute`) and the
@@ -80,18 +76,22 @@
   accepted`, which passes `:same-site \"Strict\"` + a string `:expires`)
   lock that tolerance in.
 
-  A schema that enforced Spec-Schemas' strict types would reject those
-  string forms at the Spec 010 §step-5 boundary BEFORE the CRLF gate runs
-  — changing the surfaced error from the specific `:rf.error/cookie-
-  invalid-<attr>` to a generic `:rf.error/schema-validation-failure`, and
+  A schema that enforced strict canonical types would reject those string
+  forms at the Spec 010 §step-5 boundary BEFORE the CRLF gate runs —
+  changing the surfaced error from the specific `:rf.error/cookie-invalid-
+  <attr>` to a generic `:rf.error/schema-validation-failure`, and
   rejecting the legitimately-tolerated string `:same-site`/`:expires`. So
-  the three coercible attrs widen to `[:or <spec-type> :string]` here: the
-  canonical spec type is documented + validated, AND the deliberately-
-  tolerated string form passes the shape gate so it reaches the CRLF
-  defence. `:secure` / `:http-only` / `:name` / `:value` / `:path` /
-  `:domain` match Spec-Schemas exactly. The divergence (tighten the fx to
-  the spec's strict cookie schema, OR amend Spec-Schemas to bless the
-  string forms) is Mike's call — see the follow-up decision bead."
+  the three coercible attrs widen to `[:or <canonical-type> :string]`: the
+  canonical type is documented + validated, AND the deliberately-tolerated
+  string form passes the shape gate so it reaches the CRLF defence.
+  `:secure` / `:http-only` / `:name` / `:value` / `:path` / `:domain` are
+  the bare canonical types. This is ingress CR/LF-inspection tolerance,
+  NOT a serialisability promise: the string form is tolerated at the fx
+  ingress but is not a generally-valid canonical shape — `:expires`, in
+  particular, MUST be an epoch-millis int at the host boundary (the Ring
+  adapter throws `:rf.error/cookie-invalid-expires` on a non-integer
+  `:expires`), so a string `:expires` fails at head materialisation by
+  design."
   [:map
    [:name      :string]
    [:value     :string]
@@ -155,14 +155,14 @@
   the redirect target. The CRLF / open-redirect gates live in
   `re-frame.ssr.response`; this is the structural shape check.
 
-  [Spec-Schemas]'s `RedirectFxArgs` names only `:location`, but Spec 011
-  §Standard fx (line 435) documents the target as `:location` **or
-  `:url`/`:to`**, and `re-frame.ssr.response/redirect-fx` reads all
-  three (`(or :location :url :to)`). The schema must not be narrower
-  than the documented + implemented fx contract, so it accepts any ONE
-  of the three target keys (a `:string`), each optional, plus the
-  optional `:int` `:status`. The fx handler resolves precedence
-  (`:location` wins, then `:url`, then `:to`).
+  [Spec-Schemas §`:rf.fx.server/redirect-args`]'s `RedirectFxArgs`, Spec
+  011 §Standard fx (line 435), and `re-frame.ssr.response/redirect-fx`
+  all agree: the target is supplied under any ONE of `:location` /
+  `:url` / `:to`, and redirect-fx reads all three (`(or :location :url
+  :to)`). The schema accepts any one of the three target keys (a
+  `:string`), each optional, plus the optional `:int` `:status`. The fx
+  handler resolves precedence (`:location` wins, then `:url`, then
+  `:to`).
 
   PERMISSIVE on the no-target case (rf2-ee38b.11 contract, the live half
   of decision rf2-cwfy2). All three target keys are optional AND a

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2212,8 +2212,10 @@ The HTTP-response accumulator owned by the request frame during SSR. Per [011 §
    [:headers  {:optional true} [:vector [:tuple :string :string]]]         ;; ordered [name value] pairs; case-insensitive name match
    [:cookies  {:optional true} [:vector [:ref :rf.server/cookie]]]         ;; structured cookies (per :rf.server/cookie below)
    [:redirect {:optional true} [:maybe [:map
-                                        [:status   {:optional true} :int] ;; default 302
-                                        [:location :string]]]]
+                                        [:status   {:optional true} :int]    ;; default 302
+                                        [:location {:optional true} :string] ;; redirect target (or :url / :to); see RedirectFxArgs — all optional, no-target permitted
+                                        [:url      {:optional true} :string]
+                                        [:to       {:optional true} :string]]]]
    [:content-type {:optional true} :string]])                              ;; convenience accessor; mirrors headers' "content-type"
 ```
 
@@ -2232,16 +2234,23 @@ The structured-cookie shape that `:rf.server/set-cookie` and `:rf.server/delete-
   [:map
    [:name      :string]
    [:value     :string]
-   [:max-age   {:optional true} :int]
-   [:expires   {:optional true} :int]                                      ;; ms-since-epoch; alternative to :max-age
+   [:max-age   {:optional true} [:or :int :string]]                        ;; canonical :int; string admitted at ingress (see §Ingress tolerance below)
+   [:expires   {:optional true} [:or :int :string]]                        ;; canonical ms-since-epoch :int; string admitted at ingress only (see below); Ring REQUIRES an int at the host boundary
    [:secure    {:optional true} :boolean]
    [:http-only {:optional true} :boolean]
-   [:same-site {:optional true} [:enum :strict :lax :none]]
+   [:same-site {:optional true} [:or [:enum :strict :lax :none] :string]]  ;; canonical enum; string admitted at ingress (see below)
    [:path      {:optional true} :string]
    [:domain    {:optional true} :string]])
 ```
 
 Either `:max-age` or `:expires` may be supplied (or neither — session cookie). User code does not build wire strings.
+
+**Ingress tolerance vs canonical/host-serialisable shape.** The `:max-age`, `:expires`, and `:same-site` attributes carry a `[:or <canonical-type> :string]` shape rather than the bare canonical type. This is **ingress tolerance for CR/LF inspection, not a serialisability promise.** Apps frequently build cookie attributes from host-data that arrives as strings, and the per-attribute CR/LF/NUL injection gate (`re-frame.ssr.response/validate-cookie!`, per [011 §CRLF fail-fast](011-SSR.md#crlf-fail-fast-on-header-values)) must be able to *see* those string forms to reject a forged `"3600\r\nSet-Cookie: admin=1"` payload at the fx boundary. The fx-args `:schema` here is a **shape/type gate**; `validate-cookie!` is the **separate CR/LF/NUL injection gate**. So these three attributes admit the string form purely so it reaches the injection gate.
+
+Two distinctions follow:
+
+- `validate-cookie!` only `str`-coerces a scalar attribute to *inspect* it for CR/LF/NUL; it does **not** write a coercion back. The cookie keeps the caller's original scalar types downstream.
+- The string form is **not** blessed as a generally-valid canonical shape. In particular, **`:expires` must be epoch-millis `:int` at the host (Ring) boundary**: the Ring adapter throws `:rf.error/cookie-invalid-expires` when `:expires` is non-integer (it needs a primitive long for `Instant/ofEpochMilli`). A string `:expires` is tolerated at the fx ingress (so the CR/LF gate can inspect host-derived values) but **fails at head materialisation by design**. The canonical-shape authority is the host adapter; the schema widening above represents ingress tolerance, not a promise that every string form is serialisable by every host.
 
 ### `:rf/head-model`
 
@@ -2406,11 +2415,24 @@ The `:rf/effect-map`'s `:fx` is `[[fx-id args] ...]`. Each *standard* `fx-id` (t
    [:path   {:optional true} :string]
    [:domain {:optional true} :string]])
 
-;; :rf.server/redirect — set status (default 302) and Location; truncates HTML body
+;; :rf.server/redirect — set status (default 302) and the redirect target; truncates HTML body.
+;; The target is supplied under any ONE of :location / :url / :to — all three are
+;; documented in [011 §Standard fx](011-SSR.md#standard-fx) and read by
+;; re-frame.ssr.response/redirect-fx (`(or :location :url :to)`, :location winning).
+;; All three are OPTIONAL and a redirect with ZERO target keys is NOT a structural
+;; error: it is the established graceful-degradation path (the fx accepts it — :location
+;; is caller-trusted/optional — and the host adapter emits a warning trace plus a 3xx
+;; with no Location header so the defect is observable rather than silently shipping a
+;; broken redirect). The schema is therefore a pure SHAPE gate (key types only) and does
+;; NOT require at-least-one target; a target-requiring clause would 400 the no-target
+;; redirect before that warn-then-302 path runs. (`:rf.server/safe-redirect` differs —
+;; :location is its validation target and so is REQUIRED there.)
 (def RedirectFxArgs
   [:map
    [:status   {:optional true} :int]                                       ;; default 302
-   [:location :string]])
+   [:location {:optional true} :string]                                    ;; redirect target (or :url / :to)
+   [:url      {:optional true} :string]                                    ;; synonym for :location
+   [:to       {:optional true} :string]])                                  ;; synonym for :location
 
 ;; :rf.server/safe-redirect — caller-UNtrusted redirect (open-redirect mitigation);
 ;; :location is the validation target and so is REQUIRED here (unlike :rf.server/redirect,


### PR DESCRIPTION
Closes rf2-cwfy2 (RULED **A with precision** by Mike 2026-06-05).

`spec/Spec-Schemas.md` was the lone stale artefact for the SSR `:rf.server/*` fx-args ingress contract. The registered schemas, Spec 011, and the impl already agreed on the wider contract; this PR makes the doc catch up. **No impl/behaviour change** — the schema EDN in `server_fx_schemas.cljc` is untouched (only its KNOWN-DIVERGENCE docstrings were reconciled).

## What changed

**REDIRECT — two stale spots widened + no-target permitted**
- `RedirectFxArgs` (Spec-Schemas): `:location` made optional; `:url` / `:to` added as synonyms; no at-least-one-target clause (the no-target shape passes the shape gate).
- Response `:redirect` shape (Spec-Schemas, the second spot the original framing missed): same widening.

**COOKIE — `:max-age` / `:expires` / `:same-site` admit string forms as INGRESS tolerance**
- `Cookie` schema widened to `[:or <canonical-type> :string]` for the three coercible attrs.
- Prose distinguishes ingress CR/LF-inspection tolerance from canonical/host-serialisable shape, and explicitly states `:expires` must be epoch-millis int at the Ring host boundary (a string `:expires` is tolerated at ingress but fails at head materialisation by design).

**Impl-side docstrings reconciled** (no EDN change): the `cookie` and `redirect-args` KNOWN-DIVERGENCE docstrings no longer claim a divergence.

## Impl-line cross-refs (proving the doc now matches)

| Doc spot | Matches impl |
|---|---|
| `RedirectFxArgs` + Response `:redirect`: `:location`/`:url`/`:to` all optional | `server_fx_schemas.cljc` `redirect-args` (`:location`/`:url`/`:to` each `{:optional true} :string`); `response.cljc:506-509` `(or (:location m) (:url m) (:to m))`; Spec `011-SSR.md:435` documents "(or :url/:to)" |
| no-target redirect permitted (warn→302), not 400 | `response.cljc:510` validates only `(when (some? location) …)`; default `:status 302` at `:517`; pinned by `ssr_end_to_end_test.clj:2134` (no-target → PASSES schema, warn path) |
| Cookie `:max-age` `[:or :int :string]`, `:expires` `[:or :int :string]`, `:same-site` `[:or <enum> :string]` | `server_fx_schemas.cljc` `cookie` var (lines 95-104) — identical shape |
| `validate-cookie!` str-coerces only to inspect for CR/LF/NUL | `response.cljc:266-318` `validate-cookie-attr!` / `validate-cookie!` (`str`-coerce, ban CR/LF/NUL, original scalar flows downstream) |
| `:expires` must be epoch-millis int at host boundary | `ssr-ring/cookie.clj:154` throws `:rf.error/cookie-invalid-expires` on non-integer `:expires` |

After this PR the four artefacts agree: Spec-Schemas (RedirectFxArgs + Response `:redirect` + Cookie), Spec 011:435/:496, the registered `re-frame.ssr.server-fx-schemas`, and the impl.

## Out of scope (flagged for Mike, not actioned here)
Whether to prune the three redirect-target synonyms (`:location`/`:url`/`:to`) to a deliberately-chosen canonical set is a separate API-design decision. cwfy2 reconciles the doc to the current shipped+tested contract; a prune would be its own ruling.

## Quality gates
- `python scripts/check_doc_slugs.py` — green (exit 0; no broken targets/anchors).
- `python -m mkdocs build --strict` — green (exit 0; no WARNING/ERROR lines).
- Schema EDN cross-check: the widened Spec-Schemas rows are byte-for-byte the registered shapes in `server_fx_schemas.cljc` (verified `git diff` touched only docstrings on the impl side, never the schema vectors).
