### PR TITLE
refactor(ep-0002): framework fx & runtime — carried frame, remove :rf/default operation defaults (rf2-nn0jqa)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -308,6 +308,33 @@
          (emit-no-frame-context! payload)
          (throw (ex-info (str (:rf.error/id payload)) payload))))))
 
+(defn require-frame-stamp!
+  "Operation-time companion to `require-current-frame!` (EP-0002, Spec 002
+  §Frame target resolution). Where `require-current-frame!` READS the stamp
+  off the in-effect scope, this asserts the stamp a token was *supposed to
+  carry* is actually present: it returns `frame-id` unchanged when non-nil,
+  else emits + throws the always-on `:rf.error/no-frame-context`.
+
+  This is the framework-fx / runtime-subsystem seam. A framework fx invoked
+  inside a cascade ALWAYS receives the envelope frame as the fx-context
+  `:frame` (the HELD stamp threaded by `re-frame.fx`). A history listener,
+  managed-HTTP reply, timer, or other browser-/async-originated callback
+  ALWAYS captures the owner/initiation frame at install time. If the stamp
+  is nil at the call site, that is an INVARIANT FAILURE — a token reached a
+  frame-scoped operation carrying no frame — NOT a request to repair the
+  call by mutating a synthesised `:rf/default`. Surfacing it loudly (rather
+  than defaulting) keeps replay deterministic per the carried invariant.
+
+  `operation` is the op kind; `extra` (optional) merges call-site detail
+  (`{:where '<fx-id-or-fn> :event-id <id>}`) into the payload exactly as
+  `require-current-frame!` does."
+  ([frame-id operation] (require-frame-stamp! frame-id operation nil))
+  ([frame-id operation extra]
+   (or frame-id
+       (let [payload (no-frame-context-payload operation extra)]
+         (emit-no-frame-context! payload)
+         (throw (ex-info (str (:rf.error/id payload)) payload))))))
+
 ;; ---- lookup ---------------------------------------------------------------
 
 (defn frame

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -431,7 +431,21 @@
          (when (and clear-app-schemas? clear-fn)
            (clear-fn))
          (when init-fn (init-fn))
-         (test-fn)
+         ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+         ;; and the framework operation surfaces (dispatch / subscribe /
+         ;; machine + http + routing fxs) now require a carried frame stamp.
+         ;; When the fixture installed an adapter it ALSO ensured the
+         ;; conventional `:rf/default` app frame (above), so it establishes
+         ;; that frame as the body's ambient scope — the carried-invariant
+         ;; equivalent of wrapping every test in `(with-frame :rf/default …)`.
+         ;; Tests that drive multiple frames / explicit `{:frame …}` overrides
+         ;; still work: an inner `with-frame` re-binds, and an explicit opt
+         ;; wins over the ambient scope. Adapter-less fixtures (the test
+         ;; installs its own frame) get no ambient scope.
+         (if adapter
+           (binding [frame/*current-frame* :rf/default]
+             (test-fn))
+           (test-fn))
          (finally
            (restore-registrar! snap)
            (when restore-fn (restore-fn schemas-snap))

--- a/implementation/http/src/re_frame/http_handlers.cljc
+++ b/implementation/http/src/re_frame/http_handlers.cljc
@@ -22,6 +22,7 @@
                               to the abort-fn → `finalise-failure!`
                               cascade per rf2-plngk."
   (:require [clojure.string]
+            [re-frame.frame          :as frame]
             [re-frame.http-encoding  :as encoding]
             [re-frame.http-middleware :as middleware]
             [re-frame.http-privacy   :as privacy]
@@ -205,7 +206,14 @@
     :as   args-map}
    frame-ctx]
   (let [origin-event (:event frame-ctx)
-        frame        (or (:frame frame-ctx) :rf/default)
+        ;; EP-0002 carried invariant — `:rf.http/managed` runs inside an
+        ;; event cascade, so the fx context ALWAYS carries the envelope
+        ;; frame as `:frame` (the HELD stamp used for reply-to-origin
+        ;; addressing). A nil stamp is an invariant failure
+        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+        frame        (frame/require-frame-stamp!
+                       (:frame frame-ctx) :rf.http/managed
+                       {:where 'rf.http/managed :event-id (first origin-event)})
         ;; rf2-wvkn — when the originating event-id is a spawned actor's
         ;; address, capture it so the in-flight registry can index by
         ;; actor-id alongside :request-id. The destroy cascade then has
@@ -280,7 +288,13 @@
   ;; source rather than wiring two racing abort mechanisms against one
   ;; request. Per Spec 014 §`:abort-signal` (external).
   (validate-abort-config! args-map)
-  (let [frame-id     (or (:frame frame-ctx) :rf/default)
+  (let [;; EP-0002 carried invariant — the fx context carries the cascade
+        ;; envelope frame as `:frame`; a nil stamp is an invariant failure
+        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+        frame-id     (frame/require-frame-stamp!
+                       (:frame frame-ctx) :rf.http/managed
+                       {:where 'rf.http/managed
+                        :event-id (first (:event frame-ctx))})
         ;; rf2-622e3 — resolve once, thread the result through
         ;; frame-ctx's :event slot so normalise-args reads it
         ;; directly instead of re-running the OR-chain.

--- a/implementation/http/src/re_frame/http_machine_wrapper.cljc
+++ b/implementation/http/src/re_frame/http_machine_wrapper.cljc
@@ -48,7 +48,8 @@
   which composes against these handlers directly — also lives in
   `re-frame.http-test-support` (per rf2-lwmgw — single discoverable
   home for HTTP test surfaces)."
-  (:require [re-frame.http-encoding   :as encoding]
+  (:require [re-frame.frame           :as frame]
+            [re-frame.http-encoding   :as encoding]
             [re-frame.http-middleware :as middleware]
             [re-frame.late-bind       :as late-bind]))
 
@@ -92,7 +93,13 @@
   chain walk, which the lower-level canned handlers also call with a bare
   `:value` and no `:request`."
   [frame-ctx args-map]
-  (let [frame-id     (or (:frame frame-ctx) :rf/default)
+  (let [;; EP-0002 carried invariant — the canned stub runs inside a
+        ;; cascade, so the fx context carries the envelope frame as
+        ;; `:frame`; a nil stamp is an invariant failure
+        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+        frame-id     (frame/require-frame-stamp!
+                       (:frame frame-ctx) :rf.http/managed-canned
+                       {:where 'rf.http/run-request-chain})
         origin-event (encoding/resolve-origin-event frame-ctx args-map)
         ctx0         {:request (:request args-map)
                       :args    args-map
@@ -151,7 +158,12 @@
   chain via `dispatch-canned-reply!`. Does NOT run the `:before` chain —
   the caller already did."
   [frame-ctx args-map middleware-ctx]
-  (let [frame-id (or (:frame frame-ctx) :rf/default)
+  (let [;; EP-0002 carried invariant — fx-context `:frame` is the cascade
+        ;; envelope stamp; a nil stamp is an invariant failure, never a
+        ;; synthesised `:rf/default`.
+        frame-id (frame/require-frame-stamp!
+                   (:frame frame-ctx) :rf.http/managed-canned-success
+                   {:where 'rf.http/emit-canned-success!})
         value    (get args-map :value {:stubbed true})]
     (dispatch-canned-reply!
       {:origin-event   (encoding/resolve-origin-event frame-ctx args-map)
@@ -167,7 +179,12 @@
   "Synthesise a failure reply from a PRE-COMPUTED post-`:before`
   `middleware-ctx` (rf2-azrcs). Symmetric with `emit-canned-success!`."
   [frame-ctx args-map middleware-ctx]
-  (let [frame-id (or (:frame frame-ctx) :rf/default)
+  (let [;; EP-0002 carried invariant — fx-context `:frame` is the cascade
+        ;; envelope stamp; a nil stamp is an invariant failure, never a
+        ;; synthesised `:rf/default`.
+        frame-id (frame/require-frame-stamp!
+                   (:frame frame-ctx) :rf.http/managed-canned-failure
+                   {:where 'rf.http/emit-canned-failure!})
         kind     (or (:kind args-map) :rf.http/transport)
         tags     (or (:tags args-map) {})
         failure  (assoc tags :kind kind)]

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -202,22 +202,37 @@
                   optional `:frame` (id), plus any
                   `:rf/registration-metadata` slots. The fx body splits
                   `:id` off and passes the remaining map straight through
-                  to the fn-form (per rf2-uheqq shape iii)."}
-           (fn [_ctx {:keys [id] :as args}]
-             (middleware/reg-http-interceptor id (dissoc args :id))))
+                  to the fn-form (per rf2-uheqq shape iii).
+
+                  EP-0002 — the carried frame is the fx-context `:frame`
+                  (the cascade envelope stamp); the args `:frame` is the
+                  per-call *override*. The body threads the fx-context
+                  frame in when the args omit one, so the fn-form receives
+                  an explicit frame and never falls through to a
+                  synthesised `:rf/default` (a frameless cascade would have
+                  failed at dispatch already)."}
+           (fn [{ctx-frame :frame} {:keys [id] :as args}]
+             (middleware/reg-http-interceptor
+               id (-> (dissoc args :id)
+                      (update :frame #(or % ctx-frame))))))
 
 (fx/reg-fx :rf.fx/clear-http-interceptor
            {:doc "Spec 014 §Middleware (rf2-6y3q) — clear a request-side
                   interceptor by id as an fx. Args is the map
                   `{:frame <id> :id <kw>}` (NOT positional, matching the
                   fx-convention shape — sibling to `:rf.fx/reg-http-interceptor`
-                  which also takes a map). `:frame` defaults to `:rf/default`
-                  when absent or nil. The fn-form `clear-http-interceptor` is
-                  the positional surface; this fx is the data-shaped surface
+                  which also takes a map). The fn-form `clear-http-interceptor`
+                  is the positional surface; this fx is the data-shaped surface
                   for EDN-driven callers (conformance fixtures, event
-                  handlers at boot — rf2-k7tlm)."}
-           (fn [_ctx {:keys [frame id]}]
-             (middleware/clear-http-interceptor (or frame :rf/default) id)))
+                  handlers at boot — rf2-k7tlm).
+
+                  EP-0002 — the carried frame is the fx-context `:frame`
+                  (the cascade envelope stamp); the args `:frame` is the
+                  per-call *override*. The args frame wins, else the
+                  fx-context frame, threaded explicitly into the fn-form so
+                  it never repairs to a synthesised `:rf/default`."}
+           (fn [{ctx-frame :frame} {:keys [frame id]}]
+             (middleware/clear-http-interceptor (or frame ctx-frame) id)))
 
 ;; The two canned-stub fxs (`:rf.http/managed-canned-success` /
 ;; `:rf.http/managed-canned-failure`) used to register here inside a

--- a/implementation/http/test/re_frame/flows_http_integration_test.clj
+++ b/implementation/http/test/re_frame/flows_http_integration_test.clj
@@ -80,6 +80,10 @@
   (reset! schemas/schemas-by-frame {})
   (flows/reset-last-inputs!)
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
+  ;; the managed-HTTP / flow fxs now require a carried frame stamp. Register
+  ;; `:rf/default` explicitly and pin it as the established scope for the body.
+  (frame/ensure-default-frame!)
   ;; clear-all! wiped the ns-load-time registrations of these artefacts;
   ;; :reload re-evaluates each ns body so its registrations resurrect.
   (require 're-frame.routing :reload)
@@ -88,15 +92,16 @@
   (require 're-frame.http-managed :reload)
   (require 're-frame.http-test-support :reload)
   (http-managed/clear-all-in-flight!)
-  (let [captured (atom [])]
-    (binding [*captured* captured]
-      (trace/register-listener!
-        ::flows-http-recorder
-        (fn [ev] (swap! captured conj ev)))
-      (try
-        (test-fn)
-        (finally
-          (trace/unregister-listener! ::flows-http-recorder))))))
+  (rf/with-frame :rf/default
+    (let [captured (atom [])]
+      (binding [*captured* captured]
+        (trace/register-listener!
+          ::flows-http-recorder
+          (fn [ev] (swap! captured conj ev)))
+        (try
+          (test-fn)
+          (finally
+            (trace/unregister-listener! ::flows-http-recorder)))))))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_abort_config_validation_test.clj
+++ b/implementation/http/test/re_frame/http_abort_config_validation_test.clj
@@ -34,12 +34,19 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
+  ;; the managed-HTTP fxs now require a carried frame stamp. This suite
+  ;; exercises the ambient dispatch path against a single conventional app
+  ;; frame, so register `:rf/default` explicitly and pin it as the
+  ;; established scope for the whole body via `with-frame`.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.http-managed :reload)
   (http-managed/clear-all-in-flight!)
   (http-managed/clear-all-http-interceptors!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_abort_precedence_test.clj
+++ b/implementation/http/test/re_frame/http_abort_precedence_test.clj
@@ -45,13 +45,20 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP / machine / routing fxs now require a carried
+  ;; frame stamp. This suite exercises the ambient dispatch path against
+  ;; a single conventional app frame, so register `:rf/default` explicitly
+  ;; and pin it as the established scope for the whole body via with-frame.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
   (require 're-frame.http-managed :reload)
   (machines/reset-timers!)
   (http-managed/clear-all-in-flight!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
@@ -56,13 +56,20 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP / machine / routing fxs now require a carried
+  ;; frame stamp. This suite exercises the ambient dispatch path against
+  ;; a single conventional app frame, so register `:rf/default` explicitly
+  ;; and pin it as the established scope for the whole body via with-frame.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
   (require 're-frame.http-managed :reload)
   (machines/reset-timers!)
   (http-managed/clear-all-in-flight!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_backoff_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_backoff_cancellation_test.clj
@@ -59,13 +59,20 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP / machine / routing fxs now require a carried
+  ;; frame stamp. This suite exercises the ambient dispatch path against
+  ;; a single conventional app frame, so register `:rf/default` explicitly
+  ;; and pin it as the established scope for the whole body via with-frame.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
   (require 're-frame.http-managed :reload)
   (machines/reset-timers!)
   (http-managed/clear-all-in-flight!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_body_prep_failure_test.clj
+++ b/implementation/http/test/re_frame/http_body_prep_failure_test.clj
@@ -43,13 +43,20 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP / machine / routing fxs now require a carried
+  ;; frame stamp. This suite exercises the ambient dispatch path against
+  ;; a single conventional app frame, so register `:rf/default` explicitly
+  ;; and pin it as the established scope for the whole body via with-frame.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
   (require 're-frame.http-managed :reload)
   ((requiring-resolve 're-frame.machines/reset-timers!))
   (http-managed/clear-all-in-flight!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -12,6 +12,7 @@
   (:require [cljs.test :refer-macros [deftest is testing async]]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.http :as rf.http]
             ;; rf2-wj8vv — drive the full `:rf.http/managed` pipeline (fx
             ;; registration + in-flight registry) for the backoff-window
@@ -574,6 +575,12 @@
   handle indefinitely."
     (async done
       (rf/init! reagent-adapter/adapter)
+      ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+      ;; and the managed-HTTP fxs require a carried frame stamp. Register
+      ;; `:rf/default` explicitly; each dispatch below carries `{:frame
+      ;; :rf/default}` (the override) so the sync dispatch AND the async
+      ;; abort continuation both target it without an ambient scope.
+      (frame/ensure-default-frame!)
       (http-managed/clear-all-in-flight!)
       (let [replies    (atom [])
             read-fired (atom false)
@@ -593,7 +600,7 @@
                     :request-id :loris
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
-        (rf/dispatch-sync [:issue/slow-body])
+        (rf/dispatch-sync [:issue/slow-body] {:frame :rf/default})
         (-> (test-support/poll-until
               #(seq @replies)
               {:timeout-ms 2000 :label "cljs stalled-body timeout reply"})
@@ -644,6 +651,12 @@
       ;; `use-fixtures` reset here (it would tear down before the async
       ;; body completes). Install the adapter + clear the registry inline.
       (rf/init! reagent-adapter/adapter)
+      ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+      ;; and the managed-HTTP fxs require a carried frame stamp. Register
+      ;; `:rf/default` explicitly; each dispatch below carries `{:frame
+      ;; :rf/default}` (the override) so the sync dispatch AND the async
+      ;; abort continuation both target it without an ambient scope.
+      (frame/ensure-default-frame!)
       (http-managed/clear-all-in-flight!)
       (let [fetch-count (atom 0)
             replies     (atom [])
@@ -667,7 +680,7 @@
                     :on-success [:reply/recorder]}]]}))
         (rf/reg-event-fx :do/abort
           (fn [_ _] {:fx [[:rf.http/managed-abort :race]]}))
-        (rf/dispatch-sync [:issue])
+        (rf/dispatch-sync [:issue] {:frame :rf/default})
         ;; Poll (microtask-paced) until attempt #1 has fetched, failed 5xx,
         ;; and the request is sleeping in the backoff window. The backoff
         ;; handle is distinguishable from the in-flight-fetch handle by the
@@ -683,7 +696,7 @@
               {:timeout-ms 2000 :label "cljs backoff sleeping"})
             (.then (fn [_]
                      ;; Abort squarely inside the backoff window.
-                     (rf/dispatch-sync [:do/abort])
+                     (rf/dispatch-sync [:do/abort] {:frame :rf/default})
                      (is (empty? (registry/in-flight-snapshot))
                          "the registry is cleared the instant the backoff is cancelled")
                      ;; The aborted reply dispatches through the async router;
@@ -746,6 +759,12 @@
   (testing "rf2-065xo — a `:body` thunk that throws delivers ONE :on-failure reply with :rf.http/transport (NOT :rf.error/fx-handler-exception) and clears the registry"
     (async done
       (rf/init! reagent-adapter/adapter)
+      ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+      ;; and the managed-HTTP fxs require a carried frame stamp. Register
+      ;; `:rf/default` explicitly; each dispatch below carries `{:frame
+      ;; :rf/default}` (the override) so the sync dispatch AND the async
+      ;; abort continuation both target it without an ambient scope.
+      (frame/ensure-default-frame!)
       (http-managed/clear-all-in-flight!)
       (let [replies (atom [])
             restore (with-failing-fetch)]
@@ -760,7 +779,7 @@
                     :request-id :prep-thunk
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
-        (rf/dispatch-sync [:issue/throwing-thunk])
+        (rf/dispatch-sync [:issue/throwing-thunk] {:frame :rf/default})
         (-> (test-support/poll-until
               #(seq @replies)
               {:timeout-ms 2000 :label "cljs body-thunk prep failure reply"})
@@ -786,6 +805,12 @@
   (testing "rf2-065xo — a non-serialisable body (circular ref → JSON.stringify throws) delivers ONE :on-failure reply with :rf.http/transport"
     (async done
       (rf/init! reagent-adapter/adapter)
+      ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+      ;; and the managed-HTTP fxs require a carried frame stamp. Register
+      ;; `:rf/default` explicitly; each dispatch below carries `{:frame
+      ;; :rf/default}` (the override) so the sync dispatch AND the async
+      ;; abort continuation both target it without an ambient scope.
+      (frame/ensure-default-frame!)
       (http-managed/clear-all-in-flight!)
       (let [replies   (atom [])
             restore   (with-failing-fetch)
@@ -806,7 +831,7 @@
                     :request-id :prep-encode
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
-        (rf/dispatch-sync [:issue/unencodable])
+        (rf/dispatch-sync [:issue/unencodable] {:frame :rf/default})
         (-> (test-support/poll-until
               #(seq @replies)
               {:timeout-ms 2000 :label "cljs encode prep failure reply"})
@@ -828,6 +853,12 @@
   (testing "rf2-065xo — with `:retry {:on #{:rf.http/transport} …}` a throwing body thunk RETRIES (re-invoking the thunk per attempt) then finally fails :rf.http/transport"
     (async done
       (rf/init! reagent-adapter/adapter)
+      ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+      ;; and the managed-HTTP fxs require a carried frame stamp. Register
+      ;; `:rf/default` explicitly; each dispatch below carries `{:frame
+      ;; :rf/default}` (the override) so the sync dispatch AND the async
+      ;; abort continuation both target it without an ambient scope.
+      (frame/ensure-default-frame!)
       (http-managed/clear-all-in-flight!)
       (let [replies     (atom [])
             invocations (atom 0)
@@ -848,7 +879,7 @@
                     :request-id :prep-retry
                     :on-failure [:reply/recorder]
                     :on-success [:reply/recorder]}]]}))
-        (rf/dispatch-sync [:issue/retry-thunk])
+        (rf/dispatch-sync [:issue/retry-thunk] {:frame :rf/default})
         (-> (test-support/poll-until
               #(seq @replies)
               {:timeout-ms 4000 :label "cljs prep-failure retry exhaustion reply"})

--- a/implementation/http/test/re_frame/http_helpers_integration_test.clj
+++ b/implementation/http/test/re_frame/http_helpers_integration_test.clj
@@ -30,6 +30,12 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP / machine / routing fxs now require a carried
+  ;; frame stamp. This suite exercises the ambient dispatch path against
+  ;; a single conventional app frame, so register `:rf/default` explicitly
+  ;; and pin it as the established scope for the whole body via with-frame.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
@@ -40,7 +46,8 @@
   (require 're-frame.http-test-support :reload)
   ((requiring-resolve 're-frame.machines/reset-timers!))
   (http-managed/clear-all-in-flight!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_interceptors_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_interceptors_cljs_test.cljs
@@ -19,12 +19,24 @@
   interceptor surface."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.http-managed :as http-managed]))
 
+;; EP-0002 (rf2-nn0jqa): the no-`:frame` `reg-http-interceptor` /
+;; `clear-http-interceptor` calls below resolve the frame through the
+;; carried-invariant scope chain (rf2-5q7um6), so the fixture registers
+;; `:rf/default` and pins it as the established scope for each test body —
+;; the wrapping fn form replaces the prior `:before`/`:after` map so the
+;; body can run inside `*current-frame*` :rf/default. Tests that name a
+;; frame explicitly (the per-frame-scope case) still override it.
 (use-fixtures :each
-  {:before (fn [] (http-managed/clear-all-http-interceptors!))
-   :after  (fn [] (http-managed/clear-all-http-interceptors!))})
+  (fn [t]
+    (http-managed/clear-all-http-interceptors!)
+    (frame/ensure-default-frame!)
+    (binding [frame/*current-frame* :rf/default]
+      (t))
+    (http-managed/clear-all-http-interceptors!)))
 
 ;; ---- 1. round-trip register / clear ---------------------------------------
 

--- a/implementation/http/test/re_frame/http_jvm_binary_decode_test.clj
+++ b/implementation/http/test/re_frame/http_jvm_binary_decode_test.clj
@@ -44,12 +44,19 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP / machine / routing fxs now require a carried
+  ;; frame stamp. This suite exercises the ambient dispatch path against
+  ;; a single conventional app frame, so register `:rf/default` explicitly
+  ;; and pin it as the established scope for the whole body via with-frame.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.http-managed :reload)
   (http-managed/clear-all-in-flight!)
   (http-managed/clear-all-http-interceptors!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_managed_machine_test.clj
+++ b/implementation/http/test/re_frame/http_managed_machine_test.clj
@@ -50,13 +50,20 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP / machine / routing fxs now require a carried
+  ;; frame stamp. This suite exercises the ambient dispatch path against
+  ;; a single conventional app frame, so register `:rf/default` explicitly
+  ;; and pin it as the established scope for the whole body via with-frame.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
   (require 're-frame.http-managed :reload)
   (machines/reset-timers!)
   (http-managed/clear-all-in-flight!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -44,6 +44,12 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP / machine / routing fxs now require a carried
+  ;; frame stamp. This suite exercises the ambient dispatch path against
+  ;; a single conventional app frame, so register `:rf/default` explicitly
+  ;; and pin it as the established scope for the whole body via with-frame.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
@@ -61,7 +67,8 @@
   ;; (the canned-path `:after` coverage) must clear it between tests, or
   ;; a leaked `:after` mutates every subsequent test's reply payload.
   (http-managed/clear-all-http-interceptors!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -30,6 +30,12 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP / machine / routing fxs now require a carried
+  ;; frame stamp. This suite exercises the ambient dispatch path against
+  ;; a single conventional app frame, so register `:rf/default` explicitly
+  ;; and pin it as the established scope for the whole body via with-frame.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
@@ -39,7 +45,8 @@
   (privacy-headers/clear-sensitive-headers!)
   (http-url/clear-sensitive-query-params!)
   (trace/clear-listeners!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_retry_on_validation_test.clj
+++ b/implementation/http/test/re_frame/http_retry_on_validation_test.clj
@@ -33,11 +33,18 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP / machine / routing fxs now require a carried
+  ;; frame stamp. This suite exercises the ambient dispatch path against
+  ;; a single conventional app frame, so register `:rf/default` explicitly
+  ;; and pin it as the established scope for the whole body via with-frame.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.http-managed :reload)
   (http-managed/clear-all-in-flight!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/http_swallowed_failure_test.clj
+++ b/implementation/http/test/re_frame/http_swallowed_failure_test.clj
@@ -53,8 +53,15 @@
    :sensitive?          false})
 
 (defn- ctx-on-failure-present []
+  ;; EP-0002 (rf2-nn0jqa): the present-:on-failure path actually dispatches
+  ;; the reply event, so the synthetic ctx must carry the frame stamp the
+  ;; reply dispatch reads (the `:on-failure nil` siblings are silenced and
+  ;; never dispatch, so they need none). `:rf/default` need not be a live
+  ;; frame here — the reply lands as a frame-destroyed no-op, which this
+  ;; test (asserting only the absence of a swallow warning) is indifferent to.
   {:explicit-on-failure {:supplied? true :value [:api/load-error]}
    :url                 "https://example.test/data"
+   :frame               :rf/default
    :sensitive?          false})
 
 (deftest on-failure-silenced?-detects-explicit-nil-only

--- a/implementation/http/test/re_frame/http_transport_security_test.clj
+++ b/implementation/http/test/re_frame/http_transport_security_test.clj
@@ -151,7 +151,10 @@
   read timeout still has the JDK HttpClient enforce a 30s wall-clock
   bound."
     (let [ctx (normalise-args {:request {:url "/x"}}
-                              {:event [:some/event]})]
+                              ;; EP-0002 (rf2-nn0jqa): normalise-args reads
+                              ;; the carried frame stamp off the fx-ctx; this
+                              ;; direct-call unit test supplies it explicitly.
+                              {:event [:some/event] :frame :rf/default})]
       (is (= 30000 (:timeout-ms ctx))
           "absent :timeout-ms must default to 30000"))))
 
@@ -159,7 +162,10 @@
   (testing "rf2-it1cd — an explicit `:timeout-ms 5000` overrides the default"
     (let [ctx (normalise-args {:request    {:url "/x"}
                                :timeout-ms 5000}
-                              {:event [:some/event]})]
+                              ;; EP-0002 (rf2-nn0jqa): normalise-args reads
+                              ;; the carried frame stamp off the fx-ctx; this
+                              ;; direct-call unit test supplies it explicitly.
+                              {:event [:some/event] :frame :rf/default})]
       (is (= 5000 (:timeout-ms ctx))))))
 
 (deftest normalise-args-passes-explicit-nil-timeout-ms-through
@@ -169,7 +175,10 @@
   documented in Spec 014 §`:timeout-ms` security defaults."
     (let [ctx (normalise-args {:request    {:url "/x"}
                                :timeout-ms nil}
-                              {:event [:some/event]})]
+                              ;; EP-0002 (rf2-nn0jqa): normalise-args reads
+                              ;; the carried frame stamp off the fx-ctx; this
+                              ;; direct-call unit test supplies it explicitly.
+                              {:event [:some/event] :frame :rf/default})]
       (is (nil? (:timeout-ms ctx))
           "nil opt-out threads through unchanged"))))
 
@@ -182,7 +191,10 @@
   below.)"
     (let [ctx (normalise-args {:request    {:url "/x"}
                                :timeout-ms 0}
-                              {:event [:some/event]})]
+                              ;; EP-0002 (rf2-nn0jqa): normalise-args reads
+                              ;; the carried frame stamp off the fx-ctx; this
+                              ;; direct-call unit test supplies it explicitly.
+                              {:event [:some/event] :frame :rf/default})]
       (is (zero? (:timeout-ms ctx))
           "zero opt-out threads through unchanged"))))
 

--- a/implementation/http/test/re_frame/http_url_validation_test.clj
+++ b/implementation/http/test/re_frame/http_url_validation_test.clj
@@ -35,12 +35,19 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP / machine / routing fxs now require a carried
+  ;; frame stamp. This suite exercises the ambient dispatch path against
+  ;; a single conventional app frame, so register `:rf/default` explicitly
+  ;; and pin it as the established scope for the whole body via with-frame.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.http-managed :reload)
   (http-managed/clear-all-in-flight!)
   (http-managed/clear-all-http-interceptors!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/http/test/re_frame/routing_http_composed_corners_test.clj
+++ b/implementation/http/test/re_frame/routing_http_composed_corners_test.clj
@@ -45,6 +45,12 @@
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
+  ;; and the managed-HTTP / machine / routing fxs now require a carried
+  ;; frame stamp. This suite exercises the ambient dispatch path against
+  ;; a single conventional app frame, so register `:rf/default` explicitly
+  ;; and pin it as the established scope for the whole body via with-frame.
+  (frame/ensure-default-frame!)
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
@@ -52,7 +58,8 @@
   (require 're-frame.http-test-support :reload)
   (routing/reset-counters!)
   (http-managed/clear-all-in-flight!)
-  (t))
+  (rf/with-frame :rf/default
+    (t)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -188,10 +188,16 @@
   reverse index and dispatches `event` to the bound actor. No-op when the
   system-id is unbound (symmetric with the `dispatch-to-system` FN's
   no-op fall-through). Per Spec 005 §Cross-machine messaging by name."
-  [{frame-id :frame :or {frame-id :rf/default}} [system-id event]]
-  (when-let [machine-id (machine-by-system-id system-id frame-id)]
-    (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-      (dispatch! [machine-id event] {:frame frame-id})))
+  [{frame-id :frame} [system-id event]]
+  ;; EP-0002 carried invariant — the cascade envelope frame is the
+  ;; fx-context `:frame`; a nil stamp is an invariant failure
+  ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+  (let [frame-id (frame/require-frame-stamp!
+                   frame-id :rf.machine/dispatch-to-system
+                   {:where 'rf.machine/dispatch-to-system :event-id system-id})]
+    (when-let [machine-id (machine-by-system-id system-id frame-id)]
+      (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+        (dispatch! [machine-id event] {:frame frame-id}))))
   nil)
 
 (defn reset-timers!

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -309,8 +309,15 @@
   `:spawn-all` children-iteration teardown
   (`destroy-spawn-all-children!`) per the `args` shape. See the ns
   docstring for the form semantics."
-  [{frame-id :frame :or {frame-id :rf/default}} args]
-  (let [spawn-all? (and (map? args) (true? (:rf/spawn-all args)))]
+  [{frame-id :frame} args]
+  (let [;; EP-0002 carried invariant — the cascade envelope frame is the
+        ;; fx-context `:frame`; a nil stamp is an invariant failure
+        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+        frame-id   (frame/require-frame-stamp!
+                     frame-id :rf.machine/destroy
+                     {:where 'rf.machine/destroy
+                      :event-id (when (map? args) (:rf/parent-id args))})
+        spawn-all? (and (map? args) (true? (:rf/spawn-all args)))]
     (if spawn-all?
       (destroy-spawn-all-children! frame-id
                                    (:rf/parent-id args)

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -315,7 +315,10 @@
   `:rf.error/machine-snapshot-version-mismatch` event."
   [db runtime-db frame event machine base-initial]
   (let [machine-id    (first event)
-        frame-id      (or frame :rf/default)
+        ;; EP-0002 — `frame` is the cascade-threaded envelope frame the
+        ;; calling machine handler already asserted via
+        ;; `require-frame-stamp!`; no `:rf/default` repair here.
+        frame-id      frame
         platform      (or (:platform (frame/frame-meta frame-id)) :client)
         machine       (assoc machine
                              :rf/frame     frame-id
@@ -586,13 +589,21 @@
   (let [base-initial (delay (parallel/build-initial-snapshot
                               machine {:bootstrap-pending? false}))]
     (fn [{:keys [db frame] rt :rf.db/runtime :as _cofx} event]
+      ;; EP-0002 carried invariant: a machine handler is invoked inside an
+      ;; event cascade, so the cofx ALWAYS carries the envelope `:frame`
+      ;; (the HELD stamp). A nil stamp is an invariant failure — surface
+      ;; `:rf.error/no-frame-context`, never repair to a synthesised
+      ;; `:rf/default`.
+      (frame/require-frame-stamp!
+        frame :rf.machine/event-received
+        {:where 'rf-machines/make-machine-handler :event-id (first event)})
       ;; Per Spec 009 §:op-type vocabulary: `:rf.machine/event-received`
       ;; fires at the top of the handler so consumers see the inbound
       ;; event before any state derivation.
       (trace/emit! :rf.machine :rf.machine/event-received
                    {:machine-id (first event)
                     :event      event
-                    :frame      (or frame :rf/default)})
+                    :frame      frame})
       ;; EP-0001 (rf2-vzld77): machine snapshots are durable runtime-db
       ;; state. The handler reads the snapshot from the `:rf.db/runtime`
       ;; coeffect (a fresh frame's runtime-db is `nil` until first write —
@@ -885,7 +896,12 @@
   slot declares nothing — symmetric with `reg-machine`."
   [event frame-id]
   (let [actor-id   (first event)
-        runtime-db (frame/frame-runtime-db-value (or frame-id :rf/default))
+        ;; EP-0002 — `frame-id` is the cascade-threaded envelope frame the
+        ;; router's no-handler diagnostics pass in; read its runtime-db
+        ;; directly, no `:rf/default` repair. (A nil frame-id yields nil
+        ;; runtime-db → the genuine `:no-such-handler`, never a read against
+        ;; a synthesised default.)
+        runtime-db (frame/frame-runtime-db-value frame-id)
         snapshot   (when runtime-db (get-in runtime-db (paths/snapshot-path actor-id)))
         spec       (when snapshot (resolver/spec-from-snapshot snapshot))]
     (when spec

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -236,8 +236,16 @@
   closes the Goal-2 revertibility leak: spawn writes only app-db, destroy
   removes only app-db, so `restore-epoch` (app-db-only) reverts an
   actor's liveness perfectly with ZERO registrar drift."
-  [{frame-id :frame :or {frame-id :rf/default}} args]
-  (let [;; Per rf2-gr8q: prefer the pre-allocated id (declarative :spawn
+  [{frame-id :frame} args]
+  (let [;; EP-0002 carried invariant: `:rf.machine/spawn` runs inside an
+        ;; event cascade, so the fx context ALWAYS carries the envelope
+        ;; frame as `:frame` (the HELD stamp). A nil stamp is an invariant
+        ;; failure — surface `:rf.error/no-frame-context`, never repair to
+        ;; a synthesised `:rf/default`.
+        frame-id   (frame/require-frame-stamp!
+                     frame-id :rf.machine/spawn
+                     {:where 'rf.machine/spawn :event-id (:system-id args)})
+        ;; Per rf2-gr8q: prefer the pre-allocated id (declarative :spawn
         ;; routes through the transition reducer which bumps the parent
         ;; snapshot's `:rf/spawn-counter`). Hand-emitted spawn fxs carry
         ;; no pre-allocated id; the frame's app-db spawn-counter slot
@@ -418,8 +426,15 @@
   Subsequent `:on-child-done` / `:on-child-error` events arrive at the
   parent's `make-machine-handler` boundary and are intercepted by
   `intercept-spawn-all-event` (in `lifecycle-fx.join`)."
-  [{frame-id :frame :or {frame-id :rf/default}} args]
-  (let [parent-id  (:rf/parent-id args)
+  [{frame-id :frame} args]
+  (let [;; EP-0002 carried invariant — the fx context carries the cascade
+        ;; envelope frame; a nil stamp is an invariant failure
+        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+        frame-id   (frame/require-frame-stamp!
+                     frame-id :rf.machine/spawn-all-init
+                     {:where 'rf.machine/spawn-all-init
+                      :event-id (:rf/parent-id args)})
+        parent-id  (:rf/parent-id args)
         invoke-id  (:rf/spawn-id args)
         join-state (:join-state args)
         children   (:children join-state)]

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/update_snapshot.cljc
@@ -40,8 +40,15 @@
   in the emitting frame's runtime-db. No-op when the actor has no snapshot
   (destroyed / not-yet-materialised) or when `:rf/machine-id` is absent.
   Per Spec 005 §Snapshot-level escape hatch."
-  [{frame-id :frame :or {frame-id :rf/default}} args]
-  (let [machine-id (:rf/machine-id args)
+  [{frame-id :frame} args]
+  (let [;; EP-0002 carried invariant — the cascade envelope frame is the
+        ;; fx-context `:frame`; a nil stamp is an invariant failure
+        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+        frame-id   (frame/require-frame-stamp!
+                     frame-id :rf.machine/update-snapshot
+                     {:where 'rf.machine/update-snapshot
+                      :event-id (:rf/machine-id args)})
+        machine-id (:rf/machine-id args)
         patch      (:rf/patch args)]
     (when (and machine-id (map? patch))
       ;; Hard-disallow `:db` — symmetric with the action-effect path

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -411,8 +411,15 @@
   through the standard transition cascade.
 
   No-op under `:platform :server` (per Spec 005 §SSR mode)."
-  [{frame-id :frame :or {frame-id :rf/default}} args]
-  (let [parent-id  (:rf/parent-id args)
+  [{frame-id :frame} args]
+  (let [;; EP-0002 carried invariant — the cascade envelope frame is the
+        ;; fx-context `:frame`; a nil stamp is an invariant failure
+        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+        frame-id   (frame/require-frame-stamp!
+                     frame-id :rf.machine/after-schedule
+                     {:where 'rf.machine/after-schedule
+                      :event-id (:rf/parent-id args)})
+        parent-id  (:rf/parent-id args)
         invoke-id  (:rf/spawn-id args)
         state      (:state args)
         delay-key  (:delay-key args)
@@ -454,8 +461,15 @@
   so the only cross-key axis we still iterate is `:delay` (one entry
   per :after map entry on the bearing state node — typically 1-3
   entries)."
-  [{frame-id :frame :or {frame-id :rf/default}} args]
-  (let [parent-id (:rf/parent-id args)
+  [{frame-id :frame} args]
+  (let [;; EP-0002 carried invariant — the cascade envelope frame is the
+        ;; fx-context `:frame`; a nil stamp is an invariant failure
+        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+        frame-id  (frame/require-frame-stamp!
+                    frame-id :rf.machine/after-cancel
+                    {:where 'rf.machine/after-cancel
+                     :event-id (:rf/parent-id args)})
+        parent-id (:rf/parent-id args)
         invoke-id (vec (:rf/spawn-id args))]
     (doseq [[k _entry] (get @after-timers frame-id)
             :when (and (= parent-id (:parent k))

--- a/implementation/machines/test/re_frame/dropped_snapshot_diagnostic_test.clj
+++ b/implementation/machines/test/re_frame/dropped_snapshot_diagnostic_test.clj
@@ -35,9 +35,14 @@
   (reset! frame/frames {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
+  ;; machine fxs require a carried frame stamp. Register `:rf/default`
+  ;; explicitly and pin it as the established scope for the body.
+  (frame/ensure-default-frame!)
   (require 're-frame.machines :reload)
   (machines/reset-timers!)
-  (test-fn))
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/machines/test/re_frame/initial_snapshot_unification_test.clj
+++ b/implementation/machines/test/re_frame/initial_snapshot_unification_test.clj
@@ -31,9 +31,14 @@
   (registrar/clear-all!)
   (reset! frame/frames {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
+  ;; machine fxs require a carried frame stamp. Register `:rf/default`
+  ;; explicitly and pin it as the established scope for the body.
+  (frame/ensure-default-frame!)
   (require 're-frame.machines :reload)
   (machines/reset-timers!)
-  (test-fn))
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/routing/src/re_frame/routing/can_leave.cljc
+++ b/implementation/routing/src/re_frame/routing/can_leave.cljc
@@ -23,7 +23,8 @@
   re-wires them on a fresh registrar (the `clear-all!` test-fixture
   path). Per the rf2-2yabr cohesion split: CAN-LEAVE + PENDING-NAV
   seam."
-  (:require [re-frame.late-bind :as late-bind]
+  (:require [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.routing.events :as routing-events]
             [re-frame.routing.registry :as registry]
@@ -266,10 +267,17 @@
     ;; The :bypass-leave-guard? request flag is the rf2-yursn one-shot
     ;; escape hatch :rf.route/continue uses to re-issue the original
     ;; navigation request without re-running the leave guard.
-    (let [external? (url/external-url? url)
+    (let [;; EP-0002 carried invariant — `:rf/url-requested` is a cascade
+          ;; event, so the cofx carries the envelope `:frame`; a nil stamp
+          ;; is an invariant failure (`:rf.error/no-frame-context`), never a
+          ;; synthesised `:rf/default`.
+          frame     (frame/require-frame-stamp!
+                      frame :rf/url-requested
+                      {:where 'rf.route/url-requested-handler})
+          external? (url/external-url? url)
           app-url   (url/request-url->app-url url)
           blocked   (when-not external?
-                      (maybe-block-navigation (or rdb {}) (or frame :rf/default)
+                      (maybe-block-navigation (or rdb {}) frame
                                               event-vec app-url bypass-leave-guard?))]
       (cond
         external?

--- a/implementation/routing/src/re_frame/routing/history.cljc
+++ b/implementation/routing/src/re_frame/routing/history.cljc
@@ -78,20 +78,32 @@
      This mirrors the locked routing-history contract (the
      `popstate-via-window-listener-cljs` test dispatches `dispatch-sync`)."
      []
-     (let [w (when (exists? js/window) js/window)]
+     (let [w (when (exists? js/window) js/window)
+           ;; EP-0002 (rf2-nn0jqa) — the popstate dispatch targets the
+           ;; EXPLICITLY-declared URL owner; `url-owner-frame-id` returns
+           ;; nil when no frame declared `:url-bound? true`. The runtime no
+           ;; longer synthesises `:rf/default` ownership from absence, so
+           ;; the handler resolves the owner AT POP TIME and skips the
+           ;; dispatch when none is declared rather than firing a frameless
+           ;; `:rf.route/handle-url-change` (which would raise
+           ;; `:rf.error/no-frame-context`). Installing a history listener
+           ;; without declaring a URL owner is a routing-config no-op, not
+           ;; a default-frame write.
+           dispatch-to-owner!
+           (fn []
+             (when-let [owner (nav-fx/url-owner-frame-id)]
+               (router/dispatch-sync! [:rf.route/handle-url-change (current-url)]
+                                      {:frame owner})))]
        (when w
          (when-let [prev @history-listener-atom]
            (try (.removeEventListener w "popstate" prev)
                 (catch :default _ nil)))
-         (let [handler (fn [_event]
-                         (router/dispatch-sync! [:rf.route/handle-url-change (current-url)]
-                                                {:frame (nav-fx/url-owner-frame-id)}))]
+         (let [handler (fn [_event] (dispatch-to-owner!))]
            (.addEventListener w "popstate" handler)
            (reset! history-listener-atom handler)))
        ;; Initial sync: hydrate the owner's slice from the current URL so
        ;; a deep link / reload lands on the right route on first paint.
-       (router/dispatch-sync! [:rf.route/handle-url-change (current-url)]
-                              {:frame (nav-fx/url-owner-frame-id)})
+       (dispatch-to-owner!)
        nil)))
 
 #?(:cljs

--- a/implementation/routing/src/re_frame/routing/nav_fx.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_fx.cljc
@@ -20,43 +20,46 @@
 
 (defn url-bound?-from-config
   "Read `:url-bound?` from a frame's stored config map. `nil` when
-  unset. Default-on for `:rf/default` is applied at the call site, not
-  here, so the hook can discriminate explicit-`true` from default-`true`."
+  unset."
   [config]
   (when (map? config)
     (:url-bound? config)))
 
 (defn url-owner-frame-id
-  "Return the single frame allowed to mutate browser history. The default
-  frame owns the URL unless it explicitly opts out; otherwise the first
-  explicit non-default `:url-bound? true` frame wins deterministically.
-  Duplicate registrations still emit `:rf.error/duplicate-url-binding`,
-  but this predicate enforces the one-owner rule at fx time.
+  "Return the single frame that has EXPLICITLY declared browser-history
+  ownership via `(reg-frame :id {:url-bound? true})`, or `nil` when no
+  frame has declared it.
+
+  EP-0002 (rf2-nn0jqa) — URL ownership is an explicit host/bootstrap
+  policy, NOT an absence repair. The prior contract anchored ownership on
+  `:rf/default` (the default frame owned the URL unless it opted out);
+  under the carried invariant the runtime must NOT infer `:rf/default` as
+  the owner. An app declares its one URL-owning frame explicitly; `nil`
+  here means no owner is declared (a routing-config state, surfaced by the
+  callers — outbound history mutations no-op, the inbound popstate listener
+  skips). `:rf/default` may still BE the owner, but only when it carries an
+  explicit `{:url-bound? true}` like any other frame.
 
   Public (rather than `defn-`) so the ownership-resolution contract is
-  directly assertable — in particular the single-non-default-owner case
-  the step-deck testbed relies on (rf2-6qgbs.3): when `:rf/default` opts
-  OUT (`:url-bound? false`) a non-default `:url-bound? true` frame becomes
-  the owner. A reimplemented gate cannot catch a regression in THIS
-  resolution; the test must reach the real fn."
+  directly assertable — the single declared-owner case the step-deck
+  testbed relies on (rf2-6qgbs.3). A reimplemented gate cannot catch a
+  regression in THIS resolution; the test must reach the real fn."
   []
-  (let [frames       (registrar/registrations :frame)
-        default-meta (get frames :rf/default)]
-    (if-not (false? (url-bound?-from-config default-meta))
-      :rf/default
-      (->> frames
-           (filter (fn [[id meta]]
-                     (and (not= :rf/default id)
-                          (true? (url-bound?-from-config meta)))))
-           (sort-by (fn [[id _]] (str id)))
-           ffirst))))
+  (->> (registrar/registrations :frame)
+       (filter (fn [[_id meta]] (true? (url-bound?-from-config meta))))
+       (sort-by (fn [[id _]] (str id)))
+       ffirst))
 
 (defn url-bound-frame?
   "Return true when the frame named `frame-id` is the one active URL
   owner. Per Spec 012 §Multi-frame routing, duplicate `:url-bound? true`
-  declarations are reported AND non-owners are prevented from pushing."
+  declarations are reported AND non-owners are prevented from pushing.
+
+  EP-0002 — `nil` frame-id (or no declared owner) is never the owner: the
+  runtime no longer synthesises `:rf/default` ownership from absence."
   [frame-id]
-  (= (or frame-id :rf/default) (url-owner-frame-id)))
+  (and (some? frame-id)
+       (= frame-id (url-owner-frame-id))))
 
 ;; `:rf.nav/push-url` and `:rf.nav/replace-url` share one body: gate on
 ;; the calling frame's URL ownership, then either drive the browser

--- a/implementation/routing/src/re_frame/routing/nav_token.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_token.cljc
@@ -107,7 +107,12 @@ result. Per Spec 012 §Navigation tokens — stale-result suppression."})
   ;; §Threading the `:do` slot is the wrapped fx entry to perform.
   (let [do-entry        (get args :do)
         nav-token       (get args :nav-token)
-        frame-id        (or frame :rf/default)
+        ;; EP-0002 carried invariant — the fx context carries the cascade
+        ;; envelope frame as `:frame`; a nil stamp is an invariant failure
+        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+        frame-id        (frame/require-frame-stamp!
+                          frame :rf.route/with-nav-token
+                          {:where 'rf.route/with-nav-token-handler})
         frame-record    (frame/frame frame-id)
         ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db state.
         rdb             (frame/frame-runtime-db-value frame-id)

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -12,6 +12,7 @@
   `:reload` re-wires it on a fresh registrar. Per the rf2-2yabr cohesion
   split: NAVIGATE-EVENT seam."
   (:require [clojure.string :as str]
+            [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.privacy :as privacy]
             [re-frame.registrar :as registrar]
@@ -131,7 +132,15 @@
     ;; :rf.route.nav-token/allocated as the cascade begins (rf2-d60go) —
     ;; the programmatic path matches the URL-driven path so async loaders
     ;; have a token to thread through stale-suppression.
-    (let [opts (or opts {})
+    (let [;; EP-0002 carried invariant — `:rf.route/navigate` is a cascade
+          ;; event, so the cofx carries the envelope `:frame`; a nil stamp
+          ;; is an invariant failure (`:rf.error/no-frame-context`), never a
+          ;; synthesised `:rf/default`. Validated once; the trace stamps and
+          ;; the leave-guard call below all read this carried value.
+          frame (frame/require-frame-stamp!
+                  frame :rf.route/navigate
+                  {:where 'rf.route/navigate-handler})
+          opts (or opts {})
           rdb  (or rdb-raw {})
           {:keys [route-id path-params query-params matched-fragment unmatched-url
                   throw-reason requested-url external-url-target?]}
@@ -394,7 +403,7 @@
         ;; protocol stays uniform across both entry points.
         :else
         (if-let [blocked (can-leave/maybe-block-navigation
-                           rdb (or frame :rf/default)
+                           rdb frame
                            event-vec url
                            (:bypass-leave-guard? opts))]
           blocked

--- a/implementation/routing/src/re_frame/routing/scroll.cljc
+++ b/implementation/routing/src/re_frame/routing/scroll.cljc
@@ -146,12 +146,19 @@ leaving a route."})
   [{:keys [frame]} {:keys [url position]}]
   #?(:cljs
      (when url
-       (let [pos (or position
+       (let [;; EP-0002 carried invariant — the fx context carries the
+             ;; cascade envelope frame as `:frame`; a nil stamp is an
+             ;; invariant failure (`:rf.error/no-frame-context`), never a
+             ;; synthesised `:rf/default`.
+             frame-id (frame/require-frame-stamp!
+                        frame :rf.nav/capture-scroll
+                        {:where 'rf.nav/capture-scroll-handler})
+             pos (or position
                      [(or (.-scrollX js/window) (.-pageXOffset js/window) 0)
                       (or (.-scrollY js/window) (.-pageYOffset js/window) 0)])]
          ;; EP-0001 (rf2-vzld77): scroll-position caches are durable routing
          ;; runtime-db state — write the runtime-db partition.
-         (frame/swap-runtime-db! (or frame :rf/default)
+         (frame/swap-runtime-db! frame-id
                                  save-scroll-position
                                  url
                                  pos)))

--- a/implementation/routing/src/re_frame/routing/url_bound.cljc
+++ b/implementation/routing/src/re_frame/routing/url_bound.cljc
@@ -25,14 +25,16 @@
 (defn- frame-id-of-existing-url-binding
   "Scan the registrar's `:frame` map for any frame OTHER than `exclude-id`
   that currently carries an explicit `:url-bound? true`. Returns the
-  offending frame-id or nil. The `:rf/default` frame's implicit
-  `:url-bound? true` IS counted — the existing URL owner is unchanged."
+  offending frame-id or nil.
+
+  EP-0002 (rf2-nn0jqa): URL ownership is an EXPLICIT declaration — there is
+  no `:rf/default`-owns-by-default floor. `:rf/default` is counted here only
+  when it carries an explicit `:url-bound? true` like any other frame; an
+  un-annotated `:rf/default` is NOT an implicit owner."
   [exclude-id]
   (some (fn [[other-id other-meta]]
           (when (and (not= other-id exclude-id)
-                     (or (true? (nav-fx/url-bound?-from-config other-meta))
-                         (and (= :rf/default other-id)
-                              (not (false? (nav-fx/url-bound?-from-config other-meta))))))
+                     (true? (nav-fx/url-bound?-from-config other-meta)))
             other-id))
         (registrar/registrations :frame)))
 

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -15,7 +15,8 @@
   facade owns the two `events/reg-event-fx` calls so a `:reload`
   re-wires them on a fresh registrar. Per the rf2-2yabr cohesion split:
   URL-CHANGE-EVENTS seam."
-  (:require [re-frame.registrar :as registrar]
+  (:require [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
             [re-frame.routing.can-leave :as can-leave]
             [re-frame.routing.events :as routing-events]
             [re-frame.routing.registry :as registry]
@@ -253,10 +254,17 @@
   popstate / initial / SSR routes through `:rf.route/handle-url-change`
   (default `:restore`)."
   [{:keys [frame] rdb :rf.db/runtime} [_ url opts :as event-vec]]
-  (let [opts    (or opts {})
+  (let [;; EP-0002 carried invariant — `:rf.route/transitioned` is a
+        ;; cascade event, so the cofx carries the envelope `:frame`; a nil
+        ;; stamp is an invariant failure (`:rf.error/no-frame-context`),
+        ;; never a synthesised `:rf/default`.
+        frame   (frame/require-frame-stamp!
+                  frame :rf.route/transitioned
+                  {:where 'rf.route/transitioned-handler})
+        opts    (or opts {})
         rdb     (or rdb {})
         blocked (can-leave/maybe-block-navigation
-                  rdb (or frame :rf/default)
+                  rdb frame
                   event-vec url
                   (:bypass-leave-guard? opts))]
     (or blocked
@@ -266,8 +274,8 @@
         ;; (`handle-url-change-handler`, :restore below) and the programmatic
         ;; `:rf.route/navigate {:url ...}` path. Spec 009 requires `:frame` on
         ;; `:rf.error/no-such-handler {:kind :route}` and
-        ;; `:rf.warning/no-not-found-route`. The default frame still tags
-        ;; `:rf/default` (the dispatch cofx supplies it). EP-0001 (rf2-vzld77):
+        ;; `:rf.warning/no-not-found-route`. The carried `:frame` (the
+        ;; cascade cofx supplies it) tags those traces. EP-0001 (rf2-vzld77):
         ;; the route slice is durable routing runtime-db state.
         (url-change-fx rdb url :top frame))))
 
@@ -283,10 +291,17 @@
   threaded through so the SSR error-projection listener can attribute
   the :no-such-handler trace per-frame."
   [{:keys [frame] rdb :rf.db/runtime} [_ url opts :as event-vec]]
-  (let [opts    (or opts {})
+  (let [;; EP-0002 carried invariant — `:rf.route/handle-url-change` is a
+        ;; cascade event (popstate / initial / SSR), so the cofx carries
+        ;; the envelope `:frame`; a nil stamp is an invariant failure
+        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+        frame   (frame/require-frame-stamp!
+                  frame :rf.route/handle-url-change
+                  {:where 'rf.route/handle-url-change-handler})
+        opts    (or opts {})
         rdb     (or rdb {})
         blocked (can-leave/maybe-block-navigation
-                  rdb (or frame :rf/default)
+                  rdb frame
                   event-vec url
                   (:bypass-leave-guard? opts))]
     (or blocked

--- a/implementation/routing/test/re_frame/route_link_test.clj
+++ b/implementation/routing/test/re_frame/route_link_test.clj
@@ -37,9 +37,17 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
+  ;; routing/nav fxs require a carried frame stamp. Register `:rf/default`
+  ;; explicitly as the conventional app frame; URL ownership is now an
+  ;; explicit declaration, so opt in via `{:url-bound? true}`. Pin it as the
+  ;; ambient scope for the body.
+  (rf/reg-frame :rf/default {:url-bound? true
+                             :doc "route-link suite default app frame (explicit URL owner)."})
   (require 're-frame.routing :reload)
   (routing/reset-counters!)
-  (test-fn))
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
+++ b/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
@@ -77,11 +77,19 @@
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
+  ;; routing/nav fxs require a carried frame stamp. Register `:rf/default`
+  ;; explicitly as the conventional app frame; URL ownership is now an
+  ;; explicit declaration, so opt in via `{:url-bound? true}`. Pin it as the
+  ;; ambient scope for the body.
+  (rf/reg-frame :rf/default {:url-bound? true
+                             :doc "concurrency-stress suite default app frame (explicit URL owner)."})
   ;; Framework events / fx (routing.cljc) are registered at ns-load;
   ;; clear-all! wiped them. Reload to resurrect.
   (require 're-frame.routing :reload)
   (routing/reset-counters!)
-  (test-fn))
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -59,6 +59,14 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
+  ;; routing/nav fxs now require a carried frame stamp. Register `:rf/default`
+  ;; explicitly as the conventional single app frame. URL ownership is now an
+  ;; EXPLICIT declaration (no `:rf/default`-owns-by-default floor), so this
+  ;; suite's URL-owning frame opts in via `{:url-bound? true}`; the body runs
+  ;; with `:rf/default` pinned as the ambient scope.
+  (rf/reg-frame :rf/default {:url-bound? true
+                             :doc "Routing-suite default app frame (explicit URL owner)."})
   ;; Framework events / fx (routing.cljc, ssr.cljc) are registered at
   ;; ns-load; clear-all! wiped them. Reload to resurrect.
   (require 're-frame.routing :reload)
@@ -68,7 +76,8 @@
   ;; the production façade).
   (require 're-frame.routing.test-support :reload)
   (routing/reset-counters!)
-  (test-fn))
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 
@@ -4013,8 +4022,9 @@
             (Spec 012 §Multi-frame routing)"
     (let [traces (atom [])]
       (rf/register-listener! ::dup-bind (fn [ev] (swap! traces conj ev)))
-      ;; :rf/default is implicitly :url-bound? true. A second frame
-      ;; opting in collides.
+      ;; EP-0002 (rf2-nn0jqa): URL ownership is explicit. This suite's
+      ;; fixture registered `:rf/default {:url-bound? true}` as the declared
+      ;; owner, so a second frame opting in collides with it.
       (rf/reg-frame :my-frame {:url-bound? true})
       (rf/unregister-listener! ::dup-bind)
       (is (some (fn [ev]

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -73,7 +73,7 @@ Audience column: **user** = an event apps dispatch or handle directly; **runtime
 
 ### Frame-level configuration
 
-- `:url-bound?` on `reg-frame` metadata (default true for `:rf/default` only). Only one frame may own the URL. See [§Multi-frame routing](#multi-frame-routing).
+- `:url-bound?` on `reg-frame` metadata. URL ownership is an explicit declaration (EP-0002 rf2-nn0jqa) — a frame owns the URL only with `:url-bound? true`; there is no `:rf/default`-owns-by-default floor. Only one frame may own the URL. See [§Multi-frame routing](#multi-frame-routing).
 
 ### Schemas registered with the framework
 
@@ -1161,21 +1161,21 @@ The corpus-wide `:rf.error/handler-exception` listener (`on-match-error-listener
 
 ## Multi-frame routing
 
-Each frame has its own `[:rf.runtime/routing :current]` slice. Only the default frame is URL-bound. Non-default frames have independent routes that don't push to the browser URL.
+Each frame has its own `[:rf.runtime/routing :current]` slice. URL ownership is an **explicit** declaration — a frame owns the browser URL only by carrying `:url-bound? true` on its `reg-frame` metadata. Frames that do not declare it have independent routes that don't push to the browser URL.
 
 1. Every frame's `runtime-db` may have a `:rf/route` slice at `[:rf.runtime/routing :current]` (a framework-owned runtime-db path, read through the public `:rf/route` sub — not an app-db path).
-2. The default frame (`:rf/default`) is **URL-bound** by default: `:rf.route/navigate` events on that frame fire `:rf.nav/push-url`, and `popstate` (Back/Forward) drives it. The browser URL reflects the URL-owning frame's route.
-3. Non-default frames are **not URL-bound** by default. `:rf.route/navigate` updates their `:rf/route` slice (state changes) but does not fire `:rf.nav/push-url`. This is the right default for story-variant frames, devcards, per-test fixtures.
-4. Opt-in URL binding for non-default frames via `(rf/reg-frame :my-frame {:url-bound? true})`. The runtime enforces "only one frame can own the URL at a time" — re-registering a second `:url-bound? true` frame is a `:rf.error/duplicate-url-binding` trace event. When the default frame opts out (`{:url-bound? false}`) and a single non-default frame opts in, that frame becomes the sole URL owner.
+2. A frame is **URL-bound** only when it carries an explicit `(reg-frame :id {:url-bound? true})`. The URL owner's `:rf.route/navigate` events fire `:rf.nav/push-url`, and `popstate` (Back/Forward) drives it. The browser URL reflects the URL-owning frame's route. Per EP-0002 (rf2-nn0jqa) there is **no `:rf/default`-owns-by-default floor** — the runtime never infers URL ownership from absence. `:rf/default` may BE the owner, but only when it carries `:url-bound? true` like any other frame.
+3. Frames without `:url-bound? true` are **not URL-bound**. `:rf.route/navigate` updates their `:rf/route` slice (state changes) but does not fire `:rf.nav/push-url`. This is the right default for story-variant frames, devcards, per-test fixtures.
+4. The runtime enforces "only one frame can own the URL at a time" — registering a second `:url-bound? true` frame while one already owns the URL is a `:rf.error/duplicate-url-binding` trace event. When no frame declares `:url-bound? true`, there is **no URL owner**: outbound `:rf.nav/push-url` / `:rf.nav/replace-url` no-op, and the inbound `popstate` listener skips (installing a history listener with no declared owner is a routing-config no-op, not a default-frame write).
 
 ### popstate drives the URL-owner frame, both directions
 
 URL ownership is symmetric across the app↔browser boundary, and resolves to the **same single owner** in both directions:
 
 - **Outbound (app → browser).** `:rf.nav/push-url` / `:rf.nav/replace-url` consult `url-owner-frame-id` (public) and only the owner mutates browser history. A non-owner's navigation updates its own `:rf/route` slice but no-ops the history push.
-- **Inbound (browser → app).** A `popstate` listener fires `[:rf.route/handle-url-change url] {:frame (url-owner-frame-id)}` — targeted at the **current** owner resolved at pop time, NOT hard-coded to `:rf/default`. So Back/Forward restores the owner frame's `:rf/route` slice (and the body rendered off it), whether the owner is `:rf/default` or a non-default `:url-bound? true` frame.
+- **Inbound (browser → app).** A `popstate` listener fires `[:rf.route/handle-url-change url] {:frame (url-owner-frame-id)}` — targeted at the **current** owner resolved at pop time. Per EP-0002 `url-owner-frame-id` returns the explicitly-declared owner, or `nil` when none is declared; the listener skips the dispatch (no frameless write) when there is no owner. So Back/Forward restores the owner frame's `:rf/route` slice (and the body rendered off it) whenever a frame has declared `:url-bound? true`.
 
-The routing artefact ships `install-history-listener!` (CLJS) — re-exported as `rf/install-history-listener!` — which wires this `popstate` listener and does the initial URL → owner-slice sync. Apps boot it once after registering frames. It is idempotent (re-install replaces the listener, hot-reload safe) and is the inbound counterpart of the `:rf.nav/push-url` gate; `rf/remove-history-listener!` tears it down. Targeting `url-owner-frame-id` at pop time means default-owned apps and url-bound-non-default-frame apps behave identically through the same helper — a popstate dispatched at the old owner (`:rf/default`) after ownership transferred would update a frozen slice and leave Back/Forward broken (the bug.4 fixed).
+The routing artefact ships `install-history-listener!` (CLJS) — re-exported as `rf/install-history-listener!` — which wires this `popstate` listener and does the initial URL → owner-slice sync. Apps boot it once after registering frames. It is idempotent (re-install replaces the listener, hot-reload safe) and is the inbound counterpart of the `:rf.nav/push-url` gate; `rf/remove-history-listener!` tears it down. Targeting `url-owner-frame-id` at pop time means the listener tracks whichever frame declared `:url-bound? true` — a popstate dispatched at a stale owner after ownership transferred would update a frozen slice and leave Back/Forward broken (the bug.4 fixed). Per EP-0002 the listener also skips entirely when no owner is declared, rather than synthesising `:rf/default`.
 
 The story / devcard / SSR cases all benefit:
 
@@ -1213,9 +1213,11 @@ Per [§Redirects and guards](#redirects-and-guards) v1 redirects compose as inte
 
 The two nav-token trace operations — `:rf.route.nav-token/allocated` and `:rf.route.nav-token/stale-suppressed` (per [§Navigation tokens — stale-result suppression](#navigation-tokens--stale-result-suppression)) — live under `:rf.route.nav-token/*`. An earlier carve-out grandfathered the bare `:route.nav-token/*` prefix as the sole framework trace-operation namespace outside `:rf.*` (per the now-removed paragraph in [Conventions](Conventions.md)); closed that single-bit-of-difference exception, mechanically renaming all 91 occurrences across spec, conformance fixtures, implementation, docs, skills, and tools. The Conventions single-root rule (every framework-owned keyword sits under `:rf.*`) now holds without exception.
 
-### Default frame is URL-bound; non-default frames opt in
+### URL ownership is an explicit declaration (no default-frame floor)
 
-Per [§Multi-frame routing](#multi-frame-routing) the default frame (`:rf/default`) is **URL-bound** by default; non-default frames are not. Non-default frames opt into URL binding via `(rf/reg-frame :my-frame {:url-bound? true})`; the runtime enforces "only one frame can own the URL at a time" (re-registering a second `:url-bound? true` frame emits `:rf.error/duplicate-url-binding`). This was chosen over a "first frame to dispatch `:rf.route/navigate` wins" rule because explicit declaration is auditable at registration time and matches the story / devcard / per-test-fixture / SSR-per-request use cases without surprise.
+Per [§Multi-frame routing](#multi-frame-routing) a frame owns the browser URL only by carrying an explicit `(rf/reg-frame :id {:url-bound? true})`; the runtime enforces "only one frame can own the URL at a time" (registering a second `:url-bound? true` frame emits `:rf.error/duplicate-url-binding`). This was chosen over a "first frame to dispatch `:rf.route/navigate` wins" rule because explicit declaration is auditable at registration time and matches the story / devcard / per-test-fixture / SSR-per-request use cases without surprise.
+
+EP-0002 (rf2-nn0jqa) removed the prior `:rf/default`-owns-the-URL-by-default floor: URL ownership was an *absence repair* (the default frame owned the URL unless it opted out), which the carried invariant forbids. Ownership is now a positive host/bootstrap policy. `:rf/default` may BE the URL owner, but only when it declares `:url-bound? true` like any other frame; an app with no declared owner simply has no URL owner (outbound history mutations no-op, the popstate listener skips). A migration that wants the old behaviour declares `(rf/reg-frame :rf/default {:url-bound? true})` at bootstrap.
 
 ### State-first, URL-second update order is locked
 


### PR DESCRIPTION
EP-0002 chain bead 6/11. Removes the operation-time `:rf/default` fallback from the framework fx & runtime subsystems (machines, managed HTTP, routing/nav). A framework fx invoked inside a cascade reads the HELD envelope frame off its fx-context `:frame`; a nil stamp is an invariant failure surfaced as `:rf.error/no-frame-context` (never a synthesised `:rf/default`). Adds `frame/require-frame-stamp!` (operation-time companion to `require-current-frame!`). URL ownership becomes an explicit host/bootstrap policy: `url-owner-frame-id` returns the declared `:url-bound? true` frame or nil, with no `:rf/default`-owns-by-default floor (spec/012-Routing.md updated).

## SLICE-GATE report

CI does NOT run on ep-0002 PRs; this report is the gate of record.

### test:cljs (canonical gate) — build-envelope bare-dispatch errors

- BEFORE: **235** `:where re-frame.router/build-envelope` no-frame-context errors. The run CRASHED at `re-frame.http-cljs-test` (async 'done called more than once' from a frameless managed-HTTP reply), aborting node before later namespaces ran.
- AFTER: **10** `build-envelope` errors, and the run completes through `re-frame.todomvc-cljs-test` (the http async crash is fixed). All 10 remaining are in **Story testbed tests** — RED-BY-DESIGN, owned by **rf2-bd4div** (Xray/Story/pair tools + Story testbed tests):
  - `counter-with-stories.elision-demo-cljs-test` (4)
  - `re-frame.story-open-in-editor-cljs-test` (6)

Zero `build-envelope` / no-frame-context errors remain in any `re-frame.http-*` / machines / `re-frame.routing-*` namespace — the migrated surfaces are clean.

### Other test:cljs red-by-design remainder (all prior/later-bead surfaces, NOT this bead)

no-frame-context errors, by owning bead:
- **rf2-69r7ui** (root/view/adapter): `re-frame.boot-cljs-test` (81), `re-frame.adapter.uix-react-shared` (13), `re-frame.adapter.helix-react-shared` (13), `re-frame.frame-provider-context-dom` (9) — adapter-boot / provider-context surfaces.
- **rf2-gjq3ow** (trace/elision projection / wire-egress): `re-frame.security.schema-redaction` (5), `validation-redaction-invariant` (1), `fail-closed-invariant` (1) — the `elide-wire-value` `(or … :rf/default)` floor (core/elision.cljc:576) is the documented OUT-OF-SCOPE operation-time wire-egress floor.
- **rf2-bd4div** (Xray/Story/tools): `day8.re-frame2-xray.palette.dispatch-routing`, `counter-with-stories.stories`, `login-form.stories`, `re-frame.story-*` suites.
- Example-app downstream: `re-frame.todomvc-cljs-test`, `re-frame.nine-states`, `re-frame.realworld`, `re-frame.runtime-cljs` (carried red from the chain; not fx/runtime surfaces).

(The router bead rf2-9wa0lf + subs bead rf2-jue6sp close-reasons explicitly attribute this dispatch-dominated CLJS residue to the later beads incl. nn0jqa for the fx/runtime callers — which this PR closes — and to 69r7ui / gjq3ow / bd4div for the rest.)

### Per-artefact JVM gates (clojure -M:test) — GREEN for the migrated surfaces

- **http**: 374 tests / 1695 assertions — **0 failures, 0 errors** (was 1 failure / 99 errors before fixture migration).
- **machines**: 570 tests / 1796 assertions — **0 failures, 0 errors** (was 262 errors).
- **routing**: 160 tests / 784 assertions — **0 failures, 0 errors** (was 12 failures / 68 errors; includes the URL-owner contract-change test updates).
- **flows**: 165 tests / 4676 assertions — **0 failures, 0 errors** (flows source already carried-invariant via the cofx frame; unchanged).
- **core JVM**: NOT green and NOT this bead's surface — ~34 bespoke `reset-runtime` fixtures across core (configure / drain / events / interceptor / trace / marks …) dispatch bare events and fail `:rf.error/no-frame-context`. Verified PRE-EXISTING at the ep-0002 base (stash-tested `configure-test`: 3 errors with my src changes removed). These exercise the core dispatch/trace/interceptor path (router bead rf2-9wa0lf surface), left red by the prior chain beads. The one core file this PR touches — `test_support.cljc` (the shared fixture) — was changed only to pin `:rf/default` scope when an adapter is installed, which greens the shared-fixture suites and cannot regress core (no core shared-fixture test asserts no-frame-context).

### Surfaces migrated

- **Resolver**: `frame/require-frame-stamp!` (new).
- **Machines**: `:rf.machine/spawn` / `spawn-all-init` / `destroy` / `update-snapshot` / `after-schedule` / `after-cancel` fxs; `:rf.machine/dispatch-to-system` fx; `make-machine-handler` + `prepare-machine-ctx` + `resolve-actor-handler-meta`.
- **HTTP**: `:rf.http/managed` (`managed-handler` + `normalise-args` — reply frame captured at initiation, threaded to async reply); `:rf.fx/reg-http-interceptor` / `:rf.fx/clear-http-interceptor` (fx-context frame + args override); canned-stub `run-request-chain` / `emit-canned-success!` / `emit-canned-failure!`.
- **Routing**: `navigate` / `url-requested` / `transitioned` / `handle-url-change` handlers; `with-nav-token` / `capture-scroll` fxs; `url-owner-frame-id` / `url-bound-frame?` (explicit ownership); `history` popstate listener (skips with no owner); `url-bound` duplicate-binding check.

### Out of scope (left red-by-design, documented above)

SSR/head (rf2-acjknb), trace/marks/`elide-wire-value` wire-egress (rf2-gjq3ow), Xray/Story/pair + Story testbeds (rf2-bd4div), conformance (rf2-9o48ih), root/view/adapter test fixtures (rf2-69r7ui).