### PR TITLE
docs(spec/011-SSR): de-claim stream-handler :html-shell parity (rf2-yjiond)

### DIFF
--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -980,6 +980,16 @@ The host adapter MUST emit chunks in this order:
 
 The chunk content uses HTTP `Transfer-Encoding: chunked` framing; the application-layer ordering above is what the conformance fixture pins.
 
+#### Streaming does NOT accept `:html-shell` (rf2-oq4m5)
+
+`stream-handler` shares the non-streaming handler's construction contract — the required opts (`:on-create` / `:root-view`), the hydration-payload policy, the `:on-error` precedence, and the four trusted shell-hook opts (`:head` / `:body-end` / `:script-src` / `:app-element-id`, [§Trusted shell hook contract](#trusted-shell-hook-contract)) — **with one exception**: it does **NOT** accept a custom one-piece HTML-shell override (the CLJS reference's `:html-shell` opt, a `(body-html payload-edn opts) → string` fn honoured by the non-streaming `ssr-handler`).
+
+The chunk-ordering contract above is why. The non-streaming handler has the full body + payload in hand before it composes the envelope, so a one-piece shell can wrap them arbitrarily. The streaming handler flushes the envelope as a **split** prefix/suffix straddling the continuation chunks — the prefix on the shell chunk (1), the suffix on the closing chunk (4), with N continuation chunks and the final payload in between. A one-piece shell callback can never run after streaming has started; it could only ever apply to a body the streaming path does not assemble in one piece.
+
+The framework therefore MUST **fail closed at handler-construction time**: `stream-handler` rejects a non-nil `:html-shell` (any shape) with `:rf.error/ssr-streaming-unsupported-opt` (ex-data carries `:opt-key :html-shell`, `:got`, and `:recovery`). An absent or explicit-nil `:html-shell` constructs cleanly (no override requested). Silently dropping the opt would be a fail-OPEN gap — a custom shell commonly carries CSP nonces, asset URLs, analytics/script policy, or root markup, and a deployment switching `ssr-handler` → `stream-handler` would lose all of it with no signal.
+
+Callers needing custom shell content under streaming use the split-envelope surface instead: the four trusted shell-hook opts above (honoured by `default-streaming-prefix` / `default-streaming-suffix`). A caller that genuinely needs a single one-piece shell fn must use the non-streaming `ssr-handler`.
+
 #### Boundary nesting and recursion
 
 `:rf/suspense-boundary` nodes nest. When a continuation's render walks into another `:rf/suspense-boundary`, the inner boundary registers a new continuation at the tail of the drain queue. The inner subtree's resolved chunk arrives **after** all originally-registered continuations — the order is strictly registration-order (FIFO).


### PR DESCRIPTION
## What

Follow-up to rf2-oq4m5 (#3376, merged). That change made `stream-handler` **reject** a non-nil `:html-shell` at construction time (`:rf.error/ssr-streaming-unsupported-opt`): the split streaming envelope flushes the prefix on the shell chunk and the suffix on the closing chunk, straddling the continuation chunks, so a one-piece `(body-html payload-edn opts) → string` shell fn can never run mid-stream.

`spec/011-SSR.md` previously left `stream-handler`'s opt surface implied-identical to `ssr-handler`'s (including the custom one-piece shell). This corrects the spec to match shipped behaviour.

## Change

One contiguous insertion (10 lines) in §Streaming SSR, immediately after the chunk-ordering (wire-shape) contract — the section that pins the split prefix/suffix envelope and therefore explains exactly why a one-piece shell is impossible. New subsection **"Streaming does NOT accept `:html-shell`"**:

- States `stream-handler` shares the non-streaming construction contract **except** the one-piece `:html-shell` override.
- Explains why (split envelope vs the non-streaming handler having body + payload in hand).
- Documents the fail-closed-at-boot contract (`:rf.error/ssr-streaming-unsupported-opt`, ex-data `:opt-key :html-shell` / `:got` / `:recovery`; nil/absent constructs cleanly) and why silent-drop would be fail-OPEN.
- Points callers at the two supported paths: the four trusted shell-hook opts (`:head` / `:body-end` / `:script-src` / `:app-element-id`, honoured by `default-streaming-prefix` / `default-streaming-suffix`), or the non-streaming `ssr-handler` for a genuine one-piece shell.

Wording tracks the shipped `validate-streaming-opts!` docstring verbatim in intent. Hot-zone file; edit kept minimal/surgical.

## Out of scope

The new error id `:rf.error/ssr-streaming-unsupported-opt` is not added to the 009 §Error event catalogue here (009-Instrumentation.md is a separate hot-zone file outside this bead's single-file lane). Flagging as a possible follow-up if the catalogue is meant to be exhaustive.

## Quality gates

- `python -m mkdocs build --strict` (repo root) — exit 0, "Documentation built in 11.00 seconds". No broken anchors/links introduced; the new `#trusted-shell-hook-contract` cross-link resolves to the canonical §Trusted shell hook contract heading. (The only WARNING shown is a pre-existing unrelated `the-mayor-method.md` relative-link note.)
- `python scripts/check_doc_slugs.py` — exit 0.
- `git status` — single file changed (`spec/011-SSR.md`), 10 insertions; mayor checkout untouched.

Closes rf2-yjiond.
