### PR TITLE
chore(core): remove vestigial code (rf2-rsw7no)

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -109,7 +109,7 @@
 
   Internal helper; exposed (with `^:no-doc`) so the sibling
   `re-frame.marks` ns — which mutates the SAME slot from its
-  `add-marks` / `set-marks` / `clear-app-db-marks!` / `write-marks!`
+  `add-marks` / `set-marks` / `clear-app-db-marks!`
   paths — can share a single source of truth for the read-transform-
   write skeleton. Not part of the public API."
   [frame-id f]

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -188,21 +188,6 @@
           (or existing {})
           paths))
 
-(defn- write-marks!
-  "Apply the new `sensitive-decls` / `large-decls` maps to the frame's
-  app-db elision registry, preserving the rest of the
-  `[:rf/runtime :elision]` slot. Empty maps drop the slot key entirely.
-  If the resulting `[:rf/runtime :elision]` map is empty, the slot is
-  dissoc'd from `:rf/runtime`."
-  [frame-id sensitive-decls large-decls]
-  (elision/swap-elision-slot! frame-id
-    (fn [reg]
-      (cond-> (or reg {})
-        (seq sensitive-decls)    (assoc :sensitive-declarations sensitive-decls)
-        (empty? sensitive-decls) (dissoc :sensitive-declarations)
-        (seq large-decls)        (assoc :declarations large-decls)
-        (empty? large-decls)     (dissoc :declarations)))))
-
 (defn add-marks
   "Additively merge path-marks into the `app-db` mark-set of `frame-id`.
   Per Spec 015 §App-db marks (per frame).

--- a/implementation/core/src/re_frame/source_coords/editor_uri.cljc
+++ b/implementation/core/src/re_frame/source_coords/editor_uri.cljc
@@ -225,12 +225,6 @@
     (when-let [scheme (uri-scheme uri)]
       (contains? allowed-editor-uri-schemes scheme))))
 
-(def ^:private default-editor
-  "Default editor when no `:editor` config key is set. VS Code is the
-  most-installed editor in 2026 (Stack Overflow Developer Survey 2025
-  + JetBrains DevEcosystem 2025 both put it >70%)."
-  :vscode)
-
 ;; ---- pure: source-coord normalisation -----------------------------------
 
 (defn- coord-line

--- a/implementation/core/src/re_frame/subs/tooling.cljc
+++ b/implementation/core/src/re_frame/subs/tooling.cljc
@@ -25,8 +25,7 @@
   §Subscription topology vs subscription tracking."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]))
+            [re-frame.interop :as interop]))
 
 #?(:clj (set! *warn-on-reflection* true))
 


### PR DESCRIPTION
Vestigial-code review of `implementation/core` (rf2-rsw7no). Conservative pass — core is foundational, consumed by everything; only removed with strong evidence of non-use (`git grep` across the entire repo: impl artefacts, tools, examples, skills, tests).

## Removed (3 dead-code items, all non-facade internal namespaces)

- **marks** — unused private `write-marks!` helper. Its two would-be callers (`add-marks`, `set-marks`) inline the same `swap-elision-slot!` cond-> directly; the helper had zero callers repo-wide. Synced the `swap-elision-slot!` docstring in `elision` that listed it.
- **source-coords/editor-uri** — unused `^:private default-editor` def (`:vscode`). The editor-URI cond's `:else` branch inlines `vscode-uri` as the default; the def was never referenced. (The Xray `default-editor-is-vscode` test checks Xray's own `config/get-editor`, not this def.)
- **subs/tooling** — unused `[re-frame.late-bind :as late-bind]` require (no `late-bind/` call in the ns; the hook-table defonce is established by its many other consumers).

## Kept (intentional, not vestige)

- The public `re-frame.core` facade exports — contract surface per spec/API.md.
- `router-transducer` — deliberate, documented Phase-1 reference scaffold for the v1.1 transducer-router design (rf2-cl8me, backed by `spec/Design-TransducerRouter.md`); explicitly "NOT wired into the live runtime."
- The two `#_:clj-kondo/ignore` reader-discards (test_helpers, boot_test) — legitimate linter directives.
- `re-frame.core` requiring `re-frame.substrate.plain-atom` (alias unused, but flagged not removed — see below).
- The `re-frame.spec` ns-name "back-compat alias" note — a rename decision, not dead code; out of scope for a vestige sweep.

## Flagged (not actioned — left for a maintainer decision)

- `implementation/core/src/re_frame/core.cljc:75` requires `[re-frame.substrate.plain-atom :as plain-atom]` but the alias is never used. The ns has a CLJS load-time `route-hook!` side-effect; CLJS-plain-atom hosts require the ns themselves to get `adapter`, so the facade require may be redundant — but removing a require from the foundational facade is high-blast-radius for negligible benefit. Left in place.

## Quality gates

- core JVM `clojure -M:test`: **916 tests, 4120 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (full node suite): **5899 tests, 20926 assertions, 0 failures, 0 errors**