### PR TITLE
test(security): capture expected malformed-stamp warnings on JVM path — silent-on-success (rf2-80jyfk)

### DIFF
--- a/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/fail_closed_invariant_security_cljs_test.cljc
@@ -231,7 +231,7 @@
    "relative/path"             ;; bare relative segment (no leading /)
    "/path\twith\ttabs"         ;; embedded control chars
    "/path\nwith\nnewlines"     ;; embedded control chars
-   "/path null"])         ;; embedded NUL
+   "/path\u0000null"])         ;; embedded NUL
 
 (deftest untrusted-url-inputs-never-classify-in-app
   (testing "w3qgc#2 + rf2-3bv8o — every untrusted URL-sink input fails

--- a/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
@@ -45,11 +45,50 @@
   Reverting the `scrub-snapshot` `:traces`/`:epochs` scrub makes the
   snapshot property go RED. Confirmed by temporary local revert + restore
   (see PR Quality gates)."
-  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
-               :cljs [cljs.test :refer-macros [deftest is testing]])
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing]
+                      :refer [use-fixtures]])
             [clojure.walk :as walk]
             [re-frame.mcp-base.sensitive :as sens]
             [re-frame.security.gen :as gen]))
+
+;; ---------------------------------------------------------------------------
+;; Expected-warning capture (rf2-80jyfk)
+;; ---------------------------------------------------------------------------
+;;
+;; These property tests INTENTIONALLY drive thousands of malformed
+;; `:sensitive?` stamps through `sens/strip-sensitive` / `scrub-snapshot` /
+;; `sensitive-event?` (the rf2-ih7g4 fail-closed corpus). Each malformed
+;; stamp fires `re-frame.mcp-base.sensitive`'s contract-drift warning. On the
+;; CLJS path the silent-on-success node runner stubs `js/console.warn` (see
+;; `re-frame.test-quiet.shadow-node`), so that warning never reaches test
+;; output. The JVM path emits the warning via `(binding [*out* *err*]
+;; (println …))`, which the quiet runner does NOT capture (it filters only
+;; cognitect's stdout banner) — so a green JVM run floods stderr with
+;; thousands of expected WARN lines, defeating the silent-on-success posture
+;; (rf2-80jyfk issue 1).
+;;
+;; This `:once` fixture mirrors the CLJS console.warn stub on the JVM: it
+;; binds `*err*` to a throwaway sink for the duration of the namespace's test
+;; run, so the EXPECTED malformed-stamp warnings are captured rather than
+;; leaked. The warning's having FIRED is still asserted, just not via stderr
+;; bytes — the `malformed-count` counter is the framework's observability
+;; hook and is pinned by `gate-off-malformed-stamp-counts-as-dropped`, so the
+;; fail-closed log path stays exercised + verified.
+;;
+;; Scope discipline (acceptance criteria): only `*err*` is rebound, and ONLY
+;; on the JVM. clojure.test routes assertion / FAIL / ERROR / summary output
+;; through `clojure.test/*test-out*` (bound to the real `*out*`), so failure
+;; diagnostics are untouched — a red run still reports normally. CLJS is a
+;; no-op fixture: the node runner's console.warn stub already covers it.
+#?(:clj
+   (use-fixtures :once
+     (fn [t]
+       (binding [*err* (java.io.PrintWriter. (java.io.StringWriter.))]
+         (t))))
+   :cljs
+   (use-fixtures :once
+     (fn [t] (t))))
 
 (def ^:private sentinel "S3CR3T-rf2-3cfvt-EGRESS-DO-NOT-SHIP")
 


### PR DESCRIPTION
Fixes rf2-80jyfk (2 issues).

**Issue 1 (Medium) — JVM stderr WARN flood on green.** The mcp-egress-security property tests intentionally drive the rf2-ih7g4 fail-closed malformed-`:sensitive?`-stamp corpus through `strip-sensitive` / `scrub-snapshot`, firing `re-frame.mcp-base.sensitive`'s contract-drift warning thousands of times. The CLJS node runner stubs `console.warn`; the JVM quiet runner only filters cognitect's stdout banner, so a green JVM run flooded stderr. Added a JVM-only `:once` fixture binding `*err*` to a throwaway sink for the namespace run — mirroring the CLJS console.warn-stub intent. Assertion / FAIL / ERROR / summary output routes through `clojure.test/*test-out*` (the real `*out*`), so a red run still reports normally; the existing `malformed-count` assertions still pin that the fail-closed warning path fired. CLJS fixture is a no-op (the runner stub already covers it). Scope: only `*err*`, only on the JVM, test-only — no production warning behaviour changed.

**Issue 2 (Low) — literal NUL byte in a .cljc test.** Replaced the embedded 0x00 byte in the fail-closed-invariant URL corpus with the reader-level unicode escape so ordinary text tooling (rg -n, stale-path audits) no longer treats the source file as binary. Same hostile-input semantics; matches the sibling tab/newline escapes on the two adjacent corpus lines.

## Quality gates

**Issue 1 stderr cleanliness** (security JVM tier — `cd implementation/security && clojure -M:test`):

- Before: green run (EXIT 0, 56 tests / 449 assertions) emitted **3640** `[re-frame.mcp-base.sensitive] WARN` lines to stderr (3640 total stderr lines).
- After: green run (EXIT 0, 56 tests / 449 assertions) emits **0** stderr lines — fully clean, comparable to the CLJS `npm run test:security` summary.

**Gates run:**

- `cd implementation/security && clojure -M:test` → 56 tests, 449 assertions, 0 failures, 0 errors; stderr empty.
- `npm run test:security` (CLJS counterpart of the touched .cljc) → Build completed, 0 warnings; 56 tests, 449 assertions, 0 failures, 0 errors. Validates the cross-runtime `use-fixtures` require + the unicode escape.
- `rg -n 'embedded NUL'` now line-numbers the formerly-binary file (no more "binary file matches").

No production code touched (only `implementation/security/test/`).
