### PR TITLE
fix(security): independent-review findings (rf2-gj2ae)

### DIFF
--- a/implementation/security/deps.edn
+++ b/implementation/security/deps.edn
@@ -1,0 +1,87 @@
+;; re-frame2 adversarial-property SECURITY tier (rf2-3cfvt).
+;;
+;; This is NOT a published Maven artefact — it has no `src/`. It is a
+;; cross-artefact TEST surface that probes the security boundaries the
+;; pin-and-assert regime missed: SSR escaping (rf2-1uex4), schema
+;; redaction nested at arbitrary depth (rf2-g5auo), AI/MCP-boundary
+;; egress redaction (rf2-6wvh5), the fail-closed validation/redaction
+;; invariants (rf2-ih7g4 / rf2-el9sw), and the deterministic generator's
+;; cross-runtime byte-parity (rf2-h2yvs). The namespaces sit ABOVE several
+;; artefacts (core, schemas, machines, routing, flows, ssr) + a tool
+;; (mcp-base), so they live in their own top-level `security/` surface
+;; rather than any single artefact's test tree.
+;;
+;; ## Why this deps.edn exists (rf2-gj2ae)
+;;
+;; The security namespaces are `.cljc` and advertise a cross-runtime
+;; contract — e.g. `re-frame.security.gen`'s LCG is "byte-deterministic
+;; AND identical across JVM + JS" with separate `:clj` (full-precision
+;; `long` multiply) and `:cljs` (`Math.imul`) arithmetic, and
+;; `gen-parity-security-cljs-test` pins the JVM reference sequences and
+;; states it "runs in BOTH runtimes". Before this alias the ONLY named
+;; security runner was the CLJS-side `npm run test:security` (shadow
+;; `:node-test-security`) plus the always-on `:node-test` gate; the JVM
+;; side had no wiring at all — the top-level `implementation/deps.edn`
+;; `:test` alias (ad-hoc REPL convenience) omits `security/test` and
+;; `../tools/mcp-base/src`, and the canonical per-artefact JVM gate
+;; (`scripts/test-jvm-implementation.sh`) iterates each artefact's own
+;; `:test` alias, of which `security/` had none. So the `:clj` reader-
+;; conditional arms of the security tier — `gen.cljc`'s full-precision
+;; multiply, the `:clj`/`:cljs` egress/redaction helper branches, the
+;; `clojure.walk` deep-scan — were NEVER executed on the JVM. That is a
+;; false-green cross-runtime security contract: the `:clj` arithmetic
+;; could regress (e.g. drop the `long` coercion, reintroducing the
+;; 53-bit-mantissa divergence on a hypothetical JVM consumer of `gen`)
+;; while the tier stayed green on CLJS. This alias closes the gap: it
+;; runs the SAME `.cljc` namespaces under the JVM, so a divergence
+;; between the two reader-conditional arms now goes RED on the JVM gate.
+;;
+;; ## Why test-only deps, not :local/root in :deps
+;;
+;; This artefact ships nothing, so the top-level `:deps` is empty. The
+;; cross-artefact source the test namespaces `:require`
+;; (`re-frame.core`, `re-frame.schemas[.malli]`, `re-frame.machines.*`,
+;; `re-frame.routing.*`, `re-frame.flows`, `re-frame.ssr.*`, and the
+;; spec/009 §Privacy filter `re-frame.mcp-base.sensitive`) is pulled in
+;; under the `:test` alias only. `:extra-paths` is JUST `["test"]` so the
+;; cognitect test-runner scans ONLY the security test dir — the artefact
+;; `:local/root` deps contribute their `src` (never their `:test`), so no
+;; other artefact's tests run here.
+;;
+;; ## Bundle isolation (tools/README.md)
+;;
+;; The dependency arrow flows tool → implementation, never the reverse.
+;; The `tools/mcp-base` dep below is TEST-ONLY (this artefact has no
+;; production `src/` and ships no jar), and `re-frame.mcp-base.sensitive`
+;; is a framework-agnostic `.cljc` shape with no `:local/root` dep on
+;; `implementation/`. It mirrors the existing precedent in the top-level
+;; `implementation/shadow-cljs.edn`, whose cross-artefact `:node-test`
+;; classpath already lists `../tools/mcp-base/src` for exactly these
+;; egress tests. Nothing under `implementation/` `:require`s it from a
+;; production source path, so no production bundle is widened.
+{:paths []
+ :deps  {}
+
+ :aliases
+ {:test
+  {:extra-paths ["test"]
+   ;; Artefacts whose namespaces the security tests `:require`. core
+   ;; carries `re-frame.test-support` + `re-frame.marks` +
+   ;; `re-frame.subs` + `re-frame.trace.tooling`; schemas brings
+   ;; metosin/malli transitively (so `re-frame.schemas.malli` resolves);
+   ;; machines/routing/flows/ssr supply their feature namespaces.
+   :extra-deps  {day8/re-frame2          {:local/root "../core"}
+                 day8/re-frame2-schemas  {:local/root "../schemas"}
+                 day8/re-frame2-machines {:local/root "../machines"}
+                 day8/re-frame2-routing  {:local/root "../routing"}
+                 day8/re-frame2-flows    {:local/root "../flows"}
+                 day8/re-frame2-ssr      {:local/root "../ssr"}
+                 ;; spec/009 §Privacy default-suppress egress filter
+                 ;; (`re-frame.mcp-base.sensitive`). TEST-ONLY tool dep —
+                 ;; see the bundle-isolation note above.
+                 day8/re-frame2-mcp-base {:local/root "../../tools/mcp-base"}
+                 ;; rf2-try1x — silent-on-success reporter.
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                 io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/scripts/test-jvm-implementation.sh
+++ b/scripts/test-jvm-implementation.sh
@@ -18,6 +18,15 @@ artefacts=(
   implementation/ssr
   implementation/ssr-ring
   implementation/epoch
+  # rf2-gj2ae — the adversarial-property security tier is `.cljc` and
+  # advertises a cross-runtime contract (e.g. `re-frame.security.gen`'s
+  # JVM `:clj` `long`-multiply vs the CLJS `Math.imul` arm, pinned by
+  # `gen-parity-security-cljs-test`). Its own `:test` alias
+  # (implementation/security/deps.edn) runs the SAME `.cljc` namespaces
+  # under the JVM so a divergence between the two reader-conditional arms
+  # goes RED here — previously only the CLJS side (`npm run test:security`
+  # + the always-on `:node-test` gate) ever exercised the tier.
+  implementation/security
 )
 
 for artefact in "${artefacts[@]}"; do


### PR DESCRIPTION
Closes the single independent-correctness-review finding for `implementation/security` (rf2-gj2ae). Deduped against the merged rf2-h2yvs (deep-sentinel scan + LCG determinism) and rf2-cv165 (ontouch* SSR allowlist) — neither covers this JVM test-wiring gap.

## Finding & disposition

**Finding 1 (high confidence) — false-green cross-runtime security coverage: the JVM never ran the security tier.** ACTIONED.

The adversarial-property security tier (`implementation/security/`) is `.cljc` and advertises a cross-runtime contract — most sharply `re-frame.security.gen`, whose 32-bit LCG carries a `:clj` full-precision `long` multiply and a `:cljs` `Math.imul` arm, with `gen-parity-security-cljs-test` pinning the JVM reference sequences and stating it "runs in BOTH runtimes". But the tier had **no JVM wiring**:

- The only named runner was the CLJS `npm run test:security` (shadow `:node-test-security`) plus the always-on `:node-test` gate.
- The top-level `implementation/deps.edn` `:test` alias (ad-hoc REPL convenience) omits `security/test` and `../tools/mcp-base/src` — verified via `clojure -Spath -M:test`: `core/test` present, `security/test` + `mcp-base` absent.
- The canonical per-artefact JVM gate (`scripts/test-jvm-implementation.sh`) iterates each artefact's own `:test` alias; `security/` had **no `deps.edn` at all** (only a `test/` dir).

So every `:clj` reader-conditional arm of the tier — `gen.cljc`'s full-precision multiply, the egress/redaction `:clj` branches, the `clojure.walk` deep-scan — was never executed on the JVM. The `:clj` arithmetic could regress (e.g. drop the `long` coercion, reintroducing the 53-bit-mantissa divergence on a JVM consumer of `gen`) while the tier stayed green on CLJS.

### Fix
- **`implementation/security/deps.edn`** (new): a `:test` alias that runs the SAME `.cljc` namespaces under the JVM. `:extra-paths` is just `["test"]` so the cognitect runner scans only the security test dir; the cross-artefact sources the tests `:require` (core, schemas, machines, routing, flows, ssr, and the spec/009 §Privacy filter `re-frame.mcp-base.sensitive`) come in as test-only `:local/root` deps.
  - **Bundle isolation:** the `tools/mcp-base` dep is **test-only** — this artefact has no production `src/` and ships no jar — and `re-frame.mcp-base.sensitive` is a framework-agnostic `.cljc` shape with no `:local/root` on `implementation/`. It mirrors the existing `implementation/shadow-cljs.edn` precedent that already lists `../tools/mcp-base/src` on the cross-artefact `:node-test` classpath for exactly these egress tests. No production bundle is widened; the tool→implementation arrow is unviolated (this is impl-test → tool, in a non-shipping artefact).
- **`scripts/test-jvm-implementation.sh`**: add `implementation/security` to the canonical local/rigorous JVM artefact loop so the alias is actually exercised.

### Deferred (hot-zone, sequential) → rf2-oni7gz
`.github/workflows/test.yml` has a per-artefact JVM job for every other artefact but none for security. Adding a `JVM security` CI job is a hot-zone (`.github/workflows/*`) edit that must be sequenced, so it is filed as follow-up **rf2-oni7gz** rather than bundled here. The deps.edn + rigorous-script wiring already deliver the runnable, gated JVM alias the finding's acceptance test specifies.

## Quality gates

All run from the worker worktree `C:/Users/miket/code/re-frame2-worktrees/security-indep-gj2ae`.

| Gate | Result |
|------|--------|
| `cd implementation/security && clojure -M:test` (JVM, NEW) | **56 tests / 452 assertions / 0 failures / 0 errors** — requires + runs `gen-parity-security-cljs-test` AND the MCP egress ns |
| `cd implementation && npm run test:security` (CLJS) | **56 tests / 452 assertions / 0 failures** (same suite, both runtimes now) |
| `cd implementation && npm run test:cljs` (full node gate) | **5854 tests / 20750 assertions / 0 failures / 0 errors** |

### Verify-by-injection (acceptance, non-vacuity)
- Removing `"test"` from `:extra-paths` → command **FAILS** (exit 1, `FileNotFoundException` locating the security test namespaces). The gate is non-vacuous.
- Injecting a `:clj`-only multiplier divergence into `next-state` → `next-int-sequence-is-cross-runtime-deterministic` goes **RED on the JVM** (2 failures, exit 1). Proves the JVM gate exercises the `:clj` arithmetic — the exact gap the finding identified. `gen.cljc` restored byte-identical afterward.

bd: closes rf2-gj2ae; follow-up rf2-oni7gz.