### PR TITLE
docs(conventions): retire {:depth N} trace-buffer example (rf2-ldj3r)

### DIFF
--- a/skills/re-frame2-pair/docs/initial-spec.md
+++ b/skills/re-frame2-pair/docs/initial-spec.md
@@ -93,7 +93,7 @@ Where v1 reached into re-frame-10x's internal epoch buffer, v2 consumes re-frame
 
 - `(re-frame.trace.tooling/register-listener! :re-frame2-pair cb)` — raw trace stream (also re-exported on `rf/`). The skill's listener id is fixed (one listener per skill per Spec 009).
 - `(rf/register-epoch-listener! :re-frame2-pair-epoch cb)` — assembled-epoch stream. Mirrors `register-listener!`'s contract.
-- `(re-frame.trace.tooling/trace-buffer opts)` — retain-N trace ring (default 200, configurable via `(rf/configure! :trace-buffer {:depth N})`). CLJS callers must use the `re-frame.trace.tooling` ns — `rf/trace-buffer` is a JVM-only alias and returns nil in the browser runtime.
+- `(re-frame.trace.tooling/trace-buffer opts)` — retain-N trace ring (default 200, configurable via `(rf/configure! :trace-buffer {:cascades-retained N})`). CLJS callers must use the `re-frame.trace.tooling` ns — `rf/trace-buffer` is a JVM-only alias and returns nil in the browser runtime.
 - `(rf/epoch-history frame-id)` — per-frame epoch ring (default 50, configurable via `(rf/configure! :epoch-history {:depth N})`).
 - `(rf/restore-epoch frame-id epoch-id)` — first-class time-travel with seven documented failure modes (Tool-Pair §Time-travel).
 

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -602,7 +602,7 @@ re-frame2 has three orthogonal configuration surfaces. The user-facing question 
 For knobs that apply globally to the framework runtime, are addressed by a **keyword** (no impl-reference required), and whose values are plain data (numbers, booleans, small maps). The full key vocabulary is enumerated at [API.md §Configure keys](API.md#configure-keys) and is fixed-and-additive.
 
 - `(rf/configure! :epoch-history {:depth 50})` — ring-buffer depth for the Tool-Pair epoch surface
-- `(rf/configure! :trace-buffer {:depth 200})` — ring-buffer depth for trace events
+- `(rf/configure! :trace-buffer {:cascades-retained 200})` — retained cascade-slot count for trace events
 - `(rf/configure! :elision {:rf.size/threshold-bytes 16384})` — wire-elision size threshold
 
 The opts-map sub-keys mix two shapes deliberately: cross-surface policy slots use a namespaced keyword under the area's reserved `:rf.<area>/*` sub-namespace (e.g. `:rf.size/threshold-bytes` — the same key the wire-elision walker reads); one-off per-knob settings stay bare (e.g. `:depth`, `:grace-period-ms`). The rule is closed and the discriminator is **whether the sub-key names a cross-spec policy slot or a one-off knob** — full statement at [API.md §Configure keys — Opts-key naming rule](API.md#opts-key-naming-rule).


### PR DESCRIPTION
Closes rf2-ldj3r.

## What

rf2-x3m8c (#3302) reconciled the trace-buffer config vocabulary across impl ↔ API.md ↔ Spec 009, making `:cascades-retained` the canonical `:trace-buffer` config key and warning on the retired `{:depth N}` form. Two out-of-lane docs still showed the old vocabulary; this retires them so the docs match the shipped config surface.

- `spec/Conventions.md` (HOT-ZONE, sole-toucher) — the `:trace-buffer` example in §`configure!` keys now reads `{:cascades-retained 200}` ("retained cascade-slot count for trace events"), matching API.md §Configure keys (`{:cascades-retained N}`).
- `skills/re-frame2-pair/docs/initial-spec.md` — the `trace-buffer` ring-config note now uses `{:cascades-retained N}`.

`:epoch-history`'s `{:depth N}` is left unchanged — `:depth` is still the canonical sub-key for that config key (per API.md), and the bare-`:depth` example in the Conventions opts-key-naming prose remains accurate. No back-compat shim, no "renamed from" note — the prose is clean.

The bead named `spec/Conventions.md:605` and `skills/re-frame2-pair/docs/initial-spec.md:79`; the skills line had drifted to :96. Both intended trace-buffer occurrences are updated. (API.md was already reconciled by #3302 and is out of scope.)

## Quality gates

- `python -m mkdocs build --strict` (from repo root) — PASS (built in 8.40s, exit 0; no WARNING/ERROR. The "not in nav" listing + the pre-existing `the-mayor-method.md` relative-link note are INFO-level and pre-existing).
- `python scripts/check_doc_slugs.py` — PASS (exit 0, no output).

Diff: 2 files, 2 insertions(+), 2 deletions(-).