### PR TITLE
fix(skills/re-frame2): correct Story-recorder + FormAction privacy to schema-paths/redact-interceptor (handler-meta :sensitive? is a no-op) (rf2-ja0pf)

### DIFF
--- a/skills/re-frame2/evals/evals.json
+++ b/skills/re-frame2/evals/evals.json
@@ -106,6 +106,22 @@
         "The agent does NOT read or cite re-frame v1 setup conventions (lein, re-frame-template) as if they applied — re-frame2 is the v2 line.",
         "If the agent does sketch any scaffold while handing off, it correctly names the artefact coordinates (day8/re-frame2, day8/re-frame2-machines for state machines) rather than re-frame v1 coordinates."
       ]
+    },
+    {
+      "id": 7,
+      "name": "recipe-correctness-story-recorder-sensitive-login",
+      "dimension": "recipe-correctness",
+      "prompt": "I'm using the Story recorder to capture a login + 2FA workflow into a :script body — the user types an email, a password, then a one-time 2FA code. I do NOT want the password or the 2FA code to land in the recorded snippet or in the MCP record-as-variant output. How do I mark these events so the recorder redacts them?",
+      "expected_output": "The agent loads references/tooling/story-recorder.md (and references/cross-cutting/privacy-and-elision.md) and teaches the CURRENT privacy contract: the recorder suppresses a row iff the runtime stamped :sensitive? on the emitted trace event, which is path-based (schema per-slot {:sensitive? true} on the app-db slot the handler focuses, or path-marked classification), NOT handler metadata. It explicitly rejects marking the reg-event-* handler / action {:sensitive? true} as a no-op. It uses rf/redact-interceptor for a transient payload-only secret (the 2FA code that never lands at an app-db slot) and notes that redact-interceptor scrubs payload keys but does not by itself suppress the whole row.",
+      "files": [],
+      "expectations": [
+        "Skill skills/re-frame2/ is invoked and references/tooling/story-recorder.md is read (privacy-and-elision.md may also be read).",
+        "The output states that the Story recorder keys its sensitivity filter off the emitted trace event's top-level :sensitive? field (rf/sensitive? / re-frame.privacy/sensitive?), NOT off handler metadata.",
+        "The output EXPLICITLY REJECTS handler-meta {:sensitive? true} on the reg-event-* / action as the mechanism — it states that flag is a no-op / removed from the runtime and ships credentials verbatim.",
+        "For the password (which lands at an app-db slot), the output declares that slot {:sensitive? true} in reg-app-schema (or notes path-marked classification via re-frame.marks) so the runtime stamps the trace event sensitive and the recorder substitutes the whole-row [:rf/redacted] placeholder.",
+        "For a transient payload-only secret (the one-time 2FA code that need not land at an app-db slot), the output reaches for rf/redact-interceptor with the named payload path(s), and notes it scrubs payload keys on the trace surface but does NOT by itself stamp :sensitive? / suppress the whole row.",
+        "The output does NOT claim that registering a handler :sensitive? true causes Story / MCP record-as-variant to redact the event."
+      ]
     }
   ]
 }

--- a/skills/re-frame2/patterns/form-action.md
+++ b/skills/re-frame2/patterns/form-action.md
@@ -77,7 +77,14 @@ Every form POST MUST carry a CSRF token; the server MUST reject a mismatched tok
 
 ## File uploads
 
-`enctype="multipart/form-data"` — the host adapter parses files under `:form-params` as `{:filename :content-type :size :tempfile :sensitive?}` maps. The `:tempfile` is host-specific and **opaque**: pass it to a file-storage fx (S3 PUT, disk write); never dereference it in the handler, and write only the resulting URL/storage-id into `app-db`. File **contents** never appear in trace events; a `:sensitive? true` action redacts the whole `:form-params` map (filenames leak too). Mixed sensitive + non-sensitive fields → split into two POSTs (sanitisation is map-level, not field-level).
+`enctype="multipart/form-data"` — the host adapter parses files under `:form-params` as `{:filename :content-type :size :tempfile}` maps. The `:tempfile` is host-specific and **opaque**: pass it to a file-storage fx (S3 PUT, disk write); never dereference it in the handler, and write only the resulting URL/storage-id into `app-db`. File **contents** never appear in trace events.
+
+**Marking the POST sensitive — use the current privacy surface, not handler metadata.** A handler-meta `{:sensitive? true}` flag on the action is a **no-op** — the runtime removed it and the trace surface no longer consults it, so marking the action does nothing and the `:form-params` ship verbatim into trace/Story/MCP egress. Sensitivity is path-based now (per [`../references/cross-cutting/privacy-and-elision.md`](../references/cross-cutting/privacy-and-elision.md)):
+
+- If the upload metadata (or any field) lands at an **app-db slot** that can hold credentials/PII, declare that slot `{:sensitive? true}` in `reg-app-schema` — the router auto-redacts it on the trace surface and stamps the event sensitive.
+- If a secret rides only in the **event payload** (e.g. a one-time token in `:form-params`) and never lands at an app-db slot, scrub the named payload paths with a positional `(rf/redact-interceptor [[:form-params :token] …])` on the action handler. Filenames and other payload keys that should not appear in traces are named the same way. An empty-path `(rf/redact-interceptor [[:form-params]])` scrubs the whole `:form-params` map.
+
+Mixed sensitive + non-sensitive fields → name the sensitive payload paths in the interceptor (or split into two POSTs); the scrub is per-named-path, applied via `redact-interceptor`/schema, not a whole-action toggle.
 
 ## Anti-patterns
 
@@ -96,7 +103,7 @@ No standalone example app — the SSR worked apps are `examples/reagent/ssr/core
 
 - Spec: [`spec/Pattern-FormAction.md`](../../../spec/Pattern-FormAction.md) — full worked `/cart/add` page, the failure-path projector hook, multipart privacy, the server-vs-client handler-tree table, conformance checklist.
 - Substrate: `SKILL-REDIRECT.md` → *EP — SSR (011)* (`:rf.server/request` cofx, `[:rf/response]` accumulator, the six server-only fxs, `:platforms` gating, server error projection), *EP — Schemas (010)* (`:schema` boundary check, `:sensitive?`).
-- Cross-cutting: `references/cross-cutting/ssr-authoring.md` (head/meta + the `:rf/hydrate` checks).
+- Cross-cutting: `references/cross-cutting/ssr-authoring.md` (head/meta + the `:rf/hydrate` checks); `references/cross-cutting/privacy-and-elision.md` (schema-path `:sensitive?` + `rf/redact-interceptor` — the current privacy surface; handler-meta `:sensitive?` is a no-op).
 - Compose: `patterns/forms.md` (the form-slice shape this reuses server-side), `patterns/ssr-loaders.md` (the GET-path sibling — a page uses Loaders for the initial render, FormAction for subsequent POSTs).
 
 ---

--- a/skills/re-frame2/references/tooling/story-recorder.md
+++ b/skills/re-frame2/references/tooling/story-recorder.md
@@ -39,26 +39,40 @@ The trace-bus callback short-circuits unless a recording is in flight, so it's f
 1. **Op-type** — only `:event/dispatched` emissions qualify (`:fx`, `:sub`, `:view`, `:cofx` traffic is dropped).
 2. **Frame scope** — emission `:frame` must match the recording's target variant. Typing in another canvas while a recording is active is dropped.
 3. **Event vocabulary** — `:rf.assert/*` events and Story-internal helpers (`:rf.story/*`, `:re-frame.story.*`) are filtered. Recorded `:script` bodies capture user intent; assertions get added by hand afterwards.
-4. **Sensitivity** — events whose handler is registered `:sensitive? true` (auth, 2FA, password change, API-key rotation) replace the event vector with the placeholder `[:rf/redacted]` instead of riding the raw payload into the snippet. The temporal position survives; the secret never lands in `:script` source. See the next section for details and the authoring rule.
+4. **Sensitivity** — events the runtime has stamped `:sensitive?` on the *emitted trace event* (auth, 2FA, password change, API-key rotation) replace the event vector with the placeholder `[:rf/redacted]` instead of riding the raw payload into the snippet. The temporal position survives; the secret never lands in `:script` source. The recorder keys off the trace event's top-level `:sensitive?` field (`re-frame.privacy/sensitive?`, re-exported as `rf/sensitive?`) — **NOT** handler metadata. Handler-meta `{:sensitive? true}` was removed from the runtime and does nothing. See the next section for what actually stamps that flag, plus the authoring rule.
 
 ## Sensitive events — record-but-redact
 
-A handler registered `:sensitive? true` (an auth flow, a 2FA verify, a password change) still appears in the recording, but as the placeholder vector `[:rf/redacted]` rather than the verbatim event payload. The row's temporal position survives so the dev can see "click → auth happened → click", but the credential / PII / auth-token never rides into the snippet text.
+> **CRITICAL — what makes an event sensitive.** The recorder suppresses a row **iff the runtime stamped `:sensitive? true` on the emitted trace event** (it checks `(rf/sensitive? trace-event)`, i.e. the event's top-level `:sensitive?` field). That stamp is **path-based**, never handler-based. Marking a `reg-event-*` handler `{:sensitive? true}` does **nothing** — the runtime removed that annotation and no longer consults it, so a handler-meta-only "sensitive" login event ships its credentials verbatim into the `:script` body. Authors who rely on the old handler-meta flag will leak secrets.
+
+The current privacy contract has two declaration surfaces, and only the first one stamps the trace event the recorder gates on:
+
+| Mechanism | Where you declare it | Stamps top-level trace `:sensitive?`? | Recorder behaviour |
+|---|---|---|---|
+| **Schema per-slot `{:sensitive? true}`** on an app-db path the handler focuses (via `[(rf/path …)]`) — or path-marked sensitivity via `re-frame.marks` (Spec 015), the live successor | `(rf/reg-app-schema …)` | **Yes** — the schema-sensitive handler scope is stamped | Row redacted → `[:rf/redacted]` |
+| **`rf/redact-interceptor [[:path] …]`** — transient payload scrubbing | positional interceptor on the handler | **No** — it scrubs *named payload keys* to `:rf/redacted` on the trace surface but does **not** stamp the top-level `:sensitive?` flag | Row **kept**; only the named payload keys appear redacted |
+| Handler-meta `{:sensitive? true}` | `reg-event-*` registration map | **No** — removed; ignored | Row kept, payload verbatim — **do not rely on this** |
+
+So to get a recorded login / 2FA / API-key flow suppressed, the sensitive value must live at a **schema-declared sensitive app-db slot** (the handler focuses it with `[(rf/path …)]`) or be **path-marked** — that is what stamps the trace event and triggers whole-row redaction. `rf/redact-interceptor` is the right tool for a secret that rides *only* in the event payload and never lands at an app-db slot, but note that it scrubs payload keys without suppressing the whole row.
+
+When the runtime *has* stamped the event sensitive, it still appears in the recording — as the placeholder vector `[:rf/redacted]` rather than the verbatim event payload. The row's temporal position survives so the dev can see "click → auth happened → click", but the credential / PII / auth-token never rides into the snippet text:
 
 ```clojure
-;; A recording that includes a sensitive dispatch lands like this:
+;; A recording that includes a schema-sensitive dispatch lands like this:
 [[:counter/inc]
- [:rf/redacted]                ;; placeholder for an :auth/login dispatch
+ [:rf/redacted]                ;; whole-row placeholder for an :auth/login dispatch
  [:counter/inc]]
 ```
 
-Properties:
+**Whole-row placeholder vs payload-only redaction.** The recorder substitutes the *whole event vector* with the single-element placeholder `[:rf/redacted]` — it does not emit a redacted-payload event vector (e.g. `[:auth/login {:password :rf/redacted}]`). The two redaction shapes are distinct: `rf/redact-interceptor` produces a payload-only redaction (`[:auth/login {:password :rf/redacted}]`) on the *trace surface* but, because it does not stamp the top-level `:sensitive?` flag, the recorder does not treat that row as suppressible — it captures whatever the trace event carries. Whole-row `[:rf/redacted]` is the recorder's own substitution, applied only when the trace event is stamped `:sensitive?`.
+
+Properties of the whole-row placeholder:
 
 - **Round-trips cleanly.** `[:rf/redacted]` is a well-formed event vector; `read-string` survives. Re-playing the snippet finds no handler for `:rf/redacted`, so dispatch raises a clean `:rf.error/handler-not-found` rather than a malformed-event-vector error — the dev sees they need to replace the placeholder before re-play works.
 - **The redaction counter still bumps.** The recording overlay's REDACTED indicator shows "N rows redacted" alongside the placeholders themselves, so the dev knows how many slots are pasteholders even before scrolling.
 - **`:rf.privacy/show-sensitive? true` keeps the verbatim event.** In-box debug only; never enable for snippets that ride into source control. Set via `(story/configure! {:rf.privacy/show-sensitive? true})` early in dev boot.
 
-Authoring rule: do NOT publish a `:script` body containing `[:rf/redacted]` slots into committed source — they're recordings of credential flows, not reproducible tests. Either hand-author the equivalent dispatch with a synthetic credential, or scope the recording away from the sensitive step.
+Authoring rule: do NOT publish a `:script` body containing `[:rf/redacted]` slots into committed source — they're recordings of credential flows, not reproducible tests. Either hand-author the equivalent dispatch with a synthetic credential, or scope the recording away from the sensitive step. And do NOT reach for handler-meta `{:sensitive? true}` to make a recording safe — it is a no-op; declare the sensitive app-db slot in your schema (or path-mark it) so the runtime stamps the trace event the recorder gates on. See [`../cross-cutting/privacy-and-elision.md`](../cross-cutting/privacy-and-elision.md) for the full schema-paths / `redact-interceptor` contract.
 
 ## Worked example — recorded `:script` body
 


### PR DESCRIPTION
Closes the single senior-review finding on `skills/re-frame2` (rf2-ja0pf): the Story-recorder leaf + FormAction multipart-privacy paragraph still taught a **stale privacy mechanism**.

## Problem

Both docs claimed that registering a `reg-event-*` handler / action `{:sensitive? true}` causes the Story recorder (and `record-as-variant` MCP egress) to redact the event to `[:rf/redacted]`. **Handler-meta `:sensitive?` was removed from the runtime and does nothing.** An agent following the old guidance marks a login/2FA/API-key handler `{:sensitive? true}`, believes the recorder will suppress credentials, and the runtime ships the payload verbatim into the `:script` body and over the MCP wire — credentials captured.

## Current contract (verified against the framework)

The recorder's sensitivity filter keys off the **emitted trace event's top-level `:sensitive?` field** (`re-frame.privacy/sensitive?`, re-exported `rf/sensitive?`), which is stamped **path-based**:

- **Schema per-slot `{:sensitive? true}`** on the app-db slot the handler focuses (via `[(rf/path …)]`), or path-marked classification via `re-frame.marks` (Spec 015) — **stamps** the trace event sensitive → recorder substitutes the whole-row `[:rf/redacted]` placeholder.
- **`rf/redact-interceptor [[:path] …]`** — scrubs named payload keys on the trace surface for transient payload-only secrets, but does **NOT** by itself stamp `:sensitive?` / suppress the whole row.
- **Handler-meta `{:sensitive? true}`** — no-op; removed; ignored.

Verified against: `implementation/core/src/re_frame/event_emit.cljc:41`, `implementation/core/src/re_frame/privacy.cljc` (`sensitive?` checks the trace event's `:sensitive?` field), `tools/story/src/re_frame/story/recorder.cljc` + `tools/story/src/re_frame/story/config.cljc` (`suppress-sensitive?` → `privacy/sensitive?`), and tests `sensitive_stamping_test.clj` (`handler-meta-sensitive-no-longer-stamps-events`, `schema-auto-redaction-for-path-scoped-handler` stamps `:sensitive?`) + `redact_interceptor_test.clj` (`redact-interceptor-alone-does-not-stamp-sensitive-scope`). Matches the adjacent already-corrected `references/cross-cutting/privacy-and-elision.md`.

## Changes

- `references/tooling/story-recorder.md` — rewrote filter-layer 4 + the record-but-redact section to teach the current contract; added a mechanism table (schema-path vs `redact-interceptor` vs handler-meta no-op); clarified whole-row `[:rf/redacted]` vs payload-only redaction.
- `patterns/form-action.md` — replaced the "`:sensitive? true` action redacts the whole `:form-params`" claim with the schema-path / `redact-interceptor` surface; added a privacy cross-ref pointer.
- `evals/evals.json` — added eval 7 (login/2FA story-recording workflow) that **rejects** handler-meta `:sensitive?` guidance.

GENERIC: guidance applies to any consumer re-frame2 app; no repo-specific paths. No back-compat shims.

## Quality gates

All run from the worktree, all green:

- `python -c json.load(evals.json)` — parses; 7 evals, ids 1–7.
- `scripts/check_doc_slugs.py --self-test` + full run — "no broken links" (398 md files).
- `scripts/check_skill_redirect_anchors.py` — exit 0, clean.
- `scripts/check_skill_migration_cites.py --self-test` + run — all M-id cites resolve.
- `scripts/check_skill_package_refs.py --self-test` + run — all caveats present.
- `scripts/check_skill_mcp_drift.py` — "No skill <-> MCP drift detected."