### PR TITLE
fix(mcp-base): trip :rf.error/bad-diff-sections on malformed diff marker + findings 2-3 (rf2-y3qpv)

### DIFF
--- a/tools/mcp-base/spec/descriptor-manifest.md
+++ b/tools/mcp-base/spec/descriptor-manifest.md
@@ -17,7 +17,7 @@ A generated, CI-guarded manifest prevents the drift the way the keystone's `spec
 
 - The **catalogue-row projection** (`descriptor->row`): the stable shape one registry descriptor maps to.
 - The **deterministic, byte-stable, LF-pinned EDN serialiser** (`render-edn`) — one tool row per line for surgical diffs.
-- The **drift-check** (`check`): regenerate-in-memory vs committed, with an added/removed name diff for the failure message.
+- The **drift-check** (`check`): regenerate-in-memory vs committed, with an added / removed / **changed** name diff for the failure message. `:changed` (rf2-y3qpv) names every tool present in BOTH manifests whose catalogue row drifted (a changed `:description` / `:input-keys` / `:output?` / `:annotations`) and carries its `{:name :old :new}` rows, so a tool-set-identical-but-descriptor-changed drift is row-level actionable instead of forcing a manual whole-manifest diff.
 - `build-rows` / `build-manifest` — the small assembly helpers between the two.
 
 `descriptor-manifest` does NOT own:
@@ -48,7 +48,7 @@ The full descriptor maps carry deeply-nested JSON-Schema fragments whose exact s
 | `build-rows` | `[descriptors]` | sorted-by-`:name` vector of rows |
 | `build-manifest` | `[server descriptors]` | `{:meta {:server :tool-count} :tools [rows]}` |
 | `render-edn` | `[manifest]` | deterministic, LF-pinned EDN string |
-| `check` | `[generated-manifest generated-edn committed-string-or-nil]` | `{:ok? :added :removed (:missing-file?)}` |
+| `check` | `[generated-manifest generated-edn committed-string-or-nil]` | `{:ok? :added :removed :changed (:missing-file?)}` |
 
 ## Determinism + byte-stability
 

--- a/tools/mcp-base/spec/diff-encode.md
+++ b/tools/mcp-base/spec/diff-encode.md
@@ -95,6 +95,8 @@ The `:db-after` marker carries `:sections`, so the decoder first flattens the pe
 
 The shipped decoder (`decode-db-after`) Malli-validates `:sections` at the decode boundary (`validate-sections!`, symmetric with the encoder's gate) then replays via the non-validating `apply-patches*` to avoid a redundant second Malli walk on the JVM decode hot path. Both story-mcp and re-frame2-pair-mcp consume this shape; the agent-host decoder is small.
 
+The decoder validates the **raw** `:sections` slot — it does NOT default a missing / `nil` / `false` slot to `[]` (rf2-y3qpv). A diff marker always carries an explicit `:sections` vector; a malformed `{:rf.mcp/diff-from :db-before}` marker (no / falsey `:sections`) therefore trips `:rf.error/bad-diff-sections` when Malli is present rather than decoding to a silent no-op that erases the epoch's real `:db-after` change. An explicit `:sections []` — a genuine no-change diff — stays valid and replays to `:db-before` unchanged.
+
 > **Note** root-path patches: an `[[] :assoc <full>]` patch replaces `base` outright (whole-DB replacement, e.g. `reset-frame-db!`); an `[[] :dissoc]` is a no-op by convention.
 
 ## Cross-platform

--- a/tools/mcp-base/src/re_frame/mcp_base/descriptor_manifest.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/descriptor_manifest.cljc
@@ -176,13 +176,26 @@
 ;; Drift-check — regenerate-in-memory vs committed.
 ;; ---------------------------------------------------------------------------
 
+(defn- row-by-name
+  "Index a seq of manifest rows by `:name`. Defensive against a row
+  missing a `:name` (the committed EDN may be partly malformed) — such
+  rows are dropped from the index rather than colliding under `nil`."
+  [rows]
+  (reduce (fn [m row]
+            (if-let [nm (:name row)]
+              (assoc m nm row)
+              m))
+          {}
+          rows))
+
 (defn check
   "Compare a freshly-generated manifest string against the committed
   file content. Returns a result map:
 
       {:ok?     <bool>
        :added   [<row name strings the generator produced the file lacks>]
-       :removed [<row name strings in the file the generator no longer produces>]}
+       :removed [<row name strings in the file the generator no longer produces>]
+       :changed [{:name <str> :old <committed-row> :new <generated-row>} ...]}
 
   `generated-edn` is `(render-edn (build-manifest ...))`; `committed`
   is the committed file's content string (or nil if it doesn't exist).
@@ -190,20 +203,50 @@
   checkout on Windows does not trip a spurious drift. The added/removed
   name diffs are derived from the two manifests' tool rows so the
   failure message names exactly which tool drifted — same affordance
-  the keystone's `check!` prints."
+  the keystone's `check!` prints.
+
+  ## Row-level `:changed` identity (rf2-y3qpv)
+
+  `:added` / `:removed` only name tools whose IDENTITY entered or left
+  the catalogue. When an EXISTING tool's `:description`, `:input-keys`,
+  `:output?`, or `:annotations` drifts, neither set names it — the CI
+  guard went red with `{:ok? false :added [] :removed []}` and the
+  consumer generator could only print a generic \"tool set identical;
+  descriptor changed\" message, forcing a maintainer to manually diff
+  the whole manifest. `:changed` closes that gap: for every name present
+  in BOTH manifests whose row differs, it carries
+  `{:name <str> :old <committed-row> :new <generated-row>}` so the
+  failure message can name exactly which existing tool drifted and how.
+  An in-sync manifest (`:ok? true`) and a missing-file result both carry
+  `:changed []`."
   [generated-manifest generated-edn committed]
-  (let [gen-names (set (map :name (:tools generated-manifest)))]
+  (let [gen-rows  (:tools generated-manifest)
+        gen-names (set (map :name gen-rows))]
     (if (nil? committed)
-      {:ok? false :added (vec (sort gen-names)) :removed []
+      {:ok? false :added (vec (sort gen-names)) :removed [] :changed []
        :missing-file? true}
       (let [ok?       (= (normalise-lf generated-edn) (normalise-lf committed))
-            ;; Parse committed names out of the EDN for the diff summary.
+            ;; Parse committed rows out of the EDN for the diff summary.
             ;; We read the committed EDN as data; if it's unparseable the
             ;; equality check above already failed and we report all gen
-            ;; names as added (the file is structurally broken).
-            com-names (try
-                        (set (map :name (:tools (edn/read-string committed))))
-                        (catch #?(:clj Throwable :cljs :default) _ #{}))]
+            ;; names as added (the file is structurally broken) with no
+            ;; :changed rows (we can't compare against unreadable rows).
+            com-rows  (try
+                        (:tools (edn/read-string committed))
+                        (catch #?(:clj Throwable :cljs :default) _ nil))
+            com-names (set (map :name com-rows))
+            gen-by    (row-by-name gen-rows)
+            com-by    (row-by-name com-rows)
+            ;; Names present in BOTH whose row content differs.
+            changed   (->> (set/intersection gen-names com-names)
+                           sort
+                           (keep (fn [nm]
+                                   (let [old (get com-by nm)
+                                         new (get gen-by nm)]
+                                     (when (not= old new)
+                                       {:name nm :old old :new new}))))
+                           vec)]
         {:ok?     ok?
          :added   (vec (sort (set/difference gen-names com-names)))
-         :removed (vec (sort (set/difference com-names gen-names)))}))))
+         :removed (vec (sort (set/difference com-names gen-names)))
+         :changed changed}))))

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -425,7 +425,7 @@
   input unchanged when `:db-after` isn't a diff). Provided for
   agent-host round-trip parity and for the unit tests.
 
-  ## Decoder-boundary section validation (rf2-j6oay)
+  ## Decoder-boundary section validation (rf2-j6oay / rf2-y3qpv)
 
   Mirrors the encoder's `validate-sections!` gate. `sections->patches`
   is a permissive `mapcat :patches` — a section with malformed
@@ -438,6 +438,19 @@
   slots through to an agent-host UI that paints them as truth. The
   ex-info names `'mcp-base/decode-db-after` as the decode-side boundary
   (rf2-4ypau).
+
+  The gate validates the RAW `:sections` slot — it does NOT default a
+  missing / `nil` / `false` slot to `[]` (rf2-y3qpv). A diff marker
+  always carries an explicit `:sections` vector; coercing an absent or
+  falsey slot to an empty vector before the gate let a malformed
+  `{:rf.mcp/diff-from :db-before}` marker decode to a no-op (an empty
+  seq satisfies `[:sequential section-schema]`), silently ERASING the
+  epoch's real `:db-after` change in diagnostics — the exact silent
+  pass-through this boundary posture forbids. `sections-schema`
+  rejects `nil` / `false` (neither is sequential), so wire drift now
+  trips `:rf.error/bad-diff-sections` when Malli is present. An
+  explicit `:sections []` — a genuine no-change diff — still validates
+  and replays to `:db-before` unchanged.
 
   Soft-pass + `goog-define`-elidable by construction — reuses the
   same `validate-sections!` helper as the encoder.
@@ -456,9 +469,21 @@
     (if-not (and (map? db-after)
                  (= :db-before (get db-after vocab/diff-from-key)))
       epoch
+      ;; Validate the RAW `:sections` value — do NOT default a
+      ;; missing / nil / false slot to `[]` before the gate (rf2-y3qpv).
+      ;; A diff marker carries an EXPLICIT `:sections` vector; coercing
+      ;; an absent or falsey slot to an empty vector slipped a malformed
+      ;; `{:rf.mcp/diff-from :db-before}` marker past `validate-sections!`
+      ;; (an empty seq satisfies `[:sequential section-schema]`) and
+      ;; replayed it as a no-op, silently ERASING the epoch's real
+      ;; `:db-after` change in diagnostics. `sections-schema` rejects
+      ;; `nil` / `false` (neither is sequential) so the decoder-boundary
+      ;; gate now trips `:rf.error/bad-diff-sections` on wire drift, while
+      ;; an explicit `:sections []` (a genuine no-change diff) still
+      ;; validates and replays to `:db-before` unchanged.
       (let [sections  (:sections db-after)
-            _         (validate-sections! (or sections []) 'mcp-base/decode-db-after)
-            patches   (sg/sections->patches (or sections []))
+            _         (validate-sections! sections 'mcp-base/decode-db-after)
+            patches   (sg/sections->patches sections)
             db-before (:db-before epoch)
             rebuilt   (apply-patches* db-before patches)]
         (assoc epoch :db-after rebuilt)))))

--- a/tools/mcp-base/src/re_frame/mcp_base/section_grouping.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/section_grouping.cljc
@@ -319,6 +319,17 @@
   "Flatten sections back into the patch list.
   `(apply-patches db-before (sections->patches sections))`
   reproduces the original `:db-after`. Lossless inverse of
-  `group-patches-into-sections`."
+  `group-patches-into-sections`.
+
+  `sections` that is not sequential (a `nil` / `false` / scalar slot on
+  a malformed diff marker) flattens to `[]` rather than throwing an
+  opaque `Don't know how to create ISeq` error. The decoder-boundary
+  Malli gate (`diff-encode/validate-sections!`) is the LOUD guard that
+  trips `:rf.error/bad-diff-sections` on such a marker; this fn only
+  runs after that gate (or its soft-pass when Malli is absent), so the
+  non-sequential branch is the soft-pass safety net, not the primary
+  validation (rf2-y3qpv)."
   [sections]
-  (vec (mapcat :patches sections)))
+  (if (sequential? sections)
+    (vec (mapcat :patches sections))
+    []))

--- a/tools/mcp-base/test/re_frame/mcp_base/descriptor_manifest_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/descriptor_manifest_test.clj
@@ -83,7 +83,8 @@
         res (dm/check m edn edn)]
     (is (true? (:ok? res)))
     (is (empty? (:added res)))
-    (is (empty? (:removed res)))))
+    (is (empty? (:removed res)))
+    (is (empty? (:changed res)) "an in-sync manifest reports no changed rows")))
 
 (deftest check-detects-missing-file
   (let [m   (dm/build-manifest :test sample-descriptors)
@@ -114,6 +115,51 @@
       (is (false? (:ok? res)))
       (is (empty? (:added res)))
       (is (= ["beta"] (:removed res)) "beta was dropped"))))
+
+(deftest check-detects-changed-existing-tool
+  ;; rf2-y3qpv: when an EXISTING tool's catalogue row drifts (here alpha
+  ;; gains an input key) the identity sets stay empty — neither :added
+  ;; nor :removed names it. The CI guard previously went red with no
+  ;; row-level identity of WHAT changed, forcing a manual whole-manifest
+  ;; diff. `:changed` now names the drifted tool and carries old/new rows.
+  (testing "an existing tool that gains an input key is :changed, not :added/:removed"
+    (let [committed-m   (dm/build-manifest :test sample-descriptors)
+          committed-edn (dm/render-edn committed-m)
+          ;; alpha gains a :force input property; beta is untouched.
+          alpha+        (assoc-in (second sample-descriptors)
+                                  [:inputSchema :properties :force]
+                                  {:type "boolean"})
+          gen-m         (dm/build-manifest :test [(first sample-descriptors) alpha+])
+          gen-edn       (dm/render-edn gen-m)
+          res           (dm/check gen-m gen-edn committed-edn)]
+      (is (false? (:ok? res)))
+      (is (= [] (:added res)) "no tool entered the catalogue")
+      (is (= [] (:removed res)) "no tool left the catalogue")
+      (is (= ["alpha"] (mapv :name (:changed res)))
+          "alpha's row drifted; it is named in :changed")
+      (let [{:keys [old new]} (first (:changed res))]
+        (is (= ["event"] (:input-keys old)) "old row carries the committed input-keys")
+        (is (= ["event" "force"] (:input-keys new))
+            "new row carries the regenerated input-keys — the maintainer sees the delta")))))
+
+(deftest check-changed-detects-each-drifting-row-shape
+  ;; The four catalogue-surface slots the manifest governs each trip
+  ;; :changed in isolation (description / output? / annotations, plus the
+  ;; input-keys case above). One row mutated per case; beta untouched.
+  (let [base (second sample-descriptors)] ; alpha
+    (doseq [[label mutate] [["description" #(assoc % :description "Changed prose.")]
+                            ["output?"     #(assoc % :outputSchema {:type "object"})]
+                            ["annotations" #(assoc-in % [:annotations :readOnlyHint] true)]]]
+      (testing (str "a changed :" label " trips :changed")
+        (let [committed-m   (dm/build-manifest :test sample-descriptors)
+              committed-edn (dm/render-edn committed-m)
+              gen-m         (dm/build-manifest :test [(first sample-descriptors) (mutate base)])
+              gen-edn       (dm/render-edn gen-m)
+              res           (dm/check gen-m gen-edn committed-edn)]
+          (is (false? (:ok? res)))
+          (is (= [] (:added res)))
+          (is (= [] (:removed res)))
+          (is (= ["alpha"] (mapv :name (:changed res)))))))))
 
 (deftest check-tolerates-crlf-committed
   (testing "a CRLF working-tree checkout does not trip a spurious drift"

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -419,6 +419,66 @@
                  (:where (ex-data e)))
               "ex-info names the DECODE-side boundary, not the encoder (rf2-4ypau)"))))))
 
+(deftest decode-db-after-rejects-malformed-sections-slot
+  ;; rf2-y3qpv: a diff marker whose `:sections` slot is MISSING, `nil`,
+  ;; or `false` previously decoded to a no-op via `(or sections [])` —
+  ;; an empty seq satisfies `[:sequential section-schema]`, so the gate
+  ;; never tripped and the epoch's real `:db-after` change was silently
+  ;; ERASED back to `:db-before`. The raw slot is now validated, so a
+  ;; non-sequential `:sections` trips `:rf.error/bad-diff-sections`
+  ;; (Malli present). `:db-before` carries a real change so a regression
+  ;; (silent no-op) would observably hand back `{:a 1}` instead of throwing.
+  (testing "missing :sections slot throws"
+    (let [epoch {:db-before {:a 1}
+                 :db-after  {:rf.mcp/diff-from :db-before}}]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #":rf\.error/bad-diff-sections"
+            (de/decode-db-after epoch)))))
+  (testing ":sections nil throws"
+    (let [epoch {:db-before {:a 1}
+                 :db-after  {:rf.mcp/diff-from :db-before
+                             :sections nil}}]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #":rf\.error/bad-diff-sections"
+            (de/decode-db-after epoch)))))
+  (testing ":sections false throws"
+    (let [epoch {:db-before {:a 1}
+                 :db-after  {:rf.mcp/diff-from :db-before
+                             :sections false}}]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #":rf\.error/bad-diff-sections"
+            (de/decode-db-after epoch)))))
+  (testing "the malformed-slot throw names the DECODE-side boundary"
+    (let [epoch {:db-before {:a 1}
+                 :db-after  {:rf.mcp/diff-from :db-before}}]
+      (try
+        (de/decode-db-after epoch)
+        (is false "expected throw")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :rf.error/bad-diff-sections (:rf.error/id (ex-data e))))
+          (is (= 'mcp-base/decode-db-after (:where (ex-data e)))))))))
+
+(deftest decode-db-after-explicit-empty-sections-is-valid-no-change
+  ;; rf2-y3qpv companion: an EXPLICIT `:sections []` is a legitimate
+  ;; no-change diff (db-before == db-after) and MUST still validate and
+  ;; replay to `:db-before` unchanged — the gate guards malformed shape,
+  ;; it does not reject a real empty diff.
+  (testing "encoder emits :sections [] for an unchanged epoch and decode round-trips"
+    (let [epoch   {:db-before {:a 1} :db-after {:a 1}}
+          encoded (de/diff-encode-db-after epoch)]
+      (is (= [] (get-in encoded [:db-after :sections]))
+          "no-change epoch encodes to an explicit empty section vector")
+      (is (= epoch (de/decode-db-after encoded)))))
+  (testing "a hand-built :sections [] marker decodes to :db-before without throwing"
+    (let [epoch {:db-before {:a 1 :b 2}
+                 :db-after  {:rf.mcp/diff-from :db-before
+                             :sections []}}]
+      (is (= {:db-before {:a 1 :b 2} :db-after {:a 1 :b 2}}
+             (de/decode-db-after epoch))))))
+
 (deftest decode-db-after-well-formed-sections-round-trip
   ;; The positive companion: well-formed sections decode silently and
   ;; reconstruct :db-after — proving the decode gate is a guard, not a

--- a/tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/vocab_test.clj
@@ -11,7 +11,15 @@
   (is (= :rf.mcp/diff-from     vocab/diff-from-key))
   (is (= :rf.mcp/cursor-stale  vocab/cursor-stale-reason))
   (is (= :rf.mcp/cache-hit     vocab/cache-hit-key))
-  (is (= :rf.mcp/summary       vocab/summary-key)))
+  (is (= :rf.mcp/summary       vocab/summary-key))
+  ;; rf2-y3qpv: the test stopped at :summary and omitted these two
+  ;; reserved wire-vocabulary markers, so a rename could slip past the
+  ;; base unit gate. :rf.mcp/invalid-arg is the per-call arg-rejection
+  ;; wrapper (rf2-5rdit); :rf.mcp/result is the wire-fidelity typed
+  ;; eval/handler result envelope (rf2-qobqy) that pair-mcp actively
+  ;; emits — both are cross-MCP convention an agent learns once.
+  (is (= :rf.mcp/invalid-arg   vocab/invalid-arg-key))
+  (is (= :rf.mcp/result        vocab/result-key)))
 
 (deftest rf-size-elision-keys-pinned
   (is (= :rf.size/large-elided        vocab/large-elided-key))


### PR DESCRIPTION
Senior review of `tools/mcp-base` (rf2-y3qpv, 3 findings). Lane: `tools/mcp-base/**` only.

## Per-finding disposition

### Finding 1 — `decode-db-after` silently passes malformed diff (FIXED)
`decode-db-after` defaulted a missing / `nil` / `false` `:sections` slot to `[]` via `(or sections [])` before BOTH `validate-sections!` and replay. An empty seq satisfies `[:sequential section-schema]`, so a malformed `{:rf.mcp/diff-from :db-before}` marker decoded to `:db-before` — a silent no-op that ERASED the epoch's real `:db-after` change in diagnostics, contradicting the decoder-boundary posture.

Fix: validate the RAW `:sections` value (no `(or … [])` defaulting). `sections-schema` rejects `nil` / `false` (neither is sequential), so wire drift now trips `:rf.error/bad-diff-sections` at the `'mcp-base/decode-db-after` boundary when Malli is present. Explicit `:sections []` (a genuine no-change diff) stays valid and replays to `:db-before` unchanged. `section-grouping/sections->patches` hardened to flatten `[]` for a non-sequential slot rather than throw an opaque `Don't know how to create ISeq` error on the Malli-absent soft-pass path (the loud Malli gate is the primary guard; this is the soft-pass safety net).

Tests: `decode-db-after-rejects-malformed-sections-slot` (missing / `nil` / `false` → `:rf.error/bad-diff-sections` + names the decode-side boundary) and `decode-db-after-explicit-empty-sections-is-valid-no-change` (encoder emits `:sections []` for a no-change epoch; hand-built `:sections []` marker decodes to `:db-before`). The existing CLJS soft-pass test stays green.

### Finding 2 — vocab marker-key pin omits two reserved constants (FIXED, with a noted follow-up)
`rf-mcp-marker-keys-pinned` stopped at `:summary` and omitted `:rf.mcp/invalid-arg` and `:rf.mcp/result`, so a rename of either could slip past the base vocab unit gate. Extended the test to pin `(= :rf.mcp/invalid-arg vocab/invalid-arg-key)` and `(= :rf.mcp/result vocab/result-key)`.

The finding's alternative sub-part — "add/update conformance coverage for `:rf.mcp/result` or remove the `vocab.md` doc note once cross-gated" — is NOT actioned here: the `vocab.md` note ("the wire-vocab conformance corpus does not yet pin this marker") is accurate, and adding conformance coverage lives in `tools/mcp-conformance/**` (a sibling worker's lane). Filed as follow-up. The primary harm the finding names (a rename slipping past the base unit test) is closed.

### Finding 3 — `descriptor-manifest/check` reports no row-level identity for changed tools (FIXED core; consumer-message follow-up filed)
`check` reported only `:added` / `:removed`. A changed `:description` / `:input-keys` / `:output?` / `:annotations` on an existing tool yielded `{:ok? false :added [] :removed []}` — no row-level identity. `check` now also returns `:changed [{:name :old :new} …]` for every name present in both manifests whose row drifted. Additive + backward-compatible: both consumer generators destructure only `:added`/`:removed`/`:missing-file?`, so they still compile and pass unchanged (story-mcp drift-check verified green; pair-mcp server-test + SDK conformance green).

The finding's "update story/pair generator messages to print changed names" touches `tools/story-mcp/**` and `tools/re-frame2-pair-mcp/**` — outside this lane. Filed as a follow-up; the data is now available for those consumers to consume.

Tests: `check-detects-changed-existing-tool` (alpha gains an input key → `:changed ["alpha"]`, `:added []`, `:removed []`, with old/new `:input-keys` deltas) and `check-changed-detects-each-drifting-row-shape` (description / output? / annotations each trip `:changed` in isolation); `check-passes-when-in-sync` extended to assert `:changed []`.

Specs updated in-lane: `tools/mcp-base/spec/diff-encode.md` (raw-slot validation note) and `tools/mcp-base/spec/descriptor-manifest.md` (`:changed` result key).

## Quality gates
- `tools/mcp-base` JVM (`clojure -M:test`): **201 tests, 604 assertions, 0 failures, 0 errors**
- `tools/mcp-base` CLJS (`npm run test:cljs`, Malli-absent soft-pass path): **9 tests, 45 assertions, 0 failures, 0 errors**
- `npm run test:mcp-conformance`: **ALL 6 GATES GREEN** — story-mcp JVM, story-mcp stdio roundtrip, pair-mcp server-test (941 tests / 2860 assertions), pair-mcp + story-mcp SDK-client conformance, wire-vocab (55 tests / 673 assertions)
- story-mcp `clojure -M:gen --check`: in sync (20 tools) — confirms the additive `check` change is backward-compatible
