### PR TITLE
test(security): deep-sentinel scan across all slots in MCP-egress tests + finding 2 (rf2-h2yvs)

### DIFF
--- a/implementation/security/test/re_frame/security/gen.cljc
+++ b/implementation/security/test/re_frame/security/gen.cljc
@@ -29,20 +29,54 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Seeded PRNG - a 32-bit LCG (numerical-recipes constants). Deterministic
-;; and identical across JVM + JS (we mask to 32 bits with bit-and so the
-;; arithmetic never depends on host integer width). State is an int.
+;; and IDENTICAL across JVM + JS.
+;;
+;; ## Why the multiply needs host-specific care (rf2-h2yvs finding 2)
+;;
+;; The LCG step is `s' = (s * 1103515245 + 12345) mod 2^32`. The constant
+;; `1103515245` is ~2^30, so for a 32-bit state `s` the product `s *
+;; 1103515245` is ~2^62 BEFORE the mod-2^32 truncation. On the JVM `s` is a
+;; `long` (64-bit) so `unchecked-multiply` holds the full product exactly and
+;; the subsequent `bit-and … mask32` truncates correctly. On CLJS, though,
+;; `unchecked-multiply` compiles to JS `*` on a double, which only has 53 bits
+;; of mantissa - a ~2^62 product loses its low bits, so `(s * 1103515245) &
+;; 0xFFFFFFFF` does NOT equal the true 32-bit product and the JS sequence
+;; diverges from the JVM sequence after the first step (verified: seed 1 /
+;; bound 100 gave JVM `54 24 56 95 …` vs the double path `54 25 12 28 …`).
+;;
+;; The portable primitive is `js/Math.imul`, which returns the low 32 bits of
+;; the integer product (signed) exactly. We then coerce to an UNSIGNED 32-bit
+;; state (`>>> 0` via `unsigned-bit-shift-right`) so both runtimes carry the
+;; same `0 <= state < 2^32` convention - matching what the JVM `bit-and …
+;; mask32` already yields (`mask32` is a long, so the JVM result is unsigned).
+;; The `next-int` hi-bit extraction (`(bit-shift-right s' 8) & 0x7FFFFF`) is
+;; sign-agnostic because the `& 0x7FFFFF` (23-bit) mask discards exactly the
+;; bits a signed vs unsigned shift would differ in, so it needs no change.
+;; State is an unsigned 32-bit integer on both hosts.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private mask32 0xFFFFFFFF)
 
+(def ^:private lcg-mult 1103515245)
+(def ^:private lcg-inc 12345)
+
 (defn make-rng
-  "Make a PRNG state from an integer seed."
+  "Make a PRNG state (unsigned 32-bit) from an integer seed."
   [seed]
-  (bit-and (int seed) mask32))
+  #?(:clj  (bit-and (long seed) mask32)
+     ;; `>>> 0` coerces to an unsigned 32-bit value, matching the JVM
+     ;; `bit-and … mask32` convention (`mask32` is a long there).
+     :cljs (unsigned-bit-shift-right (int seed) 0)))
 
 (defn- next-state
+  "Advance the LCG one step. Uses a portable 32-bit multiply: the JVM holds
+  the full ~2^62 product in a `long` then truncates; CLJS uses `Math.imul`
+  (exact low-32-bit product) then coerces to unsigned 32-bit. Both yield the
+  identical unsigned-32 state sequence (rf2-h2yvs finding 2)."
   [s]
-  (bit-and (unchecked-add (unchecked-multiply s 1103515245) 12345) mask32))
+  #?(:clj  (bit-and (unchecked-add (unchecked-multiply (long s) lcg-mult) lcg-inc)
+                    mask32)
+     :cljs (unsigned-bit-shift-right (+ (js/Math.imul s lcg-mult) lcg-inc) 0)))
 
 (defn next-int
   "Return `[n rng']` where `0 <= n < bound`. `bound` must be positive."

--- a/implementation/security/test/re_frame/security/gen_parity_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/gen_parity_security_cljs_test.cljc
@@ -1,0 +1,74 @@
+(ns re-frame.security.gen-parity-security-cljs-test
+  "Cross-runtime parity pin for the security-tier deterministic generator
+  (`re-frame.security.gen`) — rf2-h2yvs finding 2.
+
+  ## Why this exists
+
+  `gen.cljc` advertises a 32-bit LCG that is byte-deterministic AND identical
+  across JVM + JS: `for-all` reports a failing draw as `{:seed :index}`, and
+  the contract is that the SAME seed/index reproduces the SAME draw on either
+  host. That only holds if the LCG arithmetic agrees bit-for-bit across
+  runtimes.
+
+  Before rf2-h2yvs, `next-state` used `unchecked-multiply`, which on CLJS
+  compiles to JS `*` on a double. The LCG product `s * 1103515245` is ~2^62
+  for a 32-bit state, exceeding the 53-bit double mantissa, so the low bits
+  were lost and the JS sequence diverged from the JVM sequence after the first
+  step (seed 1 / bound 100: JVM `54 24 56 …` vs the double path `54 25 12 …`).
+  The fix routes the multiply through `js/Math.imul` (exact low-32 product) on
+  CLJS, keeps the full-precision `long` multiply on CLJ, and carries an
+  unsigned-32 state on both.
+
+  ## What this pins
+
+  The expected sequences below are the JVM reference (computed under
+  `:clj`). The test runs in BOTH runtimes; on CLJS it now reproduces these
+  exact values via `Math.imul`. A regression to the double-multiply path makes
+  the very first multi-step draw RED on CLJS. The test is named
+  `…-security-cljs-test` so it rides `npm run test:security` AND the always-on
+  `npm run test:cljs` node gate; as `.cljc` it also pins the contract for any
+  JVM run of the security tier."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [re-frame.security.gen :as gen]))
+
+(defn- draws
+  "Thread the PRNG from `seed`, drawing `n` ints in [0,bound)."
+  [seed bound n]
+  (loop [rng (gen/make-rng seed), i 0, acc []]
+    (if (< i n)
+      (let [[v rng'] (gen/next-int rng bound)]
+        (recur rng' (inc i) (conj acc v)))
+      acc)))
+
+(deftest next-int-sequence-is-cross-runtime-deterministic
+  (testing "the LCG reproduces the JVM reference draw sequence on this runtime
+            (rf2-h2yvs finding 2 — proves the Math.imul portable-multiply fix
+            keeps CLJS bit-identical to JVM)"
+    ;; Reference sequences computed under :clj with the portable next-state.
+    (is (= [54 24 56 95 79 28 42 38 60 29 94 96]
+           (draws 1 100 12))
+        "seed 1, bound 100 must match the JVM reference (was 54 25 12 … on the
+         pre-fix CLJS double-multiply path)")
+    (is (= [60 245 28 134 20 3 216 219 7 245 13 25]
+           (draws 23 256 12))
+        "seed 23, bound 256 must match the JVM reference")))
+
+(deftest sample-and-for-all-reproduce-from-seed
+  (testing "the documented `(seed, g, n)` reproducibility holds on this runtime"
+    (let [g (gen/gen-int 0 1000)]
+      ;; Same seed ⇒ same sample, and a different seed ⇒ a different sample
+      ;; (so the seed actually threads through the host-specific multiply).
+      (is (= (gen/sample g 20 7) (gen/sample g 20 7)))
+      (is (not= (gen/sample g 20 7) (gen/sample g 20 8))))
+    ;; `for-all`'s counter-example seed/index must reproduce the failing draw:
+    ;; assert "every drawn int < 5" over a [0,1000) generator; the first draw
+    ;; that is >= 5 is the counter-example, and re-drawing at that seed/index
+    ;; must yield the same value on either host.
+    (let [g    (gen/gen-int 0 1000)
+          {:keys [fail index seed]} (gen/for-all g 50 99 (fn [n] (< n 5)))]
+      (is (some? fail) "a [0,1000) draw should exceed 5 within 50 draws")
+      (is (= 99 seed))
+      ;; Re-draw `index+1` values from the same seed; the last equals `fail`.
+      (is (= fail (last (gen/sample g (inc index) seed)))
+          "the reported seed/index must reproduce the failing draw exactly"))))

--- a/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
@@ -47,10 +47,36 @@
   (see PR Quality gates)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
+            [clojure.walk :as walk]
             [re-frame.mcp-base.sensitive :as sens]
             [re-frame.security.gen :as gen]))
 
 (def ^:private sentinel "S3CR3T-rf2-3cfvt-EGRESS-DO-NOT-SHIP")
+
+(defn- contains-sentinel?
+  "Deep-walk `x`; true when the sentinel string appears ANYWHERE — as a
+  value, inside a collection, in a secondary slot (`:tags :received`), or
+  inside a stringified form. Mirrors the deep-scan helper the sibling
+  security namespaces (error-slot / http-body egress) use.
+
+  Why a deep scan and not just `:tags :value` + `sensitive-event?`
+  (rf2-h2yvs finding 1): the gate-OFF contract is \"the sentinel never
+  survives,\" not merely \"no survivor is still classified sensitive in its
+  primary slot.\" The generated sensitive event also plants the sentinel in
+  `:tags :received`; a survivor with its `:sensitive?` stamp stripped (so it
+  no longer classifies sensitive) and the sentinel only in `:received` would
+  slip past the narrow checks while this property stayed green. A deep scan
+  catches that secondary-slot leak class."
+  [x]
+  (let [hit (volatile! false)]
+    (walk/postwalk
+      (fn [node]
+        (when (and (string? node) (= sentinel node))
+          (vreset! hit true))
+        node)
+      x)
+    (or @hit
+        (boolean (re-find (re-pattern sentinel) (pr-str x))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Event generators.
@@ -114,13 +140,45 @@
                    (fn [events]
                      (sens/reset-malformed-count!)
                      (let [[kept _dropped] (sens/strip-sensitive events false)]
-                       ;; No surviving event may carry the sentinel, and no
-                       ;; survivor may itself be classified sensitive.
-                       (and (not-any? #(= sentinel (-> % :tags :value)) kept)
+                       ;; Deep-scan EVERY kept event for the sentinel in ANY
+                       ;; slot (`:tags :value` AND the secondary `:tags
+                       ;; :received` slot) — the contract is "the sentinel
+                       ;; never survives," not "no primary-slot survivor is
+                       ;; still classified sensitive" (rf2-h2yvs finding 1).
+                       ;; The `not-any? sensitive-event?` check is retained as
+                       ;; the complementary classification assertion.
+                       (and (not-any? contains-sentinel? kept)
                             (not-any? sens/sensitive-event? kept)))))]
       (is (nil? result)
           (str "a sensitive event survived the gate-OFF egress: "
                (pr-str (when result (dissoc result :threw))))))))
+
+(deftest deep-scan-catches-secondary-slot-sentinel-survivor
+  (testing "rf2-h2yvs finding 1 (non-vacuity) — a SURVIVING non-sensitive
+            event that nonetheless carries the sentinel in the SECONDARY
+            `:tags :received` slot is caught by the deep `contains-sentinel?`
+            scan, even though it is NOT classified sensitive and has no
+            sentinel in `:tags :value`. This is the leak class the prior
+            (`:tags :value` + `sensitive-event?`) assertion missed; the
+            negative fixture proves the hardened assertion is non-vacuous."
+    ;; Construct the exact survivor: no :sensitive? stamp (so strip-sensitive
+    ;; KEEPS it), sentinel ONLY in :tags :received (not :value).
+    (let [survivor       {:operation :sub/recompute
+                          :tags {:value "public-data"
+                                 :received [sentinel]}}
+          [kept dropped] (sens/strip-sensitive [survivor] false)]
+      ;; The gate keeps it (it is not classified sensitive) ...
+      (is (= [survivor] kept))
+      (is (zero? dropped))
+      ;; ... so the OLD narrow checks would BOTH read clean (vacuous green):
+      (is (not-any? #(= sentinel (-> % :tags :value)) kept)
+          "old `:tags :value` check is blind to the :received slot")
+      (is (not-any? sens/sensitive-event? kept)
+          "old classification check is blind: the survivor is non-sensitive")
+      ;; ... but the NEW deep scan catches the secondary-slot leak:
+      (is (some contains-sentinel? kept)
+          "the deep scan MUST catch the sentinel hiding in :tags :received")
+      (is (contains-sentinel? survivor)))))
 
 (deftest gate-off-malformed-stamp-counts-as-dropped
   (testing "rf2-ih7g4 fail-closed - a malformed truthy stamp is dropped AND
@@ -183,12 +241,23 @@
           [acc rng])))))
 
 (defn- snapshot-leaks-sentinel?
-  "True when any frame's scrubbed :traces / :epochs slice still carries a
-  sensitive event (the sentinel)."
+  "True when any frame's scrubbed :traces / :epochs slice still carries the
+  sentinel ANYWHERE (deep scan), or still carries an event classified
+  sensitive. Deep-scans ONLY the `:traces` / `:epochs` slices — `:app-db` is
+  left alone by design (read-time scrubbing is trace/epoch-only), so a deep
+  scan of the whole frame map would over-reach into the deliberately-kept
+  app-db.
+
+  rf2-h2yvs finding 1: the prior helper only re-ran `sensitive-event?` over
+  the slices, so a survivor whose `:sensitive?` stamp was stripped but whose
+  `:tags :received` still carried the sentinel would read as clean. The deep
+  `contains-sentinel?` scan closes that secondary-slot gap."
   [scrubbed]
   (some (fn [[_frame fm]]
           (when (map? fm)
-            (some sens/sensitive-event? (concat (:traces fm) (:epochs fm)))))
+            (let [slices (concat (:traces fm) (:epochs fm))]
+              (or (some contains-sentinel? slices)
+                  (some sens/sensitive-event? slices)))))
         scrubbed))
 
 (deftest gate-off-scrub-snapshot-leaves-no-sensitive-event
@@ -209,6 +278,34 @@
       (is (nil? result)
           (str "scrub-snapshot left a sensitive event in a frame slice: "
                (pr-str (when result (dissoc result :threw))))))))
+
+(deftest snapshot-deep-scan-catches-secondary-slot-survivor
+  (testing "rf2-h2yvs finding 1 (non-vacuity, snapshot path) — a frame whose
+            scrubbed `:traces` carries a NON-sensitive event with the sentinel
+            in `:tags :received` is flagged by the hardened
+            `snapshot-leaks-sentinel?` deep scan, while `:app-db` (which carries
+            no sentinel) is left alone by design."
+    (let [survivor   {:operation :sub/recompute
+                      :tags {:value "public-data" :received [sentinel]}}
+          ;; Model a post-scrub snapshot where a secondary-slot survivor
+          ;; remained in a frame slice (the leak class the old check missed).
+          leaked     {:frame-0 {:traces [survivor]
+                                :epochs []
+                                :app-db {:public "kept"}}}
+          clean      {:frame-0 {:traces [{:operation :fx/run
+                                          :tags {:value "public-data"}}]
+                                :epochs []
+                                :app-db {:public "kept"}}}]
+      ;; The old check (sensitive-event? over the slices) is blind here —
+      ;; the survivor is non-sensitive — so it would read this as clean.
+      (is (not (some sens/sensitive-event? (-> leaked :frame-0 :traces)))
+          "old classification check is blind: the survivor is non-sensitive")
+      ;; The hardened deep scan flags the secondary-slot leak ...
+      (is (snapshot-leaks-sentinel? leaked)
+          "deep scan MUST flag the sentinel hiding in a frame's :tags :received")
+      ;; ... and does NOT false-positive on a genuinely clean snapshot.
+      (is (not (snapshot-leaks-sentinel? clean))
+          "deep scan must not flag a sentinel-free snapshot"))))
 
 ;; ---------------------------------------------------------------------------
 ;; HOSTILE CORPUS - the named fail-closed stamp variants, pinned.


### PR DESCRIPTION
Closes rf2-h2yvs — senior review of `implementation/security` (2 findings). Test-hardening tier; the implementations (`re-frame.mcp-base.sensitive` filter + the LCG) were not the leak — these strengthen the regression net at the AI/MCP boundary.

## Finding 1 — MCP-egress test could false-green on secondary-slot leaks (FIXED)

`gate-off-strips-every-sensitive-event` asserted no sentinel survives, but only checked `:tags :value` + `sens/sensitive-event?`. The generated sensitive event also plants the sentinel in `:tags :received`, so a survivor with its `:sensitive?` stamp removed (no longer classified sensitive) carrying the sentinel only in `:received` would slip through while the property stayed green. Same shape in `snapshot-leaks-sentinel?` (it only re-ran `sensitive-event?` over scrubbed slices).

- Added a deep `contains-sentinel?` walk helper (mirrors the sibling `error-slot` / `http-body` security namespaces).
- `gate-off-strips-every-sensitive-event` now asserts `not-any? contains-sentinel?` over kept output (deep scan, any slot), retaining the `not-any? sensitive-event?` classification check as complement.
- `snapshot-leaks-sentinel?` now deep-scans the scrubbed `:traces`/`:epochs` slices for the sentinel; `:app-db` left alone by design.
- Two new negative fixtures (`deep-scan-catches-secondary-slot-sentinel-survivor`, `snapshot-deep-scan-catches-secondary-slot-survivor`) construct a surviving NON-sensitive event carrying the sentinel in `:received` and assert the old narrow checks read clean while the new deep scan flags it — proving non-vacuity.

## Finding 2 — security-tier generator was not cross-runtime deterministic (FIXED)

`gen/next-state` used `unchecked-multiply`. On CLJS that compiles to JS `*` on a double; the ~2^62 LCG product (`s * 1103515245` for a 32-bit `s`) exceeds the 53-bit mantissa, so the low bits are lost and the CLJS sequence diverges from JVM after the first step. Verified empirically: seed 1 / bound 100 gave JVM `54 24 56 95 …` vs the double path `54 25 13 17 …` (the bead's `54, 25` observation). This breaks the helper's advertised `{:seed :index}` reproducibility — a node-gate counter-example would not reproduce on JVM.

- `next-state` now uses `js/Math.imul` (exact low-32 product) on CLJS with an unsigned-32 coerce (`>>> 0`), and the full-precision `long` multiply on CLJ. State is unsigned-32 on both. `next-int`'s hi-bit extraction is sign-agnostic (the `& 0x7FFFFF` mask discards exactly the bits a signed vs unsigned shift differs in), so it is unchanged. `make-rng` coerces to the same unsigned-32 convention.
- New CLJC parity test `gen-parity-security-cljs-test` pins the JVM reference draw sequences (`54 24 56 95 …`, `60 245 28 134 …`) and the seed/index reproducibility contract; runs in both runtimes and rides `test:security` + `test:cljs`.

## Quality gates

- `cd implementation && npm run test:security` — **56 tests / 452 assertions, 0 failures, 0 errors** (was 52 / 436 on the baseline; +4 deftests, +16 assertions).
- `cd implementation && npm run test:cljs` (the security tier rides this gate) — **5813 tests / 20582 assertions, 0 failures, 0 errors**.

### Verify-by-injection (finding 1 — non-vacuity proof)

Temporarily injecting the secondary-slot survivor into the survivor generator (`gen-clean-event` planting `:received [sentinel]`, no `:sensitive?` stamp) turned **BOTH** hardened properties RED:

```
FAIL in (gate-off-strips-every-sensitive-event) … a sensitive event survived the gate-OFF egress:
  {:fail [{:operation :event/run-start, :tags {:k "public-data", :received ["S3CR3T-…"]}} …], :index 0, :seed 23}
FAIL in (gate-off-scrub-snapshot-leaves-no-sensitive-event) … scrub-snapshot left a sensitive event in a frame slice: …
Ran 56 tests containing 452 assertions. 2 failures, 0 errors.
```

The counter-example is a KEPT event (no `:sensitive?` stamp, sentinel only in `:tags :received`) — exactly the class the pre-fix `:tags :value` + `sensitive-event?` checks were blind to. Injection reverted after the proof.

### Verify-by-revert (finding 2 — divergence proof)

Temporarily restoring the CLJS double-multiply turned the parity test RED:

```
expected: (= [54 24 56 95 79 28 42 38 60 29 94 96] (draws 1 100 12))
  actual: (not (= [54 24 56 95 …] [54 25 13 17 57 49 …]))   ;; CLJS double-path diverges from JVM
Ran 56 tests containing 452 assertions. 2 failures, 0 errors.
```

Revert reverted after the proof.

## Per-finding disposition

| Finding | Verdict | Disposition |
| --- | --- | --- |
| 1 — MCP-egress false-green on secondary-slot leaks | Valid (test-hardening) | Fixed: deep `contains-sentinel?` scan over kept events + scrubbed snapshot slices; 2 negative fixtures prove non-vacuity |
| 2 — LCG not cross-runtime deterministic | Valid (verified `unchecked-multiply` → JS double divergence) | Fixed: `Math.imul` portable 32-bit multiply on CLJS + full-precision long on CLJ; CLJC parity test pins both runtimes |

Lane: `implementation/security/**` only. Do not merge.
