### PR TITLE
refactor(epoch): test reset hooks + projection docs (rf2-yw1w1u)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -572,6 +572,10 @@
    {:key         :epoch/configure!
     :producer-ns 're-frame.epoch
     :description "Configure epoch buffer size / capture policy."}
+   {:key         :epoch/reset-config!
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-yw1w1u"
+    :description "Restore epoch-history config to the shipped default baseline (test isolation) so a prior test's (rf/configure! :epoch-history ...) merge can't leak :depth / :trace-events-keep / :redact-fn. Fired by re-frame.test-support's reset-hook table so test namespaces don't reset the private re-frame.epoch.state/config var directly."}
    {:key         :epoch/clear-history!
     :producer-ns 're-frame.epoch
     :description "Clear the committed-epoch ring buffer (test isolation)."}

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -233,6 +233,16 @@
     :epoch/clear-history!            — drop the per-frame epoch ring buffer.
     :epoch/clear-epoch-listeners!          — drop the epoch-settled callback
                                        registry.
+    :epoch/reset-config!             — restore epoch-history config to the
+                                       shipped default baseline (rf2-yw1w1u).
+                                       `(rf/configure! :epoch-history ...)`
+                                       MERGES, so without this a prior test's
+                                       `:depth` / `:trace-events-keep` /
+                                       `:redact-fn` would leak into the next.
+                                       Suites that want a non-default value
+                                       re-apply it through `configure!` in
+                                       their `:init-fn` (which runs after the
+                                       post-dispose reset hooks).
     :adapter/clear-warn-once-caches! — clear per-adapter
                                        `warned-non-dom-roots` warn-once
                                        caches. Chained — re-frame.views,
@@ -249,6 +259,7 @@
    {:hook :http/clear-all-in-flight!       :phase :post-dispose}
    {:hook :epoch/clear-history!            :phase :post-dispose}
    {:hook :epoch/clear-epoch-listeners!          :phase :post-dispose}
+   {:hook :epoch/reset-config!             :phase :post-dispose}
    {:hook :adapter/clear-warn-once-caches! :phase :post-dispose}
    ;; Per Spec 015 — clear the per-(kind, id) marks table and the
    ;; per-frame sub-output propagation table so each test starts

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -166,7 +166,7 @@
 ;; ---- rf2-j9phb (TE-R2.2) — make-reset-runtime-fixture hook-cascade coverage ----
 ;;
 ;; The fixture's per-test reset drives an inline table
-;; (`test_support.cljc/reset-hook-table`) of nine late-bind hook keys
+;; (`test_support.cljc/reset-hook-table`) of late-bind hook keys
 ;; across two phases (`:pre-dispose` and `:post-dispose`). The pure-shape
 ;; refactor that landed via rf2-d7vw8 made the call-set explicit — but
 ;; the call-set is still implicit: a future change that drops a row
@@ -177,7 +177,8 @@
 ;;
 ;; Mechanism:
 ;;   1. Snapshot the late-bind hooks atom.
-;;   2. Replace each of the nine known reset-hook-table keys with a
+;;   2. Replace each known reset-hook-table key in
+;;      `reset-hook-expected-counts` with a
 ;;      sentinel that increments a per-key counter atom. (Replace
 ;;      regardless of whether the producer registered it on the test
 ;;      classpath — the sentinel ensures the fixture's hook walk
@@ -217,6 +218,7 @@
    :http/clear-all-in-flight!       1
    :epoch/clear-history!            1
    :epoch/clear-epoch-listeners!          1
+   :epoch/reset-config!             1
    :adapter/clear-warn-once-caches! 1})
 
 (deftest make-reset-runtime-fixture-fires-every-hook-the-documented-number-of-times

--- a/implementation/epoch/deps.edn
+++ b/implementation/epoch/deps.edn
@@ -42,16 +42,28 @@
 ;; And require `re-frame.epoch` in any namespace that calls
 ;; `rf/epoch-history`, `rf/restore-epoch`, `rf/register-epoch-listener!`,
 ;; `rf/unregister-epoch-listener!`, or `(rf/configure! :epoch-history ...)` —
-;; loading the namespace publishes the three router/trace late-bind hooks
-;; (`:epoch/settle!`, `:epoch/commit-halt-record!`, `:epoch/capture-event`)
-;; that the router and the trace surface look up
-;; at per-event drain-settle, per-event depth-halt, and per-trace emit time
-;; (`:epoch/discard-buffer!` is absent — there is no whole-drain rollback
-;; hook under per-event epochs; already-settled siblings are durable),
-;; plus the four query / control hooks
-;; (`:epoch/epoch-history`, `:epoch/restore-epoch`,
-;; `:epoch/register-epoch-listener!`, `:epoch/unregister-epoch-listener!`,
-;; `:epoch/configure!`) that core's re-exports late-bind to.
+;; loading the namespace publishes the artefact's late-bind contract via
+;; a single `(late-bind/set-fns! { ... })` map in `re-frame.epoch`.
+;;
+;; The authoritative, always-current hook list is that publication map
+;; (see `re-frame.epoch`'s `set-fns!` call) cross-referenced against the
+;; `re-frame.late-bind.directory/hooks` entries (the `:epoch/*` rows) —
+;; the `re-frame.late-bind-drift-test` gate pins the two in sync, so this
+;; comment intentionally does NOT maintain a parallel list that would
+;; silently drift. The hooks span: per-cascade lifecycle (router + trace
+;; capture seam — `:epoch/settle!`, `:epoch/commit-halt-record!`,
+;; `:epoch/capture-event`, `:epoch/cascade-cause`, the post-settle
+;; back-fill family `:epoch/record-render!` / `record-sub-run!` /
+;; `record-unmount!`, `:epoch/on-frame-destroyed`); introspection + the
+;; Tool-Pair write surface (`:epoch/epoch-history`, `:epoch/restore-epoch`,
+;; the `replace-*` / `reset-app-db!` injection hooks); the listener +
+;; config surface (`:epoch/register-epoch-listener!` /
+;; `unregister-epoch-listener!`, `:epoch/configure!`, the test-isolation
+;; `:epoch/clear-history!` / `clear-epoch-listeners!` / `reset-config!`
+;; hooks); and the off-box egress projection (`:epoch/projected-record`
+;; / `projected-history`). `:epoch/discard-buffer!` is intentionally
+;; ABSENT — there is no whole-drain rollback hook under per-event
+;; epochs; already-settled siblings are durable.
 ;;
 ;; Per Spec 006 §Adapter shipping convention (and the
 ;; rf2-p7va extension to per-feature splits): this artefact depends on
@@ -66,20 +78,24 @@
 
  :aliases
  {:test {:extra-paths ["test"]
-         ;; The epoch JVM tests' reset-runtime fixture touches
-         ;; `re-frame.flows/flows` and `re-frame.schemas/schemas-by-frame`
-         ;; AND reloads `re-frame.routing` so its ns-load-time
-         ;; registrations resurrect after `(registrar/clear-all!)`.
-         ;; The schema-mismatch failure-mode test exercises the
-         ;; schemas surface (a registered app-schema that the recorded
-         ;; db-after no longer satisfies) and the version-mismatch
-         ;; test exercises the machines surface (a registered machine
-         ;; whose snapshot-version drifted from the recorded snapshot).
-         ;; Pull schemas / flows / routing / machines in as test-only
-         ;; deps so the fixture loads cleanly. Mirrors the pattern in
-         ;; core/deps.edn, routing/deps.edn, flows/deps.edn,
-         ;; http/deps.edn, and ssr/deps.edn. None of these is required
-         ;; for production epoch builds.
+         ;; The epoch JVM tests use the canonical capture/restore
+         ;; fixture (`re-frame.test-support/make-reset-runtime-fixture`,
+         ;; rf2-yw1w1u): it snapshots the registrar at each test ns's
+         ;; load and restores around every test, so the schemas /
+         ;; routing / machines registrations those test ns `:require`
+         ;; chains bring live survive across tests WITHOUT a
+         ;; `clear-all!` + `re-frame.routing` reload dance. The
+         ;; schema-mismatch failure-mode test exercises the schemas
+         ;; surface (a registered app-schema the recorded db-after no
+         ;; longer satisfies), the version-mismatch test exercises the
+         ;; machines surface (a registered machine whose snapshot-version
+         ;; drifted), and the routing tests register routes via
+         ;; `rf/reg-route`. Pull schemas / flows / routing / machines in
+         ;; as test-only deps so the fixture + those test bodies load
+         ;; cleanly. Mirrors the pattern in core/deps.edn,
+         ;; routing/deps.edn, flows/deps.edn, http/deps.edn, and
+         ;; ssr/deps.edn. None of these is required for production epoch
+         ;; builds.
          :extra-deps  {day8/re-frame2-schemas    {:local/root "../schemas"}
                        day8/re-frame2-flows      {:local/root "../flows"}
                        day8/re-frame2-routing    {:local/root "../routing"}

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -121,6 +121,17 @@
   []
   (state/current-config))
 
+(defn- reset-config!
+  "Restore the epoch-history config to the shipped default baseline.
+  Test-support seam only — published through the `:epoch/reset-config!`
+  late-bind hook so `re-frame.test-support`'s reset-hook table can
+  isolate epoch config between tests without test namespaces
+  dereferencing the private `re-frame.epoch.state/config` var
+  (rf2-yw1w1u). Delegates to `state/reset-config!`, whose docstring is
+  the canonical pin."
+  []
+  (state/reset-config!))
+
 ;; The record-assembly helpers — `maybe-redact`, `current-schema-digest`,
 ;; the sensitive-rollup family, and `build-record` itself — live in
 ;; `re-frame.epoch.assembly`.
@@ -937,6 +948,11 @@
    :epoch/register-epoch-listener!   register-epoch-listener!
    :epoch/unregister-epoch-listener! unregister-epoch-listener!
    :epoch/configure!                 configure!
+   ;; rf2-yw1w1u: test-support config-isolation hook. `re-frame.test-
+   ;; support`'s reset-hook table fires this to restore epoch config to
+   ;; the shipped default between tests, so test namespaces no longer
+   ;; reset the private `state/config` var directly.
+   :epoch/reset-config!              reset-config!
    :epoch/clear-history!             clear-history!
    :epoch/clear-epoch-listeners!     clear-epoch-listeners!
 

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -86,16 +86,21 @@
   ;; the slot to `0` drops every record's `:trace-events`.
   50)
 
+(def ^:private default-config
+  ;; The shipped baseline config. Three keys today (:depth,
+  ;; :trace-events-keep, :redact-fn). Map shape kept open so future
+  ;; (rf/configure! :epoch-history {...}) extensions don't break the
+  ;; shape. Per rf2-wp70d / Tool-Pair §Time-travel §Redaction hook +
+  ;; Security.md §Epoch privacy posture: :redact-fn defaults to nil —
+  ;; apps that record sensitive material into app-db opt in by
+  ;; installing a fn. `reset-config!` restores exactly this map, and
+  ;; the `defonce` below initialises from it.
+  {:depth             default-depth
+   :trace-events-keep default-trace-events-keep
+   :redact-fn         nil})
+
 (defonce ^:private config
-  ;; Three keys today (:depth, :trace-events-keep, :redact-fn). Map
-  ;; shape kept open so future (rf/configure! :epoch-history {...})
-  ;; extensions don't break the shape. Per rf2-wp70d / Tool-Pair
-  ;; §Time-travel §Redaction hook + Security.md §Epoch privacy
-  ;; posture: :redact-fn defaults to nil — apps that record
-  ;; sensitive material into app-db opt in by installing a fn.
-  (atom {:depth             default-depth
-         :trace-events-keep default-trace-events-keep
-         :redact-fn         nil}))
+  (atom default-config))
 
 (defn non-neg-int?
   "True for non-negative integer values; nil and non-numeric values
@@ -139,6 +144,27 @@
   "Return the current epoch-history configuration map."
   []
   @config)
+
+(defn reset-config!
+  "Restore the live config atom to the shipped `default-config`
+  baseline (`:depth` 50, `:trace-events-keep` 50, `:redact-fn` nil).
+  Returns nil.
+
+  Test-support seam (rf2-yw1w1u): `re-frame.test-support`'s reset-hook
+  table fires this — via the `:epoch/reset-config!` late-bind hook —
+  once per fixture invocation so a prior test's `(rf/configure!
+  :epoch-history ...)` (which MERGES) can't leak `:trace-events-keep`,
+  `:depth`, or an installed `:redact-fn` into the next test. Resetting
+  to the WHOLE default map (rather than merging) is what clears a
+  previously-installed `:redact-fn` without the test ns reaching into
+  the private `config` var directly. Suites that intentionally want a
+  non-default value (e.g. `:trace-events-keep 5` to make the
+  keep<depth elision path reachable cheaply) re-apply it through the
+  public `configure!` boundary in their `:init-fn`, which runs AFTER
+  this reset."
+  []
+  (reset! config default-config)
+  nil)
 
 (defn depth []
   (:depth @config default-depth))

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -31,9 +31,17 @@
       have passed.
 
     * **Projected egress** — `projected-record` and `projected-history`
-      route the four payload-bearing slots through
-      `re-frame.elision/elide-wire-value` for off-box egress
-      (Xray-MCP `watch-epochs`, story / pair recorders).
+      route every payload-bearing slot through the privacy projection
+      for off-box egress (Xray-MCP `watch-epochs`, story / pair
+      recorders). That is: the canonical `:frame-state-before` /
+      `:frame-state-after` slots (app-db partition elided, runtime-db
+      partition default-redacted per EP-0001 ruling #14), the derived
+      `:db-before` / `:db-after` app-db projections, `:trigger-event`,
+      `:trace-events`, AND the value-bearing structured `:sub-runs` rows
+      (their `:prev-value` / `:value` slots — rf2-at60h). The value-free
+      `:renders` / `:effects` metadata and the record-level bookkeeping
+      pass through unchanged. `projected-record`'s own docstring is the
+      authoritative per-slot contract.
 
   Per rf2-0wi86 Phase-2 seam E. The orchestrators `restore-epoch` and
   `replace-app-db!` live in the `re-frame.epoch` facade — they wire
@@ -651,17 +659,35 @@
 ;; route through `projected-record` first, parallel to how direct-read
 ;; tools route through `elide-wire-value` (per rf2-czv3p).
 ;;
-;; The projection wraps `re-frame.elision/elide-wire-value` against the
-;; record's frame-id and the four payload-bearing slots that may carry
-;; sensitive or large material: `:db-before`, `:db-after`,
-;; `:trigger-event`, and `:trace-events`. The cheap structured slots
-;; (`:sub-runs`, `:renders`, `:effects`) carry no app-db material —
-;; they project sub-ids, render-keys, fx-ids, and outcome tags — so
-;; the projection leaves them as-is. The record-level bookkeeping
-;; (`:epoch-id`, `:frame`, `:committed-at`, `:event-id`, `:outcome`,
-;; `:halt-reason`, `:schema-digest`, `:rf.epoch/sensitive?`,
+;; The projection routes the record's frame-id and EVERY payload-bearing
+;; slot through the elision boundary. Two of those slots are
+;; value-bearing in ways the original four-slot model missed:
+;;
+;;   - The CANONICAL frame-state slots `:frame-state-before` /
+;;     `:frame-state-after` (EP-0001 rf2-3aizt1 decision #2 + ruling #14):
+;;     their `:rf.db/app` partition is elided through the same
+;;     `elide-wire-value` walk the `:db-*` projections receive, while
+;;     their `:rf.db/runtime` partition is DEFAULT-REDACTED to
+;;     `:rf/redacted` off-box (see `elide-frame-state-slot`).
+;;   - The structured `:sub-runs` rows (rf2-at60h): each carries the
+;;     sub's computed `:prev-value` / `:value`, so the rows DO carry
+;;     app-db material and the whole-output `:large?` case is projected
+;;     through the `:rf.size/large-elided` marker (see
+;;     `elide-sub-runs-slot`). Their non-value metadata (`:sub-id`,
+;;     `:query-v`, `:value-changed?`, `:cascade?`, `:cause-sub`,
+;;     `:cause-event-id`) passes through.
+;;
+;; The remaining full-value slots — the derived `:db-before` /
+;; `:db-after` app-db projections, `:trigger-event`, and `:trace-events`
+;; — also route through `elide-wire-value`. The value-free structured
+;; slots (`:renders`, `:effects`) carry no app-db material — they
+;; project render-keys, fx-ids, and outcome tags — so the projection
+;; leaves them as-is. The record-level bookkeeping (`:epoch-id`,
+;; `:frame`, `:committed-at`, `:event-id`, `:outcome`, `:halt-reason`,
+;; `:schema-digest`, `:rf.epoch/sensitive?`,
 ;; `:rf.epoch/redacted-modified-paths-count`) is structurally
-;; non-sensitive and passes through.
+;; non-sensitive and passes through. `projected-record`'s docstring is
+;; the authoritative per-slot contract.
 ;;
 ;; Per-tool reimplementation of the projection is prohibited (the
 ;; same posture as the wire-elision walker). New egress tools call

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -87,46 +87,42 @@
   de-duped; a genuine re-render never collapses back to the mount epoch."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.flows :as flows]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
+            ;; `trace` + `state` are used in test BODIES (`trace/emit!`,
+            ;; `trace/frame-trace-disabled?`, the `state/buffer-*!` /
+            ;; `state/*-mount-attribution!` private-helper exercises) —
+            ;; NOT for fixture config reset.
             [re-frame.trace :as trace]
             [re-frame.elision]
             [re-frame.epoch :as epoch]
             [re-frame.epoch.state :as state]
+            [re-frame.test-support :as test-support]
             [re-frame.machines]))
 
 ;; ---- fixture ---------------------------------------------------------------
 ;;
-;; Mirrors `re-frame.epoch-test/reset-runtime` — the attribution surface
-;; reaches the same shared atoms (`state/last-settled-epoch`,
-;; `mount-attribution`, the per-frame ring), all wiped by
-;; `epoch/clear-history!`. Per rf2-dq2b7 the former two render-attribution
-;; atoms (`mount-epoch-by-render-key` + `render-deps-by-render-key`)
-;; collapsed into a single `mount-attribution` atom.
-
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (reset! schemas/schemas-by-frame {})
-  (flows/reset-last-inputs!)
-  (trace/clear-listeners!)
-  ;; rf2-tqlmq — the per-frame trace-emission gate (`:rf.trace/frame-no-emit?`)
-  ;; is process-sticky (it tracks frame registrations, which `reset! frames {}`
-  ;; does not unwind). inv-7 registers a trace-disabled observer frame; clear
-  ;; the set between tests so a prior case's registration cannot leak in.
-  (trace/clear-frame-no-emit!)
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;; rf2-yw1w1u — canonical capture/restore fixture. Snapshots the
+;; registrar at ns-load + restores around each test, and fires the epoch
+;; reset-hook table (history / listeners / config-to-default) so the
+;; shared attribution atoms (`state/last-settled-epoch`,
+;; `mount-attribution`, the per-frame ring) start clean each test.
+;;
+;; The `:init-fn` adds two suite-specific steps the shared fixture
+;; doesn't own:
+;;   - `(rf/configure! :epoch-history {:trace-events-keep 5})` — the
+;;     suite's non-default keep (NOT the shipped 50 = :depth; Mike
+;;     pair-debug 2026-05-27), through the public boundary so no test ns
+;;     reaches into the private `state/config` var.
+;;   - `(trace/clear-frame-no-emit!)` — rf2-tqlmq: the per-frame
+;;     trace-emission gate (`:rf.trace/frame-no-emit?`) is process-sticky
+;;     and NOT a reset-hook-table row; inv-7 registers a trace-disabled
+;;     observer frame, so clear the set between tests.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn []
+                (rf/configure! :epoch-history {:trace-events-keep 5})
+                (trace/clear-frame-no-emit!))}))
 
 ;; ---- shared post-settle-emit fixture --------------------------------------
 ;;

--- a/implementation/epoch/test/re_frame/epoch_cascade_cause_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_cascade_cause_test.clj
@@ -22,34 +22,29 @@
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
             [re-frame.epoch.capture :as capture]
+            ;; `state` is used in test BODIES (`state/buffer-event!` /
+            ;; `state/buffer-for`) to populate the in-flight buffer the
+            ;; cascade-cause walk reads — NOT for fixture config reset.
             [re-frame.epoch.state :as state]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]
+            [re-frame.test-support :as test-support]
             ;; Side-effect require (mirror epoch_test.clj fixture).
             [re-frame.machines]))
 
-;; ---- fixture (mirrors epoch_test.clj's reset-runtime) ---------------------
-
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (reset! schemas/schemas-by-frame {})
-  (flows/reset-last-inputs!)
-  (trace/clear-listeners!)
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;; ---- fixture --------------------------------------------------------------
+;;
+;; rf2-yw1w1u — canonical capture/restore fixture. Snapshots the
+;; registrar at ns-load + restores around each test, fires the epoch
+;; reset-hook table (history / listeners / config-to-default), and the
+;; `:init-fn` re-applies the suite's non-default `:trace-events-keep 5`
+;; (NOT the shipped 50 = :depth; Mike pair-debug 2026-05-27) through the
+;; public `configure!` boundary — no test ns reaches into the private
+;; `state/config` var for fixture reset.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (rf/configure! :epoch-history {:trace-events-keep 5}))}))
 
 ;; ---- synthetic-buffer helpers ---------------------------------------------
 ;;

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -59,20 +59,18 @@
 ;; `test-support/make-reset-runtime-fixture` (rf2-am9d): the registrar is
 ;; snapshot/restored around each test so framework / example
 ;; registrations survive cross-ns CLJS test runs.
+;;
+;; rf2-yw1w1u — epoch state isolation (ring history, listeners, config)
+;; now flows through the fixture's reset-hook table
+;; (`:epoch/clear-history!`, `:epoch/clear-epoch-listeners!`,
+;; `:epoch/reset-config!`), so the `:init-fn` only re-applies this
+;; suite's non-default `:trace-events-keep 5` (NOT the shipped 50 =
+;; :depth) through the public `configure!` boundary — no test ns reaches
+;; into the private `state/config` var for fixture reset.
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:adapter plain-atom/adapter
-     :init-fn (fn []
-                ;; Per the JVM fixture (epoch_test.clj): reset epoch
-                ;; state and the config atom between tests so a prior
-                ;; test's `:depth 3` or pending cb leaks don't bleed
-                ;; into the next. The fixture's adapter install
-                ;; replaces the registrar / frames; epoch's own state
-                ;; lives in module-level atoms that need their own
-                ;; reset.
-                (epoch/clear-history!)
-                (epoch/clear-epoch-listeners!)
-                (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil}))}))
+     :init-fn (fn [] (rf/configure! :epoch-history {:trace-events-keep 5}))}))
 
 ;; ---- 1. Recording — happy-path record shape -------------------------------
 

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -116,44 +116,34 @@
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
             [re-frame.epoch.assembly :as assembly]
+            ;; `state` is used in test BODIES for the private back-fill
+            ;; path (`state/back-fill-sub-run!`) + the private listeners
+            ;; var (`@#'state/listeners`) the concurrency invariants
+            ;; exercise directly — NOT for fixture config reset (that now
+            ;; flows through `configure!`).
             [re-frame.epoch.state :as state]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]
+            [re-frame.test-support :as test-support]
             ;; rf2-v6z0: machines is a separate artefact whose late-bind
-            ;; hook publishes `rf/reg-machine` only when loaded. The
-            ;; epoch_test.clj fixture pulls it in for symmetry across
-            ;; the suite; we follow suit so the reset-runtime shape
-            ;; matches and the registrar/clear-all! reload works
-            ;; identically.
+            ;; hook publishes `rf/reg-machine` only when loaded. Pulled in
+            ;; for symmetry across the suite so the captured ns-load
+            ;; baseline includes the machines registrations.
             [re-frame.machines])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
-;; ---- fixture (mirrors epoch_test.clj's `reset-runtime`) ------------------
-
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (reset! schemas/schemas-by-frame {})
-  (flows/reset-last-inputs!)
-  (trace/clear-listeners!)
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  ;; Reset the config atom directly so :trace-events-keep / a stale
-  ;; :depth from a sibling test can't leak; configure! merges, so a
-  ;; per-test opt-in to elision would otherwise persist. The fixture
-  ;; forces :trace-events-keep 5 (NOT the shipped default of 50 = :depth,
-  ;; see `re-frame.epoch.state/default-trace-events-keep`).
-  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;; ---- fixture --------------------------------------------------------------
+;;
+;; rf2-yw1w1u — canonical capture/restore fixture. Snapshots the
+;; registrar at ns-load + restores around each test, fires the epoch
+;; reset-hook table (history / listeners / config-to-default), and the
+;; `:init-fn` re-applies the suite's non-default `:trace-events-keep 5`
+;; (NOT the shipped 50 = :depth; Mike pair-debug 2026-05-27) through the
+;; public `configure!` boundary — no test ns reaches into the private
+;; `state/config` var for fixture reset.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (rf/configure! :epoch-history {:trace-events-keep 5}))}))
 
 ;; ---- stress dials ---------------------------------------------------------
 

--- a/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
@@ -48,33 +48,24 @@
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.epoch :as epoch]
-            [re-frame.epoch.state :as state]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]
+            [re-frame.test-support :as test-support]
             ;; Side-effect require (mirror epoch_test.clj fixture).
             [re-frame.machines]))
 
-;; ---- fixture (mirrors epoch_test.clj's reset-runtime) ---------------------
-
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (reset! schemas/schemas-by-frame {})
-  (flows/reset-last-inputs!)
-  (trace/clear-listeners!)
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;; ---- fixture --------------------------------------------------------------
+;;
+;; rf2-yw1w1u — canonical capture/restore fixture. Snapshots the
+;; registrar at ns-load + restores around each test, fires the epoch
+;; reset-hook table (history / listeners / config-to-default), and the
+;; `:init-fn` re-applies the suite's non-default `:trace-events-keep 5`
+;; (NOT the shipped 50 = :depth; Mike pair-debug 2026-05-27) through the
+;; public `configure!` boundary — no test ns reaches into the private
+;; `state/config` var.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (rf/configure! :epoch-history {:trace-events-keep 5}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
@@ -15,33 +15,26 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
-            [re-frame.epoch.state :as state]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]
+            [re-frame.test-support :as test-support]
             ;; Side-effect require: machines publishes the late-bind hook
             ;; (see epoch_test.clj for the same dance).
             [re-frame.machines]))
 
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (reset! schemas/schemas-by-frame {})
-  (flows/reset-last-inputs!)
-  (trace/clear-listeners!)
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;; rf2-yw1w1u — canonical capture/restore fixture. Snapshots the
+;; registrar at ns-load + restores around each test, fires the epoch
+;; reset-hook table (history / listeners / config-to-default), and the
+;; `:init-fn` re-applies the suite's non-default `:trace-events-keep 5`
+;; (NOT the shipped 50 = :depth; Mike pair-debug 2026-05-27) through the
+;; public `configure!` boundary — no test ns reaches into the private
+;; `state/config` var. The `:init-fn` runs OUTSIDE each test's
+;; `(with-redefs [interop/debug-enabled? false] ...)`, so config lands at
+;; the normal gate value.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (rf/configure! :epoch-history {:trace-events-keep 5}))}))
 
 (deftest epoch-history-inert-when-debug-disabled
   (testing "Per rf2-0la4f: when the JVM debug gate reads false, the

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -58,33 +58,25 @@
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.epoch :as epoch]
-            [re-frame.epoch.state :as state]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]
+            [re-frame.test-support :as test-support]
             ;; Side-effect requires (mirror epoch_test.clj fixture).
             [re-frame.machines]))
 
 ;; ---- fixtures --------------------------------------------------------------
-
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (reset! schemas/schemas-by-frame {})
-  (flows/reset-last-inputs!)
-  (trace/clear-listeners!)
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;;
+;; rf2-yw1w1u — canonical capture/restore fixture. Snapshots the
+;; registrar at ns-load + restores around each test, fires the epoch
+;; reset-hook table (history / listeners / config-to-default), and the
+;; `:init-fn` re-applies the suite's non-default `:trace-events-keep 5`
+;; (NOT the shipped 50 = :depth; Mike pair-debug 2026-05-27) through the
+;; public `configure!` boundary — no test ns reaches into the private
+;; `state/config` var.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (rf/configure! :epoch-history {:trace-events-keep 5}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -28,40 +28,31 @@
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.epoch :as epoch]
-            [re-frame.epoch.state :as state]
-            [re-frame.flows :as flows]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.marks :as marks]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]
+            [re-frame.test-support :as test-support]
             ;; Side-effect requires (mirrors epoch_test.clj):
             [re-frame.machines]))
 
 ;; ---- fixtures --------------------------------------------------------------
-
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (reset! schemas/schemas-by-frame {})
-  (flows/reset-last-inputs!)
-  ;; The sub-output / per-registration marks tables are NOT cleared by
-  ;; `registrar/clear-all!`, so reset them here to keep the whole-output
-  ;; `:large?` propagation (rf2-at60h) from leaking across test cases.
-  (marks/clear-sub-output-marks!)
-  (marks/clear-marks!)
-  (trace/clear-listeners!)
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;;
+;; rf2-yw1w1u — canonical capture/restore fixture. Snapshots the
+;; registrar at ns-load + restores around each test, and fires the
+;; reset-hook table: epoch (history / listeners / config-to-default) AND
+;; the marks tables (`:marks/clear-marks!`,
+;; `:marks/clear-sub-output-marks!`) — those are NOT registrar kinds, so
+;; the table's late-bind hooks own resetting them between tests, keeping
+;; the whole-output `:large?` propagation (rf2-at60h) from leaking. The
+;; `:init-fn` re-applies the suite's non-default `:trace-events-keep 5`
+;; (NOT the shipped 50 = :depth; Mike pair-debug 2026-05-27) through the
+;; public `configure!` boundary — no test ns reaches into the private
+;; `state/config` var.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (rf/configure! :epoch-history {:trace-events-keep 5}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
@@ -57,36 +57,27 @@
   multiple projection calls."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.elision :as elision]
+            [re-frame.elision]
             [re-frame.epoch :as epoch]
-            [re-frame.epoch.state :as state]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.privacy :as privacy]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]
+            [re-frame.test-support :as test-support]
             ;; Side-effect requires (mirror epoch_test.clj fixture).
             [re-frame.machines]))
 
 ;; ---- fixtures --------------------------------------------------------------
-
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (reset! schemas/schemas-by-frame {})
-  (flows/reset-last-inputs!)
-  (trace/clear-listeners!)
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;;
+;; rf2-yw1w1u — canonical capture/restore fixture. Snapshots the
+;; registrar at ns-load + restores around each test, fires the epoch
+;; reset-hook table (history / listeners / config-to-default), and the
+;; `:init-fn` re-applies the suite's non-default `:trace-events-keep 5`
+;; (NOT the shipped 50 = :depth; Mike pair-debug 2026-05-27) through the
+;; public `configure!` boundary — no test ns reaches into the private
+;; `state/config` var.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (rf/configure! :epoch-history {:trace-events-keep 5}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
@@ -34,33 +34,32 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
-            [re-frame.epoch.state :as state]
-            [re-frame.flows :as flows]
             [re-frame.frame :as frame]
-            [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]
+            [re-frame.test-support :as test-support]
             ;; Side-effect requires (mirror epoch_test.clj fixture).
             [re-frame.machines]))
 
 ;; ---- fixtures --------------------------------------------------------------
-
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (reset! schemas/schemas-by-frame {})
-  (flows/reset-last-inputs!)
-  (trace/clear-listeners!)
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;;
+;; rf2-yw1w1u — the canonical capture/restore fixture. It snapshots the
+;; registrar at ns-load and restores around each test (so framework /
+;; example registrations survive cross-ns runs) and fires the epoch
+;; reset-hook table (`:epoch/clear-history!`,
+;; `:epoch/clear-epoch-listeners!`, `:epoch/reset-config!`) so each test
+;; starts from a clean epoch slate with config reset to the shipped
+;; default. The `:init-fn` re-applies the suite's non-default
+;; `:trace-events-keep 5` (NOT the shipped 50 = :depth, see
+;; `re-frame.epoch.state/default-trace-events-keep`; Mike pair-debug
+;; 2026-05-27) through the public `configure!` boundary — no test ns
+;; reaches into the private `state/config` var. The `:init-fn` runs
+;; AFTER the post-dispose reset hooks, so the override lands on top of
+;; the freshly-reset default.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (rf/configure! :epoch-history {:trace-events-keep 5}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
 

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -29,10 +29,17 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [re-frame.flows :as flows]
+            ;; Side-effect require: flows publishes the `:flows/reg-flow`
+            ;; late-bind hook at ns-load. Several restore-* tests register
+            ;; flows via `rf/reg-flow` in their bodies; without this load
+            ;; they throw `:rf.error/flows-artefact-missing`. Loading it
+            ;; HERE means the capture/restore fixture's ns-load registrar
+            ;; snapshot includes the flows surface. Alias unused — the
+            ;; fixture no longer touches the private flows atoms (the
+            ;; reset-hook table owns flows reset).
+            [re-frame.flows]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
-            [re-frame.schemas :as schemas]
             ;; rf2-szbzei — the runtime-db schema-validation precondition on
             ;; replace-runtime-db! / replace-frame-state! routes through the
             ;; machine-data boundary's `:schemas/validate-with-registered-fn`
@@ -40,16 +47,33 @@
             ;; by this .malli adapter ns). Without it the registered-validator
             ;; soft-passes and the runtime-db-validation-fires test can't drive
             ;; a real schema failure. Side-effect require — alias unused.
+            ;; (Also transitively loads `re-frame.schemas` so the fixture's
+            ;; ns-load registrar snapshot includes the schemas surface.)
             [re-frame.schemas.malli]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]
             [re-frame.elision]
             [re-frame.epoch :as epoch]
             [re-frame.epoch.assembly :as assembly]
             [re-frame.epoch.capture :as capture]
             [re-frame.epoch.listeners :as epoch.listeners]
+            ;; `state` is used in test BODIES for the deep private-impl
+            ;; unit tests (the `@#'state/value-changed-epoch-for` scan
+            ;; against a hand-built `@#'state/histories` ring, and the
+            ;; shipped-default accessor probe) — NOT for fixture config
+            ;; reset, which now flows through the public `configure!`
+            ;; boundary + the `:epoch/reset-config!` reset hook.
             [re-frame.epoch.state :as state]
             [re-frame.epoch.tool-pair :as tool-pair]
+            ;; Side-effect require: routing publishes its `:routing/*`
+            ;; late-bind hooks (incl. the `rf/reg-route` registrar kind)
+            ;; at ns-load. Several tests call `rf/reg-route` in their
+            ;; bodies; loading routing HERE (rather than reloading it in
+            ;; the fixture) means the capture/restore fixture's ns-load
+            ;; registrar snapshot includes routing's registrations and
+            ;; restores them around each test (rf2-yw1w1u).
+            [re-frame.routing]
             ;; rf2-v6z0: machines is a separate artefact whose late-bind
             ;; hook publishes `rf/reg-machine` only when the namespace is
             ;; loaded. Several restore-* tests register machines via
@@ -59,33 +83,27 @@
             [re-frame.machines]))
 
 ;; ---- fixtures --------------------------------------------------------------
-
-(defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (reset! schemas/schemas-by-frame {})
-  ;; Per smoke_test.clj fixture (rf2-xsfj): flows.cljc keeps a private
-  ;; last-inputs atom for dirty-checking. Clear it so a prior test's
-  ;; flow registration can't leak its last-inputs into a same-keyed
-  ;; flow in a subsequent test.
-  (flows/reset-last-inputs!)
-  (trace/clear-listeners!)
-  (epoch/clear-history!)
-  (epoch/clear-epoch-listeners!)
-  ;; Reset the config atom directly so :trace-events-keep (rf2-iegsz)
-  ;; doesn't leak between tests — `configure!` merges, so a per-test
-  ;; opt-in to elision would otherwise persist. The fixture forces
-  ;; :trace-events-keep 5 (NOT the shipped default of 50 = :depth, see
-  ;; `re-frame.epoch.state/default-trace-events-keep`; Mike pair-debug
-  ;; 2026-05-27) so the keep<depth elision path is reachable with a
-  ;; handful of dispatches.
-  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
-  (rf/init! plain-atom/adapter)
-  (require 're-frame.routing :reload)
-  (test-fn))
-
-(use-fixtures :each reset-runtime)
+;;
+;; rf2-yw1w1u — the canonical capture/restore fixture. It snapshots the
+;; registrar at ns-load and restores around each test (so the routing /
+;; schemas / machines registrations this ns's `:require` chain brought
+;; live survive cross-ns runs without a `clear-all!` + reload dance), and
+;; fires the epoch reset-hook table (`:epoch/clear-history!`,
+;; `:epoch/clear-epoch-listeners!`, `:epoch/reset-config!`) so each test
+;; starts from a clean epoch slate with config reset to the shipped
+;; default. The `:init-fn` re-applies the suite's non-default
+;; `:trace-events-keep 5` (rf2-iegsz — a keep<depth OVERRIDE so the
+;; elision path is reachable with a handful of dispatches; NOT the
+;; shipped default of 50 = :depth, see
+;; `re-frame.epoch.state/default-trace-events-keep`; Mike pair-debug
+;; 2026-05-27) through the public `configure!` boundary — no test ns
+;; reaches into the private `state/config` var for fixture reset. The
+;; `:init-fn` runs AFTER the post-dispose reset hooks, so the override
+;; lands on top of the freshly-reset default.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (rf/configure! :epoch-history {:trace-events-keep 5}))}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -1762,6 +1780,17 @@
 ;; records and miss a genuine value-change, mis-attributing the render. The fix
 ;; bounds the scan on the directly-observable elision state (break at the first
 ;; record MISSING `:trace-events`) so it tracks reality under any reconfigure.
+;;
+;; rf2-yw1w1u — the two tests below KEEP direct private-var access
+;; (`@#'state/histories`, `@#'state/config`, `@#'state/value-changed-epoch-for`)
+;; rather than the shared fixture / `configure!` boundary. They are
+;; narrow unit tests of the PRIVATE `value-changed-epoch-for` scan: they
+;; hand-stuff a bespoke `histories` ring (a post-reduction transient gap
+;; / a manually-elided boundary) that no public API can construct, then
+;; pin the private config to the exact keep the scenario needs. Routing
+;; the config line through `configure!` while the rest of the setup is
+;; raw private-atom manipulation would be inconsistent and add no
+;; isolation — these cases live entirely below the public surface.
 
 (defn- vc-record
   "A minimal epoch record carrying a value-changed `:rf.sub/run` for
@@ -3851,7 +3880,7 @@
             `shipped-trace-events-keep-default-is-50` for the real
             default)."
     (is (= 5 (:trace-events-keep (epoch/current-config)))
-        "fixture OVERRIDE — see reset-runtime; NOT the shipped default")))
+        "fixture OVERRIDE — see the :init-fn configure! call; NOT the shipped default")))
 
 (deftest shipped-trace-events-keep-default-is-50
   (testing "rf2-wmki8 — the SHIPPED runtime default :trace-events-keep is
@@ -3867,6 +3896,13 @@
     ;; partial `configure!` leaves). Drive a config WITHOUT the slot and
     ;; confirm the accessor reports the shipped 50 — proving the var is the
     ;; live default, not just a declared constant.
+    ;;
+    ;; rf2-yw1w1u — KEEPS direct private-var access: `configure!` /
+    ;; `merge-config!` MERGES, so it cannot produce a config map MISSING
+    ;; the `:trace-events-keep` slot (the exact shape this test needs to
+    ;; exercise the accessor's fallback). Only a raw `reset!` of the
+    ;; private `config` can build that shape — the shared fixture's
+    ;; reset-to-default always carries the slot.
     (reset! @#'state/config {:depth 50 :redact-fn nil})
     (is (= 50 (state/trace-events-keep))
         "trace-events-keep accessor falls back to the shipped 50 default")


### PR DESCRIPTION
Centralises epoch test config isolation behind a late-bind reset hook and syncs the stale egress-projection comments. rf2-yw1w1u.

## Finding 1 — centralise epoch test config isolation
- New `re-frame.epoch.state/reset-config!` restores the shipped `default-config` baseline; a `re-frame.epoch` facade publishes it through the new `:epoch/reset-config!` late-bind hook.
- Added to `re-frame.test-support`'s reset-hook-table (`:post-dispose`, beside the existing epoch history/listener hooks) + a `late-bind.directory` entry (drift-gated); `test_support_test` hook-count coverage updated.
- Migrated the 10 JVM epoch suites + the epoch CLJS suite off their copied `reset-runtime` fixtures onto `test-support/make-reset-runtime-fixture`. The suite's non-default `:trace-events-keep 5` is re-applied through the public `rf/configure!` boundary in `:init-fn` rather than `(reset! @#'state/config ...)`.
- Direct private-var access kept only in the 3 narrow unit tests that exercise private impl (the `value-changed-epoch-for` scan over a hand-built `histories` ring; the shipped-default accessor fallback), each documented inline.

## Finding 2 — sync projection / artefact comments
- `tool_pair.cljc` ns + projection-section comments now enumerate the `:frame-state-before`/`-after` slots and value-bearing `:sub-runs`, distinguished from value-free `:renders`/`:effects` (was the stale four-slot model). The `projected-record` docstring was already current.
- `epoch/deps.edn` artefact-loading comment now points at the `set-fns!` publication map (drift-gated) instead of a stale partial hook list; the `:test` alias comment describes the capture/restore fixture instead of the old `clear-all!` + routing-reload dance.

No behaviour change; bounded known conflict with the ep-0002 egress-projection rewrite (gjq3ow) accepted per the bead.

## Quality gates
- `clojure -M:test` in `implementation/epoch`: 295 tests, 1164 assertions, 0 failures/errors
- `clojure -M:test` in `implementation/core`: 1010 tests, 4401 assertions, 0 failures/errors (covers test_support hook-count + late-bind drift)
- `npm run test:cljs`: 6121 tests, 21828 assertions, 0 failures/errors