### PR TITLE
fix(machines-viz): fired-edge parity for parallel-region :on fallback + SVG export escaping (rf2-85a9do)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -770,20 +770,27 @@ state boxes. The feature stays opt-in behind `:direction :auto`.
   the match is by **edge-id** (not endpoint node-ids like the from/to
   lens), it lights **every** traversed arm — microsteps, guard-fork
   candidates — the lens cannot reach. **Palette delegated to Figma.**
-- ✅ **Parallel fired-edge coverage (rf2-8ncxrf / rf2-3v3gv1 / rf2-l8ls6w).**
+- ✅ **Parallel fired-edge coverage (rf2-8ncxrf / rf2-85a9do / rf2-3v3gv1 / rf2-l8ls6w).**
   A `:type :parallel` transition emits ONE `:rf.machine/transition` whose
   `:before` / `:after` carry the WHOLE region-map. `extract-fired-edge-ids`
   (Xray-side) derives the fired edges per region from the region-map **plus**
-  the structured `:cascade`: (a) a region that **changed via a region-local
-  transition** lights its region-scoped edge (rf2-8ncxrf); (b) a region that
-  **changed via the parallel ROOT `:on`** (no region-local edge moved it)
-  lights the MACHINE-ROOT-sourced chip whose region-qualified `:to-path` names
-  it (rf2-3v3gv1); (c) a region that was **HANDLED but UNCHANGED** — a real
-  targetless/internal or external self transition with `before == after` and a
-  non-empty cascade — lights its self/internal edge, distinguished from a
-  RESTING region (declined the event, absent from the cascade) by the
-  `:cascade` `:region` stamps (rf2-l8ls6w). All three mint ids that agree with
-  the live chart by construction (the projection is the single edge-id source).
+  the structured `:cascade`. A region that **changed** is resolved through an
+  ordered fallback (the edge shapes are mutually exclusive per region):
+  (a) **region-local transition** — lights its region-scoped edge (rf2-8ncxrf);
+  (b) **the region's OWN top-level `:on` fallback** — no region-local edge
+  matched, but the region def carried a region-level `:on` whose machine-level
+  fallback edge (`:machine-level?`, sourced from the region CONTAINER per
+  §rf2-7i7t3, in-region `:to-path`, **not** `:parallel-root-on?`) moved it; it
+  lights that edge, reserved between the region-local and root-`:on` arms
+  (rf2-85a9do); (c) **the parallel ROOT `:on`** — neither a region-local nor a
+  region-level `:on` edge matched, so the MACHINE-ROOT-sourced chip whose
+  region-qualified `:to-path` names the region lights (rf2-3v3gv1). Separately,
+  a region that was **HANDLED but UNCHANGED** — a real targetless/internal or
+  external self transition with `before == after` and a non-empty cascade —
+  lights its self/internal edge, distinguished from a RESTING region (declined
+  the event, absent from the cascade) by the `:cascade` `:region` stamps
+  (rf2-l8ls6w). All four arms mint ids that agree with the live chart by
+  construction (the projection is the single edge-id source).
 
 ## §5 — Roadmap
 

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1726,6 +1726,15 @@ plus `<title>` and `<desc>` elements summarising the machine (same
 content as the PNG sidecar). Fonts are embedded so the SVG renders with
 the same typography when pasted into a doc or a Figma frame.
 
+The `<title>` / `<desc>` text is **XML-escaped** (rf2-85a9do): the
+viewport clone is serialised with `XMLSerializer` (which escapes for us),
+but the `<title>` / `<desc>` are constructed by hand from the raw machine
+id + summary, so the five XML-significant characters (`& < > " '`) are
+escaped to entities before injection. A programmatic machine id or
+current-state label carrying `&`, `<`, or `>` therefore cannot malform
+the SVG, break the PNG rasterisation that loads the SVG into an `<img>`,
+or inject markup into a copied / exported artifact.
+
 Both image exporters throw `:rf.machines-viz.export/no-svg` when the
 chart has not rendered a viewport yet (an empty / nil-definition
 placeholder renders no chart), and `:rf.machines-viz.export/no-chart-state`

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
@@ -175,6 +175,44 @@
               (if (= 1 region-count) "region" "regions")))
        "."))
 
+(defn- xml-escape
+  "Escape the five XML-significant characters in `s` so the value is safe
+  inside element TEXT content (and, conservatively, attribute values) of
+  the manually-constructed `<title>` / `<desc>` markup. `&` MUST be
+  escaped first so the entity-introducing ampersands the others emit are
+  not double-escaped.
+
+  rf2-85a9do — the `<foreignObject>` viewport clone is serialised by
+  `XMLSerializer` (which escapes for us), but `chart-as-svg` builds the
+  `<title>`/`<desc>` by hand from raw machine ids + the alt-text summary,
+  bypassing that escaping. A programmatic machine id or state label
+  carrying `&`, `<`, or `>` would otherwise emit malformed XML — breaking
+  the SVG, the PNG rasterisation that loads the SVG into an `<img>`, and
+  any copied/exported artifact. Returns `\"\"` for nil."
+  [s]
+  (if (nil? s)
+    ""
+    (-> (str s)
+        (str/replace "&" "&amp;")
+        (str/replace "<" "&lt;")
+        (str/replace ">" "&gt;")
+        (str/replace "\"" "&quot;")
+        (str/replace "'" "&apos;"))))
+
+(defn svg-title+desc
+  "Build the escaped `<title>` / `<desc>` markup pair for `chart-as-svg`
+  from the chart-state seam `cs`. Pure (no DOM) so the escaping contract
+  is node-testable (the image exporters themselves are browser-DOM-only).
+  The `<title>` is the machine id (defaulting to `:machine`); the
+  `<desc>` is the `alt-text` summary. Both are run through `xml-escape`
+  (rf2-85a9do) so XML-significant characters in a programmatic machine id
+  or current-state label cannot inject markup into — or malform — the
+  exported SVG. Returns the concatenated `<title>…</title><desc>…</desc>`
+  string."
+  [cs]
+  (str "<title>" (xml-escape (name (or (:machine-id cs) :machine))) "</title>"
+       "<desc>" (xml-escape (alt-text cs)) "</desc>"))
+
 ;; ---------------------------------------------------------------------------
 ;; SVG
 ;;
@@ -373,12 +411,12 @@
                        :recovery    :no-recovery
                        :reason      "chart has no rendered viewport to serialise"})))
     (let [{:keys [width height] :as bounds} (viewport-content-bounds viewport)
-          inner   (clone-viewport-html viewport bounds)
-          summary (alt-text cs)
-          title   (str "<title>" (name (or (:machine-id cs) :machine)) "</title>")
-          desc    (str "<desc>" summary "</desc>")
-          w       (max 1 (js/Math.ceil width))
-          h       (max 1 (js/Math.ceil height))]
+          inner      (clone-viewport-html viewport bounds)
+          ;; rf2-85a9do — <title>/<desc> are built by hand (not via
+          ;; XMLSerializer), so XML-escape the machine id + summary.
+          title+desc (svg-title+desc cs)
+          w          (max 1 (js/Math.ceil width))
+          h          (max 1 (js/Math.ceil height))]
       ;; A standalone SVG framing the whole topology. The viewport HTML
       ;; lives in a `<foreignObject>` (xhtml namespace required so the
       ;; embedded markup renders as HTML, not opaque XML); inline styles
@@ -387,7 +425,7 @@
            "xmlns:xhtml=\"http://www.w3.org/1999/xhtml\" "
            "width=\"" w "\" height=\"" h "\" "
            "viewBox=\"0 0 " w " " h "\">"
-           title desc viewport-css
+           title+desc viewport-css
            "<foreignObject x=\"0\" y=\"0\" width=\"" w "\" height=\"" h "\">"
            "<div xmlns=\"http://www.w3.org/1999/xhtml\" "
            "style=\"width:" w "px;height:" h "px;position:relative;overflow:hidden;\">"

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/export_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/export_cljs_test.cljs
@@ -114,3 +114,53 @@
     (let [d (try (export/share-url #js {})
                  (catch :default e (ex-data e)))]
       (is (= "chart-element carries no MachineChart state seam" (:reason d))))))
+
+;; ---- rf2-85a9do — SVG <title>/<desc> XML escaping -----------------------
+;;
+;; `chart-as-svg` is browser-DOM-only, but it builds <title>/<desc> by hand
+;; (bypassing the XMLSerializer that escapes the foreignObject viewport
+;; clone). `svg-title+desc` is the PURE seam that does that construction, so
+;; the escaping contract is node-testable here.
+
+(deftest svg-title+desc-escapes-xml-significant-chars
+  (testing "a machine id carrying & < > emits ESCAPED entities, never raw markup"
+    (let [s (export/svg-title+desc
+              {:machine-id (keyword "evil/a&b<c>d")
+               :node-count 1 :edge-count 0 :region-count 0})]
+      ;; The raw XML-significant chars from the id never appear unescaped
+      ;; INSIDE the title text (the surrounding <title>…</title> tag chars
+      ;; are the only legitimate `<`/`>` — assert on the entities instead).
+      (is (str/includes? s "&amp;") "& is escaped to &amp;")
+      (is (str/includes? s "&lt;")  "< is escaped to &lt;")
+      (is (str/includes? s "&gt;")  "> is escaped to &gt;")
+      ;; No double-escaping: a single & became &amp;, not &amp;amp;.
+      (is (not (str/includes? s "&amp;amp;")) "& not double-escaped")
+      ;; The raw `a&b` substring must NOT survive as injected markup.
+      (is (not (str/includes? s "a&b")) "raw ampersand not injected")
+      (is (not (str/includes? s "b<c")) "raw < not injected")
+      (is (not (str/includes? s "c>d")) "raw > not injected"))))
+
+(deftest svg-title+desc-escapes-current-state-label
+  (testing "an XML-significant current-state label is escaped inside <desc>"
+    (let [s (export/svg-title+desc
+              {:machine-id    :ok/plain
+               :current-state (keyword "weird" "x&<y>")
+               :node-count    2 :edge-count 1 :region-count 0})]
+      (is (str/includes? s "<desc>") "still emits a <desc>")
+      ;; The label's significant chars land in the summary, escaped.
+      (is (str/includes? s "&amp;"))
+      (is (str/includes? s "&lt;"))
+      (is (str/includes? s "&gt;"))
+      ;; The literal label fragment must not appear raw.
+      (is (not (str/includes? s "x&<y>")) "raw label markup not injected"))))
+
+(deftest svg-title+desc-default-and-quotes
+  (testing "missing machine-id defaults to :machine; quotes/apostrophes escaped"
+    (let [missing (export/svg-title+desc {:node-count 0 :edge-count 0})
+          quoted  (export/svg-title+desc
+                    {:machine-id (keyword "q\"a'b")
+                     :node-count 0 :edge-count 0})]
+      (is (str/includes? missing "<title>machine</title>")
+          "nil :machine-id defaults to :machine")
+      (is (str/includes? quoted "&quot;") "\" escaped to &quot;")
+      (is (str/includes? quoted "&apos;") "' escaped to &apos;"))))

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -733,6 +733,24 @@ construction). Single-active (flat / compound) transitions are
 unaffected — they take the existing `(from, to, event)` match + the
 machine-level fallback.
 
+**Per-region CHANGED fallback ordering (rf2-85a9do).** A changed region's
+edge is resolved through an ordered, mutually-exclusive fallback:
+(1) the **region-local** edge (region-scoped in-region `:source`, above);
+else (2) the region's **OWN top-level `:on`** fallback — a region def is a
+compound state and may carry a region-level `:on`, which machines-viz
+projects (dropping the synthetic machine-root) as a `:machine-level?`
+edge sourced from the **region container** (`chart.layout/region-node-id`)
+with an in-region `:to-path` and **no** `:parallel-root-on?` (rf2-85a9do);
+else (3) the parallel **ROOT `:on`** ancestor fallback — the MACHINE-ROOT-
+sourced `:parallel-root-on?` chip whose region-qualified `:to-path` names
+the region (rf2-3v3gv1). Separately, a region **HANDLED but UNCHANGED**
+(`before == after` with a non-empty `:cascade` for the region) lights its
+self / internal edge, distinguished from a RESTING region by the
+`:cascade` `:region` stamps (rf2-l8ls6w). Without arm (2) a parallel
+region moved by its own region-level `:on` rendered the state change with
+no fired-edge highlight — the topology drew the edge but the focused
+Dynamic chart left it dark.
+
 **Render (render plane).** The host threads the multi-id set verbatim as
 `:fired-edge-ids` into `machine-canvas/Chart` → `MachineChart`; the
 projector marks **each** matching edge `:fired`, so all N region edges

--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/trace_state.cljs
@@ -350,6 +350,41 @@
               (:id e)))
           edges)))
 
+(defn- region-machine-on-fired-ids
+  "rf2-85a9do — fired-edge ids for ONE region that CHANGED via its OWN
+  region-level top-level `:on` fallback (a legal Spec 005 region-level
+  fallback — XState v5: a region is an orthogonal compound state, so its
+  `:on` is an ordinary region-scoped transition that applies when no
+  child state handles the event).
+
+  `project-parallel` (`layout.cljc` §rf2-7i7t3) projects such a region
+  def's top-level `:on` by DROPPING the synthetic machine-root node and
+  re-pointing the machine-level fallback edge's source to the REGION
+  CONTAINER (`region-node-id`). So the projected edge carries
+  `:machine-level? true`, `:from-path []`, `:source (region-node-id
+  region)`, and an in-region `:to-path` (NOT region-qualified, and NOT
+  `:parallel-root-on?`). Neither `region-local-fired-ids` (keys on the
+  region-scoped in-region source) nor `region-root-on-fired-ids` (keys on
+  `:parallel-root-on?` + a region-qualified `:to-path`) can reach it, so
+  the region top-level fallback was the one traversed arm Xray failed to
+  light — leaving a parallel region state change with no fired-edge
+  highlight (the edge-id agreement the live chart relies on, machines-viz
+  `001-Topology-Parity.md`).
+
+  We match the machine-level fallback edge whose `:source` is THIS
+  region's container, whose `:to-path` is the moved region's in-region
+  `to*`, on the event. Returns a seq of ids."
+  [edges region to* event*]
+  (let [region-source (chart-layout/region-node-id region)]
+    (keep (fn [e]
+            (when (and (:machine-level? e)
+                       (not (:parallel-root-on? e))
+                       (= region-source (:source e))
+                       (= to*           (:to-path e))
+                       (= event*        (:event e)))
+              (:id e)))
+          edges)))
+
 (defn- region-self-internal-fired-ids
   "rf2-l8ls6w — fired-edge ids for ONE region that was HANDLED but whose state
   did NOT change (`before == after`): a real targetless/internal or external
@@ -389,19 +424,27 @@
   derived from the before/after region-map PLUS the structured `:cascade`,
   NOT from a single (from, to) pair.
 
-  Per region, three outcomes light an edge:
+  Per region, the CHANGED outcome is resolved through an ordered fallback
+  (the three edge shapes are mutually exclusive per region) and the
+  HANDLED-but-UNCHANGED outcome lights the self/internal edge:
 
     - **rf2-8ncxrf — region CHANGED via a region-local transition.** `from ≠
       after`; the region-scoped (from, to, event) match (`region-local-fired-
-      ids`) lights the moved region's edge.
+      ids`) lights the moved region's edge. WINS over both fallbacks below.
+    - **rf2-85a9do — region CHANGED via its OWN top-level `:on` fallback.**
+      `from ≠ after`, no region-local edge matched, but the region def
+      carried a region-level `:on` whose machine-level fallback edge
+      (`:machine-level?`, sourced from the region CONTAINER, in-region
+      `:to-path`, NOT `:parallel-root-on?`) moved it. `region-machine-on-
+      fired-ids` lights it. Reserved between region-local and the root `:on`.
     - **rf2-3v3gv1 — region CHANGED via the parallel ROOT `:on`.** `from ≠
-      after` but NO region-local edge matched — the move came from the root
-      `:on` ancestor fallback. `region-root-on-fired-ids` lights the root-
-      sourced chip whose region-qualified `:to-path` names this region. (A
-      root `:on` moving a region while a region-local edge ALSO matches the
-      (from,to,event) cannot happen — the root `:on` is suppressed ENTIRELY
-      when any region handles the event, Spec 005; so the two are mutually
-      exclusive per region.)
+      after` but NEITHER a region-local NOR a region-level `:on` edge matched —
+      the move came from the root `:on` ancestor fallback. `region-root-on-
+      fired-ids` lights the root-sourced chip whose region-qualified
+      `:to-path` names this region. (A root `:on` moving a region while a
+      region-local/region-level edge ALSO matches cannot happen — the root
+      `:on` is suppressed ENTIRELY when any region handles the event, Spec
+      005; so the three are mutually exclusive per region.)
     - **rf2-l8ls6w — region HANDLED but UNCHANGED.** `before == after` yet the
       region appears in the `:cascade` (a real self/internal transition fired
       with a non-empty cascade). `region-self-internal-fired-ids` lights the
@@ -420,13 +463,17 @@
               from*        (normalise-path region-before)
               to*          (normalise-path region-after)]
           (cond
-            ;; CHANGED: region-local match, falling back to the root `:on`
-            ;; ancestor fallback when no region-local edge moved it.
+            ;; CHANGED: region-local match wins; else the region's OWN
+            ;; top-level `:on` fallback (rf2-85a9do); else the parallel
+            ;; ROOT `:on` ancestor fallback. The three edge shapes are
+            ;; mutually exclusive per region (a region-scoped in-region
+            ;; source, vs a region-container source, vs a `:parallel-root-
+            ;; on?` region-qualified target), so the first that matches is
+            ;; the traversed arm.
             (and from* to* (not= region-before region-after))
-            (let [local (region-local-fired-ids edges region from* to* event*)]
-              (if (seq local)
-                local
-                (region-root-on-fired-ids edges region to* event*)))
+            (or (seq (region-local-fired-ids edges region from* to* event*))
+                (seq (region-machine-on-fired-ids edges region to* event*))
+                (region-root-on-fired-ids edges region to* event*))
 
             ;; HANDLED-but-UNCHANGED: a real self/internal transition with
             ;; before == after + a non-empty cascade for this region. A

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/trace_state_cljs_test.cljs
@@ -930,6 +930,141 @@
       (is (every? projected-ids fired)
           "each root-:on fired id is one the live chart actually rendered"))))
 
+;; ---- extract-fired-edge-ids: region-level top-level `:on` (rf2-85a9do) ---
+;;
+;; A parallel REGION def is a compound state and MAY carry its OWN top-level
+;; `:on` (a legal Spec 005 region-level fallback — XState v5: a region is an
+;; orthogonal compound state). `project-parallel` (layout.cljc §rf2-7i7t3)
+;; drops the synthetic machine-root and re-points the region's machine-level
+;; fallback edge's source to the REGION CONTAINER (`region-node-id`). So the
+;; projected edge carries `:machine-level? true`, `:from-path []`, a region-
+;; container `:source`, an in-region `:to-path`, and NO `:parallel-root-on?`.
+;; Neither the region-local match (region-scoped in-region source) nor the
+;; root-:on match (`:parallel-root-on?` + region-qualified `:to-path`) reach
+;; it, so this traversed arm was previously missed — a parallel region state
+;; change with no fired-edge highlight. `region-machine-on-fired-ids` lights
+;; it, reserved between the region-local and root-:on fallbacks.
+
+(defn- region-machine-on-edge-id
+  "Look up the canonical machines-viz edge id for a REGION's top-level `:on`
+  fallback edge (the `:machine-level?` edge sourced from the region container)
+  whose in-region `:to-path` + `:event` match — projected through the SAME
+  public chart.layout/project-definition the live chart uses."
+  [definition region to-path event]
+  (->> (:edges (chart-layout/project-definition definition))
+       (some (fn [e]
+               (when (and (:machine-level? e)
+                          (not (:parallel-root-on? e))
+                          (= (chart-layout/region-node-id region) (:source e))
+                          (= to-path (:to-path e))
+                          (= event   (:event e)))
+                 (:id e))))))
+
+(deftest fired-ids-parallel-region-level-on-lights-canonical-edge
+  (testing "rf2-85a9do — a region moved by its OWN top-level :on fallback
+            (no child state handled the event) lights the region's machine-
+            level fallback edge — the canonical projected id — not a blank"
+    ;; :fetch carries a region-level :on {:abort :loading}. From :done, :abort
+    ;; is not handled by the :done leaf, so the region-level :on fires,
+    ;; moving :fetch :done -> :loading. :validate rests.
+    (let [def           {:type    :parallel
+                         :regions {:fetch    {:initial :loading
+                                              :on      {:abort :loading}
+                                              :states  {:loading {:on {:loaded :done}}
+                                                        :done    {:final? true}}}
+                                   :validate {:initial :checking
+                                              :states  {:checking {:on {:ok :done}}
+                                                        :done     {:final? true}}}}}
+          projected-ids (set (map :id (:edges (chart-layout/project-definition def))))
+          fetch-id      (region-machine-on-edge-id def :fetch [:loading] :abort)
+          events        [{:operation :rf.machine/transition
+                          :tags {:machine-id :par
+                                 :before {:state {:fetch :done :validate :checking}}
+                                 :after  {:state {:fetch :loading :validate :checking}}
+                                 :event  [:abort]
+                                 ;; only :fetch handled :abort (via its region
+                                 ;; :on); :validate rested.
+                                 :cascade [{:kind :exit  :region :fetch :state [:done]}
+                                           {:kind :entry :region :fetch :state [:loading]}]}}]
+          fired         (trace-state/extract-fired-edge-ids def events :par)]
+      (is (string? fetch-id) "the region :fetch top-level :on fallback edge exists")
+      (is (= #{fetch-id} fired)
+          "only :fetch's region-level :on fallback edge lights; :validate stays dark")
+      (is (every? projected-ids fired)
+          "the fired id is a real live-chart edge id (G3 agreement)"))))
+
+(deftest fired-ids-parallel-region-local-wins-over-region-level-on
+  (testing "rf2-85a9do — PRECEDENCE: a region-LOCAL transition wins over the
+            region's own top-level :on fallback when both could match the move"
+    ;; :a has BOTH a region-level :on {:go :two} AND a child :one {:on {:go :two}}.
+    ;; From :one, :go is handled LOCALLY by the :one leaf, so the region-local
+    ;; edge fires — the region-level :on fallback is NOT consulted.
+    (let [def        {:type    :parallel
+                      :regions {:a {:initial :one
+                                    :on      {:go :two}
+                                    :states  {:one {:on {:go :two}} :two {}}}
+                                :b {:initial :one :states {:one {} :two {}}}}}
+          projected  (:edges (chart-layout/project-definition def))
+          local-a    (->> projected
+                          (some (fn [e]
+                                  (when (and (not (:machine-level? e))
+                                             (not (:parallel-root-on? e))
+                                             (= [:one] (:from-path e))
+                                             (= [:two] (:to-path e))
+                                             (= :go (:event e))
+                                             (= (chart-layout/region-scoped-id :a [:one])
+                                                (:source e)))
+                                    (:id e)))))
+          region-on-a (region-machine-on-edge-id def :a [:two] :go)
+          events     [{:operation :rf.machine/transition
+                       :tags {:machine-id :par
+                              :before {:state {:a :one :b :one}}
+                              :after  {:state {:a :two :b :one}}
+                              :event  [:go]
+                              :cascade [{:kind :exit  :region :a :state [:one]}
+                                        {:kind :entry :region :a :state [:two]}]}}]
+          fired      (trace-state/extract-fired-edge-ids def events :par)]
+      (is (string? local-a) "the region-local :a :one→:two edge exists")
+      (is (string? region-on-a) "the region-level :on fallback edge also exists")
+      (is (= #{local-a} fired)
+          "the region-local edge wins; the region-level :on fallback does NOT light")
+      (is (not (contains? fired region-on-a))
+          "the region-level :on fallback edge is suppressed by the local match"))))
+
+(deftest fired-ids-parallel-region-level-on-distinct-from-root-on
+  (testing "rf2-85a9do — a region-level :on fallback and a parallel ROOT :on
+            are distinct arms: a machine with BOTH lights the right one per
+            region (region-level :on for the region that declared it; root :on
+            for the region the root moved) and they never cross-match"
+    ;; :a declares a region-level :on {:reset :one}; the parallel ROOT declares
+    ;; :on {:reset {:target [:b :one]}}. On :reset from {a:two, b:two}:
+    ;;   - :a is moved by its OWN region-level :on (:two -> :one)
+    ;;   - the root :on is SUPPRESSED for :b? No — Spec 005: the root :on fires
+    ;;     only when NO region handles the event. :a handled it locally (region
+    ;;     :on), so the root :on is suppressed and :b rests. Pin that.
+    (let [def           {:type    :parallel
+                         :on      {:reset {:target [:b :one]}}
+                         :regions {:a {:initial :two
+                                       :on      {:reset :one}
+                                       :states  {:one {} :two {}}}
+                                   :b {:initial :two :states {:one {} :two {}}}}}
+          projected-ids (set (map :id (:edges (chart-layout/project-definition def))))
+          region-on-a   (region-machine-on-edge-id def :a [:one] :reset)
+          events        [{:operation :rf.machine/transition
+                          :tags {:machine-id :par
+                                 :before {:state {:a :two :b :two}}
+                                 :after  {:state {:a :one :b :two}}
+                                 :event  [:reset]
+                                 ;; :a handled via its region :on; root :on
+                                 ;; suppressed, :b rested.
+                                 :cascade [{:kind :exit  :region :a :state [:two]}
+                                           {:kind :entry :region :a :state [:one]}]}}]
+          fired         (trace-state/extract-fired-edge-ids def events :par)]
+      (is (string? region-on-a) "the region-level :on fallback edge for :a exists")
+      (is (= #{region-on-a} fired)
+          "only :a's region-level :on edge lights; the suppressed root :on + resting :b are dark")
+      (is (every? projected-ids fired)))))
+
 ;; ---- extract-fired-edge-ids: HANDLED-but-UNCHANGED parallel (rf2-l8ls6w) --
 ;;
 ;; A parallel region can fire a real targetless/INTERNAL or external SELF


### PR DESCRIPTION
Fixes two senior-review findings (rf2-85a9do) in tools/machines-viz + the Xray fired-edge consumer.

**1. Fired-edge parity — region-level top-level `:on` fallback.** `extract-fired-edge-ids` lit a changed parallel region via the region-local match or the parallel ROOT `:on`, but missed a region moved by its OWN top-level `:on` fallback. machines-viz projects that as a `:machine-level?` edge sourced from the region CONTAINER (in-region `:to-path`, no `:parallel-root-on?`), which neither prior branch could reach — so the topology drew the edge but the focused Dynamic chart left it dark. Added `region-machine-on-fired-ids`, wired into the per-region CHANGED precedence: region-local wins, then region-level `:on`, then root `:on` (mutually exclusive arms).

**2. SVG export escaping.** `chart-as-svg` built `<title>` / `<desc>` by hand from the raw machine id + summary, bypassing the XMLSerializer escaping the viewport clone gets. A machine id or state label with `& < >` could malform the SVG / break PNG rasterisation / inject markup. Added an `xml-escape` helper + a pure `svg-title+desc` seam; both are now entity-escaped. XMLSerializer viewport path unchanged.

Tests: added focused fired-edge tests (region-level `:on` lights the canonical id; region-local wins over region-level `:on`; region-level `:on` distinct from root `:on`) and exporter escaping tests (`& < > " '` in machine-id / current-state escaped, no double-escape, no raw markup, `:machine` default). Specs updated: machines-viz `001-Topology-Parity.md` §4.4 + `API.md` §SVG, xray `003-Machine-Inspector.md` parallel fired-edge section.

## Quality gates

- machines-viz `clojure -M:test` — 481 tests, 0 failures, 0 errors
- xray `clojure -M:test` — 1120 tests, 0 failures, 0 errors
- `npm run test:cljs` — 6065 tests, 0 failures, 0 errors