### PR TITLE
fix(test-quiet): quiet-on-success (no green-run noise) + harness pipe deadlock (rf2-spzkgo)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
@@ -77,7 +77,13 @@
                      (or (contains? test-namespaces ns)
                          (contains? test-var-syms (symbol ns name)))))))))
 
-(defn execute-cli [{:keys [test-syms help list] :as _opts}]
+(defn execute-cli [{:keys [test-syms help list unknown-args] :as _opts}]
+  ;; Report any unknown args (the pure `cli/parse-args` collects them but
+  ;; does not print — so it can be unit-pinned without leaking a
+  ;; non-summary line on a green run; rf2-spzkgo).  Tolerated, not fatal:
+  ;; parsing continues and valid flags still take effect.
+  (doseq [arg unknown-args]
+    (println (str "Unknown arg: " arg)))
   (let [test-env (ct/empty-env)]
     (cond
       help

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node_cli.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node_cli.cljs
@@ -17,14 +17,19 @@
 
 (defn parse-args
   "Parse shadow-node CLI args into
-  `{:test-syms [..] :help? :list?}` (flags present only when set).
+  `{:test-syms [..] :help? :list? :unknown-args [..]}` (flags present
+  only when set; `:unknown-args` present only when an arg was unknown).
 
    - `--help` / `--list` set their boolean flag.
    - `--test=a,b` splits on comma into symbols and accumulates into
      `:test-syms` (repeated `--test=` flags accumulate).  A simple
      symbol selects a whole namespace; a qualified symbol selects a
      single var.
-   - any other arg is reported as unknown and otherwise ignored."
+   - any other arg is collected into `:unknown-args` (in input order)
+     and otherwise ignored.  This parser is PURE — it does not print:
+     the real CLI path (`shadow-node/execute-cli`) reports the
+     unknowns, so a contract test can pin the parse result without
+     leaking a non-summary line on a green run (rf2-spzkgo)."
   [args]
   (reduce
     (fn [opts arg]
@@ -42,8 +47,7 @@
           (update opts :test-syms into test-syms))
 
         :else
-        (do (println (str "Unknown arg: " arg))
-            opts)))
+        (update opts :unknown-args (fnil conj []) arg)))
     {:test-syms []}
     args))
 

--- a/implementation/test-quiet/test/re_frame/test_quiet_green_fixture_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_green_fixture_cljs_test.cljs
@@ -1,0 +1,15 @@
+(ns re-frame.test-quiet-green-fixture-cljs-test
+  "A deliberately minimal, always-GREEN CLJS suite used as the focused
+  target for the process-level quiet-shape regression in
+  `re-frame.test-quiet-shadow-node-cljs-test` (rf2-spzkgo).
+
+  The quiet-shape regression spawns the REAL built `out/node-test.js`
+  shadow-node entry point with `--test=<this-ns>` and asserts the green
+  stdout collapses to exactly the canonical summary — so this suite must
+  stay trivially green and emit NOTHING of its own (no `println`, no
+  warnings).  Keep it that way: any output here would be a false
+  positive for the regression."
+  (:require [cljs.test :refer-macros [deftest is]]))
+
+(deftest a-passing-test
+  (is (= 1 1)))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -68,6 +68,21 @@
     (.mkdirs pkg-dir)
     (spit (io/file pkg-dir (str file-stem ".clj")) (str source "\n"))))
 
+(defn- drain-process
+  "Drain `proc`'s stdout AND stderr concurrently, then `waitFor`.
+  Returns {:exit :out :err}.  The concurrent drain is what
+  `run-runner` relies on to avoid the pipe deadlock (rf2-spzkgo); this
+  helper is the shared primitive both it and the deadlock regression
+  use, so the regression proves the EXACT drain order the real harness
+  ships."
+  [^Process proc]
+  (let [out-f (future (slurp (.getInputStream proc)))
+        err-f (future (slurp (.getErrorStream proc)))
+        out   @out-f
+        err   @err-f
+        exit  (.waitFor proc)]
+    {:exit exit :out out :err err}))
+
 (defn- run-runner
   "Relaunch a fresh JVM that runs `re-frame.test-quiet.runner/-main` with
   `extra-args`, putting `fixture-dir` on both the classpath and the
@@ -87,11 +102,15 @@
                        extra-args)
         proc     (-> (ProcessBuilder. ^java.util.List cmd)
                      (.redirectErrorStream false)
-                     (.start))
-        out      (slurp (.getInputStream proc))
-        err      (slurp (.getErrorStream proc))
-        exit     (.waitFor proc)]
-    {:exit exit :out out :err err}))
+                     (.start))]
+    ;; Drain stdout AND stderr CONCURRENTLY (rf2-spzkgo): with separate
+    ;; pipes, slurping stdout fully and only THEN reading stderr can
+    ;; deadlock — a child that fills the stderr pipe blocks on write (so
+    ;; it never closes stdout / exits), while the parent blocks on stdout
+    ;; EOF and never reaches the stderr drain or `waitFor`.
+    ;; `drain-process` reads both on their own threads, so both pipes keep
+    ;; flowing regardless of which stream the child writes to.
+    (drain-process proc)))
 
 (defn- with-fixture-dir
   "Make a fresh temp dir, run `f` with it, then delete it."
@@ -536,3 +555,77 @@
                    " got:\n" out))
           (is (str/includes? out "0 failures, 0 errors.")
               (str "the green summary must still print; got:\n" out)))))))
+
+;; ----------------------------------------------------------------------
+;; Subprocess-harness pipe-deadlock regression — rf2-spzkgo.
+;;
+;; The harness drains a child's stdout and stderr on separate threads
+;; (see `drain-process` / `run-runner`).  Pre-fix it slurped stdout to
+;; EOF and only THEN read stderr: a child that fills the stderr pipe
+;; buffer (~64 KB on most OSes) blocks on its stderr write before
+;; closing stdout, so the parent — still blocked on stdout EOF — never
+;; reaches the stderr drain or `waitFor`, and both hang forever.
+;;
+;; This child writes a stderr payload far larger than any pipe buffer
+;; (~1 MB) AND a stdout marker, then exits NONZERO.  With the concurrent
+;; drain the harness must return the full captured stderr, the stdout
+;; marker, and the real exit code — promptly.  We run it on a bounded
+;; future so a regression that reintroduces the sequential drain fails
+;; as a TIMEOUT (deref deadline) instead of hanging the whole suite.
+
+(def ^:private big-stderr-bytes
+  "~1 MB — comfortably past any plausible OS pipe buffer (~64 KB)."
+  (* 1024 1024))
+
+(deftest harness-does-not-deadlock-on-large-stderr
+  (testing "a child flooding stderr while exiting nonzero is drained without deadlock (rf2-spzkgo)"
+    (with-fixture-dir
+      (fn [dir]
+        ;; The child program is written to a FILE rather than passed via
+        ;; `clojure.main -e`: on Windows, `ProcessBuilder` re-quoting
+        ;; strips the embedded double-quotes from an inline `-e` form, so
+        ;; `"STDOUT-MARKER"` would arrive as a bare symbol and the child
+        ;; would die compiling. A `.clj` file on disk has no such
+        ;; cross-platform arg-quoting hazard.  It writes a stdout marker,
+        ;; floods stderr with `big-stderr-bytes` of payload, then
+        ;; `System/exit`s NONZERO.
+        (let [flood-file (io/file dir "deadlock_flood.clj")]
+          (spit flood-file
+                (str "(.print (System/out) \"STDOUT-MARKER\")\n"
+                     "(.flush (System/out))\n"
+                     "(let [chunk (apply str (repeat 1024 \"E\"))]\n"
+                     "  (dotimes [_ " (quot big-stderr-bytes 1024) "]\n"
+                     "    (.print (System/err) chunk)))\n"
+                     "(.flush (System/err))\n"
+                     "(System/exit 3)\n"))
+          (let [os-win   (str/includes? (str/lower-case (System/getProperty "os.name")) "win")
+                java-bin (str (io/file (System/getProperty "java.home") "bin"
+                                       (if os-win "java.exe" "java")))
+                cmd      [java-bin "-cp" (System/getProperty "java.class.path")
+                          "clojure.main" (.getAbsolutePath flood-file)]
+                result-f (future
+                           (-> (ProcessBuilder. ^java.util.List cmd)
+                               (.redirectErrorStream false)
+                               (.start)
+                               (drain-process)))
+                ;; A correctly draining harness returns in well under a
+                ;; second; 60s is a generous ceiling that still FAILS (not
+                ;; hangs) if the sequential-drain deadlock is reintroduced.
+                result   (deref result-f 60000 ::timed-out)]
+            (is (not= ::timed-out result)
+                (str "the harness deadlocked: a >pipe-buffer stderr flood with a"
+                     " sequential (stdout-then-stderr) drain hangs forever"
+                     " (rf2-spzkgo) — it must drain both streams concurrently"))
+            (when (not= ::timed-out result)
+              (let [{:keys [exit out err]} result]
+                (is (= 3 exit)
+                    (str "the child's nonzero exit code must be captured; got "
+                         exit "\n--- stderr head ---\n"
+                         (subs err 0 (min 300 (count err)))))
+                (is (str/includes? out "STDOUT-MARKER")
+                    (str "the stdout marker must be captured alongside the"
+                         " stderr flood; got stdout:\n" out))
+                (is (>= (count err) big-stderr-bytes)
+                    (str "the full stderr flood must be captured, not truncated"
+                         " by a partial drain; got " (count err)
+                         " bytes, expected >= " big-stderr-bytes))))))))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -40,6 +40,7 @@
   ;; `-cli` ns; the console.warn stub it installs is live at runtime
   ;; anyway because shadow-node is the :node-test build's :main.
   (:require [cljs.test :refer-macros [deftest is testing] :refer [successful?]]
+            [clojure.string :as str]
             [re-frame.test-quiet.shadow-node-cli :as cli]))
 
 ;; ----------------------------------------------------------------------
@@ -69,10 +70,20 @@
     (is (= {:test-syms [] :help true} (cli/parse-args ["--help"]))))
   (testing "no args yields the run-all default (empty test-syms, no flags)"
     (is (= {:test-syms []} (cli/parse-args []))))
-  (testing "unknown args are tolerated and do not abort parsing"
-    (is (= {:test-syms '[ok.ns]}
+  (testing "unknown args are collected (not printed) and do not abort parsing"
+    ;; The pure parser must NOT print on an unknown arg — it collects
+    ;; them into `:unknown-args` and the real CLI path reports them. This
+    ;; keeps the green-run contract gate truly silent-on-success: a
+    ;; `(println \"Unknown arg: ...\")` here would leak a non-summary line
+    ;; into every consolidated `npm run test:cljs` run (rf2-spzkgo).
+    (is (= {:test-syms '[ok.ns] :unknown-args ["--bogus"]}
            (cli/parse-args ["--bogus" "--test=ok.ns"]))
-        "an unknown flag is skipped; later valid flags still parse")))
+        "an unknown flag is collected; later valid flags still parse")
+    (is (= {:test-syms '[ok.ns] :unknown-args ["--bogus" "--nope"]}
+           (cli/parse-args ["--bogus" "--test=ok.ns" "--nope"]))
+        "multiple unknown flags accumulate in input order")
+    (is (not (contains? (cli/parse-args ["--test=ok.ns"]) :unknown-args))
+        "a clean arg set carries no :unknown-args key at all")))
 
 ;; ----------------------------------------------------------------------
 ;; Var filtering — simple symbols match by ns, qualified by fully-qualified
@@ -235,3 +246,70 @@
     ;; And it must still accept a bare call without throwing.
     (is (nil? (js/console.warn "stub-smoke"))
         "the silencing stub must accept a bare call without throwing")))
+
+;; ----------------------------------------------------------------------
+;; Process-level quiet-shape regression (rf2-spzkgo).
+;;
+;; The pure-parser pins above lock that `parse-args` no longer PRINTS on
+;; an unknown arg — but the slice's core promise is that the REAL
+;; shadow-node entry point is silent-on-success.  That promise lived only
+;; in the JVM contract test (`re-frame.test-quiet-runner-contract-test`);
+;; the CLJS process path could regress without any test catching it (a
+;; stray `println`, a dropped console.warn stub, a banner leak).
+;;
+;; This regression spawns the SAME built `out/node-test.js` shadow-node
+;; runner this very process is executing, focused on a known-GREEN suite
+;; (`re-frame.test-quiet-green-fixture-cljs-test`, a single `is (= 1 1)`),
+;; captures its stdout, and fails if any green line other than the
+;; allowed canonical summary appears — `Unknown arg`, a `Testing <ns>`
+;; banner, leaked warnings, or any other non-summary text.
+
+(def ^:private node-child-process (js/require "child_process"))
+
+(def ^:private allowed-green-line-re
+  "A non-blank green stdout line must be one of the two canonical summary
+  lines.  `Ran N tests containing M assertions.` / `K failures, J errors.`"
+  #"^(Ran \d+ tests containing \d+ assertions\.|\d+ failures, \d+ errors\.)$")
+
+(deftest real-shadow-node-green-run-is-quiet
+  (testing "the real out/node-test.js entry point emits ONLY the canonical summary on a focused green run (rf2-spzkgo)"
+    ;; `process.argv[1]` is the path to the runner script THIS process is
+    ;; executing (out/node-test.js) — re-running it focused on the green
+    ;; fixture exercises the real CLI path end-to-end.
+    (let [self     (aget js/process.argv 1)
+          green-ns "re-frame.test-quiet-green-fixture-cljs-test"
+          res      (.spawnSync node-child-process
+                               (aget js/process.argv 0) ; the node binary
+                               #js [self (str "--test=" green-ns)]
+                               #js {:encoding "utf8"})
+          status   (.-status res)
+          stdout   (or (.-stdout res) "")
+          stderr   (or (.-stderr res) "")
+          ;; cljs.test spawn errors (e.g. ENOENT) surface on res.error.
+          err      (.-error res)]
+      (is (nil? err)
+          (str "spawning the real runner must not error; got: " (pr-str err)))
+      (is (zero? status)
+          (str "the focused green run must exit 0; got " status
+               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
+      (let [non-blank (->> (str/split-lines stdout)
+                           (map str/trim)
+                           (remove str/blank?))]
+        ;; The CORE pin: NOT ONE non-summary line. This is what `Unknown
+        ;; arg: --bogus` used to violate before the parser was made pure.
+        (is (every? #(re-matches allowed-green-line-re %) non-blank)
+            (str "a green run must emit ONLY the canonical summary lines —"
+                 " any other stdout line (e.g. `Unknown arg`, a `Testing`"
+                 " banner, a leaked warning) breaks silent-on-success"
+                 " (rf2-spzkgo). Got non-blank lines:\n"
+                 (str/join "\n" non-blank)))
+        (is (not (str/includes? stdout "Unknown arg"))
+            (str "the specific rf2-spzkgo regression: `Unknown arg` must"
+                 " NEVER reach a green run's stdout; got:\n" stdout))
+        (is (not (str/includes? stdout "Testing "))
+            (str "no per-ns banner may leak on green; got:\n" stdout))
+        (is (some #(str/starts-with? % "Ran ") non-blank)
+            (str "the summary `Ran ...` line must still be present; got:\n"
+                 stdout))
+        (is (some #(re-matches #"0 failures, 0 errors\." %) non-blank)
+            (str "the green tally line must be present; got:\n" stdout))))))


### PR DESCRIPTION
Fixes rf2-spzkgo (P1, senior-review). Two test-quiet defects.

**Issue 1 — green-run noise.** `parse-args` printed `Unknown arg: <arg>` inline, so the CLJS contract test's `--bogus` case leaked a non-summary line on every green consolidated node-test run, defeating silent-on-success. Made `parse-args` PURE: it collects unknowns into `:unknown-args`; the real CLI path (`shadow-node/execute-cli`) reports them. The contract test now asserts on the returned map (no stdout). Added a process-level quiet-shape regression (`real-shadow-node-green-run-is-quiet`) that spawns the real `out/node-test.js` focused on a known-green fixture and fails if any green stdout line other than the canonical summary appears.

**Issue 2 — harness pipe deadlock.** The JVM subprocess contract harness slurped stdout to EOF then read stderr, so a child filling the stderr pipe could block on write while the parent blocked on stdout EOF — a deadlock. Now drains both streams concurrently via futures (shared `drain-process` helper). Added a regression child (`harness-does-not-deadlock-on-large-stderr`) that floods ~1MB to stderr and exits nonzero, run on a bounded future so a reintroduced sequential drain fails as a timeout, not a hang.

All changes confined to `implementation/test-quiet`.

## Quality gates

- `npm run test:cljs` (consolidated node-test gate): GREEN — 6081 tests / 21618 assertions, 0 failures, 0 errors.
- Green-run cleanliness: BEFORE — `Unknown arg: --bogus` leaked on every green run that included the test-quiet contract ns. AFTER — `grep -c 'Unknown arg'` on the full gate output = 0; focused green run is exactly the canonical 3-line summary.
- test-quiet JVM suite (`clojure -M:test`): GREEN — 16 tests / 59 assertions, 0 failures, 0 errors.
- Regression verified RED-on-bug: reverting `drain-process` to the sequential drain makes the deadlock regression time out and FAIL (`the harness deadlocked`); adding a stray `println` to the green fixture makes the CLJS quiet-shape regression FAIL.