### PR TITLE
fix(machines): restore teardown + after-delay validation (rf2-apfait)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
@@ -35,10 +35,25 @@
   Source-of-truth on order: a process-side
   `re-frame.machines.spawn-order` atom records each spawned actor at
   install time. Snapshots that landed via direct `[:rf.runtime/machines :snapshots]` assoc
-  (test fixtures, hydration payloads) are not tracked in the channel
-  but DO live in app-db — the walker covers them as a stragglers pass
-  after the recorded vector drains."
-  (:require [re-frame.frame :as frame]
+  (test fixtures, hydration payloads, `replace-runtime-db!`, `restore-epoch`)
+  are not tracked in the transient channel but DO live in the durable
+  runtime-db — the walker covers them as a stragglers pass after the
+  recorded vector drains.
+
+  Per rf2-apfait — restore/hydration/full-runtime-db-replacement repopulate
+  durable runtime-db snapshots WITHOUT repopulating the process-side
+  spawn-order atom (the atom is transient bookkeeping, not durable state per
+  Spec 002 §Durable vs transient). A restored SPAWNED actor's snapshot
+  carries `:rf/machine-type` at its root (stamped by `install-spawn!`; a
+  SINGLETON snapshot never carries it — actor_liveness_test:213). The
+  straggler pass therefore SPLITS on that durable discriminator: spawned
+  stragglers run the FULL `destroy/destroy-single-actor!` teardown (handler
+  unregister, schema-mark clear, system-id release, timer cancel, snapshot
+  dissoc) in reverse-creation order DERIVED from the durable actor-id (the
+  `#<n>` suffix), not the singleton straggler path that skips all of that.
+  True singletons keep the exit-cascade-only straggler path."
+  (:require [clojure.string :as str]
+            [re-frame.frame :as frame]
             [re-frame.machines.lifecycle-fx.destroy :as destroy]
             [re-frame.machines.lifecycle-fx.exit-cascade :as exit-cascade]
             [re-frame.machines.lifecycle-fx.finalize :as finalize]
@@ -59,6 +74,44 @@
   (let [container (frame/runtime-db-container frame-id)
         rt        (when container (adapter/read-container container))]
     (or (get-in rt (paths/snapshot-path)) {})))
+
+(defn- spawned-snapshot?
+  "Per rf2-apfait — true iff `snapshot` is a SPAWNED actor's snapshot, not
+  a singleton's. The durable, app-db-derived discriminator is the presence
+  of `:rf/machine-type` at the snapshot root: `install-spawn!` stamps it on
+  every spawned actor (keyword TYPE or inline `:definition`), and a
+  singleton's `build-initial-snapshot` snapshot never carries it
+  (actor_liveness_test:213-216). The discriminator survives
+  restore/hydration/`replace-runtime-db!` because it rides the durable
+  snapshot value, so a restored spawned actor absent from the transient
+  spawn-order atom is still recognised as spawned."
+  [snapshot]
+  (some? (:rf/machine-type snapshot)))
+
+(defn- creation-rank
+  "Per rf2-apfait — derive a best-effort creation-order rank for a restored
+  spawned `actor-id` whose process-side spawn-order entry was lost across
+  restore/hydration. Spawned ids are allocated as `<type>#<n>` with a
+  monotonic per-type counter (`allocate-actor-id-in-runtime-db`), so the
+  trailing `#<n>` integer is the durable creation sequence the spawn-order
+  vector would otherwise carry. Returns the parsed `n` as a Long, or -1
+  for an id with no `#<n>` suffix (explicit `:spawn-id` literals, region-
+  prefixed ids) so those sort oldest — there is no reverse-creation
+  contract to honour for ids the allocator never sequenced.
+
+  Ordering the spawned-straggler walk by DESCENDING rank reconstructs the
+  newest-first exit order Spec 005 §Cross-Spec Interactions §1 requires,
+  derived purely from durable runtime-db (per the bead's acceptance
+  criterion)."
+  [actor-id]
+  (let [s (name actor-id)
+        i (str/last-index-of s "#")]
+    (if (and i (< (inc i) (count s)))
+      (let [tail (subs s (inc i))]
+        (if (re-matches #"\d+" tail)
+          #?(:clj (Long/parseLong tail) :cljs (js/parseInt tail 10))
+          -1))
+      -1)))
 
 (defn- emit-lifecycle-destroyed!
   "Emit the legacy `:rf.machine.lifecycle/destroyed` notification per
@@ -104,29 +157,35 @@
   "Run the full machine-cascade teardown for `frame-id`. Idempotent
   against double-invocation, fail-soft against missing artefacts.
 
-  Per rf2-vsigt the orchestration is:
+  Per rf2-vsigt + rf2-apfait the orchestration is:
    1. Snapshot `[:rf.runtime/machines :snapshots]` once.
-   2. Build the disposal order: recorded spawn-order reversed (newest
-      first) + any straggler actor-ids that live in `[:rf.runtime/machines :snapshots]`
-      but were never recorded (singleton handlers seeded directly,
-      hydration payloads, test fixtures). Stragglers run after the
-      recorded actors in app-db iteration order — there is no
-      reverse-creation contract to honour for never-tracked actors.
-   3. For each actor in the disposal order:
+   2. Build the disposal order in three segments:
+      a. Recorded spawn-order reversed (newest first) — the live-process
+         spawned actors, walked in true reverse-creation order.
+      b. SPAWNED stragglers — snapshots that carry `:rf/machine-type` but
+         are absent from the (transient) spawn-order atom. This is the
+         restore / hydration / `replace-runtime-db!` case (rf2-apfait):
+         durable runtime-db carries the snapshot, the transient atom does
+         not. Walked newest-first by `creation-rank` derived from the
+         durable `<type>#<n>` actor-id, so reverse-creation order is
+         reconstructed from durable state alone.
+      c. SINGLETON stragglers — snapshots with no `:rf/machine-type`
+         (registered via `reg-machine`, seeded directly). App-db iteration
+         order — there is no reverse-creation contract for singletons.
+   3. For each actor:
       a. Emit `:rf.machine.lifecycle/destroyed` BEFORE the destroy
          work so trace consumers see the signal while the handler
          still resolves — same convention as Spec 005 §Cancellation
          cascade D6.
-      b. Dynamically-spawned actors (recorded in spawn-order): run
-         the full single-actor destroy — exit-cascade →
-         http-abort → unified teardown projection → system-id-release
-         trace → handler-unregister → spawn-order forget.
-      c. Singletons (registered via `reg-machine`, snapshot present
-         but actor not spawned via spawn-fx): run the `:exit` cascade
-         + HTTP abort, but DO NOT unregister the handler — singleton
-         handlers live in the global registrar per Spec 005
-         §Spawning v1-partial footnote and outlive any particular
-         frame.
+      b. Spawned actors (recorded OR restored straggler): run the full
+         single-actor destroy — exit-cascade → http-abort →
+         schema-mark clear → timer cancel → unified teardown projection →
+         system-id-release trace → handler-unregister → spawn-order forget.
+      c. Singletons (registered via `reg-machine`, snapshot present but no
+         `:rf/machine-type`): run the `:exit` cascade + HTTP abort, but
+         DO NOT unregister the handler — singleton handlers live in the
+         global registrar per Spec 005 §Spawning v1-partial footnote and
+         outlive any particular frame.
    4. Clear the frame's spawn-order slot."
   [frame-id]
   (when frame-id
@@ -138,9 +197,22 @@
           ;; Stragglers: actor-ids in [:rf.runtime/machines :snapshots] but absent
           ;; from the recorded spawn-order vector. Covers singleton
           ;; machines (registered via `reg-machine`), hydrated SSR
-          ;; payloads, and test fixtures that seed snapshots directly.
-          stragglers   (remove recorded-set (keys snapshots))]
-      ;; Spawned actors: full destroy in reverse-creation order.
+          ;; payloads, restored runtime-db, and test fixtures that seed
+          ;; snapshots directly.
+          stragglers   (remove recorded-set (keys snapshots))
+          ;; rf2-apfait — partition stragglers on the durable
+          ;; `:rf/machine-type` discriminator. Spawned stragglers (restore
+          ;; / hydration / replace-runtime-db! repopulated the durable
+          ;; snapshot but not the transient spawn-order atom) MUST get the
+          ;; full spawned teardown, ordered newest-first by the durable
+          ;; `#<n>` creation rank. Singletons keep the exit-only path.
+          {spawned-stragglers   true
+           singleton-stragglers false}
+          (group-by (fn [actor-id] (spawned-snapshot? (get snapshots actor-id)))
+                    stragglers)
+          spawned-stragglers'  (sort-by creation-rank #(compare %2 %1)
+                                        spawned-stragglers)]
+      ;; (b) Recorded spawned actors: full destroy in reverse-creation order.
       (doseq [actor-id newest-first]
         (let [snapshot (get snapshots actor-id)]
           (emit-lifecycle-destroyed! frame-id actor-id snapshot))
@@ -149,10 +221,20 @@
         ;; bad actor can't strand the rest of the cascade.
         (try (destroy/destroy-single-actor! frame-id actor-id)
              (catch #?(:clj Throwable :cljs :default) _ nil)))
-      ;; Singletons / stragglers: trace + exit cascade + HTTP abort
-      ;; only. The handler stays registered (lives in the global
-      ;; registrar, outlives the frame).
-      (doseq [actor-id stragglers]
+      ;; (b') Restored spawned stragglers: SAME full destroy, newest-first
+      ;; by durable creation rank. rf2-apfait — before this fix these
+      ;; flowed through the singleton straggler path and skipped handler
+      ;; unregister / schema-mark clear / system-id release / timer cancel
+      ;; / snapshot dissoc.
+      (doseq [actor-id spawned-stragglers']
+        (let [snapshot (get snapshots actor-id)]
+          (emit-lifecycle-destroyed! frame-id actor-id snapshot))
+        (try (destroy/destroy-single-actor! frame-id actor-id)
+             (catch #?(:clj Throwable :cljs :default) _ nil)))
+      ;; (c) Singletons: trace + exit cascade + HTTP abort only. The
+      ;; handler stays registered (lives in the global registrar, outlives
+      ;; the frame).
+      (doseq [actor-id singleton-stragglers]
         (let [snapshot (get snapshots actor-id)]
           (emit-lifecycle-destroyed! frame-id actor-id snapshot))
         (try (run-singleton-exit-cascade! frame-id actor-id)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -930,6 +930,73 @@
               :slot   slot
               :target target}))))
 
+(defn- valid-after-delay-key?
+  "Per rf2-apfait + Spec-Schemas §`:rf/state-node` `:after` (1699-1705):
+  an `:after` map KEY (the delay) is well-formed iff it is one of the
+  three closed forms:
+
+    - a POSITIVE integer — literal milliseconds (the schema's `pos-int?`),
+    - a NON-EMPTY vector — a subscription vector `[sub-id & args]`
+      re-resolved at runtime (the schema's `[:vector :any]`),
+    - a FUNCTION — `(fn [{:keys [snapshot]}] ms)` computed once at entry
+      (the schema's `fn?`).
+
+  Mirrors `transition/classify-delay-source`'s `{:literal :sub :fn}`
+  triad, but applied as a REGISTRATION gate so an invalid static key
+  (`-1`, `0`, `\"soon\"`, `nil`, `[]`) is rejected at `reg-machine` time
+  rather than degrading to an `:rf.warning/no-clock-configured` no-op at
+  fx time. Dynamic resolutions (a sub vector / fn that RETURNS an invalid
+  ms at runtime) keep their fx-time warning — only the STATIC key shape is
+  gated here."
+  [delay-key]
+  (boolean
+    (or (and (integer? delay-key) (pos? delay-key))
+        (and (vector? delay-key) (seq delay-key))
+        (fn? delay-key))))
+
+(defn- validate-after-delays!
+  "Per rf2-apfait — reject any `:after` map KEY that is not a positive
+  integer, a non-empty subscription vector, or a function, at
+  registration. Walks every transition-bearing node: each state node
+  (`walk-state-nodes`), every region root + the parallel root, and the
+  flat-machine root — the same coverage the guard/action `:after` ref
+  check applies, so an invalid delay key cannot hide on a root fallback
+  `:after`.
+
+  Throws `:rf.error/machine-bad-after-delay` (a dedicated taxonomy member,
+  distinct from the value-side `:rf.error/machine-bad-after-spec` the
+  transition reducer raises for a malformed transition VALUE) so the error
+  widget / conformance can discriminate \"the delay key is wrong\" from
+  \"the transition spec is wrong\".
+
+  Keeps the runtime fx-time `:rf.warning/no-clock-configured` warning for
+  DYNAMIC delays (sub-vector / fn) that resolve to an invalid ms at
+  runtime — only the STATIC key shape is gated here."
+  [machine]
+  (let [check-key!
+        (fn [state-key delay-key]
+          (when-not (valid-after-delay-key? delay-key)
+            (throw (validation-error
+                     :rf.error/machine-bad-after-delay
+                     (str "the :after delay key " (pr-str delay-key)
+                          " on state " state-key " is invalid — an :after "
+                          "delay must be a POSITIVE integer (literal ms), a "
+                          "NON-EMPTY subscription vector ([sub-id & args]), or "
+                          "a function ((fn [{:keys [snapshot]}] ms)). Per "
+                          "Spec-Schemas §:rf/state-node :after.")
+                     {:state     state-key
+                      :slot      :after
+                      :delay-key delay-key}))))
+        roots (if (parallel/parallel? machine)
+                (cons machine (vals (:regions machine)))
+                [machine])]
+    (doseq [[state-key state-node] (walk-state-nodes machine)
+            [delay-key _t]         (:after state-node)]
+      (check-key! state-key delay-key))
+    (doseq [root           roots
+            [delay-key _t] (:after root)]
+      (check-key! :rf/root delay-key))))
+
 (defn- validate-transition-targets!
   "Per Spec 005 (005:441) + Spec-Schemas §TransitionTarget (rf2-w84jv):
   reject malformed-shape and unresolved transition `:target`s at registration
@@ -1003,7 +1070,14 @@
   compound `:on-done` / `:spawn :on-error`) must be a well-formed,
   resolvable target. Throws `:rf.error/machine-bad-target` (malformed
   shape) / `:rf.error/machine-unresolved-target` (keyword / vector that
-  names no declared state)."
+  names no declared state).
+
+  Per rf2-apfait + Spec-Schemas §`:rf/state-node` `:after`: every `:after`
+  map KEY (the delay) must be a positive integer, a non-empty subscription
+  vector, or a function. Throws `:rf.error/machine-bad-after-delay` for a
+  static key that is none of those (`-1`, `0`, `\"soon\"`, `nil`, `[]`) —
+  gated at registration rather than degrading to an fx-time
+  `:rf.warning/no-clock-configured` no-op."
   [machine]
   (validate-history! machine)
   (validate-parallel! machine)
@@ -1019,6 +1093,10 @@
     (validate-always-self-loop! path (peek path) n))
   ;; rf2-w84jv: every transition slot's `:target` shape + resolution.
   (validate-transition-targets! machine)
+  ;; rf2-apfait: every `:after` delay KEY must be a positive integer, a
+  ;; non-empty subscription vector, or a function — gated at registration
+  ;; rather than degrading to an fx-time :rf.warning/no-clock-configured.
+  (validate-after-delays! machine)
   ;; Validate guard/action references at construction time. machine-id
   ;; isn't known yet (it's the registration-site id), so error tags use
   ;; a placeholder; real misuse traces at handler-call time fill it in.

--- a/implementation/machines/test/re_frame/after_delay_validation_test.clj
+++ b/implementation/machines/test/re_frame/after_delay_validation_test.clj
@@ -1,0 +1,122 @@
+(ns re-frame.after-delay-validation-test
+  "Per rf2-apfait (Finding 2) — `:after` delay KEYS are validated at
+  registration. The schema (Spec-Schemas §`:rf/state-node` `:after`,
+  1699-1705) constrains an `:after` map key to one of three closed forms:
+  a positive integer (literal ms), a non-empty subscription vector
+  (`[sub-id & args]`), or a function. Before this fix, an invalid STATIC
+  key (`-1`, `0`, `\"soon\"`, `nil`, `[]`) passed `validate-machine!` and
+  degraded to a runtime `:rf.warning/no-clock-configured` no-op at fx time
+  — delaying authoring feedback and letting tools/conformance treat an
+  invalid machine as valid.
+
+  `validate-machine!` now rejects such keys with
+  `:rf.error/machine-bad-after-delay`. DYNAMIC delays (a subscription
+  vector / fn that RESOLVES to an invalid ms at runtime) keep their
+  fx-time warning — only the static key shape is gated here (covered by
+  `re-frame.after-test`)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- registration-throws?
+  "Try registering `machine` under `machine-id`. Returns the
+  ExceptionInfo if registration threw, else nil."
+  [machine-id machine]
+  (try (rf/reg-machine machine-id machine) nil
+       (catch clojure.lang.ExceptionInfo e e)))
+
+(defn- mk-machine
+  "A flat machine whose `:running` state declares a single `:after` entry
+  keyed by `delay-key`."
+  [delay-key]
+  {:initial :idle
+   :data    {}
+   :states  {:idle    {:on {:go :running}}
+             :running {:after {delay-key :timeout}}
+             :timeout {}}})
+
+;; ---- invalid STATIC delay keys are rejected at registration --------------
+
+(deftest negative-integer-delay-key-rejected
+  (testing "an :after key of -1 fails registration with :rf.error/machine-bad-after-delay"
+    (let [thrown (registration-throws? :adv/neg (mk-machine -1))]
+      (is (some? thrown) "negative :after delay SHOULD throw at registration")
+      (is (= ":rf.error/machine-bad-after-delay" (.getMessage thrown))
+          "error category names the bad-after-delay contract")
+      (is (= :rf.error/machine-bad-after-delay (:rf.error/id (ex-data thrown)))
+          "ex-data :rf.error/id carries the discriminator")
+      (is (= -1 (:delay-key (ex-data thrown)))
+          "ex-data carries the offending delay key")
+      (is (= :after (:slot (ex-data thrown)))
+          "ex-data names the :after slot"))))
+
+(deftest zero-delay-key-rejected
+  (testing "an :after key of 0 fails registration — pos-int? excludes zero"
+    (let [thrown (registration-throws? :adv/zero (mk-machine 0))]
+      (is (some? thrown) "zero :after delay SHOULD throw at registration")
+      (is (= :rf.error/machine-bad-after-delay (:rf.error/id (ex-data thrown)))))))
+
+(deftest string-delay-key-rejected
+  (testing "an :after key of \"soon\" fails registration"
+    (let [thrown (registration-throws? :adv/str (mk-machine "soon"))]
+      (is (some? thrown) "string :after delay SHOULD throw at registration")
+      (is (= :rf.error/machine-bad-after-delay (:rf.error/id (ex-data thrown))))
+      (is (= "soon" (:delay-key (ex-data thrown)))))))
+
+(deftest nil-delay-key-rejected
+  (testing "an :after key of nil fails registration"
+    (let [thrown (registration-throws? :adv/nil (mk-machine nil))]
+      (is (some? thrown) "nil :after delay SHOULD throw at registration")
+      (is (= :rf.error/machine-bad-after-delay (:rf.error/id (ex-data thrown)))))))
+
+(deftest empty-subscription-vector-delay-key-rejected
+  (testing "an :after key of [] (empty subscription vector) fails registration"
+    (let [thrown (registration-throws? :adv/empty-vec (mk-machine []))]
+      (is (some? thrown) "empty-vector :after delay SHOULD throw at registration")
+      (is (= :rf.error/machine-bad-after-delay (:rf.error/id (ex-data thrown)))))))
+
+;; ---- valid STATIC delay keys register cleanly ----------------------------
+
+(deftest positive-integer-delay-key-accepted
+  (testing "a positive-integer :after key registers without error"
+    (is (nil? (registration-throws? :adv/pos (mk-machine 5000)))
+        "literal pos-int ms is a valid :after delay key")))
+
+(deftest subscription-vector-delay-key-accepted
+  (testing "a non-empty subscription-vector :after key registers without error"
+    (rf/reg-sub :adv/timeout-cfg (fn [_ _] 5000))
+    (is (nil? (registration-throws? :adv/sub (mk-machine [:adv/timeout-cfg])))
+        "non-empty subscription-vector is a valid :after delay key")))
+
+(deftest function-delay-key-accepted
+  (testing "a function :after key registers without error"
+    (is (nil? (registration-throws?
+                :adv/fn (mk-machine (fn [{snap :snapshot}]
+                                      (* 1000 (:n (:data snap)))))))
+        "fn-valued delay is a valid :after delay key")))
+
+;; ---- coverage: invalid key on a NESTED / ROOT :after also rejected -------
+
+(deftest invalid-delay-key-on-nested-state-rejected
+  (testing "an invalid :after key on a NESTED compound child fails registration"
+    (let [m {:initial :outer
+             :data    {}
+             :states  {:outer {:initial :inner
+                               :states  {:inner {:after {-5 :inner}}}}}}
+          thrown (registration-throws? :adv/nested m)]
+      (is (some? thrown) "nested invalid :after delay SHOULD throw")
+      (is (= :rf.error/machine-bad-after-delay (:rf.error/id (ex-data thrown)))))))
+
+(deftest invalid-delay-key-on-root-after-rejected
+  (testing "an invalid :after key on the machine-root :after fallback fails registration"
+    (let [m {:initial :idle
+             :data    {}
+             :after   {0 :idle}
+             :states  {:idle {}}}
+          thrown (registration-throws? :adv/root m)]
+      (is (some? thrown) "root-level invalid :after delay SHOULD throw")
+      (is (= :rf.error/machine-bad-after-delay (:rf.error/id (ex-data thrown)))))))

--- a/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
+++ b/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
@@ -295,3 +295,142 @@
           "frame A's spawn-order slot is cleared")
       (is (= [:iso/child-b#1] (spawn-order/frame-order :iso/frame-b))
           "frame B's spawn-order slot is untouched"))))
+
+;; ---- restore / hydration: spawned snapshots absent from spawn-order ------
+;;
+;; Per rf2-apfait — restore / SSR hydration / `replace-runtime-db!` /
+;; `restore-epoch` repopulate the DURABLE runtime-db snapshots WITHOUT
+;; repopulating the PROCESS-SIDE (transient) `spawn-order` atom (Spec 002
+;; §Durable vs transient: the atom is runtime bookkeeping, not durable
+;; state). Before the fix, `destroy-frame!` saw such snapshots only via the
+;; straggler pass and routed them through `run-singleton-exit-cascade!`,
+;; which runs the `:exit` cascade + HTTP abort ONLY — it does NOT dissoc
+;; the snapshot, release the system-id reverse index, clear schema marks,
+;; cancel `:after` timers, or unregister a handler. A restored SPAWNED
+;; actor (snapshot carries `:rf/machine-type`) must instead flow through
+;; the FULL `destroy-single-actor!` teardown, in reverse-creation order
+;; derived from the durable `<type>#<n>` actor-id.
+;;
+;; These tests model restore by spawning normally, then wiping ONLY the
+;; transient spawn-order atom (`spawn-order/reset-all!`) while leaving the
+;; durable runtime-db snapshots in place — exactly the post-restore /
+;; post-hydration state. Asserting on the durable runtime-db cleanup then
+;; pins that the spawned-straggler path runs full teardown.
+
+(defn- runtime-snapshots
+  "The `[:rf.runtime/machines :snapshots]` map on `frame-id`'s runtime-db."
+  [frame-id]
+  (get-in (rf/runtime-db-value frame-id) [:rf.runtime/machines :snapshots]))
+
+(deftest restored-spawned-snapshots-get-full-teardown-newest-first
+  (testing "destroy-frame! treats restored spawned snapshots (absent from spawn-order) as spawned actors: full teardown, newest-first by durable actor-id"
+    (rf/reg-frame :rs/auth {:doc "restore-teardown frame"})
+    (let [exit-log (atom [])
+          child    {:initial :running
+                    :data    {}
+                    :states  {:running {:exit (fn [{data :data}]
+                                                 (swap! exit-log
+                                                        conj (:rf/self-id data))
+                                                 {})}}}
+          boot     {:initial :idle
+                    :data    {}
+                    :states
+                    {:idle {:on {:spawn-three
+                                 {:action (fn [_]
+                                    {:fx [[:rf.machine/spawn
+                                           {:machine-id :rs/child :id-prefix :rs/child}]
+                                          [:rf.machine/spawn
+                                           {:machine-id :rs/child :id-prefix :rs/child}]
+                                          [:rf.machine/spawn
+                                           {:machine-id :rs/child :id-prefix :rs/child}]]})}}}}}]
+      (rf/reg-machine :rs/child child)
+      (rf/reg-machine :rs/boot boot)
+      (rf/dispatch-sync [:rs/boot [:spawn-three]] {:frame :rs/auth})
+      ;; Sanity: three spawned actors live, with durable :rf/machine-type.
+      ;; (The :rs/boot singleton's own snapshot also lives here — it has no
+      ;; :rf/machine-type and stays a singleton straggler.)
+      (is (= #{:rs/child#1 :rs/child#2 :rs/child#3}
+             ;; the children are exactly the snapshots carrying :rf/machine-type
+             (set (keep (fn [[id snap]]
+                          (when (some? (:rf/machine-type snap)) id))
+                        (runtime-snapshots :rs/auth))))
+          "three spawned snapshots are live (each carrying :rf/machine-type) before restore")
+      ;; Simulate restore / hydration: the durable snapshots survive, but
+      ;; the transient spawn-order atom is wiped (it is NOT serialized).
+      (spawn-order/reset-all!)
+      (is (= [] (spawn-order/frame-order :rs/auth))
+          "spawn-order atom is empty post-restore (the bug's precondition)")
+      ;; Destroy the frame.
+      (rf/destroy-frame! :rs/auth)
+      ;; :exit fired for all three children, NEWEST-FIRST by the durable
+      ;; #<n> rank. (Filter to children — the boot singleton's :exit, if
+      ;; any, is irrelevant to the spawned-ordering contract.)
+      (is (= [:rs/child#3 :rs/child#2 :rs/child#1]
+             (filterv #{:rs/child#1 :rs/child#2 :rs/child#3} @exit-log))
+          ":exit ran newest-first, order derived from the durable actor-id (not the lost spawn-order atom)")
+      ;; FULL teardown: every restored SPAWNED snapshot is dissoc'd. The
+      ;; singleton straggler path would have LEFT these in runtime-db.
+      (is (empty? (keep (fn [[id snap]]
+                          (when (some? (:rf/machine-type snap)) id))
+                        (runtime-snapshots :rs/auth)))
+          "every restored spawned snapshot was dissoc'd (full teardown, not exit-only)"))))
+
+(deftest restored-spawned-snapshot-releases-system-id-index
+  (testing "destroy-frame! releases the system-id reverse index for a restored, spawn-order-less spawned actor"
+    (rf/reg-frame :rsi/auth {:doc "restore system-id frame"})
+    (let [child  {:initial :running :data {} :states {:running {}}}
+          boot   {:initial :idle
+                  :data    {}
+                  :states
+                  {:idle {:on {:bind {:action (fn [_]
+                                        {:fx [[:rf.machine/spawn
+                                               {:machine-id :rsi/child
+                                                :id-prefix  :rsi/child
+                                                :system-id  :session/primary}]]})}}}}}]
+      (rf/reg-machine :rsi/child child)
+      (rf/reg-machine :rsi/boot boot)
+      (rf/dispatch-sync [:rsi/boot [:bind]] {:frame :rsi/auth})
+      (is (= :rsi/child#1
+             (get-in (rf/runtime-db-value :rsi/auth)
+                     [:rf.runtime/machines :system-ids :session/primary]))
+          "system-id bound before restore")
+      ;; Restore: wipe the transient spawn-order; the durable snapshot +
+      ;; system-id reverse index survive.
+      (spawn-order/reset-all!)
+      (rf/destroy-frame! :rsi/auth)
+      (is (nil? (get-in (rf/runtime-db-value :rsi/auth)
+                        [:rf.runtime/machines :system-ids :session/primary]))
+          "system-id reverse index released — only the full spawned teardown does this; the singleton straggler path leaves it bound")
+      (is (nil? (get-in (rf/runtime-db-value :rsi/auth)
+                        [:rf.runtime/machines :snapshots :rsi/child#1]))
+          "restored spawned snapshot dissoc'd"))))
+
+(deftest restored-singleton-snapshot-keeps-singleton-straggler-path
+  (testing "a restored SINGLETON snapshot (no :rf/machine-type) keeps the exit-only straggler path — handler survives, snapshot left for app-db release"
+    (rf/reg-frame :rsg/auth {:doc "restore singleton frame"})
+    (let [exit-log (atom [])
+          ;; A singleton machine — registered, then driven into a state so
+          ;; its snapshot lands in runtime-db. Its snapshot carries NO
+          ;; :rf/machine-type (build-initial-snapshot does not stamp it).
+          single {:initial :live
+                  :data    {}
+                  :states  {:live {:on   {:noop {:action (fn [{d :data}] {:data d})}}
+                                   :exit (fn [_] (swap! exit-log conj :rsg/single) {})}}}]
+      (rf/reg-machine :rsg/single single)
+      ;; Touch the singleton so its snapshot materialises in this frame.
+      (rf/dispatch-sync [:rsg/single [:noop]] {:frame :rsg/auth})
+      (is (some? (get-in (rf/runtime-db-value :rsg/auth)
+                         [:rf.runtime/machines :snapshots :rsg/single]))
+          "singleton snapshot present before restore")
+      (is (nil? (:rf/machine-type
+                  (get-in (rf/runtime-db-value :rsg/auth)
+                          [:rf.runtime/machines :snapshots :rsg/single])))
+          "singleton snapshot carries NO :rf/machine-type (the discriminator)")
+      (spawn-order/reset-all!)
+      (rf/destroy-frame! :rsg/auth)
+      ;; The singleton's :exit ran (straggler path runs the exit cascade)...
+      (is (= [:rsg/single] @exit-log)
+          "singleton :exit cascade ran via the straggler path")
+      ;; ...but its TYPE handler stays globally registered (outlives the frame).
+      (is (some? (registrar/lookup :event :rsg/single))
+          "singleton handler stays registered — NOT unregistered by the straggler path"))))


### PR DESCRIPTION
Fixes rf2-apfait (2 findings).

**Finding 1 (High) — restore/hydration teardown.** A restored or SSR-hydrated spawned actor's snapshot lives in durable runtime-db but is absent from the transient process-side spawn-order atom (Spec 002 durable-vs-transient). The frame-destroy walker treated such snapshots as singleton stragglers and ran exit-only teardown — skipping snapshot dissoc, system-id release, schema-mark clear, timer cancel, and handler unregister. `teardown-on-frame-destroy!` now partitions stragglers on the durable `:rf/machine-type` discriminator: spawned stragglers run the full `destroy-single-actor!` teardown in reverse-creation order derived from the durable `<type>#<n>` actor-id; true singletons keep the exit-only path.

**Finding 2 (Medium) — :after delay validation.** Static `:after` delay keys were not validated at registration, so `{-1 :timeout}` / `{0 ...}` / `{"soon" ...}` registered and degraded to an fx-time `:rf.warning/no-clock-configured` no-op. `validate-machine!` now rejects an `:after` key that is not a positive integer, a non-empty subscription vector, or a function, with the dedicated `:rf.error/machine-bad-after-delay` category. Dynamic sub/fn delays that resolve to an invalid ms at runtime keep the fx-time warning.

Scope: `implementation/machines` (src + tests) only. No spec/hot-zone files; EP-0002 nn0jqa fx work is a separate future concern.

## Quality gates
- machines JVM: `clojure -M:test` — 583 tests, 1828 assertions, 0 failures, 0 errors
- epoch JVM (restore-adjacent): `clojure -M:test` — 295 tests, 1164 assertions, 0 failures, 0 errors
- CLJS (incl. conformance corpus running validate-machine!): `npm run test:cljs` — 6059 tests, 21531 assertions, 0 failures, 0 errors