### PR TITLE
fix(http): managed body-prep failure delivery + percent-decoded query-name redaction (rf2-065xo)

### DIFF
--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -1387,24 +1387,78 @@
          :body        body-text
          :headers     headers}))))
 
+(defn- prepare-body!
+  "rf2-065xo — the managed request-preparation PHASE. Realizes the
+  `:body` (re-invoking the thunk when `:body` is a `(fn body)`, per Spec
+  014 §Body encoding — each attempt obtains a fresh handle) and encodes
+  it, computing the effective request `:headers` (adding the encoder's
+  `Content-Type` when the request did not already set one).
+
+  Returns either:
+   - `{:ok {:enc-body … :headers …}}` on success, or
+   - `{:error failure}` where `failure` is a canonical `:rf.http/transport`
+     shape. `:rf.http/transport` is the spec's category for an error
+     \"before the HTTP transaction completed\" (Spec 014 §Failure
+     categories) — body realization / encoding is exactly such a
+     pre-transaction failure, so no new (spec-closed) category is minted.
+     The shape carries a `:stage :request-prep` discriminator so telemetry
+     can tell a prep failure apart from a network-transport failure, plus
+     the usual `:message` / `:cause` tags the category documents.
+
+  A throwing body thunk or a non-serialisable body (e.g. a value
+  `JSON.stringify` / form-encode rejects) is caught here rather than
+  escaping `run-attempt!` as a generic `:rf.error/fx-handler-exception`.
+  `:rf.http/transport` is in the retryable subset, so a caller with
+  `:retry {:on #{:rf.http/transport} …}` re-runs the whole attempt
+  (re-invoking the thunk for a fresh handle) — consistent with the
+  thunk-per-attempt contract."
+  [request]
+  (try
+    (let [body          (let [b (:body request)] (if (fn? b) (b) b))
+          [enc-body ct] (encoding/encode-body body (:request-content-type request))
+          headers       (cond-> (or (:headers request) {})
+                          (and ct (nil? (decode/content-type-of (:headers request))))
+                          (assoc "Content-Type" ct))]
+      {:ok {:enc-body enc-body :headers headers}})
+    (catch #?(:clj Throwable :cljs :default) e
+      {:error {:kind    :rf.http/transport
+               :stage   :request-prep
+               :message #?(:clj (.getMessage ^Throwable e)
+                           :cljs (.-message ^js e))
+               :cause   #?(:clj (.getName (class e))
+                           :cljs (some-> (.-name ^js e)))}})))
+
 (defn run-attempt!
   "Issue one HTTP attempt, then dispatch reply or retry. Platform-specific
   transport wiring (Fetch Promise on CLJS, CompletableFuture on JVM) is
   reader-conditional; the response cascade, retry decision, in-flight
   registry interaction, privacy redaction, and supersede suppression are
-  all shared."
+  all shared.
+
+  rf2-065xo — body realization + encoding run as a managed preparation
+  PHASE (`prepare-body!`) AFTER the in-flight handle is registered, so a
+  throwing body thunk / encode failure is routed through the normal
+  `maybe-retry!` → final-failure path (a `:rf.http/transport` reply to
+  `:on-failure`) rather than escaping as `:rf.error/fx-handler-exception`."
   [ctx]
   (let [{:keys [request timeout-ms request-id actor-id abort-signal]} ctx
         method   (or (:method request) :get)
         url      (encoding/merge-params (:url request) (:params request))
-        ;; rf2-sz4n0 — `:body` may be a thunk (Spec 014 §Body encoding); each
-        ;; attempt re-invokes it to obtain a fresh handle. Single call site,
-        ;; inlined per the audit.
-        body     (let [b (:body request)] (if (fn? b) (b) b))
-        [enc-body ct] (encoding/encode-body body (:request-content-type request))
-        headers  (cond-> (or (:headers request) {})
-                   (and ct (nil? (decode/content-type-of (:headers request))))
-                   (assoc "Content-Type" ct))
+        ;; rf2-065xo — body realization + encoding are DEFERRED past handle
+        ;; registration and run inside `prepare-body!` as a managed
+        ;; request-preparation PHASE (see below). Realizing a `:body` thunk
+        ;; or encoding the body here, in the binding `let`, ran them BEFORE
+        ;; `record-in-flight!` and the platform transport try/catch — a
+        ;; throwing thunk or `encode-body` failure escaped `run-attempt!`
+        ;; entirely and surfaced as a generic `:rf.error/fx-handler-exception`
+        ;; (the fx walk's catch-all in `fx.cljc`), stranding the caller with
+        ;; no `:on-failure` reply and skipping retry/abort semantics. Moving
+        ;; the work below the handle means a prep throw is caught, classified
+        ;; as `:rf.http/transport` (the spec category for an error "before the
+        ;; HTTP transaction completed" — closed set, no new category), and
+        ;; routed through the normal `maybe-retry!` path so `:on-failure`,
+        ;; retry policy, trace metadata, abort precedence, and sensitivity
+        ;; redaction all stay consistent.
         ctx-no-handle (assoc ctx :url url)
         ;; CLJS: per rf2-1jcpm always own an internal AbortController so
         ;; the per-attempt timeout fires even when the caller supplied
@@ -1569,87 +1623,102 @@
         ;; happens synchronously here, before any fetch is issued, so the
         ;; cell is always populated by the time any abort can fire.
         _        (reset! handle-holder handle)
-        ctx'     (assoc ctx-no-handle :handle handle)]
-    #?(:cljs
-       (-> (cljs-fetch {:method              method
-                        :url                 url
-                        :headers             headers
-                        :body                enc-body
-                        :credentials         (:credentials request)
-                        :mode                (:mode request)
-                        :redirect            (:redirect request)
-                        :cache               (:cache request)
-                        :referrer            (:referrer request)
-                        :integrity           (:integrity request)
-                        :timeout-ms          timeout-ms
-                        :abort-signal        abort-signal
-                        :internal-controller internal-controller
-                        ;; rf2-5zj6t — the transport picks the Fetch
-                        ;; body-reader (`.text()` vs `.blob()` /
-                        ;; `.arrayBuffer()` / `.formData()`) from the
-                        ;; resolved decode mode; pass it through.
-                        :decode              (:decode ctx)})
-           (.then (fn [result] (handle-response! ctx' result)))
-           ;; rf2-r40km — pass `url` so `classify-cljs-error` can
-           ;; distinguish `:rf.http/cors` from `:rf.http/transport`
-           ;; via the cross-origin heuristic.
-           ;; rf2-on7sj — when the abort-fn fired and dispatch-aborted!
-           ;; already replied, the Fetch promise still rejects (because
-           ;; `.abort internal-controller` rejects the underlying
-           ;; fetch); this .catch would call `maybe-retry!` →
-           ;; `finalise-failure!` for a second pass. The once-only
-           ;; `:finalised?` CAS on the handle short-circuits the second
-           ;; dispatch inside finalise-*, so this path stays as the
-           ;; natural-completion sink without a bespoke "did we abort?"
-           ;; check here.
-           (.catch (fn [err]
-                     (maybe-retry! ctx' (classify-cljs-error err url)))))
-       :clj
-       ;; rf2-a3wxe — monotonic start mark for the per-host timeout
-       ;; `:elapsed-ms`. `System/nanoTime` is the JDK's monotonic clock
-       ;; (immune to wall-clock adjustments); the delta is converted to
-       ;; whole milliseconds at the failure site. Captured BEFORE the
-       ;; request is issued so the measured elapsed spans the whole attempt.
-       (let [started-ns (System/nanoTime)
-             elapsed-ms #(quot (- (System/nanoTime) started-ns) 1000000)]
-         (try
-           (let [^CompletableFuture cf
-                 (jvm-fetch {:method     method
-                             :url        url
-                             :headers    headers
-                             :body       enc-body
-                             :timeout-ms timeout-ms
-                             ;; rf2-a3wxe — thread the resolved `:decode`
-                             ;; so `jvm-fetch` can read the response body
-                             ;; with `ofByteArray` for binary decode modes
-                             ;; (`:blob` / `:array-buffer` / `:form-data`)
-                             ;; and ride the raw bytes under `:body-binary`
-                             ;; instead of the lossy String fallback.
-                             :decode     (:decode ctx)
-                             ;; rf2-ee38b.7 — honour the spec's `:redirect`
-                             ;; envelope key on the JVM (default `:follow`).
-                             ;; Selects the redirect-policy-specific client.
-                             :redirect   (:redirect request)
-                             :sensitive? (true? (:sensitive? ctx))})]
-             ;; rf2-on7sj — publish cf to the abort-fn closure's holder
-             ;; BEFORE wiring whenComplete. A racing abort that arrives
-             ;; between `jvm-fetch` returning and `.whenComplete`
-             ;; registering still finds cf in the holder and can cancel
-             ;; it.
-             (reset! cf-holder cf)
-             ;; rf2-on7sj — the whenComplete callback fires even after
-             ;; `.cancel cf true`: the cancel completes-exceptionally
-             ;; with a CancellationException, which routes through this
-             ;; BiConsumer as `throwable`. `maybe-retry!` →
-             ;; `finalise-failure!` is then guarded by the once-only
-             ;; `:finalised?` CAS (the abort-fn already finalised), so
-             ;; the abort's reply is the only one that ever reaches the
-             ;; user.
-             (.whenComplete cf
-                            (reify java.util.function.BiConsumer
-                              (accept [_ result throwable]
-                                (if throwable
-                                  (maybe-retry! ctx' (classify-jvm-error throwable timeout-ms (elapsed-ms)))
-                                  (handle-response! ctx' result))))))
-           (catch Throwable t
-             (maybe-retry! ctx' (classify-jvm-error t timeout-ms (elapsed-ms)))))))))
+        ctx'     (assoc ctx-no-handle :handle handle)
+        ;; rf2-065xo — managed request-preparation PHASE. Runs AFTER the
+        ;; handle is registered (so abort precedence, the once-only reply
+        ;; guard, and registry cleanup all apply to a prep failure exactly
+        ;; as they do to a network failure) but BEFORE the platform fetch is
+        ;; issued. A throwing body thunk / encode failure becomes a
+        ;; `:rf.http/transport` reply routed through `maybe-retry!` rather
+        ;; than escaping as `:rf.error/fx-handler-exception`.
+        prep     (prepare-body! request)]
+    (if-let [prep-error (:error prep)]
+      ;; Body-prep failed — route through the normal retry/final-failure
+      ;; path on `ctx'` (which carries the registered `:handle`), so retry
+      ;; (when configured for `:rf.http/transport`), trace metadata, abort
+      ;; precedence, and the `:on-failure` reply shape all stay consistent.
+      (maybe-retry! ctx' prep-error)
+      (let [{:keys [enc-body headers]} (:ok prep)]
+        #?(:cljs
+           (-> (cljs-fetch {:method              method
+                            :url                 url
+                            :headers             headers
+                            :body                enc-body
+                            :credentials         (:credentials request)
+                            :mode                (:mode request)
+                            :redirect            (:redirect request)
+                            :cache               (:cache request)
+                            :referrer            (:referrer request)
+                            :integrity           (:integrity request)
+                            :timeout-ms          timeout-ms
+                            :abort-signal        abort-signal
+                            :internal-controller internal-controller
+                            ;; rf2-5zj6t — the transport picks the Fetch
+                            ;; body-reader (`.text()` vs `.blob()` /
+                            ;; `.arrayBuffer()` / `.formData()`) from the
+                            ;; resolved decode mode; pass it through.
+                            :decode              (:decode ctx)})
+               (.then (fn [result] (handle-response! ctx' result)))
+               ;; rf2-r40km — pass `url` so `classify-cljs-error` can
+               ;; distinguish `:rf.http/cors` from `:rf.http/transport`
+               ;; via the cross-origin heuristic.
+               ;; rf2-on7sj — when the abort-fn fired and dispatch-aborted!
+               ;; already replied, the Fetch promise still rejects (because
+               ;; `.abort internal-controller` rejects the underlying
+               ;; fetch); this .catch would call `maybe-retry!` →
+               ;; `finalise-failure!` for a second pass. The once-only
+               ;; `:finalised?` CAS on the handle short-circuits the second
+               ;; dispatch inside finalise-*, so this path stays as the
+               ;; natural-completion sink without a bespoke "did we abort?"
+               ;; check here.
+               (.catch (fn [err]
+                         (maybe-retry! ctx' (classify-cljs-error err url)))))
+           :clj
+           ;; rf2-a3wxe — monotonic start mark for the per-host timeout
+           ;; `:elapsed-ms`. `System/nanoTime` is the JDK's monotonic clock
+           ;; (immune to wall-clock adjustments); the delta is converted to
+           ;; whole milliseconds at the failure site. Captured BEFORE the
+           ;; request is issued so the measured elapsed spans the whole attempt.
+           (let [started-ns (System/nanoTime)
+                 elapsed-ms #(quot (- (System/nanoTime) started-ns) 1000000)]
+             (try
+               (let [^CompletableFuture cf
+                     (jvm-fetch {:method     method
+                                 :url        url
+                                 :headers    headers
+                                 :body       enc-body
+                                 :timeout-ms timeout-ms
+                                 ;; rf2-a3wxe — thread the resolved `:decode`
+                                 ;; so `jvm-fetch` can read the response body
+                                 ;; with `ofByteArray` for binary decode modes
+                                 ;; (`:blob` / `:array-buffer` / `:form-data`)
+                                 ;; and ride the raw bytes under `:body-binary`
+                                 ;; instead of the lossy String fallback.
+                                 :decode     (:decode ctx)
+                                 ;; rf2-ee38b.7 — honour the spec's `:redirect`
+                                 ;; envelope key on the JVM (default `:follow`).
+                                 ;; Selects the redirect-policy-specific client.
+                                 :redirect   (:redirect request)
+                                 :sensitive? (true? (:sensitive? ctx))})]
+                 ;; rf2-on7sj — publish cf to the abort-fn closure's holder
+                 ;; BEFORE wiring whenComplete. A racing abort that arrives
+                 ;; between `jvm-fetch` returning and `.whenComplete`
+                 ;; registering still finds cf in the holder and can cancel
+                 ;; it.
+                 (reset! cf-holder cf)
+                 ;; rf2-on7sj — the whenComplete callback fires even after
+                 ;; `.cancel cf true`: the cancel completes-exceptionally
+                 ;; with a CancellationException, which routes through this
+                 ;; BiConsumer as `throwable`. `maybe-retry!` →
+                 ;; `finalise-failure!` is then guarded by the once-only
+                 ;; `:finalised?` CAS (the abort-fn already finalised), so
+                 ;; the abort's reply is the only one that ever reaches the
+                 ;; user.
+                 (.whenComplete cf
+                                (reify java.util.function.BiConsumer
+                                  (accept [_ result throwable]
+                                    (if throwable
+                                      (maybe-retry! ctx' (classify-jvm-error throwable timeout-ms (elapsed-ms)))
+                                      (handle-response! ctx' result))))))
+               (catch Throwable t
+                 (maybe-retry! ctx' (classify-jvm-error t timeout-ms (elapsed-ms)))))))))))

--- a/implementation/http/src/re_frame/http_url.cljc
+++ b/implementation/http/src/re_frame/http_url.cljc
@@ -34,7 +34,8 @@
   through), but no walker runs without the trace surface."
   (:require [clojure.set :as set]
             [clojure.string :as str]
-            [re-frame.privacy :as privacy]))
+            [re-frame.privacy :as privacy])
+  #?(:clj (:import [java.net URLDecoder])))
 
 ;; ---- redaction sentinel ---------------------------------------------------
 ;;
@@ -131,6 +132,52 @@
         (or (contains? default-query-param-denylist lowered)
             (contains? @extra-query-params lowered))))))
 
+(defn- percent-decode-name
+  "rf2-065xo — percent-decode a query-param NAME for denylist comparison
+  ONLY. Returns the decoded form, or `nil` when there is nothing to
+  decode (no `%`) or when the escape sequence is malformed.
+
+  NEVER throws: a malformed escape (`%`-not-followed-by-two-hex,
+  truncated tail, invalid byte sequence) yields `nil` so the caller
+  falls back to the raw spelling. This keeps redaction total — a
+  hand-crafted or attacker-supplied URL with a broken escape can never
+  crash the trace/redaction path (Spec 014 §Privacy: redaction must not
+  throw).
+
+  Decoded for COMPARISON only — the rebuilt URL always preserves the
+  original raw param spelling (`redact-query-param` only ever swaps the
+  *value*, never re-encodes the name)."
+  [name-str]
+  (when (and (string? name-str)
+             (str/includes? name-str "%"))
+    (try
+      #?(:clj  (URLDecoder/decode name-str "UTF-8")
+         :cljs (js/decodeURIComponent name-str))
+      (catch #?(:clj Throwable :cljs :default) _
+        ;; Malformed percent-escape → fall back to raw (caller uses the
+        ;; raw-name match path). Total-by-construction.
+        nil))))
+
+(defn sensitive-query-param-name?
+  "rf2-065xo — denylist match against a query-param name comparing BOTH
+  the RAW spelling AND the percent-DECODED spelling (case-insensitively
+  via `sensitive-query-param?`).
+
+  Closes the gap where a percent-encoded denylisted name —
+  `api%5Fkey` (= `api_key`), `%61ccess_token` (= `access_token`), an
+  app-declared `shop%5Ftoken` — read as a non-sensitive raw string and
+  leaked its value into trace events unless the whole request was marked
+  sensitive. The redactor consults the decoded form so an encoded auth
+  token is denied just like its plain spelling.
+
+  Decode is comparison-only and total: a malformed escape decodes to
+  `nil`, so matching falls back to the raw name and never throws."
+  [param-name]
+  (boolean
+    (or (sensitive-query-param? param-name)
+        (when-let [decoded (percent-decode-name param-name)]
+          (sensitive-query-param? decoded)))))
+
 ;; ---- URL query-string redaction (rf2-2p8wr) -------------------------------
 
 (def ^:private redacted-url-token
@@ -173,13 +220,20 @@
   "Given a single `name=value` pair (string), return the redacted form:
   `name=:rf/redacted` if the param is denylisted OR `force-all?` is
   true; the pair unchanged otherwise. Tolerates malformed pairs (no
-  `=`, empty value)."
+  `=`, empty value).
+
+  rf2-065xo — the denylist check is `sensitive-query-param-name?`, which
+  compares both the RAW and percent-DECODED name, so an encoded
+  denylisted name (`api%5Fkey`, `%61ccess_token`, app-declared
+  `shop%5Ftoken`) is redacted. The original raw `pname` is preserved
+  verbatim in the rebuilt pair — only the value is replaced (decoding is
+  comparison-only)."
   [pair force-all?]
   (let [eq-idx (str/index-of pair "=")
         [pname _pvalue] (if eq-idx
                           [(subs pair 0 eq-idx) (subs pair (inc eq-idx))]
                           [pair nil])]
-    (if (or force-all? (sensitive-query-param? pname))
+    (if (or force-all? (sensitive-query-param-name? pname))
       (str pname "=" redacted-url-token)
       pair)))
 

--- a/implementation/http/test/re_frame/http_body_prep_failure_test.clj
+++ b/implementation/http/test/re_frame/http_body_prep_failure_test.clj
@@ -1,0 +1,184 @@
+(ns re-frame.http-body-prep-failure-test
+  "rf2-065xo finding 1 (JVM) — body realization + body encoding are a
+  MANAGED request-preparation phase.
+
+  Defect (closed by this test): `run-attempt!` realized a `:body` thunk
+  and ran `encoding/encode-body` in its outer binding `let` — BEFORE
+  `record-in-flight!` registered the handle and BEFORE the platform
+  transport try/catch. A throwing body thunk or a non-serialisable body
+  ESCAPED `run-attempt!` and surfaced as a generic
+  `:rf.error/fx-handler-exception` (the catch-all in `re-frame.fx`'s fx
+  walk) instead of the caller's `:on-failure` with a `:rf.http/*` shape.
+  The caller waited forever; retry/backoff/cancellation were skipped;
+  instrumentation saw the wrong taxonomy.
+
+  Fix: `prepare-body!` runs the realization + encoding AFTER the handle
+  is registered, catches a throw, and routes a canonical
+  `:rf.http/transport` failure (`:stage :request-prep`) through the
+  normal `maybe-retry!` path — so `:on-failure`, retry policy, trace
+  metadata, abort precedence, and sensitivity handling all stay
+  consistent. `:rf.http/transport` is the spec's category for an error
+  before the HTTP transaction completed (Spec 014 §Failure categories,
+  closed set — no new category minted), and it is in the retryable
+  subset, so a configured retry re-runs the attempt (re-invoking the
+  thunk for a fresh handle).
+
+  These cases throw in the prep phase BEFORE any socket is touched, so
+  no test server is needed — the failure is delivered synchronously
+  through the router on `dispatch-sync`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.flows :as flows]
+            [re-frame.frame :as frame]
+            [re-frame.http-managed :as http-managed]
+            [re-frame.http-registry :as registry]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+(defn- reset-runtime [t]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.machines :reload)
+  (require 're-frame.http-managed :reload)
+  ((requiring-resolve 're-frame.machines/reset-timers!))
+  (http-managed/clear-all-in-flight!)
+  (t))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- a throwing body thunk -------------------------------------------------
+
+(deftest throwing-body-thunk-delivers-managed-transport-failure
+  (testing "rf2-065xo — a `:body` thunk that throws delivers ONE :on-failure reply with :rf.http/transport (NOT :rf.error/fx-handler-exception), and clears the registry"
+    (let [replies     (atom [])
+          traces      (atom [])
+          listener-id ::body-thunk]
+      (try
+        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        (rf/reg-event-fx :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        (rf/reg-event-fx :issue/throwing-thunk
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url    "http://127.0.0.1:0/x"
+                                 :method :post
+                                 ;; The thunk is realized in the prep phase
+                                 ;; and throws — there is no live socket.
+                                 :body   (fn [] (throw (ex-info "boom-thunk" {})))}
+                    :request-id :prep-thunk
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue/throwing-thunk])
+        ;; The failure is delivered synchronously on the dispatch-sync drain
+        ;; (the throw happens before any async transport handoff).
+        (is (= 1 (count @replies))
+            "exactly one reply — the prep failure is delivered once")
+        (let [reply (first @replies)]
+          (is (= :failure (:kind reply)))
+          (is (= :rf.http/transport (get-in reply [:failure :kind]))
+              "a throwing body thunk surfaces as the managed :rf.http/transport category")
+          (is (= :request-prep (get-in reply [:failure :stage]))
+              "the :stage discriminator marks this as a request-preparation failure")
+          (is (some? (get-in reply [:failure :message]))
+              "the thrown message rides the failure for diagnostics"))
+        (is (not-any? #(= :rf.error/fx-handler-exception (:operation %)) @traces)
+            "NO generic :rf.error/fx-handler-exception escaped — the throw is caught in the prep phase")
+        (is (empty? (registry/in-flight-snapshot))
+            "the in-flight registry is cleared — the failed-prep request is not pinned")
+        (finally
+          (trace/unregister-listener! listener-id))))))
+
+;; ---- a body that fails to encode -------------------------------------------
+
+(deftest unencodable-body-delivers-managed-transport-failure
+  (testing "rf2-065xo — a body that `encode-body` (JSON) rejects delivers ONE :on-failure reply with :rf.http/transport (NOT :rf.error/fx-handler-exception)"
+    (let [replies     (atom [])
+          traces      (atom [])
+          listener-id ::encode-fail]
+      (try
+        (trace/register-listener! listener-id (fn [ev] (swap! traces conj ev)))
+        (rf/reg-event-fx :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        (rf/reg-event-fx :issue/unencodable
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   ;; :request-content-type :json forces a JSON encode of a
+                   ;; value Cheshire cannot serialise (a bare function),
+                   ;; throwing inside `encode-body` in the prep phase.
+                   {:request    {:url    "http://127.0.0.1:0/x"
+                                 :method :post
+                                 :request-content-type :json
+                                 :body   {:f (fn [])}}
+                    :request-id :prep-encode
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue/unencodable])
+        (is (= 1 (count @replies))
+            "exactly one reply — the encode failure is delivered once")
+        (let [reply (first @replies)]
+          (is (= :failure (:kind reply)))
+          (is (= :rf.http/transport (get-in reply [:failure :kind]))
+              "an encode failure surfaces as the managed :rf.http/transport category")
+          (is (= :request-prep (get-in reply [:failure :stage]))))
+        (is (not-any? #(= :rf.error/fx-handler-exception (:operation %)) @traces)
+            "NO generic :rf.error/fx-handler-exception escaped")
+        (is (empty? (registry/in-flight-snapshot)))
+        (finally
+          (trace/unregister-listener! listener-id))))))
+
+;; ---- retry when configured -------------------------------------------------
+
+(deftest throwing-body-thunk-retries-when-configured
+  (testing "rf2-065xo — when `:retry {:on #{:rf.http/transport} …}` is set, a throwing body thunk RETRIES (re-invoking the thunk per attempt) then finally fails :rf.http/transport"
+    (let [replies     (atom [])
+          invocations (atom 0)
+          listener-id ::retry-thunk]
+      (try
+        (trace/register-listener! listener-id (fn [_] nil))
+        (rf/reg-event-fx :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        (rf/reg-event-fx :issue/retry-thunk
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url    "http://127.0.0.1:0/x"
+                                 :method :post
+                                 ;; Each attempt re-invokes the thunk for a
+                                 ;; fresh handle (Spec 014 §Body encoding);
+                                 ;; here every invocation throws.
+                                 :body   (fn []
+                                           (swap! invocations inc)
+                                           (throw (ex-info "boom-retry" {})))}
+                    :retry      {:on           #{:rf.http/transport}
+                                 :max-attempts 3
+                                 ;; Zero backoff keeps the test fast; the
+                                 ;; retry still rides the backoff scheduler.
+                                 :backoff      {:base-ms 1 :factor 1 :max-ms 1}}
+                    :request-id :prep-retry
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue/retry-thunk])
+        ;; Wait for the retry sequence to exhaust (3 attempts) and the final
+        ;; failure reply to land — the backoff timer fires on a scheduler
+        ;; thread, so this completes asynchronously.
+        (let [deadline (+ (System/currentTimeMillis) 4000)]
+          (while (and (empty? @replies)
+                      (< (System/currentTimeMillis) deadline))
+            (Thread/sleep 10)))
+        (is (= 3 @invocations)
+            "the throwing thunk was re-invoked once per attempt (max-attempts 3) — prep failures honour the retry policy")
+        (is (= 1 (count @replies))
+            "exactly one FINAL reply after the retries exhaust")
+        (let [reply (first @replies)]
+          (is (= :rf.http/transport (get-in reply [:failure :kind]))
+              "the final reply carries the :rf.http/transport prep-failure category"))
+        (is (empty? (registry/in-flight-snapshot))
+            "the registry is clean after the retry sequence exhausts")
+        (finally
+          (trace/unregister-listener! listener-id))))))

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -682,3 +682,155 @@
                       (restore)
                       (is false (str "rf2-wj8vv — unexpected: " e))
                       (done))))))))
+
+;; ---- rf2-065xo — managed body-prep failure delivery (CLJS) ----------------
+;;
+;; The JVM suite (re-frame.http-body-prep-failure-test) pins the same
+;; contract against Cheshire encode failures + real threads. This CLJS
+;; counterpart proves it on the Fetch path: a throwing `:body` thunk and a
+;; non-serialisable body (circular ref → `js/JSON.stringify` throws) are
+;; caught in the `prepare-body!` phase and delivered as ONE :on-failure
+;; reply with :rf.http/transport — NOT a generic :rf.error/fx-handler-
+;; exception — and a configured retry re-invokes the thunk per attempt.
+;;
+;; The throw happens in the prep phase BEFORE any fetch, so `js/fetch` is
+;; stubbed to FAIL the test loudly if it is ever reached (proving the
+;; request never left the prep phase).
+
+(defn- with-failing-fetch
+  "Stub `js/fetch` to reject loudly — used by the prep-failure tests where
+  the body throws BEFORE any network call, so `fetch` must never run.
+  Returns a 0-arg restore fn."
+  []
+  (let [orig (.-fetch js/globalThis)]
+    (set! (.-fetch js/globalThis)
+          (fn [_url _init]
+            (js/Promise.reject
+              (js/Error. "rf2-065xo — fetch must NOT be reached: body-prep threw before any network call"))))
+    (fn [] (set! (.-fetch js/globalThis) orig))))
+
+(deftest cljs-throwing-body-thunk-delivers-managed-transport-failure
+  (testing "rf2-065xo — a `:body` thunk that throws delivers ONE :on-failure reply with :rf.http/transport (NOT :rf.error/fx-handler-exception) and clears the registry"
+    (async done
+      (rf/init! reagent-adapter/adapter)
+      (http-managed/clear-all-in-flight!)
+      (let [replies (atom [])
+            restore (with-failing-fetch)]
+        (rf/reg-event-fx :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        (rf/reg-event-fx :issue/throwing-thunk
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url    "/x"
+                                 :method :post
+                                 :body   (fn [] (throw (js/Error. "boom-thunk")))}
+                    :request-id :prep-thunk
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue/throwing-thunk])
+        (-> (test-support/poll-until
+              #(seq @replies)
+              {:timeout-ms 2000 :label "cljs body-thunk prep failure reply"})
+            (.then (fn [_]
+                     (is (= 1 (count @replies))
+                         "exactly one reply — the prep failure is delivered once")
+                     (let [reply (first @replies)]
+                       (is (= :failure (:kind reply)))
+                       (is (= :rf.http/transport (get-in reply [:failure :kind]))
+                           "a throwing body thunk surfaces as the managed :rf.http/transport category")
+                       (is (= :request-prep (get-in reply [:failure :stage]))
+                           "the :stage discriminator marks this as a request-preparation failure"))
+                     (is (empty? (registry/in-flight-snapshot))
+                         "the in-flight registry is cleared — the failed-prep request is not pinned")
+                     (restore)
+                     (done)))
+            (.catch (fn [e]
+                      (restore)
+                      (is false (str "rf2-065xo — unexpected: " e))
+                      (done))))))))
+
+(deftest cljs-unencodable-body-delivers-managed-transport-failure
+  (testing "rf2-065xo — a non-serialisable body (circular ref → JSON.stringify throws) delivers ONE :on-failure reply with :rf.http/transport"
+    (async done
+      (rf/init! reagent-adapter/adapter)
+      (http-managed/clear-all-in-flight!)
+      (let [replies   (atom [])
+            restore   (with-failing-fetch)
+            ;; A circular JS object — `js/JSON.stringify` throws a TypeError
+            ;; converting it, exercising the encode-failure prep path.
+            circular  (let [o (js-obj)]
+                        (aset o "self" o)
+                        o)]
+        (rf/reg-event-fx :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        (rf/reg-event-fx :issue/unencodable
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url    "/x"
+                                 :method :post
+                                 :request-content-type :json
+                                 :body   circular}
+                    :request-id :prep-encode
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue/unencodable])
+        (-> (test-support/poll-until
+              #(seq @replies)
+              {:timeout-ms 2000 :label "cljs encode prep failure reply"})
+            (.then (fn [_]
+                     (is (= 1 (count @replies)))
+                     (let [reply (first @replies)]
+                       (is (= :rf.http/transport (get-in reply [:failure :kind]))
+                           "an encode failure surfaces as the managed :rf.http/transport category")
+                       (is (= :request-prep (get-in reply [:failure :stage]))))
+                     (is (empty? (registry/in-flight-snapshot)))
+                     (restore)
+                     (done)))
+            (.catch (fn [e]
+                      (restore)
+                      (is false (str "rf2-065xo — unexpected: " e))
+                      (done))))))))
+
+(deftest cljs-throwing-body-thunk-retries-when-configured
+  (testing "rf2-065xo — with `:retry {:on #{:rf.http/transport} …}` a throwing body thunk RETRIES (re-invoking the thunk per attempt) then finally fails :rf.http/transport"
+    (async done
+      (rf/init! reagent-adapter/adapter)
+      (http-managed/clear-all-in-flight!)
+      (let [replies     (atom [])
+            invocations (atom 0)
+            restore     (with-failing-fetch)]
+        (rf/reg-event-fx :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        (rf/reg-event-fx :issue/retry-thunk
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url    "/x"
+                                 :method :post
+                                 :body   (fn []
+                                           (swap! invocations inc)
+                                           (throw (js/Error. "boom-retry")))}
+                    :retry      {:on           #{:rf.http/transport}
+                                 :max-attempts 3
+                                 :backoff      {:base-ms 1 :factor 1 :max-ms 1}}
+                    :request-id :prep-retry
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/dispatch-sync [:issue/retry-thunk])
+        (-> (test-support/poll-until
+              #(seq @replies)
+              {:timeout-ms 4000 :label "cljs prep-failure retry exhaustion reply"})
+            (.then (fn [_]
+                     (is (= 3 @invocations)
+                         "the throwing thunk was re-invoked once per attempt (max-attempts 3)")
+                     (is (= 1 (count @replies))
+                         "exactly one FINAL reply after the retries exhaust")
+                     (let [reply (first @replies)]
+                       (is (= :rf.http/transport (get-in reply [:failure :kind]))
+                           "the final reply carries the :rf.http/transport prep-failure category"))
+                     (is (empty? (registry/in-flight-snapshot)))
+                     (restore)
+                     (done)))
+            (.catch (fn [e]
+                      (restore)
+                      (is false (str "rf2-065xo — unexpected: " e))
+                      (done))))))))

--- a/implementation/http/test/re_frame/http_url_percent_encoded_redaction_cljs_test.cljc
+++ b/implementation/http/test/re_frame/http_url_percent_encoded_redaction_cljs_test.cljc
@@ -1,0 +1,139 @@
+(ns re-frame.http-url-percent-encoded-redaction-cljs-test
+  "rf2-065xo finding 2 — percent-encoded query-param NAMES must be
+  redacted (Spec 014 §Privacy). Cross-host `*-cljs-test.cljc` so BOTH
+  cognitect.test-runner (JVM `clojure -M:test`) and shadow-cljs
+  (`npm run test:cljs`, `cljs-test$` ns-regexp) discover it — the
+  percent-decode-for-comparison logic is reader-conditional
+  (`java.net.URLDecoder` on JVM, `js/decodeURIComponent` on CLJS) and is
+  host-symmetric by design, so one source asserted on both runtimes is
+  the right shape.
+
+  Defect (closed by this test): `redact-query-param` compared the RAW
+  query-param name to the denylist, so a percent-encoded denylisted name
+  — `api%5Fkey` (= `api_key`), `%61ccess_token` (= `access_token`), an
+  app-declared `shop%5Ftoken` (= `shop_token`) — read as a
+  non-sensitive raw string and leaked its VALUE into `:rf.http/*` trace
+  events unless the whole request was marked `:sensitive?`. Encoded auth
+  tokens reached logs/tooling — squarely the AI/MCP + logs/traces
+  threat model.
+
+  Fix: the redactor consults `sensitive-query-param-name?`, which
+  compares both the RAW spelling AND the percent-DECODED spelling
+  (case-insensitively). Decode is comparison-only — the rebuilt URL
+  preserves the original raw param spelling; only the value becomes
+  `:rf/redacted`. A malformed escape decodes to nil and falls back to
+  the raw-name match path — redaction is total and never throws."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.http-url :as url]))
+
+(use-fixtures :each
+  (fn [t]
+    (url/clear-sensitive-query-params!)
+    (t)
+    (url/clear-sensitive-query-params!)))
+
+;; ---------------------------------------------------------------------------
+;; sensitive-query-param-name? — raw + percent-decoded comparison
+;; ---------------------------------------------------------------------------
+
+(deftest encoded-default-denylist-name-matches
+  (testing "rf2-065xo — a percent-encoded DEFAULT-denylist name matches via the decoded form"
+    ;; api%5Fkey decodes to api_key; %61ccess_token decodes to access_token.
+    (is (url/sensitive-query-param-name? "api%5Fkey"))
+    (is (url/sensitive-query-param-name? "%61ccess_token"))
+    ;; case-insensitive on the decoded form too (%41PI%5FKEY → API_KEY).
+    (is (url/sensitive-query-param-name? "%41PI%5FKEY"))
+    ;; raw match path unchanged — plain names still match.
+    (is (url/sensitive-query-param-name? "api_key"))
+    (is (url/sensitive-query-param-name? "access_token"))))
+
+(deftest encoded-app-extended-denylist-name-matches
+  (testing "rf2-065xo — an app-declared denylist name matches when percent-encoded"
+    (url/declare-sensitive-query-param! "shop_token")
+    ;; shop%5Ftoken decodes to shop_token.
+    (is (url/sensitive-query-param-name? "shop%5Ftoken"))
+    (is (url/sensitive-query-param-name? "shop_token"))
+    (url/clear-sensitive-query-params!)
+    (is (not (url/sensitive-query-param-name? "shop%5Ftoken"))
+        "cleared app-extension no longer matches (decoded or raw)")
+    ;; defaults survive the clear.
+    (is (url/sensitive-query-param-name? "api%5Fkey"))))
+
+(deftest non-sensitive-encoded-name-does-not-match
+  (testing "rf2-065xo — an encoded NON-denylisted name stays non-sensitive"
+    ;; page%5Fnum decodes to page_num — not denylisted.
+    (is (not (url/sensitive-query-param-name? "page%5Fnum")))
+    (is (not (url/sensitive-query-param-name? "user%5Fid")))))
+
+(deftest malformed-escape-falls-back-to-raw-never-throws
+  (testing "rf2-065xo — a malformed percent-escape decodes to nil; matching falls back to the raw name and never throws"
+    ;; Truncated / invalid escapes — must not throw on either host.
+    (is (false? (url/sensitive-query-param-name? "api%5")))
+    (is (false? (url/sensitive-query-param-name? "%zz")))
+    (is (false? (url/sensitive-query-param-name? "page%")))
+    ;; A denylisted RAW name carrying a trailing malformed escape STILL
+    ;; matches via the raw path (the decode bails to nil; raw is consulted
+    ;; first and matches the plain segment only if it IS the denylisted
+    ;; name). Here `token` is denylisted raw; `token%` is not the raw name
+    ;; nor a valid decode, so it correctly does not match — proving no
+    ;; crash and a sane fallback.
+    (is (false? (url/sensitive-query-param-name? "token%")))
+    ;; But a valid-raw denylisted name is unaffected by the decode attempt.
+    (is (true? (url/sensitive-query-param-name? "token")))))
+
+(deftest sensitive-query-param-name-tolerates-non-string
+  (testing "rf2-065xo — nil / non-string is not sensitive and never throws"
+    (is (false? (url/sensitive-query-param-name? nil)))
+    (is (false? (url/sensitive-query-param-name? :keyword)))
+    (is (false? (url/sensitive-query-param-name? 42)))))
+
+;; ---------------------------------------------------------------------------
+;; redact-url-query-string — end-to-end: encoded name's VALUE is redacted
+;; ---------------------------------------------------------------------------
+
+(deftest redact-url-encoded-default-name-value-redacted
+  (testing "rf2-065xo — a percent-encoded default-denylist param has its VALUE redacted; the raw name spelling is preserved"
+    (let [[redacted any?] (url/redact-url-query-string
+                            "https://api.example.com/x?api%5Fkey=SECRET&page=2"
+                            false)]
+      (is (= "https://api.example.com/x?api%5Fkey=:rf/redacted&page=2" redacted)
+          "raw name spelling preserved; only the value replaced; non-denylisted page untouched")
+      (is (true? any?)
+          "the encoded denylisted name is the signal — sensitivity is stamped"))))
+
+(deftest redact-url-encoded-name-leading-escape-value-redacted
+  (testing "rf2-065xo — %61ccess_token (= access_token) value is redacted"
+    (let [[redacted any?] (url/redact-url-query-string
+                            "https://api.example.com/x?%61ccess_token=SECRET&q=hi"
+                            false)]
+      (is (= "https://api.example.com/x?%61ccess_token=:rf/redacted&q=hi" redacted))
+      (is (true? any?)))))
+
+(deftest redact-url-encoded-app-extended-name-value-redacted
+  (testing "rf2-065xo — an app-declared denylist name, percent-encoded, has its value redacted"
+    (url/declare-sensitive-query-param! "shop_token")
+    (let [[redacted any?] (url/redact-url-query-string
+                            "https://api.example.com/x?shop%5Ftoken=SECRET&page=2"
+                            false)]
+      (is (= "https://api.example.com/x?shop%5Ftoken=:rf/redacted&page=2" redacted))
+      (is (true? any?)))))
+
+(deftest redact-url-malformed-escape-does-not-throw-and-passes-through
+  (testing "rf2-065xo — a malformed percent-escape in a non-denylisted name does not throw and is preserved unchanged"
+    (let [[redacted any?] (url/redact-url-query-string
+                            "https://api.example.com/x?weird%5=v&page=2"
+                            false)]
+      (is (= "https://api.example.com/x?weird%5=v&page=2" redacted)
+          "malformed escape on a non-denylisted name — value preserved, no crash")
+      (is (false? any?)))))
+
+(deftest redact-url-malformed-escape-on-other-param-still-redacts-real-denylist-hit
+  (testing "rf2-065xo — a malformed escape elsewhere in the URL does not stop a real (encoded) denylisted name from being redacted"
+    (let [[redacted any?] (url/redact-url-query-string
+                            "https://api.example.com/x?weird%5=v&api%5Fkey=SECRET"
+                            false)]
+      (is (= "https://api.example.com/x?weird%5=v&api%5Fkey=:rf/redacted" redacted))
+      (is (true? any?)
+          "redaction is total — the malformed-escape param is left alone and the encoded denylist hit is still redacted"))))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -203,6 +203,8 @@ If `:body` is a Clojure collection AND `:request-content-type` is unset, the fx 
 
 Multipart upload: pass `(js/FormData.)` directly as `:body` (or as the return value of a thunk) and let the runtime not set `Content-Type` (the platform sets the boundary).
 
+**Body realization + encoding is a managed preparation phase.** Invoking the `:body` thunk and encoding the body run *inside* the managed request, after the request is registered but before the transport issues it. A thunk that throws, or a body the encoder rejects (e.g. a non-serialisable value under `:request-content-type :json`), is **not** an uncaught error — it is delivered as a `:rf.http/transport` failure (with a `:stage :request-prep` discriminator and the usual `:message` / `:cause` tags; see [§Failure categories](#failure-categories-closed-set)) routed through the normal failure path. So a prep failure dispatches the caller's `:on-failure`, honours the `:retry` policy (`:rf.http/transport` is retryable — a retry re-invokes the thunk for a fresh handle), respects abort precedence, and carries the same trace + sensitivity treatment as a network-transport failure. It never surfaces as a generic `:rf.error/fx-handler-exception`.
+
 ## Decoding
 
 The `:decode` key controls how the response body is parsed.
@@ -484,7 +486,7 @@ Every failure carries a `:kind` keyword (under the framework-reserved `:rf.http/
 
 | `:kind` | When | Tags |
 |---|---|---|
-| `:rf.http/transport` | Network / DNS / connection-refused / connection-reset error before the HTTP transaction completed | `:message`, `:cause` |
+| `:rf.http/transport` | Network / DNS / connection-refused / connection-reset error before the HTTP transaction completed — **also** a request-preparation failure (a throwing `:body` thunk or a body the encoder rejects; see [§Body encoding](#body-encoding)), which carries an extra `:stage :request-prep` tag | `:message`, `:cause`, (`:stage` on a prep failure) |
 | `:rf.http/cors` | CORS preflight rejected or response blocked by browser CORS policy. Distinct from `:transport` because CORS is a configuration error, not a network error. CLJS-only; JVM never emits this. | `:message`, `:url` |
 | `:rf.http/timeout` | Per-attempt timeout fired | `:elapsed-ms` (measured wall-clock delta, `>= :limit-ms`, same semantics on both hosts — see [§JVM transport](#jvm-transport--degraded-behaviour-for-cljs-only-options)), `:limit-ms` (the configured per-attempt budget) |
 | `:rf.http/http-4xx` | Non-2xx 4xx response | `:status`, `:status-text`, `:body` (the raw response text — decode is skipped on non-2xx; see [§Classification order](#classification-order)), `:headers` |
@@ -1230,6 +1232,8 @@ Apps extend the denylist for app-specific tokens (e.g. `shop_token` for Shopify,
 ```
 
 Names stored lower-cased; matching is case-insensitive. The default denylist is fixed at boot; the app-extended set is mutable and clearable for test ergonomics via `(rf.http/clear-sensitive-query-params!)`.
+
+Matching is **percent-decoding-aware**: a query-param name is compared against the denylist in both its raw spelling **and** its percent-decoded form, so an encoded denylisted name (`?api%5Fkey=…` for `api_key`, `?%61ccess_token=…` for `access_token`, an app-declared `?shop%5Ftoken=…`) is redacted just like its plain spelling. The decode is comparison-only — the rebuilt URL preserves the original raw name verbatim and replaces only the value. A malformed percent-escape decodes to nothing and falls back to the raw-name match; redaction is total and never throws.
 
 A query-param denylist hit **alone** (no per-request / per-call `:sensitive?`) **stamps `:sensitive? true`** on the resulting trace event — the presence of a denylisted parameter name is itself a signal that the request carries an auth secret, and downstream privacy-honouring consumers should treat the event accordingly. This is the analogue of the header denylist contract: the name is the signal.
 


### PR DESCRIPTION
Closes the 2 findings in the senior review of `implementation/http` (rf2-065xo).

## Finding 1 — body-thunk / encode exceptions bypassed managed failure delivery (CONFIRMED, fixed)

`run-attempt!` realized a `:body` thunk and ran `encoding/encode-body` in its **outer binding `let`** — BEFORE `record-in-flight!` registered the handle and BEFORE the platform transport try/catch. A throwing body thunk or a non-serialisable body (e.g. a function / circular ref under `:request-content-type :json`) escaped `run-attempt!` and was caught by the fx walk's catch-all in `re-frame.fx`, surfacing as a generic `:rf.error/fx-handler-exception`. The caller's `:on-failure` never fired, retry/backoff/cancellation were skipped, and instrumentation saw the wrong taxonomy.

**Fix:** body realization + encoding now run as a managed **request-preparation phase** (`prepare-body!`) AFTER the in-flight handle is registered (so abort precedence, the once-only reply guard, and registry cleanup all apply) but before the platform fetch is issued. A throw is caught and delivered as a canonical `:rf.http/transport` failure with a `:stage :request-prep` discriminator (+ `:message` / `:cause`), routed through the normal `maybe-retry!` path. `:rf.http/transport` is the spec's category for an error "before the HTTP transaction completed" (closed set — no new category minted) and is in the retryable subset, so a configured `:retry {:on #{:rf.http/transport} …}` re-runs the attempt, re-invoking the thunk for a fresh handle per the thunk-per-attempt contract.

## Finding 2 — percent-encoded query-param names bypassed redaction (CONFIRMED, fixed)

`redact-query-param` compared the **raw** query-param name to the denylist, so `?api%5Fkey=` (`api_key`), `?%61ccess_token=` (`access_token`), and an app-declared `?shop%5Ftoken=` were semantically denylisted but leaked their values into trace events unless the whole request was marked `:sensitive?`.

**Fix:** matching is now percent-decoding-aware (`sensitive-query-param-name?`): names are compared in their **raw** spelling AND their percent-**decoded** form, case-insensitively. Decode is comparison-only — the rebuilt URL preserves the original raw name verbatim and replaces only the value. A malformed percent-escape decodes to `nil` and falls back to the raw-name match; redaction is **total and never throws** (`URLDecoder` on JVM / `decodeURIComponent` on CLJS, both wrapped).

## Tests

- `implementation/http/test/re_frame/http_body_prep_failure_test.clj` (JVM, new) — throwing thunk + Cheshire-unencodable body + retry-when-configured prove no `:rf.error/fx-handler-exception`, one `:rf.http/transport` `:on-failure` reply, registry cleared, and retry re-invokes the thunk per attempt.
- `implementation/http/test/re_frame/http_cljs_test.cljs` (CLJS, +3) — same contract on the Fetch path (throwing thunk, circular-ref encode failure, retry exhaustion); `fetch` stubbed to fail loudly to prove the request never left the prep phase.
- `implementation/http/test/re_frame/http_url_percent_encoded_redaction_cljs_test.cljc` (cross-host, new) — default + app-extended denylist percent-encoded names + invalid-escape cases → value becomes `:rf/redacted` and sensitivity is stamped; never throws.
- `spec/014-HTTPRequests.md` — documents the managed body-prep failure phase (Body encoding + the `:rf.http/transport` row) and the percent-decoding-aware query-param denylist.

## Quality gates

| Gate | Result |
|------|--------|
| `cd implementation/http && clojure -M:test` | **371 tests, 1686 assertions, 0 failures, 0 errors** |
| `cd implementation && npm run test:cljs` | **5820 tests, 20606 assertions, 0 failures, 0 errors** |

mkdocs `--strict` not run locally (mkdocs not on PATH); spec edits are additive prose against existing valid anchors — CI docs gate will verify.