### PR TITLE
fix(examples/scripts): independent-review findings (rf2-y9o5e3)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -172,15 +172,41 @@ else
         mcp_conformance=true
         mcp_live=true
         ;;
-      examples/scripts/serve-and-run-examples-tests.cjs|examples/scripts/run-examples-tests.cjs|examples/scripts/spec-helpers.cjs|examples/scripts/examples-filter.cjs)
+      examples/scripts/serve-and-run-examples-tests.cjs|examples/scripts/run-examples-tests.cjs|examples/scripts/spec-helpers.cjs|examples/scripts/examples-filter.cjs|examples/scripts/examples-port.cjs)
         # rf2-bxdk8 + rf2-cjp0i — the orchestrator + runner + helpers
         # under examples/scripts/ drive the adapter-testbed-smokes job
         # (via `npm run test:examples`). rf2-l72e2 — examples-filter.cjs
         # is the shared example-set manifest + selection logic both the
         # orchestrator and runner import, so a change to it must fire the
-        # gate too. They are the *only* paths under examples/ that fire
-        # this gate; the rest of examples/** is test-free per rf2-8cevm.
+        # gate too. rf2-y9o5e3 — examples-port.cjs is the port resolver
+        # the orchestrator's main() calls before any compile/serve; a
+        # break there false-greens the adapter smoke gate, so it fires it
+        # too. These are the adapter-smoke executable paths under
+        # examples/scripts/; the rest of examples/** is test-free per
+        # rf2-8cevm. (port-resolver.cjs is shared with the Story launchers
+        # and is handled in its own case below so it fires BOTH gates.)
         adapter_testbed_smokes=true
+        ;;
+      examples/scripts/serve-and-run-story-feature-load-tests.cjs|examples/scripts/run-story-feature-load-tests.cjs|examples/scripts/serve-and-run-story-play-scripts.cjs|examples/scripts/story-feature-load-port.cjs)
+        # rf2-y9o5e3 — the Story CI-as-test launchers + their dedicated
+        # port resolver under examples/scripts/ are the executable
+        # orchestration for `npm run test:story-feature-load` and
+        # `npm run test:story-play-scripts`, both of which run under the
+        # story-xray-browser PR job. A break in one of these launchers
+        # (compile step, server staging, port resolution, runner spawn)
+        # can break the Story browser gate, so editing one must fire that
+        # gate — closing the false-green hole where the launcher could
+        # break and still avoid the gate it drives.
+        story_xray_browser=true
+        ;;
+      examples/scripts/port-resolver.cjs)
+        # rf2-y9o5e3 — port-resolver.cjs is the shared free-port resolver
+        # imported by BOTH examples-port.cjs (adapter smoke orchestrator)
+        # and story-feature-load-port.cjs (Story launchers). A break here
+        # affects every examples/scripts browser gate, so it fires BOTH
+        # the adapter-testbed-smokes and the story-xray-browser gates.
+        adapter_testbed_smokes=true
+        story_xray_browser=true
         ;;
       implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/epoch/*|implementation/deps.edn)
         # rf2-8jz9t — adapter_testbed_smokes NOT fired here. Per-feature

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -29,8 +29,10 @@
  * matching spec.cjs exists under SPEC_ROOTS; never stage a surface
  * that nothing tests.
  *
- * Cross-platform: compile via npx, but launch http-server directly from the
- * local package so teardown kills the real server process on Windows too.
+ * Cross-platform: compile shadow-cljs shell-free by resolving its JS
+ * entry-point and spawning it under THIS node binary (process.execPath),
+ * and launch http-server the same way so teardown kills the real server
+ * process on Windows too. Never npx/npx.cmd under a shell (rf2-y9o5e3).
  */
 
 const { spawnSync } = require('child_process');
@@ -111,6 +113,22 @@ const RUNNER = path.resolve(__dirname, 'run-examples-tests.cjs');
 const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
   paths: [IMPL_ROOT],
 });
+// shadow-cljs is a devDependency of implementation/package.json. Resolve
+// its JS entry-point from there so compileAll() can spawn it shell-free
+// under process.execPath — never `npx`/`npx.cmd` under a shell, which on
+// Windows resolves a workspace-local `.cmd` ahead of PATH from a repo-
+// controlled cwd (the command-hijack accident class). rf2-y9o5e3.
+let SHADOW_CLJS_RUNNER;
+try {
+  SHADOW_CLJS_RUNNER = require.resolve('shadow-cljs/cli/runner.js', {
+    paths: [IMPL_ROOT],
+  });
+} catch {
+  throw new Error(
+    'serve-and-run-examples-tests: could not resolve shadow-cljs. Run ' +
+      `\`npm install\` in ${IMPL_ROOT} first.`,
+  );
+}
 const READY_TIMEOUT_MS = 30000;
 const cleanup = createHarnessCleanup();
 cleanup.installSignalHandlers();
@@ -134,8 +152,6 @@ function selectedExamples() {
 }
 
 function compileAll() {
-  const isWin = process.platform === 'win32';
-  const cmd = isWin ? 'npx.cmd' : 'npx';
   // Compile every build in one shadow-cljs invocation — faster: it
   // shares the JVM warmup across builds. Silent-on-success: shadow-
   // cljs's own status lines flow through; that output is build-tool,
@@ -146,14 +162,16 @@ function compileAll() {
       `EXAMPLES_FILTER='${FILTER}' matched zero builds; nothing to compile.`,
     );
   }
-  const args = ['shadow-cljs', 'compile', ...builds];
-  const result = spawnSync(cmd, args, {
+  // Spawn the resolved shadow-cljs JS entry-point under THIS node binary,
+  // shell-free (rf2-y9o5e3). Same hardened posture as story-build.cjs /
+  // dev-testbed.cjs in implementation/scripts.
+  const args = [SHADOW_CLJS_RUNNER, 'compile', ...builds];
+  const result = spawnSync(process.execPath, args, {
     cwd: IMPL_ROOT,
     stdio: 'inherit',
-    shell: isWin,
   });
   if (result.status !== 0) {
-    console.error(`> ${cmd} ${args.join(' ')}`);
+    console.error(`> shadow-cljs compile ${builds.join(' ')}`);
     throw new Error(`shadow-cljs compile failed (exit ${result.status})`);
   }
 }

--- a/examples/scripts/serve-and-run-story-feature-load-tests.cjs
+++ b/examples/scripts/serve-and-run-story-feature-load-tests.cjs
@@ -26,6 +26,21 @@ const RUNNER = path.resolve(__dirname, 'run-story-feature-load-tests.cjs');
 const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
   paths: [IMPL_ROOT],
 });
+// Resolve shadow-cljs's JS entry-point so compileAll() spawns it
+// shell-free under process.execPath — never npx/npx.cmd/cmd.exe (the
+// Windows command-hijack accident class). rf2-y9o5e3; matches
+// story-build.cjs / dev-testbed.cjs.
+let SHADOW_CLJS_RUNNER;
+try {
+  SHADOW_CLJS_RUNNER = require.resolve('shadow-cljs/cli/runner.js', {
+    paths: [IMPL_ROOT],
+  });
+} catch {
+  throw new Error(
+    'serve-and-run-story-feature-load-tests: could not resolve shadow-cljs. ' +
+      `Run \`npm install\` in ${IMPL_ROOT} first.`,
+  );
+}
 const READY_TIMEOUT_MS = 30000;
 const VERBOSE = process.env.RF2_VERBOSE_TESTS === '1';
 const cleanup = createHarnessCleanup();
@@ -45,14 +60,13 @@ const TESTBEDS = [
 ];
 
 function compileAll() {
-  const isWin = process.platform === 'win32';
-  const npx = isWin ? 'npx.cmd' : 'npx';
-  const shadowArgs = ['shadow-cljs', 'compile', ...TESTBEDS.map((t) => t.build)];
-  const command = isWin ? 'cmd.exe' : npx;
-  const args = isWin
-    ? ['/d', '/s', '/c', [npx, ...shadowArgs].join(' ')]
-    : shadowArgs;
-  const result = spawnSync(command, args, {
+  const builds = TESTBEDS.map((t) => t.build);
+  // Spawn the resolved shadow-cljs JS entry-point under THIS node binary,
+  // shell-free (rf2-y9o5e3). Capture output and surface it only on
+  // failure (or under RF2_VERBOSE_TESTS) — the quiet-on-success posture
+  // this gate already kept.
+  const args = [SHADOW_CLJS_RUNNER, 'compile', ...builds];
+  const result = spawnSync(process.execPath, args, {
     cwd: IMPL_ROOT,
     encoding: 'utf8',
   });
@@ -61,7 +75,7 @@ function compileAll() {
     process.stdout.write(output);
   }
   if (result.status !== 0) {
-    console.error(`> ${npx} ${shadowArgs.join(' ')}`);
+    console.error(`> shadow-cljs compile ${builds.join(' ')}`);
     throw new Error(`shadow-cljs compile failed (exit ${result.status})`);
   }
 }

--- a/examples/scripts/serve-and-run-story-play-scripts.cjs
+++ b/examples/scripts/serve-and-run-story-play-scripts.cjs
@@ -106,6 +106,23 @@ function httpServerBin() {
 function loadChromium() {
   return require(require.resolve('playwright', { paths: [IMPL_ROOT] })).chromium;
 }
+// Resolve shadow-cljs's JS entry-point lazily (inside compileTestbed)
+// for the same reason as httpServerBin/loadChromium: the script-policy
+// unit test require()s this module for its pure helpers without the
+// browser/build toolchain installed. compileTestbed() spawns the
+// resolved runner shell-free under process.execPath — never
+// npx/npx.cmd/cmd.exe (the Windows command-hijack accident class).
+// rf2-y9o5e3; matches story-build.cjs / dev-testbed.cjs.
+function shadowCljsRunner() {
+  try {
+    return require.resolve('shadow-cljs/cli/runner.js', { paths: [IMPL_ROOT] });
+  } catch {
+    throw new Error(
+      'serve-and-run-story-play-scripts: could not resolve shadow-cljs. ' +
+        `Run \`npm install\` in ${IMPL_ROOT} first.`,
+    );
+  }
+}
 
 const cleanup = createHarnessCleanup();
 cleanup.installSignalHandlers();
@@ -120,14 +137,11 @@ function log(line) {
 }
 
 function compileTestbed() {
-  const isWin = process.platform === 'win32';
-  const npx = isWin ? 'npx.cmd' : 'npx';
-  const shadowArgs = ['shadow-cljs', 'compile', TESTBED_BUILD];
-  const command = isWin ? 'cmd.exe' : npx;
-  const args = isWin
-    ? ['/d', '/s', '/c', [npx, ...shadowArgs].join(' ')]
-    : shadowArgs;
-  const result = spawnSync(command, args, {
+  // Spawn the resolved shadow-cljs JS entry-point under THIS node binary,
+  // shell-free (rf2-y9o5e3). Quiet-on-success: capture output and surface
+  // it only on failure (or under RF2_VERBOSE_TESTS).
+  const args = [shadowCljsRunner(), 'compile', TESTBED_BUILD];
+  const result = spawnSync(process.execPath, args, {
     cwd: IMPL_ROOT,
     encoding: 'utf8',
   });
@@ -136,7 +150,7 @@ function compileTestbed() {
     process.stdout.write(output);
   }
   if (result.status !== 0) {
-    console.error(`> ${npx} ${shadowArgs.join(' ')}`);
+    console.error(`> shadow-cljs compile ${TESTBED_BUILD}`);
     throw new Error(`shadow-cljs compile failed (exit ${result.status})`);
   }
 }

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -390,6 +390,69 @@ test('examples/scripts/examples-filter.cjs (shared manifest) fires adapter_testb
   assert.equal(result.adapter_testbed_smokes, 'true');
 });
 
+// rf2-y9o5e3 — every EXECUTABLE examples/scripts gate file must fire the
+// browser gate it drives, so a PR breaking a launcher / shared port
+// resolver can't avoid the gate it can break. The adapter-smoke
+// orchestrator + runner + helpers (incl. examples-port.cjs) fire
+// adapter_testbed_smokes; the Story launchers + their dedicated port
+// resolver fire story_xray_browser; the SHARED port-resolver.cjs fires
+// BOTH. Static-only scanners (check-examples-assets.cjs,
+// check-reagent-slim-boundary.cjs) stay on the always-on JS harness path
+// (cljs_browser only) — they have always-on .test.cjs coverage under
+// test:script-policy and drive no browser gate.
+
+const ADAPTER_SMOKE_GATE_FILES = [
+  'examples/scripts/serve-and-run-examples-tests.cjs',
+  'examples/scripts/run-examples-tests.cjs',
+  'examples/scripts/spec-helpers.cjs',
+  'examples/scripts/examples-filter.cjs',
+  'examples/scripts/examples-port.cjs',
+];
+for (const file of ADAPTER_SMOKE_GATE_FILES) {
+  test(`${file} fires adapter_testbed_smokes (rf2-y9o5e3)`, () => {
+    const result = classify(file);
+    assert.equal(result.adapter_testbed_smokes, 'true');
+  });
+}
+
+const STORY_GATE_FILES = [
+  'examples/scripts/serve-and-run-story-feature-load-tests.cjs',
+  'examples/scripts/run-story-feature-load-tests.cjs',
+  'examples/scripts/serve-and-run-story-play-scripts.cjs',
+  'examples/scripts/story-feature-load-port.cjs',
+];
+for (const file of STORY_GATE_FILES) {
+  test(`${file} fires story_xray_browser (rf2-y9o5e3)`, () => {
+    const result = classify(file);
+    assert.equal(result.story_xray_browser, 'true');
+  });
+}
+
+test('examples/scripts/port-resolver.cjs (shared resolver) fires BOTH browser gates (rf2-y9o5e3)', () => {
+  const result = classify('examples/scripts/port-resolver.cjs');
+  assert.equal(result.adapter_testbed_smokes, 'true');
+  assert.equal(result.story_xray_browser, 'true');
+});
+
+test('examples/scripts static-only scanners stay on the always-on JS harness path, no browser gate (rf2-y9o5e3)', () => {
+  for (const file of [
+    'examples/scripts/check-examples-assets.cjs',
+    'examples/scripts/check-reagent-slim-boundary.cjs',
+  ]) {
+    const result = classify(file);
+    assert.equal(
+      result.adapter_testbed_smokes,
+      'false',
+      `${file} is a static scanner with always-on .test.cjs coverage; it must NOT fire adapter_testbed_smokes`,
+    );
+    assert.equal(
+      result.story_xray_browser,
+      'false',
+      `${file} is a static scanner; it must NOT fire story_xray_browser`,
+    );
+  }
+});
+
 test('framework-testbeds workflow job is removed (rf2-t5slp)', () => {
   const workflow = fs.readFileSync(WORKFLOW, 'utf8');
   assert.doesNotMatch(workflow, /^\s*framework-testbeds:/m);

--- a/implementation/scripts/_script-spawn-policy.test.cjs
+++ b/implementation/scripts/_script-spawn-policy.test.cjs
@@ -3,11 +3,12 @@
 'use strict';
 
 /*
- * Source-policy gate: every `implementation/scripts/**` launcher that
+ * Source-policy gate: every `implementation/scripts/**` launcher AND
+ * every executable `examples/scripts/**` browser-gate launcher that
  * spawns a child process must use the HARDENED, shell-free posture
- * (rf2-wn4o1). Two accident classes are gated here, both static (no
- * process is spawned by this suite — it reads the script sources and
- * asserts on their text):
+ * (rf2-wn4o1; examples/scripts coverage added by rf2-y9o5e3). Two
+ * accident classes are gated here, both static (no process is spawned by
+ * this suite — it reads the script sources and asserts on their text):
  *
  *   1. No `shell: true` / `shell: isWin` on any spawn in these scripts.
  *      On Windows `shell:true` + a bare exe name (`npx`/`npm`/`clojure`)
@@ -50,6 +51,20 @@ const fs = require('fs');
 const path = require('path');
 
 const SCRIPTS_DIR = __dirname;
+// rf2-y9o5e3 — the executable browser-gate launchers under
+// examples/scripts/ run the SAME shadow-cljs compile + http-server spawn
+// posture as the implementation/scripts launchers, and `npm run
+// test:examples` / `test:story-feature-load` / `test:story-play-scripts`
+// drive them on Windows local runs. They were previously OUTSIDE this
+// policy gate (it scanned only implementation/scripts/), so a forbidden
+// npx.cmd/cmd.exe/shell posture survived there. Pull them in here.
+const EXAMPLES_SCRIPTS_DIR = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'examples',
+  'scripts',
+);
 
 const tests = [];
 function test(name, fn) {
@@ -101,14 +116,23 @@ function stripComments(src) {
   return out;
 }
 
-// Every `.cjs` launcher in the scripts dir (excludes the test suites and
-// the lib/ helpers — the harness lib carries its own taskkill/spawn that
-// is exercised by _local-browser-harness.test.cjs).
-function gateScriptFiles() {
+// Every `.cjs` launcher in a scanned scripts dir (excludes the test
+// suites and the lib/ helpers — the harness lib carries its own
+// taskkill/spawn that is exercised by _local-browser-harness.test.cjs).
+function cjsFilesIn(dir) {
   return fs
-    .readdirSync(SCRIPTS_DIR)
+    .readdirSync(dir)
     .filter((f) => f.endsWith('.cjs') && !f.endsWith('.test.cjs'))
-    .map((f) => path.join(SCRIPTS_DIR, f));
+    .map((f) => path.join(dir, f));
+}
+
+// implementation/scripts/** (the original rf2-wn4o1 scope) PLUS the
+// executable launchers under examples/scripts/** (rf2-y9o5e3). The
+// examples/scripts dir holds the three browser-gate launchers, their
+// Playwright runners, port resolvers, helpers, and static scanners; none
+// may carry a shell:true/npx.cmd posture, so the whole dir is scanned.
+function gateScriptFiles() {
+  return [...cjsFilesIn(SCRIPTS_DIR), ...cjsFilesIn(EXAMPLES_SCRIPTS_DIR)];
 }
 
 const SHELL_OPT_RE = /\bshell\s*:\s*(true|isWin)\b/;
@@ -190,6 +214,32 @@ test('serve-and-run-xray-feature-gate.cjs resolves shadow-cljs runner + spawns i
   // The compile step spawns the resolved runner constant under node.
   assert.match(src, /spawnSync\(\s*process\.execPath,\s*args/);
 });
+
+// rf2-y9o5e3 — positive guards for the three examples/scripts browser-gate
+// launchers. Each must resolve the shadow-cljs JS entry-point and spawn it
+// shell-free under process.execPath (the same hardened posture as the
+// implementation/scripts launchers above), so a future edit can't quietly
+// regress to the npx.cmd/cmd.exe/shell posture this bead removed.
+const EXAMPLES_LAUNCHERS = [
+  'serve-and-run-examples-tests.cjs',
+  'serve-and-run-story-feature-load-tests.cjs',
+  'serve-and-run-story-play-scripts.cjs',
+];
+for (const base of EXAMPLES_LAUNCHERS) {
+  test(`${base} resolves shadow-cljs runner + spawns the compile under process.execPath (rf2-y9o5e3)`, () => {
+    const src = fs.readFileSync(path.join(EXAMPLES_SCRIPTS_DIR, base), 'utf8');
+    assert.match(
+      src,
+      /require\.resolve\(\s*['"]shadow-cljs\/cli\/runner\.js['"]/,
+      `${base} must resolve shadow-cljs's JS entry-point via require.resolve(...).`,
+    );
+    assert.match(
+      src,
+      /spawnSync\(\s*process\.execPath/,
+      `${base} must spawn the shadow-cljs compile under process.execPath (shell-free).`,
+    );
+  });
+}
 
 // Loopback-bind policy (rf2-utvst): every implementation http-server
 // launcher only ever serves a loopback consumer (the readiness probe +


### PR DESCRIPTION
Closes the two independent-correctness-review findings on `examples/scripts` (rf2-y9o5e3). Both verified current against source before fixing; neither was covered by the deduped beads (rf2-54xbp play-script zero-row guard, rf2-utvst impl/scripts loopback floors).

## Finding 1 — changed-surface classifier leaves examples/scripts launchers + shared port resolver unpinned

`.github/scripts/report-changed-surfaces.sh` only fired `adapter_testbed_smokes` for four examples/scripts files; the Story launchers, the shared port resolver, and `examples-port.cjs` fell through the generic `examples/*` branch (fires `cljs_browser` only), so a PR could break a browser-gate launcher and still skip the gate it drives.

**Disposition: fixed.**
- `examples-port.cjs` added to the `adapter_testbed_smokes` case (the adapter-smoke orchestrator's port resolver).
- New case: `serve-and-run-story-feature-load-tests.cjs`, `run-story-feature-load-tests.cjs`, `serve-and-run-story-play-scripts.cjs`, `story-feature-load-port.cjs` fire `story_xray_browser` (the PR `story-xray-browser` job runs `test:story-feature-load` / `test:story-play-scripts`).
- New case: `port-resolver.cjs` (shared by both the adapter and Story launchers) fires BOTH gates.
- Static-only scanners (`check-examples-assets.cjs`, `check-reagent-slim-boundary.cjs`) deliberately STAY on the always-on JS harness path (`cljs_browser` only); they have always-on `.test.cjs` coverage under `test:script-policy` and drive no browser gate — per the bead.
- `implementation/scripts/_changed-surfaces.test.cjs`: added a classifier test for every executable examples/scripts gate file (adapter-smoke set, Story set, the shared resolver firing both, and a guard that the static scanners fire neither) so a future addition cannot fall through silently.

## Finding 2 — examples launchers spawn via npx/npx.cmd + shell/cmd.exe (command-hijack class)

All three launchers compiled shadow-cljs via a bare `npx`/`npx.cmd` path with `shell:isWin` or `cmd.exe` string composition. The hardened spawn policy (`_script-spawn-policy.test.cjs`) enumerated only `implementation/scripts`, so the gap was invisible.

**Disposition: fixed.**
- All three launchers (`serve-and-run-examples-tests.cjs`, `serve-and-run-story-feature-load-tests.cjs`, `serve-and-run-story-play-scripts.cjs`) now resolve `shadow-cljs/cli/runner.js` from `IMPL_ROOT` and spawn it shell-free under `process.execPath` — the same posture as `story-build.cjs` / `dev-testbed.cjs`. No `npx`/`npx.cmd`/`cmd.exe`/`shell:` literals left.
- `_script-spawn-policy.test.cjs` extended to scan `examples/scripts/**` alongside `implementation/scripts/**`, plus positive assertions pinning the resolve-plus-process.execPath posture for the three launchers.

## Quality gates
Run from `implementation/` (all green):
- `node scripts/_changed-surfaces.test.cjs` -> 59 passed (+13 new)
- `node scripts/_script-spawn-policy.test.cjs` -> 100 passed (examples/scripts now in scope)
- `node scripts/_story-script-runners-policy.test.cjs` -> 11 passed
- `npm run test:script-policy` (the always-on aggregate wiring all of the above) -> green end to end
- `node scripts/check-examples-compile.test.cjs` -> green
- `bash -n` on the classifier + manual edge-case probes: `examples-port.cjs` -> adapter only, `port-resolver.cjs` -> both, `serve-and-run-story-play-scripts.cjs` -> story only, generic `examples/*.cljs` -> `cljs_browser` only (unchanged).

Do not merge.
