### PR TITLE
fix(xray/machines): stabilize MachineChart identity across Prev/Next (rf2-un3gfo)

### DIFF
--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/parse_cache_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/parse_cache_cljs_test.cljs
@@ -212,3 +212,49 @@
                 "density / direction / layout-options changes do NOT reparse")
             (is (> (:layout @counts) layouts-after-mount)
                 "but they DO re-run layout (the layout-key includes them)")))))))
+
+(deftest prev-next-highlight-deltas-do-not-rerun-elk-rf2-un3gfo
+  (testing "rf2-un3gfo — the chart end of the no-flicker contract. When the
+            Xray Machine panel's section key is STABLE across Prev/Next (the
+            panel-side fix, pinned in
+            `machine-inspector-helpers-cljs-test/section-key-is-stable-…`),
+            the SAME MachineChart instance receives the per-epoch highlight
+            deltas as prop changes — `:from-highlight` / `:to-highlight` /
+            `:current-state` / `:fired-edge-ids` — with the `:definition`
+            (hence the layout-key) UNCHANGED. Those deltas MUST NOT re-run
+            ELK: the topology positions stay put and only the highlights
+            re-paint. (Before the key fix, each Prev/Next REMOUNTED the
+            chart, so ELK re-ran from scratch every navigation → the
+            flicker.) This simulates the exact prop sequence the preserved
+            instance now sees."
+    (with-seam-spies
+      (fn [counts]
+        ;; Mount on the focused machine's first transition (idle → loading).
+        (let [rfn (chart/MachineChart
+                    {:machine-id     :m :definition machine-a
+                     :from-highlight :idle :to-highlight :loading
+                     :fired-edge-ids ["idle->loading"]})]
+          (render! rfn {:machine-id     :m :definition machine-a
+                        :from-highlight :idle :to-highlight :loading
+                        :fired-edge-ids ["idle->loading"]})
+          (is (= 1 (:parse @counts)) "mount parses once")
+          (is (= 1 (:layout @counts)) "mount runs ELK once (new layout-key)")
+          ;; --- Next → the loading → done transition ---
+          (render! rfn {:machine-id     :m :definition machine-a
+                        :from-highlight :loading :to-highlight :done
+                        :fired-edge-ids ["loading->done"]})
+          ;; --- Next again → a no-op resting in :done (current-state grammar) ---
+          (render! rfn {:machine-id    :m :definition machine-a
+                        :current-state :done})
+          ;; --- Prev → back to loading → done ---
+          (render! rfn {:machine-id     :m :definition machine-a
+                        :from-highlight :loading :to-highlight :done
+                        :fired-edge-ids ["loading->done"]})
+          (is (= 1 (:parse @counts))
+              "Prev/Next highlight deltas (same definition) NEVER reparse")
+          (is (= 1 (:layout @counts))
+              "Prev/Next highlight deltas NEVER re-run ELK — positions stay
+               put, only highlights re-paint (the no-flicker guarantee)")
+          (is (>= (:project @counts) 1)
+              "highlight deltas DO re-project (decorative re-tint) — that is
+               the cheap repaint, not a relayout"))))))

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -147,6 +147,25 @@ The header carries:
   > `compose-focus`'s LIVE+unpaused head-tracking, which is why the
   > buttons previously appeared dead on the live panel.
 
+  > **Topology stability across Prev/Next (rf2-un3gfo).** Prev/Next
+  > navigation within the SAME machine MUST preserve the topology
+  > chart's node positions: only the per-transition highlights
+  > (`from`/`to`/`current`/fired-edge) re-paint as the operator steps
+  > through epochs — the chart is NOT re-laid-out. This is a structural
+  > guarantee, not an emergent one: the per-machine focused-event
+  > section's React `:key` is keyed on the STRUCTURAL identity
+  > `[target-frame machine-id]` only — never on the epoch/record id,
+  > the from/to-state, the fired-edge ids, or any highlight value — so
+  > React preserves the section (and the nested `MachineChart`) instance
+  > across navigation, keeping the chart's per-instance parse + ELK
+  > layout caches warm. A genuinely different machine (different
+  > topology) or a frame switch still produces a distinct key → a clean
+  > instance + its own layout. Highlights remain a pure visual overlay
+  > orthogonal to `MachineChart`'s ELK layout-key
+  > (`[definition direction layout-options density]`, see
+  > `tools/machines-viz/spec/API.md`); re-fitting the viewport on
+  > navigation rides the orthogonal `:fit-signal` nonce, never a remount.
+
 The header previously also carried a right-aligned **Share button**;
 **rf2-nugvv (2026-06-04) removed it** along with the whole Xray share
 surface (see [§Share affordance](#share-affordance) below) — the Machine

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -1088,7 +1088,13 @@
         ;; single-instance, event-driven, rf2-8og3k): pick the first
         ;; transition by trace order. The upstream projection already
         ;; sorts cascade-document-order, so `first` is the tiebreaker.
-        record (h/pick-focused-transition records)]
+        record (h/pick-focused-transition records)
+        ;; rf2-un3gfo — the inspected frame id. Part of the STRUCTURAL
+        ;; section key below so the L1 frame picker (which re-seeds the
+        ;; panel against a different runtime) gets a clean section
+        ;; instance, while ordinary Prev/Next within one frame+machine
+        ;; preserves it.
+        target-frame @(rf/subscribe [:rf.xray/target-frame])]
     (when record
       [:div {:data-testid "rf-xray-machine-focused-event"
              ;; The host carries the count of records the cascade
@@ -1098,11 +1104,20 @@
              :data-section-count "1"
              :data-cascade-transition-count (str (count records))
              :style focused-event-view-host-style}
+       ;; rf2-un3gfo — STRUCTURAL key (target-frame + machine-id), NOT
+       ;; per-epoch. The old key embedded `(:id)` / `(:from-state)` /
+       ;; `(:to-state)`, all of which change on every Prev/Next, so React
+       ;; remounted the whole section + the nested MachineChart on each
+       ;; navigation — discarding the chart's per-instance parse/layout
+       ;; caches and re-running ELK every time (the topology flicker).
+       ;; Highlights flow as reactive props (`:from-highlight` /
+       ;; `:to-highlight` / `:current-state` / `:fired-edge-ids`) and the
+       ;; section's `:data-*` attrs recompute from `record` on each
+       ;; ordinary re-render, so the per-epoch repaint needs no remount.
+       ;; Re-fitting on navigation rides the orthogonal `:fit-signal`
+       ;; nonce (rf2-6tw7t). See `h/focused-event-section-key`.
        (with-meta (focused-event-section record)
-         {:key (str (:machine-id record) "-"
-                    (:id record) "-"
-                    (:from-state record) "-"
-                    (:to-state record))})])))
+         {:key (h/focused-event-section-key target-frame record)})])))
 
 (defn- blank-state
   "Rendered when the focused event has no machine activity in its

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
@@ -998,6 +998,52 @@
   [transition-records]
   (first transition-records))
 
+(defn focused-event-section-key
+  "rf2-un3gfo — the STRUCTURAL React `:key` for the per-machine
+  focused-event section. Keyed ONLY on the chart's topology identity —
+  the inspected `target-frame` id + the record's `:machine-id` — so
+  ordinary Prev/Next epoch navigation WITHIN the same machine preserves
+  the section (and the nested MachineChart) React instance.
+
+  ### Why structural, not per-epoch
+
+  The pre-fix key embedded `(:id record)` (epoch/record id) +
+  `(:from-state record)` + `(:to-state record)`, all of which change on
+  every Prev/Next. React therefore treated each navigation as a
+  different element → unmount + remount the section + the chart → the
+  chart's per-instance `parse-cache` / `layout-state` / `layout-key`
+  caches were discarded → a full topology re-parse + a fresh ELK relayout
+  ran on every Prev/Next → the topology flickered.
+
+  The per-epoch visuals do NOT need the key to change: the from/to/
+  current/fired highlights flow into the chart as REACTIVE PROPS
+  (`:from-highlight` / `:to-highlight` / `:current-state` /
+  `:fired-edge-ids`), and the section's own `:data-*` attrs are recomputed
+  from `record` on each ordinary re-render. With the instance preserved,
+  ELK runs once per topology (`[definition direction layout-options
+  density]`) and Prev/Next only re-paints highlights at stable positions.
+
+  ### What IS in the key
+
+  - `target-frame` — the inspected frame id. Switching the L1 frame
+    picker re-seeds the panel against a DIFFERENT runtime, where the same
+    `machine-id` may name a different machine instance; a fresh instance
+    there is correct (and the chart's own layout-key would relayout
+    anyway, but a clean remount avoids carrying stale per-instance state
+    across frames).
+  - `machine-id` — the topology identity. A genuinely different machine
+    (different topology) STILL gets a distinct key → a clean instance +
+    its own ELK layout, exactly as before.
+
+  Highlight values, epoch/record id, from/to-state, and fired-edge ids
+  are deliberately EXCLUDED. Re-fitting the viewport on navigation rides
+  the orthogonal `:fit-signal` nonce (rf2-6tw7t), never a remount.
+
+  Pure fn — JVM-runnable. `target-frame` may be nil (single-frame /
+  pre-seed); the key tolerates it."
+  [target-frame {:keys [machine-id]}]
+  (str target-frame "::" machine-id))
+
 (def empty-state-text
   "The Dynamic Machines panel's empty-state placeholder text, rendered
   verbatim per spec/003 §Empty state — focused event does not target a

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_helpers_cljs_test.cljc
@@ -32,6 +32,7 @@
     9. **format-* helpers**      — display formatters."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
             [day8.re-frame2-xray.panels.machine-inspector-helpers :as h]))
 
 ;; ---- (1) transition-event? ---------------------------------------------
@@ -812,3 +813,91 @@
                    {:epoch-id 7 :trace-events []}]]
       (is (nil? (h/focused-epoch-record history {:epoch-id 99}))
           "evicted pinned epoch must be nil (not the head record)"))))
+
+;; ---- focused-event-section-key (rf2-un3gfo) -----------------------------
+;;
+;; The per-machine focused-event section's React `:key` must be
+;; STRUCTURAL (target-frame + machine-id) so ordinary Prev/Next epoch
+;; navigation within the SAME machine preserves the section + nested
+;; MachineChart instance (keeping the chart's parse/layout caches warm,
+;; so ELK does NOT re-run and the topology does not flicker). A genuinely
+;; different machine — or a frame switch — must still produce a distinct
+;; key so the new topology gets a clean instance + its own ELK layout.
+
+(deftest section-key-is-stable-across-prev-next-for-same-machine
+  (testing "rf2-un3gfo — Prev/Next walks records for the SAME machine
+            whose epoch id + from/to-state change every navigation. The
+            structural key must NOT change across those records — only the
+            machine-id (and inspected frame) are load-bearing, so React
+            preserves the chart instance and ELK is not re-run."
+    (let [frame :rf/default
+          ;; Three records the operator walks via Prev/Next: same machine,
+          ;; different epoch ids + transition endpoints each time.
+          rec-1 {:machine-id :auth/login :id 1
+                 :from-state :idle    :to-state :authing}
+          rec-2 {:machine-id :auth/login :id 2
+                 :from-state :authing :to-state :done}
+          rec-3 {:machine-id :auth/login :id 3
+                 :from-state :done    :to-state :idle}
+          k1 (h/focused-event-section-key frame rec-1)
+          k2 (h/focused-event-section-key frame rec-2)
+          k3 (h/focused-event-section-key frame rec-3)]
+      (is (= k1 k2 k3)
+          "the section key is identical across Prev/Next records of the
+           same machine — no remount, so the chart instance + its
+           parse/layout caches survive and ELK does not re-run")
+      ;; Pin that the per-epoch fields are NOT in the key — a regression
+      ;; that folded epoch id / from-state / to-state back into the key
+      ;; would reintroduce the per-nav remount + ELK relayout flicker.
+      (is (not (str/includes? k1 "1"))
+          "the record/epoch id is NOT in the key")
+      (is (not (str/includes? k1 "idle"))
+          "from-state is NOT in the key")
+      (is (not (str/includes? k1 "authing"))
+          "to-state is NOT in the key"))))
+
+(deftest section-key-changes-for-a-different-machine-topology
+  (testing "rf2-un3gfo — switching to a genuinely different machine
+            (different topology) MUST change the key so React mounts a
+            fresh section + chart, and the new topology gets its own ELK
+            layout. This is the half of the contract that must NOT
+            regress in pursuit of stability."
+    (let [frame :rf/default
+          auth  (h/focused-event-section-key
+                  frame {:machine-id :auth/login :id 1
+                         :from-state :idle :to-state :authing})
+          door  (h/focused-event-section-key
+                  frame {:machine-id :door/main :id 1
+                         :from-state :idle :to-state :authing})]
+      (is (not= auth door)
+          "a different machine yields a different key (clean instance +
+           its own ELK layout)"))))
+
+(deftest section-key-changes-across-inspected-frames
+  (testing "rf2-un3gfo — the L1 frame picker re-seeds the panel against a
+            DIFFERENT runtime, where the same machine-id may name a
+            different machine instance. Including the target-frame in the
+            key gives that frame switch a clean section instance."
+    (let [rec {:machine-id :auth/login :id 1
+               :from-state :idle :to-state :authing}]
+      (is (not= (h/focused-event-section-key :rf/default rec)
+                (h/focused-event-section-key :rf/checkout rec))
+          "the same machine in a different inspected frame yields a
+           different key")
+      ;; Same frame + same machine collapses to one key (the steady case).
+      (is (= (h/focused-event-section-key :rf/default rec)
+             (h/focused-event-section-key :rf/default rec))
+          "same frame + same machine is one stable key"))))
+
+(deftest section-key-tolerates-nil-target-frame
+  (testing "rf2-un3gfo — a single-frame / pre-seed render may have a nil
+            target-frame. The key must still build (not throw) and remain
+            stable across Prev/Next."
+    (let [k1 (h/focused-event-section-key
+               nil {:machine-id :auth/login :id 1
+                    :from-state :idle :to-state :authing})
+          k2 (h/focused-event-section-key
+               nil {:machine-id :auth/login :id 2
+                    :from-state :authing :to-state :done})]
+      (is (string? k1) "key builds with a nil target-frame")
+      (is (= k1 k2) "still stable across Prev/Next when frame is nil"))))


### PR DESCRIPTION
## What & why

In Xray's **Machines** tab, clicking **Prev/Next** through the per-machine epoch walker flickered the topology chart. The per-machine focused-event section's React `:key` embedded per-epoch data — `(:id record)` (epoch/record id) + `(:from-state)` + `(:to-state)` — all of which change on every navigation. React therefore treated each Prev/Next as a different element → unmount + remount the section and the nested `MachineChart` → the chart's per-instance parse/layout caches were discarded → a full topology re-parse + a fresh ELK relayout ran on **every** navigation.

The chart already had the right highlight/layout separation: `MachineChart`'s ELK layout-key is `[definition direction layout-options density]` and excludes every highlight. The bug was that cache *persistence* was thrown away by a remount, not that highlights perturbed the layout.

## The fix (minimal identity-stability, per the bead ruling)

- Key the focused-event section on **structural identity only** — `[target-frame machine-id]` — via a new pure helper `h/focused-event-section-key`. Prev/Next within the same machine now **preserves** the section + `MachineChart` instance, keeping its parse/ELK caches warm.
- Per-epoch visuals already flow as **reactive props** (`:from-highlight` / `:to-highlight` / `:current-state` / `:fired-edge-ids`) and the section's `:data-*` attrs recompute from `record` on each ordinary re-render — so the per-epoch repaint needs no remount.
- A genuinely **different machine** (different topology) or a **frame switch** still yields a distinct key → a clean instance + its own ELK layout. The "switching topology still relayouts" half of the contract is preserved.
- Re-fitting the viewport on navigation rides the orthogonal **`:fit-signal`** nonce (rf2-6tw7t), never a remount. (Prev/Next within one machine keeps positions put and preserves the operator's manual zoom/pan, which is the desired behaviour.)
- The chart's ELK layout-key invariant `[definition direction layout-options density]` is **untouched** — highlights stay a pure visual overlay orthogonal to layout (`tools/machines-viz/chart.cljs` not modified).

**Module-level parse/layout-cache hoisting is DEFERRED** per the bead ruling. Evidence below shows the key fix alone runs ELK **zero** times on Prev/Next, so no module cache is warranted.

## Before/after evidence (the no-relayout claim)

A new chart-level test (`prev-next-highlight-deltas-do-not-rerun-elk-rf2-un3gfo`) drives the exact prop sequence the now-preserved instance sees across a Prev → Next → Next → Prev walk (same `:definition`, changing highlights/current-state/fired-edge-ids) and counts ELK runs via the existing `chart/compute-layout!` seam:

- **After (this PR):** ELK runs **exactly 1** time (the mount) across the whole Prev/Next sequence — `0` additional layout passes for navigation. To prove the assertion is live, the `(= 1 (:layout @counts))` check was temporarily flipped to `(= 999 …)` and the suite reported `actual: (not (= 999 1))`, confirming the preserved instance re-ran ELK exactly the mount-time once and **zero** times for the deltas. Reverted.
- **Before (pre-fix behaviour):** the per-epoch key forced a remount → a fresh `MachineChart` instance per Prev/Next → ELK re-ran from scratch on every navigation (1 relayout per nav), which is the observed flicker.

## Quality gates

- `npm run test:cljs` (node-runtime CLJS gate; includes both new test suites): **PASS** — `Ran 5875 tests containing 20798 assertions. 0 failures, 0 errors.` (exit 0)
- `clojure -M:test` in `tools/xray` (JVM, runs the `.cljc` key helper tests): **PASS** — `Ran 1101 tests containing 4577 assertions. 0 failures, 0 errors.`
- `clojure -M:test` in `tools/machines-viz` (JVM): **PASS** — `Ran 406 tests containing 1304 assertions. 0 failures, 0 errors.`
- `npm run test:xray-feature-gate` — **not run / not required:** the Xray feature matrix (`tools/xray/testbeds/feature_matrix/scenarios.cjs`) is **not touched**. This change is a render-identity perf fix + a pure internal helper + a spec note; no panel/feature/data-testid surface changed.

## Spec update note

Per the standing "Xray specs kept current" rule: `tools/xray/spec/003-Machine-Inspector.md` gains a normative **"Topology stability across Prev/Next (rf2-un3gfo)"** note under the prev/next nav section — codifying that Prev/Next within the same machine preserves node positions (highlights re-paint only), the section key is structural `[target-frame machine-id]`, and highlights stay orthogonal to the ELK layout-key. `tools/machines-viz/spec/*` is unchanged because `chart.cljs` was not modified — the layout/highlight contract it documents already holds and is preserved.

Closes rf2-un3gfo.