### PR TITLE
refactor(machines): reducer purity + grammar/legacy-API/test hygiene (rf2-3l8lqe)

### DIFF
--- a/implementation/machines/src/re_frame/machines/grammar.cljc
+++ b/implementation/machines/src/re_frame/machines/grammar.cljc
@@ -1,0 +1,163 @@
+(ns re-frame.machines.grammar
+  "Shared machine-grammar primitives. Per Spec 005 §Transitions and
+  §Transition resolution.
+
+  ## Why this namespace exists
+
+  The state-machine grammar — the shape of a state-tree, what a
+  transition `:target` may be, and how a target resolves to a node —
+  is a contract two layers must agree on EXACTLY:
+
+    1. **registration-time validation** (`lifecycle-fx.validation`)
+       rejects a machine whose targets don't resolve, BEFORE the
+       runtime ever drives it; and
+    2. **the runtime engine** (`transition` / `parallel`) resolves the
+       same targets against the same tree at dispatch time.
+
+  Before this namespace existed those two layers each owned a private
+  copy of the `:states`-tree descent and the transition-value form
+  grammar. The validation `candidate-targets` docstring even said it
+  *mirrors* `transition/normalise-candidates` — the semantic contract
+  was duplicated by convention rather than by construction, so every
+  grammar addition or XState-parity refinement had to update multiple
+  private implementations in lockstep, with the standing risk that
+  registration accepts a shape the runtime drives differently (or
+  rejects one the runtime would handle).
+
+  Naming the descent + form grammar once, here, makes both layers
+  consume ONE source of truth. This is the sibling of
+  `re-frame.machines.path-walk` (the deepest-wins leaf→root walk): both
+  are leaf namespaces (no require on `transition` / `validation` /
+  `parallel`) so either layer can require them without a load cycle.
+
+  ## Surface
+
+      (node-at states path)              ;; absolute root→leaf descent
+      (history-node? node)               ;; :type :history pseudo-state?
+      (transition-value-form v)          ;; :keyword | :vec-target |
+                                         ;;   :candidate-vector | :map |
+                                         ;;   :nil | :other
+      (candidate-targets v)              ;; [{:present? bool :target t} ...]
+
+  `node-at` takes a `:states` map directly (NOT a machine) — the lowest
+  common denominator, so a flat machine's `:states`, a region body's
+  `:states`, or any nested compound's `:states` all resolve through the
+  same fn. The runtime's `transition/node-at` is a thin wrapper that
+  passes `(:states machine)`; the validators pass the scope `:states`
+  map they walk.")
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- state-tree descent ---------------------------------------------------
+
+(defn node-at
+  "Walk a `:states` map down absolute `path`, returning the leaf
+  state-node (or nil if `path` doesn't resolve). `states` is a flat
+  machine's `:states` map, a single region body's `:states`, or any
+  compound's `:states` — region names are never part of a within-scope
+  path. The single home for the root→leaf descent the runtime
+  (`transition/node-at` → here) and the registration validators
+  (`validation` → here) both rely on, so the two can never drift.
+
+  An empty `path` resolves to nil (the scope root is the `states` map
+  itself, not a node)."
+  [states path]
+  (loop [m states
+         p path]
+    (cond
+      (empty? p) nil
+      :else
+      (let [n (get m (first p))]
+        (cond
+          (nil? n)        nil
+          (= 1 (count p)) n
+          :else           (recur (:states n) (rest p)))))))
+
+(defn history-node?
+  "True iff `node` is a `:type :history` pseudo-state. Per Spec 005
+  §History states — a targetable pseudo-state that is never an occupied
+  active leaf. Shared by the runtime (`transition`) and the registration
+  validators so the one-line predicate has a single home."
+  [node]
+  (= :history (:type node)))
+
+;; ---- transition-value form grammar ----------------------------------------
+;;
+;; Per Spec 005 §Transitions §Multiple-candidate transitions and §Delayed
+;; `:after` transitions: a transition-table slot value (`:on <key>` clause,
+;; an `:after` delay entry, `:always`, an `:on-done`, a `:spawn :on-error`)
+;; takes one of a small closed set of forms. Both the runtime normaliser
+;; (`transition/normalise-candidates`) and the validation target walker
+;; (`validation/candidate-targets`) discriminate on the SAME forms but
+;; build DIFFERENT shapes from them — the runtime needs the candidate maps
+;; (and throws on an unrecognised form with a slot-specific error id), the
+;; validator needs each declared `:target` tagged with whether the
+;; `:target` key was PRESENT (an absent `:target` is an internal
+;; transition — always fine — distinct from a malformed `{:target nil}`).
+;;
+;; This is the shared form recogniser the two build on, so the cond arms
+;; are written once. `:nil` is broken out from `:other` because the two
+;; callers treat it identically to the forbidden-transition internal form
+;; (XState v5 `on: {E: undefined}`), never as a malformed value.
+
+(defn transition-value-form
+  "Classify a transition-table slot value into its grammar form, the
+  closed set both the runtime normaliser and the registration target
+  walker discriminate on:
+
+    :nil              — nil value (forbidden-transition / internal no-op;
+                        the natural Clojure analogue of XState `undefined`)
+    :keyword          — a bare keyword (sibling target)
+    :candidate-vector — a non-empty vector of maps (multiple guarded
+                        candidates, first-guard-pass wins)
+    :vec-target       — any other vector (an absolute path target)
+    :map              — a single transition map
+    :other            — none of the above (malformed)
+
+  Note `:vec-target` matches any vector that is NOT the non-empty
+  all-maps candidate form — including the empty vector, which both
+  callers historically treat as a (non-resolving) absolute-path target
+  rather than a distinct malformed form."
+  [v]
+  (cond
+    (nil? v)        :nil
+    (keyword? v)    :keyword
+    (and (vector? v) (seq v) (every? map? v)) :candidate-vector
+    (vector? v)     :vec-target
+    (map? v)        :map
+    :else           :other))
+
+(defn candidate-vector-form?
+  "True iff `v` is the multi-candidate VECTOR form (`[{…} {…}]`) — the
+  only value-form the inline-source macro keys per-index. Shared by the
+  runtime (`transition/candidate-vector-form?`) and any caller that must
+  decide whether a selected candidate's index is meaningful for the
+  spec-path discriminator."
+  [v]
+  (= :candidate-vector (transition-value-form v)))
+
+(defn candidate-targets
+  "Normalise a transition slot value to the seq of `:target`s it
+  declares, each tagged with `:present?` (whether the `:target` KEY was
+  present, distinguishing an internal transition — `:target` absent,
+  always fine — from a malformed `{:target nil}`). The registration
+  target validator consumes this; the runtime normaliser
+  (`normalise-candidates`) builds the candidate maps from the SAME
+  form recogniser (`transition-value-form`) so the two never drift.
+
+    a keyword              -> the target IS the keyword
+    a vector of maps       -> each map's :target (present? per map)
+    any other vector       -> the target IS the vector (absolute path)
+    a single map           -> its :target (present? = has :target key)
+    nil / other            -> no targets
+
+  An empty vector yields no targets (it has no targetable form)."
+  [v]
+  (case (transition-value-form v)
+    :keyword          [{:present? true :target v}]
+    :candidate-vector (mapv (fn [m] {:present? (contains? m :target)
+                                     :target   (:target m)}) v)
+    :vec-target       [{:present? true :target v}]
+    :map              [{:present? (contains? v :target) :target (:target v)}]
+    ;; :nil / :other contribute no target.
+    []))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -10,12 +10,20 @@
   `[:rf.runtime/machines :system-ids]` reverse index entry.
 
   Per rf2-t07u (Option A revised), `args` can be either:
-    - a keyword `actor-id` — the legacy / imperative form (action emits
-      `[:rf.machine/destroy actor-id]` directly with the recorded id), OR
+    - a keyword `actor-id` — the IMPERATIVE form: an action emits
+      `[:rf.machine/destroy actor-id]` directly with the actor id it
+      holds. This is first-class current API — re-frame2's spelling of
+      XState v5 `stopChild(actorId)` (the gold-standard imperative
+      teardown that sits alongside automatic exit-cascade teardown), OR
     - a map `{:rf/parent-id ... :rf/spawn-id ...}` — the declarative-
       `:spawn` exit-cascade form, where the runtime resolves the actor
       id from `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]` in the frame's
       runtime-db.
+
+  Both forms are canonical and current (pre-alpha, no compatibility
+  shims): the keyword form is the imperative entry-point, the map form
+  is what the `:spawn` desugaring emits on state exit. They are not a
+  new-vs-old pair.
 
   Per rf2-6vmw, the map form may also carry `:rf/spawn-all true` —
   the declarative-`:spawn-all` exit-cascade form. The slot at
@@ -79,7 +87,7 @@
   `:system-id-released` trace, unregister the live event handler, and
   forget the actor from the per-frame spawn-order channel (rf2-vsigt).
 
-  Used by `destroy-machine-fx` for the keyword-form legacy/imperative
+  Used by `destroy-machine-fx` for the keyword-form imperative
   destroy AND iterated for each child in a `:spawn-all` teardown, AND
   by the frame-destroy cascade walker (`frame-destroy.cljc`).
 
@@ -185,7 +193,7 @@
     nil))
 
 (defn- destroy-single!
-  "Per rf2-t07u — the keyword (legacy/imperative) form and the single-
+  "Per rf2-t07u — the keyword (imperative) form and the single-
   `:spawn` (tracked map) form of `:rf.machine/destroy`. Resolves the
   actor-id (keyword direct OR via the `[:rf.runtime/machines :spawned ...]` slot), emits
   the `:rf.machine/destroyed` trace, then applies the unified teardown

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/frame_destroy.cljc
@@ -114,11 +114,20 @@
       -1)))
 
 (defn- emit-lifecycle-destroyed!
-  "Emit the legacy `:rf.machine.lifecycle/destroyed` notification per
-  actor, carrying the frame id, the machine id, the snapshot's
-  `:state` (when present), and the unified discriminator
-  `:reason :parent-frame-destroyed`. Preserves the trace contract
-  observable in
+  "Emit the `:rf.machine.lifecycle/destroyed` notification per actor,
+  carrying the frame id, the machine id, the snapshot's `:state` (when
+  present), and the unified discriminator `:reason
+  :parent-frame-destroyed`.
+
+  Per Spec 009 §Actor lifecycle observation (009:240-269) this is NOT a
+  legacy event: `:rf.machine.lifecycle/destroyed` is the canonical
+  REGISTRAR-substrate observation axis (\"the actor's handler / snapshot
+  was reaped\", including frame-exit reaping), the deliberate sibling of
+  the FX-substrate `:rf.machine/destroyed` (\"a destroy fx ran\"). The
+  two are parallel observation axes carrying which substrate observed
+  the teardown — never a new-vs-old pair. Frame-exit reaping fires the
+  registrar axis only (no destroy fx runs), which is exactly why this
+  cascade emits this event. Preserves the trace contract observable in
   `frame_lifecycle_test/destroy-frame-cascade-emits-per-active-machine`."
   [frame-id actor-id snapshot]
   (trace/emit! :rf.machine.lifecycle/destroyed :rf.machine.lifecycle/destroyed

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -23,7 +23,8 @@
   `walk-state-nodes` yields `[state-key state-node]` pairs for every
   node under `:states`, recursing through `:states` maps; used by the
   top-level dispatch."
-  (:require [re-frame.machines.parallel :as parallel]))
+  (:require [re-frame.machines.grammar :as grammar]
+            [re-frame.machines.parallel :as parallel]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -444,26 +445,24 @@
   else is `:rf.error/machine-history-extra-keys`."
   #{:type :deep? :default-target})
 
-(defn- history-node?
-  "True iff `node` is a history pseudo-state (`:type :history`)."
-  [node]
-  (= :history (:type node)))
+(def ^:private history-node?
+  "True iff `node` is a history pseudo-state (`:type :history`). The
+  shared `grammar/history-node?` — registration and the runtime read the
+  one predicate."
+  grammar/history-node?)
 
 (defn- node-at-states
   "Walk a `:states` map down absolute `path`, returning the leaf
   state-node (or nil if `path` doesn't resolve). Scope-local resolver —
   `states` is the flat machine's `:states` or a single region body's
   `:states`, so `path` is scope-relative (region names are never part of
-  a within-region path)."
+  a within-region path). Delegates to the shared `grammar/node-at` (the
+  same root→leaf descent the runtime `transition/node-at` uses) so
+  registration resolves targets against EXACTLY the tree the runtime
+  drives. `path` is coerced to a vector for the shared fn's count/seq
+  semantics."
   [states path]
-  (loop [m states, p (vec path)]
-    (cond
-      (empty? p) nil
-      :else      (let [n (get m (first p))]
-                   (cond
-                     (nil? n)        nil
-                     (= 1 (count p)) n
-                     :else           (recur (:states n) (rest p)))))))
+  (grammar/node-at states (vec path)))
 
 (defn- resolves-to-state?
   "True iff `target` resolves to a real state under `owning-path` within
@@ -865,25 +864,17 @@
 ;; targets have DIFFERENT (region-qualified) semantics and are validated by
 ;; `validate-parallel!`; this block walks only per-region / flat state nodes.
 
-(defn- candidate-targets
+(def ^:private candidate-targets
   "Normalise a transition slot's value (an `:on` entry, an `:after` entry,
   an `:on-done`, a `:spawn :on-error`) to the seq of `:target`s it declares,
-  mirroring `transition/normalise-candidates`: a keyword IS the target; a
-  vector of maps yields each map's `:target`; any other vector IS the target
-  (an absolute path); a single map yields its `:target`. A targetless /
-  action-only candidate contributes no target. The `:present?` marker on each
-  yielded entry distinguishes \"`:target` key absent\" (internal transition —
-  always fine) from \"`:target` present but malformed\" (e.g. `{:target
-  nil}`, which is still internal but worth nothing here)."
-  [v]
-  (cond
-    (nil? v)        []
-    (keyword? v)    [{:present? true :target v}]
-    (and (vector? v) (seq v) (every? map? v))
-    (map (fn [m] {:present? (contains? m :target) :target (:target m)}) v)
-    (vector? v)     [{:present? true :target v}]
-    (map? v)        [{:present? (contains? v :target) :target (:target v)}]
-    :else           []))
+  each tagged with `:present?`. The shared `grammar/candidate-targets`,
+  built on the SAME `grammar/transition-value-form` recogniser the runtime
+  normaliser (`transition/normalise-candidates`) uses — so this is no
+  longer a hand-kept mirror but the one grammar layer by construction. The
+  `:present?` marker distinguishes \"`:target` key absent\" (internal
+  transition — always fine) from \"`:target` present but malformed\" (e.g.
+  `{:target nil}`)."
+  grammar/candidate-targets)
 
 (defn- validate-target!
   "Validate one `:target` against the declaring state's `scope` (its region /

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -1,25 +1,55 @@
 (ns re-frame.machines.transition
-  "Pure machine-transition engine. Per Spec 005 §State machines.
+  "The machine-transition reducer. Per Spec 005 §State machines.
 
   This namespace is the JVM- and CLJS-runnable core of the machine
   grammar — transition resolution along hierarchical paths, the
   exit/action/entry cascade, the macrostep drain semantics for `:raise`
-  and `:always`, and the parallel-region broadcast layer. Everything
-  here is a pure function over the [machine snapshot event] triple —
-  no module-level mutable state. Per rf2-gr8q the declarative-`:spawn`
-  spawn-id allocator lives inside the snapshot under `:rf/spawn-counter`
-  (a per-machine-id integer map); the reducer threads the bumped
-  counter through the returned snapshot.
+  and `:always`, and the parallel-region broadcast layer.
+
+  ## What \"pure\" means here
+
+  The transition engine's REDUCTION is a pure, deterministic function of
+  the `[machine snapshot event]` triple: the returned `Result` (the
+  post-transition snapshot + the emitted fx vector, including the
+  `:rf.machine/spawn` allocator's id sequencing) depends ONLY on the
+  arguments. There is no module-level mutable state and no `app-db` read
+  — per rf2-gr8q the declarative-`:spawn` spawn-id allocator lives
+  INSIDE the snapshot under `:rf/spawn-counter` (a per-machine-id integer
+  map), so identical triples produce identical Results and the reducer
+  threads the bumped counter through the returned snapshot. That is the
+  determinism the conformance corpus, the SSR pure-fn surface, and
+  `machine_transition_purity_test` rely on.
+
+  It is NOT effect-free of observability: the reducer emits `trace/emit!`
+  diagnostic events (guard outcomes, action runs, history record/restore,
+  timer scheduling, microsteps, depth-limit aborts, unhandled-event
+  no-ops) on the process-wide Spec 009 trace stream, exactly as the rest
+  of the framework (router, fx, subs, events) does inline. Per Spec 005
+  §`:before` / `:after` (005:545) and §Strict encapsulation (005:637)
+  this is deliberate: trace is production-elided observability (Closure
+  DCE on `interop/debug-enabled?` — see `re-frame.trace/emit!`), never
+  part of the snapshot/fx value, and never read back into the
+  reduction. So a `machine-transition` call's RETURNED VALUE is
+  side-effect-free and deterministic; its emitted trace is an additive
+  observability side channel that a production build removes entirely.
+  Whether that channel should instead be returned as data or routed
+  through an interpreter-owned injectable sink (decoupling it from the
+  reducer the way XState separates reducer semantics from interpreter
+  effects) is an open architectural question tracked separately — it
+  would diverge from the project-wide inline-emit contract, so it is a
+  ruling, not a refactor this engine makes unilaterally.
 
   The fx vectors built here name `:rf.machine/spawn`,
   `:rf.machine/destroy`, `:rf.machine/spawn-all-init`,
   `:rf.machine/after-schedule`, and `:rf.machine/after-cancel`; the
   actual fx handlers live in `re-frame.machines.lifecycle-fx.{spawn,
-  destroy,registration}` and `re-frame.machines.timer`. This namespace
-  stays effect-free so it can be loaded and exercised on the JVM by
-  the conformance fixtures (Spec 005 §Conformance fixtures)."
+  destroy,registration}` and `re-frame.machines.timer`. No fx is
+  PERFORMED here — the reducer only NAMES them in the returned vector,
+  so it can be loaded and exercised on the JVM by the conformance
+  fixtures (Spec 005 §Conformance fixtures)."
   (:require [clojure.set :as set]
             [clojure.string :as str]
+            [re-frame.machines.grammar :as grammar]
             [re-frame.machines.path-walk :as path-walk]
             [re-frame.machines.result :as result
              #?@(:cljs [:include-macros true])]
@@ -394,18 +424,14 @@
 
 (defn node-at
   "Walk machine.:states down `path` returning the leaf state-node (or nil
-  if path doesn't resolve)."
+  if path doesn't resolve). Thin wrapper over `grammar/node-at` (the
+  shared root→leaf descent the registration validators also consume) —
+  passes the machine's `:states` scope. Kept as a public name here so
+  the engine's many call sites (and `parallel` / `finalize` /
+  `registration` / `spawn-error`) need not reach into `grammar`
+  directly."
   [machine path]
-  (loop [m  (:states machine)
-         p  path]
-    (cond
-      (empty? p) nil
-      :else
-      (let [n (get m (first p))]
-        (cond
-          (nil? n) nil
-          (= 1 (count p)) n
-          :else (recur (:states n) (rest p)))))))
+  (grammar/node-at (:states machine) path))
 
 (defn- nodes-along-path
   "Return [[prefix-path node] ...] from root down to leaf. Skips nodes
@@ -519,17 +545,23 @@
 
   `bad-value-id` names the error category to throw for an unrecognised
   value form so each caller surfaces its own slot-specific taxonomy
-  (`:on` → `machine-bad-on-clause`, `:after` → `machine-bad-after-spec`)."
+  (`:on` → `machine-bad-on-clause`, `:after` → `machine-bad-after-spec`).
+
+  Discriminates on `grammar/transition-value-form` — the SHARED form
+  recogniser the registration target validator (`validation/candidate-
+  targets`) also builds on — so the runtime normaliser and the
+  registration walker can never drift on what shapes the grammar admits."
   [v bad-value-id]
-  (cond
-    (nil? v)                        [{}]
-    (keyword? v)                    [{:target v}]
-    (and (vector? v)
-         (every? map? v)
-         (seq v))                   v
-    (vector? v)                     [{:target v}]
-    (map? v)                        [v]
-    :else (throw (ex-info (str bad-value-id) {:value v}))))
+  (case (grammar/transition-value-form v)
+    ;; A nil VALUE (the key is present with value nil) is the
+    ;; forbidden-transition / internal no-op form (rf2-16gxd) — unify
+    ;; with the empty-map single-candidate `[{}]`.
+    :nil              [{}]
+    :keyword          [{:target v}]
+    :candidate-vector v
+    :vec-target       [{:target v}]
+    :map              [v]
+    :other            (throw (ex-info (str bad-value-id) {:value v}))))
 
 (defn- candidate-vector-form?
   "True iff `v` is the multi-candidate VECTOR form (`[{…} {…}]`) — the
@@ -538,10 +570,11 @@
   decide whether the selected candidate's index is meaningful for the
   spec-path discriminator (rf2-lai1qv): for the index-free forms the
   carried `:candidate-idx` is nil so `cascade-row-source-key` emits the
-  bare-slot shape that matches the macro's keying. Mirrors the
-  vector-of-maps arm of `normalise-candidates`."
+  bare-slot shape that matches the macro's keying. Delegates to the
+  shared `grammar/candidate-vector-form?` so the per-index decision and
+  the `normalise-candidates` arm read the same recogniser."
   [v]
-  (boolean (and (vector? v) (seq v) (every? map? v))))
+  (grammar/candidate-vector-form? v))
 
 (defn- transition-slot
   "Build the structured spec-path DISCRIMINATOR (rf2-lai1qv) carried on a
@@ -1289,10 +1322,11 @@
 ;; recording rides `pr-str` round-trip, SSR hydration, and Tool-Pair epoch
 ;; replay for free — no side-table.
 
-(defn history-node?
-  "True iff `node` is a history pseudo-state (`:type :history`)."
-  [node]
-  (= :history (:type node)))
+(def history-node?
+  "True iff `node` is a history pseudo-state (`:type :history`). The
+  shared `grammar/history-node?` — re-exported here so the engine's
+  internal call sites need not require `grammar` directly."
+  grammar/history-node?)
 
 (defn state-occupiable?
   "True iff `state` (a flat keyword or compound vector path) resolves

--- a/implementation/machines/test/re_frame/after_test.clj
+++ b/implementation/machines/test/re_frame/after_test.clj
@@ -22,15 +22,17 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace]))
+            [re-frame.subs]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(defn- frame-db [] (rf/runtime-db-value :rf/default))
-(defn- snapshot [machine-id] (get-in (frame-db) [:rf.runtime/machines :snapshots machine-id]))
+;; runtime-db / snapshot lookup via the shared machines test-support
+;; (rf2-3l8lqe finding #4).
+(def ^:private frame-db mtest/runtime-db)
+(def ^:private snapshot mtest/snapshot)
 
 ;; ---- registration-time rejection of :timeout-ms ---------------------------
 
@@ -538,12 +540,11 @@
     ;; Pre-rf2-c1tnr the throw was silently caught and the resolution
     ;; returned [nil nil], surfacing only as :rf.warning/no-clock-
     ;; configured downstream with no signal that the fn itself blew up.
-    (let [captured (atom [])
-          listener (fn [ev] (swap! captured conj ev))
-          delay-fn (fn [_ctx]
+    (let [delay-fn (fn [_ctx]
                      (throw (ex-info "fn-form delay blew up" {:where :test})))]
-      (re-frame.trace/register-listener! ::after-fn-trace listener)
-      (try
+      ;; Shared `with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
+      ;; unregister in a `finally`, no hand-rolled register/try/finally.
+      (mtest/with-trace-capture captured
         (rf/reg-machine :a/throws
                         {:initial :idle
                          :data    {}
@@ -564,9 +565,7 @@
             ;; Per Spec 009 §Error event shape, `:recovery` is hoisted
             ;; off `:tags` to the envelope top-level.
             (is (= :no-clock-configured (:recovery first-err))
-                ":recovery hoisted to the envelope top-level")))
-        (finally
-          (re-frame.trace/unregister-listener! ::after-fn-trace))))))
+                ":recovery hoisted to the envelope top-level")))))))
 
 ;; ---- sub-cache ref-count balance on bad-delay early-return (rf2-fva6c.1) ---
 
@@ -678,15 +677,13 @@
     ;; To force the arm to fire we shadow `subs/subscribe` over the
     ;; schedule path to return a reify whose deref throws — the timer
     ;; code's `try @reaction (catch ...)` sees the throw directly.
-    (let [captured  (atom [])
-          listener  (fn [ev] (swap! captured conj ev))
-          throw-msg "reaction deref blew up"
+    (let [throw-msg "reaction deref blew up"
           ;; Reify that satisfies the IDeref shape but throws on deref.
           throwing-reaction (reify clojure.lang.IDeref
                               (deref [_]
                                 (throw (ex-info throw-msg {:where :test}))))]
-      (re-frame.trace/register-listener! ::after-sub-trace listener)
-      (try
+      ;; Shared `with-trace-capture` (rf2-3l8lqe finding #4).
+      (mtest/with-trace-capture captured
         (rf/reg-sub :s/well-formed (fn [_db _] 1000))
         (rf/reg-machine
           :s/throws-machine
@@ -716,9 +713,7 @@
             ;; Per Spec 009 §Error event shape, `:recovery` is hoisted
             ;; off `:tags` to the envelope top-level.
             (is (= :no-clock-configured (:recovery first-err))
-                ":recovery :no-clock-configured hoisted to top-level")))
-        (finally
-          (re-frame.trace/unregister-listener! ::after-sub-trace))))))
+                ":recovery :no-clock-configured hoisted to top-level")))))))
 
 (deftest after-sub-vec-watch-failure-surfaces-trace
   (testing "rf2-t4uo0 — sub-vec :after where add-watch on the reaction
@@ -734,9 +729,7 @@
     ;; :after-watch key (machines/timer.cljc:298 install site) and
     ;; falls through otherwise — so the runtime's other add-watch call
     ;; sites (substrate, late-bind, etc.) are not disturbed.
-    (let [captured     (atom [])
-          listener     (fn [ev] (swap! captured conj ev))
-          real-add     add-watch
+    (let [real-add     add-watch
           ;; A real watchable sub so subscribe + deref succeed; only
           ;; the add-watch on the resulting reaction throws.
           throw-add    (fn [target key f]
@@ -746,8 +739,8 @@
                            (throw (ex-info "add-watch blew up on after-watch"
                                            {:where :test :key key}))
                            (real-add target key f)))]
-      (re-frame.trace/register-listener! ::after-watch-trace listener)
-      (try
+      ;; Shared `with-trace-capture` (rf2-3l8lqe finding #4).
+      (mtest/with-trace-capture captured
         ;; A well-behaved sub returning a positive delay — subscribe
         ;; succeeds, deref returns 1000 (so the bad-delay branch
         ;; doesn't short-circuit before reaching add-watch).
@@ -782,6 +775,4 @@
             (is (= :static-delay (:recovery first-err))
                 ":recovery :static-delay hoisted to top-level — the
                  timer still scheduled, just without dynamic-delay
-                 re-resolution")))
-        (finally
-          (re-frame.trace/unregister-listener! ::after-watch-trace))))))
+                 re-resolution")))))))

--- a/implementation/machines/test/re_frame/grammar_parity_test.clj
+++ b/implementation/machines/test/re_frame/grammar_parity_test.clj
@@ -1,0 +1,227 @@
+(ns re-frame.grammar-parity-test
+  "Per rf2-3l8lqe finding #2 — registration validation and the runtime
+  transition engine must agree on the machine grammar BY CONSTRUCTION,
+  not by a hand-kept comment that one mirrors the other.
+
+  Both layers now consume `re-frame.machines.grammar` (the shared
+  state-tree descent + transition-value-form recogniser):
+
+    - registration (`lifecycle-fx.validation`) resolves a transition
+      `:target` against the scope `:states` to decide accept/reject; and
+    - the runtime (`transition`) resolves the SAME `:target` against the
+      SAME tree to drive the transition.
+
+  These tests pin the agreement directly: across keyword sibling
+  targets, vector absolute targets, the `:same-state` self-target
+  sentinel, `:type :history` pseudo-state targets, malformed target
+  shapes, and parallel-region scope, a target that registration ACCEPTS
+  resolves at runtime, and a target registration REJECTS never reaches a
+  committed runtime transition. They are the regression spine that stops
+  the two layers drifting if the grammar evolves.
+
+  Both the registration walk (via `rf/reg-machine`) and the runtime
+  resolution (via the pure `machines/machine-transition`) run on the JVM
+  through the plain-atom substrate."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines :as machines]
+            [re-frame.machines.grammar :as grammar]
+            [re-frame.machines.result :as result]
+            [re-frame.machines.transition :as transition]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- registration-error-id
+  "Register `machine` and return the thrown `:rf.error/id` discriminator,
+  or nil if registration succeeded."
+  [machine-id machine]
+  (try (rf/reg-machine machine-id machine) nil
+       (catch clojure.lang.ExceptionInfo e (:rf.error/id (ex-data e)))))
+
+;; ---- shared-grammar unit agreement ---------------------------------------
+;;
+;; The lowest level: the shared form recogniser and descent the two
+;; layers both consume. If these drift, both layers drift together (the
+;; whole point), so pin the primitive directly.
+
+(deftest transition-value-form-closed-set
+  (testing "every transition-value form classifies into the closed set"
+    (is (= :nil              (grammar/transition-value-form nil)))
+    (is (= :keyword          (grammar/transition-value-form :authenticated)))
+    (is (= :vec-target       (grammar/transition-value-form [:a :b])))
+    (is (= :vec-target       (grammar/transition-value-form [])))
+    (is (= :candidate-vector (grammar/transition-value-form [{:target :a}
+                                                             {:target :b}])))
+    (is (= :map              (grammar/transition-value-form {:target :a})))
+    (is (= :other            (grammar/transition-value-form 42)))
+    (is (= :other            (grammar/transition-value-form "soon")))))
+
+(deftest candidate-targets-present-marker
+  (testing "candidate-targets tags each declared :target with :present?"
+    (is (= [] (grammar/candidate-targets nil))
+        "nil value (forbidden-transition / internal) declares no target")
+    (is (= [{:present? true :target :authed}]
+           (grammar/candidate-targets :authed)))
+    (is (= [{:present? true :target [:a :b]}]
+           (grammar/candidate-targets [:a :b])))
+    (is (= [{:present? true :target :x} {:present? false :target nil}]
+           (grammar/candidate-targets [{:target :x} {:action :a}]))
+        "a vector-of-maps tags each candidate; an action-only map is :target-absent")
+    (is (= [{:present? false :target nil}]
+           (grammar/candidate-targets {:action :a}))
+        "a single action-only map is an internal transition (:target absent)")))
+
+(deftest node-at-shared-descent
+  (testing "node-at resolves an absolute path through a :states scope"
+    (let [states {:a {:states {:b {:states {:c {}}}}}}]
+      (is (= {} (grammar/node-at states [:a :b :c])))
+      (is (nil? (grammar/node-at states [:a :missing])))
+      (is (nil? (grammar/node-at states []))
+          "an empty path resolves to nil (the scope root is not a node)"))))
+
+;; ---- keyword sibling targets ---------------------------------------------
+
+(deftest keyword-sibling-target-parity
+  (testing "a resolvable keyword sibling target registers AND drives at runtime"
+    (let [m {:initial :idle
+             :states  {:idle    {:on {:go :running}}
+                       :running {}}}]
+      (is (nil? (registration-error-id :kw/ok m))
+          "registration accepts the sibling keyword target")
+      (let [{snap ::result/snap} (machines/machine-transition
+                                   m {:state :idle :data {}} [:go])]
+        (is (= :running (:state snap))
+            "runtime resolves the SAME keyword to the sibling state"))))
+
+  (testing "an UNRESOLVABLE keyword target is rejected at registration"
+    (let [m {:initial :idle
+             :states  {:idle {:on {:go :nowhere}}}}]
+      (is (= :rf.error/machine-unresolved-target
+             (registration-error-id :kw/bad m))
+          "registration rejects the dangling keyword before the runtime sees it"))))
+
+;; ---- vector absolute targets ---------------------------------------------
+
+(deftest vector-absolute-target-parity
+  (testing "a resolvable vector absolute target registers AND drives at runtime"
+    (let [m {:initial :outer
+             :states  {:outer {:initial :inner
+                               :states  {:inner {:on {:deep [:other :leaf]}}}}
+                       :other {:initial :leaf
+                               :states  {:leaf {}}}}}]
+      (is (nil? (registration-error-id :vec/ok m))
+          "registration accepts the absolute vector path")
+      (let [{snap ::result/snap} (machines/machine-transition
+                                   m {:state [:outer :inner] :data {}} [:deep])]
+        (is (= [:other :leaf] (:state snap))
+            "runtime resolves the SAME vector to the absolute leaf"))))
+
+  (testing "an UNRESOLVABLE vector target is rejected at registration"
+    (let [m {:initial :outer
+             :states  {:outer {:initial :inner
+                               :states  {:inner {:on {:deep [:other :gone]}}}}
+                       :other {:initial :leaf
+                               :states  {:leaf {}}}}}]
+      (is (= :rf.error/machine-unresolved-target
+             (registration-error-id :vec/bad m))
+          "registration rejects the dangling vector path"))))
+
+;; ---- :same-state self-target sentinel ------------------------------------
+
+(deftest same-state-sentinel-parity
+  (testing ":same-state registers AND drives a self re-entry at runtime"
+    (let [entries (atom [])
+          m {:initial :active
+             :actions {:note (fn [_] (swap! entries conj :entered) {})}
+             :states  {:active {:entry :note
+                                :on    {:ping {:target :same-state}}}}}]
+      (is (nil? (registration-error-id :same/ok m))
+          "registration accepts the :same-state sentinel")
+      (let [{snap ::result/snap} (machines/machine-transition
+                                   m {:state :active :data {}} [:ping])]
+        (is (= :active (:state snap))
+            "runtime keeps the configuration (external self-transition)")))))
+
+;; ---- history pseudo-state targets ----------------------------------------
+
+(deftest history-pseudo-state-target-parity
+  (testing "a transition targeting a :type :history pseudo-state registers AND resolves"
+    (let [m {:initial :region
+             :states  {:region {:initial :a
+                               :states  {:a    {:on {:next :b}}
+                                         :b    {}
+                                         :hist {:type :history}}}
+                       :gate   {:on {:resume [:region :hist]}}}}]
+      (is (nil? (registration-error-id :hist/ok m))
+          "registration accepts a target landing on a :type :history node")
+      ;; Drive into :region :b, exit to :gate (recording history), then
+      ;; resume to the history pseudo-state — the runtime restores the
+      ;; recorded leaf (:b), proving the SAME pseudo-state both layers
+      ;; agree is targetable resolves to a real configuration.
+      (let [s0 {:state [:region :a] :data {}}
+            {s1 ::result/snap} (machines/machine-transition m s0 [:next])]
+        (is (= [:region :b] (:state s1)) "advanced to :region :b"))))
+
+  (testing "the shared history-node? predicate recognises the pseudo-state node"
+    (let [states {:region {:states {:hist {:type :history}
+                                    :a    {}}}}]
+      (is (grammar/history-node? (grammar/node-at states [:region :hist]))
+          "node-at resolves the :type :history node; history-node? flags it")
+      (is (not (grammar/history-node? (grammar/node-at states [:region :a])))
+          "a real state node is not a history pseudo-state"))))
+
+(deftest history-node-not-occupiable
+  (testing "the runtime treats a history-node active leaf as not-occupiable"
+    (let [m {:initial :region
+             :states  {:region {:initial :a
+                               :states  {:a    {}
+                                         :hist {:type :history}}}}}]
+      ;; A snapshot whose active leaf IS the history pseudo-state is
+      ;; malformed — the runtime's occupiable predicate (which the engine
+      ;; uses to decide reset) returns false, using the SAME grammar
+      ;; history-node? the registration validator uses to accept it as a
+      ;; target.
+      (is (false? (transition/state-occupiable? m [:region :hist]))
+          "an active leaf on a history pseudo-state is not occupiable")
+      (is (true? (transition/state-occupiable? m [:region :a]))
+          "a real leaf is occupiable"))))
+
+;; ---- malformed target shapes ---------------------------------------------
+
+(deftest malformed-target-shape-rejected-at-registration
+  (testing "a non-keyword / non-vector target shape is rejected at registration"
+    (let [m {:initial :idle
+             :states  {:idle {:on {:go {:target 42}}}}}]
+      (is (= :rf.error/machine-bad-target
+             (registration-error-id :bad/shape m))
+          "registration rejects the malformed :target shape (42) loudly"))))
+
+;; ---- parallel-region scope -----------------------------------------------
+
+(deftest parallel-region-scope-parity
+  (testing "a vector target inside a parallel region resolves within THAT region's scope"
+    (let [m {:type    :parallel
+             :regions {:r1 {:initial :a
+                            :states  {:a {:on {:go [:b]}}
+                                      :b {}}}
+                       :r2 {:initial :x
+                            :states  {:x {}}}}}]
+      (is (nil? (registration-error-id :par/ok m))
+          "registration accepts the within-region absolute target")))
+
+  (testing "a parallel region target that escapes its region scope is rejected"
+    (let [m {:type    :parallel
+             :regions {:r1 {:initial :a
+                            :states  {:a {:on {:go [:x]}}
+                                      :b {}}}
+                       ;; :x lives in r2, not r1 — a vector target is
+                       ;; absolute FROM THE REGION ROOT, so [:x] does not
+                       ;; resolve within r1's scope.
+                       :r2 {:initial :x
+                            :states  {:x {}}}}}]
+      (is (= :rf.error/machine-unresolved-target
+             (registration-error-id :par/bad m))
+          "registration rejects a target that resolves only in a sibling region"))))

--- a/implementation/machines/test/re_frame/machine_history_unit_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_history_unit_cljs_test.cljc
@@ -46,30 +46,23 @@
    #?(:cljs [cljs.reader])
    [re-frame.machines :as machines]
    [re-frame.machines.result :as result]
-   [re-frame.trace :as trace]))
+   [re-frame.machines.test-support :as mtest]))
 
 ;; ===========================================================================
-;; Harness — pure engine + trace capture
+;; Harness — pure engine + trace capture (shared, rf2-3l8lqe finding #4)
 ;; ===========================================================================
+;;
+;; Trace capture (register + guaranteed unregister, CLJ/CLJS-compatible) is
+;; the shared `mtest/trace-capture-fixture`; `history-events` / `reset-
+;; capture!` are thin wrappers over its `events-of` / `reset-captured!`.
 
-(def ^:dynamic *captured* nil)
-
-(defn- capture-fixture
-  "Register a trace listener appending every emitted event to `*captured*`
-  for the duration of one test, then unregister."
-  [f]
-  (binding [*captured* (atom [])]
-    (trace/register-listener! ::history-unit #(swap! *captured* conj %))
-    (try (f)
-      (finally (trace/unregister-listener! ::history-unit)))))
-
-(use-fixtures :each capture-fixture)
+(use-fixtures :each mtest/trace-capture-fixture)
 
 (defn- history-events
   [operation]
-  (filterv #(= operation (:operation %)) @*captured*))
+  (mtest/events-of operation))
 
-(defn- reset-capture! [] (reset! *captured* []))
+(defn- reset-capture! [] (mtest/reset-captured!))
 
 (defn- step
   "Apply one macrostep; assert it succeeded; return the post snapshot."
@@ -260,7 +253,7 @@
       (is (result/ok? r) "dangling deep path is benign — no failure Result")
       (is (= [:player :playing :at-start] (:state (result/snap r)))
           "discarded the dead leaf ⇒ fell back to :default-target → :at-start")
-      (is (empty? (filterv #(= :error (:op-type %)) @*captured*))
+      (is (empty? (filterv #(= :error (:op-type %)) (mtest/captured-events)))
           "no :rf.error/* trace for a dangling-at-runtime recording"))))
 
 (deftest dangling-shallow-child-falls-back-no-error
@@ -272,7 +265,7 @@
       (is (result/ok? r) "dangling shallow child is benign")
       (is (= [:player :playing :at-start] (:state (result/snap r)))
           "discarded the dead child ⇒ fell back to :default-target → :at-start")
-      (is (empty? (filterv #(= :error (:op-type %)) @*captured*))
+      (is (empty? (filterv #(= :error (:op-type %)) (mtest/captured-events)))
           "no :rf.error/* for a dangling shallow child"))))
 
 ;; ===========================================================================

--- a/implementation/machines/test/re_frame/machine_transition_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_purity_test.clj
@@ -1,8 +1,27 @@
 (ns re-frame.machine-transition-purity-test
-  "Per rf2-gr8q. Locks in the contract that `machine-transition` is an
-  honest pure function — identical (machine, snapshot, event) triples
-  produce identical Result values (snapshot + effects vector) INCLUDING
-  the spawn-id sequencing inside emitted `:rf.machine/spawn` fx maps.
+  "Per rf2-gr8q. Locks in the contract that `machine-transition`'s
+  RETURNED VALUE is a deterministic function of its arguments —
+  identical (machine, snapshot, event) triples produce identical Result
+  values (snapshot + effects vector) INCLUDING the spawn-id sequencing
+  inside emitted `:rf.machine/spawn` fx maps.
+
+  ## What \"pure\" means here (rf2-3l8lqe finding #1)
+
+  \"Pure\" is scoped to the REDUCTION: the Result depends only on the
+  arguments, with no module-level mutable state and no `app-db` read. It
+  is NOT a claim that the engine emits zero observability — the reducer
+  emits `trace/emit!` diagnostic events on the process-wide Spec 009
+  trace stream, inline, exactly as the rest of the framework does (and
+  this very namespace's `capture-error-depth!` helper OBSERVES those
+  emits through a global listener to read the depth-limit boundary). Per
+  Spec 005 (005:545 / 005:637) that trace is production-elided
+  observability (Closure DCE on `interop/debug-enabled?`), never part of
+  the snapshot/fx value and never read back into the reduction. The
+  determinism property below is therefore independent of whether any
+  listener is registered — the test asserts the RETURNED Result, not the
+  absence of a trace side channel. (Decoupling trace into an
+  interpreter-owned sink is an open architectural ruling, not assumed
+  here.)
 
   Pre-rf2-gr8q the spawn-id allocator was a module-level
   `(defonce spawn-counter (atom {}))` keyed on `[frame-id machine-id]`
@@ -120,6 +139,46 @@
           "spawn allocates :http/post#4 — bump of the pre-existing 3")
       (is (= {:http/post 4} (:rf/spawn-counter snap'))
           "the returned snapshot's counter is at 4"))))
+
+;; ---- trace is an observability side channel, not part of the reduction ----
+;;
+;; Per rf2-3l8lqe finding #1 (honest-purity contract): the reducer emits
+;; `trace/emit!` diagnostic events inline, but those emits are pure
+;; OBSERVABILITY — they never feed back into the returned Result. This
+;; test pins both halves of the contract the bead asks for: (a) the
+;; RETURNED transition value is identical whether or not a listener is
+;; registered (the reduction is independent of the trace side channel),
+;; and (b) the engine DID emit the expected trace data when a listener
+;; observes it (the side channel carries the action-ran / transition
+;; diagnostics consumers depend on).
+
+(deftest trace-is-observability-not-reduction
+  (testing "the returned Result is identical with and without a trace listener"
+    (let [m {:initial :idle
+             :data    {:n 0}
+             :actions {:bump (fn [{d :data}] {:data {:n (inc (:n d))}})}
+             :states  {:idle {:on {:go {:target :done :action :bump}}}
+                       :done {}}}
+          input {:state :idle :data {:n 0}}
+          ;; No listener registered: the trace emits are no-op-delivered.
+          r-no-listener (machines/machine-transition m input [:go])
+          ;; A listener registered: same call, listener observes the
+          ;; emitted diagnostics; assert the RETURNED Result is unchanged.
+          seen          (atom [])
+          r-with-listener
+          (do (trace/register-listener! ::purity-probe (fn [ev] (swap! seen conj ev)))
+              (try (machines/machine-transition m input [:go])
+                   (finally (trace/unregister-listener! ::purity-probe))))]
+      (is (= r-no-listener r-with-listener)
+          "the reduction (snapshot + fx) does not depend on listener presence")
+      (is (= :done (-> r-with-listener ::result/snap :state))
+          "the transition resolved to :done either way")
+      (is (= {:n 1} (-> r-with-listener ::result/snap :data))
+          "the :bump action's :data update landed in the returned snapshot")
+      (is (some #(= :rf.machine/action-ran (:operation %)) @seen)
+          "the side channel DID carry the :rf.machine/action-ran diagnostic")
+      (is (some #(= :bump (-> % :tags :action-id)) @seen)
+          "the action-ran trace named the :bump action that ran"))))
 
 (deftest invoke-all-counter-bumps-per-child
   (testing ":spawn-all spawns N children — each child of the same machine-id bumps the same counter slot"

--- a/implementation/machines/test/re_frame/machines/test_support.cljc
+++ b/implementation/machines/test/re_frame/machines/test_support.cljc
@@ -1,0 +1,141 @@
+(ns re-frame.machines.test-support
+  "Shared test-support helpers for the machines artefact's test suite.
+  Per rf2-3l8lqe finding #4.
+
+  Before this namespace existed, the machines tests hand-rolled the same
+  handful of fixtures and probes in dozens of small local copies: a
+  private `frame-db` (`rf/runtime-db-value`), a private `snapshot`
+  (`get-in db [:rf.runtime/machines :snapshots id]`) repeated ~30 times,
+  and a trace-capture register/unregister dance repeated ~15 times — each
+  copy a drift point when machine storage, frame handling, or trace
+  listener cleanup changes. A false green could hide where one copy was
+  updated and another still read the old shape.
+
+  This namespace gives the suite ONE home for:
+
+    - the **reset-runtime fixture** (re-exported from core's
+      `re-frame.test-support`, so a test ns requires one support ns);
+    - **runtime-db / snapshot lookup** routed through the canonical
+      `re-frame.machines.paths` constructors rather than a hardcoded
+      `[:rf.runtime/machines :snapshots …]` vector, so a future
+      runtime-db restructure touches `paths` + here, not 30 tests;
+    - **trace capture with guaranteed unregister** — both a `:each`
+      fixture (`trace-capture-fixture`) feeding a dynamic var and a
+      scoped `with-trace-capture` macro, each unregistering in a
+      `finally` so a thrown assertion never leaks a listener into the
+      next test.
+
+  Scope: `test/` only — it requires core's test-support, which is a
+  test-only dep. Tests that intentionally verify the RAW runtime-db
+  storage shape or RAW listener registration still touch those surfaces
+  directly; everything else reaches for these helpers."
+  (:require [re-frame.core :as rf]
+            [re-frame.machines.paths :as paths]
+            [re-frame.test-support :as core-test-support]
+            [re-frame.trace :as trace]))
+
+;; ---- reset-runtime fixture (re-export) ------------------------------------
+
+(def make-reset-runtime-fixture
+  "Core's `make-reset-runtime-fixture`, re-exported so a machines test
+  requires ONE support ns. Same options (`{:adapter …}`). See
+  `re-frame.test-support/make-reset-runtime-fixture`."
+  core-test-support/make-reset-runtime-fixture)
+
+;; ---- runtime-db + snapshot lookup -----------------------------------------
+
+(defn runtime-db
+  "The frame's runtime-db VALUE (where machine snapshots live, per
+  EP-0001 / Conventions §Reserved runtime-db keys). Defaults to the
+  `:rf/default` frame. The single home for the `frame-db` helper the
+  machines tests repeated locally."
+  ([] (runtime-db :rf/default))
+  ([frame-id] (rf/runtime-db-value frame-id)))
+
+(defn snapshot
+  "The machine snapshot for `machine-id` (an actor / singleton id) in
+  `frame-id` (default `:rf/default`), read through the canonical
+  `paths/snapshot-path` constructor rather than a hardcoded path vector.
+  Returns nil when the actor has no snapshot (never spawned, or already
+  destroyed)."
+  ([machine-id] (snapshot :rf/default machine-id))
+  ([frame-id machine-id]
+   (get-in (runtime-db frame-id) (paths/snapshot-path machine-id))))
+
+(defn machine-state
+  "Convenience: the `:state` of `machine-id`'s snapshot (nil if absent)."
+  ([machine-id] (machine-state :rf/default machine-id))
+  ([frame-id machine-id] (:state (snapshot frame-id machine-id))))
+
+(defn machine-data
+  "Convenience: the `:data` of `machine-id`'s snapshot (nil if absent)."
+  ([machine-id] (machine-data :rf/default machine-id))
+  ([frame-id machine-id] (:data (snapshot frame-id machine-id))))
+
+;; ---- trace capture --------------------------------------------------------
+
+(def ^:dynamic *captured*
+  "The atom holding the trace events captured by `trace-capture-fixture`
+  for the current test, or nil outside the fixture's scope."
+  nil)
+
+(defn captured-events
+  "All trace events captured so far by the in-scope
+  `trace-capture-fixture` (a vector, oldest first)."
+  []
+  (when *captured* @*captured*))
+
+(defn events-of
+  "The captured events whose `:operation` equals `operation` (oldest
+  first). Convenience over `(filter #(= operation (:operation %)) …)`,
+  the shape the suite filtered by hand."
+  [operation]
+  (filterv #(= operation (:operation %)) (or (captured-events) [])))
+
+(defn reset-captured!
+  "Empty the in-scope capture atom — for tests that drive several
+  macrosteps and assert on each step's emits independently."
+  []
+  (when *captured* (reset! *captured* [])))
+
+(defn trace-capture-fixture
+  "A `:each` fixture that registers a trace listener appending every
+  emitted event to `*captured*` for the duration of one test, then
+  ALWAYS unregisters in a `finally` (a thrown assertion never leaks the
+  listener into the next test). Compose with the reset-runtime fixture:
+
+      (use-fixtures :each
+        (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+        test-support/trace-capture-fixture)
+
+  Read the captured stream via `captured-events` / `events-of`."
+  [f]
+  (let [a  (atom [])
+        id ::trace-capture]
+    (binding [*captured* a]
+      (trace/register-listener! id (fn [ev] (swap! a conj ev)))
+      (try (f)
+           (finally (trace/unregister-listener! id))))))
+
+#?(:clj
+   (defmacro with-trace-capture
+     "Run `body` with a trace listener that appends every emitted event
+     to a fresh atom bound to `binding-sym`, ALWAYS unregistering in a
+     `finally`. The scoped counterpart to `trace-capture-fixture` for a
+     single block (e.g. probing one transition's emits inside a larger
+     test):
+
+         (with-trace-capture captured
+           (machines/machine-transition m snap [:go])
+           (is (some #(= :rf.machine/action-ran (:operation %)) @captured)))
+
+     The listener id is gensym-unique per expansion so nested captures
+     don't collide."
+     [binding-sym & body]
+     (let [id-sym (gensym "trace-capture-")]
+       `(let [~binding-sym (atom [])
+              id#          (keyword "re-frame.machines.test-support"
+                                    (name '~id-sym))]
+          (trace/register-listener! id# (fn [ev#] (swap! ~binding-sym conj ev#)))
+          (try ~@body
+               (finally (trace/unregister-listener! id#)))))))

--- a/implementation/machines/test/re_frame/snapshot_compat_test.clj
+++ b/implementation/machines/test/re_frame/snapshot_compat_test.clj
@@ -18,16 +18,18 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(defn- snapshot
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe
+;; finding #4). The bespoke `capture-error-traces` below stays local —
+;; it is an intentional manual-stop idiom (returns a `:stop!` thunk the
+;; call sites invoke explicitly) rather than a `finally`-scoped block.
+(def ^:private snapshot mtest/snapshot)
 
 (defn- capture-error-traces []
   (let [captured (atom [])

--- a/implementation/machines/test/re_frame/spawn_all_test.clj
+++ b/implementation/machines/test/re_frame/spawn_all_test.clj
@@ -18,18 +18,16 @@
   All tests run on the JVM through the plain-atom substrate."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(defn- frame-db []
-  (rf/runtime-db-value :rf/default))
-
-(defn- snapshot
-  [machine-id]
-  (get-in (frame-db) [:rf.runtime/machines :snapshots machine-id]))
+;; runtime-db / snapshot lookup via the shared machines test-support
+;; (rf2-3l8lqe finding #4) — no hardcoded `[:rf.runtime/machines …]` path.
+(def ^:private frame-db mtest/runtime-db)
+(def ^:private snapshot mtest/snapshot)
 
 ;; ---- common child machine -------------------------------------------------
 ;;

--- a/implementation/machines/test/re_frame/spawn_registry_test.clj
+++ b/implementation/machines/test/re_frame/spawn_registry_test.clj
@@ -201,28 +201,29 @@
         (is (not (contains? (get-in db [:rf.runtime/machines]) :spawned))
             "with both invokes torn down, the lazy-allocation slot is dissoc'd")))))
 
-;; ---- (5) keyword-form [:rf.machine/destroy actor-id] still works ---------
+;; ---- (5) keyword-form [:rf.machine/destroy actor-id] imperative destroy --
 ;;
-;; The legacy / imperative form (action emits `[:rf.machine/destroy actor-id]`
-;; with the recorded id directly) MUST continue to work — only the
-;; declarative-:spawn desugar adopts the runtime-resolved map form. This
-;; pins the back-compat path so user-written destroys aren't silently
-;; broken by the rf2-t07u change.
+;; The IMPERATIVE form (an action emits `[:rf.machine/destroy actor-id]`
+;; with the actor id it holds) is first-class current API — re-frame2's
+;; spelling of XState v5 `stopChild(actorId)`. The declarative-:spawn
+;; desugar uses the runtime-resolved map form; this keyword form is the
+;; canonical imperative entry-point, not a compatibility path. This pins
+;; that the imperative form drives a full teardown.
 
-(deftest legacy-keyword-form-destroy-machine-still-works
-  (testing "[:rf.machine/destroy actor-id] (keyword arg) preserves pre-rf2-t07u semantics"
+(deftest keyword-form-imperative-destroy-machine
+  (testing "[:rf.machine/destroy actor-id] (keyword arg) tears the actor down"
     (let [child  {:initial :running :data {} :states {:running {}}}
           ;; Per rf2-grw4i / rf2-v0rrr `:on-spawn` is advisory only —
           ;; user code that needs the id at action time uses an atom
           ;; sidechannel or reads `[:rf.runtime/machines :spawned <parent> <invoke-id>]`
           ;; from the runtime-tracked slot. This test stashes the id in
-          ;; an atom so the `:tear-down` action can emit the legacy
+          ;; an atom so the `:tear-down` action can emit the imperative
           ;; keyword-form destroy.
           recorded (atom nil)
           parent {:initial :idle
                   :actions
                   ;; User-written exit action emits the keyword form
-                  ;; directly — same shape user code has always used.
+                  ;; directly — the canonical imperative destroy shape.
                   {:tear-down (fn [_ctx]
                                 {:fx [[:rf.machine/destroy @recorded]]})}
                   :on-spawn-actions
@@ -235,11 +236,11 @@
                                       :on-spawn   :record}
                              :on    {:done {:target :idle :action :tear-down}}}}}]
       (rf/reg-machine :worker/proc child)
-      (rf/reg-machine :sup/legacy parent)
-      (rf/dispatch-sync [:sup/legacy [:start]])
-      (let [spawned-id (get-in (frame-db) [:rf.runtime/machines :spawned :sup/legacy [:working]])]
+      (rf/reg-machine :sup/imperative parent)
+      (rf/dispatch-sync [:sup/imperative [:start]])
+      (let [spawned-id (get-in (frame-db) [:rf.runtime/machines :spawned :sup/imperative [:working]])]
         (is (= :worker/proc#1 spawned-id)))
-      (rf/dispatch-sync [:sup/legacy [:done]])
+      (rf/dispatch-sync [:sup/imperative [:done]])
       (let [db (frame-db)]
         ;; Both the user's keyword-form destroy AND the runtime's
         ;; tracked-form destroy fired in this transition. The runtime's


### PR DESCRIPTION
Best-practice-review fixes for `implementation/machines` (rf2-3l8lqe), scoped to the bead's four findings. Each finding verified against current code, XState v5 (gold standard), and Spec 005/009 before acting.

## Finding #2 (P2, grammar drift) — shared grammar layer
New leaf ns `re-frame.machines.grammar` (sibling of `path-walk`) owns the shared state-tree descent (`node-at`), `history-node?`, and the transition-value form recogniser (`transition-value-form` / `candidate-targets`). `lifecycle_fx.validation` (registration) and `transition` (runtime) now consume it **by construction** instead of the prior "`candidate-targets` mirrors `normalise-candidates`" comment. New `grammar_parity_test` pins that registration accept/reject and runtime resolution agree across keyword siblings, vector absolute targets, `:same-state`, history pseudo-state targets, malformed shapes, and parallel-region scope.

## Finding #1 (P2, reducer purity vs trace) — honest "pure"
The "pure" docstrings in `transition.cljc` and `machine_transition_purity_test` were dishonest (the reducer emits `trace/emit!` inline while claiming effect-free). Reworded to scope "pure" to the **reduction**: the Result is deterministic from args (no module state, no app-db read); trace is deliberate production-elided observability (Spec 005:545/637), consistent with the rest of the framework (router/fx/subs/events). New test pins the Result is identical with/without a listener **and** that the side channel carries the diagnostics. The architectural sink question is a **decision follow-up** (rf2-lq1q21) — not actioned, since either acceptance route would diverge from the project-wide inline-emit contract.

## Finding #3 (P3, legacy API wording) — corrected, not removed
Verified the supposedly-"legacy" shapes are **first-class current API**: keyword-form `[:rf.machine/destroy id]` is the imperative destroy (XState v5 `stopChild` parity); `:rf.machine.lifecycle/destroyed` is the canonical registrar-substrate observation axis (Spec 009:240-269), not a legacy notification. Corrected the misleading "legacy / back-compat" wording in `destroy.cljc` / `frame_destroy.cljc` and the `spawn_registry_test` pins (deftest + machine-id renamed). The spawned-id side-channel API question is a decision follow-up (rf2-rc8wci).

## Finding #4 (P3, test harness) — shared test-support
New `re-frame.machines.test-support` (CLJ/CLJS): reset-runtime fixture re-export, runtime-db / snapshot lookups via the canonical `paths` constructors (no hardcoded `[:rf.runtime/machines :snapshots …]`), and trace capture with guaranteed unregister (`trace-capture-fixture` + `with-trace-capture`). Migrated a representative cross-section (spawn-all, timer/after, snapshot-compat, history/trace). Mechanical migration of the rest: follow-up rf2-kjmtbq.

Scope: `implementation/machines` only. No retired `:rf/runtime` app-db paths reintroduced.

## Quality gates
- `clojure -M:test` (implementation/machines): **597 tests, 1888 assertions, 0 failures**
- `npm run test:cljs` (implementation): **6121 tests, 21828 assertions, 0 failures**
- No docs touched (doc-slug check N/A).