### PR TITLE
fix(scripts): independent-review findings (rf2-mwx08)

### DIFF
--- a/implementation/package.json
+++ b/implementation/package.json
@@ -36,7 +36,7 @@
     "test:xray-feature-gate": "node scripts/serve-and-run-xray-feature-gate.cjs",
     "test:xray-feature-gate:smoke": "node scripts/serve-and-run-xray-feature-gate.cjs --smoke",
     "test:story-static": "node scripts/check-story-static.cjs",
-    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_story-script-runners-policy.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs && node scripts/check-reagent-slim-boundary.test.cjs",
+    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_story-script-runners-policy.test.cjs && node scripts/_impl-browser-runners-pageerror-policy.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs && node scripts/check-reagent-slim-boundary.test.cjs",
     "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs && node scripts/_read-release-bundle.test.cjs && node scripts/dev-testbed.test.cjs",
     "test:mcp-conformance": "node scripts/test-mcp-conformance.cjs"
   }

--- a/implementation/scripts/_browser-test-report.test.cjs
+++ b/implementation/scripts/_browser-test-report.test.cjs
@@ -28,6 +28,66 @@ test('summary parser extracts cljs.test counts from noisy text', () => {
   });
 });
 
+// rf2-mwx08 (regression): a prelude app log shaped exactly like a
+// zero-failure cljs.test summary (`0 failures, 0 errors.`) that PRECEDES
+// the real `Ran ...` line must NOT be paired as the failure summary. The
+// old first-match-of-each parser returned `{failErr: "0 failures, 0
+// errors."}` here and false-greened a red run. The paired parser binds
+// the failures/errors line that FOLLOWS the selected `Ran ...` line.
+test('noisy zero-failure prelude before the real run is not mis-paired as green (rf2-mwx08)', () => {
+  const blob = [
+    '[browser:log] app boot: 0 failures, 0 errors.',
+    'FAIL in (my-test) expected: 1 actual: 2',
+    'Ran 8 tests containing 20 assertions.',
+    '1 failures, 0 errors.',
+  ].join('\n');
+  const parts = summaryPartsFromText(blob);
+  assert.equal(parts.ran, 'Ran 8 tests containing 20 assertions.');
+  // MUST be the real red line, never the prelude zero line.
+  assert.equal(parts.failErr, '1 failures, 0 errors.');
+  const counts = parseFailureCounts(parts.failErr);
+  assert.equal(counts.failures > 0 || counts.errors > 0, true,
+    'red run must parse to a non-zero count, not green');
+});
+
+// rf2-mwx08: a bare `failures, errors` line with no preceding `Ran ...`
+// is console noise, not a summary — it must be ignored, leaving failErr
+// null (the "no verdict yet → run fails" signal in run-browser-tests).
+test('a failures/errors line with no preceding Ran line is ignored (rf2-mwx08)', () => {
+  const parts = summaryPartsFromText([
+    '[browser:log] some lib says: 0 failures, 0 errors.',
+    '[browser:log] still booting',
+  ].join('\n'));
+  assert.deepEqual(parts, { ran: null, failErr: null });
+});
+
+// rf2-mwx08: when a page emits more than one cljs.test summary (e.g. a
+// re-run), the LAST complete pair wins, and each failErr stays bound to
+// its own Ran line.
+test('last complete cljs.test summary pair wins on a re-run (rf2-mwx08)', () => {
+  const parts = summaryPartsFromText([
+    'Ran 3 tests containing 9 assertions.',
+    '0 failures, 0 errors.',
+    '[browser:log] re-running suite',
+    'Ran 4 tests containing 12 assertions.',
+    '2 failures, 1 errors.',
+  ].join('\n'));
+  assert.equal(parts.ran, 'Ran 4 tests containing 12 assertions.');
+  assert.equal(parts.failErr, '2 failures, 1 errors.');
+});
+
+// rf2-mwx08: an un-paired `Ran ...` line (failures/errors not yet
+// streamed) surfaces the `ran` half for a meaningful timeout message,
+// but failErr stays null so no green verdict can form.
+test('a Ran line with no failures/errors line yet surfaces ran only (rf2-mwx08)', () => {
+  const parts = summaryPartsFromText([
+    '[browser:log] booted',
+    'Ran 8 tests containing 20 assertions.',
+  ].join('\n'));
+  assert.equal(parts.ran, 'Ran 8 tests containing 20 assertions.');
+  assert.equal(parts.failErr, null);
+});
+
 test('failure count parser returns numeric counts', () => {
   assert.deepEqual(parseFailureCounts('2 failures, 1 errors.'), {
     failures: 2,

--- a/implementation/scripts/_impl-browser-runners-pageerror-policy.test.cjs
+++ b/implementation/scripts/_impl-browser-runners-pageerror-policy.test.cjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/*
+ * Policy gate for the THREE implementation-side browser runners that
+ * could previously ship green while Chromium observed an uncaught
+ * `pageerror` (rf2-mwx08). Same correctness class rf2-wf5al fixed for the
+ * examples/scripts Story play runner, here applied to:
+ *
+ *   - run-browser-tests.cjs           (a green cljs.test summary ignored
+ *                                      pageerrors)
+ *   - serve-and-run-xray-feature-gate.cjs
+ *                                     (scenario marked passed even when a
+ *                                      pageerror was captured)
+ *   - check-story-static.cjs          (static smoke passed on visible
+ *                                      assertions, ignoring pageerrors)
+ *
+ * These runners drive a headless Chromium end-to-end, so their verdict
+ * paths are not cleanly unit-testable without launching a browser.
+ * Following the rf2-wf5al precedent (_story-script-runners-policy.test.cjs),
+ * we pin the verdict wiring STATICALLY: each runner must (a) record
+ * pageerrors into a separately-tracked array — NOT merely into the
+ * diagnostic buffer — and (b) flip its verdict to fail when that array is
+ * non-empty. A refactor that drops the pageerror signal back to an
+ * assertions-only / summary-only verdict trips this gate.
+ *
+ * Console noise stays diagnostic-only by design; only `pageerror` is
+ * fatal — matching every adjacent runner's policy.
+ *
+ * Wired into package.json via `test:script-policy`.
+ */
+
+const assert = require('assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const SCRIPTS_DIR = path.resolve(__dirname);
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+function read(name) {
+  return fs.readFileSync(path.join(SCRIPTS_DIR, name), 'utf8');
+}
+
+// ---- run-browser-tests.cjs ----
+
+test('run-browser-tests: pageerrors are tracked in a dedicated array, not just diagnostics (rf2-mwx08)', () => {
+  const src = read('run-browser-tests.cjs');
+  assert.match(
+    src,
+    /const\s+pageErrors\s*=\s*\[\]/,
+    'must declare a dedicated pageErrors array',
+  );
+  assert.match(
+    src,
+    /page\.on\(\s*['"]pageerror['"][\s\S]{0,160}?pageErrors\.push\(/,
+    'the pageerror handler must push into the dedicated pageErrors array',
+  );
+});
+
+test('run-browser-tests: a green cljs.test summary still fails when pageErrors were captured (rf2-mwx08)', () => {
+  const src = read('run-browser-tests.cjs');
+  // After the failures/errors-count guard, there must be a pageErrors
+  // length check that returns the failure exit code (1) before the
+  // green/compact-summary return.
+  assert.match(
+    src,
+    /if\s*\(\s*pageErrors\.length\s*>\s*0\s*\)\s*\{[\s\S]{0,400}?return\s+1\s*;/,
+    'must fail the run (return 1) when pageErrors.length > 0, even on a green summary',
+  );
+  // And the fatal check must sit BEFORE the green compact-summary print.
+  const fatalIdx = src.search(/if\s*\(\s*pageErrors\.length\s*>\s*0\s*\)/);
+  const greenIdx = src.search(/formatCompactSummary\(/);
+  assert.ok(fatalIdx > -1 && greenIdx > -1, 'both call-sites must exist');
+  assert.ok(
+    fatalIdx < greenIdx,
+    'the pageerror fatal check must precede the green compact-summary return',
+  );
+});
+
+// ---- serve-and-run-xray-feature-gate.cjs ----
+
+test('xray-feature-gate: a scenario with a captured pageerror is not marked passed (rf2-mwx08)', () => {
+  const src = read('serve-and-run-xray-feature-gate.cjs');
+  // The handler already records into browserState.pageErrors; pin that
+  // the run path THROWS (→ passed stays false / anyFailed flips) when
+  // that array is non-empty, BEFORE `passed = true`.
+  assert.match(
+    src,
+    /if\s*\(\s*browserState\.pageErrors\.length\s*>\s*0\s*\)\s*\{[\s\S]{0,300}?throw\s+new\s+Error/,
+    'must throw when browserState.pageErrors is non-empty so the scenario fails',
+  );
+  const throwIdx = src.search(/browserState\.pageErrors\.length\s*>\s*0/);
+  const passedIdx = src.search(/\bpassed\s*=\s*true\s*;/);
+  assert.ok(throwIdx > -1 && passedIdx > -1, 'both call-sites must exist');
+  assert.ok(
+    throwIdx < passedIdx,
+    'the pageerror fatal check must precede `passed = true`',
+  );
+});
+
+// ---- check-story-static.cjs ----
+
+test('check-story-static: pageerrors are tracked in a dedicated array, not just diagnostics (rf2-mwx08)', () => {
+  const src = read('check-story-static.cjs');
+  assert.match(
+    src,
+    /const\s+pageErrors\s*=\s*\[\]/,
+    'must declare a dedicated pageErrors array',
+  );
+  assert.match(
+    src,
+    /page\.on\(\s*['"]pageerror['"][\s\S]{0,160}?pageErrors\.push\(/,
+    'the pageerror handler must push into the dedicated pageErrors array',
+  );
+});
+
+test('check-story-static: the smoke throws on a captured pageerror even when assertions passed (rf2-mwx08)', () => {
+  const src = read('check-story-static.cjs');
+  assert.match(
+    src,
+    /if\s*\(\s*pageErrors\.length\s*>\s*0\s*\)\s*\{[\s\S]{0,300}?throw\s+new\s+Error/,
+    'must throw when pageErrors is non-empty so the smoke fails (exit 1)',
+  );
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+  } catch (err) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(err && err.stack ? err.stack : err);
+  }
+}
+
+if (failed > 0) {
+  console.error(`impl-browser-runners-pageerror-policy tests: ${failed} failed.`);
+  process.exit(1);
+}
+
+console.log(`impl-browser-runners-pageerror-policy tests: ${tests.length} passed.`);

--- a/implementation/scripts/check-story-static.cjs
+++ b/implementation/scripts/check-story-static.cjs
@@ -260,9 +260,18 @@ async function smokeTest(baseUrl, diagnostics) {
   const context = await browser.newContext();
   const page = await context.newPage();
 
+  // rf2-mwx08: track uncaught browser/runtime exceptions SEPARATELY from
+  // console noise. The static-export smoke passes when its visible
+  // assertions resolve; previously an uncaught `pageerror` was
+  // diagnostic-only, so the smoke could ship green while the page threw a
+  // runtime exception the assertions happened not to cover. Console
+  // output stays diagnostic-only; only `pageerror` is fatal. Mirrors the
+  // rf2-wf5al fix for the examples/scripts Story play runner.
+  const pageErrors = [];
   diagnostics.add('Spec: story-static static export smoke');
   diagnostics.add(`URL: ${baseUrl}`);
   page.on('pageerror', (err) => {
+    pageErrors.push(err.stack || err.message);
     diagnostics.add(`[browser:pageerror] ${err.message}`, 'stderr');
     if (err.stack) diagnostics.add(err.stack, 'stderr');
   });
@@ -328,6 +337,19 @@ async function smokeTest(baseUrl, diagnostics) {
       .getByText(':story.counter/empty', { exact: false })
       .first()
       .waitFor({ state: 'visible', timeout: 10000 });
+
+    // rf2-mwx08: all visible assertions passed — but an uncaught
+    // `pageerror` is still fatal. A green smoke that ignored a runtime
+    // exception is a false-green. Allow a brief settle for any
+    // post-interaction pageerror to surface, then fail if any were seen.
+    await new Promise((r) => setTimeout(r, 200));
+    if (pageErrors.length > 0) {
+      throw new Error(
+        `story-static smoke assertions passed, but the page emitted ` +
+          `${pageErrors.length} uncaught pageerror(s) — failing the smoke ` +
+          `(rf2-mwx08). First: ${pageErrors[0]}`,
+      );
+    }
 
   } finally {
     await browser.close();

--- a/implementation/scripts/lib/browser-test-report.cjs
+++ b/implementation/scripts/lib/browser-test-report.cjs
@@ -9,8 +9,15 @@
 // the failure/error counts — without echoing the whole noisy log on a
 // green run.
 //
-//   summaryPartsFromText(text)  → { ran, failErr } (each the matched
-//                                  line or null).
+//   summaryPartsFromText(text)  → { ran, failErr } — the LAST complete
+//                                  cljs.test summary PAIR in the stream:
+//                                  a `Ran ...` line plus the
+//                                  `failures, errors` line that FOLLOWS
+//                                  it. Returned as an atomic pair so a
+//                                  prelude `0 failures, 0 errors.` app
+//                                  log that PRECEDES the real `Ran ...`
+//                                  line can never be mis-paired as the
+//                                  failure summary (rf2-mwx08).
 //   parseFailureCounts(failErr) → { failures, errors } or null. A gate
 //                                  is green only when both are 0 AND a
 //                                  `Ran ...` line was seen.
@@ -28,13 +35,63 @@ function isVerboseTests(env = process.env) {
   return env.RF2_VERBOSE_TESTS === '1';
 }
 
+// Extract the cljs.test summary as an ATOMIC, ORDERED pair rather than
+// two independent first-matches (rf2-mwx08). cljs.test always emits the
+// `Ran N tests ...` line FIRST and the `K failures, L errors.` line
+// IMMEDIATELY AFTER it. Arbitrary browser-console noise — including a
+// prior app log shaped exactly like a zero-failure summary
+// (`0 failures, 0 errors.`) — may be interleaved before the real run.
+//
+// The previous implementation took the first `Ran ...` match and the
+// first `failures, errors` match from the whole blob independently, so a
+// preceding noise line could be accepted as the failure summary and then
+// paired with the later real `Ran ...` line — false-greening a red run.
+//
+// We instead walk the lines, and for each `Ran ...` line we look for the
+// FIRST `failures, errors` line that FOLLOWS it (before the next
+// `Ran ...`). That candidate pair is the summary for that run; we keep
+// the LAST such complete pair (the most recent run wins if a page emits
+// more than one cljs.test summary). A `failures, errors` line with no
+// preceding `Ran ...` is ignored — it cannot be a cljs.test summary.
 function summaryPartsFromText(text) {
   const value = text == null ? '' : String(text);
-  const ran = value.match(RAN_RE);
-  const failErr = value.match(FAIL_RE);
+  const lines = value.split('\n');
+
+  let pendingRan = null; // a `Ran ...` line awaiting its failures/errors pair
+  let pairedRan = null;
+  let pairedFailErr = null;
+
+  for (const line of lines) {
+    const ranMatch = line.match(RAN_RE);
+    if (ranMatch) {
+      // A new run begins. Any earlier un-paired `Ran ...` is abandoned
+      // (its failures/errors line never arrived before this next run).
+      pendingRan = ranMatch[0];
+      continue;
+    }
+    if (pendingRan == null) {
+      // No `Ran ...` seen yet on this run — a bare `failures, errors`
+      // line here is console noise, not a cljs.test summary. Ignore it.
+      continue;
+    }
+    const failMatch = line.match(FAIL_RE);
+    if (failMatch) {
+      // Complete pair: the failures/errors line that follows the most
+      // recent `Ran ...`. Record it as the latest complete summary and
+      // reset so a subsequent run can form its own pair.
+      pairedRan = pendingRan;
+      pairedFailErr = failMatch[0];
+      pendingRan = null;
+    }
+  }
+
+  // If a `Ran ...` line was seen but its failures/errors line has not
+  // arrived yet (still streaming), surface the `ran` half so callers can
+  // report a meaningful timeout. `failErr` stays null until the matching
+  // line lands — which is exactly the "no green verdict yet" signal.
   return {
-    ran: ran ? ran[0] : null,
-    failErr: failErr ? failErr[0] : null,
+    ran: pairedRan != null ? pairedRan : pendingRan,
+    failErr: pairedFailErr,
   };
 }
 

--- a/implementation/scripts/run-browser-tests.cjs
+++ b/implementation/scripts/run-browser-tests.cjs
@@ -39,20 +39,28 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// rf2-mwx08: capture the `ran` + `failErr` lines as an ATOMIC pair from
+// a single source. summaryPartsFromText now only ever yields a non-null
+// `failErr` together with the `Ran ...` line it directly follows, so the
+// failure verdict can never be assembled from a `ran` line in one source
+// and a noise-shaped `failures, errors` line in another. We lock the
+// summary the moment ONE source produces a complete pair. The `ran`-only
+// half is still remembered (best-effort, for a meaningful timeout
+// message) but never combined cross-source into a green verdict.
 function rememberSummary(summary, hit, sourceName) {
-  if (hit.ran && !summary.ran) {
+  if (hit.ran && hit.failErr) {
+    summary.ran = hit.ran;
+    summary.failErr = hit.failErr;
+    summary.ranSource = sourceName;
+    summary.failErrSource = sourceName;
+    summary.source = sourceName;
+    return true;
+  }
+  // Partial: a `Ran ...` line with no failures/errors pair yet. Keep it
+  // for diagnostics only — do NOT pair it with any prior `failErr`.
+  if (hit.ran && !summary.failErr) {
     summary.ran = hit.ran;
     summary.ranSource = sourceName;
-  }
-  if (hit.failErr && !summary.failErr) {
-    summary.failErr = hit.failErr;
-    summary.failErrSource = sourceName;
-  }
-  if (summary.ran && summary.failErr) {
-    summary.source = summary.ranSource === summary.failErrSource
-      ? summary.ranSource
-      : `${summary.ranSource}; ${summary.failErrSource}`;
-    return true;
   }
   return false;
 }
@@ -87,6 +95,12 @@ async function main() {
     // Capture every console line so we can scan for the cljs.test summary.
     // Flush the buffer only on failure or RF2_VERBOSE_TESTS=1.
     const consoleLines = [];
+    // rf2-mwx08: track uncaught browser/runtime exceptions SEPARATELY from
+    // console noise. A green cljs.test summary must NOT exit 0 if Chromium
+    // observed an uncaught `pageerror` (a real runtime regression the
+    // suite happened not to assert on). Console output stays diagnostic-
+    // only; only `pageerror` is fatal. Mirrors the rf2-wf5al fix.
+    const pageErrors = [];
     diagnostics.add(`URL: ${URL}`);
     page.on('console', (msg) => {
       const text = msg.text();
@@ -94,6 +108,7 @@ async function main() {
       diagnostics.add(`[browser:${msg.type()}] ${text}`);
     });
     page.on('pageerror', (err) => {
+      pageErrors.push(err.stack || err.message);
       diagnostics.add(`[browser:pageerror] ${err.message}`, 'stderr');
       if (err.stack) diagnostics.add(err.stack, 'stderr');
     });
@@ -162,6 +177,20 @@ async function main() {
     }
 
     if (counts.failures > 0 || counts.errors > 0) {
+      printSummaryDetails(summary);
+      flushDiagnostics(diagnostics);
+      return 1;
+    }
+
+    // rf2-mwx08: even a green cljs.test summary fails the run if Chromium
+    // observed an uncaught `pageerror`. The suite may simply not assert on
+    // the regression that threw; a passing summary is necessary but not
+    // sufficient for a green verdict.
+    if (pageErrors.length > 0) {
+      console.error(
+        `cljs.test summary was green, but the browser emitted ` +
+          `${pageErrors.length} uncaught pageerror(s) — failing the run (rf2-mwx08).`,
+      );
       printSummaryDetails(summary);
       flushDiagnostics(diagnostics);
       return 1;

--- a/implementation/scripts/serve-and-run-xray-feature-gate.cjs
+++ b/implementation/scripts/serve-and-run-xray-feature-gate.cjs
@@ -451,6 +451,21 @@ async function runScenarios(baseUrl) {
             setTimeout(() => reject(new Error(`Scenario timed out after ${TIMEOUT_MS}ms`)), TIMEOUT_MS);
           }),
         ]);
+        // rf2-mwx08: an uncaught browser/runtime exception is fatal even
+        // when the scenario's visible assertions all passed. pageErrors
+        // are captured by the `pageerror` listener above (line ~430) and
+        // were previously diagnostic-only — a green verdict could ship
+        // while Chromium observed an uncaught exception. Console noise
+        // stays diagnostic-only (this gate never treated it as fatal);
+        // only `pageerror` flips the verdict. Mirrors the rf2-wf5al fix
+        // for the examples/scripts Story play runner.
+        if (browserState.pageErrors.length > 0) {
+          throw new Error(
+            `Scenario emitted ${browserState.pageErrors.length} uncaught ` +
+              `browser pageerror(s) — failing the gate (rf2-mwx08). ` +
+              `First: ${browserState.pageErrors[0]}`,
+          );
+        }
         passed = true;
       } catch (err) {
         failure = err;


### PR DESCRIPTION
Independent correctness review of `implementation/scripts` — closes **rf2-mwx08**. Both findings are no-false-green / gate-hardening fixes (pre-alpha masterpiece posture: CORRECTNESS + GOOD PRACTICE). No back-compat shims.

## Findings (per-finding disposition)

### Finding 1 — `lib/browser-test-report.cjs` first-match summary decoupling — **FIXED**
`summaryPartsFromText` took the first `Ran ...` match and the first `N failures, M errors` match from the whole blob independently. A prelude app log shaped like a zero-failure summary (`0 failures, 0 errors.`) that PRECEDED the real cljs.test line was accepted as the failure summary and later paired with the real `Ran ...` line — false-greening a failing CLJS browser run.

Fix: parse the summary as an atomic, ordered pair — the `failures, errors` line that FOLLOWS the selected `Ran ...` line; keep the last complete pair (re-run wins); ignore a bare `failures, errors` line with no preceding `Ran ...`. `run-browser-tests.cjs::rememberSummary` now locks the pair from a single source rather than combining `ran`/`failErr` cross-source (latent companion bug). Regression coverage added to `_browser-test-report.test.cjs` (the exact bead repro + ordering edge cases).

### Finding 2 — `pageerror` is diagnostic-only across 3 implementation runners — **FIXED**
Same correctness class rf2-wf5al fixed for the examples/scripts Story play runner, here applied to the implementation side:
- `serve-and-run-xray-feature-gate.cjs:430/454` — scenario marked `passed = true` even when Chromium captured an uncaught `pageerror`.
- `run-browser-tests.cjs:96` — a green cljs.test summary returned 0 while a `pageerror` was observed.
- `check-story-static.cjs:265` — static smoke passed on visible assertions, ignoring `pageerror`.

Fix: each runner now tracks `pageErrors` in a dedicated array (separate from the diagnostic buffer) and flips its verdict to fail when non-empty; console noise stays diagnostic-only (no runner here treated it as fatal). New `_impl-browser-runners-pageerror-policy.test.cjs` pins the verdict wiring statically (the rf2-wf5al `_story-script-runners-policy.test.cjs` precedent — these runners are Chromium-integration scripts), wired into `test:script-policy`.

## Dedup
Verified vs merged **rf2-utvst** (empty-bundle floors / loopback bind — untouched here) and **rf2-4v79f** (api-manifest CI wiring — untouched). No overlap; both findings confirmed live against current source. rf2-wf5al was scoped to examples/scripts; this is the same class in implementation/scripts and was not covered.

## Quality gates
- `node scripts/_browser-test-report.test.cjs` — **16 passed** (added 4 rf2-mwx08 regression cases).
- `node scripts/_impl-browser-runners-pageerror-policy.test.cjs` — **5 passed** (new).
- `npm run test:script-policy` — **green** (all suites incl. the new policy test).
- `npm run test:script-helpers` — **green**.
- `node --check` on all edited runners + lib + new test — **OK**.

Browser-launch runs (`test:browser`, the Xray gate, story-static smoke) are Chromium-integration and not run in this worker; the verdict-wiring is pinned by the static policy test + the helper unit tests.

## Lane note
All changes under `implementation/scripts/**` except one additive line in `implementation/package.json` wiring the new policy test into `test:script-policy` (the exact rf2-wf5al precedent). `package.json` is NOT a hot-zone file; no workflow file touched.