### PR TITLE
feat(core): EP-0002 subscriptions & read helpers — require carried frame, no :rf/default (rf2-jue6sp)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -797,20 +797,30 @@
 
 ;; ---- frame-handle (the keystone) + frame-aware closures ------------------
 ;;
-;; `current-frame-id` exposes the 3-tier resolution chain (dynamic var →
-;; React context → `:rf/default`), single-sourced through
-;; `frame/resolve-current-frame`. `frame-handle` is the keystone: a
-;; per-frame OPERATION BUNDLE (`{:frame :dispatch :dispatch-sync
-;; :subscribe}`) captured at CREATION time, so its ops survive async
-;; boundaries that unwind the dynamic-var / React-context binding.
+;; `current-frame-id` reads the carried-invariant scope/hold stamp via
+;; `frame/require-current-frame!` (EP-0002): the dynamic `*current-frame*`
+;; var or a React-context frame-provider scope, with NO `:rf/default`
+;; floor — absence raises `:rf.error/no-frame-context`. `frame-handle` is
+;; the keystone: a per-frame OPERATION BUNDLE (`{:frame :dispatch
+;; :dispatch-sync :subscribe}`) captured at CREATION time, so its ops
+;; survive async boundaries that unwind the dynamic-var / React-context
+;; scope. The no-arg `frame-handle` / `frame-bound-fn*` capture forms
+;; capture ONLY when a real scope exists at capture time.
 
 (defn current-frame-id
-  "Return the active frame id at the call site. Resolution chain: dynamic
-  var -> React context (CLJS only, via `:adapter/current-frame` late-
-  bind hook) -> `:rf/default`. A keyword. Per Spec 002 §Reading the
-  frame from React context."
+  "Return the active frame id the in-effect scope carries — a keyword.
+  Resolution is the carried-invariant scope/hold chain via
+  `frame/require-current-frame!` (EP-0002): the dynamic `*current-frame*`
+  stamp or a React-context frame-provider scope (CLJS only, via the
+  `:adapter/current-frame` late-bind hook). There is NO `:rf/default`
+  floor — called under no established scope it raises
+  `:rf.error/no-frame-context` rather than reporting an invented default.
+  This is the context READER form; it is `frame-scoped` and so requires a
+  scope. Per Spec 002 §Resolver surface + §Reading the frame from React
+  context."
   []
-  (frame/resolve-current-frame))
+  (frame/require-current-frame! :current-frame-id
+                                {:where 're-frame.core/current-frame-id}))
 
 (defn make-frame-handle
   "Internal constructor for `frame-handle` (and the `reg-view` injection
@@ -903,8 +913,19 @@
   A per-call `:frame` in the dispatch opts MUST NOT override the
   captured frame — the handle is LOCKED to one frame. It is an
   OPERATION BUNDLE, not a container: read the frame's app-db value via
-  `(rf/app-db-value (:frame handle))`, not the handle itself."
-  ([]         (make-frame-handle (current-frame-id) nil))
+  `(rf/app-db-value (:frame handle))`, not the handle itself.
+
+  EP-0002: the no-arg form captures the scope/hold stamp at CREATION
+  time via `frame/require-current-frame!` — it captures ONLY when a real
+  scope exists at capture time. Capturing outside any scope raises
+  `:rf.error/no-frame-context`, never a captured `:rf/default` (per Spec
+  002 §Resolver surface). Use the 1-arity `(frame-handle frame-id)` to
+  lock a handle to a named frame from outside any scope (the right shape
+  for async callbacks / tools / tests / SSR)."
+  ([]         (make-frame-handle
+                (frame/require-current-frame!
+                  :frame-handle {:where 're-frame.core/frame-handle})
+                nil))
   ([frame-id] (make-frame-handle frame-id nil)))
 
 ;; ---- frame-scope lexical macros ------------------------------------------
@@ -993,9 +1014,17 @@
   realised with `doall` / `mapv` / `into` inside the render scope).
   Reach for `frame-bound-fn*` when you have a genuine async-boundary
   case; reach for `doall` when you have a reactive-tracking case. Per
-  rf2-atqkg the two are not interchangeable."
+  rf2-atqkg the two are not interchangeable.
+
+  EP-0002: the 1-arity form captures the scope/hold stamp at WRAP time
+  via `frame/require-current-frame!` — it captures ONLY when a real scope
+  exists at wrap time. Wrapping outside any scope raises
+  `:rf.error/no-frame-context`, never a captured `:rf/default` (per Spec
+  002 §Resolver surface). Use the 2-arity `(frame-bound-fn* frame-id f)`
+  to bind an explicit frame from outside any scope."
   ([f]
-   (let [frame (current-frame-id)]
+   (let [frame (frame/require-current-frame!
+                 :frame-bound-fn* {:where 're-frame.core/frame-bound-fn*})]
      (fn [& args]
        (binding [frame/*current-frame* frame]
          (apply f args)))))
@@ -1258,13 +1287,18 @@
 
 (defn snapshot-of
   "Return the value at `path` in a frame's app-db — convenience over
-  `(get-in (rf/app-db-value frame-id) path)`. Frame resolution:
-  `(:frame opts)` if supplied, else `(current-frame-id)`. Returns `nil`
-  if the frame is missing or the path resolves to nothing. Per Spec 002
-  §The public registrar query API."
+  `(get-in (rf/app-db-value frame-id) path)`. Frame resolution (EP-0002
+  carried invariant): an explicit `(:frame opts)` override WINS; else the
+  scope/hold stamp via `frame/require-current-frame!`. Returns `nil` if
+  the frame is missing or the path resolves to nothing. A snapshot read
+  under no `:frame` opt and no established scope raises
+  `:rf.error/no-frame-context` rather than reading an invented default.
+  Per Spec 002 §The public registrar query API."
   ([path] (snapshot-of path nil))
   ([path opts]
-   (let [frame-id (or (:frame opts) (current-frame-id))]
+   (let [frame-id (or (:frame opts)
+                      (frame/require-current-frame!
+                        :snapshot-of {:where 're-frame.core/snapshot-of}))]
      (get-in (frame/frame-app-db-value frame-id) path))))
 
 ;; Per rf2-bmzq0: `sub-topology` and `sub-cache-snapshot` live in
@@ -1281,9 +1315,14 @@
      (defn sub-cache
        "Inspect a frame's runtime sub-cache — CLJS-only, returns
        `{query-v {:value v :ref-count n}}`. JVM returns `nil` (cache has no
-       reaction values). No-arg form uses the active frame. Per Spec 002
-       §The public registrar query API."
-       ([] (sub-cache (current-frame-id)))
+       reaction values). No-arg form resolves the scope/hold stamp via
+       `frame/require-current-frame!` (EP-0002) — called under no
+       established scope it raises `:rf.error/no-frame-context` rather than
+       inspecting an invented default. Pass the 1-arity form to inspect a
+       named frame from outside any scope. Per Spec 002 §The public
+       registrar query API."
+       ([] (sub-cache (frame/require-current-frame!
+                        :sub-cache {:where 're-frame.core/sub-cache})))
        ([frame-id]
         (subs/sub-cache-snapshot frame-id)))
 

--- a/implementation/core/src/re_frame/core_machines.cljc
+++ b/implementation/core/src/re_frame/core_machines.cljc
@@ -51,13 +51,17 @@
 
 (defwrapper machine-by-system-id
   "Look up the spawned-machine id currently bound to `system-id` in the
-  active frame's `[:rf.runtime/machines :system-ids]` reverse index, or nil. The optional
-  `frame-id` arg targets an explicit frame; without it, resolution uses
-  the current frame (per `with-frame` / frame-provider, defaulting to
-  `:rf/default`).
+  active frame's `[:rf.runtime/machines :system-ids]` reverse index, or nil.
 
-  Per Spec 005 §Named addressing via :system-id. Returns nil when the
-  machines artefact is not on the classpath."
+  EP-0002 carried invariant: the optional `frame-id` arg is an explicit
+  override targeting a named frame; without it the 1-arity ambient form
+  resolves the frame through the scope/hold chain (`with-frame` /
+  frame-provider / a carried stamp) via `frame/require-current-frame!` —
+  a lookup under no established scope raises `:rf.error/no-frame-context`,
+  with NO `:rf/default` floor.
+
+  Per Spec 005 §Named addressing via :system-id + Spec 002 §Resolver
+  surface. Returns nil when the machines artefact is not on the classpath."
   {:hook :machines/machine-by-system-id :artefact machines-artefact :on-absent :nil}
   ([system-id]          :delegate)
   ([system-id frame-id] :delegate))

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -808,11 +808,15 @@
 
 (defn subscribe
   "Per Spec 006 §Lookup algorithm. Returns the reaction for query-v;
-  build-and-cache on miss; reuse on hit. The 1-arity form resolves
-  the active frame via the `:adapter/current-frame` late-bind hook
-  (rf2-d4sf) so subscribe inside a with-frame or under a
-  frame-provider auto-routes through the 3-tier chain (dynamic var
-  → React context → :rf/default).
+  build-and-cache on miss; reuse on hit. The 1-arity ambient form
+  resolves the active frame through the carried-invariant scope/hold
+  chain via `frame/require-current-frame!` (EP-0002): a `with-frame` /
+  frame-provider scope (the `:adapter/current-frame` late-bind hook,
+  rf2-d4sf) or a captured `*current-frame*` stamp. There is NO
+  `:rf/default` floor — a subscribe issued under no established scope
+  raises `:rf.error/no-frame-context` rather than silently reading the
+  wrong frame. Pass the 2-arity `(subscribe frame-id query-v)` to read a
+  named frame from outside any scope (async callbacks, tools, tests, SSR).
 
   Per Spec 006 §Plain-fn-under-non-default-frame warning (rf2-d3k3):
   the 1-arity form runs the plain-fn detection check — if the
@@ -850,15 +854,33 @@
   miss path (`:rf.error/no-such-sub`, `:rf.error/frame-destroyed`)
   carries the invocation coord."
   ([query-v]
+   ;; EP-0002 §Subscriptions And Read Helpers — the carried-invariant
+   ;; read. The 1-arity ambient form resolves the frame through the
+   ;; scope/hold chain via `require-current-frame!`: a `with-frame` /
+   ;; frame-provider scope (`resolve-current-frame`) or a captured
+   ;; `*current-frame*` stamp. There is NO `:rf/default` floor — a
+   ;; subscribe issued under no established scope (no with-frame, no
+   ;; enclosing provider, no carried stamp) raises the always-on
+   ;; `:rf.error/no-frame-context` (with capture-site ancestry) rather
+   ;; than silently reading the wrong frame's app-db. The `extra` threads
+   ;; the sub-id into the error payload's `:event-id` slot so a frameless
+   ;; subscribe's error is attributed to the query it carried.
    #?(:cljs
-      (let [frame-id (frame/resolve-current-frame)]
+      (let [frame-id (frame/require-current-frame!
+                       :subscribe
+                       {:where    're-frame.subs/subscribe
+                        :event-id (first query-v)})]
         (when interop/debug-enabled?
           (when-let [warn! (late-bind/get-fn
                             :views/maybe-warn-plain-fn-under-non-default-frame!)]
             (warn! frame-id query-v)))
         (subscribe frame-id query-v))
       :clj
-      (subscribe (frame/resolve-current-frame) query-v)))
+      (subscribe (frame/require-current-frame!
+                   :subscribe
+                   {:where    're-frame.subs/subscribe
+                    :event-id (first query-v)})
+                 query-v)))
   ([frame-id query-v]
    ;; rf2-9hoos (CLJS, dev-only): record the view→sub edge — push this
    ;; query-v into the in-flight render's deref sink so `:rf.view/rendered`
@@ -1001,8 +1023,19 @@
   the slot alive via ref-count and are unaffected — `subscribe-once`'s
   decrement only drives the eviction when it owned the last reference.
 
-  See also: `subscribe`, `unsubscribe`, `compute-sub`, `inject-cofx`."
-  ([query-v] (subscribe-once (frame/resolve-current-frame) query-v))
+  See also: `subscribe`, `unsubscribe`, `compute-sub`, `inject-cofx`.
+
+  EP-0002: the 1-arity ambient form resolves the frame through the
+  scope/hold chain via `frame/require-current-frame!` — a one-shot read
+  under no established scope raises `:rf.error/no-frame-context`, never a
+  `:rf/default` floor. Pass the 2-arity form to read a named frame from
+  outside any scope."
+  ([query-v]
+   (subscribe-once (frame/require-current-frame!
+                     :subscribe-once
+                     {:where    're-frame.subs/subscribe-once
+                      :event-id (first query-v)})
+                   query-v))
   ([frame-id query-v]
    (let [reaction (subscribe frame-id query-v)
          v        (when reaction @reaction)]
@@ -1320,9 +1353,19 @@
 
   Per rf2-0ytl4 seam S-A: ref-counting and synchronous dispose live in
   `re-frame.subs.cache`; this facade fn holds the public API shape and
-  delegates to `subs-cache/unsubscribe!` after resolving the cache + key."
+  delegates to `subs-cache/unsubscribe!` after resolving the cache + key.
+
+  EP-0002: the 1-arity ambient form resolves the frame through the
+  scope/hold chain via `frame/require-current-frame!` — an unsubscribe
+  issued under no established scope raises `:rf.error/no-frame-context`,
+  never a `:rf/default` floor. Pass the 2-arity form to release a slot in
+  a named frame from outside any scope."
   ([query-v]
-   (unsubscribe (frame/resolve-current-frame) query-v))
+   (unsubscribe (frame/require-current-frame!
+                  :unsubscribe
+                  {:where    're-frame.subs/unsubscribe
+                   :event-id (first query-v)})
+                query-v))
   ([frame-id query-v]
    (when-let [cache (:sub-cache (frame/frame frame-id))]
      ;; rf2-mrnur — thread `frame-id` through so the `:rf.sub/dispose`

--- a/implementation/core/src/re_frame/subs/cache.cljc
+++ b/implementation/core/src/re_frame/subs/cache.cljc
@@ -268,10 +268,15 @@
   generally prefers `make-reset-runtime-fixture` (per `test_support`) which
   bundles cache-clearing with registrar / frame state reset.
 
-  Zero-arity targets `:rf/default`; one-arity targets the named frame.
-  Returns nil. See also: `re-frame.subs/clear-sub` (registrar-side
-  counterpart)."
-  ([] (clear-sub-cache! :rf/default))
+  Zero-arity resolves the scope/hold stamp via
+  `frame/require-current-frame!` (EP-0002) — called under no established
+  scope it raises `:rf.error/no-frame-context` rather than clearing an
+  invented default. One-arity targets the named frame (the right shape
+  for fixtures / tools outside any scope). Returns nil. See also:
+  `re-frame.subs/clear-sub` (registrar-side counterpart)."
+  ([] (clear-sub-cache! (frame/require-current-frame!
+                          :clear-sub-cache!
+                          {:where 're-frame.subs.cache/clear-sub-cache!})))
   ([frame-id]
    (when-let [cache (:sub-cache (frame/frame frame-id))]
      (doseq [[k entry] @cache]

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -32,6 +32,12 @@
   (reset! schemas/schemas-by-frame {})
   (flows/reset-last-inputs!)
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-jue6sp): `init!` no longer synthesises `:rf/default`.
+  ;; Register it explicitly as an ordinary frame so the registrar-query
+  ;; tests below (which assert `:rf/default` is enumerable) have a real
+  ;; frame to find. `current-frame-id` outside a scope still RAISES — the
+  ;; with-frame tests assert the carried-invariant absence path directly.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.machines :reload)
@@ -44,15 +50,25 @@
 ;; ===========================================================================
 
 (deftest with-frame-bare-keyword
-  (testing "(with-frame :keyword body) binds *current-frame* across body"
+  (testing "(with-frame :keyword body) binds *current-frame* across body;
+            outside the macro current-frame-id raises :rf.error/no-frame-context
+            (EP-0002 — no :rf/default floor, rf2-jue6sp)"
     (rf/reg-frame :wf/alpha {:doc "alpha"})
-    (is (= :rf/default (rf/current-frame-id))
-        "outside the macro: resolves to :rf/default")
+    ;; Outside the macro: the carried-invariant absence error.
+    (is (= :rf.error/no-frame-context
+           (:rf.error/id (ex-data
+                           (try (rf/current-frame-id) nil
+                                (catch clojure.lang.ExceptionInfo e e)))))
+        "outside the macro: current-frame-id raises rather than defaulting")
     (let [observed (rf/with-frame :wf/alpha (rf/current-frame-id))]
       (is (= :wf/alpha observed)
           "inside the macro body: resolves to the bound id"))
-    (is (= :rf/default (rf/current-frame-id))
-        "after the macro returns: dynamic binding unwinds")))
+    ;; After the macro returns the dynamic binding has unwound — absence again.
+    (is (= :rf.error/no-frame-context
+           (:rf.error/id (ex-data
+                           (try (rf/current-frame-id) nil
+                                (catch clojure.lang.ExceptionInfo e e)))))
+        "after the macro returns: the dynamic binding unwinds, absence raises")))
 
 (deftest with-frame-multi-form-body
   (testing "(with-frame :keyword expr1 expr2 ...) evaluates all body forms,
@@ -98,8 +114,13 @@
           "the body saw the just-created id as current-frame")
       (is (nil? (rf/frame-meta @captured-id))
           "the frame was destroyed on body exit")
-      (is (= :rf/default (rf/current-frame-id))
-          "*current-frame* reverted after the body"))))
+      ;; EP-0002 (rf2-jue6sp): after the body the dynamic scope has
+      ;; unwound — current-frame-id raises rather than reporting :rf/default.
+      (is (= :rf.error/no-frame-context
+             (:rf.error/id (ex-data
+                             (try (rf/current-frame-id) nil
+                                  (catch clojure.lang.ExceptionInfo e e)))))
+          "*current-frame* reverted after the body — absence raises"))))
 
 (deftest with-new-frame-destroys-on-exception
   (testing "(with-new-frame [f ...] body) destroys the frame even when body throws"
@@ -255,8 +276,11 @@
     (let [all (rf/frame-ids)]
       (is (contains? all :fi/alpha))
       (is (contains? all :fi/beta))
+      ;; EP-0002 (rf2-jue6sp): `init!` no longer synthesises `:rf/default`;
+      ;; the fixture registers it explicitly, and frame-ids enumerates it
+      ;; like any other ordinary frame.
       (is (contains? all :rf/default)
-          "the default frame is always present"))))
+          "the explicitly-registered :rf/default frame is enumerated"))))
 
 (deftest frame-ids-1-arity-filters-by-prefix
   (testing "(frame-ids ns-prefix) returns ids whose keyword namespace

--- a/implementation/core/test/re_frame/frame_handle_test.clj
+++ b/implementation/core/test/re_frame/frame_handle_test.clj
@@ -26,6 +26,12 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-jue6sp): `init!` no longer synthesises `:rf/default`.
+  ;; Register it explicitly as an ordinary frame so the tests that
+  ;; observe `:rf/default`'s app-db (and the explicit-id capture cases)
+  ;; have a real frame; the no-arg capture forms still REQUIRE a carried
+  ;; scope at capture time (covered by the *-requires-scope tests below).
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.machines :reload)
@@ -72,7 +78,10 @@
     (rf/reg-event-db :fh/seed (fn [_ [_ v]] {:value v}))
     (rf/reg-sub :fh/value (fn [db _] (:value db)))
     (rf/dispatch-sync [:fh/seed :B-value] {:frame :fh/B})
-    (rf/dispatch-sync [:fh/seed :default-value])
+    ;; Seed :rf/default explicitly (EP-0002: no ambient :rf/default floor)
+    ;; so the assertion can prove the captured subscribe reads :fh/B, not
+    ;; :rf/default's app-db.
+    (rf/dispatch-sync [:fh/seed :default-value] {:frame :rf/default})
     (let [{:keys [subscribe]} (rf/with-frame :fh/B (rf/frame-handle))
           reaction            (subscribe [:fh/value])]
       (is (= :B-value @reaction)
@@ -96,19 +105,37 @@
       (is (nil? (:touched? (rf/app-db-value :fh/other)))
           "the per-call :frame :fh/other was IGNORED — the handle is locked"))))
 
-;; ---- contract: (frame-handle) outside any with-frame captures :rf/default --
+;; ---- contract: (frame-handle) outside any scope RAISES (EP-0002) ---------
+;;
+;; rf2-jue6sp: the no-arg capture form captures ONLY when a real scope
+;; exists at capture time. Capturing outside any with-frame / provider
+;; raises :rf.error/no-frame-context — it does NOT capture :rf/default.
 
-(deftest frame-handle-outside-with-frame-defaults
-  (testing "(frame-handle) with no active with-frame captures :rf/default"
-    (rf/reg-event-db :fh/default-touch (fn [db _] (assoc db :touched? true)))
-    (let [h (rf/frame-handle)]
+(deftest frame-handle-outside-with-frame-raises-no-frame-context
+  (testing "(frame-handle) with no active scope raises :rf.error/no-frame-context
+            instead of capturing :rf/default (rf2-jue6sp)"
+    (is (nil? frame/*current-frame*) "no with-frame scope established")
+    (let [e (try (rf/frame-handle) nil
+                 (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? e) "no-arg frame-handle outside any scope must throw")
+      (is (= :rf.error/no-frame-context (:rf.error/id (ex-data e)))
+          ":rf.error/id is the carried-invariant absence error")
+      (is (= :frame-handle (:operation (ex-data e)))
+          ":operation attributes the failure to frame-handle"))))
+
+(deftest frame-handle-explicit-frame-works-outside-scope
+  (testing "(frame-handle frame-id) needs no scope — the explicit-id capture
+            shape for async callbacks / tools / tests (rf2-jue6sp)"
+    (rf/reg-event-db :fh/explicit-touch (fn [db _] (assoc db :touched? true)))
+    (is (nil? frame/*current-frame*) "no scope established")
+    (let [h (rf/frame-handle :rf/default)]
       (is (= :rf/default (:frame h))
-          "the captured :frame is :rf/default outside any with-frame")
-      ((:dispatch h) [:fh/default-touch])
+          "the explicit frame-id is captured verbatim")
+      ((:dispatch h) [:fh/explicit-touch])
       (test-support/poll-until #(:touched? (rf/app-db-value :rf/default))
-                               {:label "default handle drains to :rf/default"})
+                               {:label "explicit handle drains to :rf/default"})
       (is (true? (:touched? (rf/app-db-value :rf/default)))
-          "the handle outside any with-frame routes to :rf/default"))))
+          "the explicit handle routes to the named frame"))))
 
 ;; ---- frame-bound-fn (macro) + frame-bound-fn* (fn, both arities) ---------
 
@@ -151,16 +178,40 @@
       (is (= 1 (:n (rf/app-db-value :fbf/C)))
           "the explicit frame-id was re-established inside the body"))))
 
+(deftest frame-bound-fn*-one-arity-outside-scope-raises
+  (testing "(frame-bound-fn* f) wrapped outside any scope raises
+            :rf.error/no-frame-context at WRAP time — it does not capture
+            :rf/default (rf2-jue6sp / EP-0002)"
+    (is (nil? frame/*current-frame*) "no with-frame scope established")
+    (let [e (try (rf/frame-bound-fn* (fn [] :unreached)) nil
+                 (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? e) "no-arg frame-bound-fn* outside any scope must throw at wrap time")
+      (is (= :rf.error/no-frame-context (:rf.error/id (ex-data e)))
+          ":rf.error/id is the carried-invariant absence error")
+      (is (= :frame-bound-fn* (:operation (ex-data e)))
+          ":operation attributes the failure to frame-bound-fn*"))))
+
 ;; ---- renamed reads -------------------------------------------------------
 
-(deftest current-frame-id-returns-keyword
-  (testing "(current-frame-id) returns a keyword frame id"
+(deftest current-frame-id-requires-scope
+  (testing "(current-frame-id) reads the established scope's id inside a scope,
+            and raises :rf.error/no-frame-context outside any scope — no
+            :rf/default floor (rf2-jue6sp / EP-0002)"
     (rf/reg-frame :cfi/probe {:doc "probe"})
-    (is (= :rf/default (rf/current-frame-id))
-        "outside any with-frame: :rf/default")
-    (is (keyword? (rf/current-frame-id)) "always a keyword")
+    ;; Inside a scope: the bound id.
     (is (= :cfi/probe (rf/with-frame :cfi/probe (rf/current-frame-id)))
-        "inside with-frame: the bound id")))
+        "inside with-frame: the bound id")
+    (is (keyword? (rf/with-frame :cfi/probe (rf/current-frame-id)))
+        "always a keyword inside a scope")
+    ;; Outside any scope: the carried-invariant absence error.
+    (is (nil? frame/*current-frame*) "no with-frame scope established")
+    (let [e (try (rf/current-frame-id) nil
+                 (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? e) "current-frame-id outside any scope must throw")
+      (is (= :rf.error/no-frame-context (:rf.error/id (ex-data e)))
+          "raises the carried-invariant absence error instead of :rf/default")
+      (is (= :current-frame-id (:operation (ex-data e)))
+          ":operation attributes the failure to current-frame-id"))))
 
 (deftest app-db-value-returns-a-value
   (testing "(app-db-value frame-id) returns the app-db VALUE (a plain map), not a container"

--- a/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
@@ -52,6 +52,13 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-jue6sp): `init!` no longer synthesises `:rf/default`;
+  ;; register it explicitly so these single-app-frame cache tests have a
+  ;; conventional frame to read. NB the cross-thread subscribe/unsubscribe
+  ;; calls below pass `:rf/default` EXPLICITLY (2-arity) — a `with-frame`
+  ;; dynamic binding does not convey into the worker threads, so the
+  ;; carried-invariant stamp must be passed as a value across the boundary.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.machines :reload)
@@ -228,7 +235,7 @@
   (testing "concurrent unsubscribe calls dispose exactly once per slot under contention"
     (rf/reg-event-db :seed (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
-    (rf/dispatch-sync [:seed])
+    (rf/dispatch-sync [:seed] {:frame :rf/default})
 
     (let [n-trials      200
           n-threads     6
@@ -244,14 +251,17 @@
                               (swap! trial-counter inc)
                               (orig-dispose! r))]
           (with-redefs [interop/dispose! dispose-proxy]
-            (rf/subscribe [:n])  ;; ref-count 1
+            ;; Explicit `:rf/default` (2-arity) — the dynamic-var scope
+            ;; does not convey into the worker threads, so the frame stamp
+            ;; rides as a value across the boundary (rf2-jue6sp / EP-0002).
+            (rf/subscribe :rf/default [:n])  ;; ref-count 1
             (let [latch (CountDownLatch. 1)
                   threads (mapv (fn [_]
                                   (Thread.
                                     ^Runnable
                                     (fn []
                                       (.await latch 5 TimeUnit/SECONDS)
-                                      (rf/unsubscribe [:n]))))
+                                      (rf/unsubscribe :rf/default [:n]))))
                                 (range n-threads))]
               (doseq [t threads] (.start t))
               (.countDown latch)

--- a/implementation/core/test/re_frame/sub_cache_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_test.clj
@@ -26,10 +26,21 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-jue6sp): `init!` no longer synthesises `:rf/default`,
+  ;; and ambient subscribe / unsubscribe / clear-sub-cache! now require a
+  ;; carried frame stamp (no `:rf/default` floor). These cache tests
+  ;; exercise the ambient read surface against a single conventional app
+  ;; frame, so the fixture registers `:rf/default` explicitly and pins it
+  ;; as the established scope for the whole test body via `with-frame` —
+  ;; the standard "small app chooses :rf/default as its explicit id"
+  ;; shape. The frameless-read failure path is covered separately by
+  ;; `subscribe-frameless-read-raises-no-frame-context` below.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.machines :reload)
-  (test-fn))
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 
@@ -702,3 +713,87 @@
                        (= :answer (:id (:tags ev)))))
                 @traces)
           "expected :rf.registry/handler-replaced trace"))))
+
+;; ===========================================================================
+;; rf2-jue6sp (EP-0002 §Subscriptions And Read Helpers) — ambient read
+;; surfaces require a carried frame; absence is :rf.error/no-frame-context,
+;; NOT a silent read of an invented :rf/default.
+;;
+;; The reset-runtime fixture pins `with-frame :rf/default` for the whole
+;; body, so these absence tests explicitly UNWIND that scope by rebinding
+;; `*current-frame*` to nil — modelling a read issued with no established
+;; scope and no carried stamp (the async-callback / tool / SSR case).
+;; ===========================================================================
+
+(defn- no-frame-context-ex?
+  "True when `thrown` is the EP-0002 absence error."
+  [thrown]
+  (and (some? thrown)
+       (= :rf.error/no-frame-context (:rf.error/id (ex-data thrown)))))
+
+(deftest subscribe-frameless-read-raises-no-frame-context
+  (testing "1-arity subscribe / subscribe-once / unsubscribe / clear-sub-cache!
+            under NO established scope raise :rf.error/no-frame-context
+            instead of falling through to :rf/default (rf2-jue6sp)"
+    (rf/reg-event-db :init (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    ;; Unwind the fixture's with-frame :rf/default scope → genuinely no
+    ;; carried stamp and no React-context provider (JVM).
+    (binding [frame/*current-frame* nil]
+      (let [e (try (rf/subscribe [:n]) nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+        (is (no-frame-context-ex? e)
+            "1-arity subscribe outside any scope raises :rf.error/no-frame-context")
+        (is (= :subscribe (:operation (ex-data e)))
+            ":operation attributes the failure to subscribe")
+        (is (= :n (:event-id (ex-data e)))
+            ":event-id carries the attempted sub-id")
+        (is (= :supply-frame (:recovery (ex-data e)))
+            ":recovery points the caller at supplying a frame"))
+      (is (no-frame-context-ex?
+            (try (rf/subscribe-once [:n]) nil
+                 (catch clojure.lang.ExceptionInfo e e)))
+          "1-arity subscribe-once outside any scope raises")
+      (is (no-frame-context-ex?
+            (try (rf/unsubscribe [:n]) nil
+                 (catch clojure.lang.ExceptionInfo e e)))
+          "1-arity unsubscribe outside any scope raises")
+      (is (no-frame-context-ex?
+            (try (rf/clear-sub-cache!) nil
+                 (catch clojure.lang.ExceptionInfo e e)))
+          "zero-arity clear-sub-cache! outside any scope raises"))))
+
+(deftest subscribe-under-with-frame-resolves-the-scope
+  (testing "1-arity subscribe under with-frame routes to the scope's frame —
+            the ambient form still works INSIDE a real scope (rf2-jue6sp)"
+    (rf/reg-frame :jue/scoped {:doc "explicit non-default scope"})
+    (rf/reg-event-db :seed (fn [_ [_ v]] {:v v}))
+    (rf/reg-sub :v (fn [db _] (:v db)))
+    (rf/dispatch-sync [:seed :scoped-value] {:frame :jue/scoped})
+    ;; Unwind the fixture scope first, then establish :jue/scoped.
+    (binding [frame/*current-frame* nil]
+      (rf/with-frame :jue/scoped
+        (is (= :scoped-value @(rf/subscribe [:v]))
+            "ambient subscribe resolves the with-frame scope, not :rf/default")))))
+
+(deftest subscribe-wrong-frame-prevention-for-reads
+  (testing "ambient reads land on the ESTABLISHED scope's frame, never bleed
+            into a sibling frame — the carried-invariant read isolation
+            (rf2-jue6sp; wrong-frame prevention for READS as well as writes)"
+    (rf/reg-frame :jue/left  {:doc "left frame"})
+    (rf/reg-frame :jue/right {:doc "right frame"})
+    (rf/reg-event-db :seed (fn [_ [_ v]] {:v v}))
+    (rf/reg-sub :v (fn [db _] (:v db)))
+    (rf/dispatch-sync [:seed :left-value]  {:frame :jue/left})
+    (rf/dispatch-sync [:seed :right-value] {:frame :jue/right})
+    (binding [frame/*current-frame* nil]
+      ;; Reading under the :jue/left scope sees ONLY :jue/left's app-db.
+      (rf/with-frame :jue/left
+        (is (= :left-value @(rf/subscribe [:v]))
+            "ambient read under :jue/left resolves :jue/left")
+        (is (not= :right-value @(rf/subscribe [:v]))
+            "the read did NOT bleed into the sibling :jue/right frame"))
+      ;; And under :jue/right it sees ONLY :jue/right's app-db.
+      (rf/with-frame :jue/right
+        (is (= :right-value @(rf/subscribe [:v]))
+            "ambient read under :jue/right resolves :jue/right")))))

--- a/implementation/core/test/re_frame/sub_dispose_trace_test.clj
+++ b/implementation/core/test/re_frame/sub_dispose_trace_test.clj
@@ -43,10 +43,19 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-jue6sp): `init!` no longer synthesises `:rf/default`,
+  ;; and ambient subscribe / unsubscribe / clear-sub-cache! now require a
+  ;; carried frame stamp. These dispose-trace tests exercise the ambient
+  ;; cache lifecycle against a single conventional app frame, so the
+  ;; fixture registers `:rf/default` explicitly and pins it as the
+  ;; established scope for the whole body via `with-frame` — the dispose
+  ;; traces still assert `:frame :rf/default`.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
-  (test-fn))
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/sub_memo_layer_1_test.clj
+++ b/implementation/core/test/re_frame/sub_memo_layer_1_test.clj
@@ -31,10 +31,17 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-jue6sp): `init!` no longer synthesises `:rf/default`,
+  ;; and ambient subscribe / dispatch now require a carried frame stamp.
+  ;; These memoization tests run against a single conventional app frame,
+  ;; so register `:rf/default` explicitly and pin it as the established
+  ;; scope for the whole body via `with-frame`.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.machines :reload)
-  (test-fn))
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/sub_memo_layer_n_1_test.clj
+++ b/implementation/core/test/re_frame/sub_memo_layer_n_1_test.clj
@@ -33,10 +33,17 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-jue6sp): `init!` no longer synthesises `:rf/default`,
+  ;; and ambient subscribe / dispatch now require a carried frame stamp.
+  ;; These memoization tests run against a single conventional app frame,
+  ;; so register `:rf/default` explicitly and pin it as the established
+  ;; scope for the whole body via `with-frame`.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.machines :reload)
-  (test-fn))
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/sub_parametric_inputs_test.clj
+++ b/implementation/core/test/re_frame/sub_parametric_inputs_test.clj
@@ -46,10 +46,17 @@
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-jue6sp): `init!` no longer synthesises `:rf/default`,
+  ;; and ambient subscribe / dispatch now require a carried frame stamp.
+  ;; These parametric-input tests run against a single conventional app
+  ;; frame, so register `:rf/default` explicitly and pin it as the
+  ;; established scope for the whole body via `with-frame`.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.machines :reload)
-  (test-fn))
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (defn- capture-errors!
   "Register a one-shot trace listener that collects every emitted error

--- a/implementation/core/test/re_frame/subs_override_seam_cljs_test.cljs
+++ b/implementation/core/test/re_frame/subs_override_seam_cljs_test.cljs
@@ -22,12 +22,14 @@
        failure trace."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.subs :as subs]
             [re-frame.registrar :as registrar]
             [re-frame.late-bind :as late-bind]
             [re-frame.schemas.malli]                ;; install the default Malli validator
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace.tooling :as trace-tooling]))
+            [re-frame.trace.tooling :as trace-tooling])
+  (:require-macros [re-frame.core :refer [with-frame]]))
 
 ;; ---- fixtures + helpers ---------------------------------------------------
 
@@ -47,13 +49,22 @@
         (when (and (map? ovr) (contains? ovr query-v))
           [(get ovr query-v)])))))
 
+;; EP-0002 (rf2-jue6sp): the override-seam tests exercise the ambient
+;; 1-arity subscribe read path, which now requires a carried frame stamp.
+;; A function fixture registers :rf/default explicitly and pins it as the
+;; established scope for the whole test body via with-frame (the map-shape
+;; :before hook cannot wrap the body).
 (use-fixtures :each
-  {:before (fn []
-             (registrar/clear-all!)
-             (reset! override-atom nil)
-             (try (rf/init! plain-atom/adapter) (catch :default _ nil))
-             (install-test-resolver!))
-   :after  (fn [] (reset! override-atom nil))})
+  (fn [test-fn]
+    (registrar/clear-all!)
+    (reset! override-atom nil)
+    (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+    (frame/ensure-default-frame!)
+    (install-test-resolver!)
+    (try
+      (with-frame :rf/default
+        (test-fn))
+      (finally (reset! override-atom nil)))))
 
 (defn- with-overrides* [m thunk]
   (reset! override-atom m)

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -139,13 +139,24 @@
 
 (defn machine-by-system-id
   "Look up the spawned-machine id currently bound to `system-id` in the
-  active frame's `[:rf.runtime/machines :system-ids]` reverse index, or nil. The `frame`
-  arg defaults to the current frame (per `frame/current-frame`); pass
-  an explicit frame-id for cross-frame lookups.
+  active frame's `[:rf.runtime/machines :system-ids]` reverse index, or nil.
 
-  Per Spec 005 §Named addressing via :system-id."
+  EP-0002 carried invariant: the 1-arity ambient form resolves the frame
+  through the scope/hold chain via `frame/require-current-frame!` — a
+  lookup issued under no established scope raises
+  `:rf.error/no-frame-context` rather than reading an invented default's
+  reverse index. Pass the 2-arity `(machine-by-system-id system-id
+  frame-id)` to look up a named frame from outside any scope (async
+  callbacks / tools / cross-frame lookups).
+
+  Per Spec 005 §Named addressing via :system-id + Spec 002 §Resolver
+  surface."
   ([system-id]
-   (machine-by-system-id system-id (frame/current-frame)))
+   (machine-by-system-id
+     system-id
+     (frame/require-current-frame!
+       :machine-by-system-id
+       {:where 're-frame.machines/machine-by-system-id})))
   ([system-id frame-id]
    ;; EP-0001 (rf2-vzld77): the system-ids reverse index is durable
    ;; machine runtime-db state — read it off the runtime-db partition.


### PR DESCRIPTION
EP-0002 chain bead 3/11 (serial). Migrate the SUBSCRIBE/READ surface to the carried-invariant frame contract (spec/002-Frames.md §Resolver surface). Each context-defaulting form now resolves the frame through the scope/hold chain via frame/require-current-frame! and FAILS with :rf.error/no-frame-context outside any established scope — no :rf/default floor, no silent wrong-frame read.

## Read-helper changes
- 1-arity subscribe / subscribe-once / unsubscribe (re-frame.subs) — resolve-current-frame reader replaced with require-current-frame!; the sub-id rides the error payload :event-id.
- zero-arity clear-sub-cache! (re-frame.subs.cache) — was a literal :rf/default default.
- current-frame-id / no-arg frame-handle / no-arg frame-bound-fn* / snapshot-of / no-arg sub-cache (re-frame.core). The no-arg hold-capture forms (frame-handle / frame-bound-fn*) capture ONLY when a real scope exists at capture/wrap time; outside any scope they raise rather than capturing :rf/default. snapshot-of keeps explicit :frame override winning.
- 1-arity machine-by-system-id (re-frame.machines) — ambient resolution now requires the carried frame; the core defwrapper + sub-machine / machine-has-tag? inherit via the migrated subscribe.

No spec change needed: spec/002-Frames.md §Resolver surface (landed by bead piwhsw) already enumerates these as require-helper call sites.

## Tests fixed (this bead)
- frame_handle_test: frame-handle-outside-with-frame and current-frame-id-returns-keyword rewritten to assert :rf.error/no-frame-context outside scope (+ explicit-frame works outside scope); added frame-bound-fn*-one-arity-outside-scope-raises; seeded :rf/default explicitly where the test proves capture is frame-faithful.
- core_api_additions_test: with-frame-bare-keyword + with-new-frame-let-binding assert absence raises after scope unwinds; fixture registers :rf/default explicitly so the registrar-query tests still enumerate it.
- sub_cache_test: fixture pins with-frame :rf/default; added subscribe-frameless-read-raises-no-frame-context (subscribe / subscribe-once / unsubscribe / clear-sub-cache! outside scope all raise), subscribe-under-with-frame-resolves-the-scope, and subscribe-wrong-frame-prevention-for-reads (READ isolation across sibling frames).
- sub_cache_concurrency_test: fixture registers :rf/default; cross-thread subscribe/unsubscribe pass :rf/default explicitly (dynamic scope does not convey to worker threads).
- sub_dispose_trace_test / sub_memo_layer_1_test / sub_memo_layer_n_1_test / sub_parametric_inputs_test: fixtures pin with-frame :rf/default (subscribe-surface suites).
- subs_override_seam_cljs_test (CLJS): map-shape fixture converted to a function fixture pinning with-frame :rf/default; verified in a focused node-test run (seam resolves, no :rf.error/no-frame-context).

## Quality gates
core clojure -M:test: all subscribe/read-helper + frame-handle/current-frame-id namespaces GREEN — frame_handle_test, core_api_additions_test, sub_cache_test, sub_cache_concurrency_test, sub_dispose_trace_test, sub_memo_layer_1_test, sub_memo_layer_n_1_test, sub_parametric_inputs_test (verified 0 failures/0 errors in isolation AND in the full-suite context). CLJS node-test compiles clean (1180 files, 0 warnings).

Remaining RED-BY-DESIGN (later-bead caller breakage, serial chain). Across the full core JVM run the no-frame-context residue is 251 :dispatch vs only 8 :subscribe + 3 :current-frame-id; the latter 11 all live in NON-subscribe-primary test files owned by other beads:
- :dispatch (251) — router/event-emit/fx ambient dispatch: bead nn0jqa (fx/runtime — fx_test, http, machines spawn/dispatch, dispatch-to-system-fx), bead 9wa0lf residue + feature beads (events, interceptor, drain, on_error, success_path/trigger_handler, db_pending, event_emit).
- :subscribe / :current-frame-id (11) — reg_view_injection_test + hot_reload (views → 69r7ui); success_path_trigger_handler_test + trigger_handler_coord_test (trace trigger-handler → gjq3ow); marks_test (marks/elision → gjq3ow); source_coord_test (source-coord capture); examples_test (SSR end-to-end → acjknb).
- elision/marks/redact/sensitive (gjq3ow trace/elision); partitioned_commit (EP-0001); conformance (bead 12).

CLJS node-test cannot run to its summary on the integration branch: a pre-existing async-dispatch crash in http-cljs-test (a setTimeout-armed :dispatch fails with :rf.error/no-frame-context, :where re-frame.router/build-envelope — bead 9wa0lf's router change × the http fx, nn0jqa territory; the http test file predates the EP chain) terminates the node process before the alphabetically-later subscribe namespaces run. Not introduced by this bead (no http/dispatch code touched here); owned by nn0jqa.

Scope boundary respected: only subscribe/read helpers + their tests. Did NOT touch root/view/adapter (69r7ui), registration (5q7um6), fx/runtime (nn0jqa), SSR (acjknb), trace/elision (gjq3ow), tools (bd4div).