### PR TITLE
fix(routing): senior-review finding (rf2-8xvyo)

### DIFF
--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -1005,18 +1005,28 @@
            ;; honest. This narrows the spec's "present-but-falsy round-trips"
            ;; to the values that actually CAN (`false`, `0`); `""` is the
            ;; one falsy value with no legitimate segment form.
+           ;; A PRESENT value for a path segment must be non-empty. Shared
+           ;; by `require-param` (top-level segments) and `emit-group`
+           ;; (optional-group inner segments): the empty-string-segment
+           ;; rule is a property of the SEGMENT, not of where it sits in
+           ;; the pattern. Spec 012 §`route-url` nil-policy: `""` on a path
+           ;; param is a hard error on EITHER side because a zero-length
+           ;; segment (`/articles/`) round-trips back as the param ABSENT.
+           reject-empty-segment
+           (fn [k kind v]
+             (if (= "" (str v))
+               (throw (route-error
+                        :rf.error/missing-route-param
+                        'rf/route-url
+                        (str "route " route-id " requires a non-empty " kind " param " k
+                             " but it was an empty string (a zero-length path segment "
+                             "cannot round-trip through match-url)")
+                        {:param k :route-id route-id :value v}))
+               v))
            require-param
            (fn [k kind]
              (if-some [v (get path-params k)]
-               (if (= "" (str v))
-                 (throw (route-error
-                          :rf.error/missing-route-param
-                          'rf/route-url
-                          (str "route " route-id " requires a non-empty " kind " param " k
-                               " but it was an empty string (a zero-length path segment "
-                               "cannot round-trip through match-url)")
-                          {:param k :route-id route-id :value v}))
-                 v)
+               (reject-empty-segment k kind v)
                (throw (route-error
                         :rf.error/missing-route-param
                         'rf/route-url
@@ -1042,11 +1052,21 @@
 
                    ;; `:name` / `*name` inside an optional group — the
                    ;; group is only entered when all its inner params are
-                   ;; present, so read directly (no require check).
+                   ;; `some?` (absent → the whole group elides), so the
+                   ;; ABSENT case is already handled by the enclosing gate.
+                   ;; A PRESENT `""` is NOT elision: `(some? "")` is true,
+                   ;; so the group is entered and would emit a zero-length
+                   ;; segment (`/articles/` for `{:id ""}`) that round-trips
+                   ;; back as the param absent — the same un-round-trippable
+                   ;; URL the top-level path rejects. Spec 012's nil-policy
+                   ;; table makes `""` a hard error for ANY path segment, so
+                   ;; reject it here too (`false`/`0` still round-trip).
                    (or (= ch \:) (= ch \*))
-                   (let [[end k] (param-seg-bounds pattern n i)]
-                     (recur end (conj parts (encode-param (= ch \*)
-                                                          (get path-params k)))))
+                   (let [splat?  (= ch \*)
+                         [end k] (param-seg-bounds pattern n i)
+                         v       (reject-empty-segment k (if splat? "splat" "path")
+                                                       (get path-params k))]
+                     (recur end (conj parts (encode-param splat? v))))
 
                    :else
                    (recur (inc i) (conj parts (str ch)))))))

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -2773,6 +2773,81 @@
            (routing/route-url :route/articles2 {:id "intro" :slug "welcome"}))
         "all inner params present → group emits")))
 
+;; ---- rf2-8xvyo: empty-string path param inside an OPTIONAL GROUP is
+;; rejected on emission, exactly like a top-level required path param.
+;;
+;; The optional-group gate enters a group when every inner param is
+;; `some?`. `(some? "")` is TRUE, so `{:id ""}` ENTERS the group and the
+;; pre-fix emitter wrote the value directly — emitting a zero-length
+;; segment (`/articles/`) that `match-url`'s trailing-slash normalisation
+;; erases (`/articles/` → `/articles`) before matching. The URL then
+;; round-trips back as the param ABSENT, diverging the committed route
+;; slice from the address bar (reload / popstate / SSR-hydration drift).
+;; Spec 012 §`route-url` nil-policy makes `""` a HARD ERROR for ANY path
+;; segment — the optional-group path must apply the same invariant as the
+;; top-level `require-param` (rf2-ede1h.2). `false` / `0` are non-empty
+;; legitimate segments and still round-trip on either side.
+
+(deftest route-url-optional-group-empty-string-rejected
+  (testing "rf2-8xvyo: an empty-string param inside an optional group is
+            REJECTED on emission — it cannot emit an un-round-trippable
+            trailing slash (`/articles/`)"
+    (rf/reg-route :route/og-articles {:path "/articles{/:id}?"})
+    ;; Sanity: absent elides, present-non-empty emits, as before.
+    (is (= "/articles"
+           (routing/route-url :route/og-articles {}))
+        "absent :id → group elides; bare /articles")
+    (is (= "/articles/intro"
+           (routing/route-url :route/og-articles {:id "intro"}))
+        "present non-empty :id → group emits")
+    ;; The bug: `(some? "")` enters the group, then emits `/articles/`.
+    (let [ex (try
+               (routing/route-url :route/og-articles {:id ""})
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex)
+          "\"\" optional-group param throws (it would emit \"/articles/\", which match-url normalises to \"/articles\" and re-parses with :id ABSENT)")
+      (is (= ":rf.error/missing-route-param" (ex-message ex))
+          "reuses the missing/empty-required-param error id")
+      (is (= "" (:value (ex-data ex)))
+          "ex-data carries the offending empty-string value")))
+
+  (testing "rf2-8xvyo: empty-string rejection holds for an optional group
+            trailing a REQUIRED top-level param (/articles/:id{/:slug}?)"
+    (rf/reg-route :route/og-slug {:path "/articles/:id{/:slug}?"})
+    ;; The required :id still round-trips; absent :slug elides.
+    (is (= "/articles/5"
+           (routing/route-url :route/og-slug {:id "5"}))
+        "required :id present, optional :slug absent → group elides")
+    (is (= "/articles/5/welcome"
+           (routing/route-url :route/og-slug {:id "5" :slug "welcome"}))
+        "both present → group emits")
+    ;; Empty optional-group :slug rejected (would emit "/articles/5/").
+    (let [ex (try
+               (routing/route-url :route/og-slug {:id "5" :slug ""})
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex)
+          "\"\" optional-group :slug throws — it would emit the un-round-trippable \"/articles/5/\"")
+      (is (= ":rf.error/missing-route-param" (ex-message ex)))
+      (is (= "" (:value (ex-data ex))))))
+
+  (testing "rf2-8xvyo: false and 0 inside an optional group STILL round-trip —
+            only the empty string is rejected (non-empty falsy is legitimate)"
+    (rf/reg-route :route/og-flag {:path "/items{/:flag}?"})
+    (is (= "/items/false"
+           (routing/route-url :route/og-flag {:flag false}))
+        "false → non-empty segment \"false\"")
+    (is (= "/items/0"
+           (routing/route-url :route/og-flag {:flag 0}))
+        "0 → non-empty segment \"0\"")
+    (is (= {:flag "false"}
+           (:params (routing/match-url (routing/route-url :route/og-flag {:flag false}))))
+        "false round-trips through match-url")
+    (is (= {:flag "0"}
+           (:params (routing/match-url (routing/route-url :route/og-flag {:flag 0}))))
+        "0 round-trips through match-url")))
+
 ;; ---- rf2-8zvajk: slash-OWNED INLINE optional group ({:base}?) ------------
 ;;
 ;; The grammar permits TWO optional-group shapes (Spec 012 §Path-pattern


### PR DESCRIPTION
## Summary

Senior-review finding rf2-8xvyo: `route-url` enforced the non-empty path-segment invariant for top-level required params (via `require-param`) but params inside `{...}?` optional groups bypassed it.

The optional-group gate enters a group when every inner param is `(some? ...)`. `(some? "")` is `true`, so `{:id ""}` **entered** the group, and `emit-group` wrote `(get path-params k)` directly — emitting a zero-length segment (`/articles/`). `match-url` normalises that to `/articles` and re-parses with the param **absent**, so the URL cannot round-trip: the committed route slice diverges from the address bar (reload / popstate / SSR-hydration drift), and `:on-match` can suppress or re-fire on a slice the URL cannot represent.

Spec 012 §`route-url` nil-policy makes `""` a **hard error** for any path segment, top-level or optional-group ("a zero-length segment cannot round-trip").

## Fix

- Extracted `reject-empty-segment` as a shared helper in `route-url`'s `let`.
- `require-param` now delegates its empty-string check to it (behaviour unchanged for top-level params).
- `emit-group` applies `reject-empty-segment` to each optional-group inner param — a present `""` throws `:rf.error/missing-route-param`, matching the top-level path. Absent params still elide the whole group (unchanged); `false` / `0` are non-empty legitimate segments and still round-trip.

No back-compat shim; stricter rejection matches the existing top-level behaviour and the spec.

## Quality gates

- routing JVM (`clojure -M:test`): **160 tests, 784 assertions, 0 failures, 0 errors** (includes the new `route-url-optional-group-empty-string-rejected` deftest).
- `npm run test:cljs`: **5870 tests, 20783 assertions, 0 failures, 0 errors**.

New regression coverage: `/articles{/:id}?` and `/articles/:id{/:slug}?` prove `""` cannot emit an un-round-trippable trailing slash; `/items{/:flag}?` proves `false` and `0` still round-trip.

## Disposition

Genuinely live — verified the optional-group bypass against current source before fixing. Not a duplicate of rf2-ede1h (which fixed the top-level required-param path only). Fixed, not closed-as-dup.

Closes rf2-8xvyo.
