### PR TITLE
fix(template): release gate runs emitted-app smoke + finding 2 (rf2-ek857f)

### DIFF
--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -105,9 +105,23 @@ jobs:
   # ─────────────────────────────────────────────────────────────────
   # 2. Pre-release test gate. Runs the template's JVM test suite end-
   #    to-end (shape + static-parse framework-surface + behavioural
-  #    emission + the rf2 / shadow / react pin-lockstep guards). A
-  #    drift in any of these blocks the release — the tagged commit
-  #    must emit the same shape the test suite asserts on.
+  #    emission + the rf2 / shadow / react pin-lockstep guards) AND the
+  #    behavioural emitted-app tier. A drift in any of these blocks the
+  #    release — the tagged commit must emit a shape that compiles,
+  #    runs, and survives an `:advanced` release build.
+  #
+  #    rf2-ek857f F1 — the emitted-app compile/run/release tier in
+  #    `emitted_test_run_test.clj` defaults OFF (opt-in via
+  #    RF2_TEMPLATE_RUN_EMITTED_TESTS=1) and needs a populated
+  #    implementation/node_modules so the emitted bundle's React imports
+  #    resolve. Without the Node + `npm ci` + env-var setup below, a
+  #    `template-v…` tag would cut a GitHub Release while skipping the
+  #    ONLY gate that compiles generated `:app` + `:test` builds, runs
+  #    the generated tests, and checks the Reagent `:advanced` release
+  #    bundle — i.e. it could publish a broken scaffold even though the
+  #    PR/nightly template gates (test.yml / expensive-tests.yml) catch
+  #    it. This job therefore mirrors that PR/nightly emitted-app setup
+  #    so the release gate is at least as strong as the PR gate.
   # ─────────────────────────────────────────────────────────────────
   test-template:
     name: Template pre-release test gate
@@ -128,6 +142,18 @@ jobs:
           cli: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # rf2-ek857f F1 — Node.js is required for the emitted-app smoke in
+      # `emitted_test_run_test.clj` (compiles + runs the emitted
+      # `events_test.cljs` and the Reagent `:advanced` release build via
+      # `clojure -M:shadow`). Mirrors test.yml:jvm-tools-template /
+      # expensive-tests.yml.
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -135,13 +161,30 @@ jobs:
             ~/.m2/repository
             ~/.gitlibs
             ~/.deps.clj
-          key: ${{ runner.os }}-clj-release-template-${{ hashFiles('tools/template/deps.edn') }}
+          key: ${{ runner.os }}-clj-release-template-${{ hashFiles('tools/template/deps.edn', 'implementation/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-clj-release-template-
             ${{ runner.os }}-clj-
 
-      - name: JVM tests (template artefact)
+      # rf2-ek857f F1 — `npm ci` populates implementation/node_modules so
+      # the emitted-app's compiled :node-test + :advanced :app bundles
+      # resolve React at compile/run time. The emitted-test-run slice
+      # symlinks (or NODE_PATHs to) this tree rather than `npm install`-ing
+      # per substrate. Mirrors test.yml:1805 / expensive-tests.yml:125.
+      - name: npm install (for emitted-app smoke)
+        working-directory: implementation
+        run: npm ci
+
+      # rf2-ek857f F1 — RF2_TEMPLATE_RUN_EMITTED_TESTS=1 flips the
+      # behavioural emitted-app tier ON (default-off for the local fast
+      # loop). The release gate MUST run it, or a tag could publish a
+      # scaffold that fails to compile / run / release. Keep this env var
+      # set; removing it regresses the gate to a fast-loop-only shape
+      # check (release_gate_test.clj asserts this very step survives).
+      - name: JVM tests + emitted-app smoke (template artefact)
         working-directory: tools/template
+        env:
+          RF2_TEMPLATE_RUN_EMITTED_TESTS: "1"
         run: clojure -M:test
 
   # ─────────────────────────────────────────────────────────────────

--- a/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
@@ -8,11 +8,22 @@
             ;; lives in `re-frame.trace.tooling`, NOT `re-frame.core` —
             ;; CLJS production bundles DCE the tooling namespace
             ;; wholesale, so the `rf/...` alias for these fns is
-            ;; deliberately JVM-only (per rf2-qwm0a). Listener
-            ;; observability in `:advanced` + `goog.DEBUG=false`
-            ;; production builds is intentionally a no-op:
-            ;; `trace/emit!` is gated on `interop/debug-enabled?` and
-            ;; elides at compile time.
+            ;; deliberately JVM-only (per rf2-qwm0a).
+            ;;
+            ;; Production elision has two halves and BOTH matter:
+            ;;   1. `trace/emit!` is gated on `interop/debug-enabled?`
+            ;;      and elides at compile time, so no trace events are
+            ;;      ever built in `:advanced` + `goog.DEBUG=false`.
+            ;;   2. The *registration call site* itself must be wrapped
+            ;;      in a `goog.DEBUG` gate, or Closure keeps the listener
+            ;;      closure (and the substituted "[{{namespace}}]" marker
+            ;;      string) in the optimized bundle even though it can
+            ;;      never fire. The framework contract is explicit on
+            ;;      this — see `re-frame.core/register-listener!`'s
+            ;;      docstring: "production CLJS bundles DCE the
+            ;;      registration site when wrapped in a `goog.DEBUG`
+            ;;      gate." That is why the `register-listener!` form
+            ;;      below sits inside `(when ^boolean goog.DEBUG ...)`.
             [re-frame.trace.tooling :as trace-tooling]
             ;; Schema artefact — required as a side-effecting load so
             ;; the late-bind hooks publish before {{namespace}}.schema
@@ -45,14 +56,25 @@
 ;; re-registration replaces the previous callback atomically (per
 ;; Spec 009 §Re-registration semantics), so hot-reload re-runs this
 ;; form without leaking listeners.
+;;
+;; The whole registration is wrapped in `(when ^boolean goog.DEBUG ...)`
+;; so Closure dead-code-eliminates it under `:advanced` +
+;; `goog.DEBUG=false` — the dev-only console-error closure and its app
+;; namespace marker never reach the production bundle (per the
+;; `register-listener!` contract; see the require comment above). In
+;; dev / `npx shadow-cljs watch app` (`goog.DEBUG=true`) it runs
+;; unchanged. When you replace this with real production error
+;; projection (toast / Sentry / etc.), register that sink OUTSIDE this
+;; gate so it ships in the optimized build.
 
-(trace-tooling/register-listener!
-  ::error-sink
-  (fn [trace-event]
-    (when (= :error (:op-type trace-event))
-      (js/console.error "[{{namespace}}]"
-                        (:operation trace-event)
-                        (clj->js (:tags trace-event))))))
+(when ^boolean goog.DEBUG
+  (trace-tooling/register-listener!
+    ::error-sink
+    (fn [trace-event]
+      (when (= :error (:op-type trace-event))
+        (js/console.error "[{{namespace}}]"
+                          (:operation trace-event)
+                          (clj->js (:tags trace-event)))))))
 
 ;; --- Initialisation --------------------------------------------------------
 ;;

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -387,7 +387,30 @@
                                 " (:devtools/preloads is dev-only). Found "
                                 "'day8.re_frame2_xray.preload' in "
                                 "resources/public/js/main.js — the "
-                                "cut-from-release invariant is broken."))))))))))
+                                "cut-from-release invariant is broken."))
+                       ;; rf2-ek857f F2 — events.cljs registers the
+                       ;; default error-sink trace listener behind
+                       ;; `(when ^boolean goog.DEBUG ...)`, so Closure
+                       ;; must DCE both the listener closure AND its
+                       ;; substituted "[acme.my-app]" console marker out
+                       ;; of the `:advanced` + `goog.DEBUG=false` bundle.
+                       ;; If the gate is dropped (or someone re-registers
+                       ;; the listener ungated), the marker string
+                       ;; survives verbatim — assert its absence so a
+                       ;; dev-only console listener can't leak into the
+                       ;; production bundle and ship green.
+                       (is (not (string/includes?
+                                  bundle-text
+                                  "[acme.my-app]"))
+                           (str "The dev-only error-sink listener marker "
+                                "\"[acme.my-app]\" must be DCE'd from the "
+                                ":advanced release bundle for " label
+                                ". Its presence means the "
+                                "`(when ^boolean goog.DEBUG ...)` gate "
+                                "around events.cljs's register-listener! "
+                                "is gone — a dev-only console listener "
+                                "closure is leaking into the production "
+                                "bundle (rf2-ek857f F2)."))))))))))
        (finally
          (delete-recursively tmp))))))
 

--- a/tools/template/test/day8/re_frame2_template/release_gate_test.clj
+++ b/tools/template/test/day8/re_frame2_template/release_gate_test.clj
@@ -1,0 +1,104 @@
+(ns day8.re-frame2-template.release-gate-test
+  "Workflow-sanity coverage for `.github/workflows/template-release.yml`
+   (rf2-ek857f F1).
+
+   The tag-triggered template release runs a pre-release test gate
+   (`test-template`) before cutting a GitHub Release. The gate is only
+   meaningful if it actually exercises the behavioural emitted-app tier
+   in `emitted_test_run_test.clj` — that tier compiles the generated
+   `:app` + `:test` builds, runs the generated tests, and runs the
+   Reagent `:advanced` release build. That tier is OFF by default and
+   needs:
+
+     1. `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` (the opt-in env var), and
+     2. a populated `implementation/node_modules` (`npm ci` in
+        `implementation`) so the emitted bundle's React imports resolve.
+
+   Before rf2-ek857f the release job ran a plain `clojure -M:test` with
+   neither — so a `template-v…` tag could publish a scaffold that fails
+   to compile / run / release, even though the PR + nightly template
+   gates (test.yml / expensive-tests.yml) would have caught it.
+
+   These tests pin the release gate's shape so it cannot silently
+   regress back to a fast-loop-only run. They read the workflow YAML as
+   text (no YAML parser dependency — the assertions are on stable
+   substrings, mirroring how the sibling shape/static-parse tests assert
+   on emitted source). They run in the default `clojure -M:test` (no
+   Node, no env-var gate) — this is the cheap signal the release gate
+   itself is correctly wired."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.java.io :as io]
+            [clojure.string :as string]
+            [day8.re-frame2-template.test-support :refer [repo-root]]))
+
+(defn- release-workflow-text
+  "Slurp `.github/workflows/template-release.yml` from the repo root.
+  Throws a legible error if it has moved/been deleted — a renamed or
+  removed release workflow is itself a regression these tests should
+  surface, not silently skip."
+  []
+  (let [f (io/file (repo-root) ".github/workflows/template-release.yml")]
+    (is (.isFile f)
+        (str ".github/workflows/template-release.yml must exist — it is "
+             "the tag-triggered template release pipeline. Looked at "
+             (.getPath f)))
+    (when (.isFile f) (slurp f))))
+
+(defn- test-template-job
+  "The `test-template:` job block of the workflow text — from the job
+  key up to (but not including) the next top-level `github-release:`
+  job. Lets the assertions below scope to the pre-release gate without
+  matching incidental substrings elsewhere in the file."
+  [yaml]
+  (let [start (string/index-of yaml "\n  test-template:")
+        end   (string/index-of yaml "\n  github-release:")]
+    (when (and start end (< start end))
+      (subs yaml start end))))
+
+(deftest release-gate-exists-test
+  (testing "the template release workflow is present and tag-triggered"
+    (let [yaml (release-workflow-text)]
+      (when yaml
+        (is (string/includes? yaml "template-v[0-9]+.[0-9]+.[0-9]+")
+            "release workflow triggers on a template-v… tag push")
+        (is (string/includes? yaml "test-template:")
+            "release workflow has a pre-release test-template gate job")
+        (is (string/includes? yaml "github-release:")
+            "release workflow has a github-release job")))))
+
+(deftest release-gate-runs-emitted-app-tier-test
+  (testing "the pre-release gate enables + provisions the emitted-app
+            behavioural tier (cannot regress to a fast-loop-only run)"
+    (let [yaml (release-workflow-text)
+          job  (some-> yaml test-template-job)]
+      (is (some? job)
+          "could not isolate the test-template job block — has it been
+           renamed or merged with github-release?")
+      (when job
+        ;; The opt-in env var. Without it `emitted_test_run_test.clj`
+        ;; short-circuits every behavioural deftest to a skip-assert, so
+        ;; the gate would compile/run nothing.
+        (is (string/includes? job "RF2_TEMPLATE_RUN_EMITTED_TESTS")
+            "test-template must set RF2_TEMPLATE_RUN_EMITTED_TESTS — it is
+             the opt-in flag that turns the emitted-app compile/run/release
+             tier ON. Without it the release gate is a fast-loop-only shape
+             check and a broken scaffold can be published (rf2-ek857f F1).")
+        (is (re-find #"RF2_TEMPLATE_RUN_EMITTED_TESTS:\s*[\"']?1" job)
+            "RF2_TEMPLATE_RUN_EMITTED_TESTS must be set to 1 (string),
+             matching test.yml / expensive-tests.yml.")
+        ;; Node + npm ci provision implementation/node_modules so the
+        ;; emitted bundle's React imports resolve at compile/run time.
+        (is (string/includes? job "setup-node")
+            "test-template must set up Node.js — the emitted-app tier
+             shells out to `node` and shadow-cljs needs it.")
+        (is (re-find #"npm ci" job)
+            "test-template must `npm ci` in implementation/ so
+             implementation/node_modules is populated for the emitted
+             bundle's React imports (the smoke symlinks/junctions to it).")
+        (is (string/includes? job "working-directory: implementation")
+            "the npm ci step must run in implementation/ (where the
+             node_modules tree the smoke links to lives).")
+        ;; Still actually invokes the JVM test suite.
+        (is (re-find #"clojure -M:test" job)
+            "test-template must run `clojure -M:test` from tools/template
+             (the suite the env var + node_modules unlock).")))))


### PR DESCRIPTION
Independent correctness review of `tools/template` — rf2-ek857f (2 findings, both confirmed real and fixed).

## Per-finding disposition

### F1 — `template-release.yml` skips the emitted-app gate (CONFIRMED, FIXED)
The tag-triggered release ran a plain `clojure -M:test`. The emitted-app compile/run/release tier in `emitted_test_run_test.clj` defaults OFF unless `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` **and** `implementation/node_modules` is populated — neither of which the release job provided (unlike `test.yml:jvm-tools-template` and `expensive-tests.yml`). So a `template-v…` tag could cut a GitHub Release while skipping the only gate that compiles the generated `:app`+`:test` builds, runs the generated tests, and checks the Reagent `:advanced` release bundle — publishing a broken scaffold the PR/nightly gates would have caught.

**Fix:** `test-template` now mirrors the PR/nightly emitted-app setup — `actions/setup-node` (same pinned SHA + `node-version: 24` + npm cache as test.yml), `npm ci` in `implementation/`, and `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` on the `clojure -M:test` step. The cache key + `cache-dependency-path` now include `implementation/package-lock.json`. Added `release_gate_test.clj` (runs in the default fast tier, no Node) asserting the workflow keeps the env var, Node setup, `npm ci` in implementation, and the `clojure -M:test` invocation — so the gate cannot silently regress to a fast-loop-only run.

### F2 — generated app leaks a dev-only listener into the production bundle (CONFIRMED, FIXED)
`_shared/events.cljs` registered the `::error-sink` trace listener at top level. Closure therefore retained the listener closure **and** the substituted `[acme.my-app]` console marker in the `:advanced` + `goog.DEBUG=false` bundle — contradicting the template's own comment that production observability elides, and the framework contract (`re-frame.core/register-listener!`: "production CLJS bundles DCE the registration site when wrapped in a `goog.DEBUG` gate"). `trace/emit!` elision only removes emitted *events*, not the registration site.

**Fix:** wrap the registration in `(when ^boolean goog.DEBUG ...)` — the canonical, framework-documented gate (`re-frame.interop/debug-enabled?` is `^boolean goog/DEBUG`). Dev/`watch` behaviour is unchanged (`goog.DEBUG=true`); the closure + marker DCE out of release. Corrected the now-accurate require/registration comments, and noted that real production sinks (Sentry/toast/etc.) register *outside* the gate. Extended the emitted release smoke (Reagent default + with-story) to assert `[acme.my-app]` is absent from the optimized bundle, alongside the existing Xray-preload-absence check.

## Quality gates
- `tools/template` fast tier: `clojure -M:test` → **31 tests, 384 assertions, 0 failures, 0 errors** (includes new `release_gate_test.clj`; existing shape test still green — gated form keeps the `register-listener!` substring).
- `tools/template` emitted-app smoke: `RF2_TEMPLATE_RUN_EMITTED_TESTS=1 clojure -M:test` (after `npm ci` in implementation) → **31 tests, 420 assertions, 0 failures, 0 errors** — confirms the gated listener DCEs out (new `[acme.my-app]`-absence assertion green across both Reagent variants) and the `:advanced` release build is clean.
- `template-release.yml` parses (PyYAML) and its `test-template` job mirrors `test.yml:jvm-tools-template` element-for-element (same `setup-node` SHA, `node-version: 24`, npm cache config, `npm ci` working-directory `implementation`).

Closes rf2-ek857f.