### PR TITLE
fix(skills/re-frame2): independent-review findings (rf2-dj66bo)

### DIFF
--- a/skills/re-frame2/patterns/async-effect.md
+++ b/skills/re-frame2/patterns/async-effect.md
@@ -97,17 +97,28 @@ Do NOT hardcode runtime values in the fx registration's options map — registra
 
 **Listener registered at boot.** When the reply channel is a single broadcast surface (a Web Worker's `onmessage`, a Service Worker `MessageChannel`, a native bridge), register the listener once at boot — it dispatches a correlation-keyed event; the fx-handler just posts and includes a correlation id in the payload.
 
+A boot-registered listener has **no ambient frame** when the reply fires — it is not inside the originating fx's closure — so the reply would land in `:rf/default` unless the originating frame round-trips through the posted message. The fx-handler reads `:frame` off its first-arg map and posts it as `:reply-frame`; the listener threads it back into the reply dispatch.
+
 ```clojure
 (defn install-worker-listener! [worker]
   (set! (.-onmessage worker)
         (fn [msg-event]
-          (let [{:keys [reply-event payload]} (js->clj (.-data msg-event) :keywordize-keys true)]
-            (rf/dispatch (conj reply-event payload))))))
+          (let [{:keys [reply-event payload reply-frame]}
+                (js->clj (.-data msg-event) :keywordize-keys true)]
+            ;; reply-frame came back from the posted message; without it the
+            ;; reply would silently land in :rf/default (see anti-patterns).
+            (rf/dispatch (conj reply-event payload)
+                         {:frame (keyword reply-frame)})))))   ;; "rf/default" → :rf/default
 
 (rf/reg-fx :worker/post
-  (fn fx-worker-post [_ {:keys [op args reply-event]}]
-    (.postMessage @worker-instance #js {:op op :args args :reply-event reply-event})))
+  (fn fx-worker-post [m {:keys [op args reply-event]}]
+    ;; subs/str preserves the namespace: (subs (str :rf/default) 1) => "rf/default"
+    (.postMessage @worker-instance
+                  #js {:op op :args args :reply-event reply-event
+                       :reply-frame (subs (str (:frame m)) 1)})))   ;; carry the originating frame
 ```
+
+(`(keyword "rf/default")` reconstructs the namespaced id, so the namespace survives the worker boundary. For a non-keyword or gensym'd frame id, capture an `(rf/frame-handle (:frame m))` at fx time instead and dispatch through `(:dispatch handle)`.)
 
 **Streaming / multi-reply.** LLM-style or SSE-style where each chunk is a separate dispatch. Each emission is a normal dispatched event; the receiving handler appends to a buffer slice. The fx posts once; the reply channel fires N events. Pattern-RemoteData's `:streaming` lifecycle layers on top.
 

--- a/skills/re-frame2/patterns/boot.md
+++ b/skills/re-frame2/patterns/boot.md
@@ -64,7 +64,9 @@ For trivial boots (≤3 steps, no error states, no progress UI), use the chained
       :authenticating
       {:entry  :phase-auth
        :spawn {:machine-id :auth/restore-session
-                :data       (fn [{:keys [data]} _] {:auth-url (-> data :config :auth-url)})}
+                ;; :spawn :data fn takes ONE context-map arg {:keys [snapshot event]};
+                ;; the parent's data lives at (:data snapshot), not the top-level arg.
+                :data       (fn [{:keys [snapshot]}] {:auth-url (-> snapshot :data :config :auth-url)})}
        :on     {:succeeded {:target :loading-profile}
                 :failed    [{:guard :under-retry-limit? :target :retrying-auth :action :bump-attempt}
                             {:target :auth-failed :action :record-error}]}}
@@ -74,8 +76,8 @@ For trivial boots (≤3 steps, no error states, no progress UI), use the chained
       :loading-profile
       {:entry  :phase-profile
        :spawn {:machine-id :rf.http/managed
-                :data       (fn [{:keys [data]} _]
-                              {:request {:method :get :url (-> data :config :profile-url)}
+                :data       (fn [{:keys [snapshot]}]
+                              {:request {:method :get :url (-> snapshot :data :config :profile-url)}
                                :decode  :json})}
        :on     {:succeeded {:target :hydrating :action :record-user}
                 :failed    {:target :profile-failed :action :record-error}}}

--- a/skills/re-frame2/patterns/long-running-work.md
+++ b/skills/re-frame2/patterns/long-running-work.md
@@ -55,7 +55,7 @@ One parent coordinator spawns N children declaratively via `:spawn-all`. Each ch
     :processing     {:entry :process-one :always [{:target :checking-done}]}
     :checking-done  {:always [{:guard :done?      :target :done}
                               {:guard :more-work? :target :yielding}]}
-    :yielding       {:after  {(fn [snap] (-> snap :data :tick-ms)) :processing}}
+    :yielding       {:after  {(fn [{:keys [snapshot]}] (-> snapshot :data :tick-ms)) :processing}}
     :done           {:meta {:terminal? true} :entry :dispatch-done}}})
 
 ;; THE PARENT COORDINATOR
@@ -115,16 +115,16 @@ Exiting `:working` fires one `:rf.machine/destroy` fx carrying `:rf/spawn-all tr
  :processing    {:entry :process-chunk :always [{:target :checking-done}]}
  :checking-done {:always [{:guard :done? :target :complete}
                           {:guard :more-work? :target :yielding}]}
- :yielding      {:after {0 :processing} :on {:cancel :cancelled}}
+ :yielding      {:after {1 :processing} :on {:cancel :cancelled}}
  :complete      {:on {:reset :idle}}
  :cancelled     {:on {:reset :idle}}}
 ```
 
-`:after {0 :processing}` schedules the next chunk after one browser tick. `:cancel` need only be declared on `:yielding` — the user can't click while the JS thread is in `:processing`.
+`:after {1 :processing}` schedules the next chunk after one browser tick — long enough to yield the JS thread, short enough to feel instant. **Do not use `:after {0 …}` for a machine timer:** a non-positive `:after` delay never schedules (the runtime emits `:rf.warning/no-clock-configured` and skips), so a zero-delay chunk loop silently stalls. Use the smallest positive delay (`1`) for the browser yield. `:cancel` need only be declared on `:yielding` — the user can't click while the JS thread is in `:processing`.
 
 **Worker offload.** Genuinely heavy work belongs in a Web Worker via Pattern-AsyncEffect; cancellation stays epoch-based (Pattern-StaleDetection). The chunked-main-thread pattern is the fallback when worker offload isn't feasible (DOM access required, awkward-to-serialise data).
 
-**One-shot heavy block (replaces v1's `^:flush-dom`).** Render a modal before a one-shot heavy computation: `:dispatch-later {:ms 0 :dispatch ...}` gives the browser a render tick. No machine needed.
+**One-shot heavy block (replaces v1's `^:flush-dom`).** Render a modal before a one-shot heavy computation: `:dispatch-later {:ms 0 :event [:do-heavy-block]}` gives the browser a render tick. No machine needed. (The fx key is `:event`, not v1's `:dispatch`; `:ms 0` is fine here — it is a host `setTimeout` yield, not a machine `:after` timer.)
 
 **Progress UI from the machine.** Register subs on `[:rf/machine <id>]` and project `:data` fields into the view.
 
@@ -136,7 +136,7 @@ Exiting `:working` fires one `:rf.machine/destroy` fx carrying `:rf/spawn-all tr
 - **Multiple `assoc`s expecting interleaved renders.** Re-frame2 batches per drain — one render. Chunking is the only way to get intermediate renders.
 - **Manual chunk-state with `setTimeout`.** Re-derives what `:after` already provides; loses tracing and automatic teardown.
 - **Forgetting cancellation.** The exit cascade makes it trivial; omitting `:cancel` on `:working` leaves a runaway loop.
-- **`:always` cycles without `:after 0` between batches.** Hits `:rf.error/machine-always-depth-exceeded` (default 16). `:yielding`'s `:after` resets depth.
+- **`:always` cycles without a yielding `:after` between batches.** Hits `:rf.error/machine-always-depth-exceeded` (default 16). A `:yielding` state with a small positive `:after` delay (e.g. `:after {1 …}` — **not** `:after {0 …}`, which never schedules) resets depth between batches.
 - **Per-child bookkeeping in the parent's `:data`.** The runtime owns join-state at `[:rf/runtime :machines :spawned ...]`; re-implementing re-derives.
 
 ## Worked example

--- a/skills/re-frame2/patterns/remote-data.md
+++ b/skills/re-frame2/patterns/remote-data.md
@@ -40,11 +40,14 @@ The dominant shape; used wherever an explicit `:status` keyword and Pattern-Remo
 
 (rf/reg-event-fx :articles/load
   (fn [{:keys [db]} _]
+    ;; First load runs against an EMPTY db — reg-app-schema validates app-db, it
+    ;; does NOT materialise schema :default values into it, so (:attempt) is nil
+    ;; on the first dispatch. Use (fnil inc 0), never bare inc, or it throws.
     (let [has-data? (some? (get-in db [:articles :data]))]
       {:db (-> db
                (assoc-in  [:articles :status] (if has-data? :fetching :loading))
                (assoc-in  [:articles :error]  nil)
-               (update-in [:articles :attempt] inc))
+               (update-in [:articles :attempt] (fnil inc 0)))
        :fx [[:rf.http/managed
              {:request    {:method :get :url "/api/articles"}
               :on-success [:articles/loaded]
@@ -63,6 +66,13 @@ The dominant shape; used wherever an explicit `:status` keyword and Pattern-Remo
     (-> db
         (assoc-in [:articles :status] :error)
         (assoc-in [:articles :error]  failure))))
+
+;; The fourth lifecycle event: seed (or re-seed) the whole slice explicitly.
+;; This is the supported way to initialise the slice — :default schema props
+;; are validation hints, not an app-db seed, so the slice must be written.
+(rf/reg-event-db :articles/reset
+  (fn [db _]
+    (assoc db :articles {:status :idle :data nil :error nil :loaded-at nil :attempt 0})))
 
 (rf/reg-sub :articles            (fn [db _] (get db :articles)))
 (rf/reg-sub :articles/status     :<- [:articles] :status)

--- a/skills/re-frame2/patterns/websocket.md
+++ b/skills/re-frame2/patterns/websocket.md
@@ -125,9 +125,11 @@ The pattern below uses `:cred-ref` as the placeholder; substitute whatever opaqu
 
       :reconnecting
       {:always [{:guard :max-retries-exceeded? :target :failed}]
-       ;; fn-form delay — re-evaluated each :reconnecting entry against the entering snapshot.
-       :after  {(fn [snap] (let [{:keys [retries base-ms max-backoff-ms]} (:data snap)]
-                             (min (* base-ms (Math/pow 2 retries)) max-backoff-ms)))
+       ;; fn-form delay — ONE context-map arg {:keys [snapshot]}; the snapshot's
+       ;; :data is at (:data snapshot). Re-evaluated each :reconnecting entry.
+       :after  {(fn [{:keys [snapshot]}]
+                  (let [{:keys [retries base-ms max-backoff-ms]} (:data snapshot)]
+                    (min (* base-ms (Math/pow 2 retries)) max-backoff-ms)))
                 {:target [:active]}}
        :on     {:ws/connect     {:target [:active] :action :record-connection-opts}
                 :ws/rotate-cred {:action :rotate-cred}

--- a/skills/re-frame2/references/fundamentals/event-state-cycle.md
+++ b/skills/re-frame2/references/fundamentals/event-state-cycle.md
@@ -110,7 +110,7 @@ Every `:rf.error/*` trace event emitted from inside a running handler — event,
 
 `:kind` is the registry kind (`:event` / `:sub` / `:fx` / `:cofx` / `:view` / `:interceptor` / `:late-bind`); `:id` is the registered id; `:source-coord` comes from the `reg-*` macro's capture. The field is **present** whenever a handler is currently executing and **absent** for dispatch-time errors like `:rf.error/no-such-event`, where no handler is yet in scope. It is **not elided in production** — production debugging benefits most.
 
-Tooling (Xray, re-frame2-pair) renders click-to-jump links straight to the offending handler off this field; in tests / REPL the same field surfaces in `(rf/trace-buffer {:op-type :error})`.
+Tooling (Xray, re-frame2-pair) renders click-to-jump links straight to the offending handler off this field; in tests / REPL the same field surfaces in `(rf/trace-buffer :rf/default {:flat true :op-type :error})`. `trace-buffer` is **per-frame** — the first arg is a `frame-id` (use `:rf/default`, or your explicit frame id), and the filter map is the *second* arg; `{:flat true}` returns raw trace events (filterable by `:op-type`) rather than the default cascade bundles. Passing the opts map as the first arg reads it as a frame id and returns an empty buffer.
 
 ## Common gotchas
 

--- a/skills/re-frame2/references/fundamentals/frames.md
+++ b/skills/re-frame2/references/fundamentals/frames.md
@@ -15,7 +15,8 @@ Most apps never touch any of this — a single-frame app just calls `rf/dispatch
 | Create + own + destroy a frame for a scope (tests / SSR) | `with-new-frame` |
 | Scope a React subtree to a frame | `frame-provider` |
 | Hold a frame's ops as a value (async / closures) | `frame-handle` (common); `frame-bound-fn` / `frame-bound-fn*` (advanced) |
-| One-off explicit routing | `{:frame …}` opt on `dispatch` / `subscribe` |
+| One-off explicit routing (`dispatch`) | `{:frame …}` trailing opt on `dispatch` / `dispatch-sync` |
+| One-off explicit routing (`subscribe`) | leading `frame-id` arg — `(rf/subscribe :frame-id query-v)` (NOT a `{:frame …}` opt) |
 | Read a frame's app-db / its id | `app-db-value` / `current-frame-id` |
 
 A `reg-view` body needs none of these for ordinary dispatch / subscribe — the macro injects frame-aware `dispatch` and `subscribe` locals automatically. A plain (non-`reg-view`) Reagent / UIx / Helix fn that needs to dispatch asks for `(rf/frame-handle)`. An arbitrary async callback uses `frame-bound-fn`.
@@ -54,12 +55,15 @@ Three tiers (the frame-resolution chain in `re-frame.frame` / `re-frame.core`):
 2. **React context** (CLJS only) — read via the `:adapter/current-frame` late-bind hook, populated by the installed adapter under a `frame-provider`.
 3. **`:rf/default`** — fallback when neither of the above applies.
 
-`dispatch` and `subscribe` default `:frame` to `(rf/current-frame-id)`. To target an explicit frame, use the `{:frame …}` opt — the first-class explicit-routing surface (tools, tests, SSR, fx handlers), not a workaround:
+`dispatch` and `subscribe` both default the target frame to `(rf/current-frame-id)`, but their explicit-routing surfaces differ — **`dispatch` / `dispatch-sync` take a trailing `{:frame …}` opts map; `subscribe` / `subscribe-once` / `unsubscribe` take a *leading* `frame-id` argument** (no opts map). The explicit form is first-class (tools, tests, SSR, fx handlers), not a workaround:
 
 ```clojure
-(rf/dispatch  [:foo]      {:frame :stories})
-(rf/subscribe [:my-sub])                          ;; uses current-frame-id
+(rf/dispatch  [:foo] {:frame :stories})           ;; dispatch: trailing {:frame …} opt
+(rf/subscribe :stories [:my-sub])                 ;; subscribe: LEADING frame-id arg
+(rf/subscribe [:my-sub])                          ;; no frame-id → uses current-frame-id
 ```
+
+A trailing `{:frame …}` map passed to `subscribe` is **not** an opts map — it would be read as the `query-v`, silently subscribing to the wrong query. To read a non-default frame's app-db as a plain value (no reaction), use `(rf/app-db-value :frame-id)`.
 
 ## Carrying the frame into async callbacks
 
@@ -137,7 +141,7 @@ Wraps a Reagent / Helix / UIx subtree so descendants resolve `current-frame-id` 
 ## Common gotchas
 
 - **`reg-frame` is atomic and hot-reload safe.** First call creates and runs `:on-create`; subsequent calls perform a **surgical update** of metadata only — existing app-db, sub-cache, queue, machine snapshots all preserved (`reg-frame` in `re-frame.frame`). Use `reset-frame!` for a full destroy+recreate.
-- **`destroy-frame!` cascades.** Per active machine snapshot, the runtime emits *one* `:rf.machine.lifecycle/destroyed` trace carrying `:reason :parent-frame-destroyed` under `:tags` (the unified lifecycle channel — same op-type used at `reg-machine`'s `:created` emit); in-flight HTTP requests get an abort hook; sub-cache reactions all dispose. Subsequent dispatch / subscribe raises `:rf.error/frame-destroyed`. See [009 §`:op-type` vocabulary](../../../../spec/009-Instrumentation.md#op-type-vocabulary).
+- **`destroy-frame!` cascades.** Per active machine snapshot, the runtime emits *one* `:rf.machine.lifecycle/destroyed` trace carrying `:reason :parent-frame-destroyed` under `:tags` (the unified lifecycle channel — same op-type used at `reg-machine`'s `:created` emit); in-flight HTTP requests get an abort hook; sub-cache reactions all dispose. **Subsequent dispatch / subscribe does NOT throw** — the runtime recovers (a teardown / hot-reload race must not crash the caller) but still emits an observable `:rf.error/frame-destroyed` so a genuine use-after-destroy bug stays visible (the `recover-but-emit` contract). The two outcomes differ: a **dispatch** to a destroyed frame **no-ops** (the envelope is dropped, the drain continues) and emits the error; a **subscribe** **returns `nil`** (no reaction) and emits the error. Tests must assert the no-op / `nil` outcome plus the emitted trace — **never** a thrown exception or a try/catch path. See [009 §`:op-type` vocabulary](../../../../spec/009-Instrumentation.md#op-type-vocabulary).
 - **`with-frame` works on both CLJS and the JVM.** The `re-frame.core/with-frame` macro expands on both platforms — use it from JVM tests / SSR / REPL as well as CLJS. For programmatic frame-pinning where a macro is awkward, bind the current-frame dynamic var directly (see the frame-resolution chain above).
 - **Wrapping plain Reagent fns in a non-default `frame-provider` doesn't bind the frame.** Use `reg-view` so the `:contextType` wiring picks up the provider. Watch for the once-per-handler warning.
 - **`:rf/default` is implicit.** Don't re-`reg-frame :rf/default` unless you specifically want to attach metadata to it — calling it without any is a no-op.

--- a/skills/re-frame2/references/state-machines/cancellation.md
+++ b/skills/re-frame2/references/state-machines/cancellation.md
@@ -71,20 +71,22 @@ When the parent destroys the child, the child's exit cascade fires `:ws/close` b
 
 ### Parent-side `:exit` on the `:spawn`-bearing state
 
-If the parent needs to capture the child's last reported value before tearing it down, declare a parent `:exit` action — it runs **before** the auto-destroy (Spec 005 §Composition with explicit `:entry` / `:exit`, `spec/005-StateMachines.md:1889`):
+If the parent needs to capture the child's last reported value before tearing it down, declare a parent `:exit` action — it runs **before** the auto-destroy (Spec 005 §Composition with explicit `:entry` / `:exit`, `spec/005-StateMachines.md:1889`). A machine action receives **only its context map** `(fn [{:keys [data event state meta]}] …)` — `app-db` is **not** in scope, and a direct `@app-db` read would both fail to compile and cross the frame / encapsulation boundary. The supported shape is: the child *reports* the value the parent needs (an ordinary event the parent folds into its own `:data`), then the parent `:exit` reads it straight off the context map's `:data`.
 
 ```clojure
 {:authenticating
  {:spawn {:machine-id :auth-flow}
-  :exit   (fn [{:keys [data]}]
-            ;; The child's snapshot is still at [:rf/runtime :machines :snapshots <id>]; read it.
-            {:fx [[:analytics/record [:auth-attempt
-                                      (get-in @app-db [:rf/runtime :machines :snapshots :auth-flow#1 :data])]]]})
-  :on     {:succeeded :authenticated
-           :failed    :auth-failed}}}
+  ;; Fold the child's progress reports into the parent's own :data as they arrive.
+  :on   {:auth-flow/progress {:action (fn [{data :data [_ report] :event}]
+                                        {:data (assoc data :last-auth-report report)})}
+         :succeeded :authenticated
+         :failed    :auth-failed}
+  ;; :exit reads the last report from the context map — never @app-db.
+  :exit (fn [{:keys [data]}]
+          {:fx [[:analytics/record [:auth-attempt (:last-auth-report data)]]]})}}
 ```
 
-The auto-destroy runs after the user's `:exit` — wire-level concatenation, not nesting.
+If the value lives only in the child's `:data` and the child never reported it up, the supported reads are an ordinary (non-machine) `reg-event-fx` with a cofx — which sees `app-db` through the proper frame API — or `(rf/app-db-value frame-id)` from outside any machine action. The auto-destroy runs after the user's `:exit` — wire-level concatenation, not nesting.
 
 ## Common gotchas
 


### PR DESCRIPTION
Independent correctness review of `skills/re-frame2` (bead rf2-dj66bo, 9 findings). Every claim was verified against the **current** framework source / spec before editing. None of the 9 findings overlapped the already-merged senior reviews (uyg91 = set-schema-validator!/cofx/on-spawn/cred-namespace; ja0pf = Story-recorder/FormAction privacy) — all 9 were genuinely open. Lane: `skills/re-frame2/**` only; guidance kept GENERIC (any consumer app).

## Quality gates

| Gate | Result |
|---|---|
| `scripts/check_doc_slugs.py` | pass (exit 0) |
| `scripts/check_skill_redirect_anchors.py` | pass (exit 0) |
| `scripts/check_skill_mcp_drift.py` | pass (exit 0) |
| `scripts/check_skill_migration_cites.py` | pass (exit 0) |
| `scripts/check_skill_package_refs.py` | pass (exit 0) |
| `scripts/check_skill_pair_authoring_drift.py` | pass (exit 0) |
| `evals.json` valid JSON | pass (untouched — the suite is behavioural, not a static-grep harness) |

## Per-finding disposition

All 9 **fixed** (all verified genuinely open against current source):

1. **fixed** — `frames.md:18,57`. Verified `re-frame.core/subscribe` is positional `(subscribe query-v)` / `(subscribe frame-id query-v)`; only `dispatch`/`dispatch-sync` take the trailing `{:frame …}` opts map. Split the table row + prose; added the "trailing map is read as query-v" warning and the `app-db-value` pointer.
2. **fixed** — `frames.md:140`. Verified router `handle-frame-destroyed!` + subs destroyed-frame branch: per rf2-2hvga `recover-but-emit`, dispatch **no-ops** and subscribe returns **nil**, both emit `:rf.error/frame-destroyed` — neither throws. Replaced "raises" with the concrete no-op/nil + trace behaviour, distinguishing the two outcomes.
3. **fixed** — `cancellation.md:82`. Verified machine actions receive only the context map `(fn [{:keys [data event state meta]}] …)` (spec 005 §Actions, table line 662); `app-db` is not in scope. Removed the `@app-db` read; showed the supported shape (child reports up → parent folds into `:data` → `:exit` reads from ctx), plus the non-machine `reg-event-fx`/`app-db-value` escape hatch.
4. **fixed** — `boot.md:67,77`. Verified canonical `:spawn :data` signature `(fn [{:keys [snapshot event]}] data)` (spec 005 table line 662); parent data at `(:data snapshot)`. Rewrote both fns from the old two-arg `(fn [{:keys [data]} _] …)` form. (Matches the already-correct form at `ssr-loaders.md` / `websocket.md:96`.)
5. **fixed** — `long-running-work.md:58,118,123,139` + `websocket.md:129`. Verified `:after` delay-fns are called with `{:snapshot …}` (`machines/timer.cljc` `resolve-delay-ms`) and that a non-positive resolved delay hits the `(not (pos? resolved-ms))` branch → emits `:rf.warning/no-clock-configured` `:recovery :skipped` and **never schedules**. Changed delay-fns to `(fn [{:keys [snapshot]}] …)`; replaced `:after {0 …}` with `:after {1 …}` + a yield note. (See spec-divergence note below.)
6. **fixed** — `long-running-work.md:127`. Verified `:dispatch-later` fx destructures `{:keys [ms event]}` and dispatches `event` (`core/fx.cljc:282`). Changed legacy `:dispatch` → `:event`; noted `:ms 0` is fine for a host `setTimeout` yield (unlike a machine `:after` timer).
7. **fixed** — `remote-data.md:47`. Verified spec 010: `reg-app-schema` **validates** app-db paths post-commit; it does **not** materialise `:default` props into app-db. First load against an empty db → `(inc nil)` throws. Changed slice-form to `(fnil inc 0)` (matching the machine-form's already-correct `:bump-attempt`), and added the named `:articles/reset` event so the leaf's "four-event lifecycle" is actually shown.
8. **fixed** — `async-effect.md:105`. Boot listener has no ambient frame, so `(rf/dispatch (conj reply-event payload))` lands in `:rf/default` (contradicting the leaf's own anti-pattern). Round-tripped `:reply-frame` through the posted message (namespace-preserving str/keyword round-trip); noted the `frame-handle` fallback for gensym'd ids.
9. **fixed** — `event-state-cycle.md:113`. Verified `trace-buffer` is per-frame `(trace-buffer frame-id)` / `(trace-buffer frame-id opts)` and raw events need `{:flat true}` (`core.cljc:1390`). Changed to `(rf/trace-buffer :rf/default {:flat true :op-type :error})` with the arity explanation.

## Notes for the mayor

- **Drift-test suggestions not actioned (by design).** Several findings suggest "add a grep/eval drift guard." `evals/evals.json` is a *behavioural* eval suite (discovery / recipe-correctness / routing-correctness), not a static-grep harness, and no such grep-drift infrastructure exists for this skill. Adding one is out-of-scope gold-plating for a correctness review; the source fixes are the load-bearing deliverable.
- **Spec/impl divergence surfaced (out of lane — recommend a follow-up bead).** Finding 5 is correct about the runtime: `machines/timer.cljc` skips non-positive `:after` delays via `:rf.warning/no-clock-configured`. But `spec/005-StateMachines.md:2749` canonically blesses `:after 0` as the Pattern-LongRunningWork "browser yield between chunks" idiom. The skill now teaches the runtime's actual behaviour (positive delay); the spec text should be reconciled to match (or the runtime taught to treat `0` as a yield). This is a `spec/` hot-zone change outside this skill lane.
