### PR TITLE
fix(ssr-ring): include head fragment in unified render hash (Spec 011 v1) (rf2-9fw2de)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -246,6 +246,41 @@
                           :recovery  :no-recovery})
       {:head-html "" :html-attrs nil :body-attrs nil})))
 
+(defn render-document-hash
+  "The canonical structural hash for the FULL SSR document state — body
+  render tree PLUS the resolved head fragment (`:head-html`) and the
+  `<html>`/`<body>` attribute bags (`:html-attrs` / `:body-attrs`).
+
+  Per Spec 011 §Head/meta contract and §Mismatch detection — head: in v1
+  the head rides the UNIFIED `:rf/render-hash` channel; the server-rendered
+  HTML carries a single structural hash covering both head and body, so the
+  bundled v1 hydration-mismatch detector cannot tell a head-only divergence
+  from a body-only one but DOES detect either. Hashing only the body (the
+  prior shape) silently accepted a head-only mismatch — a contract drift
+  against §624-626/§648-650 (rf2-9fw2de).
+
+  `head-bag` is the map returned by `resolve-head` (or the explicit-`:head`
+  shape `{:head-html <string> :html-attrs nil :body-attrs nil}`). We wrap
+  the body tree and the head fragment in a self-describing canonical vector
+  and hand it to `render-tree-hash`:
+
+    [:rf/ssr-document <body-hiccup> {:head-html  <string-or-nil>
+                                     :html-attrs <map-or-nil>
+                                     :body-attrs <map-or-nil>}]
+
+  `render-tree-hash`'s canonical-EDN walk sorts map keys and prunes nil
+  values (`hash.cljc`), so the wrapper is deterministic and byte-identical
+  across JVM/CLJS — the same cross-runtime contract the body-only hash
+  honoured. The `:rf/ssr-document` tag keeps the head channel structurally
+  distinct from any body subtree that might happen to be a 3-element vector,
+  so a body-only change and a head-only change can never collide."
+  [body-hiccup {:keys [head-html html-attrs body-attrs]}]
+  (rf/render-tree-hash
+    [:rf/ssr-document body-hiccup
+     {:head-html  head-html
+      :html-attrs html-attrs
+      :body-attrs body-attrs}]))
+
 (defn validate-on-create!
   "Validate the caller's :on-create event vector and return it verbatim.
   `:on-create` is required (per `validate-required-opts!`), so a

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -306,19 +306,6 @@
         {:keys [hash-str body-html head-html html-attrs body-attrs]}
         (rf/with-frame frame-id
           (let [hiccup    (lifecycle/resolve-root-view root-view)
-                ;; rf2-i15nh / rf2-atmvj: compute the structural hash
-                ;; ONCE per request. The same hex feeds the root-element
-                ;; `data-rf-render-hash` (via render-to-string's
-                ;; `:render-hash` opt) AND the payload's
-                ;; `:rf/render-hash`, so the canonical-EDN walk runs
-                ;; once per request. When `:emit-hash?` is false the
-                ;; hash is still needed for the payload slot.
-                hash-str  (ssr/render-tree-hash hiccup)
-                body-html (ssr/render-to-string
-                            hiccup
-                            {:doctype?    false
-                             :emit-hash?  emit-hash?
-                             :render-hash (when emit-hash? hash-str)})
                 ;; rf2-4dra9 / rf2-h2ujj: resolve the active route's
                 ;; :head (or default-head fallback). The head fragment
                 ;; goes through the shell as the :head opt; the
@@ -328,11 +315,33 @@
                 ;; explicit :head string take precedence — they chose to
                 ;; bypass route-driven head resolution, and an explicit
                 ;; string carries no attr-bag sidechannel.
+                ;;
+                ;; rf2-9fw2de: head is resolved BEFORE the hash so the
+                ;; structural hash can fold the head fragment in — Spec
+                ;; 011 §624-626/§648-650 lock head + body onto the unified
+                ;; `:rf/render-hash` channel.
                 head-bag  (if explicit-head
                             {:head-html explicit-head
                              :html-attrs nil
                              :body-attrs nil}
-                            (lifecycle/resolve-head frame-id))]
+                            (lifecycle/resolve-head frame-id))
+                ;; rf2-i15nh / rf2-atmvj: compute the structural hash
+                ;; ONCE per request. rf2-9fw2de: the canonical hash input
+                ;; is the FULL document state (body tree + resolved head
+                ;; fragment + html/body attr bags), not body alone, so a
+                ;; head-only server/client divergence changes the hash and
+                ;; the bundled v1 mismatch detector catches it. The same
+                ;; hex feeds the root-element `data-rf-render-hash` (via
+                ;; render-to-string's `:render-hash` opt) AND the payload's
+                ;; `:rf/render-hash`, so the canonical-EDN walk runs once
+                ;; per request. When `:emit-hash?` is false the hash is
+                ;; still needed for the payload slot.
+                hash-str  (lifecycle/render-document-hash hiccup head-bag)
+                body-html (ssr/render-to-string
+                            hiccup
+                            {:doctype?    false
+                             :emit-hash?  emit-hash?
+                             :render-hash (when emit-hash? hash-str)})]
             (assoc head-bag
                    :hash-str  hash-str
                    :body-html body-html)))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -80,8 +80,17 @@
   "The shell prefix flushed as the first chunk. Mirrors the non-streaming
   `default-html-shell`'s open + head + body-open + app-div-open. Shares
   the `:html-attrs`/`:lang` fallback with the non-streaming shell via
-  `shell/html-attr-bag` so the two envelopes can't diverge."
-  [head-html {:keys [html-attrs body-attrs lang app-element-id]
+  `shell/html-attr-bag` so the two envelopes can't diverge.
+
+  rf2-9fw2de: when `:render-hash` is supplied (the handler passes it iff
+  `:emit-hash?` is true), `data-rf-render-hash` is stamped on the streaming
+  root element — the `#app` div, the first DOM root of the streamed
+  document — mirroring the non-streaming handler's root-element marker
+  (Spec 011 §362-363). The hash value is the full-document structural hash
+  shared with the final payload's `:rf/render-hash`, so toggling
+  `:emit-hash?` has an observable effect on the wire and a host/tool can
+  verify the streamed root against the payload."
+  [head-html {:keys [html-attrs body-attrs lang app-element-id render-hash]
               :or   {lang "en" app-element-id "app"}}]
   (let [attr-bag (shell/html-attr-bag html-attrs lang)]
     (str "<!DOCTYPE html>"
@@ -94,8 +103,13 @@
          ;; rf2-7x0qk — `:app-element-id` is an attribute-value position;
          ;; escape through `html/escape-attr` (same split as the non-
          ;; streaming `default-html-shell`). `:head` stays raw (content
-         ;; position).
-         "<div id=\"" (html/escape-attr app-element-id) "\">")))
+         ;; position). rf2-9fw2de — the `data-rf-render-hash` value is an
+         ;; 8-char hex (canonical-EDN FNV) so it needs no escaping, but it
+         ;; only emits when supplied (`:emit-hash?` true).
+         "<div id=\"" (html/escape-attr app-element-id) "\""
+         (when render-hash
+           (str " data-rf-render-hash=\"" render-hash "\""))
+         ">")))
 
 (defn default-streaming-suffix
   "The shell suffix flushed after the final-payload chunk. Closes the
@@ -158,8 +172,17 @@
      :head-html     \"…\"                        ;; resolved <head> fragment
      :html-attrs    {…} or nil                  ;; stamped on <html>
      :body-attrs    {…} or nil                  ;; stamped on <body>
+     :doc-hash      \"…\"                         ;; full-document structural hash
      :shell-html    \"…\"                        ;; chunk 1 body
      :continuations [{:id … :subtree …} …]}     ;; drain queue (FIFO)
+
+  rf2-9fw2de: `:doc-hash` is the canonical FULL-document structural hash
+  (body tree + resolved head fragment + html/body attr bags) computed via
+  `lifecycle/render-document-hash`. It drives BOTH the final-payload
+  `:rf/render-hash` AND the streaming root-element `data-rf-render-hash`
+  marker (when `:emit-hash?` is true) — preserving wire/payload parity with
+  the non-streaming handler and folding the head into the unified hash
+  channel per Spec 011 §624-626/§648-650.
 
   Throws propagate to the caller (the handler's outer try/catch routes
   them through the projector → fail-closed non-200, rf2-r06pc). The
@@ -186,15 +209,23 @@
   (shell/check-body-end-csp-hosts! body-end csp-script-src-allowlist)
   (rf/with-frame frame-id
     (let [hiccup     (lifecycle/resolve-root-view root-view)
-          {:keys [head-html html-attrs body-attrs]}
-          (if (:head opts)
-            {:head-html (:head opts) :html-attrs nil :body-attrs nil}
-            (lifecycle/resolve-head frame-id))
+          head-bag   (if (:head opts)
+                       {:head-html (:head opts) :html-attrs nil :body-attrs nil}
+                       (lifecycle/resolve-head frame-id))
+          {:keys [head-html html-attrs body-attrs]} head-bag
+          ;; rf2-9fw2de: the streaming structural hash folds the head
+          ;; fragment in, identically to the non-streaming handler — Spec
+          ;; 011 §624-626/§648-650 lock head + body onto the unified
+          ;; `:rf/render-hash` channel. Computed once here on the request
+          ;; thread; drives the final-payload `:rf/render-hash` AND (when
+          ;; `:emit-hash?`) the streaming root-element marker.
+          doc-hash   (lifecycle/render-document-hash hiccup head-bag)
           {:keys [shell-html continuations]} (streaming/render-shell hiccup)]
       {:hiccup        hiccup
        :head-html     head-html
        :html-attrs    html-attrs
        :body-attrs    body-attrs
+       :doc-hash      doc-hash
        :shell-html    shell-html
        :continuations continuations})))
 
@@ -233,11 +264,21 @@
   [^OutputStream out frame-id rendered opts]
   (try
     (let [{:keys [emit-hash? version schema-digest payload]} opts
-          {:keys [hiccup head-html html-attrs body-attrs
-                  shell-html continuations]} rendered
+          ;; rf2-9fw2de — the writer no longer recomputes the hash from
+          ;; `hiccup`; `doc-hash` (full-document) was computed once on the
+          ;; request thread by `render-streaming-shell!`. `:hiccup` stays in
+          ;; the `rendered` map for diagnostics but is not destructured here.
+          {:keys [head-html html-attrs body-attrs
+                  doc-hash shell-html continuations]} rendered
           shell-opts (merge opts
-                            {:html-attrs html-attrs
-                             :body-attrs body-attrs})]
+                            {:html-attrs  html-attrs
+                             :body-attrs  body-attrs
+                             ;; rf2-9fw2de — honour `:emit-hash?` on the
+                             ;; streaming path: stamp the full-document
+                             ;; hash onto the root `#app` div when true, no
+                             ;; marker when false (a true no-op was the
+                             ;; bug). Same hash the final payload carries.
+                             :render-hash (when emit-hash? doc-hash)})]
       ;; Chunk 1 — shell prefix + shell HTML (with template fallbacks).
       (write-chunk! out (default-streaming-prefix head-html shell-opts))
       (write-chunk! out shell-html)
@@ -279,12 +320,17 @@
             (recur (into (pop queue) continuations)))))
       ;; Chunk N+2 — final canonical __rf_payload.
       ;;
-      ;; rf2-5knxf.2 — the streaming final-payload `:rf/render-hash` is
-      ;; computed over `hiccup` (the resolved root view returned by
-      ;; `render-streaming-shell!`) via `render-tree-hash`, the IDENTICAL
-      ;; mechanism the non-streaming `build-full-response*` uses (it hashes
-      ;; `(resolve-root-view root-view)` the same way). This is the correct
-      ;; structural hash, NOT a streaming-specific divergence:
+      ;; rf2-5knxf.2 — the streaming final-payload `:rf/render-hash` is the
+      ;; full-document structural hash (`doc-hash`) computed ONCE on the
+      ;; request thread in `render-streaming-shell!` via
+      ;; `lifecycle/render-document-hash` — the IDENTICAL mechanism the
+      ;; non-streaming `build-full-response*` uses. rf2-9fw2de: it folds the
+      ;; resolved head fragment (+ html/body attr bags) into the canonical
+      ;; input alongside the body `hiccup`, so a head-only divergence
+      ;; changes the hash (Spec 011 §624-626/§648-650). It is reused (not
+      ;; recomputed) so the final-payload `:rf/render-hash` and the streamed
+      ;; root-element `data-rf-render-hash` marker are byte-identical. This
+      ;; is the correct structural hash, NOT a streaming-specific divergence:
       ;;
       ;;   - `render-tree-hash` is a PURE structural FNV-1a over the
       ;;     canonical-EDN of the hiccup (hash.cljc). It does NOT expand
@@ -316,10 +362,9 @@
       ;;     :app/root))`). It is NOT a marker bug and NOT streaming-specific.
       ;;     Spec 011 §Hydration equivalence rule (structural, not textual)
       ;;     + §Hydration-mismatch detection.
-      (let [final-hash    (rf/with-frame frame-id (ssr/render-tree-hash hiccup))
-            final-payload (rf/with-frame frame-id
+      (let [final-payload (rf/with-frame frame-id
                             (streaming/build-final-payload
-                              frame-id final-hash
+                              frame-id doc-hash
                               {:version       version
                                :schema-digest schema-digest
                                :payload       payload}))]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -1043,3 +1043,106 @@
           "explicit-nil :html-shell still opens the default document")
       (is (str/includes? body "<h1>News</h1>")
           "explicit-nil :html-shell still streams the default envelope"))))
+
+;; ===========================================================================
+;; rf2-9fw2de — streaming: the HEAD folds into the unified render hash, AND
+;; the streamed root element honours :emit-hash? with a data-rf-render-hash
+;; marker equal to the final payload's :rf/render-hash.
+;;
+;; Issue 1 (High): the streaming final-payload `:rf/render-hash` was computed
+;; over the body `hiccup` alone, excluding the head — so a head-only
+;; divergence left the hash unchanged (Spec 011 §624-626/§648-650 lock head +
+;; body onto the unified channel). Fix: the streaming hash is the canonical
+;; FULL-document hash (`lifecycle/render-document-hash`), folding the head.
+;;
+;; Issue 2 (Medium): `stream-handler` advertised `:emit-hash?` (default true)
+;; but `run-streaming-writer!` destructured it without use — the streamed
+;; shell never carried a `data-rf-render-hash` root marker, making
+;; `:emit-hash?` a public no-op for the HTML path (Spec 011 §362-363 requires
+;; the server marker on the root element). Fix: the streaming prefix stamps
+;; the full-document hash onto the `#app` root div when `:emit-hash?` is true.
+;; ===========================================================================
+
+(defn- stream-payload-hash
+  "Pull the `:rf/render-hash` out of a streamed document's final
+  `__rf_payload` script. Matches the `#:rf{…}` namespace-map shorthand too."
+  [body]
+  (let [payload-edn (second (re-find
+                              #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>"
+                              body))]
+    (when payload-edn
+      (second (re-find #":(?:rf/)?render-hash \"([0-9a-f]{8})\"" payload-edn)))))
+
+(defn- stream-root-wire-hash
+  "Pull the `data-rf-render-hash` stamped on the streamed `#app` root div."
+  [body]
+  (second (re-find #"data-rf-render-hash=\"([0-9a-f]{8})\"" body)))
+
+(deftest stream-handler-head-folds-into-render-hash
+  (testing "rf2-9fw2de: identical body + DIFFERENT explicit :head → DIFFERENT
+            streamed final-payload :rf/render-hash. The head rides the unified
+            hash channel for the streaming path too."
+    (let [mk      (fn [head]
+                    (ssr-ring/stream-handler
+                      {:on-create [:rf.test.server/init]
+                       :root-view [:test/root]
+                       :head      head
+                       :payload   :rf.ssr.payload/whole-app-db}))
+          body-a  (drain-stream (:body ((mk "<title>Alpha</title>")
+                                        {:uri "/" :request-method :get})))
+          body-b  (drain-stream (:body ((mk "<title>Beta</title>")
+                                        {:uri "/" :request-method :get})))
+          ha      (stream-payload-hash body-a)
+          hb      (stream-payload-hash body-b)]
+      (is (str/includes? body-a "<h1>News</h1>") "body A identical")
+      (is (str/includes? body-b "<h1>News</h1>") "body B identical")
+      (is (some? ha) "streamed payload A carries :rf/render-hash")
+      (is (some? hb) "streamed payload B carries :rf/render-hash")
+      (is (not= ha hb)
+          "rf2-9fw2de: identical streamed body but different head → DIFFERENT
+           final-payload :rf/render-hash (head folded into the unified
+           streaming hash channel)"))))
+
+(deftest stream-handler-emit-hash-true-stamps-root-marker-equal-to-payload
+  (testing "rf2-9fw2de (Issue 2): :emit-hash? true → the streamed #app root
+            div carries data-rf-render-hash, and it EQUALS the final payload's
+            :rf/render-hash (the same canonical full-document hash)."
+    (let [handler  (ssr-ring/stream-handler
+                     {:on-create  [:rf.test.server/init]
+                      :root-view  [:test/root]
+                      :emit-hash? true
+                      :payload    :rf.ssr.payload/whole-app-db})
+          body     (drain-stream (:body (handler {:uri "/" :request-method :get})))
+          wire     (stream-root-wire-hash body)
+          payload  (stream-payload-hash body)]
+      (is (some? wire)
+          "rf2-9fw2de: :emit-hash? true stamps data-rf-render-hash on the
+           streamed root element (was a no-op before — Issue 2)")
+      (is (some? payload) "final payload carries :rf/render-hash")
+      (is (= wire payload)
+          "streamed root data-rf-render-hash == final payload :rf/render-hash
+           (both the canonical full-document hash)")
+      ;; The marker lands on the #app root div, not buried in a child.
+      (is (re-find #"<div id=\"app\" data-rf-render-hash=\"[0-9a-f]{8}\">" body)
+          "the marker is stamped on the opening #app root div"))))
+
+(deftest stream-handler-emit-hash-false-omits-root-marker
+  (testing "rf2-9fw2de (Issue 2): :emit-hash? false → NO data-rf-render-hash on
+            the streamed shell. Toggling the opt now has an observable effect
+            on the wire (it was a no-op for the HTML path before)."
+    (let [handler  (ssr-ring/stream-handler
+                     {:on-create  [:rf.test.server/init]
+                      :root-view  [:test/root]
+                      :emit-hash? false
+                      :payload    :rf.ssr.payload/whole-app-db})
+          body     (drain-stream (:body (handler {:uri "/" :request-method :get})))]
+      (is (str/includes? body "<div id=\"app\">")
+          "the #app root div is present without a hash marker")
+      (is (not (str/includes? body "data-rf-render-hash"))
+          "rf2-9fw2de: :emit-hash? false → no data-rf-render-hash anywhere in
+           the streamed shell")
+      ;; The payload still carries the hash (the payload slot is hash-driven
+      ;; regardless of :emit-hash?, mirroring the non-streaming handler).
+      (is (some? (stream-payload-hash body))
+          "the final payload still carries :rf/render-hash when :emit-hash?
+           is false (only the wire MARKER is gated by the opt)"))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -629,6 +629,139 @@
             "side-effect counter confirms the fn was invoked exactly once")))))
 
 ;; ===========================================================================
+;; ssr-handler — the unified render hash folds in the HEAD fragment
+;; (rf2-9fw2de)
+;;
+;; Spec 011 §Head/meta contract (§624-626) and §Mismatch detection — head
+;; (§648-650) lock head + body onto the UNIFIED `:rf/render-hash` channel:
+;; the server-rendered HTML carries a single structural hash that covers
+;; BOTH head and body, so the bundled v1 hydration-mismatch detector cannot
+;; tell a head-only divergence from a body-only one but DOES catch either.
+;;
+;; The bug (rf2-9fw2de): the hash was computed over the BODY tree alone, so
+;; a server/client divergence that changed only reg-head output / route head
+;; attrs / explicit head content left `:rf/render-hash` (and the wire
+;; `data-rf-render-hash`) unchanged — the detector silently accepted a head
+;; mismatch. These tests pin the fix: two renders with an IDENTICAL body but
+;; a DIFFERENT head produce DIFFERENT `:rf/render-hash` (and wire) values.
+;; ===========================================================================
+
+(defn- extract-wire+payload-hash
+  "Pull the wire `data-rf-render-hash` AND the payload `:rf/render-hash`
+  out of a rendered SSR document body string. Returns
+  `{:wire <hex-or-nil> :payload <hex-or-nil>}`."
+  [body]
+  (let [wire        (second (re-find #"data-rf-render-hash=\"([0-9a-f]{8})\"" body))
+        payload-edn (second (re-find
+                              #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>"
+                              body))
+        payload     (when payload-edn
+                      ;; Payload EDN may use the `#:rf{…}` namespace-map
+                      ;; shorthand (pr-str collapses `:rf/render-hash` to
+                      ;; `:render-hash`); match either rendering.
+                      (second (re-find #":(?:rf/)?render-hash \"([0-9a-f]{8})\""
+                                       payload-edn)))]
+    {:wire wire :payload payload}))
+
+(deftest ssr-handler-explicit-head-folds-into-render-hash
+  (testing "rf2-9fw2de: identical body + DIFFERENT explicit :head → DIFFERENT
+            :rf/render-hash. The head rides the unified hash channel (Spec
+            011 §624-626/§648-650); a head-only change MUST move the hash."
+    (rf/reg-event-db :init/noop-head (fn [db _] db))
+    (rf/reg-view* :pages/fixed-body (fn [] [:div.body "identical body"]))
+
+    (let [mk      (fn [head]
+                    (ssr-ring/ssr-handler
+                      {:on-create [:init/noop-head]
+                       :root-view [:pages/fixed-body]
+                       :head      head
+                       :payload   :rf.ssr.payload/whole-app-db}))
+          body-a  (:body ((mk "<title>Alpha</title>") {:uri "/" :request-method :get}))
+          body-b  (:body ((mk "<title>Beta</title>")  {:uri "/" :request-method :get}))
+          ha      (extract-wire+payload-hash body-a)
+          hb      (extract-wire+payload-hash body-b)]
+      ;; Sanity: both bodies carry the SAME body content.
+      (is (str/includes? body-a "identical body"))
+      (is (str/includes? body-b "identical body"))
+      ;; Wire == payload within each render (single canonical document hash).
+      (is (some? (:wire ha)) "render A carries a wire hash")
+      (is (some? (:payload ha)) "render A carries a payload hash")
+      (is (= (:wire ha) (:payload ha))
+          "render A: wire data-rf-render-hash == payload :rf/render-hash
+           (both derive from the same canonical full-document hash)")
+      (is (= (:wire hb) (:payload hb))
+          "render B: wire == payload")
+      ;; The load-bearing assertion: a head-only divergence MOVES the hash.
+      (is (not= (:payload ha) (:payload hb))
+          "rf2-9fw2de: identical body but different head → DIFFERENT
+           :rf/render-hash (head folded into the unified hash channel —
+           a head mismatch is no longer silently accepted)"))))
+
+(deftest ssr-handler-route-head-folds-into-render-hash
+  (testing "rf2-9fw2de: identical body + DIFFERENT route-driven reg-head
+            output → DIFFERENT :rf/render-hash. Covers the route-head path
+            (not just explicit :head)."
+    (rf/reg-head :head/variant-a (fn [_db _route] {:title "Route head A"}))
+    (rf/reg-head :head/variant-b (fn [_db _route] {:title "Route head B"}))
+    (rf/reg-route :route/head-a {:doc "A" :path "/" :head :head/variant-a})
+    (rf/reg-route :route/head-b {:doc "B" :path "/" :head :head/variant-b})
+    (rf/reg-event-fx :init/seed-head-a
+      (fn [{rt :rf.db/runtime} _]
+        {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:id :route/head-a})}))
+    (rf/reg-event-fx :init/seed-head-b
+      (fn [{rt :rf.db/runtime} _]
+        {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:id :route/head-b})}))
+    (rf/reg-view* :pages/shared-body (fn [] [:div.body "same body, different head"]))
+
+    (let [mk      (fn [init]
+                    (ssr-ring/ssr-handler
+                      {:on-create [init]
+                       :root-view [:pages/shared-body]
+                       :payload   :rf.ssr.payload/whole-app-db}))
+          body-a  (:body ((mk :init/seed-head-a) {:uri "/" :request-method :get}))
+          body-b  (:body ((mk :init/seed-head-b) {:uri "/" :request-method :get}))
+          ha      (extract-wire+payload-hash body-a)
+          hb      (extract-wire+payload-hash body-b)]
+      (is (str/includes? body-a "<title>Route head A</title>"))
+      (is (str/includes? body-b "<title>Route head B</title>"))
+      (is (= (:wire ha) (:payload ha)) "render A: wire == payload")
+      (is (= (:wire hb) (:payload hb)) "render B: wire == payload")
+      (is (not= (:payload ha) (:payload hb))
+          "rf2-9fw2de: different reg-head title (identical body) → DIFFERENT
+           :rf/render-hash"))))
+
+(deftest ssr-handler-html-body-attrs-fold-into-render-hash
+  (testing "rf2-9fw2de: the head model's :html-attrs / :body-attrs are part
+            of the canonical document hash — a change to them (identical body
+            + identical title) moves :rf/render-hash."
+    (rf/reg-head :head/attrs-a
+                 (fn [_db _route] {:title "T" :html-attrs {:lang "en"}}))
+    (rf/reg-head :head/attrs-b
+                 (fn [_db _route] {:title "T" :html-attrs {:lang "fr"}}))
+    (rf/reg-route :route/attrs-a {:doc "A" :path "/" :head :head/attrs-a})
+    (rf/reg-route :route/attrs-b {:doc "B" :path "/" :head :head/attrs-b})
+    (rf/reg-event-fx :init/seed-attrs-a
+      (fn [{rt :rf.db/runtime} _]
+        {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:id :route/attrs-a})}))
+    (rf/reg-event-fx :init/seed-attrs-b
+      (fn [{rt :rf.db/runtime} _]
+        {:rf.db/runtime (assoc-in (or rt {}) [:rf.runtime/routing :current] {:id :route/attrs-b})}))
+    (rf/reg-view* :pages/attrs-body (fn [] [:div.body "body"]))
+
+    (let [mk      (fn [init]
+                    (ssr-ring/ssr-handler
+                      {:on-create [init]
+                       :root-view [:pages/attrs-body]
+                       :payload   :rf.ssr.payload/whole-app-db}))
+          ha      (extract-wire+payload-hash
+                    (:body ((mk :init/seed-attrs-a) {:uri "/" :request-method :get})))
+          hb      (extract-wire+payload-hash
+                    (:body ((mk :init/seed-attrs-b) {:uri "/" :request-method :get})))]
+      (is (not= (:payload ha) (:payload hb))
+          "rf2-9fw2de: differing :html-attrs (identical body + title) →
+           DIFFERENT :rf/render-hash"))))
+
+;; ===========================================================================
 ;; ssr-handler — Ring → :rf.server/request cofx (rf2-afxhv)
 ;;
 ;; The canonical Ring-adapter ↔ cofx boundary. Per Spec 011 §Request


### PR DESCRIPTION
Fixes rf2-9fw2de. The unified SSR render hash excluded the head fragment, so a head-only server/client divergence (reg-head output, route head attrs, explicit :head content, html/body attrs) did NOT change :rf/render-hash — the bundled v1 hydration-mismatch detector silently accepted a head mismatch, contradicting Spec 011 §624-626/§648-650 (head + body share the unified hash channel).

Issue 1 (High): new lifecycle/render-document-hash computes the canonical structural hash over the FULL document state (body tree + resolved head fragment + html/body attr bags) via a self-describing [:rf/ssr-document …] wrapper hashed with render-tree-hash. The non-streaming pipeline resolves the head BEFORE the hash and uses the document hash for BOTH the root-element data-rf-render-hash and the payload :rf/render-hash. The streaming writer reuses the same document hash (computed once on the request thread) for the final-payload :rf/render-hash.

Issue 2 (Medium): stream-handler advertised :emit-hash? but never emitted data-rf-render-hash in the streamed shell (a public no-op for the HTML path). default-streaming-prefix now stamps the full-document hash onto the #app root div when :emit-hash? is true (Spec 011 §362-363), equal to the final payload :rf/render-hash; the marker is omitted when :emit-hash? is false. The payload always carries the hash regardless of :emit-hash?, mirroring the non-streaming handler.

Spec 011 already states the v1 contract correctly; this brings the implementation into compliance (no spec change).

## Quality gates
- ssr-ring `clojure -M:test` — 141 tests, 622 assertions, 0 failures/errors (includes 6 new tests)
- ssr `clojure -M:test` — 314 tests, 1228 assertions, 0 failures/errors
- `npm run test:cljs` — 6079 tests, 21608 assertions, 0 failures/errors
- mkdocs --strict: not run (no spec change)

New tests: identical body + different head → different :rf/render-hash for ssr-handler (explicit :head, route reg-head, :html-attrs) and stream-handler; plus positive/negative streaming data-rf-render-hash marker tests with marker == final payload hash.