### PR TITLE
fix(scripts): close gate-parser + API-manifest-probe false-greens (rf2-nlnd9y rf2-4ka7c2)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -120,6 +120,24 @@ else
       .github/workflows/test.yml|.github/workflows/expensive-tests.yml|.github/scripts/report-changed-surfaces.sh|TESTING.md)
         mark_all
         ;;
+      spec/api-manifest-metadata.edn|spec/api-manifest.edn|spec/API.md)
+        # rf2-4ka7c2.1 — false-green fix. The CLJS-only adapter / Xray /
+        # pair-MCP public surfaces cannot be `require`d on the JVM, so their
+        # rows live in the sidecar (spec/api-manifest-metadata.edn) under
+        # :cljs-only and the JVM generator carries them through VERBATIM into
+        # spec/api-manifest.edn. The ONLY live runtime verifier for those rows
+        # is the CLJS enumeration probe
+        # (implementation/scripts/api-manifest/probe/, wired into the
+        # consolidated :node-test build), which runs only when
+        # cljs_node_test=true. A PR editing the sidecar / generated manifest /
+        # API.md without touching implementation/, tools/, or shadow-cljs.edn
+        # previously left cljs_node_test=false — so a stale/missing CLJS-only
+        # row could ship with green CI (lint.yml runs only the JVM generator +
+        # projection checks, not the CLJS probe). Fire cljs_node_test so the
+        # probe reconciles the :cljs-only rows against the live CLJS public
+        # vars on any sidecar/generated-manifest/API.md change.
+        cljs_node_test=true
+        ;;
       implementation/core/*)
         # rf2-8jz9t + rf2-k9ekz + rf2-t5slp — adapter_testbed_smokes
         # and story_xray_browser are NOT fired here. The Playwright

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,6 +48,11 @@ on:
       - 'examples/**'
       - 'testbeds/**'
       - '.clj-kondo/**'
+      # Splint reads its per-project config from `.splint.edn` at repo root
+      # (rf2-nlnd9y.3). A push that changes ONLY `.splint.edn` — including
+      # broken syntax, disabled rules, or a missing exclude — must run the
+      # lint workflow so the Splint gate validates the new config.
+      - '.splint.edn'
       - '.github/workflows/lint.yml'
       # Public-API manifest drift-check surface (rf2-3nbl5.2).
       - 'spec/API.md'
@@ -112,6 +117,14 @@ jobs:
             [ -z "$file" ] && continue
             case "$file" in
               implementation/*|tools/*|examples/*|testbeds/*|.clj-kondo/*|.github/workflows/lint.yml)
+                lint_surface=true ;;
+              # `.splint.edn` is the Splint gate's per-project config
+              # (rf2-nlnd9y.3): a PR that changes ONLY it — broken syntax,
+              # disabled rules, a removed exclude — must run the Splint job so
+              # the config is validated. Without this the detect classifier
+              # left lint_surface=false and Splint skipped, letting a config
+              # change ship unverified behind a green `Lint required`.
+              .splint.edn)
                 lint_surface=true ;;
               # spec/ feeds the public-API manifest drift-check (the
               # api-manifest job below): API.md, the curated sidecar, and

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -36,7 +36,7 @@
     "test:xray-feature-gate": "node scripts/serve-and-run-xray-feature-gate.cjs",
     "test:xray-feature-gate:smoke": "node scripts/serve-and-run-xray-feature-gate.cjs --smoke",
     "test:story-static": "node scripts/check-story-static.cjs",
-    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_story-script-runners-policy.test.cjs && node scripts/_impl-browser-runners-pageerror-policy.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs && node scripts/check-reagent-slim-boundary.test.cjs",
+    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_lint-workflow-policy.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_story-script-runners-policy.test.cjs && node scripts/_impl-browser-runners-pageerror-policy.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs && node scripts/check-reagent-slim-boundary.test.cjs",
     "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs && node scripts/_read-release-bundle.test.cjs && node scripts/dev-testbed.test.cjs",
     "test:mcp-conformance": "node scripts/test-mcp-conformance.cjs"
   }

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -180,6 +180,42 @@ test('Xray CLJS src change runs cljs (node-test compiles tools/xray) (rf2-f79t8)
   assert.equal(result.cljs_node_test, 'true');
 });
 
+// rf2-4ka7c2.1 — API-manifest probe routing false-green fix. The CLJS-only
+// adapter / Xray / pair-MCP public surfaces live in the sidecar
+// (spec/api-manifest-metadata.edn) under :cljs-only and are carried into
+// spec/api-manifest.edn verbatim. Their ONLY live runtime verifier is the
+// CLJS enumeration probe in the consolidated :node-test build, gated on
+// cljs_node_test. A sidecar / generated-manifest / API.md change must
+// therefore light cljs_node_test so the probe reconciles those rows — else a
+// stale/missing CLJS-only row ships with green CI (lint.yml runs only the JVM
+// generator + projection checks, never the CLJS probe).
+
+test('API-manifest sidecar change lights cljs_node_test (CLJS probe routing) (rf2-4ka7c2)', () => {
+  const result = classify('spec/api-manifest-metadata.edn');
+  assert.equal(
+    result.cljs_node_test,
+    'true',
+    'a sidecar edit must run the CLJS manifest probe (its only runtime verifier)',
+  );
+});
+
+test('Generated api-manifest.edn change lights cljs_node_test (rf2-4ka7c2)', () => {
+  const result = classify('spec/api-manifest.edn');
+  assert.equal(result.cljs_node_test, 'true');
+});
+
+test('spec/API.md change lights cljs_node_test (rf2-4ka7c2)', () => {
+  const result = classify('spec/API.md');
+  assert.equal(result.cljs_node_test, 'true');
+});
+
+test('Other spec/*.md change does NOT light cljs_node_test (scope discipline) (rf2-4ka7c2)', () => {
+  // The routing is scoped to the THREE manifest surfaces — an unrelated spec
+  // doc must not drag the consolidated :node-test build into a docs PR.
+  const result = classify('spec/006-ReactiveSubstrate.md');
+  assert.equal(result.cljs_node_test, 'false');
+});
+
 // rf2-jdj17.1 — template_expensive false-green fix. The template's
 // generated `:app` build transitively compiles against tools/xray
 // (:devtools/preloads [day8.re-frame2-xray.preload]),

--- a/implementation/scripts/_lint-workflow-policy.test.cjs
+++ b/implementation/scripts/_lint-workflow-policy.test.cjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/*
+ * Workflow-policy guard for `.github/workflows/lint.yml` (rf2-nlnd9y.3).
+ *
+ * `.splint.edn` at repo root is the Splint gate's per-project config — Splint
+ * reads it live once the job runs. But the lint workflow's ROUTING omitted
+ * it: the `push` path filter and the PR `detect` classifier both listed
+ * implementation/tools/examples/testbeds/.clj-kondo but NOT `.splint.edn`. So
+ * a PR (or push) that changed ONLY `.splint.edn` — broken syntax, disabled
+ * rules, a removed exclude — left `lint_surface=false`, the Splint job
+ * skipped, and the required `Lint required` aggregator passed (all-skipped is
+ * OK). A bad Splint config could ship behind a green gate.
+ *
+ * This guard pins that `.splint.edn` is wired into BOTH routing surfaces and
+ * that the Splint job stays gated on `lint_surface` (so the routing is what
+ * decides whether Splint runs). It is a TEXT/policy assertion over the
+ * committed workflow — no Actions runtime needed — mirroring the
+ * test.yml-shape assertions in `_changed-surfaces.test.cjs`. Wired into
+ * `test:script-policy`.
+ */
+
+'use strict';
+
+const assert = require('assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const IMPL_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(IMPL_ROOT, '..');
+const LINT_WORKFLOW = path.join(REPO_ROOT, '.github', 'workflows', 'lint.yml');
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+const workflow = fs.readFileSync(LINT_WORKFLOW, 'utf8');
+
+// Narrow the workflow text to a named job/section block: from a `\n<indent>
+// <name>:` header to the next sibling at the same indent. Used to scope
+// assertions so a match can't leak across sections.
+function sectionBlock(text, headerRe, siblingRe) {
+  const m = headerRe.exec(text);
+  assert.notEqual(m, null, `section ${headerRe} not found in lint.yml`);
+  const rest = text.slice(m.index + 1);
+  const next = rest.search(siblingRe);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+test('push path filter includes .splint.edn (rf2-nlnd9y.3)', () => {
+  // The `on: push: paths:` block lives before `jobs:`. Assert the quoted
+  // `.splint.edn` entry appears in the trigger section.
+  const onBlock = workflow.slice(0, workflow.indexOf('\njobs:'));
+  assert.match(
+    onBlock,
+    /^\s+-\s+'\.splint\.edn'\s*$/m,
+    'push trigger paths must list .splint.edn so a .splint.edn-only push runs lint',
+  );
+});
+
+test('PR detect classifier routes .splint.edn to lint_surface=true (rf2-nlnd9y.3)', () => {
+  // The detect job's case statement classifies changed files. Assert there is
+  // a `.splint.edn)` case arm that sets lint_surface=true.
+  const detectBlock = sectionBlock(
+    workflow,
+    /\n {2}detect:\r?\n/,
+    /\n {2}[A-Za-z0-9_-]+:\r?\n/,
+  );
+  // A `.splint.edn)` case label must be present...
+  assert.match(
+    detectBlock,
+    /\.splint\.edn\)/,
+    'detect classifier must carry a `.splint.edn)` case arm',
+  );
+  // ...and the arm must set lint_surface=true (the arm is `.splint.edn)`
+  // immediately followed by the `lint_surface=true ;;` body, allowing CRLF).
+  assert.match(
+    detectBlock,
+    /\.splint\.edn\)\s*\r?\n\s*lint_surface=true ;;/,
+    'the `.splint.edn)` case arm must set lint_surface=true',
+  );
+});
+
+test('Splint job stays gated on lint_surface so routing decides whether it runs (rf2-nlnd9y.3)', () => {
+  const splintBlock = sectionBlock(
+    workflow,
+    /\n {2}splint:\r?\n/,
+    /\n {2}[A-Za-z0-9_-]+:\r?\n/,
+  );
+  assert.match(splintBlock, /needs: detect/);
+  assert.match(
+    splintBlock,
+    /if: needs\.detect\.outputs\.lint_surface == 'true'/,
+    'Splint must be gated on lint_surface (the routing the .splint.edn fix lights)',
+  );
+});
+
+test('Splint job still runs with --fail-on-errors (regression: teeth intact) (rf2-nlnd9y.3)', () => {
+  const splintBlock = sectionBlock(
+    workflow,
+    /\n {2}splint:\r?\n/,
+    /\n {2}[A-Za-z0-9_-]+:\r?\n/,
+  );
+  assert.match(splintBlock, /--fail-on-errors/);
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+  } catch (err) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(err && err.stack ? err.stack : err);
+  }
+}
+
+if (failed > 0) {
+  console.error(`lint-workflow-policy tests: ${failed} failed.`);
+  process.exit(1);
+}
+
+console.log(`lint-workflow-policy tests: ${tests.length} passed.`);

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -57,7 +57,19 @@
   only) is treated as a non-var row and skipped."
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [re-frame.api-manifest.gen :as gen]))
+            [re-frame.api-manifest.gen :as gen]
+            [re-frame.api-manifest.projection :as projection]))
+
+(def ^:private min-var-rows
+  "Non-vacuous extracted-row floor for the spec/API.md projection
+   (rf2-4ka7c2.2). The live extracted-var-row count is ~196; a parser /
+   table-shape / tier-header / marker-cell drift that collapses extraction
+   toward zero would otherwise let `check!` report a VACUOUS OK while most of
+   API.md's public-var references go unchecked against the manifest. This
+   floor is set well below the live count so it trips ONLY on a near-total
+   collapse (the vacuous-green class), never on ordinary API.md churn — the
+   same calibration the secondary projection floors use (rf2-utvst)."
+  150)
 
 (def ^:private api-md-file (delay (io/file gen/repo-root "spec" "API.md")))
 
@@ -238,6 +250,17 @@
                    :api-tier tier :manifest-tiers tiers}))))
           api-rows)))
 
+(defn floor-violation
+  "Pure non-vacuous-floor predicate (rf2-4ka7c2.2 — extracted so the
+   zero-row / near-collapse contract is unit-testable without the live
+   spec/API.md file). Returns the projection floor-problem map when
+   `extracted` (the number of API.md var-rows the parser actually recovered)
+   is below `min-var-rows`, else nil. A non-nil result MUST fail `check!`:
+   an empty problem list with a collapsed extraction would otherwise report
+   a vacuous OK."
+  [extracted]
+  (projection/vacuity-floor-problem "spec/API.md" extracted min-var-rows))
+
 (defn check!
   "Validate spec/API.md var-rows against the manifest. Returns true when
    every API.md var-row resolves to a manifest row with a MATCHING tier;
@@ -249,14 +272,33 @@
         ;; (post-v1-lib surfaces the reference impl does not yet ship).
         known-unmanifested (set (:api-md-known-unmanifested (gen/read-sidecar)))
         api-rows   (parse-api-md-var-rows)
+        extracted  (count api-rows)
+        ;; Non-vacuous floor (rf2-4ka7c2.2): if extraction has collapsed
+        ;; (table-shape / tier-header / marker drift), an empty `problems`
+        ;; seq below would report a VACUOUS OK with most of API.md unchecked.
+        ;; Detect that BEFORE the tier reconcile so a near-collapse fails
+        ;; loudly rather than passing green.
+        floor      (floor-violation extracted)
         problems   (reconcile {:rows               rows
                                :api-rows           api-rows
                                :known-unmanifested known-unmanifested
                                :aliases            adapter-aliases})]
-    (if (empty? problems)
+    (cond
+      ;; Vacuity-floor violation: extraction collapsed — refuse a green.
+      floor
+      (do (binding [*out* *err*]
+            (println (format (str "DRIFT: spec/API.md var-row extraction collapsed — only %d "
+                                  "var-row(s) extracted, below the non-vacuous floor of %d.")
+                             extracted min-var-rows))
+            (println (str "  " (:detail floor))))
+          false)
+
+      (empty? problems)
       (do (println (format "OK: spec/API.md projection in sync (%d var-rows checked against the manifest)."
-                           (count api-rows)))
+                           extracted))
           true)
+
+      :else
       (do (binding [*out* *err*]
             (println "DRIFT: spec/API.md var-rows disagree with spec/api-manifest.edn.")
             (println "Each API.md var-row's Tier must match the manifest (regenerate the")

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -262,13 +262,37 @@
          (sort-by (juxt first second))
          vec)))
 
+(defn duplicate-rows
+  "Return a sorted vector of `[[namespace var] count]` for every
+   `[namespace var]` key carried by MORE THAN ONE manifest row (rf2-nlnd9y.2).
+
+   The manifest contract is one row per public var (this ns docstring's THE
+   ARTEFACT note). JVM-derived rows are unique by construction (a namespace's
+   `ns-publics` map has unique var names, and `extra-vars` adds distinct
+   pairs). But the curated `:cljs-only` sidecar rows are carried through
+   VERBATIM and concatenated with the JVM rows, with no uniqueness check — so
+   a duplicated `:cljs-only` entry, or a `:cljs-only` row colliding with a
+   JVM-derived row, produced a manifest with two rows for one var (possibly
+   with conflicting tier/kind/status/runtime metadata) and an inflated
+   `:var-count`. Downstream projections then either silently overwrite one
+   row (`index-by-ns+var` `assoc`) or tolerate multiple tiers — masking the
+   contradiction. Detecting duplicates HERE, before write / `--check`, keeps
+   the one-row-per-var invariant where it is generated."
+  [rows]
+  (->> rows
+       (group-by (juxt :namespace :var))
+       (keep (fn [[k group]] (when (> (count group) 1) [k (count group)])))
+       (sort-by (comp (juxt first second) first))
+       vec))
+
 (defn build-manifest
   "Build the full manifest data structure (the value written to
    spec/api-manifest.edn). Throws on missing / stale sidecar entries with
    an actionable message — that throw is what turns the drift-check red."
   [sidecar]
   (let [[rows missing] (build-rows sidecar)
-        stale          (stale-sidecar-entries sidecar)]
+        stale          (stale-sidecar-entries sidecar)
+        dups           (duplicate-rows rows)]
     (when (seq missing)
       (throw (ex-info
               (str "Public vars with no sidecar classification (add a "
@@ -284,6 +308,24 @@
                    "spec/api-manifest-metadata.edn):\n  "
                    (str/join "\n  " (map #(str/join "/" %) stale)))
               {:stale stale})))
+    ;; One-row-per-public-var invariant (rf2-nlnd9y.2). A duplicate
+    ;; `[namespace var]` — within `:cljs-only`, or between a `:cljs-only`
+    ;; row and a JVM-derived row — must FAIL generation / `--check`, never
+    ;; ship two rows for one var (which inflates :var-count and lets
+    ;; downstream projections silently overwrite or mask conflicting tiers).
+    (when (seq dups)
+      (throw (ex-info
+              (str "Duplicate manifest rows — these `[namespace var]` keys "
+                   "appear MORE THAN ONCE (the manifest is one row per public "
+                   "var). A duplicate within `:cljs-only`, or a `:cljs-only` "
+                   "row colliding with a JVM-derived row, must be removed from "
+                   "spec/api-manifest-metadata.edn (a JVM-loadable var must "
+                   "NOT also be hand-rowed under :cljs-only):\n  "
+                   (str/join "\n  "
+                             (map (fn [[[ns-str var-str] n]]
+                                    (str ns-str "/" var-str " (" n " rows)"))
+                                  dups)))
+              {:duplicates dups})))
     {:meta {:doc        (str "GENERATED public-API manifest — do NOT hand-edit "
                              "the :vars list. Regenerate with: clojure -M -m "
                              "re-frame.api-manifest.gen (run from "

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -156,3 +156,37 @@
            (otherwise this regression would be vacuous)")
       (is (true? (c/check!))
           "live drift: spec/API.md var-rows disagree with the manifest"))))
+
+;; ---------------------------------------------------------------------------
+;; Non-vacuous extracted-row floor (rf2-4ka7c2.2).
+;;
+;; api-md-check/check! reported OK whenever its problem list was empty — even
+;; with ZERO extracted var-rows. A table-shape / tier-header / marker-cell /
+;; parser drift that collapses extraction toward 0 would then pass green
+;; while most of spec/API.md's public-var references went unchecked. The
+;; floor turns a near-collapse into a FAILURE.
+;; ---------------------------------------------------------------------------
+
+(deftest zero-extracted-rows-violates-the-floor
+  (testing "ZERO extracted var-rows (a total parser collapse) trips the floor"
+    (is (some? (c/floor-violation 0))
+        "zero extracted rows must be a floor violation (vacuous OK refused)")))
+
+(deftest near-collapse-extraction-violates-the-floor
+  (testing "a near-collapse (a small subset extracted, well below the live
+            ~196) trips the floor"
+    (is (some? (c/floor-violation 5))
+        "5 extracted rows is a near-total collapse — must trip the floor")
+    (is (some? (c/floor-violation 149))
+        "149 rows is below the 150 floor — must trip it")))
+
+(deftest healthy-extraction-does-not-violate-the-floor
+  (testing "the live extracted-row count (~196) is comfortably above the floor"
+    (is (nil? (c/floor-violation 196))
+        "the live count must NOT trip the floor (no false positive)")
+    (is (nil? (c/floor-violation 150))
+        "exactly at the floor is acceptable (strictly-below trips)")
+    ;; And the REAL parse over the committed API.md is above the floor — the
+    ;; floor is calibrated below the live count, never tripping on real churn.
+    (is (nil? (c/floor-violation (count (c/parse-api-md-var-rows))))
+        "the real spec/API.md extraction must clear the floor")))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/gen_test.clj
@@ -1,0 +1,114 @@
+(ns re-frame.api-manifest.gen-test
+  "Regression tests for the manifest generator's one-row-per-public-var
+  invariant (rf2-nlnd9y.2).
+
+  THE BUG. The generated manifest is contractually one row per public var
+  (gen ns docstring §THE ARTEFACT). JVM-derived rows are unique by
+  construction, but the curated `:cljs-only` sidecar rows were concatenated
+  with the JVM rows and emitted VERBATIM with no uniqueness check. A
+  duplicated `:cljs-only` entry — or a `:cljs-only` row colliding with a
+  JVM-derived row — produced two manifest rows for one var (possibly with
+  conflicting tier/kind/status/runtime metadata) and an inflated
+  `:var-count`. Drift checks could still pass (committed + regenerated agree
+  on the duplicate), while downstream projections silently overwrite one row
+  (`index-by-ns+var`'s `assoc`) or tolerate multiple tiers — masking the
+  spec/implementation contradiction through generation AND verification.
+
+  THE FIX. `duplicate-rows` detects any `[namespace var]` carried by more
+  than one row, and `build-manifest` throws on it before writing output or
+  reporting `--check` success. These tests pin that through `duplicate-rows`
+  (pure, synthetic inputs) plus `build-manifest` (the throw), and assert the
+  live committed manifest is duplicate-free."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.api-manifest.gen :as gen]))
+
+;; ---------------------------------------------------------------------------
+;; duplicate-rows — pure detection over synthetic rows.
+;; ---------------------------------------------------------------------------
+
+(deftest no-duplicates-yields-empty
+  (testing "a manifest with distinct [namespace var] keys has no duplicates"
+    (is (empty? (gen/duplicate-rows
+                  [{:namespace "re-frame.core" :var "reg-event-db" :tier :front-porch}
+                   {:namespace "re-frame.core" :var "subscribe"    :tier :front-porch}
+                   {:namespace "re-frame.adapter.uix" :var "adapter" :tier :adapter}])))))
+
+(deftest duplicate-within-cljs-only-detected
+  (testing "two rows sharing one [namespace var] (e.g. a duplicated :cljs-only
+            sidecar entry, possibly with a CHANGED tier) are flagged"
+    (let [dups (gen/duplicate-rows
+                 [{:namespace "re-frame.adapter.uix" :var "adapter" :tier :adapter}
+                  ;; same [ns var], conflicting tier — the exact probe shape
+                  {:namespace "re-frame.adapter.uix" :var "adapter" :tier :tooling}
+                  {:namespace "re-frame.core" :var "subscribe" :tier :front-porch}])]
+      (is (= 1 (count dups)))
+      (is (= [["re-frame.adapter.uix" "adapter"] 2] (first dups))))))
+
+(deftest duplicate-between-jvm-and-cljs-only-detected
+  (testing "a [namespace var] carried by BOTH a JVM-derived row and a
+            :cljs-only row is flagged (the cross-category collision)"
+    (let [dups (gen/duplicate-rows
+                 [{:namespace "re-frame.core" :var "frame-provider"
+                   :tier :front-porch :runtime-verified? true}
+                  {:namespace "re-frame.core" :var "frame-provider"
+                   :tier :advanced :runtime-verified? false}])]
+      (is (= 1 (count dups)))
+      (is (= [["re-frame.core" "frame-provider"] 2] (first dups))))))
+
+(deftest duplicates-are-sorted
+  (testing "the duplicate report is sorted by [namespace var] for stable output"
+    (let [dups (gen/duplicate-rows
+                 [{:namespace "zzz" :var "b"} {:namespace "zzz" :var "b"}
+                  {:namespace "aaa" :var "a"} {:namespace "aaa" :var "a"}])]
+      (is (= [["aaa" "a"] ["zzz" "b"]] (map first dups))))))
+
+;; ---------------------------------------------------------------------------
+;; build-manifest — the throw (drift-check / generation refusal).
+;; ---------------------------------------------------------------------------
+
+(defn- live-sidecar-with-duplicate-cljs-only
+  "The REAL committed sidecar with one of its `:cljs-only` rows DUPLICATED
+   (the bead's injected-duplicate probe shape). Using the real sidecar keeps
+   the missing/stale classification checks passing (the live JVM vars are all
+   classified) so the duplicate check is what fires — exactly how a hand-added
+   duplicate `:cljs-only` entry would behave in production. We pick the first
+   `:cljs-only` row and append a copy with a CHANGED tier (a conflicting
+   duplicate, the worst case)."
+  []
+  (let [sidecar (gen/read-sidecar)
+        cljs    (vec (:cljs-only sidecar))
+        _       (assert (seq cljs) "precondition: sidecar carries :cljs-only rows")
+        dup     (assoc (first cljs) :tier :tooling)]
+    (update sidecar :cljs-only conj dup)))
+
+(deftest build-manifest-throws-on-duplicate
+  (testing "build-manifest refuses to produce a manifest with a duplicate
+            [namespace var] — the throw is what turns generation / --check red"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Duplicate manifest rows"
+          (gen/build-manifest (live-sidecar-with-duplicate-cljs-only))))))
+
+(deftest build-manifest-duplicate-ex-data-lists-the-key
+  (testing "the thrown ex-data names the duplicate [namespace var] + count so
+            the sidecar/source var can be fixed"
+    (let [dup-row (first (:cljs-only (gen/read-sidecar)))
+          expected-key [(:namespace dup-row) (:var dup-row)]]
+      (try
+        (gen/build-manifest (live-sidecar-with-duplicate-cljs-only))
+        (is false "expected build-manifest to throw on the duplicate")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= [[expected-key 2]] (:duplicates (ex-data e)))
+              "ex-data must name the duplicated [namespace var] + count 2"))))))
+
+;; ---------------------------------------------------------------------------
+;; Live: the committed manifest is duplicate-free (the CI contract).
+;; ---------------------------------------------------------------------------
+
+(deftest live-manifest-has-no-duplicate-rows
+  (testing "the committed spec/api-manifest.edn carries one row per
+            [namespace var] (non-vacuous: it has many rows)"
+    (let [rows (:vars (gen/read-committed-manifest))]
+      (is (pos? (count rows)) "precondition: the manifest is non-empty")
+      (is (empty? (gen/duplicate-rows rows))
+          "the committed manifest must not carry duplicate [namespace var] rows"))))

--- a/implementation/scripts/check-examples-compile.cjs
+++ b/implementation/scripts/check-examples-compile.cjs
@@ -173,12 +173,123 @@ function buildsWithWarnings(output) {
   return parseBuildSummaries(output).completed.filter((b) => b.warnings > 0);
 }
 
+/**
+ * A warning-shaped marker that shadow-cljs prints when a build emits a
+ * compile warning — `------ WARNING #1 - :undeclared-var --------------`.
+ * Used as a corroborating signal: if such a marker appears in the captured
+ * output but NO parsable per-build summary carries `warnings > 0`, the
+ * summary parser has drifted (or shadow's summary format changed) and the
+ * warning evidence would otherwise be silently erased — a false green.
+ */
+const WARNING_MARKER_RE = /-{2,}\s*WARNING\b/;
+
+/**
+ * Normalise a build coord to the colon-prefixed form shadow-cljs prints in
+ * its summary lines (`:examples/login-uix`). The enumeration returns the
+ * colon-STRIPPED form the CLI expects (`examples/login-uix`); the summary
+ * parser captures the colon-PREFIXED form. Reconciling the two requires one
+ * canonical shape — we pick the `:`-prefixed form (the summary form).
+ */
+function normaliseBuildId(id) {
+  return id.startsWith(':') ? id : `:${id}`;
+}
+
+/**
+ * Reconcile the parsed compile summaries against the list of builds that
+ * were REQUESTED of `shadow-cljs compile` (the enumeration), on the
+ * assumption the child exited 0 (no hard `Build failed`). Returns a list of
+ * problem strings; an empty list means every requested build produced
+ * exactly one parsable completed summary AND no orphan warning marker was
+ * left unaccounted for.
+ *
+ * THE FALSE-GREEN THIS CLOSES (rf2-nlnd9y.1). The gate's teeth are the
+ * per-build `warnings` count parsed out of each summary line. But the gate
+ * previously failed ONLY on a parsed `warnings > 0` row (or a non-zero child
+ * exit). If a requested build's summary line never appeared in the captured
+ * output — or appeared in a shape the summary regex no longer matches (a
+ * shadow-cljs format change, a `1 warning` singular, a truncated line) —
+ * then `buildsWithWarnings` returns `[]`, the child still exited 0, and the
+ * gate reported SUCCESS having verified nothing about that build. A missing
+ * or unparseable summary is now a FAILURE, not a silent pass:
+ *
+ *   - every requested build must have EXACTLY ONE completed summary;
+ *   - a build with zero summaries is `missing` (drift / disappeared);
+ *   - a build with more than one summary is `duplicate` (ambiguous output);
+ *   - a completed summary for a build that was NOT requested is `unexpected`;
+ *   - a WARNING marker in the output with no parsable warning row anywhere
+ *     is `orphan-warning` (the parser drifted past warning evidence).
+ *
+ * @param {string[]} requested  enumerated build ids (colon-stripped form).
+ * @param {string}   output     combined compile output.
+ * @returns {string[]} human-readable problem descriptions (empty = OK).
+ */
+function reconcileRequestedBuilds(requested, output) {
+  const { completed } = parseBuildSummaries(output);
+  const problems = [];
+
+  // Count completed summaries per (normalised) build coord.
+  const counts = new Map();
+  for (const { build } of completed) {
+    const k = normaliseBuildId(build);
+    counts.set(k, (counts.get(k) || 0) + 1);
+  }
+
+  const requestedSet = new Set(requested.map(normaliseBuildId));
+
+  // 1) Every requested build must have exactly one completed summary.
+  for (const id of requestedSet) {
+    const n = counts.get(id) || 0;
+    if (n === 0) {
+      problems.push(
+        `${id}: requested but NO parsable "Build completed." summary was ` +
+          `found in shadow-cljs output (the build's summary disappeared or ` +
+          `no longer matches the parser — warning evidence for it would be ` +
+          `silently erased; refusing to pass it green).`,
+      );
+    } else if (n > 1) {
+      problems.push(
+        `${id}: ${n} "Build completed." summaries parsed (expected exactly ` +
+          `one) — ambiguous output; cannot trust the warning count.`,
+      );
+    }
+  }
+
+  // 2) A completed summary for a build that was never requested is drift in
+  //    the OTHER direction (the enumeration and the compiled set disagree).
+  for (const id of counts.keys()) {
+    if (!requestedSet.has(id)) {
+      problems.push(
+        `${id}: a "Build completed." summary was parsed for a build that ` +
+          `was NOT in the requested set — enumeration/output mismatch.`,
+      );
+    }
+  }
+
+  // 3) A WARNING marker with no parsable warning row anywhere means the
+  //    summary parser drifted past real warning evidence (the exact
+  //    false-green class: warnings present, exit 0, parser blind).
+  if (
+    WARNING_MARKER_RE.test(output) &&
+    buildsWithWarnings(output).length === 0
+  ) {
+    problems.push(
+      `a WARNING marker appears in the compile output but NO per-build ` +
+        `summary carries warnings>0 — the summary parser has drifted past ` +
+        `real warning evidence (warnings would ship green).`,
+    );
+  }
+
+  return problems;
+}
+
 module.exports = {
   readShadowEdn,
   stripEdnComments,
   enumerateExampleBuilds,
   parseBuildSummaries,
   buildsWithWarnings,
+  normaliseBuildId,
+  reconcileRequestedBuilds,
 };
 
 // ---------------------------------------------------------------------------
@@ -293,9 +404,30 @@ if (require.main === module) {
       process.exit(1);
     }
 
+    // 3) Coverage reconciliation (rf2-nlnd9y.1): a clean exit + zero parsed
+    //    warning rows is NOT sufficient. A requested build whose summary is
+    //    missing/unparsable, a duplicate/unexpected summary, or a WARNING
+    //    marker the parser missed all mean the warning analysis above was
+    //    BLIND for at least one build — a false green. Verify every requested
+    //    build produced exactly one parsable completed summary before
+    //    declaring success.
+    const coverageProblems = reconcileRequestedBuilds(builds, captured);
+    if (coverageProblems.length > 0) {
+      console.error(
+        `\ncheck-examples-compile: ${coverageProblems.length} build-summary ` +
+          `coverage problem(s) — shadow-cljs exited 0 but the gate could not ` +
+          `confirm a clean warning analysis for every requested build. A ` +
+          `missing/unparsable summary FAILS the gate (it would otherwise ship ` +
+          `a warning silently green):`,
+      );
+      for (const p of coverageProblems) console.error(`  ${p}`);
+      process.exit(1);
+    }
+
     console.log(
       `\ncheck-examples-compile: all ${builds.length} example builds compiled ` +
-        `with zero warnings.`,
+        `with zero warnings (every requested build produced exactly one ` +
+        `parsable completed summary).`,
     );
   });
 }

--- a/implementation/scripts/check-examples-compile.test.cjs
+++ b/implementation/scripts/check-examples-compile.test.cjs
@@ -37,6 +37,8 @@ const {
   enumerateExampleBuilds,
   parseBuildSummaries,
   buildsWithWarnings,
+  normaliseBuildId,
+  reconcileRequestedBuilds,
 } = require('./check-examples-compile.cjs');
 
 let failed = 0;
@@ -235,6 +237,122 @@ it('a warning (typo\'d var) IS detected so the gate fails RED', () => {
 it('a hard "Build failed" is surfaced via parseBuildSummaries.failed', () => {
   const { failed } = parseBuildSummaries(FAILED_OUTPUT);
   assert.deepStrictEqual(failed, [':examples/login-uix']);
+});
+
+// --- Coverage reconciliation teeth (rf2-nlnd9y.1) -------------------------
+// A clean child exit + zero PARSED warning rows is NOT proof every build was
+// analysed. If a requested build's summary is missing or unparsable, the
+// warning analysis was BLIND for that build — the gate must FAIL, not pass
+// vacuously. These pin reconcileRequestedBuilds (the new teeth) so a
+// missing/unparseable summary, a duplicate/unexpected summary, and a
+// parser-missed WARNING marker all turn the gate RED.
+
+it('normaliseBuildId canonicalises both colon shapes to the :-prefixed form', () => {
+  assert.strictEqual(normaliseBuildId('examples/login-uix'), ':examples/login-uix');
+  assert.strictEqual(normaliseBuildId(':examples/login-uix'), ':examples/login-uix');
+});
+
+it('reconcile is clean when every requested build has exactly one summary', () => {
+  // CLEAN_OUTPUT carries login-uix + login-helix summaries; request exactly
+  // those (enumeration uses the colon-stripped coords).
+  const problems = reconcileRequestedBuilds(
+    ['examples/login-uix', 'examples/login-helix'],
+    CLEAN_OUTPUT,
+  );
+  assert.deepStrictEqual(problems, [], `expected no problems, got: ${problems}`);
+});
+
+it('a requested build with NO parsable summary is a coverage FAILURE (false-green closed)', () => {
+  // Request a third build (dashboard-uix) whose summary never appears — the
+  // exact false-green: child exits 0, no warning row, gate previously passed.
+  const problems = reconcileRequestedBuilds(
+    ['examples/login-uix', 'examples/login-helix', 'examples/dashboard-uix'],
+    CLEAN_OUTPUT,
+  );
+  assert.strictEqual(problems.length, 1, `expected one problem, got: ${problems}`);
+  assert.ok(
+    problems[0].includes(':examples/dashboard-uix') &&
+      /NO parsable/.test(problems[0]),
+    `expected a missing-summary problem for dashboard-uix, got: ${problems[0]}`,
+  );
+});
+
+it('an UNPARSEABLE warning summary (singular "1 warning") FAILS the gate', () => {
+  // shadow prints `... 1 warnings` (plural) today; a format drift to the
+  // singular `1 warning` no longer matches COMPLETED_RE, so the summary is
+  // unparseable AND a WARNING marker is present. Both the missing-summary
+  // and orphan-warning teeth must fire — the warning would otherwise vanish.
+  const drifted = [
+    '[:examples/login-helix] Compiling ...',
+    '------ WARNING #1 - :undeclared-var --------------',
+    ' Use of undeclared Var login-helix.core/typo',
+    '[:examples/login-helix] Build completed. (196 files, 1 compiled, 1 warning, 5.47s)',
+  ].join('\n');
+  // The unparseable summary yields zero completed rows...
+  assert.deepStrictEqual(parseBuildSummaries(drifted).completed, []);
+  assert.deepStrictEqual(buildsWithWarnings(drifted), []);
+  // ...so the OLD gate would pass green. The reconciler must FAIL: the
+  // requested build has no parsable summary, and a WARNING marker is orphaned.
+  const problems = reconcileRequestedBuilds(['examples/login-helix'], drifted);
+  assert.ok(
+    problems.some((p) => /NO parsable/.test(p)),
+    `expected a missing-summary problem, got: ${problems}`,
+  );
+  assert.ok(
+    problems.some((p) => /WARNING marker/.test(p)),
+    `expected an orphan-WARNING-marker problem, got: ${problems}`,
+  );
+});
+
+it('zero parsed summaries with builds requested is a coverage FAILURE', () => {
+  // The whole-output-unparseable case (parser drift erased everything): no
+  // completed rows at all, but builds were requested → every one is missing.
+  const garbage = 'Build done. nothing the parser recognises here.\n';
+  assert.deepStrictEqual(parseBuildSummaries(garbage).completed, []);
+  const problems = reconcileRequestedBuilds(
+    ['examples/login-uix', 'examples/login-helix'],
+    garbage,
+  );
+  assert.strictEqual(problems.length, 2, `expected two missing, got: ${problems}`);
+  assert.ok(problems.every((p) => /NO parsable/.test(p)));
+});
+
+it('a DUPLICATE completed summary for one build is a coverage FAILURE', () => {
+  const dup = [
+    '[:examples/login-uix] Build completed. (188 files, 187 compiled, 0 warnings, 5.10s)',
+    '[:examples/login-uix] Build completed. (188 files, 0 compiled, 0 warnings, 0.10s)',
+  ].join('\n');
+  const problems = reconcileRequestedBuilds(['examples/login-uix'], dup);
+  assert.strictEqual(problems.length, 1, `expected one problem, got: ${problems}`);
+  assert.ok(/2 "Build completed." summaries/.test(problems[0]));
+});
+
+it('an UNEXPECTED completed summary (not requested) is a coverage FAILURE', () => {
+  // login-helix completed but was never requested — enumeration/output drift.
+  const problems = reconcileRequestedBuilds(['examples/login-uix'], CLEAN_OUTPUT);
+  assert.ok(
+    problems.some(
+      (p) => p.includes(':examples/login-helix') && /NOT in the requested set/.test(p),
+    ),
+    `expected an unexpected-summary problem for login-helix, got: ${problems}`,
+  );
+});
+
+it('a fully-clean WARNED_OUTPUT still has its warning caught (regression: orphan check does not mask real warnings)', () => {
+  // WARNED_OUTPUT carries a parsable `1 warnings` row, so buildsWithWarnings
+  // is non-empty and the orphan-warning branch must NOT fire (the real
+  // warning is caught by the primary buildsWithWarnings path in the CLI).
+  assert.deepStrictEqual(buildsWithWarnings(WARNED_OUTPUT), [
+    { build: ':examples/login-helix', warnings: 1 },
+  ]);
+  const problems = reconcileRequestedBuilds(
+    ['examples/login-helix', 'examples/login-uix'],
+    WARNED_OUTPUT,
+  );
+  // Both requested builds have exactly one summary, and the WARNING marker is
+  // accounted for by a parsable warning row — so reconcile is clean here (the
+  // warning is failed by the buildsWithWarnings path, not the orphan check).
+  assert.deepStrictEqual(problems, [], `expected no coverage problems, got: ${problems}`);
 });
 
 if (failed > 0) {


### PR DESCRIPTION
Closes two P1 CI-integrity false-greens (gates passing while masking real failures), both in `implementation/scripts` + their CI routing. EP-0002-clean.

## rf2-nlnd9y

1. **Example-compile gate parser collapse (P1).** `check-examples-compile.cjs` failed only on a parsed `warnings>0` row or a non-zero child exit. A requested build whose summary was missing or unparseable (format drift, disappeared line) made `buildsWithWarnings` return [] while the child exited 0 — gate passed having verified nothing. Added `reconcileRequestedBuilds`: after a clean exit, every requested build must have exactly one parsable completed summary; a missing/duplicate/unexpected summary or an orphan WARNING marker now FAILS.

2. **Manifest uniqueness (P2).** `gen.clj` concatenated `:cljs-only` sidecar rows with JVM rows and emitted verbatim with no uniqueness check — a duplicate `[namespace var]` (within `:cljs-only` or colliding with a JVM row) shipped two rows + inflated `:var-count`. Added `duplicate-rows`; `build-manifest` now throws (turns generation/--check red) on any duplicate.

3. **Splint routing (P2).** `.splint.edn` was absent from lint.yml's push path filter AND the PR detect classifier, so a `.splint.edn`-only change left `lint_surface=false` and the Splint job skipped behind a green aggregator. Added `.splint.edn` to both; new `_lint-workflow-policy.test.cjs` guards the routing.

## rf2-4ka7c2

1. **API-manifest probe routing (High).** The CLJS-only adapter/Xray/pair-MCP rows' only runtime verifier is the CLJS probe (gated on `cljs_node_test`). `report-changed-surfaces.sh` never set it for sidecar/generated-manifest/API.md changes, so a stale `:cljs-only` row could ship green. Routed `spec/api-manifest-metadata.edn`, `spec/api-manifest.edn`, `spec/API.md` to `cljs_node_test=true`.

2. **API.md projection vacuity (Medium).** `api-md-check/check!` reported OK with no extracted-row floor — a parser/table-shape collapse toward 0 rows passed vacuously. Added a non-vacuous floor (150, below the live 196) reusing `projection/vacuity-floor-problem`.

## Quality gates

False-green-now-fails (proven locally):
- Example-compile: `reconcileRequestedBuilds` unit tests — a missing summary, an unparseable singular `1 warning`, zero parsed summaries, duplicate, and unexpected summary all FAIL (were silent green).
- Manifest uniqueness: injected a duplicate `:cljs-only` row → `gen --check` exited 2 with `Duplicate manifest rows … re-frame.core/frame-provider (2 rows)` (reverted).
- Splint routing: simulated detect classifier on a `.splint.edn`-only change → `lint_surface=true` (was false).
- API.md floor: `floor-violation` fails at 0/5/149 rows.

Clean-still-passes:
- `gen --check` → OK, 484 public vars, exit 0.
- `api-md-check` → OK, 196 var-rows, exit 0.
- api-manifest `clojure -M:test` → 27 tests, 57 assertions, 0 failures.
- `check-examples-compile.test.cjs`, `_changed-surfaces.test.cjs` (63), `_lint-workflow-policy.test.cjs` (4), full script-policy component suite — all green.
- `.splint.edn`-only and unrelated-file routing both behave correctly (green path preserved).