### PR TITLE
fix(examples/_shared): AA-contrast palette + focus indicators / OG raster (rf2-mon7tz rf2-febmqu)

### DIFF
--- a/examples/_shared/css/style.css
+++ b/examples/_shared/css/style.css
@@ -47,13 +47,21 @@
   /* ink — warm neutrals, not pure black */
   --ex-ink:         #1A1814;
   --ex-ink-muted:   #5C5448;
-  --ex-ink-faint:   #8A8270;
+  /* --ex-ink-faint darkened from #8A8270 (≤3.81:1, sub-AA) to #6E6654 so muted
+     /skeleton text clears WCAG AA 4.5:1 on every shipped surface: 5.14:1 on
+     paper, 5.69:1 on white, 4.61:1 on sunken (rf2-febmqu). */
+  --ex-ink-faint:   #6E6654;
   --ex-rule:        #DCD3BF;
   --ex-rule-strong: #B8AC93;
 
-  /* accents */
-  --ex-accent:      #C8741A;  /* amber-sienna — primary action */
-  --ex-accent-deep: #9C4F0E;
+  /* accents.
+     --ex-accent (#C8741A) is a DECORATIVE/large-fill amber only: as normal-text
+     foreground or as a white-text filled background it is ≤3.52:1 (sub-AA). Use
+     --ex-accent-deep (#9C4F0E) for text links, white-text filled buttons, and
+     text-bearing status pills — it clears AA at ≥5.37:1 on paper/white and
+     5.94:1 white-on-deep (rf2-febmqu). */
+  --ex-accent:      #C8741A;  /* amber-sienna — decorative fill / focus accent */
+  --ex-accent-deep: #9C4F0E;  /* AA-safe text / filled-button background */
   --ex-accent-soft: #E5A23D;  /* warm gold — secondary highlight */
   --ex-success:     #4A7340;  /* forest green for connected/ok states */
   --ex-warn:        #C49419;  /* warm amber for warnings */
@@ -159,13 +167,15 @@ code {
 }
 
 a, .nav-link {
-  color: var(--ex-accent);
+  /* --ex-accent-deep (≥5.37:1 on paper/white), not --ex-accent (≤3.52:1,
+     sub-AA), so link text clears WCAG AA (rf2-febmqu). */
+  color: var(--ex-accent-deep);
   text-decoration-color: var(--ex-accent-soft);
   text-underline-offset: 3px;
   transition: color 120ms ease;
 }
 
-a:hover, .nav-link:hover { color: var(--ex-accent-deep); }
+a:hover, .nav-link:hover { color: var(--ex-ink); }
 
 /* Forms ------------------------------------------------------------------ */
 
@@ -179,10 +189,28 @@ input, textarea, select {
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
-input:focus, textarea:focus, select:focus {
+/* Keyboard focus indicator (rf2-mon7tz).
+   The old rule set `outline: none` and replaced it with a low-alpha amber ring
+   (≈1.5:1 against the light surfaces) — keyboard users effectively lost the
+   focus indicator. We now keep a visible, solid ring built from
+   --ex-accent-deep (#9C4F0E), which clears the WCAG 1.4.11 non-text/focus
+   3:1 bar on every shipped surface: 5.37:1 on paper, 5.94:1 on white, 4.81:1
+   on sunken. A 2px transparent outline carries the indicator in forced-colors
+   / high-contrast mode where box-shadow is dropped. */
+input:focus-visible, textarea:focus-visible, select:focus-visible {
+  outline: 2px solid transparent; /* forced-colors fallback */
+  outline-offset: 2px;
+  border-color: var(--ex-accent-deep);
+  box-shadow: 0 0 0 3px var(--ex-accent-deep);
+}
+
+/* Pointer-driven focus keeps a calmer accent border without the full ring,
+   so the strong keyboard indicator above is reserved for :focus-visible. */
+input:focus:not(:focus-visible),
+textarea:focus:not(:focus-visible),
+select:focus:not(:focus-visible) {
   outline: none;
-  border-color: var(--ex-accent);
-  box-shadow: 0 0 0 3px rgba(200,116,26,0.18);
+  border-color: var(--ex-accent-deep);
 }
 
 button {
@@ -200,22 +228,27 @@ button {
 }
 
 button:hover:not([disabled]) {
-  background: var(--ex-accent);
-  border-color: var(--ex-accent);
+  /* --ex-accent-deep, not --ex-accent: the button text is white, and white on
+     --ex-accent is only 3.52:1 (sub-AA); white on --ex-accent-deep is 5.94:1
+     (rf2-febmqu). */
+  background: var(--ex-accent-deep);
+  border-color: var(--ex-accent-deep);
 }
 
 button:active:not([disabled]) { transform: translateY(1px); }
 
-/* Form-bound submit gets the accent fill */
+/* Form-bound submit gets the accent fill — using --ex-accent-deep so the
+   white label clears AA (white-on-deep 5.94:1; white-on-accent was 3.52:1,
+   sub-AA). rf2-febmqu. */
 .login-form button[type="submit"] {
-  background: var(--ex-accent);
-  border-color: var(--ex-accent);
+  background: var(--ex-accent-deep);
+  border-color: var(--ex-accent-deep);
   color: #fff;
 }
 
 .login-form button[type="submit"]:hover:not([disabled]) {
-  background: var(--ex-accent-deep);
-  border-color: var(--ex-accent-deep);
+  background: var(--ex-ink);
+  border-color: var(--ex-ink);
 }
 
 .error {
@@ -235,9 +268,18 @@ button:active:not([disabled]) { transform: translateY(1px); }
   color: var(--ex-ink);
 }
 
-.pill.disconnected   { background: #8A8270; }
+/* Pills carry white text by default (structure.css). Backgrounds are chosen so
+   white-on-fill clears WCAG AA 4.5:1, or the pill overrides to ink text where
+   the fill is too light (rf2-febmqu):
+   - disconnected  : --ex-ink-muted #5C5448 → white 7.46:1 (was #8A8270, 3.81:1)
+   - authenticating: --ex-accent-deep #9C4F0E → white 5.94:1 (was --ex-accent, 3.52:1)
+   - connected     : --ex-success #4A7340 → white 5.50:1
+   - failed        : --ex-error #B23A2E → white 5.94:1
+   - connecting / reconnecting: --ex-accent-soft is light, so they use ink text
+     (8.08:1). */
+.pill.disconnected   { background: var(--ex-ink-muted); }
 .pill.connecting     { background: var(--ex-accent-soft); color: var(--ex-ink); }
-.pill.authenticating { background: var(--ex-accent); }
+.pill.authenticating { background: var(--ex-accent-deep); }
 .pill.connected      { background: var(--ex-success); }
 .pill.reconnecting   { background: var(--ex-accent-soft); color: var(--ex-ink); }
 .pill.failed         { background: var(--ex-error); }
@@ -266,7 +308,7 @@ button:active:not([disabled]) { transform: translateY(1px); }
   border-bottom: 1px solid var(--ex-rule);
 }
 
-.nav-link { color: var(--ex-accent); font-weight: 500; }
+.nav-link { color: var(--ex-accent-deep); font-weight: 500; }
 .article-preview { border-bottom-color: var(--ex-rule); }
 .article-preview h1 { font-family: var(--ex-sans); font-weight: 700; }
 

--- a/examples/scripts/check-examples-assets.cjs
+++ b/examples/scripts/check-examples-assets.cjs
@@ -299,6 +299,129 @@ function readFileSafe(io, p) {
   }
 }
 
+// Read a file as RAW BYTES (a Buffer), never decoded as text — used to inspect
+// the og.png signature/dimensions. The CLI passes the real fs (no encoding =>
+// Buffer); the synthetic test io returns whatever string was stored, which
+// validatePng coerces to a Buffer so a fixture can supply real PNG bytes.
+function readBytesSafe(io, p) {
+  try {
+    return io.readFileSync(p); // no encoding => Buffer for the real fs
+  } catch {
+    return null;
+  }
+}
+
+// The 8-byte PNG file signature (89 50 4E 47 0D 0A 1A 0A).
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+// The canonical social-preview raster dimensions (examples/_shared/README.md
+// declares img/og.png is the 1200x630 card).
+const OG_PNG_WIDTH = 1200;
+const OG_PNG_HEIGHT = 630;
+
+// Validate that `data` is a decodable PNG whose IHDR declares the expected
+// dimensions. Returns { ok, width, height, reason }. A spec-conformant PNG
+// always opens with the 8-byte signature immediately followed by the IHDR
+// chunk (length=13, type='IHDR', then width:uint32be, height:uint32be), so
+// reading the dimensions needs no full decoder — just the first 24 bytes.
+// Accepts a Buffer or coerces a string fixture to one (latin1 preserves bytes).
+function validatePng(data, expectedWidth = OG_PNG_WIDTH, expectedHeight = OG_PNG_HEIGHT) {
+  const buf = Buffer.isBuffer(data) ? data : Buffer.from(String(data), 'latin1');
+  if (buf.length < 24) {
+    return { ok: false, reason: `file is only ${buf.length} byte(s); too short to be a PNG` };
+  }
+  if (!buf.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    return { ok: false, reason: 'missing the 8-byte PNG signature (not a PNG file)' };
+  }
+  // Bytes 8..16 are the IHDR chunk length (must be 13) + type ('IHDR').
+  if (buf.subarray(12, 16).toString('latin1') !== 'IHDR') {
+    return { ok: false, reason: "first chunk is not IHDR (malformed PNG header)" };
+  }
+  const width = buf.readUInt32BE(16);
+  const height = buf.readUInt32BE(20);
+  if (width !== expectedWidth || height !== expectedHeight) {
+    return {
+      ok: false,
+      width,
+      height,
+      reason: `dimensions are ${width}x${height}, expected ${expectedWidth}x${expectedHeight}`,
+    };
+  }
+  return { ok: true, width, height };
+}
+
+// ---------------------------------------------------------------------------
+// WCAG contrast — the shared palette must clear AA for normal text and the
+// focus-indicator must clear the 3:1 non-text bar (rf2-febmqu + rf2-mon7tz).
+// A small static check over the :root tokens declared in style.css, so a
+// regression that re-introduces a sub-AA foreground (or restores the old
+// low-alpha amber focus ring) turns the gate RED — examples are teaching
+// surfaces and must not model an accessibility-regressed default.
+// ---------------------------------------------------------------------------
+
+const WCAG_AA_NORMAL_TEXT = 4.5; // 1.4.3 — normal-size text
+const WCAG_NON_TEXT = 3.0; // 1.4.11 — UI component / focus indicator
+
+function srgbToLinear(channel) {
+  const c = channel / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+// Relative luminance of a #rrggbb / #rgb hex colour (WCAG 2.x definition).
+function relativeLuminance(hex) {
+  let h = hex.replace('#', '').trim();
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+
+// WCAG contrast ratio between two hex colours (1..21).
+function contrastRatio(fgHex, bgHex) {
+  const l1 = relativeLuminance(fgHex);
+  const l2 = relativeLuminance(bgHex);
+  const hi = Math.max(l1, l2);
+  const lo = Math.min(l1, l2);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// Parse the `--ex-*: #hex;` custom-property declarations out of a style.css
+// source into a { tokenName: '#hex' } map. Only solid hex values are read
+// (the contrast checks operate on opaque token pairs).
+function parseExTokens(css) {
+  const tokens = {};
+  for (const m of css.matchAll(/(--ex-[a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{3,8})\b/g)) {
+    tokens[m[1]] = m[2];
+  }
+  return tokens;
+}
+
+// The shared token contrast contract. Each row is a foreground token paired
+// with the background token(s) it is actually rendered against in the shipped
+// CSS, plus the WCAG floor it must clear. Computed from the parsed --ex-*
+// tokens so a palette edit that drops a pair below threshold fails the gate.
+// `min` = the contrast floor; `worst` background is whichever the row lists.
+function sharedContrastContract(tokens) {
+  const surfaces = ['--ex-bg', '--ex-bg-raised', '--ex-bg-sunken'];
+  return [
+    // Normal text / link / muted / skeleton foregrounds on every paper surface.
+    { fg: '--ex-accent-deep', bgs: surfaces, min: WCAG_AA_NORMAL_TEXT, role: 'link / value text' },
+    { fg: '--ex-ink-faint', bgs: surfaces, min: WCAG_AA_NORMAL_TEXT, role: 'muted / skeleton text' },
+    { fg: '--ex-ink-muted', bgs: surfaces, min: WCAG_AA_NORMAL_TEXT, role: 'secondary text' },
+    { fg: '--ex-ink', bgs: surfaces, min: WCAG_AA_NORMAL_TEXT, role: 'body text' },
+    // White-text filled action backgrounds (buttons / login submit / pills):
+    // white-on-fill must clear AA, so the FILL is the "fg" against #FFFFFF here.
+    { fg: '--ex-accent-deep', bgs: ['#FFFFFF'], min: WCAG_AA_NORMAL_TEXT, role: 'white label on filled action', invert: true },
+    { fg: '--ex-success', bgs: ['#FFFFFF'], min: WCAG_AA_NORMAL_TEXT, role: 'white label on connected pill', invert: true },
+    { fg: '--ex-error', bgs: ['#FFFFFF'], min: WCAG_AA_NORMAL_TEXT, role: 'white label on error pill', invert: true },
+    { fg: '--ex-ink-muted', bgs: ['#FFFFFF'], min: WCAG_AA_NORMAL_TEXT, role: 'white label on disconnected pill', invert: true },
+    // The keyboard focus indicator ring uses --ex-accent-deep; it must clear
+    // the 3:1 non-text bar against every surface it can sit on.
+    { fg: '--ex-accent-deep', bgs: surfaces, min: WCAG_NON_TEXT, role: 'focus-indicator ring' },
+  ];
+}
+
 // Resolve a local reference from `pageDir` to its real SOURCE location,
 // modelling the orchestrator's staging. A `_shared/...` reference is staged
 // from the single canonical examples/_shared/ tree (copied into every page's
@@ -466,6 +589,30 @@ function checkSharedTree(io, opts = {}) {
       );
     }
   }
+
+  // The shipped og.png is the social-preview RASTER every page references. A
+  // bare existence check (above) would stay green if the bytes were replaced
+  // by non-PNG content (a renamed SVG/text file) or a wrong-size export — both
+  // break link-preview scrapers silently. Validate the actual bytes: decodable
+  // PNG signature + IHDR + the documented 1200x630 dimensions (rf2-mon7tz).
+  const ogPngPath = path.join(sharedRoot, 'img', 'og.png');
+  if (io.existsSync(ogPngPath)) {
+    const bytes = readBytesSafe(io, ogPngPath);
+    if (bytes == null) {
+      errors.push(`examples/_shared/img/og.png: could not read the raster bytes.`);
+    } else {
+      const v = validatePng(bytes);
+      if (!v.ok) {
+        errors.push(
+          `examples/_shared/img/og.png: not a valid ${OG_PNG_WIDTH}x${OG_PNG_HEIGHT} ` +
+            `social-preview PNG — ${v.reason}. The canonical card is the ` +
+            `${OG_PNG_WIDTH}x${OG_PNG_HEIGHT} raster (examples/_shared/README.md); ` +
+            `re-export img/og.svg to a real PNG. Link-preview scrapers receive a ` +
+            `broken/wrong-size image otherwise (rf2-mon7tz).`,
+        );
+      }
+    }
+  }
   const externalImportAllowlist =
     opts.externalImportAllowlist || EXTERNAL_IMPORT_ALLOWLIST;
 
@@ -547,6 +694,67 @@ function checkSharedTree(io, opts = {}) {
       );
     }
   }
+
+  // Accessibility contracts on style.css (rf2-febmqu + rf2-mon7tz).
+  if (style != null) {
+    // (a) Shared palette CONTRAST contract (rf2-febmqu): every shipped
+    //     foreground/background token pair must clear its WCAG floor (AA 4.5:1
+    //     for normal text, 3:1 for the focus-indicator ring). Computed from the
+    //     parsed --ex-* tokens so a palette edit that drops a pair below the
+    //     floor turns the gate RED.
+    const tokens = parseExTokens(style);
+    const resolve = (name) =>
+      name.startsWith('--ex-') ? tokens[name] : name; // literal hex passthrough
+    for (const row of sharedContrastContract(tokens)) {
+      const fgHex = resolve(row.fg);
+      if (!fgHex) continue; // token not declared (renamed) — not this check's job
+      for (const bg of row.bgs) {
+        const bgHex = resolve(bg);
+        if (!bgHex) continue;
+        const ratio = contrastRatio(fgHex, bgHex);
+        if (ratio < row.min) {
+          const pair = row.invert
+            ? `white text on ${row.fg} (${fgHex})`
+            : `${row.fg} (${fgHex}) on ${bg} (${bgHex})`;
+          errors.push(
+            `examples/_shared/css/style.css: ${row.role} fails WCAG ` +
+              `${row.min === WCAG_AA_NORMAL_TEXT ? 'AA' : 'non-text'} — ` +
+              `${pair} is ${ratio.toFixed(2)}:1, below ${row.min}:1. Use an ` +
+              `AA-safe token (prefer --ex-accent-deep / --ex-ink-muted) ` +
+              `(rf2-febmqu).`,
+          );
+        }
+      }
+    }
+
+    // (b) FOCUS-INDICATOR contract (rf2-mon7tz): the form-control focus rule
+    //     must not strip the native outline without an accessible replacement.
+    //     The old rule paired `outline: none` with a ≈1.5:1 low-alpha amber
+    //     ring (rgba(200,116,26,0.18)) — keyboard users lost the indicator.
+    //     Require a :focus-visible treatment whose ring uses the AA-safe accent
+    //     token, and forbid the low-alpha amber ring from coming back.
+    const hasFocusVisible = /input:focus-visible[^{]*\{[^}]*box-shadow:[^}]*--ex-accent-deep/m.test(
+      style,
+    );
+    if (!hasFocusVisible) {
+      errors.push(
+        `examples/_shared/css/style.css: form controls must carry a visible ` +
+          `':focus-visible' indicator whose ring uses the AA-safe ` +
+          `'--ex-accent-deep' token (≥3:1 on every surface). A bare ` +
+          `'outline: none' without an accessible replacement is forbidden ` +
+          `(rf2-mon7tz).`,
+      );
+    }
+    // The low-alpha amber ring (the pre-fix ≈1.5:1 indicator) must not return.
+    if (/box-shadow:[^;}]*rgba\(\s*200\s*,\s*116\s*,\s*26\s*,\s*0?\.\d+\s*\)/m.test(style)) {
+      errors.push(
+        `examples/_shared/css/style.css: the low-alpha amber focus ring ` +
+          `'rgba(200,116,26,0.18)' is below the 3:1 focus-indicator bar and ` +
+          `must not be used as the focus indicator. Use a solid ` +
+          `'--ex-accent-deep' ring (rf2-mon7tz).`,
+      );
+    }
+  }
   return errors;
 }
 
@@ -580,6 +788,18 @@ module.exports = {
   scanPage,
   checkSharedTree,
   scanAll,
+  // og.png raster byte-validation (rf2-mon7tz)
+  PNG_SIGNATURE,
+  OG_PNG_WIDTH,
+  OG_PNG_HEIGHT,
+  validatePng,
+  // shared palette contrast + focus-indicator contract (rf2-febmqu + rf2-mon7tz)
+  WCAG_AA_NORMAL_TEXT,
+  WCAG_NON_TEXT,
+  contrastRatio,
+  relativeLuminance,
+  parseExTokens,
+  sharedContrastContract,
 };
 
 // ---------------------------------------------------------------------------

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -45,7 +45,41 @@ const {
   scanAll,
   listExampleIndexHtml,
   EXAMPLES_ROOT,
+  validatePng,
+  OG_PNG_WIDTH,
+  OG_PNG_HEIGHT,
+  contrastRatio,
+  parseExTokens,
+  sharedContrastContract,
+  WCAG_AA_NORMAL_TEXT,
 } = scanner;
+
+// A real, decodable 1200x630 PNG (signature + IHDR + IDAT + IEND), used wherever
+// a fixture's _shared tree must scan clean — the gate now validates the og.png
+// BYTES, so an opaque 'PNGDATA' string no longer passes checkSharedTree
+// (rf2-mon7tz). Stored latin1 so the synthetic io (which returns the stored
+// value verbatim) round-trips the bytes; validatePng coerces it back to a
+// Buffer the same way.
+const VALID_OG_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAABLAAAAJ2CAIAAADAIuwLAAAACUlEQVR4nGMAAAABAAFe/335AAAAAElFTkSuQmCC',
+  'base64',
+).toString('latin1');
+
+// An AA-safe, focus-accessible style.css that satisfies the shared contrast +
+// focus-indicator contracts (rf2-febmqu + rf2-mon7tz), for checkSharedTree
+// fixtures whose tree must scan clean. Mirrors the shipped palette decisions.
+const GOOD_SHARED_STYLE = [
+  "@import url('structure.css');",
+  ':root {',
+  '  --ex-bg: #F7F3EC; --ex-bg-raised: #FFFFFF; --ex-bg-sunken: #ECE7DC;',
+  '  --ex-bg-elevated: #F1ECE0;',
+  '  --ex-ink: #1A1814; --ex-ink-muted: #5C5448; --ex-ink-faint: #6E6654;',
+  '  --ex-accent: #C8741A; --ex-accent-deep: #9C4F0E; --ex-accent-soft: #E5A23D;',
+  '  --ex-success: #4A7340; --ex-warn: #C49419; --ex-error: #B23A2E;',
+  '}',
+  'input:focus-visible { border-color: var(--ex-accent-deep);',
+  '  box-shadow: 0 0 0 3px var(--ex-accent-deep); }',
+].join('\n');
 
 let failed = 0;
 function it(label, fn) {
@@ -392,7 +426,7 @@ it('TEETH: an external @import in the _shared tree is rejected by checkSharedTre
       '.send-form input[type="text"] { min-width: 240px; }\n' +
       '.cells-grid input { width: 56px; }',
     [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
-    [path.join(SHARED_ROOT, 'img', 'og.png')]: 'PNGDATA',
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: VALID_OG_PNG,
     [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
   });
   const errors = checkSharedTree(io, { sharedRoot: SHARED_ROOT });
@@ -577,7 +611,8 @@ it('TEETH: a .jpg / .webp og:image scans clean (any raster is allowed)', () => {
 
 it('TEETH: a missing og.png raster is reported by checkSharedTree', () => {
   const io = makeIo({
-    [path.join(SHARED_ROOT, 'css', 'style.css')]: "@import url('structure.css');",
+    // AA-safe + focus-accessible style.css so only the missing-raster error fires.
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: GOOD_SHARED_STYLE,
     // A cascade-clean structure.css so only the missing-raster error fires.
     [path.join(SHARED_ROOT, 'css', 'structure.css')]:
       '.send-form input[type="text"] { min-width: 240px; }\n' +
@@ -590,6 +625,215 @@ it('TEETH: a missing og.png raster is reported by checkSharedTree', () => {
   assert.ok(
     errors.some((e) => e.includes('og.png')),
     `expected a missing-og.png error, got: ${errors.join(' | ')}`,
+  );
+});
+
+// ---- TEETH: og.png raster BYTE validation (rf2-mon7tz) ------------------
+//
+// A bare "the file exists" check stayed green if og.png were replaced by
+// non-PNG bytes or a wrong-size export — both break link-preview scrapers
+// silently. The gate now decodes the signature + IHDR dimensions.
+
+it('validatePng accepts a real 1200x630 PNG', () => {
+  const v = validatePng(VALID_OG_PNG);
+  assert.ok(v.ok, `expected the fixture PNG to validate, got: ${v.reason}`);
+  assert.strictEqual(v.width, OG_PNG_WIDTH);
+  assert.strictEqual(v.height, OG_PNG_HEIGHT);
+});
+
+it('TEETH: non-PNG bytes at og.png fail validatePng (signature)', () => {
+  const v = validatePng('PNGDATA'); // the old opaque placeholder is NOT a PNG
+  assert.ok(!v.ok, 'opaque non-PNG bytes must fail');
+  assert.ok(/signature|too short/.test(v.reason), `expected a signature failure, got: ${v.reason}`);
+});
+
+it('TEETH: a wrong-dimension PNG fails validatePng', () => {
+  // Same valid PNG bytes, but assert against a different expected size.
+  const v = validatePng(VALID_OG_PNG, 800, 600);
+  assert.ok(!v.ok, 'a wrong-size PNG must fail');
+  assert.ok(/dimensions/.test(v.reason), `expected a dimensions failure, got: ${v.reason}`);
+  assert.strictEqual(v.width, OG_PNG_WIDTH);
+  assert.strictEqual(v.height, OG_PNG_HEIGHT);
+});
+
+it('TEETH: checkSharedTree rejects non-PNG bytes at og.png', () => {
+  const io = sharedCssIo(
+    '.send-form input[type="text"] { min-width: 240px; }\n' +
+      '.cells-grid input { width: 56px; }',
+  );
+  // Overwrite the og.png with non-PNG bytes (a renamed SVG/text file).
+  const ioBad = makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: GOOD_SHARED_STYLE,
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]:
+      '.send-form input[type="text"] { min-width: 240px; }\n' +
+      '.cells-grid input { width: 56px; }',
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: '<svg>not a png</svg>',
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
+  });
+  const errors = checkSharedTree(ioBad, { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('og.png') && e.includes('not a valid')),
+    `expected a bad-PNG-bytes error, got: ${errors.join(' | ')}`,
+  );
+  // Sanity: the real-PNG fixture (sharedCssIo) is clean of any PNG error.
+  const cleanErrors = checkSharedTree(io, { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    !cleanErrors.some((e) => e.includes('og.png')),
+    `the valid-PNG fixture must not report a PNG error, got: ${cleanErrors.join(' | ')}`,
+  );
+});
+
+it('TEETH: checkSharedTree rejects a wrong-dimension og.png', () => {
+  // Build an 800x600 PNG and confirm the 1200x630 contract rejects it.
+  const zlib = require('zlib');
+  function crc32(buf) {
+    let c = ~0;
+    for (let i = 0; i < buf.length; i++) {
+      c ^= buf[i];
+      for (let k = 0; k < 8; k++) c = (c >>> 1) ^ (0xedb88320 & -(c & 1));
+    }
+    return (~c) >>> 0;
+  }
+  function chunk(type, data) {
+    const len = Buffer.alloc(4);
+    len.writeUInt32BE(data.length);
+    const t = Buffer.from(type, 'latin1');
+    const crc = Buffer.alloc(4);
+    crc.writeUInt32BE(crc32(Buffer.concat([t, data])));
+    return Buffer.concat([len, t, data, crc]);
+  }
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(800, 0);
+  ihdr.writeUInt32BE(600, 4);
+  ihdr[8] = 8; ihdr[9] = 2;
+  const png = Buffer.concat([
+    sig,
+    chunk('IHDR', ihdr),
+    chunk('IDAT', zlib.deflateSync(Buffer.from([0]))),
+    chunk('IEND', Buffer.alloc(0)),
+  ]).toString('latin1');
+  const io = makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: GOOD_SHARED_STYLE,
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]:
+      '.send-form input[type="text"] { min-width: 240px; }\n' +
+      '.cells-grid input { width: 56px; }',
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: png,
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
+  });
+  const errors = checkSharedTree(io, { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('og.png') && e.includes('800x600')),
+    `expected a wrong-dimension og.png error, got: ${errors.join(' | ')}`,
+  );
+});
+
+// ---- TEETH: shared palette CONTRAST contract (rf2-febmqu) ---------------
+
+it('LIVE: the shipped --ex-* palette clears its WCAG contrast contract', () => {
+  const fs = require('fs');
+  const style = fs.readFileSync(
+    path.join(EXAMPLES_ROOT, '_shared', 'css', 'style.css'),
+    'utf8',
+  );
+  const tokens = parseExTokens(style);
+  const offenders = [];
+  for (const row of sharedContrastContract(tokens)) {
+    const fg = tokens[row.fg] || row.fg;
+    for (const bg of row.bgs) {
+      const bgHex = bg.startsWith('--ex-') ? tokens[bg] : bg;
+      if (!fg || !bgHex) continue;
+      const r = contrastRatio(fg, bgHex);
+      if (r < row.min) offenders.push(`${row.role}: ${row.fg} on ${bg} = ${r.toFixed(2)} < ${row.min}`);
+    }
+  }
+  assert.deepStrictEqual(
+    offenders,
+    [],
+    `shipped palette contrast offenders:\n` + offenders.map((o) => `    - ${o}`).join('\n'),
+  );
+});
+
+it('TEETH: a sub-AA accent foreground in style.css fails checkSharedTree', () => {
+  // The exact rf2-febmqu regression: --ex-accent (#C8741A, 3.18:1 on paper)
+  // used as a normal text foreground. Model it by making --ex-accent-deep
+  // equal to the sub-AA --ex-accent value and confirm the gate fires.
+  const badStyle = GOOD_SHARED_STYLE.replace(
+    '--ex-accent-deep: #9C4F0E;',
+    '--ex-accent-deep: #C8741A;', // dropped back to the sub-AA amber
+  );
+  const io = makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: badStyle,
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]:
+      '.send-form input[type="text"] { min-width: 240px; }\n' +
+      '.cells-grid input { width: 56px; }',
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: VALID_OG_PNG,
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
+  });
+  const errors = checkSharedTree(io, { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('WCAG AA') && e.includes('rf2-febmqu')),
+    `expected a sub-AA contrast error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('contrastRatio matches a known pair (white on #9C4F0E ≈ 5.94)', () => {
+  const r = contrastRatio('#FFFFFF', '#9C4F0E');
+  assert.ok(Math.abs(r - 5.94) < 0.05, `expected ≈5.94, got ${r.toFixed(2)}`);
+});
+
+// ---- TEETH: focus-indicator contract (rf2-mon7tz) -----------------------
+
+it('LIVE: the shipped style.css carries an AA-safe :focus-visible indicator', () => {
+  const errors = checkSharedTree(require('fs'));
+  assert.ok(
+    !errors.some((e) => e.includes('focus-visible') || e.includes('focus ring')),
+    `the shipped focus indicator must satisfy the contract, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: a bare outline:none focus rule (no :focus-visible ring) fails', () => {
+  // Strip the :focus-visible ring → the focus-indicator contract must fire.
+  const badStyle = GOOD_SHARED_STYLE.replace(
+    /input:focus-visible[^]*$/m,
+    'input:focus { outline: none; }',
+  );
+  const io = makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: badStyle,
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]:
+      '.send-form input[type="text"] { min-width: 240px; }\n' +
+      '.cells-grid input { width: 56px; }',
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: VALID_OG_PNG,
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
+  });
+  const errors = checkSharedTree(io, { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('focus-visible') && e.includes('rf2-mon7tz')),
+    `expected a missing-focus-indicator error, got: ${errors.join(' | ')}`,
+  );
+});
+
+it('TEETH: the old low-alpha amber focus ring rgba(200,116,26,0.18) is rejected', () => {
+  const badStyle =
+    GOOD_SHARED_STYLE +
+    '\ninput:focus { outline: none; box-shadow: 0 0 0 3px rgba(200,116,26,0.18); }';
+  const io = makeIo({
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: badStyle,
+    [path.join(SHARED_ROOT, 'css', 'structure.css')]:
+      '.send-form input[type="text"] { min-width: 240px; }\n' +
+      '.cells-grid input { width: 56px; }',
+    [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: VALID_OG_PNG,
+    [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
+  });
+  const errors = checkSharedTree(io, { sharedRoot: SHARED_ROOT });
+  assert.ok(
+    errors.some((e) => e.includes('low-alpha amber') && e.includes('rf2-mon7tz')),
+    `expected the low-alpha amber ring to be rejected, got: ${errors.join(' | ')}`,
   );
 });
 
@@ -621,11 +865,14 @@ it('LIVE: no real example page ships an SVG (or otherwise non-raster) og:image',
 // (SHARED_ROOT is declared up with the other path constants.)
 function sharedCssIo(structureCss) {
   return makeIo({
-    [path.join(SHARED_ROOT, 'css', 'style.css')]: "@import url('structure.css');",
+    // An AA-safe style.css so the contrast/focus contracts (rf2-febmqu +
+    // rf2-mon7tz) are satisfied — this helper pins the CSS-CASCADE contract.
+    [path.join(SHARED_ROOT, 'css', 'style.css')]: GOOD_SHARED_STYLE,
     [path.join(SHARED_ROOT, 'css', 'structure.css')]: structureCss,
     [path.join(SHARED_ROOT, 'img', 'favicon.svg')]: '<svg/>',
-    // checkSharedTree requires both the shipped raster and its source art.
-    [path.join(SHARED_ROOT, 'img', 'og.png')]: 'PNGDATA',
+    // checkSharedTree requires both the shipped raster and its source art, and
+    // now validates the og.png BYTES — supply a real 1200x630 PNG.
+    [path.join(SHARED_ROOT, 'img', 'og.png')]: VALID_OG_PNG,
     [path.join(SHARED_ROOT, 'img', 'og.svg')]: '<svg/>',
   });
 }


### PR DESCRIPTION
Fixes two examples/_shared accessibility beads in one PR (same surface).

rf2-febmqu — shared palette below-AA text contrast. Moved text/control foregrounds and white-text fills off the sub-AA --ex-accent (<=3.52:1) onto --ex-accent-deep, darkened --ex-ink-faint, and reassigned the disconnected/authenticating status pills. All shipped --ex-* token pairs now clear WCAG AA 4.5:1.

rf2-mon7tz — focus indicators + OG raster validation. Replaced outline:none + the ~1.5:1 low-alpha amber ring with a solid --ex-accent-deep :focus-visible ring (>=4.81:1, clears the 3:1 focus bar) plus a 2px transparent outline forced-colors fallback. Added static gate teeth: og.png byte validation (PNG signature + IHDR 1200x630), a shared --ex-* contrast contract, and the focus-indicator contract — each with negative unit tests.

## Quality gates

Contrast ratios (foreground vs surface, AA 4.5:1 / focus 3:1):
- Links / .nav-link / .card p.value (--ex-accent-deep): 5.37 paper / 5.94 white / 4.81 sunken (was --ex-accent 3.18 / 3.52 / 2.85).
- White label on buttons / login-submit / authenticating pill (--ex-accent-deep fill): 5.94 (was --ex-accent 3.52).
- Muted / skeleton text (--ex-ink-faint #6E6654): 5.14 / 5.69 / 4.61 (was #8A8270 3.45 / 3.81 / 3.09).
- Disconnected pill white-on-fill (--ex-ink-muted): 7.46 (was #8A8270 3.81).
- Connected pill white-on-success 5.50; failed pill white-on-error 5.94.
- Focus-visible ring (--ex-accent-deep, non-text 3:1 bar): 5.37 / 5.94 / 4.81.

og.png validated: PNG signature OK, IHDR 1200x630, decodable (matches README contract).

- node examples/scripts/check-examples-assets.cjs — 28 pages + _shared tree clean.
- node implementation/scripts/check-examples-assets.test.cjs — 47 tests pass (incl. new byte/contrast/focus teeth + negatives).
- npm run test:script-policy — green.