### PR TITLE
fix(xray): focused Machine view renders all fired transitions for a parallel multi-region event (rf2-8ncxrf)

### DIFF
--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -693,6 +693,57 @@ muted `[NO OP] staying in {state}` cascade-row (rf2-iu3no) — that surface is
 the per-event cascade narration; this section is the Machines TAB's topology
 read. Both key off the one `:rf.machine.event/unhandled-no-op` trace.
 
+### Parallel multi-region fired-edge highlight (rf2-8ncxrf)
+
+A `:type :parallel` machine's snapshot `:state` is a **region-map** —
+one active leaf per orthogonal region (Spec 005 §Parallel regions). A
+single external event can fire transitions in **N regions at once**, yet
+the runtime emits exactly **ONE** `:rf.machine/transition` whose
+`:before` / `:after` carry the WHOLE composite region-map (machines ·
+`lifecycle_fx.registration/commit-or-finalize`). The focused Machine view
+must light **every** region's fired edge for that one event.
+
+The motivating case (Mike, live `examples/machine-epochs` HVAC,
+2026-06-08): `:hvac/controller` in `{:climate :idle, :fan :off}`;
+dispatch `[:hvac/power-cycle]` fires `:climate :idle→:running` AND
+`:fan :off→:on` in the same macrostep. The STATIC topology renders both
+`power-cycle` event-nodes, but the EVENT-FOCUSED dynamic view showed **NO
+transition** — `extract-fired-edge-ids` ran the trace's `:before` /
+`:after` `:state` through the single-active path coercion
+(`normalise-path`), which returns nil for a **map**, so it lit ZERO
+edges and the chart went blank.
+
+**Derivation (data plane).** `panels/machines/trace-state/extract-fired-edge-ids`
+detects the region-map shape on a transition's RAW (un-normalised)
+`:before` / `:after` `:state`. For a region-map it derives the fired set
+from the **machine-state change across ALL regions** — NOT from a single
+`(from, to)` pair (and NOT from the cascade db-diff, which can report
+empty changed-paths even though the machine snapshot under
+`[:rf/runtime :machines :snapshots]` changed). For each region whose
+`(from ≠ to)`, it matches the per-region `(from-path, to-path, event)`
+against the projected region edges, disambiguated by the edge's
+**region-scoped `:source`** (`chart.layout/region-scoped-id` of the
+region + in-region from-path — the SAME injective scheme
+`chart.layout/highlight-ids` resolves a region-map against, rf2-wnzha).
+This attributes each fired edge to exactly the region that moved, so two
+regions sharing a state NAME never cross-light. A region that did NOT
+move this event contributes no edge. The returned ids are the EXACT
+canonical machines-viz edge-ids the live chart mints (agreement by
+construction). Single-active (flat / compound) transitions are
+unaffected — they take the existing `(from, to, event)` match + the
+machine-level fallback.
+
+**Render (render plane).** The host threads the multi-id set verbatim as
+`:fired-edge-ids` into `machine-canvas/Chart` → `MachineChart`; the
+projector marks **each** matching edge `:fired`, so all N region edges
+paint the fired treatment at once. No render-plane change was needed —
+the fired-edge set was always a SET; the bug was purely the data-plane
+derivation returning empty for the region-map shape.
+
+DOM pin: the chart root surfaces the sorted multi-id set on
+`data-fired-edge-ids` (space-joined), so a parallel multi-region event
+pins **all** fired region-edge ids, not one.
+
 ### Guard-blocked edge highlight on the topology chart (rf2-fzrzlw)
 
 A guard-blocked no-op (above) emits NO `:rf.machine/transition`, so the chart's

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
@@ -134,6 +134,47 @@
                          (get-in ev [:payload :from]))]
     (normalise-path (or before-state from))))
 
+;; ---- raw (un-normalised) before/after state -----------------------------
+;;
+;; rf2-8ncxrf — a PARALLEL machine's snapshot `:state` is a region-MAP
+;; (`{:climate :idle :fan :off}`), one active leaf per orthogonal region
+;; (Spec 005 §Parallel regions). `from-path-from-trace` / `to-path-from-trace`
+;; run that value through `normalise-path`, which returns nil for a map —
+;; correct for the single-active path resolvers, but it means a parallel
+;; transition's before/after vanish there and `extract-fired-edge-ids` lights
+;; NO edge for an event that fired in N regions at once. The parallel branch
+;; needs the RAW `:state` value (keyword / vector / region-map) so it can
+;; iterate the per-region (from, to) pairs. These readers mirror the
+;; before/after slot tolerance of the path readers but DON'T normalise.
+
+(defn- before-state-from-trace
+  "Pull the RAW (un-normalised) `:before` (source) state value off a
+  `:rf.machine/transition` trace — a keyword, a path vector, OR a
+  parallel region-MAP. Same slot tolerance as `from-path-from-trace`
+  (modern `:tags :before :state`, legacy `:tags :from` / `:from` /
+  `:payload :from`); returns the value verbatim (no path coercion)."
+  [ev]
+  (let [before-state (get-in ev [:tags :before :state])]
+    (if (some? before-state)
+      before-state
+      (or (get-in ev [:tags :from])
+          (:from ev)
+          (get-in ev [:payload :from])))))
+
+(defn- after-state-from-trace
+  "Pull the RAW (un-normalised) `:after` (target) state value off a
+  `:rf.machine/transition` trace — a keyword, a path vector, OR a
+  parallel region-MAP. Same slot tolerance as `to-path-from-trace`
+  (modern `:tags :after :state`, legacy `:tags :to` / `:to` /
+  `:payload :to`); returns the value verbatim (no path coercion)."
+  [ev]
+  (let [after-state (get-in ev [:tags :after :state])]
+    (if (some? after-state)
+      after-state
+      (or (get-in ev [:tags :to])
+          (:to ev)
+          (get-in ev [:payload :to])))))
+
 (defn- event-from-trace
   "Pull the event keyword off a `:rf.machine/transition` trace event.
 
@@ -214,6 +255,77 @@
 
 ;; ---- fired-edge ids (machines-viz canonical) ----------------------------
 
+(defn- single-transition-fired-ids
+  "Fired-edge ids for ONE single-active (flat / compound) transition: the
+  `(from*, to*, event*)` paths read off the trace (already path-coerced).
+  A STATE-LOCAL edge matches on all three; falls back to a MACHINE-LEVEL
+  (top-level `:on`) edge matched on (to, event) alone — rf2-vcnvj projects
+  the fallback ONCE from the synthetic MACHINE-ROOT node, so its
+  `:from-path` is the root context `[]`, not the concrete leaf the runtime
+  fired it from. Without that fallback the door `:door/audit` fallback
+  firing from `:alarming` would highlight no edge. Returns a seq of ids."
+  [edges from* to* event*]
+  (let [local (keep (fn [e]
+                      (when (and (not (:machine-level? e))
+                                 (= from*  (:from-path e))
+                                 (= to*    (:to-path e))
+                                 (= event* (:event e)))
+                        (:id e)))
+                    edges)]
+    (if (seq local)
+      local
+      (keep (fn [e]
+              (when (and (:machine-level? e)
+                         (= to*    (:to-path e))
+                         (= event* (:event e)))
+                (:id e)))
+            edges))))
+
+(defn- parallel-transition-fired-ids
+  "Fired-edge ids for ONE PARALLEL multi-region transition (rf2-8ncxrf).
+
+  A `:type :parallel` machine's snapshot `:state` is a region-MAP — one
+  active leaf per orthogonal region (Spec 005 §Parallel regions). A single
+  external event (e.g. `[:hvac/power-cycle]`) fires transitions in N
+  regions at once, but the runtime emits ONE `:rf.machine/transition`
+  whose `:before` / `:after` carry the WHOLE composite region-map (per
+  `lifecycle_fx.registration/commit-or-finalize`). So the fired EDGES are
+  the per-region edges of every region that CHANGED — derived from the
+  before/after region-map, NOT from a single (from, to) pair.
+
+  `project-parallel` (machines-viz `chart.layout`) region-SCOPES each
+  region's edges: an edge's `:from-path` / `:to-path` are the IN-REGION
+  paths (e.g. `[:idle]` → `[:running]`) and its `:source` is
+  `(region-scoped-id region from-path)` — the SAME injective id-scheme
+  `highlight-ids` resolves a region-map against (rf2-wnzha). Edges carry
+  no `:region` key, so two regions sharing a state NAME would collide on
+  the `(from, to, event)` triple; we disambiguate by matching the edge's
+  region-scoped `:source` against `(region-scoped-id region from-path)`,
+  guaranteeing each fired id belongs to the region that actually moved.
+
+  Only regions whose `(from ≠ to)` contribute — an event that moves some
+  regions and leaves others resting lights exactly the moved regions.
+  Per-region `from` / `to` are coerced through `normalise-path` (a region
+  value is a keyword or in-region vector). Returns a seq of ids."
+  [edges before-map after-map event*]
+  (when event*
+    (mapcat
+      (fn [[region region-before]]
+        (let [region-after (get after-map region)
+              from*        (normalise-path region-before)
+              to*          (normalise-path region-after)]
+          ;; Skip a region that did not move, or whose paths don't coerce.
+          (when (and from* to* (not= region-before region-after))
+            (let [scoped-source (chart-layout/region-scoped-id region from*)]
+              (keep (fn [e]
+                      (when (and (= from*         (:from-path e))
+                                 (= to*           (:to-path e))
+                                 (= event*        (:event e))
+                                 (= scoped-source (:source e)))
+                        (:id e)))
+                    edges)))))
+      before-map)))
+
 (defn extract-fired-edge-ids
   "Given a machine `definition`, a vector of `:rf.machine/transition`
   trace events for the focused epoch, and the `machine-id` of interest,
@@ -236,45 +348,38 @@
   Transitions that don't carry an explicit event-id are excluded (they
   can't be matched to a declared edge).
 
+  rf2-8ncxrf — PARALLEL multi-region transitions. A `:type :parallel`
+  machine's `:before` / `:after` `:state` is a region-MAP, and ONE event
+  fires transitions in N regions simultaneously yet emits ONE trace. The
+  per-event branch detects the region-map shape and lights EVERY changed
+  region's edge (`parallel-transition-fired-ids`), so the focused Machine
+  view renders all N fired region-transitions — not a blank chart (the
+  single-active path returns nil for a map, which is why the event-focused
+  view showed NO transition for `[:hvac/power-cycle]`).
+
   Returns `#{}` for a nil/empty definition or no matching transitions."
   [definition trace-events machine-id]
   (let [edges (:edges (chart-layout/project-definition definition))]
     (->> (machine-transitions trace-events machine-id)
          (mapcat
            (fn [ev]
-             (let [from*  (from-path-from-trace ev)
-                   to*    (to-path-from-trace ev)
-                   event* (event-from-trace ev)]
-               (when (and from* to* event*)
-                 ;; A transition trace carries the concrete (from, to,
-                 ;; event) the runtime took. A STATE-LOCAL edge matches on
-                 ;; all three. A MACHINE-LEVEL (top-level `:on`) fallback,
-                 ;; however, is now projected ONCE from the synthetic
-                 ;; MACHINE-ROOT node (rf2-vcnvj) — its `:from-path` is the
-                 ;; root context `[]`, not the concrete leaf the runtime
-                 ;; fired it from. So when a trace's (from, event, to)
-                 ;; matches NO state-local edge, fall back to matching the
-                 ;; machine-level edge on (to, event) alone — the single
-                 ;; root-sourced chip lights regardless of which leaf
-                 ;; inherited it (the correct visual for a machine-wide
-                 ;; fallback). Without this fallback the door `:door/audit`
-                 ;; fallback firing from `:alarming` would highlight no
-                 ;; edge at all.
-                 (let [local (keep (fn [e]
-                                     (when (and (not (:machine-level? e))
-                                                (= from*  (:from-path e))
-                                                (= to*    (:to-path e))
-                                                (= event* (:event e)))
-                                       (:id e)))
-                                   edges)]
-                   (if (seq local)
-                     local
-                     (keep (fn [e]
-                             (when (and (:machine-level? e)
-                                        (= to*    (:to-path e))
-                                        (= event* (:event e)))
-                               (:id e)))
-                           edges)))))))
+             (let [event*      (event-from-trace ev)
+                   before-raw  (before-state-from-trace ev)
+                   after-raw   (after-state-from-trace ev)]
+               (if (or (map? before-raw) (map? after-raw))
+                 ;; PARALLEL multi-region: derive from the region-maps so
+                 ;; every region that moved this event lights its edge.
+                 (parallel-transition-fired-ids
+                   edges
+                   (if (map? before-raw) before-raw {})
+                   (if (map? after-raw) after-raw {})
+                   event*)
+                 ;; Single-active (flat / compound): the existing
+                 ;; (from, to, event) match + machine-level fallback.
+                 (let [from* (from-path-from-trace ev)
+                       to*   (to-path-from-trace ev)]
+                   (when (and from* to* event*)
+                     (single-transition-fired-ids edges from* to* event*)))))))
          set)))
 
 ;; ---- guard-blocked-edge ids (rf2-fzrzlw) --------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
@@ -585,3 +585,132 @@
       (is (seq blocked))
       (is (every? projected-ids blocked)
           "each guard-blocked id is one the live chart actually rendered"))))
+
+;; ---- extract-fired-edge-ids: PARALLEL multi-region (rf2-8ncxrf) ----------
+;;
+;; A `:type :parallel` machine's snapshot `:state` is a region-MAP (one
+;; active leaf per orthogonal region — Spec 005 §Parallel regions). A single
+;; external event fires transitions in N regions AT ONCE, but the runtime
+;; emits ONE `:rf.machine/transition` whose `:before` / `:after` carry the
+;; WHOLE composite region-map. The single-active (from, to) match returns
+;; nil for a map, so before this fix the event-focused Machine view lit NO
+;; edge for `[:hvac/power-cycle]` (the bug). `extract-fired-edge-ids` now
+;; detects the region-map shape and lights EVERY changed region's edge.
+
+(defn- hvac-definition
+  "The bead's repro: a 2-region parallel HVAC controller. `[:hvac/power-cycle]`
+  toggles BOTH regions at once (climate idle⇄running, fan off⇄on)."
+  []
+  {:type :parallel
+   :regions {:climate {:initial :idle
+                       :states  {:idle    {:on {:hvac/power-cycle :running}}
+                                 :running {:on {:hvac/power-cycle :idle}}}}
+             :fan     {:initial :off
+                       :states  {:off {:on {:hvac/power-cycle :on}}
+                                 :on  {:on {:hvac/power-cycle :off}}}}}})
+
+(deftest fired-ids-parallel-light-every-changed-region
+  (testing "rf2-8ncxrf — one [:hvac/power-cycle] event firing in BOTH regions
+            lights BOTH region edges (climate idle→running + fan off→on),
+            not a blank chart"
+    (let [def           (hvac-definition)
+          projected     (:edges (chart-layout/project-definition def))
+          projected-ids (set (map :id projected))
+          climate-id    (->> projected
+                             (some (fn [e]
+                                     (when (and (= [:idle]    (:from-path e))
+                                                (= [:running] (:to-path e))
+                                                (= :hvac/power-cycle (:event e)))
+                                       (:id e)))))
+          fan-id        (->> projected
+                             (some (fn [e]
+                                     (when (and (= [:off] (:from-path e))
+                                                (= [:on]  (:to-path e))
+                                                (= :hvac/power-cycle (:event e)))
+                                       (:id e)))))
+          ;; The LIVE runtime shape: ONE transition trace, region-map
+          ;; before/after, `:tags :event` a `[event-id & args]` vector.
+          events        [{:operation :rf.machine/transition
+                          :tags {:machine-id :hvac/controller
+                                 :before {:state {:climate :idle :fan :off}}
+                                 :after  {:state {:climate :running :fan :on}}
+                                 :event  [:hvac/power-cycle]}}]
+          fired         (trace-state/extract-fired-edge-ids
+                          def events :hvac/controller)]
+      (is (string? climate-id) "the climate idle→running edge exists")
+      (is (string? fan-id)     "the fan off→on edge exists")
+      (is (= #{climate-id fan-id} fired)
+          "BOTH fired region edges light — the multi-region event renders")
+      (is (every? projected-ids fired)
+          "each fired id is a real live-chart edge id"))))
+
+(deftest fired-ids-parallel-only-changed-regions
+  (testing "rf2-8ncxrf — an event that moves ONE region and leaves the other
+            resting lights ONLY the moved region's edge"
+    (let [def        (hvac-definition)
+          projected  (:edges (chart-layout/project-definition def))
+          climate-id (->> projected
+                          (some (fn [e]
+                                  (when (and (= [:idle]    (:from-path e))
+                                             (= [:running] (:to-path e))
+                                             (= :hvac/power-cycle (:event e)))
+                                    (:id e)))))
+          ;; climate moved idle→running; fan stayed off (region unchanged).
+          events     [{:operation :rf.machine/transition
+                       :tags {:machine-id :hvac/controller
+                              :before {:state {:climate :idle :fan :off}}
+                              :after  {:state {:climate :running :fan :off}}
+                              :event  [:hvac/power-cycle]}}]
+          fired      (trace-state/extract-fired-edge-ids
+                       def events :hvac/controller)]
+      (is (= #{climate-id} fired)
+          "only the climate edge lights — the resting fan region is skipped"))))
+
+(deftest fired-ids-parallel-disambiguate-shared-state-names-across-regions
+  (testing "rf2-8ncxrf / rf2-wnzha — two regions sharing a state NAME mint
+            DISTINCT region-scoped edge ids; the region-scoped :source match
+            attributes each fired edge to the region that actually moved"
+    ;; Both regions declare an `:a`/`:b` pair on the same `:go` event — the
+    ;; (from, to, event) triple alone would collide across regions. The
+    ;; region-scoped :source disambiguates.
+    (let [def        {:type :parallel
+                      :regions {:left  {:initial :a
+                                        :states  {:a {:on {:go :b}}
+                                                  :b {}}}
+                                :right {:initial :a
+                                        :states  {:a {:on {:go :b}}
+                                                  :b {}}}}}
+          projected  (:edges (chart-layout/project-definition def))
+          left-id    (->> projected (some (fn [e]
+                                            (when (= "region__left__a"  (:source e))
+                                              (:id e)))))
+          right-id   (->> projected (some (fn [e]
+                                            (when (= "region__right__a" (:source e))
+                                              (:id e)))))
+          ;; Only :left moved a→b; :right stayed at :a.
+          events     [{:operation :rf.machine/transition
+                       :tags {:machine-id :twin
+                              :before {:state {:left :a :right :a}}
+                              :after  {:state {:left :b :right :a}}
+                              :event  [:go]}}]
+          fired      (trace-state/extract-fired-edge-ids def events :twin)]
+      (is (string? left-id))
+      (is (string? right-id))
+      (is (not= left-id right-id) "the two regions' :a→:b edges have distinct ids")
+      (is (= #{left-id} fired)
+          "ONLY the :left edge lights — the region-scoped source discriminates"))))
+
+(deftest fired-ids-parallel-agree-with-projected-chart-edge-ids
+  (testing "rf2-8ncxrf — every parallel fired id is a real projected chart edge :id"
+    (let [def           (hvac-definition)
+          projected-ids (set (map :id (:edges (chart-layout/project-definition def))))
+          events        [{:operation :rf.machine/transition
+                          :tags {:machine-id :hvac/controller
+                                 :before {:state {:climate :idle :fan :off}}
+                                 :after  {:state {:climate :running :fan :on}}
+                                 :event  [:hvac/power-cycle]}}]
+          fired         (trace-state/extract-fired-edge-ids
+                          def events :hvac/controller)]
+      (is (= 2 (count fired)) "both region edges fired")
+      (is (every? projected-ids fired)
+          "each parallel fired id is one the live chart actually rendered"))))


### PR DESCRIPTION
## Quality gates

| Gate | Result |
| --- | --- |
| xray `clojure -M:test` | 1101 tests, 4577 assertions, **0 failures** |
| machines-viz `clojure -M:test` | 437 tests, 1457 assertions, **0 failures** |
| `npm run test:cljs` | 5921 tests, 21006 assertions, **0 failures** |
| `npm run test:xray-feature-gate` | **16/16 scenarios, 0 failures** (13 matrix rows) |

## Root cause

A `:type :parallel` machine's snapshot `:state` is a **region-map** — one active
leaf per orthogonal region (Spec 005 §Parallel regions). A single event
(`[:hvac/power-cycle]`) fires transitions in **N regions at once**, but the
runtime emits exactly **ONE** `:rf.machine/transition` whose `:before` /
`:after` carry the WHOLE composite region-map (machines ·
`lifecycle_fx.registration/commit-or-finalize`).

`extract-fired-edge-ids` resolved the trace's before/after `:state` through the
single-active path coercion (`normalise-path`), which returns **nil for a map**.
So for a parallel transition it lit **zero** edges — and the event-focused
Machine view rendered NO transition for `[:hvac/power-cycle]`, even though both
regions had moved. (The cascade db-diff lead from the bead is the same symptom
from a different angle: an empty changed-paths diff also yields nothing; the fix
derives from the machine SNAPSHOT change, not the db-diff.)

## The fix

Entirely xray-side, in `panels/machines/trace_state.cljs`:

- Add raw (un-normalised) `before-state-from-trace` / `after-state-from-trace`
  readers that return the `:state` value verbatim (keyword / vector / region-map).
- `extract-fired-edge-ids` now detects the region-map shape per transition. For a
  region-map it derives the fired set from the machine-state change across **ALL**
  regions: for each region whose `(from ≠ to)`, match the per-region
  `(from-path, to-path, event)` against the projected region edges, disambiguated
  by the edge's **region-scoped `:source`** (`chart.layout/region-scoped-id` —
  the same injective scheme `chart.layout/highlight-ids` resolves a region-map
  against, rf2-wnzha) so two regions sharing a state NAME never cross-light. A
  region that did not move contributes no edge.
- Single-active (flat / compound) transitions are unchanged — the existing
  `(from, to, event)` match + machine-level fallback is preserved (refactored into
  `single-transition-fired-ids`).

The returned ids are the EXACT canonical machines-viz edge-ids the live chart
mints (agreement by construction). **No render-plane change** — the chart's
`:fired-edge-ids` was always a SET; the bug was purely the data-plane derivation
returning empty for the region-map shape.

**machines-viz NOT touched** — only read-only use of its public
`region-scoped-id` / `highlight-ids` / `project-definition`. The disjoint
boundary with the concurrent `lxk3h3` worker (projection/layout) is respected.

## Before / after

- **Before:** focused Machine view for a selected `[:hvac/power-cycle]` event on
  the parallel `:hvac/controller` → **blank** chart, no fired transition. The
  `data-fired-edge-ids` attr was empty.
- **After:** both region edges paint the fired treatment at once —
  `#{"region__climate__idle__running__hvac/power-cycle"
  "region__fan__off__on__hvac/power-cycle"}` — and `data-fired-edge-ids` pins
  the sorted multi-id set.

## Tests

4 new parallel cases in `trace_state_cljs_test.cljs`:
- both regions light for one multi-region event;
- only the moved region lights (resting region skipped);
- two regions sharing a state name disambiguate via region-scoped `:source`;
- every parallel fired id is a real projected chart edge id.

## Spec

`tools/xray/spec/003-Machine-Inspector.md` gains a **Parallel multi-region
fired-edge highlight (rf2-8ncxrf)** section documenting the region-map detection,
the per-region snapshot-change derivation, the region-scoped disambiguation, and
the DOM pin.

Closes rf2-8ncxrf.
