### PR TITLE
fix(xray): disambiguate guard-blocked edges by source path + reconcile DOM-pin spec (rf2-tjm3u2 rf2-bdwolc)

### DIFF
--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -272,6 +272,19 @@
           ;; (registration.cljc) before the engine is invoked; nil-safe
           ;; for pure-function callers (conformance corpus, JVM fixtures).
           frame-id   (:rf/frame machine)
+          ;; rf2-tjm3u2 — the ACTIVE state the guard was evaluated against
+          ;; (the snapshot's `:state`: a keyword, a vector path, or — for a
+          ;; parallel region's snapshot — a region value). Stamped on the
+          ;; trace so a downstream consumer can disambiguate WHICH state's
+          ;; edge a guard-block belongs to. Without it, two states that
+          ;; declare the SAME event + SAME guard id are indistinguishable by
+          ;; `(event, guard)` alone, and a single guard failure paints BOTH
+          ;; edges (the bug). The guard runs during the active-configuration
+          ;; resolution, so the active `:state` is the discriminator: the
+          ;; consumer (`panels.machines.trace-state/extract-guard-blocked-
+          ;; edge-ids`) matches only edges whose declaring `:from-path` is on
+          ;; this active path. nil-safe — a hand-built snapshot may omit it.
+          state      (:state snapshot)
           input      {:data (:data snapshot) :event event}]
       (try
         (let [outcome (boolean (call-guard g snapshot event))]
@@ -279,6 +292,7 @@
                        {:machine-id machine-id
                         :guard-id   guard-ref
                         :input      input
+                        :state      state
                         :outcome    (if outcome :pass :fail)
                         :frame      frame-id})
           outcome)
@@ -287,6 +301,7 @@
                        {:machine-id machine-id
                         :guard-id   guard-ref
                         :input      input
+                        :state      state
                         :outcome    :threw
                         :exception  e
                         :frame      frame-id})

--- a/implementation/machines/test/re_frame/guard_action_traces_test.clj
+++ b/implementation/machines/test/re_frame/guard_action_traces_test.clj
@@ -5,6 +5,8 @@
     :rf.machine/guard-evaluated
       {:guard-id <kw-or-fn>
        :input    {:data <data> :event <event-vec>}
+       :state    <active-state>   ;; rf2-tjm3u2 — the active state the
+                                  ;; guard ran against (source disambiguation)
        :outcome  :pass | :fail}
 
     :rf.machine/action-ran
@@ -73,7 +75,12 @@
         (is (= {:ready? false} (-> g :tags :input :data))
             "input :data carries the snapshot's :data slot")
         (is (= [:go] (-> g :tags :input :event))
-            "input :event carries the originating event vec")))))
+            "input :event carries the originating event vec")
+        ;; rf2-tjm3u2 — the active state the guard ran against is stamped
+        ;; so a consumer can disambiguate which state's edge a block
+        ;; belongs to (two states reusing the same event + guard id).
+        (is (= :idle (-> g :tags :state))
+            ":state carries the active state the guard was evaluated against")))))
 
 (deftest guard-evaluated-pass-outcome
   (testing "guard returning true emits :pass outcome and the transition fires"

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -364,6 +364,24 @@ ids: `<spec-edge-id>__in` / `<spec-edge-id>__out`. Event-node ids:
 `:eventLabel` slot on these edges is empty (the event-node holds the
 visible text).
 
+> **Edge-half `:guardBlocked` is projection/rendering data, NOT a DOM pin
+> (rf2-bdwolc).** The per-half `:guardBlocked` flag drives the half's
+> STROKE + arrowhead colour (the `__in` half goes pink, the `__out` half
+> stays resting). It is *not* surfaced as a `data-guard-blocked` DOM
+> attribute on the edge halves: `chart.edges/transition-edge` emits the
+> edge-label `<div>` (and its `data-guard-blocked` / `data-fired` /
+> `data-active` attrs) **only when the edge carries a non-empty
+> `:eventLabel`** (`(when (seq label) …)`), and under events-as-nodes the
+> `__in` / `__out` halves carry an EMPTY label (the text rides the
+> event-node). So the structural halves render no edge-label element and
+> no edge-half `data-guard-blocked` attribute exists to read. The
+> CANONICAL guard-blocked DOM pins are the **event-node**
+> (`[data-testid^="rf-mv-chart-event-"]` carries `data-guard-blocked`
+> unconditionally) and the **chart root**
+> (`data-guard-blocked-edge-ids`). A DOM test asserting the per-half
+> blocked highlight reads the `:guardBlocked` projection value (e.g. via
+> a projection unit test), not an edge-half DOM attribute.
+
 elk routes each of those two segments independently, so the
 `:edge-points` map `chart.cljs/elk-result->positions` produces is keyed
 by the **elk edge id** — `<spec-edge-id>__in` and `<spec-edge-id>__out`

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -818,11 +818,28 @@ transition and highlights NOTHING — it does not paint a guard-failed edge
 colour. This is a SUPERSET enhancement, only possible because re-frame2 emits
 `:rf.machine/guard-evaluated` (observable-everything ethos).
 
-DOM pins: the guard-blocked event-node + its `__in` (source → event-node) edge
-half carry `data-guard-blocked="true"`; the `__out` (event-node → target) half
-carries `data-guard-blocked="false"` (rf2-4nxgqq — the highlight stops at the
-event-node). The chart root surfaces the sorted set on
-`data-guard-blocked-edge-ids` (mirroring `data-fired-edge-ids`).
+**DOM pins (rf2-bdwolc — corrected).** The CANONICAL guard-blocked DOM pins are
+the **guard-blocked event-node** and the **chart root**:
+
+- the guard-blocked event-node (`[data-testid^="rf-mv-chart-event-"]`) carries
+  `data-guard-blocked="true"` UNCONDITIONALLY (its `IF <guard>` chip also
+  carries `data-guard-blocked`);
+- the chart root surfaces the sorted set on `data-guard-blocked-edge-ids`
+  (mirroring `data-fired-edge-ids`).
+
+The per-half `:guardBlocked` STATE (`__in` true / `__out` false per rf2-4nxgqq —
+the highlight stops at the event-node) is **projection/rendering data, NOT an
+edge-half DOM pin**. It drives the half's stroke + arrowhead colour, but no
+`data-guard-blocked` attribute exists on the `__in` / `__out` edge DOM:
+`chart.edges/transition-edge` emits the edge-label element (and its
+`data-guard-blocked` / `data-fired` attrs) ONLY when the edge has a non-empty
+`:eventLabel` (`(when (seq label) …)`), and under events-as-nodes (rf2-qo5xy)
+both halves carry an EMPTY label (the text rides the event-node). A test that
+needs the per-half blocked treatment asserts the `:guardBlocked` projection
+value (a `chart.projection` unit test), not an edge-half DOM attribute. (Earlier
+revisions of this doc claimed the `__in` / `__out` halves carried
+`data-guard-blocked` DOM attrs; they do not — the event-node + chart-root are
+the real pins.)
 
 ### Relationship to the focused-transition lens (rf2-99rhe)
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
@@ -428,6 +428,32 @@
       (vector? event)  (first event)
       :else            nil)))
 
+(defn- guard-state-from-trace
+  "Pull the ACTIVE state path the guard was evaluated against off a
+  `:rf.machine/guard-evaluated` trace (rf2-tjm3u2). The runtime stamps the
+  snapshot's `:state` under `:tags :state` (machines · transition.cljc
+  `evaluate-guard`). Coerced through `normalise-path` so a keyword
+  (`:open`) or vector path (`[:authenticated :cart]`) both land as a path
+  vector; a parallel region-MAP `:state` (no single active leaf) or an
+  absent slot returns nil — and a nil state then disables source-path
+  disambiguation (the consumer falls back to the `(event, guard)` match,
+  preserving the pre-rf2-tjm3u2 behaviour for traces that carry no state)."
+  [ev]
+  (normalise-path (get-in ev [:tags :state])))
+
+(defn- on-active-path?
+  "True iff `from-path` (an edge's declaring source path) is on the active
+  `state-path` — i.e. `from-path` is a (possibly equal) PREFIX of
+  `state-path`. A STATE-LOCAL edge declares on the active leaf (`from-path`
+  == `state-path`); an INHERITED edge declares on an ANCESTOR still on the
+  active path (`from-path` is a strict prefix). An edge declared on a
+  DIFFERENT branch (the bug's sibling state reusing the same event + guard)
+  is NOT a prefix of the active path, so it is excluded. nil `state-path`
+  (region-map / absent) disables the check upstream — never reaches here."
+  [from-path state-path]
+  (and (<= (count from-path) (count state-path))
+       (= (vec from-path) (vec (take (count from-path) state-path)))))
+
 (defn extract-guard-blocked-edge-ids
   "Given a machine `definition`, a vector of trace events for the
   focused epoch, and the `machine-id` of interest, return the SET of
@@ -440,18 +466,40 @@
   (it carries no transition), so the operator cannot see which edge the
   event hit or that a guard rejected it. The runtime emits the exact
   data on the no-op path: `:rf.machine/guard-evaluated {:guard-id …
-  :outcome :fail/:threw :input {:event …}}` carrying the NAMED guard,
-  so the blocked-edge match is EXACT — `(event, guard)` uniquely picks
-  the declining candidate even within a guarded fork (the precision the
-  bare transition trace lacks; see `extract-fired-edge-ids`' loose
-  `(from, to, event)` match).
+  :outcome :fail/:threw :input {:event …} :state …}` carrying the NAMED
+  guard AND the ACTIVE state the guard ran against (rf2-tjm3u2), so the
+  blocked-edge match is EXACT.
+
+  rf2-tjm3u2 — match by `(source-path, event, guard)`, NOT `(event,
+  guard)` alone. A machine may declare the SAME event + SAME guard id on
+  MULTIPLE states (`:open` and `:ajar` both with `:door/close` guarded by
+  `:may-close?`). `(event, guard)` alone matched EVERY such edge, so ONE
+  guard failure in ONE active state painted ALL of them pink. The guard
+  runs during the ACTIVE-configuration resolution, so the trace's `:state`
+  (the active path) is the discriminator: only an edge whose declaring
+  `:from-path` is ON that active path (a prefix of it — `on-active-path?`)
+  could have produced this block. A STATE-LOCAL edge declares on the
+  active leaf; an INHERITED edge declares on an ancestor still on the
+  active path; a SIBLING state's same-(event, guard) edge is NOT on the
+  active path and is correctly excluded. The MACHINE-LEVEL fallback
+  (top-level `:on`, `:from-path []`) is on EVERY active path (the empty
+  vector is a prefix of all), so it still matches — matching the
+  machine-level fallback `extract-fired-edge-ids` keeps.
+
+  Backward-compatible: when the trace carries NO `:state` (a region-MAP
+  parallel snapshot, or an older/hand-built trace), `on-active-path?` is
+  not consulted and the match falls back to `(event, guard)` alone — the
+  pre-rf2-tjm3u2 behaviour. So a guarded FORK on a single state (two
+  same-source candidates differing by guard) still lights ONLY the arm
+  whose named guard the trace reports failing (the named guard remains the
+  fork-arm discriminator).
 
   The returned ids are the EXACT ids the live MachineChart mints: the
   definition is projected through `chart.layout/project-definition` and
-  each fail/threw guard trace's `(event, guard-ref)` is matched against
-  the projected edges' `:event` / `:guard`. The guard refs compare with
-  `=` because both the trace's `:guard-id` and the edge's `:guard` are
-  the SAME user-declared ref off the SAME definition (keyword or fn).
+  each fail/threw guard trace is matched against the projected edges'
+  `:from-path` / `:event` / `:guard`. The guard refs compare with `=`
+  because both the trace's `:guard-id` and the edge's `:guard` are the
+  SAME user-declared ref off the SAME definition (keyword or fn).
 
   Scope is GUARD-BLOCKED only (rf2-fzrzlw design call (3)): a truly-
   unhandled event (no declared edge for it) is a separate state-node
@@ -467,20 +515,32 @@
          (mapcat
            (fn [ev]
              (let [guard* (guard-ref-from-trace ev)
-                   event* (guard-event-from-trace ev)]
-               ;; A blocked candidate is uniquely (event, guard): the
-               ;; named guard discriminates which arm of a guarded fork
-               ;; declined. Match every projected edge carrying that
-               ;; same (event, guard) pair — typically exactly one. An
-               ;; edge with no guard cannot be the blocked candidate, so
-               ;; the `(some? guard*)` precondition keeps a guardless
-               ;; trace (which the runtime never emits — `evaluate-guard`
-               ;; skips the synthesised always-true guard) from lighting
-               ;; every same-event edge.
+                   event* (guard-event-from-trace ev)
+                   ;; rf2-tjm3u2 — the active state path the guard ran
+                   ;; against. nil (region-map / absent) disables source-
+                   ;; path disambiguation (the `(event, guard)` fallback).
+                   state* (guard-state-from-trace ev)]
+               ;; A blocked candidate is uniquely (source-path, event,
+               ;; guard): the named guard discriminates which arm of a
+               ;; guarded fork declined, and the active state discriminates
+               ;; WHICH state's edge when several states reuse the same
+               ;; (event, guard). An edge with no guard cannot be the
+               ;; blocked candidate, so the `(some? guard*)` precondition
+               ;; keeps a guardless trace (which the runtime never emits —
+               ;; `evaluate-guard` skips the synthesised always-true guard)
+               ;; from lighting every same-event edge.
                (when (and (some? guard*) event*)
                  (keep (fn [e]
                          (when (and (= event* (:event e))
-                                    (= guard* (:guard e)))
+                                    (= guard* (:guard e))
+                                    ;; Source-path gate: skip only when the
+                                    ;; trace carried a usable `:state` AND
+                                    ;; this edge's declaring `:from-path` is
+                                    ;; NOT on that active path. nil `state*`
+                                    ;; → no gate (the (event, guard)
+                                    ;; fallback).
+                                    (or (nil? state*)
+                                        (on-active-path? (:from-path e) state*)))
                            (:id e)))
                        edges)))))
          set)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
@@ -455,11 +455,13 @@
             (from, event, guard) edge id the live chart mints"
     (let [def        (door-definition)
           close-id   (canonical-guard-edge-id def [:open] :door/close :may-close?)
-          ;; the LIVE runtime shape: :guard-id + :outcome + :input {:event}.
+          ;; the LIVE runtime shape: :guard-id + :outcome + :state +
+          ;; :input {:data :event} (rf2-tjm3u2 added :state).
           events     [{:operation :rf.machine/guard-evaluated
                        :tags {:machine-id :door
                               :guard-id   :may-close?
                               :outcome    :fail
+                              :state      [:open]
                               :input      {:data {:held-open? true}
                                            :event [:door/close]}}}]
           blocked    (trace-state/extract-guard-blocked-edge-ids def events :door)]
@@ -564,15 +566,100 @@
           lo-id     (->> projected (some (fn [e] (when (= :lo? (:guard e)) (:id e)))))
           ;; :hi? failed; the engine walked on to :lo? (which passed and
           ;; fired) — only the :hi? ARM is guard-blocked.
+          ;; rf2-tjm3u2 — both fork arms declare on the SAME state (:idle),
+          ;; so source-path can't discriminate them; the NAMED guard does.
           events    [{:operation :rf.machine/guard-evaluated
                       :tags {:machine-id :m :guard-id :hi? :outcome :fail
+                             :state [:idle]
                              :input {:event :check}}}]
           blocked   (trace-state/extract-guard-blocked-edge-ids def events :m)]
       (is (string? hi-id))
       (is (string? lo-id))
       (is (not= hi-id lo-id) "the two fork arms have distinct ids")
       (is (= #{hi-id} blocked)
-          "ONLY the :hi? arm lights — the named guard discriminates the fork"))))
+          "ONLY the :hi? arm lights — same source state, the named guard
+           discriminates the fork (source-path agrees for both arms)"))))
+
+(deftest guard-blocked-ids-disambiguate-by-source-state-path
+  (testing "rf2-tjm3u2 — two states both declaring the SAME event + SAME
+            guard id: a guard failure in ONE active state lights ONLY that
+            state's edge, NOT the sibling's reused-id edge"
+    (let [;; Two siblings BOTH declare `:door/close` guarded by `:may-close?`.
+          ;; Before the fix, a guard-block in :open painted BOTH edges pink.
+          def       {:initial :open
+                     :states  {:open {:on {:door/close {:target :closed
+                                                        :guard  :may-close?}}}
+                               :ajar {:on {:door/close {:target :closed
+                                                        :guard  :may-close?}}}
+                               :closed {}}}
+          open-id   (canonical-guard-edge-id def [:open] :door/close :may-close?)
+          ajar-id   (canonical-guard-edge-id def [:ajar] :door/close :may-close?)
+          ;; The guard FAILED while :open was the active state — the runtime
+          ;; stamps the active `:state` on the trace (rf2-tjm3u2).
+          events    [{:operation :rf.machine/guard-evaluated
+                      :tags {:machine-id :door
+                             :guard-id   :may-close?
+                             :outcome    :fail
+                             :state      [:open]
+                             :input      {:event :door/close}}}]
+          blocked   (trace-state/extract-guard-blocked-edge-ids def events :door)]
+      (is (string? open-id))
+      (is (string? ajar-id))
+      (is (not= open-id ajar-id)
+          "the two states' reused-id edges have distinct canonical ids")
+      (is (= #{open-id} blocked)
+          "ONLY the active :open state's edge lights — the source path in the
+           trace's :state disambiguates it from :ajar's identical (event, guard)"))))
+
+(deftest guard-blocked-ids-no-state-falls-back-to-event-guard-match
+  (testing "rf2-tjm3u2 — a trace with NO :state (region-map / older trace)
+            falls back to the (event, guard) match (pre-tjm3u2 behaviour):
+            both same-id edges light, since the source cannot be resolved"
+    (let [def      {:initial :open
+                    :states  {:open {:on {:door/close {:target :closed
+                                                       :guard  :may-close?}}}
+                              :ajar {:on {:door/close {:target :closed
+                                                       :guard  :may-close?}}}
+                              :closed {}}}
+          open-id  (canonical-guard-edge-id def [:open] :door/close :may-close?)
+          ajar-id  (canonical-guard-edge-id def [:ajar] :door/close :may-close?)
+          ;; No :state on the trace — the source-path gate is disabled.
+          events   [{:operation :rf.machine/guard-evaluated
+                     :tags {:machine-id :door
+                            :guard-id   :may-close?
+                            :outcome    :fail
+                            :input      {:event :door/close}}}]
+          blocked  (trace-state/extract-guard-blocked-edge-ids def events :door)]
+      (is (= #{open-id ajar-id} blocked)
+          "without a :state to disambiguate, both reused-id edges light —
+           the conservative (event, guard) fallback"))))
+
+(deftest guard-blocked-ids-inherited-transition-on-active-path
+  (testing "rf2-tjm3u2 — an INHERITED transition (declared on an ANCESTOR
+            still on the active path) is matched: the ancestor's :from-path
+            is a strict PREFIX of the active leaf state"
+    (let [;; `:open` is a COMPOUND with `:door/close` declared at the PARENT
+          ;; level; the active leaf is `[:open :wide]`.
+          def      {:initial :open
+                    :states  {:open {:initial :wide
+                                     :on      {:door/close {:target :closed
+                                                            :guard  :may-close?}}
+                                     :states  {:wide {} :narrow {}}}
+                              :closed {}}}
+          close-id (canonical-guard-edge-id def [:open] :door/close :may-close?)
+          events   [{:operation :rf.machine/guard-evaluated
+                     :tags {:machine-id :door
+                            :guard-id   :may-close?
+                            :outcome    :fail
+                            ;; active leaf is the nested [:open :wide]; the
+                            ;; edge declares at [:open] (a prefix of it).
+                            :state      [:open :wide]
+                            :input      {:event :door/close}}}]
+          blocked  (trace-state/extract-guard-blocked-edge-ids def events :door)]
+      (is (string? close-id))
+      (is (= #{close-id} blocked)
+          "the inherited edge lights — its [:open] :from-path is a prefix of
+           the active [:open :wide] leaf"))))
 
 (deftest guard-blocked-ids-agree-with-projected-chart-edge-ids
   (testing "every guard-blocked id is a real projected chart edge :id"


### PR DESCRIPTION
Two guard-blocked-edge beads on one surface (Xray machine inspector + machines guard trace), one PR.

## rf2-tjm3u2 (P3 BUG) — disambiguate guard-blocked edge ids by source path

`extract-guard-blocked-edge-ids` matched blocked topology edges by `(event, guard)` ONLY. A machine reusing the same event + guard id on multiple states had ONE guard failure paint ALL matching edges pink. Now matches by `(source-path, event, guard)`:

- **Runtime** (`implementation/machines/.../transition.cljc` `evaluate-guard`) stamps the snapshot's active `:state` on every `:rf.machine/guard-evaluated` trace — additive tag, nil-safe for pure-fn callers.
- **Xray matcher** (`trace_state.cljs`) reads it (`guard-state-from-trace`) and gates each candidate edge by `on-active-path?`: an edge's declaring `:from-path` must be a PREFIX of the active state path (state-local == active leaf; inherited == ancestor still on the path; the machine-level `[]` fallback is on every path). A sibling state's same-`(event, guard)` edge is off the active path → excluded.
- **Backward-compatible**: a trace with no `:state` (parallel region-map / older / hand-built trace) falls back to the `(event, guard)` match. A guarded fork on ONE state still disambiguates by the named guard.

Regression added (`guard-blocked-ids-disambiguate-by-source-state-path`) — two states both declaring `:door/close [may-close?]`; a block in `:open` lights only `:open`'s edge. Plus the no-`:state` fallback case and an inherited-transition (ancestor-declared) case. **Probe-confirmed**: with the source-path gate disabled, the regression FAILS.

## rf2-bdwolc (P4) — reconcile guard-blocked edge DOM-pin contract

**Decision: the spec was wrong (conservative default).** Read the renderer first: `chart.edges/transition-edge` emits the edge-label DOM element (and its `data-guard-blocked` / `data-fired` / `data-active` attrs) ONLY `(when (seq label) ...)`. Under events-as-nodes (rf2-qo5xy) the `__in` / `__out` halves carry an EMPTY `:eventLabel` (the text rides the event-node), so NO edge-half `data-guard-blocked` DOM attribute is ever emitted. The earlier spec claim that the `__in`/`__out` halves carry `data-guard-blocked` was inaccurate.

Updated `tools/xray/spec/003-Machine-Inspector.md` + `tools/machines-viz/spec/API.md`: canonical guard-blocked DOM pins are the **event-node** (`data-guard-blocked`, unconditional) + the **chart root** (`data-guard-blocked-edge-ids`). The per-half `:guardBlocked` is documented as **projection/rendering data** (drives stroke + arrowhead colour), NOT a DOM pin. Did NOT add a renderer/path-level hook — it would be redundant: the event-node already pins the blocked state and the projection data already carries the per-half resolution. The existing machines-viz DOM tests already assert ONLY the event-node + chart-root pins, so they confirm the corrected contract (no test change needed).

## Quality gates

- `tools/xray/` `clojure -M:test` — 1108 tests, 0 failures
- `implementation/` `npm run test:cljs` (trace-state regression + machines on node-test) — 5981 tests, 0 failures (probe confirmed the regression catches the bug)
- `implementation/machines/` `clojure -M:test` (guard-evaluated `:state` assertion) — 551 tests, 0 failures
- `tools/machines-viz/` `clojure -M:test` — 467 tests, 0 failures

## Follow-up

`rf2-ulq7z1` filed: `spec/005-StateMachines.md` §guard-evaluated tag list (a hot-zone file outside this worker's allowed surface) should gain the additive `:state` tag — pure doc reconcile.