### PR TITLE
fix(machines-viz): post-ELK transpose event-node spacing (rf2-vb359s)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -705,9 +705,14 @@ pure ns `chart.post-elk`:
    children swap their within-region x/y (the intra-region flow that ran
    vertically under root `DOWN` now runs **horizontally** — the Stately
    intra-region axis), and the region containers re-stack into a single
-   **vertical column** (`region-stack-gap` between bands). Region-touching
-   edge routes are cleared so they re-route via the renderer's bezier
-   fallback through the transposed handles.
+   **vertical column** (`region-stack-gap` between bands). After the swap the
+   flow ranks are **re-packed** along the new x-axis (`post-elk/respace-flow-
+   ranks`) by each rank's actual WIDTH + `intra-region-flow-gap` — the bare
+   swap inherits the flow pitch ELK budgeted for node HEIGHTS (state 58 / chip
+   34), too tight once boxes occupy their WIDTHS along x (state 152 / chip
+   96), which buried the intra-region event-node chips into the state boxes
+   (rf2-vb359s). Region-touching edge routes are cleared so they re-route via
+   the renderer's bezier fallback through the transposed handles.
 
 **OPT-IN — not auto-applied (the redo lock).** Both levers fire ONLY when a
 machine OPTS IN via `:direction :auto` (`chart.post-elk/adaptive?`); with
@@ -720,10 +725,13 @@ redo keeps every existing non-opted machine pixel-identical (verified: the
 path vs `main`). The selective-beside-the-source event-node placement the
 research also floated (the flat-branchy event-node rank cost) remains a
 SEPARATE, still-out-of-scope item — the direction heuristic recovers the
-flat-aspect win without it. **Known rough edge (held for sign-off):** under
-the parallel transpose, intra-region event-node chips can overlap state
-boxes after the coordinate swap + route-clear; this is why the feature is
-opt-in and the PR is held for a visual ruling, not auto-merged.
+flat-aspect win without it. **Resolved rough edge (rf2-vb359s):** the
+parallel transpose previously left intra-region event-node chips overlapping
+state boxes after the bare coordinate swap (the swap inherited ELK's
+height-sized flow pitch, too tight for the wider boxes along the new x-axis);
+the transpose now re-packs the flow ranks by their actual widths
+(`respace-flow-ranks` + `intra-region-flow-gap`), so the chips clear the
+state boxes. The feature stays opt-in behind `:direction :auto`.
 
 ### 4.4 G3 — fired-edge id consistency ✅ CLOSED
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc
@@ -331,25 +331,92 @@
   node` paints — this is the spacing between them)."
   40)
 
+(def intra-region-flow-gap
+  "rf2-vb359s — horizontal gap (px) between consecutive flow RANKS inside a
+  transposed region (a state box and the next state box, or a state box and
+  the event-node chip between them). After the transpose the within-region
+  flow runs along the NEW x-axis, but a bare coordinate swap inherits the
+  flow spacing ELK budgeted for node HEIGHTS (state 58 / chip 34 + the 50px
+  between-layer gap ≈ 108px rank pitch), which is far too tight once the
+  boxes occupy their WIDTHS along x (state 152 / chip 96) — adjacent ranks
+  overlap, and the intra-region event-node chips bury into the state boxes
+  (the bug). So the transpose re-packs the ranks left-to-right by each rank's
+  ACTUAL width plus this gap. Mirrors ELK's `nodeNodeBetweenLayers` (50) flow
+  pitch so a transposed region reads with the same rank rhythm as a
+  non-transposed column."
+  50)
+
+(defn- box-width
+  "The layout width (px) of a transposed child box, floored to the state-node
+  minimum so a child that lost its measured `:width` still reserves a sane
+  rank pitch. Pure."
+  [pos]
+  (or (:width pos) projection/state-node-min-width))
+
+(defn- respace-flow-ranks
+  "rf2-vb359s — after the coordinate swap, re-pack the transposed children
+  along the NEW x-axis (the within-region flow axis) so adjacent flow RANKS
+  clear each other by their actual widths + `intra-region-flow-gap`. Pure:
+  transposed `{child-id pos}` submap → the same submap with x re-spaced.
+
+  A bare swap inherits the flow spacing ELK sized for node HEIGHTS, which is
+  too tight once boxes occupy their WIDTHS along x — so intra-region event-
+  node chips overlap the state boxes (the bug). We group children into ranks
+  by their swapped x (the original flow layer, incl. the +0.5 event-node
+  inter-ranks), order the ranks left-to-right, and re-base each rank's x to
+  the running cursor = previous rank's right edge + gap. The y-axis (the
+  cross-flow spread of within-rank siblings) is left UNTOUCHED — only the
+  flow pitch is corrected."
+  [transposed]
+  (if (empty? transposed)
+    transposed
+    (let [start-x   (reduce min (map :x (vals transposed)))
+          ;; group child-ids by their swapped x (the flow rank), ordered
+          ;; ascending so the re-pack preserves the transposed flow order.
+          ranks     (->> transposed
+                         (group-by (fn [[_ pos]] (:x pos)))
+                         (sort-by key))
+          ;; fold the ranks left-to-right, advancing the x-cursor by each
+          ;; rank's widest box + the flow gap.
+          [_ x->new]
+          (reduce
+            (fn [[cursor acc] [_ entries]]
+              (let [rank-w (reduce max 0 (map (fn [[_ pos]] (box-width pos)) entries))
+                    acc'   (reduce (fn [m [id _]] (assoc m id cursor)) acc entries)]
+                [(+ cursor rank-w intra-region-flow-gap) acc']))
+            [start-x {}]
+            ranks)]
+      (reduce-kv (fn [m id pos]
+                   (assoc m id (assoc pos :x (get x->new id (:x pos)))))
+                 {}
+                 transposed))))
+
 (defn transpose-region-interior
   "rf2-lamdfl — transpose the WITHIN-region layout of one region so its
   intra-region flow runs HORIZONTALLY (Stately) instead of vertically (root
   DOWN). Pure: takes the region's `{child-id position}` submap (positions are
   parent-relative) and returns the transposed submap.
 
-  The transpose swaps each child's local x↔y AND its width↔height-driven
-  extent: a child at local `{:x a :y b :width w :height h}` moves to
-  `{:x b :y a :width w :height h}` — the POSITION axes swap (so a vertical
-  stack becomes a horizontal row) while each node keeps its own box (a state
-  box is not rotated, only repositioned). We then re-base to the title-strip
-  inset so children still clear the region header, preserving the
+  The transpose swaps each child's local x↔y: a child at local
+  `{:x a :y b :width w :height h}` moves to `{:x b :y a :width w :height h}` —
+  the POSITION axes swap (so a vertical stack becomes a horizontal row) while
+  each node keeps its own box (a state box is not rotated, only repositioned).
+
+  rf2-vb359s — a BARE swap leaves the flow ranks spaced by the heights ELK
+  budgeted (state 58 / chip 34 + the 50px between-layer gap), which is far too
+  tight once the boxes occupy their WIDTHS along x (state 152 / chip 96), so
+  intra-region event-node chips overlapped the state boxes. After the swap we
+  therefore RE-PACK the ranks along the new x-axis (`respace-flow-ranks`) by
+  each rank's actual width + `intra-region-flow-gap`. We then re-base to the
+  title-strip inset so children still clear the region header, preserving the
   `container-elk-padding` reservation."
   [region-children]
-  (let [transposed (reduce-kv
-                      (fn [m id {:keys [x y] :as pos}]
-                        (assoc m id (assoc pos :x y :y x)))
-                      {}
-                      region-children)
+  (let [transposed (->> (reduce-kv
+                          (fn [m id {:keys [x y] :as pos}]
+                            (assoc m id (assoc pos :x y :y x)))
+                          {}
+                          region-children)
+                        respace-flow-ranks)
         ;; re-base so the transposed cluster's top-left returns to the
         ;; original interior inset (the smallest original local x/y), keeping
         ;; the header-strip clearance the padding reserved.

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/post_elk_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/post_elk_cljs_test.cljc
@@ -301,6 +301,78 @@
         (is (apply = ys) "transposed children share a y (horizontal row)")
         (is (not (apply = xs)) "transposed children spread on x")))))
 
+(defn- x-overlap?
+  "Do two boxes `{:x :width}` overlap along the x-axis (open intervals)? Pure."
+  [a b]
+  (and (< (:x a) (+ (:x b) (:width b)))
+       (< (:x b) (+ (:x a) (:width a)))))
+
+(deftest transpose-event-chips-clear-state-boxes
+  ;; rf2-vb359s — after the transpose, intra-region event-node chips must NOT
+  ;; overlap the state boxes. A bare coordinate swap inherits the flow spacing
+  ;; ELK sized for node HEIGHTS (state 58 / chip 34), far too tight once boxes
+  ;; occupy their WIDTHS along the new x-axis (state 152 / chip 96), so the
+  ;; chips buried into the state boxes. The re-pack must space the ranks by
+  ;; their actual widths.
+  (let [parsed (layout/project-definition parallel-machine)
+        desc   (post-elk/region-descendant-ids parsed)
+        audio-rid (layout/region-node-id :audio)
+        video-rid (layout/region-node-id :video)
+        ;; an ELK-shaped column inside each region: states at REALISTIC widths
+        ;; (152×58) stacked vertically with an event chip (96×34) between
+        ;; consecutive states (the +0.5 inter-rank events-as-nodes shape). The
+        ;; vertical pitch (108px) is sized for the heights the bug inherits.
+        state-ids  (fn [rid] (->> (get desc rid)
+                                  (remove #(str/starts-with? % "event__"))
+                                  sort))
+        event-ids  (fn [rid] (->> (get desc rid)
+                                  (filter #(str/starts-with? % "event__"))
+                                  sort))
+        region-cols
+        (fn [rid x0]
+          (let [ss (state-ids rid)
+                es (event-ids rid)
+                ;; states on integer ranks 0,1,…; events on the +0.5 ranks
+                ;; between them — exactly the column ELK produces for a region.
+                state-pos (into {} (map-indexed
+                                     (fn [i id] [id {:x (+ x0 20) :y (* 108 i)
+                                                     :width 152 :height 58}])
+                                     ss))
+                event-pos (into {} (map-indexed
+                                     (fn [i id] [id {:x (+ x0 48) :y (+ 54 (* 108 i))
+                                                     :width 96 :height 34}])
+                                     es))]
+            (merge state-pos event-pos)))
+        positions (merge
+                    {audio-rid {:x 0   :y 0 :width 200 :height 500}
+                     video-rid {:x 400 :y 0 :width 200 :height 500}}
+                    (region-cols audio-rid 0)
+                    (region-cols video-rid 400))
+        stub {:positions positions :edge-points {} :edge-labels {}}
+        out  (post-elk/transpose-parallel-regions stub parsed)
+        np   (:positions out)
+        check-region
+        (fn [rid]
+          (let [s-boxes (map #(get np %) (state-ids rid))
+                e-boxes (map #(get np %) (event-ids rid))]
+            (doseq [eb e-boxes
+                    sb s-boxes]
+              (is (not (x-overlap? eb sb))
+                  (str "event chip " eb " overlaps state box " sb
+                       " in region " rid " after transpose")))))]
+    (testing "audio region: no event chip overlaps a state box on the flow axis"
+      (check-region audio-rid))
+    (testing "video region: no event chip overlaps a state box on the flow axis"
+      (check-region video-rid))
+
+    (testing "the re-packed ranks read left-to-right with positive flow pitch"
+      ;; the transposed audio children must occupy DISTINCT x ranks (not all
+      ;; piled on one x), with each rank cleared of the previous.
+      (let [audio-children (map #(get np %) (get desc audio-rid))
+            xs (sort (distinct (map :x audio-children)))]
+        (is (> (count xs) 1) "children spread across multiple flow ranks")
+        (is (apply < xs) "ranks are strictly increasing on x")))))
+
 (deftest transpose-clears-region-edge-routes
   (let [parsed (layout/project-definition parallel-machine)
         ;; seed an ELK route on an intra-region edge, then assert the


### PR DESCRIPTION
Follow-up from the post-ELK opt-in redo (rf2-lamdfl / rf2-gnrkke, #3458). When `:direction :auto` is opted in, the parallel-region transpose structurally worked but left intra-region **event-node chips overlapping state boxes**.

## Root cause

`transpose-region-interior` did a bare coordinate swap (`{:x a :y b}` -> `{:x b :y a}`), keeping each box's width/height. ELK lays a region out vertically (root `DOWN`), spacing nodes along the y-axis by their **heights** (state 58 / chip 34) + the 50px between-layer gap (~108px rank pitch). After the swap those y-deltas became x-deltas, but the boxes now occupy their **widths** along x (state 152 / chip 96) — far wider than the inherited pitch — so adjacent ranks (and especially the event chips between states) overlapped the state boxes.

## Fix

After the swap, re-pack the flow ranks left-to-right along the new x-axis (`respace-flow-ranks`): group children by swapped-x (the flow rank, including the +0.5 event-node inter-ranks), order ascending, and re-base each rank's x to the running cursor = previous rank's right edge + `intra-region-flow-gap` (50, mirroring ELK's `nodeNodeBetweenLayers`). The y-axis (cross-flow sibling spread) is untouched — only the flow pitch is corrected.

## Before / after

- **Before:** transposed event chip at x ≈ old-y (~54px past the state's x) — overlaps the 152px-wide state box behind it.
- **After:** ranks spaced by actual widths + 50px gap — state(152) | gap | chip(96) | gap | state(152) … strictly increasing x, no overlap. New regression test `transpose-event-chips-clear-state-boxes` pins this with realistic ELK-shaped column input (states 152×58, chips 96×34 on +0.5 inter-ranks) and asserts zero x-overlap between any chip and any state box in each region.

Default `:tb` path stays byte-identical: the fix is reached only via `apply-post-elk` on the opt-in `:direction :auto` path; the `adaptive?` gate, `resolve-direction`, and `chart.cljs` are unchanged.

`tools/machines-viz/spec/001-Topology-Parity.md` §4.3.2 updated (the "known rough edge" note now records the fix).

## Quality gates

- machines-viz `clojure -M:test` — **456 tests / 1540 assertions, 0 failures** (+1 deftest / +10 assertions for the regression test)
- xray `clojure -M:test` — **1102 tests / 4579 assertions, 0 failures**
- `npm run test:cljs` — **5941 tests / 21081 assertions, 0 failures**
- `npm run test:xray-feature-gate` — **16/16 scenarios, 0 failures**

Closes rf2-vb359s.