### PR TITLE
fix(machines): reject ALL parallel-root :on-done target forms loudly (was silent stall) (rf2-6srk5)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -4,16 +4,19 @@
 
   `apply-transition-once` emits `[:rf.machine/spawn args]` into the fx
   vector whenever entry cascades cross a `:spawn`-bearing state. Per
-  Spec 005 §Spawning, the spawned actor is itself an event handler
-  whose id is the actor address; `spawn-fx` registers the live handler
-  under the spawned id and seeds its initial snapshot at
-  `[:rf/runtime :machines :snapshots <id>]`.
-
-  The two-tier registry described in Spec 005 (frame-local handlers
-  that revert with the frame's snapshot) is not yet built — for v1 the
-  registration goes through the global registrar via
-  `events/reg-event-fx`. Frame isolation is preserved by the snapshot
-  living at `[:rf/runtime :machines :snapshots <id>]` inside the spawning frame's app-db.
+  Spec 005 §Spawning + rf2-a2sn1, a spawned actor's liveness is
+  APP-DB-ONLY: `spawn-fx` seeds the actor's initial snapshot at
+  `[:rf/runtime :machines :snapshots <spawned-id>]` in the spawning
+  frame's app-db, stamping the revertible TYPE reference at
+  `:rf/machine-type`. There is NO per-instance event-handler
+  registration — the actor's liveness IS that snapshot's presence in the
+  (revertible) frame value, and the snapshot's `:rf/machine-type` lets
+  the lazy resolver (`lifecycle-fx.resolver`) re-materialise the actor's
+  handler on dispatch. Spawn is therefore a pure app-db write; destroy
+  removes only app-db, so `restore-epoch` (app-db-only) reverts an
+  actor's liveness perfectly with zero registrar drift (the Goal-2
+  revertibility invariant). Frame isolation follows from the snapshot
+  living inside the spawning frame's app-db.
 
   Per rf2-6vmw `spawn-all-init-fx` also lives here — the runtime
   emits `[:rf.machine/spawn-all-init args]` alongside per-child

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -215,11 +215,15 @@
       state-tree declares `:type :parallel`; nested parallel regions
       aren't supported in v1.
     - `:rf.error/machine-parallel-on-done-target` — the parallel root's
-      `:on-done` declares an in-machine `:target` (rf2-bnjb3). A root-only
-      `:type :parallel` machine has no sibling flat state to land a target
-      on; the parallel `:on-done` runs its `:action` + emits `:fx` (the
-      \"then continue\" is a dispatch/raise in that fx), never an in-machine
-      transition target.
+      `:on-done` declares an in-machine `:target` in ANY value form
+      (rf2-bnjb3 / rf2-6srk5): a bare-keyword target, a vector-path target,
+      a map with `:target`, or a candidate vector containing a target map.
+      A root-only `:type :parallel` machine has no sibling flat state to
+      land a target on; the parallel `:on-done` runs its `:action` + emits
+      `:fx` (the \"then continue\" is a dispatch/raise in that fx), never an
+      in-machine transition target. (Before rf2-6srk5 only the map / vector-
+      of-maps forms were rejected, so bare-keyword and vector-path targets
+      slipped through to a silent runtime stall.)
     - `:rf.error/machine-parallel-root-on-bad-target` — a root parallel `:on`
       transition's `:target` is NOT region-qualified (rf2-tsq6g). The root
       `:on` is the ancestor fallback; a `:target` must name one or more
@@ -252,22 +256,47 @@
                     "event the root :on (or a sibling region) handles. Per "
                     "Spec 005 §Transition broadcast §Root parallel :on.")
                {:after (:after machine)})))
-    ;; Per rf2-bnjb3: the parallel root's `:on-done` must not carry an
-    ;; in-machine `:target` (root-only parallel has no flat sibling to land
-    ;; on). Normalise the candidate(s) and reject any that declare `:target`.
-    (when-let [on-done (:on-done machine)]
-      (let [cands (cond
-                    (map? on-done)    [on-done]
-                    (vector? on-done) (filterv map? on-done)
-                    :else             [])]
+    ;; Per rf2-bnjb3 / rf2-6srk5: the parallel root's `:on-done` must not carry
+    ;; an in-machine `:target` in ANY form (root-only parallel has no flat
+    ;; sibling to land on). Normalise EVERY value-form `:on-done` admits —
+    ;; mirroring `transition/normalise-candidates` (the runtime grammar the
+    ;; parallel-root `apply-on-done-action` resolves through) — to its
+    ;; candidate map(s), then reject if any candidate declares `:target`.
+    ;;
+    ;; The pre-rf2-6srk5 check only normalised the MAP and vector-of-maps forms,
+    ;; so a bare-keyword target (`:on-done :next`) and a vector-path target
+    ;; (`:on-done [:next]`) slipped past validation, then normalised at runtime
+    ;; to a `:target`-only / action-less candidate that `apply-on-done-action`
+    ;; selected, ran no action for, marked the done signal handled (suppressing
+    ;; auto-destroy), and moved nowhere — a SILENT STALL in the all-final
+    ;; configuration. Per the loud-failure posture, every target-bearing form
+    ;; must be rejected loudly at registration. Action / fx-only `:on-done`
+    ;; (no `:target`) stays accepted.
+    (when (contains? machine :on-done)
+      (let [on-done (:on-done machine)
+            ;; Mirror transition/normalise-candidates: keyword → {:target kw};
+            ;; vector-of-maps → as-is; any other vector → {:target vec};
+            ;; map → [map]; nil/other → no target-bearing candidate.
+            cands   (cond
+                      (keyword? on-done) [{:target on-done}]
+                      (and (vector? on-done)
+                           (seq on-done)
+                           (every? map? on-done)) on-done
+                      (vector? on-done)  [{:target on-done}]
+                      (map? on-done)     [on-done]
+                      :else              [])]
         (when (some #(contains? % :target) cands)
           (throw (validation-error
                    :rf.error/machine-parallel-on-done-target
                    (str "a parallel root's :on-done cannot declare an in-machine "
-                        ":target — a :type :parallel machine is root-only (no "
-                        "sibling flat state). Express \"then continue\" as an "
-                        ":action / :fx (e.g. a dispatch to a coordinator). Per "
-                        "Spec 005 §Final states §The done-state signal.")
+                        ":target (a bare-keyword target, a vector-path target, a "
+                        "map with :target, or a candidate vector containing one) "
+                        "— a :type :parallel machine is root-only (no sibling "
+                        "flat state to land a target on; an accepted target "
+                        "would silently STALL in the all-final configuration). "
+                        "Express \"then continue\" as an :action / :fx (e.g. a "
+                        "dispatch to a coordinator). Per Spec 005 §Final states "
+                        "§The done-state signal.")
                    {:on-done on-done})))))
     ;; Per rf2-tsq6g: every root parallel `:on` transition's `:target` (if
     ;; present) MUST be region-qualified — the root ancestor fallback has no

--- a/implementation/machines/test/re_frame/done_signal_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/done_signal_cljs_test.cljc
@@ -352,6 +352,64 @@
              :on-done {:target :somewhere}
              :regions {:a {:initial :run :states {:run {} }}}})))))
 
+;; rf2-6srk5 — EVERY target-bearing :on-done value-form must be rejected
+;; LOUDLY at registration (not just the map form). Before the fix, a bare-
+;; keyword target and a vector-path target slipped past validation and then
+;; SILENTLY STALLED at runtime: apply-on-done-action normalised them to a
+;; target-only / action-less candidate, ran no action, marked the parallel
+;; done-signal handled (suppressing auto-destroy), and moved nowhere.
+(deftest parallel-on-done-bare-keyword-target-rejected
+  (testing "rf2-6srk5: a parallel root's :on-done declaring a BARE-KEYWORD
+            target (:on-done :next) is rejected at registration — it would
+            otherwise silently stall in the all-final config"
+    (is (thrown-with-msg?
+          #?(:clj Exception :cljs js/Error)
+          #":rf.error/machine-parallel-on-done-target"
+          (rf/reg-machine :rf2-6srk5/bad-kw-target
+            {:type    :parallel
+             :on-done :next
+             :regions {:a {:initial :run :states {:run {}}}}})))))
+
+(deftest parallel-on-done-vector-path-target-rejected
+  (testing "rf2-6srk5: a parallel root's :on-done declaring a VECTOR-PATH
+            target (:on-done [:next]) is rejected at registration"
+    (is (thrown-with-msg?
+          #?(:clj Exception :cljs js/Error)
+          #":rf.error/machine-parallel-on-done-target"
+          (rf/reg-machine :rf2-6srk5/bad-vec-target
+            {:type    :parallel
+             :on-done [:next]
+             :regions {:a {:initial :run :states {:run {}}}}})))))
+
+(deftest parallel-on-done-candidate-vector-target-rejected
+  (testing "rf2-6srk5: a parallel root's :on-done CANDIDATE VECTOR containing
+            a target-bearing map is rejected at registration"
+    (is (thrown-with-msg?
+          #?(:clj Exception :cljs js/Error)
+          #":rf.error/machine-parallel-on-done-target"
+          (rf/reg-machine :rf2-6srk5/bad-cand-vec-target
+            {:type    :parallel
+             :on-done [{:guard :g :target :next} {:action :a}]
+             :guards  {:g (constantly true)}
+             :actions {:a (fn [{d :data}] {:data d})}
+             :regions {:a {:initial :run :states {:run {}}}}})))))
+
+(deftest parallel-on-done-action-fx-only-accepted
+  (testing "rf2-6srk5: an :action / :fx-only parallel root :on-done (NO
+            :target) stays ACCEPTED at registration and fires exactly once"
+    (let [ran (atom 0)]
+      (rf/reg-machine :rf2-6srk5/ok-action-only
+        {:type    :parallel
+         :data    {:n 0}
+         :actions {:bump (fn [{d :data}] (swap! ran inc) {:data (update d :n inc)})}
+         :on-done {:action :bump}
+         :regions {:left  {:initial :run :states {:run {:on {:fin :done}} :done {:final? true}}}
+                   :right {:initial :run :states {:run {:on {:fin :done}} :done {:final? true}}}}})
+      (rf/dispatch-sync [:rf2-6srk5/ok-action-only [:fin]])
+      (is (= {:left :done :right :done} (:state (snapshot :rf2-6srk5/ok-action-only)))
+          "both regions reached final — action-only :on-done was accepted")
+      (is (= 1 @ran) "the action-only :on-done fired exactly once"))))
+
 (deftest compound-on-done-unresolved-action-rejected
   (testing "a compound :on-done referencing an unregistered action keyword is
             rejected at registration (fail-fast ref resolution)"


### PR DESCRIPTION
Fixes the two findings in **rf2-6srk5** (Senior review: implementation/machines).

## Finding 1 — parallel-root `:on-done` bare/vector targets silently stall (FIXED)

`validate-parallel!` (`lifecycle_fx/validation.cljc`) only rejected a parallel-root `:on-done` target when the value normalised to a **map** carrying `:target` (`(some #(contains? % :target) cands)` over a `cands` list that included only map / vector-of-maps forms). A bare-keyword target (`:on-done :next`) and a vector-path target (`:on-done [:next]`) passed validation. At runtime `transition/apply-on-done-action` then normalised those via `normalise-candidates` to a `:target`-only / **action-less** candidate, `select-passing-candidate` picked it, `run-action` ran nothing (nil `:action`), it returned `(ok snap [])`, and the parallel done-signal was marked handled — **suppressing auto-destroy** — while moving **nowhere**. Result: a natural author spelling silently STALLS in the all-final configuration, violating the root-only parallel policy and the loud-failure / XState-v5-parity posture (unsupported in-machine continuation on a parallel root must fail loud, not no-op).

**Fix:** the on-done validation now normalises **every** value form `:on-done` admits — mirroring `transition/normalise-candidates` (keyword → `{:target kw}`; vector-of-maps → as-is; any other vector → `{:target vec}`; map → `[map]`) — and rejects any target-bearing candidate loudly with the existing `:rf.error/machine-parallel-on-done-target`. Action / fx-only `:on-done` (no `:target`) stays accepted and fires once.

Regressions added beside `parallel-on-done-target-rejected` in `done_signal_cljs_test.cljc`:
- `parallel-on-done-bare-keyword-target-rejected` (`:on-done :next`)
- `parallel-on-done-vector-path-target-rejected` (`:on-done [:next]`)
- `parallel-on-done-candidate-vector-target-rejected` (`:on-done [{:guard :g :target :next} {:action :a}]`)
- `parallel-on-done-action-fx-only-accepted` (positive — action-only `:on-done` accepted, fires exactly once)
- (the pre-existing map-target case `parallel-on-done-target-rejected` remains)

**Spec:** `spec/005` (lines 2899/2903) and `Spec-Schemas.md` already state "Registration rejects a `:target` on a parallel root's `:on-done`" with no value-form carve-out — the policy was always all-target-forms; this was an implementation enforcement gap, not a spec divergence. **Spec unchanged because the documented policy already covers every target form.**

## Finding 2 — stale `spawn.cljc` namespace docstring (FIXED)

The `spawn.cljc` namespace docstring claimed a spawned actor is registered as an event handler and that `spawn-fx` registers the live handler via `events/reg-event-fx`, plus a "two-tier registry not yet built" deferral. That contradicts the current rf2-a2sn1 design (already documented correctly in the `spawn-fx` / `install-spawn!` function docstrings): spawned-actor liveness is **app-db-only** with **lazy handler resolution** and **no per-instance registrar entry** — spawn is a pure app-db write, so `restore-epoch` reverts liveness with zero registrar drift (the Goal-2 revertibility invariant). Rewrote the namespace docstring to match. Acceptance verified: a grep of `spawn.cljc` for `reg-event-fx` / "registers the live handler" / "two-tier registry" / "not yet built" / "registration goes through the global registrar" returns no matches. Actor-liveness tests unchanged.

## Quality gates

- `cd implementation/machines && clojure -M:test` → **524 tests, 1634 assertions, 0 failures, 0 errors**.
- `cd implementation && npm run test:cljs` → **5831 tests, 20646 assertions, 0 failures, 0 errors**.
- Done-signal namespace alone → 18 tests, 43 assertions, 0 failures (was 14 — 4 new).
- Probe confirmed `:on-done :next` and `:on-done [:next]` now throw `:rf.error/machine-parallel-on-done-target` at registration.
- Conformance: the corpus does not cover parallel-root `:on-done` rejection (no fixture references `machine-parallel-on-done-target`), so no fixtures to add.
