### PR TITLE
fix(testbeds/deep_machine): repair unresolved spawn/transition target so the testbed boots (rf2-2fbucy)

### DIFF
--- a/testbeds/deep_machine/core.cljs
+++ b/testbeds/deep_machine/core.cljs
@@ -193,7 +193,15 @@
                :entry  :bump-tick
                :spawn {:machine-id :helper/tick
                         :data       (fn [_snap _ev] {:ticked? false})}
-               :on    {:work/done {:target :resolving
+               ;; :resolving is a sibling of :phase-a at the :work region
+               ;; root, five compound levels ABOVE this leaf — a keyword
+               ;; target only names a sibling of the declaring state, so
+               ;; the cross-level lift to :resolving must be an absolute
+               ;; vector path from the region root ([:resolving]). Per
+               ;; Spec-Schemas §TransitionTarget + Spec 005 §Transition
+               ;; resolution; XState v5 likewise reaches a non-sibling
+               ;; target by absolute (id-rooted) path, not a bare key.
+               :on    {:work/done {:target [:resolving]
                                    :action :mark-phase-a-ran}}}}}}}}}}}
 
       :resolving


### PR DESCRIPTION
Fixes **rf2-2fbucy** (P2, BUG) — deep_machine testbed fails to boot: `:rf.error/machine-unresolved-target` (xray-feature-gate "deep machine inspector substrate" FAIL).

## Which target was unresolved, and how it's fixed

`testbeds/deep_machine/core.cljs` — the `:work` region's deepest leaf `:leaf-a` (active path `[:work :phase-a :sub-a :nested-a :deep-a :leaf-a]`) declared:

```clojure
:on {:work/done {:target :resolving :action :mark-phase-a-ran}}
```

A **bare-keyword** `:target` names a *sibling* of the declaring state — i.e. a direct child of the declaring state's parent compound (`:deep-a`). But `:resolving` is a child of the **`:work` region root**, five compound levels *above* the leaf. So the keyword never resolves to a real node.

Before **rf2-gl588** (`b5402a600`, 3 days ago) strengthened `validate-transition-targets!` (`re-frame.machines.lifecycle-fx.validation`), this slipped past registration and committed an invalid snapshot at runtime. The strengthened validator now throws `:rf.error/machine-unresolved-target` at `reg-machine` time → `deep-machine.core/run` was never defined → the app never booted → `runDeepMachine` timed out waiting for `[data-testid=work-go]`.

**Fix (one line):** express the cross-level lift as an **absolute vector path** from the region root — `:target [:resolving]`. This is the idiomatic re-frame2 form for a non-sibling target (Spec-Schemas §TransitionTarget = `[:or :keyword [:vector :keyword]]`; XState v5 likewise reaches a non-sibling target by absolute id-rooted path, not a bare key). Intent fully preserved: `:work/done` still lands `:work` in `:resolving`, whose `:always` cascade settles to `:done-a` (the `:mark-phase-a-ran` action flips the guard true).

No framework / shared code touched — testbed-only. The testbed continues to exercise every spec/005 spawn / compound / `:always` / `:spawn-all` capability; only the malformed target shape changed.

## Quality gates

- `npm run test:xray-feature-gate` (nightly-full sweep, from `implementation/`): **16/16 scenarios pass, 0 failures** (13 matrix rows). The previously-failing "deep machine inspector substrate" arm now PASSES; all other arms stay green. All 14 surfaces compiled with 0 warnings, including `:testbeds/deep-machine`.
- `npm run test:cljs`: not run — no shared / framework code changed (testbed `.cljs` only), per the bead's lane.

Closes rf2-2fbucy.