### PR TITLE
chore(epoch): remove vestigial code (rf2-mvuryn)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -259,7 +259,7 @@
   vector, or nil when absent (evicted, or the epoch never landed). The
   one shared 'where is this epoch in the ring?' primitive — the
   back-fills `assoc` at the returned index, and `render-key-already-in-
-  epoch?` reuses it for its record lookup. `write/find-epoch-in` answers
+  epoch?` reuses it for its record lookup. `tool-pair/find-epoch-in` answers
   the sibling 'give me the record' question off a deref'd history."
   [history epoch-id]
   (some (fn [i]


### PR DESCRIPTION
Vestigial-code review of `implementation/epoch` (rf2-mvuryn). Low-signal slice as predicted — the source is clean, heavily documented, every def referenced. One in-slice removal plus one flagged cross-cutting finding.

## Change

- `epoch/state.cljc` `epoch-index` docstring cited `write/find-epoch-in`. The `.write` namespace was renamed to `.tool-pair` (rf2-dga99); the cross-reference was left behind. Repointed to `tool-pair/find-epoch-in`. (Renamed-surface remnant per the review checklist.)

## Quality gates

- `clojure -M:test` (implementation/epoch): **276 tests, 1066 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5899 tests, 20926 assertions, 0 failures, 0 errors**

## Flagged (NOT actioned — cross-slice / hot-zone, needs a sequenced follow-up bead)

**Orphaned `:epoch/discard-buffer!` hook.** The private `discard-buffer!` (epoch.cljc:402) and its late-bind publication (`:epoch/discard-buffer!`, epoch.cljc:630) have **no runtime invoker anywhere in the repo** (verified by `git grep`). Its own docstring concedes "the fn itself takes no direct callers" and claims it "remains for the destroy-hook belt-and-braces path" — but `on-frame-destroyed!` (listeners.cljc:374) clears the buffer via `state/drop-frame-buffer!` directly and never routes through this hook. The router's halt paths were rerouted through `settle!` (rf2-v0jwt). The retention rationale is stale; this looks like a genuine vestige.

Not removed here because a clean removal spans hot-zone / shared files outside this slice:
- `implementation/core/src/re_frame/late_bind/directory.cljc` (directory entry, shared core)
- `spec/Conventions.md` (hot-zone — artefact-surface table lists the hook)
- `migration/from-re-frame-v1/README.md` (hot-zone)
- stale "the router calls discard-buffer!" comments in `implementation/core` tests

Recommend a sequenced follow-up bead to drop the hook + the four references together.