### PR TITLE
fix(examples/scripts): reject unallowlisted external CSS @imports in asset scanner (rf2-vou5mm)

### DIFF
--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -30,8 +30,20 @@
  *      og:image meta, and transitively the @import targets inside any
  *      referenced local CSS) to a real file in the repo source tree. A
  *      reference to a missing/renamed/typo'd local asset fails the gate.
- *      External URLs (http(s):// + protocol-relative //) and the build
- *      output main.js (produced by shadow-cljs, not source) are skipped.
+ *      External URLs in <link href> / <script src> (http(s):// +
+ *      protocol-relative //) and the build output main.js (produced by
+ *      shadow-cljs, not source) are skipped.
+ *
+ *      EXTERNAL CSS @import is NOT skipped (rf2-vou5mm). An external
+ *      `@import url(https://…)` (or a protocol-relative `@import url(//…)`)
+ *      inside any scanned CSS pulls a third-party network dependency into
+ *      every staged example at load time — exactly the Google-Fonts
+ *      regression rf2-byf7y removed. So the gate REJECTS any external CSS
+ *      @import unless its URL is explicitly allowlisted (with a reason) in
+ *      EXTERNAL_IMPORT_ALLOWLIST below. The allowlist starts EMPTY: the
+ *      shared design system declares zero remote fonts / hosts (see
+ *      examples/_shared/README.md §Visual identity), so the contract is
+ *      fail-closed — a re-introduced external @import turns the gate RED.
  *
  *      Staging-aware resolution: a page references _shared assets at the
  *      relative path `_shared/...`, but in the SOURCE tree _shared lives
@@ -134,6 +146,33 @@ const ALLOWLIST = {
     assetExemptions: ['_shared/css/style.css'],
     localAssets: ['base.css', 'index.css'],
   },
+};
+
+// ---------------------------------------------------------------------------
+// External CSS @import allowlist (rf2-vou5mm) — the ONE encoded place that
+// names an external `@import url(https://…|http://…|//…)` the scanner is
+// permitted to see inside scanned CSS, each with a reason. Any external CSS
+// @import NOT listed here fails the gate.
+//
+// Why this exists: an external CSS @import (e.g. Google Fonts) makes every
+// staged example fire a third-party network request at load time — the exact
+// regression rf2-byf7y removed. The shared design system deliberately loads
+// NO remote fonts/hosts (examples/_shared/README.md §Visual identity), so this
+// allowlist starts EMPTY and the contract is fail-closed: re-introducing an
+// external @import without an entry here turns the gate RED.
+//
+// Shape mirrors ALLOWLIST: key = the external URL with any ?query/#hash
+// STRIPPED (the scanner normalises @import targets that way before the lookup);
+// value = { reason } explaining why the remote dependency is intentional.
+// ---------------------------------------------------------------------------
+const EXTERNAL_IMPORT_ALLOWLIST = {
+  // (empty) — no example CSS may pull a remote stylesheet/font. Add an entry
+  // here ONLY with a deliberate decision and a reason. NB: the key is the
+  // query-stripped URL — e.g. `@import url(https://x/css2?family=Inter)` is
+  // keyed as 'https://x/css2':
+  //   'https://fonts.googleapis.com/css2': {
+  //     reason: 'why this remote font is intentionally loaded',
+  //   },
 };
 
 // Build output produced by shadow-cljs at stage time — never a repo-source
@@ -274,14 +313,32 @@ function resolveRef(ref, pageDir, sharedParent = EXAMPLES_ROOT) {
 }
 
 // Resolve + check a single local CSS file's @import targets, recursively.
-// Records an error for any local import that does not resolve to a real file.
-function checkCssImports(io, cssAbsPath, displayRef, errors, seen) {
+// Records an error for any local import that does not resolve to a real file,
+// and for any EXTERNAL @import (http/https/protocol-relative) not present in
+// the external-import allowlist (rf2-vou5mm).
+function checkCssImports(io, cssAbsPath, displayRef, errors, seen, externalAllowlist = EXTERNAL_IMPORT_ALLOWLIST) {
   if (seen.has(cssAbsPath)) return;
   seen.add(cssAbsPath);
   const css = readFileSafe(io, cssAbsPath);
   if (css == null) return; // a missing CSS file is reported by its referrer
   for (const imp of extractCssImports(css)) {
-    if (isExternalRef(imp)) continue;
+    if (isExternalRef(imp)) {
+      // An external CSS @import pulls a third-party network dependency into
+      // every staged example at load time. Reject it unless its exact URL is
+      // allowlisted with a reason (fail-closed — see EXTERNAL_IMPORT_ALLOWLIST).
+      // data:/#fragment schemes are not network deps; only http/https and the
+      // protocol-relative `//host/...` form are gated.
+      const isNetwork = /^https?:/i.test(imp) || imp.startsWith('//');
+      if (isNetwork && !Object.prototype.hasOwnProperty.call(externalAllowlist, imp)) {
+        errors.push(
+          `${displayRef}: external @import '${imp}' pulls a third-party ` +
+            `network dependency into staged examples. External CSS @imports ` +
+            `are forbidden unless explicitly allowlisted with a reason in ` +
+            `EXTERNAL_IMPORT_ALLOWLIST in check-examples-assets.cjs (rf2-vou5mm).`,
+        );
+      }
+      continue;
+    }
     const target = path.resolve(path.dirname(cssAbsPath), imp);
     if (!io.existsSync(target)) {
       errors.push(
@@ -291,13 +348,14 @@ function checkCssImports(io, cssAbsPath, displayRef, errors, seen) {
       continue;
     }
     if (target.toLowerCase().endsWith('.css')) {
-      checkCssImports(io, target, `${displayRef} -> ${imp}`, errors, seen);
+      checkCssImports(io, target, `${displayRef} -> ${imp}`, errors, seen, externalAllowlist);
     }
   }
 }
 
 function scanPage(io, indexAbsPath, opts = {}) {
   const allowlist = opts.allowlist || ALLOWLIST;
+  const externalImportAllowlist = opts.externalImportAllowlist || EXTERNAL_IMPORT_ALLOWLIST;
   const required = opts.required || REQUIRED_SHARED_ASSETS;
   const errors = [];
   const relIndex = path.relative(REPO_ROOT, indexAbsPath).split(path.sep).join('/');
@@ -333,7 +391,7 @@ function scanPage(io, indexAbsPath, opts = {}) {
     }
     // Transitively check @import targets inside any referenced local CSS.
     if (target.toLowerCase().endsWith('.css')) {
-      checkCssImports(io, target, `${relIndex} (${ref})`, errors, seenCss);
+      checkCssImports(io, target, `${relIndex} (${ref})`, errors, seenCss, externalImportAllowlist);
     }
   }
 
@@ -408,6 +466,39 @@ function checkSharedTree(io, opts = {}) {
       );
     }
   }
+  const externalImportAllowlist =
+    opts.externalImportAllowlist || EXTERNAL_IMPORT_ALLOWLIST;
+
+  // No EXTERNAL @import in the shared CSS (rf2-vou5mm). An external
+  // `@import url(https://…|//…)` here makes every staged example fire a
+  // third-party network request at load time — the Google-Fonts regression
+  // rf2-byf7y removed. Fail-closed: reject any external @import in style.css /
+  // structure.css whose exact URL is not allowlisted. Checked HERE (not only
+  // via the page reference graph) so the contract holds even if no scanned page
+  // happens to link the file.
+  for (const cssName of ['style.css', 'structure.css']) {
+    const cssPath = path.join(sharedRoot, 'css', cssName);
+    const css = readFileSafe(io, cssPath);
+    if (css == null) continue; // missing-file is reported by the mustExist loop
+    for (const imp of extractCssImports(css)) {
+      const isNetwork = /^https?:/i.test(imp) || imp.startsWith('//');
+      if (
+        isNetwork &&
+        !Object.prototype.hasOwnProperty.call(externalImportAllowlist, imp)
+      ) {
+        errors.push(
+          `examples/_shared/css/${cssName}: external @import '${imp}' pulls a ` +
+            `third-party network dependency into every staged example. The ` +
+            `shared design system loads NO remote fonts/hosts (see ` +
+            `examples/_shared/README.md §Visual identity). External CSS ` +
+            `@imports are forbidden unless explicitly allowlisted with a ` +
+            `reason in EXTERNAL_IMPORT_ALLOWLIST in ` +
+            `check-examples-assets.cjs (rf2-vou5mm).`,
+        );
+      }
+    }
+  }
+
   // structure.css reachable from style.css's @import.
   const stylePath = path.join(sharedRoot, 'css', 'style.css');
   const style = readFileSafe(io, stylePath);
@@ -477,6 +568,7 @@ module.exports = {
   SOCIAL_PREVIEW_RASTER_EXTS,
   SOCIAL_PREVIEW_REQUIRED,
   ALLOWLIST,
+  EXTERNAL_IMPORT_ALLOWLIST,
   BUILD_OUTPUTS,
   listExampleIndexHtml,
   isExternalRef,
@@ -530,10 +622,11 @@ if (require.main === module) {
     );
     for (const e of errors) console.error(`  - ${e}`);
     console.error(
-      `\nA missing/renamed _shared asset, a broken @import, or a page that ` +
-        `drops a required shared asset without an encoded ALLOWLIST ` +
-        `exception fails this gate. Fix the reference, restore the asset, or ` +
-        `encode the exception (with a reason) in ` +
+      `\nA missing/renamed _shared asset, a broken @import, an unallowlisted ` +
+        `EXTERNAL CSS @import, or a page that drops a required shared asset ` +
+        `without an encoded ALLOWLIST exception fails this gate. Fix the ` +
+        `reference, restore the asset, drop the remote @import, or encode the ` +
+        `exception (with a reason) in ALLOWLIST / EXTERNAL_IMPORT_ALLOWLIST in ` +
         `examples/scripts/check-examples-assets.cjs.`,
     );
     process.exit(1);

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -34,6 +34,7 @@ const {
   REQUIRED_SHARED_ASSETS,
   SOCIAL_PREVIEW_REQUIRED,
   ALLOWLIST,
+  EXTERNAL_IMPORT_ALLOWLIST,
   isExternalRef,
   extractHtmlRefs,
   extractOgImageRefs,
@@ -162,7 +163,10 @@ const STRUCTURE = path.join(EXAMPLES_ROOT, '_shared', 'css', 'structure.css');
 const SHARED_ROOT = path.join(EXAMPLES_ROOT, '_shared');
 
 // A well-formed page that links all three shared assets, plus a style.css
-// that @imports structure.css and an external Google-Fonts URL.
+// that @imports structure.css. The shared design system loads NO remote fonts
+// (rf2-byf7y removed the Google-Fonts @import; rf2-vou5mm now REJECTS any
+// re-introduced external @import) — so the clean fixture has only the local
+// structure.css import.
 function goodHtml() {
   return [
     '<!doctype html><html><head>',
@@ -174,7 +178,6 @@ function goodHtml() {
 }
 function goodStyleCss() {
   return [
-    "@import url('https://fonts.googleapis.com/css2?family=Inter');",
     "@import url('structure.css');",
     'body { color: #1A1814; }',
   ].join('\n');
@@ -279,11 +282,125 @@ it('TEETH: a style.css @import to a missing structure.css is reported', () => {
   );
 });
 
-it('TEETH: the external Google-Fonts @import is NOT flagged as missing', () => {
-  const { errors } = scanPage(fullIo(), PAGE);
+// ---- TEETH: external @import is REJECTED unless allowlisted (rf2-vou5mm) ---
+//
+// rf2-byf7y found the scanner SKIPPED external CSS @imports, so a Google-Fonts
+// network dependency stayed green. The contract is now fail-closed: an
+// unallowlisted external @import (http/https/protocol-relative) in any scanned
+// CSS fails the gate, while still NOT being checked on disk.
+
+it('TEETH: an unallowlisted external Google-Fonts @import is REJECTED', () => {
+  // Inject a style.css with a re-introduced external @import (the exact
+  // rf2-byf7y regression) and confirm the gate fails — and never tries to
+  // resolve the remote URL on disk.
+  const io = fullIo({
+    [STYLE]: [
+      "@import url('https://fonts.googleapis.com/css2?family=Inter');",
+      "@import url('structure.css');",
+      'body { color: #1A1814; }',
+    ].join('\n'),
+  });
+  const { errors } = scanPage(io, PAGE);
   assert.ok(
-    !errors.some((e) => e.includes('fonts.googleapis.com')),
-    'an external @import URL must never be checked on disk',
+    errors.some(
+      (e) =>
+        e.includes('external @import') && e.includes('fonts.googleapis.com'),
+    ),
+    `expected the external @import to be rejected, got: ${errors.join(' | ')}`,
+  );
+  // It must be rejected as a policy violation, NOT mis-reported as a
+  // missing-on-disk file (the URL is never resolved against the filesystem).
+  assert.ok(
+    !errors.some((e) => e.includes('does not resolve to a file')),
+    `an external @import must never be checked on disk, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: a protocol-relative external @import (//host/...) is REJECTED', () => {
+  const io = fullIo({
+    [STYLE]: [
+      "@import url('//cdn.example.com/x.css');",
+      "@import url('structure.css');",
+    ].join('\n'),
+  });
+  const { errors } = scanPage(io, PAGE);
+  assert.ok(
+    errors.some(
+      (e) => e.includes('external @import') && e.includes('//cdn.example.com/x.css'),
+    ),
+    `expected the protocol-relative @import to be rejected, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('an external @import whose exact URL is allowlisted (with reason) scans clean', () => {
+  // The scanner normalises @import targets by stripping ?query/#hash before
+  // the allowlist lookup, so the allowlist key is the query-stripped URL.
+  const written = 'https://fonts.googleapis.com/css2?family=Inter';
+  const allowKey = 'https://fonts.googleapis.com/css2';
+  const io = fullIo({
+    [STYLE]: [
+      `@import url('${written}');`,
+      "@import url('structure.css');",
+    ].join('\n'),
+  });
+  const { errors } = scanPage(io, PAGE, {
+    externalImportAllowlist: {
+      [allowKey]: { reason: 'deliberate remote font for this test' },
+    },
+  });
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `an allowlisted external @import should scan clean, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('the LIVE EXTERNAL_IMPORT_ALLOWLIST is empty (no remote CSS deps shipped)', () => {
+  assert.deepStrictEqual(
+    Object.keys(EXTERNAL_IMPORT_ALLOWLIST),
+    [],
+    'the shipped example CSS must declare NO remote @import; the external ' +
+      'import allowlist is fail-closed and starts empty (rf2-vou5mm / rf2-byf7y)',
+  );
+});
+
+it('TEETH: a data: @import is NOT treated as a network dep (not rejected)', () => {
+  // data: URIs are inlined, not a third-party network request — they are
+  // external (not resolved on disk) but must not trip the network-dep gate.
+  const io = fullIo({
+    [STYLE]: [
+      "@import url('data:text/css,body{}');",
+      "@import url('structure.css');",
+    ].join('\n'),
+  });
+  const { errors } = scanPage(io, PAGE);
+  assert.deepStrictEqual(
+    errors,
+    [],
+    `a data: @import must not be rejected as a network dep, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: an external @import in the _shared tree is rejected by checkSharedTree', () => {
+  // checkSharedTree enforces the no-remote-CSS contract directly on the
+  // _shared source, independent of any page's reference graph.
+  const io = makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]:
+      "@import url('https://fonts.googleapis.com/css2?family=Inter');\n" +
+      "@import url('structure.css');",
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]:
+      '.send-form input[type="text"] { min-width: 240px; }\n' +
+      '.cells-grid input { width: 56px; }',
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: 'PNGDATA',
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
+  });
+  const errors = checkSharedTree(io, { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some(
+      (e) => e.includes('external @import') && e.includes('fonts.googleapis.com'),
+    ),
+    `expected checkSharedTree to reject the external @import, got: ${errors.join(' | ')}`,
   );
 });
 


### PR DESCRIPTION
@
Follow-up to rf2-byf7y. The shared-stylesheet network dependency (a remote Google-Fonts `@import` in `examples/_shared/css/style.css`) was removed in #3378, but the scanner half of that finding remained: `examples/scripts/check-examples-assets.cjs` intentionally SKIPPED external CSS `@import`s (the `isExternalRef` short-circuit in `checkCssImports`), so a future re-introduction of a remote `@import` from `_shared` would pass the gate green again.

## What changed

The asset scanner is now **fail-closed** on external CSS `@import`s:

- An external `@import` (`http://`, `https://`, or protocol-relative `//host/...`) inside any scanned CSS — or directly in the `_shared` `style.css` / `structure.css` — fails the gate **unless** its query-stripped URL is explicitly allowlisted with a reason in the new `EXTERNAL_IMPORT_ALLOWLIST`.
- The allowlist **starts empty**: the shared design system ships zero remote fonts/hosts (see `examples/_shared/README.md` §Visual identity). Re-introducing a remote `@import` without an entry turns the gate RED.
- `data:` / `#fragment` imports are NOT network deps and are not rejected; external URLs are still never resolved on disk (rejected as a policy violation, not mis-reported as a missing file).
- Enforced on two paths: the page reference graph (`checkCssImports`, threaded through `scanPage` via `opts.externalImportAllowlist`) and directly on the `_shared` source (`checkSharedTree`), so the contract holds even if no scanned page happens to link the CSS.
- `EXTERNAL_IMPORT_ALLOWLIST` is exported; the allowlist key is the **query-stripped** URL (the scanner normalises `?query`/`#hash` before lookup) — documented inline.

Scope is the scanner + its test only, both OUTSIDE the `examples/_shared` lane (which is why the `_shared`-only rf2-byf7y worker could not do it).

## Test changes

- Replaced the old `TEETH: the external Google-Fonts @import is NOT flagged as missing` test (which encoded the now-removed skip-external behaviour) with reject-unless-allowlisted coverage: https rejected, protocol-relative `//host` rejected, allowlisted-URL clean, `data:` clean, and a `_shared`-direct `checkSharedTree` rejection.
- Added a LIVE assertion that the shipped `EXTERNAL_IMPORT_ALLOWLIST` is empty (no remote CSS deps shipped).
- Dropped the Google-Fonts `@import` from the clean `goodStyleCss()` fixture (it would otherwise now fail every page using it).

## Quality gates

- `node implementation/scripts/check-examples-assets.test.cjs` — **36 PASS / 0 FAIL** (was 35 PASS pre-change; the old skip-external test replaced by 6 new reject/allowlist/data:/_shared tests).
- `node examples/scripts/check-examples-assets.cjs` (live CLI) — **green**, 28 example pages + `_shared` tree resolve clean (post-byf7y tree has only the local `structure.css` import).
- `cd implementation && npm run test:script-policy` — full gate **green** end-to-end.

Closes rf2-vou5mm.
@