### PR TITLE
feat(core): physical frame-state container + atomic partitioned commit (rf2-adwcv6)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
@@ -915,11 +915,11 @@
     (let [post-go-db (rf/app-db-value :rf/default)]
       (is (= :working (get-in post-go-db [:rf/runtime :machines :snapshots :test/m :state]))
           "machine reached :working")
-      ;; Tool-Pair-style revert: replace-container! to a snapshot where
-      ;; the machine is in :idle.
-      (let [container (frame/app-db-container :rf/default)
-            reverted  (assoc-in post-go-db [:rf/runtime :machines :snapshots :test/m :state] :idle)]
-        (adapter/replace-container! container reverted))
+      ;; Tool-Pair-style revert: write the app-db PARTITION to a snapshot
+      ;; where the machine is in :idle (EP-0001 rf2-adwcv6 — app-db-container
+      ;; is now a read-only projection, so revert via swap-frame-db!).
+      (frame/swap-frame-db! :rf/default
+        (fn [db] (assoc-in db [:rf/runtime :machines :snapshots :test/m :state] :idle)))
       (is (= :idle (get-in (rf/app-db-value :rf/default)
                            [:rf/runtime :machines :snapshots :test/m :state]))
           "after replace-container! the snapshot reads back as :idle")

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -372,12 +372,14 @@
         ;; Seed the snapshot's :data :retries past :max-retries via a
         ;; direct write to the machine's :data slot. This is a test
         ;; helper — production code never does this.
-        (let [db (rf/app-db-value f)
-              max-retries (get-in db [:rf/runtime :machines :snapshots :ws/connection :data :max-retries])
-              new-db (update-in db [:rf/runtime :machines :snapshots :ws/connection :data]
-                                assoc :retries (inc max-retries))]
-          (re-frame.substrate.adapter/replace-container!
-            (re-frame.frame/app-db-container f) new-db))
+        ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION via swap-frame-db!
+        ;; — app-db-container is now a read-only projection. The machine
+        ;; snapshot still lives at [:rf/runtime …] inside app-db until bead 6.
+        (re-frame.frame/swap-frame-db! f
+          (fn [db]
+            (let [max-retries (get-in db [:rf/runtime :machines :snapshots :ws/connection :data :max-retries])]
+              (update-in db [:rf/runtime :machines :snapshots :ws/connection :data]
+                         assoc :retries (inc max-retries)))))
         ;; Now drive a :ws/closed — the parent transitions to :reconnecting
         ;; and immediately into :failed via :always-cascade.
         (let [snap-before (snapshot (rf/app-db-value f))]

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1557,12 +1557,9 @@
 ;;   behavior change: it is the new name for the same write. The rename of
 ;;   the legacy `reset-frame-db!` Tool-Pair surface (and the new app-db-only
 ;;   `reset-app-db!`) is rf2-tfepxu (bead 9); both names coexist until then.
-;; - `replace-runtime-db!` / `replace-frame-state!` write partitions that
-;;   have no physical slot yet. The one-container frame-state + projection
-;;   reactions land in rf2-adwcv6 (bead 5); the atomic partitioned commit
-;;   path is beads 4-5. Faking a partial write now would be a behavior
-;;   change against today's structure, so these introduce the surface with a
-;;   deferred-semantics throw rather than a no-op that silently loses data.
+;; - `replace-runtime-db!` / `replace-frame-state!` write the physical
+;;   frame-state container's partitions through the atomic
+;;   `frame/commit-frame-transition!` path (rf2-adwcv6, bead 5 — now real).
 
 (def ^{:doc "Replace `frame-id`'s `app-db` partition with `app-db`,
   bypassing the dispatch loop. The canonical Tool-Pair write surface for
@@ -1583,25 +1580,22 @@
   replace-app-db!    rf-epoch/reset-frame-db!)
 
 (defn replace-runtime-db!
-  "Replace `frame-id`'s `runtime-db` partition with `runtime-db` — the
+  "Replace ONLY `frame-id`'s `runtime-db` partition with `runtime-db` — the
   framework-owned subsystem state. Privileged runtime / full-frame tool
-  surface. Returns `true` on success, `false` for an unknown / destroyed
+  surface; app-db is untouched. Atomic install through the one physical
+  frame-state container. Returns the set of changed frame-state partition
+  keys (a subset of `#{:rf.db/app :rf.db/runtime}`; empty when the supplied
+  value `=` the current runtime-db), or `nil` for an unknown / destroyed
   frame.
 
-  EP-0001 (rf2-q4i9ko): introduces the SURFACE only. The physical
-  runtime-db partition and its atomic commit path land in rf2-adwcv6
-  (bead 5) + rf2-bvwoi4 (bead 4). There is no runtime-db slot to write
-  today; rather than fake a write that silently drops data, this raises
-  until the partition exists. Per Spec 002 §Frame-state value accessors
-  and mutators and API.md `replace-runtime-db!`."
-  [frame-id _runtime-db]
-  ;; full semantics land in rf2-adwcv6 (bead 5) — the one-container
-  ;; frame-state holds the `:rf.db/runtime` projection this writes.
-  (throw (ex-info "replace-runtime-db! has no physical partition to write yet — the runtime-db partition lands in rf2-adwcv6 (bead 5)"
-                  {:rf.error/id :rf.error/not-yet-implemented
-                   :surface     :replace-runtime-db!
-                   :frame       frame-id
-                   :deferred-to :rf2-adwcv6})))
+  EP-0001 (rf2-adwcv6): real partition write — installs the runtime-db slice
+  of the single physical frame-state container via
+  `frame/commit-frame-transition!`. Supports whole-value replacement
+  (decision #5: restore / hydration / reset use this; ordinary subsystem
+  writes prefer operation-style helpers). Per Spec 002 §Frame-state value
+  accessors and mutators and API.md `replace-runtime-db!`."
+  [frame-id runtime-db]
+  (frame/replace-runtime-db! frame-id runtime-db))
 
 (defn replace-frame-state!
   "Replace BOTH partitions of `frame-id` atomically with `frame-state`
@@ -1609,24 +1603,16 @@
   tool-driven replay / fixture install (epoch restore, time travel, SSR
   hydration, frame reset, test-fixture install). A db-shaped name never
   silently replaces runtime-db — this is the explicit full-frame surface
-  (Mike ruling #10). Returns `true` on success, `false` for an unknown /
+  (Mike ruling #10). Both partitions install in ONE atomic write. Returns
+  the set of changed frame-state partition keys, or `nil` for an unknown /
   destroyed frame.
 
-  EP-0001 (rf2-q4i9ko): introduces the SURFACE only. The single physical
-  frame-state container that makes a two-partition install atomic lands in
-  rf2-adwcv6 (bead 5). There is no container to install both partitions
-  into today; rather than apply only the app-db half (a behavior change
-  that would silently drop the runtime-db half), this raises until the
-  container exists. Per Spec 002 §Frame-state value accessors and mutators
-  and API.md `replace-frame-state!`."
-  [frame-id _frame-state]
-  ;; full semantics land in rf2-adwcv6 (bead 5) — the single frame-state
-  ;; container is what makes the two-partition install one atomic transition.
-  (throw (ex-info "replace-frame-state! has no physical frame-state container to install into yet — the one-container frame-state lands in rf2-adwcv6 (bead 5)"
-                  {:rf.error/id :rf.error/not-yet-implemented
-                   :surface     :replace-frame-state!
-                   :frame       frame-id
-                   :deferred-to :rf2-adwcv6})))
+  EP-0001 (rf2-adwcv6): real full-frame install — both partitions written to
+  the single physical frame-state container in one atomic
+  `frame/commit-frame-transition!`. Per Spec 002 §Frame-state value
+  accessors and mutators and API.md `replace-frame-state!`."
+  [frame-id frame-state]
+  (frame/replace-frame-state! frame-id frame-state))
 
 ;; Per Security.md §Epoch privacy posture and rf2-mrsck — single
 ;; normative projection helpers for off-box epoch egress.

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -111,14 +111,18 @@
   `re-frame.marks` ns — which mutates the SAME slot from its
   `add-marks` / `set-marks` / `clear-app-db-marks!`
   paths — can share a single source of truth for the read-transform-
-  write skeleton. Not part of the public API."
+  write skeleton. Not part of the public API.
+
+  EP-0001 (rf2-adwcv6): writes through `frame/swap-frame-db!` (the app-db
+  partition of the one physical frame-state container) rather than a direct
+  `replace-container!` — `frame/app-db-container` is now a READ-ONLY
+  projection. The elision registry still lives at `[:rf/runtime :elision]`
+  INSIDE app-db until bead 6 (rf2-vzld77) migrates elision to runtime-db, so
+  this stays an app-db write."
   [frame-id f]
-  (when-let [container (frame/app-db-container frame-id)]
-    (let [old-db  (adapter/read-container container)
-          old-reg (get-in old-db [:rf/runtime :elision])
-          new-reg (f old-reg)
-          new-db  (write-elision-slot old-db new-reg)]
-      (adapter/replace-container! container new-db)))
+  (frame/swap-frame-db! frame-id
+                        (fn [old-db]
+                          (write-elision-slot old-db (f (get-in old-db [:rf/runtime :elision])))))
   nil)
 
 (defn declarations

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -25,13 +25,45 @@
 ;;
 ;; Per Spec 002 §What lives in a frame, a frame is a map with:
 ;;   :id          the keyword identity
-;;   :app-db      substrate-managed reactive container (opaque; through adapter)
+;;   :frame-state the ONE physical durable container (opaque; through adapter)
+;;                — holds BOTH partitions as a frame-state value
+;;                `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`.
+;;   :app-db      the app-db PROJECTION REACTION over :frame-state
+;;                (`make-derived-value [frame-state] :rf.db/app`). Read-only —
+;;                layer-1 app subs read it; writes go through the frame-state
+;;                container, never `replace-container!` on this projection.
+;;   :runtime-db  the runtime-db PROJECTION REACTION over :frame-state
+;;                (`make-derived-value [frame-state] :rf.db/runtime`). Read-only
+;;                — framework subs read it.
 ;;   :router      per-frame queue + drain-state FSM (defined in router.cljc)
 ;;   :sub-cache   per-frame sub-cache (defined in subs.cljc)
 ;;   :lifecycle   {:created-at :destroyed? :listeners}
 ;;   :config      the metadata that reg-frame was given
 ;;
+;; Per Spec 002 §One physical container, two projection reactions + Spec 006
+;; §Frame-state container and partition projections (EP-0001 decision #3):
+;; the frame holds ONE physical frame-state container; app-db and runtime-db
+;; are PROJECTION REACTIONS over it. Partition-aware sub-cache invalidation
+;; falls out of `make-derived-value`'s memoised `=`-equality — NO dirty flags
+;; (decision #7): a runtime-only commit recomputes the app-db projection,
+;; finds `:rf.db/app` `=`, and does not propagate to app subs; an app-only
+;; commit is symmetric.
+;;
 ;; Frame records are stored in `frames` keyed by id.
+;;
+;; The two reserved partition keys inside the physical frame-state value.
+;; `:rf.db/app` is the app-db partition slot; `:rf.db/runtime` is the
+;; runtime-db partition slot (per Spec 002 §The two-partition frame contract
+;; and Conventions §Reserved partition keys). Held here as the single source
+;; of truth for the commit + projection machinery in this ns.
+
+(def ^:const app-partition-key
+  "Reserved frame-state key naming the app-db partition (`:rf.db/app`)."
+  :rf.db/app)
+
+(def ^:const runtime-partition-key
+  "Reserved frame-state key naming the runtime-db partition (`:rf.db/runtime`)."
+  :rf.db/runtime)
 
 (defonce
   ^{:doc "Map of frame-id → frame-record. Per-process (one global frame registry)."}
@@ -188,88 +220,234 @@
                              (clojure.string/starts-with? ns prefix)))))
            @frames))))
 
+(defn frame-state-container
+  "Return the frame's ONE physical frame-state **container** — the
+  substrate-managed reactive cell that holds the frame-state VALUE
+  `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}` (an `r/atom` under
+  the stock Reagent adapter, a `clojure.core/atom` under plain-atom /
+  React-hook adapters). This is the single physical write target; every
+  durable state write flows through it via `commit-frame-transition!` /
+  the partition mutators.
+
+  Internals only: the router commit path and the partition write helpers
+  call `replace-container!` against this cell. App-db and runtime-db are
+  READ-ONLY projection reactions over it (`app-db-container` /
+  `runtime-db-container`).
+
+  Returns `nil` when the frame is not registered or has been destroyed.
+  Per Spec 002 §One physical container, two projection reactions and
+  Spec 006 §Frame-state container and partition projections."
+  [id]
+  (:frame-state (frame id)))
+
 (defn app-db-container
-  "Return the underlying app-db **container** for the frame — the
-  substrate-managed reactive cell that holds the app-db value (an atom
-  under the stock Reagent adapter, an MVT cell under others). Internals
-  only: tools, tests, and core machinery that need to call
-  `read-container` / `replace-container!` against the cell.
+  "Return the app-db **projection reaction** for the frame — the read-only
+  derived value `(make-derived-value [frame-state] :rf.db/app)` over the
+  one physical frame-state container. Layer-1 app subs read it as their
+  signal source, so the subscription machinery only ever sees app-db (the
+  partition split is invisible to the invalidation algorithm — a
+  runtime-only commit recomputes this projection, finds `:rf.db/app` `=`,
+  and does not propagate). Distinct from `frame-state-container`, the
+  writable physical cell.
+
+  READ-ONLY: this is a `make-derived-value` result, so
+  `adapter/replace-container!` on it throws `:rf.error/derived-container-
+  replaced` (per Spec 006 §`make-derived-value`). App-db writes go through
+  `swap-frame-db!` / `replace-app-db!` / `commit-frame-transition!`, which
+  write the app-db partition of the physical frame-state container.
 
   Distinct from `re-frame.core/app-db-value`, which returns the deref'd
   app-db **value** (a plain map). User handlers receive `db` via cofx.
 
-  Returns `nil` when the frame is not registered or has been destroyed."
+  Returns `nil` when the frame is not registered or has been destroyed.
+  Per Spec 002 §One physical container, two projection reactions."
   [id]
   (:app-db (frame id)))
 
+(defn runtime-db-container
+  "Return the runtime-db **projection reaction** for the frame — the
+  read-only derived value `(make-derived-value [frame-state] :rf.db/runtime)`
+  over the one physical frame-state container. Framework subs
+  (`sub-machine`, `[:rf.route/*]`) read it as their signal source; an
+  app-only commit leaves `:rf.db/runtime` `=`, so the projection does not
+  propagate and framework subs are untouched.
+
+  READ-ONLY (a derived value); runtime-db writes go through
+  `replace-runtime-db!` / `commit-frame-transition!`, which write the
+  runtime-db partition of the physical frame-state container.
+
+  Returns `nil` when the frame is not registered or has been destroyed.
+  Per Spec 002 §One physical container, two projection reactions."
+  [id]
+  (:runtime-db (frame id)))
+
 (defn frame-app-db-value
-  "Read the current app-db value for a frame as a plain map (deref through
-  the substrate adapter)."
+  "Read the current app-db value for a frame as a plain map (deref the
+  app-db projection through the substrate adapter)."
   [id]
   (when-let [container (app-db-container id)]
     (adapter/read-container container)))
 
-;; ---- EP-0001 two-partition readers (rf2-q4i9ko) ---------------------------
+;; ---- EP-0001 two-partition readers (rf2-q4i9ko / rf2-adwcv6) --------------
 ;;
 ;; Per Spec 002 §The two-partition frame contract a frame owns two durable
 ;; partitions — user `app-db` and framework `runtime-db` — projected as a
 ;; coherent `frame-state` value `{:rf.db/app … :rf.db/runtime …}`.
 ;;
-;; This bead introduces the read SURFACE only (Mike ruling #1). The physical
-;; one-container frame-state + projection reactions land in rf2-adwcv6 (bead
-;; 5); the `:rf.db/runtime` partition has no physical slot until then, so
-;; `frame-runtime-db-value` reads as `nil` today. `frame-state-value`
-;; composes the two readers, so it already yields the correct shape and grows
-;; a populated `:rf.db/runtime` slot for free once bead 5 lands.
+;; rf2-q4i9ko (bead 3) introduced the read SURFACE; rf2-adwcv6 (bead 5, this
+;; one) makes the physical one-container frame-state + projection reactions
+;; real, so `frame-runtime-db-value` now reads the live runtime-db partition.
 
 (defn frame-runtime-db-value
   "Read the current runtime-db partition value for a frame — the
-  framework-owned subsystem state (`:rf.runtime/*` children). Returns `nil`
-  for an unknown / destroyed frame.
+  framework-owned subsystem state. Returns `nil` for an unknown / destroyed
+  frame.
 
-  EP-0001 (rf2-q4i9ko): the read surface only. The physical runtime-db
-  partition is introduced by the one-container frame-state work in rf2-adwcv6
-  (bead 5); until then there is no runtime-db slot and this reads `nil` for a
-  live frame too. Per Spec 002 §The two-partition frame contract."
+  rf2-adwcv6 (bead 5): reads the real `:rf.db/runtime` partition off the one
+  physical frame-state container (via the runtime-db projection). A fresh
+  frame's runtime-db starts `{}`. Per Spec 002 §The two-partition frame
+  contract."
   [id]
-  ;; full semantics land in rf2-adwcv6 (bead 5): once the single frame-state
-  ;; container exists, this reads its `:rf.db/runtime` projection. No physical
-  ;; slot exists yet, so the live value is `nil`; the `(when (frame id) …)`
-  ;; guard keeps the unknown-frame and live-frame answers both `nil` without
-  ;; faking a partition that is not there.
-  (when (frame id)
-    nil))
+  (when-let [container (runtime-db-container id)]
+    (adapter/read-container container)))
 
 (defn frame-state-value
   "Read the coherent frame-state projection for a frame —
   `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`. Returns `nil` for an
   unknown / destroyed frame.
 
-  EP-0001 (rf2-q4i9ko): composes `frame-app-db-value` with
-  `frame-runtime-db-value`. The `:rf.db/runtime` slot is `nil` until the
-  physical partition lands in rf2-adwcv6 (bead 5); the shape is final.
-  Per Spec 002 §The two-partition frame contract."
+  rf2-adwcv6 (bead 5): reads the one physical frame-state container directly
+  (a single deref) rather than composing two reads, so the returned value is
+  the exact coherent snapshot the commit installed. Per Spec 002 §The
+  two-partition frame contract."
   [id]
-  (when (frame id)
-    {:rf.db/app     (frame-app-db-value id)
-     :rf.db/runtime (frame-runtime-db-value id)}))
+  (when-let [container (frame-state-container id)]
+    (adapter/read-container container)))
+
+;; ---- EP-0001 partition commit + write helpers (rf2-adwcv6) ----------------
+;;
+;; The frame-state container is the ONE physical write target. Every durable
+;; state write — the router's per-event commit, the privileged runtime
+;; mutators, full-frame tool install — flows through `replace-container!` on
+;; it. Per Spec 002 §An ordinary :db return replaces only app-db + §Write
+;; authority is by convention, and Spec 006 §Commit boundary.
+
+(defn commit-frame-transition!
+  "Atomically install a frame transition into the ONE physical frame-state
+  container (Spec 002 §Drain-loop pseudocode §commit; Spec 006 §Commit
+  boundary). `partitions` is a map that MAY carry `:rf.db/app` (the new
+  app-db value — the ordinary `:db` effect, scoped to the app-db partition)
+  and/or `:rf.db/runtime` (the new runtime-db value — the reserved
+  `:rf.db/runtime` effect). The partition(s) NOT present are carried forward
+  unchanged from the current frame-state, so:
+
+    - an APP-ONLY commit (`{:rf.db/app v}`) replaces only the app-db slice;
+      runtime-db is untouched — the handler cannot drop it through `:db`;
+    - a RUNTIME-ONLY commit (`{:rf.db/runtime v}`) replaces only runtime-db;
+    - a commit touching BOTH installs the combined result as ONE coherent
+      transition — there is never a window where one partition is committed
+      and the other is not.
+
+  Returns the SET of partition keys that actually changed by `=` (a subset
+  of `#{:rf.db/app :rf.db/runtime}`) — the caller uses it to drive the
+  partition-tagged change traces (`:rf.event/db-changed` /
+  `:rf.event/frame-state-changed`). A no-op partition (the supplied value
+  `=` the current slice) is NOT reported as changed, so the projection
+  reactions and the change signals agree. Returns `nil` for an unknown /
+  destroyed frame (the nil-container guard in `replace-container!` also
+  covers the destroy-race when called through it).
+
+  NOTE the `partitions` map keys are the frame-state partition keys
+  (`:rf.db/app` / `:rf.db/runtime`), NOT the effect keys (`:db` /
+  `:rf.db/runtime`) — the router maps `:db` effect → `:rf.db/app` partition
+  before calling this."
+  [id partitions]
+  (when-let [container (frame-state-container id)]
+    (let [current   (adapter/read-container container)
+          app-given? (contains? partitions app-partition-key)
+          rt-given?  (contains? partitions runtime-partition-key)
+          next-app  (if app-given? (get partitions app-partition-key)
+                        (get current app-partition-key))
+          next-rt   (if rt-given? (get partitions runtime-partition-key)
+                        (get current runtime-partition-key))
+          next-fs   {app-partition-key     next-app
+                     runtime-partition-key next-rt}
+          changed   (cond-> #{}
+                      (and app-given?
+                           (not= next-app (get current app-partition-key)))
+                      (conj app-partition-key)
+                      (and rt-given?
+                           (not= next-rt (get current runtime-partition-key)))
+                      (conj runtime-partition-key))]
+      ;; ONE atomic frame-state install — both partitions in one write, per
+      ;; Spec 006 §Commit boundary. Even a no-op (changed empty) re-installs
+      ;; the equal value; the projection reactions' `=`-memoisation collapses
+      ;; the downstream notification so a value-equal commit costs nothing.
+      (adapter/replace-container! container next-fs)
+      changed)))
+
+(defn replace-app-db!
+  "Replace ONLY the app-db partition of `id`'s frame-state, leaving
+  runtime-db untouched (Spec 002 §Frame-state value accessors and mutators,
+  Mike ruling #1 / #10 — a db-shaped name never silently replaces
+  runtime-db). Atomic install through the one physical container. Returns
+  the set of changed partition keys, or `nil` for an unknown / destroyed
+  frame. Internal write boundary used by the Tool-Pair `replace-app-db!` /
+  epoch `reset-frame-db!` path."
+  [id app-db]
+  (commit-frame-transition! id {app-partition-key app-db}))
+
+(defn replace-runtime-db!
+  "Replace ONLY the runtime-db partition of `id`'s frame-state, leaving
+  app-db untouched (Spec 002 §Frame-state value accessors and mutators).
+  The privileged runtime / full-frame write surface. Atomic install through
+  the one physical container. Returns the set of changed partition keys, or
+  `nil` for an unknown / destroyed frame."
+  [id runtime-db]
+  (commit-frame-transition! id {runtime-partition-key runtime-db}))
+
+(defn replace-frame-state!
+  "Replace BOTH partitions of `id` atomically with `frame-state`
+  (`{:rf.db/app … :rf.db/runtime …}`) — the full-frame install for
+  tool-driven replay / fixture install (epoch restore, time travel, SSR
+  hydration, frame reset). A db-shaped name never silently replaces
+  runtime-db; this is the explicit full-frame surface (Mike ruling #10).
+  Both partitions install in ONE atomic write. Returns the set of changed
+  partition keys, or `nil` for an unknown / destroyed frame.
+
+  `frame-state` MUST carry both partition keys; a missing key installs
+  `nil` for that partition (a full-frame replace is whole-value by
+  contract). Use `replace-app-db!` / `replace-runtime-db!` for a
+  single-partition write."
+  [id frame-state]
+  (commit-frame-transition! id {app-partition-key     (get frame-state app-partition-key)
+                                runtime-partition-key (get frame-state runtime-partition-key)}))
 
 (defn swap-frame-db!
-  "Mutate the frame's app-db: read the current value, compute
-  `(apply f db args)`, and replace the container with the result. Returns
-  the new-db, or nil if the frame is not registered.
+  "Mutate the frame's app-db PARTITION: read the current app-db value,
+  compute `(apply f db args)`, and install the result into the app-db
+  partition of the one physical frame-state container (runtime-db
+  untouched). Returns the new app-db, or nil if the frame is not registered.
 
-  Models `swap!` over the substrate-managed reactive container. Under the
-  single-drainer invariant (Spec 002 §Single drainer per frame) the
-  read-then-replace is effectively atomic — `replace-container!` is the
-  only writer during fx drain. The helper is the canonical \"mutate the
-  frame's app-db\" surface; the read-container / replace-container dance
-  belongs here, not at every fx-handler call site."
+  Models `swap!` over the app-db partition. Under the single-drainer
+  invariant (Spec 002 §Single drainer per frame) the read-then-replace is
+  effectively atomic — `commit-frame-transition!` is the only writer during
+  fx drain. The helper is the canonical \"mutate the frame's app-db\"
+  surface; the read / partition-commit dance belongs here, not at every
+  fx-handler call site.
+
+  EP-0001 (rf2-adwcv6): now writes the app-db partition of the physical
+  frame-state container (was a direct `replace-container!` on the old app-db
+  store). The machine / routing / SSR `:rf/runtime`-under-app-db writers that
+  call this keep working unchanged — `:rf/runtime` still lives inside app-db
+  until bead 6 (rf2-vzld77) migrates them to runtime-db."
   [id f & args]
-  (when-let [container (app-db-container id)]
-    (let [old-db (adapter/read-container container)
-          new-db (apply f old-db args)]
-      (adapter/replace-container! container new-db)
+  (when-let [container (frame-state-container id)]
+    (let [current (adapter/read-container container)
+          old-db  (get current app-partition-key)
+          new-db  (apply f old-db args)]
+      (adapter/replace-container! container
+                                  (assoc current app-partition-key new-db))
       new-db)))
 
 ;; ---- lifecycle-vs-drain serialization (rf2-2woz9) -------------------------
@@ -404,9 +582,24 @@
 ;; ---- registration ---------------------------------------------------------
 
 (defn- new-frame-record [id config]
-  {:id         id
-   :app-db     (adapter/make-state-container {})
-   :router     (atom {:queue interop/empty-queue :scheduled? false})
+  ;; ONE physical frame-state container holding both partitions (Spec 002
+  ;; §One physical container, two projection reactions; EP-0001 decision #3).
+  ;; A fresh frame starts with an empty app-db (Spec 002 §Frames always start
+  ;; with app-db = {}) and an empty runtime-db.
+  (let [frame-state (adapter/make-state-container {app-partition-key     {}
+                                                   runtime-partition-key {}})]
+   {:id          id
+    :frame-state frame-state
+    ;; app-db / runtime-db are READ-ONLY projection reactions over the one
+    ;; physical container — `make-derived-value` memoises on `=`, so a
+    ;; runtime-only commit does not propagate to app subs (and vice versa),
+    ;; with no dirty flags (decision #7). The compute-fn is the bare keyword
+    ;; lookup of the partition slice; `make-derived-value`'s recompute closure
+    ;; arity-specialises the 1-source case so the projection costs a single
+    ;; keyword invoke per recompute.
+    :app-db      (adapter/make-derived-value [frame-state] app-partition-key)
+    :runtime-db  (adapter/make-derived-value [frame-state] runtime-partition-key)
+    :router      (atom {:queue interop/empty-queue :scheduled? false})
    ;; Single-drainer invariant: a separate CAS-able cell that admits
    ;; at most one thread into `drain!` at a time. On the JVM the
    ;; executor's `next-tick` callback can wake while the calling
@@ -418,11 +611,11 @@
    ;; single-threaded so the CAS is uncontended there, but the same
    ;; flag preserves the contract under any future concurrent host.
    :drain-lock (atom false)
-   :sub-cache  (atom {})
-   :lifecycle  {:created-at (interop/now-ms)
-                :destroyed? false
-                :listeners  []}
-   :config     config})
+    :sub-cache  (atom {})
+    :lifecycle  {:created-at (interop/now-ms)
+                 :destroyed? false
+                 :listeners  []}
+    :config     config}))
 
 (declare destroy-frame!)
 
@@ -713,6 +906,22 @@
                  (catch #?(:clj Throwable :cljs :default) _ nil))))
         (reset! cache {})))))
 
+(defn- tear-down-partition-projections!
+  "Dispose the two partition projection reactions (`:app-db` /
+  `:runtime-db`) that `make-derived-value` layered over the physical
+  frame-state container (rf2-adwcv6). Each projection holds a watch on the
+  physical container (on the React-hook / plain-atom spine) or a Reagent
+  reaction; left undisposed across a `destroy-frame!`, those watches /
+  reactions leak in long-lived processes (test bundles, SSR per-request
+  frame churn, hot-reload). Best-effort — a throwing dispose does not abort
+  teardown. The physical frame-state container itself is GC'd with the
+  dropped frame record once `dissoc-frame!` runs; no explicit dispose."
+  [f]
+  (doseq [k [:app-db :runtime-db]]
+    (when-let [proj (get f k)]
+      (try (interop/dispose! proj)
+           (catch #?(:clj Throwable :cljs :default) _ nil)))))
+
 (defn- emit-frame-destroyed-trace!
   [id]
   (trace/emit! :rf.frame :rf.frame/destroyed
@@ -849,6 +1058,12 @@
         (notify-machine-destruction! id)
         (mark-frame-destroyed! id)
         (tear-down-sub-cache! id f)
+        ;; Dispose the app-db / runtime-db projection reactions (rf2-adwcv6)
+        ;; AFTER the sub-cache (the sub-cache's layer-1 reactions watch the
+        ;; app-db projection; disposing the projection first would orphan
+        ;; their source watch). The projections watch the physical
+        ;; frame-state container; disposing here releases those watches.
+        (tear-down-partition-projections! f)
         (safe-call-hook! :privacy/clear-suppression-cache!)
         (safe-call-hook! :elision/clear-warning-cache!)
         (safe-call-hook! :ssr/on-frame-destroyed id)

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -860,104 +860,160 @@
                      (seq dropped-machine-ids)
                      (assoc :dropped-machine-ids dropped-machine-ids))))))
 
-(defn- commit-db-effect!
-  "Apply :db atomically: replace the app-db container, emit the
-  :event/db-changed trace, then run post-commit schema validation.
-  Returns true when the commit is durable (no :db effect, or all
-  schemas conformed); false when post-commit validation rejected the
-  new state and the container has been **rolled back** to the
-  pre-handler value (per Spec 010 §Per-step recovery row 4 /
-  rf2-wkxng / rf2-6m0se).
+(defn- emit-frame-state-changed!
+  "Emit the partition-tagged `:rf.event/frame-state-changed` trace
+  (EP-0001 decision #6 / Spec 009 §Canonical per-event trace sequence).
+  `changed` is the set of frame-state partition keys that changed by `=`
+  (a subset of `#{:rf.db/app :rf.db/runtime}` returned by
+  `frame/commit-frame-transition!`); the trace carries
+  `:rf.event/partitions` mapped to the tooling-facing tag set
+  `#{:app-db :runtime-db}`. Fires only when at least one partition
+  changed. Dev-only — `trace/emit!` is internally gated on
+  `interop/debug-enabled?`, and the `phase` keyword is carried through for
+  the rollback re-emit."
+  ([event-id emit-event frame changed]
+   (emit-frame-state-changed! event-id emit-event frame changed nil))
+  ([event-id emit-event frame changed phase]
+   (when (seq changed)
+     (let [tags (cond-> #{}
+                  (contains? changed frame/app-partition-key)     (conj :app-db)
+                  (contains? changed frame/runtime-partition-key) (conj :runtime-db))]
+       (trace/emit! :rf.event :rf.event/frame-state-changed
+                    (cond-> {:rf.trace/event-id     event-id
+                             :rf.event/v            emit-event
+                             :frame                 frame
+                             :rf.event/partitions   tags}
+                      phase (assoc :rf.trace/phase phase)))))))
 
-  Per Spec 013 §Drain integration (rf2-u0zz5): `(:db effects)` here is
-  the FLOW-AUGMENTED value — the OUTERMOST flows-after-interceptor has
-  already rewritten the pending `:db` effect by the time the chain
-  returns. So `:event/db-changed` reflects the flow-derived db and fires
-  AFTER `:rf.flow/computed` (per Spec 009 §Canonical per-event trace
-  sequence).
+(defn- commit-frame-effects!
+  "Install the partitioned frame transition atomically (EP-0001 rf2-adwcv6,
+  Spec 002 §Drain-loop pseudocode §commit + §An ordinary :db return replaces
+  only app-db). A cascade may produce:
 
-  On rollback, a second :event/db-changed trace is emitted for the
-  restored state with `:phase :rollback` so listeners (subs, 10x,
-  pair-tools) observe the post-rollback app-db without ambiguity —
-  the trace stream's load-bearing ordering is `:db-changed (post-
-  handler) → :rf.error/schema-validation-failure → :db-changed
-  (post-rollback)`, mirroring the depth-exceeded pattern (the error
-  trace fires AFTER the container is back at its pre-handler value,
-  so a trace listener that reads app-db sees the rolled-back state).
-  Subscriptions whose inputs changed re-fire on the second commit so
-  the UI never settles on a non-conforming snapshot.
+    - an ordinary `:db` effect — the app-db partition write (scoped to
+      app-db; `:db` is NOT the whole frame);
+    - a reserved `:rf.db/runtime` effect — the runtime-db partition write
+      (whole-value replacement; decision #5 — operation-style writes go
+      through `swap-frame-db!` / the runtime mutators);
+    - both — installed as ONE coherent transition;
+    - neither — a no-op (a pre-install throw leaves no partition effect, so
+      this installs nothing and the event aborts with both partitions
+      unchanged).
 
-  Schema-derived redaction is reflected in the `:event/db-changed`
-  trace event's `:tags :event` slot. The router-installed internal
-  interceptor stashes the scrubbed form under `:rf/redacted-event`;
-  this commit path reads it through.
+  Both partitions install in ONE atomic `commit-frame-transition!` on the
+  single physical frame-state container — there is never a window where one
+  partition is committed and the other is not (Spec 006 §Commit boundary).
 
-  Per rf2-4wqu6 finding 1: on rollback the flow dirty-check
-  (`last-inputs`) bookkeeping is rolled back in lock-step with the
-  app-db. The flow transform advanced each computed flow's `last-inputs`
-  row inside the chain (folding the output into the now-discarded
-  pending `:db`); restoring app-db to `db-before` without also restoring
+  Returns true when the commit is durable (no partition effect, or app-db
+  schema conformed); false when post-commit app-db schema validation
+  rejected the new state and the frame-state has been **rolled back** to the
+  pre-handler value (per Spec 010 §Per-step recovery row 4 / rf2-wkxng /
+  rf2-6m0se). App-db schema validation is APP-DB-ONLY (app schemas validate
+  the app partition, Mike ruling #11); a rejection unwinds the WHOLE
+  transition (both partitions) so the frame is left coherently at its
+  pre-handler state.
+
+  Change traces (per Spec 009 §Canonical per-event trace sequence):
+    - `:rf.event/db-changed` — APP-DB-ONLY (Mike ruling #6): fires only when
+      the app-db partition changed; NEVER for a runtime-only commit;
+    - `:rf.event/frame-state-changed` — fires when EITHER partition changed,
+      partition-tagged (`#{:app-db}` / `#{:runtime-db}` / both).
+  A runtime-only commit emits ONLY frame-state-changed (`#{:runtime-db}`);
+  an app-only commit emits both (db-changed + frame-state-changed
+  `#{:app-db}`).
+
+  Per Spec 013 §Drain integration (rf2-u0zz5): `(:db effects)` here is the
+  FLOW-AUGMENTED app-db value — the OUTERMOST flows-after-interceptor has
+  already rewritten the pending `:db` effect by the time the chain returns.
+  So `:event/db-changed` reflects the flow-derived db and fires AFTER
+  `:rf.flow/computed` (per Spec 009 §Canonical per-event trace sequence).
+
+  On rollback, a second `:event/db-changed` (+ `frame-state-changed`) trace
+  is emitted for the restored state with `:phase :rollback` so listeners
+  (subs, 10x, pair-tools) observe the post-rollback frame-state without
+  ambiguity — the trace stream's load-bearing ordering is `:db-changed
+  (post-handler) → :rf.error/schema-validation-failure → :db-changed
+  (post-rollback)`, mirroring the depth-exceeded pattern (the error trace
+  fires AFTER the container is back at its pre-handler value).
+
+  Schema-derived redaction is reflected in the change traces' `:tags :event`
+  slot via `privacy/redacted-event-from-ctx`.
+
+  Per rf2-4wqu6 finding 1: on rollback the flow dirty-check (`last-inputs`)
+  bookkeeping is rolled back in lock-step (the flow transform advanced each
+  computed flow's row inside the chain; restoring app-db without restoring
   those rows would leave the dirty-check believing the flows are
-  up-to-date, so the next clean drain would skip them on `=`-equal
-  inputs and the output would never re-materialise. `ctx` carries the
-  pre-drain snapshot under `:rf/flow-last-inputs-before` (stashed by
-  `flows-after-interceptor`); the rollback arm restores it through the
-  frame-scoped `:flows/restore-last-inputs!` hook — the mirror of
-  `run-flows-on-db`'s throw-path rollback at the post-commit boundary."
-  [effects event-id event frame ctx db-before]
-  (if (contains? effects :db)
-    (let [container  (frame/app-db-container frame)
-          new-db     (:db effects)
-          emit-event (privacy/redacted-event-from-ctx ctx)]
-      (adapter/replace-container! container new-db)
-      (trace/emit! :rf.event :rf.event/db-changed
-                   {:rf.trace/event-id event-id :rf.event/v emit-event :frame frame})
-      (if (run-post-commit-validation! new-db event-id frame)
-        (do
-          ;; (rf2-p806o) Loud-failure guard: a durable `:db` commit that
-          ;; wholesale-replaced app-db and dropped a live `:rf/runtime`
-          ;; subsystem (machine snapshots / routing / elision / ssr) with no
-          ;; replacement is the silent `{:db fresh-map}` footgun — surface it.
-          ;; Fires only AFTER a durable commit (a rolled-back commit restores
-          ;; `db-before`, so no drop persists); see `detect-dropped-runtime-state!`
-          ;; for the discriminator that keeps restore-epoch / reset-frame-db /
-          ;; `:rf/hydrate` from false-firing.
-          (detect-dropped-runtime-state! db-before new-db event-id emit-event frame)
-          true)
-        (do
-          ;; Roll back: restore the pre-handler container value, then
-          ;; emit a second :event/db-changed with :phase :rollback so
-          ;; subs / listeners see the restored state on the trace
-          ;; stream. The error trace from validate-app-schema! has
-          ;; already fired between the two commits — consumers see
-          ;; (in order): forward commit, schema-failure error,
-          ;; rollback commit.
-          (adapter/replace-container! container db-before)
-          ;; Per rf2-4wqu6 finding 1: app-db rolled back to its pre-handler
-          ;; value, so the flow dirty-check (`last-inputs`) bookkeeping MUST
-          ;; roll back too — the flow transform already advanced each
-          ;; computed flow's row inside the chain, but those outputs were
-          ;; just discarded along with the rolled-back db. Restore THIS
-          ;; frame's pre-drain `last-inputs` snapshot (stashed on the ctx by
-          ;; `flows-after-interceptor`) so the next clean drain re-reads
-          ;; changed inputs and re-materialises the flow output instead of
-          ;; skipping it as `=`-equal. This is the exact mirror of
-          ;; `run-flows-on-db`'s throw-path rollback, applied at the
-          ;; post-commit boundary the flows artefact cannot reach. Both the
-          ;; snapshot and the restorer are frame-scoped (rf2-94ol5): a
-          ;; sibling frame's container is a different atom and is untouched.
-          ;; No-op when no flow ran (no snapshot stashed) or the flows
-          ;; artefact never loaded (restorer hook nil).
-          (when (contains? ctx :rf/flow-last-inputs-before)
-            (when-let [restore-li (late-bind/get-fn-cached :flows/restore-last-inputs!)]
-              (restore-li frame (:rf/flow-last-inputs-before ctx))))
+  up-to-date). `ctx` carries the pre-drain snapshot under
+  `:rf/flow-last-inputs-before`; the rollback arm restores it through the
+  frame-scoped `:flows/restore-last-inputs!` hook."
+  [effects event-id event frame ctx db-before runtime-before]
+  (let [app-effect? (contains? effects :db)
+        rt-effect?  (contains? effects :rf.db/runtime)]
+    (if (or app-effect? rt-effect?)
+      (let [new-db     (:db effects)
+            emit-event (privacy/redacted-event-from-ctx ctx)
+            ;; Map the EFFECT keys (:db / :rf.db/runtime) to the frame-state
+            ;; PARTITION keys (:rf.db/app / :rf.db/runtime). `:db` scopes to
+            ;; the app-db partition; `:rf.db/runtime` to runtime-db. A
+            ;; partition not present is carried forward unchanged by
+            ;; `commit-frame-transition!`.
+            partitions (cond-> {}
+                         app-effect? (assoc frame/app-partition-key     new-db)
+                         rt-effect?  (assoc frame/runtime-partition-key (:rf.db/runtime effects)))
+            ;; ONE atomic frame-state install. Returns the set of partition
+            ;; keys that actually changed by `=`.
+            changed    (frame/commit-frame-transition! frame partitions)
+            app-changed? (contains? changed frame/app-partition-key)]
+        ;; APP-DB-ONLY db-changed (Mike ruling #6) — only when the app-db
+        ;; partition actually changed. A runtime-only commit never fires it.
+        (when app-changed?
           (trace/emit! :rf.event :rf.event/db-changed
-                       {:rf.trace/event-id event-id
-                        :rf.event/v        emit-event
-                        :frame             frame
-                        :rf.trace/phase    :rollback})
-          false)))
-    true))
+                       {:rf.trace/event-id event-id :rf.event/v emit-event :frame frame}))
+        ;; Partition-tagged frame-state-changed — when EITHER partition changed.
+        (emit-frame-state-changed! event-id emit-event frame changed)
+        ;; App-db schema validation is app-db-only; it runs only when a `:db`
+        ;; effect produced a new app-db. A runtime-only commit skips it (app
+        ;; schemas do not describe runtime-db, Mike ruling #11).
+        (if (or (not app-effect?)
+                (run-post-commit-validation! new-db event-id frame))
+          (do
+            ;; (rf2-p806o) Loud-failure guard for the `{:db fresh-map}`
+            ;; footgun — surfaces a durable `:db` commit that wholesale-
+            ;; replaced app-db and dropped a live `:rf/runtime` subsystem.
+            ;; (Pre-bead-6, runtime subsystems still live at `:rf/runtime`
+            ;; INSIDE app-db, so the footgun and this guard remain on the
+            ;; app-db partition; bead 6 migrates them to runtime-db.) Fires
+            ;; only after a durable app-db commit.
+            (when app-effect?
+              (detect-dropped-runtime-state! db-before new-db event-id emit-event frame))
+            true)
+          (do
+            ;; Roll back the WHOLE transition (both partitions) to the
+            ;; pre-handler frame-state so the frame stays coherent — app-db
+            ;; schema rejection unwinds any runtime-db write in the same
+            ;; cascade too. Then emit the rollback change traces so subs /
+            ;; listeners see the restored state. The schema-failure error
+            ;; trace already fired between the forward and rollback commits.
+            (let [rb-changed (frame/replace-frame-state!
+                               frame
+                               {frame/app-partition-key     db-before
+                                frame/runtime-partition-key runtime-before})]
+              ;; Per rf2-4wqu6 finding 1: roll back the flow dirty-check
+              ;; (`last-inputs`) bookkeeping in lock-step with the app-db
+              ;; (frame-scoped, rf2-94ol5). No-op when no flow ran or the
+              ;; flows artefact never loaded.
+              (when (contains? ctx :rf/flow-last-inputs-before)
+                (when-let [restore-li (late-bind/get-fn-cached :flows/restore-last-inputs!)]
+                  (restore-li frame (:rf/flow-last-inputs-before ctx))))
+              (when (contains? rb-changed frame/app-partition-key)
+                (trace/emit! :rf.event :rf.event/db-changed
+                             {:rf.trace/event-id event-id
+                              :rf.event/v        emit-event
+                              :frame             frame
+                              :rf.trace/phase    :rollback}))
+              (emit-frame-state-changed! event-id emit-event frame rb-changed :rollback))
+            false)))
+      true)))
 
 (def ^:private flows-after-interceptor
   "Per Spec 013 §Drain integration (rf2-u0zz5): the framework-owned
@@ -1521,10 +1577,15 @@
   of any downstream rollback — it is the proximate, most-actionable
   signal."
   [final-ctx event-id event frame frame-record fx-overrides envelope start-ms]
-  (let [effects    (:effects final-ctx)
-        error      (:rf/interceptor-error final-ctx)
-        flow-error (:rf/flow-error final-ctx)
-        db-before  (get-in final-ctx [:coeffects :db])]
+  (let [effects        (:effects final-ctx)
+        error          (:rf/interceptor-error final-ctx)
+        flow-error     (:rf/flow-error final-ctx)
+        db-before      (get-in final-ctx [:coeffects :db])
+        ;; Pre-handler runtime-db partition (EP-0001 rf2-adwcv6): the
+        ;; `:rf.db/runtime` coeffect `assemble-initial-ctx` injected by
+        ;; reference. Needed by `commit-frame-effects!` so an app-db schema
+        ;; rollback unwinds the WHOLE transition (both partitions) coherently.
+        runtime-before (get-in final-ctx [:coeffects :rf.db/runtime])]
     (when error
       (emit-pipeline-exception! error event-id event frame final-ctx start-ms))
     (cond
@@ -1543,11 +1604,12 @@
       (do
         (emit-flow-eval-exception! flow-error event event-id frame start-ms)
         :flow-error)
-      ;; Per Spec 010 §Per-step recovery row 4: `commit-db-effect!`
-      ;; returns false when post-commit schema validation rejected the
-      ;; new state and rolled the container back to its pre-handler
-      ;; value. `:fx` is skipped; the dispatch failed.
-      (not (commit-db-effect! effects event-id event frame final-ctx db-before))
+      ;; Per Spec 010 §Per-step recovery row 4: `commit-frame-effects!`
+      ;; returns false when post-commit app-db schema validation rejected
+      ;; the new state and rolled the WHOLE frame-state transition back to
+      ;; its pre-handler value. `:fx` is skipped; the dispatch failed.
+      (not (commit-frame-effects! effects event-id event frame final-ctx
+                                  db-before runtime-before))
       :rolled-back
       :else
       (do

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -1916,11 +1916,12 @@
       (rf/dispatch-sync [:test/m [:go]])
       (let [post-go-db (rf/app-db-value :rf/default)]
         (is (= :working (get-in post-go-db [:rf/runtime :machines :snapshots :test/m :state])) "machine reached :working")
-        (let [container (frame/app-db-container :rf/default)
-              reverted  (assoc-in post-go-db [:rf/runtime :machines :snapshots :test/m :state] :idle)]
-          (substrate-adapter/replace-container! container reverted))
+        ;; EP-0001 (rf2-adwcv6): revert via the app-db PARTITION write
+        ;; (swap-frame-db!) — app-db-container is now a read-only projection.
+        (frame/swap-frame-db! :rf/default
+          (fn [db] (assoc-in db [:rf/runtime :machines :snapshots :test/m :state] :idle)))
         (is (= :idle (get-in (rf/app-db-value :rf/default) [:rf/runtime :machines :snapshots :test/m :state]))
-            "after replace-container! the snapshot reads back as :idle")
+            "after the partition revert the snapshot reads back as :idle")
         (rf/dispatch-sync [:test/m [:go]])
         (is (= :working (get-in (rf/app-db-value :rf/default) [:rf/runtime :machines :snapshots :test/m :state]))
             "re-dispatch after revert advances from the restored state")))))

--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -450,9 +450,11 @@
     (let [adapter-helpers
           {:read-db!  (fn [frame-id]
                         (frame/frame-app-db-value frame-id))
+           ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION via
+           ;; `swap-frame-db!` — `frame/app-db-container` is now a READ-ONLY
+           ;; projection over the one physical frame-state container.
            :write-db! (fn [frame-id new-db]
-                        (let [container (frame/app-db-container frame-id)]
-                          (substrate-adapter/replace-container! container new-db)))
+                        (frame/swap-frame-db! frame-id (constantly new-db)))
            :dispatch! (fn [event frame-id]
                         (rf/dispatch event {:frame frame-id}))
            ;; Per Cross-Spec Interaction §14 (rf2-60szl): dispatch-sync

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -481,10 +481,13 @@
     (let [adapter-helpers
           {:read-db!  (fn [frame-id]
                         (frame/frame-app-db-value frame-id))
+           ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION of the one
+           ;; physical frame-state container. `frame/app-db-container` is now
+           ;; a READ-ONLY projection, so a direct `replace-container!` on it
+           ;; throws; `swap-frame-db!` (constant fn) installs the new app-db
+           ;; into the app-db partition, leaving runtime-db untouched.
            :write-db! (fn [frame-id new-db]
-                        (let [container (frame/app-db-container frame-id)]
-                          ((requiring-resolve 're-frame.substrate.adapter/replace-container!)
-                           container new-db)))
+                        (frame/swap-frame-db! frame-id (constantly new-db)))
            :dispatch! (fn [event frame-id]
                         (rf/dispatch event {:frame frame-id}))
            ;; Per Cross-Spec Interaction §14 (rf2-60szl): dispatch-sync

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -322,47 +322,55 @@
   (testing "app-db-value returns nil for an unknown frame"
     (is (nil? (rf/app-db-value :pp/no-such-frame)))))
 
-(deftest runtime-db-value-is-nil-until-bead-5
-  (testing "runtime-db-value reads nil — the physical partition lands in bead 5"
+(deftest runtime-db-value-reads-real-partition
+  (testing "runtime-db-value reads the real runtime-db partition (rf2-adwcv6, bead 5)"
     (rf/reg-frame :pp/runtime {:doc "runtime"})
-    (is (nil? (rf/runtime-db-value :pp/runtime))
-        "live frame: runtime-db has no physical slot yet (rf2-adwcv6)")
+    (is (= {} (rf/runtime-db-value :pp/runtime))
+        "live frame: a fresh frame's runtime-db starts {} (the physical partition is real now)")
     (is (nil? (rf/runtime-db-value :pp/no-such-frame))
-        "unknown frame: nil")))
+        "unknown frame: nil")
+    (rf/replace-runtime-db! :pp/runtime {:rf.runtime/machines {:m 1}})
+    (is (= {:rf.runtime/machines {:m 1}} (rf/runtime-db-value :pp/runtime))
+        "runtime-db-value reads back exactly what replace-runtime-db! wrote")))
 
 (deftest frame-state-value-projection-shape
-  (testing "frame-state-value yields {:rf.db/app … :rf.db/runtime …}"
+  (testing "frame-state-value yields {:rf.db/app … :rf.db/runtime …} with the real runtime-db"
     (rf/reg-frame :pp/fs {:doc "frame-state"})
     (rf/reg-event-db :pp/seed-fs (fn [_ [_ db]] db))
     (rf/dispatch-sync [:pp/seed-fs {:a 1}] {:frame :pp/fs})
-    (is (= {:rf.db/app {:a 1} :rf.db/runtime nil}
+    (is (= {:rf.db/app {:a 1} :rf.db/runtime {}}
            (rf/frame-state-value :pp/fs))
-        "app-db slot carries the live app-db; runtime-db slot nil until bead 5")
+        "app-db slot carries the live app-db; runtime-db slot is the real (fresh {}) partition")
     (is (= {:a 1} (:rf.db/app (rf/frame-state-value :pp/fs)))
         "the :rf.db/app slot equals app-db-value")
     (is (= (rf/app-db-value :pp/fs) (:rf.db/app (rf/frame-state-value :pp/fs)))
-        "frame-state :rf.db/app is the same value app-db-value returns")))
+        "frame-state :rf.db/app is the same value app-db-value returns")
+    (is (= (rf/runtime-db-value :pp/fs) (:rf.db/runtime (rf/frame-state-value :pp/fs)))
+        "frame-state :rf.db/runtime is the same value runtime-db-value returns")))
 
 (deftest frame-state-value-unknown-frame-is-nil
   (testing "frame-state-value returns nil for an unknown frame"
     (is (nil? (rf/frame-state-value :pp/no-such-frame)))))
 
-(deftest replace-runtime-db-defers-to-bead-5
-  (testing "replace-runtime-db! throws until the physical partition lands (rf2-adwcv6)"
+(deftest replace-runtime-db-writes-real-partition
+  (testing "replace-runtime-db! writes the runtime-db partition only (rf2-adwcv6)"
     (rf/reg-frame :pp/rdb {:doc "runtime-mutate"})
-    (let [e (try (rf/replace-runtime-db! :pp/rdb {:rf.runtime/machines {}}) nil
-                 (catch clojure.lang.ExceptionInfo e e))]
-      (is (some? e) "replace-runtime-db! must signal rather than silently drop data")
-      (is (= :rf.error/not-yet-implemented (:rf.error/id (ex-data e))))
-      (is (= :rf2-adwcv6 (:deferred-to (ex-data e)))
-          "ex-data names bead 5 as the home of the physical write"))))
+    (rf/reg-event-db :pp/seed-app (fn [_ [_ db]] db))
+    (rf/dispatch-sync [:pp/seed-app {:app :data}] {:frame :pp/rdb})
+    (rf/replace-runtime-db! :pp/rdb {:rf.runtime/machines {}})
+    (is (= {:rf.runtime/machines {}} (rf/runtime-db-value :pp/rdb))
+        "runtime-db partition replaced")
+    (is (= {:app :data} (rf/app-db-value :pp/rdb))
+        "app-db partition untouched by a runtime-db-only write")))
 
-(deftest replace-frame-state-defers-to-bead-5
-  (testing "replace-frame-state! throws until the physical container lands (rf2-adwcv6)"
+(deftest replace-frame-state-writes-both-partitions
+  (testing "replace-frame-state! installs both partitions atomically (rf2-adwcv6)"
     (rf/reg-frame :pp/fsm {:doc "frame-state-mutate"})
-    (let [e (try (rf/replace-frame-state! :pp/fsm {:rf.db/app {} :rf.db/runtime {}}) nil
-                 (catch clojure.lang.ExceptionInfo e e))]
-      (is (some? e) "replace-frame-state! must signal rather than apply only the app-db half")
-      (is (= :rf.error/not-yet-implemented (:rf.error/id (ex-data e))))
-      (is (= :rf2-adwcv6 (:deferred-to (ex-data e)))
-          "ex-data names bead 5 as the home of the atomic full-frame install"))))
+    (rf/replace-frame-state! :pp/fsm {:rf.db/app {:a 7} :rf.db/runtime {:rf.runtime/routing {:r 1}}})
+    (is (= {:a 7} (rf/app-db-value :pp/fsm))
+        "app-db partition installed")
+    (is (= {:rf.runtime/routing {:r 1}} (rf/runtime-db-value :pp/fsm))
+        "runtime-db partition installed")
+    (is (= {:rf.db/app {:a 7} :rf.db/runtime {:rf.runtime/routing {:r 1}}}
+           (rf/frame-state-value :pp/fsm))
+        "frame-state reads back the coherent both-partition snapshot")))

--- a/implementation/core/test/re_frame/event_context_partition_test.clj
+++ b/implementation/core/test/re_frame/event_context_partition_test.clj
@@ -90,8 +90,8 @@
       (let [cofx @captured]
         (is (contains? cofx :rf.db/runtime)
             ":rf.db/runtime coeffect is present (runtime-db partition)")
-        (is (nil? (:rf.db/runtime cofx))
-            ":rf.db/runtime reads nil until the physical partition lands (bead 5 / rf2-adwcv6)")
+        (is (= {} (:rf.db/runtime cofx))
+            ":rf.db/runtime reads the real (fresh {}) runtime-db partition (rf2-adwcv6, bead 5)")
         (is (= (rf/runtime-db-value :ctx/partitions) (:rf.db/runtime cofx))
             ":rf.db/runtime coeffect equals runtime-db-value")
         (is (= :ctx/partitions (:rf.frame/id cofx))

--- a/implementation/core/test/re_frame/partitioned_commit_test.clj
+++ b/implementation/core/test/re_frame/partitioned_commit_test.clj
@@ -1,0 +1,342 @@
+(ns re-frame.partitioned-commit-test
+  "EP-0001 (rf2-adwcv6) — the partitioned COMMIT: the physical heart of the
+  two-partition frame. Pins the bead-5 contract:
+
+    1. ONE physical frame-state container; app-db / runtime-db are PROJECTION
+       REACTIONS over it (decision #3). `frame-state-container` is the single
+       writable cell; `app-db-container` / `runtime-db-container` are
+       read-only projections.
+    2. An ordinary `:db` effect is scoped to the app-db partition — it
+       replaces ONLY app-db; runtime-db is untouched (the footgun is gone).
+    3. A reserved `:rf.db/runtime` effect commits to the runtime-db partition
+       (whole-value replacement). Operation-style runtime writes go through
+       the helpers / mutators (decision #5 — both shapes supported).
+    4. An app+runtime cascade installs BOTH partitions as ONE atomic
+       frame-state transition (Spec 006 §Commit boundary).
+    5. Projection-equality invalidation, NO dirty flags (decision #7): a
+       runtime-only commit leaves the app-db projection `=` and does not
+       invalidate app subs; an app-only commit leaves the runtime-db
+       projection `=` and does not invalidate framework subs.
+    6. `:rf.event/db-changed` stays APP-DB-ONLY (decision #6); a new
+       `:rf.event/frame-state-changed` fires partition-tagged for EITHER
+       partition.
+    7. `replace-app-db!` / `replace-runtime-db!` / `replace-frame-state!`
+       are real partition writes (the bead-3 :not-yet-implemented throws are
+       gone).
+    8. Atomicity: an app-db schema rollback unwinds the WHOLE transition
+       (both partitions) — preserving the pre-commit-transactional /
+       post-commit-best-effort fx asymmetry (Mike-ruled, unchanged)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (when-let [clear-schemas! (late-bind/get-fn :schemas/clear-by-frame!)]
+    (clear-schemas!))
+  (trace/clear-listeners!)
+  (rf/init! plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- record-traces! [listener-id]
+  (let [a (atom [])]
+    (rf/register-listener! listener-id (fn [ev] (swap! a conj ev)))
+    a))
+
+(defn- events-of [recorded operation]
+  (filterv #(= operation (:operation %)) @recorded))
+
+;; A framework-authority handler (machine registrar would mint this) can
+;; emit `:rf.db/runtime` without firing the dev diagnostic. We use the same
+;; `:rf/machine? true` marker the diagnostic keys on.
+(defn- reg-fw-runtime-handler! [id f]
+  (rf/reg-event-fx id {:doc "framework-authority" :rf/machine? true} f))
+
+;; ===========================================================================
+;; 1 — one physical container + two projection reactions (decision #3)
+;; ===========================================================================
+
+(deftest one-physical-container-two-projections
+  (testing "a frame holds one frame-state container; app-db / runtime-db are projections over it"
+    (rf/reg-frame :pc/shape {:doc "shape"})
+    (let [fs   (frame/frame-state-container :pc/shape)
+          app  (frame/app-db-container :pc/shape)
+          rt   (frame/runtime-db-container :pc/shape)]
+      (is (some? fs) "the physical frame-state container exists")
+      (is (some? app) "the app-db projection exists")
+      (is (some? rt) "the runtime-db projection exists")
+      (is (= {:rf.db/app {} :rf.db/runtime {}}
+             (adapter/read-container fs))
+          "the physical container holds the coherent frame-state value (both partitions)")
+      (is (= {} (adapter/read-container app))
+          "the app-db projection derefs the :rf.db/app slice")
+      (is (= {} (adapter/read-container rt))
+          "the runtime-db projection derefs the :rf.db/runtime slice"))))
+
+(deftest projections-are-read-only
+  (testing "writing the app-db / runtime-db projection throws derived-container-replaced"
+    (rf/reg-frame :pc/ro {:doc "ro"})
+    (doseq [container [(frame/app-db-container :pc/ro)
+                       (frame/runtime-db-container :pc/ro)]]
+      (let [e (try (adapter/replace-container! container {:x 1}) nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? e) "a projection reaction rejects replace-container!")
+        (is (= :rf.error/derived-container-replaced (:rf.error/id (ex-data e)))
+            "the rejection carries the canonical derived-container-replaced id")))))
+
+;; ===========================================================================
+;; 2 — ordinary :db scoped to the app-db partition (the footgun is gone)
+;; ===========================================================================
+
+(deftest ordinary-db-effect-scoped-to-app-db
+  (testing "an ordinary :db effect replaces ONLY app-db; runtime-db is untouched"
+    (rf/reg-frame :pc/scope {:doc "scope"})
+    ;; Seed a runtime-db partition (framework-authority write).
+    (reg-fw-runtime-handler! :pc/seed-rt
+      (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:door {:state :open}}}}))
+    (rf/dispatch-sync [:pc/seed-rt] {:frame :pc/scope})
+    (is (= {:rf.runtime/machines {:door {:state :open}}}
+           (rf/runtime-db-value :pc/scope)))
+    ;; A fresh-map app handler — the classic footgun shape — must NOT drop
+    ;; runtime-db, because :db is scoped to the app-db partition.
+    (rf/reg-event-db :pc/fresh (fn [_ _] {:session :anonymous}))
+    (rf/dispatch-sync [:pc/fresh] {:frame :pc/scope})
+    (is (= {:session :anonymous} (rf/app-db-value :pc/scope))
+        "app-db replaced wholesale")
+    (is (= {:rf.runtime/machines {:door {:state :open}}}
+           (rf/runtime-db-value :pc/scope))
+        "runtime-db SURVIVES a fresh-map :db return — the partition footgun is structurally gone")))
+
+;; ===========================================================================
+;; 3 — runtime-db commit (both write shapes — decision #5)
+;; ===========================================================================
+
+(deftest runtime-db-effect-whole-value-commit
+  (testing "a framework :rf.db/runtime effect commits the runtime-db partition (whole-value)"
+    (rf/reg-frame :pc/rtfx {:doc "rtfx"})
+    (rf/reg-event-db :pc/seed-app (fn [_ _] {:app :data}))
+    (rf/dispatch-sync [:pc/seed-app] {:frame :pc/rtfx})
+    (reg-fw-runtime-handler! :pc/write-rt
+      (fn [_ _] {:rf.db/runtime {:rf.runtime/routing {:current {:id :home}}}}))
+    (rf/dispatch-sync [:pc/write-rt] {:frame :pc/rtfx})
+    (is (= {:rf.runtime/routing {:current {:id :home}}}
+           (rf/runtime-db-value :pc/rtfx))
+        "the :rf.db/runtime effect installed the runtime-db partition")
+    (is (= {:app :data} (rf/app-db-value :pc/rtfx))
+        "app-db is untouched by a runtime-only effect")))
+
+(deftest runtime-db-operation-style-write
+  (testing "operation-style runtime writes (via the mutator) coexist with whole-value (decision #5)"
+    (rf/reg-frame :pc/rtop {:doc "rtop"})
+    ;; whole-value seed
+    (rf/replace-runtime-db! :pc/rtop {:rf.runtime/machines {:a 1}})
+    (is (= {:rf.runtime/machines {:a 1}} (rf/runtime-db-value :pc/rtop)))
+    ;; operation-style update over the partition (read-modify-write)
+    (rf/replace-runtime-db! :pc/rtop
+                            (assoc (rf/runtime-db-value :pc/rtop)
+                                   :rf.runtime/routing {:current {:id :x}}))
+    (is (= {:rf.runtime/machines {:a 1}
+            :rf.runtime/routing {:current {:id :x}}}
+           (rf/runtime-db-value :pc/rtop))
+        "an operation-style write merges into the existing runtime-db partition")))
+
+;; ===========================================================================
+;; 4 — atomic cross-partition commit (Spec 006 §Commit boundary)
+;; ===========================================================================
+
+(deftest atomic-cross-partition-commit
+  (testing "an app+runtime cascade installs both partitions as ONE coherent transition"
+    (rf/reg-frame :pc/both {:doc "both"})
+    (reg-fw-runtime-handler! :pc/app-and-rt
+      (fn [{:keys [db]} _]
+        {:db (assoc db :page :account)
+         :rf.db/runtime {:rf.runtime/routing {:current {:id :account}}}}))
+    (rf/dispatch-sync [:pc/app-and-rt] {:frame :pc/both})
+    (is (= {:page :account} (rf/app-db-value :pc/both))
+        "app-db partition committed")
+    (is (= {:rf.runtime/routing {:current {:id :account}}}
+           (rf/runtime-db-value :pc/both))
+        "runtime-db partition committed")
+    ;; The physical container holds the coherent both-partition value — there
+    ;; is no window where one partition is committed and the other is not.
+    (is (= {:rf.db/app {:page :account}
+            :rf.db/runtime {:rf.runtime/routing {:current {:id :account}}}}
+           (adapter/read-container (frame/frame-state-container :pc/both)))
+        "both partitions are present in the single physical frame-state value")))
+
+;; ===========================================================================
+;; 5 — projection-equality invalidation: NO dirty flags (decision #7)
+;; ===========================================================================
+
+(deftest runtime-only-commit-does-not-invalidate-app-subs
+  (testing "a runtime-only commit leaves app-db `=` and does not recompute app subs"
+    ;; Use :rf/default + with-frame so subscribe resolves a derefable reaction
+    ;; (the {:frame …} subscribe opt has a separate JVM resolution path).
+    (rf/reg-event-db :pc/seed (fn [_ _] {:n 1}))
+    (rf/dispatch-sync [:pc/seed])
+    (let [runs (atom 0)]
+      (rf/reg-sub :pc/app-sub (fn [db _] (swap! runs inc) (:n db)))
+      ;; prime the sub
+      (is (= 1 (rf/with-frame :rf/default @(rf/subscribe [:pc/app-sub]))))
+      (let [after-prime @runs]
+        ;; runtime-only commit — app-db (:rf.db/app) is value-identical
+        (reg-fw-runtime-handler! :pc/touch-rt
+          (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:m 1}}}))
+        (rf/dispatch-sync [:pc/touch-rt])
+        ;; force a deref to give the sub the chance to recompute
+        (is (= 1 (rf/with-frame :rf/default @(rf/subscribe [:pc/app-sub]))))
+        (is (= after-prime @runs)
+            "the app sub did NOT recompute — the app-db projection stayed `=` on a runtime-only commit")
+        (is (= {:rf.runtime/machines {:m 1}} (rf/runtime-db-value :rf/default))
+            "the runtime-only commit DID land in runtime-db")))))
+
+(deftest app-only-commit-does-not-invalidate-runtime-projection
+  (testing "an app-only commit leaves runtime-db `=` (the runtime-db projection does not change)"
+    (rf/reg-frame :pc/inval-rt {:doc "inval-rt"})
+    (reg-fw-runtime-handler! :pc/seed-rt2
+      (fn [_ _] {:rf.db/runtime {:rf.runtime/routing {:current {:id :home}}}}))
+    (rf/dispatch-sync [:pc/seed-rt2] {:frame :pc/inval-rt})
+    (let [rt-before (rf/runtime-db-value :pc/inval-rt)]
+      ;; app-only commit
+      (rf/reg-event-db :pc/app-write (fn [db _] (assoc db :touched? true)))
+      (rf/dispatch-sync [:pc/app-write] {:frame :pc/inval-rt})
+      (is (true? (:touched? (rf/app-db-value :pc/inval-rt))))
+      (is (identical? rt-before (rf/runtime-db-value :pc/inval-rt))
+          "runtime-db is reference-identical across an app-only commit — no spurious runtime change"))))
+
+;; ===========================================================================
+;; 6 — change traces: db-changed app-db-only + partition-tagged frame-state-changed
+;; ===========================================================================
+
+(deftest app-only-commit-trace-shape
+  (testing "an app-only commit emits db-changed AND frame-state-changed #{:app-db}"
+    (rf/reg-frame :pc/tr-app {:doc "tr-app"})
+    (let [recorded (record-traces! ::tr-app)]
+      (rf/reg-event-db :pc/app-only (fn [db _] (assoc db :k 1)))
+      (rf/dispatch-sync [:pc/app-only] {:frame :pc/tr-app})
+      (let [dbc (events-of recorded :rf.event/db-changed)
+            fsc (events-of recorded :rf.event/frame-state-changed)]
+        (is (= 1 (count dbc)) "db-changed fires for an app-db change")
+        (is (= 1 (count fsc)) "frame-state-changed fires too")
+        (is (= #{:app-db} (:rf.event/partitions (:tags (first fsc))))
+            "frame-state-changed is tagged #{:app-db}")))))
+
+(deftest runtime-only-commit-trace-shape
+  (testing "a runtime-only commit emits frame-state-changed #{:runtime-db} and NO db-changed"
+    (rf/reg-frame :pc/tr-rt {:doc "tr-rt"})
+    (let [recorded (record-traces! ::tr-rt)]
+      (reg-fw-runtime-handler! :pc/rt-only
+        (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:m 1}}}))
+      (rf/dispatch-sync [:pc/rt-only] {:frame :pc/tr-rt})
+      (let [dbc (events-of recorded :rf.event/db-changed)
+            fsc (events-of recorded :rf.event/frame-state-changed)]
+        (is (empty? dbc)
+            ":rf.event/db-changed is APP-DB-ONLY (Mike ruling #6) — NOT emitted for a runtime-only commit")
+        (is (= 1 (count fsc)) "frame-state-changed fires for the runtime change")
+        (is (= #{:runtime-db} (:rf.event/partitions (:tags (first fsc))))
+            "frame-state-changed is tagged #{:runtime-db}")))))
+
+(deftest both-partition-commit-trace-shape
+  (testing "a both-partition commit emits db-changed + frame-state-changed #{:app-db :runtime-db}"
+    (rf/reg-frame :pc/tr-both {:doc "tr-both"})
+    (let [recorded (record-traces! ::tr-both)]
+      (reg-fw-runtime-handler! :pc/both-tr
+        (fn [{:keys [db]} _]
+          {:db (assoc db :k 1)
+           :rf.db/runtime {:rf.runtime/routing {:current {:id :x}}}}))
+      (rf/dispatch-sync [:pc/both-tr] {:frame :pc/tr-both})
+      (let [dbc (events-of recorded :rf.event/db-changed)
+            fsc (events-of recorded :rf.event/frame-state-changed)]
+        (is (= 1 (count dbc)) "db-changed fires (app-db changed)")
+        (is (= 1 (count fsc)) "frame-state-changed fires once")
+        (is (= #{:app-db :runtime-db} (:rf.event/partitions (:tags (first fsc))))
+            "frame-state-changed names both touched partitions")))))
+
+(deftest no-op-partition-commit-emits-no-change-trace
+  (testing "a :db effect equal to the current app-db emits neither change trace"
+    (rf/reg-frame :pc/tr-noop {:doc "tr-noop"})
+    (rf/reg-event-db :pc/seed (fn [_ _] {:k 1}))
+    (rf/dispatch-sync [:pc/seed] {:frame :pc/tr-noop})
+    (let [recorded (record-traces! ::tr-noop)]
+      ;; return the SAME app-db value
+      (rf/reg-event-db :pc/same (fn [db _] db))
+      (rf/dispatch-sync [:pc/same] {:frame :pc/tr-noop})
+      (is (empty? (events-of recorded :rf.event/db-changed))
+          "a value-equal app-db commit is not reported as a change")
+      (is (empty? (events-of recorded :rf.event/frame-state-changed))
+          "neither is frame-state-changed — change derives from projection equality, no dirty flags"))))
+
+;; ===========================================================================
+;; 7 — the mutators are real (bead-3 throws are gone)
+;; ===========================================================================
+
+(deftest replace-app-db-leaves-runtime-untouched
+  (testing "replace-app-db! writes only app-db; runtime-db survives"
+    (rf/reg-frame :pc/m-app {:doc "m-app"})
+    (rf/replace-runtime-db! :pc/m-app {:rf.runtime/machines {:m 1}})
+    ;; The frame-level helper (epoch artefact not on core's classpath, so the
+    ;; public `rf/replace-app-db!` epoch-delegate is exercised in the epoch
+    ;; artefact's own suite).
+    (frame/replace-app-db! :pc/m-app {:k 1})
+    (is (= {:k 1} (rf/app-db-value :pc/m-app)))
+    (is (= {:rf.runtime/machines {:m 1}} (rf/runtime-db-value :pc/m-app))
+        "replace-app-db! never silently replaces runtime-db (Mike ruling #10)")))
+
+(deftest replace-frame-state-is-atomic-both-partitions
+  (testing "replace-frame-state! installs both partitions in one write"
+    (rf/reg-frame :pc/m-fs {:doc "m-fs"})
+    (rf/replace-frame-state! :pc/m-fs {:rf.db/app {:a 1}
+                                       :rf.db/runtime {:rf.runtime/routing {:r 1}}})
+    (is (= {:rf.db/app {:a 1} :rf.db/runtime {:rf.runtime/routing {:r 1}}}
+           (rf/frame-state-value :pc/m-fs))
+        "both partitions installed coherently")))
+
+(deftest mutators-return-changed-partition-set
+  (testing "the frame-level commit helpers report which partition(s) changed"
+    (rf/reg-frame :pc/m-ret {:doc "m-ret"})
+    (is (= #{:rf.db/app} (frame/replace-app-db! :pc/m-ret {:k 1}))
+        "an app-db write reports #{:rf.db/app}")
+    (is (= #{} (frame/replace-app-db! :pc/m-ret {:k 1}))
+        "a value-equal write reports no change (projection-equality)")
+    (is (= #{:rf.db/runtime} (frame/replace-runtime-db! :pc/m-ret {:rf.runtime/machines {}}))
+        "a runtime-db write reports #{:rf.db/runtime}")
+    (is (nil? (frame/replace-app-db! :pc/no-such {:k 1}))
+        "an unknown frame returns nil")))
+
+;; ===========================================================================
+;; 8 — atomicity: app-db schema rollback unwinds the whole transition
+;; ===========================================================================
+
+(deftest schema-rollback-unwinds-both-partitions
+  (testing "an app-db schema rejection rolls back BOTH partitions to the pre-handler state"
+    ;; Only run when the schemas artefact is on the classpath (optional).
+    (when (late-bind/get-fn :schemas/validate-app-schema!)
+      (rf/reg-frame :pc/rb {:doc "rb"})
+      ;; seed a coherent pre-handler frame-state
+      (rf/replace-frame-state! :pc/rb {:rf.db/app {:n 0}
+                                       :rf.db/runtime {:rf.runtime/machines {:m :pre}}})
+      ;; app schema (root path) demanding :n be a non-negative int — scoped to
+      ;; the frame via with-frame (reg-app-schema is current-frame-scoped).
+      (rf/with-frame :pc/rb
+        (rf/reg-app-schema [] [:map [:n [:int {:min 0}]]]))
+      (reg-fw-runtime-handler! :pc/bad
+        (fn [_ _]
+          {:db {:n -5}                                   ;; violates the schema
+           :rf.db/runtime {:rf.runtime/machines {:m :post}}}))
+      (rf/dispatch-sync [:pc/bad] {:frame :pc/rb})
+      (is (= {:n 0} (rf/app-db-value :pc/rb))
+          "app-db rolled back to the pre-handler value")
+      (is (= {:rf.runtime/machines {:m :pre}} (rf/runtime-db-value :pc/rb))
+          "runtime-db ALSO rolled back — the whole transition unwinds coherently"))))

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -49,7 +49,6 @@
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
-            [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
 ;; ---- configuration --------------------------------------------------------
@@ -477,12 +476,18 @@
   canonical `:rf.error/no-such-handler` (kind `:frame`) failure trace and
   returns `false`, matching the destroyed-frame contract."
   [frame-id new-db]
-  (let [{:keys [outcome op tags container]} (tool-pair/live-container-or-fail frame-id)]
+  (let [{:keys [outcome op tags]} (tool-pair/live-container-or-fail frame-id)]
     (if (= :fail outcome)
       (do (tool-pair/emit-precondition-failure! op tags)
           false)
-      (let [db-before (adapter/read-container container)]
-        (adapter/replace-container! container new-db)
+      (let [db-before (frame/frame-app-db-value frame-id)]
+        ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION of the one
+        ;; physical frame-state container — `frame/app-db-container` is now a
+        ;; READ-ONLY projection, so a direct `replace-container!` on it
+        ;; throws. `reset-frame-db!` / `replace-app-db!` replace the app-db
+        ;; partition only; runtime-db is untouched (Mike ruling #10 — a
+        ;; db-shaped name never silently replaces runtime-db).
+        (frame/replace-app-db! frame-id new-db)
         ;; Record a synthetic epoch so `restore-epoch` can rewind the
         ;; previous state. The record's :trigger-event is the
         ;; pair-tool injection sentinel (no application event ran).

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -398,12 +398,17 @@
   the canonical `:rf.error/no-such-handler` (kind `:frame`) failure trace
   and returns `false`, matching the destroyed-frame contract."
   [frame-id epoch]
-  (let [{:keys [outcome op tags container]} (live-container-or-fail frame-id)]
+  (let [{:keys [outcome op tags]} (live-container-or-fail frame-id)]
     (if (= :fail outcome)
       (do (emit-precondition-failure! op tags)
           false)
       (let [db-target (:db-after epoch)]
-        (adapter/replace-container! container db-target)
+        ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION of the one
+        ;; physical frame-state container — `frame/app-db-container` is now
+        ;; a READ-ONLY projection, so a direct `replace-container!` on it
+        ;; throws. `restore-epoch` rewinds the app-db partition only here;
+        ;; the full frame-state (runtime-db) restore is bead 7 (rf2-3aizt1).
+        (frame/replace-app-db! frame-id db-target)
         (trace/emit! :rf.epoch :rf.epoch/restored
                      {:frame    frame-id
                       :epoch-id (:epoch-id epoch)})

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -40,7 +40,6 @@
             [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.source-coords :as source-coords]
-            [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
 ;; ---- state ---------------------------------------------------------------
@@ -760,20 +759,25 @@
   intermediate cases without writing nil parents or throwing (per audit
   rf2-q25os).
 
-  Per rf2-2vpac: skips `replace-container!` when the dissoc branch was a
-  no-op (missing key, or `dissoc-in-safe` returning `db` literally on
+  Per rf2-2vpac: skips the write when the dissoc branch was a no-op
+  (missing key, or `dissoc-in-safe` returning `db` literally on
   unmaterialised-parent / non-map-intermediate). Otherwise we trigger
   reactive sub-cache invalidation for a no-op write — cheap-but-needless
   walk of the sub graph (`identical?` is O(1)). No-op when the frame has
-  no app-db container."
+  no app-db container.
+
+  EP-0001 (rf2-adwcv6): writes the app-db PARTITION of the one physical
+  frame-state container via `frame/swap-frame-db!` — `app-db-container` is
+  now a READ-ONLY projection. Flow OUTPUTS are app-db values (Mike ruling
+  #12), so vacating one is an app-db write. The `identical?` no-op skip is
+  preserved by computing `new-db` first and only swapping when it changed."
   [frame-id path]
-  (when-let [container (frame/app-db-container frame-id)]
-    (let [db     (adapter/read-container container)
-          new-db (if (= 1 (count path))
+  (when-let [db (frame/frame-app-db-value frame-id)]
+    (let [new-db (if (= 1 (count path))
                    (dissoc db (first path))
                    (dissoc-in-safe db path))]
       (when-not (identical? new-db db)
-        (adapter/replace-container! container new-db)))))
+        (frame/swap-frame-db! frame-id (constantly new-db))))))
 
 ;; ---- registrar-slot owner maintenance (rf2-73pi1) ------------------------
 ;;

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -231,9 +231,11 @@
   surface. Mirrors core's runner shape."
   []
   {:read-db!  (fn [frame-id] (frame/frame-app-db-value frame-id))
+   ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION via swap-frame-db! —
+   ;; app-db-container is now a read-only projection over the one physical
+   ;; frame-state container.
    :write-db! (fn [frame-id new-db]
-                (let [container (frame/app-db-container frame-id)]
-                  (substrate-adapter/replace-container! container new-db)))
+                (frame/swap-frame-db! frame-id (constantly new-db)))
    :dispatch! (fn [event frame-id] (rf/dispatch event {:frame frame-id}))})
 
 (defn- realise-event-sub-fx-handlers

--- a/implementation/machines/test/re_frame/actor_liveness_test.cljc
+++ b/implementation/machines/test/re_frame/actor_liveness_test.cljc
@@ -55,9 +55,14 @@
   "Reset `frame-id`'s app-db to `db` — exactly what `restore-epoch` /
   `reset-frame-db!` do internally (app-db only, no registrar touch). Used
   here so the machines unit test exercises the revertibility property
-  without test-dep'ing the epoch artefact."
+  without test-dep'ing the epoch artefact.
+
+  EP-0001 (rf2-adwcv6): writes the app-db PARTITION of the one physical
+  frame-state container via `frame/swap-frame-db!` — `app-db-container` is
+  now a READ-ONLY projection. Matches what `restore-epoch` / `reset-frame-db!`
+  do post-bead-5 (`frame/replace-app-db!`)."
   [frame-id db]
-  (adapter/replace-container! (frame/app-db-container frame-id) db))
+  (frame/swap-frame-db! frame-id (constantly db)))
 
 ;; A parent that spawns one child of a registered TYPE on `:go` and
 ;; destroys it on `:drop`. The child increments a counter on `:bump` so

--- a/implementation/machines/test/re_frame/dropped_snapshot_diagnostic_test.clj
+++ b/implementation/machines/test/re_frame/dropped_snapshot_diagnostic_test.clj
@@ -101,13 +101,13 @@
   (testing "restore-epoch / reset-frame-db install a COMPLETE db via a direct adapter/replace-container! — they never flow through a :db effect, so they never reach the guard"
     (register-live-machine!)
     ;; Reproduce exactly what re-frame.epoch's restore-epoch / reset-frame-db
-    ;; do: call adapter/replace-container! directly with a complete db that
-    ;; carries NO machine snapshot (e.g. restoring to a pre-spawn epoch).
-    ;; Because this is not a `:db` effect, `commit-db-effect!` is never on the
-    ;; stack and the guard cannot fire.
-    (let [container (frame/app-db-container :rf/default)
-          warnings  (with-recorder
-                      #(adapter/replace-container! container {:restored-past true}))]
+    ;; do: install a complete app-db that carries NO machine snapshot (e.g.
+    ;; restoring to a pre-spawn epoch) via the app-db PARTITION write
+    ;; `frame/swap-frame-db!` (EP-0001 rf2-adwcv6 — `app-db-container` is now a
+    ;; read-only projection). Because this is not a `:db` effect,
+    ;; `commit-frame-effects!` is never on the stack and the guard cannot fire.
+    (let [warnings  (with-recorder
+                      #(frame/swap-frame-db! :rf/default (constantly {:restored-past true})))]
       (is (empty? warnings)
           "a direct container replace is not a :db commit — out of the guard's scope")
       (is (not (live-snapshot? :diag/m1))

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -191,9 +191,11 @@
   runner shape."
   []
   {:read-db!  (fn [frame-id] (frame/frame-app-db-value frame-id))
+   ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION via swap-frame-db! —
+   ;; app-db-container is now a read-only projection over the one physical
+   ;; frame-state container.
    :write-db! (fn [frame-id new-db]
-                (let [container (frame/app-db-container frame-id)]
-                  (substrate-adapter/replace-container! container new-db)))
+                (frame/swap-frame-db! frame-id (constantly new-db)))
    :dispatch! (fn [event frame-id] (rf/dispatch event {:frame frame-id}))})
 
 (defn- collect-cofx-keys

--- a/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
@@ -32,10 +32,13 @@
 (use-fixtures :each tf/reset-runtime)
 
 (defn- set-app-db!
-  "Set the live app-db value for `frame-id` (defaults to :rf/default)."
+  "Set the live app-db value for `frame-id` (defaults to :rf/default).
+  EP-0001 (rf2-adwcv6): writes the app-db PARTITION via `frame/swap-frame-db!`
+  — `app-db-container` is now a read-only projection over the one physical
+  frame-state container."
   ([db] (set-app-db! :rf/default db))
   ([frame-id db]
-   (substrate-adapter/replace-container! (frame/app-db-container frame-id) db)))
+   (frame/swap-frame-db! frame-id (constantly db))))
 
 (defn- capture
   "Run `body-fn` collecting trace events whose `:operation` is

--- a/implementation/ssr/test/re_frame/ssr_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_conformance_test.clj
@@ -210,9 +210,11 @@
   surface. Mirrors core's runner shape."
   []
   {:read-db!  (fn [frame-id] (frame/frame-app-db-value frame-id))
+   ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION via swap-frame-db! —
+   ;; app-db-container is now a read-only projection over the one physical
+   ;; frame-state container.
    :write-db! (fn [frame-id new-db]
-                (let [container (frame/app-db-container frame-id)]
-                  (substrate-adapter/replace-container! container new-db)))
+                (frame/swap-frame-db! frame-id (constantly new-db)))
    :dispatch! (fn [event frame-id] (rf/dispatch event {:frame frame-id}))})
 
 (defn- collect-cofx-keys

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -360,8 +360,9 @@
   ["re-frame.core" "frame-meta"]           {:tier :tooling :owner "002" :status "v1"}
   ["re-frame.core" "app-db-value"]         {:tier :advanced :owner "002" :status "v1"}
   ;; EP-0001 two-partition readers (rf2-q4i9ko / bead 3). Per spec/API.md
-  ;; §Public registrar query API rows. Surface introduced ahead of the
-  ;; physical partition (rf2-adwcv6 / bead 5); runtime-db reads nil today.
+  ;; §Public registrar query API rows. The physical partition landed in
+  ;; rf2-adwcv6 (bead 5): runtime-db-value reads the real runtime-db
+  ;; partition off the one physical frame-state container.
   ["re-frame.core" "runtime-db-value"]     {:tier :tooling :owner "002" :status "v1"}
   ["re-frame.core" "frame-state-value"]    {:tier :tooling :owner "002" :status "v1"}
   ["re-frame.core" "snapshot-of"]          {:tier :tooling :owner "002" :status "v1"}
@@ -420,9 +421,9 @@
   ;; EP-0001 two-partition mutators (rf2-q4i9ko / bead 3). Per spec/API.md
   ;; §Epoch / Tool-Pair rows. replace-app-db! is a thin alias of the existing
   ;; app-db replacement (coexists with reset-frame-db! until the rename in
-  ;; rf2-tfepxu / bead 9). The runtime-db / frame-state mutators introduce the
-  ;; surface ahead of the physical partition (rf2-adwcv6 / bead 5) and throw
-  ;; until it exists.
+  ;; rf2-tfepxu / bead 9). The runtime-db / frame-state mutators are real
+  ;; partition writes as of rf2-adwcv6 (bead 5): they install into the one
+  ;; physical frame-state container via frame/commit-frame-transition!.
   ["re-frame.core" "replace-app-db!"]            {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}
   ["re-frame.core" "replace-runtime-db!"]        {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}
   ["re-frame.core" "replace-frame-state!"]       {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -2004,9 +2004,11 @@
    (frame-container variant-id)))
 
 (defn- replace-frame-db! [variant-id new-db]
-  ((requiring-resolve 're-frame.substrate.adapter/replace-container!)
-   (frame-container variant-id)
-   new-db))
+  ;; EP-0001 (rf2-adwcv6): write the app-db PARTITION via swap-frame-db! —
+  ;; `frame/app-db-container` is now a read-only projection over the one
+  ;; physical frame-state container.
+  ((requiring-resolve 're-frame.frame/swap-frame-db!)
+   variant-id (constantly new-db)))
 
 (defn- ensure-variant-frame!
   "Allocate `variant-id`'s frame if it doesn't already exist. The fixture


### PR DESCRIPTION
EP-0001 action item 5/10 — the partitioned COMMIT: the physical heart of the two-partition frame.

## What landed

- **One physical frame-state container** per frame holding both partitions (`{:rf.db/app … :rf.db/runtime …}`); **app-db and runtime-db are read-only projection reactions** over it (`make-derived-value`). Partition-aware sub-cache invalidation derives from projection equality — **no dirty flags** (decisions #3 + #7).
- **Ordinary `:db` scoped to the app-db partition** — replaces only app-db; runtime-db survives a fresh-map return (the footgun is structurally gone).
- **`:rf.db/runtime` effect commits the runtime-db partition** (whole-value); operation-style runtime writes go through `swap-frame-db!` / the mutators (decision #5 — both write shapes).
- **`frame/commit-frame-transition!`** installs both partitions in ONE atomic write (Spec 006 §Commit boundary). An app-db schema rejection unwinds the WHOLE transition (both partitions) coherently. The pre-commit-transactional / post-commit-best-effort FX-atomicity asymmetry is **unchanged** (Mike-ruled).
- **`:rf.event/db-changed` stays APP-DB-ONLY** (decision #6); new **`:rf.event/frame-state-changed`** fires partition-tagged (`#{:app-db}` / `#{:runtime-db}` / both) for either partition. Both DCE-elide in production (ride `trace/emit!`).
- **`replace-runtime-db!` / `replace-frame-state!` are real partition writes** (the bead-3 `:not-yet-implemented` throws are gone); `runtime-db-value` reads the real partition. `reset-frame-db!` / `restore-epoch` write the app-db partition (`app-db-container` is now a read-only projection).
- Existing app-db writers (machines/routing/SSR/elision/flows via `swap-frame-db!`, epoch reset/restore, conformance + test harnesses) re-pointed to the app-db partition write.

## What beads 6-10 still cover

- **bead 6 (rf2-vzld77)** — migrate machines/routing/elision/SSR off `:rf/runtime`-under-app-db to runtime-db.
- **bead 7 (rf2-3aizt1)** — epoch/SSR snapshot/restore/hydration/reset/destroy → frame-state projections (`:frame-state-before`/`-after`).
- **bead 8** — subs/tooling/Xray egress distinguish app-db / runtime-db / frame-state.
- **bead 9 (rf2-tfepxu)** — legacy `:rf/runtime` hard error + reserved-key diagnostics + reset renames.
- **bead 10** — docs/examples/skills rewrite.

## Quality gates

- JVM core `clojure -M:test`: **985 tests, 0 failures, 0 errors**
- `npm run test:cljs`: **5978 tests, 0 failures, 0 errors**
- `npm run test:elision`: **PASS** (production 40/40 absent — the new `frame-state-changed` / `db-changed` traces DCE-elide; control 40/40 present)
- `npm run test:bundle-isolation` / `test:perf-bundle`: **PASS**
- `npm run test:mcp-conformance`: **ALL GREEN (6/6)**
- `npm run test:xray-feature-gate`: **16 scenarios, 0 failures**
- JVM artefacts (epoch / machines / schemas / routing / flows / ssr / ssr-ring / http / security): **all 0 failures, 0 errors**
- New `partitioned_commit_test` namespace pins: app-db `:db` scoping, runtime-db commit (both write shapes), atomic cross-partition commit, projection-equality invalidation (no dirty flags), `frame-state-changed` partition-tagged + `db-changed` app-db-only, the real mutators, and cross-partition schema rollback.
