### PR TITLE
fix(routing): independent-review findings (rf2-8zvajk)

### DIFF
--- a/implementation/routing/src/re_frame/routing/can_leave.cljc
+++ b/implementation/routing/src/re_frame/routing/can_leave.cljc
@@ -150,19 +150,37 @@
     (when-not ok?
       (let [[db' pn-id] (routing-events/alloc-pending-nav-id db)
             guard-id    (can-leave-guard-id current-meta)
-            pending-nav (cond-> {:id                 pn-id
-                                 :requested-by-event (vec event-vec)
-                                 :requested-url      requested-url
-                                 :reason             :can-leave
-                                 :rejecting-route    (:id current-route)}
-                          guard-id (assoc :rejecting-guard guard-id))
             ;; rf2-ede1h.3: a blocked popstate (Back/Forward) has already
             ;; moved the address bar; restore it to the slice's URL so URL
             ;; and slice agree. Only `:rf.route/handle-url-change` carries
             ;; that already-moved-URL semantics; the forward-nav entry
             ;; points never moved the URL, so they emit no restore.
             popstate?   (= :rf.route/handle-url-change (first event-vec))
-            restore-url (when popstate? (current-slice->url current-route))]
+            restore-url (when popstate? (current-slice->url current-route))
+            ;; rf2-8zvajk: record whether THIS block performed a URL
+            ;; restore. `:rf.route/continue` reads it to decide whether the
+            ;; resume must re-move the address bar. A blocked popstate's
+            ;; resume re-dispatches the original
+            ;; `[:rf.route/handle-url-change requested-url]` (bypassing the
+            ;; guard); that handler rewrites the slice but emits NO history
+            ;; mutation because it assumes the browser already moved. That
+            ;; assumption held at the ORIGINAL popstate, but the restore
+            ;; above moved the address bar BACK to the rejecting route — so
+            ;; on resume the browser URL is stale and `continue-handler`
+            ;; must replace it with `:requested-url`, or the committed slice
+            ;; and the address bar diverge (refresh / copy-URL / Back-Forward
+            ;; all operate on the wrong URL). Forward-nav blocks (no restore)
+            ;; never moved the URL, so their resume re-runs the full
+            ;; `:rf/url-requested` policy chain that pushes — no extra
+            ;; restore needed; the flag stays absent.
+            url-restored? (some? restore-url)
+            pending-nav (cond-> {:id                 pn-id
+                                 :requested-by-event (vec event-vec)
+                                 :requested-url      requested-url
+                                 :reason             :can-leave
+                                 :rejecting-route    (:id current-route)}
+                          guard-id      (assoc :rejecting-guard guard-id)
+                          url-restored? (assoc :url-restored? true))]
         ;; Per Spec 012 §Navigation blocking §Default flow step 4e: the
         ;; trace marks the blocked transition for tools.
         (trace/emit! :rf.event :rf.route/navigation-blocked
@@ -282,14 +300,35 @@
     ;; with the URL push).
     (let [pending  (get-in db [:rf/runtime :routing :pending-navigation])
           original (:requested-by-event pending)
-          url      (:requested-url pending)]
+          url      (:requested-url pending)
+          ;; rf2-8zvajk: when the block was a popstate that RESTORED the
+          ;; address bar (`:url-restored?`), the resume must re-move the
+          ;; browser URL to `:requested-url` itself — the re-dispatched
+          ;; `[:rf.route/handle-url-change requested-url {:bypass-leave-guard?
+          ;; true}]` (built by `inject-bypass-leave-guard`) rewrites the
+          ;; slice but emits NO history mutation (it assumes the browser
+          ;; already moved). After the restore that assumption is false, so
+          ;; without this the slice commits to `:requested-url` while the
+          ;; address bar stays on the rejecting route. A `:rf.nav/replace-url`
+          ;; (not push) keeps the popstate entry's place in the history stack
+          ;; — confirming a blocked Back/Forward must not grow history.
+          ;; Emitted FIRST so the address bar is correct by the time the
+          ;; bypassed handler synchronously rewrites the slice. Forward-nav
+          ;; resumes (`:url-restored?` absent — no restore happened) re-run
+          ;; the full `:rf/url-requested` policy chain, which pushes on its
+          ;; own; adding a replace there would clobber that push.
+          restore-fx (when (:url-restored? pending)
+                       [:rf.nav/replace-url url])
+          dispatch-fx [:dispatch (if (vector? original)
+                                   (inject-bypass-leave-guard original url)
+                                   [:rf/url-requested {:url url
+                                                       :bypass-leave-guard? true}])]]
       (if (and pending (= pn-id (:id pending)))
         (cond-> {:db (update-in db [:rf/runtime :routing] dissoc :pending-navigation)}
           (or (vector? original) url)
-          (assoc :fx [[:dispatch (if (vector? original)
-                                   (inject-bypass-leave-guard original url)
-                                   [:rf/url-requested {:url url
-                                                       :bypass-leave-guard? true}])]]))
+          (assoc :fx (cond-> []
+                       restore-fx (conj restore-fx)
+                       :always    (conj dispatch-fx))))
         {})))
 
 (defn cancel-handler

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -1063,7 +1063,55 @@
                      (if all-present?
                        (let [[i' parts'] (emit-group (inc i) parts)]
                          (recur i' parts'))
-                       (recur close-end parts)))
+                       ;; rf2-8zvajk: ELIDE the group — and own the
+                       ;; separator-slash elision so a slash-OWNED inline
+                       ;; group (`{:base}?`, body without a leading `/`) does
+                       ;; not orphan a literal `/`. The grammar permits two
+                       ;; optional-group shapes (Spec 012 §Path-pattern grammar
+                       ;; rule 2 + `validate-optional-group!`): the group either
+                       ;; OWNS its leading slash (`{/:id}?` — the `/` is inside
+                       ;; the body, so eliding the body drops it cleanly) or is
+                       ;; SLASH-OWNED INLINE (`{:base}?` — bracketed by LITERAL
+                       ;; `/`s in the surrounding pattern, e.g. `/{:base}?/about`
+                       ;; or `/docs/{:section}?/about`). Spec 012's own
+                       ;; ranking-rule-5 example uses the inline shape
+                       ;; (`/about` beats `/{:base}?/about`), so it is
+                       ;; spec-endorsed and cannot be rejected at registration.
+                       ;; For the inline shape the present form is
+                       ;; `/before/<v>/after`; the absent form must collapse to
+                       ;; `/before/after` (one separator, not two). Without this,
+                       ;; the prior emitter left BOTH literal slashes, producing
+                       ;; `//about` — a PROTOCOL-RELATIVE URL (`route-link` would
+                       ;; render `href="//about"`, a modifier-click escapes the
+                       ;; app; programmatic `pushState` skips/rejects it, so the
+                       ;; route slice and the address bar diverge).
+                       ;;
+                       ;; Rule: the slash BEFORE the elided group is redundant
+                       ;; when the group is followed by a separator `/` (the
+                       ;; trailing slash supplies the join) or when nothing
+                       ;; follows (a dangling trailing `/`). Pop that leading
+                       ;; separator unless it is the lone ROOT slash (so
+                       ;; `/{:base}?` absent stays `/`, never `""`). A
+                       ;; slash-OWNING group (`{/:id}?`) has a NON-slash char
+                       ;; before `{` (`...articles{` → last part `"articles"`),
+                       ;; so the guard is a no-op for it — its existing clean
+                       ;; elision is unchanged. A global `//`→`/` collapse is
+                       ;; deliberately NOT used: a splat value legitimately
+                       ;; carries embedded `//` (`{:rest "a//b"}` → `/files/a//b`)
+                       ;; and must survive.
+                       (let [prev-slash? (= "/" (peek parts))
+                             next-slash? (and (< close-end n)
+                                              (= \/ (.charAt ^String pattern close-end)))
+                             at-end?     (>= close-end n)
+                             ;; the lone root slash has no non-slash part before
+                             ;; it; popping it would emit `""` instead of `/`.
+                             root-only?  (every? #(= "/" %) parts)
+                             parts'      (if (and prev-slash?
+                                                  (or next-slash?
+                                                      (and at-end? (not root-only?))))
+                                           (pop parts)
+                                           parts)]
+                         (recur close-end parts'))))
 
                    ;; `:name` / `*name` in the top-level pattern — the
                    ;; value is REQUIRED; `require-param` throws on absent.

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -625,6 +625,68 @@
       (is (= "/editor/articles/X" (current-url *history-state*))
           "the address bar still shows the editor route (it never moved)"))))
 
+;; ---- rf2-8zvajk: CONTINUE after a blocked popstate re-moves the URL ------
+;;
+;; The block above restored the address bar to the rejecting route's URL via
+;; replaceState. On `:rf.route/continue` the resume re-dispatches the
+;; original `[:rf.route/handle-url-change requested-url {:bypass-leave-guard?
+;; true}]`, which rewrites the slice but emits NO history mutation (it
+;; assumes the browser already moved). After the restore that assumption is
+;; false — so without a fix the slice commits to /cart while the address bar
+;; stays on /editor/articles/X, leaving the visible route and the browser
+;; URL / history entry divergent (refresh, copy-URL, and subsequent
+;; Back/Forward all operate on the stale URL). The fix: a blocked popstate
+;; that restored the URL records `:url-restored?`, and continue replaces the
+;; address bar with `:requested-url` (replaceState — preserving the popstate
+;; entry's place, history length unchanged).
+
+(deftest blocked-popstate-continue-restores-url-cljs
+  (testing "rf2-8zvajk: :rf.route/continue after a blocked popstate moves the
+            address bar to the requested URL — slice and URL agree, no new
+            history entry"
+    (rf/reg-route :hist/cart   {:path "/cart"})
+    (rf/reg-route :hist/editor {:path      "/editor/articles/:id"
+                                :params    [:map [:id :string]]
+                                :can-leave :hist/can-leave?})
+    (rf/reg-event-db :hist/dirty (fn [db [_ v]] (assoc-in db [:editor :dirty?] v)))
+    (rf/reg-sub :hist/can-leave?
+                (fn [db _] (not (boolean (get-in db [:editor :dirty?])))))
+
+    ;; A → B: land on /cart, then push the guarded editor route.
+    (rf/dispatch-sync [:rf/url-requested {:url "/cart"}])
+    (rf/dispatch-sync [:rf/url-requested {:url "/editor/articles/X"}])
+    (rf/dispatch-sync [:hist/dirty true])
+
+    ;; Browser Back to /cart, then dispatch the popstate-style change. The
+    ;; guard blocks; the runtime restores the address bar to the editor URL.
+    (.back (.-history js/globalThis.window))
+    (rf/dispatch-sync [:rf.route/handle-url-change (current-url *history-state*)])
+    (is (= "/editor/articles/X" (current-url *history-state*))
+        "the block restored the address bar to the editor route")
+    (let [pending (get-in (rf/app-db-value :rf/default)
+                          [:rf/runtime :routing :pending-navigation])]
+      (is (some? pending) "pending-nav populated on the blocked popstate")
+      (is (true? (:url-restored? pending))
+          "the pending-nav records that a URL restore was performed")
+
+      ;; The history stack is at 3 entries before continue resolves.
+      (let [entries-before (count (:entries @*history-state*))
+            pn-id          (:id pending)]
+        ;; CONTINUE: resume the rejected Back navigation.
+        (rf/dispatch-sync [:rf.route/continue pn-id])
+
+        (is (nil? (get-in (rf/app-db-value :rf/default)
+                          [:rf/runtime :routing :pending-navigation]))
+            "continue clears the pending-nav slot")
+        (is (= :hist/cart
+               (:id (get-in (rf/app-db-value :rf/default)
+                            [:rf/runtime :routing :current])))
+            "continue committed the slice to the requested /cart route")
+        (is (= "/cart" (current-url *history-state*))
+            "continue moved the address bar to /cart — slice and URL agree")
+        (is (= entries-before (count (:entries @*history-state*)))
+            "the URL move was a replace, not a push — history length unchanged")))))
+
 ;; =========================================================================
 ;; 3. hashchange — fragment-only round-trip
 ;; =========================================================================

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -2773,6 +2773,86 @@
            (routing/route-url :route/articles2 {:id "intro" :slug "welcome"}))
         "all inner params present → group emits")))
 
+;; ---- rf2-8zvajk: slash-OWNED INLINE optional group ({:base}?) ------------
+;;
+;; The grammar permits TWO optional-group shapes (Spec 012 §Path-pattern
+;; grammar rule 2 + `validate-optional-group!`): the group either OWNS its
+;; leading slash (`{/:id}?` — exercised by `route-url-optional-group-elision`
+;; above) or is SLASH-OWNED INLINE (`{:base}?` — bracketed by LITERAL `/`s
+;; in the surrounding pattern). Spec 012's own ranking-rule-5 example uses
+;; the inline shape — "`/about` beats `/{:base}?/about` for `/about`" — so it
+;; is spec-endorsed and cannot be rejected at registration.
+;;
+;; Pre-fix the emitter elided only the group body, leaving BOTH bracketing
+;; slashes, so absent params produced a DOUBLE slash: `//about` (a
+;; PROTOCOL-RELATIVE / external-looking URL — `route-link` renders
+;; `href="//about"`, a modifier-click escapes the app, and programmatic
+;; `pushState` skips it so slice and address bar diverge). The emitter now
+;; owns separator elision so an absent inline group collapses to a single
+;; separator and the URL round-trips through `match-url` without `//`.
+
+(deftest route-url-inline-optional-group-no-double-slash
+  (testing "rf2-8zvajk: a slash-OWNED inline optional group ({:base}?) emits
+            a single separator when absent — never `//`"
+    (rf/reg-route :route/inline-about {:path "/{:base}?/about"})
+    (is (= "/about"
+           (routing/route-url :route/inline-about {}))
+        "absent :base → single leading separator, NOT the protocol-relative `//about`")
+    (is (= "/docs/about"
+           (routing/route-url :route/inline-about {:base "docs"}))
+        "present :base → /docs/about")
+    (is (not (clojure.string/includes? (subs (routing/route-url :route/inline-about {}) 1) "//"))
+        "no protocol-relative double slash anywhere in the absent emission")
+    ;; Round-trip: emitted absent URL re-parses to the same route, no params.
+    (let [m (routing/match-url (routing/route-url :route/inline-about {}))]
+      (is (= :route/inline-about (:route-id m))
+          "absent emission round-trips through match-url to the same route")
+      (is (= {} (:params m))
+          "no :base param survives the round-trip")))
+
+  (testing "rf2-8zvajk: a MID-PATH inline optional group (/docs/{:section}?/about)
+            collapses the orphaned separator on both sides"
+    (rf/reg-route :route/docs-about {:path "/docs/{:section}?/about"})
+    (is (= "/docs/about"
+           (routing/route-url :route/docs-about {}))
+        "absent :section → /docs/about, NOT /docs//about")
+    (is (= "/docs/api/about"
+           (routing/route-url :route/docs-about {:section "api"}))
+        "present :section → /docs/api/about"))
+
+  (testing "rf2-8zvajk: a TRAILING inline optional group (/articles/{:id}?)
+            does not leave a dangling slash"
+    (rf/reg-route :route/articles-id {:path "/articles/{:id}?"})
+    (is (= "/articles"
+           (routing/route-url :route/articles-id {}))
+        "absent :id → /articles, NOT the dangling /articles/")
+    (is (= "/articles/5"
+           (routing/route-url :route/articles-id {:id "5"}))
+        "present :id → /articles/5"))
+
+  (testing "rf2-8zvajk: a ROOT-only inline optional group (/{:base}?) stays `/`
+            when absent — the lone root slash is never popped"
+    (rf/reg-route :route/root-base {:path "/{:base}?"})
+    (is (= "/"
+           (routing/route-url :route/root-base {}))
+        "absent :base → root `/`, never the empty string")
+    (is (= "/x"
+           (routing/route-url :route/root-base {:base "x"}))
+        "present :base → /x"))
+
+  (testing "rf2-8zvajk: the slash-OWNING form ({/:id}?) is UNCHANGED — its
+            leading slash lives inside the group body and elides cleanly"
+    (rf/reg-route :route/owning {:path "/articles{/:id}?"})
+    (is (= "/articles" (routing/route-url :route/owning {})))
+    (is (= "/articles/5" (routing/route-url :route/owning {:id "5"}))))
+
+  (testing "rf2-8zvajk: a splat value carrying embedded `//` is PRESERVED —
+            the fix collapses elision separators, NOT every `//` globally"
+    (rf/reg-route :route/files {:path "/files/*rest"})
+    (is (= "/files/a//b"
+           (routing/route-url :route/files {:rest "a//b"}))
+        "an embedded double slash inside a splat value survives untouched")))
+
 ;; ---- T4b: match-url optional-group param is ABSENT, not nil-valued ------
 ;;
 ;; Regression for rf2-yejde. Per Spec 012 §Path-pattern grammar (Optional


### PR DESCRIPTION
Independent correctness review of `implementation/routing` (rf2-8zvajk). Both findings confirmed at the REPL against current source, deduped against the merged rf2-w3qgc routing work and the senior-review bead rf2-8xvyo.

## Per-finding disposition

### Finding 1 — `route-url` orphans a separator slash for slash-owned inline optional groups (`registry.cljc`) — FIXED
The grammar permits two optional-group shapes: the group OWNS its leading slash (`{/:id}?`, slash inside the body) or is SLASH-OWNED INLINE (`{:base}?`, bracketed by literal `/`s, e.g. `/{:base}?/about`). Spec 012's ranking rule-5 example uses the inline form (`/about` beats `/{:base}?/about`), so it is spec-endorsed and **cannot** be rejected at registration — the emitter must own separator elision (the bead's option 2).

Confirmed pre-fix behaviour:
- `/{:base}?/about` absent → `//about` (protocol-relative — `route-link` renders `href="//about"`, modifier-click escapes the app; `pushState` skips it so slice ↔ address bar diverge)
- `/docs/{:section}?/about` absent → `/docs//about`

Fix: when eliding an inline group, pop the redundant leading separator slash when a trailing `/` (or end-of-pattern) supplies the join — never the lone root slash, and never via a global `//`→`/` collapse (splat values carrying embedded `//` must survive).

Post-fix (verified): `/{:base}?/about`→`/about`, `/docs/{:section}?/about`→`/docs/about`, `/articles/{:id}?`→`/articles`, `/{:base}?`→`/`, `{/:id}?` form unchanged, splat `{:rest "a//b"}`→`/files/a//b`. Present forms unchanged. Absent emissions round-trip through `match-url` with no `//`.

JVM coverage added (`route-url-inline-optional-group-no-double-slash`): absent/present for inline, mid-path, trailing, root-only, slash-owning, and splat-preservation cases.

**Dedupe:** Distinct from rf2-8xvyo (empty-string params inside optional groups). The merged rf2-w3qgc work (nil-query elision, fail-closed non-string URLs, frame tags) does not touch optional-group separator elision.

### Finding 2 — `:rf.route/continue` after a blocked popstate leaves slice ↔ URL divergent (`can_leave.cljc`) — FIXED
A blocked popstate restores the address bar to the rejecting route via `:rf.nav/replace-url`. On `:rf.route/continue` the resume re-dispatches the bypassed `:rf.route/handle-url-change`, which rewrites the slice but emits no history mutation (it assumes the browser already moved — false after the restore). Result: slice commits to the requested route, address bar stays on the rejecting route.

Fix: `maybe-block-navigation` records `:url-restored? true` on the pending-nav when (and only when) a popstate restore occurred; `continue-handler` then emits `:rf.nav/replace-url :requested-url` (replace, not push — history length unchanged) ahead of the bypassed slice rewrite. Forward-nav blocks (no restore, flag absent) re-run the full `:rf/url-requested` policy chain that pushes on its own — untouched.

CLJS coverage added (`blocked-popstate-continue-restores-url-cljs`): after a blocked Back, continue clears pending-nav, moves the slice to `/cart`, sets `current-url` to `/cart`, and leaves history length unchanged.

**Dedupe:** No existing bead; existing tests covered blocked-popstate restore + cancel, but not continue.

## Quality gates
- `cd implementation/routing && clojure -M:test` → **159 tests, 770 assertions, 0 failures, 0 errors** (was 158/756 — +1 test, +14 assertions for the new JVM test)
- `cd implementation && npm run test:cljs` → **5855 tests, 20757 assertions, 0 failures, 0 errors** (includes the new CLJS continue test)
- SSR/route-link route-link gate: `route_link_test.clj` + `routing_test.clj` (route-link SSR render through `route-url`) are in the routing JVM suite above — green. No dedicated `test:ssr-route-link` npm script exists; route-link SSR coverage rides the JVM + CLJS suites.

Closes rf2-8zvajk.