### PR TITLE
chore(schemas): remove orphaned :schemas/malli-humanize hook (rf2-8k6qly)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -294,10 +294,6 @@
     :producer-ns 're-frame.schemas
     :design-bead "rf2-2ek7t"
     :description "Humanize the raw m/explain output into operator-readable shape. Per-validator adapters install their own humanizer; Malli's installs (malli.error/humanize ...). Absent the hook, the substrate ships only :explain (raw); Xray's violation block falls back to the raw map. Consulted by validate.cljc's emit-validation-failure! helper when building the :rf.error/schema-validation-failure trace payload — augments tags with :explain-humanized when present."}
-   {:key         :schemas/malli-humanize
-    :producer-ns 're-frame.schemas.malli
-    :design-bead "rf2-2ek7t"
-    :description "Default-installed Malli humanizer (malli.error/humanize). Consulted by re-frame.schemas/humanize-explain! through the standard validator-fn extension point — the same opt-in pattern as :schemas/malli-validate / :schemas/malli-explain. Apps that load re-frame.schemas.malli get the humanized payload on every schema-validation-failure trace event automatically."}
    {:key         :schemas/extract-large-paths-from-schema
     :producer-ns 're-frame.schemas
     :design-bead "rf2-nwv63"

--- a/implementation/schemas/src/re_frame/schemas/malli.cljc
+++ b/implementation/schemas/src/re_frame/schemas/malli.cljc
@@ -78,7 +78,6 @@
 
 (late-bind/set-fn! :schemas/malli-validate  malli.core/validate)
 (late-bind/set-fn! :schemas/malli-explain   malli.core/explain)
-(late-bind/set-fn! :schemas/malli-humanize  malli.error/humanize)
 
 ;; rf2-2ek7t — also publish the canonical :schemas/humanize-explain!
 ;; hook so consumers (Xray's violation block, future tools) read

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -246,8 +246,7 @@ The raw `:explain` value the registered explainer produces is structurally preci
 
 The humanize hook is a late-bind extension point — same opt-in pattern as `set-schema-validator!` / `set-schema-explainer!` / `set-schema-printer!`:
 
-- **Producer hook key**: `:schemas/humanize-explain!` (published by `re-frame.schemas`).
-- **Adapter hook key**: `:schemas/malli-humanize` (published by `re-frame.schemas.malli` — the CLJS reference's Malli adapter installs `malli.error/humanize`; the producer routes through it via the standard validator-fn extension point).
+- **Hook key**: `:schemas/humanize-explain!`. The producer (`re-frame.schemas`) consumes it; each port's validator adapter publishes it. The CLJS reference's Malli adapter (`re-frame.schemas.malli`) installs `malli.error/humanize` directly under this key on ns-load.
 
 When the hook is installed, the schemas artefact's `emit-validation-failure!` helper augments every `:rf.error/schema-validation-failure` trace event's `:tags` map with `:explain-humanized` alongside the existing `:explain`. Consumers read `:explain-humanized` when present and fall back to `:explain` otherwise — non-Malli validators (or apps that haven't required the Malli adapter ns) ship raw `:explain` only, and tools must degrade gracefully.
 
@@ -579,7 +578,7 @@ What the extension point does NOT cover: a *mix* of validators in one process. T
 
 ### Schema implies validation on CLJS (Malli wired by the artefact)
 
-On the CLJS reference, **requiring the schemas artefact wires the default Malli validator automatically** — there is nothing extra to opt into. The `re-frame.schemas` facade `:require`s the `re-frame.schemas.malli` adapter ns, whose only job is to publish `malli.core/validate` / `malli.core/explain` / `malli.error/humanize` into the framework's late-bind hook table on ns-load (`:schemas/malli-validate` / `:schemas/malli-explain` / `:schemas/malli-humanize`). The schemas artefact's default validator consults these hooks on every call:
+On the CLJS reference, **requiring the schemas artefact wires the default Malli validator automatically** — there is nothing extra to opt into. The `re-frame.schemas` facade `:require`s the `re-frame.schemas.malli` adapter ns, whose only job is to publish `malli.core/validate` / `malli.core/explain` / `malli.error/humanize` into the framework's late-bind hook table on ns-load (`:schemas/malli-validate` / `:schemas/malli-explain` / `:schemas/humanize-explain!`). The schemas artefact's default validator consults these hooks on every call:
 
 ```clojure
 (ns my-app.core


### PR DESCRIPTION
@
## Quality gates

| Gate | Result |
|---|---|
| schemas `clojure -M:test` | 274 tests, 18593 assertions, 0 failures, 0 errors |
| core JVM `clojure -M:test` (incl. late-bind drift gate) | 916 tests, 4114 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | 5899 tests, 20926 assertions, 0 failures, 0 errors |

## Removed surfaces

The late-bind hook `:schemas/malli-humanize` was published + catalogued + documented but had NO consumer. `git grep` confirmed zero `get-fn :schemas/malli-humanize` anywhere (impl, tools, tests). The real humanize path (`validate.cljc` `humanize-explain`) reads only `:schemas/humanize-explain!`, which `malli.cljc` binds directly to `malli.error/humanize` — so `:schemas/malli-humanize` was pure dead weight (the documented "producer routes through adapter" indirection was never implemented).

- **Publication** — dropped `(late-bind/set-fn! :schemas/malli-humanize malli.error/humanize)` from `implementation/schemas/src/re_frame/schemas/malli.cljc`. (`malli.error` require kept — still used by the canonical `:schemas/humanize-explain!` binding.)
- **Directory** — dropped the `:schemas/malli-humanize` entry (whose description wrongly claimed it was "Consulted by re-frame.schemas/humanize-explain!") from `implementation/core/src/re_frame/late_bind/directory.cljc`. The live `:schemas/humanize-explain!` entry is unchanged.
- **Spec** — reconciled `spec/010-Schemas.md`: collapsed the §Humanize-hook two-key (producer + adapter) description to the single `:schemas/humanize-explain!` hook the adapter actually publishes, and corrected the §Schema-implies-validation hook-list to `:schemas/humanize-explain!`.

Removal end-to-end keeps the late-bind drift gate (`every-directory-entry-is-actually-published`) consistent — both publication and directory entry removed together.

Closes rf2-8k6qly.
@