### PR TITLE
feat(flows): read runtime-db via explicit partition-qualified inputs (EP-0001 §535-551) (rf2-4eisfr)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -198,7 +198,7 @@
    {:key         :flows/run-flows-on-db
     :producer-ns 're-frame.flows
     :design-bead "rf2-u0zz5"
-    :description "Run the frame's flows over a given db value, returning the flow-augmented db. Invoked by the router's outermost flows-after-interceptor to transform the handler's pending `:db` effect (after the rest of the `:after` chain, before the `:db` install)."}
+    :description "Run the frame's flows over the pending frame-state, returning the flow-augmented APP-DB. Called `[frame db]` (app-db only) or `[frame db runtime-db]` (both pending partitions — EP-0001 §535-551, rf2-4eisfr). Bare `:inputs` resolve against app-db; `[:rf.db/runtime …]` inputs resolve against runtime-db (any flow may read runtime-db; only writes are reserved). Invoked by the router's outermost flows-after-interceptor to transform the handler's pending `:db` effect (after the rest of the `:after` chain, before the `:db` install)."}
    {:key         :flows/reset-last-inputs!
     :producer-ns 're-frame.flows
     :description "Reset memoised last-input snapshots (test isolation)."}

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -968,10 +968,32 @@
       (let [frame       (:frame (:coeffects ctx))
             effects     (:effects ctx)
             has-db?     (contains? effects :db)
+            ;; EP-0001 §535-551 (rf2-4eisfr): a runtime-db write also lands as
+            ;; a pending `:rf.db/runtime` effect (e.g. a pure
+            ;; `:rf.route/transitioned` returns `{:rf.db/runtime …}` and NO
+            ;; `:db`). The flow transform must observe the SETTLED pending
+            ;; runtime-db so a flow reading a `[:rf.db/runtime …]`-qualified
+            ;; input recomputes — the dual-partition TRIGGER (§542-544) keys on
+            ;; BOTH partitions, NOT on app-db publication alone. Missing this
+            ;; is a SILENT regression: a route/machine-reading flow would just
+            ;; stop updating. Note `has-runtime-effect?` (not `has-db?`):
+            ;; the runtime-db is resolved independently of whether the handler
+            ;; touched app-db.
+            has-runtime-effect? (contains? effects :rf.db/runtime)
             run-on-db   (late-bind/get-fn-cached :flows/run-flows-on-db)
             pending-db  (if has-db?
                           (:db effects)
                           (when run-on-db (frame/frame-app-db-value frame)))
+            ;; The pending runtime-db partition the flows read their qualified
+            ;; inputs against: the handler's `:rf.db/runtime` effect when one
+            ;; landed, else the current (unchanged) runtime-db. Only resolved
+            ;; when the flows artefact is loaded — apps without flows never
+            ;; touch it. Flow outputs write app-db only (runtime writes
+            ;; reserved, §539), so this value is read-only for the whole pass.
+            pending-runtime-db (when run-on-db
+                                 (if has-runtime-effect?
+                                   (:rf.db/runtime effects)
+                                   (frame/frame-runtime-db-value frame)))
             ;; Per rf2-ta0y7: stamp `:rf.event/v` + `:rf.trace/event-id`
             ;; on the t1 / t2 trace events so they carry the same
             ;; per-event attribution every other `:op-type :rf.event`
@@ -1021,7 +1043,13 @@
                   ;; which case there are no rows and nothing to restore.
                   snapshot-li (late-bind/get-fn-cached :flows/snapshot-last-inputs)
                   li-before   (when snapshot-li (snapshot-li frame))
-                  new-db (run-on-db frame pending-db)]
+                  ;; EP-0001 §535-551 (rf2-4eisfr): hand the flow transform
+                  ;; BOTH partitions of the pending frame-state. Bare `:inputs`
+                  ;; resolve against `pending-db` (app-db); `[:rf.db/runtime …]`
+                  ;; inputs resolve against `pending-runtime-db`. The returned
+                  ;; value is the flow-augmented APP-DB (runtime-db is read-only
+                  ;; for the pass).
+                  new-db (run-on-db frame pending-db pending-runtime-db)]
               ;; t2 — flows transformed the pending `:db`. Stamp the
               ;; flow-augmented value so the Xray panel can render the
               ;; t1→t2 reshape. The dirty-check below is the same

--- a/implementation/core/test/re_frame/event_emit_test.cljc
+++ b/implementation/core/test/re_frame/event_emit_test.cljc
@@ -134,11 +134,13 @@
       ;; Stub the flow-transform hook to throw, driving the router's
       ;; flows-after-interceptor down its catch branch (which DISCARDS the
       ;; pending :db effect + stashes :rf/flow-error → event aborts before
-      ;; install + :fx). The hook is the (frame db) -> db transform; on
-      ;; throw it carries only :rf.flow/failed-id for attribution — there
-      ;; is no partial-db (no partial commit per the atomicity contract).
+      ;; install + :fx). The hook is the (frame db runtime-db) -> db transform
+      ;; (EP-0001 §535-551, rf2-4eisfr — the router now hands both pending
+      ;; partitions); on throw it carries only :rf.flow/failed-id for
+      ;; attribution — there is no partial-db (no partial commit per the
+      ;; atomicity contract).
       (late-bind/set-fn! :flows/run-flows-on-db
-                         (fn [_frame _db]
+                         (fn [_frame _db _runtime-db]
                            (throw (ex-info "flow output blew up"
                                            {:rf.flow/failed-id :flow/derived}))))
       (rf/register-event-listener!
@@ -166,7 +168,7 @@
       (late-bind/set-fn! :schemas/validate-app-schema!
                          (fn [_db-after _event-id _frame] true))
       (late-bind/set-fn! :flows/run-flows-on-db
-                         (fn [_frame db] db))
+                         (fn [_frame db _runtime-db] db))
       (rf/register-event-listener!
         :test/recorder
         (fn [record] (swap! seen conj record)))

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -55,8 +55,66 @@
 ;; the pending `:db` effect before install and before :fx (per Spec 013
 ;; §Drain integration).
 
-(defn- read-inputs [db flow]
-  (mapv (fn [path] (get-in db path)) (:inputs flow)))
+;; ---- partition-qualified input resolution (EP-0001 §535-551, rf2-4eisfr) --
+;;
+;; Mike RULED (b) 2026-06-09: flows read runtime-db via EXPLICIT partition-
+;; qualified inputs — this IS EP-0001 normative text (§535-551), not a fresh
+;; design call. The binary syntax (mayor refinement (i) — NO redundant
+;; `[:rf.db/app …]` explicit-app form):
+;;
+;;   bare path            → app-db    e.g. [:user :first]
+;;   [:rf.db/runtime …]   → runtime-db e.g. [:rf.db/runtime :rf.runtime/routing :current :id]
+;;
+;; ANY flow may read runtime-db this way (mayor refinement (ii) — user flows
+;; AND framework flows); only the WRITE side is reserved (flow outputs land
+;; in app-db only — see `evaluate-flow!`'s `assoc-in db (:path flow)`). The
+;; resolver reads the SETTLED post-transition / post-macrostep PENDING frame-
+;; state the flow transform was handed (app-db = the pending `:db` effect /
+;; current app-db; runtime-db = the pending `:rf.db/runtime` effect / current
+;; runtime-db) — so a runtime-only event (e.g. a pure `:rf.route/transitioned`
+;; with no app-db change) still presents the changed route value here.
+;;
+;; A qualified runtime input never creates a spurious topo dependency edge:
+;; `topo/depends-on?` compares a flow's `:inputs` against another flow's
+;; OUTPUT `:path`, and outputs are always app-db paths (writes are reserved),
+;; so a `[:rf.db/runtime …]`-rooted input can never prefix-match an output
+;; `:path`. The dirty-check `:input-values` vector includes the resolved
+;; runtime value, so the trigger keys on BOTH partitions by construction
+;; (EP-0001 §542-544): a runtime-db change makes `new-inputs` differ from
+;; the cached row, forcing recompute — it cannot be hidden merely because the
+;; app-db partition was value-identical.
+
+(def ^:private runtime-partition-key
+  "The reserved partition key that, as a leading `:inputs`-path element,
+  opts a flow input into the runtime-db partition (`:rf.db/runtime`). Bare
+  paths (any other leading element) resolve against app-db. Held as a const
+  so the resolver and the doc stay in lockstep."
+  :rf.db/runtime)
+
+(defn- runtime-input?
+  "True iff `path` is a partition-qualified runtime-db input — a vector whose
+  FIRST element is `:rf.db/runtime`. Everything else is a bare app-db path
+  (binary syntax — rf2-4eisfr refinement (i): there is no third
+  `[:rf.db/app …]` explicit-app form)."
+  [path]
+  (= runtime-partition-key (first path)))
+
+(defn- resolve-input
+  "Resolve one flow `:inputs` path against the pending frame-state's two
+  partitions. A `[:rf.db/runtime …rest]` path reads `runtime-db` at `…rest`
+  (the partition key stripped); a bare path reads `db` (app-db) verbatim."
+  [db runtime-db path]
+  (if (runtime-input? path)
+    (get-in runtime-db (subvec path 1))
+    (get-in db path)))
+
+(defn- read-inputs
+  "Read a flow's `:inputs` against the pending frame-state — `db` is the
+  pending app-db partition, `runtime-db` the pending runtime-db partition.
+  Bare paths read app-db; `[:rf.db/runtime …]` paths read runtime-db
+  (EP-0001 §535-551, rf2-4eisfr)."
+  [db runtime-db flow]
+  (mapv (fn [path] (resolve-input db runtime-db path)) (:inputs flow)))
 
 (defn- elide-inputs
   "Walk a flow's just-read input values through `elision/elide-wire-value`,
@@ -150,7 +208,10 @@
                                redact (->> (redact schema)))))))))
 
 (defn- evaluate-flow!
-  "Evaluate one flow against the given db. Returns `[new-db dirty?]` on
+  "Evaluate one flow against the pending frame-state. `db` is the pending
+  app-db partition (the cascade accumulator threaded through prior flows'
+  writes); `runtime-db` is the pending runtime-db partition (read-only — flow
+  WRITES are app-db only, EP-0001 §535-540). Returns `[new-db dirty?]` on
   successful evaluation (skip or recompute); on the failure path the
   exception re-throws after the `:rf.flow/failed` trace fires.
 
@@ -177,9 +238,9 @@
   perf slice). Future editors: keep the gate OUTERMOST on each emit
   site and keep wire-value walks INSIDE it — Closure DCE folds the
   whole branch under `:advanced` + `goog.DEBUG=false`."
-  [frame-id db flow]
+  [frame-id db runtime-db flow]
   (let [flow-id    (:id flow)
-        new-inputs (read-inputs db flow)
+        new-inputs (read-inputs db runtime-db flow)
         ;; Per rf2-94ol5 dirty-check storage is PER-FRAME: read this
         ;; flow's last-seen inputs from THIS frame's own `last-inputs`
         ;; container. Per-frame dirty-check windows stay independent by
@@ -341,10 +402,30 @@
                           e)))))))
 
 (defn run-flows-on-db
-  "Per Spec 013 §Drain integration (rf2-u0zz5): walk THIS FRAME'S
-  registered flows in topological order over the given `db` VALUE,
-  dirty-check each one, recompute and assoc-in the result into a
-  transformed db. Returns the flow-augmented db value.
+  "Per Spec 013 §Drain integration (rf2-u0zz5) + EP-0001 §535-551
+  (rf2-4eisfr): walk THIS FRAME'S registered flows in topological order over
+  the pending frame-state, dirty-check each one, recompute and assoc-in the
+  result into a transformed APP-DB. Returns the flow-augmented APP-DB value.
+
+  Two arities:
+    `[frame-id db]`            — app-db-only pending state (runtime-db is
+                                 nil; only bare app-db inputs resolve).
+    `[frame-id db runtime-db]` — the full pending frame-state. `db` is the
+                                 pending app-db partition; `runtime-db` the
+                                 pending runtime-db partition.
+
+  EP-0001 §535-551 (Mike RULED (b) 2026-06-09): a flow reads app-db by
+  default (bare `:inputs` paths) and runtime-db only through EXPLICIT
+  partition-qualified inputs `[:rf.db/runtime …]` (binary syntax — there is
+  NO redundant `[:rf.db/app …]` form). ANY flow — user or framework — may
+  read runtime-db this way; only the WRITE side is reserved. Flow outputs
+  write ONLY app-db (the cascade threads and returns the APP-DB partition;
+  runtime-db is read-only for the whole pass). The trigger / dirty-check
+  keys on BOTH partitions: a runtime-db change shows up in the resolved
+  `:input-values`, so a runtime-only event (e.g. a pure
+  `:rf.route/transitioned`) recomputes a route-reading flow even when app-db
+  is value-identical (EP-0001 §542-544 — a runtime write cannot be hidden
+  from a flow merely because the app-db partition did not change).
 
   This is the **outermost-`:after` flow transform**. The router installs
   it as the OUTERMOST `:after` interceptor (re-frame.router/flows-after-
@@ -388,7 +469,8 @@
   so this rollback cannot clobber its just-advanced dirty-check rows. The
   per-frame-independence invariant (Spec 002 rule 1 / Spec 013
   §Frame-scoping) holds by construction, not by careful keying."
-  [frame-id db]
+  ([frame-id db] (run-flows-on-db frame-id db nil))
+  ([frame-id db runtime-db]
   (let [flow-map (get (registry/flows-snapshot) frame-id)]
     (if-not (seq flow-map)
       db
@@ -401,8 +483,13 @@
             ;; frame is structurally untouched. Restored in the catch below.
             last-inputs-before (registry/frame-last-inputs-snapshot frame-id)]
         (try
-          ;; The drain threads ONLY the transformed `db` — the loop is a pure
-          ;; left-fold over the topo-ordered flows. `evaluate-flow!` returns a
+          ;; The drain threads ONLY the transformed APP-DB `db` — the loop is
+          ;; a pure left-fold over the topo-ordered flows. `runtime-db` is the
+          ;; pending runtime-db partition, read-only for the WHOLE pass: flow
+          ;; outputs write app-db only (EP-0001 §539 — runtime writes
+          ;; reserved), and a flow's qualified `[:rf.db/runtime …]` inputs all
+          ;; resolve against the SAME pending runtime-db snapshot (no cascade-
+          ;; local runtime mutation to thread). `evaluate-flow!` returns a
           ;; `[new-db dirty?]` tuple but the cascade has no consumer for the
           ;; dirty flag: the router writes the returned db value straight into
           ;; the `:db` effect slot regardless. So discard the second slot here
@@ -413,7 +500,7 @@
             (if (empty? remaining)
               db
               (let [flow         (flow-map (first remaining))
-                    [new-db _]   (evaluate-flow! frame-id db flow)]
+                    [new-db _]   (evaluate-flow! frame-id db runtime-db flow)]
                 (recur (rest remaining) new-db))))
           (catch #?(:clj Throwable :cljs :default) e
             ;; Atomicity contract: discard ALL flow side-effects of this
@@ -424,7 +511,7 @@
             ;; untouched. The throw (carrying `:rf.flow/failed-id` from
             ;; `evaluate-flow!`) propagates unchanged for router attribution.
             (registry/reset-frame-last-inputs-to! frame-id last-inputs-before)
-            (throw e)))))))
+            (throw e))))))))
 
 ;; ---- late-bind hook registration ----------------------------------------
 ;;

--- a/implementation/ssr/test/re_frame/flows_integration_test.clj
+++ b/implementation/ssr/test/re_frame/flows_integration_test.clj
@@ -38,16 +38,23 @@
       the installed flow-augmented db).
     - An event whose `:fx` `:dispatch`es child events gives EACH child its
       OWN independent flow eval, not the parent's.
-    - A flow whose `:inputs` overlap the `[:rf.runtime/routing :current]`
-      slice reads the POST-transition route (the slice rewrite is the
-      handler's pending `:db`; the flow at the outermost `:after`
-      transforms that pending value before install — there is no
-      pre-transition window the flow could observe). The dual atomicity
-      assertion: a flow throw on a `:rf.route/transitioned` dispatch
-      aborts the WHOLE event — slice stays on the previous route,
-      `:on-match` `:dispatch` fxs are NOT walked. Pin (rf2-qm8m3):
-      regression coverage for the routing × flows composition the
-      rf2-hm4gi delta audit flagged."
+    - A flow whose `:inputs` opt into runtime-db via the partition-
+      qualified form `[:rf.db/runtime :rf.runtime/routing :current …]`
+      reads the POST-transition route (EP-0001 §535-551, rf2-4eisfr —
+      Mike RULED (b) 2026-06-09: flows read runtime-db via EXPLICIT
+      partition-qualified inputs; the route slice rewrite is the handler's
+      pending `:rf.db/runtime` effect; the flow at the outermost `:after`
+      transforms against that pending runtime-db before install — there is
+      no pre-transition window the flow could observe). The dual-partition
+      TRIGGER (§542-544): a runtime-only `:rf.route/transitioned` event
+      (no `:db` effect) still recomputes the route-reading flow, because
+      the dirty-check keys on BOTH partitions — a runtime-db change cannot
+      be hidden merely because app-db was value-identical. The dual
+      atomicity assertion: a flow throw on a `:rf.route/transitioned`
+      dispatch aborts the WHOLE event (BOTH partitions) — slice stays on
+      the previous route, `:on-match` `:dispatch` fxs are NOT walked. Pin
+      (rf2-qm8m3): regression coverage for the routing × flows composition
+      the rf2-hm4gi delta audit flagged."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
@@ -146,14 +153,14 @@
 ;; exactly once for the dispatch (no eval-per-microstep, no missed eval).
 ;; ===========================================================================
 
-;; EP-0001 (rf2-vzld77) — DISABLED pending rf2-4eisfr. This test registers a
-;; flow whose `:inputs` read `[:rf.runtime/machines :snapshots …]`. The
-;; migration moved machine snapshots to the runtime-db partition, but the flow
-;; transform reads the app-db value (the pending `:db` effect), so a flow can
-;; no longer observe a runtime-db path. Whether flows MAY observe runtime-db
-;; inputs is undecided (decision #12 keeps flows app-db); rf2-4eisfr captures
-;; the ruling. `#_` reader-discards the whole deftest until then.
-#_(deftest machine-multi-microstep-macrostep-then-single-flow-eval
+;; EP-0001 §535-551 (rf2-4eisfr) — RE-ENABLED. Mike RULED (b) 2026-06-09:
+;; flows read runtime-db via EXPLICIT partition-qualified inputs. Machine
+;; snapshots live in the runtime-db partition (EP-0001 rf2-vzld77), so this
+;; flow's `:inputs` opt into runtime-db via the qualified form
+;; `[:rf.db/runtime :rf.runtime/machines :snapshots …]` (bare paths still
+;; read app-db; binary syntax — no `[:rf.db/app …]` form). The flow transform
+;; resolves the qualified input against the pending runtime-db partition.
+(deftest machine-multi-microstep-macrostep-then-single-flow-eval
   (testing "a multi-microstep (:always + :raise) machine macrostep settles
             within one dispatched event, THEN exactly ONE flow eval runs on
             the settled db — the flow reads the final machine-driven value"
@@ -186,7 +193,7 @@
       ;; label into a plain app-db path. Logging the input it observed lets
       ;; us prove it saw the FINAL (settled) value, not an intermediate one.
       (rf/reg-flow {:id     :gauge/label
-                    :inputs [[:rf.runtime/machines :snapshots :gauge/flow :data :ticks]]
+                    :inputs [[:rf.db/runtime :rf.runtime/machines :snapshots :gauge/flow :data :ticks]]
                     :output (fn [ticks]
                               (swap! flow-evals conj ticks)
                               (str "ticks=" ticks))
@@ -472,10 +479,15 @@
 ;; stage that the flow-throw path skips wholesale).
 ;; ===========================================================================
 
-;; EP-0001 (rf2-vzld77) — DISABLED pending rf2-4eisfr (flow `:inputs` reads
-;; `[:rf.runtime/routing :current :id]`, now a runtime-db path the flow
-;; transform cannot observe — see the note on machine-multi-microstep above).
-#_(deftest flow-over-route-slice-reads-settled-post-transition-route
+;; EP-0001 §535-551 (rf2-4eisfr) — RE-ENABLED. The route slice lives in the
+;; runtime-db partition (EP-0001 rf2-vzld77), so this flow's `:inputs` opt
+;; into runtime-db via the qualified form
+;; `[:rf.db/runtime :rf.runtime/routing :current :id]`. The flow transform
+;; resolves the qualified input against the pending runtime-db (the
+;; post-transition slice rewrite), and the dual-partition TRIGGER fires this
+;; flow on the runtime-only `:rf.route/transitioned` event even though app-db
+;; did not change (EP-0001 §542-544).
+(deftest flow-over-route-slice-reads-settled-post-transition-route
   (testing "a flow whose :inputs overlap [:rf.runtime/routing :current]
             reads the POST-transition route — the slice rewrite is the
             handler's pending :db; the flow at the outermost :after
@@ -489,7 +501,7 @@
     ;; post-transition slice, not the pre-transition one.
     (let [flow-inputs (atom [])]
       (rf/reg-flow {:id     :route/label
-                    :inputs [[:rf.runtime/routing :current :id]]
+                    :inputs [[:rf.db/runtime :rf.runtime/routing :current :id]]
                     :output (fn [route-id]
                               (swap! flow-inputs conj route-id)
                               (str "you are at " route-id))
@@ -538,9 +550,14 @@
             "the :rf.flow/computed trace's :input-values carries the
              post-transition route id")))))
 
-;; EP-0001 (rf2-vzld77) — DISABLED pending rf2-4eisfr (flow `:inputs` reads
-;; `[:rf.runtime/routing :current :id]`, now a runtime-db path — see above).
-#_(deftest flow-throw-on-route-transition-aborts-event-slice-unchanged-no-on-match-fx
+;; EP-0001 §535-551 (rf2-4eisfr) — RE-ENABLED. The throwing flow reads the
+;; route slice via the qualified runtime-db input
+;; `[:rf.db/runtime :rf.runtime/routing :current :id]`. Step 3 of the ruling:
+;; a flow throw aborts BOTH partitions — `:db` AND `:rf.db/runtime` (the slice
+;; rewrite) AND `:fx` are all skipped, consistent with the atomic
+;; cross-partition commit (`commit-and-flow!` short-circuits on `:rf/flow-error`
+;; before `commit-frame-effects!`, so neither partition installs).
+(deftest flow-throw-on-route-transition-aborts-event-slice-unchanged-no-on-match-fx
   (testing "a flow throw on a :rf.route/transitioned dispatch aborts the
             WHOLE event — the slice rewrite does NOT land, the route stays
             on the pre-transition value, AND the :on-match :dispatch fxs
@@ -571,7 +588,7 @@
         ;; Register a flow that throws on every eval, then transition to a
         ;; route whose :on-match would dispatch :route/load-article.
         (rf/reg-flow {:id     :route/boom
-                      :inputs [[:rf.runtime/routing :current :id]]
+                      :inputs [[:rf.db/runtime :rf.runtime/routing :current :id]]
                       :output (fn [_]
                                 (throw (ex-info "flow boom on route"
                                                 {:why :test})))
@@ -605,3 +622,140 @@
             "NO :rf.event/db-changed in the throw stream — the event
              aborted before install (contrast: a clean transition would
              emit one :rf.event/db-changed for the slice rewrite)")))))
+
+;; ===========================================================================
+;; 6. dual-partition TRIGGER (EP-0001 §542-544, rf2-4eisfr) — a RUNTIME-ONLY
+;;    event recomputes a runtime-db-reading flow even though app-db is
+;;    value-identical.
+;;
+;; This is the SILENT-regression guard the ruling calls out: the flow
+;; dirty-check must key on BOTH partitions, NOT on app-db publication. A pure
+;; `:rf.route/transitioned` returns `{:rf.db/runtime …}` and NO `:db` effect —
+;; app-db never changes across the transition. A flow whose ONLY changing
+;; input is the qualified runtime-db route slice must STILL recompute (a
+;; route-reading breadcrumb that just stopped updating would be the
+;; regression). The test pins: (a) the flow recomputes on the runtime-only
+;; event; (b) it observes the NEW runtime value; (c) it does NOT recompute a
+;; second time when nothing in either partition changes (the dirty-check still
+;; suppresses an unchanged re-eval — the trigger widens to runtime-db without
+;; losing the skip).
+;; ===========================================================================
+
+(deftest runtime-only-event-triggers-runtime-db-reading-flow-recompute
+  (testing "a runtime-only :rf.route/transitioned event (no :db effect)
+            recomputes a flow whose only changing input is a qualified
+            [:rf.db/runtime …] route-slice path — the dirty-check keys on
+            BOTH partitions (EP-0001 §542-544), so the flow does NOT silently
+            stop updating when app-db is value-identical"
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    (rf/reg-route :route/home    {:path "/"})
+    (let [flow-evals (atom [])]
+      ;; The flow's ONLY input is the qualified runtime-db route id. Its
+      ;; output writes to a plain app-db path (writes are app-db only).
+      (rf/reg-flow {:id     :nav/breadcrumb
+                    :inputs [[:rf.db/runtime :rf.runtime/routing :current :id]]
+                    :output (fn [route-id]
+                              (swap! flow-evals conj route-id)
+                              (str "at:" route-id))
+                    :path   [:nav :breadcrumb]})
+
+      ;; Land on /home — the flow recomputes for the first runtime-only event.
+      (rf/dispatch-sync [:rf.route/transitioned "/"])
+      (is (= [:route/home] @flow-evals)
+          "the flow recomputed on the FIRST runtime-only transition (no :db
+           effect was returned by the handler, yet the runtime-db read fired
+           the trigger)")
+      (is (= "at::route/home" (get-in (rf/app-db-value :rf/default)
+                                      [:nav :breadcrumb]))
+          "the flow output (derived from the runtime-db route slice) landed
+           in app-db")
+
+      ;; Transition to /articles/42 — again a runtime-only event. app-db does
+      ;; NOT change across this transition; ONLY the runtime-db route slice
+      ;; does. The flow MUST recompute and observe the NEW route id — this is
+      ;; the silent-regression guard: if the dirty-check keyed on app-db
+      ;; publication alone, the flow would never re-fire.
+      (let [app-db-before (rf/app-db-value :rf/default)]
+        (reset! flow-evals [])
+        (rf/dispatch-sync [:rf.route/transitioned "/articles/42"])
+        (is (= [:route/article] @flow-evals)
+            "the flow recomputed on the runtime-only transition even though
+             the only change was in the runtime-db partition — the trigger
+             keys on BOTH partitions (§542-544)")
+        (is (= "at::route/article" (get-in (rf/app-db-value :rf/default)
+                                           [:nav :breadcrumb]))
+            "the recompute observed the NEW runtime-db route id")
+        (is (not= app-db-before (rf/app-db-value :rf/default))
+            "app-db changed only via the FLOW's output write — the handler
+             returned no :db effect; the change is the breadcrumb the flow
+             derived from the runtime-only route change"))
+
+      ;; A re-dispatch to the SAME route changes neither partition's route
+      ;; slice value — the dirty-check still SKIPS (the trigger widened to
+      ;; runtime-db without losing the value-equal skip).
+      (reset! flow-evals [])
+      (reset! *captured* [])
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/42"])
+      (is (= [] @flow-evals)
+          "a transition to the SAME route does NOT recompute the flow — the
+           runtime-db route id is value-equal, so the dirty-check skips
+           (widening the trigger to runtime-db preserves the skip)")
+      (is (seq (by-op :rf.flow/skip))
+          ":rf.flow/skip fired for the value-equal re-transition"))))
+
+;; ===========================================================================
+;; 7. binary-syntax mixed inputs (EP-0001 §535-538, rf2-4eisfr) — ONE flow
+;;    reading BOTH a bare app-db input AND a qualified [:rf.db/runtime …]
+;;    input resolves each against the correct partition.
+;;
+;; Pins the binary input syntax end-to-end: bare = app-db, [:rf.db/runtime …]
+;; = runtime-db, on a single flow. Proves the resolver routes per-input, not
+;; per-flow, and that a flow composing both partitions fires when EITHER
+;; partition's input changes.
+;; ===========================================================================
+
+(deftest flow-composing-app-db-and-runtime-db-inputs-resolves-each-partition
+  (testing "a single flow with one bare app-db input and one qualified
+            [:rf.db/runtime …] runtime-db input resolves each against its own
+            partition, and recomputes when EITHER changes"
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    (rf/reg-route :route/home    {:path "/"})
+    (rf/reg-event-db :set-greeting (fn [db [_ g]] (assoc db :greeting g)))
+    (let [flow-evals (atom [])]
+      ;; Bare [:greeting] reads app-db; qualified route id reads runtime-db.
+      (rf/reg-flow {:id     :nav/banner
+                    :inputs [[:greeting]
+                             [:rf.db/runtime :rf.runtime/routing :current :id]]
+                    :output (fn [greeting route-id]
+                              (swap! flow-evals conj [greeting route-id])
+                              (str greeting " @ " route-id))
+                    :path   [:nav :banner]})
+
+      ;; Seed app-db greeting (app-only event) — flow fires reading both
+      ;; partitions; route id is nil until the first transition.
+      (rf/dispatch-sync [:set-greeting "Hi"])
+      (is (= [["Hi" nil]] @flow-evals)
+          "the flow resolved the bare input against app-db (\"Hi\") and the
+           qualified input against runtime-db (nil — no route yet)")
+
+      ;; A runtime-only transition — the qualified input changes; the bare
+      ;; input is unchanged. The flow recomputes (BOTH-partition trigger).
+      (reset! flow-evals [])
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/42"])
+      (is (= [["Hi" :route/article]] @flow-evals)
+          "the runtime-only transition recomputed the flow; the bare app-db
+           input kept its value, the qualified runtime-db input took the new
+           route id")
+      (is (= "Hi @ :route/article" (get-in (rf/app-db-value :rf/default)
+                                           [:nav :banner]))
+          "the composed output landed in app-db (writes are app-db only)")
+
+      ;; An app-only event — the bare input changes; the qualified input is
+      ;; unchanged. The flow recomputes too.
+      (reset! flow-evals [])
+      (rf/dispatch-sync [:set-greeting "Yo"])
+      (is (= [["Yo" :route/article]] @flow-evals)
+          "the app-only event recomputed the flow; the bare input took the
+           new greeting, the qualified runtime-db input kept the route id"))))


### PR DESCRIPTION
Implements EP-0001 §535-551 (rf2-4eisfr). Mike RULED (b) 2026-06-09: "flows read runtime-db via EXPLICIT partition-qualified inputs; this IS EP-0001 normative text (EP-0001:535-551), not a fresh call." Mayor refinements: (i) binary syntax only — NO redundant `[:rf.db/app …]` form; (ii) ANY flow (user + framework) may read runtime-db via qualified inputs — only the WRITE side is reserved.

## What changed
- **Widen `run-flows-on-db`** (`implementation/flows/src/re_frame/flows.cljc`) to resolve `:inputs` against the pending frame-state: bare path → app-db, `[:rf.db/runtime …]` → runtime-db (partition key stripped). New arity `[frame-id db runtime-db]`; `[frame-id db]` preserved (runtime-db nil). Flow outputs write app-db only — runtime-db is read-only for the whole pass.
- **Dual-partition TRIGGER** (`implementation/core/src/re_frame/router.cljc`, flows-after-interceptor only): the interceptor now computes the pending runtime-db (`:rf.db/runtime` effect when present, else current runtime-db) and hands it to the transform. A runtime-only event (e.g. a pure `:rf.route/transitioned` with no `:db` effect) recomputes a route/machine-reading flow even when app-db is value-identical — the dirty-check keys on BOTH partitions (§542-544). This is the silent-regression guard the ruling flags.
- **Flow throw aborts BOTH partitions**: `commit-and-flow!` already short-circuits on `:rf/flow-error` before `commit-frame-effects!`, so neither `:db` nor `:rf.db/runtime` installs and `:fx` is skipped (verified by the re-enabled route-throw test).
- **Re-enabled the 3 skipped tests** in `implementation/ssr/test/re_frame/flows_integration_test.clj` with qualified input paths (`[:rf.db/runtime :rf.runtime/machines …]` / `[:rf.db/runtime :rf.runtime/routing :current :id]`): machine-multi-microstep, flow-over-route-slice, flow-throw-on-route-transition.
- **Added two tests**: (6) the dual-partition trigger — a runtime-only event recomputes a runtime-reading flow + still skips on value-equal re-transition; (7) a flow composing a bare app-db input with a qualified runtime-db input resolves each against its own partition.
- Updated the two `:flows/run-flows-on-db` stubs in `event_emit_test.cljc` to the 3-arg signature, and the late-bind directory description.

## Quality gates
- `flows` JVM: 165 tests, 4676 assertions, 0 failures / 0 errors
- `ssr` JVM (the 3 re-enabled + 2 new tests live here): 315 tests, 1219 assertions, 0/0; `flows-integration-test` ns focused: 9 tests, 52 assertions, 0/0
- `core` JVM: 997 tests, 4365 assertions, 0/0
- `npm run test:cljs`: 6065 tests, 21556 assertions, 0/0