### PR TITLE
chore(examples/_shared): remove vestigial code (rf2-yq1qfi)

### DIFF
--- a/examples/_shared/css/structure.css
+++ b/examples/_shared/css/structure.css
@@ -62,20 +62,9 @@
   padding: 12px 0;
 }
 
-dl.boot-summary {
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: 6px 16px;
-  margin: 0;
-}
-
-dl.boot-summary dt { font-weight: 600; }
-dl.boot-summary dd { margin: 0; }
-
 /* -- Realworld / Conduit layout ----------------------------------------- */
 
-.navbar,
-.realworld-footer {
+.navbar {
   padding: 12px 20px;
 }
 

--- a/examples/_shared/css/style.css
+++ b/examples/_shared/css/style.css
@@ -15,12 +15,11 @@
  * Atmosphere        : subtle paper-grain radial gradients fixed to the
  *                     viewport + soft warm-toned shadows. No heavy textures.
  *
- * Token convention  : the canonical names are --ex-*. The per-substrate
- *                     prefixes --rg-*, --ux-*, --hx-* are aliased onto the
- *                     same shared values so the design-led examples
- *                     (notebook, dashboard_uix, process_monitor_helix)
- *                     that consume them render identically across
- *                     substrates.
+ * Token convention  : the canonical names are --ex-*. Two design-led
+ *                     examples still consume per-substrate prefix aliases
+ *                     (notebook → --rg-*, process_monitor_helix → --hx-*),
+ *                     which map onto the same shared values so they render
+ *                     identically. New examples should use --ex-* directly.
  *
  * @imports structure.css for layout-only class shapes
  *          (forms, banners, pills, boot, navbar, cards, cells grid,
@@ -64,56 +63,34 @@
   /* fonts */
   --ex-sans:  'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
   --ex-mono:  'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-  --ex-serif: 'Inter', system-ui, sans-serif;  /* alias for legacy serif refs */
 
   /* alias consumed by structure.css */
   --rf2-mono: var(--ex-mono);
 
   /* ---- Per-substrate prefix aliases ----------------------------------- *
-   * The design-led examples (notebook, dashboard_uix,
-   * process_monitor_helix) carry per-example inline CSS that references
-   * --rg-*, --ux-*, --hx-* tokens. These all map onto the same shared
-   * palette so every example renders identically.
+   * Two design-led examples carry per-example inline CSS that references
+   * prefixed tokens: notebook (--rg-*) and process_monitor_helix (--hx-*).
+   * These map onto the same shared palette so every example renders
+   * identically. Only the tokens those examples actually use are kept.
    * ----------------------------------------------------------------- */
 
-  /* Reagent legacy (--rg-*) */
+  /* Reagent legacy (--rg-*) — tokens consumed by the notebook example */
   --rg-bg:           var(--ex-bg);
   --rg-bg-raised:    var(--ex-bg-raised);
   --rg-bg-sunken:    var(--ex-bg-sunken);
   --rg-ink:          var(--ex-ink);
-  --rg-ink-muted:    var(--ex-ink-muted);
   --rg-ink-faint:    var(--ex-ink-faint);
   --rg-rule:         var(--ex-rule);
   --rg-sienna:       var(--ex-accent);
   --rg-sienna-deep:  var(--ex-accent-deep);
-  --rg-gold:         var(--ex-accent-soft);
-  --rg-oxblood:      var(--ex-error);
-  --rg-forest:       var(--ex-success);
   --rg-serif:        var(--ex-sans);
   --rg-sans:         var(--ex-sans);
   --rg-mono:         var(--ex-mono);
 
-  /* UIx legacy (--ux-*) */
-  --ux-bg:           var(--ex-bg);
-  --ux-bg-raised:    var(--ex-bg-raised);
-  --ux-bg-sunken:    var(--ex-bg-sunken);
-  --ux-grid:         rgba(26,24,20,0.045);
-  --ux-ink:          var(--ex-ink);
-  --ux-ink-mute:     var(--ex-ink-muted);
-  --ux-ink-faint:    var(--ex-ink-faint);
-  --ux-rule:         var(--ex-rule);
-  --ux-cyan:         var(--ex-accent);          /* remapped to amber */
-  --ux-cyan-deep:    var(--ex-accent-deep);
-  --ux-yellow:       var(--ex-accent-soft);
-  --ux-coral:        var(--ex-error);
-  --ux-mint:         var(--ex-success);
-  --ux-sans:         var(--ex-sans);
-  --ux-mono:         var(--ex-mono);
-
-  /* Helix legacy (--hx-*) — was dark; now mapped to the shared light theme */
+  /* Helix legacy (--hx-*) — was dark; now mapped to the shared light theme.
+     Tokens consumed by the process_monitor_helix example. */
   --hx-bg:           var(--ex-bg);
   --hx-bg-surface:   var(--ex-bg-sunken);
-  --hx-bg-raised:    var(--ex-bg-raised);
   --hx-bg-elevated:  var(--ex-bg-elevated);
   --hx-ink:          var(--ex-ink);
   --hx-ink-muted:    var(--ex-ink-muted);
@@ -121,13 +98,10 @@
   --hx-rule:         var(--ex-rule);
   --hx-rule-strong:  var(--ex-rule-strong);
   --hx-green:        var(--ex-success);
-  --hx-green-deep:   #345B2E;
-  --hx-magenta:      var(--ex-accent);          /* remapped */
   --hx-amber:        var(--ex-warn);
   --hx-red:          var(--ex-error);
   --hx-cyan:         var(--ex-info);
   --hx-mono:         var(--ex-mono);
-  --hx-sans:         var(--ex-sans);
 }
 
 html, body {
@@ -284,19 +258,12 @@ button:active:not([disabled]) { transform: translateY(1px); }
 
 .boot-hint { color: var(--ex-ink-faint); font-style: italic; }
 .main-app section { border-top: 1px solid var(--ex-rule); }
-dl.boot-summary dt { color: var(--ex-ink-muted); }
 
 /* Realworld / Conduit ---------------------------------------------------- */
 
-.navbar, .realworld-footer {
+.navbar {
   background: var(--ex-bg-raised);
   border-bottom: 1px solid var(--ex-rule);
-}
-
-.realworld-footer {
-  border-bottom: 0;
-  border-top: 1px solid var(--ex-rule);
-  margin-top: 2em;
 }
 
 .nav-link { color: var(--ex-accent); font-weight: 500; }


### PR DESCRIPTION
Vestigial-code review of `examples/_shared` (rf2-yq1qfi). Removes dead CSS tokens and rules from the shared examples design system. Every removal was verified unreferenced via `git grep` across all example decks (the `_shared` tree is consumed broadly, so each candidate was checked against every consumer including inline-style references in `index.html` and `.cljs` views).

## Findings (removed)

- **`--ex-serif`** — defined, never referenced. Comment self-identified it as "alias for legacy serif refs"; no serif refs exist.
- **Entire `--ux-*` alias block (16 tokens)** — 100% unused. The sole UIx design-led example (`dashboard_uix`) was migrated to the canonical `--ex-*` tokens and references none of `--ux-*`. The README/CSS claim that `dashboard_uix` consumes `--ux-*` was stale.
- **Unused `--rg-*` tokens** (`ink-muted`, `gold`, `oxblood`, `forest`) — the `notebook` example consumes the rest of the `--rg-*` block but not these four.
- **Unused `--hx-*` tokens** (`bg-raised`, `green-deep`, `magenta`, `sans`) — `process_monitor_helix` consumes the rest of the `--hx-*` block but not these four.
- **`dl.boot-summary` rules** (structure.css + style.css) — the boot view emits a bare `[:dl ...]` with no `boot-summary` class; the selectors matched nothing.
- **`.realworld-footer` rules** (structure.css + style.css) — the realworld footer emits a bare `[:footer ...]` with no `realworld-footer` class; the selectors matched nothing.

Alias-block comments refreshed to match the surviving tokens and drop the stale `dashboard_uix` / `--ux-*` claim.

## Kept (justified)

- **`img/og.svg`** — not referenced by any page, but it is the editable OG-card source art and the asset gate (`check-examples-assets.cjs`) explicitly requires it on disk. Left as-is (README documents it as source art).
- All live `--rg-*` / `--hx-*` tokens, every actively-emitted CSS class, `og.png`, `favicon.svg`, `README.md`.

No README change (it carried no references to any removed token/class), so `check_readme_*` was not triggered.

## Quality gates

- `npm run test:examples-compile` — PASS (all 39 example builds compiled, 0 warnings).
- `node examples/scripts/check-examples-assets.cjs` — PASS (28 pages resolve assets; `_shared` tree intact).