### PR TITLE
fix(machines): stamp inline source for single-map :always transitions + xray source-key (rf2-k7yqod)

### DIFF
--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -815,9 +815,20 @@
                             (assoc! acc (conj tp i) src)))))
                     nil)
                   nil on-map)))
-            ;; :always — vector of transition maps.
+            ;; :always — single transition MAP or a vector of candidate maps
+            ;; (rf2-k7yqod; mirrors the `:on` single-map / vector forms the
+            ;; runtime + validator both accept — `transition/pick-always-
+            ;; transition` wraps a non-vector `:always` into `[always]`,
+            ;; `validation/always-entries` does the same). The single-map
+            ;; form is keyed at the bare `:always` path (the transition MAP
+            ;; IS the `:always` value, like a single-map `:on` entry); the
+            ;; vector form keys each candidate by index.
             (when-let [always (:always node)]
-              (when (vector? always)
+              (cond
+                (map? always)
+                (when-let [src (node-inline-source always)]
+                  (assoc! acc (conj node-path :always) src))
+                (vector? always)
                 (doseq [[i tx] (map-indexed vector always)
                         :when (map? tx)]
                   (when-let [src (node-inline-source tx)]

--- a/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
@@ -194,6 +194,69 @@
     (is (fn? (get-in (rf/machine-meta :rf2-se70xj/inline) [:states :idle :on :cancel :action])))
     (is (fn? (get-in (rf/machine-meta :rf2-se70xj/inline) [:states :idle :entry])))))
 
+(deftest reg-machine-stamps-inline-always-single-map-source-code-cljs
+  (testing "an inline `:always` `:action` written as a SINGLE MAP (not a
+  vector of candidates) carries its `:source-code` at the bare `:always`
+  spec-path — parity with the vector `:always [{…}]` form (rf2-k7yqod). The
+  runtime + validator both accept the single-map `:always` (wrapping it into
+  a one-candidate vector), so the macro must stamp it too — otherwise the
+  Epoch panel renders `#object[Function]` for it."
+    (rf/reg-machine :rf2-k7yqod/always-single-map
+      {:initial :a
+       :data    {:pending? true}
+       :states
+       {:a {:always {:target :b
+                     :guard  (fn [{data :data}] (:pending? data))
+                     :action (fn [{data :data}]
+                               {:data (assoc data :always-single-fired? true)})}}
+        :b {}}})
+    ;; Single-map `:always` keys at the bare `:always` path (no index).
+    (let [action-src (inline-source :rf2-k7yqod/always-single-map [:states :a :always] :action)
+          guard-src  (inline-source :rf2-k7yqod/always-single-map [:states :a :always] :guard)]
+      (is (string? action-src)
+          "single-map :always :action carries :source-code at [:states :a :always]")
+      (is (re-find #":always-single-fired\?" action-src)
+          "the captured :source-code is the inline action body")
+      (is (string? guard-src)
+          "single-map :always :guard carries :source-code at [:states :a :always]")
+      (is (re-find #":pending\?" guard-src)))
+    ;; The slot values stay bare fns (the runtime resolves them via fn?).
+    (is (fn? (get-in (rf/machine-meta :rf2-k7yqod/always-single-map)
+                     [:states :a :always :action])))
+    (is (fn? (get-in (rf/machine-meta :rf2-k7yqod/always-single-map)
+                     [:states :a :always :guard])))
+    ;; The single-map form does NOT mistakenly key under an index 0.
+    (is (nil? (inline-source :rf2-k7yqod/always-single-map [:states :a :always 0] :action))
+        "single-map :always is NOT keyed at index 0 (that's the vector form)")))
+
+(deftest reg-machine-stamps-inline-always-vector-source-code-cljs
+  (testing "a VECTOR `:always` co-locates each candidate map's inline
+  `:action` source at its index (rf2-k7yqod). The vector form keys per
+  index; a multi-candidate vector stamps each candidate independently so the
+  Epoch source lookup does NOT hardcode index 0 onto the wrong candidate."
+    (rf/reg-machine :rf2-k7yqod/always-vector
+      {:initial :a
+       :data    {}
+       :guards  {:first? (fn [_] false)}
+       :states
+       {:a {:always [{:guard  :first?
+                      :target :b
+                      :action (fn [_] {:data {:always-vec-0-fired? true}})}
+                     {:target :c
+                      :action (fn [_] {:data {:always-vec-1-fired? true}})}]}
+        :b {}
+        :c {}}})
+    ;; Each candidate's inline :action is stamped at its OWN index.
+    (let [src-0 (inline-source :rf2-k7yqod/always-vector [:states :a :always 0] :action)
+          src-1 (inline-source :rf2-k7yqod/always-vector [:states :a :always 1] :action)]
+      (is (string? src-0) "vector :always candidate 0 carries :source-code at index 0")
+      (is (re-find #":always-vec-0-fired\?" src-0))
+      (is (string? src-1) "vector :always candidate 1 carries :source-code at index 1")
+      (is (re-find #":always-vec-1-fired\?" src-1))
+      ;; The two candidates' sources are DISTINCT — index 0 is not reused.
+      (is (not= src-0 src-1)
+          "each candidate keys its own source — Xray must not hardcode index 0"))))
+
 (deftest reg-machine-skips-inline-source-for-keyword-references-cljs
   (testing "keyword-reference slots carry NO inline :source-code — their body
   lives on the named :actions / :guards entry's own :source-code (rf2-se70xj)"

--- a/implementation/machines/test/re_frame/machine_source_coord_test.clj
+++ b/implementation/machines/test/re_frame/machine_source_coord_test.clj
@@ -200,6 +200,67 @@
       (is (string? src) "inline :guard carries :source-code")
       (is (re-find #":ready\?" src)))))
 
+(deftest reg-machine-stamps-inline-always-single-map-source-code
+  (testing "an inline `:always` `:action` / `:guard` written as a SINGLE MAP
+  carries its `:source-code` at the bare `:always` spec-path (rf2-k7yqod).
+  The runtime + validator both accept the single-map `:always`, so the macro
+  must stamp it — parity with the vector `:always [{…}]` form. Works on JVM:
+  the source is the `pr-str` of the fn LITERAL (a list the LispReader
+  decorates), and the co-location is `assoc-in`/`get-in` on the enclosing
+  map — neither needs map-literal reader meta."
+    (rf/reg-machine :rf2-k7yqod/always-single
+      {:initial :a
+       :data    {:pending? true}
+       :states
+       {:a {:always {:target :b
+                     :guard  (fn [{data :data}] (:pending? data))
+                     :action (fn [{data :data}]
+                               {:data (assoc data :always-single-fired? true)})}}
+        :b {}}})
+    (let [action-src (inline-source :rf2-k7yqod/always-single [:states :a :always] :action)
+          guard-src  (inline-source :rf2-k7yqod/always-single [:states :a :always] :guard)]
+      (is (string? action-src)
+          "single-map :always :action carries :source-code at [:states :a :always]")
+      (is (re-find #"\(fn" action-src))
+      (is (re-find #":always-single-fired\?" action-src)
+          "the captured :source-code is the action body, not the enclosing map")
+      (is (string? guard-src) "single-map :always :guard carries :source-code")
+      (is (re-find #":pending\?" guard-src)))
+    ;; The inline-fn slot values stay BARE fns (the runtime resolves via fn?).
+    (is (fn? (get-in (rf/machine-meta :rf2-k7yqod/always-single)
+                     [:states :a :always :action])))
+    (is (fn? (get-in (rf/machine-meta :rf2-k7yqod/always-single)
+                     [:states :a :always :guard])))
+    ;; The single-map form does NOT mistakenly key at index 0.
+    (is (nil? (inline-source :rf2-k7yqod/always-single [:states :a :always 0] :action))
+        "single-map :always is NOT keyed at index 0 (that's the vector form)")))
+
+(deftest reg-machine-stamps-inline-always-vector-source-code
+  (testing "a VECTOR `:always` co-locates each candidate map's inline
+  `:action` source at its OWN index (rf2-k7yqod) — so the source lookup does
+  not hardcode index 0 onto the wrong candidate."
+    (rf/reg-machine :rf2-k7yqod/always-vec-src
+      {:initial :a
+       :data    {}
+       :guards  {:first? (fn [_] false)}
+       :states
+       {:a {:always [{:guard  :first?
+                      :target :b
+                      :action (fn [_] {:data {:always-vec-0-fired? true}})}
+                     {:target :c
+                      :action (fn [_] {:data {:always-vec-1-fired? true}})}]}
+        :b {}
+        :c {}}})
+    (let [src-0 (inline-source :rf2-k7yqod/always-vec-src [:states :a :always 0] :action)
+          src-1 (inline-source :rf2-k7yqod/always-vec-src [:states :a :always 1] :action)]
+      (is (string? src-0) "vector :always candidate 0 carries :source-code at index 0")
+      (is (re-find #":always-vec-0-fired\?" src-0))
+      (is (string? src-1) "vector :always candidate 1 carries :source-code at index 1")
+      (is (re-find #":always-vec-1-fired\?" src-1))
+      (is (not= src-0 src-1)
+          "each candidate keys its own source — the index-0 hardcode would
+           reuse the wrong body"))))
+
 (deftest reg-machine-skips-inline-source-for-keyword-references
   (testing "keyword-reference slots (`:action :clear-hold`) carry NO inline
   :source-code on the enclosing node — their body lives on the named

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1828,6 +1828,7 @@ distinct from the inline `:source-code` body above.
 | `:action`| inline-fn, `:entry`     | `[:states <target-state>... :entry]`                  | enclosing state-node `:source-code :entry` | enclosing state-node `:source-coords` |
 | `:action`| inline-fn, `:exit`      | `[:states <source-state>... :exit]`                   | enclosing state-node `:source-code :exit` | enclosing state-node `:source-coords` |
 | `:action`| inline-fn, `:transition`| `[:states <source-state>... :on <event> :action]`     | enclosing transition-map `:source-code :action` | enclosing transition-map `:source-coords` |
+| `:action`| inline-fn, `:always`    | `[:states <source-state>... :always :action]`        | enclosing `:always` map `:source-code :action` (read-back also probes the index-0 vector-candidate path) | enclosing `:always` map / state-node `:source-coords` (walk-up) |
 | `:guard` | keyword `guard-id`      | `[:guards <id>]`                                      | entry `:source-code` | entry `:source-coords` |
 | `:guard` | inline-fn               | `[:states <source-state>... :on <event> :guard]`      | enclosing transition-map `:source-code :guard` | enclosing transition-map `:source-coords` |
 | `:transition` | —                  | `[:states <source-state>... :on <event>]`             | logical-state delta box (not source) | transition-map `:source-coords` |
@@ -1843,6 +1844,22 @@ one). Multi-microstep cascades carry one transition emit per
 macrostep — intermediate-state inline-fns fall back to the
 headline state; source-key resolution degrades to the macrostep's
 source/target.
+
+**`:always` single-map vs vector candidate (rf2-k7yqod).** The runtime
+and validator both accept `:always` as EITHER a single transition map
+(`:always {:action (fn …)}`) OR a vector of guarded candidates
+(`:always [{:guard … :target …} {…}]`). The macro keys each form
+differently: a single-map `:always` is stamped at the bare `:always`
+path (`[:states <s> :always]`, mirroring single-map `:on`); a vector
+keys each candidate by index (`[:states <s> :always <i>]`). The
+source-key returns the INDEX-FREE single-map shape; the view read-back
+(`cascade-row-source-form`) probes the index-free path FIRST and, on a
+miss, the index-0 vector-candidate path — so a single-element vector
+`:always [{…}]` still resolves its body. Richer per-candidate index
+resolution for MULTI-candidate vectors (carrying the substrate's matched
+always-index onto the cascade row) is the rf2-lai1qv follow-on; until
+then a multi-candidate vector resolves its FIRST candidate's source
+(best-effort).
 
 For `:transition` rows, the body renders the **logical-state DELTA
 box** (rf2-iwy0c — see "Transition row" below), NOT a source form;

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
@@ -322,9 +322,15 @@
       (source-state)
     - `:transition`               → `[:states <state>... :on <event> :action]`
       (source-state + event-id)
-    - `:always`                   → `[:states <state>... :always 0 :action]`
-      (best-effort: index 0; richer index resolution requires
-      substrate-side carrier of the always-index, deferred)
+    - `:always`                   → `[:states <state>... :always :action]`
+      (the index-free single-map shape, mirroring the single-map `:on`
+      convention — the macro keys a single-map `:always` at the bare
+      `:always` path, rf2-k7yqod). The view read-back PROBES BOTH this
+      index-free path AND the index-0 vector-candidate path
+      (`[:states <state>... :always 0 :source-code :action]`) so a
+      vector `:always [{…}]` still resolves; richer per-candidate index
+      resolution (carrying the matched always-index from the substrate)
+      is the rf2-lai1qv follow-on.
     - `:after-action`             → `[:states <state>... :after :action]`
       (best-effort: timer fn-form path; the macro doesn't yet stamp
       per-delay `:after` coords; D2 follow-on bead handles richer index).
@@ -359,7 +365,12 @@
         (when (and source-prefix event-id)
           (conj source-prefix :on event-id :action))
         (= :always phase)
-        (when source-prefix (conj source-prefix :always 0 :action))
+        ;; The index-free single-map shape (rf2-k7yqod). The macro keys a
+        ;; single-map `:always` at the bare `:always` path; the view's
+        ;; read-back additionally probes the index-0 vector-candidate path
+        ;; so a `:always [{…}]` vector resolves too (rf2-lai1qv carries the
+        ;; exact matched index for richer multi-candidate resolution).
+        (when source-prefix (conj source-prefix :always :action))
         (= :after-action phase)
         (when source-prefix (conj source-prefix :after :action))
         :else nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -2645,8 +2645,18 @@
         (let [slot          (last k)
               enclosing-path (vec (butlast k))
               inline-src    (when (seq enclosing-path)
-                              (get-in spec (conj enclosing-path :source-code slot)))]
+                              (get-in spec (conj enclosing-path :source-code slot)))
+              ;; rf2-k7yqod — the `:always` source-key is the index-free
+              ;; single-map shape (`[:states … :always :action]`). When the
+              ;; spec wrote the VECTOR-candidate form (`:always [{…}]`), the
+              ;; source lives one level deeper at index 0; probe it so a
+              ;; vector `:always` resolves too. (rf2-lai1qv will carry the
+              ;; exact matched index for multi-candidate vectors.)
+              always-vec-src (when (and (nil? inline-src)
+                                        (= :always (peek enclosing-path)))
+                               (get-in spec (conj enclosing-path 0 :source-code slot)))]
           (or inline-src
+              always-vec-src
               (get-in spec k)))))))
 
 (defn- cascade-outcome-chip

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1334,6 +1334,36 @@
                {:kind :action :action-id inline-fn :phase :transition
                 :source-state :idle :event-id :submit}))))))
 
+(deftest cascade-row-source-key-inline-always-action-test
+  (testing "rf2-k7yqod — inline-fn `:always` `:action` resolves to the
+            INDEX-FREE single-map shape `[:states <src> :always :action]`,
+            mirroring the single-map `:on` convention (the macro keys a
+            single-map `:always` at the bare `:always` path). The view
+            read-back additionally probes the index-0 vector path, so the
+            source-key need not hardcode index 0."
+    (let [inline-fn (fn [_] {})]
+      (is (= [:states :a :always :action]
+             (fmt/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :always
+                :source-state :a}))
+          "flat machine: index-free :always :action slot")
+      (is (= [:states :outer :states :inner :always :action]
+             (fmt/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :always
+                :source-state [:outer :inner]}))
+          "hierarchical source-state expands to nested :states path")
+      ;; The key must NOT bake in index 0 (the rf2-k7yqod regression — that
+      ;; mis-resolved a single-map `:always` AND hardcoded the wrong
+      ;; candidate for a multi-candidate vector).
+      (is (not (some #{0} (fmt/cascade-row-source-key
+                            {:kind :action :action-id inline-fn :phase :always
+                             :source-state :a})))
+          "the :always source-key is index-free (no hardcoded 0)")
+      ;; Missing source-state → nil (cannot build the path).
+      (is (nil? (fmt/cascade-row-source-key
+                  {:kind :action :action-id inline-fn :phase :always}))
+          "missing source-state → nil"))))
+
 (deftest cascade-row-source-key-inline-guard-test
   (testing "rf2-wwc3j — inline-fn `:guard` resolves to
             `[:states <src> :on <event> :guard]`"


### PR DESCRIPTION
Closes rf2-k7yqod. The reg-machine inline-source walker (`walk-states-inline-source`) only captured VECTOR `:always` entries, while the runtime (`transition/pick-always-transition`) and validator (`validation/always-entries`) both accept a single-MAP `:always` (wrapping a non-vector into a one-candidate list). So an inline `:always {:action (fn ...)}` got no co-located `:source-code` and the Epoch panel rendered `#object[Function]`.

- Walker: handle single-map `:always` (keyed at the bare `:always` path, mirroring single-map `:on`) AND the vector form (keyed per index).
- Xray source-key (`cascade-row-source-key`): emit the index-free `[:states <s> :always :action]` shape; the view read-back probes the index-free path first then the index-0 vector-candidate path, so neither form hardcodes index 0 incorrectly. Keeps the source-key contract clean for rf2-lai1qv.
- Spec: `tools/xray/spec/021-Dynamic-Panel-Designs.md` source-key table + single-map/vector `:always` note.

## Quality gates
- `implementation/machines` `clojure -M:test` — 553 tests, 0 failures (incl. new single-map + vector `:always` source-code tests).
- `tools/xray` `clojure -M:test` — 1110 tests, 0 failures (incl. new index-free `:always` source-key test).
- `npm run test:cljs` — 6018 tests, 0 failures. Probed the single-map `:always` CLJS source-stamping test executes (sentinel-fail then reverted).