### PR TITLE
fix(examples): helix narrow-viewport layout + reagent Story/schema drift (rf2-civdws rf2-t5ky67)

### DIFF
--- a/examples/helix/README.md
+++ b/examples/helix/README.md
@@ -30,7 +30,7 @@ Per Decision 4 the `reg-view` macro stays Reagent-only; Helix users write `defnc
   Same login state machine (`:idle -> :submitting -> :authed`/`:error-shown`/`:locked-out`), same Malli schemas, same `:auth.login.demo/managed-stub` stub fx as the Reagent and UIx login examples. The view layer is a Helix `defnc` form using `helix.hooks/use-state` for local input state. Entering credentials and submitting drives the machine to `:authed` and the welcome banner appears.
 
 - **`helix/process_monitor_helix/`** ([build id `examples/process-monitor-helix`](../../implementation/shadow-cljs.edn))
-  Design-led example proving Helix can drive a substantive multi-pane layout. Shares the `_shared/css/style.css` "Editorial Warm" identity with the Reagent notebook and UIx dashboard counterparts. No state machines, no HTTP — design-led examples exist to prove polished visuals + interaction, not to replay platform features other examples already cover.
+  Design-led example proving Helix can drive a substantive multi-pane layout. Shares the `_shared/css/style.css` "Editorial Warm" identity with the Reagent notebook and UIx dashboard counterparts. The desktop layout is the canonical two-pane shell (process pane + log pane); narrow viewports get a responsive path (stacked panes ≤900px, wrapping summary tiles and collapsed row/log tracks ≤560px) so the declared `width=device-width` viewport renders without horizontal overflow on phones and tablets. No state machines, no HTTP — design-led examples exist to prove polished visuals + interaction, not to replay platform features other examples already cover.
 
 ## Testing
 

--- a/examples/helix/process_monitor_helix/index.html
+++ b/examples/helix/process_monitor_helix/index.html
@@ -188,6 +188,72 @@
     .pm-log-level-warn  { color: var(--hx-amber); }
     .pm-log-level-error { color: var(--hx-red); }
     .pm-log-msg { color: var(--hx-ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+    /* ── Responsive layout ──────────────────────────────────────────────
+       The desktop composition above is the canonical two-pane shell. The
+       breakpoints below give the design-led example a usable narrow-viewport
+       path so it never produces document-level horizontal overflow at
+       phone / tablet widths (rf2-civdws). Everything stays within the
+       element box: panes stack, tiles wrap, and the fixed desktop row/log
+       tracks collapse to auto-fit content rather than reserving fixed px. */
+
+    /* Tablet and below: drop the two-column shell to a single stacked
+       column so the minmax(380px, …) left pane no longer forces a floor
+       wider than a narrow viewport. The right (log) pane moves below the
+       process pane; the divider becomes a bottom rule. */
+    @media (max-width: 900px) {
+      .pm-grid {
+        grid-template-columns: 1fr;
+        grid-auto-rows: minmax(0, auto);
+      }
+      .pm-pane {
+        border-right: 0;
+        border-bottom: 1px solid var(--hx-rule-strong);
+      }
+      .pm-pane:last-child { border-bottom: 0; }
+      /* Give each scroll pane a bounded height once stacked so neither
+         pane monopolises the viewport. */
+      .pm-list, .pm-loglist { max-height: 48vh; }
+    }
+
+    /* Narrow phones: wrap the summary tiles to as many equal columns as
+         fit (min 8.5em each) instead of forcing five, tighten the shell-head
+         padding, and collapse the fixed process/log row tracks so the
+         flexible name/message column absorbs the remaining width. */
+    @media (max-width: 560px) {
+      .pm-shell-head { padding: 1.1em 1em 0.9em; }
+      .pm-tiles {
+        grid-template-columns: repeat(auto-fit, minmax(8.5em, 1fr));
+      }
+      .pm-pane-head { padding: 0.8em 1em; flex-wrap: wrap; gap: 0.5em; }
+      .pm-row, .pm-log { padding-left: 1em; padding-right: 1em; }
+      /* Process rows: explicit two-row template so the six DOM children
+         (dot, name, pid, meter, cpu, mem) place deterministically. Row 1
+         carries dot + name + pid + cpu + mem; the meter spans the full
+         width on row 2. No fixed px tracks remain, so nothing forces the
+         row wider than its container. */
+      .pm-row {
+        grid-template-columns: 12px minmax(0, 1fr) auto auto auto;
+        grid-template-areas:
+          "dot name pid cpu mem"
+          "meter meter meter meter meter";
+        column-gap: 8px;
+        row-gap: 6px;
+      }
+      .pm-row > .pm-dot      { grid-area: dot; }
+      .pm-row > .pm-row-name { grid-area: name; }
+      .pm-row > .pm-row-pid  { grid-area: pid; }
+      .pm-row > .pm-row-meter{ grid-area: meter; }
+      .pm-row > .pm-row-cpu  { grid-area: cpu; }
+      .pm-row > .pm-row-mem  { grid-area: mem; }
+      /* Log rows: tick + level + message; the pid is dropped on narrow
+         widths and the message keeps the flexible track. */
+      .pm-log {
+        grid-template-columns: auto auto minmax(0, 1fr);
+        column-gap: 8px;
+      }
+      .pm-log-pid { display: none; }
+    }
   </style>
 </head>
 <body>

--- a/examples/reagent/boot/README.md
+++ b/examples/reagent/boot/README.md
@@ -108,7 +108,7 @@ which drives this example's production source and runs under
 core.cljs               — mount + boot trigger + demo HTTP stubs
 boot.cljs               — :app/boot machine + :boot/loader child machine
 views.cljs              — boot-progress + main-app + failure views
-schema.cljs             — Malli schemas (BootSnapshot, Config, Flags, ...)
+schema.cljs             — Malli schemas (BootData, LoaderData, Config, Flags, ...)
 index.html
 ```
 

--- a/examples/reagent/boot/boot.cljs
+++ b/examples/reagent/boot/boot.cljs
@@ -205,6 +205,13 @@
 
 (rf/reg-machine :app/boot
   {:initial :configuring
+   ;; Validates the `:app/boot` snapshot's `:data` slot at the
+   ;; `:where :machine-data` boundary (Spec 010 §Machine data schema +
+   ;; Spec 005 §Schema validation). `BootData` describes `:data` only —
+   ;; the singleton's snapshot is runtime-db, so its `:data-schema` (not
+   ;; an `reg-app-schema`) is the snapshot-validation surface, symmetric
+   ;; with the `:boot/loader` child above.
+   :data-schema schema/BootData
    :data    {:phase  :configuring
              :config nil
              :flags  nil

--- a/examples/reagent/boot/schema.cljs
+++ b/examples/reagent/boot/schema.cljs
@@ -8,20 +8,25 @@
    schemas describe the wire shape returned by each mocked endpoint,
    the boot-machine snapshot itself, and the child loader's `:data`.
 
-   Two attachment mechanisms appear here, picked by how the runtime
-   addresses each snapshot:
+   Two schema surfaces appear here, picked by what each schema validates
+   (Spec 010 §Machine data schema + Spec 005 §Schema validation):
 
-   - The singleton `:app/boot` machine, the `[:boot/staging]` slot, and
-     the four top-level slices live at fixed app-db paths, so they are
-     attached with `rf/reg-app-schema` on those paths.
-   - The `:boot/loader` child is spawned (once per asset) and gets a
-     gensym'd id (e.g. `:boot/loader#0`), so its snapshot lives at an
-     unknown per-instance path no fixed `reg-app-schema` can reach.
-     `LoaderData` is therefore attached via the child machine's
-     `:data-schema` slot on `reg-machine` (see `boot.cljs`), which validates
-     each spawned instance's initial `:data` at spawn time, before the
-     snapshot installs (Spec 005 §Schema validation §Spawn-time
-     validation)."
+   - **App-db slices** — the `[:boot/staging]` slot and the four
+     top-level slices (`[:config]`, `[:flags]`, `[:user]`, `[:routes]`)
+     live at fixed app-db paths, so they are attached with
+     `rf/reg-app-schema` on those paths; app schemas validate the app-db
+     partition ONLY.
+   - **Machine `:data`** — both the singleton `:app/boot` machine and the
+     spawned `:boot/loader` child declare a top-level `:data-schema` on
+     `reg-machine` (see `boot.cljs`) that validates the snapshot's `:data`
+     slot at the `:where :machine-data` boundary. `BootData` describes the
+     `:app/boot` machine's `:data`; `LoaderData` describes each spawned
+     loader's `:data` (validated at spawn time, before the snapshot
+     installs — Spec 005 §Schema validation §Spawn-time validation —
+     since a spawned loader's gensym'd id, e.g. `:boot/loader#0`, lives at
+     a per-instance path no fixed `reg-app-schema` could reach). Machine
+     snapshots are runtime-db, not app-db, so `reg-app-schema` is NOT the
+     surface for them."
   (:require [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
@@ -77,24 +82,31 @@
     [:path :string]]])
 
 ;; ============================================================================
-;; BOOT-MACHINE SNAPSHOT
+;; BOOT-MACHINE :data SHAPE — :app/boot
 ;; ============================================================================
 ;;
-;; The boot machine lives in runtime-db at [:rf.runtime/machines :snapshots :app/boot]. Its `:state`
-;; cycles `:configuring → :loading-deps → :hydrating → :ready`
-;; (terminal), with `:failed` (terminal) reached if any child errors.
-;; `:data` carries the per-phase progress slot and the loaded payloads.
+;; The boot machine lives in runtime-db at
+;; [:rf.runtime/machines :snapshots :app/boot]. Its `:state` cycles
+;; `:configuring → :loading-deps → :hydrating → :ready` (terminal), with
+;; `:failed` (terminal) reached if any child errors. `:data` carries the
+;; per-phase progress slot and the loaded payloads.
+;;
+;; `BootData` describes the `:data` SLOT only (Spec 010 §Machine data
+;; schema — the machine `:data-schema` validates `:data`, not the whole
+;; `{:state … :data …}` snapshot and not an app-db path). It is attached
+;; via the `:app/boot` machine's top-level `:data-schema` on `reg-machine`
+;; (see `boot.cljs`) and validates at the `:where :machine-data` boundary.
+;; Every payload slot is `:maybe` because they are nil through the
+;; staging/loading phases and only fill on entering `:hydrating`.
 
-(def BootSnapshot
+(def BootData
   [:map
-   [:state [:enum :configuring :loading-deps :hydrating :ready :failed]]
-   [:data  [:map
-            [:phase  [:maybe :keyword]]
-            [:config [:maybe Config]]
-            [:flags  [:maybe Flags]]
-            [:user   [:maybe User]]
-            [:routes [:maybe Routes]]
-            [:error  [:maybe :any]]]]])
+   [:phase  [:maybe :keyword]]
+   [:config [:maybe Config]]
+   [:flags  [:maybe Flags]]
+   [:user   [:maybe User]]
+   [:routes [:maybe Routes]]
+   [:error  [:maybe :any]]])
 
 ;; ============================================================================
 ;; CHILD LOADER :data SHAPE — :boot/loader (one instance per asset)
@@ -158,8 +170,10 @@
 ;; EP-0001 (rf2-vzld77): machine snapshots are runtime-db state, not app-db —
 ;; an `reg-app-schema` on a machine-snapshot path validates nothing (app
 ;; schemas validate the app-db partition only, Mike ruling #11). The
-;; machine's own `:data-schema` is the snapshot-validation surface, so the
-;; vestigial app-schema reg is removed.
+;; `:app/boot` machine's own `:data-schema schema/BootData` (attached on
+;; `reg-machine` in boot.cljs) is the snapshot-`:data` validation surface,
+;; so no app-schema reg applies to the boot machine snapshot. The
+;; `reg-app-schema` calls below validate only the app-db slices.
 
 ;; The :spawn-all children stage their payloads into [:boot/staging]
 ;; before signalling completion to the parent. The :enter-hydrating

--- a/examples/reagent/login/README.md
+++ b/examples/reagent/login/README.md
@@ -15,10 +15,13 @@ in one file, kept compact for AI-readability.
   snapshot lives in runtime-db at `[:rf.runtime/machines :snapshots
   :auth.login/flow]`, read via `sub-machine`. States: `:idle →
   :submitting → {:error-shown | :authed | :locked-out}`.
-- **CP-8 schema attachment** — Malli schema for the machine snapshot's
-  `:data`, attached via the machine's `:data-schema` slot. (Machine
-  snapshots are runtime-db, not app-db, so `reg-app-schema` — which
-  validates the app-db partition only — is not the surface for them.)
+- **CP-8 schema attachment** — `AuthLoginData`, a Malli schema for the
+  machine snapshot's `:data` SLOT (the `:attempts` + `:error` map — not
+  the whole `{:state … :data …}` snapshot), attached via the machine's
+  top-level `:data-schema` slot on `make-machine-handler`. It validates
+  at the `:where :machine-data` boundary. (Machine snapshots are
+  runtime-db, not app-db, so `reg-app-schema` — which validates the
+  app-db partition only — is not the surface for them.)
 - **CP-1 + CP-2** — pure `reg-event-db` handlers and pure `reg-sub`
   derivations off the machine snapshot.
 - **CP-3 registered fx** — `:rf.http/managed` (Spec 014) plus

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -134,20 +134,25 @@
    [:? :any]])
 
 ;; The login flow's runtime state lives in the machine snapshot at
-;; [:rf.runtime/machines :snapshots :auth.login/flow] (per [005 §Where snapshots live]).
-;; The snapshot shape is {:state <kw> :data <map>} per Spec 005.
-(def AuthLoginSnapshot
+;; [:rf.runtime/machines :snapshots :auth.login/flow] (runtime-db, NOT
+;; app-db — per [005 §Where snapshots live]). Per Spec 010 §Machine data
+;; schema + Spec 005 §Schema validation, a machine declares a top-level
+;; `:data-schema` that validates the snapshot's `:data` SLOT only — not
+;; the whole `{:state … :data …}` snapshot, and not an app-db path. So
+;; this schema describes the `:data` map (`:attempts` + `:error`) the
+;; machine seeds and the actions evolve; it is attached via the machine's
+;; `:data-schema` slot on the `make-machine-handler` spec below and
+;; validates at the `:where :machine-data` boundary.
+(def AuthLoginData
   [:map
-   [:state [:enum :idle :submitting :error-shown :authed :locked-out]]
-   [:data  [:map
-            [:attempts {:default 0} :int]
-            [:error    [:maybe :string]]]]])
+   [:attempts {:default 0} :int]
+   [:error    [:maybe :string]]])
 
 ;; EP-0001 (rf2-vzld77): machine snapshots are runtime-db state, not app-db —
 ;; an `reg-app-schema` on a machine-snapshot path validates nothing (app
 ;; schemas validate the app-db partition only, Mike ruling #11). The
-;; machine's own `:data-schema` is the snapshot-validation surface, so the
-;; vestigial app-schema reg is removed.
+;; machine's own `:data-schema` (attached below) is the snapshot-validation
+;; surface, so no app-schema reg applies to the login snapshot.
 
 ;; ============================================================================
 ;; FX  (Spec 014 + per-app demo stub)
@@ -230,14 +235,23 @@
 ;; maps and are referenced by keyword from the transition table; resolution
 ;; is machine-local (no global registry).
 
-(rf/reg-event-fx :auth.login/flow
-  {:doc    "Login flow: idle → submitting → authed / error-shown / locked-out."
-   :schema AuthLoginEvent}
-  (rf/make-machine-handler
-    ;; Per Spec 005 §Where snapshots live: the spec map does NOT carry
-    ;; :id; the machine's id is the surrounding reg-event-fx id.
-    {:initial :idle
-     :data    {:attempts 0 :error nil}
+;; The login flow's machine spec. Bound to a `def` (rather than inlined into
+;; `reg-event-fx`) so the SAME spec value can be both built into the handler
+;; AND stamped onto the registration metadata as `:rf/machine` — see the
+;; registration note below.
+(def auth-login-machine
+  ;; Per Spec 005 §Where snapshots live: the spec map does NOT carry :id;
+  ;; the machine's id is the surrounding registration id.
+  {:initial :idle
+   ;; Spec 010 §Machine data schema — `:data-schema` validates the
+   ;; snapshot's `:data` slot (not the whole snapshot) at the
+   ;; `:where :machine-data` boundary. The macrostep walker resolves it
+   ;; via `(machine-meta :auth.login/flow)`, so the registration below
+   ;; MUST stamp `:rf/machine?` / `:rf/machine` for this to validate.
+   ;; Malformed `:data` (e.g. a non-string `:error`) fails the run with
+   ;; `:rf.error/schema-validation-failure :where :machine-data`.
+   :data-schema AuthLoginData
+   :data    {:attempts 0 :error nil}
 
      :guards
      {:under-retry-limit
@@ -322,7 +336,27 @@
       ;; terminal lockout must be visible and non-interactive, not a live
       ;; form (rf2-q6bm7d).
       {:tags #{:auth/locked}
-       :meta {:terminal? true}}}}))
+       :meta {:terminal? true}}}})
+
+;; Register the machine as the `:auth.login/flow` event handler.
+;;
+;; This machine ALSO validates its dispatched event VECTOR (against
+;; `AuthLoginEvent`), so it can't use the bare `(reg-machine :id spec)`
+;; macro — that surface takes no event `:schema`. Instead we register via
+;; `reg-event-fx` with the machine handler and stamp the SAME metadata
+;; `reg-machine` would (`:rf/machine? true` + `:rf/machine spec`) alongside
+;; the event `:schema`. The `:rf/machine?` / `:rf/machine` keys are what
+;; `(machine-meta :auth.login/flow)` reads, and the `:where :machine-data`
+;; macrostep walker resolves the `:data-schema` THROUGH that metadata — so
+;; without these keys the `:data-schema` above would never validate (it
+;; would be dead documentation). This is the documented "machine + event-
+;; vector schema" idiom (the login / realworld auth shape).
+(rf/reg-event-fx :auth.login/flow
+  {:doc        "Login flow: idle → submitting → authed / error-shown / locked-out."
+   :schema     AuthLoginEvent
+   :rf/machine? true
+   :rf/machine  auth-login-machine}
+  (rf/make-machine-handler auth-login-machine))
 
 ;; ============================================================================
 ;; EVENTS  (CP-1)

--- a/examples/reagent/nine_states/stories.cljs
+++ b/examples/reagent/nine_states/stories.cljs
@@ -56,9 +56,15 @@
    ## Xray-richness — the managed-HTTP cascade
 
    Story allocates each variant its own frame under `:preset :story`
-   (spec/002 §Frame presets), which redirects `:rf.http/managed` to
-   the framework-shipped `:rf.http/managed-canned-success` /
-   `-canned-failure` stubs. `:nine-states.story/load` issues a real
+   (spec/002 §Frame presets). The preset's contract is a SUCCESS stub
+   by DEFAULT: it redirects `:rf.http/managed` to the framework-shipped
+   `:rf.http/managed-canned-success` stub only (frame.cljc
+   `preset-expansion` — there is no automatic canned-failure branch).
+   A variant that wants the FAILURE path stamps its own
+   `:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}`,
+   which wins over the preset default (the variant-owned `:fx-overrides`
+   replaces the preset's in the frame-config merge — see the lifecycle
+   `…/error` variant below). `:nine-states.story/load` issues a real
    `:rf.http/managed` request carrying the synthetic todos on the
    request's `:value` slot (the slot the canned-success stub echoes
    back), so the FULL fetch lifecycle runs:
@@ -135,18 +141,31 @@
 
 (rf/reg-event-fx :nine-states.story/load-failing
   {:doc "Story-shell variant of `:nine-states.demo/load-with-failure`.
-         Drives the real fetch cascade into the `:error` branch — the
-         `:rf.http/managed` request carries no `:value` and routes
-         through the `:preset :story` frame's canned-FAILURE stub by
-         declaring `:on-failure` against a request the stub cannot
-         satisfy, so `:fetch-failed` fires and the `:data` region
-         lands at `:error`."}
+         Drives the same real fetch cascade — `:fetch-started` →
+         `:rf.http/managed` → reply → `:fetch-failed` — into the
+         `:error` branch.
+
+         The `:story` preset's default fx-override routes
+         `:rf.http/managed` to the canned-SUCCESS stub (frame.cljc
+         `preset-expansion`), which would take the `:on-success` path.
+         The error VARIANT therefore stamps its own
+         `:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}`
+         (a variant-owned `:fx-overrides` wins over the preset's via the
+         frame-config merge in `expand-preset`), so this same event runs
+         against the canned-FAILURE stub instead — that stub reads the
+         top-level `:kind`/`:tags` slots below, synthesises a failure
+         reply, and dispatches `:on-failure`, landing the `:data` region
+         at `:error`."}
   (fn handler-story-load-failing [_ _]
     {:fx [[:dispatch [:ui/nine-states [:fetch-started]]]
           [:rf.http/managed
+           ;; `:kind`/`:tags` are the slots `emit-canned-failure!` reads
+           ;; (NOT a nested `:failure` map — the stub ignores that), so
+           ;; the synthesised failure carries this category through to
+           ;; `:nine-states.demo/load-failed`.
            {:request    {:method :get :url "/api/todos/fail"}
-            :failure    {:kind :rf.http/transport
-                         :message "Network unreachable."}
+            :kind       :rf.http/transport
+            :tags       {:message "Network unreachable."}
             :decode     :json
             :on-success [:nine-states.demo/loaded]
             :on-failure [:nine-states.demo/load-failed]}]]}))
@@ -327,14 +346,24 @@
      :substrates #{:reagent}})
 
   (story/reg-variant :story.nine-states-lifecycle/error
-    {:doc        "Lifecycle — the `:error` branch. The `:rf.http/managed`
-                 request fails; `:fetch-failed` lands the `:data` region
-                 at `:error`. The failure cascade lights up Xray's Side
-                 Effects + Trace panels alongside the success path."
-     :setup      [[:nine-states.app/initialise]
-                  [:nine-states.story/load-failing]]
-     :tags       #{:dev :docs}
-     :substrates #{:reagent}})
+    {:doc           "Lifecycle — the `:error` branch. This variant stamps
+                    `:fx-overrides {:rf.http/managed
+                    :rf.http/managed-canned-failure}` so its
+                    `:rf.http/managed` request runs through the canned-
+                    FAILURE stub (overriding the `:story` preset's
+                    canned-success default); `:fetch-failed` then lands
+                    the `:data` region at `:error`. The failure cascade
+                    lights up Xray's Side Effects + Trace panels
+                    alongside the success path."
+     ;; Variant-owned `:fx-overrides` win over the `:story` preset's
+     ;; canned-success default (frame-config merge in `expand-preset`),
+     ;; so this is the explicit failure-fx-override the failing variant
+     ;; needs — the success variants keep the preset's canned-success.
+     :fx-overrides  {:rf.http/managed :rf.http/managed-canned-failure}
+     :setup         [[:nine-states.app/initialise]
+                     [:nine-states.story/load-failing]]
+     :tags          #{:dev :docs}
+     :substrates    #{:reagent}})
 
   ;; -------------------------------------------------------------------------
   ;; reg-workspace — two layouts over the canonical nine.

--- a/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
@@ -34,11 +34,18 @@
      - boot-failure-path          — a failure during the parallel
        phase routes the boot to :failed and records the error in
        :data."
-  (:require [cljs.test :refer-macros [deftest testing use-fixtures]]
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
+            ;; The schemas Malli adapter publishes the registered validator
+            ;; the `:where :machine-data` boundary routes through; boot.core
+            ;; pulls it transitively (via boot.schema), require explicitly so
+            ;; this ns is self-sufficient.
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.malli]
+            [boot.schema :as boot-schema]
             [re-frame.views]
             ;; The canned-stub helpers below resolve
             ;; :rf.http/managed-canned-success / failure via registrar
@@ -204,3 +211,106 @@
         (let [err (rf/compute-sub [:app.boot/error] db)]
           (assert (some? err)
                   "expected :app.boot/error to be populated on the failure path"))))))
+
+;; ============================================================================
+;; MACHINE :data SCHEMA BOUNDARY  (rf2-t5ky67 issue 2)
+;; ============================================================================
+;;
+;; The singleton `:app/boot` machine attaches a top-level `:data-schema`
+;; (`boot.schema/BootData`) that validates the snapshot's `:data` slot at the
+;; `:where :machine-data` boundary (Spec 010 §Machine data schema). These
+;; tests prove the schema is attached, rejects malformed `:data`, fires the
+;; boundary trace + rolls back on a real violating macrostep, and that the
+;; app-db slice schemas (`reg-app-schema [:config]` etc.) keep validating the
+;; app-db partition independently.
+
+(defn- collect-machine-data-traces!
+  "Run `thunk` while collecting `:rf.error/schema-validation-failure` traces
+   with `:where :machine-data`. Returns the captured (filtered) vector."
+  [thunk]
+  (let [traces (atom [])]
+    (rf/register-listener! ::collect (fn [ev] (swap! traces conj ev)))
+    (try (thunk)
+         (finally (rf/unregister-listener! ::collect)))
+    (filterv #(and (= :rf.error/schema-validation-failure (:operation %))
+                   (= :machine-data (-> % :tags :where)))
+             @traces)))
+
+(deftest boot-data-schema-attached
+  (testing "the :app/boot machine carries BootData on its :data-schema slot"
+    (let [meta (rf/machine-meta :app/boot)]
+      (is (some? meta) "machine-meta resolves the registered :app/boot machine")
+      (is (= boot-schema/BootData (:data-schema meta))
+          "the :data-schema round-trips as boot.schema/BootData")))
+  (testing "BootData validates the :data slot only (rejects a malformed :config)"
+    (is (true?  (schemas/validate-with-registered-fn
+                  boot-schema/BootData
+                  {:phase :configuring :config nil :flags nil
+                   :user nil :routes nil :error nil}))
+        "the initial all-nil :data conforms")
+    (is (true?  (schemas/validate-with-registered-fn
+                  boot-schema/BootData
+                  {:phase :hydrating :config test-config :flags nil
+                   :user nil :routes nil :error nil}))
+        "a well-formed promoted :config conforms")
+    (is (false? (schemas/validate-with-registered-fn
+                  boot-schema/BootData
+                  {:phase :loading-deps :config {:api-base "/api"} :flags nil
+                   :user nil :routes nil :error nil}))
+        "a :config missing required keys (:env/:build/:title) fails the data-slot schema")))
+
+(deftest boot-malformed-data-fails-boundary
+  (testing "a config child returning a malformed Config drives :promote-staged to write bad :data, failing the :machine-data boundary"
+    ;; canned-success returns a structurally-WRONG config (missing
+    ;; :env / :build / :title) for /config.json; the other URLs are
+    ;; never reached because the config macrostep fails first.
+    (reg-canned-success-by-url!
+      :boot.test/canned-bad-config
+      (fn [url]
+        (if (re-find #"/config\.json$" (str url))
+          {:api-base "/api"}     ;; missing :env :build :title → violates Config
+          {})))
+    (let [frame  (atom nil)
+          traces (collect-machine-data-traces!
+                   #(reset! frame
+                      (rf/make-frame
+                        {:on-create    [:boot/initialise]
+                         :fx-overrides {:rf.http/managed
+                                        :boot.test/canned-bad-config}})))]
+      (try
+        (is (<= 1 (count traces))
+            "at least one :where :machine-data trace fires when the boot machine's :data goes malformed")
+        (is (some #(= :app/boot (-> % :tags :machine-id)) traces)
+            "a trace names the :app/boot machine")
+        ;; `:recovery` rides the trace ENVELOPE, not :tags (rf2-twt7m) —
+        ;; mirrors the :where :app-db projection.
+        (let [boot-trace (some #(when (= :app/boot (-> % :tags :machine-id)) %) traces)]
+          (is (= :no-recovery (:recovery boot-trace))))
+        (finally (when @frame (rf/destroy-frame! @frame))))))
+
+  (testing "the app-db slice schema validates the app-db partition independently of the machine :data boundary"
+    ;; The example registers `[:config] [:maybe Config]` as an APP schema
+    ;; (validates the app-db partition only). App schemas are frame-scoped,
+    ;; so register the example's own `Config` on this test frame, then write
+    ;; a structurally-wrong slice: the post-commit app-db validator must
+    ;; reject it at `:where :app-db` — a DIFFERENT boundary from the
+    ;; machine `:data` one above, proving the two surfaces are distinct.
+    (let [app-traces (atom [])]
+      (rf/register-listener! ::app
+                             (fn [ev]
+                               (when (and (= :rf.error/schema-validation-failure (:operation ev))
+                                          (= :app-db (-> ev :tags :where)))
+                                 (swap! app-traces conj ev))))
+      (try
+        (with-new-frame [f (rf/make-frame {})]
+          (rf/reg-app-schema [:config] [:maybe boot-schema/Config] {:frame f})
+          (rf/dispatch-sync [::write-bad-config] {:frame f}))
+        (finally (rf/unregister-listener! ::app)))
+      (is (pos? (count @app-traces))
+          "a malformed [:config] app-db slice fails at :where :app-db (slice schema validates app-db only)"))))
+
+;; A tiny event used only by the test above to write a malformed [:config]
+;; app-db slice, so the app-db slice schema's :where :app-db boundary is
+;; exercised distinctly from the machine :data boundary.
+(rf/reg-event-db ::write-bad-config
+  (fn [db _] (assoc db :config {:api-base "/api"})))   ;; missing required Config keys

--- a/implementation/adapters/reagent/test/re_frame/login_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/login_cljs_test.cljs
@@ -1,0 +1,145 @@
+(ns re-frame.login-cljs-test
+  "Regression: the login example's `:auth.login/flow` machine attaches a
+   top-level `:data-schema` (`login.core/AuthLoginData`) that validates the
+   snapshot's `:data` slot at the `:where :machine-data` boundary
+   (rf2-t5ky67 issue 2 / Spec 010 §Machine data schema).
+
+   The fixture fns live HERE (the adapter test tree), not under
+   examples/reagent/login/ — the example source stays test-free per the
+   locked test-free-examples policy (rf2-8cevm). The ns requires the
+   example's production source (`login.core`) so its machine / events /
+   schemas register at ns-load, then exercises them directly.
+
+   Coverage:
+     - data-schema-attached         — `(machine-meta :auth.login/flow)`
+       carries `AuthLoginData`; the schema rejects malformed `:data`.
+     - malformed-data-fails-boundary — driving the machine so `:record-error`
+       writes a NON-string into `:error` (the schema requires
+       `[:maybe :string]`) emits exactly one
+       `:rf.error/schema-validation-failure :where :machine-data` trace and
+       rolls the snapshot back (the bad `:data` never sticks).
+     - well-formed-data-passes      — a normal failing login (string
+       message) settles without any `:where :machine-data` trace."
+  (:require [cljs.test :refer-macros [deftest testing use-fixtures is]]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; The schemas Malli adapter publishes the registered validator
+            ;; the `:where :machine-data` boundary routes through; login.core
+            ;; pulls it transitively, require here so the ns is self-sufficient.
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.malli]
+            ;; canned-failure stub (`:rf.http/managed-canned-failure`).
+            [re-frame.http-test-support]
+            [login.core])
+  (:require-macros [re-frame.core :refer [with-new-frame]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- machine-data [f]
+  (get-in (rf/frame-state-value f)
+          [:rf.db/runtime :rf.runtime/machines :snapshots :auth.login/flow :data]))
+
+(defn- collect-machine-data-traces!
+  "Run `f` while collecting `:rf.error/schema-validation-failure` traces with
+   `:where :machine-data`. Returns the captured (filtered) trace vector."
+  [thunk]
+  (let [traces (atom [])]
+    (rf/register-listener! ::collect (fn [ev] (swap! traces conj ev)))
+    (try (thunk)
+         (finally (rf/unregister-listener! ::collect)))
+    (filterv #(and (= :rf.error/schema-validation-failure (:operation %))
+                   (= :machine-data (-> % :tags :where)))
+             @traces)))
+
+(def ^:private valid-creds {:email "alice@example.com" :password "hunter2pw"})
+
+(defn- reg-sync-failure-override!
+  "Register a synchronous `:rf.http/managed` override delegating to the
+   framework canned-FAILURE stub with the given `:tags` (no `:after-ms`, so
+   the reply resolves inside the same drain)."
+  [fx-id tags]
+  (rf/reg-fx fx-id
+    {:platforms #{:client :server}}
+    (fn [frame-ctx args]
+      (let [stub (registrar/handler :fx :rf.http/managed-canned-failure)]
+        (stub frame-ctx (assoc args :kind :rf.http/http-4xx :tags tags))))))
+
+;; ---------------------------------------------------------------------------
+;; (1) attachment + schema rejects malformed :data
+;; ---------------------------------------------------------------------------
+
+(deftest data-schema-attached
+  (testing "the login machine carries AuthLoginData on its :data-schema slot"
+    (let [meta (rf/machine-meta :auth.login/flow)]
+      (is (some? meta) "machine-meta resolves the registered login machine")
+      (is (= login.core/AuthLoginData (:data-schema meta))
+          "the :data-schema round-trips as login.core/AuthLoginData")))
+  (testing "AuthLoginData validates the :data slot only (rejects a non-string :error)"
+    (is (true?  (schemas/validate-with-registered-fn login.core/AuthLoginData {:attempts 0 :error nil})))
+    (is (true?  (schemas/validate-with-registered-fn login.core/AuthLoginData {:attempts 1 :error "Login failed."})))
+    (is (false? (schemas/validate-with-registered-fn login.core/AuthLoginData {:attempts 0 :error {:not "a string"}}))
+        "a non-string :error fails the data-slot schema")
+    (is (false? (schemas/validate-with-registered-fn login.core/AuthLoginData {:attempts "x" :error nil}))
+        "a non-int :attempts fails the data-slot schema")))
+
+;; ---------------------------------------------------------------------------
+;; (2) malformed machine :data fails at :where :machine-data + rolls back
+;; ---------------------------------------------------------------------------
+
+(deftest malformed-data-fails-boundary
+  (testing "a failure reply whose message is non-string drives :record-error to write a bad :error, failing the :machine-data boundary and rolling back"
+    (reg-sync-failure-override! :login.test/canned-bad-message
+                                {:status 401 :message {:not "a string"}})
+    (with-new-frame [f (rf/make-frame
+                         {:fx-overrides {:rf.http/managed
+                                         :login.test/canned-bad-message}})]
+      ;; A valid submit drives :idle → :submitting and fires :issue-request;
+      ;; the synchronous canned-failure reply dispatches :auth.login/failure
+      ;; whose :record-error action writes the non-string message into
+      ;; :error — which AuthLoginData's [:maybe :string] rejects.
+      (let [traces   (collect-machine-data-traces!
+                       #(rf/dispatch-sync
+                          [:auth.login/flow [:auth.login/submit valid-creds]]
+                          {:frame f}))
+            trace-ev (first traces)
+            tag      (:tags trace-ev)]
+        (is (= 1 (count traces))
+            "exactly one :where :machine-data trace fired on the violating macrostep")
+        (is (= :auth.login/flow (:machine-id tag))
+            "the trace names the login machine")
+        ;; `:recovery` rides the trace ENVELOPE, not :tags (rf2-twt7m).
+        (is (= :no-recovery (:recovery trace-ev)))
+        ;; Rollback: the bad :data never sticks. The snapshot's :error must
+        ;; NOT be the rejected map.
+        (is (not= {:not "a string"} (:error (machine-data f)))
+            "the violating :data was rolled back (the bad :error did not commit)")))))
+
+;; ---------------------------------------------------------------------------
+;; (3) well-formed :data passes the boundary cleanly
+;; ---------------------------------------------------------------------------
+
+(deftest well-formed-data-passes
+  (testing "a normal failing login (string message) settles with no :machine-data trace"
+    (reg-sync-failure-override! :login.test/canned-ok-message
+                                {:status 401 :message "Invalid credentials."})
+    (with-new-frame [f (rf/make-frame
+                         {:fx-overrides {:rf.http/managed
+                                         :login.test/canned-ok-message}})]
+      (let [traces (collect-machine-data-traces!
+                     #(rf/dispatch-sync
+                        [:auth.login/flow [:auth.login/submit valid-creds]]
+                        {:frame f}))]
+        (is (zero? (count traces))
+            "no :where :machine-data trace for a well-formed (string) :error")
+        (is (= "Invalid credentials." (:error (machine-data f)))
+            "the string failure message committed into the machine's :data")
+        (is (= 1 (:attempts (machine-data f)))
+            "the attempt counter advanced (the transition committed)")))))

--- a/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
@@ -28,7 +28,22 @@
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.views]
-            [nine-states.core])
+            ;; `re-frame.http-test-support` registers
+            ;; `:rf.http/managed-canned-failure` — the fx the failing Story
+            ;; variant routes `:rf.http/managed` to. nine-states.core
+            ;; already pulls it transitively, but require it here so this
+            ;; ns is self-sufficient.
+            [re-frame.http-test-support]
+            [nine-states.core]
+            ;; Requiring the example's Story file brings
+            ;; `:nine-states.story/load-failing` (the variant's setup
+            ;; event) into the registry. The story-failure-variant test
+            ;; below exercises the SAME mechanism the
+            ;; `:story.nine-states-lifecycle/error` variant uses — the
+            ;; canned-FAILURE fx-override plus that load event — and
+            ;; asserts the resulting frame computes `[:ui/render]` as
+            ;; `:error`.
+            [nine-states.stories])
   (:require-macros [re-frame.core :refer [with-new-frame]]))
 
 (use-fixtures :each
@@ -152,3 +167,67 @@
     (test-state-8-correct))
   (testing "state 9 — done (terminal, read-only)"
     (test-state-9-done)))
+
+;; ----------------------------------------------------------------------------
+;; STORY LIFECYCLE — :error variant
+;;
+;; The `:story.nine-states-lifecycle/error` variant in
+;; examples/reagent/nine_states/stories.cljs stamps
+;; `:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}` so
+;; its `[:nine-states.story/load-failing]` setup runs against the canned-
+;; FAILURE stub (overriding the `:story` preset's canned-success default).
+;; This regression pins that the failing variant actually takes the error
+;; branch: a frame carrying the SAME failure override, running the SAME
+;; load-failing event, must land the `:data` region at `:error` (tag
+;; `:data/error`) and compute `[:ui/render]` as `:error` — NOT settle on a
+;; loaded/empty success state, which is the bug rf2-t5ky67 caught.
+;; ----------------------------------------------------------------------------
+
+(def ^:private story-failure-overrides
+  "The exact `:fx-overrides` the lifecycle `:error` variant stamps — routes
+   `:rf.http/managed` to the framework canned-FAILURE stub."
+  {:rf.http/managed :rf.http/managed-canned-failure})
+
+(deftest story-lifecycle-error-variant-takes-failure-path
+  (testing "the failing Story variant's mechanism lands :data at :error and renders :error"
+    ;; Sanity: requiring nine-states.stories registered the variant's
+    ;; setup event.
+    (is (some? (rf/handler-meta :event :nine-states.story/load-failing))
+        ":nine-states.story/load-failing registered (stories.cljs required)")
+    (with-new-frame [f (rf/make-frame
+                         {:on-create    [:nine-states.app/initialise]
+                          :fx-overrides story-failure-overrides})]
+      ;; Drive the variant's setup load event. The canned-failure stub
+      ;; resolves synchronously (no :after-ms), dispatching :on-failure →
+      ;; :nine-states.demo/load-failed → :fetch-failed → :data/:error.
+      (rf/dispatch-sync [:nine-states.story/load-failing] {:frame f})
+      (is       (machine-has-tag? f :data/error)
+                "the :data region reaches the :error state (tag :data/error)")
+      (is (not  (machine-has-tag? f :data/some))
+                "it did NOT settle on a success/loaded cardinality bucket")
+      (is (=    :error (render-model f))
+          "[:ui/render] resolves to :error under the machine snapshot")
+      ;; The failure category threaded through to the snapshot's :data.
+      (let [err (rf/compute-sub [:todos/error] (rf/frame-state-value f))]
+        (is (some? err)
+            "the failure value is recorded in the machine's :data :error slot")))))
+
+(deftest story-lifecycle-success-variant-stays-on-success-path
+  (testing "the loaded variant's success-stub mechanism still proves the canned-success cascade"
+    ;; Mirror the `:story` preset's DEFAULT: route `:rf.http/managed` to
+    ;; the canned-SUCCESS stub (which echoes the request's `:value` slot),
+    ;; exactly as the `:story.nine-states-lifecycle/loaded` variant does
+    ;; with no per-variant override. Guards that success and failure stay
+    ;; SEPARATELY represented (acceptance: keep the success lifecycle
+    ;; variant proving canned-success).
+    (with-new-frame [f (rf/make-frame
+                         {:on-create    [:nine-states.app/initialise]
+                          :fx-overrides {:rf.http/managed
+                                         :rf.http/managed-canned-success}})]
+      ;; `:nine-states.story/load` carries the synthetic todos on `:value`
+      ;; (the slot canned-success echoes), so 4 items land the :data
+      ;; region at :some via the :always-cascade.
+      (rf/dispatch-sync [:nine-states.story/load {:n 4}] {:frame f})
+      (is       (machine-has-tag? f :data/some))
+      (is (not  (machine-has-tag? f :data/error)))
+      (is (=    :some (render-model f))))))


### PR DESCRIPTION
Fixes two examples beads in disjoint dirs (examples/helix + examples/reagent).

## rf2-civdws — helix process-monitor narrow-viewport layout (P3)
Added a responsive layout path to process_monitor_helix/index.html: tablet and below (<=900px) stack the two-pane shell to one column with bounded scroll panes; narrow phones (<=560px) wrap the summary tiles to auto-fit columns, tighten shell-head padding, and collapse the fixed process/log row tracks (explicit grid-template-areas; the cpu/mem columns auto-size, the meter spans a second row, the log pid is hidden). Desktop two-pane composition unchanged. README updated to describe the responsive path.

Verified with headless Chromium against a faithful DOM+CSS harness: pre-fix 320px overflowed by +324px and 375px by +272px; post-fix documentElement.scrollWidth == clientWidth at 320 / 375 / 768 / 1280px.

## rf2-t5ky67 — reagent Story failure variant + machine-schema drift (P2)
Issue 1 (Story error variant): the :story preset only auto-routes :rf.http/managed to canned-SUCCESS, so the lifecycle :error variant previously resolved through the success path. The variant now stamps its own :fx-overrides {:rf.http/managed :rf.http/managed-canned-failure} (variant-owned wins over the preset in the frame-config merge), and load-failing now carries the top-level :kind/:tags the canned-failure stub actually reads. Story prose corrected to the success-by-default / failure-requires-override contract. Success lifecycle variant still proves canned-success separately.

Issue 2 (machine :data-schema): renamed the dead full-snapshot schemas to data-slot schemas (AuthLoginData, BootData) and attached them via :data-schema on the login and :app/boot machines. The login machine uses the direct reg-event-fx + make-machine-handler form (it needs an event-vector :schema, which reg-machine does not take); that form does not stamp machine-meta, so its :data-schema was inert — now it stamps :rf/machine?/:rf/machine so the :where :machine-data walker validates it. Stale app-db/app-schema prose rewritten in login core/README and boot schema/README.

Coverage lives in the framework adapter test tree (examples stay test-free per rf2-8cevm): nine-states error/success variant tests assert [:ui/render] :error vs :some; new login_cljs_test + boot machine-data tests prove malformed machine :data fails at :where :machine-data while app-db slice schemas validate the app-db partition independently.

Follow-up rf2-genufr filed: the same inert-:data-schema pattern affects helix/uix login and realworld auth (the direct-registration form's :data-schema never validates) — needs a framework decision.

## Quality gates
- npm run test:cljs (node-test): 6104 tests, 21758 assertions, 0 failures, 0 errors (includes the new nine-states/login/boot coverage)
- examples-compile: all 39 example builds compiled, 0 warnings
- python scripts/check_doc_slugs.py: pass
- python scripts/check_readme_links.py: pass
- Layout fix verified via headless-Chromium overflow probe at 320/375/768/1280px (negative control confirmed pre-fix overflow)