### PR TITLE
docs+test(http): reconcile Spec 014 :after-shipped drift + stub scope isolation (rf2-vn8qjv)

### DIFF
--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -1844,8 +1844,11 @@
     (rf/with-managed-request-stubs*
       {[:get "/articles"] {:reply {:ok [:hello :world]}}}
       (fn []
-        (rf/dispatch-sync [:articles/list]
-                          {:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}})
+        ;; Documented wrapper form — NO manual :fx-overrides. The wrapper
+        ;; installs the :rf.http/managed override for the body's dynamic
+        ;; extent (rf2-rzqan); rf2-vn8qjv made that override a per-scope id,
+        ;; so hardcoding the stub id here would route to an unregistered fx.
+        (rf/dispatch-sync [:articles/list])
         (let [db (rf/app-db-value :rf/default)]
           (is (= :success (get-in db [:result :kind])))
           (is (= [:hello :world] (get-in db [:result :value]))))))))
@@ -1863,8 +1866,9 @@
     (rf/with-managed-request-stubs*
       {[:get "/articles"] {:reply {:failure {:kind :rf.http/http-4xx :status 404}}}}
       (fn []
-        (rf/dispatch-sync [:articles/list]
-                          {:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}})
+        ;; Documented wrapper form — NO manual :fx-overrides (see
+        ;; assert-http-with-managed-request-stubs; rf2-rzqan / rf2-vn8qjv).
+        (rf/dispatch-sync [:articles/list])
         (let [db (rf/app-db-value :rf/default)]
           (is (= :failure (get-in db [:result :kind])))
           (is (= :rf.http/http-4xx (get-in db [:result :failure :kind])))

--- a/implementation/http/src/re_frame/http_test_support.cljc
+++ b/implementation/http/src/re_frame/http_test_support.cljc
@@ -83,6 +83,7 @@
             [re-frame.http-handlers        :as handlers]
             [re-frame.http-machine-wrapper :as machine-wrapper]
             [re-frame.late-bind            :as late-bind]
+            [re-frame.registrar            :as registrar]
             [re-frame.router               :as router]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -267,6 +268,28 @@
 
 (def ^:private stub-fx-id :rf.http/managed-test-stub)
 
+;; rf2-vn8qjv (issue 2) — stack/token discipline for the lower-level
+;; install/uninstall surface. The single stub fx-id `:rf.http/managed-test-stub`
+;; is the DOCUMENTED routing target — users hardcode it in
+;; `:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}`, so the id
+;; must stay stable. But a naive "register then unconditionally clear" makes
+;; nested installs clobber: an inner `install!` replaces the outer handler and
+;; the inner `uninstall!` clears it, leaving the outer scope routing to a
+;; now-absent fx. We snapshot the prior handler onto a stack at install and
+;; restore the top-of-stack at uninstall, so an outer install survives a fully
+;; nested inner install/uninstall pair. Empty stack → clear the fx (no prior
+;; handler to restore), so a balanced top-level install/uninstall leaks nothing.
+(defonce ^:private stub-fx-handler-stack (atom []))
+
+(defn- peek-and-pop!
+  "Pop the top element off the `stack-atom`'s vector, returning a
+  `[popped]` 1-tuple (nil-safe — an empty stack yields `[nil]`). Test-time
+  single-threaded use; the read-then-swap is not atomic and need not be."
+  [stack-atom]
+  (let [top (peek @stack-atom)]
+    (swap! stack-atom (fn [s] (if (seq s) (pop s) s)))
+    [top]))
+
 (defn install-managed-request-stubs!
   "Test-time helper. `stubs` is `{[method url] {:reply <:ok|:failure>}}`.
   Registers the `:rf.http/managed-test-stub` fx — a route-map-consulting
@@ -276,13 +299,19 @@
   `:rf.http/managed` through it. To route, either dispatch with
   `:fx-overrides {:rf.http/managed :rf.http/managed-test-stub}`, or — far
   more usually — wrap the test body via `with-managed-request-stubs` /
-  `with-managed-request-stubs*`, which install BOTH the stub fx AND the
-  `:rf.http/managed → :rf.http/managed-test-stub` override for the body's
+  `with-managed-request-stubs*`, which install a per-scope stub fx AND the
+  matching `:rf.http/managed → <scope-stub>` override for the body's
   dynamic extent, so plain `dispatch-sync` calls auto-route with no manual
   `:fx-overrides`.
 
+  rf2-vn8qjv — stack/token discipline: install snapshots any prior
+  `:rf.http/managed-test-stub` handler before overwriting it, so a nested
+  install/uninstall pair restores the outer install on exit. Always paired
+  with `uninstall-managed-request-stubs!` (LIFO).
+
   Per Spec 014 §Testing — the framework ships canonical stub fxs."
   [stubs]
+  (swap! stub-fx-handler-stack conj (registrar/handler :fx stub-fx-id))
   (fx/reg-fx stub-fx-id
              {:doc "with-managed-request-stubs synthesised stub"}
              (fn [frame-ctx args-map]
@@ -290,41 +319,78 @@
   stub-fx-id)
 
 (defn uninstall-managed-request-stubs!
-  "Tear down the per-call stub fx-override `install-managed-request-stubs!`
-  registered. Idempotent — clearing an already-absent fx id is a no-op,
-  so a teardown that runs without a matching install (or twice) is safe.
-  Test-time helper."
+  "Tear down the stub fx `install-managed-request-stubs!` registered. Pops
+  the install stack: if an outer install's handler was snapshotted it is
+  restored (so a nested install/uninstall pair leaves the outer install
+  intact); otherwise the fx id is cleared.
+
+  Idempotent — calling without a matching install (empty stack) clears the
+  fx id, a no-op when it is already absent, so a teardown that runs without
+  a matching install (or twice) is safe and leaks no test fx. Test-time
+  helper."
   []
-  (fx/clear-fx stub-fx-id)
+  (let [[prior] (peek-and-pop! stub-fx-handler-stack)]
+    (if prior
+      (fx/reg-fx stub-fx-id
+                 {:doc "with-managed-request-stubs synthesised stub"}
+                 prior)
+      (fx/clear-fx stub-fx-id)))
   nil)
+
+;; rf2-vn8qjv (issue 2) — `with-managed-request-stubs*` allocates a UNIQUE
+;; override fx-id per scope so nested scopes compose. The lower-level
+;; install/uninstall surface above keys off the single stable id (the
+;; documented `:fx-overrides` target); the scoped wrapper instead mints a
+;; fresh fx-id per invocation and binds the override to THAT id. An outer
+;; scope's fx and override therefore stay live and correctly-routed while a
+;; fully-nested inner scope installs, runs, and tears down its own distinct
+;; fx — no clobber, no order-dependence.
+(defonce ^:private scope-stub-counter (atom 0))
+
+(defn- next-scope-stub-id
+  "Mint a process-unique `:rf.http/managed-test-stub-<n>` fx-id for one
+  `with-managed-request-stubs*` scope."
+  []
+  (keyword "rf.http" (str "managed-test-stub-" (swap! scope-stub-counter inc))))
 
 (defn with-managed-request-stubs*
   "Function form: install stubs, route `:rf.http/managed` through them for
   the dynamic extent of `thunk`, run `thunk`, then uninstall. Test-time
   helper.
 
-  `stubs` is `{[method url] {:reply <:ok|:failure>}}`. Beyond registering
-  the `:rf.http/managed-test-stub` fx, this also binds the lexical-scope
-  fx-override `{:rf.http/managed :rf.http/managed-test-stub}`
+  `stubs` is `{[method url] {:reply <:ok|:failure>}}`. The wrapper mints a
+  process-unique stub fx-id for THIS scope (rf2-vn8qjv), registers the
+  route-map-consulting stub under it, and binds the lexical-scope
+  fx-override `{:rf.http/managed <scope-stub-id>}`
   (`re-frame.router/*fx-overrides*`, the public `rf/with-fx-overrides`
   seam) for the thunk's dynamic extent. So every `dispatch-sync` inside
   the body auto-routes by `:request :method` + `:request :url` with NO
   per-call `:fx-overrides` — matching the documented contract (Spec 014
   §Testing). A dispatch that deliberately supplies its OWN `:fx-overrides`
   still wins: the router merges the lexical default UNDER the per-call opt
-  (per-call > lexical > per-frame)."
+  (per-call > lexical > per-frame).
+
+  Nesting composes: because each scope owns a distinct fx-id, an inner
+  `with-managed-request-stubs*` registers and tears down ITS id without
+  touching the outer scope's still-live fx + override. After the inner
+  scope exits, an outer-scope dispatch still routes to the outer stub."
   [stubs thunk]
-  (try
-    (install-managed-request-stubs! stubs)
-    ;; Bind the lexical-scope override so plain dispatches in the body
-    ;; route `:rf.http/managed` → the route-map stub automatically. The
-    ;; thunk's dispatches run synchronously within this dynamic extent;
-    ;; per-call `:fx-overrides` still take precedence (router merge).
-    (binding [router/*fx-overrides* (merge router/*fx-overrides*
-                                           {:rf.http/managed stub-fx-id})]
-      (thunk))
-    (finally
-      (uninstall-managed-request-stubs!))))
+  (let [scope-stub-id (next-scope-stub-id)]
+    (try
+      (fx/reg-fx scope-stub-id
+                 {:doc "with-managed-request-stubs (scoped) synthesised stub"}
+                 (fn [frame-ctx args-map]
+                   (stub-handler stubs frame-ctx args-map)))
+      ;; Bind the lexical-scope override so plain dispatches in the body
+      ;; route `:rf.http/managed` → this scope's route-map stub
+      ;; automatically. The thunk's dispatches run synchronously within
+      ;; this dynamic extent; per-call `:fx-overrides` still take
+      ;; precedence (router merge).
+      (binding [router/*fx-overrides* (merge router/*fx-overrides*
+                                             {:rf.http/managed scope-stub-id})]
+        (thunk))
+      (finally
+        (fx/clear-fx scope-stub-id)))))
 
 #?(:clj
    (defmacro with-managed-request-stubs

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -1230,6 +1230,86 @@
           (re-frame.http-test-support/uninstall-managed-request-stubs!)
           (late-bind/set-fn! :router/dispatch! original))))))
 
+;; ---- 11a-vn8qjv. scoped stubs compose under nesting -----------------------
+;;
+;; rf2-vn8qjv (issue 2) — `with-managed-request-stubs*` must be stack-safe
+;; for nested lexical scopes. Pre-fix every scope keyed off ONE global stub
+;; fx id (`:rf.http/managed-test-stub`): the inner scope's install replaced
+;; the outer handler and the inner's `finally` CLEARED it, so an outer-scope
+;; dispatch after the inner exit routed to a now-absent fx. The fix mints a
+;; UNIQUE fx id per scope and binds the override to that id, so the outer
+;; scope's fx + override survive a fully-nested inner scope.
+
+(deftest scoped-stubs-compose-under-nesting-rf2-vn8qjv
+  (testing "rf2-vn8qjv — an outer A stub wraps an inner B stub; after the
+            inner B scope exits, a later outer-scope request still routes to
+            the A stub (pre-fix the inner's teardown cleared the shared fx and
+            the outer dispatch hit a missing fx / wrong handler)"
+    ;; Distinct event + route per call site so each scope keys off its own url.
+    (rf/reg-event-fx :vn8qjv/load-a
+      (fn [{:keys [db]} [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db (assoc db :result-a reply)}
+          {:fx [[:rf.http/managed {:request {:method :get :url "/a"} :decode :json}]]})))
+    (rf/reg-event-fx :vn8qjv/load-b
+      (fn [{:keys [db]} [_ msg]]
+        (if-let [reply (:rf/reply msg)]
+          {:db (assoc db :result-b reply)}
+          {:fx [[:rf.http/managed {:request {:method :get :url "/b"} :decode :json}]]})))
+    (rf/with-managed-request-stubs
+      {[:get "/a"] {:reply {:ok {:from :outer-a}}}}
+      ;; Inner scope B — distinct route + reply. Its install + teardown must
+      ;; not disturb the outer A scope.
+      (rf/with-managed-request-stubs
+        {[:get "/b"] {:reply {:ok {:from :inner-b}}}}
+        (rf/dispatch-sync [:vn8qjv/load-b])
+        (let [db (await-reply! #(some? (:result-b %)) 2000)]
+          (is (= {:from :inner-b} (get-in db [:result-b :value]))
+              "inner B scope routed to the B stub")))
+      ;; Inner scope has exited. The outer A scope's stub MUST still be live.
+      (rf/dispatch-sync [:vn8qjv/load-a])
+      (let [db (await-reply! #(some? (:result-a %)) 2000)]
+        (is (= :success (get-in db [:result-a :kind]))
+            "outer A scope still synthesised a reply after the inner B exit")
+        (is (= {:from :outer-a} (get-in db [:result-a :value]))
+            "outer A scope still routed to the A stub — not cleared by inner B teardown")))))
+
+;; ---- 11a-vn8qjv (lower-level). install/uninstall stack + no fx leak --------
+;;
+;; rf2-vn8qjv (issue 2) — the lower-level install/uninstall surface keeps the
+;; STABLE documented id (`:rf.http/managed-test-stub`, the `:fx-overrides`
+;; target users hardcode), but install snapshots the prior handler and
+;; uninstall restores it, so a nested install/uninstall pair leaves the outer
+;; install intact; a balanced top-level pair leaks no fx.
+
+(deftest lower-level-install-uninstall-stack-discipline-rf2-vn8qjv
+  (testing "rf2-vn8qjv — nested install/uninstall on the stable id restores the
+            outer handler; balanced top-level pair leaks no test fx"
+    (let [stub-id :rf.http/managed-test-stub]
+      (is (nil? (registrar/handler :fx stub-id))
+          "no stub fx registered before install")
+      (re-frame.http-test-support/install-managed-request-stubs!
+        {[:get "/outer"] {:reply {:ok {:from :outer}}}})
+      (let [outer-handler (registrar/handler :fx stub-id)]
+        (is (some? outer-handler) "outer install registered the stub fx")
+        ;; Nested install replaces the handler in place.
+        (re-frame.http-test-support/install-managed-request-stubs!
+          {[:get "/inner"] {:reply {:ok {:from :inner}}}})
+        (is (not (identical? outer-handler (registrar/handler :fx stub-id)))
+            "inner install replaced the handler")
+        ;; Inner uninstall RESTORES the outer handler (stack discipline).
+        (re-frame.http-test-support/uninstall-managed-request-stubs!)
+        (is (identical? outer-handler (registrar/handler :fx stub-id))
+            "inner uninstall restored the outer install's handler")
+        ;; Outer uninstall clears (no prior on the stack).
+        (re-frame.http-test-support/uninstall-managed-request-stubs!)
+        (is (nil? (registrar/handler :fx stub-id))
+            "balanced top-level install/uninstall leaves no leaked test fx")
+        ;; Idempotent: an extra uninstall is a safe no-op.
+        (re-frame.http-test-support/uninstall-managed-request-stubs!)
+        (is (nil? (registrar/handler :fx stub-id))
+            "extra uninstall is an idempotent no-op")))))
+
 ;; ---- 11b. canned-stub fxs gated on explicit test-support require (rf2-cdmle)
 ;;
 ;; Per rf2-cdmle (follow-up to rf2-zk08x): the gate that decides whether

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -666,7 +666,7 @@ The reply dispatch lands in the **same frame** the request was issued from. The 
 
 ## Middleware
 
-Per — apps repeatedly want to apply a transform to every outgoing `:rf.http/managed` request: attach a Bearer token, stamp a correlation-id, rewrite a base URL in dev. v1 ships a **per-frame request-side interceptor chain** that sits between the user's args and the transport.
+Apps repeatedly want to apply a transform to every `:rf.http/managed` request or response: attach a Bearer token, stamp a correlation-id, rewrite a base URL in dev (request side); parse rate-limit headers, compute response-time deltas, flag a 401 for auth refresh (response side). v1 ships a **per-frame interceptor chain** with both phases — a `:before` request-side transform that sits between the user's args and the transport, and an `:after` response-side transform that sits between the transport's reply and the `:on-success` / `:on-failure` dispatch. The shape mirrors the event-interceptor `{:id :before :after}` onion (Spec 002): symmetric on both sides, `:before` in registration order, `:after` in reverse.
 
 ### Shape
 
@@ -1312,15 +1312,10 @@ Adjacent surfaces that are first-class re-frame2 commitments but live in their o
 - **WebSocket** — bidirectional. Lives in [Pattern-WebSocket](Pattern-WebSocket.md); state-machine-shaped.
 - **GraphQL-specific batching / persisted queries.** Layer on top — `:rf.http/managed` hands you the decoded response, your application wraps for batching.
 - **HTTP/2 server push.** Not a re-frame2 concern; the platform handles it transparently.
-- **Response-side interceptors (`:after`).** v1's middleware contract is request-side only ([§Middleware](#middleware)). Apps that want to project / log / retry on response paths use `:accept` (domain-failure normalisation) and the trace stream; a future `:after` slot composes additively when it lands.
 
 ## Open questions
 
-> **SA-4 classification.** Per [SPEC-AUTHORING §SA-4](SPEC-AUTHORING.md): all three items are **post-v1, untracked notes** — additive surfaces that do not block v1 and have no tracking bead filed yet (so none qualifies as `:post-v1 tracked`, which requires a `rf2-<id>`). A tracking bead is filed for each only when its "deferred until …" condition is met.
-
-### Response-side middleware composition (post-v1)
-
-Per [§Middleware](#middleware) v1 ships request-side middleware only. A response-side `:after` slot — composing additively with `:accept` and `:before` — would let apps project / log / retry on response paths without per-event boilerplate. Deferred until the request-side surface settles in practice and the composition order with `:accept` is decided.
+> **SA-4 classification.** Per [SPEC-AUTHORING §SA-4](SPEC-AUTHORING.md): both items are **post-v1, untracked notes** — additive surfaces that do not block v1 and have no tracking bead filed yet (so neither qualifies as `:post-v1 tracked`, which requires a `rf2-<id>`). A tracking bead is filed for each only when its "deferred until …" condition is met.
 
 ### Streaming responses (`:rf.http/streaming`) (post-v1)
 
@@ -1344,9 +1339,9 @@ Per [§Failure categories (closed set)](#failure-categories-closed-set) the fail
 
 Per [§Failure categories (closed set)](#failure-categories-closed-set) the `:rf.http/cors` row is CLJS-only — JVM transports never emit it. CORS is a browser-policy concern; the JVM has no cross-origin policy to enforce. The asymmetry is documented so tools that consume the trace stream don't assume the row exists on every host.
 
-### Request-side middleware only in v1
+### Per-frame interceptor chain with both request- and response-side phases
 
-Per [§Middleware](#middleware) the v1 middleware contract is per-frame request-side only — the interceptor chain sits between the user's args and the transport, not between the transport and the reply. The request-side cases (Bearer token, correlation-id, base-URL rewrite) all surfaced as the high-frequency pattern; response-side composition is deferred to [§Open questions](#open-questions). The request-side surface ships first because its shape is settled.
+Per [§Middleware](#middleware) the v1 middleware contract is a per-frame interceptor chain carrying both phases: a `:before` request-side transform between the user's args and the transport, and an `:after` response-side transform between the transport's reply and the `:on-success` / `:on-failure` dispatch. The request-side cases (Bearer token, correlation-id, base-URL rewrite) and the response-side cases (rate-limit header parsing, response-time telemetry, 401 auth-refresh tagging) were chosen as the high-frequency patterns. The two phases compose via one `{:id :before :after}` registration that mirrors the event-interceptor onion (Spec 002): `:before` runs in registration order, `:after` in reverse, and the `:after` sees the same ctx the `:before` chain produced for that request — so request-correlated response handling (e.g. a start-mark stamped by `:before`, read by `:after`) is a single-interceptor concern. Response-side composition with `:accept` is settled: `:accept` runs first inside the transport (domain-failure normalisation produces the `{:kind :success|:failure}` response), then the `:after` chain transforms that response before the reply dispatch.
 
 ### Frame-aware reply dispatch
 


### PR DESCRIPTION
Fixes rf2-vn8qjv (both issues).

## Issue 1 — Spec 014 :after-shipped drift
Spec 014 described response-side HTTP interceptors (`:after`) as deferred / a post-v1 open question, while the implementation, schema, public API table, and tests already ship and depend on `:after`. Reconciled Spec 014 to one authoritative contract: `:after` is a shipped v1 phase. Rewrote the Middleware intro to describe both request- (`:before`) and response-side (`:after`) phases; removed the request-side-only bullet from 'What Spec 014 does NOT cover'; removed the 'Response-side middleware composition (post-v1)' open question (two items remain); and replaced the 'Request-side middleware only in v1' resolved decision with one stating both phases ship and stating the settled `:accept`-then-`:after` response composition order (verified against http_transport finalise-success!: `:accept` runs first, then the `:after` chain transforms the resulting reply-payload). Verified `:after` reality against http_middleware.cljc, http_transport.cljc, Spec-Schemas :rf/http-interceptor-meta, API.md, and the http interceptor tests.

## Issue 2 — stub scope isolation
Scoped managed-request stubs were not stack-safe: every `with-managed-request-stubs*` scope keyed off one global stub fx id, so a nested inner scope replaced the outer handler and cleared it on exit, breaking later outer-scope dispatches. Now `with-managed-request-stubs*` mints a process-unique fx id per scope and binds the override to it, so nested scopes compose cleanly. The lower-level `install-managed-request-stubs!` / `uninstall-managed-request-stubs!` keep the documented stable id (the hardcoded `:fx-overrides` target) but snapshot/restore the prior handler with LIFO stack discipline, so nested installs compose and a balanced top-level pair leaks no test fx (idempotent cleanup preserved). Added JVM regressions: outer-A-wraps-inner-B nesting (inner exits, outer still routes to A) and the install/uninstall stack + idempotent-cleanup discipline. Updated the two react_shared_suite assertions to the documented no-manual-override wrapper form (they previously hardcoded the now-per-scope stub id).

## Quality gates
- http JVM (`clojure -M:test`): 376 tests, 1704 assertions, 0 failures
- `npm run test:cljs`: 6059 tests, 21531 assertions, 0 failures
- `check_doc_slugs.py`: pass
- `mkdocs build --strict`: pass (no warnings/errors; Spec 014 changed)