### PR TITLE
test(machines-viz): scope chart_dom prefix-selector assertions to outer nodes (rf2-6c2r83)

### DIFF
--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -823,10 +823,19 @@
            :definition     idle-loading-done
            :fired-edge-ids #{start-id}}
           (fn [_root node]
+            ;; Scope the per-node `data-fired` sweep to OUTER event-NODES
+            ;; via `[data-node-id]` (the same precise-event-node convention
+            ;; as the guard-blocked test + the `[data-variant]` count at the
+            ;; bottom of this file). The bare `rf-mv-chart-event-` prefix also
+            ;; matches the inner header/guard/reenter/action spans, which
+            ;; carry NO `data-node-id`; scoping keeps `others` to real nodes
+            ;; so the every?-is-false assertion can't be polluted as more
+            ;; inner-span attrs land (rf2-6c2r83).
             (let [fired-el (.querySelector
                              node (str "[data-testid=\"rf-mv-chart-event-" fired-ev-id "\"]"))
                   all-evs  (array-seq
-                             (.querySelectorAll node "[data-testid^=\"rf-mv-chart-event-\"]"))
+                             (.querySelectorAll
+                               node "[data-testid^=\"rf-mv-chart-event-\"][data-node-id]"))
                   others   (remove #(= % fired-el) all-evs)]
               (when (some? fired-el)
                 (is (= "true" (.getAttribute fired-el "data-fired")))


### PR DESCRIPTION
## Summary

Audit of the `chart_dom_cljs_test.cljs` prefix-selector (`^=`) assertions for inner-span pollution (root-cause from rf2-rn7zbe / the guard-blocked fix). As inner header/guard/reenter/action `<span>`s gain `data-*` attrs, a bare `rf-mv-chart-event-` prefix selector that then runs an `every?`/`some?` over the matched set can wrongly include those spans.

## Selectors hardened

- **`chart-fired-event-node-renders-data-fired`** — its `all-evs` set fed an `every? ... data-fired` per-node sweep using the bare `[data-testid^="rf-mv-chart-event-"]` prefix, the direct analogue of the already-fixed guard-blocked test. Scoped to outer event-nodes via `[data-testid^="rf-mv-chart-event-"][data-node-id]` (matching the guard-blocked fix + the `[data-variant]` convention). `data-node-id`, `data-variant`, `data-fired`, `data-machine-level` are carried ONLY by the outer event-node `<div>`; the inner spans carry none. The test previously survived only via the assertion's `nil?` tolerance — scoping removes the latent break as more inner-span attrs land.

## Selectors confirmed safe (left alone)

- `chart-machine-level-on-renders-single-root-sourced-chip` (line ~507) — `[...event-][data-machine-level="true"]`: the attr filter already restricts to the outer div (inner spans lack `data-machine-level`).
- The structural `(number? (.-length ...))` count in the fired test — legitimately counts all matches incl. spans; no per-node attr asserted.
- `rf-mv-chart-edge-` (bezier-fallback test) — reads `labels[0]` only (the outer div, first in document order); not an `every?`/`some?` over the set.
- `rf-mv-chart-root-container-context-` family — `querySelector` (first-match → parent div) presence/single-attr reads, or the more-specific `-inferred-` prefix.
- `rf-mv-chart-node-`, `rf-mv-chart-region-`, `rf-mv-chart-final-ring-`, `rf-mv-chart-root-container-title-` — each has exactly one emitter (the outer node); no shared-prefix inner spans, so counts/sweeps are exact. The region `every? data-active` and the `[data-variant]` count are scoped by attrs only the outer node carries.

## Quality gates

- machines-viz `clojure -M:test` — 456 tests, 1540 assertions, 0 failures, 0 errors
- `npm run test:browser` (chart_dom runs in-browser) — 196 tests, 590 assertions, 0 failures, 0 errors