### PR TITLE
docs(EP): define proposal→accepted→final status vocabulary (terse) (rf2-ujteqo)

### DIFF
--- a/docs/EP/README.md
+++ b/docs/EP/README.md
@@ -4,6 +4,8 @@ Design proposals for re-frame2.
 
 EPs are *proposals*, not normative specification. The normative artefact remains [`spec/`](https://github.com/day8/re-frame2/tree/main/spec). An EP graduates into `spec/` + implementation beads once accepted. Each EP carries a stable PEP-style number (`EP-0001`, …), a `Status:` line, and standard sections (Abstract, Motivation, Relationships, Specification, …); dependencies live in each EP's `Relationships` section.
 
+Status lifecycle: **proposal** (under discussion) → **accepted** (approved, graduating into `spec/` + beads) → **final** (graduated; the spec is now authoritative).
+
 ## Index
 
 | EP       | Title | Status | Summary |


### PR DESCRIPTION
Adds a single terse status-lifecycle note to `docs/EP/README.md`, completing the intent of rf2-itujk9 after the terse-README pass (rf2-ivxwlg) removed the Conventions section that previously defined the status vocabulary. No verbose section reintroduced — one inline sentence.

Closes rf2-ujteqo.

## Quality gates

- `python scripts/check_doc_slugs.py` — pass (exit 0)
- `python scripts/check_ep_status_sync.py` — pass (exit 0)
- `mkdocs build --strict` — pass (exit 0)