### PR TITLE
chore(adapters): remove vestigial code (rf2-jgvxeq)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.clj
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.clj
@@ -23,8 +23,7 @@
   `defn`s (the classification logic is pure-data), so any macro that
   wants to amortise the runtime detection — `re-frame.core/reg-view`
   or otherwise — can call them directly. No CLJS-side runtime code
-  lives in this ns."
-  (:refer-clojure :exclude [fn?]))
+  lives in this ns.")
 
 ;; ---------------------------------------------------------------------------
 ;; Compile-time form classification

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.clj
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.clj
@@ -12,8 +12,7 @@
       10x / Dash8 / rf8 (per §2.3 \"Symbols not shipped\" list).
 
   No CLJ-side runtime code lives here; only the macros consumed by CLJS
-  build sites via `:require-macros`."
-  (:refer-clojure :exclude [run!]))
+  build sites via `:require-macros`.")
 
 (defmacro reaction
   "Sugar for (make-reaction (fn [] body)). The body executes inside a

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
@@ -7,7 +7,7 @@
     Protocols:  IReactiveAtom, IDisposable
     Functions:  atom, make-reaction, dispose!, add-on-dispose!,
                 reactive?, flush!
-    Macros:     reaction, run!  (in reagent2/ratom.clj)
+    Macros:     reaction  (in reagent2/ratom.clj)
 
   Symbols deliberately NOT shipped (audit-confirmed zero usage across
   re-com / 10x / Dash8 / rf8 — see IMPL-SPEC §2.3 + §2.3a):
@@ -48,7 +48,7 @@
   on each commit boundary to drain the reactive queue synchronously.
   ratom itself never names `batching` — the edge is one-way (batching
   → ratom), keeping this ns DOM/component-free."
-  (:refer-clojure :exclude [atom run!])
+  (:refer-clojure :exclude [atom])
   (:require-macros [reagent2.ratom])
   (:require [clojure.set :as set]))
 


### PR DESCRIPTION
Vestigial-code review of `implementation/adapters/` (bead **rf2-jgvxeq**). Reviewed all six sub-adapters: reagent / reagent-slim / uix / helix / test-react / testbed.

## Quality gates
- `npm run test:cljs` — **5899 tests / 20926 assertions, 0 failures, 0 errors**.
- `npm run test:reagent-slim:bundle-isolation` — **PASS** (4 contracts, 21 sentinel checks; slim bundle still free of stock reagent / react-dom / react-dom-server).

## Per-substrate findings

**reagent-slim — the only real vestige (removed):** a planned-then-dropped `run!` macro left residue across the `reagent2.*` macro nses.
- `reagent2/ratom.cljs` header claimed `Macros: reaction, run!  (in reagent2/ratom.clj)`, but the `.clj` macro file ships no `run!` macro — its own docstring states "`run!` is NOT shipped — audit-confirmed zero usage." Removed the stale claim and dropped `run!` from `(:refer-clojure :exclude [atom run!])`.
- `reagent2/ratom.clj` carried `(:refer-clojure :exclude [run!])` while defining only the `reaction` macro. Removed (kept the negative-space docstring note documenting the deliberate absence).
- `reagent2/impl/component.clj` carried `(:refer-clojure :exclude [fn?])` but never defines or references `fn?`; the `.cljs` sibling uses `clojure.core/fn?` and must NOT exclude it. Removed.

No `:require` changes, so bundle isolation is unaffected by construction. The `reagent.ratom/run!` references in the stock-Reagent adapter tests are stock Reagent's real macro, unrelated to `reagent2`.

**reagent / uix / helix / test-react / testbed — reviewed, clean.** No dead defs, no unused requires, no orphaned files, no commented-out blocks, no back-compat shims. The Class B throw-on-call shims (`reagent2.dom`, `reagent2.core/render`+`dom-node`) and the "Symbols NOT shipped" docstring lists are deliberate React-19-floor design (per `DESIGN-RATIONALE.md` §3/§8 + `FORM-3.md`), not vestige — they are absence documented as prose, exactly the caveat the bead flagged. The single `#_:clj-kondo/ignore` in `reagent2/ratom.cljs` is a legitimate linter directive, not a discarded form.

Closes work for **rf2-jgvxeq**.