### PR TITLE
fix(core): sub-input-fn error records carry sub source-coords + reg-sub :parametric docstring (rf2-bxud9v rf2-yfxwh4)

### DIFF
--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -104,6 +104,66 @@
   code should never call this. Returns nil."
   (:clear registry))
 
+;; ---- kind-aware source-coord lookup (rf2-bxud9v) --------------------------
+;;
+;; The always-on `error-coords-by-id` parallel registry is keyed by
+;; `[registry-kind id]` — the SAME `kind` the public reg-* macro path
+;; stamped at registration (`re-frame.registrar/register!` →
+;; `remember-error-coords!`). A `reg-sub` stores coords under `[:sub
+;; sub-id]`; a `reg-event-*` under `[:event event-id]`. So the lookup
+;; MUST pivot on the registry kind the failing `id` was registered with,
+;; not assume `:event`.
+;;
+;; The error categories carry that kind: a `:rf.error/sub-*` record's
+;; `:event-id` slot holds a SUB id (the call sites in `subs.cljc` /
+;; `subs/memo.cljc` pass `query-id`), so its coords live under `[:sub …]`.
+;; All other production categories (handler / interceptor / cofx / flow /
+;; reserved-fx / no-such-handler) carry an EVENT id under `[:event …]`.
+;;
+;; `:rf.error/frame-destroyed` is the one shared category — fired with an
+;; EVENT id from `router.cljc` (a dispatch into a destroyed frame) AND with
+;; a SUB id from `subs.cljc` (a subscribe into a destroyed frame). We can't
+;; disambiguate on the kw alone, so for it we try `:sub` then `:event`
+;; (a sub-id never collides with an event-id under the same registry, so
+;; the first hit is unambiguous; a miss falls through to nil → slot absent).
+
+(def ^:private sub-error-categories
+  "Categories whose `:event-id` slot carries a SUB id — their source
+  coords live under `[:sub sub-id]` in the always-on registry. Per
+  rf2-bxud9v: `dispatch-on-error!` looked these up under `[:event …]`
+  (the hardcoded default), so the always-on production error records
+  for the parametric input-fn failures (and the reactive sub-exception)
+  omitted the failing sub's `:source-coord`."
+  #{:rf.error/sub-input-fn-exception
+    :rf.error/sub-input-fn-bad-return
+    :rf.error/sub-exception
+    :rf.error/no-such-sub})
+
+(defn- error-source-coord
+  "Resolve the `{:ns :file :line}` source-coord for the failing `id` of an
+  `error-kw` category, pivoting on the registry kind the `id` was
+  registered with (rf2-bxud9v). Returns nil when no coords were captured
+  (programmatic registration that bypassed the macro path, or an id that
+  was never registered) — the caller `cond->`s the slot in, so nil means
+  the `:source-coord` slot is ABSENT from the record rather than nil.
+
+    - `:rf.error/sub-*` categories → look under `[:sub id]`.
+    - `:rf.error/frame-destroyed` is fired with both an event-id (router)
+      and a sub-id (subs), so try `[:sub id]` first then `[:event id]`.
+    - every other category → look under `[:event id]`."
+  [error-kw id]
+  (when id
+    (cond
+      (contains? sub-error-categories error-kw)
+      (source-coords/error-coords-for :sub id)
+
+      (= :rf.error/frame-destroyed error-kw)
+      (or (source-coords/error-coords-for :sub id)
+          (source-coords/error-coords-for :event id))
+
+      :else
+      (source-coords/error-coords-for :event id))))
+
 ;; ---- emission -------------------------------------------------------------
 
 (defn- emit-policy-exception!
@@ -232,15 +292,20 @@
   layers cannot static-require this ns — load cycle). Returns nil."
   [error-kw event event-id frame-id exception elapsed-ms time error-event]
   (let [;; Per rf2-3un2g §Always-on error-coord registry: source-coords
-        ;; for the failing handler ride the always-on parallel registry
-        ;; (NOT the public registry-meta — which is stripped of coord-
-        ;; keys under CLJS `:advanced + goog.DEBUG=false`). The lookup
-        ;; here surfaces `{:ns :file :line}` for Sentry-style shippers
-        ;; and the per-frame `:on-error` policy fn in BOTH dev AND
-        ;; production. Returns nil for programmatic registrations that
+        ;; for the failing handler/sub ride the always-on parallel
+        ;; registry (NOT the public registry-meta — which is stripped of
+        ;; coord-keys under CLJS `:advanced + goog.DEBUG=false`). The
+        ;; lookup here surfaces `{:ns :file :line}` for Sentry-style
+        ;; shippers and the per-frame `:on-error` policy fn in BOTH dev
+        ;; AND production. Returns nil for programmatic registrations that
         ;; bypassed the macro path — that's fine; the slot is absent
         ;; from the record / tags rather than nil.
-        source-coord (when event-id (source-coords/error-coords-for :event event-id))
+        ;;
+        ;; Per rf2-bxud9v the lookup is KIND-AWARE: the registry is keyed
+        ;; by `[registry-kind id]`, so a sub-id (`:rf.error/sub-*`
+        ;; categories) must resolve under `[:sub …]`, not the hardcoded
+        ;; `[:event …]`. See [[error-source-coord]] / [[sub-error-categories]].
+        source-coord (error-source-coord error-kw event-id)
         ;; Per-path wire-walker: paths flagged `:sensitive?` / `:large?`
         ;; via the per-frame `[:rf/runtime :elision]` registry get their
         ;; per-path substitutions.

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -166,21 +166,32 @@
   in v2 — `reg-sub-raw` is dropped (per Spec 002 §Subscriptions
   composing).
 
-  Three shapes:
+  Four shapes — one per input-producer kind (Spec 006 §Subscription
+  input producers):
 
-      ;; Layer-1 — reads `app-db` directly.
+      ;; :db — Layer-1: reads `app-db` directly (no input producer).
       (reg-sub :id
         (fn [db query-v] ...derived-value...))
 
-      ;; Layer-2, single input — chains off one upstream sub.
+      ;; :static, single input — the literal `:<-` producer chains off
+      ;; one upstream sub.
       (reg-sub :id
         :<- [:upstream-id]
         (fn [upstream-val query-v] ...derived-value...))
 
-      ;; Layer-2, multi input — chains off N upstream subs.
+      ;; :static, multi input — the literal `:<-` producer chains off N
+      ;; upstream subs.
       (reg-sub :id
         :<- [:a-sub]
         :<- [:b-sub]
+        (fn [[a-val b-val] query-v] ...derived-value...))
+
+      ;; :parametric — an `input-fn` producer (two trailing fns, NO `:<-`
+      ;; chain). The first fn is a pure `query-v -> vector-of-query-vectors`
+      ;; that computes the inputs PER concrete query; the second is the
+      ;; computation fn over those realized inputs.
+      (reg-sub :id
+        (fn [query-v] [[:a (second query-v)] [:b]])   ;; input-fn
         (fn [[a-val b-val] query-v] ...derived-value...))
 
   An optional metadata-map may precede the `:<-` chain / handler:
@@ -1224,14 +1235,18 @@
                               ;; `:error-emit/dispatch-on-error` late-bind hook
                               ;; (subs cannot static-require `re-frame.error-emit`
                               ;; — load cycle). A pure `compute-sub` has no
-                              ;; triggering event vector, so `:event` / `:event-id`
-                              ;; are nil.
+                              ;; triggering event vector OR reactive frame, so
+                              ;; `:frame` is nil; per rf2-bxud9v the failing sub's
+                              ;; `query-v` / `query-id` ride `:event` / `:event-id`
+                              ;; (mirroring the sub-input-fn path) so the kind-aware
+                              ;; error-emit lookup resolves the sub's `:source-coord`
+                              ;; under `[:sub query-id]` for off-box shippers.
                               (when-let [dispatch-on-error!
                                          (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
                                 (dispatch-on-error!
                                   :rf.error/sub-exception
-                                  nil                       ;; event (pure compute — none)
-                                  nil                       ;; event-id
+                                  query-v                   ;; failing query-vector (as :event)
+                                  query-id                  ;; sub-id (as :event-id) — drives [:sub …] coord lookup
                                   nil                       ;; frame (pure compute — no reactive frame)
                                   e
                                   0                         ;; elapsed-ms

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -383,7 +383,11 @@
           ;; leaks `:exception` / message; that detail rides the trace +
           ;; off-box listener record only (Spec 011 §Internal trace
           ;; events are not leaked). A reactive sub has no triggering
-          ;; event vector, so `:event` / `:event-id` are nil.
+          ;; event vector, but per rf2-bxud9v the failing sub's `query-v`
+          ;; / `query-id` ride `:event` / `:event-id` (mirroring the
+          ;; sub-input-fn path) so the kind-aware error-emit lookup
+          ;; resolves the sub's `:source-coord` under `[:sub query-id]`
+          ;; for off-box shippers — `:frame` already carries `frame-id`.
           ;;
           ;; Reached via the late-bind hook `:error-emit/dispatch-on-
           ;; error` — this subs layer cannot statically require
@@ -405,8 +409,8 @@
                      (late-bind/get-fn-cached :error-emit/dispatch-on-error)]
             (dispatch-on-error!
               :rf.error/sub-exception
-              nil                                 ;; event (reactive — none)
-              nil                                 ;; event-id
+              query-v                             ;; failing query-vector (as :event)
+              query-id                            ;; sub-id (as :event-id) — drives [:sub …] coord lookup
               frame-id
               e
               0                                   ;; elapsed-ms

--- a/implementation/core/test/re_frame/on_error_test.cljc
+++ b/implementation/core/test/re_frame/on_error_test.cljc
@@ -486,6 +486,77 @@
         (is (some? r) "listener received :rf.error/sub-exception from compute-sub")
         (is (some? (:exception r)) ":exception present on the record")))))
 
+;; ============================================================================
+;; rf2-bxud9v — sub error records carry the failing SUB's source-coord.
+;; ----------------------------------------------------------------------------
+;; The always-on `error-coords-by-id` registry is keyed by `[registry-kind
+;; id]`. A `reg-sub` stores coords under `[:sub sub-id]`, but
+;; `dispatch-on-error!` previously looked source coords up under the
+;; hardcoded `[:event event-id]` — so the production error records for the
+;; sub categories (whose `:event-id` slot carries a SUB id) OMITTED the
+;; failing sub's `:source-coord`. The fix is a kind-aware lookup
+;; (`error-emit/error-source-coord`) that resolves the sub categories under
+;; `[:sub …]`. These tests pin that the records now carry the right coord.
+;; ============================================================================
+
+(deftest sub-input-fn-error-record-carries-sub-source-coord
+  (testing "Per rf2-bxud9v: a parametric `input-fn` throw fans
+            `:rf.error/sub-input-fn-exception` through the always-on
+            listener with `query-id` in `:event-id`. The record's
+            `:source-coord` must resolve under `[:sub …]` (kind-aware
+            lookup) — the sub was registered via the public `reg-sub`
+            macro path, so its coords ride the always-on registry."
+    (let [seen (atom [])]
+      (rf/register-error-listener! :test/recorder
+                                   (fn [record] (swap! seen conj record)))
+      ;; Parametric sub: input-fn (arity-1) THROWS at materialization.
+      ;; Registered via the public macro so `[:sub …]` coords are captured.
+      (rf/reg-sub :bxud9v/input-throws
+                  (fn [_q] (throw (ex-info "input-fn-boom" {})))
+                  (fn [_in _q] :unreachable))
+      ;; Reactive subscribe path → `compute-and-cache!` runs the input-fn,
+      ;; catches the throw, emits :rf.error/sub-input-fn-exception, recovers nil.
+      (is (nil? (rf/subscribe-once :rf/default [:bxud9v/input-throws]))
+          "subscribe recovers to nil on an input-fn throw")
+      (let [r (some (fn [x] (when (= :rf.error/sub-input-fn-exception (:error x)) x)) @seen)]
+        (is (some? r) "listener received :rf.error/sub-input-fn-exception")
+        (is (= :bxud9v/input-throws (:event-id r))
+            "the failing sub-id rides :event-id")
+        (is (some? (:exception r)) ":exception present (input-fn threw)")
+        ;; The kind-aware lookup resolves the coord under [:sub sub-id].
+        (let [sc (:source-coord r)]
+          (is (some? sc)
+              "record carries :source-coord resolved under [:sub …] (rf2-bxud9v)")
+          (is (symbol?  (:ns   sc)) ":source-coord :ns is the defining ns symbol")
+          (is (integer? (:line sc)) ":source-coord :line is the reg-sub line")
+          (is (string?  (:file sc)) ":source-coord :file is the defining file"))))))
+
+(deftest sub-exception-record-carries-sub-source-coord
+  (testing "Per rf2-bxud9v: a reactive sub whose body throws fans
+            `:rf.error/sub-exception` through the always-on listener;
+            its `:source-coord` resolves under `[:sub …]` now that the
+            reactive call site supplies `query-id` in `:event-id` and the
+            lookup is kind-aware."
+    (let [seen (atom [])]
+      (rf/register-error-listener! :test/recorder
+                                   (fn [record] (swap! seen conj record)))
+      ;; Layer-1 sub whose body throws on the reactive run.
+      (rf/reg-sub :bxud9v/body-throws
+                  (fn [_db _q] (throw (ex-info "body-boom" {}))))
+      (is (nil? (rf/subscribe-once :rf/default [:bxud9v/body-throws]))
+          "reactive subscribe recovers to nil on a body throw")
+      (let [r (some (fn [x] (when (= :rf.error/sub-exception (:error x)) x)) @seen)]
+        (is (some? r) "listener received :rf.error/sub-exception")
+        (is (= :bxud9v/body-throws (:event-id r))
+            "the failing sub-id rides :event-id (rf2-bxud9v)")
+        (is (some? (:exception r)) ":exception present on the record")
+        (let [sc (:source-coord r)]
+          (is (some? sc)
+              "record carries :source-coord resolved under [:sub …] (rf2-bxud9v)")
+          (is (symbol?  (:ns   sc)))
+          (is (integer? (:line sc)))
+          (is (string?  (:file sc))))))))
+
 (deftest non-recovery-categories-do-not-invoke-on-error-policy
   (testing "Per rf2-2hvga axis-2 (NARROW): the per-frame `:on-error`
             policy fn (#5) is NOT invoked for invalid-operation /


### PR DESCRIPTION
rf2-bxud9v (P3 BUG): the always-on error-emit substrate looked source-coords up under the hardcoded `[:event event-id]`, but the always-on `error-coords-by-id` registry is keyed by `[registry-kind id]` and `reg-sub` stores coords under `[:sub sub-id]`. Since the sub categories pass the failing SUB id in `:event-id`, the production error records for `:rf.error/sub-input-fn-exception` / `:rf.error/sub-input-fn-bad-return` (and the reactive `:rf.error/sub-exception`) OMITTED the failing sub's `:source-coord`. Fix: a kind-aware lookup (`error-emit/error-source-coord` + `sub-error-categories`) that resolves the sub categories under `[:sub …]`, with a try-`:sub`-then-`:event` fallback for the shared `:rf.error/frame-destroyed` category. The two reactive/compute sub-exception call sites now also supply `query-id` in `:event-id` (mirroring the sub-input-fn path) so the kind-aware lookup can resolve their coord. New `register-error-listener` tests pin that sub-input-fn-exception (reactive) and sub-exception records carry `:source-coord` resolved under `[:sub …]` with `:ns`/`:line`/`:file`.

rf2-yfxwh4 (P4): the source-of-truth `re-frame.subs/reg-sub` full docstring documented only the `:db` + `:<-` shapes and omitted the `:parametric` input-fn producer shape. Added the `:parametric` shape (Four shapes now), matching the core.cljc macro docstring + API + Spec 006. Docstring only, no behavior change.

## Quality gates
- `npm run test:cljs` — 6015 tests, 21343 assertions, 0 failures, 0 errors
- core `clojure -M:test` — 988 tests, 4333 assertions, 0 failures, 0 errors
- security `clojure -M:test` — 56 tests, 449 assertions, 0 failures, 0 errors
- Probed the new bxud9v test executes + the fix works (inverted assertion FAILED on the populated `:source-coord` {:ns re-frame.on-error-test :file ... :line 514 :column 7}, then reverted).