### PR TITLE
fix(testbed-support): cross-platform override normalization (rf2-d01s6s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,9 @@ tools/                         CLJS dev/inspection tools that consume re-frame2'
   machines-viz/                day8/re-frame2-machines-viz — substrate-agnostic MachineChart
                                component + read-only viewer surfaces (the chart extracted out of
                                Xray; also hosts the pure Mermaid emitter)
-  testbed-support/             Shared testbed-config helper (single ns re-frame.testbed.config);
-                               consumed by the framework testbed builds
+  testbed-support/             Shared testbed helpers (re-frame.testbed.config project-root resolver
+                               + re-frame.testbed.story-host hash-toggle host); consumed by the
+                               framework testbed builds
   mcp-base/                    Shared CLJC library for the MCP servers (arg parsing, redaction,
                                cap, overflow); bundle-isolated boundary helpers
   mcp-conformance/             Cross-server MCP conformance harness — gates wire-vocabulary parity

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -171,14 +171,20 @@
                 ;; `:examples/counter-with-stories` and
                 ;; `:story-static/counter-with-stories` builds below.
                 "../tools/story/testbeds"
-                ;; tools/testbed-support (rf2-5dphw — shared testbed-config
-                ;; helper). Single ns `re-frame.testbed.config` that derives
-                ;; the open-in-editor project-root from the build-env
+                ;; tools/testbed-support (rf2-5dphw — shared testbed
+                ;; helpers). Two public namespaces:
+                ;; `re-frame.testbed.config`, which derives the
+                ;; open-in-editor project-root from the build-env
                 ;; `re-frame.testbed.config/repo-root` goog-define (seeded
                 ;; per build below via `#shadow/env`), replacing the six
                 ;; hardcoded personal-path defaults the Xray / Story
-                ;; testbeds previously copied. Bundle-isolation contract
-                ;; holds (nothing under implementation/ :requires it).
+                ;; testbeds previously copied; and
+                ;; `re-frame.testbed.story-host`, the live-app ↔ Story-shell
+                ;; hash-toggle host harness the showcase testbeds share. Both
+                ;; carry `*-cljs-test` suites under src/ that the :node-test
+                ;; build's `cljs-test$` ns-regexp discovers via this source
+                ;; path. Bundle-isolation contract holds (nothing under
+                ;; implementation/ :requires it).
                 "../tools/testbed-support/src"
                 ;; Per rf2-kx74 examples/ is grouped per substrate. Each
                 ;; substrate root is its own shadow-cljs source path so

--- a/tools/README.md
+++ b/tools/README.md
@@ -107,11 +107,16 @@ wired into the build, and consumers can use it today.
   [`tools/machines-viz/README.md`](./machines-viz/README.md).
 
 - **`tools/testbed-support/`** — a small dev-only support library
-  (single ns `re-frame.testbed.config`) the Xray / Story browser
-  testbeds share: `resolve-project-root` derives the on-disk project
-  root for "open in editor" from a build-env `goog-define` (seeded per
-  build via `#shadow/env`, so it's cross-platform with no hardcoded
-  checkout path) with a `?project-root=` per-session override. It is
+  (two namespaces: `re-frame.testbed.config` and
+  `re-frame.testbed.story-host`) the Xray / Story browser testbeds share.
+  `config/resolve-project-root` derives the on-disk project root for
+  "open in editor" from a build-env `goog-define` (seeded per build via
+  `#shadow/env`, so it's cross-platform with no hardcoded checkout path)
+  with a `?project-root=` per-session override, normalising both tiers to
+  a canonical forward-slash form so Windows and POSIX checkout roots
+  resolve identically. `story-host/mount-with-hash-routing!` owns the
+  live-app ↔ Story-shell hash-toggle host harness the showcase testbeds
+  share. It is
   **not a published jar** — no `deps.edn`/Clojars coord; it's wired into
   the testbed builds as an extra source path in
   `implementation/shadow-cljs.edn`. Bundle-isolated (nothing under

--- a/tools/testbed-support/README.md
+++ b/tools/testbed-support/README.md
@@ -36,9 +36,15 @@ other clone and every Mac/Linux maintainer (rf2-5dphw).
   source coords resolve (rf2-w4yw9q). Paste the checkout root unencoded,
   including a literal `+` (e.g. `?project-root=/home/dev/re-frame2+wip`);
   the parser decodes percent-escapes but preserves `+` rather than
-  mapping it to a space (rf2-xdsat.1). When neither tier is present it
-  returns `nil`, and the testbed configures no root — "open in editor"
-  degrades to a graceful no-op rather than a broken link.
+  mapping it to a space (rf2-xdsat.1). Both tiers and the subdir are
+  normalised to a canonical forward-slash form (`\` → `/`, trailing /
+  leading slash stripped), so a Windows override
+  (`?project-root=C:\Users\me\code\re-frame2\`, raw or `%5C`-encoded)
+  resolves to a clean single-separator path rather than a `\/` boundary —
+  matching the launcher's build-env normalisation and the
+  separator-agnostic editor-URI composer (rf2-d01s6s). When neither tier
+  is present it returns `nil`, and the testbed configures no root —
+  "open in editor" degrades to a graceful no-op rather than a broken link.
 
 ## The Story host harness (`story-host`)
 
@@ -70,7 +76,8 @@ tools/testbed-support/
 └── src/re_frame/testbed/
     ├── config.cljs                           ; resolve-project-root + the repo-root goog-define
     ├── config_cljs_test.cljs                 ; CLJS unit tests for the resolver
-    └── story_host.cljs                       ; mount-with-hash-routing! (live-app↔shell host)
+    ├── story_host.cljs                       ; mount-with-hash-routing! (live-app↔shell host)
+    └── story_host_cljs_test.cljs             ; CLJS unit tests for the host harness
 ```
 
 ## How it's wired
@@ -85,9 +92,14 @@ and seed `re-frame.testbed.config/repo-root` via that file's
 
 ## How to test
 
-The `config_cljs_test.cljs` corpus runs as part of the testbed CLJS test
-surface; there is no standalone test alias for this directory (no
-`deps.edn`).
+Both `config_cljs_test.cljs` (the resolver) and `story_host_cljs_test.cljs`
+(the host harness's listener lifecycle / hot-reload behaviour) run as part
+of the always-on CLJS gate: `npm run test:cljs` from `implementation/`
+compiles the `:node-test` build, whose `:ns-regexp "cljs-test$"` discovers
+both namespaces through this slice's wired `../tools/testbed-support/src`
+source path. There is no standalone test alias for this directory (no
+`deps.edn`); the suites live under `src/` precisely so that wired source
+path picks them up.
 
 ## See also
 

--- a/tools/testbed-support/src/re_frame/testbed/config.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config.cljs
@@ -118,8 +118,21 @@
   (when (exists? js/window)
     (query-param-from-search (-> js/window .-location .-search) param-name)))
 
+(defn- to-forward-slashes
+  "Canonicalise every path separator in `s` to a forward slash. A Windows
+  checkout root (`C:\\Users\\me\\code\\re-frame2`) and a POSIX one
+  (`/home/dev/re-frame2`) thus reduce to the SAME `/`-separated form, the
+  canonical shape this helper emits — matching the launcher's build-env
+  normalisation (`implementation/scripts/dev-testbed.cjs`) and the
+  separator-agnostic editor-URI composer (`source_coords/editor_uri.cljc`,
+  which accepts both `/` and `\\` on input and joins with `/`)."
+  [s]
+  (str/replace s #"\\" "/"))
+
 (defn- strip-trailing-slash
-  "Return `s` without a single trailing slash, leaving a lone `\"/\"` intact."
+  "Return `s` without a single trailing forward slash, leaving a lone
+  `\"/\"` intact. Callers canonicalise backslashes to `/` first
+  (`to-forward-slashes`), so this only needs to consider forward slashes."
   [s]
   (if (and (> (count s) 1) (str/ends-with? s "/"))
     (subs s 0 (dec (count s)))
@@ -127,17 +140,24 @@
 
 (defn- join-root+subdir
   "Join a checkout `root` with the tool-relative testbed `subdir`,
-  normalising both sides so the result carries exactly one separator.
+  normalising both sides so the result carries exactly one separator and
+  uses the canonical forward-slash form on every platform.
 
-  `root` has any single trailing slash stripped (so `/repo/` + `sub`
-  never yields `/repo//sub`); `subdir` is trimmed and any leading
-  slash(es) removed (so callers may pass it with or without a leading
-  slash). A blank / nil / slash-only `subdir` collapses to the
-  normalised root verbatim."
+  Both sides are first canonicalised so any `\\` separator (a raw or
+  `%5C`-decoded Windows override root, e.g.
+  `C:\\Users\\me\\code\\re-frame2\\`) becomes `/` — so a Windows
+  `?project-root=` value joins exactly like a POSIX one rather than
+  yielding a `\\/` boundary (`C:\\...\\/tools/xray/testbeds`) that relied
+  on downstream tolerant path normalisation. `root` then has any single
+  trailing slash stripped (so `/repo/` + `sub` never yields `/repo//sub`);
+  `subdir` is trimmed and any leading slash(es) removed (so callers may
+  pass it with or without a leading slash). A blank / nil / slash-only
+  `subdir` collapses to the normalised root verbatim."
   [root subdir]
-  (let [normalized-root   (strip-trailing-slash (str/trim root))
+  (let [normalized-root   (-> root str/trim to-forward-slashes strip-trailing-slash)
         normalized-subdir (-> (or subdir "")
                               str/trim
+                              to-forward-slashes
                               (str/replace #"^/+" ""))]
     (if (seq normalized-subdir)
       (str normalized-root "/" normalized-subdir)
@@ -164,16 +184,19 @@
        hatch (CI, a reader on a different machine, a copied bundle served
        elsewhere). Wins over the build-time tier. Paste the checkout root
        unencoded, a literal `+` included (it is preserved, NOT decoded to
-       a space; see `query-param-from-search`); `subdir` is appended just
-       like tier 2.
+       a space; see `query-param-from-search`); a Windows root may use
+       `\\` separators (raw or `%5C`-encoded) and is canonicalised to `/`
+       (see `join-root+subdir`); `subdir` is appended just like tier 2.
     2. The build-time `repo-root` goog-define — the default for a normal
        `npm run dev ...` launch; `subdir` is appended.
     3. `nil` — neither root is available. The caller configures no root
        and open-in-editor is a graceful no-op (matching
        `set-project-root!`'s blank-input contract).
 
-  `subdir` is normalised (trim + leading-slash strip) so callers may
-  pass it with or without a leading slash."
+  Both root tiers and `subdir` are normalised to the canonical
+  forward-slash form (`\\` → `/`, trim, trailing/leading-slash strip) so
+  callers may pass either separator style with or without a leading
+  slash, and the result carries exactly one separator at every boundary."
   [subdir]
   (when-let [root (non-blank (or (query-param "project-root") repo-root))]
     (join-root+subdir root subdir)))

--- a/tools/testbed-support/src/re_frame/testbed/config_cljs_test.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/config_cljs_test.cljs
@@ -68,6 +68,7 @@
   The node degradation (no window → adapter returns nil → repo-root tier)
   is still asserted in `resolve-project-root-nil-when-root-blank` below."
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
             [re-frame.testbed.config :as config]))
 
 ;; ---- private helper: non-blank -----------------------------------------
@@ -109,6 +110,29 @@
             the inner slash (documents the single-strip contract;
             normal callers never pass `//`)"
     (is (= "/repo/" (#'config/strip-trailing-slash "/repo//")))))
+
+;; ---- private helper: to-forward-slashes --------------------------------
+;;
+;; The canonicalisation step (rf2-d01s6s): a Windows path with `\`
+;; separators reduces to the same `/`-separated form a POSIX path already
+;; has, matching the launcher's build-env normalisation and the
+;; separator-agnostic editor-URI composer.
+
+(deftest to-forward-slashes-canonicalises-backslashes
+  (testing "every backslash becomes a forward slash; a path that is
+            already forward-slashed is unchanged; a literal + survives"
+    (is (= "C:/Users/me/code/re-frame2"
+           (#'config/to-forward-slashes "C:\\Users\\me\\code\\re-frame2"))
+        "a raw Windows checkout root canonicalises to forward slashes")
+    (is (= "C:/Users/me/code/re-frame2/"
+           (#'config/to-forward-slashes "C:\\Users\\me\\code\\re-frame2\\"))
+        "a trailing backslash canonicalises too (left for strip-trailing-slash)")
+    (is (= "/home/dev/re-frame2"
+           (#'config/to-forward-slashes "/home/dev/re-frame2"))
+        "an already-forward-slashed POSIX root is unchanged")
+    (is (= "C:/code/app+1"
+           (#'config/to-forward-slashes "C:\\code\\app+1"))
+        "a literal + is preserved through canonicalisation")))
 
 ;; ---- resolve-project-root: blank-root tier (default goog-define) -------
 
@@ -395,6 +419,115 @@
           "override and build-time tier compose to the identical on-disk path")
       (is (= "/home/dev/re-frame2+wip/tools/xray/testbeds/standard_epochs/core.cljs"
              via-override)))))
+
+;; ---- Windows override normalisation (rf2-d01s6s) -----------------------
+;;
+;; A Windows reader pasting `?project-root=C:\Users\me\code\re-frame2\`
+;; (raw `\` separators, with or without a trailing `\`) — or its
+;; %5C-encoded transport form — must resolve to a CLEAN, single-separator,
+;; forward-slash path, NOT the `C:\...\/tools/xray/testbeds` boundary
+;; duplication that relied on downstream tolerant path normalisation. Both
+;; root tiers go through the SAME canonicalising join, so this holds for
+;; the build-time `repo-root` tier as well as the query override.
+
+(deftest query-param-from-search-decodes-encoded-backslash
+  (testing "a %5C-encoded backslash in the override transport form decodes
+            to a literal `\\` (the join then canonicalises it to `/`)"
+    (is (= "C:\\Users\\me\\code\\re-frame2"
+           (#'config/query-param-from-search
+            "?project-root=C%3A%5CUsers%5Cme%5Ccode%5Cre-frame2" "project-root"))
+        "%5C → \\, %3A → : — the raw Windows root is reconstituted")))
+
+(deftest resolve-project-root-normalises-raw-windows-override
+  (testing "a raw Windows `?project-root=` value (with `\\` separators)
+            resolves to a clean forward-slash path with exactly one
+            separator at the root/subdir boundary — no `\\/` duplication"
+    (with-redefs [config/query-param (fn [param]
+                                       (when (= param "project-root")
+                                         "C:\\Users\\me\\code\\re-frame2"))
+                  config/repo-root ""]
+      (is (= "C:/Users/me/code/re-frame2/tools/xray/testbeds"
+             (config/resolve-project-root "tools/xray/testbeds"))
+          "backslashes canonicalised, subdir appended with one /"))))
+
+(deftest resolve-project-root-normalises-windows-override-trailing-backslash
+  (testing "a trailing `\\` on a raw Windows override never doubles the
+            separator (the exact `C:\\...\\/tools/...` symptom in the bead)"
+    (with-redefs [config/query-param (fn [param]
+                                       (when (= param "project-root")
+                                         "C:\\Users\\me\\code\\re-frame2\\"))
+                  config/repo-root ""]
+      (let [resolved (config/resolve-project-root "tools/xray/testbeds")]
+        (is (= "C:/Users/me/code/re-frame2/tools/xray/testbeds" resolved)
+            "trailing backslash canonicalised then stripped — single separator")
+        (is (not (str/includes? resolved "\\/"))
+            "no \\/ boundary duplication")
+        (is (not (str/includes? resolved "\\"))
+            "no backslash survives into the resolved path")
+        (is (not (str/includes? resolved "//"))
+            "no // boundary duplication")))))
+
+(deftest resolve-project-root-normalises-encoded-windows-override
+  (testing "the %5C-encoded transport form of a Windows override (with a
+            trailing %5C) resolves to the SAME clean forward-slash path as
+            the raw form — the override exists to survive URL transport"
+    (with-redefs [config/query-param
+                  (fn [param]
+                    (when (= param "project-root")
+                      ;; mirrors the decode-component output for
+                      ;; ?project-root=C%3A%5CUsers%5Cme%5Ccode%5Cre-frame2%5C
+                      (#'config/query-param-from-search
+                       "?project-root=C%3A%5CUsers%5Cme%5Ccode%5Cre-frame2%5C"
+                       "project-root")))
+                  config/repo-root ""]
+      (is (= "C:/Users/me/code/re-frame2/tools/xray/testbeds"
+             (config/resolve-project-root "tools/xray/testbeds"))
+          "encoded Windows root + trailing %5C → clean single-separator path"))))
+
+(deftest resolve-project-root-normalises-windows-build-time-tier
+  (testing "the build-time repo-root tier is normalised the same way —
+            a `\\`-separated define (e.g. an unnormalised launcher value)
+            still resolves to a clean forward-slash path"
+    (with-redefs [config/query-param (constantly nil)
+                  config/repo-root "C:\\Users\\me\\code\\re-frame2"]
+      (is (= "C:/Users/me/code/re-frame2/tools/story/testbeds"
+             (config/resolve-project-root "tools/story/testbeds"))))))
+
+(deftest windows-override-composes-to-intended-on-disk-file
+  (testing "rf2-d01s6s + rf2-w4yw9q: a Windows `?project-root=` override
+            composes with a representative classpath-relative source coord
+            to the intended on-disk file with the tool-source-root segment
+            present and exactly one separator everywhere — proving no
+            missing `tools/<tool>/testbeds` segment and no `\\/` / `//`
+            duplication in the path Xray/Story actually prefix"
+    (with-redefs [config/query-param (fn [param]
+                                       (when (= param "project-root")
+                                         "C:\\Users\\me\\code\\re-frame2\\"))
+                  config/repo-root ""]
+      (let [root (config/resolve-project-root "tools/xray/testbeds")
+            composed (composed-editor-path root "standard_epochs/core.cljs")]
+        (is (= "C:/Users/me/code/re-frame2/tools/xray/testbeds" root))
+        (is (= "C:/Users/me/code/re-frame2/tools/xray/testbeds/standard_epochs/core.cljs"
+               composed)
+            "the composed editor path reaches the actual on-disk source file")
+        (is (str/includes? composed "/tools/xray/testbeds/")
+            "the tool source-root segment is present (not missing)")
+        (is (not (str/includes? composed "\\"))
+            "no backslash survives")
+        (is (not (str/includes? composed "//"))
+            "no // boundary duplication")))))
+
+(deftest windows-override-preserves-literal-plus-in-checkout
+  (testing "a Windows checkout with a `+` in the path (e.g.
+            `C:\\code\\re-frame2+wip`) round-trips: `\\` → `/` but the
+            literal `+` is preserved (the existing rf2-xdsat.1 semantics)"
+    (with-redefs [config/query-param (fn [param]
+                                       (when (= param "project-root")
+                                         "C:\\code\\re-frame2+wip"))
+                  config/repo-root ""]
+      (is (= "C:/code/re-frame2+wip/tools/xray/testbeds"
+             (config/resolve-project-root "tools/xray/testbeds"))
+          "+ survives canonicalisation; \\ → /"))))
 
 ;; ---- public-surface stability sentinel ---------------------------------
 


### PR DESCRIPTION
Fixes rf2-d01s6s. The `?project-root=` Windows override was not normalized at the testbed-support join boundary: `strip-trailing-slash` / `join-root+subdir` only handled forward slashes, so a Windows root like `C:\Users\me\code\re-frame2\` produced `C:\...\/tools/xray/testbeds` and relied on downstream tolerant path normalization.

**Fix.** A new `to-forward-slashes` canonicalises every `\` to `/` on both the root and the subdir before the existing trailing/leading-slash strip, so both root tiers (query override + build-time `repo-root`) and the subdir resolve to a clean single-separator forward-slash path on Windows and POSIX alike. This matches the launcher's build-env normalization (`dev-testbed.cjs`) and the separator-agnostic editor-URI composer (`source_coords/editor_uri.cljc`). Literal-`+` preservation (rf2-xdsat.1) is unchanged.

**Tests.** Added `config_cljs_test` coverage for raw and `%5C`-encoded Windows override roots (with/without trailing backslash), the build-time tier, the `+`-in-checkout case, and the composed Xray source-coord path — asserting no `\/` or `//` boundary duplication and no missing `tools/<tool>/testbeds` segment. Existing literal-`+` semantics kept intact.

**Docs (issue 2).** Root README, `tools/README.md`, the `shadow-cljs.edn` source-path comment, and the slice README layout/test sections now describe both public namespaces (`config` + `story-host`) and both CLJS test namespaces, naming the actual gate.

## Quality gates
- `npm run test:cljs` (the canonical gate; `:node-test` `cljs-test$` regexp discovers this slice's `src/`): **6089 tests, 21636 assertions, 0 failures, 0 errors**. Verified the new tests actually execute via a temporary sentinel-fail (surfaced from `to-forward-slashes-canonicalises-backslashes`, then reverted).
- `python scripts/check_doc_slugs.py`: exit 0.
- `shadow-cljs compile node-test`: 0 warnings (confirms the `shadow-cljs.edn` comment edit parses).
