### PR TITLE
fix(examples/reagent): senior-review findings (rf2-r57h2)

### DIFF
--- a/examples/reagent/README.md
+++ b/examples/reagent/README.md
@@ -29,7 +29,7 @@ reagent/
   realworld/                   <-- the canonical multi-artefact integration test
 ```
 
-Per [`spec/Conventions.md`](../../spec/Conventions.md): all examples register their app-db slices via `reg-app-schema`; views are registered via the `reg-view` macro (Var-reference Form-1); the catalogue at [`../README.md`](../README.md) maps each example to the Specs it exercises.
+Per [`spec/Conventions.md`](../../spec/Conventions.md): schema-bearing examples register their app-db slices via `reg-app-schema`; views are registered via the `reg-view` macro (Var-reference Form-1); the catalogue at [`../README.md`](../README.md) maps each example to the Specs it exercises. The intentionally minimal examples (`counter`, `routing`, `todomvc`, `notebook`, `managed_http_counter`) are deliberately schema-free — `counter` in particular is kept dependency-light so it doubles as a bundle-isolation fixture, so adding a schema there would weaken that coverage.
 
 ## Running
 

--- a/examples/reagent/managed_http_counter/README.md
+++ b/examples/reagent/managed_http_counter/README.md
@@ -40,9 +40,17 @@ keep in your head, complete enough to drive every code path.
 
 ```
 managed_http_counter/
-  core.cljs    — events, sub, view, mount, canned-stub override.
-  index.html   — minimal host page.
+  core.cljs       — events, sub, view, mount, canned-stub override.
+  index.html      — minimal host page.
+  api/inc.json    — `{"delta": 1}` static asset the +1 happy path fetches.
 ```
+
+The **+1** button issues a REAL `GET api/inc.json`, so that file is a
+runtime asset the served output dir must carry — it is fetched by the
+running app, not referenced from `index.html`, so the static asset gate
+(`examples/scripts/check-examples-assets.cjs`, which walks `index.html`
+references) does not cover it. Stage it alongside `main.js` (see
+[How to run](#how-to-run)).
 
 ## How to run
 
@@ -54,7 +62,11 @@ shadow-cljs watch examples/managed-http-counter
 The watch build emits `main.js` into
 `out/examples/managed-http-counter/`; copy this folder's hand-written
 [`index.html`](index.html) (and the shared assets it references under
-[`../../_shared/`](../../_shared/)) alongside it, then serve
+[`../../_shared/`](../../_shared/)) alongside it, **and copy this
+folder's [`api/`](api/) directory to
+`out/examples/managed-http-counter/api/`** so the **+1** button's real
+`GET api/inc.json` resolves (without it the headline success path 404s
+and the example demonstrates the failure branch instead). Then serve
 `out/examples/managed-http-counter/` over HTTP.
 (`npm run test:examples` does not build this example — it compiles and
 serves only the three adapter testbeds; see


### PR DESCRIPTION
Actions the two enumerated findings of **rf2-r57h2** (senior review: examples/reagent). Docs-only fixes; both findings verified against current source.

## Per-finding disposition

**Finding 1 — `managed_http_counter` +1 happy path 404s on documented run steps. FIXED.**
The **+1** button issues a REAL `GET api/inc.json`. The source asset `examples/reagent/managed_http_counter/api/inc.json` exists, but the README's "How to run" only told readers to copy `index.html` + `_shared`, and the static asset gate (`check-examples-assets.cjs`, which walks `index.html` references) cannot see a runtime-fetched asset. A reader following the docs got a 404 on the headline success path. Took the **option-(a)** fix (document/stage the asset) rather than option (b) (convert +1 to a canned stub), because the REAL round-trip for +1 is the documented design point of this example — converting it would weaken the example's purpose. Added `api/inc.json` to the Files listing, a note explaining why the gate doesn't cover it, and the explicit copy step in "How to run".

**Finding 2 — over-broad `reg-app-schema` claim in `examples/reagent/README.md:32`. FIXED.**
Verified against current source: `counter`, `routing`, `todomvc`, `notebook`, and `managed_http_counter` all write app-db with no `reg-app-schema`/`reg-app-schemas` call. The blanket claim was false and would push maintainers toward adding schemas to intentionally-minimal examples — `counter` in particular is kept dependency-light so it doubles as a bundle-isolation fixture. Qualified the sentence to "schema-bearing examples" and named the intentional schema-free set. (Conventions.md makes no "every example must use reg-app-schema" claim, so no spec change needed.)

## Quality gates

- `npm run test:examples-compile` — **PASS** (39 example builds compiled, 0 warnings).
- `python scripts/check_readme_links.py` — **PASS** (exit 0; new `api/`, `index.html`, `#how-to-run` links resolve).
- `python scripts/check_doc_slugs.py` — **PASS** (exit 0).
- `python scripts/check_readme_inventories.py` — **PASS on intended content.** The single reported violation (`implementation/README.md:36` omits `node_modules, out`) is a false positive: both are gitignored dirs created by this worker's `npm install` + shadow-cljs build in the worktree, not files in the diff. The script enumerates on-disk dirs without respecting `.gitignore`; the tracked diff touches neither `implementation/README.md` nor those dirs. CI runs the gate on tracked content and is unaffected.

Closes rf2-r57h2.
