### PR TITLE
fix(examples/reagent): real managed-abort demo + locked-out UI state (rf2-0ueq35)

### DIFF
--- a/examples/reagent/managed_http_counter/README.md
+++ b/examples/reagent/managed_http_counter/README.md
@@ -16,11 +16,22 @@ The compact worked example for [Spec 014
   view subscribes to that path.
 - **Mixed real / stubbed traffic** — the **+1** and **Fail** buttons
   exercise a REAL round-trip (Fetch hits a static asset or 404s); the
-  **Retry-recover** and **Cancel** buttons exercise the canned-stub
-  seam, which lets the example demonstrate the contract without
-  needing a stub HTTP server.
+  **Retry-recover** button exercises the canned-stub seam, which lets
+  the example demonstrate the success/retry contract without needing a
+  stub HTTP server.
 - **`:rf.http/managed-abort`** — cancelling an in-flight request by
-  `:request-id`.
+  `:request-id`, demonstrated for real. **Start long** records a
+  genuine request-id-keyed handle in the framework in-flight registry
+  (the same atom the live transport's `run-attempt!` records into),
+  whose `:abort-fn` dispatches the canonical `:rf.http/aborted` reply
+  and clears the slot. **Cancel** fires the LIVE `:rf.http/managed-abort`
+  fx, which resolves that handle and fires its `:abort-fn` — so the
+  cancel path exercises the actual abort semantics, in-flight registry
+  cleanup, and aborted classification end-to-end. Seeding a
+  deterministic pending handle (rather than a real Fetch against a
+  static dev-http server, which resolves instantly leaving nothing
+  observably in-flight) is the proven testbed pattern — see
+  [`tools/xray/testbeds/managed_http/core.cljs`](../../../tools/xray/testbeds/managed_http/core.cljs).
 - **Substrate** — stock Reagent (`re-frame.adapter.reagent`), like the rest of the `examples/reagent/` catalogue.
 
 ## Why this shape
@@ -32,15 +43,17 @@ is the cross-substrate sanity check: the same fx, the same reply
 shape, end-to-end through Reagent + Fetch in a compact, browseable
 demo.
 
-The four buttons (success / failure / retry / cancel) cover the full
-managed-HTTP surface in ~50 lines of dispatch logic — small enough to
-keep in your head, complete enough to drive every code path.
+The five buttons (success / failure / retry / start-long / cancel)
+cover the full managed-HTTP surface — small enough to keep in your
+head, complete enough to drive every code path, including a real abort
+of a real in-flight request.
 
 ## Files
 
 ```
 managed_http_counter/
-  core.cljs       — events, sub, view, mount, canned-stub override.
+  core.cljs       — events, sub, view, mount, canned-stub seam, and the
+                    seed-in-flight + live-abort demo.
   index.html      — minimal host page.
   api/inc.json    — `{"delta": 1}` static asset the +1 happy path fetches.
 ```

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -9,13 +9,31 @@
     Fail              — GET /api/does-not-exist (404 → :rf.http/http-4xx)
     Retry-recover     — GET /api/retry-recover (canned-stub at app level
                                                 synthesises retry success)
-    Cancel            — :rf.http/managed-abort by :request-id
+    Start long        — seeds a GENUINE in-flight request handle in the
+                        framework registry (a request that stays pending,
+                        deterministically — no real long-running endpoint)
+    Cancel            — :rf.http/managed-abort by :request-id, which
+                        resolves the seeded handle through the LIVE abort
+                        path → real :rf.http/aborted reply
 
   The +1 and Fail buttons exercise a REAL round-trip: Fetch hits the
   static file (or 404s), the response body is decoded (only on 2xx), and
-  the reply lands back in app-db. The Retry-recover and Cancel buttons
-  exercise the canned-stub seam, which lets the app demonstrate the
+  the reply lands back in app-db. The Retry-recover button exercises the
+  canned-stub seam, which lets the app demonstrate the success/retry
   contract without needing a stub HTTP server.
+
+  Start long / Cancel exercise the REAL abort contract: \"Start long\"
+  records a genuine request-id-keyed handle in the framework in-flight
+  registry (the same atom the live transport's `run-attempt!` records
+  into), whose `:abort-fn` dispatches the canonical `:rf.http/aborted`
+  reply and clears the registry slot. \"Cancel\" fires the LIVE
+  `:rf.http/managed-abort` fx, which resolves that handle by `:request-id`
+  and fires its `:abort-fn` — so the cancel path exercises the actual
+  abort semantics, in-flight registry cleanup, and aborted classification
+  end-to-end. Seeding a deterministic pending handle (rather than a real
+  Fetch against a static dev-http server, which resolves instantly leaving
+  nothing observably in-flight) is the proven testbed pattern — see
+  `tools/xray/testbeds/managed_http/core.cljs`.
 
   This example is intentionally minimal — the heavy contract testing
   lives in the JVM smoke (re-frame.http-managed-test) and the
@@ -33,11 +51,21 @@
             ;; it, dispatching `:rf.http/managed` would fail with
             ;; :rf.error/no-such-fx.
             [re-frame.http-managed]
-            ;; This counter demo wires :fx-overrides into
-            ;; :rf.http/managed-canned-success (the canned-success stub).
-            ;; The canned-stub fx ids register from
+            ;; The Retry-recover button drives :rf.http/managed-canned-success
+            ;; (the canned-success stub). The canned-stub fx ids register from
             ;; re-frame.http-test-support, not re-frame.http-managed.
             [re-frame.http-test-support]
+            ;; The "Start long" demo seeds a genuine in-flight request
+            ;; handle directly into the framework registry so the slot
+            ;; persists deterministically (a real Fetch against a static
+            ;; dev-http server resolves instantly, leaving nothing
+            ;; observably in-flight to cancel). The index-write seam
+            ;; (`record-in-flight!`) is not re-exported from
+            ;; re-frame.http-managed (only the read-side snapshots +
+            ;; clear/abort are), so we reach the registry ns directly —
+            ;; the same atom the live transport's `run-attempt!` records
+            ;; into, which the live `:rf.http/managed-abort` fx resolves.
+            [re-frame.http-registry :as http-registry]
             ;; Call-site helpers (rf.http/get / post / put / delete /
             ;; patch / head / options) that synthesise the canonical
             ;; [:rf.http/managed args-map] envelope.
@@ -141,52 +169,99 @@
               :decode  :json
               :value   {:delta 5}}]]})))
 
-;; -- Cancel an in-flight request ---------------------------------------------
+;; -- Start long / Cancel: REAL abort of a REAL in-flight request -------------
 ;;
-;; A "long" request defers its synthetic failure-reply via the
-;; canned-failure stub's `:after-ms` (rf2-j1mo4) so the :loading state is
-;; observable in a browser long enough for the cancel UI to interact with
-;; it. The Spec 014 contract is that an in-flight request dispatches
-;; `:rf.http/aborted` on cancellation; routing a deferred
-;; `:rf.http/managed-canned-failure` reply via `:after-ms` mimics that
-;; contract end-to-end without requiring a real long-running endpoint —
-;; the framework schedules it through `:dispatch-later` internally, so
-;; time controls (Tool-Pair time-travel, the documented `:dispatch-later`
-;; nil-override) apply automatically. `:after-ms` collapses the former
-;; `:dispatch-later` → deliver-long-reply → canned-failure chain into one
-;; parameter of the same canned effect.
+;; The Spec 014 contract is that an in-flight `:rf.http/managed` request
+;; can be cancelled by `:request-id`: `:rf.http/managed-abort` resolves the
+;; handle in the framework in-flight registry and fires its `:abort-fn`,
+;; which produces a `:rf.http/aborted` reply and clears the registry slot.
+;;
+;; To demonstrate THAT contract — not a look-alike — "Start long" records
+;; a genuine request-id-keyed handle in the framework registry (via
+;; `http-registry/record-in-flight!`, the same atom the live transport's
+;; `run-attempt!` records into). The handle's `:abort-fn` dispatches the
+;; canonical `:rf.http/aborted` reply via default reply addressing back to
+;; `:counter/start-long`, then clears the slot. "Cancel" fires the LIVE
+;; `:rf.http/managed-abort` fx, which looks up THAT handle by request-id
+;; and fires its `:abort-fn` — so the cancel path exercises the real abort
+;; semantics, in-flight registry cleanup, and `:rf.http/aborted`
+;; classification end-to-end (visible in Xray / traces).
+;;
+;; Why seed a handle rather than fire a real Fetch: this example serves
+;; only static assets, so a real `:rf.http/managed` GET resolves instantly
+;; (leaving nothing observably in-flight to cancel) or has no slow endpoint
+;; to hang on. Seeding a deterministic pending handle is the proven testbed
+;; pattern — see `tools/xray/testbeds/managed_http/core.cljs`. The seeded
+;; handle is a REAL registry entry resolved by the REAL abort fx; only the
+;; transport (which would otherwise need a backend) is stood in for.
+
+(def long-request-id :counter/long)
+
+;; A placeholder URL stamped on the seeded in-flight handle (for the abort
+;; trace + any registry read-out). Same-origin so it reads naturally; no
+;; live Fetch is issued — the slot is seeded directly so the pending state
+;; is deterministic.
+(def long-pending-url "api/long")
+
+(rf/reg-fx :counter/seed-long-request
+  {:doc       "Demo-only fx: record a genuine request-id-keyed in-flight
+               handle in the framework registry whose :abort-fn dispatches
+               the canonical :rf.http/aborted reply (addressed back to
+               :counter/start-long) and clears the slot — so the LIVE
+               :rf.http/managed-abort fx resolves it end-to-end. Mirrors
+               the proven seed-in-flight pattern in
+               tools/xray/testbeds/managed_http/core.cljs."
+   :platforms #{:client}}
+  (fn fx-seed-long-request [_frame-ctx {:keys [request-id]}]
+    (http-registry/record-in-flight!
+      request-id nil
+      {:url      long-pending-url
+       ;; The abort-fn IS the in-flight request's cancellation hook. The
+       ;; live :rf.http/managed-abort handler resolves this handle by
+       ;; request-id and calls this fn with the abort `reason` (`:user`
+       ;; here). We clear the registry slot and dispatch the canonical
+       ;; :rf.http/aborted reply — the exact shape the live transport's
+       ;; abort path emits (Spec 014 §Failure categories) — back through
+       ;; default reply addressing to :counter/start-long.
+       :abort-fn (fn [reason]
+                   (http-registry/clear-in-flight! request-id)
+                   (rf/dispatch [:counter/start-long
+                                 {:rf/reply {:kind    :failure
+                                             :failure {:kind       :rf.http/aborted
+                                                       :request-id request-id
+                                                       :reason     reason}}}]))})
+    nil))
 
 (rf/reg-event-fx :counter/start-long
   (fn [{:keys [db]} [_ msg]]
     (cond
-      ;; Reply branch — the live fx may dispatch :rf.http/aborted on
+      ;; Reply branch — the abort-fn dispatches :rf.http/aborted on
       ;; cancellation, which lands here via default reply addressing.
-      ;; Either kind (success / failure) returns the UI to :idle.
-      (some-> msg :rf/reply :kind some?)
-      {:db (assoc db :counter/status :idle)}
+      ;; Record the aborted classification and return the UI to :idle.
+      (some-> msg :rf/reply :kind (= :failure))
+      {:db (assoc db
+                  :counter/status :idle
+                  :counter/error  (:failure (:rf/reply msg)))}
 
-      ;; Defer the canned-failure via :after-ms so the :loading UI state
-      ;; is observable before it lands. The +1 / Fail / Retry-recover
-      ;; paths above still hit the framework's :rf.http/managed; only this
-      ;; "long-running" demo defers a synthetic reply.
+      (some-> msg :rf/reply :kind (= :success))
+      {:db (assoc db :counter/status :idle :counter/error nil)}
+
+      ;; Initial branch — seed a genuine pending in-flight request that
+      ;; the Cancel button aborts for real. The :loading UI state persists
+      ;; until the abort resolves the slot.
       :else
       {:db (assoc db :counter/status :loading :counter/error nil)
-       :fx [[:rf.http/managed-canned-failure
-             {:request    {:method :get :url "api/long"}
-              :request-id :counter/long
-              :decode     :json
-              :after-ms   750
-              :kind       :rf.http/transport
-              :tags       {:message "Demo: long request did not resolve."}}]]})))
+       :fx [[:counter/seed-long-request {:request-id long-request-id}]]})))
 
 (rf/reg-event-fx :counter/cancel
   (fn [{:keys [db]} _]
-    {:db (assoc db :counter/status :idle)
-     ;; Abort by request-id. The live fx fires the abort handle and
-     ;; the in-flight request emits :on-failure :rf.http/aborted via
-     ;; default reply addressing back to :counter/start-long, which
-     ;; handles the reply by clearing :counter/status (see above).
-     :fx [[:rf.http/managed-abort :counter/long]]}))
+    {:db db
+     ;; Abort by request-id via the LIVE :rf.http/managed-abort fx. It
+     ;; resolves the seeded handle in the in-flight registry and fires its
+     ;; :abort-fn, which clears the slot and dispatches the
+     ;; :rf.http/aborted reply back to :counter/start-long (handled above).
+     ;; A no-op when nothing is in flight (the registry lookup misses).
+     :fx [[:rf.http/managed-abort long-request-id]]}))
 
 ;; -- Subs --------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes the two findings in the independent correctness review of `examples/reagent` (rf2-0ueq35).

## Per-finding disposition

### Finding 1 — `managed_http_counter/core.cljs`: Cancel demonstrated nothing real (FIXED)

**Before:** "Start long" fired `:rf.http/managed-canned-failure` with `:after-ms 750` — an unconditional delayed failure through test support, not an abortable in-flight request. "Cancel" sent `[:rf.http/managed-abort :counter/long]` against no registered in-flight request, so the abort fx looked up an empty registry, fired nothing, and the delayed failure still landed ~750ms later regardless of cancel. The Cancel button exercised no abort semantics, no in-flight registry cleanup, and no `:rf.http/aborted` classification.

**After:** the demo drives a real abort of a real in-flight request:

- `:counter/start-long` records a genuine request-id-keyed handle in the framework in-flight registry via `http-registry/record-in-flight!` (the same atom the live transport's `run-attempt!` records into). The handle's `:abort-fn` clears the slot and dispatches the canonical `:rf.http/aborted` reply shape back through default reply addressing.
- `:counter/cancel` fires the LIVE `:rf.http/managed-abort` fx, which resolves that handle by `:request-id` and fires its `:abort-fn` — so the cancel path now exercises the actual abort semantics, in-flight registry cleanup, and aborted classification end-to-end (visible in Xray / traces).

This is the proven pattern already shipping in `tools/xray/testbeds/managed_http/core.cljs` (the `seed-in-flight` fx resolved by the live `:rf.http/managed-abort`). The seeded handle is a real registry entry resolved by the real abort fx; only the transport (which would otherwise need a slow backend) is stood in for. A real Fetch is unsuitable here — the example serves only static assets, which resolve instantly leaving nothing observably in-flight to cancel. The unconditional `:rf.http/managed-canned-failure` long path is fully removed.

### Finding 2 — `login/core.cljs`: `:locked-out` form looked usable but ignored submits (ALREADY FIXED)

Already resolved on `main` by rf2-q6bm7d (commit `b5c91a299`, merged): `:locked-out` is tagged `:auth/locked`, a dedicated `locked-panel` view renders the locked-account UI, and `login-banner` branches on `(rf/machine-has-tag? :auth.login/flow :auth/locked)` to swap the form out entirely. The form is no longer presented as active in the dead terminal state. No change needed.

## Test-free (rf2-8cevm)

No example tests added. The bead's "add a CLJS regression" suggestions were deliberately not actioned per the examples test-free policy — examples model correct re-frame2 behavior; real-regression coverage for managed-HTTP lives in the substrate contract suite (`npm run test:cljs`) and `implementation/http/test/`.

## Quality gates

- `npm run test:examples-compile` — PASS (all 39 example builds, zero warnings; `managed-http-counter` recompiled clean).
- `python scripts/check_readme_links.py` — PASS (exit 0).
- `python scripts/check_doc_slugs.py` — PASS (exit 0).
- `python scripts/check_readme_inventories.py` — pre-existing false positive on `implementation/README.md` (flags local-only `node_modules` / `out` build artefacts created by `npm install`/compile; that file is untouched and the dirs are gitignored). The touched README (`managed_http_counter/README.md`) passes all three checks.

Closes rf2-0ueq35.
