### PR TITLE
fix(scripts): release-bundle gates fail on present-but-empty (zero-byte) output + findings 2-3 (rf2-utvst)

### DIFF
--- a/implementation/scripts/_read-release-bundle.test.cjs
+++ b/implementation/scripts/_read-release-bundle.test.cjs
@@ -41,6 +41,7 @@ const path = require('path');
 const {
   readReleaseBlob,
   listReleaseJsFiles,
+  classifyReleaseBundle,
   escapeRe,
   countMatches,
   countSubstring,
@@ -155,7 +156,69 @@ test('readReleaseBlob returns "" for a present dir with no *.js (distinct from m
   const dir = makeBundleDir({ 'manifest.edn': '{}' });
   // Present-but-empty is a real, non-null state: the dir exists, the
   // release simply emitted no JS. Distinct from the null missing-dir case.
+  // NOTE: this is the low-level reader's contract; gates MUST NOT branch
+  // on this alone — they use classifyReleaseBundle to reject the empty
+  // case (rf2-utvst non-vacuous floor) so an empty bundle is not a
+  // vacuous GREEN. See the classifyReleaseBundle tests below.
   assert.equal(readReleaseBlob(dir), '');
+});
+
+// ----- classifyReleaseBundle (rf2-utvst non-vacuous floor) -------------------
+
+test('classifyReleaseBundle reports status "missing" for a missing dir', () => {
+  const c = classifyReleaseBundle(missingDir());
+  assert.equal(c.status, 'missing');
+  assert.equal(c.files, null);
+  assert.equal(c.blob, null);
+});
+
+test('classifyReleaseBundle reports status "empty" for a present dir with no *.js', () => {
+  // The false-GREEN class: a present `out/examples/counter` with no
+  // top-level JS (release emitted nothing, or a stale empty dir was left
+  // behind). Gates branching only on missing-dir would pass this dir
+  // through every sentinel-absence check vacuously.
+  const dir = makeBundleDir({ 'manifest.edn': '{}' });
+  const c = classifyReleaseBundle(dir);
+  assert.equal(c.status, 'empty');
+  assert.deepEqual(c.files, []);
+  assert.equal(c.blob, '');
+});
+
+test('classifyReleaseBundle reports status "empty" when every top-level *.js is zero-byte', () => {
+  // A present dir whose only top-level JS files carry no content is just
+  // as vacuous as a dir with no JS at all — the bundle did not build.
+  const dir = makeBundleDir({ 'main.js': '', 'cljs_base.js': '' });
+  const c = classifyReleaseBundle(dir);
+  assert.equal(c.status, 'empty');
+  assert.equal(c.files.length, 2);
+  assert.equal(c.blob.trim(), '');
+});
+
+test('classifyReleaseBundle reports status "empty" when top-level *.js is whitespace-only', () => {
+  const dir = makeBundleDir({ 'main.js': '   \n\t \n' });
+  const c = classifyReleaseBundle(dir);
+  assert.equal(c.status, 'empty');
+});
+
+test('classifyReleaseBundle reports status "ok" for a real bundle (non-empty top-level *.js)', () => {
+  const dir = makeBundleDir({ 'main.js': 'RELEASE_TOKEN();' });
+  const c = classifyReleaseBundle(dir);
+  assert.equal(c.status, 'ok');
+  assert.equal(c.files.length, 1);
+  assert.equal(c.blob.includes('RELEASE_TOKEN'), true);
+});
+
+test('classifyReleaseBundle ignores stale cljs-runtime dev sources when deciding ok/empty (rf2-z9a06)', () => {
+  // The only top-level JS is empty, but a stale cljs-runtime/ dev source
+  // has content. The classifier must still report "empty" — the release
+  // artefact is the top-level JS, not the recursively-walked dev tree.
+  const dir = makeBundleDir({
+    'main.js': '',
+    'cljs-runtime/re_frame.core.js': 'DEV_ONLY_CONTENT();',
+  });
+  const c = classifyReleaseBundle(dir);
+  assert.equal(c.status, 'empty', 'stale dev sources must not rescue an empty release artefact');
+  assert.equal(c.blob.includes('DEV_ONLY_CONTENT'), false);
 });
 
 // ----- escapeRe --------------------------------------------------------------

--- a/implementation/scripts/_script-spawn-policy.test.cjs
+++ b/implementation/scripts/_script-spawn-policy.test.cjs
@@ -191,6 +191,38 @@ test('serve-and-run-xray-feature-gate.cjs resolves shadow-cljs runner + spawns i
   assert.match(src, /spawnSync\(\s*process\.execPath,\s*args/);
 });
 
+// Loopback-bind policy (rf2-utvst): every implementation http-server
+// launcher only ever serves a loopback consumer (the readiness probe +
+// the headless browser both hit 127.0.0.1), so each must spawn
+// http-server with an explicit `-a 127.0.0.1` rather than relying on
+// http-server's broad 0.0.0.0 default — otherwise the generated app
+// bundle and the per-run `.rf-harness-token` endpoint are reachable on
+// non-loopback interfaces during a test run. This mirrors the examples-
+// side guard in _story-script-runners-policy.test.cjs (rf2-wf5al.2). The
+// regex matches the http-server bin token followed (within a short
+// window) by the `'-a', '127.0.0.1'` pair. NB `[\s\S]{0,80}?` not `[^]`
+// (the JS-regex `[^]`-any-char gotcha).
+const LOOPBACK_BIND_RE =
+  /HTTP_SERVER_BIN,[\s\S]{0,80}?['"]-a['"]\s*,\s*['"]127\.0\.0\.1['"]/;
+const IMPL_LOOPBACK_LAUNCHERS = [
+  'serve-and-run-browser-tests.cjs',
+  'check-story-static.cjs',
+  'serve-and-run-xray-feature-gate.cjs',
+];
+for (const base of IMPL_LOOPBACK_LAUNCHERS) {
+  test(`${base}: http-server is bound to 127.0.0.1 explicitly (rf2-utvst)`, () => {
+    const src = fs.readFileSync(path.join(SCRIPTS_DIR, base), 'utf8');
+    assert.match(
+      src,
+      LOOPBACK_BIND_RE,
+      `${base} must spawn http-server with '-a', '127.0.0.1' (loopback only) — ` +
+        `http-server's default is 0.0.0.0, and this launcher only ever serves ` +
+        `127.0.0.1 (readiness probe + headless browser). Match ` +
+        `serve-and-run-examples-tests.cjs.`,
+    );
+  });
+}
+
 // stripComments sanity: it must remove a forbidden token that appears
 // only in a comment, but keep one that appears in real code. Guards the
 // gate itself against false-negatives (a comment masking a live spawn)

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/doc_guide_check.clj
@@ -24,13 +24,24 @@
 
 (def ^:private core-ns "re-frame.core")
 
+(def ^:private min-references
+  "Non-vacuous floor (rf2-utvst). The guide carries ~504 live `(rf/<var>`
+   references across ~30 chapters; this floor sits an order of magnitude
+   below that, so it trips only on a near-total collapse (the guide dir
+   moved, the `(rf/<var>` extraction broke, the alias convention changed) —
+   the cases that would otherwise turn the gate into a vacuous green —
+   never on ordinary content churn."
+  100)
+
 (defn check!
   []
   (let [rows      (proj/manifest-rows)
         core-vars (set (map :var (proj/rows-in-ns rows core-ns)))
         allow     (set (:doc-guide-known-unmanifested (gen/read-sidecar)))
         dir       (proj/repo-file "docs" "guide")
-        files     (proj/markdown-files dir)
+        ;; require-markdown-files (rf2-utvst): fail loudly if docs/guide/
+        ;; moves or is renamed, rather than silently checking zero files.
+        files     (proj/require-markdown-files "docs/guide/" dir)
         results   (for [file files
                         ref  (proj/alias-call-references "rf" (proj/numbered-lines file))]
                     (assoc ref :file (proj/repo-relative file)))
@@ -40,7 +51,7 @@
                             {:file file :line line :raw raw
                              :detail "no re-frame.core manifest row"}))
                         results)]
-    (proj/report-result! "docs/guide/" (count results) problems)))
+    (proj/report-with-floor! "docs/guide/" (count results) min-references problems)))
 
 (defn -main [& _]
   (System/exit (if (check!) 0 1)))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/projection.clj
@@ -79,7 +79,13 @@
 
 (defn markdown-files
   "Every `*.md` file under `dir` (an `io/file`), recursively, sorted by
-   path for deterministic reporting. Skips a missing dir (returns nil)."
+   path for deterministic reporting. Skips a missing dir (returns nil).
+
+   NB (rf2-utvst): a `nil` return is INDISTINGUISHABLE from a present-but-
+   empty dir, and silently produces zero work in the downstream check —
+   a directory move / rename then turns the projection gate into a
+   vacuous green. Callers that own an EXPECTED directory must use
+   `require-markdown-files` instead, which fails loudly on a missing dir."
   [dir]
   (when (.isDirectory ^java.io.File dir)
     (->> (file-seq dir)
@@ -95,6 +101,27 @@
       (.relativize (.toPath file))
       str
       (str/replace "\\" "/")))
+
+(defn require-markdown-files
+  "Like `markdown-files`, but throws when `dir` does not exist or is not a
+   directory (rf2-utvst non-vacuous floor). A check that owns an EXPECTED
+   surface directory (skills/, docs/guide/) must fail loudly when that
+   directory moves or is renamed rather than silently checking zero files
+   and reporting a vacuous OK. `label` names the surface for the error."
+  [label dir]
+  (when-not (.isDirectory ^java.io.File dir)
+    ;; Render the dir relative-to-repo-root for the message, but never let
+    ;; the diagnostic itself throw (a non-relativizable path falls back to
+    ;; the raw path string).
+    (let [shown (try (repo-relative dir) (catch Exception _ (str dir)))]
+      (throw (ex-info
+               (format (str "%s: expected directory is missing — %s. The "
+                            "projection gate cannot run against a non-existent "
+                            "surface (a moved/renamed dir would otherwise pass "
+                            "vacuously). Reconcile the surface path.")
+                       label shown)
+               {:label label :dir (str dir)}))))
+  (markdown-files dir))
 
 ;; ---------------------------------------------------------------------------
 ;; Reference extraction.
@@ -208,3 +235,37 @@
           (doseq [{:keys [file line raw detail]} problems]
             (println (format "  %s:%d  `%s`  %s" file line raw detail))))
         false)))
+
+(defn vacuity-floor-problem
+  "Return a problem-map describing a non-vacuous-floor violation when
+   `checked` (the number of public-var references the extractor actually
+   reconciled) is below `min-refs`, else nil (rf2-utvst).
+
+   A projection check reports OK whenever its problem list is empty — even
+   if it extracted ZERO references. A docs/skills directory move, a markdown
+   table-shape change, an alias-convention change, or parser drift can
+   silently drop the extracted-reference count toward 0 and turn the gate
+   into a vacuous green: stale public-API references would no longer be
+   reconciled against the manifest. `min-refs` is a deliberately low floor —
+   set well below the current live count — so it trips ONLY on a near-total
+   collapse (the vacuous-green class), never on ordinary content churn."
+  [label checked min-refs]
+  (when (< checked min-refs)
+    {:file  "(extractor)"
+     :line  0
+     :raw   (format "%d reference(s) extracted" checked)
+     :detail (format (str "below the non-vacuous floor of %d for %s — the "
+                          "extractor reconciled almost nothing, so an OK "
+                          "verdict would be vacuous. Likely a moved/renamed "
+                          "surface dir, a table-shape/alias-convention change, "
+                          "or parser drift. Investigate before trusting GREEN.")
+                     min-refs label)}))
+
+(defn report-with-floor!
+  "Like `report-result!`, but first enforces a non-vacuous floor: if fewer
+   than `min-refs` references were reconciled, prepend a floor-violation
+   problem so the gate goes RED even when the (possibly empty) `problems`
+   seq would otherwise report a vacuous OK (rf2-utvst)."
+  [label checked min-refs problems]
+  (let [floor (vacuity-floor-problem label checked min-refs)]
+    (report-result! label checked (if floor (cons floor problems) problems))))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/skills_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/skills_check.clj
@@ -37,6 +37,15 @@
    by design)."
   "skills/re-frame-migration")
 
+(def ^:private min-references
+  "Non-vacuous floor (rf2-utvst). The skills tree carries ~505 live
+   `(rf/<var>` references across ~127 checked `*.md` files; this floor sits
+   an order of magnitude below that, so it trips only on a near-total
+   collapse (the skills dir moved, the `(rf/<var>` extraction broke, the
+   alias convention changed) — the cases that would otherwise turn the gate
+   into a vacuous green — never on ordinary content churn."
+  100)
+
 (defn check!
   []
   (let [rows      (proj/manifest-rows)
@@ -45,7 +54,9 @@
         core-vars (set (map :var (proj/rows-in-ns rows core-ns)))
         allow     (set (:skills-known-unmanifested (gen/read-sidecar)))
         dir       (proj/repo-file "skills")
-        files     (->> (proj/markdown-files dir)
+        ;; require-markdown-files (rf2-utvst): fail loudly if skills/ moves
+        ;; or is renamed, rather than silently checking zero files.
+        files     (->> (proj/require-markdown-files "skills/" dir)
                        (remove #(str/includes?
                                  (str/replace (proj/repo-relative %) "\\" "/")
                                  excluded-skill-dir)))
@@ -58,7 +69,8 @@
                             {:file file :line line :raw raw
                              :detail "no re-frame.core manifest row"}))
                         results)]
-    (proj/report-result! "skills/ (excl. re-frame-migration)" (count results) problems)))
+    (proj/report-with-floor! "skills/ (excl. re-frame-migration)"
+                             (count results) min-references problems)))
 
 (defn -main [& _]
   (System/exit (if (check!) 0 1)))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/story_spec_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/story_spec_check.clj
@@ -23,6 +23,15 @@
 
 (def ^:private story-ns "re-frame.story")
 
+(def ^:private min-var-rows
+  "Non-vacuous floor (rf2-utvst). tools/story/spec/API.md carries ~65
+   back-ticked-identifier var-rows; this floor sits well below that, so it
+   trips only when the table shape changes (the first-cell back-ticked-
+   identifier discriminator stops matching) or the doc is gutted — the
+   cases that would turn the gate into a vacuous green — never on ordinary
+   row churn."
+  20)
+
 (defn check!
   []
   (let [rows       (proj/manifest-rows)
@@ -37,7 +46,8 @@
                              {:file rel :line line :raw var
                               :detail "no re-frame.story manifest row"}))
                          var-rows)]
-    (proj/report-result! "tools/story/spec/API.md" (count var-rows) problems)))
+    (proj/report-with-floor! "tools/story/spec/API.md"
+                             (count var-rows) min-var-rows problems)))
 
 (defn -main [& _]
   (System/exit (if (check!) 0 1)))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/xray_spec_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/xray_spec_check.clj
@@ -52,6 +52,15 @@
 
 (def ^:private xray-ns-prefix "day8.re-frame2-xray.")
 
+(def ^:private min-references
+  "Non-vacuous floor (rf2-utvst). tools/xray/spec/API.md carries ~23 live
+   references (qualified panel symbols + bare `mount-*!` names); this floor
+   sits below that, so it trips only when the extraction collapses (the
+   `day8.re-frame2-xray.*/` symbol shape or the `mount-<panel>!` pattern
+   stops matching, or the spec is gutted) — the cases that would turn the
+   gate into a vacuous green — never on ordinary panel churn."
+  8)
+
 (def ^:private mount-fn-re
   "The `mount-<panel>!` aggregator family the spec names as the mountable-
    panel contract (007-UX-IA §Mountable panel contract)."
@@ -119,9 +128,10 @@
                                     :qualified-allow qualified-allow
                                     :bare-allow      bare-allow
                                     :rel             rel})]
-    (proj/report-result! "tools/xray/spec/API.md"
-                         (+ (count qualified-refs) (count bare-refs))
-                         problems)))
+    (proj/report-with-floor! "tools/xray/spec/API.md"
+                             (+ (count qualified-refs) (count bare-refs))
+                             min-references
+                             problems)))
 
 (defn -main [& _]
   (System/exit (if (check!) 0 1)))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/projection_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/projection_test.clj
@@ -1,0 +1,56 @@
+(ns re-frame.api-manifest.projection-test
+  "Regression tests for the projection non-vacuous floors (rf2-utvst).
+
+  The vacuity class: a projection check reports OK whenever its problem
+  list is empty — even if it reconciled ZERO references. A docs/skills
+  directory move, a markdown table-shape change, an alias-convention
+  change, or parser drift can silently drop the extracted-reference count
+  toward 0 and turn the gate into a vacuous green: stale public-API
+  references would no longer be reconciled against the manifest.
+
+  These tests pin (1) `vacuity-floor-problem` synthesises a problem when
+  `checked` is below the floor and nil otherwise, (2) `report-with-floor!`
+  goes RED on a sub-floor count even with an empty problem list, and (3)
+  `require-markdown-files` throws (rather than returning nil) for a missing
+  directory so a moved/renamed surface fails loudly."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.api-manifest.projection :as proj]))
+
+(deftest vacuity-floor-problem-trips-below-floor
+  (testing "checked below the floor synthesises a floor-violation problem"
+    (let [p (proj/vacuity-floor-problem "skills/" 0 100)]
+      (is (some? p))
+      (is (= "(extractor)" (:file p)))
+      (is (re-find #"below the non-vacuous floor of 100" (:detail p)))))
+  (testing "checked just below the floor still trips"
+    (is (some? (proj/vacuity-floor-problem "skills/" 99 100))))
+  (testing "checked AT or ABOVE the floor does not trip"
+    (is (nil? (proj/vacuity-floor-problem "skills/" 100 100)))
+    (is (nil? (proj/vacuity-floor-problem "skills/" 505 100)))))
+
+(deftest report-with-floor-goes-red-on-vacuous-empty
+  (testing "an empty problem list with a sub-floor count is RED (the bug)"
+    ;; The vacuous-green case: zero problems found because zero references
+    ;; were extracted. Must be a FALSE verdict, not a vacuous OK.
+    (is (false? (proj/report-with-floor! "skills/" 0 100 []))))
+  (testing "an empty problem list ABOVE the floor is GREEN"
+    (is (true? (proj/report-with-floor! "skills/" 505 100 []))))
+  (testing "a real drift problem is RED regardless of the floor"
+    (is (false? (proj/report-with-floor!
+                  "skills/" 505 100
+                  [{:file "skills/x.md" :line 1 :raw "rf/gone" :detail "no row"}])))))
+
+(deftest require-markdown-files-throws-on-missing-dir
+  (testing "a missing/renamed surface dir throws (does NOT return nil)"
+    ;; An absolute path under the repo root, as real callers pass via
+    ;; repo-file — a moved/renamed surface dir.
+    (let [absent (proj/repo-file (str "definitely-missing-surface-"
+                                      (System/currentTimeMillis)))]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #"expected directory is missing"
+            (proj/require-markdown-files "skills/" absent)))))
+  (testing "an existing dir returns its markdown files (delegates to markdown-files)"
+    ;; The committed skills/ surface exists and carries many *.md files.
+    (let [files (proj/require-markdown-files "skills/" (proj/repo-file "skills"))]
+      (is (pos? (count files))))))

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -45,7 +45,7 @@
 const path = require('path');
 const { createGateReporter } = require('./lib/gate-report.cjs');
 const {
-  readReleaseBlob,
+  classifyReleaseBundle,
   countMatches,
   countSubstring,
 } = require('./lib/read-release-bundle.cjs');
@@ -574,12 +574,23 @@ function main() {
   report.detail('=== Bundle isolation: counter example (rf2-51x5) ===');
 
   const bundleDir = path.join(ROOT, 'out', 'examples', 'counter');
-  const blob = readReleaseBlob(bundleDir);
+  const { status, blob } = classifyReleaseBundle(bundleDir);
 
-  if (blob == null) {
+  if (status !== 'ok') {
     report.flushDetails();
-    console.error(`[bundle-isolation] bundle path missing — ${bundleDir}`);
-    console.error('                   Did you run "shadow-cljs release examples/counter"?');
+    if (status === 'empty') {
+      // Non-vacuous floor (rf2-utvst): a present-but-empty output dir
+      // satisfies every absence check and would false-GREEN. Reject it.
+      console.error(`[bundle-isolation] bundle present but empty (zero top-level JS) — ${bundleDir}`);
+      console.error('                   The release emitted no inspectable bundle, so the');
+      console.error('                   sentinel-absence checks would pass vacuously. A clean');
+      console.error('                   release must produce top-level *.js with real content.');
+      console.error('                   Did "shadow-cljs release examples/counter" actually build,');
+      console.error('                   or is this a stale empty out/ dir?');
+    } else {
+      console.error(`[bundle-isolation] bundle path missing — ${bundleDir}`);
+      console.error('                   Did you run "shadow-cljs release examples/counter"?');
+    }
     process.exit(1);
   }
 

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -35,7 +35,7 @@
 const fs   = require('fs');
 const path = require('path');
 const { createGateReporter } = require('./lib/gate-report.cjs');
-const { readReleaseBlob } = require('./lib/read-release-bundle.cjs');
+const { classifyReleaseBundle } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const report = createGateReporter();
@@ -431,11 +431,21 @@ const DEV_ONLY_SENTINELS = [
 // only; a stale dev-build `cljs-runtime/` subdir is skipped.
 
 function checkBundle(label, bundlePath, mustContain) {
-  const blob = readReleaseBlob(bundlePath);
-  if (blob == null) {
+  const { status, blob } = classifyReleaseBundle(bundlePath);
+  if (status === 'missing') {
     console.error(`[elision] ${label}: bundle path missing — ${bundlePath}`);
     console.error('         Did you run "shadow-cljs release elision-probe"?');
     return { ok: false, checked: 0, passed: 0, bytes: null, missing: true };
+  }
+  if (status === 'empty') {
+    // Non-vacuous floor (rf2-utvst): a present-but-empty bundle satisfies
+    // every sentinel-absence check and would false-GREEN the production
+    // elision assertion.
+    console.error(`[elision] ${label}: bundle present but empty (zero top-level JS) — ${bundlePath}`);
+    console.error('         The release emitted no inspectable bundle; an empty bundle');
+    console.error('         proves only that nothing got elided-checked. Rebuild with');
+    console.error('         "shadow-cljs release elision-probe" or clear the stale dir.');
+    return { ok: false, checked: 0, passed: 0, bytes: 0, empty: true };
   }
   report.detail(`[elision] ${label}: ${bundlePath}`);
   report.detail(`          bundle size: ${blob.length} chars`);

--- a/implementation/scripts/check-perf-bundle.cjs
+++ b/implementation/scripts/check-perf-bundle.cjs
@@ -32,7 +32,7 @@
 
 const path = require('path');
 const { createGateReporter } = require('./lib/gate-report.cjs');
-const { readReleaseBlob } = require('./lib/read-release-bundle.cjs');
+const { classifyReleaseBundle } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const report = createGateReporter();
@@ -66,11 +66,21 @@ const PERF_SENTINELS = [
 // only; a stale dev-build `cljs-runtime/` subdir is skipped.
 
 function checkBundle(label, bundlePath, mustContain) {
-  const blob = readReleaseBlob(bundlePath);
-  if (blob == null) {
+  const { status, blob } = classifyReleaseBundle(bundlePath);
+  if (status === 'missing') {
     console.error(`[perf-bundle] ${label}: bundle path missing — ${bundlePath}`);
     console.error('              Did you run the matching shadow-cljs release?');
     return { ok: false, checked: 0, passed: 0, bytes: null, missing: true };
+  }
+  if (status === 'empty') {
+    // Non-vacuous floor (rf2-utvst): a present-but-empty bundle satisfies
+    // every sentinel-absence check and would false-GREEN the perf-off
+    // isolation assertion.
+    console.error(`[perf-bundle] ${label}: bundle present but empty (zero top-level JS) — ${bundlePath}`);
+    console.error('              The release emitted no inspectable bundle; an empty bundle');
+    console.error('              proves nothing about perf-flag isolation. Rebuild the');
+    console.error('              matching shadow-cljs release or clear the stale dir.');
+    return { ok: false, checked: 0, passed: 0, bytes: 0, empty: true };
   }
   report.detail(`[perf-bundle] ${label}: ${bundlePath}`);
   report.detail(`              bundle size: ${blob.length} chars`);
@@ -123,9 +133,13 @@ function main() {
   const on  = checkBundle('perf-on  (counter-perf,  enabled?=true) ',
                           onDir,  true);
 
-  // Report the counts the bead asks for.
-  const offBlob = readReleaseBlob(offDir);
-  const onBlob  = readReleaseBlob(onDir);
+  // Report the counts the bead asks for. classifyReleaseBundle returns
+  // blob=null for a missing dir (countOccurrences guards null) and the
+  // real blob otherwise; the off/on checks above already fail the gate
+  // on a missing/empty dir, so these counts are only ever consulted for
+  // the diagnostic report.
+  const offBlob = classifyReleaseBundle(offDir).blob;
+  const onBlob  = classifyReleaseBundle(onDir).blob;
   const patterns = ['performance\\.mark',
                     'performance\\.measure',
                     're-frame\\.performance'];

--- a/implementation/scripts/check-reagent-slim-bundle-isolation.cjs
+++ b/implementation/scripts/check-reagent-slim-bundle-isolation.cjs
@@ -43,7 +43,7 @@
 
 const path = require('path');
 const { createGateReporter } = require('./lib/gate-report.cjs');
-const { readReleaseBlob, countSubstring } = require('./lib/read-release-bundle.cjs');
+const { classifyReleaseBundle, countSubstring } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const report = createGateReporter();
@@ -173,22 +173,41 @@ function main() {
 
   const slimDir  = path.join(ROOT, 'out', 'examples', 'counter-slim-and-fast');
   const stockDir = path.join(ROOT, 'out', 'examples', 'counter');
-  const slim  = readReleaseBlob(slimDir);
-  const stock = readReleaseBlob(stockDir);
+  const slimCls  = classifyReleaseBundle(slimDir);
+  const stockCls = classifyReleaseBundle(stockDir);
+  const slim  = slimCls.blob;
+  const stock = stockCls.blob;
 
-  if (slim == null) {
+  if (slimCls.status !== 'ok') {
     report.flushDetails();
-    console.error(`[reagent-slim-bundle-isolation] slim bundle missing — ${slimDir}`);
-    console.error('                    Did you run "shadow-cljs release examples/counter-slim-and-fast"?');
+    if (slimCls.status === 'empty') {
+      // Non-vacuous floor (rf2-utvst): the slim bundle is checked
+      // negative-only (Contracts 2+3); a present-but-empty slim dir
+      // satisfies both absence checks and would false-GREEN.
+      console.error(`[reagent-slim-bundle-isolation] slim bundle present but empty (zero top-level JS) — ${slimDir}`);
+      console.error('                    The release emitted no bundle; the stock-Reagent and');
+      console.error('                    react-dom/server absence checks would pass vacuously.');
+      console.error('                    Rebuild "shadow-cljs release examples/counter-slim-and-fast".');
+    } else {
+      console.error(`[reagent-slim-bundle-isolation] slim bundle missing — ${slimDir}`);
+      console.error('                    Did you run "shadow-cljs release examples/counter-slim-and-fast"?');
+    }
     process.exit(1);
   }
-  if (stock == null) {
+  if (stockCls.status !== 'ok') {
     report.flushDetails();
-    console.error(`[reagent-slim-bundle-isolation] stock bundle missing — ${stockDir}`);
-    console.error('                    Did you run "shadow-cljs release examples/counter"?');
-    console.error('                    The stock bundle is required as the methodology control:');
-    console.error('                    its presence of the stock-Reagent sentinels proves the');
-    console.error('                    grep has signal.');
+    if (stockCls.status === 'empty') {
+      console.error(`[reagent-slim-bundle-isolation] stock bundle present but empty (zero top-level JS) — ${stockDir}`);
+      console.error('                    The methodology control emitted no bundle; the stock-');
+      console.error('                    Reagent present-check would have no signal.');
+      console.error('                    Rebuild "shadow-cljs release examples/counter".');
+    } else {
+      console.error(`[reagent-slim-bundle-isolation] stock bundle missing — ${stockDir}`);
+      console.error('                    Did you run "shadow-cljs release examples/counter"?');
+      console.error('                    The stock bundle is required as the methodology control:');
+      console.error('                    its presence of the stock-Reagent sentinels proves the');
+      console.error('                    grep has signal.');
+    }
     process.exit(1);
   }
 

--- a/implementation/scripts/check-schemas-bundle.cjs
+++ b/implementation/scripts/check-schemas-bundle.cjs
@@ -50,7 +50,10 @@ const fs   = require('fs');
 const path = require('path');
 const zlib = require('zlib');
 const { createGateReporter } = require('./lib/gate-report.cjs');
-const { listReleaseJsFiles } = require('./lib/read-release-bundle.cjs');
+const {
+  listReleaseJsFiles,
+  classifyReleaseBundle,
+} = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const report = createGateReporter();
@@ -112,6 +115,18 @@ function main() {
   let bundlesOk = true;
 
   for (const bundle of BUNDLES) {
+    // Non-vacuous floor (rf2-utvst): a present-but-empty output dir sums
+    // to 0 gzipped bytes and would pass the `<= ceiling` size assertion
+    // (and the equality guard) vacuously. Reject it before measuring.
+    const cls = classifyReleaseBundle(bundle.bundleDir);
+    if (cls.status === 'empty') {
+      console.error(`[schemas-bundle] ${bundle.name}: bundle present but empty (zero top-level JS) — ${bundle.bundleDir}`);
+      console.error('              The release emitted no bundle; a zero-byte bundle would');
+      console.error('              pass the size ceiling vacuously. Rebuild with "shadow-cljs');
+      console.error(`              release ${bundle.name}" or clear the stale dir.`);
+      bundlesOk = false;
+      continue;
+    }
     const total = sumGzippedBytes(bundle.bundleDir);
     if (total == null) {
       console.error(`[schemas-bundle] ${bundle.name}: bundle dir missing — ${bundle.bundleDir}`);

--- a/implementation/scripts/check-story-static.cjs
+++ b/implementation/scripts/check-story-static.cjs
@@ -362,13 +362,18 @@ async function smokeTest(baseUrl, diagnostics) {
   const port = await resolvePort(diagnostics);
   diagnostics.add(`Serving ${OUT_DIR} on http://127.0.0.1:${port}`);
 
+  // Bind 127.0.0.1 (not http-server's 0.0.0.0 default): the readiness
+  // probe and the headless browser only ever hit loopback, so the
+  // listener must not be exposed on non-loopback interfaces during a
+  // test run (rf2-utvst; matches serve-and-run-examples-tests.cjs).
+  const serverArgs = [HTTP_SERVER_BIN, OUT_DIR, '-a', '127.0.0.1', '-p', String(port), '-s', '-c-1'];
   const server = cleanup.trackProcess(spawnHarnessProcess(
     process.execPath,
-    [HTTP_SERVER_BIN, OUT_DIR, '-p', String(port), '-s', '-c-1'],
+    serverArgs,
     { cwd: IMPL_ROOT, stdio: ['ignore', 'pipe', 'pipe'] },
   ));
   diagnostics.add(
-    `Process: ${process.execPath} ${[HTTP_SERVER_BIN, OUT_DIR, '-p', String(port), '-s', '-c-1'].join(' ')}`,
+    `Process: ${process.execPath} ${serverArgs.join(' ')}`,
   );
   server.stdout.on('data', (d) => addChunk(diagnostics, '[http-server:stdout] ', d));
   server.stderr.on('data', (d) => addChunk(diagnostics, '[http-server:stderr] ', d, 'stderr'));

--- a/implementation/scripts/check-uix-helix-reagent-free.cjs
+++ b/implementation/scripts/check-uix-helix-reagent-free.cjs
@@ -36,7 +36,7 @@
 
 const path = require('path');
 const { createGateReporter } = require('./lib/gate-report.cjs');
-const { readReleaseBlob, countSubstring } = require('./lib/read-release-bundle.cjs');
+const { classifyReleaseBundle, countSubstring } = require('./lib/read-release-bundle.cjs');
 
 const ROOT = path.resolve(__dirname, '..');
 const report = createGateReporter();
@@ -72,11 +72,21 @@ const REAGENT_SENTINELS = [
 // (rf2-jkake.15).
 
 function checkBundle(label, bundlePath, mustContain) {
-  const blob = readReleaseBlob(bundlePath);
-  if (blob == null) {
+  const { status, blob } = classifyReleaseBundle(bundlePath);
+  if (status === 'missing') {
     console.error(`[uix-helix-reagent-free] ${label}: bundle path missing — ${bundlePath}`);
     console.error('                          Did you run the matching shadow-cljs release?');
     return { ok: false, checked: 0, passed: 0, bytes: null, missing: true };
+  }
+  if (status === 'empty') {
+    // Non-vacuous floor (rf2-utvst): the UIx/Helix bundles are checked
+    // negative-only; a present-but-empty bundle satisfies every Reagent-
+    // sentinel absence check and would false-GREEN.
+    console.error(`[uix-helix-reagent-free] ${label}: bundle present but empty (zero top-level JS) — ${bundlePath}`);
+    console.error('                          The release emitted no inspectable bundle; the');
+    console.error('                          Reagent-absence checks would pass vacuously.');
+    console.error('                          Rebuild the matching shadow-cljs release.');
+    return { ok: false, checked: 0, passed: 0, bytes: 0, empty: true };
   }
   report.detail(`  ${label}: ${bundlePath}`);
   report.detail(`    bundle size: ${blob.length} chars`);

--- a/implementation/scripts/lib/read-release-bundle.cjs
+++ b/implementation/scripts/lib/read-release-bundle.cjs
@@ -25,6 +25,28 @@
 //                              `dir` doesn't exist. For per-file work
 //                              (e.g. gzipped-size totalling).
 //
+// Non-vacuous floor (rf2-utvst). Both readers above intentionally
+// distinguish a MISSING dir (null) from a PRESENT-BUT-EMPTY dir (''/[]),
+// because those are genuinely different filesystem states. But every
+// consuming gate runs negative-only (sentinel-absence) checks, and a
+// present-but-empty output dir — a present `out/examples/counter` with
+// no top-level `*.js`, i.e. a release that emitted nothing or a stale
+// empty dir left behind — satisfies *every* absence check and passes as
+// a zero-byte bundle. That is a silent false-GREEN: the gate is meant to
+// prove production bundle isolation/elision, but an empty bundle proves
+// only that nothing got inspected. `classifyReleaseBundle` collapses the
+// two failure modes into one decision so each consumer's existing
+// missing-dir guard can reject the empty case with the same exit path:
+//   classifyReleaseBundle(dir) → { status, files, blob }
+//     status: 'missing'  — `dir` doesn't exist (files=null, blob=null)
+//             'empty'     — `dir` exists but has zero top-level *.js, or
+//                           every top-level *.js is zero-byte / blank
+//                           (the bundle didn't build); files=[]|paths,
+//                           blob='' or whitespace-only
+//             'ok'        — at least one top-level *.js with real content
+//   A status other than 'ok' MUST fail the gate. `'ok'` carries a
+//   non-empty `blob` and a non-empty `files` array.
+//
 // Plus the grep primitives the sibling check-*-bundle scanners run
 // against the blob. Each scanner used to carry its own verbatim copies
 // of these (rf2-jkake.15 folded them here so the bundle-grep family
@@ -66,6 +88,27 @@ function readReleaseBlob(dir) {
   return out.join('\n');
 }
 
+// Classify a release output dir into one of three states so a gate can
+// reject both a missing dir AND a present-but-empty (zero-byte) bundle
+// with the same guard (rf2-utvst). See the module header for the full
+// rationale. `blob.trim() === ''` is the non-vacuous floor: a present
+// dir whose only top-level *.js files are empty or whitespace carries no
+// inspectable artefact and must not pass an absence-only gate.
+function classifyReleaseBundle(dir) {
+  const files = listReleaseJsFiles(dir);
+  if (files == null) {
+    return { status: 'missing', files: null, blob: null };
+  }
+  if (files.length === 0) {
+    return { status: 'empty', files, blob: '' };
+  }
+  const blob = files.map((f) => fs.readFileSync(f, 'utf8')).join('\n');
+  if (blob.trim() === '') {
+    return { status: 'empty', files, blob };
+  }
+  return { status: 'ok', files, blob };
+}
+
 function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -88,6 +131,7 @@ function countSubstring(blob, needle) {
 module.exports = {
   readReleaseBlob,
   listReleaseJsFiles,
+  classifyReleaseBundle,
   escapeRe,
   countMatches,
   countSubstring,

--- a/implementation/scripts/serve-and-run-browser-tests.cjs
+++ b/implementation/scripts/serve-and-run-browser-tests.cjs
@@ -298,7 +298,11 @@ async function waitForReady(port, expectedToken, deadline, state) {
   // resolved absolute `.js` entry-point is the only thing the OS
   // interprets, so a workspace-local `npx.cmd` can no longer hijack the
   // launch, and there is no `shell:true` warning/quoting class.
-  const args = [HTTP_SERVER_BIN, ROOT, '-p', String(port), '-s', '-c-1'];
+  // Bind 127.0.0.1 (not http-server's 0.0.0.0 default): the readiness
+  // probe and the browser only ever hit loopback, so the listener must
+  // not be exposed on non-loopback interfaces during a test run
+  // (rf2-utvst; matches serve-and-run-examples-tests.cjs).
+  const args = [HTTP_SERVER_BIN, ROOT, '-a', '127.0.0.1', '-p', String(port), '-s', '-c-1'];
   const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, args, {
     cwd: IMPL_ROOT,
     stdio: ['ignore', 'inherit', 'inherit'],

--- a/implementation/scripts/serve-and-run-xray-feature-gate.cjs
+++ b/implementation/scripts/serve-and-run-xray-feature-gate.cjs
@@ -555,7 +555,12 @@ async function main() {
   const baseUrl = `http://127.0.0.1:${port}`;
   console.log(`Serving ${OUT_ROOT} on ${baseUrl}`);
 
-  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(port), '-s', '-c-1'], {
+  // Bind 127.0.0.1 (not http-server's 0.0.0.0 default): the ownership-
+  // token readiness probe and the headless browser only ever hit
+  // loopback, so the staged Xray bundle must not be exposed on non-
+  // loopback interfaces during the gate run (rf2-utvst; matches
+  // serve-and-run-examples-tests.cjs).
+  const server = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [HTTP_SERVER_BIN, OUT_ROOT, '-a', '127.0.0.1', '-p', String(port), '-s', '-c-1'], {
     cwd: IMPL_ROOT,
     stdio: ['ignore', 'inherit', 'inherit'],
   }));


### PR DESCRIPTION
Fixes the three senior-review findings in `implementation/scripts` (bead rf2-utvst). All changes are confined to `implementation/scripts/**`.

## Per-finding disposition

### Finding 1 — release-bundle gates false-green on a present-but-empty (zero-byte) output dir (CONFIRMED, fixed)
`readReleaseBlob` returns `''` (not `null`) for a present dir with no/empty top-level `*.js`, and the six consumers branch only on `blob == null`. A present-but-empty `out/examples/counter` (release emitted nothing, or a stale empty dir left behind) therefore satisfied every sentinel-absence check and passed as a zero-byte bundle — a silent false-green. Same false-green class as the merged 54xbp/lbo79/wf5al gate-hardening.

**Fix.** Added a shared non-vacuous floor `classifyReleaseBundle(dir) → { status, files, blob }` to `lib/read-release-bundle.cjs`:
- `missing` — dir doesn't exist
- `empty` — dir present but zero top-level `*.js`, or every top-level `*.js` is zero-byte / whitespace (the bundle didn't build)
- `ok` — at least one top-level `*.js` with real content

Wired consistently into all six listed consumers; each fails with a clear empty-vs-missing diagnostic:
- `check-bundle-isolation.cjs`
- `check-elision.cjs`
- `check-perf-bundle.cjs`
- `check-schemas-bundle.cjs` (the size-ceiling shape: a 0-byte bundle previously passed `0 <= 100 KB`)
- `check-reagent-slim-bundle-isolation.cjs`
- `check-uix-helix-reagent-free.cjs`

The low-level readers (`readReleaseBlob`/`listReleaseJsFiles`) keep their existing `null`-vs-`''`/`[]` contract; the classifier is the gate-facing decision.

### Finding 2 — implementation http-server launchers don't bind loopback (CONFIRMED, fixed)
Three launchers advertise `http://127.0.0.1:<port>` but spawn `http-server` with no `-a 127.0.0.1`, relying on http-server's broad `0.0.0.0` default — exposing the generated app bundle + the `.rf-harness-token` endpoint on non-loopback interfaces during test runs. The examples Story runners already enforce `-a 127.0.0.1` (`serve-and-run-examples-tests.cjs`, gated by `_story-script-runners-policy.test.cjs`).

**Fix.** Added `'-a', '127.0.0.1'` to:
- `serve-and-run-browser-tests.cjs`
- `check-story-static.cjs` (also extracted the spawn args to one const so the diagnostic log stays in sync)
- `serve-and-run-xray-feature-gate.cjs`

Extended `_script-spawn-policy.test.cjs` with a positive loopback-bind guard for these three launchers (mirrors the examples-side rf2-wf5al.2 guard).

### Finding 3 — api-manifest projection checks report OK on zero extracted references (CONFIRMED, fixed)
`report-result!` returns OK whenever the problem list is empty, even if zero references were reconciled. `markdown-files` returns `nil` for a missing dir, so `skills-check`/`doc-guide-check` silently do zero work on a moved/renamed dir; `story-spec-check`/`xray-spec-check` had no minimum-reference floor. A docs/skills dir move, table-shape change, alias-convention change, or parser drift turns the projection gate vacuous-green.

**Fix.** Added to `projection.clj`:
- `vacuity-floor-problem` / `report-with-floor!` — synthesise a floor-violation problem (→ RED) when fewer than `min-refs` references were reconciled.
- `require-markdown-files` — throws (instead of returning nil) for a missing/renamed surface dir.

Per-surface floors (an order of magnitude below current live counts, so they trip only on a near-total collapse, never ordinary churn):
| surface | current | floor | missing-dir |
|---|---|---|---|
| skills/ | 505 refs / 127 files | 100 | throws |
| docs/guide/ | 504 refs / 30 files | 100 | throws |
| tools/story/spec/API.md | 65 var-rows | 20 | n/a (single file; loud on missing) |
| tools/xray/spec/API.md | 23 refs | 8 | n/a (single file; loud on missing) |

New `projection_test.clj` pins the floor + missing-dir throw. (Xray-spec keeps its report-only posture — the floor fails on extraction collapse, it does not edit the spec.)

No `.github/workflows` edit needed: all three surfaces are already gated (`test:script-helpers`, `test:script-policy`, and `clojure -M:test` in `implementation/scripts/api-manifest` via `lint.yml`). No workflow follow-up to flag.

## Quality gates

Finding-1 gates — built REAL release bundles and ran each gate (all PASS on a real bundle):
```
PASS bundle-isolation: 17 artefact entries; 35 internal sentinels absent; 3 allow-list budgets ok; counter=459665 chars
PASS uix-helix-reagent-free: 3 bundles checked; 6 sentinel checks
PASS elision: production 40/40 absent (567231); control 40/40 present (644622)
PASS reagent-slim-bundle-isolation: 3 contracts passed; 19 sentinel checks
PASS perf-bundle: off-count=0; on-count=12
PASS schemas-bundle: probe=94.1 KB/100.0; probe-malli=94.1 KB/100.0; delta=0.0 KB
```

Finding-2 / unit gates:
```
read-release-bundle tests: 25 passed   (npm run test:script-helpers — all green)
script-spawn-policy tests: 58 passed   (npm run test:script-policy — all green; +3 loopback guards)
story-script-runners-policy tests: 11 passed
```

Finding-3 gates (live projection checks + new unit tests):
```
OK: skills/ (excl. re-frame-migration) projection in sync (505 references)
OK: docs/guide/ projection in sync (504 references)
OK: tools/story/spec/API.md projection in sync (65 references)
OK: tools/xray/spec/API.md projection in sync (23 references)
api-manifest clojure -M:test → Ran 17 tests, 41 assertions, 0 failures, 0 errors
```

## Empty-bundle proof (Finding 1)

The bug is the false-GREEN on a present-but-empty bundle. Proven the new floor trips, then restores:

1. **Real bundle present → PASS** (built `out/examples/counter`, gate exits 0 — see Quality gates).
2. **Real dir emptied of top-level `*.js` (keeping the dir + `manifest.edn`)** — exactly the bead's `out/examples/counter` present-but-empty scenario:
   ```
   $ mv out/examples/counter/*.js /tmp ; ls out/examples/counter  → manifest.edn
   $ node scripts/check-bundle-isolation.cjs ; echo $?            → 1   (was: vacuous PASS)
   [bundle-isolation] bundle present but empty (zero top-level JS) — .../out/examples/counter
                      The release emitted no inspectable bundle, so the
                      sentinel-absence checks would pass vacuously. ...
   $ mv /tmp/*.js out/examples/counter/ ; node ... ; echo $?      → 0   (restored)
   ```
3. **Zero-byte top-level `main.js`** (release emitted an empty JS file): `check-bundle-isolation.cjs` exits **1**.
4. **All six consumers** exit **1** on a present-but-empty bundle dir:
   ```
   check-elision.cjs                       → 1
   check-perf-bundle.cjs                   → 1
   check-schemas-bundle.cjs                → 1   (was: 0-byte bundle passed the size ceiling)
   check-reagent-slim-bundle-isolation.cjs → 1
   check-uix-helix-reagent-free.cjs        → 1
   check-bundle-isolation.cjs              → 1
   ```

Empty-floor proof (Finding 3):
```
report-with-floor! "skills/" 0   100 []  → false   (vacuous-green case now RED)
report-with-floor! "skills/" 505 100 []  → true    (green path intact)
require-markdown-files on a missing dir   → throws "expected directory is missing"
```

Closes rf2-utvst.