### PR TITLE
fix(examples/uix): independent-review finding (rf2-ijqlmi)

### DIFF
--- a/examples/uix/login_uix/README.md
+++ b/examples/uix/login_uix/README.md
@@ -15,9 +15,13 @@ layer differs.
   unchanged under UIx. The same registrations, the same machine
   transitions, the same canned-stub seam.
 - **Cross-substrate parity at the tag layer** — machine states
-  carry Spec 005 `:tags` (`:auth/busy`, `:auth/authenticated`); the
-  view reads them via the `:rf/machine-has-tag?` framework sub. Same
-  tag taxonomy as the Reagent reference; only the hook idiom differs.
+  carry Spec 005 `:tags` (`:auth/busy`, `:auth/authenticated`,
+  `:auth/locked`); the view reads them via the `:rf/machine-has-tag?`
+  framework sub. The terminal `:locked-out` state (reached after the
+  fourth failed submit) is surfaced as a non-interactive
+  locked-account panel rather than a dead-but-enabled form — same
+  tag + locked-panel pattern as the state-machines walkthrough; only
+  the hook idiom differs.
 - **No auto-injection** — UIx components take `dispatch` off a
   `(rf/frame-handle)` and call `use-subscribe` directly. The component
   layer is explicit; the artefact layer beneath is identical.

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -8,10 +8,11 @@
    substrate-agnostic — only the view layer differs across substrates.
 
    Cross-substrate parity is exercised end-to-end: machine states carry
-   Spec 005 `:tags` (`:auth/busy`, `:auth/authenticated`) and views read
-   them via the `:rf/machine-has-tag?` framework sub — same tag taxonomy
-   as the Reagent reference example, only the substrate's hook idiom
-   differs.
+   Spec 005 `:tags` (`:auth/busy`, `:auth/authenticated`, `:auth/locked`)
+   and views read them via the `:rf/machine-has-tag?` framework sub —
+   same tag taxonomy as the state-machines walkthrough, only the
+   substrate's hook idiom differs. The terminal `:locked-out` state is
+   surfaced as a non-interactive locked-account panel (rf2-ijqlmi).
 
    `reg-view` stays Reagent-only; UIx components are plain `defui`.
    There is no auto-injection."
@@ -190,7 +191,15 @@
        :meta {:terminal? true}}
 
       :locked-out
-      {:meta {:terminal? true}}}}))
+      ;; :auth/locked tag — after the fourth failed submit the flow lands
+      ;; in this terminal state. Views query
+      ;; [:rf/machine-has-tag? :auth.login/flow :auth/locked] to swap the
+      ;; form for a locked-account panel and refuse further submits — same
+      ;; tag + locked-panel pattern as the state-machines walkthrough. A
+      ;; terminal lockout must be visible and non-interactive, not a live
+      ;; form (rf2-ijqlmi).
+      {:tags #{:auth/locked}
+       :meta {:terminal? true}}}}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS
@@ -225,9 +234,10 @@
        {:data-testid "login-form"
         :on-submit (fn [e]
                      (.preventDefault e)
-                     (dispatch [:auth.login/flow
-                                [:auth.login/submit {:email email
-                                                     :password password}]]))}
+                     (when-not busy?
+                       (dispatch [:auth.login/flow
+                                  [:auth.login/submit {:email email
+                                                       :password password}]])))}
        ($ :input  {:type        "email"
                    :placeholder "Email"
                    :disabled    busy?
@@ -243,13 +253,24 @@
           (if busy? "Signing in…" "Sign in"))
        (when err ($ :p.error {:data-testid "login-error"} err)))))
 
+;; Terminal lockout panel — rendered once the flow reaches :locked-out
+;; (tagged :auth/locked). The state has no transitions, so the form is
+;; swapped out entirely rather than left enabled-but-dead.
+(defui locked-panel []
+  ($ :div.locked {:data-testid "locked-panel"}
+     ($ :h2 "Account locked")
+     ($ :p "Three failed attempts. Contact support to unlock.")))
+
 (defui login-banner []
   (let [authed? (uix-adapter/use-subscribe [:rf/machine-has-tag?
-                                            :auth.login/flow :auth/authenticated])]
+                                            :auth.login/flow :auth/authenticated])
+        locked? (uix-adapter/use-subscribe [:rf/machine-has-tag?
+                                            :auth.login/flow :auth/locked])]
     ($ :div.banner {:data-testid "login-banner"}
-       (if authed?
-         ($ :span "Welcome!")
-         ($ login-form)))))
+       (cond
+         authed? ($ :span "Welcome!")
+         locked? ($ locked-panel)
+         :else   ($ login-form)))))
 
 (defui root-view []
   ($ :div.app


### PR DESCRIPTION
## Summary

Independent correctness review of `examples/uix` (rf2-ijqlmi, 1 finding). The UIx login example reached the terminal `:locked-out` state after a fourth failed submit, but the view layer branched only on `:auth/busy` and `:auth/authenticated`. `:locked-out` carried no tag and no view branch, so the rendered demo fell back to an enabled sign-in form with no lockout message — a terminal dead state shown as a live form, with further submits silent no-ops (`:locked-out` has no transitions).

Fix, scoped to `examples/uix/**`:

- Tag `:locked-out` with `:auth/locked` in the machine.
- `login-banner` now branches `authed` / `locked` / form; add a `locked-panel` (`defui`) rendering a non-interactive locked-account panel — matching the state-machines walkthrough's `:auth/locked` tag + locked-panel pattern, expressed in the UIx `defui` + `use-subscribe` idiom.
- Guard the form submit handler against the busy state.
- Keep the ns docstring and the README accurate (now name `:auth/locked` and the walkthrough pattern, dropping the stale "tag taxonomy identical to the Reagent reference" claim — the reference deliberately omits the lockout branch; the walkthrough is the matching pattern).

No example tests added (examples are test-free, rf2-8cevm). No back-compat shims.

## Disposition

Finding confirmed against current source and **actioned** (not a dup). Dedup checked vs merged ddcel and rf2-16wm9 (UIx smoke-contract wording / registry-id collisions only) — neither covers the invisible UIx lockout state.

Note: the sibling `examples/reagent/login` and `examples/helix/login_helix` carry the identical machine + "no lockout branch" view and the same latent defect, but they are out of this bead's `examples/uix` lane — flagged here for a follow-up if the mayor wants the Reagent/Helix twins aligned.

## Quality gates

- `npm run test:examples-compile` — PASS. All 39 example builds compiled with zero warnings, incl. `:examples/login-uix` (188 files, 0 warnings).
- `python scripts/check_readme_links.py` — PASS (exit 0).
- `python scripts/check_doc_slugs.py` — PASS (exit 0).
- `python scripts/check_readme_inventories.py` — flagged `implementation/README.md` for omitting `node_modules` / `out`; these are gitignored build artifacts created locally by `npm install` + the compile gate, not part of the tracked tree and unrelated to the `examples/uix` README edit. Not a CI-visible regression.

Closes rf2-ijqlmi.