### PR TITLE
docs: reconcile stale :rf/runtime app-db-path comments to runtime-db (rf2-h0r2wj rf2-z5mjuj)

### DIFF
--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -280,7 +280,7 @@
   gated like the dev trace. Every caller MUST keep identifiers tight,
   elide `:event` (done here via the wire-walker), and carry NO raw
   app-db slice. Sensitive-data redaction on this path is path-based:
-  the per-frame `[:rf/runtime :elision]` registry's `:sensitive-
+  the per-frame `:rf.runtime/elision` registry's `:sensitive-
   declarations` drive the wire-walker's per-slot substitutions.
   Handler-meta `:sensitive?` is no longer consulted (path-marked
   classification is the v2 mechanism; separate spec doc; in progress).
@@ -307,7 +307,7 @@
         ;; `[:event …]`. See [[error-source-coord]] / [[sub-error-categories]].
         source-coord (error-source-coord error-kw event-id)
         ;; Per-path wire-walker: paths flagged `:sensitive?` / `:large?`
-        ;; via the per-frame `[:rf/runtime :elision]` registry get their
+        ;; via the per-frame `:rf.runtime/elision` registry get their
         ;; per-path substitutions.
         elided-event (elision/elide-wire-value event {:frame frame-id})
         record       (cond-> {:error      error-kw

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -200,7 +200,7 @@
 ;;   1. The captured trace stream already stamps `:sensitive?` per
 ;;      handler-meta scope — if any event in `:trace-events` carries the
 ;;      stamp, the record's cascade involved sensitive material.
-;;   2. The frame's schema-declared `[:rf/runtime :elision :sensitive-declarations]`
+;;   2. The frame's schema-declared `[:rf.runtime/elision :sensitive-declarations]`
 ;;      registry names paths that hold sensitive data; if any such path
 ;;      resolves to a non-nil leaf in `:db-before` or `:db-after`, the
 ;;      record's app-db state carries sensitive material.
@@ -265,7 +265,7 @@
 ;; Per Security.md §Epoch privacy posture and rf2-dl3gx (follow-on to
 ;; rf2-bz1cl's Xray-side heuristic chip): the record carries a
 ;; top-level integer count of schema-declared sensitive paths
-;; (`[:rf/runtime :elision :sensitive-declarations]`) whose value differs between
+;; (`[:rf.runtime/elision :sensitive-declarations]`) whose value differs between
 ;; `:db-before` and `:db-after`. Computed inside `build-record` from RAW
 ;; values BEFORE the installed `:redact-fn` runs — parallel to the
 ;; `:rf.epoch/sensitive?` rollup pattern just above.

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -261,7 +261,7 @@
           ;; slice's root the wrapped value lives — `:result` and
           ;; `:before` BOTH live at the flow's output path; each
           ;; `:input-values` entry is the value at the matching input
-          ;; path. The walker reads `[:rf/runtime :elision
+          ;; path. The walker reads `[:rf.runtime/elision
           ;; :declarations <path>]` and emits the marker for
           ;; schema-declared large slots.
           ;;

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -369,7 +369,7 @@
 ;; the schema-first wire walker (`elision/elide-wire-value`) already reads.
 ;; We translate the registration's output-rooted marks into ABSOLUTE app-db
 ;; declarations rooted at `(:path flow)` and write them into the frame's
-;; `[:rf/runtime :elision :sensitive-declarations]` / `:declarations` slots.
+;; `[:rf.runtime/elision :sensitive-declarations]` / `:declarations` slots.
 ;;
 ;; ONE walker then covers BOTH channels:
 ;;   - the flow trace `:result` / `:before` already ride

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -338,7 +338,7 @@
      :path             path
      :snapshot         snapshot
      ;; `:existing-snap?` records whether the handler found a snapshot
-     ;; ALREADY in app-db at entry. It distinguishes the two FRESH
+     ;; ALREADY in runtime-db at entry. It distinguishes the two FRESH
      ;; flavours for the `:rf.machine/started` `:cause` (rf2-gl588):
      ;;   - nil snapshot  → singleton (`:explicit` / `:lazy`, by trigger);
      ;;   - present + `:rf/bootstrap-pending?` → spawn-pre-seeded (`:spawned`).
@@ -351,7 +351,7 @@
   "Compute the `:rf.machine.start/cause` enum for a `maybe-boot` that ran
   the initial-entry cascade (rf2-gl588). Three-way, per Mike 2026-06-03:
 
-    - `:spawned`  — the handler found a snapshot ALREADY in app-db (the
+    - `:spawned`  — the handler found a snapshot ALREADY in runtime-db (the
                     spawn fx pre-seeded it + stamped `:rf/bootstrap-pending?`);
                     init ran on the actor's first dispatch.
     - `:explicit` — no pre-existing snapshot (singleton) AND the dispatched

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc
@@ -37,7 +37,7 @@
 (defn update-snapshot-fx
   "fx handler for `:rf.machine/update-snapshot`. Merges the spec-permitted
   keys of `:rf/patch` onto the snapshot at `[:rf.runtime/machines :snapshots <machine-id>]`
-  in the emitting frame's app-db. No-op when the actor has no snapshot
+  in the emitting frame's runtime-db. No-op when the actor has no snapshot
   (destroyed / not-yet-materialised) or when `:rf/machine-id` is absent.
   Per Spec 005 §Snapshot-level escape hatch."
   [{frame-id :frame :or {frame-id :rf/default}} args]

--- a/implementation/routing/src/re_frame/routing/scroll.cljc
+++ b/implementation/routing/src/re_frame/routing/scroll.cljc
@@ -6,10 +6,10 @@
   saved-position map at `[:rf.runtime/routing :scroll-positions]`,
   LRU-capped by `scroll-positions-cap`. Recency anchor lives at
   `[:rf.runtime/routing :scroll-positions-order]` as an internal
-  vector. Both sit under the framework-owned `:rf/runtime` root
-  (spec/Conventions §Reserved app-db keys, Spec-Schemas §`:rf/runtime`)
-  so all routing runtime state in app-db sits beneath the single
-  framework root.
+  vector. Both sit under the framework-owned `:rf.runtime/routing`
+  child of the runtime-db partition (spec/Conventions §Reserved
+  runtime-db keys) so all routing runtime state lives in runtime-db,
+  not in app-db.
 
   Internal namespace; the public facade is `re-frame.routing`. The
   facade owns the two `fx/reg-fx` calls so a `:reload` re-wires them on
@@ -22,19 +22,21 @@
   "Soft upper bound on tracked URLs in the per-frame scroll-positions map.
   Sized for typical SPA navigation depth — large enough that real
   Back-button restoration hits saved positions, small enough that the
-  per-frame app-db slice stays bounded over long sessions."
+  per-frame runtime-db slice stays bounded over long sessions."
   50)
 
 (defn lookup-scroll-position
-  "Return the saved [x y] for url in this frame's app-db, or nil if none."
+  "Return the saved [x y] for url in this frame's runtime-db, or nil if none.
+  `db` is the runtime-db value."
   [db url]
   (get-in db [:rf.runtime/routing :scroll-positions url]))
 
 (defn save-scroll-position
-  "Pure: return db with the scroll position for url recorded at
-  [:rf.runtime/routing :scroll-positions url]. Used inside :db effect
-  maps so scroll positions live under the frame boundary (Spec 012
-  §Multi-frame routing). The map is LRU-capped at `scroll-positions-cap`
+  "Pure: return runtime-db with the scroll position for url recorded at
+  [:rf.runtime/routing :scroll-positions url]. Applied to the frame's
+  runtime-db partition (via `swap-runtime-db!`) so scroll positions live
+  under the frame boundary (Spec 012 §Multi-frame routing). `db` is the
+  runtime-db value. The map is LRU-capped at `scroll-positions-cap`
   entries — re-saving an existing url promotes it to most-recent; new
   saves past the cap evict the least-recently-used entry."
   [db url xy]

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -223,9 +223,9 @@
 (late-bind/set-fn! :schemas/set-schema-fns!       set-schema-fns!)
 
 ;; Schema-walker hooks consumed by `re-frame.elision` to feed the
-;; unified `[:rf/runtime :elision]` registry without statically depending on the
+;; unified `:rf.runtime/elision` registry without statically depending on the
 ;; schemas artefact. Per rf2-ynnq0 Option A — schemas owns the deep
-;; walker; the elision artefact owns the app-db write. The Path D impl
+;; walker; the elision artefact owns the runtime-db write. The Path D impl
 ;; (rf2-w3n5u) wires `re-frame.elision/populate-elision-from-schemas!`
 ;; to consume these two hooks; the per-slot extract-* hooks are the
 ;; single surface elision needs.

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -365,14 +365,14 @@
 ;; re-registration") and §Registry feeder (rf2-c1l4d): the runtime walks
 ;; every registered app-schema and writes the `{:large? true …}` /
 ;; `{:sensitive? true …}` declarations into the frame's
-;; `[:rf/runtime :elision :declarations]` / `[:rf/runtime :elision :sensitive-declarations]`
+;; `[:rf.runtime/elision :declarations]` / `[:rf.runtime/elision :sensitive-declarations]`
 ;; slots. `re-frame.router` already refreshes these per-dispatch via the
 ;; same `:elision/populate-from-schemas!` hook, but that leaves a gap for
 ;; wire-boundary emits / digests that fire BEFORE the first dispatch
 ;; (boot-time SSR serialise, initial epoch snapshot). Populating at
 ;; registration closes that gap and matches the spec's "on re-registration"
 ;; contract. Best-effort: the hook is a no-op when the elision artefact is
-;; absent, and the elision write itself no-ops when the frame's app-db
+;; absent, and the elision write itself no-ops when the frame's runtime-db
 ;; container does not exist yet (registration before frame creation).
 ;;
 ;; PERF (rf2-ee38b.6): `:elision/populate-from-schemas!` re-walks EVERY
@@ -685,7 +685,7 @@
 ;;      live `app-db` value at the path fails the new shape (Spec 010
 ;;      §Schema migration on hot-reload). See `maybe-emit-schema-violation!`.
 ;;   2. Schema-derived elision-registry refresh — re-populates the
-;;      frame's `[:rf/runtime :elision …]` declarations so size-elision / privacy
+;;      frame's `[:rf.runtime/elision …]` declarations so size-elision / privacy
 ;;      stays in sync with the schema set (Spec 010 §`:large?` /
 ;;      §Registry feeder). See `populate-elision-for-frame!`.
 ;; Both are gated on `interop/debug-enabled?` and DCE'd in production.

--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -6,18 +6,18 @@
   (`:large? true` or `:sensitive? true`) in its per-slot properties
   (per Spec-Schemas §`:rf/app-schema-meta` — the per-slot metadata
   vocabulary) is registered into the frame's
-  `[:rf/runtime :elision :declarations]` (`:large?`) or
-  `[:rf/runtime :elision :sensitive-declarations]` (`:sensitive?`) slot
+  `[:rf.runtime/elision :declarations]` (`:large?`) or
+  `[:rf.runtime/elision :sensitive-declarations]` (`:sensitive?`) slot
   with `:source :schema`. Both registries are sibling slots under the
-  shared `[:rf/runtime :elision]` sub-container; flags compose
+  shared `:rf.runtime/elision` runtime-db sub-tree; flags compose
   orthogonally — a slot may carry either or both, and the validation
   walker resolves the conflict at emit time. Storing them separately
   keeps the per-flag query
-  (`(get-in db [:rf/runtime :elision :sensitive-declarations <path>])`)
+  (`(get-in runtime-db [:rf.runtime/elision :sensitive-declarations <path>])`)
   O(1) without value-shape inspection.
 
   This file owns the **walker** that maps a registered schema's EDN form
-  to a `{path declaration}` map; the actual app-db write lives in
+  to a `{path declaration}` map; the actual runtime-db write lives in
   `re-frame.elision` (rf2-v9tw2) so that file owns the unified registry
   surface for schema-owned declarations. The seam between the two is
   the per-flag late-bind hook registered by the outer façade.
@@ -273,7 +273,7 @@
   Spec 009 §Size elision in traces — the schema-driven nomination path.
 
   Returned declarations carry `:source :schema` per Spec 009 —
-  introspection (`(get-in db [:rf/runtime :elision :declarations <path>])`)
+  introspection (`(get-in runtime-db [:rf.runtime/elision :declarations <path>])`)
   reports schema provenance for wire-boundary elision."
   [schema base-path]
   (walk-flagged-schema :large? schema base-path {}))

--- a/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
@@ -14,7 +14,7 @@
        (\"at boot, and on `reg-app-schema` re-registration\") + §Registry
        feeder (rf2-c1l4d). Registering a schema with `:large?` /
        `:sensitive?` per-slot flags writes the corresponding declarations
-       into the frame's `[:rf/runtime :elision …]` slots so size-elision / privacy
+       into the frame's `[:rf.runtime/elision …]` slots so size-elision / privacy
        redaction is live for wire emits — including those that fire BEFORE
        the first dispatch (the gap the per-dispatch router refresh leaves).
 
@@ -151,7 +151,7 @@
 (deftest reg-app-schema-populates-large-declarations
   (testing "rf2-ee38b.6 — registering a schema with a `:large?` per-slot
             flag writes the declaration into
-            [:rf/runtime :elision :declarations] at registration time
+            [:rf.runtime/elision :declarations] at registration time
             (no dispatch required)"
     (rf/reg-app-schema [:user]
                        [:map
@@ -165,7 +165,7 @@
 (deftest reg-app-schema-populates-sensitive-declarations
   (testing "rf2-ee38b.6 — registering a schema with a `:sensitive?`
             per-slot flag writes the declaration into
-            [:rf/runtime :elision :sensitive-declarations] at registration time"
+            [:rf.runtime/elision :sensitive-declarations] at registration time"
     (rf/reg-app-schema [:auth]
                        [:map [:token {:sensitive? true} :string]])
     (let [decls (elision/sensitive-declarations :rf/default)]


### PR DESCRIPTION
Comment/docstring-only sweep. After the EP-0001 runtime-db migration (rf2-vzld77), durable framework state moved to the runtime-db partition (`[:rf.runtime/* ...]`). Several NON-executable comments/docstrings in files NOT touched by that PR still described the retired app-db `[:rf/runtime ...]` placement. Executable code is already correct; this reconciles the stale text. No behavior change.

Sites fixed: schemas (walker.cljc 9-16/20/276, storage.cljc 368/375/688, schemas.cljc 226/228, schemas_reg_side_effects_test.clj 17/154/168), flows (flows.cljc 264, registry.cljc 372), core/error_emit.cljc (283/310), routing/scroll.cljc (ns header 9-12 + scroll-positions-cap/lookup-scroll-position/save-scroll-position docstrings — now runtime-db via swap-runtime-db!, not a :db effect), epoch/assembly.cljc (203/268 — rf2-z5mjuj), machines/lifecycle_fx (registration.cljc 341/354, update_snapshot.cljc 40).

Mapping applied: `[:rf/runtime :elision ...]` -> `[:rf.runtime/elision ...]`, `[:rf/runtime :routing ...]` -> `[:rf.runtime/routing ...]` (Conventions Reserved runtime-db keys).

## Sites SKIPPED (for follow-up, concurrency-safety)
- core.cljc facade docstrings (1082/1140/1477/1483), core_machines.cljc:54, core_routing.cljc:71 — core facade, concurrently edited by other workers.
- subs/memo.cljc:200 — subs.cljc concurrently edited.
- flows/test/flows_trace_test.clj:717 — comment describes pre-migration WIPE behavior (a replacing :db handler clobbering the elision slot), not just a path label; under the partition that wipe is structurally impossible, so the test's defensive `merge` setup may be vestigial. Needs behavior-aware review beyond comment-only scope.
- Correctly-historical refs left as-is (NOT stale): machines/paths.cljc:8 ('retired app-db :rf/runtime root'), dropped_snapshot_diagnostic_test.clj (deliberately describes pre-migration state).

## Quality gates
- `clojure -M:test` green for every touched artefact: schemas (274 tests / 18593 assertions), flows (165/4676), routing (160/784), machines (564/1771), epoch (278/1074), core (998/4352). 0 failures, 0 errors.
- `git grep :rf/runtime` over all touched files: clean (no stale path remains).
- No docs touched (check_doc_slugs.py N/A).