### PR TITLE
feat: EP-0002 registration-time frame-local surfaces require explicit frame, no :rf/default-at-load (rf2-5q7um6)

### DIFF
--- a/examples/reagent/boot/schema.cljs
+++ b/examples/reagent/boot/schema.cljs
@@ -34,7 +34,8 @@
             ;; Malli validation — without it, the default validator
             ;; soft-passes per Spec 010 §Recommended soft-pass and
             ;; no failure trace fires for malformed app-db slices.
-            [re-frame.schemas.malli]))
+            [re-frame.schemas.malli])
+  (:require-macros [re-frame.core :refer [with-frame]]))
 
 ;; ============================================================================
 ;; WIRE SHAPES — what the mocked endpoints return
@@ -161,17 +162,25 @@
 ;; machine's own `:data-schema` is the snapshot-validation surface, so the
 ;; vestigial app-schema reg is removed.
 
-;; The :spawn-all children stage their payloads into [:boot/staging]
-;; before signalling completion to the parent. The :enter-hydrating
-;; action reads the staging slot and promotes each payload into the
-;; canonical top-level slot below. Registered here so the staging
-;; writes are schema-validated like every other slice.
-(rf/reg-app-schema [:boot/staging] [:maybe BootStagingSlice])
+;; EP-0002 (rf2-5q7um6): `reg-app-schema` is context-required frame-local —
+;; a bare ns-load call under no scope raises `:rf.error/no-frame-context`
+;; (boot-time namespace loading is NOT a reason to synthesise `:rf/default`,
+;; per Spec 002 §Frame target resolution). This example's app runs in the
+;; `:rf/default` frame (see `core/run`, which `reg-frame`s it explicitly),
+;; so name the frame explicitly here via `with-frame` — the registrations
+;; carry a frame stamp even though they land at module-load before `init!`.
+(with-frame :rf/default
+  ;; The :spawn-all children stage their payloads into [:boot/staging]
+  ;; before signalling completion to the parent. The :enter-hydrating
+  ;; action reads the staging slot and promotes each payload into the
+  ;; canonical top-level slot below. Registered here so the staging
+  ;; writes are schema-validated like every other slice.
+  (rf/reg-app-schema [:boot/staging] [:maybe BootStagingSlice])
 
-;; The boot machine writes its final payloads into top-level app-db
-;; slices on entering `:hydrating`. These are the slices the main app
-;; reads via subs once the boot reaches `:ready`.
-(rf/reg-app-schema [:config] [:maybe Config])
-(rf/reg-app-schema [:flags]  [:maybe Flags])
-(rf/reg-app-schema [:user]   [:maybe User])
-(rf/reg-app-schema [:routes] [:maybe Routes])
+  ;; The boot machine writes its final payloads into top-level app-db
+  ;; slices on entering `:hydrating`. These are the slices the main app
+  ;; reads via subs once the boot reaches `:ready`.
+  (rf/reg-app-schema [:config] [:maybe Config])
+  (rf/reg-app-schema [:flags]  [:maybe Flags])
+  (rf/reg-app-schema [:user]   [:maybe User])
+  (rf/reg-app-schema [:routes] [:maybe Routes]))

--- a/examples/reagent/flows/core.cljs
+++ b/examples/reagent/flows/core.cljs
@@ -54,7 +54,7 @@
             [re-frame.flows]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ============================================================================
 ;; FLOWS  (Spec 013 §Registration shape)
@@ -65,6 +65,13 @@
 
 (defn- line-total [{:keys [price qty]}]
   (* price qty))
+
+;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local; a bare
+;; ns-load call raises :rf.error/no-frame-context. This example runs in the
+;; :rf/default frame, so name it explicitly here. (The runtime-toggleable
+;; `:cart/discount-rate` flow is registered later via :rf.fx/reg-flow, which
+;; inherits the cascade frame — see the discount button handler.)
+(with-frame :rf/default
 
 (rf/reg-flow
   {:id     :cart/subtotal
@@ -97,7 +104,7 @@
    :output (fn [subtotal discount-rate]
              (let [rate (or discount-rate 0)]
                (Math/round (* subtotal (- 1 rate)))))
-   :path   [:cart :total]})
+   :path   [:cart :total]}))
 
 ;; ============================================================================
 ;; EVENTS

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -93,7 +93,7 @@
             [re-frame.http-test-support]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ============================================================================
 ;; CONSTANTS
@@ -133,7 +133,11 @@
    [:errors  {:default {}} [:map-of :keyword [:vector :string]]]
    [:touched {:default #{}} [:set :keyword]]])
 
-(rf/reg-app-schema [:new-todo] NewTodoSlice)
+;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local; a
+;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
+;; :rf/default (see `run`/`reg-frame :rf/default`), so name it explicitly.
+(with-frame :rf/default
+  (rf/reg-app-schema [:new-todo] NewTodoSlice))
 
 ;; ============================================================================
 ;; FX  (test-friendly stubs)

--- a/examples/reagent/realworld/schema.cljs
+++ b/examples/reagent/realworld/schema.cljs
@@ -20,7 +20,8 @@
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schemas resolves at the call site below.
-            [re-frame.schemas]))
+            [re-frame.schemas])
+  (:require-macros [re-frame.core :refer [with-frame]]))
 
 ;; ============================================================================
 ;; WIRE SHAPES — what the RealWorld API returns
@@ -235,7 +236,12 @@
 ;; All paths here are app-db paths. Machine snapshots are NOT app-db — they
 ;; live in runtime-db and are validated through each machine's `:data-schema`
 ;; (the *Data schemas above), so they do not appear in this app-schema map.
-(rf/reg-app-schemas
+;;
+;; EP-0002 (rf2-5q7um6): reg-app-schemas is context-required frame-local; a
+;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
+;; :rf/default (see `core/run`'s `reg-frame :rf/default`), so name it here.
+(with-frame :rf/default
+ (rf/reg-app-schemas
   {[:auth]                          AuthSlice
    [:articles]                      RequestSlice
    [:articles :data]                [:vector Article]
@@ -254,4 +260,4 @@
    [:comment-form]                  FormSlice
    [:auth :login-form]              FormSlice
    [:auth :register-form]           FormSlice
-   [:editor]                        EditorSlice})
+   [:editor]                        EditorSlice}))

--- a/examples/reagent/websocket/schema.cljs
+++ b/examples/reagent/websocket/schema.cljs
@@ -22,7 +22,8 @@
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
             ;; rf/reg-app-schema resolves at the call sites below.
-            [re-frame.schemas]))
+            [re-frame.schemas])
+  (:require-macros [re-frame.core :refer [with-frame]]))
 
 ;; ============================================================================
 ;; CONNECTION MACHINE :data SHAPE
@@ -130,4 +131,9 @@
 ;; schemas validate the app-db partition only, Mike ruling #11). The
 ;; machine's own `:data-schema` is the snapshot-validation surface, so the
 ;; vestigial app-schema reg is removed.
-(rf/reg-app-schema [:messages]                   MessagesSlice)
+;;
+;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local; a
+;; bare ns-load call raises :rf.error/no-frame-context. This example runs in
+;; the :rf/default frame, so name it explicitly here.
+(with-frame :rf/default
+  (rf/reg-app-schema [:messages]                   MessagesSlice))

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -135,14 +135,26 @@
   nil)
 
 (defn declarations
-  "Return schema-derived `:large?` declarations for `frame-id`."
-  ([] (declarations :rf/default))
+  "Return schema-derived `:large?` declarations for `frame-id`. EP-0002 —
+  the zero-arity ambient form resolves the frame through the
+  carried-invariant scope chain (`frame/require-current-frame!`); under no
+  established scope it raises `:rf.error/no-frame-context` rather than
+  reading a synthesised `:rf/default` registry."
+  ([] (declarations (frame/require-current-frame!
+                      :elision-declarations
+                      {:where 're-frame.elision/declarations})))
   ([frame-id]
    (or (get (registry-of frame-id) :declarations) {})))
 
 (defn sensitive-declarations
-  "Return schema-derived `:sensitive?` declarations for `frame-id`."
-  ([] (sensitive-declarations :rf/default))
+  "Return schema-derived `:sensitive?` declarations for `frame-id`. EP-0002
+  — the zero-arity ambient form resolves the frame through the
+  carried-invariant scope chain (`frame/require-current-frame!`); under no
+  established scope it raises `:rf.error/no-frame-context` rather than
+  reading a synthesised `:rf/default` registry."
+  ([] (sensitive-declarations (frame/require-current-frame!
+                                :elision-sensitive-declarations
+                                {:where 're-frame.elision/sensitive-declarations})))
   ([frame-id]
    (or (get (registry-of frame-id) :sensitive-declarations) {})))
 
@@ -178,8 +190,16 @@
 
 (defn populate-elision-from-schemas!
   "Populate `[:rf.runtime/elision :declarations]` from `{:large? true}`
-  schema slot metadata. Returns the populated paths."
-  ([] (populate-elision-from-schemas! (frame/current-frame)))
+  schema slot metadata. Returns the populated paths. EP-0002 — the
+  zero-arity ambient form resolves the frame through the carried-invariant
+  scope chain (`frame/require-current-frame!`); under no established scope
+  it raises `:rf.error/no-frame-context` rather than populating a
+  synthesised `:rf/default` registry. The per-dispatch / registration-time
+  callers (router, schema storage) always pass an explicit `frame-id`."
+  ([] (populate-elision-from-schemas!
+        (frame/require-current-frame!
+          :populate-elision-from-schemas
+          {:where 're-frame.elision/populate-elision-from-schemas!})))
   ([frame-id]
    (install-schema-declarations!
      frame-id
@@ -189,8 +209,14 @@
 (defn populate-sensitive-from-schemas!
   "Populate `[:rf.runtime/elision :sensitive-declarations]` from
   `{:sensitive? true}` schema slot metadata. Returns the populated
-  paths."
-  ([] (populate-sensitive-from-schemas! (frame/current-frame)))
+  paths. EP-0002 — the zero-arity ambient form resolves the frame through
+  the carried-invariant scope chain (`frame/require-current-frame!`); under
+  no scope it raises `:rf.error/no-frame-context` rather than populating a
+  synthesised `:rf/default` registry."
+  ([] (populate-sensitive-from-schemas!
+        (frame/require-current-frame!
+          :populate-sensitive-from-schemas
+          {:where 're-frame.elision/populate-sensitive-from-schemas!})))
   ([frame-id]
    (install-schema-declarations!
      frame-id
@@ -198,8 +224,14 @@
      (schema-declarations frame-id :schemas/extract-sensitive-paths-from-schema))))
 
 (defn populate-from-schemas!
-  "Refresh both schema-owned declaration registries for `frame-id`."
-  ([] (populate-from-schemas! (frame/current-frame)))
+  "Refresh both schema-owned declaration registries for `frame-id`. EP-0002
+  — the zero-arity ambient form resolves the frame through the
+  carried-invariant scope chain; under no scope it raises
+  `:rf.error/no-frame-context`."
+  ([] (populate-from-schemas!
+        (frame/require-current-frame!
+          :populate-from-schemas
+          {:where 're-frame.elision/populate-from-schemas!})))
   ([frame-id]
    {:large     (populate-elision-from-schemas! frame-id)
     :sensitive (populate-sensitive-from-schemas! frame-id)}))
@@ -531,7 +563,14 @@
 
 (defn elide-wire-value
   "Walk `v` and substitute schema-declared sensitive or large paths for
-  wire egress. Sensitive wins over large when both declarations match."
+  wire egress. Sensitive wins over large when both declarations match.
+
+  EP-0002 scope boundary: the `(or … :rf/default)` floor below is the
+  OPERATION-TIME wire-egress projection path, owned by the trace/elision
+  projection bead (rf2-gjq3ow), which makes frameless egress FAIL CLOSED
+  (redact conservatively / refuse) rather than borrow `:rf/default` marks.
+  It is intentionally NOT migrated here — this bead (rf2-5q7um6) covers the
+  REGISTRATION-time surfaces only."
   ([v] (elide-wire-value v nil))
   ([v opts]
    (let [frame-id  (or (:frame opts) (frame/current-frame) :rf/default)

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -23,7 +23,17 @@
   ;; `config` is a `defonce` (survives `:reload`); restore the documented
   ;; default so a configure tweak in one test does not leak into the next.
   (elision/configure! {:rf.size/threshold-bytes 16384})
-  (test-fn))
+  ;; EP-0002 (rf2-5q7um6): reg-app-schema + the zero-arity
+  ;; populate-*-from-schemas! / declarations / sensitive-declarations
+  ;; readers are context-required frame-local — an ambient call under no
+  ;; scope raises :rf.error/no-frame-context. Pin :rf/default as the
+  ;; established scope so those ambient registration/populate calls carry a
+  ;; frame stamp (the elide-wire-value wire-egress path still floors to
+  ;; :rf/default until rf2-gjq3ow makes it fail-closed, so both read the
+  ;; same :rf/default registry — consistent end-to-end).
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -931,19 +931,35 @@
 ;; surface; this test pins their round-trip contract.
 
 (deftest frame-ids-round-trip
-  (testing "(rf/frame-ids) returns every registered, non-destroyed frame id
-            plus :rf/default"
+  (testing "(rf/frame-ids) returns every registered, non-destroyed frame id"
+    ;; EP-0002 (rf2-5q7um6): `:rf/default` is an ORDINARY id — `init!` no
+    ;; longer creates it, and `frame-ids` is a frame-neutral enumeration
+    ;; surface (it reports exactly the registered frames, never synthesises
+    ;; a default). It appears here only because this test registers it
+    ;; explicitly, alongside the user frames — proving the round-trip
+    ;; without leaning on a runtime-synthesised floor.
+    (rf/reg-frame :rf/default     {:doc "explicitly-registered ordinary default frame"})
     (rf/reg-frame :tenants/acme    {:doc "acme tenant"  :preset :default})
     (rf/reg-frame :tenants/widgets {:doc "widgets co"   :preset :default})
     (let [ids (rf/frame-ids)]
       (is (set? ids) "frame-ids returns a set")
       (is (contains? ids :rf/default)
-          ":rf/default appears alongside user-registered frames")
+          ":rf/default appears because it was EXPLICITLY registered (no runtime floor)")
       (is (contains? ids :tenants/acme))
       (is (contains? ids :tenants/widgets))
       ;; Sanity: a never-registered id is absent.
       (is (not (contains? ids :tenants/nonexistent))
-          "frame-ids excludes ids that were never registered"))))
+          "frame-ids excludes ids that were never registered")))
+  (testing "frame-ids does NOT synthesise :rf/default when it was never registered"
+    ;; Fresh slate (the :each fixture already reset frames + init!'d without
+    ;; creating :rf/default). Register only user frames.
+    (reset! frame/frames {})
+    (rf/init! plain-atom/adapter)
+    (rf/reg-frame :tenants/solo {:doc "sole user frame"})
+    (let [ids (rf/frame-ids)]
+      (is (not (contains? ids :rf/default))
+          "EP-0002: :rf/default is not present unless explicitly registered")
+      (is (contains? ids :tenants/solo)))))
 
 (deftest frame-meta-round-trip
   (testing "(rf/frame-meta id) returns the canonical flat :rf/frame-meta shape

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -508,13 +508,22 @@
   Required keys on the flow map: :id :inputs :output :path.
   Optional: :doc :schema.
 
-  The frame to register against comes from the optional :frame opt;
-  default is (frame/current-frame) — usually :rf/default unless
-  called inside a (with-frame ...) wrapper or under a frame-provider."
+  EP-0002 — flows are CONTEXT-REQUIRED FRAME-LOCAL registration. The
+  frame to register against is the explicit `:frame` opt (the *override*),
+  else the carried-invariant scope chain via `frame/require-current-frame!`
+  (a `with-frame` / frame-provider scope, or a frame `:on-create` hook). A
+  `reg-flow` issued under no established scope and no explicit `:frame`
+  raises the always-on `:rf.error/no-frame-context` (per Spec 002 §Frame
+  target resolution) rather than silently registering against `:rf/default`
+  — namespace-load time is not a reason to synthesise a default frame."
   ([flow] (reg-flow flow {}))
   ([flow {:keys [frame] :as _opts}]
    (validate-flow flow)
-   (let [frame-id (or frame (frame/current-frame))
+   (let [frame-id (or frame
+                      (frame/require-current-frame!
+                        :reg-flow
+                        {:where    'rf/reg-flow
+                         :event-id (:id flow)}))
          flow-id  (:id flow)]
      ;; ATOMIC check-and-insert (rf2-qxwib). The cycle check and the
      ;; commit are ONE `swap!` update fn over `@flows`: it reads the
@@ -829,7 +838,12 @@
 
 (defn clear-flow
   "Deregister a flow from a frame; dissoc its output path from that
-  frame's app-db (only that frame). Frame defaults to (current-frame).
+  frame's app-db (only that frame). EP-0002 — context-required
+  frame-local: the explicit `:frame` opt (the *override*) wins, else the
+  carried-invariant scope chain via `frame/require-current-frame!`. A
+  `clear-flow` issued under no established scope and no explicit `:frame`
+  raises `:rf.error/no-frame-context` rather than clearing against
+  `:rf/default`.
 
   Per audit rf2-q25os: the nested-path dissoc is robust against the
   output path never having been materialised (no spurious nil parent
@@ -847,7 +861,11 @@
   not the parent's emptiness."
   ([id] (clear-flow id {}))
   ([id {:keys [frame] :as _opts}]
-   (let [frame-id (or frame (frame/current-frame))
+   (let [frame-id (or frame
+                      (frame/require-current-frame!
+                        :clear-flow
+                        {:where    'rf/clear-flow
+                         :event-id id}))
          ;; rf2-4wqu6 finding 2: the flow lookup + `:path` capture MUST
          ;; happen INSIDE the drain-lock, not before it. Pre-fix this
          ;; read the flow and captured `path` ahead of

--- a/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
+++ b/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
@@ -118,7 +118,12 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
+  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
+  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -140,6 +140,17 @@
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.flows :reload)
+  ;; EP-0002 (rf2-5q7um6): the conformance corpus registers flows and
+  ;; dispatches ambiently against :rf/default; reg-flow + dispatch are now
+  ;; context-required (no :rf/default floor). Register :rf/default as an
+  ;; ordinary frame here so the scope is available — but do NOT pin
+  ;; `*current-frame*` around the whole body: `run-fixture`'s `reg-frame`
+  ;; must run with no in-flight scope so its `:on-create` cascade fires
+  ;; SYNCHRONOUSLY (frame/reg-frame async-queues on-create when
+  ;; `*current-frame*` is bound — Spec 002 §reg-frame from inside a
+  ;; handler). `run-fixture` pins the scope itself, after `reg-frame`,
+  ;; around `realise-flows!` + the dispatch loop.
+  (frame/ensure-default-frame!)
   (test-fn))
 
 (use-fixtures :each reset-runtime)
@@ -518,12 +529,23 @@
           ;; registering them before the destroy would wipe them.
           _            (rf/destroy-frame! :rf/default)
           _            (realise-event-sub-fx-handlers fixture)
+          ;; reg-frame runs with NO in-flight scope so its `:on-create`
+          ;; cascade fires SYNCHRONOUSLY (Spec 002 §reg-frame from inside a
+          ;; handler async-queues on-create when `*current-frame*` is bound;
+          ;; EP-0002 / rf2-5q7um6). The carried-invariant scope is pinned
+          ;; AFTER reg-frame, around `realise-flows!` + the dispatch loop.
           _            (if (seq frames-spec)
                          (doseq [f frames-spec]
                            (rf/reg-frame (:id f) (dissoc f :id)))
                          (rf/reg-frame :rf/default frame-config))
-          _            (realise-flows! fixture)
           dispatches   (or (:fixture/dispatches fixture) [])]
+      ;; EP-0002 (rf2-5q7um6): reg-flow + bare single-frame dispatches are
+      ;; context-required frame-local. Pin :rf/default as the established
+      ;; scope for the no-explicit-frame calls below. Multi-frame fixtures
+      ;; pass explicit `{:frame …}` envelopes (the override), which win over
+      ;; this ambient binding.
+      (binding [frame/*current-frame* :rf/default]
+       (realise-flows! fixture)
       ;; Dispatches may be:
       ;;   - a bare event vector (single-frame default)
       ;;   - an envelope map `{:event [...] :frame <id> ...}` (multi-frame,
@@ -545,7 +567,7 @@
               (rf/dispatch-sync event (dissoc opts :event))))
 
           :else
-          (rf/dispatch-sync ev)))
+          (rf/dispatch-sync ev))))
       ;; ---- assertion gathering -----------------------------------------
       (let [expect           (or (:fixture/expect fixture) {})
             expected-db      (:final-app-db expect)

--- a/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
+++ b/implementation/flows/test/re_frame/flows_destroy_frame_teardown_test.clj
@@ -39,7 +39,12 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
+  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
+  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
+++ b/implementation/flows/test/re_frame/flows_lifecycle_drain_race_test.clj
@@ -67,7 +67,12 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
+  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
+  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/flows/test/re_frame/flows_output_marks_test.clj
+++ b/implementation/flows/test/re_frame/flows_output_marks_test.clj
@@ -50,8 +50,13 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
+  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
+  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
+  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  (frame/ensure-default-frame!)
   (let [captured (atom [])]
-    (binding [*captured* captured]
+    (binding [*captured*           captured
+              frame/*current-frame* :rf/default]
       (trace/register-listener!
         ::flow-marks-recorder
         (fn [ev] (swap! captured conj ev)))

--- a/implementation/flows/test/re_frame/flows_path_overlap_test.clj
+++ b/implementation/flows/test/re_frame/flows_path_overlap_test.clj
@@ -52,7 +52,12 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
+  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
+  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
+++ b/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
@@ -60,7 +60,12 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
+  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
+  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/flows/test/re_frame/flows_reg_flow_toctou_test.clj
+++ b/implementation/flows/test/re_frame/flows_reg_flow_toctou_test.clj
@@ -59,7 +59,12 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
+  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
+  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/flows/test/re_frame/flows_rollback_dirty_check_test.clj
+++ b/implementation/flows/test/re_frame/flows_rollback_dirty_check_test.clj
@@ -56,8 +56,14 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
+  ;; EP-0002 (rf2-5q7um6): reg-flow / reg-app-schema are context-required
+  ;; frame-local — an ambient call under no scope raises
+  ;; :rf.error/no-frame-context. Pin :rf/default (an ordinary frame) as the
+  ;; established scope for the body.
+  (frame/ensure-default-frame!)
   (try
-    (test-fn)
+    (binding [frame/*current-frame* :rf/default]
+      (test-fn))
     (finally
       (schemas/reset-schema-validator!))))
 

--- a/implementation/flows/test/re_frame/flows_schema_validation_test.clj
+++ b/implementation/flows/test/re_frame/flows_schema_validation_test.clj
@@ -51,8 +51,14 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
+  ;; EP-0002 (rf2-5q7um6): reg-flow / reg-app-schema are context-required
+  ;; frame-local — an ambient call under no scope raises
+  ;; :rf.error/no-frame-context. Pin :rf/default (an ordinary frame) as the
+  ;; established scope for the body.
+  (frame/ensure-default-frame!)
   (let [captured (atom [])]
-    (binding [*captured* captured]
+    (binding [*captured*           captured
+              frame/*current-frame* :rf/default]
       (trace/register-listener!
         ::schema-violation-recorder
         (fn [ev]

--- a/implementation/flows/test/re_frame/flows_t2_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_t2_trace_test.clj
@@ -41,7 +41,12 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
+  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
+  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -49,7 +49,16 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-5q7um6): `reg-flow` / `clear-flow` are context-required
+  ;; frame-local — an ambient call under NO established scope now raises
+  ;; `:rf.error/no-frame-context` (there is no `:rf/default` floor). `init!`
+  ;; no longer creates `:rf/default`; register it as an ordinary frame and
+  ;; pin `*current-frame*` so the ambient `reg-flow` / `dispatch-sync` calls
+  ;; in the bodies below carry a scope stamp. Fixture-level equivalent of
+  ;; wrapping each body in `(rf/with-frame :rf/default …)`.
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -39,8 +39,13 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
+  ;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local — an
+  ;; ambient call under no scope raises :rf.error/no-frame-context. Pin
+  ;; :rf/default (an ordinary frame) as the established scope for the body.
+  (frame/ensure-default-frame!)
   (let [captured (atom [])]
-    (binding [*captured* captured]
+    (binding [*captured*           captured
+              frame/*current-frame* :rf/default]
       (trace/register-listener!
         ::flow-trace-recorder
         (fn [ev]

--- a/implementation/flows/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/flows/test/re_frame/late_bind_missing_test.clj
@@ -121,11 +121,18 @@
     (with-hook-as-nil :flows/run-flows-on-db
       (fn []
         (rf/init! plain-atom/adapter)
-        (rf/reg-event-db :flows-absent/init (fn [_ _] {:probe :ok}))
-        (is (do (rf/dispatch-sync [:flows-absent/init]) :ok)
-            "dispatch completes without throwing when the run-flows! hook is absent")
-        (is (= {:probe :ok} (rf/app-db-value :rf/default))
-            ":db commit lands even though the outermost-`:after` flow walker is a no-op")))))
+        ;; EP-0002 (rf2-5q7um6): `init!` no longer creates `:rf/default`,
+        ;; and a bare `dispatch-sync` under no established scope raises
+        ;; `:rf.error/no-frame-context`. Register `:rf/default` and pin it
+        ;; as the established scope so this absent-flows-artefact drain test
+        ;; carries a frame stamp (the carried invariant).
+        (frame/ensure-default-frame!)
+        (binding [frame/*current-frame* :rf/default]
+          (rf/reg-event-db :flows-absent/init (fn [_ _] {:probe :ok}))
+          (is (do (rf/dispatch-sync [:flows-absent/init]) :ok)
+              "dispatch completes without throwing when the run-flows! hook is absent")
+          (is (= {:probe :ok} (rf/app-db-value :rf/default))
+              ":db commit lands even though the outermost-`:after` flow walker is a no-op"))))))
 
 (deftest reset-last-inputs!-no-ops-when-flows-artefact-missing
   (testing "test-support's reset-runtime fixture no-ops when :flows/reset-last-inputs! hook is nil"

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -69,7 +69,8 @@
   `re-frame.flows.registry`'s private `flows` atom + the
   `flows-snapshot` accessor). Frame-scoped: an interceptor registered
   against frame A does not fire for a request dispatched from frame B."
-  (:require [re-frame.http-encoding :as encoding]
+  (:require [re-frame.frame        :as frame]
+            [re-frame.http-encoding :as encoding]
             [re-frame.http-privacy :as privacy]
             [re-frame.interop      :as interop]
             [re-frame.source-coords :as source-coords]
@@ -115,7 +116,10 @@
     - `:before` (optional) — `(fn [ctx] ctx')`, request-side transform
     - `:after`  (optional) — `(fn [ctx response] response')`,
                               response-side transform
-    - `:frame`  (optional) — frame id, default `:rf/default`
+    - `:frame`  (optional) — frame id (the EP-0002 *override*). Absent,
+                              the carried-invariant scope chain resolves it;
+                              registering under no scope raises
+                              `:rf.error/no-frame-context`.
     - `:doc` / `:tags` / `:schema` / `:sensitive?` — standard
       `:rf/registration-metadata` (per `:rf/http-interceptor-meta`)
 
@@ -165,7 +169,19 @@
                      :recovery :no-recovery
                      :received {:id id :interceptor-map interceptor-map}
                      :reason   "expected (reg-http-interceptor id interceptor-map): id keyword; interceptor-map a map carrying at least one of :before / :after (each a fn), optional :frame keyword, optional :rf/registration-metadata"})))
-  (let [frame-id  (or (:frame interceptor-map) :rf/default)
+  (let [frame-id  (or (:frame interceptor-map)
+                      ;; EP-0002 — HTTP interceptor registration is
+                      ;; CONTEXT-REQUIRED FRAME-LOCAL: the explicit `:frame`
+                      ;; (the *override*) wins, else the carried-invariant
+                      ;; scope chain (a `with-frame` / frame-provider scope,
+                      ;; or a frame `:on-create` hook). Registering under no
+                      ;; scope and no explicit `:frame` raises the always-on
+                      ;; `:rf.error/no-frame-context` rather than installing
+                      ;; the interceptor against a synthesised `:rf/default`
+                      ;; chain (per Spec 002 §Frame target resolution).
+                      (frame/require-current-frame!
+                        :reg-http-interceptor
+                        {:where 'rf/reg-http-interceptor :event-id id}))
         before    (:before interceptor-map)
         after     (:after  interceptor-map)
         user-meta (dissoc interceptor-map :frame :before :after)
@@ -192,12 +208,24 @@
 (defn clear-http-interceptor
   "Unregister an HTTP interceptor by id from a frame's chain.
 
-  Single-arity: clear by id on `:rf/default`.
-  Two-arity: clear by id on the named frame.
-  No-arg form not supported — explicit ids only."
-  ([id] (clear-http-interceptor :rf/default id))
+  EP-0002 — context-required frame-local. The single-arity
+  `(clear-http-interceptor id)` resolves the frame through the
+  carried-invariant scope chain (a `with-frame` / frame-provider scope);
+  the two-arity `(clear-http-interceptor frame id)` names the frame
+  explicitly (the *override*). Either form, when the resolved frame is
+  absent (single-arity under no scope, or two-arity passed `nil`), raises
+  the always-on `:rf.error/no-frame-context` rather than clearing against a
+  synthesised `:rf/default`. No-arg form not supported — explicit ids only."
+  ([id] (clear-http-interceptor
+          (frame/require-current-frame!
+            :clear-http-interceptor
+            {:where 'rf/clear-http-interceptor :event-id id})
+          id))
   ([frame id]
-   (let [frame-id (or frame :rf/default)
+   (let [frame-id (or frame
+                      (frame/require-current-frame!
+                        :clear-http-interceptor
+                        {:where 'rf/clear-http-interceptor :event-id id}))
          existed? (some? (some (fn [v] (when (= (:id v) id) v))
                                (get @interceptors frame-id)))]
      (swap! interceptors update frame-id

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -47,7 +47,14 @@
   (require 're-frame.http-managed :reload)
   (http-managed/clear-all-in-flight!)
   (http-managed/clear-all-http-interceptors!)
-  (t))
+  ;; EP-0002 (rf2-5q7um6): reg-http-interceptor / clear-http-interceptor are
+  ;; context-required frame-local, and these tests dispatch managed HTTP to
+  ;; exercise the chain — both raise :rf.error/no-frame-context under no
+  ;; scope. Pin :rf/default (an ordinary frame) as the established scope for
+  ;; the body; tests that target an explicit frame pass {:frame …}.
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_source_coords_test.clj
+++ b/implementation/http/test/re_frame/http_source_coords_test.clj
@@ -39,7 +39,14 @@
   (require 're-frame.http-managed :reload)
   (http-managed/clear-all-in-flight!)
   (http-managed/clear-all-http-interceptors!)
-  (t))
+  ;; EP-0002 (rf2-5q7um6): reg-http-interceptor is context-required
+  ;; frame-local — an ambient call under no scope raises
+  ;; :rf.error/no-frame-context. Pin :rf/default as the established scope so
+  ;; the frameless registrations land there; the :rf/api case passes
+  ;; {:frame :rf/api} explicitly.
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -10,10 +10,12 @@
   registered against the active frame at registration time and looked
   up per frame at validation time. Stories, multi-instance widgets,
   per-test fixtures need shape-flexibility — a stripped-down schema
-  registered against `:story.foo/empty` does NOT bleed into the
-  `:rf/default` frame's contract. `(reg-app-schema path schema)` uses
-  the active frame (`(frame/current-frame)`); `(reg-app-schema path
-  schema {:frame frame-id})` registers explicitly.
+  registered against `:story.foo/empty` does NOT bleed into another
+  frame's contract. EP-0002 — context-required frame-local: `(reg-app-schema
+  path schema)` resolves the frame through the carried-invariant scope
+  chain (a `with-frame` / frame-provider scope, or a frame `:on-create`
+  hook) and raises `:rf.error/no-frame-context` under no scope; `(reg-app-schema
+  path schema {:frame frame-id})` names the frame explicitly (the *override*).
 
   Per Spec 010 §Non-Malli validators the validator/explainer fns are
   pluggable via `set-schema-validator!` / `set-schema-explainer!`. The

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -40,9 +40,20 @@
   (atom {}))
 
 (defn resolve-frame
-  "Pluck :frame from the opts map; default to (frame/current-frame)."
-  [opts]
-  (or (:frame opts) (frame/current-frame)))
+  "Resolve the frame a schema registration / read targets. EP-0002 —
+  app-db schemas are CONTEXT-REQUIRED FRAME-LOCAL: the explicit `:frame`
+  opt (the *override*) wins, else the carried-invariant scope chain via
+  `frame/require-current-frame!` (a `with-frame` / frame-provider scope, or
+  a frame `:on-create` hook). Called under no established scope and no
+  explicit `:frame`, it raises the always-on `:rf.error/no-frame-context`
+  (per Spec 002 §Frame target resolution) rather than resolving to a
+  synthesised `:rf/default` floor — namespace-load time is not a reason to
+  pick a default frame. `operation` (optional) names the surface for the
+  error payload's `:operation` slot."
+  ([opts] (resolve-frame opts :reg-app-schema))
+  ([opts operation]
+   (or (:frame opts)
+       (frame/require-current-frame! operation {:where 'rf/reg-app-schema}))))
 
 (defn coerce-opts
   "Permit the keyword-only sugar `(app-schemas frame-id)` and the
@@ -121,8 +132,9 @@
 (defn coerce->frame-id
   "Resolve a frame-id from the `opts-or-frame-id` argument the read
   surface accepts: coerce through `coerce-opts` (keyword sugar / opts
-  map / throw on bad shape), then `resolve-frame` (`:frame` or the
-  active frame). The query entry points (`app-schema-at` /
+  map / throw on bad shape), then `resolve-frame` (`:frame` override or
+  the carried-invariant scope frame; raises `:rf.error/no-frame-context`
+  outside any scope per EP-0002). The query entry points (`app-schema-at` /
   `app-schema-meta-at` / `app-schemas` / `app-schemas-digest`) use the
   opts ONLY to name a frame, so they collapse the coerce+resolve pair
   through this helper. The `reg-*` entry points keep the two-step form —
@@ -428,9 +440,12 @@
   :rf.error/schema-validation-failure.
 
   Per Spec 010 §Per-frame schemas this registration is frame-scoped.
-  The frame to register against comes from the optional :frame opt;
-  default is (frame/current-frame) — usually :rf/default unless the
-  caller is inside a (with-frame ...) wrapper or a frame-provider.
+  EP-0002 — context-required frame-local: the frame comes from the
+  explicit :frame opt (the *override*), else the carried-invariant scope
+  chain (a (with-frame ...) wrapper, a frame-provider, or a frame
+  :on-create hook). Registering under no established scope and no
+  explicit :frame raises :rf.error/no-frame-context — namespace-load time
+  is not a reason to register against a synthesised :rf/default.
 
   Per rf2-0frdi / rf2-cq1ak the schemas artefact owns its own per-frame
   side-table (`schemas-by-frame`) — app-db schemas are NOT a registrar
@@ -543,9 +558,13 @@
 
     (rf/reg-app-schemas {[:foo] FooSchema} {:frame :tenant/a})
 
-  Per Spec 010 §Per-frame schemas registration is frame-scoped; the
-  `:frame` opt overrides the default `(frame/current-frame)` resolution
-  for every entry in the map (you cannot mix frames in a single call).
+  Per Spec 010 §Per-frame schemas registration is frame-scoped; EP-0002 —
+  context-required frame-local: the `:frame` opt (the *override*) names
+  the frame for every entry in the map (you cannot mix frames in a single
+  call), else the carried-invariant scope chain resolves it. Registering
+  under no scope and no explicit `:frame` raises
+  `:rf.error/no-frame-context` (the up-front path-shape sweep still runs
+  first).
   The singular form `reg-app-schema` remains available and is used
   internally for each entry — every entry stamps its own per-frame side-
   table entry with source-coords captured from this call site.
@@ -609,7 +628,7 @@
   "Look up the registered schema for a path in a frame, or nil.
 
   Arities:
-    (app-schema-at path)         ;; current frame (or :rf/default)
+    (app-schema-at path)         ;; carried-invariant scope frame (EP-0002)
     (app-schema-at path opts)    ;; opts map; :frame names the frame
                                  ;; (keyword sugar also accepted)
 
@@ -634,7 +653,7 @@
   the per-frame side-table is the single source of truth.
 
   Arities:
-    (app-schema-meta-at path)         ;; current frame (or :rf/default)
+    (app-schema-meta-at path)         ;; carried-invariant scope frame (EP-0002)
     (app-schema-meta-at path opts)    ;; opts map; :frame names the frame
                                       ;; (keyword sugar also accepted)"
   ([path] (app-schema-meta-at path {}))

--- a/implementation/schemas/test/re_frame/schemas/printer_seam_test.clj
+++ b/implementation/schemas/test/re_frame/schemas/printer_seam_test.clj
@@ -23,6 +23,7 @@
   clojure.spec port) needs to be able to plug into the digest
   pipeline without re-implementing it."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.frame :as frame]
             [re-frame.schemas :as schemas]
             [re-frame.schemas.validator :as validator]))
 
@@ -31,7 +32,16 @@
   ;; are framework-wide; restore the defaults around each test so
   ;; sibling tests are not poisoned.
   (schemas/reset-schema-validator!)
-  (try (test-fn)
+  ;; EP-0002 (rf2-5q7um6): the digest-seam tests register schemas via
+  ;; reg-app-schema, which is now context-required frame-local. Pin
+  ;; :rf/default as the established scope so those ambient registrations
+  ;; carry a frame stamp (no :rf/default floor). No `ensure-default-frame!`
+  ;; here — these tests install no adapter; `reg-app-schema` only needs the
+  ;; carried STAMP (it writes the plain `schemas-by-frame` atom), and the
+  ;; schema-derived elision-populate step no-ops when the frame has no live
+  ;; runtime-db container.
+  (try (binding [frame/*current-frame* :rf/default]
+         (test-fn))
        (finally (schemas/reset-schema-validator!))))
 
 (use-fixtures :each reset)

--- a/implementation/schemas/test/re_frame/schemas/test_fixture.clj
+++ b/implementation/schemas/test/re_frame/schemas/test_fixture.clj
@@ -46,7 +46,21 @@
     per-(kind, id) warn-once caches (missing-doc, registration-collision)
     so each test sees a clean suppression slate.
   - `(rf/init! plain-atom/adapter)` — installs the schemas-artefact
-    JVM tests' standard substrate."
+    JVM tests' standard substrate.
+
+  ## EP-0002 frame scope (rf2-5q7um6)
+
+  `reg-app-schema` is context-required frame-local: an ambient call under
+  no established scope now raises `:rf.error/no-frame-context` (there is no
+  `:rf/default` floor). `init!` no longer creates `:rf/default`, so the
+  fixture registers it as an ordinary frame and pins `*current-frame*` so
+  the schemas-artefact tests' ambient `reg-app-schema` calls carry a scope
+  stamp — the fixture-level equivalent of wrapping each body in
+  `(rf/with-frame :rf/default …)`. A test that registers against an
+  explicit frame passes `{:frame …}`, which overrides this ambient pin.
+  (The schemas conformance runner unbinds this scope around its own
+  `reg-frame` so its `:on-create` cascade still fires synchronously — see
+  `schemas_conformance_test`.)"
   (:require [re-frame.core :as rf]
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
@@ -68,4 +82,8 @@
   (schemas/clear-sensitive-paths-cache!)
   (registrar/clear-warning-caches!)
   (rf/init! plain-atom/adapter)
-  (test-fn))
+  ;; EP-0002 (rf2-5q7um6): establish an explicit :rf/default scope for the
+  ;; body so ambient reg-app-schema calls carry a frame stamp.
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (test-fn)))

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -470,7 +470,14 @@
           ;; with the schemas in place — the on-create's db commit
           ;; will trigger validate-app-schema! against the new slate.
           _            (realise-app-schemas fixture)
-          _            (rf/reg-frame :rf/default frame-config)
+          ;; EP-0002 (rf2-5q7um6): the shared `tf/reset-runtime` pins
+          ;; `*current-frame* :rf/default` for the body. Unbind it around
+          ;; `reg-frame` so the fixture's `:on-create` cascade fires
+          ;; SYNCHRONOUSLY — `frame/reg-frame` async-queues on-create when
+          ;; `*current-frame*` is bound (Spec 002 §reg-frame from inside a
+          ;; handler), which would land the seed AFTER the first dispatch.
+          _            (binding [frame/*current-frame* nil]
+                         (rf/reg-frame :rf/default frame-config))
           dispatches   (or (:fixture/dispatches fixture) [])]
       (doseq [ev dispatches]
         (run-dispatch ev))

--- a/testbeds/deliberate_throw/core.cljs
+++ b/testbeds/deliberate_throw/core.cljs
@@ -21,7 +21,7 @@
             [re-frame.machines]                          ;; load-time hook for make-machine-handler
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ----------------------------------------------------------------------------
 ;; App-db
@@ -84,14 +84,18 @@
 ;; `:db` is preserved (prior writes survive); the failing flow's
 ;; `last-inputs` is NOT advanced.
 
-(rf/reg-flow
-  {:id     ::throws
-   :inputs [[:flow-input]]
-   :output (fn [_input]
-             ;; HOT PATH — the throw site for :rf.error/flow-eval-exception.
-             (throw (ex-info "deliberate-throw / flow" {:where :flow})))
-   :path   [:flow-output]
-   :doc    "Flow :output that throws every recompute."})
+;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local; a bare
+;; ns-load call raises :rf.error/no-frame-context. This testbed hosts on
+;; :rf/default, so name it explicitly.
+(with-frame :rf/default
+  (rf/reg-flow
+    {:id     ::throws
+     :inputs [[:flow-input]]
+     :output (fn [_input]
+               ;; HOT PATH — the throw site for :rf.error/flow-eval-exception.
+               (throw (ex-info "deliberate-throw / flow" {:where :flow})))
+     :path   [:flow-output]
+     :doc    "Flow :output that throws every recompute."}))
 
 (rf/reg-event-db ::throw-in-flow
   (fn [db _ev]

--- a/testbeds/large_dispatcher/core.cljs
+++ b/testbeds/large_dispatcher/core.cljs
@@ -42,7 +42,7 @@
             [re-frame.schemas]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ----------------------------------------------------------------------------
 ;; The canonical "large" payload — 20 KiB above the 16 KiB threshold
@@ -73,13 +73,17 @@
    [:schema-large-value {:large? true :hint "Nested schema-declared slot"}
     [:maybe :string]]])
 
-(rf/reg-app-schemas
-  {[:declared-large-value]
-   [:maybe [:string {:large? true :hint "Flat schema-declared slot"}]]
-   [:fx-declared-value]
-   [:maybe [:string {:large? true :hint "Second flat schema-declared slot"}]]
-   [:schema-bag]
-   SchemaLarge})
+;; EP-0002 (rf2-5q7um6): reg-app-schemas is context-required frame-local; a
+;; bare ns-load call raises :rf.error/no-frame-context. This testbed hosts on
+;; :rf/default, so name it explicitly.
+(with-frame :rf/default
+  (rf/reg-app-schemas
+    {[:declared-large-value]
+     [:maybe [:string {:large? true :hint "Flat schema-declared slot"}]]
+     [:fx-declared-value]
+     [:maybe [:string {:large? true :hint "Second flat schema-declared slot"}]]
+     [:schema-bag]
+     SchemaLarge}))
 
 ;; ----------------------------------------------------------------------------
 ;; App-db

--- a/testbeds/long_flow_w_failure/core.cljs
+++ b/testbeds/long_flow_w_failure/core.cljs
@@ -65,7 +65,7 @@
             [re-frame.flows]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ----------------------------------------------------------------------------
 ;; Constants
@@ -160,6 +160,11 @@
 ;; app-db (incl. :input, :a-result, :b-result, :c-result) is frozen at
 ;; tick N-1's committed value.
 
+;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local; a bare
+;; ns-load call raises :rf.error/no-frame-context. This testbed hosts on
+;; :rf/default, so name it explicitly for all three flows.
+(with-frame :rf/default
+
 (rf/reg-flow
   {:id     ::flow-a
    :inputs [[:input]]
@@ -228,7 +233,7 @@
              (+ a b))
    :path   [:c-result]
    :doc    "Sums :a-result + :b-result. Watches :flow-a and
-            :flow-b's outputs."})
+            :flow-b's outputs."}))
 
 ;; ----------------------------------------------------------------------------
 ;; Tick handler — the cascade engine

--- a/testbeds/schema_violation/core.cljs
+++ b/testbeds/schema_violation/core.cljs
@@ -26,7 +26,7 @@
             [re-frame.schemas.malli]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ----------------------------------------------------------------------------
 ;; App-db + schemas
@@ -39,7 +39,11 @@
 (def AuthSlice
   [:map [:token :string]])
 
-(rf/reg-app-schema [:auth] AuthSlice)
+;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local; a
+;; bare ns-load call raises :rf.error/no-frame-context. This testbed hosts on
+;; :rf/default, so name it explicitly.
+(with-frame :rf/default
+  (rf/reg-app-schema [:auth] AuthSlice))
 
 (rf/reg-event-db ::initialise
   (fn [_db _ev]

--- a/tools/story/testbeds/counter_with_stories/elision_demo.cljs
+++ b/tools/story/testbeds/counter_with_stories/elision_demo.cljs
@@ -71,7 +71,7 @@
             [re-frame.core :as rf]
             [re-frame.schemas]
             [re-frame.schemas.malli])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ============================================================================
 ;; SCHEMAS  (Spec 010 §`:large?` per-slot meta)
@@ -99,9 +99,19 @@
 ;; schema MUST permit nil. We wrap with `:maybe`; the `:large? true`
 ;; flag lives on the inner `:string` slot so the walker still surfaces
 ;; it under the `[:user/avatar-pdf]` registered path.
-(rf/reg-app-schema [:user/avatar-pdf]
-                   [:maybe [:string {:large? true
-                                     :hint   "Avatar PDF blob"}]])
+;;
+;; EP-0002 (rf2-5q7um6): `reg-app-schema` is context-required frame-local —
+;; a bare ns-load call under no scope raises `:rf.error/no-frame-context`
+;; (boot-time namespace loading is NOT a reason to synthesise `:rf/default`,
+;; per Spec 002 §Frame target resolution). This demo's app runs in the
+;; `:rf/default` frame (see `core/run`), so name it explicitly here via
+;; `with-frame` — the registration carries a frame stamp even though it
+;; lands at module-load before `init!`. (The broader testbed migration to a
+;; root provider is owned by the Story/tools bead rf2-bd4div.)
+(with-frame :rf/default
+  (rf/reg-app-schema [:user/avatar-pdf]
+                     [:maybe [:string {:large? true
+                                       :hint   "Avatar PDF blob"}]]))
 
 ;; ============================================================================
 ;; EVENTS  (Spec 009 §`:sensitive?`)

--- a/tools/story/testbeds/counter_with_stories/elision_demo_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/elision_demo_cljs_test.cljs
@@ -61,9 +61,13 @@
   ;; ns-load `reg-app-schema` call ran once at module load; the
   ;; preceding `(clear!)` step wiped it. Re-stamping it here keeps
   ;; the schema-driven elision branch (test 3) working.
+  ;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local;
+  ;; pass the target frame explicitly (the *override*) rather than relying on
+  ;; an ambient default.
   (rf/reg-app-schema [:user/avatar-pdf]
                      [:maybe [:string {:large? true
-                                       :hint   "Avatar PDF blob"}]])
+                                       :hint   "Avatar PDF blob"}]]
+                     {:frame :rf/default})
   ;; Re-run the schema-driven elision-registry boot population
   ;; against the post-init frame. The demo ns's `reg-app-schema`
   ;; call lives in registry-meta land; the per-frame `[:rf.runtime/elision

--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -121,7 +121,7 @@
             ;; testbed reuses `root` + `steps` with its own per-frame
             ;; host-frame + run-step events.
             [runner.core :as runner])
-  (:require-macros [re-frame.core :refer [reg-view]]))
+  (:require-macros [re-frame.core :refer [reg-view with-frame]]))
 
 ;; ============================================================================
 ;; APP-DB SEED
@@ -174,7 +174,11 @@
 ;; schema-violation issue survives in Xray's Issues lens.
 
 (def AuthSlice [:map [:token :string]])
-(rf/reg-app-schema [:auth] AuthSlice)
+;; EP-0002 (rf2-5q7um6): reg-app-schema is context-required frame-local; a
+;; bare ns-load call raises :rf.error/no-frame-context. This testbed's deck
+;; hosts on :rf/default (see `host-frame` below), so name it explicitly.
+(with-frame :rf/default
+  (rf/reg-app-schema [:auth] AuthSlice))
 
 ;; ============================================================================
 ;; COEFFECT — :standard-epochs/now  (button #2)
@@ -271,12 +275,15 @@
 ;; changed. Button #5 bumps `:base`; App-db shows `:derived` recompute
 ;; and Trace shows the flow run.
 
-(rf/reg-flow
-  {:id     :standard-epochs/derived
-   :inputs [[:base]]
-   :output (fn [base] (* 2 (or base 0)))
-   :path   [:derived]
-   :doc    "Derived = 2 × :base. Recomputes on the post-handler flows pass."})
+;; EP-0002 (rf2-5q7um6): reg-flow is context-required frame-local; name the
+;; :rf/default host frame explicitly for this ns-load registration.
+(with-frame :rf/default
+  (rf/reg-flow
+    {:id     :standard-epochs/derived
+     :inputs [[:base]]
+     :output (fn [base] (* 2 (or base 0)))
+     :path   [:derived]
+     :doc    "Derived = 2 × :base. Recomputes on the post-handler flows pass."}))
 
 ;; ============================================================================
 ;; EVENTS — the button ladder


### PR DESCRIPTION
EP-0002 chain bead 5/11. Classifies + migrates each registration-time `reg-*` surface that resolved a frame at namespace-load via `(or frame (frame/current-frame))` / `(or ... :rf/default)` into the carried-invariant contract.

## Per-surface classification + migration

All migrated surfaces are **context-required frame-local**: explicit `:frame` (override) wins, else the scope chain via `frame/require-current-frame!`; absence raises `:rf.error/no-frame-context` (no `:rf/default` floor, no boot-time synthesis).

- **reg-flow / clear-flow** (`flows/registry.cljc`) — context-required frame-local.
- **reg-app-schema / reg-app-schemas** + the `resolve-frame` read seam (`schemas/storage.cljc`) — context-required frame-local; the read query surfaces (`app-schema-at` / `app-schemas` / `app-schemas-digest`) route through the same require seam.
- **reg-http-interceptor / clear-http-interceptor** (`http_middleware.cljc`) — context-required frame-local (single + two-arity).
- **populate-elision-from-schemas! / populate-sensitive-from-schemas! / populate-from-schemas!** + the `declarations` / `sensitive-declarations` zero-arity readers (`core/elision.cljc`) — context-required frame-local.

## Scope boundary

- `elide-wire-value`'s `(or ... :rf/default)` wire-egress floor is **operation-time** — left for **rf2-gjq3ow** (fail-closed), documented in its docstring.
- HTTP managed request/reply + the `:rf.fx/reg-http-interceptor` / `:rf.fx/clear-http-interceptor` fx defaults are **operation-time** — left for **rf2-nn0jqa**.
- `validate-app-schema!` zero/one-arity `current-frame` defaulting is operation-time (router supplies the explicit cascade frame); it no longer synthesises `:rf/default` (the resolver bead already made `current-frame` return nil).

## Tests fixed vs deferred

**Fixed** (the registration cases rf2-69r7ui deferred to this bead):
- `frame-ids-round-trip` — re-authored: `:rf/default` appears only when explicitly registered; added a negative case proving `frame-ids` never synthesises it.
- The registration `:rf/default` cases across flows / schemas / http-interceptor / core-elision suites — fixtures establish an explicit `:rf/default` scope (`ensure-default-frame!` + pinned `*current-frame*`), the fixture-level equivalent of `(with-frame :rf/default …)`.
- Conformance + schemas runners **unbind** that scope around their `reg-frame` so the fixture `:on-create` cascade fires synchronously (it async-queues when `*current-frame*` is bound).
- Example + testbed **ns-load** `reg-*` wrapped in `(with-frame :rf/default)` so the node-test build imports cleanly (boot/realworld/websocket/nine_states/flows examples; counter_with_stories/elision_demo + standard_epochs + deliberate_throw / large_dispatcher / long_flow_w_failure / schema_violation testbeds).

**Deferred (red-by-design, owners noted):** operation-time bare-dispatch failures (rf2-nn0jqa), SSR (rf2-acjknb), trace/elision projection incl. `elide-wire-value` (rf2-gjq3ow), Xray/Story/pair tools (rf2-bd4div).

## Quality gates

Slice gates run locally (feature-branch; CI does not run on ep-0002 PRs):

- **flows** `clojure -M:test` — **GREEN** 165 tests / 4676 assertions, 0 failures, 0 errors.
- **schemas** `clojure -M:test` — **GREEN** 274 tests / 18593 assertions, 0 failures, 0 errors.
- **http** interceptor-registration namespaces (`http-interceptors-test` + `http-source-coords-test`) — **GREEN** 34 tests / 112 assertions, 0/0. The rest of the http suite (95 errors) is operation-time managed-HTTP bare-dispatch — **red-by-design, owner rf2-nn0jqa** (all at `frame.cljc:309`, the no-frame-context throw; no registration-origin errors).
- **core** `frame-ids-round-trip` (1/7) + `elision-test` (34/86) — **GREEN 0/0**. (frame_lifecycle's two child-frame-on-create-from-handler tests are operation-time bare-dispatch — red-by-design, rf2-nn0jqa.)
- **npm run test:cljs** — build completes (1180 files, 0 warnings); suite runs to completion with **0 registration-origin errors** (no `reg_app_schema` / `reg_flow` / `reg_http` / `storage.cljc` / `flows.registry` in any stack). The 235 remaining errors are all `re-frame.router/build-envelope` bare-dispatch (**rf2-nn0jqa**) + Story testbed tests (**rf2-bd4div**) — red-by-design, matching the rf2-jue6sp precedent.