### PR TITLE
fix(examples/realworld): repair SSR hydration payload to EP-0001 two-partition shape — green main (rf2-ilmu4g)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -817,17 +817,38 @@
 ;; ============================================================================
 
 (defn- hydration-payload-test []
-  (let [db {:rf/runtime {:routing {:current {:id :realworld/home}}}
-            :auth {:user {:username "alice"} :token "jwt"}
-            :articles {:status :loaded :data [] :error nil :loaded-at 1 :attempt 1}
-            :transient {:popup true}}
-        payload (ssr/hydration-payload db [:div "hello"])
+  ;; EP-0001 (rf2-vzld77): the SSR payload is built from a two-partition
+  ;; frame-state value `{:rf.db/app … :rf.db/runtime …}` (the shape
+  ;; `rf/frame-state-value` returns), NOT a flat single-map db. Application
+  ;; slices live in the `:rf.db/app` partition; the framework-owned
+  ;; subsystem trees (routing, machines) live in `:rf.db/runtime`. The
+  ;; payload splits them across `:rf/app-db` + `:rf/runtime-db` (the two
+  ;; slices the `:rf/hydrate` handler installs into the two partitions).
+  (let [frame-state {:rf.db/app     {:auth      {:user {:username "alice"} :token "jwt"}
+                                     :articles  {:status :loaded :data [] :error nil :loaded-at 1 :attempt 1}
+                                     :transient {:popup true}}
+                     :rf.db/runtime {:rf.runtime/routing  {:current {:id :realworld/home}}
+                                     :rf.runtime/machines {:snapshots {:settings/form {:state :neutral}}}
+                                     :rf.runtime/http     {:in-flight {}}}}
+        payload (ssr/hydration-payload frame-state [:div "hello"])
         exported-auth (get-in payload [:rf/app-db :auth])]
-    (is (= #{:rf/runtime :auth :articles}
+    ;; The app-db slice carries only the whitelisted application slices —
+    ;; `:auth` + `:articles` — and NOT the framework runtime trees (those
+    ;; ride `:rf/runtime-db`) nor the non-exported `:transient` slice.
+    (is (= #{:auth :articles}
            (set (keys (:rf/app-db payload)))))
+    ;; The runtime-db slice carries the durable, serializable runtime
+    ;; children — the route slice + machine snapshots — so the client
+    ;; resumes from the server's route and any mid-flow machines. Transient
+    ;; runtime state (in-flight HTTP) is excluded.
+    (is (= #{:rf.runtime/routing :rf.runtime/machines}
+           (set (keys (:rf/runtime-db payload)))))
+    (is (= {:id :realworld/home}
+           (get-in payload [:rf/runtime-db :rf.runtime/routing :current]))
+        "the server route slice rides the runtime-db partition")
     ;; rf2-ygh4m ITEM 7 — the bearer JWT must NOT cross the SSR seam.
     ;; The :auth slice still rides along (the client needs :user), but
-    ;; :token is redacted at the payload boundary (ssr/exportable-db);
+    ;; :token is redacted at the payload boundary (ssr/exportable-app-db);
     ;; the client re-derives it from localStorage on hydrate.
     (is (= {:username "alice"} (:user exported-auth))
         "the :auth :user payload survives hydration")


### PR DESCRIPTION
Fixes the 2 pre-existing `realworld-ssr` hydration-payload failures that made `main` RED (and propagated to every PR's `test:cljs`).

## Root cause

The `hydration-payload-test` (in `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`) was on the **legacy** side of the EP-0001 SSR migration. It built a flat single-map `db` with a `:rf/runtime` app-db root and passed it to `ssr/hydration-payload`. Under EP-0001 that fn destructures a two-partition frame-state value `{:rf.db/app … :rf.db/runtime …}` — so the flat input yielded an empty `:rf/app-db` and a nil exported `:auth`, failing both assertions. The example (`examples/reagent/realworld/ssr.cljc`) and the shared `:rf/hydrate` impl were already correct; only the test was stale.

## Fix

Rebuild the test input as the EP-0001 two-partition frame-state value (app slices in `:rf.db/app`, routing/machines in `:rf.db/runtime`) and update the expectations:
- `:rf/app-db` exports `:auth` + `:articles` (no `:rf/runtime` root — that hard-errors).
- `:rf/runtime-db` exports the route slice + machine snapshots (new assertion).
- JWT still redacted at the seam.

No production / impl change — test-only.

## Quality gates

- `npm run test:cljs`: **before 2 failures, 0 errors → after 0 failures, 0 errors** (6055 tests, 21506 assertions; +2 new assertions).
- `implementation/ssr` `clojure -M:test`: 0 failures, 0 errors (310 tests, 1186 assertions).

Closes rf2-ilmu4g.