### PR TITLE
fix(examples/reagent-slim): independent-review finding (rf2-y4ai7h)

### DIFF
--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -98,8 +98,26 @@
   ;; property. The closure compiler treats writes to extern-shaped
   ;; properties on `globalThis` as side effects; the call survives
   ;; `:advanced`. (A no-op like `js/console.log` would be elided.)
-  (set! (.-counterSlimPrerender js/globalThis)
-        (rds/render-to-static-markup [counter-app]))
+  ;;
+  ;; SUB-CACHE TEARDOWN: `render-to-static-markup` is the pure-CLJS
+  ;; static walker — it invokes `counter-app`/`counter-buttons` as plain
+  ;; fns and walks the resulting hiccup, but mounts NO Reagent component
+  ;; lifecycle. The view derefs `@(subscribe [:counter/value])`, so the
+  ;; static render builds and caches that reactive subscription in the
+  ;; default frame's sub-cache with ref-count 1, and nothing ever
+  ;; auto-unsubscribes it (there is no component to unmount). Left as-is
+  ;; the boot would carry a headless `[:counter/value]` reaction into the
+  ;; live runtime — a hidden leak the browser mount can't reclaim (its
+  ;; unmount only drops the browser-owned reference). Bracket the
+  ;; prerender so the orphaned SSR subscription is disposed before the
+  ;; client mount builds its own; `try`/`finally` guarantees teardown even
+  ;; if the static render throws. The browser mount below then starts from
+  ;; a clean cache and owns the only `[:counter/value]` reaction.
+  (try
+    (set! (.-counterSlimPrerender js/globalThis)
+          (rds/render-to-static-markup [counter-app]))
+    (finally
+      (rf/clear-sub-cache!)))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))


### PR DESCRIPTION
## Summary

Independent correctness review of `examples/reagent-slim` (bead rf2-y4ai7h, P4). One finding, **confirmed against current source and actioned**.

### Finding (confirmed, fixed)

`counter_slim_and_fast/core.cljs` `run` exercises `reagent2.dom.server/render-to-static-markup` by rendering `[counter-app]` at boot (to make the pure-CLJS SSR contract non-vacuous). `counter-app` → `counter-buttons` derefs `@(subscribe [:counter/value])`. `render-to-static-markup` is the pure-CLJS static walker: it invokes the view as a plain fn (`emit-user-fn` → `(apply f ...)`) and walks the resulting hiccup, but mounts **no Reagent component lifecycle**. So `subscribe` runs `compute-and-cache!`, which `assoc`es the `[:counter/value]` reaction into the default frame's `:sub-cache` with `ref-count 1` — and nothing ever auto-unsubscribes it (no component to unmount). The headless reaction leaks into the live runtime; the subsequent browser mount can only ever drop its own browser-owned reference, leaving the SSR-owned reaction alive until `clear-sub-cache!` / frame destruction.

### Fix

Bracket the prerender in `try`/`finally` and call `rf/clear-sub-cache!` before the client mount, so the orphaned SSR subscription is disposed before the browser mount builds its own. `try`/`finally` guarantees teardown even if the static render throws. `clear-sub-cache!` clears only the reactive cache, not app-db, so the `:counter/value` of 5 survives and the client render is unchanged.

Chose this over the alternative (an SSR-only `subscribe-once` sentinel view) because it keeps the example's intent intact — the SSR path still walks the **real** view with its reactive `subscribe`, faithfully exercising static markup of the actual component, while explicitly tearing down the imperatively-created subscription (exactly the non-reactive-consumer teardown `clear-sub-cache!` documents).

### Scope / dedup

- Touches ONLY `examples/reagent-slim/**` (the example). Distinct from the merged **adapter** work (ygknv/e4pyb/o3hqr — `implementation/adapters/reagent-slim`).
- The behavioural twin `examples/reagent/counter` does NOT do the SSR prerender, so this is slim-example-specific, not twin-shared.
- Per rf2-8cevm the example tree is test-free — no `*.spec.cjs` added. Real regression coverage lives in the substrate contract tests / bundle-isolation gate.

## Quality gates

- `npm run test:examples-compile` — PASS. All 39 example builds compiled with zero warnings, including `examples/counter-slim-and-fast`.
- README not touched → `check_doc_slugs.py` / `check_readme_*` not applicable.
- Change is bundle-neutral (`rf/clear-sub-cache!` is core `re-frame.subs.cache`, already in the bundle; introduces no `reagent.impl.*` / `react-dom/server` symbols), so `test:reagent-slim:bundle-isolation` is unaffected.

## Disposition

Finding **confirmed and fixed** (not a dup, not already-resolved). Closes rf2-y4ai7h.