### PR TITLE
docs(examples/uix): canonical UIx style + runnable polish (rf2-pdo5mx)

### DIFF
--- a/examples/scripts/examples-staging.cjs
+++ b/examples/scripts/examples-staging.cjs
@@ -1,0 +1,230 @@
+/*
+ * Shared staging helpers for the example runners (rf2-pdo5mx).
+ *
+ * Two scripts need to stage an example's hand-written `index.html` plus the
+ * `examples/_shared/` design-system tree next to the compiled `main.js`:
+ *
+ *   - serve-and-run-examples-tests.cjs  (the adapter-smoke orchestrator)
+ *   - serve-example.cjs                 (the standalone-example dev runner)
+ *
+ * The recursive copy + `_shared` fan-out logic used to live inline in the
+ * orchestrator. It is hoisted here so the dev runner reuses the SAME hardened
+ * staging rather than re-implementing an ad hoc copy. One source of truth for
+ * "what lands in an example's output dir".
+ *
+ * This module ALSO derives the standalone-example manifest (build id ->
+ * output dir + source folder + index.html) directly from shadow-cljs.edn, so
+ * the dev runner has no hardcoded build->folder table that could drift. The
+ * derivation reads shadow-cljs.edn ONLY (it is a hot-zone file — never edited
+ * here), mirroring the read-only enumeration the compile gate already does.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// __dirname is <repo>/examples/scripts. REPO_ROOT is <repo>.
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
+const EXAMPLES_ROOT = path.join(REPO_ROOT, 'examples');
+const SHARED_SRC = path.join(EXAMPLES_ROOT, '_shared');
+
+// ---------------------------------------------------------------------------
+// Recursive copy + _shared staging (hoisted from serve-and-run-examples-tests).
+// ---------------------------------------------------------------------------
+
+// Minimal recursive copy. Each file overwrites the destination
+// unconditionally so repeat runs pick up re-compiled bundles.
+function copyDirRecursive(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirRecursive(s, d);
+    } else if (entry.isFile()) {
+      fs.copyFileSync(s, d);
+    }
+  }
+}
+
+// Stage the shared design-system tree (one stylesheet + favicon + OG image)
+// into `outDir/_shared`. The hand-written index.html files reference these via
+// relative paths like `_shared/css/style.css`, so each example's output dir
+// gets its own copy alongside main.js + index.html. No-op when _shared is
+// absent (it always exists in-repo; the guard keeps this safe in a partial
+// checkout).
+function stageShared(outDir) {
+  if (!fs.existsSync(SHARED_SRC)) return;
+  copyDirRecursive(SHARED_SRC, path.join(outDir, '_shared'));
+}
+
+// Stage one example's hand-written index.html + the _shared tree into its
+// output dir. Creates the output dir if the build hasn't emitted into it yet
+// (so the dev runner can stage before the first watch compile lands). Throws
+// with the offending path when the HTML source is missing.
+//
+// `entry` shape: { build, outDir, htmlSrc } — as produced by
+// listStandaloneExamples() (and compatible with the orchestrator's EXAMPLES
+// entries, which also carry outDir + htmlSrc).
+function stageExample(entry) {
+  if (!fs.existsSync(entry.htmlSrc)) {
+    throw new Error(`HTML source missing: ${entry.htmlSrc}`);
+  }
+  fs.mkdirSync(entry.outDir, { recursive: true });
+  fs.copyFileSync(entry.htmlSrc, path.join(entry.outDir, 'index.html'));
+  stageShared(entry.outDir);
+}
+
+// ---------------------------------------------------------------------------
+// Standalone-example manifest, derived from shadow-cljs.edn.
+//
+// We hand-roll a focused scan rather than pull in an EDN dependency — the only
+// shapes we read are the `:examples/<name> { ... :output-dir "..." ...
+// :init-fn <ns>/run }` build defs. This mirrors the parser style the compile
+// gate (check-examples-compile.cjs) already uses on the same file.
+// ---------------------------------------------------------------------------
+
+function readShadowEdn() {
+  return fs.readFileSync(path.join(IMPL_ROOT, 'shadow-cljs.edn'), 'utf8');
+}
+
+// Strip `;`-to-EOL line comments so a commented-out build def can't be read as
+// live (same approach as check-examples-compile.cjs).
+function stripEdnComments(edn) {
+  return edn
+    .split('\n')
+    .map((line) => {
+      const i = line.indexOf(';');
+      return i === -1 ? line : line.slice(0, i);
+    })
+    .join('\n');
+}
+
+// Parse every `:examples/<name>` build def into { build, outputDir, initFn }.
+// `build` is the colon-stripped coord shadow-cljs's CLI expects
+// (`examples/counter-uix`); `outputDir` is the build's `:output-dir`; `initFn`
+// is the `<ns>/run` symbol the build mounts.
+//
+// Line-based block scan: a build def opens with a two-space-indented
+// `  :examples/<name>` key (the opening `{` is on the SAME or the FOLLOWING
+// line in shadow-cljs.edn). Its body runs until the NEXT two-space top-level
+// key (`  :something`) or EOF. This avoids the consume-the-delimiter bug a
+// single non-greedy regex with a lookahead hits (it silently skips every
+// other entry when the lookahead eats the next key's opening char).
+function parseExampleBuilds(edn) {
+  const lines = stripEdnComments(edn).split('\n');
+  // Any two-space-indented keyword key ends the previous build's body.
+  const topKeyRe = /^\s{2}:[\w.-]+(?:\/[\w.-]+)?\b/;
+  const exampleKeyRe = /^\s{2}:(examples\/[\w.-]+)\s*$|^\s{2}:(examples\/[\w.-]+)\s*\{/;
+  const builds = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(exampleKeyRe);
+    if (!m) continue;
+    const build = m[1] || m[2];
+    // Gather the body: this line plus every following line until the next
+    // two-space top-level key (a sibling build / map entry) or EOF.
+    const bodyLines = [lines[i]];
+    for (let j = i + 1; j < lines.length; j++) {
+      if (topKeyRe.test(lines[j])) break;
+      bodyLines.push(lines[j]);
+    }
+    const body = bodyLines.join('\n');
+    const outMatch = body.match(/:output-dir\s+"([^"]+)"/);
+    const initMatch = body.match(/:init-fn\s+([\w.\-]+\/[\w.\-]+)/);
+    builds.push({
+      build,
+      outputDir: outMatch ? outMatch[1] : null,
+      initFn: initMatch ? initMatch[1] : null,
+    });
+  }
+  return builds;
+}
+
+// Locate the example source folder that declares `ns` by scanning the
+// examples/ tree for a .cljs/.cljc file whose `(ns <ns> ...)` form matches.
+// Returns the absolute folder path, or null. We cache a ns->folder index on
+// first use so a multi-build run scans the tree once.
+let _nsIndex = null;
+
+function buildNsIndex(root = EXAMPLES_ROOT) {
+  const index = new Map();
+  const stack = [root];
+  const nsRe = /\(ns\s+([\w.\-]+)/;
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '_shared') continue;
+        stack.push(full);
+      } else if (entry.isFile() && /\.clj[sc]$/.test(entry.name)) {
+        let head;
+        try {
+          head = fs.readFileSync(full, 'utf8').slice(0, 4096);
+        } catch {
+          continue;
+        }
+        const m = head.match(nsRe);
+        if (m && !index.has(m[1])) index.set(m[1], path.dirname(full));
+      }
+    }
+  }
+  return index;
+}
+
+function folderForNs(ns) {
+  if (_nsIndex == null) _nsIndex = buildNsIndex();
+  return _nsIndex.get(ns) || null;
+}
+
+// The set of standalone examples that are RUNNABLE by the dev server: a build
+// def whose init-fn namespace resolves to an examples/ source folder that
+// carries a hand-written index.html. Builds whose source lives outside
+// examples/ (none today) or that lack a colocated index.html are skipped — the
+// dev server can only serve a page that exists.
+//
+// Each returned entry: { build, outDir, htmlSrc, srcDir } — `outDir` is the
+// absolute output dir (IMPL_ROOT-relative `:output-dir`), `htmlSrc` the
+// colocated index.html, `srcDir` the source folder.
+function listStandaloneExamples({ io = fs } = {}) {
+  const edn = readShadowEdn();
+  const out = [];
+  for (const def of parseExampleBuilds(edn)) {
+    if (!def.outputDir || !def.initFn) continue;
+    const ns = def.initFn.replace(/\/[^/]+$/, ''); // strip `/run`
+    const srcDir = folderForNs(ns);
+    if (!srcDir) continue;
+    const htmlSrc = path.join(srcDir, 'index.html');
+    if (!io.existsSync(htmlSrc)) continue;
+    out.push({
+      build: def.build,
+      outDir: path.resolve(IMPL_ROOT, def.outputDir),
+      htmlSrc,
+      srcDir,
+    });
+  }
+  return out.sort((a, b) => a.build.localeCompare(b.build));
+}
+
+module.exports = {
+  REPO_ROOT,
+  IMPL_ROOT,
+  EXAMPLES_ROOT,
+  SHARED_SRC,
+  copyDirRecursive,
+  stageShared,
+  stageExample,
+  readShadowEdn,
+  stripEdnComments,
+  parseExampleBuilds,
+  listStandaloneExamples,
+};

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -44,6 +44,10 @@ const {
   parseFilterPatterns,
   selectEntries,
 } = require('./examples-filter.cjs');
+// Shared staging helpers (rf2-pdo5mx) — the recursive copy + _shared fan-out
+// live in one place so the standalone-example dev runner (serve-example.cjs)
+// reuses the SAME staging this orchestrator does, rather than duplicating it.
+const { stageShared } = require('./examples-staging.cjs');
 const {
   createHarnessCleanup,
   spawnHarnessProcess,
@@ -176,35 +180,10 @@ function compileAll() {
   }
 }
 
-function copyDirRecursive(src, dest) {
-  // Minimal recursive copy. Used by `stageShared` below to fan the
-  // `examples/_shared/` design-system tree into every staged smoke
-  // dir. Each file overwrites the destination unconditionally so
-  // repeat runs pick up re-compiled bundles.
-  fs.mkdirSync(dest, { recursive: true });
-  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
-    const s = path.join(src, entry.name);
-    const d = path.join(dest, entry.name);
-    if (entry.isDirectory()) {
-      copyDirRecursive(s, d);
-    } else if (entry.isFile()) {
-      fs.copyFileSync(s, d);
-    }
-  }
-}
-
-// Shared examples design system: one stylesheet + favicon + OG image
-// across all three substrates. The hand-written index.html files
-// reference these via relative paths like `_shared/css/style.css`, so
-// the orchestrator stages the `examples/_shared/` tree into every
-// example's output dir alongside main.js + index.html. Single source
-// on disk; one copy step per build (cheap — a handful of small files).
-const SHARED_SRC = path.join(REPO_ROOT, 'examples', '_shared');
-
-function stageShared(outDir) {
-  if (!fs.existsSync(SHARED_SRC)) return;
-  copyDirRecursive(SHARED_SRC, path.join(outDir, '_shared'));
-}
+// `copyDirRecursive` + `stageShared` (the `examples/_shared/` design-system
+// fan-out) are hoisted into examples-staging.cjs (rf2-pdo5mx) so the
+// standalone-example dev runner reuses the SAME staging. `stageShared` is
+// imported at the top of this file.
 
 function stageHtml() {
   // Silent-on-success: per-file staging notices are suppressed.

--- a/examples/scripts/serve-example.cjs
+++ b/examples/scripts/serve-example.cjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/*
+ * `serve-example` — one-command dev runner for a STANDALONE example build
+ * (rf2-pdo5mx).
+ *
+ * The gap this closes
+ * -------------------
+ * A standalone example (e.g. `examples/counter-uix`) was only runnable via a
+ * multi-step manual recipe: `shadow-cljs watch <build>`, then hand-copy the
+ * example's `index.html` AND the `examples/_shared/` design-system tree next
+ * to the emitted `main.js`, then serve the output dir yourself. Easy to get
+ * wrong or stale — and a compile-only gate can stay green while the page a
+ * beginner actually opens is missing its HTML or shared assets.
+ *
+ * This script collapses that recipe into ONE command. It:
+ *
+ *   1. Resolves the selected build's output dir + source folder by READING
+ *      the build def from shadow-cljs.edn (its `:output-dir` + `:init-fn`),
+ *      so there is no hardcoded build->folder table to drift. The example's
+ *      hand-written `index.html` is the one colocated with the source file
+ *      that declares the build's init-fn namespace.
+ *   2. Stages `index.html` + the `examples/_shared/` tree into the output dir
+ *      (the SAME staging the adapter-smoke orchestrator uses — reused from
+ *      examples-staging.cjs, not re-implemented).
+ *   3. Resolves a free port (reusing the examples port resolver) and serves
+ *      the output dir over http-server on 127.0.0.1.
+ *   4. Spawns `shadow-cljs watch <build>` so edits recompile live. A
+ *      `--no-watch` flag runs a one-shot `compile` instead (CI-shaped).
+ *
+ * The shared staging + harness helpers do the hardened work (cross-platform
+ * shell-free spawning, process-tree teardown, port pre-flight); this script
+ * is just the dev-ergonomics front door.
+ *
+ * Policy preserved: `npm run test:examples` stays the adapter-smoke runner,
+ * and standalone examples keep their compile coverage via
+ * `test:examples-compile`. This is a DEV command, not a test gate — it adds
+ * no `*.spec.cjs` under examples/ (the tree stays test-free, rf2-8cevm).
+ *
+ * CLI
+ * ---
+ *   node examples/scripts/serve-example.cjs --build examples/counter-uix
+ *   node examples/scripts/serve-example.cjs examples/dashboard-uix   # positional
+ *   node examples/scripts/serve-example.cjs --build examples/login-uix --no-watch
+ *   node examples/scripts/serve-example.cjs --list                   # list buildable examples
+ *
+ * Via npm (from implementation/):
+ *   npm run dev:example -- examples/counter-uix
+ *
+ * SPAWN FORM: resolve shadow-cljs's / http-server's own JS entry-points and
+ * run them under THIS node binary (process.execPath), shell-free — never
+ * `npx`/`npx.cmd` under a shell (rf2-y9o5e3). Same hardened posture as
+ * serve-and-run-examples-tests.cjs.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { resolveExamplesPort } = require('./examples-port.cjs');
+const { stageExample, listStandaloneExamples } = require('./examples-staging.cjs');
+const {
+  createHarnessCleanup,
+  spawnHarnessProcess,
+  waitForHttpReady,
+} = require('../../implementation/scripts/lib/local-browser-harness.cjs');
+
+// __dirname is <repo>/examples/scripts. REPO_ROOT is <repo>; IMPL_ROOT is
+// where shadow-cljs runs and node_modules lives.
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
+const READY_TIMEOUT_MS = 30000;
+
+function parseArgs(argv) {
+  let build = '';
+  let watch = true;
+  let list = false;
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--list') list = true;
+    else if (a === '--no-watch') watch = false;
+    else if (a === '--watch') watch = true;
+    else if (a === '--build') build = (argv[i + 1] || '').trim(), i++;
+    else if (a.startsWith('--build=')) build = a.slice('--build='.length).trim();
+    else if (!a.startsWith('--') && !build) build = a.trim();
+  }
+  // Normalise: accept `counter-uix` as shorthand for `examples/counter-uix`.
+  if (build && !build.startsWith('examples/')) build = `examples/${build}`;
+  return { build, watch, list };
+}
+
+function resolveShadowRunner() {
+  try {
+    return require.resolve('shadow-cljs/cli/runner.js', { paths: [IMPL_ROOT] });
+  } catch {
+    throw new Error(
+      `serve-example: could not resolve shadow-cljs. Run \`npm install\` in ${IMPL_ROOT} first.`,
+    );
+  }
+}
+
+function resolveHttpServerBin() {
+  return require.resolve('http-server/bin/http-server', { paths: [IMPL_ROOT] });
+}
+
+async function main() {
+  const { build, watch, list } = parseArgs(process.argv);
+  const examples = listStandaloneExamples();
+
+  if (list) {
+    console.log('serve-example: buildable standalone examples:');
+    for (const e of examples) console.log(`  ${e.build}`);
+    return 0;
+  }
+
+  if (!build) {
+    console.error(
+      'serve-example: no build selected. Pass one, e.g.\n' +
+        '  node examples/scripts/serve-example.cjs --build examples/counter-uix\n' +
+        '  npm run dev:example -- examples/counter-uix\n' +
+        'Run with --list to see every buildable standalone example.',
+    );
+    return 1;
+  }
+
+  const entry = examples.find((e) => e.build === build);
+  if (!entry) {
+    console.error(
+      `serve-example: '${build}' is not a known standalone example build.\n` +
+        'Run with --list to see the available builds.',
+    );
+    return 1;
+  }
+
+  const cleanup = createHarnessCleanup();
+  cleanup.installSignalHandlers();
+
+  // Pre-flight the port before any compile work so a clash fails fast.
+  const PORT = await resolveExamplesPort({ env: process.env });
+
+  const shadowRunner = resolveShadowRunner();
+  const httpServerBin = resolveHttpServerBin();
+
+  // For `--no-watch` we compile once up front (CI-shaped: the output dir is
+  // fully built before staging + serving). For the default watch mode the
+  // watch process below produces main.js, so we stage immediately and the
+  // first compile lands in place — http-server serves the freshly built file
+  // the moment the watch finishes its initial compile.
+  if (!watch) {
+    const { spawnSync } = require('child_process');
+    const result = spawnSync(process.execPath, [shadowRunner, 'compile', entry.build], {
+      cwd: IMPL_ROOT,
+      stdio: 'inherit',
+    });
+    if (result.status !== 0) {
+      throw new Error(`shadow-cljs compile ${entry.build} failed (exit ${result.status})`);
+    }
+  }
+
+  // Stage index.html + the _shared design-system tree into the output dir.
+  // The output dir is created by the staging helper if the watch hasn't
+  // emitted into it yet, so the page's assets are present from the start.
+  stageExample(entry);
+
+  if (watch) {
+    cleanup.trackProcess(
+      spawnHarnessProcess(process.execPath, [shadowRunner, 'watch', entry.build], {
+        cwd: IMPL_ROOT,
+        stdio: 'inherit',
+      }),
+    );
+  }
+
+  // Serve the example's output dir on 127.0.0.1 (loopback-only — the dev
+  // browser hits localhost, and it sidesteps the Windows dual-stack EACCES
+  // surprise). `-c-1` disables caching so a recompiled main.js is picked up
+  // on reload.
+  const server = cleanup.trackProcess(
+    spawnHarnessProcess(
+      process.execPath,
+      [httpServerBin, entry.outDir, '-a', '127.0.0.1', '-p', String(PORT), '-s', '-c-1'],
+      { cwd: IMPL_ROOT, stdio: ['ignore', 'inherit', 'inherit'] },
+    ),
+  );
+
+  let serverDown = false;
+  server.on('exit', (code, signal) => {
+    serverDown = true;
+    if (code !== 0 && code !== null) {
+      console.error(`http-server exited unexpectedly (code=${code}, signal=${signal}).`);
+    }
+  });
+
+  const ready = await waitForHttpReady(PORT, Date.now() + READY_TIMEOUT_MS, {
+    isAborted: () => serverDown,
+  });
+  if (!ready || serverDown) {
+    console.error(`http-server did not become reachable on :${PORT} within ${READY_TIMEOUT_MS}ms.`);
+    return 1;
+  }
+
+  console.log(
+    `\nserve-example: ${entry.build} is live at http://127.0.0.1:${PORT}/` +
+      (watch ? '  (shadow-cljs watch running — edits recompile live)' : '  (one-shot compile)') +
+      '\n  Press Ctrl+C to stop.\n',
+  );
+
+  // The watch + server run until interrupted; resolve only when the server
+  // exits (Ctrl+C is handled by the installed signal handlers, which tear the
+  // whole process tree down).
+  if (watch) {
+    await new Promise((resolve) => server.on('exit', resolve));
+    return 0;
+  }
+
+  // --no-watch: keep serving until the server is stopped (Ctrl+C).
+  await new Promise((resolve) => server.on('exit', resolve));
+  return 0;
+}
+
+main()
+  .then(async (code) => {
+    await cleanupAndExit(code);
+  })
+  .catch(async (err) => {
+    if (err && err.actionable) {
+      console.error(err.message);
+    } else {
+      console.error(err && err.stack ? err.stack : err);
+    }
+    await cleanupAndExit(1);
+  });
+
+// The cleanup handle is created inside main(); for the top-level catch we
+// fall back to a plain exit (the in-main signal handlers already cover the
+// tracked-process teardown on Ctrl+C, and a throw before they're installed
+// has no children to sweep).
+async function cleanupAndExit(code) {
+  process.exit(code == null ? 1 : code);
+}

--- a/examples/uix/README.md
+++ b/examples/uix/README.md
@@ -53,13 +53,25 @@ npm run test:examples
 
 That compiles the three adapter testbeds (`adapters/reagent-testbed`, `adapters/uix-testbed`, `adapters/helix-testbed`), stages each `index.html`, serves them, and drives the three `spec.cjs` smokes; the example builds in this directory carry no `spec.cjs` (the `examples/` tree is test-free). They do, however, get **compile coverage**: `npm run test:examples-compile` (from `implementation/`) `shadow-cljs compile`s every declared standalone `:examples/*` build — including `examples/login-uix` and `examples/dashboard-uix` — and fails on any compile error or warning, so a namespace / `:init-fn` / `:require` / UIx-form regression in these builds can no longer ship green. See [`examples/TESTING.md`](../TESTING.md#compile-coverage-gate-testexamples-compile). Bundle isolation is verified separately (each per-substrate shadow-cljs build lets CI confirm a Reagent bundle's `main.js` carries no UIx code and vice versa, and likewise for UIx ↔ Helix).
 
-To iterate on one UIx example interactively, from `implementation/`:
+To run one UIx example interactively in a browser, from `implementation/`:
+
+```bash
+npm run dev:example -- examples/counter-uix
+```
+
+That one command stages the example's hand-written `index.html` + the shared `_shared/` assets next to the compiled `main.js`, starts `shadow-cljs watch` (edits recompile live), serves the output dir on a free local port, and prints the URL to open. Swap in `examples/login-uix` or `examples/dashboard-uix` for the others; `npm run dev:example -- --list` lists every runnable standalone example. Add `--no-watch` for a one-shot compile-and-serve.
+
+<details><summary>Advanced / troubleshooting: raw <code>shadow-cljs watch</code></summary>
+
+The one-command runner wraps the raw watch + manual staging recipe:
 
 ```bash
 shadow-cljs watch examples/counter-uix
 ```
 
-The build emits `main.js` into `out/examples/counter-uix/`; copy the example's hand-written [`counter_uix/index.html`](counter_uix/index.html) (and the shared assets it references under [`../_shared/`](../_shared/)) alongside it to load the watched build in a browser.
+The build emits `main.js` into `out/examples/counter-uix/`; you then copy the example's hand-written [`counter_uix/index.html`](counter_uix/index.html) (and the shared assets it references under [`../_shared/`](../_shared/)) alongside it and serve the output dir yourself. `npm run dev:example` does this staging + serving for you, so reach for the raw command only when you need to drive shadow-cljs directly.
+
+</details>
 
 ## Cross-references
 

--- a/examples/uix/counter_uix/README.md
+++ b/examples/uix/counter_uix/README.md
@@ -56,19 +56,32 @@ counter_uix/
 
 ```bash
 # From implementation/:
-shadow-cljs watch examples/counter-uix
+npm run dev:example -- examples/counter-uix
 ```
 
-The watch build emits `main.js` into `out/examples/counter-uix/`;
-copy this folder's hand-written [`index.html`](index.html) (and the
-shared assets it references under [`../../_shared/`](../../_shared/))
-alongside it, then serve `out/examples/counter-uix/` over HTTP.
+One command: it stages this folder's hand-written
+[`index.html`](index.html) + the shared `_shared/` assets next to the
+compiled `main.js`, starts `shadow-cljs watch` (edits recompile live),
+serves `out/examples/counter-uix/` on a free local port, and prints the
+URL to open. Add `--no-watch` for a one-shot compile-and-serve.
+
 (`npm run test:examples` does not build this example — it compiles and
 serves only the three adapter testbeds; see
 [`examples/uix/README.md`](../README.md).) Examples are
 test-free per [`examples/README.md`](../../README.md); the UIx adapter
 smoke lives at
 [`implementation/adapters/uix/testbed/spec.cjs`](../../../implementation/adapters/uix/testbed/spec.cjs).
+
+<details><summary>Advanced: raw <code>shadow-cljs watch</code></summary>
+
+`npm run dev:example` wraps the raw watch + manual staging recipe. To
+drive shadow-cljs directly: `shadow-cljs watch examples/counter-uix`
+emits `main.js` into `out/examples/counter-uix/`; you then copy this
+folder's [`index.html`](index.html) (and the shared assets under
+[`../../_shared/`](../../_shared/)) alongside it and serve the output dir
+yourself.
+
+</details>
 
 ## Cross-references
 

--- a/examples/uix/dashboard_uix/README.md
+++ b/examples/uix/dashboard_uix/README.md
@@ -53,17 +53,73 @@ dashboard_uix/
 
 ```bash
 # From implementation/:
-shadow-cljs watch examples/dashboard-uix
+npm run dev:example -- examples/dashboard-uix
 ```
 
-The watch build emits `main.js` into `out/examples/dashboard-uix/`;
-copy this folder's hand-written [`index.html`](index.html) (and the
-shared assets it references under [`../../_shared/`](../../_shared/))
-alongside it, then serve `out/examples/dashboard-uix/` over HTTP.
+One command: it stages this folder's hand-written
+[`index.html`](index.html) + the shared `_shared/` assets next to the
+compiled `main.js`, starts `shadow-cljs watch` (edits recompile live),
+serves `out/examples/dashboard-uix/` on a free local port, and prints
+the URL to open. Add `--no-watch` for a one-shot compile-and-serve.
+
 (`npm run test:examples` does not build this example — it compiles and
 serves only the three adapter testbeds; see
 [`examples/uix/README.md`](../README.md).) Examples are test-free per
 [`examples/README.md`](../../README.md).
+
+<details><summary>Advanced: raw <code>shadow-cljs watch</code></summary>
+
+`npm run dev:example` wraps the raw watch + manual staging recipe. To
+drive shadow-cljs directly: `shadow-cljs watch examples/dashboard-uix`
+emits `main.js` into `out/examples/dashboard-uix/`; you then copy this
+folder's [`index.html`](index.html) (and the shared assets under
+[`../../_shared/`](../../_shared/)) alongside it and serve the output
+dir yourself.
+
+</details>
+
+## Accessibility + responsive — what to copy, and a manual checklist
+
+Because this is the UIx example meant to model a *polished* multi-pane
+app, its controls and layout demonstrate the accessibility +
+responsive shape a real UIx app should copy:
+
+- **Tag filter chips are multi-select toggles** — each chip is a real
+  `<button>` carrying `aria-pressed`, and the row is a `role="group"`
+  with an `aria-label`. Assistive tech reads the on/off state, not just
+  a visual class.
+- **The range picker is a single-select mode control** — it uses the
+  radio idiom (`role="radiogroup"` on the row, `role="radio"` +
+  `aria-checked` on each chip), so it announces as a one-of-N choice
+  rather than three independent buttons.
+- **Sparklines are decorative** (`aria-hidden="true"`) — the card's
+  eyebrow, value, and label already carry the metric name + value as
+  text, so the SVG is a visual restatement, not a separate nameless
+  graphic to announce.
+- **Layout stays within its box at every width** — the card grid floor
+  is `minmax(min(100%, 280px), 1fr)` so a narrow viewport collapses to
+  one full-width column instead of overflowing; two `@media`
+  breakpoints stack the header and shrink the oversized H1 / card
+  padding on tablet + phone.
+
+Examples are **test-free** (no `*.spec.cjs` under `examples/`), so this
+class of design-led polish is guarded by the manual checklist below
+rather than a per-example browser spec. Run it when you touch this
+example's markup or CSS (the WCAG palette-contrast + focus-ring
+contracts on the shared stylesheet are already enforced statically by
+`check-examples-assets`; the items here are the layout/semantics that
+need an eye):
+
+1. **Keyboard** — Tab reaches every chip + the range buttons; the
+   focus ring is visible on each; Enter/Space toggles them.
+2. **Screen reader** (VoiceOver / NVDA) — tag chips announce
+   "pressed/not pressed"; range chips announce as a radio group with
+   the selected one "checked"; the sparklines are NOT announced.
+3. **Narrow viewport** (≈360px, DevTools device toolbar) — no
+   horizontal scrollbar; the grid is one column; the header stacks;
+   the H1 does not overrun the edge.
+4. **Wide viewport** (≥1180px) — the grid is multi-column; the header
+   row aligns title left / controls right.
 
 ## Cross-references
 

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -144,11 +144,17 @@
 ;; ============================================================================
 
 (defui sparkline [{:keys [series id]}]
+  ;; The card's <header> eyebrow, value, and label already carry the
+  ;; metric's name + current value as text, so the sparkline is a
+  ;; decorative restatement of that information for assistive tech.
+  ;; `aria-hidden="true"` (rather than a generic `role="img"`
+  ;; `aria-label="sparkline"`) keeps a screen reader from announcing a
+  ;; nameless graphic on every card — the accessible name lives on the
+  ;; surrounding text, which is where the information actually is.
   ($ :svg.dash-sparkline
      {:viewBox "0 0 100 30"
       :preserveAspectRatio "none"
-      :role "img"
-      :aria-label "sparkline"
+      :aria-hidden "true"
       :data-testid (str "dashboard-sparkline-" (name id))}
      ($ :path {:d (sparkline-path series)
                :fill "none"
@@ -200,27 +206,45 @@
        ($ sparkline {:series series :id id}))))
 
 (defui filter-chips []
+  ;; MULTI-select toggles: any subset of tags can be on at once. Each chip
+  ;; is a real <button> carrying `aria-pressed` — the value assistive tech
+  ;; reads as the on/off state (the `is-on` CSS class is presentation only).
+  ;; The chips share a `role="group"` with an `aria-label` so a screen
+  ;; reader announces them as one labelled set of toggles, not three loose
+  ;; buttons.
   (let [active-tags (uix-adapter/use-subscribe [:dashboard/active-tags])
         dispatch    (:dispatch (rf/frame-handle))]
-    ($ :div.dash-chips
+    ($ :div.dash-chips {:role "group" :aria-label "Filter metrics by category"}
        (for [{:keys [id label]} all-tags]
-         ($ :button {:key id
-                     :class (str "dash-chip " (when (contains? active-tags id) "is-on"))
-                     :data-testid (str "dashboard-chip-" (name id))
-                     :on-click #(dispatch [:dashboard/toggle-tag id])}
-            ($ :span.dash-chip-dot {:class (str "tag-" (name id))})
-            label)))))
+         (let [on? (contains? active-tags id)]
+           ($ :button {:key id
+                       :type "button"
+                       :class (str "dash-chip " (when on? "is-on"))
+                       :aria-pressed (if on? "true" "false")
+                       :data-testid (str "dashboard-chip-" (name id))
+                       :on-click #(dispatch [:dashboard/toggle-tag id])}
+              ($ :span.dash-chip-dot {:class (str "tag-" (name id))})
+              label))))))
 
 (defui range-picker []
+  ;; SINGLE-select mode control: exactly one range is active. This is the
+  ;; radio idiom, not a set of independent toggles, so it gets
+  ;; `role="radiogroup"` on the container and `role="radio"` +
+  ;; `aria-checked` on each chip — assistive tech announces it as a
+  ;; one-of-N choice. The `is-on` class stays presentation-only.
   (let [active-range-id (uix-adapter/use-subscribe [:dashboard/range])
         dispatch        (:dispatch (rf/frame-handle))]
-    ($ :div.dash-chips
+    ($ :div.dash-chips {:role "radiogroup" :aria-label "Time range"}
        (for [{:keys [id label]} ranges]
-         ($ :button {:key id
-                     :class (str "dash-chip " (when (= active-range-id id) "is-on"))
-                     :data-testid (str "dashboard-range-" (name id))
-                     :on-click #(dispatch [:dashboard/set-range id])}
-            label)))))
+         (let [on? (= active-range-id id)]
+           ($ :button {:key id
+                       :type "button"
+                       :role "radio"
+                       :class (str "dash-chip " (when on? "is-on"))
+                       :aria-checked (if on? "true" "false")
+                       :data-testid (str "dashboard-range-" (name id))
+                       :on-click #(dispatch [:dashboard/set-range id])}
+              label))))))
 
 (defui dashboard []
   (let [visible-metrics (uix-adapter/use-subscribe [:dashboard/visible-metrics])

--- a/examples/uix/dashboard_uix/index.html
+++ b/examples/uix/dashboard_uix/index.html
@@ -88,7 +88,11 @@
 
     .dash-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      /* `min(100%, 280px)` is the responsive-grid floor: on a viewport
+         narrower than 280px the track shrinks to the content width instead
+         of forcing a 280px column that overflows the page. On wide
+         viewports it behaves exactly like the plain 280px minimum. */
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
       gap: 1.25em;
     }
 
@@ -154,6 +158,38 @@
       letter-spacing: 0.1em;
       font-size: 0.74rem;
       color: var(--ex-ink-faint);
+    }
+
+    /* Responsive overrides. The desktop layout above is wide-first
+       (a fixed-end flex head row, a 3rem H1, right-aligned controls,
+       a 280px grid floor). These two breakpoints keep the page within
+       its element box at tablet/phone widths so nothing produces
+       document-level horizontal overflow (matches the process-monitor
+       sibling's responsive shape). */
+
+    /* Tablet and below: stop the head row from forcing a fixed two-column
+       split — stack the title above the controls so neither half gets
+       squeezed, and let the controls left-align under the title rather
+       than cling to the right edge. */
+    @media (max-width: 720px) {
+      .dash-shell { padding: 2em min(6vw, 32px); }
+      .dash-shell-head {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1.25em;
+      }
+      .dash-controls { align-items: flex-start; }
+    }
+
+    /* Narrow phones: shrink the oversized H1 so it can't overrun the
+       viewport, and tighten card padding. The grid already collapses to a
+       single full-width column via the `min(100%, 280px)` floor above, so
+       no grid override is needed here — the chip rows wrap on their own
+       `flex-wrap`. */
+    @media (max-width: 480px) {
+      .dash-shell-head h1 { font-size: 2.2rem; }
+      .dash-card { padding: 1.2em 1.2em; }
+      .dash-value { font-size: 2rem; }
     }
   </style>
 </head>

--- a/examples/uix/login_uix/README.md
+++ b/examples/uix/login_uix/README.md
@@ -51,17 +51,30 @@ login_uix/
 
 ```bash
 # From implementation/:
-shadow-cljs watch examples/login-uix
+npm run dev:example -- examples/login-uix
 ```
 
-The watch build emits `main.js` into `out/examples/login-uix/`; copy
-this folder's hand-written [`index.html`](index.html) (and the shared
-assets it references under [`../../_shared/`](../../_shared/))
-alongside it, then serve `out/examples/login-uix/` over HTTP.
+One command: it stages this folder's hand-written
+[`index.html`](index.html) + the shared `_shared/` assets next to the
+compiled `main.js`, starts `shadow-cljs watch` (edits recompile live),
+serves `out/examples/login-uix/` on a free local port, and prints the
+URL to open. Add `--no-watch` for a one-shot compile-and-serve.
+
 (`npm run test:examples` does not build this example — it compiles and
 serves only the three adapter testbeds; see
 [`examples/uix/README.md`](../README.md).) Examples are test-free
 per [`examples/README.md`](../../README.md).
+
+<details><summary>Advanced: raw <code>shadow-cljs watch</code></summary>
+
+`npm run dev:example` wraps the raw watch + manual staging recipe. To
+drive shadow-cljs directly: `shadow-cljs watch examples/login-uix`
+emits `main.js` into `out/examples/login-uix/`; you then copy this
+folder's [`index.html`](index.html) (and the shared assets under
+[`../../_shared/`](../../_shared/)) alongside it and serve the output
+dir yourself.
+
+</details>
 
 ## Cross-references
 

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -225,19 +225,35 @@
     {:tags #{:auth/locked}
      :meta {:terminal? true}}}})
 
-;; Registration uses the lower-level `reg-event-fx` form (not the canonical
-;; `reg-machine` / `reg-machine*` surface) deliberately: this login flow needs
-;; BOTH a live machine `:data-schema` AND an event-vector `:schema`
-;; (`AuthLoginEvent`, the `:where :event` boundary on the dispatched vector),
-;; and the public `reg-machine` surface takes only `[machine-id machine]` — no
-;; slot for an event-vector `:schema`. So we stamp the machine metadata
-;; (`:rf/machine? true` + the `:rf/machine` spec) ourselves alongside `:schema`.
-;; `rf/machine-meta` reads `:data-schema` back off the `:rf/machine` spec
-;; (Spec 005 §Querying machines), so the `:where :machine-data` validator goes
-;; live — a bad machine `:data` update emits/rolls back at that boundary, while
-;; the `:schema` boundary still validates the event vector before the handler
-;; runs. This flat machine has no parallel regions, so the region-machine cache
-;; `reg-machine*` installs is not needed here.
+;; A machine that ALSO validates its outer event vector. The canonical
+;; surface for registering a machine is `reg-machine` / `reg-machine*`
+;; (Spec 005 §reg-machine — the form tools, examples, and scaffolds default
+;; to). Reach for it first. This login flow is the one shape it cannot
+;; express today: it needs BOTH a live machine `:data-schema` AND an
+;; event-vector `:schema` (`AuthLoginEvent`, the `:where :event` boundary on
+;; the dispatched vector), and `reg-machine` takes only `[machine-id machine]`
+;; — no slot for an event-vector `:schema`.
+;;
+;; So this example composes the two surfaces explicitly: it registers via the
+;; documented lower-level `reg-event-fx` + `make-machine-handler` form (the
+;; SAME registry slot `reg-machine` reaches — Spec 005 §Registration), and on
+;; the handler's metadata map it carries the public, documented machine keys
+;; alongside `:schema`:
+;;   :rf/machine? true   — the machine discriminator (Spec 005 §Querying
+;;                         machines / §Registration-metadata stamp). `(machines)`
+;;                         filters on it; `machine-meta` reads the spec back.
+;;   :rf/machine <spec>   — the spec map. `machine-meta` reads `:data-schema`
+;;                         off it, so the `:where :machine-data` validator goes
+;;                         live: a bad `:data` update emits/rolls back at that
+;;                         boundary, while the `:schema` boundary validates the
+;;                         event vector before the handler runs.
+;; These are the same two keys `reg-machine*` stamps — not private internals.
+;; The only thing the macro adds that this hand-form does not is source-coord
+;; co-location (jump-to-source in tooling); a flat singleton like this needs
+;; none of `reg-machine*`'s region-machine cache.
+;;
+;; A first-class arity for "machine + event-vector schema" is the documented
+;; public-surface gap (rf2-wgmipl); when it lands this example moves onto it.
 (rf/reg-event-fx :auth.login/flow
   {:doc         "Login flow: idle → submitting → authed / error-shown / locked-out."
    :schema      AuthLoginEvent

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -30,13 +30,14 @@
     "test:examples-compile": "node scripts/check-examples-compile.cjs",
     "test:reagent-slim:bundle-isolation": "shadow-cljs release examples/counter examples/counter-slim-and-fast && node scripts/check-reagent-slim-bundle-isolation.cjs",
     "test:examples": "node ../examples/scripts/serve-and-run-examples-tests.cjs",
+    "dev:example": "node ../examples/scripts/serve-example.cjs",
     "story:build": "node scripts/story-build.cjs",
     "test:story-feature-load": "node ../examples/scripts/serve-and-run-story-feature-load-tests.cjs",
     "test:story-play-scripts": "node ../examples/scripts/serve-and-run-story-play-scripts.cjs",
     "test:xray-feature-gate": "node scripts/serve-and-run-xray-feature-gate.cjs",
     "test:xray-feature-gate:smoke": "node scripts/serve-and-run-xray-feature-gate.cjs --smoke",
     "test:story-static": "node scripts/check-story-static.cjs",
-    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_lint-workflow-policy.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_story-script-runners-policy.test.cjs && node scripts/_impl-browser-runners-pageerror-policy.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_mcp-conformance-install-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs && node scripts/check-reagent-slim-boundary.test.cjs",
+    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_lint-workflow-policy.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_story-script-runners-policy.test.cjs && node scripts/_impl-browser-runners-pageerror-policy.test.cjs && node scripts/_script-spawn-policy.test.cjs && node scripts/_mcp-conformance-install-policy.test.cjs && node scripts/_examples-filter.test.cjs && node scripts/_examples-staging.test.cjs && node scripts/check-examples-compile.test.cjs && node scripts/check-examples-assets.test.cjs && node scripts/check-reagent-slim-boundary.test.cjs",
     "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs && node scripts/_read-release-bundle.test.cjs && node scripts/dev-testbed.test.cjs",
     "test:mcp-conformance": "node scripts/test-mcp-conformance.cjs"
   }

--- a/implementation/scripts/_examples-staging.test.cjs
+++ b/implementation/scripts/_examples-staging.test.cjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/*
+ * Tests for `examples/scripts/examples-staging.cjs` — the shared staging
+ * helpers + the standalone-example manifest derived from shadow-cljs.edn
+ * (rf2-pdo5mx).
+ *
+ * What these pin
+ * --------------
+ *   - parseExampleBuilds reads EVERY `:examples/<name>` build def, including
+ *     the brace-on-the-NEXT-line shape shadow-cljs.edn actually uses (the
+ *     parser's first cut used a single non-greedy regex + lookahead that
+ *     silently skipped every OTHER entry — the consume-the-delimiter bug;
+ *     these tests would have caught it).
+ *   - each parsed build recovers its :output-dir and :init-fn.
+ *   - the real-repo derivation is non-vacuous (the project ships well over a
+ *     dozen example builds) and the three UIx examples resolve to a runnable
+ *     entry with a colocated index.html on disk.
+ *
+ * Standalone node-runnable suite — no external test framework. Wired into
+ * package.json via `test:script-policy`.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const assert = require('assert');
+
+const {
+  parseExampleBuilds,
+  listStandaloneExamples,
+  readShadowEdn,
+} = require('../../examples/scripts/examples-staging.cjs');
+
+let failed = 0;
+
+function it(label, f) {
+  try {
+    f();
+    console.log(`  PASS  ${label}`);
+  } catch (err) {
+    failed++;
+    console.error(`  FAIL  ${label}`);
+    console.error(`        ${err.message || err}`);
+  }
+}
+
+console.log('examples-staging tests (rf2-pdo5mx)');
+
+// ---- parser: synthetic fixture, both brace placements --------------------
+
+// Mirrors shadow-cljs.edn shape: a top-level map of build defs, with the
+// build-id key on its OWN line and the opening `{` on the FOLLOWING line
+// (the shape that broke the first parser cut), plus an inline-brace variant
+// to prove both are read. Adjacent example builds must BOTH be recovered.
+const FIXTURE = `{:builds
+ {:node-test {:target :node-test}
+
+  :examples/alpha
+  {:target     :browser
+   :output-dir "out/examples/alpha"
+   :asset-path "."
+   :modules    {:main {:init-fn alpha.core/run}}}
+
+  ;; a comment line :examples/should-be-ignored {
+  :examples/beta
+  {:target     :browser
+   :output-dir "out/examples/beta"
+   :modules    {:main {:init-fn beta.views/run}}}
+
+  :examples/gamma {:target :browser
+                   :output-dir "out/examples/gamma"
+                   :modules {:main {:init-fn seven-guis.gamma.core/run}}}
+
+  :some-other-build
+  {:target :browser}}}`;
+
+it('parseExampleBuilds recovers every adjacent example build (no skip-every-other bug)', () => {
+  const builds = parseExampleBuilds(FIXTURE);
+  assert.deepStrictEqual(
+    builds.map((b) => b.build).sort(),
+    ['examples/alpha', 'examples/beta', 'examples/gamma'],
+  );
+});
+
+it('parseExampleBuilds recovers :output-dir + :init-fn per build', () => {
+  const byId = Object.fromEntries(parseExampleBuilds(FIXTURE).map((b) => [b.build, b]));
+  assert.strictEqual(byId['examples/alpha'].outputDir, 'out/examples/alpha');
+  assert.strictEqual(byId['examples/alpha'].initFn, 'alpha.core/run');
+  assert.strictEqual(byId['examples/beta'].initFn, 'beta.views/run');
+  assert.strictEqual(byId['examples/gamma'].initFn, 'seven-guis.gamma.core/run');
+  assert.strictEqual(byId['examples/gamma'].outputDir, 'out/examples/gamma');
+});
+
+it('parseExampleBuilds ignores commented-out build keys', () => {
+  const ids = parseExampleBuilds(FIXTURE).map((b) => b.build);
+  assert.ok(!ids.includes('examples/should-be-ignored'));
+});
+
+// ---- real-repo derivation: non-vacuous + the three UIx examples ----------
+
+it('parseExampleBuilds(shadow-cljs.edn) is non-vacuous and every build has out+init', () => {
+  const builds = parseExampleBuilds(readShadowEdn());
+  assert.ok(
+    builds.length >= 30,
+    `expected the full example set (>=30), got ${builds.length} — parser/edn drift`,
+  );
+  for (const b of builds) {
+    assert.ok(b.outputDir, `build ${b.build} missing :output-dir`);
+    assert.ok(b.initFn, `build ${b.build} missing :init-fn`);
+  }
+});
+
+it('listStandaloneExamples resolves the three UIx examples to a colocated index.html', () => {
+  const byId = Object.fromEntries(listStandaloneExamples().map((e) => [e.build, e]));
+  for (const build of ['examples/counter-uix', 'examples/login-uix', 'examples/dashboard-uix']) {
+    const e = byId[build];
+    assert.ok(e, `runnable manifest missing ${build}`);
+    assert.ok(fs.existsSync(e.htmlSrc), `${build} index.html missing on disk: ${e.htmlSrc}`);
+    assert.ok(
+      /out[\\/]examples[\\/]/.test(e.outDir),
+      `${build} outDir not under out/examples: ${e.outDir}`,
+    );
+  }
+});
+
+if (failed > 0) {
+  console.error(`\nexamples-staging tests: ${failed} FAILED.`);
+  process.exit(1);
+}
+console.log('\nexamples-staging tests: all passed.');


### PR DESCRIPTION
Actions rf2-pdo5mx (best-practice-review) for examples/uix. Branched off latest origin/main (includes #3594 / rf2-384975 login_uix :data-schema fix).

## Finding 2 — dashboard_uix accessibility + responsive (P3)
- Tag filter chips are multi-select toggles: role=group + aria-label, each a real button with aria-pressed (verified toggling true to false at runtime).
- Range picker is a single-select mode control: role=radiogroup + role=radio + aria-checked.
- Sparklines are decorative (aria-hidden=true) — the card eyebrow/value/label already carry the metric name+value as text.
- Responsive CSS: grid floor minmax(min(100%, 280px), 1fr) + two @media breakpoints (header stacks, oversized H1/card padding shrink). Verified no horizontal overflow at a 360px viewport.
- README gains accessibility/responsive notes + a manual checklist (examples are test-free, so the static guard is the checklist plus the existing check-examples-assets WCAG palette/focus contracts).

## Finding 3 — one-command runnable (P3)
- New examples/scripts/serve-example.cjs + npm run dev:example: stages index.html + _shared, runs shadow-cljs watch (or --no-watch one-shot), serves a free local port, prints the URL. Verified end-to-end on counter-uix and dashboard-uix (index.html, _shared/css/style.css, main.js, favicon all 200).
- Hoisted the recursive-copy + _shared staging into examples-staging.cjs so the smoke orchestrator and the dev runner share it (no duplicated copy logic). The standalone-example manifest is derived from shadow-cljs.edn (read-only).
- _examples-staging.test.cjs pins the parser (it caught a consume-the-delimiter bug in the first cut).
- The four UIx READMEs point at the one-command path; raw shadow-cljs watch kept as advanced/troubleshooting context.

## Finding 1 — login_uix machine registration (P2)
The public reg-machine / reg-machine* surface takes only [machine-id machine] — no slot for an event-vector :schema. The login flow needs both a machine :data-schema and an event :schema, so the example composes reg-event-fx + make-machine-handler by hand. Reframed the comment to teach this as a documented public composition (the same :rf/machine? / :rf/machine keys reg-machine* stamps), not a workaround. The first-class public arity is a framework + hot-zone change out of this examples-only slice — filed as rf2-wgmipl.

## Quality gates
- npm run test:examples-compile — all 39 example builds compile, 0 warnings (post-rebase).
- npm run test:script-policy — all pass, incl. new _examples-staging.test.cjs + spawn-policy over the two new scripts (107 passed).
- python scripts/check_doc_slugs.py — exit 0 (READMEs touched).
- Runtime: Playwright headless confirmed the dashboard aria semantics render and that there is no horizontal overflow at 360px.