### PR TITLE
feat(core): event-context partition keys + effect-map widening + runtime-effect diagnostic (rf2-bvwoi4)

### DIFF
--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -122,20 +122,40 @@
 ;; ---- effect-map shape policing (Spec migration M-8) -----------------------
 ;;
 ;; Per migration/from-re-frame-v1/README.md §M-8 and Spec-Schemas.md §:rf/effect-map,
-;; the effect-map a reg-event-fx handler returns is a CLOSED shape: only :db
-;; and :fx live at the top level. Legacy v1 top-level keys (:dispatch,
-;; :dispatch-later, :dispatch-n, :http, etc.) must move into :fx as
-;; [[fx-id args] ...] entries.
+;; the effect-map a reg-event-fx handler returns is a CLOSED shape: only :db,
+;; :rf.db/runtime, and :fx live at the top level. Legacy v1 top-level keys
+;; (:dispatch, :dispatch-later, :dispatch-n, :http, etc.) must move into :fx
+;; as [[fx-id args] ...] entries.
 ;;
-;; The runtime polices this contract: any non-:db / non-:fx top-level key
+;; EP-0001 (rf2-bvwoi4): the partition split widened the closed set from
+;; #{:db :fx} to #{:db :rf.db/runtime :fx} (per Spec-Schemas §:rf/effect-map +
+;; Spec 002 §Write authority). `:db` is the app-db partition (still targets
+;; app-db); `:rf.db/runtime` is the runtime-db partition — the one new
+;; state-bearing top-level key, reserved BY CONVENTION for framework-authority
+;; writers (NOT a security boundary). `:rf.db/runtime` is NOT a shape error
+;; here — a non-framework handler emitting it is surfaced by the
+;; `:rf.warning/app-handler-runtime-effect` dev diagnostic (in
+;; `commit-fx-effects`), not dropped. All OTHER unknown top-level keys remain
+;; shape errors.
+;;
+;; The runtime polices this contract: any top-level key outside the closed set
 ;; emits a structured :rf.error/effect-map-shape trace per Spec 009 §Error
 ;; contract, with :recovery :logged-and-skipped. The offending key is dropped
 ;; (NOT merged silently nor routed through the fx machinery).
 
+(def ^:private closed-effect-map-keys
+  "The closed set of top-level effect-map keys a `reg-event-fx` handler may
+  return. Per Spec-Schemas §:rf/effect-map — `:db` (app-db partition),
+  `:rf.db/runtime` (runtime-db partition, framework-authority by convention,
+  EP-0001 rf2-bvwoi4), and `:fx` (everything else). Widening this set is a
+  Spec change; any other top-level key is a shape error."
+  #{:db :rf.db/runtime :fx})
+
 (defn- police-effect-map-shape!
-  "Emit :rf.error/effect-map-shape for each non-:db / non-:fx top-level key
-  in `effects`. Per Spec migration M-8 the effect-map is closed at the top
-  level. Returns the list of offending keys (which the caller drops).
+  "Emit :rf.error/effect-map-shape for each top-level key in `effects`
+  outside `closed-effect-map-keys`. Per Spec migration M-8 + EP-0001 the
+  effect-map is closed at the top level (`#{:db :rf.db/runtime :fx}`).
+  Returns the list of offending keys (which the caller drops).
 
   Hot-path short-circuit (rf2-4ymm0 EV4): the well-shaped case is the
   overwhelming majority — handlers return `{}`, `{:db ...}`, `{:fx ...}`,
@@ -144,16 +164,16 @@
   via `every?` (no allocation), and fall through to the doseq/vec build
   only when at least one key is offending."
   [effects event]
-  (if (every? #{:db :fx} (keys effects))
+  (if (every? closed-effect-map-keys (keys effects))
     nil
     (let [event-id (when (vector? event) (first event))
           offending (->> (keys effects)
-                         (remove #{:db :fx})
+                         (remove closed-effect-map-keys)
                          (vec))]
       (doseq [k offending]
         (let [v      (get effects k)
               reason (str "Effect-map for `" event-id "` returned top-level key `" k
-                          "`; only `:db` and `:fx` are allowed at the top level.")]
+                          "`; only `:db`, `:rf.db/runtime`, and `:fx` are allowed at the top level.")]
           (trace/emit-error! :rf.error/effect-map-shape
                              {:failing-id        event-id
                               :rf.trace/event-id event-id
@@ -225,19 +245,63 @@
 ;; dispatch table. This collapses the historical db/fx/ctx triple into one
 ;; well-named primitive — adding a new event kind becomes a one-row edit.
 
+(defn- police-runtime-effect-authority!
+  "EP-0001 (rf2-bvwoi4): when `effects` carries a `:rf.db/runtime` effect AND
+  the running handler does NOT have framework-write authority, emit the
+  `:rf.warning/app-handler-runtime-effect` dev diagnostic. `:rf.db/runtime`
+  is reserved BY CONVENTION for framework / runtime-extension code (Mike
+  ruling #4) — NOT a security boundary: the effect is STILL applied (recovery
+  `:warned`); the diagnostic names the runtime-db ownership rule rather than
+  enforcing a capability or silently dropping the effect.
+
+  Framework-minted handlers (today: machine handlers — `assemble-initial-ctx`
+  stamps `:rf/framework-authority? true` from `:rf/machine?`) write
+  `:rf.db/runtime` legitimately and DO NOT fire this diagnostic.
+
+  Dev-only — gated on `interop/debug-enabled?` so production DCE-elides the
+  whole check, the reason string, and the emit (per Spec 009 §Production
+  builds)."
+  [ctx event effects]
+  (when (and interop/debug-enabled?
+             (contains? effects :rf.db/runtime)
+             (not (:rf/framework-authority? ctx)))
+    (let [event-id (when (vector? event) (first event))]
+      (trace/emit! :warning :rf.warning/app-handler-runtime-effect
+                   {:rf.trace/event-id event-id
+                    :rf.event/v        event
+                    :frame             (interceptor/get-coeffect ctx :rf.frame/id)
+                    :recovery          :warned
+                    :reason
+                    (str "Event `" event-id "` returned a reserved `:rf.db/runtime` effect, "
+                         "but is not a framework-authority handler. `:rf.db/runtime` is the "
+                         "framework-owned runtime-db partition — reserved by convention for "
+                         "framework / runtime-extension code, not application handlers. The "
+                         "effect is still applied (convention, not enforcement); ordinary app "
+                         "code should reach subsystem state through public framework "
+                         "subscriptions and effects, and write application data via `:db`.")}))))
+
 (defn- commit-fx-effects
-  "fx-kind commit: enforce the closed effect-map (M-8) and assoc :db / :fx
-  into the context. Bad-return / nil-return policy lives here too — `nil`
-  is the documented legal no-op (rf2-k3bj); any non-map return emits
-  :rf.error/effect-handler-bad-return with :no-recovery and the dispatch
-  becomes a no-op.
+  "fx-kind commit: enforce the closed effect-map (M-8 + EP-0001) and assoc
+  :db / :rf.db/runtime / :fx into the context. Bad-return / nil-return policy
+  lives here too — `nil` is the documented legal no-op (rf2-k3bj); any
+  non-map return emits :rf.error/effect-handler-bad-return with :no-recovery
+  and the dispatch becomes a no-op.
 
   Two shape checks run before commit: `police-effect-map-shape!` rejects
-  non-:db/:fx top-level keys (M-8), and `fx-value-ok?` rejects a
-  non-sequential `:fx` value (rf2-24zly) — both emit
+  top-level keys outside `#{:db :rf.db/runtime :fx}` (M-8 + EP-0001), and
+  `fx-value-ok?` rejects a non-sequential `:fx` value (rf2-24zly) — both emit
   :rf.error/effect-map-shape (:logged-and-skipped) and DROP the offending
   slot, so a malformed effect map never reaches `fx/do-fx` to throw a raw
-  host exception after the :db commit."
+  host exception after the :db commit.
+
+  EP-0001 (rf2-bvwoi4): `:db` targets the app-db partition; `:rf.db/runtime`
+  targets the runtime-db partition (reserved by convention — a non-framework
+  handler emitting it fires `:rf.warning/app-handler-runtime-effect` via
+  `police-runtime-effect-authority!`, but the effect is still committed). The
+  `:rf.db/runtime` effect is assoc'd into the context here; the actual
+  PARTITIONED commit (scoping `:db` to app-db, installing the runtime-db /
+  full-frame write as one atomic frame-state transition) lands in rf2-adwcv6
+  (bead 5)."
   [ctx event effects]
   (cond
     (nil? effects) ctx                       ;; documented legal no-op
@@ -253,8 +317,14 @@
     :else
     (do
       (police-effect-map-shape! effects event)
+      (police-runtime-effect-authority! ctx event effects)
       (cond-> ctx
         (contains? effects :db) (interceptor/assoc-effect :db (:db effects))
+        ;; runtime-db partition effect (EP-0001 rf2-bvwoi4). Carried through the
+        ;; context here; the partitioned/atomic commit path lands in rf2-adwcv6
+        ;; (bead 5). Reserved-by-convention — the authority diagnostic above has
+        ;; already fired for a non-framework writer; the effect is applied either way.
+        (contains? effects :rf.db/runtime) (interceptor/assoc-effect :rf.db/runtime (:rf.db/runtime effects))
         (and (contains? effects :fx)
              (fx-value-ok? effects event)) (interceptor/assoc-effect :fx (:fx effects))))))
 

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -714,8 +714,12 @@
 
   `:db` + `:event` are populated by `assemble-initial-ctx`; `:frame` ditto.
   `:source` + `:trace-id` are envelope keys also surfaced on the cofx
-  map by `assemble-initial-ctx` for handler-body convenience."
-  #{:db :event :frame :source :trace-id})
+  map by `assemble-initial-ctx` for handler-body convenience.
+  `:rf.db/runtime` (the runtime-db partition) + `:rf.frame/id` (the
+  runtime-context frame id) are the EP-0001 partition coeffects, likewise
+  injected by `assemble-initial-ctx` — framework defaults, not user cofx
+  (rf2-bvwoi4)."
+  #{:db :event :frame :source :trace-id :rf.db/runtime :rf.frame/id})
 
 (defn user-injected-coeffects
   "Project the user-injected subset of a coeffects map. Pure data → data.

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -405,16 +405,51 @@
 (defn- assemble-initial-ctx
   "Build the initial interceptor context per the standard shape. Envelope
   keys (:source :trace-id) are surfaced as cofx entries so handler bodies
-  can read them. Per Spec 002 §Routing — the dispatch envelope."
-  [envelope frame frame-record fx-overrides]
-  (let [event     (:event envelope)
-        db-value  (frame/frame-app-db-value frame)]
-    {:coeffects (cond-> {:db    db-value
-                         :event event
-                         :frame frame}
+  can read them. Per Spec 002 §Routing — the dispatch envelope.
+
+  EP-0001 (rf2-bvwoi4) — the event context threads BOTH durable partitions
+  plus the frame id (per Spec 002 §Event context threads both partitions):
+
+    :db            the app-db partition value (the inherited bare key — KEEPS
+                   meaning app-db, NOT the whole frame).
+    :rf.db/runtime the runtime-db partition value, injected BY REFERENCE (no
+                   copy) so a pure app event pays nothing for a partition it
+                   never touches.
+    :rf.frame/id   the running frame's id — the runtime-context spelling of
+                   the frame id, distinct from the public `:frame` opt.
+
+  The runtime-db partition has no physical slot until the one-container
+  frame-state lands in rf2-adwcv6 (bead 5); until then `frame-runtime-db-
+  value` reads `nil` for a live frame, which is the correct injected value
+  (an empty/absent runtime-db). The shape is final — bead 5 grows a populated
+  `:rf.db/runtime` coeffect for free.
+
+  `:rf/framework-authority?` is a NON-coeffect context flag (not visible to
+  handler bodies) recording whether THIS handler has framework-write
+  authority over the reserved `:rf.db/runtime` partition. It is true for
+  framework-minted handlers (today: machine handlers, `:rf/machine? true` —
+  the machine registrar mints a framework-authority handler per Spec 002
+  §Write authority). The effect-commit site reads it to decide whether a
+  returned `:rf.db/runtime` effect is in-bounds or should fire the
+  `:rf.warning/app-handler-runtime-effect` dev diagnostic (reserved BY
+  CONVENTION, not a security boundary — Mike ruling #4). It is NOT a
+  capability gate: the effect is applied either way."
+  [envelope frame frame-record handler-meta fx-overrides]
+  (let [event       (:event envelope)
+        db-value    (frame/frame-app-db-value frame)
+        ;; populated in rf2-adwcv6 (bead 5): the runtime-db partition has no
+        ;; physical slot yet, so this reads `nil` (an absent runtime-db) for a
+        ;; live frame. Injected by reference per Spec 002 §Event context.
+        runtime-db  (frame/frame-runtime-db-value frame)]
+    {:coeffects (cond-> {:db            db-value
+                         :event         event
+                         :frame         frame
+                         :rf.db/runtime runtime-db
+                         :rf.frame/id   frame}
                   (:source envelope)   (assoc :source (:source envelope))
                   (:trace-id envelope) (assoc :trace-id (:trace-id envelope)))
      :effects {}
+     :rf/framework-authority? (boolean (:rf/machine? handler-meta))
      :rf/fx-overrides fx-overrides}))
 
 (def ^:private handler-wrapping-interceptor-ids
@@ -1380,7 +1415,7 @@
         ;; :interceptors` still sees the user-authored chain with the
         ;; handler-wrapper at its tail.
         full-chain      (into [flows-after-interceptor] redacted-chain)
-        initial-ctx     (assemble-initial-ctx envelope frame frame-record fx-overrides)
+        initial-ctx     (assemble-initial-ctx envelope frame frame-record handler-meta fx-overrides)
         all-paths       (into (vec redaction-paths) user-paths)]
     {:full-chain   full-chain
      :initial-ctx  initial-ctx

--- a/implementation/core/test/re_frame/event_context_partition_test.clj
+++ b/implementation/core/test/re_frame/event_context_partition_test.clj
@@ -1,0 +1,181 @@
+(ns re-frame.event-context-partition-test
+  "EP-0001 (rf2-bvwoi4) — event-context partition keys + effect-map widening
+  + the runtime-effect dev diagnostic.
+
+  Pins the event-CONTEXT contract introduced by bead 4 (the partitioned
+  COMMIT is bead 5 / rf2-adwcv6):
+
+    1. `:db` coeffect KEEPS meaning app-db (NOT the whole frame).
+    2. `:rf.db/runtime` + `:rf.frame/id` are present in the event context
+       (per Spec 002 §Event context threads both partitions). `:rf.db/runtime`
+       reads `nil` until the physical partition lands in bead 5.
+    3. The closed effect-map is widened to `#{:db :rf.db/runtime :fx}`
+       (per Spec-Schemas §:rf/effect-map): a `:rf.db/runtime` effect is NOT a
+       shape error, while a foreign top-level key still is.
+    4. `:rf.warning/app-handler-runtime-effect` fires when an ORDINARY app
+       handler returns a `:rf.db/runtime` effect, and DOES NOT fire for a
+       framework-authority handler (`:rf/machine? true`) — reserved BY
+       CONVENTION, not a security boundary (Mike ruling #4). The effect is
+       applied either way (the diagnostic is a warning, not a gate)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (when-let [clear-schemas! (late-bind/get-fn :schemas/clear-by-frame!)]
+    (clear-schemas!))
+  (trace/clear-listeners!)
+  (rf/init! plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- record-traces! [listener-id]
+  (let [a (atom [])]
+    (rf/register-listener! listener-id (fn [ev] (swap! a conj ev)))
+    a))
+
+(defn- warning-events [recorded operation]
+  (filterv (fn [ev]
+             (and (= :warning (:op-type ev))
+                  (= operation (:operation ev))))
+           @recorded))
+
+(defn- error-events [recorded operation]
+  (filterv (fn [ev]
+             (and (= :error (:op-type ev))
+                  (= operation (:operation ev))))
+           @recorded))
+
+;; ===========================================================================
+;; 1 + 2 — event-context partition keys
+;; ===========================================================================
+
+(deftest db-coeffect-is-app-db-not-whole-frame
+  (testing ":db coeffect equals the app-db partition value, not the frame-state"
+    (rf/reg-frame :ctx/db-is-app-db {:doc "ctx"})
+    (rf/reg-event-db :ctx/seed (fn [_ [_ db]] db))
+    (rf/dispatch-sync [:ctx/seed {:user/id 42}] {:frame :ctx/db-is-app-db})
+    (let [captured (atom nil)]
+      (rf/reg-event-ctx :ctx/capture
+        (fn [ctx] (reset! captured (:coeffects ctx)) ctx))
+      (rf/dispatch-sync [:ctx/capture] {:frame :ctx/db-is-app-db})
+      (let [cofx @captured]
+        (is (= {:user/id 42} (:db cofx))
+            ":db is the plain app-db map")
+        (is (= (rf/app-db-value :ctx/db-is-app-db) (:db cofx))
+            ":db equals app-db-value (NOT the {:rf.db/app … :rf.db/runtime …} frame-state)")
+        (is (not (contains? (:db cofx) :rf.db/app))
+            ":db is NOT the frame-state projection")
+        (is (not (contains? (:db cofx) :rf.db/runtime))
+            ":db carries no runtime partition")))))
+
+(deftest runtime-and-frame-id-coeffects-present
+  (testing ":rf.db/runtime and :rf.frame/id are threaded into the event context"
+    (rf/reg-frame :ctx/partitions {:doc "ctx"})
+    (let [captured (atom nil)]
+      (rf/reg-event-ctx :ctx/capture
+        (fn [ctx] (reset! captured (:coeffects ctx)) ctx))
+      (rf/dispatch-sync [:ctx/capture] {:frame :ctx/partitions})
+      (let [cofx @captured]
+        (is (contains? cofx :rf.db/runtime)
+            ":rf.db/runtime coeffect is present (runtime-db partition)")
+        (is (nil? (:rf.db/runtime cofx))
+            ":rf.db/runtime reads nil until the physical partition lands (bead 5 / rf2-adwcv6)")
+        (is (= (rf/runtime-db-value :ctx/partitions) (:rf.db/runtime cofx))
+            ":rf.db/runtime coeffect equals runtime-db-value")
+        (is (= :ctx/partitions (:rf.frame/id cofx))
+            ":rf.frame/id is the running frame's id (runtime-context spelling)")
+        ;; The public `:frame` opt remains unchanged + distinct.
+        (is (= :ctx/partitions (:frame cofx))
+            ":frame coeffect still carries the resolved frame")))))
+
+;; ===========================================================================
+;; 3 — effect-map widening (closed set #{:db :rf.db/runtime :fx})
+;; ===========================================================================
+
+(deftest runtime-db-effect-is-not-a-shape-error
+  (testing "a framework-authority handler returning :rf.db/runtime emits no :rf.error/effect-map-shape"
+    (rf/reg-frame :ctx/runtime-fx {:doc "ctx"})
+    (let [recorded (record-traces! ::no-shape-err)]
+      ;; :rf/machine? marks framework-write authority (machine registrar mints
+      ;; framework-authority handlers — Spec 002 §Write authority).
+      (rf/reg-event-fx :ctx/fw-runtime
+        {:doc "framework-authority runtime write" :rf/machine? true}
+        (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {}} :fx []}))
+      (rf/dispatch-sync [:ctx/fw-runtime] {:frame :ctx/runtime-fx})
+      (is (empty? (error-events recorded :rf.error/effect-map-shape))
+          ":rf.db/runtime is inside the widened closed set — no shape error"))))
+
+(deftest foreign-top-level-key-still-a-shape-error
+  (testing "a foreign top-level key (legacy :http) is still policed after the widening"
+    (rf/reg-frame :ctx/foreign-fx {:doc "ctx"})
+    (let [recorded (record-traces! ::foreign-err)]
+      (rf/reg-event-fx :ctx/foreign
+        (fn [_ _] {:db {:ok? true} :http {:url "/api"}}))
+      (rf/dispatch-sync [:ctx/foreign] {:frame :ctx/foreign-fx})
+      (let [errs (error-events recorded :rf.error/effect-map-shape)]
+        (is (= 1 (count errs))
+            "exactly one shape error for the foreign :http key")
+        (is (= :http (:offending-key (:tags (first errs))))
+            "the offending key is :http")
+        (is (= :logged-and-skipped (:recovery (first errs))))
+        (is (true? (:ok? (rf/app-db-value :ctx/foreign-fx)))
+            "the legal :db still committed; only :http was dropped")))))
+
+;; ===========================================================================
+;; 4 — :rf.warning/app-handler-runtime-effect diagnostic
+;; ===========================================================================
+
+(deftest app-handler-runtime-effect-warns
+  (testing "an ORDINARY app handler returning :rf.db/runtime fires the dev diagnostic"
+    (rf/reg-frame :ctx/app-runtime {:doc "ctx"})
+    (let [recorded (record-traces! ::app-warn)]
+      (rf/reg-event-fx :ctx/app-emits-runtime
+        (fn [_ _] {:rf.db/runtime {:rf.runtime/routing {}}}))
+      (rf/dispatch-sync [:ctx/app-emits-runtime] {:frame :ctx/app-runtime})
+      (let [warns (warning-events recorded :rf.warning/app-handler-runtime-effect)]
+        (is (= 1 (count warns))
+            "exactly one :rf.warning/app-handler-runtime-effect for the non-framework writer")
+        (let [t (:tags (first warns))]
+          (is (= :ctx/app-emits-runtime (:rf.trace/event-id t)))
+          (is (= [:ctx/app-emits-runtime] (:rf.event/v t)))
+          (is (= :ctx/app-runtime (:frame t))
+              ":frame tag is the running frame (read from the :rf.frame/id coeffect)")
+          (is (string? (:reason t)))
+          (is (re-find #"rf\.db/runtime" (:reason t))))
+        (is (= :warned (:recovery (first warns)))
+            "recovery is :warned — convention, not enforcement")))))
+
+(deftest framework-authority-runtime-effect-does-not-warn
+  (testing "a framework-authority handler (:rf/machine? true) does NOT fire the diagnostic"
+    (rf/reg-frame :ctx/fw-authority {:doc "ctx"})
+    (let [recorded (record-traces! ::fw-quiet)]
+      (rf/reg-event-fx :ctx/fw-emits-runtime
+        {:doc "framework-authority" :rf/machine? true}
+        (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {}}}))
+      (rf/dispatch-sync [:ctx/fw-emits-runtime] {:frame :ctx/fw-authority})
+      (is (empty? (warning-events recorded :rf.warning/app-handler-runtime-effect))
+          "the framework-authority path is in-bounds — no diagnostic"))))
+
+(deftest plain-db-fx-handler-does-not-warn
+  (testing "an ordinary handler that does NOT return :rf.db/runtime stays silent"
+    (rf/reg-frame :ctx/plain {:doc "ctx"})
+    (let [recorded (record-traces! ::plain-quiet)]
+      (rf/reg-event-fx :ctx/plain-db
+        (fn [{:keys [db]} _] {:db (assoc db :touched? true) :fx []}))
+      (rf/dispatch-sync [:ctx/plain-db] {:frame :ctx/plain})
+      (is (empty? (warning-events recorded :rf.warning/app-handler-runtime-effect))
+          "no :rf.db/runtime effect ⇒ no diagnostic")
+      (is (true? (:touched? (rf/app-db-value :ctx/plain)))
+          "the :db effect committed normally"))))


### PR DESCRIPTION
EP-0001 action item 4/10 (rf2-bvwoi4). Inject the two-partition keys into the event context and widen the closed effect-map, per the MERGED contract (Spec 002 §Event context, Spec-Schemas §`:rf/effect-map`, Spec 009 §`:rf.warning/app-handler-runtime-effect`). Event-CONTEXT only — the partitioned commit is bead 5 (rf2-adwcv6).

## What changed (implementation/core)

- **`router/assemble-initial-ctx`** — inject `:rf.db/runtime` (runtime-db partition, by reference) + `:rf.frame/id` (runtime-context frame id) coeffects alongside the existing `:db`, which **keeps meaning app-db** (not the whole frame). `runtime-db` reads `nil` until the physical partition lands in bead 5. Stamp `:rf/framework-authority?` (from `:rf/machine?`) onto the context as the diagnostic discriminator.
- **`events/commit-fx-effects` + `police-effect-map-shape!`** — widen the closed effect-map from `#{:db :fx}` to `#{:db :rf.db/runtime :fx}` (new `closed-effect-map-keys` def). Assoc the `:rf.db/runtime` effect into the context. A foreign top-level key is still policed as `:rf.error/effect-map-shape`.
- **`events/police-runtime-effect-authority!`** — emit `:rf.warning/app-handler-runtime-effect` (dev-only, `interop/debug-enabled?`-gated) when a non-framework-authority handler returns `:rf.db/runtime`. Reserved **by convention** (Mike ruling #4): the effect is still applied (`:warned`), not gated/dropped.
- **`fx/framework-coeffect-keys`** — add `:rf.db/runtime` + `:rf.frame/id` so the new framework-default coeffects are filtered out of the `:rf.event/run-end` user-cofx stamp.
- **New test** `core/test/re_frame/event_context_partition_test.clj` — pins all four contract points.

## Deferred to bead 5 (rf2-adwcv6)

The actual partitioned **commit** is NOT built here: scoping `:db` writes to app-db, the runtime/full-frame commit paths, the one physical frame-state container + projection reactions, and `:rf.event/frame-state-changed`. The `:rf.db/runtime` effect is carried in the context but not yet committed (it is inert in the current `:db`-only commit + `:fx`-only `do-fx` paths); `frame-runtime-db-value` reads `nil`, so the injected runtime coeffect is the correct best value until bead 5 populates the partition.

## Quality gates

- `npm run test:cljs` — 5978 tests / 21195 assertions, **0 failures**.
- JVM core `clojure -M:test` — 969 tests / 4269 assertions, **0 failures** (incl. the new test file).
- `npm run test:elision` — production 40/40 absent, control 40/40 present (the dev diagnostic DCE-elides).
- API manifest drift-check — in sync (480 public vars; no new facade export).