### PR TITLE
docs(EP): terse README + minimal front-matter + EP-0004 final status (rf2-ivxwlg + rf2-lm6ncs + rf2-itujk9)

### DIFF
--- a/docs/EP/README.md
+++ b/docs/EP/README.md
@@ -1,25 +1,15 @@
 # Enhancement Proposals (EPs)
 
-Design proposals for re-frame2. Each EP states a **problem**, the proposed **re-frame2 solution**, the **options considered**, concrete **examples**, and an **implementation / bead plan**.
+Design proposals for re-frame2.
 
-EPs are *proposals*, not normative specification. The normative artefact remains [`spec/`](https://github.com/day8/re-frame2/tree/main/spec). The lifecycle is:
-
-> exploratory findings (local `ai/findings/`) → **EP** (synthesised proposal, here) → accepted EP graduates into `spec/` + implementation beads.
-
-## Conventions
-
-- One EP per file, **flat** in this directory, kebab-case named, each self-contained.
-- Each EP carries a stable PEP-style **number** (`EP-0001`, `EP-0002`, …) assigned in `Created`-date order (oldest = `EP-0001`). The number lives in the doc's header metadata (`Number:`), its H1 title, and the index below. Numbers are stable and never reused; the descriptive filename is kept (the number does not rename the file).
-- Header metadata block: `Number`, `Status` (`proposal` / `accepted` / `superseded`), `Type`, `Date`, `Created`, `Author`, `Target Artifact`, and `Requires` (dependency EPs/specs). Inter-EP dependencies live **in each EP** — its `Requires:` header and a `Relationships` section — not here.
-- Standard sections, modelled on [`subscription-inputs.md`](subscription-inputs.md): Abstract, Motivation, Goals/Non-Goals, Relationships, Specification, Rationale / Runtime Semantics, Backwards Compatibility, Migration, Rejected Ideas, Open Issues, Recommendation.
-- Add new EPs to the table below (next free number) and to the `EP` section of [`mkdocs.yml`](https://github.com/day8/re-frame2/blob/main/mkdocs.yml).
+EPs are *proposals*, not normative specification. The normative artefact remains [`spec/`](https://github.com/day8/re-frame2/tree/main/spec). An EP graduates into `spec/` + implementation beads once accepted. Each EP carries a stable PEP-style number (`EP-0001`, …), a `Status:` line, and standard sections (Abstract, Motivation, Relationships, Specification, …); dependencies live in each EP's `Relationships` section.
 
 ## Index
 
-| EP | Title | Status | Summary |
-|----|-------|--------|---------|
+| EP       | Title | Status | Summary |
+|----------|-------|--------|---------|
 | [EP-0001](app-db-runtime-partition.md) | Frame App/Runtime Partitions | proposal | A frame owns two durable partitions — user-owned **app-db** (`:db`) and framework-owned **runtime-db** (`:rf.db/runtime`) — committed coherently by one cascade, removing the footgun where a fresh `:db` return clobbers runtime state. |
 | [EP-0002](frame-target-resolution.md) | Explicit Frame Target Resolution | proposal | Remove the ambient `:rf/default` fallback; frame-scoped operations resolve their target from explicit frame context, and missing context fails instead of touching the wrong frame. |
 | [EP-0003](resource-queries.md) | Resource Queries | proposal | An optional `day8/re-frame2-resources` artefact for declarative server-state — the re-frame2 answer to TanStack Query / RTK Query / SWR — with resource identity, caching, invalidation, lifecycle/GC, and route + SSR preload. |
-| [EP-0004](subscription-inputs.md) | Parametric Subscription Inputs | proposal | Restore v1's two-function `reg-sub` shape via input functions that return a vector of query vectors, keeping `:<-` as static-input sugar and dependencies pure, inspectable, JVM-runnable, and Xray-visible. |
+| [EP-0004](subscription-inputs.md) | Parametric Subscription Inputs | final | Restore v1's two-function `reg-sub` shape via input functions that return a vector of query vectors, keeping `:<-` as static-input sugar and dependencies pure, inspectable, JVM-runnable, and Xray-visible. |
 | [EP-0005](machine-data-schema.md) | Machine `:data` Schema | proposal | Rename `defmachine`'s `:schema` key to `:data-schema` for the machine's `:data` context, close the schema→marks redaction bridge, switch machines-viz to declared-over-inferred Context shape, and document XState v5 parity. |

--- a/docs/EP/app-db-runtime-partition.md
+++ b/docs/EP/app-db-runtime-partition.md
@@ -1,43 +1,6 @@
 # EP-0001: Frame App/Runtime Partitions
 
-Number: EP-0001
-
 Status: proposal
-
-Type: Standards Track
-
-Date: 2026-06-06
-
-Created: 2026-06-06
-
-Author: re-frame2 maintainers
-
-Topic: frame state ownership
-
-Target Artifact: `day8/re-frame2-core`
-
-Impacts: frames, events, subscriptions, machines, routing, SSR, schemas, Xray, pair tools, docs, skills
-
-Requires:
-
-- explicit frame identity, coherent frame transitions
-- [Spec 002 - Frames](https://github.com/day8/re-frame2/blob/main/spec/002-Frames.md)
-- [Spec 005 - State Machines](https://github.com/day8/re-frame2/blob/main/spec/005-StateMachines.md)
-- [Spec 006 - Reactive Substrate](https://github.com/day8/re-frame2/blob/main/spec/006-ReactiveSubstrate.md)
-- [Spec 009 - Instrumentation](https://github.com/day8/re-frame2/blob/main/spec/009-Instrumentation.md)
-- [Spec 011 - SSR](https://github.com/day8/re-frame2/blob/main/spec/011-SSR.md)
-- [Spec 012 - Routing](https://github.com/day8/re-frame2/blob/main/spec/012-Routing.md)
-- [Runtime Architecture](https://github.com/day8/re-frame2/blob/main/spec/Runtime-Architecture.md)
-- [Conventions](https://github.com/day8/re-frame2/blob/main/spec/Conventions.md)
-
-Related:
-
-- [Guide 02 - app-db](../guide/02-app-db.md)
-- [Guide 04 - Events and the cascade](../guide/04-events-and-the-cascade.md)
-- [Guide 18 - Frames](../guide/18-frames.md)
-- [Guide 21 - Runtime model](../guide/21-dynamic-model.md)
-- [Explicit Frame Target Resolution EP](frame-target-resolution.md)
-- [Resource Queries EP](resource-queries.md)
 
 ## Abstract
 

--- a/docs/EP/frame-target-resolution.md
+++ b/docs/EP/frame-target-resolution.md
@@ -1,48 +1,6 @@
 # EP-0002: Explicit Frame Target Resolution
 
-Number: EP-0002
-
 Status: proposal
-
-Type: Standards Track
-
-Date: 2026-06-06
-
-Created: 2026-06-06
-
-Author: re-frame2 maintainers
-
-Target Artifact: `day8/re-frame2-core`
-
-Target API Surface:
-
-- frame resolution
-- dispatch and subscribe
-- root frame providers
-- framework effects
-- SSR and hydration
-- Xray, Story, pair tooling, and AI tool accessors
-
-Requires:
-
-- [Spec 002 - Frames](https://github.com/day8/re-frame2/blob/main/spec/002-Frames.md)
-- [Spec 004 - Views](https://github.com/day8/re-frame2/blob/main/spec/004-Views.md)
-- [Spec 006 - Reactive Substrate](https://github.com/day8/re-frame2/blob/main/spec/006-ReactiveSubstrate.md)
-- [Spec 009 - Instrumentation](https://github.com/day8/re-frame2/blob/main/spec/009-Instrumentation.md)
-- [Spec 011 - SSR](https://github.com/day8/re-frame2/blob/main/spec/011-SSR.md)
-- [Spec 014 - HTTP Requests](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md)
-- [Runtime Architecture](https://github.com/day8/re-frame2/blob/main/spec/Runtime-Architecture.md)
-- [Tool Pair](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md)
-- [Xray API](../xray/api/index.md)
-- [App/Runtime Partition EP](app-db-runtime-partition.md)
-
-Benchmark References:
-
-- TanStack Query `QueryClientProvider`
-- React Redux `Provider`
-- Apollo Client `ApolloProvider`
-- Relay `RelayEnvironmentProvider`
-- re-frame2 frames, SSR request frames, Xray, Story, and pair tools
 
 ## Abstract
 

--- a/docs/EP/machine-data-schema.md
+++ b/docs/EP/machine-data-schema.md
@@ -1,43 +1,6 @@
 # EP-0005: Machine `:data` Schema (`defmachine` `:data-schema`)
 
-Number: EP-0005
-
 Status: proposal
-
-Type: Standards Track
-
-Date: 2026-06-08
-
-Created: 2026-06-08
-
-Author: re-frame2 maintainers
-
-Target Artifact: `day8/re-frame2-machines`
-
-Target API Surface:
-
-- the `defmachine` / `reg-machine` transition-table grammar (the `:data` /
-  `:schema` slot)
-- machine `:data` validation at the `:where :machine-data` boundary
-- machine snapshot redaction / wire elision (Xray, pair-MCP, epoch egress)
-- machines-viz declared-vs-inferred Context-shape panel
-
-Requires:
-
-- [Spec 005 - State Machines](https://github.com/day8/re-frame2/blob/main/spec/005-StateMachines.md)
-- [Spec 009 - Instrumentation](https://github.com/day8/re-frame2/blob/main/spec/009-Instrumentation.md)
-- [Spec 010 - Schemas](https://github.com/day8/re-frame2/blob/main/spec/010-Schemas.md)
-- [Spec 015 - Data Classification](https://github.com/day8/re-frame2/blob/main/spec/015-Data-Classification.md)
-- [Spec-Schemas](https://github.com/day8/re-frame2/blob/main/spec/Spec-Schemas.md)
-- [Conventions](https://github.com/day8/re-frame2/blob/main/spec/Conventions.md)
-- [App/Runtime Partition EP](app-db-runtime-partition.md)
-
-Benchmark References:
-
-- XState v5 typed context (`setup({ types: { context } })`, input/context
-  schemas) and Stately's rendered "Context:" chart header
-- re-frame2's existing per-registration `:schema` key on `reg-event-*`,
-  `reg-sub`, `reg-fx`, `reg-cofx`, `reg-app-schema`
 
 ## Abstract
 

--- a/docs/EP/resource-queries.md
+++ b/docs/EP/resource-queries.md
@@ -1,49 +1,6 @@
 # EP-0003: Resource Queries
 
-Number: EP-0003
-
 Status: proposal
-
-Type: Standards Track
-
-Date: 2026-06-06
-
-Created: 2026-06-06
-
-Author: re-frame2 maintainers
-
-Target Artifact: `day8/re-frame2-resources`
-
-Target API Surface:
-
-- MVP: `reg-resource`, `clear-resource`, resource subscriptions, resource
-  events, and resource introspection
-- First public-beta gate: `reg-mutation`, `clear-mutation`, and mutation
-  execution events
-
-Requires:
-
-- [App/Runtime Partition EP](app-db-runtime-partition.md)
-- [Explicit Frame Target Resolution EP](frame-target-resolution.md)
-- [Parametric Subscription Inputs EP](subscription-inputs.md)
-- [Spec 014 - HTTP Requests](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md)
-- [Spec 012 - Routing](https://github.com/day8/re-frame2/blob/main/spec/012-Routing.md)
-- [Spec 005 - State Machines](https://github.com/day8/re-frame2/blob/main/spec/005-StateMachines.md)
-
-Related:
-
-- [Guide 10 - HTTP](../guide/10-http.md)
-- [Guide 19 - Routing](../guide/19-routing.md)
-- [Guide 21 - Runtime model](../guide/21-dynamic-model.md)
-- [Pattern - Remote Data](https://github.com/day8/re-frame2/blob/main/spec/Pattern-RemoteData.md)
-
-Benchmark References:
-
-- TanStack Query
-- RTK Query
-- SWR
-- Apollo Client and Relay
-- `shipclojure/re-frame-query`
 
 ## Abstract
 

--- a/docs/EP/subscription-inputs.md
+++ b/docs/EP/subscription-inputs.md
@@ -1,38 +1,6 @@
 # EP-0004: Parametric Subscription Inputs
 
-Number: EP-0004
-
-Status: proposal
-
-Type: Standards Track
-
-Date: 2026-06-08
-
-Created: 2026-06-08
-
-Author: re-frame2 maintainers
-
-Target Artifact: `day8/re-frame2-core`
-
-Target API Surface:
-
-- `reg-sub`
-- `subscribe`
-- `subscribe-once`
-- `compute-sub`
-- `sub-topology`
-- subscription cache entries
-- Xray subscription topology and live-sub inspection
-- migration guidance from re-frame v1
-
-Requires:
-
-- [Spec 006 - Reactive Substrate](https://github.com/day8/re-frame2/blob/main/spec/006-ReactiveSubstrate.md)
-- [Spec 008 - Testing](https://github.com/day8/re-frame2/blob/main/spec/008-Testing.md)
-- [Spec 009 - Instrumentation](https://github.com/day8/re-frame2/blob/main/spec/009-Instrumentation.md)
-- [Spec API](https://github.com/day8/re-frame2/blob/main/spec/API.md)
-- [Conventions](https://github.com/day8/re-frame2/blob/main/spec/Conventions.md)
-- [Explicit Frame Target Resolution EP](frame-target-resolution.md)
+Status: final
 
 ## Abstract
 


### PR DESCRIPTION
Coordinated single pass over `docs/EP/` for three beads (authored in sequence; rf2-ivxwlg's "remove Conventions" overrides the other two's "document conventions").

## What changed

**rf2-lm6ncs — trim EP front-matter (all 5 EPs)**
Stripped the heavy formal-PEP header down to the H1 title (carrying its `EP-000N` number) plus a single `Status:` line. Dropped: Type, Date, Created, Author, Target Artifact, Target API Surface, Impacts, Topic, Requires, Related, Benchmark References. Nothing lost — dependency info already lives in each EP's body `Relationships` section, and benchmark / API-surface detail is already covered in the body (Motivation / Specification / Rationale / Benchmark Standard sections), so no folding was needed.

**rf2-itujk9 — EP-0004 status flip**
`subscription-inputs.md` (EP-0004) is fully landed (spec/core/skill/docs/tooling merged + final sweep passed), so `Status:` is now `final`. Introduced the minimal PEP-style lifecycle `proposal -> accepted -> final`; EP-0004 is `final`, and EP-0001/0002/0003/0005 stay `proposal` (not yet actioned).

**rf2-ivxwlg — terse README**
`docs/EP/README.md`: first paragraph is exactly `Design proposals for re-frame2.`; removed the `Conventions` section entirely (self-evident — this supersedes the "document conventions/lifecycle" instruction in the other two beads); kept a tight index table (number + title + status + summary + link) with the first column widened; trimmed verbose prose.

## Quality gates
- `mkdocs build --strict` — pass (exit 0, no warnings)
- `python scripts/check_doc_slugs.py` — pass (exit 0)
