### PR TITLE
fix(examples): silence helix+reagent login lockout managed-HTTP reply (rf2-6bjboe rf2-pmw8n9)

### DIFF
--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -159,9 +159,18 @@
                    (assoc :error (or (:message failure) "Login failed.")))})
 
       :lock-account
+      ;; Fire-and-forget telemetry beacon (Spec 014 §Reply addressing
+      ;; "Silenced"): the lockout POST wants no reply folded back into the
+      ;; machine. `:on-success nil` / `:on-failure nil` silence both reply
+      ;; branches explicitly — without them the omitted-target default
+      ;; (co-located addressing) would dispatch
+      ;; `[:auth.login/flow {:rf/reply ...}]`, a map in the sub-event slot
+      ;; that `AuthLoginEvent` rejects, stranding noise after lockout.
       (fn [_]
         {:fx [[:rf.http/managed
-               {:request {:method :post :url "/api/auth/lock"}}]]})
+               {:request    {:method :post :url "/api/auth/lock"}
+                :on-success nil
+                :on-failure nil}]]})
 
       :store-session
       (fn [{[_ {:keys [value]}] :event}]

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -289,9 +289,18 @@
 
       :lock-account
       ;; Mark the account as locked after too many failed attempts.
+      ;; Fire-and-forget telemetry beacon (Spec 014 §Reply addressing
+      ;; "Silenced"): the lockout POST wants no reply folded back into the
+      ;; machine. `:on-success nil` / `:on-failure nil` silence both reply
+      ;; branches explicitly — without them the omitted-target default
+      ;; (co-located addressing) would dispatch
+      ;; `[:auth.login/flow {:rf/reply ...}]`, a map in the sub-event slot
+      ;; that `AuthLoginEvent` rejects, stranding noise after lockout.
       (fn [_]
         {:fx [[:rf.http/managed
-               {:request {:method :post :url "/api/auth/lock"}}]]})
+               {:request    {:method :post :url "/api/auth/lock"}
+                :on-success nil
+                :on-failure nil}]]})
 
       :store-session
       ;; Persist the session token returned by a successful login.


### PR DESCRIPTION
Twins of rf2-j6i2pz (examples/uix, #3606). Both the Helix (`examples/helix/login_helix/core.cljs`) and Reagent (`examples/reagent/login/core.cljs`) login `:lock-account` actions emitted a managed-HTTP POST to `/api/auth/lock` with no `:on-success`/`:on-failure`. Per Spec 014 §Reply addressing, an omitted target falls back to co-located default addressing, which dispatches a malformed `[:auth.login/flow {:rf/reply ...}]` (a map in the machine sub-event slot that `AuthLoginEvent` rejects) after the lockout panel renders.

The lockout POST is a fire-and-forget telemetry beacon. This adds explicit `:on-success nil` and `:on-failure nil` (Spec 014 §Reply addressing 'Silenced') with an explanatory comment to both examples, mirroring the uix fix in #3606.

Closes rf2-6bjboe (helix), rf2-pmw8n9 (reagent).

## Quality gates
- `npm run test:examples-compile` — all 39 example builds compiled, 0 warnings (incl. `:examples/login-helix` + `:examples/login-form`)