### PR TITLE
fix(flows): close classification-API fail-open gaps (rf2-cgk0wb)

### DIFF
--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -241,6 +241,12 @@
 ;; The tightened validator rejects each malformation up front with a stable
 ;; error id and ex-data that names the offending entries / elements so
 ;; callers don't have to chase the failure into the topo / evaluator stack.
+;;
+;; The OPTIONAL output data-classification keys (`:sensitive` / `:large` /
+;; `:sensitive?` / `:large?`, Spec 015 §7) are validated in the same table
+;; (rf2-cgk0wb): previously they were FAIL-OPEN — a malformed declaration
+;; (`:sensitive [:token]`, `:large "blob"`, `:sensitive? :yes`) registered
+;; cleanly but installed no redaction, the worst failure for a safety feature.
 
 (defn- valid-path-element?
   "Path elements are scalar map keys: keyword, string, integer, symbol, or
@@ -255,6 +261,16 @@
   "A path is a non-empty vector of valid path elements."
   [x]
   (and (vector? x) (seq x) (every? valid-path-element? x)))
+
+(defn- valid-output-subpath?
+  "A flow output classification subpath (an entry of `:sensitive` / `:large`)
+  is a vector of scalar path elements, AND — unlike a flow `:inputs` path or
+  the flow `:path` — the EMPTY vector `[]` is legal: it marks the whole
+  output value (the `[[]]` whole-value convention, Spec 015:81). So this is
+  `valid-path?` minus the non-empty requirement: a vector whose every element
+  (if any) is a scalar key."
+  [x]
+  (and (vector? x) (every? valid-path-element? x)))
 
 ;; Every validation throw shares the canonical thrown-error skeleton
 ;; (per Spec 009 §The thrown-error shape):
@@ -353,7 +369,75 @@
    {:pred     (fn [flow] (every? valid-path-element? (:path flow)))
     :error-kw :rf.error/flow-bad-path
     :reason   ":path elements must each be a scalar key (keyword / string / integer / symbol / boolean)"
-    :extras   (fn [flow] {:bad-elements (vec (remove valid-path-element? (:path flow)))})}])
+    :extras   (fn [flow] {:bad-elements (vec (remove valid-path-element? (:path flow)))})}
+
+   ;; rf2-cgk0wb issue 2: the OPTIONAL output data-classification keys
+   ;; (`:sensitive` / `:large` per-path vectors; `:sensitive?` / `:large?`
+   ;; whole-output booleans) were FAIL-OPEN. `explicit-flow-output-mark-paths`
+   ;; silently `(filter vector?)`-dropped malformed `:sensitive` / `:large`
+   ;; entries and only honoured a LITERAL `true` for `:sensitive?` / `:large?`,
+   ;; so a typo (`:sensitive [:token]`, `:large "blob"`, `:sensitive? :yes`,
+   ;; `:large? 1`) registered with a normal return value and NO diagnostic
+   ;; while the intended redaction / large-elision silently never happened.
+   ;; That is the worst failure mode for a SAFETY feature: the author believes
+   ;; a slot is protected and it is not. Reject at the API boundary instead —
+   ;; same fail-FAST posture the core flow-path validation already takes, and
+   ;; the same `:rf.error/flow-bad-*` family. These rules fire AFTER the core
+   ;; `:id` / `:inputs` / `:output` / `:path` rules (a flow with a broken
+   ;; required shape reports that first), but BEFORE any registry / app-db /
+   ;; elision-declaration state mutates (validate-flow is the first call in
+   ;; `reg-flow`, before `frame-id` / the `swap!`), so a rejected registration
+   ;; installs NO flow row and NO elision declaration.
+   ;;
+   ;; Vector-of-subpaths rules: `:sensitive` / `:large`, when PRESENT, must be
+   ;; a vector whose every entry is a valid output subpath — a vector of
+   ;; scalar keys, with `[]` legal (the `[[]]` whole-output convention,
+   ;; Spec 015:81). `valid-output-subpath?` is `valid-path?` minus the
+   ;; non-empty requirement. The `vector?`-of-the-whole and
+   ;; every-entry-well-formed checks are split so the diagnostic distinguishes
+   ;; "you passed a non-vector" from "one of your entries is malformed".
+   {:pred     (fn [flow] (or (not (contains? flow :sensitive))
+                             (vector? (:sensitive flow))))
+    :error-kw :rf.error/flow-bad-marks
+    :reason   ":sensitive, when present, must be a vector of output subpaths (each a vector of scalar keys; [] marks the whole output)"
+    :extras   (fn [flow] {:bad-key :sensitive :bad-value (:sensitive flow)})}
+
+   {:pred     (fn [flow] (or (not (contains? flow :sensitive))
+                             (every? valid-output-subpath? (:sensitive flow))))
+    :error-kw :rf.error/flow-bad-marks
+    :reason   ":sensitive entries must each be a vector of scalar keys (keyword / string / integer / symbol / boolean); [] marks the whole output"
+    :extras   (fn [flow] {:bad-key     :sensitive
+                          :bad-entries (vec (remove valid-output-subpath? (:sensitive flow)))})}
+
+   {:pred     (fn [flow] (or (not (contains? flow :large))
+                             (vector? (:large flow))))
+    :error-kw :rf.error/flow-bad-marks
+    :reason   ":large, when present, must be a vector of output subpaths (each a vector of scalar keys; [] marks the whole output)"
+    :extras   (fn [flow] {:bad-key :large :bad-value (:large flow)})}
+
+   {:pred     (fn [flow] (or (not (contains? flow :large))
+                             (every? valid-output-subpath? (:large flow))))
+    :error-kw :rf.error/flow-bad-marks
+    :reason   ":large entries must each be a vector of scalar keys (keyword / string / integer / symbol / boolean); [] marks the whole output"
+    :extras   (fn [flow] {:bad-key     :large
+                          :bad-entries (vec (remove valid-output-subpath? (:large flow)))})}
+
+   ;; Whole-output boolean rules: `:sensitive?` / `:large?`, when PRESENT,
+   ;; must be an actual boolean. `explicit-flow-output-mark-paths` and the
+   ;; propagation resolver branch on literal `true` / `false`; any other
+   ;; present value (`:yes`, `1`, `"true"`) would silently behave as ABSENT
+   ;; (neither force-mark nor opt-out), which is exactly the fail-open trap.
+   {:pred     (fn [flow] (or (not (contains? flow :sensitive?))
+                             (boolean? (:sensitive? flow))))
+    :error-kw :rf.error/flow-bad-marks
+    :reason   ":sensitive?, when present, must be a boolean (true forces the whole output sensitive; false opts out of propagation)"
+    :extras   (fn [flow] {:bad-key :sensitive? :bad-value (:sensitive? flow)})}
+
+   {:pred     (fn [flow] (or (not (contains? flow :large?))
+                             (boolean? (:large? flow))))
+    :error-kw :rf.error/flow-bad-marks
+    :reason   ":large?, when present, must be a boolean (true forces the whole output large)"
+    :extras   (fn [flow] {:bad-key :large? :bad-value (:large? flow)})}])
 
 (defn- validate-flow [flow]
   (some (fn [{:keys [pred error-kw reason extras]}]

--- a/implementation/flows/test/re_frame/flows_output_marks_test.clj
+++ b/implementation/flows/test/re_frame/flows_output_marks_test.clj
@@ -657,3 +657,191 @@
         "the propagated output mark is dropped once the input is no longer marked")
     (is (= "x!-out" (computed-result :echo))
         "the output rides raw after declassification of the input")))
+
+;; ---------------------------------------------------------------------------
+;; 8. Malformed classification metadata is rejected FAIL-CLOSED (rf2-cgk0wb)
+;;
+;; Pre-fix, the OPTIONAL output data-classification keys fail-OPEN:
+;;   - `explicit-flow-output-mark-paths` silently `(filter vector?)`-dropped
+;;     malformed `:sensitive` / `:large` entries (`:sensitive [:token]`,
+;;     `:large "blob"`), and
+;;   - only a LITERAL `true` was honoured for `:sensitive?` / `:large?`, so a
+;;     present-but-malformed `:sensitive? :yes` / `:large? 1` behaved as ABSENT.
+;; A privacy/size declaration typo therefore registered with a normal return
+;; value and NO diagnostic, while the intended redaction NEVER happened — the
+;; worst failure mode for a safety feature. `validate-flow` now rejects each
+;; malformation at the API boundary with the `:rf.error/flow-bad-marks`
+;; discriminator BEFORE any registry / app-db / elision-declaration state
+;; mutates. These tests pin the rejection id + the canonical thrown-error
+;; shape, and prove NO flow row and NO elision declaration is installed.
+;; ---------------------------------------------------------------------------
+
+(defn- flow-row?
+  "True iff `flow-id` has a registry row on `:rf/default` after a (rejected)
+  registration attempt."
+  [flow-id]
+  (contains? (get (flows/flows-snapshot) :rf/default) flow-id))
+
+(defn- no-decls?
+  "True iff neither elision sub-map carries any entry on `:rf/default`."
+  []
+  (and (empty? (sensitive-decls :rf/default))
+       (empty? (large-decls :rf/default))))
+
+(deftest reg-flow-rejects-malformed-sensitive-vector
+  (testing ":sensitive [:token] (bare keywords, not vector-of-subpaths) is rejected"
+    (let [ex   (try (rf/reg-flow {:id        :bad/sens
+                                  :inputs    [[:n]]
+                                  :output    identity
+                                  :path      [:out]
+                                  :sensitive [:token]})    ; should be [[:token]]
+                    (catch Throwable t t))
+          data (ex-data ex)]
+      (is (some? ex) "registration threw")
+      (is (= :rf.error/flow-bad-marks (:rf.error/id data))
+          ":rf.error/id carries the bad-marks discriminator")
+      (is (= ":rf.error/flow-bad-marks" (ex-message ex))
+          "message string is the stringified discriminator kw")
+      (is (= 'rf/reg-flow (:where data))         ":where names the user-facing surface")
+      (is (= :fix-registration (:recovery data))  ":recovery names the disposition")
+      (is (= :sensitive (:bad-key data))          ":bad-key names the offending classification key")
+      (is (= [:token] (:bad-entries data))        ":bad-entries names the malformed entry")
+      (is (not (flow-row? :bad/sens))  "no flow row installed for a rejected registration")
+      (is (no-decls?)                  "no elision declaration installed")))
+  (testing ":sensitive \"blob\" (non-vector whole value) is rejected with :bad-value"
+    (let [ex   (try (rf/reg-flow {:id        :bad/sens2
+                                  :inputs    [[:n]]
+                                  :output    identity
+                                  :path      [:out]
+                                  :sensitive "blob"})
+                    (catch Throwable t t))
+          data (ex-data ex)]
+      (is (= :rf.error/flow-bad-marks (:rf.error/id data)))
+      (is (= :sensitive (:bad-key data)))
+      (is (= "blob" (:bad-value data)) ":bad-value names the non-vector value")
+      (is (not (flow-row? :bad/sens2)))
+      (is (no-decls?)))))
+
+(deftest reg-flow-rejects-malformed-large-vector
+  (testing ":large \"blob\" (a string, not a vector) is rejected"
+    (let [ex   (try (rf/reg-flow {:id     :bad/large
+                                  :inputs [[:n]]
+                                  :output identity
+                                  :path   [:out]
+                                  :large  "blob"})
+                    (catch Throwable t t))
+          data (ex-data ex)]
+      (is (some? ex) "registration threw")
+      (is (= :rf.error/flow-bad-marks (:rf.error/id data))
+          ":rf.error/id carries the bad-marks discriminator")
+      (is (= :large (:bad-key data))   ":bad-key names :large")
+      (is (= "blob" (:bad-value data)) ":bad-value names the non-vector value")
+      (is (not (flow-row? :bad/large)) "no flow row installed")
+      (is (no-decls?)                  "no elision declaration installed")))
+  (testing ":large [42] (a scalar entry, not a subpath vector) is rejected"
+    (let [ex   (try (rf/reg-flow {:id     :bad/large2
+                                  :inputs [[:n]]
+                                  :output identity
+                                  :path   [:out]
+                                  :large  [42]})
+                    (catch Throwable t t))
+          data (ex-data ex)]
+      (is (= :rf.error/flow-bad-marks (:rf.error/id data)))
+      (is (= :large (:bad-key data)))
+      (is (= [42] (:bad-entries data)) ":bad-entries names the malformed entry")
+      (is (not (flow-row? :bad/large2)))
+      (is (no-decls?)))))
+
+(deftest reg-flow-rejects-malformed-sensitive?-boolean
+  (testing ":sensitive? :yes (not a boolean) is rejected"
+    (let [ex   (try (rf/reg-flow {:id         :bad/sensq
+                                  :inputs     [[:n]]
+                                  :output     identity
+                                  :path       [:out]
+                                  :sensitive? :yes})
+                    (catch Throwable t t))
+          data (ex-data ex)]
+      (is (some? ex) "registration threw")
+      (is (= :rf.error/flow-bad-marks (:rf.error/id data))
+          ":rf.error/id carries the bad-marks discriminator")
+      (is (= :sensitive? (:bad-key data)) ":bad-key names :sensitive?")
+      (is (= :yes (:bad-value data))      ":bad-value names the non-boolean value")
+      (is (not (flow-row? :bad/sensq))    "no flow row installed")
+      (is (no-decls?)                     "no elision declaration installed")))
+  (testing ":sensitive? nil (present-but-nil) is rejected (not a literal false opt-out)"
+    (let [ex (try (rf/reg-flow {:id         :bad/sensq-nil
+                                :inputs     [[:n]]
+                                :output     identity
+                                :path       [:out]
+                                :sensitive? nil})
+                  (catch Throwable t t))]
+      (is (= :rf.error/flow-bad-marks (:rf.error/id (ex-data ex)))
+          "a present nil is rejected — only literal true/false are valid")
+      (is (not (flow-row? :bad/sensq-nil))))))
+
+(deftest reg-flow-rejects-malformed-large?-boolean
+  (testing ":large? 1 (not a boolean) is rejected"
+    (let [ex   (try (rf/reg-flow {:id     :bad/largeq
+                                  :inputs [[:n]]
+                                  :output identity
+                                  :path   [:out]
+                                  :large? 1})
+                    (catch Throwable t t))
+          data (ex-data ex)]
+      (is (some? ex) "registration threw")
+      (is (= :rf.error/flow-bad-marks (:rf.error/id data))
+          ":rf.error/id carries the bad-marks discriminator")
+      (is (= :large? (:bad-key data)) ":bad-key names :large?")
+      (is (= 1 (:bad-value data))     ":bad-value names the non-boolean value")
+      (is (not (flow-row? :bad/largeq)) "no flow row installed")
+      (is (no-decls?)                   "no elision declaration installed"))))
+
+(deftest reg-flow-accepts-empty-subpath-whole-output-mark
+  (testing "the `[[]]` whole-output convention is VALID (a regression guard so
+            the tightened validator does not reject the legitimate whole-value
+            mark — [] is the one empty subpath that is legal)"
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
+    (is (= :ok/whole
+           (rf/reg-flow {:id        :ok/whole
+                         :inputs    [[:n]]
+                         :output    (fn [_] {:v 1})
+                         :path      [:derived :whole]
+                         :sensitive [[]]}))
+        "a `:sensitive [[]]` whole-output mark registers cleanly")
+    (is (contains? (sensitive-decls :rf/default) [:derived :whole])
+        "the whole-output declaration is installed at :path itself")))
+
+(deftest fx-reg-flow-rejects-malformed-marks-no-state-installed
+  ;; The runtime `:rf.fx/reg-flow` effect routes through the SAME
+  ;; `registry/reg-flow` (via `:flows/reg-flow`), so `validate-flow` — the
+  ;; first call in `reg-flow`, before `frame-id` / the `swap!` — rejects a
+  ;; malformed-marks registration on the fx path too, BEFORE any flow row or
+  ;; elision declaration is installed. Whether the throw escapes the drain or
+  ;; is routed to the framework error handler, the post-condition is the same:
+  ;; the registry and the elision registry stay clean.
+  (testing ":rf.fx/reg-flow with malformed :sensitive installs no flow row / decl"
+    (rf/reg-event-fx :enter-bad-sens
+      (fn [_ _]
+        {:fx [[:rf.fx/reg-flow {:id        :fx/bad-sens
+                                :inputs    [[:n]]
+                                :output    identity
+                                :path      [:out]
+                                :sensitive [:token]}]]}))   ; malformed
+    (try (rf/dispatch-sync [:enter-bad-sens]) (catch Throwable _ nil))
+    (is (not (flow-row? :fx/bad-sens))
+        "the malformed fx registration installed no flow row")
+    (is (no-decls?)
+        "the malformed fx registration installed no elision declaration"))
+  (testing ":rf.fx/reg-flow with malformed :sensitive? installs no flow row / decl"
+    (rf/reg-event-fx :enter-bad-sensq
+      (fn [_ _]
+        {:fx [[:rf.fx/reg-flow {:id         :fx/bad-sensq
+                                :inputs     [[:n]]
+                                :output     identity
+                                :path       [:out]
+                                :sensitive? :yes}]]}))      ; malformed
+    (try (rf/dispatch-sync [:enter-bad-sensq]) (catch Throwable _ nil))
+    (is (not (flow-row? :fx/bad-sensq))
+        "the malformed fx registration installed no flow row")
+    (is (no-decls?)
+        "the malformed fx registration installed no elision declaration")))


### PR DESCRIPTION
Closes the remaining fail-open gap rf2-cgk0wb identified in implementation/flows: reg-flow accepted malformed output data-classification metadata silently. `:sensitive` / `:large` entries were `(filter vector?)`-dropped and `:sensitive?` / `:large?` honoured only on a literal `true`, so a typo (`:sensitive [:token]`, `:large "blob"`, `:sensitive? :yes`, `:large? 1`) registered cleanly with no diagnostic while the intended redaction never happened — the worst failure mode for a safety feature. validate-flow now rejects each malformation at the API boundary with the `:rf.error/flow-bad-marks` discriminator (canonical thrown-error shape; `:bad-key` + `:bad-value` / `:bad-entries`) before any registry / app-db / elision-declaration state mutates. Covers both the public API and the runtime `:rf.fx/reg-flow` path (both route through `registry/reg-flow`). The `[[]]` whole-output convention stays valid (regression-guarded). The other gap cgk0wb flagged — input-to-output classification PROPAGATION — was already implemented by #3608 (rf2-ihfz9o) and is covered by its host-gate tests (incl. `propagation-t2-pending-post-flow-redacts-output`, the host-gate equivalent of the Spec 015:568 `flow-output-inherits-from-input` fixture); Spec 015's propagation claim is now accurate, so no spec change. ## Quality gates - `clojure -M:test` in implementation/flows: 184 tests, 4759 assertions, 0 failures, 0 errors. - `npm run test:cljs` (implementation): 6104 tests, 21758 assertions, 0 failures, 0 errors.