### PR TITLE
fix(core/substrate+adapters): unique use-subscribe watch key + unmask release reagent-slim gate + test-react local-only (rf2-e4pyb)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,9 +170,15 @@ jobs:
         working-directory: implementation/adapters/reagent
         run: clojure -M:test || echo "no JVM-runnable tests in reagent artefact (expected)"
 
-      - name: JVM tests (reagent-slim artefact, classpath probe)
+      # The reagent-slim artefact (rf2-5djt Stage 4, rf2-6hyy) ships a
+      # JVM-runnable test namespace — reagent2.impl.component-test (the
+      # component-shape detection contract). This is a REAL JVM surface,
+      # NOT a skip-on-empty classpath probe, so the test-runner's non-zero
+      # exit MUST stop the release — no `|| echo` fallback (mirrors the
+      # `jvm-reagent-slim` job in .github/workflows/test.yml).
+      - name: JVM tests (reagent-slim artefact)
         working-directory: implementation/adapters/reagent-slim
-        run: clojure -M:test || echo "no JVM-runnable tests in reagent-slim artefact (expected)"
+        run: clojure -M:test
 
       - name: JVM tests (uix artefact, classpath probe)
         working-directory: implementation/adapters/uix

--- a/implementation/adapters/README.md
+++ b/implementation/adapters/README.md
@@ -12,11 +12,18 @@ This directory groups re-frame2's **substrate adapters** — implementations of 
 | [`uix/`](uix/) | UIx adapter | `day8/re-frame2-uix` | UIx 2.x — modern hooks-based React layer |
 | [`helix/`](helix/) | Helix adapter | `day8/re-frame2-helix` | Helix 0.2.x — minimal React wrapper |
 | [`reagent-slim/`](reagent-slim/) | Reagent-slim adapter | `day8/reagent-slim` [^slim-coord] | Reagent rewrite for React 19 — Stage 4 landed (full `reagent2.*` rewrite) |
-| [`test-react/`](test-react/) | Test-React adapter | `day8/re-frame2-test-react` | Pure-CLJC React class-3 lifecycle simulator — unit-testable lifecycle bug catching; carries ported regressions incl. the organic rf2-4l7t2 sync-unmount-during-render repro (rf2-gqyqv skeleton, broadened rf2-n2cuo) |
 
 [^slim-coord]: The `re-frame2-` prefix is dropped on this coord (per IMPL-SPEC DECISION-1); it is the lone adapter artefact published as `day8/reagent-slim` rather than `day8/re-frame2-*`.
 
 A consumer picks one (or more) by adding the matching artefact to their `deps.edn` alongside `day8/re-frame2`. Bundle isolation is **structural** — the wrong adapter is absent from the classpath, not eliminated by dead-code analysis. See [Conventions §Substrate-adapter shipping convention](../../spec/Conventions.md).
+
+## Local-test-only adapter
+
+| Directory | Adapter | Coordinate | Target |
+|---|---|---|---|
+| [`test-react/`](test-react/) | Test-React adapter | **none — local-test-only** | Pure-CLJC React class-3 lifecycle simulator — unit-testable lifecycle bug catching; carries ported regressions incl. the organic rf2-4l7t2 sync-unmount-during-render repro (rf2-gqyqv skeleton, broadened rf2-n2cuo) |
+
+The **test-react** adapter is **not a published artefact**. It is a development/test fixture only: it has no Maven coordinate, no `:clein/build` descriptor, and is absent from the lockstep array, the release deploy matrix, and the CI JVM job set by design. Consumers never depend on it; it exists solely so the project's own unit tests can simulate React class-3 lifecycle on the JVM and Node-CLJS without a browser. Bundle isolation treats it as test-only — no example or production build should ever pull it in.
 
 The `reagent-slim` adapter has landed Stage 4 (the full `reagent2.*` rewrite — reactive primitives, render scheduler, hiccup translation, and pure-CLJS render-to-string). It now carries its own CLJS test suite (substrate-shape contract, container round-trip, derived-value tracking, the disposal-MUST list, render Root-API call sequence, and source-coord / view-id stamping under the slim adapter) alongside the `reagent2.*` internals tests.
 
@@ -55,13 +62,13 @@ adapters/
 │   ├── src/reagent2/...      ; the slim Reagent rewrite (Stage 4: full reagent2.* rewrite)
 │   ├── src/re_frame/adapter/reagent_slim.cljs
 │   └── test/...
-└── test-react/
-    ├── deps.edn              ; declares day8/re-frame2-test-react
+└── test-react/              ; local-test-only — NOT published (no Maven coord, no :clein/build)
+    ├── deps.edn              ; depends on core via :local/root; carries no publish descriptor
     ├── src/re_frame/adapter/test_react.cljc  ; pure-CLJC class-3 lifecycle simulator
     └── test/...
 ```
 
-All five depend on `day8/re-frame2 {:local/root "../../core"}`. None depend on each other.
+All four published adapters declare `day8/re-frame2 {:local/root "../../core"}`; the unpublished test-react fixture declares the same `:local/root` dep. None depend on each other.
 
 ## Where the substrate logic lives
 

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -68,6 +68,29 @@
         v (helix-adapter/use-subscribe target [:rf.helix-use-subscribe-test/m])]
     (d/div (str "m=" v))))
 
+;; ---- sibling-collision probes (rf2-e4pyb) ---------------------------------
+;; Two INDEPENDENT siblings reading the SAME query under the SAME frame —
+;; they share one cached reaction. Each renders its observed value into a
+;; distinct text node so the suite reads "a=N b=N" off the parent's
+;; textContent. The bug (hash-of-reaction watch key) leaves the
+;; first-mounted sibling stale; the fix (unique per-invocation key) keeps
+;; both subscribers' useSyncExternalStore callbacks alive.
+
+(def ^:private siblings-observed-a (atom []))
+(def ^:private siblings-observed-b (atom []))
+
+(defnc ProbeSiblingA []
+  (let [target @refcount-target
+        v (helix-adapter/use-subscribe target [:rf.helix-siblings/n])]
+    (swap! siblings-observed-a conj v)
+    (d/span (str "a=" v))))
+
+(defnc ProbeSiblingB []
+  (let [target @refcount-target
+        v (helix-adapter/use-subscribe target [:rf.helix-siblings/n])]
+    (swap! siblings-observed-b conj v)
+    (d/span (str " b=" v))))
+
 ;; ---- 2-arg explicit-pin probes (rf2-y0db2 — parity with UIx's rf2-rcgsc) --
 
 (def ^:private probe-2arg-a-observed (atom []))
@@ -141,6 +164,13 @@
    :probe-refcount-element (fn [] ($ ProbeRefcount))
    :rc-frame              :rf.helix-use-subscribe-test/refcount-frame
    :rc-query              :rf.helix-use-subscribe-test/m
+   ;; sibling-collision (rf2-e4pyb) — both siblings under one parent div so
+   ;; the suite reads "a=N b=N" off textContent.
+   :probe-siblings-element (fn [] ($ :div ($ ProbeSiblingA) ($ ProbeSiblingB)))
+   :siblings-observed-a   siblings-observed-a
+   :siblings-observed-b   siblings-observed-b
+   :sib-frame             :rf.helix-siblings/frame
+   :sib-query             :rf.helix-siblings/n
    ;; stable deps key
    :probe-stable-deps-element (fn [] ($ ProbeStableDepsParent))
    :stable-deps-set-tick  stable-deps-set-tick
@@ -164,6 +194,13 @@
 
 (deftest use-subscribe-cleanup-decrements-sub-cache-refcount
   (suite/assert-use-subscribe-cleanup-decrements-refcount cfg))
+
+;; rf2-e4pyb — two sibling components subscribing to the SAME cached
+;; reaction must BOTH receive invalidation after one dispatch (the
+;; hash-of-reaction watch key let the last-mounted sibling overwrite the
+;; earlier one's useSyncExternalStore callback → stale UI).
+(deftest use-subscribe-siblings-same-query-both-invalidate
+  (suite/assert-use-subscribe-siblings-same-query-both-invalidate cfg))
 
 ;; rf2-nymuy — StrictMode double-mount: the refcount/disposal dance under
 ;; React's default-dev double-invoke (the riskiest seam, previously

--- a/implementation/adapters/test-react/README.md
+++ b/implementation/adapters/test-react/README.md
@@ -1,6 +1,6 @@
 # Test-React adapter
 
-Maven artefact: `day8/re-frame2-test-react`. Public ns: `re-frame.adapter.test-react`. Status: **carries ported lifecycle regressions** (rf2-gqyqv skeleton, broadened under rf2-n2cuo). The headline rf2-4l7t2 sync-unmount-during-render bug is now reproduced *organically* (a child/sibling render body trips the guard), not via fabricated in-flight state.
+Packaging: **local-test-only — not a published artefact** (no Maven coordinate, no `:clein/build`; absent from the lockstep array, release matrix, and CI JVM job set by design — see this directory's `deps.edn` header). Public ns: `re-frame.adapter.test-react`. Status: **carries ported lifecycle regressions** (rf2-gqyqv skeleton, broadened under rf2-n2cuo). The headline rf2-4l7t2 sync-unmount-during-render bug is now reproduced *organically* (a child/sibling render body trips the guard), not via fabricated in-flight state.
 
 A substrate adapter that simulates React class-3 lifecycle (constructor → did-mount → did-update → will-unmount) in pure CLJC. **No React, no DOM, no jsdom** — runs on the JVM and on Node-CLJS at unit-test speed.
 

--- a/implementation/adapters/test-react/deps.edn
+++ b/implementation/adapters/test-react/deps.edn
@@ -1,4 +1,4 @@
-;; day8/re-frame2-test-react — Test-React adapter (rf2-gqyqv).
+;; Test-React adapter (rf2-gqyqv) — LOCAL-TEST-ONLY, NOT a published artefact.
 ;;
 ;; A substrate adapter that simulates React class-3 lifecycle
 ;; (constructor → didMount → didUpdate → willUnmount) in pure CLJC.
@@ -6,10 +6,15 @@
 ;; unit-test speed. Purpose: catch React-lifecycle-driven bugs (the
 ;; rf2-4l7t2 unmount-during-render class) without browser machinery.
 ;;
-;; Per Spec 006 §Adapter shipping convention: each adapter ships in
-;; its own Maven artefact. This artefact supplies the
-;; re-frame.adapter.test-react ns and depends on the core artefact for
-;; everything else.
+;; Packaging status: this is a development/test fixture, NOT a published
+;; Maven artefact. It deliberately carries NO Maven coordinate and NO
+;; :clein/build descriptor, and is absent from the lockstep array
+;; (.github/scripts/verify-version-lockstep.sh), the release deploy
+;; matrix, and the CI JVM job set. Unlike the four published adapters
+;; (reagent, reagent-slim, uix, helix — each its own Clojars artefact),
+;; consumers never depend on this; it supplies the
+;; re-frame.adapter.test-react ns ONLY for the project's own unit tests,
+;; and depends on the core artefact via :local/root for everything else.
 ;;
 ;; NOT for production use. Tests `:require [re-frame.adapter.test-react]`
 ;; and call `(rf/init! test-react/adapter)` in a fixture; bundle-isolation

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -65,6 +65,29 @@
         v (uix-adapter/use-subscribe target [:rf.uix-use-subscribe-test/m])]
     ($ :div (str "m=" v))))
 
+;; ---- sibling-collision probes (rf2-e4pyb) ---------------------------------
+;; Two INDEPENDENT siblings reading the SAME query under the SAME frame —
+;; they share one cached reaction. Each renders its observed value into a
+;; distinct text node so the suite reads "a=N b=N" off the parent's
+;; textContent. The bug (hash-of-reaction watch key) leaves the
+;; first-mounted sibling stale; the fix (unique per-invocation key) keeps
+;; both subscribers' useSyncExternalStore callbacks alive.
+
+(def ^:private siblings-observed-a (atom []))
+(def ^:private siblings-observed-b (atom []))
+
+(defui ProbeSiblingA []
+  (let [target @refcount-target
+        v (uix-adapter/use-subscribe target [:rf.uix-siblings/n])]
+    (swap! siblings-observed-a conj v)
+    ($ :span (str "a=" v))))
+
+(defui ProbeSiblingB []
+  (let [target @refcount-target
+        v (uix-adapter/use-subscribe target [:rf.uix-siblings/n])]
+    (swap! siblings-observed-b conj v)
+    ($ :span (str " b=" v))))
+
 ;; ---- 2-arg explicit-pin probes (rf2-rcgsc) --------------------------------
 
 (def ^:private probe-2arg-a-observed (atom []))
@@ -137,6 +160,13 @@
    :probe-refcount-element (fn [] (uix/$ ProbeRefcount))
    :rc-frame              :rf.uix-use-subscribe-test/refcount-frame
    :rc-query              :rf.uix-use-subscribe-test/m
+   ;; sibling-collision (rf2-e4pyb) — both siblings under one parent div so
+   ;; the suite reads "a=N b=N" off textContent.
+   :probe-siblings-element (fn [] (uix/$ :div (uix/$ ProbeSiblingA) (uix/$ ProbeSiblingB)))
+   :siblings-observed-a   siblings-observed-a
+   :siblings-observed-b   siblings-observed-b
+   :sib-frame             :rf.uix-siblings/frame
+   :sib-query             :rf.uix-siblings/n
    ;; stable deps key
    :probe-stable-deps-element (fn [] (uix/$ ProbeStableDepsParent))
    :stable-deps-set-tick  stable-deps-set-tick
@@ -160,6 +190,13 @@
 
 (deftest use-subscribe-cleanup-decrements-sub-cache-refcount
   (suite/assert-use-subscribe-cleanup-decrements-refcount cfg))
+
+;; rf2-e4pyb — two sibling components subscribing to the SAME cached
+;; reaction must BOTH receive invalidation after one dispatch (the
+;; hash-of-reaction watch key let the last-mounted sibling overwrite the
+;; earlier one's useSyncExternalStore callback → stale UI).
+(deftest use-subscribe-siblings-same-query-both-invalidate
+  (suite/assert-use-subscribe-siblings-same-query-both-invalidate cfg))
 
 ;; rf2-nymuy — StrictMode double-mount: the refcount/disposal dance under
 ;; React's default-dev double-invoke (the riskiest seam, previously

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1385,10 +1385,13 @@
         replace-cont!      (make-replace-container-fn scheduler)
         make-derived       (make-derived-value-fn gensym-prefix-derived scheduler)
         ;; Precompute the `use-subscribe` watch-key keyword namespace
-        ;; once (outside the render hot path). The per-reaction key
-        ;; derives from `(hash reaction)` so the subscribe-fn closure
-        ;; pays one hash + one keyword intern per reaction-identity
-        ;; change — no process-wide gensym counter tick per render.
+        ;; once (outside the render hot path). Each `subscribe-fn`
+        ;; invocation mints a UNIQUE per-call suffix under this namespace
+        ;; (see the subscribe-fn closure below) so sibling subscribers to
+        ;; the same cached reaction never collide on the same `add-watch`
+        ;; key. The closure runs once per reaction-identity change (it is
+        ;; `use-callback`-memoized on `[reaction]`), so the per-call
+        ;; keyword is not paid per render.
         use-sub-watch-ns   (let [s gensym-prefix-use-sub
                                  n (count s)]
                              ;; Strip the trailing "-" the gensym prefix
@@ -1550,11 +1553,23 @@
                 subscribe-fn
                 (use-callback
                   (fn [on-change]
-                    ;; Hash-of-reaction-identity keyword rather than a
-                    ;; fresh `gensym` per call — stable for the
-                    ;; reaction's lifetime, sidesteps the process-wide
-                    ;; gensym counter, unique across distinct reactions.
-                    (let [k (keyword use-sub-watch-ns (str (hash reaction)))]
+                    ;; UNIQUE watch key per `subscribe-fn` INVOCATION,
+                    ;; closed over by the returned cleanup. The key MUST
+                    ;; NOT derive from `(hash reaction)`: subscriptions are
+                    ;; cached/deduped by query, so sibling UIx/Helix
+                    ;; components reading the SAME query share the SAME
+                    ;; cached reaction. A hash-of-reaction key would be
+                    ;; IDENTICAL across those siblings, and `add-watch`
+                    ;; replaces an existing watcher with the same key — so
+                    ;; the last-mounted sibling's `on-change` would silently
+                    ;; overwrite every earlier sibling's `useSyncExternalStore`
+                    ;; callback, leaving the earlier ones rendering stale UI
+                    ;; until an unrelated parent render refreshed them.
+                    ;; `subscribe-fn` is `use-callback`-memoized on
+                    ;; `[reaction]`, so React calls it once per
+                    ;; reaction-identity change (NOT per render); a fresh
+                    ;; keyword per call is cheap and collision-free.
+                    (let [k (keyword use-sub-watch-ns (str (gensym "watch-")))]
                       (when reaction
                         (add-watch reaction k (fn [_ _ _ _] (on-change))))
                       (fn unsubscribe []

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -2804,6 +2804,86 @@
           (finally
             (try (.unmount root) (catch :default _ nil)))))))))
 
+(defn assert-use-subscribe-siblings-same-query-both-invalidate
+  "rf2-e4pyb finding 1: two INDEPENDENT sibling components subscribing to
+  the SAME (frame, query) pair must BOTH receive invalidation after a
+  single dispatch, and BOTH must clean up on unmount.
+
+  WHY THIS IS THE REGRESSION. Subscriptions are cached/deduped by query,
+  so sibling subscribers to the same query share the SAME cached reaction
+  object. The buggy spine derived the `add-watch` key from
+  `(hash reaction)` — identical across the siblings — so `add-watch`
+  (which replaces an existing watcher with the same key) let the
+  last-mounted sibling's `useSyncExternalStore` `on-change` SILENTLY
+  OVERWRITE the earlier sibling's. The earlier sibling then rendered
+  STALE: a dispatch invalidated the reaction, but its callback was gone,
+  so its committed DOM never updated. The fix mints a UNIQUE watch key
+  per `subscribe-fn` invocation, so each sibling's callback survives.
+
+  PROOF SHAPE. We seed n=1, mount TWO sibling probes reading the same
+  query under the same frame, dispatch ::sib-inc ONCE, and assert BOTH
+  sibling DOM nodes show n=2 (the buggy spine leaves the first-mounted
+  sibling at n=1). We assert on the COMMITTED DOM text — not just the
+  observation atoms — because a stale render is precisely a DOM that
+  React never re-committed for the orphaned subscriber. After unmount the
+  shared cache entry's ref-count must return to 0 (both cleanups ran;
+  neither leaked, and neither double-released).
+
+  cfg keys:
+    :probe-siblings-element  thunk → an element wrapping TWO sibling
+                             probes that BOTH read [:sib-query] under
+                             :refcount-target's frame and render their
+                             value into distinct DOM nodes
+    :siblings-observed-a / :siblings-observed-b  atoms each sibling
+                             pushes its observed values into
+    :refcount-target         atom the sibling probes read their target
+                             frame-id from
+    :sib-frame               frame-id keyword the siblings resolve under
+    :sib-query               query-v keyword both siblings subscribe to"
+  [{:keys [name probe-siblings-element siblings-observed-a siblings-observed-b
+           refcount-target sib-frame sib-query]}]
+  (testing (str name " — sibling subscribers to the same query both invalidate (rf2-e4pyb)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! siblings-observed-a [])
+      (reset! siblings-observed-b [])
+      (reset! refcount-target sib-frame)
+      (rf/reg-frame sib-frame {:doc "rf2-e4pyb sibling-collision probe frame"})
+      (rf/reg-event-db ::sib-seed (fn [_ _] {:n 1}))
+      (rf/reg-event-db ::sib-inc  (fn [db _] (update db :n inc)))
+      (rf/dispatch-sync [::sib-seed] {:frame sib-frame})
+      (rf/reg-sub sib-query (fn [db _] (:n db)))
+      (let [cache-key-v [sib-query]
+            cache       (:sub-cache (frame/frame sib-frame))
+            mount-node  (make-mount-node!)
+            root        (react-dom-client/createRoot mount-node)]
+        (try
+          (act-fn (fn [] (.render root (probe-siblings-element))))
+          ;; Both siblings share ONE cached reaction (same query) — the
+          ;; cache entry's ref-count reflects both live subscribers.
+          (is (= "a=1 b=1" (.-textContent mount-node))
+              "both siblings committed the seeded value n=1")
+          ;; ONE dispatch. The fix guarantees BOTH siblings' on-change
+          ;; callbacks survive on the shared reaction, so React re-commits
+          ;; BOTH. The bug leaves sibling A's callback overwritten by
+          ;; sibling B's → A renders STALE at n=1.
+          (act-fn (fn [] (rf/dispatch-sync [::sib-inc] {:frame sib-frame})))
+          (is (= "a=2 b=2" (.-textContent mount-node))
+              "BOTH siblings re-committed n=2 after one dispatch — neither
+               sibling's useSyncExternalStore callback was overwritten by
+               the other's (rf2-e4pyb: unique per-invocation watch key)")
+          (is (some #{2} @siblings-observed-a)
+              "sibling A observed the incremented value (not just stale n=1)")
+          (is (some #{2} @siblings-observed-b)
+              "sibling B observed the incremented value")
+          (act-fn (fn [] (.unmount root)))
+          (is (or (nil? (get @cache cache-key-v))
+                  (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
+              "post-unmount the shared cache entry's ref-count is zero (or
+               dropped) — BOTH sibling cleanups ran, neither leaked")
+          (finally
+            (try (.unmount root) (catch :default _ nil)))))))))
+
 (defn assert-use-subscribe-stable-deps-key
   "rf2-mwft2: stable-literal query-v across N re-renders ⇒ exactly one
   subs/subscribe call (the deps element is JS-ref-stable across renders),


### PR DESCRIPTION
Senior review of `implementation/adapters` — 3 findings (rf2-e4pyb). The bead is authoritative.

## Per-finding disposition

### Finding 1 — use-subscribe watch-key collision (CORRECTNESS) — FIXED
`spine.cljs` minted the `add-watch` key from `(hash reaction)`. Subscriptions are cached/deduped by query, so sibling UIx/Helix components reading the **same** query share **one** cached reaction object — they all derived the **same** watch key. `add-watch` replaces an existing watcher with the same key, so the last-mounted sibling silently overwrote earlier siblings' `useSyncExternalStore` `on-change` callbacks. Earlier siblings then rendered **stale** (a dispatch invalidated the reaction but their callback was gone) until an unrelated parent render refreshed them.

**Fix:** mint a UNIQUE per-invocation key — `(keyword use-sub-watch-ns (str (gensym "watch-")))` — closed over by the returned cleanup. `subscribe-fn` is `use-callback`-memoized on `[reaction]`, so React calls it once per reaction-identity change (not per render); the per-call keyword is cheap and collision-free. Updated the now-stale precompute-block comment.

**Test:** new shared-suite assertion `assert-use-subscribe-siblings-same-query-both-invalidate`, wired into both the UIx and Helix `*_use_subscribe_dom_cljs_test.cljs` entry files (so a gap on one is a gap on both, per the suite's design). Two independent sibling probes on the same query both commit `n=2` after a single dispatch (asserted on committed `textContent`, since a stale render is a DOM React never re-committed) and both clean up (shared cache entry ref-count → 0 on unmount). **Proven non-vacuous:** reverting to the `(hash reaction)` key produces **4 browser-test failures**; the fix is green.

### Finding 2 — release.yml reagent-slim gate-mask (GOOD PRACTICE) — FIXED
The release pre-gate ran reagent-slim's JVM tests as `clojure -M:test || echo "no JVM-runnable tests…"`, masking a real failure that PR CI (`test.yml` `jvm-reagent-slim`) treats as fatal — a broken component-shape contract could ship past a release tag.

**Fix:** dropped the `|| echo` fallback so a non-zero exit stops the release, renamed the step (no "classpath probe"), and aligned the comment with `test.yml`'s `jvm-reagent-slim` job. The reagent/uix/helix steps keep `|| echo` because they are genuinely skip-on-empty classpath probes — only reagent-slim ships a real JVM test surface (`reagent2.impl.component-test`). Confirmed that surface is green (11 tests, 12 assertions, 0 failures), so the unmasked gate exposes no latent failure.

### Finding 3 — test-react packaging claim (CLARITY) — FIXED (conservative: local-test-only)
`adapters/README.md` + `test-react/deps.edn` documented test-react as published Maven artefact `day8/re-frame2-test-react`, but it is absent from the lockstep array (`verify-version-lockstep.sh`), the release deploy matrix, and the CI JVM job set, and has no `:clein/build`. Its own deps.edn header and README state "NOT for production use" — **no evidence it was meant to publish.**

**Fix (conservative, per bead):** removed the Maven-artefact publish claims and made local-test-only status explicit — moved test-react out of the "Adapters that ship today" table into a dedicated "Local-test-only adapter" section, updated the layout map and "all five depend…" line, rewrote the deps.edn header, and updated `test-react/README.md`'s "Maven artefact:" line. Did **not** invent release wiring.

**Out-of-lane note:** the top-level `README.md` (project layout map, line ~224) still carries the same `day8/re-frame2-test-react` coord claim. It is outside this bead's file lane (not a hot-zone spec; not in the assigned file set), so it is left for a follow-up rather than edited here.

## Quality gates
- `implementation/core` `clojure -M:test` — **908 tests, 4075 assertions, 0 failures, 0 errors**
- `implementation` `npm run test:cljs` — **5809 tests, 20566 assertions, 0 failures, 0 errors** (+2 new deftests, UIx + Helix)
- `implementation` `npm run test:browser` — **192 tests, 571 assertions, 0 failures, 0 errors** (includes the new sibling-collision DOM regression; buggy spine → 4 failures, confirming non-vacuous)
- `implementation/adapters/reagent-slim` `clojure -M:test` — **11 tests, 12 assertions, 0 failures** (the now-unmasked release gate is green)
- `release.yml` + `test.yml` — YAML parse OK; reagent-slim release step now mirrors `test.yml`'s `jvm-reagent-slim`

Closes rf2-e4pyb.