### PR TITLE
fix(mcp-conformance): independent-review findings (rf2-wqi4n4)

### DIFF
--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -14,6 +14,7 @@
     "test:flag-gates": "node test/end-to-end-flag-gates.cjs",
     "test:exec-safety": "node --test test/exec-safety.test.cjs",
     "test:runner-watchdog": "node --test test/runner-watchdog.test.cjs",
+    "test:hermetic-setup-timeout": "node --test test/hermetic-setup-timeout.test.cjs",
     "test": "node scripts/test-all.cjs"
   },
   "dependencies": {

--- a/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
+++ b/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
@@ -51,6 +51,15 @@
  * on a cold CI runner. The shadow-cljs `watch` child + Playwright
  * browser are killed in the `finally`; SIGINT/SIGTERM also wire to the
  * same cleanup.
+ *
+ * Per rf2-wqi4n4 finding 2: the fixture `npm install` setup runs under an
+ * ASYNC spawn with its own `SETUP_COMMAND_TIMEOUT_MS` cap (see
+ * `runTrusted`). A synchronous `crossSpawn.sync` there would block the
+ * event loop for the install's whole lifetime — during which the
+ * HERMETIC_TIMEOUT_MS watchdog (and signal handlers) physically cannot
+ * fire — so a hung `npm install` would have wedged the run past the outer
+ * CI job timeout. The async spawn keeps the loop live so BOTH the
+ * per-command timeout AND the whole-run watchdog stay armed across setup.
  */
 'use strict';
 
@@ -426,30 +435,125 @@ function trustedExe(name) {
   return resolved;
 }
 
+// Hard cap on any trusted SETUP command (fixture `npm install`). Generous
+// enough for a cold-cache install of the tiny fixture's deps on a slow CI
+// runner, but bounded so a wedged package-manager child can't wedge the
+// whole hermetic run (rf2-wqi4n4 finding 2). Distinct from
+// `HERMETIC_TIMEOUT_MS` (the whole-run cap) — this is the per-setup-command
+// cap that the whole-run watchdog physically CANNOT enforce while a
+// synchronous child blocks the event loop.
+//
+// `$HERMETIC_SETUP_TIMEOUT_MS` overrides the cap for the rf2-wqi4n4
+// finding-2 regression harness ONLY (`hermetic-setup-timeout.test.cjs`
+// drives `runTrusted` against a never-exiting child under a tiny cap to
+// prove the timeout/kill path fires and the loop stays live). Production
+// CI never sets it, so the 300s cap stands.
+const SETUP_COMMAND_TIMEOUT_MS =
+  Number(process.env.HERMETIC_SETUP_TIMEOUT_MS) || 300_000;
+
+// Run a trusted setup command (resolved to an absolute path outside the
+// workspace via `trustedExe`) under an ASYNC spawn with an explicit
+// child-level timeout/kill.
+//
+// Per rf2-wqi4n4 finding 2: the pre-fix shape used `crossSpawn.sync`, which
+// SYNCHRONOUSLY blocks the Node event loop for the child's entire lifetime.
+// While blocked, Node delivers no signals and runs no timers — so the
+// `HERMETIC_TIMEOUT_MS` `setTimeout` watchdog (and the SIGINT/SIGTERM
+// handlers) CANNOT fire. A hung `npm install` (stuck registry fetch, a
+// package-manager prompt, a lock contention) would therefore wedge the
+// whole hermetic job until the OUTER CI job timeout, bypassing this
+// script's own hard time-cap and diagnostics. This is the SAME failure
+// mode the inner-test spawn already documents + avoids (rf2-i3ffz F-PERF-1,
+// `crossSpawn(...)` async there); the setup command had the same hole.
+//
+// The async spawn keeps the event loop live, so both the per-command
+// timeout below AND the whole-run watchdog stay armed. On timeout we
+// SIGTERM the child, then SIGKILL after a short grace, and reject with an
+// orchestration error — surfacing as exit 2 (orchestration failure) within
+// `SETUP_COMMAND_TIMEOUT_MS` rather than the multi-minute CI job timeout.
 function runTrusted(name, args, cwd) {
   const bin = trustedExe(name);
-  // cross-spawn.sync handles the `.cmd` -> cmd.exe dispatch on Windows
+  // cross-spawn (async) handles the `.cmd` -> cmd.exe dispatch on Windows
   // without re-introducing PATH/cwd lookup ambiguity — see the module
   // comment at the top of this file for the contract. Passing the
-  // absolute path is what keeps cross-spawn's `which.sync` from doing
-  // its own cwd-relative walk.
+  // absolute path is what keeps cross-spawn's `which` from doing its own
+  // cwd-relative walk.
   log(`running ${name} ${args.join(' ')} in ${cwd} (bin=${bin})`);
-  const r = crossSpawn.sync(bin, args, {
-    cwd,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: process.env,
+  return new Promise((resolve, reject) => {
+    const child = crossSpawn(bin, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let killTimer = null;
+
+    const settle = (fn, arg) => {
+      if (settled) return;
+      settled = true;
+      if (killTimer) clearTimeout(killTimer);
+      if (timer) clearTimeout(timer);
+      fn(arg);
+    };
+
+    // Per-command hard cap, enforced by the live event loop (the whole
+    // point of the async spawn). On elapse: SIGTERM, then SIGKILL after a
+    // short grace, then reject as an orchestration failure.
+    const timer = setTimeout(() => {
+      logErr(
+        `${name} ${args.join(' ')} exceeded SETUP_COMMAND_TIMEOUT_MS ` +
+          `(${SETUP_COMMAND_TIMEOUT_MS}ms) — killing the setup child`,
+      );
+      try { child.kill('SIGTERM'); } catch {}
+      killTimer = setTimeout(() => {
+        try { child.kill('SIGKILL'); } catch {}
+      }, 5000);
+      killTimer.unref();
+      settle(
+        reject,
+        new Error(
+          `${name} ${args.join(' ')} in ${cwd} timed out after ` +
+            `${SETUP_COMMAND_TIMEOUT_MS}ms (setup command hung — killed)`,
+        ),
+      );
+    }, SETUP_COMMAND_TIMEOUT_MS);
+    timer.unref();
+
+    child.stdout.on('data', (d) => {
+      stdout += String(d);
+      recordChunk(`[${name}:stdout] `, d);
+    });
+    child.stderr.on('data', (d) => {
+      stderr += String(d);
+      recordChunk(`[${name}:stderr] `, d, 'stderr');
+    });
+    child.on('error', (err) => settle(reject, err));
+    child.on('exit', (code, signal) => {
+      if (signal) {
+        // Signal-terminated (incl. our own timeout SIGKILL, which the
+        // timeout branch has already rejected for). Treat as a failure so a
+        // killed setup child never reads as success.
+        settle(
+          reject,
+          new Error(
+            `${name} ${args.join(' ')} in ${cwd} killed by ${signal}`,
+          ),
+        );
+        return;
+      }
+      if (code !== 0) {
+        settle(
+          reject,
+          new Error(`${name} ${args.join(' ')} in ${cwd} exited ${code}`),
+        );
+        return;
+      }
+      log(`${name} exited ${code}`);
+      settle(resolve, undefined);
+    });
   });
-  if (r.stdout) recordChunk(`[${name}:stdout] `, r.stdout);
-  if (r.stderr) recordChunk(`[${name}:stderr] `, r.stderr, 'stderr');
-  if (r.error) {
-    throw r.error;
-  }
-  if (r.status !== 0) {
-    throw new Error(`${name} ${args.join(' ')} in ${cwd} exited ${r.status}`);
-  }
-  log(`${name} exited ${r.status}`);
 }
 
 function resolvePlaywright() {
@@ -517,9 +621,13 @@ async function main() {
   }
 
   // ---- Install fixture deps --------------------------------------------
+  // `await` the async spawn (rf2-wqi4n4 finding 2): the setup command now
+  // runs under a live event loop with its own hard timeout, so a hung
+  // `npm install` is bounded by `SETUP_COMMAND_TIMEOUT_MS` instead of
+  // wedging the whole run past the outer CI job cap.
   if (!exists(path.join(FIXTURE_DIR, 'node_modules'))) {
     log(`installing fixture deps in ${FIXTURE_DIR}`);
-    runTrusted('npm', ['install', '--no-audit', '--no-fund'], FIXTURE_DIR);
+    await runTrusted('npm', ['install', '--no-audit', '--no-fund'], FIXTURE_DIR);
   }
 
   // ---- Boot shadow-cljs watch ------------------------------------------
@@ -826,21 +934,37 @@ const watchdog = setTimeout(() => {
 }, HERMETIC_TIMEOUT_MS);
 watchdog.unref();
 
-main()
-  .then(() => {
-    clearTimeout(watchdog);
-    console.log(
-      `RE-FRAME2-PAIR-MCP live hermetic conformance passed (${INNER_TESTS.length} inner tests).`,
-    );
-    process.exit(0);
-  })
-  .catch((err) => {
-    clearTimeout(watchdog);
-    logErr('FAIL: ' + (err && err.message ? err.message : err));
-    if (err && err.stack) logErr(err.stack);
-    flushDiagnostics();
-    // err.exitCode is set when the inner live-re-frame2-pair-overflow.cjs itself
-    // exited non-zero — surface it so CI distinguishes conformance
-    // failure (1) from orchestration failure (2).
-    process.exit(err && typeof err.exitCode === 'number' ? err.exitCode : 2);
-  });
+// Only auto-run the orchestrator when invoked as the entry-point. Required
+// as a module (by the rf2-wqi4n4 finding-2 `runTrusted` regression test),
+// it exports the unit under test WITHOUT kicking off the whole hermetic run
+// (which would spawn shadow-cljs + Chromium). Guarding the run here keeps
+// the watchdog timer from arming on `require` too.
+if (require.main === module) {
+  main()
+    .then(() => {
+      clearTimeout(watchdog);
+      console.log(
+        `RE-FRAME2-PAIR-MCP live hermetic conformance passed (${INNER_TESTS.length} inner tests).`,
+      );
+      process.exit(0);
+    })
+    .catch((err) => {
+      clearTimeout(watchdog);
+      logErr('FAIL: ' + (err && err.message ? err.message : err));
+      if (err && err.stack) logErr(err.stack);
+      flushDiagnostics();
+      // err.exitCode is set when the inner live-re-frame2-pair-overflow.cjs itself
+      // exited non-zero — surface it so CI distinguishes conformance
+      // failure (1) from orchestration failure (2).
+      process.exit(err && typeof err.exitCode === 'number' ? err.exitCode : 2);
+    });
+} else {
+  // Required as a module — don't arm the whole-run watchdog.
+  clearTimeout(watchdog);
+}
+
+// Exported for the rf2-wqi4n4 finding-2 regression harness. `runTrusted` is
+// the async, timeout-bounded setup-command spawn; the test drives it
+// against a never-exiting child to prove a hung setup command is killed
+// within `SETUP_COMMAND_TIMEOUT_MS` instead of wedging the event loop.
+module.exports = { runTrusted, SETUP_COMMAND_TIMEOUT_MS };

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -48,8 +48,12 @@ const TESTS = [
     argv: ['--test', 'test/exec-safety.test.cjs'],
   },
   {
-    name: 'runner watchdog connect-hang teardown (rf2-2js41 finding 2)',
+    name: 'runner watchdog connect-hang teardown (rf2-2js41 finding 2 + rf2-wqi4n4 finding 1)',
     argv: ['--test', 'test/runner-watchdog.test.cjs'],
+  },
+  {
+    name: 'hermetic setup-command timeout (rf2-wqi4n4 finding 2)',
+    argv: ['--test', 'test/hermetic-setup-timeout.test.cjs'],
   },
   {
     name: 're-frame2-pair-mcp end-to-end',

--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -164,6 +164,35 @@ async function closeQuietly(client) {
   }
 }
 
+// Module-scope set of SECONDARY MCP clients the watchdog must ALSO tear
+// down on a timeout (rf2-wqi4n4 finding 1). `runWithWatchdog` owns at most
+// ONE primary client (`activeClient`); but two gates boot ADDITIONAL
+// in-process servers via bare `connectServer` INSIDE the body
+// (`live-re-frame2-pair-redaction.cjs`'s inner-projection + gate-ON arms),
+// and those were never reachable by the outer watchdog — a hang in a
+// secondary boot or a later secondary tool call orphaned that child despite
+// the harness reporting a watchdog timeout. A body registers each secondary
+// client here (via `registerAuxClient`, fired the instant the client is
+// constructed) and deregisters it on teardown; the watchdog drains every
+// surviving member so EVERY spawned child the conformance process owns is
+// reachable by the timeout path from the moment it can exist until teardown.
+const AUX_CLIENTS = new Set();
+
+// Register a secondary client so the active watchdog reaps it on a timeout.
+// Call it from a bare `connectServer`'s `onClient` (BEFORE connect awaits)
+// so a hung secondary boot is reachable from the moment its child exists.
+// Returns the client unchanged for fluent use.
+function registerAuxClient(client) {
+  if (client) AUX_CLIENTS.add(client);
+  return client;
+}
+
+// Drop a secondary client from the watchdog set once its arm has torn it
+// down (or is about to). Idempotent; safe to call in a `finally`.
+function unregisterAuxClient(client) {
+  if (client) AUX_CLIENTS.delete(client);
+}
+
 async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) {
   // The watchdog must OWN the active client so a timeout tears the
   // spawned child down instead of orphaning it (rf2-voux7 finding 5).
@@ -202,8 +231,17 @@ async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) 
     // hard-exit fallback so a hung close can't keep the process alive.
     const hardExit = setTimeout(() => process.exit(2), 2000);
     hardExit.unref();
-    if (activeClient) {
-      closeQuietly(activeClient).finally(() => process.exit(2));
+    // Close the primary AND every registered secondary client (rf2-wqi4n4
+    // finding 1) so a hang in ANY in-process MCP child the body spawned is
+    // reaped, not just the runner-managed primary. `closeQuietly` never
+    // throws; wait for all closes to settle before the exit.
+    const toClose = [];
+    if (activeClient) toClose.push(activeClient);
+    for (const aux of AUX_CLIENTS) toClose.push(aux);
+    if (toClose.length > 0) {
+      Promise.all(toClose.map((c) => closeQuietly(c))).finally(() =>
+        process.exit(2),
+      );
     } else {
       process.exit(2);
     }
@@ -612,6 +650,8 @@ module.exports = {
   runWithWatchdog,
   connectServer,
   closeQuietly,
+  registerAuxClient,
+  unregisterAuxClient,
   assertJsonRpcErrorCodes,
   assertDescriptorShape,
   assertClassificationRatchet,

--- a/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
+++ b/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
@@ -96,7 +96,13 @@ const FIXTURE_BODY_EDN = '{:doc "flag-gate conformance probe." :tags #{:dev}}';
 // is a boot-time atom — we can't flip it on a running server through the
 // MCP surface, which is exactly the point). Three sequential boots fit
 // comfortably under the watchdog with margin.
-const WATCHDOG_MS = 180000;
+//
+// `$FLAG_GATE_WATCHDOG_MS` overrides the cap for the hermetic
+// connect-hang regression harness ONLY (rf2-wqi4n4 finding 1's
+// `runner-watchdog.test.cjs` drives this module with a stubbed
+// never-resolving connect under a 200ms cap to prove the watchdog tears
+// the hung JVM down). Production CI never sets it, so the 180s cap stands.
+const WATCHDOG_MS = Number(process.env.FLAG_GATE_WATCHDOG_MS) || 180000;
 
 // ---------------------------------------------------------------------------
 // Boot one story-mcp server with the given extra CLI args, run `body`
@@ -116,6 +122,19 @@ const WATCHDOG_MS = 180000;
 // watchdog and the hermetic orchestrator rf2-e6enf fix). `withStoryServer`
 // publishes its connected client here for the spawn's lifetime and clears
 // it on teardown; the boots are sequential so at most one is live at once.
+//
+// Per rf2-wqi4n4 finding 1: publish the handle via `connectServer`'s
+// `onClient` callback — fired the INSTANT the client is constructed,
+// BEFORE the `await client.connect()` handshake — not after `connectServer`
+// resolves. The transport spawns the JVM during construction, so a story-mcp
+// child that boots and then HANGS mid-`initialize` (connect never resolving,
+// never throwing) leaves `await connectServer(...)` blocked forever; the
+// post-resolve `activeFlagGateClient = client` below would never run, the
+// module-scope watchdog would fire with `activeFlagGateClient === null`, and
+// its `else` branch would `process.exit(2)` WITHOUT tearing the hung JVM
+// down — orphaning exactly the child the watchdog exists to reap. `onClient`
+// closes that window. (This is the bare-caller analogue of the rf2-2js41
+// finding-2 fix in `runWithWatchdog`, which these callers bypass.)
 let activeFlagGateClient = null;
 
 async function withStoryServer(extraArgs, body) {
@@ -127,6 +146,11 @@ async function withStoryServer(extraArgs, body) {
       cwd: STORY_MCP_CWD,
       env: { ...process.env },
     },
+    // Capture the teardown handle BEFORE connect awaits, so a connect that
+    // hangs mid-handshake is still reachable by the module-scope watchdog
+    // (rf2-wqi4n4 finding 1). The post-resolve assignment below is now
+    // redundant on the happy path but kept belt-and-braces.
+    onClient: (c) => { activeFlagGateClient = c; },
   });
   activeFlagGateClient = client;
   try {

--- a/tools/mcp-conformance/test/flag-gates-hang-harness.cjs
+++ b/tools/mcp-conformance/test/flag-gates-hang-harness.cjs
@@ -1,0 +1,75 @@
+// Child harness for `runner-watchdog.test.cjs` (rf2-wqi4n4 finding 1).
+//
+// Pins the bare-`connectServer` connect-hang teardown contract in
+// `end-to-end-flag-gates.cjs`. That module does NOT use `runWithWatchdog`
+// (it needs three fresh in-process JVM boots, which the single-boot runner
+// can't serve); it runs its OWN module-scope watchdog over an
+// `activeFlagGateClient` handle. Pre-fix that handle was assigned only AFTER
+// `await connectServer(...)` RESOLVED — so a story-mcp JVM that spawns and
+// then HANGS mid-`initialize` (connect never resolving) left
+// `activeFlagGateClient === null` when the watchdog fired, and the
+// watchdog's `else` branch `process.exit(2)`'d WITHOUT tearing the hung JVM
+// down. The fix publishes the handle via `connectServer`'s `onClient`
+// callback BEFORE connect awaits.
+//
+// This harness is HERMETIC: it stubs the SDK so the first (and only)
+// `connect()` NEVER resolves, points `$STORY_MCP_CMD` at the running node
+// binary (so `resolveTrustedExe` is bypassed — no `clojure` on PATH
+// needed), and shortens the module-scope watchdog to 200ms via
+// `$FLAG_GATE_WATCHDOG_MS`. The stub `close()` prints a marker; its
+// presence in the child output proves the watchdog had a teardown handle
+// for the hung JVM (i.e. `activeFlagGateClient` was set BEFORE connect).
+
+'use strict';
+
+const Module = require('node:module');
+const path = require('node:path');
+
+const CLOSE_MARKER = 'HARNESS: flag-gate client.close() invoked';
+
+class StubClient {
+  // The hang: connect never settles — a story-mcp JVM that spawned but
+  // stalled mid-`initialize`.
+  connect() {
+    return new Promise(() => {});
+  }
+  async close() {
+    process.stdout.write(CLOSE_MARKER + '\n');
+  }
+}
+
+class StubTransport {
+  constructor() {
+    this.stderr = null;
+  }
+}
+
+const SDK_STUBS = {
+  '@modelcontextprotocol/sdk/client/index.js': { Client: StubClient },
+  '@modelcontextprotocol/sdk/client/stdio.js': { StdioClientTransport: StubTransport },
+  '@modelcontextprotocol/sdk/types.js': {
+    ErrorCode: { MethodNotFound: -32601, InvalidParams: -32602, InternalError: -32603 },
+    McpError: class McpError extends Error {},
+  },
+};
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (Object.prototype.hasOwnProperty.call(SDK_STUBS, request)) {
+    return SDK_STUBS[request];
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+// Bypass `resolveTrustedExe('clojure')` (no real toolchain in the hermetic
+// child) and shorten the module-scope watchdog. Set BEFORE requiring the
+// module under test — it reads both at module-load time.
+process.env.STORY_MCP_CMD = process.execPath;
+process.env.FLAG_GATE_WATCHDOG_MS = '200';
+
+// Requiring the module runs its `main()` (the three gate probes). The first
+// `withStoryServer` boot's connect hangs, so `main()` never progresses; the
+// 200ms module-scope watchdog is the only exit path. With the fix it tears
+// the (stubbed) hung JVM client down — printing CLOSE_MARKER — before
+// `process.exit(2)`.
+require(path.join(__dirname, 'end-to-end-flag-gates.cjs'));

--- a/tools/mcp-conformance/test/hermetic-setup-timeout.test.cjs
+++ b/tools/mcp-conformance/test/hermetic-setup-timeout.test.cjs
@@ -1,0 +1,134 @@
+// Regression test for the hermetic orchestrator's SETUP-command timeout
+// contract (rf2-wqi4n4 finding 2).
+//
+// Uses Node's built-in `node:test` (same posture as
+// `runner-watchdog.test.cjs` / `exec-safety.test.cjs` — no extra
+// dev-dependency).
+//
+// ## The bug this pins
+//
+// `scripts/run-live-re-frame2-pair-overflow-hermetic.cjs` installs a
+// `HERMETIC_TIMEOUT_MS` `setTimeout` watchdog meant to bound the WHOLE run.
+// But the fixture dependency setup (`npm install`) ran through
+// `crossSpawn.sync` in `runTrusted` — a SYNCHRONOUS spawn that blocks the
+// Node event loop for the child's entire lifetime. While blocked, Node
+// delivers no signals and runs no timers, so neither the whole-run watchdog
+// nor the SIGINT/SIGTERM handlers could fire. A hung `npm install` (stuck
+// registry fetch, package-manager prompt, lock contention) would wedge the
+// hermetic job until the OUTER CI job timeout, bypassing the script's own
+// hard cap and diagnostics.
+//
+// The fix converts `runTrusted` to an ASYNC spawn with an explicit
+// per-command timeout/kill (`SETUP_COMMAND_TIMEOUT_MS`). The async spawn
+// keeps the event loop live, so both the per-command timeout AND the
+// whole-run watchdog stay armed across setup.
+//
+// ## What this test drives
+//
+// It requires the orchestrator AS A MODULE (the auto-run is guarded behind
+// `require.main === module`, so requiring it does NOT boot shadow-cljs /
+// Chromium) and calls the exported `runTrusted` against a never-exiting
+// child (`node -e "setInterval(...)"`), with `$HERMETIC_SETUP_TIMEOUT_MS`
+// shrunk to a tiny cap. It asserts:
+//
+//   1. `runTrusted` REJECTS within a small wall-clock bound (the per-command
+//      timeout fired) — NOT after the default 300s, and NOT never. This is
+//      the load-bearing assertion: a `crossSpawn.sync` regression would
+//      block the event loop and this `await` would never see a rejection
+//      within the bound (the test's own node:test timeout would kill it).
+//   2. the rejection message names the timeout (so attribution is clear).
+//   3. the event loop stayed LIVE during the wait — proven by an
+//      independent `setTimeout` that MUST have fired before the reject
+//      settled (a synchronous-spawn regression would starve this timer).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+
+const ORCH = path.join(
+  __dirname,
+  '..',
+  'scripts',
+  'run-live-re-frame2-pair-overflow-hermetic.cjs',
+);
+
+// Shrink the per-command cap BEFORE requiring the orchestrator — it reads
+// `$HERMETIC_SETUP_TIMEOUT_MS` at module-load time.
+process.env.HERMETIC_SETUP_TIMEOUT_MS = '750';
+
+const { runTrusted, SETUP_COMMAND_TIMEOUT_MS } = require(ORCH);
+
+test('hermetic runTrusted env override wired (rf2-wqi4n4 finding 2)', () => {
+  assert.equal(
+    SETUP_COMMAND_TIMEOUT_MS,
+    750,
+    'the orchestrator did not honour $HERMETIC_SETUP_TIMEOUT_MS — the ' +
+      'regression harness cannot drive a short per-command cap.',
+  );
+});
+
+test('runTrusted kills a hung setup command within its timeout, loop stays live (rf2-wqi4n4 finding 2)', async () => {
+  // A never-exiting child: `node -e` with an unref'd interval would let
+  // node exit, so use a ref'd interval that keeps the child alive until our
+  // timeout SIGTERM/SIGKILL reaps it.
+  const NEVER_EXIT = 'setInterval(() => {}, 1000);';
+
+  // Independent liveness probe: this timer can ONLY fire if the event loop
+  // keeps turning while `runTrusted` awaits. A `crossSpawn.sync` regression
+  // would block the loop and this stays false until the (much later) sync
+  // child returns — by which point the test's node:test timeout has killed
+  // the run.
+  let loopStayedLive = false;
+  const liveProbe = setTimeout(() => { loopStayedLive = true; }, 200);
+
+  const start = Date.now();
+  let rejected = false;
+  let message = '';
+  try {
+    await runTrusted('node', ['-e', NEVER_EXIT], os.tmpdir());
+  } catch (err) {
+    rejected = true;
+    message = (err && err.message) || String(err);
+  }
+  const elapsed = Date.now() - start;
+  clearTimeout(liveProbe);
+
+  // 1. The hung child was reaped by the per-command timeout (rejection),
+  // not left to run forever.
+  assert.ok(
+    rejected,
+    'runTrusted did NOT reject on a never-exiting child — the per-command ' +
+      'timeout never fired. A synchronous-spawn regression would block here ' +
+      'until the child exits (it never does), so this path must REJECT.',
+  );
+
+  // 2. The rejection is the timeout path, named clearly for attribution.
+  assert.ok(
+    /timed out after/.test(message),
+    'runTrusted rejected but NOT via the timeout path; got: ' + message,
+  );
+
+  // 3. It rejected within a small bound of the configured cap — proving the
+  // timer actually fired on a live loop, not the default 300s. Generous
+  // upper bound (cap + spawn + SIGTERM grace) so a slow CI box doesn't
+  // flake, but FAR below the 300s default a regression would exhibit.
+  assert.ok(
+    elapsed < 15000,
+    'runTrusted took ' + elapsed + 'ms to reject — far past the 750ms cap. ' +
+      'The event loop was likely blocked (synchronous spawn regression) so ' +
+      'the per-command timer could not fire promptly.',
+  );
+
+  // 4. The event loop kept turning during the await (the load-bearing
+  // distinction from `crossSpawn.sync`).
+  assert.ok(
+    loopStayedLive,
+    'the event loop did NOT turn while runTrusted awaited — the independent ' +
+      'liveness timer never fired. This is the synchronous-spawn signature ' +
+      'finding 2 pins: a blocked loop starves both this timer AND the ' +
+      'whole-run HERMETIC_TIMEOUT_MS watchdog.',
+  );
+});

--- a/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-redaction.cjs
@@ -97,7 +97,13 @@
 
 const path = require('node:path');
 const os = require('node:os');
-const { runWithWatchdog, connectServer, closeQuietly } = require('./_runner.cjs');
+const {
+  runWithWatchdog,
+  connectServer,
+  closeQuietly,
+  registerAuxClient,
+  unregisterAuxClient,
+} = require('./_runner.cjs');
 
 const SERVER = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp', 'out', 'server.js');
 
@@ -565,6 +571,12 @@ async function runInnerProjectionArm() {
       cwd: os.tmpdir(),
       env: { ...process.env },
     },
+    // Register with the outer watchdog the INSTANT this secondary child is
+    // constructed — BEFORE connect awaits — so a hang in THIS arm's boot or
+    // a later tool call is reaped by the outer timeout instead of orphaning
+    // the secondary Node child (rf2-wqi4n4 finding 1). The bare-caller
+    // analogue of the rf2-2js41 finding-2 fix.
+    onClient: registerAuxClient,
   });
   try {
     await enableEpochRecording(client, 'inner');
@@ -648,6 +660,9 @@ async function runInnerProjectionArm() {
     assertInnerRedacted(we, 'watch-epochs (inner projected-record value-redaction)');
     console.log('OK   watch-epochs (gate OFF, inner layer SOLE) -> :db-after :rf/redacted + :dropped-sensitive 0');
   } finally {
+    // Deregister before the explicit close so the watchdog set doesn't hold
+    // a stale handle past teardown (rf2-wqi4n4 finding 1).
+    unregisterAuxClient(client);
     await closeQuietly(client);
   }
 }
@@ -676,6 +691,11 @@ async function runGateOnArm() {
       cwd: os.tmpdir(),
       env: { ...process.env },
     },
+    // Register with the outer watchdog the INSTANT this secondary child is
+    // constructed — BEFORE connect awaits — so a hang in this gate-ON boot
+    // or a later tool call is reaped by the outer timeout instead of
+    // orphaning the secondary Node child (rf2-wqi4n4 finding 1).
+    onClient: registerAuxClient,
   });
   try {
     // Same seed: enable epoch recording, declare the sensitive slot, and
@@ -714,6 +734,9 @@ async function runGateOnArm() {
     }
     console.log('OK   gate-ON watch-epochs (+:include-sensitive) -> sentinel SHIPS (opt-in honoured)');
   } finally {
+    // Deregister before the explicit close so the watchdog set doesn't hold
+    // a stale handle past teardown (rf2-wqi4n4 finding 1).
+    unregisterAuxClient(client);
     await closeQuietly(client);
   }
 }

--- a/tools/mcp-conformance/test/runner-aux-client-hang-harness.cjs
+++ b/tools/mcp-conformance/test/runner-aux-client-hang-harness.cjs
@@ -1,0 +1,120 @@
+// Child harness for `runner-watchdog.test.cjs` (rf2-wqi4n4 finding 1).
+//
+// Simulates the SECONDARY-client orphan the redaction live test could hit:
+// `runWithWatchdog` boots its primary client fine, but the body then boots
+// an ADDITIONAL in-process server (the inner-projection / gate-ON arms in
+// `live-re-frame2-pair-redaction.cjs`) whose connect HANGS during the
+// `initialize` handshake. Pre-fix, the outer watchdog only owned the
+// PRIMARY client — a hang in (or after) a secondary boot was unreachable by
+// the timeout path, so the secondary child was orphaned despite the harness
+// reporting a watchdog timeout.
+//
+// The fix registers each secondary client with the outer watchdog (via
+// `registerAuxClient`, fired from a bare `connectServer`'s `onClient`
+// BEFORE connect awaits), so the watchdog drains the primary AND every
+// secondary on a timeout.
+//
+// This harness is HERMETIC: it stubs the three SDK specifiers `_runner.cjs`
+// requires. The PRIMARY connect resolves cleanly (so the body runs and gets
+// to boot the secondary); the SECONDARY connect NEVER resolves (the hang).
+// Each stub `close()` prints a distinct marker so the parent test can prove
+// BOTH clients were torn down before exit.
+
+'use strict';
+
+const Module = require('node:module');
+const path = require('node:path');
+
+const PRIMARY_CLOSE_MARKER = 'HARNESS: primary client.close() invoked';
+const AUX_CLOSE_MARKER = 'HARNESS: aux client.close() invoked';
+const BODY_MARKER = 'HARNESS: body reached';
+const AUX_SPAWNED_MARKER = 'HARNESS: aux client constructed';
+
+// ---------------------------------------------------------------------
+// SDK stubs. The FIRST client constructed is the primary (connect
+// resolves); the SECOND is the secondary (connect hangs). A module-scope
+// counter distinguishes them so a single stub class serves both.
+// ---------------------------------------------------------------------
+
+let clientSeq = 0;
+
+class StubClient {
+  constructor() {
+    this._seq = clientSeq++;
+    this._isPrimary = this._seq === 0;
+  }
+  connect() {
+    if (this._isPrimary) {
+      // Primary connects cleanly so the body runs and boots the secondary.
+      return Promise.resolve();
+    }
+    // Secondary: connect NEVER settles — the orphan-prone hang.
+    process.stdout.write(AUX_SPAWNED_MARKER + '\n');
+    return new Promise(() => {});
+  }
+  async close() {
+    process.stdout.write(
+      (this._isPrimary ? PRIMARY_CLOSE_MARKER : AUX_CLOSE_MARKER) + '\n',
+    );
+  }
+  // The body issues no tool calls before booting the secondary; a stub
+  // is enough for the primary's lifecycle.
+}
+
+class StubTransport {
+  constructor() {
+    this.stderr = null;
+  }
+}
+
+const SDK_STUBS = {
+  '@modelcontextprotocol/sdk/client/index.js': { Client: StubClient },
+  '@modelcontextprotocol/sdk/client/stdio.js': { StdioClientTransport: StubTransport },
+  '@modelcontextprotocol/sdk/types.js': {
+    ErrorCode: { MethodNotFound: -32601, InvalidParams: -32602, InternalError: -32603 },
+    McpError: class McpError extends Error {},
+  },
+};
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (Object.prototype.hasOwnProperty.call(SDK_STUBS, request)) {
+    return SDK_STUBS[request];
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+// ---------------------------------------------------------------------
+// Drive the real runner. The body boots a SECONDARY server via the real
+// `connectServer` + registers it with the outer watchdog via the real
+// `registerAuxClient` — exactly the redaction arms' shape. The secondary
+// connect hangs, so the body's `await connectServer(...)` never resolves
+// and the only exit path is the outer watchdog.
+// ---------------------------------------------------------------------
+
+const {
+  runWithWatchdog,
+  connectServer,
+  registerAuxClient,
+} = require(path.join(__dirname, '_runner.cjs'));
+
+runWithWatchdog(
+  {
+    watchdogMs: 200,
+    transportSpec: { command: 'node', args: ['-e', '0'] },
+    clientName: 'mcp-conformance-aux-hang-harness-primary',
+  },
+  async () => {
+    process.stdout.write(BODY_MARKER + '\n');
+    // Boot a secondary server the SAME way the redaction arms do: bare
+    // `connectServer` with `onClient: registerAuxClient`. The secondary
+    // connect hangs, so this await never resolves; the outer watchdog must
+    // reap BOTH the primary and this secondary.
+    await connectServer({
+      clientName: 'mcp-conformance-aux-hang-harness-secondary',
+      transportSpec: { command: 'node', args: ['-e', '0'] },
+      onClient: registerAuxClient,
+    });
+    process.stdout.write('HARNESS: secondary connect resolved (UNEXPECTED)\n');
+  },
+);

--- a/tools/mcp-conformance/test/runner-watchdog.test.cjs
+++ b/tools/mcp-conformance/test/runner-watchdog.test.cjs
@@ -47,8 +47,14 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const HARNESS = path.join(__dirname, 'runner-watchdog-hang-harness.cjs');
+const AUX_HARNESS = path.join(__dirname, 'runner-aux-client-hang-harness.cjs');
+const FLAG_GATES_HARNESS = path.join(__dirname, 'flag-gates-hang-harness.cjs');
 const CLOSE_MARKER = 'HARNESS: client.close() invoked';
 const BODY_MARKER = 'HARNESS: body reached';
+const PRIMARY_CLOSE_MARKER = 'HARNESS: primary client.close() invoked';
+const AUX_CLOSE_MARKER = 'HARNESS: aux client.close() invoked';
+const AUX_SPAWNED_MARKER = 'HARNESS: aux client constructed';
+const FLAG_GATE_CLOSE_MARKER = 'HARNESS: flag-gate client.close() invoked';
 
 test('watchdog tears the child down when connect hangs mid-initialize (rf2-2js41 finding 2)', () => {
   // Spawn the hermetic harness in its own process — `runWithWatchdog`
@@ -104,5 +110,101 @@ test('watchdog tears the child down when connect hangs mid-initialize (rf2-2js41
       'connect-hang (the stub client.close() marker is absent). This is ' +
       'the rf2-2js41 finding-2 orphan: activeClient was undefined when ' +
       'the watchdog fired, so the child was abandoned.\n--- output ---\n' + out,
+  );
+});
+
+test('watchdog tears the SECONDARY (body-booted) client down when its connect hangs (rf2-wqi4n4 finding 1)', () => {
+  // The redaction live test boots ADDITIONAL in-process servers inside the
+  // runWithWatchdog body (inner-projection + gate-ON arms). Pre-fix the
+  // outer watchdog owned only the PRIMARY client, so a hang in a SECONDARY
+  // boot orphaned that child despite the harness reporting a timeout. The
+  // harness boots a primary (connect resolves) then a secondary (connect
+  // hangs) via the real connectServer + registerAuxClient, and asserts the
+  // watchdog reaps BOTH.
+  const child = spawnSync(process.execPath, [AUX_HARNESS], {
+    cwd: path.resolve(__dirname, '..'),
+    encoding: 'utf8',
+    timeout: 15000,
+    env: process.env,
+  });
+  const out = (child.stdout || '') + (child.stderr || '');
+
+  assert.equal(
+    child.signal,
+    null,
+    'aux-hang harness was killed by the test timeout (signal ' + child.signal +
+      ') — the process never exited, i.e. a hung secondary connect kept it ' +
+      'alive instead of the watchdog reaping it.\n--- output ---\n' + out,
+  );
+  assert.equal(
+    child.status,
+    2,
+    'secondary connect-hang MUST exit via the watchdog with code 2; got ' +
+      child.status + '.\n--- output ---\n' + out,
+  );
+  // The secondary MUST actually have been constructed (otherwise the test
+  // is vacuous — the hang must be in the secondary, not the primary).
+  assert.ok(
+    out.includes(AUX_SPAWNED_MARKER),
+    'the secondary client was never constructed — the harness is not ' +
+      'exercising the secondary-hang path.\n--- output ---\n' + out,
+  );
+  // 1. The PRIMARY was torn down (the pre-existing rf2-voux7 guarantee).
+  assert.ok(
+    out.includes(PRIMARY_CLOSE_MARKER),
+    'the watchdog did NOT close the PRIMARY client on the secondary hang.\n' +
+      '--- output ---\n' + out,
+  );
+  // 2. THE load-bearing assertion: the SECONDARY (body-booted) client was
+  // ALSO torn down. Absent the registerAuxClient fix the watchdog has no
+  // handle to it and the secondary child is orphaned.
+  assert.ok(
+    out.includes(AUX_CLOSE_MARKER),
+    'the watchdog timeout path did NOT tear the SECONDARY client down ' +
+      '(the aux close marker is absent). This is the rf2-wqi4n4 finding-1 ' +
+      'orphan: a body-booted secondary server was unreachable by the outer ' +
+      'watchdog.\n--- output ---\n' + out,
+  );
+});
+
+test('flag-gates module watchdog tears the hung JVM client down on a connect-hang (rf2-wqi4n4 finding 1)', () => {
+  // end-to-end-flag-gates.cjs runs its OWN module-scope watchdog (not
+  // runWithWatchdog) over `activeFlagGateClient`. Pre-fix that handle was
+  // set only AFTER `await connectServer(...)` resolved — so a story-mcp JVM
+  // that hung mid-initialize left it null and the watchdog exited WITHOUT
+  // tearing the JVM down. The harness stubs a never-resolving connect,
+  // bypasses resolveTrustedExe via $STORY_MCP_CMD, and shrinks the watchdog
+  // via $FLAG_GATE_WATCHDOG_MS.
+  const child = spawnSync(process.execPath, [FLAG_GATES_HARNESS], {
+    cwd: path.resolve(__dirname, '..'),
+    encoding: 'utf8',
+    timeout: 15000,
+    env: process.env,
+  });
+  const out = (child.stdout || '') + (child.stderr || '');
+
+  assert.equal(
+    child.signal,
+    null,
+    'flag-gates harness was killed by the test timeout (signal ' +
+      child.signal + ') — the module-scope watchdog never exited on a hung ' +
+      'connect.\n--- output ---\n' + out,
+  );
+  assert.equal(
+    child.status,
+    2,
+    'flag-gates connect-hang MUST exit via the module watchdog with code 2; ' +
+      'got ' + child.status + '.\n--- output ---\n' + out,
+  );
+  // THE load-bearing assertion: the hung JVM client was torn down. Absent
+  // the onClient fix `activeFlagGateClient` is null when the watchdog fires
+  // and the marker never prints.
+  assert.ok(
+    out.includes(FLAG_GATE_CLOSE_MARKER),
+    'the flag-gates module watchdog did NOT tear the hung JVM client down ' +
+      '(close marker absent). This is the rf2-wqi4n4 finding-1 orphan: ' +
+      'activeFlagGateClient was null when the watchdog fired because the ' +
+      'handle was published only after connectServer resolved.\n' +
+      '--- output ---\n' + out,
   );
 });


### PR DESCRIPTION
Independent correctness review of `tools/mcp-conformance` (rf2-wqi4n4, 2 findings). Both are conformance-gate correctness holes: the harness reported a watchdog timeout while orphaning a spawned child (finding 1), and the hermetic orchestrator's setup command could wedge the whole run past its own hard cap (finding 2). Deduped against the merged rf2-2js41 (cursor-stale multi-server contract + `runWithWatchdog` connect-hang teardown) and rf2-voux7 (per-type summary/marker schemas + watchdog orphans) — both findings sit in residual gaps neither closed.

## Per-finding disposition

### Finding 1 — bare `connectServer` callers bypass the watchdog teardown — FIXED
rf2-2js41 finding 2 made `runWithWatchdog` capture its primary `activeClient` via `connectServer`'s `onClient` (before `connect` awaits), so a connect that *hangs* mid-`initialize` is still reaped. But three call sites bypass that:

- **`test/end-to-end-flag-gates.cjs`** runs its OWN module-scope watchdog over `activeFlagGateClient`, assigned only *after* `await connectServer(...)` resolved. A story-mcp JVM that boots then hangs left the handle `null`, so the watchdog `else`-branch `process.exit(2)`'d without tearing the hung JVM down. Fix: publish via `onClient` before connect awaits.
- **`test/live-re-frame2-pair-redaction.cjs`** boots two SECONDARY in-process servers (inner-projection + gate-ON arms) via bare `connectServer` inside the outer `runWithWatchdog` body; they were never registered with the outer watchdog, so a hang in a secondary boot or a later secondary tool call orphaned that child. Fix: new `registerAuxClient`/`unregisterAuxClient` pair in `_runner.cjs` — each arm registers via `onClient` (before connect) and deregisters in its `finally`; the watchdog now drains the primary AND every registered secondary on a timeout.

Regression nets (hermetic, `node:test`, no toolchain): `runner-aux-client-hang-harness.cjs` (primary connect resolves, secondary connect hangs — asserts BOTH closed) + `flag-gates-hang-harness.cjs` (stubbed never-resolving connect under a shortened module watchdog — asserts the hung JVM client is closed), both asserted in `runner-watchdog.test.cjs`. Each fails RED on reversion (verified: neutering the aux-drain turns the secondary case red, leaving the flag-gates case green — confirms independence).

### Finding 2 — hermetic setup command blocks the event loop, bypassing the hard cap — FIXED
`scripts/run-live-re-frame2-pair-overflow-hermetic.cjs`'s fixture `npm install` ran through `crossSpawn.sync` in `runTrusted`. A synchronous spawn blocks the Node event loop for the child's entire lifetime, so a hung `npm install` could not be reaped by the `HERMETIC_TIMEOUT_MS` `setTimeout` watchdog (or the SIGINT/SIGTERM handlers) — the run would wedge until the outer CI job timeout. This is the same blockage the inner-test spawn already documents + avoids (rf2-i3ffz F-PERF-1); the setup command had the same hole. Fix: `runTrusted` is now an async `crossSpawn` with its own `SETUP_COMMAND_TIMEOUT_MS` timeout (SIGTERM then SIGKILL), awaited at the call site. The orchestrator's auto-run is guarded behind `require.main === module` so the unit can be required for testing without booting shadow-cljs/Chromium.

Regression net: `hermetic-setup-timeout.test.cjs` drives `runTrusted` against a never-exiting child under a tiny `$HERMETIC_SETUP_TIMEOUT_MS` cap and asserts (a) it rejects via the timeout path within a small bound, and (b) an independent `setTimeout` fired during the await — proving the loop stayed live (the load-bearing distinction from `crossSpawn.sync`). Fails RED on reversion (verified: neutering the timer hangs the test to its `--test-timeout`).

## Quality gates

- `npm run test:mcp-conformance` (full 6-gate suite, from `implementation/`): **ALL MCP-CONFORMANCE GATES GREEN**, exit 0. Every gate `[OK]`:
  - `[1/6]` JVM story-mcp `clojure -M:test` — 241 tests / 1180 assertions, 0 fail/0 err
  - `[2/6]` Node story-mcp stdio roundtrip
  - `[3/6]` Node re-frame2-pair-mcp `:server-test` — 958 tests / 2901 assertions, 0 fail/0 err
  - `[4+5/6]` `test-all.cjs` — includes the new `runner-watchdog.test.cjs` (3 cases, finding 1) + `hermetic-setup-timeout.test.cjs` (2 cases, finding 2); live-* SKIP without `$SHADOW_CLJS_NREPL_PORT` as designed; flag-gates ran its 3 real JVM boots green
  - `[6/6]` wire-vocab artefact tests `clojure -M:test` — 57 tests / 687 assertions, 0 fail/0 err
- Wire-vocab artefact tests also run standalone: **57 tests / 687 assertions, 0 failures, 0 errors**.
- New `node:test` harnesses run standalone green (13 pass, 4 pre-existing symlink SKIPs on Windows).

No back-compat shims. Touches `tools/mcp-conformance/**` only.

Closes rf2-wqi4n4.
