### PR TITLE
fix(examples/reagent): SSR hydrate + request lifecycle (rf2-kb7zis)

### DIFF
--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -17,18 +17,21 @@
    - Server-only fx via :platforms #{:server}        (and skipping on the client)
    - Pure hiccup → HTML emitter                       (rf/render-to-string)
    - Hydration payload format                         (:rf/hydration-payload schema)
-   - :rf/hydrate replaces (not merges) the client app-db, per the locked
-     :replace-app-db policy
-   - data-rf-render-hash structural marker on the root element; the runtime
-     diffs server vs. client hashes after first render and emits
-     :rf.ssr/hydration-mismatch on disagreement
+   - Per-request frame teardown in a `finally`        (rf/destroy-frame!)
+   - Framework-owned hydration: the client boots via the `ssr/hydrate!`
+     helper, which dispatches the framework's reserved `:rf/hydrate` event
+     (the app does NOT re-register it). `:rf/hydrate` replaces (not merges)
+     the client frame-state, per the locked :replace-frame-state policy.
+   - data-rf-render-hash structural marker on the root element; `ssr/hydrate!`
+     verifies the client render-tree hash against the server's after first
+     render and the runtime emits :rf.ssr/hydration-mismatch on disagreement
 
    Runnable form: the hand-written `index.html` next to this
    file ships with pre-rendered HTML inside `<div id='app'>` and a pre-
    baked `<script id='__rf_payload'>` — exactly the shape `handle-request`
    below would emit if a real Clojure server were sitting in front. The
-   browser-side `run` reads the payload, dispatches `:rf/hydrate`, and
-   renders against the now-seeded app-db."
+   browser-side `run` calls `ssr/hydrate!` (read payload → dispatch
+   `:rf/hydrate` → verify) and renders against the now-seeded frame-state."
   (:require [re-frame.core :as rf]
             ;; `re-frame.schemas` ships in day8/re-frame2-schemas.
             ;; Loading the ns here registers its late-bind hooks so
@@ -60,7 +63,6 @@
             ;; `:ssr/project-error`). Without the require the four core
             ;; re-exports raise `:rf.error/ssr-artefact-missing`.
             [re-frame.ssr :as ssr]
-            #?(:cljs [cljs.reader])
             #?(:cljs [reagent.dom.client :as rdc])
             #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
 
@@ -122,26 +124,24 @@
   (fn handler-articles-loaded [db [_ {:keys [value]}]]
     (assoc db :articles value)))
 
-;; The runtime ships a default :rf/hydrate handler that uses the locked
-;; :replace-frame-state policy (per Spec 011 §The :rf/hydrate event): server is
-;; authoritative for the initial client frame-state. Hydration installs a whole
-;; frame-state — the payload's :rf/app-db (app-db partition) AND :rf/runtime-db
-;; (the serializable runtime-db projection: machine snapshots, route slice, …)
-;; — in one atomic transition. We re-register here only to document the contract
-;; for the example's readers; the body matches the runtime default. (This
-;; example carries no machines and doesn't hydrate the route, so its
+;; HYDRATION IS FRAMEWORK-OWNED. `:rf/hydrate` is a reserved `:rf/*` event
+;; (Conventions §Reserved namespaces) registered by `re-frame.ssr` — the app
+;; MUST NOT re-register it. The framework handler installs a coherent
+;; frame-state in one atomic transition under the locked :replace-frame-state
+;; policy (Spec 011 §The :rf/hydrate event): server is authoritative for the
+;; initial client frame-state, so the payload's :rf/app-db replaces the app-db
+;; partition AND :rf/runtime-db replaces the serializable runtime-db projection
+;; (machine snapshots, route slice, …). It also does work the app must not
+;; reinvent: it validates the payload fail-closed (a non-map payload or a
+;; present-but-non-map :rf/app-db / :rf/runtime-db slice is REJECTED, leaving
+;; the client frame-state untouched), and it stashes the server's
+;; :rf/render-hash under [:rf.runtime/ssr :hydration :server-hash] so
+;; `ssr/verify-hydration!` can drive mismatch detection after the first render.
+;; (This example carries no machines and doesn't hydrate the route, so its
 ;; :rf/runtime-db is empty — but the shape is the same one a richer app uses.)
-;; If you wanted client-only transient state to survive hydration, this is the
-;; place you'd switch to an explicit merge — but the default is replace, and
-;; that's the spec lock.
-(rf/reg-event-fx :rf/hydrate
-  {:doc       "Install a coherent frame-state (app-db + serializable runtime-db) from the server payload."
-   :platforms #{:client}}
-  (fn handler-rf-hydrate [_ [_ {:rf/keys [app-db runtime-db version schema-digest]}]]
-    {:db            app-db                          ;; app-db partition (replace, not merge)
-     :rf.db/runtime (or runtime-db {})              ;; runtime-db partition (replace, not merge)
-     :fx (cond-> [[:rf.ssr/check-version version]]
-           schema-digest (conj [:rf.ssr/check-schema-digest schema-digest]))}))
+;; The client `run` below boots via `ssr/hydrate!`, the framework helper that
+;; reads the payload, dispatches `[:rf/hydrate payload]`, and verifies — see
+;; the CLIENT ENTRY POINT section.
 
 ;; ============================================================================
 ;; CLIENT-SIDE INTERACTIVITY EVENTS
@@ -214,19 +214,32 @@
 ;;      transport uses java.net.http.HttpClient under the hood).
 ;;   5. Render to string via the pure hiccup → HTML emitter.
 ;;   6. Serialise app-db; ship in the HTML.
+;;   7. destroy-frame! in a `finally` — per Spec 011 §Per-request frame
+;;      teardown contract every per-request server frame ends with
+;;      `destroy-frame!`. This is load-bearing for memory hygiene on a
+;;      long-running server: it drops the frame record AND fires the
+;;      `:ssr/on-frame-destroyed` hook, which releases the per-frame
+;;      request slot + response accumulator + error-trace buffer (all
+;;      frame-id-keyed side-channel atoms). Without it, every request
+;;      leaks a frame + a request entry. The `finally` runs on BOTH the
+;;      success and throw paths (e.g. a render or fetch error), so no
+;;      partially-built frame leaks either. This mirrors `ssr_streaming`'s
+;;      `handle-request` and the bundled `re-frame.ssr.ring` host adapter,
+;;      which both tear the frame down on every exit path.
 
 #?(:clj
    (defn handle-request [request]
-     (let [fid (keyword "rf.frame" (str (gensym "")))
+     (let [fid (keyword "rf.frame" (str (gensym "f")))
            _   (ssr/set-request! fid request)
            f   (rf/reg-frame fid
                  {:doc       "ssr-example per-request frame"
                   :platform  :server
                   :on-create [:rf/server-init]})]
-       (rf/with-frame f
-         (let [final-db      (rf/app-db-value f)        ;; app-db partition
-               final-runtime (rf/runtime-db-value f)    ;; runtime-db partition (serializable)
-               hiccup   ((rf/view :app/root))
+       (try
+         (rf/with-frame f
+           (let [final-db      (rf/app-db-value f)        ;; app-db partition
+                 final-runtime (rf/runtime-db-value f)    ;; runtime-db partition (serializable)
+                 hiccup   ((rf/view :app/root))
                  ;; render-to-string with :emit-hash? embeds
                  ;; data-rf-render-hash="<hex>" on the root element. The
                  ;; client recomputes the hash after its first render and
@@ -256,33 +269,45 @@
                    (pr-str payload)
                    "</script>"
                    "<script src='/main.js'></script>"
-                   "</body></html>")})))))
+                   "</body></html>")}))
+         ;; Tear the per-request frame down on EVERY exit path. The
+         ;; `:ssr/on-frame-destroyed` hook (fired by destroy-frame!)
+         ;; clears the request slot + the SSR side-channel atoms, so no
+         ;; explicit `clear-request!` is needed here.
+         (finally
+           (rf/destroy-frame! fid))))))
 
 ;; ============================================================================
 ;; CLIENT ENTRY POINT
 ;; ============================================================================
 ;;
-;; The client flow:
-;;   1. Read the embedded :__rf_payload.
-;;   2. Create the client frame.
-;;   3. dispatch-sync :rf/hydrate before first render. The handler *replaces*
-;;      app-db with the server slice (locked :replace-app-db policy).
-;;   4. Render against the now-seeded state. The runtime hashes the client
-;;      render-tree, compares to the data-rf-render-hash on the server's
-;;      root element, and emits :rf.ssr/hydration-mismatch on disagreement.
-
-#?(:cljs
-   (defn read-server-payload []
-     (when-let [el (.getElementById js/document "__rf_payload")]
-       (cljs.reader/read-string (.-textContent el)))))
+;; The client flow is `ssr/hydrate!` — the framework's client-boot helper,
+;; the symmetric counterpart of the server-side render pipeline (Spec 011
+;; §Client flow / §Client-side hydration boot helper). One call fuses the
+;; three steps the spec mandates, in order:
+;;   1. READ    — the embedded `__rf_payload` `<script>` via the pinned id.
+;;                A malformed payload fails CLOSED (no app-db replacement) and
+;;                a missing payload is the client-only first-load shape.
+;;   2. HYDRATE — dispatch-sync `[:rf/hydrate payload]` BEFORE first render.
+;;                The framework handler *replaces* the frame-state with the
+;;                server slice (locked :replace-frame-state policy) and stashes
+;;                the server's :rf/render-hash for the verify step.
+;;   3. VERIFY  — after first render, hash the `:render-tree-fn` result and
+;;                compare it to the server hash; a disagreement emits
+;;                :rf.ssr/hydration-mismatch.
+;; `hydrate!` returns the payload it applied (nil on a client-only load), so
+;; `run` branches on "was this server-rendered?" without re-reading the DOM.
+;; The app does NOT hand-roll a `read-server-payload` + bare dispatch — that
+;; bypasses the fail-closed validation, the metadata stash, and the verify
+;; step the helper pins.
 
 ;; User events live under an app-chosen namespace, NEVER under the
 ;; reserved `:rf/*` root (Conventions §Reserved namespaces — user code MUST
-;; NOT register handlers under `:rf/*`). The `:rf/hydrate` / `:rf/server-init`
-;; handlers above are legitimate re-registrations of documented framework
-;; pattern events the app is expected to supply; this client-only-load
-;; bootstrap is a fresh user invention, so it gets the app's own `:ssr/`
-;; namespace.
+;; NOT register handlers under `:rf/*`). `:rf/hydrate` and `:rf/server-init`
+;; are framework-owned (the runtime / re-frame.ssr register `:rf/hydrate`;
+;; `:rf/server-init` is the documented per-request server-init pattern event
+;; the app supplies a body for). This client-only-load bootstrap is a fresh
+;; user invention, so it gets the app's own `:ssr/` namespace.
 (rf/reg-event-db :ssr/client-bootstrap
   {:doc "Client-side init that runs even if the server didn't render this page."}
   (fn [db _] db))
@@ -303,25 +328,43 @@
      ;; default-adapter registry — each adapter ns exports an `adapter`
      ;; var the consumer requires and passes here.
      (rf/init! reagent-adapter/adapter)
-     ;; If the page was server-rendered, `:rf/hydrate` installs the server's
-     ;; frame-state — the payload's :rf/app-db and :rf/runtime-db slices
-     ;; (locked :replace-frame-state policy per Spec 011 §The :rf/hydrate
-     ;; event). On a "client-only" load (no payload script),
-     ;; :ssr/client-bootstrap runs as a no-op and the page renders the
-     ;; empty-articles fallback. Hydrate BEFORE first render so the initial
-     ;; render runs against the seeded frame-state.
-     (if-let [payload (read-server-payload)]
-       (rf/dispatch-sync [:rf/hydrate payload])
-       (rf/dispatch-sync [:ssr/client-bootstrap]))
+     ;; `ssr/hydrate!` is the framework client-boot helper (Spec 011
+     ;; §Client-side hydration boot helper). It READs the `__rf_payload`
+     ;; script, dispatch-syncs `[:rf/hydrate payload]` to install the
+     ;; server's frame-state BEFORE first render (locked
+     ;; :replace-frame-state policy), and — given a `:render-tree-fn` — runs
+     ;; the post-hydrate VERIFY step: it hashes the client render-tree and
+     ;; compares it to the server's :rf/render-hash (stashed by the
+     ;; framework `:rf/hydrate` handler at [:rf.runtime/ssr :hydration
+     ;; :server-hash]), emitting :rf.ssr/hydration-mismatch on disagreement.
+     ;; `:render-tree-fn` must return the SAME *resolved* hiccup tree the
+     ;; server hashed — the server computed `(rf/render-tree-hash
+     ;; ((rf/view :app/root)))`, so we CALL the view fn here, `((rf/view
+     ;; :app/root))`, rather than the vector-wrapped component reference
+     ;; `[(rf/view :app/root)]` we hand Reagent to mount. The helper targets
+     ;; the default client frame. It returns the payload it applied (nil on
+     ;; a client-only first load with no payload script), so we can branch on
+     ;; "was this server-rendered?".
+     (let [payload (ssr/hydrate! {:render-tree-fn (fn [] ((rf/view :app/root)))})]
+       (when-not payload
+         ;; Client-only load (no server render): run the app's own
+         ;; bootstrap; the page renders the empty-articles fallback.
+         (rf/dispatch-sync [:ssr/client-bootstrap])))
      (when (exists? js/document)
        (when-not @react-root
          (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
        (rdc/render @react-root [(rf/view :app/root)]))))
 
-;; The JVM-runnable headless test that exercises the full server flow
-;; (per-request frame → :rf/server-init → managed-HTTP via a canned stub →
-;; render-to-string → render-hash) lives in re-frame.examples-test
-;; (implementation/core/test/), folded inline as the
-;; `ssr-example-runs-end-to-end` deftest (rf2-cd2zo), keeping this example
-;; source pure demonstrative code (the example tree is test-free,
-;; rf2-8cevm). It runs on the JVM.
+;; The JVM-runnable headless tests for this example live in
+;; re-frame.examples-test (implementation/core/test/), keeping this example
+;; source pure demonstrative code (the example tree is test-free, rf2-8cevm).
+;; They run on the JVM:
+;;   - `ssr-example-runs-end-to-end` — the full server flow (per-request
+;;     frame → :rf/server-init → managed-HTTP via a canned stub →
+;;     render-to-string → render-hash) (rf2-cd2zo).
+;;   - `ssr-example-handle-request-tears-down-per-request-frame` +
+;;     `…-tears-down-on-throw` — per-request frame teardown on both the
+;;     success and throw paths (rf2-kb7zis).
+;;   - `ssr-example-client-hydration-*` — the client hydration path against
+;;     the framework-owned :rf/hydrate: server-hash stash, matching/divergent
+;;     hash verify, and fail-closed on a malformed payload (rf2-kb7zis).

--- a/examples/reagent/ssr/index.html
+++ b/examples/reagent/ssr/index.html
@@ -26,9 +26,17 @@
     state.
 
     The data-rf-render-hash attribute would normally be emitted by
-    render-to-string with :emit-hash? true; we omit it from the static page
-    because we don't recompute the FNV-1a hash here. That side of Spec 011
-    is exercised by the JVM-side ssr-example-runs-end-to-end deftest in
+    render-to-string with :emit-hash? true, and the matching :rf/render-hash
+    would ride the payload below; we omit BOTH from this static page because
+    we don't recompute the FNV-1a hash here. The client `run` still calls
+    `ssr/hydrate!` with a `:render-tree-fn`, so the verify step runs — but
+    `verify-hydration!` short-circuits silently when no server hash is
+    present (per Spec 011 §Hydration-mismatch detection), so this stand-in
+    page does NOT emit a spurious :rf.ssr/hydration-mismatch. A real Clojure
+    server stamps the genuine hash (see `handle-request` in core.cljc) and
+    mismatch detection then activates end-to-end. The hash-comparison side
+    of Spec 011 is exercised directly by the JVM-side
+    ssr-example-client-hydration-* deftests in
     implementation/core/test/re_frame/examples_test.clj (and by the
     re-frame.ssr conformance suite).
   -->
@@ -46,8 +54,7 @@
 {:rf/version 1
  :rf/app-db {:articles [{:id "a" :title "Article A" :body "Body A"}
                         {:id "b" :title "Article B" :body "Body B"}]}
- :rf/runtime-db {:rf.runtime/routing {:current {:id :ssr.app/articles :params {}}}}
- :rf/render-hash "deadbeef"}
+ :rf/runtime-db {:rf.runtime/routing {:current {:id :ssr.app/articles :params {}}}}}
   </script>
   <script src="main.js"></script>
 </body>

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -17,7 +17,8 @@
   the `examples/.../test/` source dirs. Each test re-`require`s only the
   production example source (so its ns-load registrations fire against the
   reset registrar) and exercises it directly."
-  (:require [clojure.string]
+  (:require [clojure.set]
+            [clojure.string]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -26,6 +27,9 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.ssr :as ssr]
+            [re-frame.ssr.error-listener :as ssr-error-listener]
+            [re-frame.ssr.request :as ssr-request]
+            [re-frame.ssr.response :as ssr-response]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
 (defn- reset-runtime [test-fn]
@@ -61,6 +65,28 @@
   ;; earlier-loaded ns happened to (re-)register `:rf/machine` since the last
   ;; clear-all! — an ordering-dependent flake.
   (require 're-frame.machines :reload)
+  ;; clear-all! also drops the SSR registrations that fire at re-frame.ssr
+  ;; load time — the `:rf/hydrate` event, the `:rf.ssr/check-*` fxs, the six
+  ;; `:rf.server/*` fxs, the `:rf.server/request` cofx — AND the late-bind
+  ;; hooks (`:ssr/on-frame-destroyed`, `:ssr/render-to-string`,
+  ;; `:ssr/render-tree-hash`). The ssr example's client-hydration tests
+  ;; dispatch `:rf/hydrate` and its lifecycle tests rely on `destroy-frame!`
+  ;; firing `:ssr/on-frame-destroyed` to release the per-request request slot;
+  ;; both need these resurrected. Transitive require from the example ns is
+  ;; idempotent (won't re-fire the toplevel forms once loaded), so reload here
+  ;; — mirroring the http / machines reloads above (rf2-kb7zis).
+  (require 're-frame.ssr :reload)
+  ;; Reset the SSR per-frame side-channel atoms (request slots, response
+  ;; accumulators, pending error traces) between tests. These are `defonce`
+  ;; tables keyed by frame-id, OUTSIDE app-db, so neither `clear-all!` nor
+  ;; the `frame/frames` reset touches them. Tests that drive the server flow
+  ;; without destroying the frame (e.g. `ssr-example-runs-end-to-end` sets a
+  ;; request slot and never tears the frame down) leak a slot that would
+  ;; otherwise bleed into the per-request-lifecycle teardown assertions
+  ;; (rf2-kb7zis). Clearing here gives each test a clean side-channel slate.
+  (reset! ssr-request/request-slots {})
+  (reset! ssr-response/response-slots {})
+  (reset! ssr-error-listener/pending-error-traces {})
   ;; Drop any cached require of the example namespaces so each test
   ;; re-evaluates their namespace-level handlers against a fresh registrar.
   (remove-ns 'ssr.core)
@@ -129,6 +155,205 @@
       ;; :rf.ssr/hydration-mismatch trace event on disagreement.
       (is (re-matches #"[0-9a-f]{8}" render-hash))
       (is (clojure.string/includes? html "data-rf-render-hash")))))
+
+;; ============================================================================
+;; ssr — per-request frame lifecycle (rf2-kb7zis). The example's
+;; `handle-request` wraps its render in `try`/`finally` and calls
+;; `rf/destroy-frame!` so a long-running server leaks neither the
+;; generated per-request frame nor its SSR request side-channel slot.
+;; Spec 011 §Per-request frame teardown contract: the destroy step is
+;; load-bearing for memory hygiene. The pre-rf2-kb7zis example skipped it
+;; (`examples_test`'s render-only assertions were a false-green for
+;; lifecycle correctness), so these tests pin teardown on BOTH the success
+;; and throw paths.
+;; ============================================================================
+
+(defn- install-canned-articles-stub!
+  "Register the per-test `:rf.http/managed` redirect the ssr example's
+  `handle-request` routes through `:fx-overrides` — a canned-success stub
+  yielding two articles. Mirrors `ssr-example-runs-end-to-end`."
+  []
+  (rf/reg-fx :ssr.http/canned-articles
+    {:platforms #{:server :client}}
+    (fn [frame-ctx args-map]
+      (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+        (stub frame-ctx
+              (assoc args-map
+                     :value [{:id "a" :title "Article A" :body "Body A"}
+                             {:id "b" :title "Article B" :body "Body B"}]))))))
+
+(deftest ssr-example-handle-request-tears-down-per-request-frame
+  (testing "examples/reagent/ssr — handle-request leaves no per-request frame
+            in the registry and no SSR request slot after it returns
+            (Spec 011 §Per-request frame teardown contract)"
+    (require 'ssr.core :reload)
+    (rf/init! ssr/adapter)
+    (install-canned-articles-stub!)
+    ;; The example's `:rf/server-init` fires `:rf.http/managed`; redirect it
+    ;; to the canned stub via the lexical-scope `with-fx-overrides` so the
+    ;; per-request frame's `:on-create` drain (which runs synchronously
+    ;; inside `reg-frame`, inside this dynamic scope) routes through the stub
+    ;; — no real network traffic. (The same seam the state-machine example
+    ;; test uses; we don't redefine the `reg-frame` macro.)
+    (let [handle-request (resolve 'ssr.core/handle-request)
+          frames-before  (set (keys @frame/frames))
+          resp           (rf/with-fx-overrides
+                           {:rf.http/managed :ssr.http/canned-articles}
+                           (handle-request {:uri "/articles"}))]
+      ;; The request still rendered correctly (state loaded, HTML emitted).
+      (is (= 200 (:status resp)))
+      (is (clojure.string/includes? (:body resp) "Article A"))
+      ;; …and the per-request frame + its request slot are GONE.
+      (let [frames-after (set (keys @frame/frames))
+            new-frames   (clojure.set/difference frames-after frames-before)]
+        (is (empty? new-frames)
+            (str "handle-request must destroy its per-request frame; "
+                 "leaked frames: " (pr-str new-frames)))
+        ;; The request side-channel slot table holds no leftover entry (the
+        ;; :ssr/on-frame-destroyed hook drops the per-frame slot on
+        ;; destroy-frame!). request-slots is keyed by frame-id; an empty
+        ;; table proves the gensym'd per-request slot was released.
+        (is (empty? @ssr-request/request-slots)
+            (str "no request slot survives for the per-request frame; "
+                 "leftover slots: " (pr-str (keys @ssr-request/request-slots))))))))
+
+(deftest ssr-example-handle-request-tears-down-on-throw
+  (testing "examples/reagent/ssr — handle-request destroys the per-request
+            frame even when the render path throws, so a failing request
+            leaks nothing (Spec 011 §Per-request frame teardown contract —
+            cleanup runs on the throw path too)"
+    (require 'ssr.core :reload)
+    (rf/init! ssr/adapter)
+    (install-canned-articles-stub!)
+    (let [handle-request (resolve 'ssr.core/handle-request)
+          frames-before  (set (keys @frame/frames))]
+      (with-redefs [;; Force the render to throw AFTER the frame + request
+                    ;; slot were allocated, exercising the `finally` path.
+                    rf/render-to-string
+                    (fn [& _] (throw (ex-info "boom — render failure" {})))]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (rf/with-fx-overrides
+                       {:rf.http/managed :ssr.http/canned-articles}
+                       (handle-request {:uri "/articles"})))
+            "the render throw propagates (the example does not swallow it)")
+        (let [frames-after (set (keys @frame/frames))
+              new-frames   (clojure.set/difference frames-after frames-before)]
+          (is (empty? new-frames)
+              (str "the `finally` must destroy the per-request frame on the "
+                   "throw path; leaked frames: " (pr-str new-frames)))
+          (is (empty? @ssr-request/request-slots)
+              (str "the throw-path teardown must release the request slot; "
+                   "leftover slots: " (pr-str (keys @ssr-request/request-slots)))))))))
+
+;; ============================================================================
+;; ssr — client hydration path (rf2-kb7zis). The example now boots the
+;; client via the framework `ssr/hydrate!` helper (it relies on the
+;; framework-registered `:rf/hydrate`, no longer a stale local copy). These
+;; tests pin the contract the example depends on, against the example's own
+;; registrations: a payload carrying `:rf/render-hash` stashes the server
+;; hash under [:rf.runtime/ssr :hydration :server-hash]; a matching client
+;; render-tree-fn is silent; a divergent one emits :rf.ssr/hydration-mismatch;
+;; and a malformed payload does NOT replace app-db (fail-closed). JVM-driven
+;; with an explicit :payload on a :client-platform frame (no DOM to read).
+;; ============================================================================
+
+(defn- capture-traces!
+  "Run f under a trace listener; return the captured event vector."
+  [f]
+  (let [traces (atom [])
+        cb-id  (gensym "::examples-ssr-capture-")]
+    (rf/register-listener! cb-id (fn [ev] (swap! traces conj ev)))
+    (try (f) (finally (rf/unregister-listener! cb-id)))
+    @traces))
+
+(deftest ssr-example-client-hydration-stashes-server-hash-and-seeds-db
+  (testing "examples/reagent/ssr — ssr/hydrate! against the example's
+            framework-owned :rf/hydrate stashes the payload's :rf/render-hash
+            under [:rf.runtime/ssr :hydration :server-hash] and replaces app-db
+            with the :rf/app-db slice"
+    (require 'ssr.core :reload)
+    (rf/init! ssr/adapter)
+    (let [client-frame (rf/make-frame {:doc "ssr-example client frame"
+                                       :platform :client})
+          payload      {:rf/version     1
+                        :rf/render-hash "abc12345"
+                        :rf/app-db      {:articles [{:id "a" :title "A" :body "ba"}]}
+                        :rf/runtime-db  {}}
+          returned     (ssr/hydrate! {:frame client-frame :payload payload})]
+      (is (= payload returned)
+          "hydrate! returns the applied payload")
+      (is (= [{:id "a" :title "A" :body "ba"}]
+             (:articles (rf/app-db-value client-frame)))
+          ":rf/hydrate replaced app-db with the server slice")
+      (is (= "abc12345"
+             (get-in (rf/runtime-db-value client-frame)
+                     [:rf.runtime/ssr :hydration :server-hash]))
+          "the server render-hash is stashed for the verify step"))))
+
+(deftest ssr-example-client-hydration-matching-hash-is-silent
+  (testing "examples/reagent/ssr — a client render-tree whose hash MATCHES the
+            payload's :rf/render-hash emits NO :rf.ssr/hydration-mismatch"
+    (require 'ssr.core :reload)
+    (rf/init! ssr/adapter)
+    (let [client-frame (rf/make-frame {:doc "ssr-example verify-match frame"
+                                       :platform :client
+                                       :ssr {:detect-mismatch? true}})
+          client-tree  [:div.page [:h1 "Recent articles"]]
+          matched-hash (rf/render-tree-hash client-tree)
+          payload      {:rf/version 1 :rf/render-hash matched-hash
+                        :rf/app-db {:articles []} :rf/runtime-db {}}
+          traces       (capture-traces!
+                         (fn []
+                           (ssr/hydrate! {:frame          client-frame
+                                          :payload        payload
+                                          :render-tree-fn (fn [] client-tree)})))]
+      (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %)) traces)
+          (str "matching hashes → no mismatch trace; saw: "
+               (pr-str (mapv :operation traces)))))))
+
+(deftest ssr-example-client-hydration-divergent-hash-fires-mismatch
+  (testing "examples/reagent/ssr — a client render-tree whose hash DIVERGES
+            from the payload's :rf/render-hash emits :rf.ssr/hydration-mismatch
+            (the verify step the example's `run` wires via :render-tree-fn)"
+    (require 'ssr.core :reload)
+    (rf/init! ssr/adapter)
+    (let [client-frame (rf/make-frame {:doc "ssr-example verify-divergent frame"
+                                       :platform :client
+                                       :ssr {:detect-mismatch? true}})
+          payload      {:rf/version 1
+                        :rf/render-hash "server00"   ;; != the client tree hash
+                        :rf/app-db {:articles []} :rf/runtime-db {}}
+          traces       (capture-traces!
+                         (fn []
+                           (ssr/hydrate!
+                             {:frame          client-frame
+                              :payload        payload
+                              :render-tree-fn (fn [] [:div.page [:h1 "Recent articles"]])})))]
+      (is (some #(= :rf.ssr/hydration-mismatch (:operation %)) traces)
+          (str "divergent hash → mismatch trace; saw: "
+               (pr-str (mapv :operation traces)))))))
+
+(deftest ssr-example-client-hydration-malformed-payload-does-not-replace-db
+  (testing "examples/reagent/ssr — a MALFORMED payload (a present-but-non-map
+            :rf/app-db slice) is rejected fail-closed: app-db is left
+            unchanged (Spec 011 §The :rf/hydrate event — both partitions
+            validate fail-closed before installation)"
+    (require 'ssr.core :reload)
+    (rf/init! ssr/adapter)
+    (let [client-frame (rf/make-frame {:doc "ssr-example fail-closed frame"
+                                       :platform :client})]
+      ;; Seed a known app-db value first so we can prove it survives.
+      (rf/dispatch-sync [:articles/loaded {:value [{:id "keep" :title "Keep" :body "b"}]}]
+                        {:frame client-frame})
+      (is (= [{:id "keep" :title "Keep" :body "b"}]
+             (:articles (rf/app-db-value client-frame)))
+          "precondition: app-db seeded")
+      ;; A non-map :rf/app-db slice is the malformed shape.
+      (let [bad-payload {:rf/version 1 :rf/app-db "not-a-map"}]
+        (ssr/hydrate! {:frame client-frame :payload bad-payload})
+        (is (= [{:id "keep" :title "Keep" :body "b"}]
+               (:articles (rf/app-db-value client-frame)))
+            "malformed payload rejected — app-db unchanged (fail-closed)")))))
 
 ;; ============================================================================
 ;; ssr_streaming — exercises the server stream (shell render → per-card


### PR DESCRIPTION
Fixes rf2-kb7zis. The non-streaming `examples/reagent/ssr` example overrode the framework hydration contract and leaked per-request frames. Both are fixed within the example dir, with regression coverage added to the framework test tree (examples are test-free).

## What changed

**Hydration (framework-owned).** Removed the example's stale local `:rf/hydrate` re-registration; the client now relies on `re-frame.ssr`'s registered framework handler. That handler does what the local copy omitted: fail-closed payload validation, the `[:rf.runtime/ssr :hydration :server-hash]` metadata stash, and `:rf/render-hash` preservation. `:rf/hydrate` is a reserved `:rf/*` event — apps must not re-register it.

**Client boot.** `run` now boots via `ssr/hydrate!` with a `:render-tree-fn`, so `:rf/render-hash` drives the post-render verify step (read -> dispatch `:rf/hydrate` -> verify), instead of a hand-rolled `read-server-payload` + bare dispatch that skipped `verify-hydration!`. (Dropped the now-unused `cljs.reader` require.)

**Request lifecycle.** Server `handle-request` wraps the render in `try`/`finally` and calls `rf/destroy-frame!` on every exit path (Spec 011 Per-request frame teardown contract). The `:ssr/on-frame-destroyed` hook releases the per-frame request slot + response/error side-channel atoms, so a long-running server no longer leaks a frame + request entry per request. Aligns with `ssr_streaming` and the bundled `re-frame.ssr.ring` host adapter. Also switched the gensym prefix to a non-numeric one so the frame-id stays EDN-readable in the wire payload.

**Static demo.** `index.html` drops the placeholder `:rf/render-hash "deadbeef"` (which contradicted its own comment and would now trip a spurious mismatch). With no server hash present, `verify-hydration!` short-circuits silently; a real server stamps the genuine hash and mismatch detection then activates end-to-end.

**Coverage** (in `implementation/core/test/re_frame/examples_test.clj`): client hydration path (server-hash stash, matching-hash silent, divergent-hash fires `:rf.ssr/hydration-mismatch`, malformed payload does not replace app-db) and per-request lifecycle teardown on both the success and throw paths. The shared fixture now also resets the SSR side-channel atoms between tests (a pre-existing slot-leak from the render-only test bled into lifecycle assertions).

## Quality gates

- `clojure -M:test -n re-frame.examples-test` (core) — 9 tests, 39 assertions, 0 failures.
- `clojure -M:test` (core, full) — 1003 tests, 4379 assertions, 0 failures.
- `clojure -M:test` (ssr artefact) — 319 tests, 1261 assertions, 0 failures.
- `npx shadow-cljs release examples/ssr` — Build completed, 0 warnings (CLJS branch compiles with `ssr/hydrate!`).
- Doc-slug gate N/A (no docs touched). Spec 011 read-only as reference; not edited.