### PR TITLE
feat(xray): host-overridable chart theme default + testbed SVG-export require

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -69,6 +69,31 @@
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens sans-stack mono-stack]]))
 
+;; ---- default chart theme (rf2-az6e2 follow-on) --------------------------
+;;
+;; Xray's surface is dark, so the chart's `:theme` default is `:dark`. It is
+;; held in a module-level atom (rather than a literal `:or` default) so a
+;; host / capture harness can flip the WHOLE chart palette to `:light`
+;; without threading a prop through every call site. The `:or` default in
+;; `Chart` reads this atom, so both render paths (the focused-transition
+;; canvas + the static topology) honour the override. No UI toggle is built
+;; in — this is the seam a future host theme switch (or an off-line capture
+;; run) writes through `set-default-theme!`.
+(defonce ^:private default-chart-theme (atom :dark))
+
+(defn ^:export set-default-theme!
+  "Set the default chart `:theme` (`:dark` / `:light`). Accepts a keyword
+  or its name string (`\"light\"`), so a JS caller (capture harness /
+  page.evaluate) can flip the palette with no CLJS interop. Returns the
+  normalised keyword now in effect. Unknown values fall back to `:dark`."
+  [theme]
+  (let [kw (cond
+             (keyword? theme)          theme
+             (= "light" (str theme))   :light
+             (= "dark"  (str theme))   :dark
+             :else                      :dark)]
+    (reset! default-chart-theme (if (#{:light :dark} kw) kw :dark))))
+
 ;; ---- app-db slots -------------------------------------------------------
 
 (def slot-root
@@ -401,11 +426,13 @@
     :or   {show-after-rings?       true
            show-view-mode-toggle?  true
            show-controls?          true
-           ;; rf2-az6e2 — Xray's surface is dark; pass `:theme :dark`
-           ;; through to the chart. No light/dark toggle UI in this bead
-           ;; (the chart reads the active-theme tokens for real now, so a
-           ;; future host toggle just flips this prop).
-           theme                   :dark
+           ;; rf2-az6e2 — Xray's surface is dark; the chart `:theme`
+           ;; defaults to `@default-chart-theme` (`:dark`). Held in a
+           ;; module-level atom (not a literal) so a host / capture run can
+           ;; flip the WHOLE palette to `:light` via `set-default-theme!`
+           ;; without threading a prop through every call site. An explicit
+           ;; `:theme` prop still wins. No toggle UI is built in.
+           theme                   @default-chart-theme
            testid                  "rf-xray-machine-canvas-host"
            inner-testid            "rf-mv-chart"}}]
   [:div

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -123,6 +123,16 @@
             ;; (`:rf.xray/select-frame`) without the deck reaching into Xray's
             ;; own `:rf/xray` frame.
             [day8.re-frame2-xray.focus :as xray-focus]
+            ;; Capture-enabling require (ai/topology/capture.cjs): pulling
+            ;; the machines-viz export ns onto THIS testbed's build graph
+            ;; exposes `window.day8.re_frame2_machines_viz.export.chart_as_svg`
+            ;; so the off-line capture harness can serialise each rendered
+            ;; chart to SVG alongside the PNG screenshot. The export ns is
+            ;; otherwise only on the standalone-viewer + test build graphs;
+            ;; it is bundle-isolated from production (tools/ never ships in a
+            ;; prod build), and this is a TEST surface, so the extra weight
+            ;; here is inert. Drop this require to opt out of SVG capture.
+            [day8.re-frame2-machines-viz.export]
             [re-frame.testbed.config :as testbed-config]
             [machine-epochs.machines :as machines])
   (:require-macros [re-frame.core :refer [reg-view]]))


### PR DESCRIPTION
Enabler for the xray-vs-stately machine-topology parity work (rf2-npb4jj). Lets the off-line capture harness (`ai/topology/capture.cjs`) render every machine chart in BOTH themes and export SVG, so xray output can be compared side-by-side against the stately.ai reference renderings.

## Changes
- **`machine_canvas.cljs`** — a module-level `default-chart-theme` atom + an exported `set-default-theme!` setter, read as the `Chart` `:theme` `:or` default. Xray still defaults `:dark`; an explicit `:theme` prop still wins. This is the seam a host (or the capture run) flips to `:light` via one `page.evaluate`, instead of threading a prop through every call site. No toggle UI.
- **`machine-epochs` testbed `core.cljs`** — require the machines-viz `export` ns so `chart-as-svg` is reachable on the testbed build for SVG capture. Bundle-isolated from production (`tools/` never ships in a prod build); test surface only; commented as droppable to opt out of SVG capture.

## Notes
- Compile clean (0 warnings).
- **Spec unchanged**: additive host-override seam + a test-surface export require; no documented panel-contract change (Xray remains dark by default).