### PR TITLE
fix(machines-viz): declared :data-schema suppresses inference for all map shapes (rf2-2btfzr)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/context_shape.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/context_shape.cljc
@@ -134,52 +134,99 @@
 
     :else "value"))
 
+;; Malli wrapper heads whose FIRST contained schema carries the real shape —
+;; `[:and [:map …] [:fn …]]`, `[:or …]`, `[:schema [:map …]]`, etc. Walking
+;; these as plain data lets a declared `:map` nested under a refinement
+;; wrapper still be recognised as DECLARED (rf2-2btfzr) rather than slipping
+;; through to one-sample inference. Heads are matched by the schema's vector
+;; HEAD keyword; everything that is not one of these stops the unwrap.
+(def ^:private map-unwrap-heads #{:and :or :schema :ref})
+
+(defn map-schema
+  "rf2-2btfzr — unwrap common Malli wrappers to find the contained `:map`
+  schema and return it (the `[:map …]` vector), else nil. A bare `[:map …]`
+  is returned as-is; a wrapper such as `[:and [:map …] [:fn …]]`,
+  `[:or [:map …] …]`, or `[:schema [:map …]]` is descended (FIRST informative
+  child, skipping a props map) until a `:map` head is reached or the form is
+  not a recognised wrapper. Pure; walks plain data — no Malli runtime.
+
+  This is what makes a `:data-schema` wrapped in a refinement still count as
+  DECLARED for the declared-over-inferred contract: a contained `:map`
+  declares the per-key context shape regardless of the outer wrapper."
+  [schema]
+  (loop [s schema
+         ;; Guard against a pathological self-referential `:ref`/`:schema`
+         ;; cycle in malformed plain data — bound the descent.
+         budget 32]
+    (when (and (vector? s) (pos? budget))
+      (let [head (first s)]
+        (cond
+          (= :map head) s
+          (contains? map-unwrap-heads head)
+          (recur (some #(when-not (map? %) %) (rest s)) (dec budget))
+          :else nil)))))
+
 (defn declared-shape
-  "rf2-3q4k5b — derive `{key → type-caption}` from a machine's declared
-  `:data-schema` (a Malli `[:map …]`). Returns nil when the schema is absent
-  or is not a `:map` form (only a `:map` declares per-KEY context shape; a
-  non-map schema validates `:data` as a whole and carries no key→type table
-  to render). Pure; walks the schema as plain data — no Malli runtime.
+  "rf2-3q4k5b / rf2-2btfzr — derive `{key → type-caption}` from a machine's
+  declared `:data-schema` when it is (or WRAPS) a Malli `:map`. Returns the
+  shape map — POSSIBLY EMPTY for a declared-but-empty `[:map]` /
+  `[:map {:closed true}]` — when a contained `:map` is found, else nil when
+  the schema is absent or declares no per-KEY context shape (a non-map schema
+  validates `:data` as a whole and carries no key→type table to render).
+
+  A non-nil (even empty) return is AUTHORITATIVE: `static-context-shape` must
+  NOT fall back to one-sample inference once a `:map` schema is declared —
+  declared-but-empty ≠ undeclared (the EP-0005 declared-over-inferred
+  contract). Pure; walks the schema as plain data — no Malli runtime.
 
   Map-entry forms handled (Malli `:map`):
     `[k child]`            → key `k`, type from `child`
     `[k props child]`      → key `k`, props (e.g. `{:optional true}`) skipped
-    `[k {:optional true} child]` → optional key rendered the same shape"
+    `[k {:optional true} child]` → optional key rendered the same shape
+
+  Wrappers handled: a `:map` nested under `:and` / `:or` / `:schema` / `:ref`
+  is unwrapped (see `map-schema`) so a declared-but-wrapped map still wins."
   [data-schema]
-  (when (and (vector? data-schema)
-             (= :map (first data-schema)))
-    (let [entries (->> (rest data-schema)
+  (when-let [ms (map-schema data-schema)]
+    (let [entries (->> (rest ms)
                        ;; A `:map` may carry an opening props map
                        ;; (`[:map {:closed true} [k …] …]`); skip it. Every
                        ;; real entry is itself a vector `[k …]`.
                        (filter vector?))]
-      (when (seq entries)
-        (into {}
-              (map (fn [entry]
-                     (let [k        (first entry)
-                           ;; Drop an optional per-entry props map; the last
-                           ;; remaining child is the value schema.
-                           children (->> (rest entry) (remove map?))
-                           child    (last children)]
-                       [k (schema-type-caption child)])))
-              entries)))))
+      ;; ALWAYS return a map (possibly empty) once a `:map` is declared, so
+      ;; the empty `[:map]` / `[:map {:closed true}]` case is authoritative
+      ;; rather than dropping to inference (rf2-2btfzr).
+      (into {}
+            (map (fn [entry]
+                   (let [k        (first entry)
+                         ;; Drop an optional per-entry props map; the last
+                         ;; remaining child is the value schema.
+                         children (->> (rest entry) (remove map?))
+                         child    (last children)]
+                     [k (schema-type-caption child)])))
+            entries))))
 
 ;; ---- declared-over-inferred top-level ----------------------------------
 
 (defn static-context-shape
-  "rf2-3q4k5b — the declared-over-inferred static Context shape for a machine
-  DEFINITION. Returns `{:shape {key → type-caption} :inferred? bool}`:
+  "rf2-3q4k5b / rf2-2btfzr — the declared-over-inferred static Context shape
+  for a machine DEFINITION. Returns `{:shape {key → type-caption} :inferred?
+  bool}`:
 
-    - When the definition declares a `:data-schema` (a Malli `[:map …]`), the
-      shape is AUTHORITATIVE off the schema and `:inferred?` is FALSE (the
-      chart drops the `inferred from :data` badge — EP-0005 option-A).
+    - When the definition declares a `:data-schema` that is (or WRAPS) a
+      Malli `:map` — INCLUDING an empty `[:map]` / `[:map {:closed true}]` or
+      a wrapper like `[:and [:map …] [:fn …]]` — the shape is AUTHORITATIVE
+      off the schema and `:inferred?` is FALSE (the chart drops the `inferred
+      from :data` badge — EP-0005 option-A). A declared-but-empty map yields
+      `{:shape {} :inferred? false}`; the host hides the band on an empty
+      shape, but inference is NOT triggered (declared-but-empty ≠ undeclared).
     - Otherwise the shape is INFERRED from one sample of the initial `:data`
       and `:inferred?` is TRUE (rf2-5tz9p's behaviour, unchanged).
 
-  Returns nil when neither a `:map` `:data-schema` nor a map `:data` is
-  present (the panel stays hidden). Pure — testable without a browser."
+  Returns nil when neither a `:map`-shaped `:data-schema` nor a map `:data`
+  is present (the panel stays hidden). Pure — testable without a browser."
   [definition]
-  (or (when-let [shape (declared-shape (:data-schema definition))]
-        {:shape shape :inferred? false})
-      (when-let [shape (infer-shape definition)]
-        {:shape shape :inferred? true})))
+  (if-let [shape (declared-shape (:data-schema definition))]
+    {:shape shape :inferred? false}
+    (when-let [shape (infer-shape definition)]
+      {:shape shape :inferred? true})))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/context_shape_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/context_shape_cljs_test.cljc
@@ -109,15 +109,73 @@
           "quoted predicate symbols map onto number / string captions"))))
 
 (deftest non-map-schema-falls-back-to-inferred
-  (testing "rf2-3q4k5b — a non-`:map` `:data-schema` (validates :data as a
-            whole, no per-key table) yields no declared shape; the derivation
-            falls back to the inferred `:data` sample."
+  (testing "rf2-3q4k5b — a `:data-schema` that is NOT (and does not WRAP) a
+            `:map` — it validates :data as a whole, no per-key table — yields
+            no declared shape; the derivation falls back to the inferred
+            `:data` sample."
     (let [result (cs/static-context-shape
                    {:initial     :s
                     :data        {:n 1}
-                    :data-schema [:and [:map [:n :int]] [:fn 'some?]]
+                    ;; A scalar/refinement schema with no contained :map.
+                    :data-schema [:and :int [:fn 'pos?]]
                     :states      {:s {}}})]
-      ;; The top-level head is :and, not :map → no per-key declared table.
       (is (= {:n "number"} (:shape result)))
       (is (true? (:inferred? result))
           "non-:map schema → fall back to inferred from the :data sample"))))
+
+;; ---- declared-over-inferred: empty + wrapped map schemas (rf2-2btfzr) ---
+
+(deftest empty-map-schema-is-declared-not-inferred
+  (testing "rf2-2btfzr — a declared-but-EMPTY `[:map]` is AUTHORITATIVE: an
+            empty shape with `:inferred? false`. Declared-but-empty ≠
+            undeclared — the misleading one-sample `:data` keys MUST NOT be
+            inferred (EP-0005 declared-over-inferred contract)."
+    (let [result (cs/static-context-shape
+                   {:initial     :s
+                    ;; A partial/misleading sample that, pre-fix, leaked
+                    ;; through as inferred context.
+                    :data        {:secret 1 :nonce "x"}
+                    :data-schema [:map]
+                    :states      {:s {}}})]
+      (is (= {} (:shape result))
+          "empty `[:map]` → empty authoritative shape, not the :data sample")
+      (is (false? (:inferred? result))
+          "declared (even empty) → inferred? false")
+      (is (not (contains? (:shape result) :secret))
+          "undeclared sample key :secret is NOT rendered as inferred context")
+      (is (not (contains? (:shape result) :nonce))
+          "undeclared sample key :nonce is NOT rendered as inferred context"))))
+
+(deftest empty-closed-map-schema-is-declared-not-inferred
+  (testing "rf2-2btfzr — a declared-but-empty `[:map {:closed true}]` (an
+            opening props map, no entries) is likewise AUTHORITATIVE-empty,
+            not inferred."
+    (let [result (cs/static-context-shape
+                   {:initial     :s
+                    :data        {:secret 1}
+                    :data-schema [:map {:closed true}]
+                    :states      {:s {}}})]
+      (is (= {} (:shape result))
+          "empty closed `[:map …]` → empty authoritative shape")
+      (is (false? (:inferred? result)))
+      (is (not (contains? (:shape result) :secret))
+          "undeclared sample key is NOT rendered as inferred context"))))
+
+(deftest wrapped-map-schema-is-declared-not-inferred
+  (testing "rf2-2btfzr — a `:map` WRAPPED in a Malli refinement (`[:and [:map
+            …] [:fn …]]`) is unwrapped: the contained `:map`'s declared keys
+            win, and undeclared sample keys are NOT inferred."
+    (let [result (cs/static-context-shape
+                   {:initial     :s
+                    ;; The sample carries an EXTRA undeclared key :secret —
+                    ;; pre-fix this leaked through as inferred context because
+                    ;; the :and head was treated as non-:map.
+                    :data        {:n 1 :secret 99}
+                    :data-schema [:and [:map [:n :int]] [:fn 'some?]]
+                    :states      {:s {}}})]
+      (is (= {:n "number"} (:shape result))
+          "unwrapped `:map`'s declared key :n wins; :secret is excluded")
+      (is (false? (:inferred? result))
+          "wrapped declared `:map` → inferred? false (authoritative)")
+      (is (not (contains? (:shape result) :secret))
+          "undeclared sample key :secret is NOT rendered as inferred context"))))


### PR DESCRIPTION
@
Fixes rf2-2btfzr.

`context-shape`/`static-context-shape` (machines-viz) fell back to one-sample `:data` inference when `:data-schema` was `[:map]`, `[:map {:closed true}]`, or a wrapper such as `[:and [:map …] [:fn …]]`. That violated the EP-0005 **declared-over-inferred** contract — inference must happen only when NO `:data-schema` is declared.

## What changed

- `declared-shape` now returns an authoritative shape (possibly EMPTY) whenever a `:map` is declared. Declared-but-empty ≠ undeclared, so `[:map]` / `[:map {:closed true}]` yield `{:shape {} :inferred? false}` instead of dropping to inference. The host already hides the band on an empty shape (`(seq machine-data)`), so no inferred keys leak.
- New `map-schema` helper unwraps common Malli wrappers (`:and` / `:or` / `:schema` / `:ref`, bounded descent) to find a contained `:map` and use its declared keys.
- `static-context-shape` switches `or` → `if-let` so a declared empty (truthy `{}`) shape is taken authoritatively rather than falling through to inference.
- Tests for `[:map]`, `[:map {:closed true}]`, and `[:and [:map [:n :int]] [:fn …]]` assert undeclared sample keys are NOT rendered as inferred context. The prior `non-map-schema-falls-back-to-inferred` test now uses a genuinely non-`:map` schema (`[:and :int [:fn pos?]]`) so the legitimate fall-through is still covered.

Stayed within `tools/machines-viz/`. No `implementation/` or `tools/xray/` changes. Spec already documents the declared-over-inferred contract correctly (`spec/API.md`, `spec/001-Topology-Parity.md`) — no spec change needed; this fix closes the implementation gap against the existing contract.

## Quality gates

- `clojure -M:test` (tools/machines-viz): 481 tests, 1667 assertions, 0 failures, 0 errors. New declared-empty/wrapper tests confirmed executing via probe-then-revert.
- `npm run test:cljs` (implementation): 6015 tests, 21341 assertions, 0 failures, 0 errors.
- `npm run test:browser` (implementation): 205 tests, 633 assertions, 0 failures, 0 errors.
@