### PR TITLE
docs(skills/re-frame2-pair): remove vestigial guidance (rf2-mco6j8)

### DIFF
--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -221,7 +221,7 @@ re-frame2 supports multiple, named frames (Spec 002). Most apps run with one app
 
 These three are NOT subject to the `:ambiguous-frame` refusal themselves — they are how you *resolve* the ambiguity. (The eval-based `frames-list` / `select-frame!` / `frames-meta` runtime helpers in [references/ops.md §Frames](references/ops.md#frames) are the lower-level surface the tools wrap; reach for them only for `frames/meta`, which has no dedicated tool.)
 
-When the operating frame is ambiguous (two-plus **app** frames registered and the session hasn't pinned one), **every other frame-targeted op refuses with `:ambiguous-frame`** rather than guess — a write that lands in the wrong frame is unrecoverable without `restore-epoch`. (Read ops via the eval helpers warn-and-default to `:rf/default`; the dedicated `snapshot` / `get-path` tools refuse like the writes do.) This mirrors the Spec 002 §Frame presets / lifecycle convention.
+When the operating frame is ambiguous (two-plus **app** frames registered and the session hasn't pinned one), **every other frame-targeted op refuses with `:ambiguous-frame`** rather than guess — a write that lands in the wrong frame is unrecoverable without `restore-epoch`. Reads refuse too: the validated read helpers (`subs-sample`, `read-sub!`, `sub-cache-info`, …) return `:reason :ambiguous-frame` rather than silently reading `:rf/default`, and the dedicated `snapshot` / `get-path` tools refuse like the writes do. This mirrors the Spec 002 §Frame presets / lifecycle convention.
 
 ---
 

--- a/skills/re-frame2-pair/docs/LOCAL_DEV.md
+++ b/skills/re-frame2-pair/docs/LOCAL_DEV.md
@@ -185,7 +185,7 @@ The app hasn't called `(rf/init!)` yet (or the only frame was destroyed). Wait f
 
 ### `:ambiguous-frame`
 
-Two-plus app frames are registered and the session hasn't pinned one. Pin one with `set-operating-frame {frame: ":foo"}`, or pass `frame: ":foo"` per call. The dedicated `snapshot` / `get-path` / `dispatch` tools refuse rather than guess; the lower-level eval helpers warn-and-default to `:rf/default`.
+Two-plus app frames are registered and the session hasn't pinned one. Pin one with `set-operating-frame {frame: ":foo"}`, or pass `frame: ":foo"` per call. Both writes and reads refuse rather than guess: the dedicated `snapshot` / `get-path` / `dispatch` tools refuse, and the lower-level read helpers (`subs-sample` / `read-sub!` / `sub-cache-info`) return `:reason :ambiguous-frame` rather than silently reading `:rf/default`.
 
 ### Watch ops don't stream anything
 

--- a/skills/re-frame2-pair/docs/capabilities.md
+++ b/skills/re-frame2-pair/docs/capabilities.md
@@ -85,7 +85,7 @@ What re-frame2-pair can see inside a live re-frame2 app.
 |---|---|---|
 | `reset-frame-db` is logged via `tap>` and `--allow-writes`-gated | *done* | Previous + next + timestamp are tap'd so the human sees the change. Delegates to `rf/reset-frame-db!` (Tool-Pair §Pair-tool writes) so the synthetic `:rf.epoch/db-replaced` record is appended and `restore-epoch` can rewind past the injection. The tool is OFF unless the server is launched with `--allow-writes`. |
 | `eval-cljs` treated as full-authority | *guardrail* | Default-ON (opt out with `--no-eval`); SKILL.md instructs Claude to prefer the structured tools, and flags that `eval-cljs` returns its value un-elided and is not governed by `--allow-sensitive-reads` |
-| Mutating ops refuse on `:ambiguous-frame` | *done* | The structured `snapshot` / `get-path` / `dispatch` tools refuse; the lower-level eval helpers warn-and-default to `:rf/default` |
+| Ops refuse on `:ambiguous-frame` | *done* | Both writes and reads refuse rather than guess: the structured `snapshot` / `get-path` / `dispatch` tools refuse, and the lower-level read helpers (`subs-sample` / `read-sub!` / `sub-cache-info`) return `:reason :ambiguous-frame` rather than silently reading `:rf/default` |
 | Watches and background processes always stop cleanly | *done* | Auto-terminate on disconnect, idle (default 30s), hard-cap (default 5min), or count cap (default 5) |
 | Restore-failure traces are structured | *done* | Seven `:rf.epoch/*` operations with `:tags` — Tool-Pair contract |
 | Time-travel rewinds app-db only — surface limit | *guardrail* | SKILL.md style guidance + recipe text |

--- a/skills/re-frame2-pair/docs/initial-spec.md
+++ b/skills/re-frame2-pair/docs/initial-spec.md
@@ -222,7 +222,7 @@ Four surfaces — see `docs/TESTING.md`.
 
 - **No re-frame-10x dependency.** Every 10x reach has been replaced with a re-frame2 Tool-Pair surface. See `SKILL.md`'s "Dropped from v1" section for the exhaustive substitution table.
 - **First-class time-travel.** `restore-epoch` is shipped by re-frame2; no adapter, no stubs, seven documented failure modes.
-- **Multi-frame.** Every op carries an operating-frame concept; reads use `:rf/default` when unambiguous; mutating ops refuse on `:ambiguous-frame`.
+- **Multi-frame.** Every op carries an operating-frame concept; the operating frame resolves to the sole registered app frame when unambiguous; both reads and writes refuse on `:ambiguous-frame` (reads return `:reason :ambiguous-frame` rather than silently reading `:rf/default`).
 - **Origin tagging.** Pair dispatches carry `:origin :pair` so they can be filtered out of a trace stream that also carries `:app` / `:ui` / `:timer` / `:http` events.
 - **Render projection consumed verbatim.** `:renders` and `:sub-runs` are projected by re-frame2 itself; no re-com classifier in the runtime (Spec-Schemas owns the projection shape).
 - **Source-coord bridge takes re-frame2's annotation first, re-com's as a fallback.**

--- a/skills/re-frame2-pair/scripts/discover-app.sh
+++ b/skills/re-frame2-pair/scripts/discover-app.sh
@@ -4,8 +4,11 @@
 # structured edn result. (The runtime ships via shadow-cljs :devtools
 # :preloads; there is no per-session inject step — see SKILL.md §Setup.)
 #
-# DEPRECATED: prefer the MCP tool `discover-app` from
-# `@day8/re-frame2-pair-mcp` (tools/re-frame2-pair-mcp/). Kept for back-compat.
+# RETIRED from the skill's tool surface: the skill drives `discover-app`
+# via the MCP server (`@day8/re-frame2-pair-mcp`, tools/re-frame2-pair-mcp/),
+# the only skill-facing transport. This shim is on disk only for the
+# project's own test harness (tests/shim/, tests/e2e/) and ad-hoc shell
+# use outside the skill — NOT a skill-facing fallback transport.
 #
 # Usage:
 #   scripts/discover-app.sh [--build=app]

--- a/skills/re-frame2-pair/scripts/dispatch.sh
+++ b/skills/re-frame2-pair/scripts/dispatch.sh
@@ -2,8 +2,11 @@
 # dispatch.sh — fire a re-frame2 event in the connected app, tagged
 # with :origin :pair (Spec 002 §Dispatch origin tagging).
 #
-# DEPRECATED: prefer the MCP tool `dispatch` from
-# `@day8/re-frame2-pair-mcp` (tools/re-frame2-pair-mcp/). Kept for back-compat.
+# RETIRED from the skill's tool surface: the skill drives `dispatch`
+# via the MCP server (`@day8/re-frame2-pair-mcp`, tools/re-frame2-pair-mcp/),
+# the only skill-facing transport. This shim is on disk only for the
+# project's own test harness (tests/shim/, tests/e2e/) and ad-hoc shell
+# use outside the skill — NOT a skill-facing fallback transport.
 #
 # Default mode is queued dispatch (`rf/dispatch`).
 # --sync  forces `rf/dispatch-sync` for deterministic before/after.

--- a/skills/re-frame2-pair/scripts/eval-cljs.sh
+++ b/skills/re-frame2-pair/scripts/eval-cljs.sh
@@ -2,11 +2,13 @@
 # eval-cljs.sh — evaluate a ClojureScript form in the connected browser
 # runtime via shadow-cljs's cljs-eval. Prints edn on stdout.
 #
-# DEPRECATED: prefer the MCP tool `eval-cljs` from
-# `@day8/re-frame2-pair-mcp` (tools/re-frame2-pair-mcp/). The MCP server holds
-# one persistent nREPL connection per session and drops per-op latency
-# from ~700ms to ~5-50ms. This bash shim is kept for back-compat with
-# sessions where the MCP server isn't configured.
+# RETIRED from the skill's tool surface: the skill drives `eval-cljs`
+# via the MCP server (`@day8/re-frame2-pair-mcp`, tools/re-frame2-pair-mcp/),
+# the only skill-facing transport. The MCP server holds one persistent
+# nREPL connection per session and drops per-op latency from ~700ms to
+# ~5-50ms. This shim is on disk only for the project's own test harness
+# (tests/shim/, tests/e2e/) and ad-hoc shell use outside the skill — NOT
+# a skill-facing fallback transport.
 #
 # Usage:
 #   scripts/eval-cljs.sh '(+ 1 2)' [--build=app]

--- a/skills/re-frame2-pair/scripts/ops.clj
+++ b/skills/re-frame2-pair/scripts/ops.clj
@@ -10,17 +10,18 @@
 ;;;; that exec's `bb ops.clj <subcommand> [args...]` and forwards the edn
 ;;;; printed on stdout.
 ;;;;
-;;;; Transport status — bash-shim is the **legacy / fallback** transport.
-;;;; The structural successor is the persistent-connection MCP server in
-;;;; `tools/re-frame2-pair-mcp/`, which holds a single nREPL connection per session
-;;;; (~14× faster than the per-call connect/disconnect this file performs).
-;;;; Keep the shims for ad-hoc shell scripting, CI scripts, or when the
-;;;; MCP server isn't configured in the agent host. Op semantics are
-;;;; identical between transports — see
+;;;; Transport status — the bash-shim is **retired from the skill's tool
+;;;; surface** (the `allowed-tools:` frontmatter carries no shell tool, so
+;;;; an agent cannot run it). It is NOT a skill-facing fallback transport.
+;;;; The MCP server in `tools/re-frame2-pair-mcp/` is the only skill-facing
+;;;; transport; it holds a single nREPL connection per session (~14× faster
+;;;; than the per-call connect/disconnect this file performs). These shims
+;;;; remain on disk only for the project's own test harness (`tests/shim/`,
+;;;; `tests/e2e/`) and ad-hoc shell use OUTSIDE the skill. Op semantics are
+;;;; identical between the shim and the MCP surface — see
 ;;;; `skills/re-frame2-pair/references/ops.md` for the full op catalogue
-;;;; (MCP form in the Invocation column; bash-shim forms in the
-;;;; back-compat appendix) and `references/mcp-transport.md` for the MCP
-;;;; surface.
+;;;; (MCP form in the Invocation column; the shim mapping in the harness
+;;;; appendix) and `references/mcp-transport.md` for the MCP surface.
 ;;;;
 ;;;; Subcommands (each maps 1:1 to a shim under `scripts/`)
 ;;;; -----------------------------------------------------
@@ -52,7 +53,7 @@
 ;;;;   here that calls it via `cljs-eval-value`. Document in
 ;;;;   `references/ops.md`. The runtime is the source of truth.
 ;;;; - **Bash-only flag tweak** (new `--foo` on an existing subcommand):
-;;;;   inline it here, update `references/ops.md` back-compat appendix.
+;;;;   inline it here, update the `references/ops.md` harness appendix.
 ;;;; - **Anything else** (new transport, new wire format, new shim):
 ;;;;   probably belongs in `tools/re-frame2-pair-mcp/` rather than another shim.
 ;;;;

--- a/skills/re-frame2-pair/scripts/tail-build.sh
+++ b/skills/re-frame2-pair/scripts/tail-build.sh
@@ -2,8 +2,11 @@
 # tail-build.sh — coordinate with shadow-cljs hot-reload after a source
 # edit.
 #
-# DEPRECATED: prefer the MCP tool `tail-build` from
-# `@day8/re-frame2-pair-mcp` (tools/re-frame2-pair-mcp/). Kept for back-compat.
+# RETIRED from the skill's tool surface: the skill drives `tail-build`
+# via the MCP server (`@day8/re-frame2-pair-mcp`, tools/re-frame2-pair-mcp/),
+# the only skill-facing transport. This shim is on disk only for the
+# project's own test harness (tests/shim/, tests/e2e/) and ad-hoc shell
+# use outside the skill — NOT a skill-facing fallback transport.
 #
 # --wait-ms N       how long to wait for the reload to land (default 5000)
 # --probe '<form>'  a CLJS form whose return value changes after the edit is

--- a/skills/re-frame2-pair/scripts/trace-window.sh
+++ b/skills/re-frame2-pair/scripts/trace-window.sh
@@ -2,8 +2,11 @@
 # trace-window.sh — return epochs added to the operating frame's
 # epoch-history in the last N ms.
 #
-# DEPRECATED: prefer the MCP tool `trace-window` from
-# `@day8/re-frame2-pair-mcp` (tools/re-frame2-pair-mcp/). Kept for back-compat.
+# RETIRED from the skill's tool surface: the skill drives `trace-window`
+# via the MCP server (`@day8/re-frame2-pair-mcp`, tools/re-frame2-pair-mcp/),
+# the only skill-facing transport. This shim is on disk only for the
+# project's own test harness (tests/shim/, tests/e2e/) and ad-hoc shell
+# use outside the skill — NOT a skill-facing fallback transport.
 #
 # Usage:
 #   scripts/trace-window.sh 3000           # last 3 seconds of epochs

--- a/skills/re-frame2-pair/scripts/watch-epochs.sh
+++ b/skills/re-frame2-pair/scripts/watch-epochs.sh
@@ -2,10 +2,13 @@
 # watch-epochs.sh — pull-mode live watch of the operating frame's
 # epoch-history.
 #
-# DEPRECATED: prefer the MCP tool `watch-epochs` from
-# `@day8/re-frame2-pair-mcp` (tools/re-frame2-pair-mcp/). The MCP tool returns
-# one bundle of matches per call (pull-mode); call it repeatedly with
-# the same `since-id` for a tight watch loop. Kept for back-compat.
+# RETIRED from the skill's tool surface: the skill drives `watch-epochs`
+# via the MCP server (`@day8/re-frame2-pair-mcp`, tools/re-frame2-pair-mcp/),
+# the only skill-facing transport. The MCP tool returns one bundle of
+# matches per call (pull-mode); call it repeatedly with the same
+# `since-id` for a tight watch loop. This shim is on disk only for the
+# project's own test harness (tests/shim/, tests/e2e/) and ad-hoc shell
+# use outside the skill — NOT a skill-facing fallback transport.
 #
 # Emits one edn line per matching epoch, plus a final {:finished?} summary.
 #

--- a/skills/re-frame2-pair/spec/authoring-prompt.md
+++ b/skills/re-frame2-pair/spec/authoring-prompt.md
@@ -54,7 +54,7 @@ A self-contained prompt that re-authors the `re-frame2-pair` skill from this `sp
 > *2. **No re-frame-10x dependency** — time-travel and trace consumption ride on `register-listener!` / `register-epoch-listener!` / `epoch-history` / `restore-epoch`.*
 > *3. **Connect first, every session** — `discover-app` before any op. Failures return structured edn; report verbatim, don't improvise workarounds.*
 > *4. **Two modes of changing the app** — REPL changes ephemeral; source edits permanent (must `hot-reload/wait` after).*
-> *5. **Multi-frame model** — mutating ops refuse with `:ambiguous-frame` if more than one frame is registered and none selected. Read ops fall back to `:rf/default` after warning.*
+> *5. **Multi-frame model** — ops refuse with `:ambiguous-frame` if more than one app frame is registered and none selected. Reads refuse too — the read helpers return `:reason :ambiguous-frame` rather than silently reading `:rf/default`.*
 > *6. **One trace listener and one epoch listener** under `:re-frame2-pair` / `:re-frame2-pair-epoch`. Multi-tool coexistence is the expected default.*
 > *7. **Use the assembled epoch stream by default; reach for the raw trace stream when the projection drops detail.***
 > *8. **Read before you write** — ground a hypothesis in a snapshot / epoch / sub-run before proposing a change.*

--- a/skills/re-frame2-pair/spec/design.md
+++ b/skills/re-frame2-pair/spec/design.md
@@ -55,7 +55,7 @@ Before any op, `discover-app` runs. This locates the nREPL port, connects, verif
 
 ### L6 — Multi-frame model, operating-frame selection
 
-re-frame2 apps may run multiple named frames (Spec 002). The session caches an operating frame; mutating ops refuse with `:ambiguous-frame` if more than one frame is registered and none selected. Read ops proceed against `:rf/default` after warning. This matches Spec 002 §Frame-presets / lifecycle convention.
+re-frame2 apps may run multiple named frames (Spec 002). The session caches an operating frame; ops refuse with `:ambiguous-frame` if more than one app frame is registered and none selected. Read ops refuse too — the read helpers return `:reason :ambiguous-frame` rather than silently reading `:rf/default`. This matches Spec 002 §Frame-presets / lifecycle convention.
 
 ### L7 — One trace listener and one epoch listener per skill
 


### PR DESCRIPTION
## Quality gates

- `bb tests/prompts/prompt_regression_test.clj` — 19 tests, 72 assertions, 0 failures.
- `bb tests/shim/shim_test.clj` — 11 tests, 43 assertions, 0 failures.
- `bb tests/runtime/multi_frame_test.clj` — 23 tests, 39 assertions, 0 failures (sanity; multi-frame contract unchanged).
- Comment/prose-only changes; no behaviour change.

## Findings

Vestigial-code review of `skills/re-frame2-pair/` (70 files). The bash-shim *lineage history*, the `spec/` provenance meta-docs, and the MCP-primary narrative are all intentional and were left in place. No orphaned files, no `#_`-discarded forms, no commented-out code blocks, no dead vars. Two concrete vestiges that would actually mislead an agent or maintainer today were found and fixed:

**1. Bash-shim self-classification drift.** The shim headers (`scripts/ops.clj` + all six `*.sh` wrappers) still described themselves as a "legacy / fallback transport" "kept for back-compat ... when the MCP server isn't configured." The rf2-ojo3z review retired the shims from the skill's tool surface and reclassified them as a **retained test harness only** (explicitly *not* a skill-facing fallback transport). Every other doc already reflects the settled classification — README, `references/ops.md`, `references/mcp-transport.md`, `docs/initial-spec.md`, `docs/TESTING.md` (test-guarded: "retained harness" + "only skill-facing transport"), `docs/LOCAL_DEV.md`, `spec/inputs.md`, `spec/design.md` L3. Only the script headers lagged. Aligned them.

**2. Stale `:rf/default` default-read claim** (the frame-target EP audit flag). Five docs claimed read ops "warn-and-default to `:rf/default`" / "fall back to `:rf/default` after warning" in an ambiguous multi-frame session. The actual runtime (`preload/re_frame2_pair/runtime.cljs` — `current-frame`, `subs-sample`, `read-sub!`, `sub-cache-info`) **refuses with `:reason :ambiguous-frame`** and never silently reads `:rf/default`. `tests/runtime/multi_frame_test.clj` asserts exactly that ("must NOT silently fall back to :rf/default") and even cites `capabilities.md:88` as a contract source it contradicted. Corrected `SKILL.md`, `docs/capabilities.md`, `docs/LOCAL_DEV.md`, `docs/initial-spec.md`, `spec/design.md`, `spec/authoring-prompt.md`. This is a targeted correctness-drift fix, not a frame-model rewrite.

Closes rf2-mco6j8.
