### PR TITLE
fix(examples/uix): lockout managed-HTTP reply lifecycle (rf2-j6i2pz)

### DIFF
--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -167,9 +167,18 @@
                  (assoc :error (or (:message failure) "Login failed.")))})
 
     :lock-account
+    ;; Fire-and-forget telemetry beacon (Spec 014 §Reply addressing
+    ;; "Silenced"): the lockout POST wants no reply folded back into the
+    ;; machine. `:on-success nil` / `:on-failure nil` silence both reply
+    ;; branches explicitly — without them the omitted-target default
+    ;; (co-located addressing) would dispatch
+    ;; `[:auth.login/flow {:rf/reply ...}]`, a map in the sub-event slot
+    ;; that `AuthLoginEvent` rejects, stranding noise after lockout.
     (fn [_]
       {:fx [[:rf.http/managed
-             {:request {:method :post :url "/api/auth/lock"}}]]})
+             {:request    {:method :post :url "/api/auth/lock"}
+              :on-success nil
+              :on-failure nil}]]})
 
     :store-session
     (fn [{[_ {:keys [value]}] :event}]


### PR DESCRIPTION
Fixes rf2-j6i2pz. The login_uix `:lock-account` action emitted `[:rf.http/managed {:request {:method :post :url "/api/auth/lock"}}]` with no `:on-success`/`:on-failure`. Per Spec 014 Reply-addressing, an omitted target uses co-located default addressing, which dispatches `[:auth.login/flow {:rf/reply ...}]` — a map in the machine sub-event slot that `AuthLoginEvent` rejects. The demo managed-stub resolves `/api/auth/lock` via canned-success with a 50ms deferred reply, so after the fourth failed login the lockout panel appears and then a malformed event fires back through the flow. The lockout POST is a true fire-and-forget beacon, so this adds explicit `:on-success nil` and `:on-failure nil` (Spec 014 'Silenced'). Scoped to examples/uix; Helix (rf2-6bjboe) and Reagent (rf2-pmw8n9) twins filed as follow-ups. Examples are test-free — the framework silenced-reply contract is already covered in implementation/http test tree; the corrected example is the regression guard via the compile gate. ## Quality gates - `npm run test:examples-compile`: all 39 example builds compiled, 0 warnings (login-uix included).