### PR TITLE
fix(skills/xray): independent-review finding (rf2-i87fjs)

### DIFF
--- a/skills/re-frame2-xray/references/launch-modes.md
+++ b/skills/re-frame2-xray/references/launch-modes.md
@@ -148,10 +148,25 @@ App dev pages should keep the default `true` posture and provide
 
 ### Disable entirely
 
-```clojure
-;; Either: remove the preload entry from :devtools/preloads
-;; Or: closure-define the disable flag in the dev build
-:closure-defines {re-frame.interop/debug-enabled? false}
+Two distinct levers — pick the one that matches your intent:
+
+- **Xray-specific disable** — remove Xray's preload entry from
+  `:devtools/preloads`. The framework's instrumentation surface (trace
+  bus, epoch history) stays live for other tools; only Xray's foundation
+  block (collector/epoch-cb registration, keybinding, browser API,
+  auto-open) is gone.
+
+- **Build-wide debug elision** — set `goog.DEBUG false`. This is the
+  canonical CLJS production flag; it gates *every* dev-only branch,
+  including Xray's. `re-frame.interop/debug-enabled?` is an alias of
+  `goog.DEBUG` (`(def ^boolean debug-enabled? "@define {boolean}"
+  ^boolean goog/DEBUG)`), so you closure-define `goog.DEBUG`, **not**
+  `re-frame.interop/debug-enabled?` directly.
+
+```edn
+;; shadow-cljs.edn — build-wide debug elision (production posture)
+{:builds {:app {:target           :browser
+                :compiler-options {:closure-defines {goog.DEBUG false}}}}}
 ```
 
 ## Overlay fallback (open-overlay!)


### PR DESCRIPTION
## Summary

Fixes the single finding in independent correctness-review bead **rf2-i87fjs** for `skills/re-frame2-xray`.

`skills/re-frame2-xray/references/launch-modes.md` "Disable entirely" snippet told users to set `:closure-defines {re-frame.interop/debug-enabled? false}`. That define is **stale and a no-op**: `re-frame.interop/debug-enabled?` is an alias of `goog.DEBUG` (`implementation/core/src/re_frame/interop.cljs:149` — `(def ^boolean debug-enabled? "@define {boolean}" ^boolean goog/DEBUG)`), so closure-defining the alias name directly does nothing. A user following the snippet could believe Xray is hard-disabled while the `debug-enabled?` gate stays true, leaving the preload side effects (collector/epoch-cb registration, keybinding, browser API, auto-open) live in a dev-like build.

The fix replaces it with the two **real** levers, distinguished explicitly:
- **Xray-specific disable** — remove Xray's preload entry from `:devtools/preloads`.
- **Build-wide debug elision** — `:compiler-options {:closure-defines {goog.DEBUG false}}`, the canonical CLJS production flag. This matches the canonical example in `spec/009-Instrumentation.md:877-893` and the file's own "Production posture" section (`launch-modes.md:308-314`, which already correctly references `goog.DEBUG false`).

### Regression-grep disposition
The bead suggested adding a regression grep/eval that fails on the stale define. I did **not** add one: this skill's `evals/evals.json` is a trigger-only activation fixture (per its own `convention` field), not a content-drift surface, and the existing `check_skill_*.py` gates are each purpose-specific (redirect anchors, package refs, MCP drift). Spinning up a new dedicated gate for a single removed snippet would be over-engineering for a GENERIC one-finding fix. The fix itself plus the now-consistent file (Production posture + Disable entirely both reference `goog.DEBUG`) is the masterpiece move.

## Quality gates
- `python scripts/check_doc_slugs.py` — pass (exit 0)
- `python scripts/check_skill_mcp_drift.py` — pass (exit 0)
- `python scripts/check_skill_migration_cites.py` — pass (exit 0)
- `python scripts/check_skill_package_refs.py` — pass (exit 0)
- `python scripts/check_skill_pair_authoring_drift.py` — pass (exit 0)
- `python scripts/check_skill_redirect_anchors.py` — pass (exit 0)
- `evals/evals.json` not touched (trigger-only fixture; re-validation N/A)
- residue grep: `closure-defines {re-frame.interop/debug-enabled?` — 0 matches across `skills/`

### Disposition
Finding verified against current source (not already fixed by merged rf2-6fch0 / rf2-ao4l3 — those covered popout!/init!/Settings and overlay front-matter/arrow-keys/install respectively, not the disable snippet). Single doc fix, no code/behaviour change.

Closes rf2-i87fjs.