### PR TITLE
fix(story): independent-review findings (rf2-76l69l)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1958,7 +1958,15 @@ step (setup-phase cascades, framework bootstrap) collect under a leading
 when the runner stamps each committed epoch with `:rf.story/script-idx`
 (the per-step settle boundary), and falls back to an even forward
 partition across the dispatch steps for a bare `epoch-history` tape. Every
-epoch lands in exactly one span.
+epoch lands in exactly one span. When several `:auto-run?` plays run in
+one settle (the multi-play sequencer), the narrative spans the
+**concatenated** play scripts, so the per-step settle boundaries MUST
+ACCUMULATE across the whole sequence — the sequencer clears the boundaries
+ONCE up front and each play APPENDS its absolute boundaries (the
+append-only epoch tape is never reset between plays), keeping the
+positional boundary→script-step zip aligned. Clearing per-play would drop
+every earlier play's boundaries and mis-attribute later-play effects to
+earlier-play steps — a green run with false provenance (rf2-76l69l).
 
 **Narrative navigation (the scrub backbone).** The two-level `:narrative`
 is a *tree* (spans over beats), but a Test-mode / Docs-mode **scrub** moves

--- a/tools/story/spec/022-Story-UI-Docs-And-Share.md
+++ b/tools/story/spec/022-Story-UI-Docs-And-Share.md
@@ -226,6 +226,20 @@ Share semantics:
   a fresh mount with no URL state at all (the localStorage hydrators run first
   on mount, and `apply-parsed-to-state` only runs when the URL carries query
   params);
+- stale overrides are DROPPED AND REPORTED, not silently merged (rf2-76l69l):
+  a URL override is dropped at two stages — `parse-overrides-param*` drops an
+  UNPARSEABLE entry (malformed EDN, a non-keyword key), and
+  `drop-stale-overrides` then drops every parsed override whose arg-key the
+  CURRENTLY-SELECTED variant no longer DECLARES (the variant's args were
+  refactored, renamed, or removed since the URL was captured). The declared
+  contract is the same arg surface the controls panel exposes — the variant's
+  resolved-args keys, its (and its parent story's) `:argtypes` keys, and the
+  compiled view-args schema's top-level `:map` entry keys
+  (`re-frame.story.ui.share/declared-arg-keys`). Both drop classes feed the
+  share-import hint's `:dropped` count, so a stale override DOWNGRADES the
+  reproducibility status and surfaces the drift banner instead of being
+  installed as an orphan live arg `args/resolve-args` would merge into the
+  recipient's effective state (a partial artifact masquerading as full);
 - a shared link restores VIEW STATE (it lands the recipient on the cell);
   it does not replay a run — that is the recorder's `:play-script` export;
 - the reproducibility status is computed (purely) by

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -140,7 +140,12 @@
   The boundaries accumulate in dispatch-step execution order, which — for
   both the single-play and multi-play (sequential) runner — is exactly the
   order the dispatch steps appear in the concatenated executed-script the
-  narrative spans."
+  narrative spans. For multi-play this holds ONLY because the sequencer
+  clears once up front and drives each play with `:clear-boundaries? false`
+  (rf2-76l69l): the boundaries from play K+1 (absolute epoch-history
+  lengths) tail play K's, so the full vector zips positionally against the
+  concatenated script. A per-play clear would drop every earlier play's
+  boundaries, leaving only the last play's to be mis-zipped."
   [frame-id step]
   (when (evidence/dispatch-step? step)
     (swap! step-boundaries update frame-id (fnil conj []) (epoch-count frame-id)))
@@ -1256,13 +1261,28 @@
                                     is the play's `:name` string (or
                                     nil for the single-script case);
                                     callers handing a hand-built `spec`
-                                    pass its `:name` as `play-key`."
+                                    pass its `:name` as `play-key`.
+  - `[variant-id play-key spec done-cb opts]` — as above + an options
+                                    map. `{:clear-boundaries? false}`
+                                    SUPPRESSES the per-run settle-boundary
+                                    reset, for a caller SEQUENCING several
+                                    plays against one frame (rf2-76l69l):
+                                    the sequencer clears ONCE up front and
+                                    each subsequent play APPENDS its
+                                    absolute boundaries, so the
+                                    concatenated-script attribution stays
+                                    positionally aligned. Defaults to
+                                    `{:clear-boundaries? true}` — the
+                                    standalone single-play contract."
   ([variant-id]
-   (run! variant-id nil nil nil))
+   (run! variant-id nil nil nil nil))
   ([variant-id done-cb]
    ;; Two-arity: variant-id + done-cb. Picks the default play.
-   (run! variant-id nil nil done-cb))
+   (run! variant-id nil nil done-cb nil))
   ([variant-id play-key spec done-cb]
+   (run! variant-id play-key spec done-cb nil))
+  ([variant-id play-key spec done-cb {:keys [clear-boundaries?]
+                                      :or   {clear-boundaries? true}}]
    (let [spec  (or spec
                    (resolve-play variant-id play-key)
                    ;; Fall back to the legacy single-script path so the
@@ -1288,7 +1308,20 @@
      ;; the boundaries snapshot the ABSOLUTE epoch-history length, so any setup
      ;; epochs already on the tape precede the first boundary (in the
      ;; orchestrator path setup runs in phase-2, before phase-4 drives `run!`).
-     (clear-step-boundaries! variant-id)
+     ;;
+     ;; rf2-76l69l — a MULTI-PLAY sequencer (`run-plays-sequentially!`, the
+     ;; orchestrator `runtime/run-phase-4!`) passes `:clear-boundaries? false`
+     ;; for the 2nd…Nth play so the boundaries ACCUMULATE across the whole
+     ;; auto-run sequence. The narrative spans the CONCATENATED script
+     ;; (`(mapcat :script auto-plays)`), and the epoch tape is append-only
+     ;; across the run (no per-play reset), so each play's absolute boundaries
+     ;; tail the previous play's — keeping the positional zip in `stamp-tape`
+     ;; aligned. Clearing per-play (the old behaviour) dropped every earlier
+     ;; play's boundaries, leaving only the LAST play's absolute boundaries to
+     ;; be mis-zipped against the concatenated script's leading dispatch steps
+     ;; — a false-green evidence-provenance failure.
+     (when clear-boundaries?
+       (clear-step-boundaries! variant-id))
      (set-state! variant-id pk started)
      (set-active-play! variant-id pk)
      (run-loop! variant-id pk token done-cb)
@@ -1362,9 +1395,19 @@
 (defn- run-plays-sequentially!
   "Internal: run `plays` against `variant-id` one after another.
   Resolves `done-cb` with a vector of terminal states once every play
-  has finished (or the loop is interrupted by a missing frame)."
+  has finished (or the loop is interrupted by a missing frame).
+
+  rf2-76l69l — clears the per-dispatch-step settle boundaries ONCE up
+  front, then drives each play with `:clear-boundaries? false` so the
+  boundaries ACCUMULATE across the sequence. The evidence narrative spans
+  the CONCATENATED play scripts, and the epoch tape is append-only across
+  the run, so each play's absolute boundaries must tail the previous
+  play's for the positional `stamp-tape` zip to stay aligned. Letting each
+  `run!` clear (the old behaviour) left only the last play's boundaries,
+  mis-attributing later-play effects to earlier-play steps."
   [variant-id plays done-cb]
   (let [acc (atom [])]
+    (clear-step-boundaries! variant-id)
     (letfn [(step! [remaining]
               (if (empty? remaining)
                 (when done-cb
@@ -1375,7 +1418,8 @@
                   (run! variant-id pk spec
                         (fn [final]
                           (swap! acc conj final)
-                          (step! (rest remaining)))))))]
+                          (step! (rest remaining)))
+                        {:clear-boundaries? false}))))]
       (step! plays))))
 
 (defn run-all-plays!

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -961,9 +961,17 @@
                          (do (settle-terminal-assertions! variant-id plan)
                              (resolve (read-assertions variant-id)))
                          (let [spec (first remaining)]
+                           ;; rf2-76l69l — the orchestrator cleared the settle
+                           ;; boundaries ONCE above (before the loop). Drive
+                           ;; every auto-play with `:clear-boundaries? false`
+                           ;; so the per-play absolute boundaries ACCUMULATE
+                           ;; across the concatenated `:executed-script` rather
+                           ;; than each `run!` wiping the prior play's — the
+                           ;; multi-play attribution-boundary fix.
                            (runner-events/run! variant-id (:name spec) spec
                                                (fn [_state]
-                                                 (step! (rest remaining)))))))]
+                                                 (step! (rest remaining)))
+                                               {:clear-boundaries? false}))))]
                (step! auto-plays))))]))))
 
 (defn- finalise-run!

--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -334,6 +334,40 @@
   [s]
   (:overrides (parse-overrides-param* s)))
 
+(defn drop-stale-overrides
+  "Second-stage filter over a `parse-overrides-param*` result: drop every
+  parsed override whose TOP-LEVEL arg-key is NOT in `declared-keys` —
+  the set of arg-keys the currently selected variant still declares
+  (rf2-76l69l). `parse-overrides-param*` only drops UNPARSEABLE entries
+  (malformed EDN, non-keyword keys); it has no view of the live variant
+  contract, so an override for an arg the variant RENAMED or REMOVED
+  parses fine and — without this filter — gets installed as a live arg
+  and silently merged by `args/resolve-args`, inflating the recipient's
+  state with orphan args and HIDING the share-import drift (a run/share
+  marked more reproducible than it is).
+
+  Takes `parsed` (`{:overrides <map-or-nil> :dropped [<token> ...]}`, the
+  `parse-overrides-param*` shape) and `declared-keys` (a set/coll of
+  keyword arg-keys, or nil). Returns the SAME shape with stale-key
+  overrides moved from `:overrides` into `:dropped` (as a `pr-str` token
+  `\"<k> <v>\"` matching the parser's drop-token idiom), preserving the
+  parser's own malformed-drop tokens.
+
+  `declared-keys` nil → no contract known (an unregistered / uncompilable
+  variant): every parsed override is kept verbatim, so this degrades to
+  the parser's pre-filter behaviour rather than dropping everything.
+  Pure data → data; JVM-testable."
+  [{:keys [overrides dropped] :as _parsed} declared-keys]
+  (if (nil? declared-keys)
+    {:overrides (not-empty overrides) :dropped (vec dropped)}
+    (let [declared (set declared-keys)
+          stale    (->> overrides
+                        (remove (fn [[k _]] (contains? declared k)))
+                        (mapv (fn [[k v]] (str (pr-str k) " " (pr-str v)))))
+          kept     (into {} (filter (fn [[k _]] (contains? declared k)) overrides))]
+      {:overrides (not-empty kept)
+       :dropped   (into (vec dropped) stale)})))
+
 (defn- ^:no-doc kv-pair
   "Build a `k=v` URL parameter fragment. `k` is a keyword;
   `v-encoded` is the already-percent-encoded value string."

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -62,12 +62,14 @@
             [re-frame.story.args :as args]
             [re-frame.story.config :as config]
             [re-frame.story.egress :as egress]
+            [re-frame.story.malli-schema :as msu]
             [re-frame.story.plan :as plan]
             [re-frame.story.registrar :as registrar]
             [re-frame.story.review-dialog :as review-dialog]
             [re-frame.story.share :as share]
             [re-frame.story.ui.a11y-dialog :as a11y-dialog]
             [re-frame.story.ui.state :as state]
+            [re-frame.story.view-args :as view-args]
             [re-frame.story.theme.typography :as typography :refer [mono-stack sans-stack]]
             [re-frame.story.theme.colors :as colors]))
 
@@ -82,6 +84,36 @@
           (js/URLSearchParams. search)
           (catch :default _ nil))))))
 
+(defn declared-arg-keys
+  "The set of TOP-LEVEL arg-keys `variant-id` currently declares — the
+  share-import contract a stale URL override is checked against
+  (rf2-76l69l). The same surface the controls panel exposes as editable
+  args: the union of
+
+    - the resolved args' keys (`args/resolve-args` WITHOUT cell-overrides
+      — the global / story / variant-chain `:args` layers);
+    - the variant's + parent story's explicit `:argtypes` keys;
+    - the compiled view-args (props) schema's top-level `:map` entry keys
+      (`view-args/compiled-view-args-schema`).
+
+  Returns nil for an unregistered / uncompilable variant (no contract
+  known) so `share/drop-stale-overrides` degrades to keeping every parsed
+  override rather than dropping all. Best-effort: any read failure
+  contributes its empty layer; the resolved-args layer alone is the
+  floor."
+  [variant-id]
+  (when (and variant-id (registrar/registered? :variant variant-id))
+    (let [story-id   (args/parent-story-id variant-id)
+          vb         (registrar/handler-meta :variant variant-id)
+          sb         (when story-id (registrar/handler-meta :story story-id))
+          arg-keys   (set (keys (args/resolve-args variant-id)))
+          argtype-ks (into (set (keys (:argtypes sb)))
+                           (keys (:argtypes vb)))
+          schema     (view-args/compiled-view-args-schema variant-id)
+          schema-ks  (when (and (vector? schema) (= :map (msu/schema-op schema)))
+                       (map msu/map-entry-key (msu/schema-children schema)))]
+      (into (into arg-keys argtype-ks) schema-ks))))
+
 (defn hydrate-from-url!
   "Hydrate the share-URL-owned shell state from `window.location.search`.
 
@@ -95,15 +127,32 @@
   a non-blocking hint when a recorded URL has drifted (variant args
   refactored, removed, renamed). Returns nothing — side-effect only.
   Pure helper exposed via `share/parse-overrides-param*` so tests can
-  assert per-axis without touching the ratom."
+  assert per-axis without touching the ratom.
+
+  rf2-76l69l — drift is detected at TWO stages: `parse-overrides-param*`
+  drops UNPARSEABLE entries, then `share/drop-stale-overrides` drops every
+  parsed override whose arg-key the selected variant no longer DECLARES
+  (renamed / removed args — `declared-arg-keys`). Both classes land in
+  `:dropped` and feed the share-import hint, so a stale override is
+  reported (reproducibility downgraded) instead of silently installed as
+  an orphan live arg."
   []
   (when-let [params (current-url-params)]
     (let [variant-id (share/parse-keyword-token (.get params "variant"))
-          parsed     (share/parse-overrides-param* (.get params "overrides"))
+          valid?     (and variant-id (registrar/registered? :variant variant-id))
+          parsed0    (share/parse-overrides-param* (.get params "overrides"))
+          ;; Second stage: drop overrides for args the selected variant no
+          ;; longer declares (renamed / removed) so they are REPORTED, not
+          ;; merged as orphan live args. Only meaningful for a valid variant
+          ;; (its declared-key contract); an invalid variant installs nothing
+          ;; anyway. `declared-arg-keys` returns nil → keep-all degrade.
+          parsed     (if valid?
+                       (share/drop-stale-overrides parsed0
+                                                   (declared-arg-keys variant-id))
+                       parsed0)
           overrides  (:overrides parsed)
           dropped    (:dropped parsed)
-          substrate  (share/parse-substrate-param (.get params "substrate"))
-          valid?     (and variant-id (registrar/registered? :variant variant-id))]
+          substrate  (share/parse-substrate-param (.get params "substrate"))]
       (state/swap-state!
         (fn [s]
           (let [s' (if valid?
@@ -112,7 +161,7 @@
                                  (state/select-workspace nil))
                        (seq overrides)
                        (assoc-in [:cell-overrides variant-id] overrides)
-                       (and valid? (seq dropped))
+                       (seq dropped)
                        (assoc-in [:rf.story/share-import-hint variant-id]
                                  {:dropped-count (count dropped)
                                   :dropped       (vec dropped)}))

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -566,6 +566,61 @@
                 (fingerprint/run-hash (dissoc result :narrative)))
              "dropping the stamped :narrative does not change the run-hash")))))
 
+;; ---- rf2-76l69l: multi-play auto-run attribution spans EVERY play --------
+;;
+;; The unified result's :narrative spans the CONCATENATED auto-run play
+;; scripts. The per-play settle boundaries MUST accumulate across the whole
+;; sequence — the sequencer clears once up front and each play APPENDS its
+;; absolute boundaries (the append-only epoch tape is never reset between
+;; plays). Before the fix every `run!` cleared the boundaries on entry, so
+;; after two+ auto-run plays only the LAST play's boundaries survived; the
+;; concatenated-script narrative then mis-attributed later-play effects to
+;; earlier-play steps while earlier effects appeared as unattributed setup —
+;; a green run with false provenance.
+
+#?(:clj
+   (deftest run-variant-multi-play-narrative-attributes-every-play-step
+     (testing "two :auto-run? plays (the second re-dispatching) attribute each
+              epoch beat to its OWN step across the concatenated script —
+              earlier-play effects are NOT lost to setup, later-play effects
+              are NOT mis-credited to earlier steps (rf2-76l69l)"
+       (rf/reg-event-db :ml/a (fn [db _] (assoc db :a true)))
+       (rf/reg-event-db :ml/b (fn [db _] (assoc db :b true)))
+       ;; :ml/c re-dispatches :ml/d, so the second play's second step settles
+       ;; to two epochs — the discriminating re-dispatch the bead calls for.
+       (rf/reg-event-fx :ml/c (fn [_ _] {:fx [[:dispatch [:ml/d]]]}))
+       (rf/reg-event-db :ml/d (fn [db _] (assoc db :d true)))
+       (story/reg-variant :story.ml/two-plays
+         {:events []
+          :plays  [{:name "alpha" :auto-run? true
+                    :script [[:dispatch-sync [:ml/a]]
+                             [:dispatch-sync [:ml/b]]]}
+                   {:name "beta" :auto-run? true
+                    :script [[:dispatch-sync [:ml/c]]]}]})
+       (let [result (async/deref-blocking
+                      (story/run-variant :story.ml/two-plays) 5000)
+             by     (->> (evidence/narrative-beats (:narrative result))
+                         (reduce (fn [m {:keys [step trigger-event]}]
+                                   (update m step (fnil conj []) trigger-event))
+                                 {}))]
+         (is (= :pass (:status result)))
+         ;; alpha's two steps own exactly their own leaf epochs…
+         (is (= [[:ml/a]] (get by [:dispatch-sync [:ml/a]]))
+             "play alpha step 0 owns ONLY :ml/a")
+         (is (= [[:ml/b]] (get by [:dispatch-sync [:ml/b]]))
+             "play alpha step 1 owns ONLY :ml/b — NOT lost to the setup span")
+         ;; …and beta's re-dispatching step owns its dispatch AND its fan-out.
+         (is (= [[:ml/c] [:ml/d]] (get by [:dispatch-sync [:ml/c]]))
+             "play beta's step owns its dispatch AND its re-dispatch — EXACT")
+         ;; RED-before pin: per-play clearing kept only beta's single boundary,
+         ;; which the concatenated script (3 dispatch steps) zipped onto step 0
+         ;; (alpha's :ml/a) — so :ml/c/:ml/d effects landed under :ml/a and the
+         ;; later steps held nothing. Assert that mis-grouping is gone.
+         (is (not (contains? (set (get by [:dispatch-sync [:ml/a]])) [:ml/c]))
+             "beta's :ml/c is NOT mis-attributed to alpha's first step")
+         (is (not (contains? (set (get by [:dispatch-sync [:ml/a]])) [:ml/d]))
+             "beta's re-dispatched :ml/d is NOT mis-attributed to alpha's step")))))
+
 #?(:clj
    (deftest assert-dom-skipped-on-jvm-is-cannot-run
      (testing "a no-DOM :assert-dom step (JVM) records NO slot pass — it

--- a/tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/share_egress_cljs_test.cljs
@@ -10,6 +10,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.story :as story]
+            [re-frame.story.share :as share]
             [re-frame.story.ui.share :as ui-share]
             [re-frame.story.ui.state :as state]))
 
@@ -138,3 +139,41 @@
       (on-click nil)
       (is (some? (ui-share/share-export-dialog))
           "clicking the chip opens the dialog (it now renders a tree)"))))
+
+;; ---- rf2-76l69l: declared-arg-keys is the stale-override contract --------
+
+(deftest declared-arg-keys-unions-args-and-argtypes
+  (testing "rf2-76l69l — declared-arg-keys is the variant's editable arg
+            surface: resolved-args keys ∪ :argtypes keys"
+    (story/reg-variant :story.dak/v
+      {:tags     #{:dev}
+       :events   []
+       :args     {:label "Hi" :count 1}
+       :argtypes {:flavour {:control :select}}})
+    (let [ks (ui-share/declared-arg-keys :story.dak/v)]
+      (is (contains? ks :label) "an :args key is declared")
+      (is (contains? ks :count) "an :args key is declared")
+      (is (contains? ks :flavour) "an :argtypes-only key is declared")
+      (is (not (contains? ks :removed)) "a never-declared key is NOT in the set"))))
+
+(deftest declared-arg-keys-nil-for-unregistered
+  (testing "rf2-76l69l — an unregistered variant has no known contract → nil
+            (so drop-stale-overrides degrades to keep-all, not drop-all)"
+    (is (nil? (ui-share/declared-arg-keys :story.dak/never-registered)))))
+
+(deftest drop-stale-overrides-against-live-contract
+  (testing "rf2-76l69l — a stale override (an arg the variant removed) is
+            dropped + reported against the live declared-key set, while a
+            still-declared override survives — the end-to-end finding-2 fix"
+    (story/reg-variant :story.dak/contract
+      {:tags   #{:dev}
+       :events []
+       :args   {:label "Hi"}})
+    (let [parsed {:overrides {:label "Renamed" :gone 9} :dropped []}
+          out    (share/drop-stale-overrides
+                   parsed (ui-share/declared-arg-keys :story.dak/contract))]
+      (is (= {:label "Renamed"} (:overrides out))
+          "the still-declared :label override survives")
+      (is (= 1 (count (:dropped out))) "the removed :gone override is dropped")
+      (is (re-find #":gone" (first (:dropped out)))
+          "the dropped token names the stale key"))))

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -237,6 +237,59 @@
       (is (nil? overrides) "unreadable EDN payload yields no overrides")
       (is (= 1 (count dropped)) "whole token reported dropped"))))
 
+;; ---- rf2-76l69l: stale-key overrides are dropped + reported --------------
+;;
+;; `parse-overrides-param*` only drops UNPARSEABLE entries; a perfectly
+;; well-formed override for an arg the variant RENAMED / REMOVED parses fine
+;; and — without the second-stage `drop-stale-overrides` filter — would be
+;; installed as a live arg and merged by `args/resolve-args`, hiding the
+;; share-import drift. This filter splits parsed overrides against the
+;; variant's declared-key contract.
+
+(deftest drop-stale-overrides-splits-by-declared-keys
+  (testing "rf2-76l69l — drop-stale-overrides keeps overrides whose key the
+            variant still declares and moves the rest (renamed/removed args)
+            into :dropped, preserving the parser's own malformed drops"
+    (let [parsed {:overrides {:label "Hi" :gone 9 :count 3}
+                  :dropped   ["bogus"]}
+          out    (share/drop-stale-overrides parsed #{:label :count})]
+      (is (= {:label "Hi" :count 3} (:overrides out))
+          "only declared keys survive")
+      (is (= 2 (count (:dropped out)))
+          "the parser's malformed drop PLUS the one stale-key drop")
+      (is (some #(= "bogus" %) (:dropped out))
+          "the parser's malformed token is preserved")
+      (is (some #(re-find #":gone" %) (:dropped out))
+          "the stale :gone override is reported as dropped, not installed"))))
+
+(deftest drop-stale-overrides-all-stale-nils-overrides
+  (testing "rf2-76l69l — when every parsed override is stale, :overrides is
+            nil (not an empty map) and each stale key is reported"
+    (let [out (share/drop-stale-overrides
+                {:overrides {:old-a 1 :old-b 2} :dropped []}
+                #{:current})]
+      (is (nil? (:overrides out)) "all-stale collapses to nil overrides")
+      (is (= 2 (count (:dropped out)))))))
+
+(deftest drop-stale-overrides-nil-declared-keeps-all
+  (testing "rf2-76l69l — a nil declared-key set (unregistered / uncompilable
+            variant: no contract known) keeps every parsed override verbatim
+            rather than dropping all — degrades to the parser's behaviour"
+    (let [parsed {:overrides {:a 1 :b 2} :dropped ["bad"]}
+          out    (share/drop-stale-overrides parsed nil)]
+      (is (= {:a 1 :b 2} (:overrides out)))
+      (is (= ["bad"] (:dropped out))))))
+
+(deftest drop-stale-overrides-empty-declared-drops-all
+  (testing "rf2-76l69l — an EMPTY (but non-nil) declared-key set means the
+            variant declares NO args, so every override is stale (distinct
+            from the nil keep-all case)"
+    (let [out (share/drop-stale-overrides
+                {:overrides {:a 1} :dropped []}
+                #{})]
+      (is (nil? (:overrides out)))
+      (is (= 1 (count (:dropped out)))))))
+
 (deftest variant-share-url-preserves-hash-route
   (testing "variant-share-url inserts params before # so the Story route survives"
     (let [url (share/variant-share-url


### PR DESCRIPTION
Fixes both findings in the independent correctness review of `tools/story` (rf2-76l69l). Lane: `tools/story/**` only. Deduped against merged 2cpoo (run-opts→plan compile + cell-override URL clear) and fkmnh (URL-authoritative-for-all-slots + share-URL contract) — neither covers these.

## Per-finding disposition

### Finding 1 — multi-play auto-run evidence loses attribution boundaries (high) — FIXED
`run-phase-4!` concatenates every auto-run play's `:script` into `:executed-script`, but `runner-events/run!` cleared the per-dispatch-step settle boundaries on every entry (the rf2-vkdam single-play reset). When the orchestrator sequenced two+ auto-run plays through its `step!` loop, each `run!` wiped the prior play's boundaries, so `settle-boundaries` returned ONLY the last play's absolute boundaries. `stamp-tape` then zipped those positionally against the CONCATENATED script's leading dispatch steps — attributing later-play effects to earlier-play steps while earlier-play effects appeared as unattributed setup. The run still reported green: a false-green evidence-provenance failure.

**Fix:** the two multi-play sequencers (`runtime/run-phase-4!` and `runner-events/run-plays-sequentially!`) now clear the boundaries ONCE up front and drive each play with a new `:clear-boundaries? false` opt on `run!`. The epoch tape is append-only across the whole run (never reset per-play), so each play's absolute boundaries tail the previous play's, keeping the positional `stamp-tape` zip aligned with the concatenated script. The single-play / interactive-rerun / stepper paths keep the rf2-vkdam clear-on-entry default.

### Finding 2 — stale share-URL overrides imported as live args, not dropped (medium-high) — FIXED
`hydrate-from-url!` installed every PARSED override under `[:cell-overrides variant-id]`; `parse-overrides-param*` only drops UNPARSEABLE entries (malformed EDN / non-keyword keys). An override for a renamed or removed arg parses cleanly and was merged by `args/resolve-args` as an orphan live arg — hiding the share-import drift banner and marking the artifact more reproducible than it is.

**Fix:** a second-stage pure `share/drop-stale-overrides` splits parsed overrides against the selected variant's declared-arg contract (`ui.share/declared-arg-keys` = resolved-args keys ∪ variant/story `:argtypes` keys ∪ compiled view-args schema map-entry keys — the same surface the controls panel exposes). Stale-key overrides move into `:dropped` and feed the existing share-import hint, downgrading reproducibility. A nil declared-key set (unregistered/uncompilable variant) degrades to keep-all rather than drop-all.

## Specs
- `017-Testing-Story.md` — narrative attribution: multi-play boundaries accumulate across the concatenated script.
- `022-Story-UI-Docs-And-Share.md` — share import contract: stale overrides dropped + reported.

## Quality gates
- `implementation` `npm run test:cljs`: **5857 tests, 20758 assertions, 0 failures, 0 errors** (covers `declared-arg-keys` + end-to-end drop-stale CLJS regressions).
- `tools/story` `clojure -M:test`: **1652 tests, 6132 assertions, 0 failures, 0 errors** (covers the multi-play narrative-attribution live-run regression + pure `drop-stale-overrides` regressions).

Default new tests to CLJS unit (no new Playwright). Closes rf2-76l69l. Do NOT merge — review gate.