### PR TITLE
fix(ssr-ring): facade :doc/:arglists metadata + writer-failed phase context + test consolidation (rf2-l1qgjw)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -103,17 +103,50 @@
 
 ;; ---- public-surface re-exports --------------------------------------------
 ;;
-;; `def`s expose the sub-namespace fns at `re-frame.ssr.ring/<name>` so
-;; consumers see the same surface they did pre-split.
+;; The façade re-exposes sub-namespace fns at `re-frame.ssr.ring/<name>`
+;; so consumers see the same surface they did pre-split (rf2-pjsrc /
+;; rf2-zkca8.1). A plain `(def alias other-ns/fn)` copies the VALUE but
+;; NOT the var metadata, so REPL `doc`, editor hover, completion, and the
+;; JVM-introspected api-manifest all saw EMPTY docs + nil arglists at the
+;; very namespace users are told to require (rf2-l1qgjw issue 1). The
+;; `import-fn` macro below re-points the alias AND copies the source var's
+;; authored `:doc` / `:arglists` onto the façade var, so the canonical
+;; function contract surfaces at the façade boundary. `:added` /
+;; `:deprecated` ride along when present (forward-compatible); `:line` /
+;; `:file` are deliberately NOT copied (they point at the implementation
+;; ns, which is the correct source-navigation target — the façade docs
+;; name the sub-namespace for deeper detail).
 
-(def cookie->set-cookie-header cookie/cookie->set-cookie-header)
-(def default-html-shell        shell/default-html-shell)
+(defmacro ^:private import-fn
+  "Re-export `src-sym` (a fully-qualified var symbol) at this namespace
+  under the same name, preserving its `:doc` + `:arglists` (and `:added`
+  / `:deprecated` when present). Unlike a bare `(def alias src)` — which
+  drops all metadata — the façade var carries the source var's authored
+  contract so REPL/editor/api-manifest tooling sees real docs + arglists
+  at `re-frame.ssr.ring/<name>` (rf2-l1qgjw).
+
+  The metadata is copied via `alter-meta!` AFTER the `def` (rather than
+  attached to the def symbol literal) so the `:arglists` value — a list
+  of param vectors — is treated as DATA, not evaluated as a form."
+  [src-sym]
+  (when-not (resolve src-sym)
+    (throw (ex-info (str "import-fn: cannot resolve " src-sym) {:sym src-sym})))
+  (let [nm (symbol (name src-sym))]
+    `(do
+       (def ~nm ~src-sym)
+       (alter-meta! (var ~nm) merge
+                    (select-keys (meta (var ~src-sym))
+                                 [:doc :arglists :added :deprecated]))
+       (var ~nm))))
+
+(import-fn cookie/cookie->set-cookie-header)
+(import-fn shell/default-html-shell)
 
 ;; Streaming SSR surface (rf2-ojakd / rf2-olb64 (a)) — chunked-HTTP
 ;; counterpart of `ssr-handler`. Per Spec 011 §Streaming SSR.
-(def stream-handler            streaming/stream-handler)
-(def default-streaming-prefix  streaming/default-streaming-prefix)
-(def default-streaming-suffix  streaming/default-streaming-suffix)
+(import-fn streaming/stream-handler)
+(import-fn streaming/default-streaming-prefix)
+(import-fn streaming/default-streaming-suffix)
 
 ;; ---- handler defaults + re-exported construction helpers ------------------
 ;;
@@ -126,10 +159,24 @@
 ;; `stream-handler` so the fail-closed-at-boot + rf2-c1tac on-error
 ;; contracts are single-sourced.
 
+(import-fn lifecycle/make-default-on-error)
+
+;; `default-on-error` is a DATA var (a 2-arity fn VALUE held in a `def`,
+;; not a `defn`), so it carries no `:arglists`. Re-export it copying the
+;; authored `:doc` so REPL `doc` works at the façade, but it is correctly
+;; excluded from the fn-arglists api-manifest check (data var, like
+;; `handler-defaults`).
 (def default-on-error lifecycle/default-on-error)
-(def make-default-on-error lifecycle/make-default-on-error)
+(alter-meta! #'default-on-error assoc
+             :doc (-> #'lifecycle/default-on-error meta :doc))
 
 (def handler-defaults
+  "Default `ssr-handler` opts merged under caller-supplied opts at
+  construction time (`:emit-hash?`, `:html-shell`, `:content-type`).
+  A DATA var, not a fn — exposed so callers can read or extend the
+  baseline. `:on-error` is deliberately NOT here (it is resolved
+  separately via `lifecycle/resolve-on-error` so the defaults stay
+  orthogonal to on-error precedence)."
   {:emit-hash?   true
    :html-shell   shell/default-html-shell
    :content-type "text/html; charset=utf-8"})

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -250,7 +250,39 @@
 ;; already flushed — the first chunk has already committed the success
 ;; status to the wire, so a truncate-and-close is the only safe outcome
 ;; (the status can no longer change). The server logs the trace via
-;; `:rf.error/ssr-streaming-writer-failed`.
+;; `:rf.error/ssr-streaming-writer-failed`, which carries WRITER-PHASE
+;; context (rf2-l1qgjw): a `:phase` tag (`:shell-prefix` / `:shell-html`
+;; / `:continuation-template` / `:continuation-delta` / `:final-payload`
+;; / `:suffix`), a `:boundary-id` tag when the failure is inside a
+;; continuation drain, and a coarse `:committed? true` — so ops can tell
+;; a broken client pipe from a bad final payload from a specific
+;; boundary drain rather than seeing one undifferentiated event.
+
+;; rf2-l1qgjw issue 2 — writer-failure phase context. The writer drains
+;; several distinct chunk phases AFTER the response head has committed
+;; (Spec 011 §Failure semantics — once the first chunk lands the status
+;; is on the wire and can no longer change). When a write throws, the
+;; bare `:frame`/`:exception`/`:ex-class`/`:recovery` shape gave ops the
+;; SAME trace for a broken client pipe, a bad final payload, a bad suffix
+;; hook, or a specific continuation drain — turning incident triage into
+;; log archaeology. We track the active phase in a `volatile!` as the
+;; writer advances and stamp it (plus the continuation `:boundary-id` and
+;; a coarse `:committed?`) onto the trace so the recovery channel names
+;; WHERE the stream broke. The phases, in wire order:
+;;
+;;   :shell-prefix          — chunk 1a, the <!DOCTYPE>…<div id=app> open
+;;   :shell-html            — chunk 1b, the shell body with <template>s
+;;   :continuation-template — a resolved/failed boundary <template> chunk
+;;   :continuation-delta    — a boundary's hydration-delta <script> chunk
+;;   :final-payload         — the canonical __rf_payload <script>
+;;   :suffix                — the </div>…</body></html> close
+;;
+;; `:committed?` is true from the moment the FIRST byte is attempted
+;; (`:shell-prefix` onward) — i.e. for every phase here, since the writer
+;; only runs after the request thread committed the chunked head. It is
+;; carried explicitly (rather than inferred from `:phase`) so the contract
+;; is self-describing for log/observability consumers and stays correct if
+;; a future pre-commit phase is ever added to this thread.
 
 (defn- run-streaming-writer!
   "Run the streaming writer on the calling (daemon) thread. The caller
@@ -260,9 +292,23 @@
   shell failures fail closed there; this thread only drains the chunk
   stream). On any throw, the catch arm emits a
   `:rf.error/ssr-streaming-writer-failed` trace and closes the stream
-  cleanly so the Ring server can EOF the response."
+  cleanly so the Ring server can EOF the response.
+
+  The trace carries WRITER-PHASE context (rf2-l1qgjw issue 2): a `:phase`
+  tag naming which chunk was in flight when the write threw (one of
+  `:shell-prefix` / `:shell-html` / `:continuation-template` /
+  `:continuation-delta` / `:final-payload` / `:suffix`), a `:boundary-id`
+  tag when the failure happened inside a continuation drain, and a coarse
+  `:committed? true` (every writer phase runs post-head-commit). That
+  shape lets ops distinguish a broken client pipe from a bad final payload
+  from a specific boundary drain in JFR / log streams instead of seeing
+  one undifferentiated writer-failed event."
   [^OutputStream out frame-id rendered opts]
-  (try
+  ;; Phase tracker — a 2-tuple `[phase boundary-id]`. `boundary-id` is nil
+  ;; outside a continuation drain. Updated as the writer advances so the
+  ;; catch arm can name the in-flight phase.
+  (let [phase (volatile! [:shell-prefix nil])]
+   (try
     (let [{:keys [emit-hash? version schema-digest payload]} opts
           ;; rf2-9fw2de — the writer no longer recomputes the hash from
           ;; `hiccup`; `doc-hash` (full-document) was computed once on the
@@ -280,7 +326,12 @@
                              ;; bug). Same hash the final payload carries.
                              :render-hash (when emit-hash? doc-hash)})]
       ;; Chunk 1 — shell prefix + shell HTML (with template fallbacks).
+      ;; rf2-l1qgjw — stamp the phase before each write so the catch arm
+      ;; names the in-flight chunk. `:shell-prefix` is already the initial
+      ;; volatile value, set explicitly here for symmetry/readability.
+      (vreset! phase [:shell-prefix nil])
       (write-chunk! out (default-streaming-prefix head-html shell-opts))
+      (vreset! phase [:shell-html nil])
       (write-chunk! out shell-html)
       ;; Chunks 2..N+1 — one per continuation, FIFO over registration.
       ;;
@@ -301,6 +352,10 @@
                 tmpl-fn (if failed?
                           streaming/failed-template
                           streaming/resolved-template)]
+            ;; rf2-l1qgjw — a write throw inside a continuation drain names
+            ;; the boundary :id so ops correlate the failure to a specific
+            ;; deferred subtree (not just "some continuation broke").
+            (vreset! phase [:continuation-template id])
             (write-chunk! out (tmpl-fn id html))
             ;; rf2-kjf3m.5 — emit the per-boundary hydration-delta <script>
             ;; ONLY when the delta carries something to hydrate. A
@@ -314,6 +369,7 @@
             ;; carry `:delta nil` (also falsy here), so the `not failed?`
             ;; arm is now redundant but kept for intent clarity.
             (when (and (not failed?) (seq delta))
+              (vreset! phase [:continuation-delta id])
               (write-chunk! out (streaming/hydrate-delta-script id (pr-str delta))))
             ;; Pop the drained entry, append any nested continuations at
             ;; the tail (FIFO), continue until empty.
@@ -362,6 +418,12 @@
       ;;     :app/root))`). It is NOT a marker bug and NOT streaming-specific.
       ;;     Spec 011 §Hydration equivalence rule (structural, not textual)
       ;;     + §Hydration-mismatch detection.
+      ;; rf2-l1qgjw — the `:final-payload` phase spans BOTH the
+      ;; `build-final-payload` assembly (which can throw on a bad payload
+      ;; policy / serialise) AND its write, so a throw in either surfaces
+      ;; as `:phase :final-payload` rather than leaking out as the prior
+      ;; `:continuation-template`/`:shell-html` phase.
+      (vreset! phase [:final-payload nil])
       (let [final-payload (rf/with-frame frame-id
                             (streaming/build-final-payload
                               frame-id doc-hash
@@ -372,15 +434,28 @@
         ;; (rf2-7ksyr) — same helper the non-streaming shell uses.
         (write-chunk! out (shell/payload-script-tag (pr-str final-payload))))
       ;; Chunk N+3 — shell suffix close.
+      (vreset! phase [:suffix nil])
       (write-chunk! out (default-streaming-suffix opts)))
     (catch Throwable t
-      (trace/emit-error! :rf.error/ssr-streaming-writer-failed
-                         {:frame    frame-id
-                          :exception (.getMessage t)
-                          :ex-class  (.getName (class t))
-                          :recovery  :truncate-and-close}))
+      ;; rf2-l1qgjw — stamp the in-flight phase + (when inside a
+      ;; continuation drain) the boundary id + a coarse `:committed?` so
+      ;; the writer-failed trace names WHERE the post-commit stream broke.
+      ;; `:recovery` is hoisted to top-level by `build-event` (Spec 009
+      ;; §Error event shape); `:phase` / `:boundary-id` / `:committed?`
+      ;; ride in `:tags`. `:boundary-id` is omitted entirely (not nil)
+      ;; outside a continuation phase so the tag's presence is itself the
+      ;; "failed inside a boundary drain" signal.
+      (let [[ph boundary-id] @phase]
+        (trace/emit-error! :rf.error/ssr-streaming-writer-failed
+                           (cond-> {:frame      frame-id
+                                    :exception  (.getMessage t)
+                                    :ex-class   (.getName (class t))
+                                    :phase      ph
+                                    :committed? true
+                                    :recovery   :truncate-and-close}
+                             (some? boundary-id) (assoc :boundary-id boundary-id)))))
     (finally
-      (try (.close out) (catch Throwable _ nil)))))
+      (try (.close out) (catch Throwable _ nil))))))
 
 ;; ---- public surface ------------------------------------------------------
 

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
@@ -80,15 +80,12 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.test-fixture :as tf]
-            [ring.adapter.jetty :as jetty])
+            [re-frame.ssr.ring.test-support :as ts]
+            [re-frame.ssr.test-fixture :as tf])
   (:import [java.io InputStream IOException]
-           [java.net URI]
-           [java.net.http HttpClient HttpRequest HttpResponse$BodyHandlers]
-           [java.time Duration]
+           [java.net.http HttpResponse$BodyHandlers]
            [java.util.concurrent CountDownLatch TimeUnit]
-           [java.util.concurrent.atomic AtomicInteger AtomicLong]
-           [org.eclipse.jetty.server Server]))
+           [java.util.concurrent.atomic AtomicInteger AtomicLong]))
 
 (use-fixtures :each tf/reset-runtime)
 
@@ -109,87 +106,29 @@
       10000))
 
 ;; ===========================================================================
-;; Jetty + HttpClient harness (mirrors streaming_robustness_test.clj)
+;; Jetty + HttpClient harness + leak detector
 ;; ===========================================================================
+;;
+;; rf2-l1qgjw — the ephemeral Jetty host, the `java.net.http` client /
+;; request builder, and the `rf2-ssr-streaming-*` daemon-thread leak
+;; detector now live in `re-frame.ssr.ring.test-support` (aliased `ts`),
+;; shared with the other live-host / streaming-thread test namespaces.
+;; The concurrency burst's intentional per-test knobs stay explicit at
+;; the call sites below: a 30s read timeout (slower-completing under
+;; contention than the single-request tests' 10s) and a 50ms leak-poll
+;; cadence (slower than the single-request 10ms because we expect a
+;; higher transient peak count and don't want the poll observable in
+;; profiles).
 
-(defn- start-jetty!
-  [handler]
-  (let [^Server server (jetty/run-jetty handler
-                                        {:port                 0
-                                         :host                 "127.0.0.1"
-                                         :join?                false
-                                         :send-server-version? false
-                                         :send-date-header?    false})
-        port (.. server (getURI) (getPort))]
-    {:server server :port port}))
-
-(defn- stop-jetty!
-  [^Server server]
-  (.stop server))
-
-(defmacro with-jetty
-  [[port-sym handler-expr] & body]
-  `(let [{server# :server port# :port} (start-jetty! ~handler-expr)
-         ~port-sym port#]
-     (try
-       ~@body
-       (finally
-         (stop-jetty! server#)))))
-
-(defn- new-http-client
-  "Single shared HttpClient — `HttpClient` instances are fully thread-
-  safe and pool connections internally per the JDK contract, so all
-  worker threads can share one without contention beyond the
-  underlying socket pool."
-  []
-  (-> (HttpClient/newBuilder)
-      (.connectTimeout (Duration/ofSeconds 5))
-      (.build)))
-
-(defn- http-get-request
-  [port path]
-  (-> (HttpRequest/newBuilder)
-      (.uri (URI/create (str "http://127.0.0.1:" port path)))
-      (.timeout (Duration/ofSeconds 30))
-      (.GET)
-      (.build)))
-
-;; ===========================================================================
-;; Daemon-thread leak detector (shared with streaming_robustness_test.clj
-;; intent — duplicated here so this ns is independently runnable and the
-;; two tests don't co-load each other's scaffolding)
-;; ===========================================================================
-
-(def ^:private daemon-thread-name-prefix "rf2-ssr-streaming-")
-
-(defn- live-streaming-threads
-  []
-  (->> (Thread/getAllStackTraces)
-       (.keySet)
-       (filter (fn [^Thread t]
-                 (and (.isAlive t)
-                      (some-> (.getName t)
-                              (.startsWith daemon-thread-name-prefix)))))
-       vec))
+(def ^:private read-timeout-secs 30)
+(def ^:private leak-poll-ms 50)
 
 (defn- await-no-streaming-threads!
-  "Poll until no `rf2-ssr-streaming-*` thread is alive, or `timeout-ms`
-  elapses. 50ms poll cadence — slightly slower than the per-request
-  test's 10ms because we expect a higher transient peak count and
-  don't want the poll itself to be observable in profiles.
-
-  rf2-fun38: NOT a thin wrapper over `test-support/poll-until` — that
-  helper *throws* on timeout, but this site WANTS the leaked-thread
-  vec on timeout so the test assertion can name the offending threads
-  in its failure message. Different return contract; keep this loop."
+  "Concurrency-burst poll cadence (50ms) over the shared leak detector.
+  rf2-fun38: returns the leaked-thread vec on timeout (does not throw) so
+  the assertion can name the offenders."
   [timeout-ms]
-  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-    (loop []
-      (let [alive (live-streaming-threads)]
-        (cond
-          (empty? alive)                           []
-          (>= (System/currentTimeMillis) deadline) alive
-          :else (do (Thread/sleep 50) (recur)))))))
+  (ts/await-no-streaming-threads! timeout-ms leak-poll-ms))
 
 ;; ===========================================================================
 ;; Token-echo handler — proves per-request frame isolation
@@ -265,8 +204,8 @@
                     {:on-create [:rf.test.ozhy9/init]
                      :root-view [:rf.test.ozhy9/root]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (with-jetty [port handler]
-        (let [client     (new-http-client)
+      (ts/with-jetty [port handler]
+        (let [client     (ts/new-http-client)
               latch      (CountDownLatch. 1)
               ;; AtomicInteger counts COMPLETIONS — successful response
               ;; receipt regardless of body content. The body-token
@@ -287,7 +226,7 @@
                     (try
                       (dotimes [iter-idx n-reqs-per-thread]
                         (let [token    (token-for thread-idx iter-idx)
-                              req      (http-get-request port (str "/req/" token))
+                              req      (ts/http-get-request port (str "/req/" token) read-timeout-secs)
                               response (.send client req
                                               (HttpResponse$BodyHandlers/ofString))
                               status   (.statusCode response)
@@ -401,8 +340,8 @@
                     {:on-create [:rf.test.ozhy9/init]
                      :root-view [:rf.test.ozhy9/root]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (with-jetty [port handler]
-        (let [client     (new-http-client)
+      (ts/with-jetty [port handler]
+        (let [client     (ts/new-http-client)
               latch      (CountDownLatch. 1)
               completed  (AtomicInteger. 0)
               futures
@@ -413,7 +352,7 @@
                     (dotimes [iter-idx n-reqs-per-thread]
                       (try
                         (let [token    (token-for thread-idx iter-idx)
-                              req      (http-get-request port (str "/req/" token))
+                              req      (ts/http-get-request port (str "/req/" token) read-timeout-secs)
                               response (.send client req
                                               (HttpResponse$BodyHandlers/ofInputStream))
                               ^InputStream body-is (.body response)
@@ -479,8 +418,8 @@
                     {:on-create [:rf.test.ozhy9/init]
                      :root-view [:rf.test.ozhy9/root]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (with-jetty [port handler]
-        (let [client     (new-http-client)
+      (ts/with-jetty [port handler]
+        (let [client     (ts/new-http-client)
               latch      (CountDownLatch. 1)
               ;; AtomicInteger that we sample peak across — every
               ;; sampler thread contends here.
@@ -498,7 +437,7 @@
                   ;; sampler-stop counts down. CPU cost is bounded by
                   ;; the burst duration (a few seconds at most).
                   (while (zero? (.getCount sampler-stop))
-                    (let [n (count (live-streaming-threads))]
+                    (let [n (count (ts/live-streaming-threads))]
                       (loop []
                         (let [cur (.get peak-count)]
                           (when (and (> n cur)
@@ -512,7 +451,7 @@
                     (.await latch)
                     (dotimes [iter-idx n-reqs-per-thread]
                       (let [token (token-for thread-idx iter-idx)
-                            req   (http-get-request port (str "/req/" token))]
+                            req   (ts/http-get-request port (str "/req/" token) read-timeout-secs)]
                         (.send client req
                                (HttpResponse$BodyHandlers/ofString)))))))]
           (.start sampler-thread)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/facade_metadata_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/facade_metadata_test.clj
@@ -1,0 +1,90 @@
+(ns re-frame.ssr.ring.facade-metadata-test
+  "Per rf2-l1qgjw issue 1 — pin that the canonical `re-frame.ssr.ring`
+  facade carries real `:doc` + `:arglists` metadata on its public
+  FUNCTION vars.
+
+  The facade re-exposes seven sub-namespace fns. A bare `(def alias
+  other-ns/fn)` copies the value but DROPS the var metadata, so REPL
+  `doc`, editor hover, completion, and the JVM-introspected api-manifest
+  all saw empty docs + nil arglists at the very namespace users are told
+  to require. `import-fn` (in `re-frame.ssr.ring`) now copies the source
+  var's authored `:doc`/`:arglists` onto the façade var. This test is the
+  regression tripwire: a future re-export that reverts to a bare `def`
+  (or forgets the metadata copy) re-opens the gap, and this fails.
+
+  Data vars are EXCLUDED — `handler-defaults` (a config map) and
+  `default-on-error` (a 2-arity fn VALUE held in a `def`, not a `defn`,
+  so it carries no `:arglists`). `default-on-error` still gets a doc
+  check below since it is a documented public surface."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.ssr.ring :as ssr-ring]))
+
+;; The public FUNCTION surface of the facade — every entry MUST carry a
+;; non-empty docstring AND a useful :arglists. (Listed explicitly rather
+;; than reflected so adding a public fn forces a deliberate decision
+;; about its metadata here.)
+(def ^:private public-fn-syms
+  '[cookie->set-cookie-header
+    default-html-shell
+    stream-handler
+    default-streaming-prefix
+    default-streaming-suffix
+    make-default-on-error
+    ssr-handler
+    ssr-middleware])
+
+;; Documented DATA vars — checked for :doc only (no :arglists; they are
+;; not fns). `handler-defaults` is a config map; `default-on-error` is a
+;; fn value held in a `def`.
+(def ^:private public-data-syms
+  '[default-on-error
+    handler-defaults])
+
+(defn- facade-var [sym]
+  (ns-resolve 're-frame.ssr.ring sym))
+
+(deftest facade-public-fns-carry-doc-and-arglists
+  (testing "rf2-l1qgjw — every public re-frame.ssr.ring FUNCTION var has a
+            non-empty :doc and a non-empty :arglists (the import-fn
+            metadata-preserving re-export contract)"
+    (doseq [sym public-fn-syms]
+      (let [v (facade-var sym)
+            m (meta v)]
+        (is (some? v) (str "re-frame.ssr.ring/" sym " resolves"))
+        (is (and (string? (:doc m)) (seq (:doc m)))
+            (str "re-frame.ssr.ring/" sym " has a non-empty :doc "
+                 "(a bare `def` alias would drop it) — saw: "
+                 (pr-str (:doc m))))
+        (is (and (seq (:arglists m))
+                 (every? vector? (:arglists m)))
+            (str "re-frame.ssr.ring/" sym " has a non-empty :arglists of "
+                 "param vectors (a bare `def` alias would drop it) — saw: "
+                 (pr-str (:arglists m))))))))
+
+(deftest facade-public-data-vars-carry-doc
+  (testing "rf2-l1qgjw — documented public DATA vars (handler-defaults,
+            default-on-error) carry a non-empty :doc; they are correctly
+            excluded from the :arglists check (not fns)"
+    (doseq [sym public-data-syms]
+      (let [v (facade-var sym)
+            m (meta v)]
+        (is (some? v) (str "re-frame.ssr.ring/" sym " resolves"))
+        (is (and (string? (:doc m)) (seq (:doc m)))
+            (str "re-frame.ssr.ring/" sym " has a non-empty :doc — saw: "
+                 (pr-str (:doc m))))))))
+
+(deftest facade-doc-matches-implementation-contract
+  (testing "rf2-l1qgjw — the re-exported :doc/:arglists are the source
+            var's authored contract (not a stub), so the facade is the
+            same documentation surface as the sub-namespace home var"
+    ;; Spot-check two representative re-exports against their home vars:
+    ;; one cookie fn and one streaming fn. If `import-fn` ever copied an
+    ;; empty/placeholder doc instead of the source's, these diverge.
+    (is (= (-> #'re-frame.ssr.ring/cookie->set-cookie-header meta :doc)
+           (-> (requiring-resolve 're-frame.ssr.ring.cookie/cookie->set-cookie-header)
+               meta :doc))
+        "cookie->set-cookie-header facade :doc == home var :doc")
+    (is (= (-> #'re-frame.ssr.ring/stream-handler meta :arglists)
+           (-> (requiring-resolve 're-frame.ssr.ring.streaming/stream-handler)
+               meta :arglists))
+        "stream-handler facade :arglists == home var :arglists")))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -83,14 +83,11 @@
             [re-frame.interop :as interop]
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.ring.streaming :as streaming]
-            [re-frame.ssr.test-fixture :as tf]
-            [ring.adapter.jetty :as jetty])
+            [re-frame.ssr.ring.test-support :as ts]
+            [re-frame.ssr.test-fixture :as tf])
   (:import [java.io InputStream IOException OutputStream
                     PipedInputStream PipedOutputStream]
-           [java.net URI]
-           [java.net.http HttpClient HttpRequest HttpResponse$BodyHandlers]
-           [java.time Duration]
-           [org.eclipse.jetty.server Server]))
+           [java.net.http HttpResponse$BodyHandlers]))
 
 (use-fixtures :each tf/reset-runtime)
 
@@ -132,90 +129,26 @@
       [:test/comments-section]]
      [:footer "End"]]))
 
-;; ---- Jetty + JDK HTTP client (mirrors ring_e2e_validator_test) -----------
+;; ---- Jetty + JDK HTTP client + leak detector -----------------------------
+;;
+;; rf2-l1qgjw — the ephemeral Jetty host, the `java.net.http` client /
+;; request builder, and the `rf2-ssr-streaming-*` daemon-thread leak
+;; detector now live in `re-frame.ssr.ring.test-support` (aliased `ts`),
+;; shared with the other live-host / streaming-thread test namespaces.
+;; The per-test knobs stay explicit at the call sites below: a 10s read
+;; timeout (`http-get-request`/`http-get` 3rd arg) and a 10ms leak-poll
+;; cadence (`await-no-streaming-threads!` 2nd arg — the single-request
+;; tests poll faster than the concurrency burst's 50ms).
 
-(defn- start-jetty!
-  "Run `handler` on an ephemeral port. Same shape as the
-  ring_e2e_validator_test harness — `:port 0`, `:host \"127.0.0.1\"`,
-  `:join? false`, response noise trimmed."
-  [handler]
-  (let [^Server server (jetty/run-jetty handler
-                                        {:port                 0
-                                         :host                 "127.0.0.1"
-                                         :join?                false
-                                         :send-server-version? false
-                                         :send-date-header?    false})
-        port (.. server (getURI) (getPort))]
-    {:server server :port port}))
-
-(defn- stop-jetty!
-  [^Server server]
-  (.stop server))
-
-(defmacro with-jetty
-  "Bind `bindings` to `(start-jetty! handler)` and tear the server down
-  in `finally`. `bindings` is `[port-sym handler-expr]`."
-  [[port-sym handler-expr] & body]
-  `(let [{server# :server port# :port} (start-jetty! ~handler-expr)
-         ~port-sym port#]
-     (try
-       ~@body
-       (finally
-         (stop-jetty! server#)))))
-
-(defn- new-http-client
-  "Shared `HttpClient` factory — 5s connect timeout. The `send` arity is
-  per-call so we can use `BodyHandlers/ofInputStream` (for the
-  disconnect test, where we partially read then close) and
-  `BodyHandlers/ofString` (for the happy-path smoke at the top of each
-  test) without rebuilding a client."
-  []
-  (-> (HttpClient/newBuilder)
-      (.connectTimeout (Duration/ofSeconds 5))
-      (.build)))
-
-(defn- http-get-request
-  [port path]
-  (-> (HttpRequest/newBuilder)
-      (.uri (URI/create (str "http://127.0.0.1:" port path)))
-      (.timeout (Duration/ofSeconds 10))
-      (.GET)
-      (.build)))
-
-;; ---- daemon-thread leak detector -----------------------------------------
-
-(def ^:private daemon-thread-name-prefix "rf2-ssr-streaming-")
-
-(defn- live-streaming-threads
-  "Return the seq of currently-live Threads whose name begins with the
-  streaming writer's prefix (`rf2-ssr-streaming-`). Used to assert no
-  orphan thread remains after a failed request."
-  []
-  (->> (Thread/getAllStackTraces)
-       (.keySet)
-       (filter (fn [^Thread t]
-                 (and (.isAlive t)
-                      (some-> (.getName t)
-                              (.startsWith daemon-thread-name-prefix)))))
-       vec))
+(def ^:private read-timeout-secs 10)
+(def ^:private leak-poll-ms 10)
 
 (defn- await-no-streaming-threads!
-  "Poll until no `rf2-ssr-streaming-*` thread is alive, or `timeout-ms`
-  elapses. Returns the final seq of live threads (empty on success,
-  non-empty on timeout). 10ms poll cadence.
-
-  rf2-fun38: NOT a thin wrapper over `test-support/poll-until` — that
-  helper *throws* on timeout, but this site WANTS the leaked-thread vec
-  on timeout so the test assertion can name the offending threads in
-  its failure message. Different return contract; keep this loop."
+  "Single-request poll cadence (10ms) over the shared leak detector.
+  rf2-fun38: returns the leaked-thread vec on timeout (does not throw) so
+  the assertion can name the offenders."
   [timeout-ms]
-  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-    (loop []
-      (let [alive (live-streaming-threads)]
-        (cond
-          (empty? alive)                       []
-          (>= (System/currentTimeMillis) deadline) alive
-          :else (do (Thread/sleep 10) (recur)))))))
+  (ts/await-no-streaming-threads! timeout-ms leak-poll-ms))
 
 ;; ===========================================================================
 ;; Test 1 — broken pipe on .write absorbed by the writer's catch arm
@@ -334,9 +267,9 @@
                     {:on-create [:rf.test.server/init]
                      :root-view [:test/root]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (with-jetty [port handler]
-        (let [client   (new-http-client)
-              req      (http-get-request port "/")
+      (ts/with-jetty [port handler]
+        (let [client   (ts/new-http-client)
+              req      (ts/http-get-request port "/" read-timeout-secs)
               response (.send client req (HttpResponse$BodyHandlers/ofInputStream))
               ;; Read a small prefix so we know the writer thread has
               ;; flushed the shell chunk. We don't care WHAT we read,
@@ -413,9 +346,9 @@
                            {:on-create [:rf.test.server/init-min]
                             :root-view throwing-root
                             :payload :rf.ssr.payload/whole-app-db})]
-      (with-jetty [port handler]
-        (let [client   (new-http-client)
-              req      (http-get-request port "/")
+      (ts/with-jetty [port handler]
+        (let [client   (ts/new-http-client)
+              req      (ts/http-get-request port "/" read-timeout-secs)
               response (.send client req (HttpResponse$BodyHandlers/ofString))
               status   (.statusCode response)
               body     (.body response)]
@@ -487,7 +420,7 @@
         (try
           (is (.await latch 5 java.util.concurrent.TimeUnit/SECONDS)
               "the writer thread reached the parking-section continuation")
-          (reset! observed (live-streaming-threads))
+          (reset! observed (ts/live-streaming-threads))
           (finally
             (.countDown release)
             @drain))
@@ -495,7 +428,7 @@
             "at least one rf2-ssr-streaming-* daemon thread was alive
              while the writer was mid-render")
         (let [names (map (fn [^Thread t] (.getName t)) @observed)]
-          (is (every? #(.startsWith ^String % daemon-thread-name-prefix) names)
+          (is (every? #(.startsWith ^String % ts/daemon-thread-name-prefix) names)
               (str "every captured thread name starts with the
                    `rf2-ssr-streaming-` prefix — captured names: "
                    (vec names))))
@@ -639,14 +572,8 @@
 ;; handler order and asserts the WIRE status is 500, bytes-on-wire through
 ;; Jetty.
 
-(defn- http-get-string
-  "Issue a real HTTP GET and return `{:status :body}` observed on the
-  wire (full body read as a String)."
-  [^HttpClient client port path]
-  (let [resp (.send client (http-get-request port path)
-                    (HttpResponse$BodyHandlers/ofString))]
-    {:status (.statusCode resp)
-     :body   (.body resp)}))
+;; rf2-l1qgjw — the full-body `{:status :body}` GET now uses the shared
+;; `ts/http-get` (the local `http-get-string` was its duplicate).
 
 (deftest rendertime-sub-throw-fails-closed-non-200-bytes-on-wire
   (testing "rf2-r06pc / rf2-vvwmi: a production-mode reactive sub that
@@ -676,9 +603,9 @@
       ;; render + the post-shell re-read — so the buffered 500 is observed
       ;; and committed before the response is returned to Jetty.
       (with-redefs [interop/debug-enabled? false]
-        (with-jetty [port handler]
-          (let [client (new-http-client)
-                {:keys [status]} (http-get-string client port "/")]
+        (ts/with-jetty [port handler]
+          (let [client (ts/new-http-client)
+                {:keys [status]} (ts/http-get client port "/" read-timeout-secs)]
             (is (= 500 status)
                 "render-time sub-throw fail-closed 500 rides the full
                  Jetty round-trip — never a silent 200 (rf2-r06pc)")))))))
@@ -733,9 +660,9 @@
                     {:on-create [:rf.test.server/init-nested]
                      :root-view [:test/wire-nested-root]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (with-jetty [port handler]
-        (let [client (new-http-client)
-              {:keys [status body]} (http-get-string client port "/")
+      (ts/with-jetty [port handler]
+        (let [client (ts/new-http-client)
+              {:keys [status body]} (ts/http-get client port "/" read-timeout-secs)
               idx-outer-resolved (str/index-of body "data-rf2-suspense-id=\":wire/outer\" data-rf2-suspense-resolved=\"1\"")
               idx-inner-resolved (str/index-of body "data-rf2-suspense-id=\":wire/inner\" data-rf2-suspense-resolved=\"1\"")
               idx-inner-body     (str/index-of body "WIRE_INNER_BODY")

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
@@ -45,10 +45,12 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.ssr.ring :as ssr-ring]
+            [re-frame.ssr.ring.lifecycle :as lifecycle]
+            [re-frame.ssr.ring.pipeline :as pipeline]
             [re-frame.ssr.ring.streaming :as streaming]
             [re-frame.ssr.test-fixture :as tf]
             [re-frame.trace :as trace])
-  (:import [java.io InputStream PipedInputStream PipedOutputStream]))
+  (:import [java.io InputStream OutputStream PipedInputStream PipedOutputStream]))
 
 (use-fixtures :each tf/reset-runtime)
 
@@ -162,3 +164,147 @@
             (str "the per-request frame MUST be destroyed even though
                  the shell render threw — found leaked frame-ids: "
                  (vec leaked)))))))
+
+;; ===========================================================================
+;; Writer-failure PHASE context (rf2-l1qgjw issue 2)
+;; ===========================================================================
+;;
+;; The writer-failed trace now names WHICH chunk phase was in flight when
+;; the post-commit write threw (`:phase`), the continuation `:boundary-id`
+;; when the failure is inside a continuation drain, and a coarse
+;; `:committed?`. These tests force DIFFERENT writer phases to throw and
+;; assert the traces carry DISTINCT phase tags — so ops can tell a broken
+;; client pipe from a bad final payload from a specific boundary drain.
+;;
+;; Mechanism: a counting `OutputStream` that throws on its Nth
+;; `write(byte[])` call. The writer calls `.write` once per chunk via
+;; `write-chunk!`, so the chunk ordering (shell-prefix, shell-html,
+;; [continuation-template, continuation-delta]*, final-payload, suffix)
+;; maps writes → phases deterministically. We build a GENUINE `rendered`
+;; map by setting up a real per-request frame and calling
+;; `render-streaming-shell!`, so `build-final-payload` succeeds and the
+;; throw comes from the WRITE (the phase under test), not from shell
+;; resolution.
+
+(defn- throw-on-nth-write-stream
+  "An OutputStream that throws `IOException` on its Nth `write(byte[])`
+  call (1-indexed). Earlier writes are swallowed. Used to target a
+  specific writer phase deterministically."
+  ^OutputStream [n]
+  (let [calls (atom 0)]
+    (proxy [OutputStream] []
+      (write
+        ([b]
+         (when (= n (swap! calls inc))
+           (throw (java.io.IOException. (str "forced-write-failure-at-" n))))
+         nil)
+        ([b off len]
+         (when (= n (swap! calls inc))
+           (throw (java.io.IOException. (str "forced-write-failure-at-" n))))
+         nil))
+      (flush [] nil)
+      (close [] nil))))
+
+(defn- setup-streaming-frame!
+  "Register a real per-request server frame for `opts` and return its
+  frame-id. The `:on-create` event seeds the app-db the views read."
+  [opts]
+  (let [{:keys [frame-id]} (pipeline/setup-request-frame! opts {:uri "/" :request-method :get})]
+    frame-id))
+
+(defn- capture-writer-failure
+  "Drive `run-streaming-writer!` against a stream that throws on the Nth
+  write, capture the writer-failed trace, and return its first event (or
+  nil). `rendered` is a genuine `render-streaming-shell!` result."
+  [frame-id rendered opts throw-at-write]
+  (let [captured (atom [])]
+    (with-trace-capture captured
+      #(@#'streaming/run-streaming-writer!
+         (throw-on-nth-write-stream throw-at-write) frame-id rendered opts))
+    (->> @captured
+         (filterv #(= :rf.error/ssr-streaming-writer-failed (:operation %)))
+         first)))
+
+(deftest writer-failed-trace-carries-distinct-phase-per-chunk
+  (testing "rf2-l1qgjw: forcing different writer chunks to throw produces
+            writer-failed traces with DISTINCT :phase tags (shell-prefix
+            vs final-payload vs suffix), all marked :committed? true"
+    (rf/reg-event-fx :rf.test.phase/init
+      {:platforms #{:server}}
+      (fn [_ _] {:db {:n 1}}))
+    (rf/reg-sub :rf.test.phase/n (fn [db _] (:n db)))
+    (rf/reg-view ^{:rf/id :rf.test.phase/root} phase-root []
+      [:main [:span @(subscribe [:rf.test.phase/n])]])
+    (let [opts     {:on-create [:rf.test.phase/init]
+                    :root-view [:rf.test.phase/root]
+                    :emit-hash? true
+                    :payload :rf.ssr.payload/whole-app-db}
+          ;; A no-suspense root → the write order is exactly:
+          ;;   1 shell-prefix, 2 shell-html, 3 final-payload, 4 suffix.
+          mk       (fn [throw-at]
+                     (let [fid      (setup-streaming-frame! opts)
+                           rendered (#'streaming/render-streaming-shell! fid opts)
+                           ev       (capture-writer-failure fid rendered opts throw-at)]
+                       (lifecycle/destroy-frame-quietly! fid)
+                       ev))
+          prefix-ev (mk 1)
+          final-ev  (mk 3)
+          suffix-ev (mk 4)]
+      (is (= :shell-prefix (-> prefix-ev :tags :phase))
+          "throw on write 1 → :phase :shell-prefix")
+      (is (= :final-payload (-> final-ev :tags :phase))
+          "throw on write 3 → :phase :final-payload")
+      (is (= :suffix (-> suffix-ev :tags :phase))
+          "throw on write 4 → :phase :suffix")
+      ;; The discriminating contract: the three phases are pairwise
+      ;; distinct (a single undifferentiated trace would fail this).
+      (is (= 3 (count (distinct [(-> prefix-ev :tags :phase)
+                                 (-> final-ev :tags :phase)
+                                 (-> suffix-ev :tags :phase)])))
+          "three forced phases yield three DISTINCT :phase tags")
+      ;; Every writer phase runs post-head-commit.
+      (doseq [ev [prefix-ev final-ev suffix-ev]]
+        (is (true? (-> ev :tags :committed?))
+            ":committed? true on every writer phase (post-head-commit)")
+        (is (= :truncate-and-close (:recovery ev))
+            ":recovery hoisted to top-level, unchanged"))
+      ;; No :boundary-id outside a continuation drain.
+      (doseq [ev [prefix-ev final-ev suffix-ev]]
+        (is (not (contains? (:tags ev) :boundary-id))
+            "no :boundary-id tag outside a continuation phase")))))
+
+(deftest writer-failed-trace-carries-boundary-id-on-continuation-phase
+  (testing "rf2-l1qgjw: a write throw during a continuation drain tags the
+            trace :phase :continuation-template AND :boundary-id <id>, so
+            ops correlate the failure to a specific deferred subtree"
+    (rf/reg-event-fx :rf.test.phase/init-sb
+      {:platforms #{:server}}
+      (fn [_ _] {:db {:items [:a :b]}}))
+    (rf/reg-sub :rf.test.phase/items (fn [db _] (:items db)))
+    (rf/reg-view ^{:rf/id :rf.test.phase/section} phase-section []
+      (into [:ul] (for [i @(subscribe [:rf.test.phase/items])] [:li (name i)])))
+    (rf/reg-view ^{:rf/id :rf.test.phase/sb-root} sb-root []
+      [:main
+       [:h1 "hdr"]
+       [:rf/suspense-boundary
+        {:id :rf.test.phase/the-boundary :fallback [:p "loading"]}
+        [:rf.test.phase/section]]])
+    (let [opts     {:on-create [:rf.test.phase/init-sb]
+                    :root-view [:rf.test.phase/sb-root]
+                    :emit-hash? true
+                    :payload :rf.ssr.payload/whole-app-db}
+          fid      (setup-streaming-frame! opts)
+          rendered (#'streaming/render-streaming-shell! fid opts)]
+      ;; With one boundary the write order is:
+      ;;   1 shell-prefix, 2 shell-html, 3 continuation-template, ...
+      ;; Throw on write 3 to hit the continuation-template phase.
+      (is (seq (:continuations rendered))
+          "the rendered shell registered the suspense continuation")
+      (let [ev (capture-writer-failure fid rendered opts 3)]
+        (lifecycle/destroy-frame-quietly! fid)
+        (is (= :continuation-template (-> ev :tags :phase))
+            "throw on the boundary's template write → :phase :continuation-template")
+        (is (= :rf.test.phase/the-boundary (-> ev :tags :boundary-id))
+            ":boundary-id names the specific continuation that was draining")
+        (is (true? (-> ev :tags :committed?))
+            ":committed? true — the continuation phase is post-head-commit")))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/test_support.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/test_support.clj
@@ -1,0 +1,171 @@
+(ns re-frame.ssr.ring.test-support
+  "Shared JVM test scaffolding for the ssr-ring suite (rf2-l1qgjw issue 3).
+
+  Five live-host / streaming-thread test namespaces had grown
+  near-identical copies of: an ephemeral-port Jetty start/stop +
+  `with-jetty` macro, a `java.net.http` client + request builder + two
+  `http-get` result shapes, and a `rf2-ssr-streaming-*` daemon-thread
+  leak detector. Small drift had already crept in (request timeouts of
+  10s vs 30s, poll cadences of 10ms vs 50ms). This namespace single-
+  sources the MECHANISM; every intentional per-test difference (request
+  timeout, leak-poll cadence) stays an explicit PARAMETER so a caller
+  reads its own knobs at the call site rather than hiding them in a copy
+  edit.
+
+  This is the established local pattern: the artefact already shares
+  `re-frame.ssr.test-fixture` for the per-test reset (deps.edn
+  `:extra-paths`), and `with-jetty` etc. are pure test plumbing with no
+  production-path coupling — so consolidating them here removes review
+  surface without introducing a new abstraction style.
+
+  Independence note: requiring this ns does NOT co-load any test
+  namespace (it depends only on `ring.adapter.jetty` + JDK classes), so
+  every test ns stays independently runnable under the artefact `:test`
+  alias.
+
+  Contract smoke coverage for these helpers lives in
+  `test_support_contract_test.clj` (rf2-l1qgjw)."
+  (:require [ring.adapter.jetty :as jetty])
+  (:import [java.net URI]
+           [java.net.http HttpClient HttpRequest HttpResponse$BodyHandlers]
+           [java.time Duration]
+           [org.eclipse.jetty.server Server]))
+
+;; ===========================================================================
+;; Ephemeral Jetty host
+;; ===========================================================================
+
+(defn start-jetty!
+  "Run `handler` under Jetty on an ephemeral port and return
+  `{:server <Server> :port <int>}`.
+
+    :port 0                  — OS-assigned ephemeral port (the test reads
+                               the bound port back off the Server).
+    :host \"127.0.0.1\"        — loopback only; never bind a public
+                               interface in CI.
+    :join? false             — this thread does not block on the server.
+    :send-server-version? false / :send-date-header? false
+                             — trim ambient response-header noise so
+                               header assertions see only what the
+                               adapter emitted."
+  [handler]
+  (let [^Server server (jetty/run-jetty handler
+                                        {:port                 0
+                                         :host                 "127.0.0.1"
+                                         :join?                false
+                                         :send-server-version? false
+                                         :send-date-header?    false})
+        port (.. server (getURI) (getPort))]
+    {:server server :port port}))
+
+(defn stop-jetty!
+  "Stop a Jetty `Server` returned by `start-jetty!`."
+  [^Server server]
+  (.stop server))
+
+(defmacro with-jetty
+  "Bind `port-sym` to the ephemeral port of a Jetty server running
+  `handler-expr`, evaluate `body`, and stop the server in `finally`.
+  `bindings` is `[port-sym handler-expr]`."
+  [[port-sym handler-expr] & body]
+  `(let [{server# :server port# :port} (start-jetty! ~handler-expr)
+         ~port-sym port#]
+     (try
+       ~@body
+       (finally
+         (stop-jetty! server#)))))
+
+;; ===========================================================================
+;; java.net.http client + requests
+;; ===========================================================================
+
+(defn new-http-client
+  "Construct a JDK `java.net.http.HttpClient` with a 5s connect timeout.
+  `HttpClient` instances are thread-safe and pool connections internally
+  (JDK contract), so concurrency tests can share one across worker
+  threads. The `.send` arity stays per-call so a caller picks the body
+  handler (`ofString` / `ofInputStream`) it needs."
+  []
+  (-> (HttpClient/newBuilder)
+      (.connectTimeout (Duration/ofSeconds 5))
+      (.build)))
+
+(defn http-get-request
+  "Build a GET `HttpRequest` for `http://127.0.0.1:<port><path>` with a
+  per-request `timeout-secs` read timeout. `timeout-secs` is the
+  load-bearing per-test knob (the old copies drifted 10s vs 30s), so it
+  is required — the caller states it explicitly at the call site."
+  ^HttpRequest [port path timeout-secs]
+  (-> (HttpRequest/newBuilder)
+      (.uri (URI/create (str "http://127.0.0.1:" port path)))
+      (.timeout (Duration/ofSeconds timeout-secs))
+      (.GET)
+      (.build)))
+
+(defn http-get
+  "Issue a real HTTP GET against `http://127.0.0.1:<port><path>` and
+  return the wire-observed result.
+
+    (http-get client port path timeout-secs)
+      → {:status int :body string}
+
+    (http-get client port path timeout-secs :with-headers? true)
+      → {:status int :headers {name [val ...]} :body string}
+
+  `:headers` is java.net.http's natural `{name -> [val ...]}` multimap,
+  preserved verbatim so a CRLF/header-noise scan reads every value
+  exactly as it arrived. `timeout-secs` is the explicit per-call read
+  timeout (see `http-get-request`)."
+  [^HttpClient client port path timeout-secs & {:keys [with-headers?]}]
+  (let [req  (http-get-request port path timeout-secs)
+        resp (.send client req (HttpResponse$BodyHandlers/ofString))
+        base {:status (.statusCode resp)
+              :body   (.body resp)}]
+    (if with-headers?
+      (assoc base :headers (->> (.. resp (headers) (map))
+                                (map (fn [[k v]] [k (vec v)]))
+                                (into {})))
+      base)))
+
+;; ===========================================================================
+;; Streaming-writer daemon-thread leak detector
+;; ===========================================================================
+
+(def daemon-thread-name-prefix
+  "Name prefix the streaming writer (`stream-handler`) gives each
+  per-request daemon thread (`rf2-ssr-streaming-<frame-id>`). Leak
+  detection scopes by this prefix so it never counts unrelated threads."
+  "rf2-ssr-streaming-")
+
+(defn live-streaming-threads
+  "Return the vector of currently-live Threads whose name begins with
+  `daemon-thread-name-prefix` — i.e. streaming-writer daemon threads
+  still alive. Empty when the no-leak teardown has settled."
+  []
+  (->> (Thread/getAllStackTraces)
+       (.keySet)
+       (filter (fn [^Thread t]
+                 (and (.isAlive t)
+                      (some-> (.getName t)
+                              (.startsWith daemon-thread-name-prefix)))))
+       vec))
+
+(defn await-no-streaming-threads!
+  "Poll until no `rf2-ssr-streaming-*` thread is alive, or `timeout-ms`
+  elapses. RETURNS the final seq of live threads — empty on success,
+  non-empty (the leaked threads) on timeout — so a caller's assertion
+  can name the offenders in its failure message. Does NOT throw on
+  timeout (rf2-fun38: a deliberately different contract from a throwing
+  `poll-until`).
+
+  `poll-ms` is the explicit poll cadence (the old copies used 10ms for
+  single-request tests and 50ms for the higher-peak concurrency burst;
+  keep it a parameter so each caller states its own cadence)."
+  [timeout-ms poll-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (let [alive (live-streaming-threads)]
+        (cond
+          (empty? alive)                           []
+          (>= (System/currentTimeMillis) deadline) alive
+          :else (do (Thread/sleep (long poll-ms)) (recur)))))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/test_support_contract_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/test_support_contract_test.clj
@@ -1,0 +1,60 @@
+(ns re-frame.ssr.ring.test-support-contract-test
+  "Per rf2-l1qgjw issue 3 — smoke coverage for the shared SSR/Ring test
+  scaffolding in `re-frame.ssr.ring.test-support`. The helpers are now
+  load-bearing for five live-host / streaming-thread test namespaces, so
+  pin their behaviour directly: an ephemeral Jetty round-trips a Ring
+  handler over real `java.net.http`, the leak detector reports an empty
+  set when no writer threads are alive, and `await-no-streaming-threads!`
+  returns (rather than throws) the leaked set on timeout."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.ssr.ring.test-support :as ts]))
+
+(deftest with-jetty-round-trips-a-ring-handler
+  (testing "rf2-l1qgjw — ts/with-jetty stands up an ephemeral-port Jetty,
+            ts/new-http-client + ts/http-get observe the handler's
+            response on the wire (status + body), and the server is torn
+            down in the macro's finally"
+    (let [handler (fn [_req]
+                    {:status  201
+                     :headers {"Content-Type" "text/plain"}
+                     :body    "ts-smoke-ok"})]
+      (ts/with-jetty [port handler]
+        (let [client (ts/new-http-client)
+              {:keys [status body]} (ts/http-get client port "/" 5)]
+          (is (= 201 status) "wire status is the handler's status")
+          (is (= "ts-smoke-ok" body) "wire body is the handler's body"))))))
+
+(deftest http-get-with-headers-returns-multimap-headers
+  (testing "rf2-l1qgjw — :with-headers? true adds the {name -> [val ...]}
+            header multimap (the shape the CRLF-on-wire scan needs)"
+    (let [handler (fn [_req]
+                    {:status  200
+                     :headers {"X-Ts-Smoke" "yep"}
+                     :body    "h"})]
+      (ts/with-jetty [port handler]
+        (let [client (ts/new-http-client)
+              {:keys [status headers]} (ts/http-get client port "/" 5
+                                                    :with-headers? true)]
+          (is (= 200 status))
+          (is (map? headers) "headers present as a map")
+          ;; java.net.http lowercases header names; values are vectors.
+          (let [h (into {} (map (fn [[k v]] [(str/lower-case k) v]) headers))]
+            (is (= ["yep"] (get h "x-ts-smoke"))
+                "custom header surfaces as a single-element value vector")))))))
+
+(deftest leak-detector-reports-empty-when-no-writers
+  (testing "rf2-l1qgjw — with no streaming request in flight, the leak
+            detector sees no rf2-ssr-streaming-* threads"
+    (is (= "rf2-ssr-streaming-" ts/daemon-thread-name-prefix)
+        "the prefix matches the writer thread's naming contract")
+    (is (empty? (ts/live-streaming-threads))
+        "no streaming-writer daemon thread is alive in a quiescent JVM")))
+
+(deftest await-no-streaming-threads-returns-empty-fast-when-quiescent
+  (testing "rf2-l1qgjw — await-no-streaming-threads! returns [] immediately
+            when nothing is leaked, and does NOT throw (rf2-fun38 contract
+            — callers want the leaked vec, not an exception)"
+    (let [result (ts/await-no-streaming-threads! 1000 10)]
+      (is (= [] result)
+          "returns an empty vector (no leak) rather than throwing"))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
@@ -84,14 +84,10 @@
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
             [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.test-fixture :as tf]
-            [ring.adapter.jetty :as jetty])
-  (:import [java.net URI]
-           [java.net.http HttpClient HttpRequest HttpResponse$BodyHandlers]
-           [java.time Duration]
-           [java.util.concurrent CountDownLatch]
-           [java.util.concurrent.atomic AtomicLong]
-           [org.eclipse.jetty.server Server]))
+            [re-frame.ssr.ring.test-support :as ts]
+            [re-frame.ssr.test-fixture :as tf])
+  (:import [java.util.concurrent CountDownLatch]
+           [java.util.concurrent.atomic AtomicLong]))
 
 ;; rf2-i3qc0 — canonical reset-runtime fixture; same shape every
 ;; ssr-ring JVM test uses. Each test starts from a wiped registrar +
@@ -101,50 +97,23 @@
 (use-fixtures :each tf/reset-runtime)
 
 ;; ===========================================================================
-;; Jetty + java.net.http harness (mirrors ring_e2e_validator_test.clj)
+;; Jetty + java.net.http harness
 ;; ===========================================================================
+;;
+;; rf2-l1qgjw — the ephemeral Jetty host + `java.net.http` client / GET
+;; helper now live in `re-frame.ssr.ring.test-support` (aliased `ts`),
+;; shared with the other live-host test namespaces. The 30s read timeout
+;; (these drain-time + concurrency-split tests complete slower than the
+;; 10s single-request streaming tests) stays an explicit `ts/http-get`
+;; argument at each call site.
 
-(defn- start-jetty!
-  [handler]
-  (let [^Server server (jetty/run-jetty handler
-                                        {:port                 0
-                                         :host                 "127.0.0.1"
-                                         :join?                false
-                                         :send-server-version? false
-                                         :send-date-header?    false})
-        port (.. server (getURI) (getPort))]
-    {:server server :port port}))
-
-(defn- stop-jetty!
-  [^Server server]
-  (.stop server))
-
-(defmacro with-jetty
-  [[port-sym handler-expr] & body]
-  `(let [{server# :server port# :port} (start-jetty! ~handler-expr)
-         ~port-sym port#]
-     (try
-       ~@body
-       (finally
-         (stop-jetty! server#)))))
-
-(defn- new-http-client []
-  (-> (HttpClient/newBuilder)
-      (.connectTimeout (Duration/ofSeconds 5))
-      (.build)))
+(def ^:private read-timeout-secs 30)
 
 (defn- http-get
-  "Issue a real HTTP GET against `http://127.0.0.1:<port><path>` and
-  return `{:status :body}` observed on the wire."
-  [^HttpClient client port path]
-  (let [req  (-> (HttpRequest/newBuilder)
-                 (.uri (URI/create (str "http://127.0.0.1:" port path)))
-                 (.timeout (Duration/ofSeconds 30))
-                 (.GET)
-                 (.build))
-        resp (.send client req (HttpResponse$BodyHandlers/ofString))]
-    {:status (.statusCode resp)
-     :body   (.body resp)}))
+  "Issue a real HTTP GET and return `{:status :body}` observed on the
+  wire (this suite's 30s read-timeout pinned via the shared helper)."
+  [client port path]
+  (ts/http-get client port path read-timeout-secs))
 
 ;; ===========================================================================
 ;; Stub validator — interpret a `:params` schema as a Clojure predicate
@@ -227,8 +196,8 @@
 
       (testing "bytes-on-the-wire through Jetty — a real HTTP server
                 preserves the projected 404 status"
-        (with-jetty [port handler]
-          (let [client (new-http-client)
+        (ts/with-jetty [port handler]
+          (let [client (ts/new-http-client)
                 {:keys [status body]} (http-get client port "/no-such-page")]
             (is (= 404 status)
                 "the projected 404 survives the full Jetty round-trip")
@@ -298,8 +267,8 @@
                    render-time body replacement)")))
 
           (testing "bytes-on-the-wire through Jetty — 400 survives the round-trip"
-            (with-jetty [port handler]
-              (let [client (new-http-client)
+            (ts/with-jetty [port handler]
+              (let [client (ts/new-http-client)
                     {:keys [status body]} (http-get client port "/articles/zoo")]
                 (is (= 400 status)
                     "drain-time :schema-validation-failure → default
@@ -349,8 +318,8 @@
                      :ssr       {:public-error-id   :rf.ssr/default-error-projector
                                  :dev-error-detail? false}
                      :payload :rf.ssr.payload/whole-app-db})]
-      (with-jetty [port handler]
-        (let [client       (new-http-client)
+      (ts/with-jetty [port handler]
+        (let [client       (ts/new-http-client)
               n-threads     8
               n-per-thread  10
               latch         (CountDownLatch. 1)

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
@@ -84,12 +84,8 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.test-fixture :as tf]
-            [ring.adapter.jetty :as jetty])
-  (:import [java.net URI]
-           [java.net.http HttpClient HttpRequest HttpResponse$BodyHandlers]
-           [java.time Duration]
-           [org.eclipse.jetty.server Server]))
+            [re-frame.ssr.ring.test-support :as ts]
+            [re-frame.ssr.test-fixture :as tf]))
 
 ;; rf2-i3qc0 — canonical reset-runtime fixture; same shape as
 ;; `ring_test.clj`. Each test starts from a wiped registrar + reloaded
@@ -103,49 +99,23 @@
 ;; ===========================================================================
 ;; Server lifecycle helpers
 ;; ===========================================================================
+;;
+;; rf2-l1qgjw — the ephemeral Jetty host (`ts/with-jetty`) + `java.net.http`
+;; GET (`ts/http-get`) now live in `re-frame.ssr.ring.test-support`. This
+;; suite needs the `{:status :headers :body}` shape to run its CRLF-on-wire
+;; header scan, so it calls `ts/http-get` with `:with-headers? true`. The
+;; 10s read timeout (its requests are single, fast) stays explicit.
 
-(defn- start-jetty!
-  "Run `handler` under Jetty on an ephemeral port (`:port 0`) and return
-  `{:server <Server> :port <int>}`. `:join? false` so this thread does
-  not block; `:host \"127.0.0.1\"` so we never bind a public interface
-  in CI. `:send-server-version? false` and `:send-date-header? false`
-  trim ambient noise out of header assertions."
-  [handler]
-  (let [^Server server (jetty/run-jetty handler
-                                        {:port                 0
-                                         :host                 "127.0.0.1"
-                                         :join?                false
-                                         :send-server-version? false
-                                         :send-date-header?    false})
-        port (.. server (getURI) (getPort))]
-    {:server server :port port}))
-
-(defn- stop-jetty!
-  [^Server server]
-  (.stop server))
+(def ^:private read-timeout-secs 10)
 
 (defn- http-get
-  "Issue a real HTTP GET against `http://127.0.0.1:<port>/<path>` via
-  `java.net.http.HttpClient` (JDK-built-in; no extra dep). Returns
-  `{:status :headers :body}` where `:headers` is a `{name -> [val ...]}`
-  map (java.net.http's natural multimap shape — preserved here so the
-  CRLF-on-wire scan reads every value verbatim)."
+  "Issue a real HTTP GET and return `{:status :headers :body}` observed on
+  the wire. `:headers` is java.net.http's `{name -> [val ...]}` multimap
+  (preserved verbatim so the CRLF scan reads every value), via the shared
+  `ts/http-get` helper with a per-call client."
   [port path]
-  (let [client  (-> (HttpClient/newBuilder)
-                    (.connectTimeout (Duration/ofSeconds 5))
-                    (.build))
-        req     (-> (HttpRequest/newBuilder)
-                    (.uri (URI/create (str "http://127.0.0.1:" port path)))
-                    (.timeout (Duration/ofSeconds 10))
-                    (.GET)
-                    (.build))
-        resp    (.send client req (HttpResponse$BodyHandlers/ofString))
-        headers (->> (.. resp (headers) (map))
-                     (map (fn [[k v]] [k (vec v)]))
-                     (into {}))]
-    {:status  (.statusCode resp)
-     :headers headers
-     :body    (.body resp)}))
+  (ts/http-get (ts/new-http-client) port path read-timeout-secs
+               :with-headers? true))
 
 (defn- any-header-contains-crlf?
   "Scan every wire header value for CR / LF / NUL. The point of the
@@ -161,17 +131,6 @@
                 vs))
         (vals headers)))
 
-(defmacro with-jetty
-  "Bind `bindings` to `(start-jetty! handler)` and tear the server down
-  in `finally`. `bindings` is `[port-sym handler-expr]`; the macro
-  exposes `port-sym` to the body."
-  [[port-sym handler-expr] & body]
-  `(let [{server# :server port# :port} (start-jetty! ~handler-expr)
-         ~port-sym port#]
-     (try
-       ~@body
-       (finally
-         (stop-jetty! server#)))))
 
 ;; ===========================================================================
 ;; Test 1 — bad tag-name keyword → 500 via the SSR error projector
@@ -210,7 +169,7 @@
                     {:on-create [:init/ok-bad-tag]
                      :root-view [:pages/bad-tag]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (with-jetty [port handler]
+      (ts/with-jetty [port handler]
         (let [{:keys [status body headers]} (http-get port "/")]
           (is (= 500 status)
               "tag-name validator throw surfaces as 500 on the wire —
@@ -265,7 +224,7 @@
                       {:on-create [:init/ok-render-throw]
                        :root-view [:pages/render-throw]
                        :payload :rf.ssr.payload/whole-app-db})]
-      (with-jetty [port handler-a]
+      (ts/with-jetty [port handler-a]
         (let [{status-a :status body-a :body} (http-get port "/")]
           (is (= 500 status-a))
           ;; Path B: drain-time throw via CRLF cookie value (separate
@@ -283,7 +242,7 @@
                             {:on-create [:init/drain-throw]
                              :root-view [:pages/drain-throw]
                              :payload :rf.ssr.payload/whole-app-db})]
-            (with-jetty [port-b handler-b]
+            (ts/with-jetty [port-b handler-b]
               (let [{status-b :status body-b :body} (http-get port-b "/")]
                 (is (= 500 status-b))
                 (is (= status-a status-b)
@@ -349,7 +308,7 @@
                     {:on-create [:init/bad-cookie]
                      :root-view [:pages/bad-cookie-page]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (with-jetty [port handler]
+      (ts/with-jetty [port handler]
         (let [{:keys [status headers]} (http-get port "/")]
           (is (= 500 status)
               "validator's `:rf.error/cookie-invalid-value` trace flowed
@@ -395,7 +354,7 @@
                     {:on-create [:init/bad-header]
                      :root-view [:pages/bad-header-page]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (with-jetty [port handler]
+      (ts/with-jetty [port handler]
         (let [{:keys [status headers]} (http-get port "/")]
           (is (= 500 status)
               "validator's `:rf.error/header-invalid-value` trace flowed
@@ -447,7 +406,7 @@
                     {:on-create [:init/ok]
                      :root-view [:pages/greeting]
                      :payload :rf.ssr.payload/whole-app-db})]
-      (with-jetty [port handler]
+      (ts/with-jetty [port handler]
         (let [{:keys [status body headers]} (http-get port "/")]
           (is (= 200 status))
           (let [ct (or (first (get headers "content-type"))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_rendertime_sub_failclosed_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_rendertime_sub_failclosed_test.clj
@@ -61,60 +61,26 @@
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
             [re-frame.ssr.ring :as ssr-ring]
-            [re-frame.ssr.test-fixture :as tf]
-            [ring.adapter.jetty :as jetty])
-  (:import [java.net URI]
-           [java.net.http HttpClient HttpRequest HttpResponse$BodyHandlers]
-           [java.time Duration]
-           [org.eclipse.jetty.server Server]))
+            [re-frame.ssr.ring.test-support :as ts]
+            [re-frame.ssr.test-fixture :as tf]))
 
 (use-fixtures :each tf/reset-runtime)
 
 ;; ===========================================================================
-;; Jetty + java.net.http harness (mirrors ring_draintime_error_test.clj)
+;; Jetty + java.net.http harness
 ;; ===========================================================================
+;;
+;; rf2-l1qgjw — the ephemeral Jetty host (`ts/with-jetty`) + `java.net.http`
+;; client / GET now live in `re-frame.ssr.ring.test-support` (aliased `ts`).
+;; The 30s read timeout stays explicit at the call site via `ts/http-get`.
 
-(defn- start-jetty!
-  [handler]
-  (let [^Server server (jetty/run-jetty handler
-                                        {:port                 0
-                                         :host                 "127.0.0.1"
-                                         :join?                false
-                                         :send-server-version? false
-                                         :send-date-header?    false})
-        port (.. server (getURI) (getPort))]
-    {:server server :port port}))
-
-(defn- stop-jetty!
-  [^Server server]
-  (.stop server))
-
-(defmacro with-jetty
-  [[port-sym handler-expr] & body]
-  `(let [{server# :server port# :port} (start-jetty! ~handler-expr)
-         ~port-sym port#]
-     (try
-       ~@body
-       (finally
-         (stop-jetty! server#)))))
-
-(defn- new-http-client []
-  (-> (HttpClient/newBuilder)
-      (.connectTimeout (Duration/ofSeconds 5))
-      (.build)))
+(def ^:private read-timeout-secs 30)
 
 (defn- http-get
-  "Issue a real HTTP GET against `http://127.0.0.1:<port><path>` and
-  return `{:status :body}` observed on the wire."
-  [^HttpClient client port path]
-  (let [req  (-> (HttpRequest/newBuilder)
-                 (.uri (URI/create (str "http://127.0.0.1:" port path)))
-                 (.timeout (Duration/ofSeconds 30))
-                 (.GET)
-                 (.build))
-        resp (.send client req (HttpResponse$BodyHandlers/ofString))]
-    {:status (.statusCode resp)
-     :body   (.body resp)}))
+  "Issue a real HTTP GET and return `{:status :body}` observed on the
+  wire (30s read-timeout pinned via the shared helper)."
+  [client port path]
+  (ts/http-get client port path read-timeout-secs))
 
 ;; ===========================================================================
 ;; A root-view whose reactive sub THROWS during the render walk.
@@ -181,8 +147,8 @@
 
         (testing "bytes-on-the-wire through Jetty — the 500 survives the
                   full round-trip"
-          (with-jetty [port handler]
-            (let [client (new-http-client)
+          (ts/with-jetty [port handler]
+            (let [client (ts/new-http-client)
                   {:keys [status]} (http-get client port "/uses-throwing-sub")]
               (is (= 500 status)
                   "the render-time sub-throw fail-closed 500 rides the


### PR DESCRIPTION
Closes rf2-l1qgjw (3 issues in implementation/ssr-ring).

## Issue 1 — facade metadata
re-frame.ssr.ring re-exported 7 public fns as bare `def` aliases that DROP `:doc`/`:arglists` (cookie->set-cookie-header, default-html-shell, stream-handler, default-streaming-prefix/suffix, make-default-on-error). Added an `import-fn` macro that copies the source var's authored `:doc`/`:arglists` (+ `:added`/`:deprecated`) onto the facade var via `alter-meta!`, so REPL doc / editor hover / completion / api-manifest see real contracts at the namespace users require. `default-on-error` (data var) re-exported with its doc; `handler-defaults` gained a docstring. New `facade_metadata_test` asserts public fn vars carry non-empty doc + useful arglists (data vars excluded from the arglists check) and spot-checks doc/arglists equal the home-var contract.

## Issue 2 — writer-failed phase context (CODE; spec/009 deferred)
`:rf.error/ssr-streaming-writer-failed` now carries writer-phase context. `run-streaming-writer!` tracks a `[phase boundary-id]` volatile as it advances through chunks; the catch arm emits `:phase` (`:shell-prefix`|`:shell-html`|`:continuation-template`|`:continuation-delta`|`:final-payload`|`:suffix`), `:boundary-id` (continuation phases only), and `:committed? true`. `:recovery :truncate-and-close` unchanged (hoisted to top-level). New tests in `streaming_writer_trace_test` force >=2 phases to throw (shell-prefix / final-payload / suffix) and assert DISTINCT phase tags, plus a continuation-drain test asserting `:phase :continuation-template` + the specific `:boundary-id`.

The spec/009 error-event catalogue row is DEFERRED to follow-up bead rf2-konr71 — spec/009-Instrumentation.md is hot-zone and currently being edited by the in-flight EP-0002 chain (rf2-gjq3ow); a concurrent edit would conflict at merge. rf2-konr71 is noted to sequence after the ep-0002 -> main merge.

## Issue 3 — test-support consolidation
Extracted the duplicated ephemeral-Jetty host, java.net.http client/request/GET helpers, and the `rf2-ssr-streaming-*` daemon-thread leak detector into `re-frame.ssr.ring.test-support`. Intentional per-test differences (request read timeout, leak-poll cadence) stay EXPLICIT parameters at each call site. Five test namespaces now consume the shared helpers (streaming_robustness, concurrency_stress, ring_draintime_error, ring_e2e_validator, ring_rendertime_sub_failclosed); each stays independently runnable. New `test_support_contract_test` smoke-covers the helpers (round-trip a Ring handler, header multimap shape, leak-detector empty-when-quiescent, await returns rather than throws).

## Quality gates
- `clojure -M:test` in implementation/ssr-ring: 150 tests, 677 assertions, 0 failures, 0 errors (includes the ^:stress concurrency suite: 3 tests / 33 assertions = 160 concurrent streamed requests, green on the shared helpers).
- New namespaces verified directly: facade_metadata + streaming_writer_trace + test_support_contract = 11 tests / 64 assertions green.
- No spec/docs touched (check_doc_slugs not applicable). All changes within implementation/ssr-ring. `.beads/issues.jsonl` not committed.