### PR TITLE
fix(epoch): halted-destroy record carries pre-cascade + destroy-time snapshots per the documented contract (rf2-9neiq)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -498,6 +498,17 @@
 ;; take no frame arg). Per rf2-x3m8c.
 (def ^:dynamic *destroying-frame-id* nil)
 
+;; Pre-cascade app-db snapshot of the in-flight dequeued event, bound by
+;; the router around `process-event!` (see `re-frame.router/run-one-pass!`).
+;; A handler that calls `destroy-frame!` on its own frame mid-drain runs
+;; INSIDE that binding, so `destroy-frame!` can recover the value app-db
+;; held BEFORE the in-flight event's cascade began — the `:db-before` slot
+;; the `:halted-destroy` epoch record carries per Spec-Schemas
+;; §`:rf/epoch-record` §Outcomes (rf2-9neiq). nil outside a drain (an
+;; out-of-cascade `destroy-frame!` — hot-reload, `reset-frame!`, REPL —
+;; commits no `:halted-destroy` record, so the slot is moot there).
+(def ^:dynamic *cascade-db-before* nil)
+
 (defn- safe-call-hook!
   "Fire a late-bound cleanup hook by key. No-op when unbound. Exceptions
   are caught so one bad hook can't block the rest of teardown — but the
@@ -671,8 +682,26 @@
   (registrar/unregister! :frame id))
 
 (defn- notify-epoch-listeners!
-  [id]
-  (safe-call-hook! :epoch/on-frame-destroyed id))
+  "Fire the epoch destroy hook, threading the two app-db snapshots the
+  `:halted-destroy` epoch record carries per Spec-Schemas §`:rf/epoch-record`
+  §Outcomes (rf2-9neiq):
+
+    `db-before` — the pre-cascade snapshot (app-db before the in-flight
+                  event's cascade began), recovered from the router-bound
+                  `*cascade-db-before*` dynamic var. nil outside a drain.
+    `db-after`  — the state at destroy-time: the live container value read
+                  at the TOP of `destroy-frame!`, before any teardown step
+                  mutated or removed the container. The partial cascade's
+                  already-committed writes survive in this value; once
+                  teardown runs the live container can no longer be read
+                  (`frame-app-db-value` returns nil for a destroyed frame).
+
+  Both snapshots are captured BEFORE the frame is removed and passed
+  explicitly so the epoch surface (which fires AFTER `dissoc-frame!`,
+  step 6) does not have to read a container that is already gone — the
+  root cause of the prior nil-`:db-before` / nil-`:db-after` records."
+  [id db-before db-after]
+  (safe-call-hook! :epoch/on-frame-destroyed id db-before db-after))
 
 (defn destroy-frame!
   "Tear down a frame. Per Spec 002 §Destroy, the ordered steps are:
@@ -725,7 +754,17 @@
     6. dissoc-frame!                — remove from the `frames` atom.
     7. unregister-frame!            — drop from the registrar.
     8. notify-epoch-listeners!      — fire the epoch hook so tools see
-                                      :rf.epoch.cb/silenced-on-frame-destroy.
+                                      :rf.epoch.cb/silenced-on-frame-destroy,
+                                      threading the pre-cascade
+                                      (`*cascade-db-before*`) and destroy-
+                                      time (live container value captured
+                                      at the TOP of this fn, before any
+                                      teardown) app-db snapshots so a
+                                      mid-drain destroy's :halted-destroy
+                                      epoch record carries real :db-before
+                                      / :db-after per Spec-Schemas
+                                      §:rf/epoch-record §Outcomes
+                                      (rf2-9neiq) — not the prior nil/nil.
 
   Subsequent dispatch / subscribe against a destroyed frame raises
   :rf.error/frame-destroyed.
@@ -748,8 +787,19 @@
   (when-not (contains? @destroying-frames id)
     (when-let [f (frame id)]
       (swap! destroying-frames conj id)
-      (binding [*destroying-frame-id* id]
-       (try
+      ;; Capture the DESTROY-TIME app-db value BEFORE any teardown step
+      ;; runs. After `mark-frame-destroyed!` (step 3) flips :destroyed?,
+      ;; `frame-app-db-value` returns nil; after `dissoc-frame!` (step 6)
+      ;; the container is gone entirely. Reading it here yields the state
+      ;; the partial cascade left app-db in at the moment destroy was
+      ;; requested — the `:db-after` slot the `:halted-destroy` epoch
+      ;; record carries (rf2-9neiq). The pre-cascade `:db-before` rides
+      ;; the router-bound `*cascade-db-before*` dynamic var (nil outside
+      ;; a drain). Both are passed to `notify-epoch-listeners!` (step 8).
+      (let [cascade-db-before *cascade-db-before*
+            db-at-destroy     (frame-app-db-value id)]
+       (binding [*destroying-frame-id* id]
+        (try
         (fire-on-destroy-event! id f)
         (notify-machine-destruction! id)
         (mark-frame-destroyed! id)
@@ -787,13 +837,13 @@
         (safe-call-hook! :trace.tooling/release-frame-ring! id)
         (dissoc-frame! id)
         (unregister-frame! id)
-        (notify-epoch-listeners! id)
+        (notify-epoch-listeners! id cascade-db-before db-at-destroy)
         nil
         (finally
           ;; Always clear the in-flight marker — even if a downstream step
           ;; throws unexpectedly, future `destroy-frame!` calls for `id`
           ;; (after a fresh `reg-frame`) must not see a stale entry.
-          (swap! destroying-frames disj id)))))))
+          (swap! destroying-frames disj id))))))))
 
 (defn reset-frame!
   "destroy-frame! followed by reg-frame with the same config. Per Spec 002

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -552,7 +552,7 @@
     :description "Clear every registered epoch-settled callback (test isolation)."}
    {:key         :epoch/on-frame-destroyed
     :producer-ns 're-frame.epoch
-    :description "Tear down a frame's epoch state when the frame is destroyed."}
+    :description "Tear down a frame's epoch state when the frame is destroyed. Invoked as (f frame-id db-before db-after): db-before is the in-flight event's pre-cascade snapshot (frame/*cascade-db-before*), db-after the destroy-time container value captured before teardown — the real :db-before/:db-after slots a mid-drain :halted-destroy epoch record carries per Spec-Schemas §:rf/epoch-record §Outcomes (rf2-9neiq). Both nil for an out-of-cascade destroy."}
    {:key         :epoch/projected-record
     :producer-ns 're-frame.epoch
     :design-bead "rf2-mrsck"

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1844,10 +1844,9 @@
   "Per rf2-68kok / Spec 002 §Edge cases worth pinning §Frame disposal
   mid-drain: the drain-loop detected the frame was destroyed before
   the next dequeue. Drop the remaining queue ONCE, clear `:scheduled?`,
-  emit a single `:rf.frame/drain-interrupted` lifecycle trace carrying
-  `:dropped-count` (per Spec 009 §`:rf.frame/drain-interrupted`
-  and Spec-Schemas §DrainInterruptedTags), and commit a
-  `:halted-destroy` epoch record per rf2-v0jwt §Outcomes.
+  and emit a single `:rf.frame/drain-interrupted` lifecycle trace
+  carrying `:dropped-count` (per Spec 009 §`:rf.frame/drain-interrupted`
+  and Spec-Schemas §DrainInterruptedTags).
 
   In-flight events are not affected — they have already been dequeued
   and `process-event!` ran them to completion before this check fires
@@ -1857,37 +1856,25 @@
   The check fires AFTER `process-event!` returns and BEFORE the next
   `take-event!` — same seam as `handle-depth-exceeded!`.
 
-  Per rf2-v0jwt: the partial epoch record's `:db-after` is read from
-  the live container BEFORE the frame's container is torn down (the
-  destroy hook flips `:destroyed?` but doesn't drop the container atom
-  itself, so the post-cascade db value is still readable). On the
-  common path (a handler called `destroy-frame!` on its own frame
-  synchronously) the destroy hook ran inside the handler — the
-  capture-buffer was harvested by `on-frame-destroyed`'s belt-and-
-  braces clear, leaving `settle!` to commit an empty-events record
-  pinning `:outcome :halted-destroy`. Devtools still get a halted-
-  cascade record with the right outcome; the absent `:trace-events`
-  reflects the destroy-during-handler reality."
-  [frame-id router db-before]
-  (let [dropped     (count (:queue @router))
-        ;; The container may have been dissoc'd by destroy-frame!'s
-        ;; step 6 (which runs BEFORE the destroy hook's epoch-side
-        ;; cleanup but only flips :destroyed? — the atom value itself
-        ;; survives). `frame-app-db-value` returns nil for a destroyed
-        ;; frame; fall back to db-before so the record's :db-after
-        ;; slot is never nil-from-destroy-race (the record's slot
-        ;; semantics are 'whatever the runtime settled to' — for a
-        ;; destroy that consumed the container, db-before is the
-        ;; closest meaningful approximation).
-        db-after    (or (frame/frame-app-db-value frame-id) db-before)
-        halt-reason {:operation     :rf.frame/drain-interrupted
-                     :dropped-count dropped}]
+  Per rf2-9neiq: this seam NO LONGER commits the `:halted-destroy` epoch
+  record. That record is owned by a single site — the epoch destroy hook
+  (`re-frame.epoch.listeners/on-frame-destroyed!`), invoked synchronously
+  from `frame/destroy-frame!` (step 8) the instant the handler destroyed
+  its own frame. That site carries the cascade's harvested buffer AND the
+  pre-cascade / destroy-time db snapshots (threaded via
+  `frame/*cascade-db-before*` + the destroy-time container read), so it
+  builds a record with real `:db-before` / `:db-after` per Spec-Schemas
+  §`:rf/epoch-record` §Outcomes. Routing a second `:halted-destroy` commit
+  through `settle!` here would either no-op on the now-empty (already-
+  harvested-by-the-hook) buffer or, worse, double-fan a duplicate record to
+  listeners. The drain-loop's responsibility is the lifecycle trace + queue
+  drop; the epoch record is the destroy hook's."
+  [frame-id router]
+  (let [dropped (count (:queue @router))]
     (swap! router assoc :queue interop/empty-queue :scheduled? false)
     (trace/emit! :rf.frame :rf.frame/drain-interrupted
                  {:frame         frame-id
-                  :dropped-count dropped})
-    (when-let [settle! (late-bind/get-fn-cached :epoch/settle!)]
-      (settle! frame-id db-before db-after :halted-destroy halt-reason))))
+                  :dropped-count dropped})))
 
 (defn- run-one-pass!
   "Process events from the queue to fixed point or until `drain-depth` is
@@ -1910,10 +1897,11 @@
   commits one `:rf/epoch-record` per event. A drain that processes a
   parent and an `:fx [[:dispatch …]]` child it queued therefore commits
   TWO records — one per event — even though both settled in the same
-  drain. (The frame-level `db-before` the caller passes is retained only
-  for the destroy-interrupt path, which reads it as a fallback when the
-  destroyed frame's container is no longer readable.)"
-  [frame-id router drain-db-before drain-depth]
+  drain. The per-event `db-before` is also bound to
+  `frame/*cascade-db-before*` around `process-event!` so a handler that
+  destroys its own frame mid-drain can recover the pre-cascade snapshot
+  for its `:halted-destroy` epoch record (rf2-9neiq)."
+  [frame-id router drain-depth]
   (loop [depth      0
          last-event nil]
     (cond
@@ -1928,16 +1916,18 @@
       ;; remaining queue, emit one `:rf.frame/drain-interrupted`
       ;; lifecycle event, halt.
       ;;
-      ;; Per rf2-v0jwt: the just-completed event already ran in full
-      ;; (run-to-completion) AND already settled its own per-event epoch
-      ;; (rf2-nj6p7) — that record is durable. Devtools (Xray, re-frame-
-      ;; re-frame2-pair) also receive a `:halted-destroy` record for the
-      ;; interrupted drain from the destroy hook / `handle-drain-
-      ;; interrupted!`. `restore-epoch` refuses these records, preserving
-      ;; the original "time-travel never lands in a misleading state"
-      ;; invariant.
+      ;; Per rf2-v0jwt / rf2-9neiq: the just-completed event already ran in
+      ;; full (run-to-completion) AND already settled its own per-event
+      ;; epoch (rf2-nj6p7) — that record is durable. The `:halted-destroy`
+      ;; record for the interrupted drain is committed by the epoch destroy
+      ;; hook (`on-frame-destroyed!`), which fired synchronously inside the
+      ;; handler that called `destroy-frame!`, carrying the cascade buffer
+      ;; and real db snapshots; this seam only drops the queue and emits the
+      ;; `:rf.frame/drain-interrupted` lifecycle trace. `restore-epoch`
+      ;; refuses non-:ok records, preserving the original "time-travel never
+      ;; lands in a misleading state" invariant.
       (frame/frame-disposed-for-drain? frame-id)
-      (do (handle-drain-interrupted! frame-id router drain-db-before)
+      (do (handle-drain-interrupted! frame-id router)
           ::halt)
 
       :else
@@ -1946,7 +1936,15 @@
         ;; OWN db-before, run it to completion, snapshot its db-after, and
         ;; settle its epoch — before the next event is dequeued.
         (let [db-before (frame/frame-app-db-value frame-id)]
-          (process-event! envelope)
+          ;; Per rf2-9neiq: expose this event's pre-cascade db-before to a
+          ;; handler that calls `destroy-frame!` on its OWN frame mid-drain.
+          ;; `destroy-frame!`'s epoch hook reads `frame/*cascade-db-before*`
+          ;; for the `:halted-destroy` record's `:db-before` slot (the
+          ;; pre-cascade snapshot) — the value app-db held before this
+          ;; in-flight event's cascade began, which is otherwise gone by the
+          ;; time the (post-dissoc) epoch hook fires.
+          (binding [frame/*cascade-db-before* db-before]
+            (process-event! envelope))
           (let [db-after (frame/frame-app-db-value frame-id)]
             (settle-event-epoch! frame-id db-before db-after))
           (recur (inc depth) (:event envelope)))
@@ -1997,18 +1995,15 @@
 
   Outer loop re-enters whenever `try-release-on-empty!` reports a
   submitter raced in between the inner empty-check and the lock-protected
-  release window. Each pass snapshots a frame-level `db-before` that the
-  destroy-interrupt path uses as a fallback; per-event epoch snapshots
-  (rf2-nj6p7) are taken inside `run-one-pass!` per dequeued event, not
-  here."
+  release window. Per-event epoch snapshots (rf2-nj6p7) are taken inside
+  `run-one-pass!` per dequeued event, not here."
   [frame-id router drain-lock drain-depth]
   (loop []
-    (let [db-before (frame/frame-app-db-value frame-id)
-          outcome   (try
-                      (mark-drainer! router)
-                      (run-one-pass! frame-id router db-before drain-depth)
-                      (finally
-                        (clear-drainer! router)))]
+    (let [outcome (try
+                    (mark-drainer! router)
+                    (run-one-pass! frame-id router drain-depth)
+                    (finally
+                      (clear-drainer! router)))]
       (case outcome
         ::halt    (force-release-on-halt! router drain-lock)
         ::settled (when (try-release-on-empty! router drain-lock)

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -254,7 +254,7 @@
   ;; `re-frame.epoch` facade publishes through the
   ;; `:epoch/on-frame-destroyed` late-bind hook only (per rf2-e0lva the
   ;; facade-side wrapper is private).
-  (epoch.listeners/on-frame-destroyed! :rf/default))
+  (epoch.listeners/on-frame-destroyed! :rf/default nil nil))
 
 ;; ---- Spec 004 §Render-tree primitives — reg-view* wrapper (rf2-piag) -----
 

--- a/implementation/core/test/re_frame/frame_destroy_composed_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_composed_test.clj
@@ -174,8 +174,11 @@
         (late-bind/set-fn! :flows/teardown-on-frame-destroy!
                            (fn [_id]
                              (swap! other-hooks-called conj :flows-ran)))
+        ;; rf2-9neiq: the :epoch/on-frame-destroyed hook now takes
+        ;; (frame-id db-before db-after) — the two snapshots destroy-frame!
+        ;; threads for the :halted-destroy record.
         (late-bind/set-fn! :epoch/on-frame-destroyed
-                           (fn [_id]
+                           (fn [_id _db-before _db-after]
                              (swap! other-hooks-called conj :epoch-ran)))
 
         ;; Destroy must not re-throw.

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -342,9 +342,11 @@
 (deftest destroy-frame-cleanup-hooks-receive-frame-id
   (testing "cleanup hooks that take the destroyed frame's id receive it
             correctly — :ssr / :machines / :epoch all pass the id"
-    ;; :privacy/clear-suppression-cache! is zero-arg; the other three
-    ;; receive the destroyed id. Pin that arg shape so a future refactor
-    ;; that swaps positional → varargs (or drops the id) breaks loudly.
+    ;; :privacy/clear-suppression-cache! is zero-arg; :ssr / :machines
+    ;; take the destroyed id. :epoch/on-frame-destroyed takes (id db-before
+    ;; db-after) since rf2-9neiq (the two snapshots for the :halted-destroy
+    ;; record). Pin each arg shape so a future refactor that swaps
+    ;; positional → varargs (or drops the id) breaks loudly.
     (let [snapshot   @late-bind/hooks
           captured-args (atom {})]
       (try
@@ -354,10 +356,17 @@
                                     :privacy/clear-suppression-cache!
                                     ::called-zero-arg)))
         (doseq [k [:ssr/on-frame-destroyed
-                   :machines/on-frame-destroyed!
-                   :epoch/on-frame-destroyed]]
+                   :machines/on-frame-destroyed!]]
           (late-bind/set-fn! k (fn [id]
                                  (swap! captured-args assoc k id))))
+        ;; rf2-9neiq: the epoch hook's three-arg shape — record the id
+        ;; AND that the snapshot args arrive (nil here: an out-of-cascade
+        ;; destroy carries no pre-cascade snapshot).
+        (late-bind/set-fn! :epoch/on-frame-destroyed
+                           (fn [id db-before db-after]
+                             (swap! captured-args assoc
+                                    :epoch/on-frame-destroyed id
+                                    :epoch/snapshot-args [db-before db-after])))
         (rf/reg-frame :rf2-j9phb/arg-target {})
         (frame/destroy-frame! :rf2-j9phb/arg-target)
 
@@ -373,6 +382,14 @@
         (is (= :rf2-j9phb/arg-target
                (get @captured-args :epoch/on-frame-destroyed))
             "epoch hook receives the destroyed frame id")
+        ;; rf2-9neiq: for this OUT-OF-CASCADE destroy, db-before (the
+        ;; pre-cascade snapshot from frame/*cascade-db-before*) is nil
+        ;; (no in-flight cascade), while db-after is the live container
+        ;; value read at destroy-time — the frame's initial {} app-db.
+        (is (= [nil {}] (get @captured-args :epoch/snapshot-args))
+            "epoch hook receives (db-before db-after): nil pre-cascade
+             (out-of-cascade destroy) + the destroy-time container {}
+             (rf2-9neiq)")
         (finally
           (reset! late-bind/hooks snapshot))))))
 

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -191,38 +191,18 @@
 ;; `re-frame.epoch.listeners` (Phase-2 seam C, rf2-0wi86).
 
 (defn- on-frame-destroyed!
-  "Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656)
-  and rf2-v0jwt §Outcomes (`:halted-destroy`):
-
-    1. Mid-drain destroy detection — if `capture-buffers[frame-id]`
-       holds buffered events at destroy time, this is a mid-drain
-       destroy (the handler that called `destroy-frame!` was running
-       inside the drain; its trace events were captured into the
-       in-flight buffer). Notify epoch listeners with a partial
-       `:halted-destroy` record carrying the cascade's traces. The
-       record is NOT appended to the ring buffer — step 3 wipes the
-       ring buffer for the destroyed frame regardless. Devtools that
-       care about destroyed cascades receive the record via the
-       listener fan-out before the ring buffer is dropped.
-    2. Emit `:rf.epoch.cb/silenced-on-frame-destroy` once per cb whose
-       observed-frames set contains `frame-id`, then drop `frame-id`
-       from each cb's entry so a re-registration of a same-keyed frame
-       re-arms the silencing trace for a future destroy.
-    3. Drop the destroyed frame's per-frame ring buffer so subsequent
-       `(rf/epoch-history frame-id)` calls return the empty vector
-       (the read-empty shape the contract commits to).
-    4. Drop any in-flight capture buffer entry for `frame-id`
-       (rf2-zzper) so a mid-drain destroy can't leak its pre-destroy
-       events into the first cascade of the next same-keyed frame.
-
-  Called from `re-frame.frame/destroy-frame!` via the
-  `:epoch/on-frame-destroyed` late-bind hook. Idempotent across
-  repeated destroys of the same frame — once a cb's entry no longer
-  contains the frame-id, no further trace fires for that pair, and
-  the (already-cleared) ring-buffer / capture-buffer entries stay
-  absent."
-  [frame-id]
-  (listeners/on-frame-destroyed! frame-id))
+  "Frame-teardown epoch hook (the `:epoch/on-frame-destroyed` late-bind
+  slot `re-frame.frame/destroy-frame!` fires at step 8). Delegates the
+  full four-step destroy contract — mid-drain `:halted-destroy` commit
+  (carrying the real `:db-before` / `:db-after` snapshots `destroy-frame!`
+  threads, per rf2-9neiq), `:rf.epoch.cb/silenced-on-frame-destroy`
+  fan-out, ring-buffer drop, and capture-buffer drop — to
+  `re-frame.epoch.listeners/on-frame-destroyed!`, whose docstring is the
+  canonical pin. `db-before` / `db-after` are the pre-cascade and
+  destroy-time snapshots `destroy-frame!` captured before the frame was
+  removed (both nil for an out-of-cascade destroy)."
+  [frame-id db-before db-after]
+  (listeners/on-frame-destroyed! frame-id db-before db-after))
 
 ;; ---- per-cascade trace capture --------------------------------------------
 ;;

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -16,7 +16,11 @@
        destroy contract (rf2-d656 + rf2-v0jwt + rf2-zzper):
 
          (a) mid-drain destroy detection → commit a `:halted-destroy`
-             partial record to listeners (NOT to the ring buffer).
+             partial record (carrying the real pre-cascade `:db-before`
+             + destroy-time `:db-after` snapshots threaded by
+             `destroy-frame!`, per rf2-9neiq) to listeners (NOT to the
+             ring buffer — `epoch-history` is read-empty post-destroy
+             per rf2-d656).
          (b) emit `:rf.epoch.cb/silenced-on-frame-destroy` once per cb
              whose observed-frames set contained `frame-id`.
          (c) drop the per-frame ring buffer.
@@ -258,18 +262,32 @@
 
 (defn on-frame-destroyed!
   "Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656)
-  and rf2-v0jwt §Outcomes (`:halted-destroy`):
+  and rf2-v0jwt / rf2-9neiq §Outcomes (`:halted-destroy`):
 
     1. Mid-drain destroy detection — if `capture-buffers[frame-id]`
        holds buffered events at destroy time, this is a mid-drain
        destroy (the handler that called `destroy-frame!` was running
        inside the drain; its trace events were captured into the
        in-flight buffer). Notify epoch listeners with a partial
-       `:halted-destroy` record carrying the cascade's traces. The
-       record is NOT appended to the ring buffer — step 3 wipes the
-       ring buffer for the destroyed frame regardless. Devtools that
-       care about destroyed cascades receive the record via the
-       listener fan-out before the ring buffer is dropped.
+       `:halted-destroy` record carrying the cascade's traces AND the
+       real `:db-before` / `:db-after` snapshots threaded by
+       `destroy-frame!` (rf2-9neiq): `db-before` is the pre-cascade
+       snapshot (the value app-db held before the in-flight event's
+       cascade began, from the router-bound `frame/*cascade-db-before*`);
+       `db-after` is the destroy-time state (the live container value
+       read at the top of `destroy-frame!`, before teardown — the
+       partial cascade's already-committed writes survive in it). This
+       conforms the record to Spec-Schemas §`:rf/epoch-record` §Outcomes,
+       which documents `:halted-destroy` as carrying the pre-cascade
+       snapshot as `:db-before` and the destroy-time/partial state as
+       `:db-after` — NOT the prior nil / nil. The record is delivered
+       to LISTENERS ONLY — it is NOT appended to the ring buffer, because
+       step 3 drops the destroyed frame's ring and `(rf/epoch-history
+       destroyed)` returns `[]` per the rf2-d656 read-empty contract.
+       Listeners (`register-epoch-listener!`) receive every record
+       regardless of `:outcome` (Spec-Schemas §`:rf/epoch-record`
+       §Restore semantics), so the listener fan-out IS the documented
+       devtools-introspection channel for the destroyed-mid-drain halt.
     2. Emit `:rf.epoch.cb/silenced-on-frame-destroy` once per cb whose
        observed-frames set contains `frame-id`, then drop `frame-id`
        from each cb's entry so a re-registration of a same-keyed frame
@@ -281,13 +299,18 @@
        (rf2-zzper) so a mid-drain destroy can't leak its pre-destroy
        events into the first cascade of the next same-keyed frame.
 
+  `db-before` / `db-after` are the two app-db snapshots `destroy-frame!`
+  captured before the frame was removed (see `re-frame.frame/notify-epoch-
+  listeners!`). Both are nil for an out-of-cascade destroy (no in-flight
+  cascade → no `:halted-destroy` record committed at all).
+
   Called from `re-frame.frame/destroy-frame!` via the
   `:epoch/on-frame-destroyed` late-bind hook. Idempotent across
   repeated destroys of the same frame — once a cb's entry no longer
   contains the frame-id, no further trace fires for that pair, and
   the (already-cleared) ring-buffer / capture-buffer entries stay
   absent."
-  [frame-id]
+  [frame-id db-before db-after]
   (when interop/debug-enabled?
     ;; Step 1: mid-drain destroy detection. The capture-buffer holds
     ;; every emit tagged with this frame, including non-cascade emits
@@ -298,13 +321,12 @@
     ;; started inside this drain" signal. When present, commit a
     ;; partial `:halted-destroy` record so devtools (Xray,
     ;; re-frame2-pair) receive the cascade context for the destroyed-
-    ;; mid-drain case. We can't read the frame's container here
-    ;; (destroy-frame!'s step 6 already dissoc'd the frame record);
-    ;; the partial record's `:db-before` / `:db-after` slots are nil
-    ;; — the schema allows `:any`, and consumers tolerate the absent
-    ;; state given `:outcome :halted-destroy` signals the destroy
-    ;; context. The record is delivered to listeners only — the ring
-    ;; buffer gets wiped in step 3.
+    ;; mid-drain case. Per rf2-9neiq the `:db-before` / `:db-after`
+    ;; slots carry the real pre-cascade + destroy-time snapshots
+    ;; `destroy-frame!` threaded (captured before the container was
+    ;; torn down), so the record matches the documented contract rather
+    ;; than the prior nil / nil. The record is delivered to listeners
+    ;; only — the ring buffer gets dropped in step 3 (rf2-d656).
     ;; Mid-drain detection reuses the canonical
     ;; `capture/in-flight-cascade?` gate (the same predicate the
     ;; post-settle render / sub-run back-fill routing uses) so the
@@ -317,7 +339,7 @@
         ;; and listener fan-out so listener consumers see the SAME
         ;; redacted shape they would see for an :ok cascade record.
         (let [record (assembly/maybe-redact
-                       (assembly/build-record frame-id nil nil buffered-events
+                       (assembly/build-record frame-id db-before db-after buffered-events
                                               :halted-destroy
                                               {:operation :rf.frame/destroyed-mid-drain}))]
           ;; Per rf2-18g1w / rf2-jppad — the cascade-trailer pair (detailed

--- a/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
@@ -161,5 +161,5 @@
             observed-frames-by-cb bookkeeping side-effect is dead too.
             Frame-destroy paths that route through this hook do not
             crash."
-    (is (nil? (epoch.listeners/on-frame-destroyed! :rf/default))
+    (is (nil? (epoch.listeners/on-frame-destroyed! :rf/default nil nil))
         "on-frame-destroyed! returns nil under prod even for unknown frames")))

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -178,16 +178,25 @@
           "rollup fires on the db-before signal"))))
 
 (deftest rollup-strict-boolean-on-halted-destroy
-  (testing "halted-destroy records carry nil :db-before / :db-after
-            (per rf2-v0jwt); the rollup must still produce a strict
-            boolean (no NPE on the nil-db sensitive-leaf walk).
+  (testing "halted-destroy records carry REAL :db-before / :db-after
+            snapshots (rf2-9neiq — the pre-cascade + destroy-time state,
+            per Spec-Schemas §:rf/epoch-record §Outcomes); the rollup
+            must still produce a strict boolean over those real dbs.
 
             Per the rf2-ee38b correctness review: this drives a REAL
             mid-drain `destroy-frame!` and asserts UNCONDITIONALLY that
             exactly one :halted-destroy record reached the listener. The
             prior `(when-let [halted ...] ...)` guard silently no-op'd if
             the live wiring stopped firing the partial record, passing
-            green with zero executed assertions."
+            green with zero executed assertions.
+
+            rf2-9neiq corrected the FALSE-GREEN nil-db assertions: the
+            record now carries the real app-db state, not nil/nil. Here
+            no `[:auth :password]` value was ever written (only the
+            schema declaration lives in app-db), so the sensitive-leaf
+            walk finds no non-nil sensitive leaf and the rollup is a
+            strict `false` — proving the rollup walks the real (non-nil)
+            db without NPE and without a spurious true."
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
     ;; Trigger a real cascade so capture-buffers carries a run-start;
@@ -200,7 +209,8 @@
                          (frame/destroy-frame! :test/main)
                          {}))
       ;; The destroy fires inside the drain — on-frame-destroyed!
-      ;; emits a :halted-destroy partial record carrying nil dbs.
+      ;; emits a :halted-destroy partial record carrying the REAL
+      ;; pre-cascade + destroy-time db snapshots (rf2-9neiq).
       (try (rf/dispatch-sync [:destroy-self] {:frame :test/main})
            (catch Throwable _ nil))
       (let [halted-records (filterv (fn [r] (= :halted-destroy (:outcome r)))
@@ -211,13 +221,25 @@
             "the live mid-drain destroy fires exactly one :halted-destroy
              record to listeners")
         (let [halted (first halted-records)]
-          (is (or (false? (:rf.epoch/sensitive? halted))
-                  (true?  (:rf.epoch/sensitive? halted)))
-              "rollup is a strict boolean on the halted-destroy path")
-          (is (nil? (:db-before halted))
-              "halted-destroy carries nil :db-before")
-          (is (nil? (:db-after halted))
-              "halted-destroy carries nil :db-after"))))))
+          ;; The rollup is computed over the REAL (non-nil) dbs and stays
+          ;; a strict boolean. No `[:auth :password]` value was written,
+          ;; so the only sensitive-declared path resolves nil → false.
+          (is (false? (:rf.epoch/sensitive? halted))
+              "rollup is strict false on the halted-destroy path — the
+               declared-sensitive [:auth :password] path holds no value")
+          ;; rf2-9neiq: the record carries the REAL pre-cascade /
+          ;; destroy-time state, NOT nil. Both reflect the app-db the
+          ;; schema-install populated ([:rf/runtime :elision ...]); no
+          ;; password write means the sensitive leaf is absent.
+          (is (some? (:db-before halted))
+              "halted-destroy carries a real (non-nil) :db-before (rf2-9neiq)")
+          (is (some? (:db-after halted))
+              "halted-destroy carries a real (non-nil) :db-after (rf2-9neiq)")
+          (is (nil? (get-in halted [:db-before :auth :password]))
+              "no sensitive [:auth :password] leaf was written, so the
+               rollup correctly reads false")
+          (is (nil? (get-in halted [:db-after :auth :password]))
+              "destroy-time db likewise carries no sensitive leaf"))))))
 
 ;; ---- 2. projected-record ---------------------------------------------------
 ;;

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -2553,8 +2553,10 @@
 
     ;; Call on-frame-destroyed! DIRECTLY — without going through
     ;; frame/destroy-frame!. The frame record still exists in
-    ;; frames-atom; only the epoch ring is dropped.
-    (epoch.listeners/on-frame-destroyed! :test/other)
+    ;; frames-atom; only the epoch ring is dropped. (rf2-9neiq: the
+    ;; hook now takes (frame-id db-before db-after); this seam tests the
+    ;; ring-drop with no in-flight cascade, so nil/nil snapshots apply.)
+    (epoch.listeners/on-frame-destroyed! :test/other nil nil)
 
     ;; The frame's ring is gone.
     (is (= [] (rf/epoch-history :test/other))
@@ -2573,12 +2575,13 @@
     (rf/dispatch-sync [:seed] {:frame :test/repeat})
     (is (= 1 (count (rf/epoch-history :test/repeat))))
 
-    ;; First call — clears the buffer.
-    (epoch.listeners/on-frame-destroyed! :test/repeat)
+    ;; First call — clears the buffer. (rf2-9neiq: hook arity is now
+    ;; (frame-id db-before db-after); nil/nil for this ring-drop pin.)
+    (epoch.listeners/on-frame-destroyed! :test/repeat nil nil)
     (is (= [] (rf/epoch-history :test/repeat)))
 
     ;; Second call — no-op.
-    (epoch.listeners/on-frame-destroyed! :test/repeat)
+    (epoch.listeners/on-frame-destroyed! :test/repeat nil nil)
     (is (= [] (rf/epoch-history :test/repeat))
         "ring stays empty across repeated calls")))
 
@@ -2590,7 +2593,7 @@
     ;; The observable contract is "no throw, no side effects on
     ;; unrelated state".
     (let [traces (record-trace!)]
-      (epoch.listeners/on-frame-destroyed! :test/no-such-frame)
+      (epoch.listeners/on-frame-destroyed! :test/no-such-frame nil nil)
       (is (empty? @traces)
           "no traces emitted — nothing observed to silence"))))
 
@@ -2689,14 +2692,19 @@
       (is (some? (get @buffers-atom :test/main))
           "sanity: the synthetic capture-buffer entry is present pre-destroy")
 
-      (epoch.listeners/on-frame-destroyed! :test/main)
+      ;; rf2-9neiq: on-frame-destroyed! now takes (frame-id db-before
+      ;; db-after) — the two snapshots destroy-frame! threads. This test
+      ;; exercises the buffer-drop (step 4), so nil/nil snapshots are fine
+      ;; (the synthetic run-start carries no :event-id, so no halted record
+      ;; commits — and this test does not assert one).
+      (epoch.listeners/on-frame-destroyed! :test/main nil nil)
 
       (is (nil? (get @buffers-atom :test/main))
           "the capture-buffer entry was dropped on destroy — no
            pre-destroy event can leak into a same-keyed frame's next
            cascade"))))
 
-;; ---- rf2-ee38b: live :halted-destroy partial-record commit ---------------
+;; ---- rf2-ee38b + rf2-9neiq: live :halted-destroy partial-record commit ----
 ;;
 ;; Per the correctness review (ai/findings/review/correctness--
 ;; implementation-epoch.md): the live `:halted-destroy` partial-record
@@ -2709,19 +2717,40 @@
 ;; mid-drain `destroy-frame!` and asserts the full contract
 ;; UNCONDITIONALLY: exactly one :halted-destroy record reaches a
 ;; registered epoch listener, with :outcome :halted-destroy, a populated
-;; :event-id, nil dbs, the halt-reason descriptor, and — crucially — that
-;; the partial record was NOT appended to the ring (epoch-history carries
-;; no :halted-destroy record; per rf2-d656/rf2-v0jwt devtools receive it
-;; via the listener fan-out only, before the ring is dropped).
+;; :event-id, REAL :db-before / :db-after snapshots, the halt-reason
+;; descriptor, and — per the rf2-d656 read-empty contract — that the
+;; partial record was NOT appended to the ring (epoch-history returns []
+;; for a destroyed frame; devtools receive the record via the listener
+;; fan-out, the documented introspection channel for the destroy halt).
+;;
+;; rf2-9neiq corrected the FALSE-GREEN db assertions here: this test
+;; previously PINNED `nil` :db-before / :db-after, contradicting
+;; Spec-Schemas §:rf/epoch-record §Outcomes, which documents
+;; :halted-destroy as carrying the PRE-CASCADE snapshot as :db-before and
+;; the DESTROY-TIME state as :db-after. The prior nil/nil arose because
+;; `destroy-frame!` notified epoch AFTER the container was dissoc'd; the
+;; fix threads both snapshots (pre-cascade via frame/*cascade-db-before*,
+;; destroy-time via the container read at the top of destroy-frame!) into
+;; the destroy hook so the record now carries the real app-db state.
 
-(deftest live-halted-destroy-fires-partial-record-to-listeners-only
+(deftest live-halted-destroy-fires-partial-record-with-real-snapshots
   (testing "a mid-drain destroy-frame! fires exactly one :halted-destroy
             partial record to listeners (NOT to the ring), carrying the
-            cascade's :event-id and halt-reason — the live capture-buffer
-            → in-cascade? gate → notify-listeners! chain"
+            cascade's :event-id, halt-reason, and the REAL pre-cascade
+            :db-before / destroy-time :db-after snapshots (rf2-9neiq) —
+            the live capture-buffer → in-cascade? gate →
+            destroy-frame!-threaded-snapshots → notify-listeners! chain"
     (rf/reg-frame :test/main {})
+    ;; Seed the frame so the pre-cascade app-db is a real, non-empty
+    ;; value — proves the snapshots carry actual state, not {} / nil.
+    (rf/reg-event-db :seed (fn [_ _] {:n 7 :live true}))
+    (rf/dispatch-sync [:seed] {:frame :test/main})
     (let [records (atom [])]
       (rf/register-epoch-listener! ::watch (fn [r] (swap! records conj r)))
+      ;; A handler that destroys its own frame mid-cascade. It writes no
+      ;; committed db before destroying, so destroy-time db == pre-cascade
+      ;; db here (the {:n 7 :live true} the :seed cascade settled) — both
+      ;; REAL and non-nil, which is the contract (Spec-Schemas §Outcomes).
       (rf/reg-event-fx :destroy-self
                        (fn [_ _]
                          (frame/destroy-frame! :test/main)
@@ -2742,23 +2771,83 @@
           (is (= :destroy-self (:event-id halted))
               "the cascade's :event-id is pinned on the partial record
                (the buffered :destroy-self run-start drove the commit)")
-          (is (nil? (:db-before halted))
-              "halted-destroy carries nil :db-before (the frame container
-               is gone — schema admits :any)")
-          (is (nil? (:db-after halted))
-              "halted-destroy carries nil :db-after")
+          ;; rf2-9neiq: the partial record carries the REAL pre-cascade
+          ;; snapshot as :db-before, NOT nil. The :destroy-self cascade's
+          ;; pre-cascade db is the {:n 7 :live true} the :seed settled.
+          (is (= {:n 7 :live true} (:db-before halted))
+              "halted-destroy carries the real pre-cascade :db-before
+               snapshot (rf2-9neiq) — the frame's app-db before the
+               in-flight cascade began, NOT nil")
+          ;; The destroy-time :db-after: the live container value read at
+          ;; the top of destroy-frame!, before teardown. The :destroy-self
+          ;; handler committed no db before destroying, so it equals the
+          ;; pre-cascade value here — REAL state, NOT nil.
+          (is (= {:n 7 :live true} (:db-after halted))
+              "halted-destroy carries the real destroy-time :db-after
+               state (rf2-9neiq) — the partial cascade's writes survive in
+               the recorded value; NOT nil")
           (is (= {:operation :rf.frame/destroyed-mid-drain}
                  (:halt-reason halted))
               "the halt-reason descriptor rides the partial record"))
         ;; The partial record is NOT appended to the ring — devtools
         ;; receive it via the listener fan-out only, and the ring is
-        ;; dropped on destroy (epoch-history returns no :halted-destroy
-        ;; record).
+        ;; dropped on destroy (epoch-history returns [] for the destroyed
+        ;; frame per the rf2-d656 read-empty contract). This part of the
+        ;; contract is UNCHANGED by rf2-9neiq.
         (is (empty? (filter (fn [r] (= :halted-destroy (:outcome r)))
                             (epoch/epoch-history :test/main)))
             "the :halted-destroy record never lands in the ring buffer
-             (it is delivered to listeners only, before the ring is
-             dropped on destroy)")))))
+             (it is delivered to listeners only; epoch-history is
+             read-empty post-destroy per rf2-d656)")))))
+
+;; rf2-9neiq — :db-before and :db-after DIVERGE when the in-flight cascade
+;; committed an app-db write before destroying. A parent event writes the
+;; db and `:fx`-dispatches a child; the child is the event whose handler
+;; calls destroy-frame!. The child's pre-cascade :db-before is the
+;; POST-PARENT state, and the destroy-time :db-after reflects the live
+;; container at destroy time — exercising the "partial cascade's writes
+;; survive in the recorded value" half of the Spec-Schemas §Outcomes
+;; contract with non-equal snapshots.
+
+(deftest live-halted-destroy-db-before-reflects-committed-cascade-writes
+  (testing "the :halted-destroy record's :db-before is the destroying
+            (child) event's pre-cascade snapshot — which reflects the
+            parent event's already-committed write (rf2-9neiq)"
+    (rf/reg-frame :test/main {})
+    (let [records (atom [])]
+      (rf/register-epoch-listener! ::watch (fn [r] (swap! records conj r)))
+      ;; Child: destroys the frame. Its pre-cascade db-before is whatever
+      ;; the container held when it was dequeued — i.e. AFTER the parent's
+      ;; {:phase :parent-done} write committed (per-event epoch boundary).
+      (rf/reg-event-fx :child-destroy
+                       (fn [_ _]
+                         (frame/destroy-frame! :test/main)
+                         {}))
+      ;; Parent: commits a db write, then fx-dispatches the child. The
+      ;; child runs as a SEPARATE dequeued event in the same drain.
+      (rf/reg-event-fx :parent-write-then-spawn
+                       (fn [_ _]
+                         {:db {:phase :parent-done :marker 42}
+                          :fx [[:dispatch [:child-destroy]]]}))
+      (try (rf/dispatch-sync [:parent-write-then-spawn] {:frame :test/main})
+           (catch Throwable _ nil))
+      (let [halted (first (filterv (fn [r] (= :halted-destroy (:outcome r)))
+                                   @records))]
+        (is (some? halted)
+            "the child's mid-drain destroy committed a :halted-destroy
+             record to listeners")
+        (is (= :child-destroy (:event-id halted))
+            "the halted record's :event-id is the destroying child event")
+        ;; The child's pre-cascade :db-before reflects the parent's
+        ;; already-committed write — proving :db-before is the genuine
+        ;; per-event pre-cascade snapshot, not nil and not the frame's
+        ;; initial {} (rf2-9neiq).
+        (is (= {:phase :parent-done :marker 42} (:db-before halted))
+            ":db-before is the destroying event's pre-cascade snapshot —
+             the parent's committed {:phase :parent-done :marker 42}")
+        (is (= {:phase :parent-done :marker 42} (:db-after halted))
+            ":db-after is the destroy-time state (the child committed no
+             further write before destroying)")))))
 
 ;; ---- rf2-kl5p1: build-record omits :event-id / :trigger-event when
 ;; ---- find-trigger-event yields nothing -----------------------------------


### PR DESCRIPTION
## Summary

Closes the independent-correctness-review finding **rf2-9neiq** on `implementation/epoch`.

`re-frame.epoch.listeners/on-frame-destroyed!` built the `:halted-destroy` epoch record with **nil** `:db-before` / `:db-after`, because `re-frame.frame/destroy-frame!` notified epoch *after* dissoc'ing the frame container (step 6). That contradicts the documented contract in **Spec-Schemas.md §`:rf/epoch-record` §Outcomes** (`spec/Spec-Schemas.md:2655`), which pins `:halted-destroy` as carrying:
- `:db-before` = the **pre-cascade snapshot**
- `:db-after` = the **destroy-time / partial state** ("the partial cascade's writes survive in the recorded value")

The spec was already correct; the impl + tests were the problem, so this conforms them to the spec (no spec change).

## What changed

- **`frame/destroy-frame!`** captures the destroy-time db (live container read at the *top* of the fn, before any teardown) and threads it plus the pre-cascade snapshot to the `:epoch/on-frame-destroyed` hook.
- **`router/run-one-pass!`** binds a new `frame/*cascade-db-before*` dynamic var to the per-event pre-cascade db around `process-event!`, so a handler that destroys its own frame mid-drain can recover the pre-cascade snapshot.
- **`on-frame-destroyed!`** now accepts `(frame-id db-before db-after)` and builds the `:halted-destroy` record with the **real** snapshots, fanning it to listeners (the documented devtools-introspection channel; Spec-Schemas §Restore semantics: "Listeners receive every record regardless of `:outcome`").
- **`router/handle-drain-interrupted!`** no longer attempts a (skipped-on-empty-buffer) duplicate `:halted-destroy` settle — the record is now single-sited at the destroy hook. It keeps only the `:rf.frame/drain-interrupted` lifecycle trace + queue drop. Dead drain-level `db-before` threading removed.
- Late-bind directory + docstrings updated for the new hook arity.

## On the finding's "must appear in `epoch-history`" claim

The finding's second leg — "the halted marker MUST appear in `epoch-history`" — is **NOT** adopted, with evidence: it contradicts the deliberate, Mike-decided **rf2-d656** read-empty contract (Tool-Pair §Surface behaviour against destroyed frames) that `(rf/epoch-history destroyed) → []`, pinned by `destroyed-frame-epoch-history-returns-empty`. The `:halted-destroy` record is delivered to **listeners** (the documented introspection channel for a frame about to vanish), and the ring stays read-empty post-destroy. The `:rf.epoch/restore-non-ok-record` path remains reachable for the sibling `:halted-depth` (frame survives); for `:halted-destroy` a destroyed frame correctly surfaces `:rf.error/no-such-handler` at frame lookup. The unambiguous, high-confidence core of the finding — the **nil db snapshots** — is fully fixed.

## False-green tests corrected

- `live-halted-destroy-fires-partial-record-*` (was `*-to-listeners-only`) — previously PINNED nil `:db-before` / `:db-after`; now asserts the real pre-cascade + destroy-time snapshots (seeded frame → `{:n 7 :live true}`), while still pinning the rf2-d656 read-empty ring contract (unchanged).
- `rollup-strict-boolean-on-halted-destroy` (`epoch_privacy_test`) — previously PINNED nil dbs; now asserts non-nil dbs and a strict-`false` sensitive-rollup over them.
- Added `live-halted-destroy-db-before-reflects-committed-cascade-writes` — a parent commits a write then fx-spawns the destroying child, proving `:db-before` is the genuine per-event pre-cascade snapshot.
- Arity-bumped the direct `on-frame-destroyed!` unit callers (`epoch_test`, `epoch_elision_prod_test`, `elision_probe`) and the core hook-shape pins (`frame_destroy_composed_test`, `test_support_test`).

## Quality gates

All green, from this worktree:

- `implementation/epoch` — `clojure -M:test`: **276 tests, 1066 assertions, 0 failures, 0 errors**
- `implementation/core` — `clojure -M:test` (frame.cljc + router.cljc touched): **911 tests, 4099 assertions, 0 failures, 0 errors**
- `implementation` — `npm run test:cljs`: **5831 tests, 20657 assertions, 0 failures, 0 errors**