### PR TITLE
fix(pair-mcp): precheck cache invalidation + port-file discovery drift (rf2-ww877w)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/002-nREPL-Transport.md
+++ b/tools/re-frame2-pair-mcp/spec/002-nREPL-Transport.md
@@ -86,11 +86,23 @@ transport and registers handlers; the first `tools/call` triggers the
 five-step cascade.
 
 **Per-tool-call port-file re-read.** After the initial discovery, each
-subsequent tool call re-reads `<project-home>/.shadow-cljs/nrepl.port`
-before using the cached socket. If the port has changed (shadow was
-restarted; the dev server picks a fresh ephemeral port on each `watch`
-start), the cached socket is closed and a new one opened transparently.
-If the port file vanished, discovery re-runs from step 1.
+subsequent tool call re-reads **the exact port-file discovery resolved**
+before using the cached socket. Discovery surfaces that file path
+(rf2-ww877w): the explicit `--port-file` returns its own path verbatim;
+the roots walk (step 3) and the shadow HTTP probe (step 4) each surface
+the WINNING candidate (`target/shadow-cljs/nrepl.port`,
+`.shadow-cljs/nrepl.port`, or `.nrepl-port`). The server caches that
+exact path rather than deriving a fixed `<project-home>/.shadow-cljs/
+nrepl.port` — the pre-fix derivation produced a wrong path for an
+explicit `target/shadow-cljs/nrepl.port` (it became
+`target/shadow-cljs/.shadow-cljs/nrepl.port`), which read as missing and
+forced a needless reconnect + per-connection cache reset on every call.
+If the port has changed (shadow was restarted; the dev server picks a
+fresh ephemeral port on each `watch` start), the cached socket is closed
+and a new one opened transparently. If the port file genuinely vanished,
+discovery re-runs from step 1. The cwd-scan last resort (step 5) has no
+`:project-home` anchor and so surfaces no cached file path; that mode
+alone retains the derivation as a defensive backstop.
 
 ### Why `roots/list` is the primary path
 

--- a/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
@@ -360,8 +360,9 @@ Post-Lock additions accumulated as follows:
   table for the catalogue addition. `set` / `reset` are `:cacheable? false`
   (session-state writes); `get` is `:cacheable? true` (a read of the
   frame registry + pin, caught by the post-eval result-hash cache — the
-  precheck path is `snapshot`/`get-path`-only, so a pin write between two
-  `get`s is never served stale).
+  precheck path is single-frame app-db-only `snapshot`-only (rf2-ww877w
+  retired `get-path` from precheck eligibility), so a pin write between
+  two `get`s is never served stale).
 - **rf2-3bu3d.7 / rf2-3bu3d.8** added the **read-orientation pair** —
   `read-sub` and `orient`. `read-sub {sub-id}` is the validated single-
   subscription read: resolve the named subscription against the reactive

--- a/tools/re-frame2-pair-mcp/spec/Principles.md
+++ b/tools/re-frame2-pair-mcp/spec/Principles.md
@@ -872,20 +872,34 @@ Saving the round-trip too needs a server-side hash precheck
 first, only ship the body on miss) — out of scope for
 rf2-3rt1f, filed as a follow-on bead.
 
-**Precheck eligibility (rf2-36xod follow-on; rf2-3ljsa)**. The
-precheck landed: `(re-frame2-pair.runtime/app-db-hash frame)` is
-shipped first, and a match short-circuits the tool eval. Because
-that hash is `(hash app-db@frame)` ONLY, a tool is precheck-eligible
-solely when its result is a pure function of `app-db@frame`. For
-`snapshot` this constrains the resolved `:include` to the app-db-
-derived slices `{:app-db :machines}` — `:sub-cache`/`:epochs`/
-`:traces` accrue without an app-db write (every event cascade
-appends an epoch + trace record, even a no-`:db` handler), so a
-snapshot retaining any of those three (including the default all-
-five `:include`) is NOT precheck-eligible and falls back to the
-post-eval result-hash cache above, which hashes the full text and
-so never serves a stale non-app-db slice. `get-path` reads an
-app-db subtree and so is always eligible.
+**Precheck eligibility (rf2-36xod follow-on; rf2-3ljsa; rf2-ww877w)**.
+The precheck landed: `(re-frame2-pair.runtime/app-db-hash frame)` is
+shipped first, and a match short-circuits the tool eval. Because that
+hash is `(hash app-db@frame)` ONLY, a tool is precheck-eligible solely
+when its result is a pure function of `app-db@frame`. For `snapshot`
+this constrains the resolved `:include` to the single app-db-derived
+slice `{:app-db}`. The other four slices change WITHOUT an app-db
+write, so a snapshot retaining any of them (including the default
+all-five `:include`) is NOT precheck-eligible and falls back to the
+post-eval result-hash cache above, which hashes the full text and so
+never serves a stale slice:
+
+- `:machines` is RUNTIME-DB state (rf2-ww877w) — EP-0001 (rf2-vzld77)
+  moved machine snapshots out of app-db into the durable runtime-db
+  partition (`[:rf.runtime/machines :snapshots]`), so a machine
+  transition rewrites the slice while `(hash app-db)` stays constant.
+- `:sub-cache` is a reactive cache over external inputs.
+- `:epochs`/`:traces` accrue a record on every event cascade, even a
+  no-`:db` handler.
+
+`get-path` is also NOT precheck-eligible (rf2-ww877w): although it
+reads an app-db subtree, its wire result is post-processed by
+`re-frame.core/elide-wire-value`, whose elision registry lives in the
+runtime-db partition (`[:rf.runtime/elision]`). A later elision
+declaration (or a sensitive/large classification flip) can re-shape
+the egress of an UNCHANGED subtree, which the `(hash app-db)` precheck
+hash cannot observe — so `get-path` falls back to the post-eval
+result-hash cache, which hashes the actual post-elision text.
 
 **Why opt-in by default**. Agent hosts that haven't been
 taught the `:rf.mcp/cache-hit` marker shape would receive a

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -77,12 +77,23 @@
 
 (defn- read-port-at-base
   "Resolve `port-file-candidates` against an absolute base directory and
-  return the first hit's parsed port — or nil. Uses `node-path/join` so
-  the candidates are platform-correct on Windows + POSIX without each
-  call site building paths by string-concat."
+  return the first hit as `{:port <int> :port-file <abs-path>}` — or nil
+  when no candidate reads. Uses `node-path/join` so the candidates are
+  platform-correct on Windows + POSIX without each call site building
+  paths by string-concat.
+
+  rf2-ww877w — the result carries the WINNING candidate path, not just
+  the parsed port. The server caches that exact path so the per-tool-call
+  re-read (`ensure-connection!`) checks the file that actually won the
+  candidate scan, instead of server.cljs deriving a fixed
+  `.shadow-cljs/nrepl.port` that may not be the candidate that hit (which
+  then reads as 'file disappeared' and forces a needless reconnect)."
   [base]
   (when (and base (seq base))
-    (some (fn [rel] (read-port-file (node-path/join base rel)))
+    (some (fn [rel]
+            (let [pf (node-path/join base rel)]
+              (when-let [port (read-port-file pf)]
+                {:port port :port-file pf})))
           port-file-candidates)))
 
 (defn read-port-from-fs
@@ -127,11 +138,15 @@
     1. `--port-file <path>`   explicit, cwd-independent override
                               (rf2-3dbwh). Wins outright WHEN READABLE;
                               `:project-home` is the dirname of the port
-                              file. An explicit-but-unreadable / non-
-                              numeric file falls through to steps 2-5
-                              (rf2-olvr5) — mirroring `read-port-from-fs`
-                              — so a stale port file can't strand a live
-                              port reachable via env / roots / HTTP / cwd.
+                              file and `:port-file` is the EXACT path the
+                              caller named (rf2-ww877w — so the server
+                              caches it verbatim rather than deriving a
+                              `.shadow-cljs/nrepl.port` that may not exist).
+                              An explicit-but-unreadable / non-numeric file
+                              falls through to steps 2-5 (rf2-olvr5) —
+                              mirroring `read-port-from-fs` — so a stale
+                              port file can't strand a live port reachable
+                              via env / roots / HTTP / cwd.
     2. `$SHADOW_CLJS_NREPL_PORT` env var. `:project-home` left nil
                               (env-overridden discovery doesn't surface a
                               root); the per-tool-call port-file re-read
@@ -149,10 +164,16 @@
     4. **Shadow HTTP probe** (rf2-umoz2) — `shadow-probe-fn` returns the
                               consumer project's absolute `:project-home`;
                               we then read `port-file-candidates` resolved
-                              against that root. Cwd-robust legacy
-                              fallback for clients without `roots/list`.
+                              against that root. The result surfaces the
+                              WINNING candidate path as `:port-file`
+                              (rf2-ww877w) so the server caches the exact
+                              file that hit, not a derived one. Cwd-robust
+                              legacy fallback for clients without
+                              `roots/list`.
     5. CWD-relative scan of `port-file-candidates` — legacy fallback for
-                              environments without the shadow HTTP API.
+                              environments without the shadow HTTP API. No
+                              `:port-file` is surfaced (no project-home
+                              anchor for a stable absolute path).
 
   ## Why steps 3, 4, and 5 share the same candidate list
 
@@ -189,8 +210,17 @@
     ;; have found a live port (rf2-olvr5 finding 4).
     (and explicit-port-file (seq explicit-port-file)
          (some? (read-port-file explicit-port-file)))
+    ;; rf2-ww877w — return the EXACT explicit port-file path the caller
+    ;; named, so the server caches it verbatim. The pre-fix shape omitted
+    ;; `:port-file`; server.cljs then DERIVED `<project-home>/.shadow-cljs/
+    ;; nrepl.port` (= dirname-of-explicit-file + .shadow-cljs/nrepl.port),
+    ;; which for an explicit `target/shadow-cljs/nrepl.port` resolves to a
+    ;; non-existent `target/shadow-cljs/.shadow-cljs/nrepl.port`. The next
+    ;; ensure-connection! read that derived path as missing and forced a
+    ;; needless reconnect + per-connection cache reset.
     (js/Promise.resolve {:port         (read-port-file explicit-port-file)
-                         :project-home (node-path/dirname explicit-port-file)})
+                         :project-home (node-path/dirname explicit-port-file)
+                         :port-file    explicit-port-file})
 
     ;; Step 2 — $SHADOW_CLJS_NREPL_PORT.
     (some? (read-env-port))
@@ -205,8 +235,14 @@
         (.then
           (fn [r]
             (case (:status r)
+              ;; rf2-ww877w — the roots candidate carries its own
+              ;; `:port-file` (the `.shadow-cljs/nrepl.port` adjacent to
+              ;; the discovered `shadow-cljs.edn`); thread it through so the
+              ;; server caches the exact discovered file rather than
+              ;; re-deriving one.
               :one  (let [c (:candidate r)]
-                      {:port (:port c) :project-home (:project-home c)})
+                      {:port (:port c) :project-home (:project-home c)
+                       :port-file (:port-file c)})
               :many {:port nil :ambiguous (:candidates r)}
               :error
               ;; Roots unavailable or no shadow in roots — try step 4 (HTTP probe).
@@ -214,9 +250,17 @@
                     shadow-discovery/default-host
                     (or http-port shadow-discovery/default-http-port))
                   (.then (fn [project-home]
-                           (if-let [port (read-port-at-base project-home)]
-                             {:port port :project-home project-home}
-                             ;; Step 5 — cwd-relative scan, last resort.
+                           (if-let [{:keys [port port-file]} (read-port-at-base project-home)]
+                             ;; rf2-ww877w — thread the WINNING candidate
+                             ;; file through so the server caches the exact
+                             ;; path that hit (target/shadow-cljs/nrepl.port
+                             ;; vs .shadow-cljs/nrepl.port vs .nrepl-port),
+                             ;; not a derived one.
+                             {:port port :project-home project-home :port-file port-file}
+                             ;; Step 5 — cwd-relative scan, last resort. No
+                             ;; project-home to anchor a stable port-file, so
+                             ;; none is surfaced (the cwd path can't supply an
+                             ;; absolute, restart-stable file path).
                              {:port (some read-port-file port-file-candidates)}))))))))))
 
 (defn discover-port

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -148,6 +148,19 @@
   [conn]
   (swap! session-state assoc :conn conn :discovered? true :discovery-error nil))
 
+(defn set-discovered-for-tests!
+  "Record a FULLY-discovered session (conn + port + the exact cached
+  port-file) and flip `:discovered?`. Exposed so the port-file-stability
+  contract (rf2-ww877w) can be exercised: a second `ensure-connection!`
+  call must stay on the cached conn when the cached port-file still reads
+  the same port — without re-deriving a `.shadow-cljs/nrepl.port` that
+  may not be the file discovery actually resolved."
+  [{:keys [conn port port-file project-home]}]
+  (swap! session-state assoc
+         :conn conn :port port :port-file port-file
+         :project-home project-home
+         :discovered? true :discovery-error nil))
+
 ;; The Server instance is captured here when `build-server` returns it,
 ;; so the discovery flow can reach `listRoots()` and `elicitInput()`
 ;; without threading the server through every handler signature.
@@ -252,6 +265,19 @@
                     conn (new-conn-for-port port)]
                 (swap! session-state assoc
                        :project-home ph
+                       ;; rf2-ww877w — PREFER the exact port-file discovery
+                       ;; resolved (explicit `--port-file`, roots candidate,
+                       ;; or the winning HTTP-probe candidate). Every
+                       ;; discovery mode that yields a `:project-home` now
+                       ;; also yields the `:port-file` that actually read, so
+                       ;; the derived `.shadow-cljs/nrepl.port` below is a
+                       ;; pure defensive backstop — never reached for those
+                       ;; modes. The pre-fix shape DERIVED unconditionally
+                       ;; from `ph`, producing e.g.
+                       ;; `target/shadow-cljs/.shadow-cljs/nrepl.port` for an
+                       ;; explicit `target/shadow-cljs/nrepl.port`; the next
+                       ;; `ensure-connection!` saw that path missing and
+                       ;; forced a needless reconnect + per-conn cache reset.
                        :port-file    (or (:port-file result)
                                          (when ph
                                            (node-path/join ph ".shadow-cljs/nrepl.port")))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/precheck.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/precheck.cljs
@@ -11,12 +11,12 @@
   the full tool eval.
 
   Eligibility (today): single-frame `snapshot` whose resolved
-  `:include` is app-db-derived only, and `get-path`. Their result is a
-  function of `(frame, args, app-db@frame)`; same frame + same args +
-  same db-hash ⇒ same result. Multi-frame `snapshot`
-  (`:frames :all` or a vector) is NOT eligible because we'd need to
-  hash every frame's db separately and combine — out of scope; the
-  legacy post-eval `apply-cache` path still catches those.
+  `:include` is app-db-derived only. Its result is a function of
+  `(frame, args, app-db@frame)`; same frame + same args + same db-hash
+  ⇒ same result. Multi-frame `snapshot` (`:frames :all` or a vector) is
+  NOT eligible because we'd need to hash every frame's db separately and
+  combine — out of scope; the legacy post-eval `apply-cache` path still
+  catches those.
 
   Snapshot's `:include` slices split by what the precheck hash sees
   (rf2-3ljsa). The precheck hash is `(re-frame2-pair.runtime/app-db-hash
@@ -25,9 +25,14 @@
   function of `app-db@frame`:
 
     - `:app-db`   — IS the frame db. Sound.
-    - `:machines` — `:state` lives at `[:rf/runtime :machines :snapshots]`
-                    INSIDE app-db; `:ids` is the install-time registrar
-                    list (stable across event cascades). Sound.
+    - `:machines` — runtime-db state (rf2-ww877w): EP-0001 (rf2-vzld77)
+                    moved machine snapshots OUT of app-db `:rf/runtime`
+                    into the durable runtime-db partition, read via
+                    `rf/runtime-db-value` at `[:rf.runtime/machines
+                    :snapshots]` (see runtime.cljs `snapshot-frame-slice`).
+                    A machine transition rewrites that runtime-db slot
+                    WITHOUT an app-db write, so the slice can change while
+                    `app-db-hash` stays constant. NOT sound.
     - `:sub-cache`— reactive cache over external inputs; can move without
                     an app-db write. NOT sound.
     - `:epochs`   — the per-frame epoch ring; a record is appended on
@@ -37,12 +42,25 @@
     - `:traces`   — the per-frame trace ring; same accrue-without-db-
                     change behaviour as `:epochs`. NOT sound.
 
-  A default snapshot (no `:include`) resolves to ALL FIVE slices, which
-  contains the unsound three — so the default is NOT precheck-eligible
-  and falls through to the post-eval `apply-cache`, which hashes the
-  full result text and so cannot serve a stale `:epochs`/`:traces`/
-  `:sub-cache` payload. Precheck is taken only when the caller narrows
-  `:include` to the app-db-derived subset.
+  Only `:app-db` is precheck-sound. A default snapshot (no `:include`)
+  resolves to ALL FIVE slices, which contains the four unsound ones — so
+  the default is NOT precheck-eligible and falls through to the post-eval
+  `apply-cache`, which hashes the full result text and so cannot serve a
+  stale `:machines`/`:epochs`/`:traces`/`:sub-cache` payload. Precheck is
+  taken only when the caller narrows `:include` to the app-db-derived
+  subset.
+
+  `get-path` is NOT precheck-eligible (rf2-ww877w). Although it reads an
+  app-db subtree, its wire result is post-processed by
+  `re-frame.core/elide-wire-value`, whose elision registry lives in the
+  runtime-db partition (`[:rf.runtime/elision]` — see
+  `implementation/core/src/re_frame/elision.cljc`). A later elision
+  declaration (or sensitive/large classification flip) can change the
+  egress shape of an unchanged app-db subtree, which the
+  `(hash app-db)` precheck hash cannot observe. So get-path falls
+  through to the post-eval `apply-cache`, which hashes the actual
+  serialized (post-elision) result text and therefore recomputes when
+  the egress shape changes.
 
   Trace tools (`trace-window`, `watch-epochs`, `discover-app`) are not
   eligible — their result depends on the epoch ring / health surface,
@@ -57,41 +75,54 @@
 (def app-db-derived-snapshot-slices
   "Snapshot slices whose value is a pure function of `app-db@frame`
   (rf2-3ljsa). Only these are precheck-sound under the
-  `(hash app-db@frame)` precheck hash; `:sub-cache`/`:epochs`/`:traces`
-  can change while that hash stays constant, so a snapshot whose
-  resolved `:include` is NOT a subset of this set is precheck-ineligible
-  and falls back to the post-eval result-hash cache. See the ns
-  docstring for the per-slice rationale."
-  #{:app-db :machines})
+  `(hash app-db@frame)` precheck hash;
+  `:machines`/`:sub-cache`/`:epochs`/`:traces` can change while that
+  hash stays constant, so a snapshot whose resolved `:include` is NOT a
+  subset of this set is precheck-ineligible and falls back to the
+  post-eval result-hash cache. See the ns docstring for the per-slice
+  rationale.
+
+  rf2-ww877w dropped `:machines` from this set: EP-0001 (rf2-vzld77)
+  moved machine snapshots into the runtime-db partition, so a machine
+  transition rewrites the slice without an app-db write — the
+  `(hash app-db)` precheck hash can't see it move."
+  #{:app-db})
 
 (defn precheck-target
   "Resolve the precheck target for a single-frame precheck. Returns a
   tagged 2-tuple — one of:
 
-    [:explicit       <frame-keyword>]   — caller named a specific frame.
-    [:operating-frame nil]              — runtime resolves the frame.
-    nil                                 — tool not precheck-eligible.
+    [:explicit <frame-keyword>]   — caller named a specific frame.
+    nil                           — tool not precheck-eligible.
 
   Tagged-tuple dispatch supersedes the prior sentinel-keyword shape
   (`:rf.mcp.cache/operating-frame`) — `precheck-form` dispatches on
   the tag rather than pattern-matching against a magic keyword, and
-  the eligibility / runtime-resolution distinction is now type-level,
-  not value-level. Future targets (e.g. multi-frame combined-hash)
-  add a new tag without colliding with a reserved keyword.
+  the eligibility distinction is now type-level, not value-level.
+  Future targets (e.g. multi-frame combined-hash, or an
+  operating-frame-resolved hash) add a new tag without colliding with a
+  reserved keyword. The only live tag today is `:explicit`
+  (rf2-ww877w retired the `get-path` `:operating-frame` tag along with
+  its precheck eligibility — see the get-path note below).
 
   `snapshot` is eligible only when BOTH (a) `:frames` resolves to a
   single frame (an explicit one-element vector or a single scalar) AND
   (b) the resolved `:include` is a subset of
-  `app-db-derived-snapshot-slices` (rf2-3ljsa). `:all` or a
-  multi-element vector — or an `:include` that retains
-  `:sub-cache`/`:epochs`/`:traces` (including the default all-five
-  include) — returns nil so the caller falls back to the post-eval
-  cache, which hashes the full result text and so cannot serve stale
-  non-app-db slices.
+  `app-db-derived-snapshot-slices` (rf2-3ljsa) — i.e. `#{:app-db}`.
+  `:all` or a multi-element vector — or an `:include` that retains
+  `:machines`/`:sub-cache`/`:epochs`/`:traces` (including the default
+  all-five include) — returns nil so the caller falls back to the
+  post-eval cache, which hashes the full result text and so cannot serve
+  stale non-app-db slices.
 
-  `get-path` is always eligible (its `:frame` slot is single-valued by
-  contract; absent means \"operating frame\"; it reads an app-db
-  subtree, so any app-db change flips the precheck hash)."
+  `get-path` is NOT precheck-eligible (rf2-ww877w). Its app-db subtree
+  read is post-processed by `re-frame.core/elide-wire-value`, whose
+  elision registry lives in the runtime-db partition; a later elision
+  declaration (or sensitive/large classification flip) can change the
+  egress shape of an unchanged subtree, which the `(hash app-db)`
+  precheck hash cannot observe. It falls through to the post-eval
+  `apply-cache`, which hashes the actual serialized (post-elision)
+  result text."
   [tool raw-args]
   (case tool
     "snapshot"
@@ -101,8 +132,8 @@
           app-db-derived? (every? app-db-derived-snapshot-slices include)]
       (cond
         ;; an :include retaining a non-app-db-derived slice
-        ;; (:sub-cache/:epochs/:traces) — the precheck hash can't see
-        ;; those move, so NOT eligible (rf2-3ljsa).
+        ;; (:machines/:sub-cache/:epochs/:traces) — the precheck hash
+        ;; can't see those move, so NOT eligible (rf2-3ljsa, rf2-ww877w).
         (not app-db-derived?)
         nil
         ;; explicit single-frame vector
@@ -116,36 +147,33 @@
         nil
         :else nil))
 
-    "get-path"
-    ;; nil-frame is allowed — runtime resolves to operating frame, so
-    ;; the eval form computes the hash over whichever frame the runtime
-    ;; picks. The hash still keys on (tool, args), so the cache slot is
-    ;; consistent.
-    (if-let [f (some-> (wire/arg raw-args :frame) args/->frame-keyword)]
-      [:explicit f]
-      [:operating-frame nil])
-
+    ;; get-path — NOT precheck-eligible (rf2-ww877w). The elision
+    ;; registry (runtime-db) can re-shape the egress of an unchanged
+    ;; app-db subtree, which the app-db precheck hash can't observe;
+    ;; the post-eval result-hash cache is the sound backstop.
+    ;;
     ;; Other tools — not precheck-eligible yet.
     nil))
 
 (defn precheck-form
   "The CLJS eval form for the runtime-side cheap hash. Dispatches on
-  the tag in `target` (`[:explicit <kw>]` / `[:operating-frame nil]`)
-  — the keyword sentinel of the prior shape is gone.
+  the tag in `target` (today only `[:explicit <kw>]`) — the keyword
+  sentinel of the prior shape is gone.
 
   Threads through `re-frame2-pair.runtime/app-db-hash` (rf2-9pe31),
   which returns the per-frame cached `(hash app-db)` integer in O(1).
   The cache is maintained by the runtime's epoch listener at every
   settled mutation; lazy-computed on the first read for a frame whose
   hash hasn't been observed yet. The wire payload is a single integer
-  regardless of app-db size."
+  regardless of app-db size.
+
+  A future operating-frame-resolved target would re-add a
+  `:operating-frame` arm emitting the 0-arity `app-db-hash` call; it was
+  removed with the `get-path` precheck retirement (rf2-ww877w)."
   [[tag frame :as _target]]
   (case tag
     :explicit
     (ef/emit (ef/rt-call 'app-db-hash frame))
-
-    :operating-frame
-    (ef/emit (ef/rt-call 'app-db-hash))
 
     nil))
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
@@ -159,24 +159,31 @@
 
 (deftest precheck-hit-short-circuits-dispatch
   (async done
-    (let [args        (args-js {:cache "true" :path "[:k]"})
+    ;; rf2-ww877w — the precheck-eligible vehicle is a single-frame
+    ;; APP-DB-ONLY snapshot (get-path is no longer precheck-eligible). The
+    ;; pipeline mechanics under test (precheck hit ⇒ dispatch skipped) are
+    ;; tool-agnostic; we just need a tool whose `precheck-target` is
+    ;; non-nil so `precheck-step` issues the stubbed fetch.
+    (let [args        (args-js {:cache "true"
+                                :frames #js ["rf/default"]
+                                :include #js ["app-db"]})
           dispatched? (atom false)
           ;; rf2-olvr5 finding 3 — the cache key now includes the resolved
           ;; build, so the priming MUST use the same build the `invoke`
           ;; pipeline will derive (`arg-build nil args` = the env / `:app`
           ;; default here) or the lookup key won't match.
-          _ (cache/apply-cache (mcp-result "{:k :v}")
-                               {:tool "get-path"
+          _ (cache/apply-cache (mcp-result "{:app-db {:k :v}}")
+                               {:tool "snapshot"
                                 :args args
                                 :enabled? true
                                 :build (wire/arg-build nil args)
                                 :precheck-hash 42})]
       (set-stubs!
         {:fetch-precheck-hash (fn [_conn _args _frame] (js/Promise.resolve 42))
-         :get-path-tool       (fn [_conn _args]
+         :snapshot-tool       (fn [_conn _args]
                                 (reset! dispatched? true)
                                 (js/Promise.resolve (mcp-result "{:should-not-ship :true}")))})
-      (-> (tools/invoke nil "get-path" args nil)
+      (-> (tools/invoke nil "snapshot" args nil)
           (.then (fn [result]
                    (is (false? @dispatched?)
                        "precheck hit MUST skip the tool body entirely")
@@ -199,20 +206,25 @@
 
 (deftest precheck-miss-stores-hash-for-next-call
   (async done
-    (let [args       (args-js {:cache "true" :path "[:k]"})
+    ;; rf2-ww877w — vehicle is the single-frame app-db-only snapshot (the
+    ;; sole precheck-eligible surface now). The mechanics are unchanged:
+    ;; cold miss stores the precheck-hash; the next call short-circuits.
+    (let [args       (args-js {:cache "true"
+                               :frames #js ["rf/default"]
+                               :include #js ["app-db"]})
           call-count (atom 0)]
       (set-stubs!
         {:fetch-precheck-hash (fn [_conn _args _frame] (js/Promise.resolve 999))
-         :get-path-tool       (fn [_conn _args]
+         :snapshot-tool       (fn [_conn _args]
                                 (swap! call-count inc)
-                                (js/Promise.resolve (mcp-result "{:db {:k :v}}")))})
-      (-> (tools/invoke nil "get-path" args nil)
+                                (js/Promise.resolve (mcp-result "{:app-db {:k :v}}")))})
+      (-> (tools/invoke nil "snapshot" args nil)
           (.then (fn [first-result]
                    (is (= 1 @call-count)
                        "first call: precheck cold miss → dispatch runs")
                    (is (not (cache-hit? first-result))
                        "first call returns the fresh result, not a marker")
-                   (tools/invoke nil "get-path" args nil)))
+                   (tools/invoke nil "snapshot" args nil)))
           (.then (fn [second-result]
                    (is (= 1 @call-count)
                        "second call: precheck matched → dispatch SKIPPED")
@@ -478,11 +490,14 @@
            (precheck/precheck-target
              "snapshot" (args-js {:frames #js ["rf/default"] :include #js ["app-db"]})))
         ":include [:app-db] is app-db-derived — precheck-eligible")
-    (is (= [:explicit :rf/default]
-           (precheck/precheck-target
-             "snapshot" (args-js {:frames #js ["rf/default"]
-                                  :include #js ["app-db" "machines"]})))
-        ":machines reads app-db only — still eligible"))
+    (is (nil? (precheck/precheck-target
+                "snapshot" (args-js {:frames #js ["rf/default"]
+                                     :include #js ["app-db" "machines"]})))
+        ;; rf2-ww877w — :machines is RUNTIME-DB state (EP-0001 rf2-vzld77
+        ;; moved machine snapshots to the runtime-db partition). A machine
+        ;; transition rewrites the slice WITHOUT an app-db write, so the
+        ;; `(hash app-db)` precheck hash can't see it move ⇒ ineligible.
+        ":machines reads runtime-db — NOT app-db-derived ⇒ ineligible"))
   (testing "single-frame snapshot, default (all-five) include → ineligible"
     (is (nil? (precheck/precheck-target
                 "snapshot" (args-js {:frames #js ["rf/default"]})))
@@ -490,13 +505,40 @@
   (testing "single-frame snapshot retaining a non-app-db slice → ineligible"
     (doseq [slice [#js ["app-db" "epochs"]
                    #js ["app-db" "traces"]
-                   #js ["app-db" "sub-cache"]]]
+                   #js ["app-db" "sub-cache"]
+                   ;; rf2-ww877w — :machines is now runtime-db-backed, so
+                   ;; an :include retaining it is precheck-ineligible too.
+                   #js ["app-db" "machines"]
+                   #js ["machines"]]]
       (is (nil? (precheck/precheck-target
                   "snapshot" (args-js {:frames #js ["rf/default"] :include slice})))
           (str "include " (vec slice) " retains an unsound slice — ineligible"))))
   (testing "multi-frame snapshot stays ineligible regardless of include"
     (is (nil? (precheck/precheck-target
                 "snapshot" (args-js {:frames #js ["a" "b"] :include #js ["app-db"]}))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-ww877w — get-path is NOT precheck-eligible. Its app-db subtree read
+;; is post-processed by `elide-wire-value`, whose elision registry lives in
+;; runtime-db; a later elision declaration / classification flip can re-shape
+;; the egress of an UNCHANGED app-db subtree, which the `(hash app-db)`
+;; precheck hash can't observe. So get-path falls through to the post-eval
+;; result-hash cache (which hashes the actual post-elision text).
+;; ---------------------------------------------------------------------------
+
+(deftest precheck-target-get-path-is-ineligible
+  (testing "get-path with an explicit frame → ineligible (rf2-ww877w)"
+    (is (nil? (precheck/precheck-target
+                "get-path" (args-js {:frame "rf/default" :path "[:k]"})))
+        "explicit-frame get-path no longer registers a precheck target"))
+  (testing "get-path with no frame (operating-frame-resolved) → ineligible"
+    (is (nil? (precheck/precheck-target
+                "get-path" (args-js {:path "[:k]"})))
+        "operating-frame get-path no longer registers a precheck target"))
+  (testing "get-path batch read → ineligible"
+    (is (nil? (precheck/precheck-target
+                "get-path" (args-js {:paths "[[:a] [:b]]"})))
+        "batch get-path is ineligible too — same elision-registry hazard")))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-3ljsa — END-TO-END staleness guard. A single-frame DEFAULT-include

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -529,6 +529,11 @@
             (.then (fn [r]
                      (is (= 9001 (:port r))
                          "explicit --port-file wins the cascade")
+                     ;; rf2-ww877w — the explicit branch returns the EXACT
+                     ;; path the caller named, so the server caches it
+                     ;; verbatim (no derived `.shadow-cljs/nrepl.port`).
+                     (is (= "explicit/nrepl.port" (:port-file r))
+                         "explicit --port-file returns the exact path it read")
                      (is (false? @probed?)
                          "the HTTP probe must not be hit when step 1 resolves")
                      (is (false? @rooted?)
@@ -634,6 +639,13 @@
                          "step 4 caught the port after step 3 was unsupported")
                      (is (= "/abs/proj/root" (:project-home r))
                          "project-home flows through from shadow probe step")
+                     ;; rf2-ww877w — the HTTP-probe result surfaces the
+                     ;; WINNING candidate file (here target/shadow-cljs/
+                     ;; nrepl.port resolved against the shadow root) so the
+                     ;; server caches the exact path that read.
+                     (is (re-find #"target[\\/]shadow-cljs[\\/]nrepl\.port$"
+                                  (str (:port-file r)))
+                         "winning candidate file (target/shadow-cljs/nrepl.port) is surfaced")
                      (restore!)
                      (done))))))))
 
@@ -654,6 +666,91 @@
             (.then (fn [r]
                      (is (= 5550 (:port r))
                          "first candidate (target/shadow-cljs/nrepl.port) wins")
+                     ;; rf2-ww877w — the winning candidate's path is surfaced
+                     ;; (target/shadow-cljs/nrepl.port, the first candidate).
+                     (is (re-find #"target[\\/]shadow-cljs[\\/]nrepl\.port$"
+                                  (str (:port-file r)))
+                         "winning candidate file surfaced as :port-file")
+                     (restore!)
+                     (done))))))))
+
+;; rf2-ww877w — exhaustive port-file surfacing for the HTTP-probe path. For
+;; EACH candidate order (only the .shadow-cljs file present, only the
+;; .nrepl-port present), the SURFACED :port-file must be the candidate that
+;; actually read — NOT a fixed derivation. This is the drift the bead kills:
+;; the server caches whatever discovery resolved, so the per-tool-call
+;; re-read checks the right file and doesn't false-positive "file vanished".
+(deftest discover-port-shadow-probe-surfaces-each-candidate-file
+  (testing ".shadow-cljs/nrepl.port wins → that exact file is surfaced"
+    (async done
+      (let [stub-fn (fn [^js path]
+                      (let [p (str path)]
+                        (cond
+                          ;; target candidate absent — falls to .shadow-cljs.
+                          (re-find #"target[\\\\/]shadow-cljs[\\\\/]nrepl\.port" p)
+                          (throw (js/Error. "ENOENT"))
+                          (re-find #"\.shadow-cljs[\\\\/]nrepl\.port" p) "5561"
+                          :else (throw (js/Error. "ENOENT")))))
+            restore! (install-fs-stub! nil stub-fn)]
+        (-> (nrepl/discover-port* nil nil (shadow-returns "/abs/proj/root") roots-unsupported)
+            (.then (fn [r]
+                     (is (= 5561 (:port r)) ".shadow-cljs candidate read the port")
+                     (is (re-find #"\.shadow-cljs[\\/]nrepl\.port$" (str (:port-file r)))
+                         "the .shadow-cljs/nrepl.port file is surfaced — not target/...")
+                     (is (not (re-find #"target[\\/]shadow-cljs" (str (:port-file r))))
+                         "the absent target candidate is NOT what's cached")
+                     (restore!)
+                     (done)))))))
+  (testing ".nrepl-port wins (last candidate) → that exact file is surfaced"
+    (async done
+      (let [stub-fn (fn [^js path]
+                      (let [p (str path)]
+                        (cond
+                          (re-find #"target[\\\\/]shadow-cljs[\\\\/]nrepl\.port" p)
+                          (throw (js/Error. "ENOENT"))
+                          (re-find #"\.shadow-cljs[\\\\/]nrepl\.port" p)
+                          (throw (js/Error. "ENOENT"))
+                          (re-find #"\.nrepl-port" p) "5562"
+                          :else (throw (js/Error. "ENOENT")))))
+            restore! (install-fs-stub! nil stub-fn)]
+        (-> (nrepl/discover-port* nil nil (shadow-returns "/abs/proj/root") roots-unsupported)
+            (.then (fn [r]
+                     (is (= 5562 (:port r)) ".nrepl-port candidate read the port")
+                     (is (re-find #"\.nrepl-port$" (str (:port-file r)))
+                         "the .nrepl-port file is surfaced as the winning candidate")
+                     (restore!)
+                     (done))))))))
+
+;; rf2-ww877w — the roots/list single-candidate path threads the candidate's
+;; own :port-file through (the `.shadow-cljs/nrepl.port` adjacent to the
+;; discovered shadow-cljs.edn), so the server caches the discovered file.
+(deftest discover-port-roots-single-candidate-surfaces-port-file
+  (testing "step 3 single candidate → its :port-file flows through"
+    (async done
+      (let [restore! (install-fs-stub! nil throwing-read)]
+        (-> (nrepl/discover-port* nil nil shadow-fails (roots-one "/abs/proj" 8765))
+            (.then (fn [r]
+                     (is (= 8765 (:port r)))
+                     (is (= "/abs/proj/.shadow-cljs/nrepl.port" (:port-file r))
+                         "roots candidate :port-file surfaces verbatim")
+                     (restore!)
+                     (done))))))))
+
+;; rf2-ww877w — the cwd-scan last resort (step 5) supplies NO :port-file:
+;; there is no project-home anchor for a stable absolute path, so the server
+;; must fall back to its derivation (or skip the per-call re-read).
+(deftest discover-port-cwd-scan-surfaces-no-port-file
+  (testing "step 5 (cwd scan) → :port-file is nil (no project-home anchor)"
+    (async done
+      ;; roots unsupported + shadow probe returns nil ⇒ fall to cwd scan.
+      ;; The cwd candidate reads, but no project-home is known.
+      (let [stub-fn (read-returning "\\.nrepl-port" "5599")
+            restore! (install-fs-stub! nil stub-fn)]
+        (-> (nrepl/discover-port* nil nil shadow-fails roots-unsupported)
+            (.then (fn [r]
+                     (is (= 5599 (:port r)) "cwd scan caught the port")
+                     (is (nil? (:port-file r))
+                         "cwd scan surfaces no port-file — server derivation is the backstop here")
                      (restore!)
                      (done))))))))
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_file_stability_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/port_file_stability_test.cljs
@@ -1,0 +1,133 @@
+(ns re-frame2-pair-mcp.port-file-stability-test
+  "Regression for the port-file discovery drift (rf2-ww877w).
+
+  THE BUG: discovery resolved a port via an explicit `--port-file` (or
+  the shadow HTTP probe) but did NOT surface WHICH file it read. The
+  server then DERIVED a fixed `<project-home>/.shadow-cljs/nrepl.port`
+  as the cached `:port-file`. For an explicit
+  `target/shadow-cljs/nrepl.port` that derivation produced the
+  non-existent `target/shadow-cljs/.shadow-cljs/nrepl.port`. The very
+  next `ensure-connection!` read that derived path as MISSING, treated
+  it as a shadow shutdown, closed the socket, forced rediscovery, and
+  reset the per-connection build/probe caches — on every tool call.
+
+  THE FIX: discovery surfaces the exact `:port-file` it resolved
+  (nrepl.cljs); the server caches that path verbatim instead of
+  deriving one. A second `ensure-connection!` then re-reads the SAME
+  file, sees the SAME port, and stays on the cached connection.
+
+  These tests exercise the server's `ensure-connection!` cached-path
+  branch directly with a stubbed `fs.readFileSync`, asserting the
+  cached conn is REUSED when the cached port-file still reads the same
+  port — i.e. no spurious 'file vanished' reconnect."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [applied-science.js-interop :as j]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.server :as server]
+            ["fs" :as fs]))
+
+(use-fixtures :each
+  {:before (fn [] (server/reset-session-state-for-tests!))
+   :after  (fn [] (server/reset-session-state-for-tests!))})
+
+(defn- with-fs-read
+  "Install `stub-fn` as `fs.readFileSync` for the duration of `body`,
+  restoring afterwards. Returns a 0-arity restore thunk (the async
+  bodies here call it inside their final `.then` before `(done)`)."
+  [stub-fn]
+  (let [orig (.-readFileSync fs)]
+    (set! (.-readFileSync fs) stub-fn)
+    (fn restore! [] (set! (.-readFileSync fs) orig))))
+
+(defn- reads-port-at
+  "A `readFileSync` stub returning `content` for `wanted-path` (exact
+  string match) and throwing ENOENT for any other path — modelling the
+  cached file present at exactly the discovered path and NOWHERE else."
+  [wanted-path content]
+  (fn [^js path]
+    (if (= (str path) wanted-path)
+      content
+      (throw (js/Error. "ENOENT")))))
+
+(deftest cached-explicit-port-file-stays-on-connection-when-unchanged
+  (testing "ensure-connection! reuses the cached conn when the EXACT cached port-file still reads the same port (rf2-ww877w)"
+    (async done
+      (let [explicit-pf "C:/repo/target/shadow-cljs/nrepl.port"
+            conn        (nrepl/make-conn 7001 "127.0.0.1")
+            ;; The exact file discovery resolved is present and reads 7001;
+            ;; the bug's DERIVED path
+            ;; (C:/repo/target/shadow-cljs/.shadow-cljs/nrepl.port) does NOT
+            ;; exist, so if the server had cached THAT it would mis-fire the
+            ;; "vanished" branch.
+            restore!    (with-fs-read (reads-port-at explicit-pf "7001"))]
+        (server/set-discovered-for-tests!
+          {:conn conn :port 7001 :port-file explicit-pf
+           :project-home "C:/repo/target/shadow-cljs"})
+        ;; A second tool call: discovered? is true, the cached port-file
+        ;; reads the same port ⇒ fast path, same conn, no reconnect.
+        (-> (server/ensure-connection! {} (fn [_] (js/Promise.reject (js/Error. "must not re-discover"))))
+            (.then (fn [resolved-conn]
+                     (is (= conn resolved-conn)
+                         "the cached conn is REUSED — no spurious reconnect")
+                     (is (true? (:discovered? (server/session-state-snapshot)))
+                         "session stays discovered (no forced rediscovery)")
+                     (is (= explicit-pf (:port-file (server/session-state-snapshot)))
+                         "the cached port-file is the exact explicit path, unchanged")
+                     (restore!)
+                     (done)))
+            (.catch (fn [e]
+                      (is false (str "ensure-connection! must NOT reject: " (.-message e)))
+                      (restore!)
+                      (done))))))))
+
+(deftest cached-probe-winning-candidate-stays-on-connection
+  (testing "a winning HTTP-probe candidate (target/shadow-cljs/nrepl.port) is reused when unchanged (rf2-ww877w)"
+    (async done
+      ;; The probe winner was target/shadow-cljs/nrepl.port, NOT the
+      ;; derived .shadow-cljs/nrepl.port. Cache the winning path; re-read
+      ;; sees the same port ⇒ stay put.
+      (let [winning-pf "/abs/proj/root/target/shadow-cljs/nrepl.port"
+            conn       (nrepl/make-conn 6789 "127.0.0.1")
+            restore!   (with-fs-read (reads-port-at winning-pf "6789"))]
+        (server/set-discovered-for-tests!
+          {:conn conn :port 6789 :port-file winning-pf
+           :project-home "/abs/proj/root"})
+        (-> (server/ensure-connection! {} (fn [_] (js/Promise.reject (js/Error. "must not re-discover"))))
+            (.then (fn [resolved-conn]
+                     (is (= conn resolved-conn)
+                         "cached conn reused — the winning candidate path re-read fine")
+                     (is (= winning-pf (:port-file (server/session-state-snapshot)))
+                         "the cached port-file is the winning candidate, not a derived one")
+                     (restore!)
+                     (done)))
+            (.catch (fn [e]
+                      (is false (str "ensure-connection! must NOT reject: " (.-message e)))
+                      (restore!)
+                      (done))))))))
+
+(deftest cached-port-file-genuine-disappearance-still-rediscovers
+  (testing "when the cached (exact) port-file genuinely vanishes, ensure-connection! still rediscovers — the fix doesn't mask real shutdowns"
+    (async done
+      (let [explicit-pf "C:/repo/target/shadow-cljs/nrepl.port"
+            conn        (nrepl/make-conn 7001 "127.0.0.1")
+            redisc?     (atom false)
+            ;; Every read throws — the file is truly gone (shadow stopped).
+            restore!    (with-fs-read (fn [_] (throw (js/Error. "ENOENT"))))
+            discover-fn (fn [_]
+                          (reset! redisc? true)
+                          (server/mark-discovered-for-tests!
+                            (nrepl/make-conn 7002 "127.0.0.1"))
+                          (js/Promise.resolve :ok))]
+        (server/set-discovered-for-tests!
+          {:conn conn :port 7001 :port-file explicit-pf
+           :project-home "C:/repo/target/shadow-cljs"})
+        (-> (server/ensure-connection! {} discover-fn)
+            (.then (fn [_]
+                     (is (true? @redisc?)
+                         "a genuine vanished port-file STILL forces rediscovery (no false reuse)")
+                     (restore!)
+                     (done)))
+            (.catch (fn [e]
+                      (is false (str "rediscovery should succeed here: " (.-message e)))
+                      (restore!)
+                      (done))))))))


### PR DESCRIPTION
Fixes rf2-ww877w (P1, senior-review). Two infra fixes in `tools/re-frame2-pair-mcp` — precheck cache identity + nREPL port-file discovery. Scoped to cache/port-file logic; disjoint from the EP-0002 frame-attribution surface (bd4div).

## Issue 1 — precheck cache identity ignored runtime-db / elision state
The precheck hash is `(hash app-db@frame)` only, but two cacheable reads depend on state OUTSIDE app-db, so a precheck `:rf.mcp/cache-hit` could serve stale state:
- `:machines` snapshot slice reads runtime-db (`[:rf.runtime/machines :snapshots]`, moved there by EP-0001 rf2-vzld77). A machine transition rewrites it without an app-db write. Dropped `:machines` from `app-db-derived-snapshot-slices` — `:app-db` is now the sole precheck-sound slice.
- `get-path` output is post-processed by `elide-wire-value`, whose elision registry lives in runtime-db (`[:rf.runtime/elision]`). A later elision declaration / sensitive-or-large classification flip re-shapes egress of an unchanged subtree, invisible to the app-db hash. Made get-path precheck-ineligible.
- Both now fall back to the post-eval result-hash cache, which hashes the actual serialized (post-elision) text and so never serves a stale payload. Retired the now-dead `:operating-frame` precheck tag (was get-path-only).

## Issue 2 — nREPL discovery dropped the actual port-file path
`--port-file C:/repo/target/shadow-cljs/nrepl.port` connected, then the server cached a DERIVED `<project-home>/.shadow-cljs/nrepl.port` = `target/shadow-cljs/.shadow-cljs/nrepl.port` (a doubled, non-existent path). The next `ensure-connection!` read it as missing, treated it as shutdown, reconnected, and reset per-connection build/probe caches — every call. Same for HTTP-probe when `target/...` or `.nrepl-port` won instead of `.shadow-cljs/...`.
- Explicit `--port-file` branch returns the exact path it read.
- `read-port-at-base` returns `{:port :port-file}`; the HTTP-probe + roots steps surface the WINNING candidate file; the server caches that exact path.
- cwd-scan last resort surfaces no port-file (no project-home anchor); the server derivation is retained only as that mode's defensive backstop.

## Tests
- Dropped the stale `:machines reads app-db only — still eligible` assertion; added `:machines`-ineligible + get-path-ineligible coverage (`invoke_test`).
- Re-vehicled the precheck-pipeline mechanics tests onto an app-db-only single-frame snapshot (the sole eligible surface now).
- `nrepl_test`: assert returned `:port-file` for explicit + each HTTP candidate order (target / .shadow-cljs / .nrepl-port) + roots single-candidate + cwd-no-file.
- New `port_file_stability_test`: a second `ensure-connection!` stays on the cached conn when the winning file is unchanged (explicit + probe-winner); a genuine vanish still rediscovers.

## Spec
Updated Principles.md (precheck eligibility), DESIGN-RATIONALE.md (precheck-path scope), 002-nREPL-Transport.md (per-tool-call re-read uses the exact discovered file).

## Quality gates
- `npm test` (tools/re-frame2-pair-mcp): 1002 tests, 3032 assertions, 0 failures, 0 errors (was 995 / 3012).
- `npm run check:descriptors`: in sync (28 tools).