### PR TITLE
feat(xray): hint to set an editor when open-in-editor is unconfigured (rf2-4s08ov)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1334,7 +1334,16 @@ the user's editor.
 - **No URL-encoding of the path.** The path MUST be passed verbatim
   into the URI — slashes stay slashes, colons stay colons.
 - **No handler-installed fallback.** When the URI's scheme has no
-  registered OS handler, the click MUST be a clean no-op.
+  registered OS handler, the click is a clean no-op at the OS level
+  (the JS layer cannot observe the miss). For a host that has actually
+  CONFIGURED an editor this is the correct best-effort behaviour. For
+  an UNCONFIGURED host (the bare-preload `:vscode` default that neither
+  the host nor the operator confirmed) the panel-side
+  `:rf.xray/open-in-editor` event-fx MUST surface the
+  unconfigured-host DX hint instead of the silent navigation — see
+  [§Unconfigured-host DX hint](#unconfigured-host-dx-hint-rf2-4s08ov)
+  below and
+  [`015-Configuration.md` §Unconfigured-host DX hint](./015-Configuration.md#unconfigured-host-dx-hint-rf2-4s08ov).
 - **Click vector.** The chip MUST invoke navigation by setting
   `window.location.href` (or rendering an `<a href>` and letting the
   browser follow it).
@@ -1390,6 +1399,37 @@ picker** is the per-machine override.
   (`http:` / `https:` / `javascript:` / `data:` / `vbscript:`)
   silently no-ops at the chip — the picker is NOT a route around the
   allowlist.
+
+### Unconfigured-host DX hint (rf2-4s08ov)
+
+A host that wires only the bare preload never sets `:rf.xray/editor`,
+so click-to-source targets the framework default `:vscode`. The URI
+resolves and navigation fires, but if VS Code is not the developer's
+editor the OS has no `vscode:` handler and the click is a silent
+no-op the JS layer cannot detect (the No-handler-installed fallback
+above). rf2-ffijtp documented the fix; rf2-4s08ov makes the chip
+itself guide the developer.
+
+- **Trigger.** The panel-side `:rf.xray/open-in-editor` event-fx reads
+  `config/editor-configured?`. When false — NEITHER the host
+  explicitly set `:rf.xray/editor` NOR a valid operator override is
+  present — the event MUST NOT fire the silent `:rf.editor/open`
+  navigation. It dispatches `:rf.xray/editor-hint-show` instead.
+- **Configured = navigate.** `editor-configured?` is true the moment
+  EITHER the host calls `set-editor!` / `configure!` (an explicit set,
+  even of `:vscode`, counts) OR a valid operator override exists. In
+  that state the click resolves + navigates exactly as before; the
+  hint never fires. A malformed override degrades to unconfigured.
+- **The hint.** A small, non-intrusive bottom-corner toast ("No
+  editor configured") with a one-line note and an **Open Settings**
+  button. The toast is NOT a modal — it does not block the chrome. It
+  is dismissable (✕ / Esc) and self-dismisses on Open-Settings.
+- **Open-Settings.** `:rf.xray/editor-hint-open-settings` dismisses
+  the toast and dispatches `:rf.xray/settings-open`, which lands the
+  operator on the General tab — the editor picker's home.
+- **State.** One boolean app-db slot `:editor-hint-open?` on
+  `:rf/xray`; the `:rf.xray/editor-hint-open?` sub gates the toast
+  mount (mounted at the shell-view root, sibling to the modals).
 
 ### Cross-references
 

--- a/tools/xray/spec/015-Configuration.md
+++ b/tools/xray/spec/015-Configuration.md
@@ -232,6 +232,41 @@ Tests cover the resolution order, the localStorage round-trip, and
 the `open-chip` / `:rf.xray/open-in-editor` consumers under
 `tools/xray/test/day8/re_frame2_xray/settings/editor_override_cljs_test.cljs`.
 
+#### Unconfigured-host DX hint (rf2-4s08ov)
+
+A host that wires only the bare preload never sets `:rf.xray/editor`,
+so the open-in-editor chip targets the framework default `:vscode`.
+The URI resolves and `Location.assign` fires — but if VS Code is not
+the developer's editor, the OS has no `vscode:` protocol handler and
+the click is a **silent no-op** the JS layer cannot observe (the
+no-handler-installed clean-no-op fallback in
+[`007-UX-IA.md` §URI construction](./007-UX-IA.md#uri-construction-normative)).
+rf2-ffijtp documented the fix (hosts MUST set `:rf.xray/editor`);
+rf2-4s08ov surfaces it at click-time.
+
+When `config/editor-configured?` is false — NEITHER the host
+explicitly set `:rf.xray/editor` NOR a valid operator override sits in
+`[:general :editor-override]` — the `:rf.xray/open-in-editor` event-fx
+MUST NOT fire the silent `:rf.editor/open` navigation. Instead it
+dispatches `:rf.xray/editor-hint-show`, which mounts a small,
+non-intrusive bottom-corner toast ("No editor configured") carrying an
+**Open Settings** button that lands the operator on the General-tab
+editor picker (`:rf.xray/editor-hint-open-settings` →
+`:rf.xray/settings-open`). The toast is dismissable (✕ / Esc) and
+self-dismisses on Open-Settings.
+
+`editor-configured?` is true the moment EITHER the host calls
+`set-editor!` / `(configure! {:rf.xray/editor …})` (an explicit set —
+even of `:vscode` — counts as confirmation) OR a valid operator
+override is present. In that state the chip click resolves + navigates
+exactly as before; the hint never fires. A malformed override
+(rejected by `valid-editor-override?`) does NOT count as configured —
+it degrades to the unconfigured state like `get-editor` does.
+
+Tests cover the predicate (`config_test.clj`), the event-fx routing
+(`open_in_editor_cljs_test.cljs`), and the toast events / sub / render
++ Open-Settings wiring (`settings/editor_hint_cljs_test.cljs`).
+
 ### `:rf.xray/project-root`
 
 The on-disk root prepended to the source-coord's classpath-relative

--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -375,6 +375,37 @@
   editor
   (atom :vscode))
 
+;; ---- editor-explicitly-set? (rf2-4s08ov — open-in-editor DX hint) -------
+;;
+;; The `editor` atom defaults to `:vscode`, so a host that NEVER calls
+;; `set-editor!` / `(configure! {:rf.xray/editor …})` is indistinguishable
+;; by VALUE from a host that explicitly chose `:vscode`. That ambiguity
+;; matters for the open-in-editor DX: a bare host gets the `:vscode`
+;; default scheme, but if VS Code is not the developer's editor the OS
+;; has no handler and the click is a SILENT no-op (the URI resolves
+;; fine — `Location.assign` fires — but nothing happens because no OS
+;; protocol handler is registered; JS cannot observe that failure). Per
+;; rf2-ffijtp the fix was documented; rf2-4s08ov surfaces an actionable
+;; "pick an editor in Settings" hint at click-time instead of the
+;; silent no-op.
+;;
+;; This flag records whether the host EXPLICITLY chose an editor.
+;; `set-editor!` sets it true on any non-nil call (the host has signalled
+;; intent — even choosing `:vscode` explicitly counts); a nil reset
+;; clears it back to the unconfigured state. `editor-configured?` (below)
+;; OR's this against a live operator override so the hint fires only when
+;; NEITHER the host nor the operator has confirmed an editor.
+
+(defonce
+  ^{:doc "Atom: did the host EXPLICITLY set `:rf.xray/editor`? Default
+         `false` — the `editor` atom's `:vscode` default is the
+         framework default the host never confirmed. Set `true` by
+         `set-editor!` on any non-nil call. Read by `editor-configured?`
+         to decide whether the open-in-editor click should hint to
+         pick an editor in Settings (rf2-4s08ov)."}
+  editor-explicitly-set?
+  (atom false))
+
 (defn set-editor!
   "Set Xray's 'Open in editor' preference. Hosts call this once at
   boot (typically inside their `app.core` ns alongside any Xray-
@@ -390,9 +421,15 @@
                                    `{line}` / `{column}` placeholders.
     - `nil`               — reset to `:vscode` default.
 
+  Per rf2-4s08ov a non-nil call flips `editor-explicitly-set?` to true
+  (the host has confirmed an editor — even `:vscode` explicitly counts);
+  a nil reset clears the flag back to the unconfigured state so the
+  open-in-editor DX hint re-arms.
+
   Returns nothing."
   [e]
   (reset! editor (or e :vscode))
+  (reset! editor-explicitly-set? (some? e))
   nil)
 
 (defn get-host-editor-default
@@ -470,6 +507,30 @@
                               :value    raw})
                        nil))]
     (or override @editor)))
+
+(defn editor-configured?
+  "True iff an editor has been EFFECTIVELY configured (rf2-4s08ov) —
+  i.e. either the host explicitly set `:rf.xray/editor`
+  (`editor-explicitly-set?`) OR a valid non-nil operator override sits
+  in the `[:general :editor-override]` settings slot.
+
+  False means the open-in-editor target is the implicit framework
+  default (`:vscode`) that NEITHER the host nor the operator has
+  confirmed. In that state a chip click resolves to a `vscode://…` URI
+  and `Location.assign` fires, but if VS Code is not the developer's
+  editor the OS has no protocol handler and the click is a silent
+  no-op. The `:rf.xray/open-in-editor` event-fx reads this predicate
+  and surfaces the 'pick an editor in Settings' hint instead of
+  launching the silent navigation.
+
+  A corrupted / malformed override (rejected by `valid-editor-override?`)
+  does NOT count as configured — it degrades to the unconfigured state
+  exactly like the read-side `get-editor` does."
+  []
+  (let [raw      (try (get-in @settings [:general :editor-override])
+                      (catch #?(:clj Throwable :cljs :default) _ nil))
+        override (when (valid-editor-override? raw) raw)]
+    (boolean (or @editor-explicitly-set? (some? override)))))
 
 ;; ---- *project-root* (rf2-5m5n2 — 'Open in editor' path prefix) ----------
 ;;

--- a/tools/xray/src/day8/re_frame2_xray/open_in_editor.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/open_in_editor.cljs
@@ -325,11 +325,26 @@
   ;; "click → open" trail is observable.
   (rf/reg-event-fx :rf.xray/open-in-editor
     (fn [_ctx [_event-id payload]]
-      (let [coord (coerce-coord payload)
-            uri   (resolve-uri coord)]
-        ;; Always emit the fx — even when uri is nil. `open!` is a
-        ;; no-op for nil, and routing through the fx (rather than
-        ;; short-circuiting in the handler) keeps the side-effect
-        ;; bookkeeping in one place + makes the fx the single
-        ;; instrumentable seam for replay/dev-tools.
-        {:fx [[:rf.editor/open {:uri uri}]]}))))
+      ;; rf2-4s08ov — DX hint when no editor is effectively configured.
+      ;; A host that wired only the bare preload (never called
+      ;; `(xray-config/configure! {:rf.xray/editor …})`) and an operator
+      ;; who never set an override are both targeting the implicit
+      ;; framework default `:vscode`. The URI resolves fine and
+      ;; `Location.assign` fires — but if VS Code is not the developer's
+      ;; editor the OS has no `vscode:` handler and the click is a
+      ;; silent no-op (rf2-ffijtp). Instead of that silent navigation,
+      ;; surface the 'pick an editor in Settings' toast so the chip
+      ;; itself guides the developer. Once EITHER the host or the
+      ;; operator has confirmed an editor (`config/editor-configured?`),
+      ;; the click resolves + navigates exactly as before — the hint
+      ;; never fires.
+      (if-not (config/editor-configured?)
+        {:fx [[:dispatch [:rf.xray/editor-hint-show]]]}
+        (let [coord (coerce-coord payload)
+              uri   (resolve-uri coord)]
+          ;; Always emit the fx — even when uri is nil. `open!` is a
+          ;; no-op for nil, and routing through the fx (rather than
+          ;; short-circuiting in the handler) keeps the side-effect
+          ;; bookkeeping in one place + makes the fx the single
+          ;; instrumentable seam for replay/dev-tools.
+          {:fx [[:rf.editor/open {:uri uri}]]})))))

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -61,6 +61,7 @@
             [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.palette :as palette]
+            [day8.re-frame2-xray.settings.editor-hint :as editor-hint]
             [day8.re-frame2-xray.settings.effects :as settings-effects]
             [day8.re-frame2-xray.settings.popup :as settings-popup]
             [day8.re-frame2-xray.spine :as spine]
@@ -829,6 +830,13 @@
     ;; dependency read is clearer.
     (epoch/install!)
     (open-in-editor/install!)
+    ;; rf2-4s08ov — open-in-editor 'pick an editor in Settings' hint
+    ;; toast. Installs before settings-popup since its
+    ;; `:rf.xray/editor-hint-open-settings` event dispatches
+    ;; `:rf.xray/settings-open` (registered by settings-popup), but the
+    ;; registrar resolves dispatch targets lazily so the order is
+    ;; cosmetic.
+    (editor-hint/install!)
     (palette/install!)
     (settings-popup/install!)
     ;; rf2-l4625 — edn-inspector popup overlay (subs + events). The

--- a/tools/xray/src/day8/re_frame2_xray/settings/editor_hint.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/editor_hint.cljs
@@ -1,0 +1,182 @@
+(ns day8.re-frame2-xray.settings.editor-hint
+  "Open-in-editor 'pick an editor in Settings' hint toast (rf2-4s08ov).
+
+  ## The problem (rf2-ffijtp finding)
+
+  Xray's 'Open in editor' chip resolves a source-coord to an editor
+  URI (`vscode://…` by default) and fires `Location.assign`. When the
+  host application wired only the bare preload — it never called
+  `(xray-config/configure! {:rf.xray/editor …})` — the chip targets the
+  framework default `:vscode`. If VS Code is not the developer's editor,
+  the OS has no protocol handler registered for `vscode:` and the click
+  is a SILENT no-op: the URI resolves, `Location.assign` fires, and
+  nothing happens. JS cannot observe the OS-level handler miss, so the
+  developer gets no feedback at all.
+
+  rf2-ffijtp documented the fix (host apps must set `:rf.xray/editor`);
+  rf2-4s08ov surfaces it at click-time so the chip itself guides the
+  developer.
+
+  ## The hint
+
+  When `config/editor-configured?` is false (NEITHER the host nor the
+  operator has confirmed an editor — the target is the implicit
+  framework default), the `:rf.xray/open-in-editor` event-fx routes to
+  `:rf.xray/editor-hint-show` instead of `:rf.editor/open`. This toast
+  appears in the bottom-right of the shell with a one-line note and an
+  'Open Settings' button that lands the operator on the General tab's
+  editor picker. Once an editor IS configured (host or operator), the
+  click resolves and navigates exactly as before — the hint never fires.
+
+  Conservative by design (per the bead): a small, non-intrusive
+  bottom-corner toast, NOT a redesign of Settings and NOT a modal that
+  blocks the chrome. It is dismissable (✕) and self-dismisses the moment
+  the operator opens Settings.
+
+  ## State
+
+  One boolean app-db slot, `:editor-hint-open?`, on the `:rf/xray`
+  frame. Three events + one sub, all installed by `install!`:
+
+      :rf.xray/editor-hint-show          — show the toast
+      :rf.xray/editor-hint-dismiss       — hide the toast (✕ / Esc)
+      :rf.xray/editor-hint-open-settings — open Settings (General) + hide
+      :rf.xray/editor-hint-open?         — sub: drives the toast mount
+
+  Mounted at the shell-view root (sibling to the other modals) so its
+  subscribe resolves through the shell's `:rf/xray` frame-provider."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-xray.theme.tokens
+             :refer [tokens sans-stack mono-stack type-scale]]))
+
+;; ---- events + sub -------------------------------------------------------
+
+(defn install!
+  "Idempotent install for the editor-hint toast's events + sub. Called
+  from `registry/register-xray-handlers!` (gated by the orchestrator's
+  sentinel)."
+  []
+  (rf/reg-event-db :rf.xray/editor-hint-show
+    (fn [db _event]
+      (assoc db :editor-hint-open? true)))
+
+  (rf/reg-event-db :rf.xray/editor-hint-dismiss
+    (fn [db _event]
+      (assoc db :editor-hint-open? false)))
+
+  ;; Open the Settings popup on the General tab (where the editor
+  ;; picker lives) and dismiss the toast in the same reduce. The
+  ;; `:rf.xray/settings-open` handler already resets the active tab to
+  ;; `:general` and seeds the settings snapshot, so opening it lands
+  ;; the operator directly on the editor picker.
+  (rf/reg-event-fx :rf.xray/editor-hint-open-settings
+    (fn [{:keys [db]} _event]
+      {:db (assoc db :editor-hint-open? false)
+       :fx [[:dispatch [:rf.xray/settings-open]]]}))
+
+  (rf/reg-sub :rf.xray/editor-hint-open?
+    (fn [db _query]
+      (boolean (get db :editor-hint-open? false))))
+  nil)
+
+;; ---- styles -------------------------------------------------------------
+
+(defn- toast-style []
+  {:position      "absolute"
+   :right         "16px"
+   :bottom        "16px"
+   :max-width     "300px"
+   :z-index       2147483645
+   :background    (:bg-2 tokens)
+   :border        (str "1px solid " (:warning tokens))
+   :border-radius "6px"
+   :box-shadow    "rgba(0,0,0,0.5) 0 8px 24px"
+   :padding       "12px 14px"
+   :font-family   sans-stack
+   :color         (:text-primary tokens)})
+
+(defn- title-row-style []
+  {:display         "flex"
+   :align-items     "center"
+   :justify-content "space-between"
+   :gap             "8px"
+   :margin-bottom   "6px"})
+
+(defn- dismiss-button-style []
+  {:background    "transparent"
+   :border        "none"
+   :color         (:text-secondary tokens)
+   :font-size     "16px"
+   :line-height   1
+   :cursor        "pointer"
+   :padding       "0 2px"})
+
+(defn- open-settings-button-style []
+  {:background    (:accent tokens)
+   :color         (:white tokens)
+   :border        "none"
+   :padding       "5px 12px"
+   :border-radius "4px"
+   :cursor        "pointer"
+   :font-family   sans-stack
+   :font-size     (:body type-scale)
+   :font-weight   500})
+
+;; ---- view ---------------------------------------------------------------
+
+(defn toast-view
+  "Hiccup for the open editor-hint toast. The caller (`Toast`) gates
+  the mount on `:rf.xray/editor-hint-open?`. `dispatch` (rf2-nesy9) is
+  the frame-aware dispatcher injected by the `reg-view` body so the
+  deferred `:on-click` handlers land on the surrounding instance frame."
+  [dispatch]
+  [:div {:data-testid "rf-xray-editor-hint-toast"
+         :role        "status"
+         :aria-live   "polite"
+         :on-key-down (fn [^js e]
+                        (when (or (= "Escape" (.-key e)) (= "Esc" (.-key e)))
+                          (.stopPropagation e)
+                          (dispatch [:rf.xray/editor-hint-dismiss])))
+         :style       (toast-style)}
+   [:div {:style (title-row-style)}
+    [:span {:style {:font-weight 600
+                    :font-size   (:body type-scale)
+                    :color       (:text-primary tokens)}}
+     "No editor configured"]
+    [:button {:data-testid "rf-xray-editor-hint-dismiss"
+              :aria-label  "Dismiss"
+              :title       "Dismiss"
+              :on-click    (fn [^js e]
+                             (.stopPropagation e)
+                             (dispatch [:rf.xray/editor-hint-dismiss]))
+              :style       (dismiss-button-style)}
+     "✕"]]
+   [:p {:style {:margin    "0 0 10px 0"
+                :font-size (:caption type-scale)
+                :color     (:text-secondary tokens)
+                :line-height 1.45}}
+    "Open-in-editor uses the default "
+    [:code {:style {:font-family mono-stack
+                    :color       (:text-tertiary tokens)}}
+     ":vscode"]
+    " scheme, which does nothing if VS Code is not your editor. "
+    "Pick your editor in Settings to make click-to-source work."]
+   [:button {:data-testid "rf-xray-editor-hint-open-settings"
+             :on-click    (fn [^js e]
+                            (.stopPropagation e)
+                            (dispatch [:rf.xray/editor-hint-open-settings]))
+             :style       (open-settings-button-style)}
+    "Open Settings"]])
+
+(rf/reg-view Toast
+  "The open-in-editor editor-hint toast. Renders only when
+  `:rf.xray/editor-hint-open?` is true; closed-state is a single
+  subscribe + a `when` — cheap.
+
+  Per rf2-in6l2 `reg-view`-registered so the body's subscribes route
+  through the React-context tier to `:rf/xray`. rf2-nesy9 — the
+  reg-view-injected `dispatch` is threaded into `toast-view` so the
+  deferred `:on-click` handlers land on the surrounding instance frame."
+  []
+  (when @(rf/subscribe [:rf.xray/editor-hint-open?])
+    (toast-view dispatch)))

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -141,6 +141,7 @@
             [day8.re-frame2-xray.panels.l2-timeline :as l2-timeline]
             [day8.re-frame2-xray.palette :as palette]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
+            [day8.re-frame2-xray.settings.editor-hint :as editor-hint]
             [day8.re-frame2-xray.settings.popup :as settings-popup]
             [day8.re-frame2-xray.views.edn-inspector-popup
              :as edn-inspector-popup]
@@ -2665,6 +2666,15 @@
     ;; through the shell's `:rf/xray` frame-provider, and the modal
     ;; short-circuits to nil when `:rf.xray/settings-open?` is false.
     [settings-popup/Modal]
+    ;; Open-in-editor 'pick an editor in Settings' hint toast
+    ;; (rf2-4s08ov). Same shell-root mount discipline as the modals so
+    ;; its subscribe resolves through the `:rf/xray` frame-provider; the
+    ;; toast is `position: absolute` in the bottom-right corner and
+    ;; short-circuits to nil when `:rf.xray/editor-hint-open?` is false.
+    ;; Shown when an open-in-editor chip is clicked but no editor is
+    ;; effectively configured (host never set `:rf.xray/editor`, no
+    ;; operator override) — instead of the silent `vscode:` no-op.
+    [editor-hint/Toast]
     ;; Cancellation-cascade popover (rf2-59e7k) — single waterfall view
     ;; of the rf2-wvkn cancellation contract. Opened from the Trace tab
     ;; (right-click a destroy-event row → 'Show cancellation cascade')

--- a/tools/xray/test/day8/re_frame2_xray/config_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/config_test.clj
@@ -49,6 +49,72 @@
     (config/configure! {:rf.xray/editor :idea})
     (is (= :idea (config/get-editor)))))
 
+;; ---- editor-configured? (rf2-4s08ov — open-in-editor DX hint) ----------
+;;
+;; The predicate the open-in-editor event-fx reads to decide whether to
+;; navigate or surface the 'pick an editor in Settings' hint. True iff
+;; the host explicitly set an editor OR a valid operator override exists.
+
+(deftest editor-configured-false-for-bare-default
+  (testing "rf2-4s08ov — a host that never set an editor (the bare
+            framework-default :vscode) is NOT configured"
+    ;; Clear the explicit flag the fixture's `set-editor!` set, and the
+    ;; override slot, to model the bare-preload host.
+    (reset! config/editor-explicitly-set? false)
+    (config/update-setting! :general :editor-override nil)
+    (is (false? (config/editor-configured?)))))
+
+(deftest editor-configured-true-when-host-set
+  (testing "rf2-4s08ov — an explicit set-editor! (even :vscode) counts
+            as configured"
+    (reset! config/editor-explicitly-set? false)
+    (config/update-setting! :general :editor-override nil)
+    (config/set-editor! :vscode)
+    (is (true? (config/editor-configured?))
+        "explicit :vscode counts — the host confirmed the editor")
+    (config/set-editor! :cursor)
+    (is (true? (config/editor-configured?)))))
+
+(deftest editor-configured-cleared-by-nil-reset
+  (testing "rf2-4s08ov — set-editor! nil clears the explicit flag so the
+            hint re-arms"
+    (config/set-editor! :cursor)
+    (is (true? (config/editor-configured?)))
+    (config/set-editor! nil)
+    (config/update-setting! :general :editor-override nil)
+    (is (false? (config/editor-configured?)))))
+
+(deftest editor-configured-true-when-operator-override
+  (testing "rf2-4s08ov — a valid operator override counts as configured
+            even with no host set"
+    (reset! config/editor-explicitly-set? false)
+    (config/update-setting! :general :editor-override :cursor)
+    (is (true? (config/editor-configured?)))
+    ;; A custom-template override also counts.
+    (config/update-setting! :general :editor-override
+                            {:custom "subl://open?url={path}"})
+    (is (true? (config/editor-configured?)))
+    ;; Clean up the override slot for the next test.
+    (config/update-setting! :general :editor-override nil)))
+
+(deftest editor-configured-false-for-malformed-override
+  (testing "rf2-4s08ov — a malformed override (rejected by
+            valid-editor-override?) does NOT count as configured — it
+            degrades to the unconfigured state like get-editor does"
+    (reset! config/editor-explicitly-set? false)
+    (config/update-setting! :general :editor-override :not-a-real-editor)
+    (is (false? (config/editor-configured?)))
+    (config/update-setting! :general :editor-override nil)))
+
+(deftest configure-editor-sets-configured-flag
+  (testing "rf2-4s08ov — configure! {:rf.xray/editor …} flips
+            editor-configured? on (it routes through set-editor!)"
+    (reset! config/editor-explicitly-set? false)
+    (config/update-setting! :general :editor-override nil)
+    (is (false? (config/editor-configured?)))
+    (config/configure! {:rf.xray/editor :cursor})
+    (is (true? (config/editor-configured?)))))
+
 (deftest configure-without-editor-leaves-preference
   (testing "configure! without :rf.xray/editor leaves the preference unchanged"
     (config/set-editor! :cursor)

--- a/tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs
@@ -32,6 +32,12 @@
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
 (defn reset-editor! []
+  ;; rf2-4s08ov — reset the operator-override slot too so a sibling
+  ;; test's `[:general :editor-override]` write does not leak into the
+  ;; chip-render tests' `get-editor` reads. `reset-settings!` clears the
+  ;; whole settings map (incl. the override slot); `set-editor! :vscode`
+  ;; re-arms the host default + the editor-explicitly-set? flag.
+  (config/reset-settings!)
   (config/set-editor! :vscode)
   (config/set-project-root! nil))
 
@@ -487,6 +493,100 @@
       (is (= "vscode://file/C:/Users/me/code/my-app/src/app/views.cljs:42:7"
              (:uri (first @captured-editor-fx)))
           "fx's :uri ≡ chip's :href once :project-root is configured"))))
+
+;; ---- rf2-4s08ov — open-in-editor DX hint when no editor configured ------
+;;
+;; The rf2-ffijtp finding: a host that wired only the bare preload never
+;; set `:rf.xray/editor`, so the chip targets the framework default
+;; `:vscode`. The URI resolves and `Location.assign` fires, but if VS
+;; Code is not the developer's editor the OS has no `vscode:` handler and
+;; the click is a SILENT no-op. Instead of that silent navigation, the
+;; event-fx surfaces the 'pick an editor in Settings' hint toast. The
+;; block below pins the contract:
+;;
+;;   1. When NEITHER the host nor the operator has confirmed an editor
+;;      (`config/editor-configured?` false), the open-in-editor event
+;;      routes to `:rf.xray/editor-hint-show` (NOT `:rf.editor/open`).
+;;   2. Once the host explicitly sets an editor (even `:vscode`), or an
+;;      operator override is present, the click resolves + navigates as
+;;      before — the hint never fires.
+
+(defn- setup-unconfigured!
+  "Like `setup!` but clears the editor-explicitly-set? flag + any
+  operator override so `config/editor-configured?` is false — the bare
+  host scenario rf2-4s08ov targets."
+  []
+  (setup!)
+  ;; `reset-editor!` (via the fixture) called `set-editor! :vscode`,
+  ;; which flips the explicit flag on. Clear it back to the
+  ;; unconfigured framework-default state.
+  (reset! config/editor-explicitly-set? false)
+  (config/update-setting! :general :editor-override nil))
+
+(deftest open-in-editor-event-hints-when-no-editor-configured
+  (testing "rf2-4s08ov — with NO editor effectively configured, the
+            event does NOT fire `:rf.editor/open` (the silent vscode:
+            navigation) — it routes to the editor-hint instead"
+    (setup-unconfigured!)
+    (is (false? (config/editor-configured?))
+        "precondition: editor is the unconfirmed framework default")
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/open-in-editor
+                         {:file "src/x.cljs" :line 1}])
+      (is (= 0 (count @captured-editor-fx))
+          "no `:rf.editor/open` fx fires — the silent vscode: nav is
+           replaced by the hint dispatch")))
+  ;; Reset the override slot so the leaked `nil` write does not bleed
+  ;; into sibling tests' `get-editor` reads.
+  (config/update-setting! :general :editor-override nil))
+
+(deftest editor-hint-show-and-dismiss-flip-the-sub
+  (testing "rf2-4s08ov — the `:rf.xray/editor-hint-show` /
+            `-dismiss` events flip the `:rf.xray/editor-hint-open?`
+            sub (the toast's mount gate)"
+    (setup!)
+    (rf/with-frame :rf/xray
+      (is (false? @(rf/subscribe [:rf.xray/editor-hint-open?]))
+          "closed by default")
+      (rf/dispatch-sync [:rf.xray/editor-hint-show])
+      (is (true? @(rf/subscribe [:rf.xray/editor-hint-open?]))
+          "shown after editor-hint-show")
+      (rf/dispatch-sync [:rf.xray/editor-hint-dismiss])
+      (is (false? @(rf/subscribe [:rf.xray/editor-hint-open?]))
+          "dismissed after editor-hint-dismiss"))))
+
+(deftest open-in-editor-event-navigates-when-host-set-editor
+  (testing "rf2-4s08ov — once the host explicitly sets an editor (even
+            the framework-default :vscode), the click resolves + fires
+            `:rf.editor/open` as before; the hint never fires"
+    (setup-unconfigured!)
+    (config/set-editor! :vscode)
+    (is (true? (config/editor-configured?))
+        "an explicit set — even of :vscode — counts as configured")
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/open-in-editor
+                         {:file "src/x.cljs" :line 1}])
+      (is (= 1 (count @captured-editor-fx))
+          "the open fx fires for an explicitly-configured editor")
+      (is (= "vscode://file/src/x.cljs:1:1"
+             (:uri (first @captured-editor-fx)))))))
+
+(deftest open-in-editor-event-navigates-when-operator-override-set
+  (testing "rf2-4s08ov — an operator override (no host set) also counts
+            as configured: the click navigates, no hint"
+    (setup-unconfigured!)
+    (config/update-setting! :general :editor-override :cursor)
+    (is (true? (config/editor-configured?)))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/open-in-editor
+                         {:file "src/x.cljs" :line 10}])
+      (is (= "cursor://file/src/x.cljs:10:1"
+             (:uri (first @captured-editor-fx)))
+          "the override editor's URI rides the fx"))
+    ;; Reset the override slot so :cursor does not bleed into sibling
+    ;; tests' `get-editor` reads (the fixture resets the editor atom +
+    ;; project-root but NOT the settings override slot).
+    (config/update-setting! :general :editor-override nil)))
 
 ;; ---- click-time navigation (rf2-muvs8) ----------------------------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -344,6 +344,9 @@
    ;; rf2-ttnst — Settings popup expansion convenience subs.
    :rf.xray/density
    :rf.xray/long-keyword-threshold
+   ;; rf2-4s08ov — open-in-editor 'pick an editor in Settings' hint
+   ;; toast mount-gate sub.
+   :rf.xray/editor-hint-open?
    ;; rf2-9poxq — Settings popup subs.
    :rf.xray/setting
    :rf.xray/settings
@@ -487,6 +490,13 @@
    :rf.xray/delete-edit-popup
    :rf.xray/edit-popup-set-mode
    :rf.xray/edit-popup-set-pattern
+   ;; rf2-4s08ov — open-in-editor 'pick an editor in Settings' hint
+   ;; toast events. Shown when an open-in-editor chip is clicked but no
+   ;; editor is effectively configured (instead of a silent vscode:
+   ;; no-op).
+   :rf.xray/editor-hint-show
+   :rf.xray/editor-hint-dismiss
+   :rf.xray/editor-hint-open-settings
    ;; rf2-sc3r1 — Epoch panel per-row expansion events.
    :rf.xray.epoch/toggle-row-expand
    :rf.xray.epoch/clear-row-expand
@@ -1378,6 +1388,11 @@
             contract assertions live in `open_in_editor_cljs_test.cljs`;
             here we pin the registry-level shape only."
     (setup-xray-frame!)
+    ;; rf2-4s08ov — model a wired host: explicitly set an editor so the
+    ;; click navigates (fires `:rf.editor/open`) rather than surfacing
+    ;; the unconfigured-host DX hint. The unconfigured-host branch is
+    ;; covered in `open_in_editor_cljs_test.cljs`.
+    (config/set-editor! :vscode)
     (let [captured (atom [])]
       ;; Replace the open fx with a capture stub (same pattern as the
       ;; time-travel reg-fx tests above).

--- a/tools/xray/test/day8/re_frame2_xray/settings/editor_hint_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/editor_hint_cljs_test.cljs
@@ -1,0 +1,149 @@
+(ns day8.re-frame2-xray.settings.editor-hint-cljs-test
+  "CLJS tests for the open-in-editor 'pick an editor in Settings' hint
+  toast (rf2-4s08ov).
+
+  Asserts:
+  - `:rf.xray/editor-hint-show` / `-dismiss` flip the
+    `:rf.xray/editor-hint-open?` sub.
+  - `Toast` short-circuits to nil when closed, renders the toast +
+    'Open Settings' button when open.
+  - `:rf.xray/editor-hint-open-settings` opens the Settings popup
+    (General tab) and dismisses the toast.
+
+  Uses the explicit map-shape `use-fixtures` (per the `cljs.test/async`
+  requirement — the open-settings test drains the async router queue
+  that the `:rf.xray/editor-hint-open-settings` event-fx's `:dispatch`
+  fx feeds), mirroring `popup_dispatch_routing_cljs_test.cljs`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.settings.editor-hint :as editor-hint]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+;; ---- fixture (map shape per cljs.test/async requirement) ---------------
+
+(def ^:private fixture-snap (atom nil))
+
+(defn- setup-runtime! []
+  (xray-test-support/reset-all!)
+  (trace-collector/reset-for-test!)
+  (config/reset-settings!)
+  (reset! fixture-snap (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (substrate-adapter/install-adapter! plain-atom/adapter)
+  (frame/ensure-default-frame!)
+  (registry/register-xray-handlers!)
+  (frame/reg-frame :rf/xray {}))
+
+(defn- teardown-runtime! []
+  (when-let [snap @fixture-snap]
+    (test-support/restore-registrar! snap)
+    (reset! fixture-snap nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each
+  {:before setup-runtime!
+   :after  teardown-runtime!})
+
+;; ---- hiccup walker (mirrors popup_dispatch_routing) --------------------
+
+(declare expand-tree)
+
+(defn- expand-tree
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+;; ---- events + sub -------------------------------------------------------
+
+(deftest show-and-dismiss-flip-the-sub
+  (rf/with-frame :rf/xray
+    (is (false? @(rf/subscribe [:rf.xray/editor-hint-open?]))
+        "closed by default")
+    (rf/dispatch-sync [:rf.xray/editor-hint-show])
+    (is (true? @(rf/subscribe [:rf.xray/editor-hint-open?]))
+        "show flips the sub on")
+    (rf/dispatch-sync [:rf.xray/editor-hint-dismiss])
+    (is (false? @(rf/subscribe [:rf.xray/editor-hint-open?]))
+        "dismiss flips it back off")))
+
+;; ---- Toast render ------------------------------------------------------
+
+(deftest toast-renders-nil-when-closed
+  (rf/with-frame :rf/xray
+    (is (nil? (editor-hint/Toast))
+        "Toast renders nil when editor-hint-open? is false")))
+
+(deftest toast-renders-when-open
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/editor-hint-show]))
+  (rf/with-frame :rf/xray
+    (let [rendered (editor-hint/Toast)]
+      (is (some? rendered)
+          "Toast renders hiccup when editor-hint-open? is true")
+      (is (find-by-testid rendered "rf-xray-editor-hint-toast")
+          "the toast root is present")
+      (is (find-by-testid rendered "rf-xray-editor-hint-open-settings")
+          "the 'Open Settings' button is present")
+      (is (find-by-testid rendered "rf-xray-editor-hint-dismiss")
+          "the dismiss ✕ button is present"))))
+
+;; ---- open-settings wiring ----------------------------------------------
+
+(deftest open-settings-opens-popup-on-general-and-dismisses
+  (testing "rf2-4s08ov — :rf.xray/editor-hint-open-settings dismisses the
+            toast (synchronously in :db) and opens the Settings popup,
+            which lands on the :general tab (the editor picker's home)"
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/editor-hint-show]))
+    (is (true? (boolean (:editor-hint-open? (rf/app-db-value :rf/xray))))
+        "toast is open before Open-Settings")
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/editor-hint-open-settings]))
+    ;; The :db dismiss is synchronous; the settings-open lands via the
+    ;; async `:dispatch` fx, so poll the router drain before asserting.
+    (async done
+      (-> (test-support/poll-until
+            #(true? (boolean (:settings-open? (rf/app-db-value :rf/xray))))
+            {:label "settings popup opens after editor-hint-open-settings"
+             :timeout-ms 1000})
+          (.then (fn [_]
+                   (let [db (rf/app-db-value :rf/xray)]
+                     (is (false? (boolean (:editor-hint-open? db)))
+                         "the toast is dismissed when Settings opens")
+                     (is (true? (boolean (:settings-open? db)))
+                         "the Settings popup is open")
+                     (is (= :general (:settings-active-tab db))
+                         "Settings opens on the General tab — the editor
+                          picker's home"))
+                   (done)))
+          (.catch (fn [e] (is false (.-message e)) (done)))))))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -348,6 +348,23 @@ async function clickSourceCoordChip(page, { panel, sourceIncludes = [] }) {
 async function assertSourceCoordBridge(page, state, ctx, opts) {
   const beforeUrl = page.url();
   const requestStart = ctx && ctx.browserState ? ctx.browserState.requestFailures.length : 0;
+
+  // rf2-4s08ov — explicitly configure an editor before clicking the
+  // chip. The counter surface (this scenario's host) wires only the
+  // bare preload and never sets `:rf.xray/editor`, so by default the
+  // click would now surface the 'pick an editor in Settings' DX hint
+  // (the intended behaviour for an unconfigured host) instead of
+  // firing the `vscode://` navigation this scenario asserts. Setting
+  // `:vscode` explicitly models a properly-wired host and exercises
+  // the click → `Location.assign` bridge the scenario is about.
+  await page.evaluate(() => {
+    const cfg = window.day8 && window.day8.re_frame2_xray &&
+                window.day8.re_frame2_xray.config;
+    if (cfg && typeof cfg.set_editor_BANG_ === 'function') {
+      cfg.set_editor_BANG_(window.cljs.core.keyword('vscode'));
+    }
+  });
+
   const click = await clickSourceCoordChip(page, opts);
   if (!click.clicked) {
     failWithDetails('Could not click source-coordinate chip', {


### PR DESCRIPTION
## What

When an open-in-editor chip is clicked but **no editor is effectively configured**, surface a small "pick an editor in Settings" toast instead of the silent `vscode:` no-op (the rf2-ffijtp finding).

A host that wires only the bare preload never sets `:rf.xray/editor`, so the chip targets the framework default `:vscode`. The URI resolves and `Location.assign` fires — but if VS Code is not the developer's editor, the OS has no `vscode:` protocol handler and the click is a silent no-op the JS layer cannot observe. rf2-ffijtp documented the fix (hosts must set `:rf.xray/editor`); this makes the chip itself guide the developer.

## Before / after

- **Before:** bare-preload host → click open-in-editor chip → URI resolves to `vscode://…`, `Location.assign` fires, OS has no handler → **nothing happens, no feedback**.
- **After:** bare-preload host → click → bottom-corner toast "No editor configured" with an **Open Settings** button that lands the operator on the General-tab editor picker. Once the host (or operator) configures an editor — even `:vscode` explicitly — the click navigates exactly as before; the hint never fires.

## How

- `config`: `editor-explicitly-set?` flag (set by `set-editor!` on any non-nil call) + `editor-configured?` predicate (true iff the host explicitly set an editor OR a valid operator override exists; a malformed override degrades to unconfigured, like `get-editor`).
- `open-in-editor` event-fx: when `(not (editor-configured?))`, dispatch `:rf.xray/editor-hint-show` instead of firing the silent `:rf.editor/open`.
- `settings/editor-hint` (new ns): the toast — events (`-show` / `-dismiss` / `-open-settings`) + the `:rf.xray/editor-hint-open?` sub + a `reg-view Toast`. Non-intrusive, dismissable (✕ / Esc), self-dismisses on Open-Settings. Mounted at the shell-view root, sibling to the modals.
- feature-matrix gate: the source-coord bridge scenario now sets `:vscode` explicitly before clicking (models a wired host) so the click→`Location.assign` bridge it asserts still fires.
- spec: `015-Configuration.md` + `007-UX-IA.md` document the unconfigured-host DX hint and the `editor-configured?` trigger.

## Quality gates

| Gate | Result |
|------|--------|
| xray `clojure -M:test` (JVM) | 1108 tests, 4589 assertions, 0 failures (config-test: 55 tests incl. the 6 new `editor-configured?` cases) |
| `npm run test:cljs` | 5966 tests, 21155 assertions, 0 failures |
| `npm run test:xray-feature-gate` | 16 scenarios, 0 failures, 13 matrix rows |
| `npm run test:browser` | 197 tests, 593 assertions, 0 failures |

Closes rf2-4s08ov.
