### PR TITLE
fix(mcp-conformance): promote cursor-stale to a multi-server (pair+story) reason-value contract + finding 2 (rf2-2js41)

### DIFF
--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -13,6 +13,7 @@
     "test:story": "node test/end-to-end-story.cjs",
     "test:flag-gates": "node test/end-to-end-flag-gates.cjs",
     "test:exec-safety": "node --test test/exec-safety.test.cjs",
+    "test:runner-watchdog": "node --test test/runner-watchdog.test.cjs",
     "test": "node scripts/test-all.cjs"
   },
   "dependencies": {

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -48,6 +48,10 @@ const TESTS = [
     argv: ['--test', 'test/exec-safety.test.cjs'],
   },
   {
+    name: 'runner watchdog connect-hang teardown (rf2-2js41 finding 2)',
+    argv: ['--test', 'test/runner-watchdog.test.cjs'],
+  },
+  {
     name: 're-frame2-pair-mcp end-to-end',
     argv: ['test/end-to-end-re-frame2-pair.cjs'],
   },

--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -107,10 +107,30 @@ const CLIENT_VERSION = '0.1.0';
 //                        line. Defaults to `[server]`; the redaction
 //                        gate-ON arm passes `[server:gate-on]` to keep
 //                        the two concurrent servers' logs distinguishable.
+//   - `onClient`       — OPTIONAL `(client) => void` callback, invoked
+//                        with the constructed client BEFORE the
+//                        `await client.connect()` handshake. The
+//                        watchdog form (`runWithWatchdog`) uses it to
+//                        capture a teardown handle the moment the child
+//                        is spawned — so a server that spawns and then
+//                        HANGS during the initialize handshake (connect
+//                        never resolving, never throwing) is still torn
+//                        down by the timeout path instead of orphaning
+//                        the child (rf2-2js41 finding 2; the connect
+//                        try/catch below only covers a connect that
+//                        THROWS — a connect that hangs never reaches it).
 // ---------------------------------------------------------------------
-async function connectServer({ transportSpec, clientName, stderrPrefix = '[server]' }) {
+async function connectServer({ transportSpec, clientName, stderrPrefix = '[server]', onClient }) {
   const transport = new StdioClientTransport({ ...transportSpec, stderr: 'pipe' });
   const client = new Client({ name: clientName, version: CLIENT_VERSION }, { capabilities: {} });
+  // Hand the caller a teardown handle the moment the client exists —
+  // BEFORE the connect handshake. The child has already been spawned by
+  // the transport construction above, so a connect that hangs (server
+  // boots but never finishes `initialize`) would otherwise leave the
+  // watchdog with no client to close (rf2-2js41 finding 2). `onClient`
+  // closes that window: the watchdog captures `client` here, not after
+  // `connect` resolves.
+  if (onClient) onClient(client);
   // Pipe the child's stderr to ours with the (prefixed) tag. Same shape
   // every historical caller used; the closure captures the transport
   // reference cleanly.
@@ -148,8 +168,16 @@ async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) 
   // The watchdog must OWN the active client so a timeout tears the
   // spawned child down instead of orphaning it (rf2-voux7 finding 5).
   // `activeClient` is the closure handle the watchdog reads; it is
-  // assigned the moment `connectServer` returns, so a hang ANYWHERE
-  // after spawn (inside `body`, inside a slow tool call) is cleaned up.
+  // assigned via `connectServer`'s `onClient` callback the moment the
+  // client is constructed — BEFORE the `await client.connect()`
+  // handshake — so a hang ANYWHERE after spawn (during `initialize`,
+  // inside `body`, inside a slow tool call) is cleaned up. Pre-fix
+  // (rf2-2js41 finding 2) `activeClient` was assigned only AFTER
+  // `connectServer` RESOLVED, i.e. after `connect` completed; a server
+  // that spawned and then hung mid-handshake (connect never resolving,
+  // never throwing) left the watchdog with no client and the timeout
+  // path orphaned the child — the exact orphan class this watchdog
+  // exists to prevent.
   //
   // Pre-fix the watchdog called `process.exit(2)` directly, leaving the
   // spawned MCP server (Node bundle or JVM) running — it can keep the
@@ -189,7 +217,17 @@ async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) 
   let bodyError;
   try {
     let transport;
-    ({ client, transport } = await connectServer({ transportSpec, clientName }));
+    // Capture the teardown handle via `onClient` — fired the instant the
+    // client is constructed, BEFORE connect awaits — so a hang during the
+    // initialize handshake is still reachable by the watchdog (rf2-2js41
+    // finding 2). The post-resolve `activeClient = client` below is now
+    // redundant on the happy path but kept as a belt-and-braces guarantee
+    // (and to leave `client` bound for the `finally` teardown).
+    ({ client, transport } = await connectServer({
+      transportSpec,
+      clientName,
+      onClient: (c) => { activeClient = c; },
+    }));
     activeClient = client;
     await body(client, transport);
     exitCode = 0;

--- a/tools/mcp-conformance/test/runner-watchdog-hang-harness.cjs
+++ b/tools/mcp-conformance/test/runner-watchdog-hang-harness.cjs
@@ -1,0 +1,117 @@
+// Child harness for `runner-watchdog.test.cjs` (rf2-2js41 finding 2).
+//
+// Simulates the exact failure mode finding 2 describes: an MCP server
+// that SPAWNS and then HANGS during the `initialize` handshake — i.e.
+// `client.connect(transport)` neither resolves nor rejects. The watchdog
+// in `runWithWatchdog` is the only escape from that hang; the bug was
+// that `activeClient` (the watchdog's teardown handle) was assigned only
+// AFTER `connectServer` resolved, so a connect that hangs left the
+// watchdog with no client and the timeout path orphaned the spawned
+// child.
+//
+// This harness is HERMETIC: it does NOT require the real
+// `@modelcontextprotocol/sdk` package. A `Module._load` override
+// intercepts the three SDK specifiers `_runner.cjs` requires and
+// supplies in-process stubs:
+//
+//   - `Client.connect()`  returns a never-resolving promise (the hang).
+//   - `Client.close()`    resolves, and records that it was called by
+//                         printing the marker line below — the assertion
+//                         the parent test greps for.
+//   - `StdioClientTransport` is a no-op constructor (no real child is
+//                         spawned; `stderr` is null so the optional-chain
+//                         pipe in `connectServer` is a no-op).
+//
+// The harness installs the override, requires the real `_runner.cjs`
+// (so the production teardown path under test is exercised verbatim),
+// and calls `runWithWatchdog` with a short `watchdogMs`. Expected
+// behaviour with the fix: the watchdog fires, sees `activeClient` (set
+// via the new `onClient` callback BEFORE connect awaited), calls
+// `closeQuietly(activeClient)` which invokes our stub `close()` (printing
+// the marker), then `process.exit(2)`. The parent asserts exit code 2
+// AND the marker line — i.e. teardown ran before exit.
+//
+// Without the fix `activeClient` would be undefined when the watchdog
+// fires, the marker would NOT print, and the child would be orphaned.
+
+'use strict';
+
+const Module = require('node:module');
+const path = require('node:path');
+
+// The marker the parent test greps for. Printed from the stub
+// `client.close()` — its presence proves teardown ran before exit.
+const CLOSE_MARKER = 'HARNESS: client.close() invoked';
+
+// ---------------------------------------------------------------------
+// SDK stubs — never-resolving connect, recording close.
+// ---------------------------------------------------------------------
+
+class StubClient {
+  constructor() {
+    this._connected = false;
+  }
+  // The hang: connect returns a promise that NEVER settles, modelling a
+  // server that spawned but stalled mid-`initialize`.
+  connect() {
+    return new Promise(() => {});
+  }
+  // Records teardown — the load-bearing observation. Resolves cleanly so
+  // `closeQuietly` doesn't take its catch branch.
+  async close() {
+    process.stdout.write(CLOSE_MARKER + '\n');
+  }
+}
+
+class StubTransport {
+  constructor() {
+    // `connectServer` reads `transport.stderr?.on(...)`; null short-
+    // circuits the optional chain so no real pipe is wired.
+    this.stderr = null;
+  }
+}
+
+// ---------------------------------------------------------------------
+// Module._load override — intercept the three SDK specifiers.
+// ---------------------------------------------------------------------
+
+const SDK_STUBS = {
+  '@modelcontextprotocol/sdk/client/index.js': { Client: StubClient },
+  '@modelcontextprotocol/sdk/client/stdio.js': { StdioClientTransport: StubTransport },
+  '@modelcontextprotocol/sdk/types.js': {
+    // `_runner.cjs` imports ErrorCode / McpError at module load; the
+    // watchdog-hang path never touches them, but they must exist so the
+    // require doesn't throw. Minimal stand-ins.
+    ErrorCode: { MethodNotFound: -32601, InvalidParams: -32602, InternalError: -32603 },
+    McpError: class McpError extends Error {},
+  },
+};
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (Object.prototype.hasOwnProperty.call(SDK_STUBS, request)) {
+    return SDK_STUBS[request];
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+// ---------------------------------------------------------------------
+// Drive the real runner with the hang stub.
+// ---------------------------------------------------------------------
+
+const { runWithWatchdog } = require(path.join(__dirname, '_runner.cjs'));
+
+runWithWatchdog(
+  {
+    // Short watchdog so the test completes fast. The hang means connect
+    // never resolves, so this fire is the only exit path.
+    watchdogMs: 200,
+    transportSpec: { command: 'node', args: ['-e', '0'] },
+    clientName: 'mcp-conformance-watchdog-hang-harness',
+  },
+  // `body` is never reached — connect hangs before it runs. If it WERE
+  // reached the test would be meaningless, so mark that loudly.
+  async () => {
+    process.stdout.write('HARNESS: body reached (UNEXPECTED — connect should hang)\n');
+  },
+);

--- a/tools/mcp-conformance/test/runner-watchdog.test.cjs
+++ b/tools/mcp-conformance/test/runner-watchdog.test.cjs
@@ -1,0 +1,108 @@
+// Regression test for the `runWithWatchdog` connect-hang teardown
+// contract (rf2-2js41 finding 2).
+//
+// Uses Node's built-in `node:test` so the harness picks up no extra
+// dev-dependency (same posture as `exec-safety.test.cjs`). Runs quiet
+// on success.
+//
+// ## The bug this pins
+//
+// `runWithWatchdog` (in `_runner.cjs`) installs a watchdog `setTimeout`
+// whose timeout path tears the spawned MCP child down via
+// `closeQuietly(activeClient)` so a hung server can't be orphaned past
+// the runner's exit. The watchdog reads `activeClient` — a closure
+// handle.
+//
+// Pre-fix, `activeClient` was assigned only AFTER `connectServer`
+// RESOLVED, and `connectServer` resolves only after
+// `await client.connect(transport)` completes. So a server that spawns
+// and then HANGS during the `initialize` handshake (connect never
+// resolving, never throwing) left `activeClient` undefined when the
+// watchdog fired: the timeout path took its `else` branch and
+// `process.exit(2)`'d immediately WITHOUT calling `client.close()` /
+// tearing the transport down — orphaning exactly the child the watchdog
+// is meant to reap.
+//
+// The fix gives the watchdog a teardown handle the moment the client is
+// constructed (via `connectServer`'s `onClient` callback, fired BEFORE
+// the connect await). This test drives the real `runWithWatchdog`
+// through a hermetic child harness whose stubbed `client.connect()`
+// never resolves, and asserts:
+//
+//   1. the child exits with the watchdog's code 2 (the timeout fired —
+//      connect genuinely hung, so this is the only exit path), AND
+//   2. the stub `client.close()` ran BEFORE that exit (the harness
+//      prints a marker from `close()`; its presence proves the watchdog
+//      had a teardown handle and used it).
+//
+// Without the fix, (1) still holds (the watchdog still exits 2) but (2)
+// fails — the marker never prints because `activeClient` was undefined.
+// So the marker assertion is the load-bearing one.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const HARNESS = path.join(__dirname, 'runner-watchdog-hang-harness.cjs');
+const CLOSE_MARKER = 'HARNESS: client.close() invoked';
+const BODY_MARKER = 'HARNESS: body reached';
+
+test('watchdog tears the child down when connect hangs mid-initialize (rf2-2js41 finding 2)', () => {
+  // Spawn the hermetic harness in its own process — `runWithWatchdog`
+  // `process.exit`s, so it MUST run in a child. The harness stubs the
+  // SDK with a never-resolving `connect`, so the watchdog (200ms) is the
+  // only exit path.
+  const child = spawnSync(process.execPath, [HARNESS], {
+    cwd: path.resolve(__dirname, '..'),
+    encoding: 'utf8',
+    // Generous cap so a genuinely-orphaning regression (process kept
+    // alive by a wedged child / unresolved close) trips the timeout
+    // here rather than hanging CI.
+    timeout: 15000,
+    env: process.env,
+  });
+
+  const out = (child.stdout || '') + (child.stderr || '');
+
+  // The harness must not have been killed by our own spawn timeout — if
+  // it was, `signal` is set and `status` is null. That itself is a
+  // regression signal (the process never exited), so surface it.
+  assert.equal(
+    child.signal,
+    null,
+    'harness was killed by the test timeout (signal ' + child.signal +
+      ') — runWithWatchdog never exited, i.e. a hung connect kept the ' +
+      'process alive instead of the watchdog reaping it.\n--- output ---\n' + out,
+  );
+
+  // 1. The watchdog fired and exited with its canonical code 2.
+  assert.equal(
+    child.status,
+    2,
+    'connect-hang MUST exit via the watchdog with code 2; got ' +
+      child.status + '.\n--- output ---\n' + out,
+  );
+
+  // Sanity: the body must NOT have run (connect hung before it).
+  assert.ok(
+    !out.includes(BODY_MARKER),
+    'the runner body ran — connect did not hang, so this test is not ' +
+      'exercising the watchdog teardown path.\n--- output ---\n' + out,
+  );
+
+  // 2. THE load-bearing assertion: teardown ran before exit. The marker
+  // is printed only from the stub `client.close()`, which the watchdog
+  // path reaches only if it had a teardown handle (`activeClient` set
+  // before the connect await). This is the assertion that fails when the
+  // fix is reverted.
+  assert.ok(
+    out.includes(CLOSE_MARKER),
+    'the watchdog timeout path did NOT tear the spawned child down on a ' +
+      'connect-hang (the stub client.close() marker is absent). This is ' +
+      'the rf2-2js41 finding-2 orphan: activeClient was undefined when ' +
+      'the watchdog fired, so the child was abandoned.\n--- output ---\n' + out,
+  );
+});

--- a/tools/mcp-conformance/wire-vocab/deps.edn
+++ b/tools/mcp-conformance/wire-vocab/deps.edn
@@ -76,5 +76,26 @@
                        day8/de-dupe
                        {:git/url "https://github.com/day8/de-dupe.git"
                         :git/tag "v0.3.0"
-                        :git/sha "367de784faf13c710a895bed867f36a36e594a2a"}}
+                        :git/sha "367de784faf13c710a895bed867f36a36e594a2a"}
+                       ;; rf2-2js41 finding 1 — `:rf.mcp/cursor-stale` is
+                       ;; a MULTI-server reason value: pair-mcp emits it
+                       ;; on epoch-ring rotation, story-mcp emits the SAME
+                       ;; reason when a Docs `list-*` registry changes
+                       ;; between cursor pages. Both delegate to the
+                       ;; shared `mcp-base/cursor.cljc/cursor-stale-result`.
+                       ;; This dep puts story-mcp's own
+                       ;; `re-frame.story-mcp.tools.cursor/cursor-stale-result`
+                       ;; on the classpath so the gate can drive the
+                       ;; SECOND server's builder LIVE (mirroring the
+                       ;; pair-mcp + diff-encode + de-dupe live-emission
+                       ;; gates) — closing the false-green hole where a
+                       ;; story-mcp cursor-stale drift was caught only by
+                       ;; story-mcp's local unit tests, not by the
+                       ;; cross-MCP vocabulary surface. `:local/root` (not
+                       ;; an `:extra-paths` to story-mcp's `src`) is the
+                       ;; idiomatic, deprecation-warning-free form; the
+                       ;; transitive story/implementation tree it pulls is
+                       ;; the cost of validating the real builder.
+                       day8/re-frame2-story-mcp
+                       {:local/root "../../story-mcp"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -93,7 +93,11 @@
             [re-frame.mcp-base.diff-encode :as de]
             [re-frame.mcp-base.overflow :as mcp-overflow]
             [re-frame.mcp-base.vocab :as mcp-vocab]
-            [re-frame.mcp-conformance.fixtures :as fx]))
+            [re-frame.mcp-conformance.fixtures :as fx]
+            ;; rf2-2js41 finding 1 — story-mcp's cursor-stale builder, so
+            ;; the gate can drive the SECOND server's emission live and
+            ;; pin cursor-stale as a genuinely multi-server contract.
+            [re-frame.story-mcp.tools.cursor :as story-cursor]))
 
 ;; ---------------------------------------------------------------------------
 ;; Repo-root + slurp helpers live in `re-frame.mcp-conformance.fixtures`
@@ -446,9 +450,10 @@
 
 (def CursorStaleResult
   "Structured error-result envelope where `:reason :rf.mcp/cursor-stale`
-  signals the cursor's epoch-id is no longer in the runtime ring (per
-  `mcp-base/vocab.cljc/cursor-stale-reason` and re-frame2-pair-mcp
-  `tools/cursor.cljs/cursor-stale-result`).
+  signals a cursor no longer addresses a valid position. The canonical
+  `:reason` value + the cross-MCP envelope builder live in
+  `mcp-base/vocab.cljc/cursor-stale-reason` +
+  `mcp-base/cursor.cljc/cursor-stale-result`.
 
   Unlike the other markers in this file, `:rf.mcp/cursor-stale` is NOT
   a top-level wrapper — it rides as the `:reason` value on a generic
@@ -459,8 +464,29 @@
   slots (`:requested-id`, `:head-id`, `:tool`, `:hint`) are open
   per-server.
 
-  Single-server today (re-frame2-pair-mcp); the reason value is reserved
-  cross-MCP for any future pagination surface."
+  ## MULTI-server reason value (rf2-2js41 finding 1)
+
+  cursor-stale is emitted by BOTH MCP servers, for two distinct
+  staleness causes that share the same agent recovery vocabulary:
+
+  - re-frame2-pair-mcp — the cursor's epoch-id has rotated out of the
+    bounded epoch RING (`tools/cursor.cljs/cursor-stale-result`).
+  - story-mcp — the underlying registry's id-set CHANGED between
+    cursor-mint and cursor-deref, so the offset/total/sig cursor no
+    longer addresses the same page
+    (`tools/story-mcp/.../tools/cursor.cljc/cursor-stale-result`).
+
+  Both builders delegate to the shared
+  `mcp-base/cursor.cljc/cursor-stale-result`, which sources the
+  `:reason` from `vocab/cursor-stale-reason` — so an agent that learned
+  the drop-and-restart path on one server reuses it on the other. The
+  story-mcp builder wraps that data-map in story-mcp's MCP wire
+  envelope (`{:content … :isError true :structuredContent <this shape>}`)
+  — so it is the `:structuredContent` slot of story-mcp's emission that
+  this schema validates (see `story-cursor-stale-emitted-live-by-canonical-builder`
+  below). Previously documented as pair-only; promoted to a multi-server
+  reason-value contract once story-mcp shipped cursor pagination for the
+  Docs `list-*` tools."
   [:map
    {:closed false}
    [:ok?    [:enum false]]
@@ -1638,7 +1664,8 @@
                "(rf2-koq5m / rf2-c2wbp).")))))
 
 ;; ---------------------------------------------------------------------------
-;; `:rf.mcp/cursor-stale` reason-value gate (rf2-i3ffz F-GAP-5).
+;; `:rf.mcp/cursor-stale` MULTI-server reason-value gate
+;; (rf2-i3ffz F-GAP-5; promoted to multi-server by rf2-2js41 finding 1).
 ;;
 ;; Unlike the wrapper-shaped markers in `canonical-markers` above,
 ;; `:rf.mcp/cursor-stale` rides as the `:reason` value on a generic
@@ -1647,11 +1674,29 @@
 ;; itself: a rename or pluralisation would silently break every agent
 ;; that pattern-matches on it.
 ;;
-;; The pin shape mirrors the wrapper-marker pins above:
-;;   1. fixture validates against `CursorStaleResult` schema.
-;;   2. literal appears in re-frame2-pair-mcp's emit-source (mcp-base/vocab.cljc).
-;;   3. literal appears in re-frame2-pair-mcp's doc-sources (003-Tool-Catalogue.md).
-;;   4. no near-miss spelling co-exists in any conformance-tracked file.
+;; BOTH MCP servers emit this reason value (rf2-2js41 finding 1):
+;;   - re-frame2-pair-mcp — epoch-id rotated out of the bounded ring
+;;     (`tools/cursor.cljs/cursor-stale-result`).
+;;   - story-mcp — the Docs `list-*` registry id-set changed between
+;;     cursor-mint and cursor-deref
+;;     (`tools/story-mcp/.../tools/cursor.cljc/cursor-stale-result`).
+;; Both delegate to the shared `mcp-base/cursor.cljc/cursor-stale-result`,
+;; which sources `:reason` from `vocab/cursor-stale-reason` so the two
+;; emissions stay byte-identical on the reason keyword.
+;;
+;; The pin shape mirrors the wrapper-marker pins above, across BOTH
+;; servers:
+;;   1. authored fixtures validate against `CursorStaleResult` (one per
+;;      server emission shape).
+;;   2. LIVE-builder gates drive EACH server's `cursor-stale-result` and
+;;      validate the emission (pair-mcp's data-map directly; story-mcp's
+;;      `:structuredContent` slot).
+;;   3. literal appears in the shared emit-source (mcp-base/vocab.cljc)
+;;      AND in story-mcp's own cursor source (it documents/restarts on
+;;      the reason).
+;;   4. literal appears in re-frame2-pair-mcp's doc-sources (003-Tool-Catalogue.md).
+;;   5. no near-miss spelling co-exists in any conformance-tracked file
+;;      — now INCLUDING story-mcp's cursor source (added to the sweep).
 ;; ---------------------------------------------------------------------------
 
 (def ^:private cursor-stale-fixture
@@ -1666,10 +1711,31 @@
    :head-id      "epoch-9101"
    :hint         "Cursor's epoch-id is no longer in the runtime ring. Drop the cursor or widen the window."})
 
+(def ^:private story-cursor-stale-fixture
+  "Canonical story-mcp emission shape — the `:structuredContent` slot of
+  `re-frame.story-mcp.tools.cursor/cursor-stale-result` (per
+  `tools/story-mcp/.../tools/result.cljc/error-result`). story-mcp's
+  staleness cause is a registry id-set change between cursor pages, not
+  a ring rotation, but the cross-MCP `:reason` + `:ok? false` posture is
+  identical — that shared vocabulary IS the contract this fixture pins.
+  Authored here; the live-builder gate below proves the real story-mcp
+  builder actually emits it."
+  {:ok?    false
+   :reason :rf.mcp/cursor-stale
+   :tool   "list-stories"
+   :hint   "Drop :cursor and re-request from offset 0."})
+
 (deftest cursor-stale-fixture-conforms-to-schema
-  (is (m/validate CursorStaleResult cursor-stale-fixture)
-      (str "Fixture for :rf.mcp/cursor-stale failed schema validation:\n"
-           (me/humanize (m/explain CursorStaleResult cursor-stale-fixture)))))
+  ;; Both per-server emission-shape fixtures validate against the single
+  ;; canonical schema (rf2-2js41 finding 1 — cursor-stale is multi-server).
+  (testing "re-frame2-pair-mcp emission shape (ring rotation)"
+    (is (m/validate CursorStaleResult cursor-stale-fixture)
+        (str "pair-mcp fixture for :rf.mcp/cursor-stale failed schema validation:\n"
+             (me/humanize (m/explain CursorStaleResult cursor-stale-fixture)))))
+  (testing "story-mcp emission shape (registry change between pages)"
+    (is (m/validate CursorStaleResult story-cursor-stale-fixture)
+        (str "story-mcp fixture for :rf.mcp/cursor-stale failed schema validation:\n"
+             (me/humanize (m/explain CursorStaleResult story-cursor-stale-fixture))))))
 
 (deftest cursor-stale-rejects-non-error-envelopes
   ;; The reason value MUST ride a `:ok? false` envelope — emitting
@@ -1733,6 +1799,84 @@
       (is (= "epoch-9001" (:requested-id emitted)))
       (is (= "epoch-9101" (:head-id emitted))))))
 
+(deftest story-cursor-stale-emitted-live-by-canonical-builder
+  ;; SECOND-server LIVE-emission gate for `:rf.mcp/cursor-stale`
+  ;; (rf2-2js41 finding 1). The gate above drives pair-mcp's reason
+  ;; through the SHARED `mcp-base/cursor.cljc` builder; this one drives
+  ;; STORY-MCP's own `re-frame.story-mcp.tools.cursor/cursor-stale-result`
+  ;; — the builder for the Docs `list-*` pagination surface.
+  ;;
+  ;; The gap this closes: before this gate, story-mcp's cursor-stale
+  ;; emission was caught ONLY by story-mcp's local unit tests
+  ;; (`tools/story-mcp/test/...`). A drift in story-mcp's envelope shape
+  ;; or a decoupling of its `:reason` from the cross-MCP vocab constant
+  ;; would NOT trip the conformance surface that exists to enforce the
+  ;; SHARED agent vocabulary across servers. The cross-server contract
+  ;; was weaker than the (now multi-server) implementation.
+  ;;
+  ;; story-mcp's `cursor-stale-result` wraps the shared mcp-base builder
+  ;; in its MCP wire envelope via `result/error-result`, so the emission
+  ;; is `{:content [...] :isError true :structuredContent <data-map>}`.
+  ;; The cross-MCP reason-value contract lives on the `:structuredContent`
+  ;; slot — that is what we validate against canonical `CursorStaleResult`
+  ;; (the same schema pair-mcp's data-map validates against). Validating
+  ;; the structured slot, not the text blob, is the load-bearing pin: an
+  ;; agent host that reads JSON pattern-matches on `:reason` there.
+  (let [emitted    (story-cursor/cursor-stale-result "list-stories")
+        structured (:structuredContent emitted)]
+    (testing "story-mcp wraps the reason in an MCP error envelope"
+      (is (true? (:isError emitted))
+          "story-mcp cursor-stale rides an :isError true MCP result (per result/error-result)")
+      (is (some? structured)
+          "story-mcp cursor-stale MUST carry the structured data-map on :structuredContent"))
+    (testing "the structured content sources :reason from vocab/cursor-stale-reason"
+      (is (= mcp-vocab/cursor-stale-reason (:reason structured))
+          (str "story-mcp cursor-stale-result MUST emit the canonical "
+               ":reason value (vocab/cursor-stale-reason). If this fails, "
+               "story-mcp's builder drifted from the shared cross-MCP "
+               "constant agents pattern-match on. Got :reason = "
+               (pr-str (:reason structured)))))
+    (testing "the emitted :reason is the pinned cross-MCP keyword"
+      (is (= :rf.mcp/cursor-stale (:reason structured))
+          "the canonical reason keyword is :rf.mcp/cursor-stale"))
+    (testing "the structured content validates against canonical CursorStaleResult"
+      (is (m/validate CursorStaleResult structured)
+          (str "Live-emitted story-mcp cursor-stale :structuredContent failed "
+               "CursorStaleResult validation:\n"
+               (me/humanize (m/explain CursorStaleResult structured)))))
+    (testing "the builder preserves the :ok? false error posture"
+      (is (false? (:ok? structured))
+          "cursor-stale rides an :ok? false envelope — success never carries a stale-reason"))
+    (testing "the tool name threads through to the structured slot"
+      (is (= "list-stories" (:tool structured))))
+    (testing "pair-mcp + story-mcp emit the IDENTICAL cross-MCP reason value"
+      ;; The whole point of the multi-server contract: an agent learns
+      ;; the keyword once and reuses the recovery path on either server.
+      (let [pair-reason (:reason (mcp-cursor/cursor-stale-result
+                                   (fn [_m data] data) "watch-epochs" {}))]
+        (is (= pair-reason (:reason structured))
+            "the two servers MUST agree on the :rf.mcp/cursor-stale reason value")))))
+
+(def ^:private story-mcp-cursor-source
+  "story-mcp's cursor source — the builder for the Docs `list-*`
+  pagination surface (rf2-2js41 finding 1). It documents the cross-MCP
+  `:rf.mcp/cursor-stale` reason and routes through the shared
+  `mcp-base/cursor.cljc/cursor-stale-result` (sourcing `:reason` from
+  the vocab symbol, not the literal). Pinned in the cursor-stale source
+  sweep so a story-mcp-side vocabulary drift (a near-miss spelling, a
+  dropped reason) trips this cross-MCP gate, not only story-mcp's local
+  unit tests."
+  "tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc")
+
+(def ^:private cursor-stale-near-miss-source-files
+  "The full set of conformance-tracked source/spec files the cursor-stale
+  near-miss anti-pin sweeps (rf2-2js41 finding 1). The base
+  `all-source-files` covers the shared vocab declaration + pair-mcp
+  specs; cursor-stale ALSO rides story-mcp's own cursor source, so that
+  file is folded into story-mcp's sweep here. A near-miss spelling
+  introduced on EITHER server's cursor surface now trips the gate."
+  (update all-source-files :story-mcp (fnil conj []) story-mcp-cursor-source))
+
 (deftest cursor-stale-literal-in-re-frame2-pair-mcp-emit-source
   ;; The canonical declaration lives in mcp-base/vocab.cljc — same
   ;; emit-source as the wrapper markers. Stripped before grep so a
@@ -1758,13 +1902,32 @@
     (is (some (fn [rel] (str/includes? (fx/read-source rel) literal)) files)
         (str literal " missing from re-frame2-pair-mcp doc-sources " files))))
 
+(deftest cursor-stale-literal-in-story-mcp-cursor-source
+  ;; story-mcp source pin (rf2-2js41 finding 1). cursor-stale is a
+  ;; multi-server reason value; story-mcp's cursor source MUST reference
+  ;; the canonical `:rf.mcp/cursor-stale` literal (it documents the
+  ;; shared recovery vocabulary on the builder that routes through
+  ;; `mcp-base/cursor.cljc`). Looser raw `str/includes?` — story-mcp
+  ;; sources the reason from the vocab SYMBOL (not the literal as data),
+  ;; so the literal lives in the docstring; a drop here means story-mcp
+  ;; stopped documenting the cross-MCP reason it emits.
+  (let [literal ":rf.mcp/cursor-stale"]
+    (is (str/includes? (fx/read-source story-mcp-cursor-source) literal)
+        (str literal " missing from story-mcp cursor source "
+             story-mcp-cursor-source
+             ". story-mcp emits this cross-MCP reason via the shared "
+             "mcp-base builder; its cursor source must reference the "
+             "canonical literal."))))
+
 (deftest cursor-stale-no-near-miss-in-any-server-source
   ;; Defence-in-depth: a rename to a near-miss form (snake_case,
   ;; pluralised, predicate `?` suffix) MUST NOT co-exist anywhere in
   ;; the conformance-tracked source/spec tree. Mirrors the marker-key
-  ;; near-miss anti-pin above.
+  ;; near-miss anti-pin above. The sweep set is extended with story-mcp's
+  ;; cursor source (rf2-2js41 finding 1) so a near-miss introduced on the
+  ;; SECOND server's pagination surface trips here too.
   (doseq [variant (near-miss-variants :rf.mcp/cursor-stale)
-          [server files] all-source-files
+          [server files] cursor-stale-near-miss-source-files
           rel files]
     (testing (str server " — " rel " — near-miss " variant)
       (is (not (str/includes? (fx/read-source rel) variant))


### PR DESCRIPTION
Senior-review bead **rf2-2js41** (P2) — 2 findings in `tools/mcp-conformance`.

## Finding 1 — cursor-stale modelled a single server (pair-mcp) — FIXED

`:rf.mcp/cursor-stale` was documented and gated as pair-only ("Single-server today (re-frame2-pair-mcp)"), but story-mcp now emits the **same** cross-MCP reason via `re-frame.story-mcp.tools.cursor/cursor-stale-result` for the Docs `list-*` pagination tools. Both builders delegate to the shared `mcp-base/cursor.cljc/cursor-stale-result`, which sources `:reason` from `vocab/cursor-stale-reason`. The cross-server vocabulary contract was therefore **weaker than the implementation**: a story-mcp cursor-stale envelope/keyword drift was caught only by story-mcp's local unit tests, not by the cross-MCP conformance surface that exists to enforce shared agent vocabulary — a false-green hole.

Promoted to an explicitly **multi-server** reason-value contract:
- Added `day8/re-frame2-story-mcp {:local/root "../../story-mcp"}` to the wire-vocab `:test` deps so the gate can reach the second server's builder (idiomatic `:local/root`, not an external `:extra-paths` that trips the tools.deps deprecation warning).
- Added a story-mcp emission-shape **fixture** validated against the canonical `CursorStaleResult` schema.
- Added a **LIVE-builder gate** (`story-cursor-stale-emitted-live-by-canonical-builder`) that drives the real `story-cursor/cursor-stale-result`, validates its `:structuredContent` slot against `CursorStaleResult`, asserts `:reason` is sourced from `vocab/cursor-stale-reason`, the `:ok? false` posture, and that **both servers agree on the identical reason value**.
- Extended the cursor-stale **near-miss source sweep** to include story-mcp's cursor source, and added a positive source-mention pin for it.
- Rewrote the `CursorStaleResult` docstring + the section header so cursor-stale is documented as a multi-server reason-value contract, no longer pair-only.

## Finding 2 — watchdog orphans the child on a connect-hang — FIXED

`runWithWatchdog` (`test/_runner.cjs`) assigned its watchdog teardown handle (`activeClient`) only **after** `connectServer` resolved — i.e. after `await client.connect()` completed. A server that spawned and then **hung** during the `initialize` handshake (connect never resolving, never throwing — the connect try/catch only covers a connect that *throws*) left the watchdog with no client; the timeout path took its `else` branch and `process.exit(2)`'d **without** calling `client.close()` / tearing the spawned child's transport down — orphaning exactly the child the watchdog exists to reap.

- Gave `connectServer` an optional `onClient` callback fired the **moment the client is constructed**, before the connect await. `runWithWatchdog` captures `activeClient` through it, so a hang anywhere after spawn (including mid-handshake) is reachable by the watchdog.
- Added a hermetic `node:test` regression (`test/runner-watchdog.test.cjs` + `runner-watchdog-hang-harness.cjs`): a `Module._load` override stubs the SDK with a never-resolving `connect()` and a recording `close()`, drives the real `runWithWatchdog`, and asserts the timeout path invokes `close()` **before** exit (exit code 2). Verified it fails when the fix is reverted.
- Wired the new test into `scripts/test-all.cjs` (cheap-unit slot, next to exec-safety) and added a `test:runner-watchdog` npm script.

## Quality gates

- `npm run test:mcp-conformance` (full 6-gate suite) — **ALL GATES GREEN**:
  - [1/6] JVM story-mcp `clojure -M:test` — OK
  - [2/6] Node story-mcp stdio roundtrip — OK
  - [3/6] Node pair-mcp shadow-cljs `:server-test` — OK
  - [4+5/6] pair-mcp + story-mcp SDK-client conformance (`test-all.cjs`, incl. new **runner watchdog connect-hang teardown** test) — OK
  - [6/6] wire-vocab `clojure -M:test` — **57 tests, 687 assertions, 0 failures, 0 errors**
- Finding-2 regression independently verified: passes with the fix, FAILS when `onClient` wiring is reverted (orphan reproduced).
- Finding-1 live-builder gate independently verified: passes; FAILS when a deliberate `:tool` mismatch is injected (proves it observes the real story-mcp emission, not a no-op).

## Lane

Touched only `tools/mcp-conformance/**`. Read (did not modify) `tools/story-mcp/.../tools/cursor.cljc` to reference its builder. No mcp-base / story-mcp source changes.