### PR TITLE
fix(xray/machines-viz): render guard-blocked transitions on the topology chart (rf2-fzrzlw)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -56,6 +56,7 @@ registry).
 | `:from-highlight` | no | `nil` | Focused-event lens origin (a `:state` value). |
 | `:to-highlight` | no | `nil` | Focused-event lens landing (a `:state` value). |
 | `:fired-edge-ids` | no | `#{}` | rf2-qeemm (closes parity gap **G3**). A **set** of canonical edge-ids (the EXACT scheme `chart.layout` mints) that fired **this epoch**. Each matching edge gets the FIRED treatment — emphasised + animated stroke + `data-fired` — along its routed path (coexisting with G2 bend-points + G1 active styling). Distinct from the from/to lens (`:from-highlight` / `:to-highlight`, matched by ENDPOINT state): this matches the **edge** directly, so every traversed arm (microsteps, guard-fork candidates) lights up. The host (Xray) resolves it for the focused epoch via `panels.machines.trace-state/extract-fired-edge-ids`; the ids agree with the chart by construction. The chart root surfaces the sorted set as `data-fired-edge-ids`. `nil` / `#{}` → no fired highlight. **Colour delegated to Figma** (`:accent` baseline, distinct from the focused/active `:info`). |
+| `:guard-blocked-edge-ids` | no | `#{}` | rf2-fzrzlw. A **set** of canonical edge-ids (same scheme as `:fired-edge-ids`) whose **guard REJECTED** the event this epoch — a guard-blocked **no-op** (the runtime emitted `:rf.machine/guard-evaluated` fail/threw but **NO** `:rf.machine/transition`, so the fired set is empty for it). Each matching edge **and its event-node** gets the guard-blocked treatment — emphasised **PINK** stroke + emphasised pink `IF <guard>` chip + `data-guard-blocked` — which **WINS** over fired/focused/active on that edge (`theme.tokens/edge-color` ranks `blocked? > fired? > focused?/active? > quiet`), so the attempted-and-rejected edge stands out from the all-exits affordance-blue. Without it a blocked no-op gives ZERO signal which edge the event hit. The host (Xray) resolves it via `panels.machines.trace-state/extract-guard-blocked-edge-ids` (matching on the named-guard `(event, guard)` the `:rf.machine/guard-evaluated` trace carries). The chart root surfaces the sorted set as `data-guard-blocked-edge-ids`. `nil` / `#{}` → no guard-blocked highlight. **SUPERSET of XState/Stately** (which highlights nothing on a block) — only possible because re-frame2 emits guard-evaluated. Colour = `:edge-guard-blocked` (pink `:magenta-pink`). |
 | `:sim?` | no | `nil` | Flips the highlight palette to amber for the simulator path. |
 | `:on-state-click` | no | `nil` | `(fn [path] ...)`. Fires when the user clicks a **real statechart-state node** — a **leaf state** (its body) or a **compound state** (its **title strip** only; the compound's body stays pointer-transparent so a click inside it falls through to the nested leaf). `path` is the clicked state's path. **Not** fired for the synthetic **machine-root** chip or **parallel-region** containers (no region-selection concept yet) — the projector threads the callback onto leaf + compound `:data` only (rf2-34ff3). No-op'd when `:read-only?` is true. |
 | `:read-only?` | no | `nil` | When `true`, all `:on-*` callbacks are no-op'd. The viewer page sets this. |
@@ -343,14 +344,17 @@ carry: `:eventLabel` (the `chart.layout/event-segment` glyph-aware
 text), `:guard` (string), `:action` (string), `:variant` (`:on` /
 `:after` / `:always`), `:eventId` (raw fireable keyword for the
 on-chart sim — nil for `:after` / `:always` / wildcard), `:fromPath`
-/ `:toPath`, `:focused`, `:fired`, `:internal`, `:reenter` (rf2-9dj21r —
+/ `:toPath`, `:focused`, `:fired`, `:guardBlocked` (rf2-fzrzlw — the
+guard-blocked no-op marker; drives the PINK border + emphasised pink
+`IF <guard>` chip), `:internal`, `:reenter` (rf2-9dj21r —
 the external-restart axis; drives the `↻` reenter chip), `:machineLevel`,
 `:onClick` (the host-supplied callback), `:afterMs`, `:chart`
 (resolved visual-constants).
 
 The inbound + outbound edges carry the structural / styling state
 that used to live on the single state→state edge: `:active`,
-`:focused`, `:fired`, `:crossHierarchy`, and elk-routed `:points`. Edge
+`:focused`, `:fired`, `:guardBlocked` (rf2-fzrzlw — both halves paint the
+PINK guard-blocked stroke), `:crossHierarchy`, and elk-routed `:points`. Edge
 ids: `<spec-edge-id>__in` / `<spec-edge-id>__out`. Event-node ids:
 `event__<spec-edge-id>` via `chart.projection/event-node-id`. The
 `:eventLabel` slot on these edges is empty (the event-node holds the
@@ -1005,6 +1009,7 @@ chrome-only tokens (`:chrome-ribbon-*`, `:diff-*`, `:syntax-*`,
 | `:event-chip-bg` / `:event-chip-border` | route-chip fill / border (subordinate) |
 | `:pseudo-marker` | initial / history pseudo-state (neutral, NOT accent) |
 | `:edge-quiet` / `:edge-active` / `:edge-fired` | source→event quiet / event→target+active / fired-epoch |
+| `:edge-guard-blocked` | rf2-fzrzlw — the guard-blocked no-op edge (a transition whose guard rejected the event): PINK (`:magenta-pink`), distinct from the blue fired/active hues AND the red `:final-error` ring. Wins over fired/active in `edge-color` (`blocked? > fired? > focused?/active? > quiet`). |
 | `:active` / `:focus` / `:sim` / `:final` | runtime-state accents (reserved for runtime, NOT static structure) |
 
 ### Resolution rules

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -815,6 +815,21 @@
                          (Xray) resolves it for the focused epoch via
                          `extract-fired-edge-ids`; nil / `#{}` → no fired
                          highlight (the standalone viewer / Story path).
+    :guard-blocked-edge-ids — rf2-fzrzlw. A SET of canonical edge-ids
+                         whose guard REJECTED the event this epoch (a
+                         guard-blocked no-op: the runtime emitted
+                         `:rf.machine/guard-evaluated` fail/threw but NO
+                         `:rf.machine/transition`). Each matching edge +
+                         its event-node gets the PINK guard-blocked
+                         treatment (emphasised pink stroke + emphasised
+                         pink `IF <guard>` chip + `data-guard-blocked`),
+                         winning over fired/focused/active so the
+                         attempted-and-rejected edge stands out. Without
+                         it a blocked no-op gives ZERO signal which edge
+                         the event hit. The host (Xray) resolves it via
+                         `extract-guard-blocked-edge-ids`; nil / `#{}` →
+                         no guard-blocked highlight. SUPERSET of XState
+                         (which highlights nothing on a block).
     :sim?              — flips the highlight palette to amber for
                          the simulator path.
     :on-state-click    — `(fn [path] ...)` invoked on node click.
@@ -1125,7 +1140,7 @@
                 (reset! graph-cache fresh)
                 fresh))))]
     (fn [{:keys [machine-id definition current-state from-highlight to-highlight
-                 fired-edge-ids
+                 fired-edge-ids guard-blocked-edge-ids
                  sim? on-state-click on-edge-click read-only?
                  direction layout-options density theme
                  height show-minimap? show-controls? show-background?
@@ -1358,6 +1373,10 @@
                 {:keys [positions edge-points edge-labels layout-error]}
                 @layout-state
                 fired-edge-id-set (set fired-edge-ids)
+                ;; rf2-fzrzlw — the guard-blocked no-op edge-id set; the
+                ;; projector marks each matching edge + event-node
+                ;; `:guardBlocked`. nil → #{} default.
+                guard-blocked-edge-id-set (set guard-blocked-edge-ids)
                 ;; rf2-dnmbs — memoise the projection + JS marshalling
                 ;; (`xyflow-graph` then `clj->js`) on the inputs that
                 ;; actually change the projected graph. A tick-only /
@@ -1371,7 +1390,8 @@
                 ;; keyed directly so a changed handler identity rebuilds.
                 cache-key  [parsed positions edge-points edge-labels
                             highlight-ids from-highlight-id to-highlight-id
-                            fired-edge-id-set sim? callback edge-callback
+                            fired-edge-id-set guard-blocked-edge-id-set
+                            sim? callback edge-callback
                             density theme]
                 {:keys [js-nodes js-edges]}
                 (project+convert!
@@ -1399,6 +1419,10 @@
                                ;; edge-id set; the projector marks each
                                ;; matching edge :fired. nil → #{} default.
                                :fired-edge-ids    fired-edge-id-set
+                               ;; rf2-fzrzlw — the guard-blocked no-op
+                               ;; edge-id set; the projector marks each
+                               ;; matching edge + event-node :guardBlocked.
+                               :guard-blocked-edge-ids guard-blocked-edge-id-set
                                :chart             chart-vc
                                ;; rf2-az6e2 — the resolved chart-semantic
                                ;; token map for the active theme; the
@@ -1491,6 +1515,12 @@
                    ;; DOM tests can read every traversed arm at the chart
                    ;; root (mirrors `data-highlight-ids`). "" when none.
                    :data-fired-edge-ids (str/join " " (sort (set fired-edge-ids)))
+                   ;; rf2-fzrzlw — the guard-blocked no-op edge-id set
+                   ;; surfaces as a sorted, space-joined attr so hosts +
+                   ;; DOM tests can read every attempted-and-rejected arm
+                   ;; at the chart root (mirrors `data-fired-edge-ids`).
+                   ;; "" when none.
+                   :data-guard-blocked-edge-ids (str/join " " (sort (set guard-blocked-edge-ids)))
                    ;; rf2-4lyvh — surface ELK layout-failure as a root
                    ;; data-attr so DOM tests + hosts can pin the failure
                    ;; without inspecting the banner DOM. "true" / "false";

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -336,7 +336,12 @@
       (tokens/chart-tokens))))
 
 (defn- edge-stroke
-  "rf2-qeemm (G3) — `fired?` (the edge traversed THIS epoch) wins over
+  "rf2-fzrzlw — `blocked?` (the edge's guard rejected the event this
+  epoch) wins OUTRIGHT so the pink guard-blocked hue overrides the
+  affordance-blue / fired / active on that specific edge (bead design
+  call (2): the attempted-and-rejected edge must stand out).
+
+  rf2-qeemm (G3) — `fired?` (the edge traversed THIS epoch) wins over
   `focused?` / `active?` so a fired arm reads as 'what just happened' in
   the FIRED hue, distinct from the focused/active hue.
 
@@ -356,7 +361,8 @@
   rf2-dt5b1 — otherwise delegates to the shared `tokens/edge-color`, the
   SINGLE source the projector's arrowhead-`:markerEnd` colour also routes
   through, so a stroke and its arrowhead can never resolve different
-  colours for the same edge state."
+  colours for the same edge state (rf2-fzrzlw — `:blocked?` resolves to
+  the pink guard-blocked hue there, winning over fired/active)."
   [ct {:keys [entry?] :as flags}]
   (if entry?
     (:pseudo-marker ct)
@@ -371,16 +377,20 @@
   rf2-qeemm (G3) — `fired?` paints at the emphasis width (the heaviest
   treatment), at least as prominent as `focused?`.
 
+  rf2-fzrzlw — `blocked?` (the guard-blocked no-op edge) paints at the
+  emphasis width too so the pink rejected edge stands out as much as a
+  fired arm — the operator must not miss the attempted transition.
+
   rf2-az6e2 — the QUIET source→event segment (`quiet?`) paints ONE notch
   THINNER than the resting width (so the pair reads as one route: the
   quiet inbound half + the primary outbound half). A quiet segment that
   is itself fired/focused still picks up the emphasis width so a
   traversed route lights BOTH segments together."
-  [{:keys [active? focused? fired? quiet? chart]
+  [{:keys [active? focused? fired? blocked? quiet? chart]
     :or   {chart vc/chart-regular}}]
   (let [{:keys [stroke-width stroke-width-emphasis]} chart]
     (cond
-      (or fired? focused?) stroke-width-emphasis
+      (or fired? focused? blocked?) stroke-width-emphasis
       active?              (/ (+ stroke-width stroke-width-emphasis) 2.0)
       ;; resting quiet inbound half — one notch under the resting width.
       quiet?               (max 0.75 (- stroke-width 0.5))
@@ -421,6 +431,14 @@
         ;; FIRED treatment (emphasised + animated stroke, `data-fired`),
         ;; winning over the focused/active styling per `edge-stroke`.
         fired?     (boolean (.-fired d))
+        ;; rf2-fzrzlw — this edge's guard REJECTED the event this epoch
+        ;; (a guard-blocked no-op: the runtime emitted
+        ;; `:rf.machine/guard-evaluated` fail/threw but NO transition).
+        ;; Drives the PINK guard-blocked treatment (emphasised stroke +
+        ;; emphasised guard label, `data-guard-blocked`), winning OUTRIGHT
+        ;; over fired/focused/active per `edge-stroke` so the attempted-
+        ;; and-rejected edge stands out (bead design call (2)).
+        blocked?   (boolean (.-guardBlocked d))
         after-ms   (.-afterMs d)
         ;; rf2-u422r — on-chart click wiring. `:onClick` is the host
         ;; callback (e.g. Xray's on-chart sim → sim-step); `:eventId`
@@ -502,9 +520,10 @@
         stroke  (if fork-connector?
                   (:pseudo-marker ct)
                   (edge-stroke ct {:active? active? :focused? focused? :fired? fired?
-                                   :entry? entry?}))
+                                   :blocked? blocked? :entry? entry?}))
         stroke-w (edge-stroke-width {:active? active? :focused? focused?
-                                     :fired? fired? :quiet? quiet? :chart vc})]
+                                     :fired? fired? :blocked? blocked?
+                                     :quiet? quiet? :chart vc})]
     (r/as-element
       [:<>
        ;; rf2-o6vh7 — every edge renders its own SVG path + arrowhead.
@@ -544,6 +563,10 @@
                ;; rf2-qeemm (G3) — DOM pin for the fired-this-epoch edge
                ;; treatment; tests + hosts read it to find the traversed arm.
                :data-fired (str fired?)
+               ;; rf2-fzrzlw — DOM pin for the guard-blocked no-op edge
+               ;; treatment; tests + hosts read it to find the attempted-
+               ;; and-rejected arm (the pink edge whose guard declined).
+               :data-guard-blocked (str blocked?)
                :data-after-ms (when after-ms (str after-ms))
                ;; rf2-ee38b.21 — surface internal / machine-level so the
                ;; DOM suite + a host can distinguish self-transition kind

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/event_node.cljs
@@ -115,6 +115,13 @@
     :action        — action name as a string, or nil.
     :focused       — focused-event lens hit; emphasised border.
     :fired         — this event fired THIS epoch; FIRED treatment.
+    :guardBlocked  — rf2-fzrzlw — this transition's guard REJECTED the
+                     event this epoch (a guard-blocked no-op: the runtime
+                     emitted `:rf.machine/guard-evaluated` fail/threw but
+                     NO transition). PINK guard-blocked treatment: pink
+                     border + an EMPHASISED pink `IF <guard>` chip so the
+                     node reads as the guard that rejected it (bead design
+                     call (1)). Wins over fired/focused on this node.
     :clickable     — host wired an on-click for this event (the
                      on-chart sim path).
     :eventId       — raw fireable event keyword the host receives on
@@ -145,6 +152,12 @@
         action      (.-action d)
         focused?    (boolean (.-focused d))
         fired?      (boolean (.-fired d))
+        ;; rf2-fzrzlw — this transition's guard rejected the event this
+        ;; epoch (guard-blocked no-op). Drives the PINK guard-blocked
+        ;; treatment (pink border + emphasised pink `IF <guard>` chip),
+        ;; winning over fired/focused on this node so the rejected
+        ;; transition stands out (bead design call (1) + (2)).
+        blocked?    (boolean (.-guardBlocked d))
         fork-order  (.-forkOrder d)
         internal?   (boolean (.-internal d))
         reenter?    (boolean (.-reenter d))
@@ -161,13 +174,17 @@
                 event-chip-pad-y event-chip-radius event-chip-px
                 event-chip-action-px action-pill-height action-pill-pad-x
                 action-pill-radius stroke-width stroke-width-emphasis]} vc
-        emphasised? (or focused? fired?)
+        emphasised? (or focused? fired? blocked?)
         stroke-w    (if emphasised? stroke-width-emphasis stroke-width)
         ;; rf2-az6e2 — the route chip is SUBORDINATE to states: a quiet
         ;; neutral fill + neutral border by default. Runtime state
         ;; (focused lens / fired-this-epoch) swaps the border to the
         ;; runtime accent; a clickable (sim) chip gets a faint amber wash.
+        ;; rf2-fzrzlw — a guard-blocked no-op swaps the border to the PINK
+        ;; guard-blocked hue (winning over fired/focused) so the rejected
+        ;; transition stands out.
         stroke-col  (cond
+                      blocked?  (:edge-guard-blocked ct)
                       fired?    (:edge-fired ct)
                       focused?  (:edge-active ct)
                       :else     (:event-chip-border ct))
@@ -196,6 +213,10 @@
              :data-fork-order (when fork-order (str fork-order))
              :data-machine-level (str machine-level?)
              :data-fired (str fired?)
+             ;; rf2-fzrzlw — DOM pin for the guard-blocked no-op event
+             ;; treatment; tests + hosts read it to find the attempted-
+             ;; and-rejected transition (the pink chip whose guard declined).
+             :data-guard-blocked (str blocked?)
              :data-focused (str focused?)
              :data-clickable (str clickable?)
              :data-after-ms (when after-ms (str after-ms))
@@ -235,7 +256,10 @@
                      :user-select    "none"
                      :box-shadow     (when emphasised?
                                        (str "0 0 0 2px "
-                                            (if fired? (:glow-fired ct) (:glow ct))))
+                                            (cond
+                                              blocked? (:edge-guard-blocked ct)
+                                              fired?   (:glow-fired ct)
+                                              :else    (:glow ct))))
                      :animation      (when fired?
                                        "mv-chart-transition-glow 720ms ease-out infinite")
                      :transition     "border-color 120ms ease, background 120ms ease"}}
@@ -254,11 +278,18 @@
         (fork-badge (.-id props) fork-order ct event-chip-px)
         header
         (when guard
+          ;; rf2-fzrzlw — a guard-blocked no-op EMPHASISES the guard chip
+          ;; in the pink guard-blocked hue (bold pink `IF <guard>`) so the
+          ;; node reads "this guard rejected it"; the resting guard chip
+          ;; stays quiet tertiary.
           [:span {:data-testid (str "rf-mv-chart-event-guard-" (.-id props))
                   :data-guard guard
+                  :data-guard-blocked (str blocked?)
                   :style {:margin-left "5px"
-                          :color (:text-tertiary ct)
-                          :font-weight 600}}
+                          :color (if blocked?
+                                   (:edge-guard-blocked ct)
+                                   (:text-tertiary ct))
+                          :font-weight (if blocked? 700 600)}}
            (str "IF " guard)])
         ;; rf2-9dj21r — the EXTERNAL restart marker. A targeted transition
         ;; is internal by default (XState v5 / Spec 005); a `↻` reenter chip

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -414,6 +414,10 @@
                             ;; label-less render off.
                             :forkConnector true
                             :active false :focused false :fired false
+                            ;; rf2-fzrzlw — the decorative connector is never
+                            ;; a guard-blocked transition; false keeps the
+                            ;; every-edge :data shape whole.
+                            :guardBlocked false
                             :afterMs nil :guard nil :action nil
                             :selfLoop false :loopIndex nil
                             :crossHierarchy false
@@ -977,6 +981,25 @@
                            matches the EDGE directly, so it lights every
                            traversed arm (microsteps, guard-fork
                            candidates) the lens cannot. Defaults to `#{}`.
+    :guard-blocked-edge-ids — rf2-fzrzlw. A SET of canonical edge-ids
+                           whose guard REJECTED the event this epoch (a
+                           guard-blocked no-op: the runtime emitted
+                           `:rf.machine/guard-evaluated` fail/threw but NO
+                           `:rf.machine/transition`). An edge — AND its
+                           event-node — is marked `:guardBlocked` when its
+                           id ∈ this set; the renderer paints the PINK
+                           guard-blocked treatment (emphasised pink stroke +
+                           emphasised pink `IF <guard>` chip, `data-guard-
+                           blocked`) which WINS over fired/focused/active on
+                           that edge so the attempted-and-rejected edge
+                           stands out (bead design calls (1) + (2)). Without
+                           this the chart paints ALL of the active state's
+                           exits affordance-blue and gives ZERO signal which
+                           edge the event hit or that a guard blocked it. The
+                           host (Xray) resolves the set via
+                           `panels.machines.trace-state/extract-guard-blocked-edge-ids`.
+                           SUPERSET of XState/Stately (which highlights
+                           nothing on a block). Defaults to `#{}`.
     :chart               — rf2-k647w. The resolved visual-constants
                            map for the active `:density`
                            (`visual-constants/chart-for-density`).
@@ -1005,9 +1028,9 @@
    positions
    {:keys [highlight-id highlight-ids from-highlight-id to-highlight-id sim?
            on-state-click on-edge-click edge-points edge-labels
-           fired-edge-ids chart palette]
+           fired-edge-ids guard-blocked-edge-ids chart palette]
     :or   {chart vc/chart-regular edge-points {} edge-labels {}
-           fired-edge-ids #{}}}]
+           fired-edge-ids #{} guard-blocked-edge-ids #{}}}]
   (let [;; rf2-az6e2 — resolve the chart-semantic token map for the
         ;; active theme ONCE. nil → dark chart-tokens (a theme-less
         ;; caller keeps the dark surface). Threaded onto every node/edge
@@ -1300,6 +1323,12 @@
                                         (= src from-highlight-id)
                                         (= tgt to-highlight-id))
                       fired?       (contains? fired-edge-ids (:id e))
+                      ;; rf2-fzrzlw — this edge's guard rejected the event
+                      ;; this epoch (guard-blocked no-op). Drives the PINK
+                      ;; guard-blocked treatment on both the event-node and
+                      ;; the `__in`/`__out` edge halves, winning over
+                      ;; fired/focused/active.
+                      blocked?     (contains? guard-blocked-edge-ids (:id e))
                       self-loop?   (= src tgt)
                       internal?    (boolean (:internal? e))
                       ;; rf2-9dj21r — the EXTERNAL restart axis (`:reenter?
@@ -1360,6 +1389,7 @@
                    :parent-id parent-id
                    :focused?  focused?
                    :fired?    fired?
+                   :blocked?  blocked?
                    :from-active? from-active?
                    :self-loop? self-loop?
                    :internal? internal?
@@ -1376,7 +1406,7 @@
         ;; `+ <action>` pill row.
         event-nodes
         (mapv (fn [{:keys [edge variant ev-node-id parent-id
-                           focused? fired? internal? reenter? event-id]}]
+                           focused? fired? blocked? internal? reenter? event-id]}]
                 (let [src (:source edge)
                       src-pos (get positions src {:x 0 :y 0})
                       ev-pos  (get positions ev-node-id
@@ -1406,6 +1436,12 @@
                                        :forkOrder   (get fork-order (:id edge))
                                        :focused     focused?
                                        :fired       fired?
+                                       ;; rf2-fzrzlw — guard-blocked no-op:
+                                       ;; the event-node paints the PINK
+                                       ;; guard-blocked treatment (pink
+                                       ;; border + emphasised pink IF-guard
+                                       ;; chip).
+                                       :guardBlocked blocked?
                                        :internal    internal?
                                        ;; rf2-9dj21r — the external-restart
                                        ;; axis surfaced to the event-node
@@ -1474,12 +1510,13 @@
         ;; (`:arrow-width-quiet` for `__in`, `:arrow-width` for `__out`)
         ;; so the head scales with the stroke instead of a baked literal.
         marker-color
-        (fn [{:keys [fired? focused? from-active?]}]
+        (fn [{:keys [fired? focused? blocked? from-active?]}]
           (tokens/edge-color ct {:fired?   fired?
                                  :focused? focused?
+                                 :blocked? blocked?
                                  :active?  from-active?}))
         events-as-nodes-edge
-        (fn [half {:keys [edge ev-node-id from-active? focused? fired?
+        (fn [half {:keys [edge ev-node-id from-active? focused? fired? blocked?
                           cross-hier?] :as desc} points label-pos]
           (let [in? (= half :in)
                 w   (if in?
@@ -1504,6 +1541,11 @@
                          :active     from-active?
                          :focused    focused?
                          :fired      fired?
+                         ;; rf2-fzrzlw — guard-blocked no-op: both halves of
+                         ;; the route paint the PINK guard-blocked stroke
+                         ;; (winning over fired/focused/active) so the
+                         ;; attempted-and-rejected edge stands out.
+                         :guardBlocked blocked?
                          :afterMs    nil
                          :guard      nil
                          :action     nil
@@ -1624,6 +1666,10 @@
                  ;; so the "every edge has X" projection invariants hold.
                  :data        {:eventLabel "" :eventLineLabel "" :entry true
                                :active false :focused false :fired false
+                               ;; rf2-fzrzlw — the initial-marker entry edge
+                               ;; is never a guard-blocked transition; false
+                               ;; keeps the every-edge :data shape whole.
+                               :guardBlocked false
                                :afterMs nil
                                :guard nil :action nil :selfLoop false
                                ;; rf2-shv82 — entry edges are never self-

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -305,8 +305,10 @@
     :pseudo-marker
        — initial / history pseudo-state glyph colour (neutral, NOT the
          accent-blue runtime marker).
-    :edge-quiet / :edge-active / :edge-fired
-       — source→event quiet segment, event→target / active, fired-epoch.
+    :edge-quiet / :edge-active / :edge-fired / :edge-guard-blocked
+       — source→event quiet segment, event→target / active, fired-epoch,
+         and the GUARD-BLOCKED no-op edge (rf2-fzrzlw — a pink/error
+         hue marking a transition whose guard rejected it).
     :text-primary / :text-secondary / :text-tertiary
        — re-exported off the palette so a renderer reads one map.
     :active / :focus / :sim / :final
@@ -345,6 +347,16 @@
       :edge-quiet  (with-alpha :border-default 0.55 palette)
       :edge-active (g :info)
       :edge-fired  (g :accent)
+      ;; rf2-fzrzlw — the GUARD-BLOCKED no-op edge hue. A transition
+      ;; whose guard evaluated fail/threw paints PINK so the operator
+      ;; sees which edge the event hit AND that a guard rejected it (a
+      ;; no-op emits no `:rf.machine/transition`, so the fired set is
+      ;; empty and the affordance-blue gives zero rejection signal). The
+      ;; pink `:magenta-pink` (pink-500) reads as "blocked" distinct from
+      ;; the red `:final-error` terminal ring and the blue fired/active
+      ;; hues. SUPERSET of XState/Stately (which highlights nothing on a
+      ;; block) — only possible because re-frame2 emits guard-evaluated.
+      :edge-guard-blocked (g :magenta-pink)
       ;; text
       :text-primary   (g :text-primary)
       :text-secondary (g :text-secondary)
@@ -382,14 +394,19 @@
   the arrowhead paints) route through this fn so a stroke and its
   arrowhead can never disagree on colour for the same edge state.
 
-  Ordering (XState/Stately gold standard): `fired?` (the edge traversed
-  THIS epoch) wins over `focused?` / `active?` so a fired arm reads as
-  'what just happened' in the FIRED hue; focused / active share the
-  ACTIVE hue; everything else is the resting QUIET hue.
+  Ordering (XState/Stately gold standard): `blocked?` (rf2-fzrzlw — the
+  edge's guard rejected the event this epoch) wins OUTRIGHT so the pink
+  guard-blocked hue overrides the affordance-blue / fired / active on
+  that specific edge — the attempted-and-rejected edge must stand out
+  (bead design call (2)); then `fired?` (the edge traversed THIS epoch)
+  wins over `focused?` / `active?` so a fired arm reads as 'what just
+  happened' in the FIRED hue; focused / active share the ACTIVE hue;
+  everything else is the resting QUIET hue.
 
   Pure data → string; JVM-portable."
-  [ct {:keys [active? focused? fired?]}]
+  [ct {:keys [active? focused? fired? blocked?]}]
   (cond
+    blocked?              (:edge-guard-blocked ct)
     fired?                (:edge-fired ct)
     (or focused? active?) (:edge-active ct)
     :else                 (:edge-quiet ct)))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -843,6 +843,66 @@
             (is (= "" (.getAttribute root "data-fired-edge-ids"))
                 "no fired set → empty data-fired-edge-ids")))))))
 
+;; ---- guard-blocked no-op edge highlight (rf2-fzrzlw) -------------------
+;;
+;; The bead's repro: door in `:open`, `:door/close` blocked by the
+;; `:may-close?` guard → no-op. The host resolves the blocked edge-ids via
+;; `extract-guard-blocked-edge-ids` (from the named-guard guard-evaluated
+;; fail/threw traces) and passes them as `:guard-blocked-edge-ids`. The
+;; matching event-node renders with `data-guard-blocked="true"` (the DOM
+;; pin for the PINK guard-blocked treatment) and the chart root surfaces
+;; the sorted set on `data-guard-blocked-edge-ids`.
+
+(def ^:private guarded-door-machine
+  "rf2-fzrzlw — minimal door with a guarded `:door/close [may-close?]`
+  (`:open` → `:closed`) so the guard-blocked no-op edge can be exercised."
+  {:initial :closed
+   :states  {:closed {:on {:door/open :open}}
+             :open   {:on {:door/close {:target :closed :guard :may-close?}}}}})
+
+(deftest chart-guard-blocked-event-node-renders-data-guard-blocked
+  (testing "rf2-fzrzlw — passing :guard-blocked-edge-ids #{<close id>}
+            marks the matching event-node with data-guard-blocked=\"true\";
+            non-blocked event-nodes carry data-guard-blocked=\"false\"."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (let [close-id (canonical-edge-id guarded-door-machine [:open] [:closed] :door/close)
+            blocked-ev-id (str "event__" close-id)]
+        (with-mounted-chart
+          {:machine-id     :test/door
+           :definition     guarded-door-machine
+           :guard-blocked-edge-ids #{close-id}}
+          (fn [_root node]
+            (let [blocked-el (.querySelector
+                               node (str "[data-testid=\"rf-mv-chart-event-" blocked-ev-id "\"]"))
+                  all-evs    (array-seq
+                               (.querySelectorAll node "[data-testid^=\"rf-mv-chart-event-\"]"))
+                  others     (remove #(= % blocked-el) all-evs)]
+              (when (some? blocked-el)
+                (is (= "true" (.getAttribute blocked-el "data-guard-blocked")))
+                (is (every? #(or (= "false" (.getAttribute % "data-guard-blocked"))
+                                 (nil? (.getAttribute % "data-guard-blocked"))) others))))))))))
+
+(deftest chart-guard-blocked-edge-ids-surfaces-on-root
+  (testing "rf2-fzrzlw — the chart root surfaces the sorted guard-blocked
+            set on data-guard-blocked-edge-ids; absent the prop the attr
+            is empty"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (let [close-id (canonical-edge-id guarded-door-machine [:open] [:closed] :door/close)]
+        (with-mounted-chart
+          {:machine-id     :test/door
+           :definition     guarded-door-machine
+           :guard-blocked-edge-ids #{close-id}}
+          (fn [root _node]
+            (is (= close-id (.getAttribute root "data-guard-blocked-edge-ids"))
+                "the guard-blocked edge-id surfaces on the root")))
+        (with-mounted-chart
+          {:machine-id :test/door :definition guarded-door-machine}
+          (fn [root _node]
+            (is (= "" (.getAttribute root "data-guard-blocked-edge-ids"))
+                "no guard-blocked set → empty data-guard-blocked-edge-ids")))))))
+
 ;; ---- compound-endpoint edges render in DOM (rf2-shv82, Issue 1) --------
 ;;
 ;; The bug: xyflow v12 silently drops every edge whose source or target

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -2375,6 +2375,110 @@
       (is (false? (:fired (:data entry)))
           "entry edges are never fired"))))
 
+;; ---- guard-blocked no-op edge highlight (rf2-fzrzlw) -------------------
+;;
+;; The bead's repro: door in `:open`, dispatch `:door/close`, the
+;; `:may-close?` guard fails → guard-blocked NO-OP. NO `:rf.machine/
+;; transition` is emitted (so `:fired-edge-ids` is empty), and before
+;; rf2-fzrzlw the chart painted ALL of `:open`'s exits affordance-blue,
+;; giving ZERO signal that `:door/close` was attempted-and-rejected. The
+;; Xray inspector resolves the blocked edge-ids
+;; (`extract-guard-blocked-edge-ids`, from the named-guard `:rf.machine/
+;; guard-evaluated` fail/threw traces) and threads them as
+;; `:guard-blocked-edge-ids` (a SET) into the projector, which marks each
+;; matching edge AND its event-node `:guardBlocked`. The renderer then
+;; paints the PINK guard-blocked treatment (the DOM suite pins the
+;; rendered `data-guard-blocked` attr + pink hue). The match is by
+;; EDGE-ID so the precise rejected arm lights — including the exact arm
+;; of a guarded fork.
+
+(defn- door-close-edge-id
+  "The canonical id of the door's guarded `:door/close [may-close?]`
+  edge (`:open` → `:closed`) off `door-cyclic-machine`."
+  [parsed]
+  (->> (:edges parsed)
+       (some (fn [e] (when (and (= [:open] (:from-path e))
+                                (= :door/close (:event e))
+                                (= :may-close? (:guard e)))
+                       (:id e))))))
+
+(deftest xyflow-graph-marks-guard-blocked-event-node-and-its-edges
+  (testing "rf2-fzrzlw — a parsed-edge id in :guard-blocked-edge-ids marks
+            BOTH the inbound + outbound edges AND the event-node for that
+            transition with `:guardBlocked true`. Other edges / event-nodes
+            stay `:guardBlocked false`."
+    (let [parsed   (layout/project-definition door-cyclic-machine)
+          close-id (door-close-edge-id parsed)
+          graph    (projection/xyflow-graph
+                     parsed {} {:guard-blocked-edge-ids #{close-id}})
+          ev-node  (event-node-for graph close-id)
+          in-edge  (inbound-edge-for  graph close-id)
+          out-edge (outbound-edge-for graph close-id)
+          other-ev (remove #(= (:id %) (:id ev-node))
+                           (filter #(= "rf2-event" (:type %)) (:nodes graph)))
+          other-ed (remove #(#{(:id in-edge) (:id out-edge)} (:id %))
+                           (:edges graph))]
+      (is (string? close-id) "fixture has the guarded :door/close edge")
+      (is (true? (:guardBlocked (:data ev-node))))
+      (is (true? (:guardBlocked (:data in-edge))))
+      (is (true? (:guardBlocked (:data out-edge))))
+      (is (every? #(false? (:guardBlocked (:data %))) other-ev))
+      (is (every? #(false? (:guardBlocked (:data %))) other-ed)))))
+
+(deftest xyflow-graph-no-guard-blocked-ids-leaves-all-unblocked
+  (testing "rf2-fzrzlw — omitting :guard-blocked-edge-ids leaves EVERY edge
+            + event-node `:guardBlocked false`"
+    (let [parsed (layout/project-definition door-cyclic-machine)
+          graph  (projection/xyflow-graph parsed {} {})]
+      (is (seq (:edges graph)))
+      (is (every? #(false? (:guardBlocked (:data %))) (:edges graph))
+          "no guard-blocked set → no guard-blocked edges")
+      (is (every? #(false? (:guardBlocked (:data %)))
+                  (filter #(= "rf2-event" (:type %)) (:nodes graph)))
+          "no guard-blocked set → no guard-blocked event-nodes"))))
+
+(deftest xyflow-graph-guard-blocked-marker-colour-distinct
+  (testing "rf2-fzrzlw — a guard-blocked edge's arrowhead colour is the
+            PINK guard-blocked hue, distinct from a non-blocked edge's, so
+            the attempted-and-rejected edge stands out"
+    (let [parsed     (layout/project-definition door-cyclic-machine)
+          close-id   (door-close-edge-id parsed)
+          ct         (tokens/chart-tokens)
+          graph      (projection/xyflow-graph
+                       parsed {} {:guard-blocked-edge-ids #{close-id}})
+          blocked-in (inbound-edge-for graph close-id)
+          plain-e    (first (remove #(or (= (:id %) (:id blocked-in))
+                                         (:guardBlocked (:data %))
+                                         (:entry (:data %)))
+                                    (:edges graph)))]
+      (is (some? plain-e) "fixture has a non-blocked transition edge")
+      (is (= (:edge-guard-blocked ct) (:color (:markerEnd blocked-in)))
+          "the blocked arrowhead paints the pink guard-blocked hue")
+      (is (not= (:color (:markerEnd blocked-in))
+                (:color (:markerEnd plain-e)))
+          "blocked vs non-blocked arrowheads are distinct colours"))))
+
+(deftest xyflow-graph-guard-blocked-wins-over-active-affordance
+  (testing "rf2-fzrzlw design call (2) — when the source state is ACTIVE
+            (all-exits affordance-blue) AND the edge is guard-blocked, the
+            blocked PINK overrides the affordance-blue on that edge so it
+            stands out (does not merely sit under the all-exits-blue)."
+    (let [parsed     (layout/project-definition door-cyclic-machine)
+          close-id   (door-close-edge-id parsed)
+          ct         (tokens/chart-tokens)
+          ;; :open is active → its exits are affordance-blue; :door/close is
+          ;; ALSO guard-blocked, so its arrowhead must read PINK, not blue.
+          graph      (projection/xyflow-graph
+                       parsed {} {:highlight-id (layout/node-id [:open])
+                                  :guard-blocked-edge-ids #{close-id}})
+          blocked-in (inbound-edge-for graph close-id)]
+      (is (true? (:active (:data blocked-in)))
+          "the source :open is active, so this exit is affordance-active")
+      (is (true? (:guardBlocked (:data blocked-in)))
+          "AND it is guard-blocked")
+      (is (= (:edge-guard-blocked ct) (:color (:markerEnd blocked-in)))
+          "the PINK guard-blocked hue WINS over the affordance-blue"))))
+
 ;; ---- compound-endpoint edges (rf2-shv82, Issue 1) -----------------------
 ;;
 ;; A parent-level transition like `:active → :disconnected` (declared on

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
@@ -224,3 +224,45 @@
       (is (= (:edge-quiet ct) (tokens/edge-color ct {})))
       (is (= (:edge-quiet ct)
              (tokens/edge-color ct {:fired? false :focused? false :active? false}))))))
+
+;; ---- guard-blocked edge hue (rf2-fzrzlw) -------------------------------
+
+(deftest chart-tokens-guard-blocked-is-pink
+  (testing "rf2-fzrzlw — `:edge-guard-blocked` resolves to the palette's
+            PINK `:magenta-pink` token in BOTH themes, and is DISTINCT
+            from the fired/active/quiet edge hues AND the red `:final-error`
+            terminal ring (a pink 'blocked' signal, not a red error)."
+    (doseq [palette [tokens/dark-palette tokens/light-palette]]
+      (let [ct (tokens/chart-tokens palette)]
+        (is (= (:magenta-pink palette) (:edge-guard-blocked ct))
+            "guard-blocked edge tracks the palette pink hue")
+        (is (string? (:edge-guard-blocked ct)))
+        (is (not= (:edge-fired ct)  (:edge-guard-blocked ct)))
+        (is (not= (:edge-active ct) (:edge-guard-blocked ct)))
+        (is (not= (:edge-quiet ct)  (:edge-guard-blocked ct)))
+        (is (not= (:final-error ct) (:edge-guard-blocked ct))
+            "pink blocked-edge is distinct from the red error-final ring")))))
+
+(deftest edge-color-blocked-wins-outright
+  (testing "rf2-fzrzlw design call (2) — `blocked?` wins OUTRIGHT over
+            fired / focused / active so the attempted-and-rejected edge
+            paints the PINK guard-blocked hue, standing out from the
+            affordance-blue exits."
+    (let [ct (tokens/chart-tokens)]
+      (is (= (:edge-guard-blocked ct)
+             (tokens/edge-color ct {:blocked? true})))
+      (is (= (:edge-guard-blocked ct)
+             (tokens/edge-color ct {:blocked? true :fired? true
+                                    :focused? true :active? true}))
+          "blocked beats fired + focused + active all at once"))))
+
+(deftest edge-color-unblocked-falls-through-to-fired-ladder
+  (testing "rf2-fzrzlw — `blocked? false` (or absent) leaves the existing
+            fired > focused/active > quiet ladder intact (no regression)."
+    (let [ct (tokens/chart-tokens)]
+      (is (= (:edge-fired ct)
+             (tokens/edge-color ct {:blocked? false :fired? true})))
+      (is (= (:edge-active ct)
+             (tokens/edge-color ct {:blocked? false :focused? true})))
+      (is (= (:edge-quiet ct)
+             (tokens/edge-color ct {:blocked? false}))))))

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -660,14 +660,23 @@ transition does, with these differences:
   from-highlight / to-highlight — so the chart paints a single active-state
   highlight on the current node rather than a misleading `state → state`
   self-transition edge.
+- **The guard-blocked edge paints PINK (rf2-fzrzlw).** When the no-op is a
+  GUARD-BLOCK (a clause for the event-id exists but its `:guard` returned
+  false / threw), the chart marks that exact edge — and its event-node —
+  GUARD-BLOCKED so the operator sees _which_ edge the event hit and that a
+  guard rejected it. See
+  [§Guard-blocked edge highlight on the topology chart (rf2-fzrzlw)](#guard-blocked-edge-highlight-on-the-topology-chart-rf2-fzrzlw)
+  for the full mechanism. (Before rf2-fzrzlw the chart painted ALL of the
+  active state's exits affordance-blue and gave ZERO rejection signal.)
 - **No snapshot drill-in.** The no-op trace carries no `:before` / `:after`
   snapshot pair (`:data` did not change), so the drill-in suppresses cleanly.
-- **No guards / actions list.** Today's substrate does not emit
-  `:rf.machine/guard-evaluated` for the declining (guard-blocked) candidate —
-  the no-op trace is the sole signal — so there are no guard / action rows to
-  attach. (A follow-on bead may surface the failing guard in the lens once the
-  substrate emits a guard trace on the no-op path; the record shape stays
-  stable.)
+- **No guards / actions LIST in the lens.** The lens's GUARDS-RUN / ACTIONS-RUN
+  forensic LIST is still driven off the cascade projection (the no-op trace is
+  its sole signal there), so no rows attach to the lens list. (The CHART,
+  however, DOES surface the failing guard — it consumes the
+  `:rf.machine/guard-evaluated` fail/threw trace directly; see the rf2-fzrzlw
+  section. A follow-on bead may surface the failing guard in the lens LIST too;
+  the record shape stays stable.)
 
 A machine that BOTH transitioned (or was born) AND no-op'd in the same cascade
 surfaces only its transition / birth record — a no-op is single-signalled
@@ -680,6 +689,62 @@ The Epoch panel's EVENT HANDLER section renders the SAME no-op signal as a
 muted `[NO OP] staying in {state}` cascade-row (rf2-iu3no) — that surface is
 the per-event cascade narration; this section is the Machines TAB's topology
 read. Both key off the one `:rf.machine.event/unhandled-no-op` trace.
+
+### Guard-blocked edge highlight on the topology chart (rf2-fzrzlw)
+
+A guard-blocked no-op (above) emits NO `:rf.machine/transition`, so the chart's
+fired-edge set ([§fired-this-epoch](#focused-transition-lens--above-the-chart-rf2-99rhe))
+is empty for it. Pre-rf2-fzrzlw the chart therefore painted ALL of the active
+state's outgoing edges affordance-blue and gave the operator ZERO signal that a
+specific edge was _attempted and rejected_. The motivating case (Mike, live
+`examples/machine-epochs` door, 2026-06-08): door in `:open` with `held-open?
+true`; dispatch `[:door/close]`; the `:may-close? = (not held-open?)` guard
+fails → guard-blocked no-op.
+
+**The data already exists.** On the declining candidate the runtime emits
+`:rf.machine/guard-evaluated {:machine-id … :guard-id <named-guard> :outcome
+:fail|:threw :input {:event <event>}}` (machines · `transition.cljc`
+`evaluate-guard`). The named guard is the PRECISION the bare transition trace
+lacks: `(event, guard)` uniquely picks the declining candidate — even one arm
+of a guarded fork.
+
+**Derivation (data plane).** `panels/machines/trace-state/extract-guard-blocked-edge-ids`
+filters the focused epoch's `:rf.machine/guard-evaluated` traces (for this
+`:machine-id`) to the `:fail` / `:threw` outcomes, then matches each by
+`(event, guard-ref)` against the edges of `chart.layout/project-definition`,
+returning the CANONICAL machines-viz edge-ids (the EXACT ids the live chart
+mints — agreement by construction, mirroring `extract-fired-edge-ids`). The
+host threads the set as `:guard-blocked-edge-ids` into `machine-canvas/Chart` →
+`MachineChart` (both the Dynamic Machine tab and the Static Topology view).
+
+**Render (render plane).** `chart.projection/xyflow-graph` marks each matching
+edge and its event-node `:guardBlocked`; `chart.nodes.event-node` +
+`chart.edges` then paint the guard-blocked treatment off the new
+`theme/tokens` `:edge-guard-blocked` token (a PINK hue — `:magenta-pink`,
+distinct from the blue fired/active hues AND the red `:final-error` ring):
+
+1. The edge stroke + arrowhead paint PINK and emphasised-width (`tokens/edge-color`
+   resolves `:blocked?` with HIGHEST precedence).
+2. The event-node border + box-shadow go PINK and its `IF <guard>` chip is
+   EMPHASISED (bold pink) so the node reads as the guard that rejected it.
+
+**Design calls (Mike-ruled 2026-06-08):**
+
+- _(1) BOTH_ — pink the edge stroke AND emphasise the guard label.
+- _(2) The attempted edge WINS_ — on a guard-blocked no-op the PINK overrides
+  the all-exits affordance-blue on that specific edge (it does NOT merely sit
+  under the blue). `tokens/edge-color` ranks `blocked? > fired? > focused?/active? > quiet`.
+- _(3) Scope = guard-blocked ONLY_ — a truly-unhandled event (no declared edge)
+  is a separate state-node "ignored event" marker, filed separately.
+
+**Beyond XState.** Stately labels the guarded edge but, on a block, takes no
+transition and highlights NOTHING — it does not paint a guard-failed edge
+colour. This is a SUPERSET enhancement, only possible because re-frame2 emits
+`:rf.machine/guard-evaluated` (observable-everything ethos).
+
+DOM pins: every guard-blocked edge label / event-node carries
+`data-guard-blocked="true"`; the chart root surfaces the sorted set on
+`data-guard-blocked-edge-ids` (mirroring `data-fired-edge-ids`).
 
 ### Relationship to the focused-transition lens (rf2-99rhe)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -380,6 +380,14 @@
                           traversed edges paint the FIRED treatment on the
                           live chart — not just the from/to lens. nil /
                           `#{}` → no fired highlight (Static passes none).
+    :guard-blocked-edge-ids — rf2-fzrzlw. A SET of canonical machines-viz
+                          edge-ids whose guard REJECTED the event this
+                          epoch (a guard-blocked no-op — resolved by the
+                          host via
+                          `panels.machines.trace-state/extract-guard-blocked-edge-ids`).
+                          Forwarded to `mv-chart/MachineChart` so the
+                          attempted-and-rejected edges paint the PINK
+                          guard-blocked treatment. nil / `#{}` → none.
     :sim?               — rf2-u422r. When true the active-state
                           highlight uses the amber sim palette (so the
                           on-chart hermetic simulator reads distinct
@@ -418,7 +426,7 @@
   internally — no host-side viewport machinery is needed
   post-migration."
   [{:keys [definition machine-id from-highlight to-highlight current-state
-           fired-edge-ids machine-data
+           fired-edge-ids guard-blocked-edge-ids machine-data
            sim? on-state-click on-edge-click
            show-after-rings? show-view-mode-toggle?
            show-controls? theme testid inner-testid
@@ -461,6 +469,7 @@
       :to-highlight    to-highlight
       :current-state   current-state
       :fired-edge-ids  fired-edge-ids
+      :guard-blocked-edge-ids guard-blocked-edge-ids
       :sim?            sim?
       :theme           theme
       :on-state-click  on-state-click

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -211,7 +211,7 @@
   toolbar."
   [cascade
    {:keys [machine-id from-state to-state definition fired-edge-ids
-           start? no-op?]
+           guard-blocked-edge-ids start? no-op?]
     :as _record}]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — the host-side ELK
   ;; layout dance is GONE; xyflow + elkjs own positioning end-to-end
@@ -294,6 +294,11 @@
               ;; JVM/hiccup suite + hosts pin the wiring without reaching
               ;; into the xyflow canvas. "" when none fired.
               :data-fired-edge-ids (str/join " " (sort (set fired-edge-ids)))
+              ;; rf2-fzrzlw — the focused epoch's guard-blocked no-op edge
+              ;; ids on the canvas wrapper (sorted, space-joined) so the
+              ;; JVM/hiccup suite + hosts pin the wiring without reaching
+              ;; into the xyflow canvas. "" when none blocked.
+              :data-guard-blocked-edge-ids (str/join " " (sort (set guard-blocked-edge-ids)))
               :data-view-mode "canvas"
               ;; rf2-zdfbm — fill the section's remaining height so the
               ;; topology chart expands into the panel. `flex 1` +
@@ -336,6 +341,12 @@
            ;; rf2-qeemm (G3) — the traversed edges paint the FIRED
            ;; treatment on the live chart.
            :fired-edge-ids     fired-edge-ids
+           ;; rf2-fzrzlw — the attempted-and-rejected edges (guard-blocked
+           ;; no-op, e.g. door :door/close blocked by :may-close?) paint
+           ;; the PINK guard-blocked treatment on the live chart so the
+           ;; operator sees which edge the event hit + that a guard
+           ;; rejected it (no transition fired, so the fired set is empty).
+           :guard-blocked-edge-ids guard-blocked-edge-ids
            ;; rf2-6tw7t — fit-on-entry nonce so re-entering the Machine
            ;; tab re-frames the topology.
            :fit-signal         fit-signal
@@ -682,10 +693,22 @@
         ;; threads it into `MachineChart` so the traversed arms paint the
         ;; FIRED treatment — every microstep / guard-fork candidate the
         ;; from/to lens cannot reach.
+        ;; rf2-fzrzlw — additionally attach the guard-BLOCKED edge-ids: a
+        ;; guard-blocked no-op emits NO `:rf.machine/transition` (so
+        ;; `fired-edge-ids` is empty for it), but the runtime DOES emit
+        ;; `:rf.machine/guard-evaluated` fail/threw carrying the named
+        ;; guard, so `extract-guard-blocked-edge-ids` resolves the exact
+        ;; attempted-and-rejected edge. The view threads it into
+        ;; `MachineChart` so that edge paints the PINK guard-blocked
+        ;; treatment instead of vanishing into the affordance-blue exits.
         (mapv (fn [{:keys [machine-id definition] :as rec}]
-                (assoc rec :fired-edge-ids
-                       (trace-state/extract-fired-edge-ids
-                         definition events machine-id)))
+                (assoc rec
+                  :fired-edge-ids
+                  (trace-state/extract-fired-edge-ids
+                    definition events machine-id)
+                  :guard-blocked-edge-ids
+                  (trace-state/extract-guard-blocked-edge-ids
+                    definition events machine-id)))
               (h/project-focused-event-transitions events definitions)))))
 
   ;; ---- focused-epoch cascade events (rf2-g2axio) ------------------

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/topology_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/topology_view.cljs
@@ -165,6 +165,13 @@
                                               snapshot-state)
         fired-ids (trace-state/extract-fired-edge-ids definition trace-events
                                                       machine-id)
+        ;; rf2-fzrzlw — the guard-blocked no-op edge ids for the focused
+        ;; epoch. A guard-blocked transition emits NO `:rf.machine/transition`
+        ;; (so `fired-ids` is empty for it), but the runtime DOES emit
+        ;; `:rf.machine/guard-evaluated` fail/threw — so the attempted-and-
+        ;; rejected edge can still be marked PINK on the chart.
+        guard-blocked-ids (trace-state/extract-guard-blocked-edge-ids
+                            definition trace-events machine-id)
         ;; Case-B detection (rf2-dbi87 / spec/021 §6.2): the focused
         ;; epoch fired no transitions for this machine. The view STILL
         ;; renders the topology — only the fired-this-epoch overlay is
@@ -240,6 +247,10 @@
          ;; it. `#{}` (case-B / no transition this epoch) → no fired
          ;; highlight, identical to passing none.
          :fired-edge-ids         fired-ids
+         ;; rf2-fzrzlw — forward the guard-blocked no-op edge ids so the
+         ;; attempted-and-rejected edge paints PINK even though it fired
+         ;; no transition (the door :door/close blocked by :may-close?).
+         :guard-blocked-edge-ids guard-blocked-ids
          ;; rf2-vcnvj — surface the STATIC context shape (keys + type
          ;; captions of the definition's `:data`) so the root Context
          ;; chrome renders on the blank-state topology. nil when the

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
@@ -6,7 +6,7 @@
   ## Scope
 
   Pure data, no DOM / React / re-frame side effects. Every input is
-  data; every output is data. The four public fns answer two questions
+  data; every output is data. The public fns answer three questions
   the topology overlay asks of a buffer of trace events:
 
     1. **Which state is the machine in?** — `current-state-from-traces`
@@ -17,6 +17,20 @@
 
     2. **Which edges fired this epoch?** — `extract-fired-edge-ids`,
        returning machines-viz-CANONICAL edge ids (see below).
+
+    3. **Which edges were GUARD-BLOCKED this epoch?** —
+       `extract-guard-blocked-edge-ids` (rf2-fzrzlw), returning the
+       canonical edge ids whose guard evaluated `:fail` / `:threw` so
+       the transition was a no-op. A guard-blocked no-op emits NO
+       `:rf.machine/transition` (the chart's fired set is empty), so
+       without this the operator gets ZERO signal that the event hit an
+       edge and was rejected. The runtime DOES emit the exact data —
+       `:rf.machine/guard-evaluated {:guard-id … :outcome :fail/:threw
+       :input {:event …}}` (machines · transition.cljc) — carrying the
+       NAMED guard the bare transition trace lacks, so the blocked-edge
+       match is EXACT. This is a SUPERSET enhancement beyond XState
+       (Stately takes no transition + highlights nothing on a block);
+       only possible because re-frame2 emits `guard-evaluated`.
 
   Before rf2-8jzm1 these helpers were scattered through the pure-data
   projector `topology.cljs`, interleaved with node/edge geometry. They
@@ -261,4 +275,107 @@
                                         (= event* (:event e)))
                                (:id e)))
                            edges)))))))
+         set)))
+
+;; ---- guard-blocked-edge ids (rf2-fzrzlw) --------------------------------
+
+(defn- machine-guard-evaluated?
+  "True when `ev` is a `:rf.machine/guard-evaluated` trace event for
+  `machine-id` (or for ANY machine when `machine-id` is nil). The
+  machine-id rides under `:tags :machine-id` (machines ·
+  transition.cljc `evaluate-guard` `trace/emit!`)."
+  [ev machine-id]
+  (and (= :rf.machine/guard-evaluated (:operation ev))
+       (or (nil? machine-id)
+           (= machine-id (get-in ev [:tags :machine-id])))))
+
+(defn- guard-blocked?
+  "True when a `:rf.machine/guard-evaluated` trace's `:outcome` signals
+  the guard DECLINED the candidate — `:fail` (guard returned falsey) or
+  `:threw` (guard threw; the engine treats throw as fail and walks on,
+  per machines · transition.cljc `evaluate-guard`)."
+  [ev]
+  (contains? #{:fail :threw} (get-in ev [:tags :outcome])))
+
+(defn- guard-ref-from-trace
+  "Pull the user-declared guard REF off a `:rf.machine/guard-evaluated`
+  trace. The ref is the value AS-IS (keyword OR inline fn — Spec
+  Schemas §`:rf.machine/guard-evaluated`); it rides `:tags :guard-id`
+  (the canonical slot) with a legacy `:tags :guard` fallback (mirrors
+  `machine_inspector_helpers/guard-record`). Returns the ref or nil."
+  [ev]
+  (or (get-in ev [:tags :guard-id])
+      (get-in ev [:tags :guard])))
+
+(defn- guard-event-from-trace
+  "Pull the inbound EVENT keyword off a `:rf.machine/guard-evaluated`
+  trace. The event rides `:tags :input :event` (the unified callback
+  context the engine stamps — machines · transition.cljc
+  `evaluate-guard` `input {:data … :event …}`); a legacy `:tags :event`
+  fallback covers test fixtures that stamp it flat. The event may be a
+  bare keyword or a `[event-id & args]` vector; returns the bare event
+  keyword (the vector's head) or nil."
+  [ev]
+  (let [event (or (get-in ev [:tags :input :event])
+                  (get-in ev [:tags :event]))]
+    (cond
+      (keyword? event) event
+      (vector? event)  (first event)
+      :else            nil)))
+
+(defn extract-guard-blocked-edge-ids
+  "Given a machine `definition`, a vector of trace events for the
+  focused epoch, and the `machine-id` of interest, return the SET of
+  machines-viz-canonical edge ids that were GUARD-BLOCKED this epoch —
+  the transition's guard evaluated `:fail` / `:threw` so the event was
+  a no-op (NO `:rf.machine/transition` was emitted). Pure fn —
+  JVM-runnable. rf2-fzrzlw.
+
+  A guard-blocked no-op paints NOTHING on the chart via the fired set
+  (it carries no transition), so the operator cannot see which edge the
+  event hit or that a guard rejected it. The runtime emits the exact
+  data on the no-op path: `:rf.machine/guard-evaluated {:guard-id …
+  :outcome :fail/:threw :input {:event …}}` carrying the NAMED guard,
+  so the blocked-edge match is EXACT — `(event, guard)` uniquely picks
+  the declining candidate even within a guarded fork (the precision the
+  bare transition trace lacks; see `extract-fired-edge-ids`' loose
+  `(from, to, event)` match).
+
+  The returned ids are the EXACT ids the live MachineChart mints: the
+  definition is projected through `chart.layout/project-definition` and
+  each fail/threw guard trace's `(event, guard-ref)` is matched against
+  the projected edges' `:event` / `:guard`. The guard refs compare with
+  `=` because both the trace's `:guard-id` and the edge's `:guard` are
+  the SAME user-declared ref off the SAME definition (keyword or fn).
+
+  Scope is GUARD-BLOCKED only (rf2-fzrzlw design call (3)): a truly-
+  unhandled event (no declared edge for it) is a separate state-node
+  'ignored event' marker, filed separately.
+
+  Returns `#{}` for a nil/empty definition or no fail/threw guard
+  traces."
+  [definition trace-events machine-id]
+  (let [edges (:edges (chart-layout/project-definition definition))]
+    (->> (or trace-events [])
+         (filter #(and (machine-guard-evaluated? % machine-id)
+                       (guard-blocked? %)))
+         (mapcat
+           (fn [ev]
+             (let [guard* (guard-ref-from-trace ev)
+                   event* (guard-event-from-trace ev)]
+               ;; A blocked candidate is uniquely (event, guard): the
+               ;; named guard discriminates which arm of a guarded fork
+               ;; declined. Match every projected edge carrying that
+               ;; same (event, guard) pair — typically exactly one. An
+               ;; edge with no guard cannot be the blocked candidate, so
+               ;; the `(some? guard*)` precondition keeps a guardless
+               ;; trace (which the runtime never emits — `evaluate-guard`
+               ;; skips the synthesised always-true guard) from lighting
+               ;; every same-event edge.
+               (when (and (some? guard*) event*)
+                 (keep (fn [e]
+                         (when (and (= event* (:event e))
+                                    (= guard* (:guard e)))
+                           (:id e)))
+                       edges)))))
          set)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
@@ -418,3 +418,170 @@
       (is (some? local-edge))
       (is (= #{(:id local-edge)} fired)
           "the state-local edge lights; the machine-level fallback is not pulled in"))))
+
+;; ---- extract-guard-blocked-edge-ids (rf2-fzrzlw) ------------------------
+;;
+;; A guard-blocked transition is a NO-OP: the guard evaluated fail/threw, so
+;; the runtime emits `:rf.machine/guard-evaluated {:guard-id … :outcome
+;; :fail/:threw :input {:event …}}` but NO `:rf.machine/transition` — the
+;; fired set is empty for it. `extract-guard-blocked-edge-ids` recovers the
+;; EXACT attempted-and-rejected edge from the (event, guard) pair the guard
+;; trace carries (the named guard the transition trace lacks), so the chart
+;; can paint it PINK instead of leaving it invisible among the blue exits.
+
+(defn- door-definition
+  "The bead's repro shape: a door in `:open` with a `:door/close` guarded
+  by `:may-close?`. When `held-open? = true` the guard fails → no-op."
+  []
+  {:initial :closed
+   :states  {:closed {:on {:door/open :open}}
+             :open   {:on {:door/close {:target :closed
+                                        :guard  :may-close?}}}}})
+
+(defn- canonical-guard-edge-id
+  "Look up the canonical machines-viz edge id for an edge matching
+  `from-path` / `event` / `guard` in `definition` — projected through the
+  SAME public `chart.layout/project-definition` the live chart uses."
+  [definition from-path event guard]
+  (->> (:edges (chart-layout/project-definition definition))
+       (some (fn [e]
+               (when (and (= from-path (:from-path e))
+                          (= event     (:event e))
+                          (= guard     (:guard e)))
+                 (:id e))))))
+
+(deftest guard-blocked-ids-match-on-fail-outcome
+  (testing "rf2-fzrzlw — a guard-evaluated :fail lights the canonical
+            (from, event, guard) edge id the live chart mints"
+    (let [def        (door-definition)
+          close-id   (canonical-guard-edge-id def [:open] :door/close :may-close?)
+          ;; the LIVE runtime shape: :guard-id + :outcome + :input {:event}.
+          events     [{:operation :rf.machine/guard-evaluated
+                       :tags {:machine-id :door
+                              :guard-id   :may-close?
+                              :outcome    :fail
+                              :input      {:data {:held-open? true}
+                                           :event [:door/close]}}}]
+          blocked    (trace-state/extract-guard-blocked-edge-ids def events :door)]
+      (is (string? close-id))
+      (is (= #{close-id} blocked)
+          "the blocked edge id is the live-chart :door/close [may-close?] edge"))))
+
+(deftest guard-blocked-ids-match-on-threw-outcome
+  (testing ":threw (the guard fn blew up; engine treats it as fail) also
+            marks the edge guard-blocked"
+    (let [def      (door-definition)
+          close-id (canonical-guard-edge-id def [:open] :door/close :may-close?)
+          events   [{:operation :rf.machine/guard-evaluated
+                     :tags {:machine-id :door
+                            :guard-id   :may-close?
+                            :outcome    :threw
+                            :input      {:event :door/close}}}]
+          blocked  (trace-state/extract-guard-blocked-edge-ids def events :door)]
+      (is (= #{close-id} blocked)))))
+
+(deftest guard-blocked-ids-ignore-pass-outcome
+  (testing "a guard that PASSED is not blocked — the transition fired,
+            so it must NOT light the guard-blocked pink"
+    (let [def     (door-definition)
+          events  [{:operation :rf.machine/guard-evaluated
+                    :tags {:machine-id :door
+                           :guard-id   :may-close?
+                           :outcome    :pass
+                           :input      {:event :door/close}}}]
+          blocked (trace-state/extract-guard-blocked-edge-ids def events :door)]
+      (is (= #{} blocked)))))
+
+(deftest guard-blocked-ids-empty-and-nil-safety
+  (testing "no guard traces / nil events / nil definition → empty set"
+    (let [def (door-definition)]
+      (is (= #{} (trace-state/extract-guard-blocked-edge-ids def [] :door)))
+      (is (= #{} (trace-state/extract-guard-blocked-edge-ids def nil :door)))
+      (is (= #{} (trace-state/extract-guard-blocked-edge-ids
+                   def [{:operation :something-else}] :door)))
+      (is (= #{} (trace-state/extract-guard-blocked-edge-ids
+                   nil
+                   [{:operation :rf.machine/guard-evaluated
+                     :tags {:machine-id :door :guard-id :may-close?
+                            :outcome :fail :input {:event :door/close}}}]
+                   :door))))))
+
+(deftest guard-blocked-ids-scope-by-machine-id
+  (testing "ignores guard traces belonging to other machines"
+    (let [def      (door-definition)
+          close-id (canonical-guard-edge-id def [:open] :door/close :may-close?)
+          events   [{:operation :rf.machine/guard-evaluated
+                     :tags {:machine-id :other
+                            :guard-id   :may-close?
+                            :outcome    :fail
+                            :input      {:event :door/close}}}
+                    {:operation :rf.machine/guard-evaluated
+                     :tags {:machine-id :door
+                            :guard-id   :may-close?
+                            :outcome    :fail
+                            :input      {:event :door/close}}}]
+          blocked  (trace-state/extract-guard-blocked-edge-ids def events :door)]
+      (is (= #{close-id} blocked)
+          "only the :door machine's blocked edge lights"))))
+
+(deftest guard-blocked-ids-read-legacy-flat-event-and-guard-slots
+  (testing "legacy fixture shape: flat :tags :event + :tags :guard
+            (mirrors machine_inspector_helpers/guard-record's fallbacks)"
+    (let [def      (door-definition)
+          close-id (canonical-guard-edge-id def [:open] :door/close :may-close?)
+          events   [{:operation :rf.machine/guard-evaluated
+                     :tags {:machine-id :door
+                            :guard      :may-close?   ;; legacy :guard slot
+                            :outcome    :fail
+                            :event      :door/close}}]  ;; legacy flat :event
+          blocked  (trace-state/extract-guard-blocked-edge-ids def events :door)]
+      (is (= #{close-id} blocked)))))
+
+(deftest guard-blocked-ids-read-event-vector-head
+  (testing "the :input :event may be a [event-id & args] vector — the head
+            (:door/close) drives the match"
+    (let [def      (door-definition)
+          close-id (canonical-guard-edge-id def [:open] :door/close :may-close?)
+          events   [{:operation :rf.machine/guard-evaluated
+                     :tags {:machine-id :door
+                            :guard-id   :may-close?
+                            :outcome    :fail
+                            :input      {:event [:door/close :extra-arg]}}}]
+          blocked  (trace-state/extract-guard-blocked-edge-ids def events :door)]
+      (is (= #{close-id} blocked)))))
+
+(deftest guard-blocked-ids-disambiguate-guarded-fork-arm
+  (testing "rf2-fzrzlw precision win — a guarded FORK (two same-source/
+            same-event candidates differing by guard) lights ONLY the arm
+            whose NAMED guard the trace reports failing, not its sibling"
+    (let [def       {:initial :idle
+                     :states  {:idle {:on {:check [{:guard :hi? :target :high}
+                                                   {:guard :lo? :target :low}]}}
+                               :high {}
+                               :low  {}}}
+          projected (:edges (chart-layout/project-definition def))
+          hi-id     (->> projected (some (fn [e] (when (= :hi? (:guard e)) (:id e)))))
+          lo-id     (->> projected (some (fn [e] (when (= :lo? (:guard e)) (:id e)))))
+          ;; :hi? failed; the engine walked on to :lo? (which passed and
+          ;; fired) — only the :hi? ARM is guard-blocked.
+          events    [{:operation :rf.machine/guard-evaluated
+                      :tags {:machine-id :m :guard-id :hi? :outcome :fail
+                             :input {:event :check}}}]
+          blocked   (trace-state/extract-guard-blocked-edge-ids def events :m)]
+      (is (string? hi-id))
+      (is (string? lo-id))
+      (is (not= hi-id lo-id) "the two fork arms have distinct ids")
+      (is (= #{hi-id} blocked)
+          "ONLY the :hi? arm lights — the named guard discriminates the fork"))))
+
+(deftest guard-blocked-ids-agree-with-projected-chart-edge-ids
+  (testing "every guard-blocked id is a real projected chart edge :id"
+    (let [def           (door-definition)
+          projected-ids (set (map :id (:edges (chart-layout/project-definition def))))
+          events        [{:operation :rf.machine/guard-evaluated
+                          :tags {:machine-id :door :guard-id :may-close?
+                                 :outcome :fail :input {:event :door/close}}}]
+          blocked       (trace-state/extract-guard-blocked-edge-ids def events :door)]
+      (is (seq blocked))
+      (is (every? projected-ids blocked)
+          "each guard-blocked id is one the live chart actually rendered"))))


### PR DESCRIPTION
Fixes **rf2-fzrzlw** (P2 BUG) — a guard-blocked transition was invisible on the machine topology chart.

## Problem

Door in `:open` with `held-open? true`; dispatch `[:door/close]`; the `:may-close? = (not held-open?)` guard fails → guard-blocked **no-op**. A no-op emits **no** `:rf.machine/transition`, so the chart's fired set is empty — it painted ALL of `:open`'s exits affordance-blue and gave the operator ZERO signal which edge the event hit or that a guard rejected it.

## Fix (two coordinated planes)

**Data** — `panels/machines/trace-state/extract-guard-blocked-edge-ids` derives the canonical machines-viz edge-ids from the focused epoch's `:rf.machine/guard-evaluated` `:fail`/`:threw` traces. The trace carries the **named** `:guard-id` the bare transition trace lacks, so the `(event, guard)` match is EXACT — it picks the declining arm even within a guarded fork. Ids agree with the live chart by construction (via `project-definition`, mirroring `extract-fired-edge-ids`).

**Render** — `theme/tokens` gains `:edge-guard-blocked` (pink `:magenta-pink`, distinct from the blue fired/active hues and the red `:final-error` ring). `edge-color` ranks `blocked? > fired? > focused?/active? > quiet`, so the pink **wins** over the affordance-blue on that edge. The matching edge (both `__in`/`__out` halves) + its event-node paint pink + emphasised, and the `IF <guard>` chip goes bold pink.

Wired through `chart.cljs` `MachineChart` → `machine-canvas/Chart` → both the **Dynamic** Machine tab (`machine_inspector`) and the **Static** Topology view (`topology_view`).

DOM pins: `data-guard-blocked` on each blocked edge label / event-node; the chart root surfaces `data-guard-blocked-edge-ids`.

### Design calls (Mike-ruled 2026-06-08)
- (1) BOTH — pink the edge stroke AND emphasise the guard label.
- (2) The attempted edge WINS — pink overrides the all-exits affordance-blue on that edge.
- (3) Scope = guard-blocked ONLY (truly-unhandled events are a separate follow-up).

Superset of XState/Stately, which highlights nothing on a block — only possible because re-frame2 emits `:rf.machine/guard-evaluated`.

## Spec note (specs-kept-current)
- `tools/xray/spec/003-Machine-Inspector.md` — new §"Guard-blocked edge highlight on the topology chart (rf2-fzrzlw)"; the no-op section's "no guards surfaced" caveat updated (the chart now surfaces the failing guard).
- `tools/machines-viz/spec/API.md` — `:guard-blocked-edge-ids` prop row, `:edge-guard-blocked` token row, `:guardBlocked` edge/event-node `:data` field.

## Quality gates
- machines-viz `clojure -M:test` — **436 tests, 1446 assertions, 0 failures, 0 errors**
- xray `clojure -M:test` — **1101 tests, 4577 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **5917 tests, 20977 assertions, 0 failures, 0 errors** (includes new trace_state + projection + tokens + chart_dom tests)
- xray-feature-gate — **not run** (feature matrix untouched; 16/16 unaffected)

New regression tests pinning the now-visible guard-blocked transition: `extract-guard-blocked-edge-ids` (fail/threw/pass/scope/legacy-shape/event-vector/**fork-arm precision**/chart-agreement), projection (`:guardBlocked` on edge+event-node, pink arrowhead, wins-over-active-affordance), tokens (`edge-color` blocked-wins precedence, pink-distinct), chart_dom (`data-guard-blocked` + root attr).