### PR TITLE
fix(ssr): close hydration/runtime-db + streaming-delta fail-closed gaps (rf2-l3paoi)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
+++ b/implementation/ssr/src/re_frame/ssr/streaming/client.cljs
@@ -229,35 +229,83 @@
 
 ;; ---- chunk processing ------------------------------------------------------
 
+(defn- malformed-delta!
+  "Emit the `:rf.ssr/suspense-boundary-failed` / `:skipped-delta` trace for
+  a delta `<script>` whose body did not yield a usable delta-map — EITHER a
+  reader exception (unparseable EDN) OR a parseable-but-non-map value (a
+  vector, number, string, …). Factored out so both fail-CLOSED branches emit
+  the SAME catalogued event (Spec 009 §Error event catalogue —
+  `:rf.ssr/suspense-boundary-failed`, `:recovery :skipped-delta`). `extra` is
+  merged in to carry the branch-specific field (`:exception` for the reader
+  throw, `:malformed-value-type` for a non-map parse)."
+  [frame-id id-str reason extra]
+  (trace/emit-error! :rf.ssr/suspense-boundary-failed
+                     (merge {:id       (read-boundary-id id-str)
+                             :frame    frame-id
+                             :where    'rf.ssr/streaming-client
+                             :reason   reason
+                             :recovery :skipped-delta}
+                            extra)))
+
+(defn- read-delta
+  "Parse a delta `<script>`'s bare delta-map EDN body, failing CLOSED on any
+  shape that is NOT a usable delta-map. Returns the parsed map when the body
+  is a (possibly empty) map, else nil — and emits the malformed-delta trace
+  for the two fail-OPEN classes a silent drop would otherwise hide:
+
+    - a reader EXCEPTION (the body is not parseable EDN), and
+    - a PARSEABLE-but-non-map value (`[…]`, `42`, `\"x\"`, `:k`) — a
+      server/client wire-shape regression that `read-string` accepts but
+      which `merge-delta!`'s `(map? delta)` guard would silently no-op,
+      swapping the resolved HTML + removing the script while leaving app-db
+      stale and emitting NO diagnostic (rf2-l3paoi).
+
+  A nil parse (an empty / whitespace-only body) is the documented no-delta
+  shape — NOT malformed — and returns nil without a trace, matching the
+  prior `(when delta …)` no-op. The bare delta-map EDN body is the shipped
+  wire contract (Spec 011 §Hydration interleaving — \"the per-subtree delta
+  is shipped as the bare delta-map EDN\"); anything else is the bug."
+  [frame-id id-str body]
+  (let [parsed (try
+                 (reader/read-string body)
+                 (catch :default e
+                   (malformed-delta! frame-id id-str
+                                     (str "Malformed hydration-delta EDN for boundary " id-str)
+                                     {:exception (ex-message e)})
+                   ::skip))]
+    (cond
+      (= ::skip parsed) nil
+      (nil? parsed)     nil                              ;; no-delta body — not malformed
+      (map? parsed)     parsed
+      :else
+      (do
+        (malformed-delta! frame-id id-str
+                          (str "Hydration-delta EDN for boundary " id-str
+                               " parsed to a non-map (got " (pr-str (type parsed))
+                               "); skipped — the delta-map wire contract was violated")
+                          {:malformed-value-type (pr-str (type parsed))})
+        nil))))
+
 (defn- apply-delta-script!
   "Find the `data-rf2-suspense-hydrate` delta `<script>` for `id-str`,
   read its bare delta-map EDN, merge it into `frame-id`'s app-db, and
   drop the script node. The server emits the delta `<script>`
   immediately after the resolved `<template>`, but DOM order after our
   swap is not guaranteed, so we match by id attribute rather than
-  sibling position. A malformed delta is skipped with a trace — a bad
-  speculative chunk must not break hydration (the final payload is the
-  correctness lock)."
+  sibling position. A malformed delta (unparseable EDN, or parseable but
+  non-map) is skipped with a trace — a bad speculative chunk must not
+  break hydration (the final payload is the correctness lock), but it must
+  also not silently pass for a successful hydration (rf2-l3paoi)."
   [root frame-id id-str]
   (when-let [script (->> (query-by-attr root attr-suspense-hydrate)
                          (filter #(= id-str (.getAttribute % attr-suspense-hydrate)))
                          first)]
-    (let [delta (try
-                  (reader/read-string (.-textContent script))
-                  (catch :default e
-                    (trace/emit-error! :rf.ssr/suspense-boundary-failed
-                                       {:id        (read-boundary-id id-str)
-                                        :frame     frame-id
-                                        :where     'rf.ssr/streaming-client
-                                        :reason    (str "Malformed hydration-delta EDN for boundary " id-str)
-                                        :exception (ex-message e)
-                                        :recovery  :skipped-delta})
-                    nil))]
-      (when delta (merge-delta! frame-id delta))
-      ;; The delta is consumed; drop the script node so the DOM is left
-      ;; in its final, script-free shape.
-      (when-let [sp (.-parentNode script)]
-        (.removeChild sp script)))))
+    (when-let [delta (read-delta frame-id id-str (.-textContent script))]
+      (merge-delta! frame-id delta))
+    ;; The delta is consumed (or skipped); drop the script node so the DOM
+    ;; is left in its final, script-free shape regardless of delta validity.
+    (when-let [sp (.-parentNode script)]
+      (.removeChild sp script))))
 
 (defn- process-resolved-template!
   "Process one resolved-subtree `<template>` (carrying

--- a/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
+++ b/implementation/ssr/test/re_frame/ssr/streaming_client_dom_cljs_test.cljs
@@ -304,6 +304,106 @@
             (trace-tooling/unregister-listener! k)
             (remove-root! host)))))))
 
+(deftest parseable-non-map-delta-fails-closed
+  (testing "rf2-l3paoi — a resolved chunk whose hydrate-delta `<script>` body
+            is PARSEABLE EDN but NOT a map (a vector / number / string —
+            a server/client wire-shape regression) must fail CLOSED: the
+            resolved HTML still swaps in (DOM progress), the delta is NOT
+            merged (app-db stays unchanged), the script is consumed (DOM left
+            script-free), AND a `:rf.ssr/suspense-boundary-failed`
+            `:skipped-delta` trace fires. Before the fix `read-string`
+            accepted the non-map, `merge-delta!`'s `(map? delta)` guard
+            silently no-op'd the merge, and the script was removed with NO
+            diagnostic — progressive hydration LOOKED successful in the DOM
+            while subscriptions read stale state."
+    (if-not (browser?)
+      (is true ":node-test: no DOM")
+      ;; Each bad delta is parseable EDN but the wrong shape. Empty-string
+      ;; / `nil` bodies are the legitimate no-delta shape (covered below),
+      ;; so they are NOT in this malformed set.
+      (doseq [bad-delta [[:not :a :map]
+                         42
+                         "a bare string"
+                         :a-keyword]]
+        (let [fid      (make-client-frame!)
+              host     (make-root! [:card.revenue])
+              captured (atom [])
+              k        (str (gensym "stream-nonmap-cb"))]
+          (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+          (try
+            (append-chunk!
+              host
+              (resolved-chunk-html :card.revenue
+                                   "<div class=\"card resolved-revenue\">Revenue</div>"
+                                   bad-delta))
+            (let [stop! (streaming-client/install! {:frame fid :root host})]
+              (try
+                ;; DOM still progresses — the resolved content swapped in.
+                (is (= 1 (card-count host "resolved-revenue"))
+                    (str (pr-str bad-delta)
+                         ": resolved HTML still swaps in (DOM progress)"))
+                (is (false? (boolean (showing-fallback? host :card.revenue)))
+                    (str (pr-str bad-delta) ": mount shows resolved content, not a skeleton"))
+                ;; app-db is UNCHANGED — the malformed delta was not merged.
+                (is (= {} (frame/frame-app-db-value fid))
+                    (str (pr-str bad-delta)
+                         ": app-db must stay unchanged (malformed delta NOT merged)"))
+                (is (nil? @(rf/subscribe fid [:sct/card :revenue]))
+                    (str (pr-str bad-delta) ": subscription reads no speculative state"))
+                ;; The script is consumed regardless of delta validity.
+                (is (zero? (count (array-seq (.querySelectorAll host "[data-rf2-suspense-hydrate]"))))
+                    (str (pr-str bad-delta) ": the delta script is dropped (DOM left script-free)"))
+                ;; The fail-closed diagnostic fires.
+                (let [skipped (filter #(and (= :rf.ssr/suspense-boundary-failed (:operation %))
+                                            (= :skipped-delta (:recovery %)))
+                                      @captured)]
+                  (is (seq skipped)
+                      (str (pr-str bad-delta)
+                           ": must emit :rf.ssr/suspense-boundary-failed :skipped-delta; saw: "
+                           (pr-str (mapv (juxt :operation :recovery) @captured)))))
+                (finally (stop!))))
+            (finally
+              (trace-tooling/unregister-listener! k)
+              (remove-root! host))))))))
+
+(deftest empty-delta-body-is-not-malformed
+  (testing "rf2-l3paoi — the fail-closed guard is PRECISE: an empty-map delta
+            body (`{}`) is a legitimate no-op delta (no app-db change), and a
+            VALID map delta still merges — neither emits the malformed
+            diagnostic. This pins that the non-map fail-closed branch does not
+            over-fire on the documented valid shapes."
+    (if-not (browser?)
+      (is true ":node-test: no DOM")
+      (let [fid      (make-client-frame!)
+            host     (make-root! [:card.empty :card.full])
+            captured (atom [])
+            k        (str (gensym "stream-empty-cb"))]
+        (trace-tooling/register-listener! k (fn [ev] (swap! captured conj ev)))
+        (try
+          ;; (a) empty-map delta — valid no-op, no app-db change, no trace.
+          (append-chunk!
+            host
+            (resolved-chunk-html :card.empty
+                                 "<div class=\"card resolved-empty\">empty</div>"
+                                 {}))
+          ;; (b) valid map delta — merges normally.
+          (append-chunk!
+            host
+            (resolved-chunk-html :card.full
+                                 "<div class=\"card resolved-full\">full</div>"
+                                 {:cards {:full {:value 5}}}))
+          (let [stop! (streaming-client/install! {:frame fid :root host})]
+            (try
+              (is (= 1 (card-count host "resolved-empty")) "empty-delta chunk still swaps")
+              (is (= 5 (:value @(rf/subscribe fid [:sct/card :full]))) "valid delta merged")
+              (is (not-any? #(= :rf.ssr/suspense-boundary-failed (:operation %)) @captured)
+                  (str "valid + empty deltas must NOT emit the malformed diagnostic; saw: "
+                       (pr-str (mapv :operation @captured))))
+              (finally (stop!))))
+          (finally
+            (trace-tooling/unregister-listener! k)
+            (remove-root! host)))))))
+
 (deftest css-special-payload-id-does-not-throw
   (testing "rf2-58zvy1 finding 3 — a documented :payload-id override that is
             a VALID HTML id but carries CSS-selector-significant chars


### PR DESCRIPTION
Closes the fail-closed gaps in implementation/ssr from rf2-l3paoi.

**Issue 2 (streaming-delta) — FIXED.** The streaming client silently dropped parseable-but-non-map hydration deltas: read-string accepts a vector/number/string/keyword, merge-delta!'s (map? delta) guard no-ops it, and the script is removed — swapping the resolved HTML while leaving app-db stale with NO diagnostic. A wire-shape regression looked like successful progressive hydration in the DOM while subscriptions read wrong state. read-delta now classifies the parsed body: a map (incl. empty) merges, a nil/empty-body parse is the documented no-delta no-op, and a parseable non-map fails CLOSED with the catalogued :rf.ssr/suspense-boundary-failed :skipped-delta trace (the same event the reader-exception branch already used). The delta is not merged; the script is still consumed.

**Issue 1 (hydration runtime-db) — already closed.** The present-but-non-map :rf/runtime-db fail-closed guard + full negative-control tests landed in rf2-g00l2t (commit 1c6dbd2e2). Verified present in current code (hydrate.cljc lines 91-100 reject it; ssr_hydration_test.clj non-map-runtime-db-slice-fails-closed-through-router covers it). No further change needed.

## Quality gates
- clojure -M:test in implementation/ssr: 319 tests, 1261 assertions, 0 failures (covers issue-1 runtime-db fail-closed tests).
- npm run test:browser (CLJS, Playwright): 209 tests, 668 assertions, 0 failures (covers the new issue-2 streaming non-map delta tests; these run their DOM assertions only under the browser build).
- Negative control: with the fail-open source restored, parseable-non-map-delta-fails-closed produces 4 failures (one per malformed shape) on the missing trace — proving the new tests catch the gap.

Regression coverage added: parseable-non-map-delta-fails-closed (vector/number/string/keyword) and empty-delta-body-is-not-malformed (precision guard — empty map + valid map do not over-fire the diagnostic).