### PR TITLE
fix(machines): redact spawned-actor :data via type :data-schema marks (rf2-fm1cpl)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -683,13 +683,27 @@
   [decls]
   (mapv (fn [path] (into [:data] path)) (keys decls)))
 
-(defn- register-data-schema-marks!
+(defn register-data-schema-marks!
   "EP-0005 (rf2-w46fpt) — bridge the machine `:data-schema`'s `:sensitive?` /
   `:large?` per-slot markers into snapshot-egress redaction. Extracts the
   marked paths from `(:data-schema machine)` via the schemas walker, roots
   them under `[:data …]`, and UNIONs them into the `:event`-keyed marks entry
   for `machine-id` (composing with any manual `register-marks!`, not clobbering
   it).
+
+  Per rf2-fm1cpl this is PUBLIC because the spawn path
+  (`lifecycle-fx.spawn/spawn-fx`) re-runs the bridge keyed under the SPAWNED
+  INSTANCE id. A spawned actor's `:rf.machine/transition` /
+  `:rf.machine/snapshot-updated` trace carries `:machine-id` = the instance id
+  (`<type>#<n>` or the explicit `:spawn-id`), NOT the type id — and
+  `re-frame.marks/project-machine-tags` resolves redaction marks via
+  `(marks-for :event <machine-id>)`. The type's `:data-schema` marks key under
+  the TYPE id, so without a per-instance bridge a spawned actor's `:sensitive?`
+  `:data` slot would egress RAW (the type-id lookup never fires for an
+  instance-id trace). Re-running this fn under the instance id at spawn time
+  keys the same schema-derived marks under the id the trace actually carries,
+  covering BOTH registered-type (`:machine-id`) and inline (`:definition`)
+  spawns uniformly via the resolved spec's `:data-schema`.
 
   `prior-marks` is the machine's marks entry captured BEFORE `reg-event-fx`
   ran. The `reg-event-fx` registration calls `register-marks! :event

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -25,6 +25,7 @@
   (:require [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.machines.data-validation :as data-validation]
+            [re-frame.machines.lifecycle-fx.registration :as registration]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.paths :as paths]
             [re-frame.machines.spawn-order :as spawn-order]
@@ -323,6 +324,25 @@
                          :spawn-id invoke-id
                          :track?    track?
                          :type-ref  type-ref})
+        ;; Per rf2-fm1cpl — bridge the spawned actor's `:data-schema`
+        ;; `:sensitive?` / `:large?` markers into snapshot-egress redaction
+        ;; KEYED UNDER THE INSTANCE ID. A spawned actor's
+        ;; `:rf.machine/transition` / `:rf.machine/snapshot-updated` trace
+        ;; carries `:machine-id` = the INSTANCE id (`<type>#<n>` or the
+        ;; explicit `:spawn-id`), and `re-frame.marks/project-machine-tags`
+        ;; resolves marks via `(marks-for :event <machine-id>)`. The TYPE's
+        ;; `:data-schema` marks (bridged at `reg-machine*` time) key under the
+        ;; TYPE id, so an instance-id trace's lookup would MISS and a
+        ;; `:sensitive?` `:data` slot would egress RAW. Re-running the SAME
+        ;; bridge (`registration/register-data-schema-marks!`) under
+        ;; `spawned-id` keys the schema-derived marks under the id the trace
+        ;; actually carries — covering both registered-type (`:machine-id`)
+        ;; and inline (`:definition`) spawns via the resolved `spec''`'s
+        ;; `:data-schema`. The bridge itself rides `interop/debug-enabled?`
+        ;; (the egress surface it feeds is gated), so this is dead-elided in
+        ;; production builds. `prior-marks` nil — a per-instance id has no
+        ;; manual `register-marks!` to compose with.
+        (registration/register-data-schema-marks! spawned-id spec'' nil)
         ;; Per rf2-vsigt — record the spawned actor in the frame's
         ;; spawn-order channel so frame-destroy can walk in reverse-
         ;; creation order per Spec 005 §Cross-Spec Interactions §1.

--- a/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
+++ b/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
@@ -212,3 +212,113 @@
     (let [m (marks/marks-for :event auth-id)]
       (is (= #{[:data :token] [:data :extra]} (set (:sensitive m)))
           "union-marks! preserves the schema-sourced path"))))
+
+;; ---- (5) SPAWNED-INSTANCE egress redaction (rf2-fm1cpl) -------------------
+;;
+;; A spawned actor's `:rf.machine/transition` / `:rf.machine/snapshot-updated`
+;; trace carries `:machine-id` = the INSTANCE id (`<type>#<n>` or the explicit
+;; `:spawn-id`), NOT the type id. `project-machine-tags` resolves redaction
+;; marks via `(marks-for :event <machine-id>)`, so the TYPE's `:data-schema`
+;; marks (keyed under the type id at `reg-machine` time) do NOT cover an
+;; instance-id trace. rf2-fm1cpl re-runs the schema bridge at SPAWN time keyed
+;; under the spawned instance id so a spawned actor's `:sensitive?` `:data`
+;; slot redacts in egress exactly like a singleton's.
+
+(def ^:private spawn-type-id :rf.machine-redaction/spawn-worker)
+
+(defn- frame-db []
+  (rf/app-db-value :rf/default))
+
+(deftest spawned-instance-gets-schema-marks-keyed-under-instance-id
+  (testing "spawning an actor whose TYPE carries a :sensitive? / :large?
+            :data-schema registers the SAME schema-derived marks under the
+            SPAWNED INSTANCE id (the id its transition trace carries)"
+    ;; The spawned worker type carries auth-schema (token :sensitive?, blob
+    ;; :large?). A supervisor spawns one instance on entry to :working.
+    (rf/reg-machine spawn-type-id
+      {:initial     :anon
+       :data        {:retries 0 :token nil :blob nil}
+       :data-schema auth-schema
+       :states      {:anon {} :authed {}}})
+    (rf/reg-machine :rf.machine-redaction/sup
+      {:initial :idle
+       :states  {:idle    {:on {:start :working}}
+                 :working {:spawn {:machine-id spawn-type-id}}}})
+    (rf/dispatch-sync [:rf.machine-redaction/sup [:start]])
+    (let [spawned-id (get-in (frame-db)
+                             [:rf/runtime :machines :spawned
+                              :rf.machine-redaction/sup [:working]])
+          inst-marks (marks/marks-for :event spawned-id)]
+      (is (some? spawned-id) "an actor instance was spawned")
+      (is (some? inst-marks)
+          "a marks entry exists keyed under the SPAWNED INSTANCE id")
+      (is (= #{[:data :token]} (set (:sensitive inst-marks)))
+          ":sensitive? slot bridged under the instance id, snapshot-rooted")
+      (is (= #{[:data :blob]} (set (:large inst-marks)))
+          ":large? slot bridged under the instance id"))))
+
+(deftest spawned-instance-data-redacted-in-egress
+  (testing "a :rf.machine/transition trace keyed by the SPAWNED INSTANCE id
+            redacts the :sensitive? :data slot — the leak rf2-fm1cpl closes"
+    (rf/reg-machine spawn-type-id
+      {:initial     :anon
+       :data        {:retries 0 :token nil :blob nil}
+       :data-schema auth-schema
+       :states      {:anon {} :authed {}}})
+    (rf/reg-machine :rf.machine-redaction/sup
+      {:initial :idle
+       :states  {:idle    {:on {:start :working}}
+                 :working {:spawn {:machine-id spawn-type-id}}}})
+    (rf/dispatch-sync [:rf.machine-redaction/sup [:start]])
+    (let [spawned-id (get-in (frame-db)
+                             [:rf/runtime :machines :spawned
+                              :rf.machine-redaction/sup [:working]])
+          ;; Synthesise the instance's transition trace exactly as the
+          ;; handler emits it: :machine-id = the instance id, :data carrying
+          ;; a live secret token + large blob.
+          ev   {:operation :rf.machine/transition
+                :tags      {:machine-id spawned-id
+                            :frame      :rf/default
+                            :after      {:state :authed
+                                         :data  {:retries 1
+                                                 :token   "secret-jwt-spawned"
+                                                 :blob    "huge-spawned"}}}}
+          out  (marks/project-trace-event ev)
+          tags (:tags out)]
+      (is (= :rf/redacted (get-in tags [:after :data :token]))
+          "spawned instance's :sensitive? :data slot redacts at egress")
+      (is (contains? (get-in tags [:after :data :blob]) :rf.size/large-elided)
+          "spawned instance's :large? :data slot elides at egress")
+      (is (= 1 (get-in tags [:after :data :retries]))
+          "plain sibling rides verbatim")
+      (is (not (.contains (pr-str out) "secret-jwt-spawned"))
+          "no raw spawned-instance secret leaked into the projected trace"))))
+
+(deftest inline-definition-spawn-also-bridges-schema-marks
+  (testing "an inline-:definition spawn (no registered type) also bridges its
+            :data-schema marks under the instance id"
+    ;; The supported inline-:definition spawn form is the fx-emitted
+    ;; `[:rf.machine/spawn {:spawn-id <id> :definition <spec>}]` from an
+    ;; :entry action (mirrors machine_schema_test). The instance id is the
+    ;; explicit :spawn-id; the resolved :definition carries the :data-schema.
+    (let [inst-id    :rf.machine-redaction/inline-instance
+          child-spec {:initial     :anon
+                      :data        {:retries 0 :token nil :blob nil}
+                      :data-schema auth-schema
+                      :states      {:anon {} :authed {}}}]
+      (rf/reg-machine :rf.machine-redaction/sup-inline
+        {:initial :starting
+         :states  {:starting {:on {:go :spawning}}
+                   :spawning {:entry (fn [_]
+                                       {:fx [[:rf.machine/spawn
+                                              {:spawn-id   inst-id
+                                               :definition child-spec}]]})}}})
+      (rf/dispatch-sync [:rf.machine-redaction/sup-inline [:noop]])
+      (rf/dispatch-sync [:rf.machine-redaction/sup-inline [:go]])
+      (let [inst-marks (marks/marks-for :event inst-id)]
+        (is (some? (get-in (frame-db) [:rf/runtime :machines :snapshots inst-id]))
+            "an inline-definition actor was spawned")
+        (is (= #{[:data :token]} (set (:sensitive inst-marks)))
+            "inline-definition :data-schema :sensitive? slot bridged under the instance id")
+        (is (= #{[:data :blob]} (set (:large inst-marks)))
+            "inline-definition :data-schema :large? slot bridged under the instance id")))))


### PR DESCRIPTION
## Summary

Closes the spawned-actor `:data-schema` redaction gap triaged in **rf2-fm1cpl** (follow-up to rf2-w46fpt / #3478).

A spawned actor's `:rf.machine/transition` / `:rf.machine/snapshot-updated` trace carries `:machine-id` = the **instance** id (`<type>#<n>` or the explicit `:spawn-id`), NOT the type id. `re-frame.marks/project-machine-tags` resolves redaction marks via `(marks-for :event <machine-id>)`, but the EP-0005 `:data-schema` bridge keys the schema-derived `:sensitive?` / `:large?` marks under the **TYPE** id at `reg-machine*` time. So an instance-id trace's lookup missed the type's marks, and a spawned actor's `:sensitive?` `:data` slot egressed **RAW** past the trace bus / epoch-capture / AI-MCP boundary.

## Verdict: real gap (not a non-issue)

The type's marks do NOT cover spawned-instance egress — the instance id is a distinct key, and nothing bridged marks under it. A singleton/registered machine redacts; its spawned instances did not.

## Fix (minimal)

Re-run the SAME bridge (`registration/register-data-schema-marks!`, promoted to public) at spawn time keyed under the spawned **instance** id, sourced from the resolved spec's `:data-schema`. Covers both registered-type (`:machine-id`) and inline (`:definition`) spawns uniformly. The bridge rides `interop/debug-enabled?` (the egress surface it feeds is already gated), so it DCEs out of production bundles.

## Changes

- `lifecycle_fx/registration.cljc` — `register-data-schema-marks!` made public (was `defn-`); doc explains the per-instance re-key.
- `lifecycle_fx/spawn.cljc` — call the bridge under `spawned-id` right after `install-spawn!` (new `spawn → registration` require; verified acyclic).
- `machine_data_schema_redaction_test.clj` — new spawned-instance section: instance-id marks entry, egress redaction keyed by the instance id, inline-`:definition` coverage.

## Quality gates

- machines JVM `clojure -M:test` — 551 tests, 0 failures
- core JVM `clojure -M:test` — 955 tests, 0 failures
- `npm run test:cljs` — 5954 tests, 0 failures
- `npm run test:elision` — PASS (40/40 sensitive markers absent in production; bridge correctly DCEs)