### PR TITLE
feat(core): EP-0002 central frame resolver — carried-invariant require-current-frame! + no :rf/default synthesis (rf2-piwhsw)

### DIFF
--- a/implementation/core/src/re_frame/adapter/context.cljs
+++ b/implementation/core/src/re_frame/adapter/context.cljs
@@ -29,11 +29,25 @@
             [re-frame.interop :as interop]
             [re-frame.trace :as trace]))
 
+(def no-provider-sentinel
+  "The React-context default value — the **no-provider sentinel**, NOT
+  `:rf/default`. Per Spec 002 §Frame target resolution — the carried
+  invariant (EP-0002): the React-context default carries no framework
+  privilege and the runtime never synthesises a frame from absence. A
+  component rendered with NO enclosing `frame-provider` observes this
+  sentinel; the resolver reads it as 'no frame in scope' and returns nil
+  (it is the reader's nil, not a `:rf/default` floor). A dedicated
+  namespaced keyword (rather than nil) so a raw `_currentValue` read can
+  positively distinguish 'no Provider above me' from a genuinely corrupted
+  context value (nil / false / a number / a JS object)."
+  :rf.frame/no-provider)
+
 (defonce frame-context
-  ;; The default value is :rf/default — Spec 002 §`:rf/default` guarantees
-  ;; this frame always exists. Components without an enclosing
-  ;; frame-provider resolve to it.
-  (.createContext React :rf/default))
+  ;; Default = the no-provider sentinel (NOT :rf/default). Components
+  ;; without an enclosing frame-provider observe this; the resolver maps it
+  ;; to nil (no scope) rather than to a synthesised default frame, per the
+  ;; EP-0002 carried invariant.
+  (.createContext React no-provider-sentinel))
 
 ;; rf2-fa4ly: stamp a human-readable `displayName` on the React Context
 ;; object so React DevTools' Context inspector shows the entry as
@@ -130,15 +144,20 @@
   "Emit `:rf.error/frame-context-corrupted` (per Spec 009 §Error
   categories). The React-context value at the function-component read
   site (`_currentValue`) was a shape `coerce-context-value` cannot
-  resolve to a frame keyword — typically nil, false, a number, an
-  empty string, or a JS object. Recovery is `:replaced-with-default`:
-  the resolution chain falls through to `:rf/default`."
+  resolve to a frame keyword AND is not the no-provider sentinel —
+  typically false, a number, an empty string, or a JS object. Recovery is
+  `:no-frame-context`: the resolution chain returns nil (NOT a synthesised
+  `:rf/default` — per the EP-0002 carried invariant). A public frame-
+  scoped operation reading nil then fails loudly with
+  `:rf.error/no-frame-context`; the corruption is reported here as its own
+  distinct category so a disturbed context boundary is not silently folded
+  into ordinary 'no scope'."
   [v]
   (trace/emit-error! :rf.error/frame-context-corrupted
                      {:received v
                       :type     (value-type-tag v)
-                      :recovery :replaced-with-default
-                      :reason   "React-context `_currentValue` is not a frame keyword; check the closest `frame-provider` boundary (or whether the subtree was rendered through an unwrapped portal)."}))
+                      :recovery :no-frame-context
+                      :reason   "React-context `_currentValue` is not a frame keyword and not the no-provider sentinel; check the closest `frame-provider` boundary (or whether the subtree was rendered through an unwrapped portal)."}))
 
 ;; ---- function-component current-frame (UIx / Helix; rf2-d4sf) ------------
 ;;
@@ -160,7 +179,11 @@
 ;; what the warning targets).
 
 (defn function-component-current-frame
-  "Resolution chain for function-component substrates (UIx, Helix):
+  "Resolution chain (READER) for function-component substrates (UIx,
+  Helix). Returns the scope frame, or **nil** when no scope is
+  established — it never synthesises `:rf/default` (per Spec 002 §Frame
+  target resolution — the carried invariant, EP-0002). The two tiers it
+  observes:
 
     1. `re-frame.frame/*current-frame*` (dynamic var) — set by
        `with-frame` / `frame-bound-fn`.
@@ -168,31 +191,41 @@
        `_currentValue` off the shared context object directly (the
        substrate-portable path; UIx's `use-context` and Helix's
        `use-context` are both sugar over this read).
-    3. `:rf/default`.
+
+  Returns nil when neither tier names a frame — a component rendered with
+  no enclosing `frame-provider` observes the no-provider sentinel, which
+  resolves to nil ('no scope'). Public frame-scoped operations turn that
+  nil into a loud `:rf.error/no-frame-context` via
+  `frame/require-current-frame!`; low-level readers / tooling model 'no
+  context' with the nil directly.
 
   Tolerates Reagent's prop-stringified-keyword shape via
   `coerce-context-value` — relevant when a UIx / Helix subtree is
   embedded in a tree whose `frame-provider` was authored as a Reagent
   `[:> ...]` interop call.
 
-  Corrupted-`_currentValue` detection (rf2-8q66): the
-  `createContext` default is `:rf/default` (a keyword), so a
-  function-component read should always observe either a keyword or
-  the prop-stringified-keyword shape. Anything else (nil, false, a
-  number, an empty string, a JS object) means the React-context
-  boundary was disturbed — a portal rendering outside its Provider, a
-  library mutating `_currentValue`, or a Provider authored with a
-  non-keyword value. The runtime emits
-  `:rf.error/frame-context-corrupted` and falls through to
-  `:rf/default` (recovery `:replaced-with-default`)."
+  Corrupted-`_currentValue` detection (rf2-8q66): the `createContext`
+  default is now the no-provider sentinel (a keyword), so a function-
+  component read should always observe either a frame keyword, the prop-
+  stringified-keyword shape, or the sentinel. Anything else (false, a
+  number, an empty string, a JS object) means the React-context boundary
+  was disturbed — a portal rendering outside its Provider, a library
+  mutating `_currentValue`, or a Provider authored with a non-keyword
+  value. The runtime emits `:rf.error/frame-context-corrupted` and returns
+  nil (recovery `:no-frame-context`)."
   []
   (or frame/*current-frame*
       (let [v (.-_currentValue ^js frame-context)]
-        (or (coerce-context-value v)
-            ;; Corrupted branch: value is not a frame keyword and not
-            ;; a non-empty string — covers nil, false, numbers, empty
-            ;; strings, and JS objects. Emit the structured error and
-            ;; fall through.
-            (do (emit-frame-context-corrupted! v)
-                nil)))
-      :rf/default))
+        (cond
+          ;; No enclosing Provider — the sentinel resolves to nil ('no
+          ;; scope'), NOT a synthesised default. This is the common,
+          ;; benign case; it is NOT corruption.
+          (= v no-provider-sentinel) nil
+          ;; A real frame keyword (or prop-stringified keyword) names the
+          ;; enclosing Provider's frame.
+          (coerce-context-value v)   (coerce-context-value v)
+          ;; Corrupted branch: not a frame keyword, not the sentinel —
+          ;; covers false, numbers, empty strings, and JS objects. Emit
+          ;; the structured error and return nil (no synthesis).
+          :else                      (do (emit-frame-context-corrupted! v)
+                                         nil)))))

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1780,13 +1780,20 @@
                     (some? received) (assoc :received received)))))
 
 (defn init!
-  "Idempotent boot — installs a substrate adapter and ensures the
-  `:rf/default` frame exists. Pass the adapter spec map directly (no
-  default-adapter registry; rf2-agql):
+  "Idempotent boot — installs a substrate adapter. Pass the adapter spec
+  map directly (no default-adapter registry; rf2-agql):
     (require '[re-frame.adapter.reagent :as reagent])
     (rf/init! reagent/adapter)
   Non-map / nil raises `:rf.error/no-adapter-specified`. Per Spec 006
-  §Adapter selection at boot."
+  §Adapter selection at boot.
+
+  `init!` does NOT create a `:rf/default` frame. Per Spec 002 §`:rf/default`
+  is an ordinary id (EP-0002), the runtime never synthesises a default
+  frame — frame identity is carried, not found. Declare your app's root
+  frame explicitly (`(rf/reg-frame :app {…})` / `with-frame` / a
+  frame-provider) and dispatch / subscribe within that scope. A small app
+  or test may still choose `:rf/default` as its explicit frame id; the
+  runtime will not infer it."
   [adapter-map]
   (cond
     (nil? adapter-map)        (bad-init-arg! nil)
@@ -1795,7 +1802,6 @@
     (do
       (when-not (adapter/current-adapter)
         (adapter/install-adapter! adapter-map))
-      (frame/ensure-default-frame!)
       nil)))
 
 (defn init-platform

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -9,7 +9,13 @@
   holds keywords; this namespace holds the frame records.
 
   Reserved frame ids:
-    :rf/default              — universal default frame (always present)
+    :rf/default              — an ORDINARY frame id (per Spec 002 §`:rf/default`
+                              is an ordinary id, EP-0002). It carries NO
+                              framework privilege: the runtime never creates
+                              it, never infers it from a missing stamp, and
+                              never uses it as a resolution floor. A small
+                              app, example, or test may register and select
+                              it EXPLICITLY like any other id.
     :rf.frame/<gensym>       — anonymous instances from make-frame"
   (:require [clojure.string]
             [re-frame.registrar :as registrar]
@@ -83,20 +89,55 @@
 (defonce ^:private destroying-frames
   (atom #{}))
 
-;; ---- frame resolution at call sites --------------------------------------
+;; ---- frame resolution at call sites — the carried invariant ---------------
 ;;
-;; *current-frame* is the dynamic var that with-frame binds. Subscribe and
-;; dispatch default to (current-frame) when no :frame is supplied, so views
-;; nested under a (with-frame ...) wrapper or a Reagent frame-provider
-;; auto-route to the right frame.
+;; Per Spec 002 §Frame target resolution — the carried invariant (EP-0002):
+;; **frame identity is carried, not found.** A frame-scoped operation reads
+;; its frame from the causal token it holds — the dynamic scope a `with-frame`
+;; / frame-provider established, or a frame stamp it captured. It never
+;; *synthesises* one from absence: there is no process-global `:rf/default`
+;; floor that catches operations issued under no scope at all.
+;;
+;; The rationale leads with **replay determinism + temporal non-locality**,
+;; NOT purity (per EP-0002 §Resolved Decisions R1-R7):
+;;
+;;   - A silently-defaulted frame poisons replay — `restore-epoch`,
+;;     time-travel, and Story / Causa determinism all become unsound the
+;;     moment an operation's target depends on which frame happened to be
+;;     ambient rather than on a value carried in the token being replayed.
+;;   - "sole live frame" is true only until a second frame appears, so an
+;;     ambient floor would let adding Xray, Story, or an SSR frame silently
+;;     change the meaning of distant, untouched application code (temporal
+;;     non-locality).
+;;
+;; The surface is split deliberately (Spec 002 §Resolver surface):
+;;
+;;   - `current-frame` / `resolve-current-frame` are **readers** — they
+;;     return the scope frame or **nil**. They never repair absence. Low-
+;;     level detection, frame pickers, and tooling model "no context" with
+;;     the nil return without throwing.
+;;   - `require-current-frame!` is the **requiring** primitive — "read the
+;;     stamp on the token I hold". It returns the frame stamp or, when the
+;;     token carries none, raises/emits `:rf.error/no-frame-context`.
+;;     Public frame-scoped operations call THIS so the nil-returning reader
+;;     never silently becomes a second, softer fallback.
+;;
+;; `*current-frame*` is the dynamic var that `with-frame` (and the router's
+;; per-handler binding) sets — the *scope* carrier. It is nil at top of
+;; stack and after any async hop unwinds the binding.
 
 (def ^:dynamic *current-frame* nil)
 
 (defn current-frame
-  "Resolution chain: dynamic var → :rf/default. CLJS-side
-  re-frame.views extends this with a React-context lookup."
+  "Return the lexical/dynamic-scope frame, or **nil** when no scope is
+  established. A **reader**: it reports what scope is in effect; it does
+  NOT repair absence by synthesising `:rf/default` (per Spec 002 §Frame
+  target resolution — the carried invariant, EP-0002). The dynamic-var
+  tier only — the React-context tier is consulted by
+  `resolve-current-frame` (CLJS). Public frame-scoped operations that must
+  have a frame call `require-current-frame!`, not this reader."
   []
-  (or *current-frame* :rf/default))
+  *current-frame*)
 
 ;; Per Spec 009 §Per-frame trace rings (rf2-g1b2m / rf2-8uwce): publish
 ;; the in-flight frame-id through `late-bind` so the trace tooling
@@ -106,31 +147,166 @@
 (late-bind/set-fn! :frame/current-frame-id (fn [] *current-frame*))
 
 (defn resolve-current-frame
-  "Resolve the active frame at a no-explicit-frame call site. The
-  3-tier resolution chain — dynamic var → React context → `:rf/default` —
-  per Spec 002 §Reading the frame from React context and Spec 006
-  §Lookup algorithm.
+  "Resolve the active frame at a no-explicit-frame call site — the
+  dynamic-or-adapter/React-context scope frame, or **nil** when no scope
+  is established. A **reader**: it never repairs absence by synthesising
+  `:rf/default` (per Spec 002 §Frame target resolution — the carried
+  invariant, EP-0002). The two scope tiers it observes:
 
-  On CLJS this consults the `:adapter/current-frame` late-bind hook
-  so the React-context tier is LIVE — adapters publish their React-
-  context-aware impl through the hook at ns-load time. When the hook
-  is unbound (no adapter loaded yet, or JVM build) the fallback is
-  `current-frame` which honours the dynamic-var tier and the
-  `:rf/default` tier; the React-context tier silently no-ops.
+    1. `*current-frame*` (dynamic var) — set by `with-frame` /
+       `frame-bound-fn` / the router's per-handler binding.
+    2. The closest enclosing frame-provider via React context (CLJS).
 
-  This is the canonical 3-tier resolver — `subs/subscribe`,
-  `router/dispatch*`'s default-frame computation, and
-  `core/current-frame-id` all delegate here so the React-context tier is
-  single-sourced (rf2-jj8xf)."
+  On CLJS this consults the `:adapter/current-frame` late-bind hook so
+  the React-context tier is LIVE — adapters publish their React-context-
+  aware impl through the hook at ns-load time. That impl returns nil when
+  neither the dynamic var nor an enclosing Provider names a frame (the
+  Provider default is now the no-provider sentinel, NOT `:rf/default`, per
+  Spec 002 §`:rf/default` is an ordinary id + the EP-0002 React-context
+  bead). When the hook is unbound (no adapter loaded yet, or JVM build)
+  the result is `current-frame` — the dynamic-var tier alone; the React-
+  context tier silently no-ops to nil.
+
+  This is the canonical scope reader — `subs/subscribe`,
+  `router/dispatch*`'s frame computation, and `core/current-frame-id`
+  delegate here so the React-context tier is single-sourced (rf2-jj8xf).
+  Public frame-scoped operations that must have a frame call
+  `require-current-frame!`, which is built on this reader."
   []
   ;; Sticky hook (rf2-f72pd) — `:adapter/current-frame` is published
   ;; once per loaded React-shaped adapter at ns-load time and routed
-  ;; via `current-adapter`; it fires on every default-frame resolution
-  ;; (every dispatch and every subscribe).
+  ;; via `current-adapter`; it fires on every ambient resolution
+  ;; (every ambient dispatch and every ambient subscribe).
   #?(:cljs (if-let [f (late-bind/get-fn-cached :adapter/current-frame)]
              (f)
              (current-frame))
      :clj  (current-frame)))
+
+;; ---- :rf.error/no-frame-context — the absence-is-the-corollary error ------
+;;
+;; Per Spec 002 §The error and its ladder + §Resolver surface (EP-0002):
+;; `require-current-frame!` is "read the stamp on the token I hold";
+;; `:rf.error/no-frame-context` is "this token carries no stamp". The error
+;; is reserved for the **absence of a target**, never a **bad** target — a
+;; caller who supplies `{:frame :ghost}` HAS carried a stamp; that is a
+;; registry-lookup failure (`:rf.error/frame-destroyed`), a different
+;; category. So this error is emitted BEFORE any frame-registry lookup, so
+;; a missing context is never mis-reported as `frame-destroyed` for a
+;; synthesised default.
+;;
+;; The frameless error is itself frameless: it rides the ALWAYS-ON error
+;; axis (`re-frame.error-emit/dispatch-on-error!`, surface #4 — survives
+;; `:advanced` + `goog.DEBUG=false`), not per-frame epoch capture. It
+;; carries capture-site ancestry through the `:rf.trace/dispatch-id` /
+;; `:rf.trace/parent-dispatch-id` correlation graph (read off the in-scope
+;; `trace/*handler-scope*`), so the hardest case — a callback captured at
+;; handler X in frame Y whose continuation fires with no stamp after the
+;; cascade ended — is fully attributed even though the error has no frame
+;; of its own.
+;;
+;; `error-emit` statically requires THIS ns (the always-on error substrate
+;; sits above frame in the load order), so we reach `dispatch-on-error!`
+;; through the published `:error-emit/dispatch-on-error` late-bind hook to
+;; avoid the cycle — the producer always loads at boot, so the lookup never
+;; misses in production.
+
+(defn no-frame-context-payload
+  "Build the canonical `:rf.error/no-frame-context` payload for an ambient
+  frame-scoped `operation` that found no carried stamp and no established
+  scope. Per Spec 002 §The error and its ladder, the representative shape
+  is:
+
+    {:rf.error/id :rf.error/no-frame-context
+     :operation   <op-kw>     ;; e.g. :dispatch / :subscribe
+     :where       <sym-or-kw> ;; the resolving call site
+     :event-id    <kw>        ;; the in-flight op's id, when known
+     :recovery    :supply-frame}
+
+  `extra` (optional) merges additional context-site ancestry slots —
+  `:rf.trace/dispatch-id` / `:rf.trace/parent-dispatch-id` (capture-site
+  correlation) — and any caller-supplied `:where` / `:event-id`. Caller-
+  supplied keys win over the defaults so a call site can name itself
+  precisely."
+  ([operation] (no-frame-context-payload operation nil))
+  ([operation extra]
+   (merge {:rf.error/id :rf.error/no-frame-context
+           :operation   operation
+           :recovery    :supply-frame}
+          ;; Capture-site ancestry off the in-scope handler scope: the
+          ;; cascade's dispatch-id correlates a stampless continuation back
+          ;; to the cascade that captured the callback. nil outside any
+          ;; cascade (a genuinely top-of-stack frameless op) — `cond->`'d
+          ;; in so absent rather than nil.
+          (let [did (some-> trace/*handler-scope* :dispatch-id)]
+            (when did {:rf.trace/dispatch-id did}))
+          extra)))
+
+(defn emit-no-frame-context!
+  "Surface `:rf.error/no-frame-context` through the always-on error axis
+  (production-survivable) AND the dev-only trace surface, then return the
+  payload. Per Spec 002 §The error and its ladder the diagnostic must be
+  observable in production where the dev trace is elided, so it rides
+  `re-frame.error-emit/dispatch-on-error!` (reached via the
+  `:error-emit/dispatch-on-error` late-bind hook — `error-emit` requires
+  this ns, so a static require would cycle).
+
+  This is the EMISSION half; callers that must also halt the operation use
+  `require-current-frame!` (which emits then throws). Detection-only
+  callers (frame pickers, tooling) read the nil from `current-frame` /
+  `resolve-current-frame` and never reach here."
+  [payload]
+  (let [operation (:operation payload)
+        event-id  (:event-id payload)]
+    ;; Axis 1 (BROAD) — always-on listener registry (survives prod elision).
+    ;; LISTENER-ONLY: no-frame-context is an invalid operation with no
+    ;; recovery point (there is no {:swallow|:replacement|:default} choice
+    ;; for an operation that named no frame), so the per-frame `:on-error`
+    ;; policy fn (axis 2) is deliberately bypassed — and we have no frame to
+    ;; route a policy through anyway. Pass `nil` for `error-event`.
+    (when-let [dispatch-on-error! (late-bind/get-fn :error-emit/dispatch-on-error)]
+      (dispatch-on-error!
+        :rf.error/no-frame-context
+        nil                              ;; no event vector — absence, not a throw on a dispatch
+        event-id
+        nil                              ;; no frame — that is the whole point
+        nil                              ;; no exception — invalid op, not a throw
+        0                                ;; elapsed-ms
+        (interop/now-ms)                 ;; time
+        nil))                            ;; LISTENER-ONLY — axis 2 not invoked
+    ;; Dev-only trace path — DCEs under `:advanced` + `goog.DEBUG=false`.
+    (trace/emit-error! :rf.error/no-frame-context payload)
+    payload))
+
+(defn require-current-frame!
+  "Return the frame stamp (id) the in-effect scope carries, or raise/emit
+  `:rf.error/no-frame-context` when the token carries no stamp. This is the
+  \"read the stamp on the token I hold\" primitive (Spec 002 §Resolver
+  surface, EP-0002); absence is its corollary error.
+
+  Resolution is the scope reader (`resolve-current-frame`) ONLY — explicit
+  `{:frame …}` override resolution belongs to each public surface's call
+  site (it wins before this helper is consulted). When the reader returns a
+  frame, that stamp is returned unchanged — NO frame-registry lookup
+  happens here, so a missing context is never mis-reported as
+  `:rf.error/frame-destroyed` (the registry-lookup category for a bad
+  explicit target). When the reader returns nil, the always-on
+  `:rf.error/no-frame-context` is emitted (with capture-site ancestry) and
+  then thrown so the operation halts loudly rather than writing to an
+  invented default.
+
+  `operation` is the op kind (`:dispatch` / `:subscribe` / …). `extra`
+  (optional) supplies call-site detail merged into the payload — typically
+  `{:where '<resolving-fn> :event-id <id>}`.
+
+  Public frame-scoped operations that resolve ambiently call this; low-
+  level detection / pickers / tooling read the nil from the readers
+  directly and never throw."
+  ([operation] (require-current-frame! operation nil))
+  ([operation extra]
+   (or (resolve-current-frame)
+       (let [payload (no-frame-context-payload operation extra)]
+         (emit-no-frame-context! payload)
+         (throw (ex-info (str (:rf.error/id payload)) payload))))))
 
 ;; ---- lookup ---------------------------------------------------------------
 
@@ -1148,11 +1324,33 @@
       (destroy-frame! id)
       (reg-frame id config))))
 
-;; ---- :rf/default ----------------------------------------------------------
+;; ---- :rf/default — TEST-ONLY fixture helper -------------------------------
+;;
+;; Per Spec 002 §`:rf/default` is an ordinary id (EP-0002): `:rf/default`
+;; is NOT created by `init!`, is NOT the React-context default, is NOT a
+;; lookup tier, and is NOT inferred from a missing stamp. The runtime never
+;; synthesises it. `init!` no longer calls this.
+;;
+;; This helper survives ONLY as a convenience for TEST FIXTURES that pin
+;; `*current-frame*` to `:rf/default` and dispatch ambiently — the standard
+;; `re-frame.test-support/make-reset-runtime-fixture` and the per-suite
+;; reset-runtime fixtures across the adapter / SSR test trees call it to
+;; establish a known default scope. It is a TEST PATH, not a runtime path:
+;; no production / SSR code reaches it, and the chain's later call-site
+;; beads (EP-0002 §3+) migrate real ambient call sites to carry an explicit
+;; frame. Kept (rather than deleted) because removing it would break those
+;; out-of-scope test fixtures wholesale; the name + this banner make the
+;; test-only intent unambiguous.
 
 (defn ensure-default-frame!
-  "The :rf/default frame is registered automatically the first time the
-  runtime boots. Idempotent."
+  "TEST-ONLY fixture helper. Register the ordinary `:rf/default` frame if
+  absent (idempotent), so a test that pins `*current-frame*` to
+  `:rf/default` and dispatches ambiently has a frame to land on.
+
+  NOT a runtime path — `init!` does NOT call this (per Spec 002
+  §`:rf/default` is an ordinary id, EP-0002: the runtime never synthesises
+  a default frame). Application / SSR boot code that wants a default-named
+  app frame registers it explicitly via `(rf/reg-frame :rf/default {…})`."
   []
   (when-not (get @frames :rf/default)
-    (reg-frame :rf/default {:doc "Universal default frame."})))
+    (reg-frame :rf/default {:doc "Test-fixture default frame (ordinary id; not a runtime floor)."})))

--- a/implementation/core/src/re_frame/views/provider.cljs
+++ b/implementation/core/src/re_frame/views/provider.cljs
@@ -136,20 +136,25 @@
 (def ^:dynamic *current-frame* nil)
 
 (defn current-frame
-  "Resolution chain (per Spec 002 §Reading the frame from React context):
+  "Resolution chain (READER) per Spec 002 §Frame target resolution — the
+  carried invariant (EP-0002). Returns the scope frame, or **nil** when no
+  scope is established — it never synthesises `:rf/default` (the runtime
+  never repairs absence). The two tiers it observes:
+
     1. Dynamic var (set by with-frame).
     2. Closest enclosing frame-provider via React context.
-    3. :rf/default.
 
   Reagent-specific: the React-context tier reads `(.-context cmp)` on
   the in-flight Reagent component. Reagent's class-component machinery
   surfaces context to components whose `:contextType` matches the
   context object — that is the wiring `reg-view*` attaches via
   `{:contextType frame-context}`. Plain Reagent fns lack this wiring,
-  so `(.-context cmp)` is React's empty default — they fall through
-  to `:rf/default`. This narrowness is by design: it is what makes
-  the `:rf.warning/plain-fn-under-non-default-frame-once` warning
-  meaningful.
+  so `(.-context cmp)` is React's empty default — the no-provider
+  sentinel — and coercion returns nil (no scope). A public frame-scoped
+  operation reading nil then fails loudly via
+  `frame/require-current-frame!`; the `:rf.warning/plain-fn-under-non-
+  default-frame-once` narrowness contract (which the later EP-0002 view
+  bead sharpens into a no-frame-context path) keys off this same nil.
 
   The keyword/string coercion via
   `re-frame.adapter.context/coerce-context-value` is defensive cover
@@ -162,12 +167,18 @@
   Provider's `:value` reaches React as the original keyword (namespace
   preserved). The helper survives the slim rewrite because the
   defensive-cover use case for raw-hiccup mounts is independent of
-  which Reagent build is loaded."
+  which Reagent build is loaded.
+
+  `coerce-context-value` returns nil for the no-provider sentinel (a
+  namespaced keyword it does not special-case — it coerces only genuine
+  frame keywords / prop-stringified keywords), so a plain-fn read with no
+  enclosing Provider falls through to the trailing nil cleanly."
   []
   (or frame/*current-frame*
       (when-let [cmp (current-component)]
-        (adapter-context/coerce-context-value (.-context cmp)))
-      :rf/default))
+        (let [v (.-context cmp)]
+          (when-not (= v adapter-context/no-provider-sentinel)
+            (adapter-context/coerce-context-value v))))))
 
 ;; ---- per-render identity --------------------------------------------------
 ;;

--- a/implementation/core/test/re_frame/boot_test.clj
+++ b/implementation/core/test/re_frame/boot_test.clj
@@ -5,10 +5,15 @@
   fixture (which always calls rf/init!), but no dedicated coverage exists
   for the four entry points themselves:
 
-    * init!                 — idempotent boot; explicit-adapter contract
+    * init!                 — idempotent boot; explicit-adapter contract.
+                              Per Spec 002 §`:rf/default` is an ordinary id
+                              (EP-0002) init! does NOT create a :rf/default
+                              frame — the runtime never synthesises a default.
     * install-adapter!      — single-adapter-per-process invariant
     * dispose-adapter!      — tear down + clear the slot
-    * ensure-default-frame! — :rf/default presence guarantee
+    * ensure-default-frame! — TEST-ONLY fixture helper that registers the
+                              ordinary :rf/default frame on demand (NOT a
+                              runtime path; init! no longer calls it).
 
   Per rf2-agql `(rf/init! ...)` requires an explicit adapter spec map.
   The no-arg form and the keyword form are both errors; the only
@@ -67,7 +72,7 @@
 ;; ---- tests ----------------------------------------------------------------
 
 (deftest init-is-idempotent
-  (testing "init! is idempotent — calling twice does not double-install or duplicate :rf/default"
+  (testing "init! is idempotent — calling twice does not double-install the adapter; it creates NO :rf/default frame"
     (is (nil? (adapter/current-adapter))
         "precondition: no adapter installed at the start of the test")
     (is (zero? (count-frames))
@@ -76,8 +81,10 @@
     (rf/init! plain-atom/adapter)
     (is (some? (adapter/current-adapter))
         "init! installs the supplied adapter")
-    (is (= 1 (default-frame-count))
-        "init! registers exactly one :rf/default frame")
+    (is (zero? (default-frame-count))
+        "init! creates NO :rf/default frame (EP-0002: the runtime never synthesises a default)")
+    (is (zero? (count-frames))
+        "init! registers no frames at all")
     (let [adapter-after-first (adapter/current-adapter-spec)
           frames-after-first  @frame/frames]
       ;; Second boot — should be a no-op.
@@ -86,8 +93,8 @@
           "the second init! does NOT re-install the adapter (same identity)")
       (is (= frames-after-first @frame/frames)
           "the second init! does NOT mutate the frames registry"))
-    (is (= 1 (default-frame-count))
-        ":rf/default appears exactly once after two init! calls")))
+    (is (zero? (default-frame-count))
+        ":rf/default is still absent after two init! calls")))
 
 (deftest install-adapter-rejects-double-install
   (testing "install-adapter! raises :rf.error/adapter-already-installed on a second call"
@@ -246,8 +253,8 @@
     (rf/init! plain-atom/adapter)
     (is (identical? plain-atom/adapter (adapter/current-adapter-spec))
         "init! with a literal adapter map installs that exact spec")
-    (is (= 1 (default-frame-count))
-        ":rf/default frame is present after the literal-adapter init!")))
+    (is (zero? (default-frame-count))
+        "no :rf/default frame is created by init! (EP-0002 — the runtime never synthesises a default)")))
 
 ;; ---- current-adapter vs current-adapter-spec (rf2-ivx3a) -----------------
 ;;
@@ -297,12 +304,17 @@
 (deftest adapter-swap-resets-substrate-state-keeps-registrar
   (testing "dispose then install a different adapter — registrar survives, substrate state resets"
     ;; Boot under adapter A (plain-atom), register a handler, register a
-    ;; non-default frame, and seed the default frame's app-db.
+    ;; non-default frame, and seed the default frame's app-db. Per EP-0002
+    ;; the runtime no longer synthesises :rf/default — this test declares it
+    ;; explicitly (an ordinary id) and runs ambient ops inside an explicit
+    ;; :rf/default scope, exactly as a single-frame app would.
     (rf/init! plain-atom/adapter)
     (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
     (rf/reg-sub      :n    (fn [db _] (:n db)))
+    (rf/reg-frame :rf/default {:doc "explicit app frame"})
     (rf/reg-frame :tenant-a {:doc "tenant-a"})
-    (rf/dispatch-sync [:seed 7])
+    (binding [frame/*current-frame* :rf/default]
+      (rf/dispatch-sync [:seed 7]))
     (is (= 7 (rf/subscribe-once :rf/default [:n]))
         "before swap: the seeded value is visible via the layer-1 sub")
     (let [registrar-before @registrar/kind->id->metadata]
@@ -345,7 +357,8 @@
         ;; Handlers from before the swap are still callable — registrar
         ;; preserved them. Issue a fresh dispatch and observe via B.
         (let [replace-pre @replace-calls]
-          (rf/dispatch-sync [:seed 99])
+          (binding [frame/*current-frame* :rf/default]
+            (rf/dispatch-sync [:seed 99]))
           (is (> @replace-calls replace-pre)
               "adapter B's :replace-container! was invoked by dispatch-sync (proves event commit routes through B, not the disposed A)"))
         (is (= 99 (rf/subscribe-once :rf/default [:n]))

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -279,10 +279,15 @@
 ;; ---- Spec 002 §:rf/default — ensure-default-frame! idempotence -----------
 
 (deftest ensure-default-frame-is-idempotent
-  (testing "calling ensure-default-frame! more than once does not duplicate or replace the default frame"
-    ;; reset-runtime already called rf/init! → ensure-default-frame!.
+  (testing "calling the TEST-ONLY ensure-default-frame! helper more than once does not duplicate or replace the default frame"
+    ;; Per EP-0002, init! no longer creates :rf/default. ensure-default-frame!
+    ;; survives only as a test-fixture helper; create the frame on demand,
+    ;; then prove repeat calls are idempotent.
+    (is (nil? (frame/frame :rf/default))
+        ":rf/default is absent after init! (the runtime never synthesises it)")
+    (frame/ensure-default-frame!)
     (let [original (frame/frame :rf/default)]
-      (is (some? original) ":rf/default exists after init!")
+      (is (some? original) ":rf/default exists after the test-only helper creates it")
       ;; Repeated calls should be no-ops on the already-registered frame.
       (frame/ensure-default-frame!)
       (frame/ensure-default-frame!)

--- a/implementation/core/test/re_frame/frame_resolver_test.clj
+++ b/implementation/core/test/re_frame/frame_resolver_test.clj
@@ -1,0 +1,172 @@
+(ns re-frame.frame-resolver-test
+  "EP-0002 chain bead 1 (rf2-piwhsw) — central frame resolver, the carried
+  invariant. Per Spec 002 §Frame target resolution — the carried invariant
+  and §Resolver surface.
+
+  The resolver separates READING absence from REQUIRING a frame:
+
+    - `frame/current-frame` / `frame/resolve-current-frame` are readers —
+      they return the scope frame or nil; they NEVER synthesise `:rf/default`.
+    - `frame/require-current-frame!` is the requiring primitive — it returns
+      the carried stamp or raises/emits `:rf.error/no-frame-context`.
+
+  And `init!` no longer creates `:rf/default` (the runtime never synthesises
+  a default frame).
+
+  This suite runs cold (no shared reset-runtime fixture that pins
+  `*current-frame*`) so 'outside any scope' is genuinely outside any scope —
+  the whole point of the contract."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixture --------------------------------------------------------------
+;; Cold-start each test: install the plain-atom adapter (needed to allocate
+;; frame containers) but do NOT register or pin any frame. `*current-frame*`
+;; is unbound. This is the genuine no-scope baseline the contract targets.
+
+(defn cold-start [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (adapter/dispose-adapter!)
+  (adapter/reset-lifecycle-state-for-tests!)
+  (trace/clear-listeners!)
+  (error-emit/clear-error-listeners!)
+  (rf/init! plain-atom/adapter)
+  (test-fn)
+  (adapter/dispose-adapter!)
+  (adapter/reset-lifecycle-state-for-tests!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (trace/clear-listeners!)
+  (error-emit/clear-error-listeners!))
+
+(use-fixtures :each cold-start)
+
+;; ---- readers return nil outside any scope ---------------------------------
+
+(deftest current-frame-returns-nil-outside-scope
+  (testing "current-frame is nil with no *current-frame* binding — no :rf/default floor"
+    (is (nil? (frame/current-frame))
+        "current-frame returns nil outside any with-frame / scope"))
+  (testing "current-frame returns the dynamic-var scope frame when bound"
+    (binding [frame/*current-frame* :app]
+      (is (= :app (frame/current-frame))
+          "current-frame reads *current-frame* when a scope is established"))))
+
+(deftest resolve-current-frame-returns-nil-outside-scope
+  (testing "resolve-current-frame is nil with no scope — no :rf/default floor"
+    (is (nil? (frame/resolve-current-frame))
+        "resolve-current-frame returns nil outside any scope"))
+  (testing "resolve-current-frame returns the dynamic-var scope frame when bound"
+    (binding [frame/*current-frame* :app]
+      (is (= :app (frame/resolve-current-frame))
+          "resolve-current-frame reads the dynamic-var tier when bound"))))
+
+;; ---- require-current-frame! — return stamp or raise -----------------------
+
+(deftest require-current-frame-returns-the-carried-stamp
+  (testing "require-current-frame! returns the scope frame when one is established"
+    (binding [frame/*current-frame* :app]
+      (is (= :app (frame/require-current-frame! :dispatch))
+          "the carried stamp is returned unchanged — NO registry lookup, no repair"))))
+
+(deftest require-current-frame-returns-stamp-even-when-frame-unregistered
+  (testing "require-current-frame! does NOT consult the frame registry — a bound but unregistered stamp is still returned"
+    ;; The contract: require-current-frame! reads the stamp; absence (no
+    ;; stamp) is its only error. A bad/unregistered explicit target is a
+    ;; DIFFERENT category (:rf.error/frame-destroyed at the registry-lookup
+    ;; site), so this helper must NOT pre-empt it with a lookup.
+    (binding [frame/*current-frame* :never-registered]
+      (is (= :never-registered (frame/require-current-frame! :dispatch))
+          "a carried stamp is returned without a registry lookup — no frame-destroyed mis-report"))))
+
+(deftest require-current-frame-raises-no-frame-context-outside-scope
+  (testing "require-current-frame! with no carried stamp raises :rf.error/no-frame-context"
+    (let [thrown (try
+                   (frame/require-current-frame! :dispatch {:where 're-frame.router/dispatch!
+                                                            :event-id :todo/add})
+                   nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? thrown) "require-current-frame! throws outside any scope")
+      (is (= ":rf.error/no-frame-context" (some-> thrown ex-message))
+          "ex-message carries the :rf.error/no-frame-context tag")
+      (let [data (ex-data thrown)]
+        (is (= :rf.error/no-frame-context (:rf.error/id data))
+            "ex-data carries the canonical :rf.error/id discriminator")
+        (is (= :dispatch (:operation data))
+            "ex-data carries the :operation")
+        (is (= 're-frame.router/dispatch! (:where data))
+            "ex-data carries the caller-supplied :where")
+        (is (= :todo/add (:event-id data))
+            "ex-data carries the caller-supplied :event-id")
+        (is (= :supply-frame (:recovery data))
+            "ex-data carries :recovery :supply-frame")))))
+
+(deftest no-frame-context-rides-the-always-on-error-axis
+  (testing ":rf.error/no-frame-context fans out through the production-survivable error-emit listener registry (axis 1)"
+    (let [records (atom [])]
+      (error-emit/register-error-listener! ::probe (fn [r] (swap! records conj r)))
+      (try
+        (try (frame/require-current-frame! :subscribe) (catch clojure.lang.ExceptionInfo _ nil))
+        (finally (error-emit/unregister-error-listener! ::probe)))
+      (let [no-frame (filterv #(= :rf.error/no-frame-context (:error %)) @records)]
+        (is (= 1 (count no-frame))
+            "exactly one :rf.error/no-frame-context record reached the always-on listener")
+        (let [r (first no-frame)]
+          (is (nil? (:frame r))
+              "the record carries no frame — absence is the whole point")
+          (is (= :rf.error/no-frame-context (:error r))
+              "the record's :error is the canonical category"))))))
+
+(deftest no-frame-context-emitted-before-any-registry-lookup
+  (testing "the no-frame error is the ABSENT-target category, distinct from the bad-target :rf.error/frame-destroyed"
+    ;; Even though no :rf/default frame exists in this cold suite, the
+    ;; absence path must report no-frame-context, never frame-destroyed —
+    ;; the error is emitted BEFORE any frame-registry lookup.
+    (let [thrown (try (frame/require-current-frame! :dispatch) nil
+                      (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :rf.error/no-frame-context (:rf.error/id (ex-data thrown)))
+          "absent target → :rf.error/no-frame-context, never :rf.error/frame-destroyed"))))
+
+;; ---- init! does not create :rf/default ------------------------------------
+
+(deftest init-does-not-create-default-frame
+  (testing "init! installs the adapter but creates NO :rf/default frame (the runtime never synthesises a default)"
+    ;; The cold-start fixture already called (rf/init! plain-atom/adapter).
+    (is (some? (adapter/current-adapter))
+        "precondition: init! installed the adapter")
+    (is (nil? (frame/frame :rf/default))
+        "init! does NOT register a :rf/default frame")
+    (is (empty? @frame/frames)
+        "no frames at all are registered by init!")))
+
+(deftest default-frame-remains-a-legal-explicit-id
+  (testing ":rf/default is an ordinary id a program may register EXPLICITLY"
+    (is (nil? (frame/frame :rf/default)) "precondition: not present")
+    (rf/reg-frame :rf/default {:doc "The app frame for this program."})
+    (is (some? (frame/frame :rf/default))
+        ":rf/default registers like any ordinary frame id when chosen explicitly")
+    ;; And once explicitly in scope, ambient resolution returns it — an
+    ;; honest scope, not a synthesised floor.
+    (binding [frame/*current-frame* :rf/default]
+      (is (= :rf/default (frame/require-current-frame! :dispatch))
+          "an explicit :rf/default scope resolves like any other"))))
+
+;; ---- ensure-default-frame! survives as a TEST-ONLY fixture helper ---------
+
+(deftest ensure-default-frame-is-a-test-only-helper
+  (testing "ensure-default-frame! still registers :rf/default for test fixtures (idempotent), but it is NOT a runtime path"
+    (is (nil? (frame/frame :rf/default)) "precondition: init! did not create it")
+    (frame/ensure-default-frame!)
+    (is (some? (frame/frame :rf/default))
+        "the test-only fixture helper registers :rf/default on demand")
+    (let [original (frame/frame :rf/default)]
+      (frame/ensure-default-frame!)
+      (is (identical? original (frame/frame :rf/default))
+          "idempotent — a second call does not replace the frame"))))

--- a/implementation/core/test/re_frame/views_current_component_cljs_test.cljs
+++ b/implementation/core/test/re_frame/views_current_component_cljs_test.cljs
@@ -8,15 +8,18 @@
   `:adapter/current-component` late-bind hook, which the active adapter
   installs at ns-load time.
 
-  Resolution chain (per Spec 002 §Reading the frame from React context):
+  Resolution chain (READER, per Spec 002 §Frame target resolution — the
+  carried invariant, EP-0002):
     1. `frame/*current-frame*` (dynamic var; set by `with-frame`)
     2. closest enclosing frame-provider via React context
-    3. `:rf/default`
+    3. nil — NO `:rf/default` floor (the runtime never synthesises a default)
 
   This file exercises the no-adapter path: with the hook unset (or
-  installed but with no in-flight component), tier 2 returns nil and
-  resolution falls through to tier 3 (`:rf/default`). This is exactly
-  the headless / pre-init shape the runtime relies on.
+  installed but with no in-flight component), tier 2 returns nil and the
+  reader returns nil ('no scope'). A public frame-scoped operation turns
+  that nil into a loud `:rf.error/no-frame-context` via
+  `frame/require-current-frame!`; the reader itself never repairs absence.
+  This is exactly the headless / pre-init shape the runtime relies on.
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
@@ -39,15 +42,15 @@
         (late-bind/set-fn! hook-key original)))))
 
 (deftest current-frame-with-no-adapter-hook
-  (testing "current-frame falls through to :rf/default when the hook is unset"
+  (testing "current-frame returns nil (no scope) when the hook is unset — no :rf/default floor"
     (with-hook-as-nil :adapter/current-component
       (fn []
         (is (nil? (late-bind/get-fn :adapter/current-component))
             "precondition: the hook is unset")
-        ;; No dynamic var is bound, no adapter hook is installed → tier 3
-        ;; (:rf/default) is the only remaining tier.
-        (is (= :rf/default (views/current-frame))
-            "with no dynamic-var binding and no adapter hook, current-frame returns :rf/default")))))
+        ;; No dynamic var is bound, no adapter hook is installed → the
+        ;; reader returns nil (EP-0002: no :rf/default synthesis).
+        (is (nil? (views/current-frame))
+            "with no dynamic-var binding and no adapter hook, current-frame returns nil")))))
 
 (deftest current-frame-honours-dynamic-var-without-hook
   (testing "with the hook unset, the dynamic-var tier still wins"
@@ -61,11 +64,11 @@
   (testing "an installed hook that returns nil is equivalent to no hook"
     ;; A real adapter's `current-component` returns nil outside a render.
     ;; views.cljs must treat nil-from-hook the same as no-hook: skip the
-    ;; React-context tier, fall through to :rf/default.
+    ;; React-context tier, return nil ('no scope') — no :rf/default floor.
     (let [original (late-bind/get-fn :adapter/current-component)]
       (try
         (late-bind/set-fn! :adapter/current-component (constantly nil))
-        (is (= :rf/default (views/current-frame))
-            "hook returning nil → fall through to :rf/default")
+        (is (nil? (views/current-frame))
+            "hook returning nil → reader returns nil (no synthesis)")
         (finally
           (late-bind/set-fn! :adapter/current-component original))))))


### PR DESCRIPTION
EP-0002 chain bead 1/11 (serial). Implements the central frame resolver per spec/002-Frames.md (carried-invariant): frame/current-frame + resolve-current-frame as no-repair readers, require-current-frame! raising :rf.error/no-frame-context, React-context default as no-provider sentinel (not :rf/default), init! no longer creates :rf/default, structured no-frame-context error emitted before registry lookup. Files: frame.cljc, core.cljc, adapter/context.cljs, views/provider.cljs + tests (frame_resolver_test new, boot/frame_lifecycle/views_current_component updated). NOTE: worker completed the implementation but its final commit/PR step was lost to a garbled ending; mayor committed + opened the PR from the pushed branch. CI is the authoritative gate — downstream caller-test breakage (if any) is later-chain-bead work per EP-0002. Closes rf2-piwhsw.