### PR TITLE
fix(machines-viz): event-node measured dims via getInternalNode so relayout fires (rf2-6v4ci5)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -307,6 +307,24 @@ convergence loop. Self-loops are already dissolved by events-as-nodes
 (a spec self-transition is `state → event-node → state`, two ordinary
 ELK-routed edges), so the renderer-side self-loop fan is fallback-only.
 
+> **rf2-6v4ci5 — measure-read accessor fix (implementation defect, not a
+> behavioural change).** The d9ro2 two-pass relies on reading xyflow's
+> DOM-measured box back per node (`read-measured-dims`). In xyflow v12 that
+> box is merged onto the **internal** node (`instance.getInternalNode(id)
+> .measured`), NOT onto the user-facing `instance.getNodes()` objects — and
+> this non-interactive chart deliberately never syncs dimension changes back
+> into its controlled `:nodes` array, so `getNodes()` always reported
+> `measured = nil`. The read therefore returned an empty map, the relayout
+> gate never reached `ready?`, and the *second* pass **never fired**: every
+> node — leaf states AND event-nodes — laid out at its ELK floor, so a
+> guard- or action-widened event chip (which renders at its true content
+> width, e.g. `door/close IF may-close?` ≈ 148px vs the 96px event floor)
+> overran its floor-spaced same-layer neighbour (`door/hold`). Reading via
+> `getInternalNode` feeds ELK each node's real box, so the documented
+> two-pass behaviour (above) actually takes effect and guarded/long event
+> chips get correctly-spaced slots. General across the corpus — door, gate,
+> hvac all had floor-spacing overlaps that this closes.
+
 ## §3 — Gap analysis + deliberate divergences
 
 ### 3.1 Gaps to close for parity

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -532,13 +532,28 @@
   "rf2-d9ro2 — read xyflow's measured node boxes off a captured
   ReactFlowInstance as a pure CLJS `{node-id {:width :height}}` map.
 
-  xyflow v12 populates `node.measured {width height}` once it has
-  measured each rendered node's DOM box (after React commits + the
-  ResizeObserver fires). `instance.getNodes()` returns the current node
-  array; we keep only nodes that carry a positive measured width AND
-  height — a node still awaiting measurement (measured nil / 0) is
-  omitted, so the `measured-then-relayout` caller can tell whether the
-  WHOLE topology has been measured yet (`= (count dims) (count nodes)`).
+  rf2-6v4ci5 — the measured box lives on the INTERNAL node, reached via
+  `instance.getInternalNode(id)`, NOT on the user-facing `instance
+  .getNodes()` objects. In xyflow v12 the store merges the DOM-measured
+  `{width height}` onto its internal node representation after React
+  commits + the ResizeObserver fires; the user-facing nodes (the array
+  we feed in as a controlled `:nodes` prop, returned unchanged by
+  `getNodes()`) only carry `.measured` when dimension changes are
+  applied back into that array — which this non-interactive chart
+  deliberately does NOT do (positions are ELK-owned). Reading
+  `(.-measured n)` off `getNodes()` therefore always saw nil, so the
+  whole measure-then-relayout pass never reached `ready?` and every node
+  laid out at its ELK floor — guard/action-widened event chips overran
+  their floor-spaced same-layer neighbours (`door/close IF may-close?`
+  over `door/hold`). Reading via `getInternalNode` feeds the REAL
+  rendered box (incl. guard + action row) back to ELK.
+
+  We iterate `getNodes()` for the id set and look each id's measured box
+  up via `getInternalNode`; we keep only ids that carry a positive
+  measured width AND height — a node still awaiting measurement (measured
+  nil / 0) is omitted, so the `measured-then-relayout` caller can tell
+  whether the WHOLE topology has been measured yet
+  (`= (count dims) (count nodes)`).
 
   Public-by-convention as a test seam (mirrors `invoke-fit-view!` /
   `invoke-elk-layout!`): the relayout-lifecycle regression rebinds this
@@ -549,7 +564,8 @@
     (persistent!
       (reduce
         (fn [acc ^js n]
-          (let [m (.-measured n)
+          (let [^js internal (.getInternalNode instance (.-id n))
+                m (some-> internal .-measured)
                 w (and m (.-width m))
                 h (and m (.-height m))]
             (if (and (number? w) (number? h) (pos? w) (pos? h))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/auto_fit_view_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/auto_fit_view_cljs_test.cljs
@@ -376,25 +376,39 @@
 ;; auto-fit lifecycle above is a -cljs-test and not a DOM test.
 
 (defn- fake-instance-with-measured
-  "A stand-in ReactFlowInstance whose `.getNodes()` returns nodes
-  carrying `.measured {width height}` — the shape `read-measured-dims`
-  reads. `node-specs` is a vector of `[id width height]` (width/height
-  nil → that node is still awaiting measurement)."
+  "A stand-in ReactFlowInstance modelling xyflow v12's measured-box shape
+  (rf2-6v4ci5): `.getNodes()` returns the user-facing nodes WITHOUT
+  `.measured` (this non-interactive chart never applies dimension changes
+  back into its controlled `:nodes`, so xyflow leaves the user nodes
+  unmeasured), while `.getInternalNode(id)` returns the INTERNAL node the
+  store merges the DOM-measured `{width height}` onto. `read-measured-dims`
+  must read the latter. `node-specs` is a vector of `[id width height]`
+  (width/height nil → that node is still awaiting measurement, so its
+  internal node carries no `.measured`)."
   [node-specs]
-  #js {:getNodes
-       (fn []
-         (clj->js
-           (mapv (fn [[id w h]]
-                   (cond-> {:id id}
-                     (and w h) (assoc :measured {:width w :height h})))
-                 node-specs)))})
+  (let [internal-by-id (into {}
+                             (map (fn [[id w h]]
+                                    [id (cond-> #js {:id id}
+                                          (and w h)
+                                          (doto (aset "measured"
+                                                      #js {:width w :height h})))]))
+                             node-specs)]
+    #js {:getNodes
+         (fn []
+           ;; User-facing nodes: id only, NO `.measured` — mirrors what
+           ;; getNodes() returns for an unsynced controlled `:nodes` prop.
+           (clj->js (mapv (fn [[id _ _]] {:id id}) node-specs)))
+         :getInternalNode
+         (fn [id] (get internal-by-id id))}))
 
 (deftest read-measured-dims-keeps-only-fully-measured-nodes
-  (testing "rf2-d9ro2 — `read-measured-dims` lifts xyflow's `node.measured`
-            into `{id {:width :height}}`, KEEPING only nodes with a
-            positive measured w AND h. A node still awaiting measurement
-            (measured nil / 0) is omitted so the caller can tell when the
-            whole topology has been measured."
+  (testing "rf2-d9ro2 / rf2-6v4ci5 — `read-measured-dims` lifts xyflow's
+            measured box (read off the INTERNAL node via `getInternalNode`,
+            NOT the user-facing `getNodes()` objects) into
+            `{id {:width :height}}`, KEEPING only nodes with a positive
+            measured w AND h. A node still awaiting measurement (measured
+            nil / 0) is omitted so the caller can tell when the whole
+            topology has been measured."
     (let [inst (fake-instance-with-measured
                  [["idle" 200 60]
                   ["loading" 260 72]


### PR DESCRIPTION
## rf2-6v4ci5 — guarded event chip overlaps neighbour

### Root cause (bead hypothesis was wrong)
The bead guessed the chip was render-time width-constrained to its ELK box. It is not — the chip renders at full content width (148px for `door/close IF may-close?`). The real defect: **the entire rf2-d9ro2 measure-then-relayout pass was dead in production**.

`read-measured-dims` read `node.measured` off `instance.getNodes()`, which is **always nil** in xyflow v12 for this chart. xyflow merges the DOM-measured box onto the **internal** node (`getInternalNode(id).measured`), not the user-facing nodes array (which this non-interactive chart deliberately never syncs dimension changes back into — positions are ELK-owned). So dims was always empty → the relayout gate never reached `ready?` → the second ELK pass never fired → every node laid out at its ELK floor (event floor 96px). With `nodeNode=40` spacing, three same-layer events got uniform 136px slots; the 148px guarded chip overran by 12px flow-space ≈ 7px on-screen overlap with `door/hold`.

### Fix
Read the measured box via `(.getInternalNode instance id)`. Two-line core change; fully general — fixes all guarded/long event-nodes (also was silently broken for leaf states, which happened not to overlap because they stack vertically).

### Verification
- **0 overlaps across all 9 machines** (was: door 7x26px, hvac 1x29px). Re-captured full corpus, both themes.
- machines-viz JVM: 407 tests, 1316 assertions, 0 failures.
- Full cljs node-test (incl. the rf2-d9ro2 relayout-lifecycle + read-measured-dims tests): 5875 tests, 20824 assertions, 0 failures.
- Updated the `read-measured-dims` test fake to model xyflow's real shape (getNodes() without .measured, getInternalNode(id) with it) — the old fake was pinning the bug.
- do-not-touch surfaces (events-as-nodes grammar, IF-guard text, event_node.cljs) untouched.

### Files
- `chart.cljs` (fix + docstring)
- `auto_fit_view_cljs_test.cljs` (fake instance now models real xyflow shape)
- `spec/001-Topology-Parity.md` (rf2-6v4ci5 note in the d9ro2 two-pass passage)