### PR TITLE
docs(spec): fix :dispatch-later key :dispatch->:event in API.md + migration README (rf2-gswl7r)

### DIFF
--- a/docs/api/03-effects.md
+++ b/docs/api/03-effects.md
@@ -24,7 +24,7 @@ Anything in `:fx` is a `[fx-id args]` pair. The runtime looks up `fx-id` in the 
 | `[fx-id args]` | Args | Status | Spec | Intuition |
 |---|---|---|---|---|
 | `[:dispatch event-vec]` | event vector | v1 | 002 | "Schedule this event on the same queue." Async — runs after the current cascade completes. |
-| `[:dispatch-later {:ms ms :dispatch event-vec}]` | options map | v1 | 002 | "Schedule this event after N ms." |
+| `[:dispatch-later {:ms ms :event event-vec}]` | options map | v1 | 002 | "Schedule this event after N ms." |
 | `[:rf.http/managed args-map]` | per `:rf.fx/managed-args` | v1 (optional) | 014 | The canonical managed-HTTP fx. See [07 — HTTP](07-http.md). |
 | `[:rf.nav/push-url url-string]` | URL string | v1 | 012 | Navigate. See [06 — Routing](06-routing.md). |
 | `[:raise event-vec]` | event vector | v1 | 005 | **Machine-only.** Inside a machine action's `:fx`, routes the event back into the same machine atomically and pre-commit. Unbound outside machine actions. |

--- a/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
@@ -17,7 +17,7 @@
        handler body (the rf2-yf97 case).
     3. `:fx [[:dispatch ...]]` from a `reg-event-fx` handler (the
        documented workaround).
-    4. `:fx [[:dispatch-later {:ms 0 :dispatch ...}]]` and the
+    4. `:fx [[:dispatch-later {:ms 0 :event ...}]]` and the
        `(:dispatch (rf/frame-handle))` capture-at-creation affordance.
 
   Per rf2-l5q3 the fix routes through `process-event!`: the drain

--- a/migration/from-re-frame-v1/README.md
+++ b/migration/from-re-frame-v1/README.md
@@ -352,7 +352,7 @@ Why: per [Spec-Schemas §:rf/effect-map](../../spec/Spec-Schemas.md#rfeffect-map
              :fx [[:dispatch [:bar]]]}))
 
 (rf/reg-event-fx :baz
-  (fn [_ _] {:fx [[:dispatch-later {:ms 100 :dispatch [:tick]}]]}))
+  (fn [_ _] {:fx [[:dispatch-later {:ms 100 :event [:tick]}]]}))
 
 (rf/reg-event-fx :many
   (fn [_ _] {:fx [[:dispatch [:a]] [:dispatch [:b]] [:dispatch [:c]]]}))
@@ -370,6 +370,7 @@ Why: per [Spec-Schemas §:rf/effect-map](../../spec/Spec-Schemas.md#rfeffect-map
 3. Rewriting:
    - Single value (`:dispatch [:foo]`, `:http {:url ...}`, or a custom `:datadog/log {...}`): wrap as `[[:key value]]` inside `:fx`.
    - Vector of values (`:dispatch-n [[:a] [:b]]`, `:dispatch-later [{...} {...}]`): expand to `:fx [[:key v1] [:key v2] ...]`.
+   - **`:dispatch-later` map key rename** — v1's `:dispatch-later` map used `:dispatch` for the event-to-dispatch (`{:ms n :dispatch [:ev]}`); the v2 fx reads **`:event`** (`{:ms n :event [:ev]}`). Rename the key as you expand each map — `:dispatch-later [{:ms 100 :dispatch [:tick]}]` → `:fx [[:dispatch-later {:ms 100 :event [:tick]}]]`. A left-behind `:dispatch` key compiles and runs but the fx silently ignores it and the deferred event never fires.
 4. If the effect map already has a `:fx`, concat: `:fx (into existing-fx new-fx)`.
 5. Remove the rewritten top-level keys.
 
@@ -583,7 +584,7 @@ Treat this as a stopgap, not the destination: carrying `:rf/runtime` forward acr
 
 **Type A** (mechanical).
 
-re-frame v1 supported a `^:flush-dom` metadata on dispatched event vectors that forced a DOM repaint between handlers — used for the "show modal, then run a synchronous block" pattern. re-frame2 doesn't carry this metadata. The modern equivalent inside an effect map is `:dispatch-later {:ms 0 :dispatch <event-vec>}`, which schedules through the host clock primitive (via `re-frame.interop`) and yields one render tick before the next handler runs.
+re-frame v1 supported a `^:flush-dom` metadata on dispatched event vectors that forced a DOM repaint between handlers — used for the "show modal, then run a synchronous block" pattern. re-frame2 doesn't carry this metadata. The modern equivalent inside an effect map is `:dispatch-later {:ms 0 :event <event-vec>}`, which schedules through the host clock primitive (via `re-frame.interop`) and yields one render tick before the next handler runs.
 
 The rule has **two sub-cases** depending on where the `^:flush-dom` form appears: inside a `reg-event-fx` handler's effect map (M-16a) or at the top level as a direct `dispatch` call (M-16b). The mechanical rewrite for (a) compiles and runs unchanged; (b) compiles AND superficially looks like the (a) rewrite, but **throws at runtime** because `rf/dispatch-later` is not a function in v2. (b) needs a different rewrite.
 
@@ -603,7 +604,7 @@ Wrap the dispatched event in a `:dispatch-later` fx with `{:ms 0}` inside the ef
  :db        (assoc db :processing-X true)}
 
 ;; re-frame2
-{:fx [[:dispatch-later {:ms 0 :dispatch [:do-work-process-x]}]]
+{:fx [[:dispatch-later {:ms 0 :event [:do-work-process-x]}]]
  :db (assoc db :processing-X true)}
 ```
 
@@ -618,7 +619,7 @@ v1 also allowed `^:flush-dom` on a top-level `dispatch` call — typically in ap
 (rf/dispatch ^:flush-dom [:bootstrap])
 ```
 
-The mechanical M-16a rewrite (`{:fx [[:dispatch-later {:ms 0 :dispatch [:bootstrap]}]]}`) does NOT apply at the top level — effect maps only exist inside a `reg-event-fx` handler. A naïve port to `(rf/dispatch-later {:ms 0 :dispatch [:bootstrap]})` also fails: **`rf/dispatch-later` is NOT a function in re-frame2** — it exists only as an fx-id consumed by the `:fx` runner. The form compiles (the symbol resolves; CLJS doesn't arity-check at compile time) but throws at runtime as the `dispatch-later` symbol resolves to `nil` or raises an arity error depending on host.
+The mechanical M-16a rewrite (`{:fx [[:dispatch-later {:ms 0 :event [:bootstrap]}]]}`) does NOT apply at the top level — effect maps only exist inside a `reg-event-fx` handler. A naïve port to `(rf/dispatch-later {:ms 0 :event [:bootstrap]})` also fails: **`rf/dispatch-later` is NOT a function in re-frame2** — it exists only as an fx-id consumed by the `:fx` runner. The form compiles (the symbol resolves; CLJS doesn't arity-check at compile time) but throws at runtime as the `dispatch-later` symbol resolves to `nil` or raises an arity error depending on host.
 
 **Pick one of two rewrites depending on intent.**
 
@@ -637,7 +638,7 @@ re-frame2's run-to-completion drain (per [M-3](#m-3-dispatch-ordering--events-di
 ;; re-frame2 (ii) — wrap in a one-shot trampoline
 (rf/reg-event-fx :rf/dispatch-later-once
   (fn [_ [_ ev]]
-    {:fx [[:dispatch-later {:ms 0 :dispatch ev}]]}))
+    {:fx [[:dispatch-later {:ms 0 :event ev}]]}))
 
 ;; at the call site
 (rf/dispatch [:rf/dispatch-later-once [:bootstrap]])

--- a/spec/API.md
+++ b/spec/API.md
@@ -452,7 +452,7 @@ Standard `:fx` entries:
 | `[fx-id args]` | Args | Status | Spec | Notes |
 |---|---|---|---|---|
 | `[:dispatch [event-id ...]]` | event vector | v1 | 002 | |
-| `[:dispatch-later {:ms ms :dispatch event-vec}]` | options map | v1 | 002 | |
+| `[:dispatch-later {:ms ms :event event-vec}]` | options map | v1 | 002 | |
 | `[:http args]` | impl-specific | — | — | user-registered via `reg-fx`. |
 | `[:rf.http/managed args-map]` | args per [014 §The args map](014-HTTPRequests.md#the-args-map) | v1 (optional capability) | 014 | Framework-provided when the implementation ships Spec 014. CLJS reference: ships on Fetch + JVM `HttpClient`. See also `:rf.http/managed-abort`, `:rf.http/managed-canned-success`, `:rf.http/managed-canned-failure`. |
 | `[:rf.nav/push-url url-string]` | URL string | v1 | 012 | |

--- a/spec/Pattern-LongRunningWork.md
+++ b/spec/Pattern-LongRunningWork.md
@@ -150,7 +150,7 @@ re-frame v1 had a `^:flush-dom` event-vector metadata that forced a DOM flush be
 (rf/reg-event-fx :process/start
   (fn [{:keys [db]} _]
     {:db (assoc db :processing? true)                          ;; modal renders next tick
-     :fx [[:dispatch-later {:ms 0 :dispatch [:process/run]}]]}));; yield, then run
+     :fx [[:dispatch-later {:ms 0 :event [:process/run]}]]}));; yield, then run
 
 (rf/reg-event-fx :process/run
   (fn [{:keys [db]} _]

--- a/spec/Pattern-RemoteData.md
+++ b/spec/Pattern-RemoteData.md
@@ -235,7 +235,7 @@ Repeating fetches at a fixed interval. Use `:dispatch-later` to schedule the nex
 (rf/reg-event-fx :articles/poll
   (fn [_ _]
     {:fx [[:dispatch [:articles/load]]
-          [:dispatch-later {:ms 30000 :dispatch [:articles/poll]}]]}))
+          [:dispatch-later {:ms 30000 :event [:articles/poll]}]]}))
 ```
 
 A pause/resume pair (`:articles/poll-pause`, `:articles/poll-resume`) reads from a `:articles/poll-active?` sub if the user wants UI control over polling.

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -471,7 +471,7 @@ Every effect — including dispatching another event, scheduling a delayed dispa
 ```clojure
 {:db (assoc db :counter 1)
  :fx [[:dispatch       [:counter/saved]]
-      [:dispatch-later {:ms 1000 :dispatch [:counter/cleanup]}]
+      [:dispatch-later {:ms 1000 :event [:counter/cleanup]}]
       [:http           {:method :get :url "/api/items"}]
       [:localstorage/set {:key "counter" :value 1}]]}
 ```


### PR DESCRIPTION
Fixes the M-16 silent-fail key bug across the corpus. The runtime `:dispatch-later` fx destructures `{:keys [ms event]}` and reads **`:event`**, NOT `:dispatch`. A left-behind v1 `:dispatch` key compiles + runs but the fx silently ignores it and the deferred event never fires (same class as rf2-ni6hw0 / rf2-8aqy38).

## Runtime evidence
- `implementation/core/src/re_frame/fx.cljc:282` — `(fn [frame-id parent-envelope {:keys [ms event]}] ... (dispatch! event opts))` — dispatches the value under `:event`.
- `spec/002-Frames.md:409,1205` — canonical spec already uses `:event` (`[:dispatch-later {:ms <n> :event event-vec}]`).
- The already-corrected skill (`skills/re-frame-migration/`) used `:event` and CONTRADICTED the migration README it cites — this PR aligns the README.

## Occurrences fixed (`:dispatch` -> `:event`)
- `spec/API.md:455` — standard `:fx` entries table.
- `docs/api/03-effects.md:27` — effects table.
- `migration/from-re-frame-v1/README.md` — M-8 "New form" rewrite (355), M-16 prose (586), M-16a example (606), M-16b reference + naive port (621), M-16b (ii) trampoline (640).
- `spec/Pattern-LongRunningWork.md:153`, `spec/Pattern-RemoteData.md:238`, `spec/Spec-Schemas.md:474` — v2 worked examples found in a wide grep.
- `implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs:20` — stale ns-docstring (the test's executable code at line 214 already uses `:event`).
- Added an explicit `:dispatch-later` key-rename note to the M-8 mechanical-rewrite rules (README §3) so a mechanical sweep produces the correct key.

Left intact (correct as-is):
- README v1 "before" examples (lines 160, 335) — v1's `:dispatch-later` map legitimately used `:dispatch`.
- `skills/re-frame-migration/references/breaking-changes.md:155` — intentionally shows the wrong key to describe the bug.
- `fx.cljc` — runtime is correct; `:event` is right. Not touched.

## Quality gates
- `python scripts/check_doc_slugs.py` — pass (EXIT=0)
- `python -m mkdocs build --strict` — pass (built in 11.31s, EXIT=0; docs/api/03-effects.md touched)
- `check_skill_migration_cites.py`, `check_skill_implementor_order.py`, `check_readme_inventories.py`, `check_readme_links.py`, `check_skill_redirect_anchors.py`, `check_skill_mcp_drift.py` — all pass (EXIT=0)
- No applicable public-API manifest / API-drift gate for the spec/API.md effect table.

Closes rf2-gswl7r.
