### PR TITLE
docs(pair-skill): reads also refuse on :ambiguous-frame, not :rf/default (rf2-h3le2q)

### DIFF
--- a/skills/re-frame2-pair/docs/initial-spec.md
+++ b/skills/re-frame2-pair/docs/initial-spec.md
@@ -152,7 +152,7 @@ Structured `{:ok? false :reason ...}` — every script. Recognised reasons:
 | `:debug-disabled` | `interop/debug-enabled?` is false (production build) |
 | `:ns-not-loaded` | `:missing :re-frame2` — re-frame2 isn't loaded into the runtime |
 | `:no-frames-registered` | App hasn't called `(rf/init!)` yet |
-| `:ambiguous-frame` | Multiple frames; mutating ops require explicit selection |
+| `:ambiguous-frame` | Multiple app frames, none selected; both reads and writes refuse rather than default to `:rf/default` — pin one or pass `frame` |
 | `:eval-error`, `:cljs-eval-error` | nREPL or CLJS-eval surfaced an exception |
 | `:no-epoch-recorded` | `dispatch-sync` returned but no record landed; recording disabled or frame destroyed |
 | `:rf.epoch/restore-*` | One of the restore failure modes (Tool-Pair §Time-travel lists seven; six fire under `:rf.epoch/*`, plus **Unknown frame** under `:rf.error/no-such-handler`) |

--- a/skills/re-frame2-pair/references/ops.md
+++ b/skills/re-frame2-pair/references/ops.md
@@ -42,7 +42,7 @@ Most ops wrap a call into `re-frame2-pair.runtime`; for those, the MCP form is `
 
 ## Frames
 
-Set and inspect the operating frame (SKILL.md §Multi-frame model). Every read/write op resolves an operating frame: an explicit per-call `frame: ":foo"` arg wins, else the session pin, else the sole registered **app frame**, else `:ambiguous-frame` for mutating ops.
+Set and inspect the operating frame (SKILL.md §Multi-frame model). Every read/write op resolves an operating frame: an explicit per-call `frame: ":foo"` arg wins, else the session pin, else the sole registered **app frame**, else `:ambiguous-frame`. **Both reads and writes refuse** rather than guess — the read helpers (`subs-sample` / `read-sub!` / `sub-cache-info`) return `:reason :ambiguous-frame` rather than silently reading `:rf/default`.
 
 **Reserved tool frames are excluded from the ambiguity count (rf2-3bu3d.4).** `:rf/*` reserved tool frames — Xray's `:rf/xray`, an SSR slot, … (per [Conventions.md §Reserved namespaces](../../../spec/Conventions.md)) — are devtool surfaces the tooling mounted, not the app you are pairing against, so they are removed before counting. A single-app session that *also* carries an `:rf/xray` frame (the common Xray-instrumented case) has exactly one app frame and resolves to it automatically — **no `frames/select` is needed**. Only a session with two-plus genuine *app* frames is ambiguous. The carve-out is `:rf/default`: it shares the `:rf/*` root but IS the universal default app frame, so it is always counted as an app frame.
 


### PR DESCRIPTION
Two `skills/re-frame2-pair/` doc lines still framed `:ambiguous-frame` as a mutating-op-only refusal, even though frame-targeted **reads also refuse** rather than silently default to `:rf/default`.

- `references/ops.md` §Frames — resolution sentence now states both reads and writes refuse; the read helpers (`subs-sample` / `read-sub!` / `sub-cache-info`) return `:reason :ambiguous-frame` rather than silently reading `:rf/default`.
- `docs/initial-spec.md` reasons table — `:ambiguous-frame` row now says both reads and writes refuse rather than default to `:rf/default`.

Pure doc fix; no code touched. Aligns these two lines with the already-correct framing in `docs/capabilities.md`, `references/errors.md`, `docs/LOCAL_DEV.md`, `spec/design.md`, and `spec/authoring-prompt.md`, and with the actual runtime behavior in `preload/re_frame2_pair/runtime.cljs` (`read-sub!` etc. return `:reason :ambiguous-frame` on a nil frame).

## Quality gates
- `python scripts/check_doc_slugs.py` — EXIT 0
- `python scripts/check_skill_mcp_drift.py` — EXIT 0
- `python scripts/check_skill_pair_authoring_drift.py` — EXIT 0
- No remaining "mutating-op-only" framing in `skills/re-frame2-pair/` docs (the two residual "mutating ops refuse" hits are in test/source comments correctly describing the write-side contract).

Closes rf2-h3le2q.