### PR TITLE
refactor(scripts): runner consolidation + dependency reproducibility (rf2-vtp2er)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2170,8 +2170,13 @@ jobs:
         working-directory: tools/re-frame2-pair-mcp
         run: npx shadow-cljs compile server
 
+      # rf2-vtp2er — lockfile-exact install. tools/mcp-conformance ships a
+      # committed package-lock.json, so `npm ci` gives a reproducible,
+      # drift-detecting install (fails if package.json + lock diverge)
+      # rather than `npm install` resolving semver ranges against the live
+      # registry. Matches the posture test:mcp-conformance now uses locally.
       - name: Install mcp-conformance deps
-        run: npm install
+        run: npm ci
 
       # exec-safety helpers (rf2-33vvc): unit-test the
       # trusted-PATH-resolution + symlink-safe-unlink helpers that the
@@ -2291,8 +2296,10 @@ jobs:
             ${{ runner.os }}-clj-tools-story-mcp-
             ${{ runner.os }}-clj-
 
+      # rf2-vtp2er — lockfile-exact install (committed package-lock.json).
+      # See the mcp-conformance-re-frame2-pair job for rationale.
       - name: Install mcp-conformance deps
-        run: npm install
+        run: npm ci
 
       - name: Run story-mcp end-to-end MCP-client conformance
         run: npm run test:story

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -36,7 +36,7 @@
     "test:xray-feature-gate": "node scripts/serve-and-run-xray-feature-gate.cjs",
     "test:xray-feature-gate:smoke": "node scripts/serve-and-run-xray-feature-gate.cjs --smoke",
     "test:story-static": "node scripts/check-story-static.cjs",
-    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_lint-workflow-policy.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_story-script-runners-policy.test.cjs && node scripts/_impl-browser-runners-pageerror-policy.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs && node scripts/check-reagent-slim-boundary.test.cjs",
+    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_lint-workflow-policy.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_story-script-runners-policy.test.cjs && node scripts/_impl-browser-runners-pageerror-policy.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_mcp-conformance-install-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs && node scripts/check-reagent-slim-boundary.test.cjs",
     "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs && node scripts/_read-release-bundle.test.cjs && node scripts/dev-testbed.test.cjs",
     "test:mcp-conformance": "node scripts/test-mcp-conformance.cjs"
   }

--- a/implementation/scripts/_local-browser-harness.test.cjs
+++ b/implementation/scripts/_local-browser-harness.test.cjs
@@ -255,6 +255,71 @@ test('waitForOwnedHttpReady refuses a foreign server (token mismatch)', async ()
   }
 });
 
+// rf2-vtp2er — child-exited abort path. Both migrated callers
+// (serve-and-run-browser-tests.cjs, check-story-static.cjs) and the Xray
+// gate pass `isAborted: () => <server died>` so the owned-readiness wait
+// fails fast when http-server exits before becoming reachable, instead of
+// burning the full timeout. Model the server never coming up + isAborted
+// flipping true: the wait must resolve { ok:false, reason:'child-exited' }.
+test('waitForOwnedHttpReady aborts with child-exited when isAborted goes true', async () => {
+  let aborted = false;
+  const result = await waitForOwnedHttpReady(1, 'our-token', Date.now() + 2000, {
+    pollMs: 10,
+    isAborted: () => aborted,
+  });
+  // Flip after construction is irrelevant here — :1 is unreachable, so the
+  // first isAborted() check inside the loop decides. Assert the immediate
+  // pre-flighted abort path.
+  aborted = true;
+  const result2 = await waitForOwnedHttpReady(1, 'our-token', Date.now() + 2000, {
+    pollMs: 10,
+    isAborted: () => aborted,
+  });
+  // result1 used aborted=false the whole time against an unreachable port →
+  // it must time out (never reachable), not falsely report child-exited.
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'timeout');
+  // result2 had isAborted()===true from the first check → child-exited.
+  assert.equal(result2.ok, false);
+  assert.equal(result2.reason, 'child-exited');
+});
+
+// rf2-vtp2er — the exact owned-readiness happy path the migrated browser-
+// test / story-static launchers now drive: a server that starts tokenless
+// (http-server is up but hasn't published /.rf-harness-token yet) and then
+// begins serving the matching token. The wait must keep polling through the
+// tokenless window and resolve ok once the token appears — proving the
+// shared primitive covers the "server racing to publish the sentinel" shape
+// the bespoke per-caller waitForReady copies handled.
+test('waitForOwnedHttpReady polls through a tokenless window then succeeds when the token appears', async () => {
+  const token = crypto.randomBytes(8).toString('hex');
+  let tokenLive = false;
+  const server = http.createServer((req, res) => {
+    if (req.url === `/${TOKEN_FILE_BASENAME}`) {
+      if (!tokenLive) {
+        res.writeHead(404);
+        res.end('not yet');
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end(token);
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end('ok');
+  });
+  const port = await listenOnLoopback(server);
+  // Publish the token shortly after the wait begins.
+  const flip = setTimeout(() => { tokenLive = true; }, 80);
+  try {
+    const result = await waitForOwnedHttpReady(port, token, Date.now() + 3000, { pollMs: 10 });
+    assert.deepEqual(result, { ok: true });
+  } finally {
+    clearTimeout(flip);
+    server.close();
+  }
+});
+
 test('waitForOwnedHttpReady reports token-never-served for a tokenless responder', async () => {
   // Reachable, but never serves /.rf-harness-token (404). Must not be
   // mistaken for "ours".

--- a/implementation/scripts/_mcp-conformance-install-policy.test.cjs
+++ b/implementation/scripts/_mcp-conformance-install-policy.test.cjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/*
+ * Reproducible-install policy gate for `test-mcp-conformance.cjs`
+ * (rf2-vtp2er).
+ *
+ * `npm run test:mcp-conformance` must be a (near-)pure verification
+ * command: it must not silently re-mutate dependency state on every run,
+ * and where a tool package ships a committed package-lock.json the runner
+ * must install lockfile-exact via `npm ci` (which FAILS on package.json /
+ * lock drift) rather than `npm install` (which resolves semver ranges
+ * against the live registry and can rewrite the lock).
+ *
+ * This is a STATIC source-policy gate (it reads the runner source + the
+ * on-disk lockfile state; it does NOT spawn npm). It pins three
+ * invariants so a future edit can't quietly regress the posture:
+ *
+ *   1. Install prep steps are declared via the `install: true` marker and
+ *      routed through `resolveInstallStep`, NOT hard-coded as
+ *      `args: ['install']`. (The marker is what lets the runner pick the
+ *      most reproducible install per-package at run time.)
+ *   2. `resolveInstallStep` chooses `npm ci` when a committed lockfile is
+ *      present, and only ever falls back to `npm install` when there is no
+ *      committed lockfile.
+ *   3. LIVE: every tool package this runner installs that currently ships
+ *      a committed package-lock.json resolves to `npm ci` (and a clean
+ *      `npm ci --dry-run`-able lock). A package without a committed lock
+ *      (a deliberately lock-gitignored published package) is exempt and
+ *      may bootstrap via a skip-if-present `npm install`.
+ *
+ * Wired into `package.json` via `test:script-policy`.
+ */
+
+const assert = require('assert/strict');
+const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const SCRIPTS_DIR = __dirname;
+const RUNNER_PATH = path.join(SCRIPTS_DIR, 'test-mcp-conformance.cjs');
+const REPO_ROOT = path.resolve(SCRIPTS_DIR, '..', '..');
+const TOOLS = path.join(REPO_ROOT, 'tools');
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+const RUNNER_SRC = fs.readFileSync(RUNNER_PATH, 'utf8');
+
+// Strip line- and block-comments so policy assertions match EXECUTABLE
+// source only — the doc-comment necessarily quotes `npm install`. Reuse
+// the same simple stripper shape as _script-spawn-policy.test.cjs.
+function stripComments(src) {
+  let out = '';
+  let i = 0;
+  const n = src.length;
+  let inLine = false;
+  let inBlock = false;
+  let inStr = false;
+  let strQuote = '';
+  while (i < n) {
+    const c = src[i];
+    const c2 = src[i + 1];
+    if (inLine) {
+      if (c === '\n') { inLine = false; out += c; }
+      i += 1;
+      continue;
+    }
+    if (inBlock) {
+      if (c === '*' && c2 === '/') { inBlock = false; i += 2; continue; }
+      i += 1;
+      continue;
+    }
+    if (inStr) {
+      out += c;
+      if (c === '\\') { out += c2 == null ? '' : c2; i += 2; continue; }
+      if (c === strQuote) { inStr = false; strQuote = ''; }
+      i += 1;
+      continue;
+    }
+    if (c === '/' && c2 === '/') { inLine = true; i += 2; continue; }
+    if (c === '/' && c2 === '*') { inBlock = true; i += 2; continue; }
+    if (c === '"' || c === "'" || c === '`') {
+      inStr = true; strQuote = c; out += c; i += 1; continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
+const RUNNER_CODE = stripComments(RUNNER_SRC);
+
+// 1. Install steps are declared via `install: true` + resolved through
+//    resolveInstallStep — not hard-coded `args: ['install']`.
+test('test-mcp-conformance.cjs declares install prep via the install marker', () => {
+  assert.match(
+    RUNNER_CODE,
+    /\binstall:\s*true\b/,
+    "expected install prep steps declared with `install: true` so the " +
+      'runner can pick npm ci / npm install per-package reproducibly.',
+  );
+});
+
+test('test-mcp-conformance.cjs routes install steps through resolveInstallStep', () => {
+  assert.match(
+    RUNNER_CODE,
+    /resolveInstallStep\s*\(/,
+    'expected the run loop to resolve install steps via resolveInstallStep.',
+  );
+  assert.match(
+    RUNNER_CODE,
+    /function\s+resolveInstallStep\b/,
+    'expected resolveInstallStep to be defined in the runner.',
+  );
+});
+
+test('test-mcp-conformance.cjs does NOT hard-code npm install args in a STEPS prep entry', () => {
+  // A literal `args: ['install']` inside a STEPS entry (npm install
+  // hard-coded as a prep step) is exactly the unpinned mutation this gate
+  // forbids — install prep must flow through resolveInstallStep, which
+  // prefers `npm ci` where a lockfile exists. The ONE legitimate
+  // `args: ['install']` occurrence is the first-run bootstrap fallback
+  // INSIDE resolveInstallStep (gated on "no committed lock AND no
+  // node_modules"); exclude that function body before scanning.
+  const codeOutsideResolver = RUNNER_CODE.replace(
+    /function\s+resolveInstallStep\b[\s\S]*?\n\}/,
+    '/* resolveInstallStep body elided for this scan */',
+  );
+  assert.doesNotMatch(
+    codeOutsideResolver,
+    /args:\s*\[\s*['"]install['"]\s*\]/,
+    "test-mcp-conformance.cjs hard-codes `args: ['install']` for a prep " +
+      'step — declare it `install: true` and let resolveInstallStep pick ' +
+      'the reproducible command (rf2-vtp2er).',
+  );
+  // Sanity: the elision actually removed the resolver (so we didn't just
+  // pass because the regex failed to find the function).
+  assert.ok(
+    codeOutsideResolver.includes('resolveInstallStep body elided'),
+    'expected the resolveInstallStep body to be elided before the scan.',
+  );
+});
+
+// 2. resolveInstallStep prefers `npm ci` when a lockfile is present.
+test('resolveInstallStep selects npm ci when a committed lockfile is present', () => {
+  // The ci branch is gated on the committed-lockfile predicate and must
+  // emit `['ci']`. Match both the predicate and the ci args near it.
+  assert.match(
+    RUNNER_CODE,
+    /hasCommittedLockfile\s*\(/,
+    'resolveInstallStep must branch on a committed-lockfile predicate.',
+  );
+  assert.match(
+    RUNNER_CODE,
+    /args:\s*\[\s*['"]ci['"]\s*\]/,
+    'resolveInstallStep must install lockfile-backed packages via `npm ci`.',
+  );
+});
+
+// 3. LIVE: every tool package the runner installs that ships a committed
+//    package-lock.json must end up on `npm ci`, and that lock must be a
+//    clean `npm ci --dry-run`-able lock (no drift). Packages WITHOUT a
+//    committed lock are exempt (deliberately lock-gitignored published
+//    packages bootstrap via skip-if-present npm install).
+//
+// We re-derive the package set from the runner source rather than
+// hard-coding it: any `cwd: <CONST>` paired with an `install: true` step
+// names a package the runner installs.
+const TOOL_PKG_CONSTS = {
+  PAIR_MCP: path.join(TOOLS, 're-frame2-pair-mcp'),
+  CONFORMANCE: path.join(TOOLS, 'mcp-conformance'),
+  STORY_MCP: path.join(TOOLS, 'story-mcp'),
+};
+
+function installedPkgDirs() {
+  // Find `{ ... install: true, ... cwd: <CONST>, ... }` blocks. The STEPS
+  // entries put `install: true` and `cwd: <CONST>` within a few lines of
+  // each other; scan for the cwd const that accompanies an install marker.
+  const dirs = new Set();
+  const stepRe = /\{[^}]*\binstall:\s*true\b[^}]*\}/g;
+  let m;
+  while ((m = stepRe.exec(RUNNER_CODE)) !== null) {
+    const block = m[0];
+    const cwdMatch = block.match(/cwd:\s*([A-Z_]+)/);
+    if (cwdMatch && TOOL_PKG_CONSTS[cwdMatch[1]]) {
+      dirs.add(TOOL_PKG_CONSTS[cwdMatch[1]]);
+    }
+  }
+  return [...dirs];
+}
+
+test('LIVE: lockfile-backed tool packages the runner installs have a present, drift-free lock', () => {
+  const pkgDirs = installedPkgDirs();
+  assert.ok(
+    pkgDirs.length > 0,
+    'expected to derive at least one install-prep package dir from the runner source.',
+  );
+  let checkedLocked = 0;
+  for (const pkgDir of pkgDirs) {
+    const lock = path.join(pkgDir, 'package-lock.json');
+    if (!fs.existsSync(lock)) {
+      // No committed lock — exempt (bootstrap-only npm install path).
+      continue;
+    }
+    checkedLocked += 1;
+
+    // Hermetic structural drift check (no network, no npm spawn): npm ci
+    // refuses to run when package.json's declared deps are not all present
+    // in the lockfile's root-package dep map. Assert that invariant
+    // directly so the gate is deterministic on offline CI rather than
+    // depending on registry reachability.
+    const pkg = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf8'));
+    const lockJson = JSON.parse(fs.readFileSync(lock, 'utf8'));
+    const rootPkg = (lockJson.packages && lockJson.packages['']) || {};
+    const lockedRootDeps = {
+      ...(rootPkg.dependencies || {}),
+      ...(rootPkg.devDependencies || {}),
+      ...(rootPkg.optionalDependencies || {}),
+    };
+    const declared = {
+      ...(pkg.dependencies || {}),
+      ...(pkg.devDependencies || {}),
+      ...(pkg.optionalDependencies || {}),
+    };
+    for (const [name, range] of Object.entries(declared)) {
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(lockedRootDeps, name),
+        `${path.relative(REPO_ROOT, pkgDir)}: package.json declares "${name}" ` +
+          'but package-lock.json does not record it for the root package — ' +
+          'package.json and the lock have drifted. The runner installs this ' +
+          'package via `npm ci`, which would FAIL. Re-run `npm install` and ' +
+          'commit the refreshed lock (rf2-vtp2er).',
+      );
+      assert.equal(
+        lockedRootDeps[name],
+        range,
+        `${path.relative(REPO_ROOT, pkgDir)}: package.json declares "${name}": ` +
+          `"${range}" but the lock records "${lockedRootDeps[name]}" — drift. ` +
+          'The runner installs via `npm ci`, which would FAIL. Re-sync the lock.',
+      );
+    }
+
+    // Belt-and-braces: a clean `npm ci --dry-run` is the authoritative
+    // drift oracle. Run it opportunistically, but only FAIL on the
+    // definitive lock-mismatch signal — never on a network/registry error
+    // (so this gate stays green on offline CI). cp/the dry-run is the only
+    // network-touching line in the suite; everything above is hermetic.
+    const res = cp.spawnSync(
+      process.platform === 'win32' ? 'npm.cmd' : 'npm',
+      ['ci', '--dry-run', '--no-audit', '--no-fund'],
+      { cwd: pkgDir, encoding: 'utf8' },
+    );
+    if (res.error || res.status == null) {
+      // npm unavailable / spawn failure — structural check above stands.
+      continue;
+    }
+    if (res.status !== 0) {
+      const stderr = String(res.stderr || '');
+      const isDrift =
+        /can only install packages when your package\.json and package-lock\.json/i.test(stderr) ||
+        /lock file('?s)? .*(out of sync|missing)/i.test(stderr) ||
+        /Missing:.*from lock file/i.test(stderr);
+      assert.ok(
+        !isDrift,
+        `npm ci --dry-run reported lock drift in ${path.relative(REPO_ROOT, pkgDir)} ` +
+          `— the runner's npm ci would fail. Re-sync the lock.\nstderr:\n${stderr}`,
+      );
+      // Non-drift non-zero (e.g. offline registry error) — tolerate.
+    }
+  }
+  assert.ok(
+    checkedLocked > 0,
+    'expected at least one lockfile-backed tool package (mcp-conformance) ' +
+      'to be exercised by this gate.',
+  );
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+    console.log(`PASS  ${name}`);
+  } catch (err) {
+    failed += 1;
+    console.error(`FAIL  ${name}`);
+    console.error(err && err.stack ? err.stack : err);
+  }
+}
+
+if (failed > 0) {
+  console.error(`mcp-conformance-install-policy tests: ${failed} failed.`);
+  process.exit(1);
+}
+
+console.log(`mcp-conformance-install-policy tests: ${tests.length} passed.`);

--- a/implementation/scripts/_script-spawn-policy.test.cjs
+++ b/implementation/scripts/_script-spawn-policy.test.cjs
@@ -273,6 +273,58 @@ for (const base of IMPL_LOOPBACK_LAUNCHERS) {
   });
 }
 
+// rf2-vtp2er — runner-consolidation guard. The browser-test and
+// story-static launchers were migrated off their bespoke copies of the
+// ownership-token / port-fallback protocol onto the shared
+// local-browser-harness.cjs primitives (the same API the Xray gate
+// consumes). Pin that: each must (a) import resolveServePort +
+// waitForOwnedHttpReady from the shared helper, and (b) NOT redefine the
+// local copies that previously lived inline (`function fetchToken`,
+// `function waitForReady`, `function isPortFree`, `function findFreePort`,
+// `function probe`). A future edit re-introducing a bespoke copy — the
+// exact three-implementations-in-one-surface drift the bead removed —
+// trips here. (Scanned over stripped source so a comment mentioning the
+// old names is not a false positive.)
+const CONSOLIDATED_LAUNCHERS = [
+  'serve-and-run-browser-tests.cjs',
+  'check-story-static.cjs',
+];
+const SHARED_HARNESS_IMPORT_RE = /require\(\s*['"]\.\/lib\/local-browser-harness\.cjs['"]\s*\)/;
+const RESOLVE_SERVE_PORT_RE = /\bresolveServePort\b/;
+const WAIT_OWNED_RE = /\bwaitForOwnedHttpReady\b/;
+const LOCAL_HARNESS_DEFN_RES = [
+  /function\s+fetchToken\b/,
+  /function\s+waitForReady\b/,
+  /function\s+isPortFree\b/,
+  /function\s+findFreePort\b/,
+  /function\s+probe\b/,
+];
+for (const base of CONSOLIDATED_LAUNCHERS) {
+  test(`${base}: consumes the shared local-browser-harness port/token primitives (rf2-vtp2er)`, () => {
+    const code = stripComments(
+      fs.readFileSync(path.join(SCRIPTS_DIR, base), 'utf8'),
+    );
+    assert.match(code, SHARED_HARNESS_IMPORT_RE,
+      `${base} must require ./lib/local-browser-harness.cjs.`);
+    assert.match(code, RESOLVE_SERVE_PORT_RE,
+      `${base} must resolve its serve port via the shared resolveServePort.`);
+    assert.match(code, WAIT_OWNED_RE,
+      `${base} must wait for owned readiness via the shared waitForOwnedHttpReady.`);
+  });
+
+  test(`${base}: does NOT redefine the consolidated harness primitives (rf2-vtp2er)`, () => {
+    const code = stripComments(
+      fs.readFileSync(path.join(SCRIPTS_DIR, base), 'utf8'),
+    );
+    for (const re of LOCAL_HARNESS_DEFN_RES) {
+      assert.doesNotMatch(code, re,
+        `${base} redefines a harness primitive that now lives in ` +
+          `./lib/local-browser-harness.cjs — import it instead of keeping ` +
+          `a bespoke copy (rf2-vtp2er consolidation).`);
+    }
+  });
+}
+
 // stripComments sanity: it must remove a forbidden token that appears
 // only in a comment, but keep one that appears in real code. Guards the
 // gate itself against false-negatives (a comment masking a live spawn)

--- a/implementation/scripts/check-story-static.cjs
+++ b/implementation/scripts/check-story-static.cjs
@@ -41,16 +41,17 @@
 const { spawnSync } = require('child_process');
 const crypto = require('crypto');
 const fs = require('fs');
-const http = require('http');
-const net = require('net');
 const path = require('path');
 const {
   createDiagnosticBuffer,
   isVerboseTests,
 } = require('./lib/browser-test-report.cjs');
 const {
+  TOKEN_FILE_BASENAME,
   createHarnessCleanup,
+  resolveServePort,
   spawnHarnessProcess,
+  waitForOwnedHttpReady,
 } = require('./lib/local-browser-harness.cjs');
 
 const IMPL_ROOT = path.resolve(__dirname, '..');
@@ -79,8 +80,9 @@ cleanup.addCleanup(() => {
 cleanup.installSignalHandlers();
 
 // Per rf2-o38lb: ownership-token sentinel, same shape as
-// serve-and-run-browser-tests.cjs.
-const TOKEN_FILE_BASENAME = '.rf-harness-token';
+// serve-and-run-browser-tests.cjs. The basename + the probe/token-fetch/
+// owned-readiness mechanics come from the shared local-browser-harness.cjs;
+// this script only owns the per-run token write/cleanup.
 const TOKEN_PATH = path.join(OUT_DIR, TOKEN_FILE_BASENAME);
 
 function addChunk(diagnostics, prefix, chunk, stream = 'stdout') {
@@ -125,39 +127,19 @@ function runBuild(diagnostics) {
   diagnostics.add(`story-build.cjs exited ${result.status}`);
 }
 
-// True if the given TCP port is currently free on 127.0.0.1.
-function isPortFree(port) {
-  return new Promise((resolve) => {
-    const srv = net.createServer();
-    srv.once('error', () => resolve(false));
-    srv.once('listening', () => {
-      srv.close(() => resolve(true));
-    });
-    srv.listen(port, '127.0.0.1');
-  });
-}
-
-// Ask the OS for a free port (listen on 0, capture, close).
-function findFreePort() {
-  return new Promise((resolve, reject) => {
-    const srv = net.createServer();
-    srv.once('error', reject);
-    srv.listen(0, '127.0.0.1', () => {
-      const { port } = srv.address();
-      srv.close(() => resolve(port));
-    });
-  });
-}
-
+// Resolve the port via the shared harness primitive: prefer DEFAULT_PORT
+// when free, else fall back to an OS-chosen free port (rf2-84gzw). The
+// shared resolveServePort carries the strict 1..65535 explicit-port
+// contract (rf2-0u8kz); the launcher-specific fallback note is logged
+// into the diagnostics buffer.
 async function resolvePort(diagnostics) {
-  if (await isPortFree(DEFAULT_PORT)) {
-    return DEFAULT_PORT;
-  }
-  const fallback = await findFreePort();
-  diagnostics.add(
-    `Default port ${DEFAULT_PORT} is busy; falling back to free port ${fallback}.`,
-  );
-  return fallback;
+  return await resolveServePort(DEFAULT_PORT, {
+    onFallback: (preferred, fallback) => {
+      diagnostics.add(
+        `Default port ${preferred} is busy; falling back to free port ${fallback}.`,
+      );
+    },
+  });
 }
 
 function writeOwnershipToken() {
@@ -173,72 +155,6 @@ function removeOwnershipToken() {
   } catch (_) {
     // best-effort cleanup
   }
-}
-
-function probe(port) {
-  return new Promise((resolve) => {
-    const req = http.get(
-      { host: '127.0.0.1', port, path: '/', timeout: 1000 },
-      (res) => {
-        res.resume();
-        resolve(res.statusCode != null);
-      },
-    );
-    req.on('error', () => resolve(false));
-    req.on('timeout', () => {
-      req.destroy();
-      resolve(false);
-    });
-  });
-}
-
-function fetchToken(port) {
-  return new Promise((resolve) => {
-    const req = http.get(
-      { host: '127.0.0.1', port, path: `/${TOKEN_FILE_BASENAME}`, timeout: 1000 },
-      (res) => {
-        if (res.statusCode !== 200) {
-          res.resume();
-          resolve(null);
-          return;
-        }
-        let body = '';
-        res.setEncoding('utf8');
-        res.on('data', (chunk) => { body += chunk; });
-        res.on('end', () => resolve(body.trim()));
-        res.on('error', () => resolve(null));
-      },
-    );
-    req.on('error', () => resolve(null));
-    req.on('timeout', () => { req.destroy(); resolve(null); });
-  });
-}
-
-// Race-style readiness wait: resolves true once the server on `port`
-// answers AND its ownership token matches `expectedToken`. Resolves
-// false on timeout, on early child exit, or if the token mismatches —
-// signals we're talking to a foreign server that happens to be bound
-// to the same port; refuse to proceed against unowned content.
-async function waitForReady(port, expectedToken, deadline, state) {
-  let sawReachable = false;
-  while (Date.now() < deadline) {
-    if (state.exited) return { ok: false, reason: 'child-exited' };
-    if (await probe(port)) {
-      sawReachable = true;
-      if (state.exited) return { ok: false, reason: 'child-exited' };
-      const got = await fetchToken(port);
-      if (got && got === expectedToken) {
-        return { ok: true };
-      }
-      if (got && got !== expectedToken) {
-        return { ok: false, reason: 'token-mismatch', got };
-      }
-      // token absent yet — keep polling.
-    }
-    if (state.exited) return { ok: false, reason: 'child-exited' };
-    await new Promise((r) => setTimeout(r, POLL_MS));
-  }
-  return { ok: false, reason: sawReachable ? 'token-never-served' : 'timeout' };
 }
 
 async function smokeTest(baseUrl, diagnostics) {
@@ -413,8 +329,12 @@ async function smokeTest(baseUrl, diagnostics) {
     }
   });
 
-  // 5. Wait for ready WITH ownership-token verification.
-  const ready = await waitForReady(port, token, Date.now() + READY_TIMEOUT_MS, state);
+  // 5. Wait for ready WITH ownership-token verification via the shared
+  //    harness primitive (rf2-84gzw / rf2-gkf9).
+  const ready = await waitForOwnedHttpReady(port, token, Date.now() + READY_TIMEOUT_MS, {
+    pollMs: POLL_MS,
+    isAborted: () => state.exited,
+  });
   if (!ready.ok) {
     if (ready.reason === 'child-exited' || state.exited) {
       console.error(

--- a/implementation/scripts/serve-and-run-browser-tests.cjs
+++ b/implementation/scripts/serve-and-run-browser-tests.cjs
@@ -25,13 +25,15 @@
 
 const crypto = require('crypto');
 const fs = require('fs');
-const http = require('http');
-const net = require('net');
 const path = require('path');
 const { enforcePolicy, DEFAULT_OUT_ROOT } = require('./_path-policy.cjs');
 const {
+  TOKEN_FILE_BASENAME,
   createHarnessCleanup,
+  isValidExplicitPort,
+  resolveServePort,
   spawnHarnessProcess,
+  waitForOwnedHttpReady,
 } = require('./lib/local-browser-harness.cjs');
 
 const DEFAULT_PORT = 8021;
@@ -127,9 +129,13 @@ function ensureMountPoint() {
 //     gives a 200 to `/` but does NOT have our sentinel — we fail fast
 //     instead of running tests against the wrong asset tree.
 //   - A stale http-server child from a previous aborted run that
-//     re-bound the port between isPortFree() and our spawn — same
+//     re-bound the port between resolveServePort() and our spawn — same
 //     detection: its sentinel won't match this run's nonce.
-const TOKEN_FILE_BASENAME = '.rf-harness-token';
+//
+// The probe/token-fetch/owned-readiness mechanics live in the shared
+// local-browser-harness.cjs (waitForOwnedHttpReady + fetchToken); this
+// script only owns the per-run token write/cleanup + the launcher
+// diagnostics.
 const TOKEN_PATH = path.join(ROOT, TOKEN_FILE_BASENAME);
 
 function writeOwnershipToken() {
@@ -149,133 +155,36 @@ function removeOwnershipToken() {
   }
 }
 
-function fetchToken(port) {
-  return new Promise((resolve) => {
-    const req = http.get(
-      { host: '127.0.0.1', port, path: `/${TOKEN_FILE_BASENAME}`, timeout: 1000 },
-      (res) => {
-        if (res.statusCode !== 200) {
-          res.resume();
-          resolve(null);
-          return;
-        }
-        let body = '';
-        res.setEncoding('utf8');
-        res.on('data', (chunk) => { body += chunk; });
-        res.on('end', () => resolve(body.trim()));
-        res.on('error', () => resolve(null));
-      },
-    );
-    req.on('error', () => resolve(null));
-    req.on('timeout', () => { req.destroy(); resolve(null); });
-  });
-}
-
-// True if the given TCP port is currently free on 127.0.0.1.
-// We bind a temporary listener and immediately release it. EADDRINUSE
-// on the bind attempt means it's busy; any other error is treated as
-// "not free" so we fall back to OS-chosen port.
-function isPortFree(port) {
-  return new Promise((resolve) => {
-    const srv = net.createServer();
-    srv.once('error', () => resolve(false));
-    srv.once('listening', () => {
-      srv.close(() => resolve(true));
-    });
-    srv.listen(port, '127.0.0.1');
-  });
-}
-
-// Ask the OS for a free port (listen on 0, capture, close).
-function findFreePort() {
-  return new Promise((resolve, reject) => {
-    const srv = net.createServer();
-    srv.once('error', reject);
-    srv.listen(0, '127.0.0.1', () => {
-      const { port } = srv.address();
-      srv.close(() => resolve(port));
-    });
-  });
-}
-
-// Resolve the port to use, honouring $BROWSER_TEST_PORT first, then
-// the historical default 8021, then a free OS-chosen port.
+// Resolve the port to use via the shared harness primitive
+// (local-browser-harness.cjs), honouring $BROWSER_TEST_PORT first, then
+// the historical default 8021, then a free OS-chosen port. The shared
+// `resolveServePort` carries the strict 1..65535 explicit-port contract
+// and the busy-port fallback (rf2-0u8kz / rf2-84gzw); this wrapper keeps
+// the launcher-specific diagnostics (distinguishing an explicitly-set but
+// unusable BROWSER_TEST_PORT from a busy default).
 async function resolvePort() {
   const envRaw = process.env.BROWSER_TEST_PORT;
-  if (envRaw && envRaw.trim() !== '') {
-    const parsed = parseInt(envRaw, 10);
-    // A usable explicit port is an integer in 1..65535 (rf2-0u8kz). Port 0
-    // is rejected here too: it binds an ephemeral port but is useless as an
-    // advertised BASE_URL, so treat it like any other invalid value and
-    // choose a free port deterministically.
-    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
-      console.error(
-        `BROWSER_TEST_PORT="${envRaw}" is not a valid TCP port (want 1..65535); ignoring and choosing a free port.`
-      );
-      return await findFreePort();
-    }
-    if (await isPortFree(parsed)) {
-      return parsed;
-    }
-    const fallback = await findFreePort();
-    console.warn(
-      `BROWSER_TEST_PORT=${parsed} is busy; falling back to free port ${fallback}.`
-    );
-    return fallback;
-  }
-  if (await isPortFree(DEFAULT_PORT)) {
-    return DEFAULT_PORT;
-  }
-  const fallback = await findFreePort();
-  console.warn(
-    `Default port ${DEFAULT_PORT} is busy; falling back to free port ${fallback}. ` +
-      `Set BROWSER_TEST_PORT to pin a specific port.`
-  );
-  return fallback;
-}
-
-function probe(port) {
-  return new Promise((resolve) => {
-    const req = http.get({ host: '127.0.0.1', port, path: '/', timeout: 1000 }, (res) => {
-      res.resume();
-      resolve(res.statusCode != null);
-    });
-    req.on('error', () => resolve(false));
-    req.on('timeout', () => {
-      req.destroy();
-      resolve(false);
-    });
+  const envSet = !!(envRaw && envRaw.trim() !== '');
+  const preferred = envSet ? parseInt(envRaw, 10) : DEFAULT_PORT;
+  return await resolveServePort(preferred, {
+    onFallback: (pref, fallback) => {
+      if (envSet && !isValidExplicitPort(pref)) {
+        console.error(
+          `BROWSER_TEST_PORT="${envRaw}" is not a valid TCP port (want 1..65535); ` +
+            `ignoring and using free port ${fallback}.`
+        );
+      } else if (envSet) {
+        console.warn(
+          `BROWSER_TEST_PORT=${pref} is busy; falling back to free port ${fallback}.`
+        );
+      } else {
+        console.warn(
+          `Default port ${DEFAULT_PORT} is busy; falling back to free port ${fallback}. ` +
+            `Set BROWSER_TEST_PORT to pin a specific port.`
+        );
+      }
+    },
   });
-}
-
-// Race-style readiness wait: resolves true once the server on `port`
-// answers AND its ownership token matches `expectedToken`. Resolves
-// false on timeout, on early child exit, or if the token mismatches
-// after the server becomes reachable (signals we're talking to a
-// foreign server that happens to be bound to the same port — refuse to
-// proceed). The caller distinguishes timeout vs early-exit vs
-// foreign-server via the state object and the returned reason.
-async function waitForReady(port, expectedToken, deadline, state) {
-  let sawReachable = false;
-  while (Date.now() < deadline) {
-    if (state.exited) return { ok: false, reason: 'child-exited' };
-    if (await probe(port)) {
-      sawReachable = true;
-      if (state.exited) return { ok: false, reason: 'child-exited' };
-      const got = await fetchToken(port);
-      if (got && got === expectedToken) {
-        return { ok: true };
-      }
-      if (got && got !== expectedToken) {
-        return { ok: false, reason: 'token-mismatch', got };
-      }
-      // token absent yet — http-server may have started but not yet
-      // be serving the sentinel file. Keep polling.
-    }
-    if (state.exited) return { ok: false, reason: 'child-exited' };
-    await new Promise((r) => setTimeout(r, POLL_MS));
-  }
-  return { ok: false, reason: sawReachable ? 'token-never-served' : 'timeout' };
 }
 
 (async () => {
@@ -310,8 +219,8 @@ async function waitForReady(port, expectedToken, deadline, state) {
 
   // Track the server's lifecycle so the readiness loop can fail fast
   // if http-server dies before becoming reachable. With pre-binding via
-  // isPortFree() this should be rare, but a slow-to-release socket or a
-  // race against a sibling spawner can still trigger EADDRINUSE.
+  // resolveServePort() this should be rare, but a slow-to-release socket
+  // or a race against a sibling spawner can still trigger EADDRINUSE.
   const state = { exited: false, exitCode: null, exitSignal: null };
   server.on('exit', (code, signal) => {
     state.exited = true;
@@ -319,7 +228,13 @@ async function waitForReady(port, expectedToken, deadline, state) {
     state.exitSignal = signal;
   });
 
-  const ready = await waitForReady(port, token, Date.now() + READY_TIMEOUT_MS, state);
+  // Readiness WITH ownership-token verification via the shared harness
+  // primitive (rf2-84gzw / rf2-gkf9): refuse to run tests against any
+  // server on `port` that does not serve this run's token.
+  const ready = await waitForOwnedHttpReady(port, token, Date.now() + READY_TIMEOUT_MS, {
+    pollMs: POLL_MS,
+    isAborted: () => state.exited,
+  });
   if (!ready.ok) {
     if (ready.reason === 'child-exited' || state.exited) {
       console.error(

--- a/implementation/scripts/test-mcp-conformance.cjs
+++ b/implementation/scripts/test-mcp-conformance.cjs
@@ -43,6 +43,7 @@
  */
 'use strict';
 
+const fs = require('node:fs');
 const path = require('node:path');
 
 const HERE = __dirname;
@@ -124,12 +125,64 @@ function trustedExe(name) {
 // always the currently-running Node, always outside the workspace by
 // construction — so they skip the PATH walk entirely (the same posture
 // the slice's `scripts/test-all.cjs` uses for its own node sub-tests).
+// Reproducible-install posture (rf2-vtp2er). A bare `npm install` mutates
+// dependency state on every run — it can rewrite node_modules and (for a
+// package without a committed lockfile) resolve semver ranges against
+// whatever the registry happens to publish at run time. That makes a local
+// `npm run test:mcp-conformance` not a pure verification command and leaves
+// dirty-worktree noise for workers. We pin each tool package to the most
+// reproducible install its on-disk state allows:
+//
+//   - A package WITH a committed package-lock.json (tools/mcp-conformance)
+//     installs via `npm ci`: a clean, lockfile-exact install that FAILS if
+//     package.json and the lock have drifted, rather than silently
+//     rewriting the lock. (`npm ci` requires the lock, so it can only be
+//     used where one is committed.)
+//   - A package WITHOUT a committed lockfile (tools/re-frame2-pair-mcp is a
+//     PUBLISHED npm package that deliberately .gitignores its lock — see
+//     tools/re-frame2-pair-mcp/.gitignore) falls back to `npm install`, but
+//     ONLY when its node_modules is absent. A present node_modules is
+//     treated as already-bootstrapped and the install is SKIPPED, so a
+//     repeated verification run does not re-mutate dependency state.
+//     Whether this package SHOULD carry a committed lockfile is a separate
+//     architecture decision flagged to the operator (rf2-vtp2er follow-up);
+//     this runner does not decide it.
+//
+// `resolveInstallStep` turns the declarative `install` marker into the
+// concrete exe/args (or a skip) at run time, against the live on-disk
+// lockfile / node_modules state.
+function hasCommittedLockfile(pkgDir) {
+  return fs.existsSync(path.join(pkgDir, 'package-lock.json'));
+}
+
+function nodeModulesPresent(pkgDir) {
+  return fs.existsSync(path.join(pkgDir, 'node_modules'));
+}
+
+function resolveInstallStep(step) {
+  const pkgDir = step.cwd;
+  if (hasCommittedLockfile(pkgDir)) {
+    // Lockfile-exact, fails on drift, never rewrites the lock.
+    return { ...step, exe: 'npm', args: ['ci'], skip: false };
+  }
+  if (nodeModulesPresent(pkgDir)) {
+    // Already bootstrapped + no committed lock to install against —
+    // skip rather than re-mutate. The compile/test steps that follow
+    // surface any genuinely-missing dep with an actionable error.
+    return { ...step, skip: true };
+  }
+  // No lock and no node_modules — first-run bootstrap. `npm install` is
+  // the only option here (npm ci requires a lock); it is reproducible
+  // enough for a first bootstrap and won't run again once node_modules
+  // exists.
+  return { ...step, exe: 'npm', args: ['install'], skip: false };
+}
+
 const STEPS = [
   // ---- prep ----
   {
     name: 'install tools/re-frame2-pair-mcp deps',
-    exe: 'npm',
-    args: ['install'],
+    install: true,
     cwd: PAIR_MCP,
     prep: true,
   },
@@ -142,8 +195,7 @@ const STEPS = [
   },
   {
     name: 'install tools/mcp-conformance deps',
-    exe: 'npm',
-    args: ['install'],
+    install: true,
     cwd: CONFORMANCE,
     prep: true,
   },
@@ -196,7 +248,21 @@ function banner(line) {
 const results = [];
 let firstFailure = null;
 
-for (const step of STEPS) {
+for (const rawStep of STEPS) {
+  // Install steps resolve their concrete command (npm ci / npm install /
+  // skip) from the live on-disk lockfile + node_modules state (rf2-vtp2er).
+  const step = rawStep.install ? resolveInstallStep(rawStep) : rawStep;
+
+  if (step.skip) {
+    banner(
+      '▷ ' + step.name +
+        '\n  cwd: ' + step.cwd +
+        '\n  SKIPPED: node_modules already present and no committed ' +
+        'lockfile to install against (reproducible-verify; rf2-vtp2er).',
+    );
+    continue;
+  }
+
   // Resolve the executable up-front: `node` steps use the absolute
   // `process.execPath`; native-tool steps resolve their bare name to a
   // trusted absolute path outside the workspace (rf2-1irs7 / rf2-33vvc).


### PR DESCRIPTION
Closes rf2-vtp2er.

Finding 1 — runner consolidation. `serve-and-run-browser-tests.cjs` and `check-story-static.cjs` each carried bespoke copies of the port-fallback + ownership-token protocol (isPortFree / findFreePort / resolvePort / probe / fetchToken / waitForReady). Both now consume the shared `local-browser-harness.cjs` primitives (`resolveServePort` + `waitForOwnedHttpReady`) — the same API the Xray feature-gate already uses — preserving each launcher's diagnostics and env/default-port semantics. Removed the duplicated local code paths. Extended the harness self-test with the bead-enumerated shapes (child-exited readiness abort; tokenless-window-then-token success) and added a script-policy guard pinning that neither launcher re-introduces a bespoke copy.

Finding 2 — dependency reproducibility. `test-mcp-conformance.cjs` install prep now resolves per-package from live lockfile/node_modules state: a committed `package-lock.json` (tools/mcp-conformance) installs via `npm ci` (lockfile-exact, fails on drift); a lock-less package skips the install when node_modules is already present rather than re-mutating dependency state. Both CI mcp-conformance install steps aligned to `npm ci`. Added `_mcp-conformance-install-policy.test.cjs` (wired into `test:script-policy`) pinning the npm-ci-where-locked posture and structurally drift-checking any committed lock.

`tools/re-frame2-pair-mcp` deliberately gitignores its lockfile (it is a published npm package). Whether it should commit one is a contract decision, filed as rf2-j9jbga for the operator rather than guessed here. pair-mcp's CI install stays `npm install` accordingly.

No gate coverage was lost: the shared primitives are logic-identical to the removed copies, the harness self-test now covers every migrated call shape, and the consolidation guards + install-policy gate lock the posture against regression.

Hot-zone note: `.github/workflows/test.yml` touched for the two mcp-conformance `npm install` -> `npm ci` lines only (gate wiring required by finding 2's CI-alignment criterion).

## Quality gates
- `npm run test:script-policy` — green (101 spawn-policy + 5 new install-policy + all others)
- `node scripts/_local-browser-harness.test.cjs` — green (17 passed, incl. 2 new cases)
- `node scripts/_lint-workflow-policy.test.cjs` — green (4 passed)
- `node --check` on both migrated launchers + the runner — clean
- Runtime smoke of the shared primitives in the exact migrated call shapes — all OK