### PR TITLE
fix(xray): forward static context shape + reconcile fallback/controls prose (rf2-eao0s0 rf2-8ym737 rf2-9kv3oc)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1043,7 +1043,7 @@ for the work cost of rebuilding auto-layout / zoom-pan-fit from scratch.
 | Transition edge animation | xyflow's `animated: true` edge prop. Color via Xray palette (`:accent` — the single GitHub-blue accent — for "fired this epoch"; `:text-tertiary` for "registered but not fired this epoch"). |
 | Current-state highlight pulse | Custom node CSS class that applies the `pulse` keyframe (~1.2s ease-in-out; CSS-variable interpolated through `--rf-xray-motion-scale` so `prefers-reduced-motion` collapses it). Pulse outline color = `:green` (the panel-domain accent). |
 | Auto-layout | **elkjs** (the Eclipse Layout Kernel, `Layered` algorithm) runs as xyflow's layout backend inside `MachineChart` (2026-05-19 ELK lock — superseded the originally-sketched dagre `getLayoutedElements`). Async one-shot layout, cached per machine-id; recomputed only when topology changes. |
-| Zoom + pan + fit | xyflow's built-in `Controls` component (re-styled to match Xray's button chrome). Default zoom: fit-on-mount with 20px padding. `[− 100% +] [Fit][Reset]` chrome already shown in the existing mockups maps 1:1 to xyflow's `Controls`. |
+| Zoom + pan + fit | xyflow's built-in `<Controls>` component ONLY (mounted `{:showZoom true :showFitView true :showInteractive false}`; xyflow positions it bottom-left). The cluster ships **zoom-in `+` / zoom-out `−` / fit-view `⛶`** buttons — no `NN%` zoom-readout chip, no `Reset` button, no custom Xray toolbar. Default framing: fit-on-mount via `:fitViewOptions {:padding 0.1}`; Xray re-frames on panel-entry by bumping the orthogonal `:fit-signal` nonce (rf2-6tw7t). See spec/007 §"Controls" for the authoritative reconciliation. |
 | Label-on-edge transitions | xyflow's `label` prop on edges; rendered inline on the edge, not in a side legend. Font: JetBrains Mono 10px (`:micro` size). |
 | Parallel-state side-by-side | Parallel-region containers render as sibling group-nodes with a dashed border (`:border-default` at `dash-array: 4 4`). Inner states laid out independently per region. |
 | Final states | Thick border ring (2px solid `:green` outer + 1px solid `:bg-2` inner gap, recreating Stately's double-ring convention). |
@@ -1099,9 +1099,12 @@ the nodes and edges with Xray palette tokens.
 │▌ stripe: mode accent (one GitHub-blue accent, both modes)             │
 │                                                                       │
 │ machine :title/flow            (no activity this epoch · current ●)   │
-│ ┌──────────────────────────────────────────────[− 100% +] [Fit][Reset]│
+│ ┌────────────────────────────────────────────────────────────────────┐│
 │ │  ( idle ) ──→ (( loaded )) ──→ ( error )                            │
 │ │                  ↑ current                                          │
+│ │ ┌──────┐                                                            │
+│ │ │ + − ⛶ │ ← xyflow <Controls> (bottom-left)                         │
+│ │ └──────┘                                                            │
 │ └────────────────────────────────────────────────────────────────────┘│
 │                                                                       │
 │ machine :other/flow            (no activity this epoch · current ●)   │
@@ -1128,7 +1131,7 @@ accent; the fired transition edge carries its **event label + guard + action inl
 ┌─ MACHINES · epoch #42 (machine :title/flow [:rf/init]) ─ [◀ Prev] [Next ▶] ─┐
 │▌ stripe: mode accent (one GitHub-blue accent, both modes)                   │
 │ machine :title/flow                                                          │
-│ ┌────────────────────────────────────────────────[− 100% +] [Fit][Reset]──┐│
+│ ┌──────────────────────────────────────────────────────────────────────────┐│
 │ │ ┌─ active (compound) ──────────────────────────────────┐                  ││
 │ │ │  ( idle ) ════════▶ (( loading )) ───→ ( loaded )     │      ( error )   ││
 │ │ │   FROM    [:rf/init]    TO/current                    │       ↑          ││
@@ -1137,6 +1140,9 @@ accent; the fired transition edge carries its **event label + guard + action inl
 │ │ └───────────────────────────────────────────────────────┘                 ││
 │ │  FROM = dashed/dim · TO = double-circle, mode-accent, pulse                 ││
 │ │  fired edge = mode-accent 2px animated · registered = dim 1px · error = red ││
+│ │ ┌──────┐                                                                    ││
+│ │ │ + − ⛶ │ ← xyflow <Controls> (bottom-left)                                 ││
+│ │ └──────┘                                                                    ││
 │ └────────────────────────────────────────────────────────────────────────────┘│
 │ guards: token? [pass]    actions: [fetch!]    after: ◴ 5s → :timeout         │
 │ Cancellation cascade (none)                                                  │
@@ -1159,8 +1165,10 @@ sketch called for a left-to-right `rankdir: 'LR'` default; the elkjs
 backend that shipped (`MachineChart`, 2026-05-19 ELK lock) maps `:lr` →
 elk `RIGHT` / `:tb` → elk `DOWN` and defaults to `DOWN`. Operator-facing
 direction flip (Settings → View → Machines layout direction) is deferred
-to a follow-on bead. Default zoom: fit-on-mount with 20px padding around
-the bounding box of all nodes.
+to a follow-on bead. Default framing: fit-on-mount via xyflow's
+`:fitViewOptions {:padding 0.1}` (a fractional viewport padding, not a
+fixed pixel inset); Xray re-frames on panel-entry by bumping the
+`:fit-signal` nonce (rf2-6tw7t).
 
 ### §6.3 Queries
 
@@ -5283,7 +5291,7 @@ operators will see.
 │  ◆  (panel header icon, :green)                                     │
 │  ──────────────────────────────────────────────────────             │
 │   :rf.machine.cart/lifecycle    :populated → :submitting            │
-│  ┌──[xyflow canvas]──────────────────────[− 100% +][Fit][Reset]──┐ │
+│  ┌──[xyflow canvas]────────────────────────────────────────────┐ │
 │  │                                                                │ │
 │  │   ╭───────╮  registered   ╭───────────╮  fired  ╭──────────╮  │ │
 │  │   │:empty │ ╴ ╴ ╴ ╴ ╴ ╴▷ │:populated │ ═════▶ │:submitting│  │ │
@@ -5305,6 +5313,9 @@ operators will see.
 │  │     ╭═╮ final state                        :bg-2 + 2px :green   │ │
 │  │     ╭◉╮ current state                      :bg-2 + 2px :green   │ │
 │  │            + 1.2s pulse animation                                │ │
+│  │   ┌──────┐                                                      │ │
+│  │   │ + − ⛶ │ ← xyflow <Controls> (bottom-left); zoom-±/fit only,  │ │
+│  │   └──────┘    no NN% chip, no Reset                              │ │
 │  └────────────────────────────────────────────────────────────────┘ │
 │   Guards    ✓ :cart-non-empty?                                      │
 │   Actions   ✓ :clear-form  ✓ :set-submitting-state                  │
@@ -5392,8 +5403,13 @@ the edge id keeps every branch addressable in xyflow.
   called for a left-to-right dagre `rankdir: 'LR'`; the elkjs backend
   that shipped maps `:lr` → elk `RIGHT` / `:tb` → elk `DOWN` and defaults
   to `DOWN`.
-- **Default zoom**: `fitView` on mount with 20px padding around the
-  bounding box. The `Fit` button in the Controls re-runs `fitView`.
+- **Default framing**: `fitView` on mount via `:fitViewOptions {:padding
+  0.1}` (a fractional viewport padding, not a fixed pixel inset). The
+  fit-view `⛶` button in the `<Controls>` cluster re-runs `fitView`;
+  Xray additionally re-frames on panel-entry by bumping the `:fit-signal`
+  nonce (rf2-6tw7t). There is no `NN%` zoom-readout chip and no `Reset`
+  button — the `<Controls>` cluster is zoom-±/fit only (`{:showZoom true
+  :showFitView true :showInteractive false}`); see spec/007 §"Controls".
 - **Min/max zoom**: 0.2× to 4.0× (`MachineChart`'s `minZoom` / `maxZoom`).
   Wheel-zoom enabled.
 - **Pan**: drag-to-pan on the canvas background (xyflow `panOnDrag`);

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/topology.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/topology.cljs
@@ -73,13 +73,16 @@
 
   ## Layout posture
 
-  Initial v1 uses a deterministic top-to-bottom grid lift from the
-  existing `chart-layout/layout` (the SVG chart's pure-CLJS layout
-  fn) so the xyflow render's node positions visually align with the
-  legacy chart. xyflow's `dagre`-based `getLayoutedElements` helper
-  could ship as a follow-on bead (spec §17.4.4 calls for `rankdir:
-  LR` ultimately); for v1 the simple grid keeps the projection
-  self-contained + JVM-portable.
+  This fallback projector lays out nodes with a deterministic,
+  top-to-bottom grid lift from the existing `chart-layout/layout`
+  (the pure-CLJS layout fn). It is a self-contained, JVM-portable
+  grid projection that lives OFF the live render path — the live
+  Machines panel renders through the shared machines-viz
+  `MachineChart`, whose hierarchical layout is driven internally by
+  ELK (default downward `DOWN` flow) inside xyflow. The grid
+  projection survives only as a deterministic fallback + a JVM-
+  testable layout/style catalogue; its output is never handed to
+  React.
 
   ## current-state-path resolution
 

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
@@ -74,6 +74,7 @@
   wrapper that wires the helpers to the reactive substrate."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.panels.machine-canvas :as machine-canvas]
+            [day8.re-frame2-xray.panels.machines.topology-view :as topology-view]
             [day8.re-frame2-xray.static.machines.sim-helpers :as sim-h]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack type-scale]]))
@@ -669,6 +670,13 @@
       `:current-state` with `:sim? true`, so the live node highlights
       AMBER (distinct from the live cyan highlight on the Dynamic
       surface).
+    - **Context band** — the machine's STATIC context shape (keys +
+      type captions, rf2-eao0s0) drives the chart's `:machine-data`
+      so the root Context band renders here too (the Dynamic + Static
+      Topology charts already pass it). Shape + declared-over-inferred
+      provenance come from the shared `topology-view/static-context-
+      shape` / `static-context-inferred?` helpers — no duplicate
+      derivation.
     - **Taken transition** — the last audit-trail row's `:from` / `:to`
       (`:sim-last-transition`) drive the chart's focused-event lens
       (`:from-highlight` / `:to-highlight`), animating the edge just
@@ -705,6 +713,13 @@
       {:definition             definition
        :machine-id             machine-id
        :current-state          current
+       ;; rf2-eao0s0 — surface the STATIC context shape so the root
+       ;; Context band renders on the Static Sim chart too (the Dynamic
+       ;; topology + focused-event + Static Topology charts already do).
+       ;; Shape + provenance come from the shared machines-viz-backed
+       ;; helpers; nil shape → the chart hides the panel.
+       :machine-data           (topology-view/static-context-shape definition)
+       :machine-data-inferred? (topology-view/static-context-inferred? definition)
        :from-highlight         (:from last-trans)
        :to-highlight           (:to last-trans)
        :sim?                   true

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
@@ -50,6 +50,7 @@
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.panels.machine-canvas :as machine-canvas]
+            [day8.re-frame2-xray.panels.machines.topology-view :as topology-view]
             [day8.re-frame2-xray.static.machines.helpers :as h]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens sans-stack mono-stack type-scale]]))
@@ -78,7 +79,18 @@
     :show-after-rings?      false  — no focused-event lens on static.
     :testid                        — overrides the inner SVG testid
                                      so the existing static-panel
-                                     tests still match."
+                                     tests still match.
+
+  rf2-eao0s0 — forward the STATIC context shape (keys + type captions)
+  into the chart so the root Context band renders on the Static
+  Topology surface too. The Dynamic topology + focused-event charts
+  already pass this; the Static charts had been mounting only
+  definition / machine-id, so the root Context chrome was missing.
+  Derived via the SHARED `topology-view/static-context-shape` /
+  `static-context-inferred?` helpers (which delegate to machines-viz
+  `context-shape`) — no duplicate derivation. nil shape → the chart
+  hides the panel; the declared-over-inferred provenance gates the
+  `inferred from :data` badge."
   [dispatch {:keys [definition machine-id fit-signal]}]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — ELK is now driven
   ;; internally by xyflow inside `mv-chart/MachineChart`; the
@@ -101,6 +113,12 @@
      [machine-canvas/Chart
       {:definition             definition
        :machine-id             machine-id
+       ;; rf2-eao0s0 — surface the STATIC context shape so the root
+       ;; Context band renders without a live snapshot (the Dynamic
+       ;; topology + focused-event charts already do this). Shape +
+       ;; provenance come from the shared machines-viz-backed helpers.
+       :machine-data           (topology-view/static-context-shape definition)
+       :machine-data-inferred? (topology-view/static-context-inferred? definition)
        :show-after-rings?      false
        ;; rf2-6tw7t — fit-on-entry nonce so entering the Static Machines
        ;; tab re-frames the topology (xyflow's one-shot `:fitView` +

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/sim_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/sim_cljs_test.cljs
@@ -566,6 +566,77 @@
         (is (fn? (:on-edge-click chart-props))
             "the chart gets an on-edge-click callback")))))
 
+;; rf2-eao0s0 — the Static Sim chart must forward the STATIC context
+;; shape into machine-canvas/Chart so the root Context band renders on
+;; the Sim surface too (the Dynamic + Static Topology charts already do).
+
+(def ^:private inferred-fixture-definition
+  "No :data-schema → the context shape is INFERRED from one sample of
+  the initial :data (the chart keeps the `inferred from :data` badge)."
+  {:initial :idle
+   :data    {:counter 0 :label "x"}
+   :states  {:idle {:on {:start :authing}}
+             :authing {:final? true}}})
+
+(def ^:private declared-fixture-definition
+  "Declares a :data-schema → the context shape is AUTHORITATIVE off the
+  schema (the chart drops the inferred badge)."
+  {:initial     :idle
+   :data        {:counter 0 :label "x"}
+   :data-schema [:map [:counter :int] [:label :string]]
+   :states      {:idle {:on {:start :authing}}
+                 :authing {:final? true}}})
+
+(defn- sim-chart-props
+  "Render SimChart for `definition` and return the embedded
+  machine-canvas/Chart props (via the RAW walker so the chart survives
+  as data)."
+  [definition]
+  (let [tree       (sim/SimChart rf/dispatch* {:machine-id :auth/login
+                                  :definition definition})
+        chart-node (some (fn [node]
+                           (when (and (vector? node)
+                                      (= machine-canvas/Chart (first node)))
+                             node))
+                         (raw-hiccup-seq tree))]
+    (second chart-node)))
+
+(deftest sim-chart-forwards-inferred-context-shape-to-canvas
+  (testing "rf2-eao0s0 — an inferred (:data, no schema) machine: the Static
+            Sim chart hands the canvas the {key → type-caption} shape with
+            :machine-data-inferred? TRUE (the inferred-from-:data badge)."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login inferred-fixture-definition})
+      (select-static-machine! :auth/login)
+      (rf/dispatch-sync [:rf.xray.static.machines/sim-start
+                         {:machine-id :auth/login
+                          :definition inferred-fixture-definition}])
+      (let [props (sim-chart-props inferred-fixture-definition)]
+        (is (= {:counter "number" :label "string"} (:machine-data props))
+            "the static context SHAPE reaches the chart's :machine-data")
+        (is (true? (:machine-data-inferred? props))
+            "inferred sample → :machine-data-inferred? TRUE reaches the chart")))))
+
+(deftest sim-chart-forwards-declared-context-shape-to-canvas
+  (testing "rf2-eao0s0 — a declared (:data-schema) machine: the Static Sim
+            chart hands the canvas the AUTHORITATIVE schema shape with
+            :machine-data-inferred? FALSE (badge dropped)."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login declared-fixture-definition})
+      (select-static-machine! :auth/login)
+      (rf/dispatch-sync [:rf.xray.static.machines/sim-start
+                         {:machine-id :auth/login
+                          :definition declared-fixture-definition}])
+      (let [props (sim-chart-props declared-fixture-definition)]
+        (is (= {:counter "number" :label "string"} (:machine-data props))
+            "the declared schema SHAPE reaches the chart's :machine-data")
+        (is (false? (:machine-data-inferred? props))
+            "declared schema → :machine-data-inferred? FALSE reaches the chart")))))
+
 (deftest sim-body-renders-chart-and-rail-panes
   (testing "rf2-u422r — the sim body is a two-pane split: the on-chart sim
             surface (primary) + the rail side column"

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/topology_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/topology_cljs_test.cljs
@@ -1,0 +1,101 @@
+(ns day8.re-frame2-xray.static.machines.topology-cljs-test
+  "rf2-eao0s0 — Static Machines Topology → machine-canvas/Chart prop
+  boundary.
+
+  The Dynamic topology + focused-event charts forward the machine's
+  STATIC context shape into `machine-canvas/Chart` so the root Context
+  band renders without a live snapshot. The Static Topology chart
+  wrapper had been mounting only definition / machine-id, so the root
+  Context band was missing there. These tests pin that the wrapper now
+  forwards `:machine-data` (the {key → type-caption} shape) +
+  `:machine-data-inferred?` for BOTH an inferred (`:data`-sample) and a
+  declared (`:data-schema`) definition.
+
+  The chart wrapper is the private `topology/chart` fn; we invoke it via
+  its var so the `[machine-canvas/Chart {...}]` mount survives as data
+  (a raw tree-seq, no fn-component expansion, finds its props)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-xray.panels.machine-canvas :as machine-canvas]
+            [day8.re-frame2-xray.static.machines.topology :as topology]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(def ^:private inferred-definition
+  "No :data-schema → the context shape is INFERRED from one sample of the
+  initial :data (the chart keeps the `inferred from :data` badge)."
+  {:initial :idle
+   :data    {:opened-count 0 :held-open? false :trail []}
+   :states  {:idle {:on {:open :opening}}
+             :opening {:final? true}}})
+
+(def ^:private declared-definition
+  "Declares a :data-schema → the context shape is AUTHORITATIVE off the
+  schema (the chart drops the inferred badge)."
+  {:initial     :idle
+   :data        {:opened-count 0 :held-open? false}
+   :data-schema [:map [:opened-count :int] [:held-open? :boolean]]
+   :states      {:idle {:on {:open :opening}}
+                 :opening {:final? true}}})
+
+(def ^:private no-data-definition
+  "Neither :data nor :data-schema → the shape is nil so the chart hides
+  the Context panel."
+  {:initial :idle
+   :states  {:idle {} :opening {}}})
+
+;; ---- raw walker ---------------------------------------------------------
+;;
+;; A RAW tree-seq that does NOT invoke fn components, so the
+;; `[machine-canvas/Chart {...}]` child of the wrapper survives as data
+;; and its props are assertable.
+
+(defn- raw-hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- chart-props
+  "Render the private `topology/chart` wrapper for `definition` and return
+  the embedded machine-canvas/Chart props map (or nil if absent)."
+  [definition]
+  (let [tree       (#'topology/chart
+                     identity
+                     {:definition definition :machine-id :door/main})
+        chart-node (some (fn [node]
+                           (when (and (vector? node)
+                                      (= machine-canvas/Chart (first node)))
+                             node))
+                         (raw-hiccup-seq tree))]
+    (second chart-node)))
+
+;; ---- tests --------------------------------------------------------------
+
+(deftest topology-forwards-inferred-context-shape-to-chart
+  (testing "rf2-eao0s0 — an inferred (:data, no schema) machine: the Static
+            Topology chart forwards the {key → type-caption} shape with
+            :machine-data-inferred? TRUE."
+    (let [props (chart-props inferred-definition)]
+      (is (some? props) "the chart wrapper mounts machine-canvas/Chart")
+      (is (= {:opened-count "number" :held-open? "boolean" :trail "vector"}
+             (:machine-data props))
+          "the static context SHAPE reaches the chart's :machine-data")
+      (is (true? (:machine-data-inferred? props))
+          "inferred sample → :machine-data-inferred? TRUE reaches the chart"))))
+
+(deftest topology-forwards-declared-context-shape-to-chart
+  (testing "rf2-eao0s0 — a declared (:data-schema) machine: the Static
+            Topology chart forwards the AUTHORITATIVE schema shape with
+            :machine-data-inferred? FALSE."
+    (let [props (chart-props declared-definition)]
+      (is (= {:opened-count "number" :held-open? "boolean"}
+             (:machine-data props))
+          "the declared schema SHAPE reaches the chart's :machine-data")
+      (is (false? (:machine-data-inferred? props))
+          "declared schema → :machine-data-inferred? FALSE reaches the chart"))))
+
+(deftest topology-hides-context-panel-when-no-shape
+  (testing "rf2-eao0s0 — a machine that declares neither :data nor a
+            :data-schema forwards a nil :machine-data so the chart hides
+            the Context panel (the existing chart contract)."
+    (let [props (chart-props no-data-definition)]
+      (is (some? props) "the chart wrapper still mounts machine-canvas/Chart")
+      (is (nil? (:machine-data props))
+          "no shape → :machine-data is nil (Context panel stays hidden)"))))


### PR DESCRIPTION
Three xray beads in one PR (all under `tools/xray/`).

## rf2-eao0s0 (CODE) — forward static context shape to Static Machines charts
The Static Machines **Topology** + **Sim** chart wrappers mounted only `:definition` / `:machine-id` into `machine-canvas/Chart`, so the root Context band was missing there (the Dynamic topology + focused-event charts already pass `:machine-data`). Both static wrappers now derive the context shape via the shared `topology-view/static-context-shape` / `static-context-inferred?` helpers (which delegate to machines-viz `context-shape` — no duplicate derivation) and pass `:machine-data` + `:machine-data-inferred?`. New hiccup-level tests assert both props reach the chart for inferred (`:data` sample) AND declared (`:data-schema`) definitions:
- new ns `static.machines.topology-cljs-test` (invokes the private `topology/chart` wrapper via its var; raw walker finds the chart props)
- new tests in `static.machines.sim-cljs-test` (`SimChart` path)

## rf2-8ym737 (docstring) — fallback projector posture
Rewrote the `panels/machines/topology.cljs` namespace docstring Layout-posture section: the fallback projector is a deterministic, JVM-portable, off-live-path grid projection. Removed the stale dagre `getLayoutedElements` / `rankdir LR` / "spec section 17.4.4 calls for LR" wording (the live path is the ELK / default-`DOWN` `MachineChart`).

## rf2-9kv3oc (spec) — spec 021 machine-chart controls
Reconciled spec 021's machine-chart controls to xyflow reality: xyflow built-in `<Controls>` ONLY (`{:showZoom true :showFitView true :showInteractive false}` — zoom-+/- and fit-view), no `NN%` chip, no `Reset`, no custom Xray toolbar, `:fitViewOptions {:padding 0.1}`. Updated the §6.0 table row, the §6.2 Case B / Case C ASCII mockups, the §17.4.1 polished mockup, and the §17.4.4 default-framing prose — aligned to spec/007's authoritative reconciliation. No headings changed (anchors stable).

## Quality gates
- `clojure -M:test` (tools/xray) — **1108 tests / 4589 assertions, 0 failures, 0 errors** (JVM).
- `npm run test:cljs` (implementation) — **5987 tests / 21220 assertions, 0 failures, 0 errors** (runs the new view tests).
- Probe-then-revert confirmed both new eao0s0 tests execute (the probes failed with the real props `{:counter "number" :label "string"}` / `{:opened-count "number" :held-open? "boolean" :trail "vector"}`, then reverted to green).
- `python scripts/check_doc_slugs.py` — exit 0.
- `git grep` confirms 8ym737's removed terms (dagre / getLayoutedElements / rankdir / 17.4.4) are gone from `topology.cljs`, and old-chrome strings (`[Fit]` / `[Reset]` / `[- 100% +]` / "20px padding") are gone from spec 021.
