### PR TITLE
fix(flows): senior-review finding (rf2-ouemt)

### DIFF
--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -455,10 +455,16 @@
   (when sub-id
     (marks-for :sub sub-id)))
 
-(defn- flow-marks
-  [flow-id]
-  (when flow-id
-    (marks-for :flow flow-id)))
+;; Flow output marks are NOT resolved through this per-(kind, id) table
+;; (rf2-ouemt). Spec 013 lets the SAME flow-id carry different definitions —
+;; hence different `:sensitive` / `:large` declarations — in different
+;; frames, so a frame-blind `{flow-id marks}` shape is wrong for flows.
+;; `re-frame.flows.registry` instead installs each flow's output marks
+;; FRAME-AWARE into that frame's app-db elision registry, rooted at the
+;; flow's `:path`; the schema-first wire walker (`elision/elide-wire-value`)
+;; the flow trace emits already ride, plus `project-db-tags` /
+;; `project-view-rendered-tags` below, redact the flow output through that
+;; single per-frame source of truth.
 
 ;; ---- sub-output propagation registry -------------------------------------
 ;;

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -34,10 +34,10 @@
   re-aggregates the per-frame atoms back into the canonical
   `{flow-id {frame-id inputs}}` observation shape so its public contract
   is unchanged across the storage restructure."
-  (:require [re-frame.flows.topo :as topo]
+  (:require [re-frame.elision :as elision]
+            [re-frame.flows.topo :as topo]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.source-coords :as source-coords]
             [re-frame.substrate.adapter :as adapter]
@@ -345,6 +345,152 @@
             (throw (flow-error error-kw reason flow (when extras (extras flow))))))
         validation-rules))
 
+;; ---- Spec 015 §7 flow-output data classification (rf2-ouemt) --------------
+;;
+;; A `reg-flow` registration may carry data-classification keys describing
+;; the SENSITIVITY / SIZE of the flow's OWN OUTPUT value:
+;;
+;;   :sensitive? true   — the whole output is sensitive
+;;   :large?     true   — the whole output is large
+;;   :sensitive  [paths]— per-output-path sensitive sub-slots ([[]] = whole)
+;;   :large      [paths]— per-output-path large sub-slots ([[]] = whole)
+;;
+;; The flow's output lands in app-db at `(:path flow)`, so a sensitive /
+;; large output value egresses through TWO observation channels:
+;;   1. the `:rf.flow/computed` `:result` / `:before` trace slots (and the
+;;      `:rf.flow/failed` failure path), and
+;;   2. the app-db destination slot itself — visible to App-DB-Diff style
+;;      observation, the `:rf.event/db` pending-db trace, view render-arg
+;;      egress, and any downstream sub reading the slot.
+;;
+;; Rather than projecting the registration marks at each flow emit site (a
+;; flow-id→marks table is wrong for flows — Spec 013 lets the SAME flow-id
+;; carry DIFFERENT definitions, hence different marks, in different frames),
+;; we make the marks FIRST-CLASS through the SAME per-frame elision registry
+;; the schema-first wire walker (`elision/elide-wire-value`) already reads.
+;; We translate the registration's output-rooted marks into ABSOLUTE app-db
+;; declarations rooted at `(:path flow)` and write them into the frame's
+;; `[:rf/runtime :elision :sensitive-declarations]` / `:declarations` slots.
+;;
+;; ONE walker then covers BOTH channels:
+;;   - the flow trace `:result` / `:before` already ride
+;;     `elide-wire-value` rooted at `(:path flow)` (see `re-frame.flows`),
+;;     so they pick the declarations up with no emit-site change; and
+;;   - `project-db-tags` / `project-view-rendered-tags` (re-frame.marks)
+;;     elide the app-db destination slot through the SAME registry, so the
+;;     db-diff / pending-db / view egress paths redact it too.
+;;
+;; Frame-scoping is structural: the declarations live in the FRAME's own
+;; app-db elision registry, so the same flow-id registered against two
+;; frames with different marks writes into two different registries — no
+;; cross-frame bleed. Entries are stamped `{:source :flow :flow-id <id>}`
+;; so lifecycle cleanup (clear-flow / path-change re-register / frame
+;; destroy) can drop exactly this flow's contributions while leaving
+;; schema-sourced (`:source :schema`) and add-marks-sourced
+;; (`:source :marks`) entries untouched.
+
+(defn- flow-output-mark-paths
+  "Translate a flow's output-rooted classification keys into ABSOLUTE
+  app-db declaration paths rooted at the flow's `:path`. Returns
+  `[sensitive-paths large-paths]` (each a vector of absolute path vectors).
+
+  - whole-output `:sensitive?` / `:large?` (true) ⇒ the flow's `:path`
+    itself;
+  - per-path `:sensitive` / `:large` entries ⇒ `(:path flow)` ++ sub-path
+    (`[[]]` whole-value mark ⇒ the `:path` itself);
+  - `:sensitive? false` / `:large? false` ⇒ NO whole-output mark (flows
+    carry no upstream propagation, so the explicit-false override is
+    simply the absence of a whole-output declaration — per-path entries,
+    if any, still apply)."
+  [flow]
+  (let [base       (:path flow)
+        abs        (fn [sub] (into (vec base) sub))
+        per-sens   (->> (:sensitive flow) (filter vector?) (map abs))
+        per-large  (->> (:large flow)     (filter vector?) (map abs))
+        whole-sens (when (true? (:sensitive? flow)) [(vec base)])
+        whole-lg   (when (true? (:large? flow))     [(vec base)])]
+    [(vec (concat whole-sens per-sens))
+     (vec (concat whole-lg   per-large))]))
+
+(defn- flow-declares-marks?
+  "True when the flow registration carries any output data-classification
+  key. Used to gate the elision-registry write so the common no-marks
+  FIRST registration skips it entirely (a re-registration still writes —
+  it may need to CLEAR a prior definition's marks)."
+  [flow]
+  (or (contains? flow :sensitive)
+      (contains? flow :large)
+      (contains? flow :sensitive?)
+      (contains? flow :large?)))
+
+(defn- drop-flow-sourced
+  "Remove every `{:source :flow :flow-id <flow-id>}` entry from a
+  declaration map, preserving schema- and marks-sourced entries (and any
+  OTHER flow's entries — disjoint output paths guarantee none overlap, but
+  the `:flow-id` filter keeps the operation surgical regardless)."
+  [decls flow-id]
+  (when decls
+    (reduce-kv (fn [acc path decl]
+                 (if (and (= :flow (:source decl))
+                          (= flow-id (:flow-id decl)))
+                   acc
+                   (assoc acc path decl)))
+               {}
+               decls)))
+
+(defn- assoc-flow-paths
+  "Add `paths` to `existing` declaration map, each stamped
+  `{:source :flow :flow-id <flow-id>}` so lifecycle cleanup can find
+  them. The value-shape is what `elision/elide-wire-value` reads: the
+  sensitive table is membership-only, and the large table's entry rides
+  as the `->marker` hint declaration (we carry no `:hint`, which the
+  walker tolerates — `(:hint nil)` ⇒ no hint)."
+  [existing paths flow-id]
+  (reduce (fn [acc path]
+            (assoc acc (vec path) {:source :flow :flow-id flow-id}))
+          (or existing {})
+          paths))
+
+(defn- write-flow-output-marks!
+  "Install (or refresh) `flow-id`'s output marks into `frame-id`'s app-db
+  elision registry. Drops THIS flow's prior `:source :flow` entries first
+  (so a re-registration that changed `:path` or the mark set replaces
+  cleanly), then overlays the new absolute declarations — a now-unmarked
+  re-registration therefore clears the prior definition's marks. The
+  caller gates a first, no-marks registration out entirely. Shares
+  `swap-elision-slot!` with `re-frame.marks` so the runtime-prune
+  semantics stay uniform."
+  [frame-id flow]
+  (let [flow-id           (:id flow)
+        [sens-abs lg-abs] (flow-output-mark-paths flow)]
+    (elision/swap-elision-slot! frame-id
+      (fn [reg]
+        (let [carry-s (drop-flow-sourced (get reg :sensitive-declarations) flow-id)
+              carry-l (drop-flow-sourced (get reg :declarations) flow-id)
+              new-s   (assoc-flow-paths carry-s sens-abs flow-id)
+              new-l   (assoc-flow-paths carry-l lg-abs flow-id)]
+          (cond-> (or reg {})
+            (seq new-s)    (assoc :sensitive-declarations new-s)
+            (empty? new-s) (dissoc :sensitive-declarations)
+            (seq new-l)    (assoc :declarations new-l)
+            (empty? new-l) (dissoc :declarations)))))))
+
+(defn- clear-flow-output-marks!
+  "Drop `flow-id`'s `:source :flow` declarations from `frame-id`'s app-db
+  elision registry. Called on `clear-flow` and frame-destroy teardown so a
+  deregistered flow leaves no orphaned redaction declaration behind.
+  Schema- and marks-sourced entries survive."
+  [frame-id flow-id]
+  (elision/swap-elision-slot! frame-id
+    (fn [reg]
+      (let [new-s (drop-flow-sourced (get reg :sensitive-declarations) flow-id)
+            new-l (drop-flow-sourced (get reg :declarations) flow-id)]
+        (cond-> (or reg {})
+          (seq new-s)    (assoc :sensitive-declarations new-s)
+          (empty? new-s) (dissoc :sensitive-declarations)
+          (seq new-l)    (assoc :declarations new-l)
+          (empty? new-l) (dissoc :declarations))))))
+
 ;; ---- registration --------------------------------------------------------
 
 ;; `reg-flow`'s same-frame `:path`-change branch (rf2-73pi1) vacates the
@@ -472,6 +618,23 @@
              (let [old-path (:path prior)]
                (when (not= old-path (:path flow))
                  (vacate-output-path! frame-id old-path))))
+           ;; Spec 015 §7 / rf2-ouemt: install this flow's output data-
+           ;; classification marks into the frame's app-db elision registry,
+           ;; rooted at `(:path flow)`. `write-flow-output-marks!` drops THIS
+           ;; flow's prior `:source :flow` entries first, so a re-registration
+           ;; that changed `:path` or the mark set replaces cleanly (covering
+           ;; the old-path declarations the value-vacate above does not touch).
+           ;; Inside the serialized region so a concurrent drain's
+           ;; `elide-wire-value` read cannot observe a half-updated registry.
+           ;;
+           ;; Gate: a FIRST registration with no classification keys skips the
+           ;; registry write entirely (no marks to install, none to clear) so
+           ;; the common no-marks flow pays zero cost and triggers no spurious
+           ;; reactive invalidation. A re-registration (`prior-on-frame`
+           ;; non-nil) ALWAYS writes — even a now-unmarked replacement must
+           ;; CLEAR the prior definition's marks.
+           (when (or (flow-declares-marks? flow) (some? @prior-on-frame))
+             (write-flow-output-marks! frame-id flow))
            ;; Cycle check + commit done atomically above. The :flow registrar
            ;; slot keys on flow-id only; stamp :frame into the metadata so
            ;; introspection
@@ -529,13 +692,17 @@
                        :inputs  (:inputs flow)
                        :path    (:path flow)
                        :frame   frame-id})))
-     ;; Per Spec 015 §7. Flows — stash `:sensitive` / `:large` and
-     ;; `:sensitive?` / `:large?` declarations so emit-time projection
-     ;; resolves the flow's output marks. Late-bound — no-op when the
-     ;; marks artefact is absent (which it never is in core, but the
-     ;; indirection keeps flows decoupled).
-     (when-let [register-marks! (late-bind/get-fn :marks/register-marks!)]
-       (register-marks! :flow flow-id flow))
+     ;; Spec 015 §7. Flows — the output data-classification marks are
+     ;; installed FRAME-AWARE into the app-db elision registry via
+     ;; `write-flow-output-marks!` inside the serialized region above
+     ;; (rf2-ouemt). We deliberately do NOT also stash them in the global
+     ;; `re-frame.marks` per-(kind, id) table: that table is keyed by
+     ;; flow-id ALONE, but Spec 013 lets the SAME flow-id carry DIFFERENT
+     ;; definitions (hence different marks) per frame, so a frame-blind
+     ;; `{flow-id marks}` entry is the wrong shape for flows. The
+     ;; frame-scoped elision-registry write is the single source of truth
+     ;; the wire walker, the db-diff projection, and the view-render-arg
+     ;; projection all read.
      flow-id)))
 
 (defn- dissoc-in-safe
@@ -708,6 +875,11 @@
              (when-let [flow (get-in @flows [frame-id id])]
                (let [path (:path flow)]
                  (vacate-output-path! frame-id path)
+                 ;; Spec 015 §7 / rf2-ouemt: drop this flow's output data-
+                 ;; classification declarations from the frame's app-db elision
+                 ;; registry so a deregistered flow leaves no orphaned redaction
+                 ;; behind. Schema- / add-marks-sourced entries survive.
+                 (clear-flow-output-marks! frame-id id)
                  ;; Drop the flow from `frame-id`'s per-frame slot; when that was
                  ;; the LAST flow on the frame, prune the now-empty `frame-id` key
                  ;; entirely rather than leave a `{frame-id {}}` husk (rf2-4bbaw).

--- a/implementation/flows/test/re_frame/flows_output_marks_test.clj
+++ b/implementation/flows/test/re_frame/flows_output_marks_test.clj
@@ -1,0 +1,358 @@
+(ns re-frame.flows-output-marks-test
+  "JVM coverage for Spec 015 §7 (Flows) data-classification on `reg-flow`
+  (rf2-ouemt — senior-review finding).
+
+  A `reg-flow` registration may carry output data-classification keys
+  (`:sensitive?` / `:large?` whole-output, `:sensitive` / `:large`
+  per-output-path). Pre-fix these were stashed in the frame-blind global
+  `re-frame.marks` `{flow-id marks}` table whose only reader (`flow-marks`)
+  was never wired into the central trace projection switch — so the contract
+  was silently inert: a `{:sensitive [[:secret]]}` or `{:sensitive? true}`
+  flow emitted its raw `:result` on `:rf.flow/computed` AND wrote the raw
+  value to its app-db destination slot (visible to App-DB-Diff / pending-db
+  egress / view render-arg egress).
+
+  The fix makes flow output marks FIRST-CLASS through the SAME per-frame
+  app-db elision registry the schema-first wire walker
+  (`elision/elide-wire-value`) already reads: `reg-flow` translates the
+  output-rooted marks into absolute declarations rooted at `(:path flow)`
+  and installs them frame-aware. ONE walker then redacts BOTH the flow
+  trace `:result` / `:before` slots AND the app-db destination slot.
+
+  These tests pin the five acceptance cases the bead enumerates:
+    1. per-path flow output redaction (`:sensitive` / `:large` sub-paths);
+    2. whole-output `:sensitive? true`;
+    3. `:large` whole-output markers;
+    4. `:sensitive? false` opt-out (no whole-output mark installed);
+    5. same-flow-id multi-frame registrations with DIFFERENT marks (frame
+       isolation — the frame-blind table would conflate them)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.frame :as frame]
+            [re-frame.privacy :as privacy]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+(def ^:dynamic ^:private *captured* nil)
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (reset! schemas/schemas-by-frame {})
+  (flows/reset-last-inputs!)
+  (error-emit/clear-error-listeners!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (let [captured (atom [])]
+    (binding [*captured* captured]
+      (trace/register-listener!
+        ::flow-marks-recorder
+        (fn [ev] (swap! captured conj ev)))
+      (try
+        (test-fn)
+        (finally
+          (trace/unregister-listener! ::flow-marks-recorder))))))
+
+(use-fixtures :each reset-runtime)
+
+(defn- by-op [op] (filterv #(= op (:operation %)) @*captured*))
+
+(defn- sensitive-decls [frame-id]
+  (elision/sensitive-declarations frame-id))
+
+(defn- large-decls [frame-id]
+  (elision/declarations frame-id))
+
+;; ---------------------------------------------------------------------------
+;; 1. Per-path flow output redaction — `:sensitive [[:secret]]`
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-sensitive-subpath-redacts-result-and-app-db
+  (testing "a flow declaring `:sensitive [[:secret]]` redacts the :secret
+            sub-slot of its output on the :rf.flow/computed :result AND on
+            the app-db destination egress, while a sibling slot rides raw"
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-flow {:id        :creds
+                  :inputs    [[:n]]
+                  :output    (fn [_] {:secret :S :public :P})
+                  :path      [:derived :creds]
+                  :sensitive [[:secret]]})
+    ;; The absolute declaration was installed rooted at the flow's :path.
+    (is (contains? (sensitive-decls :rf/default) [:derived :creds :secret])
+        "an absolute sensitive declaration is installed at :path ++ [:secret]")
+    (reset! *captured* [])
+    (rf/dispatch-sync [:init])
+    (let [tags (:tags (last (by-op :rf.flow/computed)))]
+      (is (= :creds (:flow-id tags)))
+      (is (= privacy/redacted-sentinel (get-in (:result tags) [:secret]))
+          ":secret is redacted on the :result trace slot")
+      (is (= :P (get-in (:result tags) [:public]))
+          ":public rides raw — only the declared sub-path redacts"))
+    ;; App-db destination egress: the t2 pending-db stamp rides through
+    ;; `project-db-tags` → `elide-wire-value`, reading the SAME registry.
+    (let [t2 (last (filterv #(= :rf.event/db-pending-post-flow (:operation %))
+                            @*captured*))
+          stamped (-> t2 :tags :rf.event/db)]
+      (is (some? t2) "a post-flow pending-db trace fired")
+      (is (= privacy/redacted-sentinel (get-in stamped [:derived :creds :secret]))
+          "the app-db destination :secret slot is redacted on db egress")
+      (is (= :P (get-in stamped [:derived :creds :public]))
+          ":public rides raw on the db egress too"))))
+
+;; ---------------------------------------------------------------------------
+;; 2. Whole-output `:sensitive? true`
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-whole-output-sensitive-redacts-entire-result
+  (testing "a flow declaring `:sensitive? true` redacts its WHOLE output on
+            :result and at the app-db destination slot"
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-flow {:id         :token
+                  :inputs     [[:n]]
+                  :output     (fn [_] {:jwt "header.payload.sig"})
+                  :path       [:auth :token]
+                  :sensitive? true})
+    (is (contains? (sensitive-decls :rf/default) [:auth :token])
+        "the whole-output sensitive declaration is installed at :path itself")
+    (reset! *captured* [])
+    (rf/dispatch-sync [:init])
+    (let [tags (:tags (last (by-op :rf.flow/computed)))]
+      (is (= privacy/redacted-sentinel (:result tags))
+          "the entire :result is redacted to the sentinel"))
+    (let [t2 (last (filterv #(= :rf.event/db-pending-post-flow (:operation %))
+                            @*captured*))
+          stamped (-> t2 :tags :rf.event/db)]
+      (is (= privacy/redacted-sentinel (get-in stamped [:auth :token]))
+          "the whole app-db destination slot is redacted on db egress"))))
+
+;; ---------------------------------------------------------------------------
+;; 3. `:large` markers (whole-output and per-path)
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-large-whole-output-marks-result
+  (testing "a flow declaring `:large? true` substitutes the
+            :rf.size/large-elided marker for its whole output on :result"
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-flow {:id     :blob
+                  :inputs [[:n]]
+                  :output (fn [_] {:bytes "BIG"})
+                  :path   [:derived :blob]
+                  :large? true})
+    (is (contains? (large-decls :rf/default) [:derived :blob])
+        "the whole-output large declaration is installed at :path itself")
+    (reset! *captured* [])
+    (rf/dispatch-sync [:init])
+    (let [tags (:tags (last (by-op :rf.flow/computed)))]
+      (is (elision/marker? (:result tags))
+          ":result is replaced by the large-elided marker")
+      (let [marker (:rf.size/large-elided (:result tags))]
+        (is (= [:derived :blob] (:path marker))
+            "marker carries the flow's output path")
+        ;; Flow output marks are installed into the SAME per-frame elision
+        ;; registry the schema-first wire walker (`elide-wire-value`) reads,
+        ;; so the marker is produced by `elision/->marker` and carries its
+        ;; `:reason :schema` stamp. That uniformity is the point — one
+        ;; walker, one marker shape, regardless of whether the declaration
+        ;; was schema-sourced or reg-flow-sourced.
+        (is (= :schema (:reason marker))
+            "marker rides the unified walker's :reason :schema stamp")))))
+
+(deftest reg-flow-large-subpath-marks-only-that-slot
+  (testing "a flow declaring `:large [[:big]]` marks only the :big sub-slot"
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-flow {:id     :payload
+                  :inputs [[:n]]
+                  :output (fn [_] {:big {:k "BIG"} :small 1})
+                  :path   [:out]
+                  :large  [[:big]]})
+    (is (contains? (large-decls :rf/default) [:out :big])
+        "the large declaration is installed at :path ++ [:big]")
+    (reset! *captured* [])
+    (rf/dispatch-sync [:init])
+    (let [tags (:tags (last (by-op :rf.flow/computed)))]
+      (is (elision/marker? (get-in (:result tags) [:big]))
+          ":big is replaced by the large-elided marker")
+      (is (= 1 (get-in (:result tags) [:small]))
+          ":small rides raw — only the declared sub-path is marked"))))
+
+;; ---------------------------------------------------------------------------
+;; 4. `:sensitive? false` opt-out — no whole-output mark installed
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-sensitive-false-installs-no-whole-output-mark
+  (testing "a flow declaring `:sensitive? false` installs NO whole-output
+            declaration — its result rides raw (flows carry no upstream
+            propagation, so the explicit-false override is the absence of a
+            mark); per-path declarations on the same flow still apply"
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-flow {:id         :mixed
+                  :inputs     [[:n]]
+                  :output     (fn [_] {:hashed :H :raw :R})
+                  :path       [:safe]
+                  :sensitive? false
+                  :sensitive  [[:hashed]]})
+    ;; No whole-output declaration at :path itself.
+    (is (not (contains? (sensitive-decls :rf/default) [:safe]))
+        ":sensitive? false installs no whole-output declaration at :path")
+    ;; The per-path declaration still applies.
+    (is (contains? (sensitive-decls :rf/default) [:safe :hashed])
+        "the per-path :sensitive [[:hashed]] declaration is still installed")
+    (reset! *captured* [])
+    (rf/dispatch-sync [:init])
+    (let [result (:result (:tags (last (by-op :rf.flow/computed))))]
+      (is (map? result)
+          ":result is NOT wholesale-redacted (sensitive? false opt-out)")
+      (is (= privacy/redacted-sentinel (get-in result [:hashed]))
+          ":hashed sub-slot is still redacted by the per-path declaration")
+      (is (= :R (get-in result [:raw]))
+          ":raw rides through — neither whole-output nor per-path marked"))))
+
+(deftest reg-flow-no-marks-leaves-registry-untouched
+  (testing "a plain flow (no classification keys) installs no declarations —
+            the no-marks common case stays zero-overhead"
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-flow {:id     :plain
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:doubled]})
+    (is (empty? (sensitive-decls :rf/default))
+        "no sensitive declarations for a no-marks flow")
+    (is (empty? (large-decls :rf/default))
+        "no large declarations for a no-marks flow")))
+
+;; ---------------------------------------------------------------------------
+;; 5. Same-flow-id multi-frame registrations with DIFFERENT marks
+;;
+;; Spec 013 lets the SAME flow-id carry different definitions — hence
+;; different marks — in different frames. The frame-blind `{flow-id marks}`
+;; table the old code used would conflate them (last-writer-wins). The
+;; frame-aware elision-registry install keeps them isolated by construction.
+;; ---------------------------------------------------------------------------
+
+(deftest same-flow-id-different-frames-different-marks-isolated
+  (testing "the same flow-id registered against two frames with DIFFERENT
+            output marks redacts independently per frame"
+    (rf/reg-frame :left  {:doc "left"})
+    (rf/reg-frame :right {:doc "right"})
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    ;; :left — whole output sensitive.
+    (rf/reg-flow {:id         :shared
+                  :inputs     [[:n]]
+                  :output     (fn [_] {:v :LEFT})
+                  :path       [:out]
+                  :sensitive? true}
+                 {:frame :left})
+    ;; :right — same id, NO marks (rides raw).
+    (rf/reg-flow {:id     :shared
+                  :inputs [[:n]]
+                  :output (fn [_] {:v :RIGHT})
+                  :path   [:out]}
+                 {:frame :right})
+    ;; Registry isolation: :left carries the declaration, :right does not.
+    (is (contains? (sensitive-decls :left) [:out])
+        ":left frame carries the whole-output sensitive declaration")
+    (is (empty? (sensitive-decls :right))
+        ":right frame carries NO declaration — the marks did not bleed across")
+    (reset! *captured* [])
+    (rf/dispatch-sync [:init] {:frame :left})
+    (rf/dispatch-sync [:init] {:frame :right})
+    (let [left-tags  (:tags (last (filterv #(and (= :rf.flow/computed (:operation %))
+                                                 (= :left (-> % :tags :frame)))
+                                           @*captured*)))
+          right-tags (:tags (last (filterv #(and (= :rf.flow/computed (:operation %))
+                                                 (= :right (-> % :tags :frame)))
+                                           @*captured*)))]
+      (is (= privacy/redacted-sentinel (:result left-tags))
+          ":left's result is redacted (its frame declared :sensitive? true)")
+      (is (= {:v :RIGHT} (:result right-tags))
+          ":right's result rides raw — its frame declared no marks"))))
+
+;; ---------------------------------------------------------------------------
+;; 6. Lifecycle: clear-flow drops the flow's output declarations
+;; ---------------------------------------------------------------------------
+
+(deftest clear-flow-drops-output-marks
+  (testing "clear-flow removes the flow's :source :flow elision declarations"
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-flow {:id         :token
+                  :inputs     [[:n]]
+                  :output     (fn [_] {:jwt "x"})
+                  :path       [:auth :token]
+                  :sensitive? true})
+    (is (contains? (sensitive-decls :rf/default) [:auth :token])
+        "declaration present after reg-flow")
+    (rf/clear-flow :token)
+    (is (not (contains? (sensitive-decls :rf/default) [:auth :token]))
+        "declaration dropped after clear-flow")))
+
+(deftest clear-flow-preserves-other-sources
+  (testing "clear-flow drops only :source :flow entries — schema- and
+            add-marks-sourced declarations on adjacent paths survive"
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    ;; An add-marks-sourced sensitive path the flow does not own.
+    (rf/add-marks :rf/default {[:user :ssn] :sensitive})
+    (rf/reg-flow {:id         :token
+                  :inputs     [[:n]]
+                  :output     (fn [_] {:jwt "x"})
+                  :path       [:auth :token]
+                  :sensitive? true})
+    (rf/clear-flow :token)
+    (is (not (contains? (sensitive-decls :rf/default) [:auth :token]))
+        "the flow-sourced declaration is gone")
+    (is (contains? (sensitive-decls :rf/default) [:user :ssn])
+        "the add-marks-sourced declaration survives clear-flow")))
+
+;; ---------------------------------------------------------------------------
+;; 7. Lifecycle: re-registration that changes :path moves the declaration
+;; ---------------------------------------------------------------------------
+
+(deftest reg-flow-path-change-moves-output-marks
+  (testing "re-registering a flow with a NEW :path drops the OLD path's
+            flow-sourced declaration and installs it at the new path"
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-flow {:id         :token
+                  :inputs     [[:n]]
+                  :output     (fn [_] {:jwt "x"})
+                  :path       [:old :token]
+                  :sensitive? true})
+    (is (contains? (sensitive-decls :rf/default) [:old :token])
+        "declaration at the original path")
+    ;; Re-register the SAME id on the SAME frame with a NEW path.
+    (rf/reg-flow {:id         :token
+                  :inputs     [[:n]]
+                  :output     (fn [_] {:jwt "x"})
+                  :path       [:new :token]
+                  :sensitive? true})
+    (is (not (contains? (sensitive-decls :rf/default) [:old :token]))
+        "the OLD path's flow declaration is dropped on path-change")
+    (is (contains? (sensitive-decls :rf/default) [:new :token])
+        "the declaration is installed at the NEW path")))
+
+(deftest reg-flow-re-register-with-fewer-marks-replaces-cleanly
+  (testing "re-registering with a REDUCED mark set replaces the prior flow
+            declarations wholesale (no stale leftovers)"
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (rf/reg-flow {:id        :creds
+                  :inputs    [[:n]]
+                  :output    (fn [_] {:a 1 :b 2})
+                  :path      [:out]
+                  :sensitive [[:a] [:b]]})
+    (is (contains? (sensitive-decls :rf/default) [:out :a]))
+    (is (contains? (sensitive-decls :rf/default) [:out :b]))
+    ;; Re-register dropping :b from the sensitive set.
+    (rf/reg-flow {:id        :creds
+                  :inputs    [[:n]]
+                  :output    (fn [_] {:a 1 :b 2})
+                  :path      [:out]
+                  :sensitive [[:a]]})
+    (is (contains? (sensitive-decls :rf/default) [:out :a])
+        ":a's declaration survives the re-registration")
+    (is (not (contains? (sensitive-decls :rf/default) [:out :b]))
+        ":b's stale declaration is cleared — re-registration replaces in full")))


### PR DESCRIPTION
## Summary

Senior-review finding for `implementation/flows` (bead **rf2-ouemt**, P1): `reg-flow`'s Spec 015 §7 output data-classification keys (`:sensitive` / `:large` / `:sensitive?` / `:large?`) were silently **inert**.

`reg-flow` stashed those keys in `re-frame.marks`' frame-blind `{flow-id marks}` table, but the only reader (`flow-marks`) was never wired into the central `project-trace-event` switch. As a result a `{:sensitive [[:secret]]}` or `{:sensitive? true}` flow:
- emitted its **raw** `:result` on `:rf.flow/computed` (and `:before` / `:rf.flow/failed`), and
- wrote the **raw** value to its app-db destination slot, visible to App-DB-Diff style observation, the `:rf.event/db` pending-db trace, view render-arg egress, and any downstream sub reading the slot.

## Fix

Make flow output marks **first-class through the per-frame app-db elision registry** that the schema-first wire walker (`elision/elide-wire-value`) already reads. `reg-flow` now translates the registration's output-rooted marks into **absolute** declarations rooted at `(:path flow)` and installs them **frame-aware**, stamped `{:source :flow :flow-id <id>}`.

ONE walker then covers both egress channels:
- the flow trace `:result` / `:before` already ride `elide-wire-value` rooted at `(:path flow)`, so they pick the declarations up with no emit-site change; and
- `project-db-tags` / `project-view-rendered-tags` (re-frame.marks) elide the app-db destination slot through the same registry — closing the **destination-propagation** gap the finding explicitly flags.

**Frame-scoping is structural.** Declarations live in each frame's own elision registry, so the same flow-id registered against two frames with different marks stays isolated by construction — exactly the multi-frame case (Spec 013) that the old frame-blind `{flow-id marks}` table would have conflated.

**Lifecycle.** `clear-flow` and a `:path`-change re-registration drop / move the `:source :flow` entries (a now-unmarked re-registration clears the prior marks); frame-destroy reclaims them with the app-db. A first, no-marks registration skips the registry write entirely (zero overhead, no spurious reactive invalidation).

**Dead code removed.** The frame-blind path is gone: the `register-marks! :flow` call in `flows.registry` and the unused `flow-marks` helper in `core/marks`.

No spec change: Spec 015 §7 already documents this contract (incl. "the `:path` write in `app-db` carries the mark" and the `:sensitive? false` opt-out). The implementation simply was not honoring it.

## Disposition

Live finding (NOT a dup of the recently-merged #3365 / rf2-4wqu6 rollback + clear-flow work, nor rf2-o69h5 which only covered schema-validation `:where :flow-output` redaction). Fixed.

## Quality gates

| Gate | Result |
|------|--------|
| flows JVM (`clojure -M:test`) | **165 tests / 4676 assertions — 0 failures, 0 errors** |
| core JVM (`clojure -M:test`) | **916 tests / 4120 assertions — 0 failures, 0 errors** |
| `npm run test:cljs` | **5870 tests / 20783 assertions — 0 failures, 0 errors** |
| clj-kondo (changed files) | clean (2 pre-existing marks.cljc warnings unrelated to this change) |

No new late-bind hook published, so the late-bind drift gate does not apply.

New regression suite `flows_output_marks_test.clj` pins: per-path redaction (trace + app-db egress), whole-output `:sensitive? true`, `:large` whole/per-path markers, `:sensitive? false` opt-out, same-flow-id multi-frame isolation, and clear / path-change / reduced-mark-set lifecycle.

Closes rf2-ouemt.