### PR TITLE
fix(schemas): senior-review findings (rf2-mxs7a)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -469,11 +469,23 @@
                               value-bearing-slots)]
             (emit-malformed-schema!
               (assoc base
-                     :schema    schema
-                     :reason    (str "Registered schema " (pr-str schema)
-                                     " is malformed and could not be "
-                                     "evaluated: " reason)
-                     :recovery  :no-recovery))
+                     :schema   schema
+                     :reason   (str "Registered schema " (pr-str schema)
+                                    " is malformed and could not be "
+                                    "evaluated: " reason)
+                     ;; Per rf2-mxs7a — preserve the surface-specific
+                     ;; recovery the caller's build-base-tags supplied
+                     ;; (validate-fx! → :skipped, validate-sub! →
+                     ;; :replaced-with-default; event/cofx →
+                     ;; :no-recovery). The runtime applies that local
+                     ;; fallback even on a malformed schema (fx.cljc
+                     ;; skips the offending fx; subs/memo.cljc returns
+                     ;; the default), so the malformed-schema trace must
+                     ;; report the SAME recovery the data plane actually
+                     ;; took rather than unconditionally lying with
+                     ;; :no-recovery. Default to :no-recovery only when
+                     ;; the surface did not carry one.
+                     :recovery (get base :recovery :no-recovery)))
             false)
 
           ;; Legitimate validation failure — the existing emit path.

--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -35,13 +35,31 @@
   `m/schema` ↔ raw EDN — round-tripping a registry ref loses the slot
   metadata).
 
-  ## Discoverability caveat — non-vector forms (rf2-yaioz)
+  ## Discoverability caveat — non-vector forms (rf2-yaioz / rf2-mxs7a)
 
   A user that registers a schema via a compiled `m/schema` value or a
   registry reference and adds per-slot `:sensitive?` / `:large?` flags
-  inside that opaque value will see the walker **silently skip** them.
-  No warning fires; the validation-failure trace will not redact the
-  sensitive slot.
+  inside that opaque value will see the walker **silently skip** them —
+  the validation-failure trace will not redact the sensitive slot. The
+  two opaque shapes differ in diagnostics:
+
+    - **Compiled / non-keyword opaque values** (a compiled `m/schema`
+      object, a map, any non-vector non-keyword form) **warn once per
+      process at registration time.** `reg-app-schema` /
+      `reg-app-schemas` emit `:rf.warning/schema-walker-opaque` (the
+      one-shot warn-once nudge owned by `re-frame.schemas.storage`,
+      pinned by `schemas_walker_opaque_warning_test`) naming the two
+      workable shapes below.
+
+    - **Keyword registry refs** (`:my/user-schema`) stay **silent by
+      design.** A bare keyword is a valid Malli schema in two flavours
+      — a primitive (`:int` / `:string`) and a registry ref — and the
+      predicate cannot cheaply tell them apart without a registry
+      consult, which Spec 010 §The `:schema` value is opaque to
+      re-frame forbids. A primitive keyword provably carries no
+      per-slot flags, so warning on every keyword would be a frequent
+      false positive to catch a rare registry-ref true positive
+      (rf2-ee38b.6); the keyword case is suppressed entirely.
 
   Two workable shapes when per-slot flags need to apply:
 

--- a/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_fail_open_test.clj
@@ -78,6 +78,11 @@
             (is (= :event (-> m :tags :where)))
             (is (= [:vector] (-> m :tags :schema)) ":schema carries the malformed form to fix")
             (is (string? (-> m :tags :reason)))
+            ;; rf2-mxs7a — the malformed trace reports the surface's
+            ;; recovery; the event handler is skipped (:no-recovery).
+            ;; `:recovery` is hoisted to the top-level envelope by
+            ;; trace/build-event (Spec 009 §Core fields hoist contract).
+            (is (= :no-recovery (:recovery m)))
             ;; fail-closed: no value-bearing slot leaks into the malformed trace.
             (is (not (contains? (:tags m) :received)))
             (is (not (contains? (:tags m) :value)))))))))
@@ -108,7 +113,11 @@
         (is (= 0 @calls) "handler skipped — cofx malformed-schema is no longer a silent pass")
         (let [mal (malformed-traces traces)]
           (is (= 1 (count mal)))
-          (is (= :cofx (-> (first mal) :tags :where))))))))
+          (is (= :cofx (-> (first mal) :tags :where)))
+          ;; rf2-mxs7a — cofx malformed-schema skips the handler
+          ;; (:no-recovery), matching the legitimate-failure path.
+          ;; `:recovery` hoists to the top-level envelope.
+          (is (= :no-recovery (:recovery (first mal)))))))))
 
 (deftest fx-malformed-schema-fails-closed-skipping-only-offender
   (testing "rf2-a5kzs (finding 2) — a malformed fx :schema skips ONLY the
@@ -128,7 +137,14 @@
         (is (= 1 @good-calls) "the sibling fx still ran")
         (let [mal (malformed-traces traces)]
           (is (= 1 (count mal)))
-          (is (= :fx-args (-> (first mal) :tags :where))))))))
+          (is (= :fx-args (-> (first mal) :tags :where)))
+          ;; rf2-mxs7a — the malformed fx trace must report the ACTUAL
+          ;; recovery the data plane took: only the offending fx is
+          ;; skipped (:skipped), NOT :no-recovery. The trace previously
+          ;; lied with :no-recovery even though the sibling fx ran.
+          ;; `:recovery` hoists to the top-level envelope.
+          (is (= :skipped (:recovery (first mal)))
+              "malformed fx trace reports :skipped (sibling fx still ran)"))))))
 
 (deftest sub-malformed-schema-fails-closed-replaced-with-default
   (testing "rf2-a5kzs (finding 2) — a malformed sub :schema yields the default
@@ -145,7 +161,13 @@
                          "malformed sub schema → nil (replaced-with-default), not the raw value")))]
       (let [mal (malformed-traces traces)]
         (is (pos? (count mal)) "a malformed-schema trace fired")
-        (is (= :sub-return (-> (first mal) :tags :where)))))))
+        (is (= :sub-return (-> (first mal) :tags :where)))
+        ;; rf2-mxs7a — the malformed sub trace must report
+        ;; :replaced-with-default (the sub yielded nil), NOT the
+        ;; previous unconditional :no-recovery lie. `:recovery` hoists
+        ;; to the top-level envelope.
+        (is (= :replaced-with-default (:recovery (first mal)))
+            "malformed sub trace reports :replaced-with-default (yielded the default)")))))
 
 (deftest boundary-seam-malformed-schema-returns-false
   (testing "rf2-a5kzs (finding 2, boundary seam) — validate-with-registered-fn


### PR DESCRIPTION
Senior review of `implementation/schemas` — bead **rf2-mxs7a** (2 findings). Both verified live against current source; both fixed. Lane confined to `implementation/schemas/**`.

## Per-finding disposition

### Finding 1 — malformed-schema trace lies about recovery (LIVE → fixed)
`implementation/schemas/src/re_frame/schemas/validate.cljc:472`

The shared malformed-schema branch in `run-validation` rebuilt each surface's structural tags via `build-base-tags`, then unconditionally `assoc`'d `:recovery :no-recovery`. That overwrote the surface-specific recovery the caller actually supplied — `validate-fx!` (`:skipped`) and `validate-sub!` (`:replaced-with-default`). The data plane still applied the local fallback even on a malformed schema (`fx.cljc` skips only the offending fx; `subs/memo.cljc` returns the default), so the emitted `:rf.error/malformed-schema` trace reported `:no-recovery` even though a local fallback occurred — a diagnostic/API-contract lie (not a data-plane fail-open).

**Fix:** preserve the surface's `:recovery` from `base`, defaulting to `:no-recovery` only when absent (`(get base :recovery :no-recovery)`). `:recovery` is not in `value-bearing-slots`, so it survives the fail-closed `dissoc`.

**Acceptance:** extended `schemas_fail_open_test` so the malformed fx trace asserts `:recovery :skipped`, the malformed sub trace asserts `:recovery :replaced-with-default`, and event/cofx remain `:no-recovery`. Assertions read the top-level `:recovery` (hoisted out of `:tags` by `trace/build-event` per Spec 009 §Core fields hoist contract).

### Finding 2 — stale walker docstring (LIVE → fixed)
`implementation/schemas/src/re_frame/schemas/walker.cljc:43`

The "## Discoverability caveat" section said opaque compiled/registry schemas silently skip per-slot flags and "No warning fires." That is now stale: `storage.cljc` has an explicit `:rf.warning/schema-walker-opaque` one-shot warning (pinned by `schemas_walker_opaque_warning_test`) that fires once per process for genuinely opaque **non-keyword** values (compiled `m/schema` objects, maps). Only **keyword registry refs** stay silent by design — indistinguishable from primitive keywords without a forbidden registry consult (rf2-ee38b.6).

**Fix:** rewrote the caveat to distinguish the two cases (compiled/non-keyword → warn-once; keyword registry refs → silent/suppressed), so the docstring, the storage warning text, and `schemas_walker_opaque_warning_test` describe the same contract. Docs-only; no behaviour change.

## Dedup note
Verified against merged schemas work: the class-sweep redaction invariant + fail-closed invariant and `redact-validation-tags`/`redact-event-tags` already landed; neither finding overlaps them. Finding 1 is a recovery-contract bug independent of redaction; finding 2 is a doc-staleness fix downstream of the already-landed storage warning path.

## Quality gates

- schemas JVM (`clojure -M:test`): **274 tests, 18593 assertions, 0 failures, 0 errors**
- CLJS node-runtime (`npm run test:cljs`, run because `validate.cljc` is shared `.cljc`): **5870 tests, 20783 assertions, 0 failures, 0 errors**

Closes rf2-mxs7a.
