### PR TITLE
fix(http): independent-review findings (rf2-azrcs)

### DIFF
--- a/implementation/http/src/re_frame/http_handlers.cljc
+++ b/implementation/http/src/re_frame/http_handlers.cljc
@@ -108,10 +108,16 @@
                                :retryable-set retryable-categories
                                :reason        "`:retry :on` must be drawn exclusively from the closed retryable set #{:rf.http/transport :rf.http/cors :rf.http/timeout :rf.http/http-4xx :rf.http/http-5xx}; `:rf.http/aborted`, `:rf.http/decode-failure`, and `:rf.http/accept-failure` are non-retryable by construction"})))))))))
 
-(defn- validate-url!
+(defn validate-url!
   "Per Spec 014 §Request envelope `:url` is the only REQUIRED key in the
   request envelope; per Spec 009 §Error catalogue a missing/blank `:url`
   surfaces as `:rf.error/http-bad-request` (rf2-93bck).
+
+  Public (rf2-azrcs) so the canned-stub override target
+  (`http-machine-wrapper`/`http-test-support`'s route-map stub) validates
+  the FINAL post-`:before` url with the same canonical error the real
+  `:rf.http/managed` handler emits — a `:before` that blanks the url must
+  raise `:rf.error/http-bad-request`, not receive a synthetic stubbed reply.
 
   Validated AFTER `run-interceptor-chain!` produces the final `:request`,
   because a `:before` interceptor may legitimately SET the url (e.g. a

--- a/implementation/http/src/re_frame/http_machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http_machine_wrapper.cljc
@@ -68,7 +68,7 @@
 ;; `encoding/resolve-origin-event` (single source of truth shared with
 ;; `http-managed/managed-handler`).
 
-(defn- run-request-chain
+(defn run-request-chain
   "Per rf2-yhfgf — the request-side middleware chain (Spec 014 §Middleware)
   fires for every issued request, not just real-transport ones. The canned
   stub fxs replace the TRANSPORT, not the entire managed pipeline, so they
@@ -83,7 +83,14 @@
   Returns the post-`:before` middleware-ctx so the caller can thread it
   through `run-after-chain!` — the same ctx the `:after` chain sees on
   the real-transport path (carried forward by `managed-handler` as the
-  normalised ctx's `:middleware-ctx`)."
+  normalised ctx's `:middleware-ctx`). The route-map stub
+  (`http-test-support/stub-handler`, rf2-azrcs) ALSO reads the
+  post-`:before` `:request` back off this ctx to key its match against
+  the url the managed pipeline would actually issue, and runs
+  `handlers/validate-url!` on it — the final-url validation belongs to the
+  `:rf.http/managed` OVERRIDE-TARGET role (the stub), not to this shared
+  chain walk, which the lower-level canned handlers also call with a bare
+  `:value` and no `:request`."
   [frame-ctx args-map]
   (let [frame-id     (or (:frame frame-ctx) :rf/default)
         origin-event (encoding/resolve-origin-event frame-ctx args-map)
@@ -131,22 +138,21 @@
      :reply-payload  reply-payload
      :kind           kind}))
 
-(defn canned-success-handler
-  "Stub fx — synthesises a success reply per Spec 014 §Testing.
-
-  Per rf2-yhfgf — walks the per-frame request-side (`:before`) interceptor
-  chain before synthesising the reply, so `:before` interceptors with
-  load-bearing side effects (auth headers, observability) fire on the
-  canned path the same way they fire on the real-transport path.
-
-  Per rf2-r5m22 — also threads the reply through the response-side
-  (`:after`) chain (via `dispatch-canned-reply!`), mirroring
-  `http-transport/dispatch-reply!` so the stub path is a faithful test
-  seam for BOTH halves of the middleware chain."
-  [frame-ctx args-map]
-  (let [middleware-ctx (run-request-chain frame-ctx args-map)
-        frame-id       (or (:frame frame-ctx) :rf/default)
-        value          (get args-map :value {:stubbed true})]
+;; rf2-azrcs — the canned-success / canned-failure bodies split into a
+;; pre-computed-ctx emit (`emit-canned-success!` / `emit-canned-failure!`)
+;; plus a thin run-the-chain-then-emit wrapper. The route-map stub
+;; (`http-test-support/stub-handler`) runs the `:before` chain ONCE itself
+;; (so it can key its route match against the post-`:before` url), then
+;; calls the emit fns with that same ctx — WITHOUT re-running `:before`
+;; (which would double-fire load-bearing interceptor side effects).
+(defn emit-canned-success!
+  "Synthesise a success reply from a PRE-COMPUTED post-`:before`
+  `middleware-ctx` (rf2-azrcs). Threads the reply through the `:after`
+  chain via `dispatch-canned-reply!`. Does NOT run the `:before` chain —
+  the caller already did."
+  [frame-ctx args-map middleware-ctx]
+  (let [frame-id (or (:frame frame-ctx) :rf/default)
+        value    (get args-map :value {:stubbed true})]
     (dispatch-canned-reply!
       {:origin-event   (encoding/resolve-origin-event frame-ctx args-map)
        :explicit-on    {:supplied? (contains? args-map :on-success)
@@ -156,6 +162,41 @@
        :frame          frame-id
        :middleware-ctx middleware-ctx})
     nil))
+
+(defn emit-canned-failure!
+  "Synthesise a failure reply from a PRE-COMPUTED post-`:before`
+  `middleware-ctx` (rf2-azrcs). Symmetric with `emit-canned-success!`."
+  [frame-ctx args-map middleware-ctx]
+  (let [frame-id (or (:frame frame-ctx) :rf/default)
+        kind     (or (:kind args-map) :rf.http/transport)
+        tags     (or (:tags args-map) {})
+        failure  (assoc tags :kind kind)]
+    (dispatch-canned-reply!
+      {:origin-event   (encoding/resolve-origin-event frame-ctx args-map)
+       :explicit-on    {:supplied? (contains? args-map :on-failure)
+                        :value     (:on-failure args-map)}
+       :reply-payload  {:kind :failure :failure failure}
+       :kind           :failure
+       :frame          frame-id
+       :middleware-ctx middleware-ctx})
+    nil))
+
+(defn canned-success-handler
+  "Stub fx — synthesises a success reply per Spec 014 §Testing.
+
+  Per rf2-yhfgf — walks the per-frame request-side (`:before`) interceptor
+  chain before synthesising the reply, so `:before` interceptors with
+  load-bearing side effects (auth headers, observability) fire on the
+  canned path the same way they fire on the real-transport path.
+  Per rf2-azrcs — the chain walk (`run-request-chain`) also validates the
+  final post-`:before` url with the canonical `:rf.error/http-bad-request`.
+
+  Per rf2-r5m22 — also threads the reply through the response-side
+  (`:after`) chain (via `dispatch-canned-reply!`), mirroring
+  `http-transport/dispatch-reply!` so the stub path is a faithful test
+  seam for BOTH halves of the middleware chain."
+  [frame-ctx args-map]
+  (emit-canned-success! frame-ctx args-map (run-request-chain frame-ctx args-map)))
 
 (defn canned-failure-handler
   "Stub fx — synthesises a failure reply per Spec 014 §Testing.
@@ -169,20 +210,7 @@
   (`:after`) chain (via `dispatch-canned-reply!`), mirroring
   `http-transport/dispatch-reply!`."
   [frame-ctx args-map]
-  (let [middleware-ctx (run-request-chain frame-ctx args-map)
-        frame-id       (or (:frame frame-ctx) :rf/default)
-        kind           (or (:kind args-map) :rf.http/transport)
-        tags           (or (:tags args-map) {})
-        failure        (assoc tags :kind kind)]
-    (dispatch-canned-reply!
-      {:origin-event   (encoding/resolve-origin-event frame-ctx args-map)
-       :explicit-on    {:supplied? (contains? args-map :on-failure)
-                        :value     (:on-failure args-map)}
-       :reply-payload  {:kind :failure :failure failure}
-       :kind           :failure
-       :frame          frame-id
-       :middleware-ctx middleware-ctx})
-    nil))
+  (emit-canned-failure! frame-ctx args-map (run-request-chain frame-ctx args-map)))
 
 ;; ---- machine-shape wrapper spec (rf2-ijm7) --------------------------------
 

--- a/implementation/http/src/re_frame/http_test_support.cljc
+++ b/implementation/http/src/re_frame/http_test_support.cljc
@@ -80,6 +80,7 @@
   (:require [re-frame.events               :as events]
             [re-frame.fx                   :as fx]
             [re-frame.http-encoding        :as encoding]
+            [re-frame.http-handlers        :as handlers]
             [re-frame.http-machine-wrapper :as machine-wrapper]
             [re-frame.http-middleware      :as middleware]
             [re-frame.late-bind            :as late-bind]
@@ -207,30 +208,63 @@
 ;; not own.
 
 (defn- stub-handler
+  "Route-map-consulting `:rf.http/managed` override target.
+
+  rf2-azrcs — the stub now keys its route match against the request the
+  managed pipeline would ACTUALLY issue, not the pre-middleware draft. It
+  runs the per-frame `:before` chain ONCE (`run-request-chain`, which also
+  validates the final url with the canonical `:rf.error/http-bad-request`),
+  reads the post-`:before` `:method`/`:url` back off that ctx to key the
+  route map, then emits the canned reply through the `:after` chain with
+  that SAME ctx — without re-running `:before` (no double-firing of
+  load-bearing interceptor side effects).
+
+  Consequences of the prior pre-`:before` matching this fixes:
+   - a base-URL / url-rewriting `:before` made the stub match the ORIGINAL
+     url (false-green when keyed to the draft, false-fail when keyed to the
+     final url the production transport sends); and
+   - a `:before` that blanked the url received a synthetic stubbed reply
+     instead of the production `:rf.error/http-bad-request`, masking the
+     invalid request. `run-request-chain` now throws before any match."
   [stubs frame-ctx args-map]
-  (let [req    (:request args-map)
-        method (or (:method req) :get)
-        url    (:url req)
-        entry  (get stubs [method url])
-        reply  (:reply entry)]
+  ;; Run the `:before` chain ONCE up front (a `:before` throw propagates
+  ;; exactly as the real `:rf.http/managed` handler's does — no reply is
+  ;; synthesised). Then validate the FINAL post-`:before` url with the
+  ;; canonical `:rf.error/http-bad-request` — the stub is the
+  ;; `:rf.http/managed` override target, so it owes the same final-url
+  ;; guard the real handler runs after its `:before` chain. A `:before`
+  ;; that blanks the url now throws here instead of receiving a synthetic
+  ;; stubbed reply.
+  (let [middleware-ctx (machine-wrapper/run-request-chain frame-ctx args-map)
+        _              (handlers/validate-url! (:request middleware-ctx))
+        ;; Match against the POST-`:before` request — the url the managed
+        ;; pipeline would actually send.
+        req            (:request middleware-ctx)
+        method         (or (:method req) :get)
+        url            (:url req)
+        entry          (get stubs [method url])
+        reply          (:reply entry)]
     (cond
       (and entry (contains? reply :ok))
-      (machine-wrapper/canned-success-handler frame-ctx (assoc args-map :value (:ok reply)))
+      (machine-wrapper/emit-canned-success! frame-ctx (assoc args-map :value (:ok reply))
+                                            middleware-ctx)
 
       (and entry (contains? reply :failure))
-      (machine-wrapper/canned-failure-handler frame-ctx
-                                              (-> args-map
-                                                  (assoc :kind (or (:kind (:failure reply))
-                                                                   :rf.http/transport))
-                                                  (assoc :tags (dissoc (:failure reply) :kind))))
+      (machine-wrapper/emit-canned-failure! frame-ctx
+                                            (-> args-map
+                                                (assoc :kind (or (:kind (:failure reply))
+                                                                 :rf.http/transport))
+                                                (assoc :tags (dissoc (:failure reply) :kind)))
+                                            middleware-ctx)
 
       :else
-      (machine-wrapper/canned-failure-handler frame-ctx
-                                              (assoc args-map
-                                                     :kind :rf.http/transport
-                                                     :tags {:message "no stub matched"
-                                                            :method  method
-                                                            :url     url})))))
+      (machine-wrapper/emit-canned-failure! frame-ctx
+                                            (assoc args-map
+                                                   :kind :rf.http/transport
+                                                   :tags {:message "no stub matched"
+                                                          :method  method
+                                                          :url     url})
+                                            middleware-ctx))))
 
 (def ^:private stub-fx-id :rf.http/managed-test-stub)
 

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -252,14 +252,29 @@
 #?(:cljs
    (defn- cross-origin?
      "Heuristic: is `url` cross-origin relative to the current page?
-     Returns `false` for same-origin URLs, relative URLs (no scheme/host),
-     `data:`/`blob:`/`file:` schemes, and any URL the host can't parse.
-     The conservative path returns `false` so we never misclassify a
-     same-origin Fetch failure as CORS.
+     Returns `false` for same-origin URLs (incl. relative + same-host
+     protocol-relative), `data:`/`blob:`/`file:` schemes, and any URL the
+     host can't parse. The conservative path returns `false` so we never
+     misclassify a same-origin Fetch failure as CORS.
 
      `js/location.origin` is the comparison base in browser hosts; on
      non-browser CLJS targets (Node / shadow-cljs node tests) the global
-     is absent and we return `false`."
+     is absent and we return `false`.
+
+     rf2-azrcs — resolution semantics:
+
+     - The URL is parsed WITH `loc-origin` as the base (`js/URL. url base`),
+       so relative (`/x`, `?q`, `#f`), protocol-relative (`//host/x`), and
+       absolute (`https://host/x`) URLs all resolve through one path. A
+       protocol-relative URL inherits the page SCHEME but carries its own
+       HOST, so `//other.invalid/x` is genuinely cross-origin while
+       `//app.example/x` (same host) is same-origin — the prior
+       single-slash short-circuit misclassified BOTH as same-origin.
+     - The `data:`/`blob:`/`file:` scheme exclusion is matched
+       CASE-INSENSITIVELY (URL schemes are case-insensitive per RFC 3986
+       §3.1). The prior lowercase-only prefix check let `DATA:`/`FILE:`
+       fall through to the parse, where their parsed origin is the literal
+       string `\"null\"` (≠ page origin) and so false-classified as CORS."
      [^String url]
      (try
        (let [loc-origin (some-> js/globalThis
@@ -268,17 +283,20 @@
          (cond
            (nil? url)        false
            (nil? loc-origin) false
-           ;; Relative URLs are always same-origin.
-           (or (str/starts-with? url "/")
-               (str/starts-with? url "?")
-               (str/starts-with? url "#"))           false
            ;; data:/blob:/file: schemes are not http(s) origins; treat
            ;; as not-cross-origin (transport errors there are not CORS).
-           (or (str/starts-with? url "data:")
-               (str/starts-with? url "blob:")
-               (str/starts-with? url "file:"))       false
+           ;; Scheme match is case-insensitive (RFC 3986 §3.1).
+           (let [lower (str/lower-case url)]
+             (or (str/starts-with? lower "data:")
+                 (str/starts-with? lower "blob:")
+                 (str/starts-with? lower "file:")))   false
            :else
-           (let [parsed (js/URL. url)
+           ;; Parse WITH the page origin as the base so relative,
+           ;; protocol-relative, and absolute URLs all resolve in one
+           ;; path. Same-origin relatives inherit `loc-origin`; a
+           ;; protocol-relative URL with a different host resolves to its
+           ;; own (cross) origin.
+           (let [parsed (js/URL. url loc-origin)
                  origin (.-origin parsed)]
              (and (string? origin)
                   (not= origin loc-origin)))))

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -216,7 +216,40 @@
             (let [err (js/TypeError. "Failed to fetch")
                   out (classify-cljs-error err url)]
               (is (= :rf.http/transport (:kind out))
-                  (str url " is relative/same-origin, never CORS")))))))))
+                  (str url " is relative/same-origin, never CORS")))))
+
+        ;; rf2-azrcs — protocol-relative URLs inherit the page SCHEME but
+        ;; carry their OWN host, so the host decides cross-origin. The
+        ;; pre-fix single-slash short-circuit (`starts-with? url "/"`)
+        ;; misclassified BOTH a different-host and a same-host
+        ;; protocol-relative URL as same-origin.
+        (testing "a protocol-relative URL with a DIFFERENT host → :rf.http/cors"
+          (let [err (js/TypeError. "Failed to fetch")
+                out (classify-cljs-error err "//other.invalid/x")]
+            (is (= :rf.http/cors (:kind out))
+                "//other.invalid/x resolves to https://other.invalid (cross-origin)")
+            (is (= "//other.invalid/x" (:url out))
+                ":url tag rides the original (unresolved) URL")))
+
+        (testing "a protocol-relative URL with the SAME host → :rf.http/transport"
+          (let [err (js/TypeError. "Failed to fetch")
+                out (classify-cljs-error err "//app.example/x")]
+            (is (= :rf.http/transport (:kind out))
+                "//app.example/x resolves to https://app.example (same-origin)")))
+
+        ;; rf2-azrcs — URL schemes are case-insensitive (RFC 3986 §3.1).
+        ;; The pre-fix lowercase-only prefix check let `DATA:`/`FILE:` fall
+        ;; through to `js/URL.`, where their parsed origin is the literal
+        ;; string "null" (≠ page origin) → false-classified as CORS.
+        (testing "uppercase / mixed-case non-http schemes are scheme-excluded
+        → :rf.http/transport (case-insensitive scheme match)"
+          (doseq [url ["DATA:text/plain,hello"
+                       "Blob:https://app.example/uuid"
+                       "FILE:///etc/hosts"]]
+            (let [err (js/TypeError. "Failed to fetch")
+                  out (classify-cljs-error err url)]
+              (is (= :rf.http/transport (:kind out))
+                  (str url " is scheme-excluded case-insensitively, never CORS")))))))))
 
 ;; ---- rf2-5zj6t — binary decode reads the native Fetch body ---------------
 

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -19,6 +19,7 @@
             [re-frame.http-decode :as http-decode]
             [re-frame.http-encoding :as http-encoding]
             [re-frame.http-managed :as http-managed]
+            [re-frame.late-bind :as late-bind]
             ;; rf2-cdmle — the canned-stub fxs no longer register at
             ;; `re-frame.http-managed` load time. This test file uses
             ;; `:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}`
@@ -1124,6 +1125,110 @@
                           {:fx-overrides {:rf.http/managed :rzqan/explicit-override}})
         (is (= :explicit @chosen)
             "the per-call :fx-overrides won over the helper's lexical default")))))
+
+;; ---- 11a-azrcs. route-map stub keys off the POST-`:before` request --------
+;;
+;; rf2-azrcs (independent-review finding #2) — the route-map stub picked
+;; `:method`/`:url` from the ORIGINAL pre-middleware args, then delegated to
+;; the canned handler that ran the `:before` chain LATER. The real
+;; `:rf.http/managed` handler runs `:before` FIRST, validates the FINAL url,
+;; then sends the post-middleware request. So a base-URL / url-rewriting
+;; `:before` made the stub key off the draft url:
+;;   - false-fail when the route map is keyed to the FINAL url (what
+;;     production sends) — the draft url misses it; and
+;;   - false-green when keyed to the ORIGINAL url even though production
+;;     issues a different one.
+;; The fix runs the `:before` chain ONCE in the stub, keys the match against
+;; the post-`:before` url, and emits via that same middleware-ctx (no
+;; double-`:before`). A url-erasing `:before` now throws the production
+;; `:rf.error/http-bad-request` instead of a synthetic stubbed reply.
+
+(deftest stub-matches-post-before-url-rewrite-rf2-azrcs
+  (testing "rf2-azrcs — a base-URL `:before` rewrites `/articles` → `/v2/articles`;
+            the stub keyed to the FINAL `/v2/articles` matches (pre-fix it
+            keyed off the draft `/articles` and fell through to the
+            no-stub-matched failure)"
+    (rf/reg-http-interceptor :azrcs/base-url
+      {:before (fn [ctx]
+                 (update-in ctx [:request :url]
+                            (fn [u] (clojure.string/replace u #"^/" "/v2/"))))})
+    (rf/reg-event-fx :azrcs/list
+      (fn [{:keys [db]} [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db (assoc db :result reply)}
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/articles"}
+                  :decode  :json}]]})))
+    (rf/with-managed-request-stubs
+      ;; Keyed to the FINAL url the `:before` produces — NOT the draft.
+      {[:get "/v2/articles"] {:reply {:ok [:rewritten :ok]}}}
+      (rf/dispatch-sync [:azrcs/list])
+      (let [db (await-reply! #(some? (:result %)) 2000)]
+        (is (= :success (get-in db [:result :kind]))
+            "the stub matched the post-`:before` url")
+        (is (= [:rewritten :ok] (get-in db [:result :value]))
+            "the configured :ok value for the FINAL url rode through")))))
+
+(deftest stub-does-not-match-stale-original-url-rf2-azrcs
+  (testing "rf2-azrcs (complement) — a route map keyed to the ORIGINAL
+            (draft) url no longer false-greens: with a url-rewriting
+            `:before`, the post-`:before` url is what the stub matches, so
+            the stale-key entry misses and the no-stub-matched failure fires"
+    (rf/reg-http-interceptor :azrcs/base-url2
+      {:before (fn [ctx]
+                 (update-in ctx [:request :url]
+                            (fn [u] (clojure.string/replace u #"^/" "/v2/"))))})
+    (rf/reg-event-fx :azrcs/list2
+      (fn [{:keys [db]} [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db (assoc db :result reply)}
+          {:fx [[:rf.http/managed
+                 {:request {:method :get :url "/articles"}
+                  :decode  :json}]]})))
+    (rf/with-managed-request-stubs
+      ;; Keyed to the ORIGINAL draft url — production would issue /v2/articles,
+      ;; so this stub must NOT match (pre-fix it false-matched).
+      {[:get "/articles"] {:reply {:ok [:should :not :match]}}}
+      (rf/dispatch-sync [:azrcs/list2])
+      (let [db (await-reply! #(some? (:result %)) 2000)]
+        (is (= :failure (get-in db [:result :kind]))
+            "the stale original-url key did NOT match the post-`:before` url")
+        (is (= "no stub matched" (get-in db [:result :failure :message]))
+            "the no-stub-matched synthetic failure fired (not the stale :ok)")
+        (is (= "/v2/articles" (get-in db [:result :failure :url]))
+            "the no-match failure reports the FINAL post-`:before` url")))))
+
+(deftest stub-url-erasing-before-throws-bad-request-rf2-azrcs
+  (testing "rf2-azrcs (complement) — a `:before` that BLANKS the url makes
+            the stub throw the production `:rf.error/http-bad-request` and
+            dispatch NO synthetic reply (pre-fix the stub keyed off the
+            original valid url and returned a stubbed reply, masking the
+            invalid request the real handler would reject)"
+    (rf/reg-http-interceptor :azrcs/url-eraser
+      {:before (fn [ctx] (assoc-in ctx [:request :url] nil))})
+    ;; Install the stub fx directly so the throw is observable (a throw
+    ;; inside dispatch-sync's fx phase is swallowed into the error sink).
+    (let [recorded (atom [])
+          original (late-bind/get-fn :router/dispatch!)]
+      (late-bind/set-fn! :router/dispatch!
+                         (fn [ev opts] (swap! recorded conj [ev opts])))
+      (try
+        (re-frame.http-test-support/install-managed-request-stubs!
+          {[:get "/x"] {:reply {:ok {:stubbed true}}}})
+        (let [stub-fx (registrar/handler :fx :rf.http/managed-test-stub)
+              ex      (try (stub-fx {:frame :rf/default :event [:azrcs/erase]}
+                                    {:request {:method :get :url "/x"}})
+                           nil
+                           (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? ex) "the url-erasing :before made the stub throw")
+          (is (= ":rf.error/http-bad-request" (.getMessage ex))
+              "the throw is the canonical production bad-request, not a stubbed reply")
+          (is (= :rf.error/http-bad-request (:rf.error/id (ex-data ex))))
+          (is (empty? @recorded)
+              "NO synthetic reply was dispatched — the invalid request is rejected, not masked"))
+        (finally
+          (re-frame.http-test-support/uninstall-managed-request-stubs!)
+          (late-bind/set-fn! :router/dispatch! original))))))
 
 ;; ---- 11b. canned-stub fxs gated on explicit test-support require (rf2-cdmle)
 ;;


### PR DESCRIPTION
Independent correctness-review pass over `implementation/http` (rf2-azrcs). Both findings verified genuinely-open against current `main` (065xo body-prep/query-redaction and rznrz multi-valued-headers/accept-phase/merge-params are unrelated) and fixed.

## Findings disposition

### Finding #1 — `cross-origin?` CORS heuristic (`http_transport.cljc:253`) — FIXED
- **Protocol-relative URLs**: `//host/x` starts with `/`, so the leading-slash branch short-circuited it to same-origin. A cross-host protocol-relative API URL (`//api.example.com/v1`) therefore misclassified a Fetch `TypeError` as `:rf.http/transport` instead of `:rf.http/cors` — breaking `:retry :on #{:rf.http/cors}` and tooling/error projection. Fixed by parsing with the page origin as the base (`js/URL. url loc-origin`), so relative, protocol-relative, and absolute URLs resolve through one path and the HOST decides cross-origin (`//other.invalid/x` → cors; `//app.example/x` → transport). Verified empirically in Node: `new URL("//other.invalid/x", "https://app.example").origin === "https://other.invalid"`.
- **Case-sensitive scheme exclusion**: the `data:`/`blob:`/`file:` prefix check was lowercase-only. Uppercase `DATA:`/`FILE:` fell through to `js/URL.`, whose parsed origin is the literal string `"null"` (≠ page origin) → false-classified as CORS. Scheme match is now case-insensitive (RFC 3986 §3.1).
- **Not covered by 065xo/rznrz** (CORS heuristic untouched by either). Existing rf2-r40km/rf2-u5xwa tests cover absolute cross-origin, same-origin, relative, and lowercase schemes — not protocol-relative or case-normalized schemes.

### Finding #2 — route-map stub keyed off pre-`:before` request (`http_test_support.cljc:211`) — FIXED
The stub matched the route map against the ORIGINAL `args-map` `:method`/`:url`, then delegated to the canned handler that ran the `:before` chain LATER. The real `:rf.http/managed` handler (`http_handlers.cljc/managed-handler`) runs `:before` FIRST, validates the FINAL url, then sends the post-middleware request. Consequences fixed:
- a base-URL / url-rewriting `:before` made the stub **false-green** when keyed to the draft url, or **false-fail** when keyed to the final url production sends;
- a url-blanking `:before` received a synthetic stubbed reply instead of the production `:rf.error/http-bad-request`, masking the invalid request.

Fix: `stub-handler` runs the `:before` chain ONCE (`run-request-chain`, made public), validates the final url via `handlers/validate-url!` (made public — the override-target role owes the same final-url guard the real handler runs post-chain), keys the route match against the post-`:before` method/url, and emits via that same `middleware-ctx` **without re-running `:before`** (split `emit-canned-success!` / `emit-canned-failure!` out of the canned handlers so no load-bearing interceptor side effect double-fires). The final-url validation lives in the stub (override-target role), NOT in the shared `run-request-chain` — the lower-level canned handlers are still called directly with a bare `:value` and no `:request` (e.g. `http_test_support_test`), so a blanket validation there would have broken them.
- **Not covered by 065xo/rznrz**: `bd search` for `route-map stub`, `base-url interceptor`, etc. found none; the existing `with-managed-request-stubs` tests use a no-`:before` route map.

## Quality gates
- `cd implementation/http && clojure -M:test` → **Ran 374 tests, 1695 assertions, 0 failures, 0 errors** (includes 3 new rf2-azrcs JVM stub tests + all existing canned-path tests, confirming the refactor preserves the canned-path contract).
- `cd implementation && npm run test:cljs` → **Ran 5831 tests, 20663 assertions, 0 failures, 0 errors** (includes new rf2-azrcs cross-origin CLJS tests).

## Tests added
- `http_cljs_test.cljs`: protocol-relative cross-host → cors, protocol-relative same-host → transport, uppercase/mixed-case `DATA:`/`Blob:`/`FILE:` → transport (case-insensitive scheme exclusion).
- `http_managed_test.clj`: stub matches post-`:before` url-rewrite; stale original-url key does NOT false-match (no-stub-matched failure reports final url); url-erasing `:before` throws `:rf.error/http-bad-request` and dispatches NO synthetic reply.