### PR TITLE
fix(template): close release-gate + npm-pin-lockstep false-greens (rf2-8n4s71 rf2-6yuzo4)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -297,6 +297,27 @@ else
         cljs_prod=true
         bundle_isolation=true
         reagent_slim_bundle=true
+        # rf2-6yuzo4 — template npm-pin lockstep. The template's hooks.clj
+        # pins :shadow-version + :react-version, and version_lockstep_test
+        # asserts those emitted pins match implementation/package.json's
+        # react / react-dom / shadow-cljs entries (the source of truth).
+        # The emitted-app smoke (emitted_test_run_test, the ONLY PR-time
+        # gate that compiles + runs the generated project) symlinks
+        # implementation/node_modules — populated from
+        # implementation/package-lock.json — into the scaffold so React
+        # resolves. So a PR that bumps those package.json pins, or the
+        # lockfile the smoke links against, must run jvm-tools-template:
+        # otherwise the template keeps emitting a stale pin (or links a
+        # drifted node_modules) and merges GREEN while breaking the
+        # lockstep contract + the advertised smoke-tested combination.
+        # Scoped to package.json + the lockfile; shadow-cljs.edn and
+        # implementation/scripts/* don't carry the emitted npm pins, so
+        # they stay off template_expensive (the nightly full matrix
+        # covers any build-config drift they can introduce).
+        case "$file" in
+          implementation/package.json|implementation/package-lock.json)
+            template_expensive=true ;;
+        esac
         ;;
       examples/*)
         # rf2-bxdk8 + rf2-cjp0i + rf2-8cevm — examples/** is test-free.

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -110,6 +110,23 @@ jobs:
   #    release — the tagged commit must emit a shape that compiles,
   #    runs, and survives an `:advanced` release build.
   #
+  #    rf2-8n4s71 #1 — SCOPE of this gate, stated honestly. The emitted-
+  #    app tier (`emitted_test_run_test.clj`) rewrites the generated
+  #    `day8/re-frame2*` `:mvn/version "0.0.1.alpha"` coords to monorepo
+  #    `:local/root` paths BEFORE compiling. So this gate proves
+  #    "generated code compiles + runs + survives :advanced against the
+  #    in-repo framework source" — it does NOT prove "the emitted deps.edn
+  #    coords RESOLVE". They cannot pre-split: the 0.0.1.alpha coords are
+  #    unpublished (re-frame2 ships via git-coord, not Maven) and the
+  #    `io.github.day8/re-frame2-template` git-coord does not resolve until
+  #    the split repo exists (rf2-7jgkv). The GitHub Release body therefore
+  #    carries a loud pre-split caveat (job 3 below) so a local-root-only
+  #    release cannot be mistaken for a usable public scaffold. The
+  #    published-coord resolve smoke (scaffold via
+  #    `io.github.day8/re-frame2-template#<tag>` + `clojure -P` / `npm test`
+  #    WITHOUT the :local/root rewrite) is a post-split gate —
+  #    tools/template/spec/005-Repo-Split.md §3.2 / §3.4.
+  #
   #    rf2-ek857f F1 — the emitted-app compile/run/release tier in
   #    `emitted_test_run_test.clj` defaults OFF (opt-in via
   #    RF2_TEMPLATE_RUN_EMITTED_TESTS=1) and needs a populated
@@ -209,7 +226,26 @@ jobs:
           body: |
             `day8/re-frame2-template` ${{ needs.verify-version.outputs.version }} — git-coord release.
 
-            Consumers resolve the template via deps-new at this tag:
+            > [!WARNING]
+            > **Pre-split release — not yet a usable public scaffold (rf2-8n4s71).**
+            > This tag was cut from the `day8/re-frame2` monorepo before the
+            > template repo split-out (rf2-7jgkv). The pre-release gate
+            > compiles + runs the generated project only after rewriting the
+            > emitted `day8/re-frame2*` dependency coords to monorepo
+            > `:local/root` paths — it proves "generated code compiles", **not**
+            > "the released template emits a project whose `deps.edn` coords
+            > resolve". The emitted `:mvn/version "0.0.1.alpha"` framework
+            > coords are **not published** (re-frame2 distributes via git-coord,
+            > not Maven), and the `io.github.day8/re-frame2-template` git-coord
+            > below does **not resolve** until the split repo exists. A real
+            > consumer following the invocation below will fail during
+            > dependency resolution before any scaffolded code runs. Do **not**
+            > treat this release as a usable public scaffold. The published-coord
+            > smoke that proves the shipped dependency surface is a post-split
+            > gate (`tools/template/spec/005-Repo-Split.md` §3.2 / §3.4).
+
+            Once the split repo exists, consumers resolve the template via
+            deps-new at this tag:
 
             ```bash
             clojure -Tnew create \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1885,8 +1885,18 @@ jobs:
       # `-P` against the published coords cannot resolve and would always
       # red. The behavioural tier transitively resolves + compiles the
       # full deps tree under the :local/root rewrite, which is the
-      # strongest resolve signal achievable pre-publish. A published-coord
-      # resolve probe is a forward concern for the §3 release pipeline.
+      # strongest resolve signal achievable pre-publish.
+      #
+      # rf2-8n4s71 #1 — be precise about scope: this proves "generated
+      # code compiles + runs against the in-repo framework source", NOT
+      # "the emitted deps.edn coords RESOLVE for a real consumer". The
+      # local-root rewrite swaps out exactly the coords a published
+      # consumer would have to resolve. The published-coord resolve smoke
+      # (scaffold via `io.github.day8/re-frame2-template#<tag>` +
+      # `clojure -P` / `npm test` WITHOUT the rewrite) is a post-split
+      # forward concern — see tools/template/spec/005-Repo-Split.md
+      # §3.2 / §3.4 and the pre-split caveat in the release-template.yml
+      # GitHub Release body.
       - name: Run JVM tests (tools/template artefact)
         env:
           RF2_TEMPLATE_RUN_EMITTED_TESTS: "1"

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -237,6 +237,45 @@ test('Adapter change still arms template_expensive (regression) (rf2-jdj17.1)', 
   assert.equal(result.template_expensive, 'true');
 });
 
+// rf2-6yuzo4 — template npm-pin lockstep false-green. hooks.clj pins
+// :shadow-version + :react-version; version_lockstep_test asserts those
+// emitted pins match implementation/package.json's react / react-dom /
+// shadow-cljs entries (the source of truth), and the emitted-app smoke
+// symlinks implementation/node_modules (populated from
+// implementation/package-lock.json). Before the fix, a PR bumping those
+// package.json pins or the lockfile classified template_expensive=false
+// — so jvm-tools-template (the ONLY PR gate running version_lockstep_test
+// + the emitted-app smoke) was skipped and the template could keep
+// emitting a stale npm pin GREEN. These assertions lock the classifier
+// arming template_expensive on the npm source-of-truth + its lockfile,
+// while keeping shadow-cljs.edn / implementation/scripts/* off it (they
+// carry no emitted npm pin).
+
+test('implementation/package.json arms template_expensive (npm-pin lockstep) (rf2-6yuzo4)', () => {
+  const result = classify('implementation/package.json');
+  assert.equal(result.template_expensive, 'true');
+});
+
+test('implementation/package-lock.json arms template_expensive (emitted smoke links node_modules) (rf2-6yuzo4)', () => {
+  const result = classify('implementation/package-lock.json');
+  assert.equal(result.template_expensive, 'true');
+});
+
+test('implementation/shadow-cljs.edn does NOT arm template_expensive (no emitted npm pin) (rf2-6yuzo4)', () => {
+  const result = classify('implementation/shadow-cljs.edn');
+  assert.equal(result.template_expensive, 'false');
+});
+
+test('implementation/scripts/* does NOT arm template_expensive (no emitted npm pin) (rf2-6yuzo4)', () => {
+  const result = classify('implementation/scripts/build-foo.cjs');
+  assert.equal(result.template_expensive, 'false');
+});
+
+test('implementation/package.json still arms cljs_node_test (regression — it defines node deps) (rf2-6yuzo4)', () => {
+  const result = classify('implementation/package.json');
+  assert.equal(result.cljs_node_test, 'true');
+});
+
 // rf2-f79t8 (a) — workflow-level shape: jvm-core + cljs must be
 // job-level gated (needs + if), NOT trigger-filtered, and the
 // pull_request trigger must stay unfiltered so the aggregator is always

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -27,27 +27,38 @@ file save) are fast.
 `shadow-cljs watch` rebuilds on every file save and re-invokes
 `{{namespace}}.core/init` — shadow's `:browser` target re-runs the
 module's `:init-fn` automatically after each hot reload, so no
-`:after-load` hook is needed. The entry fn is **idempotent**:
-re-frame2's
-`rf/init!` accepts being called repeatedly, the registrar
-re-registers in place, and `dispatch-sync [:counter/initialise]`
-re-seeds app-db.
+`:after-load` hook is needed. Two distinct mechanisms combine to give
+you a clean reload:
 
-Under the hood re-frame2 guarantees a **per-frame re-init contract**:
-each call to `init!` on a frame snapshots the registrar, re-installs
-the adapter, and resets the frame's app-db to a known state — your
-handlers and subs come back wired to the new code without leaking
-state from the previous build. Add new `reg-event-db` / `reg-sub` /
-`reg-view` forms and they show up live; rename or remove a handler
-and the next reload drops the old registration.
+1. **Namespace reload re-runs your registrations.** Reloading
+   `events.cljs` / `subs.cljs` / `views.cljs` re-evaluates the
+   `reg-event-db` / `reg-sub` / `reg-view` forms at the top level, so
+   each handler / sub / view re-registers in place against the new
+   code. Add a new `reg-*` form and it shows up live; rename or remove
+   a handler and the next reload drops the old registration.
+
+2. **`rf/init!` is safe to re-call but does NOT reset anything by
+   itself.** It is idempotent: it installs the substrate adapter **only
+   when none is already seated** and ensures the `:rf/default` frame
+   exists. A second call (which every hot reload makes) does **not**
+   re-install the adapter, does **not** snapshot the registrar, and
+   does **not** touch app-db. So `init!` running again is a no-op for
+   your state.
+
+The thing that re-seeds the demo state on reload is the entry fn's own
+explicit `rf/dispatch-sync [:counter/initialise]` call in `core.cljs`
+— not `init!`. That is the reset boundary: the `:counter/initialise`
+event handler writes the starter app-db, so editing it (or removing
+the `dispatch-sync` call) is what changes what a reload re-seeds.
 
 ## In-app devtools (Xray)
 
 `shadow-cljs.edn` wires `day8.re-frame2-xray.preload` into
 `:devtools/preloads` on the `:app` build — the scaffold ships Xray
 **on by default** for development. `resources/public/index.html`
-includes the `[data-rf-xray-host]` left layout column, so Xray
-auto-opens beside your app once `rf/init!` runs. Press
+includes the `[data-rf-xray-host]` right-side layout host (the
+`<aside>` follows `<main id="app">`, so it lays out to the right), so
+Xray auto-opens beside your app once `rf/init!` runs. Press
 **Ctrl+Shift+C** to hide/show it: per-epoch dispatch log, app-db diff,
 causality graph, time-travel scrubber.
 Release builds drop the preload automatically (shadow only runs

--- a/tools/template/test/day8/re_frame2_template/release_gate_test.clj
+++ b/tools/template/test/day8/re_frame2_template/release_gate_test.clj
@@ -55,6 +55,15 @@
     (when (and start end (< start end))
       (subs yaml start end))))
 
+(defn- github-release-job
+  "The `github-release:` job block — from the job key to end-of-file
+  (it is the last job). Scopes the Release-body assertions to the job
+  that cuts the GitHub Release."
+  [yaml]
+  (let [start (string/index-of yaml "\n  github-release:")]
+    (when start
+      (subs yaml start))))
+
 (deftest release-gate-exists-test
   (testing "the template release workflow is present and tag-triggered"
     (let [yaml (release-workflow-text)]
@@ -102,3 +111,37 @@
         (is (re-find #"clojure -M:test" job)
             "test-template must run `clojure -M:test` from tools/template
              (the suite the env var + node_modules unlock).")))))
+
+(deftest release-body-carries-pre-split-caveat-test
+  (testing "the GitHub Release body warns the pre-split, local-root-only
+            release is NOT a usable public scaffold (rf2-8n4s71 #1)"
+    (let [yaml (release-workflow-text)
+          job  (some-> yaml github-release-job)]
+      (is (some? job)
+          "could not isolate the github-release job block — has it been
+           renamed or removed?")
+      (when job
+        ;; The pre-release gate proves only "generated code compiles
+        ;; after the emitted framework coords are rewritten to monorepo
+        ;; :local/root paths" (emitted_test_run_test.clj). It does NOT
+        ;; prove the emitted :mvn/version coords resolve — they are
+        ;; unpublished and the io.github.day8/re-frame2-template git-coord
+        ;; does not resolve until the repo split. So the cut Release MUST
+        ;; carry a loud caveat: otherwise a `template-v…` tag advertises a
+        ;; usable public scaffold that fails at the first consumer's
+        ;; dependency resolution (the very false-green this guards).
+        (is (re-find #"(?i)not\s+(yet\s+)?a usable public scaffold" job)
+            "the GitHub Release body must state the pre-split release is
+             NOT a usable public scaffold — the emitted coords don't
+             resolve until the template repo split (rf2-8n4s71 #1).")
+        (is (string/includes? job "rf2-8n4s71")
+            "the Release-body caveat must cite rf2-8n4s71 so the
+             provenance of the pre-split warning is traceable.")
+        (is (re-find #"(?i):local/root" job)
+            "the Release-body caveat must name the :local/root rewrite —
+             the reason the gate proves 'compiles' but not 'coords
+             resolve' (rf2-8n4s71 #1).")
+        (is (re-find #"(?i)not\s+published|do(es)?\s+not\s+resolve" job)
+            "the Release-body caveat must say the framework coords are
+             not published / the git-coord does not resolve pre-split
+             (rf2-8n4s71 #1).")))))

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -227,6 +227,67 @@
             (is (.contains readme-text "License-MIT")
                 "README ships a License badge"))
 
+          ;; -- README hot-reload contract accuracy (rf2-8n4s71 #2) --
+          ;; The generated README MUST describe the ACTUAL rf/init!
+          ;; contract (implementation/core/src/re_frame/core.cljc init!;
+          ;; pinned by implementation/core/test/re_frame/boot_test.clj):
+          ;; init! is idempotent — it installs the adapter ONLY when none
+          ;; is seated and ensures :rf/default; a second call does NOT
+          ;; re-install the adapter, snapshot the registrar, or reset
+          ;; app-db. The earlier README overstated this ("each call to
+          ;; init! snapshots the registrar, re-installs the adapter, and
+          ;; resets the frame's app-db"), teaching a false mental model.
+          ;; The reset boundary is the starter's explicit
+          ;; dispatch-sync [:counter/initialise] in core.cljs, not init!.
+          (let [readme-text (slurp (io/file root "README.md"))
+                ;; Scope the false-claim greps to the Hot reload section
+                ;; (from its heading to the next ## heading) so an honest
+                ;; mention elsewhere (e.g. the adapter API discussion)
+                ;; can't trip them.
+                hot-reload-start (.indexOf readme-text "## Hot reload")
+                hot-reload-end   (let [i (.indexOf readme-text "\n## " (inc hot-reload-start))]
+                                   (if (neg? i) (count readme-text) i))
+                hot-reload-sec   (subs readme-text hot-reload-start hot-reload-end)]
+            (is (not (neg? hot-reload-start))
+                "README has a Hot reload section")
+            ;; The actual contract is stated.
+            (is (.contains readme-text "dispatch-sync [:counter/initialise]")
+                "README names the explicit dispatch-sync [:counter/initialise]
+                 as what re-seeds the demo state on reload (the reset
+                 boundary — rf2-8n4s71 #2)")
+            ;; The false claims must be gone — init! by itself does none
+            ;; of these (boot_test.clj pins the second-call no-op).
+            (is (not (.contains hot-reload-sec "snapshots the registrar"))
+                "README Hot reload section must NOT claim rf/init! snapshots
+                 the registrar — boot_test.clj pins the second call as a
+                 no-op (rf2-8n4s71 #2)")
+            (is (not (.contains hot-reload-sec "re-installs the adapter"))
+                "README Hot reload section must NOT claim rf/init! re-installs
+                 the adapter on each call — it installs ONLY when none is
+                 seated (core.cljc init!; rf2-8n4s71 #2)")
+            (is (not (.contains hot-reload-sec "resets the frame's app-db"))
+                "README Hot reload section must NOT claim rf/init! resets
+                 app-db by itself — the explicit dispatch-sync
+                 [:counter/initialise] is the reset boundary (rf2-8n4s71 #2)"))
+
+          ;; -- README Xray host wording — right-side, not left (rf2-8n4s71 #3) --
+          ;; The emitted index.html orders <main id="app"> BEFORE
+          ;; <aside data-rf-xray-host> and app.css documents/implements a
+          ;; RIGHT-side host (pinned by the Xray layout-host audit in
+          ;; template_emission_test.clj; matches
+          ;; tools/xray/spec/011-Launch-Modes.md). The README must agree
+          ;; — it previously said "left layout column", contradicting the
+          ;; emitted layout + the Xray spec.
+          (let [readme-text (slurp (io/file root "README.md"))]
+            (is (not (.contains readme-text "left layout column"))
+                "README must NOT call the Xray host a 'left layout column' —
+                 the emitted index.html/app.css ship a RIGHT-side host
+                 (rf2-8n4s71 #3)")
+            (is (re-find #"right-side layout host" readme-text)
+                "README describes the Xray host as a right-side layout host
+                 (matches the emitted index.html/app.css + Xray spec —
+                 rf2-8n4s71 #3)"))
+
           ;; -- Baseline CI workflow (rf2-k2z79) --
           (let [ci-text (slurp (io/file root ".github/workflows/ci.yml"))]
             (is (.contains ci-text "name: ci")


### PR DESCRIPTION
Fixes two tools/template CI-integrity false-greens.

**rf2-8n4s71 (P1) — release gate + generated docs drift**
- #1 (High) Release-gate honesty: the pre-release gate compiles the emitted app only after rewriting framework coords to :local/root, so it proves 'generated code compiles', not 'emitted deps.edn coords resolve'. The cut GitHub Release body now carries a loud pre-split caveat (release is NOT a usable public scaffold — coords unpublished + git-coord unresolvable until the repo split); test.yml + workflow comments state the scope honestly; release_gate_test.clj pins the caveat against regression. The published-coord resolve smoke remains the documented post-split forward concern (spec 005-Repo-Split §3.2/§3.4) since the coords can't resolve pre-split.
- #2 (Med) README hot-reload rewritten to the actual rf/init! contract (idempotent; installs only when no adapter seated; ensures :rf/default; does NOT re-install/snapshot/reset by itself). The explicit dispatch-sync [:counter/initialise] is named as the reset boundary. template_test.clj asserts the contract and forbids the old overstatements.
- #3 (Low) README 'left layout column' -> 'right-side layout host' to match the emitted index.html/app.css + Xray spec; regression added.

**rf2-6yuzo4 (P2) — npm pin lockstep can skip PR gate**
- implementation/package.json and implementation/package-lock.json now arm template_expensive=true in the changed-surface classifier, so a react/react-dom/shadow-cljs pin bump (or the lockfile the emitted smoke links node_modules from) runs jvm-tools-template (version_lockstep_test + emitted-app smoke). shadow-cljs.edn + implementation/scripts/* stay off it (no emitted npm pin). Added 5 classifier self-test fixtures.

Hot-zone note: .github/workflows/template-release.yml + test.yml are hot-zone; edits there are comment/Release-body only (no job-structure or routing change). The rf2-6yuzo4 false-green lives in .github/scripts/report-changed-surfaces.sh, edited there.

## Quality gates
- tools/template clojure -M:test: 32 tests, 397 assertions, 0 failures 0 errors (default tier; emitted-app tier opt-in via RF2_TEMPLATE_RUN_EMITTED_TESTS not run locally).
- implementation/scripts/_changed-surfaces.test.cjs: 64 passed.
- Negative controls: reverting the README right-side wording fails the #3 assertions; stripping the Release-body caveat fails release-body-carries-pre-split-caveat-test.
- Classifier probes: package.json/package-lock.json -> template_expensive=true; shadow-cljs.edn / implementation/scripts/* -> false.