### PR TITLE
docs(xray): reconcile click-to-source to editor-hint + Settings/configure! + relative project-root (rf2-0uewxk)

### DIFF
--- a/docs/xray/01-installation.md
+++ b/docs/xray/01-installation.md
@@ -117,7 +117,7 @@ If Xray does not appear, check:
 
 ## Clickable Jump-To-Source
 
-Every panel that surfaces a source-coord wraps it in an `open` chip. Clicking jumps to that line in your editor — but only once Xray knows which editor to open. On a plain host app wiring just the preload, the chip uses the `:vscode` default scheme; if that is not your editor, the OS has no handler for it and the click silently no-ops.
+Every panel that surfaces a source-coord wraps it in an `open` chip. Clicking jumps to that line in your editor — but only once Xray knows which editor to open. On a plain host app wiring just the preload, no editor is configured: the chip targets the `:vscode` default scheme, but if that is not your editor the OS has no handler for it and the click would silently go nowhere. So rather than navigate into the void, an unconfigured click surfaces a **"No editor configured" hint** — a small bottom-corner toast with an **Open Settings** button that lands you on the editor picker. Once an editor is configured (in Settings or at boot), the click resolves and navigates straight to source; the hint never fires.
 
 Set your editor either in **Xray Settings** (the "Click-to-source links open in" picker on the General tab — persisted per-dev in localStorage, so each teammate can pick their own), or once at boot in code:
 

--- a/docs/xray/05-click-to-source.md
+++ b/docs/xray/05-click-to-source.md
@@ -37,18 +37,38 @@ That is not for production. It is a dev-only bridge from pixels back to the view
 
 ## Xray Back To Editor
 
-Xray's source chips use the configured editor protocol. The supported editor preferences live under the Xray config surface:
+Xray's source chips wrap each coordinate in an `open` chip. Clicking resolves the coordinate to your editor's URI scheme — `vscode://file/...`, `cursor://...`, `idea://open?...` — and hands it to the OS so your editor jumps to the line.
+
+### Tell Xray Which Editor
+
+The catch: Xray cannot guess your editor. A host that wires only the preload never sets one, so the chip falls back to the framework default `:vscode` scheme. If VS Code is not your editor, the OS has no handler for that scheme and the navigation goes nowhere — and the browser cannot observe an OS-level handler miss, so the click would be a silent dead end.
+
+Rather than navigate into the void, an unconfigured click surfaces a **"No editor configured" hint**: a small, non-intrusive toast in the bottom corner of the panel with an **Open Settings** button that lands you on the editor picker. Once an editor is configured, the hint never fires and the click navigates straight to source.
+
+There are two ways to configure the editor:
+
+- **Xray Settings (per-dev).** The General tab's "Click-to-source links open in" picker. The choice persists per-developer in `localStorage`, so each teammate picks their own editor on their own machine — and the Open-Settings button on the hint toast lands you right here.
+- **`configure!` at boot (project default).** Set it once in your app's boot code:
+
+  ```clojure
+  (require '[day8.re-frame2-xray.config :as xray-config])
+  (xray-config/configure! {:rf.xray/editor :cursor})
+  ;; :vscode (default) | :cursor | :windsurf | :zed | :idea | {:custom "<uri-template>"}
+  ```
+
+  The `{:custom "<uri-template>"}` form supports a team's own editor bridge via `{path}` / `{file}` / `{line}` / `{column}` placeholders.
+
+The two compose: **the Settings picker overrides the boot-time `configure!` value, per machine.** So a mixed-editor team sets a sensible project default in code and individuals override locally without touching the host's boot config — the override is purely client-side and never mutates the shared default.
+
+### Relative Coordinates And `:rf.xray/project-root`
+
+`:rf.xray/project-root` is **only** for classpath-*relative* source coordinates. Editor URI handlers resolve paths against the filesystem, so a relative path fails with "Path does not exist" — when your stamped coords are relative, set the on-disk root so Xray can prefix it into an absolute URI:
 
 ```clojure
-(require '[day8.re-frame2-xray.core :as xray])
-
-(xray/set-editor! :vscode)
-;; or :cursor, :windsurf, :zed, :idea
+(xray-config/configure! {:rf.xray/project-root "/abs/path/to/project/src"})
 ```
 
-Custom URI templates are also supported through the lower-level config namespace when a team has its own editor bridge.
-
-For local testbeds and docs screenshots, the project root is seeded so Xray can turn a classpath-relative file into an absolute editor URI. In your app, configure that root when your build environment does not provide one.
+The normal `reg-*` / `reg-machine` registration path stamps **absolute** coordinates, which Xray ships verbatim — in that (common) case leave `:rf.xray/project-root` unset. Do not hardcode a machine-specific path "to make Open work"; if absolute coords already open, you do not need it.
 
 ## A Practical Loop
 

--- a/skills/re-frame-migration/references/xray-replaces-10x.md
+++ b/skills/re-frame-migration/references/xray-replaces-10x.md
@@ -85,7 +85,7 @@ The preload registers Xray's listeners under `register-listener!` and `register-
 
 ### 4. Set your editor for clickable jump-to-source
 
-For Xray's `open` chips to jump to source on click, Xray must know which editor to open — the bare preload defaults to the `:vscode` scheme, so if that isn't your editor the click silently no-ops. Set it in **Xray Settings** ("Click-to-source links open in" on the General tab — persisted per-dev) or once at boot:
+For Xray's `open` chips to jump to source on click, Xray must know which editor to open — the bare preload defaults to the `:vscode` scheme. Until you tell Xray your editor, a click does not navigate; instead it surfaces a **"No editor configured" hint** (a bottom-corner toast with an **Open Settings** button) so the dead click is never silent. Set your editor in **Xray Settings** ("Click-to-source links open in" on the General tab — persisted per-dev) or once at boot, and clicks navigate straight to source:
 
 ```clojure
 (require '[day8.re-frame2-xray.config :as xray-config])


### PR DESCRIPTION
Reconciles click-to-source docs to the current contract after #3486 landed the deferred unconfigured-editor hint (rf2-4s08ov). The docs still described the unconfigured click as silently no-oping; they now describe the editor-hint toast, the Settings/`configure!` setup path, and the relative-only `:rf.xray/project-root` guidance.

## What changed

- `docs/xray/01-installation.md` — §Clickable Jump-To-Source: an unconfigured click now surfaces the "No editor configured" hint toast (Open Settings button) instead of a silent no-op; configured hosts navigate.
- `docs/xray/05-click-to-source.md` — §Xray Back To Editor rewritten: editor-hint behaviour; the two setup paths (Settings picker per-dev / `configure!` boot default) and that **Settings overrides the boot `configure!` value**; new §Relative Coordinates clarifying `:rf.xray/project-root` is ONLY for classpath-relative coords (absolute coords from `reg-*`/`reg-machine` ship verbatim — leave it unset).
- `skills/re-frame-migration/references/xray-replaces-10x.md` — §4 editor setup: same silent-no-op → editor-hint reconciliation.

## Behaviour verification

Verified against #3486 source (READ ONLY): `tools/xray/src/day8/re_frame2_xray/open_in_editor.cljs` (unconfigured → `:rf.xray/editor-hint-show`; configured → navigate), `settings/editor_hint.cljs` (bottom-corner toast + Open Settings), `config.cljc` (`editor-configured?` = host `set-editor!`/`configure!` OR valid operator override; three-tier `get-editor`: override > host > `:vscode`; operator override is client-side and does not mutate the host atom; `project-root` is nil-default and only prefixes relative coords).

## Quality gates

- `python scripts/check_doc_slugs.py` — pass (exit 0)
- `python -m mkdocs build --strict` — pass (exit 0, built in 8.49s, no warnings on changed files)
- `python scripts/check_skill_migration_cites.py` — pass (exit 0)
- `python scripts/check_skill_redirect_anchors.py` — pass (exit 0)
- `git grep -nE "silently no-op|silent no-op"` in `docs/xray/` + migration skill — no remaining click-to-source claims (only unrelated `init!`/dispatch/JVM-fx no-op mentions)

Closes rf2-0uewxk.