### PR TITLE
chore(story-mcp): remove vestigial code (rf2-p9zqpv)

### DIFF
--- a/tools/story-mcp/README.md
+++ b/tools/story-mcp/README.md
@@ -91,7 +91,7 @@ tools/story-mcp/
         ├── result.cljc                           ; result-envelope builders (pr-edn, text-result, error-result)
         ├── args.cljc                             ; arg readers + bounded-allowlist coercions (with-variant, read-run-opts, include-sensitive?)
         ├── cljs_resolve.cljc                     ; cross-platform CLJS var resolution (registered-substrates)
-        ├── egress.cljc                           ; wire-egress scrubbers (elide-app-db, scrub-assertions, scrub-rendered)
+        ├── egress.cljc                           ; wire-egress scrubbers (elide-app-db, scrub-assertions+count, scrub-rendered)
         ├── schemas.cljc                          ; recurring JSON-schema fragments
         ├── dev.cljc                              ; get-story-instructions, preview-variant, list-substrates
         ├── docs.cljc                             ; list-stories, get-story, get-variant, list-tags, list-modes, list-decorators, list-assertions, variant->edn, get-docs-markdown

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
@@ -32,7 +32,7 @@
   STRUCTURE slots) is intentionally public and NOT scrubbed; see
   `scrub-frame-value` for the runtime-vs-authored split.
 
-  ## Path-based redaction (`elide-app-db`, `scrub-assertions`)
+  ## Path-based redaction (`elide-app-db`, `scrub-assertions+count`)
 
   Apply the cross-MCP privacy-posture rules to every live `:app-db`
   slice and assertion accumulator before egress. Off-box defaults
@@ -147,14 +147,6 @@
     include?       [(vec (or records [])) 0]
     (nil? records) [[] 0]
     :else          (sensitive/strip-sensitive records false)))
-
-(defn scrub-assertions
-  "Kept-vec-only projection of `scrub-assertions+count` — the historical
-  signature for call sites that don't surface the dropped count. New
-  egress paths SHOULD prefer `scrub-assertions+count` and thread the
-  count onto the envelope via `with-indicators` (rf2-koq5m)."
-  [records include?]
-  (first (scrub-assertions+count records include?)))
 
 ;; ---------------------------------------------------------------------------
 ;; Derived-tree value-based redaction (rf2-ee38b.17)


### PR DESCRIPTION
Vestigial-code review of `tools/story-mcp` (rf2-p9zqpv).

## Finding

One genuine vestige: `egress/scrub-assertions` — a dead back-compat wrapper.

- Introduced by the rf2-koq5m egress-indicator fix (commit `fc32433aa`) as a "historical signature for call sites that don't surface the dropped count". That same commit rewired every live caller to `scrub-assertions+count`.
- Zero callers in `src` (all three handlers — preview-variant / run-variant / read-failures — use `scrub-assertions+count`).
- Zero references in the test corpus.
- Its own docstring directs new paths to `+count`.

Pre-alpha = no shim, so the wrapper is removed. The two stale prose references that named it (egress.cljc ns-docstring section heading, README leaf map) are refreshed to the live `scrub-assertions+count`.

## Scope confirmed clean (no change)

- `#_` reader-discards: none. Commented-out code blocks: none (all `;;` lines are prose).
- Orphaned files: none — all 18 src files are on the require graph; both test fixtures (`tool-names.json`, `stdio-roundtrip.js`) are referenced.
- All other public defs verified live (protocol error helpers, cursor/dedup/egress/args helpers all have callers).
- Egress "kept for" prose + run-result-roundtrip "no shim" text + the retired-`:passing?`/removed-`:play` mentions are intentional prose documenting the *absence* of vestige — left as-is per the brief.
- Wire surface unchanged: descriptor manifest in sync (20 tools), no tool added/removed/renamed.

## Quality gates

- `clojure -M:test` — 249 tests, 1206 assertions, 0 failures, 0 errors.
- `clojure -M:gen --check` — OK: tool-descriptors.edn in sync (20 tools).
- mcp-conformance not run: wire surface unchanged (removed fn was never on the wire).