### PR TITLE
ci: add JVM security-tier job to test.yml (rf2-oni7gz)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -208,7 +208,7 @@ else
         adapter_testbed_smokes=true
         story_xray_browser=true
         ;;
-      implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/epoch/*|implementation/deps.edn)
+      implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/epoch/*|implementation/security/*|implementation/deps.edn)
         # rf2-8jz9t — adapter_testbed_smokes NOT fired here. Per-feature
         # artefact changes are covered by their own JVM + CLJS unit
         # suites (implementation_jvm, cljs_browser, cljs_prod) and by

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -728,6 +728,59 @@ jobs:
       - name: Run JVM tests (ssr artefact)
         run: clojure -M:test
 
+  jvm-security:
+    name: JVM security (clojure -M:test)
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation/security
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-security-${{ hashFiles('implementation/security/deps.edn', 'implementation/core/deps.edn', 'implementation/schemas/deps.edn', 'implementation/machines/deps.edn', 'implementation/routing/deps.edn', 'implementation/flows/deps.edn', 'implementation/ssr/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-security-
+            ${{ runner.os }}-clj-
+
+      # rf2-oni7gz — closes the gap left by rf2-gj2ae. gj2ae added the
+      # implementation/security :test alias (a cross-artefact, src-less
+      # adversarial-property tier) and wired it into the local rigorous
+      # gate (scripts/test-jvm-implementation.sh), but no PR-CI job ran it
+      # on the JVM. The security namespaces are .cljc and advertise a
+      # cross-runtime contract — most pointedly re-frame.security.gen's LCG
+      # ("byte-deterministic AND identical across JVM + JS", separate :clj
+      # full-precision `long` multiply vs :cljs Math.imul arms). Without
+      # this job the :clj reader-conditional arms (gen's multiply, the
+      # egress/redaction :clj helper branches, the clojure.walk deep-scan)
+      # never executed on the JVM in CI — a false-green cross-runtime
+      # security contract. This job runs the SAME .cljc namespaces under
+      # the JVM via the cognitect test-runner (non-zero exit on any
+      # failure), so a :clj-arm divergence in re-frame.security.gen now
+      # turns the PR CI red.
+      - name: Run JVM tests (security tier)
+        run: clojure -M:test
+
   jvm-ssr-ring:
     name: JVM ssr-ring (clojure -M:test)
     needs: detect_changed_surfaces
@@ -2495,6 +2548,7 @@ jobs:
       - jvm-flows
       - jvm-http
       - jvm-ssr
+      - jvm-security
       - jvm-ssr-ring
       - jvm-epoch
       - cljs


### PR DESCRIPTION
Follow-up to rf2-gj2ae. Closes the PR-CI gap for the `implementation/security` adversarial-property tier.

## What

rf2-gj2ae added the `implementation/security/deps.edn` `:test` alias (a src-less, cross-artefact adversarial-property test surface) and wired it into the local rigorous gate (`scripts/test-jvm-implementation.sh`). But `test.yml` had a per-artefact `JVM <artefact>` job for every implementation artefact EXCEPT security, so the tier never ran on the JVM in PR CI. The security namespaces are `.cljc` and advertise a cross-runtime contract — most pointedly `re-frame.security.gen`'s LCG (separate `:clj` full-precision `long`-multiply vs `:cljs` `Math.imul` arms). The `:clj` reader-conditional arms (gen multiply, the egress/redaction `:clj` helper branches, the `clojure.walk` deep-scan) were never executed in CI: a false-green cross-runtime security contract.

- **`.github/workflows/test.yml`** — add a `jvm-security` job mirroring `jvm-ssr` exactly (same `setup-clojure` / cache shape, `working-directory: implementation/security`, `clojure -M:test`). Cache key hashes the security deps + its transitive artefact deps (core/schemas/machines/routing/flows/ssr). Wired into the `all-required-passed` aggregator `needs:` so it gates merges.
- **`.github/scripts/report-changed-surfaces.sh`** — add `implementation/security/*` to the per-feature artefact classifier case so a security-only PR fires `implementation_jvm` (the job's `if`-gate) and `cljs_node_test`. Without this the new job would *skip* on a security-only PR and never gate — defeating the bead's acceptance criterion ("a JVM-side `:clj`-arm divergence in `re-frame.security.gen` turns the PR CI red"). This second file is outside the test.yml lane but is load-bearing for the gate to be real; flagging it explicitly.

Acceptance (rf2-oni7gz): a JVM-side `:clj`-arm divergence in `re-frame.security.gen` now turns the PR CI red.

## Quality gates

- `clojure -M:test` from `implementation/security` — **56 tests, 452 assertions, 0 failures, 0 errors** (matches the bead's expected 56).
- `python yaml.safe_load` on `test.yml` — parses; `jvm-security` is a defined job AND present in the aggregator `needs:`.
- Job shape verified to mirror `jvm-ssr` (checkout / JDK 21 / Clojure CLI / Maven cache steps identical; same `if`-gate, `needs: detect_changed_surfaces`, `clojure -M:test`).
- `bash -n` on `report-changed-surfaces.sh` — syntax OK.
- Classifier behaviour: `bash report-changed-surfaces.sh implementation/security/test/...cljc` now emits `implementation_jvm=true` + `cljs_node_test=true` (was `false` before the fix).

Closes rf2-oni7gz.
