### PR TITLE
fix(flows): independent-review findings (rf2-4wqu6)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -186,6 +186,14 @@
    {:key         :flows/reset-last-inputs!
     :producer-ns 're-frame.flows
     :description "Reset memoised last-input snapshots (test isolation)."}
+   {:key         :flows/snapshot-last-inputs
+    :producer-ns 're-frame.flows
+    :design-bead "rf2-4wqu6"
+    :description "Snapshot a frame's dirty-check (`last-inputs`) rows as a plain `{flow-id inputs}` map. The router's flows-after-interceptor captures this BEFORE the flow transform advances the rows so a post-commit schema/machine-data rollback can roll the dirty-check bookkeeping back in lock-step with app-db (paired with `:flows/restore-last-inputs!`)."}
+   {:key         :flows/restore-last-inputs!
+    :producer-ns 're-frame.flows
+    :design-bead "rf2-4wqu6"
+    :description "Restore a frame's dirty-check (`last-inputs`) rows to a previously-captured snapshot. Invoked by `commit-db-effect!` when post-commit validation rolls app-db back to its pre-handler value — without it the eagerly-advanced rows survive a rollback and the next clean drain skips the flow on `=`-equal inputs, never re-materialising the output. Frame-scoped (rf2-94ol5)."}
    {:key         :flows/reset-flows!
     :producer-ns 're-frame.flows
     :description "Clear the per-frame flow registry (test isolation)."}

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -855,7 +855,20 @@
   Schema-derived redaction is reflected in the `:event/db-changed`
   trace event's `:tags :event` slot. The router-installed internal
   interceptor stashes the scrubbed form under `:rf/redacted-event`;
-  this commit path reads it through."
+  this commit path reads it through.
+
+  Per rf2-4wqu6 finding 1: on rollback the flow dirty-check
+  (`last-inputs`) bookkeeping is rolled back in lock-step with the
+  app-db. The flow transform advanced each computed flow's `last-inputs`
+  row inside the chain (folding the output into the now-discarded
+  pending `:db`); restoring app-db to `db-before` without also restoring
+  those rows would leave the dirty-check believing the flows are
+  up-to-date, so the next clean drain would skip them on `=`-equal
+  inputs and the output would never re-materialise. `ctx` carries the
+  pre-drain snapshot under `:rf/flow-last-inputs-before` (stashed by
+  `flows-after-interceptor`); the rollback arm restores it through the
+  frame-scoped `:flows/restore-last-inputs!` hook — the mirror of
+  `run-flows-on-db`'s throw-path rollback at the post-commit boundary."
   [effects event-id event frame ctx db-before]
   (if (contains? effects :db)
     (let [container  (frame/app-db-container frame)
@@ -885,6 +898,24 @@
           ;; (in order): forward commit, schema-failure error,
           ;; rollback commit.
           (adapter/replace-container! container db-before)
+          ;; Per rf2-4wqu6 finding 1: app-db rolled back to its pre-handler
+          ;; value, so the flow dirty-check (`last-inputs`) bookkeeping MUST
+          ;; roll back too — the flow transform already advanced each
+          ;; computed flow's row inside the chain, but those outputs were
+          ;; just discarded along with the rolled-back db. Restore THIS
+          ;; frame's pre-drain `last-inputs` snapshot (stashed on the ctx by
+          ;; `flows-after-interceptor`) so the next clean drain re-reads
+          ;; changed inputs and re-materialises the flow output instead of
+          ;; skipping it as `=`-equal. This is the exact mirror of
+          ;; `run-flows-on-db`'s throw-path rollback, applied at the
+          ;; post-commit boundary the flows artefact cannot reach. Both the
+          ;; snapshot and the restorer are frame-scoped (rf2-94ol5): a
+          ;; sibling frame's container is a different atom and is untouched.
+          ;; No-op when no flow ran (no snapshot stashed) or the flows
+          ;; artefact never loaded (restorer hook nil).
+          (when (contains? ctx :rf/flow-last-inputs-before)
+            (when-let [restore-li (late-bind/get-fn-cached :flows/restore-last-inputs!)]
+              (restore-li frame (:rf/flow-last-inputs-before ctx))))
           (trace/emit! :rf.event :rf.event/db-changed
                        {:rf.trace/event-id event-id
                         :rf.event/v        emit-event
@@ -1014,7 +1045,31 @@
                         :rf.event/db       pending-db}))
         (if run-on-db
           (try
-            (let [new-db (run-on-db frame pending-db)]
+            (let [;; Per rf2-4wqu6 finding 1: snapshot THIS frame's
+                  ;; dirty-check (`last-inputs`) rows BEFORE the flow transform
+                  ;; advances them. The transform eagerly advances a flow's row
+                  ;; the moment it recomputes, folding the output into the
+                  ;; pending `:db`. But whether that pending `:db` becomes
+                  ;; DURABLE is decided AFTER the chain, in `commit-db-effect!`:
+                  ;; a POST-commit schema / machine-data validation failure
+                  ;; rolls app-db back to `db-before`. `run-flows-on-db`'s own
+                  ;; throw-path snapshot/restore cannot cover that — the
+                  ;; rollback lands outside it. Without restoring here, the
+                  ;; advanced rows survive a rollback, so the next clean drain
+                  ;; sees `=`-equal inputs, SKIPS the flow, and the output
+                  ;; never re-materialises (a deterministic dev/test failure
+                  ;; can permanently suppress a flow). We stash the pre-drain
+                  ;; snapshot on the ctx; `commit-db-effect!` restores it iff it
+                  ;; rolls back — the exact mirror of the throw-path rollback,
+                  ;; at the post-commit boundary. Frame-scoped (rf2-94ol5): the
+                  ;; snapshot is `frame`'s own container, structurally unable to
+                  ;; touch a sibling frame draining on another thread. The
+                  ;; snapshot is a persistent map (pointer-sized to stash); the
+                  ;; hook is nil only when the flows artefact never loaded, in
+                  ;; which case there are no rows and nothing to restore.
+                  snapshot-li (late-bind/get-fn-cached :flows/snapshot-last-inputs)
+                  li-before   (when snapshot-li (snapshot-li frame))
+                  new-db (run-on-db frame pending-db)]
               ;; t2 — flows transformed the pending `:db`. Stamp the
               ;; flow-augmented value so the Xray panel can render the
               ;; t1→t2 reshape. The dirty-check below is the same
@@ -1037,9 +1092,15 @@
               ;; the value OR the handler already had one — a no-flow /
               ;; no-write event must not synthesise a spurious `:db`
               ;; effect (which would force an app-db install + db-changed
-              ;; trace on an event that wrote nothing).
+              ;; trace on an event that wrote nothing). When we DO publish a
+              ;; `:db`, stash the pre-drain dirty-check snapshot + the
+              ;; restorer fn (rf2-4wqu6 finding 1) so `commit-db-effect!` can
+              ;; roll `last-inputs` back in lock-step with an app-db rollback.
+              ;; A no-flow / no-write event publishes no `:db`, hits no
+              ;; commit/rollback boundary, and needs no snapshot.
               (if (or has-db? (not (identical? new-db pending-db)))
-                (interceptor/assoc-effect ctx :db new-db)
+                (cond-> (interceptor/assoc-effect ctx :db new-db)
+                  snapshot-li (assoc :rf/flow-last-inputs-before li-before))
                 ctx))
             (catch #?(:clj Throwable :cljs :default) e
               ;; Atomicity contract (Spec 013 §Failure semantics, Mike

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -446,6 +446,24 @@
 (late-bind/set-fn! :flows/run-flows-on-db    run-flows-on-db)
 (late-bind/set-fn! :flows/reset-last-inputs! reset-last-inputs!)
 (late-bind/set-fn! :flows/reset-flows!       reset-flows!)
+;; Per rf2-4wqu6 finding 1 — the dirty-check-rollback pair the router uses
+;; to keep this frame's `last-inputs` bookkeeping aligned with the DURABLE
+;; app-db across a POST-commit schema/machine-data rollback. The flow
+;; transform runs inside the chain and eagerly advances `last-inputs` for
+;; each computed flow; but the rollback decision lands AFTER the chain, in
+;; `commit-db-effect!`, OUTSIDE `run-flows-on-db`'s own throw-path
+;; snapshot/restore. Without these hooks a rolled-back commit restores
+;; app-db to `db-before` but leaves the advanced `last-inputs` rows, so the
+;; next clean drain sees `=`-equal inputs, SKIPS the flow, and the flow
+;; output never re-materialises — a deterministic dev/test failure path can
+;; permanently suppress a flow. The router snapshots the draining frame's
+;; rows BEFORE the flow transform and, on a rollback, restores them — the
+;; exact mirror of the in-`run-flows-on-db` throw-path rollback, just at the
+;; post-commit boundary the flows artefact cannot see. Both delegate to the
+;; SAME frame-scoped registry primitives the throw path uses (rf2-94ol5):
+;; structurally incapable of touching a sibling frame's container.
+(late-bind/set-fn! :flows/snapshot-last-inputs registry/frame-last-inputs-snapshot)
+(late-bind/set-fn! :flows/restore-last-inputs!  registry/reset-frame-last-inputs-to!)
 ;; Per rf2-wbtjn — frame-destroy teardown hook (symmetric with the
 ;; machines `:machines/teardown-on-frame-destroy!` hook landed by
 ;; rf2-vsigt). `frame/destroy-frame!` invokes this hook so per-frame

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -676,63 +676,80 @@
   not the parent's emptiness."
   ([id] (clear-flow id {}))
   ([id {:keys [frame] :as _opts}]
-   (let [frame-id (or frame (frame/current-frame))]
-     (when-let [flow (get-in @flows [frame-id id])]
-       (let [path (:path flow)]
-         ;; rf2-2woz9 finding 1: the vacate-then-deregister sequence below
-         ;; MUST be atomic w.r.t. the frame drain. Pre-fix, `vacate-output-
-         ;; path!` ran, then a same-frame drain could start, observe the
-         ;; STILL-registered flow, recompute it, and re-commit the output
-         ;; this clear vacated — and clear-flow, having already vacated,
-         ;; never vacated again, leaving stale derived state in app-db
-         ;; (violating Spec 013's clear-flow cleanup contract). Serializing
-         ;; the whole mutation against the drain (`:drain-lock`) makes the
-         ;; flow vanish from registry + app-db as one indivisible step the
-         ;; drain can never interleave with. Reentrant: a mid-drain
-         ;; `:rf.fx/clear-flow` runs directly inside the single-drainer
-         ;; window (see `frame/call-serialized-with-drain!`).
+   (let [frame-id (or frame (frame/current-frame))
+         ;; rf2-4wqu6 finding 2: the flow lookup + `:path` capture MUST
+         ;; happen INSIDE the drain-lock, not before it. Pre-fix this
+         ;; read the flow and captured `path` ahead of
+         ;; `call-serialized-with-drain!`; on the JVM a competing same-frame
+         ;; same-id `reg-flow` replacement could win the lock after that
+         ;; stale read, install a NEW `:path`, a drain could materialise the
+         ;; replacement's new output, and this clear-flow would then run
+         ;; under the lock using the OLD path — vacating a now-empty old
+         ;; path (a no-op) while removing the live registry row and leaving
+         ;; the replacement's new output stale in app-db (violating Spec
+         ;; 013's clear-flow cleanup contract). It would also emit a
+         ;; misleading `:rf.flow/cleared` for the old path.
+         ;;
+         ;; The fix folds the lookup, path capture, app-db vacate, registry
+         ;; removal, dirty-row drop, and registrar realignment into ONE
+         ;; serialized operation over the SAME live flow definition. The
+         ;; thunk returns the path it actually cleared (or nil when no flow
+         ;; was registered under the lock) so the `:rf.flow/cleared` emit
+         ;; below fires only on a real clear, with the path captured under
+         ;; the lock. (rf2-2woz9 finding 1: serializing the mutation against
+         ;; the drain already made the vacate→deregister sequence atomic;
+         ;; this extends that atomicity to the lookup the sequence reads.)
+         ;; Reentrant: a mid-drain `:rf.fx/clear-flow` runs directly inside
+         ;; the single-drainer window (see `frame/call-serialized-with-drain!`).
+         cleared-path
          (frame/call-serialized-with-drain!
            frame-id
            (fn []
-             (vacate-output-path! frame-id path)
-             ;; Drop the flow from `frame-id`'s per-frame slot; when that was
-             ;; the LAST flow on the frame, prune the now-empty `frame-id` key
-             ;; entirely rather than leave a `{frame-id {}}` husk (rf2-4bbaw).
-             ;; The husk was harmless (bounded by frame count, tolerated by the
-             ;; concurrency-stress invariant) but a naive `flows-snapshot`
-             ;; consumer would iterate the empty entry; pruning keeps the
-             ;; registry exactly symmetric with `teardown-on-frame-destroy!`'s
-             ;; `(swap! flows dissoc frame-id)`.
-             (swap! flows (fn [m]
-                            (let [m' (update m frame-id dissoc id)]
-                              (cond-> m'
-                                (empty? (get m' frame-id)) (dissoc frame-id)))))
-             ;; Drop the cleared flow's dirty-check row from THIS frame's own
-             ;; `last-inputs` container (rf2-94ol5). Frame-local — a sibling
-             ;; frame registering the same id keeps its own row untouched.
-             (drop-frame-flow-row! frame-id id)
-             ;; Keep the shared `:flow` registrar slot aligned with a live
-             ;; owner (rf2-73pi1): unregister when this was the LAST frame
-             ;; holding the id, or re-point the slot to a surviving owner
-             ;; when the cleared frame was the slot's current (now-stale)
-             ;; metadata writer. Pre-fix this only unregistered on
-             ;; last-owner-release, leaving the slot pointing at the cleared
-             ;; frame whenever a sibling still held the id.
-             (realign-registrar-owner! @flows id frame-id)))
-         ;; Per Spec 009 §:op-type vocabulary: :rf.flow/cleared fires after
-         ;; clear-flow has removed the flow from the per-frame registry
-         ;; and dissoc-in'd its output path. Tools observe this to drop
-         ;; their per-flow display state. The outer `debug-enabled?` gate
-         ;; matches the hot-path emits in flows.cljc (per Spec 009
-         ;; §Production builds, "keep the gate OUTERMOST"); clear-flow is
-         ;; a cold path so the cost is negligible, but the gate keeps the
-         ;; tag-map literal out of CLJS prod and the convention uniform
-         ;; across every flow emit site (rf2-ee38b.9).
-         (when interop/debug-enabled?
-           (trace/emit! :flow :rf.flow/cleared
-                        {:flow-id id
-                         :path    path
-                         :frame   frame-id}))))
+             (when-let [flow (get-in @flows [frame-id id])]
+               (let [path (:path flow)]
+                 (vacate-output-path! frame-id path)
+                 ;; Drop the flow from `frame-id`'s per-frame slot; when that was
+                 ;; the LAST flow on the frame, prune the now-empty `frame-id` key
+                 ;; entirely rather than leave a `{frame-id {}}` husk (rf2-4bbaw).
+                 ;; The husk was harmless (bounded by frame count, tolerated by the
+                 ;; concurrency-stress invariant) but a naive `flows-snapshot`
+                 ;; consumer would iterate the empty entry; pruning keeps the
+                 ;; registry exactly symmetric with `teardown-on-frame-destroy!`'s
+                 ;; `(swap! flows dissoc frame-id)`.
+                 (swap! flows (fn [m]
+                                (let [m' (update m frame-id dissoc id)]
+                                  (cond-> m'
+                                    (empty? (get m' frame-id)) (dissoc frame-id)))))
+                 ;; Drop the cleared flow's dirty-check row from THIS frame's own
+                 ;; `last-inputs` container (rf2-94ol5). Frame-local — a sibling
+                 ;; frame registering the same id keeps its own row untouched.
+                 (drop-frame-flow-row! frame-id id)
+                 ;; Keep the shared `:flow` registrar slot aligned with a live
+                 ;; owner (rf2-73pi1): unregister when this was the LAST frame
+                 ;; holding the id, or re-point the slot to a surviving owner
+                 ;; when the cleared frame was the slot's current (now-stale)
+                 ;; metadata writer. Pre-fix this only unregistered on
+                 ;; last-owner-release, leaving the slot pointing at the cleared
+                 ;; frame whenever a sibling still held the id.
+                 (realign-registrar-owner! @flows id frame-id)
+                 path))))]
+     ;; Per Spec 009 §:op-type vocabulary: :rf.flow/cleared fires after
+     ;; clear-flow has removed the flow from the per-frame registry
+     ;; and dissoc-in'd its output path. Tools observe this to drop
+     ;; their per-flow display state. Only emit when a flow was ACTUALLY
+     ;; cleared (rf2-4wqu6 finding 2 — a no-op clear-flow for an unregistered
+     ;; id, or one that lost the race to a competing lifecycle op, emits
+     ;; nothing), carrying the path captured under the lock. The outer
+     ;; `debug-enabled?` gate matches the hot-path emits in flows.cljc (per
+     ;; Spec 009 §Production builds, "keep the gate OUTERMOST"); clear-flow is
+     ;; a cold path so the cost is negligible, but the gate keeps the
+     ;; tag-map literal out of CLJS prod and the convention uniform
+     ;; across every flow emit site (rf2-ee38b.9).
+     (when (and cleared-path interop/debug-enabled?)
+       (trace/emit! :flow :rf.flow/cleared
+                    {:flow-id id
+                     :path    cleared-path
+                     :frame   frame-id}))
      nil)))
 
 ;; ---- frame-destroy teardown ---------------------------------------------

--- a/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
+++ b/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
@@ -267,3 +267,114 @@
                "stale 10. Got " (:out (rf/app-db-value :rf/default))))
       (is (:touched (rf/app-db-value :rf/default))
           "the unrelated event's own write also landed"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-4wqu6 finding 2 — clear-flow's flow lookup + `:path` capture must
+;; happen UNDER the drain-lock, not before it. A stale PRE-LOCK read can race
+;; a same-id same-frame `reg-flow` replacement that moves the output to a new
+;; `:path`, leaving clear-flow vacating the OLD (now-empty) path while the
+;; replacement's NEW path stays materialised after the flow is removed from
+;; the registry — a stale-derived-state leak (violating Spec 013's clear-flow
+;; cleanup contract) plus a misleading `:rf.flow/cleared` for the old path.
+;;
+;; This is DISTINCT from rf2-2woz9: that fix serialized clear-flow's
+;; vacate→deregister MUTATION against the drain, but left the lookup + path
+;; capture OUTSIDE the lock. rf2-4wqu6 finding 2 folds the lookup into the
+;; serialized region so the whole op runs over the SAME live flow definition.
+;; ---------------------------------------------------------------------------
+
+(deftest clear-flow-lookup-happens-under-the-lock-vs-a-racing-path-change-replacement
+  ;; Deterministic reproduction of the stale PRE-LOCK read, using a REAL
+  ;; drain as the lock-holder so the reentrancy / materialisation are natural
+  ;; (no manual lock-juggling, no reentrancy deadlock).
+  ;;
+  ;; A replacement event's HANDLER pauses early in the drain — the drain
+  ;; already holds the frame's `:drain-lock` and the OLD flow (`:path
+  ;; [:out-a]`) is still the live definition (the replacement `reg-flow`
+  ;; runs LATER, after the handler resumes). While the handler is parked we
+  ;; start `clear-flow` on thread B (its PRE-LOCK read, if any, captures the
+  ;; OLD `[:out-a]` here) and let B reach the lock-wait. We then resume the
+  ;; handler: it `reg-flow`s `:scaled` to `:path [:out-b]` (reentrant — the
+  ;; drainer already holds the lock) and the drain's flow transform
+  ;; MATERIALISES :out-b. The drain completes, releases the lock, and B's
+  ;; serialized region finally runs.
+  ;;
+  ;;   PRE-FIX: B vacates the stale pre-lock `[:out-a]` (a no-op — already
+  ;;            empty) and removes the registry row, leaving the
+  ;;            replacement's materialised `[:out-b]` STALE in app-db.
+  ;;   POST-FIX: B reads the LIVE flow UNDER the lock — `[:out-b]` — and
+  ;;            vacates THAT, so no stale derived state remains.
+  (testing "clear-flow vacates the replacement's NEW path, not the stale pre-lock OLD path"
+    (let [in-handler (CountDownLatch. 1) ;; drain parked in handler, OLD flow live
+          release    (CountDownLatch. 1)] ;; resume the handler → swap + materialise
+      (rf/reg-event-db :seed (fn [_ _] {:n 5}))
+      ;; OLD flow: :out-a = 2 × :n.
+      (rf/reg-flow {:id     :scaled
+                    :inputs [[:n]]
+                    :output (fn [n] (* 2 (or n 0)))
+                    :path   [:out-a]})
+      (rf/dispatch-sync [:seed])
+      (is (= 10 (:out-a (rf/app-db-value :rf/default)))
+          "precondition: the OLD flow materialised :out-a = 2 × :n = 10")
+
+      ;; The replacement handler: park early in the drain (lock held, OLD
+      ;; flow still live), then on resume re-register :scaled to :out-b. The
+      ;; reg-flow runs reentrantly inside the single-drainer window; the
+      ;; drain's flow transform then materialises :out-b = 100 × :n = 500.
+      ;; The handler dissocs the OLD output (:out-a) from its returned db so
+      ;; the deferred `:db` commit reflects the path change (the abandoned
+      ;; old-path value does not survive the move — mirrors what the path-
+      ;; change vacate intends; the reentrant vacate writes the container
+      ;; directly, but the drain's deferred commit installs THIS db, so the
+      ;; dissoc here is what makes the move durable through the drain).
+      (rf/reg-event-db :replace-scaled
+                       (fn [db _]
+                         (.countDown in-handler)
+                         (await! release "replace-scaled handler release")
+                         (rf/reg-flow {:id     :scaled
+                                       :inputs [[:n]]
+                                       :output (fn [n] (* 100 (or n 0)))
+                                       :path   [:out-b]}
+                                      {:frame :rf/default})
+                         (dissoc db :out-a)))
+
+      (let [;; Thread A: the replacement drain. Parks in the handler holding
+            ;; the drain-lock with the OLD flow still live.
+            replacer (future (rf/dispatch-sync [:replace-scaled] {:frame :rf/default}))]
+        ;; Wait until A's drain is parked in the handler.
+        (await! in-handler "in-handler (main)")
+        ;; Thread B: clear :scaled. Pre-fix its pre-lock read captures the
+        ;; OLD `[:out-a]` now (A hasn't swapped yet); in BOTH versions it
+        ;; then blocks on the drain-lock A's drain holds.
+        (let [clearer (future (rf/clear-flow :scaled {:frame :rf/default}))]
+          ;; B must NOT complete while A holds the lock — it's blocked on the
+          ;; drain-lock (bounded wait; B's pre-lock read, if any, is a few
+          ;; instructions before the blocking acquire).
+          (is (= ::still-blocked (deref clearer 1000 ::still-blocked))
+              "clear-flow is blocked on the drain-lock A's drain holds")
+          ;; Resume A: it swaps :scaled → :out-b, the flow transform
+          ;; materialises :out-b = 500, the drain commits + releases the
+          ;; lock. B's serialized region then runs.
+          (.countDown release)
+          (is (not= ::timeout (deref replacer 30000 ::timeout))
+              "the replacement drain completed within 30s")
+          (is (not= ::timeout (deref clearer 30000 ::timeout))
+              "clear-flow completed within 30s")))
+
+      ;; --- The load-bearing post-conditions (bead acceptance) -----------
+      (is (not (contains? (get (flows/flows-snapshot) :rf/default) :scaled))
+          "registry row gone: clear-flow removed :scaled")
+      (is (not (contains? (flows/last-inputs-snapshot) :scaled))
+          "last-inputs row gone")
+      (is (nil? (registrar/lookup :flow :scaled))
+          "the :flow registrar slot was vacated (last owner released)")
+      ;; THE FINDING-2 ASSERT: clear-flow vacated the REPLACEMENT's live path
+      ;; (:out-b), not the stale pre-lock :out-a. Pre-fix :out-b would linger
+      ;; (500) after the flow was removed from the registry.
+      (is (not (contains? (rf/app-db-value :rf/default) :out-b))
+          (str ":out-b ABSENT — clear-flow read the LIVE flow under the lock "
+               "and vacated the replacement's new path. Pre-fix it vacated the "
+               "stale pre-lock :out-a and left :out-b = "
+               (:out-b (rf/app-db-value :rf/default)) " in app-db."))
+      (is (not (contains? (rf/app-db-value :rf/default) :out-a))
+          ":out-a also absent (the replacement vacated it on the path change)"))))

--- a/implementation/flows/test/re_frame/flows_rollback_dirty_check_test.clj
+++ b/implementation/flows/test/re_frame/flows_rollback_dirty_check_test.clj
@@ -1,0 +1,173 @@
+(ns re-frame.flows-rollback-dirty-check-test
+  "Per rf2-4wqu6 finding 1 — a POST-commit app-db schema rollback MUST roll
+  the flow dirty-check (`last-inputs`) bookkeeping back in lock-step with
+  app-db.
+
+  THE BUG. The flow transform runs as the router's OUTERMOST `:after`
+  interceptor: the moment a flow recomputes it advances THIS frame's
+  `last-inputs` row and folds the output into the chain's PENDING `:db`
+  effect. Whether that pending `:db` becomes DURABLE, however, is decided
+  AFTER the chain returns, in `commit-db-effect!`: a post-commit
+  schema / machine-data validation failure rolls app-db back to the
+  pre-handler value. `run-flows-on-db`'s OWN throw-path snapshot/restore
+  cannot cover that — the rollback lands OUTSIDE it.
+
+  Pre-fix the advanced `last-inputs` row SURVIVED the rollback. So even
+  though app-db was restored (the flow output gone), the dirty-check
+  believed the flow was up-to-date: the next clean drain saw `=`-equal
+  inputs, SKIPPED the flow, and the output NEVER re-materialised. A
+  deterministic dev/test failure path (a validator that rejects once and
+  then passes) could permanently suppress a flow until an input changed,
+  the flow re-registered, or fixtures reset the runtime.
+
+  THE FIX (rf2-4wqu6 finding 1). `flows-after-interceptor` snapshots the
+  draining frame's `last-inputs` rows BEFORE the flow transform advances
+  them (via the new `:flows/snapshot-last-inputs` hook) and stashes the
+  snapshot on the ctx. `commit-db-effect!`'s rollback arm restores it (via
+  `:flows/restore-last-inputs!`) the instant it rolls app-db back — the
+  exact mirror of the throw-path rollback, at the post-commit boundary the
+  flows artefact cannot reach. Frame-scoped (rf2-94ol5): a sibling frame's
+  container is a different atom and is untouched.
+
+  The validator seam is the pluggable predicate seam the rest of Spec 010
+  uses (`set-schema-fns!`) so the test exercises the exact production
+  rollback path without pulling Malli onto the classpath."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- per-test reset -------------------------------------------------------
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (reset! schemas/schemas-by-frame {})
+  (schemas/reset-schema-validator!)
+  (flows/reset-last-inputs!)
+  (error-emit/clear-error-listeners!)
+  (trace/clear-listeners!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (try
+    (test-fn)
+    (finally
+      (schemas/reset-schema-validator!))))
+
+(use-fixtures :each reset-runtime)
+
+;; A pluggable predicate validator: a registered "schema" here is a 1-arg
+;; predicate fn applied to the slice at its registered path. This exercises
+;; the `:schemas/validate-with-registered-fn` seam without Malli (Spec 010
+;; §Non-Malli validators).
+(defn- install-predicate-validator! []
+  (schemas/set-schema-fns!
+    {:validate (fn [schema value] (boolean (schema value)))
+     :explain  (fn [schema value] (when-not (schema value) {:failed value}))}))
+
+;; ---------------------------------------------------------------------------
+;; Finding 1 — app-db rollback restores the flow's last-inputs, and a later
+;; clean drain re-materialises the flow output WITHOUT an input change.
+;; ---------------------------------------------------------------------------
+
+(deftest app-db-rollback-restores-flow-last-inputs-and-recomputes-on-next-clean-drain
+  (testing "a post-commit app-db schema rollback rolls back the flow dirty-check, so the next clean drain re-materialises the output without an input change"
+    (install-predicate-validator!)
+    ;; `:reject-out?` flips the validator's verdict on the flow's output
+    ;; slice. First flow-augmented commit is rejected (rollback); after we
+    ;; flip it, the slice passes.
+    (let [reject-out? (atom false)]
+      ;; The flow doubles :n into :out.
+      (rf/reg-event-db :seed       (fn [_ _] {:n 1}))
+      (rf/reg-event-db :touch-other (fn [db _] (assoc db :other true)))
+      ;; App-db schema on the flow's OUTPUT slot: reject while the flag is
+      ;; set, otherwise accept. A nil slice (output absent) always passes —
+      ;; so the seeding dispatch (before :out exists / before the flow is
+      ;; registered) is never rejected.
+      (rf/reg-app-schema [:out]
+                         (fn [out]
+                           (or (nil? out) (not @reject-out?)))
+                         {:frame :rf/default})
+
+      ;; Seed :n = 1 DURABLY (no flow registered yet, so :out is absent and
+      ;; the schema passes). This is the pre-handler db the rollback below
+      ;; restores to.
+      (rf/dispatch-sync [:seed])
+      (is (= {:n 1} (rf/app-db-value :rf/default))
+          "precondition: :n = 1 committed durably, :out absent")
+
+      ;; Register the flow and arm the rejection. The flow computes on the
+      ;; NEXT drain (registration does not drain).
+      (rf/reg-flow {:id     :double
+                    :inputs [[:n]]
+                    :output (fn [n] (* 2 (or n 0)))
+                    :path   [:out]})
+      (reset! reject-out? true)
+
+      ;; A drain whose handler does NOT touch :n. The flow transform computes
+      ;; :out = 2 into the pending db and advances :double's last-inputs to
+      ;; [1], but the post-commit validator rejects the :out slice → the
+      ;; whole commit rolls back to the pre-handler db {:n 1}. (No :out, no
+      ;; :other land.)
+      (rf/dispatch-sync [:touch-other])
+
+      ;; --- Post-rollback state (the bug's trigger) ----------------------
+      (is (= {:n 1} (rf/app-db-value :rf/default))
+          "app-db rolled back to {:n 1} — the rejected :out write was discarded")
+      (is (not (contains? (rf/app-db-value :rf/default) :out))
+          ":out absent after the rollback")
+      ;; THE LOAD-BEARING FINDING-1 ASSERT: the flow's dirty-check row was
+      ;; rolled back in lock-step. Pre-fix it stayed advanced to [1], so the
+      ;; flow looked up-to-date despite its output never reaching app-db.
+      (is (not (contains? (flows/last-inputs-snapshot) :double))
+          (str "flow :double's last-inputs row was rolled back with app-db "
+               "(pre-fix it stayed advanced to {:double {:rf/default [1]}}, "
+               "permanently suppressing the flow). Got "
+               (pr-str (flows/last-inputs-snapshot))))
+
+      ;; Flip the validator to accept, then drive a CLEAN drain whose event
+      ;; does NOT change :n (the flow's only input). Pre-fix this no-op drain
+      ;; would skip the flow on =-equal inputs and :out would NEVER appear.
+      ;; Post-fix the rolled-back dirty-check forces a recompute.
+      (reset! reject-out? false)
+      (rf/dispatch-sync [:touch-other])
+
+      ;; --- Acceptance: the flow re-materialised on a no-input-change drain
+      (is (= 2 (:out (rf/app-db-value :rf/default)))
+          (str "the next clean drain re-materialised :out = 2 × :n = 2 "
+               "WITHOUT an input change. Pre-fix the stale dirty-check row "
+               "skipped the flow and :out stayed absent. Got "
+               (pr-str (rf/app-db-value :rf/default))))
+      (is (:other (rf/app-db-value :rf/default))
+          "the no-op event's own write also landed")
+      (is (= [1] (get-in (flows/last-inputs-snapshot) [:double :rf/default]))
+          "after the successful recompute the dirty-check row is advanced to [1]"))))
+
+;; ---------------------------------------------------------------------------
+;; Companion — a DURABLE commit (no rollback) leaves the dirty-check advanced
+;; as normal. Pins that the fix only rolls back the bookkeeping on an actual
+;; rollback (no over-restore on the happy path).
+;; ---------------------------------------------------------------------------
+
+(deftest durable-commit-leaves-dirty-check-advanced
+  (testing "a flow whose output passes post-commit validation commits durably and advances last-inputs"
+    (install-predicate-validator!)
+    (rf/reg-event-db :seed (fn [_ _] {:n 3}))
+    (rf/reg-flow {:id     :double
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 (or n 0)))
+                  :path   [:out]})
+    ;; Schema always accepts.
+    (rf/reg-app-schema [:out] (fn [_] true) {:frame :rf/default})
+    (rf/dispatch-sync [:seed])
+    (is (= 6 (:out (rf/app-db-value :rf/default)))
+        "the flow output committed durably")
+    (is (= [3] (get-in (flows/last-inputs-snapshot) [:double :rf/default]))
+        "last-inputs advanced normally on a durable commit (no over-restore)")))


### PR DESCRIPTION
Fixes the two correctness findings from the independent review of `implementation/flows` (bead rf2-4wqu6). Deduped against the merged rf2-2woz9 lifecycle-race fix.

## Finding 1 — app-db rollback must roll back the flow dirty-check (`last-inputs`)

`evaluate-flow!` advances a flow's `last-inputs` row the moment it recomputes, folding the output into the chain's pending `:db`. Whether that `:db` becomes durable, however, is decided **after** the chain returns, in `commit-db-effect!`: a post-commit schema / machine-data validation failure rolls app-db back to `db-before`. `run-flows-on-db`'s own throw-path snapshot/restore cannot cover that — the rollback lands outside it.

Pre-fix the advanced `last-inputs` row **survived** the rollback, so the next clean drain saw `=`-equal inputs, **skipped** the flow, and the output never re-materialised — a deterministic dev/test path (a validator that rejects once then passes) could permanently suppress a flow. Confirmed in an in-memory probe and reproduced in the new test.

**Fix.** `flows-after-interceptor` snapshots the draining frame's `last-inputs` rows **before** the flow transform advances them (new frame-scoped hook `:flows/snapshot-last-inputs`) and stashes the snapshot on the ctx under `:rf/flow-last-inputs-before`. `commit-db-effect!`'s rollback arm restores it through `:flows/restore-last-inputs!` the instant it rolls app-db back — the exact mirror of the throw-path rollback at the post-commit boundary. Both delegate to the same frame-scoped registry primitives the throw path uses (rf2-94ol5): structurally incapable of touching a sibling frame's container.

## Finding 2 — `clear-flow`'s lookup + `:path` capture must happen under the drain-lock

Pre-fix `clear-flow` read the flow and captured `:path` **before** entering `frame/call-serialized-with-drain!`. On the JVM a same-frame same-id `reg-flow` replacement could win the lock after that stale read, install a new `:path`, a drain could materialise the replacement's new output, and `clear-flow` would then run under the lock using the **old** path — vacating a now-empty old path (a no-op) while removing the live registry row, leaving the replacement's new output **stale** in app-db (violating Spec 013's `clear-flow` cleanup contract) and emitting a misleading `:rf.flow/cleared` for the old path. Distinct from rf2-2woz9, which serialized the *mutation* but left the lookup outside the lock.

**Fix.** The lookup, path capture, vacate, registry removal, dirty-row drop, and registrar realignment are now one serialized operation over the **same live flow definition**. The serialized thunk returns the path it actually cleared; `:rf.flow/cleared` fires only on a real clear, with the path captured under the lock.

## Per-finding disposition

| Finding | Disposition |
| --- | --- |
| 1 — dirty-check survives app-db rollback | **Fixed.** Snapshot-before / restore-on-rollback via two new frame-scoped late-bind hooks. New test `flows_rollback_dirty_check_test`. |
| 2 — `clear-flow` stale pre-lock lookup vs racing path-change replacement | **Fixed.** Lookup folded under the drain-lock. New JVM regression in `flows_lifecycle_drain_race_test`. |

Both findings verified against current source; neither was already covered by the merged rf2-2woz9 fix.

## Core touches (flagged)

The lane is `implementation/flows/**`. Finding 1's root cause is the rollback site in **`implementation/core/src/re_frame/router.cljc`** (the bead's identified location, line ~887), so two core files are touched and flagged:
- `router.cljc` — snapshot stash in `flows-after-interceptor`, restore in `commit-db-effect!`'s rollback arm.
- `late_bind/directory.cljc` — directory entries for the two new hooks (required by the late-bind drift gate for any new publication).

`core/frame.cljc` is **not** touched.

## Quality gates

- `cd implementation/flows && clojure -M:test` → **154 tests, 4637 assertions, 0 failures, 0 errors**
- `cd implementation/core && clojure -M:test` → **916 tests, 4120 assertions, 0 failures, 0 errors**
- late-bind drift gate (`re-frame.late-bind-drift-test`) → **5 tests, 478 assertions, 0 failures**
- `cd implementation && npm run test:cljs` → **5854 tests, 20750 assertions, 0 failures, 0 errors**

The finding-2 regression was verified to **fail** against a simulated pre-lock-read (`:out-b = 500` lingers stale) while the existing rf2-2woz9 regressions in the same file still pass — confirming it pins exactly the bug.

Closes rf2-4wqu6.