### PR TITLE
fix(machines-viz): back-edge :lr elbows + parallel transpose origin + adaptive layout-key (rf2-hpe9ws rf2-qp613a rf2-9qbn0g)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -550,10 +550,24 @@ projector emits xyflow nodes/edges) the pass:
    bowed `back-edge-detour-offset` px to the quiet side of the spine.
 3. **Reroutes** the back-edge's two segments (`<id>__in` / `<id>__out`) as
    a clean **side-detour** (source → out the side → lifted chip → in to the
-   target) so the return reads as a path AROUND the cluster.
+   target) so the return reads as a path AROUND the cluster. The elbow
+   **mirrors the flow axis** (rf2-hpe9ws): for `:tb` (vertical flow) the
+   route leaves the source SIDEWAYS to the side lane then runs vertically to
+   the lifted chip; for `:lr` (horizontal flow) it leaves the source
+   VERTICALLY to the side lane then runs horizontally to the chip. A
+   `:tb`-shaped elbow on an `:lr` layout would run along the flow row first,
+   crossing the forward edges.
 
 Forward edges and self/internal transitions are untouched (`back-edge?`
 excludes them); a back-edge ELK already placed compactly keeps its route.
+
+The opt-in `apply-post-elk` transform (back-edge reroute + parallel
+transpose) is gated by the RAW `:auto` opt-in, while ELK is fed the RESOLVED
+direction. So the `MachineChart` layout-key folds in the opt-in MODE flag
+alongside the resolved direction (rf2-9qbn0g): when `:auto` resolves to the
+same direction as a forced/default `:tb` (a linear / parallel machine), a
+`:tb → :auto → :tb` flip still invalidates the cached layout so the transform
+applies on opt-IN and is removed on opt-OUT rather than stale-caching.
 
 **OPT-IN — not auto-applied (the rf2-lamdfl/rf2-gnrkke redo lock).** The
 reroute runs ONLY when a machine OPTS IN via `:direction :auto`

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -273,6 +273,35 @@
       (cond-> (contains? (projection/fork-branch-container-ids parsed) nil)
         (assoc "elk.layered.crossingMinimization.semiInteractive" "true"))))
 
+(defn compute-layout-key
+  "rf2-9qbn0g — the memo key the chart uses to decide whether to re-run the
+  ELK layout pass. Pure; extracted as a directly-assertable fn so the cache-
+  invalidation contract is regression-guarded. (Named `compute-layout-key`,
+  not `layout-key`, because the component binds a local `layout-key` r/atom
+  that would shadow it.)
+
+  The key folds together every input that changes the laid-out result:
+
+    - `definition`     — the machine topology;
+    - `elk-direction`  — the RESOLVED direction ELK is fed (`:tb`/`:lr`);
+    - `layout-options` — host ELK overrides;
+    - `density`        — drives the derived container padding (rf2-8q5pt);
+    - `context-rows`   — the root-container Context band height (rf2-8z1rca);
+    - `adaptive?`      — the post-ELK MODE flag (rf2-9qbn0g).
+
+  `adaptive?` MUST be in the key even though `elk-direction` already is: the
+  post-ELK transform (parallel transpose + back-edge reroute) is gated by the
+  RAW `:auto` opt-in, NOT the resolved direction. When `:auto` resolves to the
+  SAME direction as a forced/default `:tb` (a linear or parallel machine,
+  where `post-elk/aspect-direction` returns `:tb`), `elk-direction` is
+  identical for `:direction :tb` and `:direction :auto`. Without the flag a
+  `:tb → :auto → :tb` flip would NOT invalidate the cache — the back-edge
+  reroute / parallel transpose would never apply on opt-IN and would
+  stale-stay on opt-OUT. The flag makes the flip re-run the pass (apply then
+  remove the transform) while ELK is still fed the resolved `elk-direction`."
+  [definition elk-direction layout-options density context-rows adaptive?]
+  [definition elk-direction layout-options density context-rows adaptive?])
+
 (defn- ->elk-input
   "Build an elk.js JS-side input graph for the given parsed nodes +
   edges + direction. Parallel machines (rf2-lkwev) get a hierarchical
@@ -1280,7 +1309,21 @@
             ;; rf2-8z1rca — `context-rows` joins the layout key so adding /
             ;; removing context (which changes the reserved root top padding)
             ;; re-runs ELK rather than rendering against the prior band height.
-            this-key   [definition elk-direction layout-options density context-rows]
+            ;; rf2-9qbn0g — `adaptive?` (the post-ELK MODE flag) joins the key.
+            ;; The pass is keyed by the RESOLVED `elk-direction`, but the post-
+            ;; ELK transform (parallel transpose + back-edge reroute) is gated
+            ;; by the RAW `:auto` opt-in, not the resolved direction. When
+            ;; `:auto` resolves to the SAME direction as a forced/default `:tb`
+            ;; (a linear / parallel machine, where `aspect-direction` returns
+            ;; `:tb`), `elk-direction` is identical for `:direction :tb` and
+            ;; `:direction :auto`, so toggling the prop did NOT invalidate the
+            ;; cached layout — the back-edge reroute / parallel transpose never
+            ;; applied on opt-IN, and stale-stayed on opt-OUT. Folding the
+            ;; opt-in flag into the key makes a `:tb → :auto → :tb` flip re-run
+            ;; the pass (apply then remove the transform) while still feeding
+            ;; the resolved `elk-direction` to ELK.
+            this-key   (compute-layout-key definition elk-direction layout-options
+                                           density context-rows adaptive?)
             ;; rf2-d9ro2 — one ELK pass. `measured-dims` is nil on the
             ;; FIRST pass (nodes not yet rendered/measured) and the
             ;; xyflow-measured `{node-id {:width :height}}` map on the

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/post_elk.cljc
@@ -476,15 +476,23 @@
           ;; LEFT-align the stacked column to the leftmost region's root x
           ;; (Stately stacks the regions in one vertical column, not at their
           ;; original side-by-side x-offsets).
-          column-x      (->> region-nodes
-                             (map #(:x (get positions (:id %) {:x 0})))
-                             (reduce min 0))
+          ;;
+          ;; rf2-qp613a — compute the column origin from the ACTUAL region
+          ;; positions only, NOT seeded with 0. A root-container-wrapped chart
+          ;; positions its region containers relative to the root frame's
+          ;; padding/header, so every region origin is POSITIVE; seeding the
+          ;; reduce with 0 (`(reduce min 0 …)`) clamped a positive origin to
+          ;; zero, sliding the stacked column up/left into the reserved root
+          ;; chrome. `(reduce min …)` over the region xs/ys alone preserves the
+          ;; leftmost/topmost region's true origin (and stays total — the
+          ;; outer `if-not (:parallel? …)` guarantees ≥1 region here).
+          region-xs     (map #(:x (get positions (:id %) {:x 0})) region-nodes)
+          region-ys     (map #(:y (get positions (:id %) {:y 0})) region-nodes)
+          column-x      (reduce min region-xs)
           ;; the column's top (the y the first region's band starts at) —
           ;; preserve the topmost region's original root y so the stack
           ;; doesn't jump to the canvas origin.
-          column-y      (->> region-nodes
-                             (map #(:y (get positions (:id %) {:y 0})))
-                             (reduce min 0))
+          column-y      (reduce min region-ys)
           ;; 1 + 2 — transpose each region interior, then re-stack containers.
           ;; We fold over the ordered regions, accumulating the running y
           ;; cursor for the vertical column.
@@ -620,10 +628,18 @@
   The chip is lifted to mid-height between the source and target centres
   (the Stately compact mid-height return) and bowed `back-edge-detour-offset`
   px to the LEAVING side (the side the source exits toward — left of the
-  spine for a `:tb` layout, biasing the loop away from the forward column).
-  The `__in` segment runs source → out the side → the lifted chip; the
-  `__out` runs chip → in to the target — a clean detour AROUND the cluster
-  rather than the deep plunge."
+  spine for a `:tb` layout, above the flow row for an `:lr` layout, biasing
+  the loop away from the forward column / row). The `__in` segment runs
+  source → out the side → the lifted chip; the `__out` runs chip → in to the
+  target — a clean detour AROUND the cluster rather than the deep plunge.
+
+  rf2-hpe9ws — the elbow construction MIRRORS the flow axis. For `:tb`
+  (vertical flow) the route leaves the source SIDEWAYS to the side lane
+  (`detour-x`, keeping the source's y) then runs vertically to the lifted
+  chip; for `:lr` (horizontal flow) it must leave the source VERTICALLY to
+  the side lane (`detour-y`, keeping the source's x) then run horizontally
+  to the chip. A `:tb`-shaped elbow on an `:lr` layout would run along the
+  flow row first, crossing the forward edges (the bug)."
   [edge positions direction]
   (let [src (:source edge)
         tgt (:target edge)
@@ -636,8 +652,8 @@
             ;; mid-point between the endpoints (the Stately mid-height return)
             mid-flow {:x (/ (+ (:x sc) (:x tc)) 2)
                       :y (/ (+ (:y sc) (:y tc)) 2)}
-            ;; bow to the LEFT of the spine for :tb (above for :lr) — the
-            ;; quiet side a return route hugs.
+            ;; bow to the LEFT of the spine for :tb (above the row for :lr) —
+            ;; the quiet side a return route hugs.
             detour-x (if tb? (- (:x mid-flow) back-edge-detour-offset) (:x mid-flow))
             detour-y (if tb? (:y mid-flow) (- (:y mid-flow) back-edge-detour-offset))
             ;; the lifted event-node position (top-left): centre the chip at
@@ -648,13 +664,23 @@
                     :y (- detour-y (/ ev-h 2))}
             chip-c {:x detour-x :y detour-y}]
         {:event-pos  ev-pos
-         ;; source centre → side → lifted chip
+         ;; source centre → out the side lane → lifted chip. The elbow leaves
+         ;; the source ORTHOGONAL to the flow axis: sideways (to detour-x) for
+         ;; :tb so it then runs vertically up the lane; upward (to detour-y)
+         ;; for :lr so it then runs horizontally along the lane (rf2-hpe9ws —
+         ;; mirror the elbow, don't reuse the :tb shape).
          :in-points  [sc
-                      {:x detour-x :y (:y sc)}
+                      (if tb?
+                        {:x detour-x :y (:y sc)}
+                        {:x (:x sc) :y detour-y})
                       chip-c]
-         ;; lifted chip → side → target centre
+         ;; lifted chip → in to the target. Mirror: the elbow drops back onto
+         ;; the target ORTHOGONAL to the flow axis — to the target's x then
+         ;; into it for :tb, to the target's y then into it for :lr.
          :out-points [chip-c
-                      {:x detour-x :y (:y tc)}
+                      (if tb?
+                        {:x detour-x :y (:y tc)}
+                        {:x (:x tc) :y detour-y})
                       tc]}))))
 
 (defn reroute-back-edges

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/auto_fit_view_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/auto_fit_view_cljs_test.cljs
@@ -46,6 +46,8 @@
   reason `chart-dom-cljs-test` skips awaiting the elkjs Promise)."
   (:require [cljs.test :refer-macros [deftest is testing async]]
             [day8.re-frame2-machines-viz.chart :as chart]
+            [day8.re-frame2-machines-viz.chart.layout :as layout]
+            [day8.re-frame2-machines-viz.chart.post-elk :as post-elk]
             [re-frame.trace :as trace]))
 
 ;; ---- fixtures ----------------------------------------------------------
@@ -624,3 +626,76 @@
       (is (zero? (count @spy)) "no entry-fit on a layout-error settle")
       (is (= ::chart-unfit (:fit-sig @fit-state))
           "signal unrecorded — banner paints, not a degenerate fit"))))
+
+;; ---- 9. layout-key folds in the adaptive post-ELK mode (rf2-9qbn0g) ---
+;;
+;; The chart keys its ELK layout pass by the RESOLVED `elk-direction`, but the
+;; post-ELK transform (parallel transpose + back-edge reroute) is gated by the
+;; RAW `:auto` opt-in. When `:auto` resolves to the SAME direction as a
+;; forced/default `:tb` (a linear / parallel machine — `aspect-direction`
+;; returns `:tb`), the resolved direction is identical for `:direction :tb`
+;; and `:direction :auto`, so without the opt-in flag in the key a
+;; `:tb → :auto → :tb` flip would NOT invalidate the cached layout: the
+;; back-edge reroute / parallel transpose would never apply on opt-IN and
+;; would stale-stay on opt-OUT. `chart/layout-key` folds the `adaptive?` mode
+;; flag in to fix this.
+
+(def ^:private door-cyclic-definition
+  "The door shape: a forward spine with a back-edge whose `:auto` aspect-
+  heuristic resolves to `:tb` (a chain with a 2-way fan, under the landscape
+  threshold) — so its resolved `elk-direction` is `:tb` whether the host
+  forces `:tb` or opts in with `:auto`. The collision case rf2-9qbn0g fixes."
+  {:initial :locked
+   :states  {:locked   {:on {:insert-coin :closed}}
+             :closed   {:on {:push :open}}
+             :open     {:on {:close :closed :trip :alarming}}
+             :alarming {:on {:reset :locked}}}})
+
+(deftest layout-key-folds-in-adaptive-mode
+  (let [parsed   (layout/project-definition door-cyclic-definition)]
+    (testing "sanity: :auto resolves to the SAME direction as a forced :tb here"
+      ;; this is what makes the resolved-direction-only key collide.
+      (is (= :tb (post-elk/resolve-direction :auto parsed)))
+      (is (= :tb (post-elk/resolve-direction :tb parsed))))
+
+    (let [;; what the chart computes on each path: the RESOLVED elk-direction
+          ;; is :tb for BOTH, but adaptive? differs (true on :auto, false on
+          ;; :tb). All other key components are held constant.
+          forced-tb-key (chart/compute-layout-key door-cyclic-definition :tb nil :comfortable 0 false)
+          auto-key      (chart/compute-layout-key door-cyclic-definition :tb nil :comfortable 0 true)]
+      (testing "the forced-:tb and resolved-to-:tb-:auto keys DIFFER (mode is in the key)"
+        (is (not= forced-tb-key auto-key)
+            "without adaptive? in the key these collide — the post-ELK pass
+             never applies on opt-in and stale-stays on opt-out"))
+
+      (testing "a :tb → :auto → :tb flip re-invalidates each way (the gate fires)"
+        ;; model the auto-fit/relayout gate: a fit (and a relayout) fires only
+        ;; when the new key differs from the last one. Walk the flip.
+        (let [fit-state (atom {:instance fake-instance :fit-key nil})
+              spy       (atom [])
+              maybe-fit! (fn [k]
+                           (let [{:keys [instance fit-key]} @fit-state]
+                             (when (and instance (not= k fit-key))
+                               (swap! fit-state assoc :fit-key k)
+                               (swap! spy conj k))))]
+          (maybe-fit! forced-tb-key)   ;; mount as :tb
+          (maybe-fit! auto-key)        ;; flip to :auto (transform must APPLY)
+          (maybe-fit! forced-tb-key)   ;; flip back to :tb (transform must REMOVE)
+          (is (= [forced-tb-key auto-key forced-tb-key] @spy)
+              "each direction-prop flip invalidates the layout, so the post-ELK
+               transform applies on opt-in and is removed on opt-out")))
+
+      (testing "an unrelated re-render with the SAME prop set does NOT re-run"
+        (let [fit-state (atom {:instance fake-instance :fit-key nil})
+              spy       (atom [])
+              maybe-fit! (fn [k]
+                           (let [{:keys [instance fit-key]} @fit-state]
+                             (when (and instance (not= k fit-key))
+                               (swap! fit-state assoc :fit-key k)
+                               (swap! spy conj k))))]
+          (maybe-fit! auto-key)
+          (maybe-fit! auto-key)
+          (maybe-fit! auto-key)
+          (is (= 1 (count @spy))
+              "same prop set → same key → no needless relayout (the flag does
+               not over-invalidate)"))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/post_elk_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/post_elk_cljs_test.cljc
@@ -139,6 +139,47 @@
      :edge-points {}
      :edge-labels {}}))
 
+(defn- row-positions
+  "rf2-hpe9ws — the `:lr` mirror of `col-positions`: lay every REAL state node
+  out in a single horizontal ROW (x = layer index × step) in parse order,
+  with each transition's synthetic event-node placed at the layer to the
+  RIGHT of its source. A back-edge's source is the rightmost state, so its
+  event-node sinks to the far RIGHT (greater x than both endpoints) — the
+  `:lr` analogue of the §4.3.1 sunk signature `col-positions` builds on y.
+
+  Returns `{:positions … :edge-points {} :edge-labels {}}`."
+  [parsed]
+  (let [step 100
+        states (->> (:nodes parsed)
+                    (remove #(or (:region? %) (:root-container? %)
+                                 (:machine-root? %) (:parallel-root? %))))
+        layer-of (into {} (map-indexed (fn [i n] [(:id n) i]) states))
+        state-pos (into {}
+                        (map (fn [n]
+                               [(:id n) {:x (* step (get layer-of (:id n) 0))
+                                         :y 200
+                                         :width 120 :height 50}]))
+                        states)
+        max-layer (reduce max 0 (vals layer-of))
+        event-pos (into {}
+                        (keep (fn [e]
+                                (when (:target e)
+                                  (let [sl (get layer-of (:source e))
+                                        tl (get layer-of (:target e))]
+                                    ;; forward edge: event between source +
+                                    ;; target; back-edge (target left of
+                                    ;; source): event sinks to the far right.
+                                    [(projection/event-node-id e)
+                                     {:x (if (< tl sl)
+                                           (* step (inc max-layer)) ;; sunk right
+                                           (* step (+ sl 0.5)))
+                                      :y 200
+                                      :width 96 :height 34}]))))
+                        (:edges parsed))]
+    {:positions   (merge state-pos event-pos)
+     :edge-points {}
+     :edge-labels {}}))
+
 ;; ====================================================================
 ;; Step 0 — the OPT-IN gate (rf2-lamdfl + rf2-gnrkke redo)
 ;; ====================================================================
@@ -301,6 +342,50 @@
         (is (apply = ys) "transposed children share a y (horizontal row)")
         (is (not (apply = xs)) "transposed children spread on x")))))
 
+(deftest transpose-preserves-positive-region-origin
+  ;; rf2-qp613a — for a root-container-wrapped chart the region containers are
+  ;; positioned relative to the root frame's padding/header, so every region
+  ;; origin is POSITIVE. The column origin must be computed from the ACTUAL
+  ;; region positions, NOT `(reduce min 0 …)` which clamped a positive origin
+  ;; to zero and slid the stacked column up/left into the reserved root chrome.
+  (let [parsed (layout/project-definition parallel-machine)
+        desc   (post-elk/region-descendant-ids parsed)
+        audio-rid (layout/region-node-id :audio)
+        video-rid (layout/region-node-id :video)
+        ;; the root frame reserves chrome: a left padding (60) + a top
+        ;; header band (120). BOTH region containers start at that positive
+        ;; origin (side-by-side: audio at root-x, video offset right).
+        root-x 60
+        root-y 120
+        child-col (fn [ids]
+                    (into {} (map-indexed
+                               (fn [i id] [id {:x 20 :y (+ 40 (* 80 i))
+                                               :width 120 :height 50}])
+                               ids)))
+        positions (merge
+                    {audio-rid {:x root-x        :y root-y :width 200 :height 400}
+                     video-rid {:x (+ root-x 400) :y root-y :width 200 :height 400}}
+                    (child-col (sort (get desc audio-rid)))
+                    (child-col (sort (get desc video-rid))))
+        stub {:positions positions :edge-points {} :edge-labels {}}
+        out  (post-elk/transpose-parallel-regions stub parsed)
+        np   (:positions out)]
+    (testing "the stacked column preserves the leftmost region's POSITIVE x origin"
+      (is (= root-x (:x (get np audio-rid)))
+          "audio container keeps the reserved root x (not clamped to 0)")
+      (is (= root-x (:x (get np video-rid)))
+          "video container left-aligns to the same positive column x"))
+
+    (testing "the stacked column preserves the topmost region's POSITIVE y origin"
+      (is (= root-y (:y (get np audio-rid)))
+          "the topmost (audio) band starts at the reserved root y (not 0)")
+      (is (>= (:y (get np video-rid)) root-y)
+          "the second band stacks below, still inside the reserved frame"))
+
+    (testing "the column does NOT slide into the reserved root chrome"
+      (is (>= (:x (get np audio-rid)) root-x))
+      (is (>= (:y (get np audio-rid)) root-y)))))
+
 (defn- x-overlap?
   "Do two boxes `{:x :width}` overlap along the x-axis (open intervals)? Pure."
   [a b]
@@ -442,6 +527,82 @@
     (testing "both segments are multi-point detour routes"
       (is (>= (count in-points) 3))
       (is (>= (count out-points) 3)))))
+
+(deftest back-edge-detour-lr-mirrors-the-elbow
+  ;; rf2-hpe9ws — on an :lr layout the back-edge detour must MIRROR the elbow:
+  ;; leave the source VERTICALLY to the side lane (above the row), then run
+  ;; horizontally to the lifted chip — NOT run along the flow row first (the
+  ;; :tb elbow shape, which would cross the forward edges).
+  (let [parsed (layout/project-definition door-cyclic-machine)
+        ;; an :lr row layout where the back-edge event-node sank to the far
+        ;; RIGHT of both endpoints (the :lr sunk signature).
+        stub   (row-positions parsed)
+        positions (:positions stub)
+        back-e (first (filter (fn [e]
+                                (and (= (:source e) (layout/node-id [:alarming]))
+                                     (= (:target e) (layout/node-id [:locked]))))
+                              (:edges parsed)))]
+    (testing "the :lr back-edge IS detected (its event-node sank to the right)"
+      (is (true? (post-elk/back-edge? back-e positions :lr))))
+
+    (let [sc (#'post-elk/node-center positions (:source back-e))
+          tc (#'post-elk/node-center positions (:target back-e))
+          {:keys [event-pos in-points out-points]}
+          (post-elk/back-edge-detour back-e positions :lr)
+          ev-w   projection/event-node-elk-width
+          ev-h   projection/event-node-elk-height
+          chip-cx (+ (:x event-pos) (/ ev-w 2))
+          chip-cy (+ (:y event-pos) (/ ev-h 2))
+          in-elbow  (second in-points)
+          out-elbow (second out-points)]
+      (testing "the chip is lifted ABOVE the flow row (bowed off the :lr spine on y)"
+        (is (< chip-cy (:y sc))
+            "rerouted chip y is above the source/target row")
+        (is (= (:y sc) (:y tc))
+            "sanity: the :lr endpoints share the flow row"))
+
+      (testing "the chip lands mid-WIDTH between the endpoints (the :lr flow axis)"
+        (is (<= (min (:x sc) (:x tc)) chip-cx (max (:x sc) (:x tc)))))
+
+      (testing "the __in elbow leaves the source VERTICALLY (keeps source x, drops to the lane y)"
+        ;; the bug used {:x detour-x :y (:y sc)} — running along the flow row
+        ;; first. The :lr mirror keeps the source's x and moves to the lane y.
+        (is (= (:x sc) (:x in-elbow))
+            "the in-elbow shares the source's x (leaves vertically, not along the row)")
+        (is (= chip-cy (:y in-elbow))
+            "the in-elbow drops to the side-lane y before running horizontally"))
+
+      (testing "the __out elbow re-enters the target VERTICALLY (keeps target x at the lane y)"
+        (is (= (:x tc) (:x out-elbow))
+            "the out-elbow shares the target's x (drops onto the target vertically)")
+        (is (= chip-cy (:y out-elbow))
+            "the out-elbow stays at the lane y until it is above the target")))))
+
+(deftest back-edge-detour-tb-keeps-its-elbow
+  ;; rf2-hpe9ws — guard the :tb branch is UNCHANGED by the mirror: the :tb
+  ;; elbow still leaves the source SIDEWAYS (to the side lane x) keeping the
+  ;; source's y, the historical shape.
+  (let [parsed (layout/project-definition door-cyclic-machine)
+        stub   (col-positions parsed)
+        positions (:positions stub)
+        back-e (first (filter (fn [e]
+                                (and (= (:source e) (layout/node-id [:alarming]))
+                                     (= (:target e) (layout/node-id [:locked]))))
+                              (:edges parsed)))
+        sc (#'post-elk/node-center positions (:source back-e))
+        tc (#'post-elk/node-center positions (:target back-e))
+        {:keys [in-points out-points]}
+        (post-elk/back-edge-detour back-e positions :tb)
+        in-elbow  (second in-points)
+        out-elbow (second out-points)]
+    (testing "the :tb __in elbow keeps the source's y and moves to the side lane x"
+      (is (= (:y sc) (:y in-elbow))
+          "the in-elbow shares the source's y (leaves sideways, the :tb shape)")
+      (is (not= (:x sc) (:x in-elbow))
+          "the in-elbow moves off the spine x to the side lane"))
+    (testing "the :tb __out elbow keeps the target's y and stays on the side lane x"
+      (is (= (:y tc) (:y out-elbow))
+          "the out-elbow shares the target's y (the :tb shape)"))))
 
 (deftest reroute-back-edges-rewrites-positions-and-routes
   (let [parsed (layout/project-definition door-cyclic-machine)


### PR DESCRIPTION
Three chart-layout correctness fixes in the post-ELK subsystem, reviewed out of PR #3458.

- **rf2-hpe9ws** — `back-edge-detour` now MIRRORS the elbow per flow axis. For `:tb` (vertical flow) the route leaves the source SIDEWAYS to the side lane then runs vertically to the lifted chip; for `:lr` (horizontal flow) it leaves the source VERTICALLY to the side lane then runs horizontally. The `:tb`-shaped elbow on an `:lr` layout ran along the flow row first, risking crossings with the forward edges.
- **rf2-qp613a** — `transpose-parallel-regions` computes the stacked column origin from the ACTUAL region positions (`reduce min` over region xs/ys) instead of `(reduce min 0 …)`, which clamped positive root-container-relative origins to zero and slid the transposed stack up/left into the reserved root chrome.
- **rf2-9qbn0g** — the MachineChart layout-key folds in the adaptive opt-in MODE flag. The pass is keyed by the RESOLVED `elk-direction` but the post-ELK transform is gated by the RAW `:auto` opt-in; when `:auto` resolves to the same direction as a forced/default `:tb` the keys collided, so a `:tb → :auto → :tb` flip did not invalidate the cache (transform never applied on opt-in, stale-stayed on opt-out). Extracted a pure `compute-layout-key` helper (renamed off `layout-key` to avoid shadowing the component's local `layout-key` atom — a shadowing TypeError the new test caught).

Each fix carries a regression test (probed: each fails when its fix is reverted, passes when restored). `spec/001-Topology-Parity.md` §4.3.1 updated to narrate the mirrored elbow + the layout-key mode flag.

## Quality gates

- **rf2-hpe9ws** — `back-edge-detour-lr-mirrors-the-elbow` + `back-edge-detour-tb-keeps-its-elbow` (post_elk JVM/node)
- **rf2-qp613a** — `transpose-preserves-positive-region-origin` (post_elk JVM/node)
- **rf2-9qbn0g** — `layout-key-folds-in-adaptive-mode` (auto-fit node test)
- `clojure -M:test` (machines-viz JVM): 478 tests, 1657 assertions, 0 failures, 0 errors
- `npm run test:cljs` (node): 6010 tests, 21319 assertions, 0 failures, 0 errors
- `npm run test:browser` (Playwright): 205 tests, 633 assertions, 0 failures, 0 errors