### PR TITLE
docs(skills/re-frame2-setup): remove vestigial guidance (rf2-xplsvk)

### DIFF
--- a/skills/re-frame2-setup/spec/authoring-prompt.md
+++ b/skills/re-frame2-setup/spec/authoring-prompt.md
@@ -12,8 +12,8 @@ A self-contained prompt that re-authors the `re-frame2-setup` skill from this `s
 >
 > *1. `skills/re-frame2-setup/spec/design.md` — the locked design decisions (L1 through L10). Pillars 1-4 in §2 are non-negotiable. Q14 lock applies (NO verification module).*
 > *2. `skills/re-frame2-setup/spec/inputs.md` — the canonical inputs the skill leans on.*
-> *3. `examples/reagent/counter/` — the canonical first-counter shape (`core.cljs`, `shadow-cljs.edn`, `index.html`). `references/first-counter.md` is a trimmed version of this example.*
-> *4. `implementation/core/src/re_frame/core.cljc` (for the `rf/init!` contract) + `implementation/reagent/src/re_frame/adapter/reagent.cljs` (for the adapter spec map shape).*
+> *3. `examples/reagent/counter/` — the canonical first-counter shape (`core.cljs`, `index.html`; the examples share a single repo-level build, so there is no per-example `shadow-cljs.edn` — derive the greenfield build from the generator template, per `inputs.md`). `references/first-counter.md` is a trimmed version of this example.*
+> *4. `implementation/core/src/re_frame/core.cljc` (for the `rf/init!` contract) + `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs` (for the adapter spec map shape).*
 > *5. `skills/re-frame-migration/SKILL.md` + `skills/re-frame-migration/spec/` — the closest structural sibling with an existing `spec/` triad. Voice / shape mirror this.*
 > *6. `skills/re-frame2/SKILL.md` — the parent skill the author switches to once setup is done. The setup skill's routing-on-exit table points here.*
 >


### PR DESCRIPTION
Vestigial-content review of `skills/re-frame2-setup`. Two stale references found and fixed, both in the skill-internal reauthor prompt (`spec/authoring-prompt.md`, not user-facing — excluded from the npm package).

## Findings

1. **Relocated adapter source path.** `spec/authoring-prompt.md` pointed reauthor sessions at `implementation/reagent/src/re_frame/adapter/reagent.cljs`. The adapters were moved under `implementation/adapters/`; the old directory no longer exists in the tree (`git ls-files implementation/reagent/*` is empty). Fixed to `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs`. (`README.md:74` already used the correct path.)

2. **Dead example-file reference.** The reauthor prompt listed `examples/reagent/counter/shadow-cljs.edn` as part of the "canonical first-counter shape." That directory ships `core.cljs` + `index.html` + `README.md` only; the examples share a single repo-level build. The skill's own `spec/inputs.md:12` already documents this — the prompt was internally contradicting it. Reworded to match.

### Reviewed and deliberately NOT changed

- **`:rf/default` is always auto-registered** (frame-target EP audit flag). Verified CURRENTLY ACCURATE against `implementation/core/src/re_frame/frame.cljc:860-864` (auto-registers `:rf/default` on first frame use). The EP that would change this has not landed, so per the conservative rule the claim stays.
- All other referenced surfaces are live: `reg-view`, `re-frame.views`, `frame-handle` (public `defn`), `re-frame.adapter.{uix,helix}`, `use-subscribe`, the xray config vars, the template `_uix`/`_helix` deps, and every `implementation/` / sibling-skill / `migration/from-re-frame-v1/` path.

## Quality gates

- `bb tests/setup_drift_test.clj` — 17 tests, 47 assertions, 0 failures, 0 errors.
- `python3 scripts/check_readme_links.py` — exit 0.
- `python3 scripts/check_skill_package_refs.py` — exit 0.
- Manual relative-link sanity pass on SKILL.md + the four reference leaves: all resolve.