### PR TITLE
feat(core): partition accessor/mutator helpers — app-db/runtime-db/frame-state (rf2-q4i9ko)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1213,6 +1213,33 @@
   [frame-id]
   (frame/frame-app-db-value frame-id))
 
+(defn runtime-db-value
+  "Return the current `runtime-db` partition VALUE for the named frame —
+  the framework-owned subsystem state (the `:rf.runtime/*` children), or
+  `nil` for an unknown / destroyed frame. The tool / privileged-runtime
+  read of the framework partition.
+
+  EP-0001 (rf2-q4i9ko): introduces the read surface. The physical
+  runtime-db partition is built by the one-container frame-state work in
+  rf2-adwcv6 (bead 5); until then this reads `nil` even for a live frame.
+  Per Spec 002 §The two-partition frame contract and API.md
+  `runtime-db-value`."
+  [frame-id]
+  (frame/frame-runtime-db-value frame-id))
+
+(defn frame-state-value
+  "Return the coherent frame-state projection for the named frame —
+  `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`, or `nil` for an
+  unknown / destroyed frame. The full-frame read for SSR / epoch /
+  time-travel / Xray.
+
+  EP-0001 (rf2-q4i9ko): composes `app-db-value` with `runtime-db-value`.
+  The `:rf.db/runtime` slot is `nil` until the physical partition lands in
+  rf2-adwcv6 (bead 5); the projection shape is final. Per Spec 002 §The
+  two-partition frame contract and API.md `frame-state-value`."
+  [frame-id]
+  (frame/frame-state-value frame-id))
+
 (defn snapshot-of
   "Return the value at `path` in a frame's app-db — convenience over
   `(get-in (rf/app-db-value frame-id) path)`. Frame resolution:
@@ -1516,6 +1543,91 @@
   when the artefact is absent. Per Tool-Pair §Pair-tool writes
   (rf2-zq55). Late-bound via `:epoch/reset-frame-db!`."}
   reset-frame-db!    rf-epoch/reset-frame-db!)
+
+;; ---- EP-0001 two-partition mutators (rf2-q4i9ko) --------------------------
+;;
+;; Per Spec 002 §Frame-state value accessors and mutators + API.md, the
+;; partition write surface is `replace-app-db!` / `replace-runtime-db!` /
+;; `replace-frame-state!`. This bead (rf2-q4i9ko) introduces the SURFACE
+;; (Mike ruling #1 / #10), NOT the physical partition split.
+;;
+;; - `replace-app-db!` is a true thin alias of the existing app-db
+;;   replacement mechanism — same delegate (`rf-epoch/reset-frame-db!`),
+;;   same synthetic-epoch recording, same gating and failure modes. No
+;;   behavior change: it is the new name for the same write. The rename of
+;;   the legacy `reset-frame-db!` Tool-Pair surface (and the new app-db-only
+;;   `reset-app-db!`) is rf2-tfepxu (bead 9); both names coexist until then.
+;; - `replace-runtime-db!` / `replace-frame-state!` write partitions that
+;;   have no physical slot yet. The one-container frame-state + projection
+;;   reactions land in rf2-adwcv6 (bead 5); the atomic partitioned commit
+;;   path is beads 4-5. Faking a partial write now would be a behavior
+;;   change against today's structure, so these introduce the surface with a
+;;   deferred-semantics throw rather than a no-op that silently loses data.
+
+(def ^{:doc "Replace `frame-id`'s `app-db` partition with `app-db`,
+  bypassing the dispatch loop. The canonical Tool-Pair write surface for
+  app-db state injection — pair tools, story fixtures, conformance
+  harnesses, and time-travel from JSON repros. Records a synthetic
+  `:rf/epoch-record` so `restore-epoch` can rewind. Returns `true` on
+  success, `false` on a documented failure (unknown frame, drain in
+  flight, schema mismatch). Dev-only (gated on `interop/debug-enabled?`).
+  Raises `:rf.error/epoch-artefact-missing` when the epoch artefact is
+  absent.
+
+  EP-0001 (rf2-q4i9ko): thin wrapper — the new partition-aware name for
+  the existing app-db replacement; same delegate and behavior as
+  `reset-frame-db!`. Replaces ONLY the app-db partition; runtime-db is a
+  partition this surface never touches (Mike ruling #10 — a db-shaped
+  name never silently replaces runtime-db). Per Spec 002 §Frame-state
+  value accessors and mutators and API.md `replace-app-db!`."}
+  replace-app-db!    rf-epoch/reset-frame-db!)
+
+(defn replace-runtime-db!
+  "Replace `frame-id`'s `runtime-db` partition with `runtime-db` — the
+  framework-owned subsystem state. Privileged runtime / full-frame tool
+  surface. Returns `true` on success, `false` for an unknown / destroyed
+  frame.
+
+  EP-0001 (rf2-q4i9ko): introduces the SURFACE only. The physical
+  runtime-db partition and its atomic commit path land in rf2-adwcv6
+  (bead 5) + rf2-bvwoi4 (bead 4). There is no runtime-db slot to write
+  today; rather than fake a write that silently drops data, this raises
+  until the partition exists. Per Spec 002 §Frame-state value accessors
+  and mutators and API.md `replace-runtime-db!`."
+  [frame-id _runtime-db]
+  ;; full semantics land in rf2-adwcv6 (bead 5) — the one-container
+  ;; frame-state holds the `:rf.db/runtime` projection this writes.
+  (throw (ex-info "replace-runtime-db! has no physical partition to write yet — the runtime-db partition lands in rf2-adwcv6 (bead 5)"
+                  {:rf.error/id :rf.error/not-yet-implemented
+                   :surface     :replace-runtime-db!
+                   :frame       frame-id
+                   :deferred-to :rf2-adwcv6})))
+
+(defn replace-frame-state!
+  "Replace BOTH partitions of `frame-id` atomically with `frame-state`
+  (`{:rf.db/app … :rf.db/runtime …}`) — the full-frame install for
+  tool-driven replay / fixture install (epoch restore, time travel, SSR
+  hydration, frame reset, test-fixture install). A db-shaped name never
+  silently replaces runtime-db — this is the explicit full-frame surface
+  (Mike ruling #10). Returns `true` on success, `false` for an unknown /
+  destroyed frame.
+
+  EP-0001 (rf2-q4i9ko): introduces the SURFACE only. The single physical
+  frame-state container that makes a two-partition install atomic lands in
+  rf2-adwcv6 (bead 5). There is no container to install both partitions
+  into today; rather than apply only the app-db half (a behavior change
+  that would silently drop the runtime-db half), this raises until the
+  container exists. Per Spec 002 §Frame-state value accessors and mutators
+  and API.md `replace-frame-state!`."
+  [frame-id _frame-state]
+  ;; full semantics land in rf2-adwcv6 (bead 5) — the single frame-state
+  ;; container is what makes the two-partition install one atomic transition.
+  (throw (ex-info "replace-frame-state! has no physical frame-state container to install into yet — the one-container frame-state lands in rf2-adwcv6 (bead 5)"
+                  {:rf.error/id :rf.error/not-yet-implemented
+                   :surface     :replace-frame-state!
+                   :frame       frame-id
+                   :deferred-to :rf2-adwcv6})))
+
 ;; Per Security.md §Epoch privacy posture and rf2-mrsck — single
 ;; normative projection helpers for off-box epoch egress.
 (def ^{:doc "Project an `:rf/epoch-record` for off-box egress — the

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -209,6 +209,51 @@
   (when-let [container (app-db-container id)]
     (adapter/read-container container)))
 
+;; ---- EP-0001 two-partition readers (rf2-q4i9ko) ---------------------------
+;;
+;; Per Spec 002 §The two-partition frame contract a frame owns two durable
+;; partitions — user `app-db` and framework `runtime-db` — projected as a
+;; coherent `frame-state` value `{:rf.db/app … :rf.db/runtime …}`.
+;;
+;; This bead introduces the read SURFACE only (Mike ruling #1). The physical
+;; one-container frame-state + projection reactions land in rf2-adwcv6 (bead
+;; 5); the `:rf.db/runtime` partition has no physical slot until then, so
+;; `frame-runtime-db-value` reads as `nil` today. `frame-state-value`
+;; composes the two readers, so it already yields the correct shape and grows
+;; a populated `:rf.db/runtime` slot for free once bead 5 lands.
+
+(defn frame-runtime-db-value
+  "Read the current runtime-db partition value for a frame — the
+  framework-owned subsystem state (`:rf.runtime/*` children). Returns `nil`
+  for an unknown / destroyed frame.
+
+  EP-0001 (rf2-q4i9ko): the read surface only. The physical runtime-db
+  partition is introduced by the one-container frame-state work in rf2-adwcv6
+  (bead 5); until then there is no runtime-db slot and this reads `nil` for a
+  live frame too. Per Spec 002 §The two-partition frame contract."
+  [id]
+  ;; full semantics land in rf2-adwcv6 (bead 5): once the single frame-state
+  ;; container exists, this reads its `:rf.db/runtime` projection. No physical
+  ;; slot exists yet, so the live value is `nil`; the `(when (frame id) …)`
+  ;; guard keeps the unknown-frame and live-frame answers both `nil` without
+  ;; faking a partition that is not there.
+  (when (frame id)
+    nil))
+
+(defn frame-state-value
+  "Read the coherent frame-state projection for a frame —
+  `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`. Returns `nil` for an
+  unknown / destroyed frame.
+
+  EP-0001 (rf2-q4i9ko): composes `frame-app-db-value` with
+  `frame-runtime-db-value`. The `:rf.db/runtime` slot is `nil` until the
+  physical partition lands in rf2-adwcv6 (bead 5); the shape is final.
+  Per Spec 002 §The two-partition frame contract."
+  [id]
+  (when (frame id)
+    {:rf.db/app     (frame-app-db-value id)
+     :rf.db/runtime (frame-runtime-db-value id)}))
+
 (defn swap-frame-db!
   "Mutate the frame's app-db: read the current value, compute
   `(apply f db args)`, and replace the container with the result. Returns

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -19,6 +19,10 @@
             [re-frame.flows :as flows]
             [re-frame.machines]
             [re-frame.routing]
+            ;; rf2-q4i9ko — replace-app-db! delegates to the epoch artefact's
+            ;; reset-frame-db! (synthetic-epoch recording); load it so the
+            ;; mutator round-trip below resolves a live hook.
+            [re-frame.epoch]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
 (defn reset-runtime [test-fn]
@@ -290,3 +294,75 @@
       (is (contains? wide-ids :wide.a/one))
       (is (contains? wide-ids :wide.b/two))
       (is (not (contains? wide-ids :elsewhere/one))))))
+
+;; ===========================================================================
+;; rf2-q4i9ko — EP-0001 two-partition accessor/mutator helpers (bead 3)
+;;
+;; This bead introduces the SURFACE only (Mike ruling #1 / #10), no behavior
+;; change. The physical runtime-db partition + one-container frame-state land
+;; in rf2-adwcv6 (bead 5); the partition-aware tests come with beads 4-5.
+;; These tests pin: the app-db read/replace round-trip, the frame-state
+;; projection shape, runtime-db reading nil today, and the deferred-semantics
+;; mutators throwing rather than silently dropping data.
+;; ===========================================================================
+
+(deftest app-db-value-and-replace-app-db-round-trip
+  (testing "replace-app-db! then app-db-value round-trips the app-db partition"
+    (rf/reg-frame :pp/round-trip {:doc "round-trip"})
+    (rf/reg-event-db :pp/seed (fn [_ [_ db]] db))
+    (rf/dispatch-sync [:pp/seed {:k 1}] {:frame :pp/round-trip})
+    (is (= {:k 1} (rf/app-db-value :pp/round-trip))
+        "app-db-value reads the seeded app-db")
+    (is (true? (rf/replace-app-db! :pp/round-trip {:k 2 :j 9}))
+        "replace-app-db! returns true on success (thin alias of reset-frame-db!)")
+    (is (= {:k 2 :j 9} (rf/app-db-value :pp/round-trip))
+        "app-db-value reads back exactly what replace-app-db! wrote")))
+
+(deftest app-db-value-unknown-frame-is-nil
+  (testing "app-db-value returns nil for an unknown frame"
+    (is (nil? (rf/app-db-value :pp/no-such-frame)))))
+
+(deftest runtime-db-value-is-nil-until-bead-5
+  (testing "runtime-db-value reads nil — the physical partition lands in bead 5"
+    (rf/reg-frame :pp/runtime {:doc "runtime"})
+    (is (nil? (rf/runtime-db-value :pp/runtime))
+        "live frame: runtime-db has no physical slot yet (rf2-adwcv6)")
+    (is (nil? (rf/runtime-db-value :pp/no-such-frame))
+        "unknown frame: nil")))
+
+(deftest frame-state-value-projection-shape
+  (testing "frame-state-value yields {:rf.db/app … :rf.db/runtime …}"
+    (rf/reg-frame :pp/fs {:doc "frame-state"})
+    (rf/reg-event-db :pp/seed-fs (fn [_ [_ db]] db))
+    (rf/dispatch-sync [:pp/seed-fs {:a 1}] {:frame :pp/fs})
+    (is (= {:rf.db/app {:a 1} :rf.db/runtime nil}
+           (rf/frame-state-value :pp/fs))
+        "app-db slot carries the live app-db; runtime-db slot nil until bead 5")
+    (is (= {:a 1} (:rf.db/app (rf/frame-state-value :pp/fs)))
+        "the :rf.db/app slot equals app-db-value")
+    (is (= (rf/app-db-value :pp/fs) (:rf.db/app (rf/frame-state-value :pp/fs)))
+        "frame-state :rf.db/app is the same value app-db-value returns")))
+
+(deftest frame-state-value-unknown-frame-is-nil
+  (testing "frame-state-value returns nil for an unknown frame"
+    (is (nil? (rf/frame-state-value :pp/no-such-frame)))))
+
+(deftest replace-runtime-db-defers-to-bead-5
+  (testing "replace-runtime-db! throws until the physical partition lands (rf2-adwcv6)"
+    (rf/reg-frame :pp/rdb {:doc "runtime-mutate"})
+    (let [e (try (rf/replace-runtime-db! :pp/rdb {:rf.runtime/machines {}}) nil
+                 (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? e) "replace-runtime-db! must signal rather than silently drop data")
+      (is (= :rf.error/not-yet-implemented (:rf.error/id (ex-data e))))
+      (is (= :rf2-adwcv6 (:deferred-to (ex-data e)))
+          "ex-data names bead 5 as the home of the physical write"))))
+
+(deftest replace-frame-state-defers-to-bead-5
+  (testing "replace-frame-state! throws until the physical container lands (rf2-adwcv6)"
+    (rf/reg-frame :pp/fsm {:doc "frame-state-mutate"})
+    (let [e (try (rf/replace-frame-state! :pp/fsm {:rf.db/app {} :rf.db/runtime {}}) nil
+                 (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? e) "replace-frame-state! must signal rather than apply only the app-db half")
+      (is (= :rf.error/not-yet-implemented (:rf.error/id (ex-data e))))
+      (is (= :rf2-adwcv6 (:deferred-to (ex-data e)))
+          "ex-data names bead 5 as the home of the atomic full-frame install"))))

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -171,12 +171,11 @@
    ;; the impl beads (3-10); these vars don't yet exist as live public vars, so
    ;; the generated manifest cannot carry them. Remove each from this allowlist
    ;; as its impl bead lands and the regenerated manifest picks it up.
-   "runtime-db-value"       ; EP-0001 runtime-db partition reader (002) — unshipped
-   "frame-state-value"      ; EP-0001 frame-state projection reader (002) — unshipped
-   "replace-app-db!"        ; EP-0001 app-db-partition mutator (Tool-Pair; renamed from reset-frame-db!) — unshipped
-   "reset-app-db!"          ; EP-0001 app-db-only reset (Tool-Pair) — unshipped
-   "replace-runtime-db!"    ; EP-0001 runtime-db-partition mutator (Tool-Pair) — unshipped
-   "replace-frame-state!"}  ; EP-0001 full-frame mutator (Tool-Pair) — unshipped
+   ;; rf2-q4i9ko (bead 3) shipped runtime-db-value / frame-state-value /
+   ;; replace-app-db! / replace-runtime-db! / replace-frame-state! as live
+   ;; vars — they are now manifested and classified below, so they are removed
+   ;; from this allowlist.
+   "reset-app-db!"}         ; EP-0001 app-db-only reset (Tool-Pair) — unshipped (rf2-tfepxu / bead 9)
 
  ;; --------------------------------------------------------------------------
  ;; SECONDARY projection-check allowlists (rf2-gkp0t). The keystone guards
@@ -360,6 +359,11 @@
   ["re-frame.core" "frame-ids"]            {:tier :tooling :owner "002" :status "v1"}
   ["re-frame.core" "frame-meta"]           {:tier :tooling :owner "002" :status "v1"}
   ["re-frame.core" "app-db-value"]         {:tier :advanced :owner "002" :status "v1"}
+  ;; EP-0001 two-partition readers (rf2-q4i9ko / bead 3). Per spec/API.md
+  ;; §Public registrar query API rows. Surface introduced ahead of the
+  ;; physical partition (rf2-adwcv6 / bead 5); runtime-db reads nil today.
+  ["re-frame.core" "runtime-db-value"]     {:tier :tooling :owner "002" :status "v1"}
+  ["re-frame.core" "frame-state-value"]    {:tier :tooling :owner "002" :status "v1"}
   ["re-frame.core" "snapshot-of"]          {:tier :tooling :owner "002" :status "v1"}
   ["re-frame.core" "sub-topology"]         {:tier :tooling :owner "002" :status "v1"}
   ["re-frame.core" "sub-cache"]            {:tier :tooling :owner "002" :status "v1"}
@@ -413,6 +417,15 @@
   ["re-frame.core" "epoch-history"]              {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}
   ["re-frame.core" "restore-epoch"]              {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}
   ["re-frame.core" "reset-frame-db!"]            {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}
+  ;; EP-0001 two-partition mutators (rf2-q4i9ko / bead 3). Per spec/API.md
+  ;; §Epoch / Tool-Pair rows. replace-app-db! is a thin alias of the existing
+  ;; app-db replacement (coexists with reset-frame-db! until the rename in
+  ;; rf2-tfepxu / bead 9). The runtime-db / frame-state mutators introduce the
+  ;; surface ahead of the physical partition (rf2-adwcv6 / bead 5) and throw
+  ;; until it exists.
+  ["re-frame.core" "replace-app-db!"]            {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}
+  ["re-frame.core" "replace-runtime-db!"]        {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}
+  ["re-frame.core" "replace-frame-state!"]       {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}
   ["re-frame.core" "register-epoch-listener!"]   {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}
   ["re-frame.core" "unregister-epoch-listener!"] {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}
   ["re-frame.core" "projected-record"]           {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 475,
+ :var-count 480,
  :tier-vocab
  [:front-porch
   :advanced
@@ -114,6 +114,7 @@
   {:namespace "re-frame.core", :var "frame-ids", :tier :tooling, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "frame-meta", :tier :tooling, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "frame-provider", :tier :front-porch, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? false}
+  {:namespace "re-frame.core", :var "frame-state-value", :tier :tooling, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "get-coeffect", :tier :advanced, :kind :fn, :owner "002", :status "v1 (preserved)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "get-effect", :tier :advanced, :kind :fn, :owner "002", :status "v1 (preserved)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "group-cascades", :tier :tooling, :kind :fn, :owner "009", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
@@ -171,12 +172,16 @@
   {:namespace "re-frame.core", :var "render-head", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "render-to-string", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "render-tree-hash", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "replace-app-db!", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "replace-frame-state!", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "replace-runtime-db!", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "require-feature!", :tier :advanced, :kind :fn, :owner "Conventions", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reset-frame!", :tier :advanced, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reset-frame-db!", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "restore-epoch", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "route-link", :tier :advanced, :kind :fn, :owner "012", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "route-url", :tier :advanced, :kind :fn, :owner "012", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "runtime-db-value", :tier :tooling, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "sensitive?", :tier :tooling, :kind :fn, :owner "009", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "set-marks", :tier :advanced, :kind :fn, :owner "015", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "set-schema-explainer!", :tier :advanced, :kind :fn, :owner "010", :status "v1", :facade? true, :runtime-verified? true}


### PR DESCRIPTION
EP-0001 action item 3/10 (`rf2-q4i9ko`). Introduces the two-partition frame **surface** in `implementation/core` (Mike ruling #1 / #10) as thin wrappers with **no behavior change**. The physical one-container frame-state + projection reactions are bead 5 (`rf2-adwcv6`); event-context/commit partitioning is beads 4-5; renaming `reset-frame-db!` is bead 9 (`rf2-tfepxu`).

## What landed

Readers (`re-frame.frame` + `re-frame.core` facade):
- `runtime-db-value` — reads the framework runtime-db partition. Returns `nil` today (no physical slot until bead 5) and `nil` for unknown/destroyed frames.
- `frame-state-value` — composes `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`; projection shape is final, `:rf.db/runtime` grows a populated value for free once bead 5 lands. `nil` for unknown frames.
- `app-db-value` — already present, unchanged.

Mutators (`re-frame.core` facade):
- `replace-app-db!` — **true thin wrapper**: aliases the existing app-db replacement (same delegate `re-frame.epoch/reset-frame-db!`, same synthetic-epoch recording, same gating/failure modes). The partition-aware name; coexists with `reset-frame-db!` until bead 9.
- `replace-runtime-db!` / `replace-frame-state!` — introduce the surface ahead of the physical partition. They **throw** `:rf.error/not-yet-implemented` (ex-data `:deferred-to :rf2-adwcv6`) rather than fake a partial write that would silently drop the runtime-db half — there is no physical slot/container to write into yet.

## Wrapper vs deferred-to-bead-5
- **True wrappers / final now:** `app-db-value`, `runtime-db-value` (reads nil), `frame-state-value` (composition), `replace-app-db!` (alias of existing write).
- **Surface-only, full semantics in bead 5 (`rf2-adwcv6`):** `replace-runtime-db!`, `replace-frame-state!` — and the populated `:rf.db/runtime` slot that `runtime-db-value`/`frame-state-value` will then read.

## Facade-export classification
Per the standing facade-classification rule, the five new `re-frame.core` exports are classified in `spec/api-manifest-metadata.edn`:
- `runtime-db-value`, `frame-state-value` — `:tier :tooling :owner "002" :status "v1"` (matches their `spec/API.md` rows).
- `replace-app-db!`, `replace-runtime-db!`, `replace-frame-state!` — `:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"`.

`spec/api-manifest.edn` regenerated from live vars (475 → 480). The five were removed from the `:api-md-known-unmanifested` allowlist (now shipped); `reset-app-db!` stays in the allowlist as it is bead 9's surface.

## Quality gates
- `npm run test:cljs` — **5969 tests / 21160 assertions, 0 failures, 0 errors**.
- `clojure -M:test` (JVM core, from `implementation/core`) — **962 tests / 4245 assertions, 0 failures, 0 errors** (includes 7 new round-trip/projection/deferred-throw tests in `core_api_additions_test`).
- api-manifest drift-check (`gen --check`) — in sync (480 vars).
- `api-md-check`, `story-spec-check`, `xray-spec-check`, `skills-check`, `doc-guide-check` — all in sync.

Closes `rf2-q4i9ko`.