### PR TITLE
docs(xray): reconcile spec 021/007 drift + dead xyflow fallback (rf2-r1u79d)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -549,9 +549,9 @@ it pans, zooms, and fits to viewport.
 - `−` / `+` — Zoom out / Zoom in about the viewport centre.
 - `NN%` chip — current zoom level, integer percentage.
 - `Fit` — fits the laid-out content into the viewport with padding
-  on all sides; centred. (Toolbar emits `:fit-request` which the
-  Xray-side handler expands to a full `:fit` using the measured
-  viewport dims + the content dims from `chart/layout`.)
+  on all sides; centred. (Owned by the machines-viz `MachineChart`
+  via xyflow's built-in `fitView`; Xray re-frames on panel-entry by
+  bumping the orthogonal `:fit-signal` nonce, rf2-6tw7t.)
 - `Reset` — zoom 100%, pan (0, 0).
 
 > **rf2-48fwsi — Canvas/List view-mode toggle removed.** The canvas
@@ -565,15 +565,14 @@ it pans, zooms, and fits to viewport.
 
 **Direct manipulation:**
 
-- **Mouse wheel** zooms toward the cursor (wheel-toward-cursor
-  invariant — the chart-world coord under the cursor is fixed
-  through the zoom transition). Trackpad pinch arrives as a wheel
-  event with `ctrlKey=true`; both are accepted.
+- **Mouse wheel** zooms toward the cursor (xyflow's `zoomOnScroll`;
+  the chart-world coord under the cursor is fixed through the zoom
+  transition). Trackpad pinch arrives as a wheel event with
+  `ctrlKey=true`; both are accepted.
 - **Click-drag** anywhere on canvas background (not on a state
-  node) pans. The drag handler walks up to 5 DOM ancestors looking
-  for `data-testid` starting `rf-mv-chart-node-` /
-  `rf-mv-chart-edge-`; clicks that hit a node fall through to
-  the node's own `:on-click` (state-click event).
+  node) pans (xyflow's `panOnDrag`; `nodesDraggable` is `false`,
+  so node hits fall through to the node's own `:on-click`
+  state-click event rather than dragging the node).
 
 **Keyboard shortcuts** (chart canvas must hold focus — `tabIndex=0`
 on the canvas host):
@@ -590,10 +589,15 @@ on the canvas host):
 **Bounds:** zoom is clamped to `[0.2, 4.0]`. Wheel notches step
 ×1.1; toolbar +/- and `+`/`-` keys step ×1.2.
 
-**`:after` rings track the canvas (rf2-obp4z).** The countdown-ring
-overlay receives the same viewport-transform the chart applies and
-wraps its rings group in `translate(tx,ty) scale(s)`. Rings stay
-anchored to their bearing-state node centres at every zoom + pan.
+**`:after` rings track the canvas (rf2-obp4z · rf2-uv1on).** The
+countdown-ring overlay (machines-viz `chart.overlays.after-rings/
+AfterRingsOverlay`) walks the rendered xyflow node DOM
+(`[data-testid=rf-mv-chart-node-…]`) to find each bearing node's
+bounding box and absolute-positions a ring there. Because xyflow
+owns node positions post-migration, the ring tracks the node's
+on-screen box at every zoom + pan (superseding the old elk-coordinate
+`{:cx :cy :r}` + SVG `translate(tx,ty) scale(s)` viewport-transform
+model the SVG renderer used).
 
 **Reduced motion.** Toolbar buttons + the canvas transform ride
 Xray's `--rf-xray-motion-scale` seam — no extra wiring here;
@@ -604,17 +608,23 @@ with the rest of Xray's surface.
 
 | Slot | Shape | Purpose |
 |---|---|---|
-| `:viewports {<machine-id> {:scale :tx :ty}}` | per-machine `{:scale s :tx tx :ty ty}` | current viewport |
-| `:viewport-dims {<machine-id> {:width :height}}` | per-machine | last-measured viewport box (drives `:fit`, keyboard) |
-| `:drag {:machine-id … :dragging? :origin-x :origin-y :origin-viewport}` | transient | mouse-down pan accumulator; cleared on mouseup |
+| `:chart-collapsed-by-id {<machine-id> boolean}` | per-machine boolean | operator's choice to hide the chart real-estate (default expanded); persisted to localStorage and rehydrated on load |
 
-(rf2-48fwsi removed the `:view-mode-by-id` slot + its
-`view-mode-for` / `view-mode-by-id` subs along with the dead
-Canvas/List toggle.)
+**Viewport state is NOT an Xray app-db slot (rf2-gpzb4 — 2026-05-21
+xyflow migration).** xyflow owns zoom / pan / fit internally; the
+former host-side viewport-reducer machinery (`:viewports`,
+`:viewport-dims`, `:drag` slots + the
+`:rf.xray.machine-canvas/viewport-for` /
+`viewport-dims-for` subs + the `/drag-start` · `/drag-move` ·
+`/drag-end` · `/measure` events) was removed when the SVG renderer
+gave way to `MachineChart`. Fit re-frames ride the orthogonal
+`:fit-signal` nonce (rf2-6tw7t), not a stored viewport. rf2-48fwsi
+likewise removed the `:view-mode-by-id` slot + its `view-mode-for` /
+`view-mode-by-id` subs along with the dead Canvas/List toggle.
 
 Subscriptions exposed for tools / tests:
-`:rf.xray.machine-canvas/viewport-for`,
-`:rf.xray.machine-canvas/viewport-dims-for`.
+`:rf.xray.machine-canvas/chart-collapsed-for`,
+`:rf.xray.machine-canvas/chart-collapsed-by-id`.
 
 ## IN/OUT filter pills
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1025,7 +1025,7 @@ for the work cost of rebuilding auto-layout / zoom-pan-fit from scratch.
 | License | MIT |
 | Bundle cost | ~50-80KB gzipped depending on which xyflow submodules are imported |
 | Mount mechanic | xyflow is a React component; Xray is Reagent. Use Reagent's React-component interop (`reagent/adapt-react-class` or `[:>` syntax) to mount xyflow inside the Xray Machines-panel Reagent component. |
-| Adapter layer | ~100 LoC CLJS — one-way walker from re-frame2 machine spec → xyflow's node/edge JSON. Lives at `tools/xray/src/day8/re_frame2_xray/machines/xyflow_adapter.cljs` (new ns implied by this design). |
+| Adapter layer | The live render path is the shared machines-viz `MachineChart` (`day8.re-frame2-machines-viz.chart`), mounted via the Xray-side `panels/machine_canvas.cljs` wrapper (rf2-gpzb4 — 2026-05-21 the SVG renderer gave way to xyflow). The original design's standalone `tools/xray/src/.../machines/xyflow_adapter.cljs` ns was never created; a self-contained, JVM-portable pure projector + palette catalogue survive off the live path as a unit-tested fallback at `panels/machines/topology.cljs` (`project`) + `panels/machines/xyflow_style.cljs`. |
 
 **Visual conventions to recreate (Stately reference, Xray palette):**
 
@@ -1034,7 +1034,7 @@ for the work cost of rebuilding auto-layout / zoom-pan-fit from scratch.
 | Nested state containment | xyflow's group/parent-node mechanic. Parent state renders as a containing rect; child states are nested xyflow nodes whose `parentNode` references the parent. |
 | Transition edge animation | xyflow's `animated: true` edge prop. Color via Xray palette (`:accent` — the single GitHub-blue accent — for "fired this epoch"; `:text-tertiary` for "registered but not fired this epoch"). |
 | Current-state highlight pulse | Custom node CSS class that applies the `pulse` keyframe (~1.2s ease-in-out; CSS-variable interpolated through `--rf-xray-motion-scale` so `prefers-reduced-motion` collapses it). Pulse outline color = `:green` (the panel-domain accent). |
-| Auto-layout | xyflow's built-in `getLayoutedElements` helper (dagre algorithm). One-shot layout on first render; cached per machine-id; recomputed only when topology changes. |
+| Auto-layout | **elkjs** (the Eclipse Layout Kernel, `Layered` algorithm) runs as xyflow's layout backend inside `MachineChart` (2026-05-19 ELK lock — superseded the originally-sketched dagre `getLayoutedElements`). Async one-shot layout, cached per machine-id; recomputed only when topology changes. |
 | Zoom + pan + fit | xyflow's built-in `Controls` component (re-styled to match Xray's button chrome). Default zoom: fit-on-mount with 20px padding. `[− 100% +] [Fit][Reset]` chrome already shown in the existing mockups maps 1:1 to xyflow's `Controls`. |
 | Label-on-edge transitions | xyflow's `label` prop on edges; rendered inline on the edge, not in a side legend. Font: JetBrains Mono 10px (`:micro` size). |
 | Parallel-state side-by-side | Parallel-region containers render as sibling group-nodes with a dashed border (`:border-default` at `dash-array: 4 4`). Inner states laid out independently per region. |
@@ -1145,11 +1145,14 @@ active-node / dashed compound container / inline guard+action labels +
 the `after: ◴ Ns → :event` countdown ring are the visual elements the
 Figma design fixes; xyflow renders them with the §6.0 palette mapping.
 
-Layout direction: **left-to-right by default** (matches typical state-
-machine convention; xyflow's dagre layout option `rankdir: 'LR'`).
-Operator can flip to top-to-bottom via Settings → View → Machines layout
-direction (deferred to follow-on bead). Default zoom: fit-on-mount with
-20px padding around the bounding box of all nodes.
+Layout direction: **top-to-bottom by default** (elk's `elk.direction
+DOWN`, the `MachineChart` default Xray does not override). The original
+sketch called for a left-to-right `rankdir: 'LR'` default; the elkjs
+backend that shipped (`MachineChart`, 2026-05-19 ELK lock) maps `:lr` →
+elk `RIGHT` / `:tb` → elk `DOWN` and defaults to `DOWN`. Operator-facing
+direction flip (Settings → View → Machines layout direction) is deferred
+to a follow-on bead. Default zoom: fit-on-mount with 20px padding around
+the bounding box of all nodes.
 
 ### §6.3 Queries
 
@@ -5350,24 +5353,37 @@ the edge id keeps every branch addressable in xyflow.
 
 #### §17.4.4 Layout direction + default zoom
 
-- **Direction**: left-to-right (xyflow `dagre` `rankdir: 'LR'`) — matches
-  Stately's convention; matches reading order.
+- **Direction**: top-to-bottom (elk `elk.direction DOWN`, the
+  `MachineChart` default Xray does not override). The original sketch
+  called for a left-to-right dagre `rankdir: 'LR'`; the elkjs backend
+  that shipped maps `:lr` → elk `RIGHT` / `:tb` → elk `DOWN` and defaults
+  to `DOWN`.
 - **Default zoom**: `fitView` on mount with 20px padding around the
   bounding box. The `Fit` button in the Controls re-runs `fitView`.
-- **Min/max zoom**: 0.25× to 2×. Wheel-zoom enabled.
-- **Pan**: drag-to-pan on the canvas background; node-drag disabled
-  (it's a read-only render).
+- **Min/max zoom**: 0.2× to 4.0× (`MachineChart`'s `minZoom` / `maxZoom`).
+  Wheel-zoom enabled.
+- **Pan**: drag-to-pan on the canvas background (xyflow `panOnDrag`);
+  node-drag disabled (`nodesDraggable false` — read-only render).
 
 #### §17.4.5 Xray-palette token integration into xyflow style props
 
-Sketched in §6.0; restated here as the canonical reference the
-xyflow-adapter bead (§17.5) implements against:
+Sketched in §6.0. **NOTE (drift reconcile, rf2-r1u79d):** the live
+Machines panel renders through the shared machines-viz `MachineChart`,
+which carries its OWN Stately-style node/edge styling — the catalogue
+below is NOT the live styling source. It survives as the self-contained,
+JVM-portable **fallback** palette at
+`tools/xray/src/day8/re_frame2_xray/panels/machines/xyflow_style.cljs`
+(unit-tested, off the hot path), paired with the
+`panels/machines/topology.cljs` `project` projector. The originally-
+designed standalone `xyflow_adapter.cljs` ns (§6.0 / §17.5) was never
+created.
 
 ```clojure
-;; tools/xray/src/day8/re_frame2_xray/machines/xyflow_style.cljs
-;; The single source of truth for xyflow visual props.
+;; tools/xray/src/day8/re_frame2_xray/panels/machines/xyflow_style.cljs
+;; The single source of truth for the FALLBACK projector's xyflow
+;; visual props (the live panel styles through machines-viz MachineChart).
 
-(ns day8.re-frame2-xray.machines.xyflow-style
+(ns day8.re-frame2-xray.panels.machines.xyflow-style
   (:require [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack type-scale duration-css with-alpha]]))
 
@@ -5452,14 +5468,16 @@ pass implies. Format: title + 2-line description + dependencies.
 Mayor reviews + files these alongside the structural per-panel beads
 already drafted in §13.
 
-- **rf2-?????** — *Xray: xyflow integration adapter — re-frame2 machine
-  spec → xyflow JSON.* New ns
-  `tools/xray/src/day8/re_frame2_xray/machines/xyflow_adapter.cljs`
-  walks `reg-machine` topology + per-epoch transition trace and emits
-  xyflow nodes/edges JSON. Plus `xyflow_style.cljs` per §17.4.5. Plus
-  Reagent ↔ React mount wiring per §6.0. Depends: xyflow added to
-  `package.json` (~50-80KB gzipped, MIT). Gates: Machines panel
-  redesign (§6).
+- **DONE (superseded · rf2-gpzb4)** — *Xray: xyflow integration adapter
+  — re-frame2 machine spec → xyflow JSON.* Shipped NOT as the originally-
+  sketched standalone `machines/xyflow_adapter.cljs` ns, but via the
+  shared machines-viz `MachineChart` (`day8.re-frame2-machines-viz.chart`
+  — xyflow + **elkjs** layout) wrapped by Xray's `panels/machine_canvas.
+  cljs`. The pure projector + palette catalogue (`panels/machines/
+  topology.cljs` `project` + `panels/machines/xyflow_style.cljs`) survive
+  off the live path as a unit-tested JVM-portable fallback. xyflow +
+  elkjs are machines-viz `devDependency`s (bundle-isolated from
+  production).
 
 - **rf2-?????** — *Xray: edn-inspector renderer component — lazy tree
   + inline diff + keyword accent + clickable paths.* New ns


### PR DESCRIPTION
Reconciles `tools/xray/spec/021-Dynamic-Panel-Designs.md` + `007-UX-IA.md` against the post-xyflow-migration code. Closes rf2-r1u79d. **Spec-only — no src touched.** Each claim verified via `git grep` against current code before changing.

## What was stale (verified gone/different in code)

**021 §6.0 / §17.5 — `xyflow_adapter.cljs` never created.** The spec described a standalone `re_frame2_xray/machines/xyflow_adapter.cljs` ns + `~100 LoC` adapter. `git grep` confirms it never existed in src. The live render path is the shared machines-viz `MachineChart` (xyflow) wrapped by `panels/machine_canvas.cljs` (rf2-gpzb4, 2026-05-21 migration). Reconciled the Adapter-layer row + marked the §17.5 follow-on bullet **DONE (superseded)**.

**021 §6.0 / §6.2 / §17.4.4 — dagre → elkjs.** Spec said xyflow's `getLayoutedElements` (dagre) with `rankdir: 'LR'` default. Code uses **elkjs** `Layered` (machines-viz `chart.cljs`, 2026-05-19 ELK lock) and the actual default direction is `elk.direction DOWN` (top-to-bottom) — Xray passes no direction override. Fixed both algorithm and default direction in three places.

**021 §17.4.4 — zoom clamp.** Spec said `0.25× to 2×`; chart's `minZoom`/`maxZoom` are `0.2 / 4.0`. Corrected; attributed pan/node-drag to xyflow `panOnDrag` / `nodesDraggable false`.

**021 §17.4.5 — `xyflow_style.cljs` path + framing.** Corrected the ns path (`panels/machines/xyflow_style.cljs`, not `machines/...`) and flagged it as the off-the-live-path **fallback** styling (the live panel styles through `MachineChart`), not "the single source of truth for xyflow visual props."

**007 — machine-canvas SVG-reducer viewport debt (folded-in gpzb4 item from the 48fwsi worker).** The state table listed `:viewports` / `:viewport-dims` / `:drag` slots + `:rf.xray.machine-canvas/viewport-for` / `viewport-dims-for` subs. `git grep` confirms these (and the `/drag-start` · `/drag-move` · `/drag-end` · `/measure` events) are gone from src — xyflow owns viewport internally; only `:chart-collapsed-by-id` survives. Replaced the table; fixed the `Fit` toolbar text (now `:fit-signal` nonce, no xray-side `:fit` handler), the direct-manipulation bullets, and the `:after`-rings text (now walks xyflow node-DOM bboxes per rf2-uv1on, not an SVG `translate/scale` transform).

## xyflow_style fallback retention decision

The bead asks Mike to decide remove-vs-keep on the `topology/project` + `grid-positions` + `xyflow_style.cljs` fallback. `git grep` confirms it is provably **off the live render path** (only `topology/parse-definition` is still live, used by `topology_view` for node/edge counts) but it is a **deliberate, documented, unit-tested JVM-portable fallback** — not unreachable-by-accident. Per the conservative brief ("remove ONLY if proven unreachable, else leave + note"), source left intact; the keep/remove call remains Mike's. Doc reconciled to state the off-the-live-path reality.

## Follow-ups noted (not in this PR's scope)

- `static/machines/topology.cljs:171` docstring still references the removed `:rf.xray.machine-canvas/viewport-for` sub (out of this bead's xray-spec + xyflow_style scope).
- 007 keyboard-shortcut table (`+`/`-`/`0`/`f`/arrows) + step factors appear to predate xyflow's `<Controls>` keyboard handling; a code-by-code audit (possibly machines-viz spec) is a separate question, not in the bead's enumerated drift items.

## Quality gates

- xray `clojure -M:test` — **1101 tests / 4577 assertions / 0 failures / 0 errors**
- `npm run test:cljs` — **5912 tests / 20959 assertions / 0 failures / 0 errors**
- `npm run test:xray-feature-gate` — **16 scenarios / 0 failures** (13 matrix rows; schema-violation timeline SKIP is the known migration skip)
