### PR TITLE
fix(machines-viz): correct SCXML self-target export + close validation false-green (rf2-0pp6as)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1893,8 +1893,10 @@ documenting comment and does **not** survive the parse back.
 | `:states` (flat)                      | `<state id="...">` |
 | `:states` (compound)                  | nested `<state>` with `initial` |
 | `:final? true`                        | `<final id="...">` |
-| `:on {:event :target}`                | `<transition event="event" target="target"/>` |
+| `:on {:event :target}`                | `<transition event="event" target="target" type="internal"/>` |
 | `:on {:event {:target ... :guard G}}` | `<transition cond="G" .../>` |
+| Self-target (`:target :same-state`, or a keyword naming the state's OWN key) (rf2-0pp6as) | `<transition … target="<source-id>" type="internal"/>` — references the SOURCE state's REAL declared id (NEVER the dangling `same_2dstate` phantom); `type="internal"` is the explicit XState-v5 internal default. Round-trips to the canonical `:same-state`. |
+| `:reenter? true` (any target) (rf2-9dj21r) | `type="external"` — the EXTERNAL restart axis (re-run `:exit`+`:entry`); a target-bearing transition WITHOUT `:reenter?` carries `type="internal"`. |
 | `:after {ms :target}`                 | `<transition event="after.ms" target="target"/>` |
 | `:always [...]`                       | `<transition target="..."/>` (eventless) |
 | `{:type :parallel :regions ...}`      | `<parallel>` containing region `<state>`s |
@@ -1942,6 +1944,24 @@ documenting comment and does **not** survive the parse back.
 
 - `:spawn-all` rows — omitted; the parent state renders without
   spawn affordances.
+- **Internal-default self / proper-ancestor self-transition semantics
+  (rf2-0pp6as).** re-frame2 / XState v5 make a targeted transition
+  INTERNAL by default — the targeted state's own `:exit` / `:entry` do
+  **not** re-run (see [Spec 005 §Self-transitions](../../../spec/005-StateMachines.md)).
+  W3C SCXML's `type="internal"` only changes the transition domain for a
+  **compound source whose target is a proper descendant** (the one case
+  where the export is the exact equivalent — it emits
+  `target="<descendant-id>" type="internal"`). For a **self-target**
+  (source == target) or a **proper-ancestor** target, SCXML re-enters the
+  source regardless of `type`, so the re-frame2 internal default has no
+  exact SCXML equivalent. The export still references the source state's
+  **real declared id** (never the pre-fix dangling `same_2dstate`
+  phantom) and emits `type="internal"` to record the intended axis, and
+  the local `scxml->spec` round-trips the `:same-state` sentinel exactly —
+  but a strict external SCXML engine executing the imported self-target
+  will re-run the source's exit/entry where re-frame2 would not. This
+  irreducible loss is documented rather than masked by the round-trip
+  oracle.
 - Machine-level (top-level) `:on` fallback transitions — W3C SCXML
   has no clean root-fallback slot (`<scxml>` does not host
   `<transition>` children per the schema, and the import side drops

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -42,6 +42,8 @@
   | `:on {:event :target}`                | `<transition event=\"event\" target=\"target\"/>` |
   | `:on {:event {:target ... :guard G}}` | `<transition cond=\"G\" .../>` |
   | `:on {:event {:action A}}` — INTERNAL (no `:target`) | `<transition event=\"event\"><!-- action: A --></transition>` — round-trips to `{:action A}`, NOT the `{}` forbidden block (rf2-mnp93.5) |
+  | Self-target (`:target :same-state`, or a keyword naming the state's OWN key) (rf2-0pp6as) | `<transition … target=\"<source-id>\" type=\"internal\"/>` — references the SOURCE state's REAL declared id (NEVER the dangling `same_2dstate` phantom); `type=\"internal\"` is the explicit XState-v5 internal default. Round-trips to the canonical `:same-state`. |
+  | `:reenter? true` (any target) (rf2-9dj21r) | `type=\"external\"` — the EXTERNAL restart axis (re-run `:exit`+`:entry`). A target-bearing transition WITHOUT `:reenter?` carries `type=\"internal\"`. |
   | `:after {ms :target}`                 | `<transition event=\"after.ms\" target=\"target\"/>` |
   | `:always [...]`                       | `<transition target=\"...\"/>` (eventless) |
   | `{:type :parallel :regions ...}`      | `<parallel>` containing region `<state>`s |
@@ -75,6 +77,22 @@
 
   - `:spawn-all` rows — omitted; the parent state renders without
     spawn affordances.
+  - INTERNAL-default self / proper-ancestor SELF-TRANSITION semantics
+    (rf2-0pp6as) — re-frame2 / XState v5 make a targeted transition
+    INTERNAL by default (the targeted state's OWN `:exit` / `:entry` do
+    NOT re-run); W3C SCXML's `type=\"internal\"` only changes the
+    transition domain for a COMPOUND source whose target is a PROPER
+    DESCENDANT (the one case where the export IS the exact equivalent).
+    For a self-target (source == target) or a proper-ancestor target,
+    SCXML ALWAYS re-enters the source regardless of `type`, so the
+    re-frame2 internal default has no exact SCXML equivalent. The export
+    emits `type=\"internal\"` to record the intended axis and references
+    the source state's REAL declared id (never the pre-fix dangling
+    `same_2dstate` phantom), and the local `scxml->spec` round-trips the
+    `:same-state` sentinel exactly — but a STRICT external SCXML engine
+    executing the imported chart will re-run the source's exit/entry on
+    the self-target where re-frame2 would not. This is the irreducible
+    loss; it is documented here rather than papered over.
   - Machine-level (top-level) `:on` fallback transitions — W3C SCXML
     has no clean root-fallback slot (`<scxml>` does not host
     `<transition>` children per the schema, and the import side drops
@@ -317,14 +335,32 @@
 
 (defn- resolve-target-path
   "Resolve a transition target to its ABSOLUTE path from the machine
-  root. A keyword target is a SIBLING of the source state (Spec 005); a
-  vector-path target is absolute. `source-path` is the source state's
-  absolute path."
+  root. `source-path` is the source state's absolute path.
+
+  - `:same-state` (Spec 005 §Self-transitions self-target sentinel) →
+    the SOURCE state's OWN path. This MUST match the runtime resolver
+    (`re-frame.machines.transition/target-path`) and the chart / Mermaid
+    projectors (`chart.layout/resolve-target-path`,
+    `mermaid/resolve-target-path`), which ALL special-case `:same-state`
+    to the declaring state's own path. rf2-0pp6as — pre-fix the SCXML
+    resolver had NO `:same-state` arm, so the sentinel fell through to the
+    keyword branch and produced the ABSOLUTE path `[:same-state]` — a
+    DANGLING `target=\"same_2dstate\"` referencing a state the document
+    never declares. The local `scxml->spec` decoded that phantom id back
+    to `:same-state`, so the round-trip oracle false-greened over invalid
+    W3C SCXML. Resolving to `source-path` emits the SOURCE state's real
+    unique id, exactly as a sibling-keyword self-target (`:target :a` on
+    state `:a`) already did — the two are the SAME self-transition per
+    Spec 005, and SCXML has no self-sentinel, only a target referencing
+    the state's own id.
+  - a keyword target is a SIBLING of the source state (Spec 005).
+  - a vector-path target is absolute."
   [source-path target]
   (cond
-    (keyword? target)     (conj (parent-path source-path) target)
-    (target-path? target) (vec target)
-    :else                 nil))
+    (= :same-state target) (vec source-path)
+    (keyword? target)      (conj (parent-path source-path) target)
+    (target-path? target)  (vec target)
+    :else                  nil))
 
 (defn- qualified-id
   "The unique xsd:ID for a state at absolute `path` (rf2-mnp93.7)."
@@ -337,17 +373,39 @@
   it so the emitted `target` is the unique xsd:ID of the destination
   (rf2-mnp93.7).
 
-  rf2-9dj21r — the re-frame2 `:reenter? true` axis (Spec 005
-  §Self-transitions / XState v5: a targeted transition is INTERNAL by
+  rf2-9dj21r / rf2-0pp6as — the re-frame2 `:reenter? true` axis (Spec 005
+  §Self-transitions / XState v5: a TARGETED transition is INTERNAL by
   default; `:reenter?` opts into the EXTERNAL restart) maps onto W3C
-  SCXML's `<transition type=\"external\">`. SCXML's `type` is the SAME
-  external-vs-internal axis — `type=\"external\"` re-runs the exit/entry
-  of states common to the source and target. We emit `type=\"external\"`
-  only for a `:reenter? true` candidate; the default (no attr) is SCXML's
-  `internal` for a targetless action-only transition and is the natural
-  encoding for the re-frame2 internal-default targeted transition. Without
-  this a `{:target :same-state}` and a `{:target :same-state :reenter?
-  true}` exported + round-tripped IDENTICALLY."
+  SCXML's `<transition type=\"internal|external\">`, which is the SAME
+  external-vs-internal axis. Spec 005 §Self-transitions L332 records the
+  inversion: SCXML's targeted-transition DEFAULT is `external`
+  (`type=\"internal\"` opts out); XState v5 / re-frame2 FLIPPED it
+  (internal default, `:reenter?` opts IN). So a target-bearing re-frame2
+  transition must be EXPLICIT about the type — leaving it absent would let
+  the export silently inherit SCXML's EXTERNAL default and mis-state the
+  re-frame2 internal-default intent (the rf2-0pp6as drift). We therefore:
+
+  - emit `type=\"external\"` for a target-bearing `:reenter? true`
+    candidate (the external restart — re-run exit/entry); and
+  - emit `type=\"internal\"` for a target-bearing transition WITHOUT
+    `:reenter?` (the re-frame2 / XState-v5 internal default).
+
+  A TARGETLESS (action-only) transition carries NO `type` — SCXML's own
+  default for a targetless transition is already `internal` and `external`
+  is meaningless with no state to re-enter; this also keeps the round-trip
+  for the existing action-only shapes unchanged.
+
+  SCXML's `type=\"internal\"` is strictly equivalent to `external` for a
+  COMPOUND source whose target is a PROPER DESCENDANT (the only case where
+  W3C `getTransitionDomain` differs); for a self / proper-ancestor target
+  it is an irreducible LOSS — SCXML re-enters the source on a self-target
+  regardless of `type`, whereas re-frame2's internal default does NOT
+  re-run the source's own exit/entry. `type=\"internal\"` records the
+  intended axis (and is the exact equivalent for the descendant case); the
+  irreducible self/ancestor loss is documented in API.md §Not supported
+  rather than papered over by the local round-trip oracle. The decoder
+  inverts this axis: `type=\"external\"` ⇒ `:reenter? true`, any other
+  value (incl. `internal` / absent) ⇒ the internal default."
   [event-name {:keys [target guard action reenter?]} source-path depth]
   (let [target-id (when target
                     (qualified-id (resolve-target-path source-path target)))
@@ -360,6 +418,13 @@
                 ;; meaningless without a target).
                 (and target reenter?)
                 (conj "type=\"external\"")
+                ;; rf2-0pp6as — the internal default is EXPLICIT. A
+                ;; target-bearing transition WITHOUT `:reenter?` emits
+                ;; `type=\"internal\"` so the export does NOT inherit SCXML's
+                ;; EXTERNAL targeted-transition default (which would mis-state
+                ;; the re-frame2 / XState-v5 internal default — see docstring).
+                (and target (not reenter?))
+                (conj "type=\"internal\"")
                 ;; rf2-m285a — `ref->label` tolerates an inline-fn guard
                 ;; (lossy name/`fn` label) instead of crashing in
                 ;; `keyword->id-string` on a non-keyword.
@@ -742,15 +807,29 @@
 (defn- decode-target
   "Reconstruct a transition target's RELATIVE grammar form from the
   qualified `target` id and the source state's absolute `source-path`
-  (rf2-mnp93.7). A target whose parent equals the source's parent is a
-  SIBLING — re-frame2 writes it as the bare keyword (the last segment);
-  any other target is written as the absolute vector path. This inverts
-  `resolve-target-path` so the round-trip is exact."
+  (rf2-mnp93.7). This inverts `resolve-target-path` so the round-trip is
+  exact:
+
+  - rf2-0pp6as — a SELF-TARGET (the resolved target path EQUALS the source
+    state's own path) decodes to the canonical `:same-state` sentinel
+    (Spec 005 §Self-transitions). The emitter resolves BOTH `:target
+    :same-state` AND a keyword naming the state's own key to the source
+    state's own id, and SCXML has no self-sentinel — it just references the
+    state's own id. Those two re-frame2 spellings are the SAME
+    self-transition per Spec 005 (L327, transition.cljc L1248-1250), so the
+    canonical decode is `:same-state` for both. This keeps the round-trip
+    exact for `{:target :same-state}` even though the export no longer
+    emits the dangling `same_2dstate` phantom id.
+  - a target whose parent equals the source's parent is a SIBLING —
+    re-frame2 writes it as the bare keyword (the last segment).
+  - any other target is written as the absolute vector path."
   [target-str source-path]
-  (let [abs-path (id-string->abs-path target-str)]
-    (if (= (parent-path (vec abs-path)) (parent-path (vec source-path)))
-      (last abs-path)
-      (vec abs-path))))
+  (let [abs-path (vec (id-string->abs-path target-str))
+        src      (vec source-path)]
+    (cond
+      (= abs-path src)                          :same-state
+      (= (parent-path abs-path) (parent-path src)) (last abs-path)
+      :else                                     abs-path)))
 
 (defn- tokenize
   "Walk an XML string and return a flat seq of token maps:

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -203,7 +203,12 @@
       (is (str/includes? out "target=\"ready\""))
       ;; rf2-mnp93.1 — guard hex-escaped (`:ready?` → `ready_3f`).
       (is (str/includes? out "cond=\"ready_3f\""))
-      (is (str/includes? out "<transition target=\"blocked\"/>"))
+      ;; rf2-0pp6as — a targeted internal-default transition now carries
+      ;; the explicit `type="internal"` axis (so the export does not inherit
+      ;; SCXML's EXTERNAL targeted-transition default). The `:always`
+      ;; candidate is eventless (no `event=`) but is still a targeted
+      ;; internal-default transition, so it carries `type="internal"`.
+      (is (str/includes? out "<transition target=\"blocked\" type=\"internal\"/>"))
       ;; Eventless transitions must not carry event= — confirm by
       ;; searching for the malformed combination.
       (is (not (re-find #"event=\"\"" out))))))
@@ -952,13 +957,19 @@
       (is (true? (get-in back [:states :a :on :ping :reenter?]))
           "the decoded candidate carries `:reenter? true`")))
 
-  (testing "rf2-9dj21r — the internal-DEFAULT self-target emits NO
-            `type=\"external\"` and round-trips WITHOUT `:reenter?`"
+  (testing "rf2-9dj21r / rf2-0pp6as — the internal-DEFAULT self-target emits
+            the explicit `type=\"internal\"` (NEVER `type=\"external\"`) and
+            round-trips WITHOUT `:reenter?`"
     (let [xml  (scxml/spec->scxml internal-self-machine)
           back (scxml/scxml->spec xml)
           cand (get-in back [:states :a :on :ping])]
       (is (not (str/includes? xml "type=\"external\""))
           "the internal default does NOT emit the external type attr")
+      ;; rf2-0pp6as — the internal default is EXPLICIT: a target-bearing
+      ;; transition without `:reenter?` emits `type="internal"` so the
+      ;; export does not inherit SCXML's EXTERNAL targeted-transition default.
+      (is (str/includes? xml "type=\"internal\"")
+          "the internal default emits the explicit SCXML internal type axis")
       ;; A SOLE target-only candidate normalises to the bare-keyword
       ;; shorthand (`:same-state`) on import — the canonical, semantically
       ;; identical form. The point is it stays a TARGET-ONLY transition with
@@ -991,3 +1002,137 @@
           back (scxml/scxml->spec xml)]
       (is (not (str/includes? xml "type=\"external\"")))
       (is (= spec back)))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-0pp6as — SCXML self-target export must reference a DECLARED state id
+;; (never the dangling `same_2dstate` phantom), and must be EXPLICIT about
+;; the XState-v5-internal vs SCXML-external default-inversion. Pre-fix the
+;; SCXML resolver had no `:same-state` arm, so the sentinel exported the
+;; absolute path `[:same-state]` → `target="same_2dstate"` — a DANGLING id
+;; the document never declares. The local `scxml->spec` decoded that phantom
+;; back to `:same-state`, so the round-trip oracle FALSE-GREENED over invalid
+;; W3C SCXML. These tests assert the EXTERNAL form (declared-id validity +
+;; internal/external type axis), not just the local round-trip, so the suite
+;; cannot pass by decoding an invalid export back into the original EDN.
+
+(defn- declared-state-ids
+  "Every state / final / parallel / history id declared in an SCXML
+  document (the set of valid `target=` referents per xsd:ID uniqueness)."
+  [xml]
+  (->> (re-seq #"<(?:state|final|parallel|history)\b[^>]*\bid=\"([^\"]+)\"" xml)
+       (map second)
+       set))
+
+(defn- transition-target-ids
+  "Every nonempty `target=` id appearing on a `<transition>` in an SCXML
+  document."
+  [xml]
+  (->> (re-seq #"<transition\b[^>]*\btarget=\"([^\"]+)\"" xml)
+       (map second)
+       (remove str/blank?)
+       set))
+
+(defn- assert-targets-declared
+  "Validity guard (rf2-0pp6as): EVERY nonempty transition `target=` id must
+  reference a state DECLARED in the same SCXML document. This is the guard
+  the pre-fix dangling `same_2dstate` export would FAIL — the phantom id is
+  not in `declared-state-ids`."
+  [xml]
+  (let [declared (declared-state-ids xml)]
+    (doseq [t (transition-target-ids xml)]
+      (is (contains? declared t)
+          (str "transition target=\"" t "\" must reference a declared "
+               "state id; declared = " (pr-str declared))))))
+
+(deftest scxml-self-target-references-declared-id
+  (testing "rf2-0pp6as — ATOMIC self-target (`:same-state`) exports the
+            SOURCE state's real id, NEVER the dangling `same_2dstate`"
+    (let [spec {:initial :a
+                :states  {:a {:on {:ping {:target :same-state}}}}}
+          xml  (scxml/spec->scxml spec)]
+      (is (not (str/includes? xml "same_2dstate"))
+          "the `:same-state` sentinel must NOT leak as a phantom target id")
+      (is (str/includes? xml "<transition event=\"ping\" target=\"a\" type=\"internal\"/>")
+          "self-target references the source state's own id, internal default")
+      (assert-targets-declared xml)
+      ;; supplement the external-form assertions with the local round-trip:
+      ;; the canonical decode of a self-target is `:same-state`.
+      (is (= :same-state (get-in (scxml/scxml->spec xml) [:states :a :on :ping]))
+          "round-trips to the canonical `:same-state` self-target form")))
+
+  (testing "rf2-0pp6as — a keyword target NAMING the state's own key is the
+            SAME self-transition; it too references the declared id + decodes
+            to the canonical `:same-state`"
+    (let [spec {:initial :a
+                :states  {:a {:on {:ping {:target :a}}}}}
+          xml  (scxml/spec->scxml spec)]
+      (is (not (str/includes? xml "same_2dstate")))
+      (is (str/includes? xml "target=\"a\""))
+      (assert-targets-declared xml)
+      (is (= :same-state (get-in (scxml/scxml->spec xml) [:states :a :on :ping]))
+          "own-keyword self-target canonicalises to `:same-state` (Spec 005)")))
+
+  (testing "rf2-0pp6as — COMPOUND self/ancestor target (`:same-state` declared
+            on a compound) references the compound's own declared id"
+    (let [spec {:initial :outer
+                :states  {:outer {:initial :inner1
+                                  :on      {:reset {:target :same-state}}
+                                  :states  {:inner1 {} :inner2 {}}}}}
+          xml  (scxml/spec->scxml spec)]
+      (is (not (str/includes? xml "same_2dstate")))
+      (is (str/includes? xml "<transition event=\"reset\" target=\"outer\" type=\"internal\"/>")
+          "the compound self-target references the compound's own id, internal default")
+      (assert-targets-declared xml)
+      (is (= :same-state (get-in (scxml/scxml->spec xml) [:states :outer :on :reset]))
+          "round-trips to the canonical `:same-state` form")))
+
+  (testing "rf2-0pp6as — COMPOUND-declared DESCENDANT target references the
+            descendant's fully-qualified declared id with `type=\"internal\"`
+            (the case where SCXML internal IS the exact equivalent)"
+    (let [spec {:initial :outer
+                :states  {:outer {:initial :inner1
+                                  :on      {:go {:target [:outer :inner2]}}
+                                  :states  {:inner1 {} :inner2 {}}}}}
+          xml  (scxml/spec->scxml spec)
+          back (scxml/scxml->spec xml)]
+      (is (str/includes? xml "target=\"outer___inner2\" type=\"internal\"")
+          "descendant target references the qualified declared id, internal default")
+      (assert-targets-declared xml)
+      (is (= [:outer :inner2] (get-in back [:states :outer :on :go]))
+          "descendant target round-trips to its absolute vector path")))
+
+  (testing "rf2-0pp6as — the EXTERNAL (`:reenter? true`) self-target also
+            references the declared id and carries `type=\"external\"`"
+    (let [spec {:initial :a
+                :states  {:a {:on {:ping {:target :same-state :reenter? true}}}}}
+          xml  (scxml/spec->scxml spec)]
+      (is (not (str/includes? xml "same_2dstate")))
+      (is (str/includes? xml "<transition event=\"ping\" target=\"a\" type=\"external\"/>")
+          "the external self-target references the source id, type external")
+      (assert-targets-declared xml)
+      (is (= {:target :same-state :reenter? true}
+             (get-in (scxml/scxml->spec xml) [:states :a :on :ping]))
+          "exact round-trip preserves the external `:reenter?` axis")))
+
+  (testing "rf2-0pp6as — internal vs external self-targets export to DISTINCT,
+            DECLARED-id-valid SCXML (the two are runtime-distinct)"
+    (let [internal {:initial :a :states {:a {:on {:ping {:target :same-state}}}}}
+          external {:initial :a :states {:a {:on {:ping {:target :same-state :reenter? true}}}}}
+          xi (scxml/spec->scxml internal)
+          xe (scxml/spec->scxml external)]
+      (is (not= xi xe) "internal vs external must produce DISTINCT SCXML")
+      (is (str/includes? xi "type=\"internal\""))
+      (is (str/includes? xe "type=\"external\""))
+      (assert-targets-declared xi)
+      (assert-targets-declared xe))))
+
+(deftest scxml-all-fixtures-targets-declared
+  (testing "rf2-0pp6as — the declared-target validity guard holds for EVERY
+            non-parallel fixture's export (no dangling `target=` ids anywhere)"
+    (doseq [spec [idle-loading-success-error
+                  compound-machine
+                  always-machine
+                  reenter-self-machine
+                  internal-self-machine
+                  reenter-ancestor-machine]]
+      (assert-targets-declared (scxml/spec->scxml spec)))))


### PR DESCRIPTION
Fixes rf2-0pp6as. The SCXML resolver had no `:same-state` arm, so the self-target sentinel exported the absolute path `[:same-state]` -> a dangling `target="same_2dstate"` referencing a state the document never declares. The local `scxml->spec` decoded that phantom back to `:same-state`, so the round-trip oracle false-greened over invalid W3C SCXML.

Fix: `resolve-target-path` special-cases `:same-state` to the source state's own path (matching the runtime / chart / Mermaid resolvers); `emit-transition` makes the XState-v5 internal-vs-external axis explicit (`type="internal"` for the internal default, `type="external"` for `:reenter? true`) so the export no longer inherits SCXML's external targeted-transition default; `decode-target` canonicalises a self-target back to `:same-state` keeping the round-trip exact. New regression tests cover atomic / compound-self / ancestor / descendant self-targets, the type axis, and a validity guard that every emitted `target=` id is declared in the same document. API.md + ns docstring document the irreducible self/ancestor internal-self-transition loss (SCXML re-enters on a self-target regardless of `type`).

Spec update: `tools/machines-viz/spec/API.md` updated (grammar table + Not-supported). `tools/xray/spec/*` unchanged because those specs cover the chart inspector's self-transition rendering, not the SCXML import/export contract (which lives in machines-viz API.md).

## Quality gates
- `clojure -M:test` (tools/machines-viz): 483 tests, 1704 assertions, 0 failures, 0 errors
- `python scripts/check_doc_slugs.py`: EXIT=0