### PR TITLE
fix(pair-mcp): wire-cap the subscribe progress-tick notification + findings 2-3 (rf2-wz66k7)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -386,36 +386,66 @@
 (defn- handle-list [_req]
   (js/Promise.resolve #js {:tools (tools/tool-descriptors-js)}))
 
+(declare handle-call*)
+
 (defn- handle-call [launch-flags req extra]
   (let [params (j/get req :params)
         name   (j/get params :name)
         args   (or (j/get params :arguments) #js {})]
-    (-> (ensure-connection! launch-flags)
-        (.then (fn [conn]
-                 (-> (tools/invoke conn name args extra)
-                     (.catch (fn [err]
-                               (log! "handler threw for" name "—" (.-message err))
-                               (let [payload {:ok?     false
-                                              :reason  :handler-threw
-                                              :message (.-message err)}]
-                                 #js {:isError          true
-                                      :content          #js [#js {:type "text"
-                                                                  :text (pr-str payload)}]
-                                      :structuredContent (clj->js payload)}))))))
-        (.catch
-          (fn [err]
-            ;; Discovery failed — surface a structured tool-call error.
-            (let [data    (or (ex-data err) {})
-                  payload {:ok?    false
-                           :reason (or (:rf.error/id data) :nrepl-port-not-found)
-                           :hint   (or (:hint data) port-not-found-hint)}
-                  payload (if-let [cs (:candidates data)]
-                            (assoc payload :candidates cs)
-                            payload)]
-              #js {:isError          true
-                   :content          #js [#js {:type "text"
-                                               :text (pr-str payload)}]
-                   :structuredContent (clj->js payload)}))))))
+    (if-let [refusal (writes/refuse-pre-connection name)]
+      ;; rf2-wz66k7 — a gated write tool (restore-epoch / reset-frame-db)
+      ;; with `--allow-writes` OFF is refused HERE, before `ensure-
+      ;; connection!`. Otherwise a stock install with no nREPL port returns
+      ;; a misleading `:nrepl-port-not-found` (or runs discovery /
+      ;; elicitation) for a request that should be refused locally — the
+      ;; default-safe write posture would be observably false at the real
+      ;; MCP boundary. The tool body's own gate stays as defence in depth.
+      (js/Promise.resolve refusal)
+      (handle-call* launch-flags name args extra))))
+
+(defn handle-call-for-tests
+  "Test seam onto the private `handle-call` (rf2-wz66k7). Lets the
+  server-boundary test drive a `tools/call` request through the SAME
+  pre-dispatch path the SDK invokes — proving a disabled write tool is
+  refused with `:rf.error/writes-disabled` BEFORE `ensure-connection!`
+  (no discovery, no `:nrepl-port-not-found`). Builds the `req` shape the
+  SDK hands `handle-call`."
+  [launch-flags tool-name args extra]
+  (handle-call launch-flags
+               #js {:params #js {:name tool-name :arguments args}}
+               extra))
+
+(defn- handle-call*
+  "Normal tool-dispatch path: ensure the nREPL connection, then route to
+  the tool dispatcher. Reached for every tool EXCEPT a gated write
+  refused at the pre-connection boundary (rf2-wz66k7)."
+  [launch-flags name args extra]
+  (-> (ensure-connection! launch-flags)
+      (.then (fn [conn]
+               (-> (tools/invoke conn name args extra)
+                   (.catch (fn [err]
+                             (log! "handler threw for" name "—" (.-message err))
+                             (let [payload {:ok?     false
+                                            :reason  :handler-threw
+                                            :message (.-message err)}]
+                               #js {:isError          true
+                                    :content          #js [#js {:type "text"
+                                                                :text (pr-str payload)}]
+                                    :structuredContent (clj->js payload)}))))))
+      (.catch
+        (fn [err]
+          ;; Discovery failed — surface a structured tool-call error.
+          (let [data    (or (ex-data err) {})
+                payload {:ok?    false
+                         :reason (or (:rf.error/id data) :nrepl-port-not-found)
+                         :hint   (or (:hint data) port-not-found-hint)}
+                payload (if-let [cs (:candidates data)]
+                          (assoc payload :candidates cs)
+                          payload)]
+            #js {:isError          true
+                 :content          #js [#js {:type "text"
+                                             :text (pr-str payload)}]
+                 :structuredContent (clj->js payload)})))))
 
 ;; ---------------------------------------------------------------------------
 ;; Server boot.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
@@ -420,6 +420,49 @@
         [:ok n]
         (err-int arg-name raw "a non-negative integer (>= 0; 0 = unbounded)")))))
 
+;; ---------------------------------------------------------------------------
+;; Timeout / wait millisecond args (rf2-wz66k7).
+;;
+;; Three NON-streaming tools thread a millisecond deadline straight from
+;; the MCP args into an `(>= elapsed deadline)` poll comparison with NO
+;; coercion or lower-bound check:
+;;
+;;   - `tail-build`  → `:wait-ms`   (probe-change poll loop);
+;;   - `eval-cljs :await` / `dispatch :await-render` → `:timeout-ms`
+;;     (both thread into `await-promise/poll-mailbox!`'s
+;;     `(>= elapsed timeout-ms)`).
+;;
+;; A non-numeric value (`"never"`) makes the elapsed comparison
+;; (`(>= number NaN)`) NEVER true, so a stuck probe / pending mailbox
+;; polls FOREVER — unbounded background nREPL traffic, the exact failure
+;; the timeout knob exists to prevent. A zero / negative value times out
+;; immediately (or, for `tail-build`, schedules a negative `setTimeout`
+;; delay). These deadlines must be POSITIVE millisecond integers (>= 1);
+;; 0 is not a meaningful "wait/await for no time" sentinel here (unlike
+;; subscribe's `max-ms`, where 0 means UNBOUNDED — the opposite polarity).
+;; So this reuses the POSITIVE-int contract, not the non-negative one.
+;;
+;; Returns the same tagged `[:ok n|nil]` / `[:err {…}]` shape as the
+;; subscribe validators so each tool short-circuits a bad value to an
+;; honest `:ok? false` / isError envelope (the masterpiece-CORRECTNESS
+;; posture: an unbounded-poll arg is an agent error worth telling the
+;; agent about, not a value to silently paper over). An ABSENT arg is
+;; `[:ok nil]` — the caller falls back to its documented default.
+
+(defn parse-timeout-arg
+  "Validate an OPTIONAL positive-millisecond MCP timeout/wait arg value
+  (rf2-wz66k7). A thin alias over `parse-positive-int-arg` — the
+  millisecond deadline knobs (`tail-build :wait-ms`, `eval-cljs` /
+  `dispatch` `:timeout-ms`) share the positive-integer contract (>= 1).
+  Named distinctly so the call sites read as a timeout check and a future
+  divergence in the timeout contract lands here, not on the shared
+  positive-int helper. Returns `[:ok nil]` when absent, `[:ok n]` for an
+  integer `>= 1`, and `[:err {…}]` (`:reason :invalid-numeric-arg`) for a
+  zero / negative / fractional / non-numeric value — the value that would
+  otherwise spin or collapse the poll loop."
+  [arg-name raw]
+  (parse-positive-int-arg arg-name raw))
+
 (defn parse-filter-arg
   "MCP-side filter arg can be either a JS object or an EDN string. We
   accept both for ergonomic parity with the bash-shim chain (`pred`

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cap.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/cap.cljs
@@ -201,3 +201,43 @@
                          :cap      cap
                          :hint     (get overflow-hints tool)
                          :strategy strategy})))
+
+(defn cap-message
+  "Per-notification wire-cap for a single serialised EDN message string
+  (rf2-wz66k7). Returns `message` unchanged when under the cap (or the
+  cap is disabled via `nil`), else the `pr-str` of the same
+  `{:rf.mcp/overflow {...}}` marker the result path emits.
+
+  Unlike `apply-cap` — which walks an MCP result's `:content` / structured
+  slots — this caps the ONE pre-serialised `:message` string the
+  `subscribe` streaming loop ships in a `notifications/progress`
+  notification. The MCP `tools/call` RESULT path is capped at the `invoke`
+  chokepoint (`apply-cap`), but a progress NOTIFICATION never crosses that
+  chokepoint, so the per-tick payload would otherwise egress un-capped —
+  busting the per-notification token budget the spec pins
+  (`spec/Principles.md` §Streaming over batch: \"the cap applies per
+  notification\"; §Subscribe streaming: progress frames apply the same
+  wrap per-tick; `003-Tool-Catalogue.md` §Universal dedup: the per-tick
+  `:events` vector participates in the wire-cap discipline). This is the
+  same cap-completeness class as rf2-ycfu1 (count `:structuredContent`
+  toward the cap) — a wire-bearing payload that bypassed the gate.
+
+  Uses the SAME two-stage gate (`base-cap/over-cap?` — token sum OR the
+  secondary char gate) and the SAME `overflow/overflow-payload` shape as
+  the result path, so an agent that learned the `:rf.mcp/overflow` marker
+  on a `tools/call` result recognises it identically on the progress
+  channel. The overflow marker carries the `subscribe` per-tool hint so
+  the agent's next step (tighten `filter`, lower the buffer caps, set
+  `max-events`) is specific."
+  [message {:keys [tool cap]}]
+  (if (or (nil? cap) (nil? message))
+    message
+    (let [tokens (base-overflow/token-estimate message)
+          chars  (count message)]
+      (if-not (base-cap/over-cap? tokens chars cap)
+        message
+        (pr-str (base-overflow/overflow-payload
+                  {:tool        tool
+                   :token-count (base-cap/reported-count tokens chars cap)
+                   :cap         cap
+                   :hint        (get overflow-hints tool)}))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
@@ -306,7 +306,15 @@
         ;; — no Promise / mailbox), so it wins over every other mode flag.
         settle?      (boolean (wire/arg args :settle))
         await-render? (boolean (and (wire/arg args :await-render) (not settle?)))
-        timeout-ms   (or (wire/arg args :timeout-ms) await-promise/default-timeout-ms)
+        ;; rf2-wz66k7 — validate `:timeout-ms` as a positive-millisecond
+        ;; integer BEFORE it threads into `await-promise/poll-mailbox!`'s
+        ;; `(>= elapsed timeout-ms)` deadline (the `:await-render` path).
+        ;; A non-numeric value (`"never"`) makes `(>= n NaN)` never true ⇒
+        ;; the render-settle mailbox poll loop runs FOREVER; a zero /
+        ;; negative value times out immediately. Absent ⇒ the documented
+        ;; default. Bad value short-circuits to an honest isError below.
+        timeout-r    (args/parse-timeout-arg "timeout-ms" (wire/arg args :timeout-ms))
+        timeout-ms   (or (second timeout-r) await-promise/default-timeout-ms)
         ;; rf2-gfu33: `:await-render` forces synchronous dispatch — the
         ;; cascade must have committed before the render can settle
         ;; against the new state. `:settle` likewise forces sync. An
@@ -354,11 +362,19 @@
                        false)
         project?     (not incl?)
         [tag payload] (parse-event-edn event-str)]
-    (case tag
-      :err
-      (js/Promise.resolve (wire/err-text payload))
+    (cond
+      ;; rf2-wz66k7 — a malformed `:timeout-ms` short-circuits to an honest
+      ;; isError BEFORE the dispatch eval, rather than threading a value
+      ;; that would spin the `:await-render` mailbox poll loop unbounded.
+      (= :err (first timeout-r))
+      (js/Promise.resolve (wire/err-text (second timeout-r)))
 
-      :ok
+      :else
+      (case tag
+        :err
+        (js/Promise.resolve (wire/err-text payload))
+
+        :ok
       (let [event-vec payload
             opts-form (cond-> {}
                         frame        (assoc :frame frame)
@@ -445,4 +461,4 @@
                 (.then (fn [_] (raw-state/signal-runtime! conn build-id)))
                 (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
                 (.then (fn [v] (runtime-envelope->result mode v)))
-                (.catch (fn [err] (probe/err->result :dispatch-failed err))))))))))
+                (.catch (fn [err] (probe/err->result :dispatch-failed err)))))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
@@ -218,13 +218,23 @@
         build-id   (wire/arg-build conn args)
         explicit?  (wire/arg-build-explicit? conn args)
         await?     (boolean (wire/arg args :await))
-        timeout-ms (or (wire/arg args :timeout-ms) await-promise/default-timeout-ms)
+        ;; rf2-wz66k7 — validate `:timeout-ms` as a positive-millisecond
+        ;; integer BEFORE it threads into `await-promise/poll-mailbox!`'s
+        ;; `(>= elapsed timeout-ms)` deadline. A non-numeric value
+        ;; (`"never"`) makes `(>= n NaN)` never true ⇒ the mailbox poll
+        ;; loop runs FOREVER on a pending await; a zero / negative value
+        ;; times out immediately. Absent ⇒ the documented default.
+        timeout-r  (args/parse-timeout-arg "timeout-ms" (wire/arg args :timeout-ms))
+        timeout-ms (or (second timeout-r) await-promise/default-timeout-ms)
         ;; rf2-ntuzf — optional `:frame` arg targets a named frame for
         ;; the form's lexical scope. Same coercion as dispatch/
         ;; snapshot/get-path: bare names (\"rf/default\") and EDN-
         ;; shaped strings (\":rf/default\") both accepted.
         frame      (some-> (wire/arg args :frame) args/->frame-keyword)]
     (cond
+      (= :err (first timeout-r))
+      (js/Promise.resolve (wire/err-text (second timeout-r)))
+
       (not @eval-allowed?)
       (js/Promise.resolve
         (wire/err-text

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -45,6 +45,7 @@
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
+            [re-frame2-pair-mcp.tools.cap :as cap]
             [re-frame2-pair-mcp.tools.probe :as probe]
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.dedup :as dedup]
@@ -201,17 +202,24 @@
   The split keeps the wire shape congruent with `(rf/trace-buffer
   frame-id)` for cascade-bundle topics — one tick = one cascade's
   traces as a unit. The `:cascade?` flag on `tick-state` carries the
-  topic-shape signal."
-  [{:keys [send-note progress-tk sub-id]} dedup? tick-state]
+  topic-shape signal.
+
+  rf2-wz66k7 — the serialised `:message` EDN runs through
+  `cap/cap-message` BEFORE it crosses the notification wire, applying the
+  SAME per-notification token budget (and `:rf.mcp/overflow` overflow
+  marker) the `tools/call` result path enforces. Without this, a single
+  busy trace/epoch drain could ship a multi-megabyte progress message
+  even though ordinary results are capped — busting the per-notification
+  budget the spec pins (`Principles.md` §Streaming over batch /
+  §Subscribe streaming). The drop counts on `_meta.data` are tiny scalars
+  and ride uncapped; only the payload-bearing `:message` is gated. `cap`
+  is the resolved per-call `max-tokens` budget (`nil` ⇒ caller disabled
+  the cap via `max-tokens 0`)."
+  [{:keys [send-note progress-tk sub-id cap]} dedup? tick-state]
   (let [{:keys [tick cascade? dedup-events ev-dropped by-dropped
                 ov-reason dropped tick-elided]} tick-state
-        payload-slot (if cascade? :cascades :events)]
-    (try
-      (send-note
-        #js {:method "notifications/progress"
-             :params (progress-payload
-                       progress-tk
-                       tick
+        payload-slot (if cascade? :cascades :events)
+        message      (cap/cap-message
                        (pr-str (wire/with-indicators
                                  (cond-> {:sub-id         sub-id
                                           payload-slot    dedup-events
@@ -221,6 +229,14 @@
                                    ov-reason
                                    (assoc :overflow-reason ov-reason))
                                  {:dropped dropped :elided tick-elided}))
+                       {:tool "subscribe" :cap cap})]
+    (try
+      (send-note
+        #js {:method "notifications/progress"
+             :params (progress-payload
+                       progress-tk
+                       tick
+                       message
                        ev-dropped
                        by-dropped
                        ov-reason)})
@@ -331,7 +347,7 @@
   ordering (a denied cycle MUST NOT call the destructive drain)."
   [{:keys [conn build-id sub-id topic resolve state
            signal send-note progress-tk poll-ms max-events
-           incl? elision? dedup?]}]
+           incl? elision? dedup? cap]}]
   (let [drain-src    (drain-form sub-id elision? incl?)
         terminated?  (atom false)
         terminate
@@ -427,7 +443,8 @@
                           (emit-progress-tick!
                             {:send-note   send-note
                              :progress-tk progress-tk
-                             :sub-id      sub-id}
+                             :sub-id      sub-id
+                             :cap         cap}
                             dedup?
                             {:tick         (:tick s')
                              :cascade?     cascade?
@@ -467,7 +484,7 @@
   point need explicit release."
   [{:keys [conn raw-args topic build-id filter-map max-buf-events
            max-buf-bytes poll-ms max-ms max-events
-           incl? elision? dedup? signal send-note progress-tk]}]
+           incl? elision? dedup? cap signal send-note progress-tk]}]
   (let [subscribe-form
         (ef/emit
           (ef/rt-call 'subscribe!
@@ -497,7 +514,8 @@
                              :signal      signal      :send-note   send-note
                              :progress-tk progress-tk :poll-ms     poll-ms
                              :max-events  max-events  :incl?       incl?
-                             :elision?    elision?    :dedup?      dedup?})]
+                             :elision?    elision?    :dedup?      dedup?
+                             :cap         cap})]
                       (when (pos? max-ms)
                         (js/setTimeout #(terminate :max-ms-reached) max-ms))
                       (poll))))))))
@@ -562,6 +580,16 @@
                              (args/parse-bool-arg raw-args :elision)
                              true)
         dedup?             (args/parse-bool-arg raw-args :dedup)
+        ;; rf2-wz66k7 — the per-call wire-cap budget for the streamed
+        ;; progress notifications. The `invoke` chokepoint (tools.cljs)
+        ;; already validates `max-tokens` and short-circuits a NEGATIVE /
+        ;; fractional value to an isError BEFORE this tool runs, so the
+        ;; arg here is always a valid integer cap, `nil` (caller disabled
+        ;; via `max-tokens 0`), or the default. `cap/max-tokens-arg` is
+        ;; the same resolver the result path uses, so the progress channel
+        ;; honours the SAME per-call budget override as `tools/call`
+        ;; results — one `max-tokens` knob governs both surfaces.
+        cap                (cap/max-tokens-arg raw-args)
         {:keys [signal send-note progress-tk]} (parse-mcp-extra extra)]
     (cond
       (or (nil? topic)
@@ -602,5 +630,5 @@
              :filter-map filter-map
              :max-buf-events max-buf-events :max-buf-bytes max-buf-bytes
              :poll-ms poll-ms :max-ms max-ms :max-events max-events
-             :incl? incl? :elision? elision? :dedup? dedup?
+             :incl? incl? :elision? elision? :dedup? dedup? :cap cap
              :signal signal :send-note send-note :progress-tk progress-tk}))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/tail_build.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/tail_build.cljs
@@ -24,6 +24,7 @@
   with no value information returned the operator had to manually call
   `handler-meta` to confirm the rebuild had actually landed."
   (:require [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.wire :as wire]))
 
 (def ^:private default-wait-ms
@@ -65,10 +66,20 @@
 
 (defn tail-build-tool [conn args]
   (let [build-id (wire/arg-build conn args)
-        wait-ms  (or (wire/arg args :wait-ms) default-wait-ms)
+        ;; rf2-wz66k7 — validate `:wait-ms` as a positive-millisecond
+        ;; integer BEFORE it reaches the `(>= elapsed wait-ms)` poll
+        ;; comparison. A non-numeric value (`"never"`) makes `(>= n NaN)`
+        ;; never true ⇒ the probe-change loop polls the nREPL socket
+        ;; FOREVER; a zero / negative value times out immediately. Absent
+        ;; ⇒ the documented `default-wait-ms`.
+        wait-r   (args/parse-timeout-arg "wait-ms" (wire/arg args :wait-ms))
+        wait-ms  (or (second wait-r) default-wait-ms)
         probe    (wire/arg args :probe)
         poll-ms  probe-poll-ms]
     (cond
+      (= :err (first wait-r))
+      (js/Promise.resolve (wire/err-text (second wait-r)))
+
       (nil? probe)
       ;; Soft delay — matches the bash version's behaviour when no probe
       ;; is supplied. We just resolve after a short sleep.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/writes.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/writes.cljs
@@ -81,3 +81,45 @@
      :hint   (str "State-mutating tools (restore-epoch, reset-frame-db) are "
                   "disabled by default; pass --allow-writes at server launch "
                   "to opt in. Read tools and dispatch are unaffected.")}))
+
+;; ---------------------------------------------------------------------------
+;; Server-boundary pre-dispatch gate (rf2-wz66k7).
+;;
+;; The write-tool BODIES (`restore-epoch-tool` / `reset-frame-db-tool`)
+;; each refuse `:rf.error/writes-disabled` as their first action without
+;; touching the nREPL socket — correct AT THE TOOL LAYER. But the real MCP
+;; server handler (`server.cljs/handle-call`) calls `ensure-connection!`
+;; for EVERY tool BEFORE the tool body runs. On a stock install with no
+;; nREPL port available, that connection step REJECTS (`:nrepl-port-not-
+;; found`) and the tool body — and thus its write gate — NEVER fires. So a
+;; disabled `restore-epoch` / `reset-frame-db` returned a misleading
+;; discovery error instead of the intended destructive-tool refusal, and
+;; (when discovery WAS available) performed unnecessary connect /
+;; elicitation work for a request that should be refused locally.
+;;
+;; This set + predicate let the server refuse the gated writes at the
+;; pre-dispatch boundary — BEFORE `ensure-connection!` — when writes are
+;; off, restoring the "default-safe write posture is observably true at
+;; the MCP boundary" contract (spec/Tool-Pair.md §Pair-tool writes;
+;; tools/writes.cljs §Default-safe). The tool-body gates STAY (defence in
+;; depth + the direct-call test surface); this is the missing outer ring.
+
+(def gated-write-tools
+  "Tool names refused at the server boundary when `--allow-writes` is OFF
+  (rf2-wz66k7). These two MUTATE app-db wholesale and can be refused with
+  NO runtime connection — the gate is a pure function of the boot flag."
+  #{"restore-epoch" "reset-frame-db"})
+
+(defn refuse-pre-connection
+  "Server-boundary pre-dispatch guard (rf2-wz66k7). Returns the
+  `:rf.error/writes-disabled` result when `tool` is a gated write tool
+  AND `--allow-writes` is OFF — so `server.cljs/handle-call` can refuse it
+  locally BEFORE `ensure-connection!` runs (no nREPL socket touched, no
+  discovery / elicitation triggered). Returns `nil` for any tool that
+  must proceed to normal dispatch (a non-write tool, or a write tool when
+  writes are enabled — the latter falls through to its body, which then
+  needs the connection). The tool-body gates remain as defence in depth."
+  [tool]
+  (when (and (contains? gated-write-tools tool)
+             (not (writes-allowed?)))
+    (disabled-result tool)))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/args_test.cljs
@@ -203,3 +203,48 @@
   (is (= [:err :invalid-filter-edn]
          (args/parse-filter-arg "(((")) ;; unbalanced delimiters
       "unparseable filter EDN → honest :err tag, not a nonsense map"))
+
+;; ---------------------------------------------------------------------------
+;; parse-timeout-arg — positive-millisecond deadline knobs (rf2-wz66k7).
+;;
+;; `tail-build :wait-ms` and `eval-cljs` / `dispatch :await-render`
+;; `:timeout-ms` thread their value straight into an `(>= elapsed
+;; deadline)` poll comparison. A non-numeric value made `(>= n NaN)`
+;; never true ⇒ unbounded background polling; a zero / negative value
+;; timed out immediately. These deadlines must be POSITIVE-ms integers
+;; (>= 1); 0 is NOT an unbounded sentinel here (unlike subscribe max-ms).
+;; ---------------------------------------------------------------------------
+
+(deftest parse-timeout-arg-absent-is-ok-nil
+  (is (= [:ok nil] (args/parse-timeout-arg "wait-ms" nil))
+      "absent ⇒ caller falls back to the documented default"))
+
+(deftest parse-timeout-arg-accepts-positive-integer
+  (is (= [:ok 5000] (args/parse-timeout-arg "timeout-ms" 5000)))
+  (is (= [:ok 1]    (args/parse-timeout-arg "wait-ms" 1))))
+
+(deftest parse-timeout-arg-accepts-numeric-string
+  (is (= [:ok 250] (args/parse-timeout-arg "timeout-ms" "250"))
+      "MCP hosts sometimes stringify numbers"))
+
+(deftest parse-timeout-arg-rejects-non-numeric
+  ;; THE Finding-2 regression: "never" / "bogus" must NOT slip through as
+  ;; a deadline that makes `(>= elapsed NaN)` never true (unbounded poll).
+  (let [[tag env] (args/parse-timeout-arg "wait-ms" "never")]
+    (is (= :err tag) "a non-numeric deadline is rejected, not threaded raw")
+    (is (= :invalid-numeric-arg (:reason env)))
+    (is (= "wait-ms" (:arg env)))
+    (is (= "never" (:given env))))
+  (let [[tag _] (args/parse-timeout-arg "timeout-ms" "bogus")]
+    (is (= :err tag))))
+
+(deftest parse-timeout-arg-rejects-zero-and-negative
+  (let [[tag-z _] (args/parse-timeout-arg "wait-ms" 0)
+        [tag-n env] (args/parse-timeout-arg "timeout-ms" -100)]
+    (is (= :err tag-z) "zero is not a meaningful wait/await deadline")
+    (is (= :err tag-n) "a negative deadline would time out immediately / negative setTimeout")
+    (is (re-find #"positive integer" (:hint env)))))
+
+(deftest parse-timeout-arg-rejects-fractional
+  (let [[tag _] (args/parse-timeout-arg "timeout-ms" 12.5)]
+    (is (= :err tag) "a fractional millisecond is not a valid integer deadline")))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
@@ -175,6 +175,44 @@
                    (is (= :invalid-event-edn (:reason edn))))
                  (done))))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-wz66k7 — `:timeout-ms` (the `:await-render` deadline) is validated
+;; as a positive-millisecond integer BEFORE the dispatch eval. A
+;; non-numeric value (`"bogus"`) made `await-promise/poll-mailbox!`'s
+;; `(>= elapsed timeout-ms)` deadline `(>= n NaN)` — never true — so the
+;; render-settle mailbox poll loop ran FOREVER. The tool now short-circuits
+;; to an honest validation error WITHOUT touching nREPL (the validation is
+;; the first `cond` branch, ahead of the event-parse + eval).
+;; ---------------------------------------------------------------------------
+
+(deftest bogus-timeout-ms-rejected-before-touching-nrepl
+  ;; A VALID event with a bogus :timeout-ms must surface the numeric-arg
+  ;; error, not reach the (never-stubbed) eval. The fresh-conn has no live
+  ;; socket; if the validation didn't short-circuit, this would fail
+  ;; differently (a probe/eval failure), so the assertion is load-bearing.
+  (async done
+    (-> (dispatch/dispatch-tool (fresh-conn)
+                                #js {:event "[:cart/add]" :await-render true
+                                     :timeout-ms "bogus"})
+        (.then (fn [r]
+                 (is (err? r) "malformed :timeout-ms surfaces as :isError true")
+                 (let [edn (read-result-text r)]
+                   (is (= :invalid-numeric-arg (:reason edn)))
+                   (is (= "timeout-ms" (:arg edn))))
+                 (done))))))
+
+(deftest negative-timeout-ms-rejected
+  (async done
+    (-> (dispatch/dispatch-tool (fresh-conn)
+                                #js {:event "[:cart/add]" :await-render true
+                                     :timeout-ms -50})
+        (.then (fn [r]
+                 (is (err? r))
+                 (let [edn (read-result-text r)]
+                   (is (= :invalid-numeric-arg (:reason edn)))
+                   (is (= "timeout-ms" (:arg edn))))
+                 (done))))))
+
 (deftest rejects-blank-event
   (async done
     (-> (dispatch/dispatch-tool (fresh-conn) #js {:event "   "})

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_cljs_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_cljs_test.cljs
@@ -226,6 +226,41 @@
                  (done))))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-wz66k7 — `:timeout-ms` is validated as a positive-millisecond
+;; integer BEFORE the await-mailbox poll loop. A non-numeric value
+;; (`"bogus"`) made `await-promise/poll-mailbox!`'s `(>= elapsed
+;; timeout-ms)` deadline `(>= n NaN)` — never true — so an `:await` over a
+;; pending Promise polled FOREVER. The tool now short-circuits to an honest
+;; validation error WITHOUT touching nREPL (validation is the first `cond`
+;; branch, ahead of the eval).
+;; ---------------------------------------------------------------------------
+
+(deftest bogus-timeout-ms-rejected-before-touching-nrepl
+  (async done
+    ;; No runtime stub installed; if validation didn't short-circuit, the
+    ;; tool would reach the nREPL preflight and fail differently. A
+    ;; fresh-conn with no live socket would NOT surface :invalid-numeric-arg.
+    (-> (eval-cljs/eval-cljs-tool (fresh-conn)
+                                  #js {:form "(+ 1 2)" :await true :timeout-ms "bogus"})
+        (.then (fn [r]
+                 (is (err? r) "malformed :timeout-ms surfaces as :isError true")
+                 (let [edn (read-edn r)]
+                   (is (= :invalid-numeric-arg (:reason edn)))
+                   (is (= "timeout-ms" (:arg edn))))
+                 (done))))))
+
+(deftest negative-timeout-ms-rejected
+  (async done
+    (-> (eval-cljs/eval-cljs-tool (fresh-conn)
+                                  #js {:form "(+ 1 2)" :await true :timeout-ms -1})
+        (.then (fn [r]
+                 (is (err? r))
+                 (let [edn (read-edn r)]
+                   (is (= :invalid-numeric-arg (:reason edn)))
+                   (is (= "timeout-ms" (:arg edn))))
+                 (done))))))
+
+;; ---------------------------------------------------------------------------
 ;; Typed result envelope (rf2-qobqy) — the default (non-await) path wraps
 ;; the form so a genuine nil, an eval-error, and an unserializable value
 ;; are DISTINCT outcomes instead of collapsing to a bare null. The stub

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
@@ -13,6 +13,7 @@
             [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.tools.args :as args]
+            [re-frame2-pair-mcp.tools.cap :as cap]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.subscribe :as sub]))
 
@@ -753,6 +754,85 @@
     (is (every? #(nil? (get-in % [:tags :rf.trace/dispatch-id]))
                 (:events frameless-tick))
         "frameless events MUST carry no :rf.trace/dispatch-id tag")))
+
+;; ---------------------------------------------------------------------------
+;; rf2-wz66k7 — the per-tick progress notification is wire-capped.
+;;
+;; `emit-progress-tick!` ships its per-tick payload as the `:message` of a
+;; `notifications/progress` notification. That notification NEVER crosses
+;; the `invoke` chokepoint where `apply-cap` runs on `tools/call` RESULTS,
+;; so before this fix an oversized drain shipped a multi-megabyte progress
+;; message un-capped — busting the per-notification token budget the spec
+;; pins. The fix runs the `:message` through `cap/cap-message` with the
+;; per-call cap threaded down from `subscribe-tool`.
+;; ---------------------------------------------------------------------------
+
+(defn- capture-progress-message
+  "Drive `emit-progress-tick!` with a capturing `send-note`, returning the
+  `:message` string the notification carried. `cap` is the resolved
+  per-notification budget."
+  [dedup-events cap]
+  (let [captured (atom nil)
+        send-note (fn [note]
+                    (reset! captured
+                            (j/get-in note [:params :message])))]
+    (sub/emit-progress-tick!
+      {:send-note   send-note
+       :progress-tk "tok-1"
+       :sub-id      "sub-1"
+       :cap         cap}
+      false
+      {:tick         1
+       :cascade?     false
+       :dedup-events dedup-events
+       :ev-dropped   0
+       :by-dropped   0
+       :ov-reason    nil
+       :dropped      0
+       :tick-elided  0})
+    @captured))
+
+(deftest emit-progress-tick-small-payload-rides-verbatim
+  ;; A small tick ships its EDN message unchanged — the gate must not
+  ;; over-trip a genuinely small notification.
+  (let [msg (capture-progress-message [{:id 1} {:id 2}] cap/default-max-tokens)
+        edn (cljs.reader/read-string msg)]
+    (is (not (contains? edn :rf.mcp/overflow))
+        "a small progress tick is not capped")
+    (is (= "sub-1" (:sub-id edn)))
+    (is (= [{:id 1} {:id 2}] (:events edn))
+        "the flat-topic payload rides under :events")))
+
+(deftest emit-progress-tick-oversized-payload-is-overflow-marked
+  ;; THE Finding-1 acceptance test (rf2-wz66k7): an oversized per-tick
+  ;; drain MUST emit an overflow marker on the progress channel, NOT a
+  ;; multi-megabyte raw message. FAILS before the fix (the notification
+  ;; bypassed the cap); PASSES after.
+  (let [fat (apply str (repeat 4000 "x"))
+        big-events (vec (repeat 50 {:payload fat}))
+        msg (capture-progress-message big-events 500)
+        edn (cljs.reader/read-string msg)]
+    (is (contains? edn :rf.mcp/overflow)
+        "an oversized progress tick MUST be replaced with the overflow marker")
+    (let [marker (:rf.mcp/overflow edn)]
+      (is (= :reached (:limit marker)))
+      (is (= "subscribe" (:tool marker)))
+      (is (= 500 (:cap-tokens marker)))
+      (is (> (:token-count marker) 500)))
+    (is (<= (cap/token-estimate msg) 500)
+        "the overflow-marker message itself stays under the cap")))
+
+(deftest emit-progress-tick-nil-cap-disables-gate
+  ;; `max-tokens 0` resolves to a nil cap — the caller opted out of the
+  ;; budget; even a fat tick ships raw (the documented escape hatch).
+  (let [fat (apply str (repeat 4000 "x"))
+        big-events (vec (repeat 50 {:payload fat}))
+        msg (capture-progress-message big-events nil)
+        edn (cljs.reader/read-string msg)]
+    (is (not (contains? edn :rf.mcp/overflow))
+        "nil cap (max-tokens 0) disables the per-notification gate")
+    (is (= 50 (count (:events edn)))
+        "the full fat payload rides when the cap is disabled")))
 
 (deftest cursor-stale-does-not-apply-to-subscribe-streams
   ;; rf2-mscih clarification — `:rf.mcp/cursor-stale` is a cursor-

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/tail_build_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/tail_build_test.cljs
@@ -149,3 +149,46 @@
                              (is (string? (:note edn))))
                            (done))))))
           (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-wz66k7 — `:wait-ms` is validated as a positive-millisecond integer
+;; BEFORE the poll loop. A non-numeric value (`"bogus"`) made the
+;; `(>= elapsed wait-ms)` comparison `(>= n NaN)` — never true — so a
+;; stuck probe polled the nREPL socket FOREVER. The tool now short-circuits
+;; to an honest validation error WITHOUT touching nREPL.
+;; ---------------------------------------------------------------------------
+
+(deftest bogus-wait-ms-errors-honestly-without-polling
+  (testing "a non-numeric :wait-ms returns a validation error, not an unbounded poll"
+    (async done
+      ;; A rejecting eval-stub would surface as :probe-errored IF the tool
+      ;; reached the nREPL call. It must NOT — the validation short-circuits
+      ;; first, so this resolves to the validation error regardless of the
+      ;; (never-invoked) eval surface.
+      (-> (with-rejecting-eval! "should-not-be-called"
+            (fn []
+              (-> (tail/tail-build-tool nil (tu/args->js {:probe "(some-form)"
+                                                          :wait-ms "bogus"}))
+                  (.then (fn [result]
+                           (is (tu/error? result)
+                               "malformed :wait-ms surfaces as :isError true")
+                           (let [edn (tu/extract-edn result)]
+                             (is (false? (:ok? edn)))
+                             (is (= :invalid-numeric-arg (:reason edn)))
+                             (is (= "wait-ms" (:arg edn)))
+                             (is (not= :probe-errored (:reason edn))
+                                 "validation runs BEFORE the nREPL probe eval"))
+                           (done))))))
+          (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done)))))))
+
+(deftest negative-wait-ms-errors-honestly
+  (testing "a negative :wait-ms (immediate timeout / negative setTimeout) is rejected"
+    (async done
+      (-> (tail/tail-build-tool nil (tu/args->js {:probe "(some-form)" :wait-ms -5}))
+          (.then (fn [result]
+                   (is (tu/error? result))
+                   (let [edn (tu/extract-edn result)]
+                     (is (= :invalid-numeric-arg (:reason edn)))
+                     (is (= "wait-ms" (:arg edn))))
+                   (done)))
+          (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_cap_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/wire_cap_test.cljs
@@ -318,3 +318,61 @@
         edn   (read-edn out)]
     (is (contains? edn :rf.mcp/overflow)
         "non-marker payload over budget is still capped")))
+
+;; ---------------------------------------------------------------------------
+;; cap-message — per-notification wire-cap for a single serialised EDN
+;; message string (rf2-wz66k7).
+;;
+;; The `subscribe` streaming loop ships its per-tick payload as the
+;; `:message` of a `notifications/progress` notification — which NEVER
+;; crosses the `invoke` chokepoint where `apply-cap` runs on `tools/call`
+;; RESULTS. `cap-message` is the per-notification gate that closes that
+;; bypass: the SAME two-stage budget + the SAME `:rf.mcp/overflow` marker
+;; shape, applied to the one pre-serialised message string.
+;; ---------------------------------------------------------------------------
+
+(deftest cap-message-passes-under-budget-string-untouched
+  (let [msg (pr-str {:sub-id "s" :events [{:id 1} {:id 2}]})
+        out (cap/cap-message msg {:tool "subscribe" :cap cap/default-max-tokens})]
+    (is (= msg out) "an under-budget progress message rides the wire verbatim")))
+
+(deftest cap-message-nil-cap-disables-enforcement
+  ;; `max-tokens 0` resolves to a nil cap — the caller opted out; even a
+  ;; huge message passes through unchanged.
+  (let [msg (pr-str {:events [(big-string 100000)]})
+        out (cap/cap-message msg {:tool "subscribe" :cap nil})]
+    (is (= msg out) "nil cap disables the per-notification gate")))
+
+(deftest cap-message-nil-message-is-passthrough
+  (is (nil? (cap/cap-message nil {:tool "subscribe" :cap 500}))))
+
+(deftest cap-message-over-budget-emits-overflow-marker
+  ;; THE Finding-1 acceptance: an oversized per-tick message is REPLACED
+  ;; with the `:rf.mcp/overflow` marker EDN, not shipped raw. Before the
+  ;; fix the progress notification bypassed the cap entirely and a
+  ;; multi-megabyte tick busted the per-notification token budget.
+  (let [big (apply str (repeat 8000 "x"))
+        msg (pr-str {:sub-id "s" :events [{:huge big}]})
+        out (cap/cap-message msg {:tool "subscribe" :cap 500})
+        edn (cljs.reader/read-string out)]
+    (is (contains? edn :rf.mcp/overflow)
+        "over-budget progress message MUST become the overflow marker")
+    (let [marker (:rf.mcp/overflow edn)]
+      (is (= :reached (:limit marker)))
+      (is (= "subscribe" (:tool marker)))
+      (is (= 500 (:cap-tokens marker)))
+      (is (> (:token-count marker) 500))
+      (is (string? (:hint marker)))
+      (is (re-find #"(?i)filter|max-events|max-buffered" (:hint marker))
+          "the marker carries the subscribe per-tool next-step hint"))
+    (is (<= (cap/token-estimate out) 500)
+        "the overflow-marker message itself stays under the cap")))
+
+(deftest cap-message-respects-custom-cap-override
+  ;; A small custom cap trips on a payload the default 5k would pass.
+  (let [msg (pr-str {:events (vec (range 400))})
+        under-default (cap/cap-message msg {:tool "subscribe" :cap cap/default-max-tokens})
+        over-tight    (cap/cap-message msg {:tool "subscribe" :cap 1})]
+    (is (= msg under-default) "passes the generous default")
+    (is (contains? (cljs.reader/read-string over-tight) :rf.mcp/overflow)
+        "trips the tight per-call override")))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/writes_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/writes_test.cljs
@@ -1,0 +1,97 @@
+(ns re-frame2-pair-mcp.writes-test
+  "Server-boundary write-gate tests (rf2-wz66k7).
+
+  The write-tool BODIES (`restore-epoch-tool` / `reset-frame-db-tool`)
+  refuse `:rf.error/writes-disabled` as their first action without
+  touching nREPL — already covered (restore_epoch_test /
+  reset_frame_db_test). But the real MCP server handler
+  (`server.cljs/handle-call`) runs `ensure-connection!` for EVERY tool
+  BEFORE the tool body. On a stock install with NO nREPL port, that
+  connection step REJECTS and the tool body's gate NEVER fires, so a
+  disabled `restore-epoch` / `reset-frame-db` returned a misleading
+  `:nrepl-port-not-found` (or ran discovery / elicitation) instead of the
+  intended destructive-tool refusal — the default-safe write posture was
+  observably FALSE at the MCP boundary.
+
+  These tests pin the missing OUTER ring: the pre-connection guard
+  (`writes/refuse-pre-connection`) and the server `handle-call` ordering
+  that proves the refusal precedes `ensure-connection!` (discovery never
+  runs; the session-state stays pristine)."
+  (:require [cljs.test :refer-macros [deftest is async use-fixtures]]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.server :as server]
+            [re-frame2-pair-mcp.tools.writes :as writes]))
+
+(use-fixtures :each
+  {:before (fn []
+             (server/reset-session-state-for-tests!)
+             (writes/set-allow-writes! false))
+   :after  (fn []
+             (server/reset-session-state-for-tests!)
+             (writes/set-allow-writes! false))})
+
+(def ^:private read-edn tu/extract-edn)
+(def ^:private err? tu/error?)
+
+;; ---------------------------------------------------------------------------
+;; refuse-pre-connection — the pure pre-dispatch predicate.
+;; ---------------------------------------------------------------------------
+
+(deftest refuse-pre-connection-gates-the-two-write-tools-when-off
+  (writes/set-allow-writes! false)
+  (doseq [tool ["restore-epoch" "reset-frame-db"]]
+    (let [result (writes/refuse-pre-connection tool)]
+      (is (some? result) (str tool " is refused at the boundary when writes are OFF"))
+      (is (err? result))
+      (let [edn (read-edn result)]
+        (is (= :rf.error/writes-disabled (:reason edn)))
+        (is (= tool (:tool edn)) "the refusal names the specific tool")))))
+
+(deftest refuse-pre-connection-passes-write-tools-through-when-on
+  (writes/set-allow-writes! true)
+  (doseq [tool ["restore-epoch" "reset-frame-db"]]
+    (is (nil? (writes/refuse-pre-connection tool))
+        (str tool " falls through to normal dispatch when writes are ON"))))
+
+(deftest refuse-pre-connection-never-gates-non-write-tools
+  (writes/set-allow-writes! false)
+  (doseq [tool ["snapshot" "get-path" "dispatch" "eval-cljs" "subscribe"
+                "trace-window" "discover-app"]]
+    (is (nil? (writes/refuse-pre-connection tool))
+        (str tool " is not a gated write tool — must proceed to dispatch"))))
+
+;; ---------------------------------------------------------------------------
+;; Server boundary — the refusal precedes ensure-connection! (no discovery).
+;; ---------------------------------------------------------------------------
+
+(defn- assert-refused-locally [tool-name done]
+  ;; The session-state is reset (pristine, :discovered? false) by the
+  ;; fixture, and no --port-file / env is configured in the test harness,
+  ;; so the real discovery cascade would REJECT with :nrepl-port-not-found
+  ;; if `handle-call` reached `ensure-connection!`. Proving the result is
+  ;; :rf.error/writes-disabled (NOT :nrepl-port-not-found) AND that the
+  ;; session stayed pristine shows the refusal ran FIRST.
+  (-> (server/handle-call-for-tests {} tool-name #js {} nil)
+      (.then (fn [result]
+               (is (err? result))
+               (let [edn (read-edn result)]
+                 (is (= :rf.error/writes-disabled (:reason edn))
+                     (str tool-name " returns writes-disabled, NOT nrepl-port-not-found"))
+                 (is (= tool-name (:tool edn))))
+               (let [snap (server/session-state-snapshot)]
+                 (is (false? (:discovered? snap))
+                     "discovery was NOT run — the refusal short-circuited before ensure-connection!")
+                 (is (nil? (:discovery-error snap))
+                     "no discovery attempt recorded — connection step never reached"))
+               (done)))
+      (.catch (fn [e] (is false (str "handle-call rejected: " (.-message e))) (done)))))
+
+(deftest restore-epoch-refused-before-connection
+  (async done
+    (writes/set-allow-writes! false)
+    (assert-refused-locally "restore-epoch" done)))
+
+(deftest reset-frame-db-refused-before-connection
+  (async done
+    (writes/set-allow-writes! false)
+    (assert-refused-locally "reset-frame-db" done)))


### PR DESCRIPTION
Independent correctness review of `tools/re-frame2-pair-mcp` (rf2-wz66k7) — three findings, deduped against the just-merged **rf2-uvfph** senior review (rate-gate-before-drain, subscribe numeric-arg validation, the `--allow-writes` README example).

## Per-finding disposition

### Finding 1 — progress-tick notification bypasses the wire-cap — **FIXED** (genuinely open; not touched by uvfph)
`emit-progress-tick!` shipped its per-tick `:events`/`:cascades` payload as the `notifications/progress` `:message` via `(pr-str ...)` with NO cap. The progress NOTIFICATION never crosses the `invoke` chokepoint where `apply-cap` runs on `tools/call` RESULTS, so an oversized trace/epoch drain could egress a multi-megabyte progress message and bust the per-notification token budget the spec pins (`Principles.md` §Streaming over batch — "the cap applies per notification"; §Subscribe streaming — progress frames apply the same wrap per-tick; `003-Tool-Catalogue.md:59-64` — the per-tick `:events` vector participates in the wire-cap discipline).

Fix: added `cap/cap-message` — the SAME two-stage gate (`base-cap/over-cap?`: token sum OR the secondary char gate) and the SAME `:rf.mcp/overflow` marker shape as the result path, applied to the one pre-serialised message string, carrying the `subscribe` per-tool hint. Threaded the resolved per-call `max-tokens` budget from `subscribe-tool` → `run-acquired` → `make-stream-controller` → `emit-progress-tick!`. `max-tokens 0` (nil cap) disables the gate, mirroring the result path. Same cap-completeness class as the merged **rf2-ycfu1** (count `:structuredContent` toward the cap).

### Finding 2 — timeout/wait args thread raw into the poll comparison — **FIXED** (uvfph covered only subscribe's five numeric args)
`tail-build :wait-ms`, `eval-cljs :await` / `dispatch :await-render` `:timeout-ms` (all reaching `await-promise/poll-mailbox!`'s `(>= elapsed timeout-ms)`) threaded the raw value with no coercion. A non-numeric `"never"`/`"bogus"` makes `(>= n NaN)` never true ⇒ unbounded background nREPL polling; a negative times out immediately / schedules a negative `setTimeout`. Centralized `args/parse-timeout-arg` (positive-ms integer contract, `[:ok n|nil]`/`[:err …]` shape matching the subscribe validators); each tool short-circuits a bad value to an honest `:invalid-numeric-arg` isError WITHOUT touching nREPL.

### Finding 3 — write gate refused after `ensure-connection!` — **FIXED** (not covered by uvfph)
The `restore-epoch`/`reset-frame-db` tool bodies refuse `:rf.error/writes-disabled` first, but `server.cljs/handle-call` runs `ensure-connection!` for EVERY tool BEFORE the body. On a stock no-nREPL install the connection step rejects and the body's gate never fires, so a disabled write returned a misleading `:nrepl-port-not-found` (or ran discovery/elicitation) — the default-safe write posture was observably false at the real MCP boundary. Fix: `writes/refuse-pre-connection` + a `handle-call` pre-dispatch guard that refuses the gated writes locally BEFORE `ensure-connection!`. Tool-body gates stay as defence in depth.

## Quality gates
Run from the worker worktree (`tools/re-frame2-pair-mcp/`, plus `implementation/` for the conformance orchestrator):

- `npm run build` (`:server`) — **0 warnings** (136 files compiled)
- `npm test` (`:server-test`) — **983 tests / 2985 assertions, 0 failures, 0 errors, 0 warnings**
- `npm run check:descriptors` — **in sync (28 tools)** (no descriptor changes, drift-check confirms)
- `npm run test:mcp-conformance` — **ALL 6 GATES GREEN** (incl. the re-frame2-pair-mcp end-to-end SDK Client driver + wire-vocab 57 tests / 687 assertions)

## Tests added
- `wire_cap_test.cljs` — `cap-message` under/over/nil-cap + custom-override + overflow-marker-shape
- `subscribe_test.cljs` — `emit-progress-tick!` ships overflow marker on an oversized tick, rides small ticks verbatim, nil-cap disables
- `args_test.cljs` — `parse-timeout-arg` positive/string/non-numeric/zero/negative/fractional
- `tail_build_test.cljs`, `eval_cljs_test.cljs`, `dispatch_test.cljs` — bogus/negative timeout short-circuits to validation error without touching nREPL
- `writes_test.cljs` (new) — `refuse-pre-connection` gating + server `handle-call` proving the refusal precedes discovery (session-state stays pristine)

Lane: `tools/re-frame2-pair-mcp/**` only. No skills/preload runtime change required.