### PR TITLE
docs(EP): sync README index statuses + drop stale Requires prose + add status-sync check (rf2-8cw3m7 rf2-on7ulj)

### DIFF
--- a/docs/EP/EP-0002-frame-target-resolution.md
+++ b/docs/EP/EP-0002-frame-target-resolution.md
@@ -125,9 +125,8 @@ frame-aware features harden their public APIs.
   explicit frame target and should not be built against the ambient
   `:rf/default` fallback this EP removes.
 - **Composes with the app/runtime partition.** Both partitions in the
-  [App/Runtime Partition EP](EP-0001-frame-partitions.md) (listed under
-  `Requires`) are frame-owned; resolving the frame target precedes committing or
-  projecting either partition.
+  [App/Runtime Partition EP](EP-0001-frame-partitions.md) are frame-owned;
+  resolving the frame target precedes committing or projecting either partition.
 - **Subscription inputs inherit the resolved frame.** Parametric subscription
   input query vectors are frame-agnostic data resolved in the outer
   subscription's frame; see the [Parametric Subscription Inputs

--- a/docs/EP/EP-0004-subscription-inputs.md
+++ b/docs/EP/EP-0004-subscription-inputs.md
@@ -130,7 +130,7 @@ This is a Reactive Substrate proposal that other view-model EPs build on:
 - **Composes with explicit frame target resolution.** Input query vectors are
   frame-agnostic data; the runtime resolves them in the frame of the outer
   subscription. See the [Explicit Frame Target Resolution
-  EP](EP-0002-frame-target-resolution.md) (listed under `Requires`) and the
+  EP](EP-0002-frame-target-resolution.md) and the
   [§Frame resolution](#frame-resolution) section below.
 
 ## Specification

--- a/docs/EP/README.md
+++ b/docs/EP/README.md
@@ -8,7 +8,7 @@ EPs are *proposals*, not normative specification. The normative artefact remains
 
 | EP       | Title | Status | Summary |
 |----------|-------|--------|---------|
-| [EP-0001](EP-0001-frame-partitions.md) | Frame App/Runtime Partitions | proposal | A frame owns two durable partitions — user-owned **app-db** (`:db`) and framework-owned **runtime-db** (`:rf.db/runtime`) — committed coherently by one cascade, removing the footgun where a fresh `:db` return clobbers runtime state. |
+| [EP-0001](EP-0001-frame-partitions.md) | Frame App/Runtime Partitions | accepted | A frame owns two durable partitions — user-owned **app-db** (`:db`) and framework-owned **runtime-db** (`:rf.db/runtime`) — committed coherently by one cascade, removing the footgun where a fresh `:db` return clobbers runtime state. |
 | [EP-0002](EP-0002-frame-target-resolution.md) | Explicit Frame Target Resolution | proposal | Remove the ambient `:rf/default` fallback; frame-scoped operations resolve their target from explicit frame context, and missing context fails instead of touching the wrong frame. |
 | [EP-0003](EP-0003-resource-queries.md) | Resource Queries | proposal | An optional `day8/re-frame2-resources` artefact for declarative server-state — the re-frame2 answer to TanStack Query / RTK Query / SWR — with resource identity, caching, invalidation, lifecycle/GC, and route + SSR preload. |
 | [EP-0004](EP-0004-subscription-inputs.md) | Parametric Subscription Inputs | final | Restore v1's two-function `reg-sub` shape via input functions that return a vector of query vectors, keeping `:<-` as static-input sugar and dependencies pure, inspectable, JVM-runnable, and Xray-visible. |

--- a/scripts/check_ep_status_sync.py
+++ b/scripts/check_ep_status_sync.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Freshness check: docs/EP/README.md index statuses match each EP's Status: line.
+
+Each Enhancement Proposal under docs/EP/ carries a single source-of-truth
+`Status:` line in its front-matter (e.g. `Status: accepted`).  The
+docs/EP/README.md `## Index` table restates that status in its `Status`
+column.  The two drift apart by hand — rf2-8cw3m7 caught EP-0001 sitting at
+`Status: accepted` in the EP while the README index still listed it as
+`proposal`.
+
+This guard re-derives the README index status for every EP from the
+per-EP `Status:` line and fails when they disagree, when an EP file has no
+index row, or when an index row points at a missing EP file.  Wire it into a
+doc gate so the drift fails before it ships.
+
+What is checked:
+    * STATUS MISMATCH  — README index status column != the EP file's Status: line.
+    * MISSING ROW      — an EP-NNNN-*.md file has no matching README index row.
+    * ORPHAN ROW       — a README index row links a file that does not exist.
+
+Exit code:
+    0  index in sync with every EP's Status: line
+    1  at least one mismatch / missing row / orphan row
+    2  invocation / setup error
+
+The script is dependency-light — Python stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+# EP source files are named EP-NNNN-<slug>.md and carry one `Status: <word>`
+# line in their front-matter.  README.md is the index, not an EP.
+_EP_FILE_RE = re.compile(r"^EP-(\d{4})-.+\.md$")
+
+# The per-EP front-matter status line: `Status: accepted` (leading whitespace
+# tolerated, value is a single token up to end-of-line, trimmed).
+_STATUS_LINE_RE = re.compile(r"^\s*Status:\s*(\S.*?)\s*$", re.MULTILINE)
+
+# A README `## Index` table body row.  The table is:
+#   | EP | Title | Status | Summary |
+# with the first cell a markdown link `[EP-NNNN](EP-NNNN-<slug>.md)`.  We
+# capture the linked filename and the third (Status) column.  Cell contents
+# are trimmed by the caller.
+_INDEX_ROW_RE = re.compile(
+    r"^\|\s*\[EP-(\d{4})\]\(([^)]+)\)\s*\|"   # col 1: EP link -> (number, filename)
+    r"[^|]*\|"                                  # col 2: Title (ignored)
+    r"\s*([^|]*?)\s*\|"                        # col 3: Status (captured)
+    r".*\|\s*$"                                 # col 4+: Summary etc.
+)
+
+
+def _ep_dir(repo_root: Path) -> Path:
+    return repo_root / "docs" / "EP"
+
+
+def _read_ep_status(path: Path) -> str | None:
+    """Return the EP file's declared Status: token, or None if absent."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    m = _STATUS_LINE_RE.search(text)
+    return m.group(1).strip() if m else None
+
+
+def _read_index_rows(readme: Path) -> dict[str, tuple[str, str, int]]:
+    """Parse the README index table.
+
+    Returns a mapping: filename -> (ep_number, status, line_number).
+    Only rows inside fenced code blocks are skipped (defensive — the real
+    index table is not fenced).
+    """
+    rows: dict[str, tuple[str, str, int]] = {}
+    in_fence = False
+    for line_no, raw in enumerate(
+        readme.read_text(encoding="utf-8", errors="replace").splitlines(), start=1
+    ):
+        if raw.lstrip().startswith(("```", "~~~")):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = _INDEX_ROW_RE.match(raw)
+        if not m:
+            continue
+        ep_number, filename, status = m.group(1), m.group(2).strip(), m.group(3).strip()
+        rows[filename] = (ep_number, status, line_no)
+    return rows
+
+
+def check(repo_root: Path, verbose: bool = False) -> int:
+    """Validate README index statuses against per-EP Status: lines.
+
+    Returns the number of defects found (0 == in sync).
+    """
+    ep_dir = _ep_dir(repo_root)
+    readme = ep_dir / "README.md"
+    if not readme.is_file():
+        sys.stderr.write(f"error: no EP index at {readme}\n")
+        return 1
+
+    ep_files = sorted(
+        p for p in ep_dir.iterdir() if p.is_file() and _EP_FILE_RE.match(p.name)
+    )
+    index_rows = _read_index_rows(readme)
+
+    if verbose:
+        sys.stderr.write(
+            f"checking {len(ep_files)} EP file(s) against "
+            f"{len(index_rows)} index row(s) in {readme.relative_to(repo_root)}\n"
+        )
+
+    mismatches: list[str] = []
+    missing_rows: list[str] = []
+    orphan_rows: list[str] = []
+
+    indexed_filenames = set(index_rows)
+    ep_filenames = {p.name for p in ep_files}
+
+    for ep in ep_files:
+        declared = _read_ep_status(ep)
+        if declared is None:
+            mismatches.append(
+                f"  NO STATUS: {ep.relative_to(repo_root)} has no `Status:` line"
+            )
+            continue
+        row = index_rows.get(ep.name)
+        if row is None:
+            missing_rows.append(
+                f"  MISSING ROW: {ep.name} (Status: {declared}) has no README index row"
+            )
+            continue
+        _, index_status, line_no = row
+        if index_status != declared:
+            mismatches.append(
+                f"  STATUS MISMATCH: docs/EP/README.md:{line_no} lists "
+                f"{ep.name} as '{index_status}' but the EP's Status: line is "
+                f"'{declared}'"
+            )
+
+    for filename in sorted(indexed_filenames - ep_filenames):
+        _, _, line_no = index_rows[filename]
+        orphan_rows.append(
+            f"  ORPHAN ROW: docs/EP/README.md:{line_no} links {filename} "
+            "but no such EP file exists"
+        )
+
+    defects = mismatches + missing_rows + orphan_rows
+    if defects:
+        sys.stderr.write(
+            f"\n{len(defects)} EP status-sync defect(s) found:\n\n"
+        )
+        for line in defects:
+            sys.stderr.write(line + "\n")
+        sys.stderr.write(
+            "\nFix: update the docs/EP/README.md `## Index` Status column to "
+            "match each EP's `Status:` line (the per-EP line is the source of "
+            "truth), or add/remove the index row.\n"
+        )
+    elif verbose:
+        sys.stderr.write("EP index statuses are in sync.\n")
+
+    return len(defects)
+
+
+# --------------------------------------------------------------------------
+# Self-tests — fixture-driven, mirroring scripts/check_doc_slugs.py's style
+# but generated into a temp dir so the self-test leaves zero scratch files in
+# the repo tree (the fixtures are trivial enough to mint in-process; there is
+# nothing for a human to hand-edit, so committing static copies would just be
+# a second source of truth that can drift from the generator below).
+#
+# Each fixture is a self-contained mini-repo: a mkdocs.yml at the root (so the
+# repo-root guard accepts it) plus a docs/EP/ tree.
+# --------------------------------------------------------------------------
+
+
+def _write_fixture(root: Path, ep_files: dict[str, str], readme: str) -> None:
+    ep_dir = root / "docs" / "EP"
+    ep_dir.mkdir(parents=True, exist_ok=True)
+    (root / "mkdocs.yml").write_text("site_name: fixture\n", encoding="utf-8")
+    for name, body in ep_files.items():
+        (ep_dir / name).write_text(body, encoding="utf-8")
+    (ep_dir / "README.md").write_text(readme, encoding="utf-8")
+
+
+def _build_self_test_fixtures(base: Path) -> None:
+    """Generate the fixtures under base so the self-tests are hermetic."""
+
+    def ep(num: str, status: str) -> str:
+        return f"# EP-{num}: Fixture\n\nStatus: {status}\n\n## Abstract\n\nx\n"
+
+    def index(*rows: str) -> str:
+        head = (
+            "# EPs\n\n## Index\n\n"
+            "| EP | Title | Status | Summary |\n"
+            "|----|-------|--------|---------|\n"
+        )
+        return head + "".join(rows) + "\n"
+
+    def row(num: str, status: str, fname: str | None = None) -> str:
+        fname = fname or f"EP-{num}-fixture.md"
+        return f"| [EP-{num}]({fname}) | Fixture | {status} | s. |\n"
+
+    # in_sync: index matches each EP's Status: line.
+    _write_fixture(
+        base / "in_sync",
+        {"EP-0001-fixture.md": ep("0001", "accepted"),
+         "EP-0002-fixture.md": ep("0002", "proposal")},
+        index(row("0001", "accepted"), row("0002", "proposal")),
+    )
+
+    # status_mismatch: EP says accepted, index says proposal (the rf2-8cw3m7 shape).
+    _write_fixture(
+        base / "status_mismatch",
+        {"EP-0001-fixture.md": ep("0001", "accepted")},
+        index(row("0001", "proposal")),
+    )
+
+    # missing_row: EP file exists but has no index row.
+    _write_fixture(
+        base / "missing_row",
+        {"EP-0001-fixture.md": ep("0001", "accepted"),
+         "EP-0002-fixture.md": ep("0002", "final")},
+        index(row("0001", "accepted")),
+    )
+
+    # orphan_row: index links an EP file that does not exist.
+    _write_fixture(
+        base / "orphan_row",
+        {"EP-0001-fixture.md": ep("0001", "accepted")},
+        index(row("0001", "accepted"), row("0002", "final")),
+    )
+
+
+def _run_self_tests(verbose: bool = False) -> int:
+    cases: list[tuple[str, int]] = [
+        ("in_sync", 0),
+        ("status_mismatch", 1),
+        ("missing_row", 1),
+        ("orphan_row", 1),
+    ]
+    failures = 0
+    with tempfile.TemporaryDirectory(prefix="ep_status_sync_selftest_") as tmp:
+        base = Path(tmp)
+        _build_self_test_fixtures(base)
+        for fixture, expected in cases:
+            root = base / fixture
+            saved_stderr = sys.stderr
+            sys.stderr = _DevNull()
+            try:
+                got = check(root, verbose=False)
+            finally:
+                sys.stderr = saved_stderr
+            if got == expected:
+                if verbose:
+                    sys.stderr.write(f"self-test PASS: {fixture} (defects={got})\n")
+            else:
+                sys.stderr.write(
+                    f"self-test FAIL: {fixture} expected defects={expected}, "
+                    f"got {got}\n"
+                )
+                failures += 1
+    if failures:
+        sys.stderr.write(f"\n{failures} self-test failure(s).\n")
+        return 1
+    if verbose:
+        sys.stderr.write(f"all {len(cases)} self-tests passed.\n")
+    return 0
+
+
+class _DevNull:
+    def write(self, *_args, **_kwargs) -> int:
+        return 0
+
+    def flush(self) -> None:  # pragma: no cover
+        return None
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check docs/EP/README.md index statuses match each EP's "
+            "Status: line (rf2-8cw3m7)."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Path to the repo root.  Defaults to the script's grandparent.",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Print progress to stderr."
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run the bundled fixture-based self-tests and exit.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _run_self_tests(verbose=args.verbose)
+
+    if args.repo_root:
+        repo_root = Path(args.repo_root).resolve()
+    else:
+        repo_root = Path(__file__).resolve().parent.parent
+
+    if not (repo_root / "mkdocs.yml").is_file():
+        sys.stderr.write(
+            f"error: {repo_root} does not look like the re-frame2 repo root "
+            "(no mkdocs.yml).  Pass --repo-root explicitly.\n"
+        )
+        return 2
+
+    defects = check(repo_root, verbose=args.verbose)
+    return 0 if defects == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -16,9 +16,10 @@ set -euo pipefail
 #   scripts/test-fast-pr.sh --no-docs    skip markdown gates even if .md changed
 #
 # Markdown-gate components:
-#   1. python scripts/check_readme_links.py — README anchor + target validator
-#   2. python scripts/check_doc_slugs.py    — docs corpus anchor validator
-#   3. mkdocs build --strict (when mkdocs on PATH; soft-skip on Windows when not)
+#   1. python scripts/check_readme_links.py     — README anchor + target validator
+#   2. python scripts/check_doc_slugs.py        — docs corpus anchor validator
+#   3. python scripts/check_ep_status_sync.py   — docs/EP index status-sync guard
+#   4. mkdocs build --strict (when mkdocs on PATH; soft-skip on Windows when not)
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -154,6 +155,16 @@ if [ "$markdown_changed" = "true" ]; then
 
   run "docs corpus anchor validator" "python scripts/check_doc_slugs.py" \
     python "$repo_root/scripts/check_doc_slugs.py"
+
+  # EP index status-sync guard (rf2-8cw3m7): docs/EP/README.md restates each
+  # EP's Status: line in its index table; the two drift by hand (EP-0001 sat at
+  # `accepted` while the index still said `proposal`).  Self-test first (proves
+  # the guard fires on mismatch / missing-row / orphan-row), then the live scan.
+  run "EP status-sync self-test" "python scripts/check_ep_status_sync.py --self-test" \
+    python "$repo_root/scripts/check_ep_status_sync.py" --self-test
+
+  run "EP status-sync" "python scripts/check_ep_status_sync.py" \
+    python "$repo_root/scripts/check_ep_status_sync.py"
 
   run_soft "mkdocs --strict build" "mkdocs build --strict" mkdocs \
     bash -lc "cd '$repo_root' && mkdocs build --strict"


### PR DESCRIPTION
Two docs/EP consistency fixes in one PR.

## rf2-8cw3m7 — README index status out of sync
`docs/EP/README.md` listed EP-0001 as `proposal` while `EP-0001-frame-partitions.md` reads `Status: accepted`. Synced the index to `accepted`. Audited EP-0001..EP-0005: only EP-0001 was wrong (0002/0003 `proposal`, 0004/0005 `final` already matched).

Added a lightweight freshness guard `scripts/check_ep_status_sync.py` that re-derives each README index status from the per-EP `Status:` line and fails on STATUS MISMATCH / MISSING ROW / ORPHAN ROW. Wired into the existing markdown doc gate in `scripts/test-fast-pr.sh` (self-test + live scan), next to `check_doc_slugs.py`. Style mirrors `check_doc_slugs.py` (stdlib-only, `--self-test`, `--verbose`, repo-root guard); self-test fixtures are minted in a temp dir so the run leaves no scratch in the tree.

## rf2-on7ulj — stale "(listed under Requires)" prose
A minimal-front-matter pass removed the `Requires:` headers, but EP-0002 and EP-0004 still carried `(listed under Requires)` prose. Reworded both Relationships bullets so dependencies are expressed solely through the Relationships section, matching the README index and the other EPs. `git grep "Requires" docs/EP/` is now empty.

## Quality gates
- `python scripts/check_doc_slugs.py --verbose` — pass (405 files, no broken links)
- `python scripts/check_ep_status_sync.py --self-test --verbose` — pass (4/4: in_sync, status_mismatch, missing_row, orphan_row)
- `python scripts/check_ep_status_sync.py --verbose` — pass (5 EPs, in sync). Verified it FAILS on a deliberate EP-0001 mismatch (exit 1, correct diagnostic), then reverted.
- `python -m mkdocs build --strict` — pass (exit 0, no WARNINGs; spec/ + migration/ staged per CI)
- `git grep "(listed under \`Requires\`)" docs/EP/` and `git grep "Requires" docs/EP/` — both empty

**Workflow touched: NO.** The freshness check is wired into the existing `scripts/test-fast-pr.sh` markdown doc gate only — no `.github/workflows/*` edit.
