### PR TITLE
docs(reagent-slim): IMPL-SPEC §2.3 — ratom.clj ships only the reaction macro (rf2-n71j3q)

### DIFF
--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -226,7 +226,7 @@ Symbols **not shipped** (per Stage 1 §2.4 + DECISION-7 + Stage 2 §2.7 audit-co
 
 Files:
 - `src/reagent2/ratom.cljs` — type definitions + public Vars.
-- `src/reagent2/ratom.clj` — the `reaction` and `run!` macros (Stage 1 §1.6 marks these SHOULD; Stage 2 §2.6 ships `reaction` as a 5-line indirection over `make-reaction`; `run!` not shipped — zero usage in audits).
+- `src/reagent2/ratom.clj` — the `reaction` macro only (Stage 1 §1.6 marked both `reaction` and `run!` SHOULD; Stage 2 §2.6 ships `reaction` as a 5-line indirection over `make-reaction`). `run!` is not shipped — see the "Symbols not shipped" list below.
 
 Public Vars:
 


### PR DESCRIPTION
Reconciles a self-contradiction in `implementation/adapters/reagent-slim/IMPL-SPEC.md` §2.3.

The section's file list described `src/reagent2/ratom.clj` as providing both the `reaction` AND `run!` macros, while the same section's "Symbols not shipped" list (and the §2.3a negative-space rationale) correctly states `run!` is not shipped. A prior cleanup (PR #3423 review) removed the dead reagent-slim `run!`/`fn?` residue from the code; this aligns the doc to match.

§2.3 now describes `ratom.clj` as shipping the `reaction` macro only. `run!` remains only in the not-shipped note (pointing to the list) and the "Symbols not shipped" list itself — no remaining claim that it ships.

Verified against the actual `src/reagent2/ratom.clj`: only the `reaction` macro is defined; its own docstring documents `run!` as not shipped (audit-confirmed zero usage across re-com / 10x / Dash8 / rf8).

## Quality gates

- Pure doc-wording reconciliation; no code changed; scope confined to `implementation/adapters/reagent-slim/IMPL-SPEC.md`.
- IMPL-SPEC is an adapter-local impl spec, NOT part of the doc site (`docs_dir: docs/`; not referenced in `mkdocs.yml` nav). Per the bead's gate, ran internal-consistency confirmation instead of `check_doc_slugs.py` / `mkdocs build --strict`.
- Internal consistency confirmed: `run!` no longer appears anywhere in §2.3 as a shipped symbol; it survives only in the not-shipped note + list.

Closes rf2-n71j3q.
