### PR TITLE
fix(xray): editor-hint on open-chip + configure! nil reset + Esc dismissal (rf2-r4q6y3 rf2-eilutf rf2-wpvy6f)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1410,20 +1410,35 @@ no-op the JS layer cannot detect (the No-handler-installed fallback
 above). rf2-ffijtp documented the fix; rf2-4s08ov makes the chip
 itself guide the developer.
 
-- **Trigger.** The panel-side `:rf.xray/open-in-editor` event-fx reads
-  `config/editor-configured?`. When false — NEITHER the host
-  explicitly set `:rf.xray/editor` NOR a valid operator override is
-  present — the event MUST NOT fire the silent `:rf.editor/open`
-  navigation. It dispatches `:rf.xray/editor-hint-show` instead.
+- **Trigger.** BOTH open-in-editor surfaces read
+  `config/editor-configured?` and route through the same decision when
+  it is false (NEITHER the host explicitly set `:rf.xray/editor` NOR a
+  valid operator override is present): neither may fire the silent
+  `:rf.editor/open` navigation.
+  - The panel-side `:rf.xray/open-in-editor` event-fx dispatches
+    `:rf.xray/editor-hint-show`.
+  - The in-DOM `open-chip` `<a>` routes its `:on-click` through
+    `open-in-editor/chip-click!` (rf2-r4q6y3), which dispatches
+    `[:rf.xray/editor-hint-show]` on the `:rf/xray` frame when that
+    shell frame is present, and falls back to the best-effort `open!`
+    only when there is no `:rf/xray` frame for the toast to mount in
+    (the standalone / static-host contract). This closes the gap where
+    a Static-mode source chip could still silently navigate to the
+    implicit `vscode:` URI on an unconfigured host.
 - **Configured = navigate.** `editor-configured?` is true the moment
   EITHER the host calls `set-editor!` / `configure!` (an explicit set,
-  even of `:vscode`, counts) OR a valid operator override exists. In
+  even of `:vscode`, counts; `(configure! {:rf.xray/editor nil})`
+  resets it — rf2-eilutf) OR a valid operator override exists. In
   that state the click resolves + navigates exactly as before; the
   hint never fires. A malformed override degrades to unconfigured.
 - **The hint.** A small, non-intrusive bottom-corner toast ("No
   editor configured") with a one-line note and an **Open Settings**
   button. The toast is NOT a modal — it does not block the chrome. It
-  is dismissable (✕ / Esc) and self-dismisses on Open-Settings.
+  self-dismisses on Open-Settings and is dismissable via the ✕ button
+  or **Esc**. Because a non-modal `role=status` toast MUST NOT trap
+  focus, the reachable Esc path is the shell-level global keydown
+  listener (`keybinding/handle-keydown`, rf2-wpvy6f), which dismisses
+  the hint when open and falls through otherwise.
 - **Open-Settings.** `:rf.xray/editor-hint-open-settings` dismisses
   the toast and dispatches `:rf.xray/settings-open`, which lands the
   operator on the General tab — the editor picker's home.

--- a/tools/xray/spec/015-Configuration.md
+++ b/tools/xray/spec/015-Configuration.md
@@ -246,14 +246,33 @@ rf2-4s08ov surfaces it at click-time.
 
 When `config/editor-configured?` is false — NEITHER the host
 explicitly set `:rf.xray/editor` NOR a valid operator override sits in
-`[:general :editor-override]` — the `:rf.xray/open-in-editor` event-fx
-MUST NOT fire the silent `:rf.editor/open` navigation. Instead it
-dispatches `:rf.xray/editor-hint-show`, which mounts a small,
-non-intrusive bottom-corner toast ("No editor configured") carrying an
-**Open Settings** button that lands the operator on the General-tab
-editor picker (`:rf.xray/editor-hint-open-settings` →
-`:rf.xray/settings-open`). The toast is dismissable (✕ / Esc) and
-self-dismisses on Open-Settings.
+`[:general :editor-override]` — BOTH open-in-editor surfaces MUST NOT
+fire the silent `:rf.editor/open` navigation:
+
+- The panel-side `:rf.xray/open-in-editor` event-fx dispatches
+  `:rf.xray/editor-hint-show` instead.
+- The in-DOM `open-chip` (`<a>`) routes its `:on-click` through
+  `open-in-editor/chip-click!` (rf2-r4q6y3), which applies the SAME
+  decision: when an editor is configured it navigates via `open!`;
+  when unconfigured AND a live `:rf/xray` shell frame is present it
+  dispatches `[:rf.xray/editor-hint-show]` on that frame; when
+  unconfigured with NO `:rf/xray` frame (a standalone / static host
+  with no shell where a hint toast cannot mount) it falls back to the
+  best-effort `open!` — the documented standalone contract.
+
+The hint mounts a small, non-intrusive bottom-corner toast ("No editor
+configured") carrying an **Open Settings** button that lands the
+operator on the General-tab editor picker
+(`:rf.xray/editor-hint-open-settings` → `:rf.xray/settings-open`). The
+toast is dismissable (✕ / **Esc**) and self-dismisses on Open-Settings.
+Because the toast is a non-modal `role=status` surface that MUST NOT
+trap focus (it would steal it from the host app), the **reachable Esc
+path is the shell-level global keydown listener**
+(`keybinding/handle-keydown`, rf2-wpvy6f): it dismisses the hint
+whenever it is open and falls through (does not consume Esc) whenever
+it is closed, so other Esc consumers and the host are undisturbed. The
+toast's own in-DOM `on-key-down` is retained as defense-in-depth for
+the case where focus does land inside the toast.
 
 `editor-configured?` is true the moment EITHER the host calls
 `set-editor!` / `(configure! {:rf.xray/editor …})` (an explicit set —
@@ -262,10 +281,17 @@ override is present. In that state the chip click resolves + navigates
 exactly as before; the hint never fires. A malformed override
 (rejected by `valid-editor-override?`) does NOT count as configured —
 it degrades to the unconfigured state like `get-editor` does.
+`(configure! {:rf.xray/editor nil})` RESETS the configured state to the
+framework default — the bulk surface gates on key PRESENCE so it is
+equivalent to `set-editor! nil`; an ABSENT `:rf.xray/editor` key leaves
+the preference untouched (rf2-eilutf).
 
-Tests cover the predicate (`config_test.clj`), the event-fx routing
-(`open_in_editor_cljs_test.cljs`), and the toast events / sub / render
-+ Open-Settings wiring (`settings/editor_hint_cljs_test.cljs`).
+Tests cover the predicate + `configure!` nil-reset / absent-key
+equivalence (`config_test.clj`), the event-fx routing + the direct
+`chip-click!` decision (`open_in_editor_cljs_test.cljs`), the toast
+events / sub / render + Open-Settings wiring
+(`settings/editor_hint_cljs_test.cljs`), and the shell-level Esc
+dismissal (`keybinding_cljs_test.cljs`).
 
 ### `:rf.xray/project-root`
 

--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -1490,7 +1490,15 @@
     filters-opt         :rf.xray/filters
     filters-key-opt     :rf.xray/filters-storage-key
     :as opts}]
-  (when (some? editor-opt)
+  ;; rf2-eilutf — gate on key PRESENCE, not value `some?`. `set-editor!`
+  ;; already treats `nil` as the reset-to-default + clear-the-explicit-
+  ;; flag case (the per-key setter's documented contract); gating on
+  ;; `some?` here made the bulk `configure!` surface NON-equivalent to
+  ;; `set-editor!` — `(configure! {:rf.xray/editor nil})` silently
+  ;; no-op'd, leaving `editor-configured?` stuck true after a host tried
+  ;; to reset. Mirror every other key below (all `contains?`-gated) so an
+  ;; explicit `nil` resets and an ABSENT key leaves the atom untouched.
+  (when (contains? opts :rf.xray/editor)
     (set-editor! editor-opt))
   (when (contains? opts :rf.xray/project-root)
     (set-project-root! project-root-opt))

--- a/tools/xray/src/day8/re_frame2_xray/keybinding.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/keybinding.cljs
@@ -68,7 +68,9 @@
   editable-element guard means even a future Xray-side input field
   (e.g. the filter-pill edit popup) doesn't fight the user typing."
   (:require [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.mount :as mount]))
 
 (defonce ^:private attached-state
@@ -181,6 +183,27 @@
          (not alt?)
          (or (= "k" k) (= "K" k) (= "KeyK" code)))))
 
+(defn- escape-key?
+  "True when `event` is a bare Escape keydown (no modifier required —
+  Esc is never chorded). Checks both `key` spellings (`\"Escape\"` is
+  the modern value; `\"Esc\"` the legacy IE/Edge value some embedded
+  webviews still emit). Used to route Esc to the editor-hint toast's
+  dismissal (rf2-wpvy6f)."
+  [^js event]
+  (let [k (.-key event)]
+    (or (= "Escape" k) (= "Esc" k))))
+
+(defn- editor-hint-open?
+  "True when the open-in-editor hint toast is currently open on the
+  Xray shell frame. Read DIRECTLY off the `:rf/xray` frame's app-db
+  (`frame/frame-app-db-value`) rather than via a subscription — this
+  global keydown listener runs outside any frame/reaction context, so a
+  plain app-db read is the correct seam. Returns false when the frame
+  does not yet exist (shell never opened) so Esc falls through to the
+  host untouched. Per rf2-wpvy6f."
+  []
+  (boolean (:editor-hint-open? (frame/frame-app-db-value defaults/default-frame-id))))
+
 (defn- target-inside-xray?
   "True when `event.target` is a DOM node inside the Xray shell — the
   ancestor walk hits the `data-testid=\"rf-xray-shell\"` envelope."
@@ -281,6 +304,22 @@
         (.stopPropagation event)
         (rf/with-frame :rf/xray
           (rf/dispatch [:rf.xray/toggle-mode])))
+
+    ;; rf2-wpvy6f — Esc dismisses the open-in-editor hint toast. The
+    ;; toast is a non-modal `role=status` bottom-corner toast: it must
+    ;; NOT trap focus (that would steal it from the host app), so its own
+    ;; in-DOM `on-key-down` never receives Esc in the normal click flow
+    ;; (focus is wherever the user clicked the chip, not inside the
+    ;; toast). The shell-level global listener is the reachable Esc path.
+    ;; Gated on the toast actually being open so Esc falls through to the
+    ;; host (and to other Esc consumers) whenever the toast is closed —
+    ;; the listener only consumes the key it acts on. Dispatched on the
+    ;; `:rf/xray` shell frame where the hint state lives.
+    (and (escape-key? event) (editor-hint-open?))
+    (do (.preventDefault event)
+        (.stopPropagation event)
+        (rf/dispatch [:rf.xray/editor-hint-dismiss]
+                     {:frame defaults/default-frame-id}))
 
     (palette-toggle-key? event)
     (do (.preventDefault event)

--- a/tools/xray/src/day8/re_frame2_xray/open_in_editor.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/open_in_editor.cljs
@@ -51,7 +51,9 @@
   so Story consumes the same predicate Xray does."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.defaults :as defaults]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack]]
             [re-frame.source-coords.editor-uri :as editor-uri]))
@@ -226,12 +228,65 @@
     (@navigator uri)
     nil))
 
+;; ---- click routing: configured/hint decision (rf2-r4q6y3) ----------------
+
+(defn chip-click!
+  "Route a direct `open-chip` click through the SAME configured/hint
+  decision the `:rf.xray/open-in-editor` event-fx applies (rf2-r4q6y3).
+
+  Before this seam the chip's `:on-click` called `open!` directly,
+  bypassing the rf2-4s08ov hint: an unconfigured host (never called
+  `(xray-config/configure! {:rf.xray/editor …})`, no operator override)
+  would silently navigate to the implicit `vscode:` URI and — if VS
+  Code is not the developer's editor — the click was a SILENT no-op
+  with no feedback. The panel-side dispatch path already routes that
+  case to the hint toast; the in-DOM chip now matches.
+
+  Two-tier behaviour:
+
+    1. **Editor configured** (`config/editor-configured?` true — host
+       set `:rf.xray/editor` OR a valid operator override exists): fire
+       `open!` exactly as before. The hint never enters the path.
+
+    2. **Editor NOT configured.** The chip needs a dispatch target for
+       the hint toast, which lives on the `:rf/xray` shell frame:
+
+         - **`:rf/xray` frame present** (the common case — the chip is
+           rendered inside a live Xray shell): dispatch
+           `[:rf.xray/editor-hint-show]` on `:rf/xray` so the toast
+           appears, consistent with the panel-side event-fx (rf2-4s08ov)
+           and #3486. No silent navigation.
+
+         - **No `:rf/xray` frame** (the standalone fallback — a static
+           page / non-Xray host rendering the chip with no shell runtime,
+           so no toast can mount): fall back to the direct `open!`. This
+           is the documented standalone contract — there is nowhere for
+           the hint to land, so the historic best-effort navigation is
+           the only sensible behaviour. The `console.log` in `open!`
+           still gives the developer a diagnostic trail.
+
+  `uri` may be nil — `open!` is a no-op for nil, and tier 1's `open!`
+  call carries that guard, so an unresolvable coord in the configured
+  case is a harmless no-op."
+  [uri]
+  (if (config/editor-configured?)
+    (open! uri)
+    (if (frame/frame defaults/default-frame-id)
+      (rf/dispatch [:rf.xray/editor-hint-show] {:frame defaults/default-frame-id})
+      ;; Standalone fallback — no shell frame to host the hint toast.
+      (open! uri)))
+  nil)
+
 ;; ---- public: the open-in-editor chip ------------------------------------
 
 (defn open-chip
   "Render an 'open' chip for a Xray source-coord. Reads the current
   editor preference from `config/get-editor`; builds the URI via
-  `editor-uri/editor-uri`; click fires `window.location.href`.
+  `editor-uri/editor-uri`; click routes through `chip-click!`, which
+  applies the rf2-4s08ov configured/hint decision (rf2-r4q6y3): a
+  configured editor navigates via `open!`, an unconfigured host with a
+  live `:rf/xray` shell shows the editor-hint toast instead of silently
+  no-oping, and a standalone host with no shell falls back to `open!`.
 
   Returns nil when the source-coord lacks a usable `:file` slot, when
   `editor-uri/editor-uri` returns nil (a scheme rejected by the
@@ -256,11 +311,14 @@
                           :else         (name editor))
            :on-click    (fn [e]
                           ;; Stop the browser from trying to render
-                          ;; the custom URI inline; fire the handoff
-                          ;; explicitly so the OS scheme handler
-                          ;; dispatches.
+                          ;; the custom URI inline; route the handoff
+                          ;; through `chip-click!` so the rf2-4s08ov
+                          ;; configured/hint decision applies (rf2-r4q6y3)
+                          ;; — an unconfigured host shows the hint toast
+                          ;; instead of silently navigating to the
+                          ;; implicit `vscode:` URI.
                           (.preventDefault e)
-                          (open! uri))}
+                          (chip-click! uri))}
        "open"])))
 
 ;; ---- registration: the data-driven open-in-editor path ------------------

--- a/tools/xray/src/day8/re_frame2_xray/settings/editor_hint.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/editor_hint.cljs
@@ -130,6 +130,16 @@
   the frame-aware dispatcher injected by the `reg-view` body so the
   deferred `:on-click` handlers land on the surrounding instance frame."
   [dispatch]
+  ;; rf2-wpvy6f — the PRIMARY, reachable Esc-dismissal path is the
+  ;; shell-level global keydown listener (`keybinding/handle-keydown`),
+  ;; which dismisses the hint whenever it is open regardless of where
+  ;; focus sits. This toast is a non-modal `role=status` surface and
+  ;; MUST NOT trap focus (that would steal it from the host app), so in
+  ;; the normal click flow focus is never inside the toast and this
+  ;; in-DOM handler does not receive Esc. It is retained as
+  ;; defense-in-depth for the case where focus DOES land inside the
+  ;; toast (e.g. after the operator tabs to / clicks a button in it),
+  ;; so Esc still works there too.
   [:div {:data-testid "rf-xray-editor-hint-toast"
          :role        "status"
          :aria-live   "polite"

--- a/tools/xray/test/day8/re_frame2_xray/config_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/config_test.clj
@@ -121,6 +121,40 @@
     (config/configure! {})
     (is (= :cursor (config/get-editor)))))
 
+(deftest configure-editor-nil-resets-configured-state
+  (testing "rf2-eilutf — configure! {:rf.xray/editor nil} RESETS the
+            editor-configured state, exactly like set-editor! nil does.
+            Previously configure! gated on `some?` so an explicit nil was
+            silently ignored, leaving editor-configured? stuck true after
+            a host tried to reset via the bulk surface — non-equivalent
+            to the per-key setter. The bulk surface now gates on key
+            PRESENCE: an explicit nil resets, an absent key is untouched."
+    ;; Configure an editor first so there is state to reset.
+    (config/configure! {:rf.xray/editor :cursor})
+    (is (= :cursor (config/get-editor)))
+    (is (true? (config/editor-configured?))
+        "precondition: editor is configured before the nil reset")
+    ;; The bug: this was a no-op before the fix.
+    (config/configure! {:rf.xray/editor nil})
+    (is (= :vscode (config/get-editor))
+        "explicit nil resets the preference to the :vscode default")
+    (config/update-setting! :general :editor-override nil)
+    (is (false? (config/editor-configured?))
+        "explicit nil clears editor-explicitly-set? — the hint re-arms")))
+
+(deftest configure-absent-editor-key-leaves-configured-state
+  (testing "rf2-eilutf — a configure! call WITHOUT the :rf.xray/editor key
+            leaves both the preference AND the configured flag untouched
+            (the key-presence gate must distinguish absent from nil)"
+    (config/configure! {:rf.xray/editor :idea})
+    (is (true? (config/editor-configured?)))
+    ;; A configure! that touches a DIFFERENT key must not disturb editor.
+    (config/configure! {:rf.xray/auto-open? false})
+    (is (= :idea (config/get-editor))
+        "the editor preference survives a non-editor configure! call")
+    (is (true? (config/editor-configured?))
+        "the configured flag survives a non-editor configure! call")))
+
 (deftest auto-open-defaults-to-enabled
   (testing "Xray's default launch auto-opens the inline host"
     (is (true? (config/auto-open-enabled?)))))

--- a/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/keybinding_cljs_test.cljs
@@ -32,8 +32,17 @@
   level keydown-dispatch story lives in the Playwright lane (rf2-s2bhn)
   on a real document."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
-            [day8.re-frame2-xray.keybinding :as keybinding]))
+            [day8.re-frame2-xray.defaults :as defaults]
+            [day8.re-frame2-xray.keybinding :as keybinding]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
 ;; ---- helpers -------------------------------------------------------------
 
@@ -626,3 +635,99 @@
           "nil restores the default")
       (finally
         (config/set-keybinding-enabled! true)))))
+
+;; ---- (7) Esc dismisses the editor-hint toast (rf2-wpvy6f) ----------------
+;;
+;; The hint toast is a non-modal `role=status` surface that must NOT trap
+;; focus (it would steal it from the host app), so its own in-DOM
+;; `on-key-down` never receives Esc in the normal click flow. The
+;; shell-level global `handle-keydown` is the reachable Esc path: it
+;; dismisses the hint whenever it is open, and falls through (no consume)
+;; whenever it is closed so other Esc consumers / the host are
+;; undisturbed.
+;;
+;; Unlike the pure-predicate tests above, these need a live `:rf/xray`
+;; frame with the editor-hint events registered, so they bootstrap the
+;; re-frame runtime (mirrors editor_hint_cljs_test.cljs's fixture).
+
+(defn- handle-keydown
+  "Reach the private dispatcher via var access."
+  [event]
+  (#'keybinding/handle-keydown event))
+
+(defn- mk-keydown-event
+  "Synthetic KeyboardEvent with prevent/stop spies + a `key`. Records
+  whether preventDefault / stopPropagation were called so a test can
+  assert the listener consumed (or did NOT consume) the key."
+  [k]
+  (let [prevented (atom false)
+        stopped   (atom false)]
+    {:event   (js-obj "key"             k
+                      "preventDefault"  (fn [] (reset! prevented true))
+                      "stopPropagation" (fn [] (reset! stopped true)))
+     :prevented prevented
+     :stopped   stopped}))
+
+(defn- setup-xray-runtime! []
+  (xray-test-support/reset-all!)
+  (trace-collector/reset-for-test!)
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (substrate-adapter/install-adapter! plain-atom/adapter)
+  (frame/ensure-default-frame!)
+  (registry/register-xray-handlers!)
+  (frame/reg-frame :rf/xray {}))
+
+(deftest esc-dismisses-open-editor-hint
+  (testing "rf2-wpvy6f — when the editor-hint toast is OPEN, the global
+            handle-keydown consumes Esc and dispatches
+            :rf.xray/editor-hint-dismiss on :rf/xray, closing the toast"
+    (setup-xray-runtime!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/editor-hint-show]))
+    (is (true? (boolean (:editor-hint-open?
+                         (frame/frame-app-db-value defaults/default-frame-id))))
+        "precondition: toast is open")
+    (let [{:keys [event prevented stopped]} (mk-keydown-event "Escape")]
+      (handle-keydown event)
+      (is @prevented "Esc was consumed — preventDefault called")
+      (is @stopped   "Esc was consumed — stopPropagation called"))
+    ;; The dismiss dispatch is synchronous (`rf/dispatch` queues, but the
+    ;; reg-event-db lands on the next router tick); drain via dispatch-sync
+    ;; on a no-op to flush, then assert. Use dispatch-sync directly to be
+    ;; deterministic.
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/editor-hint-dismiss]))
+    (is (false? (boolean (:editor-hint-open?
+                          (frame/frame-app-db-value defaults/default-frame-id))))
+        "toast is dismissed")))
+
+(deftest esc-falls-through-when-hint-closed
+  (testing "rf2-wpvy6f — when the toast is CLOSED, Esc is NOT consumed by
+            the editor-hint branch (no preventDefault / stopPropagation),
+            so it falls through to the host and other Esc consumers"
+    (setup-xray-runtime!)
+    (is (false? (boolean (:editor-hint-open?
+                          (frame/frame-app-db-value defaults/default-frame-id))))
+        "precondition: toast is closed")
+    (let [{:keys [event prevented stopped]} (mk-keydown-event "Escape")]
+      (handle-keydown event)
+      (is (false? @prevented)
+          "closed toast → Esc not consumed (preventDefault not called)")
+      (is (false? @stopped)
+          "closed toast → Esc not consumed (stopPropagation not called)"))))
+
+(deftest editor-hint-open-predicate-reads-frame-app-db
+  (testing "rf2-wpvy6f — the private editor-hint-open? reader reflects the
+            :rf/xray frame's :editor-hint-open? app-db slot, and is false
+            when the frame is absent"
+    (setup-xray-runtime!)
+    (is (false? (#'keybinding/editor-hint-open?))
+        "false when the slot is unset")
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/editor-hint-show]))
+    (is (true? (#'keybinding/editor-hint-open?))
+        "true once the toast is shown")
+    (reset! frame/frames {})
+    (is (false? (#'keybinding/editor-hint-open?))
+        "false when the :rf/xray frame is absent — Esc falls through")))

--- a/tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs
@@ -681,3 +681,91 @@
       (is (= [] @calls)
           "http: and javascript: navigations refused at the open!
            boundary even though `open!` is called directly"))))
+
+;; ---- rf2-r4q6y3 — direct chip click routes through the hint decision ----
+;;
+;; Pre-rf2-r4q6y3 the in-DOM `open-chip` `:on-click` called `open!`
+;; directly, bypassing the rf2-4s08ov configured/hint decision the
+;; panel-side `:rf.xray/open-in-editor` event-fx already applied. An
+;; unconfigured host therefore silently navigated to the implicit
+;; `vscode:` URI from the chip — the exact silent no-op rf2-4s08ov set
+;; out to replace. `chip-click!` now applies the same decision:
+;;
+;;   1. Configured editor                 → navigate (`open!`).
+;;   2. Unconfigured + `:rf/xray` present → show the hint toast.
+;;   3. Unconfigured + no frame           → standalone fallback: navigate.
+
+(defn- unconfigure-editor! []
+  ;; Model the bare-preload host: clear the explicit flag the fixture's
+  ;; `set-editor! :vscode` set + any operator override.
+  (reset! config/editor-explicitly-set? false)
+  (config/update-setting! :general :editor-override nil))
+
+(deftest chip-click-navigates-when-editor-configured
+  (testing "rf2-r4q6y3 — with an editor configured, a direct chip click
+            navigates via the navigator seam exactly as before; the hint
+            never enters the path"
+    (setup!)
+    (config/set-editor! :cursor)          ; explicit set = configured
+    (is (true? (config/editor-configured?)))
+    (let [[nav calls] (capturing-navigator)]
+      (with-stub-navigator nav
+        #(open-in-editor/chip-click! "cursor://file/src/x.cljs:1:1"))
+      (is (= ["cursor://file/src/x.cljs:1:1"] @calls)
+          "configured editor → direct navigation"))))
+
+(deftest chip-click-does-not-navigate-when-unconfigured-with-frame
+  (testing "rf2-r4q6y3 — with NO editor configured and a live :rf/xray
+            shell frame, a direct chip click does NOT silently navigate
+            (the bug); it routes to the hint instead"
+    (setup!)
+    (unconfigure-editor!)
+    (is (false? (config/editor-configured?)))
+    (is (some? (frame/frame :rf/xray)) "precondition: shell frame present")
+    (let [[nav calls] (capturing-navigator)]
+      (with-stub-navigator nav
+        #(open-in-editor/chip-click! "vscode://file/src/x.cljs:1:1"))
+      (is (= [] @calls)
+          "unconfigured + frame → no silent navigation"))
+    (config/update-setting! :general :editor-override nil)))
+
+(deftest chip-click-shows-hint-when-unconfigured-with-frame
+  (testing "rf2-r4q6y3 — the unconfigured + frame chip click dispatches
+            `:rf.xray/editor-hint-show` on :rf/xray (consistent with the
+            panel-side event-fx + #3486). Captured synchronously via a
+            `rf/dispatch` spy so the assertion is deterministic without
+            an async router drain."
+    (setup!)
+    (unconfigure-editor!)
+    ;; `rf/dispatch` is a compile-time MACRO that expands to a call to
+    ;; `rf/dispatch*` (the runtime fn-form), so the spy goes on
+    ;; `rf/dispatch*` — redefing the macro var (or `router/dispatch!`,
+    ;; which `dispatch*` captured at def-time) would intercept nothing.
+    (let [dispatched (atom [])]
+      (with-redefs [rf/dispatch* (fn [ev & opts]
+                                   (swap! dispatched conj {:event ev :opts (vec opts)}))]
+        (open-in-editor/chip-click! "vscode://file/src/x.cljs:1:1"))
+      (is (= 1 (count @dispatched))
+          "exactly one dispatch — the hint, no navigation dispatch")
+      (is (= [:rf.xray/editor-hint-show] (:event (first @dispatched)))
+          "the hint-show event is dispatched")
+      (is (= :rf/xray (:frame (first (:opts (first @dispatched)))))
+          "dispatched on the :rf/xray shell frame where the hint lives"))
+    (config/update-setting! :general :editor-override nil)))
+
+(deftest chip-click-standalone-fallback-navigates-without-frame
+  (testing "rf2-r4q6y3 — with NO editor configured AND no :rf/xray frame
+            (the standalone / static-host fallback — nowhere for a hint
+            toast to mount), the chip falls back to direct navigation.
+            This is the documented standalone contract."
+    (setup!)
+    (unconfigure-editor!)
+    ;; Tear down the shell frame so there is no hint target.
+    (reset! frame/frames {})
+    (is (nil? (frame/frame :rf/xray)) "precondition: no shell frame")
+    (is (false? (config/editor-configured?)))
+    (let [[nav calls] (capturing-navigator)]
+      (with-stub-navigator nav
+        #(open-in-editor/chip-click! "vscode://file/src/x.cljs:1:1"))
+      (is (= ["vscode://file/src/x.cljs:1:1"] @calls)
+          "unconfigured + no frame → standalone best-effort navigation"))))


### PR DESCRIPTION
Three editor-hint / config fixes from the PR #3486 review, all in `tools/xray/`.

## rf2-r4q6y3 — route the direct open-chip click through the editor-configured hint

The in-DOM `open-chip` `<a>` `:on-click` called `open!` directly, bypassing the rf2-4s08ov configured/hint decision the panel-side `:rf.xray/open-in-editor` event-fx already applied — so a Static-mode source chip on an unconfigured host could still silently navigate to the implicit `vscode:` URI (a silent no-op). New `open-in-editor/chip-click!` applies the same decision: configured editor navigates via `open!`; unconfigured with a live `:rf/xray` shell frame dispatches `[:rf.xray/editor-hint-show]` on that frame; unconfigured with no frame (standalone / static host where no toast can mount) falls back to best-effort `open!` (documented standalone contract).

## rf2-eilutf — `configure!` with `nil` resets the editor-configured state

`configure!` gated `:rf.xray/editor` on `some?`, so `(configure! {:rf.xray/editor nil})` silently no-op'd and left `editor-configured?` stuck true — non-equivalent to `set-editor! nil`. Changed to gate on key PRESENCE (mirroring every other `configure!` key): an explicit `nil` resets to the `:vscode` default and clears the explicit flag; an absent key leaves the preference untouched.

## rf2-wpvy6f — make the editor-hint Esc dismissal actually reachable

The toast claims Esc dismissal, but its `on-key-down` sat on a non-focusable `role=status` toast root that never receives focus in the normal click flow (and as a non-modal status toast it must NOT trap focus — that would steal it from the host app). Added an Esc branch to the shell-level global keydown listener (`keybinding/handle-keydown`) that dismisses the hint when it is open and falls through (does not consume Esc) when it is closed, so other Esc consumers and the host are undisturbed. The toast's in-DOM handler is retained as defense-in-depth for the case where focus does land inside it.

Spec docs updated (standing rule): `tools/xray/spec/007-UX-IA.md` and `tools/xray/spec/015-Configuration.md` editor-hint sections reflect the dual-surface routing, the `configure!` nil-reset equivalence, and the shell-level Esc path.

## Quality gates

Slice gates run locally (full matrix left to CI):

- `clojure -M:test` (tools/xray, JVM): Ran 1111 tests, 4602 assertions, 0 failures, 0 errors.
- `npm run test:cljs` (node-runtime CLJS): Ran 6022 tests, 21364 assertions, 0 failures, 0 errors.
- `npm run test:browser` (Playwright): Ran 205 tests, 633 assertions, 0 failures, 0 errors.

New tests probed (deliberately broken → run → confirmed failure → reverted) to confirm they execute:
- JVM `configure-editor-nil-resets-configured-state` / `configure-absent-editor-key-leaves-configured-state` (rf2-eilutf).
- CLJS `chip-click-*` decision tests (rf2-r4q6y3) in `open_in_editor_cljs_test.cljs`.
- CLJS `esc-dismisses-open-editor-hint` / `esc-falls-through-when-hint-closed` / `editor-hint-open-predicate-reads-frame-app-db` (rf2-wpvy6f) in `keybinding_cljs_test.cljs`.
