### PR TITLE
fix(adapters): dispose/reinstall clears sub-cache state — no stale cross-lifecycle reads (rf2-ghfkkk)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -239,6 +239,14 @@
   (suite/assert-view-unmount-emits-on-react-hook-teardown
     {:substrate-kw :helix :name "Helix"}))
 
+;; rf2-ghfkkk — a registered view returning a VOID DOM root (<input>) mounts
+;; + unmounts with no React void-element warning/error, and still fires
+;; exactly one :rf.view/unmounted (the unmount sentinel rides as a Fragment
+;; sibling, not a child of the void element). Probe built in the suite.
+(deftest void-root-view-unmount-no-warning
+  (suite/assert-void-root-view-unmount-no-warning
+    {:substrate-kw :helix :name "Helix"}))
+
 ;; ---- regression: frame-provider under the idiomatic `$` trailing-children shape (rf2-9ok1s / rf2-z7hfp / rf2-7kii2) -
 ;;
 ;; Pins the moved-up seam (rf2-z7hfp) AND the unified trailing-children

--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -55,6 +55,7 @@
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.atom-container :as atom-container]
+            [re-frame.subs.cache :as subs-cache]
             [re-frame.frame :as frame]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -72,13 +73,17 @@
   ;; a handful of times per case.
   ;;
   ;; rf2-pyp3n: IDeref ONLY — deliberately no IWatchable / no disposal
-  ;; protocol. The sub-cache's dispose/ref-count path therefore works on the
-  ;; JVM (interop.clj implements dispose by reaction identity) but is a
+  ;; protocol. The sub-cache's per-reaction dispose path therefore works on
+  ;; the JVM (interop.clj implements dispose by reaction identity) but is a
   ;; SILENT no-op under CLJS (this adapter withholds the :adapter/dispose! /
   ;; :adapter/add-on-dispose! late-bind hooks — see the routing block at the
   ;; foot of this ns — and interop.cljs routes through them, so unregistered
-  ;; hooks no-op). Acceptable for the test adapter: the derived value holds
-  ;; no host resources, so there is nothing for a dispose walk to release.
+  ;; hooks no-op). The derived value holds no host resources, so the
+  ;; PER-REACTION dispose has nothing to release. But the CACHE ENTRY itself
+  ;; (the `{:reaction … :ref-count n}` slot held on the frame) DOES survive a
+  ;; reaction that never auto-disposes — so `dispose-adapter!` MUST reset
+  ;; every live frame's sub-cache to clear stale entries + ref-counts across
+  ;; a dispose/reinstall cycle (rf2-ghfkkk). See `dispose-adapter!`.
   (reify
     #?(:clj clojure.lang.IDeref :cljs IDeref)
     (#?(:clj deref :cljs -deref) [_]
@@ -326,17 +331,35 @@
   ;; cycle. Matches plain-atom's dispose-adapter! (a no-op that leaves the
   ;; emitter alone).
   ;;
-  ;; rf2-pyp3n: this drains active-mounts (the host-resource MUST) but does
-  ;; NOT walk per-frame sub-caches the way the React adapters do via
-  ;; `spine/dispose-frame-sub-caches!` — this adapter is CLJC and the spine
-  ;; is CLJS-only. Acceptable because test-react's `make-derived-value` holds
-  ;; no host resources (plain IDeref reify); nothing for the walk to dispose.
+  ;; rf2-ghfkkk: this ALSO walks every live frame's per-frame sub-cache and
+  ;; resets it, the externally-visible counterpart of the React adapters'
+  ;; `spine/dispose-frame-sub-caches!` (Spec 006 §Adapter disposal lifecycle
+  ;; MUST 1 + §Lifetime contract — frame disposal §Adapter symmetry). The
+  ;; React-adapter walk is CLJS-only (the spine is CLJS-only); test-react is
+  ;; CLJC, so it routes through the CLJC-safe shared helper
+  ;; `subs-cache/clear-all-frame-sub-caches!` instead. Why this matters even
+  ;; though `make-derived-value` holds no host resource (plain IDeref reify,
+  ;; so the per-reaction dispose is a CLJS no-op): the CACHE ENTRIES + REF-
+  ;; COUNTS live on the FRAME, not the reaction, and a reaction that never
+  ;; auto-disposes leaves its `{:reaction … :ref-count n}` slot in the frame's
+  ;; sub-cache. Without this reset a test process carries stale slots + stale
+  ;; ref-counts across a dispose/reinstall cycle — a later subscribe reads the
+  ;; stale cached value instead of recomputing from fresh state, breaking
+  ;; isolation. The reset clears the slots so the next subscribe is a fresh
+  ;; cache miss that recomputes. (The helper fires BEFORE the active-mounts
+  ;; drain below, but order is immaterial — they touch disjoint state.)
+  ;;
   ;; Drain flat over active-mounts: children are themselves registered in
   ;; active-mounts (mount-tree! adds every mount, parent or child), so a flat
   ;; walk drains the whole forest without recursing through :children. We do
   ;; NOT route through the public unmount thunk (it would throw on the
   ;; currently-rendering? / render-depth guard) — forced teardown is the
   ;; escape hatch the guard deliberately cannot block.
+  ;;
+  ;; rf2-ghfkkk — dispose every live frame's sub-cache (the reactive-
+  ;; subscription MUST). CLJC-safe shared helper, equal semantics to the
+  ;; React adapters' spine walk.
+  (subs-cache/clear-all-frame-sub-caches!)
   (doseq [mount @active-mounts]
     (when @(:mounted? mount)
       (log-phase! mount :forced-teardown)

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_dispose_sub_cache_cljs_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_dispose_sub_cache_cljs_test.cljc
@@ -1,0 +1,101 @@
+(ns re-frame.adapter.test-react-dispose-sub-cache-cljs-test
+  "CLJS-gate companion to the rf2-ghfkkk High finding's coverage in
+  `re-frame.adapter.test-react-test`.
+
+  The substantive assertion lives in both: test-react's `dispose-adapter!`
+  MUST clear every live frame's per-frame sub-cache (entries + ref-counts),
+  the externally-visible counterpart of the React adapters' CLJS-only
+  `re-frame.substrate.spine/dispose-frame-sub-caches!` walk — routed here
+  through the CLJC-safe shared helper
+  `re-frame.subs.cache/clear-all-frame-sub-caches!`. Pre-fix, because
+  test-react's `make-derived-value` is a plain IDeref reify whose reaction
+  never auto-disposes, the `{:reaction … :ref-count n}` cache slot (held on
+  the FRAME, not the reaction) survived a dispose/reinstall cycle, allowing a
+  later subscribe to read a stale value and breaking process isolation.
+
+  Why a SEPARATE ns from `test_react_test.cljc`: the sibling's ns
+  (`re-frame.adapter.test-react-test`) ends in `-test` but NOT `-cljs-test`,
+  so it runs only under the JVM cognitect runner (`clojure -M:test`) — the
+  shadow-cljs `:node-test` build's `cljs-test$` ns-regexp does not match it.
+  This ns ends in `-cljs-test`, so it ALSO rides `npm run test:cljs`, giving
+  the contract CLJS coverage. It uses the standard
+  `make-reset-runtime-fixture` (mirroring `plain_atom_dispose_cljs_test`) for
+  airtight per-test isolation rather than hand-managing frame/registrar
+  state."
+  (:require [re-frame.adapter.test-react :as test-react]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support]
+            #?(:clj  [clojure.test :as ctest :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :as ctest :refer-macros [deftest is testing use-fixtures]])))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter test-react/adapter}))
+
+(defn- sub-cache-keys []
+  (if-let [cache (:sub-cache (frame/frame :rf/default))]
+    (set (keys @cache))
+    #{}))
+
+(defn- entry-ref-count [query-v]
+  (get-in @(:sub-cache (frame/frame :rf/default)) [query-v :ref-count]))
+
+(deftest dispose-adapter-clears-sub-cache-and-recomputes-fresh
+  (testing "rf2-ghfkkk — test-react dispose-adapter! disposes + clears every
+            live frame's sub-cache; a re-subscribe after reinstall recomputes
+            from the current app-db (no stale cross-lifecycle read)"
+    (rf/reg-event-db ::seed (fn [_ [_ v]] {:n v}))
+    (rf/reg-sub ::n (fn [db _] (:n db)))
+    (rf/dispatch-sync [::seed 1])
+
+    ;; Materialise a real sub-cache slot (ref-count 1).
+    (let [r (subs/subscribe :rf/default [::n])]
+      (is (= 1 @r) "sub reads the seeded value")
+      (is (contains? (sub-cache-keys) [::n]) "subscribe materialised a cache slot")
+      (is (= 1 (entry-ref-count [::n])) "slot ref-count = 1"))
+
+    ;; Dispose the adapter — the cache MUST be cleared (entries + ref-counts).
+    (substrate-adapter/dispose-adapter!)
+    (is (empty? (sub-cache-keys))
+        "dispose-adapter! cleared the frame's sub-cache")
+    (is (nil? (entry-ref-count [::n]))
+        "no stale ref-count carried across the dispose")
+
+    ;; Reinstall, mutate app-db, re-subscribe — must reflect the NEW value.
+    (substrate-adapter/install-adapter! test-react/adapter)
+    (rf/dispatch-sync [::seed 99])
+    (let [r2 (subs/subscribe :rf/default [::n])]
+      (is (= 99 @r2)
+          "re-subscribe recomputed from the current app-db, not a stale slot")
+      (is (= 1 (entry-ref-count [::n]))
+          "rebuilt slot is a fresh cache miss (ref-count 1)")
+      (subs/unsubscribe :rf/default [::n]))))
+
+(deftest dispose-adapter-clears-sub-caches-across-multiple-frames
+  (testing "rf2-ghfkkk — the walk covers EVERY live frame, not just
+            :rf/default: a per-instance frame's materialised slot is disposed
+            and cleared by the same dispose-adapter! call"
+    (rf/reg-event-db ::seed (fn [_ [_ v]] {:n v}))
+    (rf/reg-sub ::n (fn [db _] (:n db)))
+    (let [other (frame/make-frame {:doc "second frame"})]
+      ;; Seed + subscribe in BOTH frames so each carries a live cache slot.
+      ;; Frame targeting rides the opts map (`:frame`) via the fn-form
+      ;; `dispatch-sync*` — the `dispatch-sync` macro has no frame-positional
+      ;; arity.
+      (rf/dispatch-sync* [::seed 1] {:frame :rf/default})
+      (rf/dispatch-sync* [::seed 2] {:frame other})
+      (subs/subscribe :rf/default [::n])
+      (subs/subscribe other [::n])
+      (is (contains? (set (keys @(:sub-cache (frame/frame :rf/default)))) [::n])
+          ":rf/default carries a slot")
+      (is (contains? (set (keys @(:sub-cache (frame/frame other)))) [::n])
+          "the second frame carries a slot")
+
+      (substrate-adapter/dispose-adapter!)
+      (is (empty? (set (keys @(:sub-cache (frame/frame :rf/default)))))
+          ":rf/default sub-cache cleared")
+      (is (empty? (set (keys @(:sub-cache (frame/frame other)))))
+          "the second frame's sub-cache cleared too — walk covers every frame")
+      (substrate-adapter/install-adapter! test-react/adapter))))

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_test.cljc
@@ -37,6 +37,9 @@
      unmount thunk, and deep (grandchild) leaf-upward cascade ordering."
   (:require [re-frame.adapter.test-react :as test-react]
             [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            [re-frame.frame :as frame]
             #?(:clj  [clojure.test :as ctest :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :as ctest :refer-macros [deftest is testing use-fixtures]])))
 
@@ -191,6 +194,97 @@
           "emitter still bound after dispose + reinstall")
       (finally
         (test-react/set-hiccup-emitter! nil)))))
+
+;; ---- dispose-adapter! clears every live frame's sub-cache (rf2-ghfkkk) ----
+;;
+;; The HIGH-severity finding: test-react's `dispose-adapter!` drained
+;; active-mounts (the host-resource MUST) but did NOT walk per-frame
+;; sub-caches the way the React adapters do via `spine/dispose-frame-sub-
+;; caches!`. Because `make-derived-value` is a plain IDeref reify whose
+;; reaction never auto-disposes (no IWatchable, no published :adapter/dispose!
+;; hook on CLJS), the `{:reaction … :ref-count n}` CACHE ENTRY — which lives
+;; on the FRAME, not the reaction — survived a dispose/reinstall cycle. A
+;; later subscribe could then read the stale cached value instead of
+;; recomputing from fresh state, breaking process isolation.
+;;
+;; The fix routes `dispose-adapter!` through the CLJC-safe shared helper
+;; `re-frame.subs.cache/clear-all-frame-sub-caches!`, the externally-visible
+;; counterpart of the spine walk. This test materializes a real frame
+;; sub-cache entry (with a ref-count), disposes the adapter, asserts the
+;; sub-cache is empty + the ref-count is gone, and verifies a re-subscribe
+;; after reinstall recomputes from the CURRENT app-db rather than serving a
+;; stale slot. Runs on both the JVM (`clojure -M:test`) and — by virtue of
+;; this ns also ending in `-test` — has a `-cljs-test` companion at
+;; `test_react_dispose_sub_cache_cljs_test.cljc` that exercises the same
+;; contract under `npm run test:cljs`.
+
+(defn- default-sub-cache-keys
+  "The set of cache-keys currently materialised in the :rf/default frame's
+  per-frame sub-cache. Empty when the frame is absent."
+  []
+  (if-let [cache (:sub-cache (frame/frame :rf/default))]
+    (set (keys @cache))
+    #{}))
+
+(defn- default-entry-ref-count
+  "The :ref-count on the :rf/default frame's sub-cache slot for `query-v`,
+  or nil if the slot is absent."
+  [query-v]
+  (get-in @(:sub-cache (frame/frame :rf/default)) [query-v :ref-count]))
+
+(deftest dispose-adapter-clears-frame-sub-cache-no-stale-cross-lifecycle-reads
+  (testing "dispose-adapter! clears every live frame's sub-cache entries +
+            ref-counts (the rf2-ghfkkk High finding): a materialised slot does
+            NOT survive a dispose/reinstall cycle, and a re-subscribe after
+            reinstall recomputes from the CURRENT app-db — no stale read."
+    ;; Start from a clean frame registry so prior tests in this ns can't leak
+    ;; a frame/cache in. The :each fixture installed test-react; ensure the
+    ;; :rf/default frame exists under it.
+    (reset! frame/frames {})
+    (frame/ensure-default-frame!)
+    (rf/reg-event-db ::seed (fn [_ [_ v]] {:n v}))
+    (rf/reg-sub ::n (fn [db _] (:n db)))
+    (try
+      ;; Seed app-db = {:n 1} and materialise a sub-cache entry by subscribing.
+      ;; Use the explicit-frame `subs/subscribe` (the macro resolves a render-
+      ;; time frame context headless tests do not establish).
+      (rf/dispatch-sync [::seed 1])
+      (let [r (subs/subscribe :rf/default [::n])]
+        (is (= 1 @r) "sub reads the seeded value")
+        (is (contains? (default-sub-cache-keys) [::n])
+            "subscribe materialised a cache slot on the frame")
+        (is (= 1 (default-entry-ref-count [::n]))
+            "the slot carries a ref-count of 1"))
+
+      ;; Dispose the adapter. Pre-fix this left the [::n] slot + its ref-count
+      ;; in the frame's sub-cache (the reaction never auto-disposes, so the
+      ;; entry survived). The fix walks every live frame's sub-cache and resets
+      ;; it.
+      (substrate-adapter/dispose-adapter!)
+      (is (empty? (default-sub-cache-keys))
+          "dispose-adapter! cleared the frame's sub-cache — no surviving slot")
+      (is (nil? (default-entry-ref-count [::n]))
+          "the stale ref-count is gone — not carried across the dispose")
+
+      ;; Reinstall and change the app-db. A re-subscribe MUST recompute from
+      ;; the new state (98 → 99 below), not serve a stale cached 1. If the
+      ;; pre-fix slot had survived, the re-subscribe would have aliased the old
+      ;; reaction and the isolation guarantee would be broken.
+      (substrate-adapter/install-adapter! test-react/adapter)
+      (rf/dispatch-sync [::seed 99])
+      (let [r2 (subs/subscribe :rf/default [::n])]
+        (is (= 99 @r2)
+            "re-subscribe after reinstall recomputed from the CURRENT app-db")
+        (is (= 1 (default-entry-ref-count [::n]))
+            "the rebuilt slot is a FRESH cache miss (ref-count back to 1), not
+             a resurrected stale entry")
+        (subs/unsubscribe :rf/default [::n]))
+      (finally
+        ;; Clean up: drop the test registrations + the frame so the ns's other
+        ;; tests (and the :each fixture's outer dispose) start clean. The
+        ;; adapter is left installed for the fixture's dispose to tear down.
+        (rf/clear-sub ::n)
+        (reset! frame/frames {})))))
 
 ;; ----------------------------------------------------------------------------
 ;; A'. Recursive child mounting — the structural seam the regressions ride on

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -235,6 +235,14 @@
   (suite/assert-view-unmount-emits-on-react-hook-teardown
     {:substrate-kw :uix :name "UIx"}))
 
+;; rf2-ghfkkk — a registered view returning a VOID DOM root (<input>) mounts
+;; + unmounts with no React void-element warning/error, and still fires
+;; exactly one :rf.view/unmounted (the unmount sentinel rides as a Fragment
+;; sibling, not a child of the void element). Probe built in the suite.
+(deftest void-root-view-unmount-no-warning
+  (suite/assert-void-root-view-unmount-no-warning
+    {:substrate-kw :uix :name "UIx"}))
+
 ;; ---- regression: frame-provider under the idiomatic `$` trailing-children shape (rf2-8svnm / rf2-z7hfp / rf2-7kii2) -
 ;;
 ;; The UIx twin of the Helix rf2-9ok1s defect, now pinning the moved-up

--- a/implementation/core/src/re_frame/subs/cache.cljc
+++ b/implementation/core/src/re_frame/subs/cache.cljc
@@ -286,6 +286,33 @@
               (catch #?(:clj Throwable :cljs :default) _ nil))))
      (reset! cache {}))))
 
+(defn clear-all-frame-sub-caches!
+  "CLJC-safe adapter-disposal sub-cache walk: dispose every cached entry
+  in EVERY live frame's runtime sub-cache and reset each cache to `{}`.
+
+  This is the per-process counterpart to `clear-sub-cache!` (one frame) —
+  the externally-visible equal of `re-frame.substrate.spine/dispose-frame-
+  sub-caches!` (the CLJS-only walk wired into the React-shaped adapters'
+  `dispose-adapter!`), lifted into this CLJC ns so the CLJC adapters
+  (`test-react`, `plain-atom`) can satisfy Spec 006 §Adapter disposal
+  lifecycle MUST 1 (`dispose-adapter!` cancels all in-flight reactive
+  subscriptions across every live frame's sub-cache) without taking a
+  static dependency on the CLJS-only spine. Per Spec 006 §Lifetime
+  contract — frame disposal §Adapter symmetry: the adapter's
+  `dispose-adapter!` disposes every frame's sub-cache as part of process
+  teardown (rf2-ghfkkk).
+
+  Best-effort, per-frame: a throwing per-entry dispose does NOT abort the
+  rest of the walk — every other cached entry in the same frame AND every
+  subsequent frame's cache still gets disposed and reset (`clear-sub-cache!`
+  already swallows per-entry throws). Emits `:rf.sub/dispose` with
+  `:rf.sub/reason :cache-clear` per evicted slot (the closed-enum reason
+  shared with explicit `clear-sub-cache!` test/REPL teardown). Returns nil."
+  []
+  (doseq [frame-id (frame/frame-ids)]
+    (clear-sub-cache! frame-id))
+  nil)
+
 ;; ---- frame-destroy eviction (rf2-x3m8c) ----------------------------------
 ;;
 ;; `re-frame.frame/destroy-frame!` tears the destroyed frame's sub-cache

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1169,25 +1169,83 @@
         #js [])
       nil)))
 
-(defn- append-unmount-sentinel
-  "Append an unmount-sentinel child element to `annotated` (the source-
-  coord / view-id-annotated user output) so the view instance fires
-  `:rf.view/unmounted` on teardown (rf2-te71r). `cloneElement` with a
-  trailing extra child preserves the root's `type`, `key`, and existing
-  props/children — the source-coord + view-id contract is untouched (the
-  inspected output is still the user's annotated root element, NOT a
-  Fragment wrapper), and the sentinel renders no DOM, so the committed
-  tree gains nothing visible. On a headless direct invocation of the
-  wrapped fn (the suite's render-trace tests call `((rf/view id))`) this
-  merely builds an element object whose sentinel child's hooks never run;
-  only a real React mount renders the sentinel and arms its useEffect
-  cleanup.
+(def ^:private void-dom-tags
+  "HTML5 void elements — self-closing, MUST NOT receive children. React
+  raises a void-element error (and SSR/hydration breaks) if `input`,
+  `img`, `br`, … are given a child. The set is fixed in HTML5 (no
+  maintenance burden).
 
-  Non-element / nil output (a view returning a string or nil) cannot
-  carry a child — pass it through unchanged (no unmount arm; consistent
-  with such a view having no mountable instance to tear down)."
+  Lockstep with `reagent2.impl.template/void-tags` and
+  `re-frame.ssr.emit/void-elements` (same membership, keyword vs string
+  shapes). Bundle isolation forbids `:require` across artefacts (core
+  must not reach into the adapters or the SSR artefact), so the set is
+  duplicated by intent. If HTML5 ever extends the void-element list
+  (extraordinarily unlikely), update every copy."
+  #{"area" "base" "br" "col" "embed" "hr" "img" "input" "link"
+    "meta" "param" "source" "track" "wbr"})
+
+(defn- void-dom-root?
+  "True when `react-element` is a void HTML DOM element (string `type`
+  in `void-dom-tags`) — React rejects children on such roots, so the
+  unmount sentinel must ride as a SIBLING (in a Fragment) rather than a
+  child. Function/class components and Fragments have non-string types
+  and are never void."
+  [react-element]
+  (let [t (some-> ^js react-element .-type)]
+    (and (string? t) (contains? void-dom-tags t))))
+
+(defn- append-unmount-sentinel
+  "Attach an unmount-sentinel to `annotated` (the source-coord /
+  view-id-annotated user output) so the view instance fires
+  `:rf.view/unmounted` on teardown (rf2-te71r). Two shapes, keyed on
+  whether the user's root is a VOID DOM element:
+
+  - Non-void root (the dominant case): `cloneElement` with a trailing
+    extra CHILD. This preserves the root's `type`, `key`, and existing
+    props/children — the inspected output is still the user's annotated
+    root element, NOT a Fragment wrapper, so the source-coord + view-id
+    contract and the layout-critical no-wrapper guarantee both hold.
+
+  - Void root (`input` / `img` / `br` / …, rf2-ghfkkk): React rejects
+    children on void elements (it raises a void-element error and breaks
+    hydration), so the sentinel CANNOT be a child. Instead, return a
+    `React.Fragment` holding the user's annotated root element UNCHANGED
+    (its `data-rf2-source-coord` / `data-rf-view` attrs intact) plus the
+    sentinel as a SIBLING. A Fragment renders no wrapper DOM node, so the
+    committed tree's DOM semantics are stable — the void element stays a
+    direct child of its real parent, with no synthetic host element. The
+    inspected root is still the user's annotated void element; only the
+    sentinel's sibling position changes. This keeps a valid registered
+    view returning a void root valid under dev-mode instrumentation
+    (pre-fix it became invalid, producing React void-element errors that
+    vanished in production).
+
+  The sentinel renders no DOM in BOTH shapes. On a headless direct
+  invocation of the wrapped fn (the suite's render-trace tests call
+  `((rf/view id))`) this merely builds an element object whose sentinel
+  hooks never run; only a real React mount renders the sentinel and arms
+  its useEffect cleanup.
+
+  Non-element / nil output (a view returning a string or nil) has no
+  mountable root instance — pass it through unchanged (no unmount arm,
+  consistent with such a view having nothing to tear down)."
   [unmount-sentinel id frame-id annotated]
-  (if (and (some? annotated) (some? (.-type ^js annotated)))
+  (cond
+    (or (nil? annotated) (nil? (.-type ^js annotated)))
+    annotated
+
+    (void-dom-root? annotated)
+    ;; Void root — sentinel rides as a SIBLING inside a Fragment so the
+    ;; user's void element receives NO children. The annotated root is
+    ;; forwarded unchanged (source-coord / data-rf-view attrs intact).
+    (let [sentinel-el (React/createElement unmount-sentinel
+                                           #js {:viewId id :frame frame-id})]
+      (React/createElement (.-Fragment React) nil annotated sentinel-el))
+
+    :else
+    ;; Non-void root — append the sentinel as a CHILD (no Fragment wrap,
+    ;; so layout-critical positioning / flexbox / grid / :nth-child stay
+    ;; intact).
     (let [sentinel-el (React/createElement unmount-sentinel
                                            #js {:viewId id :frame frame-id})
           existing    (some-> ^js annotated .-props .-children)
@@ -1201,8 +1259,7 @@
                         (array? existing) (.concat existing #js [sentinel-el])
                         :else             #js [existing sentinel-el])]
       (.apply React/cloneElement nil
-              (.concat #js [annotated nil] children)))
-    annotated))
+              (.concat #js [annotated nil] children)))))
 
 (defn make-wrap-view
   "Return a `wrap-view` fn parameterised on the substrate's per-adapter

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -134,6 +134,26 @@
       (finally
         (set! (.-warn js/console) original)))))
 
+(defn- with-captured-console-warn+error
+  "Replace BOTH js/console.warn and js/console.error with recording shims
+  around `thunk`. Returns the vector of joined-message strings observed on
+  EITHER channel (React reports the void-element-children violation via
+  `console.error`). Restores both originals on the way out, even if thunk
+  throws. Used by the rf2-ghfkkk void-root DOM mount test to assert React
+  raised no void-element diagnostic."
+  [thunk]
+  (let [calls     (atom [])
+        orig-warn  (.-warn js/console)
+        orig-error (.-error js/console)]
+    (try
+      (set! (.-warn js/console)  (fn [& args] (swap! calls conj (apply str args))))
+      (set! (.-error js/console) (fn [& args] (swap! calls conj (apply str args))))
+      (thunk)
+      @calls
+      (finally
+        (set! (.-warn js/console)  orig-warn)
+        (set! (.-error js/console) orig-error)))))
+
 (defn- mint-kw
   "Mint a substrate-scoped keyword so the UIx and Helix suites never
   collide on a process-wide `defonce` (warn-once set, etc.)."
@@ -479,6 +499,58 @@
         (is (= n (count (distinct keys)))
             (str "all " n " per-item keys are distinct after the wrap-view passes — no collision; got "
                  (pr-str keys)))))))
+
+;; ===========================================================================
+;; void-element unmount-sentinel (rf2-ghfkkk) — wrap-view must NOT attach a
+;; child to a void DOM root (input / img / br / …). React rejects children on
+;; void elements and would raise a void-element error / break hydration; the
+;; sentinel must ride as a Fragment SIBLING instead. Headless structural
+;; assertion (runs under node-test for BOTH UIx + Helix via the macro); the
+;; DOM-mount counterpart (no warning + exactly-one :rf.view/unmounted) lives
+;; in `assert-void-root-view-unmount-no-warning` (browser gate).
+;; ===========================================================================
+
+(defn assert-void-root-view-sentinel-is-fragment-sibling
+  "rf2-ghfkkk: a registered view whose root is a VOID DOM element emerges
+  from the wrap-view passes as a `React.Fragment` holding the user's void
+  element (source-coord + data-rf-view attrs intact, and crucially NO
+  children) plus the unmount sentinel as a SIBLING — never as a child of
+  the void element. Headless `((rf/view id))` runs the full wrap-view path
+  under goog.DEBUG=true, so this pins the structure the DOM-mount test then
+  proves renders without a React void-element error. Parameterised ⇒ a gap
+  on UIx is a gap on Helix."
+  [{:keys [substrate-kw name]}]
+  (testing (str name " — void root: sentinel is a Fragment sibling, not a child of the void element")
+    (doseq [void-tag ["input" "img" "br"]]
+      (let [id      (mint-kw substrate-kw (str "void-root-" void-tag))
+            user-fn (fn [] (React/createElement void-tag #js {}))]
+        (rf/reg-view* id user-fn)
+        (let [out ((rf/view id))]
+          (is (some? out) (str "registered view returned a non-nil element (" void-tag ")"))
+          ;; The wrap output is a Fragment (its `type` is React.Fragment, a
+          ;; non-string symbol/object), NOT the bare void element.
+          (is (= (.-Fragment React) (.-type out))
+              (str "void <" void-tag "> root wrapped in a React.Fragment so the "
+                   "sentinel can be a sibling"))
+          (let [kids   (some-> ^js out .-props .-children)
+                ;; Fragment children: [annotated-void-el sentinel-el].
+                kids-v  (cond (array? kids) (vec kids) (nil? kids) [] :else [kids])
+                root-el (first kids-v)]
+            (is (= 2 (count kids-v))
+                "Fragment carries exactly two children: the void element + the sentinel")
+            (is (= void-tag (.-type root-el))
+                (str "first Fragment child is the user's <" void-tag "> root, type preserved"))
+            ;; The CRITICAL assertion: the void element itself has NO children.
+            (let [void-children (some-> ^js root-el .-props .-children)]
+              (is (or (nil? void-children)
+                      (and (array? void-children) (zero? (alength ^js void-children))))
+                  (str "the void <" void-tag "> element received NO children — React "
+                       "would raise a void-element error otherwise")))
+            ;; Source-coord + view-id attrs still land on the user's void root.
+            (is (string? (source-coord root-el))
+                "data-rf2-source-coord still annotates the void root")
+            (is (= (str id) (view-attr root-el))
+                "data-rf-view still annotates the void root")))))))
 
 ;; ===========================================================================
 ;; frame-context corrupted `_currentValue` (Spec 009 §Error contract) — G4
@@ -3544,4 +3616,61 @@
                     ":rf.view/render-key's head is the view-id")))
             (finally
               (trace-tooling/unregister-listener! ::view-unmounted-recorder)
+              (try (.unmount root) (catch :default _ nil))))))))))
+
+(defn assert-void-root-view-unmount-no-warning
+  "rf2-ghfkkk (DOM-mount counterpart of
+  `assert-void-root-view-sentinel-is-fragment-sibling`): a registered view
+  whose root is a VOID DOM element (`input`) mounts and unmounts under the
+  React-hook substrate with NO React void-element warning/error, and STILL
+  fires exactly one `:rf.view/unmounted` on teardown. Pre-fix the spine
+  appended the unmount sentinel as a CHILD of the void element, which React
+  rejects (console.error: 'input is a void element tag and must neither
+  have children nor use dangerouslySetInnerHTML') — and the broken element
+  could fail to mount, dropping the unmount emit. The Fragment-sibling fix
+  keeps the void root child-free while preserving the sentinel's teardown
+  arm.
+
+  Browser-DOM gate (real createRoot / unmount); skipped on node-test via
+  `with-browser-act`. cfg keys: :substrate-kw, :name."
+  [{:keys [substrate-kw name]}]
+  (testing (str name " — void <input> root: mounts/unmounts with no React void-element warning; :rf.view/unmounted still fires once (rf2-ghfkkk)")
+    (with-browser-act
+     (fn [act-fn]
+      (let [view-id  (mint-kw substrate-kw "void-root-unmount-probe")
+            recorded (atom [])]
+        (trace-tooling/register-listener! ::void-view-unmounted-recorder
+          (fn [ev]
+            (when (= :rf.view/unmounted (:operation ev))
+              (swap! recorded conj ev))))
+        ;; Registered view returns a VOID DOM root (an <input>). The spine's
+        ;; wrap-view must Fragment-wrap it with the sentinel as a sibling so
+        ;; React never sees children on the void element.
+        (rf/reg-view* view-id (fn [] (React/createElement "input" #js {:type "text"})))
+        (let [render-fn  (rf/view view-id)
+              host       (fn host-cmp [_props] (render-fn))
+              mount-node (make-mount-node!)
+              root       (react-dom-client/createRoot mount-node)
+              ;; Capture console.warn + console.error across the mount: React
+              ;; reports the void-element-children violation via console.error.
+              warns      (with-captured-console-warn+error
+                           (fn [] (act-fn (fn [] (.render root (React/createElement host #js {}))))))
+              void-msgs  (filter #(and (string? %)
+                                       (re-find #"(?i)void element" %))
+                                 warns)]
+          (try
+            (is (empty? void-msgs)
+                (str "no React void-element warning/error on mounting a void root; got "
+                     (pr-str (vec warns))))
+            (is (empty? @recorded)
+                "no :rf.view/unmounted before teardown")
+            (act-fn (fn [] (.unmount root)))
+            (is (= 1 (count @recorded))
+                "exactly one :rf.view/unmounted fired on teardown — the sentinel's
+                 useEffect cleanup still armed despite the void root")
+            (when-let [ev (first @recorded)]
+              (is (= view-id (:rf.view/id (:tags ev)))
+                  ":rf.view/id tag matches the registered void-root view"))
+            (finally
+              (trace-tooling/unregister-listener! ::void-view-unmounted-recorder)
               (try (.unmount root) (catch :default _ nil))))))))))

--- a/implementation/core/test/re_frame/adapter/react_shared_suite_tests.clj
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite_tests.clj
@@ -95,6 +95,10 @@
    {:test 'reg-view-react-key-preserved
     :fn   'assert-reg-view-react-key-preserved}
 
+   {:section "void-element unmount-sentinel (rf2-ghfkkk)"}
+   {:test 'void-root-view-sentinel-is-fragment-sibling
+    :fn   'assert-void-root-view-sentinel-is-fragment-sibling}
+
    {:section "frame-context corrupted (Spec 009)"}
    {:test 'frame-context-corrupted
     :fn   'assert-frame-context-corrupted}


### PR DESCRIPTION
Fixes the two High findings in rf2-ghfkkk; the Medium (reagent-slim flush-render! sync-commit) is split to follow-up rf2-0bz5ah.

## Issue 1 (High) — dispose/reinstall must clear the sub-cache

test-react's dispose-adapter! drained active-mounts but did NOT walk per-frame sub-caches. Because make-derived-value is a plain IDeref reify whose reaction never auto-disposes, the {:reaction :ref-count} cache slot — held on the FRAME, not the reaction — survived a dispose/reinstall cycle, allowing a later subscribe to read a stale value and breaking process isolation.

- New CLJC-safe re-frame.subs.cache/clear-all-frame-sub-caches!: the externally-visible counterpart of the CLJS-only spine dispose-frame-sub-caches! walk, reusing the per-frame clear-sub-cache! across every live frame (Spec 006 §Adapter disposal lifecycle MUST 1 + §Adapter symmetry). Stays within the closed :rf.sub/reason enum (:cache-clear).
- test-react dispose-adapter! routes through it; the active-mount drain is unchanged.
- Coverage: test_react_test.cljc (JVM) materialises a real sub-cache slot, disposes, asserts the cache + ref-count are gone, and verifies a re-subscribe after reinstall recomputes from the CURRENT app-db. A -cljs-test companion runs the same contract (single + multi-frame) under the node-test gate.

## Issue 2 (High) — instrumentation must not add children to void DOM roots

The React-hook unmount-sentinel was cloned as a CHILD onto any root element, including void DOM roots (input/img/br). React rejects children on void elements, so dev-mode instrumentation could turn a valid registered view into a React void-element error that vanished in production.

- append-unmount-sentinel now wraps a void root in a React.Fragment with the sentinel as a SIBLING — the void element stays child-free, source-coord/data-rf-view attrs intact, no synthetic host DOM node. Non-void roots keep the no-wrapper append-child path. Local void-tag set (lockstep with reagent-slim template + ssr.emit), DCE'd in production via wrap-view's interop/debug-enabled? gate.
- Headless structural assertion (UIx + Helix via the shared-suite macro) proves the Fragment-sibling shape; browser DOM-mount assertions prove a void <input> root mounts with no void-element warning/error and still fires exactly one :rf.view/unmounted.

## Issue 3 (Medium) — split out

reagent-slim flush-render! not pinned to React's synchronous-commit API → follow-up rf2-0bz5ah. Distinct adapter surface; the AC is verify-the-premise-then-conditionally-fix, kept out of this dispose/sub-cache PR.

## Quality gates

- clojure -M:test (test-react adapter): 23 tests, 0 failures
- clojure -M:test (core, incl. subs.cache): 997 tests, 0 failures
- npm run test:cljs: 6085 tests, 0 failures
- npm run test:browser: 207 tests, 0 failures (void-root DOM mount proven)
- npm run test:elision: production elision OK (void-tag helpers DCE)
- npm run test:bundle-isolation: OK

Note: EP-0002 already reworked the adapter provider spine (69r7ui) + sub-cache clear (jue6sp) on its branch; a deferred conflict at the ep-0002→main merge is expected and mayor-resolved (merge both intents). This change is kept minimal/surgical.