### PR TITLE
docs(xray): document :rf.xray/editor setup for open-in-editor + project-root scope (rf2-ffijtp)

### DIFF
--- a/docs/xray/01-installation.md
+++ b/docs/xray/01-installation.md
@@ -115,6 +115,22 @@ If Xray does not appear, check:
 - `rf/init!` has run with a substrate adapter.
 - `window.day8.re_frame2_xray.status()` has no missing-host diagnostic.
 
+## Clickable Jump-To-Source
+
+Every panel that surfaces a source-coord wraps it in an `open` chip. Clicking jumps to that line in your editor — but only once Xray knows which editor to open. On a plain host app wiring just the preload, the chip uses the `:vscode` default scheme; if that is not your editor, the OS has no handler for it and the click silently no-ops.
+
+Set your editor either in **Xray Settings** (the "Click-to-source links open in" picker on the General tab — persisted per-dev in localStorage, so each teammate can pick their own), or once at boot in code:
+
+```clojure
+(require '[day8.re-frame2-xray.config :as xray-config])
+(xray-config/configure! {:rf.xray/editor :cursor})
+;; :vscode (default) | :cursor | :windsurf | :zed | :idea | {:custom "<uri-template>"}
+```
+
+The Settings picker overrides the boot-time `configure!` value per-machine, so a mixed-editor team sets a project default in code and individuals override locally.
+
+`:rf.xray/project-root` is **only** needed when your stamped source-coords are classpath-*relative* (an editor cannot resolve a relative path). The normal `reg-*` / `reg-machine` registration path stamps **absolute** coords, which Xray ships verbatim — leave `:rf.xray/project-root` unset in that case. Do not hardcode a machine-specific path "to make Open work"; if absolute coords already open, you do not need it.
+
 ## Production Posture
 
 Production builds should not include the preload. Even if a dev-only path accidentally remains reachable, Xray's substrate is gated by re-frame2's debug flag and the bundle-isolation checks guard against Xray strings leaking into production bundles.

--- a/skills/re-frame-migration/references/xray-replaces-10x.md
+++ b/skills/re-frame-migration/references/xray-replaces-10x.md
@@ -83,6 +83,17 @@ Xray is **dev-only by construction** — production builds elide every byte of i
 
 The preload registers Xray's listeners under `register-listener!` and `register-epoch-listener!`, attaches the global keydown listener (`Ctrl+Shift+C` and the rest — see [Keybindings](#keybindings-whats-actually-wired)), and auto-opens the panel into the layout host after `rf/init!`. No `(require '[day8.re-frame2-xray.core])`. No `init!` call. The preload plus the host element are the full integration surface.
 
+### 4. Set your editor for clickable jump-to-source
+
+For Xray's `open` chips to jump to source on click, Xray must know which editor to open — the bare preload defaults to the `:vscode` scheme, so if that isn't your editor the click silently no-ops. Set it in **Xray Settings** ("Click-to-source links open in" on the General tab — persisted per-dev) or once at boot:
+
+```clojure
+(require '[day8.re-frame2-xray.config :as xray-config])
+(xray-config/configure! {:rf.xray/editor :cursor}) ; / :vscode (default) / :windsurf / :zed / :idea / {:custom "<uri-template>"}
+```
+
+`:rf.xray/project-root` is **only** needed when stamped source-coords are classpath-*relative*. The normal `reg-*` / `reg-machine` path stamps **absolute** coords (shipped verbatim), so leave it unset — do not hardcode a machine-specific path to "make Open work" when absolute coords already resolve. See [`docs/xray/01-installation.md` §Clickable Jump-To-Source](../../../docs/xray/01-installation.md#clickable-jump-to-source).
+
 ---
 
 ## The layout host (true-inline default)


### PR DESCRIPTION
@
## Quality gates

- `mkdocs build --strict` — green (only `docs/xray/01-installation.md` is in the mkdocs site; pre-existing INFO lines only, no errors)
- `python scripts/check_doc_slugs.py` — green
- `python scripts/check_skill_migration_cites.py` — green (validates the skill doc citations touched)
- `python scripts/check_skill_redirect_anchors.py` — green
- `python scripts/check_skill_package_refs.py` — green

## What changed

Closes the Xray open-in-editor onboarding/docs gap (rf2-ffijtp). NOT a bug — source-coords are stamped and absolute; the gap is that a plain host app wiring only the bare `day8.re-frame2-xray.preload` never tells Xray which editor to open, so the `open` chip silently no-ops when the default `:vscode` scheme has no OS handler.

**`docs/xray/01-installation.md`** — new `## Clickable Jump-To-Source` section:
- Set your editor in Xray Settings ("Click-to-source links open in" picker, persisted per-dev) or via `(day8.re-frame2-xray.config/configure! {:rf.xray/editor :cursor})` at boot.
- `:rf.xray/project-root` is ONLY needed for classpath-RELATIVE stamped coords; the normal `reg-*` / `reg-machine` path stamps ABSOLUTE coords (shipped verbatim) — leave it unset, do not hardcode a machine-specific path.

**`skills/re-frame-migration/references/xray-replaces-10x.md`** — added step 4 to the swap mirroring the same guidance, cross-linked to the installation section. Kept generic to any host app.

Verified before documenting: `:rf.xray/editor` keyword + `configure!` fn + Settings editor-override picker ("Click-to-source links open in" label) all exist; `compose-path` returns absolute paths unchanged regardless of project-root (confirms the relative-only scope).

Scope boundary: DOCS only. The optional click-hint DX (surface "pick an editor" instead of silent no-op) touches `view.cljs`, held by open PR #3473 — filed as a follow-up bead instead.
@