### PR TITLE
fix(story-mcp+pair-mcp): surface :changed tool names in descriptor-manifest drift messages (rf2-ijn9k)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/descriptor_manifest_gen.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/descriptor_manifest_gen.cljs
@@ -62,13 +62,25 @@
     (println (str "Wrote " p " (" (-> manifest :meta :tool-count) " tools)."))
     manifest))
 
+(defn- row-slot-deltas
+  "Seq of `[slot old-val new-val]` for the catalogue slots that differ
+  between a tool's committed `old` row and regenerated `new` row. Names
+  exactly which of the manifest's governed slots drifted so a descriptor-
+  only change is actionable without a manual whole-manifest diff."
+  [old new]
+  (for [slot [:description :input-keys :output? :annotations]
+        :let [o (get old slot)
+              n (get new slot)]
+        :when (not= o n)]
+    [slot o n]))
+
 (defn check! []
   (let [manifest  (build)
         edn       (dm/render-edn manifest)
         p         (manifest-path)
         committed (when (.existsSync fs p)
                     (.toString (.readFileSync fs p)))
-        {:keys [ok? added removed missing-file?]} (dm/check manifest edn committed)]
+        {:keys [ok? added removed changed missing-file?]} (dm/check manifest edn committed)]
     (if ok?
       (do (println (str "OK: tool-descriptors.edn in sync ("
                         (-> manifest :meta :tool-count) " tools)."))
@@ -79,13 +91,20 @@
               (println "DRIFT: generated manifest differs from tool-descriptors.edn."))
             (println "Regenerate with: node scripts/descriptor-manifest-gen.cjs")
             (when (seq added)
-              (println "  Tools the registry has that the committed file lacks (new/renamed tool, or changed catalogue shape):")
+              (println "  Tools the registry has that the committed file lacks (new/renamed tool):")
               (doseq [n added] (println "    +" n)))
             (when (seq removed)
               (println "  Tools in the committed file the registry no longer has (removed/renamed tool):")
               (doseq [n removed] (println "    -" n)))
-            (when (and (empty? added) (empty? removed))
-              (println "  (tool set identical; a descriptor's input-keys / output? / annotations changed — regenerate)")))
+            (when (seq changed)
+              (println "  Existing tools whose descriptor catalogue row changed (input-keys / output? / annotations / description):")
+              (doseq [{:keys [name old new]} changed]
+                (println "    ~" name)
+                (doseq [[slot o n] (row-slot-deltas old new)]
+                  (println (str "        " (cljs.core/name slot) ": "
+                                (pr-str o) " -> " (pr-str n))))))
+            (when (and (empty? added) (empty? removed) (empty? changed))
+              (println "  (tool set identical; the committed file is structurally broken or its provenance banner/meta drifted — regenerate)")))
           false))))
 
 (defn -main [& args]

--- a/tools/story-mcp/src/re_frame/story_mcp/descriptor_manifest_gen.clj
+++ b/tools/story-mcp/src/re_frame/story_mcp/descriptor_manifest_gen.clj
@@ -53,6 +53,18 @@
                      (-> manifest :meta :tool-count)))
     manifest))
 
+(defn- row-slot-deltas
+  "Seq of `[slot old-val new-val]` for the catalogue slots that differ
+  between a tool's committed `old` row and regenerated `new` row. Names
+  exactly which of the manifest's governed slots drifted so a descriptor-
+  only change is actionable without a manual whole-manifest diff."
+  [old new]
+  (for [slot [:description :input-keys :output? :annotations]
+        :let [o (get old slot)
+              n (get new slot)]
+        :when (not= o n)]
+    [slot o n]))
+
 (defn check!
   "Regenerate in memory + compare to the committed file. Returns true
   when in sync, false (with a printed diff summary) when drifted."
@@ -61,7 +73,7 @@
         edn       (dm/render-edn manifest)
         f         (manifest-file)
         committed (when (.exists ^java.io.File f) (slurp f))
-        {:keys [ok? added removed missing-file?]} (dm/check manifest edn committed)]
+        {:keys [ok? added removed changed missing-file?]} (dm/check manifest edn committed)]
     (if ok?
       (do (println (format "OK: tool-descriptors.edn in sync (%d tools)."
                            (-> manifest :meta :tool-count)))
@@ -73,15 +85,23 @@
             (println "Regenerate with: clojure -M:gen (from tools/story-mcp/)")
             (when (seq added)
               (println "  Tools the registry has that the committed file lacks"
-                       "(new/renamed tool, or changed catalogue shape):")
+                       "(new/renamed tool):")
               (doseq [n added] (println "    +" n)))
             (when (seq removed)
               (println "  Tools in the committed file the registry no longer has"
                        "(removed/renamed tool):")
               (doseq [n removed] (println "    -" n)))
-            (when (and (empty? added) (empty? removed))
-              (println "  (tool set identical; a descriptor's input-keys / output? /"
-                       "annotations changed — regenerate)")))
+            (when (seq changed)
+              (println "  Existing tools whose descriptor catalogue row changed"
+                       "(input-keys / output? / annotations / description):")
+              (doseq [{:keys [name old new]} changed]
+                (println "    ~" name)
+                (doseq [[slot o n] (row-slot-deltas old new)]
+                  (println (format "        %s: %s -> %s" (clojure.core/name slot)
+                                   (pr-str o) (pr-str n))))))
+            (when (and (empty? added) (empty? removed) (empty? changed))
+              (println "  (tool set identical; the committed file is structurally"
+                       "broken or its provenance banner/meta drifted — regenerate)")))
           false))))
 
 (defn -main [& args]


### PR DESCRIPTION
Follow-on to rf2-y3qpv / PR #3305. `re-frame.mcp-base.descriptor-manifest/check` now returns `:changed [{:name :old :new} ...]` — the row-level identity of which EXISTING tool's catalogue row drifted (description / input-keys / output? / annotations). The two consumer drift-check generators still destructured only `{:keys [ok? added removed missing-file?]}` and printed the generic "tool set identical; a descriptor changed — regenerate" fallback whenever `:added`/`:removed` were empty, forcing a maintainer to manually diff the whole manifest to find what moved.

## What changed

Both `check!` generators now:
- destructure `:changed` from the `dm/check` result;
- print, per drifted tool, its name and the per-slot deltas — only the catalogue slots that actually differ (`description` / `input-keys` / `output?` / `annotations`) — via a small shared `row-slot-deltas` helper, so a descriptor-only drift is actionable without a manual whole-manifest diff;
- correct the `:added` message wording (a descriptor-only change no longer surfaces as `:added` now that `:changed` exists — `:added` is purely identity-entry);
- rephrase the now-rare all-empty fallback to its actual remaining cause (structurally broken committed file, or banner/meta drift).

Files (sibling lanes, not touched by rf2-y3qpv which was mcp-base-only):
- `tools/story-mcp/src/re_frame/story_mcp/descriptor_manifest_gen.clj` (`check!`)
- `tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/descriptor_manifest_gen.cljs` (`check!`)

No back-compat shim. No change to any tool descriptor, registry, or committed `tool-descriptors.edn` — message-only.

## Quality gates

All run from the worktree on this branch:

- story-mcp `clojure -M:gen --check` — `OK: tool-descriptors.edn in sync (20 tools).`
- story-mcp `clojure -M:test` — 245 tests / 1196 assertions, 0 failures, 0 errors.
- pair-mcp `npm run check:descriptors` — `OK: tool-descriptors.edn in sync (28 tools).` (CLJS build: 0 warnings)
- pair-mcp `npm test` — 983 tests / 2985 assertions, 0 failures, 0 errors.
- `npm run test:mcp-conformance` (from implementation/) — ALL MCP-CONFORMANCE GATES GREEN (6/6 stages; wire-vocab 57 tests / 687 assertions, 0 failures).

Closes rf2-ijn9k.
