### PR TITLE
fix(re-frame2-pair-mcp): reduce setup friction for claude --continue (rf2-646lr)

### DIFF
--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -123,6 +123,8 @@ Verification — run `discover-app` (the MCP tool `mcp__re-frame2-pair__discover
 
 Report the hint to the user verbatim — they can fix it in seconds without re-cloning anything.
 
+**Registering the MCP server takes a fresh session, not `--continue` (rf2-646lr).** Wiring `@day8/re-frame2-pair-mcp` into the agent host (`claude mcp add`, or editing `settings.json`) only takes effect in sessions that **start** afterwards. A session resumed with `claude --continue` will not surface the re-frame2-pair tools even though `claude mcp list` reports the server `Connected` — exit and start a new session (`claude --resume`, or a plain new `claude`) after registering the server. This is agent-host behaviour, not a server flag; the same applies after pulling MCP source changes and rebuilding `out/server.js`.
+
 ---
 
 ## Cardinal rule — two modes of changing the app
@@ -167,7 +169,7 @@ This locates the shadow-cljs nREPL port, connects, switches the session to `:clj
 - `:fresh` — runtime connected, heartbeat recent, build not recompiled since load. Read away.
 - `:stale-build` — the tab is serving OLD code (a recompile landed the runtime never picked up). The `:hint` tells the user the exact URL to reload.
 - `:no-runtime` — no live CLJS runtime is connected (WS dropped, no tab open) — reads will come back blank. The `:hint` names the exact `http://localhost:<port>` to reload, then "re-run discover-app".
-- `:unknown` — the JVM-side build-worker state couldn't be read even after a retry. **This is not a green light.** The `:hint` is actionable: reload the named URL if reads come back blank, and if it stays `:unknown`, restart `shadow-cljs watch <build>` — the build worker isn't answering.
+- `:unknown` — the JVM-side build-worker state couldn't be read even after a retry, so stale-build detection is blind (reads may still work). **This is not a green light.** The dominant cause is **multiple / zombie shadow-cljs JVMs** — a `Ctrl-C`'d watch that didn't free its ports left an orphan JVM, and the socket reached a runtime whose build worker is in a *different* JVM. The `:hint` is actionable: relay it to the user, who should run `npx shadow-cljs stop` (frees the orphan ports a bare `Ctrl-C` leaves held), start exactly **one** `shadow-cljs watch <build>`, reload the tab, and re-run discover-app to confirm `:fresh`.
 
 You **cannot reload a browser yourself** — so when the verdict is non-`:fresh`, relay the `:freshness :hint` to the user as the single next step rather than firing reads that will return blank.
 

--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -89,6 +89,19 @@ Add to your `~/.claude/settings.json` (or per-project `.claude/settings.json`):
 }
 ```
 
+> **After `claude mcp add`, start a FRESH session — not `--continue`
+> (rf2-646lr).** Registering the server with `claude mcp add` (or editing
+> `settings.json`) does not retroactively load the MCP into a session
+> that was already running. Field report: a session resumed with
+> `claude --continue` did **not** surface the re-frame2-pair tools even
+> though `claude mcp list` showed the server `Connected`; the tools only
+> appeared after a full exit and `claude --resume` (or a plain new
+> `claude`). MCP servers are wired up at session **start**, so launch a
+> new session after registering the server (or after pulling MCP source
+> changes and rebuilding `out/server.js` — see the
+> [stale-binary hook](#stale-binary-post-merge-hook-rf2-6jj3r)). This is
+> agent-host behaviour, not a server flag.
+
 The server auto-discovers the nREPL port from (highest precedence first):
 
 1. `--port-file <path>` launch flag — an explicit, **cwd-independent**
@@ -460,6 +473,30 @@ the failure path and reports one of four specific reasons:
 
 The ladder costs one extra `jvm-eval` (active-builds enumeration) on
 the failure path; the probe cache means the success path stays free.
+
+### Persistent `:liveness :unknown` — the zombie-shadow case (rf2-646lr)
+
+`discover-app`'s freshness token reports `:liveness :unknown` when it
+can't read the JVM-side build-worker state (so stale-build detection is
+blind), while reads themselves may still work. The dominant cause is
+**multiple / zombie shadow-cljs JVMs**: `Ctrl-C` of a `shadow-cljs
+watch` does not always free shadow's ports, so an orphan JVM lingers
+holding 9630–963x. The MCP server's nREPL socket then reaches a runtime
+whose build worker lives in a *different* JVM, and the worker lookup
+misses — for the whole session — even though evals and reads succeed.
+
+When `:liveness` stays `:unknown`, the token's `:hint` now names this
+case and the remediation directly:
+
+```bash
+npx shadow-cljs stop      # kills ALL shadow JVMs and frees the orphan ports
+npx shadow-cljs watch app # start exactly ONE watch
+# then reload the app tab and re-run discover-app to confirm :liveness :fresh
+```
+
+`npx shadow-cljs stop` is the operative move: it frees the ports that a
+bare `Ctrl-C` leaves held. Starting a *single* watch afterwards ensures
+the nREPL socket and the build worker live in the same JVM.
 
 ## Spec
 

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -424,23 +424,29 @@ read-family ops (`orient`, `read-dom`, `read-ui`, `eval-cljs`) echo the
 resolved `:build` on their result so the operating target stays visible
 even when implicitly selected (rf2-fmho5).
 
-**Freshness / liveness token (rf2-ertqw, rf2-jkwu4).** Every `:ok? true`
-discover-app payload carries `:freshness {:liveness <verdict> :hint <str>
-…}` — the browser-half (runtime-instance-id + load time) merged with the
-JVM-half build-worker state (monotonic compile-cycle + last-flush + WS
-heartbeat age), cross-checked to one `:liveness` verdict:
+**Freshness / liveness token (rf2-ertqw, rf2-jkwu4, rf2-646lr).** Every
+`:ok? true` discover-app payload carries `:freshness {:liveness <verdict>
+:hint <str> …}` — the browser-half (runtime-instance-id + load time)
+merged with the JVM-half build-worker state (monotonic compile-cycle +
+last-flush + WS heartbeat age), cross-checked to one `:liveness` verdict:
 `:fresh` / `:stale-build` / `:no-runtime` / `:unknown`. The JVM-half read
 is **retried once** before a `:unknown` degrade — a nil first read is
 most often a transient socket hiccup, not a genuinely-unreadable old
 shadow (rf2-jkwu4). For every **non-`:fresh`** verdict the `:hint` is
 **actionable**: it names the EXACT `http://localhost:<port>` the human
 reloads (when discover-app was called with a `:port`, which also rides on
-the token), and for `:unknown` escalates to restarting
-`shadow-cljs watch <build>` when the worker stays unreadable. The agent
-cannot reload a browser itself, so a non-`:fresh` verdict is an early,
-crisp human-in-the-loop instruction — relay the `:hint` rather than
-firing reads that will return blank. A `:stale-build` verdict is also
-promoted to a top-level `:warning :stale-build`.
+the token). For `:unknown` the hint names the **dominant cause** —
+MULTIPLE / ZOMBIE shadow-cljs JVMs (rf2-646lr): a stale watch Ctrl-C'd
+without freeing its ports leaves an orphan JVM, and the nREPL socket can
+reach a runtime whose build worker lives in a *different* JVM, so the
+worker lookup misses even while reads still work. The remediation it
+names is `npx shadow-cljs stop` (which kills all shadow JVMs and frees
+the orphan ports, where Ctrl-C does not) followed by exactly **one**
+`shadow-cljs watch <build>`, a reload, and a re-run of discover-app. The
+agent cannot reload a browser or stop a JVM itself, so a non-`:fresh`
+verdict is an early, crisp human-in-the-loop instruction — relay the
+`:hint` rather than firing reads that will return blank. A `:stale-build`
+verdict is also promoted to a top-level `:warning :stale-build`.
 
 **Id representation (rf2-cg37y).** Every build/frame id discover-app
 surfaces — `:build-id`, `:frames`, and the diagnostic `:running-builds`

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/freshness.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/freshness.cljs
@@ -61,8 +61,15 @@
                      rf2-lo28u killer.)
     :no-runtime      no REPL runtime connected for the build (WS dropped
                      / no tab open).
-    :unknown         the JVM half couldn't be read (old shadow, socket
-                     hiccup) — degrade to browser-half-only, never crash.
+    :unknown         the JVM half couldn't be read after a retry — degrade
+                     to browser-half-only, never crash. The dominant cause
+                     is MULTIPLE / ZOMBIE shadow-cljs JVMs (a stale watch
+                     Ctrl-C'd without freeing its ports; the socket reaches
+                     a runtime whose build worker is in a DIFFERENT JVM, so
+                     the worker lookup misses). The hint names the
+                     `npx shadow-cljs stop` → single-watch remediation
+                     (rf2-646lr). Rarer: an old shadow without get-worker,
+                     or a transient socket hiccup.
 
   Everything here is best-effort: a JVM probe failure degrades to the
   browser half plus `:liveness :unknown`. The token is a DIAGNOSTIC
@@ -214,7 +221,8 @@
                    browser is serving old code (RELOAD).
     :fresh         runtime connected, heartbeat recent, build not
                    recompiled since load.
-    :unknown       the JVM half is absent (couldn't read shadow state).
+    :unknown       the JVM half is absent (couldn't read shadow state —
+                   most often a multiple/zombie-shadow JVM split, rf2-646lr).
 
   Order matters: `:no-runtime` wins over `:stale-build` (you can't be
   serving stale code if nothing's connected), and both win over
@@ -280,14 +288,20 @@
 
       :unknown
       (str "LIVENESS UNKNOWN: could not read the shadow-cljs build worker "
-           "state after a retry (old shadow without get-worker, or the "
-           "watch worker is down). The browser-side instance id + load "
-           "time are still reported, but stale-build detection is "
-           "unavailable this call. ACTION (the agent cannot do this): if "
-           "reads come back blank, reload " target " then re-run "
-           "discover-app; if it stays unknown, restart `shadow-cljs watch "
-           (if (some? build-id) (pr-str build-id) "<build>") "` — the "
-           "JVM-side build worker is not answering.")
+           "state after a retry. The browser-side instance id + load time "
+           "are still reported and reads may still work, but stale-build "
+           "detection is unavailable this call. Most common cause: MULTIPLE / "
+           "ZOMBIE shadow-cljs JVMs — a stale watch (Ctrl-C does not always "
+           "free shadow's ports) left an orphan JVM, and the nREPL socket "
+           "reached a runtime whose build worker lives in a DIFFERENT JVM, so "
+           "the worker lookup misses. (Less common: an old shadow without "
+           "get-worker, or the watch worker is down.) ACTION (the agent "
+           "cannot do this): run `npx shadow-cljs stop` to kill ALL shadow "
+           "JVMs, then start exactly ONE `shadow-cljs watch "
+           (if (some? build-id) (pr-str build-id) "<build>") "`, reload "
+           target ", and re-run discover-app to confirm :liveness :fresh. If "
+           "it still stays unknown after a single clean watch, the JVM-side "
+           "build worker genuinely is not answering (old shadow).")
 
       nil)))
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/freshness_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/freshness_test.cljs
@@ -224,6 +224,27 @@
                 "names the watch restart as the escalation")
             (done))))))
 
+(deftest unknown-hint-diagnoses-the-zombie-shadow-case
+  ;; rf2-646lr field report: discover-app stayed :liveness :unknown for an
+  ;; entire session because MULTIPLE / ZOMBIE shadow-cljs JVMs held the
+  ;; ports — reads worked (the socket reached a runtime) but the build
+  ;; worker lived in a different JVM, so the worker lookup missed. The
+  ;; :unknown hint must NAME that case and recommend the `npx shadow-cljs
+  ;; stop` → single-watch remediation that actually frees the orphan ports.
+  (async done
+    (-> (with-jvm-half! nil ; nil JVM half ⇒ :unknown
+          (fn [] (fresh/assemble nil :examples/machine-epochs browser-half {:port 8033})))
+        (.then
+          (fn [token]
+            (is (= :unknown (:liveness token)))
+            (is (re-find #"(?i)zombie" (:hint token))
+                "names the multiple/zombie-shadow case as the dominant cause")
+            (is (re-find #"npx shadow-cljs stop" (:hint token))
+                "recommends the remediation that frees the orphan ports")
+            (is (re-find #"(?i)one" (:hint token))
+                "tells the operator to start exactly ONE watch")
+            (done))))))
+
 (deftest unknown-hint-degrades-to-build-name-without-a-port
   (async done
     (-> (with-jvm-half! nil


### PR DESCRIPTION
@
Fixes **rf2-646lr** (P2). Two field-report findings from wiring re-frame2-pair-mcp into a real project (rf8 migration debug).

## Finding 1 — `claude --continue` did not load the MCP

After `claude mcp add` registered the server (showed `Connected`), `claude --continue` did **not** surface the MCP tools — they only appeared after a full exit + `claude --resume`. This is **agent-host behaviour** (MCP servers are wired up at session start), not a server flag, so the fix is a **setup-doc note**:

- `README.md` Configure-Claude-Code section: warn to start a fresh session (not `--continue`) after registering the server (or after pulling MCP source + rebuilding `out/server.js`).
- `skills/re-frame2-pair/SKILL.md` Setup: same note, generic to any consumer app.

## Finding 2 — persistent `:liveness :unknown` under zombie shadow

`discover-app` returned `:liveness :unknown` for the **entire session** (stale-build detection blind) while reads worked fine. Correlated with multiple/zombie shadow-cljs JVMs holding ports 9630–963x (Ctrl-C of the watch did not free them; `npx shadow-cljs stop` would). Root signature: the nREPL socket reached a runtime whose build worker lived in a *different* JVM, so the JVM-side `get-worker` lookup missed.

The `:unknown` verdict hint (`freshness.cljs`) now **names this dominant cause** and recommends the remediation that actually frees the orphan ports: `npx shadow-cljs stop` → start exactly **one** `shadow-cljs watch <build>` → reload → re-run discover-app. Updated in lockstep:

- `src/.../tools/freshness.cljs` — enriched `:unknown` hint + docstrings.
- `spec/003-Tool-Catalogue.md` — freshness-token doc (rf2-646lr cross-ref).
- `skills/re-frame2-pair/SKILL.md` — `:unknown` liveness line.
- `test/.../freshness_test.cljs` — new `unknown-hint-diagnoses-the-zombie-shadow-case` assertion.

No product decision required: both findings resolve to a setup-doc note + an enriched diagnostic hint. No wire/transport/session-model change. No back-compat shims.

## Quality gates

- `npm test` (cljs unit, includes conformance_test): **984 tests / 2989 assertions, 0 failures, 0 errors**.
- `npm run check:descriptors`: **OK — tool-descriptors.edn in sync (28 tools)**.
- `npm run test:mcp-conformance`: **not triggered** — change is freshness-token hint *data* + docs, not a wire/server-surface change; `check:descriptors` confirms the 28-tool surface is unchanged and in-tree `conformance_test.cljs` (part of the 984 passing) covers wire shape. The conformance suite does not assert liveness-hint content.

## Disposition

Fix landed (clear doc/diagnostic improvement). Closes rf2-646lr.
@