### PR TITLE
fix(skills/pair): independent-review findings (rf2-a85bb2)

### DIFF
--- a/skills/re-frame2-pair/README.md
+++ b/skills/re-frame2-pair/README.md
@@ -50,7 +50,7 @@ Designed for web apps built from the following stack:
 - Optional: re-frame2's source-coord annotation enabled (`(rf/configure! :source-coords {:annotate-dom? true})`) — and/or [`re-com`](https://github.com/day8/re-com) with debug instrumentation + `:src (at)` at call sites. Without one of these, the `dom/*` ops degrade gracefully.
 - [shadow-cljs](https://shadow-cljs.github.io/) as the build tool, with nREPL enabled on the dev build
 
-You don't need to make any changes to your code/project to use it — the MCP server (Node) handles transport, and only re-frame2's own dev-build instrumentation is required on the application side.
+You don't need to change your application *code* to use it — the MCP server (Node) handles transport, and only re-frame2's own dev-build instrumentation is required on the application side. The one build-config change is the dev-only preload: install the `@day8/re-frame2-pair` package and add its `preload/` directory to `:source-paths` plus the namespace to `:devtools :preloads` (two `shadow-cljs.edn` lines — see *Install* below). The preload loads only in dev builds; production is untouched.
 
 ## No re-frame-10x dependency
 
@@ -153,7 +153,8 @@ Here's the kinds of conversations you can have with Claude.
 
 1. Install the MCP server: `npm install -g @day8/re-frame2-pair-mcp`.
 2. Add an `mcpServers` entry to your Claude Code settings — see [`tools/re-frame2-pair-mcp/README.md`](../../tools/re-frame2-pair-mcp/README.md) for the configuration snippet and the full tool surface.
-3. Add the shadow-cljs `:devtools :preloads` entry (`[re-frame2-pair.runtime]`) and a `:source-paths` line pointing at the bundled `preload/` directory — see `SKILL.md` §Setup for the two-line snippet. No extra deps, no closure-defines. The preload only loads in dev; production builds are untouched.
+3. Install the preload package into your app as a dev dependency: `npm install -D @day8/re-frame2-pair`. This ships the `re-frame2-pair.runtime` CLJS namespace under its `preload/` directory; the MCP server package does **not** carry it. **The preload is required** — without it `discover-app` refuses every session with `:reason :runtime-not-preloaded`.
+4. Add the shadow-cljs `:devtools :preloads` entry (`[re-frame2-pair.runtime]`) and a `:source-paths` line pointing at the installed `node_modules/@day8/re-frame2-pair/preload` directory — see `SKILL.md` §Setup for the two-line snippet. No closure-defines. The preload only loads in dev; production builds are untouched.
 
 ### How the connection works
 

--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -93,7 +93,13 @@ Every operation eventually becomes a short ClojureScript form evaluated through 
 
 The skill's helper namespace ships into the app via shadow-cljs's standard `:devtools :preloads` mechanism. This is re-frame2-pair's runtime-helper requirement, separate from Xray's devtools preload and true-inline `[data-rf-xray-host]` panel contract. **The re-frame2-pair preload is required**; there is no per-session cljs-eval inject fallback. `discover-app` refuses with `:reason :runtime-not-preloaded` when it can't find the marker.
 
-Two-line setup. In `shadow-cljs.edn`:
+First install the preload package as a dev dependency in the consumer app:
+
+```bash
+npm install -D @day8/re-frame2-pair
+```
+
+This is a **separate package from the MCP server** (`@day8/re-frame2-pair-mcp`, installed globally) — the MCP server does NOT ship the `preload/` directory, so installing only the server leaves `discover-app` failing with `:runtime-not-preloaded`. Then the two-line `shadow-cljs.edn` change:
 
 ```clojure
 {:source-paths ["src"
@@ -105,8 +111,8 @@ Two-line setup. In `shadow-cljs.edn`:
 Where the runtime lives:
 
 - **Source of truth**: `skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs` in this repo. The path layout matches the CLJS namespace `re-frame2-pair.runtime` so shadow-cljs picks it up on `:source-paths`.
-- **npm consumers**: the `@day8/re-frame2-pair` package ships the `preload/` directory; the source-path entry above points there.
-- **Local-dev / linked checkouts**: substitute the absolute path to `skills/re-frame2-pair/preload/` for the `node_modules/...` entry.
+- **npm consumers**: the `@day8/re-frame2-pair` package (`npm install -D` above) ships the `preload/` directory; the source-path entry above points there.
+- **Local-dev / linked checkouts**: substitute the absolute path to `skills/re-frame2-pair/preload/` for the `node_modules/...` entry (no package install needed — see [`docs/LOCAL_DEV.md`](docs/LOCAL_DEV.md)).
 
 Verification — run `discover-app` (the MCP tool `mcp__re-frame2-pair__discover-app`). The success result is the runtime health map merged with `:ok? true` and `:build-id`, e.g. `:ok? true :debug-enabled? true :frames [:rf/default] :coord-annotation-enabled? true :build-id :app` (plus `:session-id`, `:selected-frame`, `:operating-frame` and the other health slots). If the preload is missing you get back:
 

--- a/skills/re-frame2-pair/docs/LOCAL_DEV.md
+++ b/skills/re-frame2-pair/docs/LOCAL_DEV.md
@@ -15,6 +15,7 @@ Same as the README's *Requirements*:
 - The **MCP server** — the only skill-facing transport. Install it with `npm install -g @day8/re-frame2-pair-mcp` and add an `mcpServers` entry (see [`tools/re-frame2-pair-mcp/README.md`](../../../tools/re-frame2-pair-mcp/README.md)), or run it straight from this clone — see [§MCP server from a clone](#mcp-server-from-a-clone) below.
 - [Claude Code](https://docs.claude.com/en/docs/claude-code).
 - A re-frame2 + shadow-cljs app to exercise it against. (Optional: re-com — used as a fallback source-coord source, not required.)
+- The **`re-frame2-pair.runtime` preload** on the app's `:source-paths`. From a clone (this doc's install paths) it comes for free off the linked skill dir's `preload/` — point `:source-paths` at the absolute `skills/re-frame2-pair/preload/` path. For a non-clone (npm) install, run `npm install -D @day8/re-frame2-pair` in the app first and point at `node_modules/@day8/re-frame2-pair/preload` (see the README's *Install* §). Either way the preload is **required** — `discover-app` refuses with `:runtime-not-preloaded` without it.
 
 > **Babashka is not a skill requirement.** The retired bash shims under
 > `scripts/` (and the project's own `tests/shim/` harness) exec `bb`, but

--- a/skills/re-frame2-pair/docs/capabilities.md
+++ b/skills/re-frame2-pair/docs/capabilities.md
@@ -42,7 +42,7 @@ What re-frame2-pair can see inside a live re-frame2 app.
 | Show effects fired for one epoch | *partial* | `:effects` projection captures warning/error outcomes; successful-fx attribution requires walking `:trace-events` |
 | Follow cascaded dispatch chains | *done* | `:dispatch-id` / `:parent-dispatch-id` correlation; the `:cascades` bundle on the `subscribe` trace topics walks the tree |
 | Show components that re-rendered | *done* | `:renders` projection per epoch |
-| Attach source location to renders | *done* | Source coords flow from registrar metadata; `:render-key` is opaque pending spec finalisation |
+| Attach source location to renders | *done* | Source coords flow from registrar metadata; `:render-key` is a finalised **tuple** `[<view-id-or-:rf.view/anonymous> <instance-token>]` — resolve coords from `(first render-key)` via `handler-meta {kind: "view"}`, or `read-ui`'s `:source-coord` for anonymous fns (see `references/recipes.md` "Explain this dispatch") |
 | List registered machines, see their state | *done* | `list-handlers {kind: "machine"}`, `handler-meta {kind: "machine"}` over `rf/machines` / `rf/machine-meta` / `rf/snapshot-of` |
 | List registered app-schemas | *done* | `rf/app-schemas` (schemas are not a registrar kind — query via the runtime helper) |
 | Frame enumeration / metadata | *done* | `get-operating-frame` (lists all registered frames) over `rf/frame-ids` / `rf/frame-meta` |

--- a/skills/re-frame2-pair/references/recipes.md
+++ b/skills/re-frame2-pair/references/recipes.md
@@ -98,7 +98,7 @@ Fire the event and capture its full epoch in one call — `dispatch {event: "[:c
 - Effects map (visible as `:event/do-fx` plus per-fx warning/error traces; the `:effects` projection only carries warning/error outcomes — successful fx executions live in the raw `:trace-events` slot, see Spec-Schemas note)
 - `app-db` diff between `:db-before` and `:db-after`
 - Subs that re-ran (the `:sub-runs` projection); the absence of a sub from this list means it cache-hit
-- Components that re-rendered (the `:renders` projection), with `:ns` / `:line` / `:file` resolvable via `handler-meta {kind: "view", id: <render-key>}` for registered views
+- Components that re-rendered (the `:renders` projection). Each row's `:render-key` is a **tuple** `[<view-id-or-:rf.view/anonymous> <instance-token>]` (Spec-Schemas `:rf/epoch-record` `:renders`), so resolve source coords from the **first** slot, not the whole tuple: `(first render-key)` is the registered view id you pass to `handler-meta {kind: "view", id: <view-id>}` to get `:ns` / `:line` / `:file`. When the first slot is `:rf.view/anonymous` (a plain Reagent fn, not `reg-view`-registered) `handler-meta` will return `:not-registered` — fall back to `read-ui`'s `:entity` `:view-id` / `:source-coord`, which resolves the producing entity directly. Passing the whole tuple as the `id` always yields `:not-registered`.
 
 Keep it short. One compact paragraph per domino.
 

--- a/skills/re-frame2-pair/references/wire-size-budget.md
+++ b/skills/re-frame2-pair/references/wire-size-budget.md
@@ -45,8 +45,13 @@ return the input unchanged. The expand is local to the agent host;
 no extra round-trip to the runtime.
 
 **Where it fires.** `:epochs` slice on `snapshot`, `trace-window`,
-`watch-epochs`; per-tick `:events` vector on `subscribe`. Always
-opt-out via `dedup false` if your host hasn't been taught the marker.
+`watch-epochs`; the per-tick subscribe payload slot on `subscribe`.
+That slot is **topic-dependent** (per `streaming-subscriptions.md`):
+`:events` for the flat topics (`:epoch` / `:frameless`) and `:cascades`
+for the cascade-bundle topics (`:trace` / `:fx` / `:error`). A host
+decoding subscribe dedup must look under whichever slot the topic
+delivers, not `:events` alone. Always opt-out via `dedup false` if
+your host hasn't been taught the marker.
 
 **Empty / scalar inputs** are passed through unmodified (no marker),
 so the only thing that ever needs `expand` is something that already

--- a/skills/re-frame2-pair/tests/prompts/prompt_regression_test.clj
+++ b/skills/re-frame2-pair/tests/prompts/prompt_regression_test.clj
@@ -54,6 +54,7 @@
 (def ^:private testing-md (delay (slurp-rel "docs/TESTING.md")))
 (def ^:private streaming-md (delay (slurp-rel "references/streaming-subscriptions.md")))
 (def ^:private variant-md (delay (slurp-rel "references/variant-as-frame.md")))
+(def ^:private wire-size-md (delay (slurp-rel "references/wire-size-budget.md")))
 
 ;; ---------------------------------------------------------------------------
 ;; The canonical-prompts table
@@ -353,6 +354,55 @@
         (str "SKILL.md must state subscribe has no `frame` arg so the "
              "operating-frame pin does not scope a streaming subscription "
              "(rf2-ojo3z)."))))
+
+;; ---------------------------------------------------------------------------
+;; Independent-review findings (rf2-a85bb2)
+;; ---------------------------------------------------------------------------
+;;
+;; Finding 2 — wire-size-budget.md must describe the SAME topic-dependent
+;; subscribe payload slot as streaming-subscriptions.md: `:events` for the
+;; flat topics (epoch/frameless) and `:cascades` for the cascade-bundle
+;; topics (trace/fx/error). A host decoding subscribe dedup off the
+;; size-budget leaf that only knew `:events` would leave trace/fx/error
+;; cascade ticks unexpanded. Mirrors the streaming-subscriptions guard above.
+
+(deftest wire-size-budget-names-both-subscribe-slots
+  (testing "wire-size-budget.md subscribe dedup names both :events and :cascades (rf2-a85bb2 finding 2)"
+    (is (and (str/includes? @wire-size-md ":cascades")
+             (str/includes? @wire-size-md ":events"))
+        (str "wire-size-budget.md must document the topic-dependent subscribe "
+             "payload slot — :events (epoch/frameless) AND :cascades "
+             "(trace/fx/error) — not :events alone, or a host will leave "
+             "cascade-bundle dedup ticks unexpanded (rf2-a85bb2)."))))
+
+;; Finding 3 — the render-source-coord recipe must NOT tell an agent to pass
+;; the whole `:render-key` tuple to `handler-meta {kind: "view"}`. The schema
+;; defines `:render-key` as `[<view-id-or-:rf.view/anonymous> <instance-token>]`;
+;; `handler-meta :view` is keyed by the FIRST slot (the registered view id).
+;; The recipe must steer to `(first render-key)` / the `view-id`, and
+;; capabilities.md must not still call `:render-key` opaque-pending-finalisation.
+
+(deftest render-key-recipe-uses-first-tuple-slot
+  (testing "recipes.md resolves render source from the first render-key slot, not the whole tuple (rf2-a85bb2 finding 3)"
+    (is (not (str/includes? @recipes-md "id: <render-key>"))
+        (str "recipes.md tells an agent to pass the whole render-key tuple as "
+             "the handler-meta {kind: \"view\"} id — that yields :not-registered. "
+             "The id is the FIRST tuple slot (the registered view id) (rf2-a85bb2)."))
+    (is (str/includes? @recipes-md "first render-key")
+        (str "recipes.md must steer render-coord resolution to `(first "
+             "render-key)` (the view id) for handler-meta {kind: \"view\"} "
+             "(rf2-a85bb2)."))
+    (is (str/includes? @recipes-md ":rf.view/anonymous")
+        (str "recipes.md must handle the :rf.view/anonymous first-slot case "
+             "(fall back to read-ui's :source-coord) (rf2-a85bb2).")))
+  (testing "capabilities.md no longer calls :render-key opaque-pending-finalisation (rf2-a85bb2 finding 3)"
+    (is (not (str/includes? @capabilities-md "opaque pending spec finalisation"))
+        (str "capabilities.md still calls :render-key opaque-pending-"
+             "finalisation — the schema defines a finalised tuple "
+             "[<view-id> <instance-token>] (rf2-a85bb2)."))
+    (is (str/includes? @capabilities-md "first render-key")
+        (str "capabilities.md must point at `(first render-key)` for source-"
+             "coord resolution, matching recipes.md (rf2-a85bb2)."))))
 
 ;; ---------------------------------------------------------------------------
 ;; Run


### PR DESCRIPTION
Fixes the three independent correctness-review findings for `skills/re-frame2-pair` (bead rf2-a85bb2). All three are distinct from merged **rf2-pok18**, which scoped only the re-authoring `spec/*` + `docs/initial-spec.md` drift gate (verified: that gate's `SCOPED_FILES` does not include any file touched here).

## Findings + fixes

**1. Missing public preload-package install (high)** — `README.md` / `SKILL.md`
The install flow installed only the MCP server (`@day8/re-frame2-pair-mcp`, global) but pointed `:source-paths` at `node_modules/@day8/re-frame2-pair/preload` — a package never installed. The preload lives in the **separate** `@day8/re-frame2-pair` package (the skill's own `package.json`, which ships `preload/`). A clean consumer following the README configured the server correctly but failed every session with `:runtime-not-preloaded`.
- Added `npm install -D @day8/re-frame2-pair` as an explicit install step (README §Install, SKILL.md §Setup).
- Qualified the over-broad "No extra deps" / "no changes to your code/project" claims to name the one build-config (preload) change.
- Noted in `LOCAL_DEV.md` that the clone/symlink path needs no package install (preload comes off the linked skill dir).

**2. wire-size-budget.md subscribe-dedup slot (high)** — `references/wire-size-budget.md`
Said dedup fires on the per-tick `:events` vector only. The subscribe payload slot is **topic-dependent** (per `streaming-subscriptions.md`): `:events` for flat topics (`:epoch` / `:frameless`), `:cascades` for cascade-bundle topics (`:trace` / `:fx` / `:error`). A host decoding off `:events` alone would leave trace/fx/error dedup ticks unexpanded. Updated to name both slots; added a prompt-regression guard mirroring the existing `streaming-progress-payload-matches-impl` test.

**3. render-key handler-meta resolution (high)** — `references/recipes.md`, `docs/capabilities.md`
The dispatch-explanation recipe told an agent to pass the whole `:render-key` to `handler-meta {kind: \"view\"}`. The schema (`Spec-Schemas.md` `:rf/epoch-record` `:renders`) defines `:render-key` as the tuple `[<view-id-or-:rf.view/anonymous> <instance-token>]`; `handler-meta :view` is keyed by the **first** slot. Passing the tuple yields `:not-registered`. Recipe now resolves coords from `(first render-key)`, handles `:rf.view/anonymous` via `read-ui`'s `:source-coord` fallback; `capabilities.md` no longer calls `:render-key` "opaque pending spec finalisation". Added a structural guard.

## Quality gates
- `bb tests/prompts/prompt_regression_test.clj` — **19 tests, 72 assertions, 0 failures** (17 pre-existing + 2 new: `wire-size-budget-names-both-subscribe-slots`, `render-key-recipe-uses-first-tuple-slot`).
- `check_skill_pair_authoring_drift.py` (incl. `--self-test`), `check_skill_mcp_drift.py`, `check_skill_package_refs.py`, `check_skill_redirect_anchors.py`, `check_skill_migration_cites.py` — all exit 0.
- `check_doc_slugs.py` — exit 0.
- `evals.json` untouched (no reference to changed content).

## Disposition
All three findings reproduced against current source and fixed; none was already resolved by rf2-pok18. Lane respected: changes scoped entirely to `skills/re-frame2-pair/**`. GENERIC (applies to any consumer app). No back-compat shims, no day8 coupling.

Closes rf2-a85bb2.