### PR TITLE
fix(xray): guard-blocked highlight stops at the guard event-node (rf2-4nxgqq)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -353,8 +353,12 @@ the external-restart axis; drives the `↻` reenter chip), `:machineLevel`,
 
 The inbound + outbound edges carry the structural / styling state
 that used to live on the single state→state edge: `:active`,
-`:focused`, `:fired`, `:guardBlocked` (rf2-fzrzlw — both halves paint the
-PINK guard-blocked stroke), `:crossHierarchy`, and elk-routed `:points`. Edge
+`:focused`, `:fired`, `:guardBlocked` (rf2-fzrzlw / rf2-4nxgqq — the
+PINK guard-blocked stroke covers the `__in` source→event-node half ONLY;
+the `__out` event-node→target half carries `:guardBlocked false` because a
+guard-blocked transition is a no-op that never reached the target, so the
+highlight STOPS at the guard event-node and the onward arrow stays resting),
+`:crossHierarchy`, and elk-routed `:points`. Edge
 ids: `<spec-edge-id>__in` / `<spec-edge-id>__out`. Event-node ids:
 `event__<spec-edge-id>` via `chart.projection/event-node-id`. The
 `:eventLabel` slot on these edges is empty (the event-node holds the

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -995,18 +995,28 @@
                            whose guard REJECTED the event this epoch (a
                            guard-blocked no-op: the runtime emitted
                            `:rf.machine/guard-evaluated` fail/threw but NO
-                           `:rf.machine/transition`). An edge — AND its
-                           event-node — is marked `:guardBlocked` when its
-                           id ∈ this set; the renderer paints the PINK
-                           guard-blocked treatment (emphasised pink stroke +
+                           `:rf.machine/transition`). The event-node AND its
+                           `__in` (source-state → event-node) half are
+                           marked `:guardBlocked` when the canonical id ∈
+                           this set; the renderer paints the PINK guard-
+                           blocked treatment (emphasised pink stroke +
                            emphasised pink `IF <guard>` chip, `data-guard-
-                           blocked`) which WINS over fired/focused/active on
-                           that edge so the attempted-and-rejected edge
-                           stands out (bead design calls (1) + (2)). Without
-                           this the chart paints ALL of the active state's
-                           exits affordance-blue and gives ZERO signal which
-                           edge the event hit or that a guard blocked it. The
-                           host (Xray) resolves the set via
+                           blocked`) which WINS over fired/focused/active so
+                           the attempted-and-rejected edge stands out (bead
+                           design calls (1) + (2)). rf2-4nxgqq — the
+                           highlight STOPS at the guard event-node: the
+                           `__out` (event-node → target-state) half is NOT
+                           marked, because a blocked transition is a no-op
+                           (the machine stayed in the source state; the
+                           target was never reached) and an onward pink arrow
+                           would falsely imply the transition progressed. The
+                           static `__out` topology edge still renders; only
+                           the live blocked-overlay stops at the event-node.
+                           Without any of this the chart paints ALL of the
+                           active state's exits affordance-blue and gives
+                           ZERO signal which edge the event hit or that a
+                           guard blocked it. The host (Xray) resolves the set
+                           via
                            `panels.machines.trace-state/extract-guard-blocked-edge-ids`.
                            SUPERSET of XState/Stately (which highlights
                            nothing on a block). Defaults to `#{}`.
@@ -1587,6 +1597,20 @@
         (fn [half {:keys [edge ev-node-id from-active? focused? fired? blocked?
                           cross-hier?] :as desc} points label-pos]
           (let [in? (= half :in)
+                ;; rf2-4nxgqq — a guard-BLOCKED transition is a no-op: the
+                ;; guard declined, the machine STAYED in the source state,
+                ;; the target was NEVER reached. So the guard-blocked
+                ;; HIGHLIGHT must stop at the guard event-node — it covers
+                ;; the `__in` (source→event-node) half ONLY, never the
+                ;; `__out` (event-node→target) half. Lighting the onward
+                ;; arrow would falsely imply the transition progressed to
+                ;; the target. The STATIC `__out` topology edge still
+                ;; renders (the transition exists in the definition); only
+                ;; the live blocked-overlay is withheld from it. General to
+                ;; ALL guard-blocked transitions (each guarded-fork branch's
+                ;; own `__out` half independently drops the overlay). The
+                ;; event-node itself + the `__in` half stay PINK (unchanged).
+                half-blocked? (and blocked? in?)
                 w   (if in?
                       (:arrow-width-quiet chart)
                       (:arrow-width chart))]
@@ -1600,8 +1624,11 @@
              ;; `__out` (event→target) half and the pair reads as ONE
              ;; transition route. Both sizes ride the resolved density map
              ;; (trimmed toward Stately's small/thin heads).
+             ;; rf2-4nxgqq — `half-blocked?` (not the raw `blocked?`) drives
+             ;; the arrowhead colour so the onward `__out` head is NOT pink
+             ;; for a guard-blocked no-op (the head + stroke agree per half).
              :markerEnd {:type   "arrowclosed"
-                         :color  (marker-color desc)
+                         :color  (marker-color (assoc desc :blocked? half-blocked?))
                          :width  w
                          :height w}
              :data      {:eventLabel ""
@@ -1609,11 +1636,15 @@
                          :active     from-active?
                          :focused    focused?
                          :fired      fired?
-                         ;; rf2-fzrzlw — guard-blocked no-op: both halves of
-                         ;; the route paint the PINK guard-blocked stroke
-                         ;; (winning over fired/focused/active) so the
-                         ;; attempted-and-rejected edge stands out.
-                         :guardBlocked blocked?
+                         ;; rf2-fzrzlw + rf2-4nxgqq — guard-blocked no-op: the
+                         ;; PINK guard-blocked stroke (winning over
+                         ;; fired/focused/active) covers the `__in`
+                         ;; (source→event-node) half ONLY. The `__out`
+                         ;; (event-node→target) half stays resting — the
+                         ;; target was never reached, so the onward arrow must
+                         ;; NOT imply the transition progressed. `half-blocked?`
+                         ;; is `blocked?` AND `in?`.
+                         :guardBlocked half-blocked?
                          :afterMs    nil
                          :guard      nil
                          :action     nil

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -2444,10 +2444,12 @@
                        (:id e))))))
 
 (deftest xyflow-graph-marks-guard-blocked-event-node-and-its-edges
-  (testing "rf2-fzrzlw — a parsed-edge id in :guard-blocked-edge-ids marks
-            BOTH the inbound + outbound edges AND the event-node for that
-            transition with `:guardBlocked true`. Other edges / event-nodes
-            stay `:guardBlocked false`."
+  (testing "rf2-fzrzlw + rf2-4nxgqq — a parsed-edge id in
+            :guard-blocked-edge-ids marks the event-node AND its `__in`
+            (source→event-node) half `:guardBlocked true`, but NOT its
+            `__out` (event-node→target) half — the highlight stops at the
+            guard event-node because the no-op never reached the target.
+            Other edges / event-nodes stay `:guardBlocked false`."
     (let [parsed   (layout/project-definition door-cyclic-machine)
           close-id (door-close-edge-id parsed)
           graph    (projection/xyflow-graph
@@ -2460,11 +2462,49 @@
           other-ed (remove #(#{(:id in-edge) (:id out-edge)} (:id %))
                            (:edges graph))]
       (is (string? close-id) "fixture has the guarded :door/close edge")
-      (is (true? (:guardBlocked (:data ev-node))))
-      (is (true? (:guardBlocked (:data in-edge))))
-      (is (true? (:guardBlocked (:data out-edge))))
+      (is (true? (:guardBlocked (:data ev-node))) "event-node is blocked")
+      (is (true? (:guardBlocked (:data in-edge)))
+          "the `__in` source→event-node half is blocked")
+      (is (false? (:guardBlocked (:data out-edge)))
+          "rf2-4nxgqq — the `__out` event-node→target half is NOT blocked
+           (the no-op never reached the target)")
       (is (every? #(false? (:guardBlocked (:data %))) other-ev))
       (is (every? #(false? (:guardBlocked (:data %))) other-ed)))))
+
+(deftest xyflow-graph-guard-blocked-highlight-stops-at-event-node
+  (testing "rf2-4nxgqq — a guard-BLOCKED transition is a no-op: the guard
+            declined, the machine stayed in the source state, the target was
+            never reached. So the live blocked HIGHLIGHT covers
+            source→event-node ONLY, never event-node→target. Concretely:
+            the `__in` half AND the event-node carry `:guardBlocked true` +
+            the PINK arrowhead hue, while the `__out` half carries
+            `:guardBlocked false` + the RESTING (non-pink) arrowhead — so the
+            onward arrow does NOT falsely imply the transition progressed.
+            The `__out` STATIC topology edge still renders (the transition
+            exists in the definition); only the live overlay is withheld."
+    (let [parsed     (layout/project-definition door-cyclic-machine)
+          close-id   (door-close-edge-id parsed)
+          ct         (tokens/chart-tokens)
+          graph      (projection/xyflow-graph
+                       parsed {} {:guard-blocked-edge-ids #{close-id}})
+          ev-node    (event-node-for  graph close-id)
+          in-edge    (inbound-edge-for  graph close-id)
+          out-edge   (outbound-edge-for graph close-id)]
+      ;; The `__out` topology edge still EXISTS (static rendering preserved).
+      (is (some? out-edge)
+          "the event-node→target `__out` edge still renders (static topology)")
+      ;; The blocked overlay reaches the event-node + the inbound half.
+      (is (true? (:guardBlocked (:data ev-node))) "event-node is blocked")
+      (is (true? (:guardBlocked (:data in-edge)))
+          "source→event-node half carries the blocked overlay")
+      (is (= (:edge-guard-blocked ct) (:color (:markerEnd in-edge)))
+          "the `__in` arrowhead is the PINK guard-blocked hue")
+      ;; The overlay STOPS at the event-node — the onward half stays resting.
+      (is (false? (:guardBlocked (:data out-edge)))
+          "event-node→target half is NOT blocked — the highlight stops here")
+      (is (not= (:edge-guard-blocked ct) (:color (:markerEnd out-edge)))
+          "the `__out` arrowhead is NOT the pink guard-blocked hue — the
+           onward arrow must not imply the transition progressed"))))
 
 (deftest xyflow-graph-no-guard-blocked-ids-leaves-all-unblocked
   (testing "rf2-fzrzlw — omitting :guard-blocked-edge-ids leaves EVERY edge

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -720,16 +720,35 @@ mints — agreement by construction, mirroring `extract-fired-edge-ids`). The
 host threads the set as `:guard-blocked-edge-ids` into `machine-canvas/Chart` →
 `MachineChart` (both the Dynamic Machine tab and the Static Topology view).
 
-**Render (render plane).** `chart.projection/xyflow-graph` marks each matching
-edge and its event-node `:guardBlocked`; `chart.nodes.event-node` +
-`chart.edges` then paint the guard-blocked treatment off the new
-`theme/tokens` `:edge-guard-blocked` token (a PINK hue — `:magenta-pink`,
-distinct from the blue fired/active hues AND the red `:final-error` ring):
+**Render (render plane).** Under the events-as-nodes paradigm (rf2-qo5xy) each
+transition splits into two segments: a `__in` (source-state → event-node) half
+and a `__out` (event-node → target-state) half. `chart.projection/xyflow-graph`
+marks the matching event-node + its `__in` half `:guardBlocked`;
+`chart.nodes.event-node` + `chart.edges` then paint the guard-blocked treatment
+off the new `theme/tokens` `:edge-guard-blocked` token (a PINK hue —
+`:magenta-pink`, distinct from the blue fired/active hues AND the red
+`:final-error` ring):
 
-1. The edge stroke + arrowhead paint PINK and emphasised-width (`tokens/edge-color`
-   resolves `:blocked?` with HIGHEST precedence).
+1. The `__in` edge stroke + arrowhead paint PINK and emphasised-width
+   (`tokens/edge-color` resolves `:blocked?` with HIGHEST precedence).
 2. The event-node border + box-shadow go PINK and its `IF <guard>` chip is
    EMPHASISED (bold pink) so the node reads as the guard that rejected it.
+
+**The highlight STOPS at the guard event-node (rf2-4nxgqq, Mike-ruled
+2026-06-08).** A guard-blocked transition is a NO-OP: the guard declined, the
+machine STAYED in the source state, the target was NEVER reached (the renderer
+distinguishes blocked from fired precisely because the machine state did not
+advance — `db-before` state == `db-after` state). So the live blocked HIGHLIGHT
+covers `source → event-node` ONLY, NEVER `event-node → target`. The `__out`
+half therefore carries `:guardBlocked false` and paints RESTING (non-pink) —
+lighting the onward arrow would FALSELY imply the transition progressed to the
+target. The `__out` STATIC topology edge still renders (the transition exists
+in the definition); only the live blocked-overlay is withheld from it. This is
+GENERAL to ALL guard-blocked transitions: each branch of a guarded fork
+independently drops the overlay from its own onward half. Implementation:
+`chart.projection`'s `events-as-nodes-edge` gates the blocked flag per half
+(`half-blocked? = blocked? AND in?`), driving both `:guardBlocked` and the
+arrowhead colour.
 
 **Design calls (Mike-ruled 2026-06-08):**
 
@@ -739,14 +758,19 @@ distinct from the blue fired/active hues AND the red `:final-error` ring):
   under the blue). `tokens/edge-color` ranks `blocked? > fired? > focused?/active? > quiet`.
 - _(3) Scope = guard-blocked ONLY_ — a truly-unhandled event (no declared edge)
   is a separate state-node "ignored event" marker, filed separately.
+- _(4) Highlight stops at the event-node (rf2-4nxgqq)_ — the onward
+  `event-node → target` half is NOT highlighted, because the no-op never
+  reached the target.
 
 **Beyond XState.** Stately labels the guarded edge but, on a block, takes no
 transition and highlights NOTHING — it does not paint a guard-failed edge
 colour. This is a SUPERSET enhancement, only possible because re-frame2 emits
 `:rf.machine/guard-evaluated` (observable-everything ethos).
 
-DOM pins: every guard-blocked edge label / event-node carries
-`data-guard-blocked="true"`; the chart root surfaces the sorted set on
+DOM pins: the guard-blocked event-node + its `__in` (source → event-node) edge
+half carry `data-guard-blocked="true"`; the `__out` (event-node → target) half
+carries `data-guard-blocked="false"` (rf2-4nxgqq — the highlight stops at the
+event-node). The chart root surfaces the sorted set on
 `data-guard-blocked-edge-ids` (mirroring `data-fired-edge-ids`).
 
 ### Relationship to the focused-transition lens (rf2-99rhe)


### PR DESCRIPTION
Closes rf2-4nxgqq.

A guard-BLOCKED transition is a no-op: the guard declines, the machine **stays** in the source state, the target is **never reached**. Under the events-as-nodes paradigm (rf2-qo5xy) the transition `open --door/close [may-close?]--> closed` renders as `open -> [door/close IF may-close?] event-node -> closed`, split into a `__in` (source-state → event-node) half and a `__out` (event-node → target) half. Before this change the live PINK guard-blocked overlay (rf2-fzrzlw) lit **both** halves, so the onward arrow falsely implied the transition progressed to the target.

## Fix

Gate the blocked flag per half in `chart.projection`'s `events-as-nodes-edge` (`half-blocked? = blocked? AND in?`), driving both `:guardBlocked` and the arrowhead colour. General to ALL guard-blocked transitions, including guarded forks (each branch's own onward half independently drops the overlay). The renderer distinguishes blocked from fired because the machine state did not advance (db-before == db-after for the noop).

### Before / after — which segments highlight (PINK)

| segment | before | after |
| --- | --- | --- |
| event-node | PINK | PINK (unchanged) |
| `__in` (source → event-node) | PINK | PINK (unchanged) |
| `__out` (event-node → target) | **PINK** ← bug | **RESTING** (non-pink) |

The STATIC `__out` topology edge still renders (the transition exists in the definition); only the live blocked-overlay stops at the event-node.

## Specs (same PR)

- `tools/xray/spec/003-Machine-Inspector.md` — rf2-fzrzlw guard-blocked section: new "highlight STOPS at the guard event-node" subsection + design call (4) + updated render-plane / DOM-pins text.
- `tools/machines-viz/spec/API.md` — corrected the inbound/outbound `:guardBlocked` note (was "both halves paint PINK").

(Avoided spec/021 + spec/007 + xyflow_style.cljs — owned by concurrent worker r1u79d.)

## Quality gates

- machines-viz `clojure -M:test` — **437 tests, 1457 assertions, 0 failures, 0 errors**
- xray `clojure -M:test` — **1101 tests, 4577 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **5913 tests, 20970 assertions, 0 failures, 0 errors**
- `npm run test:xray-feature-gate` — **16/16 scenarios, 0 failures**

New/updated tests pinning the behavior:
- `xyflow-graph-marks-guard-blocked-event-node-and-its-edges` — updated to assert `__out` is `:guardBlocked false`.
- `xyflow-graph-guard-blocked-highlight-stops-at-event-node` (new) — pins PINK `__in` arrowhead + resting `__out` arrowhead + the still-rendered static `__out` edge.
