### PR TITLE
fix(core): remove unused plain-atom facade require + reconcile fixtures (rf2-1mdvlv)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -72,7 +72,18 @@
              #?@(:cljs [:include-macros true])]
             [re-frame.core-call-site-macros  :as csm]
             [re-frame.core-reg-view-macro    :as rvm]
-            [re-frame.substrate.plain-atom :as plain-atom]
+            ;; NOTE: re-frame.substrate.plain-atom is deliberately NOT
+            ;; required here. It carries no ns-load side-effect that core
+            ;; needs — its only load-time effect is the CLJS
+            ;; `:adapter/add-on-dispose!` / `:adapter/dispose!` route-hook!
+            ;; block, which is keyed on the adapter being the
+            ;; `(rf/init! ...)`-installed one and so is inert unless a
+            ;; consumer installs plain-atom. `rf/init!` takes the adapter
+            ;; map directly (no default-adapter registry), so consumers
+            ;; that want the plain-atom path require the ns themselves and
+            ;; pass `plain-atom/adapter` — eagerly pulling it into the
+            ;; facade would ship JVM/SSR adapter code into every consumer
+            ;; (rf2-1mdvlv).
             #?@(:cljs [[re-frame.views :as views]]))
   ;; The macros are defined in this ns's `#?(:clj ...)` blocks below.
   ;; CLJS users see them under `rf/<name>` via this self-`:require-


### PR DESCRIPTION
## Summary

PR #3426 review found `re-frame.core` eagerly required `[re-frame.substrate.plain-atom :as plain-atom]` even though the `plain-atom` alias is unused in `core.cljc`.

**Verdict: unused alias AND not load-bearing — removed.**

- The alias is referenced only at the require site; the one other `plain-atom` mention in core.cljc is a docstring keyword (`:plain-atom`), not the alias.
- The require is NOT load-bearing for side-effect registration. plain-atom's only ns-load effect is the CLJS `:adapter/add-on-dispose!` / `:adapter/dispose!` `route-hook!` block, which dispatches via `route-hook!` keyed on `(identical? adapter-spec (current-adapter-spec))` — inert unless plain-atom is the `(rf/init! ...)`-installed adapter. `rf/init!` takes the adapter map directly (no default-adapter registry), so consumers that want the plain-atom path require the ns themselves and pass `plain-atom/adapter`.
- plain-atom's own ns doc already states "There is no default-adapter registry and no ns-load side-effect. Consumers ... call `(rf/init! plain-atom/adapter)` explicitly" — consistent with removal, no doc reconciliation needed.

## Fixtures

No fixtures needed changes. Audited all 159 in-tree files using `plain-atom/adapter`: every one that uses it in CODE already requires `re-frame.substrate.plain-atom` directly. The only file referencing `plain-atom/adapter` without a require is `core/src/re_frame/test_support.cljc`, where it appears only in a docstring example (no code dependency). Replaced the removed require with an explanatory source comment.

## Quality gates

- `npm install` — clean
- core artefact `clojure -M:test` — **997 tests, 4359 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **6055 tests, 21504 assertions, 0 failures, 0 errors** (exercises the CLJS plain-atom load path + adapter routing/disposal)
- ssr artefact `clojure -M:test` — **310 tests, 1186 assertions, 0 failures, 0 errors** (plain-atom is the SSR adapter)
- `git grep` — no dangling `plain-atom/adapter` without a require remains (test_support docstring-only confirmed benign)

Closes rf2-1mdvlv.