### PR TITLE
fix(core): independent-review findings (rf2-va65k)

### DIFF
--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -9,7 +9,9 @@
 
   Each frame owns its own cascade-keyed ring. Storage shape (per frame):
 
-      {:cascades-retained N             ;; the per-frame ring depth
+      {:cascades-retained N             ;; the per-frame ring depth (cap)
+       :override?         <boolean>     ;; true iff N came from an explicit
+                                        ;; per-frame `:rf.trace/cascades-retained`
        :cascade-order [<dispatch-id> ...]  ;; oldest-first cascade slots
        :cascades {<dispatch-id> [<event> ...]}}
 
@@ -19,6 +21,12 @@
     unit.
   - `:cascades-retained` defaults to 50; per-frame override via
     `:rf.trace/cascades-retained` on `reg-frame`.
+  - `:override?` distinguishes an explicit per-frame override from an
+    inherited process default. EVERY ring stores `:cascades-retained`
+    (it is the live cap consulted on each push), so the cap value alone
+    cannot tell the two apart — `configure-trace-buffer!` keys on
+    `:override?` to decide which rings the new process default may
+    retune (rf2-va65k).
   - `:cascades-retained 0` disables retention (no slots allocated; the
     live stream still fires).
   - Frameless emits (no `:rf.trace/dispatch-id` in scope) **skip the
@@ -90,6 +98,7 @@
 ;; Storage shape (per Spec 009 §Per-frame trace rings):
 ;;
 ;;   trace-rings  = {<frame-id> {:cascades-retained N
+;;                               :override?         <boolean>
 ;;                               :cascade-order [<dispatch-id> ...]
 ;;                               :cascades       {<dispatch-id> [<event>...]}}}
 ;;
@@ -98,6 +107,9 @@
 ;; - `:cascades` is a flat map from `:dispatch-id` → trace events
 ;;   emitted under that dispatch, in arrival order.
 ;; - The slot count is bounded by `:cascades-retained` (default 50).
+;; - `:override?` true iff the cap is an explicit per-frame override
+;;   (`set-frame-cascades-retained!`); false for an inherited default.
+;;   `configure-trace-buffer!` retunes inherited rings, skips overrides.
 ;; - Frames lazily allocate slots on first emit. Apps with one frame
 ;;   pay one slot of ring overhead.
 
@@ -115,15 +127,23 @@
 ;; Per Spec 009 §Retention contract — the single knob.
 (defonce ^:private process-cascades-retained (atom default-cascades-retained))
 
-(defn- empty-ring [retained]
-  {:cascades-retained retained
-   :cascade-order     []
-   :cascades          {}})
+(defn- empty-ring
+  "A fresh ring at cap `retained`. `override?` records whether the cap is
+  an explicit per-frame override (default false = inherited process
+  default) so `configure-trace-buffer!` can tell the two apart."
+  ([retained] (empty-ring retained false))
+  ([retained override?]
+   {:cascades-retained retained
+    :override?         override?
+    :cascade-order     []
+    :cascades          {}}))
 
 (defn- effective-retained
-  "Return the cascades-retained value for `frame-id`. Honours an
-  existing per-frame override (`set-frame-cascades-retained!`'s prior
-  write) before falling back to the process default."
+  "Return the live cascades-retained cap for `frame-id`. Honours the
+  ring's stored cap (whether it came from an explicit per-frame override
+  or a previously-inherited process default — both store
+  `:cascades-retained`) before falling back to the current process
+  default for a frame that has no ring yet."
   [rings frame-id]
   (or (get-in rings [frame-id :cascades-retained])
       @process-cascades-retained))
@@ -133,6 +153,13 @@
   from `frame.cljc`'s `reg-frame` when the config carries the key).
   Trims existing slots if the new value is lower than current
   occupancy; raising keeps existing cascades and grows the slot cap.
+
+  Always writes a COMPLETE ring (`:cascade-order` + `:cascades` present)
+  and stamps `:override? true`. Registering a per-frame cap BEFORE the
+  frame's first emit therefore leaves a valid (empty) ring rather than a
+  partial `{:cascades-retained N}` map — a partial map would later make
+  `push-to-ring!` start `:cascade-order` from nil, `conj` a list, and
+  crash `subvec` once the cap was exceeded (rf2-va65k finding 2).
 
   Per Spec 009 §Lowering cascades-retained on a populated ring."
   [frame-id retained]
@@ -147,7 +174,7 @@
                  ;; so reads return [] cleanly.
                  (zero? retained)
                  (assoc rings frame-id
-                        (empty-ring 0))
+                        (empty-ring 0 true))
 
                  ;; Trim if existing order exceeds the new cap.
                  (> (count order) retained)
@@ -156,11 +183,19 @@
                        kept-order (subvec order drop-n)]
                    (assoc rings frame-id
                           {:cascades-retained retained
+                           :override?         true
                            :cascade-order     kept-order
                            :cascades          (apply dissoc cascades evicted)}))
 
+                 ;; New cap fits the current occupancy: keep the slots,
+                 ;; write a full ring (a never-emitted frame gets a valid
+                 ;; empty ring instead of a partial map — finding 2).
                  :else
-                 (assoc-in rings [frame-id :cascades-retained] retained))))))
+                 (assoc rings frame-id
+                        {:cascades-retained retained
+                         :override?         true
+                         :cascade-order     order
+                         :cascades          cascades}))))))
   nil)
 
 (defn release-frame-ring!
@@ -205,15 +240,23 @@
       (when (and dispatch-id frame-id)
         (swap! trace-rings
                (fn [rings]
-                 (let [retained (effective-retained rings frame-id)]
+                 (let [retained  (effective-retained rings frame-id)
+                       override? (true? (get-in rings [frame-id :override?]))]
                    (if (zero? retained)
                      ;; Disabled-but-live: live stream still fires
                      ;; (push-to-ring! is one step in the pipeline);
-                     ;; just don't allocate.
-                     (assoc rings frame-id (empty-ring 0))
-                     (let [existing (get rings frame-id (empty-ring retained))
-                           order    (:cascade-order existing)
-                           cascades (:cascades existing)
+                     ;; just don't allocate. Preserve the override flag so
+                     ;; a 0-cap override survives a push attempt.
+                     (assoc rings frame-id (empty-ring 0 override?))
+                     (let [existing (get rings frame-id (empty-ring retained override?))
+                           ;; Defensive nil-coercion: a ring written before
+                           ;; this frame's first emit is now always complete
+                           ;; (set-frame-cascades-retained! writes a full
+                           ;; ring), but coerce anyway so any future partial
+                           ;; ring can't make `conj` build a list / `subvec`
+                           ;; throw (rf2-va65k finding 2).
+                           order    (or (:cascade-order existing) [])
+                           cascades (or (:cascades existing) {})
                            known?   (contains? cascades dispatch-id)
                            order'   (if known? order (conj order dispatch-id))
                            cascades' (update cascades dispatch-id
@@ -227,6 +270,7 @@
                                [o c]))]
                        (assoc rings frame-id
                               {:cascades-retained retained
+                               :override?         override?
                                :cascade-order     order''
                                :cascades          cascades''}))))))))))
 
@@ -540,8 +584,12 @@
     (swap! trace-rings
            (fn [rings]
              (if (contains? rings frame-id)
-               (let [retained (effective-retained rings frame-id)]
-                 (assoc rings frame-id (empty-ring retained)))
+               (let [retained  (effective-retained rings frame-id)
+                     ;; Preserve the override flag — emptying the buffer
+                     ;; must not silently downgrade an explicit per-frame
+                     ;; override to inherited (rf2-va65k).
+                     override? (true? (get-in rings [frame-id :override?]))]
+                 (assoc rings frame-id (empty-ring retained override?)))
                rings))))
   nil)
 
@@ -601,32 +649,43 @@
              (number? cascades-retained)
              (not (neg? cascades-retained)))
     (reset! process-cascades-retained cascades-retained)
-    ;; Apply the new default to any frame whose ring did not set its own
-    ;; per-frame retention — those frames inherit the default.
+    ;; Apply the new default to every frame whose cap was INHERITED
+    ;; (`:override? false`), retuning + trimming the already-allocated
+    ;; ring. Frames carrying an explicit per-frame override
+    ;; (`:override? true`) are left untouched. Keying on `:override?`
+    ;; (not the always-present `:cascades-retained` key) is the fix for
+    ;; rf2-va65k finding 1: every allocated ring stores
+    ;; `:cascades-retained`, so the old `(some? (get-in ... :cascades-retained))`
+    ;; guard was always true and silently skipped EVERY existing ring —
+    ;; lowering the default never trimmed an already-used inherited frame.
     (swap! trace-rings
            (fn [rings]
              (reduce-kv
               (fn [acc frame-id ring]
-                (let [own-set? (some? (get-in rings [frame-id :cascades-retained]))]
-                  (if own-set?
-                    acc
-                    (let [order   (:cascade-order ring)
-                          cascades (:cascades ring)]
-                      (cond
-                        (zero? cascades-retained)
-                        (assoc acc frame-id (empty-ring 0))
+                (if (true? (:override? ring))
+                  acc
+                  (let [order    (or (:cascade-order ring) [])
+                        cascades (or (:cascades ring) {})]
+                    (cond
+                      (zero? cascades-retained)
+                      (assoc acc frame-id (empty-ring 0))
 
-                        (> (count order) cascades-retained)
-                        (let [drop-n     (- (count order) cascades-retained)
-                              kept-order (subvec order drop-n)
-                              evicted    (subvec order 0 drop-n)]
-                          (assoc acc frame-id
-                                 {:cascades-retained cascades-retained
-                                  :cascade-order     kept-order
-                                  :cascades          (apply dissoc cascades evicted)}))
+                      (> (count order) cascades-retained)
+                      (let [drop-n     (- (count order) cascades-retained)
+                            kept-order (subvec order drop-n)
+                            evicted    (subvec order 0 drop-n)]
+                        (assoc acc frame-id
+                               {:cascades-retained cascades-retained
+                                :override?         false
+                                :cascade-order     kept-order
+                                :cascades          (apply dissoc cascades evicted)}))
 
-                        :else
-                        (assoc-in acc [frame-id :cascades-retained] cascades-retained))))))
+                      :else
+                      (assoc acc frame-id
+                             {:cascades-retained cascades-retained
+                              :override?         false
+                              :cascade-order     order
+                              :cascades          cascades})))))
               rings
               rings))))
   nil)

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -198,6 +198,95 @@
       (is (seq @recv)
           "live stream continues firing under cascades-retained 0"))))
 
+;; ---- 1e-bis. Re-configuring the process default retunes inherited rings ---
+;; (rf2-va65k finding 1)
+
+(deftest configure-lowers-already-used-inherited-frame
+  (testing "lowering the process default trims an ALREADY-USED inherited ring"
+    ;; The frame's ring is allocated (it emitted cascades) and inherits
+    ;; the process default — no per-frame override. Lowering the default
+    ;; afterwards must retune + trim it. The pre-fix bug: every allocated
+    ;; ring stores :cascades-retained, so the inherited/override guard was
+    ;; always true and configure! silently skipped this ring.
+    (rf/reg-event-db :ping (fn [db _] db))
+    (dotimes [_ 10] (rf/dispatch-sync [:ping]))
+    (is (= 10 (count (rf/trace-buffer :rf/default)))
+        ":rf/default retained all 10 cascades at the default cap")
+    (rf/configure! :trace-buffer {:cascades-retained 1})
+    (is (<= (count (rf/trace-buffer :rf/default)) 1)
+        "lowering the default trimmed the already-used inherited ring")
+    ;; A subsequent emit also respects the lowered cap.
+    (rf/dispatch-sync [:ping])
+    (is (<= (count (rf/trace-buffer :rf/default)) 1)
+        "post-reconfigure emits stay within the lowered cap")))
+
+(deftest configure-retunes-inherited-but-preserves-override
+  (testing "a re-configured default retunes inherited frames; explicit overrides survive"
+    (rf/configure! :trace-buffer {:cascades-retained 50})
+    ;; :tb/inherit takes the process default; :tb/pinned pins its own cap.
+    (rf/reg-frame :tb/inherit {:doc "inherits the default"})
+    (rf/reg-frame :tb/pinned  {:rf.trace/cascades-retained 8
+                               :doc "explicit per-frame override"})
+    (rf/reg-event-db :spam (fn [db _] db))
+    (dotimes [_ 10] (rf/dispatch-sync [:spam] {:frame :tb/inherit}))
+    (dotimes [_ 10] (rf/dispatch-sync [:spam] {:frame :tb/pinned}))
+    (is (= 10 (count (rf/trace-buffer :tb/inherit))))
+    (is (= 8  (count (rf/trace-buffer :tb/pinned)))
+        ":tb/pinned capped at its own override (8)")
+    ;; Lower the process default: inherited frame is retuned, override is not.
+    (rf/configure! :trace-buffer {:cascades-retained 2})
+    (is (<= (count (rf/trace-buffer :tb/inherit)) 2)
+        "inherited frame trimmed to the new default")
+    (is (= 8 (count (rf/trace-buffer :tb/pinned)))
+        "explicit per-frame override is NOT clobbered by the new default")))
+
+(deftest configure-zero-disables-inherited-ring-only
+  (testing "configure! 0 disables inherited rings but leaves overrides alone"
+    (rf/reg-frame :tb/inherit {:doc "inherits"})
+    (rf/reg-frame :tb/pinned  {:rf.trace/cascades-retained 4 :doc "override"})
+    (rf/reg-event-db :spam (fn [db _] db))
+    (dotimes [_ 6] (rf/dispatch-sync [:spam] {:frame :tb/inherit}))
+    (dotimes [_ 6] (rf/dispatch-sync [:spam] {:frame :tb/pinned}))
+    (rf/configure! :trace-buffer {:cascades-retained 0})
+    (is (= [] (rf/trace-buffer :tb/inherit))
+        "inherited ring disabled by the new 0 default")
+    (is (= 4 (count (rf/trace-buffer :tb/pinned)))
+        "override frame keeps its retained cascades")))
+
+;; ---- 1e-ter. Per-frame override registered BEFORE first emit -------------
+;; (rf2-va65k finding 2)
+
+(deftest per-frame-override-before-first-emit-does-not-crash
+  (testing "reg-frame with a low cap BEFORE first dispatch survives a cap-exceeding burst"
+    ;; Pre-fix: set-frame-cascades-retained! wrote a partial
+    ;; {:cascades-retained N} map (no :cascade-order). push-to-ring!
+    ;; started :cascade-order from nil → conj built a PersistentList →
+    ;; subvec threw ClassCastException once the cap was exceeded.
+    (rf/reg-frame :tb/early {:rf.trace/cascades-retained 3
+                             :doc "cap registered before first emit"})
+    (rf/reg-event-db :tb/ev (fn [db _] db))
+    ;; Four dispatches: the fourth pushes past the cap of 3.
+    (is (nil? (dotimes [_ 4] (rf/dispatch-sync [:tb/ev] {:frame :tb/early})))
+        "dispatch past the cap does not throw")
+    (let [cs (rf/trace-buffer :tb/early)]
+      (is (= 3 (count cs))
+          "ring caps at the per-frame override of 3")
+      ;; Oldest-first retained order: the FIRST cascade was evicted, so
+      ;; the three retained dispatch-ids are strictly increasing and the
+      ;; earliest retained is greater than the very first emitted id.
+      (let [ids (mapv :dispatch-id cs)]
+        (is (apply < ids) "retained cascades are in oldest-first order")
+        (is (= ids (vec (sort ids))) "oldest-first preserved after eviction")))))
+
+(deftest per-frame-override-zero-before-first-emit-disables-cleanly
+  (testing "a 0 per-frame override before first emit disables the ring without crashing"
+    (rf/reg-frame :tb/silent {:rf.trace/cascades-retained 0 :doc "disabled"})
+    (rf/reg-event-db :tb/ev (fn [db _] db))
+    (is (nil? (dotimes [_ 5] (rf/dispatch-sync [:tb/ev] {:frame :tb/silent})))
+        "dispatches against a 0-cap override frame do not throw")
+    (is (= [] (rf/trace-buffer :tb/silent))
+        "0-cap override retains nothing")))
+
 ;; ---- 1f. clear-trace-buffer! and frame-destroy --------------------------
 
 (deftest clear-trace-buffer-clears-only-the-named-frame


### PR DESCRIPTION
@
Fixes both correctness findings in bead rf2-va65k. Both live in the per-frame cascade-keyed trace rings (`implementation/core/src/re_frame/trace/tooling.cljc`).

**Shared root cause.** A ring stored only `:cascades-retained` (the live cap) with no way to tell an *explicit per-frame override* from an *inherited process default*. The fix adds an `:override?` flag to the ring shape and threads it through every ring-mutation site (`empty-ring`, `set-frame-cascades-retained!`, `push-to-ring!`, `clear-trace-buffer!`, `configure-trace-buffer!`).

## Findings — disposition

**Finding 1 (tooling.cljc:610, `configure-trace-buffer!`) — fixed.**
The inherited-vs-override guard was `(some? (get-in rings [frame-id :cascades-retained]))`. Every allocated ring stores `:cascades-retained`, so the guard was *always true* and `configure-trace-buffer!` silently skipped every existing ring — lowering the process default never trimmed an already-used inherited frame, leaving retention misleadingly high. Now keys on `:override?`: inherited rings are retuned + trimmed; explicit per-frame overrides are left untouched.

**Finding 2 (tooling.cljc:163, `set-frame-cascades-retained!`) — fixed.**
The `:else` branch wrote a partial `{:cascades-retained N}` map (no `:cascade-order` / `:cascades`) when registering a per-frame cap before first emit. `push-to-ring!` then started `:cascade-order` from nil, `conj` built a `PersistentList`, and `subvec` threw `ClassCastException` once the cap was exceeded. Now writes a complete ring; `push-to-ring!` also nil-coerces `:cascade-order`/`:cascades` defensively.

**Dedup vs rf2-x3m8c (#3302).** Confirmed both findings still open on current `main` after x3m8c merged. x3m8c reconciled the config *vocabulary* (`{:cascades-retained}` canonical, retired `{:depth}` rejected with `:rf.warning/trace-buffer-unrecognised-opts`) plus the frame-destroy/teardown findings — it did **not** touch the override-detection logic. No overlap.

## Regression coverage
Added to `trace_buffer_test.clj`:
- `configure-lowers-already-used-inherited-frame` — emit 10 cascades on `:rf/default`, `configure! {:cascades-retained 1}`, assert `<= 1` (finding 1 acceptance test).
- `configure-retunes-inherited-but-preserves-override` — inherited frame retuned, explicit override (8) preserved when default lowered to 2.
- `configure-zero-disables-inherited-ring-only` — `{:cascades-retained 0}` disables inherited ring, leaves override frame intact.
- `per-frame-override-before-first-emit-does-not-crash` — `reg-frame {:rf.trace/cascades-retained 3}` before first emit, dispatch 4×, assert no throw, count 3, oldest-first eviction (finding 2 acceptance test).
- `per-frame-override-zero-before-first-emit-disables-cleanly`.

Verified both acceptance tests **fail** with the pre-fix logic reintroduced (finding 1 → assertion fail; finding 2 → `PersistentList cannot be cast to IPersistentVector`).

## Quality gates
- `implementation/core` JVM (`clojure -M:test`): **916 tests, 4113 assertions, 0 failures, 0 errors**.
- `implementation` CLJS (`npm run test:cljs`): **5831 tests, 20657 assertions, 0 failures, 0 errors**.
- `check_doc_slugs.py`: not applicable — no spec/docs touched (core src + test only).

Lane: touches only `implementation/core/**`.
@