### PR TITLE
fix(mcp-base): cross-runtime finite/range guard on numeric arg coercion + findings 2-4 (rf2-ykv9a0)

### DIFF
--- a/tools/mcp-base/spec/args.md
+++ b/tools/mcp-base/spec/args.md
@@ -30,8 +30,8 @@ The rejection posture (default-suppress vs default-allow) is named at the call-s
 | Parser | Accepts | Output | Notes |
 |---|---|---|---|
 | `parse-boolean` | bools, strings (`"true"`/`"false"`/`"1"`/`"0"`/`"yes"`/`"no"`/`"y"`/`"n"`/`"on"`/`"off"`, case-insensitive), keywords (`:true`/`:false`), nil | boolean | Unrecognised → `default`. Call-sites wrap to bake the default. |
-| `parse-positive-int` | ints, parsable strings | positive int or `default` | Strictly positive; zero falls to `default`. |
-| `parse-non-negative-int` | ints, parsable strings | non-negative int or `default` | Zero allowed. |
+| `parse-positive-int` | ints, parsable strings | positive int or `default` | Strictly positive; zero clamps to 1. Out-of-domain numerics (`##Inf`/`##NaN`/past the safe-integer window) → `default`, never a crash or a real floor (rf2-ykv9a0). |
+| `parse-non-negative-int` | ints, parsable strings | non-negative int or `default` | Zero allowed. Out-of-domain numerics → `default` (same cross-runtime guard). |
 | `fresh-keyword` | keywords, strings (leading `:` optional), nil | keyword or `nil` | The `:` prefix is stripped on string input. **Positive-named intern (rf2-xxtrz)**: the name signals the call-site is ALLOCATING a new id, not resolving an existing one. INTERNS by design — reserved for operator-gated write paths whose registrar grammar bounds the per-id allocation cost (e.g. story-mcp's `register-variant`). For finite option sets, use `safe-keyword`. |
 | `safe-keyword` | keywords, strings, nil | keyword from `allowed` set, or `nil` | Bounded-allowlist gate — NEVER interns a fresh keyword on rejection. The right primitive for finite option sets and any input that doesn't go straight to a registry lookup with a bounded known set. Per rf2-ih7g4. |
 | `parse-mode` | enum-shaped strings / keywords | one of an allowed set, otherwise `default` | Bakes an `allowed-modes` set; rejected values fall to `default`. Routes through `safe-keyword` so unrecognised input never interns (rf2-ih7g4). |
@@ -47,6 +47,15 @@ The cross-MCP rule:
 3. **`parse-mode` routes through `safe-keyword`.** The convention's enum-shaped parser is internally safe; consumers should use it rather than rolling their own.
 
 The keyword-interning cap (`:rf.http/max-decoded-keys`) defends against the body-decode threat; this convention defends against the argument-parse threat. Both close the same DoS / keyword-table-poisoning vector.
+
+## Cross-runtime numeric domain (rf2-ykv9a0)
+
+`parse-positive-int` / `parse-non-negative-int` (and, via `cursor/parse-limit-arg` and `cap/max-tokens`, every numeric MCP arg) coerce through one shared finite/range guard (`coerce-finite-long`) BEFORE `(long raw)`. The guard exists because `(long raw)` is unsafe at the arg boundary:
+
+- On the JVM `(long ##Inf)` and `(long 1.0E20)` THROW `IllegalArgumentException` — a crash at the wire boundary instead of a recoverable default; `(long ##NaN)` truncates to a real `0` (a real, non-sentinel value).
+- The string arm diverged across hosts: a digit string just past the JS safe-integer ceiling parsed on the JVM (`Long/parseLong`) but defaulted on CLJS (`Number.isSafeInteger`), so the SAME wire arg behaved differently per host.
+
+The admissible domain is the JS safe-integer window `[-(2^53−1), 2^53−1]` — the strictest of the two hosts, and far wider than any real MCP arg (pagination limits, token caps). An out-of-domain value (non-finite, NaN, or past the window) is treated uniformly: the int parsers fall to `default`; `cap/max-tokens` rejects with `{:rf.mcp/invalid-arg}`. Never a crash, never a real `0`-cap, never a host-divergent result.
 
 ## Default-handling posture
 
@@ -69,8 +78,8 @@ This split keeps the parser pure data — no thread-local policy, no global conf
 
 All six parsers are pure `.cljc`. They use:
 
-- `boolean?` / `int?` / `keyword?` / `string?` host predicates.
-- Reader-conditional-free `Integer/parseInt` (JVM) / `js/parseInt` (CLJS) via a small `.cljc` adapter.
+- `boolean?` / `number?` / `keyword?` / `string?` host predicates.
+- A reader-conditional finite/range guard: `Double/isNaN`/`isInfinite` + the safe-integer window (JVM), `js/isFinite`/`isNaN` + `Number.isSafeInteger` (CLJS). The numeric string arm parses via `bigint` (JVM) / `js/parseInt` (CLJS) and clamps to the same window so the two hosts agree.
 - Standard collection ops; no host-specific machinery.
 
 `safe-keyword`'s rejection branch carries the bounded-allowlist check — a fresh keyword is created with `keyword` only after the allowlist passes.

--- a/tools/mcp-base/spec/cap.md
+++ b/tools/mcp-base/spec/cap.md
@@ -10,7 +10,7 @@ This doc is one of eleven per-namespace contracts indexed from [`README.md`](REA
 `cap` owns:
 
 - The two-stage cap algorithm (sum tokens + chars in one pass → primary token gate OR secondary char gate → pass-through or replace).
-- The `max-tokens` per-call cap resolver (`0` resolves to `nil` = disabled; absent / non-number → `default-max-tokens`; **negative → `{:rf.mcp/invalid-arg {...}}` rejection**, rf2-5rdit).
+- The `max-tokens` per-call cap resolver (`0` resolves to `nil` = disabled; absent / non-number → `default-max-tokens`; **negative, fractional-in-(0,1), or non-finite / out-of-range → `{:rf.mcp/invalid-arg {...}}` rejection**, rf2-5rdit / rf2-li6y2.2 / rf2-ykv9a0).
 - The `ResultIO` protocol — the per-consumer specialisation hook.
 - The recursion-safety invariant (the overflow marker itself must fit under the cap).
 
@@ -137,11 +137,15 @@ The structural guarantee comes from the marker shape — `:limit`, `:token-count
 
 The default-ON posture matches the agent-ergonomics threat model: a stock install never accidentally floods the agent's context.
 
-## Negative `:max-tokens` is rejected (rf2-5rdit)
+## Out-of-domain `:max-tokens` is rejected (rf2-5rdit / rf2-li6y2.2 / rf2-ykv9a0)
 
-A **negative** `:max-tokens` is neither a disable signal nor a valid cap. `max-tokens` rejects it with an `{:rf.mcp/invalid-arg {:arg :max-tokens :value <n> :hint "max-tokens must be >= 0; 0 disables the cap"}}` marker; the consumer surfaces that as an `isError: true` tool-result (the agent reads it and corrects the arg). The handler is never dispatched and the rejection never reaches `apply-cap` as a `:cap`.
+An out-of-domain `:max-tokens` is neither a disable signal nor a valid cap. `max-tokens` rejects it with an `{:rf.mcp/invalid-arg {:arg :max-tokens :value <n> :hint "max-tokens must be an integer >= 1; 0 disables the cap"}}` marker; the consumer surfaces that as an `isError: true` tool-result (the agent reads it and corrects the arg). The handler is never dispatched and the rejection never reaches `apply-cap` as a `:cap`. The rejected domain:
 
-Why reject rather than clamp / treat-as-default (Mike ruled A, 2026-06-01): a negative value used to fall through to `(long raw)`, producing a negative ceiling. `over-cap?` (`(> tokens cap)`) is then true for ANY non-negative token count, so **every** response — even a 2-character one — was replaced by the `:rf.mcp/overflow` marker, locking the agent out of all tool data and emitting a nonsensical `:cap-tokens -1`. An honest, recoverable rejection at the AI/MCP boundary is the masterpiece CORRECTNESS posture: a malformed cap is an agent error worth telling the agent about, not a value to silently paper over.
+- **Negative** (rf2-5rdit) — `(long raw)` produced a negative ceiling; `over-cap?` (`(> tokens cap)`) is then true for ANY non-negative token count, so **every** response — even a 2-character one — was replaced by the `:rf.mcp/overflow` marker, locking the agent out and emitting a nonsensical `:cap-tokens -1`.
+- **Fractional positive in (0,1)** (rf2-li6y2.2) — e.g. `0.5` floored to a REAL `0` cap (non-nil, NOT the disable sentinel), reproducing the same lockout on every non-empty payload.
+- **Non-finite / out-of-range** (rf2-ykv9a0) — `##Inf` and a finite magnitude past the safe-integer window (`1.0E20`) THROW `IllegalArgumentException` on `(long raw)` (a crash at the wire boundary); `##NaN` truncated to a real `0` cap (the same lockout). The resolver routes through the shared `args/coerce-finite-long` guard BEFORE `(long raw)`, so each is rejected honestly and IDENTICALLY on JVM and CLJS rather than crashing the tool or minting a 0-cap.
+
+Why reject rather than clamp / treat-as-default (Mike ruled A, 2026-06-01): an honest, recoverable rejection at the AI/MCP boundary is the masterpiece CORRECTNESS posture — a malformed cap is an agent error worth telling the agent about, not a value to silently paper over (or crash on).
 
 Helpers (in `cap`):
 

--- a/tools/mcp-base/spec/cursor.md
+++ b/tools/mcp-base/spec/cursor.md
@@ -55,7 +55,7 @@ Decode an opaque base64 cursor back to its EDN payload map.
 Returns:
 
 - `nil` — the cursor arg is absent (nil / undefined) or blank. The caller treats this as "start from the beginning" (offset 0 / head).
-- `::malformed` — the cursor exists but is not a well-formed, `valid?`-passing payload map: it failed to base64/EDN-decode, carried a tagged literal, exceeded `max-cursor-bytes`, or its payload map failed the consumer's `valid?` predicate. Callers treat `::malformed` exactly like a STALE cursor — drop it and restart.
+- `::malformed` — the cursor exists but is not a well-formed, `valid?`-passing payload map: it failed to base64/EDN-decode, carried a tagged literal, decoded to MORE THAN ONE EDN form (a trailing object after the payload map — rf2-ykv9a0), exceeded `max-cursor-bytes`, or its payload map failed the consumer's `valid?` predicate. Callers treat `::malformed` exactly like a STALE cursor — drop it and restart.
 
 `valid?` is the consumer's payload-shape predicate (e.g. `#(and (map? %) (integer? (:offset %)) (string? (:sig %)))` for story; `#(and (map? %) (string? (:after-id %)))` for pair).
 
@@ -87,6 +87,12 @@ The EDN reader inside `decode-cursor` rejects **every** tagged literal — custo
 - `:readers` overrides throw on the **built-in** `#inst` / `#uuid` tags. These have registered readers (`clojure.edn` / `cljs.reader` resolve them from `*data-readers*` / the tag-table), so they **bypass `:default`** and would otherwise decode to a host `java.util.Date` / `UUID` (JVM) or `js/Date` / `cljs.core/UUID` (CLJS). Because `:readers` is consulted **before** `:default` on both platforms, the override wins and the built-in tag never materialises a host object.
 
 A hostile / corrupt cursor therefore cannot smuggle any tagged literal — or the host object it would decode to — past the reader. The throw is caught by the surrounding try in `decode-cursor` and surfaces as `::malformed`. (This closes the built-in-tag hole found in the rf2-13wbe correctness review: `pair-mcp`'s permissive `some? :after-id` predicate would have let `{:v 1 :after-id 1 :junk #inst "…"}` survive validation, carrying a `Date` through the MCP cursor boundary.)
+
+## One-form requirement (rf2-ykv9a0)
+
+A cursor is **one** opaque EDN payload map. The reader requires the decoded text to be **exactly one form** and rejects any trailing form as `::malformed`. A plain `read-string` reads only the FIRST form and never checks exhaustion, so before this a token whose decoded text was a valid map followed by a second form — e.g. `{:v 1 :offset 0 :sig "s"} #inst "2024-01-01"` or `{…} {:junk 1}` — decoded as the valid map, silently ignoring the trailing object and weakening the opacity / corruption guard.
+
+The reader closes that by wrapping the decoded text in `[ … ]` and reading the WHOLE thing as one vector: a single clean form yields a one-element vector (trailing whitespace / comments absorbed), while ANY trailing form yields a 2+-element vector → rejected. This is a pure-`read-string` technique that behaves identically on the JVM (`clojure.edn`) and CLJS (`cljs.reader`) without reaching into either host's pushback-reader internals; tagged literals anywhere inside still throw via the readers above.
 
 ## Why this ns
 

--- a/tools/mcp-base/spec/diff-encode.md
+++ b/tools/mcp-base/spec/diff-encode.md
@@ -83,15 +83,13 @@ The `:db-after` marker carries `:sections`, so the decoder first flattens the pe
             (let [[path op v] patch]
               (case op
                 :assoc  (if (empty? path) v (assoc-in acc path v))
-                :dissoc (let [parent (vec (butlast path))
-                              k      (last path)]
-                          (if (empty? parent)
-                            (dissoc acc k)
-                            (update-in acc parent dissoc k))))))
+                :dissoc (dissoc-in acc path))))         ; missing-/scalar-parent no-op
           base
           patches))
       db-after)))   ; not diff-encoded; passthrough
 ```
+
+> **`:dissoc` is a no-op when the key does not exist (rf2-ykv9a0).** The decoder routes nested `:dissoc` through a `dissoc-in` helper that dissocs only when the parent path resolves to a map. A naive `(update-in acc parent dissoc k)` violated the spec contract two ways: a MISSING parent manufactured nil branches (`{} + [[[:missing :leaf] :dissoc]] ⇒ {:missing nil}`), and a SCALAR parent threw a host `ClassCastException` at the wire decoder boundary. `apply-patches` is the public decoder; a malformed / corrupt / third-party diff replayed against a mismatched base must neither corrupt the base into a shape neither side emitted nor crash — so the missing-/scalar-parent case is a no-op, honouring the contract below.
 
 The shipped decoder (`decode-db-after`) Malli-validates `:sections` at the decode boundary (`validate-sections!`, symmetric with the encoder's gate) then replays via the non-validating `apply-patches*` to avoid a redundant second Malli walk on the JVM decode hot path. Both story-mcp and re-frame2-pair-mcp consume this shape; the agent-host decoder is small.
 

--- a/tools/mcp-base/spec/section-grouping.md
+++ b/tools/mcp-base/spec/section-grouping.md
@@ -12,6 +12,7 @@ This doc is one of eleven per-namespace contracts indexed from [`README.md`](REA
 - `group-patches-into-sections` — the flat-patch-list → sections projection.
 - `sections->patches` — the lossless inverse (flatten sections back to a replayable patch list).
 - `default-opts` (`{:max-coalesce-depth 3}`) — the tunable cluster-coalescence knob, mirroring Xray's defaults.
+- `group-patches-into-sections` `opts` also accepts `:db-before` — the pre-change value the patches diff from. When supplied, a `:section-kind :added` is claimed only for an all-`:assoc` direct-child cluster whose container was ABSENT in `:db-before` (rf2-ykv9a0); when absent, the classifier conservatively emits `:modified`.
 
 `section-grouping` does NOT own:
 
@@ -57,8 +58,12 @@ Mirrors the Xray pass (`section_grouping.cljc` §3.1.1), recast over patches:
 
 5. **Classify each section** (`:section-kind`):
    - all `:dissoc` → `:removed`.
-   - all `:assoc` AND every patch is exactly one segment deeper than `:section-path` (a newly-introduced container) → `:added`.
-   - otherwise → `:modified` (the conservative default; a mix of inserts / changes / deletes). A more precise `:added` vs `:modified` split would need `:db-before` to detect "was this path previously absent?" — patches alone can't tell, so the rule errs toward `:modified`.
+   - all `:assoc` AND every patch is exactly one segment deeper than `:section-path` AND the container was ABSENT in `:db-before` → `:added`.
+   - otherwise → `:modified` (the conservative default; a mix of inserts / changes / deletes, or an existing container whose direct children changed).
+
+   **Why `:added` needs `:db-before` (rf2-ykv9a0).** The patch grammar uses `:assoc` for BOTH inserted and changed leaves, so patch SHAPE alone cannot distinguish a newly-added container from an existing one whose direct children changed. `{:user {:name "bob"}}` → `{:user {:name "ada" :email "…"}}` emits the SAME all-`:assoc` direct-child cluster under `[:user]` as a genuinely new `[:user]` subtree — a patch-only classifier mislabels the FIRST (a modification) as `:added`, a false skim signal to the agent. So `:added` is claimed only when `:db-before` (threaded through `opts`, supplied by the `diff-encode-db-after` caller) proves the section-path container did not previously exist. When `:db-before` is absent (the standalone projection used by tests / advanced consumers diffing arbitrary structures), the classifier cannot prove addition and conservatively emits `:modified` for every all-`:assoc` cluster. The cosmetic `:section-kind` never affects round-trip — concatenating `:patches` replays losslessly regardless.
+
+   > Note: over the `collect-patches` pipeline a genuinely-new multi-key container is emitted as a single whole-subtree `[[:k] :assoc {...}]` patch (collect-patches doesn't recurse into an absent key), which heads as a singleton → `:modified`. The all-`:assoc` direct-child `:added` shape therefore arises only from an advanced consumer supplying a synthetic patch list whose `:db-before` proves the container absent.
 
 ## Ordering
 

--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -46,34 +46,95 @@
   arms with this regex closes the divergence."
   #"[-+]?\d+")
 
+;; ---------------------------------------------------------------------------
+;; Cross-runtime finite/range guard (rf2-ykv9a0).
+;;
+;; `(long raw)` is UNSAFE on out-of-domain numerics: on the JVM `##Inf`,
+;; `##NaN`, and finite values past the long range (`1.0E20`) THROW
+;; `IllegalArgumentException`, while `##NaN` quietly truncates to `0` — a
+;; real, non-sentinel cap that locks the agent out. The string arm
+;; diverged too: a digit string above the JS safe-integer ceiling parsed
+;; on the JVM (`Long/parseLong "9007199254740992"`) but defaulted on
+;; CLJS (`Number.isSafeInteger` rejects it), so the SAME wire arg behaved
+;; differently per host.
+;;
+;; The cross-runtime-safe domain is the JS safe-integer range
+;; (`±(2^53 − 1)`). It is the strictest of the two hosts (a JVM long is
+;; wider), and the MCP arg surface only ever carries small ints
+;; (pagination limits, token caps) — so clamping the admissible domain to
+;; what BOTH hosts represent losslessly costs nothing real and makes the
+;; coercion host-independent. `coerce-finite-long` is the single guard
+;; both the numeric arm here and `cap/max-tokens` reuse: it returns a
+;; `long` for an in-domain value and `nil` for anything non-finite,
+;; non-integral-in-range, or out of the safe-integer window. Callers map
+;; the `nil` to their own out-of-domain posture (default here, reject in
+;; `cap/max-tokens`).
+
+(def ^:private max-safe-integer
+  "The JS safe-integer ceiling, `2^53 − 1` (9 007 199 254 740 991). The
+  cross-runtime domain boundary: a value strictly inside `[-max, max]`
+  round-trips losslessly through both a JS `number` and a JVM `long`."
+  9007199254740991)
+
+(defn coerce-finite-long
+  "Coerce a number to a `long` IFF it is finite and within the JS
+  safe-integer window `[-(2^53−1), 2^53−1]`; otherwise return `nil`.
+
+  This is the cross-runtime arg-boundary guard (rf2-ykv9a0). It must be
+  called BEFORE `(long raw)` on any caller-supplied numeric, because
+  `(long ##Inf)` / `(long 1.0E20)` THROW on the JVM and `(long ##NaN)`
+  truncates to a real `0`. A fractional in-range value is floored toward
+  zero via `long` (the documented benign floor — e.g. `2.9` ⇒ `2`); a
+  fractional that floors below the domain is still in-range and floors
+  normally. Returns `nil` for `##NaN`, `##Inf`, `##-Inf`, and any finite
+  magnitude `>= 2^53`.
+
+  Non-number input is a caller error — gate with `number?` first."
+  [n]
+  (when (and #?(:clj  (not (or (Double/isNaN (double n))
+                               (Double/isInfinite (double n))))
+               :cljs (and (not (js/isNaN n))
+                          (js/isFinite n)))
+             (<= (- max-safe-integer) n max-safe-integer))
+    (long n)))
+
 (defn- parse-int*
   "Shared helper for `parse-positive-int` / `parse-non-negative-int`.
   `floor` is the lower clamp (1 for positive, 0 for non-negative).
-  Two input arms: a numeric `raw` is floored directly; a string `raw`
-  is strict-parsed (must match `int-string-re` end-to-end — trailing
-  garbage falls back to `default`, identically on JVM and CLJS).
-  Every other shape falls back to `default`."
+  Two input arms: a numeric `raw` is finite/range-guarded then floored
+  (out-of-domain — `##Inf` / `##NaN` / past the safe-integer window —
+  falls back to `default` rather than throwing or truncating to a real
+  value); a string `raw` is strict-parsed (must match `int-string-re`
+  end-to-end, then sit inside the same safe-integer window — trailing
+  garbage and out-of-range magnitudes fall back to `default`, identically
+  on JVM and CLJS, rf2-ee38b.19 + rf2-ykv9a0). Every other shape falls
+  back to `default`."
   [raw default floor]
   (cond
     (nil? raw)
     default
 
     (number? raw)
-    (max floor (long raw))
+    (if-let [n (coerce-finite-long raw)]
+      (max floor n)
+      default)
 
     (string? raw)
     (let [s (str/trim raw)]
       (if-not (re-matches int-string-re s)
         default
-        #?(:clj  (try
-                   (max floor (Long/parseLong s))
-                   (catch NumberFormatException _ default))
-           ;; Match the JVM `Long/parseLong` posture: a digit string
-           ;; outside the safely-representable integer range is a parse
-           ;; failure → `default` (JVM throws NumberFormatException on
-           ;; long overflow; JS would silently coerce to a lossy float).
-           ;; `js/Number.isSafeInteger` is the CLJS analogue of "fits a
-           ;; long" for the small ints the agent surface produces.
+        ;; Parse to a number, then route through the SAME finite/range
+        ;; guard the numeric arm uses so the string and numeric arms agree
+        ;; AND the two hosts agree (rf2-ykv9a0). On the JVM a digit string
+        ;; past the long range threw `NumberFormatException`; on CLJS a
+        ;; digit string past the safe-integer ceiling silently became a
+        ;; lossy float. Reading both as a BigInteger / BigInt and feeding
+        ;; the safe-integer guard gives one cross-host rejection threshold
+        ;; (the JS safe-integer window) instead of two divergent ones.
+        #?(:clj  (let [n (try (bigint s) (catch NumberFormatException _ nil))]
+                   (if (and n (<= (- max-safe-integer) n max-safe-integer))
+                     (max floor (long n))
+                     default))
            :cljs (let [n (js/parseInt s 10)]
                    (if (and (not (js/isNaN n))
                             (js/Number.isSafeInteger n))

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -61,7 +61,8 @@
   reads the same way on both sides. mcp-base stays free of
   platform-specific deps (`js-interop`, JVM reflection, etc); those
   live in the consumer's IO instance."
-  (:require [re-frame.mcp-base.overflow :as overflow]
+  (:require [re-frame.mcp-base.args :as args]
+            [re-frame.mcp-base.overflow :as overflow]
             [re-frame.mcp-base.vocab :as vocab]))
 
 ;; ---------------------------------------------------------------------------
@@ -118,10 +119,12 @@
 
 (def ^:const invalid-arg-hint
   "Recovery hint embedded in the `:rf.mcp/invalid-arg` rejection when a
-  caller supplies an out-of-domain `:max-tokens` — a negative (rf2-5rdit)
-  or a fractional positive in (0,1) that would floor to a 0-cap lockout
-  (rf2-li6y2.2). States the valid domain AND the disable sentinel so the
-  agent's next call is correct."
+  caller supplies an out-of-domain `:max-tokens` — a negative (rf2-5rdit),
+  a fractional positive in (0,1) that would floor to a 0-cap lockout
+  (rf2-li6y2.2), or a non-finite / out-of-range value (`##Inf`, `##NaN`,
+  `1.0E20`) that would crash or truncate `(long raw)` (rf2-ykv9a0).
+  States the valid domain AND the disable sentinel so the agent's next
+  call is correct."
   "max-tokens must be an integer >= 1; 0 disables the cap")
 
 (defn invalid-arg-marker
@@ -153,8 +156,10 @@
   Returns the integer cap in tokens, `nil` when the cap is disabled
   (caller passed `0`), `overflow/default-max-tokens` when absent or
   not a number, or — for an out-of-domain number (a NEGATIVE, rf2-5rdit;
-  or a fractional positive in (0,1) that would floor to a 0-cap lockout,
-  rf2-li6y2.2) — an `{:rf.mcp/invalid-arg {...}}` REJECTION marker.
+  a fractional positive in (0,1) that would floor to a 0-cap lockout,
+  rf2-li6y2.2; or a NON-FINITE / OUT-OF-RANGE value — `##Inf`, `##NaN`,
+  `1.0E20` — that would crash or truncate `(long raw)`, rf2-ykv9a0) — an
+  `{:rf.mcp/invalid-arg {...}}` REJECTION marker.
 
   Each consumer extracts the raw value from its platform-specific args
   object — re-frame2-pair-mcp uses `(j/get args \"max-tokens\")` against a JS
@@ -171,9 +176,11 @@
     OR supplied a non-number. The default applies.
   - positive integer return ⇒ caller supplied a custom cap.
   - `{:rf.mcp/invalid-arg {...}}` return ⇒ caller supplied an out-of-domain
-    number: a NEGATIVE (rf2-5rdit) OR a fractional positive in (0,1) that
-    would floor to a real 0-cap lockout (rf2-li6y2.2). The consumer surfaces
-    this as an `isError: true` result (test via `invalid-arg?`) and MUST NOT
+    number: a NEGATIVE (rf2-5rdit), a fractional positive in (0,1) that
+    would floor to a real 0-cap lockout (rf2-li6y2.2), or a NON-FINITE /
+    OUT-OF-RANGE value (`##Inf` / `##NaN` / past the safe-integer window —
+    rf2-ykv9a0). The consumer surfaces this as an `isError: true` result
+    (test via `invalid-arg?`) and MUST NOT
     pass it to `apply-cap`.
 
   ## Why negatives are rejected, not clamped (rf2-5rdit)
@@ -191,16 +198,28 @@
   [raw]
   (cond
     (nil? raw)                       overflow/default-max-tokens
-    (and (number? raw) (zero? raw))  nil
-    (and (number? raw) (neg? raw))   (invalid-arg-marker :max-tokens raw invalid-arg-hint)
+    (not (number? raw))              overflow/default-max-tokens
+    (zero? raw)                      nil
+    (neg? raw)                       (invalid-arg-marker :max-tokens raw invalid-arg-hint)
     ;; A fractional positive in (0,1) — e.g. 0.5 — would `(long …)` floor
     ;; to a REAL 0 cap (non-nil, NOT the disable sentinel). `apply-cap`
     ;; then over-trips on EVERY non-empty payload, locking the agent out —
     ;; the exact lockout class rf2-5rdit rejected for negatives (rf2-li6y2.2).
     ;; Reject it honestly rather than silently flooring to a 0-cap lockout.
-    (and (number? raw) (< raw 1))    (invalid-arg-marker :max-tokens raw invalid-arg-hint)
-    (number? raw)                    (long raw)
-    :else                            overflow/default-max-tokens))
+    (< raw 1)                        (invalid-arg-marker :max-tokens raw invalid-arg-hint)
+    ;; Finite/range guard BEFORE `(long raw)` (rf2-ykv9a0). `##Inf` and a
+    ;; finite magnitude past the safe-integer window (`1.0E20`) THROW
+    ;; `IllegalArgumentException` on `(long raw)` (JVM); `##NaN` truncates
+    ;; to a real `0` cap — the exact 0-cap lockout this resolver exists to
+    ;; refuse. (`##NaN`/`##-Inf` are also already excluded by `(neg? raw)`
+    ;; / `(< raw 1)` being false for them, so they reach here.) Coerce
+    ;; through the shared cross-runtime guard: an out-of-domain value
+    ;; yields `nil` ⇒ reject honestly, identically on JVM and CLJS, rather
+    ;; than crashing the tool or minting a 0-cap.
+    :else
+    (if-let [n (args/coerce-finite-long raw)]
+      n
+      (invalid-arg-marker :max-tokens raw invalid-arg-hint))))
 
 ;; ---------------------------------------------------------------------------
 ;; sum-text-tokens — cumulative token count across the result's :text slots.

--- a/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
@@ -147,21 +147,57 @@
   {'inst (fn [_] (bad-tag! 'inst))
    'uuid (fn [_] (bad-tag! 'uuid))})
 
+(defn- bad-trailing!
+  "Throw the cursor-boundary multi-form rejection. A cursor is ONE
+  opaque EDN payload map; decoded text carrying a second form (a
+  trailing tagged literal, a trailing ordinary EDN value, garbage)
+  is malformed. Caught by the surrounding try in `decode-cursor` →
+  `::malformed`."
+  []
+  (throw (ex-info ":rf.error/mcp-cursor-trailing-form"
+                  {:rf.error/id :rf.error/mcp-cursor-trailing-form
+                   :where       'mcp-base/decode-cursor
+                   :recovery    :no-recovery
+                   :reason      "EDN cursor decoded to more than one form — a cursor is one opaque payload map"})))
+
 (defn- read-edn-no-tags
-  "Read an EDN string with EVERY tagged literal rejected — built-in
-  (`#inst` / `#uuid`) AND custom (`#js`, `#foo/bar`, …). The `:readers`
-  overrides throw on the two built-in tags that would otherwise bypass
-  `:default` (they have registered readers), and the `:default`
-  data-reader throws `:rf.error/mcp-cursor-bad-edn-tag` on every
-  remaining unregistered tag. A hostile / corrupt cursor therefore
-  cannot smuggle ANY tagged literal — or the host object it would
-  decode to — past the reader. Caught by the surrounding try in
-  `decode-cursor` → `::malformed`."
+  "Read a cursor's decoded EDN string as EXACTLY ONE form, with EVERY
+  tagged literal rejected — built-in (`#inst` / `#uuid`) AND custom
+  (`#js`, `#foo/bar`, …). The `:readers` overrides throw on the two
+  built-in tags that would otherwise bypass `:default` (they have
+  registered readers), and the `:default` data-reader throws
+  `:rf.error/mcp-cursor-bad-edn-tag` on every remaining unregistered
+  tag.
+
+  ## One form, EOF-exhausted (rf2-ykv9a0)
+
+  A cursor is ONE opaque payload map; a token whose decoded text is a
+  valid map FOLLOWED by a second form — e.g.
+  `{:v 1 :offset 0 :sig \"s\"} #inst \"2024-01-01\"` or
+  `{...} {:junk 1}` — must be rejected as `::malformed`, not silently
+  accepted on the strength of its first form (which would ignore the
+  trailing object and weaken the opacity / corruption guard). A plain
+  `read-string` reads only the FIRST form and never checks exhaustion.
+
+  We close that by wrapping the decoded text in `[ … ]` and reading the
+  WHOLE thing as one vector: a single clean form yields a one-element
+  vector (trailing whitespace / comments are absorbed), while ANY
+  trailing form yields a 2+-element vector → `bad-trailing!`. This is a
+  pure-`read-string` technique that behaves identically on the JVM
+  (`clojure.edn`) and CLJS (`cljs.reader`) without reaching into either
+  host's pushback-reader internals. Tagged literals anywhere inside the
+  wrapped text still throw via the readers above. Returns the sole
+  decoded form (so the caller's `map?` / `valid?` checks are unchanged).
+  Caught by the surrounding try in `decode-cursor` → `::malformed`."
   [s]
-  (let [opts {:readers no-tag-readers
-              :default (fn [tag _val] (bad-tag! tag))}]
-    #?(:clj  (edn/read-string opts s)
-       :cljs (cljs.reader/read-string opts s))))
+  (let [opts    {:readers no-tag-readers
+                 :default (fn [tag _val] (bad-tag! tag))}
+        wrapped (str "[" s "]")
+        forms   #?(:clj  (edn/read-string opts wrapped)
+                   :cljs (cljs.reader/read-string opts wrapped))]
+    (if (and (vector? forms) (= 1 (count forms)))
+      (first forms)
+      (bad-trailing!))))
 
 (defn decode-cursor
   "Decode an opaque base64 cursor back to its EDN payload map.
@@ -173,6 +209,8 @@
     - `::malformed` — the cursor exists but is not a well-formed,
                       `valid?`-passing payload map: it failed to
                       base64/EDN-decode, carried a tagged literal,
+                      decoded to MORE THAN ONE EDN form (a trailing
+                      object after the payload map — rf2-ykv9a0),
                       exceeded `max-cursor-bytes`, or its payload map
                       failed the consumer's `valid?` predicate. Callers
                       treat `::malformed` exactly like a STALE cursor —

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -316,12 +316,50 @@
   [a b path]
   (collect-patches-into [] a b path))
 
+(defn- dissoc-in
+  "Remove the key at `path` (a non-empty path vector) from `m`, a
+  no-op when the path's parent is absent or is not a map (rf2-ykv9a0).
+
+  The spec contract for `[<path> :dissoc]` is 'remove the key at
+  `path`; a no-op if it does not exist'. The naive
+  `(update-in m parent dissoc k)` violates this two ways when the
+  parent path doesn't resolve to a map:
+
+    - a MISSING parent manufactures nil branches —
+      `(update-in {} [:missing] dissoc :leaf)` ⇒ `{:missing nil}`,
+      `(update-in {:a {}} [:a :b] dissoc :c)` ⇒ `{:a {:b nil}}` —
+      corrupting the reconstructed `:db-after` into a shape neither
+      encoder side emitted;
+    - a SCALAR parent throws a host `ClassCastException`
+      (`(update-in {:a 1} [:a] dissoc :b)`), surfacing a raw host
+      exception at the wire decoder boundary.
+
+  `apply-patches`'s own grammar gate pins the patch SHAPE, but cannot
+  prove a patch's parent path exists in THIS `base` — a malformed /
+  corrupt / third-party diff replayed against a mismatched base is
+  exactly the case this guards. We honour the spec no-op: dissoc only
+  when the parent resolves to a map; otherwise return `m` unchanged.
+
+  `path` is always non-empty here (the root `[]` `:dissoc` is handled
+  by convention as a no-op in `apply-patches*` before this is called)."
+  [m path]
+  (let [parent-path (vec (butlast path))
+        k           (last path)]
+    (if (empty? parent-path)
+      (if (map? m) (dissoc m k) m)
+      (let [parent (get-in m parent-path)]
+        (if (map? parent)
+          (assoc-in m parent-path (dissoc parent k))
+          m)))))
+
 (defn- apply-patches*
   "Replay an already-validated patch vector against `base`, returning
   the reconstructed value. Patches are `[path :assoc v]` or
   `[path :dissoc]`. Root-path patches (path `[]`) replace `base`
   outright (for `:assoc`) or are a no-op (for `:dissoc`, by
-  convention).
+  convention). Nested `:dissoc` routes through `dissoc-in`, whose
+  missing-/scalar-parent no-op honours the spec contract (no
+  nil-branch manufacture, no host `ClassCastException` — rf2-ykv9a0).
 
   This is the non-validating core: callers that have ALREADY validated
   the patch grammar (e.g. `decode-db-after`, whose `validate-sections!`
@@ -340,11 +378,7 @@
           (= op :assoc)
           (assoc-in acc path v)
           (= op :dissoc)
-          (let [parent-path (vec (butlast path))
-                k           (last path)]
-            (if (empty? parent-path)
-              (dissoc acc k)
-              (update-in acc parent-path dissoc k)))
+          (dissoc-in acc path)
           :else acc)))
     base
     patches))
@@ -409,7 +443,13 @@
     epoch
     (let [patches  (collect-patches (:db-before epoch) (:db-after epoch) [])
           _        (validate-patches! patches 'mcp-base/diff-encode-db-after)
-          sections (sg/group-patches-into-sections patches)
+          ;; Thread `:db-before` so section classification can prove a
+          ;; container is genuinely NEW before claiming `:added` — patch
+          ;; shape alone cannot (`:assoc` covers both insert and change,
+          ;; rf2-ykv9a0). Without this an existing parent whose direct
+          ;; child changed would be mislabelled `:added` to the agent.
+          sections (sg/group-patches-into-sections
+                     patches {:db-before (:db-before epoch)})
           _        (validate-sections! sections 'mcp-base/diff-encode-db-after)]
       (assoc epoch :db-after
              {vocab/diff-from-key :db-before

--- a/tools/mcp-base/src/re_frame/mcp_base/section_grouping.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/section_grouping.cljc
@@ -50,10 +50,13 @@
         :patches      [[[:checkout :state] :assoc :paying]]}]
 
   `:section-kind` summarises the cluster: `:added` when every patch
-  is `:assoc` at a path strictly deeper than the section-path
-  (newly-introduced subtree); `:removed` when every patch is
-  `:dissoc`; otherwise `:modified`. The agent uses this to skim
-  cluster intent without walking every patch.
+  is `:assoc` at a path one level under the section-path AND the
+  section-path container was ABSENT in `:db-before` (newly-introduced
+  subtree); `:removed` when every patch is `:dissoc`; otherwise
+  `:modified`. The agent uses this to skim cluster intent without
+  walking every patch. (`:added` requires `:db-before` context —
+  see §Classify each section for why patch shape alone can't prove
+  it; rf2-ykv9a0.)
 
   ## Algorithm
 
@@ -95,21 +98,32 @@
      - All `:dissoc` → `:section-kind :removed`.
      - All `:assoc` AND `:section-path` is the immediate parent of
        each patch's path (the cluster sits one level deep under the
-       header) → `:section-kind :added` (newly-introduced
-       container). Most-common case for newly-added subtrees.
+       header) AND the container was ABSENT in `:db-before` →
+       `:section-kind :added` (newly-introduced container).
      - Otherwise → `:section-kind :modified`. The conservative
        default; the agent reads `:modified` and knows the cluster
        carries a mix of inserts / changes / deletes.
 
-     A more precise `:added` vs `:modified` split would require
-     looking at `:db-before` to detect 'was this path previously
-     absent?' — patches alone can't tell. The current rule is the
-     cheapest accurate signal: a section is `:added` only when all
-     its patches insert leaves under a fresh parent. False
-     negatives (a wholly-added subtree shaped as multiple
-     `:assoc`s under the same header that actually corresponds to
-     a parent that already existed but was empty) are tagged
-     `:modified` — semantically defensible.
+     ## Why `:added` needs `:db-before` (rf2-ykv9a0)
+
+     The patch grammar uses `:assoc` for BOTH inserted and changed
+     leaves, so patch SHAPE alone cannot distinguish a newly-added
+     container from an existing one whose direct children changed.
+     `{:user {:name \"bob\"}}` → `{:user {:name \"ada\" :email \"…\"}}`
+     emits the SAME all-`:assoc` direct-child cluster under `[:user]`
+     as a genuinely new `[:user]` subtree — a patch-only classifier
+     mislabels the FIRST (a modification) as `:added`, a false skim
+     signal to the agent. So `:added` is claimed ONLY when
+     `:db-before` (threaded through `opts`, supplied by the
+     `diff-encode-db-after` caller) proves the section-path container
+     did not previously exist.
+
+     When `:db-before` is NOT supplied — the standalone projection
+     used by tests / advanced consumers diffing arbitrary structures —
+     the classifier cannot prove addition, so it conservatively errs
+     to `:modified` for every all-`:assoc` cluster rather than risk a
+     false `:added`. Concatenating sections' `:patches` still
+     round-trips losslessly regardless of the cosmetic `:section-kind`.
 
   ## Whole-DB replacement
 
@@ -232,8 +246,9 @@
 
 (defn- patches-all-direct-child?
   "True when every patch's path is exactly one segment deeper than
-  `prefix`. Together with all-`:assoc` this signals 'newly-added
-  subtree under a fresh container' — the `:added` case."
+  `prefix`. Together with all-`:assoc` AND a previously-absent container
+  this signals 'newly-added subtree under a fresh container' — the
+  `:added` case."
   [patches prefix]
   (let [prefix-len (count prefix)]
     (every? (fn [patch]
@@ -241,16 +256,47 @@
                 (= (count path) (inc prefix-len))))
             patches)))
 
+(def ^:private absent
+  "Private sentinel for `get-in` miss detection — distinguishes a stored
+  `nil` from an absent key (rf2-ykv9a0)."
+  #?(:clj (Object.) :cljs (js-obj)))
+
+(defn- path-present?
+  "True when `path` resolves to a present key in `m` (a map). Uses a
+  private sentinel so a stored `nil` counts as present and an absent key
+  counts as absent. The empty path `[]` denotes the root, always
+  present. A non-map `m` (no `:db-before` context) yields `false` only
+  via the caller's guard — this fn assumes `m` is a map."
+  [m path]
+  (or (empty? path)
+      (not (identical? absent (get-in m path absent)))))
+
 (defn- section-kind
   "Classify a cluster as `:added` / `:removed` / `:modified`. See
-  §Classify each section in the ns docstring for the rules."
-  [prefix patches]
+  §Classify each section in the ns docstring for the rules.
+
+  `container-existed?` answers 'did the cluster's section-path container
+  ALREADY exist in `:db-before`?'. The patch grammar uses `:assoc` for
+  BOTH inserted and changed leaves, so patch shape ALONE cannot tell a
+  newly-added container from an existing one whose direct children
+  changed (rf2-ykv9a0): `{:user {:name \"bob\"}}` →
+  `{:user {:name \"ada\" :email \"…\"}}` emits the SAME all-`:assoc`
+  direct-child cluster under `[:user]` as a genuinely new `[:user]`
+  subtree would. `:added` is therefore claimed ONLY when the patches are
+  all-`:assoc` direct children AND the container did NOT previously
+  exist. When the caller cannot supply that context (the
+  `db-before`-less standalone projection), `container-existed?` is
+  passed as `true` so the classifier conservatively errs to `:modified`
+  rather than a false `:added` — the masterpiece-CORRECTNESS posture
+  (a false `:added` mislabels a modification to the agent's skim signal)."
+  [prefix patches container-existed?]
   (cond
     (all-op? patches :dissoc)
     :removed
 
     (and (all-op? patches :assoc)
-         (patches-all-direct-child? patches prefix))
+         (patches-all-direct-child? patches prefix)
+         (not container-existed?))
     :added
 
     :else
@@ -290,12 +336,31 @@
   Args:
     `patches` — the flat patch vector (e.g. from
                 `re-frame.mcp-base.diff-encode/collect-patches`).
-    `opts`    — optional `{:max-coalesce-depth 3}` (default).
+    `opts`    — optional map:
+                `:max-coalesce-depth` (default 3).
+                `:db-before` — the pre-change value the patches diff
+                from. When supplied, `:section-kind :added` is claimed
+                only for an all-`:assoc` direct-child cluster whose
+                container was ABSENT in `:db-before` (rf2-ykv9a0).
+                When absent, the classifier cannot prove addition and
+                errs to `:modified` for every all-`:assoc` cluster.
 
   Pure data → data; JVM-runnable (`.cljc`)."
   ([patches] (group-patches-into-sections patches nil))
   ([patches opts]
-   (let [{:keys [max-coalesce-depth]} (merge default-opts opts)]
+   (let [{:keys [max-coalesce-depth db-before]} (merge default-opts opts)
+         ;; `:added` requires PROOF the container is newly introduced —
+         ;; patch shape alone cannot supply it (`:assoc` covers both
+         ;; insert and change, rf2-ykv9a0). When `:db-before` is threaded
+         ;; in (the `diff-encode-db-after` caller has it in hand), a
+         ;; cluster is `:added` only if its section-path was ABSENT
+         ;; before. Without it (standalone projection) every cluster's
+         ;; container counts as 'existed' so the classifier errs to the
+         ;; conservative `:modified` rather than a false `:added`.
+         container-existed?
+         (if (map? db-before)
+           (fn [prefix] (path-present? db-before prefix))
+           (constantly true))]
      (cond
        (or (nil? patches) (empty? patches))
        []
@@ -309,7 +374,8 @@
          (mapv (fn [cluster]
                  (let [{:keys [prefix patches]} (promote-singleton cluster)]
                    {:section-path prefix
-                    :section-kind (section-kind prefix patches)
+                    :section-kind (section-kind prefix patches
+                                                (container-existed? prefix))
                     :patches      patches}))
                clusters))))))
 

--- a/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
@@ -109,6 +109,52 @@
   (is (= 50 (args/parse-positive-int "99999999999999999999999999" 50))))
 
 ;; ---------------------------------------------------------------------------
+;; Cross-runtime finite/range guard (rf2-ykv9a0).
+;;
+;; The numeric arm called `(long raw)` with no finite/range guard. On the
+;; JVM `(long ##Inf)` / `(long 1.0E20)` THROW IllegalArgumentException and
+;; `(long ##NaN)` truncates to a real `0` — neither the recoverable
+;; default nor a crash-free, host-consistent result. The string arm
+;; diverged across hosts at the JS safe-integer ceiling. The fix routes
+;; both arms through one safe-integer-windowed guard so an out-of-domain
+;; numeric / string DEFAULTS (never throws, never truncates to a real
+;; value) identically on JVM and CLJS. The CLJS mirror lives in
+;; cljs_branches_cljs_test.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-positive-int-out-of-domain-numerics-default-not-throw
+  (is (= 50 (args/parse-positive-int ##Inf 50)) "##Inf defaults (was IllegalArgumentException)")
+  (is (= 50 (args/parse-positive-int ##-Inf 50)) "##-Inf defaults")
+  (is (= 50 (args/parse-positive-int ##NaN 50)) "##NaN defaults (was a real floor of 1)")
+  (is (= 50 (args/parse-positive-int 1.0E20 50)) "1.0E20 defaults (was IllegalArgumentException)")
+  (is (= 50 (args/parse-positive-int -1.0E20 50)) "-1.0E20 defaults"))
+
+(deftest parse-non-negative-int-out-of-domain-numerics-default-not-throw
+  (is (= 5000 (args/parse-non-negative-int ##Inf 5000)) "##Inf defaults")
+  (is (= 5000 (args/parse-non-negative-int ##NaN 5000)) "##NaN defaults (was a real floor of 0)")
+  (is (= 5000 (args/parse-non-negative-int 1.0E20 5000)) "1.0E20 defaults"))
+
+(deftest parse-positive-int-in-domain-numerics-still-parse
+  ;; The guard must not regress the legitimate small-int surface.
+  (is (= 5 (args/parse-positive-int 5 50)))
+  (is (= 2 (args/parse-positive-int 2.9 50)) "in-range fractional floors (benign)")
+  (is (= 1 (args/parse-positive-int 0.5 50)) "sub-1 positive floors to 0 then clamps to the floor 1")
+  (is (= 9007199254740991 (args/parse-positive-int 9007199254740991 50))
+      "the safe-integer ceiling itself is in-domain"))
+
+(deftest parse-positive-int-string-threshold-aligns-to-safe-integer
+  ;; rf2-ykv9a0 — the string arm previously diverged: the JVM
+  ;; `Long/parseLong` accepted "9007199254740992" (a valid long, just
+  ;; past the JS safe-integer ceiling) while CLJS rejected it via
+  ;; Number.isSafeInteger. Aligning the JVM arm to the SAME safe-integer
+  ;; window makes the two hosts agree (the cross-runtime contract). The
+  ;; CLJS mirror asserts the identical value in cljs_branches_cljs_test.
+  (is (= 50 (args/parse-positive-int "9007199254740992" 50))
+      "one past the safe-integer ceiling defaults on BOTH hosts now (was parsed on JVM)")
+  (is (= 9007199254740991 (args/parse-positive-int "9007199254740991" 50))
+      "exactly the safe-integer ceiling is still accepted on both hosts"))
+
+;; ---------------------------------------------------------------------------
 ;; fresh-keyword — positive-named intern for operator-gated write paths
 ;; (rf2-xxtrz, the successor to the retired `parse-keyword`).
 ;; ---------------------------------------------------------------------------

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -129,6 +129,33 @@
   (is (= 1000 (cap/max-tokens 1000.0)))
   (is (integer? (cap/max-tokens 1000.0))))
 
+(deftest max-tokens-non-finite-out-of-range-rejected-not-crash-not-0-cap
+  ;; rf2-ykv9a0 — `(long raw)` is UNSAFE on non-finite / out-of-range
+  ;; numerics. Pre-fix, on the JVM `##Inf` and `1.0E20` THREW
+  ;; IllegalArgumentException (a crash at the wire boundary), and `##NaN`
+  ;; truncated to a real `0` cap — the exact 0-cap lockout shape rf2-5rdit
+  ;; / rf2-li6y2.2 refused. The resolver now rejects each honestly as an
+  ;; {:rf.mcp/invalid-arg} marker, the recoverable cross-runtime posture.
+  (doseq [[label raw] [["##Inf" ##Inf]
+                       ["##NaN" ##NaN]
+                       ["1.0E20" 1.0E20]
+                       ["-1.0E20" -1.0E20]]]
+    (let [out (cap/max-tokens raw)]
+      (is (cap/invalid-arg? out)
+          (str label " resolves to an :rf.mcp/invalid-arg rejection, not a crash / cap"))
+      (is (not (number? out))
+          (str label " is NOT a (real) cap integer"))
+      (is (not= 0 out)
+          (str label " must NOT be a real 0 cap (the apply-cap lockout shape)"))
+      (is (some? out)
+          (str label " must NOT be nil (nil is the disable sentinel, distinct from a rejection)"))))
+  ;; ##-Inf is caught earlier by the (neg? raw) arm — still a rejection.
+  (is (cap/invalid-arg? (cap/max-tokens ##-Inf)) "##-Inf rejects (via the negative arm)")
+  ;; The legitimate surface is untouched.
+  (is (= 5000 (cap/max-tokens 5000)) "in-range cap still passes through")
+  (is (= 9007199254740991 (cap/max-tokens 9007199254740991))
+      "the safe-integer ceiling itself is an in-domain cap"))
+
 ;; ---------------------------------------------------------------------------
 ;; sum-text-tokens — sums every :text slot via ResultIO.
 ;; ---------------------------------------------------------------------------

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -31,6 +31,7 @@
             [re-frame.mcp-base.diff-encode :as de]
             [re-frame.mcp-base.envelope :as envelope]
             [re-frame.mcp-base.overflow :as overflow]
+            [re-frame.mcp-base.section-grouping :as sg]
             [re-frame.mcp-base.vocab :as vocab]))
 
 ;; ---------------------------------------------------------------------------
@@ -234,6 +235,98 @@
     (is (= 1 (args/parse-positive-int "-5" 50)) "clamps to floor"))
   (testing "out-of-safe-range digit string rejected (mirrors JVM long overflow)"
     (is (= 50 (args/parse-positive-int "99999999999999999999999999" 50)))))
+
+;; ---------------------------------------------------------------------------
+;; 5b. Cross-runtime finite/range guard on numeric arg coercion (rf2-ykv9a0).
+;;     The numeric arm previously called `(long raw)` with no guard:
+;;     on the JVM `##Inf` / `1.0E20` THROW and `##NaN` truncates to a real
+;;     value, while CLJS would silently coerce. The fix routes both hosts
+;;     through one safe-integer-windowed guard so out-of-domain numerics
+;;     DEFAULT (never crash, never become a real value) IDENTICALLY. These
+;;     CLJS assertions mirror the JVM ones in args_test / cap_test.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-int-finite-range-guard-cljs
+  (testing "out-of-domain numerics default (mirrors JVM)"
+    (is (= 50 (args/parse-positive-int js/Infinity 50)) "Infinity defaults")
+    (is (= 50 (args/parse-positive-int (- js/Infinity) 50)) "-Infinity defaults")
+    (is (= 50 (args/parse-positive-int js/NaN 50)) "NaN defaults (not a real floor)")
+    (is (= 50 (args/parse-positive-int 1e20 50)) "1e20 defaults (past safe-integer window)")
+    (is (= 5000 (args/parse-non-negative-int js/NaN 5000)) "NaN defaults (not a real 0)"))
+  (testing "in-domain numerics still parse"
+    (is (= 5 (args/parse-positive-int 5 50)))
+    (is (= 2 (args/parse-positive-int 2.9 50)) "in-range fractional floors")
+    (is (= 1 (args/parse-positive-int 0.5 50)) "sub-1 positive floors then clamps to floor 1")
+    (is (= 9007199254740991 (args/parse-positive-int 9007199254740991 50))
+        "safe-integer ceiling is in-domain"))
+  (testing "string threshold aligns to the safe-integer window on both hosts"
+    (is (= 50 (args/parse-positive-int "9007199254740992" 50))
+        "one past the ceiling defaults on CLJS AND JVM (JVM no longer parses it)")
+    (is (= 9007199254740991 (args/parse-positive-int "9007199254740991" 50))
+        "exactly the ceiling still parses on both hosts")))
+
+(deftest max-tokens-finite-range-guard-cljs
+  ;; rf2-ykv9a0 — non-finite / out-of-range `:max-tokens` rejects with an
+  ;; {:rf.mcp/invalid-arg} marker on CLJS too, never a crash / real 0-cap.
+  (doseq [raw [js/Infinity js/NaN 1e20 (- 1e20)]]
+    (let [out (cap/max-tokens raw)]
+      (is (cap/invalid-arg? out) "non-finite / out-of-range max-tokens rejects")
+      (is (not (number? out)) "rejection is a marker, not a real cap")
+      (is (some? out) "not nil — distinct from the disable sentinel")))
+  (is (cap/invalid-arg? (cap/max-tokens (- js/Infinity))) "-Infinity rejects (negative arm)")
+  (is (= 5000 (cap/max-tokens 5000)) "in-range cap passes through"))
+
+;; ---------------------------------------------------------------------------
+;; 5c. Cursor rejects trailing forms on CLJS too (rf2-ykv9a0). A cursor is
+;;     ONE opaque payload map; decoded text with a trailing form (tagged
+;;     literal, ordinary EDN, scalar) ⇒ ::malformed. The wrap-in-[...]
+;;     one-form check runs identically on cljs.reader.
+;; ---------------------------------------------------------------------------
+
+(deftest cursor-rejects-trailing-forms-cljs
+  (let [pair? (fn [m] (and (map? m) (some? (:after-id m))))]
+    (testing "valid map + trailing form ⇒ ::malformed"
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor
+               (cursor/b64-encode "{:v 1 :after-id 1} #inst \"2024-01-01T00:00:00.000-00:00\"")
+               pair?)))
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor
+               (cursor/b64-encode "{:v 1 :after-id 1} {:junk 1}")
+               pair?)))
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor
+               (cursor/b64-encode "{:v 1 :after-id 1} 42")
+               pair?))))
+    (testing "a single clean cursor still round-trips"
+      (is (= {:v 1 :after-id "ev-9"}
+             (cursor/decode-cursor (cursor/encode-cursor {:v 1 :after-id "ev-9"}) pair?))))))
+
+;; ---------------------------------------------------------------------------
+;; 5d. apply-patches nested :dissoc no-op + section-kind :db-before
+;;     classification run under CLJS too (rf2-ykv9a0).
+;; ---------------------------------------------------------------------------
+
+(deftest apply-patches-nested-dissoc-noop-cljs
+  (testing "missing / scalar parent ⇒ no-op (no nil branches, no host throw)"
+    (is (= {} (de/apply-patches {} [[[:missing :leaf] :dissoc]])))
+    (is (= {:a {}} (de/apply-patches {:a {}} [[[:a :b :c] :dissoc]])))
+    (is (= {:a 1} (de/apply-patches {:a 1} [[[:a :b] :dissoc]]))))
+  (testing "valid nested + root dissoc unchanged"
+    (is (= {:a {:c 2}} (de/apply-patches {:a {:b 1 :c 2}} [[[:a :b] :dissoc]])))
+    (is (= {:a 1} (de/apply-patches {:a 1 :b 2} [[[:b] :dissoc]])))))
+
+(deftest section-kind-db-before-classification-cljs
+  (let [patches [[[:user :name]  :assoc "ada"]
+                 [[:user :email] :assoc "x"]]]
+    (is (= :modified (:section-kind (first (sg/group-patches-into-sections patches))))
+        "no :db-before ⇒ conservative :modified")
+    (is (= :modified (:section-kind (first (sg/group-patches-into-sections
+                                             patches {:db-before {:user {:name "bob"}}}))))
+        "existing container ⇒ :modified, not a false :added")
+    (is (= :added (:section-kind (first (sg/group-patches-into-sections
+                                          patches {:db-before {}}))))
+        "absent container + direct-child assocs ⇒ :added")))
 
 ;; ---------------------------------------------------------------------------
 ;; 6. Shared cursor codec round-trips under CLJS (rf2-ee38b.19). The base64

--- a/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
@@ -180,6 +180,36 @@
              (cursor/decode-cursor (cursor/encode-cursor {:v 1 :after-id "ev-9"})
                                    permissive?))))))
 
+(deftest decode-cursor-rejects-trailing-forms
+  ;; rf2-ykv9a0 — a cursor is ONE opaque EDN payload map. Before the fix
+  ;; `read-edn-no-tags` used `read-string`, which reads only the FIRST
+  ;; form and never checks the input is exhausted: a token whose decoded
+  ;; text is a valid map FOLLOWED by a second form decoded as the valid
+  ;; map, silently IGNORING the trailing object — accepting mutated
+  ;; multi-form cursor text and weakening the opacity / corruption guard.
+  ;; The reader now requires the decoded text to be exactly one form;
+  ;; any trailing form ⇒ ::malformed.
+  (testing "valid map + trailing #inst ⇒ ::malformed (not the silently-accepted first form)"
+    (let [evil (cursor/b64-encode "{:v 1 :offset 0 :total 1 :sig \"s\"} #inst \"2024-01-01\"")]
+      (is (= ::cursor/malformed (cursor/decode-cursor evil offset-cursor?)))))
+  (testing "valid map + trailing custom tag ⇒ ::malformed"
+    (let [evil (cursor/b64-encode "{:v 1 :offset 0 :total 1 :sig \"s\"} #foo/bar 1")]
+      (is (= ::cursor/malformed (cursor/decode-cursor evil offset-cursor?)))))
+  (testing "valid map + trailing ordinary EDN ⇒ ::malformed"
+    (let [evil (cursor/b64-encode "{:v 1 :offset 0 :total 1 :sig \"s\"} {:junk 1}")]
+      (is (= ::cursor/malformed (cursor/decode-cursor evil offset-cursor?)))))
+  (testing "valid map + trailing scalar ⇒ ::malformed"
+    (let [evil (cursor/b64-encode "{:v 1 :offset 0 :total 1 :sig \"s\"} 42")]
+      (is (= ::cursor/malformed (cursor/decode-cursor evil offset-cursor?)))))
+  (testing "a single clean cursor (incl. trailing whitespace) still round-trips"
+    (let [clean (cursor/encode-cursor {:v 1 :offset 0 :total 1 :sig "s"})]
+      (is (= {:v 1 :offset 0 :total 1 :sig "s"}
+             (cursor/decode-cursor clean offset-cursor?))))
+    (let [trailing-ws (cursor/b64-encode "{:v 1 :offset 0 :total 1 :sig \"s\"}   ")]
+      (is (= {:v 1 :offset 0 :total 1 :sig "s"}
+             (cursor/decode-cursor trailing-ws offset-cursor?))
+          "trailing whitespace is absorbed — one form, valid"))))
+
 (deftest malformed?-predicate
   (is (true? (cursor/malformed? ::cursor/malformed)))
   (is (false? (cursor/malformed? nil)))

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -82,6 +82,30 @@
            (de/apply-patches {:a 1} [[[:a] :dissoc]
                                      [[:a] :assoc 7]])))))
 
+(deftest apply-patches-nested-dissoc-missing-or-scalar-parent-is-noop
+  ;; rf2-ykv9a0 — `[<path> :dissoc]` is a no-op when the key does not
+  ;; exist (per the spec). The naive `(update-in acc parent dissoc k)`
+  ;; violated this: a MISSING parent manufactured nil branches, and a
+  ;; SCALAR parent threw a host ClassCastException at the decoder
+  ;; boundary. `apply-patches` is the public wire decoder; a malformed /
+  ;; corrupt / third-party diff replayed against a mismatched base must
+  ;; not corrupt the base into a shape neither side emitted, nor crash.
+  (testing "missing direct parent ⇒ no-op (no nil-branch manufacture)"
+    (is (= {} (de/apply-patches {} [[[:missing :leaf] :dissoc]]))
+        "was {:missing nil} before the fix"))
+  (testing "missing deeper parent ⇒ no-op"
+    (is (= {:a {}} (de/apply-patches {:a {}} [[[:a :b :c] :dissoc]]))
+        "was {:a {:b nil}} before the fix"))
+  (testing "scalar parent ⇒ no-op (no host ClassCastException)"
+    (is (= {:a 1} (de/apply-patches {:a 1} [[[:a :b] :dissoc]]))
+        "was a thrown ClassCastException before the fix"))
+  (testing "valid nested dissoc still removes the key"
+    (is (= {:a {:c 2}} (de/apply-patches {:a {:b 1 :c 2}} [[[:a :b] :dissoc]]))))
+  (testing "root-key dissoc unchanged"
+    (is (= {:a 1} (de/apply-patches {:a 1 :b 2} [[[:b] :dissoc]]))))
+  (testing "dissoc of an absent root key ⇒ no-op"
+    (is (= {:a 1} (de/apply-patches {:a 1} [[[:z] :dissoc]])))))
+
 ;; ---------------------------------------------------------------------------
 ;; diff-encode-db-after / decode-db-after — round-trip.
 ;; ---------------------------------------------------------------------------
@@ -100,6 +124,50 @@
       (is (= [:b] (:section-path s)))
       (is (= :modified (:section-kind s)))
       (is (= [[[:b] :assoc 3]] (:patches s))))))
+
+(deftest diff-encode-db-after-classifies-modified-not-false-added
+  ;; rf2-ykv9a0 — the encoder threads :db-before into section
+  ;; classification so an all-:assoc direct-child cluster is :added ONLY
+  ;; when its container was genuinely absent before. Patch shape alone
+  ;; can't tell an insert from a change (both are :assoc), so an existing
+  ;; parent whose direct child changed was mislabelled :added — a false
+  ;; skim signal to the agent.
+  ;;
+  ;; Note on collect-patches shapes: a GENUINELY-new multi-key container
+  ;; is emitted as a single whole-subtree `[[:user] :assoc {...}]` patch
+  ;; (collect-patches doesn't recurse into an absent key), which heads as
+  ;; a singleton → :modified. The all-:assoc DIRECT-CHILD shape over the
+  ;; collect-patches pipeline therefore ALWAYS means the container
+  ;; ALREADY existed and its children changed — i.e. the exact case the
+  ;; old patch-only rule falsely tagged :added. The genuine direct-child
+  ;; :added shape only arises from an advanced consumer supplying a
+  ;; synthetic patch list (pinned at the group-patches-into-sections
+  ;; level in section_grouping_test).
+  (testing "existing container, child changed + sibling added ⇒ :modified (NOT a false :added)"
+    (let [epoch    {:db-before {:user {:name "bob"}}
+                    :db-after  {:user {:name "ada" :email "ada@example.com"}}}
+          sections (get-in (de/diff-encode-db-after epoch) [:db-after :sections])
+          user-s   (first (filter #(= [:user] (:section-path %)) sections))]
+      (is (some? user-s) "a [:user] section was produced")
+      (is (= :modified (:section-kind user-s))
+          "[:user] existed in db-before; the cluster is a modification, not an addition")))
+  (testing "genuinely new multi-key container ⇒ one whole-subtree :modified section"
+    (let [epoch    {:db-before {:session :idle}
+                    :db-after  {:session :idle
+                                :user {:name "ada" :email "ada@example.com"}}}
+          sections (get-in (de/diff-encode-db-after epoch) [:db-after :sections])
+          user-s   (first (filter #(= [:user] (:section-path %)) sections))]
+      (is (some? user-s) "a [:user] section was produced")
+      (is (= :modified (:section-kind user-s))
+          "a brand-new key is a whole-subtree singleton assoc — heads :modified, never a false :added")
+      (is (= [[[:user] :assoc {:name "ada" :email "ada@example.com"}]] (:patches user-s)))))
+  (testing "round-trip still reconstructs db-after regardless of cosmetic :section-kind"
+    (doseq [epoch [{:db-before {:user {:name "bob"}}
+                    :db-after  {:user {:name "ada" :email "x"}}}
+                   {:db-before {:session :idle}
+                    :db-after  {:session :idle :user {:name "ada" :email "x"}}}]]
+      (is (= epoch (de/decode-db-after (de/diff-encode-db-after epoch)))
+          (str "encode→decode round-trips for " (pr-str epoch))))))
 
 (deftest diff-encode-then-decode-restores-original
   (let [epoch   {:db-before {:user {:name "ada" :age 30}

--- a/tools/mcp-base/test/re_frame/mcp_base/section_grouping_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/section_grouping_test.clj
@@ -62,8 +62,8 @@
     (is (= 1 (count sections)))
     (let [s (first sections)]
       (is (= [:cart :items 0] (:section-path s)))
-      (is (= :added (:section-kind s))
-          "all-:assoc, all direct children → :added (newly-added subtree)")
+      (is (= :modified (:section-kind s))
+          "all-:assoc direct children WITHOUT :db-before context → :modified (rf2-ykv9a0): patch shape can't prove the container is new")
       (is (= 2 (count (:patches s)))))))
 
 (deftest unrelated-root-keys-stand-as-separate-sections
@@ -154,13 +154,51 @@
         sections (sg/group-patches-into-sections patches)]
     (is (= :removed (:section-kind (first sections))))))
 
-(deftest all-assoc-direct-children-classify-as-added
-  ;; All patches are :assoc at exactly one level below the section
-  ;; path → :added.
+(deftest all-assoc-direct-children-classify-as-added-only-with-db-before-proof
+  ;; rf2-ykv9a0 — the patch grammar uses :assoc for BOTH inserted and
+  ;; changed leaves, so all-:assoc direct-child shape alone CANNOT prove
+  ;; a container is newly added. `:added` is claimed only when :db-before
+  ;; proves the container was absent.
   (let [patches  [[[:user :name]  :assoc "ada"]
-                  [[:user :email] :assoc "ada@example.com"]]
-        sections (sg/group-patches-into-sections patches)]
-    (is (= :added (:section-kind (first sections))))))
+                  [[:user :email] :assoc "ada@example.com"]]]
+    (testing "without :db-before context → conservative :modified (no false :added)"
+      (is (= :modified (:section-kind (first (sg/group-patches-into-sections patches))))))
+    (testing ":db-before proves [:user] is genuinely new → :added"
+      (is (= :added (:section-kind
+                      (first (sg/group-patches-into-sections
+                               patches {:db-before {}}))))
+          "container [:user] absent in db-before ⇒ newly-introduced subtree"))
+    (testing ":db-before shows [:user] already existed (a sibling changed) → :modified, NOT a false :added"
+      (is (= :modified (:section-kind
+                         (first (sg/group-patches-into-sections
+                                  patches {:db-before {:user {:name "bob"}}}))))
+          "existing [:user] whose direct children changed is a modification, not an addition"))))
+
+(deftest synthetic-direct-child-cluster-under-absent-container-classifies-as-added
+  ;; rf2-ykv9a0 — the genuine :added shape. An advanced consumer
+  ;; supplies a synthetic patch list (NOT from collect-patches, which
+  ;; emits a whole-subtree singleton for a brand-new key): direct-child
+  ;; :assoc patches under a container that :db-before proves was absent.
+  ;; THAT is a real newly-introduced subtree → :added.
+  (let [patches [[[:user :name]  :assoc "ada"]
+                 [[:user :email] :assoc "ada@example.com"]]]
+    (is (= :added (:section-kind
+                    (first (sg/group-patches-into-sections patches {:db-before {}}))))
+        "[:user] absent in db-before + all-:assoc direct children ⇒ :added")
+    (is (= :added (:section-kind
+                    (first (sg/group-patches-into-sections patches {:db-before {:session :idle}}))))
+        "[:user] still absent (only :session present) ⇒ :added")))
+
+(deftest db-before-with-stored-nil-counts-container-as-present
+  ;; A stored `nil` under the container key is PRESENT, not absent — the
+  ;; sentinel-based path-present? check distinguishes a stored nil from a
+  ;; missing key. So an all-:assoc direct-child cluster whose container
+  ;; key is present-but-nil classifies :modified, not a false :added.
+  (let [patches [[[:user :name]  :assoc "ada"]
+                 [[:user :email] :assoc "ada@example.com"]]]
+    (is (= :modified (:section-kind
+                       (first (sg/group-patches-into-sections patches {:db-before {:user nil}}))))
+        "[:user] present (stored nil) ⇒ :modified, not a false :added")))
 
 (deftest mixed-assoc-and-dissoc-classify-as-modified
   (let [patches  [[[:user :name]  :assoc "ada"]


### PR DESCRIPTION
Fixes the four findings in the independent correctness review of `tools/mcp-base` (rf2-ykv9a0). All four reproduced via local JVM/CLJS probes before fixing. Lane: `tools/mcp-base/**` only — no consumer (pair-mcp / story-mcp) files touched; the shared coercion fix flows to both consumers through `:local/root`.

## Per-finding disposition

**Finding 1 — arg coercion crashes / diverges on out-of-domain numerics (`args.cljc:56` + `cap.cljc:202`). FIXED.**
Confirmed: JVM `parse-positive-int ##Inf` / `1.0E20` and `max-tokens ##Inf` / `1.0E20` threw `IllegalArgumentException`; `##NaN` floored to a real `1` (positive-int) / `0` (a real 0-cap for max-tokens!); the string arm parsed `"9007199254740992"` on JVM but defaulted on CLJS. Added a shared `args/coerce-finite-long` guard over the JS safe-integer window `[-(2^53-1), 2^53-1]` (the strictest of the two hosts; far wider than any real MCP arg), called BEFORE `(long raw)` by both `parse-int*` and `cap/max-tokens`. Out-of-domain numerics now DEFAULT (int parsers) or REJECT with `:rf.mcp/invalid-arg` (max-tokens), identically on JVM and CLJS — never a crash, never a real 0-cap, never a host-divergent result. The string arm's JVM threshold was aligned to the same safe-integer window (read via `bigint` then range-clamp) so both hosts agree.

**Finding 2 — cursor accepts trailing forms (`cursor.cljc:163`). FIXED.**
Confirmed: `{:v 1 :offset 0 :total 1 :sig "s"} #inst "2024-01-01"`, `{...} {:junk 1}`, `{...} #foo/bar 1` all decoded as the valid first map, silently ignoring the trailing form. `read-edn-no-tags` now wraps the decoded text in `[...]` and requires exactly one form — any trailing form (tagged literal, ordinary EDN, scalar) => `::malformed`. Pure `read-string` technique, identical on `clojure.edn` / `cljs.reader`; trailing whitespace / comments are absorbed; a single clean cursor still round-trips.

**Finding 3 — nested `:dissoc` manufactures nil branches / throws (`diff_encode.cljc:347`). FIXED.**
Confirmed: `{} + [[[:missing :leaf] :dissoc]] => {:missing nil}`; `{:a {}} + [[[:a :b :c] :dissoc]] => {:a {:b nil}}`; `{:a 1} + [[[:a :b] :dissoc]]` threw `ClassCastException`. Added a `dissoc-in` helper that honours the spec no-op (dissoc only when the parent path resolves to a map); a missing or scalar parent is a no-op — no nil-branch manufacture, no host exception at the public wire decoder boundary. Root-key and valid nested dissoc behaviour unchanged.

**Finding 4 — `section-kind` misclassifies modifications as `:added` (`section_grouping.cljc:244`). FIXED (thread `:db-before`).**
Confirmed: `{:user {:name "bob"}}` -> `{:user {:name "ada" :email "..."}}` tagged the `[:user]` cluster `:added` even though `:user` already existed. The patch grammar uses `:assoc` for both insert and change, so patch shape alone cannot prove addition. Threaded `:db-before` through `diff-encode-db-after` -> `group-patches-into-sections` so `:added` is claimed only when the container was genuinely ABSENT before; without `:db-before` (standalone projection) the classifier conservatively emits `:modified`. (Note: over the `collect-patches` pipeline a genuinely-new multi-key container is a whole-subtree singleton `:assoc` -> `:modified`; the direct-child `:added` shape only arises from a synthetic patch list, pinned at the `group-patches-into-sections` level.)

Per-ns spec docs (`args.md`, `cap.md`, `cursor.md`, `diff-encode.md`, `section-grouping.md`) updated to match.

## Quality gates

- `tools/mcp-base` JVM (`clojure -M:test`): **211 tests, 661 assertions, 0 failures, 0 errors**.
- `tools/mcp-base` CLJS (`npm run test:cljs`): **14 tests, 82 assertions, 0 failures, 0 errors**.
- `tools/story-mcp` JVM consumer (`clojure -M:test`): **241 tests, 1180 assertions, 0 failures, 0 errors**.
- `npm run test:mcp-conformance` (repo root): **all six gates GREEN** (story-mcp JVM + Node stdio, pair-mcp :server-test, pair-mcp + story-mcp end-to-end conformance, wire-vocab 57/687).

Closes rf2-ykv9a0.