### PR TITLE
fix(schemas): independent-review findings (rf2-612mri)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -72,14 +72,18 @@
   with `:explain` (present as the `:rf/redacted` sentinel on sensitive
   failures, not omitted).
 
-  Per rf2-ss06u.1 the `:path` tag's normally-structural segments have one
-  value-bearing carve-out: a `:set` failure's segment is the failing
-  ELEMENT VALUE itself (Malli has no positional index for a set). On a
-  sensitive `:set`-nested failure `validate-app-schema!` scrubs that
-  segment to `:rf/redacted` via `walker/sanitize-sensitive-path` so the
-  sensitive element (and any sibling secrets in it) never ships verbatim
-  in `:path` — navigable `:vector` / `:map-of` / `:tuple` / map segments
-  stay intact so `:path` remains a `get-in` locator for those shapes.
+  Per rf2-ss06u.1 / rf2-612mri the `:path` tag's normally-structural
+  segments have several value-bearing carve-outs that
+  `walker/sanitize-sensitive-path` scrubs to `:rf/redacted` on a sensitive
+  failure (the same scrubbed path also feeds `:reason`, so neither slot
+  leaks): a `:set` failure's segment is the failing ELEMENT VALUE itself
+  (Malli has no positional index for a set); a `:map-of` key whose KEY
+  SCHEMA declares `:sensitive?` is the secret used AS the key
+  (rf2-612mri); and any scalar in the FAIL-CLOSED tail past an ambiguous
+  wrapper (`:orn` / `:multi`) cannot be proven a locator and may be a
+  value-bearing `:set` scalar element (rf2-612mri). Navigable `:vector` /
+  `:tuple` / `:map` segments and NON-sensitive `:map-of` keys stay intact
+  so `:path` remains a `get-in` locator for those shapes.
 
   Per rf2-ss06u.3 a structurally MALFORMED registered schema (childless
   `[:vector]`, unknown op) makes the registered validator THROW at
@@ -653,18 +657,23 @@
                        sensitive?  (if in-path
                                      (walker/schema-sensitive-at? schema in-path)
                                      (walker/schema-has-sensitive? schema))
-                       ;; Per rf2-ss06u.1 — a `:set` failure's `:in`
-                       ;; segment is the failing ELEMENT VALUE itself
-                       ;; (Malli has no positional index for a set), so
-                       ;; concatenating the raw `:in` into the structural
-                       ;; `:path` tag ships the entire sensitive element
-                       ;; map (sibling secrets included) VERBATIM —
-                       ;; defeating the redaction the `:value` / `:explain`
-                       ;; slots apply. When the slot is sensitive, scrub the
-                       ;; `:set`-element value segments out of the `:path`
-                       ;; (navigable `:vector` / `:map-of` / `:tuple` / map
-                       ;; segments are kept so `:path` stays a useful
-                       ;; locator for those shapes — the bead regression).
+                       ;; Per rf2-ss06u.1 / rf2-612mri — some `:in`
+                       ;; segments are value-bearing, not structural: a
+                       ;; `:set` failure's segment is the failing ELEMENT
+                       ;; VALUE (Malli has no positional index for a set), a
+                       ;; sensitive `:map-of` KEY is the secret used as the
+                       ;; key, and a scalar in the fail-closed tail past an
+                       ;; ambiguous wrapper may be a `:set` scalar element.
+                       ;; Concatenating the raw `:in` into the structural
+                       ;; `:path` tag would ship those verbatim — defeating
+                       ;; the redaction the `:value` / `:explain` slots
+                       ;; apply, and re-leaking through `:reason` (built from
+                       ;; the same path). When the slot is sensitive, scrub
+                       ;; the value-bearing segments out of `:path` via
+                       ;; `sanitize-sensitive-path` (navigable `:vector` /
+                       ;; `:tuple` / `:map` segments + NON-sensitive `:map-of`
+                       ;; keys are kept so `:path` stays a useful locator for
+                       ;; those shapes — the bead regression).
                        path-in     (if (and in-path sensitive?)
                                      (walker/sanitize-sensitive-path schema in-path)
                                      in-path)

--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -479,15 +479,6 @@
 ;; `privacy/redacted-sentinel`; the two agree by definition.
 (def ^:private path-redacted-sentinel :rf/redacted)
 
-(defn- scalar-locator?
-  "True when `x` is a scalar that can serve as a `get-in` path segment — a
-  keyword / string / number / symbol / boolean. A composite (map / set /
-  vector / seq) can NEVER be a navigable locator AND is exactly the shape
-  Malli reports as a `:set`-element value — so a non-scalar segment in a
-  failing `:in` path is always value-bearing, never a locator."
-  [x]
-  (or (keyword? x) (string? x) (number? x) (symbol? x) (boolean? x)))
-
 (defn sanitize-sensitive-path
   "Return `in-path` with every VALUE-BEARING segment replaced by the
   `:rf/redacted` sentinel, walking `schema` in lockstep with the raw
@@ -506,10 +497,18 @@
 
     - `:set` — the segment is the failing ELEMENT VALUE; ALWAYS scrub it
       (it is both unnavigable AND value-bearing), even when scalar.
-    - `:map` keys, `:vector` / `:sequential` / `:tuple` integer indices,
-      `:map-of` keys — navigable scalar locators; KEEP them so `:path`
-      stays a useful `get-in` locator for those shapes (the bead's
-      regression requirement).
+    - `:map-of` keys — navigable locators by default (KEEP them so `:path`
+      stays a useful `get-in` locator), UNLESS the key SCHEMA itself is
+      declared `:sensitive?` (rf2-612mri). A `[:map-of [:string
+      {:sensitive? true}] …]` uses the secret AS the key; Malli reports
+      that secret verbatim as the `:in` key segment, so a failing value
+      under a sensitive key would otherwise ship the secret in `:path` /
+      `:reason` despite `:value` / `:explain` being redacted. When the key
+      schema declares sensitivity, the key segment is scrubbed.
+    - `:map` keys, `:vector` / `:sequential` / `:tuple` integer indices —
+      navigable scalar locators; KEEP them so `:path` stays a useful
+      `get-in` locator for those shapes (the bead's regression
+      requirement).
     - Transparent wrappers (`:maybe` / `:and` / `:or` / `:multi` / `:orn`)
       contribute NO `:in` segment — descend without consuming. For the
       single-child wrappers (`:maybe` / `:and` / `:or`) the inner schema is
@@ -517,28 +516,37 @@
       multi-branch wrappers (`:multi` / `:orn`) and any other / opaque op
       the branch is ambiguous, so the walk drops to a FAIL-CLOSED tail.
 
-  FAIL-CLOSED tail (rf2-ss06u.1 / rf2-ss06u.2): once the lockstep walk
-  cannot confidently continue (a multi-branch / opaque op, or the schema
-  bottoms out before the path does), every remaining segment is scrubbed
-  UNLESS it is a scalar locator (`scalar-locator?`). A non-scalar segment
-  past an unresolvable point can only be a value-bearing collection (a
-  `:set` element map/set/vector, the exact leak shape) — never a locator —
-  so scrubbing it can never lose navigability, and keeping it would
-  under-redact. Per the bead: over-redaction on these wrapper shapes is
-  acceptable; the value-protection direction must never under-redact. This
-  closes the deep nesting the adversarial generator surfaced
-  (`{:a #{{:auth #{{:secret …}}}}}` under an `:orn`) where the prior
-  pass-through-verbatim fallback leaked the set-element maps into `:path`.
+  FAIL-CLOSED tail (rf2-ss06u.1 / rf2-ss06u.2 / rf2-612mri): once the
+  lockstep walk cannot confidently continue (a multi-branch / opaque op,
+  or the schema bottoms out before the path does), EVERY remaining segment
+  is scrubbed — scalars included. Past an unresolvable point the sanitizer
+  cannot PROVE a segment is a structural locator: a scalar in the tail may
+  be a navigable index/key OR a value-bearing `:set` scalar element (the
+  rf2-612mri leak shape — `[:orn [:tokens [:set [:string {:sensitive?
+  true}]]]]` reports `:in = [123456789]`, the secret element itself, and
+  the prior scalar-keep pass leaked it into `:path` / `:reason`), and a
+  non-scalar can only be a value-bearing collection. Since the sanitizer
+  runs ONLY on slots already proven `:sensitive?`, fail-closed scrubbing of
+  the unresolvable tail can never lose navigability that matters (the
+  resolvable `:map` / `:vector` / `:tuple` / `:map-of` shapes keep their
+  locators on their OWN branches above and never reach the tail) — and
+  keeping any tail scalar would under-redact. Per the bead: over-redaction
+  on these wrapper shapes is acceptable; the value-protection direction
+  must never under-redact. This closes both the deep nesting the
+  adversarial generator surfaced (`{:a #{{:auth #{{:secret …}}}}}` under an
+  `:orn`) and the scalar set-element leak (rf2-612mri).
 
   Pure; same `(schema, in-path)` always produces the same output.
   Returns a vector."
   [schema in-path]
   (letfn [(fail-closed-tail [out in]
-            ;; Cannot resolve the schema further — scrub every remaining
-            ;; non-scalar segment; keep scalar locators.
-            (into out (map (fn [seg]
-                             (if (scalar-locator? seg) seg path-redacted-sentinel)))
-                  in))]
+            ;; Cannot resolve the schema further — scrub EVERY remaining
+            ;; segment (rf2-612mri). A tail scalar cannot be proven a
+            ;; structural locator past an unresolvable op (it may be a
+            ;; value-bearing `:set` element), so keeping it would
+            ;; under-redact; the resolvable navigable shapes keep their
+            ;; locators on their own branches above and never reach here.
+            (into out (map (constantly path-redacted-sentinel)) in))]
     (loop [schema schema
            in     (vec in-path)
            out    []]
@@ -572,14 +580,31 @@
               (= op :set)
               (recur (nth children 0 nil) (subvec in 1) (conj out path-redacted-sentinel))
 
+              ;; `:map-of` — the segment is the failing entry's KEY (Malli
+              ;; reports the key VALUE verbatim, e.g. `["secret-token-123"
+              ;; :age]`). A `:map-of` key is normally a navigable locator and
+              ;; is KEPT so `:path` stays a `get-in` locator — BUT when the
+              ;; KEY SCHEMA (child 0) itself declares `:sensitive?`
+              ;; (rf2-612mri), the key IS the secret and must be scrubbed,
+              ;; else it ships verbatim in `:path` / `:reason` despite
+              ;; `:value` / `:explain` being redacted. Descend into the
+              ;; VALUE schema (child 1) either way.
+              (= op :map-of)
+              (let [key-schema (nth children 0 nil)
+                    val-schema (nth children 1 nil)
+                    seg-out    (if (schema-has-sensitive? key-schema)
+                                 path-redacted-sentinel
+                                 seg)]
+                (recur val-schema (subvec in 1) (conj out seg-out)))
+
               ;; Other index-bearing ops — the segment is a navigable index
-              ;; (`:vector` / `:sequential` / `:tuple`) or key (`:map-of`);
-              ;; keep it and descend into the element / value schema.
+              ;; (`:vector` / `:sequential` / `:tuple`); keep it and descend
+              ;; into the element schema (`:tuple` indexes per-position).
               (contains? index-bearing-ops op)
               (let [child (if (= op :tuple)
                             (when (and (int? seg) (< seg (count children)))
                               (nth children seg))
-                            (nth children (if (= op :map-of) 1 0) nil))]
+                            (nth children 0 nil))]
                 (recur child (subvec in 1) (conj out seg)))
 
               ;; Single-child transparent wrappers — no `:in` segment

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -441,6 +441,95 @@
       (is (not= :rf/redacted (-> v :tags :value))
           ":value rides verbatim — no spurious redaction"))))
 
+;; ---- sensitive SCALAR collection elements / map-of KEYS in :path (rf2-612mri)
+;; Two residual scalar-leak shapes the rf2-ss06u.1 :set-element scrub did NOT
+;; cover, because the value-bearing scalar is the KEY (`:map-of`) or rides in
+;; the FAIL-CLOSED tail under an ambiguous wrapper (`:orn`/`:multi`):
+;;
+;;   (a) `[:map-of [:string {:sensitive? true}] …]` — Malli reports the key
+;;       VALUE verbatim as the `:in` key segment (`["secret-token-123" :age]`),
+;;       and the prior `:map-of` branch KEPT every key (a navigable locator),
+;;       so a secret-as-key shipped raw in `:path` / `:reason`.
+;;   (b) `[:orn [:tokens [:set [:string {:sensitive? true}]]]]` — the `:orn`
+;;       is multi-branch, so the walk drops to the fail-closed tail with the
+;;       set element value as the remaining segment (`[123456789]`); the prior
+;;       scalar-keep tail KEPT it, leaking the scalar secret in `:path` /
+;;       `:reason`.
+;;
+;; The fix scrubs a `:map-of` key whose KEY SCHEMA declares `:sensitive?`, and
+;; fail-closes EVERY tail segment (scalars included) past an unresolvable op,
+;; while non-sensitive `:map-of` keys / `:vector` / `:tuple` indices stay
+;; navigable. These fail before the fix (the secret rides in :path / :reason)
+;; and pass after.
+
+(deftest app-db-validation-map-of-sensitive-key-scrubbed-from-path
+  (testing "rf2-612mri (a) — a :map-of with a :sensitive? KEY schema and a
+            failing value child scrubs the secret key from :path AND :reason;
+            the secret never appears anywhere in the emitted tags"
+    (let [v (app-db-failure-trace
+              [:by-token]
+              [:map-of [:string {:sensitive? true}] [:map [:age :int]]]
+              {:by-token {"secret-token-123" {:age "not-an-int"}}}
+              :by-token/bad)]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v))
+          "top-level :sensitive? stamp present — the key schema is sensitive")
+      (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+      ;; The sensitive KEY is scrubbed; the navigable inner :age segment
+      ;; (a real :map key, not the secret) survives so :path stays locatable
+      ;; down to the failing slot.
+      (is (= [:by-token :rf/redacted :age] (-> v :tags :path))
+          ":path's sensitive :map-of key segment is the :rf/redacted sentinel")
+      (is (not (str/includes? (pr-str (-> v :tags :path)) "secret-token-123"))
+          "the secret key does NOT appear in :path")
+      (is (not (str/includes? (pr-str (-> v :tags :reason)) "secret-token-123"))
+          "the secret key does NOT appear in the generated :reason text")
+      ;; Belt-and-braces: NO secret anywhere in the whole tag map.
+      (is (not (str/includes? (pr-str (:tags v)) "secret-token-123"))
+          "the secret key does NOT appear anywhere in the emitted tags"))))
+
+(deftest app-db-validation-orn-wrapped-set-sensitive-scalar-scrubbed
+  (testing "rf2-612mri (b) — an :orn-wrapped :set of :sensitive? SCALARS scrubs
+            the scalar element from :path AND :reason via the fail-closed tail;
+            the scalar secret never appears anywhere in the emitted tags"
+    (let [v (app-db-failure-trace
+              [:tokens]
+              [:orn [:tokens [:set [:string {:sensitive? true}]]]]
+              {:tokens #{123456789}}
+              :tokens/bad)]
+      (is (some? v) "a trace fired")
+      (is (true? (:sensitive? v))
+          "top-level :sensitive? stamp present — the set element schema is sensitive")
+      (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> v :tags :explain)) ":explain redacted")
+      ;; The :orn is ambiguous, so the walk fail-closes the tail — the
+      ;; scalar set element is scrubbed (it is value-bearing, not a locator).
+      (is (= [:tokens :rf/redacted] (-> v :tags :path))
+          ":path's fail-closed scalar set-element segment is the :rf/redacted sentinel")
+      (is (not (str/includes? (pr-str (-> v :tags :path)) "123456789"))
+          "the sensitive scalar element does NOT appear in :path")
+      (is (not (str/includes? (pr-str (-> v :tags :reason)) "123456789"))
+          "the sensitive scalar element does NOT appear in the generated :reason text")
+      (is (not (str/includes? (pr-str (:tags v)) "123456789"))
+          "the sensitive scalar element does NOT appear anywhere in the emitted tags"))))
+
+(deftest app-db-validation-non-sensitive-map-of-key-stays-navigable
+  (testing "rf2-612mri regression — a :map-of whose KEY schema is NOT sensitive
+            (only the nested VALUE slot is) keeps the navigable map key in
+            :path; the fix scrubs sensitive KEYS only, never plain keys"
+    (let [v (app-db-failure-trace
+              [:by-id]
+              [:map-of :string [:map [:secret {:sensitive? true} :string]]]
+              {:by-id {"a" {:secret 99}}}
+              :by-id/bad)]
+      (is (some? v))
+      (is (true? (:sensitive? v))
+          "the nested :secret value slot is sensitive — redaction still runs")
+      (is (= [:by-id "a" :secret] (-> v :tags :path))
+          ":path keeps the navigable plain map-of key (\"a\") — no over-redaction")
+      (is (= :rf/redacted (-> v :tags :value))))))
+
 ;; ---- ancestor-sensitive container wrapped by :and/:multi/:orn (rf2-ss06u.2)
 ;; When a slot is declared {:sensitive? true} as a CONTAINER and the failing
 ;; leaf lives under a transparent-but-unrecognised wrapper op


### PR DESCRIPTION
Independent correctness review of `implementation/schemas` (rf2-612mri). One finding, verified live against current source (not deduped by a5kzs or the Class-sweep redaction-invariant work — those cover sensitive-event redaction / fail-open and the uniform value-slot redaction; neither touches `:path` / `:reason` scalar leakage).

## Finding disposition

**Finding 1 — sensitive scalar key/element leaks through `:path` and `:reason` (CONFIRMED LIVE, FIXED).**
`walker/sanitize-sensitive-path` redacted `:set`-element segments (rf2-ss06u.1) but kept two residual scalar shapes:

- **(a) `:map-of` with a `:sensitive?` KEY schema.** Malli reports the key value verbatim as the `:in` key segment (`["secret-token-123" :age]`). The `:map-of` branch kept every key as a navigable locator, so the secret used *as* the key shipped raw in `:path` / `:reason`. Verified: `sanitize-sensitive-path` returned `["secret-token-123" :age]`.
- **(b) `:orn`/`:multi`-wrapped `:set` of `:sensitive?` SCALARS.** The ambiguous wrapper drops the walk to the fail-closed tail, which kept scalar locators. A scalar set element is value-bearing, not a locator. Verified: `sanitize-sensitive-path` returned `[123456789]`.

Both shapes are stamped `:sensitive? true` and have `:value` / `:explain` redacted, yet the secret rode in the structural `:path` tag and the `:reason` text built from it — leaking to trace listeners, devtools, logs, and epoch capture.

**Fix (schemas-only, no core seam needed):**
- New dedicated `:map-of` branch — scrub the key segment when the *key schema* declares `:sensitive?`; otherwise keep it (non-sensitive keys stay navigable `get-in` locators).
- The fail-closed tail now scrubs **every** remaining segment (scalars included). Past an unresolvable op a scalar cannot be *proven* a structural locator and may be a `:set` element; resolvable navigable shapes keep their locators on their own branches and never reach the tail, so navigability that matters is never lost. Per the bead, over-redaction on these ambiguous wrapper shapes is acceptable; under-redaction is not.
- Removed the now-dead `scalar-locator?` helper.
- `:reason` is built from the same scrubbed path, so fixing the path fixes both slots. Docstrings/comments in `validate.cljc` updated to describe the new carve-outs.

**Regression tests** (`schemas_sensitive_test.clj`):
- `app-db-validation-map-of-sensitive-key-scrubbed-from-path` — (a); asserts `:path = [:by-token :rf/redacted :age]`, no secret in `:path` / `:reason` / whole tag map.
- `app-db-validation-orn-wrapped-set-sensitive-scalar-scrubbed` — (b); asserts `:path = [:tokens :rf/redacted]`, no secret anywhere.
- `app-db-validation-non-sensitive-map-of-key-stays-navigable` — no over-redaction: a plain `:map-of` key (only the nested value sensitive) keeps its navigable key (`[:by-id "a" :secret]`).

## Quality gates
- `cd implementation/schemas && clojure -M:test` — **274 tests, 18589 assertions, 0 failures, 0 errors** (was 271/18569; +3 new tests).
- `cd implementation && npm run test:cljs` — **5854 tests, 20750 assertions, 0 failures, 0 errors**.

Closes rf2-612mri.