### PR TITLE
docs(EP): number EPs + formal-PEP structure + relationships into EP docs (rf2-dtzhiz + rf2-0ium2h + rf2-2l7kew)

### DIFF
--- a/docs/EP/README.md
+++ b/docs/EP/README.md
@@ -9,25 +9,17 @@ EPs are *proposals*, not normative specification. The normative artefact remains
 ## Conventions
 
 - One EP per file, **flat** in this directory, kebab-case named, each self-contained.
-- Front matter: a one-line `Status:` (`proposal` / `accepted` / `superseded`), a `Date:`, and a `Related:` list of guide/spec links.
-- Add new EPs to the table below and to the `EP` section of [`mkdocs.yml`](https://github.com/day8/re-frame2/blob/main/mkdocs.yml).
+- Each EP carries a stable PEP-style **number** (`EP-0001`, `EP-0002`, …) assigned in `Created`-date order (oldest = `EP-0001`). The number lives in the doc's header metadata (`Number:`), its H1 title, and the index below. Numbers are stable and never reused; the descriptive filename is kept (the number does not rename the file).
+- Header metadata block: `Number`, `Status` (`proposal` / `accepted` / `superseded`), `Type`, `Date`, `Created`, `Author`, `Target Artifact`, and `Requires` (dependency EPs/specs). Inter-EP dependencies live **in each EP** — its `Requires:` header and a `Relationships` section — not here.
+- Standard sections, modelled on [`subscription-inputs.md`](subscription-inputs.md): Abstract, Motivation, Goals/Non-Goals, Relationships, Specification, Rationale / Runtime Semantics, Backwards Compatibility, Migration, Rejected Ideas, Open Issues, Recommendation.
+- Add new EPs to the table below (next free number) and to the `EP` section of [`mkdocs.yml`](https://github.com/day8/re-frame2/blob/main/mkdocs.yml).
 
 ## Index
 
-| EP | Status | Summary |
-|----|--------|---------|
-| [App/Runtime Partition](app-db-runtime-partition.md) | proposal | A frame owns two durable partitions — user-owned **app-db** (`:db`) and framework-owned **runtime-db** (`:rf.db/runtime`) — committed coherently by one cascade. Removes the footgun where an ordinary `:db` return silently clobbers machine / routing / elision / SSR runtime state, while preserving one coherent app+runtime snapshot for time-travel and SSR. |
-| [Explicit Frame Target Resolution](frame-target-resolution.md) | proposal | Remove ambient `:rf/default` fallback. Frame-scoped operations must resolve their target from explicit frame context (frame id/handle, provider, cascade, lexical binding, or tool/session target), and missing context fails instead of mutating or reading the wrong frame. |
-| [Parametric Subscription Inputs](subscription-inputs.md) | proposal | Restore the useful part of re-frame v1's two-function `reg-sub` shape by adding input functions that return a vector of query vectors. Keep `:<-` as static-input sugar while making query-vector-parametric subscription dependencies pure, inspectable, JVM-runnable, and Xray-visible. |
-| [Resource Queries](resource-queries.md) | proposal | An optional `day8/re-frame2-resources` artefact for declarative server-state — the re-frame2 answer to TanStack Query / RTK Query / SWR / `shipclojure/re-frame-query`. Resource identity, caching, staleness, dedupe, tag invalidation, active-owner lifecycle/GC, route + SSR preload, built on managed-HTTP (Spec 014) and the runtime partition. |
-| [Machine `:data` Schema](machine-data-schema.md) | proposal | Rename `defmachine`'s existing `:schema` key → `:data-schema` for the machine's `:data` (its context), the re-frame2 analog of XState v5 typed context. Corrects the premise that machine `:data` is un-schema'd (validation already shipped under rf2-jbbp7); the real work is closing the schema→marks **redaction** bridge so `:sensitive?` slots are elided in snapshot egress, switching machines-viz to **declared-over-inferred** Context shape (the deferred wto1k option-A), and documenting the XState parity. |
-
-## Relationships
-
-The **App/Runtime Partition** EP is foundational: **Resource Queries** stores its cache in the framework-owned runtime partition (`:rf.runtime/resources`) that EP introduces, so the partition should land (or its key vocabulary be fixed) before resources rely on it.
-
-The **Explicit Frame Target Resolution** EP is a cross-cutting safety proposal. It should be resolved before large frame-aware features such as resource queries, Xray control surfaces, SSR hydration helpers, and work-ledger tooling harden their public APIs.
-
-The **Parametric Subscription Inputs** EP is a Reactive Substrate proposal. It should be resolved before resource-query, route-model, or Hasura helpers lean on parameterized subscription view models, because it determines whether those helpers use static `:<-`, vector-of-query-vectors input functions, or broader app-db reads.
-
-The **Machine `:data` Schema** EP touches the same `[:rf/runtime :machines :snapshots]` path the **App/Runtime Partition** EP renames to `[:rf.runtime/machines :snapshots]`; if both land, the machine-data-schema redaction-bridge work sequences after the partition rename so it targets the final path. It is otherwise independent.
+| EP | Title | Status | Summary |
+|----|-------|--------|---------|
+| [EP-0001](app-db-runtime-partition.md) | Frame App/Runtime Partitions | proposal | A frame owns two durable partitions — user-owned **app-db** (`:db`) and framework-owned **runtime-db** (`:rf.db/runtime`) — committed coherently by one cascade, removing the footgun where a fresh `:db` return clobbers runtime state. |
+| [EP-0002](frame-target-resolution.md) | Explicit Frame Target Resolution | proposal | Remove the ambient `:rf/default` fallback; frame-scoped operations resolve their target from explicit frame context, and missing context fails instead of touching the wrong frame. |
+| [EP-0003](resource-queries.md) | Resource Queries | proposal | An optional `day8/re-frame2-resources` artefact for declarative server-state — the re-frame2 answer to TanStack Query / RTK Query / SWR — with resource identity, caching, invalidation, lifecycle/GC, and route + SSR preload. |
+| [EP-0004](subscription-inputs.md) | Parametric Subscription Inputs | proposal | Restore v1's two-function `reg-sub` shape via input functions that return a vector of query vectors, keeping `:<-` as static-input sugar and dependencies pure, inspectable, JVM-runnable, and Xray-visible. |
+| [EP-0005](machine-data-schema.md) | Machine `:data` Schema | proposal | Rename `defmachine`'s `:schema` key to `:data-schema` for the machine's `:data` context, close the schema→marks redaction bridge, switch machines-viz to declared-over-inferred Context shape, and document XState v5 parity. |

--- a/docs/EP/app-db-runtime-partition.md
+++ b/docs/EP/app-db-runtime-partition.md
@@ -1,19 +1,26 @@
-# EP: Frame App/Runtime Partitions
+# EP-0001: Frame App/Runtime Partitions
+
+Number: EP-0001
 
 Status: proposal
+
 Type: Standards Track
+
 Date: 2026-06-06
+
 Created: 2026-06-06
+
+Author: re-frame2 maintainers
+
 Topic: frame state ownership
-Requires: explicit frame identity, coherent frame transitions
+
+Target Artifact: `day8/re-frame2-core`
+
 Impacts: frames, events, subscriptions, machines, routing, SSR, schemas, Xray, pair tools, docs, skills
 
-Related:
+Requires:
 
-- [Guide 02 - app-db](../guide/02-app-db.md)
-- [Guide 04 - Events and the cascade](../guide/04-events-and-the-cascade.md)
-- [Guide 18 - Frames](../guide/18-frames.md)
-- [Guide 21 - Runtime model](../guide/21-dynamic-model.md)
+- explicit frame identity, coherent frame transitions
 - [Spec 002 - Frames](https://github.com/day8/re-frame2/blob/main/spec/002-Frames.md)
 - [Spec 005 - State Machines](https://github.com/day8/re-frame2/blob/main/spec/005-StateMachines.md)
 - [Spec 006 - Reactive Substrate](https://github.com/day8/re-frame2/blob/main/spec/006-ReactiveSubstrate.md)
@@ -22,6 +29,13 @@ Related:
 - [Spec 012 - Routing](https://github.com/day8/re-frame2/blob/main/spec/012-Routing.md)
 - [Runtime Architecture](https://github.com/day8/re-frame2/blob/main/spec/Runtime-Architecture.md)
 - [Conventions](https://github.com/day8/re-frame2/blob/main/spec/Conventions.md)
+
+Related:
+
+- [Guide 02 - app-db](../guide/02-app-db.md)
+- [Guide 04 - Events and the cascade](../guide/04-events-and-the-cascade.md)
+- [Guide 18 - Frames](../guide/18-frames.md)
+- [Guide 21 - Runtime model](../guide/21-dynamic-model.md)
 - [Explicit Frame Target Resolution EP](frame-target-resolution.md)
 - [Resource Queries EP](resource-queries.md)
 
@@ -140,6 +154,26 @@ This proposal does not:
 - settle every epoch record field name;
 - redesign machine snapshot internals;
 - define the resource query API, except by reserving a runtime partition for it.
+
+## Relationships
+
+This EP is foundational for other EPs that store framework-owned state.
+
+- **Foundational for resource queries.** The [Resource Queries
+  EP](resource-queries.md) stores its cache in the framework-owned runtime
+  partition (`:rf.runtime/resources`) this EP introduces, so this partition
+  should land — or at least its key vocabulary be fixed — before resources rely
+  on it.
+- **Shares a path with the machine `:data` schema EP.** The [Machine `:data`
+  Schema EP](machine-data-schema.md) touches the same
+  `[:rf/runtime :machines :snapshots]` path this EP renames to
+  `[:rf.runtime/machines :snapshots]`. If both land, the machine-data-schema
+  redaction-bridge work sequences *after* this partition rename so it targets the
+  final path. The two are otherwise independent.
+- **Composes with explicit frame target resolution.** Both partitions are
+  frame-owned; resolving the frame target precedes committing or projecting
+  either partition. See the [Explicit Frame Target Resolution
+  EP](frame-target-resolution.md).
 
 ## Specification
 
@@ -752,6 +786,31 @@ Compatibility work should be limited to:
 
 The stable vocabulary should be the final vocabulary.
 
+## Migration
+
+Migration is in-repo only — re-frame2 ships no external alpha — and is mechanical
+rather than gradual:
+
+- **Move runtime subsystems off app-db.** Machines, routing, elision, SSR, and
+  related schemas move from `:rf/runtime` paths under app-db to the framework-owned
+  runtime-db (`:rf.runtime/*`). Snapshots move from
+  `[:rf/runtime :machines :snapshots]` to `[:rf.runtime/machines :snapshots]`.
+- **Classify write authority at call sites.** Every existing `[:rf/runtime …]`
+  reader/writer is reclassified: ordinary app handlers keep returning `:db`
+  (app-db only); framework subsystems write runtime-db through privileged
+  framework-authority paths.
+- **Reserve `:rf.db/runtime` in the effect map.** The closed top-level event
+  effect map (`:db`, `:fx`) gains `:rf.db/runtime` as a deliberate reserved key
+  writable only by framework-authority handlers.
+- **Update full-frame operations.** Epoch records, SSR hydration, `restore-epoch`,
+  reset, and destroy switch from app-db-only snapshots to frame-state projections.
+- **Drive legacy access loud.** A short-lived `:rf/runtime`-access diagnostic eases
+  the in-repo migration during implementation, then is removed; the stable
+  vocabulary is the final vocabulary (see Backwards Compatibility above).
+
+The detailed staged sequence lives in [Reference Implementation](#reference-implementation)
+and [Bead Plan](#bead-plan) below.
+
 ## Security And Privacy Considerations
 
 The current `:rf/runtime` location is not only a machine/routing correctness
@@ -1149,6 +1208,25 @@ than app-db/runtime-db.
    ambiguous context-key use, and unauthorized `:rf.db/runtime` effects.
 10. Docs/examples/skills bead: rewrite human docs, AI specs, examples, and
     skills to teach the new model.
+
+## Recommendation
+
+Adopt the two-partition frame model: a frame owns a user-owned **app-db** (`:db`)
+and a framework-owned **runtime-db** (`:rf.db/runtime`), committed coherently by
+one cascade and projectable as a single frame-state value for SSR, epoch restore,
+time travel, and Xray.
+
+This makes accidental runtime-state deletion structurally impossible for ordinary
+app handlers while preserving the ergonomic re-frame meaning of `:db`, keeping one
+coherent app+runtime snapshot, and giving app-db a pure application contract an
+agent can read without framework noise. The pre-alpha posture favors the clean
+break (no long-lived `:rf/runtime` aliases) over compatibility shims.
+
+The design-review appendices below record two open considerations the maintainers
+should settle alongside adoption: pinning write-authority at registration so the
+"structurally impossible" guarantee is earned (Appendix A), and whether the
+upstream handler-contract question should be decided before the partition is
+locked (Appendix B).
 
 ## Source Findings
 

--- a/docs/EP/frame-target-resolution.md
+++ b/docs/EP/frame-target-resolution.md
@@ -1,4 +1,6 @@
-# EP: Explicit Frame Target Resolution
+# EP-0002: Explicit Frame Target Resolution
+
+Number: EP-0002
 
 Status: proposal
 
@@ -7,6 +9,8 @@ Type: Standards Track
 Date: 2026-06-06
 
 Created: 2026-06-06
+
+Author: re-frame2 maintainers
 
 Target Artifact: `day8/re-frame2-core`
 
@@ -150,6 +154,26 @@ This EP should not:
 - make Xray or pair tools unable to discover frames;
 - solve app/runtime partitioning by itself;
 - introduce backwards-compatibility shims for v1-style frameless calls.
+
+## Relationships
+
+This is a cross-cutting safety proposal that should resolve before large
+frame-aware features harden their public APIs.
+
+- **Resolve before frame-aware features.** This EP should be resolved before
+  large frame-aware features — such as [resource queries](resource-queries.md),
+  Xray control surfaces, SSR hydration helpers, and work-ledger tooling — harden
+  their public APIs, because each of those features carries (or depends on) an
+  explicit frame target and should not be built against the ambient
+  `:rf/default` fallback this EP removes.
+- **Composes with the app/runtime partition.** Both partitions in the
+  [App/Runtime Partition EP](app-db-runtime-partition.md) (listed under
+  `Requires`) are frame-owned; resolving the frame target precedes committing or
+  projecting either partition.
+- **Subscription inputs inherit the resolved frame.** Parametric subscription
+  input query vectors are frame-agnostic data resolved in the outer
+  subscription's frame; see the [Parametric Subscription Inputs
+  EP](subscription-inputs.md).
 
 ## Developer And AI Use Cases
 
@@ -724,7 +748,7 @@ It must not borrow `:rf/default` marks.
 ;; => :rf.error/no-frame-context
 ```
 
-## Alternatives Considered
+## Rejected Ideas
 
 ### A. Keep Status Quo
 
@@ -780,7 +804,8 @@ Cons:
 - requires better root/bootstrap examples;
 - revokes the earlier single-frame invisibility goal.
 
-Recommendation: **Option C**.
+The recommended option is **Option C** — explicit frame context, no default
+fallback. See [Recommendation](#recommendation) below.
 
 ## Backwards Compatibility
 
@@ -795,7 +820,9 @@ is less valuable than frame correctness once SSR, Story, Xray, pair tools, AI
 tooling, resource management, managed effects, and runtime partitions all depend
 on frame isolation.
 
-Migration should be mechanical:
+## Migration
+
+Migration is mechanical:
 
 - choose an application frame id;
 - register it explicitly;
@@ -807,6 +834,11 @@ Migration should be mechanical:
 
 A migration may choose `:rf/default` as the explicit id. The runtime will not
 infer it.
+
+The full implementation order — sequential because the fallback is embedded in
+hot-zone specs, tests, tooling, docs, and developer education — lives in
+[Reference Implementation Plan](#reference-implementation-plan) and
+[Bead Structure](#bead-structure) below.
 
 ## Security And Privacy
 
@@ -1078,7 +1110,7 @@ Rollout should be sequential because hot-zone specs, tools, docs, and tests all
 reference the old contract. Do not dispatch implementation beads in parallel
 across the same spec and core-runtime files without a coordinator.
 
-## Open Decisions
+## Open Issues
 
 1. Should `init!` stop creating any frame, or should a separate app bootstrap
    helper create a frame explicitly from opts?
@@ -1104,6 +1136,22 @@ across the same spec and core-runtime files without a coordinator.
    Recommendation: always-on error emission, not per-frame epoch only.
 7. Do boot-time frame-local `reg-*` forms require explicit `:frame`?
    Recommendation: yes, unless the surface is classified as globally registered.
+
+## Recommendation
+
+Adopt **Option C**: remove the ambient `:rf/default` fallback. Frame-scoped
+operations must resolve their target from explicit frame context — a frame
+id/handle, a provider, a cascade, a lexical binding, or a tool/session target —
+and missing context must fail loudly rather than mutate or read the wrong frame.
+
+This is the strongest frame-isolation rule, the easiest to teach ("no frame
+context, no operation"), and the one that makes async and tooling boundaries
+honest. It matches the explicit provider/client/environment patterns in the
+benchmark libraries and fits the pre-alpha no-compatibility posture. The cost — a
+repo-wide migration of tests, docs, examples, tools, and skills that assume
+`:rf/default`, and revoking the earlier single-frame invisibility goal — is
+accepted because frame correctness now underpins SSR, Story, Xray, pair tools, AI
+tooling, resource management, managed effects, and the runtime partition.
 
 ## Bead Structure
 

--- a/docs/EP/machine-data-schema.md
+++ b/docs/EP/machine-data-schema.md
@@ -1,4 +1,6 @@
-# EP: Machine `:data` Schema (`defmachine` `:data-schema`)
+# EP-0005: Machine `:data` Schema (`defmachine` `:data-schema`)
+
+Number: EP-0005
 
 Status: proposal
 
@@ -7,6 +9,8 @@ Type: Standards Track
 Date: 2026-06-08
 
 Created: 2026-06-08
+
+Author: re-frame2 maintainers
 
 Target Artifact: `day8/re-frame2-machines`
 
@@ -224,6 +228,21 @@ other (CLARITY-of-name vs cross-registration-consistency).
 - The app/runtime partition rename of `[:rf/runtime :machines :snapshots]` →
   `[:rf.runtime/machines :snapshots]`. That is the App/Runtime Partition EP's
   concern; this EP uses today's path and sequences after it if both land.
+
+## Relationships
+
+This EP is largely independent but shares one path with the partition EP.
+
+- **Sequences after the app/runtime partition rename.** This EP's redaction
+  bridge targets the machine-snapshot path `[:rf/runtime :machines :snapshots]`,
+  which the [App/Runtime Partition EP](app-db-runtime-partition.md) (listed under
+  `Requires`) renames to `[:rf.runtime/machines :snapshots]`. If both land, the
+  redaction-bridge work sequences *after* the partition rename so it targets the
+  final path. The two are otherwise independent.
+- **In-bead relationships.** For the relationship to the closed beads `rf2-wto1k`
+  (deferred declared-context option A) and `rf2-5tz9p` (inferred-context badge),
+  see [Relationship To `rf2-5tz9p` And `rf2-wto1k`](#relationship-to-rf2-5tz9p-and-rf2-wto1k)
+  below.
 
 ## Benchmark Standard And Prior Art
 
@@ -515,7 +534,7 @@ introduced — `:data-schema` is an unqualified spec-map key like `:data` /
 - machines-viz infers `Context: count: number` badged "inferred from :data"
   (`rf2-5tz9p`), exactly as today.
 
-## Alternatives Considered
+## Rejected Ideas
 
 ### A. Status quo — keep `:schema`, do nothing else
 
@@ -563,6 +582,25 @@ project ships no external alpha yet, the only consumers are in-repo testbeds,
 examples, and tests, all updated in the same work. A short-lived registration
 diagnostic — *"machine spec carries `:schema`; rename to `:data-schema`"* — can
 ease the in-repo migration during implementation, then be removed.
+
+## Migration
+
+Migration is in-repo only and mechanical (option B):
+
+- **Rename the key.** `(:schema spec)` → `(:data-schema spec)` in
+  `data_validation.cljc`, the `machine-meta` round-trip, and every in-repo machine
+  spec, testbed, example, and test that declares a machine `:data` schema. This is
+  a one-token edit per machine spec.
+- **Drive legacy usage loud.** Ship the short-lived `:schema`-present registration
+  diagnostic during the rename so any missed call site surfaces, then remove it.
+  (Whether to ship the diagnostic at all or do a silent atomic in-repo rename is
+  [Open Issue 4](#open-issues).)
+- **No app-side migration.** With no external alpha, there are no downstream
+  consumers; the rename is contained to this repo and lands in the same work.
+
+The redaction bridge and machines-viz changes (gaps 2–3) add new behavior rather
+than migrating existing usage; their sequencing is in the
+[Reference Implementation Plan](#reference-implementation-plan-if-adopted) below.
 
 ## Security And Privacy Considerations
 
@@ -623,7 +661,7 @@ Sequential, because spec/005 is a machines HOT-ZONE file.
 6. **Docs/examples bead.** Update any in-repo machine spec using `:schema` →
    `:data-schema`; refresh the machines guide if it teaches the key.
 
-## Open Questions (for Mike)
+## Open Issues
 
 1. **Naming (the load-bearing one).** Rename `:schema` → `:data-schema`
    (option B, recommended — local clarity + your ruling A) or keep `:schema`
@@ -640,6 +678,23 @@ Sequential, because spec/005 is a machines HOT-ZONE file.
    consumers yet)?
 5. **Scope of the spec edit.** Should the §XState-parity subsection live in
    spec/005 (recommended, beside §Schema validation) or in a machines guide doc?
+
+## Recommendation
+
+Adopt **Option B**: rename `defmachine`'s existing `:schema` key to
+`:data-schema` for the machine's `:data` (its context, the re-frame2 analog of
+XState v5 typed context), and close the remaining gaps.
+
+The rename buys local clarity — the key now names what it validates — and the work
+that follows is the real engineering: close the schema→marks **redaction** bridge
+so `:sensitive?` slots are elided in snapshot egress (gap 2, precise per-slot R1),
+switch machines-viz to **declared-over-inferred** Context shape (gap 3, the
+deferred `rf2-wto1k` option A), and document the XState-v5 parity (gap 4). Validation
+itself already shipped under `rf2-jbbp7`, so this EP corrects the premise that
+machine `:data` is un-schema'd and finishes the documented-but-non-functional
+privacy capability. The final naming call is Mike's (see [Open
+Issues](#open-issues)), because it inverts the "mirrors every other `reg-*` kind"
+symmetry rationale Spec 005 currently uses.
 
 ## Sources Consulted
 

--- a/docs/EP/resource-queries.md
+++ b/docs/EP/resource-queries.md
@@ -1,4 +1,6 @@
-# EP: Resource Queries
+# EP-0003: Resource Queries
+
+Number: EP-0003
 
 Status: proposal
 
@@ -7,6 +9,8 @@ Type: Standards Track
 Date: 2026-06-06
 
 Created: 2026-06-06
+
+Author: re-frame2 maintainers
 
 Target Artifact: `day8/re-frame2-resources`
 
@@ -17,17 +21,21 @@ Target API Surface:
 - First public-beta gate: `reg-mutation`, `clear-mutation`, and mutation
   execution events
 
+Requires:
+
+- [App/Runtime Partition EP](app-db-runtime-partition.md)
+- [Explicit Frame Target Resolution EP](frame-target-resolution.md)
+- [Parametric Subscription Inputs EP](subscription-inputs.md)
+- [Spec 014 - HTTP Requests](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md)
+- [Spec 012 - Routing](https://github.com/day8/re-frame2/blob/main/spec/012-Routing.md)
+- [Spec 005 - State Machines](https://github.com/day8/re-frame2/blob/main/spec/005-StateMachines.md)
+
 Related:
 
 - [Guide 10 - HTTP](../guide/10-http.md)
 - [Guide 19 - Routing](../guide/19-routing.md)
 - [Guide 21 - Runtime model](../guide/21-dynamic-model.md)
 - [Pattern - Remote Data](https://github.com/day8/re-frame2/blob/main/spec/Pattern-RemoteData.md)
-- [Spec 014 - HTTP Requests](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md)
-- [Spec 012 - Routing](https://github.com/day8/re-frame2/blob/main/spec/012-Routing.md)
-- [Spec 005 - State Machines](https://github.com/day8/re-frame2/blob/main/spec/005-StateMachines.md)
-- [App/Runtime Partition EP](app-db-runtime-partition.md)
-- [Explicit Frame Target Resolution EP](frame-target-resolution.md)
 
 Benchmark References:
 
@@ -191,6 +199,26 @@ The initial artifact should not:
 - promise offline persistence, cross-tab broadcast, infinite resources, polling,
   or optimistic rollback in the first slice;
 - hide server-state behavior inside React/Reagent component lifecycle.
+
+## Relationships
+
+This EP depends on three other EPs and should land after them.
+
+- **Depends on the app/runtime partition.** Resource Queries stores its cache in
+  the framework-owned runtime partition (`:rf.runtime/resources`) introduced by
+  the [App/Runtime Partition EP](app-db-runtime-partition.md), so that partition
+  should land — or at least its key vocabulary be fixed — before resources rely
+  on it.
+- **Depends on explicit frame target resolution.** Resource queries are a large
+  frame-aware feature; their public API should harden against the explicit
+  frame-target contract of the [Explicit Frame Target Resolution
+  EP](frame-target-resolution.md), not the ambient `:rf/default` fallback it
+  removes.
+- **Depends on parametric subscription inputs.** Whether resource subscription
+  view-models use static `:<-`, vector-of-query-vectors input functions, or
+  broader app-db reads is determined by the [Parametric Subscription Inputs
+  EP](subscription-inputs.md); that EP should resolve before these helpers lean
+  on parameterized subscription view models.
 
 ## Developer and AI Use Cases
 
@@ -1778,6 +1806,41 @@ mutations.
 The machine remains the semantic workflow. The resource runtime handles cached
 read mechanics.
 
+## Backwards Compatibility
+
+This EP adds a new optional artifact (`day8/re-frame2-resources`); it does not
+change existing core APIs. Apps that do not require it are unaffected, and the
+existing patterns it supersedes — Pattern-RemoteData plus managed HTTP (Spec 014)
+— keep working for apps that have not adopted resources.
+
+Within the pre-alpha posture there are no compatibility shims. The artifact stores
+its cache in the framework-owned runtime partition (`:rf.runtime/resources`); it
+relies on the final partition vocabulary from the [App/Runtime Partition
+EP](app-db-runtime-partition.md) rather than any interim `:rf/runtime` location.
+Resource registration, subscriptions, and events are new surfaces, so there is no
+prior resource API to keep compatible.
+
+## Migration
+
+There is no in-repo resource API to migrate from; migration is adoption.
+
+- **From hand-rolled RemoteData.** Apps currently expressing server state with
+  Pattern-RemoteData plus `:rf.http/managed` move each remote read to a
+  `reg-resource` registration, replacing ad-hoc cache keys, in-flight flags, and
+  staleness bookkeeping with resource identity, status, and tag invalidation.
+- **From `shipclojure/re-frame-query`.** Existing re-frame apps using that library
+  map query keys to resource identity (canonical params), `invalidateQueries` to
+  tag invalidation, and component-level observers to active owners. The
+  [Sources Consulted](#sources-consulted) prior-art mapping is the migration
+  reference; a guide chapter and migration notes are part of the docs bead.
+- **Route and SSR loading.** Component-tree request waterfalls move to route
+  `:resources` and SSR blocking-resource drain, so adoption is per-route rather
+  than all-at-once.
+
+The slice order — read-resource MVP first, mutations at the first public-beta gate
+— is in [Acceptance Criteria And Rollout](#acceptance-criteria-and-rollout) and
+[Bead Structure](#bead-structure) below.
+
 ## Reference Implementation Plan
 
 ### 1. Artifact and Namespaces
@@ -2084,7 +2147,7 @@ Initial conformance fixtures should cover:
 - trace redaction and pruning for params/scopes;
 - redacted tool summaries.
 
-## Alternatives Considered
+## Rejected Ideas
 
 ### A. Pattern Only
 
@@ -2226,7 +2289,7 @@ Where TanStack and alternatives remain ahead:
 The goal is not imitation. The goal is to make server state a first-class
 re-frame2 runtime process.
 
-## Open Decisions
+## Open Issues
 
 1. Should the file and guide title say "resources", "resource queries", or
    "server state"?
@@ -2266,6 +2329,23 @@ re-frame2 runtime process.
 12. How much previous-data support belongs in v1?
     Recommendation: support `:keep-previous?` for ordinary route/list churn;
     keep arbitrary placeholder data deferred.
+
+## Recommendation
+
+Adopt **Option C**: build a first-class optional `day8/re-frame2-resources`
+artifact for declarative server-state, starting with a read-resource MVP and
+gating mutations to the first public-beta slice.
+
+This is the re-frame2 answer to TanStack Query / RTK Query / SWR /
+`shipclojure/re-frame-query`: resource identity, caching, staleness, dedupe, tag
+invalidation, active-owner lifecycle/GC, and route + SSR preload, built on managed
+HTTP (Spec 014) and the framework-owned runtime partition. Pattern-only
+cookbooks, adopting `shipclojure/re-frame-query` wholesale, normalized-cache-first,
+and projection-first were each rejected because none owns re-frame2 frames,
+runtime partitions, route metadata, SSR, Xray visibility, privacy, and
+event-causal traces the way a first-class artifact does. The pre-alpha posture
+favors building the right primitive when the problem is real and recurring; this
+one is.
 
 ## Bead Structure
 

--- a/docs/EP/subscription-inputs.md
+++ b/docs/EP/subscription-inputs.md
@@ -1,4 +1,6 @@
-# EP: Parametric Subscription Inputs
+# EP-0004: Parametric Subscription Inputs
+
+Number: EP-0004
 
 Status: proposal
 
@@ -7,6 +9,8 @@ Type: Standards Track
 Date: 2026-06-08
 
 Created: 2026-06-08
+
+Author: re-frame2 maintainers
 
 Target Artifact: `day8/re-frame2-core`
 
@@ -143,6 +147,23 @@ programmers, Xray, tests, and AI agents.
 - Do not allow ordinary input functions to choose dependencies from app-db.
 - Do not make subscriptions perform fetching or other effects.
 - Do not make every possible parametric edge enumerable at registration time.
+
+## Relationships
+
+This is a Reactive Substrate proposal that other view-model EPs build on:
+
+- **Resolves before resource/route/Hasura subscription view-models.** This EP
+  should be resolved before the [Resource Queries EP](resource-queries.md), the
+  route-model helpers, or Hasura helpers lean on parameterized subscription view
+  models, because it determines whether those helpers use static `:<-`,
+  vector-of-query-vectors input functions, or broader app-db reads. Downstream
+  view-model surfaces should not commit a subscription-input shape until this EP
+  is resolved.
+- **Composes with explicit frame target resolution.** Input query vectors are
+  frame-agnostic data; the runtime resolves them in the frame of the outer
+  subscription. See the [Explicit Frame Target Resolution
+  EP](frame-target-resolution.md) (listed under `Requires`) and the
+  [§Frame resolution](#frame-resolution) section below.
 
 ## Specification
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,11 +242,11 @@ nav:
 
   - EP:
     - EP/README.md
-    - "App/Runtime Partition": EP/app-db-runtime-partition.md
-    - "Explicit Frame Target Resolution": EP/frame-target-resolution.md
-    - "Parametric Subscription Inputs": EP/subscription-inputs.md
-    - "Resource Queries": EP/resource-queries.md
-    - "Machine :data Schema": EP/machine-data-schema.md
+    - "EP-0001 Frame App/Runtime Partitions": EP/app-db-runtime-partition.md
+    - "EP-0002 Explicit Frame Target Resolution": EP/frame-target-resolution.md
+    - "EP-0003 Resource Queries": EP/resource-queries.md
+    - "EP-0004 Parametric Subscription Inputs": EP/subscription-inputs.md
+    - "EP-0005 Machine :data Schema": EP/machine-data-schema.md
 
   - API:
     # Section label IS the API overview page (navigation.indexes, rf2-qgpkm).


### PR DESCRIPTION
Coordinated single-pass formalization of the five EPs under `docs/EP/`, addressing three beads that share the same files.

## Quality gates

- `python scripts/check_doc_slugs.py` — passes (exit 0). Spec links remain full GitHub URLs; all internal EP-to-EP links and the new custom anchors resolve.
- `python -m mkdocs build --strict` — passes (exit 0). No warnings/errors; all five EP pages are in nav and render. The only INFO is a pre-existing, unrelated note about `the-mayor-method.md`.

## Numbering scheme (rf2-dtzhiz)

Stable PEP-style numbers assigned in `Created`-date order (oldest = `EP-0001`); ties within a date broken by dependency order (foundational EPs first), which coincides with the existing index order. Filenames are **not** renamed (keeps mkdocs slugs, cross-links, and `check_doc_slugs` green); the number lives in the `Number:` header field, the H1 title, the README index, and the mkdocs nav.

| EP | Created | File |
|----|---------|------|
| EP-0001 Frame App/Runtime Partitions | 2026-06-06 | `app-db-runtime-partition.md` |
| EP-0002 Explicit Frame Target Resolution | 2026-06-06 | `frame-target-resolution.md` |
| EP-0003 Resource Queries | 2026-06-06 | `resource-queries.md` |
| EP-0004 Parametric Subscription Inputs | 2026-06-08 | `subscription-inputs.md` |
| EP-0005 Machine `:data` Schema | 2026-06-08 | `machine-data-schema.md` |

## Formal-PEP structure (rf2-0ium2h)

Reconciled every EP to the `subscription-inputs.md` template (header metadata block + standard section set) **without changing technical content or decisions**:

- Header metadata normalized to the spaced template style; added `Number:` and `Author:` to every EP; promoted prose `Requires` into dependency-list form.
- Renamed `Alternatives Considered` → `Rejected Ideas` and `Open Decisions` / `Open Questions (for Mike)` → `Open Issues` (EP-0002, EP-0003, EP-0005).
- Added missing standard sections: `Migration` (EP-0001, EP-0002, EP-0003, EP-0005), `Recommendation` (EP-0001, EP-0002, EP-0003, EP-0005), and `Backwards Compatibility` (EP-0003). EP-0004 already had the full shape.
- Reordered the mkdocs nav to EP-number order.

## Relationships into EPs (rf2-2l7kew)

The README `Relationships` dependency prose is removed and relocated into the EPs themselves:

- Each EP gained a `Requires:` header entry and a `## Relationships` section carrying its own dependencies/dependents (partition foundational for resources; frame-target-resolution before frame-aware features; subscription-inputs before resource/route/Hasura sub view-models; machine-data-schema sequences after the partition rename).
- README reduced to a clean index table (EP number + title + status + one-line summary + link), plus updated Conventions describing the numbering + section template. No dependency prose remains in the README.

Closes rf2-dtzhiz, rf2-0ium2h, rf2-2l7kew.
