### PR TITLE
fix(epoch): project value-bearing :sub-runs at the off-box egress boundary (rf2-at60h)

### DIFF
--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -337,11 +337,19 @@
     (string? v) :string
     :else       :scalar))
 
-(defn- large-marker
-  "Mirror of `re-frame.elision/->marker`'s shape — inlined so this ns
+(defn large-marker
+  "Build the `:rf.size/large-elided` marker for value `v` at `path`.
+  Mirror of `re-frame.elision/->marker`'s shape — inlined so this ns
   carries no dependency on elision's privates. Carries `:reason
   :marks` so consumers can discriminate per-registration marks
-  from schema-driven marks."
+  from schema-driven marks.
+
+  Public because the off-box epoch egress projector
+  (`re-frame.epoch.tool-pair/projected-record`, rf2-at60h) reuses it to
+  substitute the marker for a whole-output `:large?`-stamped sub's
+  `:value` / `:prev-value` in the structured `:sub-runs` row — the same
+  `:reason :marks` provenance the whole-output propagation table sets,
+  built in ONE place rather than re-inlined a third time."
   [v path]
   (let [p (vec path)]
     {:rf.size/large-elided

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -447,7 +447,22 @@
   on the classpath. The projection threads it `cond->` so the row slot
   is likewise absent in those cases — consumers reading `(:cause-event-id row)`
   see nil and treat as no-attribution, parity with the OMITTED-vs-nil
-  semantics of the trace tag."
+  semantics of the trace tag.
+
+  PAYLOAD-BEARING value slots (rf2-at60h): `:prev-value` and `:value`
+  carry the sub's computed app-data, so this row is NOT value-free. The
+  whole-output `:sensitive?` stamp (rf2-isdwf) is already honoured at the
+  marks emit site (`re-frame.marks/project-sub-tags`) — `:value` /
+  `:prev-value` arrive carrying the `:rf/redacted` sentinel, so no further
+  projection is needed for the sensitive case. The whole-output `:large?`
+  stamp, however, only marks largeness on the trace tag and leaves the raw
+  value intact (the on-box ring must keep the exact value for Xray diff /
+  REPL / `restore-epoch`). We thread that tag onto the row as `:large?` so
+  the off-box `projected-record` egress boundary can substitute the
+  `:rf.size/large-elided` marker for `:value` / `:prev-value` under the
+  `:include-large? false` default. Threaded `cond->` (absent, not false,
+  when the sub's output is not large) — parity with the trace tag's
+  presence semantics."
   [event]
   (when (= :rf.sub/run (:operation event))
     (let [tags (:tags event)]
@@ -460,7 +475,10 @@
                :cascade?       (:rf.sub/cascade? tags)
                :cause-sub      (:rf.sub/cause-sub tags)}
         (contains? tags :rf.sub/cause-event-id)
-        (assoc :cause-event-id (:rf.sub/cause-event-id tags))))))
+        (assoc :cause-event-id (:rf.sub/cause-event-id tags))
+
+        (:large? tags)
+        (assoc :large? true)))))
 
 (defn render-row
   "Project a `:rf.view/rendered` trace event into its structured

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -45,6 +45,7 @@
             [re-frame.epoch.state :as state]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
+            [re-frame.marks :as marks]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
@@ -542,19 +543,77 @@
         (reroot-trace-event-db-slots frame-id)
         (elision/elide-wire-value {:frame frame-id}))))
 
+(defn- elide-sub-run-row
+  "Project a single structured `:sub-runs` row for off-box egress
+  (rf2-at60h). The row carries value-bearing `:prev-value` / `:value`
+  slots holding the sub's computed app-data — so, unlike the non-value
+  metadata (`:sub-id`, `:query-v`, `:value-changed?`, `:cascade?`,
+  `:cause-sub`, `:cause-event-id`), they MUST respect the projection
+  contract.
+
+  The whole-output `:sensitive?` case is already redacted at the marks
+  emit site (the slots arrive carrying `:rf/redacted`), so no work is
+  needed here for sensitive. The whole-output `:large?` case is carried
+  on the row as `:large?` (threaded by `capture/sub-run-row`) with the
+  RAW value still attached (the on-box ring keeps the exact value). For
+  the off-box `:include-large? false` default we substitute the canonical
+  `:rf.size/large-elided` marker (`re-frame.marks/large-marker`, the
+  same `:reason :marks` provenance the propagation table sets) for both
+  value slots, then strip the now-spent `:large?` flag so the projected
+  row's shape matches the on-box base shape's metadata. Idempotent: a
+  marker value rebuilt through a second pass would be wrong-sized, so a
+  slot already carrying a marker is left untouched.
+
+  Per-PATH large declarations (a sub with `:large [<path>]` marks but no
+  whole-output `:large?` stamp) are already substituted INTO the value
+  at the marks emit site (`redact-with-paths`), so they ride the row
+  pre-marked and need no projection here."
+  [row]
+  (if-not (:large? row)
+    row
+    (-> row
+        (cond-> (contains? row :value)
+          (update :value (fn [v]
+                            (if (elision/marker? v) v (marks/large-marker v [:value]))))
+          (contains? row :prev-value)
+          (update :prev-value (fn [v]
+                                (if (elision/marker? v) v (marks/large-marker v [:prev-value])))))
+        (dissoc :large?))))
+
+(defn- elide-sub-runs-slot
+  "Project the structured `:sub-runs` vector for off-box egress: walk
+  each row through `elide-sub-run-row`. Nil- and non-sequential-
+  preserving (a `:redact-fn` may have already replaced the slot with a
+  scalar sentinel)."
+  [sub-runs]
+  (if-not (sequential? sub-runs)
+    sub-runs
+    (mapv elide-sub-run-row sub-runs)))
+
 (defn projected-record
   "Project an `:rf/epoch-record` for off-box egress. Routes the four
-  payload-bearing slots (`:db-before`, `:db-after`, `:trigger-event`,
+  full-value payload slots (`:db-before`, `:db-after`, `:trigger-event`,
   `:trace-events`) through `re-frame.elision/elide-wire-value` against
   the record's frame, with the off-box defaults
   `:include-sensitive? false` / `:include-large? false`. Sensitive
   paths land as `:rf/redacted`; large paths land as
-  `:rf.size/large-elided` markers per the §Composition rule. The
-  record-level bookkeeping (`:epoch-id`, `:frame`, `:committed-at`,
+  `:rf.size/large-elided` markers per the §Composition rule.
+
+  The structured `:sub-runs` rows are ALSO value-bearing (rf2-at60h):
+  each carries the sub's computed `:prev-value` / `:value`. Their
+  whole-output `:sensitive?` case is already redacted at the marks emit
+  site, but the whole-output `:large?` case leaves the raw value on the
+  row (the on-box ring keeps exact state), so this projection substitutes
+  the `:rf.size/large-elided` marker for those slots under the
+  `:include-large? false` default — see `elide-sub-runs-slot`. The
+  non-value row metadata (`:sub-id`, `:query-v`, `:value-changed?`,
+  `:cascade?`, `:cause-sub`, `:cause-event-id`) and the value-free
+  `:renders` / `:effects` projections pass through unchanged.
+
+  The record-level bookkeeping (`:epoch-id`, `:frame`, `:committed-at`,
   `:event-id`, `:outcome`, `:halt-reason`, `:schema-digest`,
   `:rf.epoch/sensitive?`, `:rf.epoch/redacted-modified-paths-count`)
-  and the cheap structured projections (`:sub-runs`, `:renders`,
-  `:effects`) pass through unchanged — they carry no app-db material.
+  also passes through unchanged — it carries no app-db material.
 
   Per Security.md §Epoch privacy posture and rf2-mrsck: this is the
   single normative projection emission site for off-box egress. Tools
@@ -584,7 +643,10 @@
         (update :trigger-event elide-payload-slot frame-id)
 
         (contains? record :trace-events)
-        (update :trace-events  elide-trace-events-slot frame-id)))))
+        (update :trace-events  elide-trace-events-slot frame-id)
+
+        (contains? record :sub-runs)
+        (update :sub-runs      elide-sub-runs-slot)))))
 
 (defn projected-history
   "Convenience: return the projected vector of records for a frame.

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -32,6 +32,7 @@
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
+            [re-frame.marks :as marks]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -47,6 +48,11 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (flows/reset-last-inputs!)
+  ;; The sub-output / per-registration marks tables are NOT cleared by
+  ;; `registrar/clear-all!`, so reset them here to keep the whole-output
+  ;; `:large?` propagation (rf2-at60h) from leaking across test cases.
+  (marks/clear-sub-output-marks!)
+  (marks/clear-marks!)
   (trace/clear-listeners!)
   (epoch/clear-history!)
   (epoch/clear-epoch-listeners!)
@@ -286,6 +292,83 @@
               (elision/marker? marked))
           "projected record substitutes a :rf.size/large-elided marker"))))
 
+(deftest projected-record-elides-large-sub-output
+  (testing "rf2-at60h — a whole-output `:large?`-marked subscription's
+            computed value rides the structured `:sub-runs` row as
+            `:value` / `:prev-value`. The raw on-box record keeps the
+            exact value (Xray diff / restore-epoch need it), but the
+            off-box `projected-record` / `projected-history` egress
+            boundary MUST substitute a `:rf.size/large-elided` marker for
+            those value slots under the `:include-large? false` default —
+            otherwise a bulky derived value escapes the projection
+            contract (the pre-fix leak). The non-value row metadata
+            (`:sub-id`, `:query-v`, `:value-changed?`, `:cascade?`) is
+            preserved, and the now-spent `:large?` row flag is stripped."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    ;; A whole-output `:large?` sub: its output is treated as large for
+    ;; downstream egress regardless of any per-path declaration. The
+    ;; reactive sub-cache records this via `mark-sub-output!` at build
+    ;; time; `re-frame.marks/project-sub-tags` then stamps the `:rf.sub/run`
+    ;; trace tag with bare `:large?` and leaves the raw value in place.
+    (rf/reg-sub :big {:large? true}
+                (fn [db _] (big-string 50000)))
+    ;; Read the sub inside a handler so a `:rf.sub/run` lands in the
+    ;; cascade's structured `:sub-runs` (mirrors epoch_test's
+    ;; sub-runs-projection).
+    (rf/reg-event-fx :read-big
+                     (fn [_ _]
+                       (let [_v (rf/subscribe-once :test/main [:big])]
+                         {})))
+    (rf/dispatch-sync [:seed]     {:frame :test/main})
+    (rf/dispatch-sync [:read-big] {:frame :test/main})
+
+    ;; Sanity: the propagation table marked the sub's output large.
+    (is (true? (marks/sub-output-large? :test/main :big))
+        "whole-output :large? propagation recorded")
+
+    (let [raw       (last-record :test/main)
+          raw-row   (->> (:sub-runs raw)   (filter #(= :big (:sub-id %))) first)
+          projected (epoch/projected-record raw)
+          proj-row  (->> (:sub-runs projected) (filter #(= :big (:sub-id %))) first)]
+      (is (some? raw-row)   "the :big sub produced a structured :sub-runs row")
+      (is (some? proj-row)  "the projected record keeps the :big sub-run row")
+
+      ;; Raw on-box row carries the exact 50KB value (and the :large? flag
+      ;; threaded by capture/sub-run-row).
+      (is (= 50000 (count (:value raw-row)))
+          "raw on-box row carries the full computed value")
+      (is (true? (:large? raw-row))
+          "raw row threads the whole-output :large? marker")
+
+      ;; Off-box projected row: value slot is a marker, NOT the raw value.
+      (is (elision/marker? (:value proj-row))
+          "projected :sub-runs :value is a :rf.size/large-elided marker, not raw")
+      (is (not= (:value raw-row) (:value proj-row))
+          "the raw 50KB value does NOT egress in the projected :sub-runs")
+      ;; The prev-value slot (nil on first recompute) is left as-is; if a
+      ;; bulky prev-value were present it would also be a marker — assert
+      ;; it is never the raw bulky value.
+      (when (contains? proj-row :prev-value)
+        (is (or (nil? (:prev-value proj-row))
+                (elision/marker? (:prev-value proj-row)))
+            "projected :prev-value is never a raw bulky value"))
+
+      ;; Non-value metadata preserved; the spent :large? flag is stripped.
+      (is (= (:sub-id raw-row)  (:sub-id proj-row)))
+      (is (= (:query-v raw-row) (:query-v proj-row)))
+      (is (= (:value-changed? raw-row) (:value-changed? proj-row)))
+      (is (not (contains? proj-row :large?))
+          "the now-spent :large? row flag is stripped from the projection")
+
+      ;; projected-history routes through the same projection.
+      (let [hist-row (->> (epoch/projected-history :test/main)
+                          (mapcat :sub-runs)
+                          (filter #(= :big (:sub-id %)))
+                          first)]
+        (is (elision/marker? (:value hist-row))
+            "projected-history also elides the large :sub-runs value")))))
+
 (deftest projected-record-bookkeeping-passes-through
   (testing "bookkeeping slots are preserved by the projection — the
             projection only mutates payload-bearing slots"
@@ -303,9 +386,17 @@
             (str "bookkeeping slot " k " passes through unchanged"))))))
 
 (deftest projected-record-structured-projections-pass-through
-  (testing ":sub-runs / :renders / :effects pass through unchanged —
-            they carry no app-db material (only sub-ids, render-keys,
-            fx-ids, and outcome tags)"
+  (testing ":renders / :effects carry no app-db material (only
+            render-keys, fx-ids, and outcome tags), so they pass through
+            the projection unchanged. `:sub-runs` rows carry value-bearing
+            `:prev-value` / `:value` (rf2-at60h) so they are NOT value-free
+            in general — but a row that is neither whole-output sensitive
+            (already redacted at the marks emit site) nor whole-output
+            large (no `:large?` flag → nothing to substitute) survives the
+            projection byte-for-byte. This cascade declares only a SENSITIVE
+            schema path and reads no large-marked sub, so its `:sub-runs`
+            rows still pass through identically; the large-value egress
+            case is pinned by `projected-record-elides-large-sub-output`."
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
     (rf/reg-event-db :login

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -956,6 +956,46 @@
             ":cause-event-id key is ABSENT when the trace tag was
              omitted at the emit site (cond-> on (contains? tags ...))")))))
 
+(deftest sub-run-row-threads-large-marker
+  (testing "rf2-at60h — the whole-output `:large?` stamp that
+            `re-frame.marks/project-sub-tags` writes onto a `:rf.sub/run`
+            trace tag (when the sub's output is marked large but its raw
+            value is left in place for the on-box ring) is threaded onto
+            the structured `:sub-runs` row as `:large?`, so the off-box
+            `projected-record` egress boundary can substitute a
+            `:rf.size/large-elided` marker for `:value` / `:prev-value`.
+            Direct unit test against `capture/sub-run-row`."
+    (testing ":large? tag PRESENT → row carries :large? true, value intact
+              (the projection, not the row builder, does the substitution)"
+      (let [row (capture/sub-run-row
+                  {:op-type   :rf.sub
+                   :operation :rf.sub/run
+                   :tags      {:rf.sub/id             :big/value
+                               :rf.sub/query-v        [:big/value]
+                               :rf.sub/value-changed? true
+                               :rf.sub/prev-value     "small"
+                               :rf.sub/value          "BIG"
+                               :rf.sub/cascade?       false
+                               :rf.sub/cause-sub      nil
+                               :large?                true}})]
+        (is (true? (:large? row))
+            ":large? is lifted from the trace tag so the egress projector sees it")
+        (is (= "BIG" (:value row))
+            "the raw value stays on the row — on-box ring keeps exact state")))
+    (testing ":large? tag ABSENT (non-large sub) → row omits the flag"
+      (let [row (capture/sub-run-row
+                  {:op-type   :rf.sub
+                   :operation :rf.sub/run
+                   :tags      {:rf.sub/id             :small/value
+                               :rf.sub/query-v        [:small/value]
+                               :rf.sub/value-changed? true
+                               :rf.sub/prev-value     0
+                               :rf.sub/value          1
+                               :rf.sub/cascade?       false
+                               :rf.sub/cause-sub      nil}})]
+        (is (not (contains? row :large?))
+            ":large? key is ABSENT when the sub's output is not large")))))
+
 (deftest effects-projection-skipped-on-platform
   (testing ":effects captures :skipped-on-platform outcomes"
     (rf/reg-frame :test/main {})


### PR DESCRIPTION
@-