### PR TITLE
fix(xray): requiring core no longer triggers preload side-effects before init!/configure! (rf2-5w06uu)

### DIFF
--- a/implementation/core/src/re_frame/core_epoch.cljc
+++ b/implementation/core/src/re_frame/core_epoch.cljc
@@ -195,9 +195,18 @@
   record so on-box devtools (Xray diff, REPL, `restore-epoch`) can
   reason about exact state. Returns `nil` for non-map input. No-op
   (returns `nil`) when the `day8/re-frame2-epoch` artefact is not on
-  the classpath. Late-bound via `:epoch/projected-record`."
+  the classpath. Late-bound via `:epoch/projected-record`.
+
+  The 2-arity accepts a trusted-local egress `opts` map (rf2-5w06uu —
+  `{:include-sensitive? :include-large? :include-runtime-db?}`, all
+  defaulting `false`): `:include-sensitive?` / `:include-large?` opt the
+  APP-DB partition's privacy / size posture back in across every payload
+  slot; they do NOT lift the frame-state `:rf.db/runtime` partition
+  boundary, which stays `:rf/redacted` unless `:include-runtime-db? true`
+  is also passed. The 1-arity is the safe, fully-redacted off-box path."
   {:hook :epoch/projected-record :artefact epoch-artefact :on-absent :nil}
-  ([record] :delegate))
+  ([record] :delegate)
+  ([record opts] :delegate))
 
 (defwrapper projected-history
   "Convenience: return the projected vector of records for a frame.
@@ -207,6 +216,10 @@
   rather than walking the raw ring and re-wrapping each record. Empty
   vector when the frame has no recorded epochs, when recording is
   disabled, or when the `day8/re-frame2-epoch` artefact is not on the
-  classpath. Late-bound via `:epoch/projected-history`."
+  classpath. Late-bound via `:epoch/projected-history`.
+
+  The 2-arity threads a trusted-local egress `opts` map (rf2-5w06uu) to
+  every record; the 1-arity is the safe, fully-redacted off-box path."
   {:hook :epoch/projected-history :artefact epoch-artefact :on-absent :empty-vec}
-  ([frame-id] :delegate))
+  ([frame-id] :delegate)
+  ([frame-id opts] :delegate))

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -769,18 +769,30 @@
   returns `nil` in that case, no elision called. Production builds
   elide the entire epoch surface; consumers gate any
   `register-epoch-listener!` registration under `interop/debug-enabled?`
-  per Spec 009 §User-side listener registration."
-  [record]
-  (tool-pair/projected-record record))
+  per Spec 009 §User-side listener registration.
+
+  ## Egress opts (rf2-5w06uu)
+
+  The 2-arity accepts a trusted-local `opts` map —
+  `{:include-sensitive? :include-large? :include-runtime-db?}`, all
+  defaulting `false`. `:include-sensitive?` / `:include-large?` opt the
+  APP-DB partition's privacy / size posture back in across every payload
+  slot; they do NOT lift the frame-state `:rf.db/runtime` partition
+  boundary, which stays `:rf/redacted` unless `:include-runtime-db? true`
+  is also passed. The 1-arity is the safe, fully-redacted off-box path."
+  ([record] (tool-pair/projected-record record))
+  ([record opts] (tool-pair/projected-record record opts)))
 
 (defn projected-history
   "Convenience: return the projected vector of records for a frame.
-  Equivalent to `(mapv projected-record (epoch-history frame-id))`.
+  Equivalent to `(mapv #(projected-record % opts) (epoch-history frame-id))`.
   Tools that egress the whole ring (an MCP `watch-epochs` initial
   snapshot, a recorder dumping the full session) can call this once
-  rather than walking the raw ring and re-wrapping each record."
-  [frame-id]
-  (tool-pair/projected-history frame-id))
+  rather than walking the raw ring and re-wrapping each record. The
+  2-arity threads the trusted-local egress `opts` (rf2-5w06uu) to every
+  record; the 1-arity is the safe, fully-redacted off-box path."
+  ([frame-id] (tool-pair/projected-history frame-id))
+  ([frame-id opts] (tool-pair/projected-history frame-id opts)))
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -651,16 +651,30 @@
 ;; same posture as the wire-elision walker). New egress tools call
 ;; `projected-record` and trust the contract.
 
+(defn- elide-wire-opts
+  "Build the `elide-wire-value` opts map from a `projected-record` egress
+  opts map (rf2-5w06uu). `:include-sensitive?` / `:include-large?` default
+  `false` (the off-box default — the safe path); a trusted-local caller
+  opts back in per call. Translates the plain opt keys to the framework's
+  `:rf.size/*` namespaced keys and stamps the record frame so
+  schema-declared sensitive / large paths (keyed by absolute app-db path)
+  match the walked value."
+  [frame-id {:keys [include-sensitive? include-large?]}]
+  {:frame                      frame-id
+   :rf.size/include-sensitive? (boolean include-sensitive?)
+   :rf.size/include-large?     (boolean include-large?)})
+
 (defn- elide-payload-slot
   "Walk one payload slot through `elide-wire-value` rooted at the named
-  frame, with off-box defaults (`:include-sensitive? false`,
-  `:include-large? false`). Returns the elided value; `nil` slots are
-  preserved as nil (a halted-destroy record's `:db-before` /
-  `:db-after` are nil per rf2-v0jwt; the schema admits the absent /
-  nil slot — the projection MUST NOT fabricate a value)."
-  [v frame-id]
+  frame. Off-box defaults (`:include-sensitive? false`,
+  `:include-large? false`) hold unless `opts` opts back in (rf2-5w06uu).
+  Returns the elided value; `nil` slots are preserved as nil (a
+  halted-destroy record's `:db-before` / `:db-after` are nil per
+  rf2-v0jwt; the schema admits the absent / nil slot — the projection
+  MUST NOT fabricate a value)."
+  [v frame-id opts]
   (when (some? v)
-    (elision/elide-wire-value v {:frame frame-id})))
+    (elision/elide-wire-value v (elide-wire-opts frame-id opts))))
 
 (defn- elide-frame-state-slot
   "Project a `:frame-state-before` / `:frame-state-after` slot for off-box
@@ -671,26 +685,39 @@
     - `:rf.db/app` — the application state. Elided through the standard
       `elide-wire-value` walk (sensitive paths → `:rf/redacted`, large
       paths → markers), the SAME projection the `:db-before` / `:db-after`
-      app-db projections receive.
+      app-db projections receive. `opts` `:include-sensitive?` /
+      `:include-large?` opt the app-db partition's privacy / size posture
+      back in (rf2-5w06uu).
 
     - `:rf.db/runtime` — the framework runtime-db. REDACTED by default off-box
       (Mike ruling #14 — Spec 011 §Off-box redaction + Security.md §Epoch
       privacy posture): the runtime-db side is substituted with the
       `:rf/redacted` sentinel rather than walked, so machine snapshots /
       route slice / SSR metadata do not egress to AI / log channels by
-      default. Trusted-local tools that need richer diagnostics request them
-      explicitly (a future opt); the default fails closed.
+      default. The runtime-db partition boundary is ORTHOGONAL to the
+      app-db `:include-sensitive?` / `:include-large?` opt-ins — those do
+      NOT lift it (the rf2-5w06uu bypass). A TRUSTED-LOCAL caller that
+      genuinely needs runtime-db diagnostics opts in explicitly with
+      `:include-runtime-db? true`; the runtime-db value is then elided
+      through the same walk (its own per-slot sensitive / large
+      declarations still apply) rather than redacted whole.
 
   Nil-preserving (a halted-destroy record may carry a nil frame-state slot;
   the projection MUST NOT fabricate a value)."
-  [fs frame-id]
+  [fs frame-id {:keys [include-runtime-db?] :as opts}]
   (when (some? fs)
     (cond-> fs
       (contains? fs :rf.db/app)
-      (update :rf.db/app elision/elide-wire-value {:frame frame-id})
-      ;; Default-redact the runtime-db side off-box (ruling #14).
-      (contains? fs :rf.db/runtime)
-      (assoc :rf.db/runtime :rf/redacted))))
+      (update :rf.db/app elision/elide-wire-value (elide-wire-opts frame-id opts))
+      ;; Default-redact the runtime-db side off-box (ruling #14). The
+      ;; trusted-local `:include-runtime-db? true` opt-in lifts the
+      ;; partition redaction; the value still rides the value walk so its
+      ;; own sensitive / large declarations apply (rf2-5w06uu).
+      (and (contains? fs :rf.db/runtime) (not include-runtime-db?))
+      (assoc :rf.db/runtime :rf/redacted)
+
+      (and (contains? fs :rf.db/runtime) include-runtime-db?)
+      (update :rf.db/runtime elision/elide-wire-value (elide-wire-opts frame-id opts)))))
 
 (defn- reroot-trace-event-db-slots
   "Per rf2-ta0y7: the `:rf.event/db-pending` (t1) and
@@ -723,21 +750,22 @@
   `:trace-events` slot with a scalar sentinel (`:rf/redacted`) — the
   fn returns it untouched in that case (no descend into a non-
   vector)."
-  [trace-events frame-id]
+  [trace-events frame-id opts]
   (if-not (sequential? trace-events)
     trace-events
-    (mapv (fn [ev]
-            (if-not (map? ev)
-              ev
-              (let [op (:operation ev)]
-                (if (and (or (= op :rf.event/db-pending)
-                             (= op :rf.event/db-pending-post-flow))
-                         (some? (get-in ev [:tags :rf.event/db])))
-                  (update-in ev [:tags :rf.event/db]
-                             elision/elide-wire-value
-                             {:frame frame-id :path []})
-                  ev))))
-          trace-events)))
+    (let [wire-opts (assoc (elide-wire-opts frame-id opts) :path [])]
+      (mapv (fn [ev]
+              (if-not (map? ev)
+                ev
+                (let [op (:operation ev)]
+                  (if (and (or (= op :rf.event/db-pending)
+                               (= op :rf.event/db-pending-post-flow))
+                           (some? (get-in ev [:tags :rf.event/db])))
+                    (update-in ev [:tags :rf.event/db]
+                               elision/elide-wire-value
+                               wire-opts)
+                    ev))))
+            trace-events))))
 
 (defn- elide-trace-events-slot
   "The `:trace-events` projection chain (rf2-ta0y7): first re-root the
@@ -745,13 +773,15 @@
   sensitive / large declarations match natively, then run the bulk
   `elide-wire-value` walk over the whole vector to handle the other
   payload-bearing tag values (`:rf.event/v`, `:rf.cofx/value`, etc.)
-  with their own per-tag paths. Idempotent (a second pass walks
-  already-redacted scalars). Nil-preserving."
-  [v frame-id]
+  with their own per-tag paths. `opts` `:include-sensitive?` /
+  `:include-large?` opt the per-call posture back in (rf2-5w06uu).
+  Idempotent (a second pass walks already-redacted scalars).
+  Nil-preserving."
+  [v frame-id opts]
   (when (some? v)
     (-> v
-        (reroot-trace-event-db-slots frame-id)
-        (elision/elide-wire-value {:frame frame-id}))))
+        (reroot-trace-event-db-slots frame-id opts)
+        (elision/elide-wire-value (elide-wire-opts frame-id opts)))))
 
 (defn- elide-sub-run-row
   "Project a single structured `:sub-runs` row for off-box egress
@@ -777,10 +807,17 @@
   Per-PATH large declarations (a sub with `:large [<path>]` marks but no
   whole-output `:large?` stamp) are already substituted INTO the value
   at the marks emit site (`redact-with-paths`), so they ride the row
-  pre-marked and need no projection here."
-  [row]
-  (if-not (:large? row)
-    row
+  pre-marked and need no projection here.
+
+  `opts` `:include-large? true` opts the whole-output large value back in
+  (rf2-5w06uu): a trusted-local caller keeps the raw `:value` /
+  `:prev-value`; the `:large?` flag is still stripped so the projected
+  row's shape matches the on-box base shape's metadata."
+  [row {:keys [include-large?]}]
+  (cond
+    (not (:large? row)) row
+    include-large?      (dissoc row :large?)
+    :else
     (-> row
         (cond-> (contains? row :value)
           (update :value (fn [v]
@@ -792,13 +829,13 @@
 
 (defn- elide-sub-runs-slot
   "Project the structured `:sub-runs` vector for off-box egress: walk
-  each row through `elide-sub-run-row`. Nil- and non-sequential-
-  preserving (a `:redact-fn` may have already replaced the slot with a
-  scalar sentinel)."
-  [sub-runs]
+  each row through `elide-sub-run-row` with the per-call `opts`. Nil- and
+  non-sequential-preserving (a `:redact-fn` may have already replaced the
+  slot with a scalar sentinel)."
+  [sub-runs opts]
   (if-not (sequential? sub-runs)
     sub-runs
-    (mapv elide-sub-run-row sub-runs)))
+    (mapv #(elide-sub-run-row % opts) sub-runs)))
 
 (defn projected-record
   "Project an `:rf/epoch-record` for off-box egress. Routes the
@@ -808,6 +845,28 @@
   off-box defaults `:include-sensitive? false` / `:include-large? false`.
   Sensitive paths land as `:rf/redacted`; large paths land as
   `:rf.size/large-elided` markers per the §Composition rule.
+
+  ## Egress opts (rf2-5w06uu)
+
+  The 2-arity accepts an `opts` map of trusted-local per-call overrides:
+
+      {:include-sensitive?  <bool>   ;; reveal app-db sensitive values
+       :include-large?      <bool>   ;; reveal app-db large values
+       :include-runtime-db? <bool>}  ;; reveal the frame-state runtime-db partition
+
+  All default `false` — the 1-arity (`(projected-record record)`) is the
+  safe, fully-redacted off-box path. `:include-sensitive?` /
+  `:include-large?` opt the APP-DB partition's privacy / size posture back
+  in across every payload slot. They are ORTHOGONAL to the runtime-db
+  partition boundary: the `:rf.db/runtime` side of the frame-state slots
+  stays `:rf/redacted` UNLESS the trusted-local caller ALSO passes
+  `:include-runtime-db? true` (which routes runtime-db through the same
+  value walk, where its own per-slot sensitive / large declarations still
+  apply). This closes the rf2-5w06uu bypass where a per-tool egress path
+  walked the raw record and lifted the runtime-db partition just because
+  the caller asked for sensitive / large APP-DB values. Extending the
+  normative projection (rather than per-tool reimplementation) keeps
+  Security.md §Off-box egress's single-emission-site contract.
 
   EP-0001 (rf2-3aizt1, decision #2 + Mike ruling #14): the CANONICAL
   `:frame-state-before` / `:frame-state-after` slots egress with their
@@ -846,40 +905,46 @@
   elide the entire epoch surface; consumers gate any
   `register-epoch-listener!` registration under `interop/debug-enabled?`
   per Spec 009 §User-side listener registration."
-  [record]
-  (when (map? record)
-    (let [frame-id (:frame record)]
-      (cond-> record
-        ;; EP-0001 (rf2-3aizt1, decision #2 + ruling #14): the CANONICAL
-        ;; frame-state slots egress with the app-db partition elided and the
-        ;; runtime-db partition default-redacted off-box (see
-        ;; `elide-frame-state-slot`).
-        (contains? record :frame-state-before)
-        (update :frame-state-before elide-frame-state-slot frame-id)
+  ([record] (projected-record record nil))
+  ([record opts]
+   (when (map? record)
+     (let [frame-id (:frame record)]
+       (cond-> record
+         ;; EP-0001 (rf2-3aizt1, decision #2 + ruling #14): the CANONICAL
+         ;; frame-state slots egress with the app-db partition elided and the
+         ;; runtime-db partition default-redacted off-box (see
+         ;; `elide-frame-state-slot`). rf2-5w06uu — `opts` thread the
+         ;; trusted-local sensitive / large / runtime-db overrides.
+         (contains? record :frame-state-before)
+         (update :frame-state-before elide-frame-state-slot frame-id opts)
 
-        (contains? record :frame-state-after)
-        (update :frame-state-after  elide-frame-state-slot frame-id)
+         (contains? record :frame-state-after)
+         (update :frame-state-after  elide-frame-state-slot frame-id opts)
 
-        (contains? record :db-before)
-        (update :db-before     elide-payload-slot frame-id)
+         (contains? record :db-before)
+         (update :db-before     elide-payload-slot frame-id opts)
 
-        (contains? record :db-after)
-        (update :db-after      elide-payload-slot frame-id)
+         (contains? record :db-after)
+         (update :db-after      elide-payload-slot frame-id opts)
 
-        (contains? record :trigger-event)
-        (update :trigger-event elide-payload-slot frame-id)
+         (contains? record :trigger-event)
+         (update :trigger-event elide-payload-slot frame-id opts)
 
-        (contains? record :trace-events)
-        (update :trace-events  elide-trace-events-slot frame-id)
+         (contains? record :trace-events)
+         (update :trace-events  elide-trace-events-slot frame-id opts)
 
-        (contains? record :sub-runs)
-        (update :sub-runs      elide-sub-runs-slot)))))
+         (contains? record :sub-runs)
+         (update :sub-runs      elide-sub-runs-slot opts))))))
 
 (defn projected-history
   "Convenience: return the projected vector of records for a frame.
-  Equivalent to `(mapv projected-record (epoch-history frame-id))`.
+  Equivalent to `(mapv #(projected-record % opts) (epoch-history frame-id))`.
   Tools that egress the whole ring (an MCP `watch-epochs` initial
   snapshot, a recorder dumping the full session) can call this once
-  rather than walking the raw ring and re-wrapping each record."
-  [frame-id]
-  (mapv projected-record (state/history-for frame-id)))
+  rather than walking the raw ring and re-wrapping each record. The
+  2-arity threads the trusted-local egress `opts` (rf2-5w06uu —
+  `:include-sensitive?` / `:include-large?` / `:include-runtime-db?`) to
+  every record; the 1-arity is the safe, fully-redacted off-box path."
+  ([frame-id] (projected-history frame-id nil))
+  ([frame-id opts]
+   (mapv #(projected-record % opts) (state/history-for frame-id))))

--- a/tools/xray/spec/011-Launch-Modes.md
+++ b/tools/xray/spec/011-Launch-Modes.md
@@ -421,6 +421,31 @@ is ready, it MUST find the configured layout host and mount the shell
 there. If the host is missing, it MUST emit the diagnostic described in
 §Layout host contract and leave the app running.
 
+**The foundation side-effects fire on the preload path only (rf2-5w06uu).**
+The two-phase boot above runs at the load of
+`day8.re-frame2-xray.preload` (the `:devtools/preloads` entry) — the
+zero-config convenience path that SHOULD self-install. The MANUAL
+alternative — `(require '[day8.re-frame2-xray.core])` then `configure!`
+→ `init!`/`open!` — MUST be inert until the host explicitly calls
+`init!`/`open!`. Requiring the `core` facade (or any namespace
+transitively required to reach `configure!`/`init!`) MUST NOT run any
+of the five foundation side-effects: no handler / trace / epoch
+registration, no browser-global install, no keybinding attach, no
+auto-open scheduled. Concretely, `core` MUST NOT `:require` a namespace
+whose load performs the installation side-effects — the callable install
+primitives live in a side-effect-free-on-load namespace
+(`day8.re-frame2-xray.install`) that both `core/init!` and the
+`preload` boot block invoke; only the `preload` namespace's top-level
+boot block fires them at load. This separation is what makes the
+documented `configure!`-before-auto-open ordering reliable: a host that
+sets `:rf.xray/auto-open? false` or `:rf.xray/keybinding-enabled? false`
+via `core/configure!` BEFORE calling `init!` wins deterministically,
+because nothing fired merely from requiring the facade. `core/init!`
+then performs the manual install explicitly (register handlers →
+register trace collector → register epoch collector → attach keybinding,
+the same boot order as the foundation phase), and auto-open remains a
+preload-only concern — `init!` is open-explicit (the host calls `open!`).
+
 **Boot order.** Within the preload's foundation phase the side-
 effects MUST run in the order **register-handlers → register-
 trace-cb → register-epoch-listener → attach-keybinding**. The keybinding

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -199,6 +199,31 @@ so the common boot-time wiring lands in one require. The full setter
 inventory lives in `day8.re-frame2-xray.config` — see §Wider public
 surface below.
 
+**Requiring the facade is side-effect-free (rf2-5w06uu).** The two
+install paths are strictly separated:
+
+- The **zero-config preload path** — wiring
+  `day8.re-frame2-xray.preload` into shadow-cljs's `:devtools/preloads`
+  — auto-installs on namespace load (the six side-effects above): it is
+  the canonical convenience path and SHOULD self-install.
+- The **manual facade path** — `(require '[day8.re-frame2-xray.core])`
+  then `configure!` → `init!`/`open!` — is INERT until the host calls
+  `init!` (or `open!`). Requiring `core`, and calling its boot-time
+  config setters (`configure!`, `set-auto-open!`, …), registers NO trace
+  / epoch collectors, attaches NO keybinding, installs NO browser globals,
+  and schedules NO auto-open. The side-effecting work fires only inside
+  `init!`. This is what lets a host's `configure!` win deterministically
+  *before* any auto-open — boot flags like `:rf.xray/auto-open? false` /
+  `:rf.xray/keybinding-enabled? false` set via `configure!` before `init!`
+  are honoured because `init!`'s `keybinding/attach!` reads the
+  already-set config slot.
+
+  The facade reaches its install primitives through the inert-on-load
+  `day8.re-frame2-xray.install` namespace, NOT `day8.re-frame2-xray.preload`
+  (whose top-level boot block is what makes the preload path self-install).
+  `init!` itself performs the manual install (registry + trace collector +
+  epoch collector + keybinding attach) explicitly.
+
 ### Wider public surface
 
 Beyond the canonical facade, Xray exposes additional public surfaces
@@ -716,12 +741,25 @@ default `false` — sensitive slots become `:rf/redacted`, large slots
 become the `:rf.size/large-elided` marker. A caller that is itself the
 trust boundary opts back in per call
 (`{:include-sensitive? true}` / `{:include-large? true}`). `egress-record`
-routes through `projected-record` on the safe default path (bookkeeping
-slots pass through unchanged) and through `egress-value` when the
-caller opts in (the projection has no opt-in arg). This is the runtime's
-half of MUST-inventory rows #2 / #15 / #17 / #19; callers pass plain
-`:include-sensitive?` / `:include-large?` opts, the fns translate to the
-framework's `:rf.size/*` namespaced opt keys.
+routes through `projected-record` on **every** path — both the safe
+default and the opt-in — threading the opts into the normative projection
+(rf2-5w06uu). It NEVER walks the raw record through `egress-value`: doing
+so on opt-in (the former shape) both lifted the orthogonal `:rf.db/runtime`
+partition of the frame-state slots off-box just because the caller asked
+for sensitive / large APP-DB values, AND mis-rooted the app-db path
+tracker so frame-state app-db sensitive declarations never matched.
+Per [Security.md §Off-box egress](../../../spec/Security.md) the projection
+is the single normative emission site and per-tool reimplementation is
+prohibited — so the framework's `projected-record` was extended to accept
+the egress opts rather than Xray re-deriving the partition logic. The
+`:rf.db/runtime` frame-state partition stays `:rf/redacted` under
+`:include-sensitive?` / `:include-large?`; a trusted-local caller reveals
+it only with `{:include-runtime-db? true}` (the runtime-db value then
+rides the same value walk, where its own per-slot declarations apply) —
+the same partition-opt-in `egress-runtime-db-value` exposes for live reads.
+This is the runtime's half of MUST-inventory rows #2 / #15 / #17 / #19;
+callers pass plain `:include-sensitive?` / `:include-large?` /
+`:include-runtime-db?` opts.
 
 **Event-level default-suppress (the envelope, not just the value).**
 `egress-value` scrubs the VALUES carried inside a trace event, but it does
@@ -783,7 +821,7 @@ gate is reachable only through the runtime accessors.
 | Accessor (fn) | Tool name | Returns | Reads |
 |---|---|---|---|
 | `get-trace-buffer` | `get-trace-buffer` | `{:ok? true :events <vec> :count <n>}` | `trace-tooling/trace-buffer` — filtered slice of the trace stream. Filter keys are the canonical Spec 009 vocabulary (`:operation` / `:op-type` / `:since` / `:frame` / `:severity` / `:event-id` / `:handler-id` / `:source` / `:origin` / `:dispatch-id` / `:since-ms` / `:between` / `:pred`). Whole `:sensitive? true` events are default-SUPPRESSED before value-scrubbing — the envelope is dropped unless `{:include-sensitive? true}` (rf2-to36uj). |
-| `get-epoch-history` | `get-epoch-history` | `{:ok? true :frame <id> :epochs <vec> :count <n>}` | `rf/epoch-history` per-frame vector of `:rf/epoch-record`. |
+| `get-epoch-history` | `get-epoch-history` | `{:ok? true :frame <id> :epochs <vec> :count <n>}` | `rf/epoch-history` per-frame vector of `:rf/epoch-record`, each routed through `egress-record` → `projected-record`. `:include-sensitive?` / `:include-large?` opt the **app-db** partition's privacy / size posture back in; the frame-state `:rf.db/runtime` partition stays `:rf/redacted` unless a trusted-local caller also passes `:include-runtime-db? true` (rf2-5w06uu). |
 | `get-app-db` | `get-app-db` | `{:ok? true :frame <id> :path <vec> :value <edn>}` | `rf/app-db-value` (optionally scoped by `:path`). The `:value` routes through `egress-value`; when `:path` is supplied the absolute path is threaded into the walker so a scoped slice elides against schema-declared sensitive / large paths — fail-closed, symmetric with the whole-db read and the `get-app-db-diff` slices (rf2-a96xq). |
 | `get-app-db-diff` | `get-app-db-diff` | `{:ok? true :frame <id> :epoch-id <uuid> :diff {:added [{:path :value}] :removed [{:path :value}] :changed [{:path :before :after}]}}` | Projects the changed-paths slice diff between a named epoch's `:db-before` + `:db-after` via the canonical Editscript-A* engine (`diff.engine/project`). Only the changed paths' slices egress — each `:value` / `:before` / `:after` routed through `egress-value`, never two whole app-db snapshots (rf2-uv2q2). Heavier nested-diff projection lives MCP-side. |
 | `get-machine-state` | `get-machine-state` | `{:ok? true :frame <id> :machine-id <kw> :state <live-state-path> :snapshot {:state :data :tags …} :spec <registered-definition>}` | The LIVE FSM position — reads the machine's snapshot from the frame's **runtime-db partition** at `[:rf.runtime/machines :snapshots <machine-id>]` (EP-0001 rf2-vzld77 — machine snapshots are durable runtime-db state; the same slot the Machine Inspector's `:rf.xray/machine-snapshots` sub + the framework resolver read). `:state` is the running state-path (a region→state map for a `:parallel` machine — Spec 005), NOT derived from the static spec; the registered definition is returned separately under `:spec`. A registered-but-not-yet-started machine has no live snapshot — `:state` / `:snapshot` are `nil` and `:reason` is `:not-yet-started` (still `:ok? true`). **Partition-aware off-box redaction (rf2-jj1xer · Mike ruling #14):** `:state` / `:snapshot` are RUNTIME-DB state, so they egress through `egress-runtime-db-value` and are REDACTED to `:rf/redacted` off-box by default; a trusted-local caller opts in with `:include-runtime-db? true` (the inner walk then honours per-slot sensitive / large declarations). `:spec` is a static registry value (not runtime-db), so it egresses through `egress-value` regardless of the runtime-db opt-in. |

--- a/tools/xray/src/day8/re_frame2_xray/core.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/core.cljs
@@ -54,9 +54,18 @@
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.focus :as focus]
+            ;; rf2-5w06uu — require the INERT install-helper ns, NOT the
+            ;; side-effecting `day8.re-frame2-xray.preload`. Loading
+            ;; `preload` runs its top-level boot block (settings load,
+            ;; handler/collector registration, browser globals,
+            ;; keybinding attach, auto-open) — so requiring this facade
+            ;; to reach the MANUAL `init!`/`configure!` API used to fire
+            ;; full preload behaviour before the host's `configure!`
+            ;; could win. `install` is load-inert; the side-effects fire
+            ;; only when `init!` (below) calls them.
+            [day8.re-frame2-xray.install :as install]
             [day8.re-frame2-xray.keybinding :as keybinding]
             [day8.re-frame2-xray.mount :as mount]
-            [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.effects :as settings-effects]
             [day8.re-frame2-xray.theme.global-styles :as global-styles]))
@@ -154,8 +163,8 @@
    (init! nil))
   ([{:keys [default-frame theme density buffer-depths] :as _opts}]
    (registry/register-xray-handlers!)
-   (preload/register-trace-collector!)
-   (preload/register-epoch-collector!)
+   (install/register-trace-collector!)
+   (install/register-epoch-collector!)
    (keybinding/attach!)
    (when default-frame
      (rf/with-frame :rf/xray

--- a/tools/xray/src/day8/re_frame2_xray/install.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/install.cljs
@@ -1,0 +1,174 @@
+(ns day8.re-frame2-xray.install
+  "Side-effect-free Xray install helpers (rf2-5w06uu).
+
+  This namespace holds the *callable* install primitives Xray's two
+  install paths share — the trace/epoch collector registrations and
+  the browser-API export installer — WITHOUT performing any work at
+  namespace-load time. Loading this ns is inert; the side-effects fire
+  only when a caller invokes one of the helpers below.
+
+  ## Why this split exists
+
+  Before rf2-5w06uu the foundation registrations lived in
+  `day8.re-frame2-xray.preload`, whose top-level
+  `(when interop/debug-enabled? …)` boot block runs them on load. But
+  the user-facing facade `day8.re-frame2-xray.core` requires `preload`
+  to reach `init!`'s registration helpers — so a host that chose the
+  *manual* `require core → configure! → init!` path got the full
+  preload behaviour (settings load, handler/collector registration,
+  browser globals, keybinding attach, auto-open) merely by requiring
+  `core`, defeating `configure!`-before-auto-open ordering and boot
+  flags like `:rf.xray/auto-open? false`.
+
+  Splitting the inert helpers here lets:
+
+  - `core` require *this* ns (load-inert) instead of `preload`, so
+    requiring the manual facade no longer fires preload side-effects.
+  - `preload` require this ns and call these helpers from its
+    side-effecting boot block — the zero-config `:devtools/preloads`
+    path keeps auto-installing exactly as before.
+
+  ## Production posture
+
+  As with the preload, the registration/install work is no-op-safe in
+  production: the trace surface elides via `interop/debug-enabled?`,
+  the browser-API export guards on `js/window`, and the framework's
+  epoch listener registration is itself a no-op when the epoch artefact
+  is absent. But the right answer is still to keep Xray out of
+  production builds via shadow-cljs's `:dev`-only `:devtools` block."
+  (:require [goog.object :as gobj]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            ;; rf2-qwm0a — the public-tooling listener surface
+            ;; (`register-listener!` etc.) lives in
+            ;; `re-frame.trace.tooling` for production-DCE reasons.
+            ;; Xray's trace-collector registration below targets the
+            ;; tooling sibling directly. The two consumers of this ns
+            ;; (preload + core) are both dev-only, so this require is
+            ;; excluded from production bundles.
+            [re-frame.trace.tooling :as trace-tooling]
+            [day8.re-frame2-xray.mount :as mount]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+;; ---- registrations -------------------------------------------------------
+
+(defonce ^:private trace-cb-registered?
+  ;; Idempotency sentinel for the trace-callback registration. Cf.
+  ;; `re-frame.trace/register-listener!`: passing the same id twice
+  ;; replaces the callback. The replacement is harmless but emits a
+  ;; warning trace on every reload that pollutes the dev console;
+  ;; this sentinel suppresses re-registration on `:after-load`.
+  (atom false))
+
+(defonce ^:private epoch-cb-registered?
+  ;; Idempotency sentinel for the epoch-callback registration. Same
+  ;; rationale as `trace-cb-registered?`. Phase 3 (rf2-t53ze) — the
+  ;; Time Travel panel needs a per-settle pump from
+  ;; `rf/register-epoch-listener!` into Xray's app-db so the scrubber's
+  ;; subscriptions re-fire when the framework appends an epoch.
+  (atom false))
+
+(defn register-trace-collector!
+  "Register Xray's trace-collector callback under
+  `:rf.xray/trace-collector`. Idempotent via the
+  `trace-cb-registered?` sentinel — a second call is a silent no-op
+  (no warning trace, no replacement). Public so tests can drive
+  it directly without `#'`-piercing into private vars."
+  []
+  (when (compare-and-set! trace-cb-registered? false true)
+    (trace-tooling/register-listener! :rf.xray/trace-collector
+                                      trace-collector/collect-trace!))
+  nil)
+
+(defn register-epoch-collector!
+  "Register Xray's epoch-settle pump under `:rf.xray/epoch-collector`.
+
+  On every drain-settle the framework's epoch artefact fires this
+  callback with the assembled `:rf/epoch-record`; the cb dispatches
+  `:rf.xray/epoch-recorded` into the `:rf/xray` frame so the
+  registry's event handler re-reads `rf/epoch-history` and pumps the
+  fresh snapshot into Xray's app-db. The scrubber's
+  `:rf.xray/epoch-history` sub then re-fires off the standard
+  app-db-write reactive path.
+
+  ## Pre-mount guard (rf2-1barg)
+
+  The preload runs at app boot but `:rf/xray` is lazy-registered by
+  `mount.cljs/open!` on the first Ctrl+Shift+C keypress. Host
+  dispatches that fire BEFORE the user opens Xray would otherwise
+  flow through this cb and dispatch into a frame that doesn't yet
+  exist — the runtime would emit `:rf.error/frame-destroyed` and the
+  record would be lost. The `frame/frame :rf/xray` guard makes
+  pre-mount cbs a silent no-op; `ensure-xray-frame!` seeds the
+  panel's `:epoch-history` slot with the framework's current
+  `(rf/epoch-history target)` snapshot at first open, so the
+  pre-mount window's records still surface.
+
+  Idempotent via the `epoch-cb-registered?` sentinel. No-op when the
+  `day8/re-frame2-epoch` artefact is not on the classpath
+  (`rf/register-epoch-listener!` is itself a no-op in that case)."
+  []
+  (when (compare-and-set! epoch-cb-registered? false true)
+    (rf/register-epoch-listener! :rf.xray/epoch-collector
+      (fn [record]
+        ;; Pre-mount no-op — see the docstring's §Pre-mount guard.
+        ;; Resolved against the framework's frame registry (NOT a
+        ;; Xray-side flag) so a teardown / re-register cycle stays
+        ;; correctly tracked without our needing extra state.
+        (when (frame/frame :rf/xray)
+          ;; Wrap the dispatch in :rf/xray so the registry's handler
+          ;; writes to Xray's app-db, not the host's. The cb's
+          ;; record carries :frame — pass it as the dispatch arg so
+          ;; the handler can compare against its target-frame and
+          ;; skip updates for non-target frames.
+          (rf/with-frame :rf/xray
+            (rf/dispatch [:rf.xray/epoch-recorded (:frame record)]))))))
+  nil)
+
+(defn reset-for-test!
+  "Reset the install helpers' idempotency sentinels so test fixtures can
+  drive multiple load cycles. Test-only — never call from production
+  code."
+  []
+  (reset! trace-cb-registered? false)
+  (reset! epoch-cb-registered? false)
+  nil)
+
+;; ---- public browser API exports -----------------------------------------
+
+(defn- ensure-js-object!
+  [parent key]
+  (or (gobj/get parent key)
+      (let [obj #js {}]
+        (gobj/set parent key obj)
+        obj)))
+
+(defn- install-api-on!
+  [obj]
+  (gobj/set obj "open_BANG_" mount/open!)
+  (gobj/set obj "open_overlay_BANG_" mount/open-overlay!)
+  (gobj/set obj "close_BANG_" mount/close!)
+  (gobj/set obj "toggle_BANG_" mount/toggle!)
+  (gobj/set obj "popout_BANG_" mount/popout!)
+  (gobj/set obj "status" mount/status)
+  nil)
+
+(defn install-browser-api-exports!
+  "Expose the dev-only Xray launch API on the browser global object.
+
+  The preload is the namespace shadow-cljs actually loads into host
+  dev bundles; the facade namespace (`day8.re-frame2-xray.core`) may
+  be absent from apps that only install Xray via `:devtools/preloads`.
+  Export on `window.day8.re_frame2_xray` for preload-only bundles, and
+  augment `window.day8.re_frame2_xray.core` only when Closure has
+  already created that real namespace object. Never pre-create `core`:
+  doing so races `goog.provide` in browser-test and fails with
+  \"Namespace already declared\"."
+  []
+  (when (exists? js/window)
+    (let [day8  (ensure-js-object! js/window "day8")
+          xray (ensure-js-object! day8 "re_frame2_xray")]
+      (install-api-on! xray)
+      (when-let [core (gobj/get xray "core")]
+        (install-api-on! core))))
+  nil)

--- a/tools/xray/src/day8/re_frame2_xray/preload.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/preload.cljs
@@ -43,10 +43,7 @@
   and the mount fails silently. The fallback is graceful, not
   catastrophic — but the right answer is to keep the preload out of
   production builds via shadow-cljs's `:dev`-only `:devtools` block."
-  (:require [goog.object :as gobj]
-            [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
+  (:require [re-frame.interop :as interop]
             ;; Pull `re-frame.epoch` into the dev classpath via the
             ;; Xray preload (rf2-1barg). The Xray Time Travel panel
             ;; reads epoch records via `rf/epoch-history` +
@@ -64,15 +61,16 @@
             ;; preload is dev-only and is excluded from production
             ;; bundles by the `:devtools/preloads` shadow-cljs gate.
             [re-frame.epoch]
-            ;; rf2-qwm0a — the public-tooling listener surface
-            ;; (`register-listener!` etc.) lives in
-            ;; `re-frame.trace.tooling` for production-DCE reasons.
-            ;; Xray's trace-collector registration below targets the
-            ;; tooling sibling directly. The preload is dev-only
-            ;; (gated by shadow-cljs `:devtools/preloads`) so this
-            ;; require is excluded from production bundles.
-            [re-frame.trace.tooling :as trace-tooling]
             [day8.re-frame2-xray.config :as config]
+            ;; rf2-5w06uu — the inert, callable install helpers
+            ;; (trace/epoch collector registration + browser-API
+            ;; exports) live in `day8.re-frame2-xray.install`, a
+            ;; namespace whose LOAD performs no side-effects. The
+            ;; preload's side-effecting boot block below calls them;
+            ;; the manual facade (`core`) requires `install` directly
+            ;; so requiring the facade no longer drags in this
+            ;; preload's load-time side-effects.
+            [day8.re-frame2-xray.install :as install]
             [day8.re-frame2-xray.keybinding :as keybinding]
             [day8.re-frame2-xray.mount :as mount]
             [day8.re-frame2-xray.registry :as registry]
@@ -86,130 +84,32 @@
             ;; that sentinel as its preload probe; the runtime rides
             ;; Xray-the-panel's preload, so no separate `:preloads`
             ;; entry is required on the consumer side.
-            [day8.re-frame2-xray.runtime]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.runtime]))
 
-;; ---- registrations -------------------------------------------------------
+;; ---- install-helper re-exports (rf2-5w06uu) ------------------------------
+;;
+;; The callable install primitives now live in
+;; `day8.re-frame2-xray.install` (an inert-on-load ns). Re-export them
+;; here as `def`-aliases so the established `preload/<helper>` call
+;; sites — the Xray test corpus, `test_support/reset-all!`, embed-host
+;; tooling — keep resolving against the same fn values. Identity holds:
+;; `(= install/register-trace-collector! preload/register-trace-collector!)`.
 
-(defonce ^:private trace-cb-registered?
-  ;; Idempotency sentinel for the trace-callback registration. Cf.
-  ;; `re-frame.trace/register-listener!`: passing the same id twice
-  ;; replaces the callback. The replacement is harmless but emits a
-  ;; warning trace on every reload that pollutes the dev console;
-  ;; this sentinel suppresses re-registration on `:after-load`.
-  (atom false))
+(def register-trace-collector!
+  "See `day8.re-frame2-xray.install/register-trace-collector!`."
+  install/register-trace-collector!)
 
-(defonce ^:private epoch-cb-registered?
-  ;; Idempotency sentinel for the epoch-callback registration. Same
-  ;; rationale as `trace-cb-registered?`. Phase 3 (rf2-t53ze) — the
-  ;; Time Travel panel needs a per-settle pump from
-  ;; `rf/register-epoch-listener!` into Xray's app-db so the scrubber's
-  ;; subscriptions re-fire when the framework appends an epoch.
-  (atom false))
+(def register-epoch-collector!
+  "See `day8.re-frame2-xray.install/register-epoch-collector!`."
+  install/register-epoch-collector!)
 
-(defn register-trace-collector!
-  "Register Xray's trace-collector callback under
-  `:rf.xray/trace-collector`. Idempotent via the
-  `trace-cb-registered?` sentinel — a second call is a silent no-op
-  (no warning trace, no replacement). Public so tests can drive
-  it directly without `#'`-piercing into private vars."
-  []
-  (when (compare-and-set! trace-cb-registered? false true)
-    (trace-tooling/register-listener! :rf.xray/trace-collector
-                                      trace-collector/collect-trace!))
-  nil)
+(def install-browser-api-exports!
+  "See `day8.re-frame2-xray.install/install-browser-api-exports!`."
+  install/install-browser-api-exports!)
 
-(defn register-epoch-collector!
-  "Register Xray's epoch-settle pump under `:rf.xray/epoch-collector`.
-
-  On every drain-settle the framework's epoch artefact fires this
-  callback with the assembled `:rf/epoch-record`; the cb dispatches
-  `:rf.xray/epoch-recorded` into the `:rf/xray` frame so the
-  registry's event handler re-reads `rf/epoch-history` and pumps the
-  fresh snapshot into Xray's app-db. The scrubber's
-  `:rf.xray/epoch-history` sub then re-fires off the standard
-  app-db-write reactive path.
-
-  ## Pre-mount guard (rf2-1barg)
-
-  The preload runs at app boot but `:rf/xray` is lazy-registered by
-  `mount.cljs/open!` on the first Ctrl+Shift+C keypress. Host
-  dispatches that fire BEFORE the user opens Xray would otherwise
-  flow through this cb and dispatch into a frame that doesn't yet
-  exist — the runtime would emit `:rf.error/frame-destroyed` and the
-  record would be lost. The `frame/frame :rf/xray` guard makes
-  pre-mount cbs a silent no-op; `ensure-xray-frame!` seeds the
-  panel's `:epoch-history` slot with the framework's current
-  `(rf/epoch-history target)` snapshot at first open, so the
-  pre-mount window's records still surface.
-
-  Idempotent via the `epoch-cb-registered?` sentinel. No-op when the
-  `day8/re-frame2-epoch` artefact is not on the classpath
-  (`rf/register-epoch-listener!` is itself a no-op in that case)."
-  []
-  (when (compare-and-set! epoch-cb-registered? false true)
-    (rf/register-epoch-listener! :rf.xray/epoch-collector
-      (fn [record]
-        ;; Pre-mount no-op — see the docstring's §Pre-mount guard.
-        ;; Resolved against the framework's frame registry (NOT a
-        ;; Xray-side flag) so a teardown / re-register cycle stays
-        ;; correctly tracked without our needing extra state.
-        (when (frame/frame :rf/xray)
-          ;; Wrap the dispatch in :rf/xray so the registry's handler
-          ;; writes to Xray's app-db, not the host's. The cb's
-          ;; record carries :frame — pass it as the dispatch arg so
-          ;; the handler can compare against its target-frame and
-          ;; skip updates for non-target frames.
-          (rf/with-frame :rf/xray
-            (rf/dispatch [:rf.xray/epoch-recorded (:frame record)]))))))
-  nil)
-
-(defn reset-for-test!
-  "Reset the preload's idempotency sentinels so test fixtures can drive
-  multiple load cycles. Test-only — never call from production code."
-  []
-  (reset! trace-cb-registered? false)
-  (reset! epoch-cb-registered? false)
-  nil)
-
-;; ---- public browser API exports -----------------------------------------
-
-(defn- ensure-js-object!
-  [parent key]
-  (or (gobj/get parent key)
-      (let [obj #js {}]
-        (gobj/set parent key obj)
-        obj)))
-
-(defn- install-api-on!
-  [obj]
-  (gobj/set obj "open_BANG_" mount/open!)
-  (gobj/set obj "open_overlay_BANG_" mount/open-overlay!)
-  (gobj/set obj "close_BANG_" mount/close!)
-  (gobj/set obj "toggle_BANG_" mount/toggle!)
-  (gobj/set obj "popout_BANG_" mount/popout!)
-  (gobj/set obj "status" mount/status)
-  nil)
-
-(defn install-browser-api-exports!
-  "Expose the dev-only Xray launch API on the browser global object.
-
-  The preload is the namespace shadow-cljs actually loads into host
-  dev bundles; the facade namespace (`day8.re-frame2-xray.core`) may
-  be absent from apps that only install Xray via `:devtools/preloads`.
-  Export on `window.day8.re_frame2_xray` for preload-only bundles, and
-  augment `window.day8.re_frame2_xray.core` only when Closure has
-  already created that real namespace object. Never pre-create `core`:
-  doing so races `goog.provide` in browser-test and fails with
-  \"Namespace already declared\"."
-  []
-  (when (exists? js/window)
-    (let [day8  (ensure-js-object! js/window "day8")
-          xray (ensure-js-object! day8 "re_frame2_xray")]
-      (install-api-on! xray)
-      (when-let [core (gobj/get xray "core")]
-        (install-api-on! core))))
-  nil)
+(def reset-for-test!
+  "See `day8.re-frame2-xray.install/reset-for-test!`. Test-only."
+  install/reset-for-test!)
 
 ;; ---- side-effecting boot -------------------------------------------------
 
@@ -232,9 +132,9 @@
   ;; persisted values, not on the defaults.
   (config/load-settings-from-storage!)
   (registry/register-xray-handlers!)
-  (register-trace-collector!)
-  (register-epoch-collector!)
-  (install-browser-api-exports!)
+  (install/register-trace-collector!)
+  (install/register-epoch-collector!)
+  (install/install-browser-api-exports!)
   (keybinding/attach!)
   ;; Apply the persisted CSS-var + theme-class effects. The shell
   ;; root may not exist yet (auto-open is async) — apply-all! no-ops

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -257,37 +257,56 @@
                           (seq path) (assoc :path (vec path))))))
 
 (defn egress-record
-  "The single named off-box safe-egress fn for one epoch record. On the
-  safe default path it routes the `:rf/epoch-record` through the
-  framework's normative epoch projection
-  (`re-frame.core/projected-record`) so payload slots are wire-elided
-  with off-box defaults while bookkeeping slots (`:epoch-id`,
+  "The single named off-box safe-egress fn for one epoch record. Routes
+  the `:rf/epoch-record` through the framework's normative epoch
+  projection (`re-frame.core/projected-record`) so payload slots are
+  wire-elided with off-box defaults while bookkeeping slots (`:epoch-id`,
   `:dispatch-id`, `:outcome`, …) pass through unchanged.
 
-  `projected-record` already bakes the off-box defaults — naming the
-  off-box egress of an epoch record `egress-record` (parallel to
-  `egress-value` for arbitrary values) gives a forwarder author ONE
-  obvious safe entry point for either shape instead of a choice
-  between `elide-wire-value` (and the right opts) and
-  `projected-record` (with no opts) they must first learn the
+  `projected-record` bakes the off-box defaults — naming the off-box
+  egress of an epoch record `egress-record` (parallel to `egress-value`
+  for arbitrary values) gives a forwarder author ONE obvious safe entry
+  point for either shape instead of a choice between `elide-wire-value`
+  (and the right opts) and `projected-record` they must first learn the
   difference between.
 
-  Opt-back-in: when a caller that is itself the trust boundary opts in
-  to seeing sensitive or large slots (`{:include-sensitive? true}` /
-  `{:include-large? true}`), the record is routed through
-  `egress-value` with the opt instead — the normative epoch projection
-  has no opt-in arg, so the value walker carries the per-call override.
-  No opts (or both `false`) ⇒ the normative `projected-record` path.
-  rf2-rcogp — the safe path is the short path."
+  ## Opt-back-in preserves every partition boundary (rf2-5w06uu)
+
+  When a caller that is itself the trust boundary opts in to seeing
+  sensitive or large APP-DB slots (`{:include-sensitive? true}` /
+  `{:include-large? true}`), the opts are THREADED INTO `projected-record`
+  rather than the record being walked raw through `egress-value`. This is
+  load-bearing: those opts govern the APP-DB partition's privacy / size
+  posture ONLY — they are ORTHOGONAL to the runtime-db partition
+  boundary. `projected-record` keeps the `:rf.db/runtime` side of each
+  frame-state slot (machine snapshots, route slice, spawn registry,
+  elision registry, SSR/hydration metadata) `:rf/redacted` even under
+  those opt-ins. The earlier bypass — walking the raw record through
+  `egress-value` on opt-in — lifted that orthogonal runtime-db partition
+  off-box just because the caller asked for sensitive / large APP-DB
+  values (and mis-rooted the app-db path tracker so frame-state app-db
+  sensitive declarations never matched). Routing through the normative
+  projection both closes the leak and honours Security.md §Off-box
+  egress's prohibition on per-tool reimplementation of the projection.
+
+  A TRUSTED-LOCAL caller that genuinely needs runtime-db diagnostics
+  opts into the partition explicitly with `{:include-runtime-db? true}`,
+  which `projected-record` honours (the runtime-db value then rides the
+  same value walk, where its own per-slot `:sensitive?` / `:large?`
+  declarations still apply). Mirrors `egress-runtime-db-value`'s
+  partition opt-in for the live-read accessors.
+
+  rf2-rcogp — the safe path is the short path: the bare
+  `(egress-record record)` is the fully-redacted off-box default."
   ([record]
-   (egress-record record nil))
-  ([record {:keys [include-sensitive? include-large?]
-            :or   {include-sensitive? false
-                   include-large?     false}}]
-   (if (or include-sensitive? include-large?)
-     (egress-value record {:include-sensitive? include-sensitive?
-                           :include-large?     include-large?})
-     (rf/projected-record record))))
+   (rf/projected-record record))
+  ([record {:keys [include-sensitive? include-large? include-runtime-db?]
+            :or   {include-sensitive?  false
+                   include-large?      false
+                   include-runtime-db? false}}]
+   (rf/projected-record record {:include-sensitive?  include-sensitive?
+                                :include-large?      include-large?
+                                :include-runtime-db? include-runtime-db?})))
 
 ;; ---------------------------------------------------------------------------
 ;; Partition-aware runtime-db egress (EP-0001 rf2-jj1xer · Mike ruling #14)
@@ -437,17 +456,25 @@
   `:rf/epoch-record`) per Tool-Pair §Time-travel. Returns
   `{:ok? true :frame <id> :epochs <vec>}` or `{:ok? false :reason
   :no-frame-resolved}` when the frame can't be picked. Each record
-  routes through `elide-wire-value` for privacy + size egress."
+  routes through `egress-record` for privacy + size egress.
+
+  `:include-sensitive?` / `:include-large?` opt the APP-DB partition's
+  sensitive / large values back in. The framework runtime-db partition
+  (`:rf.db/runtime` in each record's frame-state slots) stays redacted
+  under those opts — a trusted-local caller that genuinely needs
+  runtime-db diagnostics passes `:include-runtime-db? true` explicitly
+  (rf2-5w06uu)."
   ([] (get-epoch-history nil))
   ([opts]
-   (let [{:keys [frame include-sensitive? include-large?]} opts
+   (let [{:keys [frame include-sensitive? include-large? include-runtime-db?]} opts
          fid (resolve-frame frame)]
      (if (nil? fid)
        {:ok? false :reason :no-frame-resolved
         :hint "Pass :frame :foo or register at least one frame."}
        (let [records  (rf/epoch-history fid)
-             scrubbed (mapv #(egress-record % {:include-sensitive? include-sensitive?
-                                               :include-large?     include-large?})
+             scrubbed (mapv #(egress-record % {:include-sensitive?  include-sensitive?
+                                               :include-large?      include-large?
+                                               :include-runtime-db? include-runtime-db?})
                             records)]
          {:ok?    true
           :frame  fid

--- a/tools/xray/src/day8/re_frame2_xray/test_support.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/test_support.cljs
@@ -7,9 +7,14 @@
   `reset-all!` so panel additions don't ripple through the test
   corpus.
 
+  Targets the inert `day8.re-frame2-xray.install` ns for the collector
+  sentinels (rf2-5w06uu) rather than `preload`, so a fixture that only
+  needs `reset-all!` does not drag in `preload`'s side-effecting boot
+  block.
+
   **Test-only — never call from production code.** Per rf2-kmhvg
   cluster item 3e (audit rf2-i0veg §3e)."
-  (:require [day8.re-frame2-xray.preload :as preload]
+  (:require [day8.re-frame2-xray.install :as install]
             [day8.re-frame2-xray.registry :as registry]))
 
 (defn reset-all!
@@ -17,11 +22,11 @@
   single fixture-call leaves the namespaces in a re-installable state.
   Calls (in order):
 
-      preload/reset-for-test!  ; trace-cb + epoch-cb registration flags
+      install/reset-for-test!  ; trace-cb + epoch-cb registration flags
       registry/reset-for-test! ; per-panel reg-event/reg-sub flags
 
   Test-only. Returns nil."
   []
-  (preload/reset-for-test!)
+  (install/reset-for-test!)
   (registry/reset-for-test!)
   nil)

--- a/tools/xray/test/day8/re_frame2_xray/preload_decoupling_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/preload_decoupling_cljs_test.cljs
@@ -1,0 +1,290 @@
+(ns day8.re-frame2-xray.preload-decoupling-cljs-test
+  "rf2-5w06uu — requiring the manual facade `day8.re-frame2-xray.core`
+  must NOT trigger preload side-effects before the host's
+  `configure!` / `init!`.
+
+  ## The bug
+
+  `core.cljs` used to `(:require [day8.re-frame2-xray.preload …])`, and
+  `preload.cljs`'s top-level `(when interop/debug-enabled? …)` boot block
+  registers the trace + epoch collectors, installs the browser-API
+  globals, attaches the Ctrl+Shift+C keybinding, applies persisted
+  settings, and schedules auto-open. So a host that chose the MANUAL
+  `require core → configure! → init!/open!` integration got the full
+  zero-config preload behaviour merely by requiring `core` — defeating
+  `configure!`-before-auto-open ordering and boot flags like
+  `:rf.xray/auto-open? false` / `:rf.xray/keybinding-enabled? false`.
+
+  ## The fix under test
+
+  The callable install primitives moved to the inert-on-load
+  `day8.re-frame2-xray.install` ns; `core` requires THAT (not `preload`).
+  Requiring / touching the `core` facade's manual surface is now inert —
+  the install side-effects fire only when the host calls `core/init!`
+  (or `core/open!`). The zero-config `:devtools/preloads` path still
+  auto-installs (the preload boot block invokes the same `install/*`
+  helpers + `keybinding/attach!`).
+
+  ## Why node-test
+
+  The trace + epoch listener registrations are observable via the
+  framework's listener registries directly. The keybinding attach +
+  browser-global install need a `js/document` / `js/window`; node-test
+  has neither, so — mirroring `keybinding_cljs_test` — we install
+  hand-rolled stubs for the duration of the relevant tests and restore
+  the absent binding afterwards. `can-stub?` skips the stub-driven
+  bodies cleanly on the `:browser-test` host (where the globals are
+  non-configurable)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.epoch.state :as epoch-state]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace]
+            [re-frame.trace.tooling :as trace-tooling]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.core :as core]
+            [day8.re-frame2-xray.install :as install]
+            [day8.re-frame2-xray.keybinding :as keybinding]
+            [day8.re-frame2-xray.mount :as mount]
+            [day8.re-frame2-xray.preload :as preload]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+;; ---- world reset ---------------------------------------------------------
+;;
+;; The install side-effects are defonce-guarded and the framework
+;; listener registries are process-scoped, so a faithful "fresh boot"
+;; baseline clears them all before each test. This lets us assert that
+;; touching the manual facade does NOT re-install, then that the explicit
+;; entrypoint DOES.
+
+(defn- clear-world! []
+  (install/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-collector/reset-for-test!)
+  (trace-tooling/clear-listeners!)
+  (epoch-state/reset-listeners!)
+  (config/reset-settings!)
+  ;; teardown! resets mount + auto-open-state; detach! drops any keydown
+  ;; listener left attached by a neighbouring test.
+  (mount/teardown!)
+  (try (keybinding/detach!) (catch :default _ nil)))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn clear-world!}))
+
+;; ---- observability helpers ----------------------------------------------
+
+(defn- trace-collector-registered?
+  "Behaviourally probe whether Xray's trace collector is registered: the
+  framework's listener map is private, so we clear Xray's buffer, emit a
+  synthetic framework trace event, and check whether it landed in the
+  buffer. Delivery ⇒ the collector is wired; no delivery ⇒ it isn't.
+  Mirrors `preload_cljs_test`'s observable-contract approach."
+  []
+  (trace-collector/reset-for-test!)
+  (trace/emit! :info :rf.test/registration-probe {:source :test})
+  (let [delivered? (pos? (count (trace-collector/buffer-for-test)))]
+    (trace-collector/reset-for-test!)
+    delivered?))
+
+(defn- epoch-collector-registered?
+  "True iff Xray's epoch collector is in the framework's epoch-listener
+  map (the epoch state exposes a public listeners snapshot)."
+  []
+  (contains? (epoch-state/listeners-snapshot) :rf.xray/epoch-collector))
+
+;; ---- stub js/document + js/window ----------------------------------------
+;;
+;; Mirrors keybinding_cljs_test's rf2-higwg stub-and-detect pattern.
+
+(defn- can-stub? [prop]
+  (let [marker (js-obj "rf2-5w06uu-marker" true)
+        prior  (when (exists? (js* "goog.global[~{}]" prop))
+                 (js* "goog.global[~{}]" prop))]
+    (js* "goog.global[~{}] = ~{}" prop marker)
+    (let [installed? (identical? (js* "goog.global[~{}]" prop) marker)]
+      (if (some? prior)
+        (js* "goog.global[~{}] = ~{}" prop prior)
+        (when installed? (js-delete js/goog.global prop)))
+      installed?)))
+
+(defn- mk-stub-document []
+  (let [listeners (atom [])]
+    {:doc       (js-obj "addEventListener"
+                        (fn [type handler use-capture]
+                          (swap! listeners conj {:type type :handler handler
+                                                 :use-capture use-capture}))
+                        "removeEventListener"
+                        (fn [type handler use-capture]
+                          (swap! listeners
+                                 (fn [xs]
+                                   (vec (remove #(and (= type (:type %))
+                                                      (identical? handler (:handler %))
+                                                      (= use-capture (:use-capture %)))
+                                                xs))))))
+     :listeners listeners}))
+
+(defn- with-stub-dom*
+  "Run `f` with `js/document` + `js/window` stubbed (a fresh keydown-
+  listener tracker on document, a plain object as window). Restores the
+  prior bindings afterwards. No-op on a host that won't let us stub
+  (real browser)."
+  [f]
+  (when (and (can-stub? "document") (can-stub? "window"))
+    (let [{:keys [doc listeners]} (mk-stub-document)
+          win                     (js-obj)]
+      (set! js/document doc)
+      (set! js/window win)
+      (try
+        (f {:keydown-listeners listeners :window win})
+        (finally
+          (try (keybinding/detach!) (catch :default _ nil))
+          (js-delete js/goog.global "document")
+          (js-delete js/goog.global "window"))))))
+
+;; ---- (1) manual facade is inert until init! ------------------------------
+
+(deftest requiring-core-and-touching-config-is-inert
+  (testing "rf2-5w06uu — the manual `core` facade's config surface does NOT
+            register the trace/epoch collectors (the manual require/use path
+            is side-effect-free until init!/open!)"
+    ;; Baseline: clear-world! left the registries empty.
+    (is (not (trace-collector-registered?))
+        "no trace collector registered at baseline")
+    (is (not (epoch-collector-registered?))
+        "no epoch collector registered at baseline")
+    ;; Exercise the manual facade's config surface — the host's
+    ;; configure!-at-boot path. Before the fix, `core`'s require of
+    ;; `preload` had already run the boot block; now these are inert.
+    (core/configure! {:rf.xray/auto-open? false
+                      :rf.xray/keybinding-enabled? false})
+    (core/set-auto-open! false)
+    (core/set-show-sensitive! false)
+    (is (not (trace-collector-registered?))
+        "configure! did NOT register the trace collector")
+    (is (not (epoch-collector-registered?))
+        "configure! did NOT register the epoch collector")
+    (is (not (mount/mounted?))
+        "configure! did NOT mount/auto-open the shell")))
+
+(deftest init!-performs-the-manual-install
+  (testing "rf2-5w06uu — core/init! explicitly performs the documented
+            manual install: trace + epoch collectors registered"
+    (is (not (trace-collector-registered?)) "clean before init!")
+    (is (not (epoch-collector-registered?)) "clean before init!")
+    (core/init!)
+    (is (trace-collector-registered?)
+        "init! registered the trace collector (framework emit lands in buffer)")
+    (is (epoch-collector-registered?)
+        "init! registered the epoch collector")))
+
+(deftest init!-does-not-auto-open
+  (testing "rf2-5w06uu — the manual init! path does NOT auto-open the shell
+            (auto-open is a zero-config preload concern; the manual path is
+            open-explicit via core/open!)"
+    (core/init!)
+    (is (not (mount/mounted?))
+        "init! did not mount the shell — host must call open! explicitly")))
+
+;; ---- (2) configure! before init! wins deterministically ------------------
+
+(deftest configure!-before-init!-suppresses-keybinding
+  (testing "rf2-5w06uu — core/configure! {:rf.xray/keybinding-enabled? false}
+            BEFORE init! wins: init!'s keybinding/attach! reads the config
+            slot the host already set and does NOT attach the keydown
+            listener."
+    (with-stub-dom*
+      (fn [{:keys [keydown-listeners]}]
+        ;; Host boot-time config first.
+        (core/configure! {:rf.xray/keybinding-enabled? false})
+        (is (= false (config/keybinding-attach-enabled?))
+            "the boot-time config slot is set before init!")
+        ;; Now the manual install.
+        (core/init!)
+        (is (not (keybinding/attached?))
+            "init! honoured the pre-set keybinding-enabled? false")
+        (is (empty? @keydown-listeners)
+            "no keydown listener attached to document")))))
+
+(deftest configure!-keybinding-enabled-true-attaches-on-init!
+  (testing "rf2-5w06uu — control: with keybinding enabled (default), init!
+            DOES attach under a DOM, proving the suppression above is the
+            config slot's effect, not a stub artefact."
+    (with-stub-dom*
+      (fn [{:keys [keydown-listeners]}]
+        (core/configure! {:rf.xray/keybinding-enabled? true})
+        (core/init!)
+        (is (keybinding/attached?)
+            "init! attached the keydown listener when enabled")
+        (is (= 1 (count @keydown-listeners))
+            "exactly one keydown listener on document")))))
+
+(deftest configure!-auto-open-false-is-honoured-at-boot
+  (testing "rf2-5w06uu — :rf.xray/auto-open? false set via configure! before
+            boot wins: the preload's auto-open-inline! short-circuits to the
+            disabled diagnostic rather than mounting."
+    (core/configure! {:rf.xray/auto-open? false})
+    (is (= false (config/auto-open-enabled?))
+        "auto-open slot is off before any auto-open attempt")
+    (mount/auto-open-inline!)
+    (is (not (mount/mounted?))
+        "auto-open-inline! did not mount when auto-open? false")
+    (is (= :auto-open-disabled (get-in (mount/status) [:diagnostic :reason]))
+        "auto-open short-circuited to the disabled diagnostic")))
+
+;; ---- (3) the zero-config :devtools/preloads path still auto-installs ------
+
+(deftest preload-boot-helpers-still-install
+  (testing "rf2-5w06uu — the zero-config preload path still works: invoking
+            the install helpers + keybinding/attach! (exactly what the
+            preload boot block does) registers the collectors, installs the
+            browser globals, and attaches the keybinding."
+    (with-stub-dom*
+      (fn [{:keys [keydown-listeners window]}]
+        (is (not (trace-collector-registered?)) "clean before boot")
+        (is (not (epoch-collector-registered?)) "clean before boot")
+        ;; Mirror preload.cljs's boot block (minus the debug-gate, which
+        ;; is true under node-test).
+        (registry/register-xray-handlers!)
+        (install/register-trace-collector!)
+        (install/register-epoch-collector!)
+        (install/install-browser-api-exports!)
+        (keybinding/attach!)
+        (is (trace-collector-registered?)
+            "preload boot registered the trace collector")
+        (is (epoch-collector-registered?)
+            "preload boot registered the epoch collector")
+        (is (keybinding/attached?)
+            "preload boot attached the keydown listener")
+        (is (= 1 (count @keydown-listeners))
+            "one keydown listener on document")
+        ;; Browser globals installed under window.day8.re_frame2_xray.
+        (let [day8 (aget window "day8")
+              xray (when day8 (aget day8 "re_frame2_xray"))]
+          (is (some? xray) "window.day8.re_frame2_xray installed")
+          (is (fn? (aget xray "toggle_BANG_"))
+              "the toggle! launch API is exported on the global"))))))
+
+(deftest install-ns-load-is-side-effect-free
+  (testing "rf2-5w06uu — the install ns is load-inert: its re-exports are
+            identity-equal to the preload re-exports (one shared backing
+            fn), so requiring either reaches the same callable helpers and
+            neither load registers anything on its own."
+    ;; Identity holds — preload re-exports the install fns, and core calls
+    ;; them; one shared backing fn value.
+    (is (identical? install/register-trace-collector!
+                    preload/register-trace-collector!)
+        "preload re-exports install/register-trace-collector!")
+    (is (identical? install/register-epoch-collector!
+                    preload/register-epoch-collector!)
+        "preload re-exports install/register-epoch-collector!")
+    ;; clear-world! ran in the fixture; nothing registered itself just by
+    ;; the test ns loading install/core/preload.
+    (is (not (trace-collector-registered?))
+        "no trace collector registered purely by ns load")
+    (is (not (epoch-collector-registered?))
+        "no epoch collector registered purely by ns load")))

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -666,6 +666,86 @@
           ":include-sensitive? true ⇒ the raw value passes through"))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-5w06uu — epoch egress must NOT bypass frame-state runtime-db redaction
+;; when a caller opts into sensitive / large APP-DB values.
+;; ---------------------------------------------------------------------------
+;;
+;; The frame-state slots are `{:rf.db/app <app-db> :rf.db/runtime
+;; <runtime-db>}`. The `:rf.db/runtime` partition (machine snapshots,
+;; route slice, spawn registry, elision registry, SSR/hydration metadata)
+;; is REDACTED off-box by default (Mike ruling #14). `:include-sensitive?`
+;; / `:include-large?` opt into the APP-DB partition's privacy / size
+;; posture only — they MUST NOT lift the orthogonal runtime-db partition
+;; boundary. A trusted-local caller opts into runtime-db explicitly with
+;; `:include-runtime-db? true`.
+
+(defn- frame-state-record []
+  ;; A record carrying both partitions in :frame-state-after, per the
+  ;; rf2-5w06uu acceptance criteria.
+  {:epoch-id    "e1"
+   :frame       :rf/default
+   :event-id    :auth/login
+   :frame-state-after {:rf.db/app     {:auth {:username "ada" :password "shh"}}
+                       :rf.db/runtime {:rf.runtime/machines {:m :running}}}})
+
+(deftest egress-record-default-redacts-app-sensitive-and-runtime-db
+  (testing "rf2-5w06uu — default egress (no opts) redacts the app-db
+            sensitive value AND default-redacts the runtime-db partition
+            of the frame-state slot"
+    (seed-sensitive-schema!)
+    (let [out (runtime/egress-record (frame-state-record))
+          fs  (:frame-state-after out)]
+      (is (= "ada" (get-in fs [:rf.db/app :auth :username]))
+          "non-sensitive app-db value passes through")
+      (is (= :rf/redacted (get-in fs [:rf.db/app :auth :password]))
+          "sensitive app-db value redacted on the default path")
+      (is (= :rf/redacted (:rf.db/runtime fs))
+          "runtime-db partition redacted on the default path"))))
+
+(deftest egress-record-include-sensitive-keeps-runtime-db-redacted
+  (testing "rf2-5w06uu — {:include-sensitive? true} reveals app-db
+            sensitive values but KEEPS :rf.db/runtime redacted (the bypass
+            bug: it used to walk the raw record and leak runtime-db)"
+    (seed-sensitive-schema!)
+    (let [out (runtime/egress-record (frame-state-record)
+                                     {:include-sensitive? true})
+          fs  (:frame-state-after out)]
+      (is (= "shh" (get-in fs [:rf.db/app :auth :password]))
+          ":include-sensitive? true reveals the app-db sensitive value")
+      (is (= :rf/redacted (:rf.db/runtime fs))
+          ":include-sensitive? true does NOT lift the runtime-db redaction"))))
+
+(deftest egress-record-include-large-keeps-runtime-db-redacted
+  (testing "rf2-5w06uu — {:include-large? true} also keeps :rf.db/runtime
+            redacted (orthogonal partition boundary holds under the size
+            opt-in too)"
+    (seed-sensitive-schema!)
+    (let [out (runtime/egress-record (frame-state-record)
+                                     {:include-large? true})
+          fs  (:frame-state-after out)]
+      (is (= :rf/redacted (:rf.db/runtime fs))
+          ":include-large? true does NOT lift the runtime-db redaction")
+      ;; Sensitive app-db value still redacted (large opt-in is not a
+      ;; sensitive opt-in).
+      (is (= :rf/redacted (get-in fs [:rf.db/app :auth :password]))
+          ":include-large? alone does not reveal sensitive app-db values"))))
+
+(deftest egress-record-trusted-local-opts-into-runtime-db
+  (testing "rf2-5w06uu — only the explicit trusted-local
+            :include-runtime-db? true reveals the runtime-db partition;
+            sensitive/large handling still applies inside the allowed
+            partitions"
+    (seed-sensitive-schema!)
+    (let [out (runtime/egress-record (frame-state-record)
+                                     {:include-sensitive?  true
+                                      :include-runtime-db? true})
+          fs  (:frame-state-after out)]
+      (is (= {:rf.runtime/machines {:m :running}} (:rf.db/runtime fs))
+          ":include-runtime-db? true crosses the runtime-db partition")
+      (is (= "shh" (get-in fs [:rf.db/app :auth :password]))
+          ":include-sensitive? still applies inside the app-db partition"))))
+
+;; ---------------------------------------------------------------------------
 ;; EP-0001 (rf2-jj1xer · ruling #14) — partition-aware runtime-db egress.
 ;; ---------------------------------------------------------------------------
 ;;


### PR DESCRIPTION
Fixes both issues on rf2-5w06uu (P1, senior-review).

## Issue 1 — manual facade require is now side-effect-free
`core.cljs` required `day8.re-frame2-xray.preload`, whose top-level boot block auto-installs Xray (trace/epoch collectors, browser-global launch API, Ctrl+Shift+C keybinding, settings apply, auto-open). So the manual `require core -> configure! -> init!/open!` path got full preload behaviour just by requiring `core`, defeating configure!-before-auto-open ordering and boot flags.

Fix: new side-effect-free-on-load namespace `day8.re-frame2-xray.install` holds the callable install primitives (collector registrations + sentinels + browser-API exports). `core` requires `install` (load-inert) instead of `preload`; `core/init!` calls `install/*` explicitly. `preload` requires `install`, re-exports the helpers (identity-preserving so the test corpus + test-support keep resolving `preload/*`), and keeps its top-level boot block so the `:devtools/preloads` zero-config path still auto-installs.

## Issue 2 — epoch egress keeps the runtime-db partition boundary
`egress-record`'s opt-in path walked the raw record through `egress-value`, lifting the orthogonal `:rf.db/runtime` frame-state partition off-box (and mis-rooting app-db sensitive declarations). Per Security.md (single normative emission site; per-tool reimplementation prohibited), extended `projected-record` / `projected-history` to accept egress opts (`:include-sensitive?` / `:include-large?` / `:include-runtime-db?`), preserving runtime-db redaction unless the trusted-local `:include-runtime-db? true` is set. `egress-record` / `get-epoch-history` route every path through the projection.

## Tests
- `preload_decoupling_cljs_test` — requiring core + configure! is inert (no collectors / keybinding / browser-globals / auto-open until init!), configure!-before-init! wins deterministically, and the preload boot path still installs.
- `runtime_cljs_test` — default egress redacts app-sensitive + runtime-db; `{:include-sensitive? true}` reveals app-sensitive but keeps runtime-db redacted; `{:include-large? true}` keeps runtime-db redacted; only `:include-runtime-db? true` reveals it.

## Spec
- `tools/xray/spec/API.md` — side-effect-free require contract + egress-record/get-epoch-history opts.
- `tools/xray/spec/011-Launch-Modes.md` — foundation side-effects fire on the preload path only.

## Quality gates
- `npm run test:cljs` (node-test): 6071 tests, 21571 assertions, 0 failures, 0 errors.
- `clojure -M:test` tools/xray (JVM): 1120 tests, 0 failures, 0 errors.
- epoch JVM: 290 tests, 0 failures. core JVM: 997 tests, 0 failures.
- `npm run test:bundle-isolation`: PASS (new `install` ns stays out of production bundles).