### PR TITLE
fix(machines): route on-spawn callback throws through the machine error contract (rf2-km4bn4)

### DIFF
--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -1924,22 +1924,46 @@
   id-recording alternatives. `trace/emit!` is gated on
   `interop/debug-enabled?` (Closure DCE / JVM flag) so this is production-
   free and adds no module-level mutable state — the engine stays a pure
-  function of `[machine snapshot event]`."
+  function of `[machine snapshot event]`.
+
+  Error contract (rf2-km4bn4): the `:on-spawn` callback is a machine
+  action like any other, so a THROW must route through the documented
+  machine action exception contract — NOT escape as a generic
+  `:rf.error/handler-exception`. Mirroring `run-action` / `materialise-data`,
+  the call is wrapped in try/catch: on throw, return a `result/fail`
+  Result stamped with the stable action id `:rf.spawn/on-spawn` plus
+  enough context to locate the spawn (`:spawned-id`; the caller adds
+  `:spawn-id` / `:child-id`, and `apply-transition-once` stamps
+  `:decl-path` / `:transition` / `:state-path`). The lifecycle boundary
+  (`registration/trace-action-failure!`) then emits exactly one
+  `:rf.error/machine-action-exception` and drops the accumulated effects —
+  so a throwing observer never commits the parent/child snapshot or the
+  spawned registry slot. On SUCCESS the snapshot is returned UNCHANGED, as
+  before. (No `:rf.machine/action-ran` activity trace fires here on either
+  path: `:on-spawn` is an advisory observer, not a cascade action — adding
+  it would introduce a novel `:phase` outside the documented closed set,
+  Spec-Schemas.md §`action-ran`.)"
   [machine snap spawn-spec spawned-id]
-  (when-let [f (let [aref (:on-spawn spawn-spec)]
-                 (when aref
-                   (or (chase-ref (:on-spawn-actions machine) aref)
-                       (chase-ref (:actions machine) aref))))]
-    (let [ret (f {:data (:data snap) :id spawned-id})]
-      (when (some? ret)
-        (trace/emit! :warning :rf.warning/on-spawn-return-ignored
-                     {:machine-id (or (:rf/parent-id machine) (:id machine))
+  (if-let [f (let [aref (:on-spawn spawn-spec)]
+               (when aref
+                 (or (chase-ref (:on-spawn-actions machine) aref)
+                     (chase-ref (:actions machine) aref))))]
+    (try
+      (let [ret (f {:data (:data snap) :id spawned-id})]
+        (when (some? ret)
+          (trace/emit! :warning :rf.warning/on-spawn-return-ignored
+                       {:machine-id (or (:rf/parent-id machine) (:id machine))
+                        :spawned-id spawned-id
+                        :returned   ret
+                        :remedy     [:system-id
+                                     [:rf.runtime/machines :spawned :<parent> :<invoke-id>]
+                                     :rf.machine/update-snapshot]}))
+        snap)
+      (catch #?(:clj Throwable :cljs :default) e
+        (result/fail {:action-ref :rf.spawn/on-spawn
                       :spawned-id spawned-id
-                      :returned   ret
-                      :remedy     [:system-id
-                                   [:rf.runtime/machines :spawned :<parent> :<invoke-id>]
-                                   :rf.machine/update-snapshot]}))))
-  snap)
+                      :exception  e})))
+    snap))
 
 (defn- spawn-one
   "Single-spawn primitive shared by `:spawn` and `:spawn-all` per-child.
@@ -1975,8 +1999,13 @@
   runs the `:on-spawn` advisory callback.
 
   Returns `[snap-after acc-fx']` for the reducer, or a `reduced` wrapper
-  around a `result/fail` Result (stamped with
-  `:action-ref :rf.spawn/data-fn` and `:spawn-id`) on `:data` failure."
+  around a `result/fail` Result on failure. The failure is stamped
+  `:action-ref :rf.spawn/data-fn` + `:spawn-id` for a `:data`-fn throw,
+  or — per rf2-km4bn4 — `:action-ref :rf.spawn/on-spawn` + `:spawn-id`
+  (carried up from `apply-on-spawn`) for a throwing `:on-spawn` callback,
+  so the lifecycle boundary routes BOTH through the machine action
+  exception contract rather than letting an `:on-spawn` throw escape as a
+  generic handler exception."
   [machine parent-id s acc-fx prefix n event]
   (let [spawn-spec   (:spawn n)
         invoke-id    (vec prefix)
@@ -1993,8 +2022,14 @@
     (if (result/fail? spawn-r)
       (reduced spawn-r)
       (let [spawn-fx (result/fx spawn-r)
+            ;; Per rf2-km4bn4: a throwing `:on-spawn` callback returns a
+            ;; `result/fail` (not a snapshot) — short-circuit the spawn
+            ;; reducer so no parent/child snapshot or registry slot commits
+            ;; and the accumulated fx is dropped at the lifecycle boundary.
             s'       (apply-on-spawn machine s-alloc spawn-spec id)]
-        [s' (into acc-fx spawn-fx)]))))
+        (if (result/fail? s')
+          (reduced (result/fail-with s' {:spawn-id invoke-id}))
+          [s' (into acc-fx spawn-fx)])))))
 
 (defn- handle-spawn-all-decl
   "Handle the `:spawn-all` branch of the spawn reducer in
@@ -2067,13 +2102,25 @@
           children-with-ids)]
     (if (result/fail? spawn-fxs-r)
       (reduced spawn-fxs-r)
-      ;; (4) Thread :on-spawn advisory callbacks across siblings.
+      ;; (4) Thread :on-spawn advisory callbacks across siblings. Per
+      ;; rf2-km4bn4 a throwing child `:on-spawn` returns a `result/fail`
+      ;; (not the threaded snapshot); short-circuit the sibling reduce on
+      ;; the FIRST throw — stamping the failing `:child-id` + `:spawn-id`
+      ;; onto the failure — so the reducer never terminates mid-spawn
+      ;; without a machine-scoped trace, and no parent/child snapshot or
+      ;; registry slot commits.
       (let [s' (reduce
                  (fn [snap child]
-                   (apply-on-spawn machine snap child (:rf/spawned-id child)))
+                   (let [r (apply-on-spawn machine snap child (:rf/spawned-id child))]
+                     (if (result/fail? r)
+                       (reduced (result/fail-with r {:spawn-id invoke-id
+                                                     :child-id (:id child)}))
+                       r)))
                  s-alloc
                  children-with-ids)]
-        [s' (-> acc-fx (conj init-fx) (into spawn-fxs-r))]))))
+        (if (result/fail? s')
+          (reduced s')
+          [s' (-> acc-fx (conj init-fx) (into spawn-fxs-r))])))))
 
 (defn final-state-node?
   "Per Spec 005 §Final states (rf2-gn80): true iff the state-node declares

--- a/implementation/machines/test/re_frame/spawn_on_spawn_throw_test.clj
+++ b/implementation/machines/test/re_frame/spawn_on_spawn_throw_test.clj
@@ -1,0 +1,190 @@
+(ns re-frame.spawn-on-spawn-throw-test
+  "Per rf2-km4bn4. A throwing `:on-spawn` advisory callback must route
+  through the documented machine action exception contract — exactly as a
+  throwing `:action` / `:data`-fn does (spawn_data_fn_form_test §4) — and
+  MUST NOT escape as a generic `:rf.error/handler-exception`.
+
+  `:on-spawn` is a machine action (resolved through `:on-spawn-actions`
+  with `:actions` fallback, Spec 005 §Declarative `:spawn`). Pre-fix the
+  callback was invoked raw (no try/catch, no Result conversion), so a
+  buggy observer aborted the whole event as an uncaught handler failure —
+  bypassing the machine-scoped `:rf.error/machine-action-exception`
+  diagnostic, the frame-tagged trace, and the atomic-rollback discipline.
+
+  The contract the fix establishes, verified here for BOTH single `:spawn`
+  and `:spawn-all`:
+
+   1. A throwing `:on-spawn` emits EXACTLY ONE
+      `:rf.error/machine-action-exception` (op-type `:error`) stamped with
+      the stable action id `:rf.spawn/on-spawn` and the machine's frame.
+   2. NO generic `:rf.error/handler-exception` is emitted — the throw is
+      caught inside the machine layer, not at the core dispatch boundary.
+   3. ATOMIC ROLLBACK: no parent snapshot, no spawned child snapshot, and
+      no `[:rf.runtime/machines :spawned ...]` registry slot commit — the
+      accumulated effects are dropped.
+
+  All tests run on the JVM through the plain-atom substrate, exercising
+  the full lifecycle handler (the path where the bug surfaced)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- snapshot
+  [machine-id]
+  (get-in (rf/runtime-db-value :rf/default)
+          [:rf.runtime/machines :snapshots machine-id]))
+
+(defn- frame-db []
+  (rf/runtime-db-value :rf/default))
+
+(defn- capture-traces!
+  "Drive `thunk` while recording every emitted trace envelope. Returns the
+  vector of envelopes (deterministic on the JVM — no wall-clock / random)."
+  [thunk]
+  (let [seen (atom [])]
+    (trace/register-listener! ::on-spawn-throw (fn [ev] (swap! seen conj ev)))
+    (try (thunk) (finally (trace/unregister-listener! ::on-spawn-throw)))
+    @seen))
+
+(defn- action-exceptions
+  "The `:rf.error/machine-action-exception` envelopes among `traces`."
+  [traces]
+  (filter #(and (= :error (:op-type %))
+                (= :rf.error/machine-action-exception (:operation %)))
+          traces))
+
+(defn- handler-exceptions
+  "The generic `:rf.error/handler-exception` envelopes among `traces` —
+  the contract violation this fix closes (the throw must NOT reach the
+  core dispatch boundary)."
+  [traces]
+  (filter #(= :rf.error/handler-exception (:operation %)) traces))
+
+;; ---- (1) single :spawn — throwing :on-spawn ------------------------------
+
+(deftest single-spawn-on-spawn-throw-routes-to-machine-action-exception
+  (testing "a throwing :on-spawn callback on a single :spawn emits exactly
+   one :rf.error/machine-action-exception (action-id :rf.spawn/on-spawn,
+   frame-tagged), NO generic :rf.error/handler-exception, and commits no
+   snapshot or registry slot"
+    (let [child  {:initial :running :data {} :states {:running {}}}
+          parent {:initial :idle
+                  :on-spawn-actions
+                  {:boom (fn [_] (throw (ex-info "on-spawn boom" {:why :test})))}
+                  :states
+                  {:idle    {:on {:start :working}}
+                   :working {:spawn {:machine-id :worker/proc
+                                      :on-spawn   :boom}}}}]
+      (rf/reg-machine :worker/proc child)
+      (rf/reg-machine :sup/on-spawn-throw parent)
+      (let [traces (capture-traces!
+                     #(rf/dispatch-sync [:sup/on-spawn-throw [:start]]))
+            errs   (action-exceptions traces)]
+        ;; (1) exactly one machine-action-exception, correctly tagged.
+        (is (= 1 (count errs))
+            "exactly one :rf.error/machine-action-exception for the throw")
+        (let [{:keys [tags]} (first errs)]
+          (is (= :rf.spawn/on-spawn (:action-id tags))
+              "the error carries the stable :rf.spawn/on-spawn action id")
+          (is (= :sup/on-spawn-throw (:machine-id tags))
+              "the error is scoped to the spawning parent machine")
+          (is (= :rf/default (:frame tags))
+              "the error is frame-tagged (epoch-capture admission)")
+          (is (some? (:exception tags))
+              "the originating throwable rides the error trace"))
+        ;; (2) no generic handler-exception — the throw never escaped.
+        (is (zero? (count (handler-exceptions traces)))
+            "NO generic :rf.error/handler-exception — caught in the machine layer")
+        ;; (3) atomic rollback.
+        (is (nil? (snapshot :worker/proc#1))
+            "no spawned child snapshot committed (effects dropped)")
+        (let [parent-snap (snapshot :sup/on-spawn-throw)]
+          (is (or (nil? parent-snap) (= :idle (:state parent-snap)))
+              "parent did not commit the :working transition"))
+        (is (nil? (get-in (frame-db) [:rf.runtime/machines :spawned :sup/on-spawn-throw]))
+            "no [:rf.runtime/machines :spawned ...] registry slot committed")))))
+
+;; ---- (2) :spawn-all — one throwing child :on-spawn -----------------------
+
+(deftest spawn-all-on-spawn-throw-routes-to-machine-action-exception
+  (testing "a throwing :on-spawn on ONE :spawn-all child emits exactly one
+   :rf.error/machine-action-exception (action-id :rf.spawn/on-spawn,
+   frame-tagged), NO generic :rf.error/handler-exception, and terminates
+   the spawn reducer with full atomic rollback — no child snapshot, no
+   registry slot, no parent transition commit"
+    (let [child  {:initial :running :data {} :states {:running {}}}
+          parent {:initial :idle
+                  :on-spawn-actions
+                  {:ok   (fn [_] nil)
+                   :boom (fn [_] (throw (ex-info "spawn-all on-spawn boom"
+                                                 {:why :test})))}
+                  :states
+                  {:idle      {:on {:fan-out :hydrating}}
+                   :hydrating {:spawn-all
+                               {:children
+                                [{:id :a :machine-id :hydra/leaf :on-spawn :ok}
+                                 {:id :b :machine-id :hydra/leaf :on-spawn :boom}]
+                                :on-child-done   :child/done
+                                :on-child-error  :child/error
+                                :on-all-complete [:done]}}}}]
+      (rf/reg-machine :hydra/leaf child)
+      (rf/reg-machine :sup/all-throw parent)
+      (let [traces (capture-traces!
+                     #(rf/dispatch-sync [:sup/all-throw [:fan-out]]))
+            errs   (action-exceptions traces)]
+        ;; (1) exactly one machine-action-exception, correctly tagged.
+        (is (= 1 (count errs))
+            "exactly one :rf.error/machine-action-exception for the throwing child")
+        (let [{:keys [tags]} (first errs)]
+          (is (= :rf.spawn/on-spawn (:action-id tags))
+              "the error carries the stable :rf.spawn/on-spawn action id")
+          (is (= :sup/all-throw (:machine-id tags))
+              "the error is scoped to the spawning parent machine")
+          (is (= :rf/default (:frame tags))
+              "the error is frame-tagged"))
+        ;; (2) no generic handler-exception.
+        (is (zero? (count (handler-exceptions traces)))
+            "NO generic :rf.error/handler-exception for the spawn-all throw")
+        ;; (3) atomic rollback — neither child commits (the whole spawn
+        ;; phase is dropped, not just the throwing child).
+        (is (nil? (snapshot :hydra/leaf#1))
+            "no child snapshot committed — the spawn phase rolled back atomically")
+        (is (nil? (snapshot :hydra/leaf#2))
+            "the throwing child's slot also did not commit")
+        (let [parent-snap (snapshot :sup/all-throw)]
+          (is (or (nil? parent-snap) (= :idle (:state parent-snap)))
+              "parent did not commit the :hydrating transition"))
+        (is (nil? (get-in (frame-db) [:rf.runtime/machines :spawned :sup/all-throw]))
+            "no spawn-all join-state / registry slot committed")))))
+
+;; ---- (3) regression guard — a NON-throwing :on-spawn still spawns ---------
+
+(deftest non-throwing-on-spawn-still-spawns-cleanly
+  (testing "the try/catch wrap is transparent on the happy path — a quiet
+   :on-spawn observer still fires, the actor spawns, and NO error trace fires"
+    (let [observed (atom nil)
+          child    {:initial :running :data {} :states {:running {}}}
+          parent   {:initial :idle
+                    :on-spawn-actions
+                    {:observe (fn [{:keys [id]}] (reset! observed id) nil)}
+                    :states
+                    {:idle    {:on {:start :working}}
+                     :working {:spawn {:machine-id :worker/proc
+                                        :on-spawn   :observe}}}}]
+      (rf/reg-machine :worker/proc child)
+      (rf/reg-machine :sup/quiet parent)
+      (let [traces (capture-traces!
+                     #(rf/dispatch-sync [:sup/quiet [:start]]))]
+        (is (= :worker/proc#1 @observed)
+            ":on-spawn still fires (observed the spawned id) on the happy path")
+        (is (some? (snapshot :worker/proc#1))
+            "the actor spawned — the success path is unchanged")
+        (is (zero? (count (action-exceptions traces)))
+            "no machine-action-exception when :on-spawn does not throw")
+        (is (zero? (count (handler-exceptions traces)))
+            "no handler-exception on the happy path")))))


### PR DESCRIPTION
An `:on-spawn` advisory callback that throws was invoked raw in `apply-on-spawn` (no try/catch, no Result conversion), so a buggy observer aborted the whole event as an uncaught generic `:rf.error/handler-exception` instead of the documented machine-scoped `:rf.error/machine-action-exception` — bypassing the frame-tagged diagnostic, child `:on-error` routing, and the atomic-rollback discipline.

The fix wraps the callback in try/catch (mirroring `run-action` / `materialise-data`): on throw it returns a `result/fail` stamped with the stable action id `:rf.spawn/on-spawn` + `:spawned-id`. `handle-spawn-decl` and `handle-spawn-all-decl` short-circuit (`reduced`) on that failure, stamping `:spawn-id` / `:child-id`; `apply-transition-once` already stamps `:decl-path` / `:transition` / `:state-path`. The lifecycle boundary (`trace-action-failure!`) then emits exactly one `:rf.error/machine-action-exception` and drops accumulated effects, so no parent/child snapshot or registry slot commits. The success path is unchanged. No `:rf.machine/action-ran` activity trace is added (`:on-spawn` is an advisory observer, not a cascade action — a novel `:phase` would break the documented closed set).

Regression tests (`spawn_on_spawn_throw_test.clj`) cover single `:spawn` and `:spawn-all` throwing `:on-spawn` — exactly one machine-action-exception (action-id `:rf.spawn/on-spawn`, frame-tagged), zero generic handler-exception, atomic rollback (no child/parent snapshot, no registry slot) — plus a happy-path guard that the try/catch wrap is transparent. A negative-control run (catch re-throwing) confirmed the tests fail pre-fix (handler-exception leak).

## Quality gates
- `clojure -M:test` (implementation/machines): 586 tests, 1850 assertions, 0 failures, 0 errors
- `npm run test:cljs`: 6104 tests, 21758 assertions, 0 failures, 0 errors

Closes rf2-km4bn4.