### PR TITLE
fix(test-quiet): senior-review findings (rf2-pjlx6)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -53,53 +53,112 @@
 (def ^:private discovery-banner-prefix
   "The literal text cognitect-test-runner's `test` fn prints via bare
   `println` before running tests: `(format \"\\nRunning tests in %s\" dirs)`.
-  We match on this prefix so the directory-set tail (which varies) need
-  not be enumerated."
-  "Running tests in ")
 
-(defn- discovery-banner-line?
-  "True iff `line` (one logical println line, sans terminator) is
-  cognitect's discovery banner and nothing else.  The banner is emitted
-  alone on its own line, so an exact prefix match is unambiguous."
-  [^String line]
-  (.startsWith line discovery-banner-prefix))
+  `dirs` is ALWAYS a set — it defaults to `#{\"test\"}` and the `-d` CLI
+  option accumulates via `(fnil conj #{})` — so the banner renders as
+  `Running tests in #{...}`.  We match the prefix up to and including the
+  set-literal opener `#{` rather than the bare `Running tests in ` so that
+  a legitimate diagnostic such as `Running tests in local fixture...`
+  emitted by a test or fixture is forwarded, not silently swallowed: only
+  the runner's own banner opens a set literal here."
+  "Running tests in #{")
 
 (defn- banner-filtering-writer
-  "A `java.io.Writer` that forwards every character to `target` EXCEPT a
-  whole line equal to cognitect's discovery banner, which it drops.
+  "A `java.io.Writer` that forwards every character to `target` EXCEPT
+  cognitect's discovery banner line, which it drops.
 
-  Buffers the current line until a newline arrives, then forwards
-  newline-terminated lines verbatim unless they are the banner.  This is
-  line-precise: help text, parse-error diagnostics, the reporter's
-  failure output, and bare test stdout all pass through untouched; only
-  the banner line is swallowed.  Any trailing unterminated text (no final
-  newline) is forwarded on `flush`/`close` so nothing is silently lost.
+  Forwards eagerly, holding back only as much text as could still BECOME
+  the banner.  At the start of each line we are watching whether the
+  incoming characters spell out `discovery-banner-prefix`:
+
+   - while the buffered run is still a viable prefix of the banner we hold
+     it (the banner candidate);
+   - the moment it diverges from the banner prefix we forward the whole
+     run immediately and pass the rest of the line straight through;
+   - the moment it reaches the full banner prefix we know it IS the banner
+     and drop the remainder of the line.
+
+  A newline resets the watch for the next line.  The crucial property
+  versus a line-at-a-time buffer: non-banner text is never retained across
+  the runner's `System/exit` (cognitect exits straight from the computed
+  fail/error counts, so neither `flush` nor `close` runs).  An eager
+  forward means a bare `(print ...)` diagnostic with no trailing newline
+  still reaches stdout before exit.  The only text that can sit unflushed
+  at exit is a run that is character-for-character a strict prefix of the
+  banner and never terminates — which only the banner itself produces, and
+  the banner always ends in a newline (cognitect uses `println`).
+
+  Help text, parse-error diagnostics, the reporter's failure output, and
+  bare test stdout all pass through untouched; only the banner line is
+  swallowed.
 
   Clojure's `proxy` dispatches `write` by arity rather than by Java's
   static overload set, so the single-arg form must itself branch on the
   argument type (int char, `String`, or char[]).  Each arity feeds the
-  same `consume-char!` line buffer, so the banner-detection logic lives
-  in exactly one place."
+  same `consume-char!` watcher, so the banner-detection logic lives in
+  exactly one place."
   ^java.io.Writer [^java.io.Writer target]
-  (let [buf (StringBuilder.)
-        ;; Forward the buffered line `s` (without its trailing newline)
-        ;; plus the newline, unless `s` is the banner — then drop both.
-        flush-line! (fn [^String s]
-                      (when-not (discovery-banner-line? s)
-                        (.write target s)
-                        (.write target (int \newline))))
-        consume-char! (fn [c]
-                        (if (= c \newline)
-                          (do (flush-line! (.toString buf))
-                              (.setLength buf 0))
-                          (.append buf c)))
-        consume-str! (fn [^String s]
-                       (dotimes [i (.length s)]
-                         (consume-char! (.charAt s i))))
+  (let [prefix-len (.length ^String discovery-banner-prefix)
+        ;; `buf` holds the live banner-prefix candidate for the current
+        ;; line. `state` is one of:
+        ;;   :watching    — buf is a viable prefix of the banner-so-far;
+        ;;   :passthrough — this line diverged; forward chars verbatim;
+        ;;   :dropping    — this line IS the banner; drop to its newline.
+        buf   (StringBuilder.)
+        state (volatile! :watching)
+        emit! (fn [^String s] (when (pos? (.length s)) (.write target s)))
         forward-partial! (fn []
+                           ;; Forward any held candidate (only ever a
+                           ;; strict banner prefix). Called on flush/close
+                           ;; for the in-process help/return path.
                            (when (pos? (.length buf))
                              (.write target (.toString buf))
-                             (.setLength buf 0)))]
+                             (.setLength buf 0)))
+        reset-line! (fn []
+                      (.setLength buf 0)
+                      (vreset! state :watching))
+        consume-char! (fn [c]
+                        (cond
+                          (= c \newline)
+                          (do (case @state
+                                ;; Short line that never reached the full
+                                ;; banner prefix — forward the held run.
+                                :watching    (do (emit! (.toString buf))
+                                                 (.write target (int \newline)))
+                                ;; Diverged line — its chars already went
+                                ;; straight through; terminate it.
+                                :passthrough (.write target (int \newline))
+                                ;; The banner line — drop its newline too,
+                                ;; so no blank line is left behind.
+                                :dropping    nil)
+                              (reset-line!))
+
+                          (= @state :passthrough)
+                          (.write target (int c))
+
+                          (= @state :dropping)
+                          nil ; swallow the rest of the banner line
+
+                          :else ; :watching — extend the candidate
+                          (do
+                            (.append buf c)
+                            (cond
+                              ;; Reached the full prefix → confirmed banner.
+                              (>= (.length buf) prefix-len)
+                              (do (.setLength buf 0)
+                                  (vreset! state :dropping))
+                              ;; Still on track to be the banner — keep holding.
+                              (.startsWith ^String discovery-banner-prefix
+                                           (.toString buf))
+                              nil
+                              ;; Diverged → this line is not the banner.
+                              :else
+                              (do (emit! (.toString buf))
+                                  (.setLength buf 0)
+                                  (vreset! state :passthrough))))))
+        consume-str! (fn [^String s]
+                       (dotimes [i (.length s)]
+                         (consume-char! (.charAt s i))))]
     (proxy [java.io.Writer] []
       (write
         ([x]
@@ -136,10 +195,20 @@
   ;; path (from the computed fail/error counts) and on the parse-error
   ;; path, so control typically does not return past the `apply`. The
   ;; `-H`/help path is the exception: it prints usage and RETURNS without
-  ;; exiting, so we must flush the filtering writer afterwards to forward
-  ;; the trailing line. Flushing is harmless on the paths that did exit.
-  (let [real-out *out*
+  ;; exiting, so we flush the filtering writer in the `finally` to forward
+  ;; any trailing line; flushing is harmless on the paths that did exit.
+  ;;
+  ;; The `finally` cannot fire on the `System/exit` paths, so we also
+  ;; register a JVM shutdown hook that flushes the filtering writer (and,
+  ;; through it, the real stdout).  Without it, a bare `(print ...)`
+  ;; diagnostic with no trailing newline — buffered anywhere between this
+  ;; wrapper and the OS — could be lost exactly when a failing run needs
+  ;; it most.  The hook makes flush-on-exit deterministic rather than
+  ;; relying on the runtime or cognitect to flush before exiting.
+  (let [real-out  *out*
         filtering (java.io.PrintWriter. (banner-filtering-writer real-out))]
+    (.addShutdownHook (Runtime/getRuntime)
+                      (Thread. ^Runnable #(.flush filtering)))
     (binding [*out* filtering]
       (try
         (apply cognitect.test-runner/-main args)

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
@@ -31,9 +31,17 @@
 ;; Silence stray runtime warnings on green. See ns docstring for the
 ;; capture-compatibility rationale.  Installed at ns-load time so it's
 ;; in place before shadow's `run-all-tests` walks the test ns set.
+;;
+;; The stub carries a `re-frame.test-quiet/silenced` marker property so it
+;; is IDENTIFIABLE: a contract test can assert the live `console.warn` is
+;; this stub (and so fail if a regression leaves native `console.warn` —
+;; which has no such marker — in place), without requiring this
+;; `:dev/always` ns (which would form a compile cycle).
 (when (and (exists? js/console)
            (fn? (.-warn js/console)))
-  (set! (.-warn js/console) (fn [& _])))
+  (let [stub (fn [& _])]
+    (set! (.-rf-test-quiet-silenced stub) true)
+    (set! (.-warn js/console) stub)))
 
 ;; ----------------------------------------------------------------------
 ;; The single override shadow.test.node ships — exit the node process

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -418,3 +418,69 @@
                    " other stdout is forwarded; got:\n" out))
           (is (str/includes? out "0 failures, 0 errors.")
               (str "the green summary must still print; got:\n" out)))))))
+
+;; ----------------------------------------------------------------------
+;; Banner-prefix precision — rf2-pjlx6.1.
+;;
+;; The filter must drop ONLY cognitect's own banner, which always renders
+;; as `Running tests in #{...}` (the directory set is always a set: it
+;; defaults to `#{"test"}` and `-d` accumulates via `(fnil conj #{})`).  A
+;; bare prefix match on `Running tests in ` would also eat a legitimate
+;; diagnostic that merely begins with those words — e.g. a fixture that
+;; prints `Running tests in local fixture ...`.  This pins that such a
+;; line survives while the real discovery banner is still swallowed.
+
+(deftest banner-lookalike-diagnostic-survives
+  (testing "a test line beginning 'Running tests in ' but NOT the banner survives (rf2-pjlx6.1)"
+    (with-fixture-dir
+      (fn [dir]
+        (write-fixture! dir "lookalike_fixture_test" "lookalike-fixture-test"
+                        (str "(deftest a-lookalike-test"
+                             " (println \"Running tests in local fixture LOOKALIKE-MARKER\")"
+                             " (is (= 1 1)))"))
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (zero? exit)
+              (str "the lookalike suite is green; must exit 0; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? out "Running tests in local fixture LOOKALIKE-MARKER")
+              (str "a diagnostic that merely starts 'Running tests in ' (but"
+                   " is not the `#{...}` discovery banner) must survive; got:\n"
+                   out))
+          ;; Assert the real banner's distinctive `#{` shape is absent — NOT
+          ;; the bare `discovery-banner-marker` prefix, which the lookalike
+          ;; line legitimately contains.
+          (is (not (str/includes? out "Running tests in #{"))
+              (str "the real discovery banner (`Running tests in #{...}`)"
+                   " must STILL be swallowed; got:\n" out)))))))
+
+;; ----------------------------------------------------------------------
+;; Unterminated-partial survival across System/exit — rf2-pjlx6.2.
+;;
+;; cognitect exits straight from the computed fail/error counts, so the
+;; wrapper's `finally` flush never runs on the test path.  A bare
+;; `(print ...)` with no trailing newline AND no explicit flush must still
+;; reach stdout: the filter forwards non-banner text eagerly (it only ever
+;; holds back a live banner-prefix candidate) and `-main` registers a JVM
+;; shutdown hook that flushes the filtering writer.  Pre-fix, such a
+;; partial sat in the wrapper's line buffer and was lost at exit.
+
+(deftest unterminated-partial-survives-exit
+  (testing "a bare (print ...) with no newline/flush reaches stdout before System/exit (rf2-pjlx6.2)"
+    (with-fixture-dir
+      (fn [dir]
+        ;; No trailing newline, no (flush) — the worst case the finding
+        ;; describes. The marker must still survive to stdout.
+        (write-fixture! dir "partial_fixture_test" "partial-fixture-test"
+                        (str "(deftest a-partial-test"
+                             " (print \"PARTIAL-EXIT-MARKER\")"
+                             " (is (= 1 1)))"))
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (zero? exit)
+              (str "the partial-print suite is green; must exit 0; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? out "PARTIAL-EXIT-MARKER")
+              (str "a bare unterminated (print ...) must reach stdout even"
+                   " though cognitect System/exits before the finally flush;"
+                   " got:\n" out))
+          (is (str/includes? out "0 failures, 0 errors.")
+              (str "the green summary must still print; got:\n" out)))))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -219,9 +219,19 @@
       (js/console.warn "post-restore-marker")
       (is (= [] @recorded)
           "after restore the recording shim no longer captures (clean revert)")))
-  (testing "the ns-load stub is installed in this build (shadow-node is :main)"
-    ;; Soft evidence the silencing stub is live: calling console.warn at
-    ;; the baseline must not throw. This catches a regression that replaced
-    ;; the stub with something that errors on a bare call.
+  (testing "the silencing stub — not native console.warn — is the live baseline (shadow-node is :main)"
+    ;; The stub carries a `rf-test-quiet-silenced` marker property (set in
+    ;; shadow-node at ns-load).  Native Node `console.warn` has no such
+    ;; property, so asserting the marker is present is positive proof the
+    ;; SILENCING stub is installed — not just that the call returns nil
+    ;; (native console.warn also returns undefined while still EMITTING the
+    ;; warning text).  This fails if a regression drops the stub and the
+    ;; runner falls back to native `console.warn`, which would reintroduce
+    ;; green-path warning noise — the slice's core operational contract.
+    (is (true? (.-rf-test-quiet-silenced (.-warn js/console)))
+        (str "the live console.warn must be the identifiable silencing stub"
+             " (marker present) — a missing marker means native console.warn"
+             " is in place and green-path warnings would leak"))
+    ;; And it must still accept a bare call without throwing.
     (is (nil? (js/console.warn "stub-smoke"))
-        "the live baseline console.warn must accept a bare call without throwing")))
+        "the silencing stub must accept a bare call without throwing")))


### PR DESCRIPTION
Actions the three enumerated findings from the senior review of `implementation/test-quiet` (bead rf2-pjlx6). All three were verified against current source as real; all fixed. Touches only `implementation/test-quiet/**`.

## Per-finding disposition

**1. Over-broad discovery-banner prefix (runner.clj:60) — FIXED.**
The filter dropped any stdout line beginning `Running tests in `, not just cognitect's banner — a fixture printing e.g. `Running tests in local fixture...` would be silently swallowed despite the runner's "every non-banner byte passes through" contract. cognitect's banner always renders `Running tests in #{...}` (`:dir` is always a set — defaults to `#{"test"}`, `-d` accumulates via `(fnil conj #{})`), so the prefix now matches through the `#{` set-literal opener. New subprocess contract `banner-lookalike-diagnostic-survives` asserts a lookalike line survives while the real `Running tests in #{` banner stays absent.

**2. Unterminated partial lost at `System/exit` (runner.clj:119) — FIXED.**
cognitect calls `System/exit` straight from the computed fail/error counts, so the wrapper's `finally`/`flush` never runs on the test path — a bare `(print ...)` with no trailing newline sat in the line buffer and was lost. The writer now forwards eagerly (it only ever holds back a live banner-prefix candidate, never arbitrary text), and `-main` registers a JVM shutdown hook that flushes the filtering writer, making flush-on-exit deterministic. New subprocess contract `unterminated-partial-survives-exit` asserts a bare unterminated `(print "PARTIAL-EXIT-MARKER")` (no newline, no flush) reaches stdout on green exit. The now-dead `discovery-banner-line?` helper was removed.

**3. Weak console.warn stub assertion (test_quiet_shadow_node_cljs_test.cljs:223) — FIXED.**
The test only checked `(js/console.warn "stub-smoke")` returns nil — native Node `console.warn` also returns nil while still emitting warning text, so a dropped stub would not fail the test. The silencing stub is now tagged with an identifiable `rf-test-quiet-silenced` marker; the test asserts the live `console.warn` carries it, so it fails if the runner falls back to native `console.warn` (which would reintroduce green-path warning noise). Marker is set without requiring the `:dev/always` shadow-node ns (avoids the compile cycle).

## Quality gates
- test-quiet JVM self-test (`clojure -M:test` from `implementation/test-quiet`): **14 tests, 48 assertions, 0 failures, 0 errors** (was 12/42 — +2 contract tests / +6 assertions).
- `npm run test:cljs` (shadow-node runner touched): **5870 tests, 20784 assertions, 0 failures, 0 errors** (includes the strengthened `console-warn-capture-compat` marker assertion exercised under the real `:node-test` build).

Closes rf2-pjlx6.