### PR TITLE
feat(xray): Machine tab = Prev/Next + shared EVENT HANDLER mini-pipeline + chart (rf2-g2axio)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -91,44 +91,63 @@ below; the three render states are:
    quiet centered empty-state per the design system. (See
    [§Dynamic mode — single-instance, event-driven (rf2-8og3k)](#dynamic-mode--single-instance-event-driven-rf2-8og3k)
    for the full rule.)
-3. **Focused event targets a machine instance** → one section for that
-   one instance (chosen per the rf2-8og3k selection rule below). A
-   machine **birth** (`:rf.machine/started`) is a first-class member of
-   this set per [§Machine birth — the start / initial-entry case
-   (rf2-eldze)](#machine-birth--the-start--initial-entry-case-rf2-eldze)
-   below: it has no from-state (it is an entry INTO the initial state,
-   not a from→to transition), so the section renders a `[START]` marker
-   in place of the from-state and highlights the resulting initial state.
-    - Header: `<from-state> → <to-state>` with the event vector right-
-      aligned (for a birth: `[START] → <initial-state>`).
-    - Topology chart (**xyflow + elkjs** primitive — rf2-gpzb4 xyflow
-      migration; the prior host-side ELK+SVG render is gone) with the
-      FROM state drawn dashed/accent-violet and the TO state bold/cyan;
-      connecting edges emphasised. Custom Stately/xstate-style nodes
-      (initial-state marker with `↳`, compound-state nesting,
-      events-as-nodes per rf2-qo5xy — each transition projects as its
-      own `rf2-event` box between the source and target state, with
-      `[guard]` chip + `+ <action>` pills inside the event box; `⌚`
-      glyph for `:after`, `∞` for `:always`). `:after` countdown
-      rings overlay armed timer states.
-    - Guards list (when the trace carried guard-evaluated events for
-      this transition).
-    - Actions list (when the trace carried action-ran events).
-    - **Snapshot drill-in** (rf2-lxvn6 · phase 4 of rf2-oqa60). The
-      BEFORE / AFTER snapshot maps (`{:state X :data Y}`) for the
-      focused transition render via the first-class edn-inspector
-      widget. Per-machine `:panel-id` qualifier keeps two machines'
-      expansion state independent; the `:before` / `:after` phase
-      suffix scopes the two sibling mounts on the same machine. See
-      [`021-Dynamic-Panel-Designs.md` §10](021-Dynamic-Panel-Designs.md#10-shared-edn-inspector-renderer)
-      for the widget contract — distinct per-type colours, distinct
-      brackets per collection kind, inline preview of collapsed
-      collections, click-to-toggle, per-call-site isolation. The
-      block renders nothing when the trace tags lack the
-      commit-or-finalize snapshot pair (legacy fixtures).
-    - Cancellation cascade (inline, via the existing
-      `[cancellation-cascade/SidePanel]` reg-view — dormant when no
-      cancellation lands in the trace window).
+3. **Focused event targets a machine instance** → the Machine tab
+   renders **EXACTLY THREE elements, in order** (rf2-g2axio), for the one
+   instance chosen per the rf2-8og3k selection rule below. A machine
+   **birth** (`:rf.machine/started`) and a guard-blocked **no-op**
+   (`:rf.machine.event/unhandled-no-op`) are first-class members of this
+   set (per [§Machine birth (rf2-eldze)](#machine-birth--the-start--initial-entry-case-rf2-eldze)
+   and [§Guard-blocked / no-op (rf2-skmc7)](#guard-blocked--unhandled-no-op--the-no-transition-case-rf2-skmc7)).
+
+    1. **Prev/Next epoch nav** — the per-machine epoch walker (in the
+       panel header; `rf-xray-machine-inspector-prev` /
+       `rf-xray-machine-inspector-next`). Walks the spine's epoch history
+       to the prior/next epoch whose cascade ALSO touched the focused
+       machine (see the header-nav note below). Prev/Next moves the
+       focused epoch, which re-feeds **both** the mini-pipeline and the
+       chart highlights together.
+    2. **The SHARED EVENT HANDLER mini-pipeline** — the **same** renderer
+       the Epoch panel's EVENT HANDLER step uses
+       (`epoch.view/machine-cascade-mini-pipeline`, over the **same**
+       `epoch.projection/machine-cascade-rows` projection). It renders
+       the numbered machine-cascade for the focused epoch: the structured
+       EVENT HANDLER orientation line plus the microstep / exit / action /
+       entry / guard / `[START]` / `[NO OP]` rows, each with its KIND+PHASE
+       badge, verb link (click-to-source), interleaved source body, and
+       per-row outcome / data-write. Both surfaces consume the **one**
+       renderer (extract-and-reuse, rf2-g2axio) so they cannot diverge.
+       The mini-pipeline mounts under
+       `rf-xray-machine-event-handler-mini-pipeline` and carries the
+       Epoch panel's own cascade testids verbatim
+       (`rf-xray-epoch-handler-machine`,
+       `rf-xray-epoch-machine-cascade-row-N`, `-ordinal-N`, `-kind-*`,
+       `-phase-*`, `-verb-link-N`, `-source-body-N`, `-outcome-N`,
+       `-data-write-N`, and `rf-xray-epoch-event-handler-orientation`).
+    3. **The topology chart** (**xyflow + elkjs** primitive — rf2-gpzb4
+       xyflow migration) with the focused epoch's highlights: the FROM
+       state drawn dashed/accent-violet, the TO state bold/cyan,
+       connecting edges emphasised, the focused epoch's traversed edges
+       painting the FIRED treatment (rf2-qeemm), and `:after` countdown
+       rings overlaying armed timer states. The chart carries its **own**
+       toolbar (view-mode toggle + zoom/pan/fit controls) supplied by
+       `machine-canvas/Chart`; the per-machine view-mode and the chart
+       are chart-owned concerns, not tab chrome.
+
+   **Removed (rf2-g2axio):** everything else the pre-redesign section
+   carried is gone — the bespoke **focused-transition lens** (the
+   `Target Machine Instance:` · `TRANSITION` · `GUARDS RUN` ·
+   `ACTIONS RUN` forensic block, formerly rf2-99rhe / rf2-2n34o), the
+   per-machine **header ribbon** (`from → to` / `[START]` / `[NO-OP]`
+   header badges), the **list/canvas view-mode wrapper**, the
+   **chart-collapse** toggle + summary, the **snapshot drill-in**
+   (rf2-lxvn6), and the **inline cancellation cascade**. The lens's
+   forensic content is subsumed by the richer mini-pipeline cascade
+   (which carries the SAME guard pass/fail, action source, and microstep
+   detail in the SAME row stream the Epoch panel shows); timer
+   cancellations surface as the mini-pipeline's `:timer` cascade rows.
+   The redesign's purpose: the Machine tab had drifted into a thinner,
+   bespoke summary that diverged from the Epoch panel's richer microstep
+   view — sharing the one renderer fixes that permanently.
 
 The header carries:
 - A **prev/next nav** (`◀ Prev` / `Next ▶`) that walks the spine's
@@ -182,8 +201,26 @@ below; that lens is the surface a developer reads when they ask
 
 ## Focused-transition lens — above the chart (rf2-99rhe)
 
-The **focused-transition lens** is a forensic per-transition detail
-panel that lives ABOVE the chart in the Machines panel. It answers
+> **SUPERSEDED — the bespoke lens was REMOVED by rf2-g2axio.** The
+> Machine tab no longer renders this bespoke `Target Machine Instance:`
+> · `TRANSITION` · `GUARDS RUN` · `ACTIONS RUN` forensic block. The
+> Machine tab now shows EXACTLY THREE elements — Prev/Next, the
+> **SHARED EVENT HANDLER mini-pipeline** (the same renderer + projection
+> the Epoch panel uses), and the chart — see
+> [§Post-collapse Dynamic panel shape](#post-collapse-dynamic-panel-shape-rf2-y9xmf-rf2-8og3k)
+> above. The forensic question this lens answered ("this transition
+> fired — show me everything about it: which guards decided how, which
+> actions ran and what `:fx` they returned") is now answered MORE richly
+> by the mini-pipeline's per-row cascade (guard pass/fail rows, action
+> source bodies + outcomes + `:fx` data-writes, and every microstep) —
+> the SAME rows the Epoch panel's EVENT HANDLER step renders, so the two
+> surfaces cannot diverge. The §Data sources table below remains
+> accurate as the trace-contract reference the mini-pipeline's projection
+> reads; the §Selection sources and §Rendered shape subsections describe
+> the retired bespoke surface and are kept only for design history.
+
+The **focused-transition lens** was a forensic per-transition detail
+panel that lived ABOVE the chart in the Machines panel. It answered
 the question "this transition fired — show me everything about it":
 which instance, which states it moved between, which guards
 evaluated and how they decided, which actions ran and what `:fx`
@@ -191,7 +228,8 @@ they returned, and which downstream `:dispatch`es cascaded from
 those actions.
 
 The chart shows the **topology** of the transition (FROM dashed,
-TO bold, edge emphasised); the lens shows the **forensics**.
+TO bold, edge emphasised); the (now-retired) lens showed the
+**forensics** — content the shared mini-pipeline now carries.
 
 ### Selection sources
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1606,8 +1606,10 @@ state change", then the verb **`staying in {state}`** — the machine matched
 no transition, so its state is unchanged. The qualifier is an OUTLINED muted
 (`:text-tertiary`) chip — a refinement on the solid badge beside it, not a
 second filled kind pill — reusing the `badge/cascade-kind-label :no-op`
-string (`NO OP`, space not hyphen — rf2-iu3no) and the same outlined-marker
-grammar skmc7's `[NO-OP]` uses in the Machine tab's focused-event header. It
+string (`NO OP`, space not hyphen — rf2-iu3no). Since rf2-g2axio the
+Machine tab renders this SAME shared cascade row (its bespoke
+focused-event header + `[NO-OP]` badge were removed), so this qualifier
+is now the single no-op grammar across both surfaces. It
 carries the testid `rf-xray-epoch-machine-cascade-no-op-qualifier` (distinct
 from a kind pill — it qualifies the transition step, it is NOT the row's
 kind). The earlier rf2-yueoa-predecessor (rf2-iu3no) rendered a BARE `[NO
@@ -4472,7 +4474,7 @@ signal to render plainly. None set any mode flag:
 | Epoch HANDLER step `:db`             | `panels/epoch/view.cljs` — `handler-db-diff-block` (effective post-handler db `:db-post-handler` = t1, else `db-before` when no-`:db`-with-flow, else fallback `:db-after`; `:before db-before` · rf2-4wywy / rf2-48oc4) | `data-testid="rf-xray-epoch-handler-db-full-with-diff"`                     |
 | Epoch FLOW step `:db`                | `panels/epoch/view.cljs` — `render-flow-step` (path-scoped pre→post diff `:db-pre-flow` (effective post-handler db) → `:db-post-flow` (t2) · rf2-4wywy / rf2-48oc4) | `data-testid="rf-xray-epoch-flow-db-diff-<name>"`                           |
 | App-DB panel (per `:rf/*` section)   | `panels/app_db_diff_state.cljs` — `value-body` (one mount; `:before` via `cond->` for a real pre-image; `:added? true` via `cond->` for a slice absent in the focused epoch's pre-image, i.e. the `h/added` sentinel — rf2-227cz §4.3) | App-DB panel-gallery story fixtures + segment-inspector tests               |
-| Machine Inspector snapshot drill-in  | `panels/machine_inspector.cljs` — `snapshot-block` (`:before` via `cond->` when captured)  | `data-testid="rf-xray-machine-snapshot-block-<id>"` with `data-rf-xray-diff-mode="full+diff"` |
+| ~~Machine Inspector snapshot drill-in~~ (REMOVED — rf2-g2axio) | ~~`panels/machine_inspector.cljs` — `snapshot-block`~~ — the Machine tab's snapshot drill-in was removed when the tab was reduced to Prev/Next + the SHARED EVENT HANDLER mini-pipeline + the chart (see [`003-Machine-Inspector.md` §Post-collapse Dynamic panel shape](003-Machine-Inspector.md#post-collapse-dynamic-panel-shape-rf2-y9xmf-rf2-8og3k)). `:data` mutations now read off the mini-pipeline cascade rows' inline data-writes. | — |
 | Epoch SUBSCRIPTIONS step value cells | `panels/epoch/view.cljs` — `subs-value-cell` container branch (`:before` / `:added?`)      | `data-testid="rf-xray-epoch-sub-row-*"` mount                               |
 
 **Why the input is the value, not a flag** — the widget is a pure-

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -3423,42 +3423,43 @@
              :style orientation-value-style}
       (fmt/orientation-value state)]]))
 
-(defn- machine-block
-  "Render the machine-handler section as a SINGLE TIME-ORDERED CASCADE
-  (rf2-u69j7). Replaces the pre-rf2-u69j7 category-grouped layout
-  (TRANSITION / GUARDS / LIFECYCLE / AFTER-TIMERS / DATA REDUCTION /
-  SNAPSHOT DIFF / FX) with one cascade view: each row interleaves
-  source code with the row's phase + duration + outcome (per Mike's
-  authority — Bead rf2-u69j7).
+(defn machine-cascade-mini-pipeline
+  "SHARED EVENT HANDLER machine-cascade mini-pipeline (rf2-g2axio).
 
-  Order comes from the substrate's `:rf.machine/action-ran` /
-  `:rf.machine/guard-evaluated` / `:rf.machine/transition` /
-  `:rf.machine.timer/cancelled` trace events' INSERTION ORDER in the
-  epoch buffer — the substrate already emits them in cascade order
-  (Spec 005 §Trace events + rf2-82a0u). The projection's
-  `machine-cascade-rows` is a pure-data walk over the events; this
-  view layer is a faithful render of that vector.
+  The single renderer for the numbered machine-cascade rows (the
+  microstep cascade with KIND+PHASE badges, guard pass/fail rows, verb
+  links, source bodies, outcomes / data-writes) plus the structured
+  EVENT HANDLER orientation line above them. It is consumed by BOTH:
 
-  The legacy category-grouped sub-sections (TRANSITION / GUARDS /
-  LIFECYCLE / AFTER-TIMERS / DATA REDUCTION / SNAPSHOT DIFF / FX) are
-  REPLACED, not augmented (per Mike: 'pre-alpha; no back-compat
-  shim'). The full state-change story is now told inline by the
-  cascade — transitions render their `from → to` state vectors;
-  actions render their data-write + fx attribution + source code
-  body."
-  [{:keys [cascade] :as _machine-row} event-id]
+    - the Epoch panel's EVENT HANDLER step (via `machine-block`, which
+      passes the already-projected `:cascade`), and
+    - the Xray Machine tab (`panels.machine-inspector`), which passes
+      the focused epoch's projected cascade (off the SAME
+      `projection/machine-cascade-rows`).
+
+  Extract-and-reuse, NOT copy-paste: a future change to the cascade-row
+  rendering updates both surfaces at once. This was the whole point of
+  rf2-g2axio — before the extraction the Machine tab carried its OWN,
+  thinner forensic block (`focused-transition-lens`) that diverged from
+  this richer microstep view.
+
+  `cascade` is the projected cascade-row vector (see
+  `projection/machine-cascade-rows`); `event-id` is the machine handler
+  id used to resolve the registration meta (`rf/handler-meta :event …`)
+  so guard / action source-coords resolve. Returns the same
+  `rf-xray-epoch-handler-machine` host the Epoch panel always rendered,
+  so every cascade-row testid (`rf-xray-epoch-machine-cascade-row-N`,
+  `-ordinal-N`, `-kind-*`, `-phase-*`, `-verb-link-N`, `-source-body-N`,
+  `-outcome-N`, `-data-write-N`, …) is identical on both surfaces."
+  [cascade event-id]
   ;; rf2-ge6uj ISSUE 2 — read the registration meta under the `:event`
   ;; kind, NOT a (non-existent) `:machine` kind. A machine is registered
   ;; as a `reg-event-fx` carrying `:rf/machine? true` + the stamped spec
   ;; under `:rf/machine` (with co-located `:guards` / `:actions` entries
   ;; carrying `:source-coords` / `:source-code`, plus reference-site
   ;; `:source-coords` co-located on each `:states`-tree map node,
-  ;; rf2-npvsx / rf2-vqja2). The prior
-  ;; `:machine` lookup resolved nil, so `cascade-row-source-form` /
-  ;; `cascade-row-coord` saw no spec → every exit / entry action + guard
-  ;; row rendered the `<source not yet captured>` placeholder. Reading
-  ;; under `:event` surfaces the spec so the interleaved source code +
-  ;; click-to-source coords resolve.
+  ;; rf2-npvsx / rf2-vqja2). Reading under `:event` surfaces the spec so
+  ;; the interleaved source code + click-to-source coords resolve.
   (let [machine-meta (when (some? event-id)
                        (try (rf/handler-meta :event event-id)
                             (catch :default _ nil)))
@@ -3469,6 +3470,22 @@
      ;; numbered cascade pipeline below.
      (event-handler-orientation-line cascade event-id)
      (machine-cascade-view machine-meta cascade)]))
+
+(defn- machine-block
+  "Render the machine-handler section as a SINGLE TIME-ORDERED CASCADE
+  (rf2-u69j7). Delegates to the SHARED `machine-cascade-mini-pipeline`
+  (rf2-g2axio) — the SAME renderer the Xray Machine tab consumes, so the
+  two surfaces cannot diverge. The Epoch panel arrives here with the
+  cascade ALREADY projected (off the HANDLER row's `:machine {:cascade
+  …}` slot, built by `projection/machine-cascade-rows`).
+
+  Each row interleaves source code with the row's phase + duration +
+  outcome (per Mike's authority — Bead rf2-u69j7). The legacy
+  category-grouped sub-sections (TRANSITION / GUARDS / LIFECYCLE /
+  AFTER-TIMERS / DATA REDUCTION / SNAPSHOT DIFF / FX) are REPLACED, not
+  augmented (per Mike: 'pre-alpha; no back-compat shim')."
+  [{:keys [cascade] :as _machine-row} event-id]
+  (machine-cascade-mini-pipeline (or cascade []) event-id))
 
 ;; ---- handler source --------------------------------------------------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -46,7 +46,13 @@
             [re-frame.core :as rf]
             [day8.re-frame2-machines-viz.chart.layout :as chart-layout]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
-            [day8.re-frame2-xray.panels.cancellation-cascade :as cancellation-cascade]
+            ;; rf2-g2axio — the SHARED EVENT HANDLER machine-cascade
+            ;; mini-pipeline lives in the Epoch panel view; the Machine
+            ;; tab consumes the SAME renderer + the SAME cascade
+            ;; projection (no duplicate) so the two surfaces cannot
+            ;; diverge again.
+            [day8.re-frame2-xray.panels.epoch.view :as epoch-view]
+            [day8.re-frame2-xray.panels.epoch.projection :as epoch-proj]
             [day8.re-frame2-xray.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-xray.panels.machine-inspector-helpers :as h]
             [day8.re-frame2-xray.panels.machines.trace-state :as trace-state]
@@ -58,43 +64,8 @@
             ;; overridden by `compose-focus`'s LIVE+unpaused head-tracking,
             ;; which is why the buttons were dead on the live panel.
             [day8.re-frame2-xray.spine :as spine]
-            ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — the per-machine
-            ;; snapshot drill-in surface mounts the first-class
-            ;; edn-inspector widget directly. Each machine gets its own
-            ;; `:panel-id` qualifier so two machines' expansion state
-            ;; stays independent. See spec/021 §10 widget contract.
-            [day8.re-frame2-xray.views.edn-inspector :as ei]
             [day8.re-frame2-xray.theme.tokens
-             :refer [tokens mono-stack sans-stack display-stack spacing]]))
-
-;; ---- shared layout constants (rf2-3d987) ------------------------------
-;;
-;; The Machine panel's 8 layout fixes (rf2-3d987) split header styling
-;; into two tiers — OUTER (section header at the top of focused-event-
-;; section; ribbon background, larger font) and NESTED (sub-section
-;; headers inside the same section; lighter chrome, smaller font,
-;; bottom-border separator instead of full-ribbon background). Issue #7
-;; fix: nested headers MUST be visually distinguishable from outer
-;; headers so the operator's eye reads hierarchy at a glance.
-;;
-;; Both tiers consume tokens (`tokens` map · CSS variables) so the
-;; light/dark theme toggle continues to flip palette in lockstep.
-
-(def ^:private nested-header-base-style
-  "Style map for any sub-section header NESTED inside the outer
-  focused-event-section. Per rf2-3d987 issue #7 these headers use a
-  smaller font, no ribbon background, and a bottom-border separator —
-  so the operator can tell a nested header from the outer section
-  header at a glance."
-  {:padding "6px 12px"
-   :background "transparent"
-   :border-bottom (str "1px solid " (:border-subtle tokens))
-   :font-family sans-stack
-   :font-size "11px"
-   :color (:text-secondary tokens)
-   :display "flex"
-   :align-items "center"
-   :gap "8px"})
+             :refer [tokens mono-stack sans-stack spacing]]))
 
 ;; ---- section-level layout styles (rf2-alsnz · audit F6) ----------------
 ;;
@@ -173,21 +144,6 @@
    :flex-direction "column"
    :gap            (:gap-2 spacing)})
 
-(def ^:private focused-event-section-header-style
-  "OUTER section header — ribbon background + slightly larger font
-  than nested headers (rf2-3d987 issue #7 differential). Carries the
-  machine-id + from→to transition path; right-click filters the
-  event list to this machine (rf2-piye4)."
-  {:padding                 "10px 12px"
-   :display                 "flex"
-   :align-items             "center"
-   :gap                     "10px"
-   :background              (:bg-3 tokens)
-   :font-family             mono-stack
-   :font-size               "13px"
-   :color                   (:text-primary tokens)
-   :border-top-left-radius  "4px"
-   :border-top-right-radius "4px"})
 
 ;; ---- snapshot-flat-diff styles (rf2-mndut) ------------------------------
 ;;
@@ -208,524 +164,61 @@
 ;; alongside the snapshot drill-in's `:diff` mode body. FULL+DIFF is
 ;; the single rendering; the edn-inspector widget owns its chrome.
 
-;; ---- safe-name helper ---------------------------------------------------
-
-(defn- safe-name
-  "Render `x` to a string suitable for `data-testid` suffixes. Belt-and-
-  braces over the projection layer's `ref-display-id` (which normalises
-  guard/action refs into keywords). If a future trace shape pipes a fn
-  through unprojected the view still won't blow up — `cljs.core/name`
-  on a fn throws `Doesn't support name: function ...` (rf2-ujra6)."
-  [x]
-  (cond
-    (nil? x)                          ""
-    (or (keyword? x) (symbol? x))     (name x)
-    (string? x)                       x
-    :else                             (str x)))
-
-;; ---- focused-transition lens (rf2-2n34o · spec/003 §Focused-transition lens) -----
+;; ---- rf2-g2axio — bespoke forensic lens + snapshot + collapse REMOVED ---
 ;;
-;; The lens is the above-chart forensic block specified in
-;; spec/003-Machine-Inspector.md §Focused-transition lens (rf2-99rhe).
-;; It renders the EXACT shape:
-;;
-;;   Target Machine Instance: :title/flow-instance-42
-;;   TRANSITION
-;;     idle → loading
-;;   GUARDS RUN
-;;     :token?
-;;       (fn [data] (get-in data [:session :token]))
-;;       → return true
-;;   ACTIONS RUN
-;;     :fetch!
-;;       (fn [data] {:fx [[:dispatch [:loading/complete]]]})
-;;       → :fx :dispatch → [:loading/complete]
-;;
-;; Data sources (all available post-rf2-ypu5i, rf2-99rhe, rf2-8og3k):
-;;   - target instance id + from→to: `:rf.machine/transition` tags
-;;   - guard id + return: `:rf.machine/guard-evaluated` tags
-;;   - guard / action fn-source: `(rf/handler-meta :machine-guard / :machine-action ...)`
-;;   - action id + `:fx` output: `:rf.machine/action-ran` tags `:outcome`
-;;
-;; Dynamic-mode constraint (rf2-8og3k): the lens binds to EXACTLY ONE
-;; instance — the first transition record in trace order (the upstream
-;; projection already sorts cascade-document-order, so `first` is the
-;; tiebreaker). When no machine transitioned, the panel renders only the
-;; verbatim empty-state placeholder (see `blank-state`).
-
-(defn- fn-source-line
-  "Render the captured fn-source string under a guard / action id, or a
-  muted fallback when production-elision dropped it (Spec 005
-  §`reg-machine` / `reg-machine*`: programmatic registrations carry no
-  source). The string is intentionally rendered raw — no syntax
-  highlighting at v1, matching the spec's plain monospace treatment."
-  [source]
-  [:div {:style {:padding-left "16px"
-                 :color (if source (:text-secondary tokens) (:text-tertiary tokens))
-                 :font-style (when-not source "italic")
-                 :font-family mono-stack
-                 :font-size "11px"
-                 :line-height 1.5
-                 :white-space "pre-wrap"
-                 :word-break "break-word"}}
-   (or source "(fn source unavailable)")])
-
-(defn- dispatch-vectors-from-fx
-  "Extract `[:dispatch <event>]` entries from an action's returned
-  `{:fx [...]}` map. Returns a vector of event-vectors (possibly empty).
-  Tolerates `nil`, non-map outcomes, or :fx vectors carrying non-dispatch
-  fx entries (those are skipped)."
-  [outcome]
-  (let [fx (when (map? outcome) (:fx outcome))]
-    (->> (or fx [])
-         (keep (fn [entry]
-                 (when (and (vector? entry)
-                            (= :dispatch (first entry)))
-                   (second entry))))
-         vec)))
-
-(defn- lens-guard-block
-  "Render one guard's block inside the lens GUARDS RUN section:
-
-       :guard-id
-         (fn source)
-         → return <pass|fail>"
-  [machine-id {:keys [guard-id outcome]}]
-  (let [m       (try (rf/handler-meta :machine-guard [machine-id guard-id])
-                     (catch :default _ nil))
-        source  (:rf.handler/source m)
-        return  (case outcome
-                  :pass "true"
-                  :fail "false"
-                  (when (some? outcome) (pr-str outcome)))]
-    [:div {:data-testid (str "rf-xray-machine-lens-guard-"
-                             (safe-name guard-id))
-           :data-guard-id (str guard-id)
-           :data-outcome (when outcome (name outcome))
-           :style {:font-family mono-stack
-                   :font-size "12px"
-                   :color (:text-primary tokens)
-                   :margin "2px 0"}}
-     [:div {:style {:padding-left "16px"
-                    :color (:magenta tokens)}}
-      (str guard-id)]
-     (fn-source-line source)
-     (when return
-       [:div {:style {:padding-left "16px"
-                      :color (:info tokens)}}
-        (str "→ return " return)])]))
-
-(defn- lens-action-block
-  "Render one action's block inside the lens ACTIONS RUN section:
-
-       :action-id
-         (fn source)
-         → :fx :dispatch → [<dispatch-vec>]
-
-  The trailing dispatch lines surface child-cascade `:dispatch` entries
-  pulled from the action's returned `{:fx [...]}` map. When no `:fx
-  :dispatch` fired, the arrow line is suppressed."
-  [machine-id {:keys [action-id outcome]}]
-  (let [m         (try (rf/handler-meta :machine-action [machine-id action-id])
-                       (catch :default _ nil))
-        source    (:rf.handler/source m)
-        dispatches (dispatch-vectors-from-fx outcome)]
-    [:div {:data-testid (str "rf-xray-machine-lens-action-"
-                             (safe-name action-id))
-           :data-action-id (str action-id)
-           :data-dispatch-count (str (count dispatches))
-           :style {:font-family mono-stack
-                   :font-size "12px"
-                   :color (:text-primary tokens)
-                   :margin "2px 0"}}
-     [:div {:style {:padding-left "16px"
-                    :color (:magenta tokens)}}
-      (str action-id)]
-     (fn-source-line source)
-     (into [:<>]
-           (for [[idx ev] (map-indexed vector dispatches)]
-             ^{:key idx}
-             [:div {:data-testid (str "rf-xray-machine-lens-action-dispatch-"
-                                      (safe-name action-id) "-" idx)
-                    :style {:padding-left "16px"
-                            :color (:info tokens)}}
-              (str "→ :fx :dispatch → " (pr-str ev))]))]))
-
-(defn- focused-transition-lens
-  "The above-chart forensic lens per spec/003 §Focused-transition lens.
-  Reads `record` (the focused transition, picked via
-  `h/pick-focused-transition` — see Dynamic-mode rule, rf2-8og3k) and
-  renders the Target Machine Instance / TRANSITION / GUARDS RUN /
-  ACTIONS RUN block in the normative order. Pure hiccup — fn-source is
-  resolved via `rf/handler-meta` which is a pure registrar lookup.
-
-  rf2-3d987 issue #6 (option b): lens is metadata about the focused
-  transition — chrome dims relative to the interactive chart so the
-  operator's eye reads `chart = primary, lens = secondary`. Same body
-  background as the rest of the section interior (`bg-2`); padding-only
-  separation; section labels carry weight differential per issue #5."
-  [{:keys [machine-id from-state to-state guards actions start? cause no-op?]}]
-  [:div {:data-testid "rf-xray-machine-focused-transition-lens"
-         :data-machine-id (str machine-id)
-         :data-guard-count (str (count guards))
-         :data-action-count (str (count actions))
-         ;; rf2-eldze — birth markers on the lens so the forensic block
-         ;; reads INITIAL ENTRY (not a misleading `(uninit) → :initial`
-         ;; transition) when the focused epoch is a machine start.
-         :data-start (str (boolean start?))
-         :data-cause (str cause)
-         ;; rf2-skmc7 — no-op marker so the forensic block reads NO
-         ;; TRANSITION (the machine stayed in its current state — a
-         ;; guard-blocked / unhandled event) rather than a misleading
-         ;; `state → state` self-transition.
-         :data-no-op (str (boolean no-op?))
-         ;; Issue #6 option (b) — secondary-metadata treatment. No
-         ;; coloured body (matches the section's `bg-2`); slightly
-         ;; smaller mono font; lighter default text colour. The lens
-         ;; reads as supplementary rather than co-equal with the chart.
-         :style {:padding "10px 14px"
-                 :background "transparent"
-                 :font-family mono-stack
-                 :font-size "11px"
-                 :color (:text-secondary tokens)
-                 :line-height 1.55}}
-   [:div {:data-testid "rf-xray-machine-lens-target-instance"
-          :style {:margin-bottom "6px"}}
-    [:span {:style {:color (:text-tertiary tokens)
-                    :font-weight 600}}
-     "Target Machine Instance"]
-    [:span {:style {:color (:text-tertiary tokens)}} " · "]
-    [:span {:style {:color (:magenta tokens)}}
-     (h/format-machine-id machine-id)]]
-   [:div {:data-testid "rf-xray-machine-lens-transition"
-          :style {:margin "4px 0"}}
-    ;; Issue #5 — `<strong>` weight differential on the section
-    ;; label so the eye picks it out from the path that follows.
-    ;; rf2-eldze — a birth is INITIAL ENTRY, not a TRANSITION.
-    ;; rf2-skmc7 — a no-op is NO TRANSITION (the machine stayed put).
-    [:strong {:style {:color (:text-tertiary tokens)
-                      :text-transform "uppercase"
-                      :font-size "10px"
-                      :letter-spacing "0.5px"
-                      :font-weight 700}}
-     (cond
-       start? "Initial entry"
-       no-op? "No transition"
-       :else  "Transition")]
-    [:div {:style {:padding-left "16px"}}
-     (cond
-       start?
-       ;; No from-state — render only the resulting initial state, with
-       ;; the entry-arrow grammar (`↳ :initial`) the topology's initial-
-       ;; state marker mirrors.
-       [:span
-        [:span {:style {:color (:accent tokens) :margin-right "6px"}} "↳"]
-        [:span {:style {:color (:text-primary tokens) :font-weight 600}}
-         (h/format-state to-state)]
-        (when cause
-          [:span {:style {:color (:text-tertiary tokens) :margin-left "8px"}}
-           (str "(" (name cause) ")")])]
-
-       no-op?
-       ;; rf2-skmc7 — the event matched no transition (unhandled / guard-
-       ;; blocked). Render only the unchanged current state with a muted
-       ;; `(no transition)` annotation — no `→` edge, no destination.
-       [:span {:data-testid "rf-xray-machine-lens-no-op-state"}
-        [:span {:style {:color (:text-primary tokens) :font-weight 600}}
-         (h/format-state to-state)]
-        [:span {:style {:color (:text-tertiary tokens) :margin-left "8px"}}
-         "(stayed — no transition matched)"]]
-
-       :else
-       [:span
-        [:span {:style {:color (:text-secondary tokens)}}
-         (h/format-state from-state)]
-        [:span {:style {:color (:accent tokens) :margin "0 6px"}} "→"]
-        [:span {:style {:color (:text-primary tokens) :font-weight 600}}
-         (h/format-state to-state)]])]]
-   (when (seq guards)
-     [:div {:data-testid "rf-xray-machine-lens-guards-run"
-            :style {:margin "4px 0"}}
-      [:strong {:style {:color (:text-tertiary tokens)
-                       :text-transform "uppercase"
-                       :font-size "10px"
-                       :letter-spacing "0.5px"
-                       :font-weight 700}}
-       "Guards Run"]
-      (into [:div]
-            (for [g guards]
-              ^{:key (str (:guard-id g))}
-              (lens-guard-block machine-id g)))])
-   (when (seq actions)
-     [:div {:data-testid "rf-xray-machine-lens-actions-run"
-            :style {:margin "4px 0"}}
-      [:strong {:style {:color (:text-tertiary tokens)
-                       :text-transform "uppercase"
-                       :font-size "10px"
-                       :letter-spacing "0.5px"
-                       :font-weight 700}}
-       "Actions Run"]
-      (into [:div]
-            (for [a actions]
-              ^{:key (str (:action-id a))}
-              (lens-action-block machine-id a)))])])
-
-;; ---- snapshot drill-in (rf2-lxvn6 · spec/021 §10 widget contract) -----
-;;
-;; Phase 4 of rf2-oqa60 wires the per-machine snapshot value through
-;; the first-class edn-inspector widget at
-;; `day8.re-frame2-xray.views.edn-inspector`. Each call site qualifies
-;; with a per-machine `:panel-id` so two machines' (or before/after's
-;; on the same machine) expansion state stays independent — the rule
-;; per spec/021 §10.0.2 acceptance property 5 (per-call-site isolation
-;; via mount-id) and property 1 (per-type colours via CSS variables).
-;;
-;; The drill-in shows the FULL `{:state X :data Y}` snapshot map so the
-;; operator can inspect what `:data` carried at the moment of
-;; transition — the bug class spec/003 §M.10 (Snapshot diff across
-;; transitions) calls out: today the chart highlights state changes;
-;; `:data` mutations are invisible unless the user opens the app-db
-;; diff. The drill-in is the snapshot-visibility primitive that closes
-;; that gap; phase 5 (D5=a) adds the diff overlay on top of the same
-;; widget.
-
-(defn- snapshot-panel-id
-  "Compose a per-machine `:panel-id` qualifier for the snapshot
-  drill-in mount. Each machine gets a distinct namespaced keyword so
-  the widget's `:rf.xray.edn-inspector/expansion` slot scopes by
-  machine-id; expansion under `:auth/login` doesn't bleed into
-  expansion under `:checkout/flow`.
-
-  The `phase` suffix (`:before` / `:after` / `:current`) further
-  scopes a single machine's before vs after vs live-current snapshot
-  in the focused-event section so the operator can drill into both
-  without one toggle clobbering the other.
-
-  Returns a keyword shaped like `:rf.xray.machine-snapshot/auth.login-before`."
-  [machine-id phase]
-  (keyword "rf.xray.machine-snapshot"
-           (str (some-> machine-id str (subs 1) (str/replace "/" "."))
-                (when phase (str "-" (name phase))))))
-
-(defn- machine-id-suffix
-  "Render `machine-id` as a testid suffix that preserves the
-  namespaced portion (e.g. `:auth/login` → `\"auth/login\"`). Mirrors
-  the existing `focused-event-section-` testid convention so panel-
-  level tests can assert by the same shape."
-  [machine-id]
-  (cond
-    (nil? machine-id) ""
-    (keyword? machine-id) (subs (str machine-id) 1)
-    :else (str machine-id)))
-
-;; rf2-vv3m6 (2026-05-29) — `snapshot-flat-diff-rows` +
-;; `snapshot-flat-diff-body` retired alongside the snapshot drill-in's
-;; `[diff][full][full+diff]` mode toggle (rf2-yqjrd). The `:diff` lens
-;; (flat path-prefixed rows) was the only consumer; FULL+DIFF carries
-;; the same conveyance via the edn-inspector widget.
-
-(defn- snapshot-block
-  "Render a machine snapshot map (`{:state X :data Y}`) via the
-  first-class edn-inspector widget (rf2-oqa60 phase 1, rf2-lxvn6 phase
-  4). One mount, FULL+DIFF posture: the AFTER snapshot renders with
-  `:before` threaded so changed leaves carry inline `← was X`
-  annotations + row chrome (added/modified/removed).
-
-  rf2-vv3m6 (2026-05-29) — the prior `[diff][full][full+diff]` mode
-  toggle (rf2-yqjrd) retired. FULL+DIFF is the single rendering.
-
-  Renders `nil` when the snapshot is absent."
-  [{:keys [machine-id snapshot before-snapshot]}]
-  (when (some? snapshot)
-    [:div {:data-testid    (str "rf-xray-machine-snapshot-block-"
-                                (machine-id-suffix machine-id))
-           :data-machine-id (str machine-id)
-           ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis. Now
-           ;; a constant post-rf2-vv3m6; kept for selector compatibility.
-           :data-rf-xray-diff-mode "full+diff"
-           ;; Issue #2 (option b): match the outer section's `bg-2`
-           ;; rather than the brighter `bg-1` so the snapshot reads as
-           ;; continuation of the body, not as a second card layer.
-           :style {:padding "8px 12px"
-                   :background (:bg-2 tokens)
-                   :min-width 0}}
-     [ei/edn-inspector snapshot
-      (cond-> {:panel-id (snapshot-panel-id machine-id :after)
-               ;; rf2-pvsxs — machine + phase identifiers; the operator's
-               ;; drill-into-data choices survive a Machines tab leave-
-               ;; and-return round-trip. `:after` is the canonical phase
-               ;; suffix for the single-mount shape.
-               :site-id  [:rf.xray.machines/inspector-snapshot machine-id :after]
-               :default-expanded-depth 3
-               ;; rf2-l4625 — machine snapshots routinely carry deeply-
-               ;; nested `:data` maps; the popup gives the operator a
-               ;; full-modal inspection surface alongside the per-
-               ;; machine drill-in.
-               :popup-affordance? true}
-        ;; rf2-e28r3 — thread BEFORE so changed leaves carry inline
-        ;; `← was X` annotations + the R4 rail / R3 chip. Skipped when
-        ;; no BEFORE is captured, in which case the same renderer shows
-        ;; the snapshot plainly.
-        (some? before-snapshot)
-        (assoc :before before-snapshot))]]))
-
-(defn- snapshot-drill-in
-  "Snapshot drill-in section beneath the focused-event chart. Renders
-  the focused-transition snapshot via the first-class edn-inspector
-  widget so the operator can inspect what `:data` carried on either
-  side of the transition (spec/003 §M.10 bug class — `:data` mutations
-  invisible without app-db diff).
-
-  rf2-vv3m6 (2026-05-29) — the prior `[diff][full][full+diff]` toggle
-  (rf2-yqjrd) retired. The single mount paints FULL+DIFF
-  unconditionally; the snapshot flat-diff lens retired with the
-  toggle.
-
-  Per spec/021 §10 widget contract every call site qualifies with a
-  per-machine `:panel-id`; the post-rf2-yqjrd shape uses a single
-  `:after`-phase qualifier.
-
-  Renders nothing when the AFTER snapshot is absent (legacy trace
-  fixtures pre-dating the commit-or-finalize snapshot tagging — see
-  `transition-record-from-trace` docstring)."
-  [{:keys [machine-id before after]}]
-  (when (or (some? before) (some? after))
-    [:section
-     {:data-testid     "rf-xray-machine-snapshot-drill-in"
-      :data-machine-id (str machine-id)
-      :data-has-before (str (some? before))
-      :data-has-after  (str (some? after))
-      ;; rf2-xvu24 — canonical `data-rf-xray-diff-mode` axis. Now a
-      ;; constant post-rf2-vv3m6.
-      :data-rf-xray-diff-mode "full+diff"
-      :style {:background (:bg-2 tokens)}}
-     ;; Header carries the section label only — the mode-toggle retired.
-     [:header {:data-testid "rf-xray-machine-snapshot-drill-in-header"
-               :style (assoc nested-header-base-style
-                             :display "flex"
-                             :align-items "center"
-                             :gap "8px")}
-      [:strong {:style {:color (:text-tertiary tokens)
-                        :text-transform "uppercase"
-                        :font-size "10px"
-                        :letter-spacing "0.5px"
-                        :font-weight 700}}
-       "Snapshot"]
-      [:span {:style {:color (:text-tertiary tokens)}} "·"]
-      [:span {:style {:color (:text-secondary tokens)}}
-       "transition"]]
-     ;; Body — single FULL+DIFF mount.
-     (snapshot-block {:machine-id machine-id
-                      :snapshot   (or after before)
-                      :before-snapshot before})]))
+;; The Machine tab's bespoke `focused-transition-lens` (Target Machine
+;; Instance / TRANSITION / GUARDS RUN / ACTIONS RUN) + its helpers
+;; (`safe-name`, `fn-source-line`, `dispatch-vectors-from-fx`,
+;; `lens-guard-block`, `lens-action-block`), the snapshot drill-in
+;; (`snapshot-panel-id`, `machine-id-suffix`, `snapshot-block`,
+;; `snapshot-drill-in`), and the chart-collapse chrome
+;; (`chart-collapse-toggle`, `chart-collapsed-summary`) are all GONE.
+;; The Machine tab now renders EXACTLY Prev/Next + the SHARED EVENT
+;; HANDLER mini-pipeline (`epoch-view/machine-cascade-mini-pipeline` —
+;; the SAME richer microstep-cascade renderer the Epoch panel uses, so
+;; the two surfaces cannot diverge again) + the chart (which carries its
+;; own view-mode toggle + zoom/pan/fit toolbar).
 
 ;; ---- per-machine focused-event section ---------------------------------
 
-(defn- chart-collapse-toggle
-  "Inline ▾ / ▸ button that toggles the chart-collapsed state for the
-  per-machine focused-event-section (rf2-3d987 issue #4). Persisted
-  via `machine-canvas`'s chart-collapsed-by-id slot (localStorage round-
-  trip identical to view-mode-by-id) so the operator's choice survives
-  reloads.
-
-  `collapsed?` is the current state; click flips it via the
-  `:set-chart-collapsed` event with mode `:toggle`."
-  [{:keys [machine-id collapsed?]}]
-  ;; rf2-nesy9 — render-time frame capture so the deferred toggle click
-  ;; dispatches into the surrounding instance frame, not a `:rf/xray`
-  ;; literal. Rendered inside the machine-inspector Panel reg-view.
-  (let [frame (rf/current-frame-id)]
-   [:button
-   {:data-testid (str "rf-xray-machine-chart-toggle-"
-                      (machine-id-suffix machine-id))
-    :data-machine-id (str machine-id)
-    :data-collapsed (str (boolean collapsed?))
-    :aria-expanded (str (not collapsed?))
-    :title (if collapsed?
-             "Expand chart"
-             "Collapse chart (frees space for the snapshot pair)")
-    :on-click (fn [_]
-                (rf/dispatch
-                  [:rf.xray.machine-canvas/set-chart-collapsed
-                   {:machine-id machine-id :mode :toggle}]
-                  {:frame frame}))
-    :style {:background "transparent"
-            :border "none"
-            :color (:text-secondary tokens)
-            :font-family sans-stack
-            :font-size "11px"
-            :font-weight 600
-            :padding "2px 6px"
-            :cursor "pointer"
-            :border-radius "4px"
-            :display "inline-flex"
-            :align-items "center"
-            :gap "6px"}}
-   [:span {:style {:font-size "10px"}}
-    (if collapsed? "▸" "▾")]
-   [:span "Chart"]]))
-
-(defn- chart-collapsed-summary
-  "One-line summary that replaces the expanded chart when the operator
-  collapses it (rf2-3d987 issue #4). Communicates topology
-  shape (node-count / transition-count) so the operator sees the chart
-  is still here, just hidden."
-  [{:keys [machine-id definition]}]
-  (let [states     (:states definition)
-        node-count (count states)
-        ;; Each state's `:on` map is a `{event target-or-vec}` entry;
-        ;; a state may also carry `:after` (one entry) producing
-        ;; transitions to a single target. Conservative count: sum
-        ;; the `:on` cardinalities plus 1 per `:after` (when present).
-        transitions
-        (reduce
-          (fn [acc [_state-id m]]
-            (+ acc (count (or (:on m) {})) (if (:after m) 1 0)))
-          0
-          states)]
-    [:div {:data-testid (str "rf-xray-machine-chart-collapsed-summary-"
-                             (machine-id-suffix machine-id))
-           :data-machine-id (str machine-id)
-           :data-node-count (str node-count)
-           :data-transition-count (str transitions)
-           :style {:padding "8px 12px"
-                   :background (:bg-1 tokens)
-                   :font-family sans-stack
-                   :font-size "11px"
-                   :color (:text-tertiary tokens)
-                   :font-style "italic"}}
-     (str "Machine topology · " node-count " "
-          (if (= 1 node-count) "node" "nodes") " · "
-          transitions " "
-          (if (= 1 transitions) "transition" "transitions")
-          " · click ▸ to expand")]))
-
 (defn- focused-event-section
-  "Render one section per transitioned machine. Lens (above the chart,
-  rf2-2n34o) → header → chart → snapshot drill-in (rf2-lxvn6) →
-  cancellation cascade (inline) → after-rings overlay (on the chart).
-  Guards / actions detail lives in the lens, not in a separate strip
-  below the chart.
+  "Render the focused machine's section (rf2-g2axio redesign). The
+  Machine tab now shows EXACTLY THREE elements: the Prev/Next nav (in
+  the Panel header), the SHARED EVENT HANDLER mini-pipeline, and the
+  topology chart. This section renders the latter two:
 
-  rf2-3d987 layout fixes:
-   - issue #1: `gap: 8px` between sibling sub-panels via flex gap.
-   - issue #4: chart is collapsible via the per-machine
-     `:chart-collapsed` flag; toggle in the chart's nested header.
-   - issue #5: outer header uses `<strong>` weight differential on the
-     machine-id (already there) + the path uses an arrow separator.
-   - issue #7: nested headers use lighter chrome than the outer header.
-   - issue #8: outer margin bumped to 16px so the section has visible
-     breathing room from the panel host edge."
-  [{:keys [machine-id from-state to-state on-event event microstep?
-           definition fired-edge-ids start? cause no-op?]
-    :as record}]
+    1. the SHARED mini-pipeline — `epoch-view/machine-cascade-mini-
+       pipeline` renders the focused epoch's already-projected
+       machine-cascade (`cascade`, from
+       `:rf.xray/machine-focused-epoch-cascade` which uses the SAME
+       `epoch-proj/machine-cascade-rows` projection the Epoch panel
+       does) into the SAME numbered cascade the Epoch panel's EVENT
+       HANDLER step renders (microstep / guard / action rows with
+       KIND+PHASE badges, verb links, source bodies, outcomes /
+       data-writes). It is byte-for-byte the same renderer — no second
+       bespoke forensic block.
+    2. the chart — `machine-canvas/Chart` with the focused epoch's
+       from/to/current/fired highlights. The chart carries its own
+       toolbar (view-mode toggle + zoom/pan/fit controls), so the
+       bespoke list/canvas + collapse chrome is gone.
+
+  REMOVED (rf2-g2axio): the bespoke focused-transition lens (Target
+  Machine Instance / TRANSITION / GUARDS RUN / ACTIONS RUN), the
+  per-machine header ribbon, the list/canvas view-mode wrapper, the
+  chart-collapse toggle + summary, the snapshot drill-in, and the
+  inline cancellation-cascade block — all subsumed by the shared
+  mini-pipeline above the chart, or relocated to the chart's own
+  toolbar."
+  [cascade
+   {:keys [machine-id from-state to-state definition fired-edge-ids
+           start? no-op?]
+    :as _record}]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — the host-side ELK
-  ;; layout dance (layout-or-fallback / ensure-elk! / compute-layout!)
-  ;; is GONE. xyflow + elkjs now own positioning end-to-end inside
-  ;; `mv-chart/MachineChart`; the panel only computes the from/to
-  ;; node-ids for the focused-event lens highlight.
-  (let [;; rf2-nesy9 — render-time frame capture for the deferred
-        ;; right-click filter dispatch.
+  ;; layout dance is GONE; xyflow + elkjs own positioning end-to-end
+  ;; inside `MachineChart`. The panel only computes the from/to node-ids
+  ;; for the data-attr highlight pins the tests read.
+  (let [;; rf2-nesy9 — render-time frame capture for the deferred chart
+        ;; state-click dispatch.
         frame      (rf/current-frame-id)
         ;; rf2-skmc7 — a NO-OP suppresses the from→to highlight grammar
         ;; (no edge; the machine stayed put). The wrapper's highlight-id
@@ -736,8 +229,6 @@
         to-id      (when (and to-state (not no-op?))
                      (chart-layout/highlight-id to-state))
         engine     "xyflow+elkjs"
-        collapsed? @(rf/subscribe
-                      [:rf.xray.machine-canvas/chart-collapsed-for machine-id])
         ;; rf2-6tw7t — fit-on-entry nonce. Bumped by `:rf.xray/select-tab
         ;; :machines`; forwarded to the chart's `:fit-signal` so the
         ;; topology re-frames whenever the operator (re-)enters the
@@ -751,273 +242,110 @@
       :data-machine-id (str machine-id)
       :data-from-state (str from-state)
       :data-to-state (str to-state)
-      :data-on-event (str on-event)
-      :data-microstep (str (boolean microstep?))
-      ;; rf2-eldze — machine-BIRTH record markers. `:data-start "true"`
-      ;; lets tests + hosts pin that a `:rf.machine/started` epoch renders
-      ;; the topology (initial state highlighted) rather than the empty
-      ;; state; `:data-cause` surfaces the birth cause (:explicit / :lazy
-      ;; / :spawned).
-      :data-start (str (boolean start?))
-      :data-cause (str cause)
-      ;; rf2-skmc7 — guard-blocked / unhandled / NO-OP record marker.
-      ;; `:data-no-op "true"` lets tests + hosts pin that a
+      ;; rf2-eldze / rf2-skmc7 — BIRTH + NO-OP record markers stay on the
+      ;; section so tests + hosts can pin that a `:rf.machine/started` /
       ;; `:rf.machine.event/unhandled-no-op` epoch renders the topology
-      ;; (CURRENT state highlighted) rather than the 'does not target a
-      ;; state machine' empty state.
+      ;; (initial / current state highlighted) rather than the empty state.
+      :data-start (str (boolean start?))
       :data-no-op (str (boolean no-op?))
-      :data-chart-collapsed (str collapsed?)
-      ;; rf2-zdfbm — the topology is the panel's centrepiece, so the
-      ;; section grows to fill the focused-event host's available
-      ;; height. A flex column lets the canvas chart (`flex 1` below)
-      ;; expand into the panel instead of sitting in a fixed 320px box.
-      ;;
-      ;; rf2-3d987 issue #1 — `gap` on the flex column gives every
-      ;; sibling sub-panel (lens / chart / snapshot drill-in /
-      ;; cascade) visible breathing room. Background shows through
-      ;; the gap so three concerns no longer read as one wall of grey.
-      ;;
-      ;; rf2-3d987 issue #8 — outer margin bumped from 12px → 16px so
-      ;; the section has visible breathing room from the panel host
-      ;; edge at every viewport width.
+      ;; rf2-zdfbm — the section is a flex column: the SHARED mini-pipeline
+      ;; sits at the top (its natural height) and the chart grows into the
+      ;; remaining height below it.
       :style focused-event-section-style}
-     ;; Right-click on the per-machine section header fires
-     ;; `:rf.xray/filter-by-machine` with this section's machine-id
-     ;; (rf2-piye4) — drops a typed `:machine` IN pill into the ribbon
-     ;; so the L2 event list narrows to cascades involving this machine.
-     [:header {:data-testid "rf-xray-machine-focused-event-header"
-               :on-context-menu (fn [^js e]
-                                  (when machine-id
-                                    (.preventDefault e)
-                                    (rf/dispatch
-                                      [:rf.xray/filter-by-machine machine-id]
-                                      {:frame frame})))
-               :title "Right-click to filter the event list to this machine"
-               ;; OUTER header — ribbon background + slightly larger
-               ;; font than nested headers (issue #7 differential).
-               :style focused-event-section-header-style}
-      (when microstep?
-        [:span {:style {:color (:text-tertiary tokens) :font-size "10px"}}
-         "↳"])
-      [:strong {:style {:color (:accent tokens)}}
-       (h/format-machine-id machine-id)]
-      ;; rf2-eldze — machine BIRTH path: a start has NO from-state (it is
-      ;; an entry into the initial state, not a from→to). Render a
-      ;; `[START]` marker + the resulting initial state instead of the
-      ;; misleading `(uninit) → :initial` path a transition header shows.
-      ;; rf2-skmc7 — NO-OP path: a guard-blocked / unhandled event matched
-      ;; no transition, so the machine stayed in its current state. Render
-      ;; a `[NO-OP]` marker + the unchanged current state instead of a
-      ;; misleading `state → state` self-transition.
-      (cond
-        start?
-        [:<>
-         [:span {:data-testid "rf-xray-machine-focused-event-start-badge"
-                 :style {:color (:accent tokens)
-                         :font-size "10px"
-                         :font-weight 700
-                         :letter-spacing "0.5px"
-                         :text-transform "uppercase"
-                         :border (str "1px solid " (:accent tokens))
-                         :border-radius "3px"
-                         :padding "1px 5px"}}
-          "START"]
-         [:span {:style {:color (:accent tokens)}} "→"]
-         [:span {:style {:color (:text-primary tokens) :font-weight 600}}
-          (h/format-state to-state)]]
-
-        no-op?
-        [:<>
-         [:span {:data-testid "rf-xray-machine-focused-event-no-op-badge"
-                 :style {:color (:text-tertiary tokens)
-                         :font-size "10px"
-                         :font-weight 700
-                         :letter-spacing "0.5px"
-                         :text-transform "uppercase"
-                         :border (str "1px solid " (:border-default tokens))
-                         :border-radius "3px"
-                         :padding "1px 5px"}}
-          "No-op"]
-         [:span {:style {:color (:text-primary tokens) :font-weight 600}}
-          (h/format-state to-state)]]
-
-        :else
-        [:<>
-         [:span {:style {:color (:text-secondary tokens)}}
-          (h/format-state from-state)]
-         [:span {:style {:color (:accent tokens)}} "→"]
-         [:span {:style {:color (:text-primary tokens) :font-weight 600}}
-          (h/format-state to-state)]])
-      (when event
-        [:span {:style {:color (:text-tertiary tokens)
-                        :font-size "11px"
-                        :margin-left "auto"}}
-         (h/format-event event)])]
-     ;; rf2-2n34o — focused-transition lens, ABOVE the chart per
-     ;; spec/003 §Focused-transition lens. The lens is the panel's
-     ;; forensic above-chart block; the chart below shows the same
-     ;; transition's topology.
-     (focused-transition-lens record)
-     (cond
-       (nil? definition)
+     ;; ── ELEMENT 2 — the SHARED EVENT HANDLER mini-pipeline ──────────
+     ;; rf2-g2axio — the SAME renderer the Epoch panel's EVENT HANDLER
+     ;; step uses (`epoch-view/machine-cascade-mini-pipeline-for-events`),
+     ;; projecting the focused epoch's `:trace-events` into the numbered
+     ;; machine-cascade (microstep / guard / action rows with KIND+PHASE
+     ;; badges, verb links, source bodies, outcomes / data-writes). Single
+     ;; source of truth — the Machine tab and the Epoch panel cannot
+     ;; diverge. Replaces the bespoke `focused-transition-lens` forensic
+     ;; block (Target Machine Instance / TRANSITION / GUARDS RUN /
+     ;; ACTIONS RUN) the Machine tab used to render.
+     [:div {:data-testid "rf-xray-machine-event-handler-mini-pipeline"
+            :data-machine-id (str machine-id)
+            :style {:padding "10px 14px"}}
+      ;; `machine-id` IS the reg-event-fx id `handler-meta` resolves
+      ;; (a machine is registered as a `reg-event-fx` carrying its spec
+      ;; under `:rf/machine`), so the cascade rows' guard / action
+      ;; source-coords resolve identically to the Epoch panel.
+      (epoch-view/machine-cascade-mini-pipeline cascade machine-id)]
+     ;; ── ELEMENT 3 — the topology chart ─────────────────────────────
+     ;; The chart carries its OWN toolbar (view-mode toggle + zoom / pan
+     ;; / fit controls — `machine-canvas/Chart`), so the bespoke
+     ;; list/canvas wrapper + the chart-collapse toggle/summary are gone
+     ;; (rf2-g2axio). Highlights flow as reactive props off THIS focused
+     ;; epoch, so Prev/Next repaints the chart together with the
+     ;; mini-pipeline above.
+     (if (nil? definition)
        [:div {:data-testid "rf-xray-machine-focused-event-no-definition"
               :style {:padding "12px"
                       :font-family sans-stack
                       :font-size "11px"
                       :color (:text-tertiary tokens)}}
         "No introspectable definition — chart cannot render."]
-
-       :else
-       (let [view-mode @(rf/subscribe
-                          [:rf.xray.machine-canvas/view-mode-for machine-id])]
-         (case view-mode
-           :list
-           ;; List view — chrome-thin pseudo-section just rendering a
-           ;; tiny banner; the guards/actions/cascade panes that come
-           ;; AFTER this block carry the real list payload. The
-           ;; view-mode toggle still has to appear in this mode so the
-           ;; user can flip back to Canvas — it's tucked into the
-           ;; section header with a 'List view' chip.
-           [:div {:data-testid "rf-xray-machine-focused-event-list"
-                  :data-layout-engine engine
-                  :data-machine-id (str machine-id)
-                  :data-view-mode "list"
-                  :style {:padding "8px 12px"
-                          :background (:bg-1 tokens)
-                          :border-bottom (str "1px solid " (:border-subtle tokens))
-                          :display "flex"
-                          :align-items "center"
-                          :gap "10px"}}
-            (machine-canvas/view-mode-toggle
-              {:machine-id machine-id :mode view-mode})
-            [:span {:style {:color (:text-tertiary tokens)
-                            :font-family sans-stack
-                            :font-size "11px"}}
-             "Chart hidden in List view — flip to Canvas to inspect the topology."]]
-
-           ;; default — :canvas
-           ;; rf2-3d987 issue #4 — collapsible chart. The chart wrapper
-           ;; carries its own nested header with a ▾/▸ toggle. When
-           ;; collapsed the chart is replaced by a one-line summary
-           ;; so the snapshot pair sits within the operator's foveal
-           ;; band without scrolling.
-           [:div {:data-testid "rf-xray-machine-focused-event-chart"
-                  :data-layout-engine engine
-                  :data-machine-id (str machine-id)
-                  :data-from-highlight-id (or from-id "")
-                  :data-to-highlight-id (or to-id "")
-                  ;; rf2-qeemm (G3) — surface the focused epoch's fired
-                  ;; edge-ids on the canvas wrapper (sorted, space-joined)
-                  ;; so the JVM/hiccup suite + hosts pin the wiring without
-                  ;; reaching into the xyflow canvas. "" when none fired.
-                  :data-fired-edge-ids (str/join
-                                         " " (sort (set fired-edge-ids)))
-                  :data-view-mode "canvas"
-                  :data-chart-collapsed (str collapsed?)
-                  ;; rf2-zdfbm — fill the section's available height so the
-                  ;; topology chart (`machine-canvas/Chart` is `height
-                  ;; 100%`) expands into the panel rather than collapsing
-                  ;; to its 260px min. `flex 1` + `min-height 0` lets the
-                  ;; chart grow inside the flex-column section; the
-                  ;; min-height floor keeps xyflow's non-zero-parent-
-                  ;; height requirement satisfied when the panel is short.
-                  ;;
-                  ;; When collapsed the wrapper drops `flex 1` + the
-                  ;; min-height floor so the row only consumes header +
-                  ;; summary height — freeing screen real-estate for the
-                  ;; snapshot pair below (issue #4).
-                  :style (merge
-                           {:background (:bg-2 tokens)
-                            :display "flex"
-                            :flex-direction "column"
-                            :overflow "hidden"
-                            :position "relative"}
-                           (if collapsed?
-                             {:flex "0 0 auto"}
-                             {:flex "1 1 0"
-                              :min-height "320px"}))}
-            ;; Nested header (issue #7 — lighter chrome, smaller font,
-            ;; bottom-border separator). Carries the ▾ / ▸ toggle.
-            [:header {:data-testid "rf-xray-machine-focused-event-chart-header"
-                      :style nested-header-base-style}
-             (chart-collapse-toggle
-               {:machine-id machine-id :collapsed? collapsed?})]
-            (if collapsed?
-              (chart-collapsed-summary
-                {:machine-id machine-id :definition definition})
-              [:div {:style {:flex "1 1 0"
-                             :min-height 0
-                             :padding "12px"
-                             :background (:bg-1 tokens)
-                             :display "flex"
-                             :flex-direction "column"
-                             ;; position-relative so the after-rings overlay
-                             ;; can absolute-position itself over the chart SVG.
-                             :position "relative"}}
-               ;; rf2-y3l8z — the chart is now wrapped in an interactive
-               ;; viewport adapter (zoom/pan/fit + view-mode toggle +
-               ;; controls toolbar). The adapter owns the after-rings
-               ;; overlay so they stay co-located with the canvas.
-               [machine-canvas/Chart
-                {:definition         definition
-                 :machine-id         machine-id
-                 ;; rf2-skmc7 — a NO-OP has no from→to edge (the machine
-                 ;; stayed put). Suppress the from/to highlight grammar so
-                 ;; the chart does NOT paint a misleading `state → state`
-                 ;; self-transition; the CURRENT state is surfaced via
-                 ;; `:current-state` below as a single active-state highlight.
-                 :from-highlight     (when-not no-op? from-state)
-                 :to-highlight       (when-not no-op? to-state)
-                 ;; rf2-eldze — a machine BIRTH has no from→to edge; the
-                 ;; resulting initial state IS the active state. Feed it
-                 ;; through `:current-state` so the chart paints the
-                 ;; active-state highlight on the initial node even though
-                 ;; the to-highlight grammar (which `:current-state` defers
-                 ;; to) already lands the same node. Belt-and-braces: the
-                 ;; node lights up whether the chart keys off to-highlight
-                 ;; or current-state.
-                 ;; rf2-skmc7 — a NO-OP's current state IS the (unchanged)
-                 ;; `to-state` (== `from-state`); feed it so the topology
-                 ;; highlights the one current node the machine is resting in.
-                 :current-state      (cond
-                                       start? to-state
-                                       no-op? to-state
-                                       :else  nil)
-                 ;; rf2-qeemm (G3) — the focused epoch's traversed edges paint
-                 ;; the FIRED treatment on the live chart (canonical ids from
-                 ;; `extract-fired-edge-ids`, attached to the section record).
-                 :fired-edge-ids     fired-edge-ids
-                 ;; rf2-6tw7t — fit-on-entry nonce so re-entering the
-                 ;; Machine tab re-frames the topology (the layout-key
-                 ;; auto-fit alone leaves a re-entered chart at its
-                 ;; stale pan/zoom).
-                 :fit-signal         fit-signal
-                 :on-state-click     (fn [path]
-                                       (rf/dispatch
-                                         [:rf.xray/machine-state-clicked
-                                          {:machine-id machine-id
-                                           :path       path}]
-                                         {:frame frame}))
-                 :show-after-rings?  true}]])])))
-     ;; rf2-lxvn6 (phase 4 of rf2-oqa60) — snapshot drill-in. Each
-     ;; per-machine section renders the BEFORE / AFTER snapshot maps
-     ;; through the first-class edn-inspector widget (spec/021 §10).
-     ;; Per-machine `:panel-id` qualifier keeps two machines' expansion
-     ;; state independent; the `:before` / `:after` phase suffix scopes
-     ;; the two sibling mounts on the same machine. The whole block
-     ;; renders nothing when the trace tags lack the
-     ;; commit-or-finalize snapshot pair (legacy fixtures).
-     (snapshot-drill-in record)
-     ;; rf2-2n34o — guards/actions detail lives in the
-     ;; `focused-transition-lens` ABOVE the chart (per spec/003
-     ;; §Focused-transition lens). The redundant ✓/✗ status strips
-     ;; that used to render below the chart are gone — single source of
-     ;; truth for the forensic block.
-     ;; rf2-59e7k — Cancellation cascade inline (per machine). The
-     ;; SidePanel reg-view short-circuits to nil when the focused
-     ;; machine has no cancellation in the trace window, so the mount
-     ;; is dormant in the common case.
-     [cancellation-cascade/SidePanel]]))
+       [:div {:data-testid "rf-xray-machine-focused-event-chart"
+              :data-layout-engine engine
+              :data-machine-id (str machine-id)
+              :data-from-highlight-id (or from-id "")
+              :data-to-highlight-id (or to-id "")
+              ;; rf2-qeemm (G3) — the focused epoch's fired edge-ids on
+              ;; the canvas wrapper (sorted, space-joined) so the
+              ;; JVM/hiccup suite + hosts pin the wiring without reaching
+              ;; into the xyflow canvas. "" when none fired.
+              :data-fired-edge-ids (str/join " " (sort (set fired-edge-ids)))
+              :data-view-mode "canvas"
+              ;; rf2-zdfbm — fill the section's remaining height so the
+              ;; topology chart expands into the panel. `flex 1` +
+              ;; `min-height` floor keeps xyflow's non-zero-parent-height
+              ;; requirement satisfied when the panel is short.
+              :style {:background (:bg-2 tokens)
+                      :display "flex"
+                      :flex-direction "column"
+                      :overflow "hidden"
+                      :position "relative"
+                      :flex "1 1 0"
+                      :min-height "320px"}}
+        [:div {:style {:flex "1 1 0"
+                       :min-height 0
+                       :padding "12px"
+                       :background (:bg-1 tokens)
+                       :display "flex"
+                       :flex-direction "column"
+                       ;; position-relative so the after-rings overlay can
+                       ;; absolute-position itself over the chart SVG.
+                       :position "relative"}}
+         ;; rf2-y3l8z — the chart wraps an interactive viewport adapter
+         ;; (zoom/pan/fit + view-mode toggle + controls toolbar) and owns
+         ;; the after-rings overlay so they stay co-located with the canvas.
+         [machine-canvas/Chart
+          {:definition         definition
+           :machine-id         machine-id
+           ;; rf2-skmc7 — a NO-OP has no from→to edge; suppress the
+           ;; from/to highlight grammar and surface the CURRENT state via
+           ;; `:current-state` instead.
+           :from-highlight     (when-not no-op? from-state)
+           :to-highlight       (when-not no-op? to-state)
+           ;; rf2-eldze / rf2-skmc7 — a BIRTH's initial state and a
+           ;; NO-OP's unchanged current state both ride `:current-state`
+           ;; so the chart highlights the one resting node.
+           :current-state      (cond
+                                 start? to-state
+                                 no-op? to-state
+                                 :else  nil)
+           ;; rf2-qeemm (G3) — the traversed edges paint the FIRED
+           ;; treatment on the live chart.
+           :fired-edge-ids     fired-edge-ids
+           ;; rf2-6tw7t — fit-on-entry nonce so re-entering the Machine
+           ;; tab re-frames the topology.
+           :fit-signal         fit-signal
+           :on-state-click     (fn [path]
+                                 (rf/dispatch
+                                   [:rf.xray/machine-state-clicked
+                                    {:machine-id machine-id
+                                     :path       path}]
+                                   {:frame frame}))
+           :show-after-rings?  true}]]])]))
 
 ;; ---- prev/next nav (per-machine epoch walking) -------------------------
 
@@ -1069,21 +397,22 @@
 ;; ---- focused-event view + blank state ----------------------------------
 
 (defn- focused-event-view
-  "Top-level focused-event lens. Accepts the focused-event lens'
+  "Top-level focused-event view (rf2-g2axio). Accepts the focused-event
   `records` (pre-derefed by `Panel` from
-  `:rf.xray/machine-transitions-for-focused-event`) and binds the
-  panel to **exactly one** machine instance per the Dynamic-mode
-  single-instance rule (rf2-8og3k): the first transition record in
-  trace order. Returns nil when no machine transitioned in the
-  focused event's cascade — the panel renders the empty-state
-  placeholder in that case (see `blank-state`).
+  `:rf.xray/machine-transitions-for-focused-event`) and the focused
+  epoch's `cascade` (the projected machine-cascade rows the SHARED
+  mini-pipeline renders, off `:rf.xray/machine-focused-epoch-cascade`).
+  Binds the panel to **exactly one** machine instance per the
+  Dynamic-mode single-instance rule (rf2-8og3k): the first transition
+  record in trace order — that record drives the chart highlights, while
+  the cascade rows show the WHOLE focused epoch's machine cascade
+  (identical to the Epoch panel's EVENT HANDLER step). Returns nil when
+  no machine transitioned in the focused event's cascade — the panel
+  renders the empty-state placeholder in that case (see `blank-state`).
 
   rf2-alsnz — `records` flows in as an arg so the panel makes one
-  Reaction handle per render instead of two; Panel already derefs the
-  composite sub for its `:data-has-records` flag + the scope-machine-
-  id-driven prev/next nav, so this view re-derefing the same handle
-  was a duplicate sub-graph touch."
-  [records]
+  Reaction handle per render instead of two."
+  [records cascade]
   (let [;; Dynamic-mode single-instance rule (spec/003 §Dynamic mode —
         ;; single-instance, event-driven, rf2-8og3k): pick the first
         ;; transition by trace order. The upstream projection already
@@ -1116,7 +445,7 @@
        ;; ordinary re-render, so the per-epoch repaint needs no remount.
        ;; Re-fitting on navigation rides the orthogonal `:fit-signal`
        ;; nonce (rf2-6tw7t). See `h/focused-event-section-key`.
-       (with-meta (focused-event-section record)
+       (with-meta (focused-event-section cascade record)
          {:key (h/focused-event-section-key target-frame record)})])))
 
 (defn- blank-state
@@ -1172,17 +501,29 @@
 ;; ---- public view --------------------------------------------------------
 
 (rf/reg-view Panel
-  "The Machine Inspector panel's root view. Event-driven: BLANK when
-  the focused event has no machine activity; one section per machine
-  when it does. The header carries the Share button + the per-machine
-  prev/next nav (when a machine is in scope)."
+  "The Machine Inspector (Machine tab) root view (rf2-g2axio). Shows
+  EXACTLY THREE elements when the focused event targets a machine:
+
+    1. the Prev/Next epoch nav (header — per-machine epoch walker),
+    2. the SHARED EVENT HANDLER mini-pipeline (the SAME numbered
+       machine-cascade the Epoch panel renders), and
+    3. the topology chart (with its own toolbar + the focused epoch's
+       highlights).
+
+  Event-driven: BLANK when the focused event has no machine activity.
+  Prev/Next moves the spine focus, which re-feeds the mini-pipeline AND
+  the chart highlights together (both read the focused epoch)."
   []
   (let [{:keys [empty-kind]} @(rf/subscribe [:rf.xray/machine-inspector-data])
         records @(rf/subscribe [:rf.xray/machine-transitions-for-focused-event])
+        ;; rf2-g2axio — the focused epoch's projected machine-cascade rows
+        ;; for the SHARED mini-pipeline (element 2). Reads the same focused
+        ;; epoch Prev/Next drives, so the mini-pipeline + chart move
+        ;; together.
+        {:keys [cascade]} @(rf/subscribe [:rf.xray/machine-focused-epoch-cascade])
         ;; The first record's machine-id drives the prev/next nav (a
         ;; cascade may touch multiple machines; the nav's "this machine"
-        ;; is the head section's machine — same default-focus pattern
-        ;; the cascade SidePanel uses).
+        ;; is the head section's machine).
         scope-machine-id (some-> records first :machine-id)]
     [:section {:data-testid "rf-xray-machine-inspector"
                :data-view-mode "focused-event"
@@ -1212,7 +553,7 @@
        ;; does not duplicate-subscribe the same composite handle.
        [:div {:data-testid "rf-xray-machine-inspector-focused-event-host"
               :style focused-event-host-style}
-        (focused-event-view records)]
+        (focused-event-view records cascade)]
 
        :else
        (blank-state))]))
@@ -1346,6 +687,33 @@
                        (trace-state/extract-fired-edge-ids
                          definition events machine-id)))
               (h/project-focused-event-transitions events definitions)))))
+
+  ;; ---- focused-epoch cascade events (rf2-g2axio) ------------------
+  ;;
+  ;; The SHARED EVENT HANDLER mini-pipeline (extracted from the Epoch
+  ;; panel — see `panels.epoch.view/machine-cascade-mini-pipeline`)
+  ;; renders off the focused epoch's RAW `:trace-events`, projecting the
+  ;; numbered machine-cascade itself. The Machine tab subscribes to this
+  ;; sub for those events; Prev/Next moves the spine focus, which moves
+  ;; the resolved focused epoch, which re-feeds BOTH this mini-pipeline
+  ;; AND the chart highlights together. `:event-id` is the head record's
+  ;; machine-id — the reg-event-fx id `handler-meta` resolves so the
+  ;; cascade rows' guard / action source-coords resolve identically to
+  ;; the Epoch panel.
+  (rf/reg-sub :rf.xray/machine-focused-epoch-cascade
+    :<- [:rf.xray/focus]
+    :<- [:rf.xray/epoch-history]
+    :<- [:rf.xray/machine-transitions-for-focused-event]
+    (fn [[focus history records] _query]
+      (let [record   (h/focused-epoch-record history focus)
+            events   (when record (:trace-events record))
+            event-id (some-> records first :machine-id)]
+        {;; The projected machine-cascade rows the SHARED mini-pipeline
+         ;; renders — the SAME `machine-cascade-rows` projection the
+         ;; Epoch panel's HANDLER row uses (`projection/handler-row`),
+         ;; so the two surfaces are byte-for-byte identical.
+         :cascade  (epoch-proj/machine-cascade-rows (or events []))
+         :event-id event-id})))
 
   ;; Test-only overrides for the focused-event composite.
   (rf/reg-event-db :rf.xray/set-epoch-history-for-test

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -17,7 +17,6 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
-            [re-frame.core-machines :as core-machines]
             [re-frame.frame :as frame]
             ;; Boot the optional machines artefact's late-bind hooks so
             ;; `reg-machine*` resolves rather than throwing
@@ -289,9 +288,15 @@
             "the initial state is highlighted via to-highlight")
         (is (= "" (:data-from-highlight-id (second chart)))
             "a birth has no from-highlight — there was no prior state")
+        ;; rf2-g2axio — the birth story is now told by the SHARED
+        ;; mini-pipeline's `:start` cascade row (carrying the `[START]`
+        ;; kind pill), not the removed header badge.
         (is (some? (find-by-testid
-                     tree "rf-xray-machine-focused-event-start-badge"))
-            "the header renders a [START] badge rather than a (uninit) → path")
+                     tree "rf-xray-epoch-machine-cascade-kind-start"))
+            "the mini-pipeline renders a [START] cascade-row pill for the birth")
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-focused-event-start-badge"))
+            "the removed header [START] badge no longer renders (rf2-g2axio)")
         (is (nil? (find-by-testid tree "rf-xray-machine-inspector-blank"))
             "the blank-state is suppressed — the bug was an empty tab here")))))
 
@@ -343,22 +348,24 @@
             "no to-highlight — a no-op is not a from→to landing")
         (is (= "" (:data-from-highlight-id (second chart)))
             "no from-highlight — a no-op is not a from→to origin")
-        (is (some? (find-by-testid
-                     tree "rf-xray-machine-focused-event-no-op-badge"))
-            "the header renders a [NO-OP] badge rather than a state→state path")
-        (is (nil? (find-by-testid
-                    tree "rf-xray-machine-focused-event-start-badge"))
-            "a no-op is NOT a birth — no [START] badge")
         (is (nil? (find-by-testid tree "rf-xray-machine-inspector-blank"))
             "the blank-state is suppressed — the bug was an empty tab here")
-        ;; The lens reads NO TRANSITION (not a misleading self-transition).
-        (let [lens (find-by-testid
-                     tree "rf-xray-machine-focused-transition-lens")]
-          (is (= "true" (:data-no-op (second lens)))
-              "the forensic lens is flagged no-op")
-          (is (some? (find-by-testid
-                       tree "rf-xray-machine-lens-no-op-state"))
-              "the lens renders the unchanged current state, no → edge"))))))
+        ;; rf2-g2axio — the no-op story now reads off the SHARED
+        ;; mini-pipeline's `:no-op` cascade row (the `[NO OP]` qualifier
+        ;; chip), not a bespoke header badge / forensic lens. The pipeline
+        ;; host mounts; the removed header badge + lens are gone.
+        (is (some? (find-by-testid
+                     tree "rf-xray-machine-event-handler-mini-pipeline"))
+            "the SHARED mini-pipeline mounts for a no-op")
+        (is (some? (find-by-testid
+                     tree "rf-xray-epoch-machine-cascade-no-op-qualifier"))
+            "the mini-pipeline renders a [NO OP] cascade-row qualifier")
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-focused-event-no-op-badge"))
+            "the removed header [NO-OP] badge no longer renders (rf2-g2axio)")
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-focused-transition-lens"))
+            "the bespoke forensic lens is removed (rf2-g2axio)")))))
 
 (deftest gate-reads-the-migrated-rf-machine-transition-op-only
   (testing "the machine-relatedness gate keys on the `:rf.*` migrated op
@@ -479,28 +486,165 @@
                (mapv #(:data-machine-id (second %)) sections))
             "the first-by-trace-order machine wins (lowest :id wins)")))))
 
-;; ---- (4b) focused-transition lens (rf2-2n34o · spec/003 §Focused-transition lens) -----
+;; ---- (4b) the SHARED EVENT HANDLER mini-pipeline (rf2-g2axio) -----------
+;;
+;; rf2-g2axio redesigned the Machine tab to render EXACTLY THREE elements:
+;; Prev/Next + the SHARED EVENT HANDLER mini-pipeline + the chart. The
+;; mini-pipeline is the SAME renderer + projection the Epoch panel's EVENT
+;; HANDLER step uses — `epoch-view/machine-cascade-mini-pipeline` over the
+;; focused epoch's `machine-cascade-rows` projection — so the two surfaces
+;; cannot diverge. These tests pin: the bespoke forensic lens / snapshot
+;; drill-in / chart-collapse chrome is GONE, the mini-pipeline mounts, and
+;; it carries the SAME `rf-xray-epoch-machine-cascade-*` testids the Epoch
+;; panel renders.
 
-;; Per rf2-ftrcv: `:machine-guard` / `:machine-action` are NOT registrar
-;; kinds — `(rf/handler-meta :machine-guard [mid gid])` DERIVES the
-;; fn-source from the machine's `:event` registration spec's co-located
-;; `:guards` / `:actions` entries. So the lens fixtures register a real
-;; machine via `core-machines/reg-machine*` with a PRE-STAMPED spec
-;; (co-located `{:fn .. :source-code ..}` entries — the shape the
-;; `reg-machine` macro emits in dev), letting the test control the exact
-;; `:rf.handler/source` string the lens renders without depending on the
-;; macro's `pr-str` output.
-(defn- register-machine-guard-meta! [machine-id guard-id source]
-  (core-machines/reg-machine* machine-id
-    {:initial :idle
-     :guards  {guard-id {:fn (fn [_] true) :source-code source}}
-     :states  {:idle {:on {:e {:target :idle :guard guard-id}}}}}))
+(deftest machine-tab-renders-exactly-three-elements-rf2-g2axio
+  (testing "rf2-g2axio: the Machine tab renders EXACTLY THREE elements —
+            the Prev/Next nav, the SHARED EVENT HANDLER mini-pipeline,
+            and the chart — and NONE of the removed bespoke chrome (the
+            focused-transition lens, the per-machine header ribbon, the
+            list/canvas view-mode wrapper, the chart-collapse toggle/
+            summary, the snapshot drill-in, the inline cancellation
+            cascade)."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :idle    :data {}}
+                   :after      {:state :authing :data {}}
+                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree (machine-inspector/Panel)]
+        ;; ELEMENT 1 — Prev/Next nav (in the header).
+        (is (some? (find-by-testid tree "rf-xray-machine-inspector-prev"))
+            "element 1: Prev nav")
+        (is (some? (find-by-testid tree "rf-xray-machine-inspector-next"))
+            "element 1: Next nav")
+        ;; ELEMENT 2 — the SHARED mini-pipeline.
+        (is (some? (find-by-testid
+                     tree "rf-xray-machine-event-handler-mini-pipeline"))
+            "element 2: the SHARED EVENT HANDLER mini-pipeline host")
+        ;; ELEMENT 3 — the chart.
+        (is (some? (find-by-testid
+                     tree "rf-xray-machine-focused-event-chart"))
+            "element 3: the topology chart")
+        ;; REMOVED chrome — none of it renders.
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-focused-transition-lens"))
+            "the bespoke forensic lens is removed")
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-focused-event-header"))
+            "the per-machine header ribbon is removed")
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-snapshot-drill-in"))
+            "the snapshot drill-in is removed")
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-focused-event-list"))
+            "the list/canvas view-mode wrapper is removed")
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-chart-toggle-auth/login"))
+            "the chart-collapse toggle is removed")
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-cancellation-cascade"))
+            "the inline cancellation cascade is removed")))))
 
-(defn- register-machine-action-meta! [machine-id action-id source]
-  (core-machines/reg-machine* machine-id
-    {:initial :idle
-     :actions {action-id {:fn (fn [_] nil) :source-code source}}
-     :states  {:idle {:on {:e {:target :idle :action action-id}}}}}))
+(deftest machine-tab-mini-pipeline-is-the-shared-renderer-rf2-g2axio
+  (testing "rf2-g2axio: the Machine tab's mini-pipeline IS the SAME
+            renderer the Epoch panel's EVENT HANDLER step uses — it
+            carries the SAME `rf-xray-epoch-handler-machine` cascade host
+            + the SAME `rf-xray-epoch-machine-cascade-row-N` /
+            `-ordinal-N` testids (no second bespoke renderer)."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :idle    :data {}}
+                   :after      {:state :authing :data {}}
+                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree (machine-inspector/Panel)]
+        ;; The SHARED cascade host the Epoch panel renders.
+        (is (some? (find-by-testid
+                     tree "rf-xray-epoch-handler-machine"))
+            "the shared `rf-xray-epoch-handler-machine` cascade host mounts")
+        (is (some? (find-by-testid
+                     tree "rf-xray-epoch-handler-machine-cascade-rows"))
+            "the shared cascade rows host mounts")
+        ;; The numbered cascade rows the Epoch panel renders — same testids.
+        (is (some? (find-by-testid
+                     tree "rf-xray-epoch-machine-cascade-row-1"))
+            "the first numbered cascade row carries the SHARED testid")
+        (is (some? (find-by-testid
+                     tree "rf-xray-epoch-machine-cascade-ordinal-1"))
+            "the cascade row's left-rail ordinal carries the SHARED testid")
+        ;; The EVENT HANDLER orientation line the Epoch panel renders.
+        (is (some? (find-by-testid
+                     tree "rf-xray-epoch-event-handler-orientation"))
+            "the SHARED EVENT HANDLER orientation line renders")))))
+
+(deftest machine-tab-prev-next-moves-mini-pipeline-and-chart-together-rf2-g2axio
+  (testing "rf2-g2axio: Prev/Next moves the focused epoch, so BOTH the
+            SHARED mini-pipeline AND the chart highlights re-paint to the
+            newly-focused epoch together (both read the same focus)."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      ;; Two epochs that BOTH touch :auth/login with DIFFERENT transitions
+      ;; so Prev visibly changes the chart highlights + the cascade rows.
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :idle    :data {}}
+                   :after      {:state :authing :data {}}
+                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}
+         {:epoch-id 2
+          :trace-events
+          [{:id 2 :time 20 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :authing :data {}}
+                   :after      {:state :done    :data {}}
+                   :event      [:auth/ok] :rf.trace/dispatch-id "d-2"}}]}])
+      ;; Focus the LATER epoch (authing → done).
+      (focus-epoch! 2)
+      (let [tree  (machine-inspector/Panel)
+            chart (find-by-testid tree "rf-xray-machine-focused-event-chart")]
+        (is (= "authing" (:data-from-highlight-id (second chart)))
+            "chart highlights the focused (later) epoch's from-state")
+        (is (= "done" (:data-to-highlight-id (second chart)))
+            "chart highlights the focused (later) epoch's to-state")
+        (is (some? (find-by-testid
+                     tree "rf-xray-machine-event-handler-mini-pipeline"))
+            "the mini-pipeline renders for the focused epoch"))
+      ;; Prev → the earlier epoch (idle → authing). Both re-read the focus.
+      (rf/dispatch-sync [:rf.xray/machine-focus-prev])
+      (let [tree  (machine-inspector/Panel)
+            chart (find-by-testid tree "rf-xray-machine-focused-event-chart")]
+        (is (= "idle" (:data-from-highlight-id (second chart)))
+            "after Prev, the chart re-paints to the earlier epoch's from-state")
+        (is (= "authing" (:data-to-highlight-id (second chart)))
+            "after Prev, the chart re-paints to the earlier epoch's to-state")
+        ;; The mini-pipeline reads the SAME focus, so it moved too — the
+        ;; orientation line now reads the earlier epoch's pre-state (:idle).
+        (let [orient (find-by-testid
+                       tree "rf-xray-epoch-event-handler-orientation-state")]
+          (is (some? orient)
+              "the mini-pipeline's orientation state line renders")
+          (is (str/includes? (pr-str orient) "idle")
+              "after Prev, the mini-pipeline orientation reads the earlier
+               epoch's pre-transition state — it moved WITH the chart"))))))
 
 (deftest blank-state-renders-verbatim-empty-state-text-rf2-8og3k
   (testing "spec/003 §Empty state — focused event does not target a state
@@ -527,290 +671,6 @@
             "no lens in the empty state")
         (is (nil? (find-by-testid tree "rf-xray-machine-focused-event-chart"))
             "no chart in the empty state")))))
-
-(deftest lens-renders-target-instance-and-transition-rf2-2n34o
-  (testing "spec/003 §Focused-transition lens — rendered shape: the lens
-            block sits above the chart and carries Target Machine
-            Instance: + TRANSITION (from → to) lines."
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      (override-epoch-history!
-        [{:epoch-id 1
-          :trace-events
-          [{:id 1 :time 10 :operation :rf.machine/transition
-            :tags {:machine-id :auth/login
-                   :before     {:state :idle    :data {}}
-                   :after      {:state :authing :data {}}
-                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
-      (focus-epoch! 1)
-      (let [tree   (machine-inspector/Panel)
-            lens   (find-by-testid tree "rf-xray-machine-focused-transition-lens")
-            target (find-by-testid tree "rf-xray-machine-lens-target-instance")
-            transition (find-by-testid tree "rf-xray-machine-lens-transition")]
-        (is (some? lens)        "the focused-transition lens mounts above the chart")
-        (is (= ":auth/login" (:data-machine-id (second lens))))
-        (is (some? target)      "Target Machine Instance: line present")
-        (is (some? transition)  "TRANSITION line present")))))
-
-(deftest lens-renders-guard-source-and-return-rf2-2n34o
-  (testing "spec/003 §Focused-transition lens — GUARDS RUN: id + fn-source
-            (from `rf/handler-meta :machine-guard`) + return value
-            rendered. The trace's `:rf.machine/guard-evaluated` event
-            carries the outcome :pass / :fail; the lens prints
-            `→ return true` / `→ return false`."
-    (setup-xray-frame!)
-    (register-machine-guard-meta! :auth/login :token?
-      "(fn [data] (get-in data [:session :token]))")
-    (rf/with-frame :rf/xray
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      (override-epoch-history!
-        [{:epoch-id 1
-          :trace-events
-          [{:id 1 :time 10 :operation :rf.machine/transition
-            :tags {:machine-id :auth/login
-                   :before     {:state :idle    :data {}}
-                   :after      {:state :authing :data {}}
-                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}
-           {:id 2 :time 11 :operation :rf.machine/guard-evaluated
-            :tags {:machine-id :auth/login :guard-id :token? :outcome :pass}}]}])
-      (focus-epoch! 1)
-      (let [tree    (machine-inspector/Panel)
-            guard   (find-by-testid tree "rf-xray-machine-lens-guard-token?")
-            guards-run (find-by-testid tree "rf-xray-machine-lens-guards-run")
-            hiccup-strs (->> guard flatten (filter string?) (str/join " "))]
-        (is (some? guards-run) "GUARDS RUN section present")
-        (is (some? guard) "guard block rendered for :token?")
-        (is (= "pass" (:data-outcome (second guard))))
-        (is (str/includes? hiccup-strs ":token?")
-            "guard id rendered")
-        (is (str/includes?
-              hiccup-strs "(fn [data] (get-in data [:session :token]))")
-            "guard fn-source rendered from handler-meta")
-        (is (str/includes? hiccup-strs "→ return true")
-            "return value rendered as `→ return true`")))))
-
-(deftest lens-renders-action-source-and-dispatch-follow-on-rf2-2n34o
-  (testing "spec/003 §Focused-transition lens — ACTIONS RUN: id + fn-source
-            + `:fx :dispatch → [<event>]` follow-on rendered. The action's
-            `:outcome` slot on the trace carries the returned `{:fx [...]}`
-            map; the lens extracts the `:dispatch` entries."
-    (setup-xray-frame!)
-    (register-machine-action-meta! :auth/login :fetch!
-      "(fn [data] {:fx [[:dispatch [:loading/complete]]]})")
-    (rf/with-frame :rf/xray
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      (override-epoch-history!
-        [{:epoch-id 1
-          :trace-events
-          [{:id 1 :time 10 :operation :rf.machine/transition
-            :tags {:machine-id :auth/login
-                   :before     {:state :idle    :data {}}
-                   :after      {:state :authing :data {}}
-                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}
-           {:id 2 :time 11 :operation :rf.machine/action-ran
-            :tags {:machine-id :auth/login
-                   :action-id :fetch!
-                   :outcome   {:fx [[:dispatch [:loading/complete]]]}}}]}])
-      (focus-epoch! 1)
-      (let [tree        (machine-inspector/Panel)
-            actions-run (find-by-testid tree "rf-xray-machine-lens-actions-run")
-            action      (find-by-testid tree "rf-xray-machine-lens-action-fetch!")
-            dispatch    (find-by-testid
-                          tree "rf-xray-machine-lens-action-dispatch-fetch!-0")
-            hiccup-strs (->> action flatten (filter string?) (str/join " "))]
-        (is (some? actions-run) "ACTIONS RUN section present")
-        (is (some? action) "action block rendered for :fetch!")
-        (is (= "1" (:data-dispatch-count (second action))))
-        (is (some? dispatch) "downstream :dispatch line rendered")
-        (is (str/includes? hiccup-strs ":fetch!"))
-        (is (str/includes?
-              hiccup-strs "(fn [data] {:fx [[:dispatch [:loading/complete]]]})")
-            "action fn-source rendered from handler-meta")
-        (is (str/includes?
-              hiccup-strs ":fx :dispatch → [:loading/complete]")
-            "downstream dispatch event rendered after `→ :fx :dispatch →`")))))
-
-(deftest lens-falls-back-to-placeholder-when-source-absent-rf2-2n34o
-  (testing "spec/003 §Focused-transition lens — when no handler-meta is
-            registered (programmatic `reg-machine*` path, or production-
-            elided), the lens renders a muted '(fn source unavailable)'
-            line instead of crashing."
-    (setup-xray-frame!)
-    ;; No register-machine-guard-meta! call — handler-meta returns nil.
-    (rf/with-frame :rf/xray
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      (override-epoch-history!
-        [{:epoch-id 1
-          :trace-events
-          [{:id 1 :time 10 :operation :rf.machine/transition
-            :tags {:machine-id :auth/login
-                   :before     {:state :idle    :data {}}
-                   :after      {:state :authing :data {}}
-                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}
-           {:id 2 :time 11 :operation :rf.machine/guard-evaluated
-            :tags {:machine-id :auth/login :guard-id :token? :outcome :pass}}]}])
-      (focus-epoch! 1)
-      (let [tree  (machine-inspector/Panel)
-            guard (find-by-testid tree "rf-xray-machine-lens-guard-token?")
-            hiccup-strs (->> guard flatten (filter string?) (str/join " "))]
-        (is (some? guard) "guard block rendered without crashing")
-        (is (str/includes? hiccup-strs "(fn source unavailable)")
-            "muted fallback rendered when handler-meta is absent")))))
-
-;; ---- (4c) snapshot drill-in (rf2-lxvn6 · spec/021 §10 widget contract) ----
-
-(deftest snapshot-drill-in-renders-before-and-after-snapshots
-  (testing "the focused-event section's snapshot drill-in surface mounts
-            the BEFORE and AFTER snapshots through the first-class
-            edn-inspector widget (rf2-oqa60 phase 1 · rf2-lxvn6 phase 4).
-            Per spec/021 §10 the per-machine `:panel-id` qualifier keeps
-            two machines' expansion state independent; the `:before` /
-            `:after` phase suffix scopes the two sibling mounts on the
-            same machine."
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      (override-epoch-history!
-        [{:epoch-id 1
-          :trace-events
-          [{:id 1 :time 10 :operation :rf.machine/transition
-            :tags {:machine-id :auth/login
-                   :before     {:state :idle
-                                :data  {:user nil :retries 0}}
-                   :after      {:state :authing
-                                :data  {:user "alice" :retries 1}}
-                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
-      (focus-epoch! 1)
-      (let [tree   (machine-inspector/Panel)
-            drill  (find-by-testid tree "rf-xray-machine-snapshot-drill-in")
-            block  (find-by-testid
-                     tree "rf-xray-machine-snapshot-block-auth/login")]
-        (is (some? drill)
-            "drill-in section mounts when before/after snapshots are present")
-        (is (= ":auth/login" (:data-machine-id (second drill)))
-            "drill-in carries the per-machine id so tests can scope assertions")
-        (is (= "true" (:data-has-before (second drill)))
-            "before snapshot presence surfaced on the host")
-        (is (= "true" (:data-has-after (second drill)))
-            "after snapshot presence surfaced on the host")
-        ;; rf2-yqjrd — the side-by-side Before/After grid retired; a
-        ;; SINGLE mount renders the AFTER snapshot with the three-mode
-        ;; toggle controlling whether BEFORE is threaded as the diff
-        ;; pre-image. The two `-before` / `-after` blocks collapse to
-        ;; one `rf-xray-machine-snapshot-block-<machine-id>` mount.
-        (is (some? block)
-            "single snapshot block renders post-rf2-yqjrd (replaces
-             the prior Before/After side-by-side grid)")))))
-
-(defn- find-popup-affordance-containers
-  "Walk hiccup (already expand-tree'd by the find-by-testid helper) and
-  collect every edn-inspector container that carries
-  `:data-rf-popup-affordance \"1\"` (the widget surfaces the opt as a
-  data-attr on its outer `:div`)."
-  [tree]
-  (filter (fn [n]
-            (and (vector? n) (map? (second n))
-                 (= "1" (:data-rf-popup-affordance (second n)))))
-          (tree-seq (some-fn vector? seq?) seq tree)))
-
-(deftest snapshot-drill-in-edn-inspector-carries-popup-affordance
-  (testing "rf2-l4625 — every snapshot drill-in edn-inspector mount in
-            the Machine Inspector panel passes
-            `:popup-affordance? true` so the operator can pop the
-            snapshot into the popup overlay. After expansion the widget's
-            outer `:div` surfaces the opt as a `data-rf-popup-affordance`
-            attribute."
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      (override-epoch-history!
-        [{:epoch-id 1
-          :trace-events
-          [{:id 1 :time 10 :operation :rf.machine/transition
-            :tags {:machine-id :auth/login
-                   :before     {:state :idle
-                                :data  {:user nil :retries 0}}
-                   :after      {:state :authing
-                                :data  {:user "alice" :retries 1}}
-                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
-      (focus-epoch! 1)
-      (let [tree       (machine-inspector/Panel)
-            drill      (find-by-testid tree "rf-xray-machine-snapshot-drill-in")
-            containers (find-popup-affordance-containers drill)]
-        (is (some? drill) "drill-in section mounts")
-        (is (seq containers)
-            "drill-in surfaces the popup-affordance attr on its
-             edn-inspector containers")))))
-
-(deftest snapshot-drill-in-suppressed-when-legacy-trace-lacks-snapshots
-  (testing "legacy trace fixtures that pre-date the commit-or-finalize
-            snapshot pair (only `:from`/`:to` keys, no `:before`/`:after`
-            maps) suppress the drill-in entirely — the section renders
-            nothing rather than empty blocks. This keeps the M.10 surface
-            from showing 'snapshot · (uninitialised)' chrome on legacy
-            traces."
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      (override-epoch-history!
-        ;; Only legacy `:from`/`:to` tags — no `:before`/`:after` snapshots.
-        [{:epoch-id 1
-          :trace-events
-          [{:id 1 :time 10 :operation :rf.machine/transition
-            :tags {:machine-id :auth/login
-                   :from       :idle
-                   :to         :authing
-                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
-      (focus-epoch! 1)
-      (let [tree (machine-inspector/Panel)]
-        ;; The focused-event surface still mounts (the lens uses the
-        ;; from/to legacy slots), but the snapshot drill-in is hidden.
-        (is (some? (find-by-testid tree "rf-xray-machine-focused-event"))
-            "focused-event surface still mounts on a legacy trace")
-        (is (nil? (find-by-testid tree "rf-xray-machine-snapshot-drill-in"))
-            "snapshot drill-in is suppressed when before/after snapshots
-             are absent")))))
-
-(deftest snapshot-drill-in-renders-when-only-after-snapshot-present
-  (testing "an epoch that carries only an `:after` snapshot (e.g. machine
-            initialisation events emit no `:before`) still surfaces the
-            drill-in — the surface degrades gracefully, rendering only
-            the present block."
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      (override-epoch-history!
-        [{:epoch-id 1
-          :trace-events
-          [{:id 1 :time 10 :operation :rf.machine/transition
-            :tags {:machine-id :auth/login
-                   :after      {:state :idle :data {}}
-                   :event      [:auth/init] :rf.trace/dispatch-id "d-1"}}]}])
-      (focus-epoch! 1)
-      (let [tree  (machine-inspector/Panel)
-            drill (find-by-testid tree "rf-xray-machine-snapshot-drill-in")]
-        (is (some? drill)
-            "drill-in renders when at least one snapshot is present")
-        (is (= "false" (:data-has-before (second drill)))
-            "before-presence surface reflects the missing :before slot")
-        (is (= "true" (:data-has-after (second drill)))
-            "after-presence surface reflects the present :after slot")
-        ;; rf2-yqjrd — single mount; the AFTER snapshot's block paints
-        ;; even when BEFORE is missing. Mode-3 (`:full+diff`, the
-        ;; default) gracefully degrades to plain browse when no
-        ;; pre-image is threaded.
-        (is (some? (find-by-testid
-                     tree "rf-xray-machine-snapshot-block-auth/login"))
-            "AFTER-only path renders the single snapshot block")))))
 
 ;; ---- (5) per-machine prev/next nav -------------------------------------
 
@@ -1168,11 +1028,11 @@
     (:style (second node))))
 
 (deftest rf2-3d987-issue-1-focused-event-section-has-gap
-  (testing "rf2-3d987 issue #1: focused-event-section's children must
-            sit on a flex column with a non-zero :gap so sibling sub-
-            panels (lens / chart / snapshot drill-in / cascade) get
-            visible breathing room rather than reading as one wall of
-            grey."
+  (testing "rf2-3d987 issue #1 (preserved through rf2-g2axio): the
+            focused-event-section's children sit on a flex column with a
+            non-zero :gap so the two surviving sub-panels (the SHARED
+            mini-pipeline + the chart) get visible breathing room rather
+            than reading as one wall of grey."
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (override-machines!    [:auth/login])
@@ -1196,162 +1056,6 @@
             "section is a flex column")
         (is (some? (:gap style))
             "section carries a :gap so siblings get breathing room")))))
-
-(deftest rf2-3d987-issue-2-snapshot-drill-in-flat-no-second-card
-  (testing "rf2-3d987 issue #2 (option b): snapshot-drill-in matches
-            the outer section's `bg-2` so it reads as a continuation
-            of the body, not as a nested white card. The bordered
-            outer section already provides the card chrome."
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      (override-epoch-history!
-        [{:epoch-id 1
-          :trace-events
-          [{:id 1 :time 10 :operation :rf.machine/transition
-            :tags {:machine-id :auth/login
-                   :before {:state :idle :data {}}
-                   :after  {:state :authing :data {}}
-                   :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
-      (focus-epoch! 1)
-      (let [tree  (machine-inspector/Panel)
-            drill (find-by-testid tree "rf-xray-machine-snapshot-drill-in")
-            style (style-of drill)
-            ;; bg-2 token resolves to the var(--rf-xray-bg-2) CSS string.
-            expected-bg "var(--rf-xray-bg-2)"]
-        (is (some? drill)   "drill-in mounts")
-        (is (= expected-bg (:background style))
-            "drill-in body uses :bg-2 — same as outer section, no card-in-card")))))
-
-(deftest rf2-vv3m6-snapshot-drill-in-full-diff-only
-  (testing "rf2-vv3m6 (2026-05-29) — the prior
-            `[diff][full][full+diff]` toggle (rf2-yqjrd) retired. The
-            snapshot drill-in mounts a SINGLE FULL+DIFF rendering: the
-            AFTER snapshot with the BEFORE snapshot threaded as the
-            diff pre-image. No toggle UI; the testid
-            `rf-xray-machine-inspector-diff-mode` no longer renders."
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      (override-epoch-history!
-        [{:epoch-id 1
-          :trace-events
-          [{:id 1 :time 10 :operation :rf.machine/transition
-            :tags {:machine-id :auth/login
-                   :before {:state :idle :data {:user nil}}
-                   :after  {:state :authing :data {:user "alice"}}
-                   :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
-      (focus-epoch! 1)
-      (let [tree   (machine-inspector/Panel)
-            drill  (find-by-testid tree "rf-xray-machine-snapshot-drill-in")]
-        (is (some? drill)
-            "drill-in section mounts")
-        (is (nil? (find-by-testid
-                    tree "rf-xray-machine-inspector-diff-mode"))
-            "the three-mode toggle is retired (rf2-vv3m6)")
-        ;; The grid container retired with the side-by-side layout.
-        (is (nil? (find-by-testid
-                    tree "rf-xray-machine-snapshot-drill-in-grid"))
-            "the side-by-side grid container is retired")))))
-
-(deftest rf2-3d987-issue-4-chart-collapsible-toggle-and-state
-  (testing "rf2-3d987 issue #4: the chart sub-panel carries a collapse
-            toggle button + the chart wrapper surfaces the per-machine
-            `:data-chart-collapsed` flag. Default state is expanded
-            (`false`); the toggle event flips the persisted slot."
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      (override-epoch-history!
-        [{:epoch-id 1
-          :trace-events
-          [{:id 1 :time 10 :operation :rf.machine/transition
-            :tags {:machine-id :auth/login
-                   :before {:state :idle :data {}}
-                   :after  {:state :authing :data {}}
-                   :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
-      (focus-epoch! 1)
-      ;; Default state — chart is expanded.
-      (let [tree    (machine-inspector/Panel)
-            wrapper (find-by-testid
-                      tree "rf-xray-machine-focused-event-chart")
-            toggle  (find-by-testid
-                      tree "rf-xray-machine-chart-toggle-auth/login")]
-        (is (some? wrapper)   "chart wrapper mounts")
-        (is (some? toggle)    "collapse toggle button mounts")
-        (is (= "false" (:data-chart-collapsed (second wrapper)))
-            "default state — chart is expanded")
-        (is (= "false" (:data-collapsed (second toggle)))
-            "toggle reflects expanded state")
-        (is (nil? (find-by-testid
-                    tree
-                    "rf-xray-machine-chart-collapsed-summary-auth/login"))
-            "collapsed summary is hidden while expanded"))
-      ;; Toggle → collapsed.
-      (rf/dispatch-sync
-        [:rf.xray.machine-canvas/set-chart-collapsed
-         {:machine-id :auth/login :mode :collapsed}])
-      (let [tree    (machine-inspector/Panel)
-            wrapper (find-by-testid
-                      tree "rf-xray-machine-focused-event-chart")
-            summary (find-by-testid
-                      tree
-                      "rf-xray-machine-chart-collapsed-summary-auth/login")]
-        (is (= "true" (:data-chart-collapsed (second wrapper)))
-            "wrapper reflects collapsed state after dispatch")
-        (is (some? summary)
-            "collapsed summary renders when chart is collapsed")))))
-
-(deftest rf2-3d987-issue-7-nested-header-differentiated-from-outer
-  (testing "rf2-3d987 issue #7: nested headers (chart-header,
-            snapshot-drill-in-header) use lighter chrome than the outer
-            focused-event-header. Pinned by: nested headers DO NOT carry
-            the outer `bg-3` ribbon background; they use a transparent
-            background + bottom-border separator + smaller font."
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      (override-epoch-history!
-        [{:epoch-id 1
-          :trace-events
-          [{:id 1 :time 10 :operation :rf.machine/transition
-            :tags {:machine-id :auth/login
-                   :before {:state :idle :data {}}
-                   :after  {:state :authing :data {}}
-                   :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
-      (focus-epoch! 1)
-      (let [tree    (machine-inspector/Panel)
-            outer   (find-by-testid
-                      tree "rf-xray-machine-focused-event-header")
-            nested-chart  (find-by-testid
-                            tree
-                            "rf-xray-machine-focused-event-chart-header")
-            nested-snap   (find-by-testid
-                            tree
-                            "rf-xray-machine-snapshot-drill-in-header")
-            outer-bg   (-> outer style-of :background)
-            chart-bg   (-> nested-chart style-of :background)
-            snap-bg    (-> nested-snap style-of :background)
-            outer-fs   (-> outer style-of :font-size)
-            chart-fs   (-> nested-chart style-of :font-size)
-            snap-fs    (-> nested-snap style-of :font-size)]
-        (is (some? outer)         "outer header mounts")
-        (is (some? nested-chart)  "chart nested header mounts")
-        (is (some? nested-snap)   "snapshot nested header mounts")
-        (is (= "var(--rf-xray-bg-3)" outer-bg)
-            "outer header keeps the ribbon background")
-        (is (= "transparent" chart-bg)
-            "chart nested header uses transparent background")
-        (is (= "transparent" snap-bg)
-            "snapshot nested header uses transparent background")
-        (is (not= outer-fs chart-fs)
-            "chart nested header font-size differs from outer")
-        (is (not= outer-fs snap-fs)
-            "snapshot nested header font-size differs from outer")))))
 
 (deftest rf2-3d987-issue-8-section-has-panel-breathing-room
   (testing "rf2-3d987 issue #8: focused-event-section's outer margin

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -228,6 +228,10 @@
    ;; rf2-a9cke — focused-event lens composite consumed by the
    ;; Machine Inspector + the cancellation-cascade SidePanel.
    :rf.xray/machine-transitions-for-focused-event
+   ;; rf2-g2axio — the focused epoch's projected machine-cascade rows
+   ;; for the SHARED EVENT HANDLER mini-pipeline (the Machine tab
+   ;; consumes the SAME renderer the Epoch panel does).
+   :rf.xray/machine-focused-epoch-cascade
    ;; rf2-y9xmf — scrubber-position slot survives the collapse; the
    ;; `:after`-rings overlay reads it to gate ring rendering to the
    ;; `:present` position. (rf2-nugvv removed the share-URL surface that


### PR DESCRIPTION
## What

Redesign the Xray **Machine tab** (`panels/machine_inspector.cljs`) to render **EXACTLY THREE elements, in order** (rf2-g2axio):

1. **Prev/Next** epoch nav (header — the per-machine epoch walker, unchanged).
2. **The SHARED EVENT HANDLER mini-pipeline** — the numbered machine-cascade (microstep / exit / action / entry / guard / `[START]` / `[NO OP]` rows with KIND+PHASE badges, verb links, source bodies, outcomes / data-writes) + the structured orientation line.
3. **The topology chart** (`machine-canvas/Chart`) with the focused epoch's from/to/current/fired highlights and its own toolbar.

Prev/Next moves the focused epoch, which re-feeds **both** the mini-pipeline and the chart highlights together (both read the same focus).

## Architecture — extract-and-reuse (no duplication)

The EVENT HANDLER machine-cascade renderer is **extracted** into a single shared fn `epoch.view/machine-cascade-mini-pipeline` (over the **same** `epoch.projection/machine-cascade-rows` projection). It is consumed by **both** the Epoch panel's EVENT HANDLER step (`machine-block` now delegates to it) **and** the Machine tab — so the two surfaces carry byte-for-byte identical cascade output (same `rf-xray-epoch-machine-cascade-row-N` / `-ordinal-N` / `-kind-*` / `-verb-link-N` / `-source-body-N` / `-outcome-N` / `-data-write-N` testids) and cannot diverge again. That divergence (the Machine tab's old thinner bespoke lens vs the Epoch panel's richer microstep view) was the bead's core "why".

`machine_inspector.cljs` drops **~880 lines net**.

## Removed vs preserved/flagged controls (CAUTION check)

**Removed** (all subsumed by the mini-pipeline + the chart's own toolbar):
- the bespoke **focused-transition lens** (`Target Machine Instance:` / `TRANSITION` / `GUARDS RUN` / `ACTIONS RUN`) — its forensic content (guard pass/fail, action source + `:fx` outcomes, microsteps) is carried MORE richly by the shared cascade rows.
- the per-machine **header ribbon** (the `from → to` / `[START]` / `[NO-OP]` header badges) — the START/NO-OP story now reads off the cascade's `:start` / `:no-op` rows.
- the **list/canvas view-mode wrapper** — the chart's own `machine-canvas/Chart` toolbar owns the view-mode toggle (chart-owned concern, not tab chrome).
- the **chart-collapse** toggle + summary.
- the **snapshot drill-in** (`:data` mutations now read off the cascade rows' inline data-writes).
- the **inline cancellation cascade** — timer cancellations surface as the mini-pipeline's `:timer` cascade rows.

**INSTANCES sub-strip — checked, nothing to preserve.** The Dynamic Machine tab has been single-instance since rf2-y9xmf/rf2-8og3k; there is NO INSTANCES sub-strip in the pre-redesign code. Multi-instance focus is handled by the focused-event single-instance rule + Prev/Next (which already skip to the next epoch touching the focused machine). The mini-pipeline + chart still represent the one focused instance. **No control removed here was the sole entry point to a real capability** — nothing flagged to Mike.

## Spec update note (xray-specs-kept-current)

- `tools/xray/spec/003-Machine-Inspector.md` — §Post-collapse Dynamic panel shape rewritten to the three-element layout + shared-mini-pipeline reuse (with the removed-controls list); a **SUPERSEDED** banner added to §Focused-transition lens (the bespoke lens is removed; the §Data sources table kept as the trace-contract reference the projection reads).
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` — the Machine Inspector snapshot-drill-in row in the edn-inspector FULL+DIFF consumer table marked REMOVED; the `[NO-OP]` cascade-row grammar cross-ref updated (it is now the single no-op grammar across both surfaces).

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:cljs` (node-test; compiles tools/xray src+test) | **PASS** — 5866 tests / 20771 assertions, 0 failures, 0 warnings |
| xray `clojure -M:test` (JVM) | **PASS** — 1101 tests / 4577 assertions, 0 failures |
| `mkdocs build --strict` | **PASS** — built, no warnings |
| `npm run test:xray-feature-gate` | 15/16 PASS — incl. **machine-epochs** (the real Machine-tab exercise) PASS. The one FAIL ("deep machine inspector substrate") is **pre-existing and unrelated**: the `deep_machine` testbed app never boots (`:rf.error/machine-unresolved-target` thrown in `reg-machine` at `testbeds/deep_machine/core.cljs`, fallout from rf2-gl588's stronger target validation), so the Machine-tab panel code never runs. `testbeds/**` is outside this lane. Filed as **rf2-2fbucy**. |

Feature-matrix gate: scenarios reference the panel root `rf-xray-machine-inspector` only (no removed inner testids), so no gate edit was needed beyond the unrelated pre-existing failure.

Tests added pinning the redesign: Machine tab renders the 3 elements; the mini-pipeline IS the shared renderer (same `rf-xray-epoch-machine-cascade-*` testids); Prev/Next moves the mini-pipeline + chart together. Removed-chrome tests (lens / snapshot / collapse / nested-header) deleted; registry snapshot updated for the new `:rf.xray/machine-focused-epoch-cascade` sub.

Closes rf2-g2axio.
