### PR TITLE
fix(examples/reagent+helix): login :locked-out renders a locked panel, not a live form (rf2-q6bm7d)

### DIFF
--- a/examples/helix/login_helix/README.md
+++ b/examples/helix/login_helix/README.md
@@ -15,9 +15,13 @@ layer differs.
   unchanged under Helix. The same registrations, the same machine
   transitions, the same canned-stub seam.
 - **Cross-substrate parity at the tag layer** — machine states
-  carry Spec 005 `:tags` (`:auth/busy`, `:auth/authenticated`); the
-  view reads them via the `:rf/machine-has-tag?` framework sub. Same
-  tag taxonomy as the Reagent reference; only the hook idiom differs.
+  carry Spec 005 `:tags` (`:auth/busy`, `:auth/authenticated`,
+  `:auth/locked`); the view reads them via the `:rf/machine-has-tag?`
+  framework sub. The terminal `:locked-out` state (reached after the
+  fourth failed submit) is surfaced as a non-interactive
+  locked-account panel rather than a dead-but-enabled form — same
+  tag + locked-panel pattern as the state-machines walkthrough; only
+  the hook idiom differs.
 - **No auto-injection** — Helix components take `dispatch` off a
   `(rf/frame-handle)` and call `use-subscribe` directly. The component
   layer is explicit; the artefact layer beneath is identical.

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -9,10 +9,11 @@
    substrate-agnostic — only the view layer differs across substrates.
 
    Cross-substrate parity is exercised end-to-end: machine states carry
-   Spec 005 `:tags` (`:auth/busy`, `:auth/authenticated`) and views read
-   them via the `:rf/machine-has-tag?` framework sub — same tag taxonomy
-   as the Reagent reference example, only the substrate's hook idiom
-   differs.
+   Spec 005 `:tags` (`:auth/busy`, `:auth/authenticated`, `:auth/locked`)
+   and views read them via the `:rf/machine-has-tag?` framework sub —
+   same tag taxonomy as the state-machines walkthrough, only the
+   substrate's hook idiom differs. The terminal `:locked-out` state is
+   surfaced as a non-interactive locked-account panel (rf2-q6bm7d).
 
    `reg-view` stays Reagent-only; Helix components are plain `defnc`.
    There is no auto-injection."
@@ -193,7 +194,15 @@
        :meta {:terminal? true}}
 
       :locked-out
-      {:meta {:terminal? true}}}}))
+      ;; :auth/locked tag — after the fourth failed submit the flow lands
+      ;; in this terminal state. Views query
+      ;; [:rf/machine-has-tag? :auth.login/flow :auth/locked] to swap the
+      ;; form for a locked-account panel and refuse further submits — same
+      ;; tag + locked-panel pattern as the state-machines walkthrough. A
+      ;; terminal lockout must be visible and non-interactive, not a live
+      ;; form (rf2-q6bm7d).
+      {:tags #{:auth/locked}
+       :meta {:terminal? true}}}}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS
@@ -229,9 +238,10 @@
         :data-testid "login-form"
         :on-submit (fn [e]
                      (.preventDefault e)
-                     (dispatch [:auth.login/flow
-                                [:auth.login/submit {:email email
-                                                     :password password}]]))}
+                     (when-not busy?
+                       (dispatch [:auth.login/flow
+                                  [:auth.login/submit {:email email
+                                                       :password password}]])))}
        (d/input  {:type        "email"
                   :placeholder "Email"
                   :disabled    busy?
@@ -247,15 +257,28 @@
           (if busy? "Signing in…" "Sign in"))
        (when err (d/p {:class "error" :data-testid "login-error"} err)))))
 
+;; Terminal lockout panel — rendered once the flow reaches :locked-out
+;; (tagged :auth/locked). The state has no transitions, so the form is
+;; swapped out entirely rather than left enabled-but-dead.
+(defnc locked-panel []
+  (d/div
+     {:class "locked"
+      :data-testid "locked-panel"}
+     (d/h2 "Account locked")
+     (d/p "Three failed attempts. Contact support to unlock.")))
+
 (defnc login-banner []
   (let [authed? (helix-adapter/use-subscribe [:rf/machine-has-tag?
-                                              :auth.login/flow :auth/authenticated])]
+                                              :auth.login/flow :auth/authenticated])
+        locked? (helix-adapter/use-subscribe [:rf/machine-has-tag?
+                                              :auth.login/flow :auth/locked])]
     (d/div
        {:class "banner"
         :data-testid "login-banner"}
-       (if authed?
-         (d/span "Welcome!")
-         ($ login-form)))))
+       (cond
+         authed? (d/span "Welcome!")
+         locked? ($ locked-panel)
+         :else   ($ login-form)))))
 
 (defnc root-view []
   (d/div

--- a/examples/reagent/login/README.md
+++ b/examples/reagent/login/README.md
@@ -23,9 +23,13 @@ in one file, kept compact for AI-readability.
   stub, so the example runs without a backend.
 - **CP-4 registered view** — Var reference, Form-1 (canonical).
 - **State tags** (Spec 005) — `:auth/busy` on `:submitting`,
-  `:auth/authenticated` on `:authed`. Views query them via
-  `(rf/machine-has-tag? :auth.login/flow ...)` instead of
-  boolean-discriminator subs.
+  `:auth/authenticated` on `:authed`, `:auth/locked` on `:locked-out`.
+  Views query them via `(rf/machine-has-tag? :auth.login/flow ...)`
+  instead of boolean-discriminator subs. The terminal `:locked-out`
+  state (reached after the fourth failed submit) is surfaced as a
+  non-interactive locked-account panel rather than a dead-but-enabled
+  form — same tag + locked-panel pattern as the state-machines
+  walkthrough.
 - **Open-map idiom** — every shape on the wire is an open map.
 - **Headless test** — browserless smoke test demonstrating the full
   test seam.

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -14,11 +14,17 @@
    - State machine (CP-5)                  — login flow as a transition table
                                               read via [:rf/runtime :machines :snapshots :auth.login/flow]
    - State tags (Spec 005 §State tags)     — :auth/busy on :submitting,
-                                              :auth/authenticated on :authed.
+                                              :auth/authenticated on :authed,
+                                              :auth/locked on :locked-out.
                                               Views query them via
                                               `(rf/machine-has-tag? :auth.login/flow ...)`
                                               instead of boolean-discriminator
-                                              subs.
+                                              subs. The terminal :locked-out
+                                              state (reached after the fourth
+                                              failed submit) is surfaced as a
+                                              non-interactive locked-account
+                                              panel rather than a dead-but-enabled
+                                              form (rf2-q6bm7d).
    - Open-map idiom                        — every shape on the wire is an open map
 
    Test-free per the examples policy (no inline test fn, no sibling
@@ -29,9 +35,8 @@
    `implementation/core/test/re_frame/examples_test.clj` drives the
    happy-path / retry-then-lockout / pure machine-transition scenarios. The walkthrough
    registers its OWN parallel `:auth.login/flow` variant (same states,
-   guards, actions; it adds an `:auth/locked` tag on `:locked-out`
-   because its root-view renders a dedicated lockout panel — this file
-   omits that tag since its view never branches on lockout). That is a
+   guards, actions; like this file it tags `:locked-out` with
+   `:auth/locked` and renders a dedicated locked-account panel). That is a
    deliberate pedagogical variant, not the literal same registration:
    a machine id is a per-frame registry key, never a global handle, so
    two examples may name-share without colliding (and they never co-load
@@ -305,7 +310,15 @@
        :meta {:terminal? true}}
 
       :locked-out
-      {:meta {:terminal? true}}}}))
+      ;; :auth/locked tag — after the fourth failed submit the flow lands
+      ;; in this terminal state. Views query
+      ;; (rf/machine-has-tag? :auth.login/flow :auth/locked) to swap the
+      ;; form for a locked-account panel and refuse further submits — same
+      ;; tag + locked-panel pattern as the state-machines walkthrough. A
+      ;; terminal lockout must be visible and non-interactive, not a live
+      ;; form (rf2-q6bm7d).
+      {:tags #{:auth/locked}
+       :meta {:terminal? true}}}}))
 
 ;; ============================================================================
 ;; EVENTS  (CP-1)
@@ -364,7 +377,8 @@
          {:data-testid "login-form"
           :on-submit (fn [e]
                        (.preventDefault e)
-                       (dispatch [:auth.login/flow [:auth.login/submit @state]]))}
+                       (when-not busy?
+                         (dispatch [:auth.login/flow [:auth.login/submit @state]])))}
          [:input  {:type        "email"
                    :placeholder "Email"
                    :disabled    busy?
@@ -380,13 +394,24 @@
           (if busy? "Signing in…" "Sign in")]
          (when err [:p.error {:data-testid "login-error"} err])]))))
 
+;; Terminal lockout panel — rendered once the flow reaches :locked-out
+;; (tagged :auth/locked). The state has no transitions, so the form is
+;; swapped out entirely rather than left enabled-but-dead.
+(reg-view ^{:doc "Locked-account panel shown when the login flow reaches :locked-out."}
+          locked-panel []
+  [:div.locked {:data-testid "locked-panel"}
+   [:h2 "Account locked"]
+   [:p "Three failed attempts. Contact support to unlock."]])
+
 (reg-view ^{:doc "Shows the user's logged-in state and a sign-out button."}
           login-banner []
-  (let [authed? @(rf/machine-has-tag? :auth.login/flow :auth/authenticated)]
+  (let [authed? @(rf/machine-has-tag? :auth.login/flow :auth/authenticated)
+        locked? @(rf/machine-has-tag? :auth.login/flow :auth/locked)]
     [:div.banner {:data-testid "login-banner"}
-     (if authed?
-       [:span "Welcome!"]
-       [login-form])]))
+     (cond
+       authed? [:span "Welcome!"]
+       locked? [locked-panel]
+       :else   [login-form])]))
 
 (reg-view root-view []
   [:div.app


### PR DESCRIPTION
## What

The reagent + helix login twins shared the same defect rf2-ijqlmi fixed in the uix twin: the machine's `:locked-out` terminal state (reached after a fourth failed submit) carried **no tag and no view branch**, so the demo fell back to an enabled sign-in form with no message — a dead-but-live form (further submits were silent no-ops since `:locked-out` has no transitions).

Mirrors the merged uix fix (`examples/uix/login_uix/core.cljs`, rf2-ijqlmi) in each substrate idiom:

- **Tag** `:locked-out` with `:auth/locked`.
- **Add a non-interactive locked-account panel** — `reg-view` for `examples/reagent/login`, `defnc` + `use-subscribe` for `examples/helix/login_helix`. `login-banner` now branches `authed` / `locked` / `form` via `cond`.
- **Guard the submit handler** against the busy state (`when-not busy?`).
- **Docs**: updated each ns docstring + README to name `:auth/locked` and dropped the stale "view never branches on lockout" / "identical to reference" claim.

Same tag + locked-panel pattern as the state-machines walkthrough and the merged uix twin. Lane: `examples/reagent/login/**` + `examples/helix/login_helix/**` only. Examples are test-free (rf2-8cevm) — no `*.spec.cjs` added.

## Quality gates

- `npm run test:examples-compile` — **PASS**. All 39 example builds compiled with zero warnings, including `:examples/login`, `:examples/login-helix`, `:examples/login-uix`, and `:examples/login-with-stories` (the Reagent stories build, which drives the `:story.login/locked-out` variant — now renders the new locked panel).
- `python scripts/check_doc_slugs.py` — **PASS** (exit 0).
- `python scripts/check_readme_links.py` — **PASS** (exit 0).
- `python scripts/check_readme_inventories.py` — clean for the login READMEs (exit 0); the only note is the pre-existing `implementation/README.md` omitting generated `node_modules`/`out` dirs created by the local `npm install` + compile — unrelated to this change.

Closes rf2-q6bm7d.