### PR TITLE
docs(skills+story-spec): align variant schema-slot vocabulary to impl (rf2-u36yk0)

### DIFF
--- a/skills/re-frame2/references/tooling/stories.md
+++ b/skills/re-frame2/references/tooling/stories.md
@@ -140,7 +140,7 @@ Distilled from `tools/story/testbeds/counter_with_stories/stories.cljs` — ever
 The controls panel auto-derives a widget per arg-key by walking the component's Malli schema. `resolve-argtypes` consults, in order:
 
 1. **Explicit `:argtypes`** on the variant body, then the parent story (per-key override).
-2. **Explicit `:rf/schema` slot** (Spec 010 canonical key; the legacy `:schema` alias is still read for backward compat) on the variant body, then the parent story, then the registered view's `:spec`. First match wins — no merge. A variant-side `:rf/schema` is the all-or-nothing override when one variant exercises a narrower / stricter / experimental shape than the component-wide schema; the args editor inputs and the schema-validation panel both auto-derive from this one declaration.
+2. **The registered view's props schema** — first-match `[:rf/props :schema]` on the `:component` view's `reg-view` metadata: `:rf/props` is the canonical key, `:schema` the alternative location (post-M-54 `reg-*` metadata key). First match wins — no merge; there is no `:spec` slot (`:spec` is dead post-M-54, the `:spec`→`:schema` rename — the framework reads `:schema` only on registrations). The same one declaration feeds both the controls panel's argtype derivation and the schema-validation panel, resolved through the compiled variant-plan's `[:world :view-args-schema]` so an `:extends`-inherited / `:compose`-d `:component` resolves correctly.
 3. **Value-shape fallback** — infer the widget from the live CLJS value when no schema is available.
 
 Walker output for the common Malli forms:

--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -261,7 +261,9 @@ A Storybook reader who lands on Story expects to write `argTypes:
 similar for every controllable arg. **Story's answer is shorter.**
 
 The view's Malli schema is the source of truth for control widgets.
-Write `[:int {:min 0 :max 100}]` once on the view's `:rf/schema` and
+Write `[:int {:min 0 :max 100}]` once on the view's props schema
+(`:rf/props`, the canonical key; `:schema` is the alternative location
+— first-match `[:rf/props :schema]`, never `:rf/schema`) and
 **every** story of that view gets the slider. No `:argtypes`
 plumbing per-story, no per-control widget wiring, no parallel-vocab
 maintenance burden.
@@ -286,9 +288,9 @@ The headline mapping (more in [§Schema-derivation pipeline](#schema-derivation-
 | `[:vector X]` / `[:set X]` | repeater (rows + `[+]` / `[-]`) |
 | `[:tuple X Y ...]` | fixed-arity row |
 
-The contract: push every typed constraint up to the view's
-`:rf/schema` and the controls panel renders the right widget for
-free. `:argtypes` on the story or variant body is the override
+The contract: push every typed constraint up to the view's props
+schema (`:rf/props`) and the controls panel renders the right widget
+for free. `:argtypes` on the story or variant body is the override
 channel for the cases the schema can't say enough — see the [edge
 cases](#when-to-write-argtypes-the-edge-cases) below.
 
@@ -1423,9 +1425,12 @@ corresponding `:assertions` record.
 ## Schema-derivation pipeline
 
 The control-derivation logic walks the registered Malli schema for
-`:component` (or an explicit `:schema` slot on the variant/story
-body — Story consults the variant body first, then the parent story,
-then the registered view) and emits a `{arg-key → widget-spec}` map:
+`:component` — resolved off the component view's `reg-view` metadata,
+first-match `[:rf/props :schema]` (`:rf/props` canonical, `:schema` the
+post-M-54 alternative; never `:rf/schema`; `:spec` dead post-M-54),
+through the compiled variant-plan's `[:world :view-args-schema]` so an
+`:extends`-inherited / `:compose`-d `:component` resolves — and emits a
+`{arg-key → widget-spec}` map:
 
 **Scalar forms**
 

--- a/tools/story/spec/014-Chrome-Features.md
+++ b/tools/story/spec/014-Chrome-Features.md
@@ -56,15 +56,30 @@ The panel renders the active variant's:
 
 ### Schema lookup (normative order)
 
-The panel resolves the component schema by first-match wins:
+The panel does NOT re-resolve the schema itself. It reads the SAME
+view-args (props) schema the plan compiler wrote to the compiled
+variant-plan's `[:world :view-args-schema]`, through the one shared
+resolver `re-frame.story.view-args/compiled-view-args-schema`
+(`re-frame.story.ui.schema-validation/resolve-component-schema`
+delegates to it). This is the identical slot the Controls panel derives
+argtypes from, so validation and controls share one source.
 
-1. The variant body's `:schema` slot — explicit per-variant override
-   (forward-compatible with the `:rf/schema` Spec 010 slot per
-   IMPL-SPEC §9.4).
-2. The parent story body's `:schema` slot — story-wide schema.
-3. The framework registrar's `:view` metadata for the variant's
-   `:component`: `:spec` (Spec 010 canonical) then `:schema` (legacy /
-   Story-only alias).
+The compiler resolves that schema by first-match wins off the
+registered `:component` view's `reg-view` metadata, in canonical key
+order `[:rf/props :schema]`:
+
+1. `:rf/props` — the canonical props-schema key (per
+   `spec/Spec-Schemas.md` §`:rf/registration-metadata`).
+2. `:schema` — the alternative location (the post-M-54 `reg-*`
+   metadata key).
+
+First match wins; there is NO composition (a view's only schema surface
+is its props — the rf2-p5ivc (b) ruling). `:spec` is NOT a slot — it is
+dead post-M-54 (the `:spec`→`:schema` rename, see
+`migration/from-re-frame-v1/README.md` §M-54): the framework reads
+`:schema` only on registration metadata. Routing through the compiled
+plan also resolves an `:extends`-inherited or `:compose`-d `:component`
+that a bare-body read would miss.
 
 When no schema is on file, the Args section reports "no schema
 registered" and the Trace section still surfaces any


### PR DESCRIPTION
Fixes the three-way vocabulary drift on the Story view-args (props) schema slot (rf2-u36yk0), reconciling the skill doc and the Story spec to implementation ground truth.

## Ground truth (tools/story src — authoritative)

The impl is internally consistent; no genuine impl/spec intent disagreement, so no decision note — this is pure drift predating the rf2-p5ivc (b) consolidation and the M-54 `:spec`→`:schema` rename.

- `malli_schema.cljc` / `plan.cljc` / `view_args.cljc`: the props schema resolves first-match `[:rf/props :schema]` off the registered `:component` view's `reg-view` metadata, read through the compiled variant-plan's `[:world :view-args-schema]` (so `:extends` / `:compose` resolve). `:rf/props` is canonical; `:schema` is the post-M-54 alternative. No composition.
- `:spec` is dead post-M-54 (the framework reads `:schema` only on registration metadata; no back-compat shim — migration §M-54).
- `:rf/schema` is NOT a slot — the `reg-variant` body schema is `{:closed true}` over `[:rf/props :schema]`, so an author writing `:rf/schema` gets `:rf.error/variant-shape` at registration.

## What was aligned

- `skills/re-frame2/references/tooling/stories.md` — §Schema-derivation pipeline step 2 called `:rf/schema` the canonical slot (`:schema` "legacy alias") and referenced the view's `:spec`. Now: first-match `[:rf/props :schema]`, `:spec` dead, resolved through the compiled plan.
- `tools/story/spec/014-Chrome-Features.md` — §Schema lookup (normative order) claimed variant/story-body `:schema` then view `:spec`/`:schema`. Rewritten to the actual resolver path (the panel reads the compiled `[:world :view-args-schema]` via the one shared resolver; first-match `[:rf/props :schema]`).
- `tools/story/spec/001-Authoring.md` — three "the view's `:rf/schema`" references (§Schema → controls, §Schema-derivation pipeline) corrected to the canonical `:rf/props` first-match.

No src behaviour changed (doc/spec-only). Already-correct: `tools/story/spec/017-Testing-Story.md` (used as the alignment model).

## Out of scope (flagged as follow-up, src)

- The `reg-variant` body accepts `:rf/props` / `:schema` (schemas.cljc) but the live resolver reads only the component view's metadata — body-level slots are accepted-but-unread.
- `schema_validation.cljc`'s `:failing-id` comment and `014-Chrome-Features.md` line 99 still say ":spec failed" (a separate post-M-54 vestige; the spec line mirrors the src comment verbatim, so left untouched to avoid desyncing doc from src).

## Quality gates

- `python scripts/check_doc_slugs.py` — PASS (exit 0); scans `skills/` + `tools/<tool>/spec/`, covers all three edited files.
- `python scripts/check_skill_redirect_anchors.py` — PASS.
- `python scripts/check_skill_migration_cites.py` — PASS (validates the new §M-54 cite).
- `python scripts/check_skill_package_refs.py` — PASS.
- `mkdocs build --strict` — N/A: `docs_dir: docs`; the edited skill leaf and Story spec files are outside the mkdocs nav (the skill's `references/` tree is GitHub-linked, not built).
- No `re-frame2`-authoring-skill structural test exists for the edited leaf (the test dirs are for `re-frame2-pair` / `re-frame2-setup` / `re-frame-migration` / `shared`).
