### PR TITLE
fix(xray): count compound + parallel-region states in Static Machines + finding 2 (rf2-6nx8y)

### DIFF
--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -437,9 +437,23 @@ ranks the matching candidates by `:rf.route/rank` descending — the
 same order `match-url` walks the registry table. The first candidate
 is the winner.
 
+**Input normalisation (rf2-6nx8y).** The input is pasted by a human and
+is commonly copied wholesale from the browser address bar — an
+**absolute** URL with a `scheme://authority` origin. The simulator
+normalises an absolute (or protocol-relative `//host/…`) URL to its
+`pathname` — dropping the scheme + authority (userinfo / host / port) —
+*before* the query/fragment strip, so a pasted
+`https://app.example/cart?source=email#step-1` matches the registered
+`/cart` pattern. A **relative** input (`/cart`, `cart/`, `?x`, `#y`) is
+left untouched; only a `scheme://` (or leading `//`) marks an origin, so
+a relative path that legitimately contains a `:` segment is not mistaken
+for a scheme. `match-url` itself does not need this step (it only ever
+sees host-relative URLs from `location`); the simulator adds it because
+its source is human-pasted.
+
 The result block surfaces:
 
-- The normalised path (query and fragment stripped).
+- The normalised path (origin, query, and fragment stripped).
 - Every matching candidate, with its `:rf.route/rank` tuple and the
   parsed `:params` map.
 - The winner highlighted (green border + `WINNER` glyph).

--- a/tools/xray/src/day8/re_frame2_xray/panels/routing_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/routing_helpers.cljc
@@ -141,16 +141,77 @@
 ;; rank tuples, not just the winner — that's the load-bearing
 ;; interactive surface that exposes the 6-rule cascade.
 
+(defn- strip-origin
+  "Reduce an ABSOLUTE URL (`https://app.example/cart?x#y`) or a
+  protocol-relative one (`//app.example/cart`) to its `pathname +
+  search + fragment` — i.e. drop the `scheme://authority` origin so the
+  remainder is what the browser's `location.pathname + .search + .hash`
+  would yield. A RELATIVE input (`/cart`, `cart/`, `?x`, `#y`, `\"\"`) is
+  returned unchanged — it carries no origin to strip.
+
+  Pure string parsing — JVM + CLJS portable; no `js/URL` (the helper ns
+  is `.cljc` and runs under `clojure -M:test`). The origin is everything
+  up to (but excluding) the FIRST `/`, `?`, or `#` that follows the
+  `scheme://` (or bare `//`) marker; the path begins at that delimiter.
+  An origin with no following path (`https://app.example`) reduces to the
+  empty string, which the caller then normalises to `\"/\"`.
+
+  rf2-6nx8y — the simulator's `split-url` previously stripped only the
+  query + fragment, so an absolute URL pasted from the browser address
+  bar (`https://app.example/cart?source=email#step-1`) was matched as the
+  path `https://app.example/cart` and patterns like `/cart` never
+  matched. The UI/spec says to paste a URL, and the common copy-paste
+  workflow yields an absolute URL — so the simulator normalises the
+  origin away first."
+  [s]
+  (let [scheme-rel? (str/starts-with? s "//")
+        after-scheme (cond
+                       scheme-rel?
+                       (subs s 2)
+                       ;; `scheme://authority…` — find the `://` marker.
+                       :else
+                       (let [idx (str/index-of s "://")]
+                         (when idx (subs s (+ idx 3)))))]
+    (if (nil? after-scheme)
+      ;; No origin marker → relative input, return verbatim.
+      s
+      ;; `after-scheme` is `authority + path?query#frag`. The path begins
+      ;; at the first `/`, `?`, or `#`; everything before it is the
+      ;; authority (host[:port], userinfo) and is dropped.
+      (let [delim (->> [(str/index-of after-scheme "/")
+                        (str/index-of after-scheme "?")
+                        (str/index-of after-scheme "#")]
+                       (remove nil?)
+                       (reduce min ##Inf))]
+        (if (= delim ##Inf)
+          ;; Authority only (`https://app.example`) — no path.
+          ""
+          (subs after-scheme delim))))))
+
 (defn- split-url
-  "Strip fragment + query off a URL string, returning just the path
-  segment. Mirrors the splitting `match-url` performs before invoking
-  `match-against`. Fragments are dropped (do not participate in
-  matching per Spec 012 §Fragments); query strings are dropped
-  (route patterns match against the path only)."
+  "Strip the origin (scheme + authority), then fragment + query off a
+  URL string, returning just the path segment. Mirrors the splitting
+  `match-url` performs before invoking `match-against`, PLUS an
+  absolute-URL normalisation step `match-url` itself does not need
+  (it only ever sees host-relative URLs from the browser's
+  `location`): the simulator's input is pasted by a human, commonly
+  copied wholesale from the address bar, so an absolute URL is
+  normalised to its `pathname` first (rf2-6nx8y).
+
+  Order: origin → fragment → query.
+
+    - Origin (`scheme://authority`) is dropped via `strip-origin` so
+      `https://app.example/cart?x#y` reduces to `/cart?x#y` before the
+      query/fragment strip; a relative input is untouched.
+    - Fragments are dropped (do not participate in matching per Spec 012
+      §Fragments).
+    - Query strings are dropped (route patterns match against the path
+      only)."
   [url]
   (when (string? url)
-    (let [[no-frag] (str/split url #"#" 2)
-          [path]    (str/split no-frag #"\?" 2)]
+    (let [path-qs-frag (strip-origin url)
+          [no-frag]    (str/split path-qs-frag #"#" 2)
+          [path]       (str/split no-frag #"\?" 2)]
       (cond
         (str/blank? path) "/"
         :else             path))))

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/helpers.cljc
@@ -134,12 +134,59 @@
 
 ;; ---- machine-row projection ---------------------------------------------
 
+(defn- count-state-map
+  "Count every state under a `{state-id state-node}` map, recursing into
+  each compound state's nested `:states`. A compound parent counts as ONE
+  state plus the count of its substates — so `{:authed {:states {:a {}
+  :b {}}}}` is THREE states (`:authed` + `:a` + `:b`), matching the node
+  count the topology renderer emits for the same definition
+  (`panels.machines.topology/parse-definition`'s `walk-states`).
+
+  Pure data — JVM-runnable; no CLJS-only deps so the helper stays
+  portable to the `clojure -M:test` target."
+  [state-map]
+  (if (map? state-map)
+    (reduce-kv (fn [acc _state-id node]
+                 (+ acc 1 (count-state-map (:states node))))
+               0
+               state-map)
+    0))
+
 (defn- state-count
-  "Count of states in the machine's definition. Reads the canonical
-  `:states` slot (Spec 005 §Definition shape). Returns 0 when the
-  definition is missing or has no states map."
+  "Count of EVERY rendered state in the machine's definition — the same
+  total the Static Machines topology renderer paints (rf2-6nx8y).
+
+  Two definition shapes (Spec 005 §Definition shape):
+
+    - Compound machine — a `{:initial :states}` map. Counts every state
+      across all nesting levels: top-level states PLUS every compound
+      state's recursively-nested substates. Reading only the top-level
+      `:states` keys (the pre-rf2-6nx8y body) under-counted the deep
+      machines Xray exists to inspect.
+
+    - Parallel machine — `{:type :parallel :regions {...}}`. Sums each
+      region's own state count (recursively). The pre-rf2-6nx8y body
+      read `(:states definition)`, which is absent on a parallel root, so
+      every parallel machine displayed `0 states`.
+
+  Mirrors the node count `panels.machines.topology/parse-definition`
+  emits for the same definition, so the browse-list chip, the detail
+  header `<N> states`, and the `Sort: States` axis all agree with the
+  rendered topology. Returns 0 for a nil / non-map definition or one
+  carrying no states. Pure data — JVM-runnable."
   [definition]
-  (count (get definition :states {})))
+  (cond
+    (not (map? definition))
+    0
+
+    (= :parallel (:type definition))
+    (reduce-kv (fn [acc _region-id region]
+                 (+ acc (state-count region)))
+               0
+               (:regions definition))
+
+    :else
+    (count-state-map (:states definition))))
 
 (defn- live-instance-count
   "Number of times the machine-id appears in the snapshots map. v1

--- a/tools/xray/test/day8/re_frame2_xray/panels/routing_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/routing_helpers_cljs_test.cljc
@@ -227,6 +227,60 @@
       (is (= :route/exact (first ids)))
       (is (= :route/splat (second ids))))))
 
+;; ---- simulate-url: absolute-URL normalisation (rf2-6nx8y) ---------------
+;;
+;; The Simulate-URL UI says "paste a URL", and the common copy-paste
+;; workflow copies the WHOLE address-bar URL — an ABSOLUTE URL with a
+;; scheme + authority. Before rf2-6nx8y `split-url` stripped only the
+;; query + fragment, so `https://app.example/cart` was matched as the
+;; literal path `https://app.example/cart` and `/cart` never matched.
+;; The simulator now normalises an absolute (or protocol-relative) URL
+;; to its `pathname` first, while leaving relative paths untouched.
+
+(deftest simulate-url-absolute-url-test
+  (testing "absolute URL pasted from the address bar resolves its pathname"
+    (let [r (h/simulate-url cart-routes "https://app.example/cart?source=email#step-1")]
+      (is (= "/cart" (:path r))
+          "scheme + authority + query + fragment all stripped")
+      (is (= :route/cart (:winner r)))))
+
+  (testing "absolute URL with a deep path + trailing slash"
+    (let [r (h/simulate-url cart-routes "http://localhost:3000/checkout/")]
+      (is (= "/checkout" (:path r))
+          "origin stripped + trailing slash normalised")
+      (is (= :route/checkout (:winner r)))))
+
+  (testing "absolute URL whose path does not match any route → no winner"
+    (let [r (h/simulate-url cart-routes "https://app.example/nope")]
+      (is (= "/nope" (:path r)))
+      (is (= [] (:candidates r)))
+      (is (nil? (:winner r)))))
+
+  (testing "absolute URL with authority only (no path) → root"
+    (let [r (h/simulate-url cart-routes "https://app.example")]
+      (is (= "/" (:path r)))
+      (is (= :route/root (:winner r))
+          "bare origin normalises to the root path")))
+
+  (testing "userinfo + port in the authority are dropped with the origin"
+    (let [r (h/simulate-url cart-routes "https://user:pw@app.example:8443/cart")]
+      (is (= "/cart" (:path r)))
+      (is (= :route/cart (:winner r)))))
+
+  (testing "protocol-relative URL (//host/path) also strips the authority"
+    (let [r (h/simulate-url cart-routes "//app.example/cart?x=1")]
+      (is (= "/cart" (:path r)))
+      (is (= :route/cart (:winner r)))))
+
+  (testing "RELATIVE path with a colon segment is NOT treated as a scheme"
+    ;; A relative path can legitimately contain a `:` (a literal segment).
+    ;; Only a `scheme://` (or leading `//`) marks an origin, so `/a:b/cart`
+    ;; stays a relative path. cart-routes has no `/a:b/cart`, so it misses
+    ;; cleanly rather than being mangled into a host.
+    (let [r (h/simulate-url cart-routes "/cart")]
+      (is (= "/cart" (:path r)) "plain relative path unchanged")
+      (is (= :route/cart (:winner r))))))
+
 ;; ---- focused-cascade ----------------------------------------------------
 
 (deftest focused-cascade-test
@@ -536,6 +590,17 @@
       ;; Slot shape still carries path (registered) but no params (no match).
       (is (= "/cart" (:path pv)))
       (is (not (contains? (:slot-shape pv) :params))))))
+
+(deftest simulate-navigation-preview-normalises-absolute-url-test
+  (testing "preview applies the same absolute-URL normalisation as the simulator (rf2-6nx8y)"
+    ;; An absolute URL pasted into the row's Simulate-URL surface must
+    ;; match THIS row's pattern the same way the global simulator does —
+    ;; the origin is stripped before `match-against` so `/cart` matches.
+    (let [pv (h/simulate-navigation-preview cart-routes :route/cart
+                                            "https://app.example/cart?source=email#step-1")]
+      (is (true? (:matched? pv))
+          "absolute URL's pathname matches the row's pattern")
+      (is (= :route/cart (-> pv :slot-shape :id))))))
 
 (deftest simulate-navigation-preview-row-local-overlapping-test
   (testing "row preview matches the SELECTED row's pattern, not the global winner (rf2-m9rx6)"

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/helpers_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/helpers_test.cljc
@@ -102,6 +102,90 @@
     (is (= 3 (count rows)))
     (is (= [:m/a :m/b :m/c] (mapv :machine-id rows)))))
 
+;; ---- state-count: flat / compound / parallel (rf2-6nx8y) ----------------
+;;
+;; The state-count drives the browse-list chip, the detail header
+;; `<N> states`, and the `Sort: States` axis. It MUST count every state
+;; the topology renderer paints — top-level states PLUS compound
+;; substates PLUS every parallel region's states. Pre-rf2-6nx8y it read
+;; only `(count (:states definition))`, so compound substates were
+;; omitted and parallel machines (no `:states` key) showed `0 states`.
+;; The count is exercised via the public `project-row` (`state-count`
+;; itself is private).
+
+(deftest state-count-flat-counts-top-level-states
+  (testing "a flat machine counts its top-level states"
+    (let [row (h/project-row :m/flat
+                             {:initial :idle
+                              :states  {:idle    {:on {:go :busy}}
+                                        :busy    {:on {:done :idle}}
+                                        :stopped {}}}
+                             {})]
+      (is (= 3 (:state-count row))))))
+
+(deftest state-count-compound-includes-nested-substates
+  (testing "compound substates are counted, not omitted (rf2-6nx8y)"
+    ;; :unauth + :authed + (:browsing + :paying) = 4 — the same node
+    ;; count topology/parse-definition emits for this definition.
+    (let [row (h/project-row :m/compound
+                             {:initial :unauth
+                              :states  {:unauth {:on {:login :authed}}
+                                        :authed {:initial :browsing
+                                                 :states  {:browsing {:on {:checkout :paying}}
+                                                           :paying   {:on {:done :browsing}}}}}}
+                             {})]
+      (is (= 4 (:state-count row))
+          ":unauth + :authed + :browsing + :paying"))))
+
+(deftest state-count-deeply-nested-compound
+  (testing "recursion descends every compound level"
+    ;; :a + (:b + (:c + :d)) = 4
+    (let [row (h/project-row :m/deep
+                             {:initial :a
+                              :states  {:a {:initial :b
+                                            :states  {:b {:initial :c
+                                                          :states  {:c {}
+                                                                    :d {}}}}}}}
+                             {})]
+      (is (= 4 (:state-count row))
+          ":a + :b + :c + :d across three nesting levels"))))
+
+(deftest state-count-parallel-sums-region-states
+  (testing "a :type :parallel machine sums its regions' states (rf2-6nx8y)"
+    ;; region :r1 (:a + :b) + region :r2 (:c) = 3 — was 0 pre-fix
+    ;; because a parallel root carries no top-level :states key.
+    (let [row (h/project-row :m/par
+                             {:type    :parallel
+                              :regions {:r1 {:initial :a :states {:a {} :b {}}}
+                                        :r2 {:initial :c :states {:c {}}}}}
+                             {})]
+      (is (= 3 (:state-count row))
+          "two regions' states flatten: a + b + c"))))
+
+(deftest state-count-parallel-with-compound-regions
+  (testing "parallel regions whose states are themselves compound recurse"
+    ;; region :r1: :a + (:b + :b1 + :b2) = 4 ; region :r2: :c = 1 → 5
+    (let [row (h/project-row :m/par-compound
+                             {:type    :parallel
+                              :regions {:r1 {:initial :a
+                                             :states  {:a {}
+                                                       :b {:initial :b1
+                                                           :states  {:b1 {} :b2 {}}}}}
+                                        :r2 {:initial :c :states {:c {}}}}}
+                             {})]
+      (is (= 5 (:state-count row))
+          "region :r1 (a + b + b1 + b2) + region :r2 (c)"))))
+
+(deftest state-count-degenerate-shapes-are-zero
+  (testing "nil / empty / no-states definitions count 0"
+    (is (= 0 (:state-count (h/project-row :m/nil nil {}))))
+    (is (= 0 (:state-count (h/project-row :m/empty {} {}))))
+    (is (= 0 (:state-count (h/project-row :m/no-states {:initial :idle} {})))
+        "an :initial-only map with no :states map → 0")
+    (is (= 0 (:state-count (h/project-row :m/empty-parallel
+                                          {:type :parallel :regions {}} {})))
+        "a parallel root with no regions → 0")))
+
 ;; ---- search -------------------------------------------------------------
 
 (def ^:private sample-rows


### PR DESCRIPTION
Fixes the two senior-review findings on `tools/xray` from bead **rf2-6nx8y**.

## Finding 1 — Static Machines state-count ignored compound + parallel states (CONFIRMED, fixed)

`static/machines/helpers.cljc` `state-count` read only `(count (:states definition))`, so:
- compound substates were never counted (a 3-state nested machine reported its top-level count only); and
- `:type :parallel` machines — whose root carries `:regions`, not `:states` — reported **`0 states`**.

This misled the browse-list chip, the detail header `<N> states`, and the `Sort: States` axis on exactly the complex machines Xray exists to inspect.

**Fix:** a pure recursive `count-state-map` walker plus a `:type :parallel` arm that sums each region recursively. The total now equals the node count `panels.machines.topology/parse-definition` (`walk-states` + the `:parallel` region concat) emits for the same definition — so the chip / header / sort axis agree with the rendered topology.

**Why a shared pure walker, not a `require` of the projector:** `helpers.cljc` is `.cljc` and runs under the JVM `clojure -M:test` target; `panels.machines.topology` is CLJS-only (it requires `machines-viz/chart.layout`, which pulls React/tokens). Requiring it would break the JVM test target. The bead's third suggested option (a shared pure recursive walker) is the JVM-portable choice; its semantics are pinned to match the projector by the new tests.

Tests (`helpers_test.cljc`): flat, compound, deeply-nested compound, parallel, parallel-with-compound-regions, and degenerate (nil / empty / `:initial`-only / empty-`:regions`) shapes. Exercised via the public `project-row` (`state-count` is private).

## Finding 2 — Simulate-URL absolute-URL handling (CONFIRMED, fixed)

`panels/routing_helpers.cljc` `split-url` stripped only the query + fragment, so an absolute URL pasted from the browser address bar (`https://app.example/cart?source=email#step-1`) was matched as the literal path `https://app.example/cart` and a `/cart` pattern never matched — a common copy-paste workflow that reported "no route matches".

**Fix:** a `strip-origin` step normalises an absolute (or protocol-relative `//host/…`) URL to its `pathname` *before* the existing query/fragment strip, while leaving relative paths untouched (only `scheme://` / a leading `//` marks an origin, so a relative path containing a `:` segment is not mistaken for a scheme). `match-url` itself needs no such step — it only ever sees host-relative `location` URLs — but the simulator's input is human-pasted. The same normalisation flows through `simulate-navigation-preview` (it shares `split-url`).

Tests (`routing_helpers_cljs_test.cljc`): absolute URL with query+fragment, deep path + trailing slash, no-match, authority-only (→ root), userinfo+port, protocol-relative, relative-path-with-colon, and an absolute-URL case for `simulate-navigation-preview`.

## Spec

`tools/xray/spec/016-Auxiliary-Panels.md` §Simulate-URL contract updated to document the input-normalisation step (standing rule: keep `tools/xray/spec/*` current).

## Quality gates

- **`tools/xray` JVM tests** (`clojure -M:test`): **1097 tests, 4568 assertions, 0 failures, 0 errors** (was 1095 / 4551 pre-change; +9 deftests).
- **`check_doc_slugs.py`** (xray spec touched): **exit 0**.
- **`implementation/ npm run test:cljs`**: not run — not applicable. Xray is bundle-isolated from `implementation/`; the implementation node-test target does not `:require` `tools/xray`, so these helpers are not exercised there. Their canonical regression surface is the `tools/xray` JVM unit tests above (the bead's own dedupe note states real coverage lives in the unit tests).
- **`npm run test:xray-feature-gate`**: not run. It is an occasional (non-default-CI) browser/load gate that asserts panel mount + chart render, not the specific state-count value or the Simulate-URL path normalisation — so it adds no coverage for these pure-data changes. Running it requires a full `implementation/ npm install` + multi-testbed shadow-cljs compile in a fresh worktree, which the Windows file-lock notes flag as prone to leaving locked JVMs. Both behaviours are fully covered by the `.cljc` JVM unit tests, which is where these helpers are designed to be tested.

Lane: touches only `tools/xray/**`. No changes to `tools/machines-viz` (the topology projector is xray's own `parse-definition`; the new walker mirrors its semantics without modifying or requiring machines-viz).
