### PR TITLE
docs(xray): reconcile 007 keyboard-shortcut table to xyflow reality (rf2-oc0fwy)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -526,33 +526,48 @@ Programmatic callers drive Sim against `:rf/xray` via that ns.
 
 ### Interactive Machines canvas (rf2-y3l8z)
 
-Every per-machine section in the Dynamic Machines panel wraps its
-chart in an interactive viewport adapter (`panels/machine_canvas.cljs`
-→ `chart/controls.cljc`). The chart is no longer a static SVG paint;
-it pans, zooms, and fits to viewport.
+Every per-machine section in the Dynamic Machines panel renders its
+chart through the machines-viz `MachineChart` xyflow component
+(`panels/machine_canvas.cljs` → `day8.re-frame2-machines-viz.chart`).
+The chart is no longer a static SVG paint; xyflow owns pan, zoom, and
+fit internally (the pre-xyflow host-side `chart/controls.cljc`
+viewport reducer is gone — rf2-gpzb4).
 
 ```
 ┌─ :auth/login   :idle → :authing                          [:auth/submit] ─┐
-│ ┌────────────────────────────────────────────────[− 100% +] [Fit][Reset]┐│
-│ │ · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · ││
-│ │ · · ▢ idle ──→ ▣ authing · · · · · · · · · · · · · · · · · · · · · · ││
-│ │ · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · ││
-│ │ · · · · · · · ◔ :after rings track node centres under zoom + pan · · ││
-│ └─────────────────────────────────────────────────────────────────────┘│
+│ · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · ││
+│ · · ▢ idle ──→ ▣ authing · · · · · · · · · · · · · · · · · · · · · · · ││
+│ · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · ││
+│ · · · · · · · ◔ :after rings track node centres under zoom + pan · · · ││
+│ ┌──────┐                                                                 │
+│ │ + − ⛶ │ ← xyflow <Controls> (bottom-left)                              │
+│ └──────┘                                                                 │
 │ Guards   ✓ :session-fresh?                                              │
 │ Actions  ✓ :clear-form                                                  │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-**Toolbar (top-right of every canvas):**
+**Controls — xyflow's built-in `<Controls>` component** (mounted with
+`{:showZoom true :showFitView true :showInteractive false}`; xyflow
+positions it bottom-left). It is a button cluster, not a custom Xray
+toolbar:
 
-- `−` / `+` — Zoom out / Zoom in about the viewport centre.
-- `NN%` chip — current zoom level, integer percentage.
-- `Fit` — fits the laid-out content into the viewport with padding
-  on all sides; centred. (Owned by the machines-viz `MachineChart`
-  via xyflow's built-in `fitView`; Xray re-frames on panel-entry by
-  bumping the orthogonal `:fit-signal` nonce, rf2-6tw7t.)
-- `Reset` — zoom 100%, pan (0, 0).
+- **Zoom-in `+`** / **zoom-out `−`** buttons — step the viewport zoom
+  about the centre.
+- **Fit-view `⛶`** button — fits the laid-out content into the viewport
+  with padding on all sides; centred. (Driven by xyflow's `fitView`;
+  Xray additionally re-frames on panel-entry by bumping the orthogonal
+  `:fit-signal` nonce, rf2-6tw7t.)
+- The interactivity-lock toggle is suppressed (`:showInteractive
+  false`) — the chart is non-interactive (`nodesDraggable false`).
+
+> **No `NN%` zoom-readout chip and no `Reset` button.** Earlier
+> drafts of this section described a custom `[− 100% +] [Fit][Reset]`
+> toolbar carried over from the pre-xyflow SVG renderer's host-side
+> viewport adapter. xyflow's `<Controls>` ships zoom-±/fit buttons
+> only — there is no percentage readout and no reset-to-100% button.
+> Reset-to-default framing is achieved via the fit-view button (or a
+> panel-entry `:fit-signal` bump).
 
 > **rf2-48fwsi — Canvas/List view-mode toggle removed.** The canvas
 > formerly carried a top-left two-button **Canvas** | **List** pill.
@@ -574,20 +589,35 @@ it pans, zooms, and fits to viewport.
   so node hits fall through to the node's own `:on-click`
   state-click event rather than dragging the node).
 
-**Keyboard shortcuts** (chart canvas must hold focus — `tabIndex=0`
-on the canvas host):
+**Keyboard shortcuts.** The chart binds **no** zoom/pan/fit keyboard
+shortcuts. Earlier drafts of this section claimed a `+`/`=`/`-`/`_`/`0`/
+`f`/`F` + arrow-key map on a `tabIndex=0` canvas host — that surface
+belonged to the pre-xyflow SVG renderer's host-side `chart/controls.cljc`
+viewport reducer and did not survive the rf2-gpzb4 xyflow migration. The
+live chart sets no `tabIndex` and registers no `onKeyDown`; xyflow 12.x
+ships no native viewport zoom-by-key (`+`/`-`/`0`) or pan-by-arrow
+handler (its built-in arrow-key handler *moves a selected node* and is
+inert here because `nodesDraggable`/`elementsSelectable` are `false`).
 
-| Key | Action |
+Zoom / pan / fit are therefore mouse-driven plus the `<Controls>`
+buttons:
+
+| Affordance | Action |
 |---|---|
-| `+` / `=`  | Zoom in (about viewport centre) |
-| `-` / `_`  | Zoom out (about viewport centre) |
-| `0`        | Reset (100%, pan 0,0) |
-| `f` / `F`  | Fit to viewport |
-| `←` / `→`  | Pan horizontally (20px / press) |
-| `↑` / `↓`  | Pan vertically (20px / press) |
+| Mouse wheel / trackpad pinch | Zoom toward the cursor (`zoomOnScroll`) |
+| Click-drag on canvas background | Pan (`panOnDrag`) |
+| `<Controls>` `+` / `−` buttons | Zoom in / out about the centre |
+| `<Controls>` fit-view button | Fit the topology to the viewport |
 
-**Bounds:** zoom is clamped to `[0.2, 4.0]`. Wheel notches step
-×1.1; toolbar +/- and `+`/`-` keys step ×1.2.
+> **Follow-up (rf2-oc0fwy):** if a keyboard zoom/pan surface is wanted,
+> it is a *new feature* (a focusable canvas host + an `onKeyDown` that
+> drives the captured `ReactFlowInstance`'s `zoomIn`/`zoomOut`/`fitView`/
+> `setViewport`), not a spec-described-existing one. File a feature bead
+> rather than treating it as implemented.
+
+**Bounds:** zoom is clamped to `[0.2, 4.0]` (the chart's `minZoom`
+/ `maxZoom` props). Wheel + button zoom-step factors are xyflow's
+internal defaults — not configured by the chart.
 
 **`:after` rings track the canvas (rf2-obp4z · rf2-uv1on).** The
 countdown-ring overlay (machines-viz `chart.overlays.after-rings/
@@ -1152,20 +1182,15 @@ active panel). `Esc` always returns focus to the event list.
 | `Tab` / `Shift+Tab` | Cycle focusables |
 | `Esc` | Return focus to event list |
 
-### Machines canvas (when chart canvas holds focus — rf2-y3l8z)
+### Machines canvas (rf2-y3l8z)
 
-| Key | Action |
-|---|---|
-| `+` / `=` | Zoom in (about viewport centre) |
-| `-` / `_` | Zoom out (about viewport centre) |
-| `0` | Reset to 100%, pan 0,0 |
-| `f` / `F` | Fit to viewport |
-| `←` `→` `↑` `↓` | Pan 20px / press |
-
-The canvas shortcuts only fire while the canvas host (`tabIndex=0`)
-is the active focus target — they are scoped to a clicked-into chart
-and do not collide with the global Xray keymap. Wheel-zoom +
-click-drag pan have no keyboard equivalent.
+The chart binds **no keyboard shortcuts** — see §Interactive Machines
+canvas → Keyboard shortcuts. Pan / zoom / fit are mouse-wheel,
+click-drag, and the xyflow `<Controls>` buttons only. The earlier
+`+`/`=`/`-`/`_`/`0`/`f`/`F` + arrow-key map (on a `tabIndex=0` canvas
+host) was pre-xyflow SVG-renderer fiction and did not survive the
+rf2-gpzb4 migration (rf2-oc0fwy audit). A keyboard zoom/pan surface
+would be a new feature, not a documented-existing one.
 
 ### Retired keys (from pre-rewrite spec)
 


### PR DESCRIPTION
## Summary

Audit + reconcile of `tools/xray/spec/007-UX-IA.md` per **rf2-oc0fwy**. The machine-chart **keyboard-shortcut table** (`+`/`-`/`0`/`f` + arrow keys on a `tabIndex=0` canvas host) and the custom `[− 100% +] [Fit][Reset]` toolbar described the **pre-xyflow SVG renderer's host-side `chart/controls.cljc` viewport reducer**, which did not survive the rf2-gpzb4 xyflow migration. Spec-only; one file.

## Audit findings (what's real / native / fiction)

Sources: `tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs`, `tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs`, `@xyflow/react@12.4.2` dist.

| Spec claim | Verdict |
|---|---|
| `+`/`=` zoom in, `-`/`_` zoom out, `0` reset, `f`/`F` fit (keys) | **Fiction** — no `onKeyDown` anywhere; xyflow 12.x binds no viewport zoom-by-key. |
| `←`/`→`/`↑`/`↓` pan 20px/press | **Fiction** — xyflow's arrow handler *moves a selected node* and is inert here (`nodesDraggable`/`elementsSelectable` are `false`); it never pans the viewport. |
| `tabIndex=0` canvas host | **Fiction** — the live ReactFlow sets no `tabIndex`. |
| Custom `[− 100% +] [Fit][Reset]` toolbar + `NN%` chip + `Reset` button | **Fiction** — controls are xyflow's built-in `<Controls>` (`{:showZoom true :showFitView true :showInteractive false}`): zoom ± + fit buttons only, no percentage readout, no reset button. |
| `chart/controls.cljc` adapter | **Stale** — that host-side reducer is gone (rf2-gpzb4); `machine_canvas.cljs` no longer requires it. |
| Mouse-wheel zoom (`zoomOnScroll`), click-drag pan (`panOnDrag`) | **Real** — kept. |
| `<Controls>` fit button + panel-entry `:fit-signal` re-frame | **Real** — kept. |
| zoom clamp `[0.2, 4.0]` | **Real** (`minZoom`/`maxZoom`); the `+/-` key step ×1.2 is fiction; wheel/button step factors are xyflow internal defaults, not configured. |

`tools/machines-viz/spec/API.md` already documents `:show-controls?` as xyflow's built-in Controls and claims no keyboard shortcuts — **no change needed there**; the fiction was entirely in xray 007.

## Changes

- §Interactive Machines canvas: replaced the keyboard table with the mouse-wheel + click-drag + `<Controls>`-buttons reality; rewrote the Toolbar section to describe xyflow `<Controls>`; fixed the wireframe + the stale `chart/controls.cljc` reference; corrected the Bounds note.
- Keyboard-map summary §Machines canvas: replaced the duplicate fictional table with a pointer to the reconciled section.

## Follow-up

A real keyboard zoom/pan surface would be a **new feature**, not a documented-existing one — filed **rf2-5vnqhy** (focusable canvas host + `onKeyDown` driving the captured `ReactFlowInstance`).

## Quality gates

Spec-only change (single file under `tools/xray/spec/`, which is **not** in the mkdocs site and ships no code). No `docs/` and no src touched, so `mkdocs build --strict` and xray `clojure -M:test` are not applicable — nothing to run.