### PR TITLE
fix(xray): default-suppress sensitive trace events at the runtime/MCP seam (rf2-to36uj)

### DIFF
--- a/tools/xray/spec/013-Trace-Consumer.md
+++ b/tools/xray/spec/013-Trace-Consumer.md
@@ -173,6 +173,20 @@ read gate covers the steady-state read while the flag stays `false`;
 the [retroactive scrub](#retroactive-scrub-on-toggle-off) covers the
 true → false transition by clearing the rings wholesale.
 
+The **runtime/MCP accessors** (`day8.re-frame2-xray.runtime/get-trace-buffer`
+and `get-issues`, [API.md §Inspection band](API.md)) read the per-frame
+rings DIRECTLY — they bypass `snapshot-from-rings` and the panel's
+`:trace-buffer` app-db slot entirely. They therefore apply the SAME
+event-level default-suppress as their OWN gate (`drop-sensitive-events`),
+dropping whole `:sensitive? true` events before value-scrubbing. The
+opt-back-in differs from the panel surface: the panel reads the global
+`:rf.privacy/show-sensitive?` UI flag, while the seam is per-call so the
+opt is the per-call `{:include-sensitive? true}` accessor option. The
+envelope — existence, `:op-type`, timing, source, handler/event ids, and
+non-elided `:tags` — is what the seam gate protects; value-scrubbing
+(`egress-value`) alone leaves the envelope intact, which is why the
+event-level gate is load-bearing (rf2-to36uj).
+
 ### The suppressed-events counter
 
 The counter is keyed `frame-id → count` with a `:global` bucket for

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -699,6 +699,25 @@ half of MUST-inventory rows #2 / #15 / #17 / #19; callers pass plain
 `:include-sensitive?` / `:include-large?` opts, the fns translate to the
 framework's `:rf.size/*` namespaced opt keys.
 
+**Event-level default-suppress (the envelope, not just the value).**
+`egress-value` scrubs the VALUES carried inside a trace event, but it does
+not drop a whole event that is itself marked `:sensitive? true`. The
+framework's per-frame rings RETAIN every emitted event with no
+`:sensitive?` check (a faithful record of what the runtime emitted), so a
+sensitive event's ENVELOPE — its existence, `:op-type`, timing, source,
+handler/event ids, and any non-elided `:tags` — would survive
+value-scrubbing and cross the off-box boundary. Per Spec 009 §Privacy +
+[013-Trace-Consumer.md](013-Trace-Consumer.md) a framework-published trace
+consumer default-SUPPRESSES whole `:sensitive? true` events. So the two
+flat-trace-event accessors — `get-trace-buffer` and `get-issues` — drop
+every event for which `re-frame.core/sensitive?` is true BEFORE
+value-scrubbing, unless the caller explicitly opts in with
+`{:include-sensitive? true}` (the per-call opt-back-in — distinct from the
+panel-side global `:rf.privacy/show-sensitive?` UI toggle, since the seam
+is per-call). This is the runtime/MCP-seam half of the same contract the
+panel-side trace collector + `snapshot-from-rings` honour via
+`config/suppress-sensitive?` (rf2-to36uj).
+
 `egress-value` also takes an optional `:path` — the **absolute** app-db
 path the value sits at. The framework's schema-declared sensitive / large
 declarations are keyed by absolute path, so a slice egress'd in isolation
@@ -739,13 +758,13 @@ gate is reachable only through the runtime accessors.
 
 | Accessor (fn) | Tool name | Returns | Reads |
 |---|---|---|---|
-| `get-trace-buffer` | `get-trace-buffer` | `{:ok? true :events <vec> :count <n>}` | `trace-tooling/trace-buffer` — filtered slice of the trace stream. Filter keys are the canonical Spec 009 vocabulary (`:operation` / `:op-type` / `:since` / `:frame` / `:severity` / `:event-id` / `:handler-id` / `:source` / `:origin` / `:dispatch-id` / `:since-ms` / `:between` / `:pred`). |
+| `get-trace-buffer` | `get-trace-buffer` | `{:ok? true :events <vec> :count <n>}` | `trace-tooling/trace-buffer` — filtered slice of the trace stream. Filter keys are the canonical Spec 009 vocabulary (`:operation` / `:op-type` / `:since` / `:frame` / `:severity` / `:event-id` / `:handler-id` / `:source` / `:origin` / `:dispatch-id` / `:since-ms` / `:between` / `:pred`). Whole `:sensitive? true` events are default-SUPPRESSED before value-scrubbing — the envelope is dropped unless `{:include-sensitive? true}` (rf2-to36uj). |
 | `get-epoch-history` | `get-epoch-history` | `{:ok? true :frame <id> :epochs <vec> :count <n>}` | `rf/epoch-history` per-frame vector of `:rf/epoch-record`. |
 | `get-app-db` | `get-app-db` | `{:ok? true :frame <id> :path <vec> :value <edn>}` | `rf/app-db-value` (optionally scoped by `:path`). The `:value` routes through `egress-value`; when `:path` is supplied the absolute path is threaded into the walker so a scoped slice elides against schema-declared sensitive / large paths — fail-closed, symmetric with the whole-db read and the `get-app-db-diff` slices (rf2-a96xq). |
 | `get-app-db-diff` | `get-app-db-diff` | `{:ok? true :frame <id> :epoch-id <uuid> :diff {:added [{:path :value}] :removed [{:path :value}] :changed [{:path :before :after}]}}` | Projects the changed-paths slice diff between a named epoch's `:db-before` + `:db-after` via the canonical Editscript-A* engine (`diff.engine/project`). Only the changed paths' slices egress — each `:value` / `:before` / `:after` routed through `egress-value`, never two whole app-db snapshots (rf2-uv2q2). Heavier nested-diff projection lives MCP-side. |
 | `get-machine-state` | `get-machine-state` | `{:ok? true :frame <id> :machine-id <kw> :state <live-state-path> :snapshot {:state :data :tags …} :spec <registered-definition>}` | The LIVE FSM position — reads the machine's snapshot from `app-db` at `[:rf/runtime :machines :snapshots <machine-id>]` (the runtime-owned slot the Machine Inspector + the framework resolver read). `:state` is the running state-path (a region→state map for a `:parallel` machine — Spec 005), NOT derived from the static spec; the registered definition is returned separately under `:spec`. A registered-but-not-yet-started machine has no live snapshot — `:state` / `:snapshot` are `nil` and `:reason` is `:not-yet-started` (still `:ok? true`). `:state` / `:snapshot` (a live app-db slice) and `:spec` both route through `egress-value`. |
 | `get-machine-list` | `get-machine-list` | `{:ok? true :machines <map> :count <n>}` | `rf/machines` — map keyed by machine-id. |
-| `get-issues` | `get-issues` | `{:ok? true :issues <vec> :count <n>}` | Projection over the trace buffer filtered to issue-tier op-types (`:error` / `:warning` / `:rf.schema/violation` / `:rf.hydration/mismatch`). |
+| `get-issues` | `get-issues` | `{:ok? true :issues <vec> :count <n>}` | Projection over the trace buffer filtered to issue-tier op-types (`:error` / `:warning` / `:rf.schema/violation` / `:rf.hydration/mismatch`). Whole `:sensitive? true` issue events are default-SUPPRESSED before the op-type filter — the envelope is dropped unless `{:include-sensitive? true}` (rf2-to36uj, symmetric with `get-trace-buffer`). |
 | `get-handlers` | `get-handlers` | `{:ok? true :handlers <vec> :count <n>}` | `rf/registrations` per-kind. Optional `:kind` narrows to one of `:event :sub :fx :cofx :machine :flow :reg-machine :frame :view`. |
 | `get-source-coord` | `get-source-coord` | `{:ok? true :kind <kw> :id <any> :source-coord <map>}` | `rf/handler-meta` projected to `:source-coord`, routed through `egress-value` (rf2-j8b0u — Spec 009's user-supplied `:rf.handler/source` override can stamp arbitrary values into the slot, so the accessor egresses unconditionally rather than judging per-read; `:include-sensitive?` / `:include-large?` opt back in). |
 

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -290,6 +290,44 @@
      (rf/projected-record record))))
 
 ;; ---------------------------------------------------------------------------
+;; Event-level default-suppress gate (rf2-to36uj)
+;; ---------------------------------------------------------------------------
+;;
+;; `egress-value` scrubs the VALUES carried inside a trace event, but it
+;; does NOT drop a whole event that is itself marked `:sensitive? true`.
+;; The framework's per-frame rings RETAIN every emitted event with no
+;; `:sensitive?` check (`re-frame.trace.tooling/push-to-ring!` is a
+;; faithful record of what the runtime emitted), so a sensitive event's
+;; ENVELOPE — its existence, `:op-type`, timing, source, handler/event
+;; ids, and any non-elided `:tags` — survives value-scrubbing and would
+;; cross the off-box AI/MCP / log boundary by default.
+;;
+;; Per Spec 009 §Privacy + spec/013-Trace-Consumer.md (the same contract
+;; the panel-side trace collector + `snapshot-from-rings` honour via
+;; `config/suppress-sensitive?`): a framework-published trace consumer
+;; default-SUPPRESSES whole `:sensitive? true` events. The runtime/MCP
+;; seam's opt-back-in is the per-call `:include-sensitive?` opt (NOT the
+;; panel's global `:rf.privacy/show-sensitive?` UI toggle — the seam is
+;; per-call, so the gate is per-call too). We compose against the ONE
+;; framework primitive `re-frame.core/sensitive?` (re-export of
+;; `re-frame.privacy/sensitive?`) rather than reimplementing the
+;; `:sensitive? true` check, exactly as `config/sensitive-event?` does.
+
+(defn- drop-sensitive-events
+  "Default-suppress whole `:sensitive? true` trace events at the
+  runtime/MCP seam. `include-sensitive?` truthy is the explicit
+  per-call opt-back-in — pass it and the sensitive ENVELOPES survive
+  (their VALUES are still routed through `egress-value` by the caller).
+  When `include-sensitive?` is false / nil (the safe default) every
+  event for which `re-frame.core/sensitive?` is true is removed before
+  the events cross the off-box boundary (rf2-to36uj — the envelope, not
+  just the value, must respect the default-suppress contract)."
+  [events include-sensitive?]
+  (if include-sensitive?
+    events
+    (into [] (remove rf/sensitive?) events)))
+
+;; ---------------------------------------------------------------------------
 ;; Inspection band (9 accessors)
 ;; ---------------------------------------------------------------------------
 
@@ -310,9 +348,13 @@
 
   Returns `{:ok? true :events <vec> :count <n> :frame <frame-id>}`
   on success, or `{:ok? false :reason :no-frame-resolved ...}` when
-  ambiguous. Each event is routed through `elide-wire-value` so
-  sensitive / large values are scrubbed at the wire boundary
-  (MUST-inventory rows #2 / #15 / #19)."
+  ambiguous. Whole `:sensitive? true` events are default-SUPPRESSED at
+  this off-box seam (`drop-sensitive-events`) — the framework rings
+  retain them, but the consumer contract (Spec 009 §Privacy) drops the
+  whole envelope unless the caller explicitly opts in with
+  `:include-sensitive? true`. Each surviving event is then routed
+  through `egress-value` so any sensitive / large VALUES are scrubbed at
+  the wire boundary (MUST-inventory rows #2 / #15 / #19)."
   ([] (get-trace-buffer {}))
   ([opts]
    (let [{:keys [frame include-sensitive? include-large?]} opts
@@ -323,7 +365,8 @@
        (let [filter-opts (-> opts
                              (dissoc :frame :include-sensitive? :include-large?)
                              (assoc :flat true))
-             events      (trace-tooling/trace-buffer fid filter-opts)
+             events      (-> (trace-tooling/trace-buffer fid filter-opts)
+                             (drop-sensitive-events include-sensitive?))
              scrubbed    (mapv #(egress-value % {:include-sensitive? include-sensitive?
                                                  :include-large?     include-large?})
                                events)]
@@ -600,8 +643,15 @@
   into the raw flat-event shape so the existing issue filter walks
   the same vocabulary.
 
-  Returns `{:ok? true :issues <vec>}`. Routes through
-  `elide-wire-value` per MUST-inventory row #2."
+  Whole `:sensitive? true` issue events are default-SUPPRESSED at this
+  off-box seam (`drop-sensitive-events`, run on the merged stream before
+  the issue-op-type filter) — symmetric with `get-trace-buffer`. The
+  envelope (existence, `:op-type`, timing, source, ids, `:tags`) of a
+  sensitive issue is dropped unless the caller explicitly opts in with
+  `:include-sensitive? true`. Surviving issues then route through
+  `egress-value` per MUST-inventory row #2.
+
+  Returns `{:ok? true :issues <vec> :count <n>}`."
   ([] (get-issues {}))
   ([opts]
    (let [{:keys [include-sensitive? include-large?]} opts
@@ -614,6 +664,9 @@
          events   (into []
                         (mapcat #(trace-tooling/trace-buffer % {:flat true}))
                         (rf/frame-ids))
+         ;; rf2-to36uj — default-suppress whole sensitive event envelopes
+         ;; at the off-box seam before the issue filter walks them.
+         events   (drop-sensitive-events events include-sensitive?)
          issues   (filterv #(contains? issue-op-types (:op-type %)) events)
          scrubbed (mapv #(egress-value % {:include-sensitive? include-sensitive?
                                           :include-large?     include-large?})

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -45,6 +45,11 @@
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
+            ;; CLJS callers reach the per-frame trace ring directly via the
+            ;; tooling sibling — `rf/trace-buffer` / `rf/clear-trace-buffer!`
+            ;; are JVM-only aliases (core.cljc `#?(:clj ...)`). The runtime
+            ;; itself requires this same ns (rf2-qwm0a).
+            [re-frame.trace.tooling :as trace-tooling]
             [day8.re-frame2-xray.runtime :as runtime]))
 
 ;; ---------------------------------------------------------------------------
@@ -467,6 +472,79 @@
       (is (true? (:ok? result)))
       (is (vector? (:issues result)))
       (is (number? (:count result))))))
+
+;; ---------------------------------------------------------------------------
+;; (10b) Default-suppress whole `:sensitive? true` trace/issue ENVELOPES
+;;       at the runtime/MCP seam (rf2-to36uj).
+;; ---------------------------------------------------------------------------
+;;
+;; `egress-value` scrubs the VALUES inside an event but does NOT drop a
+;; whole event marked `:sensitive? true`. The framework's per-frame ring
+;; RETAINS every emitted event (a faithful record), so a sensitive
+;; event's envelope (existence, :op-type, timing, source, ids, :tags)
+;; would otherwise cross the off-box AI/MCP / log boundary by default.
+;; Per Spec 009 §Privacy + spec/013-Trace-Consumer.md the runtime/MCP
+;; seam default-SUPPRESSES whole sensitive events; the per-call
+;; `:include-sensitive? true` opt is the explicit opt-back-in.
+;;
+;; We seed the ring directly via `rf/emit-trace-event!` (the published
+;; `re-frame.trace/emit!` alias). `:sensitive?` supplied in `tags` wins
+;; (`compute-sensitive?`) and is hoisted to the event's top level; a
+;; `:rf.trace/dispatch-id` + a resolvable `:frame` are the two slots
+;; `push-to-ring!` requires to retain the event in the per-frame ring.
+
+(defn- emit-sensitive-into-ring! [op-type operation]
+  ;; A frame-bound, cascade-keyed emit so the framework's per-frame ring
+  ;; retains it (frameless emits stream live but are never retained).
+  (rf/emit-trace-event! op-type operation
+                        {:frame                 :rf/default
+                         :rf.trace/dispatch-id  (random-uuid)
+                         :sensitive?            true}))
+
+(defn- emit-plain-into-ring! [op-type operation]
+  (rf/emit-trace-event! op-type operation
+                        {:frame                :rf/default
+                         :rf.trace/dispatch-id (random-uuid)}))
+
+(deftest get-trace-buffer-default-suppresses-sensitive-envelope
+  (testing "`get-trace-buffer` DROPS a whole `:sensitive? true` trace
+            event by default — the envelope (op-type / timing / ids /
+            tags), not just the values, must respect the default-suppress
+            contract at the off-box seam (rf2-to36uj)"
+    (trace-tooling/clear-trace-buffer! :rf/default)
+    (emit-plain-into-ring!     :sub  :rf.sub/run)
+    (emit-sensitive-into-ring! :sub  :rf.sub/run)
+    (let [default (runtime/get-trace-buffer)
+          opted   (runtime/get-trace-buffer {:include-sensitive? true})]
+      (is (true? (:ok? default)))
+      (is (empty? (filterv :sensitive? (:events default)))
+          "no sensitive envelope crosses the boundary by default")
+      (is (pos? (:count default))
+          "the non-sensitive event still surfaces")
+      (is (seq (filterv :sensitive? (:events opted)))
+          ":include-sensitive? true is the explicit opt-back-in — the sensitive envelope returns")
+      (is (= (inc (:count default)) (:count opted))
+          "exactly the suppressed sensitive event is the delta between default and opted-in"))))
+
+(deftest get-issues-default-suppresses-sensitive-envelope
+  (testing "`get-issues` DROPS a whole `:sensitive? true` issue-tier
+            event by default and returns it only under
+            `:include-sensitive? true` (rf2-to36uj — symmetric with
+            get-trace-buffer)"
+    (trace-tooling/clear-trace-buffer! :rf/default)
+    (emit-plain-into-ring!     :warning :rf.warning/plain)
+    (emit-sensitive-into-ring! :error   :rf.error/handler-exception)
+    (let [default (runtime/get-issues)
+          opted   (runtime/get-issues {:include-sensitive? true})]
+      (is (true? (:ok? default)))
+      (is (empty? (filterv :sensitive? (:issues default)))
+          "no sensitive issue envelope crosses the boundary by default")
+      (is (some #(= :warning (:op-type %)) (:issues default))
+          "the non-sensitive issue still surfaces")
+      (is (seq (filterv :sensitive? (:issues opted)))
+          ":include-sensitive? true returns the sensitive issue envelope")
+      (is (= (inc (:count default)) (:count opted))
+          "exactly the suppressed sensitive issue is the delta"))))
 
 ;; ---------------------------------------------------------------------------
 ;; (11) egress-value / egress-record — the single named safe-egress fn


### PR DESCRIPTION
## Summary

Independent correctness-review finding (rf2-to36uj): the Xray runtime/MCP
accessors leaked **sensitive trace ENVELOPES** by default.

`get-trace-buffer` (`runtime.cljs`) and `get-issues` read the per-frame
trace ring directly via `trace-tooling/trace-buffer` and only value-scrubbed
via `egress-value`. The framework rings RETAIN every emitted event with no
`:sensitive?` check (a faithful record of what the runtime emitted), so a
`:sensitive? true` event's envelope — existence, `:op-type`, timing, source,
handler/event ids, non-elided `:tags` — crossed the off-box AI/MCP / log
boundary by default. Only the values *inside* the event were scrubbed.

Per Spec 009 §Privacy + `spec/013-Trace-Consumer.md`, a framework-published
trace consumer **default-SUPPRESSES** whole `:sensitive? true` events. This
is the same contract the panel-side trace collector + `snapshot-from-rings`
honour via `config/suppress-sensitive?` — but the runtime accessors bypass
`snapshot-from-rings` entirely and never applied it. Same privacy class as
the merged Class-sweep A / 8fin7.3 / at60h work (value-bearing/sensitive
data must respect the default-suppress contract at the off-box boundary;
threat model = AI/MCP boundary + logs).

Deduped against rf2-6nx8y (state-count / route-preview) — distinct seam.

## Fix

- New private `drop-sensitive-events` gate composing the framework-published
  `re-frame.core/sensitive?` primitive (re-export of
  `re-frame.privacy/sensitive?`) — no reimplemented `:sensitive? true` check.
- Applied in `get-trace-buffer` (before value-scrubbing) and `get-issues`
  (on the merged stream, before the issue-op-type filter).
- Opt-back-in is the **per-call** `:include-sensitive? true` accessor opt
  (distinct from the panel's **global** `:rf.privacy/show-sensitive?` UI
  flag — the seam is per-call, so the gate is per-call).
- No back-compat shim (pre-alpha).
- Verified the two flat-trace-event accessors are the only runtime
  accessors reading the raw ring; `get-epoch-history` reads epoch records
  (different shape, governed by `egress-record` / `projected-record`).

Spec kept current: `tools/xray/spec/API.md` (egress section + the two table
rows) and `tools/xray/spec/013-Trace-Consumer.md` (runtime/MCP seam vs panel
snapshot gate) document the seam-level default-suppress contract.

## Default-suppress proof

Two regressions in `runtime_cljs_test.cljs` seed the per-frame ring with one
plain event + one `:sensitive? true` event (via `rf/emit-trace-event!`, the
published `re-frame.trace/emit!` alias — `:sensitive?` in `tags` is hoisted
to the event top level by `build-event`):

- `get-trace-buffer-default-suppresses-sensitive-envelope` — default call
  returns **no** event with `:sensitive?`, the plain event still surfaces,
  and `{:include-sensitive? true}` returns the sensitive envelope; the
  count delta is exactly the one suppressed event.
- `get-issues-default-suppresses-sensitive-envelope` — symmetric for the
  issue-tier op-types (plain `:warning` surfaces; sensitive `:error`
  envelope dropped by default, returned only under `:include-sensitive? true`).

Both fail before the fix (the sensitive envelope returns by default) and
pass after.

## Quality gates

- `cd implementation && npm run test:cljs` — **5843 tests / 20694 assertions, 0 failures, 0 errors** (the 2 new tests add 8 assertions).
- `cd tools/xray && clojure -M:test` — **1097 tests / 4568 assertions, 0 failures, 0 errors**.
- `npm run test:xray-feature-gate` — **16 scenarios, 0 failures, 13 matrix rows** (nightly-full sweep).
- `python scripts/check_doc_slugs.py` — exit 0 (spec links validated).

Closes rf2-to36uj.