### PR TITLE
fix(story): :rf.assert/sub-equals evaluates subs against frame-state (runtime-db-aware) (rf2-pecaxy)

### DIFF
--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -460,10 +460,19 @@
       explanation (assoc :explanation explanation))))
 
 (defn- evaluate-sub-equals
-  [frame-id db [sub-vec expected]]
+  [frame-id frame-state [sub-vec expected]]
   ;; Use compute-sub against the snapshot — bypasses the reactive cache
   ;; per Spec 008. Subscriptions registered against the variant's frame
   ;; resolve the same way they would in the running app.
+  ;;
+  ;; EP-0001 (rf2-vzld77 / rf2-pecaxy): `frame-state` is the FULL frame-state
+  ;; value `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`, NOT the bare
+  ;; app-db. `compute-sub` resolves a mixed app-db/runtime-db dependency
+  ;; graph against a frame-state value (subs.cljc `partition-value-for-sub`
+  ;; extracts `:rf.db/runtime` for a `:runtime-db` sub and `:rf.db/app` for a
+  ;; `:db` sub) — the faithful read the reactive subscribe path does. Handing
+  ;; it bare app-db (the pre-pecaxy bug) made every runtime-db-projection sub
+  ;; (e.g. `:rf/machine` and any app sub deriving off it) read nil.
   ;;
   ;; Redaction: a sub reading a sensitive path propagates the sensitive
   ;; marker into its output value (spec/015 §reg-sub). We project the
@@ -473,7 +482,7 @@
   ;; common `[:sub/id & path]` shape) the projection redacts; otherwise
   ;; the value passes through unchanged.
   (let [raw     (try
-                  (subs/compute-sub sub-vec db)
+                  (subs/compute-sub sub-vec frame-state)
                   (catch #?(:clj Throwable :cljs :default) _
                     ::compute-error))
         passed? (and (not= raw ::compute-error)
@@ -1022,7 +1031,12 @@
           extras       (case evaluator-kind
                          :path-equals     (evaluate-path-equals     frame-id db payload)
                          :path-matches    (evaluate-path-matches    frame-id db payload)
-                         :sub-equals      (evaluate-sub-equals      frame-id db payload)
+                         ;; EP-0001 (rf2-vzld77 / rf2-pecaxy): subs may project
+                         ;; runtime-db state (e.g. `:rf/machine`), so hand
+                         ;; `compute-sub` the FULL frame-state value (app +
+                         ;; runtime), not the bare app-db `:db` cofx — else
+                         ;; runtime-db-projection subs read nil.
+                         :sub-equals      (evaluate-sub-equals      frame-id {:rf.db/app db :rf.db/runtime rt} payload)
                          :dispatched?     (evaluate-dispatched?     (dispatched-events frame-id) payload)
                          ;; EP-0001 (rf2-vzld77): machine snapshots live in
                          ;; runtime-db; read the `:rf.db/runtime` coeffect.

--- a/tools/story/test/re_frame/story_assertions_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_assertions_cljs_test.cljs
@@ -188,6 +188,35 @@
         (is (re-find #"threw" (:reason out))
             ":reason explains the sub threw")))))
 
+;; ---- evaluate-sub-equals — runtime-db-projection sub (rf2-pecaxy) --------
+;;
+;; A `:runtime-db` sub (the idiomatic machine-snapshot shape) projects state
+;; from the runtime-db partition. The evaluator must resolve it against the
+;; FULL frame-state value `{:rf.db/app … :rf.db/runtime …}` so `compute-sub`
+;; reads the runtime partition the sub belongs to. Pre-fix the evaluator was
+;; handed bare app-db, so the runtime-db sub read nil. Here we register a
+;; runtime-db sub, hand the evaluator a frame-state value, and assert it
+;; resolves the live runtime-db value — and that bare app-db reads nil.
+
+(deftest cljs-evaluate-sub-equals-runtime-db-projection
+  (testing "evaluate-sub-equals resolves a runtime-db-projection sub against
+            the frame-state value, not nil"
+    (subs/reg-runtime-sub :pecaxy/light
+      (fn [rt _] (get-in rt [:rf.runtime/machines :snapshots :traffic-light :state])))
+    (let [runtime    {:rf.runtime/machines {:snapshots {:traffic-light {:state :red}}}}
+          frame-state {:rf.db/app {} :rf.db/runtime runtime}
+          ;; The faithful read: the play-runner now hands the full
+          ;; frame-state value (app + runtime).
+          ok         (evaluate-sub-equals :rf/default frame-state [[:pecaxy/light] :red])
+          ;; The pre-pecaxy bug: bare app-db → the runtime-db sub reads nil.
+          bug        (evaluate-sub-equals :rf/default {:rf.db/app {}} [[:pecaxy/light] :red])]
+      (is (true? (:passed? ok))
+          "runtime-db sub resolves :red through the frame-state value")
+      (is (= :red (:actual ok)))
+      (is (false? (:passed? bug))
+          "bare app-db (no runtime partition) makes the runtime-db sub read nil")
+      (is (nil? (:actual bug))))))
+
 ;; ---- evaluate-effect-emitted — the pred-rejects-but-present arm ----------
 ;;
 ;; Only present/absent was tested. When the fx-id WAS emitted but the

--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -30,6 +30,7 @@
             [re-frame.frame            :as frame]
             [re-frame.machines         :as machines]
             [re-frame.registrar        :as registrar]
+            [re-frame.subs             :as subs]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story            :as story]
             [re-frame.story.assertions :as assertions]
@@ -170,6 +171,36 @@
     (let [r (async/deref-blocking (story/run-variant :story.sub/bad) 5000)]
       (is (false? (-> r :assertions first :passed?))))
     (story/destroy-variant! :story.sub/bad)))
+
+(deftest sub-equals-runtime-db-projection
+  ;; rf2-pecaxy regression: a `:rf.assert/sub-equals` over a sub that
+  ;; projects RUNTIME-DB state (the idiomatic machine-snapshot shape) must
+  ;; resolve the live value — NOT nil. Pre-fix the play-runner handed
+  ;; `compute-sub` the bare app-db `:db` cofx, so a `:runtime-db` sub read
+  ;; app-db and returned nil. The fix passes the full frame-state value
+  ;; `{:rf.db/app … :rf.db/runtime …}` so `compute-sub` resolves the
+  ;; runtime-db partition the sub belongs to.
+  (testing ":rf.assert/sub-equals resolves a runtime-db-projection sub (not nil)"
+    ;; Seed a machine snapshot into the runtime-db partition (EP-0001).
+    (rf/reg-event-fx :test/seed-machine-sub
+      (fn [{rt :rf.db/runtime} _]
+        {:rf.db/runtime (assoc-in (or rt {})
+                                  [:rf.runtime/machines :snapshots :traffic-light]
+                                  {:state :red})}))
+    ;; A runtime-db sub projecting the snapshot's :state — the idiomatic
+    ;; shape an app sub uses to read machine state reactively.
+    (subs/reg-runtime-sub :traffic-light/state
+      (fn [rt _] (get-in rt [:rf.runtime/machines :snapshots :traffic-light :state])))
+    (story/reg-variant :story.sub/runtime
+      {:events [[:test/seed-machine-sub]]
+       :play-script [[:dispatch-sync [:rf.assert/sub-equals [:traffic-light/state] :red]]]})
+    (let [r (async/deref-blocking (story/run-variant :story.sub/runtime) 5000)
+          a (-> r :assertions first)]
+      (is (true? (:passed? a))
+          "the runtime-db-projection sub resolved its live value through sub-equals")
+      (is (= :red (:actual a))
+          "actual is the live runtime-db value, not nil (the pre-pecaxy bug)"))
+    (story/destroy-variant! :story.sub/runtime)))
 
 ;; ===========================================================================
 ;; :rf.assert/dispatched?


### PR DESCRIPTION
Fixes rf2-pecaxy. The Story play-runner's `:rf.assert/sub-equals` evaluator (`evaluate-sub-equals`) was handed the bare app-db `:db` cofx and called `subs/compute-sub` against it. compute-sub only resolves a `:runtime-db` sub's partition when handed a frame-state value (`{:rf.db/app … :rf.db/runtime …}`); given a bare app-db map it passes it straight through, so `:rf/machine` (and any app sub deriving off it) read app-db and returned nil. Post-EP-0001 machine snapshots live in runtime-db, so every machine-snapshot-projection sub-equals silently read nil.

Fix: the call site now reconstructs the full frame-state value `{:rf.db/app db :rf.db/runtime rt}` from the handler's `:db` (app) + `:rf.db/runtime` (rt) cofx and hands it to `evaluate-sub-equals`, which passes it to `compute-sub` — the same faithful read the reactive subscribe path does (mirrors rf2-ib5acl #3540's frame-state-value + compute-sub usage). `:rf.assert/state-is` was already runtime-db-aware; `:rf.assert/path-equals` / `:rf.assert/path-matches` stay app-db-path assertions by design (state-is is the runtime-db counterpart). Scope: tools/story only.

Regression: a `:rf.assert/sub-equals` over a runtime-db-projection sub (machine-snapshot `:state`) now resolves the live value (`:red`), not nil — JVM (full run-variant path) and CLJS (direct evaluator unit test, asserting bare app-db reads nil vs frame-state reads the live value). Probe-then-revert confirmed the JVM regression goes red without the fix.

## Quality gates
- `cd implementation && npm install` + `npm run test:cljs` — 6043 tests, 0 failures (new CLJS regression compiled in + green)
- `clojure -M:test` from tools/story — 1656 tests, 0 failures (new JVM regression green; probe-revert confirmed red without fix)