### PR TITLE
docs(adapters): public-surface governance + documentation drift (rf2-xcyaei)

### DIFF
--- a/implementation/adapters/reagent-slim/DESIGN-RATIONALE.md
+++ b/implementation/adapters/reagent-slim/DESIGN-RATIONALE.md
@@ -1,6 +1,8 @@
 # reagent-slim — design rationale
 
-> Bead **rf2-kez3**. Audience: adopters evaluating `day8/reagent-slim` against `day8/reagent-classic`.
+> Bead **rf2-kez3**. Audience: adopters evaluating `day8/reagent-slim` against the classic thin-bridge adapter.
+>
+> **Bridge naming (rf2-xcyaei).** Today the classic thin-bridge adapter ships as **`day8/re-frame2-reagent`** — that is the coordinate an adopter pins right now, and the one this document names throughout as the present-day fallback. `day8/reagent-classic` is a *possible post-1.0 rename* of that bridge (see `IMPL-SPEC.md` §11.4); it has **not** shipped, so it is deliberately not used as adoption guidance here.
 >
 > Sister docs:
 > - `IMPL-SPEC.md` (this directory) — Stage 3 engineering spec, written for implementers.
@@ -10,7 +12,7 @@
 > - `findings/dash8-rf8-react19-readiness-audit.md` (rf2-kfpf) — Dash8 + rf8 lifecycle and SSR inventory.
 > - `FORM-3.md` (rf2-pe4u, future) — Form-3 cap specifics with worked examples.
 
-This document explains, decision by decision, **why** reagent-slim is shaped the way it is. If you want to know **how** it was built, read `IMPL-SPEC.md`. If you want to know what changed in your code, read `MIGRATION.md`. If you want to know whether to adopt it, read this.
+This document explains, decision by decision, **why** reagent-slim is shaped the way it is. If you want to know **how** it was built, read `IMPL-SPEC.md`. If you want to know what changed in your code, read the migration corpus ([`migration/from-re-frame-v1/README.md`](../../../migration/from-re-frame-v1/README.md)) together with `IMPL-SPEC.md` §13 (bridge → rewrite migration path). If you want to know whether to adopt it, read this.
 
 ---
 
@@ -50,7 +52,7 @@ Two empirical audits (rf2-cgcv: re-com + re-frame-10x; rf2-kfpf: Dash8 + rf8) in
 
 None of those appear in any of the four audited codebases. They also do not appear in re-frame2's own source or in any of the seventeen re-frame2 example apps.
 
-The traditional argument for shipping zero-usage surfaces is "back-compat goodwill" — keep the symbol, emit a deprecation warning, give users a window to migrate. That argument carries weight when there is no alternative. It does not carry weight when `reagent-classic` exists. Stock-Reagent users who genuinely need `with-let` or `cursor` keep their full surface by depending on `day8/reagent-classic` instead. The two artefacts coexist on the classpath because they live in separate namespace trees.
+The traditional argument for shipping zero-usage surfaces is "back-compat goodwill" — keep the symbol, emit a deprecation warning, give users a window to migrate. That argument carries weight when there is no alternative. It does not carry weight when `re-frame2-reagent` exists. Stock-Reagent users who genuinely need `with-let` or `cursor` keep their full surface by depending on `day8/re-frame2-reagent` instead. The two artefacts coexist on the classpath because they live in separate namespace trees.
 
 ### Slim impact
 
@@ -62,7 +64,7 @@ Several of the dropped surfaces have direct re-frame2 idiomatic replacements tha
 
 ### Migration note
 
-Apps using any dropped surface have two paths. (a) Migrate the call site to re-frame2 idiom. (b) Stay on `day8/reagent-classic`. Both are first-class. Path (a) is the long-term direction; path (b) is a pragmatic option for stock-Reagent codebases not ready to refactor.
+Apps using any dropped surface have two paths. (a) Migrate the call site to re-frame2 idiom. (b) Stay on `day8/re-frame2-reagent`. Both are first-class. Path (a) is the long-term direction; path (b) is a pragmatic option for stock-Reagent codebases not ready to refactor.
 
 ---
 
@@ -90,7 +92,7 @@ re-frame2 was already React-18-or-better in practice — every example mounts vi
 
 ### Migration note
 
-Adopting reagent-slim means bumping `react` and `react-dom` to 19.x in your `package.json`. Replace `reagent.dom/render` calls with `reagent2.dom.client/{create-root, render}`. Replace `reagent.dom/unmount-component-at-node` with `reagent2.dom.client/unmount`. If you have a `r/dom-node` call, it must move to a `:ref` callback — `findDOMNode` is gone. Stock-Reagent users on React 17 or 18 stay on `reagent-classic`.
+Adopting reagent-slim means bumping `react` and `react-dom` to 19.x in your `package.json`. Replace `reagent.dom/render` calls with `reagent2.dom.client/{create-root, render}`. Replace `reagent.dom/unmount-component-at-node` with `reagent2.dom.client/unmount`. If you have a `r/dom-node` call, it must move to a `:ref` callback — `findDOMNode` is gone. Stock-Reagent users on React 17 or 18 stay on `re-frame2-reagent`.
 
 ---
 
@@ -124,7 +126,7 @@ Across all four codebases combined: zero UNSAFE_ keys, zero `:component-will-rec
 
 The cap is what those audits actually found, plus zero — not an aspirational limit, not a stylistic preference, just what the ecosystem uses.
 
-The throw is loud on purpose. A user who registers `:should-component-update` is not getting a silent shrug; they get an `ex-info` at first call with the unsupported key and the supported set. Migration is mechanical: rewrite into the supported keys, or use `reagent-classic` for that component.
+The throw is loud on purpose. A user who registers `:should-component-update` is not getting a silent shrug; they get an `ex-info` at first call with the unsupported key and the supported set. Migration is mechanical: rewrite into the supported keys, or use `re-frame2-reagent` for that component.
 
 ### Slim impact
 
@@ -138,7 +140,7 @@ The cap also lets `create-class`'s validation be simple. The supported set is sm
 
 ### Migration note
 
-For the four audited codebases: zero changes. Their existing `create-class` calls work as-is. For codebases outside the audit using a banned key: rewrite the lifecycle into the supported set, or stay on `reagent-classic`. The throw fires at first invocation with a clear message — no silent breakage.
+For the four audited codebases: zero changes. Their existing `create-class` calls work as-is. For codebases outside the audit using a banned key: rewrite the lifecycle into the supported set, or stay on `re-frame2-reagent`. The throw fires at first invocation with a clear message — no silent breakage.
 
 The companion document `FORM-3.md` (rf2-pe4u, future) covers Form-3 worked examples in detail.
 
@@ -210,7 +212,7 @@ The split aligns with re-frame2's separation of concerns. SSR-with-hydration is 
 
 If your app imports `reagent.dom.server/render-to-string` for hydrate-able SSR: migrate to the `day8/re-frame2-ssr` seam. The seam's API is documented in the SSR adapter's spec.
 
-If your app imports `reagent.dom.server/render-to-static-markup` for HTML export: change the require to `reagent2.dom.server` and the rest works. Behavioural parity with React's `renderToStaticMarkup` is covered by a parity test suite (R-004 in Stage 2's risk register) — any intentional differences (attribute ordering, void-tag handling) are documented in `MIGRATION.md`.
+If your app imports `reagent.dom.server/render-to-static-markup` for HTML export: change the require to `reagent2.dom.server` and the rest works. Behavioural parity with React's `renderToStaticMarkup` is covered by a parity test suite (R-004 in Stage 2's risk register) — any intentional differences (attribute ordering, void-tag handling) are documented in the parity test's known-difference allow-list (`reagent2.dom.server` parity suite).
 
 ---
 
@@ -233,13 +235,13 @@ The Maven coord `day8/reagent-slim` is decoupled from import paths. Adopters req
 
 The decoupling is intentional. Three reasons:
 
-1. **No collision with stock Reagent.** `reagent2.*` and `reagent.*` are separate namespace trees. They coexist on the classpath without interfering. An app can depend on both `reagent-slim` and `reagent-classic` simultaneously if migration is incremental.
+1. **No collision with stock Reagent.** `reagent2.*` and `reagent.*` are separate namespace trees. They coexist on the classpath without interfering. An app can depend on both `reagent-slim` and `re-frame2-reagent` simultaneously if migration is incremental.
 
 2. **No marketing claim baked into the import path.** The `day8/reagent-slim` Maven coord carries the brand. The `reagent2.*` import path is neutral — it does not promise anything in the source code. If a future rewrite supersedes reagent-slim, the import path stays valid.
 
 3. **Type-friendly.** `reagent2.core` is shorter than `reagent-slim.core` in `(:require ...)` lines. The `2` is a version marker, not a brand statement.
 
-The adapter Var stays at `re-frame.adapter.reagent`. That is the public surface `(rf/init! ...)` consumes. Apps that already wired their init call against the bridge keep working without source changes when they swap from `reagent-classic` to `reagent-slim`. The adapter Var path is the ABI; the namespace tree underneath is the implementation.
+The adapter Var stays at `re-frame.adapter.reagent`. That is the public surface `(rf/init! ...)` consumes. Apps that already wired their init call against the bridge keep working without source changes when they swap from `re-frame2-reagent` to `reagent-slim`. The adapter Var path is the ABI; the namespace tree underneath is the implementation.
 
 ### Slim impact
 
@@ -281,7 +283,7 @@ This decision splits the dropped surfaces into two classes by why they were drop
 
 **Class B — React-internal removes.** `reagent.core/render`, `reagent.dom/render`, `reagent.dom/unmount-component-at-node`, `reagent.dom/force-update-all`, `r/dom-node`. These cannot warn-and-continue because the React APIs they depended on are gone in React 19. They ship as throw-on-call shims (per §3).
 
-For Class A, the question was whether to ship warning stubs or nothing. The "back-compat goodwill" argument for warning stubs assumes there are users to be courteous to. The audits established there are no such users. And `reagent-classic` exists for any genuine stock-Reagent user.
+For Class A, the question was whether to ship warning stubs or nothing. The "back-compat goodwill" argument for warning stubs assumes there are users to be courteous to. The audits established there are no such users. And `re-frame2-reagent` exists for any genuine stock-Reagent user.
 
 So Class A surfaces ship as nothing. A user calling `reagent2.core/cursor` fails at compile time with an unresolved-symbol error, not at runtime with a deprecation warning. This is the right pedagogy: the surface does not exist, the compiler says so, the user updates the call site.
 
@@ -295,7 +297,7 @@ The discipline is the load-bearing thing. "Warning stub" is a soft posture that 
 
 ### Migration note
 
-If your code calls a Class A surface, the compiler tells you. Migration to re-frame2 idiom: `cursor` → layer-2 sub. `next-tick` → re-frame2's scheduling primitives or `goog.async.nextTick` directly. `class-names` → a one-line userland helper or one of several CLJS string-join libraries. `is-client` → re-frame2's platform marker in `re-frame.interop`. If migration is not feasible, stay on `reagent-classic`.
+If your code calls a Class A surface, the compiler tells you. Migration to re-frame2 idiom: `cursor` → layer-2 sub. `next-tick` → re-frame2's scheduling primitives or `goog.async.nextTick` directly. `class-names` → a one-line userland helper or one of several CLJS string-join libraries. `is-client` → re-frame2's platform marker in `re-frame.interop`. If migration is not feasible, stay on `re-frame2-reagent`.
 
 Class B surfaces, per §3, throw on call with a migration message rather than failing at compile time — the React-API-gone framing means the throw is the right pedagogy for callers who try them at runtime.
 
@@ -333,7 +335,7 @@ The win is test reliability. Production-runtime impact is zero — `flush-views!
 
 ### What this adds up to for adopters
 
-Stock Reagent cannot offer these integrations because stock Reagent does not know about re-frame2's trace bus, frame-context primitive, source-coord injector, or test-flush primitive. reagent-classic carries the same blindness — it is stock Reagent under a thin bridge.
+Stock Reagent cannot offer these integrations because stock Reagent does not know about re-frame2's trace bus, frame-context primitive, source-coord injector, or test-flush primitive. re-frame2-reagent carries the same blindness — it is stock Reagent under a thin bridge.
 
 reagent-slim is the Reagent that actually knows about re-frame2. Adopters get the integration without the monkey-patches, without the wrapper-layer overhead, without the tests-race-each-other surprise.
 
@@ -380,9 +382,9 @@ This honesty matters because the doc you are reading is for adopters making a re
 
 ## §11 Side-by-side comparison
 
-| Dimension | reagent-classic | reagent-slim |
+| Dimension | re-frame2-reagent | reagent-slim |
 |---|---|---|
-| Maven coord | `day8/reagent-classic` | `day8/reagent-slim` |
+| Maven coord | `day8/re-frame2-reagent` | `day8/reagent-slim` |
 | React floor | React 17/18 (stock-Reagent constrained) | React 19 |
 | Surface | full Reagent surface (~30+ symbols) | ~20 symbols, re-com/re-frame2 scoped |
 | Bundle (gzip) vs stock Reagent 1.3 | baseline | -25% to -33% (typical), -70% (SSR-using) |
@@ -400,10 +402,10 @@ This honesty matters because the doc you are reading is for adopters making a re
 
 Adoption shape:
 
-- **Stock Reagent codebase, full surface usage, on React 17/18:** stay on `reagent-classic`. No reason to migrate.
+- **Stock Reagent codebase, full surface usage, on React 17/18:** stay on `re-frame2-reagent`. No reason to migrate.
 - **Stock Reagent codebase, re-com surface only, on React 19:** migrate to `reagent-slim`. The migration is a require-rewrite plus mount-API swap; everything else is unchanged.
 - **re-frame2-native codebase, on React 19:** migrate to `reagent-slim`. You get the full integration (trace bus, source-coord, frame-context, deterministic flush) plus the bundle savings.
-- **Codebase using a banned surface (`with-let`, `cursor`, banned Form-3 key, etc.):** either rewrite into the supported surface, or stay on `reagent-classic`. Both are first-class.
+- **Codebase using a banned surface (`with-let`, `cursor`, banned Form-3 key, etc.):** either rewrite into the supported surface, or stay on `re-frame2-reagent`. Both are first-class.
 
 ---
 

--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -1,7 +1,7 @@
 # reagent-slim — Stage 3 implementation spec
 
 > Stage 3 of rf2-5djt (parent epic). Bead **rf2-60le**.
-> The artefact is `day8/reagent-slim`; the bridge is `day8/reagent-classic`.
+> The artefact is `day8/reagent-slim`; the classic thin-bridge adapter ships today as `day8/re-frame2-reagent` (`day8/reagent-classic` is a possible post-1.0 rename of that bridge — see §11.4 — and is used in this spec only where the discussion is explicitly about that future rename).
 > Stage 1 (rf2-ui6g) closed the surface; Stage 2 (rf2-142b) sized the wins. This
 > document is the engineering spec Stage 4 (rf2-6hyy) implements against.
 >
@@ -258,7 +258,7 @@ Stage 1 §1.6 marked `RAtom`, `Reaction`, `Track`, `RCursor`, `Wrapper` as SHOUL
 
 `re-frame.interop/ratom?` (`interop.cljs:26-29`) tests `(satisfies? ratom/IReactiveAtom ^js x)` — protocol-based, not class-based. The protocol is exported; both `RAtom` and `Reaction` reify it. Cross-substrate code that does `(instance? RAtom x)` or `(instance? Reaction x)` keeps working. Code that does `(instance? Track x)` or `(instance? RCursor x)` does not — but the audits showed zero such call sites in any of the four production codebases.
 
-If a downstream consumer surfaces a need for `Track` / `RCursor` / `Wrapper` after release, the right answer is to migrate them to the bridge artefact (`day8/reagent-classic`) per the rewrite's scoping commitment, not extend the rewrite.
+If a downstream consumer surfaces a need for `Track` / `RCursor` / `Wrapper` after release, the right answer is to migrate them to the bridge artefact (`day8/re-frame2-reagent`) per the rewrite's scoping commitment, not extend the rewrite.
 
 ### §2.4 `reagent2.dom.client` — mount entry
 
@@ -415,7 +415,7 @@ The rewrite preserves this. Stage 4 confirms via a cross-substrate test that cal
 
 ### §3.5 The dropped types — `Track`, `RCursor`, `Wrapper`
 
-Per §2.3a — not shipped. Audit-confirmed zero usage. If a future consumer surfaces a real need, the migration path is `day8/reagent-classic`.
+Per §2.3a — not shipped. Audit-confirmed zero usage. If a future consumer surfaces a real need, the migration path is the bridge artefact `day8/re-frame2-reagent`.
 
 ---
 
@@ -602,7 +602,7 @@ Any other key throws `:rf.error/create-class-key-unsupported` at `create-class` 
                                  "Unsupported: " (pr-str unsupported) ". "
                                  "Migrate to the supported keys, restructure "
                                  "via :on-create / :on-destroy events, or "
-                                 "switch to day8/reagent-classic.")
+                                 "switch to the bridge adapter day8/re-frame2-reagent.")
            :keys            (vec unsupported)
            :supported-keys  supported})))
     spec))
@@ -906,7 +906,7 @@ A test-time-only build pulls in `react-dom/server` and runs both implementations
 - Sequence children with and without keys.
 - Mixed-type children (string + number + vector).
 
-The test diffs the outputs and asserts byte-for-byte equality, with explicit known-difference allow-listing for cases like attribute ordering that aren't part of the contract. Stage 4 documents any intentional differences in MIGRATION.md.
+The test diffs the outputs and asserts byte-for-byte equality, with explicit known-difference allow-listing for cases like attribute ordering that aren't part of the contract. Any intentional differences are recorded in the parity test's known-difference allow-list (`reagent2.dom.server` parity suite).
 
 ---
 
@@ -1093,9 +1093,9 @@ Per §1.5 — Stage 4 confirms `verify-version-lockstep.sh` recognises the new a
 | **R-001** Narrowed `convert-prop-value` may break apps relying on silent stringification | `template_test.cljs` exercises every `html-attr-name?` branch; tests assert the dev-mode `console.warn` fires once per `[k name-of-v]` pair. |
 | **R-002** 7-key Form-3 cap may break niche consumers | `component_test.cljs` constructs `create-class` with each of {`:component-will-mount`, `:UNSAFE_componentWillMount`, `:component-will-receive-props`, `:UNSAFE_componentWillReceiveProps`, `:component-will-update`, `:UNSAFE_componentWillUpdate`, `:should-component-update`, `:get-derived-state-from-props`, `:get-initial-state`} and asserts each throws `:rf.error/create-class-key-unsupported` with the unsupported key in `:keys`. |
 | **R-003** Compile-time Form-detection macro changes user-facing API | The runtime path is the canonical (mandatory) implementation; the `defview` macro is optional. Tests assert plain `defn` + `reg-view` works with all three Form shapes. |
-| **R-004** Pure-CLJS `render-to-static-markup` differs from `react-dom/server` | `parity_test.cljs` per §8.7 — corpus-based diff. Known-difference allow-list documented in MIGRATION.md. |
+| **R-004** Pure-CLJS `render-to-static-markup` differs from `react-dom/server` | `parity_test.cljs` per §8.7 — corpus-based diff. Known-difference allow-list documented in the parity test itself. |
 | **R-005** Microtask scheduler interacts unexpectedly with React 19 transitions | `dom_client_test.cljs` exercises `useTransition` boundaries; `flush-views!` drains React's pending work without race. |
-| **R-006** 10x v1 monkey-patches break | NOT tested in this artefact — documented as a known breakage in MIGRATION.md. 10x v1 doesn't load against the rewrite; Xray is the contract. Apps running 10x v1 stay on `day8/reagent-classic`. |
+| **R-006** 10x v1 monkey-patches break | NOT tested in this artefact — documented as a known breakage in the migration corpus (`migration/from-re-frame-v1/README.md`). 10x v1 doesn't load against the rewrite; Xray is the contract. Apps running 10x v1 stay on the bridge `day8/re-frame2-reagent`. |
 | **R-007** Bundle estimates may be off by 30-50% | Per S3-008, the comparison build is delivered (rf2-5lbx) — see §12.2 + §12.3. The S3-008 *contract* (no stock-Reagent impl-leak, no `react-dom/server` leak) is enforced quantitatively by the symbol grep. The *size* half of R-007 remains a Stage-5 follow-up: in the in-tree shadow-cljs build both adapter trees live on the same classpath, and `re-frame.interop` still statically `:require`s stock `reagent.core` / `reagent.ratom`, so a per-build classpath-pruning hook is needed before the realised-gzip-reduction measurement is meaningful. The current in-tree numbers (stock counter ~93 KB gz, slim counter ~93 KB gz) reflect that shared-classpath shape and are NOT the binding "slim" claim. |
 
 ---
@@ -1150,7 +1150,7 @@ Per-key migration recipes:
 | `:should-component-update` | Move the optimisation to React.memo or a custom reactive shape. The audit (rf2-cgcv + rf2-kfpf) found zero usage across all four codebases. |
 | `:get-derived-state-from-props` | Restructure the component to compute derived state from props at render time (idiomatic React function-component shape). Audit-confirmed zero usage. |
 
-Apps that genuinely need a banned key for a real use case stay on `day8/reagent-classic` (the bridge).
+Apps that genuinely need a banned key for a real use case stay on `day8/re-frame2-reagent` (the bridge).
 
 ### §13.3 Apps that used dropped surfaces
 

--- a/implementation/adapters/reagent-slim/deps.edn
+++ b/implementation/adapters/reagent-slim/deps.edn
@@ -33,6 +33,18 @@
                         :git/sha "2b83503246e8291fc023d688574640a9b23d8c50"}}
           :main-opts  ["-m" "noahtheduke.clein"]}
 
+  ;; :main is the in-tree adapter ns (rf2-xcyaei). NOTE the published jar
+  ;; ships the adapter at the CANONICAL `re-frame.adapter.reagent` ns, not
+  ;; this `-slim` ns: at publication the release workflow's "Rename adapter
+  ;; ns at publication (reagent-slim only)" step (.github/workflows/
+  ;; release.yml) mv's reagent_slim.cljs → reagent.cljs and rewrites the
+  ;; (ns ...) form BEFORE clein packages. The pre-rewrite :main value here
+  ;; is harmless: clein's :main only stamps a pom/jar metadata hint (no
+  ;; gen-class, no -main entry point — the adapter exposes a Var, not a
+  ;; runnable main), and it is never resolved at downstream require time.
+  ;; The in-tree value must stay `re-frame.adapter.reagent-slim` so the
+  ;; UNRENAMED monorepo build (where both adapters share a classpath) can
+  ;; package without an ns clash. See README.md "Published Maven artefact".
   :clein/build
   {:lib      day8/reagent-slim
    :main     re-frame.adapter.reagent-slim

--- a/implementation/adapters/reagent-slim/src/reagent2/core.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/core.cljs
@@ -39,8 +39,8 @@
   by `reagent2.dom.client/flush-views!`), `class-names`, `is-client`,
   `set-default-compiler!`, `create-compiler`, `with-let`.
 
-  Apps that genuinely need a dropped surface stay on
-  day8/reagent-classic (the bridge); the rewrite's commitment is
+  Apps that genuinely need a dropped surface stay on the bridge
+  adapter day8/re-frame2-reagent; the rewrite's commitment is
   to ship only the surfaces the audited codebases actually exercise."
   (:refer-clojure :exclude [atom])
   (:require [reagent2.ratom :as ratom]

--- a/implementation/adapters/reagent-slim/src/reagent2/dom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom.cljs
@@ -31,7 +31,7 @@
 ;;
 ;; Migration-message strings are fixed and visible in source so an
 ;; eyeball-level grep at the call site surfaces the migration target
-;; without consulting MIGRATION.md.
+;; without consulting the migration corpus (migration/from-re-frame-v1/README.md).
 ;; ---------------------------------------------------------------------------
 
 (defn render

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -142,7 +142,7 @@
                                 "Unsupported: " (pr-str unsupported) ". "
                                 "Migrate to the supported keys, restructure "
                                 "via :on-create / :on-destroy events, or "
-                                "switch to day8/reagent-classic.")
+                                "switch to the bridge adapter day8/re-frame2-reagent.")
            :keys           unsupported
            :supported-keys cap-keys}))))
   spec)

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
@@ -18,9 +18,9 @@
     - run-in-reaction, with-let-values (impl-internal in stock; not
       part of the rewrite's surface)
 
-  Apps that genuinely need a dropped surface stay on day8/reagent-classic
-  (the bridge); the rewrite's commitment is to ship only the surfaces
-  the audited codebases actually exercise.
+  Apps that genuinely need a dropped surface stay on the bridge adapter
+  day8/re-frame2-reagent; the rewrite's commitment is to ship only the
+  surfaces the audited codebases actually exercise.
 
   Design notes (per IMPL-SPEC §3 + Stage 2 §4 efficiency analysis):
 

--- a/implementation/adapters/uix/README.md
+++ b/implementation/adapters/uix/README.md
@@ -2,6 +2,8 @@
 
 Maven artefact: `day8/re-frame2-uix`. Target: UIx 2.x (hooks-based). Public ns: `re-frame.adapter.uix`.
 
+> **UIx product version vs Maven coordinate version.** "UIx 2.x" is the *product/API-family* name — the hooks-based generation hosted at [pitch-io/uix](https://github.com/pitch-io/uix). It is **not** a Maven version number. UIx 2 is published on Clojars as `com.pitch/uix.core` with version numbers in the **1.x.x** series, so the `com.pitch/uix.core {:mvn/version "1.4.4"}` pin in [`deps.edn`](deps.edn) *is* UIx 2.x. The legacy UIx 1 generation (roman01la/uix) is a separate, pre-hooks codebase and is explicitly out of scope. There is no `2.x.y` Maven coordinate to bump to.
+
 This adapter implements re-frame2's substrate contract on top of UIx — Pitch's modern, hooks-based CLJS React wrapper. Subscriptions are read via the `use-subscribe` hook (returning a plain value, not a reaction); frame context is composed via React context.
 
 See [`../README.md`](../README.md) for the wider adapter tier and the substrate contract; [Spec 004 — Views](../../../spec/004-Views.md) for `reg-view` / `reg-view*` semantics; [Spec 006 — Reactive substrate](../../../spec/006-ReactiveSubstrate.md) for the contract this adapter implements.

--- a/implementation/adapters/uix/deps.edn
+++ b/implementation/adapters/uix/deps.edn
@@ -15,6 +15,16 @@
 ;; Per rf2-3yij Decision 8 we target UIx 2.x (hooks-based). UIx 1.x
 ;; back-compat is explicitly out of scope.
 ;;
+;; PRODUCT-VERSION vs MAVEN-VERSION (rf2-xcyaei). "UIx 2.x" is the
+;; product/API-family name (the hooks-based generation hosted at
+;; github.com/pitch-io/uix), NOT the Maven coordinate version. UIx 2 is
+;; published on Clojars as `com.pitch/uix.core` with version numbers in
+;; the 1.x.x series — so the `com.pitch/uix.core {:mvn/version "1.4.4"}`
+;; pin below IS UIx 2.x. The legacy UIx 1 generation (roman01la/uix) is
+;; a different, pre-hooks codebase and is the surface ruled out of scope
+;; above. Do not "upgrade" this coordinate to a 2.x.y Maven version — no
+;; such version exists; that would be a non-resolving coordinate.
+;;
 ;; UIx itself is a CLJS-only library; this artefact is therefore
 ;; CLJS-only. The :test alias exists for classpath-probe parity with
 ;; the other per-adapter artefacts (Reagent's :test alias is also


### PR DESCRIPTION
Reconciles determined drift in the adapters public surface and fixes stale adopter-facing docs/messages, per rf2-xcyaei. Scoped to implementation/adapters.

- **Finding 2 — UIx target version:** documents the product-version vs Maven-version mapping. 'UIx 2.x' is the hooks-based product family (pitch-io/uix), published on Clojars as com.pitch/uix.core with 1.x.x version numbers, so the 1.4.4 pin IS UIx 2.x. Note added to uix/README.md + uix/deps.edn; no coordinate to bump (no 2.x.y Maven version exists). Verified against Clojars.
- **Finding 3 — reagent-slim fallback coordinate + missing MIGRATION.md:** the classic thin-bridge adapter ships today as day8/re-frame2-reagent; day8/reagent-classic is a possible post-1.0 rename that has NOT shipped. Replaces reagent-classic with the present-day coordinate in runtime messages + adopter guidance (create-class throw, core/ratom/dom docstrings, DESIGN-RATIONALE + IMPL-SPEC), keeping the post-1.0 rename discussion (IMPL-SPEC §11.4 + §1 dep note) explicitly separated and labelled future. Relinks every MIGRATION.md reference (no such file exists) to the actual migration corpus (migration/from-re-frame-v1/README.md + IMPL-SPEC §13) or the parity test allow-list.
- **Finding 1 — reagent-slim :clein/build :main (in-scope part):** documents why the pre-rewrite re-frame.adapter.reagent-slim value is harmless after the publication ns-rename (clein :main is a pom/jar metadata hint only; the in-tree value must stay -slim to avoid an ns clash on the shared monorepo classpath).

Out-of-scope hot-zone parts (finding 1 CI publication smoke; finding 4 broad '|| echo' false-green JVM probes — both edit .github/workflows/*) filed as decision-flagged follow-ups rf2-olo8rc and rf2-1s2mhh for mayor scheduling.

## Quality gates
- npm run test:cljs: 6115 tests, 21797 assertions, 0 failures, 0 errors
- reagent-slim clojure -M:test: 11 tests, 0 failures, 0 errors
- npm run test:bundle-isolation: PASS
- npm run test:reagent-slim:bundle-isolation: PASS
- python scripts/check_doc_slugs.py: clean