### PR TITLE
feat(testbeds/machine-epochs): add MODAL multi-event + GATE multi-guard tracks (rf2-vilpfa)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -1759,7 +1759,11 @@ action-attribution half.
   member-level tag-set delta; `:always` microsteps; `:after` timer + cancel;
   spawn / `:final?` / `:on-done` / destroy lifecycle; `:*` wildcard throw;
   deep-compound LCA + self-transitions; `:history` placement-reject + live
-  shallow/deep restore). Each step is
+  shallow/deep restore; the two xstate-render-divergence cases — MULTI-EVENT
+  transition (`modal`: one edge `:open ──► :closed` reached on three events,
+  events-as-nodes) + MULTI-BRANCH GUARDED fork (`gate`: `:gate/check` forks by
+  a guarded candidate vector to `:high` / `:low` / unguarded `:rejected`),
+  added under rf2-vilpfa). Each step is
   backed by a CLJS-unit assertion in
   `day8.re-frame2-xray.panels.epoch.machine-epochs-harness-cljs-test` (BOTH
   the machine outcome AND the cascade-render projection it lights up — cascade

--- a/tools/xray/spec/017-Test-Coverage-Matrix.md
+++ b/tools/xray/spec/017-Test-Coverage-Matrix.md
@@ -174,10 +174,17 @@ documents the testbed's shape so the browser feature gate's
 `machine-epochs multi-machine frame-isolated stepper` scenario has a
 normative reference.
 
-**Shape.** Eight machine domains (door · traffic · quiz · brew ·
-session · fuse · hvac · media) each run in their OWN frame
-(`:machine/<track>`) and own their OWN Xray epoch ring. A left-rail
-PICKER selects a track; selecting a track:
+**Shape.** Ten machine domains (door · traffic · quiz · brew ·
+session · fuse · hvac · media · modal · gate) each run in their OWN
+frame (`:machine/<track>`) and own their OWN Xray epoch ring. The
+final two — `modal` (a MULTI-EVENT transition: one edge `:open ──►
+:closed` reached on THREE distinct events, the events-as-nodes
+divergence) and `gate` (a MULTI-BRANCH GUARDED fork: `:gate/check`
+forks from `:idle` by a guarded candidate vector — `:high` / `:low` /
+unguarded-fallback `:rejected`, the guard-fork divergence) — were added
+under rf2-vilpfa to cover the two xstate-render-divergence cases the
+original eight miss. A left-rail PICKER selects a track; selecting a
+track:
 
 1. sets the SHELL frame's (`:rf/default`) runner bookkeeping
    (`:rf.runner/selected` + per-track `:rf.runner/cursors`),

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/machine_epochs_harness_cljs_test.cljs
@@ -80,7 +80,8 @@
   (preload/register-trace-collector!)
   (machines/register-all!)
   (doseq [id [:door/main :traffic/light :quiz/scorer :brew/machine
-              :session/flow :hvac/controller :media/deep :media/shallow]]
+              :session/flow :hvac/controller :media/deep :media/shallow
+              :modal/main :gate/main]]
     (rf/dispatch-sync [id [:rf.machine/start]])))
 
 (defn- snapshot [machine-id]
@@ -705,3 +706,194 @@
       (is (= [:player :playing :mid-track]
              (get-in (snapshot :media/deep) [:rf/history [:player]]))
           "(c) the snapshot's :rf/history slot holds the recorded leaf (App-db inspectable)"))))
+
+;; ============================================================================
+;; MODAL (MULTI-EVENT transition) — the events-as-nodes divergence (rf2-vilpfa)
+;; ============================================================================
+;;
+;; THE events-as-nodes case the original 8 miss: ONE edge (:open ──► :closed)
+;; reached on THREE distinct events (:modal/cancel, :modal/submit [+:save],
+;; :modal/escape). xstate v5 STACKS the three labels on one edge; re-frame2's
+;; events-as-nodes render draws THREE event-nodes fanning INTO :closed. The
+;; BEHAVIOUR is identical (XState v5 gold standard): every event lands :closed.
+;; The harness asserts (a) each event's cascade is a real :open ──► :closed
+;; transition, (b) the :submit branch ALSO runs the :save action (the data-
+;; bearing fan-in branch), and (c) the multi-event fan-in is real — the SAME
+;; (from→to) edge is reached by THREE distinct event-ids in one arc.
+
+(defn- modal-open! []
+  (drive! :modal/main [:modal/open]))
+
+(deftest modal-cancel-lands-closed
+  (testing "rf2-vilpfa — :modal/cancel (fan-in event #1) drives :open ──►
+            :closed. (a) a real transition row from :open to :closed; (b) no
+            no-op (a handled event is not a no-op); (c) the modal lands :closed."
+    (setup!)
+    (modal-open!)                                       ; :closed → :open
+    (let [record (drive! :modal/main [:modal/cancel])    ; :open → :closed
+          rows   (cascade record)
+          tx     (first (rows-of-kind rows :transition))]
+      (is (some? tx) "(c) a real transition row renders")
+      (is (= :open (:from-state tx)))
+      (is (= :closed (:to-state tx)) "(a) :modal/cancel lands :closed")
+      (is (empty? (rows-of-kind rows :no-op)) "(b) a handled event is not a no-op"))
+    (is (= :closed (:state (snapshot :modal/main))))))
+
+(deftest modal-submit-runs-save-and-lands-closed
+  (testing "rf2-vilpfa — :modal/submit (fan-in event #2) drives :open ──►
+            :closed AND runs the :save action (the data-bearing branch of the
+            fan-in). (a) the transition + an :save action whose :data-write sets
+            :saved?; (c) the modal lands :closed with :saved? true in :data."
+    (setup!)
+    (modal-open!)                                       ; → :open
+    (let [record (drive! :modal/main [:modal/submit])    ; → :closed (runs :save)
+          rows   (cascade record)
+          tx     (first (rows-of-kind rows :transition))]
+      (is (some? tx) "(c) a real transition row renders")
+      (is (= :open (:from-state tx)))
+      (is (= :closed (:to-state tx)) "(a) :modal/submit lands :closed")
+      (is (some #(true? (get-in % [:data-write :saved?]))
+                (rows-of-kind rows :action))
+          "(a)(c) the :save action ran (its :data-write set :saved?)"))
+    (is (= :closed (:state (snapshot :modal/main))))
+    (is (true? (get-in (snapshot :modal/main) [:data :saved?]))
+        "(c) the :save action wrote :saved? into the snapshot")))
+
+(deftest modal-escape-lands-closed
+  (testing "rf2-vilpfa — :modal/escape (fan-in event #3) drives :open ──►
+            :closed. (a) a real transition from :open to :closed; (c) the modal
+            lands :closed — the third event proving the multi-event fan-in."
+    (setup!)
+    (modal-open!)                                       ; → :open
+    (let [record (drive! :modal/main [:modal/escape])    ; → :closed
+          rows   (cascade record)
+          tx     (first (rows-of-kind rows :transition))]
+      (is (some? tx) "(c) a real transition row renders")
+      (is (= :open (:from-state tx)))
+      (is (= :closed (:to-state tx)) "(a) :modal/escape lands :closed"))
+    (is (= :closed (:state (snapshot :modal/main))))))
+
+(deftest modal-multi-event-fan-in-shows-three-event-nodes
+  (testing "rf2-vilpfa (events-as-nodes) — the SAME edge (:open ──► :closed) is
+            reached by THREE distinct events. Driving all three captures THREE
+            transition cascades whose (from→to) is identical (:open → :closed)
+            but whose triggering event-ids are DISTINCT — the fan-in the
+            events-as-nodes render draws as three event-nodes into the single
+            :closed node (xstate stacks the three labels on one edge)."
+    (setup!)
+    ;; Drive each of the three close events from :open, re-opening between, and
+    ;; collect the (from, to, event-id) of each macrostep's transition.
+    (let [arcs (for [close-ev [[:modal/cancel] [:modal/submit] [:modal/escape]]]
+                 (do (modal-open!)                       ; → :open
+                     (let [record (drive! :modal/main close-ev)
+                           tx     (first (rows-of-kind (cascade record) :transition))]
+                       {:from     (:from-state tx)
+                        :to       (:to-state tx)
+                        :event-id (first close-ev)})))
+          edges    (map (juxt :from :to) arcs)
+          event-ids (map :event-id arcs)]
+      (is (= 3 (count arcs)) "three close arcs driven")
+      (is (every? #(= [:open :closed] %) edges)
+          "(c) all THREE events reach the SAME edge :open ──► :closed (the fan-in target)")
+      (is (= #{:modal/cancel :modal/submit :modal/escape} (set event-ids))
+          "(c) the fan-in is reached by THREE DISTINCT event-nodes (events-as-nodes)")
+      (is (= 3 (count (distinct event-ids)))
+          "(c) three distinct event-node sources fan into the one :closed node"))
+    (is (= :closed (:state (snapshot :modal/main)))
+        "(c) the modal settled :closed after the full multi-event arc")))
+
+;; ============================================================================
+;; GATE (MULTI-BRANCH GUARDED fork) — the guard-fork divergence (rf2-vilpfa)
+;; ============================================================================
+;;
+;; THE guard-fork case the original 8 miss: ONE event (:gate/check) forks from
+;; :idle by a guarded candidate VECTOR — first guard-pass wins (:gate-high? →
+;; :high, :gate-low? → :low) with an unguarded fallback (→ :rejected). xstate v5
+;; draws ONE labelled edge per branch from :idle (the guard in the label). The
+;; harness asserts each :check lands the guarded branch AND surfaces the guard
+;; predicate(s) on the fork's guard rows (:guard-id + :outcome) — the fork's
+;; guard predicates the render shows.
+
+(defn- gate-guard-ids [record]
+  (mapv :guard-id (rows-of-kind (cascade record) :guard)))
+
+(defn- gate-guard-outcome [record guard-id]
+  (->> (rows-of-kind (cascade record) :guard)
+       (some #(when (= guard-id (:guard-id %)) (:outcome %)))))
+
+(deftest gate-high-branch-fires-on-high-level
+  (testing "rf2-vilpfa — :gate/set 7 arms :level 7 (internal action-only
+            transition), then :gate/check forks to :high: the FIRST guarded
+            candidate :gate-high? passes. (a) the fork's guard row carries
+            :guard-id :gate-high? with :outcome :pass; (c) the gate lands :high."
+    (setup!)
+    ;; :gate/set is an internal action-only transition — it arms :level, stays :idle.
+    (let [set-rows (cascade (drive! :gate/main [:gate/set 7]))]
+      (is (empty? (rows-of-kind set-rows :no-op))
+          "(b) :gate/set is a REAL internal transition (action-only), not a no-op")
+      (is (= 7 (get-in (snapshot :gate/main) [:data :level]))
+          "(c) :set-level read (second event)=7 into :data :level")
+      (is (= :idle (:state (snapshot :gate/main))) "(c) :gate/set stays :idle"))
+    ;; :gate/check forks by the guarded candidate vector — high branch.
+    (let [record (drive! :gate/main [:gate/check])
+          tx     (first (rows-of-kind (cascade record) :transition))]
+      (is (some? tx) "(c) a real transition row renders")
+      (is (= :idle (:from-state tx)))
+      (is (= :high (:to-state tx)) "(c) :gate-high? selected the :high branch")
+      (is (some #{:gate-high?} (gate-guard-ids record))
+          "(a) the fork's guard row surfaces the :gate-high? predicate")
+      (is (= :pass (gate-guard-outcome record :gate-high?))
+          "(a) :gate-high? PASSED (level 7 >= 5) — the first-guard-pass-wins branch"))
+    (is (= :high (:state (snapshot :gate/main))))))
+
+(deftest gate-low-branch-fires-when-high-fails
+  (testing "rf2-vilpfa — :gate/set 2 then :gate/check forks to :low: the FIRST
+            candidate :gate-high? FAILS (2<5), the candidate walk advances to
+            :gate-low? which passes. (a) the fork shows :gate-high? :fail AND
+            :gate-low? :pass — the multi-branch walk; (c) the gate lands :low."
+    (setup!)
+    (drive! :gate/main [:gate/set 2])
+    (let [record (drive! :gate/main [:gate/check])
+          tx     (first (rows-of-kind (cascade record) :transition))]
+      (is (= :low (:to-state tx)) "(c) :gate-low? selected the :low branch")
+      (is (= :fail (gate-guard-outcome record :gate-high?))
+          "(a) :gate-high? FAILED (2 < 5) — the first candidate's guard blocked")
+      (is (= :pass (gate-guard-outcome record :gate-low?))
+          "(a) the walk advanced to :gate-low? which PASSED (0 < 2 < 5)"))
+    (is (= :low (:state (snapshot :gate/main))))))
+
+(deftest gate-rejected-branch-fires-on-unguarded-fallback
+  (testing "rf2-vilpfa — :gate/set 0 then :gate/check forks to :rejected: BOTH
+            guards FAIL, so the UNGUARDED fallback candidate {:target :rejected}
+            fires (the else clause). (a) the fork shows :gate-high? :fail +
+            :gate-low? :fail; (c) the gate lands :rejected via the fallback."
+    (setup!)
+    (drive! :gate/main [:gate/set 0])
+    (let [record (drive! :gate/main [:gate/check])
+          tx     (first (rows-of-kind (cascade record) :transition))]
+      (is (= :rejected (:to-state tx))
+          "(c) both guards failed → the unguarded fallback selected :rejected")
+      (is (= :fail (gate-guard-outcome record :gate-high?))
+          "(a) :gate-high? FAILED (0 < 5)")
+      (is (= :fail (gate-guard-outcome record :gate-low?))
+          "(a) :gate-low? FAILED (0 is not > 0) — both guarded candidates blocked"))
+    (is (= :rejected (:state (snapshot :gate/main))))))
+
+(deftest gate-three-branches-each-land-their-guarded-target
+  (testing "rf2-vilpfa (guard-fork) — the full fork: ALL THREE :gate/check
+            branches land their guard-selected target (:high / :low /
+            :rejected), each preceded by a :reset back to :idle. Proves the
+            first-guard-pass-wins resolution + the unguarded fallback over the
+            single :idle fork node (xstate: one labelled edge per branch)."
+    (setup!)
+    (let [check-branch (fn [level expected-state]
+                         (drive! :gate/main [:gate/set level])
+                         (let [to (-> (drive! :gate/main [:gate/check])
+                                      cascade (rows-of-kind :transition) first :to-state)]
+                           (drive! :gate/main [:gate/reset])   ; back to :idle
+                           to))]
+      (is (= :high     (check-branch 7 :high))     "(c) level 7 → :high")
+      (is (= :low      (check-branch 2 :low))      "(c) level 2 → :low")
+      (is (= :rejected (check-branch 0 :rejected)) "(c) level 0 → :rejected (fallback)"))
+    (is (= :idle (:state (snapshot :gate/main)))
+        "(c) the gate is back at the :idle fork node after the three branches")))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -3306,6 +3306,86 @@ async function runMachineEpochs(page, state) {
   await clickMachineStep(page, 1); // shallow restore
   await clickMachineStep(page, 2); // deep restore
 
+  // ===== Modal (MULTI-EVENT transition — events-as-nodes, rf2-vilpfa) ====
+  // ONE edge (:open ──► :closed) reached on THREE distinct events
+  // (cancel/submit/escape). Drive all three (re-opening between) and confirm
+  // each lands :closed; the submit branch also runs :save (:saved? true). The
+  // events-as-nodes fan-in render is asserted in the CLJS harness; here we
+  // confirm the behaviour (all three events close the modal) off the snapshot.
+  await selectMachineTrack(page, 'modal');
+  await waitForTrackSnapshot(
+    page, 'modal', [':modal/main'],
+    (t) => /:modal\/main state: :closed/.test(t),
+    'modal track booted to :closed',
+  );
+  await clickMachineStep(page, 0); // open → :open
+  await waitForTrackSnapshot(
+    page, 'modal', [':modal/main'],
+    (t) => /:modal\/main state: :open/.test(t),
+    'modal#0 open -> :open',
+  );
+  await clickMachineStep(page, 1); // cancel → :closed (fan-in event #1)
+  await waitForTrackSnapshot(
+    page, 'modal', [':modal/main'],
+    (t) => /:modal\/main state: :closed/.test(t),
+    'modal#1 cancel -> :closed (multi-event fan-in #1)',
+  );
+  await clickMachineStep(page, 2); // re-open → :open
+  await clickMachineStep(page, 3); // submit → :closed + :save (fan-in event #2)
+  await waitForTrackSnapshot(
+    page, 'modal', [':modal/main'],
+    (t) => /:modal\/main state: :closed/.test(t) && /:saved\? true/.test(t),
+    'modal#3 submit -> :closed + :save ran (:saved? true) (multi-event fan-in #2)',
+  );
+  await clickMachineStep(page, 4); // re-open → :open
+  await clickMachineStep(page, 5); // escape → :closed (fan-in event #3)
+  const afterModal = await waitForTrackSnapshot(
+    page, 'modal', [':modal/main'],
+    (t) => /:modal\/main state: :closed/.test(t),
+    'modal#5 escape -> :closed (multi-event fan-in #3 — all 3 events land :closed)',
+  );
+
+  // ===== Gate (MULTI-BRANCH GUARDED fork — guard-fork, rf2-vilpfa) ========
+  // :gate/check forks from :idle by a guarded candidate vector (high?→:high,
+  // low?→:low, else→:rejected); :gate/set arms :level first. Drive all three
+  // guard branches; the fork's guard-predicate render is asserted in the CLJS
+  // harness, here we confirm each :check lands its guard-selected target.
+  await selectMachineTrack(page, 'gate');
+  await waitForTrackSnapshot(
+    page, 'gate', [':gate/main'],
+    (t) => /:gate\/main state: :idle/.test(t),
+    'gate track booted to :idle',
+  );
+  await clickMachineStep(page, 0); // set 7 — arm :level 7
+  await waitForTrackSnapshot(
+    page, 'gate', [':gate/main'],
+    (t) => /:gate\/main state: :idle/.test(t) && /:level 7/.test(t),
+    'gate#0 set 7 -> :level 7, STAYS :idle (internal action-only transition)',
+  );
+  await clickMachineStep(page, 1); // check → :high (gate-high? branch)
+  await waitForTrackSnapshot(
+    page, 'gate', [':gate/main'],
+    (t) => /:gate\/main state: :high/.test(t),
+    'gate#1 check -> :high (:gate-high? branch, first-guard-pass-wins)',
+  );
+  await clickMachineStep(page, 2); // reset → :idle
+  await clickMachineStep(page, 3); // set 2 — arm :level 2
+  await clickMachineStep(page, 4); // check → :low (gate-low? branch)
+  await waitForTrackSnapshot(
+    page, 'gate', [':gate/main'],
+    (t) => /:gate\/main state: :low/.test(t),
+    'gate#4 check -> :low (:gate-high? fails, :gate-low? passes)',
+  );
+  await clickMachineStep(page, 5); // reset → :idle
+  await clickMachineStep(page, 6); // set 0 — arm :level 0
+  await clickMachineStep(page, 7); // check → :rejected (unguarded fallback)
+  const afterGate = await waitForTrackSnapshot(
+    page, 'gate', [':gate/main'],
+    (t) => /:gate\/main state: :rejected/.test(t),
+    'gate#7 check -> :rejected (both guards fail -> unguarded fallback)',
+  );
+  await clickMachineStep(page, 8); // reset → :idle
+
   // ===== Xray Machine Inspector handoff + the throw/no-op contrast ======
   await openXray(page);
 
@@ -3370,6 +3450,8 @@ async function runMachineEpochs(page, state) {
     isolation: { doorAfterReturn: doorAfterReturn.stripText },
     quiz: { quizText: afterQuiz.stripText },
     hard: { powerText: afterHvacPower.stripText, tweakText: afterHvacTweak.stripText },
+    modal: { modalText: afterModal.stripText },
+    gate: { gateText: afterGate.stripText },
     inspectorMounted: true,
   };
 }
@@ -3563,7 +3645,11 @@ const SCENARIOS = [
     // child :final · :on-done · DESTROY), fuse (boot-on-select :entry THROW),
     // hvac (deep compound · LCA cascade · self-transitions), media (placement
     // reject + live shallow/deep restore — the restore-cascade render is
-    // asserted in the CLJS harness). It also proves the per-machine frame
+    // asserted in the CLJS harness), modal (MULTI-EVENT transition: one edge
+    // :open ──► :closed reached on THREE events — the events-as-nodes
+    // divergence, rf2-vilpfa), gate (MULTI-BRANCH GUARDED fork: :gate/check
+    // forks by guard high?/low?/else → :high/:low/:rejected — the guard-fork
+    // divergence, rf2-vilpfa). It also proves the per-machine frame
     // ISOLATION with a cross-frame flip (door -> traffic -> back to door:
     // each frame's snapshot stays intact, never interleaved) + a Restart
     // (frame reset + re-arc from boot). Then opens the Xray Machine Inspector
@@ -3575,7 +3661,7 @@ const SCENARIOS = [
     // test `panels.epoch.machine-epochs-harness-cljs-test` per the Causa/
     // Story-as-CLJS rule (the chart-render shim-survival probe stays owned by
     // the `deep machine inspector substrate` scenario).
-    name: 'machine-epochs multi-machine frame-isolated stepper (rf2-q3lfm: pick a machine -> Xray follows its own epoch ring; per-track door/traffic/quiz/brew/session/fuse/hvac/media paths; cross-frame flip isolation; restart = frame reset; boot-on-select fuse THROW)',
+    name: 'machine-epochs multi-machine frame-isolated stepper (rf2-q3lfm: pick a machine -> Xray follows its own epoch ring; per-track door/traffic/quiz/brew/session/fuse/hvac/media/modal/gate paths; cross-frame flip isolation; restart = frame reset; boot-on-select fuse THROW)',
     url: '/testbeds/machine-epochs/',
     panels: ['machines'],
     coveredRows: ['Machines'],

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -339,6 +339,18 @@
          domain (rf2-q3lfm). Both start at :tray."}
   (fn [_ _] {:fx (boot-machines-fx [:media/deep :media/shallow])}))
 
+(rf/reg-event-fx :machine-epochs/boot-modal
+  {:doc "Boot the modal machine to :closed — the multi-event-transition machine
+         whose :open ──► :closed edge is reached on THREE distinct events
+         (the events-as-nodes divergence, rf2-vilpfa)."}
+  (fn [_ _] {:fx (boot-machines-fx [:modal/main])}))
+
+(rf/reg-event-fx :machine-epochs/boot-gate
+  {:doc "Boot the gate machine to :idle — the multi-branch guarded-fork machine
+         whose :gate/check forks by guard (:high / :low / :rejected) from :idle
+         (the guard-fork divergence, rf2-vilpfa)."}
+  (fn [_ _] {:fx (boot-machines-fx [:gate/main])}))
+
 ;; ============================================================================
 ;; THE TRACK CATALOGUE — code data (the single source of truth)
 ;; ============================================================================
@@ -353,9 +365,13 @@
 ;;   the track's machine frame. The explicit 'start machine' rows of the old
 ;;   deck were DROPPED — boot-on-select produces the START epoch for free.
 ;;
-;; The 8 domains are the same clean machine features the old flat deck drove;
-;; the cross-machine fan-out steps ('Reset door + tick traffic' and the
-;; multi-machine no-op) were DROPPED (Mike ruling 5).
+;; The first 8 domains are the same clean machine features the old flat deck
+;; drove; the cross-machine fan-out steps ('Reset door + tick traffic' and the
+;; multi-machine no-op) were DROPPED (Mike ruling 5). Two later domains —
+;; :modal (multi-event transition) + :gate (multi-branch guarded fork) — were
+;; ADDED (rf2-vilpfa) to cover the two xstate-render-divergence cases the
+;; original 8 miss: events-as-nodes (one edge reached on N events) and the
+;; guard-fork (one :check forking by guarded candidate).
 
 (def tracks
   [{:id       :door
@@ -484,7 +500,73 @@
       :watch "Epoch: the :rf.machine.history/restored banner (source :recorded, SHALLOW); restored :entry steps chip 'from history'; restores the CHILD then its :initial."}
      {:label "DEEP restore (:media/deep eject → re-insert)"
       :event [:machine-epochs/history-deep-restore]
-      :watch "Epoch: the banner reads DEEP; the :entry steps descend to the EXACT recorded leaf [:player :playing :mid-track], each chipped 'from history'."}]}])
+      :watch "Epoch: the banner reads DEEP; the :entry steps descend to the EXACT recorded leaf [:player :playing :mid-track], each chipped 'from history'."}]}
+
+   {:id       :modal
+    :label    "Modal"
+    :blurb    "MULTI-EVENT — one edge (:open ──► :closed) reached on THREE events; events-as-nodes draws 3 event-nodes fanning into :closed."
+    :machines #{:modal/main}
+    :boot     :machine-epochs/boot-modal
+    :path
+    ;; Drive all THREE multi-event paths into :closed (cancel / submit / escape),
+    ;; re-opening before each. The events-as-nodes divergence is THE point: xstate
+    ;; stacks 3 labels on one edge; re-frame2 draws 3 event-nodes into :closed.
+    [{:label "Open (:closed ──► :open)"
+      :event [:modal/main [:modal/open]]
+      :watch "Plain transition opening the modal; the next three steps each close it via a DIFFERENT event — the fan-in source nodes."}
+     {:label "Cancel (:open ──► :closed) — fan-in event #1"
+      :event [:modal/main [:modal/cancel]]
+      :watch "Multi-event: :modal/cancel lands :closed. Events-as-nodes draws a :modal/cancel node fanning INTO :closed (xstate stacks it on one edge)."}
+     {:label "Re-open (:closed ──► :open)"
+      :event [:modal/main [:modal/open]]
+      :watch "Re-open so the SUBMIT path can be driven; the chart's :open node is the shared fan-OUT source for the three close events."}
+     {:label "Submit (:open ──► :closed, runs :save) — fan-in event #2"
+      :event [:modal/main [:modal/submit]]
+      :watch "Multi-event WITH action: :modal/submit runs :save (snapshot :saved? true) then lands :closed — the data-bearing branch of the fan-in."}
+     {:label "Re-open (:closed ──► :open)"
+      :event [:modal/main [:modal/open]]
+      :watch "Re-open once more so the ESCAPE path can be driven — the third fan-in source node into :closed."}
+     {:label "Escape (:open ──► :closed) — fan-in event #3"
+      :event [:modal/main [:modal/escape]]
+      :watch "Multi-event: :modal/escape lands :closed. All THREE events (cancel/submit/escape) now proven to fan into the single :closed node."}]}
+
+   {:id       :gate
+    :label    "Gate"
+    :blurb    "GUARDED FORK — :gate/check forks by guard (high?→:high, low?→:low, else→:rejected); xstate draws one labelled edge per branch from :idle."
+    :machines #{:gate/main}
+    :boot     :machine-epochs/boot-gate
+    :path
+    ;; Drive all THREE guard branches (high / low / rejected). :gate/set arms
+    ;; :level (internal action-only transition); :gate/check forks by the guarded
+    ;; candidate vector (first guard-pass wins; unguarded fallback → :rejected);
+    ;; :gate/reset returns to :idle so the next branch can be armed.
+    [{:label "Set level HIGH (:gate/set 7) — arm :level 7"
+      :event [:gate/main [:gate/set 7]]
+      :watch "Internal action-only transition: :set-level reads (second event)=7 into :data :level; stays :idle. Watch the snapshot :level."}
+     {:label "Check (──► :high) — :gate-high? branch"
+      :event [:gate/main [:gate/check]]
+      :watch "Guarded fork: the candidate vector's FIRST pass wins — :gate-high? (level>=5) passes → :high. xstate draws this as one labelled edge from :idle."}
+     {:label "Reset (──► :idle)"
+      :event [:gate/main [:gate/reset]]
+      :watch "Plain transition back to :idle so the LOW branch can be armed next."}
+     {:label "Set level LOW (:gate/set 2) — arm :level 2"
+      :event [:gate/main [:gate/set 2]]
+      :watch "Internal action-only transition: :level → 2; stays :idle. The next :check will take the :gate-low? branch (high fails, low passes)."}
+     {:label "Check (──► :low) — :gate-low? branch"
+      :event [:gate/main [:gate/check]]
+      :watch "Guarded fork: :gate-high? FAILS (2<5), :gate-low? passes (0<2<5) → :low. The candidate walk advanced past the first guard to the second."}
+     {:label "Reset (──► :idle)"
+      :event [:gate/main [:gate/reset]]
+      :watch "Plain transition back to :idle so the REJECTED branch can be armed next."}
+     {:label "Set level NONE (:gate/set 0) — arm :level 0"
+      :event [:gate/main [:gate/set 0]]
+      :watch "Internal action-only transition: :level → 0; stays :idle. Both guards will FAIL on the next :check → the unguarded fallback fires."}
+     {:label "Check (──► :rejected) — unguarded fallback"
+      :event [:gate/main [:gate/check]]
+      :watch "Guarded fork: BOTH guards fail (0 is neither >=5 nor 0<x<5) → the unguarded fallback candidate {:target :rejected} fires. The else branch."}
+     {:label "Reset (──► :idle)"
+      :event [:gate/main [:gate/reset]]
+      :watch "Plain transition back to :idle — all three guard branches (:high/:low/:rejected) now proven."}]}])
 
 (def track-by-id
   "Index `tracks` by `:id` for O(1) lookup in handlers + subs."

--- a/tools/xray/testbeds/machine_epochs/machines.cljs
+++ b/tools/xray/testbeds/machine_epochs/machines.cljs
@@ -420,6 +420,70 @@
   exit-leaf restores only to the child's `:initial`)."
   (media-player-spec false))
 
+;; ============================================================================
+;; MACHINE 9 — :modal/main  (MULTI-EVENT transition — the events-as-nodes case)
+;; ============================================================================
+;;
+;; THE events-as-nodes divergence (rf2-vilpfa). One target, `:closed`, reached
+;; from `:open` on THREE distinct events (`:modal/cancel`, `:modal/submit` [+a
+;; `:save` action], `:modal/escape`). xstate v5 STACKS the three event labels
+;; on ONE edge `:open ──► :closed`; re-frame2's events-as-nodes render draws
+;; THREE event-nodes fanning INTO the single `:closed` node. Driving all three
+;; lands `:closed` every time — the behaviour is identical to xstate (the gold
+;; standard); only the CHART topology diverges, which is the whole point of the
+;; comparison. The `:submit` path additionally runs the `:save` action so the
+;; fan-in carries a data-bearing branch alongside the two plain ones.
+
+(defmachine modal-machine
+  {:initial :closed
+   :actions
+   {:save (fn save [{data :data}]
+            {:data (assoc data :saved? true)})}
+   :states
+   {:closed
+    {:tags #{:modal/closed}
+     :on   {:modal/open :open}}
+    :open
+    {:tags #{:modal/open}
+     :on   {:modal/cancel :closed
+            :modal/submit {:target :closed :action :save}
+            :modal/escape :closed}}}})
+
+;; ============================================================================
+;; MACHINE 10 — :gate/main  (MULTI-BRANCH GUARDED fork — the guard-fork case)
+;; ============================================================================
+;;
+;; THE guard-fork divergence (rf2-vilpfa). `:gate/check` FORKS from `:idle` by
+;; a guarded candidate VECTOR: first guard-pass wins — `:gate-high?` → `:high`,
+;; `:gate-low?` → `:low`, else the unguarded fallback `{:target :rejected}`.
+;; `:gate/set` arms `:level` first (an internal `:action`-only transition,
+;; reading the level off the event payload `(second event)`). xstate v5 draws
+;; ONE labelled edge per branch from `:idle` (the guard in the label); the
+;; re-frame2 render diverges in HOW the fork is drawn, but the BEHAVIOUR is
+;; faithful — each `:check` lands the branch its guard selects. Driving all
+;; three branches (high 7 → :high, low 2 → :low, none 0 → :rejected) exercises
+;; the full first-guard-pass-wins + unguarded-fallback resolution.
+
+(defmachine gate-machine
+  {:initial :idle
+   :data    {:level 0}
+   :actions
+   {:set-level (fn set-level [{data :data event :event}]
+                {:data (assoc data :level (second event))})}  ;; event: [:gate/set <n>]
+   :guards
+   {:gate-high? (fn gate-high? [{data :data}] (>= (:level data) 5))
+    :gate-low?  (fn gate-low?  [{data :data}] (and (pos? (:level data)) (< (:level data) 5)))}
+   :states
+   {:idle
+    {:tags #{:gate/idle}
+     :on   {:gate/set   {:action :set-level}
+            :gate/check [{:guard :gate-high? :target :high}
+                         {:guard :gate-low?  :target :low}
+                         {:target :rejected}]}}
+    :low      {:tags #{:gate/low}      :on {:gate/reset :idle}}
+    :high     {:tags #{:gate/high}     :on {:gate/reset :idle}}
+    :rejected {:tags #{:gate/rejected} :on {:gate/reset :idle}}}})
+
 ;; ----------------------------------------------------------------------------
 ;; HISTORY PLACEMENT probe — the misplaced-history rejection (rung #24).
 ;; ----------------------------------------------------------------------------
@@ -471,4 +535,6 @@
   (rf/reg-machine :fuse/box         fuse-machine)
   (rf/reg-machine :hvac/controller  hvac-controller-machine)
   (rf/reg-machine :media/deep       media-deep-machine)
-  (rf/reg-machine :media/shallow    media-shallow-machine))
+  (rf/reg-machine :media/shallow    media-shallow-machine)
+  (rf/reg-machine :modal/main       modal-machine)
+  (rf/reg-machine :gate/main        gate-machine))


### PR DESCRIPTION
@
Implements **rf2-vilpfa** — adds the two xstate-render-divergence cases the original 8 Machine-Epochs machines miss, as new frame-isolated tracks + steps + harness assertions.

## What changed

- **MODAL** (`:modal/main`) — a MULTI-EVENT transition (the *events-as-nodes* divergence): one edge `:open ──► :closed` reached on THREE distinct events (`:modal/cancel`, `:modal/submit` [+`:save` action], `:modal/escape`). xstate v5 stacks the three labels on one edge; re-frame2 events-as-nodes draws three event-nodes fanning into `:closed`. Behaviour is faithful to the XState v5 gold standard (all three land `:closed`); only the chart topology diverges.
- **GATE** (`:gate/main`) — a MULTI-BRANCH GUARDED fork (the *guard-fork* divergence): `:gate/check` forks from `:idle` by a guarded candidate vector (first guard-pass wins: `:gate-high?` → `:high`, `:gate-low?` → `:low`, unguarded fallback → `:rejected`); `:gate/set` arms `:level` off the event payload `(second event)`.

Both `defmachine` specs copied verbatim into `tools/xray/testbeds/machine_epochs/machines.cljs` + registered in `register-all!`. Added as two new tracks in the frame-isolated stepper deck (`core.cljs`) — each in its own `:machine/<id>` frame, picker row (label + progress + state), Step + Restart, per-row run buttons — with steps driving every path (modal: open→cancel→open→submit→open→escape; gate: set 7→check→reset→set 2→check→reset→set 0→check→reset). Each step carries `:label` + `:watch`.

**Harness** (`machine-epochs-harness-cljs-test`) — the single-source regression: 4 modal tests (each event lands `:closed`; submit runs `:save`; the multi-event fan-in shows 3 distinct event-node sources into the same `:open→:closed` edge) + 4 gate tests (each `:check` lands its guarded branch; the fork surfaces the guard predicates via `:guard-id` + `:outcome`; the full three-branch sweep).

**Feature-matrix** (`scenarios.cjs`) — the `machine-epochs` scenario now selects the `modal` + `gate` tracks and drives their per-row RUN buttons, asserting each step off the per-frame snapshot.

**Skipped** step F (`ai/topology/` sync — local-only, not in worktree; the specs here ARE the library source so they are in sync by construction) and the optional polish (3rd traffic tick, hvac reverse paths).

## Quality gates

- `npm run test:cljs` (consolidated node-test — the harness runs here): **5875 tests / 20823 assertions, 0 failures, 0 errors** (includes the new MODAL + GATE harness tests).
- xray JVM `clojure -M:test`: **1101 tests / 4577 assertions, 0 failures, 0 errors** (no regression).
- `npm run test:xray-feature-gate`: **16/16 scenarios, 0 failures** — the machine-epochs arm passed with the two new tracks driven (machine-epochs build compiled clean, 0 warnings).
- `mkdocs build --strict`: **not run / not applicable** — mkdocs is not installed in the worker environment, and all edits are outside the published `docs/` site (the `tools/xray/spec/*` files are internal Xray specs, `docs_dir: docs`). No mkdocs-tracked content changed.

## Spec note

Per the xray-specs-current rule: `tools/xray/spec/017-Test-Coverage-Matrix.md` (the machine-epochs stepper inventory: eight → **ten** domains, documenting the two divergence cases) and `tools/xray/spec/003-Machine-Inspector.md` (the render-regression harness feature list) were updated in the same PR to list the two new tracks.

Closes rf2-vilpfa.
@