### PR TITLE
chore(http): remove vestigial code (rf2-qpcr18)

### DIFF
--- a/implementation/http/src/re_frame/http_test_support.cljc
+++ b/implementation/http/src/re_frame/http_test_support.cljc
@@ -82,7 +82,6 @@
             [re-frame.http-encoding        :as encoding]
             [re-frame.http-handlers        :as handlers]
             [re-frame.http-machine-wrapper :as machine-wrapper]
-            [re-frame.http-middleware      :as middleware]
             [re-frame.late-bind            :as late-bind]
             [re-frame.router               :as router]))
 


### PR DESCRIPTION
Vestigial-code review of `implementation/http` (managed-HTTP, Spec 014) per **rf2-qpcr18**.

## Finding

One genuine vestige: `re-frame.http-test-support` carried a dead `[re-frame.http-middleware :as middleware]` require — the `middleware/` alias has **zero** qualified references in the file. It was left behind by the rf2-lwmgw stub-macro consolidation, where the canned-reply tail moved to reach the chain through `machine-wrapper/run-request-chain` instead of `http-middleware` directly. Removed.

Everything else in the slice was reviewed and is clean:
- No `#_` reader-discard forms, no commented-out code blocks (the 40 raw "legacy/superseded/remove…" signals are all explanatory contract prose, e.g. the request-id-superseded/abort text and "pre-alpha, no back-compat" notes documenting the *absence* of vestige).
- All other `:require`s are used (verified per-file).
- The multi-arities flagged as "legacy" (`classify-jvm-error` 1/2-arity, `clear-in-flight!` 1/2-arg) are live behavioural contracts with dedicated tests — kept.
- The "public for direct test assertion only" privacy/url/encoding helpers (`redact-url`, `redact-failure`, `redact-request-tags`, `stamp-sensitive`, `valid-accept-return?`, `default-backoff`, `binary-read-kind`, `content-type-of`) are all exercised by tests — kept.
- Every `re-frame.http-managed` re-export is consumed by tests or the late-bind table.
- The canned-stub test-support surface is the only stub path — no dead duplicate.
- No orphaned files, no stray `*.spec.cjs`/backup files.

## Quality gates

- `clojure -M:test` (implementation/http, JVM): **374 tests, 1695 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5899 tests, 20926 assertions, 0 failures, 0 errors**

Refs rf2-qpcr18.