### PR TITLE
docs(machines): correct stale pre-EP-0001 app-db prose to runtime-db partition (rf2-5mfpza)

### DIFF
--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -19,7 +19,7 @@
     - Declarative :spawn that desugars into [:rf.machine/spawn args]
       on entry and [:rf.machine/destroy actor-id] on exit; deterministic
       actor ids via the in-snapshot :rf/spawn-counter (declarative) / the
-      frame's app-db [:rf.runtime/machines :spawn-counter <machine-id>]
+      frame's runtime-db [:rf.runtime/machines :spawn-counter <machine-id>]
       slot (hand-emitted) — no process-global state (rf2-gr8q / rf2-owvvr;
       the body comment below + spawn.cljc both note the global atom is gone).
     - Declarative :spawn-all — spawn-and-join sugar over N parallel
@@ -28,7 +28,7 @@
     - The :rf.machine/dispatch-to-system reserved fx-id — a machine
       action sends a message to its spawned child actor by :system-id
       (the fx counterpart to the dispatch-to-system FN).
-    - Snapshot at [:rf.runtime/machines :snapshots <id>] in app-db.
+    - Snapshot at [:rf.runtime/machines :snapshots <id>] in runtime-db.
     - Pure machine-transition fn (JVM- and CLJS-runnable, deterministic).
 
   Public surface re-exported from the sub-namespaces:
@@ -196,7 +196,7 @@
 
   Spawn-id allocation lives inside the parent snapshot's
   `:rf/spawn-counter` slot (declarative `:spawn`) or the frame's
-  app-db at `[:rf.runtime/machines :spawn-counter <machine-id>]`
+  runtime-db at `[:rf.runtime/machines :spawn-counter <machine-id>]`
   (hand-emitted spawn); both reset automatically with the registrar
   snapshot/restore + frame reset, so this hook only handles the
   frame-scoped wall-clock timer table. The 0-arity / 1-arity split

--- a/implementation/machines/src/re_frame/machines/data_validation.cljc
+++ b/implementation/machines/src/re_frame/machines/data_validation.cljc
@@ -22,7 +22,7 @@
 
   The spawn-time validator (`validate-spawn-data!`) is the sibling
   call site for `spawn-fx`'s pre-install check — a spawned actor's
-  initial `:data` is validated before the snapshot lands in app-db so
+  initial `:data` is validated before the snapshot lands in runtime-db so
   a failing spawn never installs.
 
   Both validators route through the schemas artefact's late-bind
@@ -109,7 +109,7 @@
 
   Per the bead's recovery posture:
     - `:phase :macrostep` and `:phase :bootstrap` → rollback? true
-      (the snapshot is already in app-db at validation time; the
+      (the snapshot is already in runtime-db at validation time; the
       router will restore the pre-handler db on a false return).
     - `:phase :spawn` → rollback? false (the snapshot has not yet
       installed; the spawn-fx caller skips the install on false)."
@@ -168,7 +168,7 @@
 (defn validate-spawn-data!
   "Sibling of `validate-machine-data!` for the `:rf.machine/spawn` install
   path. Validates a freshly-built initial snapshot's `:data` against the
-  spawned actor's machine `:data-schema` BEFORE the snapshot lands in app-db.
+  spawned actor's machine `:data-schema` BEFORE the snapshot lands in runtime-db.
   Returns true on conform / no schema / no validator; false on failure
   (caller skips the install).
 

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -6,7 +6,7 @@
   the fx vector whenever exit cascades cross a `:spawn`-bearing state.
   Per Spec 005 §Spawning, destroy unregisters the spawned actor's event
   handler, clears its snapshot at `[:rf.runtime/machines :snapshots <id>]` in the spawning
-  frame's app-db, and (if the actor was system-id-bound) clears the
+  frame's runtime-db, and (if the actor was system-id-bound) clears the
   `[:rf.runtime/machines :system-ids]` reverse index entry.
 
   Per rf2-t07u (Option A revised), `args` can be either:
@@ -15,7 +15,7 @@
     - a map `{:rf/parent-id ... :rf/spawn-id ...}` — the declarative-
       `:spawn` exit-cascade form, where the runtime resolves the actor
       id from `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` in the frame's
-      app-db.
+      runtime-db.
 
   Per rf2-6vmw, the map form may also carry `:rf/spawn-all true` —
   the declarative-`:spawn-all` exit-cascade form. The slot at
@@ -23,7 +23,7 @@
   `:children` sub-map has every spawned child id. The handler iterates
   `:children` and tears each one down, then clears the slot.
 
-  The actor-teardown app-db dance lives in
+  The actor-teardown runtime-db dance lives in
   `re-frame.machines.lifecycle-fx.teardown` — one helper, three
   call-sites."
   (:require [re-frame.frame :as frame]

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/exit_cascade.cljc
@@ -19,13 +19,13 @@
   `re-frame.machines.parallel/run-active-exit-cascade` (which dispatches
   flat/compound to `re-frame.machines.transition`, and parallel to the
   per-region reduce). This file is the side-effect wrapper that:
-    1. resolves the actor's snapshot from the frame's app-db,
+    1. resolves the actor's snapshot from the frame's runtime-db,
     2. resolves the actor's machine spec — a spawned actor's TYPE rides
        its snapshot under `:rf/machine-type` (per rf2-a2sn1, spawned
        actors carry no per-instance registrar entry); a singleton's spec
        comes from its registered handler,
     3. runs the pure cascade,
-    4. writes the post-cascade snapshot back to app-db so any caller
+    4. writes the post-cascade snapshot back to runtime-db so any caller
        reading the snapshot AFTER `:exit` (e.g. `finalize-machine`'s
        `:on-done` projection — though that read happens before this
        runs, the write here is for tools observing the snapshot
@@ -72,7 +72,7 @@
   snapshot at `[:rf.runtime/machines :snapshots actor-id]` or no resolvable machine spec.
 
   On a successful cascade: writes the post-cascade snapshot back to
-  app-db (so callers reading the snapshot between `:exit` and the
+  runtime-db (so callers reading the snapshot between `:exit` and the
   teardown projection see `:exit`-time `:data` writes) and fires the
   emitted fx vector via `re-frame.fx/do-fx`. On a thrown action,
   surfaces a `:rf.error/machine-action-exception` trace (matching the

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -825,7 +825,7 @@
   WITHOUT registering it — the surface the lazy-actor-handler resolver
   (rf2-a2sn1) drives a spawned actor's cascade through. Equivalent in
   shape to what `reg-machine*` installs under the machine-id, but
-  materialised on demand from the actor's (revertible) app-db snapshot
+  materialised on demand from the actor's (revertible) runtime-db snapshot
   rather than held in a per-instance registrar entry.
 
   The region-machine cache is installed (mirroring `reg-machine*`) so
@@ -853,8 +853,8 @@
   map the router can drive the cascade with — or nil to let core surface
   the genuine `:rf.error/no-such-handler`.
 
-  Resolution is purely app-db-derived (rf2-a2sn1): read the actor's live
-  snapshot from the frame's app-db, resolve its TYPE spec via
+  Resolution is purely runtime-db-derived (rf2-a2sn1): read the actor's live
+  snapshot from the frame's runtime-db, resolve its TYPE spec via
   `resolver/spec-from-snapshot`, and materialise the handler-meta from
   the spec. No live snapshot (or no resolvable type) → nil: the actor
   isn't alive in this frame value, which is the correct

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/resolver.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/resolver.cljc
@@ -1,11 +1,11 @@
 (ns re-frame.machines.lifecycle-fx.resolver
-  "Spawned-actor SPEC resolution from app-db (rf2-a2sn1) — the leaf helper
+  "Spawned-actor SPEC resolution from runtime-db (rf2-a2sn1) — the leaf helper
   beneath the lazy actor-handler resolver.
 
-  Per Spec 005 §Spawning §Liveness is derived from app-db: a spawned
+  Per Spec 005 §Spawning §Liveness is derived from runtime-db: a spawned
   actor has NO per-instance event-handler registration. Spawn is a pure
-  app-db write (install the snapshot + the spawn-registry slot); destroy
-  is a pure app-db remove. An actor's liveness IS exactly the presence
+  runtime-db write (install the snapshot + the spawn-registry slot); destroy
+  is a pure runtime-db remove. An actor's liveness IS exactly the presence
   of its snapshot at `[:rf.runtime/machines :snapshots <actor-id>]` in
   the frame's value — so `restore-epoch` (which reverts app-db only)
   reverts liveness perfectly, with ZERO registrar drift. This closes the

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -240,7 +240,7 @@
   (let [;; Per rf2-gr8q: prefer the pre-allocated id (declarative :spawn
         ;; routes through the transition reducer which bumps the parent
         ;; snapshot's `:rf/spawn-counter`). Hand-emitted spawn fxs carry
-        ;; no pre-allocated id; the frame's app-db spawn-counter slot
+        ;; no pre-allocated id; the frame's runtime-db spawn-counter slot
         ;; at `[:rf.runtime/machines :spawn-counter]` (rf2-owvvr) serves
         ;; as the fallback allocator, bumped inside the same db-swap as
         ;; the snapshot install / registry bind below.

--- a/implementation/machines/src/re_frame/machines/spawn_order.cljc
+++ b/implementation/machines/src/re_frame/machines/spawn_order.cljc
@@ -5,7 +5,7 @@
   actors leaf-to-root in **reverse-creation order** — the most recently
   spawned instance disposes first.
 
-  `[:rf.runtime/machines :snapshots]` snapshots live in app-db keyed by actor-id; the map
+  `[:rf.runtime/machines :snapshots]` snapshots live in runtime-db keyed by actor-id; the map
   iteration order is not insertion order, so an explicit order channel
   is required to satisfy the spec's reverse-creation invariant.
 

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -1863,7 +1863,7 @@
   (Option A revised): nodes being EXITED with `:spawn` emit
   `:rf.machine/destroy` carrying `{:rf/parent-id ... :rf/spawn-id ...}`
   so the destroy-machine fx handler resolves the live actor id from the
-  runtime-owned `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` slot in app-db.
+  runtime-owned `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` slot in runtime-db.
 
   Per Spec 005 §Spawn-and-join via `:spawn-all` (rf2-6vmw): on exit, tear
   down EVERY child the parent spawned plus the join-state slot. The
@@ -2006,7 +2006,7 @@
    1. Allocate one spawned-id per child up-front (thread the snapshot's
       counter through children in declaration order).
    2. Build the join-state seed map and the `:rf.machine/spawn-all-init`
-      fx that seeds `[:rf.runtime/machines :spawned <parent> <invoke-id>]` in app-db.
+      fx that seeds `[:rf.runtime/machines :spawned <parent> <invoke-id>]` in runtime-db.
    3. For each child, delegate to `spawn-one` to materialise `:data` and
       build its `:rf.machine/spawn` fx (short-circuits on the first
       child's `:data` failure).


### PR DESCRIPTION
Prose-only fix for rf2-5mfpza. Post-EP-0001 (rf2-vzld77 / rf2-owvvr) all machine runtime state under the `[:rf.runtime/machines ...]` paths (:snapshots, :spawn-counter, :spawned, :system-ids) moved from the retired app-db `:rf/runtime` root to the `:rf.db/runtime` (runtime-db) partition. The code was already correct; numerous docstrings/comments still labelled these runtime-db slots as 'app-db'. This relabels them. No code logic change. Parked tests untouched (the 3 reader-elided tests live in the SSR slice under rf2-4eisfr, not the machines slice).

Out of scope (deliberately left for a follow-up): the 'restore-epoch reverts app-db only' revert-scope statements (resolver.cljc:10, registration.cljc:878) — whether epoch capture/restore covers the runtime-db partition post-EP-0001 is a semantic/code question, not a prose s/app-db/runtime-db relabel, so untouched here.

## Quality gates
- implementation/machines `clojure -M:test`: 583 tests, 1828 assertions, 0 failures, 0 errors.
- No doc files touched (check_doc_slugs.py N/A).