### PR TITLE
feat(machines): stamp :source-code on action fns for Xray parity with guards (rf2-se70xj)

### DIFF
--- a/implementation/core/src/re_frame/core_reg_macros.cljc
+++ b/implementation/core/src/re_frame/core_reg_macros.cljc
@@ -223,12 +223,19 @@
        `{<id> {:fn <fn> :source-coords {...} :source-code \"...\"}}`. Plus
        `source-coords/collocate-state-source` splices the reference-site
        `:source-coords` onto each `:states`-tree map node at its spec-path
-       (the `{<map-spec-path> <coord>}` index from `walk-machine-spec`).
+       (the `{<map-spec-path> <coord>}` index from `walk-machine-spec`), and
+       `source-coords/collocate-state-inline-source` splices the inline-fn
+       `:source-code` strings — a `{<slot> <source-string>}` map keyed by the
+       inline `:entry`/`:exit`/`:guard`/`:action` slot — onto each enclosing
+       node (the `{<map-spec-path> {<slot> <source>}}` index from
+       `walk-machine-inline-source`; rf2-se70xj). The inline-fn slot values
+       themselves stay bare fns (the runtime engine resolves them via `fn?`
+       and stamps them as the trace `:action-id`/`:guard-id`).
      - PROD arm: `source-coords/wrap-element-fns` collapses each entry to
-       `{<id> {:fn <fn>}}` and NO state-source splice runs — NO source
-       literals, so Closure DCEs the dev arm (with its coord maps + `pr-str`
-       strings + the state-coord index) under `:advanced` +
-       `goog.DEBUG=false`.
+       `{<id> {:fn <fn>}}` and NO state-source / inline-source splice runs —
+       NO source literals, so Closure DCEs the dev arm (with its coord maps +
+       `pr-str` strings + the state-coord and inline-source indexes) under
+       `:advanced` + `goog.DEBUG=false`.
 
      `value-expr` is the runtime expression that evaluates to the spec map
      (the spec form itself for `reg-machine`; a gensym bound to it for
@@ -265,6 +272,15 @@
                                           (:line coords)   (assoc :line (:line coords))
                                           (:column coords) (assoc :column (:column coords)))]))
                                 (source-coords/walk-machine-spec spec-form ns-sym file))
+             ;; Inline-fn source-code index (rf2-se70xj): per enclosing
+             ;; `:states`-tree map-node spec-path, the `{<slot>
+             ;; <source-string>}` map for each inline `:entry`/`:exit`/
+             ;; `:guard`/`:action` fn LITERAL. Plain strings — syntax-quote-
+             ;; safe with no further quoting (unlike the coord maps' `:ns`
+             ;; symbol). Co-located alongside the reference-site coords so an
+             ;; inline action's CODE renders (it previously fell through to a
+             ;; bare-fn `pr-str` → `#object[Function]`).
+             inline-src   (source-coords/walk-machine-inline-source spec-form)
              ;; Only co-locate slots actually present on the spec; both
              ;; helpers no-op on an absent slot, but emitting calls only for
              ;; present slots keeps the expansion lean.
@@ -273,18 +289,24 @@
              ;; gated on the coords being non-empty.
              state-step   (when (seq state-coords)
                             [`(source-coords/collocate-state-source ~state-coords)])
+             ;; The inline-source co-location is likewise a single extra
+             ;; `->` step, gated on the index being non-empty.
+             inline-step  (when (seq inline-src)
+                            [`(source-coords/collocate-state-inline-source ~inline-src)])
              dev-form     `(-> ~value-expr
                               ~@(map (fn [slot]
                                        `(source-coords/collocate-element-source
                                           ~slot ~(get slot->src slot)))
                                      present-slots)
-                              ~@state-step)
+                              ~@state-step
+                              ~@inline-step)
              prod-form    `(-> ~value-expr
                               ~@(map (fn [slot]
                                        `(source-coords/wrap-element-fns ~slot))
                                      present-slots))]
-         (if (and (empty? present-slots) (empty? state-coords))
-           ;; Nothing debug-only to emit (no element slots, no states coords).
+         (if (and (empty? present-slots) (empty? state-coords) (empty? inline-src))
+           ;; Nothing debug-only to emit (no element slots, no states coords,
+           ;; no inline-fn source).
            value-expr
            `(if re-frame.interop/debug-enabled?
               ~dev-form

--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -205,6 +205,55 @@
         acc))
     spec coords))
 
+(defn collocate-state-inline-source
+  "Dev-branch runtime co-location of inline-fn `:source-code` strings onto
+  each enclosing `:states`-tree map node (rf2-se70xj). `inline-source` is the
+  `{<map-spec-path> {<slot> <source-string>}}` index the macro built via
+  [[walk-machine-inline-source]] at expansion time; this fn splices each
+  per-slot source map onto the map living at its spec-path under
+  `:source-code`, yielding e.g.
+
+      :states {:open {:entry (fn …)
+                      :on    {:door/close {:target :closed :guard :may-close?}}
+                      :source-coords {…}
+                      :source-code   {:entry \"(fn …)\"}}}
+
+  and for an inline transition `:action`:
+
+      :on {:cancel {:target :idle :action (fn [_] {})
+                    :source-coords {…}
+                    :source-code   {:action \"(fn [_] {})\"}}}
+
+  The `:source-code` map sits ALONGSIDE the `:source-coords` already
+  co-located on the node (per rf2-vqja2 / [[collocate-state-source]]); a tool
+  resolving an inline-fn slot key (`[… :action]`) reads `(get-in spec […
+  :source-code :action])` off the enclosing node. The inline SLOT itself
+  keeps its bare fn value — the runtime engine resolves it via `fn?` and
+  stamps it as the trace `:action-id`/`:guard-id`, so it must not be wrapped.
+
+  This co-location does not collide with the named-element `:source-code`
+  (a STRING on `:guards`/`:actions` entries via [[collocate-element-source]]):
+  those live under the `:guards`/`:actions` registry slots, never on a
+  `:states`-tree map node, so the two `:source-code` shapes never share a map.
+
+  Only paths whose live value is a map get a `:source-code` (the walker only
+  emits map-valued paths; this fn defends with `(map? (get-in …))` so a spec
+  whose runtime shape diverged from the literal degrades to a no-op). Returns
+  the updated spec.
+
+  This is the dev arm of the reg-machine macro's `(if interop/debug-enabled?
+  <collocate> <identity>)` gate — the `inline-source` literal is referenced
+  ONLY here, so under `:advanced` + `goog.DEBUG=false` the whole co-location
+  (with its `pr-str` source strings) DCEs and the registered state-nodes ship
+  clean."
+  [spec inline-source]
+  (reduce-kv
+    (fn [acc path src]
+      (if (map? (get-in acc path))
+        (assoc-in acc (conj (vec path) :source-code) src)
+        acc))
+    spec inline-source))
+
 ;; ---- always-on error-coord registry (rf2-3un2g) --------------------------
 ;;
 ;; The parallel registry that retains source-coords in production builds.
@@ -661,6 +710,168 @@
       ;; Reference-site stamping of MAP nodes under :states.
       (walk-states-tree (:states spec-form) [:states] acc ns-sym file)
       (persistent! acc))))
+
+;; ---- inline-fn source-code co-location (rf2-se70xj) -----------------------
+;;
+;; Per rf2-vqja2 an inline-fn slot (`:entry` / `:exit` / `:guard` / `:action`)
+;; inside the `:states` tree holds a fn VALUE, not a map, so it carries no
+;; `:source-coords` of its own — a tool resolving such a slot reads the
+;; enclosing map node's coord (jump-to-editor lands on the right line). But
+;; the enclosing map's coord cannot supply the inline fn's CODE TEXT: pr-str
+;; of the enclosing transition map (`{:target :x :action (fn …)}`) is not the
+;; action fn body, so Xray's Epoch-panel micro-step rendered an inline action
+;; as `#object[Function]` (the bare compiled fn falling through `pr-str`).
+;;
+;; The fix mirrors the guard mechanism's `:source-code` capture (the
+;; `pr-str` of the fn literal) WITHOUT wrapping the inline slot value — the
+;; runtime engine resolves `:entry`/`:exit`/`:guard`/`:action` slots
+;; directly via `fn?`/`keyword?` and stamps the slot value as the trace
+;; `:action-id`/`:guard-id`, so the slot value must stay a bare fn. Instead
+;; the inline fn's source string is co-located onto the ENCLOSING map node
+;; under `:source-code` — a `{<slot> <source-string>}` map keyed by the
+;; inline slot — parallel to the `:source-coords` already co-located there
+;; (`walk-machine-spec` / `collocate-state-source`). A tool resolving an
+;; inline-fn slot key (`[… :action]`) reads `(get-in spec [… :source-code
+;; :action])` off the enclosing map. Keyword-reference slots (`:action
+;; :clear-hold`) carry NO inline source — their body lives on the named
+;; `:actions` entry (per `walk-element-source`).
+;;
+;; The whole index rides the dev arm of the macro's `interop/debug-enabled?`
+;; gate (spliced only by `collocate-state-inline-source`), so the source
+;; strings DCE under `:advanced` + `goog.DEBUG=false` exactly as the
+;; reference-site coord index does.
+
+#?(:clj
+   (do
+
+(def ^:private inline-source-slots
+  "The inline-fn slots whose fn-literal source is co-located onto the
+   enclosing `:states`-tree map node's `:source-code` map (rf2-se70xj).
+   State-nodes carry `:entry` / `:exit`; transition maps carry `:guard` /
+   `:action`. Only fn-literal values are captured (keyword references defer
+   to the named `:guards` / `:actions` entry's own `:source-code`)."
+  [:entry :exit :guard :action])
+
+(defn- node-inline-source
+  "Build the `{<slot> <source-string>}` map for a single `:states`-tree map
+   node `form`, capturing the `pr-str` of each inline-fn slot whose value is
+   a fn LITERAL (`(fn …)` / `#(…)` reader form — a list). Keyword references
+   and non-list values are skipped (a keyword's body lives on its named
+   `:guards` / `:actions` entry; a non-list slot value carries no fn form to
+   render). Returns nil when the node carries no capturable inline fn so the
+   caller emits no entry. Compile-time / JVM-only."
+  [form]
+  (when (map? form)
+    (let [m (reduce
+              (fn [acc slot]
+                (let [v (get form slot)]
+                  ;; A fn literal reads as a list — `(fn …)` or the `#(…)`
+                  ;; reader-macro expansion. `seq?` distinguishes it from a
+                  ;; keyword reference or any non-form value, mirroring the
+                  ;; `(keyword? fn-form)` skip in `walk-element-source`.
+                  (if (seq? v)
+                    (assoc acc slot (pr-str v))
+                    acc)))
+              {}
+              inline-source-slots)]
+      (when (seq m) m))))
+
+(defn- walk-states-inline-source
+  "Recursively walk the literal `:states` map and return a flat index
+   `{<map-spec-path> {<slot> <source-string>}}` capturing each inline-fn
+   slot's fn-literal source (`:entry` / `:exit` on state-nodes; `:guard` /
+   `:action` on transition maps), keyed by the ENCLOSING map node's
+   spec-path (rf2-se70xj). Mirrors `walk-states-tree`'s structural recursion
+   so the same `:on` / `:always` / `:after` / nested-`:states` shapes are
+   covered, but collects fn-literal SOURCE rather than map-node coords.
+
+   `path` accumulates the spec-path from the spec's root. The mutable `acc`
+   transient is threaded through. Compile-time / JVM-only."
+  [states-form path acc]
+  (if-not (map? states-form)
+    acc
+    (reduce-kv
+      (fn [acc state-id node]
+        (let [node-path (conj path state-id)]
+          (when (map? node)
+            ;; State-node inline `:entry` / `:exit`.
+            (when-let [src (node-inline-source node)]
+              (assoc! acc node-path src))
+            ;; :on transitions — each transition MAP's inline `:guard` /
+            ;; `:action`. Single-map and vector-of-candidates forms.
+            (when-let [on-map (:on node)]
+              (when (map? on-map)
+                (reduce-kv
+                  (fn [_ ev-id t]
+                    (let [tp (conj node-path :on ev-id)]
+                      (cond
+                        (map? t)
+                        (when-let [src (node-inline-source t)]
+                          (assoc! acc tp src))
+                        (vector? t)
+                        (doseq [[i tx] (map-indexed vector t)
+                                :when (map? tx)]
+                          (when-let [src (node-inline-source tx)]
+                            (assoc! acc (conj tp i) src)))))
+                    nil)
+                  nil on-map)))
+            ;; :always — vector of transition maps.
+            (when-let [always (:always node)]
+              (when (vector? always)
+                (doseq [[i tx] (map-indexed vector always)
+                        :when (map? tx)]
+                  (when-let [src (node-inline-source tx)]
+                    (assoc! acc (conj node-path :always i) src)))))
+            ;; :after — map of delay → target-or-transition map.
+            (when-let [after (:after node)]
+              (when (map? after)
+                (reduce-kv
+                  (fn [_ delay t]
+                    (when (map? t)
+                      (when-let [src (node-inline-source t)]
+                        (assoc! acc (conj node-path :after delay) src)))
+                    nil)
+                  nil after)))
+            ;; Recurse into nested :states.
+            (walk-states-inline-source (:states node) (conj node-path :states) acc))
+          acc))
+      acc states-form)))
+
+(defn walk-machine-inline-source
+  "Compile-time helper. Walk a literal machine-spec form's `:states` tree
+   and return a flat index `{<map-spec-path> {<slot> <source-string>}}`
+   capturing each inline-fn slot's fn-literal source (rf2-se70xj). Keyed by
+   the ENCLOSING `:states`-tree map node's spec-path — e.g.
+   `[:states :idle :on :submit]` → `{:action \"(fn [_] {})\"}` for an inline
+   transition `:action`, `[:states :open]` → `{:entry \"(fn …)\"}` for an
+   inline state `:entry`.
+
+   Inline-fn slots hold a fn VALUE, not a map, so they cannot carry a
+   `:source-code` key of their own (per rf2-vqja2 the same reason
+   `:source-coords` lives on the enclosing node). This index is consumed by
+   [[collocate-state-inline-source]], which co-locates the per-slot source
+   strings under a `:source-code` map on each enclosing node — the read-back
+   surface Xray's Epoch-panel micro-step uses to render an inline action's
+   code (it previously fell through to `pr-str` of the bare fn → an opaque
+   `#object[Function]` token).
+
+   Keyword-reference slots (`:action :clear-hold`) are NOT captured here —
+   their body lives on the named `:actions` entry's own co-located
+   `:source-code` (via [[walk-element-source]]).
+
+   Returns `{}` when the spec form is not a map literal (a symbol /
+   let-bound expr — nothing to walk). JVM-only — runs on the Clojure side
+   of the `reg-machine` / `defmachine` macro. The whole returned literal is
+   referenced only from the dev arm of the macro's `interop/debug-enabled?`
+   gate, so it DCEs under `:advanced` + `goog.DEBUG=false`."
+  [spec-form]
+  (if-not (map? spec-form)
+    {}
+    (let [acc (transient {})]
+      (walk-states-inline-source (:states spec-form) [:states] acc)
+      (persistent! acc))))
+
+   )) ;; end #?(:clj (do ...)) for the inline-source walk
 
 ;; ---- co-located per-element source walk (rf2-npvsx) ----------------------
 ;;

--- a/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
@@ -159,6 +159,55 @@
     (is (some? (node-coords :rf2-8bp3/hier [:states :outer :states :inner :on :go]))
         "transition map inside hierarchical inner state co-locates its coord")))
 
+;; ---- inline-fn :source-code co-location (rf2-se70xj) ----------------------
+
+;; Read the inline-fn `:source-code` string for an inline slot off the
+;; enclosing `:states`-tree map node.
+(defn- inline-source [machine-id enclosing-path slot]
+  (get-in (rf/machine-meta machine-id)
+          (conj (vec enclosing-path) :source-code slot)))
+
+(deftest reg-machine-stamps-inline-action-source-code-cljs
+  (testing "inline transition `:action` / state `:entry` / `:exit` / inline
+  `:guard` fns carry their `:source-code` on the enclosing `:states`-tree map
+  node — parity with the named-guard `:source-code` stamp (rf2-se70xj). The
+  inline slot value itself stays a bare fn (the runtime resolves it via fn?)."
+    (rf/reg-machine :rf2-se70xj/inline
+      {:initial :idle
+       :guards  {:ok? (fn [_] true)}
+       :states
+       {:idle {:entry (fn [_] {:data {:entered? true}})
+               :exit  (fn [_] {:data {:exited? true}})
+               :on    {:submit {:target :done :guard (fn [{data :data}] (:ready? data))}
+                       :cancel {:target :idle :action (fn [_] {:data {:cancelled? true}})}}}
+        :done {}}})
+    ;; Inline transition :action.
+    (let [src (inline-source :rf2-se70xj/inline [:states :idle :on :cancel] :action)]
+      (is (string? src) "inline :action carries :source-code")
+      (is (re-find #":cancelled\?" src)))
+    ;; Inline state :entry / :exit.
+    (is (re-find #":entered\?" (inline-source :rf2-se70xj/inline [:states :idle] :entry)))
+    (is (re-find #":exited\?"  (inline-source :rf2-se70xj/inline [:states :idle] :exit)))
+    ;; Inline transition :guard.
+    (is (re-find #":ready\?"   (inline-source :rf2-se70xj/inline [:states :idle :on :submit] :guard)))
+    ;; Slot values stay bare fns — not wrapped into a map.
+    (is (fn? (get-in (rf/machine-meta :rf2-se70xj/inline) [:states :idle :on :cancel :action])))
+    (is (fn? (get-in (rf/machine-meta :rf2-se70xj/inline) [:states :idle :entry])))))
+
+(deftest reg-machine-skips-inline-source-for-keyword-references-cljs
+  (testing "keyword-reference slots carry NO inline :source-code — their body
+  lives on the named :actions / :guards entry's own :source-code (rf2-se70xj)"
+    (rf/reg-machine :rf2-se70xj/kw
+      {:initial :idle
+       :guards  {:ok? (fn [_] true)}
+       :actions {:do  (fn [_] {})}
+       :states
+       {:idle {:on {:submit {:target :done :guard :ok? :action :do}}}
+        :done {}}})
+    (is (nil? (inline-source :rf2-se70xj/kw [:states :idle :on :submit] :action)))
+    (is (nil? (inline-source :rf2-se70xj/kw [:states :idle :on :submit] :guard)))
+    (is (string? (get-in (rf/machine-meta :rf2-se70xj/kw) [:actions :do :source-code])))))
+
 ;; ---- programmatic call (no walking) --------------------------------------
 
 (deftest reg-machine-skips-stamping-for-non-literal-spec-cljs

--- a/implementation/machines/test/re_frame/machine_source_coord_test.clj
+++ b/implementation/machines/test/re_frame/machine_source_coord_test.clj
@@ -115,6 +115,109 @@
     (is (some? (element-coords :rf2-8bp3/on-spawn-defs :on-spawn-actions :capture-id))
         "the :capture-id on-spawn-action fn-form carries co-located :source-coords")))
 
+;; ---- inline-fn :source-code co-location (rf2-se70xj) ----------------------
+;;
+;; Inline `:entry` / `:exit` / `:guard` / `:action` fn LITERALS inside the
+;; `:states` tree hold a fn VALUE, not a map, so they cannot carry a
+;; `:source-code` of their own (per rf2-vqja2 the same reason `:source-coords`
+;; lives on the enclosing node). The reg-machine macro co-locates each inline
+;; fn's `pr-str` source onto the ENCLOSING `:states`-tree map node under a
+;; `{<slot> <source-string>}` map keyed `:source-code` — so Xray's Epoch-panel
+;; micro-step renders an inline action's CODE instead of `#object[Function]`.
+;;
+;; This works on JVM (unlike the reference-site `:source-coords`, which needs
+;; the CLJS reader's map-literal meta): the source string is the `pr-str` of
+;; the fn LITERAL (a list, which the LispReader does decorate / pr-str
+;; faithfully), and the co-location is `assoc-in`/`get-in` on the enclosing
+;; node — neither depends on map-literal reader meta.
+
+;; Read the inline-fn `:source-code` string for an inline slot off the
+;; enclosing `:states`-tree map node. `enclosing-path` is the spec-path to the
+;; enclosing state-node / transition map; `slot` is :entry/:exit/:guard/:action.
+(defn- inline-source [machine-id enclosing-path slot]
+  (get-in (rf/machine-meta machine-id)
+          (conj (vec enclosing-path) :source-code slot)))
+
+(deftest reg-machine-stamps-inline-transition-action-source-code
+  (testing "an inline transition `:action` fn carries its `:source-code` on
+  the enclosing transition map — parity with the guard `:source-code` stamp
+  (rf2-se70xj). The guard `:source-code` is the foil that already worked."
+    (rf/reg-machine :rf2-se70xj/inline-action
+      {:initial :idle
+       :guards  {:ok? (fn [_] true)}
+       :states
+       {:idle {:on {:submit {:target :done :guard :ok?}
+                    :cancel {:target :idle :action (fn [_] {:data {:cancelled? true}})}}}
+        :done {}}})
+    ;; The named guard's :source-code (the parity baseline — already worked).
+    (is (string? (get-in (rf/machine-meta :rf2-se70xj/inline-action)
+                         [:guards :ok? :source-code]))
+        "named guard carries :source-code (parity baseline)")
+    ;; The inline transition :action now carries :source-code on the
+    ;; enclosing transition map (the rf2-se70xj fix).
+    (let [src (inline-source :rf2-se70xj/inline-action [:states :idle :on :cancel] :action)]
+      (is (string? src)
+          "inline transition :action carries :source-code on the enclosing transition map")
+      (is (re-find #"\(fn" src)
+          "the captured :source-code is the inline action fn's source form")
+      (is (re-find #":cancelled\?" src)
+          "the captured :source-code is the action body, not the enclosing map"))
+    ;; The inline-fn slot value itself stays a BARE fn (the runtime engine
+    ;; resolves it via fn? and stamps it as the trace :action-id) — NOT wrapped.
+    (is (fn? (get-in (rf/machine-meta :rf2-se70xj/inline-action)
+                     [:states :idle :on :cancel :action]))
+        "inline :action slot value stays a bare fn (not wrapped into a map)")))
+
+(deftest reg-machine-stamps-inline-entry-exit-source-code
+  (testing "inline state `:entry` / `:exit` fns carry their `:source-code` on
+  the enclosing state-node (rf2-se70xj)"
+    (rf/reg-machine :rf2-se70xj/inline-ee
+      {:initial :a
+       :states
+       {:a {:entry (fn [_] {:data {:entered? true}})
+            :exit  (fn [_] {:data {:exited? true}})
+            :on    {:go :b}}
+        :b {}}})
+    (let [entry-src (inline-source :rf2-se70xj/inline-ee [:states :a] :entry)
+          exit-src  (inline-source :rf2-se70xj/inline-ee [:states :a] :exit)]
+      (is (string? entry-src) "inline :entry carries :source-code")
+      (is (re-find #":entered\?" entry-src))
+      (is (string? exit-src) "inline :exit carries :source-code")
+      (is (re-find #":exited\?" exit-src)))
+    ;; Slot values stay bare fns.
+    (is (fn? (get-in (rf/machine-meta :rf2-se70xj/inline-ee) [:states :a :entry])))
+    (is (fn? (get-in (rf/machine-meta :rf2-se70xj/inline-ee) [:states :a :exit])))))
+
+(deftest reg-machine-stamps-inline-guard-source-code
+  (testing "an inline transition `:guard` fn carries its `:source-code` on the
+  enclosing transition map (rf2-se70xj)"
+    (rf/reg-machine :rf2-se70xj/inline-guard
+      {:initial :idle
+       :states
+       {:idle {:on {:submit {:target :done :guard (fn [{data :data}] (:ready? data))}}}
+        :done {}}})
+    (let [src (inline-source :rf2-se70xj/inline-guard [:states :idle :on :submit] :guard)]
+      (is (string? src) "inline :guard carries :source-code")
+      (is (re-find #":ready\?" src)))))
+
+(deftest reg-machine-skips-inline-source-for-keyword-references
+  (testing "keyword-reference slots (`:action :clear-hold`) carry NO inline
+  :source-code on the enclosing node — their body lives on the named
+  :actions / :guards entry's own :source-code (rf2-se70xj)"
+    (rf/reg-machine :rf2-se70xj/kw-refs
+      {:initial :idle
+       :guards  {:ok? (fn [_] true)}
+       :actions {:do  (fn [_] {})}
+       :states
+       {:idle {:on {:submit {:target :done :guard :ok? :action :do}}}
+        :done {}}})
+    ;; No inline :source-code for keyword-reference slots on the transition.
+    (is (nil? (inline-source :rf2-se70xj/kw-refs [:states :idle :on :submit] :action)))
+    (is (nil? (inline-source :rf2-se70xj/kw-refs [:states :idle :on :submit] :guard)))
+    ;; The named entries DO carry their own :source-code (the existing path).
+    (is (string? (get-in (rf/machine-meta :rf2-se70xj/kw-refs) [:actions :do :source-code])))
+    (is (string? (get-in (rf/machine-meta :rf2-se70xj/kw-refs) [:guards :ok? :source-code])))))
+
 ;; ---- reference-site stamping inside the :states tree ----------------------
 
 (deftest reg-machine-stamps-on-transition-keyword-references-via-definition

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -849,7 +849,9 @@ Each MAP node inside `:states` — a state-node, a transition map under `:on` / 
 :states {:idle {:on {:submit {:target :done
                               :guard  :form-valid?
                               :action (fn [_] {})
-                              :source-coords {:ns sym :file "path/login.cljs" :line 80 :column 23}}}
+                              :source-coords {:ns sym :file "path/login.cljs" :line 80 :column 23}
+                              ;; inline-fn source — keyed by slot (rf2-se70xj):
+                              :source-code   {:action "(fn [_] {})"}}}
                 :source-coords {:ns sym :file "path/login.cljs" :line 78 :column 11}}
          :done {:source-coords {:ns sym :file "path/login.cljs" :line 84 :column 11}}}
 ```
@@ -858,19 +860,21 @@ This is the coord tools navigate to for "jump to call site" — where a transiti
 
 #### Inline-fn / keyword slots (the exemption case)
 
-Inline-fn and keyword slots inside `:states` — `:entry` / `:exit` / `:guard` / `:action` / `:on-spawn` — hold a fn or keyword VALUE, not a map, so there is no node to hang a `:source-coords` key on. They are **not** stamped individually; a tool resolving such a slot reads the `:source-coords` off its **nearest enclosing map node** (the transition map for an inline `:guard` / `:action`; the state-node for an inline `:entry` / `:exit`). This is the same source line in practice, and it mirrors the keyword-reference rule: a keyword (`:form-valid?`) is a name, not a source form, so it too falls back to the enclosing map's coord.
+Inline-fn and keyword slots inside `:states` — `:entry` / `:exit` / `:guard` / `:action` / `:on-spawn` — hold a fn or keyword VALUE, not a map, so there is no node to hang a `:source-coords` key on. They are **not** stamped with their OWN `:source-coords`; a tool resolving such a slot reads the `:source-coords` off its **nearest enclosing map node** (the transition map for an inline `:guard` / `:action`; the state-node for an inline `:entry` / `:exit`). This is the same source line in practice, and it mirrors the keyword-reference rule: a keyword (`:form-valid?`) is a name, not a source form, so it too falls back to the enclosing map's coord.
+
+**Inline-fn `:source-code` (rf2-se70xj).** The enclosing-map fallback works for `:source-coords` (the position is the same source line), but it does NOT supply an inline fn's CODE TEXT — `pr-str` of the enclosing transition map is `{:target :done :action (fn …)}`, not the action fn body. So an inline fn's `:source-code` (the `pr-str` of the fn literal) is co-located on the **enclosing map node** under a `:source-code` MAP keyed by the inline slot — `{:entry "…" :exit "…"}` on a state-node, `{:guard "…" :action "…"}` on a transition map — alongside the node's own `:source-coords`. A tool resolving an inline-fn slot key (`[… :action]`) reads `(get-in spec [… :source-code :action])` off the enclosing node. This is distinct from the named-element `:source-code` (a STRING on `:guards` / `:actions` entries): named entries live under the registry slots, never on a `:states`-tree map node, so the two `:source-code` shapes never share a map. **The inline-fn slot VALUE itself stays a bare fn** — the runtime engine resolves `:entry` / `:exit` / `:guard` / `:action` slots via `fn?` / `keyword?` and stamps the slot value as the trace `:action-id` / `:guard-id`, so it is never wrapped into a map. Keyword-reference slots (`:action :clear-hold`) carry NO inline `:source-code` — their body lives on the named `:actions` entry's own `:source-code`.
 
 Concretely for `{:guards {:form-valid? (fn …)} :states {:idle {:on {:submit {:target :done :guard :form-valid? :action (fn [_] {})}}}}}`:
 
-| Where | Co-located coord? | Why |
-|---|---|---|
-| `:guards :form-valid?` entry's `:source-coords` | ✓ (when defined) | fn literal carries reader meta |
-| `:states :idle` state-node's `:source-coords` | ✓ | state-node map carries reader meta (CLJS) |
-| `:states :idle :on :submit` transition map's `:source-coords` | ✓ | transition map carries reader meta (CLJS) |
-| `:states :idle :on :submit :guard` | — (resolves to the transition map) | `:form-valid?` is a keyword — no node |
-| `:states :idle :on :submit :action` | — (resolves to the transition map) | the inline fn is a value, not a map |
+| Where | Co-located coord? | Inline `:source-code`? | Why |
+|---|---|---|---|
+| `:guards :form-valid?` entry's `:source-coords` / `:source-code` | ✓ (when defined) | ✓ (on the `:guards` entry) | fn literal carries reader meta + `pr-str` source |
+| `:states :idle` state-node's `:source-coords` | ✓ | — (no inline `:entry`/`:exit` here) | state-node map carries reader meta (CLJS) |
+| `:states :idle :on :submit` transition map's `:source-coords` | ✓ | — | transition map carries reader meta (CLJS) |
+| `:states :idle :on :submit :guard` | — (resolves to the transition map) | — (`:form-valid?` is a keyword) | a keyword's body lives on `:guards :form-valid?` |
+| `:states :idle :on :submit :action` | — (resolves to the transition map) | ✓ via `[:states :idle :on :submit :source-code :action]` | the inline fn is a value, not a map — its source rides the enclosing transition map's `:source-code` |
 
-Tools resolving a slot walk UP from its spec-path to the nearest enclosing map carrying `:source-coords`; for a "jump to call site" click on a state's `:guard`, they land on the enclosing transition's coord (the same source line).
+Tools resolving a slot walk UP from its spec-path to the nearest enclosing map carrying `:source-coords`; for a "jump to call site" click on a state's `:guard`, they land on the enclosing transition's coord (the same source line). For the inline fn's CODE, they read `(get-in spec [<enclosing-map-path> :source-code <slot>])` — the inline `:source-code` map on that same enclosing node.
 
 #### Reading it back
 
@@ -886,13 +890,18 @@ Tools resolving a slot walk UP from its spec-path to the nearest enclosing map c
 ;; => {:ns ... :line ... :column ... :file ...}
 (get-in (rf/machine-meta :auth/login) [:states :form :on :submit :source-coords])
 ;; => {:ns ... :line ... :column ... :file ...}
+
+;; Inline-fn source — read off the enclosing node's :source-code map by slot
+;; (rf2-se70xj):
+(get-in (rf/machine-meta :auth/login) [:states :form :on :submit :source-code :action])
+;; => "(fn [{data :data}] {:fx ...})"   (nil for a keyword-reference :action)
 ```
 
 The top-level call-site coords (the position of the `(rf/reg-machine ...)` form itself) live on the registry slot as `:ns` / `:line` / `:column` / `:file`, queryable via `(rf/handler-meta :event machine-id)`. These surfaces are independent: a tool highlighting the `reg-machine` declaration uses `handler-meta`; a tool highlighting a guard's definition reads its co-located `:source-coords` on the `:guards` entry; a tool highlighting a transition's source line reads the `:source-coords` on the transition map node.
 
 #### Production elision
 
-The macro emits an `(if interop/debug-enabled? <dev> <prod>)` branch. The DEV arm co-locates `{:fn .. :source-coords .. :source-code ..}` onto each element entry AND co-locates `:source-coords` onto each `:states`-tree map node; the PROD arm collapses each element entry to `{:fn <fn>}` and runs NO state-source splice, so prod state-nodes ship clean (just the user's authored `{:on … :tags …}`). Under `:advanced` + `goog.DEBUG=false` the closure compiler constant-folds the gate to `false` and DCEs the entire dev arm — every co-located `:source-code` string and every coord literal (per-element AND state-node / transition-map) are absent from the production bundle. The separable `:fn` is what lets the source bytes DCE while the live function ships; state-nodes have no extra runtime cost in prod because the splice never runs. Verified by the `npm run test:elision` sentinel grep (the co-located `:source-code` fn-body fragments, which ride the same dev arm as the state-source splice — there is no longer a `:rf.machine/state-coords` keyword to grep, and `:source-coords` is shared with the guards/actions arm).
+The macro emits an `(if interop/debug-enabled? <dev> <prod>)` branch. The DEV arm co-locates `{:fn .. :source-coords .. :source-code ..}` onto each element entry, co-locates `:source-coords` onto each `:states`-tree map node, AND co-locates the inline-fn `:source-code` map onto each enclosing node (rf2-se70xj); the PROD arm collapses each element entry to `{:fn <fn>}` and runs NO state-source / inline-source splice, so prod state-nodes ship clean (just the user's authored `{:on … :tags …}`) and inline-fn slots ship as bare fns. Under `:advanced` + `goog.DEBUG=false` the closure compiler constant-folds the gate to `false` and DCEs the entire dev arm — every co-located `:source-code` string (named-element AND inline-fn) and every coord literal (per-element AND state-node / transition-map) are absent from the production bundle. The separable `:fn` is what lets the named-element source bytes DCE while the live function ships; inline-fn slots keep their bare fn while the inline `:source-code` map DCEs; state-nodes have no extra runtime cost in prod because the splice never runs. Verified by the `npm run test:elision` sentinel grep (the co-located `:source-code` fn-body fragments, which ride the same dev arm as the state-source / inline-source splices — there is no longer a `:rf.machine/state-coords` keyword to grep, and `:source-coords` is shared with the guards/actions arm).
 
 #### JVM caveat
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1782,30 +1782,48 @@ guard/action fn-form pr-str strings) + `:source-coords` (per-element
 `{:file :line}`), and whose `:states`-tree map nodes (state-node /
 transition map) each co-locate their own reference-site `:source-coords`
 (rf2-vqja2, supersedes the flat `:rf.machine/state-coords` index of
-rf2-npvsx / rf2-ypu5i / rf2-8bp3). The prior code read
-`(rf/handler-meta :machine event-id)`, a NON-EXISTENT registrar kind
-that always resolved nil — so `machine-spec-from-meta` saw no spec and
-every exit / entry action + guard row rendered the `<source not yet
+rf2-npvsx / rf2-ypu5i / rf2-8bp3) **plus an inline-fn `:source-code` map**
+keyed by inline slot (`{:entry "…" :exit "…"}` on a state-node,
+`{:guard "…" :action "…"}` on a transition map; rf2-se70xj). The prior
+code read `(rf/handler-meta :machine event-id)`, a NON-EXISTENT registrar
+kind that always resolved nil — so `machine-spec-from-meta` saw no spec
+and every exit / entry action + guard row rendered the `<source not yet
 captured>` placeholder. Reading under `:event` (where the machine
 handler is registered) surfaces the stamped spec so the interleaved
-source code resolves for named handlers (off the co-located entry);
-inline-fn / transition / timer rows resolve via
-`projection/state-node-source-coords` (the `:source-coords` on the
-nearest enclosing `:states`-tree map node). Source-key dispatch
-(`projection/cascade-row-source-key`) returns the spec-path tuple the
-view's `named-element-key` discriminator routes between the two lookup
-targets:
+source code resolves for named handlers (off the co-located entry's
+`:source-code`) AND for inline-fn rows (off the enclosing node's inline
+`:source-code <slot>` — rf2-se70xj; before it, an inline action's body
+fell through to the bare compiled fn and rendered `#object[Function]`,
+while its `:source-coords` click-to-source still worked off the enclosing
+node). Source-key dispatch (`projection/cascade-row-source-key`) returns
+the spec-path tuple the view's `named-element-key` discriminator routes
+between the two lookup families; the view's `cascade-row-source-form`
+then resolves the SOURCE:
 
-| Row kind | id flavour              | spec-path key                                         | lookup target |
-|----------|-------------------------|-------------------------------------------------------|---------------|
-| `:action`| keyword `action-id`     | `[:actions <id>]`                                     | co-located entry `:source-coords` / `:source-code` |
-| `:action`| inline-fn, `:entry`     | `[:states <target-state>... :entry]`                  | enclosing state-node `:source-coords` |
-| `:action`| inline-fn, `:exit`      | `[:states <source-state>... :exit]`                   | enclosing state-node `:source-coords` |
-| `:action`| inline-fn, `:transition`| `[:states <source-state>... :on <event> :action]`     | enclosing transition-map `:source-coords` |
-| `:guard` | keyword `guard-id`      | `[:guards <id>]`                                      | co-located entry `:source-coords` / `:source-code` |
-| `:guard` | inline-fn               | `[:states <source-state>... :on <event> :guard]`      | enclosing transition-map `:source-coords` |
-| `:transition` | —                  | `[:states <source-state>... :on <event>]`             | transition-map `:source-coords` |
-| `:timer` | —                       | `[:states <state>...]` (parent state-node, D1 shape)  | state-node `:source-coords` |
+- **Named** `[:guards|:actions <id>]` keys → the co-located entry's
+  `:source-code` string (fall back to the bare `:fn` in prod / fn-form
+  fixtures).
+- **Inline-fn** `[:states … <slot>]` keys → the enclosing node's inline
+  `:source-code <slot>` string (the parent of the key, `(butlast k)`, +
+  the slot `(last k)`; rf2-se70xj). Falls back to the bare slot value (a
+  compiled fn / keyword reference) when no inline source was captured
+  (prod, fn-form fixtures, value-registered non-`defmachine` specs).
+
+Click-to-source COORDS for inline-fn rows resolve via
+`projection/state-node-source-coords` (the `:source-coords` on the
+nearest enclosing `:states`-tree map node — walk-up; rf2-vqja2),
+distinct from the inline `:source-code` body above.
+
+| Row kind | id flavour              | spec-path key                                         | source-body lookup | coord lookup |
+|----------|-------------------------|-------------------------------------------------------|--------------------|--------------|
+| `:action`| keyword `action-id`     | `[:actions <id>]`                                     | entry `:source-code` | entry `:source-coords` |
+| `:action`| inline-fn, `:entry`     | `[:states <target-state>... :entry]`                  | enclosing state-node `:source-code :entry` | enclosing state-node `:source-coords` |
+| `:action`| inline-fn, `:exit`      | `[:states <source-state>... :exit]`                   | enclosing state-node `:source-code :exit` | enclosing state-node `:source-coords` |
+| `:action`| inline-fn, `:transition`| `[:states <source-state>... :on <event> :action]`     | enclosing transition-map `:source-code :action` | enclosing transition-map `:source-coords` |
+| `:guard` | keyword `guard-id`      | `[:guards <id>]`                                      | entry `:source-code` | entry `:source-coords` |
+| `:guard` | inline-fn               | `[:states <source-state>... :on <event> :guard]`      | enclosing transition-map `:source-code :guard` | enclosing transition-map `:source-coords` |
+| `:transition` | —                  | `[:states <source-state>... :on <event>]`             | logical-state delta box (not source) | transition-map `:source-coords` |
+| `:timer` | —                       | `[:states <state>...]` (parent state-node, D1 shape)  | (body elided) | state-node `:source-coords` |
 
 The per-row `:source-state` / `:target-state` / `:event-id` slots are
 stamped by `machine-cascade-rows`'s `enrich-cascade-rows` pass —

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2604,10 +2604,16 @@
     (the macro stamps it at compile time). Falls back to the entry's `:fn`
     (a compiled fn object) when no source-string was captured (production
     builds, fixture fn-form machines).
-  - Inline-fn `:entry` / `:exit` / `:guard` / `:action` rows: the spec
-    path returns the runtime value at that slot — a compiled fn object
-    or, when the user wrote a keyword reference (`:entry :enter-a`),
-    that keyword (the caller's render path will dispatch on shape).
+  - Inline-fn `:entry` / `:exit` / `:guard` / `:action` rows: prefer the
+    co-located `:source-code` STRING the macro stamped on the enclosing
+    `:states`-tree map node (rf2-se70xj) — a `{<slot> <source-string>}`
+    map under `:source-code` on the node, read at `(pop k)` + the slot
+    `(last k)`. This is what lets an inline action's CODE render (the slot
+    value itself is a bare compiled fn → an opaque `#object[Function]`
+    token, the rf2-se70xj symptom). Falls back to the runtime value at the
+    slot (a compiled fn object in production / fn-form fixture machines, or,
+    when the user wrote a keyword reference (`:entry :enter-a`), that keyword
+    — the caller's render path dispatches on shape).
   - Transition rows: the spec path returns the transition map literal
     (a renderable EDN map).
   - Timer rows: the spec path returns the entire state-node map (the
@@ -2628,7 +2634,20 @@
               ;; A pre-rf2-npvsx fixture might still carry a bare fn under
               ;; the slot; tolerate it for unit-test ergonomics.
               entry))
-        (get-in spec k)))))
+        ;; Inline-fn slot key (`[… :action]` / `:guard` / `:entry` /
+        ;; `:exit`) under `:states`. Prefer the co-located `:source-code`
+        ;; STRING the macro stamped on the ENCLOSING map node (rf2-se70xj) —
+        ;; the inline fn's body cannot live on the bare slot (the runtime
+        ;; engine needs a fn there), so it rides a `{<slot> <source>}` map
+        ;; under the enclosing node's `:source-code`. Fall back to the
+        ;; runtime slot value (the bare fn / keyword reference) when no
+        ;; source was captured (production builds, fn-form fixtures).
+        (let [slot          (last k)
+              enclosing-path (vec (butlast k))
+              inline-src    (when (seq enclosing-path)
+                              (get-in spec (conj enclosing-path :source-code slot)))]
+          (or inline-src
+              (get-in spec k)))))))
 
 (defn- cascade-outcome-chip
   "Render the outcome chip for a cascade row (rf2-u69j7). Pulls glyph

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/inline_action_source_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/inline_action_source_cljs_test.cljs
@@ -1,0 +1,120 @@
+(ns day8.re-frame2-xray.panels.epoch.inline-action-source-cljs-test
+  "rf2-se70xj — END-TO-END rendering fidelity for an INLINE machine action's
+  source code in the Epoch panel cascade.
+
+  ## The gap it closes
+
+  Before rf2-se70xj the `reg-machine` macro stamped `:source-code` (the
+  `pr-str` of the fn literal) onto NAMED `:guards` / `:actions` entries but
+  NOT onto INLINE-fn slots (`:entry` / `:exit` / `:guard` / `:action`)
+  written directly inside the `:states` tree. An inline-fn slot holds a fn
+  VALUE, not a map (per rf2-vqja2 — the same reason `:source-coords` lives on
+  the enclosing node), so Xray's `cascade-row-source-form` fell through to the
+  bare compiled fn and `source-form->string` rendered it as an opaque
+  `#object[Function]` token. Guards rendered their CLJS source correctly; an
+  inline action did not.
+
+  The fix co-locates each inline fn's source string onto the ENCLOSING
+  `:states`-tree map node under `:source-code` (a `{<slot> <source-string>}`
+  map), parallel to the reference-site `:source-coords` already co-located
+  there. The view reads the inline source off the enclosing node.
+
+  ## What this test drives + asserts
+
+  It registers a machine with an INLINE transition `:action` (and inline
+  `:entry` / `:exit`) via the `reg-machine` MACRO (a LITERAL spec — the macro
+  walks it and stamps source), drives a real macrostep through the LIVE
+  substrate, projects the cascade Xray's Epoch panel reads, renders the
+  HANDLER step, and asserts the inline action's source CODE renders (the
+  `pr-str` of the fn body), NOT the `#object[Function]` token. This is a
+  Causa/Story-style CLJS unit test (NOT a Playwright spec)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as string]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.machines]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.test-helpers :as th]
+            [day8.re-frame2-xray.panels.epoch.projection :as proj]
+            [day8.re-frame2-xray.panels.epoch.view :as view]
+            [day8.re-frame2-xray.preload :as preload]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+(defn- xray-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-collector/reset-for-test!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn xray-init!}))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  (preload/register-trace-collector!)
+  ;; INLINE spec via the MACRO — the literal walk stamps inline source.
+  ;; A distinctive marker (`:inline-action-fired? true`) rides the action
+  ;; body so the rendered source string is unambiguous to grep for.
+  (rf/reg-machine :inline/sample
+    {:initial :idle
+     :data    {}
+     :states
+     {:idle {:entry (fn [_] {:data {:inline-entry-fired? true}})
+             :on    {:go {:target :done
+                          :action (fn [{data :data}]
+                                    {:data (assoc data :inline-action-fired? true)})}}}
+      :done {}}})
+  (rf/dispatch-sync [:inline/sample [:rf.machine/start]]))
+
+(defn- drive! [event-v]
+  (trace-collector/reset-for-test!)
+  (rf/dispatch-sync [:inline/sample event-v])
+  (vec (trace-collector/buffer-for-test)))
+
+(deftest inline-transition-action-renders-its-source-not-object-function
+  (testing "rf2-se70xj — an INLINE transition `:action` renders its CLJS
+            source CODE in the Epoch cascade, NOT `#object[Function]`. The
+            macro-stamped inline `:source-code` (co-located on the enclosing
+            transition map) is what the view reads."
+    (setup!)
+    ;; The transition map carries the inline action's source on the enclosing
+    ;; node (the machine-side contract this test consumes).
+    (is (string? (get-in (rf/machine-meta :inline/sample)
+                         [:states :idle :on :go :source-code :action]))
+        "the inline transition :action's :source-code is co-located on the
+         enclosing transition map (rf2-se70xj machine-meta contract)")
+    ;; Drive the real macrostep and render the HANDLER step. The body embeds
+    ;; edn-inspectors that subscribe against the surrounding frame.
+    (frame/reg-frame :rf/xray {})
+    (let [trace  (drive! [:go])
+          rows   (proj/machine-cascade-rows trace)
+          action-rows (filterv #(= :action (:kind %)) rows)
+          tree   (rf/with-frame :rf/xray
+                   (view/render-handler-step
+                     {:step :handler :badge :HANDLER :step-number 3
+                      :flavour :reg-machine :event-id :inline/sample
+                      :fx [] :machine {:cascade rows
+                                       :transition nil :guards []
+                                       :lifecycle [] :timers []}}))
+          ;; The full rendered text of every action source body.
+          source-bodies (->> action-rows
+                             (keep (fn [r]
+                                     (some-> tree
+                                             (th/find-by-testid
+                                               (str "rf-xray-epoch-machine-cascade-source-body-"
+                                                    (:step r)))
+                                             th/text-content)))
+                             (string/join "\n"))]
+      (is (seq action-rows)
+          "the macrostep produced at least one :action cascade row")
+      (is (string/includes? source-bodies ":inline-action-fired?")
+          "the inline transition action's CLJS source CODE renders in the
+           cascade source body (rf2-se70xj — was #object[Function])")
+      ;; The regression token must be ABSENT — the bug symptom was the
+      ;; compiled fn falling through pr-str.
+      (is (not (string/includes? source-bodies "#object"))
+          "no #object[Function] token renders for the inline action source
+           (the rf2-se70xj regression symptom)"))))


### PR DESCRIPTION
## Quality gates

| Gate | Result |
|---|---|
| machines `clojure -M:test` | 540 tests / 1682 assertions · 0 failures (4 new inline-source tests) |
| xray `clojure -M:test` | 1102 tests / 4579 assertions · 0 failures |
| `npm run test:xray-feature-gate` (nightly-full) | 16 scenarios · 0 failures · 13 matrix rows |
| `npm run test:cljs` | 5944 tests / 21095 assertions · 0 failures (incl. new e2e Xray render test) |
| `npm run test:elision` | PASS — prod 40/40 absent, control 40/40 present |
| core `clojure -M:test` | 950 tests / 4217 assertions · 0 failures (macro + source-coords) |
| machines-viz `clojure -M:test` | 456 tests · 0 failures (share-payload sanitiser strips the new shape) |

## Verify-first finding — OVERSIGHT (incompleteness), not deliberate

The bead's diagnosis is correct. There are two stamping pathways:

- **Definition-site** (`walk-element-source` + `collocate-element-source`) — walks the `:guards` / `:actions` / `:on-spawn-actions` registry maps and produces `{<id> {:fn .. :source-coords .. :source-code "…"}}`. GUARDS (and named actions) use this; their CODE renders.
- **Reference-site** (`walk-machine-spec` / `collocate-state-source`) — walks the `:states` tree and co-locates only `:source-coords` (file/line) onto each enclosing map node.

Per rf2-vqja2 (spec/005 §Inline-fn / keyword slots), an inline-fn slot (`:entry`/`:exit`/`:guard`/`:action`) holds a fn VALUE, not a map, so it deliberately carries no INDIVIDUAL `:source-coords` — a tool reads the enclosing map's coord (jump-to-editor lands on the same line). That exemption is sound and intentional.

But the spec was **silent on `:source-code`** (the code TEXT) for inline fns, and the enclosing-map fallback does NOT solve it: `pr-str` of the enclosing transition map is `{:target :x :action (fn …)}`, not the action fn body. So Xray's `cascade-row-source-form` found a bare fn at `[:states … :action]` and `source-form->string` rendered `#object[Function]`. The action carrying no `:source-code` is incompleteness, not a deliberate choice (no comment/spec rationale exempts inline `:source-code`; the rf2-vqja2 table only covers `:source-coords`). Proceeded with the fix.

**Why not wrap the inline slot into a `{:fn … :source-code …}` map (the literal "guard shape")?** The runtime engine resolves `:entry`/`:exit`/`:guard`/`:action` slots directly via `fn?`/`keyword?` (`transition/resolve-action` / `resolve-guard`) and stamps the slot VALUE as the trace `:action-id`/`:guard-id` (`run-action`). Wrapping would require touching the runtime resolver + corrupt the `:action-id` trace surface, and contradicts the documented rf2-vqja2 "inline slot holds a fn VALUE, not a map" contract. So — respecting the existing decision — the fix mirrors the guard mechanism's `pr-str` capture but co-locates the inline source onto the ENCLOSING node (where `:source-coords` already lives), keyed by slot.

## Before / after machine-meta

For `{:states {:idle {:on {:cancel {:target :idle :action (fn [{data :data}] (assoc data :cancelled? true))}}}}}`:

**Before** — the inline `:action` is a bare fn; no `:source-code` anywhere on the path:
```clojure
(get-in (rf/machine-meta :m) [:states :idle :on :cancel :action])
;; => #object[Function]   ;; bare fn → Xray renders #object[Function]
(get-in (rf/machine-meta :m) [:states :idle :on :cancel :source-code])
;; => nil
```

**After** — the inline fn's source rides the enclosing transition map's `:source-code` map, keyed by slot; the slot value stays a bare fn:
```clojure
(get-in (rf/machine-meta :m) [:states :idle :on :cancel :source-code :action])
;; => "(fn [{data :data}] (assoc data :cancelled? true))"   ;; Xray renders the CODE
(get-in (rf/machine-meta :m) [:states :idle :on :cancel :action])
;; => #object[Function]   ;; still a bare fn — runtime resolver unchanged
```

Verified live via the bead's `machine-meta` repro (the new `reg-machine-stamps-inline-transition-action-source-code` test asserts the transition `:action` now carries `:source-code`; the new e2e Xray test drives a real macrostep and asserts the rendered cascade source body shows the code, not `#object`).

## Files

- `implementation/core/src/re_frame/source_coords.cljc` — new `walk-machine-inline-source` (compile-time walker) + `collocate-state-inline-source` (dev-arm splicer)
- `implementation/core/src/re_frame/core_reg_macros.cljc` — wire the inline-source index into the macro expansion's dev arm (DCEs in prod)
- `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs` — `cascade-row-source-form` reads inline `:source-code` off the enclosing node by slot
- `implementation/machines/test/re_frame/machine_source_coord_test.clj` + `_cljs_test.cljs` — inline-source parity tests (incl. keyword-ref skip)
- `tools/xray/test/.../epoch/inline_action_source_cljs_test.cljs` — new e2e: drive a real machine, assert rendered source body shows code not `#object`
- `spec/005-StateMachines.md` — extend the inline-fn exemption-case contract to `:source-code` (HOT-ZONE; sole worker)
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` — extend the cascade-row source-resolution table with the inline `:source-code` lookup

Closes rf2-se70xj.