### PR TITLE
docs(core): reconcile remaining stale :rf/runtime facade/subs comments + flows-test review (rf2-axew91)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1084,7 +1084,7 @@
 (def ^{:doc "Install a browser `popstate` listener that drives the
   URL-owning frame: Back/Forward dispatches `:rf.route/handle-url-change`
   to `(url-owner-frame-id)` (resolved at pop time), so the owner's
-  route slice (at `[:rf/runtime :routing :current]`) and rendered body restore — whether the owner is
+  route slice (at `[:rf.runtime/routing :current]`) and rendered body restore — whether the owner is
   `:rf/default` or a non-default `:url-bound? true` frame (rf2-6qgbs.4).
   Also syncs the initial URL on install. Idempotent (hot-reload safe).
   CLJS-only. The inbound counterpart of the outbound `:rf.nav/push-url`
@@ -1142,7 +1142,7 @@
   machine-meta           rf-machines/machine-meta)
 
 (def ^{:doc "Look up the spawned-machine id bound to `system-id` in the
-  active frame's `[:rf/runtime :machines :system-ids]` reverse index, or `nil`. Optional
+  active frame's `[:rf.runtime/machines :system-ids]` reverse index, or `nil`. Optional
   `frame-id` arg targets an explicit frame. Per Spec 005 §Named
   addressing via `:system-id`. Implementation ships in
   `day8/re-frame2-machines`."}
@@ -1479,13 +1479,13 @@
   Security.md §Off-box egress."}
   elide-wire-value                 elision/elide-wire-value)
 
-(def ^{:doc "Populate `[:rf/runtime :elision :declarations]` from
+(def ^{:doc "Populate `[:rf.runtime/elision :declarations]` from
   `{:large? true}` schema-slot metadata for the frame. Returns the
   populated paths. Called from boot once app-schemas are registered.
   Per Spec 010 §Schema metadata flags."}
   populate-elision-from-schemas!   elision/populate-elision-from-schemas!)
 
-(def ^{:doc "Populate `[:rf/runtime :elision :sensitive-declarations]`
+(def ^{:doc "Populate `[:rf.runtime/elision :sensitive-declarations]`
   from `{:sensitive? true}` schema-slot metadata for the frame. Returns
   the populated paths. Called from boot once app-schemas are registered.
   Per Spec 010 §Schema metadata flags."}

--- a/implementation/core/src/re_frame/core_machines.cljc
+++ b/implementation/core/src/re_frame/core_machines.cljc
@@ -51,7 +51,7 @@
 
 (defwrapper machine-by-system-id
   "Look up the spawned-machine id currently bound to `system-id` in the
-  active frame's `[:rf/runtime :machines :system-ids]` reverse index, or nil. The optional
+  active frame's `[:rf.runtime/machines :system-ids]` reverse index, or nil. The optional
   `frame-id` arg targets an explicit frame; without it, resolution uses
   the current frame (per `with-frame` / frame-provider, defaulting to
   `:rf/default`).

--- a/implementation/core/src/re_frame/core_routing.cljc
+++ b/implementation/core/src/re_frame/core_routing.cljc
@@ -68,7 +68,7 @@
   `popstate` listener that dispatches `:rf.route/handle-url-change` to the
   current URL-owning frame (`url-owner-frame-id`, resolved at pop time),
   then sync the current URL into that frame's route slice at
-  `[:rf/runtime :routing :current]`. This is
+  `[:rf.runtime/routing :current]`. This is
   the inbound (browser → app) counterpart of the outbound
   `:rf.nav/push-url` gate: Back/Forward restores the owner frame's route,
   whether the owner is `:rf/default` or a non-default `:url-bound? true`

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -196,12 +196,13 @@
   container.
 
   This is deliberate and load-bearing: calling the schema-first
-  `elision/elide-wire-value` walker here would `deref` the frame's
-  app-db container (to read the `[:rf/runtime :elision ...]` registry) INSIDE the
-  reaction's compute fn. On a Reagent substrate that registers a
-  spurious reactive dependency on app-db for every layer-2+ sub —
-  breaking the glitch-free `db → layer-1 → layer-2` layering (the sub
-  would recompute on ANY app-db change, not just its own input's). The
+  `elision/elide-wire-value` walker here would `deref` one of the frame's
+  container projections (to read the `[:rf.runtime/elision ...]` registry
+  from the runtime-db partition) INSIDE the reaction's compute fn. On a
+  Reagent substrate that registers a spurious reactive dependency on a
+  frame container for every layer-2+ sub — breaking the glitch-free
+  `db → layer-1 → layer-2` layering (the sub would recompute on ANY
+  matching container change, not just its own input's). The
   marks chokepoint reads only process-scoped atoms, so it is
   reaction-safe. A schema-`:sensitive?` sub egresses `:prev-value` /
   `:value` as `:rf/redacted`; `:value-changed?` stays a plain boolean.

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -712,11 +712,15 @@
 
 (deftest computed-trace-elides-large-result
   (testing ":rf.flow/computed :result rides through elide-wire-value — schema-large path is elided"
-    ;; Seed the app-db with `merge` semantics so the schema-installed
-    ;; elision registry survives the :init handler. A replacing handler
-    ;; (e.g. `(fn [_ _] {:n 1})`) would wipe the `[:rf/runtime :elision]` slot
-    ;; before the flow's evaluate-time registry read.
-    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    ;; A plain replacing `:init` handler is safe: under the two-partition
+    ;; contract a `:db` return replaces ONLY the app-db partition, so the
+    ;; schema-installed elision registry — which lives in the runtime-db
+    ;; partition at `[:rf.runtime/elision]` — survives untouched for the
+    ;; flow's evaluate-time registry read. (Pre-migration the registry sat
+    ;; in app-db under `:rf/runtime`, where a replacing handler WOULD have
+    ;; clobbered it; that footgun is structurally gone — see
+    ;; `re-frame.events/reject-legacy-runtime-root!`.)
+    (rf/reg-event-db :init (fn [_ _] {:n 1}))
     (rf/reg-flow {:id     :payload
                   :inputs [[:n]]
                   :output (fn [_] {:bytes "BIG"})
@@ -739,7 +743,7 @@
   (testing ":rf.flow/failed :inputs rides through elide-wire-value"
     ;; Register the flow that will throw; the input path is schema-
     ;; declared large so the walker substitutes the marker on emit.
-    (rf/reg-event-db :init (fn [db _] (merge db {:payload {:big "value"}})))
+    (rf/reg-event-db :init (fn [_ _] {:payload {:big "value"}}))
     (rf/reg-flow {:id     :boom
                   :inputs [[:payload]]
                   :output (fn [_] (throw (ex-info "boom" {})))


### PR DESCRIPTION
Reconciles the stale `:rf/runtime` (old app-db root) path references in comments/docstrings that rf2-h0r2wj skipped for concurrency, to the runtime-db partition form `[:rf.runtime/...]`: core.cljc facade docstrings (routing/machines/elision), core_machines.cljc, core_routing.cljc, subs/memo.cljc. Also simplifies the vestigial defensive `merge` setup in flows_trace_test.clj — its comment described a pre-migration `:rf/runtime`-clobber footgun that is now structurally impossible (a `:db` return replaces ONLY the app-db partition; the elision registry lives in runtime-db). Comment/docstring + test-setup only; no behavior change. Closes rf2-axew91.

## Quality gates
- core `clojure -M:test`: 997 tests, 4359 assertions, 0 failures, 0 errors
- flows `clojure -M:test`: 165 tests, 4676 assertions, 0 failures, 0 errors
- `git grep :rf/runtime` over touched files: only a single legitimate historical reference remains (in the corrected flows-test comment explaining the pre-migration footgun)