### PR TITLE
fix(story): URL hydration authoritative for all URL-owned slots (clear on omit) + finding 2 (rf2-fkmnh)

### DIFF
--- a/tools/story/spec/022-Story-UI-Docs-And-Share.md
+++ b/tools/story/spec/022-Story-UI-Docs-And-Share.md
@@ -211,6 +211,21 @@ Share semantics:
   renders WITHOUT that edit — the address bar stays the source of truth.
   Only the focused variant's slice is touched; other variants' overrides
   are left intact (rf2-2cpoo);
+- the same authoritative-clear discipline extends to EVERY URL-owned chrome
+  slot, not just overrides (rf2-fkmnh): once URL hydration is in play
+  (`apply-parsed-to-state` runs on a populated mount or any popstate), an
+  omitted `modes=` clears `:active-modes` to `[]`, an omitted `tag-filter=`
+  clears `:tag-filter` to `#{}`, and an omitted (or present-but-invalid)
+  `viewport=`/`background=` clears the slot to its neutral default (`:full`
+  / no background). A no-query popstate (back/forward to a bare URL) likewise
+  clears the URL-owned selection / modes / framing / filter rather than
+  no-op'ing. So a share link like `?variant=story.counter/loaded` restores
+  the DEFAULT view for the recipient instead of keeping their prior
+  localStorage-seeded chrome — the address bar is the source of truth for the
+  full share surface. The intentional localStorage fallback survives ONLY for
+  a fresh mount with no URL state at all (the localStorage hydrators run first
+  on mount, and `apply-parsed-to-state` only runs when the URL carries query
+  params);
 - a shared link restores VIEW STATE (it lands the recipient on the cell);
   it does not replay a run — that is the recorder's `:play-script` export;
 - the reproducibility status is computed (purely) by

--- a/tools/story/src/re_frame/story/ui/url_state.cljc
+++ b/tools/story/src/re_frame/story/ui/url_state.cljc
@@ -191,7 +191,25 @@
   no longer encodes overrides renders WITHOUT the prior control edits, and
   the address bar stays the source of truth. Only the focused variant's
   slice is touched; other variants' overrides are left intact (the URL
-  speaks for the focused variant alone)."
+  speaks for the focused variant alone).
+
+  Per rf2-fkmnh: the SAME authoritative-clear discipline applies to every
+  URL-owned chrome slot, not just overrides. `apply-parsed-to-state` only
+  runs when URL hydration is in play (mount-with-params or a popstate),
+  and at that point the applied URL is the source of truth for the full
+  share surface. So:
+    - omitted `modes=`      clears `:active-modes` to `[]`
+    - omitted `tag-filter=` clears `:tag-filter`   to `#{}`
+    - omitted (or invalid) `viewport=`/`background=` clear the slot to nil
+      so the chrome falls back to its neutral default (`:full` / no bg).
+  This means a share URL like `?variant=story.counter/loaded` restores the
+  DEFAULT framing / filter / modes for the recipient rather than keeping
+  their prior localStorage-seeded chrome, and back/forward from a populated
+  URL to one without those params drops the stale framing. The intentional
+  localStorage fallback survives ONLY for a fresh mount with no URL state
+  (shell.cljs runs the localStorage hydrators first and only calls this fn
+  when `parse-current-url` finds query params); a no-query popstate clears
+  the URL-owned slots via `apply-empty-url` (below)."
   [state parsed validators]
   (let [{:keys [variant-id workspace-id mode-tab active-modes
                 viewport background tag-filter cell-overrides
@@ -246,17 +264,20 @@
       (and keep-variant? (not (seq cell-overrides)))
       (update :cell-overrides dissoc variant-id)
 
-      (seq active-modes)
-      (assoc :active-modes (vec active-modes))
-
-      (and viewport vp-ok?)
-      (assoc :viewport viewport)
-
-      (and background bg-ok?)
-      (assoc :background background)
-
-      (seq tag-filter)
-      (assoc :tag-filter (set tag-filter))
+      ;; rf2-fkmnh: the URL is authoritative for every URL-owned chrome
+      ;; slot once hydration is in play, so each of these writes
+      ;; UNCONDITIONALLY — present ⇒ the parsed value, omitted ⇒ the
+      ;; neutral default. An absent `modes=` clears to `[]`, an absent
+      ;; `tag-filter=` clears to `#{}`. A present-but-invalid
+      ;; viewport/background (rejected by the validator) clears to nil so
+      ;; the chrome falls back to its default rather than keeping a stale
+      ;; localStorage / prior-session value — the address bar stays the
+      ;; source of truth for the full share surface.
+      :always
+      (-> (assoc :active-modes (vec active-modes))
+          (assoc :viewport   (when vp-ok? viewport))
+          (assoc :background (when bg-ok? background))
+          (assoc :tag-filter (set tag-filter)))
 
       substrate
       (assoc :substrate substrate))))
@@ -314,6 +335,25 @@
                (let [usp (js/URLSearchParams. search)]
                  (share/parse-params (params->getter usp)))
                (catch :default _ nil))))))
+
+     (defn parse-current-url-or-empty
+       "Like `parse-current-url`, but returns the all-nil parsed shape
+       (`share/parse-params {}`) instead of nil when the window is present
+       and the search is empty.
+
+       Used by the popstate handler (rf2-fkmnh): navigating back/forward to
+       a URL with NO query params must CLEAR the URL-owned slots (selection,
+       modes, viewport, background, tag-filter) — `apply-parsed-to-state` is
+       authoritative for those slots, and an all-nil parsed map drives them
+       to their defaults. (Contrast mount-time hydration, which keeps using
+       `parse-current-url` so a fresh no-URL mount preserves the intentional
+       localStorage fallback rather than clobbering it.)
+
+       Returns nil only when the window is unavailable."
+       []
+       (when-let [w (safe-window)]
+         (or (parse-current-url)
+             (share/parse-params {}))))
 
      (defn embed-flag-from-current-url
        "Read the `?embed=1` flag (rf2-pucku) from
@@ -397,6 +437,14 @@
        viewport / backgrounds nss directly). Tests can pass a no-op /
        capturing apply-fn.
 
+       rf2-fkmnh: the handler parses via `parse-current-url-or-empty`, so
+       a back/forward to a URL with NO query params applies the all-nil
+       parsed shape rather than no-op'ing. Because `apply-parsed-to-state`
+       is authoritative for the URL-owned slots, that clears the prior
+       selection / modes / viewport / background / tag-filter back to
+       their defaults — the address bar stays the source of truth across
+       history navigation, not just on populated-URL pops.
+
        Idempotent: re-installing replaces the previous handler. Returns
        the wired handler so tests can introspect."
        [shell-state-atom apply-fn]
@@ -405,7 +453,7 @@
            (try (.removeEventListener w "popstate" prev)
                 (catch :default _ nil)))
          (let [h (fn [_]
-                   (when-let [parsed (parse-current-url)]
+                   (when-let [parsed (parse-current-url-or-empty)]
                      (with-hydration-guard
                        (fn []
                          (swap! shell-state-atom apply-fn parsed)))))]

--- a/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
@@ -206,3 +206,64 @@
         (is (= :dark    (:background s)))
         (is (= #{:tag/a} (:tag-filter s)))))))
 
+;; ---- rf2-fkmnh: populated → omitted/default transition ------------------
+
+(deftest parse-current-url-or-empty-returns-empty-shape-on-blank-search
+  (testing "rf2-fkmnh — when the window is present but the search is empty
+            `parse-current-url-or-empty` returns the all-nil parsed shape
+            (not nil), so a no-query popstate drives the URL-owned slots to
+            their defaults instead of no-op'ing. (The harness URL has no
+            Story params, so this exercises the blank-search branch.)"
+    (when (browser?)
+      (let [parsed (us/parse-current-url-or-empty)]
+        (is (map? parsed) "returns a parsed map, never nil, when window present")
+        (is (nil? (:variant-id parsed)))
+        (is (nil? (:active-modes parsed)))
+        (is (nil? (:viewport parsed)))
+        (is (nil? (:background parsed)))
+        (is (nil? (:tag-filter parsed)))))))
+
+(deftest popstate-to-empty-url-clears-prior-state-via-swap
+  (testing "rf2-fkmnh — the back/forward-to-bare-URL scenario through the
+            same swap path the popstate handler takes: a populated shell,
+            then applying the all-nil parsed shape (what
+            `parse-current-url-or-empty` yields for an empty search) clears
+            every URL-owned slot. Drives the live shell-state ratom."
+    (let [apply-fn (fn [s parsed] (us/apply-parsed-to-state s parsed {}))]
+      ;; 1. populated: a deep-link with framing + filter + modes.
+      (swap! state/shell-state-atom apply-fn
+             {:variant-id   :foo/bar
+              :active-modes [:m/dark]
+              :viewport     :tablet
+              :background   :dark
+              :tag-filter   #{:tag/a}})
+      (is (= :foo/bar (:selected-variant @state/shell-state-atom)))
+      ;; 2. popstate to a no-query URL ⇒ all-nil parsed shape.
+      (swap! state/shell-state-atom apply-fn (share/parse-params {}))
+      (let [s @state/shell-state-atom]
+        (is (nil? (:selected-variant s)) "selection cleared on bare-URL pop")
+        (is (= [] (:active-modes s))      "modes cleared")
+        (is (nil? (:viewport s))          "viewport cleared")
+        (is (nil? (:background s))        "background cleared")
+        (is (= #{} (:tag-filter s))       "tag-filter cleared")))))
+
+(deftest popstate-to-partial-url-clears-omitted-slots-only
+  (testing "rf2-fkmnh — navigating from a fully-populated URL to one that
+            keeps the variant but drops modes/viewport/background/tag-filter
+            clears exactly the omitted slots (the variant survives)"
+    (let [apply-fn (fn [s parsed] (us/apply-parsed-to-state s parsed {}))]
+      (swap! state/shell-state-atom apply-fn
+             {:variant-id   :foo/bar
+              :active-modes [:m/dark]
+              :viewport     :tablet
+              :background   :dark
+              :tag-filter   #{:tag/a}})
+      ;; second URL: variant only.
+      (swap! state/shell-state-atom apply-fn {:variant-id :foo/bar})
+      (let [s @state/shell-state-atom]
+        (is (= :foo/bar (:selected-variant s)) "variant preserved")
+        (is (= [] (:active-modes s)))
+        (is (nil? (:viewport s)))
+        (is (nil? (:background s)))
+        (is (= #{} (:tag-filter s)))))))
+

--- a/tools/story/test/re_frame/story/ui/url_state_test.cljc
+++ b/tools/story/test/re_frame/story/ui/url_state_test.cljc
@@ -353,6 +353,109 @@
           "navigating to the override-free shared URL clears the stale edit —
            the address bar is authoritative"))))
 
+;; ---- rf2-fkmnh: URL authoritative for ALL URL-owned chrome slots --------
+
+(deftest apply-parsed-clears-active-modes-when-url-omits-modes
+  (testing "rf2-fkmnh — hydrating a URL that omits `modes=` clears stale
+            `:active-modes` to []. A share link like ?variant=foo/bar must
+            restore the DEFAULT (no modes) view for the recipient, not keep
+            their localStorage-seeded modes."
+    (let [stale {:active-modes [:m/dark :m/grid]}
+          out   (us/apply-parsed-to-state stale {:variant-id :foo/bar} {})]
+      (is (= [] (:active-modes out))
+          "omitted modes= clears active-modes to the empty default"))))
+
+(deftest apply-parsed-sets-active-modes-when-url-carries-them
+  (testing "rf2-fkmnh — a URL that DOES carry modes= overwrites stale modes
+            (authoritative, not a merge)"
+    (let [stale {:active-modes [:m/light]}
+          out   (us/apply-parsed-to-state
+                  stale {:variant-id :foo/bar :active-modes [:m/dark]} {})]
+      (is (= [:m/dark] (:active-modes out))))))
+
+(deftest apply-parsed-clears-tag-filter-when-url-omits-it
+  (testing "rf2-fkmnh — omitted tag-filter= clears `:tag-filter` to #{}"
+    (let [stale {:tag-filter #{:tag/a :tag/b}}
+          out   (us/apply-parsed-to-state stale {:variant-id :foo/bar} {})]
+      (is (= #{} (:tag-filter out))
+          "omitted tag-filter= clears to the empty set default"))))
+
+(deftest apply-parsed-clears-viewport-when-url-omits-it
+  (testing "rf2-fkmnh — omitted viewport= clears `:viewport` to nil so the
+            chrome falls back to the :full default"
+    (let [stale {:viewport :tablet}
+          out   (us/apply-parsed-to-state stale {:variant-id :foo/bar} {})]
+      (is (nil? (:viewport out))
+          "omitted viewport= clears to nil (chrome resolves to :full)"))))
+
+(deftest apply-parsed-clears-background-when-url-omits-it
+  (testing "rf2-fkmnh — omitted background= clears `:background` to nil"
+    (let [stale {:background :dark}
+          out   (us/apply-parsed-to-state stale {:variant-id :foo/bar} {})]
+      (is (nil? (:background out))
+          "omitted background= clears to nil (chrome resolves to default)"))))
+
+(deftest apply-parsed-clears-invalid-viewport-rather-than-keeping-stale
+  (testing "rf2-fkmnh — a present-but-INVALID viewport (rejected by the
+            validator) clears the slot rather than preserving the stale
+            in-memory value, so a poisoned URL still degrades to default"
+    (let [stale {:viewport :tablet}
+          out   (us/apply-parsed-to-state
+                  stale {:viewport :nonsense}
+                  {:viewport? (fn [v] (= v :phone))})]
+      (is (nil? (:viewport out))
+          "invalid viewport= clears the stale value, not preserves it"))))
+
+(deftest apply-parsed-clears-invalid-background-rather-than-keeping-stale
+  (testing "rf2-fkmnh — a present-but-INVALID background clears the slot"
+    (let [stale {:background :dark}
+          out   (us/apply-parsed-to-state
+                  stale {:background :nonsense}
+                  {:background? (fn [b] (= b :light))})]
+      (is (nil? (:background out))))))
+
+(deftest apply-parsed-empty-url-clears-every-url-owned-slot
+  (testing "rf2-fkmnh — applying the all-nil parsed shape (a no-query
+            popstate / share URL that omits everything) clears ALL
+            URL-owned slots back to their defaults — selection, modes,
+            viewport, background, tag-filter — so the address bar is the
+            source of truth even when it carries no params."
+    (let [stale {:selected-variant :foo/bar
+                 :active-modes     [:m/dark]
+                 :viewport         :tablet
+                 :background       :dark
+                 :tag-filter       #{:tag/a}}
+          ;; the shape share/parse-params produces for an empty getter:
+          empty-parsed {:variant-id nil :workspace-id nil :mode-tab nil
+                        :active-modes nil :viewport nil :background nil
+                        :tag-filter nil :cell-overrides nil :substrate nil}
+          out   (us/apply-parsed-to-state stale empty-parsed {})]
+      (is (nil? (:selected-variant out)))
+      (is (nil? (:selected-workspace out)))
+      (is (= [] (:active-modes out)))
+      (is (nil? (:viewport out)))
+      (is (nil? (:background out)))
+      (is (= #{} (:tag-filter out))))))
+
+(deftest apply-parsed-share-counter-link-restores-default-chrome
+  (testing "rf2-fkmnh — the bead's concrete scenario: a recipient with prior
+            localStorage-seeded chrome (modes/viewport/background/tag-filter)
+            opens a share link `?variant=story.counter/loaded` that carries
+            ONLY the variant. The recipient lands on the variant with the
+            DEFAULT chrome, not their stale local framing."
+    (let [recipient-local {:active-modes [:m/dark]
+                           :viewport     :phone
+                           :background   :light
+                           :tag-filter   #{:tag/legacy}}
+          ;; share/parse-params of just ?variant=story.counter/loaded
+          shared {:variant-id :story.counter/loaded}
+          out    (us/apply-parsed-to-state recipient-local shared {})]
+      (is (= :story.counter/loaded (:selected-variant out)))
+      (is (= [] (:active-modes out)) "recipient's local modes cleared")
+      (is (nil? (:viewport out))     "recipient's local viewport cleared")
+      (is (nil? (:background out))   "recipient's local background cleared")
+      (is (= #{} (:tag-filter out))  "recipient's local tag-filter cleared"))))
+
 (deftest apply-parsed-full-round-trip-through-state
   (testing "URL → parsed → state, then state → URL produces equivalent
             params (allowing for set vs vec re-ordering)"

--- a/tools/story/test/story_feature_load.cjs
+++ b/tools/story/test/story_feature_load.cjs
@@ -364,6 +364,10 @@ async function assertShareUrlContract(page, phase) {
   const parsed = new URL(shareUrl);
   const variant = parsed.searchParams.get('variant');
   const modes = (parsed.searchParams.get('modes') || '').split(',');
+  // `URLSearchParams.get` returns the percent-decoded value. Per rf2-j0hwf
+  // the overrides wire form is ONE `pr-str`-printed EDN map (delimiter-safe
+  // — string values may carry the list separator), e.g. `{:label "Share
+  // Slice phase"}`. NOT the retired `label:"<value>"` comma-pair token.
   const overrides = parsed.searchParams.get('overrides') || '';
   if (variant !== 'story.counter/loaded') {
     throw new Error(`share URL variant mismatch: expected story.counter/loaded, got ${variant}`);
@@ -371,8 +375,25 @@ async function assertShareUrlContract(page, phase) {
   if (!modes.includes('Mode.app/dark')) {
     throw new Error(`share URL modes missing Mode.app/dark: ${parsed.searchParams.get('modes')}`);
   }
-  if (!overrides.includes(`label:"${label}"`)) {
-    throw new Error(`share URL overrides missing label ${JSON.stringify(label)}: ${overrides}`);
+  // rf2-fkmnh: validate the CURRENT EDN-map wire contract (rf2-j0hwf), not
+  // the retired legacy codec. The decoded payload is the single EDN map.
+  if (!/^\s*\{.*\}\s*$/.test(overrides)) {
+    throw new Error(
+      `share URL overrides is not the EDN-map wire form (rf2-j0hwf): ${overrides}`,
+    );
+  }
+  if (!overrides.includes(`:label ${JSON.stringify(label)}`)) {
+    throw new Error(
+      `share URL overrides EDN map missing :label ${JSON.stringify(label)}: ${overrides}`,
+    );
+  }
+  // Guard: reject the old comma-pair-only token so the probe can never drift
+  // back to the delimiter-prone legacy codec rf2-j0hwf retired.
+  if (overrides.includes(`label:"${label}"`)) {
+    throw new Error(
+      `share URL overrides used the RETIRED legacy comma-pair codec (rf2-j0hwf); ` +
+      `expected the EDN-map wire form: ${overrides}`,
+    );
   }
   if (parsed.hash !== '#/stories') {
     throw new Error(`share URL hash mismatch: expected #/stories, got ${parsed.hash}`);


### PR DESCRIPTION
Closes rf2-fkmnh (Senior review: tools/story — 2 findings).

## Per-finding disposition

### Finding 1 — URL hydration not authoritative for all URL-owned slots (`url_state.cljc:249`) — FIXED
`apply-parsed-to-state` previously wrote `:active-modes`/`:viewport`/`:background`/`:tag-filter` only when the parsed URL carried a present/non-empty value, while `shell.cljs` hydrates localStorage-backed modes/viewport/background BEFORE URL hydration and the popstate handler no-op'd entirely on an empty `window.location.search`. So a share URL like `?variant=story.counter/loaded` kept a recipient's prior localStorage-seeded chrome instead of restoring the default view, and back/forward to a param-light URL preserved stale framing/filters.

Fix — once URL hydration is in play, the applied URL is authoritative for **every** URL-owned slot (extending the rf2-2cpoo override discipline):
- omitted `modes=` → `:active-modes` cleared to `[]`
- omitted `tag-filter=` → `:tag-filter` cleared to `#{}`
- omitted (or present-but-invalid) `viewport=`/`background=` → cleared to `nil` (chrome resolves to its `:full` / no-background default)
- a no-query popstate (back/forward to a bare URL) applies the all-nil parsed shape via a new `parse-current-url-or-empty` helper, clearing the URL-owned selection/modes/framing/filter rather than no-op'ing.

The intentional localStorage fallback is preserved **only** for a fresh mount with no URL state: the localStorage hydrators run first on mount, and `apply-parsed-to-state` only runs when the URL actually carries query params (mount-time uses `parse-current-url`, which returns nil on empty search). `:substrate` is intentionally left out of scope — it is a global build selection, not chrome framing, and the finding enumerated only modes/viewport/background/tag-filter.

Dedup vs rf2-2cpoo: that bead added the authoritative-clear for `:cell-overrides` only; this extends the same discipline to the four remaining URL-owned chrome slots + empty-search popstate, which 2cpoo did not cover.

Tests added:
- 11 pure `apply-parsed-to-state` regressions (`url_state_test.cljc`): omitted-clears for each slot, invalid-value clears, full empty-URL clear, and the concrete `?variant=story.counter/loaded` recipient scenario.
- 3 CLJS tests (`url_state_cljs_test.cljs`): `parse-current-url-or-empty` returns the all-nil shape on a blank search; populated→bare-URL popstate clears all slots through the live shell-state ratom; populated→variant-only transition clears exactly the omitted slots.

### Finding 2 — Share URL probe asserts the retired legacy override codec (`story_feature_load.cjs:374`) — FIXED
The probe asserted the retired comma-pair token `label:"<value>"`. The current codec (rf2-j0hwf) encodes overrides as one `pr-str` EDN map, so `URLSearchParams.get("overrides")` decodes to `{:label "..."}` — the probe would false-red on the Share URL row. Updated the probe to validate the EDN-map wire contract (decoded payload is an EDN map carrying `:label "<value>"`), and added a guard that **rejects** the old comma-pair token so the test can never drift back to the delimiter-prone legacy codec. Variant/modes/hash assertions kept. No existing bead covered this drift (distinct from rf2-j0hwf, which fixed the impl codec but not this CJS assertion).

## Quality gates
- `cd implementation && npm run test:cljs` → **5851 tests, 20745 assertions, 0 failures, 0 errors** (includes the new `url-state-cljs-test` cases).
- `tools/story` `clojure -M:test` → **1647 tests, 6116 assertions, 0 failures, 0 errors** (includes the new pure `apply-parsed-to-state` regressions).

`story_feature_load.cjs` is a Playwright gate (`test:story-feature-load`); the assertion change is a pure logic edit verified against the EDN-map wire form (`pr-str {:label "..."}` decodes to a string containing `:label "..."`, matching `JSON.stringify(label)` for the space-only labels the probe uses).

Spec `022-Story-UI-Docs-And-Share.md` updated to document the extended authoritative-clear discipline.