### PR TITLE
docs(xray): fix stale share.cljs comment refs (rf2-hblkl4)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/focus.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/focus.cljc
@@ -199,9 +199,8 @@
        (let [dispatches (focus-command->dispatches command)]
          ;; Fire into Xray's own shell frame (the host never sees it —
          ;; the channel is the command, not the frame split). Mirrors
-         ;; runtime.cljs's mutation accessors + share.cljs's restore
-         ;; path, which both target `defaults/default-frame-id` for the
-         ;; no-surrounding-frame case.
+         ;; runtime.cljs's mutation accessors, which target
+         ;; `defaults/default-frame-id` for the no-surrounding-frame case.
          (rf/with-frame defaults/default-frame-id
            (doseq [event-vec dispatches]
              (if sync?
@@ -232,9 +231,9 @@
 
      Dispatches each translated `:rf.xray/*` event into Xray's own
      `:rf/xray` shell frame (via `re-frame.core/with-frame` —
-     mirroring `runtime.cljs`'s mutation accessors + `share.cljs`'s
-     restore path). The host never sees Xray's internal frame; the
-     channel is the command, not the frame split.
+     mirroring `runtime.cljs`'s mutation accessors). The host never
+     sees Xray's internal frame; the channel is the command, not the
+     frame split.
 
      Returns a data-shaped result (mirroring `runtime.cljs`'s
      `{:ok? ...}` idiom):

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -2675,7 +2675,7 @@
     [cancellation-cascade/Popover]
     ;; rf2-nugvv (2026-06-04) — the Share modal (rf2-nqw0v Phase 5) is
     ;; removed. The Machine panel's Share button was its sole UI entry
-    ;; point, so the modal, its shell mount, and the `share.cljs` infra
+    ;; point, so the modal, its shell mount, and the share-URL infra
     ;; all go with it.
     ;; Mute manager modal (rf2-ikuwt) — lists every muted event-id
     ;; with per-row unmute buttons + a 'Unmute all' affordance. Same


### PR DESCRIPTION
Cleans stale comment references to `share.cljs` — the Share-URL infra file deleted by rf2-nugvv (PR #2897). A reader following those cross-refs hits a file that no longer exists.

## What was stale

- **`focus.cljc` (x2)** — the `with-frame` rationale (L200-204) and the `focus!` docstring (L233-237) both said the focus dispatch path "mirrors `runtime.cljs`'s mutation accessors + `share.cljs`'s restore path". `runtime.cljs` still exists (kept), `share.cljs` is gone (dropped). Meaning preserved: both still target `defaults/default-frame-id` for the no-surrounding-frame case.
- **`shell.cljs` (L2678)** — the rf2-nugvv Share-modal removal comment named "the `share.cljs` infra". Reworded to "the share-URL infra" — keeps the removal rationale, drops the dead file name.

Comment-only. No behavioural change.

## Deferred

The bead also lists two `share.cljs` refs in `machine_inspector.cljs` (L587, L916). That file is being actively rewritten by the concurrent **rf2-48fwsi** worker (Canvas/List view-mode toggle removal), so editing it here would conflict. Deferred to **rf2-nnbw9c** (blocked on rf2-48fwsi).

## Quality gates

- xray `clojure -M:test`: **1101 tests, 4577 assertions, 0 failures, 0 errors**

Closes rf2-hblkl4 (partial — machine_inspector.cljs portion → rf2-nnbw9c).