### PR TITLE
fix(machines-viz): cache parsed topology so decoration-only renders skip the projector (rf2-jl72i)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -216,16 +216,19 @@ signature matches, and no further pass fires. Position-only
 `onNodesChange` events never reach the comparison (the signature keys on
 measured dimensions, not position), so xyflow applying the new ELK
 positions cannot re-trigger. A new layout-key (new `:definition` /
-`:direction` / `:layout-options`) clears the signature so the new
-topology gets its own single relayout.
+`:direction` / `:layout-options` / `:density`) clears the signature so
+the new topology gets its own single relayout.
 
 This second pass is keyed on the SAME `[:definition :direction
-:layout-options]` layout-key as the first — it does not introduce a new
-layout-invalidation trigger (it is the completion of the existing pass
-once real sizes are known), so the load-bearing
+:layout-options :density]` layout-key as the first — it does not
+introduce a new layout-invalidation trigger (it is the completion of the
+existing pass once real sizes are known), so the load-bearing
 [layout-invalidation boundary](#layout-invalidation-boundary-is-load-bearing)
 below is unchanged: a decoration-prop change still never reaches the
-relayout path.
+relayout path. (`:density` is a STRUCTURAL prop — it sizes ELK's
+container `elk.padding` from the active density's title-strip + body-pad
+constants, rf2-8q5pt — so it legitimately joins the layout-key; see the
+boundary section below.)
 
 ### Sub-flow nesting — `:parentId` (NOT `:parentNode`) (rf2-xh1lm)
 
@@ -1108,10 +1111,17 @@ prop groups:
 
 - **Topology / layout plane.** The node positions, edge routes, and
   compound-state nesting. Derived solely from the structural props
-  `:definition`, `:direction`, and `:layout-options` (the host pulls
-  `:definition` from `(rf/machine-meta machine-id)`). This plane is
-  **structural**: changing it requires re-laying out the graph via
-  elkjs.
+  `:definition`, `:direction`, `:layout-options`, and `:density` (the
+  host pulls `:definition` from `(rf/machine-meta machine-id)`;
+  `:density` sizes ELK container padding per rf2-8q5pt — see the
+  [layout-invalidation boundary](#layout-invalidation-boundary-is-load-bearing)).
+  This plane is **structural**: changing it requires re-laying out the
+  graph via elkjs. The parser that walks `:definition` into the
+  `{:nodes :edges}` graph (`layout/project-definition`) is itself a
+  topology-plane computation — implementations MUST cache its result
+  keyed ONLY on `:definition` (rf2-jl72i), so a decoration-only render
+  never re-walks the definition (see §Highlight / overlay prop changes
+  below).
 - **Runtime-highlight plane.** The active-state affordance (static
   tint + bolder stroke; pulse retired 2026-05-20 per rf2-2sez0), the
   focused-event lens tint, the `:after` countdown-ring overlay, the
@@ -1141,6 +1151,11 @@ descriptor `:tick` bump, a new / changed `:overlays` descriptor `:spec` /
 
 Such a render MUST NOT:
 
+- Re-parse / re-project the topology. The definition→graph parse
+  (`layout/project-definition`) MUST be cached keyed only on
+  `:definition` (rf2-jl72i); a decoration-prop change reuses the cached
+  parsed graph (and thus the downstream layout / projection caches keyed
+  on it), never re-walking the definition.
 - Re-run layout (no `elk`/`dagre`/custom layout call).
 - Re-measure topology nodes (no `getBBox`, no `getBoundingClientRect`
   in any code path reached by a decoration-prop change — overlay
@@ -1158,10 +1173,11 @@ on the chart's hot path.
 ### Layout-invalidation boundary is load-bearing
 
 `MachineChart` keys its elkjs layout pass on the
-`[:definition :direction :layout-options]` tuple (per `chart.cljs`): a
-new layout runs **only** when that tuple changes, and the previous
-positions are kept in-flight to avoid an empty-chart flash. The **only**
-triggers permitted to invalidate the topology / layout plane are:
+`[:definition :direction :layout-options :density]` tuple (per
+`chart.cljs`): a new layout runs **only** when that tuple changes, and
+the previous positions are kept in-flight to avoid an empty-chart flash.
+The **only** triggers permitted to invalidate the topology / layout
+plane are:
 
 1. **A new `:definition`.** A changed definition map — including a
    `reg-machine` hot-reload re-registration the host re-pulls via
@@ -1169,7 +1185,16 @@ triggers permitted to invalidate the topology / layout plane are:
 2. **A `:direction` change** (`:tb` ⇄ `:lr`).
 3. **A `:layout-options` change** — host-side elkjs `layoutOptions`
    overrides.
-4. **Container resize** of the chart's bounding box (xyflow's own
+4. **A `:density` change** (`:compact` ⇄ `:regular` ⇄ `:cosy`).
+   `:density` is **structural for layout**: the ELK pass sizes each
+   compound / region container's `elk.padding` from the active density's
+   title-strip + body-pad constants (rf2-8q5pt), so a density switch
+   changes the geometry ELK must lay out — not merely the painted size.
+   It therefore re-runs layout (and re-fits), unlike `:theme` — which is
+   purely a colour swap and stays decorative. Highlight / overlay props
+   likewise stay decorative; only `:density` among the visual knobs is
+   load-bearing for layout.
+5. **Container resize** of the chart's bounding box (xyflow's own
    fit/measure; the elk pass itself is keyed on the tuple above).
 
 No other code path may invalidate layout. In particular:
@@ -1190,8 +1215,8 @@ this section and DESIGN-RATIONALE Lock #9 and Lock #11.
 
 `MachineChart` MUST re-fit the xyflow viewport **once** after each
 successful elkjs layout settle whose layout-key (the
-`[:definition :direction :layout-options]` tuple above) differs from
-the last key that was fit. xyflow's `:fitView true` prop fires only
+`[:definition :direction :layout-options :density]` tuple above) differs
+from the last key that was fit. xyflow's `:fitView true` prop fires only
 on the initial mount, but mount happens BEFORE the async elk pass
 resolves — every node sits at the default `{x 0 y 0}` and the
 one-shot fitView would frame the operator on a degenerate cluster
@@ -1211,7 +1236,7 @@ The auto-fit MUST be gated:
 - The xyflow Controls' built-in `Fit` button remains the manual
   re-fit escape hatch.
 
-A layout invalidation (any of the four triggers above) implicitly
+A layout invalidation (any of the five triggers above) implicitly
 re-fits, by design — the topology shape has changed and the
 operator's prior framing is no longer meaningful.
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -497,6 +497,24 @@
   [^js instance ^js opts]
   (.fitView instance opts))
 
+(defn invoke-project-definition!
+  "rf2-jl72i — indirection over `(layout/project-definition definition)`,
+  the topology parser. Same test-seam shape as `invoke-elk-layout!` /
+  `invoke-fit-view!` above: the per-chart parse-cache regression rebinds
+  this via `set!` to SPY parser calls (counting how many renders actually
+  walk the definition) without re-stubbing the whole `layout` ns — the
+  rest of the suite calls `layout/project-definition` directly and must
+  keep seeing the real fn.
+
+  `MachineChart` routes its single topology projection through THIS seam,
+  behind the per-chart parsed-topology cache (keyed only on `:definition`),
+  so decoration-only re-renders (`:current-state` / `:from-highlight` /
+  `:to-highlight` / overlay `:tick` / `:fit-signal` / a parent re-render)
+  reuse the cached parse instead of re-walking the definition. No
+  production code outside `MachineChart` calls it."
+  [definition]
+  (layout/project-definition definition))
+
 (defn read-measured-dims
   "rf2-d9ro2 — read xyflow's measured node boxes off a captured
   ReactFlowInstance as a pure CLJS `{node-id {:width :height}}` map.
@@ -1002,6 +1020,42 @@
         ;; per-chart-instance and disposed with the component. The shape is
         ;; `{:key <input-vec> :js-nodes #js[…] :js-edges #js[…]}`.
         graph-cache   (atom nil)
+        ;; rf2-jl72i — per-chart parsed-topology cache.
+        ;;
+        ;; The topology parser (`layout/project-definition`, the e0emp
+        ;; rename of the former `parse-definition`) walks the WHOLE
+        ;; definition and rebuilds the `{:nodes :edges :initial-path}`
+        ;; graph. rf2-dnmbs gated the DOWNSTREAM `xyflow-graph` projection
+        ;; + `clj->js` marshalling behind `graph-cache`, but the parse
+        ;; itself still ran at the TOP of EVERY render — so a decoration-
+        ;; only re-render (`:current-state` / `:from-highlight` /
+        ;; `:to-highlight` change, an overlay `:tick`, a `:fit-signal`
+        ;; bump, a bare parent re-render) paid the full O(topology)
+        ;; parse + allocation cost despite the API (spec/API.md §Lock #11,
+        ;; §Performance invariants) marking the topology and runtime-
+        ;; highlight planes as STRICTLY separate: decoration props must
+        ;; not reach the layout/topology pipeline.
+        ;;
+        ;; This cache memoises the parse keyed ONLY on `:definition`
+        ;; (identity-or-value `=`). A render with the same `:definition`
+        ;; reuses the cached `parsed` map (so `graph-cache`, the layout-
+        ;; key tuple, and the relayout signature all see the SAME parsed
+        ;; identity — their own `=`-keys then short-circuit too); a NEW
+        ;; `:definition` reparses ONCE and replaces the entry, which in
+        ;; turn busts every downstream cache (their keys embed `parsed`).
+        ;; Density / direction / layout-options / theme / highlight
+        ;; changes never reparse — they don't change `:definition`.
+        ;; Closure-held in the Form-2 outer scope: per-chart-instance,
+        ;; disposed with the component. Shape `{:definition <d> :parsed <p>}`.
+        parse-cache   (atom nil)
+        parse-topology!
+        (fn [definition]
+          (let [cached @parse-cache]
+            (if (and cached (= (:definition cached) definition))
+              (:parsed cached)
+              (let [parsed (invoke-project-definition! definition)]
+                (reset! parse-cache {:definition definition :parsed parsed})
+                parsed))))
         project+convert!
         (fn [cache-key project-fn]
           ;; `project-fn` is a thunk that returns `{:nodes :edges}` (the
@@ -1040,7 +1094,14 @@
                  ;; values passes `:machine-data-inferred? false`.
                  machine-data-inferred? true
                  testid            "rf-mv-chart"}}]
-      (let [parsed     (layout/project-definition definition)
+      (let [;; rf2-jl72i — route the SINGLE topology parse through the
+            ;; per-chart parse-cache (keyed only on `:definition`). A
+            ;; decoration-only re-render reuses the cached `parsed`
+            ;; identity, so neither the parser nor the downstream
+            ;; graph/layout/relayout caches (whose keys embed `parsed`)
+            ;; recompute. A changed `:definition` reparses once here and
+            ;; busts every downstream cache.
+            parsed     (parse-topology! definition)
             ;; rf2-lkwev — exclude synthetic parallel-region container
             ;; nodes from the state count + aria-label (they are zone
             ;; chrome, not states).

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/parse_cache_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/parse_cache_cljs_test.cljs
@@ -1,0 +1,214 @@
+(ns day8.re-frame2-machines-viz.chart.parse-cache-cljs-test
+  "rf2-jl72i — per-chart parsed-topology cache regression.
+
+  ## What this pins
+
+  `MachineChart` is a Reagent Form-2 component: calling
+  `(chart/MachineChart props)` returns the inner render fn, which closes
+  over the per-chart state atoms — including the rf2-jl72i `parse-cache`.
+  Calling that render fn repeatedly with new prop maps simulates the
+  re-render sequence a host drives (a `:current-state` highlight change,
+  an overlay `:tick` bump, a `:fit-signal` bump, a bare parent re-render,
+  a `:density` switch, a NEW `:definition`).
+
+  The topology / runtime-highlight plane separation
+  (`spec/API.md` §Topology props and runtime-highlight props MUST be
+  strictly separate, §Highlight / overlay prop changes MUST change
+  attrs/classes only) requires that a DECORATION-ONLY render NOT walk the
+  definition through the parser (`layout/project-definition`, routed via
+  the `chart/invoke-project-definition!` seam) nor re-run the downstream
+  projection (`projection/xyflow-graph`) or layout (`compute-layout!`)
+  pipelines. Only a NEW `:definition` may reparse — exactly once — and it
+  busts the downstream caches. Density / direction / layout-options
+  changes relayout but MUST NOT reparse (the parse is keyed only on
+  `:definition`).
+
+  ## Why this is a `-cljs-test` (node), not a DOM test
+
+  Building the chart's hiccup tree is pure CLJS data — it does NOT render
+  React (`[:> ReactFlow …]` is a hiccup tag, not an invocation). The only
+  eager work the render body does is the topology parse (now cached) and
+  the rf2-dnmbs `project+convert!` thunk; both reach the framework only
+  through `set!`-able seams we stub here (same idiom as
+  `auto-fit-view-cljs-test`). So the cache contract is fully Node-runnable
+  without a real xyflow instance or DOM — it rides the always-on
+  `npm run test:cljs` gate."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-machines-viz.chart :as chart]
+            [day8.re-frame2-machines-viz.chart.projection :as projection]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(def ^:private machine-a
+  {:initial :idle
+   :states  {:idle    {:on {:start :loading}}
+             :loading {:on {:ok :done}}
+             :done    {:final? true}}})
+
+(def ^:private machine-b
+  {:initial :off
+   :states  {:off {:on {:flip :on}}
+             :on  {:on {:flip :off}}}})
+
+;; ---- spy harness --------------------------------------------------------
+
+(defn- with-seam-spies
+  "Run `(f counts)` with all four framework seams the parse-cache
+  regression cares about rebound via `set!` to count their invocations,
+  then restore the originals. `counts` is an atom holding
+  `{:parse N :project N :layout N :clj->js N}`.
+
+  - `chart/invoke-project-definition!` — the topology parser seam. Returns
+    a stub parsed graph (small, fixed shape) so the downstream `clj->js`
+    in `project+convert!` is trivial.
+  - `projection/xyflow-graph` — the parsed→xyflow projection. Returns an
+    empty `{:nodes [] :edges []}` so `clj->js` of the result is trivial.
+  - `chart/compute-layout!` — the elkjs layout pass. No-op (never call the
+    real async elk).
+  - `chart/invoke-fit-view!` — the `.fitView` seam. No-op.
+  - `goog.global` `clj->js`-adjacent: we count `clj->js` indirectly via the
+    project seam, since `project+convert!` only `clj->js`-es on a graph-
+    cache MISS (which a re-projection implies). A `:project` increment
+    therefore stands in for the `clj->js` cost the bead names."
+  [f]
+  (let [counts        (atom {:parse 0 :project 0 :layout 0})
+        orig-parse    chart/invoke-project-definition!
+        orig-project  projection/xyflow-graph
+        orig-layout   chart/compute-layout!
+        orig-fit      chart/invoke-fit-view!]
+    (set! chart/invoke-project-definition!
+          (fn [_definition]
+            (swap! counts update :parse inc)
+            ;; Minimal parsed shape the render body reads: a single leaf
+            ;; node + no edges. `:region?` / `:compound?` absent so the
+            ;; count + measurable-id derivations are total.
+            {:nodes [{:id "idle"}] :edges [] :initial-path [:idle]}))
+    (set! projection/xyflow-graph
+          (fn [_parsed _positions _opts]
+            (swap! counts update :project inc)
+            {:nodes [] :edges []}))
+    ;; `compute-layout!` is a fixed-MULTI-arity `defn`; the render calls
+    ;; the arity-7 form (`parsed direction layout-options machine-id
+    ;; measured-dims chart-vc done-fn`). shadow compiles that call to the
+    ;; direct `.cljs$core$IFn$_invoke$arity$7` dispatch, so the stub must
+    ;; itself be a MULTI-arity fn (a single fixed-arity `fn` exposes only
+    ;; the generic `call`, not `arity$7`). We mirror the real fn's arity
+    ;; shape and increment on whichever the render hits. No-op: the real
+    ;; elk pass never runs.
+    (set! chart/compute-layout!
+          (fn
+            ([_p _done] (swap! counts update :layout inc) nil)
+            ([_p _d _lo _done] (swap! counts update :layout inc) nil)
+            ([_p _d _lo _mid _done] (swap! counts update :layout inc) nil)
+            ([_p _d _lo _mid _md _done] (swap! counts update :layout inc) nil)
+            ([_p _d _lo _mid _md _cv _done]
+             (swap! counts update :layout inc) nil)))
+    (set! chart/invoke-fit-view!
+          (fn [& _args] nil))
+    (try
+      (f counts)
+      (finally
+        (set! chart/invoke-project-definition! orig-parse)
+        (set! projection/xyflow-graph orig-project)
+        (set! chart/compute-layout! orig-layout)
+        (set! chart/invoke-fit-view! orig-fit)))))
+
+(defn- render!
+  "Realise one render of the Form-2 render fn `rfn` with `props`. The
+  return value (a hiccup tree) is discarded — the test asserts on the
+  seam-call counts, which are the observable side effects."
+  [rfn props]
+  (rfn props)
+  nil)
+
+;; ---- tests --------------------------------------------------------------
+
+(deftest decoration-only-renders-do-not-reparse-or-reproject-or-relayout
+  (testing "rf2-jl72i — with the SAME `:definition`, a `:current-state` /
+            `:from-highlight` / `:to-highlight` change, an overlay `:tick`
+            bump, a `:fit-signal` bump, and a bare parent re-render MUST
+            NOT call the topology parser. They also MUST NOT re-run
+            layout. (A highlight change DOES legitimately re-project — it
+            re-tints nodes — but the parse, the O(topology) cost the bead
+            targets, must be reused.)"
+    (with-seam-spies
+      (fn [counts]
+        (let [rfn (chart/MachineChart {:machine-id :m :definition machine-a})]
+          ;; First render: one parse, one layout pass (new layout-key),
+          ;; one projection.
+          (render! rfn {:machine-id :m :definition machine-a})
+          (is (= 1 (:parse @counts)) "first render parses once")
+          (is (= 1 (:layout @counts)) "first render lays out once")
+          (let [after-mount (:project @counts)]
+            ;; --- decoration-only re-renders, SAME definition ---
+            (render! rfn {:machine-id :m :definition machine-a
+                          :current-state :loading})
+            (render! rfn {:machine-id :m :definition machine-a
+                          :current-state :loading
+                          :from-highlight :idle :to-highlight :loading})
+            (render! rfn {:machine-id :m :definition machine-a
+                          :overlays [{:id :ring :tick 1}]})
+            (render! rfn {:machine-id :m :definition machine-a
+                          :overlays [{:id :ring :tick 2}]})
+            (render! rfn {:machine-id :m :definition machine-a
+                          :fit-signal 7})
+            ;; A bare parent re-render (identical props).
+            (render! rfn {:machine-id :m :definition machine-a})
+            (is (= 1 (:parse @counts))
+                "NO decoration-only render re-walks the definition")
+            (is (= 1 (:layout @counts))
+                "NO decoration-only render re-runs ELK layout")
+            (is (>= (:project @counts) after-mount)
+                "highlight changes may re-project (decorative re-tint), but
+                 never reparse/relayout")))))))
+
+(deftest new-definition-reparses-once-and-busts-downstream-caches
+  (testing "rf2-jl72i — a CHANGED `:definition` calls the parser exactly
+            once for the new topology, re-runs layout (new layout-key), and
+            re-projects. Switching back to the original definition reparses
+            again (the cache holds the LAST definition only — a per-chart
+            single-slot memo keyed on the current definition)."
+    (with-seam-spies
+      (fn [counts]
+        (let [rfn (chart/MachineChart {:machine-id :m :definition machine-a})]
+          (render! rfn {:machine-id :m :definition machine-a})
+          (is (= 1 (:parse @counts)) "machine-a parses once")
+          (is (= 1 (:layout @counts)) "machine-a lays out once")
+          ;; Swap to a NEW definition.
+          (render! rfn {:machine-id :m :definition machine-b})
+          (is (= 2 (:parse @counts)) "a new definition reparses once")
+          (is (= 2 (:layout @counts)) "a new definition re-runs layout")
+          ;; Re-render machine-b unchanged → cache hit, no reparse/relayout.
+          (render! rfn {:machine-id :m :definition machine-b
+                        :current-state :on})
+          (is (= 2 (:parse @counts)) "unchanged definition does NOT reparse")
+          (is (= 2 (:layout @counts)) "unchanged definition does NOT relayout")
+          ;; Swap back to machine-a → reparse (single-slot cache).
+          (render! rfn {:machine-id :m :definition machine-a})
+          (is (= 3 (:parse @counts)) "swapping back reparses (single-slot memo)")
+          (is (= 3 (:layout @counts)) "swapping back re-runs layout"))))))
+
+(deftest density-direction-layout-options-changes-do-not-reparse
+  (testing "rf2-jl72i — density / direction / layout-options are layout
+            props (they re-run ELK), but they MUST NOT reparse: the parse
+            is keyed ONLY on `:definition`. This pins the parse-cache key
+            against a future regression that folds density/direction into
+            the parse key."
+    (with-seam-spies
+      (fn [counts]
+        (let [rfn (chart/MachineChart {:machine-id :m :definition machine-a})]
+          (render! rfn {:machine-id :m :definition machine-a})
+          (is (= 1 (:parse @counts)) "first render parses once")
+          (let [layouts-after-mount (:layout @counts)]
+            ;; --- density switch (structural for layout, rf2-8q5pt) ---
+            (render! rfn {:machine-id :m :definition machine-a :density :compact})
+            (render! rfn {:machine-id :m :definition machine-a :density :cosy})
+            ;; --- direction switch ---
+            (render! rfn {:machine-id :m :definition machine-a :direction :lr})
+            ;; --- layout-options change ---
+            (render! rfn {:machine-id :m :definition machine-a
+                          :layout-options {"elk.spacing.nodeNode" "80"}})
+            (is (= 1 (:parse @counts))
+                "density / direction / layout-options changes do NOT reparse")
+            (is (> (:layout @counts) layouts-after-mount)
+                "but they DO re-run layout (the layout-key includes them)")))))))


### PR DESCRIPTION
Closes the 2-finding senior review of `tools/machines-viz` (rf2-jl72i).

## Finding 1 — `MachineChart` reparsed topology on every decoration-only render (FIXED)

`chart.cljs` called `layout/project-definition` at the top of EVERY render — *before* the rf2-dnmbs `graph-cache` was consulted. That cache correctly skips `projection/xyflow-graph` + `clj->js` for tick / fit-signal / parent re-renders, but the **parse** stayed outside it, so `:current-state` / `:from-highlight` / `:to-highlight` / overlay `:tick` updates still paid the full O(topology) walk + allocation — violating the topology / runtime-highlight plane separation the API promises (Lock #11: decoration props must not reach the layout/topology pipeline).

**Fix:** a per-chart parsed-topology cache in the Form-2 outer scope (disposed with the component), keyed **only** on `:definition`. The render routes its single parse through `parse-topology!`; a decoration-only render reuses the cached `parsed` identity, which lets the downstream `graph-cache`, the layout-key tuple, and the relayout signature (all of which embed `parsed`) short-circuit too. A new `:definition` reparses **once** and busts every downstream cache. Density / direction / layout-options / theme changes never reparse — they don't change `:definition`. A `set!`-able `invoke-project-definition!` seam (mirroring `invoke-elk-layout!` / `invoke-fit-view!`) lets the regression spy parser calls without re-stubbing the whole `layout` ns.

## Finding 2 — API.md layout-key was stale around density (FIXED)

`spec/API.md` named the load-bearing layout key `[:definition :direction :layout-options]` in three places, but rf2-8q5pt made ELK container `elk.padding` density-dependent and added `:density` to the implementation's key. Reconciled all three sites (measure-then-relayout second-pass key, layout-invalidation boundary, auto-fit settle) to name `[:definition :direction :layout-options :density]`, added `:density` as a 4th permitted layout-invalidation trigger with the *why* (it sizes ELK container padding — structural — unlike decorative `:theme`), and updated the topology-plane definition + the decoration-plane MUST-NOT list to document the rf2-jl72i parse-cache contract.

## spec/API.md update

Per the standing rule (keep `tools/machines-viz/spec/*` current in the same PR):
- §Topology props … strictly separate — `:density` added to the structural-prop list; parse-cache (keyed only on `:definition`) documented as a topology-plane computation.
- §Highlight / overlay prop changes MUST change attrs/classes only — added "MUST NOT re-parse / re-project the topology" to the MUST-NOT list, citing the `:definition`-keyed parse cache.
- §measure-then-relayout — second-pass key now `[:definition :direction :layout-options :density]`; new-layout-key trigger list includes `:density`.
- §Layout-invalidation boundary — key updated to include `:density`; `:density` added as trigger #4 (structural for layout) with rationale; renumbered container-resize to #5.
- §Auto-fit on async layout settle — layout-key tuple updated; "any of the five triggers" (was four).

`scripts/check_doc_slugs.py` green (398 md files, no broken links) — the new `[layout-invalidation boundary](#…)` anchor resolves.

## Quality gates

| Gate | Result |
| --- | --- |
| `npm run test:cljs` (node-test, full cross-artefact corpus) | **5810 tests / 20580 assertions / 0 failures / 0 errors** |
| `tools/machines-viz` `clojure -M:test` (JVM .cljc corpus) | **401 tests / 1264 assertions / 0 failures / 0 errors** |
| `scripts/check_doc_slugs.py` | **green** (398 md, no broken links) |
| shadow `node-test` compile | **0 warnings** |
| Mutation check (bypass the cache → run suite) | the 3 new tests **FAIL** (4 assertions), confirming they gate the fix end-to-end |

## Regression test

New Node-runnable `parse_cache_cljs_test.cljs` drives the **real** Form-2 render fn (calling `(chart/MachineChart props)` returns the inner render fn that closes over the actual `parse-cache`) with the parse / projection / layout / fit seams stubbed + counted:
- `decoration-only-renders-…` — 6 decoration-only re-renders (highlight / overlay tick / fit-signal / bare parent) with the SAME `:definition` ⇒ parser called once, layout once.
- `new-definition-reparses-once-…` — a changed `:definition` reparses once + relayouts; unchanged re-render is a cache hit; swapping back reparses (single-slot memo).
- `density-direction-layout-options-changes-do-not-reparse` — density / direction / layout-options changes relayout but never reparse (pins the parse key against a future fold-into-key regression).