### PR TITLE
fix(examples/scripts): fail the play-script gate on zero discovered rows (non-vacuous) (rf2-54xbp)

### DIFF
--- a/examples/scripts/serve-and-run-story-play-scripts.cjs
+++ b/examples/scripts/serve-and-run-story-play-scripts.cjs
@@ -35,7 +35,13 @@
  *   :story.counter-play-script/failing            → expects :fail
  *
  * Exit code: 0 if every play matched its expected status; 1 if any
- * play deviated.
+ * play deviated, if an uncaught browser `pageerror` fired (rf2-wf5al),
+ * OR if play-script discovery was VACUOUS (rf2-54xbp) — zero / a
+ * near-empty / a one-sided (no expected-fail) row set fails closed,
+ * because the testbed seeds fixtures precisely to keep both the pass and
+ * the expected-fail paths under continuous coverage, so an empty gate is
+ * a discovery/registration/lowering drift signal, not "nothing to
+ * assert".
  */
 
 'use strict';
@@ -447,6 +453,120 @@ function computeExitCode({ failures, pageErrors }) {
   return unexpectedOutcomes === 0 && uncaughtErrors === 0 ? 0 : 1;
 }
 
+// rf2-54xbp: the non-vacuous floor for play-script discovery.
+//
+// The counter-with-stories testbed INTENTIONALLY seeds play-script
+// fixtures (stories.cljs §`:script` CI fixtures) so this gate keeps both
+// the pass path AND the expected-fail path of the runner contract under
+// continuous browser coverage. The seeded inventory is six variants /
+// eight play rows:
+//
+//   passing            (1 row,  pass)
+//   failing            (1 row,  fail)
+//   pred-fn-direct     (1 row,  pass)
+//   dom                (1 row,  pass)
+//   dom-expected-fail  (1 row,  fail)
+//   multi              (3 rows: 2 pass + 1 fail)
+//
+// `MIN_PLAY_ROWS` is a conservative floor (below the seeded eight) so an
+// authored fixture can be retired without tripping the gate, while a
+// discovery/registration/lowering DRIFT that strips the fixtures to a
+// near-empty set still fails loud. The pass/fail-coverage requirement is
+// the structural half of the invariant: a vacuous gate that exercises
+// only one side of the contract is still a trust hole.
+const MIN_PLAY_ROWS = 4;
+
+/**
+ * rf2-54xbp: NON-VACUOUS guard over the discovered play-script rows.
+ *
+ * The :play-script gate previously treated an EMPTY row set as success —
+ * `runAllVariants` logged "Nothing to assert" and returned 0. So if the
+ * Story CI hook, the `:script` → `:play-script` lowering, the testbed
+ * registration, or fixture discovery drifted to expose zero rows, the
+ * gate FALSE-GREENED while exercising NONE of the runner contract (and
+ * silently skipped the failure-report artifact upload, which only fires
+ * on a non-zero exit). The adjacent static gates already fail closed on a
+ * vacuous scan (see check-examples-assets.cjs's `indexes.length < 10`
+ * floor) — this brings the play-script gate in line.
+ *
+ * The invariant is deliberately stronger than `rows.length > 0`:
+ *
+ *   1. At least `MIN_PLAY_ROWS` discovered rows (the seeded fixtures
+ *      produce eight; a near-empty set is a drift signal, not success).
+ *   2. At least one EXPECTED-PASS row AND at least one EXPECTED-FAIL row,
+ *      so a drift that strips the expected-fail fixtures — leaving the
+ *      runner's failure path uncovered — also trips, even if the floor
+ *      is otherwise met.
+ *
+ * Pure (rows in → verdict out) so it is unit-testable without a browser:
+ * a simulated empty / under-floor / one-sided discovery must yield
+ * `{ ok: false }` with a clear diagnostic.
+ *
+ * @param {Array} rows discovered ci-rows (each `{ 'variant-id', 'play-key', ... }`)
+ * @param {{ minRows?: number }} [opts]
+ * @returns {{ ok: boolean, diagnostic: (string|null), rowCount: number,
+ *             passRows: number, failRows: number }}
+ */
+function checkRowsNonVacuous(rows, opts = {}) {
+  const minRows = opts.minRows == null ? MIN_PLAY_ROWS : opts.minRows;
+  const list = Array.isArray(rows) ? rows : [];
+  let passRows = 0;
+  let failRows = 0;
+  for (const row of list) {
+    const expected = expectedStatusFor(row['variant-id'], row['play-key']);
+    if (expected === 'fail') failRows += 1;
+    else passRows += 1;
+  }
+  const rowCount = list.length;
+
+  if (rowCount === 0) {
+    return {
+      ok: false,
+      rowCount,
+      passRows,
+      failRows,
+      diagnostic:
+        'No :play-script / :plays rows were discovered. The ' +
+        'counter-with-stories testbed seeds play-script fixtures on ' +
+        'purpose to keep this gate non-vacuous, so ZERO rows means the ' +
+        'Story CI hook (window.__rf2_story_ci), the :script -> :play-script ' +
+        'lowering, the testbed registration, or fixture discovery has ' +
+        'DRIFTED — not that there is nothing to assert. Refusing to ' +
+        'false-green an empty gate (rf2-54xbp).',
+    };
+  }
+  if (rowCount < minRows) {
+    return {
+      ok: false,
+      rowCount,
+      passRows,
+      failRows,
+      diagnostic:
+        `Only ${rowCount} :play-script / :plays row(s) discovered — below ` +
+        `the non-vacuous floor of ${minRows}. The counter-with-stories ` +
+        `testbed seeds eight rows across six variants; a near-empty set is ` +
+        `a discovery/registration/lowering drift signal, not success. ` +
+        `Refusing to pass a vacuous gate (rf2-54xbp).`,
+    };
+  }
+  if (passRows === 0 || failRows === 0) {
+    return {
+      ok: false,
+      rowCount,
+      passRows,
+      failRows,
+      diagnostic:
+        `Discovered ${rowCount} row(s) but expected-pass=${passRows} / ` +
+        `expected-fail=${failRows}: the gate must exercise BOTH the pass ` +
+        `path AND the expected-fail path of the runner contract. The ` +
+        `counter-with-stories testbed seeds both (e.g. .../passing and ` +
+        `.../failing); a one-sided discovery means the failure path is no ` +
+        `longer under coverage. Refusing to pass a one-sided gate (rf2-54xbp).`,
+    };
+  }
+  return { ok: true, rowCount, passRows, failRows, diagnostic: null };
+}
+
 /**
  * Group ci-rows by variant id so we navigate ONCE per variant and
  * then drive each row's play locally.
@@ -505,12 +625,18 @@ async function runAllVariants(browser, baseUrl) {
         );
       }
     }
-    if (rows.length === 0) {
-      // No fixtures with :play-script / :plays — exit clean. The npm gate
-      // is fail-loud only on UNEXPECTED outcomes; zero rows means no
-      // signal either way.
-      log('No :play-script / :plays rows registered. Nothing to assert.');
-      return 0;
+    // rf2-54xbp: NON-VACUOUS guard. A play-script gate that exercises
+    // zero rows (or a one-sided / near-empty set) is a trust hole — the
+    // testbed seeds fixtures precisely to keep both the pass and the
+    // expected-fail paths under continuous coverage, so a drift to no
+    // rows is a discovery/registration/lowering regression, NOT "nothing
+    // to assert". Fail closed with a clear diagnostic, mirroring the
+    // adjacent static gates' vacuous-scan guards.
+    const vacuity = checkRowsNonVacuous(rows);
+    if (!vacuity.ok) {
+      log('');
+      log(`Non-vacuous play-script guard FAILED: ${vacuity.diagnostic}`);
+      throw new Error(`vacuous play-script gate: ${vacuity.diagnostic}`);
     }
 
     const results = [];
@@ -691,4 +817,10 @@ module.exports = {
   expectedStatusFor,
   isTerminalStatus,
   computeExitCode,
+  // rf2-54xbp: the non-vacuous discovery guard + its floor, exported so
+  // the script-policy unit gate can simulate empty / under-floor /
+  // one-sided discovery and assert a fail-closed verdict without a
+  // browser (symmetric with the computeExitCode unit coverage).
+  checkRowsNonVacuous,
+  MIN_PLAY_ROWS,
 };


### PR DESCRIPTION
## What

Closes the false-green hole in the Story `:play-script` CI gate
(`examples/scripts/serve-and-run-story-play-scripts.cjs`).

Previously, when discovery returned zero `:play-script` / `:plays` rows,
`runAllVariants` logged `"Nothing to assert"` and returned exit **0**. So
if the Story CI hook (`window.__rf2_story_ci`), the `:script` →
`:play-script` lowering, the testbed registration, or fixture discovery
drifted to expose no rows, `npm run test:story-play-scripts`
**false-greened** while exercising NONE of the play-script runner
contract — and silently skipped the failure-report artifact upload (which
only fires on a non-zero exit). Same false-green class as the merged
rf2-wf5al (pageerror gate) and rf2-lbo79 (test-quiet zero-match).

## The fix

A **non-vacuous guard** — pure, exported `checkRowsNonVacuous(rows)` +
`MIN_PLAY_ROWS` — that fails closed, mirroring the adjacent static gates'
vacuous-scan guards (e.g. `check-examples-assets.cjs`'s `indexes.length < 10`
floor). The invariant is deliberately stronger than `rows.length > 0`:

1. **zero rows** → fail-closed (a drift signal, NOT "nothing to assert")
2. **below `MIN_PLAY_ROWS` (=4)** → fail-closed (a near-empty set is drift;
   the seeded inventory is eight rows, so the floor is conservative — an
   authored fixture can be retired without tripping the gate)
3. **one-sided discovery** (no expected-fail row) → fail-closed; otherwise a
   drift that strips the expected-fail fixtures would leave the runner's
   **failure path** uncovered while the floor was still met

The `counter-with-stories` testbed seeds these fixtures on purpose
(`stories.cljs` §`:script` CI fixtures) precisely to keep both the pass
path AND the expected-fail path under continuous browser coverage. The
guard runs after discovery in `runAllVariants` and throws on a vacuous
verdict → top-level `.catch` → `process.exit(1)` with the diagnostic in
the log.

The helper is pure (rows in → verdict out) and exported so a fast
script-policy unit test can pin it without a browser.

## Scope note

This worker's lane is `examples/scripts/**` only. The canonical home for
the rf2-wf5al-style policy unit test is
`implementation/scripts/_story-script-runners-policy.test.cjs` (a
different lane). The helper is already exported and proven below; wiring
the permanent unit cases into that policy test is filed as **rf2-ljyp9**.
The existing policy test still passes unchanged (additive exports).

## Quality gates

### Zero-row proof (the load-bearing assertion)

Exercising the exported pure helper directly — empty / under-floor /
one-sided all fail closed with clear diagnostics; the real seeded
inventory passes:

```
[zero rows]
  ok=false rowCount=0 pass=0 fail=0
  diag: No :play-script / :plays rows were discovered. ... fixture discovery has DRIFTED — not that there is nothing to assert. Refusing to false-green an empty gate (rf2-54xbp).
[under-floor (2 rows)]
  ok=false rowCount=2 pass=1 fail=1
  diag: Only 2 ... row(s) discovered — below the non-vacuous floor of 4. ... Refusing to pass a vacuous gate (rf2-54xbp).
[one-sided (no expected-fail)]
  ok=false rowCount=4 pass=4 fail=0
  diag: Discovered 4 row(s) but expected-pass=4 / expected-fail=0: the gate must exercise BOTH the pass path AND the expected-fail path ... Refusing to pass a one-sided gate (rf2-54xbp).
[seeded inventory (8 rows)]
  ok=true rowCount=8 pass=5 fail=3

MIN_PLAY_ROWS = 4
ALL NON-VACUOUS GUARD ASSERTIONS PASSED
```

Reproduce:
```
node -e 'const m=require("./examples/scripts/serve-and-run-story-play-scripts.cjs");
  console.log(m.checkRowsNonVacuous([]));          // ok:false (DRIFTED)
  console.log(m.checkRowsNonVacuous(undefined));   // ok:false
  console.log(m.MIN_PLAY_ROWS);                    // 4'
```

### Existing policy test (regression — additive exports don't break it)
`node implementation/scripts/_story-script-runners-policy.test.cjs`
→ `story-script-runners-policy tests: 11 passed.`

### Real browser gate still green with real rows
`npm run test:story-play-scripts` → exit 0;
`Ran 29 :play-script row(s). 0 unexpected outcomes.` (27 variants / 29 rows,
both pass and fail rows present — well above the floor, so the new guard is
a no-op on the healthy path).

### Not run / not relevant
- `test:examples-compile` — not relevant: this change is pure CI-runner JS;
  no CLJS / example HTML touched.
