### PR TITLE
refactor(xray): remove vestigial Canvas/List view-mode toggle (rf2-48fwsi)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -129,9 +129,12 @@ below; the three render states are:
        connecting edges emphasised, the focused epoch's traversed edges
        painting the FIRED treatment (rf2-qeemm), and `:after` countdown
        rings overlaying armed timer states. The chart carries its **own**
-       toolbar (view-mode toggle + zoom/pan/fit controls) supplied by
-       `machine-canvas/Chart`; the per-machine view-mode and the chart
-       are chart-owned concerns, not tab chrome.
+       toolbar (xyflow zoom/pan/fit controls) supplied by
+       `machine-canvas/Chart`; the chart is a chart-owned concern, not
+       tab chrome. (rf2-48fwsi retired the vestigial Canvas/List
+       view-mode toggle that previously sat in this toolbar — it was
+       dead after the rf2-g2axio events-as-nodes redesign, with no view
+       branching on the persisted mode.)
 
    **Removed (rf2-g2axio):** everything else the pre-redesign section
    carried is gone — the bespoke **focused-transition lens** (the

--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -533,7 +533,7 @@ it pans, zooms, and fits to viewport.
 
 ```
 ┌─ :auth/login   :idle → :authing                          [:auth/submit] ─┐
-│ ┌─[Canvas|List]──────────────────────────────────[− 100% +] [Fit][Reset]┐│
+│ ┌────────────────────────────────────────────────[− 100% +] [Fit][Reset]┐│
 │ │ · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · ││
 │ │ · · ▢ idle ──→ ▣ authing · · · · · · · · · · · · · · · · · · · · · · ││
 │ │ · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · ││
@@ -554,14 +554,14 @@ it pans, zooms, and fits to viewport.
   viewport dims + the content dims from `chart/layout`.)
 - `Reset` — zoom 100%, pan (0, 0).
 
-**View-mode toggle (top-left of every canvas):**
-
-A two-button pill — **Canvas** | **List**. Per-machine slot,
-persisted to localStorage under
-`xray.machine-canvas.view-mode-by-id`. Canvas is the default; List
-opt-out renders the section without the chart (guards + actions
-only) for users who want a leaner per-event read or who prefer the
-old text-first surface.
+> **rf2-48fwsi — Canvas/List view-mode toggle removed.** The canvas
+> formerly carried a top-left two-button **Canvas** | **List** pill.
+> After the rf2-g2axio events-as-nodes redesign no view branched on
+> the persisted mode — clicking "List" only flipped a localStorage
+> slot nothing read — so the toggle, its per-machine slot, and its
+> localStorage round-trip were deleted. The chart is the sole render
+> path. A chartless guards/actions-only "List view" would be a
+> separate new feature, not a revert.
 
 **Direct manipulation:**
 
@@ -605,14 +605,15 @@ with the rest of Xray's surface.
 | Slot | Shape | Purpose |
 |---|---|---|
 | `:viewports {<machine-id> {:scale :tx :ty}}` | per-machine `{:scale s :tx tx :ty ty}` | current viewport |
-| `:view-mode-by-id {<machine-id> :canvas|:list}` | per-machine | view-mode toggle; localStorage-persisted |
 | `:viewport-dims {<machine-id> {:width :height}}` | per-machine | last-measured viewport box (drives `:fit`, keyboard) |
 | `:drag {:machine-id … :dragging? :origin-x :origin-y :origin-viewport}` | transient | mouse-down pan accumulator; cleared on mouseup |
 
+(rf2-48fwsi removed the `:view-mode-by-id` slot + its
+`view-mode-for` / `view-mode-by-id` subs along with the dead
+Canvas/List toggle.)
+
 Subscriptions exposed for tools / tests:
 `:rf.xray.machine-canvas/viewport-for`,
-`:rf.xray.machine-canvas/view-mode-for`,
-`:rf.xray.machine-canvas/view-mode-by-id`,
 `:rf.xray.machine-canvas/viewport-dims-for`.
 
 ## IN/OUT filter pills

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1002,8 +1002,12 @@ nested machines auto-fit to the available viewport via xyflow's
 `fitView`. Multiple machines stack vertically (no horizontal split) so
 the operator scans them like cards on a workstation. Guards, actions,
 and cancellation cascade chips render below each canvas as dense text
-rows — no extra modal or popout. The List view-mode fallback (§6.2)
-trades the canvas for an even denser flat textual list.
+rows — no extra modal or popout. (rf2-48fwsi retired the vestigial
+Canvas/List view-mode toggle that once advertised a flat textual
+fallback — it was dead after the rf2-g2axio events-as-nodes redesign,
+with no view branching on the persisted mode. The xyflow canvas is the
+sole render path; a chartless guards/actions-only list would be a
+separate new feature.)
 
 ### §6.0 Implementation — xyflow path (B) LOCKED
 
@@ -1087,13 +1091,13 @@ the nodes and edges with Xray palette tokens.
 │▌ stripe: mode accent (one GitHub-blue accent, both modes)             │
 │                                                                       │
 │ machine :title/flow            (no activity this epoch · current ●)   │
-│ ┌─[Canvas]─────────────────────────────────────[− 100% +] [Fit][Reset]│
+│ ┌──────────────────────────────────────────────[− 100% +] [Fit][Reset]│
 │ │  ( idle ) ──→ (( loaded )) ──→ ( error )                            │
 │ │                  ↑ current                                          │
 │ └────────────────────────────────────────────────────────────────────┘│
 │                                                                       │
 │ machine :other/flow            (no activity this epoch · current ●)   │
-│ ┌─[Canvas]──────────────────────────────────────────────────────────┐ │
+│ ┌────────────────────────────────────────────────────────────────────┐ │
 │ │  ( empty )  (( populated ))  ( submitting )  ( settled )           │ │
 │ └────────────────────────────────────────────────────────────────────┘│
 └───────────────────────────────────────────────────────────────────────┘
@@ -1116,7 +1120,7 @@ accent; the fired transition edge carries its **event label + guard + action inl
 ┌─ MACHINES · epoch #42 (machine :title/flow [:rf/init]) ─ [◀ Prev] [Next ▶] ─┐
 │▌ stripe: mode accent (one GitHub-blue accent, both modes)                   │
 │ machine :title/flow                                                          │
-│ ┌─[Canvas]────────────────────────────────────────[− 100% +] [Fit][Reset]──┐│
+│ ┌────────────────────────────────────────────────[− 100% +] [Fit][Reset]──┐│
 │ │ ┌─ active (compound) ──────────────────────────────────┐                  ││
 │ │ │  ( idle ) ════════▶ (( loading )) ───→ ( loaded )     │      ( error )   ││
 │ │ │   FROM    [:rf/init]    TO/current                    │       ↑          ││
@@ -1131,11 +1135,12 @@ accent; the fired transition edge carries its **event label + guard + action inl
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
-Per §003, the interactive chart adapter (zoom / pan / fit / Canvas|List
-view-mode) wraps each per-machine canvas. **The Canvas mode is the
-xyflow surface described in §6.0**; the List view-mode is a flat
-xyflow-free fallback for accessibility / low-power devices (preserved
-from §003 — unchanged here). The mode-accent fired-edge / double-circle
+Per §003, the interactive chart adapter (zoom / pan / fit) wraps each
+per-machine canvas. **The xyflow surface described in §6.0 is the sole
+render path** — rf2-48fwsi retired the vestigial Canvas/List view-mode
+toggle (dead after rf2-g2axio; no view branched on the persisted mode).
+A chartless guards/actions-only "List view" would be a separate new
+feature, not a revert. The mode-accent fired-edge / double-circle
 active-node / dashed compound container / inline guard+action labels +
 the `after: ◴ Ns → :event` countdown ring are the visual elements the
 Figma design fixes; xyflow renders them with the §6.0 palette mapping.

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -2,21 +2,23 @@
   "Xray-side wrapper around the machines-viz `MachineChart` xyflow
   component (rf2-gpzb4 — 2026-05-21 xyflow migration; supersedes the
   rf2-y3l8z viewport-reducer machinery the SVG renderer needed).
+  rf2-48fwsi retired the vestigial Canvas/List view-mode toggle — no
+  view ever branched on the persisted mode after the rf2-g2axio
+  events-as-nodes redesign, so the toggle, its slot, and its
+  localStorage round-trip are gone.
 
   ## What this owns post-migration
 
   Two surfaces survive:
 
-    1. **View-mode slot** — `:canvas` or `:list` per machine, living
-       at `[:rf.xray/machine-canvas :view-mode-by-id machine-id]`.
-       Persisted to localStorage so the user's choice survives
-       reloads. The toggle button + the `Chart` wrapper still read
-       this.
+    1. **Chart-collapsed slot** — a per-machine boolean living at
+       `[:rf.xray/machine-canvas :chart-collapsed-by-id machine-id]`.
+       Persisted to localStorage so the operator's choice to hide the
+       chart real-estate survives reloads.
     2. **`Chart` hiccup adapter** — thin wrapper around
        `mv-chart/MachineChart` that wires the focused-event lens
        from-state / to-state highlights, the on-state-click
-       dispatch, the Canvas/List view-mode toggle, and the
-       after-rings overlay.
+       dispatch, and the after-rings overlay.
 
   ## What this no longer owns
 
@@ -49,9 +51,6 @@
   across Static and Dynamic. Static callers pass:
 
     :show-after-rings?      false  — no live focused event on static.
-    :show-view-mode-toggle? false  — Static's L3 sub-mode pills own
-                                     per-machine mode at the panel
-                                     level.
     :testid                 \"rf-xray-static-machines-topology\""
   (:require [clojure.string :as str]
             [cljs.reader :as reader]
@@ -102,12 +101,6 @@
   rest of Xray's slots stay clean."
   :rf.xray/machine-canvas)
 
-(defn- view-mode-of
-  "Read the persisted view-mode for `machine-id`. Defaults to
-  `:canvas` — Canvas is the dominant surface."
-  [db machine-id]
-  (get-in db [slot-root :view-mode-by-id machine-id] :canvas))
-
 (defn- chart-collapsed-of
   "Read the persisted chart-collapsed flag for `machine-id`. Defaults
   to `false` — rf2-3d987 issue #4 fix: chart is expanded by default so
@@ -118,47 +111,15 @@
 
 ;; ---- localStorage round-trip --------------------------------------------
 
-(def storage-key
-  "Canonical localStorage key for the per-machine view-mode map.
-  Mirrors `static.machines.persistence/sub-mode-key`'s posture: one
-  bare EDN slot keyed by machine-id keyword."
-  "xray.machine-canvas.view-mode-by-id")
-
 (def chart-collapsed-storage-key
   "Canonical localStorage key for the per-machine chart-collapsed flag
-  map (rf2-3d987 issue #4). Same posture as `storage-key`: one EDN
-  map keyed by machine-id. Persisting per-machine lets one machine's
-  Chart be collapsed (snapshot pair foregrounded) while another's
-  Chart stays expanded."
+  map (rf2-3d987 issue #4). One EDN map keyed by machine-id.
+  Persisting per-machine lets one machine's Chart be collapsed
+  (snapshot pair foregrounded) while another's Chart stays expanded."
   "xray.machine-canvas.chart-collapsed-by-id")
 
 ;; Raw browser access lives in the shared `local-storage` seam
-;; (rf2-jkake.24); both slots are key-parameterised here.
-
-(defn save-view-mode-by-id!
-  "Persist the view-mode-by-id map to localStorage. Empty/nil clears
-  the slot."
-  [m]
-  (if (or (nil? m) (and (map? m) (empty? m)))
-    (ls/remove-item! storage-key)
-    (ls/set-item! storage-key (pr-str m)))
-  nil)
-
-(defn load-view-mode-by-id
-  "Read + normalise the persisted view-mode map. Returns `{}` when
-  the slot is absent / unparseable. Values normalise to `:canvas`
-  by default."
-  []
-  (when-let [raw (ls/get-item storage-key)]
-    (try
-      (let [parsed (reader/read-string raw)]
-        (when (map? parsed)
-          (into {}
-                (keep (fn [[k v]]
-                        (when (keyword? k)
-                          [k (if (#{:canvas :list} v) v :canvas)])))
-                parsed)))
-      (catch :default _ {}))))
+;; (rf2-jkake.24); the slot is key-parameterised here.
 
 (defn save-chart-collapsed-by-id!
   "Persist the chart-collapsed-by-id map to localStorage (rf2-3d987
@@ -188,14 +149,6 @@
 ;; ---- subs ---------------------------------------------------------------
 
 (defn- install-subs! []
-  (rf/reg-sub :rf.xray.machine-canvas/view-mode-for
-    (fn [db [_ machine-id]]
-      (view-mode-of db machine-id)))
-
-  (rf/reg-sub :rf.xray.machine-canvas/view-mode-by-id
-    (fn [db _]
-      (get-in db [slot-root :view-mode-by-id] {})))
-
   (rf/reg-sub :rf.xray.machine-canvas/chart-collapsed-for
     (fn [db [_ machine-id]]
       (chart-collapsed-of db machine-id)))
@@ -207,18 +160,6 @@
 ;; ---- events -------------------------------------------------------------
 
 (defn- install-events! []
-  (rf/reg-event-fx :rf.xray.machine-canvas/set-view-mode
-    (fn [{:keys [db]} [_ {:keys [machine-id mode]}]]
-      (let [mode' (if (#{:canvas :list} mode) mode :canvas)
-            db'   (assoc-in db [slot-root :view-mode-by-id machine-id] mode')
-            by-id (get-in db' [slot-root :view-mode-by-id])]
-        {:db db'
-         :rf.xray.machine-canvas/persist-view-mode by-id})))
-
-  (rf/reg-event-db :rf.xray.machine-canvas/hydrate-view-modes
-    (fn [db [_ by-id]]
-      (assoc-in db [slot-root :view-mode-by-id] (or by-id {}))))
-
   ;; rf2-3d987 issue #4 — toggle the per-machine chart-collapsed flag.
   ;; `mode` is :collapsed / :expanded / :toggle. Persists the post-mutation
   ;; map to localStorage so the operator's choice survives reloads.
@@ -243,10 +184,6 @@
 ;; ---- fx -----------------------------------------------------------------
 
 (defn- install-fx! []
-  (rf/reg-fx :rf.xray.machine-canvas/persist-view-mode
-    (fn [_ctx by-id]
-      (save-view-mode-by-id! by-id)))
-
   (rf/reg-fx :rf.xray.machine-canvas/persist-chart-collapsed
     (fn [_ctx by-id]
       (save-chart-collapsed-by-id! by-id))))
@@ -258,80 +195,10 @@
   ;; frame via the named `defaults/default-frame-id` Var (production-
   ;; singleton seam, no surrounding render frame), not a `{:frame
   ;; :rf/xray}` literal. Consistent with `spine-filters/hydrate!`.
-  (let [by-id (load-view-mode-by-id)]
-    (when (seq by-id)
-      (rf/dispatch [:rf.xray.machine-canvas/hydrate-view-modes by-id]
-                   {:frame defaults/default-frame-id})))
   (let [by-id (load-chart-collapsed-by-id)]
     (when (seq by-id)
       (rf/dispatch [:rf.xray.machine-canvas/hydrate-chart-collapsed by-id]
                    {:frame defaults/default-frame-id}))))
-
-;; ---- view-mode toggle ---------------------------------------------------
-
-(defn view-mode-toggle
-  "Two-button pill — Canvas | List — at the section header. Wires
-  click → `:set-view-mode`. Public so the sibling `machine_inspector`
-  panel can mount the same toggle — cross-panel reuse was already
-  happening via the private symbol; promote to public rather than
-  re-publish via a wrapper."
-  [{:keys [machine-id mode]}]
-  ;; rf2-nesy9 — capture the surrounding instance frame at render time
-  ;; so the deferred view-mode clicks dispatch into it, not a `:rf/xray`
-  ;; literal. The toggle renders inside the Chart / machine-inspector
-  ;; reg-views, so current-frame-id resolves through the React-context tier.
-  (let [frame     (rf/current-frame-id)
-        tab-style (fn [active?]
-                    {:background    (if active?
-                                      (:bg-active tokens)
-                                      "transparent")
-                     :border        "none"
-                     :color         (if active?
-                                      (:accent tokens)
-                                      (:text-tertiary tokens))
-                     :font-family   sans-stack
-                     :font-size     "10px"
-                     :font-weight   600
-                     :padding       "3px 10px"
-                     :cursor        "pointer"
-                     :border-radius "10px"
-                     :line-height   "1"})]
-    [:div {:data-testid "rf-xray-machine-canvas-view-mode-toggle"
-           :data-machine-id (str machine-id)
-           :data-active-mode (name mode)
-           :role "tablist"
-           :aria-label "Toggle Canvas / List view"
-           :style {:display       "inline-flex"
-                   :align-items   "center"
-                   :gap           "0px"
-                   :padding       "2px"
-                   :background    (:bg-3 tokens)
-                   :border        (str "1px solid " (:border-subtle tokens))
-                   :border-radius "12px"}}
-     [:button
-      {:data-testid "rf-xray-machine-canvas-view-mode-canvas"
-       :role        "tab"
-       :aria-pressed (str (= :canvas mode))
-       :on-click    (fn [_]
-                      (rf/dispatch
-                        [:rf.xray.machine-canvas/set-view-mode
-                         {:machine-id machine-id :mode :canvas}]
-                        {:frame frame}))
-       :title       "Canvas view — topology chart with zoom/pan"
-       :style       (tab-style (= :canvas mode))}
-      "Canvas"]
-     [:button
-      {:data-testid "rf-xray-machine-canvas-view-mode-list"
-       :role        "tab"
-       :aria-pressed (str (= :list mode))
-       :on-click    (fn [_]
-                      (rf/dispatch
-                        [:rf.xray.machine-canvas/set-view-mode
-                         {:machine-id machine-id :mode :list}]
-                        {:frame frame}))
-       :title       "List view — guards/actions only, no chart"
-       :style       (tab-style (= :list mode))}
-      "List"]]))
 
 ;; ---- public Chart view --------------------------------------------------
 
@@ -341,16 +208,17 @@
 
   rf2-m4xz1 — registered via `reg-view` (was a plain `defn`) so the
   React-context frame tier carries the enclosing `:rf/xray` frame
-  through to the inner view-mode-toggle subscribe. As a plain fn the
-  subscribe routed to `:rf/default` (the host app), which is a real
-  frame-leak — xray-internal slots must be read via xray's own frame.
-  Same surgery PR #2110 (rf2-uu3lp) applied to the rest of xray chrome.
+  through to xray-internal subscribes (e.g. the chart-collapsed slot).
+  As a plain fn the subscribe routed to `:rf/default` (the host app),
+  which is a real frame-leak — xray-internal slots must be read via
+  xray's own frame. Same surgery PR #2110 (rf2-uu3lp) applied to the
+  rest of xray chrome.
 
   Args (map):
 
     :definition         — machine definition map. Required.
     :machine-id         — keyword; identifies the per-machine
-                          view-mode slot and surfaces on every
+                          chart-collapsed slot and surfaces on every
                           per-node testid.
     :from-highlight     — focused-event lens origin state. Optional;
                           a state-id keyword or path vector. xyflow
@@ -401,8 +269,6 @@
     :show-after-rings?  — when true (default) overlay the
                           `:after`-timer countdown rings. Dynamic
                           keeps true; Static passes false.
-    :show-view-mode-toggle? — when true (default) render the
-                              Canvas/List pill in the chart top-left.
     :show-controls?     — when true (default) render xyflow's built-in
                           zoom/pan/fit Controls inside the chart.
     :fit-signal         — rf2-6tw7t. Opaque fit-on-entry nonce forwarded
@@ -428,11 +294,10 @@
   [{:keys [definition machine-id from-highlight to-highlight current-state
            fired-edge-ids guard-blocked-edge-ids machine-data
            sim? on-state-click on-edge-click
-           show-after-rings? show-view-mode-toggle?
+           show-after-rings?
            show-controls? theme testid inner-testid
            fit-signal]
     :or   {show-after-rings?       true
-           show-view-mode-toggle?  true
            show-controls?          true
            ;; rf2-az6e2 — Xray's surface is dark; the chart `:theme`
            ;; defaults to `@default-chart-theme` (`:dark`). Held in a
@@ -487,15 +352,7 @@
      ;; The overlay walks the chart's node DOM by data-testid to find
      ;; bbox positions; no positioned-graph prop is needed
      ;; post-migration (xyflow owns positions internally).
-     [after-rings/AfterRingsOverlay nil])
-   (when show-view-mode-toggle?
-     [:div {:style {:position "absolute"
-                    :top      "8px"
-                    :left     "8px"
-                    :z-index  2}}
-      (let [mode @(rf/subscribe
-                    [:rf.xray.machine-canvas/view-mode-for machine-id])]
-        (view-mode-toggle {:machine-id machine-id :mode mode}))])])
+     [after-rings/AfterRingsOverlay nil])])
 
 ;; ---- snapshot drill-in (rf2-lxvn6 · spec/021 §10 widget contract) -----
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -177,7 +177,7 @@
 ;; HANDLER mini-pipeline (`epoch-view/machine-cascade-mini-pipeline` —
 ;; the SAME richer microstep-cascade renderer the Epoch panel uses, so
 ;; the two surfaces cannot diverge again) + the chart (which carries its
-;; own view-mode toggle + zoom/pan/fit toolbar).
+;; own zoom/pan/fit toolbar).
 
 ;; ---- per-machine focused-event section ---------------------------------
 
@@ -199,8 +199,7 @@
        bespoke forensic block.
     2. the chart — `machine-canvas/Chart` with the focused epoch's
        from/to/current/fired highlights. The chart carries its own
-       toolbar (view-mode toggle + zoom/pan/fit controls), so the
-       bespoke list/canvas + collapse chrome is gone.
+       zoom/pan/fit toolbar, so the bespoke collapse chrome is gone.
 
   REMOVED (rf2-g2axio): the bespoke focused-transition lens (Target
   Machine Instance / TRANSITION / GUARDS RUN / ACTIONS RUN), the
@@ -271,9 +270,9 @@
       ;; source-coords resolve identically to the Epoch panel.
       (epoch-view/machine-cascade-mini-pipeline cascade machine-id)]
      ;; ── ELEMENT 3 — the topology chart ─────────────────────────────
-     ;; The chart carries its OWN toolbar (view-mode toggle + zoom / pan
-     ;; / fit controls — `machine-canvas/Chart`), so the bespoke
-     ;; list/canvas wrapper + the chart-collapse toggle/summary are gone
+     ;; The chart carries its OWN toolbar (zoom / pan / fit controls —
+     ;; `machine-canvas/Chart`), so the bespoke list/canvas wrapper +
+     ;; the chart-collapse toggle/summary are gone
      ;; (rf2-g2axio). Highlights flow as reactive props off THIS focused
      ;; epoch, so Prev/Next repaints the chart together with the
      ;; mini-pipeline above.
@@ -299,7 +298,6 @@
               ;; JVM/hiccup suite + hosts pin the wiring without reaching
               ;; into the xyflow canvas. "" when none blocked.
               :data-guard-blocked-edge-ids (str/join " " (sort (set guard-blocked-edge-ids)))
-              :data-view-mode "canvas"
               ;; rf2-zdfbm — fill the section's remaining height so the
               ;; topology chart expands into the panel. `flex 1` +
               ;; `min-height` floor keeps xyflow's non-zero-parent-height
@@ -321,8 +319,8 @@
                        ;; absolute-position itself over the chart SVG.
                        :position "relative"}}
          ;; rf2-y3l8z — the chart wraps an interactive viewport adapter
-         ;; (zoom/pan/fit + view-mode toggle + controls toolbar) and owns
-         ;; the after-rings overlay so they stay co-located with the canvas.
+         ;; (zoom/pan/fit + controls toolbar) and owns the after-rings
+         ;; overlay so they stay co-located with the canvas.
          [machine-canvas/Chart
           {:definition         definition
            :machine-id         machine-id

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/topology_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/topology_view.cljs
@@ -257,7 +257,6 @@
          ;; machine declares no `:data` (panel stays hidden).
          :machine-data           (static-context-shape definition)
          :show-after-rings?      false
-         :show-view-mode-toggle? false
          :show-controls?         show-controls?
          ;; rf2-6tw7t — fit-on-entry nonce pass-through; hosts that mount
          ;; this consumer surface inside a tab/panel bump it on entry so

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
@@ -709,7 +709,6 @@
        :to-highlight           (:to last-trans)
        :sim?                   true
        :show-after-rings?      false
-       :show-view-mode-toggle? false
        :inner-testid           "rf-xray-static-machines-sim-chart-svg"
        :on-edge-click
        (fn [payload]

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
@@ -11,18 +11,13 @@
   XState's static / read-only chart views get the same affordances;
   Xray's static surface should match.
 
-  Static differs from Dynamic in three respects:
+  Static differs from Dynamic in two respects:
 
     1. NO focused-event lens — Static is a static-read; there's no
        `:from-highlight-id` / `:to-highlight-id` to pass, and the
        after-rings overlay is suppressed (`:show-after-rings?
        false`).
-    2. NO Canvas/List view-mode toggle inside the canvas — the
-       Static Machines panel already owns a per-machine sub-mode
-       pill strip at L3 (Topology / Sim / Instances / Cascade); a
-       second toggle inside the canvas would be redundant noise.
-       (`:show-view-mode-toggle? false`.)
-    3. Click on a state node fires
+    2. Click on a state node fires
        `:rf.xray.static.machines/state-clicked` (with the clicked
        state's path) — not the Dynamic panel's inspector-lens
        navigation event.
@@ -80,7 +75,6 @@
   + keyboard shortcuts on the Static surface too. The static-
   flavoured opts are:
 
-    :show-view-mode-toggle? false  — Static panel owns sub-mode at L3.
     :show-after-rings?      false  — no focused-event lens on static.
     :testid                        — overrides the inner SVG testid
                                      so the existing static-panel
@@ -108,7 +102,6 @@
       {:definition             definition
        :machine-id             machine-id
        :show-after-rings?      false
-       :show-view-mode-toggle? false
        ;; rf2-6tw7t — fit-on-entry nonce so entering the Static Machines
        ;; tab re-frames the topology (xyflow's one-shot `:fitView` +
        ;; the layout-key auto-fit both leave a re-entered chart stale).

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_canvas_cljs_test.cljs
@@ -4,16 +4,16 @@
   rf2-gpzb4 (2026-05-21 xyflow migration) — the previous test corpus
   was dominated by the viewport-reducer + drag-state machinery the
   SVG renderer needed. Post-migration xyflow owns zoom/pan/fit
-  internally; only the view-mode toggle slot + the `Chart` hiccup
-  wrapper survive on the Xray side.
+  internally; the `Chart` hiccup wrapper + the chart-collapsed slot
+  survive on the Xray side. (rf2-48fwsi retired the dead Canvas/List
+  view-mode toggle + its slot/events/fx.)
 
   Covers:
 
     1. Registry wires the surviving subs + events + fx.
-    2. `:set-view-mode` updates the per-machine slot and fires the
-       persist-view-mode fx with the latest map.
+    2. The chart-collapsed slot mutates + persists per machine.
     3. The `Chart` view returns hiccup carrying the canvas-host
-       data-testid + the view-mode toggle (when enabled)."
+       data-testid."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -44,51 +44,12 @@
   (setup-xray-frame!)
   (rf/with-frame :rf/xray
     (testing "every machine-canvas sub resolves through rf/subscribe"
-      (doseq [q-v [[:rf.xray.machine-canvas/view-mode-for :m]
-                   [:rf.xray.machine-canvas/view-mode-by-id]
-                   [:rf.xray.machine-canvas/chart-collapsed-for :m]
+      (doseq [q-v [[:rf.xray.machine-canvas/chart-collapsed-for :m]
                    [:rf.xray.machine-canvas/chart-collapsed-by-id]]]
         (is (some? (rf/subscribe q-v))
             (str q-v " must resolve through rf/subscribe"))))))
 
-;; ---- 2. View-mode toggle + persistence fx -----------------------------
-
-(deftest set-view-mode-mutates-slot
-  (setup-xray-frame!)
-  (rf/with-frame :rf/xray
-    (rf/dispatch-sync
-      [:rf.xray.machine-canvas/set-view-mode
-       {:machine-id :m :mode :list}])
-    (let [mode @(rf/subscribe [:rf.xray.machine-canvas/view-mode-for :m])
-          by-id @(rf/subscribe [:rf.xray.machine-canvas/view-mode-by-id])]
-      (is (= :list mode))
-      (is (= {:m :list} by-id)))))
-
-(deftest set-view-mode-defaults-to-canvas
-  (setup-xray-frame!)
-  (rf/with-frame :rf/xray
-    (let [mode @(rf/subscribe [:rf.xray.machine-canvas/view-mode-for :m])]
-      (is (= :canvas mode)
-          "Unset slot defaults to :canvas — the dominant surface"))))
-
-(deftest set-view-mode-normalises-bad-input
-  (setup-xray-frame!)
-  (rf/with-frame :rf/xray
-    (rf/dispatch-sync
-      [:rf.xray.machine-canvas/set-view-mode
-       {:machine-id :m :mode :nonsense}])
-    (let [mode @(rf/subscribe [:rf.xray.machine-canvas/view-mode-for :m])]
-      (is (= :canvas mode)
-          "Unknown modes fall back to :canvas"))))
-
-(deftest persist-view-mode-fx-registered
-  (setup-xray-frame!)
-  (is (some?
-        (registrar/handler
-          :fx :rf.xray.machine-canvas/persist-view-mode))
-      "persist-view-mode fx is in the registrar"))
-
-;; ---- 2b. Chart-collapsed slot (rf2-3d987 issue #4) ---------------------
+;; ---- 2. Chart-collapsed slot (rf2-3d987 issue #4) ---------------------
 
 (deftest chart-collapsed-defaults-to-false
   (setup-xray-frame!)
@@ -171,25 +132,18 @@
       (is (some? (find-by-testid tree "rf-xray-machine-canvas-host"))
           "canvas host wrapper present"))))
 
-(deftest chart-view-emits-view-mode-toggle
-  (setup-xray-frame!)
-  (rf/with-frame :rf/xray
-    (let [tree (mc/Chart {:definition fixture-definition :machine-id :m})]
-      (is (some? (find-by-testid tree "rf-xray-machine-canvas-view-mode-toggle"))))))
-
-(deftest chart-view-omits-view-mode-toggle-when-knob-false
-  (testing "rf2-md9oz — Static Topology consumer passes
-            :show-view-mode-toggle? false to suppress the Canvas/List
-            pill (Static panel owns sub-mode at L3)."
+(deftest chart-view-never-emits-view-mode-toggle-rf2-48fwsi
+  (testing "rf2-48fwsi — the vestigial Canvas/List view-mode toggle is
+            removed; the Chart never renders it (it was dead after the
+            rf2-g2axio events-as-nodes redesign — no view branched on
+            the persisted mode)."
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
-      (let [tree (mc/Chart {:definition fixture-definition
-                            :machine-id :m
-                            :show-view-mode-toggle? false})]
+      (let [tree (mc/Chart {:definition fixture-definition :machine-id :m})]
         (is (some? (find-by-testid tree "rf-xray-machine-canvas-host"))
-            "canvas host still mounts")
+            "canvas host mounts")
         (is (nil? (find-by-testid tree "rf-xray-machine-canvas-view-mode-toggle"))
-            "view-mode toggle is suppressed")))))
+            "the retired view-mode toggle never renders")))))
 
 ;; ---- 4. SnapshotDrillIn view (rf2-lxvn6 · spec/021 §10) --------------
 

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -215,14 +215,11 @@
    :rf.xray/machine-definitions
    :rf.xray/machine-definitions-override
    :rf.xray/machine-inspector-data
-   ;; rf2-y3l8z — view-mode toggle slot subs (post-rf2-gpzb4 xyflow
-   ;; migration the viewport-state subs were retired; xyflow owns
-   ;; zoom/pan/fit internally).
-   :rf.xray.machine-canvas/view-mode-by-id
-   :rf.xray.machine-canvas/view-mode-for
    ;; rf2-3d987 issue #4 — chart-collapsed slot per machine, persisted
-   ;; alongside view-mode-by-id. Lets the operator hide the chart so
-   ;; the snapshot pair has room without scrolling.
+   ;; to localStorage. Lets the operator hide the chart so the snapshot
+   ;; pair has room without scrolling. (rf2-48fwsi retired the sibling
+   ;; view-mode-by-id / view-mode-for subs along with the dead
+   ;; Canvas/List toggle.)
    :rf.xray.machine-canvas/chart-collapsed-by-id
    :rf.xray.machine-canvas/chart-collapsed-for
    ;; rf2-a9cke — focused-event lens composite consumed by the
@@ -540,12 +537,9 @@
    ;; Phase 4 (rf2-m7co9) — ELK chart layout pulse.
    :rf.xray/machine-chart-layout-pulse
    :rf.xray/machine-state-clicked
-   ;; rf2-y3l8z — view-mode toggle events for the Dynamic Machines
-   ;; canvas (rf2-gpzb4 xyflow migration: viewport-state events
-   ;; retired — xyflow owns zoom/pan/fit internally).
-   :rf.xray.machine-canvas/hydrate-view-modes
-   :rf.xray.machine-canvas/set-view-mode
-   ;; rf2-3d987 issue #4 — chart-collapsed events.
+   ;; rf2-3d987 issue #4 — chart-collapsed events. (rf2-48fwsi retired
+   ;; the sibling set-view-mode / hydrate-view-modes events with the
+   ;; dead Canvas/List toggle.)
    :rf.xray.machine-canvas/hydrate-chart-collapsed
    :rf.xray.machine-canvas/set-chart-collapsed
    ;; (Pre-rf2-q3dzw the legacy `edn-inspector.render` engine emitted
@@ -758,13 +752,9 @@
    ;; set to localStorage in one place (mirrors the filter-persistence
    ;; shape above).
    :rf.xray.spine-filters/persist
-   ;; rf2-y3l8z — interactive Machines canvas view-mode persistence
-   ;; side-effect. Writes the per-machine view-mode-by-id map to
-   ;; localStorage on every `:set-view-mode` mutation so the user's
-   ;; Canvas / List choice survives reloads.
-   :rf.xray.machine-canvas/persist-view-mode
-   ;; rf2-3d987 issue #4 — chart-collapsed persistence side-effect. Same
-   ;; localStorage round-trip pattern as persist-view-mode.
+   ;; rf2-3d987 issue #4 — chart-collapsed persistence side-effect.
+   ;; (rf2-48fwsi retired the sibling persist-view-mode fx with the
+   ;; dead Canvas/List toggle.)
    :rf.xray.machine-canvas/persist-chart-collapsed
    ;; rf2-wm7z4 — palette pop-out side-effect. Lives under the
    ;; palette-specific prefix because it wraps a mount-layer pop-out

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
@@ -452,9 +452,11 @@
             ":inner-testid forwards through Chart to the xyflow root")))))
 
 (deftest topology-mode-omits-view-mode-toggle-on-static
-  (testing "rf2-md9oz — Static surface already owns the per-machine
-            sub-mode pill strip at L3; the canvas's Canvas/List toggle
-            is meaningless on static and must NOT mount."
+  (testing "rf2-48fwsi — the vestigial Canvas/List view-mode toggle was
+            removed framework-wide (it was dead after rf2-g2axio); it
+            must NOT mount on the Static surface either. (Pre-rf2-48fwsi
+            Static suppressed it via :show-view-mode-toggle? false; now
+            no Chart caller can render it at all.)"
     (xray-setup!)
     (seed-machines! [:m/a])
     (seed-definitions! {:m/a {:initial :idle
@@ -463,8 +465,7 @@
       (let [tree (panel/panel)]
         (is (nil? (find-by-testid tree
                                   "rf-xray-machine-canvas-view-mode-toggle"))
-            "view-mode toggle is suppressed on static via
-             :show-view-mode-toggle? false")))))
+            "the retired view-mode toggle never mounts on static")))))
 
 (deftest topology-mode-keeps-popout-and-source-coord-affordances
   (testing "The Static panel's existing 'open in popout' affordance +


### PR DESCRIPTION
Closes rf2-48fwsi.

## Evidence of deadness

The machine-canvas Canvas/List view-mode toggle was dead after the rf2-g2axio events-as-nodes redesign. Proven via `git grep`:

- **No view branches on the persisted mode.** The only consumer of `:rf.xray.machine-canvas/view-mode-for` was the toggle UI itself (to set its own active-button styling). `machine-canvas/Chart` always mounts `mv-chart/MachineChart` regardless of mode. Clicking "List" only flipped `[slot-root :view-mode-by-id machine-id]` — a localStorage-backed slot nothing read.
- **The Dynamic Machines panel was the toggle's only live render site**, reached via the `:show-view-mode-toggle? true` default (`machine_inspector` calls `Chart` without the knob). `machine_inspector` hardcodes `:data-view-mode "canvas"` and never reads the slot.
- **All three Static callers** (`static/machines/topology.cljs`, `static/machines/sim.cljs`, `panels/machines/topology_view.cljs`) explicitly passed `:show-view-mode-toggle? false`.

## Removed surfaces (xray slice, end-to-end)

- `view-mode-toggle` fn + the `show-view-mode-toggle?` mount block + knob (destructure + `:or`)
- `view-mode-of` helper + the `view-mode-for` / `view-mode-by-id` subs
- `set-view-mode` / `hydrate-view-modes` events
- `persist-view-mode` fx
- `storage-key` + `save/load-view-mode-by-id!` + the view-mode half of `hydrate!`
- the redundant `:show-view-mode-toggle? false` at the 3 Static call sites
- the orphaned `:data-view-mode "canvas"` marker on the Dynamic chart wrapper

**Kept:** the separate, still-live chart-collapsed machinery (slot / subs / events / fx / localStorage).

Tests: removed the view-mode toggle/sub/event/fx assertions; replaced the "emits toggle" test with a negative `chart-view-never-emits-view-mode-toggle-rf2-48fwsi`; updated the registry exact-set lists and the Static negative-assertion rationale.

## Specs (updated same PR)

- `003-Machine-Inspector.md` — toolbar contract (toggle dropped)
- `007-UX-IA.md` — toggle subsection, app-db slot row + sub list, ASCII diagram
- `021-Dynamic-Panel-Designs.md` — density note, Case B/C diagrams, §6.2 chart-adapter paragraph

## Quality gates

| Gate | Result |
|---|---|
| xray `clojure -M:test` | 1101 tests / 4577 assertions — 0 failures, 0 errors |
| `npm run test:cljs` | 5912 tests / 20959 assertions — 0 failures, 0 errors |
| `npm run test:xray-feature-gate` | 16/16 scenarios — 0 failures |

Out of scope: 007-UX-IA still carries pre-existing rf2-gpzb4 xyflow-migration debt (the `:viewports` / `:drag` SVG-reducer slots); left untouched.
