### PR TITLE
docs(xray): fix stale viewport-for docstring ref in topology.cljs (rf2-zkpfm4)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
@@ -167,11 +167,10 @@
   "Render Topology mode for `machine-id`. `definition` is the
   registrar's spec map; `source-coord` is its lifted coord (or nil).
 
-  The embedded `machine-canvas/Chart` (rf2-md9oz) subscribes to
-  `:rf.xray.machine-canvas/viewport-for` internally so zoom / pan
-  state lives in app-db — the body function itself is still pure
-  hiccup; the subscribe lands one level down in the canvas
-  adapter.
+  The embedded `machine-canvas/Chart` (rf2-md9oz) wraps the
+  machines-viz xyflow `MachineChart` (rf2-gpzb4), which manages
+  zoom / pan / fit internally — the body function itself is still
+  pure hiccup.
 
   `dispatch` (rf2-nesy9) is threaded from `definition_detail/body` so
   the chart's state-click + the toolbar's pop-out land on the


### PR DESCRIPTION
## Quality gates

- xray `clojure -M:test`: **1101 tests, 4577 assertions, 0 failures, 0 errors** (green).
- `git grep 'viewport-for' -- tools/xray/src`: no matches (stale ref removed; sub gone in the rf2-gpzb4 xyflow migration).

Docstring-only change to the `body` fn in `tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs`. The old docstring named the removed `:rf.xray.machine-canvas/viewport-for` sub and claimed zoom/pan state lives in app-db; post-xyflow the machines-viz `MachineChart` manages zoom/pan/fit internally. No behaviour change.

Closes rf2-zkpfm4.
