### PR TITLE
docs(EP): flatten EP/ into a flat doc set with a README index

### DIFF
--- a/docs/EP/README.md
+++ b/docs/EP/README.md
@@ -1,0 +1,24 @@
+# Enhancement Proposals (EPs)
+
+Design proposals for re-frame2. Each EP states a **problem**, the proposed **re-frame2 solution**, the **options considered**, concrete **examples**, and an **implementation / bead plan**.
+
+EPs are *proposals*, not normative specification. The normative artefact remains [`spec/`](https://github.com/day8/re-frame2/tree/main/spec). The lifecycle is:
+
+> exploratory findings (local `ai/findings/`) → **EP** (synthesised proposal, here) → accepted EP graduates into `spec/` + implementation beads.
+
+## Conventions
+
+- One EP per file, **flat** in this directory, kebab-case named, each self-contained.
+- Front matter: a one-line `Status:` (`proposal` / `accepted` / `superseded`), a `Date:`, and a `Related:` list of guide/spec links.
+- Add new EPs to the table below and to the `EP` section of [`mkdocs.yml`](https://github.com/day8/re-frame2/blob/main/mkdocs.yml).
+
+## Index
+
+| EP | Status | Summary |
+|----|--------|---------|
+| [App/Runtime Partition](app-db-runtime-partition.md) | proposal | A frame owns two durable partitions — user-owned **app-db** (`:db`) and framework-owned **runtime-db** (`:rf.db/runtime`) — committed coherently by one cascade. Removes the footgun where an ordinary `:db` return silently clobbers machine / routing / elision / SSR runtime state, while preserving one coherent app+runtime snapshot for time-travel and SSR. |
+| [Resource Queries](resource-queries.md) | proposal | An optional `day8/re-frame2-resources` artefact for declarative server-state — the re-frame2 answer to TanStack Query / RTK Query / SWR / `shipclojure/re-frame-query`. Resource identity, caching, staleness, dedupe, tag invalidation, active-owner lifecycle/GC, route + SSR preload, built on managed-HTTP (Spec 014) and the runtime partition. |
+
+## Relationships
+
+The **App/Runtime Partition** EP is foundational: **Resource Queries** stores its cache in the framework-owned runtime partition (`:rf.runtime/resources`) that EP introduces, so the partition should land (or its key vocabulary be fixed) before resources rely on it.

--- a/docs/EP/app-db-runtime-partition.md
+++ b/docs/EP/app-db-runtime-partition.md
@@ -6,10 +6,10 @@ Date: 2026-06-06
 
 Related:
 
-- [Guide 02 - app-db](../../guide/02-app-db.md)
-- [Guide 04 - Events and the cascade](../../guide/04-events-and-the-cascade.md)
-- [Guide 18 - Frames](../../guide/18-frames.md)
-- [Guide 21 - Runtime model](../../guide/21-dynamic-model.md)
+- [Guide 02 - app-db](../guide/02-app-db.md)
+- [Guide 04 - Events and the cascade](../guide/04-events-and-the-cascade.md)
+- [Guide 18 - Frames](../guide/18-frames.md)
+- [Guide 21 - Runtime model](../guide/21-dynamic-model.md)
 - [Spec 002 - Frames](https://github.com/day8/re-frame2/blob/main/spec/002-Frames.md)
 - [Spec 005 - State Machines](https://github.com/day8/re-frame2/blob/main/spec/005-StateMachines.md)
 - [Spec 006 - Reactive Substrate](https://github.com/day8/re-frame2/blob/main/spec/006-ReactiveSubstrate.md)

--- a/docs/EP/resource-queries.md
+++ b/docs/EP/resource-queries.md
@@ -6,9 +6,9 @@ Date: 2026-06-06
 
 Related:
 
-- [Guide 10 - HTTP](../../guide/10-http.md)
-- [Guide 19 - Routing](../../guide/19-routing.md)
-- [Guide 21 - Runtime model](../../guide/21-dynamic-model.md)
+- [Guide 10 - HTTP](../guide/10-http.md)
+- [Guide 19 - Routing](../guide/19-routing.md)
+- [Guide 21 - Runtime model](../guide/21-dynamic-model.md)
 - [Pattern - Remote Data](https://github.com/day8/re-frame2/blob/main/spec/Pattern-RemoteData.md)
 - [Spec 014 - HTTP Requests](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md)
 - [Spec 012 - Routing](https://github.com/day8/re-frame2/blob/main/spec/012-Routing.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -241,10 +241,9 @@ nav:
     - re-frame2-pair-retro: skills/re-frame2-pair-retro.md
 
   - EP:
-    - "Frame State":
-      - "App/Runtime Partition": EP/FrameState/app-db-runtime-partition.md
-    - "Resource Management":
-      - "Resource Queries": EP/ResourceManagement/resource-queries.md
+    - EP/README.md
+    - "App/Runtime Partition": EP/app-db-runtime-partition.md
+    - "Resource Queries": EP/resource-queries.md
 
   - API:
     # Section label IS the API overview page (navigation.indexes, rf2-qgpkm).


### PR DESCRIPTION
@
Flattens `docs/EP/` from two single-child folders into a flat doc set with a `README.md` index. Closes rf2-dlm3ax.

## What changed

- `git mv docs/EP/FrameState/app-db-runtime-partition.md` -> `docs/EP/app-db-runtime-partition.md`
- `git mv docs/EP/ResourceManagement/resource-queries.md` -> `docs/EP/resource-queries.md`
- Removed the now-empty `docs/EP/FrameState` and `docs/EP/ResourceManagement` directories.
- Fixed the relative guide links exposed by the move (files went up one level, so `](../../guide/` -> `](../guide/`): 4 links in `app-db-runtime-partition.md`, 3 in `resource-queries.md`. Absolute `https://github.com/...` spec links left as-is. No `](../../` remains under `docs/EP/`.
- Added `docs/EP/README.md`: EP overview, lifecycle, conventions, an index table of the two EPs, and the EP relationships note.
- Flattened the EP nav block in `mkdocs.yml`, with `EP/README.md` first as the section index (the `navigation.indexes` pattern, matching `- API:` / `api/README.md`).

No EP body content changed beyond the link fixes. `.beads/` untouched.

## Quality gates

- `python -m mkdocs build --strict` from the repo root: **passed** (exit 0, "Documentation built in 7.33 seconds", 0 warnings). The README is in the nav, the flat paths resolve, no broken links.
@