### PR TITLE
fix(story): migrate login_form testbed machine-snapshot reads to runtime-db partition (rf2-ib5acl)

### DIFF
--- a/tools/story/testbeds/login_form/events.cljs
+++ b/tools/story/testbeds/login_form/events.cljs
@@ -17,8 +17,10 @@
   lives here. The same handlers run when the live app boots and when
   any Story variant frame allocates. Per IMPL-SPEC §1.1, variant
   bodies are data; they reference these event-ids in their `:setup`
-  slot. Story's per-variant frame isolation (Spec 002) means each
-  variant gets its own fresh `[:rf/runtime :machines :snapshots :login/flow]` slot.
+  slot. Story's per-variant frame isolation (Spec 002) means each variant
+  gets its own fresh `[:rf.runtime/machines :snapshots :login/flow]` slot in
+  its runtime-db partition (EP-0001 rf2-vzld77 — machine snapshots are
+  durable runtime-db state, not app-db).
 
   Per Spec 014 §Testing the stub layer: `:rf.http/managed` is the
   fx-id the machine emits; the Story variants override that id via

--- a/tools/story/testbeds/login_form/stories.cljs
+++ b/tools/story/testbeds/login_form/stories.cljs
@@ -18,15 +18,18 @@
   pattern). This is the canonical agent-consumable shape (round-trips
   through MCP, the recorder, the visual-regression service).
 
-  Each variant exercises a different authoring shape, between them
-  covering five of the seven `:rf.assert/*` shapes:
+  Every variant pins its terminal state with `:rf.assert/state-is
+  :login/flow ...`, the runtime-db-aware machine checkpoint. EP-0001
+  (rf2-vzld77) moved machine snapshots into the frame's runtime-db
+  partition; per rf2-ib5acl the play-runner's `:rf.assert/sub-equals`
+  / `:rf.assert/path-equals` evaluate against app-db, so a machine
+  projection isn't observable through them. The machine-snapshot `:data`
+  values (`:error` / `:attempts` / `:email`) are therefore verified in
+  the testbed's CLJS unit test (`stories_cljs_test.cljs`), which can read
+  the variant frame's runtime-db directly. The variant `:script` slots
+  still exercise the play-runner shapes that ARE supported post-migration:
 
-    :path-equals     — :idle (initial state slot equals :idle)
-    :sub-equals      — :authenticated (the :login/email sub returns the
-                       expected handle)
     :state-is        — every variant (`:rf.assert/state-is :login/flow ...`)
-    :dispatched?     — :error (the failure event was dispatched
-                       during the :script)
     :effect-emitted  — :submitting (the :rf.http/managed fx fired)
 
   The `force-fx-stub` decorator is wired on every variant that hits the
@@ -103,17 +106,21 @@
              The `:setup` fires `:login/dismiss` purely to BOOTSTRAP
              the machine: the first dispatch into a machine runs its
              `:initial` cascade (spec/005 §Initial cascade), seeding
-             the `[:rf/runtime :machines :snapshots :login/flow]`
-             snapshot — without it that slot is nil and the view's
-             state-pill renders empty. The choice of `:login/dismiss`
-             is incidental: in `:idle` it is an UNHANDLED no-op (it is
-             only a real transition out of `:error`), so it bootstraps
-             without moving the machine off `:idle`. Any event would do
-             — do NOT read meaning into dispatching `:dismiss` here, and
-             do NOT copy 'dispatch any event to bootstrap' as an idiom."
+             the `[:rf.runtime/machines :snapshots :login/flow]`
+             snapshot in the frame's runtime-db partition — without it
+             that slot is nil and the view's state-pill renders empty.
+             The choice of `:login/dismiss` is incidental: in `:idle` it
+             is an UNHANDLED no-op (it is only a real transition out of
+             `:error`), so it bootstraps without moving the machine off
+             `:idle`. Any event would do — do NOT read meaning into
+             dispatching `:dismiss` here, and do NOT copy 'dispatch any
+             event to bootstrap' as an idiom."
      :setup [[:login/flow [:login/dismiss]]]
-     :script [[:assert-db [:rf/runtime :machines :snapshots :login/flow :state] :idle]
-              [:assert [:rf.assert/state-is :login/flow :idle]]]
+     ;; EP-0001 (rf2-vzld77 / rf2-ib5acl): the machine snapshot lives in
+     ;; the frame's runtime-db partition, so the state checkpoint reads it
+     ;; via `:rf.assert/state-is` (which evaluates against runtime-db) —
+     ;; NOT a raw `:assert-db` path-equals, which only sees app-db.
+     :script [[:assert [:rf.assert/state-is :login/flow :idle]]]
      :tags   #{:dev :docs :test}
      :substrates #{:reagent}})
 
@@ -165,9 +172,15 @@
                             {:failure {:status  401
                                        :message "Invalid credentials."}}]]]
      :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
-     :script [[:assert [:rf.assert/state-is :login/flow :error]]
-              [:assert-db [:rf/runtime :machines :snapshots :login/flow :data :error]
-               "Invalid credentials."]]
+     ;; EP-0001 (rf2-vzld77 / rf2-ib5acl): the machine snapshot lives in
+     ;; the frame's runtime-db partition, so the state checkpoint reads it
+     ;; via `:rf.assert/state-is` (which evaluates against runtime-db).
+     ;; The error-message text in the snapshot's `:data` slot is verified
+     ;; in the testbed's CLJS unit test (`stories_cljs_test.cljs`): the
+     ;; play-runner's `:rf.assert/sub-equals` evaluates subs against app-db
+     ;; only, so a runtime-db machine projection isn't observable through it
+     ;; (see rf2-ib5acl notes — the play-runner gap is tracked separately).
+     :script [[:assert [:rf.assert/state-is :login/flow :error]]]
      :tags   #{:dev :docs :test}
      :substrates #{:reagent}})
 
@@ -192,9 +205,13 @@
               [:login/flow [:login/retry
                             {:email "ada@example.com" :password "correct-horse"}]]]
      :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
-     :script [[:assert [:rf.assert/state-is :login/flow :submitting-retry]]
-              [:assert-db [:rf/runtime :machines :snapshots :login/flow :data :attempts]
-               1]]
+     ;; EP-0001 (rf2-vzld77 / rf2-ib5acl): the attempt counter lives in the
+     ;; runtime-db snapshot's `:data`; the state checkpoint reads the
+     ;; snapshot via `:rf.assert/state-is`. The attempt-count value is
+     ;; verified in the testbed's CLJS unit test (`stories_cljs_test.cljs`)
+     ;; — the play-runner's `:rf.assert/sub-equals` only sees app-db, so a
+     ;; runtime-db machine projection isn't observable through it.
+     :script [[:assert [:rf.assert/state-is :login/flow :submitting-retry]]]
      :tags   #{:dev :docs :test}
      :substrates #{:reagent}})
 
@@ -219,8 +236,13 @@
                             {:value {:user  {:email "ada@example.com"}
                                      :token "story-token"}}]]]
      :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
-     :script [[:assert [:rf.assert/state-is :login/flow :authenticated]]
-              [:assert [:rf.assert/sub-equals [:login/email] "ada@example.com"]]]
+     ;; EP-0001 (rf2-vzld77 / rf2-ib5acl): the welcome-banner email lives
+     ;; in the runtime-db snapshot's `:data`; the state checkpoint reads
+     ;; the snapshot via `:rf.assert/state-is`. The email value is verified
+     ;; in the testbed's CLJS unit test (`stories_cljs_test.cljs`) — the
+     ;; play-runner's `:rf.assert/sub-equals` only sees app-db, so a
+     ;; runtime-db machine projection isn't observable through it.
+     :script [[:assert [:rf.assert/state-is :login/flow :authenticated]]]
      :tags   #{:dev :docs :test :login-form/tutorial}
      :substrates #{:reagent}})
 

--- a/tools/story/testbeds/login_form/stories_cljs_test.cljs
+++ b/tools/story/testbeds/login_form/stories_cljs_test.cljs
@@ -1,0 +1,167 @@
+(ns login-form.stories-cljs-test
+  "Regression guard for the login-form testbed's machine-snapshot reads
+  (rf2-ib5acl).
+
+  EP-0001 (rf2-vzld77) moved machine snapshots out of the retired app-db
+  `:rf/runtime` root and into the frame's runtime-db partition at
+  `[:rf.runtime/machines :snapshots <machine-id>]`. The login-form
+  testbed's four projection subs (`:login/state` `:login/error`
+  `:login/attempts` `:login/email`) and three `:script` checkpoints used
+  to reach into the dead app-db path — they compiled fine but resolved
+  empty at runtime, and NO CLJS gate caught it (the testbed had no unit
+  test; its variants run only via the browser story runner).
+
+  This test runs each variant through `story/run-variant` under the
+  top-level `node-test` build (`npm run test:cljs`) and then, against the
+  variant frame's live `frame-state-value` (which carries the runtime-db
+  partition), computes each migrated projection sub via `rf/compute-sub`
+  and asserts it resolves the live snapshot value — NOT nil from the dead
+  app-db path. `compute-sub` resolves a `:rf/machine`-derived sub against
+  the frame-state value's `:rf.db/runtime` partition (EP-0001), so this is
+  the faithful runtime-db read the views perform reactively. If a future
+  change reverts the subs to the dead app-db path, these assertions go red
+  and the CLJS gate fails loudly.
+
+  Why compute-sub here rather than a `:rf.assert/sub-equals` `:script`
+  checkpoint: the play-runner's `:sub-equals` evaluator computes subs
+  against app-db ONLY, so a runtime-db machine projection reads nil through
+  it (tracked separately as a play-runner gap). The variant `:script`s pin
+  state with `:rf.assert/state-is` (runtime-db-aware); this CLJS test owns
+  the `:data`-slice (`:error` / `:attempts` / `:email`) verification.
+
+  The variant stories ns is required at the top — loading it fires the
+  `reg-*` macros — so the side-table + the four projection subs are
+  registered by the time the tests run."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.core      :as rf]
+            [re-frame.frame     :as frame]
+            [re-frame.machines  :as machines]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story     :as story]
+            [re-frame.story.async      :as async-lib]
+            [re-frame.story.loaders    :as loaders]
+            [re-frame.test-support     :as test-support]
+            [login-form.events]
+            [login-form.subs]
+            [login-form.stories :as lf-stories]))
+
+;; ---- fixtures ------------------------------------------------------------
+;;
+;; Snapshot/restore the registrar around each test (same shape as the
+;; counter-with-stories CLJS test): the framework-shipped events / fxs /
+;; subs registered at ns-load (the machines `:rf/machine` sub, the Story
+;; lifecycle machine, the login app's events / subs, the canonical
+;; `:rf.assert/*` handlers) survive the snapshot; per-test registrations
+;; roll back. Map-form fixture is needed for cljs.test's async bodies.
+
+(def ^:private registrar-snapshot (atom nil))
+
+(defn- before! []
+  (reset! registrar-snapshot (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (frame/ensure-default-frame!)
+  (machines/reset-timers!)
+  (loaders/clear-watchers!)
+  ;; Re-fire the Story registrations so each test starts with a freshly
+  ;; resolved registry (the four projection subs re-register here too).
+  (story/clear-all!)
+  (lf-stories/register-all!))
+
+(defn- after! []
+  (when-let [snap @registrar-snapshot]
+    (test-support/restore-registrar! snap)
+    (reset! registrar-snapshot nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each {:before before! :after after!})
+
+;; ---- registrations: the four projection subs landed ----------------------
+
+(deftest projection-subs-registered
+  (testing "the four machine-snapshot projection subs registered against
+            the registrar (their migration off the dead app-db path
+            keeps them registered as ordinary `reg-sub`s)"
+    (doseq [sub-id [:login/state :login/error :login/attempts :login/email]]
+      (is (some? (registrar/handler :sub sub-id)) (str sub-id " registered")))))
+
+;; ---- each variant runs; the migrated subs resolve the snapshot -----------
+;;
+;; The regression guard. After `run-variant`, the variant frame (keyed by
+;; the variant-id) still holds its committed state, so we compute each
+;; migrated projection sub via `rf/compute-sub` against the frame's
+;; `frame-state-value` — the same two-partition value `subscribe` resolves
+;; reactively. `compute-sub` extracts the `:rf.db/runtime` partition for a
+;; `:rf/machine`-derived sub, so a green assertion PROVES the sub reads the
+;; live runtime-db snapshot. Reverting the subs to the dead app-db
+;; `:rf/runtime` path makes them resolve nil → these go red.
+
+(defn- run-then
+  "Run `variant-id` and, on settle, invoke `(check result frame-state)`
+  with the variant frame's live frame-state value, then tear the variant
+  down and complete the async test."
+  [done variant-id check]
+  (-> (story/run-variant variant-id)
+      (async-lib/then
+        (fn [result]
+          (is (story/assertions-passing? result)
+              (str variant-id " play assertions (state-is etc): "
+                   (pr-str (:assertions result))))
+          (check result (rf/frame-state-value variant-id))
+          (story/destroy-variant! variant-id)
+          (done)))))
+
+(defn- sub-value
+  "Compute migrated projection sub `query-v` against the variant frame's
+  `frame-state` value (resolves the `:rf.db/runtime` partition for the
+  `:rf/machine`-derived projection subs)."
+  [query-v frame-state]
+  (rf/compute-sub query-v frame-state))
+
+(deftest idle-variant-state-sub-resolves
+  (testing ":story.login/idle — `:login/state` resolves :idle off the
+            runtime-db snapshot (and the `:rf.assert/state-is` checkpoint
+            passes)"
+    (async done
+      (run-then done :story.login/idle
+        (fn [_ fs]
+          (is (= :idle (sub-value [:login/state] fs))
+              ":login/state read the live runtime-db snapshot, not nil"))))))
+
+(deftest submitting-variant-state-sub-resolves
+  (testing ":story.login/submitting — `:login/state` resolves :submitting"
+    (async done
+      (run-then done :story.login/submitting
+        (fn [_ fs]
+          (is (= :submitting (sub-value [:login/state] fs))))))))
+
+(deftest error-variant-error-sub-resolves
+  (testing ":story.login/error — `:login/error` resolves the error message
+            off the runtime-db snapshot (NOT nil from the dead app-db path)"
+    (async done
+      (run-then done :story.login/error
+        (fn [_ fs]
+          (is (= :error (sub-value [:login/state] fs)))
+          (is (= "Invalid credentials." (sub-value [:login/error] fs))
+              ":login/error returned the live message, not nil"))))))
+
+(deftest submitting-retry-variant-attempts-sub-resolves
+  (testing ":story.login/submitting-retry — `:login/attempts` resolves the
+            incremented counter off the runtime-db snapshot"
+    (async done
+      (run-then done :story.login/submitting-retry
+        (fn [_ fs]
+          (is (= :submitting-retry (sub-value [:login/state] fs)))
+          (is (= 1 (sub-value [:login/attempts] fs))
+              ":login/attempts returned the live count, not the 0 default"))))))
+
+(deftest authenticated-variant-email-sub-resolves
+  (testing ":story.login/authenticated — `:login/email` resolves the
+            submitted handle off the runtime-db snapshot"
+    (async done
+      (run-then done :story.login/authenticated
+        (fn [_ fs]
+          (is (= :authenticated (sub-value [:login/state] fs)))
+          (is (= "ada@example.com" (sub-value [:login/email] fs))
+              ":login/email returned the live email, not nil"))))))

--- a/tools/story/testbeds/login_form/subs.cljs
+++ b/tools/story/testbeds/login_form/subs.cljs
@@ -1,33 +1,47 @@
 (ns login-form.subs
   "Login-form testbed subs (rf2-0sg12).
 
-  Two named subs project out the convenient pieces of the machine's
-  `:data` slot; the view also uses two `rf/machine-has-tag?` framework subs
-  for `:auth/busy` and `:auth/authenticated`. Per Spec 005 §State
+  Four named subs project out the convenient pieces of the machine's
+  current snapshot; the view also uses two `rf/machine-has-tag?` framework
+  subs for `:auth/busy` and `:auth/authenticated`. Per Spec 005 §State
   tags the tag queries replace the boolean-discriminator subs the
   pre-machines style would have used (`:submitting?` /
-  `:authenticated?`)."
+  `:authenticated?`).
+
+  EP-0001 (rf2-vzld77 / rf2-ib5acl): machine snapshots are durable
+  framework state and live in the frame's RUNTIME-DB partition at
+  `[:rf.runtime/machines :snapshots <machine-id>]`, NOT the retired
+  app-db `:rf/runtime` root. App code reads a machine's snapshot through
+  the framework `:rf/machine` sub (`(rf/sub-machine :login/flow)` is the
+  sugar) rather than reaching into the runtime-db partition by raw path;
+  the framework sub reads the right partition for us. Each projection sub
+  below is a layer-2 sub deriving off `:rf/machine` via the `:<-` chain —
+  it re-computes only when the snapshot's relevant slice changes."
   (:require [re-frame.core :as rf]))
 
 (rf/reg-sub :login/state
   {:doc "Current state of the login flow — one of :idle :submitting
         :error :submitting-retry :authenticated."}
-  (fn sub-login-state [db _query]
-    (get-in db [:rf/runtime :machines :snapshots :login/flow :state])))
+  :<- [:rf/machine :login/flow]
+  (fn sub-login-state [snapshot _query]
+    (:state snapshot)))
 
 (rf/reg-sub :login/error
   {:doc "Current error message, if any."}
-  (fn sub-login-error [db _query]
-    (get-in db [:rf/runtime :machines :snapshots :login/flow :data :error])))
+  :<- [:rf/machine :login/flow]
+  (fn sub-login-error [snapshot _query]
+    (get-in snapshot [:data :error])))
 
 (rf/reg-sub :login/attempts
   {:doc "How many login attempts the flow has rejected so far. The
         retry-state UI labels itself with this count."}
-  (fn sub-login-attempts [db _query]
-    (get-in db [:rf/runtime :machines :snapshots :login/flow :data :attempts] 0)))
+  :<- [:rf/machine :login/flow]
+  (fn sub-login-attempts [snapshot _query]
+    (get-in snapshot [:data :attempts] 0)))
 
 (rf/reg-sub :login/email
   {:doc "Email the user most recently submitted — surfaced in the
         :authenticated state's welcome banner."}
-  (fn sub-login-email [db _query]
-    (get-in db [:rf/runtime :machines :snapshots :login/flow :data :email])))
+  :<- [:rf/machine :login/flow]
+  (fn sub-login-email [snapshot _query]
+    (get-in snapshot [:data :email])))

--- a/tools/story/testbeds/login_form/views.cljs
+++ b/tools/story/testbeds/login_form/views.cljs
@@ -21,8 +21,9 @@
 ;;
 ;; Form-2 so the email/password inputs can hold component-local state
 ;; without colonising app-db with every keystroke. Per Story's design,
-;; local component state is fine — Story assertions read app-db, not
-;; component-local atoms, so the input state stays where it belongs.
+;; local component state is fine — Story assertions read framework state
+;; (app-db + the runtime-db machine snapshot), not component-local atoms,
+;; so the input state stays where it belongs.
 ;; ---------------------------------------------------------------------------
 
 (reg-view login-form []


### PR DESCRIPTION
Post-EP-0001 (rf2-vzld77) machine snapshots live in the frame's runtime-db partition at `[:rf.runtime/machines :snapshots <id>]`, not the retired app-db `:rf/runtime` root. The story login_form testbed still read the now-empty app-db path — it compiled fine but resolved nil/empty at runtime, and no CLJS gate caught it (the testbed had no unit test; its variants run only via the browser story runner).

## What changed

- `subs.cljs` — the four projection subs (`:login/state` `:login/error` `:login/attempts` `:login/email`) now derive off the framework `:rf/machine` sub via the `:<-` chain (the idiomatic app read; `:rf/machine` is a runtime-sub that reads the right partition), replacing the raw `[:rf/runtime :machines :snapshots ...]` app-db get-ins.
- `stories.cljs` — the three dead-path `:assert-db` checkpoints (plus the pre-existing `:authenticated` `[:login/email]` sub-equals, same dead-path class) are replaced with `:rf.assert/state-is`, the runtime-db-aware machine checkpoint. The play-runner's `:rf.assert/sub-equals` evaluates subs against app-db only, so a runtime-db machine projection isn't observable through it (filed separately as **rf2-pecaxy**); the `:data`-slice value checks move to the new CLJS unit test.
- `stories_cljs_test.cljs` (new) — regression guard under `npm run test:cljs`. Runs each variant and computes the migrated subs against the variant frame's `frame-state-value` (which resolves the runtime-db partition), asserting each resolves the live snapshot value, not nil. A sentinel-failure check confirmed the test executes and reads the live runtime-db value.
- `events.cljs` / `views.cljs` — stale app-db `:rf/runtime` prose references corrected to the runtime-db partition path.

## Quality gates

- `npm run test:cljs` (implementation node-test, includes the new login_form CLJS test): **6044 tests, 0 failures, 0 errors**.
- `clojure -M:test` (tools/story JVM): **1655 tests, 0 failures, 0 errors**.
- `shadow-cljs compile examples/login-form` (browser build): **0 warnings**.

Closes rf2-ib5acl. Follow-up rf2-pecaxy filed for the play-runner `:rf.assert/sub-equals` runtime-db gap.