### PR TITLE
fix: dispatch-later uses :event not :dispatch — Pattern-WebSocket spec + xray gallery (rf2-c3mpt2 rf2-j4ws6v)

### DIFF
--- a/spec/Pattern-WebSocket.md
+++ b/spec/Pattern-WebSocket.md
@@ -157,11 +157,11 @@ The connection machine composes the locked substrate:
          :fx   [[:dispatch [(:socket-id data)
                             [:send (assoc body :request-id request-id)]]]
                 [:dispatch-later
-                 {:ms       timeout-ms
-                  :dispatch [:ws/connection
-                             [:ws/request-timeout
-                              {:request-id       request-id
-                               :source-socket-id (:socket-id data)}]]}]]})
+                 {:ms    timeout-ms
+                  :event [:ws/connection
+                          [:ws/request-timeout
+                           {:request-id       request-id
+                            :source-socket-id (:socket-id data)}]]}]]})
 
       :clear-request
       (fn [data [_ {:keys [request-id]}]]

--- a/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs
@@ -772,13 +772,13 @@
                       :dispatch-n  [[:audit/log :checkout/begin]
                                     [:metrics/emit :checkout/begin]]
                       :dispatch-later {:ms 250
-                                       :dispatch [:checkout/retry-prompt]}})
+                                       :event [:checkout/retry-prompt]}})
            (fx-handled-ev :db nil 0.2)
            (fx-handled-ev :dispatch [:cart/add :apple] 0.1)
            (fx-handled-ev :dispatch-n [[:audit/log :checkout/begin]
                                        [:metrics/emit :checkout/begin]] 0.2)
            (fx-handled-ev :dispatch-later
-                          {:ms 250 :dispatch [:checkout/retry-prompt]} 0.1)
+                          {:ms 250 :event [:checkout/retry-prompt]} 0.1)
            (run-end-ev 1.4)]}))])
 
 ;; ---- VARIANT 6: long-step cascade ---------------------------------------
@@ -1040,9 +1040,9 @@
           :trace-events
           [(dispatched-ev [:checkout/begin] :ui)
            (do-fx-ev {:dispatch-later
-                      {:ms 500 :dispatch [:checkout/retry-prompt]}})
+                      {:ms 500 :event [:checkout/retry-prompt]}})
            (fx-handled-ev :dispatch-later
-                          {:ms 500 :dispatch [:checkout/retry-prompt]}
+                          {:ms 500 :event [:checkout/retry-prompt]}
                           0.1)
            (run-end-ev 0.4)]}))
    ;; CHILD cascade — fired 500ms later by the timer


### PR DESCRIPTION
The v2 reserved `:dispatch-later` fx reads `{:ms … :event …}` — the runtime destructures `{:keys [ms event]}` in `re-frame.fx` (`implementation/core/src/re_frame/fx.cljc`, line 282). Two surfaces still carried the stale v1 `:dispatch` key inside the `:dispatch-later` payload map.

- **rf2-c3mpt2 (spec)** — `spec/Pattern-WebSocket.md` request-timeout example used `{:ms … :dispatch …}` in its `[:dispatch-later …]` entry (the remaining one PR #3469 missed). Now `:event`, matching the runtime and `examples/reagent/websocket/connection.cljs`. The `docs/spec` mirror is a gitignored generated copy (regenerated by the docs build) — not separately edited.
- **rf2-j4ws6v (xray)** — `tools/xray/testbeds/panel_gallery/fixtures_epoch.cljs` epoch-panel gallery fixtures (`child-dispatches-history` + `fx-dispatch-later-source-history`) seeded fake `:rf.fx/do-fx` / `:rf.fx/handled` payloads with `{:ms … :dispatch …}`. Now `:event` so the Xray demos / visual checks reflect real runtime payloads.

Pure key reconciliation; no behaviour change. The standalone `:dispatch` and `:dispatch-n` reserved-fx entries (correct v2 keys) are untouched.

## Quality gates

- `python scripts/check_doc_slugs.py` → exit 0
- `clojure -M:test` (from `tools/xray/`) → 1109 tests, 4595 assertions, 0 failures, 0 errors (gallery fixtures load)
- `npm run test:cljs` (from `implementation/`) → 6012 tests, 21331 assertions, 0 failures, 0 errors
- `git grep` confirms no stale `:dispatch` keys remain in any `:dispatch-later` context across `spec/Pattern-WebSocket.md` + `tools/xray/`