### PR TITLE
fix(ssr-ring): independent-review findings (rf2-v0qbng)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
@@ -21,47 +21,66 @@
   header NAMES (RFC 7230 token grammar) and VALUES (CR/LF/NUL) but do
   NOT coerce a value to a string, so a non-string scalar (number,
   keyword, boolean) can reach this fold verbatim. The first occurrence
-  `assoc`s that scalar in; a repeated name must still collapse it into
-  a multi-value vector. The `:else` arm handles that case the same way
-  the `string?` arm does (existing scalar → `[existing v]`); without it
-  the `cond` would return `nil`, silently wiping the ENTIRE accumulated
+  `assoc`s the value in; a repeated name must still collapse it into a
+  multi-value vector. The `:else` arm handles that case the same way the
+  `vector?` arm does (existing scalar → `[existing v]`); without it the
+  `cond` would return `nil`, silently wiping the ENTIRE accumulated
   header map mid-fold (Content-Type, Set-Cookie, everything folded so
   far) — a silent-failure header-loss bug.
 
+  ## Fail-closed non-string coercion (rf2-v0qbng)
+
+  Ring's `:headers` contract is value = string OR vector-of-strings. A
+  number / keyword / boolean reaching this fold is undefined behaviour at
+  the servlet layer — Jetty/http-kit may reject the response while
+  committing it, or serialise it incorrectly, AFTER the handler has
+  already returned a nominally-successful Ring map (so the `:on-error`
+  path can't recover). The fx-args `:schema` boundary would catch a
+  non-string value at dispatch time, but that boundary SOFT-PASSES when
+  the optional schemas artefact is not on the production classpath (Spec
+  010 §Recommended soft-pass) — which is the default ssr-ring runtime.
+  The adapter is therefore the last line: it MUST emit a host-serialisable
+  Ring value regardless of what slipped past the (optional) fx-args gate.
+
+  We coerce a non-nil non-string value to its string form (`str`) BEFORE
+  it lands in the accumulator, so every value the materialiser emits is a
+  string (or, for repeated names, a vector of strings). The coercion runs
+  on the production classpath — it is the correctness guarantee, not a
+  diagnostic. A `nil` value is left as-is (`assoc`d under the nil-existing
+  arm): an explicit nil header is dropped by Ring servers and carries no
+  injection risk, and `(str nil)` = \"\" would fabricate an empty header.
+
   ## Dev-gated non-string warning (rf2-b0jlr)
 
-  The fold tolerates a non-string value (the `:else` arm above) so a
-  scalar that slipped past the fx-boundary name/value gates can't take
-  down the whole header map. But a non-string value here is host-
-  dependent and almost certainly a CALLER bug — Ring's `:headers`
-  contract is string OR vector-of-strings, and a number / keyword /
-  boolean reaching the wire is undefined behaviour at the servlet
-  layer. Rather than silently coercing (`(str v)`) or silently passing
-  it through, we surface it: a dev-gated `:warning` trace naming the
-  offending header key and the value's type. Production builds elide
-  the whole check (the `interop/debug-enabled?` gate + `trace/emit!`'s
-  own Closure-DCE gate), keeping the hot fold branchless on the wire.
-  Aligns with the no-silent-swallow posture (cf. the redirect-no-target
-  warning in `pipeline`)."
+  A non-string value here is almost certainly a CALLER bug, so alongside
+  the production coercion we surface it: a dev-gated `:warning` trace
+  naming the offending header key and the value's pre-coercion type.
+  Production builds elide the whole check (the `interop/debug-enabled?`
+  gate + `trace/emit!`'s own Closure-DCE gate), keeping the diagnostic off
+  the hot path — but the coercion below is unconditional, so the wire shape
+  is correct with or without the warning. Aligns with the no-silent-swallow
+  posture (cf. the redirect-no-target warning in `pipeline`)."
   [m [k v]]
-  (when (and interop/debug-enabled? (not (string? v)))
+  (when (and interop/debug-enabled? (and (some? v) (not (string? v))))
     (trace/emit! :warning :rf.ssr/ssr-non-string-header-value
                  {:where      :ssr-ring/merge-pair-into-header-map
                   :header     k
                   :value-type (some-> v class .getName)
-                  :reason     (str "header " (pr-str k) " carries a non-string "
+                  :reason     (str "header " (pr-str k) " carried a non-string "
                                    "value of type "
                                    (or (some-> v class .getName) "nil")
                                    " — Ring header values must be strings (or a "
-                                   "vector of strings); the fold passes it through "
-                                   "verbatim, but this is host-dependent and almost "
-                                   "certainly a caller bug")
-                  :recovery   :warned-and-passed-through}))
-  (let [existing (get m k)]
+                                   "vector of strings); the materialiser coerces it "
+                                   "to its string form so the wire shape is valid, "
+                                   "but this is host-dependent and almost certainly "
+                                   "a caller bug")
+                  :recovery   :coerced-to-string}))
+  (let [v*       (if (or (nil? v) (string? v)) v (str v))
+        existing (get m k)]
     (cond
-      (nil? existing)        (assoc m k v)
-      (vector? existing)     (assoc m k (conj existing v))
-      :else                  (assoc m k [existing v]))))
+      (nil? existing)        (assoc m k v*)
+      (vector? existing)     (assoc m k (conj existing v*))
+      :else                  (assoc m k [existing v*]))))
 
 (defn append-set-cookies
   "For every cookie map in the response's :cookies vector, append one

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -43,6 +43,41 @@
 
 (set! *warn-on-reflection* true)
 
+(defn ^:private fail-closed-status
+  "Coerce a resolved response `:status` to a valid Ring status int,
+  defaulting to `fallback` when absent (rf2-v0qbng).
+
+  Ring requires `:status` to be an integer; Jetty/http-kit reject (or
+  mis-serialise) a non-int status while committing the response, AFTER
+  the handler has returned a nominally-successful map — past the
+  `:on-error` recovery point. The fx-args `:schema` boundary
+  (`:rf.fx.server/set-status-args` = `:int`) would reject a non-int
+  `:rf.server/set-status` at dispatch time, but that boundary
+  SOFT-PASSES when the optional schemas artefact is absent from the
+  production classpath (Spec 010 §Recommended soft-pass) — the default
+  ssr-ring runtime. The adapter is the last line: a non-int status has
+  no faithful coercion (we will not guess that \"404\" means 404), so we
+  fail closed to a 500 — a valid, fail-closed Ring response — and surface
+  the defect on the trace bus rather than ship a malformed map."
+  [status fallback]
+  (cond
+    (nil? status)         fallback
+    (integer? status)     status
+    :else
+    (do
+      (trace/emit! :warning :rf.ssr/ssr-non-integer-status
+                   {:where       :ssr-ring/ssr-response->ring-response
+                    :status       status
+                    :status-type (some-> status class .getName)
+                    :reason      (str "response :status is a non-integer value of "
+                                      "type " (or (some-> status class .getName) "nil")
+                                      " — Ring statuses must be integers; the "
+                                      "materialiser fails closed to 500 rather than "
+                                      "emit a malformed Ring map (host-dependent; "
+                                      "almost certainly a caller bug)")
+                    :recovery    :failed-closed-to-500})
+      500)))
+
 (defn ssr-response->ring-response
   "Materialise the runtime's resolved response accumulator (per
   Spec 011 §HTTP response contract) into a Ring response map. The
@@ -54,7 +89,16 @@
   that's stamped onto the Ring header map if (and only if) the response
   pairs don't already carry a Content-Type (case-insensitive). The
   defaulting happens INSIDE the single header-fold pass
-  (`headers->ring-map+default-content-type`)."
+  (`headers->ring-map+default-content-type`).
+
+  Host-serialisability fail-closed (rf2-v0qbng): this materialiser is the
+  LAST line between the runtime accumulator and the wire, and the
+  `:rf.server/*` fx-args `:schema` boundary soft-passes off the optional
+  schemas classpath (the default ssr-ring runtime). So it must emit a
+  valid Ring response regardless of what slipped past that gate: `:status`
+  is coerced to an int (`fail-closed-status` — non-int fails closed to
+  500), the Location target is coerced to a string, and header values are
+  coerced to strings in the fold (`headers/merge-pair-into-header-map`)."
   ([resp body] (ssr-response->ring-response resp body nil))
   ([{:keys [status headers cookies redirect]} body default-content-type]
    (if redirect
@@ -71,19 +115,24 @@
        (when-not target
          (trace/emit! :warning :rf.ssr/ssr-redirect-no-target
                       {:where    :ssr-ring/ssr-response->ring-response
-                       :status   (or redirect-status status 302)
+                       :status   (fail-closed-status (or redirect-status status) 302)
                        :reason   (str ":rf.server/redirect set :redirect with no "
                                       ":location/:url/:to — the response carries a "
                                       "3xx status with no Location header (malformed "
                                       "redirect; the browser has no target)")
                        :recovery :warned-and-emitted-statusonly}))
-       {:status  (or redirect-status status 302)
+       {:status  (fail-closed-status (or redirect-status status) 302)
         :headers (-> (headers/headers->ring-map+default-content-type
                        headers default-content-type)
                      (headers/append-set-cookies cookies)
-                     (cond-> target (assoc "Location" target)))
+                     ;; The Location value must be a string — a non-string
+                     ;; target (the `:location` is caller-trusted at the fx
+                     ;; boundary) is coerced so the Ring header map is valid.
+                     (cond-> target (assoc "Location" (if (string? target)
+                                                        target
+                                                        (str target)))))
         :body    ""})
-     {:status  (or status 200)
+     {:status  (fail-closed-status status 200)
       :headers (-> (headers/headers->ring-map+default-content-type
                      headers default-content-type)
                    (headers/append-set-cookies cookies))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/pipeline_materialiser_test.clj
@@ -148,6 +148,88 @@
       (is (= "" (:body ring)) "nil body → empty string"))))
 
 ;; ===========================================================================
+;; HOST-SERIALISABILITY FAIL-CLOSED (rf2-v0qbng)
+;;
+;; The `:rf.server/*` fx-args :schema boundary (set-status-args = :int,
+;; set-header-args :value :string, …) SOFT-PASSES when the optional schemas
+;; artefact is absent from the production classpath (Spec 010 §Recommended
+;; soft-pass) — the DEFAULT ssr-ring runtime. The materialiser is the last
+;; line: a non-int status / non-string header value / non-string Location
+;; that slipped past the (optional) fx-args gate must NOT produce a Ring
+;; response carrying a non-Ring type, or Jetty/http-kit may reject /
+;; mis-serialise it WHILE committing — past the :on-error recovery point.
+;;
+;; These tests assert the wire-correct outcome with NO schemas dependency:
+;; status is always an int, header values are always strings or vectors of
+;; strings, the Location value is always a string.
+;; ===========================================================================
+
+(deftest non-integer-status-fails-closed-to-500
+  (testing "rf2-v0qbng: a string :status (what a soft-passed
+            `:rf.server/set-status \"404\"` leaves on the accumulator) does
+            NOT reach the wire as a non-int — the materialiser fails closed
+            to a valid 500 Ring response"
+    (let [ring (pipeline/ssr-response->ring-response
+                 {:status "404" :headers [["Content-Type" "text/html"]]}
+                 "<p>x</p>")]
+      (is (integer? (:status ring))
+          "the Ring :status is an integer regardless of accumulator garbage")
+      (is (= 500 (:status ring)) "a non-int status fails closed to 500")))
+  (testing "rf2-v0qbng: a non-integer redirect :status also fails closed"
+    (let [ring (pipeline/ssr-response->ring-response
+                 {:redirect {:status "302" :location "/ok"}} nil)]
+      (is (integer? (:status ring)) "redirect :status is an integer")
+      (is (= 500 (:status ring)) "non-int redirect status → 500")))
+  (testing "rf2-v0qbng: a float status (200.0) is not a valid Ring int → 500"
+    (is (= 500 (:status (pipeline/ssr-response->ring-response
+                          {:status 200.0 :headers []} "x"))))))
+
+(deftest integer-status-passes-through-unchanged
+  (testing "rf2-v0qbng: a genuine integer status is untouched by the
+            fail-closed guard (no false-positive coercion)"
+    (is (= 201 (:status (pipeline/ssr-response->ring-response
+                          {:status 201 :headers []} "x"))))
+    (is (= 302 (:status (pipeline/ssr-response->ring-response
+                          {:redirect {:status 302 :location "/x"}} nil))))
+    (is (= 200 (:status (pipeline/ssr-response->ring-response
+                          {:headers []} "x")))
+        "absent status still defaults to 200")
+    (is (= 302 (:status (pipeline/ssr-response->ring-response
+                          {:redirect {:location "/x"}} nil)))
+        "absent redirect status still defaults to 302")))
+
+(deftest non-string-header-value-coerced-in-materialiser
+  (testing "rf2-v0qbng: a non-string header value on the accumulator (what a
+            soft-passed `:rf.server/set-header {:name \"X-Count\" :value 5}`
+            leaves) is coerced to a string in the emitted Ring header map —
+            the value is never a raw scalar on the wire"
+    (let [ring (pipeline/ssr-response->ring-response
+                 {:status 200 :headers [["X-Count" 5]
+                                        ["X-Flag" true]
+                                        ["X-Kw" :enabled]]}
+                 "<p>x</p>")
+          hdrs (:headers ring)]
+      (is (= "5" (get hdrs "X-Count")) "number → string")
+      (is (= "true" (get hdrs "X-Flag")) "boolean → string")
+      (is (= ":enabled" (get hdrs "X-Kw")) "keyword → string")
+      (is (every? (fn [[_ v]] (or (string? v)
+                                  (and (vector? v) (every? string? v))))
+                  hdrs)
+          "EVERY emitted header value is a string or vector-of-strings"))))
+
+(deftest non-string-redirect-location-coerced-to-string
+  (testing "rf2-v0qbng: a non-string redirect :location (the fx is
+            caller-trusted and `(str loc)` passes its shape gate, so a raw
+            scalar can reach the accumulator) is coerced to a string in the
+            emitted Location header"
+    (let [ring (pipeline/ssr-response->ring-response
+                 {:redirect {:status 302 :location 5}} nil)
+          loc  (get (:headers ring) "Location")]
+      (is (= 302 (:status ring)))
+      (is (string? loc) "the Location header value is a string")
+      (is (= "5" loc) "the non-string target is coerced via str"))))
+
+;; ===========================================================================
 ;; headers->ring-map+default-content-type — POSITIVE default-append +
 ;; nil-content-type paths (the suppression path is covered by
 ;; ring_test/content-type-default-no-duplicate-on-mixed-case)
@@ -212,25 +294,29 @@
                (headers/merge-pair-into-header-map ["Link" "b"])
                (headers/merge-pair-into-header-map ["Link" "c"]))))))
 
-(deftest repeated-non-string-value-does-not-wipe-header-map
-  (testing "rf2-5t8mr.14: a repeated header name whose value is a
-            non-string scalar (the runtime's set/append-header fxs gate
-            CR/LF/NUL but do NOT coerce to string) must collapse into a
-            2-vector via the :else arm — NOT fall through the cond and
-            return nil, which silently wiped the ENTIRE accumulated
-            header map (Content-Type, Set-Cookie, everything)"
-    (is (= {"X-Count" [5 6]}
+(deftest repeated-non-string-value-coerced-and-does-not-wipe-header-map
+  (testing "rf2-v0qbng (was rf2-5t8mr.14): a repeated header name whose value
+            is a non-string scalar (the runtime's set/append-header fxs gate
+            CR/LF/NUL but do NOT coerce to string, and the fx-args :schema
+            soft-passes off the optional schemas classpath) must (a) collapse
+            into a 2-vector via the :else arm — NOT fall through the cond and
+            return nil, which silently wiped the ENTIRE accumulated header
+            map — AND (b) be coerced to its string form so the Ring header
+            value is a vector OF STRINGS, never of raw scalars"
+    (is (= {"X-Count" ["5" "6"]}
            (-> {}
                (headers/merge-pair-into-header-map ["X-Count" 5])
                (headers/merge-pair-into-header-map ["X-Count" 6])))
-        "two non-string values under one name collapse to a vector")
+        "two non-string values under one name collapse to a vector of strings")
     (let [result (headers/headers->ring-map+default-content-type
                    [["X-Count" 5]
                     ["X-Count" 6]
                     ["X-Other" "keep"]]
                    "text/html")]
-      (is (= [5 6] (get result "X-Count"))
-          "the repeated non-string header survives as a 2-vector")
+      (is (= ["5" "6"] (get result "X-Count"))
+          "the repeated non-string header survives as a 2-vector of strings")
+      (is (every? string? (get result "X-Count"))
+          "every member of the multi-value vector is a string (Ring contract)")
       (is (= "keep" (get result "X-Other"))
           "headers folded AFTER the repeat are NOT wiped (no nil-map)")
       (is (= "text/html" (get result "Content-Type"))
@@ -261,15 +347,16 @@
     @traces))
 
 (deftest non-string-header-value-emits-exactly-one-dev-warning
-  (testing "rf2-b0jlr: a non-string header value reaching the fold emits
-            exactly one :warning trace naming the offending key + value-type;
-            the value still folds in (the :else-arm tolerance is unchanged)"
+  (testing "rf2-b0jlr + rf2-v0qbng: a non-string header value reaching the
+            fold emits exactly one :warning trace naming the offending key +
+            value-type; the value folds in COERCED to its string form (the
+            fail-closed coercion — the wire value is always a string)"
     (let [warnings (collect-non-string-header-warnings
                      (fn []
                        (let [result (headers/merge-pair-into-header-map
                                       {} ["X-Count" 5])]
-                         (is (= {"X-Count" 5} result)
-                             "the non-string value still folds in verbatim"))))]
+                         (is (= {"X-Count" "5"} result)
+                             "the non-string value folds in coerced to a string"))))]
       (is (= 1 (count warnings)) "exactly one warning for one non-string value")
       (let [ev   (first warnings)
             tags (:tags ev)]


### PR DESCRIPTION
Independent correctness review of `implementation/ssr-ring` (rf2-v0qbng). One high-confidence finding, confirmed against current source and fixed.

## Finding 1 — materialiser can emit malformed Ring maps off the default (schemas-less) classpath

`ssr-response->ring-response` (pipeline.clj) and the header fold (headers.clj) trusted the runtime accumulator's values verbatim. The `:rf.server/*` fx-args `:schema` boundary (`set-status-args` = `:int`, `set-header-args` `:value` = `:string`, …) is the gate that would reject a non-int status / non-string header value at dispatch time — but it **soft-passes** when the optional schemas artefact is absent from the production classpath (Spec 010 §Recommended soft-pass), which is the **default** ssr-ring runtime (`ssr-ring/deps.edn` production `:deps` = core + ssr only; schemas is test-only `:extra-deps`).

Consequence on the default classpath:
- `:rf.server/set-status "404"` → Ring `:status "404"` (string)
- `:rf.server/set-header {:name "X-Count" :value 5}` → Ring header `"X-Count" 5` (raw number)
- `:rf.server/redirect {:status 302 :location 5}` → Ring `Location` header `5` (raw number)

Jetty/http-kit/Ring may reject or mis-serialise these **while committing** the response — after the handler has returned a nominally-successful map, past the `:on-error` recovery point.

**Disposition: FIXED.** The adapter is the last line between accumulator and wire, so it now fails closed without depending on the optional schemas:
- `fail-closed-status` (pipeline.clj) coerces `:status` and redirect `:status` to a valid int; a non-int (string, float) has no faithful coercion → fails closed to `500` (a valid Ring response) + emits `:rf.ssr/ssr-non-integer-status`.
- The redirect Location target is coerced to a string.
- `merge-pair-into-header-map` (headers.clj) now coerces a non-nil non-string value to its string form **before** it enters the accumulator (production-safe, unconditional), so every emitted header value is a string or vector-of-strings. The existing dev-gated `:rf.ssr/ssr-non-string-header-value` warning is retained as diagnostics (recovery now `:coerced-to-string`).

The previously false-green test (`repeated-non-string-value-does-not-wipe-header-map`, asserting `{"X-Count" [5 6]}` survives) and the dev-warning test were corrected, and default-classpath tests were added proving invalid status/header/Location inputs never yield a Ring map with non-Ring types.

### Dedup
- vs rf2-h3dg0 (Content-Length strip + CSP scan, streaming suffix): no overlap — that's the streaming wire-framing path, not status/header-value coercion in the shared materialiser.
- vs rf2-oq4m5 (stream-handler ignoring `:html-shell`): unrelated surface.
- vs rf2-b0jlr / rf2-5t8mr.14 (the existing dev-warning + map-wipe fix): this builds on them — they tolerated the non-string value (warn + pass-through); this fix makes the wire shape *correct* (coerce) on the production classpath, which the warning alone did not.

## Quality gates
All run on the default classpath (no schemas dependency for the new correctness tests):

- `implementation/ssr-ring` → `clojure -M:test`: **131 tests, 574 assertions, 0 failures, 0 errors**
- `implementation/ssr` (cross-artefact gate) → `clojure -M:test`: **307 tests, 1188 assertions, 0 failures, 0 errors**
- `implementation` → `npm run test:cljs`: **5854 tests, 20750 assertions, 0 failures, 0 errors**

Closes rf2-v0qbng.
