### PR TITLE
fix(xray): project+highlight root-parallel :on and unchanged parallel self/internal fired edges (rf2-3v3gv1 rf2-l8ls6w rf2-bz87en)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -429,6 +429,7 @@ fill), and colours resolved through the active-theme **chart-tokens**
 | **Edge (`:after` timer)** | `⌚ <ms>` event chip + `data-after-ms` hook for the countdown-ring overlay | shipped |
 | **Edge (`:always` eventless)** | `∞` event chip | shipped |
 | **Edge (machine-level fallback)** | a SINGLE route from the MACHINE-ROOT chip into the target (rf2-vcnvj — projected once, not per-leaf); `data-machine-level` hook on the event chip; the loud "machine-level" label is **muted** by default (rf2-az6e2) | shipped flag + root-sourced route |
+| **Edge (root parallel `:on` ancestor fallback — rf2-3v3gv1)** | a `:type :parallel` machine's OWN top-level `:on` is the **ancestor fallback** for its regions (Spec 005 §Root parallel `:on`; verified xstate@5.32.0): when no region-local transition handles the event the root `:on` fires, moving one or more **region-qualified targets** atomically. Projected as ONE route **per region-qualified target** from the synthetic MACHINE-ROOT chip into the **region-scoped** target node (`region-scoped-id`), flagged `:machine-level?` AND `:parallel-root-on?`; a **targetless action-only** root `:on` self-anchors on the chip as an `:internal?` affordance (moves no region). Pre-fix the projection modelled the per-region `:on` fallbacks but DROPPED the parallel root's own `:on` entirely — neither topology nor focused-event highlight could show it. `chart.layout` `collect-parallel-root-edges` + `project-parallel`. | shipped flag + root-sourced region-scoped route |
 | **Machine-root chip (rf2-vcnvj)** | a small NEUTRAL pill (root glyph `◆` + `root` caption) that anchors machine-level fallbacks; NOT a state box; `data-machine-root` hook | *`:container-header-bg` fill, `:state-border`, pill radius* |
 | **Event chip** | subordinate route chip, **no title bar**; **capsule-pill** corner radius (≈ half the chip min-height — Stately's rounded transition/event pill, not a near-rectangle); event + guard on the first line as **`IF <guard>`**; action row only when present — a **subdued ENCLOSED action chip** (rf2-fokezq: subtle `:container-header-bg` fill + `:state-border` border + `:action-pill-*` padding/rounding, density-aware font off `:event-chip-action-px`), matching the state-node entry/exit action chip and Stately's quiet action treatment, so it reads as a **contained annotation** subordinate to the event name — NOT loose free-floating text inside the trigger box; the internal-transition chip keeps its **dashed** border; clickable (host sim) gets a button affordance + distinct border | *`:event-chip-bg` / `:event-chip-border`; `:event-chip-radius` 16px regular (≈ ½ `:event-chip-min-h` 32); action chip: `:container-header-bg` / `:state-border` / `:action-pill-*`; `:sim` border when clickable* |
 | **Guarded-fork branch badge (rf2-uw3vmi)** | a small **numbered priority badge** (a circled 1-based index) LEADING the event line on **each branch of a genuine guarded multi-branch fork** — Stately's ①②③ on the gate `:gate/check` 3-way. Surfaces the deterministic first-pass-wins evaluation order (the source candidate-vector index `chart.layout` preserves). **Applies ONLY to a fork** — 2+ same-source / same-trigger candidates where at least one carries a `:guard`; a SINGLE transition (incl. a single guarded `:always`) gets NO badge, and distinct triggers on one source never merge. ADDITIVE to the settled `IF <guard>` per-branch wording (§3.2) — no ELSE-IF/ELSE text. `data-fork-order` hook on the chip + the leading badge span (`rf-mv-chart-event-fork-badge-<id>`); neutral + unobtrusive (an order annotation, not a second event), sized off the density's `:event-chip-px` | *circular badge, `:event-chip-border` fill + `:text-primary` numeral; threaded via projector `:data {:forkOrder}`* |
@@ -755,6 +756,20 @@ state boxes. The feature stays opt-in behind `:direction :auto`.
   the match is by **edge-id** (not endpoint node-ids like the from/to
   lens), it lights **every** traversed arm — microsteps, guard-fork
   candidates — the lens cannot reach. **Palette delegated to Figma.**
+- ✅ **Parallel fired-edge coverage (rf2-8ncxrf / rf2-3v3gv1 / rf2-l8ls6w).**
+  A `:type :parallel` transition emits ONE `:rf.machine/transition` whose
+  `:before` / `:after` carry the WHOLE region-map. `extract-fired-edge-ids`
+  (Xray-side) derives the fired edges per region from the region-map **plus**
+  the structured `:cascade`: (a) a region that **changed via a region-local
+  transition** lights its region-scoped edge (rf2-8ncxrf); (b) a region that
+  **changed via the parallel ROOT `:on`** (no region-local edge moved it)
+  lights the MACHINE-ROOT-sourced chip whose region-qualified `:to-path` names
+  it (rf2-3v3gv1); (c) a region that was **HANDLED but UNCHANGED** — a real
+  targetless/internal or external self transition with `before == after` and a
+  non-empty cascade — lights its self/internal edge, distinguished from a
+  RESTING region (declined the event, absent from the cascade) by the
+  `:cascade` `:region` stamps (rf2-l8ls6w). All three mint ids that agree with
+  the live chart by construction (the projection is the single edge-id source).
 
 ## §5 — Roadmap
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -737,6 +737,88 @@
               (transition-candidates spec)))
       machine-on)))
 
+(defn- normalise-root-targets
+  "rf2-3v3gv1 — normalise a PARALLEL-ROOT `:on` candidate's `:target` into a
+  vector of region-qualified absolute targets `[[<region> & <in-region-path>]
+  …]`, mirroring the runtime resolver (`re-frame.machines.parallel/
+  normalise-root-targets`) so the projected edges address the SAME regions the
+  engine moves. Per the grammar (Spec 005 §Root parallel `:on`):
+
+    - nil / absent → `[]` (TARGETLESS / action-only — runs `:action` / `:fx`,
+      moves no region);
+    - a vector of KEYWORDS (`[:a :two]`) → ONE region-qualified target (head =
+      region name, rest = the in-region path); wrapped to `[[:a :two]]`;
+    - a vector of VECTORS (`[[:a :x] [:b :y]]`) → MULTIPLE region-qualified
+      targets, returned as-is.
+
+  An empty vector return means action-only — the caller self-anchors a
+  terminal/internal root chip rather than emitting a moved-region edge."
+  [target]
+  (cond
+    (nil? target)                        []
+    (and (vector? target)
+         (every? vector? target))        (vec target)
+    (vector? target)                     [target]
+    :else                                []))
+
+(defn- collect-parallel-root-edges
+  "rf2-3v3gv1 — emit edges for a `:type :parallel` machine's OWN top-level
+  `:on` (the ROOT parallel transition — the ancestor fallback for its regions,
+  Spec 005 §Root parallel `:on`). Shipped runtime semantics: when no region
+  handles the event the root `:on` fires, moving one or more REGION-QUALIFIED
+  targets atomically (untargeted regions stay put). Pre-fix the chart
+  projection modelled the per-region `:on` fallbacks (via `project-flat` →
+  `collect-machine-edges`) but DROPPED the parallel root's own `:on`, so Xray
+  could neither render the transition in topology nor highlight it on a focused
+  event.
+
+  Each candidate projects ONCE PER region-qualified target, sourced from the
+  synthetic MACHINE-ROOT node (`machine-root-id`) into the region's
+  in-region target — exactly as a flat machine's `collect-machine-edges`
+  fallback sources its chip from the root. The edge carries:
+
+    - `:from []` (the root context, so `edge-source-id` mints `machine-root-id`),
+    - `:to [<region> & <in-region-path>]` (the absolute region-qualified path
+      the runtime applies — its node-id is `region-scoped-id` of the region +
+      in-region path, re-pointed in `project-parallel` below),
+    - `:machine-level? true` (an inherited root fallback — distinct from a
+      region-local transition; the fired-edge matcher + SCXML emitter key off
+      this), AND
+    - `:parallel-root-on? true` (this is the PARALLEL root's `:on`, not a flat
+      machine-level fallback — `project-parallel` re-points its `:target` to
+      the region-scoped node rather than a top-level state).
+
+  A TARGETLESS / action-only root `:on` candidate (no region-qualified target)
+  self-anchors on the machine-root node and is flagged `:internal? true`,
+  rendering as a hanging action chip (the parallel-root `:on-done` shape) — it
+  runs the action / `:fx` and moves no region. Returns a seq of edge maps."
+  [root-on]
+  (when (seq root-on)
+    (mapcat
+      (fn [[event-id spec]]
+        (mapcat
+          (fn [candidate]
+            (let [targets (normalise-root-targets (:target candidate))
+                  base    {:from              []
+                           :event             event-id
+                           :guard             (:guard candidate)
+                           :action            (:action candidate)
+                           :machine-level?    true
+                           :parallel-root-on? true}]
+              (if (seq targets)
+                ;; One edge per region-qualified target (single- or multi-
+                ;; region). `:to` is the absolute region-qualified path.
+                (map (fn [tgt]
+                       (cond-> (assoc base :to (vec tgt))
+                         (reenter? candidate) (assoc :reenter? true)))
+                     targets)
+                ;; Targetless / action-only — self-anchor on the machine-root
+                ;; node as an internal chip (moves no region).
+                [(cond-> (assoc base :to [] :internal? true)
+                   (reenter? candidate) (assoc :reenter? true))])))
+          (transition-candidates spec)))
+      root-on)))
+
 ;; ---- public projection --------------------------------------------------
 
 (defn- project-flat
@@ -959,11 +1041,69 @@
                      :label     "parallel"
                      :depth     0
                      :parallel-root? true
-                     :compound? false})]
-    {:nodes        (vec (concat (mapcat :nodes per-region)
+                     :compound? false})
+        ;; rf2-3v3gv1 — the PARALLEL ROOT's own `:on` (the ancestor fallback,
+        ;; Spec 005 §Root parallel `:on`). A root `:on` with region-qualified
+        ;; target(s) moves one or more regions when no region-local transition
+        ;; handles the event; pre-fix the projection dropped it entirely. Each
+        ;; edge is sourced from the synthetic MACHINE-ROOT chip (the same
+        ;; anchor a flat machine's `collect-machine-edges` fallback uses) into
+        ;; the REGION-SCOPED target node — so the chip reads as the machine-
+        ;; wide fallback hanging into the region it moves. A targetless action-
+        ;; only root `:on` (`:to []`, `:internal? true`) self-anchors on the
+        ;; machine-root chip (a hanging action affordance, moves no region).
+        root-on-raw (collect-parallel-root-edges (:on definition))
+        root-on-edges
+        (->> root-on-raw
+             (reduce
+               (fn [{:keys [seen out]} e]
+                 (let [base (edge-id (:to e) e)
+                       n    (get seen base 0)
+                       id   (if (zero? n) base (str base "__" n))
+                       ;; `edge-source-id` mints `machine-root-id` for a
+                       ;; `:machine-level?` edge; the TARGET is region-scoped
+                       ;; for a region-qualified `:to [<region> & path]`, or
+                       ;; the machine-root node itself for the targetless
+                       ;; (internal) self-anchored case.
+                       to-path  (:to e)
+                       target   (if (:internal? e)
+                                  machine-root-id
+                                  (region-scoped-id (first to-path)
+                                                    (vec (rest to-path))))]
+                   {:seen (assoc seen base (inc n))
+                    :out  (conj out
+                                (assoc e
+                                  :id          id
+                                  :source      (edge-source-id e)
+                                  :target      target
+                                  :from-path   (:from e)
+                                  :to-path     (:to e)
+                                  :event-label (edge-label e)))}))
+               {:seen {} :out []})
+             :out
+             vec)
+        ;; rf2-3v3gv1 — surface the synthetic MACHINE-ROOT chip ONLY when the
+        ;; parallel root declares an `:on` (mirrors `project-flat`'s
+        ;; rf2-vcnvj root-node-when-fallback-exists rule). Distinct from the
+        ;; parallel-ROOT `:on-done` node (`parallel-root-segment`); a machine
+        ;; with no root `:on` keeps the pre-fix node set unchanged.
+        machine-root-node (when (seq root-on-edges)
+                            {:id            machine-root-id
+                             :path          []
+                             :label         "root"
+                             :depth         0
+                             :machine-root? true
+                             :compound?     false})]
+    {;; rf2-3v3gv1 — the synthetic MACHINE-ROOT chip (when present) LEADS the
+     ;; node vector, ahead of the regions whose scoped target nodes its root
+     ;; `:on` edges address (xyflow's parent-before-child / source-before-edge
+     ;; ordering invariant — the same reason region/compound parents lead).
+     :nodes        (vec (concat (when machine-root-node [machine-root-node])
+                                (mapcat :nodes per-region)
                                 (when root-node [root-node])))
      :edges        (vec (concat (mapcat :edges per-region)
-                                root-od-edges))
+                                root-od-edges
+                                root-on-edges))
      :initial-path nil
      :parallel?    true}))
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -1000,3 +1000,117 @@
           {:keys [nodes edges]} (layout/project-definition m)]
       (is (empty? (filter :parallel-root? nodes)))
       (is (empty? (filter :on-done? edges))))))
+
+;; ---- root parallel `:on` projection (rf2-3v3gv1) ------------------------
+;;
+;; A `:type :parallel` machine's OWN top-level `:on` is the ANCESTOR FALLBACK
+;; for its regions (Spec 005 §Root parallel `:on`, verified against
+;; xstate@5.32.0). Shipped runtime semantics: when no region-local transition
+;; handles the event the root `:on` fires, moving one or more REGION-QUALIFIED
+;; targets atomically (untargeted regions stay put). Pre-rf2-3v3gv1 the chart
+;; projection modelled the per-region `:on` fallbacks but DROPPED the parallel
+;; root's own `:on` entirely — so Xray could neither render the transition in
+;; topology nor highlight it on a focused event. The projection now sources
+;; each root `:on` edge from the synthetic MACHINE-ROOT chip into the region-
+;; scoped target node (a targetless action-only root `:on` self-anchors on the
+;; chip as an internal affordance).
+
+(deftest project-definition-parallel-root-on-single-region-target
+  (testing "rf2-3v3gv1 — a root :on targeting ONE region `[:a :two]` projects
+            ONE edge from the MACHINE-ROOT chip into region :a's :two node"
+    ;; Mirrors spec/conformance/fixtures/parallel-root-on-single-region-target.
+    (let [m {:type    :parallel
+             :on      {:one {:target [:a :two]}}
+             :regions {:a {:initial :one :states {:one {} :two {}}}
+                       :b {:initial :one :states {:one {} :two {}}}}}
+          {:keys [nodes edges]} (layout/project-definition m)
+          root-ons (filter :parallel-root-on? edges)]
+      (is (= 1 (count root-ons)) "exactly one root-:on edge")
+      (let [e (first root-ons)]
+        (is (true? (:machine-level? e)) "flagged as an inherited fallback")
+        (is (= [] (:from-path e)) "sourced from the root context")
+        (is (= [:a :two] (:to-path e)) "region-qualified target path")
+        (is (= :one (:event e)))
+        (is (= layout/machine-root-id (:source e))
+            "sourced from the synthetic MACHINE-ROOT chip")
+        (is (= (layout/region-scoped-id :a [:two]) (:target e))
+            "lands on region :a's :two node (region-scoped)")
+        (is (not (:internal? e)) "a region-targeting root :on is not internal"))
+      ;; the synthetic MACHINE-ROOT chip is surfaced as the anchor
+      (let [root (first (filter :machine-root? nodes))]
+        (is (some? root) "the synthetic MACHINE-ROOT chip is present")
+        (is (= layout/machine-root-id (:id root)))))))
+
+(deftest project-definition-parallel-root-on-multi-region-target
+  (testing "rf2-3v3gv1 — a root :on with MULTIPLE region-qualified targets
+            `[[:a :x] [:b :y]]` projects ONE edge per region, both sourced
+            from the MACHINE-ROOT chip; the untargeted region :c gets none"
+    ;; Mirrors spec/conformance/fixtures/parallel-root-on-multi-region-target.
+    (let [m {:type    :parallel
+             :on      {:advance {:target [[:a :x] [:b :y]] :action :bump}}
+             :regions {:a {:initial :one :states {:one {} :x {}}}
+                       :b {:initial :one :states {:one {} :y {}}}
+                       :c {:initial :one :states {:one {}}}}}
+          {:keys [edges]} (layout/project-definition m)
+          root-ons (filter :parallel-root-on? edges)]
+      (is (= 2 (count root-ons)) "one root-:on edge per region-qualified target")
+      (is (= #{[:a :x] [:b :y]} (set (map :to-path root-ons))))
+      (is (every? #(= layout/machine-root-id (:source %)) root-ons)
+          "both sourced from the MACHINE-ROOT chip")
+      (is (= #{(layout/region-scoped-id :a [:x])
+               (layout/region-scoped-id :b [:y])}
+             (set (map :target root-ons)))
+          "each lands on its region-scoped target node")
+      (is (every? #(= :bump (:action %)) root-ons) "the root action is preserved")
+      ;; no root :on edge addresses the untargeted :c region
+      (is (not-any? #(= :c (first (:to-path %))) root-ons)
+          "the untargeted region :c gets no root :on edge"))))
+
+(deftest project-definition-parallel-root-on-targetless-action-only
+  (testing "rf2-3v3gv1 — a TARGETLESS action-only root :on self-anchors on
+            the MACHINE-ROOT chip as an internal affordance (moves no region)"
+    (let [m {:type    :parallel
+             :on      {:ping {:action :log-ping}}   ;; no :target
+             :regions {:a {:initial :one :states {:one {} :two {}}}
+                       :b {:initial :one :states {:one {} :two {}}}}}
+          {:keys [nodes edges]} (layout/project-definition m)
+          root-ons (filter :parallel-root-on? edges)]
+      (is (= 1 (count root-ons)) "one root-:on affordance")
+      (let [e (first root-ons)]
+        (is (true? (:internal? e)) "targetless → internal self-anchored chip")
+        (is (= [] (:to-path e)) "no region-qualified target")
+        (is (= layout/machine-root-id (:source e)))
+        (is (= layout/machine-root-id (:target e))
+            "self-anchored on the MACHINE-ROOT chip (moves no region)")
+        (is (= :log-ping (:action e)) "the action is preserved"))
+      (is (some? (first (filter :machine-root? nodes)))
+          "the MACHINE-ROOT chip anchors the affordance"))))
+
+(deftest project-definition-parallel-without-root-on-leaks-no-machine-root
+  (testing "rf2-3v3gv1 — a parallel machine with NO root :on keeps the
+            pre-fix node/edge set: no MACHINE-ROOT chip, no root :on edge"
+    (let [m {:type :parallel
+             :regions {:a {:initial :x :states {:x {:on {:go :y}} :y {}}}
+                       :b {:initial :p :states {:p {:on {:go :q}} :q {}}}}}
+          {:keys [nodes edges]} (layout/project-definition m)]
+      (is (empty? (filter :machine-root? nodes))
+          "no synthetic MACHINE-ROOT chip without a root :on")
+      (is (not-any? #(= layout/machine-root-id (:id %)) nodes))
+      (is (empty? (filter :parallel-root-on? edges))
+          "no root :on edges"))))
+
+(deftest project-definition-parallel-root-on-edge-ids-distinct-and-stable
+  (testing "rf2-3v3gv1 — multi-region root :on edges mint DISTINCT stable ids
+            (no xyflow duplicate-id drop) carrying the MACHINE-ROOT source"
+    (let [m {:type    :parallel
+             :on      {:advance {:target [[:a :x] [:b :y]]}}
+             :regions {:a {:initial :one :states {:one {} :x {}}}
+                       :b {:initial :one :states {:one {} :y {}}}}}
+          {:keys [edges]} (layout/project-definition m)
+          root-ons (filter :parallel-root-on? edges)
+          ids      (map :id root-ons)]
+      (is (= 2 (count ids)))
+      (is (= 2 (count (set ids))) "the two root :on edge ids are distinct")
+      (is (every? string? ids))
+      (is (every? #(str/starts-with? % layout/machine-root-id) ids)
+          "each id reads from the MACHINE-ROOT source segment"))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
@@ -281,8 +281,104 @@
                 (:id e)))
             edges))))
 
+(defn- cascade-from-trace
+  "rf2-l8ls6w — pull the structured `:cascade` step vector off a
+  `:rf.machine/transition` trace. The runtime stamps it under `:tags :cascade`
+  (modern) — `commit-or-finalize` (`lifecycle_fx/registration`) emits
+  `(trace/emit! :rf.machine :rf.machine/transition {… :cascade cascade})`, so
+  it lands under `:tags`. A legacy/test-fixture flat `:cascade` is tolerated.
+  Returns the step vector (possibly empty) — never nil."
+  [ev]
+  (or (get-in ev [:tags :cascade])
+      (:cascade ev)
+      []))
+
+(defn- handled-regions-from-cascade
+  "rf2-l8ls6w — the SET of region names a parallel macrostep actually HANDLED
+  this transition, read off the trace's structured `:cascade`. Each cascade
+  step carries `:region <region-name>` (stamped by the single-machine engine
+  from the synthetic region-spec's `:rf/region` — `transition.cljc` §structured
+  cascade steps); a region that handled the event contributes at least one
+  step (`:exit` / `:action` / `:entry`), a RESTING region (declined the event)
+  contributes none. This is the discriminator that distinguishes a HANDLED-
+  unchanged region (a real self/internal transition with `before == after` +
+  a non-empty cascade) from a region that simply did not move. Returns the set
+  of non-nil `:region`s present in the cascade."
+  [cascade]
+  (into #{} (keep :region) cascade))
+
+(defn- region-local-fired-ids
+  "rf2-8ncxrf — fired-edge ids for ONE region that CHANGED state (its
+  `before ≠ after`). The region-scoped match: the edge's `:from-path` /
+  `:to-path` are the IN-REGION paths and its `:source` is
+  `(region-scoped-id region from)` — the same injective id-scheme
+  `highlight-ids` resolves a region-map against (rf2-wnzha), so two regions
+  sharing a state NAME never cross-match. Returns a seq of ids (empty when no
+  region-LOCAL edge matched — e.g. the region moved via the parallel ROOT
+  `:on`; that fallback is matched by `region-root-on-fired-ids`)."
+  [edges region from* to* event*]
+  (let [scoped-source (chart-layout/region-scoped-id region from*)]
+    (keep (fn [e]
+            (when (and (= from*         (:from-path e))
+                       (= to*           (:to-path e))
+                       (= event*        (:event e))
+                       (= scoped-source (:source e)))
+              (:id e)))
+          edges)))
+
+(defn- region-root-on-fired-ids
+  "rf2-3v3gv1 — fired-edge ids for ONE region that the parallel ROOT `:on`
+  moved (the ancestor fallback — Spec 005 §Root parallel `:on`). When no
+  region-LOCAL transition handles the event, the root `:on` fires, moving one
+  or more REGION-QUALIFIED targets. `project-parallel`
+  (`collect-parallel-root-edges`) projects each such edge from the synthetic
+  MACHINE-ROOT chip with a region-qualified `:to-path` `[<region> &
+  <in-region-path>]` (NOT a region-scoped in-region `:from-path`/`:source`
+  like a region-local edge), so the region-local match above can't reach it.
+
+  We match a root `:on` edge (`:parallel-root-on? true`) whose region-
+  qualified `:to-path` head names THIS region and whose tail is the region's
+  in-region `to*`, on the event. `to*` is the moved region's in-region path
+  (a keyword coerces to a 1-vector); the edge's region-qualified `:to-path`
+  is `(cons region to*)`. Returns a seq of ids."
+  [edges region to* event*]
+  (let [qualified-to (vec (cons region to*))]
+    (keep (fn [e]
+            (when (and (:parallel-root-on? e)
+                       (= qualified-to (:to-path e))
+                       (= event*       (:event e)))
+              (:id e)))
+          edges)))
+
+(defn- region-self-internal-fired-ids
+  "rf2-l8ls6w — fired-edge ids for ONE region that was HANDLED but whose state
+  did NOT change (`before == after`): a real targetless/internal or external
+  self transition (`:target :same-state`). The runtime emits a
+  `:rf.machine/transition` (the macrostep was not a no-op — the handled
+  region's cascade is non-empty) and machines-viz projects the self edge, yet
+  the before/after region-map shows no change for the region, so
+  `region-local-fired-ids` (which keys on `from ≠ to`) skips it and Xray
+  highlights nothing.
+
+  A self/internal edge in the region is region-scoped exactly like any region
+  edge: its `:from-path == :to-path == self*` (the resting/self path) and its
+  `:source` is `(region-scoped-id region self*)`. We match on the region-
+  scoped source + `from == to == self*` + event, lighting BOTH the external
+  self-loop (`:from-path == :to-path`, no `:internal?`) and the internal
+  action-only edge (`:internal? true`, also self-anchored). Returns a seq of
+  ids."
+  [edges region self* event*]
+  (let [scoped-source (chart-layout/region-scoped-id region self*)]
+    (keep (fn [e]
+            (when (and (= self*         (:from-path e))
+                       (= self*         (:to-path e))
+                       (= event*        (:event e))
+                       (= scoped-source (:source e)))
+              (:id e)))
+          edges)))
+
 (defn- parallel-transition-fired-ids
-  "Fired-edge ids for ONE PARALLEL multi-region transition (rf2-8ncxrf).
+  "Fired-edge ids for ONE PARALLEL multi-region transition.
 
   A `:type :parallel` machine's snapshot `:state` is a region-MAP — one
   active leaf per orthogonal region (Spec 005 §Parallel regions). A single
@@ -290,40 +386,57 @@
   regions at once, but the runtime emits ONE `:rf.machine/transition`
   whose `:before` / `:after` carry the WHOLE composite region-map (per
   `lifecycle_fx.registration/commit-or-finalize`). So the fired EDGES are
-  the per-region edges of every region that CHANGED — derived from the
-  before/after region-map, NOT from a single (from, to) pair.
+  derived from the before/after region-map PLUS the structured `:cascade`,
+  NOT from a single (from, to) pair.
 
-  `project-parallel` (machines-viz `chart.layout`) region-SCOPES each
-  region's edges: an edge's `:from-path` / `:to-path` are the IN-REGION
-  paths (e.g. `[:idle]` → `[:running]`) and its `:source` is
-  `(region-scoped-id region from-path)` — the SAME injective id-scheme
-  `highlight-ids` resolves a region-map against (rf2-wnzha). Edges carry
-  no `:region` key, so two regions sharing a state NAME would collide on
-  the `(from, to, event)` triple; we disambiguate by matching the edge's
-  region-scoped `:source` against `(region-scoped-id region from-path)`,
-  guaranteeing each fired id belongs to the region that actually moved.
+  Per region, three outcomes light an edge:
 
-  Only regions whose `(from ≠ to)` contribute — an event that moves some
-  regions and leaves others resting lights exactly the moved regions.
-  Per-region `from` / `to` are coerced through `normalise-path` (a region
-  value is a keyword or in-region vector). Returns a seq of ids."
-  [edges before-map after-map event*]
+    - **rf2-8ncxrf — region CHANGED via a region-local transition.** `from ≠
+      after`; the region-scoped (from, to, event) match (`region-local-fired-
+      ids`) lights the moved region's edge.
+    - **rf2-3v3gv1 — region CHANGED via the parallel ROOT `:on`.** `from ≠
+      after` but NO region-local edge matched — the move came from the root
+      `:on` ancestor fallback. `region-root-on-fired-ids` lights the root-
+      sourced chip whose region-qualified `:to-path` names this region. (A
+      root `:on` moving a region while a region-local edge ALSO matches the
+      (from,to,event) cannot happen — the root `:on` is suppressed ENTIRELY
+      when any region handles the event, Spec 005; so the two are mutually
+      exclusive per region.)
+    - **rf2-l8ls6w — region HANDLED but UNCHANGED.** `before == after` yet the
+      region appears in the `:cascade` (a real self/internal transition fired
+      with a non-empty cascade). `region-self-internal-fired-ids` lights the
+      self/internal edge. A region that simply DECLINED the event (RESTING —
+      absent from the cascade) lights nothing.
+
+  `handled-regions` is the set of region names the cascade recorded (from
+  `handled-regions-from-cascade`). Per-region `from` / `to` are coerced
+  through `normalise-path` (a region value is a keyword or in-region vector).
+  Returns a seq of ids."
+  [edges before-map after-map event* handled-regions]
   (when event*
     (mapcat
       (fn [[region region-before]]
         (let [region-after (get after-map region)
               from*        (normalise-path region-before)
               to*          (normalise-path region-after)]
-          ;; Skip a region that did not move, or whose paths don't coerce.
-          (when (and from* to* (not= region-before region-after))
-            (let [scoped-source (chart-layout/region-scoped-id region from*)]
-              (keep (fn [e]
-                      (when (and (= from*         (:from-path e))
-                                 (= to*           (:to-path e))
-                                 (= event*        (:event e))
-                                 (= scoped-source (:source e)))
-                        (:id e)))
-                    edges)))))
+          (cond
+            ;; CHANGED: region-local match, falling back to the root `:on`
+            ;; ancestor fallback when no region-local edge moved it.
+            (and from* to* (not= region-before region-after))
+            (let [local (region-local-fired-ids edges region from* to* event*)]
+              (if (seq local)
+                local
+                (region-root-on-fired-ids edges region to* event*)))
+
+            ;; HANDLED-but-UNCHANGED: a real self/internal transition with
+            ;; before == after + a non-empty cascade for this region. A
+            ;; RESTING region (= but absent from the cascade) lights nothing.
+            (and from*
+                 (= region-before region-after)
+                 (contains? handled-regions region))
+            (region-self-internal-fired-ids edges region from* event*)
+
+            :else nil)))
       before-map)))
 
 (defn extract-fired-edge-ids
@@ -357,6 +470,21 @@
   single-active path returns nil for a map, which is why the event-focused
   view showed NO transition for `[:hvac/power-cycle]`).
 
+  rf2-3v3gv1 — PARALLEL ROOT `:on` (the ancestor fallback — Spec 005 §Root
+  parallel `:on`). When no region-local transition handles the event the root
+  `:on` fires, moving one or more region-qualified targets; the move shows in
+  the before/after region-map but is sourced from the synthetic MACHINE-ROOT
+  chip (region-qualified `:to-path`), not a region-local edge — so the per-
+  region branch falls back to matching the root-sourced chip.
+
+  rf2-l8ls6w — HANDLED-but-UNCHANGED parallel regions. A parallel region can
+  fire a real targetless/internal or self transition with `before == after`
+  and a non-empty cascade; the before/after region-map shows no change, so the
+  pure region-map diff skipped it. The per-region branch reads the trace's
+  structured `:cascade` (`handled-regions-from-cascade`) to distinguish a
+  HANDLED-unchanged region (lights its self/internal edge) from a RESTING
+  region that simply declined the event (lights nothing).
+
   Returns `#{}` for a nil/empty definition or no matching transitions."
   [definition trace-events machine-id]
   (let [edges (:edges (chart-layout/project-definition definition))]
@@ -367,13 +495,16 @@
                    before-raw  (before-state-from-trace ev)
                    after-raw   (after-state-from-trace ev)]
                (if (or (map? before-raw) (map? after-raw))
-                 ;; PARALLEL multi-region: derive from the region-maps so
-                 ;; every region that moved this event lights its edge.
+                 ;; PARALLEL multi-region: derive from the region-maps + the
+                 ;; structured cascade so every region that moved (region-local
+                 ;; or via the root `:on`) OR was handled-unchanged lights its
+                 ;; edge.
                  (parallel-transition-fired-ids
                    edges
                    (if (map? before-raw) before-raw {})
                    (if (map? after-raw) after-raw {})
-                   event*)
+                   event*
+                   (handled-regions-from-cascade (cascade-from-trace ev)))
                  ;; Single-active (flat / compound): the existing
                  ;; (from, to, event) match + machine-level fallback.
                  (let [from* (from-path-from-trace ev)

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/topology.cljs
@@ -4,12 +4,14 @@
 
   ## What it renders
 
-  The Static Topology body embeds `machine-canvas/Chart` — the same
-  interactive viewport adapter the Dynamic Machines panel uses — so
-  Static users get zoom / pan / fit with the same gestures and the
-  same keyboard shortcuts (`+` / `-`, arrows, `f`, `0`). Stately and
-  XState's static / read-only chart views get the same affordances;
-  Xray's static surface should match.
+  The Static Topology body embeds `machine-canvas/Chart` — the SAME
+  MachineChart surface the Dynamic Machines panel renders (rf2-gpzb4
+  xyflow migration). So the Static and Dynamic surfaces are the same
+  chart; pan / zoom / fit are driven by the mouse + xyflow's own
+  on-canvas controls (drag to pan, wheel / pinch to zoom, the controls
+  buttons to fit), NOT by Xray-owned keyboard shortcuts. There are NO
+  implemented keyboard shortcuts (`+` / `-`, arrows, `f`, `0`) on either
+  surface — viewport gestures are xyflow's.
 
   Static differs from Dynamic in two respects:
 
@@ -22,11 +24,17 @@
        state's path) — not the Dynamic panel's inspector-lens
        navigation event.
 
-  The per-machine viewport slot is shared with the Dynamic Machine
-  Inspector — if the user pans / zooms in either surface, the other
-  picks up the same viewport when it next mounts. That matches the
-  user model: 'this is the chart for machine X, parked in this
-  view.'
+  ## Viewport
+
+  There is NO stored, shared per-machine viewport slot — Static and
+  Dynamic do NOT hand a saved pan / zoom between each other. Each
+  surface's viewport lives inside its own xyflow instance for the
+  mount's lifetime. Fit-on-entry is the one piece Xray drives: entering
+  the Static Machines tab bumps a `:fit-signal` nonce (rf2-6tw7t) that
+  re-frames the topology (xyflow's one-shot `:fitView` + the layout-key
+  auto-fit both leave a re-entered chart stale), so the chart opens
+  framed to its content. After that, pan / zoom is the user's via the
+  mouse + xyflow controls.
 
   ## Empty states
 
@@ -71,10 +79,11 @@
   "Render the interactive MachineChart canvas for `definition`. NO
   highlight + NO after-rings — Static Topology is a static-read.
 
-  rf2-md9oz — delegates to `machine-canvas/Chart` (same adapter the
-  Dynamic Machines panel uses) so the user gets zoom / pan / fit
-  + keyboard shortcuts on the Static surface too. The static-
-  flavoured opts are:
+  rf2-md9oz — delegates to `machine-canvas/Chart` (the same MachineChart
+  surface the Dynamic Machines panel renders) so the user gets mouse /
+  controls-driven xyflow zoom / pan / fit on the Static surface too (no
+  Xray-owned keyboard shortcuts — viewport gestures are xyflow's). The
+  static-flavoured opts are:
 
     :show-after-rings?      false  — no focused-event lens on static.
     :testid                        — overrides the inner SVG testid

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
@@ -801,3 +801,302 @@
       (is (= 2 (count fired)) "both region edges fired")
       (is (every? projected-ids fired)
           "each parallel fired id is one the live chart actually rendered"))))
+
+;; ---- extract-fired-edge-ids: ROOT parallel `:on` (rf2-3v3gv1) ------------
+;;
+;; A `:type :parallel` machine's OWN top-level `:on` is the ANCESTOR FALLBACK
+;; for its regions (Spec 005 §Root parallel `:on`). When no region-LOCAL
+;; transition handles the event the root `:on` fires, moving one or more
+;; REGION-QUALIFIED targets. The before/after region-map shows the move, but
+;; the moved region's edge is sourced from the synthetic MACHINE-ROOT chip
+;; (region-qualified :to-path), NOT a region-local edge — so the region-local
+;; (from, to, event) match misses it and `extract-fired-edge-ids` falls back
+;; to matching the root-sourced chip whose :to-path names the moved region.
+
+(defn- root-on-edge-id
+  "Look up the canonical machines-viz edge id for the PARALLEL-ROOT `:on` edge
+  whose region-qualified `:to-path` and `:event` match — projected through the
+  SAME public chart.layout/project-definition the live chart uses."
+  [definition to-path event]
+  (->> (:edges (chart-layout/project-definition definition))
+       (some (fn [e]
+               (when (and (:parallel-root-on? e)
+                          (= to-path (:to-path e))
+                          (= event   (:event e)))
+                 (:id e))))))
+
+(deftest fired-ids-parallel-root-on-single-region-target
+  (testing "rf2-3v3gv1 — a root :on moving ONE region (no region-local edge)
+            lights the MACHINE-ROOT-sourced chip for that region; the
+            untargeted region lights nothing"
+    ;; Mirrors spec/conformance/fixtures/parallel-root-on-single-region-target:
+    ;; ONE -> {a:two, b:one}. No region declares :one; the root :on moves :a.
+    (let [def           {:type    :parallel
+                         :on      {:one {:target [:a :two]}}
+                         :regions {:a {:initial :one :states {:one {} :two {}}}
+                                   :b {:initial :one :states {:one {} :two {}}}}}
+          projected-ids (set (map :id (:edges (chart-layout/project-definition def))))
+          a-id          (root-on-edge-id def [:a :two] :one)
+          events        [{:operation :rf.machine/transition
+                          :tags {:machine-id :par
+                                 :before {:state {:a :one :b :one}}
+                                 :after  {:state {:a :two :b :one}}
+                                 :event  [:one]
+                                 ;; only :a was handled (by the root :on
+                                 ;; applied to :a); :b rested.
+                                 :cascade [{:kind :exit  :region :a :state [:one]}
+                                           {:kind :entry :region :a :state [:two]}]}}]
+          fired         (trace-state/extract-fired-edge-ids def events :par)]
+      (is (string? a-id) "the root :on edge for region :a exists")
+      (is (= #{a-id} fired)
+          "only the MACHINE-ROOT-sourced chip into :a lights; :b stays dark")
+      (is (every? projected-ids fired)
+          "the fired id is a real live-chart edge id"))))
+
+(deftest fired-ids-parallel-root-on-multi-region-target
+  (testing "rf2-3v3gv1 — a root :on with multiple region-qualified targets
+            lights BOTH region chips; an untargeted region lights nothing"
+    ;; Mirrors parallel-root-on-multi-region-target: advance -> {a:x, b:y, c:one}.
+    (let [def           {:type    :parallel
+                         :on      {:advance {:target [[:a :x] [:b :y]]}}
+                         :regions {:a {:initial :one :states {:one {} :x {}}}
+                                   :b {:initial :one :states {:one {} :y {}}}
+                                   :c {:initial :one :states {:one {}}}}}
+          projected-ids (set (map :id (:edges (chart-layout/project-definition def))))
+          a-id          (root-on-edge-id def [:a :x] :advance)
+          b-id          (root-on-edge-id def [:b :y] :advance)
+          events        [{:operation :rf.machine/transition
+                          :tags {:machine-id :par
+                                 :before {:state {:a :one :b :one :c :one}}
+                                 :after  {:state {:a :x :b :y :c :one}}
+                                 :event  [:advance]
+                                 :cascade [{:kind :entry :region :a :state [:x]}
+                                           {:kind :entry :region :b :state [:y]}]}}]
+          fired         (trace-state/extract-fired-edge-ids def events :par)]
+      (is (string? a-id))
+      (is (string? b-id))
+      (is (= #{a-id b-id} fired)
+          "both root-:on chips light; the untargeted :c stays dark")
+      (is (every? projected-ids fired)))))
+
+(deftest fired-ids-parallel-root-on-suppressed-by-region-local
+  (testing "rf2-3v3gv1 — when a region handles the event LOCALLY the root :on
+            is suppressed entirely; only the region-local edge lights"
+    ;; Mirrors parallel-root-on-region-wins: GO -> {a:two, b:one}. :a handles
+    ;; :go locally; the root :go (which would move BOTH) is suppressed, so :b
+    ;; stays. The region-local :a edge lights — NOT the root chip.
+    (let [def        {:type    :parallel
+                      :on      {:go {:target [[:a :two] [:b :two]]}}
+                      :regions {:a {:initial :one
+                                    :states  {:one {:on {:go :two}} :two {}}}
+                                :b {:initial :one :states {:one {} :two {}}}}}
+          projected  (:edges (chart-layout/project-definition def))
+          local-a    (->> projected
+                          (some (fn [e]
+                                  (when (and (not (:parallel-root-on? e))
+                                             (= [:one] (:from-path e))
+                                             (= [:two] (:to-path e))
+                                             (= :go (:event e))
+                                             (= "region__a__one" (:source e)))
+                                    (:id e)))))
+          events     [{:operation :rf.machine/transition
+                       :tags {:machine-id :par
+                              :before {:state {:a :one :b :one}}
+                              :after  {:state {:a :two :b :one}}
+                              :event  [:go]
+                              :cascade [{:kind :exit  :region :a :state [:one]}
+                                        {:kind :entry :region :a :state [:two]}]}}]
+          fired      (trace-state/extract-fired-edge-ids def events :par)]
+      (is (string? local-a) "the region-local :a :one→:two edge exists")
+      (is (= #{local-a} fired)
+          "the region-local edge lights; the suppressed root :on chip does NOT"))))
+
+(deftest fired-ids-parallel-root-on-agree-with-projected-chart-edge-ids
+  (testing "rf2-3v3gv1 — every root-:on fired id is a real projected chart edge :id"
+    (let [def           {:type    :parallel
+                         :on      {:go-all {:target [[:a :two] [:b :two]]}}
+                         :regions {:a {:initial :one :states {:one {} :two {}}}
+                                   :b {:initial :one :states {:one {} :two {}}}}}
+          projected-ids (set (map :id (:edges (chart-layout/project-definition def))))
+          events        [{:operation :rf.machine/transition
+                          :tags {:machine-id :par
+                                 :before {:state {:a :one :b :one}}
+                                 :after  {:state {:a :two :b :two}}
+                                 :event  [:go-all]
+                                 :cascade [{:kind :entry :region :a :state [:two]}
+                                           {:kind :entry :region :b :state [:two]}]}}]
+          fired         (trace-state/extract-fired-edge-ids def events :par)]
+      (is (= 2 (count fired)) "both targeted regions' root chips fired")
+      (is (every? projected-ids fired)
+          "each root-:on fired id is one the live chart actually rendered"))))
+
+;; ---- extract-fired-edge-ids: HANDLED-but-UNCHANGED parallel (rf2-l8ls6w) --
+;;
+;; A parallel region can fire a real targetless/INTERNAL or external SELF
+;; transition with before == after (the region's leaf is unchanged) AND a
+;; non-empty cascade. The runtime emits :rf.machine/transition and machines-viz
+;; projects the self edge, but the before/after region-map shows no change, so
+;; the pure region-map diff skipped it and Xray highlighted nothing. The fix
+;; reads the trace's structured :cascade to distinguish a HANDLED-unchanged
+;; region (light its self/internal edge) from a RESTING region (light nothing).
+
+(deftest fired-ids-parallel-self-transition-before-equals-after
+  (testing "rf2-l8ls6w — a region firing an external SELF transition
+            (:target :same-state, before == after) lights its self-loop edge,
+            distinguished from a resting region by the cascade"
+    (let [def        {:type    :parallel
+                      :regions {:a {:initial :idle
+                                    :states  {:idle {:on {:ping {:target :same-state
+                                                                 :action :log}}}}}
+                                :b {:initial :idle
+                                    :states  {:idle {:on {:other :done}
+                                                     } :done {}}}}}
+          projected  (:edges (chart-layout/project-definition def))
+          self-id    (->> projected
+                          (some (fn [e]
+                                  (when (and (= [:idle] (:from-path e))
+                                             (= [:idle] (:to-path e))
+                                             (= :ping (:event e))
+                                             (= "region__a__idle" (:source e)))
+                                    (:id e)))))
+          ;; :a handled :ping as a self transition (before == after); :b
+          ;; declined :ping entirely (RESTING — no cascade step).
+          events     [{:operation :rf.machine/transition
+                       :tags {:machine-id :par
+                              :before {:state {:a :idle :b :idle}}
+                              :after  {:state {:a :idle :b :idle}}
+                              :event  [:ping]
+                              :cascade [{:kind :exit   :region :a :state [:idle]}
+                                        {:kind :action :region :a :state []
+                                         :action :log}
+                                        {:kind :entry  :region :a :state [:idle]}]}}]
+          fired      (trace-state/extract-fired-edge-ids def events :par)]
+      (is (string? self-id) "the :a self-loop edge exists")
+      (is (= #{self-id} fired)
+          "the HANDLED-unchanged :a self edge lights; the RESTING :b lights nothing"))))
+
+(deftest fired-ids-parallel-internal-transition-before-equals-after
+  (testing "rf2-l8ls6w — a region firing an INTERNAL transition (no :target,
+            action-only — before == after) lights its internal self-anchored
+            edge off the non-empty cascade"
+    (let [def       {:type    :parallel
+                     :regions {:a {:initial :idle
+                                   :states  {:idle {:on {:tick {:action :count}}}}}
+                               :b {:initial :idle
+                                   :states  {:idle {} }}}}
+          projected (:edges (chart-layout/project-definition def))
+          internal-id (->> projected
+                           (some (fn [e]
+                                   (when (and (:internal? e)
+                                              (= [:idle] (:from-path e))
+                                              (= [:idle] (:to-path e))
+                                              (= :tick (:event e))
+                                              (= "region__a__idle" (:source e)))
+                                     (:id e)))))
+          events    [{:operation :rf.machine/transition
+                      :tags {:machine-id :par
+                             :before {:state {:a :idle :b :idle}}
+                             :after  {:state {:a :idle :b :idle}}
+                             :event  [:tick]
+                             :cascade [{:kind :action :region :a :state []
+                                        :action :count}]}}]
+          fired     (trace-state/extract-fired-edge-ids def events :par)]
+      (is (string? internal-id) "the :a internal self-anchored edge exists")
+      (is (= #{internal-id} fired)
+          "the internal HANDLED-unchanged :a edge lights off the cascade"))))
+
+(deftest fired-ids-parallel-resting-region-lights-nothing
+  (testing "rf2-l8ls6w — a region whose before == after AND is ABSENT from the
+            cascade (a RESTING region that declined the event) lights nothing,
+            even if a self/internal edge for the event exists in the projection"
+    (let [def       {:type    :parallel
+                     :regions {:a {:initial :idle
+                                   :states  {:idle {:on {:ping {:action :log}}}}}
+                               :b {:initial :idle
+                                   :states  {:idle {:on {:other :done}} :done {}}}}}
+          ;; :b moved on :other; :a has a self/internal :ping edge but :ping
+          ;; was NOT this event — :a rested (no cascade step). Only :b lights.
+          projected (:edges (chart-layout/project-definition def))
+          b-id      (->> projected
+                         (some (fn [e]
+                                 (when (and (= [:idle] (:from-path e))
+                                            (= [:done] (:to-path e))
+                                            (= :other (:event e))
+                                            (= "region__b__idle" (:source e)))
+                                   (:id e)))))
+          events    [{:operation :rf.machine/transition
+                      :tags {:machine-id :par
+                             :before {:state {:a :idle :b :idle}}
+                             :after  {:state {:a :idle :b :done}}
+                             :event  [:other]
+                             ;; only :b handled :other; :a is RESTING.
+                             :cascade [{:kind :exit  :region :b :state [:idle]}
+                                       {:kind :entry :region :b :state [:done]}]}}]
+          fired     (trace-state/extract-fired-edge-ids def events :par)]
+      (is (string? b-id))
+      (is (= #{b-id} fired)
+          "only the moved :b region lights; the resting :a (absent from
+           cascade) lights nothing even though it has a :ping self edge"))))
+
+(deftest fired-ids-parallel-mixed-moved-and-handled-unchanged
+  (testing "rf2-l8ls6w — one event moves region :a (changed) AND fires a self
+            transition in region :b (handled-unchanged): BOTH light"
+    (let [def       {:type    :parallel
+                     :regions {:a {:initial :one
+                                   :states  {:one {:on {:go :two}} :two {}}}
+                               :b {:initial :idle
+                                   :states  {:idle {:on {:go {:target :same-state
+                                                              :action :note}}}}}}}
+          projected (:edges (chart-layout/project-definition def))
+          a-id      (->> projected
+                         (some (fn [e]
+                                 (when (and (= [:one] (:from-path e))
+                                            (= [:two] (:to-path e))
+                                            (= :go (:event e))
+                                            (= "region__a__one" (:source e)))
+                                   (:id e)))))
+          b-self-id (->> projected
+                         (some (fn [e]
+                                 (when (and (= [:idle] (:from-path e))
+                                            (= [:idle] (:to-path e))
+                                            (= :go (:event e))
+                                            (= "region__b__idle" (:source e)))
+                                   (:id e)))))
+          events    [{:operation :rf.machine/transition
+                      :tags {:machine-id :par
+                             :before {:state {:a :one :b :idle}}
+                             :after  {:state {:a :two :b :idle}}
+                             :event  [:go]
+                             :cascade [{:kind :exit   :region :a :state [:one]}
+                                       {:kind :entry  :region :a :state [:two]}
+                                       {:kind :exit   :region :b :state [:idle]}
+                                       {:kind :action :region :b :state [] :action :note}
+                                       {:kind :entry  :region :b :state [:idle]}]}}]
+          fired     (trace-state/extract-fired-edge-ids def events :par)]
+      (is (string? a-id) "the :a moved edge exists")
+      (is (string? b-self-id) "the :b self edge exists")
+      (is (= #{a-id b-self-id} fired)
+          "the moved :a edge AND the handled-unchanged :b self edge BOTH light"))))
+
+(deftest fired-ids-parallel-no-cascade-keeps-changed-region-behaviour
+  (testing "rf2-l8ls6w — a trace with NO :cascade (legacy / hand-built) still
+            lights every CHANGED region (the pre-fix behaviour is preserved);
+            only handled-UNCHANGED detection needs the cascade"
+    (let [def        (hvac-definition)
+          projected  (:edges (chart-layout/project-definition def))
+          climate-id (->> projected
+                          (some (fn [e]
+                                  (when (and (= [:idle]    (:from-path e))
+                                             (= [:running] (:to-path e))
+                                             (= :hvac/power-cycle (:event e)))
+                                    (:id e)))))
+          ;; climate moved; no :cascade on the trace at all.
+          events     [{:operation :rf.machine/transition
+                       :tags {:machine-id :hvac/controller
+                              :before {:state {:climate :idle :fan :off}}
+                              :after  {:state {:climate :running :fan :off}}
+                              :event  [:hvac/power-cycle]}}]
+          fired      (trace-state/extract-fired-edge-ids
+                       def events :hvac/controller)]
+      (is (= #{climate-id} fired)
+          "the changed climate region still lights without a cascade"))))


### PR DESCRIPTION
## Quality gates

- `clojure -M:test` (tools/machines-viz): **475 tests, 1640 assertions, 0 failures, 0 errors**
- `clojure -M:test` (tools/xray): **1108 tests, 4589 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (implementation, node runtime — runs the new `.cljs` fired-edge tests): **6006 tests, 21297 assertions, 0 failures, 0 errors**
- `npm run test:browser` (Playwright DOM): **205 tests, 633 assertions, 0 failures, 0 errors**
- New fired-edge tests confirmed to execute (probe-then-revert in both `trace_state_cljs_test.cljs` and `layout_cljs_test.cljc`).

## rf2-3v3gv1 (P3 BUG) — render + highlight root-parallel `:on`

A `:type :parallel` machine's own top-level `:on` is the ancestor fallback for its regions (Spec 005 §Root parallel `:on`), shipped runtime semantics — but the chart projection / fired-edge path dropped it entirely.

- **machines-viz `chart.layout`**: `collect-parallel-root-edges` + `normalise-root-targets` (mirroring the runtime resolver) project each root `:on` candidate ONCE per region-qualified target, sourced from the synthetic MACHINE-ROOT chip into the region-scoped target node, flagged `:machine-level?` + `:parallel-root-on?`. A targetless action-only root `:on` self-anchors on the chip as an `:internal?` affordance. `project-parallel` surfaces the MACHINE-ROOT chip (only when a root `:on` exists — a root-`:on`-less parallel keeps the pre-fix node/edge set byte-identical) and leads it in the node vector.
- **Xray `trace_state`**: `region-root-on-fired-ids` matches the root-sourced chip whose region-qualified `:to-path` names a region that moved when no region-local edge did (the root `:on` is suppressed entirely when any region handles the event — Spec 005 — so the two are mutually exclusive per region).
- Tests for single-/multi-region targets, targetless action-only, suppression-by-region-local, and projected-id agreement.

## rf2-l8ls6w (P3 BUG) — highlight parallel self/internal fired edges with before == after

`extract-fired-edge-ids` derived parallel fired edges only from before/after region-map CHANGES, so a region that fired a real targetless/internal or external self transition (`before == after`, non-empty cascade) was skipped.

- Read the transition trace's structured `:cascade` (each step stamped with `:region`) to distinguish a HANDLED-unchanged region (lights its self/internal edge via `region-self-internal-fired-ids`) from a RESTING region that declined the event (absent from the cascade → lights nothing).
- `parallel-transition-fired-ids` now takes the handled-region set; a trace with no `:cascade` preserves the pre-fix changed-region behaviour.
- Tests for parallel external self, internal action-only, resting-region-lights-nothing, mixed moved + handled-unchanged, and no-cascade back-compat.

The two BUGs share the fired-edge-extraction path; the per-region branch is one coherent cond (region-local → root-`:on` fallback → handled-unchanged).

## rf2-bz87en (P4 docstring) — static topology viewport/keyboard prose

Rewrote the `static/machines/topology.cljs` namespace docstring (and the matching stale claim in the private `chart` fn docstring): Static Topology uses the same MachineChart surface as Dynamic Machines, mouse/controls-driven xyflow pan/zoom/fit, NO stored shared viewport slot, NO implemented keyboard shortcuts (`+`/`-`/arrows/`f`/`0`), fit-on-entry via `:fit-signal`.

## Spec

Updated `tools/machines-viz/spec/001-Topology-Parity.md` — new visual-grammar row for the root parallel `:on` ancestor fallback edge, and a §4.4 G3 bullet documenting the three-way parallel fired-edge coverage (region-local / root-`:on` / handled-unchanged). The `:fired-edge-ids` API.md prop semantics are unchanged (the new coverage is internal to `extract-fired-edge-ids`).