### PR TITLE
fix(xray): exact transition spec-path for inline source + migrate remaining :rf/runtime consumers (rf2-lai1qv rf2-tj6w9l)

### DIFF
--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -531,6 +531,78 @@
     (map? v)                        [v]
     :else (throw (ex-info (str bad-value-id) {:value v}))))
 
+(defn- candidate-vector-form?
+  "True iff `v` is the multi-candidate VECTOR form (`[{…} {…}]`) — the
+  only value-form the inline-source macro keys per-INDEX (single-map /
+  keyword / vector-target forms are keyed at the bare slot path). Used to
+  decide whether the selected candidate's index is meaningful for the
+  spec-path discriminator (rf2-lai1qv): for the index-free forms the
+  carried `:candidate-idx` is nil so `cascade-row-source-key` emits the
+  bare-slot shape that matches the macro's keying. Mirrors the
+  vector-of-maps arm of `normalise-candidates`."
+  [v]
+  (boolean (and (vector? v) (seq v) (every? map? v))))
+
+(defn- transition-slot
+  "Build the structured spec-path DISCRIMINATOR (rf2-lai1qv) carried on a
+  selected transition under `:rf/transition-slot`, so the Xray cascade
+  rows can address the EXACT inline-source spec-path slot rather than
+  reconstructing it from `source-state` / `event` / `phase` (which loses
+  the candidate index, the `:after` delay-key, and the root-vs-state
+  distinction). Pure data; substrate-side so it stays free of the
+  Xray-side `:states`-interleaved spec-path encoding (the tool builds the
+  spec-path FROM this discriminator).
+
+    {:decl-path     <state-path-vector or []>   ;; [] = root / parallel-root :on
+     :slot          :on | :always | :after
+     :event-key     <matched :on key, else nil> ;; exact / :ns/* / :* key
+     :delay-key     <:after delay key, else nil>
+     :candidate-idx <int or nil>                ;; nil = index-free (single-map / kw / vec-target)
+     :root?         <bool>}                      ;; true iff decl-path is []
+
+  `raw-value` is the RAW table value at the matched slot (the `:on <key>`
+  clause value, the `:always` value, or the `:after <delay>` value) —
+  only its vector-of-candidates shape decides whether `:candidate-idx` is
+  meaningful (`candidate-vector-form?`)."
+  [{:keys [decl-path slot event-key delay-key candidate-idx raw-value]}]
+  (let [decl-path (vec decl-path)]
+    {:decl-path     decl-path
+     :slot          slot
+     :event-key     event-key
+     :delay-key     delay-key
+     :candidate-idx (when (candidate-vector-form? raw-value) candidate-idx)
+     :root?         (empty? decl-path)}))
+
+(defn- finalize-on-transition-slot
+  "rf2-lai1qv — complete the PARTIAL `:on` `:rf/transition-slot`
+  `match-on-clause` stamped (slot / matched event-key / candidate-idx /
+  raw-value, but no decl-path) by folding in the `decl-path` the pick
+  site owns and running it through `transition-slot` (which computes
+  `:root?` and drops a non-vector form's index). A transition whose slot
+  is already complete (`:after` / `:always` matches carry the full
+  discriminator from their own pick sites) or absent (synthetic / pure-fn
+  callers) is returned unchanged. Pure data → data."
+  [transition decl-path]
+  (let [slot (:rf/transition-slot transition)]
+    (if (and slot (= :on (:slot slot)) (not (contains? slot :decl-path)))
+      (assoc transition :rf/transition-slot
+             (transition-slot (assoc slot :decl-path decl-path)))
+      transition)))
+
+(defn- select-passing-candidate-indexed
+  "Like `select-passing-candidate` but returns `[idx tspec]` — the
+  0-based index of the first guard-passing candidate alongside the
+  candidate map — or nil when none pass. The index is what the inline
+  source lookup needs to address a multi-candidate `:on` / `:after` /
+  `:always` vector's exact spec-path slot (rf2-lai1qv); the bare
+  `select-passing-candidate` wrapper drops it for callers that only need
+  the candidate."
+  [machine candidates snapshot event]
+  (some (fn [[idx t]]
+          (when (evaluate-guard machine (:guard t) snapshot event)
+            [idx t]))
+        (map-indexed vector candidates)))
+
 (defn- select-passing-candidate
   "Walk `candidates` (already normalised by `normalise-candidates`) in
   declaration order and return the first whose `:guard` passes against
@@ -541,10 +613,7 @@
   passes — it is the documented unconditional fallback that ends a
   guarded candidate list."
   [machine candidates snapshot event]
-  (some (fn [t]
-          (when (evaluate-guard machine (:guard t) snapshot event)
-            t))
-        candidates))
+  (second (select-passing-candidate-indexed machine candidates snapshot event)))
 
 (defn- after-epoch-path
   "Return the path inside the snapshot's `:data` map where the
@@ -652,10 +721,19 @@
         ;; transitions: first guard-pass wins; an unguarded candidate is the
         ;; unconditional fallback.
         (fn [prefix t]
-          (let [cands  (normalise-candidates t :rf.error/machine-bad-after-spec)
-                tspec  (select-passing-candidate machine cands snapshot event)]
+          (let [cands     (normalise-candidates t :rf.error/machine-bad-after-spec)
+                [idx tspec] (select-passing-candidate-indexed machine cands snapshot event)]
             (if tspec
-              {:transition tspec
+              {;; rf2-lai1qv — stamp the `:after` spec-path discriminator
+               ;; (decl-path prefix + the delay-key + the matched candidate
+               ;; index) so the Xray cascade row addresses the exact
+               ;; `[:states … :after <delay>]` inline-source slot.
+               :transition (assoc tspec :rf/transition-slot
+                                  (transition-slot {:decl-path     prefix
+                                                    :slot          :after
+                                                    :delay-key     delay-key
+                                                    :candidate-idx idx
+                                                    :raw-value     t}))
                :decl-path  prefix
                :delay      delay-key
                :epoch      carried-epoch}
@@ -796,13 +874,28 @@
                         ;; inherited E. Distinguishing absent from present-nil
                         ;; is the whole point of the forbidden idiom: absence ≠
                         ;; block.
+                        ;;
+                        ;; rf2-lai1qv — on a hit, stamp the PARTIAL spec-path
+                        ;; discriminator `:rf/transition-slot` (`:slot :on`, the
+                        ;; MATCHED key `k`, the candidate index, and the raw
+                        ;; value form). `decl-path` / `:root?` are filled by the
+                        ;; pick site (which owns the state-path prefix). The
+                        ;; discriminator lets the Xray cascade rows address the
+                        ;; exact inline-source slot for a multi-candidate `:on`.
                         (when (contains? on k)
-                          (select-passing-candidate
-                            machine
-                            (normalise-candidates
-                              (get on k)
-                              :rf.error/machine-bad-on-clause)
-                            snapshot event)))
+                          (let [raw-value (get on k)
+                                [idx t]   (select-passing-candidate-indexed
+                                            machine
+                                            (normalise-candidates
+                                              raw-value
+                                              :rf.error/machine-bad-on-clause)
+                                            snapshot event)]
+                            (when t
+                              (assoc t :rf/transition-slot
+                                     {:slot          :on
+                                      :event-key     k
+                                      :candidate-idx idx
+                                      :raw-value     raw-value})))))
         ;; Tier 1 — exact event-id. Tier 2 — `:ns/*` (skipped for a
         ;; non-namespaced event-id; `ns-key` is nil and `select` is never
         ;; called). Tier 3 — total `:*`. Most-specific wins; each tier is
@@ -1461,37 +1554,43 @@
   `:exit / :transition / :entry / :always / :after-action /
   :initial-entry / :destroy-exit` so the Xray Handler section's
   LIFECYCLE rendering can group rows by phase without spec-walking
-  at render time."
-  [machine snap action-ref event phase]
+  at render time.
+
+  Per rf2-lai1qv the optional `transition-slot` — the selected
+  transition's EXACT spec-path discriminator (`transition-slot`) — is
+  stamped on the emit under `:transition-slot` when present (only the
+  transition `:action` carries one; `:exit` / `:entry` boundary actions
+  pass nil). The Xray cascade row reads it to address the precise
+  inline-source slot (candidate index / `:after` delay-key / root) rather
+  than reconstructing the path from `source-state` / `event` / `phase`."
+  ([machine snap action-ref event phase]
+   (run-action machine snap action-ref event phase nil))
+  ([machine snap action-ref event phase transition-slot]
   (if action-ref
     (let [f         (resolve-action machine action-ref)
           parent-id (or (:rf/parent-id machine) (:id machine))
           ;; Per rf2-ko8jb: epoch-capture admission requires `:frame`.
-          frame-id  (:rf/frame machine)]
+          frame-id  (:rf/frame machine)
+          base-tags (cond-> {:machine-id parent-id
+                             :action-id  action-ref
+                             :phase      phase
+                             :input      {:data  (:data snap)
+                                          :event event}
+                             :frame      frame-id}
+                      transition-slot (assoc :transition-slot transition-slot))]
       (try
         (let [r (call-action f snap event)]
           (trace/emit! :rf.machine :rf.machine/action-ran
-                       {:machine-id parent-id
-                        :action-id  action-ref
-                        :phase      phase
-                        :input      {:data  (:data snap)
-                                     :event event}
-                        :outcome    (if (nil? r) :ok r)
-                        :frame      frame-id})
+                       (assoc base-tags :outcome (if (nil? r) :ok r)))
           (or r {}))
         (catch #?(:clj Throwable :cljs :default) e
           (trace/emit! :rf.machine :rf.machine/action-ran
-                       {:machine-id parent-id
-                        :action-id  action-ref
-                        :phase      phase
-                        :input      {:data  (:data snap)
-                                     :event event}
-                        :outcome    :rf.error/action-threw
-                        :exception  e
-                        :frame      frame-id})
+                       (assoc base-tags
+                              :outcome   :rf.error/action-threw
+                              :exception e))
           (result/fail {:action-ref action-ref
                         :exception  e}))))
-    {}))
+    {})))
 
 (defn enforce-db-disallow
   "Per Spec 005 §Hard-disallow `:db` (005:463): a machine action's effect
@@ -1608,7 +1707,7 @@
   ;; arity (which would churn every caller). `reduced` short-circuits on
   ;; the first throwing action, carrying the bare `:fail` Result.
   (let [acc (reduce
-              (fn [[acc-r cascade] {:keys [kind phase action state region source]}]
+              (fn [[acc-r cascade] {:keys [kind phase action state region source transition-slot]}]
                 (result/with-ok [snap fx] acc-r
                   (let [before-data (:data snap)
                         emit-phase  (or phase kind)
@@ -1623,7 +1722,7 @@
                                              :action action}
                                       source (assoc :source source))]
                     (if action
-                      (let [r0 (run-action machine snap action event emit-phase)]
+                      (let [r0 (run-action machine snap action event emit-phase transition-slot)]
                         (if (result/fail? r0)
                           (reduced [r0 cascade])
                           ;; Per Spec 005 §Hard-disallow `:db`: strip any `:db`
@@ -2210,7 +2309,14 @@
   merged, `:fx` collected), or a `result/fail` if the action threw. A
   targetless / action-less transition returns `(ok snap [])`."
   [machine snap transition event]
-  (let [r0 (run-action machine snap (:action transition) event :transition)]
+  (let [;; rf2-lai1qv — the root `:on` lives OUTSIDE `:states` (decl-path
+        ;; `[]`). `root-on-match` → `match-on-clause` stamped the partial
+        ;; `:on` discriminator; finalize it with the empty decl-path so the
+        ;; Xray cascade row addresses `[:on <event-key>]` (root-relative, no
+        ;; `:states` prefix) → `:root? true`.
+        transition (finalize-on-transition-slot transition [])
+        r0 (run-action machine snap (:action transition) event :transition
+                       (:rf/transition-slot transition))]
     (if (result/fail? r0)
       r0
       (let [r        (enforce-db-disallow machine r0 (:action transition) (:state snap))
@@ -2647,8 +2753,17 @@
                                  :region region :action (:exit n)})
                               (reverse exited-pairs)))
         action-steps  (when (:action transition)
-                        [{:kind :action :phase transition-phase :state (vec decl-path)
-                          :region region :action (:action transition)}])
+                        [(cond-> {:kind :action :phase transition-phase :state (vec decl-path)
+                                  :region region :action (:action transition)}
+                           ;; rf2-lai1qv — carry the selected transition's
+                           ;; EXACT spec-path discriminator onto the action
+                           ;; step so `run-action` can stamp it on the
+                           ;; `:rf.machine/action-ran` trace; the Xray cascade
+                           ;; row then addresses the precise inline-source slot
+                           ;; (candidate index / `:after` delay-key / root) the
+                           ;; reconstruct-from-phase path could not.
+                           (:rf/transition-slot transition)
+                           (assoc :transition-slot (:rf/transition-slot transition)))])
         ;; Per spec/009 §History trace events (line 291): each `:entry` step
         ;; produced by a history restore additively carries `:source`
         ;; (`:recorded`|`:default`) matching the `:rf.machine.history/restored`
@@ -2903,17 +3018,29 @@
   (path-walk/walk-path-leaf-to-root
     machine path
     (fn [prefix n]
-      (let [always (:always n)
-            always (cond
-                     (nil? always)    []
-                     (vector? always) always
-                     :else            [always])
-            hit    (some (fn [t]
-                           (when (evaluate-guard machine (:guard t) snapshot nil)
-                             t))
-                         always)]
+      (let [raw-always (:always n)
+            always     (cond
+                         (nil? raw-always)    []
+                         (vector? raw-always) raw-always
+                         :else                [raw-always])
+            [idx hit]  (some (fn [[i t]]
+                               (when (evaluate-guard machine (:guard t) snapshot nil)
+                                 [i t]))
+                             (map-indexed vector always))]
         (when hit
-          {:transition (assoc hit :decl-path prefix) :decl-path prefix})))))
+          ;; rf2-lai1qv — stamp the `:always` spec-path discriminator
+          ;; (decl-path prefix + the matched candidate index for the
+          ;; vector form; index-free for the single-map form, matching the
+          ;; macro's bare-`:always` keying) so the Xray cascade row
+          ;; addresses the exact inline-source slot.
+          {:transition (assoc hit
+                              :decl-path prefix
+                              :rf/transition-slot
+                              (transition-slot {:decl-path     prefix
+                                                :slot          :always
+                                                :candidate-idx idx
+                                                :raw-value     raw-always}))
+           :decl-path prefix})))))
 
 (def ^:private always-depth-limit-default
   ;; Per Spec 005 §Drain semantics: bounds the `:always` microstep loop
@@ -3362,7 +3489,18 @@
           ;; after-elapsed` event), `:transition` otherwise.
           (apply-transition-once
             machine snapshot event
-            (assoc (:transition match) :decl-path (:decl-path match))
+            (-> (:transition match)
+                (assoc :decl-path (:decl-path match))
+                ;; rf2-lai1qv — finalize the `:on` spec-path discriminator:
+                ;; `match-on-clause` stamped the PARTIAL `:rf/transition-slot`
+                ;; (slot / matched key / candidate-idx / raw value); the
+                ;; pick site owns the decl-path prefix (`[]` for a root /
+                ;; parallel-root `:on` fallback), so fold it through
+                ;; `transition-slot` to compute `:root?` + drop the index
+                ;; for index-free value forms. `:after` / `:always` matches
+                ;; already carry a complete discriminator from their pick
+                ;; sites, so only the `:on` partial is finalized here.
+                (finalize-on-transition-slot (:decl-path match)))
             (if (:delay match) :after-action :transition))
 
           :else

--- a/implementation/machines/test/re_frame/transition_slot_spec_path_test.clj
+++ b/implementation/machines/test/re_frame/transition_slot_spec_path_test.clj
@@ -1,0 +1,181 @@
+(ns re-frame.transition-slot-spec-path-test
+  "rf2-lai1qv — the substrate stamps the selected transition's EXACT
+  spec-path DISCRIMINATOR (`:transition-slot`) on the
+  `:rf.machine/action-ran` trace so Xray's cascade rows can address the
+  precise inline-source slot (candidate index, `:after` delay-key,
+  root-vs-state) rather than reconstructing the path from
+  `source-state` / `event` / `phase` (which hardcoded candidate 0,
+  could not name the delay-key, and assumed a `:states` prefix for a
+  root `:on`).
+
+  These tests drive the four enumerated cases through the live runtime
+  and pin the discriminator the trace carries. The Xray-side
+  discriminator → spec-path conversion is unit-tested in
+  `day8.re-frame2-xray.panels.epoch.projection-cljs-test`
+  (`transition-slot->spec-prefix` + the `cascade-row-source-key`
+  per-case tests)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- record-traces! [body-fn]
+  (let [seen (atom [])]
+    (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
+    (try (body-fn)
+         (finally (rf/unregister-listener! ::rec)))
+    @seen))
+
+(defn- action-ran-slot
+  "Return the `:transition-slot` discriminator off the action-ran trace
+  for `action-id`, or nil."
+  [evs action-id]
+  (some (fn [ev]
+          (when (and (= :rf.machine/action-ran (:operation ev))
+                     (= action-id (-> ev :tags :action-id)))
+            (-> ev :tags :transition-slot)))
+        evs))
+
+;; ---- (1) candidate-vector :on — the matched candidate's index ----------
+
+(deftest candidate-vector-on-carries-matched-index
+  (testing "an inline `:action` on a multi-candidate `:on` VECTOR stamps
+            the EXACT matched candidate index (not 0) on its action-ran
+            trace"
+    (rf/reg-machine :slot/cand-on
+      {:initial :idle
+       :data    {:n 2}
+       :guards  {:one? (fn [{d :data}] (= 1 (:n d)))
+                 :two? (fn [{d :data}] (= 2 (:n d)))}
+       :actions {:a0 (fn [_] nil)
+                 :a1 (fn [_] nil)
+                 :a2 (fn [_] nil)}
+       :states  {:idle {:on {:go [{:guard :one? :target :done :action :a0}
+                                  {:guard :two? :target :done :action :a2}]}}
+                 :done {}}})
+    (let [evs  (record-traces!
+                 (fn [] (rf/dispatch-sync [:slot/cand-on [:go]])))
+          slot (action-ran-slot evs :a2)]
+      (is (some? slot) ":a2 (the second candidate) fired")
+      (is (= :on (:slot slot)))
+      (is (= :go (:event-key slot)))
+      (is (= [:idle] (:decl-path slot)))
+      (is (= 1 (:candidate-idx slot))
+          "the matched candidate is index 1, NOT 0")
+      (is (false? (:root? slot))))))
+
+(deftest single-map-on-is-index-free
+  (testing "a single-map `:on` (index-free, matching the macro's bare-slot
+            keying) carries a nil candidate-idx"
+    (rf/reg-machine :slot/single-on
+      {:initial :idle
+       :actions {:do-go (fn [_] nil)}
+       :states  {:idle {:on {:go {:target :done :action :do-go}}}
+                 :done {}}})
+    (let [evs  (record-traces!
+                 (fn [] (rf/dispatch-sync [:slot/single-on [:go]])))
+          slot (action-ran-slot evs :do-go)]
+      (is (= :on (:slot slot)))
+      (is (= :go (:event-key slot)))
+      (is (nil? (:candidate-idx slot))
+          "single-map :on is index-free (bare-slot keying)"))))
+
+;; ---- (2) :always nonzero candidate -------------------------------------
+
+(deftest always-nonzero-candidate-carries-index
+  (testing "an inline `:always` `:action` on a multi-candidate VECTOR
+            stamps the matched nonzero candidate index"
+    (rf/reg-machine :slot/always
+      {:initial :a
+       :data    {:pick 1}
+       :guards  {:p0? (fn [{d :data}] (= 0 (:pick d)))
+                 :p1? (fn [{d :data}] (= 1 (:pick d)))}
+       :actions {:a0 (fn [_] nil)
+                 :a1 (fn [_] nil)}
+       :states  {:a {:on {:go {:target :b}}}
+                 :b {:always [{:guard :p0? :target :c :action :a0}
+                              {:guard :p1? :target :c :action :a1}]}
+                 :c {}}})
+    (let [evs  (record-traces!
+                 (fn [] (rf/dispatch-sync [:slot/always [:go]])))
+          slot (action-ran-slot evs :a1)]
+      (is (some? slot) ":a1 (the second :always candidate) fired")
+      (is (= :always (:slot slot)))
+      (is (= [:b] (:decl-path slot)))
+      (is (= 1 (:candidate-idx slot))
+          "the matched :always candidate is index 1"))))
+
+;; ---- (3) :after action — the exact delay-key ---------------------------
+
+(deftest after-action-carries-delay-key
+  (testing "an inline `:after` `:action` stamps the EXACT delay-key on its
+            action-ran trace (the delay-key the reconstruct path could not
+            name)"
+    (rf/reg-machine :slot/after
+      {:initial :loading
+       :actions {:do-timeout (fn [_] nil)}
+       :states  {:loading {:after {1000 {:target :done :action :do-timeout}}}
+                 :done    {}}})
+    (let [_    (rf/dispatch-sync [:slot/after [:rf.machine/start]])
+          evs  (record-traces!
+                 (fn []
+                   (rf/dispatch-sync
+                     [:slot/after [:rf.machine.timer/after-elapsed 1000 1 [:loading]]])))
+          slot (action-ran-slot evs :do-timeout)]
+      (is (some? slot) ":do-timeout fired")
+      (is (= :after (:slot slot)))
+      (is (= 1000 (:delay-key slot))
+          "the discriminator names the exact :after delay-key")
+      (is (= [:loading] (:decl-path slot))))))
+
+;; ---- (4) root :on fallback — decl-path [] / :root? true ----------------
+
+(deftest root-on-fallback-carries-root-flag
+  (testing "a machine-root `:on` `:action` (the leaf→root fallback) stamps
+            decl-path [] + :root? true so the Xray slot resolves
+            root-relative (OUTSIDE :states)"
+    (rf/reg-machine :slot/root-on
+      {:initial :auth
+       :actions {:do-logout (fn [_] nil)}
+       ;; Root-level :on — every descendant inherits it; no state-node
+       ;; handles :logout, so the leaf→root walk falls to the root.
+       :on      {:logout {:target :idle :action :do-logout}}
+       :states  {:auth {}
+                 :idle {}}})
+    (let [evs  (record-traces!
+                 (fn [] (rf/dispatch-sync [:slot/root-on [:logout]])))
+          slot (action-ran-slot evs :do-logout)]
+      (is (some? slot) ":do-logout fired from the root :on fallback")
+      (is (= :on (:slot slot)))
+      (is (= :logout (:event-key slot)))
+      (is (= [] (:decl-path slot))
+          "root :on has an empty decl-path (outside :states)")
+      (is (true? (:root? slot))))))
+
+;; ---- boundary actions carry NO discriminator ---------------------------
+
+(deftest boundary-actions-carry-no-slot
+  (testing "`:exit` / `:entry` boundary actions are NOT transition actions —
+            they carry no `:transition-slot` (the reconstruct-from-phase
+            path handles them via :source-state / :target-state)"
+    (rf/reg-machine :slot/boundary
+      {:initial :idle
+       :actions {:exit-idle (fn [_] nil)
+                 :enter-done (fn [_] nil)
+                 :do-go     (fn [_] nil)}
+       :states  {:idle {:exit :exit-idle
+                        :on   {:go {:target :done :action :do-go}}}
+                 :done {:entry :enter-done}}})
+    (let [evs (record-traces!
+                (fn [] (rf/dispatch-sync [:slot/boundary [:go]])))]
+      (is (nil? (action-ran-slot evs :exit-idle))
+          ":exit action carries no :transition-slot")
+      (is (nil? (action-ran-slot evs :enter-done))
+          ":entry action carries no :transition-slot")
+      (is (some? (action-ran-slot evs :do-go))
+          "but the transition :action DOES carry the discriminator"))))

--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -457,28 +457,40 @@ segment. The `:rf.xray/pin-slice` / `:rf.xray/unpin-slice` /
 
 ## Reserved-keys group
 
-Per rf2-eguy4 phase-A the runtime owns ONE top-level `app-db` slot —
-`:rf/runtime` — containing six logical subsystems, catalogued in
-[Conventions §Reserved app-db keys](../../../spec/Conventions.md#reserved-app-db-keys).
-Xray's `[runtime]` group surfaces these six as operator-facing
-section labels; the underlying paths all live under `:rf/runtime`:
+EP-0001 (rf2-vzld77 / rf2-tj6w9l): the framework's durable subsystem
+state — machine snapshots, the route slice, the spawn registry, the
+elision registry — moved OUT of app-db's `:rf/runtime` container into a
+SEPARATE **runtime-db partition** keyed by the reserved `:rf.runtime/*`
+namespace, catalogued in
+[Conventions §Reserved runtime-db keys](../../../spec/Conventions.md#reserved-runtime-db-keys)
+and [002-Frames §The two-partition frame contract](../../../spec/002-Frames.md).
+Xray's `[runtime]` group surfaces these six as operator-facing section
+labels; the underlying paths now live under the runtime-db partition's
+`:rf.runtime/*` roots (NOT app-db):
 
-| Section label | Underlying path | Owner | One-line role |
+| Section label | Underlying path (runtime-db partition) | Owner | One-line role |
 |---|---|---|---|
-| `:rf/machines` | `[:rf/runtime :machines :snapshots]` | machine runtime | Per-frame map of `<machine-id> → :rf/machine-snapshot` — every active machine's snapshot. |
-| `:rf/system-ids` | `[:rf/runtime :machines :system-ids]` | machine runtime | Reverse index `<system-id> → <gensym'd-machine-id>` for `:system-id` named-machine addressing. |
-| `:rf/spawned` | `[:rf/runtime :machines :spawned]` | machine runtime | Declarative-`:spawn` / `:spawn-all` spawn registry — `<parent-id> → {<invoke-id> <slot>}` for the destroy-cascade walker. |
-| `:rf/route` | `[:rf/runtime :routing :current]` | routing runtime | The current route slice `{:id :params :query :transition :error}`. |
-| `:rf/pending-navigation` | `[:rf/runtime :routing :pending-navigation]` | routing runtime | Pending-navigation slot populated when a `:can-leave` guard rejects; cleared by `:rf.route/continue` / `:rf.route/cancel`. |
-| `:rf/elision` | `[:rf/runtime :elision]` | elision runtime | Wire-elision declaration registry — `{:declarations {<path> {:large? :hint :source}} :sensitive-declarations {<path> {:sensitive? :hint :source}}}`. Populated at boot from `:large? true` / `:sensitive? true` schema slots; consulted by `rf/elide-wire-value` at every wire-boundary emit. Schemas are the only nomination path. |
+| `:rf/machines` | `[:rf.runtime/machines :snapshots]` | machine runtime | Per-frame map of `<machine-id> → :rf/machine-snapshot` — every active machine's snapshot. |
+| `:rf/system-ids` | `[:rf.runtime/machines :system-ids]` | machine runtime | Reverse index `<system-id> → <gensym'd-machine-id>` for `:system-id` named-machine addressing. |
+| `:rf/spawned` | `[:rf.runtime/machines :spawned]` | machine runtime | Declarative-`:spawn` / `:spawn-all` spawn registry — `<parent-id> → {<invoke-id> <slot>}` for the destroy-cascade walker. |
+| `:rf/route` | `[:rf.runtime/routing :current]` | routing runtime | The current route slice `{:id :params :query :transition :error}`. |
+| `:rf/pending-navigation` | `[:rf.runtime/routing :pending-navigation]` | routing runtime | Pending-navigation slot populated when a `:can-leave` guard rejects; cleared by `:rf.route/continue` / `:rf.route/cancel`. |
+| `:rf/elision` | `[:rf.runtime/elision]` | elision runtime | Wire-elision declaration registry — `{:declarations {<path> {:large? :hint :source}} :sensitive-declarations {<path> {:sensitive? :hint :source}}}`. Populated at boot from `:large? true` / `:sensitive? true` schema slots; consulted by `rf/elide-wire-value` at every wire-boundary emit. Schemas are the only nomination path. |
 
 Conventions is the canonical home; this table is the panel-facing
-projection. Xray's `partition-reserved` treats any diff triple rooted
-at `:rf/runtime` as runtime-owned — those triples render in the
-`[runtime]` group rather than as slice mini-panels. The `runtime-areas`
-lookup in `app_db_diff_helpers.cljc` maps each operator label to its
-sub-path under `:rf/runtime`. If a new subsystem lands in Conventions,
-the `runtime-areas` table and this section are updated in lockstep.
+projection. The `runtime-areas` lookup in `app_db_diff_helpers.cljc`
+maps each operator label to its sub-path under the **runtime-db
+partition value** — sourced from `:rf.xray/target-frame-runtime-db` (the
+live partition) + each focused epoch's runtime-db pre/post-image (the
+`:rf.db/runtime` projection of `:frame-state-before` / `-after`), the
+same way the Machines inspector + Routing tab read runtime-db. The TOP
+user-domain section reads the app-db partition (minus any reserved `:rf*`
+key). Because the runtime subsystems no longer live in app-db, an app-db
+diff triple is never runtime-owned; `partition-reserved` /
+`reserved-path?` now key on the reserved `:rf*` NAMESPACE family (a
+framework-internal slot a host might stash at the app-db root). If a new
+subsystem lands in Conventions, the `runtime-areas` table and this
+section are updated in lockstep.
 
 ```
 ┌─ [runtime] ───────────────────────────────────────┐
@@ -540,7 +552,8 @@ db-before / db-after values BEFORE the `:redact-fn` runs — parallel to
 the `:rf.epoch/sensitive?` rollup. A path `P` counts in the framework's
 figure when:
 
-1. `P` is schema-declared sensitive (`[:rf/runtime :elision :sensitive-declarations]`,
+1. `P` is schema-declared sensitive (`[:rf.runtime/elision :sensitive-declarations]`
+   in the runtime-db partition, EP-0001 rf2-vzld77,
    populated from `{:sensitive? true}` per-slot schema props per
    [Spec 015](../../../spec/015-Data-Classification.md)).
 2. `(not= (get-in db-before P) (get-in db-after P))` — value-equality
@@ -560,10 +573,13 @@ Xray-side heuristic — paths `P` where:
 3. `P`'s parent subtree is NOT `identical?` across `db-before` /
    `db-after` (something in the enclosing subtree changed).
 
-Distinct paths are counted independently. The reserved
-`[:rf/runtime :elision]` subtree is skipped (the elision registry's
-own values may
-include `:rf/redacted` as documentation/sentinel form). Condition (3)
+Distinct paths are counted independently. The elision registry —
+post-EP-0001 (rf2-vzld77) at `[:rf.runtime/elision]` in the runtime-db
+partition, no longer in the app-db `:db-before` / `:db-after` the
+heuristic walks — is therefore naturally excluded; a host that still
+carries a stray reserved subtree in app-db has it skipped (the elision
+registry's own values may include `:rf/redacted` as
+documentation/sentinel form). Condition (3)
 is the structural-sharing tightener — without it every redacted slot
 in `app-db` would count for every cascade. The fallback is a tight
 upper bound; it may over-state if a sibling slot changed and the

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1827,10 +1827,11 @@ distinct from the inline `:source-code` body above.
 | `:action`| keyword `action-id`     | `[:actions <id>]`                                     | entry `:source-code` | entry `:source-coords` |
 | `:action`| inline-fn, `:entry`     | `[:states <target-state>... :entry]`                  | enclosing state-node `:source-code :entry` | enclosing state-node `:source-coords` |
 | `:action`| inline-fn, `:exit`      | `[:states <source-state>... :exit]`                   | enclosing state-node `:source-code :exit` | enclosing state-node `:source-coords` |
-| `:action`| inline-fn, `:transition`| `[:states <source-state>... :on <event> :action]`     | enclosing transition-map `:source-code :action` | enclosing transition-map `:source-coords` |
-| `:action`| inline-fn, `:always`    | `[:states <source-state>... :always :action]`        | enclosing `:always` map `:source-code :action` (read-back also probes the index-0 vector-candidate path) | enclosing `:always` map / state-node `:source-coords` (walk-up) |
+| `:action`| inline-fn, `:transition`| `<slot-prefix> :action` (exact, via `:transition-slot`; fallback `[:states <source-state>... :on <event> :action]`) | enclosing transition-map `:source-code :action` | enclosing transition-map `:source-coords` |
+| `:action`| inline-fn, `:always`    | `<slot-prefix> :action` (exact, via `:transition-slot`; fallback `[:states <source-state>... :always :action]`) | enclosing `:always` map `:source-code :action` (legacy read-back also probes the index-0 vector path) | enclosing `:always` map / state-node `:source-coords` (walk-up) |
+| `:action`| inline-fn, `:after-action`| `<slot-prefix> :action` (exact, via `:transition-slot`; fallback `[:states <source-state>... :after :action]`) | enclosing `:after` transition-map `:source-code :action` | enclosing `:after` map / state-node `:source-coords` (walk-up) |
 | `:guard` | keyword `guard-id`      | `[:guards <id>]`                                      | entry `:source-code` | entry `:source-coords` |
-| `:guard` | inline-fn               | `[:states <source-state>... :on <event> :guard]`      | enclosing transition-map `:source-code :guard` | enclosing transition-map `:source-coords` |
+| `:guard` | inline-fn               | exact carried `:spec-path` if present; else `[:states <source-state>... :on <event> :guard]` | enclosing transition-map `:source-code :guard` | enclosing transition-map `:source-coords` |
 | `:transition` | —                  | `[:states <source-state>... :on <event>]`             | logical-state delta box (not source) | transition-map `:source-coords` |
 | `:timer` | —                       | `[:states <state>...]` (parent state-node, D1 shape)  | (body elided) | state-node `:source-coords` |
 
@@ -1845,21 +1846,48 @@ macrostep — intermediate-state inline-fns fall back to the
 headline state; source-key resolution degrades to the macrostep's
 source/target.
 
-**`:always` single-map vs vector candidate (rf2-k7yqod).** The runtime
-and validator both accept `:always` as EITHER a single transition map
-(`:always {:action (fn …)}`) OR a vector of guarded candidates
-(`:always [{:guard … :target …} {…}]`). The macro keys each form
-differently: a single-map `:always` is stamped at the bare `:always`
-path (`[:states <s> :always]`, mirroring single-map `:on`); a vector
-keys each candidate by index (`[:states <s> :always <i>]`). The
-source-key returns the INDEX-FREE single-map shape; the view read-back
-(`cascade-row-source-form`) probes the index-free path FIRST and, on a
-miss, the index-0 vector-candidate path — so a single-element vector
-`:always [{…}]` still resolves its body. Richer per-candidate index
-resolution for MULTI-candidate vectors (carrying the substrate's matched
-always-index onto the cascade row) is the rf2-lai1qv follow-on; until
-then a multi-candidate vector resolves its FIRST candidate's source
-(best-effort).
+**Exact transition spec-path via `:transition-slot` (rf2-lai1qv).** The
+reconstruct-from-`source-state`/`event`/`phase` path above is a FALLBACK.
+The substrate (`re-frame.machines.transition`) now stamps the SELECTED
+transition's exact spec-path DISCRIMINATOR on the `:rf.machine/action-ran`
+trace under `:transition-slot`, and `action-cascade-row` carries it onto
+the row. `cascade-row-source-key` builds the precise inline-source slot
+from it (`transition-slot->spec-prefix` + the `:action` leaf), which WINS
+over the reconstruction. The discriminator is:
+
+```
+{:decl-path     <state-path or []>   ;; [] = root / parallel-root :on
+ :slot          :on | :always | :after
+ :event-key     <matched :on key>     ;; exact / :ns/* / :* — nil for :always/:after
+ :delay-key     <:after delay key>    ;; nil otherwise
+ :candidate-idx <int or nil>          ;; nil = index-free (single-map / kw / vec-target)
+ :root?         <bool>}               ;; true iff decl-path is []
+```
+
+This closes the four cases the reconstruction missed:
+
+- **Candidate-vector `:on`** — `:candidate-idx` names the MATCHED
+  candidate (`[:states <s> :on <ev> <i>]`), not the hardcoded index 0.
+- **`:always` nonzero candidate** — `:candidate-idx` names the matched
+  `:always` candidate (`[:states <s> :always <i>]`); the index-free
+  single-map form carries `:candidate-idx nil` and resolves to the bare
+  `[:states <s> :always]` slot (the rf2-k7yqod keying).
+- **`:after`-action** — `:delay-key` names the exact `:after` slot
+  (`[:states <s> :after <delay-key>]`); the reconstruction could only
+  emit the bare `[:states <s> :after]` (delay-key unknown).
+- **Root / parallel-root `:on`** — `:decl-path []` / `:root? true`
+  resolves a root-relative `[:on <ev>]` slot OUTSIDE `:states`; the
+  reconstruction assumed a `:states` prefix.
+
+`:candidate-idx` is meaningful ONLY for the multi-candidate VECTOR value
+form (the only form the inline-source macro keys per-index); the
+single-map / keyword-target / vector-target forms carry `:candidate-idx
+nil` so the slot resolves at the bare path, matching the macro's keying.
+Boundary `:exit` / `:entry` actions are not transition actions — they
+carry NO discriminator and resolve via the `:source-state` /
+`:target-state` reconstruction. A guard's exact slot rides an explicit
+`:spec-path` tag on the `:rf.machine/guard-evaluated` trace
+(`guard-cascade-row` carries it; `cascade-row-source-key` prefers it).
 
 For `:transition` rows, the body renders the **logical-state DELTA
 box** (rf2-iwy0c — see "Transition row" below), NOT a source form;

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff.cljs
@@ -12,19 +12,24 @@
   The section model `app-db-diff-helpers/current-state-sections`
   produces drives the body:
 
-    - a TOP section — the app-db MINUS every reserved `:rf/*` key (the
-      user-domain app-db). Per spec/Conventions.md §Reserved app-db
-      keys the runtime owns ONE top-level slot, `:rf/runtime`, and any
-      `:rf.<subns>/*` keys the framework stashes at the root.
+    - a TOP section — the app-db MINUS every reserved `:rf*` key (the
+      user-domain app-db). Per spec/Conventions.md §Reserved namespaces
+      any `:rf/*` / `:rf.<subns>/*` key the framework stashes at the
+      app-db root is hidden from TOP.
     - one section per operator-facing runtime area (per the
       `runtime-areas` table — machines, routing, spawned, system-ids,
-      pending-navigation, elision — all nested under `:rf/runtime`).
-      Map-of-instances areas (`:rf/machines`, `:rf/spawned`) FAN OUT to
-      one named sub-section per instance (section title = the instance
-      id, e.g. `:title/flow`). Singleton slices (the current-route
-      slice at `[:rf/runtime :routing :current]` per spec/012 §The
-      `:rf/route` slice, and the rest) render as one section each.
-      Absent / empty areas still render, as an empty-state placeholder.
+      pending-navigation, elision), sourced from the SEPARATE runtime-db
+      partition (EP-0001 rf2-vzld77 / rf2-tj6w9l — the framework's durable
+      subsystem state moved out of app-db's `:rf/runtime` into the
+      `:rf.runtime/*` runtime-db roots; this panel reads it via
+      `:rf.xray/target-frame-runtime-db` + each focused epoch's runtime-db
+      pre/post-image, the same way the Machines inspector + Routing tab
+      do). Map-of-instances areas (`:rf/machines`, `:rf/spawned`) FAN OUT
+      to one named sub-section per instance (section title = the instance
+      id, e.g. `:title/flow`). Singleton slices (the current-route slice
+      at `[:rf.runtime/routing :current]` per spec/012 §The `:rf/route`
+      slice, and the rest) render as one section each. Absent / empty
+      areas are omitted (rf2-jcdvo).
 
   Values render through the canonical EDN widget's cljs-devtools
   current-state path (`views.edn-widget/inspect`), the same

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
@@ -31,12 +31,13 @@
 
   ## Reserved-keys partition — `partition-reserved`
 
-  Per spec §Reserved-keys group the runtime owns ONE top-level key
-  (`:rf/runtime`) which nests the per-area sub-paths catalogued in the
-  `runtime-areas` table (machines, routing, system-ids, pending-
-  navigation, spawned, …). Diff triples whose path roots in
-  `:rf/runtime` render in a separate `[runtime]` group; the rest
-  render as slice mini-panels.
+  EP-0001 (rf2-vzld77 / rf2-tj6w9l): the runtime subsystems (machines /
+  routing / elision) moved out of app-db's `:rf/runtime` into a SEPARATE
+  runtime-db partition (`:rf.runtime/*`). The `[runtime]` group is built
+  from that partition via the `runtime-areas` table + `reserved-summary`;
+  `partition-reserved` / `reserved-path?` now key on the reserved `:rf*`
+  NAMESPACE family (a framework-internal slot a host might stash at the
+  app-db root) — a normal app-db diff triple is never reserved.
 
   ## rf2-e9tb0 — pin-store helpers dropped
 
@@ -57,34 +58,51 @@
 
 ;; ---- reserved keys --------------------------------------------------------
 
+(defn reserved-namespace-key?
+  "True when `k` is a qualified keyword in the reserved `:rf/*` or
+  `:rf.<subns>/*` namespace family per spec/Conventions.md §Reserved
+  namespaces. Catches any framework-internal key the runtime / framework
+  stashes at the app-db root (e.g. a transient `:rf.machine/*` slot). The
+  user-domain TOP section must hide all of these — they're framework
+  plumbing, not user-domain state. Pure data → bool."
+  [k]
+  (boolean
+    (when (qualified-keyword? k)
+      (let [ns (namespace k)]
+        (or (= ns "rf")
+            (str/starts-with? ns "rf."))))))
+
 (def reserved-app-db-keys
-  "Per spec/Conventions.md §Reserved app-db keys + the rf2-eguy4 phase-A
-  contract the runtime owns ONE top-level slot in `app-db`: `:rf/runtime`.
-  Diff triples whose path roots in `:rf/runtime` render in the `[runtime]`
-  group rather than as a slice mini-panel.
+  "EP-0001 (rf2-vzld77 / rf2-tj6w9l): the framework's durable subsystem
+  state — machine snapshots, the route slice, the spawn registry, the
+  elision registry — moved OUT of app-db's `:rf/runtime` container into a
+  SEPARATE runtime-db partition (the reserved `:rf.runtime/*` roots). So
+  app-db no longer carries a `:rf/runtime` slot, and a normal user-domain
+  app-db roots NO key in the reserved `:rf*` namespace family. This set is
+  kept EMPTY: the App-DB panel sources its reserved AREAS from the
+  runtime-db partition (the `runtime-areas` table below + the
+  `:rf.xray/target-frame-runtime-db` sub), not from app-db diff triples,
+  so nothing in an app-db diff is runtime-owned.
 
-  The `:rf/runtime` container nests the six logical runtime subsystems:
-
-  - `[:rf/runtime :machines :snapshots]` — machine snapshots (per spec/005-StateMachines.md)
-  - `[:rf/runtime :machines :system-ids]` — system-id reverse index
-  - `[:rf/runtime :machines :spawned]` — spawned-actor table
-  - `[:rf/runtime :routing :current]` — current route slice (per spec/012-Routing.md)
-  - `[:rf/runtime :routing :pending-navigation]` — pending-nav slot
-  - `[:rf/runtime :elision]` — wire-elision declaration registry (per spec/009-Instrumentation.md §Size elision)
-
-  The panel still surfaces these as separate sections via the
-  `runtime-areas` table below (logical area-id → sub-path) — the operator
-  sees one section per subsystem, but the underlying app-db shape is the
-  single `:rf/runtime` container."
-  #{:rf/runtime})
+  The broader reserved-NAMESPACE family (`reserved-namespace-key?` —
+  `:rf/*` / `:rf.<subns>/*`) is still used by `user-domain-db` to hide any
+  framework-internal slot a host might stash at the app-db root; that is a
+  separate, namespace-level filter from this (now-empty) root-key set."
+  #{})
 
 (defn reserved-path?
-  "True when `path`'s root key is a reserved-app-db key. Pure data →
-  bool."
+  "True when `path`'s root key is in the reserved-NAMESPACE family
+  (`:rf/*` / `:rf.<subns>/*`, per `reserved-namespace-key?`) — i.e. a
+  framework-internal slot the user-domain TOP section must not surface as
+  a slice mini-panel. EP-0001 (rf2-tj6w9l): the runtime subsystems
+  (machines / routing / elision) no longer live in app-db, so a normal
+  app-db diff triple is never reserved; this predicate now catches only a
+  framework-internal `:rf*`-namespaced root a host might stash in app-db.
+  Pure data → bool."
   [path]
   (boolean (and (sequential? path)
                 (seq path)
-                (contains? reserved-app-db-keys (first path)))))
+                (reserved-namespace-key? (first path)))))
 
 ;; ---- diff algorithm -------------------------------------------------------
 
@@ -241,41 +259,52 @@
 
 ;; ---- runtime subsystem area table ---------------------------------------
 ;;
-;; Per rf2-eguy4 phase-A the runtime owns a single `:rf/runtime` top-level
-;; slot containing nested subsystem trees. The panel still surfaces these
-;; as separate operator-facing sections; this table maps the logical
-;; area-id (the operator-facing label) to the sub-path under `:rf/runtime`
-;; that carries the area's value.
+;; EP-0001 (rf2-vzld77 / rf2-tj6w9l): the framework's durable subsystem
+;; state — machine snapshots, the route slice, the spawn registry, the
+;; elision registry — moved OUT of app-db's `:rf/runtime` container into a
+;; SEPARATE runtime-db partition (`:rf.db/runtime` in the frame-state),
+;; whose top-level keys are the reserved `:rf.runtime/*` namespace family
+;; (`:rf.runtime/machines` / `:rf.runtime/routing` / `:rf.runtime/elision`).
+;; The App-DB panel surfaces these as separate operator-facing sections;
+;; this table maps the logical area-id (the operator-facing label) to the
+;; sub-path UNDER THE RUNTIME-DB PARTITION VALUE that carries the area's
+;; value — sourced from `:rf.xray/target-frame-runtime-db` (the live
+;; partition) and each focused epoch's runtime-db pre/post-image (the
+;; `:rf.db/runtime` projection of `:frame-state-before` / `-after`),
+;; mirroring the Machines inspector + Routing tab which already read
+;; runtime-db at these paths.
 
 (def runtime-areas
-  "Logical area-id → sub-path under app-db. The area-ids are the
-  operator-facing labels carried in the panel's section model (kept
-  stable across the rf2-eguy4 phase-A reshape so caller / test code that
+  "Logical area-id → sub-path under the RUNTIME-DB partition value. The
+  area-ids are the operator-facing labels carried in the panel's section
+  model (stable across the EP-0001 migration so caller / test code that
   uses `:area :rf/machines` etc. still reads as before). The paths point
-  into the new `:rf/runtime` container (per spec/Conventions.md §Reserved
-  app-db keys + spec/002-Frames.md §The `:rf/runtime` container)."
-  {:rf/machines           [:rf/runtime :machines :snapshots]
-   :rf/spawned            [:rf/runtime :machines :spawned]
-   :rf/route              [:rf/runtime :routing :current]
-   :rf/system-ids         [:rf/runtime :machines :system-ids]
-   :rf/pending-navigation [:rf/runtime :routing :pending-navigation]
-   :rf/elision            [:rf/runtime :elision]})
+  into the runtime-db partition's reserved `:rf.runtime/*` roots (per
+  spec/Conventions.md §Reserved runtime-db keys + spec/002-Frames.md §The
+  two-partition frame contract; EP-0001 rf2-vzld77)."
+  {:rf/machines           [:rf.runtime/machines :snapshots]
+   :rf/spawned            [:rf.runtime/machines :spawned]
+   :rf/route              [:rf.runtime/routing :current]
+   :rf/system-ids         [:rf.runtime/machines :system-ids]
+   :rf/pending-navigation [:rf.runtime/routing :pending-navigation]
+   :rf/elision            [:rf.runtime/elision]})
 
 (defn reserved-summary
-  "Project the current runtime subsystem slots out of `db` into a sorted
-  vector of `[area-id value]` pairs for the panel's `[runtime]` group.
-  Drops areas with no live value so the group is sized by what's
-  actually populated.
+  "Project the current runtime subsystem slots out of the RUNTIME-DB
+  partition value `runtime-db` into a sorted vector of `[area-id value]`
+  pairs for the panel's `[runtime]` group. Drops areas with no live value
+  so the group is sized by what's actually populated.
 
   Logical area-ids (`:rf/machines`, `:rf/route`, …) are the operator-
   facing labels per the `runtime-areas` table; the values are read from
-  the nested `[:rf/runtime ...]` sub-paths (per rf2-eguy4 phase-A).
+  the `[:rf.runtime/...]` sub-paths (EP-0001 rf2-vzld77 — runtime-db
+  partition, no longer app-db `:rf/runtime`).
 
   Pure data → data."
-  [db]
+  [runtime-db]
   (vec
     (for [area-id (sort (keys runtime-areas))
-          :let    [v (get-in db (get runtime-areas area-id))]
+          :let    [v (get-in runtime-db (get runtime-areas area-id))]
           :when   (some? v)]
       [area-id v])))
 
@@ -336,29 +365,16 @@
   slices rendered as one section. Pure data."
   #{:rf/machines :rf/spawned})
 
-(defn reserved-namespace-key?
-  "True when `k` is a qualified keyword in the reserved `:rf/*` or
-  `:rf.<subns>/*` namespace family per spec/Conventions.md §Reserved
-  namespaces. Catches BOTH the single explicit reserved-app-db-key
-  (`:rf/runtime`) AND any other framework-internal key the runtime
-  stashes at the app-db root (e.g. `:rf.machine/*` slots). The
-  user-domain TOP section must hide all of these — they're framework
-  plumbing, not user-domain state. Pure data → bool."
-  [k]
-  (boolean
-    (when (qualified-keyword? k)
-      (let [ns (namespace k)]
-        (or (= ns "rf")
-            (str/starts-with? ns "rf."))))))
-
 (defn user-domain-db
   "Return `db` with every reserved `:rf*`-namespaced key removed —
   the user-domain app-db that heads the inspector's TOP section. The
-  filter catches both the single explicit reserved-app-db-key
-  (`:rf/runtime`, per spec/Conventions.md §Reserved app-db keys) AND
-  any framework-internal slot the runtime stashes under the broader
-  reserved-namespace family (e.g. `:rf.machine/*`). Pure data → map.
-  nil-safe (nil db → empty map)."
+  filter catches any framework-internal slot the framework stashes at the
+  app-db root under the reserved-namespace family (`:rf/*` /
+  `:rf.<subns>/*`, e.g. a transient `:rf.machine/*` slot). EP-0001
+  (rf2-tj6w9l) — the runtime subsystems no longer live in app-db (they
+  moved to the runtime-db partition), so in practice a normal app-db has
+  no reserved key to strip; the filter remains for any host that does
+  stash one. Pure data → map. nil-safe (nil db → empty map)."
   [db]
   (into {} (remove (fn [[k _v]] (reserved-namespace-key? k))) (or db {})))
 
@@ -429,10 +445,11 @@
     []))
 
 (defn current-state-sections
-  "Decompose a current `app-db` value into the app-db tab's
-  current-state section model (rf2-okvit):
+  "Decompose the frame's TWO partitions — the `app-db` value + the
+  `runtime-db` partition value — into the app-db tab's current-state
+  section model (rf2-okvit; EP-0001 rf2-vzld77 / rf2-tj6w9l):
 
-      {:top   <db-minus-reserved-keys>          ;; user-domain app-db
+      {:top   <app-db-minus-reserved-keys>      ;; user-domain app-db
        :areas [{:area  :rf/machines
                 :kind  :instances
                 :empty? false
@@ -443,7 +460,14 @@
                 :value {…}}
                …]}
 
-  One area entry per POPULATED reserved `:rf/*` key (in
+  The TOP user-domain section is the `app-db` value minus the reserved
+  `:rf*`-namespaced keys; the reserved AREAS are read from the SEPARATE
+  `runtime-db` partition value at the `[:rf.runtime/...]` `runtime-areas`
+  paths (EP-0001 — the framework's durable subsystem state moved out of
+  app-db's `:rf/runtime` into the runtime-db partition; this panel sources
+  it the same way the Machines inspector + Routing tab do).
+
+  One area entry per POPULATED reserved subsystem (in
   `reserved-area-order`). Map-of-instances areas
   (`map-of-instances-areas`) carry `:kind :instances` + an `:instances`
   vector (one entry per id); every other reserved area is
@@ -496,33 +520,46 @@
   prior user-domain map, so a NEW user-domain key already classifies
   `:added` per-key inside the diff engine.)
 
-  Pure data → data. JVM-runnable. nil-safe throughout (absent db,
-  empty db, absent reserved keys, empty registries, absent before-db)."
-  ([db] (current-state-sections db no-diff))
-  ([db db-before]
-   (let [db          (or db {})
-         diff?       (not= no-diff db-before)
-         before-db   (if diff? (or db-before {}) no-diff)
-         before-area (fn [area-id]
-                       (if diff?
-                         (let [path (get runtime-areas area-id)
-                               v    (get-in before-db path ::absent)]
-                           ;; rf2-227cz — in diff mode a singleton slice
-                           ;; absent in `before-db` is `:added` (the slot
-                           ;; appeared this epoch — e.g. first navigation
-                           ;; populating `:rf/route`), NOT `no-diff`. Only
-                           ;; a slot genuinely present (incl. present-nil)
-                           ;; diffs in place.
-                           (if (= ::absent v) added v))
-                         no-diff))]
-     {:top   (user-domain-db db)
+  ## Arities (EP-0001 rf2-tj6w9l)
+
+    (current-state-sections app-db runtime-db)
+      — current state, no diff (`:before-top` + each `:before` are the
+        `no-diff` sentinel).
+    (current-state-sections app-db runtime-db
+                            {:app <app-db-before> :runtime <runtime-db-before>})
+      — diff mode: the TOP diffs against the app-db pre-image, each
+        reserved area diffs against the runtime-db pre-image. Pass `nil`
+        / `no-diff` for the before-image map to stay in no-diff mode.
+
+  Pure data → data. JVM-runnable. nil-safe throughout (absent / empty
+  partitions, absent reserved keys, empty registries, absent before-images)."
+  ([app-db runtime-db] (current-state-sections app-db runtime-db no-diff))
+  ([app-db runtime-db before]
+   (let [app-db        (or app-db {})
+         runtime-db    (or runtime-db {})
+         diff?         (and (some? before) (not= no-diff before))
+         app-before    (if diff? (or (:app before) {}) no-diff)
+         runtime-before (if diff? (or (:runtime before) {}) no-diff)
+         before-area   (fn [area-id]
+                         (if diff?
+                           (let [path (get runtime-areas area-id)
+                                 v    (get-in runtime-before path ::absent)]
+                             ;; rf2-227cz — in diff mode a singleton slice
+                             ;; absent in the runtime-db pre-image is `:added`
+                             ;; (the slot appeared this epoch — e.g. first
+                             ;; navigation populating `:rf/route`), NOT
+                             ;; `no-diff`. Only a slot genuinely present (incl.
+                             ;; present-nil) diffs in place.
+                             (if (= ::absent v) added v))
+                           no-diff))]
+     {:top   (user-domain-db app-db)
       :before-top (if diff?
-                    (user-domain-db before-db)
+                    (user-domain-db app-before)
                     no-diff)
       :areas (vec
                (for [area reserved-area-order
                      :let [path        (get runtime-areas area)
-                           area-value  (get-in db path ::absent)
+                           area-value  (get-in runtime-db path ::absent)
                            present?    (not= ::absent area-value)
                            area-value  (when present? area-value)
                            entry       (if (contains? map-of-instances-areas area)

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_state.cljs
@@ -5,16 +5,17 @@
   NOT a diff. This ns renders the section model
   `app-db-diff-helpers/current-state-sections` produces:
 
-    - a TOP section — the app-db MINUS every reserved `:rf/*` key (the
+    - a TOP section — the app-db MINUS every reserved `:rf*` key (the
       user-domain app-db). ALWAYS renders, even when empty.
     - one section per POPULATED operator-facing runtime area (per the
-      `runtime-areas` table — all nested under the single reserved
-      `:rf/runtime` slot per spec/Conventions.md §Reserved app-db
-      keys). Map-of-instances areas (`:rf/machines`, `:rf/spawned`)
-      FAN OUT to one named sub-section per instance — section title =
-      the instance id (e.g. `:title/flow`). Singleton slices
-      (`:rf/route`, `:rf/system-ids`, `:rf/pending-navigation`,
-      `:rf/elision`) render as one section each.
+      `runtime-areas` table — sourced from the runtime-db partition's
+      `:rf.runtime/*` roots per EP-0001 rf2-vzld77 / rf2-tj6w9l, no
+      longer app-db's retired `:rf/runtime` container). Map-of-instances
+      areas (`:rf/machines`, `:rf/spawned`) FAN OUT to one named
+      sub-section per instance — section title = the instance id (e.g.
+      `:title/flow`). Singleton slices (`:rf/route`, `:rf/system-ids`,
+      `:rf/pending-navigation`, `:rf/elision`) render as one section
+      each.
 
   rf2-jcdvo — empty / absent reserved areas are FILTERED at projection
   time (`current-state-sections` omits any `:empty?` entry). The

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
@@ -217,12 +217,26 @@
   ;;   with no diff overlay (unchanged from rf2-yng0y).
   (rf/reg-sub :rf.xray/app-db-current+diff
     :<- [:rf.xray/target-frame-db]
+    :<- [:rf.xray/target-frame-runtime-db]
     :<- [:rf.xray/epoch-history]
     :<- [:rf.xray/focus]
-    (fn [[db history focus] _query]
+    (fn [[db runtime-db history focus] _query]
       (let [epoch-id (:epoch-id focus)
             record   (when epoch-id (find-epoch-in-history history epoch-id))
-            before   (when record (:db-before record))]
+            before   (when record (:db-before record))
+            ;; EP-0001 (rf2-tj6w9l) — the reserved AREAS read the runtime-db
+            ;; PARTITION (machines / routing / elision moved there), so the
+            ;; section model needs the focused epoch's runtime-db value +
+            ;; pre-image too. The epoch record stores the WHOLE frame-state
+            ;; (`:frame-state-before` / `-after`, decision #2), each carrying
+            ;; the `:rf.db/runtime` partition; project it out so the runtime
+            ;; areas move per-epoch in lockstep with the app-db `:value` /
+            ;; `:before`. Cold boot / no focus → the LIVE runtime-db.
+            rt-value  (if record
+                        (get (:frame-state-after record) :rf.db/runtime)
+                        runtime-db)
+            rt-before (when record
+                        (get (:frame-state-before record) :rf.db/runtime))]
         {;; rf2-02j4r — `:value` is the focused epoch's `:db-after` (its
          ;; OWN post-state), so the inline diff is db-before(N) →
          ;; db-after(N) = epoch N's per-epoch delta, not the cumulative
@@ -233,37 +247,46 @@
          ;; `:value`, `:before` and `:epoch-id` all come from the SAME
          ;; record — they move together, never one-frame apart.
          :before   before
+         ;; The runtime-db partition value + pre-image for the focused
+         ;; epoch (the reserved areas' source post-EP-0001).
+         :runtime-value  rt-value
+         :runtime-before rt-before
          :epoch-id (when record epoch-id)})))
 
   ;; ---- rf2-okvit / rf2-ad7zx.11 — current-state section model ---------
   ;;
-  ;; Decomposes the atomic `{:value :before :epoch-id}` (above) into the
-  ;; section model `current-state-sections` produces: the TOP
-  ;; user-domain section (app-db minus reserved keys) + one section per
-  ;; reserved `:rf/*` area (machines/spawned fan out per instance; route
-  ;; + the other slices are singletons).
+  ;; Decomposes the atomic `{:value :before :runtime-value :runtime-before
+  ;; :epoch-id}` (above) into the section model `current-state-sections`
+  ;; produces: the TOP user-domain section (app-db minus reserved keys) +
+  ;; one section per reserved runtime subsystem (machines/spawned fan out
+  ;; per instance; route + the other slices are singletons).
   ;;
-  ;; The focused epoch's `:db-before` is threaded as the diff PRE-IMAGE
+  ;; EP-0001 (rf2-tj6w9l) — the TWO partitions feed two halves of the
+  ;; model: the app-db `:value` / `:before` drives the user-domain TOP
+  ;; section; the runtime-db `:runtime-value` / `:runtime-before` drives
+  ;; the reserved areas (machines / routing / elision moved to the
+  ;; runtime-db partition). Both move per focused-epoch in lockstep.
+  ;;
+  ;; The focused epoch's pre-images are threaded as the diff PRE-IMAGE
   ;; (spec/021 §4.3) so each section's changed nodes carry the inline
   ;; `← was X` annotation in place. Because this derives from the atomic
   ;; sub, the section model's `:before-top` / per-area `:before` slices
   ;; ALWAYS belong to the focused `:epoch-id` — no stale-`before`
   ;; intermediate frame (rf2-yng0y).
   ;;
-  ;; nil-safe — an absent / empty db yields an empty TOP + zero
+  ;; nil-safe — absent / empty partitions yield an empty TOP + zero
   ;; reserved-area entries (rf2-jcdvo — empty areas are filtered at
   ;; projection time so the renderer never draws placeholder cards).
   (rf/reg-sub :rf.xray/app-db-state
     :<- [:rf.xray/app-db-current+diff]
-    (fn [{:keys [value before]} _query]
-      ;; Diff-mode is entered iff a real pre-image is present, mirroring
-      ;; the pre-rf2-yng0y `(if-let [before (:db-before record)] …)`
-      ;; contract: an absent / nil `:db-before` (cold boot, or a record
-      ;; with no pre-image slot) renders plain current-state. The atomic
-      ;; sub carries `before` = the focused record's `:db-before` (or nil
-      ;; when no epoch is focused), so this preserves the exact prior
-      ;; diff/no-diff behaviour while inheriting the atomic sub's
-      ;; stale-`before`-free contract.
+    (fn [{:keys [value before runtime-value runtime-before]} _query]
+      ;; Diff-mode is entered iff a real app-db pre-image is present,
+      ;; mirroring the pre-rf2-yng0y `(if-let [before (:db-before record)]
+      ;; …)` contract: an absent / nil `:db-before` (cold boot, or a record
+      ;; with no pre-image slot) renders plain current-state. When diffing,
+      ;; the runtime areas diff against the SAME focused epoch's runtime-db
+      ;; pre-image.
       (if (some? before)
-        (h/current-state-sections value before)
-        (h/current-state-sections value)))))
+        (h/current-state-sections value runtime-value
+                                  {:app before :runtime runtime-before})
+        (h/current-state-sections value runtime-value)))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/format.cljc
@@ -295,11 +295,68 @@
                       (if state (pr-str state) "?"))
     (str (when kind (name kind)))))
 
+(defn transition-slot->spec-prefix
+  "rf2-lai1qv — turn the substrate's EXACT spec-path discriminator
+  (`:transition-slot`, stamped by `re-frame.machines.transition/
+  transition-slot` on a selected transition's `:rf.machine/action-ran`
+  emit) into the inline-source spec-path PREFIX — the path up to and
+  including the slot, BEFORE the `:action` / `:guard` leaf. The caller
+  appends the leaf.
+
+  The discriminator carries the matched declaration faithfully — the
+  candidate index for a multi-candidate VECTOR form (nil for the
+  index-free single-map / keyword / vector-target forms, matching the
+  macro's bare-slot keying), the `:after` delay-key, and the root-vs-state
+  distinction — so this resolves the EXACT slot that the
+  reconstruct-from-`source-state`/`event`/`phase` path could not (it
+  hardcoded candidate 0, could not name the `:after` delay-key, and
+  assumed a `:states` prefix even for a root `:on`).
+
+    {:slot :on :event-key :submit :decl-path [:idle] :candidate-idx nil}
+      => [:states :idle :on :submit]
+    {:slot :on :event-key :go :decl-path [:a :b] :candidate-idx 2}
+      => [:states :a :states :b :on :go 2]
+    {:slot :on :event-key :logout :decl-path [] :root? true}
+      => [:on :logout]                       ;; root / parallel-root :on
+    {:slot :always :decl-path [:loading] :candidate-idx 1}
+      => [:states :loading :always 1]
+    {:slot :always :decl-path [:loading] :candidate-idx nil}
+      => [:states :loading :always]          ;; single-map :always (k7yqod shape)
+    {:slot :after :delay-key 1000 :decl-path [:idle] :candidate-idx nil}
+      => [:states :idle :after 1000]
+
+  Returns nil for an unrecognised / empty discriminator (the caller then
+  falls back to the reconstruct-from-phase path). Pure data."
+  [{:keys [slot event-key delay-key candidate-idx decl-path]}]
+  (let [;; Root `:on` lives OUTSIDE `:states` (decl-path []); a state-scoped
+        ;; slot interleaves `:states`. `state-spec-path-prefix` returns nil
+        ;; for an empty path, which is exactly the root prefix.
+        prefix (or (proj/state-spec-path-prefix decl-path) [])
+        slot-path (case slot
+                    :on    (when event-key (conj prefix :on event-key))
+                    :always (conj prefix :always)
+                    :after (when (some? delay-key) (conj prefix :after delay-key))
+                    nil)]
+    (when slot-path
+      (cond-> slot-path
+        ;; A vector-candidate form carries the matched index; index-free
+        ;; forms (candidate-idx nil) stay at the bare-slot path, matching
+        ;; the macro's keying (rf2-k7yqod / rf2-lai1qv).
+        (some? candidate-idx) (conj candidate-idx)))))
+
 (defn cascade-row-source-key
   "Spec-path tuple used to look up a cascade row's source-coord on the
   registered machine spec. Pure-data; the view layer reuses this for the
   coord lookup so the source-link affordance reads off ONE authoritative
   key.
+
+  rf2-lai1qv — when the row carries an EXACT spec-path (`:spec-path`, an
+  explicit tuple) or the substrate's spec-path discriminator
+  (`:transition-slot`, for an inline transition `:action`), those WIN over
+  the reconstruct-from-`source-state`/`event`/`phase` path below. The
+  reconstruction is the fallback for rows lacking the carried slot
+  (named-handler keys, `:exit` / `:entry` boundary actions, timers, and
+  legacy traces without the discriminator).
 
   Per rf2-npvsx / rf2-vqja2 the lookup target differs by tuple shape:
   - Named `[:guards <id>]` / `[:actions <id>]` keys resolve to the
@@ -346,16 +403,30 @@
   - `:timer` → `[:states <state>...]`
     (D1 minimum-viable: the parent state's source-coord chip; richer
     per-`:after` coord is the D2 follow-on bead's surface)."
-  [{:keys [kind action-id guard-id phase source-state target-state event-id]
+  [{:keys [kind action-id guard-id phase source-state target-state event-id
+           spec-path transition-slot]
     timer-state :state}]
   (let [source-prefix (proj/state-spec-path-prefix source-state)
         target-prefix (proj/state-spec-path-prefix target-state)
-        timer-prefix  (proj/state-spec-path-prefix timer-state)]
+        timer-prefix  (proj/state-spec-path-prefix timer-state)
+        ;; rf2-lai1qv — the EXACT slot prefix the substrate's discriminator
+        ;; resolves to (candidate index / `:after` delay-key / root), or nil
+        ;; when the row carries no discriminator (boundary actions, named
+        ;; handlers, legacy traces).
+        slot-prefix   (when (map? transition-slot)
+                        (transition-slot->spec-prefix transition-slot))]
     (case kind
       :action
       (cond
         ;; Named-handler path (keyword id) — definition-site stamp.
         (keyword? action-id) [:actions action-id]
+        ;; rf2-lai1qv — an EXACT carried spec-path wins outright.
+        (vector? spec-path) spec-path
+        ;; rf2-lai1qv — the substrate's spec-path discriminator addresses
+        ;; the precise inline-source slot for the transition `:action`
+        ;; (candidate-vector `:on`, nonzero `:always` candidate, `:after`
+        ;; delay-key, root `:on`) — append the `:action` leaf.
+        slot-prefix (conj slot-prefix :action)
         ;; Inline-fn path — slot stamp under the relevant state.
         (contains? #{:entry :initial-entry} phase)
         (when target-prefix (conj target-prefix :entry))
@@ -365,11 +436,12 @@
         (when (and source-prefix event-id)
           (conj source-prefix :on event-id :action))
         (= :always phase)
-        ;; The index-free single-map shape (rf2-k7yqod). The macro keys a
+        ;; Fallback for a row WITHOUT the discriminator (legacy trace): the
+        ;; index-free single-map shape (rf2-k7yqod). The macro keys a
         ;; single-map `:always` at the bare `:always` path; the view's
         ;; read-back additionally probes the index-0 vector-candidate path
-        ;; so a `:always [{…}]` vector resolves too (rf2-lai1qv carries the
-        ;; exact matched index for richer multi-candidate resolution).
+        ;; so a `:always [{…}]` vector resolves too. The discriminator path
+        ;; above carries the EXACT matched index when present (rf2-lai1qv).
         (when source-prefix (conj source-prefix :always :action))
         (= :after-action phase)
         (when source-prefix (conj source-prefix :after :action))
@@ -378,6 +450,10 @@
       :guard
       (cond
         (keyword? guard-id) [:guards guard-id]
+        ;; rf2-lai1qv — an EXACT carried spec-path wins (the substrate may
+        ;; stamp `:spec-path` on the `:rf.machine/guard-evaluated` trace for
+        ;; an inline candidate-vector guard; `guard-cascade-row` carries it).
+        (vector? spec-path) spec-path
         :else
         (when (and source-prefix event-id)
           (conj source-prefix :on event-id :guard)))

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -624,6 +624,14 @@
              :duration-ms (common/tag-of ev :duration-ms)
              :machine-id  (common/tag-of ev :machine-id)
              :input       input}
+      ;; rf2-lai1qv — the substrate stamps the selected transition's EXACT
+      ;; spec-path discriminator (`:transition-slot`) on the action-ran
+      ;; trace for the transition `:action`; carry it onto the row so
+      ;; `cascade-row-source-key` addresses the precise inline-source slot
+      ;; (candidate index / `:after` delay-key / root) rather than
+      ;; reconstructing from source-state / event / phase.
+      (common/tag-of ev :transition-slot)
+      (assoc :transition-slot (common/tag-of ev :transition-slot))
       (common/tag-of ev :exception)
       (assoc :exception (common/tag-of ev :exception))
       (seq action-fx)

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_cljs_test.cljs
@@ -106,6 +106,23 @@
   (frame/reg-frame :rf/default {})
   (rf/reset-frame-db! :rf/default db-value))
 
+(defn- seed-host-runtime-db!
+  "Install `runtime-db-value` into the host (:rf/default) frame's
+  RUNTIME-DB partition (EP-0001 rf2-tj6w9l — the App-DB panel sources its
+  reserved AREAS from the runtime-db partition via
+  `:rf.xray/target-frame-runtime-db`). A framework-authority
+  `reg-event-fx` returning the reserved `:rf.db/runtime` effect installs
+  the partition (the same path the machines / routing lifecycle-fx write);
+  `:rf/machine? true` marks it framework-authority so the runtime-write
+  diagnostic does not fire."
+  [runtime-db-value]
+  (frame/reg-frame :rf/default {})
+  (rf/reg-event-fx :rf.xray-test/seed-runtime-db
+    {:rf/machine? true}
+    (fn [_ _] {:rf.db/runtime runtime-db-value}))
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [:rf.xray-test/seed-runtime-db])))
+
 (defn- seed-xray!
   "Wire the Phase 5 sub graph + seed history + host-frame db. The
   test environment proxies the production wiring path (preload +
@@ -511,11 +528,13 @@
 (deftest panel-sections-reserved-areas
   (testing "reserved runtime subsystems render as their own sections:
             machines fan out one section per machine id; route is a
-            singleton. App-db lives under [:rf/runtime ...]."
-    (seed-host-frame! {:cart {:items [{:id 7}]}
-                       :rf/runtime {:routing  {:current {:id :app/cart}}
-                                    :machines {:snapshots {:auth       {:state :idle}
-                                                           :title/flow {:state :playing}}}}})
+            singleton. EP-0001 (rf2-tj6w9l): the runtime subsystems live
+            in the runtime-db partition at [:rf.runtime/...], NOT app-db's
+            retired :rf/runtime container."
+    (seed-host-frame! {:cart {:items [{:id 7}]}})
+    (seed-host-runtime-db! {:rf.runtime/routing  {:current {:id :app/cart}}
+                            :rf.runtime/machines {:snapshots {:auth       {:state :idle}
+                                                              :title/flow {:state :playing}}}})
     (registry/register-xray-handlers!)
     (frame/reg-frame :rf/xray {})
     (rf/with-frame :rf/xray

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_helpers_cljs_test.cljc
@@ -149,60 +149,54 @@
 
 ;; ---- (3) reserved-keys partition ----------------------------------------
 ;;
-;; Per rf2-eguy4 phase-A the runtime owns ONE top-level slot — `:rf/runtime` —
-;; containing nested subsystem trees (`:machines :snapshots`, `:routing`,
-;; `:elision`, …). The panel still surfaces these as separate sections via
-;; the `runtime-areas` table; the reserved-keys partition now keys on the
-;; single `:rf/runtime` root.
+;; EP-0001 (rf2-vzld77 / rf2-tj6w9l): the runtime subsystems (machines /
+;; routing / elision) moved OUT of app-db's `:rf/runtime` container into a
+;; SEPARATE runtime-db partition keyed by the reserved `:rf.runtime/*`
+;; namespace. The App-DB panel surfaces them as sections via the
+;; `runtime-areas` table (now pointing into the runtime-db partition); the
+;; reserved-keys partition / `reserved-path?` now key on the reserved
+;; `:rf*` NAMESPACE family (a normal app-db diff triple is never reserved).
 
-(deftest reserved-app-db-keys-is-rf-runtime
-  (testing "reserved-app-db-keys contains the single :rf/runtime root
-            (per rf2-eguy4 phase-A)"
-    (is (= #{:rf/runtime} h/reserved-app-db-keys))))
+(deftest reserved-app-db-keys-is-empty-post-migration
+  (testing "EP-0001 (rf2-tj6w9l) — runtime subsystems moved to the
+            runtime-db partition, so app-db carries no reserved root key;
+            reserved-app-db-keys is empty"
+    (is (= #{} h/reserved-app-db-keys))))
 
-(deftest runtime-areas-covers-the-six-subsystems
+(deftest runtime-areas-covers-the-six-subsystems-in-runtime-db
   (testing "runtime-areas maps each operator-facing area-id to its
-            sub-path under :rf/runtime (per spec/Conventions.md
-            §Reserved app-db keys + rf2-eguy4 phase-A)"
-    (is (= [:rf/runtime :machines :snapshots]        (get h/runtime-areas :rf/machines)))
-    (is (= [:rf/runtime :machines :spawned]          (get h/runtime-areas :rf/spawned)))
-    (is (= [:rf/runtime :machines :system-ids]       (get h/runtime-areas :rf/system-ids)))
-    (is (= [:rf/runtime :routing :current]           (get h/runtime-areas :rf/route)))
-    (is (= [:rf/runtime :routing :pending-navigation] (get h/runtime-areas :rf/pending-navigation)))
-    (is (= [:rf/runtime :elision]                    (get h/runtime-areas :rf/elision)))))
+            sub-path under the RUNTIME-DB partition's reserved
+            :rf.runtime/* roots (EP-0001 rf2-vzld77 / rf2-tj6w9l)"
+    (is (= [:rf.runtime/machines :snapshots]         (get h/runtime-areas :rf/machines)))
+    (is (= [:rf.runtime/machines :spawned]           (get h/runtime-areas :rf/spawned)))
+    (is (= [:rf.runtime/machines :system-ids]        (get h/runtime-areas :rf/system-ids)))
+    (is (= [:rf.runtime/routing :current]            (get h/runtime-areas :rf/route)))
+    (is (= [:rf.runtime/routing :pending-navigation] (get h/runtime-areas :rf/pending-navigation)))
+    (is (= [:rf.runtime/elision]                     (get h/runtime-areas :rf/elision)))
+    ;; The OLD app-db `:rf/runtime` paths are GONE (the executable check
+    ;; for the stale-path regression rf2-tj6w9l flagged).
+    (is (not (some (fn [p] (= :rf/runtime (first p))) (vals h/runtime-areas)))
+        "no runtime-area path roots in the retired app-db :rf/runtime container")))
 
-(deftest reserved-path-true-for-rf-runtime-root
-  (testing "reserved-path? returns true when the first path key is :rf/runtime"
-    (is (true?  (h/reserved-path? [:rf/runtime :machines :snapshots :auth])))
-    (is (true?  (h/reserved-path? [:rf/runtime :routing :current])))
-    (is (true?  (h/reserved-path? [:rf/runtime])))
+(deftest reserved-path-true-for-reserved-namespace-root
+  (testing "reserved-path? catches the reserved :rf*-namespace family; a
+            normal app-db triple is never reserved (EP-0001 rf2-tj6w9l —
+            runtime subsystems no longer live in app-db)"
+    (is (true?  (h/reserved-path? [:rf/runtime :machines])) ":rf/* root")
+    (is (true?  (h/reserved-path? [:rf.machine/foo])) ":rf.<subns>/* root")
     (is (false? (h/reserved-path? [:cart :items])))
-    (is (false? (h/reserved-path? [:rf/machines :auth]))
-        "post rf2-eguy4 the OLD direct :rf/machines root is not a path consumers should emit")
+    (is (false? (h/reserved-path? [:user :name]))
+        "an ordinary user-domain app-db path is not reserved")
     (is (false? (h/reserved-path? [])))
     (is (false? (h/reserved-path? nil)))))
 
-(deftest partition-reserved-splits-the-vector
-  (testing "partition-reserved separates :rf/runtime-rooted triples from the rest"
-    (let [triples [{:op :modified :path [:cart :items] :before [] :after [1]}
-                   {:op :added    :path [:rf/runtime :routing :current] :before nil :after {:id :home}}
-                   {:op :modified :path [:user :name] :before "ada" :after "ben"}
-                   {:op :modified :path [:rf/runtime :machines :snapshots :auth]
-                    :before {} :after {:state :idle}}]
-          {:keys [reserved non-reserved]}
-          (h/partition-reserved triples)]
-      (is (= 2 (count reserved)))
-      (is (= 2 (count non-reserved)))
-      (is (every? #(h/reserved-path? (:path %)) reserved))
-      (is (every? #(not (h/reserved-path? (:path %))) non-reserved)))))
-
 (deftest reserved-summary-renders-current-runtime-subsystems
   (testing "reserved-summary projects populated runtime subsystem
-            sub-paths into [:area-id value] pairs, sorted by area-id"
-    (let [db {:user "ada"
-              :rf/runtime {:routing  {:current {:id :app/home}}
-                           :machines {:snapshots {:auth-id {:state :idle}}}}}
-          summary (h/reserved-summary db)
+            sub-paths out of the RUNTIME-DB partition value into
+            [:area-id value] pairs, sorted by area-id (EP-0001 rf2-tj6w9l)"
+    (let [runtime-db {:rf.runtime/routing  {:current {:id :app/home}}
+                      :rf.runtime/machines {:snapshots {:auth-id {:state :idle}}}}
+          summary (h/reserved-summary runtime-db)
           ks      (mapv first summary)]
       (is (= [:rf/machines :rf/route] ks)
           "sorted; only logical areas with a live value are surfaced")
@@ -210,14 +204,34 @@
               [:rf/route {:id :app/home}]]
              summary)))))
 
-;; ---- (3b) current-state sectioning (rf2-okvit) --------------------------
+(deftest partition-reserved-splits-on-reserved-namespace
+  (testing "partition-reserved separates triples whose path roots in the
+            reserved :rf* namespace family from the rest (EP-0001
+            rf2-tj6w9l — a normal app-db triple is non-reserved)"
+    (let [triples [{:op :modified :path [:cart :items] :before [] :after [1]}
+                   {:op :modified :path [:user :name] :before "ada" :after "ben"}
+                   {:op :added    :path [:rf.machine/transient :x] :before nil :after 1}]
+          {:keys [reserved non-reserved]}
+          (h/partition-reserved triples)]
+      (is (= 1 (count reserved)) "only the :rf.machine/* triple is reserved")
+      (is (= 2 (count non-reserved)) "the two user-domain triples are not")
+      (is (every? #(h/reserved-path? (:path %)) reserved))
+      (is (every? #(not (h/reserved-path? (:path %))) non-reserved)))))
+
+;; ---- (3b) current-state sectioning (rf2-okvit; EP-0001 rf2-tj6w9l) -------
 ;;
 ;; The app-db tab is a CURRENT-STATE inspector. `current-state-sections`
-;; splits the live app-db into:
+;; splits the frame's TWO partitions into:
 ;;   - TOP: app-db MINUS reserved keys (user-domain). ALWAYS present.
-;;   - one section per POPULATED reserved `:rf/*` area: machines/spawned
-;;     fan out one entry per instance id; route + the other slices are
-;;     singletons.
+;;   - one section per POPULATED reserved runtime area, read from the
+;;     SEPARATE runtime-db partition at the `:rf.runtime/*` paths:
+;;     machines/spawned fan out one entry per instance id; route + the
+;;     other slices are singletons.
+;;
+;; EP-0001 (rf2-tj6w9l): the runtime subsystems moved out of app-db's
+;; `:rf/runtime` into the runtime-db partition. The signature is now
+;; `(current-state-sections app-db runtime-db [before])` — the TOP reads
+;; app-db, the areas read runtime-db at `:rf.runtime/*`.
 ;;
 ;; rf2-jcdvo — empty / absent reserved areas are FILTERED at projection
 ;; time (omitted from `:areas` entirely). The renderer never draws
@@ -229,41 +243,39 @@
   (some (fn [a] (when (= area (:area a)) a)) (:areas model)))
 
 (deftest user-domain-db-strips-reserved-keys
-  (testing "user-domain-db drops every reserved :rf/*-namespaced key,
-            keeps the rest. Post rf2-eguy4 the single `:rf/runtime`
-            container holds the machine / routing / elision subtrees
-            and is filtered along with any other framework-internal
-            `:rf*` keys."
+  (testing "user-domain-db drops every reserved :rf*-namespaced key from
+            app-db, keeps the rest. Post EP-0001 the runtime subsystems
+            no longer live in app-db; this filter still hides any
+            framework-internal `:rf*` key a host stashes at the app-db
+            root."
     (is (= {:cart {:items []} :user "ada"}
            (h/user-domain-db {:cart {:items []}
                               :user "ada"
-                              :rf/runtime {:machines {:snapshots {:m {}}}
-                                           :routing  {:current {:id :home}}
-                                           :elision  {}}})))
+                              :rf.machine/transient {:x 1}})))
     (is (= {} (h/user-domain-db nil)) "nil db → empty map")
-    (is (= {} (h/user-domain-db {:rf/runtime {:routing {:current {:id :home}}}}))
+    (is (= {} (h/user-domain-db {:rf.machine/transient {:x 1}}))
         "reserved-keys-only db → empty user-domain map")))
 
 (deftest current-state-sections-top-is-user-domain
-  (testing "the :top section is the app-db minus the :rf/runtime container"
-    (let [db {:counter 5
-              :user {:name "ada"}
-              :rf/runtime {:routing {:current {:id :app/home}}}}
-          model (h/current-state-sections db)]
+  (testing "the :top section is the app-db minus any reserved :rf* key;
+            the runtime-db partition does NOT contribute to TOP"
+    (let [model (h/current-state-sections
+                  {:counter 5 :user {:name "ada"}}
+                  {:rf.runtime/routing {:current {:id :app/home}}})]
       (is (= {:counter 5 :user {:name "ada"}} (:top model))
-          ":top excludes the :rf/runtime container"))))
+          ":top is the user-domain app-db (runtime-db is the areas' source)"))))
 
 (deftest current-state-sections-enumerates-only-populated-areas
   (testing "rf2-jcdvo — :areas contains ONLY populated runtime
-            subsystems; empty / absent subsystems are omitted entirely
-            (no placeholder cards in the rendered panel)"
-    (let [model (h/current-state-sections {:counter 1})]
+            subsystems (read from runtime-db); empty / absent subsystems
+            are omitted entirely (no placeholder cards in the panel)"
+    (let [model (h/current-state-sections {:counter 1} {})]
       (is (= [] (:areas model))
-          "a user-domain-only db produces zero reserved-area entries"))
+          "an empty runtime-db produces zero reserved-area entries"))
     (let [model (h/current-state-sections
-                  {:counter 1
-                   :rf/runtime {:routing  {:current {:id :home}}
-                                :machines {:snapshots {:auth {:state :idle}}}}})
+                  {:counter 1}
+                  {:rf.runtime/routing  {:current {:id :home}}
+                   :rf.runtime/machines {:snapshots {:auth {:state :idle}}}})
           areas (set (map :area (:areas model)))]
       (is (= #{:rf/machines :rf/route} areas)
           "only the two populated areas appear; the other four reserved
@@ -274,10 +286,11 @@
 (deftest current-state-sections-machines-fan-out-one-per-instance
   (testing ":rf/machines fans out to one instance entry per machine id —
             section title = the machine id, NOT a single combined blob.
-            The snapshots map lives at [:rf/runtime :machines :snapshots]."
-    (let [db {:rf/runtime {:machines {:snapshots {:title/flow {:state :playing}
-                                                  :auth       {:state :idle}}}}}
-          area (area-by (h/current-state-sections db) :rf/machines)]
+            The snapshots map lives at [:rf.runtime/machines :snapshots]
+            in the runtime-db partition (EP-0001 rf2-tj6w9l)."
+    (let [runtime-db {:rf.runtime/machines {:snapshots {:title/flow {:state :playing}
+                                                        :auth       {:state :idle}}}}
+          area (area-by (h/current-state-sections {} runtime-db) :rf/machines)]
       (is (= :instances (:kind area)))
       (is (false? (:empty? area)))
       (is (= 2 (count (:instances area))))
@@ -290,9 +303,9 @@
 
 (deftest current-state-sections-spawned-fans-out-per-parent
   (testing ":rf/spawned (map-of-instances by parent id) lives at
-            [:rf/runtime :machines :spawned] and fans out per parent"
-    (let [db {:rf/runtime {:machines {:spawned {:parent-a {:invoke-1 :spawned-x}}}}}
-          area (area-by (h/current-state-sections db) :rf/spawned)]
+            [:rf.runtime/machines :spawned] and fans out per parent"
+    (let [runtime-db {:rf.runtime/machines {:spawned {:parent-a {:invoke-1 :spawned-x}}}}
+          area (area-by (h/current-state-sections {} runtime-db) :rf/spawned)]
       (is (= :instances (:kind area)))
       (is (= [:parent-a] (mapv :id (:instances area)))))))
 
@@ -300,22 +313,22 @@
   (testing "rf2-jcdvo — an absent OR present-but-empty :rf/machines
             registry is OMITTED from :areas entirely; no placeholder
             card reaches the renderer"
-    (is (nil? (area-by (h/current-state-sections {:counter 1}) :rf/machines))
-        "absent :rf/machines → no area entry")
+    (is (nil? (area-by (h/current-state-sections {:counter 1} {}) :rf/machines))
+        "absent :rf.runtime/machines → no area entry")
     (is (nil? (area-by (h/current-state-sections
-                         {:rf/runtime {:machines {:snapshots {}}}})
+                         {} {:rf.runtime/machines {:snapshots {}}})
                        :rf/machines))
         "present-but-empty registry → no area entry")))
 
 (deftest current-state-sections-route-is-singleton
-  (testing ":rf/route (logical area for [:rf/runtime :routing :current])
+  (testing ":rf/route (logical area for [:rf.runtime/routing :current])
             is a SINGLE current-route slice → :singleton kind, one
             section carrying the slice value"
     (let [route {:id :app/article :params {:id "A"}
                  :query {} :fragment nil :transition :idle
                  :error nil :nav-token "nav-1"}
           area  (area-by (h/current-state-sections
-                           {:rf/runtime {:routing {:current route}}})
+                           {} {:rf.runtime/routing {:current route}})
                          :rf/route)]
       (is (= :singleton (:kind area)))
       (is (false? (:empty? area)))
@@ -325,24 +338,25 @@
 (deftest current-state-sections-absent-route-is-omitted
   (testing "rf2-jcdvo — an absent :rf/route is OMITTED from :areas
             entirely; no placeholder card reaches the renderer"
-    (is (nil? (area-by (h/current-state-sections {:counter 1}) :rf/route))
-        "absent :rf/route → no area entry")))
+    (is (nil? (area-by (h/current-state-sections {:counter 1} {}) :rf/route))
+        "absent :rf.runtime/routing → no area entry")))
 
 (deftest current-state-sections-empty-singleton-collection-is-omitted
-  (testing "rf2-jcdvo — a present-but-empty singleton collection
-            (e.g. {} pending-nav at [:rf/runtime :routing :pending-navigation])
-            is OMITTED from :areas entirely"
+  (testing "rf2-jcdvo — a present-but-empty singleton collection (e.g. {}
+            pending-nav at [:rf.runtime/routing :pending-navigation]) is
+            OMITTED from :areas entirely"
     (is (nil? (area-by (h/current-state-sections
-                         {:rf/runtime {:routing {:pending-navigation {}}}})
+                         {} {:rf.runtime/routing {:pending-navigation {}}})
                        :rf/pending-navigation))
         "{} pending-navigation → no area entry")))
 
 (deftest current-state-sections-nil-and-empty-db-safe
-  (testing "rf2-jcdvo — nil-safe: nil / empty db yields an empty TOP +
-            ZERO reserved-area entries (every reserved area is empty so
-            every entry is filtered out)"
-    (doseq [db [nil {}]]
-      (let [model (h/current-state-sections db)]
+  (testing "rf2-jcdvo — nil-safe: nil / empty partitions yield an empty
+            TOP + ZERO reserved-area entries (every reserved area is empty
+            so every entry is filtered out)"
+    (doseq [app-db [nil {}]
+            rt     [nil {}]]
+      (let [model (h/current-state-sections app-db rt)]
         (is (= {} (:top model)))
         (is (= [] (:areas model))
             "no reserved-area entries — every reserved slot is empty so
@@ -352,60 +366,63 @@
   (testing "areas render in `reserved-area-order` — machines + spawned
             (the registries) lead, then the singleton slices. With every
             runtime subsystem populated, all six appear in canonical
-            order. Underlying app-db lives at [:rf/runtime …]."
-    (let [db    {:rf/runtime {:machines {:snapshots  {:auth {:state :idle}}
-                                         :spawned    {:parent {:invoke :child}}
-                                         :system-ids #{:app}}
-                              :routing  {:current             {:id :home}
-                                         :pending-navigation  {:to :next}}
-                              :elision  {:declarations {}}}}
-          model (h/current-state-sections db)]
+            order. The underlying values live at [:rf.runtime/…] in the
+            runtime-db partition (EP-0001 rf2-tj6w9l)."
+    (let [runtime-db {:rf.runtime/machines {:snapshots  {:auth {:state :idle}}
+                                            :spawned    {:parent {:invoke :child}}
+                                            :system-ids #{:app}}
+                      :rf.runtime/routing  {:current             {:id :home}
+                                            :pending-navigation  {:to :next}}
+                      :rf.runtime/elision  {:declarations {}}}
+          model (h/current-state-sections {} runtime-db)]
       (is (= h/reserved-area-order (mapv :area (:areas model)))))))
 
 ;; ---- inline-diff section model (spec/021 §4.3, rf2-ad7zx.11) -------------
 ;;
-;; The 2-arity `current-state-sections` threads a `db-before` pre-image
-;; so each section carries a `:before` slice for the inline `← changed`
-;; annotation. The 1-arity form (no pre-image) tags every section with
-;; the `no-diff` sentinel so the renderer falls back to plain
+;; The 3-arity `current-state-sections` threads a `{:app .. :runtime ..}`
+;; before-image so each section carries a `:before` slice for the inline
+;; `← changed` annotation. The 2-arity form (no pre-image) tags every
+;; section with the `no-diff` sentinel so the renderer falls back to plain
 ;; current-state.
 
-(deftest current-state-sections-1-arity-is-no-diff-everywhere
-  (testing "the 1-arity form tags TOP + every section with the no-diff
+(deftest current-state-sections-2-arity-is-no-diff-everywhere
+  (testing "the 2-arity form tags TOP + every section with the no-diff
             sentinel (renderer renders plain current-state, no annotation)"
     (let [model (h/current-state-sections
-                  {:counter 1
-                   :rf/runtime {:routing  {:current {:id :home}}
-                                :machines {:snapshots {:title/flow {:state :idle}}}}})]
+                  {:counter 1}
+                  {:rf.runtime/routing  {:current {:id :home}}
+                   :rf.runtime/machines {:snapshots {:title/flow {:state :idle}}}})]
       (is (= h/no-diff (:before-top model)) "TOP carries the no-diff sentinel")
       (doseq [a (:areas model)]
         (if (= :instances (:kind a))
           (doseq [inst (:instances a)]
             (is (= h/no-diff (:before inst))
-                "each instance no-diff in 1-arity"))
+                "each instance no-diff in 2-arity"))
           (is (= h/no-diff (:before a))
-              "each singleton no-diff in 1-arity"))))))
+              "each singleton no-diff in 2-arity"))))))
 
-(deftest current-state-sections-2-arity-top-before-is-prior-user-domain
-  (testing ":before-top is the user-domain slice of db-before (the
-            :rf/runtime container stripped), so the TOP section diffs old → new"
-    (let [before {:counter 1 :rf/runtime {:routing {:current {:id :home}}}}
-          after  {:counter 2 :rf/runtime {:routing {:current {:id :home}}}}
-          model  (h/current-state-sections after before)]
+(deftest current-state-sections-3-arity-top-before-is-prior-user-domain
+  (testing ":before-top is the user-domain slice of the app-db pre-image,
+            so the TOP section diffs old → new"
+    (let [model (h/current-state-sections
+                  {:counter 2}          ;; app-db now
+                  {}                     ;; runtime-db now
+                  {:app {:counter 1} :runtime {}})]
       (is (= {:counter 1} (:before-top model))
-          ":before-top excludes the :rf/runtime container, matching :top's shape")
+          ":before-top is the prior user-domain app-db")
       (is (= {:counter 2} (:top model))))))
 
-(deftest current-state-sections-2-arity-instance-before-is-prior-snapshot
+(deftest current-state-sections-3-arity-instance-before-is-prior-snapshot
   (testing "each machine instance carries its prior snapshot as :before;
             an instance absent before-cascade gets the `added` sentinel
-            (rf2-227cz — the freshly-created machine must light up
-            :added, NOT render plain like an unchanged one). Snapshots
-            live at [:rf/runtime :machines :snapshots]."
-    (let [before {:rf/runtime {:machines {:snapshots {:title/flow {:state :idle}}}}}
-          after  {:rf/runtime {:machines {:snapshots {:title/flow {:state :loaded}
-                                                       :auth       {:state :idle}}}}}
-          area   (area-by (h/current-state-sections after before) :rf/machines)
+            (rf2-227cz). Snapshots live at [:rf.runtime/machines
+            :snapshots] in the runtime-db pre/post-image."
+    (let [rt-before {:rf.runtime/machines {:snapshots {:title/flow {:state :idle}}}}
+          rt-after  {:rf.runtime/machines {:snapshots {:title/flow {:state :loaded}
+                                                       :auth       {:state :idle}}}}
+          area   (area-by (h/current-state-sections {} rt-after
+                                                    {:app {} :runtime rt-before})
+                          :rf/machines)
           flow   (some #(when (= :title/flow (:id %)) %) (:instances area))
           auth   (some #(when (= :auth (:id %)) %) (:instances area))]
       (is (= {:state :idle} (:before flow))
@@ -415,13 +432,15 @@
           "rf2-227cz — a freshly-spawned machine (absent in before) is
            the `added` sentinel, not `no-diff`"))))
 
-(deftest current-state-sections-2-arity-singleton-before-is-prior-slice
-  (testing "a singleton slice carries its prior value as :before; an
-            absent-before singleton gets the `added` sentinel (rf2-227cz)"
-    (let [before {:rf/runtime {:routing {:current {:id :home}}}}
-          after  {:rf/runtime {:routing  {:current {:id :cart}}
-                               :machines {:system-ids #{:app}}}}
-          model  (h/current-state-sections after before)
+(deftest current-state-sections-3-arity-singleton-before-is-prior-slice
+  (testing "a singleton slice carries its prior runtime-db value as
+            :before; an absent-before singleton gets the `added` sentinel
+            (rf2-227cz)"
+    (let [rt-before {:rf.runtime/routing {:current {:id :home}}}
+          rt-after  {:rf.runtime/routing  {:current {:id :cart}}
+                     :rf.runtime/machines {:system-ids #{:app}}}
+          model  (h/current-state-sections {} rt-after
+                                           {:app {} :runtime rt-before})
           route  (area-by model :rf/route)
           sysids (area-by model :rf/system-ids)]
       (is (= {:id :home} (:before route)) "route diffs old → new")
@@ -430,16 +449,17 @@
           "rf2-227cz — system-ids absent before-cascade → `added`
            (the slice appeared this epoch), not `no-diff`"))))
 
-(deftest current-state-sections-2-arity-nil-before-db-safe
-  (testing "a nil db-before (boot epoch — every slot is newly added) is
-            handled: before-db degrades to {}; an absent singleton slot
-            classifies `added` (rf2-227cz — the route slot appeared this
-            epoch)"
+(deftest current-state-sections-3-arity-nil-before-safe
+  (testing "a nil before-image map (boot epoch — every slot is newly
+            added) is handled: app/runtime befores degrade to {}; an
+            absent singleton slot classifies `added` (rf2-227cz — the
+            route slot appeared this epoch)"
     (let [model (h/current-state-sections
-                  {:counter 1 :rf/runtime {:routing {:current {:id :home}}}}
-                  nil)]
-      ;; nil db-before still flips diff? on (no-diff sentinel is the ONLY
-      ;; way to opt out), so the user-domain before is {} not the sentinel.
+                  {:counter 1}
+                  {:rf.runtime/routing {:current {:id :home}}}
+                  {:app nil :runtime nil})]
+      ;; A present (non-no-diff) before-image flips diff? on, so the
+      ;; user-domain before is {} (not the sentinel).
       (is (= {} (:before-top model)))
       (is (= h/added (:before (area-by model :rf/route)))
           "rf2-227cz — an added route slot (absent before) → `added`,

--- a/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/app_db_diff_state_cljs_test.cljs
@@ -36,20 +36,29 @@
         (hiccup-seq tree)))
 
 (defn- merge-area
-  "Stitch a single area-id's value into a `:rf/runtime` shape per the
-  `runtime-areas` table (`area-id` → sub-path). Pure data → data."
-  [db area-id v]
+  "Stitch a single area-id's value into the runtime-db PARTITION shape per
+  the `runtime-areas` table (`area-id` → `[:rf.runtime/…]` sub-path).
+  Pure data → data."
+  [rt area-id v]
   (let [path (get h/runtime-areas area-id)]
-    (if path (assoc-in db path v) db)))
+    (if path (assoc-in rt path v) rt)))
 
 (defn- runtime-db
-  "Build an app-db whose `:rf/runtime` container carries the values in
-  `areas` keyed by their logical area-id. Convenience for tests that
-  used to mint the old direct-root shape (`{:rf/machines …}`); now the
-  runtime container is nested per rf2-eguy4 phase-A."
-  ([areas] (runtime-db {} areas))
-  ([base areas]
-   (reduce-kv merge-area base areas)))
+  "Build a RUNTIME-DB partition value carrying the `areas` keyed by their
+  logical area-id (`:rf/machines` / `:rf/route` / …) at the `:rf.runtime/*`
+  paths the `runtime-areas` table names (EP-0001 rf2-tj6w9l — the runtime
+  subsystems moved to the runtime-db partition)."
+  [areas]
+  (reduce-kv merge-area {} areas))
+
+(defn- sections
+  "Build the section model the renderer consumes from a TOP user-domain
+  app-db + a map of runtime areas (stitched into the runtime-db partition
+  via `runtime-db`). Convenience wrapper over the two-partition
+  `current-state-sections` so the view-shape tests read cleanly."
+  ([areas] (sections {} areas))
+  ([app-db areas]
+   (h/current-state-sections app-db (runtime-db areas))))
 
 (defn- testids [tree]
   (->> (hiccup-seq tree)
@@ -63,8 +72,8 @@
 
 (deftest top-section-renders-user-domain-value
   (testing "the TOP section renders the app-db-minus-reserved value"
-    (let [model (h/current-state-sections (runtime-db {:counter 5 :user {:name "ada"}}
-                                                      {:rf/route {:id :home}}))
+    (let [model (sections {:counter 5 :user {:name "ada"}}
+                          {:rf/route {:id :home}})
           tree  (state/state-body model)]
       (is (some? (find-by-testid tree "rf-xray-app-db-state"))
           "panel state container present")
@@ -74,7 +83,7 @@
 (deftest top-section-empty-when-no-user-domain-keys
   (testing "a reserved-keys-only db → TOP section still renders, with the
             empty-state body (not omitted)"
-    (let [model (h/current-state-sections (runtime-db {:rf/route {:id :home}}))
+    (let [model (sections {:rf/route {:id :home}})
           tree  (state/state-body model)
           top   (find-by-testid tree "rf-xray-app-db-state-top")]
       (is (some? top) "TOP section is always present")
@@ -85,9 +94,8 @@
 
 (deftest machines-fan-out-one-section-per-id
   (testing "each machine renders its own section titled by the machine id"
-    (let [model (h/current-state-sections
-                  (runtime-db {:rf/machines {:title/flow {:state :playing}
-                                             :auth       {:state :idle}}}))
+    (let [model (sections {:rf/machines {:title/flow {:state :playing}
+                                         :auth       {:state :idle}}})
           tree  (state/state-body model)
           ids   (testids tree)]
       (is (contains? ids "rf-xray-app-db-state-instance-:rf/machines-:title/flow")
@@ -103,7 +111,7 @@
   (testing "rf2-jcdvo — absent / empty :rf/machines is OMITTED from the
             rendered tree entirely (no placeholder card with 'No
             machines registered.' copy)"
-    (let [model (h/current-state-sections {:counter 1})
+    (let [model (sections {:counter 1} {})
           tree  (state/state-body model)]
       (is (nil? (find-by-testid tree "rf-xray-app-db-state-area-:rf/machines"))
           "no machines area section in the tree")
@@ -114,10 +122,9 @@
 
 (deftest route-singleton-renders-one-section
   (testing ":rf/route renders as ONE singleton section titled `route`"
-    (let [model (h/current-state-sections
-                  (runtime-db {:rf/route {:id :app/article :params {:id "A"}
-                                          :query {} :fragment nil :transition :idle
-                                          :error nil :nav-token "nav-1"}}))
+    (let [model (sections {:rf/route {:id :app/article :params {:id "A"}
+                                      :query {} :fragment nil :transition :idle
+                                      :error nil :nav-token "nav-1"}})
           tree  (state/state-body model)]
       (is (some? (find-by-testid tree "rf-xray-app-db-state-area-:rf/route"))
           "route singleton section present"))))
@@ -126,7 +133,7 @@
   (testing "rf2-jcdvo — absent :rf/route is OMITTED from the rendered
             tree entirely (no placeholder card with 'No active route.'
             copy)"
-    (let [model (h/current-state-sections {:counter 1})
+    (let [model (sections {:counter 1} {})
           tree  (state/state-body model)]
       (is (nil? (find-by-testid tree "rf-xray-app-db-state-area-:rf/route"))
           "no route area section in the tree")
@@ -140,12 +147,14 @@
             section; every reserved-area card is omitted (data-driven
             visibility — sections appear as state accrues, not as
             persistent placeholders)"
-    (let [model (h/current-state-sections {})
+    (let [model (sections {} {})
           tree  (state/state-body model)
           ids   (testids tree)]
       (is (contains? ids "rf-xray-app-db-state-top")
           "TOP is the panel's anchor — always renders")
-      (doseq [area h/reserved-app-db-keys]
+      ;; Every logical reserved area is absent from an empty runtime-db, so
+      ;; no area card renders (EP-0001 rf2-tj6w9l — areas read runtime-db).
+      (doseq [area (keys h/runtime-areas)]
         (is (not (contains? ids (str "rf-xray-app-db-state-area-"
                                      (pr-str area))))
             (str "no placeholder card for empty reserved area " area))))))
@@ -154,10 +163,9 @@
   (testing "rf2-jcdvo — populated reserved areas render exactly as before
             (only the empty-area filtering changed); each populated area
             still gets a card the operator can read"
-    (let [model (h/current-state-sections
-                  (runtime-db {:counter 1}
-                              {:rf/route    {:id :home}
-                               :rf/machines {:auth {:state :idle}}}))
+    (let [model (sections {:counter 1}
+                          {:rf/route    {:id :home}
+                           :rf/machines {:auth {:state :idle}}})
           tree  (state/state-body model)
           ids   (testids tree)]
       (is (contains? ids "rf-xray-app-db-state-area-:rf/route")
@@ -171,8 +179,9 @@
   (testing "rf2-jcdvo — nil / empty db model renders without throwing —
             TOP empty + zero reserved-area cards (every reserved slot is
             empty so every entry is filtered out at projection time)"
-    (doseq [db [nil {}]]
-      (let [tree (state/state-body (h/current-state-sections db))]
+    (doseq [app-db [nil {}]
+            rt     [nil {}]]
+      (let [tree (state/state-body (h/current-state-sections app-db rt))]
         (is (some? (find-by-testid tree "rf-xray-app-db-state-top"))
             "TOP is the panel's anchor — always renders")
         (is (nil? (find-by-testid tree "rf-xray-app-db-state-area-:rf/route"))
@@ -197,10 +206,9 @@
   (testing "rf2-kbxgj — the dead `⤴ subs` downstream-subs trigger is gone
             from every section (TOP, machine fan-out, singleton areas,
             empty-state areas)"
-    (let [model (h/current-state-sections
-                  (runtime-db {:counter 5 :user {:name "ada"}}
-                              {:rf/route    {:id :home}
-                               :rf/machines {:title/flow {:state :playing}}}))
+    (let [model (sections {:counter 5 :user {:name "ada"}}
+                          {:rf/route    {:id :home}
+                           :rf/machines {:title/flow {:state :playing}}})
           tree  (state/state-body model)
           ids   (all-testids tree)]
       (is (not (contains? ids "rf-xray-app-db-state-top-triggers"))
@@ -213,10 +221,9 @@
   (testing "rf2-ilubp — the app-db inspect renders opt out of the EDN
             widget's universal ⎘ copy button (`:copy? false`); no
             `…-copy` testid appears on any value block"
-    (let [model (h/current-state-sections
-                  (runtime-db {:counter 5 :user {:name "ada"}}
-                              {:rf/route    {:id :home}
-                               :rf/machines {:title/flow {:state :playing}}}))
+    (let [model (sections {:counter 5 :user {:name "ada"}}
+                          {:rf/route    {:id :home}
+                           :rf/machines {:title/flow {:state :playing}}})
           tree  (state/state-body model)
           ids   (all-testids tree)]
       (is (not-any? #(.endsWith % "-copy") ids)
@@ -247,10 +254,9 @@
             section is a transparent padded container; the card chrome
             lives inside the body via the edn-inspector widget's
             `:card? true` opt"
-    (let [model  (h/current-state-sections
-                   (runtime-db {:counter 1}
-                               {:rf/route    {:id :home}
-                                :rf/machines {:title/flow {:state :idle}}}))
+    (let [model  (sections {:counter 1}
+                           {:rf/route    {:id :home}
+                            :rf/machines {:title/flow {:state :idle}}})
           tree   (state/state-body model)
           styles (section-styles tree)]
       (is (seq styles) "sections render")
@@ -265,7 +271,7 @@
   (testing "rf2-jcdvo — the TOP section's wrapper carries no border-top
             (consistent with every other section now that the divider
             was dropped)"
-    (let [model (h/current-state-sections {:counter 1})
+    (let [model (sections {:counter 1} {})
           tree  (state/state-body model)
           top   (find-by-testid tree "rf-xray-app-db-state-top")]
       (is (some? top))
@@ -277,13 +283,12 @@
             hairline border-top divider above it (the card chrome alone
             self-separates adjacent cards). With every reserved slot
             populated, every section renders without a divider."
-    (let [model (h/current-state-sections
-                  (runtime-db {:rf/machines           {:title/flow {:state :idle}}
-                               :rf/spawned            {:parent     {:invoke :child}}
-                               :rf/route              {:id :home}
-                               :rf/system-ids         #{:app}
-                               :rf/pending-navigation {:to :next}
-                               :rf/elision            {:declarations {}}}))
+    (let [model (sections {:rf/machines           {:title/flow {:state :idle}}
+                           :rf/spawned            {:parent     {:invoke :child}}
+                           :rf/route              {:id :home}
+                           :rf/system-ids         #{:app}
+                           :rf/pending-navigation {:to :next}
+                           :rf/elision            {:declarations {}}})
           tree   (state/state-body model)
           styles (section-styles tree)]
       (is (seq styles) "sections render")
@@ -327,7 +332,8 @@
   (testing "a changed user-domain value renders in DIFF mode — the
             section threads `:before` into the edn-inspector widget so
             it paints the inline `← was <prior>` annotation"
-    (let [model    (h/current-state-sections {:counter 2} {:counter 1})
+    (let [model    (h/current-state-sections {:counter 2} {}
+                                             {:app {:counter 1} :runtime {}})
           tree     (state/state-body model)
           top      (find-by-testid tree "rf-xray-app-db-state-top")
           mounts   (find-edn-inspector-mounts top)
@@ -345,7 +351,7 @@
             map as `:before` so the widget annotates the change"
     (let [before   (runtime-db {:rf/machines {:title/flow {:state :idle}}})
           after    (runtime-db {:rf/machines {:title/flow {:state :loaded}}})
-          model    (h/current-state-sections after before)
+          model    (h/current-state-sections {} after {:app {} :runtime before})
           tree     (state/state-body model)
           flow     (find-by-testid
                      tree "rf-xray-app-db-state-instance-:rf/machines-:title/flow")
@@ -375,7 +381,7 @@
     (let [before (runtime-db {:rf/machines {:door/main {:state :open}}})
           after  (runtime-db {:rf/machines {:door/main    {:state :open}
                                             :traffic/light {:state :red}}})
-          model  (h/current-state-sections after before)
+          model  (h/current-state-sections {} after {:app {} :runtime before})
           tree   (state/state-body model)
           new-mc (find-by-testid
                    tree "rf-xray-app-db-state-instance-:rf/machines-:traffic/light")
@@ -395,7 +401,7 @@
     (let [before (runtime-db {:rf/machines {:door/main {:state :open}}})
           after  (runtime-db {:rf/machines {:door/main    {:state :closed}
                                             :traffic/light {:state :red}}})
-          model  (h/current-state-sections after before)
+          model  (h/current-state-sections {} after {:app {} :runtime before})
           tree   (state/state-body model)
           door   (find-by-testid
                    tree "rf-xray-app-db-state-instance-:rf/machines-:door/main")
@@ -411,7 +417,7 @@
             with `:added? true` and no `:before`"
     (let [before (runtime-db {})
           after  (runtime-db {:rf/route {:id :home}})
-          model  (h/current-state-sections after before)
+          model  (h/current-state-sections {} after {:app {} :runtime before})
           tree   (state/state-body model)
           route  (find-by-testid tree "rf-xray-app-db-state-area-:rf/route")
           mounts (find-edn-inspector-mounts route)]
@@ -422,11 +428,10 @@
           "an :added slice carries no `:before` opt"))))
 
 (deftest no-diff-model-renders-current-state-no-annotation
-  (testing "the 1-arity (no pre-image) model renders plain current-state
-            — every mount is BROWSE mode (no `:before` opt) so the
-            widget renders no `← changed` annotation"
-    (let [model  (h/current-state-sections
-                   (runtime-db {:counter 2} {:rf/route {:id :home}}))
+  (testing "the no-diff (2-arity, no pre-image) model renders plain
+            current-state — every mount is BROWSE mode (no `:before` opt)
+            so the widget renders no `← changed` annotation"
+    (let [model  (sections {:counter 2} {:rf/route {:id :home}})
           tree   (state/state-body model)
           mounts (find-edn-inspector-mounts tree)]
       (is (seq mounts) "the panel mounts edn-inspector widget instances")
@@ -451,10 +456,9 @@
             DB tree renders comfortably in-place and the affordance
             would be unnecessary noise (Mike's live-testing call
             2026-05-26)"
-    (let [model  (h/current-state-sections
-                   (runtime-db {:counter 2}
-                               {:rf/route {:id :home}
-                                :rf/machines {:auth {:state :idle}}}))
+    (let [model  (sections {:counter 2}
+                           {:rf/route {:id :home}
+                            :rf/machines {:auth {:state :idle}}})
           tree   (state/state-body model)
           mounts (find-edn-inspector-mounts tree)]
       (is (seq mounts) "the panel mounts edn-inspector widget instances")
@@ -464,7 +468,8 @@
 (deftest diff-mode-mounts-also-omit-popup-affordance-opt
   (testing "rf2-7sdja — DIFF-mode mounts (when a pre-image is supplied)
             ALSO omit the popup affordance opt"
-    (let [model  (h/current-state-sections {:counter 2} {:counter 1})
+    (let [model  (h/current-state-sections {:counter 2} {}
+                                           {:app {:counter 1} :runtime {}})
           tree   (state/state-body model)
           mounts (find-edn-inspector-mounts tree)
           diff-mts (filter #(contains? (:opts %) :before) mounts)]
@@ -484,10 +489,9 @@
             panel produces (BROWSE mode, 1-arity / no-diff) carries
             `:card? true` so each top-level mount reads as a discrete
             inspector card"
-    (let [model  (h/current-state-sections
-                   (runtime-db {:counter 2}
-                               {:rf/route {:id :home}
-                                :rf/machines {:auth {:state :idle}}}))
+    (let [model  (sections {:counter 2}
+                           {:rf/route {:id :home}
+                            :rf/machines {:auth {:state :idle}}})
           tree   (state/state-body model)
           mounts (find-edn-inspector-mounts tree)]
       (is (seq mounts) "the panel mounts edn-inspector widget instances")
@@ -498,7 +502,8 @@
   (testing "rf2-63ie5 — DIFF-mode mounts (when a pre-image is supplied)
             ALSO carry `:card? true`; card chrome is independent of
             diff mode and applies to every top-level App-DB mount"
-    (let [model  (h/current-state-sections {:counter 2} {:counter 1})
+    (let [model  (h/current-state-sections {:counter 2} {}
+                                           {:app {:counter 1} :runtime {}})
           tree   (state/state-body model)
           mounts (find-edn-inspector-mounts tree)
           diff-mts (filter #(contains? (:opts %) :before) mounts)]
@@ -525,12 +530,12 @@
             chip now paint whenever `:before` is present, with no
             separate flag."
     (let [diff-tree  (state/state-body
-                       (h/current-state-sections {:counter 2} {:counter 1}))
+                       (h/current-state-sections {:counter 2} {}
+                                                 {:app {:counter 1} :runtime {}}))
           plain-tree (state/state-body
-                       (h/current-state-sections
-                         (runtime-db {:counter 2}
-                                     {:rf/route {:id :home}
-                                      :rf/machines {:auth {:state :idle}}})))
+                       (sections {:counter 2}
+                                 {:rf/route {:id :home}
+                                  :rf/machines {:auth {:state :idle}}}))
           mounts     (concat (find-edn-inspector-mounts diff-tree)
                              (find-edn-inspector-mounts plain-tree))]
       (is (seq mounts) "the panel mounts edn-inspector widget instances")
@@ -544,7 +549,7 @@
             reserved area"
     (let [before   (runtime-db {:rf/machines {:title/flow {:state :idle}}})
           after    (runtime-db {:rf/machines {:title/flow {:state :loaded}}})
-          model    (h/current-state-sections after before)
+          model    (h/current-state-sections {} after {:app {} :runtime before})
           tree     (state/state-body model)
           flow     (find-by-testid
                      tree "rf-xray-app-db-state-instance-:rf/machines-:title/flow")

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1378,6 +1378,131 @@
                    :source-state :idle}))
           "missing event-id → nil (the source-key cannot be built)"))))
 
+;; ---- rf2-lai1qv — EXACT transition spec-path for inline source ----------
+;;
+;; The substrate now stamps the selected transition's exact spec-path
+;; DISCRIMINATOR (`:transition-slot`) on the `:rf.machine/action-ran`
+;; trace; `action-cascade-row` carries it onto the row and
+;; `cascade-row-source-key` builds the precise inline-source slot from it —
+;; addressing the candidate index, the `:after` delay-key, and the
+;; root-vs-state distinction the reconstruct-from-phase fallback could not.
+
+(deftest transition-slot->spec-prefix-test
+  (testing "rf2-lai1qv — the discriminator → inline-source spec-path PREFIX
+            covers every selection form"
+    ;; Single-map :on (index-free, matching the macro's bare-slot keying).
+    (is (= [:states :idle :on :submit]
+           (fmt/transition-slot->spec-prefix
+             {:slot :on :event-key :submit :decl-path [:idle] :candidate-idx nil})))
+    ;; Multi-candidate VECTOR :on carries the matched index.
+    (is (= [:states :a :states :b :on :go 2]
+           (fmt/transition-slot->spec-prefix
+             {:slot :on :event-key :go :decl-path [:a :b] :candidate-idx 2})))
+    ;; Root / parallel-root :on lives OUTSIDE :states (no :states prefix).
+    (is (= [:on :logout]
+           (fmt/transition-slot->spec-prefix
+             {:slot :on :event-key :logout :decl-path [] :root? true})))
+    ;; :always — index-free single-map AND nonzero vector candidate.
+    (is (= [:states :loading :always]
+           (fmt/transition-slot->spec-prefix
+             {:slot :always :decl-path [:loading] :candidate-idx nil})))
+    (is (= [:states :loading :always 1]
+           (fmt/transition-slot->spec-prefix
+             {:slot :always :decl-path [:loading] :candidate-idx 1})))
+    ;; :after — addresses the exact delay-key slot.
+    (is (= [:states :idle :after 1000]
+           (fmt/transition-slot->spec-prefix
+             {:slot :after :delay-key 1000 :decl-path [:idle] :candidate-idx nil})))
+    ;; Unrecognised / empty discriminator → nil (caller falls back).
+    (is (nil? (fmt/transition-slot->spec-prefix {})))
+    (is (nil? (fmt/transition-slot->spec-prefix
+                {:slot :on :decl-path [:idle]}))
+        ":on with no event-key cannot build a slot path")))
+
+(deftest cascade-row-source-key-candidate-vector-on-action-test
+  (testing "rf2-lai1qv — an inline `:action` on a multi-candidate `:on`
+            VECTOR resolves to the EXACT matched-candidate index, not the
+            reconstruct-from-phase index-0 / index-free shape"
+    (let [inline-fn (fn [_] {})]
+      (is (= [:states :idle :on :submit 2 :action]
+             (fmt/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :transition
+                :source-state :idle :event-id :submit
+                :transition-slot {:slot :on :event-key :submit
+                                  :decl-path [:idle] :candidate-idx 2}}))
+          "the carried discriminator's index (2) wins over the phase fallback")
+      ;; Without the discriminator the legacy reconstruction still applies
+      ;; (single-map / index-free shape).
+      (is (= [:states :idle :on :submit :action]
+             (fmt/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :transition
+                :source-state :idle :event-id :submit}))
+          "no discriminator → reconstruct-from-phase fallback"))))
+
+(deftest cascade-row-source-key-candidate-vector-on-guard-test
+  (testing "rf2-lai1qv — an inline `:guard` on a candidate-vector `:on`
+            resolves via an EXACT carried `:spec-path` (the substrate may
+            stamp it on the guard-evaluated trace)"
+    (let [inline-fn (fn [_] true)]
+      (is (= [:states :idle :on :submit 1 :guard]
+             (fmt/cascade-row-source-key
+               {:kind :guard :guard-id inline-fn
+                :source-state :idle :event-id :submit
+                :spec-path [:states :idle :on :submit 1 :guard]}))
+          "the carried exact :spec-path wins over reconstruction")
+      (is (= [:states :idle :on :submit :guard]
+             (fmt/cascade-row-source-key
+               {:kind :guard :guard-id inline-fn
+                :source-state :idle :event-id :submit}))
+          "no carried :spec-path → reconstruct-from-state+event fallback"))))
+
+(deftest cascade-row-source-key-after-action-test
+  (testing "rf2-lai1qv — an inline `:after` `:action` resolves to the EXACT
+            `[:states <s> :after <delay-key>]` slot (the delay-key the
+            reconstruct-from-phase path could not name)"
+    (let [inline-fn (fn [_] {})]
+      (is (= [:states :idle :after 1000 :action]
+             (fmt/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :after-action
+                :source-state :idle
+                :transition-slot {:slot :after :delay-key 1000
+                                  :decl-path [:idle] :candidate-idx nil}}))
+          "the carried delay-key (1000) addresses the exact :after slot")
+      ;; Legacy fallback: a row with no discriminator lands on the bare
+      ;; `[:states <s> :after :action]` (delay-key unknown).
+      (is (= [:states :idle :after :action]
+             (fmt/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :after-action
+                :source-state :idle}))
+          "no discriminator → reconstruct-from-phase fallback (no delay-key)"))))
+
+(deftest cascade-row-source-key-always-nonzero-candidate-test
+  (testing "rf2-lai1qv — an inline `:always` `:action` on a multi-candidate
+            VECTOR resolves to the EXACT nonzero candidate index, not the
+            index-free / index-0 shape"
+    (let [inline-fn (fn [_] {})]
+      (is (= [:states :loading :always 1 :action]
+             (fmt/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :always
+                :source-state :loading
+                :transition-slot {:slot :always :decl-path [:loading]
+                                  :candidate-idx 1}}))
+          "the carried candidate index (1) wins over the index-free fallback"))))
+
+(deftest cascade-row-source-key-root-on-fallback-test
+  (testing "rf2-lai1qv — a root / parallel-root `:on` `:action` (decl-path
+            []) resolves to a root-relative `[:on <event>]` slot OUTSIDE
+            `:states` — the reconstruct path's `:states`-prefixed shape was
+            wrong for a root transition"
+    (let [inline-fn (fn [_] {})]
+      (is (= [:on :logout :action]
+             (fmt/cascade-row-source-key
+               {:kind :action :action-id inline-fn :phase :transition
+                :source-state :auth :event-id :logout
+                :transition-slot {:slot :on :event-key :logout
+                                  :decl-path [] :root? true :candidate-idx nil}}))
+          "root :on resolves to [:on :logout :action], no :states prefix"))))
+
 (deftest cascade-row-source-key-transition-row-test
   (testing "rf2-wwc3j — `:transition` row resolves to `[:states <src>
             :on <event>]` so the click-through opens the transition map

--- a/tools/xray/testbeds/routes_epochs/core.cljs
+++ b/tools/xray/testbeds/routes_epochs/core.cljs
@@ -250,14 +250,21 @@
     {:db db
      :fx [[:dispatch [:rf.route/navigate :routes-epochs/home]]]}))
 
-(rf/reg-event-db :routes-epochs/load-profile
+(rf/reg-event-fx :routes-epochs/load-profile
   {:doc "Step #8's route-driven loader — fired as
          `:routes-epochs/profile`'s `:on-match`. Reads the route params
-         from the slice and writes `:profile` into app-db (the
-         transition runs :loading → :idle around this loader)."}
-  (fn handler-load-profile [db _ev]
-    (let [user (get-in db [:rf/runtime :routing :current :params :user])]
-      (assoc db :profile {:user user :loaded-at-step (:step db)}))))
+         from the route slice and writes `:profile` into app-db (the
+         transition runs :loading → :idle around this loader).
+
+         EP-0001 (rf2-vzld77 / rf2-tj6w9l): the route slice is durable
+         routing RUNTIME-DB state at `[:rf.runtime/routing :current]`, no
+         longer in app-db `:rf/runtime`. An event handler reads it off the
+         `:rf.db/runtime` coeffect every `reg-event-fx` receives — the
+         canonical `:on-match` loader idiom (mirrors the realworld
+         example's `:profile/load`)."}
+  (fn handler-load-profile [{:keys [db] rt :rf.db/runtime} _ev]
+    (let [user (get-in rt [:rf.runtime/routing :current :params :user])]
+      {:db (assoc db :profile {:user user :loaded-at-step (:step db)})})))
 
 ;; ============================================================================
 ;; GUARDED NAV (#10/#11) — a :can-leave gate


### PR DESCRIPTION
Two xray beads in one PR.

## rf2-lai1qv — carry exact transition spec-path for inline source lookup

The Epoch panel reconstructed inline-source paths from source-state/event/phase, losing the candidate index, the :after delay-key, and the root-vs-state distinction (it hardcoded candidate 0, could not name the delay-key, and assumed a :states prefix for a root :on). Now the machines runtime stamps the selected transition's EXACT spec-path discriminator (:transition-slot — decl-path + slot + event-key/delay-key + candidate-idx + root?) on the :rf.machine/action-ran trace; cascade-row-source-key builds the precise slot from it and prefers it over the reconstruction. Builds on the merged k7yqod source-key contract.

- implementation/machines: select-passing-candidate-indexed + transition-slot discriminator; stamped at each selection site (:on via match-on-clause, :always via pick-always-transition, :after resolve-hit, root :on via run-root-transition-action); threaded through compute-cascade-paths -> collect-actions -> run-action's trace emit.
- tools/xray: transition-slot->spec-prefix + cascade-row-source-key prefers the carried :spec-path / :transition-slot; action-cascade-row carries the discriminator.
- Tests: substrate end-to-end (transition_slot_spec_path_test) across all four cases + boundary-no-slot; render tests for candidate-vector :on action/guard, :after action, :always nonzero candidate, root :on fallback.
- core/source_coords untouched (the discriminator -> spec-path conversion lives in the xray format layer; the key shape did not need changing).

## rf2-tj6w9l — migrate remaining xray :rf/runtime consumers to runtime-db

- Executable bug: routes_epochs testbed loader read the route param from the retired app-db [:rf/runtime :routing :current ...] path. Migrated to the canonical :on-match idiom — reg-event-fx reading the route slice off the :rf.db/runtime coeffect at [:rf.runtime/routing :current ...] (mirrors the realworld :profile/load).
- App-DB-Diff panel: runtime-areas now map to the runtime-db partition's :rf.runtime/* roots; current-state-sections takes both partitions (app-db -> TOP user-domain, runtime-db -> reserved areas); the panel sub joins :rf.xray/target-frame-runtime-db + each focused epoch's :rf.db/runtime pre/post-image, the same way the Machines inspector + Routing tab read runtime-db. reserved-app-db-keys is now empty (runtime moved out of app-db); reserved-path?/partition-reserved key on the reserved :rf* namespace family.
- Tests + specs (004, 021) updated.

## Quality gates

- machines clojure -M:test: 570 tests, 0 failures
- xray clojure -M:test: 1118 tests, 0 failures
- npm run test:cljs: 6048 tests, 0 failures
- npm run test:browser: 205 tests, 0 failures
- examples/routes-epochs testbed: compiles clean (0 warnings)
- npm run test:bundle-isolation: pass

Slice gates only; CI runs the full matrix.