### PR TITLE
refactor(story): drop unread body-level props schema slots + reconcile failing-id wording (rf2-hwcdh2 rf2-ahdqu7)

### DIFF
--- a/tools/story/spec/014-Chrome-Features.md
+++ b/tools/story/spec/014-Chrome-Features.md
@@ -96,7 +96,7 @@ The panel projects each trace event into a row. Per
 {:id         <int>              ;; trace event :id (stable per-process key)
  :time       <ms-since-epoch>   ;; from the trace event :time
  :where      <kw>               ;; :event / :sub-return / :cofx / :app-db / :fx-args
- :failing-id <kw|nil>           ;; the artefact id whose :spec failed
+ :failing-id <kw|nil>           ;; the registration/boundary id whose schema validation failed
  :path       <vector|nil>       ;; only for app-db failures
  :received   <any>              ;; the rejected value
  :explain    <any|nil>          ;; the validator's explanation

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -415,14 +415,18 @@
    [:decorators {:optional true} DecoratorRefs]
    [:args       {:optional true} ArgMap]
    [:argtypes   {:optional true} ArgtypesMap]
-   ;; rf2-mantt — explicit view-args/props schema slots. The canonical
-   ;; first-match key order is `[:rf/props :schema]` (per
-   ;; `re-frame.story.malli-schema/view-args-schema-keys`); `:rf/props`
-   ;; wins over `:schema`. The value is a Malli schema form. Declared so
-   ;; a story body that pins its component's props schema (the canonical
-   ;; testbed's `:story.counter-matrix`) validates on the closed map.
-   [:rf/props   {:optional true} :any]
-   [:schema     {:optional true} :any]
+   ;; rf2-hwcdh2 — a story body carries NO `:rf/props` / `:schema`
+   ;; props-schema slot. The view-args (props) schema lives ONLY on the
+   ;; registered `:component` view's `reg-view` metadata (canonical
+   ;; first-match `[:rf/props :schema]` — see `re-frame.story.malli-schema/
+   ;; view-args-schema-keys`). The plan compiler
+   ;; (`re-frame.story.plan/compile-body`) resolves it off the view-meta
+   ;; via `view-lookup`, never off the story/variant body — so a body-level
+   ;; slot passed closed-shape validation but was silently UNREAD (an
+   ;; accepted-but-dead authoring surface). The slots are removed so a
+   ;; props schema authored on the body now FAILS closed-shape validation
+   ;; with `:rf.error/story-shape`, naming the dead key, rather than being
+   ;; swallowed with no effect.
    [:tags       {:optional true} TagSet]
    [:modes      {:optional true} ModeRefSet]
    [:substrates {:optional true} SubstrateSet]
@@ -803,13 +807,20 @@
     [:plays                 {:optional true} PlaysSpec]
     [:args                  {:optional true} ArgMap]
     [:argtypes              {:optional true} ArgtypesMap]
-    ;; rf2-mantt — explicit view-args/props schema slots (canonical
-    ;; first-match order `[:rf/props :schema]`; see the Story schema +
-    ;; `re-frame.story.malli-schema/view-args-schema-keys`). A variant
-    ;; MAY pin a narrower/stricter props schema than its component-wide
-    ;; one. The value is a Malli schema form.
-    [:rf/props              {:optional true} :any]
-    [:schema                {:optional true} :any]
+    ;; rf2-hwcdh2 — a variant body carries NO `:rf/props` / `:schema`
+    ;; props-schema slot. The view-args (props) schema lives ONLY on the
+    ;; registered `:component` view's `reg-view` metadata (canonical
+    ;; first-match `[:rf/props :schema]`; see `re-frame.story.malli-schema/
+    ;; view-args-schema-keys`). The plan compiler resolves it off the
+    ;; view-meta of the resolved `:component` (`[:world :view-args-schema]`),
+    ;; never off the variant body — and `:rf/props` / `:schema` are NOT in
+    ;; `re-frame.story.plan/context-keys`, so they would not even inherit
+    ;; through `:extends`. A body-level slot was an accepted-but-dead
+    ;; authoring surface (passed closed-shape validation, silently unread),
+    ;; so it is removed: a props schema on a variant body now FAILS
+    ;; closed-shape validation with `:rf.error/variant-shape`. A variant
+    ;; that wants a narrower props schema does it on the per-variant
+    ;; `:component` view's metadata, not on the variant body.
     ;; rf2-5x1wt.14 — first-class managed-HTTP request stubs. A map of
     ;; `[method url]` → `{:reply {:ok|:failure …}}`. The plan compiler
     ;; lowers `:network` to `[:world :network]` and on to the managed-

--- a/tools/story/src/re_frame/story/ui/schema_validation.cljc
+++ b/tools/story/src/re_frame/story/ui/schema_validation.cljc
@@ -108,7 +108,10 @@
     - `:where` — `:event` / `:sub-return` / `:cofx` / `:app-db` /
                  `:fx-args` (per Spec 010 §Validation order).
     - `:failing-id` / `:event-id` / `:sub-id` / `:cofx-id` / `:fx-id`
-                 — the id of the artefact whose `:spec` failed.
+                 — the registration/boundary id whose schema validation
+                 failed (the registered event / sub / cofx / fx / app-db
+                 root). `:spec` is dead post-M-54 — this surface speaks
+                 the schema vocabulary (`reg-*` `:schema` metadata).
     - `:received` — the actual value that failed (event vector / value /
                     coeffect map / slice).
     - `:explain` — the validator's explanation (Malli explain map on
@@ -126,7 +129,7 @@
       {:id          <int>              ;; the trace event's :id (stable per-process key)
        :time        <ms-since-epoch>   ;; from the trace event's :time
        :where       <kw>               ;; :event / :sub-return / :cofx / :app-db / :fx-args
-       :failing-id  <kw|nil>           ;; the artefact id whose :spec failed
+       :failing-id  <kw|nil>           ;; the registration/boundary id whose schema validation failed
        :path        <vector|nil>       ;; only for app-db failures
        :received    <any>              ;; the rejected value
        :explain     <any|nil>          ;; the validator's explanation

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -229,6 +229,74 @@
         (is (re-find #"did you mean :script\?" (:reason (ex-data e)))
             "the nearest-key suggestion points at :script")))))
 
+;; ---- rf2-hwcdh2 — body-level props-schema slots are GONE -----------------
+;;
+;; The view-args (props) schema lives ONLY on the registered `:component`
+;; view's `reg-view` metadata (first-match `[:rf/props :schema]`, resolved
+;; off the view-meta by the plan compiler). A `:rf/props` / `:schema` slot
+;; on a STORY or VARIANT body used to pass closed-shape validation but was
+;; silently UNREAD (an accepted-but-dead authoring surface). The slots are
+;; removed, so a props schema authored on the body now REJECTS at reg-time
+;; with the dead key named, rather than being swallowed with no effect.
+
+(deftest reg-story-rejects-body-level-props-schema-slots
+  (testing ":schema on a STORY body is rejected — props schema lives on the
+            registered :component view's metadata, not the story body"
+    (try
+      (story/reg-story :story.deadprops
+        {:component :views/widget
+         :schema    [:map [:label :string]]})
+      (is false "expected an exception — body :schema must NOT be accepted")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/story-shape (:rf.error/id (ex-data e)))
+            "ex-data carries the :rf.error/story-shape sentinel")
+        (is (re-find #":schema" (:reason (ex-data e)))
+            ":reason names the dead :schema key"))))
+  (testing ":rf/props on a STORY body is rejected too"
+    (try
+      (story/reg-story :story.deadrfprops
+        {:component :views/widget
+         :rf/props  [:map [:label :string]]})
+      (is false "expected an exception — body :rf/props must NOT be accepted")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/story-shape (:rf.error/id (ex-data e))))))))
+
+(deftest reg-variant-rejects-body-level-props-schema-slots
+  (testing ":schema on a VARIANT body is rejected — a variant narrows its
+            component's props schema on the view metadata, not the body"
+    (try
+      (story/reg-variant :story.dead/schema
+        {:events []
+         :schema [:map [:label :string]]})
+      (is false "expected an exception — body :schema must NOT be accepted")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e)))
+            "ex-data carries the :rf.error/variant-shape sentinel")
+        (is (re-find #":schema" (:reason (ex-data e)))
+            ":reason names the dead :schema key"))))
+  (testing ":rf/props on a VARIANT body is rejected too"
+    (try
+      (story/reg-variant :story.dead/rfprops
+        {:events   []
+         :rf/props [:map [:label :string]]})
+      (is false "expected an exception — body :rf/props must NOT be accepted")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e))))))))
+
+(deftest props-schema-on-view-metadata-still-drives-validation
+  (testing "the LIVE path is unchanged — a props schema on the registered
+            :component view's metadata (NOT the body) still copies into the
+            compiled plan and validates :effective-args (rf2-hwcdh2)"
+    (story/reg-variant :story.live/props
+      {:component :views/widget
+       :args      {:label "Hi"}})
+    (let [view-schema [:map [:label :string]]
+          p (plan/variant-plan :story.live/props
+                               {:view-lookup {:views/widget {:rf/props view-schema}}})]
+      (is (= view-schema (get-in p [:world :view-args-schema]))
+          "the view-meta props schema is copied to [:world :view-args-schema]")
+      (is (= {:label "Hi"} (get-in p [:world :effective-args]))))))
+
 (deftest reg-variant-migrated-setup-script-authoring-validates
   (testing "the migrated authoring shape (the template scaffold, rf2-1774m)
             — :setup preconditions + :script with [:assert [:rf.assert/…]]

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -284,13 +284,7 @@
      :component  :counter-with-stories.views/counter-card
      :args       {:label "Matrix"}
      :tags       #{:dev :test :internal}
-     :substrates #{:reagent}
-     :schema     [:map
-                  [:label :string]
-                  [:settings
-                   [:map
-                    [:title :string]
-                    [:enabled? :boolean]]]]})
+     :substrates #{:reagent}})
 
   ;; ===========================================================================
   ;; EXEMPLARY BLOCK — the small, copyable teaching surface.
@@ -505,9 +499,14 @@
      :substrates #{:reagent}})
 
   (story/reg-variant :story.counter-matrix/schema-invalid
-    {:doc    "Deliberately invalid args against the parent story
-             schema. The schema-validation panel should show the exact
-             failing key while the shell stays interactive."
+    {:doc    "Args that mismatch the component's expected prop shape
+             (a numeric :label, an unused :settings map). The
+             schema-validation panel surfaces a violation only when the
+             registered :component view carries a props schema (per
+             rf2-hwcdh2 the props schema lives on the view's reg-view
+             metadata, not on the story / variant body); counter-card
+             ships none, so this variant stays interactive and the
+             panel reports 'no schema registered'."
      :args   {:label 42
               :settings {:title "Bad label" :enabled? true}}
      :setup [[:counter/initialise 4]]


### PR DESCRIPTION
Two Story schema beads, one PR. Both isolated to `tools/story/`.

## rf2-hwcdh2 — remove the accepted-but-unread body-level props-schema slots

**Decision: REMOVED** (the bead's preferred contract), not implemented-as-override.

The Story and Variant body schemas accepted `:rf/props` / `:schema` and the comments claimed a body may pin a narrower props schema — but the live resolver never read them. Verified against the actual source before deciding:

- `plan/compile-body` resolves the props schema purely from `view-meta` (the registered `:component` view's `reg-view` metadata) via `view-lookup`, writing it to `[:world :view-args-schema]`. It never reads the story/variant body's `:rf/props` / `:schema`.
- The shared `view-args/compiled-view-args-schema`, the controls panel, and the schema-validation panel all read through that compiled-plan slot.
- `:rf/props` / `:schema` are NOT in `plan/context-keys`, so they would not even inherit through `:extends`.

So a body-level slot passed closed-shape validation yet had **zero effect** — an accepted-but-dead authoring surface. Removing the slots means a props schema authored on a body now FAILS closed-shape validation with `:rf.error/story-shape` / `:rf.error/variant-shape`, naming the dead key, rather than being silently swallowed.

The view-meta key picker (`malli-schema/view-args-schema` over `[:rf/props :schema]`) and the compiled-plan resolver are unchanged — that is the live path and stays.

**Testbed reconciliation:** `:story.counter-matrix` authored exactly this dead body `:schema` (its `counter-card` view carries no props schema, so the schema never fired). Removed it and reconciled the `:schema-invalid` variant doc to the live contract (props schema lives on the view metadata; panel reports "no schema registered" here).

Files (rf2-hwcdh2):
- `tools/story/src/re_frame/story/schemas.cljc` — drop the `:rf/props` / `:schema` slots from `Story` + `Variant`; rewrite the comments to the view-metadata-only contract.
- `tools/story/testbeds/counter_with_stories/stories.cljs` — drop the dead body `:schema`; reconcile the `:schema-invalid` doc.
- `tools/story/test/re_frame/story_authoring_validation_test.clj` — new coverage: reg-time rejection of body `:rf/props` / `:schema` on both surfaces, and that the view-meta props-schema path still drives `:effective-args` validation.

## rf2-ahdqu7 — reconcile schema-validation failing-id wording post-M-54

`:spec` is dead post-M-54; this surface uses schema terminology. Updated the `:failing-id` description from "the artefact id whose `:spec` failed" to "the registration/boundary id whose schema validation failed" in:
- `tools/story/src/re_frame/story/ui/schema_validation.cljc`
- `tools/story/spec/014-Chrome-Features.md`

No test changes needed — `:failing-id` tests use the key as data; the stale wording was comment/doc-only.

## Quality gates

- `clojure -M:test` from `tools/story/`: **1655 tests, 6140 assertions, 0 failures, 0 errors** (3 new deftests for hwcdh2).
- Closed-shape validation still rejects genuinely-unknown body keys (existing `reg-variant-rejects-typoed-slot-*` tests stay green; new tests confirm the removed slots now reject).

No touches to `implementation/core/`, `tools/xray/`, or `docs/`. `tools/story/spec/*` checked for stale body-level props-schema claims — none found; the spec already correctly locates the props schema on view registration metadata.