### PR TITLE
fix(skills/improver): independent-review findings (rf2-wso1dm)

### DIFF
--- a/skills/re-frame2-improver/references/imperative-effects.md
+++ b/skills/re-frame2-improver/references/imperative-effects.md
@@ -74,7 +74,10 @@ Spec source: [`spec/Conventions.md`](../../../spec/Conventions.md) (data-only fx
 
 ;; Writes -> data-only fx (effect performed after the handler returns):
 (rf/reg-fx :local-storage/set
-  (fn [_ctx {:keys [k v]}] (.setItem js/localStorage k v)))
+  {:platforms #{:client}}                                          ;; browser-only: skipped cleanly under SSR
+  (fn [_ctx {:keys [k v]}]
+    (when-let [ls (.-localStorage js/globalThis)]                  ;; defensive: globalThis works on every platform
+      (.setItem ls k v))))
 
 (rf/reg-fx :dom/set-body-class
   {:platforms #{:client}}

--- a/skills/re-frame2-improver/references/schemaless-events.md
+++ b/skills/re-frame2-improver/references/schemaless-events.md
@@ -4,7 +4,12 @@
 
 ## Detection rules
 
-**The cardinal rule.** Any handler that crosses an untrusted boundary — HTTP response, WebSocket frame, `postMessage` payload, query-string param, `localStorage` rehydration, IndexedDB read, third-party iframe — is **flagged** unless **production validation** is wired. Production validation means an always-on gate: the `[rf/validate-at-boundary-interceptor]` interceptor on the handler, an equivalent always-on Malli-check interceptor, or a `:decode` schema on a Managed HTTP request that runs in production builds. `:schema` on the handler metadata and `reg-app-schema` on the destination path are necessary but **not sufficient on their own** — both are dev-elided in production builds (`goog.DEBUG = false`), so a handler that relies only on them is unvalidated in the deployed bundle.
+**The cardinal rule.** Any handler that crosses an untrusted boundary — HTTP response, WebSocket frame, `postMessage` payload, query-string param, `localStorage` rehydration, IndexedDB read, third-party iframe — is **flagged** unless **production validation** is wired for *the untrusted value itself*. `:schema` on the handler metadata and `reg-app-schema` on the destination path are necessary but **not sufficient on their own** — both are dev-elided in production builds (`goog.DEBUG = false`), so a handler that relies only on them is unvalidated in the deployed bundle.
+
+**Two boundary shapes, two production gates.** The untrusted value arrives in one of two places, and only the matching gate counts:
+
+- **Event-payload boundary** — the untrusted value rides *in the dispatched event vector* (an HTTP `:rf/reply`, a `postMessage` event arg, a query-string map dispatched as `[:route/params-received params]`). The always-on gate is `[rf/validate-at-boundary-interceptor]` on the handler (it forces the handler's `:schema` to run over the event vector at run-time, production included) **or** a Managed HTTP `:decode <Schema>` on the originating request (validates the response at decode time, production included). `validate-at-boundary-interceptor` only validates the **event vector** against `:schema` — it does **not** see values the handler fetches inside its own body.
+- **Body-read boundary** — the handler *reads the untrusted value mid-body* (`(.getItem js/localStorage …)`, `js/window.location.search`, `(.-data msg)` pulled from a stashed source, an IndexedDB cursor result) and then writes it to `app-db`. `validate-at-boundary-interceptor` is **useless here** — the value never appears in the event vector it checks. The always-on gate must wrap the **raw value**: a `(m/validate Schema raw)` (or `m/coerce` / `m/explain`) call in the handler body that runs unconditionally (not behind `(when ^boolean js/goog.DEBUG …)`), **or** — better — move the read into a validating cofx / interceptor / fx-reply path that materialises and validates the value *before* the handler writes it.
 
 Greppable signals — flag when **any** of these match AND no production gate is wired:
 
@@ -17,12 +22,16 @@ Greppable signals — flag when **any** of these match AND no production gate is
 Detection logic (apply for each candidate handler):
 
 1. Does the handler ingest data from an untrusted source? (See list above.) If no → not in scope for this leaf.
-2. Is **at least one** of these production-gate mechanisms present?
-   - `[rf/validate-at-boundary-interceptor]` (or an equivalent always-on validator) in the handler's interceptor chain.
-   - Managed HTTP `:decode <Schema>` on the originating request — runs in production.
-   - A custom interceptor that performs Malli validation **outside `(when ^boolean js/goog.DEBUG …)`** or any dev-only conditional.
-   If yes → not a finding.
-3. If no → **flag**, regardless of whether `:schema` and `reg-app-schema` are attached. Both are dev-elided in production; the boundary is open in the deployed bundle.
+2. **Where does the untrusted value arrive?** Classify the boundary shape — it picks which gate counts:
+   - **Event-payload** (the value is *in the dispatched event vector*): a matching production gate is **one** of —
+     - `[rf/validate-at-boundary-interceptor]` in the handler's interceptor chain (validates the event vector against `:schema` at run-time, production included), **or**
+     - Managed HTTP `:decode <Schema>` on the originating request (validates the response at decode time, production included), **or**
+     - a custom interceptor that Malli-validates the event vector **outside `(when ^boolean js/goog.DEBUG …)`** or any dev-only conditional.
+   - **Body-read** (the handler *fetches the value mid-body* — `localStorage`, query string, IndexedDB, a stashed `postMessage` source): `validate-at-boundary-interceptor` does **not** count — it only checks the event vector, which never contains the fetched value. A matching production gate is **one** of —
+     - an always-on `(m/validate Schema raw)` / `(m/coerce Schema raw …)` / `(m/explain …)` over the **raw value**, run unconditionally (not behind a dev-only `goog.DEBUG` guard), before the write, **or**
+     - the read moved into a validating cofx (`reg-cofx` that materialises *and* validates) / interceptor / fx-reply path, so the handler only ever sees a value already validated.
+   If a matching gate for the boundary shape is present → not a finding.
+3. If no matching gate → **flag**, regardless of whether `:schema` and `reg-app-schema` are attached. Both are dev-elided in production; the boundary is open in the deployed bundle. In particular, a body-read handler carrying `:schema` + `[rf/validate-at-boundary-interceptor]` **for the event id only** is still a finding — the interceptor validates the (trusted) dispatch, not the (untrusted) value the body fetched.
 
 Structural signal: the boundary between **untrusted input** and **trusted `app-db`** is crossed without a Malli schema gate **that runs in production**.
 
@@ -30,11 +39,16 @@ Structural signal: the boundary between **untrusted input** and **trusted `app-d
 
 `app-db` is the trust boundary. The whole substrate downstream of it (subs, views, machine reads, story snapshots, time-travel) assumes the values it reads conform to the application's mental model. A schemaless boundary event smuggles arbitrary data past the gate — a stale API field, a server schema change, a malformed query string, a tampered `localStorage` payload — and the failure surfaces hundreds of dispatches later in a sub that crashes on a missing key. Schemas at boundaries are Cardinal Rule #4 (`skills/re-frame2/SKILL.md`).
 
-The runtime offers two complementary dev-time tools: handler `:schema` (validates the **event vector** before the handler runs) and `reg-app-schema` (validates the **app-db path** after the handler writes). The first catches malformed dispatches; the second catches malformed writes. **Both are dev-elided in production** (gated on `goog.DEBUG`) unless explicitly attached at the boundary via the always-on `validate-at-boundary-interceptor` interceptor (or an equivalent always-on validator, e.g. a Managed HTTP `:decode` schema on the originating request). A handler that carries only `:schema` and / or `reg-app-schema` is validated in dev but unvalidated in the deployed bundle — the exact place the boundary matters.
+The runtime offers two complementary dev-time tools: handler `:schema` (validates the **event vector** before the handler runs) and `reg-app-schema` (validates the **app-db path** after the handler writes). The first catches malformed dispatches; the second catches malformed writes. **Both are dev-elided in production** (gated on `goog.DEBUG`). The always-on `validate-at-boundary-interceptor` re-runs the handler's `:schema` over the **event vector** in production — so it closes an *event-payload* boundary (Managed HTTP `:decode` is the other always-on gate there). It does **not** rescue `reg-app-schema`'s write-check, and it cannot see a value the handler reads mid-body — a *body-read* boundary (`localStorage`, query string, IndexedDB) needs the **raw value itself** validated, by an always-on `m/validate` in the body or a validating cofx. A handler that carries only `:schema` and / or `reg-app-schema` is validated in dev but unvalidated in the deployed bundle — the exact place the boundary matters.
 
 ## The canonical fix
 
-[`skills/re-frame2/references/fundamentals/schemas.md`](../../re-frame2/references/fundamentals/schemas.md) — at a minimum, an always-on gate at the boundary: the `[rf/validate-at-boundary-interceptor]` interceptor on the handler, or a Managed HTTP `:decode <Schema>` on the originating request, or an equivalent custom always-on Malli-check interceptor. `:schema` on the handler metadata and `reg-app-schema` on the destination path are valuable dev-time tools that surface mismatches early — but they do not satisfy this rule on their own, because both are elided when `goog.DEBUG` is false.
+[`skills/re-frame2/references/fundamentals/schemas.md`](../../re-frame2/references/fundamentals/schemas.md) — at a minimum, an always-on gate matched to the boundary shape:
+
+- **Event-payload boundary** (value in the event vector): the `[rf/validate-at-boundary-interceptor]` interceptor on the handler, or a Managed HTTP `:decode <Schema>` on the originating request, or an equivalent custom always-on Malli-check interceptor over the event vector.
+- **Body-read boundary** (value fetched mid-body — `localStorage`, query string, IndexedDB, a stashed `postMessage` source): an always-on `(m/validate Schema raw)` over the raw value before the write, or — preferably — move the read into a validating cofx / interceptor / fx-reply path so the handler only ever sees a validated value. `validate-at-boundary-interceptor` does **not** apply here; it only checks the event vector.
+
+`:schema` on the handler metadata and `reg-app-schema` on the destination path are valuable dev-time tools that surface mismatches early — but they do not satisfy this rule on their own, because both are elided when `goog.DEBUG` is false.
 
 Spec source: [`spec/010-Schemas.md`](../../../spec/010-Schemas.md). The `:rf.error/schema-validation-failure` error category is the corresponding instrumentation signal.
 
@@ -101,26 +115,80 @@ The handler below carries **both** `:schema` and `reg-app-schema`, and looks lik
 
 **Why it flags.** In dev, `goog.DEBUG = true` runs the `:schema` and `reg-app-schema` validators — mismatches surface fast. In a production build the JIT/CC-elision strips both, and the handler writes whatever the server returned straight into `app-db`. The trust boundary is open in the bundle the user actually ships. The fix is to add `[rf/validate-at-boundary-interceptor]` to the interceptor chain (validates the event vector at run-time, production included) or a Managed HTTP `:decode Article` on the request (validates the response at decode time, production included) — ideally both.
 
-Other untrusted-boundary shapes that hit the same rule (the source varies, the gate is identical):
+Other untrusted-boundary shapes that hit the same rule — but watch *which* gate applies, because the boundary shape decides it:
 
 ```clojure
-;; query-string ingestion
+;; query-string ingestion — EVENT-PAYLOAD (params ride in the event vector)
 (rf/reg-event-db :route/params-received                          ;; flag — no always-on gate
   {:schema [:cat keyword? :map]}
   (fn [db [_ params]] (assoc db :route/params params)))
+;;   Gate: [rf/validate-at-boundary-interceptor] — validates the event vector in prod.
 
-;; localStorage rehydration
+;; postMessage payload — EVENT-PAYLOAD (msg arrives as the event arg)
+(rf/reg-event-db :postmessage/received                           ;; flag — no always-on gate
+  (fn [db [_ msg]] (assoc db :embed/state (.-data msg))))
+;;   Gate: [rf/validate-at-boundary-interceptor] — validates the event vector in prod.
+
+;; localStorage rehydration — BODY-READ (handler fetches the value itself)
 (rf/reg-event-fx :session/rehydrate                              ;; flag — no always-on gate
   (fn [{:keys [db]} _]
     (let [raw (.getItem js/localStorage "session")]
       {:db (assoc db :session (js->clj (js/JSON.parse raw)))})))
-
-;; postMessage payload
-(rf/reg-event-db :postmessage/received                           ;; flag — no always-on gate
-  (fn [db [_ msg]] (assoc db :embed/state (.-data msg))))
+;;   Gate: [rf/validate-at-boundary-interceptor] does NOTHING here — the fetched
+;;   value never enters the event vector. Validate the raw value (m/validate) or
+;;   move the read into a validating cofx. See the regression example below.
 ```
 
-Each writes an unvalidated payload past the trust boundary in production. Each is flagged regardless of any dev-only `:schema` / `reg-app-schema` it might carry.
+The event-payload shapes are flagged unless `validate-at-boundary-interceptor` (or a Managed HTTP `:decode`) is wired; the body-read shape is flagged until the **fetched value itself** is validated — `validate-at-boundary-interceptor` is the wrong gate for it.
+
+## Regression example — body-read boundaries need the value validated, not the event
+
+This handler carries **both** a `:schema` for its event id **and** `[rf/validate-at-boundary-interceptor]`. For an event-payload boundary that would close the gate. It is **still a finding** — the untrusted value (`localStorage`) is read *inside the body*, so the interceptor validates the (empty, trusted) `[:session/rehydrate]` dispatch and never touches the parsed `localStorage` payload.
+
+```clojure
+(def Session
+  [:map [:user/id :uuid] [:user/roles [:set :keyword]]])
+
+(rf/reg-app-schema [:session] Session)                           ;; dev-only — elided in production
+
+(rf/reg-event-fx :session/rehydrate
+  {:schema [:cat [:= :session/rehydrate]]}                       ;; dev-only — pins the (trusted) dispatch shape
+  [rf/validate-at-boundary-interceptor]                          ;; validates the EVENT VECTOR — not the localStorage value
+  (fn [{:keys [db]} _]
+    (let [raw (.getItem js/globalThis.localStorage "session")]   ;; <-- untrusted body read
+      {:db (assoc db :session (js->clj (js/JSON.parse raw)))}))) ;; production: writes arbitrary localStorage straight in
+```
+
+**Why it flags.** `validate-at-boundary-interceptor` runs the handler's `:schema` over `[:session/rehydrate]` — which the app dispatched itself and is trivially valid. The interceptor has no visibility into `raw`; nothing validates the JSON a tampered or stale `localStorage` returns. In production the `reg-app-schema` write-check is elided too, so attacker-controlled or malformed session data lands in `app-db` unchecked.
+
+**The fix — validate the raw value, two equivalent shapes:**
+
+```clojure
+;; (a) Always-on Malli check over the raw value, before the write:
+(rf/reg-event-fx :session/rehydrate
+  (fn [{:keys [db]} _]
+    (let [raw    (.getItem js/globalThis.localStorage "session")
+          parsed (some-> raw js/JSON.parse (js->clj :keywordize-keys true))]
+      (if (m/validate Session parsed)                            ;; ALWAYS-ON — runs in production
+        {:db (assoc db :session parsed)}
+        {:fx [[:session/clear-corrupt]]}))))                     ;; reject, don't ingest
+
+;; (b) Better — move the read+validation into a cofx; the handler only sees a clean value:
+(rf/reg-cofx :session/stored
+  {:doc "Materialise + validate the persisted session; nil if absent/corrupt."}
+  (fn [ctx]
+    (let [parsed (some-> (.getItem js/globalThis.localStorage "session")
+                         js/JSON.parse (js->clj :keywordize-keys true))]
+      (assoc-in ctx [:coeffects :session]
+                (when (m/validate Session parsed) parsed)))))    ;; ALWAYS-ON validation in the cofx
+
+(rf/reg-event-fx :session/rehydrate
+  [(rf/inject-cofx :session/stored)]
+  (fn [{:keys [db session]} _]                                   ;; :session is already validated data
+    (cond-> {} session (assoc :db (assoc db :session session)))))
+```
+
+Both gates validate the **value the body would have read**, so the boundary is closed in the production bundle — not just the dispatch shape.
 
 ## Edge cases — when schemaless is fine
 


### PR DESCRIPTION
Fixes the two findings from the independent correctness review of `skills/re-frame2-improver` (rf2-wso1dm). GENERIC; lane is `skills/re-frame2-improver/**` only. Deduped against merged rf2-qlf5c (README/design summaries) and rf2-lwee5 (boolean-discriminator-subs) — neither covers either finding; both confirmed live against current source.

## Per-finding disposition

**F1 — `references/schemaless-events.md` (body-read boundary false negatives). Fixed.**
The detection logic treated `[rf/validate-at-boundary-interceptor]` as a sufficient production gate for *any* untrusted-boundary handler, including handlers that read `localStorage`/`sessionStorage`/`window.location.search`/`postMessage`/IndexedDB *inside the body*. The framework interceptor only re-runs the handler's `:schema` over the **dispatched event vector**; it cannot see a value the body fetches. Fix splits the guidance into two boundary shapes:
- **Event-payload** (value in the event vector) → `validate-at-boundary-interceptor` or Managed HTTP `:decode` (unchanged, correct).
- **Body-read** (value fetched mid-body) → the **raw value itself** must be validated via an always-on `m/validate` (not behind a `goog.DEBUG` guard), or the read moved into a validating cofx/interceptor/fx-reply path.

Updated: cardinal rule, numbered detection logic (steps 2–3), "why it's an anti-pattern" prose, canonical-fix section, and the other-boundary-shapes block (now per-shape gates). Added the requested regression example: a `:session/rehydrate` handler carrying `:schema` + `[rf/validate-at-boundary-interceptor]` for the event id only — **still a finding** — plus the two-shape fix (always-on Malli check; validating cofx).

**F2 — `references/imperative-effects.md:76` (missing platform gate on localStorage fx). Fixed.**
The worked "After" `:local-storage/set` fx registered with no metadata, defaulting to `#{:server :client}` and running under SSR/JVM — contradicting the leaf's own SSR-safety claim. Now carries `{:platforms #{:client}}` and guards via `(.-localStorage js/globalThis)`, mirroring `skills/re-frame2/references/fundamentals/fx.md`. Both browser-only fxs in the example now declare `:platforms #{:client}`. (The optional docs/eval lint for client-only metadata was not added — out of the minimal-scope fix; flag if wanted.)

## Quality gates

| Gate | Result |
|---|---|
| `check_doc_slugs.py` | PASS |
| `check_skill_redirect_anchors.py` | PASS |
| `check_skill_mcp_drift.py` | PASS |
| `check_skill_migration_cites.py` | PASS |
| `check_skill_package_refs.py` | PASS |
| `check_skill_pair_authoring_drift.py` | PASS |
| `check_skill_implementor_order.py` | PASS |
| `evals.json` valid JSON | PASS (untouched) |

Closes rf2-wso1dm.
