### PR TITLE
fix(mcp-conformance): hermetic runner aborts on escaped port files (rf2-khav7l)

### DIFF
--- a/tools/mcp-conformance/lib/exec-safety.cjs
+++ b/tools/mcp-conformance/lib/exec-safety.cjs
@@ -72,7 +72,19 @@
 //       doesn't exist. Throws on symlink-escape. Returns true if the
 //       file existed and was unlinked, false otherwise.
 //
-// Both helpers are pure-Node, no external deps; they're test-only
+//   safeReadFileInside(candidatePath, allowedRoot, options)
+//     → reads `candidatePath` iff its realpath (or, when the file
+//       doesn't exist, the realpath of its parent directory + basename)
+//       resolves under `realpath(allowedRoot)`. Returns the file
+//       contents (string, `utf8` default — pass `options.encoding` or a
+//       plain encoding string to override) on success, or `null` when
+//       the file doesn't exist. Throws on symlink-escape — the SAME
+//       containment check `safeUnlinkInside` enforces, so a candidate the
+//       cleanup step refused to unlink can NEVER be silently trusted as a
+//       read source (rf2-khav7l: the "refuse-delete-but-trust-read"
+//       split). Read failures other than ENOENT (e.g. EACCES) propagate.
+//
+// All three helpers are pure-Node, no external deps; they're test-only
 // fixtures (bundle-isolated by construction — `tools/mcp-conformance/`
 // is not on any production import path).
 
@@ -240,47 +252,51 @@ function resolveTrustedExe(name, opts) {
 }
 
 // ---------------------------------------------------------------------
-// safeUnlinkInside
+// Shared containment resolver for the fs helpers below.
 // ---------------------------------------------------------------------
 
 /**
- * Unlink `candidatePath` only when its realpath resolves under
- * `realpath(allowedRoot)`. Symlink-safe: if any parent component is a
- * symlink whose target escapes the allowed root, the unlink is
- * rejected. No-op when the file doesn't exist.
+ * Resolve a stable, symlink-followed absolute path for `candidatePath`
+ * and verify it stays under `realpath(allowedRoot)`. This is the SINGLE
+ * containment check both `safeUnlinkInside` (cleanup) and
+ * `safeReadFileInside` (port-file read) share — keeping them in one
+ * place is what closes the rf2-khav7l "refuse-delete-but-trust-read"
+ * split: a candidate the cleanup step refused to unlink resolves to the
+ * exact same escaped path here, so the read MUST refuse it too.
  *
- * Implementation: when the candidate exists we realpath it directly.
- * When it doesn't exist we realpath its *parent directory* + append
- * the basename and check that — this catches the symlinked-parent
- * case even when the file itself is absent (we still wouldn't want to
- * lstat-then-write through a parent symlink in a future call, but
- * here we just bail before unlink would do damage).
+ * When the leaf exists we realpath it directly. When it doesn't, we
+ * realpath the *parent directory* and re-attach the basename — this
+ * catches a symlinked parent (e.g. `<fixture>/.shadow-cljs` being a
+ * symlink whose target escapes the fixture) even when the leaf is
+ * absent.
  *
  * @param {string} candidatePath
  * @param {string} allowedRoot
- * @returns {boolean} true if the file existed and was unlinked,
- *                    false otherwise (file didn't exist).
- * @throws  If the candidate's realpath escapes the allowed root.
+ * @param {string} opName  caller name, for the error message.
+ * @returns {{ leafExists: boolean, resolvedLeaf: (string|null) }}
+ *          `resolvedLeaf` is null only when the parent directory itself
+ *          doesn't exist (so the leaf definitely doesn't either).
+ * @throws  If inputs are empty/missing, if `allowedRoot` is unreadable,
+ *          or if the candidate's realpath escapes the allowed root.
  */
-function safeUnlinkInside(candidatePath, allowedRoot) {
+function resolveContainedLeaf(candidatePath, allowedRoot, opName) {
   if (typeof candidatePath !== 'string' || candidatePath.length === 0) {
-    throw new Error('safeUnlinkInside: candidatePath must be a non-empty string');
+    throw new Error(`${opName}: candidatePath must be a non-empty string`);
   }
   if (typeof allowedRoot !== 'string' || allowedRoot.length === 0) {
-    throw new Error('safeUnlinkInside: allowedRoot must be a non-empty string');
+    throw new Error(`${opName}: allowedRoot must be a non-empty string`);
   }
   const allowedRootReal = realpathSyncOrNull(allowedRoot);
   if (!allowedRootReal) {
     throw new Error(
-      'safeUnlinkInside: allowedRoot does not exist or is unreadable: ' +
-        allowedRoot,
+      `${opName}: allowedRoot does not exist or is unreadable: ` + allowedRoot,
     );
   }
 
-  // lstat first: if the candidate doesn't exist at all, we're done.
-  // Using lstat (not stat) so a broken symlink at the leaf is still
-  // visible — we want to refuse to unlink even a dangling link if
-  // its location is outside the allowed root.
+  // lstat first: if the candidate doesn't exist at all, we still resolve
+  // the parent so a symlinked-parent escape is caught even with the leaf
+  // absent. Using lstat (not stat) so a broken/escaping symlink at the
+  // leaf is still visible.
   let leafExists;
   try {
     fs.lstatSync(candidatePath);
@@ -293,12 +309,6 @@ function safeUnlinkInside(candidatePath, allowedRoot) {
     }
   }
 
-  // Resolve a stable absolute path for the candidate. When the leaf
-  // exists we can realpath it directly; when it doesn't we realpath
-  // the parent directory (which MUST exist for unlink to be meaningful)
-  // and re-attach the basename. The parent-realpath path catches a
-  // symlinked parent — e.g. `<fixture>/.shadow-cljs` being a symlink
-  // to `/etc` — even when the leaf is absent.
   const dir = path.dirname(candidatePath);
   const base = path.basename(candidatePath);
   const parentReal = realpathSyncOrNull(dir);
@@ -317,24 +327,90 @@ function safeUnlinkInside(candidatePath, allowedRoot) {
 
   if (!resolvedLeaf) {
     // Parent directory itself doesn't exist; the file definitely
-    // doesn't either. Treat as no-op.
-    return false;
+    // doesn't either. No containment violation possible.
+    return { leafExists: false, resolvedLeaf: null };
   }
 
   if (!isPathInside(resolvedLeaf, allowedRootReal)) {
     throw new Error(
-      `safeUnlinkInside: refusing to unlink ${candidatePath} — resolved ` +
+      `${opName}: refusing to operate on ${candidatePath} — resolved ` +
         `path ${resolvedLeaf} is outside allowed root ${allowedRootReal} ` +
-        `(rf2-33vvc symlink-escape accident-gating).`,
+        `(rf2-33vvc / rf2-khav7l symlink-escape accident-gating).`,
     );
   }
 
+  return { leafExists, resolvedLeaf };
+}
+
+// ---------------------------------------------------------------------
+// safeUnlinkInside
+// ---------------------------------------------------------------------
+
+/**
+ * Unlink `candidatePath` only when its realpath resolves under
+ * `realpath(allowedRoot)`. Symlink-safe: if any parent component is a
+ * symlink whose target escapes the allowed root, the unlink is
+ * rejected. No-op when the file doesn't exist.
+ *
+ * @param {string} candidatePath
+ * @param {string} allowedRoot
+ * @returns {boolean} true if the file existed and was unlinked,
+ *                    false otherwise (file didn't exist).
+ * @throws  If the candidate's realpath escapes the allowed root.
+ */
+function safeUnlinkInside(candidatePath, allowedRoot) {
+  const { leafExists } = resolveContainedLeaf(
+    candidatePath,
+    allowedRoot,
+    'safeUnlinkInside',
+  );
   if (!leafExists) return false;
   fs.unlinkSync(candidatePath);
   return true;
 }
 
+// ---------------------------------------------------------------------
+// safeReadFileInside
+// ---------------------------------------------------------------------
+
+/**
+ * Read `candidatePath` only when its realpath resolves under
+ * `realpath(allowedRoot)`. Symlink-safe via the SAME containment check
+ * `safeUnlinkInside` enforces (`resolveContainedLeaf`), so a candidate
+ * the cleanup step refused to unlink cannot be silently trusted as a
+ * read source — the rf2-khav7l "refuse-delete-but-trust-read" split.
+ *
+ * @param {string} candidatePath
+ * @param {string} allowedRoot
+ * @param {(string|{encoding?: string})} [options]  Encoding string (or
+ *        an options object with `encoding`). Defaults to `'utf8'`.
+ * @returns {(string|Buffer|null)} the file contents on success, or
+ *          `null` when the file doesn't exist.
+ * @throws  If the candidate's realpath escapes the allowed root, or on
+ *          a read error other than ENOENT.
+ */
+function safeReadFileInside(candidatePath, allowedRoot, options) {
+  const { leafExists } = resolveContainedLeaf(
+    candidatePath,
+    allowedRoot,
+    'safeReadFileInside',
+  );
+  if (!leafExists) return null;
+  const readOpts =
+    typeof options === 'string' ? { encoding: options } : { encoding: 'utf8', ...options };
+  try {
+    return fs.readFileSync(candidatePath, readOpts);
+  } catch (e) {
+    // A race could remove the file between the containment check and the
+    // read; treat a now-missing file as "not present" rather than fatal.
+    // Any other error (EACCES, EISDIR, …) is genuine — propagate it.
+    if (e && e.code === 'ENOENT') return null;
+    throw e;
+  }
+}
+
 module.exports = {
   resolveTrustedExe,
   safeUnlinkInside,
+  safeReadFileInside,
 };

--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -15,6 +15,7 @@
     "test:exec-safety": "node --test test/exec-safety.test.cjs",
     "test:runner-watchdog": "node --test test/runner-watchdog.test.cjs",
     "test:hermetic-setup-timeout": "node --test test/hermetic-setup-timeout.test.cjs",
+    "test:port-file-escape": "node --test test/port-file-escape.test.cjs",
     "test": "node scripts/test-all.cjs"
   },
   "dependencies": {

--- a/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
+++ b/tools/mcp-conformance/scripts/run-live-re-frame2-pair-overflow-hermetic.cjs
@@ -69,7 +69,11 @@ const net = require('node:net');
 const path = require('node:path');
 const os = require('node:os');
 const crossSpawn = require('cross-spawn');
-const { resolveTrustedExe, safeUnlinkInside } = require('../lib/exec-safety.cjs');
+const {
+  resolveTrustedExe,
+  safeUnlinkInside,
+  safeReadFileInside,
+} = require('../lib/exec-safety.cjs');
 
 // We use `cross-spawn` instead of Node's `child_process.spawn` for the
 // two Windows-toolchain spawn sites (`npm` install + `npx shadow-cljs
@@ -248,20 +252,63 @@ function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-function readPortFile() {
+// Discriminate a containment-escape refusal (a candidate whose realpath
+// resolves OUTSIDE FIXTURE_DIR) from a benign fs failure (EACCES, EBUSY
+// — a Windows lock, a permission quirk). The exec-safety helpers tag
+// every escape with the `symlink-escape accident-gating` marker; benign
+// failures carry an errno `code` and no such marker. rf2-khav7l: only an
+// escape is fatal — a transient lock must not abort the whole run.
+function isContainmentEscape(e) {
+  return !!(e && typeof e.message === 'string' &&
+    e.message.includes('symlink-escape accident-gating'));
+}
+
+// `candidates` + `fixtureDir` are parameterised (defaulting to the
+// module constants) so the rf2-khav7l call-site regression test can drive
+// this exact function against a temp fixture with a symlinked
+// `.shadow-cljs` — proving the poller refuses an external port file
+// without booting shadow-cljs + Chromium.
+function readPortFile(
+  candidates = NREPL_PORT_FILE_CANDIDATES,
+  fixtureDir = FIXTURE_DIR,
+) {
   // Walk every candidate path; return `{port, source}` for the first
   // file that parses to a finite integer. The `source` string is used
   // for diagnostics so a successful read tells you *which* path
   // satisfied the wait — useful when shadow-cljs's default cache-root
   // moves between versions.
-  for (const p of NREPL_PORT_FILE_CANDIDATES) {
+  //
+  // Per rf2-khav7l: route the read through `safeReadFileInside` — the
+  // SAME containment check the cleanup loop's `safeUnlinkInside` uses.
+  // Pre-fix this did a raw `fs.readFileSync` with NO realpath check, so
+  // a candidate (or candidate parent) symlinked OUTSIDE FIXTURE_DIR that
+  // the cleanup step CORRECTLY refused to delete could still be trusted
+  // as the live nREPL source — a stale external `nrepl.port` could then
+  // satisfy the port-file wait and steer the inner conformance tests at
+  // an unrelated runtime (false-red / false-green). `safeReadFileInside`
+  // THROWS on a containment escape; we let that propagate so an escaped
+  // candidate is a FATAL orchestration error, not a silently-trusted
+  // read. A candidate that simply doesn't exist yet returns `null` —
+  // try the next.
+  for (const p of candidates) {
+    let txt;
     try {
-      const txt = fs.readFileSync(p, 'utf8').trim();
-      const n = parseInt(txt, 10);
-      if (Number.isFinite(n)) return { port: n, source: p };
-    } catch {
-      // try next
+      const contents = safeReadFileInside(p, fixtureDir);
+      if (contents == null) continue; // not present yet — try next
+      txt = contents.trim();
+    } catch (e) {
+      // A containment escape (symlinked candidate / parent that resolves
+      // outside FIXTURE_DIR) is a fatal orchestration error — DO NOT fall
+      // through and trust the file. Re-throw with context so the caller's
+      // catch surfaces it as exit 2.
+      throw new Error(
+        `refusing to read nREPL port candidate ${p}: ${e.message} ` +
+          '(rf2-khav7l: an escaped/refused port file must not be trusted ' +
+          'as the live nREPL source).',
+      );
     }
+    const n = parseInt(txt, 10);
+    if (Number.isFinite(n)) return { port: n, source: p };
   }
   return null;
 }
@@ -605,11 +652,29 @@ async function main() {
   // symlinked candidate (or symlinked parent directory) that escapes
   // FIXTURE_DIR can't be coerced into deleting a file outside the
   // fixture tree.
+  //
+  // Per rf2-khav7l: a symlink-ESCAPE refusal on a load-bearing stale
+  // port candidate is FATAL — we do NOT log-and-continue and then later
+  // read that same escaped file as the live nREPL source. (Pre-fix the
+  // cleanup logged "continuing" on the escape and `readPortFile` then
+  // raw-read the same path with no containment check.) A BENIGN unlink
+  // failure (EACCES / EBUSY — a Windows file lock, a permission quirk)
+  // is still tolerated: it doesn't widen trust, and the read path now
+  // re-checks containment regardless. `isContainmentEscape` discriminates
+  // the two so a transient lock doesn't abort the whole run while a real
+  // escape does.
   for (const p of NREPL_PORT_FILE_CANDIDATES) {
     try {
       const removed = safeUnlinkInside(p, FIXTURE_DIR);
       if (removed) log(`removed stale port file ${p}`);
     } catch (e) {
+      if (isContainmentEscape(e)) {
+        throw new Error(
+          `stale nREPL port candidate ${p} escapes FIXTURE_DIR ` +
+            `(${e.message}); aborting — the runner must not continue and ` +
+            'later trust a port file it refused to clean (rf2-khav7l).',
+        );
+      }
       log(`could not remove stale port file ${p} (${e.message}); continuing`);
     }
   }
@@ -617,6 +682,12 @@ async function main() {
     const removed = safeUnlinkInside(FIXTURE_BUNDLE_PATH, FIXTURE_DIR);
     if (removed) log(`removed stale fixture bundle ${FIXTURE_BUNDLE_PATH}`);
   } catch (e) {
+    if (isContainmentEscape(e)) {
+      throw new Error(
+        `stale fixture bundle ${FIXTURE_BUNDLE_PATH} escapes FIXTURE_DIR ` +
+          `(${e.message}); aborting (rf2-khav7l).`,
+      );
+    }
     log(`could not remove stale fixture bundle ${FIXTURE_BUNDLE_PATH} (${e.message}); continuing`);
   }
 
@@ -967,4 +1038,16 @@ if (require.main === module) {
 // the async, timeout-bounded setup-command spawn; the test drives it
 // against a never-exiting child to prove a hung setup command is killed
 // within `SETUP_COMMAND_TIMEOUT_MS` instead of wedging the event loop.
-module.exports = { runTrusted, SETUP_COMMAND_TIMEOUT_MS };
+//
+// `readPortFile` + `isContainmentEscape` are exported for the rf2-khav7l
+// call-site regression harness (`port-file-escape.test.cjs`): it drives
+// `readPortFile` against a temp fixture whose `.shadow-cljs` is symlinked
+// outside, proving the poller REFUSES an external port file (throws)
+// rather than raw-reading it — the read-side guarantee that lets the
+// cleanup loop's escape-refusal be safe.
+module.exports = {
+  runTrusted,
+  SETUP_COMMAND_TIMEOUT_MS,
+  readPortFile,
+  isContainmentEscape,
+};

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -56,6 +56,10 @@ const TESTS = [
     argv: ['--test', 'test/hermetic-setup-timeout.test.cjs'],
   },
   {
+    name: 'hermetic port-file escape refusal (rf2-khav7l)',
+    argv: ['--test', 'test/port-file-escape.test.cjs'],
+  },
+  {
     name: 're-frame2-pair-mcp end-to-end',
     argv: ['test/end-to-end-re-frame2-pair.cjs'],
   },

--- a/tools/mcp-conformance/test/exec-safety.test.cjs
+++ b/tools/mcp-conformance/test/exec-safety.test.cjs
@@ -30,7 +30,11 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { resolveTrustedExe, safeUnlinkInside } = require('../lib/exec-safety.cjs');
+const {
+  resolveTrustedExe,
+  safeUnlinkInside,
+  safeReadFileInside,
+} = require('../lib/exec-safety.cjs');
 
 // ---------------------------------------------------------------------
 // Test scratch dir
@@ -367,6 +371,150 @@ test('safeUnlinkInside: rejects empty / missing inputs', () => {
     assert.throws(() => safeUnlinkInside('/whatever', ''), /allowedRoot/);
     assert.throws(
       () => safeUnlinkInside('/whatever', '/this/path/does/not/exist/anywhere'),
+      /does not exist/,
+    );
+  } finally {
+    rmrf(root);
+  }
+});
+
+// ---------------------------------------------------------------------
+// safeReadFileInside (rf2-khav7l)
+//
+// The read-side counterpart to safeUnlinkInside: a port-file candidate
+// the cleanup step refused to UNLINK (because its realpath escapes the
+// allowed root) must ALSO be refused on READ — closing the
+// "refuse-delete-but-trust-read" split. Both helpers share the same
+// `resolveContainedLeaf` containment check, so a candidate that throws
+// from safeUnlinkInside throws identically from safeReadFileInside.
+// ---------------------------------------------------------------------
+
+test('safeReadFileInside: reads file inside allowed root', () => {
+  const root = freshTmpDir('read-ok');
+  try {
+    const target = path.join(root, 'nrepl.port');
+    fs.writeFileSync(target, '54321');
+    const contents = safeReadFileInside(target, root);
+    assert.equal(contents, '54321');
+  } finally {
+    rmrf(root);
+  }
+});
+
+test('safeReadFileInside: returns null when file does not exist', () => {
+  const root = freshTmpDir('read-missing');
+  try {
+    const target = path.join(root, 'never-existed.port');
+    assert.equal(safeReadFileInside(target, root), null);
+  } finally {
+    rmrf(root);
+  }
+});
+
+test('safeReadFileInside: honors an encoding-string option', () => {
+  const root = freshTmpDir('read-encoding');
+  try {
+    const target = path.join(root, 'nrepl.port');
+    fs.writeFileSync(target, 'abc');
+    const buf = safeReadFileInside(target, root, null); // null -> default utf8
+    assert.equal(buf, 'abc');
+    const raw = safeReadFileInside(target, root, { encoding: null });
+    assert.equal(Buffer.isBuffer(raw), true, 'encoding:null returns a Buffer');
+    assert.equal(raw.toString('utf8'), 'abc');
+  } finally {
+    rmrf(root);
+  }
+});
+
+test('safeReadFileInside: rejects when realpath escapes allowed root (symlinked leaf)', { skip: process.platform === 'win32' }, () => {
+  // The exact rf2-khav7l shape: a leaf `nrepl.port` inside the allowed
+  // root that is itself a symlink to an EXTERNAL port file. A naive
+  // `fs.readFileSync` would follow the link and trust the external
+  // port; safeReadFileInside must refuse, the same way safeUnlinkInside
+  // refuses to delete it.
+  const root = freshTmpDir('read-escape-leaf');
+  const outsideDir = freshTmpDir('read-escape-outside');
+  try {
+    const externalPort = path.join(outsideDir, 'nrepl.port');
+    fs.writeFileSync(externalPort, '9999'); // a stale EXTERNAL runtime's port
+    const candidate = path.join(root, 'nrepl.port');
+    const linked = trySymlink(externalPort, candidate);
+    if (!linked) return; // platform/permissions — soft-skip
+
+    assert.throws(
+      () => safeReadFileInside(candidate, root),
+      /symlink-escape/,
+    );
+  } finally {
+    rmrf(root);
+    rmrf(outsideDir);
+  }
+});
+
+test('safeReadFileInside: rejects when parent dir is a symlink escaping root', { skip: process.platform === 'win32' }, () => {
+  // The orchestrator's load-bearing case: `<root>/.shadow-cljs` is a
+  // symlink to an external dir carrying a stale `nrepl.port`. The
+  // candidate path APPEARS to live under the allowed root, but realpath
+  // resolves the parent symlink to outside it. The read must refuse —
+  // otherwise the runner trusts an external runtime's port.
+  const root = freshTmpDir('read-escape-parent');
+  const outsideDir = freshTmpDir('read-escape-parent-outside');
+  try {
+    const realSide = path.join(outsideDir, 'shadow-cljs');
+    fs.mkdirSync(realSide);
+    const externalPort = path.join(realSide, 'nrepl.port');
+    fs.writeFileSync(externalPort, '9999');
+
+    const symlinkedParent = path.join(root, '.shadow-cljs');
+    const linked = trySymlink(realSide, symlinkedParent);
+    if (!linked) return; // soft-skip
+
+    const candidate = path.join(symlinkedParent, 'nrepl.port');
+    assert.throws(
+      () => safeReadFileInside(candidate, root),
+      /symlink-escape/,
+    );
+  } finally {
+    rmrf(root);
+    rmrf(outsideDir);
+  }
+});
+
+test('safeReadFileInside: a candidate refused by safeUnlinkInside is also refused on read (rf2-khav7l parity)', { skip: process.platform === 'win32' }, () => {
+  // The crux of rf2-khav7l: prove the SAME escaped candidate that
+  // safeUnlinkInside refuses to delete is ALSO refused by
+  // safeReadFileInside. A future cleanup refactor cannot reintroduce the
+  // "refuse delete but trust read" split as long as this parity holds.
+  const root = freshTmpDir('read-unlink-parity');
+  const outsideDir = freshTmpDir('read-unlink-parity-outside');
+  try {
+    const realSide = path.join(outsideDir, 'shadow-cljs');
+    fs.mkdirSync(realSide);
+    const externalPort = path.join(realSide, 'nrepl.port');
+    fs.writeFileSync(externalPort, '9999');
+
+    const symlinkedParent = path.join(root, '.shadow-cljs');
+    const linked = trySymlink(realSide, symlinkedParent);
+    if (!linked) return; // soft-skip
+
+    const candidate = path.join(symlinkedParent, 'nrepl.port');
+    assert.throws(() => safeUnlinkInside(candidate, root), /symlink-escape/);
+    assert.throws(() => safeReadFileInside(candidate, root), /symlink-escape/);
+    // The external port file MUST still exist (neither op touched it).
+    assert.equal(fs.existsSync(externalPort), true);
+  } finally {
+    rmrf(root);
+    rmrf(outsideDir);
+  }
+});
+
+test('safeReadFileInside: rejects empty / missing inputs', () => {
+  const root = freshTmpDir('read-bad-inputs');
+  try {
+    assert.throws(() => safeReadFileInside('', root), /candidatePath/);
+    assert.throws(() => safeReadFileInside('/whatever', ''), /allowedRoot/);
+    assert.throws(
+      () => safeReadFileInside('/whatever', '/this/path/does/not/exist/anywhere'),
       /does not exist/,
     );
   } finally {

--- a/tools/mcp-conformance/test/port-file-escape.test.cjs
+++ b/tools/mcp-conformance/test/port-file-escape.test.cjs
@@ -1,0 +1,195 @@
+// Call-site regression for the hermetic orchestrator's port-file poller
+// (rf2-khav7l).
+//
+// Uses Node's built-in `node:test` (same posture as
+// `exec-safety.test.cjs` / `hermetic-setup-timeout.test.cjs` — no extra
+// dev-dependency).
+//
+// ## The bug this pins
+//
+// `scripts/run-live-re-frame2-pair-overflow-hermetic.cjs` wipes stale
+// nREPL port files through `safeUnlinkInside`, which CORRECTLY refuses
+// (throws) when a candidate (or its parent dir) is a symlink whose
+// realpath escapes FIXTURE_DIR. Pre-fix, the cleanup logged that refusal
+// and CONTINUED; the poller's `readPortFile` then raw-read the SAME
+// candidate with a bare `fs.readFileSync` and NO containment check. A
+// stale `nrepl.port` living behind a symlinked `.shadow-cljs` (or any
+// escaped candidate) could therefore satisfy the port-file wait and
+// steer the inner conformance tests at an UNRELATED runtime — false-red
+// or false-green live conformance, undermining the accident-gating the
+// runner exists to provide ("refuse delete but trust read" split).
+//
+// ## What this test drives
+//
+// It requires the orchestrator AS A MODULE (the auto-run is guarded
+// behind `require.main === module`, so requiring it does NOT boot
+// shadow-cljs / Chromium) and calls the exported `readPortFile` directly
+// against a temp fixture whose `.shadow-cljs` is symlinked to an external
+// dir carrying a stale `nrepl.port`. It asserts:
+//
+//   1. `readPortFile` THROWS on the escaped candidate (does NOT return
+//      the external port) — the read path rejects the same escape the
+//      cleanup step refused to delete.
+//   2. the thrown error is classified as a containment escape by
+//      `isContainmentEscape` — so the cleanup loop's "abort on escape"
+//      branch (which discriminates escape from benign EACCES/EBUSY) is
+//      driven by the same signal.
+//   3. an in-fixture `nrepl.port` (no symlink) IS read normally — the
+//      fix doesn't break the happy path.
+//
+// Symlink creation requires elevated rights on Windows; that arm
+// soft-skips there (matching `exec-safety.test.cjs`).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ORCH = path.join(
+  __dirname,
+  '..',
+  'scripts',
+  'run-live-re-frame2-pair-overflow-hermetic.cjs',
+);
+
+// Requiring is side-effect-free: the orchestrator guards its auto-run
+// behind `require.main === module`, so no shadow-cljs / Chromium spawns.
+const { readPortFile, isContainmentEscape } = require(ORCH);
+
+function freshTmpDir(label) {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), `rf2-khav7l-${label}-`));
+  // Realpath up-front: on macOS `os.tmpdir()` is itself a symlink.
+  return fs.realpathSync(base);
+}
+
+function rmrf(p) {
+  try {
+    fs.rmSync(p, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+function trySymlink(target, link, type) {
+  try {
+    fs.symlinkSync(target, link, type);
+    return link;
+  } catch {
+    return null;
+  }
+}
+
+test('readPortFile: refuses an external port file behind a symlinked .shadow-cljs (rf2-khav7l)', { skip: process.platform === 'win32' }, () => {
+  const fixture = freshTmpDir('fixture');
+  const outsideDir = freshTmpDir('outside');
+  try {
+    // The hostile shape: `<fixture>/.shadow-cljs` is a symlink to an
+    // external dir that carries a stale port file pointing at an
+    // UNRELATED runtime.
+    const realShadow = path.join(outsideDir, 'shadow-cljs');
+    fs.mkdirSync(realShadow);
+    const externalPort = path.join(realShadow, 'nrepl.port');
+    fs.writeFileSync(externalPort, '9999');
+
+    const symlinkedParent = path.join(fixture, '.shadow-cljs');
+    const linked = trySymlink(realShadow, symlinkedParent, 'dir');
+    if (!linked) return; // platform/permissions — soft-skip
+
+    const candidate = path.join(symlinkedParent, 'nrepl.port');
+    // Drive the EXACT poller function with this candidate as its first
+    // (and only) candidate + the fixture as the allowed root.
+    let thrown = null;
+    assert.throws(
+      () => readPortFile([candidate], fixture),
+      (err) => {
+        thrown = err;
+        // Must name the candidate and the rf2-khav7l rationale.
+        assert.match(err.message, /khav7l/);
+        return true;
+      },
+    );
+    // The poller did NOT return the external port — it threw.
+    // The cleanup loop's escape-vs-benign discriminator must classify
+    // this as a containment escape (so it ABORTS, not log-and-continues).
+    assert.equal(
+      isContainmentEscape(thrown),
+      true,
+      'an escaped candidate must classify as a containment escape',
+    );
+    // And the external file is untouched — we never read or deleted it.
+    assert.equal(fs.existsSync(externalPort), true);
+  } finally {
+    rmrf(fixture);
+    rmrf(outsideDir);
+  }
+});
+
+test('readPortFile: refuses an external port file behind a symlinked LEAF (rf2-khav7l)', { skip: process.platform === 'win32' }, () => {
+  const fixture = freshTmpDir('fixture-leaf');
+  const outsideDir = freshTmpDir('outside-leaf');
+  try {
+    const externalPort = path.join(outsideDir, 'nrepl.port');
+    fs.writeFileSync(externalPort, '9999');
+    // The candidate file itself is a symlink to the external port.
+    const candidate = path.join(fixture, 'nrepl.port');
+    const linked = trySymlink(externalPort, candidate);
+    if (!linked) return; // soft-skip
+
+    assert.throws(
+      () => readPortFile([candidate], fixture),
+      /khav7l/,
+    );
+    assert.equal(fs.existsSync(externalPort), true);
+  } finally {
+    rmrf(fixture);
+    rmrf(outsideDir);
+  }
+});
+
+test('readPortFile: reads a genuine in-fixture port file (happy path unbroken)', () => {
+  const fixture = freshTmpDir('fixture-ok');
+  try {
+    const shadowDir = path.join(fixture, '.shadow-cljs');
+    fs.mkdirSync(shadowDir);
+    const portFile = path.join(shadowDir, 'nrepl.port');
+    fs.writeFileSync(portFile, '54321\n');
+
+    const hit = readPortFile([portFile], fixture);
+    assert.notEqual(hit, null);
+    assert.equal(hit.port, 54321);
+    assert.equal(hit.source, portFile);
+  } finally {
+    rmrf(fixture);
+  }
+});
+
+test('readPortFile: skips a missing candidate and falls through to a present one', () => {
+  const fixture = freshTmpDir('fixture-fallthrough');
+  try {
+    const missing = path.join(fixture, '.shadow-cljs', 'nrepl.port');
+    const present = path.join(fixture, '.nrepl-port');
+    fs.writeFileSync(present, '4711');
+
+    // First candidate is absent (parent dir doesn't even exist); the
+    // poller must skip it and read the present one — NOT throw.
+    const hit = readPortFile([missing, present], fixture);
+    assert.notEqual(hit, null);
+    assert.equal(hit.port, 4711);
+    assert.equal(hit.source, present);
+  } finally {
+    rmrf(fixture);
+  }
+});
+
+test('readPortFile: returns null when no candidate is present yet', () => {
+  const fixture = freshTmpDir('fixture-none');
+  try {
+    const missing = path.join(fixture, '.shadow-cljs', 'nrepl.port');
+    assert.equal(readPortFile([missing], fixture), null);
+  } finally {
+    rmrf(fixture);
+  }
+});


### PR DESCRIPTION
Senior-review P2 (rf2-khav7l): the hermetic live runner continued after a symlink-escape cleanup refusal and later read the same escaped nREPL port candidate (raw fs.readFileSync, no containment check) — trusting a file it had just refused to clean. A stale external nrepl.port behind a symlinked .shadow-cljs could satisfy the port-file wait and steer the inner conformance tests at an unrelated runtime (false-red / false-green).

Fix: new safeReadFileInside in lib/exec-safety.cjs shares the SAME containment check as safeUnlinkInside (extracted resolveContainedLeaf), so a candidate refused on delete is refused on read. readPortFile now routes through it and re-throws on a containment escape (fatal orchestration error, exit 2). The stale-port cleanup loop ABORTS on a containment escape (vs benign EACCES/EBUSY, which still log-and-continue) so the runner never proceeds to trust an escaped file. Defence in depth: cleanup-abort + read-refusal both reject the same escape.

New test test/port-file-escape.test.cjs drives the exported readPortFile against a fixture whose .shadow-cljs is symlinked outside with an external nrepl.port — asserts the poller throws (does NOT return the external port), classifies as a containment escape, and the happy/fallthrough/null paths are unbroken. exec-safety.test.cjs gains safeReadFileInside coverage incl. a refuse-delete/refuse-read parity test so a future cleanup refactor cannot reintroduce the split. Both registered in scripts/test-all.cjs.

All changes confined to tools/mcp-conformance. Symlink test arms soft-skip on Windows (Node symlinkSync needs elevation); verified locally via a Windows directory junction that read + unlink both refuse the escape and the external file stays intact.

## Quality gates
- node --test test/exec-safety.test.cjs test/port-file-escape.test.cjs — pass (15 pass, 9 symlink arms soft-skip on Windows)
- node --test test/runner-watchdog.test.cjs test/hermetic-setup-timeout.test.cjs — pass (sibling orchestrator contracts unaffected)
- npm run test:mcp-conformance — ALL MCP-CONFORMANCE GATES GREEN (all 6 gates exit=0, incl. new 'hermetic port-file escape refusal (rf2-khav7l)')
- Junction-based local verification: readPortFile + safeReadFileInside + safeUnlinkInside all refuse a junction-escaped .shadow-cljs/nrepl.port; external file intact