### PR TITLE
docs(EP): EP-0005 decisions-final + implementation-errata note (rf2-okinuq)

### DIFF
--- a/docs/EP/EP-0005-machine-data-schema.md
+++ b/docs/EP/EP-0005-machine-data-schema.md
@@ -2,6 +2,46 @@
 
 Status: final
 
+> **`final` means the decisions are settled.** The five deferred calls were ruled
+> by Mike on 2026-06-08 (see [Resolved Decisions](#resolved-decisions)) and the
+> design is locked. The bulk of the implementation has shipped, but a handful of
+> tracked implementation errata remain open — see
+> [Implementation errata](#implementation-errata). Finalizing the *decisions* does
+> not assert the *implementation* is gap-free.
+
+## Implementation errata
+
+The EP decisions are final; these are the implementation gaps still open against
+`main` (decision-settled, build-incomplete). They track follow-on work and do not
+reopen any ruling:
+
+- **`rf2-20d6k2`** — the redaction bridge protects `:before` / `:after` / `:snapshot`
+  slots, but other machine trace events still carry raw `:data`
+  (`:rf.machine/started` direct `:data`; `:rf.machine/guard-evaluated` /
+  `:rf.machine/action-ran` `:input {:data …}`). Extend projection to redact those slots.
+- **`rf2-qpibk0`** — schema-sourced and author-sourced marks union only when the
+  manual `register-marks!` ran *before* `reg-machine`; a later `register-marks!` can
+  drop schema-derived `[:data …]` marks. Make the union order-independent
+  (decision 3).
+- **`rf2-egvm4t`** — `spawn-fx` registers per-instance `:data-schema` marks, but
+  destroy / finalize / frame teardown do not clear or restore them; epoch
+  restore/replay around spawned actors is not yet lifecycle-safe.
+- **`rf2-pjv7pz`** — the `:schema` → `:data-schema` rename (decision 1) is complete
+  in machines/spec/guide surfaces, but core probe/integration surfaces
+  (`late_bind/directory.cljc`, `router.cljc`, `elision_probe.cljs`) still carry the
+  old `:schema` spelling.
+- **`rf2-1zqh1z`** — `union-marks!` drops an existing explicit `false` whole-output
+  override when the added declaration carries only path marks; the OR semantics the
+  mark-union contract (decision 3) documents are not yet fully honoured.
+- **`rf2-0k5ubx`** *(awaiting Mike ruling)* — Spec 015 §6 + three implementor-skill
+  notes document unimplemented top-level `:sensitive` / `:large` convenience keys on
+  the machine spec; the shipped surface is the per-slot `:data-schema`
+  `:sensitive?` / `:large?` Malli props. Either reword to match the shipped surface
+  or implement the convenience keys.
+
+(The declared-over-inferred context-shape gap for empty/closed/wrapped map schemas,
+`rf2-2btfzr`, is **fixed** in PR #3523 and is no longer open.)
+
 ## Abstract
 
 A state machine's `:data` slot — its context, in XState terms — is the value the
@@ -381,5 +421,7 @@ declared-over-inferred Context shape; and document the XState v5 parity. Validat
 itself already shipped under `rf2-jbbp7`, so this EP corrects the premise that machine
 `:data` is un-schema'd and finishes a documented-but-non-functional privacy capability.
 All five deferred calls were ruled by the operator on 2026-06-08 (see
-[Resolved Decisions](#resolved-decisions)) and the work is implemented and shipped, so
-this EP is **final**.
+[Resolved Decisions](#resolved-decisions)) and the design is settled, so this EP is
+**final** — final in its *decisions*. The bulk of the work has shipped; the
+remaining implementation gaps are tracked as open
+[implementation errata](#implementation-errata), not unresolved decisions.


### PR DESCRIPTION
EP-0005 finalization text said all resolved decisions were implemented and shipped, but `main` still carries open EP-0005 implementation gaps. This keeps `Status: final` (the five rulings ARE settled — see Resolved Decisions) but clarifies `final` = decisions-final, and adds a terse **Implementation errata** section listing the still-open tracking beads. The decision-status is NOT downgraded.

## Implementation errata listed (verified open via `bd show`)

- **rf2-20d6k2** (P2) — machine data-schema marks don't reach all trace slots (`:rf.machine/started` direct `:data`, `:input {:data …}` on guard-evaluated / action-ran)
- **rf2-qpibk0** (P3) — data-schema/manual mark union not order-independent
- **rf2-egvm4t** (P3) — spawned-instance data-schema marks not lifecycle-managed (destroy/finalize/restore)
- **rf2-pjv7pz** (P3) — `:schema` → `:data-schema` rename incomplete in core probe/late-bind/router surfaces
- **rf2-1zqh1z** (P4) — `union-marks!` drops explicit `false` whole-output overrides
- **rf2-0k5ubx** (P3, awaiting Mike ruling) — Spec 015 §6 + skill notes document unimplemented top-level `:sensitive`/`:large` keys

**Excluded as fixed:** `rf2-2btfzr` (declared-over-inferred context-shape for empty/closed/wrapped maps) is CLOSED — fixed in #3523. The doc explicitly notes it as no longer open. No new context-shape regression bead needed.

## Quality gates

- `python scripts/check_doc_slugs.py` — exit 0
- `python scripts/check_ep_status_sync.py` — exit 0 (status stays `final`)
- `python -m mkdocs build --strict` — exit 0 (Documentation built)

Single-file doc edit (`docs/EP/EP-0005-machine-data-schema.md`); no `implementation/`, `spec/`, or `tools/` touched. `.beads/issues.jsonl` not committed.