### PR TITLE
docs: reg-sub producers are :db/:static/:parametric — reconcile checklist + implementor skill + docstring (rf2-eqf8wg)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -208,10 +208,15 @@
        `re-frame.events/reg-event-ctx` for the full signature.")
 
      (rm/defreg-macro reg-sub subs/reg-sub
-       "Register a subscription under `id`. Layer-1 subs read `app-db`
-       directly; layer-2 subs chain off other subs via `:<-`. Captures
-       source-coords (Spec 001) at this call site. See
-       `re-frame.subs/reg-sub` for the full signature.")
+       "Register a subscription under `id`. Every sub is one of three
+       input-fn producers: `:db` (layer-1 — reads `app-db` directly, no
+       producer), `:static` (the literal `:<-` producer — a fixed list
+       of input query-vectors), or `:parametric` (an `input-fn` producer
+       — a pure `query-v -> vector-of-query-vectors` fn computing the
+       inputs per concrete query). Captures source-coords (Spec 001) at
+       this call site. See `re-frame.subs/reg-sub` for the full
+       signature, Spec 006 §Subscription input producers, and
+       spec/API.md §`reg-sub` input-production modes.")
 
      (rm/defreg-macro reg-fx fx/reg-fx
        "Register an effect handler under `id`. Handler signature is

--- a/skills/re-frame2-implementor/references/phase-1-decisions.md
+++ b/skills/re-frame2-implementor/references/phase-1-decisions.md
@@ -233,9 +233,9 @@ From [Implementor-Checklist §Subscriptions](https://day8.github.io/re-frame2/sp
 
 **The question.** What backs the subscription DAG, and how is the per-query cache keyed?
 
-**What's at stake.** Subscriptions form a DAG over `app-db`; values cache per `=`-equality. Layer-1 subs read `app-db` directly; layer-2+ compose via `:<-`. **Equality-by-value is required** for cache invalidation — identity-only equality breaks the contract.
+**What's at stake.** Subscriptions form a DAG over `app-db`; values cache per `=`-equality. Every sub is one of three input-fn producers: `:db` (layer-1 — reads `app-db` directly, no producer), `:static` (the literal `:<-` producer), or `:parametric` (an `input-fn` producer that computes its inputs from the outer `query-v`). **Equality-by-value is required** for cache invalidation — identity-only equality breaks the contract.
 
-**Where the spec speaks.** [Implementor-Checklist §Sub1](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#sub1-signal-graph--caching). [`spec/006-ReactiveSubstrate.md` §Subscription cache](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#subscription-cache--contract-and-operational-semantics).
+**Where the spec speaks.** [Implementor-Checklist §Sub1](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#sub1-signal-graph--caching). [`spec/006-ReactiveSubstrate.md` §Subscription input producers](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#subscription-input-producers--app-db-reader-static-parametric-input-fn) and §Subscription cache. [`spec/API.md` §`reg-sub` input-production modes](https://day8.github.io/re-frame2/spec/API/#reg-sub-input-production-modes).
 
 #### Sub2 Lifecycle (when to dispose)
 

--- a/spec/Implementor-Checklist.md
+++ b/spec/Implementor-Checklist.md
@@ -219,7 +219,7 @@ For each capability included in Part 1, the implementor makes the per-capability
 
 #### Sub1. Signal graph + caching
 
-- **Why it matters.** Subscriptions form a DAG over `app-db`; values are cached per `=`-equality. Layer-1 subs read `app-db` directly; layer-2+ compose via `:<-` (per [002 §Subscriptions](002-Frames.md) and [006 §Subscription cache invalidation](006-ReactiveSubstrate.md#subscription-cache--contract-and-operational-semantics)).
+- **Why it matters.** Subscriptions form a DAG over `app-db`; values are cached per `=`-equality. Every sub is one of three input-fn producers: `:db` (layer-1 — reads `app-db` directly, no producer), `:static` (the literal `:<-` producer), or `:parametric` (an `input-fn` producer that computes its inputs from the outer `query-v`) — per [006 §Subscription input producers](006-ReactiveSubstrate.md#subscription-input-producers--app-db-reader-static-parametric-input-fn), [API §`reg-sub` input-production modes](API.md#reg-sub-input-production-modes), [002 §Subscriptions](002-Frames.md), and [006 §Subscription cache invalidation](006-ReactiveSubstrate.md#subscription-cache--contract-and-operational-semantics).
 - **Options by host.** Falls out of **F3** + **S1**.
 - **Reference-impl picks.** CLJS uses Reagent reactions for the graph.
 - **Trade-offs.** Equality-by-value is required for cache invalidation; identity-only equality breaks the contract.


### PR DESCRIPTION
Reconciles three lower-level doc sites with the parametric subscription-input model that already lives in the main API/Spec 006/guide. Subscriptions are now uniformly described as three input-fn producers: `:db` (layer-1, no producer), `:static` (literal `:<-` producer), and `:parametric` (`input-fn` producer computing inputs from the outer `query-v`), with links to Spec 006 §Subscription input producers and API §reg-sub input-production modes. Pure doc/docstring reconciliation — no code or macro-behavior change. Closes rf2-eqf8wg.

Changed: `re-frame.core` reg-sub macro docstring; `spec/Implementor-Checklist.md` Sub1; `skills/re-frame2-implementor` phase-1 Sub1.

## Quality gates
- `python scripts/check_doc_slugs.py` — clean
- skill-drift checks (implementor_order, redirect_anchors, mcp_drift, migration_cites, package_refs, pair_authoring_drift) — all clean
- core artefact `clojure -M:test` (docstring is .cljc) — 986 tests, 4317 assertions, 0 failures, 0 errors