### PR TITLE
chore(ssr): remove vestigial code (rf2-jgdyr8)

### DIFF
--- a/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
@@ -312,7 +312,6 @@
    {:rf/app-db "not-a-map"}      ;; slice present but a string
    {:rf/app-db 42}               ;; slice present but a number
    {:rf/app-db [:not :a :map]}   ;; slice present but a vector
-   {:app-db "legacy-key-string"} ;; the legacy :app-db key, non-map slice
    {:rf/app-db true}])           ;; slice present but a boolean
 
 (deftest malformed-hydration-payload-never-installs

--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -52,12 +52,12 @@
   the schemas / routing sweeps closed at their boundaries.
 
   Returns a `:rf.error/*` reason string when `payload` is not a map, or
-  when the app-db slice KEY is present but its value is not a map (incl.
-  an explicit nil / false / non-collection); nil when the payload is
-  structurally acceptable (a map, with the `:rf/app-db` / `:app-db` key
-  either absent or carrying a map). A wholly-ABSENT app-db slice key is
-  NOT malformed — it is the documented client-only / no-server-slice
-  shape that falls back to the existing `db`."
+  when the `:rf/app-db` slice KEY is present but its value is not a map
+  (incl. an explicit nil / false / non-collection); nil when the payload
+  is structurally acceptable (a map, with the `:rf/app-db` key either
+  absent or carrying a map). A wholly-ABSENT app-db slice key is NOT
+  malformed — it is the documented client-only / no-server-slice shape
+  that falls back to the existing `db`."
   [payload]
   (cond
     (not (map? payload))
@@ -65,19 +65,17 @@
          (cond (nil? payload) "nil" :else (pr-str (type payload)))
          "); hydration rejected — the client app-db is left unchanged")
 
-    ;; The app-db slice KEY is present but its value is not a map.
+    ;; The `:rf/app-db` slice KEY is present but its value is not a map.
     ;; Installing a non-map (string / number / vector / nil / false) as
     ;; the whole app-db would corrupt the frame, so a PRESENT-but-non-map
     ;; slice is rejected (a wholly-absent key is the legitimate
-    ;; no-server-slice fallback and is NOT flagged here). The canonical
-    ;; key is `:rf/app-db`; `:app-db` is the legacy alias.
-    (let [k (cond (contains? payload :rf/app-db) :rf/app-db
-                  (contains? payload :app-db)    :app-db)]
-      (and k (not (map? (get payload k)))))
-    (let [k (if (contains? payload :rf/app-db) :rf/app-db :app-db)]
-      (str "the :rf/hydrate payload's " k " slice is not a map (got "
-           (cond (nil? (get payload k)) "nil" :else (pr-str (type (get payload k))))
-           "); hydration rejected — the client app-db is left unchanged"))
+    ;; no-server-slice fallback and is NOT flagged here).
+    (and (contains? payload :rf/app-db)
+         (not (map? (:rf/app-db payload))))
+    (str "the :rf/hydrate payload's :rf/app-db slice is not a map (got "
+         (cond (nil? (:rf/app-db payload)) "nil"
+               :else (pr-str (type (:rf/app-db payload))))
+         "); hydration rejected — the client app-db is left unchanged")
 
     :else nil))
 
@@ -97,7 +95,7 @@
   :rf/hydrate event — degraded-but-running), so a corrupt payload must
   never silently install garbage as the whole app-db."
   [{:keys [db frame]} [_ payload]]
-  (let [new-db (or (:rf/app-db payload) (:app-db payload) db)]
+  (let [new-db (or (:rf/app-db payload) db)]
     (if-let [reason (malformed-hydration-payload! payload)]
       (do
         (when interop/debug-enabled?

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -368,8 +368,7 @@
                          [:not :a :map]
                          {:rf/app-db "slice-is-a-string"}
                          {:rf/app-db [:slice :is :a :vector]}
-                         {:rf/app-db 99}
-                         {:app-db "legacy-key-non-map"}]]
+                         {:rf/app-db 99}]]
       (let [client-frame (rf/make-frame {:doc "ssr-basic client frame"
                                          :platform :client})]
         ;; Seed a recognisable pre-hydration client slice so we can prove


### PR DESCRIPTION
Vestigial-code review of `implementation/ssr` (SSR emit/hydrate, Spec 011) per **rf2-jgdyr8**. The slice is overwhelmingly clean; one genuine vestige found and removed.

## Finding (removed): `:app-db` hydration-payload legacy alias

The `:rf/hydrate` handler read the app-db slice from `:rf/app-db` with a fallback to a plain `:app-db` key, documented in-line as the "legacy alias".

- **Dead on the producer side.** No payload builder anywhere in the repo emits a plain `:app-db` key — `payload-policy/build-payload` and `streaming/build-final-payload` both produce `:rf/app-db`, and the ssr-ring host adapter builds payloads through them. (`git grep` confirms the only plain-`:app-db` occurrences repo-wide are the unrelated frame-record container field, the `:where :app-db` trace tag, and pair-tool/Story snapshot slice names.)
- **Diverges from spec.** Spec 011 only ever specifies `:rf/app-db` (the canonical hydrate handler destructures `{:rf/keys [... app-db ...]}`). The alias was undocumented pre-alpha back-compat residue at odds with the `:rf/*` single-root convention — removed, no shim (pre-alpha).

Changes:
- `hydrate.cljc`: drop the `:app-db` fallback in `new-db` resolution and simplify `malformed-hydration-payload!` to a single `:rf/app-db` branch (+ docstring/comment).
- Drop the now-obsolete `{:app-db ...}` legacy-key rows from two fail-closed tests (`ssr_hydration_test.clj` in-slice; `fail_closed_invariant_security_cljs_test.cljc` — a cross-artefact test that codified the alias). A map carrying only `:app-db` is now the documented no-slice client-only fallback, not a rejected payload.

## Reviewed clean (no change)
- **Payload-policy consolidation confirmed complete** — the old two-opt `:payload-keys` + `:payload-policy` handler surface is gone from src/tests (appears only in consolidation-documenting prose; `:payload-keys` in conformance fixtures is an assertion field name, unrelated).
- **No `#_` reader-discards** in the slice — the bead's "2 discards" raw signal was a false positive (both matches are the CSS id string `"#__rf_payload"`).
- **No unused `:require`s** across all 22 src files; **no dead defs** (all private re-exports are reached by parity/hash tests); **no commented-out code** (parenthetical-leading comments are prose); **no orphaned files**.
- `response.cljc` deprecated-CTL note and `html_helpers.cljc` "framework no longer emits JSX source-coord props" stripper are intentional (live defensive code / RFC prose), not vestige.

## Out-of-slice follow-up (filed)
`docs/guide/20-server-side.md` still documents the retired two-opt `:payload-keys` / `:payload-policy` surface — filed as a follow-up bead (human guide, out of this slice).

## Quality gates
- `clojure -M:test` (implementation/ssr): **308 tests, 1190 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **5899 tests, 20923 assertions, 0 failures, 0 errors** (assertion count -3 = the obsolete legacy-alias assertions removed)