### PR TITLE
fix(ssr): independent-review findings (rf2-58zvy1)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -206,6 +206,26 @@
 (defn- emit-children [children]
   (clojure.string/join (mapv emit-element children)))
 
+(defn- emit-children-threading-root-attrs
+  "Emit `children`, threading `root-attrs` (per rf2-lxwse) onto the FIRST
+  child only (nil to the rest), so the render-hash / source-coord lands
+  exactly once on the first DOM-tag element reachable through a fragment
+  root. A fragment whose first child is itself a fragment / fn-head /
+  view-ref recurses — `emit-element` keeps threading the same root-attrs
+  down its own root path until a DOM tag consumes it. When `root-attrs`
+  is nil this is identical to `emit-children`. Per rf2-58zvy1 finding 2 —
+  the `:<>` branch previously dropped root-attrs via plain `emit-children`,
+  so a fragment-rooted SSR tree lost the `data-rf-render-hash` marker the
+  emitter docstring promises."
+  [children root-attrs]
+  (if (nil? root-attrs)
+    (emit-children children)
+    (let [v (vec children)]
+      (clojure.string/join
+        (map-indexed (fn [i child]
+                       (emit-element child (when (zero? i) root-attrs)))
+                     v)))))
+
 ;; ---- source-coord annotation on registered-view roots --------------------
 ;;
 ;; Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) and
@@ -333,12 +353,21 @@
      (let [head (first el)]
        (cond
          ;; Fragment `:<>` — emits its rendered children with no wrapper.
-         ;; Per Spec 011: root-attrs (rf2-lxwse) skip this head, source-
-         ;; coord annotation skips it, and the tag-name validator
-         ;; (rf2-z7gor) does not apply. Handled ahead of the general
-         ;; keyword branch so it never reaches `parse-tag-name`.
+         ;; Per Spec 011: source-coord annotation skips this head (the
+         ;; fragment itself is not a DOM element), and the tag-name
+         ;; validator (rf2-z7gor) does not apply. Handled ahead of the
+         ;; general keyword branch so it never reaches `parse-tag-name`.
+         ;;
+         ;; rf2-58zvy1 finding 2 — root-attrs (rf2-lxwse, the render-hash
+         ;; / `:render-hash` marker) MUST thread through a fragment root
+         ;; onto the first DOM-tag child, exactly once. The prior plain
+         ;; `emit-children` dropped them, so `[:<> [:div "x"]]` with
+         ;; `{:emit-hash? true}` lost its `data-rf-render-hash` even though
+         ;; the docstring promises threading "past … fragments". Thread
+         ;; onto the first child only; nested fragments / fn-heads /
+         ;; view-refs keep threading down their own root path.
          (= :<> head)
-         (emit-children (rest el))
+         (emit-children-threading-root-attrs (rest el) root-attrs)
 
          ;; Reagent-native interop head `:>` — `[:> Component {props} …]`
          ;; passes its children through to a React COMPONENT, not a DOM

--- a/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
+++ b/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
@@ -270,29 +270,68 @@
   observability without a 500 (Spec 011 §Failure semantics — inline
   fallback).
 
-  `seen` is an atom of the id-strings already processed so a chunk is
-  applied at most once even if the observer fires twice for the same
-  node (defensive — MutationObserver batching + the initial sweep can
-  both surface the same node). Idempotent."
+  `seen` is an atom of the id-strings already SUCCESSFULLY processed so a
+  chunk is applied at most once even if the observer fires twice for the
+  same node (defensive — MutationObserver batching + the initial sweep
+  can both surface the same node). Idempotent.
+
+  rf2-58zvy1 finding 4 — an id is marked `seen` ONLY after a successful
+  swap, and the swapped-in content is re-scanned for fallback templates
+  before later resolved templates are processed. Two coupled corners for
+  a NESTED boundary whose inner chunk is ALREADY present when the client
+  installs late:
+
+    1. The inner fallback `<template>` lives INSIDE the outer resolved
+       `<template>`'s content, so the one-shot `materialise-fallbacks!`
+       at sweep start cannot see it (it is still inert template content,
+       not live DOM). It only enters the live tree when the outer mount
+       is swapped. If we processed the (already-present) inner resolved
+       chunk before its mount existed, `replace-mount-content!` would
+       return false. Previously the id was marked seen FIRST, so that
+       failed inner swap was skipped permanently and no later sweep could
+       recover it → the nested boundary stuck on fallback forever.
+       Fix: after a successful outer swap, immediately materialise any
+       fallbacks the new content introduced, so the inner mount exists
+       before the inner resolved template is processed later in the
+       SAME `doseq`.
+    2. Mark `seen` only on a successful swap. A resolved template whose
+       mount does not exist yet (raced ahead of its fallback) stays
+       un-`seen` and is retried on the next sweep instead of being burned.
+       Idempotency is still guaranteed: a successful swap REMOVES the
+       resolved template node (`replace-mount-content!`), so a re-fire
+       cannot re-process it even before consulting `seen`.
+
+  Returns `true` when this call made PROGRESS (a swap happened, or a
+  failed-boundary fallback was applied) so the sweep can iterate to a
+  fixpoint — a nested inner chunk whose mount only appeared after the
+  outer swap is recovered within the same sweep even when document order
+  put the inner resolved template before the outer one."
   [root frame-id seen resolved-tmpl]
   (let [id-str  (.getAttribute resolved-tmpl attr-suspense-id)
         failed? (= "1" (.getAttribute resolved-tmpl attr-suspense-failed))]
-    (when (and id-str (not (contains? @seen id-str)))
-      (swap! seen conj id-str)
-      ;; Ensure a live mount exists even if the fallback template was not
-      ;; materialised yet (a resolved chunk that raced ahead of its own
-      ;; fallback in the same observer batch) — materialise-fallbacks!
-      ;; runs first in the sweep, so this is the belt-and-braces path.
+    (if (and id-str (not (contains? @seen id-str)))
       (let [swapped? (replace-mount-content! root id-str resolved-tmpl)]
-        (if failed?
+        (when swapped?
+          ;; Mark seen ONLY on success — an unresolved mount is retryable
+          ;; on the next pass rather than permanently skipped (finding 4).
+          (swap! seen conj id-str)
+          ;; The just-swapped content may carry NESTED fallback templates
+          ;; that were inert inside the resolved <template> and are now
+          ;; live DOM. Materialise them so a nested resolved chunk found
+          ;; later in this same sweep has a mount to swap into (finding 4).
+          (materialise-fallbacks! root))
+        (cond
+          failed?
           (trace/emit-error! :rf.ssr/suspense-boundary-failed
                              {:id        (read-boundary-id id-str)
                               :frame     frame-id
                               :where     'rf.ssr/streaming-client
                               :reason    "Server-side continuation render failed; client swapped the fallback HTML, no delta applied."
                               :recovery  :inline-fallback})
-          (when swapped?
-            (apply-delta-script! root frame-id id-str)))))))
+          swapped?
+          (apply-delta-script! root frame-id id-str))
+        (boolean swapped?))
+      false)))
 
 (defn- sweep!
   "One full sweep: materialise any un-mounted fallback `<template>`s into
@@ -300,19 +339,63 @@
   `<template>` (swap + delta-merge). Called once on install (chunks that
   streamed in before the bundle ran) and again whenever the observer
   reports new nodes. Fallback materialisation runs FIRST so a resolved
-  chunk in the same batch always finds a live mount to swap into."
+  chunk in the same batch always finds a live mount to swap into.
+
+  rf2-58zvy1 finding 4 — the resolved-processing pass iterates to a
+  FIXPOINT. A nested boundary whose inner resolved chunk is already in
+  the DOM when the client installs late only gets its live mount AFTER
+  the outer mount is swapped (the inner fallback was inert template
+  content inside the outer resolved <template>). A single document-order
+  pass can therefore visit the inner resolved template before its mount
+  exists; gating `seen` on success (above) keeps it retryable, and this
+  loop re-runs the pass while any swap is still making progress, so the
+  inner chunk lands within the same sweep instead of being stranded on
+  fallback until the final payload. The loop terminates because every
+  iteration that continues swapped at least one boundary (monotone:
+  boundaries only move resolved-ward, never back), and the total boundary
+  count is finite."
   [root frame-id seen]
   (materialise-fallbacks! root)
-  (doseq [t (query-by-attr root attr-suspense-resolved)]
-    (process-resolved-template! root frame-id seen t)))
+  (loop []
+    (let [progress? (reduce (fn [acc t]
+                              (or (process-resolved-template! root frame-id seen t)
+                                  acc))
+                            false
+                            (query-by-attr root attr-suspense-resolved))]
+      (when progress?
+        (recur)))))
+
+(defn- element-by-id
+  "Find an element with id `id` under `root` WITHOUT building a raw `#id`
+  CSS selector. Per rf2-58zvy1 finding 3 — a `:payload-id` override that
+  is a VALID HTML id but contains CSS-selector-significant chars (`.`,
+  `:`, `[`, space, …) makes `(.querySelector root (str \"#\" id))` either
+  select the wrong element or throw a `SyntaxError`, breaking `install!`.
+  HTML ids are matched by exact string, not by CSS grammar, so:
+
+    - Document / DocumentFragment roots have native `getElementById`
+      (the same exact-string lookup the DOM-read bootstrap uses) — use it.
+    - Element roots have no `getElementById`; scan `[id]`-bearing
+      descendants and compare `.id` exactly. `[id]` (presence) is a
+      structurally-fixed selector — it never embeds the user-supplied id —
+      so it cannot be poisoned by a CSS-special payload-id."
+  [root id]
+  (if (some? (.-getElementById root))
+    (.getElementById root id)
+    (->> (array-seq (.querySelectorAll root "[id]"))
+         (some #(when (= id (.-id %)) %)))))
 
 (defn- final-payload-present?
   "True once the canonical `__rf_payload` `<script>` has parsed into the
   DOM — the signal that streaming is complete and the observer should
   disconnect (the final `:rf/hydrate` is the reconciliation point;
-  deltas after it would race the canonical replace)."
+  deltas after it would race the canonical replace).
+
+  Per rf2-58zvy1 finding 3 — matches the payload by EXACT id string via
+  `element-by-id`, never a raw `#id` CSS selector, so a documented
+  `:payload-id` override with CSS-special chars cannot throw or mis-match."
   [root payload-id]
-  (some? (.querySelector root (str "#" payload-id))))
+  (some? (element-by-id root payload-id)))
 
 ;; ---- public surface --------------------------------------------------------
 

--- a/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
@@ -304,6 +304,111 @@
             (trace-tooling/unregister-listener! k)
             (remove-root! host)))))))
 
+(deftest css-special-payload-id-does-not-throw
+  (testing "rf2-58zvy1 finding 3 — a documented :payload-id override that is
+            a VALID HTML id but carries CSS-selector-significant chars
+            (`.`, `:`) must not make install! throw or mis-detect the
+            final payload. The prior `(.querySelector root (str \"#\" id))`
+            built a raw CSS selector, so `#rf:payload` / `#rf.payload`
+            either threw a SyntaxError or selected the wrong element.
+            install! now matches by exact id (getElementById on a Document
+            root / id-scan on an element root)."
+    (if-not (browser?)
+      (is true ":node-test: no DOM")
+      (doseq [pid ["rf:payload" "rf.payload" "rf payload" "rf[0]"]]
+        (let [fid  (make-client-frame!)
+              host (make-root! [:card.x])]
+          (try
+            ;; A resolved chunk AND a final payload using the CSS-special id
+            ;; are already present — the stream-complete case for a custom
+            ;; shell. install! must sweep the chunk and DETECT completion
+            ;; without throwing on the selector.
+            (append-chunk!
+              host
+              (resolved-chunk-html :card.x
+                                   "<div class=\"card resolved-x\">x</div>"
+                                   {:cards {:x {:value 1}}}))
+            ;; Append a final-payload script carrying the CSS-special id.
+            (append-chunk!
+              host
+              (str "<script id=\"" pid "\" type=\"application/edn\">"
+                   "{:rf/version 1 :rf/app-db {} :rf/render-hash \"00000000\"}"
+                   "</script>"))
+            (let [stop! (streaming-client/install! {:frame fid :root host :payload-id pid})]
+              (try
+                ;; No throw is the headline assertion; the chunk still
+                ;; swapped (the sweep ran before completion-detection).
+                (is (= 1 (card-count host "resolved-x"))
+                    (str "chunk swapped despite CSS-special payload-id " (pr-str pid)))
+                (is (= 1 (:value @(rf/subscribe fid [:sct/card :x])))
+                    "delta merged")
+                (finally (stop!))))
+            (finally (remove-root! host))))))))
+
+(deftest nested-resolved-chunks-recover-on-late-install
+  (testing "rf2-58zvy1 finding 4 — when an OUTER and a NESTED INNER resolved
+            chunk are both already in the DOM at install (a late-loading
+            client), and the outer resolved HTML contains the inner
+            FALLBACK template, install! must leave BOTH outer and inner
+            content live with the inner delta merged. The prior code marked
+            the inner id seen BEFORE its mount existed (the inner mount only
+            appears once the outer swap moves the inner fallback into live
+            DOM), so the inner swap failed and was skipped permanently —
+            the nested boundary stuck on fallback. The sweep now marks seen
+            only on a successful swap, re-materialises fallbacks introduced
+            by a swap, and iterates to a fixpoint."
+    (if-not (browser?)
+      (is true ":node-test: no DOM")
+      (let [fid  (make-client-frame!)
+            ;; Only the OUTER boundary has an inline shell fallback. The
+            ;; INNER boundary's fallback lives INSIDE the outer resolved
+            ;; chunk's HTML — it is inert template content until the outer
+            ;; mount swaps, exactly the nested wire shape.
+            host (make-root! [:card.outer])
+            ;; The outer resolved content embeds the inner fallback template.
+            inner-fallback (ssr/streaming-fallback-template
+                             :card.inner "<div class=\"card skeleton inner-skel\">loading inner</div>")
+            outer-resolved-html (str "<section class=\"card resolved-outer\">outer "
+                                     inner-fallback "</section>")]
+        (try
+          ;; Both chunks already present at install, NO final payload.
+          ;; Append inner FIRST so document order puts the inner resolved
+          ;; template before the outer one — the worst case for a single
+          ;; document-order pass (inner processed before its mount exists).
+          ;; Per the server contract each delta ships the FULL after-value
+          ;; for the changed top-level key (`:cards`), so the client's
+          ;; top-level `(into existing delta)` merge is lossless regardless
+          ;; of which delta the fixpoint applies last (Spec 011 §Hydration
+          ;; interleaving — same property the lossless-across-chunks test
+          ;; pins). Using distinct nested values for outer/inner here proves
+          ;; BOTH nested boundaries hydrated, not just one.
+          (append-chunk!
+            host
+            (resolved-chunk-html :card.inner
+                                 "<div class=\"card resolved-inner\">inner 99</div>"
+                                 {:cards {:outer {:value 7} :inner {:value 99}}}))
+          (append-chunk!
+            host
+            (resolved-chunk-html :card.outer
+                                 outer-resolved-html
+                                 {:cards {:outer {:value 7} :inner {:value 99}}}))
+          (is (nil? (.querySelector host "#__rf_payload"))
+              "no final payload — recovery is purely the sweep's doing")
+          (let [stop! (streaming-client/install! {:frame fid :root host})]
+            (try
+              (is (= 1 (card-count host "resolved-outer"))
+                  "outer resolved content is live")
+              (is (= 1 (card-count host "resolved-inner"))
+                  "inner resolved content is live — the nested boundary recovered")
+              (is (= 0 (card-count host "inner-skel"))
+                  "the inner skeleton fallback was replaced, not stranded")
+              (is (= 7 (:value @(rf/subscribe fid [:sct/card :outer])))
+                  "outer delta merged")
+              (is (= 99 (:value @(rf/subscribe fid [:sct/card :inner])))
+                  "inner delta merged — progressive hydration of the nested boundary")
+              (finally (stop!))))
+          (finally (remove-root! host)))))))
+
 (deftest async-observer-applies-late-chunk
   (testing "A resolved chunk that arrives AFTER install (the observer-driven
             path) is swapped + merged too. Proves the MutationObserver

--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -400,6 +400,37 @@
     (is (= "<p>a</p><p>b</p>"
            (emit/render-to-string [:<> [:p "a"] [:p "b"]] {})))))
 
+(deftest render-hash-threads-through-fragment-root
+  (testing "rf2-58zvy1 finding 2 — root-attrs (the render-hash marker)
+            thread through a `:<>` fragment ROOT onto the first DOM-tag
+            child exactly once. The prior plain `emit-children` on the
+            fragment branch dropped root-attrs, so a fragment-rooted SSR
+            tree lost the `data-rf-render-hash` the emitter docstring
+            promises (and that the emitter/Ring hash contract depends on)."
+    (testing ":emit-hash? lands data-rf-render-hash on the fragment's first child"
+      (is (re-matches #"<div data-rf-render-hash=\"[0-9a-f]+\">x</div>"
+                      (emit/render-to-string [:<> [:div "x"]] {:emit-hash? true}))
+          "single-child fragment root gets the marker on the div"))
+    (testing "the marker lands on the FIRST DOM child only, not every child"
+      (let [html (emit/render-to-string [:<> [:div "a"] [:div "b"]] {:emit-hash? true})]
+        (is (re-matches #"<div data-rf-render-hash=\"[0-9a-f]+\">a</div><div>b</div>"
+                        html)
+            (str "exactly one data-rf-render-hash, on the first div; got: " html))
+        (is (= 1 (count (re-seq #"data-rf-render-hash=" html)))
+            "marker appears exactly once across the fragment's children")))
+    (testing "an explicit :render-hash threads through the fragment root"
+      (is (= "<div data-rf-render-hash=\"deadbeef\">x</div>"
+             (emit/render-to-string [:<> [:div "x"]] {:render-hash "deadbeef"}))
+          "the supplied hash drives the root-attr marker through the fragment"))
+    (testing "nested fragments keep threading the marker down to the first DOM tag"
+      (is (re-matches #"<div data-rf-render-hash=\"[0-9a-f]+\">y</div>"
+                      (emit/render-to-string [:<> [:<> [:div "y"]]] {:emit-hash? true}))
+          "a fragment whose first child is a fragment still places the marker"))
+    (testing "no opts → no marker (fragment branch unchanged when root-attrs nil)"
+      (is (= "<div>x</div>"
+             (emit/render-to-string [:<> [:div "x"]] {}))
+          "without :emit-hash?/:render-hash the fragment root emits no marker"))))
+
 ;; ===========================================================================
 ;; rf2-bee5i — :rf/suspense-boundary is a streaming-only marker. The standard
 ;; emitter must REJECT it (fail loud, parallel to :>) rather than emit a


### PR DESCRIPTION
Independent correctness review of `implementation/ssr` — rf2-58zvy1 (4 findings). All edits confined to `implementation/ssr/**`. Deduped against rf2-hzttr (JSON-LD control-chars / payload allowlist / case-insensitive raw-text+void / atomic-drain), rf2-cwfy2 (redirect/cookie schema), rf2-wtd8z (safe-redirect / Var-heads / source-coord).

## Per-finding disposition

**Finding 1 — JSON-LD control chars (head/emit.cljc) — DUP, no change.**
Already fixed + tested by rf2-hzttr: `escape-json-control` (head/emit.cljc:93-123) escapes all U+0000–U+001F controls (short escapes for \b \t \n \f \r, `\u00XX` for the rest) on the JVM branch, matching the CLJS `JSON.stringify` path. Parity test `ld-json-string-escapes-control-chars-on-both-branches` (head_emit_cljs_test.cljc:75) covers newline/tab/CR. Resolved upstream — skipped.

**Finding 2 — render-hash dropped on `:<>` fragment root (emit.cljc) — REAL, fixed.**
The `:<>` branch used plain `emit-children`, dropping `root-attrs`, so `[:<> [:div "x"]]` with `{:emit-hash? true}` emitted `<div>x</div>` (no `data-rf-render-hash`) while a plain DOM root got the marker — contradicting the `render-to-string` docstring's promise to thread "past … fragments". Added `emit-children-threading-root-attrs`, which threads root-attrs onto the FIRST child only (nil to the rest); nested fragments / fn-heads / view-refs keep threading down their own root path until a DOM tag consumes the marker exactly once. Verified: marker lands on the first `<div>` only for a multi-child fragment; explicit `:render-hash` threads through; no opts → no marker.

**Finding 3 — CSS-special `:payload-id` breaks final-payload detection (streaming/client.cljs) — REAL, fixed.**
`final-payload-present?` built a raw `(.querySelector root (str "#" id))` selector, so a valid-but-CSS-special override id (`rf:payload`, `rf.payload`, `rf payload`, `rf[0]`) could throw `SyntaxError` (install! crash) or select the wrong element (observer never disconnects → leak). New `element-by-id` matches by EXACT id: `getElementById` on a Document/DocumentFragment root, an `[id]`-presence scan + `.id` compare on an Element root. `[id]` is a structurally-fixed selector — it never embeds the user id, so it cannot be poisoned.

**Finding 4 — nested boundaries stranded on fallback on late install (streaming/client.cljs) — REAL, fixed.**
When outer + nested-inner resolved chunks are both already in the DOM at install and the outer resolved HTML contains the inner FALLBACK template: the inner fallback is inert inside the outer resolved `<template>` until the outer mount swaps, so the already-present inner resolved chunk had no live mount when first processed. The id was marked `seen` BEFORE the swap, so the failed inner swap was skipped permanently — the nested boundary stuck on fallback until the final payload. Fix: (a) mark `seen` only on a successful swap (unresolved mounts stay retryable; idempotency preserved because a successful swap removes the resolved node); (b) re-materialise fallbacks a swap introduces into live DOM; (c) `sweep!` iterates the resolved-processing pass to a fixpoint, so the inner chunk lands in the SAME sweep regardless of document order. Loop terminates (monotone — boundaries only move resolved-ward; finite count).

## Quality gates

- `cd implementation/ssr && clojure -M:test` → **308 tests, 1194 assertions, 0 failures, 0 errors** (+1 test / +6 assertions: fragment-root render-hash regression).
- `cd implementation/ssr-ring && clojure -M:test` → **127 tests, 557 assertions, 0 failures, 0 errors** (cross-artefact ssr-ring gate).
- `cd implementation && npm run test:cljs` → **5856 tests, 20752 assertions, 0 failures, 0 errors** (node).
- `cd implementation && npm run test:browser` → **194 tests, 585 assertions, 0 failures, 0 errors** (Playwright; exercises the new CSS-special-payload-id + nested-late-install DOM regressions, which gate on `(browser?)` and no-op under node).

Closes rf2-58zvy1.