### PR TITLE
fix(skills/xray): advertise the overlay/open-overlay! launch surface + findings 2-3 (rf2-ao4l3)

### DIFF
--- a/skills/re-frame2-xray/README.md
+++ b/skills/re-frame2-xray/README.md
@@ -58,19 +58,29 @@ ln -s ~/src/re-frame2/skills/re-frame2-xray ~/.claude/skills/re-frame2-xray
 
 #### Project-local — for your whole team via the repo
 
-Copy the skill into the project's own `.claude/skills/re-frame2-xray/` and commit it. Teammates who clone the repo and open Claude Code there get the same pinned version.
+**Link, never `cp -r`.** A copy snapshots the skill and then drifts as the upstream is maintained — Claude Code keeps loading the stale copy, and fixes/evals never reach your team. Link your project's `.claude/skills/re-frame2-xray/` to the cloned re-frame2 source so the active skill is the upstream by construction:
 
 ```bash
 cd your-re-frame2-project
-cp -r /path/to/re-frame2/skills/re-frame2-xray .claude/skills/re-frame2-xray
-git add .claude/skills/re-frame2-xray
+mkdir -p .claude/skills
+ln -s ~/src/re-frame2/skills/re-frame2-xray .claude/skills/re-frame2-xray   # macOS / Linux (symlink)
 ```
+
+```powershell
+# Windows (junction, no admin):
+New-Item -ItemType Junction -Path .claude\skills\re-frame2-xray -Target $HOME\src\re-frame2\skills\re-frame2-xray
+```
+
+A symlink/junction is not committable in a portable way, so don't `git add` it; instead document the one-liner above in your project's README (or vendor with a deliberate update procedure — see below) so each teammate links on clone. This mirrors the central skill-install contract — see [`skills/README.md` §Installing (link, never copy)](../README.md#installing-link-never-copy) and the repo's `scripts/install-skills.sh` / `scripts/install-skills.ps1` installer, which links *every* skill in one idempotent pass.
+
+**If you must vendor a pinned copy** (e.g. a fully offline team that can't reference the upstream clone), treat it as a deliberate pinned fork: `cp -r` the skill, record the upstream commit you copied from, and re-run the copy whenever you pull upstream fixes. Don't reach for `cp -r` as the default — it silently drifts.
 
 #### Which to choose
 
 - **Global** if you're the only person using Claude Code here, or you want one install shared across repos.
-- **Project-local** if your team wants one pinned, shared version.
-- **Both** is fine — the project-local install takes precedence when both are present.
+- **Project-local (linked)** if your team wants one shared install tracking the upstream source.
+- **Vendored (pinned fork)** only when an offline team can't reference an upstream clone — and only with an explicit update procedure.
+- **Both global + project-local** is fine — the project-local install takes precedence when both are present.
 
 ## License
 

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -2,14 +2,18 @@
 name: re-frame2-xray
 description: >
  Read-only tour of **Xray** — the re-frame2 devtools panel. Use when the
- user wants to know how to *launch* Xray (in-app inline panel, pop-out
- window, programmatic mount, or the wired hotkeys), which of its two
+ user wants to know how to *launch* Xray (in-app inline panel, the
+ overlay fallback for hosts with no layout column / full-screen-canvas /
+ no `[data-rf-xray-host]` — `open-overlay!`, pop-out window, programmatic
+ mount, or the wired hotkeys), which of its two
  modes (Dynamic event-spine / Static registry browse) and which tab
  surfaces the data they're looking for, or what each tab is *for*.
  Trigger phrases: "open Xray", "where is X in Xray",
  "which Xray panel shows…", "Xray Static mode", "browse registered
  machines/routes/schemas in Xray", "Ctrl+Shift+C", "Xray hotkey",
- "Xray mode toggle", "Xray popout", "Xray machine inspector",
+ "Xray mode toggle", "Xray popout", "Xray overlay",
+ "Xray open-overlay!", "open Xray with no layout host / no
+ [data-rf-xray-host] / full-screen canvas", "Xray machine inspector",
  "Xray epoch cascade", "where do Xray issues show up", and similar.
  **Do not use** for: driving Xray
  programmatically from a live REPL (that's `re-frame2-pair`), authoring

--- a/skills/re-frame2-xray/package.json
+++ b/skills/re-frame2-xray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@day8/re-frame2-xray",
   "version": "0.1.0-alpha.1",
-  "description": "Read-only tour skill for Xray — the re-frame2 in-app devtools panel. Teaches how to launch Xray (true-inline, pop-out, programmatic, hotkeys, Dynamic ↔ Static mode toggle) and which tab — across the 6 Dynamic event-spine tabs and 5 Static registry-browse tabs — surfaces the data you're looking for.",
+  "description": "Read-only tour skill for Xray — the re-frame2 in-app devtools panel. Teaches how to launch Xray (true-inline, the open-overlay! fallback for no-layout-host / full-screen-canvas hosts, pop-out, programmatic, hotkeys, Dynamic ↔ Static mode toggle) and which tab — across the 6 Dynamic event-spine tabs and 5 Static registry-browse tabs — surfaces the data you're looking for.",
   "keywords": [
     "claude-code",
     "claude-code-skill",

--- a/skills/re-frame2-xray/references/shared-components.md
+++ b/skills/re-frame2-xray/references/shared-components.md
@@ -42,7 +42,12 @@ at
 [`tools/xray/src/day8/re_frame2_xray/panels/shared/film_strip/header.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/shared/film_strip/header.cljc).
 MVP: chronological walk through the L2 spine. Hit-target sizing per
 §021 §17.1.5 (28×20px, 4px vertical padding for AA target-size).
-Keyboard `←` / `→` global binding. Disabled state at spine ends.
+Disabled state at spine ends. Navigation is via the rendered
+`◀ Prev` / `Next ▶` buttons plus the wired focus-gated `j` / `k` spine
+keys (`:rf.xray/focus-cascade-prev` / `-next`, per `keybinding.cljs`) —
+the component is pure (no global keydown listener), and `keybinding.cljs`
+wires **no** `ArrowLeft` / `ArrowRight` spine handler. Do not document
+arrow-key navigation until `keybinding.cljs` actually implements it.
 
 Per-panel stretch filters (e.g. "next epoch with ⚠" — now driven off the
 issues-ribbon signal rather than an Issues tab — "next route activity"


### PR DESCRIPTION
Fixes the 3 senior-review findings on `skills/re-frame2-xray/` (rf2-ao4l3). All GENERIC (any consumer app). Deduped against the merged 6fch0 senior-review (which fixed `popout!()` / `init!` / machine-blank / Settings) — these three are distinct surfaces.

## Per-finding disposition

**Finding 1 — front-matter omits the overlay launch surface (SKILL.md:4 + package.json:4). FIXED.**
The skill front-matter and the npm `description` enumerated the launch verbs as inline / pop-out / programmatic-mount / hotkeys but omitted the shipped overlay-fallback (`open-overlay!`, no-layout-host / full-screen-canvas) surface — while README.md:7, the SKILL.md:118-127 launch table (which ships overlay as one of "Four launch surfaces"), `references/launch-modes.md` §Overlay fallback, and `evals/evals.json` id 24 (`launch-overlay`) already treat overlay as part of the public mount-verb set. Verified against the live API: `mount.cljs` exports `open-overlay!`, re-exported via `core.cljs`; `spec/API.md` §rf2-sa4fr names it one of the three open verbs. Added overlay / `open-overlay!` / no-layout-host wording to both descriptions plus trigger phrases ("Xray overlay", "Xray open-overlay!", "open Xray with no layout host / no [data-rf-xray-host] / full-screen canvas"). The `launch-overlay` positive eval was already present and is retained unchanged (26 evals total); the description-optimisation loop still scopes to launch/tab-routing, not Xray-implementation. `.claude-plugin/plugin.json` was left as-is — its description says "Teaches launch modes" generically (no verb enumeration), so it carries no omission.

**Finding 2 — false ArrowLeft/ArrowRight keybinding claim (references/shared-components.md:45). FIXED.**
The line claimed `film_strip/header` has a global "Keyboard `←` / `→`" binding. Verified against live source: `keybinding.cljs` `spine-key-id` wires Space / L / G / j / k / `,` / `s` only (j/k = `:rf.xray/focus-cascade-prev` / `-next`) and has NO ArrowLeft/ArrowRight handler; `header.cljc` is a pure component with no global keydown listener (the L2 list owns spine nav). The claim contradicted SKILL.md's "Don't invent hotkeys" contract. Rewrote to: navigation via the rendered `◀ Prev` / `Next ▶` buttons plus the focus-gated `j`/`k` spine keys, with an explicit "no arrow handler wired — do not document arrows until keybinding.cljs implements them" note.

**Finding 3 — `cp -r` project-local install contradicts the central link-never-copy contract (README.md:61). FIXED.**
The project-local install section told teams to `cp -r` the skill and commit it; `skills/README.md` §Installing (link, never copy) mandates symlinking via `scripts/install-skills.sh` / `.ps1` and explicitly forbids `cp -r` ("a copy snapshots the skill and then drifts"). Rewrote the section to a symlink (POSIX) / junction (Windows, no-admin) workflow mirroring the central installer, cross-linked to `skills/README.md`, and documented vendoring only as a deliberate pinned-fork escape hatch with an update procedure. Cross-platform per the standing maintainer rule (POSIX + Windows one-liners both given).

## Quality gates

Run from the worktree (`C:\Users\miket\code\re-frame2-worktrees\skill-xray-senior-ao4l3`):

- `scripts/check_doc_slugs.py --self-test --verbose` — PASS (11/11 self-tests).
- `scripts/check_doc_slugs.py --verbose` — 2 broken anchors reported, both pre-existing in `tools/mcp-base/spec/cap.md` + `vocab.md` (unrelated surface, not touched by this PR; not in this PR's diff). The four edited skill files are clean.
- `scripts/check_skill_package_refs.py` — PASS.
- `scripts/check_readme_links.py` — PASS (no broken README links; 67 READMEs scanned).
- `scripts/check_readme_inventories.py` — PASS.
- `scripts/check_skill_mcp_drift.py --verbose` — PASS (no skill ↔ MCP drift).
- `scripts/check_skill_migration_cites.py --verbose` — PASS.
- `scripts/check_skill_redirect_anchors.py` — PASS.
- `scripts/check_skill_pair_authoring_drift.py --verbose` — PASS.
- SKILL.md front-matter parses as valid YAML (name / description / allowed-tools keys); `description` now contains `open-overlay`.
- `evals/evals.json` parses as valid JSON, 26 evals, `launch-overlay` positive retained.
- `package.json` + `.claude-plugin/plugin.json` parse as valid JSON.
