### PR TITLE
fix(tools/testbed-support): senior-review finding (rf2-x31vn)

### DIFF
--- a/tools/testbed-support/README.md
+++ b/tools/testbed-support/README.md
@@ -48,17 +48,19 @@ shell. The plumbing that switches between them (a `defonce` React-root
 handle, the tear-down-one-before-mounting-the-other dance, and the
 `hashchange` listener) is pure React-DOM-root juggling — identical across
 every testbed but for the live-app root view. It was copy-pasted across
-five files (`counter_with_stories`, `login_form`, the `login` and
-`nine_states` examples, plus the template scaffolding), already drifting in
-the per-testbed boot specifics they each add.
+six hosts (`counter_with_stories`, `login_form`, the `login` and
+`nine_states` examples, the Xray `panel_gallery` testbed, plus the template
+scaffolding), already drifting in the per-testbed boot specifics they each add.
 
 `re-frame.testbed.story-host/mount-with-hash-routing!` owns that harness:
 the testbed does its own boot (Xray config, `rf/init!`, `story/configure!`,
 `:fx-overrides`, seed dispatches, CI hooks) and calls the helper LAST with
-its live-app root view. Four of the five copies now call it; the **template
-copy stays standalone by design** — it is `resources/` scaffolding emitted
-into a fresh consumer project whose classpath has no access to this
-dev-repo-internal helper.
+its live-app root view. Five of the six hosts now call it (the four Story
+showcases above plus `panel_gallery`, which previously installed a bare
+per-`run` `hashchange` listener — rf2-x31vn); the **template copy stays
+standalone by design** — it is `resources/` scaffolding emitted into a fresh
+consumer project whose classpath has no access to this dev-repo-internal
+helper.
 
 ## Layout
 

--- a/tools/xray/testbeds/panel_gallery/core.cljs
+++ b/tools/xray/testbeds/panel_gallery/core.cljs
@@ -73,8 +73,7 @@
   the bundle-isolation enforcement at
   `implementation/scripts/test-bundle-isolation.sh`. Production app
   code never `:requires` anything under `tools/xray/testbeds/`."
-  (:require [reagent.dom.client :as rdc]
-            [re-frame.core :as rf]
+  (:require [re-frame.core :as rf]
             [re-frame.story :as story]
             [re-frame.adapter.reagent :as reagent-adapter]
             ;; rf2-2c5xb — Xray's `configure!` to seed `:project-root`
@@ -145,7 +144,15 @@
             [panel-gallery.gallery-diff-mode-3]
             ;; Shared testbed-config helper (rf2-5dphw): derives the
             ;; open-in-editor project-root from the build env.
-            [re-frame.testbed.config :as testbed-config]))
+            [re-frame.testbed.config :as testbed-config]
+            ;; Shared live-app↔Story-shell hash-router host (rf2-tq26t /
+            ;; rf2-uv7sn). rf2-x31vn — panel-gallery adopts the helper so
+            ;; its `hashchange` listener is installed via the helper's
+            ;; remove-then-add `defonce` handle discipline rather than a
+            ;; bare per-`run` `addEventListener` (which stacks a duplicate
+            ;; listener on every CLJS hot-reload, since reload rebinds the
+            ;; `defn` to a fresh fn the browser cannot dedupe by identity).
+            [re-frame.testbed.story-host :as story-host]))
 
 ;; ============================================================================
 ;; LANDING — the URL `/` view (no `#/stories` hash)
@@ -225,32 +232,14 @@
 (defn- resolve-project-root []
   (testbed-config/resolve-project-root "tools/xray/testbeds"))
 
-(defonce ^:private app-root (atom nil))
-
-(defn- ensure-app-root! []
-  (when (nil? @app-root)
-    (reset! app-root (rdc/create-root (js/document.getElementById "app"))))
-  @app-root)
-
-(defn- tear-down-app-root! []
-  (when-let [root @app-root]
-    (try (rdc/unmount root) (catch :default _ nil))
-    (reset! app-root nil)))
-
-(defn- mount-landing! []
-  (story/unmount-shell!)
-  (ensure-app-root!)
-  (rdc/render @app-root [landing-view]))
-
-(defn- mount-stories! []
-  (tear-down-app-root!)
-  (story/mount-shell! (js/document.getElementById "app")))
-
-(defn- on-hash-change! []
-  (let [hash (or (.. js/window -location -hash) "")]
-    (if (re-find #"^#/stories" hash)
-      (mount-stories!)
-      (mount-landing!))))
+;; -- Routing between landing and Story shell ------------------------------
+;;
+;; The live-app↔Story-shell hash router + React-root host handle live in the
+;; shared `re-frame.testbed.story-host` helper (rf2-tq26t / rf2-uv7sn); `run`
+;; hands it `landing-view` as the live-app surface. The helper tears one React
+;; root down before mounting the other on the same `#app` node, and installs
+;; its `hashchange` listener via a `defonce` remove-then-add handle so a CLJS
+;; hot-reload re-`run` never stacks a duplicate (rf2-x31vn).
 
 (defn ^:export run []
   ;; rf2-2c5xb — seed `:rf.xray/project-root` BEFORE the Xray handlers
@@ -301,5 +290,10 @@
   ;; namespaces loaded before this fn ran (CLJS reload order isn't
   ;; guaranteed at the application level).
   (panel-views/register!)
-  (.addEventListener js/window "hashchange" on-hash-change!)
-  (on-hash-change!))
+  ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
+  ;; `#/stories` lands on the shell — and so the `hashchange` listener is
+  ;; installed via the helper's remove-then-add `defonce` handle rather than a
+  ;; bare per-`run` `addEventListener` that stacks duplicates across hot-reload
+  ;; (rf2-x31vn). The helper renders `[landing-view]` for any non-`#/stories`
+  ;; hash, matching the prior `mount-landing!`.
+  (story-host/mount-with-hash-routing! landing-view))


### PR DESCRIPTION
Closes rf2-x31vn (senior review: tools/testbed-support, 1 finding).

## Disposition

**Fixed** (not already-resolved). Verified against `origin/main` (d7f99e286): `tools/xray/testbeds/panel_gallery/core.cljs:304` still carried a bare per-`run` `(.addEventListener js/window "hashchange" on-hash-change!)` with no stored/removed handle, outside the shared `re-frame.testbed.story-host` helper. Not a dup of rf2-liive (that fixed the helper + its direct consumers; this migrates the still-copy-pasted panel_gallery caller).

## What changed

- **`tools/xray/testbeds/panel_gallery/core.cljs`** — migrate the host block onto `re-frame.testbed.story-host/mount-with-hash-routing!`. Removes the copied `app-root` atom + `ensure-app-root!` / `tear-down-app-root!` / `mount-landing!` / `mount-stories!` / `on-hash-change!` and the bare `addEventListener`; `run` now calls `(story-host/mount-with-hash-routing! landing-view)` last. Drops the now-unused `reagent.dom.client` require.
- **`tools/testbed-support/README.md`** — record panel_gallery as a fifth adopter of the helper; the **template copy stays standalone by design** is the only remaining exception.

### Why it was a bug

CLJS hot-reload rebinds the top-level `on-hash-change!` `defn` to a fresh function object. `removeEventListener` dedupes by reference identity, so the browser cannot no-op a repeat `addEventListener` of "the same fn" after a reload — each reloaded `run` STACKED another listener. Later hash changes then ran the mount switch N times, churning the React root on `#app` and losing Story-shell state. The shared helper's `defonce` remove-then-add handle (the exact discipline introduced for this listener-identity class) keeps exactly one listener active across any number of re-`run`s.

The migration is behaviour-preserving: the helper renders `[landing-view]` for any non-`#/stories` hash (matching the prior `mount-landing!`), and tears one React root down before mounting the other on `#app`. The one-active-listener contract is already pinned by `tools/testbed-support/src/re_frame/testbed/story_host_cljs_test.cljs` (rf2-liive).

## Quality gates

- `npm run test:cljs` (from `implementation/`): **5870 tests, 20783 assertions, 0 failures, 0 errors.** This compiles the full `node-test` build (all source paths incl. `../tools/testbed-support/src` and `../tools/xray/testbeds`), so the panel_gallery namespace compiles cleanly with the new `story-host` require, and the testbed-support tests (`config_cljs_test`, `story_host_cljs_test`) ran green.

Acceptance met: panel_gallery now has exactly one active `hashchange` listener after repeated hot-reload `run` calls with changed handler identity (delegated to the helper's tested handle discipline), and the README accurately states the remaining standalone exception (template only).

Do NOT merge — leaving for mayor review.
