### PR TITLE
docs(EP): EP-0003 rewind to HTTP-only initial scope, defer GraphQL (rf2-ik9vq4)

### DIFF
--- a/docs/EP/resource-queries.md
+++ b/docs/EP/resource-queries.md
@@ -5,10 +5,15 @@ Status: proposal
 ## Abstract
 
 This enhancement proposes an optional `day8/re-frame2-resources` artifact for
-server-state and external-resource management. The proposal is deliberately
-benchmarked against TanStack Query, RTK Query, SWR, Apollo Client, Relay, and
-`shipclojure/re-frame-query`. Those libraries set the baseline for credible
-resource management in modern SPA development.
+server-state and external-resource management. The initial scope is HTTP-only:
+`reg-resource` / `reg-mutation` over managed HTTP — the re-frame2 answer to the
+REST/HTTP server-state tools (TanStack Query, RTK Query, SWR) and
+`shipclojure/re-frame-query`. GraphQL is a deferred later phase; see
+[Deferred: GraphQL (later phase)](#deferred-graphql-later-phase). The proposal is
+deliberately benchmarked against TanStack Query, RTK Query, SWR, and
+`shipclojure/re-frame-query` for the HTTP core, with Apollo Client and Relay held
+as benchmarks for the deferred GraphQL phase. Those libraries set the baseline
+for credible resource management in modern SPA development.
 
 The goal is not to imitate those libraries. The goal is to implement
 best-in-class resource capabilities for re-frame2, matching the mature
@@ -26,9 +31,10 @@ The public vocabulary should be:
 
 A resource is a named, cached read of remote or external state. A mutation is a
 causal write that may invalidate, patch, or refetch resources. The proposal uses
-"resource" as the public term because it fits route data, HTTP reads, GraphQL
-reads, local persistence, and future non-HTTP sources. "Query" remains a useful
-prior-art term, but it should not be the re-frame2 API name.
+"resource" as the public term because it fits route data, HTTP reads, local
+persistence, and (in the deferred GraphQL phase) GraphQL reads and other future
+non-HTTP sources. "Query" remains a useful prior-art term, but it should not be
+the re-frame2 API name.
 
 The core rule is:
 
@@ -43,12 +49,15 @@ That keeps the proposal inside the re-frame2 ethos:
 - state machines model lifecycles and workflows;
 - tools and AI agents need enumerable, redacted, frame-aware metadata.
 
-The initial implementation should be a read-resource MVP: registration,
-explicit ensure/refetch/invalidate events, passive subscriptions, active owners,
-cache scopes, stale/fresh policy, dedupe, GC, route integration, SSR
-preload/hydration, built-in HTTP and GraphQL read transports, and Xray/tool
+The initial implementation should be a read-resource MVP over HTTP:
+registration, explicit ensure/refetch/invalidate events, passive subscriptions,
+active owners, cache scopes, stale/fresh policy, dedupe, GC, route integration,
+SSR preload/hydration, a built-in managed-HTTP read transport, and Xray/tool
 visibility. It should also define timer policy for stale/GC behavior and
-resolve background-refresh error semantics up front.
+resolve background-refresh error semantics up front. GraphQL read transport is
+explicitly out of the initial scope and is sketched in
+[Deferred: GraphQL (later phase)](#deferred-graphql-later-phase) as a follow-on
+once the HTTP core lands.
 
 Two distinctions are important enough to be part of the first specification:
 
@@ -90,9 +99,7 @@ re-frame2 already has strong primitives for pieces of this:
 
 - `:rf.http/managed` owns transport mechanics such as retry, abort, timeout,
   schema decode, frame-aware replies, test stubs, and structured failure data.
-- GraphQL is common enough, and different enough from endpoint-shaped HTTP, to
-  deserve a first-class v1 transport rather than being treated as a later
-  generic-transport proof of concept.
+  It is the single built-in transport for the initial HTTP-only scope.
 - Pattern-RemoteData gives the canonical `:loading` vs `:fetching` distinction.
 - Routing owns route metadata, `:on-match`, nav-tokens, route transition state,
   and SSR route entry.
@@ -117,28 +124,32 @@ inactive cache retention, mutation invalidation, optimistic updates, hydration,
 and router prefetching table stakes. RTK Query has shown how endpoint
 definitions, subscription reference counts, cache tags, and mutation-driven
 refetching fit into a centralized state model. SWR has made
-stale-while-revalidate behavior feel natural. Apollo and Relay have shown what a
-normalized graph cache can provide when the transport model warrants it.
-`re-frame-query` shows that re-frame applications also need this class of
-abstraction.
+stale-while-revalidate behavior feel natural. `re-frame-query` shows that
+re-frame applications also need this class of abstraction. (Apollo and Relay
+have shown what a normalized graph cache can provide when the transport model
+warrants it; that is the benchmark for the deferred GraphQL phase, not the HTTP
+core — see [Deferred: GraphQL (later phase)](#deferred-graphql-later-phase).)
 
-re-frame2 should treat those as a benchmark suite. If the resource artifact does
-not reach that level of capability, it will merely be another local convention.
-If it reaches that level while preserving re-frame2's causal, inspectable,
-frame-aware architecture, it can be better than the benchmark for re-frame2
-applications.
+re-frame2 should treat the HTTP-shaped tools — TanStack Query, RTK Query, SWR,
+and `re-frame-query` — as the benchmark suite for the initial scope. If the
+resource artifact does not reach that level of capability, it will merely be
+another local convention. If it reaches that level while preserving re-frame2's
+causal, inspectable, frame-aware architecture, it can be better than the
+benchmark for re-frame2 applications.
 
 ## Goals
 
 The resource artifact should:
 
 - make server state an explicit, named, frame-local runtime process;
-- match the expected baseline from TanStack Query, RTK Query, SWR, Apollo/Relay,
-  and `re-frame-query` where those semantics apply;
+- match the expected baseline from TanStack Query, RTK Query, SWR, and
+  `re-frame-query` where those HTTP server-state semantics apply (Apollo/Relay
+  set the bar for the deferred GraphQL phase, not the initial scope);
 - preserve re-frame2's event-causal model by keeping views passive and making
   route/event/machine causes explicit;
-- integrate resource ownership with frames, routes, SSR, managed HTTP, GraphQL,
-  schemas, Xray, traces, privacy elision, and AI tooling;
+- integrate resource ownership with frames, routes, SSR, managed HTTP,
+  schemas, Xray, traces, privacy elision, and AI tooling (with a transport-neutral
+  core that leaves room for the deferred GraphQL transport);
 - make cache identity, scope, staleness, invalidation, liveness, and causality
   visible as data;
 - support route and SSR data loading without component-tree request waterfalls;
@@ -151,6 +162,9 @@ The initial artifact should not:
 
 - make subscription-driven fetching the default causal model;
 - replace ordinary `reg-sub`, `reg-flow`, `:rf.http/managed`, or state machines;
+- ship a GraphQL read or mutation transport in the initial scope — GraphQL is a
+  deferred later phase (see
+  [Deferred: GraphQL (later phase)](#deferred-graphql-later-phase));
 - start with a normalized graph cache;
 - start with a general transport plugin protocol;
 - promise offline persistence, cross-tab broadcast, infinite resources, polling,
@@ -220,8 +234,10 @@ The benchmark dimensions are:
 - cache shape: document/resource cache first, graph normalization later;
 - tooling: inspectable cache entries, causes, owners, timings, and privacy
   state;
-- extensibility: a transport-neutral core with v1 built-ins for managed HTTP and
-  GraphQL, plus a path to later transports without weakening the core semantics.
+- extensibility: a transport-neutral core with a v1 built-in for managed HTTP,
+  plus a path to later transports — GraphQL first (see
+  [Deferred: GraphQL (later phase)](#deferred-graphql-later-phase)) — without
+  weakening the core semantics.
 
 ### TanStack Query
 
@@ -277,21 +293,22 @@ Pattern-RemoteData `:fetching` state.
 The hook-oriented fetch lifecycle is less useful for re-frame2. Subscription
 lifecycle should not be the default cause of network work.
 
-### Apollo and Relay
+### Apollo and Relay (deferred-GraphQL benchmark)
 
 Apollo and Relay show the normalized graph-cache path. That is powerful for
-GraphQL and entity-heavy applications, but it is too much for the first
-resource artifact.
+GraphQL and entity-heavy applications, but it is too much for the first resource
+artifact — and GraphQL itself is out of the initial HTTP-only scope.
 
-re-frame2 should start with a document/resource cache keyed by resource identity
-and canonical params. V1 should still include a GraphQL operation transport, so
-GraphQL applications get route-owned reads, SSR hydration, stale/fresh policy,
-dedupe, invalidation, and Xray visibility immediately. What is deferred is the
-normalized graph cache, entity identity policy, fragment store, and automatic
-graph-derived invalidation associated with a full GraphQL client. This keeps the
-MVP closer to TanStack Query and RTK Query than to Apollo or Relay, while
-leaving room for a future graph-cache or incremental-view artifact where the
-app's data model justifies it.
+The HTTP core starts with a document/resource cache keyed by resource identity
+and canonical params, benchmarked against TanStack Query and RTK Query rather
+than Apollo or Relay. Apollo and Relay are the benchmark for the deferred GraphQL
+phase: when GraphQL lands as a follow-on transport it should first deliver
+operation-level resource caching (route-owned reads, SSR hydration, stale/fresh
+policy, dedupe, invalidation, and Xray visibility), and only later — if the app's
+data model justifies it — the normalized graph cache, entity identity policy,
+fragment store, and automatic graph-derived invalidation associated with a full
+GraphQL client. The full GraphQL rationale and shape is consolidated in
+[Deferred: GraphQL (later phase)](#deferred-graphql-later-phase).
 
 ### shipclojure/re-frame-query
 
@@ -320,10 +337,10 @@ pure.
 
 The re-frame2 artifact should learn from `re-frame-query`, but not clone it.
 re-frame2 needs tighter integration with frames, route metadata, SSR,
-runtime/app-db partitioning, managed HTTP, GraphQL, Xray, privacy egress, and
-AI-readable metadata. It should also avoid making subscription-driven fetching
-the default because that weakens event causality and makes route behavior harder
-to inspect.
+runtime/app-db partitioning, managed HTTP, Xray, privacy egress, and AI-readable
+metadata (with GraphQL integration following in the deferred phase). It should
+also avoid making subscription-driven fetching the default because that weakens
+event causality and makes route behavior harder to inspect.
 
 ## Design Rationale
 
@@ -617,8 +634,9 @@ The default implementation should be a compact transition function, not a
 spawned machine per resource entry. Semantic retry, multi-step negotiation,
 streaming, and workflow-coupled reads can graduate to explicit machines.
 
-Transport retry belongs to the transport adapter, whether that adapter is
-managed HTTP or GraphQL over HTTP. Semantic retry belongs to machines.
+Transport retry belongs to the transport adapter — managed HTTP in the initial
+scope (and any later transport such as the deferred GraphQL one). Semantic retry
+belongs to machines.
 
 ## Specification
 
@@ -651,7 +669,7 @@ V1 should include:
 - route `:resources`;
 - blocking and non-blocking route resources;
 - SSR preload and hydration for route resources;
-- managed HTTP and GraphQL query as built-in read transports;
+- managed HTTP as the single built-in read transport;
 - exact tag invalidation;
 - conditional route resources and clear params-failure behavior;
 - timer policy for stale/fresh and inactive GC;
@@ -668,6 +686,9 @@ First public-beta gate:
 
 Later slices:
 
+- GraphQL read transport (`:rf.graphql/query`) and GraphQL mutations — the first
+  follow-on phase once the HTTP core lands (see
+  [Deferred: GraphQL (later phase)](#deferred-graphql-later-phase));
 - optimistic rollback;
 - generic transport extension protocol;
 - polling and interval revalidation;
@@ -840,18 +861,21 @@ Example:
 Required keys:
 
 - `:params-schema` validates and canonicalizes params;
-- for `:transport :rf.http/managed`, `:request` returns a Spec 014
-  managed-HTTP args map, including the nested `:request` child and top-level
-  keys such as `:decode`, `:accept`, `:retry`, and sensitivity metadata;
-- for `:transport :rf.graphql/query`, operation metadata is supplied through the
-  GraphQL transport keys;
+- for `:transport :rf.http/managed` (the only initial-scope transport),
+  `:request` returns a Spec 014 managed-HTTP args map, including the nested
+  `:request` child and top-level keys such as `:decode`, `:accept`, `:retry`,
+  and sensitivity metadata;
 - `:data-schema` validates successful data when transport decode supports it.
+
+The deferred GraphQL phase adds a `:transport :rf.graphql/query` whose operation
+metadata is supplied through GraphQL transport keys; see
+[Deferred: GraphQL (later phase)](#deferred-graphql-later-phase).
 
 Optional v1 keys:
 
 - `:doc`;
-- `:transport`, one of `:rf.http/managed` or `:rf.graphql/query` for
-  resources;
+- `:transport`, which in the initial scope is `:rf.http/managed` (the only
+  built-in; `:rf.graphql/query` is added in the deferred GraphQL phase);
 - `:stale-after-ms`;
 - `:gc-after-ms`;
 - `:scope`, a function or declarative resolver for the cache scope when the
@@ -869,11 +893,12 @@ Deferred keys:
 - `:infinite`;
 - mutation-only keys such as `:invalidates`, `:optimistic`, and `:rollback`.
 
-`:rf.http/managed` is the existing Spec 014 effect surface.
-`:rf.graphql/query` is a proposed transport supplied by the resources artifact,
-not an already-shipped core effect. Its implementation may lower to managed HTTP
-or a configured GraphQL client, but the resource lifecycle remains the owner of
-identity, staleness, dedupe, invalidation, SSR hydration, and tool metadata.
+`:rf.http/managed` is the existing Spec 014 effect surface and the single
+built-in transport for the initial scope. (The deferred GraphQL phase adds a
+`:rf.graphql/query` transport whose implementation may lower to managed HTTP or a
+configured GraphQL client, while the resource lifecycle remains the owner of
+identity, staleness, dedupe, invalidation, SSR hydration, and tool metadata; see
+[Deferred: GraphQL (later phase)](#deferred-graphql-later-phase).)
 
 For HTTP resources, the runtime owns reply addressing and request correlation.
 The managed-HTTP args returned by `:request` must not supply `:request-id`,
@@ -1182,22 +1207,19 @@ Hydration rules:
 
 ### Transport
 
-V1 should ship with two built-in transports:
+The initial scope ships with a single built-in transport:
 
 ```clojure
 :transport :rf.http/managed
-:transport :rf.graphql/query
 ```
 
-`:rf.graphql/query` is new resources-artifact API, not an existing core fx.
-Spec 014 currently defines managed HTTP; GraphQL-specific batching, persisted
-queries, and client-cache behavior all layer above that transport boundary.
-
 The resource lifecycle, cache identity, owner model, stale/fresh policy,
-invalidation, SSR hydration, and Xray surfaces must be transport-neutral. The
-core should not assume a URL, HTTP method, status code, or request body. Those
-are HTTP transport details. It also should not assume a normalized entity graph,
-fragment store, or GraphQL client cache. Those are GraphQL-client details.
+invalidation, SSR hydration, and Xray surfaces must nonetheless be
+transport-neutral. The core should not assume a URL, HTTP method, status code,
+or request body — those are HTTP transport details — so that the deferred GraphQL
+transport (and any later transport) can plug in without weakening the core
+semantics. It also should not assume a normalized entity graph, fragment store,
+or GraphQL client cache.
 
 For HTTP, the resource runtime lowers an ensure/refetch into managed HTTP:
 
@@ -1223,37 +1245,15 @@ stale-suppression diagnostics, and trace rows. Success and failure events must
 verify frame and generation before writing. Cancellation is an optimization;
 stale suppression is the correctness boundary.
 
-For GraphQL, the resource runtime lowers an ensure/refetch into a GraphQL query
-operation:
-
-```clojure
-[:rf.graphql/query
- {:request-id     request-id
-  :operation-name "UserProfile"
-  :document       user-profile-query
-  :variables      {:id "u-42"}
-  :on-success     [:rf.resource.internal/succeeded
-                   {:resource-key resource-key
-                    :scope        scope
-                    :frame        frame-id
-                    :generation   generation}]
-  :on-failure     [:rf.resource.internal/failed
-                   {:resource-key resource-key
-                    :scope        scope
-                    :frame        frame-id
-                    :generation   generation}]}]
-```
-
-GraphQL support in v1 means operation-level resource caching, route ownership,
-SSR hydration, stale/fresh policy, dedupe, invalidation, redaction, and Xray
-visibility for GraphQL reads. It does not mean Apollo/Relay-style normalized
-entity caching. Normalized graph storage is a later artifact because it needs
-entity identity policy, fragment semantics, cache writes, partial data rules,
-and graph-derived invalidation.
+The deferred GraphQL phase adds a `:rf.graphql/query` transport that lowers
+ensure/refetch into a GraphQL query operation while preserving these same
+invariants; its lowering shape and partial-success policy are in
+[Deferred: GraphQL (later phase)](#deferred-graphql-later-phase).
 
 Generic transport extension is still desirable, and `re-frame-query`
 demonstrates that demand, but it should be a later extension protocol after the
-HTTP and GraphQL built-ins have proven the resource semantics.
+HTTP built-in (and then the GraphQL transport) have proven the resource
+semantics.
 
 ### Race and In-Flight Semantics
 
@@ -1597,52 +1597,8 @@ egress and elision rules.
 The view is passive. The route caused the resource ensure. The runtime owns
 the resource state.
 
-### GraphQL Resource
-
-GraphQL reads use the same resource lifecycle as HTTP reads. The proposed
-resources-artifact transport `:rf.graphql/query` describes the operation; cache
-identity still comes from scope, resource id, and canonical params.
-
-```clojure
-(rf/reg-resource
-  :user/profile
-  {:params-schema
-   [:map [:user-id :string]]
-
-   :data-schema
-   :app/user-profile
-
-   :transport
-   :rf.graphql/query
-
-   :operation-name
-   "UserProfile"
-
-   :document
-   user-profile-query
-
-   :variables
-   (fn [{:keys [user-id]} _ctx]
-     {:id user-id})
-
-   :stale-after-ms
-   30000
-
-   :tags
-   (fn [_params {:keys [user]}]
-     #{[:user/id (:id user)]})})
-```
-
-Rules:
-
-- every variable that changes the remote identity must be represented in
-  resource params;
-- operation name, document hash, variables, and GraphQL endpoint/client id are
-  transport evidence, not a replacement for resource identity;
-- `{data ..., errors ...}` is a distinct GraphQL partial-success case, not
-  automatically the same as HTTP failure;
-- v1 caches the operation result as a resource document. It does not maintain a
-  normalized entity graph.
+(A GraphQL resource example lives in
+[Deferred: GraphQL (later phase)](#deferred-graphql-later-phase).)
 
 ### Event-Driven Ensure
 
@@ -1701,38 +1657,8 @@ Rules:
              :params   params}]]]}))
 ```
 
-### GraphQL Mutation
-
-When the mutation slice lands, the proposed `:rf.graphql/mutation` transport
-should use the same mutation runtime, invalidation, and trace semantics as HTTP
-mutations.
-
-```clojure
-(rf/reg-mutation
-  :user/update-name
-  {:params-schema
-   [:map
-    [:id :string]
-    [:name :string]]
-
-   :transport
-   :rf.graphql/mutation
-
-   :operation-name
-   "UpdateUserName"
-
-   :document
-   update-user-name-mutation
-
-   :variables
-   (fn [{:keys [id name]} _ctx]
-     {:id id
-      :name name})
-
-   :invalidates
-   (fn [{:keys [id]} _result]
-     #{[:user/id id]})})
-```
+(A GraphQL mutation example lives in
+[Deferred: GraphQL (later phase)](#deferred-graphql-later-phase).)
 
 ### Machine-Owned Resource
 
@@ -1762,6 +1688,202 @@ mutations.
 
 The machine remains the semantic workflow. The resource runtime handles cached
 read mechanics.
+
+## Deferred: GraphQL (later phase)
+
+GraphQL is **out of the initial HTTP-only scope** and is a deferred follow-on
+phase, scheduled as the first transport extension once the HTTP core (the
+read-resource MVP plus the HTTP mutation slice) has landed. This section
+consolidates the GraphQL rationale, transport shape, and examples so the design
+reads as "HTTP now, GraphQL later" rather than treating GraphQL as erased.
+
+The analysis below is retained, not normative for the initial scope. None of it
+ships until the HTTP core is stable.
+
+### Why GraphQL Is Deferred (Not Dropped)
+
+GraphQL is common enough, and different enough from endpoint-shaped HTTP, to
+deserve a first-class transport. But shipping it in the initial scope would widen
+the first artifact's design surface (operation/variable identity, partial-success
+semantics, GraphQL-client integration, and SSR hydration for GraphQL reads) while
+the core resource lifecycle is still being proven against the simpler HTTP case.
+Deferring GraphQL keeps the MVP closer to TanStack Query and RTK Query, lets the
+transport-neutral core stabilize first, and then adds GraphQL as the first proof
+that the core genuinely is transport-neutral.
+
+Apollo and Relay are the benchmarks for this phase. They show the normalized
+graph-cache path: powerful for GraphQL and entity-heavy applications, but too much
+even for the first GraphQL slice. When GraphQL lands it should first deliver
+operation-level resource caching — the same lifecycle the HTTP core already
+provides — and only later, if an app's data model justifies it, the normalized
+graph cache, entity identity policy, fragment store, and automatic graph-derived
+invalidation associated with a full GraphQL client (Hasura-/Apollo-/Relay-style).
+Normalized graph storage stays a separate later artifact because it needs entity
+identity policy, fragment semantics, cache writes, partial data rules, and
+graph-derived invalidation.
+
+### GraphQL Transport Shape
+
+GraphQL reads would use the **same resource lifecycle** as HTTP reads. The
+proposed resources-artifact transport `:rf.graphql/query` describes the operation;
+cache identity still comes from scope, resource id, and canonical params.
+`:rf.graphql/query` is new resources-artifact API, not an existing core fx;
+GraphQL-specific batching, persisted queries, and client-cache behavior all layer
+above the transport boundary. Its implementation may lower to managed HTTP or a
+configured GraphQL client/endpoint, but the resource runtime stays the owner of
+identity, staleness, dedupe, invalidation, SSR hydration, and tool metadata.
+
+The resource runtime would lower an ensure/refetch into a GraphQL operation:
+
+```clojure
+[:rf.graphql/query
+ {:request-id     request-id
+  :operation-name "UserProfile"
+  :document       user-profile-query
+  :variables      {:id "u-42"}
+  :on-success     [:rf.resource.internal/succeeded
+                   {:resource-key resource-key
+                    :scope        scope
+                    :frame        frame-id
+                    :generation   generation}]
+  :on-failure     [:rf.resource.internal/failed
+                   {:resource-key resource-key
+                    :scope        scope
+                    :frame        frame-id
+                    :generation   generation}]}]
+```
+
+Equivalently, lowered through the configured GraphQL client/endpoint:
+
+```clojure
+{:operation-kind :query
+ :operation-name "UserProfile"
+ :document       user-profile-query
+ :variables      {:id "u-42"}
+ :request-id     request-id
+ :on-success     [:rf.resource.internal/succeeded
+                  {:resource-key resource-key
+                   :scope        scope
+                   :generation   generation
+                   :frame        frame-id}]
+ :on-failure     [:rf.resource.internal/failed
+                  {:resource-key resource-key
+                   :scope        scope
+                   :generation   generation
+                   :frame        frame-id}]}
+```
+
+The GraphQL adapter must preserve the same resource invariants as HTTP:
+
+- generation checks are the correctness boundary;
+- abort is best-effort;
+- stale suppression is mandatory;
+- route and SSR ownership are unchanged;
+- scopes and params still define resource identity;
+- operation/document/variable summaries are visible to Xray with the same
+  privacy and size elision as HTTP request metadata.
+
+GraphQL support in this phase means operation-level resource caching, route
+ownership, SSR hydration, stale/fresh policy, dedupe, invalidation, redaction, and
+Xray visibility for GraphQL reads. It does not mean Apollo/Relay-style normalized
+entity caching.
+
+GraphQL partial success needs explicit policy. A response with both `data` and
+`errors` is a distinct GraphQL partial-success case, not automatically the same as
+HTTP failure: it may become loaded data plus a transport warning, a
+`:refresh-error` while preserving prior data, or a first-load `:error`, depending
+on resource policy. It must not be silently treated as ordinary success.
+
+### Deferred Example: GraphQL Resource
+
+```clojure
+(rf/reg-resource
+  :user/profile
+  {:params-schema
+   [:map [:user-id :string]]
+
+   :data-schema
+   :app/user-profile
+
+   :transport
+   :rf.graphql/query
+
+   :operation-name
+   "UserProfile"
+
+   :document
+   user-profile-query
+
+   :variables
+   (fn [{:keys [user-id]} _ctx]
+     {:id user-id})
+
+   :stale-after-ms
+   30000
+
+   :tags
+   (fn [_params {:keys [user]}]
+     #{[:user/id (:id user)]})})
+```
+
+Rules:
+
+- every variable that changes the remote identity must be represented in
+  resource params;
+- operation name, document hash, variables, and GraphQL endpoint/client id are
+  transport evidence, not a replacement for resource identity;
+- `{data ..., errors ...}` is a distinct GraphQL partial-success case, not
+  automatically the same as HTTP failure;
+- this phase caches the operation result as a resource document. It does not
+  maintain a normalized entity graph.
+
+### Deferred Example: GraphQL Mutation
+
+When the GraphQL phase lands (after the HTTP mutation slice), the proposed
+`:rf.graphql/mutation` transport should use the same mutation runtime,
+invalidation, and trace semantics as HTTP mutations.
+
+```clojure
+(rf/reg-mutation
+  :user/update-name
+  {:params-schema
+   [:map
+    [:id :string]
+    [:name :string]]
+
+   :transport
+   :rf.graphql/mutation
+
+   :operation-name
+   "UpdateUserName"
+
+   :document
+   update-user-name-mutation
+
+   :variables
+   (fn [{:keys [id name]} _ctx]
+     {:id id
+      :name name})
+
+   :invalidates
+   (fn [{:keys [id]} _result]
+     #{[:user/id id]})})
+```
+
+### Deferred GraphQL Conformance
+
+When the GraphQL phase is built, its conformance fixtures should add to the HTTP
+suite:
+
+- GraphQL resource requests preserve generation/frame stale-suppression parity
+  with HTTP;
+- GraphQL partial-success (`data` + `errors`) policy resolves to loaded data,
+  `:refresh-error`, or first-load `:error` per resource policy and never silent
+  success;
+- GraphQL operation/document/variable summaries are redacted to Xray with the
+  same privacy/size elision as HTTP request metadata;
+- GraphQL reads participate in route ownership, SSR hydration, dedupe, and tag
+  invalidation identically to HTTP reads.
 
 ## Backwards Compatibility
 
@@ -1817,12 +1939,15 @@ re_frame.resources.state
 re_frame.resources.events
 re_frame.resources.transport
 re_frame.resources.transport.http
-re_frame.resources.transport.graphql
 re_frame.resources.subs
 re_frame.resources.route
 re_frame.resources.ssr
 re_frame.resources.test-support
 ```
+
+The deferred GraphQL phase adds a `re_frame.resources.transport.graphql`
+namespace; it is not part of the initial HTTP-only build (see
+[Deferred: GraphQL (later phase)](#deferred-graphql-later-phase)).
 
 Facade integration:
 
@@ -1932,9 +2057,10 @@ Implement internal events:
 10. issue the selected built-in transport effect;
 11. record generation, request id, and trace data.
 
-### 5. Managed HTTP and GraphQL Integration
+### 5. Managed HTTP Integration
 
-For `:transport :rf.http/managed`, lower a resource request into managed HTTP.
+For `:transport :rf.http/managed` — the only initial-scope transport — lower a
+resource request into managed HTTP.
 
 The reply event must carry enough data to verify generation and frame:
 
@@ -1949,41 +2075,10 @@ The reply event must carry enough data to verify generation and frame:
 If generation does not match, suppress the reply and emit trace metadata. A
 stale reply must never overwrite newer data.
 
-For `:transport :rf.graphql/query`, lower the resource to a GraphQL operation
-over the configured GraphQL client or endpoint:
-
-```clojure
-{:operation-kind :query
- :operation-name "UserProfile"
- :document       user-profile-query
- :variables      {:id "u-42"}
- :request-id     request-id
- :on-success     [:rf.resource.internal/succeeded
-                  {:resource-key resource-key
-                   :scope        scope
-                   :generation   generation
-                   :frame        frame-id}]
- :on-failure     [:rf.resource.internal/failed
-                  {:resource-key resource-key
-                   :scope        scope
-                   :generation   generation
-                   :frame        frame-id}]}
-```
-
-The GraphQL adapter must preserve the same resource invariants as HTTP:
-
-- generation checks are the correctness boundary;
-- abort is best-effort;
-- stale suppression is mandatory;
-- route and SSR ownership are unchanged;
-- scopes and params still define resource identity;
-- operation/document/variable summaries are visible to Xray with the same
-  privacy and size elision as HTTP request metadata.
-
-GraphQL partial success needs explicit policy. A response with both `data` and
-`errors` may become loaded data plus a transport warning, a `:refresh-error`
-while preserving prior data, or a first-load `:error`, depending on resource
-policy. It must not be silently treated as ordinary success.
+The deferred GraphQL phase adds `:transport :rf.graphql/query` integration that
+lowers the resource into a GraphQL operation while preserving these same
+invariants; its lowering shape and partial-success policy are in
+[Deferred: GraphQL (later phase)](#deferred-graphql-later-phase).
 
 ### 6. Subscriptions
 
@@ -2160,7 +2255,7 @@ The v1 artifact should be considered acceptable when it includes:
 - non-liveness causes;
 - explicit cache scopes and scope clearing;
 - route `:resources`;
-- managed HTTP and GraphQL query transports;
+- managed HTTP as the single built-in transport;
 - canonical params;
 - exact tag invalidation;
 - stale/fresh policy;
@@ -2184,6 +2279,8 @@ The first public-beta gate should add:
 
 The following capabilities are explicitly deferred beyond those first slices:
 
+- GraphQL read/mutation transport — the first follow-on phase (see
+  [Deferred: GraphQL (later phase)](#deferred-graphql-later-phase));
 - optimistic rollback;
 - generic transport extension protocol;
 - polling/interval revalidation;
@@ -2223,8 +2320,8 @@ Structural advantages inside re-frame2:
 - explicit owner/cause separation, so liveness and causality do not blur;
 - cache scopes for auth, tenant, locale, impersonation, and SSR correctness;
 - runtime-owned state that ordinary app-db writes cannot clobber;
-- built-in managed HTTP and GraphQL transports over a transport-neutral resource
-  lifecycle;
+- a built-in managed-HTTP transport over a transport-neutral resource lifecycle
+  (with the deferred GraphQL transport plugging into the same lifecycle);
 - schema-aware params and decoded data;
 - derived projections through ordinary subscriptions instead of a query-local
   `:select` hook;
@@ -2270,10 +2367,11 @@ re-frame2 runtime process.
    Recommendation: use the same error envelope shape as `:error`, plus
    timestamp/attempt metadata if useful. `:status :error` is reserved for
    first-load failure with no usable data.
-8. Should GraphQL be part of v1, or deferred behind a generic transport
-   protocol?
-   Recommendation: GraphQL query should be a v1 built-in alongside managed
-   HTTP. The generic transport extension protocol should still be deferred.
+8. Should GraphQL be part of the initial scope, or deferred to a later phase?
+   Recommendation: defer GraphQL. The initial scope is HTTP-only over managed
+   HTTP; the GraphQL read transport (`:rf.graphql/query`) is the first follow-on
+   phase once the HTTP core lands, ahead of the generic transport extension
+   protocol. See [Deferred: GraphQL (later phase)](#deferred-graphql-later-phase).
 9. What is the cache scope shape?
    Recommendation: make scope explicit EDN and part of the resource key, with
    `[:rf.scope/global]` as the default and `clear-scope` for logout/account
@@ -2306,6 +2404,10 @@ one is.
 
 ## Bead Structure
 
+The initial HTTP-only scope is the bead sequence below. GraphQL beads are a
+deferred follow-on phase (see
+[Deferred: GraphQL (later phase)](#deferred-graphql-later-phase)).
+
 1. EP/spec bead: turn this proposal into a normative spec.
 2. Artifact skeleton bead: create `day8/re-frame2-resources`, facade wrappers,
    feature probes, and `:resource` registrar metadata.
@@ -2314,28 +2416,35 @@ one is.
    state.
 4. Managed HTTP bead: ensure/refetch/success/failure over `:rf.http/managed`,
    dedupe, generation checks, and stale reply suppression.
-5. GraphQL transport bead: `:rf.graphql/query`, operation metadata, variables,
-   partial-success policy, SSR hydration, trace summaries, and parity with the
-   resource lifecycle used by HTTP.
-6. Invalidation/GC bead: tags, active owners, owner indexes, stale marking,
+5. Invalidation/GC bead: tags, active owners, owner indexes, stale marking,
    active refetch, causes, stale/GC timer policy, scope clearing, and inactive
    GC.
-7. Route integration bead: `:resources`, nav-token owners, blocking resources,
+6. Route integration bead: `:resources`, nav-token owners, blocking resources,
    `:when`, dependent route resources, `:keep-previous?`, release on leave, and
    preserved `:on-match` behavior.
-8. SSR/hydration bead: blocking resource drain, resource projection, redaction,
+7. SSR/hydration bead: blocking resource drain, resource projection, redaction,
    scope isolation, projection metadata, and hydration no-double-fetch.
-9. Xray/tool/privacy bead: resource registry panel, route/resource graph,
+8. Xray/tool/privacy bead: resource registry panel, route/resource graph,
    lifecycle timeline, invalidation graph, cache growth view, summaries, trace
    operations, egress policy, and redacted accessors.
-10. Focus/reconnect bead: active-stale scan on browser focus and network
+9. Focus/reconnect bead: active-stale scan on browser focus and network
    reconnect, expressed as resource events with trace records.
-11. Mutation bead: `reg-mutation`, HTTP and GraphQL mutation execution,
-    mutation instance state, patch/populate APIs, invalidation, and trace hooks
-    for later optimistic rollback.
-12. Docs/examples bead: guide chapter, API docs, migration notes from
-    `shipclojure/re-frame-query`, route-driven example, SSR example, and
-    HTTP, GraphQL, and machine-owned resource examples.
+10. Mutation bead (HTTP): `reg-mutation`, HTTP mutation execution over
+    `:rf.http/managed`, mutation instance state, patch/populate APIs,
+    invalidation, and trace hooks for later optimistic rollback.
+11. Docs/examples bead: guide chapter, API docs, migration notes from
+    `shipclojure/re-frame-query`, route-driven example, SSR example, and HTTP and
+    machine-owned resource examples.
+
+Deferred GraphQL-phase beads (after the HTTP core lands):
+
+- GraphQL transport bead: `:rf.graphql/query`, operation metadata, variables,
+  partial-success policy, SSR hydration, trace summaries, and parity with the
+  resource lifecycle used by HTTP.
+- GraphQL mutation bead: `:rf.graphql/mutation` execution reusing the HTTP
+  mutation runtime, invalidation, and trace semantics.
+- GraphQL docs/examples bead: GraphQL resource and mutation examples added to the
+  guide and EP.
 
 ## Sources Consulted
 


### PR DESCRIPTION
Winds EP-0003 (Resource Queries) back so the **initial scope is HTTP-only**; GraphQL is deferred to a clearly-marked later phase. Editorial rescope of the proposal doc only — `Status:` stays `proposal`, no implementation. Per `bd show rf2-ik9vq4`.

## What is now HTTP-core
- Abstract / Motivation / Goals / Non-Goals lead with `reg-resource`/`reg-mutation` over managed HTTP (`:rf.http/managed`) — the TanStack Query / RTK Query / SWR / re-frame-query analog.
- Single built-in transport in the initial scope: `:rf.http/managed`. MVP scope, Acceptance Criteria, Transport section, reg-resource keys, and Reference-Impl section 5 all narrowed to HTTP.
- Benchmark suite for the initial scope: TanStack Query, RTK Query, SWR, re-frame-query (HTTP-shaped). Transport-neutral core preserved so GraphQL can plug in later.
- Bead Structure resequenced: 11 HTTP-core beads; GraphQL beads pulled into a deferred follow-on group. Mutation bead is HTTP-only.

## What moved to deferred-GraphQL
- New consolidated **"Deferred: GraphQL (later phase)"** section (analysis retained, not erased): why-deferred rationale, `:rf.graphql/query` transport shape + both lowering forms, partial-success policy, the GraphQL Resource + GraphQL Mutation examples (relocated from Examples), and a deferred-conformance list.
- Apollo Client + Relay reframed as the benchmark for the deferred GraphQL phase (was: v1 built-in justification). Hasura/normalized-graph-cache material folded in there.
- Open Issue #8 recommendation flipped to "defer GraphQL". Forward-pointers from every former GraphQL touchpoint into the deferred section.

The design reads as "HTTP now, GraphQL later." `docs/EP/README.md` index one-liner already HTTP-led (TanStack/RTK/SWR, no GraphQL mention) — unchanged.

## Quality gates
- `python scripts/check_doc_slugs.py` — pass (exit 0).
- `python -m mkdocs build --strict` — pass (exit 0); no warnings/errors reference the edited file; new `#deferred-graphql-later-phase` anchor resolves.

Closes rf2-ik9vq4.