### PR TITLE
fix(examples/_shared): senior-review finding (rf2-byf7y)

### DIFF
--- a/examples/_shared/README.md
+++ b/examples/_shared/README.md
@@ -42,6 +42,15 @@ The pairing nods to the rest of the project (Xray uses Inter + JBM,
 Story uses IBM Plex on a similarly light surface) so examples, dev
 tools, and docs all sit naturally next to one another.
 
+**No remote fonts.** The stylesheet states Inter / JetBrains Mono as the
+first-preference families but loads **no** web fonts — there is no
+`@import` of Google Fonts (or any other host). The font stacks resolve
+through their declared system fallbacks (`system-ui` / `Segoe UI` /
+`-apple-system`; `ui-monospace` / `SF Mono` / `Menlo`), so a staged
+example makes **zero** third-party network requests for styling. Offline,
+firewalled, and privacy-sensitive local runs render the same, and
+screenshots stay reproducible. (rf2-byf7y)
+
 ## Files
 
 - `css/style.css` — the shared design system. Linked by

--- a/examples/_shared/css/style.css
+++ b/examples/_shared/css/style.css
@@ -25,9 +25,15 @@
  * @imports structure.css for layout-only class shapes
  *          (forms, banners, pills, boot, navbar, cards, cells grid,
  *          testbed shell). Stays substrate-agnostic.
+ *
+ * No remote fonts. The Inter / JetBrains Mono families below are stated as
+ * the first preference but resolve entirely through the declared system
+ * fallbacks (system-ui / Segoe UI / -apple-system; ui-monospace / SF Mono /
+ * Menlo). A staged example therefore makes ZERO third-party network
+ * requests for styling — offline, firewalled, and privacy-sensitive local
+ * runs render identically and screenshots stay reproducible. (rf2-byf7y)
  * ========================================================================== */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap');
 @import url('structure.css');
 
 :root {


### PR DESCRIPTION
## Summary

Senior-review finding for `examples/_shared` (rf2-byf7y): the shared stylesheet imported Inter / JetBrains Mono from `fonts.googleapis.com` at runtime via `@import url('https://fonts.googleapis.com/...')`. The asset-contract scanner (`examples/scripts/check-examples-assets.cjs`) intentionally skips external refs, so the staged-examples surface could acquire a third-party network dependency while the gate stayed green.

**Impact addressed:** offline / firewalled / privacy-sensitive local runs no longer render differently or leak an unexpected request to Google; visual review and screenshots are reproducible; the stated "local `_shared` asset contract contains all styling inputs" now holds.

**Fix (finding's preferred option):** removed the remote `@import` and rely on the already-declared system fallbacks (`system-ui` / `Segoe UI` / `-apple-system`; `ui-monospace` / `SF Mono` / `Menlo`). Inter / JetBrains Mono remain stated as first preference and still apply when installed locally — no visual regression on machines that have them, graceful system fallback everywhere else. Vendoring the font binaries was rejected: it adds large binary blobs to `_shared` for no correctness gain over the declared fallbacks, and the families are decorative-preference not load-bearing.

`examples/_shared/README.md` typography section updated to state the no-remote-fonts contract accurately.

### Out of lane (follow-up)
The finding also suggests extending `examples/scripts/check-examples-assets.cjs` (+ its test in `implementation/scripts/`) to reject unallowlisted external `@import`s from `_shared`. Both files are outside this worker's `examples/_shared/**` lane, so that defense-in-depth gate is deferred to a separate bead. The primary network dependency — the only one that actually existed — is removed here.

## Quality gates

| Gate | Result |
| --- | --- |
| `npm run test:examples-compile` | PASS — all 39 example builds compiled, 0 warnings |
| `check-examples-assets.test.cjs` (asset-contract, live repo scan) | PASS — all tests; `_shared` tree resolves clean |
| `check_readme_links.py` | PASS (no output) |
| `check_readme_inventories.py` (on `examples/_shared/README.md`) | PASS — only pre-existing `implementation/README.md` `node_modules`/`out` build-artifact noise, untouched by this PR |

## Disposition
Finding confirmed against current source and fixed. In-lane only (`examples/_shared/css/style.css`, `examples/_shared/README.md`). Closes rf2-byf7y.