### PR TITLE
fix(testbed-support): independent-review findings (rf2-w4yw9q)

### DIFF
--- a/tools/testbed-support/README.md
+++ b/tools/testbed-support/README.md
@@ -25,11 +25,15 @@ other clone and every Mac/Linux maintainer (rf2-5dphw).
   which the dev launcher (`implementation/scripts/dev-testbed.cjs`,
   wired as the `dev` npm script) resolves from its own location using
   node's `path` module — identical on Windows, macOS, and Linux.
-- **`resolve-project-root`** — joins that build-time root with the
+- **`resolve-project-root`** — joins a checkout root with the
   tool-relative testbed subdir the caller passes (e.g.
-  `"tools/xray/testbeds"`). A `?project-root=<path>` query string wins
-  as a per-session escape hatch (CI, a reader on another machine, a
-  copied bundle). The path is used **verbatim** — paste it unencoded,
+  `"tools/xray/testbeds"`). A `?project-root=<checkout>` query string
+  wins over the build-time root as a per-session escape hatch (CI, a
+  reader on another machine, a copied bundle). It names the same thing
+  as the build-time root — a **checkout root**, not the final source-path
+  root — and the subdir is appended the same way, so the composed editor
+  URI reaches `<checkout>/tools/xray/testbeds` where the classpath-relative
+  source coords resolve (rf2-w4yw9q). Paste the checkout root unencoded,
   including a literal `+` (e.g. `?project-root=/home/dev/re-frame2+wip`);
   the parser decodes percent-escapes but preserves `+` rather than
   mapping it to a space (rf2-xdsat.1). When neither tier is present it

--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -30,9 +30,13 @@
 
   `resolve-project-root` then joins that root with the tool-relative
   testbed subdir (`\"tools/xray/testbeds\"` /  `\"tools/story/testbeds\"`)
-  the caller passes. A `?project-root=<path>` query string still wins as
-  the per-session escape hatch (CI, a reader on a different machine, a
-  testbed served from a copied bundle). When neither the override nor the
+  the caller passes. A `?project-root=<checkout>` query string still wins
+  as the per-session escape hatch (CI, a reader on a different machine, a
+  testbed served from a copied bundle) — it names the same thing as the
+  build-time root (a CHECKOUT root) and has the subdir appended the same
+  way, so the composed editor URI reaches the tool source-path root
+  (`<checkout>/tools/xray/testbeds`) the classpath-relative source coords
+  resolve against (rf2-w4yw9q). When neither the override nor the
   build-time root is present, this returns `nil` and the testbed simply
   configures no root — 'open in editor' degrades to a no-op rather than a
   broken link, exactly the graceful-absence behaviour
@@ -78,10 +82,10 @@
   itself is blank/nil.
 
   Decoding semantics (rf2-xdsat.1): a literal `+` in the value is preserved
-  VERBATIM, NOT decoded to a space. The override names an on-disk path used
-  verbatim as tier 1, so a checkout at e.g. `/home/dev/re-frame2+wip` must
-  round-trip through `?project-root=/home/dev/re-frame2+wip`. We therefore
-  split the query string manually and decode each component with
+  VERBATIM, NOT decoded to a space. The override names an on-disk checkout
+  root, so a checkout at e.g. `/home/dev/re-frame2+wip` must round-trip
+  through `?project-root=/home/dev/re-frame2+wip` with the `+` intact. We
+  therefore split the query string manually and decode each component with
   `js/decodeURIComponent` (which does NOT map `+` → space) rather than
   `js/URLSearchParams` (form-urlencoded: `+` → space, silent path
   corruption). Percent-escapes still decode (`%2F` → `/`, `%20` → space,
@@ -121,33 +125,55 @@
     (subs s 0 (dec (count s)))
     s))
 
+(defn- join-root+subdir
+  "Join a checkout `root` with the tool-relative testbed `subdir`,
+  normalising both sides so the result carries exactly one separator.
+
+  `root` has any single trailing slash stripped (so `/repo/` + `sub`
+  never yields `/repo//sub`); `subdir` is trimmed and any leading
+  slash(es) removed (so callers may pass it with or without a leading
+  slash). A blank / nil / slash-only `subdir` collapses to the
+  normalised root verbatim."
+  [root subdir]
+  (let [normalized-root   (strip-trailing-slash (str/trim root))
+        normalized-subdir (-> (or subdir "")
+                              str/trim
+                              (str/replace #"^/+" ""))]
+    (if (seq normalized-subdir)
+      (str normalized-root "/" normalized-subdir)
+      normalized-root)))
+
 (defn resolve-project-root
   "Resolve the on-disk project-root a testbed should hand to its
   open-in-editor resolver, for the given tool-relative testbed subdir
   (e.g. `\"tools/xray/testbeds\"` or `\"tools/story/testbeds\"`).
 
+  Both root tiers name a *checkout root* and have the caller's `subdir`
+  appended, because the editor URI is built by prepending the resolved
+  root to a *classpath-relative* source coord (the form-meta `:file`
+  slot, e.g. `\"standard_epochs/core.cljs\"`, relative to the testbed
+  source-path root `<checkout>/tools/xray/testbeds`). The root must
+  therefore reach down to that source-path root, or the composed editor
+  URI misses the tool source-root segment and points at a nonexistent
+  file (rf2-w4yw9q). The override and the build-time define mean the
+  same thing — a checkout root — so they share one join.
+
   Resolution order:
 
-    1. `?project-root=<path>` query string — the per-session escape
-       hatch. Wins over everything; used verbatim — paste the path
-       unencoded, a literal `+` included (it is preserved, NOT decoded
-       to a space; see `query-param-from-search`). (CI, a reader on a
-       different machine, a copied bundle served elsewhere.)
-    2. The build-time `repo-root` goog-define joined with `subdir` —
-       the default for a normal `npm run dev ...` launch.
-    3. `nil` — neither is available. The caller configures no root and
-       open-in-editor is a graceful no-op (matching `set-project-root!`'s
-       blank-input contract).
+    1. `?project-root=<checkout>` query string — the per-session escape
+       hatch (CI, a reader on a different machine, a copied bundle served
+       elsewhere). Wins over the build-time tier. Paste the checkout root
+       unencoded, a literal `+` included (it is preserved, NOT decoded to
+       a space; see `query-param-from-search`); `subdir` is appended just
+       like tier 2.
+    2. The build-time `repo-root` goog-define — the default for a normal
+       `npm run dev ...` launch; `subdir` is appended.
+    3. `nil` — neither root is available. The caller configures no root
+       and open-in-editor is a graceful no-op (matching
+       `set-project-root!`'s blank-input contract).
 
-  `subdir` is normalised so callers may pass it with or without a
-  leading slash."
+  `subdir` is normalised (trim + leading-slash strip) so callers may
+  pass it with or without a leading slash."
   [subdir]
-  (or (query-param "project-root")
-      (when-let [root (non-blank repo-root)]
-        (let [normalized-root   (strip-trailing-slash (str/trim root))
-              normalized-subdir (-> (or subdir "")
-                                    str/trim
-                                    (str/replace #"^/+" ""))]
-          (if (seq normalized-subdir)
-            (str normalized-root "/" normalized-subdir)
-            normalized-root)))))
+  (when-let [root (non-blank (or (query-param "project-root") repo-root))]
+    (join-root+subdir root subdir)))

--- a/tools/testbed-support/src/re_frame/testbed/config_cljs_test.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config_cljs_test.cljs
@@ -278,28 +278,43 @@
 ;; browser, mirroring how the join tests redefine `repo-root`.
 
 (deftest resolve-project-root-override-wins-over-repo-root
-  (testing "a present `?project-root=` override is used VERBATIM and beats
-            the build-time repo-root tier entirely — the subdir is NOT
-            appended (the override already names the final on-disk root)"
+  (testing "a present `?project-root=` override beats the build-time
+            repo-root tier, AND — like that tier — names a CHECKOUT root
+            to which the caller's subdir is appended (rf2-w4yw9q). Both
+            tiers mean the same thing, so the composed editor URI reaches
+            the tool source-path root the classpath-relative source coords
+            resolve against."
     (with-redefs [config/query-param (fn [param]
                                        (when (= param "project-root")
-                                         "/override/path"))
+                                         "/override/checkout"))
                   config/repo-root "/home/dev/re-frame2"]
-      (is (= "/override/path"
+      (is (= "/override/checkout/tools/xray/testbeds"
              (config/resolve-project-root "tools/xray/testbeds"))
-          "override wins; repo-root + subdir is not joined")
-      (is (= "/override/path"
+          "override checkout wins; the caller's subdir is still appended")
+      (is (= "/override/checkout/tools/story/testbeds"
              (config/resolve-project-root "tools/story/testbeds"))
-          "the subdir the caller passes is irrelevant when the override is set"))))
+          "the appended subdir tracks the caller, the root tracks the override"))))
+
+(deftest resolve-project-root-override-checkout-normalises-like-repo-root
+  (testing "the override goes through the SAME join as the build-time tier:
+            a trailing slash on the override checkout never doubles the
+            separator, and the subdir's leading slash is normalised away"
+    (with-redefs [config/query-param (fn [param]
+                                       (when (= param "project-root")
+                                         "/override/checkout/"))
+                  config/repo-root ""]
+      (is (= "/override/checkout/tools/xray/testbeds"
+             (config/resolve-project-root "/tools/xray/testbeds"))
+          "trailing slash on root + leading slash on subdir → single separator"))))
 
 (deftest resolve-project-root-override-wins-even-when-repo-root-blank
   (testing "the override governs regardless of the repo-root tier's state —
-            it is the highest-precedence source"
+            it is the highest-precedence root source"
     (with-redefs [config/query-param (fn [param]
                                        (when (= param "project-root")
-                                         "/override/path"))
+                                         "/override/checkout"))
                   config/repo-root ""]
-      (is (= "/override/path"
+      (is (= "/override/checkout/tools/xray/testbeds"
              (config/resolve-project-root "tools/xray/testbeds"))))))
 
 (deftest resolve-project-root-blank-override-falls-through-to-repo-root
@@ -316,6 +331,70 @@
                   config/repo-root ""]
       (is (nil? (config/resolve-project-root "tools/xray/testbeds"))
           "no override AND no repo-root → nil (graceful no-op)"))))
+
+;; ---- composed editor path: the documented override form (rf2-w4yw9q) ---
+;;
+;; The whole point of the resolved root is that the open-in-editor
+;; resolver prepends it to a CLASSPATH-RELATIVE source coord (the
+;; form-meta `:file` slot, e.g. `standard_epochs/core.cljs`, relative to
+;; the testbed source-path root `<checkout>/tools/xray/testbeds`). These
+;; tests pin that the documented override form — pasting a CHECKOUT root
+;; into `?project-root=` — composes with a representative source coord to
+;; the intended on-disk file, the exact cross-machine portability path the
+;; override exists to provide. (The downstream prepend is `(str root "/"
+;; file)`; we reproduce that single join here so the slice's unit suite
+;; pins the end-to-end contract without reaching into the Xray editor-uri
+;; resolver.)
+
+(defn- composed-editor-path
+  "Mirror the open-in-editor prepend: resolved-root + \"/\" + the
+  classpath-relative source-coord `:file`."
+  [root file]
+  (str root "/" file))
+
+(deftest documented-override-composes-to-intended-on-disk-file
+  (testing "rf2-w4yw9q: pasting a CHECKOUT root into `?project-root=` (the
+            documented `?project-root=/home/dev/re-frame2+wip` form) and
+            resolving for the xray testbed subdir composes with a
+            representative source coord to the real on-disk file —
+            `<checkout>/tools/xray/testbeds/standard_epochs/core.cljs` —
+            NOT the tool-source-root-missing
+            `<checkout>/standard_epochs/core.cljs` that the pre-fix
+            verbatim semantics produced"
+    (with-redefs [config/query-param (fn [param]
+                                       (when (= param "project-root")
+                                         "/home/dev/re-frame2+wip"))
+                  config/repo-root ""]
+      (let [root (config/resolve-project-root "tools/xray/testbeds")]
+        (is (= "/home/dev/re-frame2+wip/tools/xray/testbeds" root)
+            "the checkout override has the tool subdir appended")
+        (is (= "/home/dev/re-frame2+wip/tools/xray/testbeds/standard_epochs/core.cljs"
+               (composed-editor-path root "standard_epochs/core.cljs"))
+            "the composed editor path reaches the actual on-disk source file")))))
+
+(deftest documented-override-and-build-time-tier-compose-identically
+  (testing "rf2-w4yw9q: the override and the build-time `repo-root` tier
+            produce the SAME composed editor path for the same checkout —
+            the contract is one meaning (a checkout root) across both
+            tiers, so a reader's `?project-root=` override behaves exactly
+            like a local `npm run dev` launch from that checkout"
+    (let [coord "standard_epochs/core.cljs"
+          subdir "tools/xray/testbeds"
+          via-override (with-redefs [config/query-param
+                                     (fn [param]
+                                       (when (= param "project-root")
+                                         "/home/dev/re-frame2+wip"))
+                                     config/repo-root ""]
+                         (composed-editor-path
+                          (config/resolve-project-root subdir) coord))
+          via-build-time (with-redefs [config/query-param (constantly nil)
+                                       config/repo-root "/home/dev/re-frame2+wip"]
+                           (composed-editor-path
+                            (config/resolve-project-root subdir) coord))]
+      (is (= via-build-time via-override)
+          "override and build-time tier compose to the identical on-disk path")
+      (is (= "/home/dev/re-frame2+wip/tools/xray/testbeds/standard_epochs/core.cljs"
+             via-override)))))
 
 ;; ---- public-surface stability sentinel ---------------------------------
 


### PR DESCRIPTION
Fixes the one finding from the independent correctness review of `tools/testbed-support` (rf2-w4yw9q).

## The finding (confirmed against current source)

`resolve-project-root` had a two-tier asymmetry:

- The build-time `repo-root` tier joins the caller's tool-relative subdir, producing `<checkout>/tools/xray/testbeds`.
- The `?project-root=` query override was used **verbatim** as the final root — the subdir was NOT appended (pinned by the old `resolve-project-root-override-wins-over-repo-root` test).

The open-in-editor resolver prepends the resolved root to a **classpath-relative** source coord (the form-meta `:file` slot, e.g. `standard_epochs/core.cljs`, relative to the testbed source-path root `<checkout>/tools/xray/testbeds` — see `tools/xray/src/day8/re_frame2_xray/config.cljc:476-489`). So the **documented** override shape — pasting a checkout root such as `?project-root=/home/dev/re-frame2+wip` (README L30/33, config docstring, and the rf2-xdsat.1 `+`-example) — composed to `/home/dev/re-frame2+wip/standard_epochs/core.cljs`, missing the `tools/xray/testbeds` segment. The exact cross-machine open-in-editor portability path the override exists to provide silently produced clickable links to nonexistent files. Gates stayed green because the build-time tier (the only one exercised in CI; no `js/window` under `:node-test`) was always correct.

## Disposition

**Finding 1 (`config.cljs:145`, override contract drift) — FIXED.**

The bead left the contract choice open ("Decide and pin one contract"). Chose **Option A** (make `?project-root=` mean a checkout root and append the subdir, like the build-time tier) over Option B (keep verbatim, rewrite the docs to the `<checkout>/tools/xray/testbeds` form), because it is the more coherent contract under the masterpiece stance:

- One meaning for "project-root" across both tiers (a checkout root).
- The already-documented override example (`?project-root=/home/dev/re-frame2+wip`) becomes **correct** rather than needing a rewrite to the unintuitive source-path-root form.
- The escape-hatch use case ("a reader on a different machine") naturally pastes their checkout root.
- The verbatim semantics were an implementation artifact, not a deliberate ruling — the rf2-xdsat.1 `+`-example was itself written treating the override as a bare checkout root.

Changes (all within `tools/testbed-support/**`):

- `config.cljs` — extract a shared `join-root+subdir` helper; both the override tier and the build-time tier feed it. `repo-root`/override now share one normalisation path. Updated the ns + fn docstrings and the `query-param-from-search` docstring to the checkout-root meaning. The rf2-xdsat.1 literal-`+`-preservation decode contract is unchanged (orthogonal to subdir-append).
- `README.md` — describe the override as a checkout root with the subdir appended.
- `config_cljs_test.cljs` — rewrote the two verbatim-precedence tests to assert the subdir is now appended; added an override trailing/leading-slash normalisation test; added the **bead-requested acceptance tests** that compose `(resolve-project-root "tools/xray/testbeds")` with `standard_epochs/core.cljs` and assert the composed editor path is the intended on-disk file (`<checkout>/tools/xray/testbeds/standard_epochs/core.cljs`), plus that the override and build-time tiers compose to the identical path.

## Quality gates

- `implementation && npm run test:cljs` (node-test build; the `re-frame.testbed.config-cljs-test` ns runs here via the `../tools/testbed-support/src` source path): **5851 tests, 20739 assertions, 0 failures, 0 errors.**
- Verified the new acceptance test actually executes in the `node-test` build by injecting a temporary failing assertion (suite went red: 1 failure, `actual: "/home/dev/re-frame2+wip/tools/xray/testbeds"` — confirming the new contract) then reverting (back to green).
- `node-test` compile: 1167 files, 0 warnings. No standalone `clojure -M:test` alias exists for this dir (no `deps.edn`); tests run via the testbed CLJS surface as documented in the README.

Consuming testbeds only call `(resolve-project-root "tools/xray/testbeds")` and exercise the build-time tier (no query override in CI), whose behaviour is unchanged — no regression risk to the testbeds.
