### PR TITLE
docs(examples/reagent-slim): README staging step + bundle-isolation control drift (rf2-1vusoi rf2-w1lo2w)

### DIFF
--- a/examples/reagent-slim/README.md
+++ b/examples/reagent-slim/README.md
@@ -16,12 +16,13 @@ The example sits in its own folder with the CLJS source (`core.cljs`) and a hand
 ## What the example demonstrates
 
 - **`reagent-slim/counter_slim_and_fast/`** ([build id `examples/counter-slim-and-fast`](../../implementation/shadow-cljs.edn))
-  The same `:counter/*` events and subs as the canonical Reagent counter, mounted on the slim substrate. (Sharing the `:counter/*` event+sub ids with the stock fixture is a **deliberate, documented exception** to the example id-prefix convention — it demonstrates adapter parity; see [`examples/TESTING.md` § Exception 1 — the stock/slim counter `:counter/*` id share](../TESTING.md#exception-1--the-stockslim-counter-counter-id-share). The views are *not* shared: `reg-view` auto-namespaces them under `:counter-slim-and-fast.core/*` vs the stock `:counter.core/*`.) Its `run` fn deliberately exercises `reagent2.dom.server/render-to-static-markup` at boot so the pure-CLJS SSR contract is non-vacuous. The paired verifier asserts two bundle-isolation invariants on the `:advanced` bundle:
+  The same `:counter/*` events and subs as the canonical Reagent counter, mounted on the slim substrate. (Sharing the `:counter/*` event+sub ids with the stock fixture is a **deliberate, documented exception** to the example id-prefix convention — it demonstrates adapter parity; see [`examples/TESTING.md` § Exception 1 — the stock/slim counter `:counter/*` id share](../TESTING.md#exception-1--the-stockslim-counter-counter-id-share). The views are *not* shared: `reg-view` auto-namespaces them under `:counter-slim-and-fast.core/*` vs the stock `:counter.core/*`.) Its `run` fn deliberately exercises `reagent2.dom.server/render-to-static-markup` at boot so the pure-CLJS SSR contract is non-vacuous. The paired verifier asserts these bundle-isolation contracts on the `:advanced` bundle:
 
-  1. **Stock-Reagent impl isolation** — no `reagent.impl.*` symbols (the slim rewrite has its own `reagent2.impl.*` substrate; the bridge's impl tree must be entirely absent).
-  2. **Pure-CLJS SSR** — no `react-dom/server` symbols, even though the example runs `reagent2.dom.server/render-to-static-markup` at boot (per IMPL-SPEC §8 + S3-005).
+  1. **Stock-Reagent impl isolation** (Contract 2, S3-008) — no `reagent.impl.*` symbols in the slim bundle (the slim rewrite has its own `reagent2.impl.*` substrate; the bridge's impl tree must be entirely absent).
+  2. **Pure-CLJS SSR** (Contract 3, S3-005) — no `react-dom/server` symbols in the slim bundle, even though the example runs `reagent2.dom.server/render-to-static-markup` at boot (per IMPL-SPEC §8 + S3-005).
+  3. **SSR-absence non-vacuity** (Contract 4, S3-005) — the slim bundle *positively* contains the SSR boot/serializer presence sentinels (the `counterSlimPrerender` host-global the boot writes plus a `reagent2.dom.server` serializer-owned literal), so the (2) absence is not a vacuous proof against an SSR-free bundle.
 
-  The stock-Reagent `examples/counter` bundle is required to still contain both symbol groups as a methodology control.
+  The methodology control (Contract 1) is the stock-Reagent `examples/counter` bundle: it must still contain the **stock-Reagent impl sentinels only** — that proves the (1) grep has signal. The `react-dom/server` proof is not controlled by the stock bundle but by the positive slim-side presence check in (3).
 
 ## Testing
 

--- a/examples/reagent-slim/counter_slim_and_fast/README.md
+++ b/examples/reagent-slim/counter_slim_and_fast/README.md
@@ -18,22 +18,34 @@ The S3-008 + S3-005 contract from
 §1.4 + §1.8 + §8 — a binding adapter-owned bundle-isolation claim
 about the slim substrate:
 
-1. **Stock-Reagent impl isolation.** The advanced-compiled bundle for
-   this example contains NO `reagent.impl.*` symbols. The slim
-   rewrite has its own `reagent2.impl.*` substrate; the bridge's
-   `reagent.impl.*` internals must be entirely absent.
-2. **Pure-CLJS SSR.** The bundle contains NO `react-dom/server`
-   symbols, even though `run` exercises
+1. **Stock-Reagent impl isolation (Contract 2, S3-008).** The
+   advanced-compiled bundle for this example contains NO
+   `reagent.impl.*` symbols. The slim rewrite has its own
+   `reagent2.impl.*` substrate; the bridge's `reagent.impl.*`
+   internals must be entirely absent.
+2. **Pure-CLJS SSR (Contract 3, S3-005).** The bundle contains NO
+   `react-dom/server` symbols, even though `run` exercises
    `reagent2.dom.server/render-to-static-markup` at boot. The slim's
    SSR seam is pure-CLJS (per IMPL-SPEC §8.7), so the bundle has no
    compiled-in path to `react-dom/server`.
-3. **Methodology control.** The stock-Reagent counter bundle
-   (`examples/counter`) MUST still contain both groups of symbols —
-   that proves the grep has signal. If a future stock-Reagent upgrade
-   DCEs them out of the stock bundle too, the test fails loudly and
-   the sentinel set gets re-derived.
+3. **SSR-absence non-vacuity (Contract 4, S3-005).** The
+   `react-dom/server` absence in (2) is non-vacuous because the slim
+   bundle *positively* contains the slim SSR boot/serializer presence
+   sentinels — the `counterSlimPrerender` host-global the boot writes
+   and a `reagent2.dom.server` serializer-owned literal. Without those,
+   removing the SSR exercise would leave (2) passing against a bundle
+   that no longer does SSR at all.
 
-The grep that enforces all three invariants lives at
+The methodology control is the stock-Reagent counter bundle
+(`examples/counter`): **Contract 1** requires it to still contain the
+stock-Reagent impl sentinels, which proves the (2) grep has signal. It
+is a control for the **stock-Reagent implementation fingerprints only**
+— the `react-dom/server` proof is not controlled here but by the
+positive slim-side presence check in (3). If a future stock-Reagent
+upgrade DCEs the impl sentinels out of the stock bundle too, the test
+fails loudly and the sentinel set gets re-derived.
+
+The grep that enforces all four contracts lives at
 [`implementation/scripts/check-reagent-slim-bundle-isolation.cjs`](../../../implementation/scripts/check-reagent-slim-bundle-isolation.cjs);
 the changed-surface CI job is `cljs-reagent-slim-bundle-isolation` in
 `.github/workflows/test.yml`.
@@ -88,6 +100,17 @@ To iterate against the source, watch the build directly from
 ```bash
 shadow-cljs watch examples/counter-slim-and-fast
 ```
+
+The watch build emits `main.js` into
+`out/examples/counter-slim-and-fast/` (the build's `:output-dir` in
+`implementation/shadow-cljs.edn`). To load it in a browser, copy this
+folder's hand-written [`index.html`](index.html) alongside that
+`main.js`, stage the [`examples/_shared/`](../../_shared/) tree next to
+it so the page's `_shared/...` references resolve, then serve
+`out/examples/counter-slim-and-fast/` over HTTP.
+(`npm run test:examples` does not build this standalone example — it
+compiles and serves only the three adapter testbeds; see
+[`examples/README.md`](../../README.md).)
 
 The Reagent Slim bundle-isolation contract is exercised separately
 when slim-related paths change, and in the nightly/manual expensive

--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -10,21 +10,30 @@
 
    What this fixture proves (the Reagent Slim bundle-isolation contract):
 
-     - Stock-Reagent impl isolation (S3-008): the advanced-compiled
-       bundle for this example contains NO `reagent.impl.*` symbols.
-       The slim rewrite has its own `reagent2.impl.*` substrate; the
-       bridge's `reagent.impl.*` internals must be entirely absent.
-     - Pure-CLJS SSR (S3-005): the bundle contains NO `react-dom/server`
-       symbols. The slim's
+     - Stock-Reagent impl isolation (Contract 2, S3-008): the
+       advanced-compiled bundle for this example contains NO
+       `reagent.impl.*` symbols. The slim rewrite has its own
+       `reagent2.impl.*` substrate; the bridge's `reagent.impl.*`
+       internals must be entirely absent.
+     - Pure-CLJS SSR (Contract 3, S3-005): the slim bundle contains NO
+       `react-dom/server` symbols. The slim's
        `reagent2.dom.server/render-to-static-markup` is pure-CLJS
        (per IMPL-SPEC §8.7), so the bundle has no compiled-in path
        to `react-dom/server`.
-     - The stock-Reagent counter bundle (`examples/counter`) keeps
-       both groups of symbols, demonstrating that the assertion logic
-       actually detects them.
+     - SSR-absence non-vacuity (Contract 4, S3-005): the slim bundle
+       POSITIVELY contains the SSR boot/serializer presence sentinels
+       (the `counterSlimPrerender` host-global the boot writes plus a
+       `reagent2.dom.server` serializer-owned literal), so the
+       react-dom/server absence above is not a vacuous proof against an
+       SSR-free bundle.
+     - The methodology control (Contract 1) is the stock-Reagent
+       counter bundle (`examples/counter`): it keeps the stock-Reagent
+       impl sentinels ONLY, demonstrating that the impl-isolation grep
+       detects them. It is NOT a control for react-dom/server — that
+       proof is bound by the positive slim-side presence check above.
 
    See `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` for the
-   bundle-isolation grep that enforces both invariants in CI.
+   bundle-isolation grep that enforces all four contracts in CI.
 
    NOTE on frames: this fixture stays on the default frame
    deliberately. Keeping it single-frame focuses the bundle-isolation


### PR DESCRIPTION
Two P3 examples/reagent-slim doc fixes on one example surface.

rf2-1vusoi: the leaf counter_slim_and_fast README How-to-run section stopped at shadow-cljs watch, omitting the staging/serve step. Added the missing flow (main.js lands in out/examples/counter-slim-and-fast/, copy index.html beside it, stage examples/_shared/, serve over HTTP), matching examples/README.md and the stock counter/parent guidance, and noting test:examples does not build this standalone example.

rf2-w1lo2w: the parent README, leaf README, and core.cljs ns docstring claimed the stock examples/counter bundle must contain BOTH symbol groups as the methodology control. Reconciled to the actual verifier (implementation/scripts/check-reagent-slim-bundle-isolation.cjs Contract 1-4): the stock counter is a methodology control for the stock-Reagent impl sentinels ONLY (Contract 1); react-dom/server absence (Contract 3) is made non-vacuous by the positive slim-side SSR presence check (Contract 4, counterSlimPrerender + a reagent2.dom.server serializer literal), not by react-dom/server presence in the stock bundle. Adopted the script's Contract 1-4 vocabulary across all three docs.

Stays within examples/reagent-slim (docs only). Examples are test-free.

## Quality gates
- python scripts/check_doc_slugs.py — exit 0
- Verified runnable flow against examples/reagent-slim/counter_slim_and_fast/index.html (references _shared/ + main.js) and the build's :output-dir in implementation/shadow-cljs.edn
- Verified bundle-isolation control reality against implementation/scripts/check-reagent-slim-bundle-isolation.cjs Contract 1-4 + sentinel definitions
- Scanned for residual stale both-groups wording: none remain