### PR TITLE
docs(xray): fix stale share.cljs comment refs in machine_inspector (rf2-nnbw9c)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -582,7 +582,7 @@
     - the rings install (`:after` countdown ring overlay)
 
   rf2-nugvv (2026-06-04) — the Share affordance (button + modal +
-  `share.cljs` infra) is removed; `install!` no longer installs it.
+  share-URL infra) is removed; `install!` no longer installs it.
 
   rf2-r4nao moved the Sim engine + UI into
   `static.machines.sim` — installed via
@@ -911,8 +911,7 @@
   ;; rf2-nugvv (2026-06-04) — the Share affordance (rf2-nqw0v) is
   ;; removed. The machine panel was the sole UI entry point to the
   ;; share modal (`:rf.xray/share-modal-open`), so the button, the
-  ;; modal (`share_modal.cljs`), the shell mount, and the `share.cljs`
-  ;; infra all go with it.
+  ;; modal, the shell mount, and the share-URL infra all go with it.
 
   ;; rf2-2moh1 — register the Dynamic Machines tab with the internal L4
   ;; tab registry.


### PR DESCRIPTION
Follow-up from rf2-hblkl4 (deferred while rf2-48fwsi rewrote this file). The `share.cljs` / `share_modal.cljs` files were deleted by rf2-nugvv (PR #2897); two comments in `machine_inspector.cljs` still name-referenced the deleted files. Reworded to drop the dead file names while keeping the rf2-nugvv removal rationale — matching the hblkl4 convention (`share.cljs` infra -> share-URL infra). Comment-only, no behavioural change.

## Quality gates
- xray `clojure -M:test`: 1101 tests, 4577 assertions, 0 failures, 0 errors