### PR TITLE
fix(routing): route schema coercion + route-link anchor semantics (rf2-fwz29i)

### DIFF
--- a/docs/api/06-routing.md
+++ b/docs/api/06-routing.md
@@ -96,6 +96,8 @@ A plain primary-button click (no modifier keys, no `defaultPrevented`) calls `.p
 
 Modifier-key clicks (cmd / ctrl / shift / alt) and middle-button clicks defer to the browser so the native `href` opens in a new tab. A caller-supplied `:on-click` runs first; if it calls `.preventDefault` (or otherwise leaves `defaultPrevented` true) the framework's interception is skipped. Keys other than `:to` / `:params` / `:query` / `:fragment` / `:on-click` pass through to the underlying `<a>` element.
 
+Anchors carrying **native-handling attributes** are never intercepted — even on a plain left-click — because their DOM semantics must win: a `:target` other than `_self` (`_blank` / `_parent` / `_top` / a named frame) opens the href outside the current document, and `:download` instructs the browser to save the resource. A `route-link` rendered as `{:target "_blank"}` or `{:download "report.pdf"}` therefore behaves as the equivalent plain `<a>` would. To get SPA interception, omit those attributes (or use `:target "_self"`).
+
 Detailed semantics in [012-Routing.md §Linking from views](../../spec/012-Routing.md#linking-from-views--plain-anchor-semantics).
 
 ## Events

--- a/implementation/routing/src/re_frame/routing/link.cljc
+++ b/implementation/routing/src/re_frame/routing/link.cljc
@@ -41,6 +41,41 @@
           (not (.-shiftKey e))
           (not (.-altKey e)))))
 
+(defn- native-anchor?
+  "Return true when `props` carry HTML anchor attributes whose semantics
+  the framework MUST NOT override with same-document SPA navigation, even
+  on a plain left-click. Per rf2-fwz29i — a `route-link` rendered with
+  `{:target \"_blank\"}` or `{:download …}` looks like a normal anchor in
+  the DOM and the user expects native new-tab / new-window / download
+  behaviour; intercepting it into a `:rf/url-requested` dispatch silently
+  breaks that contract.
+
+  Native-handling attributes recognised:
+  - `:target` (or the string key `\"target\"`) set to anything other than
+    `_self` — `_blank` / `_parent` / `_top` / a named frame all open the
+    href outside the current document, which SPA interception would defeat.
+    `_self` (and a blank/absent target) is the default same-document target
+    and remains SPA-interceptable.
+  - `:download` (or `\"download\"`) present and not `false`/`nil` — the
+    browser must save the resource; SPA interception would suppress the
+    download.
+
+  Modifier-key and middle-button clicks already defer via
+  `plain-left-click?`; this predicate adds the *attribute-driven* native
+  cases the click-position checks cannot see."
+  [props]
+  (let [target            (or (:target props) (get props "target"))
+        has-download-key? (or (contains? props :download)
+                              (contains? props "download"))
+        download          (if (contains? props :download)
+                            (:download props)
+                            (get props "download"))]
+    (boolean
+      (or (and (string? target) (not= "_self" target) (not= "" target))
+          (and has-download-key?
+               (not (false? download))
+               (not (nil? download)))))))
+
 #?(:cljs
    (defn route-link-render
      "Render fn for the `:route/link` registered view. Exposed (without
@@ -69,6 +104,12 @@
      apply: plain left-click → `preventDefault` + dispatch
      `:rf/url-requested`; modifier-key or middle-click → no interception.
 
+     rf2-fwz29i: anchors carrying native-handling attributes
+     (`:target` other than `_self`, or `:download`) are NOT intercepted on
+     a plain left-click either — they look like a normal anchor in the DOM
+     and the user expects native new-tab / download behaviour
+     (see `native-anchor?`).
+
      Performance (rf2-r1in4): this is render-path code — every
      `[rf/route-link ...]` re-render walks `route-url` for the href.
      Large nav menus re-rendering frequently amortise the cost over many
@@ -76,11 +117,18 @@
      should it become a bottleneck."
      [{:keys [to params query fragment on-click] :as props} & children]
      (let [[url base-attrs] (href-attrs props)
+           ;; rf2-fwz29i: anchors carrying native-handling attributes
+           ;; (`target="_blank"`, `download`) must let the browser handle
+           ;; the click — SPA interception would defeat new-tab / download.
+           ;; Computed once at render against the resolved attrs (post
+           ;; control-key strip) so the string/keyword attr forms are seen.
+           native? (native-anchor? base-attrs)
            attrs (assoc base-attrs
                         :on-click
                         (fn [e]
                           (when on-click (on-click e))
-                          (when (and (not (.-defaultPrevented e))
+                          (when (and (not native?)
+                                     (not (.-defaultPrevented e))
                                      (plain-left-click? e))
                             (.preventDefault e)
                             ;; Per rf2-t1lxr: route-link click → :router

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -297,6 +297,87 @@
   the global `default-max-decoded-keys`."
   10000)
 
+(def ^:private coercible-scalar-type-forms
+  "The bare Malli scalar type keywords `coerce-by-type-form` knows how
+  to coerce a URL string into. `:keyword` is handled separately (it
+  rewrites to `:rf.route/keyword-unbounded`); `:string` is a deliberate
+  passthrough. Used to recognise the *optioned* form `[:int {…}]` as the
+  same coercion as the bare `:int` (rf2-fwz29i)."
+  #{:int :double :uuid :boolean})
+
+(defn- normalize-type-form
+  "Reduce a per-slot Malli type-form to the canonical coercion token
+  `coerce-by-type-form` understands. Pure; no interning. rf2-fwz29i.
+
+  Handled shapes:
+  - bare scalar `:int` / `:double` / `:uuid` / `:boolean` → itself.
+  - bare `:keyword` → `:rf.route/keyword-unbounded` (no enum allowlist;
+    stays a string at coerce time — the rf2-3k3o7 unbounded-intern guard).
+  - `[:enum :a :b …]` / `[:enum {…opts} :a :b …]` with all-keyword
+    choices → `[:rf.route/enum-keyword #{choice-names…}]` (rf2-3k3o7
+    bounded allowlist).
+  - **optioned scalar** `[:int {…}]` / `[:double {…}]` / `[:uuid {…}]` /
+    `[:boolean {…}]` → the bare scalar token; **optioned** `[:keyword {…}]`
+    → `:rf.route/keyword-unbounded`. Ordinary Malli properties on an
+    otherwise-supported scalar no longer silently disable URL-string
+    coercion (the rf2-fwz29i bug: `[:int {:min 1}]` validated `\"2\"`
+    against `[:int …]` and 404'd every valid deep link).
+  - **wrapper** `[:maybe inner]` → recurse on `inner` (optional-with-nil:
+    the present URL string still coerces to the inner type; an absent key
+    is simply absent). `[:maybe :int]`, `[:maybe [:int {…}]]` supported.
+
+  Any other form (a composite/unsupported schema, or a scalar this
+  vocabulary does not coerce — `:string`, a `[:and …]`, a ref) returns
+  the `raw` form **unchanged**: it stays in the coercion table (so a
+  declared query key is still promoted to a keyword key — the
+  `coerce-query` `declared-names` contract, rf2-5ifai) but
+  `coerce-by-type-form` passes its value through verbatim, and the route's
+  Malli `:params`/`:query` validation has the final say on the type."
+  [raw]
+  (cond
+    (= :keyword raw)
+    :rf.route/keyword-unbounded
+
+    (contains? coercible-scalar-type-forms raw)
+    raw
+
+    (vector? raw)
+    (let [head (first raw)]
+      (cond
+        ;; rf2-3k3o7: `[:enum kw kw …]` bounded keyword allowlist. Skip
+        ;; the optional opts-map at position 1 (Malli `[:enum {…} :a :b]`).
+        (= :enum head)
+        (let [tail  (rest raw)
+              items (if (and (seq tail) (map? (first tail)))
+                      (rest tail)
+                      tail)]
+          (if (and (seq items) (every? keyword? items))
+            [:rf.route/enum-keyword (into #{} (map name) items)]
+            ;; A non-keyword `[:enum …]` (string/number choices) is not a
+            ;; keyword allowlist — leave it as a value passthrough.
+            raw))
+
+        ;; rf2-fwz29i: optioned scalar `[:int {…}]` etc. The Malli
+        ;; properties map (or its absence) does not change the coercion —
+        ;; the head type drives it. `[:keyword {…}]` stays unbounded.
+        (= :keyword head)
+        :rf.route/keyword-unbounded
+
+        (contains? coercible-scalar-type-forms head)
+        head
+
+        ;; rf2-fwz29i: `[:maybe inner]` — coerce the present value against
+        ;; the inner type; nil/absent needs no coercion. Unwrap, then keep
+        ;; the slot in the table either way (an unsupported inner falls to
+        ;; the raw-passthrough below).
+        (= :maybe head)
+        (let [inner (normalize-type-form (second raw))]
+          (if (some? inner) inner raw))
+
+        :else raw))
+
+    :else raw))
+
 (defn- compile-schema-coercions
   "Flatten a `[:map [k type-or-opts] ...]` Malli vector schema into a
   `{k type-form}` map for O(1) per-key lookup during URL coercion.
@@ -308,12 +389,13 @@
   key. Schema-agnostic: the same `[:map ...]` shape drives both the query
   side and the path side.
 
-  Per rf2-3k3o7: when the slot's type-form is a bare `[:enum ...]` with
-  all-keyword choices, the type-form is rewritten as `[:rf.route/enum-keyword #{choice-names...}]`
-  — an allowlist of permitted string-→keyword conversions. A bare
-  `:keyword` type-form (no enum allowlist) is rewritten as
-  `:rf.route/keyword-unbounded` so the coercer can flag it as a
-  string-passthrough rather than an unbounded intern site."
+  Each slot's type-form is reduced to a canonical coercion token by
+  `normalize-type-form` (rf2-fwz29i): bare scalars, **optioned** scalars
+  (`[:int {…}]`), `[:enum …]` keyword allowlists (rf2-3k3o7), bare/optioned
+  `:keyword` (→ `:rf.route/keyword-unbounded`), and `[:maybe inner]`
+  wrappers all map to the right coercion; an unsupported form stays in the
+  table verbatim so its slot remains a declared key (string-passthrough at
+  coerce time, with the Malli validator having the final say)."
   [schema]
   (when (and schema (vector? schema))
     (persistent!
@@ -325,22 +407,7 @@
                               (= 2 (count slot-entry)) (second slot-entry)
                               (= 3 (count slot-entry)) (last slot-entry)
                               :else                    nil)
-                  ;; rf2-3k3o7: detect `[:enum kw kw ...]` as a bounded
-                  ;; keyword allowlist. Skip the optional opts-map at
-                  ;; position 1 when present (Malli convention:
-                  ;; `[:enum {...opts} :a :b]`).
-                  enum-set  (when (and (vector? raw) (= :enum (first raw)))
-                              (let [tail (rest raw)
-                                    ;; Strip leading opts-map if present.
-                                    items (if (and (seq tail) (map? (first tail)))
-                                            (rest tail)
-                                            tail)]
-                                (when (and (seq items) (every? keyword? items))
-                                  (into #{} (map name) items))))
-                  type-form (cond
-                              enum-set        [:rf.route/enum-keyword enum-set]
-                              (= :keyword raw) :rf.route/keyword-unbounded
-                              :else           raw)]
+                  type-form (normalize-type-form raw)]
               (assoc! acc k type-form))
             acc))
         (transient {})

--- a/implementation/routing/test/re_frame/route_link_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/route_link_cljs_test.cljs
@@ -196,6 +196,77 @@
       (is (not prevented?))
       (is (nil? dispatched)))))
 
+;; ---- rf2-fwz29i: native-anchor attributes defer to the browser ----------
+;;
+;; A route-link rendered with native-handling anchor attributes
+;; (`target="_blank"` / `download`) looks like a normal anchor in the DOM,
+;; and a user expects the native new-tab / download behaviour. Intercepting
+;; a plain left-click into a same-document `:rf/url-requested` dispatch
+;; silently breaks that contract. The pre-fix click handler intercepted on
+;; ANY unmodified primary click regardless of these attributes; the fix
+;; gates interception on `native-anchor?`. These tests prove plain
+;; left-clicks on such links do NOT preventDefault and do NOT dispatch.
+
+(deftest target-blank-defers-to-browser-rf2-fwz29i
+  (testing "{:target \"_blank\"} → plain left-click defers to the browser
+            (no preventDefault, no :rf/url-requested)"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [{:keys [dispatched prevented? href]}
+          (click! {:to :route/cart :target "_blank"} (mk-event {}))]
+      (is (= "/cart" href) "the href is still synthesised")
+      (is (not prevented?)
+          "target=_blank leaves the click for the browser (new-tab native)")
+      (is (nil? dispatched)
+          "no SPA :rf/url-requested dispatch — native target wins"))))
+
+(deftest target-parent-and-top-defer-rf2-fwz29i
+  (testing "non-self frame targets (_parent / _top / named) also defer"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (doseq [t ["_parent" "_top" "named-frame"]]
+      (let [{:keys [dispatched prevented?]}
+            (click! {:to :route/cart :target t} (mk-event {}))]
+        (is (not prevented?) (str "target=" t " defers to the browser"))
+        (is (nil? dispatched) (str "no dispatch for target=" t))))))
+
+(deftest download-defers-to-browser-rf2-fwz29i
+  (testing "{:download ...} → plain left-click defers to the browser
+            (no preventDefault, no :rf/url-requested)"
+    (rf/reg-route :route/report {:path "/report"})
+    ;; A string download name (the common case).
+    (let [{:keys [dispatched prevented?]}
+          (click! {:to :route/report :download "report.pdf"} (mk-event {}))]
+      (is (not prevented?) "download leaves the click for the browser")
+      (is (nil? dispatched) "no SPA dispatch — native download wins"))
+    ;; A boolean-true download (attribute present, no filename).
+    (let [{:keys [dispatched prevented?]}
+          (click! {:to :route/report :download true} (mk-event {}))]
+      (is (not prevented?) "download=true also defers")
+      (is (nil? dispatched)))))
+
+(deftest target-self-still-intercepts-rf2-fwz29i
+  (testing "{:target \"_self\"} is the default same-document target — it
+            still gets SPA interception (the native distinction is only
+            for off-document targets)"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [{:keys [dispatched prevented?]}
+          (click! {:to :route/cart :target "_self"} (mk-event {}))]
+      (is prevented? "target=_self is same-document — interception applies")
+      (is (= :rf/url-requested (first dispatched))
+          "_self link dispatches :rf/url-requested like a plain link"))))
+
+(deftest download-false-still-intercepts-rf2-fwz29i
+  (testing "{:download false} / {:download nil} do not request a native
+            download, so SPA interception still applies"
+    (rf/reg-route :route/cart {:path "/cart"})
+    (let [{:keys [dispatched prevented?]}
+          (click! {:to :route/cart :download false} (mk-event {}))]
+      (is prevented? "download=false does not defer")
+      (is (= :rf/url-requested (first dispatched))))
+    (let [{:keys [dispatched prevented?]}
+          (click! {:to :route/cart :download nil} (mk-event {}))]
+      (is prevented? "download=nil does not defer")
+      (is (= :rf/url-requested (first dispatched))))))
+
 ;; ---- caller-supplied :on-click can pre-empt ----------------------------
 
 (deftest caller-on-click-pre-empts-when-preventing-default

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -888,6 +888,64 @@
           ":uuid path param coerced to a #uuid object")
       (is (uuid? (get-in m [:params :id])) "the slice carries a UUID object, not a string"))))
 
+;; rf2-fwz29i: OPTIONED Malli scalar schemas (`[:int {:min 1}]`,
+;; `[:uuid {}]`, `[:double {...}]`, `[:boolean {}]`, optioned enums, and
+;; `[:maybe inner]`) must coerce the URL string identically to the bare
+;; form on CLJS, exactly as on the JVM. The pre-fix coercion table held the
+;; raw vector type-form, so the still-string value failed the optioned
+;; schema and every valid deep link 404'd. This is the CLJS half of the
+;; JVM `rf2-fwz29i-*` pins in routing_test.clj.
+(deftest optioned-scalar-coercion-cljs-rf2-fwz29i
+  (testing "optioned :query scalars coerce equivalently to bare forms on CLJS"
+    (register-routes!)
+    (rf/reg-route :hist/items
+                  {:path  "/items"
+                   :query [:map
+                           [:page [:int {:min 1}]]
+                           [:ratio [:double {:min 0.0}]]
+                           [:id [:uuid {}]]
+                           [:archived [:boolean {}]]]})
+    (let [uuid-str "550e8400-e29b-41d4-a716-446655440000"
+          m (routing/match-url
+              (str "/items?page=2&ratio=1.5&id=" uuid-str "&archived=true"))]
+      (is (= 2 (get-in m [:query :page]))
+          "[:int {:min 1}] coerces \"2\" to 2 (was string → 404)")
+      (is (= 1.5 (get-in m [:query :ratio])) "[:double {...}] coerces")
+      (is (= (parse-uuid uuid-str) (get-in m [:query :id]))
+          "[:uuid {...}] coerces to a UUID object")
+      (is (true? (get-in m [:query :archived])) "[:boolean {...}] coerces")
+      (is (false? (:validation-failed? m))
+          "coerced typed values conform to their optioned schemas — no 404")))
+
+  (testing "optioned :params (path) scalars coerce equivalently on CLJS"
+    (rf/reg-route :hist/opt-page    {:path "/op/:n"  :params [:map [:n [:int {:min 1}]]]})
+    (rf/reg-route :hist/opt-article {:path "/oa/:id" :params [:map [:id [:uuid {}]]]})
+    (is (= 2 (get-in (routing/match-url "/op/2") [:params :n]))
+        "[:int {:min 1}] path param coerces to 2")
+    (let [uuid-str "550e8400-e29b-41d4-a716-446655440000"
+          m        (routing/match-url (str "/oa/" uuid-str))]
+      (is (= (parse-uuid uuid-str) (get-in m [:params :id]))
+          "[:uuid {}] path param coerces to a UUID object")
+      (is (false? (:validation-failed? m)))))
+
+  (testing "optioned `[:enum {...} :a :b]` keeps the keyword allowlist gate"
+    (rf/reg-route :hist/sorted
+                  {:path  "/sorted"
+                   :query [:map [:sort [:enum {:default :asc} :asc :desc]]]})
+    (is (= :asc (get-in (routing/match-url "/sorted?sort=asc") [:query :sort]))
+        "declared enum value interns even with an opts map")
+    (is (= "nope" (get-in (routing/match-url "/sorted?sort=nope") [:query :sort]))
+        "value outside the allowlist stays a string"))
+
+  (testing "[:maybe inner] coerces the present value against the inner type"
+    (rf/reg-route :hist/maybe
+                  {:path  "/maybe"
+                   :query [:map [:page [:maybe [:int {:min 1}]]]]})
+    (let [m (routing/match-url "/maybe?page=7")]
+      (is (= 7 (get-in m [:query :page]))
+          "[:maybe [:int {:min 1}]] coerces through wrapper + option")
+      (is (false? (:validation-failed? m))))))
+
 ;; rf2-zmcq6 (CODE half): {:fragment ""} normalizes to nil at the navigate
 ;; boundary on CLJS so the pushed URL and slice fragment agree with
 ;; URL-driven nav.

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -2442,6 +2442,132 @@
     (is (= " 12" (get-in (routing/match-url "/p3?page=%2012") [:query :page]))
         "leading-whitespace input stays a string on both hosts")))
 
+;; ---- rf2-fwz29i: OPTIONED Malli scalar schemas coerce like bare forms ----
+;;
+;; A scalar slot carrying ordinary Malli properties — `[:int {:min 1}]`,
+;; `[:uuid {...}]`, `[:double {...}]`, `[:boolean {...}]`, or an optioned
+;; enum `[:enum {...} :a :b]` — must coerce the URL string identically to
+;; its bare form (`:int`, `:uuid`, ...). The pre-fix table took the raw
+;; vector type-form, so `coerce-by-type-form` saw `[:int {:min 1}]` (not
+;; `:int`), skipped coercion, and the still-string value `"2"` failed the
+;; route's `[:int {:min 1}]` schema → `:validation-failed? true` → every
+;; valid deep link 404'd. `[:maybe inner]` wrappers coerce the inner type.
+
+(deftest rf2-fwz29i-optioned-scalar-query-coercion
+  (testing "optioned scalar :query schemas coerce equivalently to bare forms"
+    (rf/reg-route :route/items
+                  {:path  "/items"
+                   :query [:map
+                           [:page [:int {:min 1}]]
+                           [:ratio [:double {:min 0.0}]]
+                           [:id [:uuid {}]]
+                           [:archived [:boolean {}]]]})
+    (let [uuid-str "550e8400-e29b-41d4-a716-446655440000"
+          m (routing/match-url
+              (str "/items?page=2&ratio=1.5&id=" uuid-str "&archived=true"))]
+      (is (= :route/items (:route-id m)))
+      (is (= 2 (get-in m [:query :page]))
+          "[:int {:min 1}] coerces \"2\" to 2 (was \"2\" → validation-failed)")
+      (is (= 1.5 (get-in m [:query :ratio]))
+          "[:double {...}] coerces to a number")
+      (is (= (parse-uuid uuid-str) (get-in m [:query :id]))
+          "[:uuid {...}] coerces to a UUID object")
+      (is (true? (get-in m [:query :archived]))
+          "[:boolean {...}] coerces \"true\" to true")
+      (is (false? (:validation-failed? m))
+          "coerced typed values conform to their optioned schemas — no 404")))
+
+  (testing "an optioned :int slot still FAILS validation for a value that
+            violates the option (coercion happens, the option still bites)"
+    (rf/reg-route :route/min-page
+                  {:path  "/p"
+                   :query [:map [:page [:int {:min 5}]]]})
+    (let [m (routing/match-url "/p?page=2")]
+      (is (= 2 (get-in m [:query :page]))
+          "the string coerces to the number 2 (coercion is unconditional)")
+      (is (true? (:validation-failed? m))
+          "2 < :min 5 → validation still fails (the option is enforced)")))
+
+  (testing "a non-numeric value for an optioned :int stays a string and fails"
+    (rf/reg-route :route/min-page2
+                  {:path  "/p2"
+                   :query [:map [:page [:int {:min 1}]]]})
+    (let [m (routing/match-url "/p2?page=abc")]
+      (is (= "abc" (get-in m [:query :page]))
+          "non-integer-literal stays a string (host-symmetric passthrough)")
+      (is (true? (:validation-failed? m))
+          "the string fails the :int schema — fail-closed, not a crash"))))
+
+(deftest rf2-fwz29i-optioned-scalar-path-coercion
+  (testing "optioned scalar :params (path) schemas coerce like bare forms"
+    (rf/reg-route :route/page    {:path "/page/:n"      :params [:map [:n [:int {:min 1}]]]})
+    (rf/reg-route :route/article {:path "/articles/:id" :params [:map [:id [:uuid {}]]]})
+    (rf/reg-route :route/double  {:path "/d/:x"         :params [:map [:x [:double {:min 0.0}]]]})
+
+    (testing "[:int {:min 1}] path param coerces; validation passes"
+      (let [m (routing/match-url "/page/2")]
+        (is (= :route/page (:route-id m)))
+        (is (= 2 (get-in m [:params :n])) "\"2\" coerced to 2 (was string → 404)")
+        (is (false? (:validation-failed? m)))))
+
+    (testing "[:uuid {}] path param coerces to a #uuid; canonical route matches"
+      (let [uuid-str "550e8400-e29b-41d4-a716-446655440000"
+            m        (routing/match-url (str "/articles/" uuid-str))]
+        (is (= :route/article (:route-id m)))
+        (is (= (parse-uuid uuid-str) (get-in m [:params :id])))
+        (is (uuid? (get-in m [:params :id])))
+        (is (false? (:validation-failed? m)))))
+
+    (testing "[:double {:min 0.0}] path param coerces to a number"
+      (let [m (routing/match-url "/d/3.14")]
+        (is (= 3.14 (get-in m [:params :x])))
+        (is (false? (:validation-failed? m)))))
+
+    (testing "an optioned :int path value violating the option still fails"
+      (rf/reg-route :route/minp {:path "/m/:n" :params [:map [:n [:int {:min 5}]]]})
+      (let [m (routing/match-url "/m/2")]
+        (is (= 2 (get-in m [:params :n])) "coerced to the number 2")
+        (is (true? (:validation-failed? m)) "2 < :min 5 → validation fails")))))
+
+(deftest rf2-fwz29i-optioned-enum-keyword-allowlist
+  (testing "an optioned `[:enum {...} :asc :desc]` keeps the keyword
+            allowlist gate (opts map skipped); declared values intern,
+            others stay strings"
+    (rf/reg-route :route/sorted
+                  {:path  "/items"
+                   :query [:map [:sort [:enum {:default :asc} :asc :desc]]]})
+    (let [m1 (routing/match-url "/items?sort=asc")
+          m3 (routing/match-url "/items?sort=hostile-value")]
+      (is (= :asc (get-in m1 [:query :sort]))
+          "declared enum value interns to :asc even with an opts map")
+      (is (= "hostile-value" (get-in m3 [:query :sort]))
+          "value outside the allowlist stays a string — no unbounded intern"))))
+
+(deftest rf2-fwz29i-maybe-wrapper-coercion
+  (testing "[:maybe inner] coerces the present value against the inner
+            type (query side); a coerced value conforms to the :maybe schema"
+    (rf/reg-route :route/opt
+                  {:path  "/opt"
+                   :query [:map
+                           [:page [:maybe :int]]
+                           [:size [:maybe [:int {:min 1}]]]]})
+    (let [m (routing/match-url "/opt?page=7&size=3")]
+      (is (= 7 (get-in m [:query :page]))
+          "[:maybe :int] coerces \"7\" to 7")
+      (is (= 3 (get-in m [:query :size]))
+          "[:maybe [:int {:min 1}]] coerces through both wrapper and option")
+      (is (false? (:validation-failed? m))
+          "coerced values conform to the :maybe schemas")))
+
+  (testing "[:maybe :uuid] path param coerces; absent optional key is absent"
+    (rf/reg-route :route/maybe-art {:path   "/a/:id"
+                                    :params [:map [:id [:maybe :uuid]]]})
+    (let [uuid-str "550e8400-e29b-41d4-a716-446655440000"
+          m        (routing/match-url (str "/a/" uuid-str))]
+      (is (= (parse-uuid uuid-str) (get-in m [:params :id]))
+          "[:maybe :uuid] coerces the present capture to a UUID")
+      (is (false? (:validation-failed? m))))))
+
 ;; ---- rf2-3k3o7: keyword-interning cap on query keys + values -------------
 ;;
 ;; Symmetric with rf2-wu1n5's `:rf.http/max-decoded-keys` cap on JSON

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -771,6 +771,8 @@ An external classification emits `:rf.route/external-url-requested` (carrying `:
 
 The view exposes three behavioural seams: passthrough attributes (`:class`, `:title`, `:id`, `:aria-label`, …) flow through to the `<a>`; a caller-supplied `:on-click` runs before the framework's interception and can pre-empt it by calling `.preventDefault`; and modifier-key clicks defer to the browser so middle-click / cmd-click / shift-click keep their native open-in-new-tab affordances. `route-url` is the single point where the URL is synthesised, so route-rename and route-shape changes flow into every `route-link` site without per-link edits.
 
+**Native-anchor attributes are never intercepted.** A passthrough attribute whose semantics require the browser to handle the click — a `target` other than `_self` (`_blank` / `_parent` / `_top` / a named frame), or `download` — defers to the browser even on a plain left-click, the same as a modifier-key click. SPA interception would convert a `{:target "_blank"}` link into same-document navigation and a `{:download …}` link into a no-op navigation, silently breaking the native anchor contract the DOM attributes advertise. The framework treats these attributes as a fourth defer-to-browser seam alongside modifier/middle clicks and caller `.preventDefault`: the link still renders as a real `<a href=…>` with the attributes, and the click is left for the browser. Authors who want SPA interception omit those attributes (or set `:target "_self"`).
+
 ## Scroll restoration
 
 Browser-default behaviour on `popstate` restores scroll position. For SPA-controlled scroll (e.g., scroll to top on forward navigation, restore on back), declare a `:scroll` strategy on the route or pass `:scroll` in the `:rf.route/navigate` opts.


### PR DESCRIPTION
Fixes rf2-fwz29i.

## Route schema coercion (P2)
Optioned Malli scalar schemas now coerce URL strings before validation. `compile-schema-coercions` reduces each slot's type-form via a new `normalize-type-form` helper so optioned scalars (`[:int {:min 1}]`, `[:double {...}]`, `[:uuid {...}]`, `[:boolean {...}]`), optioned `:keyword`, optioned `[:enum {...} ...]` keyword allowlists, and `[:maybe inner]` wrappers all map to the same coercion token as their bare forms. Previously the raw vector type-form bypassed `coerce-by-type-form`, so a valid `"2"` stayed a string, failed the `[:int {:min 1}]` schema, and routed to `:rf.route/not-found`. Unsupported forms stay in the table verbatim so the `coerce-query` declared-names keyword-promotion contract (rf2-5ifai) is preserved. The Malli option still bites: a coerced value that violates the option still fails validation.

## route-link native-anchor semantics (P3)
`route-link` now defers a plain left-click to the browser for anchors carrying native-handling attributes (a `:target` other than `_self`, or `:download`). SPA interception would defeat the native new-tab / new-window / download behaviour the DOM attributes advertise. `native-anchor?` gates the interception alongside the existing modifier/middle-click and caller `.preventDefault` seams. `:target "_self"` and `:download false`/`nil` still get SPA interception.

## Regression coverage
- JVM (`routing_test.clj`): optioned-scalar query + path coercion, option-still-enforced, non-coercible passthrough, optioned enum allowlist, `[:maybe ...]` wrappers.
- CLJS (`routing_history_cljs_test.cljs`): cross-host parity for all the above.
- CLJS (`route_link_cljs_test.cljs`): `target=_blank`/`_parent`/`_top`/named + `download` defer; `_self` + `download false`/`nil` still intercept.

Spec 012 §Linking and docs/api/06-routing.md document the native-anchor defer-to-browser seam.

## Quality gates
- `clojure -M:test` in implementation/routing: 171 tests, 830 assertions, 0 failures, 0 errors.
- `npm run test:cljs`: 6110 tests, 21789 assertions, 0 failures, 0 errors.
- `python scripts/check_doc_slugs.py`: exit 0.