### PR TITLE
docs(pair-mcp): pilot/ references are historical; point to production tests (rf2-gwqr2o)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
@@ -81,8 +81,9 @@ stdio JSON-RPC were both proven.
 
 ### Trail-of-thought citations
 
-- rf2-5b8e PR #423 (the toolchain pilot — `pilot/` directory is
-  preserved as the smoke harness).
+- rf2-5b8e PR #423 (the toolchain pilot). The pilot lived under a
+  `pilot/` directory; it has since been removed. Its bencode-framing
+  coverage now lives in the production test suite — see Lock #5.
 - Mike's 2026-05-12 locking comment on the PR.
 
 ---
@@ -431,9 +432,15 @@ position-vs-bytes footgun was hit; locked at PR #423 merge.
 ### Trail-of-thought citations
 
 - `tools/re-frame2-pair-mcp/spec/002-nREPL-Transport.md` § Bencode framing.
-- rf2-5b8e PR #423 description (the position-vs-bytes diagnosis).
-- The pilot's `nrepl_test.cljs` unit tests around partial-frame
-  decoding.
+- rf2-5b8e PR #423 description (the position-vs-bytes diagnosis). The
+  pilot once carried the framing unit tests; that coverage now lives
+  in the production test suite at
+  `tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs`,
+  which exercises `decode-all-frames` directly (partial-frame
+  buffering, multi-frame splitting, and the `decode.position` cursor
+  regression). On-wire round-trip coverage rides on the JS harnesses
+  `test/stdio-roundtrip.js`, `test/live-nrepl.js`, and the
+  `test/probe-decode.js` multi-frame walker diagnostic.
 
 ---
 


### PR DESCRIPTION
Reconciles stale `pilot/` references in `tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md`. The `pilot/` directory was deleted but the rationale still claimed it "is preserved as the smoke harness" and cited the pilot's `nrepl_test.cljs` as if live.

- **Lock #1 citation** — was: "`pilot/` directory is preserved as the smoke harness". Now: the pilot lived under `pilot/`; it has since been removed (past tense), with a pointer to the production suite for its coverage.
- **Lock #5 citation** — was: "The pilot's `nrepl_test.cljs` unit tests around partial-frame decoding". Now cites the real current home of bencode-framing coverage: `tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs` (exercises `decode-all-frames` directly — partial-frame buffering, multi-frame splitting, the `decode.position` cursor regression), plus the JS on-wire harnesses `test/stdio-roundtrip.js`, `test/live-nrepl.js`, and the `test/probe-decode.js` walker diagnostic.

Remaining "pilot" mentions are historical past-tense narration (pilot phase, footgun discovery) and left as-is. No code changed; scope confined to `tools/re-frame2-pair-mcp/`.

## Quality gates

- DESIGN-RATIONALE.md is a **tool-local spec**, not in the doc site (no reference in `mkdocs.yml`), so the gate is internal-consistency confirmation rather than `mkdocs build --strict`.
- `git grep -ni 'preserved\|smoke harness' DESIGN-RATIONALE.md` → no matches (the false claim is gone).
- All four cited test paths verified to exist on disk.
- `git grep -n pilot DESIGN-RATIONALE.md` → every remaining mention is historical/past-tense (the L120 hit is the substring inside "Copilot", a host name).
