### PR TITLE
docs(readme): correct project-layout map (rf2-0n08l)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ implementation/                CLJS reference implementation — per-artefact su
                                semantics, smaller footprint, capped Form-3 surface
     uix/                       day8/re-frame2-uix — the UIx adapter
     helix/                     day8/re-frame2-helix — the Helix adapter
-    test-react/                day8/re-frame2-test-react — pure-CLJC React-lifecycle simulator;
-                               catches lifecycle bugs at unit-test speed (no React/DOM/jsdom)
+    test-react/                local-test-only (no Maven coord) — pure-CLJC React-lifecycle
+                               simulator; catches lifecycle bugs at unit-test speed (no React/DOM/jsdom)
   schemas/                     day8/re-frame2-schemas — Malli boundary-validation artefact
   machines/                    day8/re-frame2-machines — state-machine artefact (xstate-flavoured)
   flows/                       day8/re-frame2-flows — registered computed-state declarations


### PR DESCRIPTION
@
## Summary

The top-level `README.md` project-layout map (~L224) still listed `test-react/` with a `day8/re-frame2-test-react` Maven coordinate. Per **rf2-e4pyb** (#3301), test-react is **local-test-only** and carries **no Maven coordinate** — the publish claim was already removed from `implementation/adapters/README.md` and `implementation/adapters/test-react/deps.edn`, but the top-level README was outside e4pybs file lane and was left stale.

This corrects the layout map line to read `local-test-only (no Maven coord)`, matching reality.

```diff
-    test-react/                day8/re-frame2-test-react — pure-CLJC React-lifecycle simulator;
-                               catches lifecycle bugs at unit-test speed (no React/DOM/jsdom)
+    test-react/                local-test-only (no Maven coord) — pure-CLJC React-lifecycle
+                               simulator; catches lifecycle bugs at unit-test speed (no React/DOM/jsdom)
```

Closes rf2-0n08l.

## Quality gates

- **No link/anchor changes**: the edited line is inside the plain-text layout map (no markdown links/anchors), so `check_readme_links.py` / `check_doc_slugs.py` are N/A.
- **mkdocs**: the top-level `README.md` is NOT in the mkdocs nav (Home is `index.md`; per the mkdocs hook the tree is full of README.md files mkdocs deliberately ignores), so `mkdocs build --strict` is not exercised by this change.
- **Scope**: single-file, text-only, 2-line diff; no code, no behaviour.
@