### PR TITLE
ci(docs): enforce EP README status-sync check in docs.yml (rf2-bxsnp7)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -147,6 +147,15 @@ jobs:
       - name: Validate doc links (targets + anchors)
         run: python scripts/check_doc_slugs.py --verbose
 
+      # docs/EP/README.md restates each EP's `Status:` line in its index
+      # table; the two drift by hand (EP-0001 sat at `accepted` while the
+      # index still said `proposal`). This guard fails the build when an
+      # index status no longer matches its EP. It already runs in the PR-gate
+      # spine (scripts/test-fast-pr.sh); this mirrors that here so CI enforces
+      # it too (rf2-bxsnp7). See scripts/check_ep_status_sync.py.
+      - name: Validate EP README status-sync
+        run: python scripts/check_ep_status_sync.py --verbose
+
       # Stage the spec/ + migration/ trees under docs/ so MkDocs (which
       # requires docs_dir to be a child of the config file) can see them.
       # The local equivalent is `cp -r spec docs/spec && cp -r migration


### PR DESCRIPTION
Wires the existing `scripts/check_ep_status_sync.py` (EP README status-sync freshness guard) into CI. The script already runs in the PR-gate spine (`scripts/test-fast-pr.sh`) but was not invoked in `.github/workflows/docs.yml`, so CI did not enforce EP index status drift. This adds one minimal step to the `build` job, immediately after the existing `check_doc_slugs.py` link validation and mirroring its style. Surfaced by rf2-8cw3m7 worker (#3513). Closes rf2-bxsnp7.

## Quality gates
- `python scripts/check_ep_status_sync.py` — passes on current main (live scan).
- `python scripts/check_ep_status_sync.py --self-test` — passes (fixture self-tests).
- YAML-validated the edited workflow: `python -c "import yaml; yaml.safe_load(open('.github/workflows/docs.yml'))"` → YAML-VALID.
- New step is well-formed and correctly placed in the docs `build` job.