### PR TITLE
fix(xray): preserve query-vector shape for parametric cause-sub inputs (rf2-nlraqq)

### DIFF
--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -2523,6 +2523,18 @@ into a single canonical home at
   fallback and was mislabeled a Level-1 reader. (A runtime with no
   captured meta but a cascade-attributed `:inputs` slot still paints
   that upstream sub as a graceful fallback for replayed traces.)
+
+  **Row `:inputs` slot shape — uniform vector-of-query-vectors (rf2-nlraqq).**
+  The projection's `:inputs` row slot is ALWAYS a vector OF query-vectors,
+  regardless of which trace source fed it. `:rf.sub/inputs` is already that
+  shape (the literal `:<-` list / realized `(input-fn query-v)` edge set).
+  `:rf.sub/cause-sub`, by contrast, is a SINGLE query-vector — the one
+  upstream input whose value drove this recompute — so the projection
+  WRAPS it as `[cause]`. The view's inputs cell iterates the slot as a list
+  of query-vectors, rendering one `edn-inspector/mini` per ENTRY. Without
+  the wrap, a PARAMETERIZED cause-sub (e.g. `[:article/by-id :a1]`) would be
+  iterated element-wise — `:article/by-id` and `:a1` rendered as TWO
+  separate inputs instead of one query-vector.
 - **SUBSCRIPTIONS `caused by <event-id>` cell (rf2-1cc03).** Below the
   sub-name + `coord-chip`, the same sub-name cell carries a CONDITIONAL
   `caused by <event-id>` chrome — a `<div>` (testid

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1886,16 +1886,30 @@
 
       :sub-id      — the registered sub id (`:rf.sub/id` tag).
       :sub-vec     — the full sub query vector (`:rf.sub/query-v` tag).
-      :inputs      — the sub's input query-vectors. Prefers the
-                     upstream `:rf.sub/cause-sub` (the single input
-                     whose value drove this recompute) when present;
-                     otherwise the FULL realized input edge set the
-                     substrate stamps on `:rf.sub/inputs` (rf2-e3acps —
-                     the literal `:<-` list for a `:static` sub, the
-                     `(input-fn query-v)` result for a `:parametric`
-                     sub, both REALIZED for the concrete cache entry).
-                     Layer-1 subs read app-db directly and surface as
-                     `:db` (empty realized edge set).
+      :inputs      — a VECTOR OF INPUT QUERY-VECTORS — uniform shape
+                     regardless of source. Prefers the upstream
+                     `:rf.sub/cause-sub` (the single input query-vector
+                     whose value drove this recompute) when present,
+                     WRAPPED as `[cause]` so the row carries a one-entry
+                     vector-of-query-vectors (rf2-nlraqq); otherwise the
+                     FULL realized input edge set the substrate stamps on
+                     `:rf.sub/inputs` (rf2-e3acps — already a vector of
+                     query-vectors: the literal `:<-` list for a `:static`
+                     sub, the `(input-fn query-v)` result for a
+                     `:parametric` sub, both REALIZED for the concrete
+                     cache entry). Layer-1 subs read app-db directly and
+                     surface as `:db` (empty realized edge set).
+
+                     The WRAP (rf2-nlraqq) keeps the two sources
+                     SHAPE-COMPATIBLE: `:rf.sub/cause-sub` is a SINGLE
+                     query-vector (e.g. a parametric cause-sub
+                     `[:article/by-id :a1]`), whereas `:rf.sub/inputs`
+                     is a vector OF query-vectors. The view's inputs cell
+                     iterates `:inputs` as a list of query-vectors; an
+                     unwrapped parametric cause-sub would be mis-iterated
+                     element-wise (`:article/by-id` + `:a1` shown as TWO
+                     inputs). Wrapping the cause-sub as `[cause]` makes a
+                     parameterized cause-sub render as ONE query-vector.
       :changed?    — true iff the sub's output value differed from the
                      prior run (`:rf.sub/value-changed?` tag).
       :first-run?  — true on the run that CREATED this sub's cache slot
@@ -1946,9 +1960,20 @@
                   ;; with the OMIT-vs-nil semantics of the trace tag.
                   cause-event-id (common/tag-of ev :rf.sub/cause-event-id)]]
         (cond-> {:sub-id      sub-id
+                 ;; rf2-nlraqq — `:rf.sub/cause-sub` is a SINGLE query-
+                 ;; vector (the one upstream input whose value drove this
+                 ;; recompute); `:rf.sub/inputs` is already a vector OF
+                 ;; query-vectors. The `:inputs` slot must carry the
+                 ;; uniform vector-of-query-vectors shape so the view's
+                 ;; inputs cell iterates it correctly, so we WRAP the
+                 ;; cause-sub as `[cause]`. Without the wrap a parametric
+                 ;; cause-sub (`[:article/by-id :a1]`) is mis-iterated
+                 ;; element-wise (`:article/by-id` + `:a1` rendered as two
+                 ;; separate inputs).
                  :sub-vec     sub-vec
-                 :inputs      (or cause
-                                  (common/tag-of ev :rf.sub/inputs))
+                 :inputs      (if (some? cause)
+                                [cause]
+                                (common/tag-of ev :rf.sub/inputs))
                  :changed?    (boolean
                                 (or (common/tag-of ev :rf.sub/value-changed?)
                                     (common/tag-of ev :rf.sub/changed?)))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -4489,6 +4489,14 @@
               ;; a cascade-attributed `:inputs` slot still paints that
               ;; upstream sub (preserves the pre-fix shape for traces
               ;; replayed against a frame where the sub isn't registered).
+              ;; rf2-nlraqq — the row's `:inputs` slot carries a uniform
+              ;; VECTOR OF QUERY-VECTORS (the projection wraps a single
+              ;; `:rf.sub/cause-sub` as `[cause]`; `:rf.sub/inputs` is
+              ;; already a vector of query-vectors). Each ELEMENT is one
+              ;; whole input query-vector, painted as a single `mini`, so
+              ;; a parameterized cause-sub (`[[:article/by-id :a1]]`)
+              ;; renders as ONE input rather than splitting :article/by-id
+              ;; and :a1 into two.
               (vector? inputs)
               (into [:div {:style subs-inputs-list-style}]
                     (map (fn [i] [:div [ei/mini i 40]]) inputs))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -2160,6 +2160,76 @@
             "the sub-run row still projects (the absence is in the
              attribution slot only, not the whole row)")))))
 
+(deftest subscriptions-row-wraps-cause-sub-as-query-vector-test
+  (testing "rf2-nlraqq — `:rf.sub/cause-sub` is a SINGLE upstream query-
+            vector (the one input whose value drove this recompute); the
+            projection WRAPS it as `[cause]` so the row's `:inputs` slot
+            carries the uniform VECTOR-OF-QUERY-VECTORS shape. The view's
+            inputs cell iterates `:inputs` as a list of query-vectors, so
+            an UNwrapped parametric cause-sub (`[:article/by-id :a1]`)
+            would be mis-iterated element-wise (`:article/by-id` + `:a1`
+            shown as two separate inputs)."
+    (testing "PARAMETERIZED cause-sub — the changed input is itself
+              parameterized; wrapping keeps it ONE query-vector"
+      (let [row (-> (proj/subscriptions-step
+                      [(ev :rf.sub :rf.sub/run
+                           {:rf.sub/id             :article/headline
+                            :rf.sub/query-v        [:article/headline :a1]
+                            :rf.sub/value-changed? true
+                            :rf.sub/cascade?       true
+                            :rf.sub/cause-sub      [:article/by-id :a1]
+                            :rf.sub/prev-value     "old"
+                            :rf.sub/value          "new"})])
+                    :rows first)]
+        (is (= [[:article/by-id :a1]] (:inputs row))
+            ":inputs carries the cause-sub WRAPPED as a one-entry vector
+             of query-vectors — NOT the bare `[:article/by-id :a1]`,
+             which the view would iterate as two inputs")
+        (is (= 1 (count (:inputs row)))
+            "exactly ONE input query-vector — the parameterized cause-sub")
+        (is (true? (:cascade? row))
+            "the cascade flag still rides alongside the wrapped cause-sub")))
+    (testing "SIMPLE (un-parameterized) cause-sub — wrap still yields a
+              one-entry vector-of-query-vectors"
+      (let [row (-> (proj/subscriptions-step
+                      [(ev :rf.sub :rf.sub/run
+                           {:rf.sub/id             :counter/doubled
+                            :rf.sub/query-v        [:counter/doubled]
+                            :rf.sub/value-changed? true
+                            :rf.sub/cascade?       true
+                            :rf.sub/cause-sub      [:counter/value]
+                            :rf.sub/prev-value     2
+                            :rf.sub/value          4})])
+                    :rows first)]
+        (is (= [[:counter/value]] (:inputs row))
+            "even a simple single-keyword cause-sub wraps to `[[:counter/value]]`")))
+    (testing "no cause-sub — falls through to `:rf.sub/inputs` (already a
+              vector OF query-vectors), passed through UNwrapped"
+      (let [row (-> (proj/subscriptions-step
+                      [(ev :rf.sub :rf.sub/run
+                           {:rf.sub/id             :report/summary
+                            :rf.sub/query-v        [:report/summary]
+                            :rf.sub/value-changed? true
+                            :rf.sub/inputs         [[:sales] [:costs]]
+                            :rf.sub/prev-value     1
+                            :rf.sub/value          2})])
+                    :rows first)]
+        (is (= [[:sales] [:costs]] (:inputs row))
+            ":rf.sub/inputs is already a vector of query-vectors — NOT
+             re-wrapped (only the single-query-vector cause-sub is wrapped)")))
+    (testing "neither cause-sub nor inputs (Level-1 app-db reader) →
+              `:inputs` nil (the view's `app-db` fallback)"
+      (let [row (-> (proj/subscriptions-step
+                      [(ev :rf.sub :rf.sub/run
+                           {:rf.sub/id             :counter/value
+                            :rf.sub/query-v        [:counter/value]
+                            :rf.sub/value-changed? true
+                            :rf.sub/prev-value     0
+                            :rf.sub/value          1})])
+                    :rows first)]
+        (is (nil? (:inputs row))
+            "no cause-sub + no realized inputs → nil → view renders app-db")))))
+
 (deftest subscriptions-step-counts-changed-vs-unchanged-test
   (testing "rf2-kfh1v — step header carries `changed` + `unchanged`
             counts so the view can render `N recomputed (M changed,

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -2661,6 +2661,73 @@
             "a genuine Level-1 reader (empty `:input-signals`) still
              shows the `app-db` source label in its INPUTS cell")))))
 
+(defn- inputs-cell
+  "The INPUTS cell node for sub-row `i` under `tree`."
+  [tree i]
+  (-> tree
+      (th/find-by-testid (str "rf-xray-epoch-sub-row-" i))
+      (th/find-by-attr :data-rf-xray-resizable-col "inputs")))
+
+(deftest parametric-cause-sub-renders-as-one-query-vector-test
+  (testing "rf2-nlraqq — a PARAMETERIZED cause-sub (`[:article/by-id :a1]`)
+            renders as ONE input query-vector in the SUBSCRIPTIONS inputs
+            cell, NOT split into `:article/by-id` + `:a1` as two inputs.
+
+            The projection wraps `:rf.sub/cause-sub` as `[cause]` so the
+            row's `:inputs` slot is a one-entry vector OF query-vectors;
+            the view iterates the slot as a list of query-vectors, so each
+            element is one whole input. The sub-id here is UNREGISTERED, so
+            `sub-input-signals` returns nil and the cell falls through to
+            the row's realized `:inputs` slot — exactly the cascade-
+            attributed path the bug mis-iterated."
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      ;; UNREGISTERED sub-id → `sub-input-signals` resolves nil → the cell
+      ;; reads the row's realized `:inputs` slot (the cause-sub path).
+      (is (nil? (rf/handler-meta :sub :article/headline))
+          "precondition: the sub is NOT registered, so the inputs cell
+           cannot resolve a static `:input-signals` topology and must
+           fall through to the row's realized `:inputs` slot")
+      (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id  :article/headline
+                          :sub-vec [:article/headline :a1]
+                          ;; the projection's wrapped cause-sub shape:
+                          ;; ONE parameterized query-vector inside a vec.
+                          :inputs  [[:article/by-id :a1]]
+                          :changed? true :cascade? true :before "old" :after "new"}]
+                  :changed 1 :unchanged 0}
+            tree   (view/render-subscriptions-step step)
+            cell   (inputs-cell tree 0)
+            minis  (th/find-all-by-attr cell :data-rf-mini "1")
+            titles (set (map #(-> % th/attrs :title) minis))]
+        (is (some? cell) "the parameterized sub's inputs cell renders")
+        (is (= 1 (count minis))
+            "the parameterized cause-sub renders as exactly ONE input
+             query-vector — pre-fix the unwrapped `[:article/by-id :a1]`
+             was iterated element-wise into TWO mini tokens")
+        (is (contains? titles "[:article/by-id :a1]")
+            "the single input is the WHOLE query-vector `[:article/by-id :a1]`")
+        (is (not (string/includes? (th/text-content cell) "app-db"))
+            "not the Level-1 `app-db` fallback — a cascade-attributed input"))))
+  (testing "rf2-nlraqq — a multi-edge `:rf.sub/inputs` set (NOT cause-sub;
+            already a vector OF query-vectors) still renders one mini per
+            edge — the wrap is cause-sub-only and does not double-wrap"
+    (epoch-orchestrator/install!)
+    (frame/reg-frame :rf/xray {})
+    (rf/with-frame :rf/xray
+      (let [step {:step :subscriptions :badge :SUBSCRIPTIONS :step-number 5
+                  :rows [{:sub-id  :report/summary
+                          :sub-vec [:report/summary]
+                          :inputs  [[:sales] [:costs]]
+                          :changed? true :before 1 :after 2}]
+                  :changed 1 :unchanged 0}
+            tree  (view/render-subscriptions-step step)
+            cell  (inputs-cell tree 0)
+            minis (th/find-all-by-attr cell :data-rf-mini "1")]
+        (is (= 2 (count minis))
+            "two realized input edges → two input query-vectors rendered")))))
+
 (deftest first-run-container-sub-renders-added-chrome-test
   (testing "rf2-kp7bw — a first-run subscription whose value is a
             CONTAINER (map / vector / set) renders the whole subtree


### PR DESCRIPTION
## Quality gates

- `clojure -M:test` (tools/xray): **1109 tests, 4595 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **6012 tests, 21331 assertions, 0 failures, 0 errors**
- `npm run test:browser`: **205 tests, 633 assertions, 0 failures, 0 errors**
- Probe-then-revert: reverting the projection wrap fails the new projection test (`count (:inputs row)` = 2 instead of 1; `[:counter/value]` instead of `[[:counter/value]]`) — confirms the regression hits the actual failing path.

## The bug

The epoch projection stored `:rf.sub/cause-sub` directly into the row `:inputs` slot. The subscriptions table's inputs cell treats ANY vector `:inputs` as a vector OF input query-vectors (one `edn-inspector/mini` per entry). But `:rf.sub/cause-sub` is a SINGLE query-vector — the one upstream input whose value drove this recompute (`re-frame.subs.memo/changed-cause-sub` returns the first changed `:<-` query-vector). So a parameterized cause-sub `[:article/by-id :a1]` was iterated element-wise and rendered as TWO separate inputs (`:article/by-id` + `:a1`) instead of one query-vector.

## Wrap vs split decision: WRAP

The projection now wraps the cause-sub as `[cause]` so the `:inputs` row slot is ALWAYS a uniform **vector-of-query-vectors**, shape-compatible with `:rf.sub/inputs` (which the substrate already stamps as a vector of query-vectors — `(vec input-signals)`). The view's existing inputs-cell iteration then renders each entry as one whole query-vector, correct for both trace sources.

**Rationale (wrap over split):** wrap keeps a single uniform `:inputs` contract — "a vector of input query-vectors" — regardless of which trace tag fed it, and requires no new view branch. The split alternative (a separate `:cause-sub` row slot distinct from realized `:inputs`) would force the view to grow a second rendering branch and re-derive which slot to display, for the same visual outcome. Wrap is the cleaner model against the projection/view contract.

## Files touched

- `tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc` — wrap `:rf.sub/cause-sub` as `[cause]` in the `:inputs` slot; docstring updated.
- `tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs` — inputs-cell comment updated to document the uniform vector-of-query-vectors slot shape.
- `tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc` — new `subscriptions-row-wraps-cause-sub-as-query-vector-test` (parameterized cause-sub, simple cause-sub, `:rf.sub/inputs` pass-through, Level-1 nil).
- `tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs` — new `parametric-cause-sub-renders-as-one-query-vector-test` (asserts one `mini` per input query-vector for a parameterized cause-sub; multi-edge `:rf.sub/inputs` still renders one mini per edge).
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` — documents the row `:inputs` slot shape (uniform vector-of-query-vectors, cause-sub wrapped).
