### PR TITLE
fix(test-quiet): close CLJS-arg false-green + JVM stdout overdrop (rf2-14nojy)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -47,6 +47,7 @@
   exit logic and changes none of it."
   (:require
     [re-frame.test-quiet]
+    [clojure.string :as str]
     [clojure.test]
     [cognitect.test-runner]))
 
@@ -62,6 +63,17 @@
   emitted by a test or fixture is forwarded, not silently swallowed: only
   the runner's own banner opens a set literal here.
 
+  The prefix is NECESSARY but not SUFFICIENT to confirm the banner (the
+  rf2-14nojy.2 overdrop): cognitect emits the banner via `println`, so it
+  is the WHOLE line — `(format \"Running tests in %s\" dirs)` and nothing
+  more — whereas a user/fixture line such as
+  `Running tests in #{:fixture :phase} MARKER` shares the exact prefix but
+  carries trailing content after the closing `}`.  Dropping on the prefix
+  alone swallowed that trailing diagnostic.  `banner-filtering-writer`
+  therefore treats a full-prefix match only as a CANDIDATE: it buffers the
+  rest of the line and drops it only if the remainder is a balanced set
+  literal followed by nothing but whitespace (`banner-line-remainder?`).
+
   Note the leading `\\n` in cognitect's format string: the banner is
   `\\nRunning tests in #{...}\\n` — it opens with a BLANK LINE.  That
   leading newline is part of the banner artefact and is swallowed along
@@ -69,6 +81,49 @@
   in `banner-filtering-writer`); the text we *match* on is the
   non-blank-line portion below."
   "Running tests in #{")
+
+(defn- banner-line-remainder?
+  "True iff `remainder` — the text on a banner-candidate line AFTER the
+  `discovery-banner-prefix` (`Running tests in #{`) — completes the
+  cognitect discovery banner and NOTHING else.
+
+  cognitect prints the banner with `println` as `(format \"Running tests
+  in %s\" dirs)` where `dirs` is the dir-string SET, so the whole line is
+  `Running tests in #{<set-body>}` and stops there.  This confirms that
+  shape: the remainder must contain the set body, the closing `}` that
+  balances the prefix's `#{`, and then only whitespace.  Anything after
+  the closing brace — e.g. the ` MARKER` in a fixture's
+  `Running tests in #{:fixture :phase} MARKER` — means it is NOT the
+  banner and must be forwarded (the rf2-14nojy.2 overdrop guard).
+
+  The scan tracks brace depth (the prefix already opened depth 1) and
+  skips over Clojure string literals so a `}` inside a quoted dir name
+  (`#{\"a}b\"}`) does not close the set early.  Returns false if the
+  remainder never balances back to depth 0 (a partial banner that has not
+  yet reached its own newline — handled as a still-open candidate by the
+  caller)."
+  [^String remainder]
+  (let [n (.length remainder)]
+    (loop [i 0, depth 1, in-str? false]
+      (if (>= i n)
+        false ; never closed the set on this line → not a complete banner
+        (let [c (.charAt remainder i)]
+          (cond
+            in-str?
+            (cond
+              (= c \\)        (recur (+ i 2) depth in-str?) ; skip escaped char
+              (= c \")        (recur (inc i) depth false)
+              :else           (recur (inc i) depth in-str?))
+
+            (= c \")          (recur (inc i) depth true)
+            (= c \{)          (recur (inc i) (inc depth) in-str?)
+            (= c \})          (let [d (dec depth)]
+                                (if (zero? d)
+                                  ;; Set closed — banner iff only whitespace
+                                  ;; (a `\r` before the `\n`, say) follows.
+                                  (str/blank? (subs remainder (inc i)))
+                                  (recur (inc i) d in-str?)))
+            :else             (recur (inc i) depth in-str?)))))))
 
 (defn- banner-filtering-writer
   "A `java.io.Writer` that forwards every character to `target` EXCEPT
@@ -82,8 +137,16 @@
      it (the banner candidate);
    - the moment it diverges from the banner prefix we forward the whole
      run immediately and pass the rest of the line straight through;
-   - the moment it reaches the full banner prefix we know it IS the banner
-     and drop the remainder of the line.
+   - the moment it reaches the full banner prefix the line is a banner
+     CANDIDATE, not a confirmed banner: cognitect prints the banner with
+     `println`, so the banner is the WHOLE line and stops at the set
+     literal's closing `}`.  We keep buffering the remainder and decide at
+     the line's newline — drop the line only if the remainder is a
+     balanced set literal followed by nothing but whitespace
+     (`banner-line-remainder?`); otherwise the prefix was shared by a
+     user/fixture diagnostic such as `Running tests in #{:fixture} MARKER`
+     and the whole buffered line is forwarded (the rf2-14nojy.2 overdrop
+     guard).
 
   cognitect's banner opens with a BLANK LINE — the format string is
   `\"\\nRunning tests in %s\"`, so the leading `\\n` renders an empty line
@@ -103,11 +166,14 @@
   fail/error counts, so neither `flush` nor `close` runs).  An eager
   forward means a bare `(print ...)` diagnostic with no trailing newline
   still reaches stdout before exit.  The only text that can sit unflushed
-  at exit is a strict banner-prefix candidate or a single pending blank —
-  both of which the `finally` flush and the JVM shutdown hook forward (a
-  genuine trailing blank line therefore still survives exit), while the
-  banner itself completes and is dropped before any exit because cognitect
-  prints it with `println` and runs the suite after.
+  at exit is a banner candidate (the full buffered line so far — a strict
+  banner prefix, possibly extended into an as-yet-unterminated banner
+  remainder) or a single pending blank — all of which the `finally` flush
+  and the JVM shutdown hook forward (a genuine trailing blank line and a
+  bare `Running tests in #{...`-prefixed partial therefore both survive
+  exit), while the real banner itself completes and is dropped before any
+  exit because cognitect prints it with `println` and runs the suite
+  after.
 
   Help text, parse-error diagnostics, the reporter's failure output, and
   bare test stdout all pass through untouched; only the banner line is
@@ -120,11 +186,15 @@
   exactly one place."
   ^java.io.Writer [^java.io.Writer target]
   (let [prefix-len (.length ^String discovery-banner-prefix)
-        ;; `buf` holds the live banner-prefix candidate for the current
-        ;; line. `state` is one of:
-        ;;   :watching    — buf is a viable prefix of the banner-so-far;
-        ;;   :passthrough — this line diverged; forward chars verbatim;
-        ;;   :dropping    — this line IS the banner; drop to its newline.
+        ;; `buf` holds the live candidate for the current line — the
+        ;; banner-prefix run while `:watching`, extended with the
+        ;; post-prefix remainder while `:banner-candidate`. `state` is one
+        ;; of:
+        ;;   :watching         — buf is a viable prefix of the banner-so-far;
+        ;;   :banner-candidate — buf reached the full prefix; keep buffering
+        ;;                       the remainder, decide drop/forward at the
+        ;;                       line's newline (rf2-14nojy.2);
+        ;;   :passthrough      — this line diverged; forward chars verbatim.
         buf   (StringBuilder.)
         state (volatile! :watching)
         ;; `pending-blank?` holds back a single empty line that MIGHT be
@@ -178,44 +248,64 @@
                                                (do (flush-pending-blank!)
                                                    (emit! (.toString buf))
                                                    (.write target (int \newline))))
+                                ;; Reached the full prefix — DECIDE now that
+                                ;; the line is complete (rf2-14nojy.2). The
+                                ;; remainder is everything buffered after the
+                                ;; prefix; if it is a balanced set literal +
+                                ;; only whitespace this IS the discovery
+                                ;; banner → drop the whole line (and the
+                                ;; pending blank that was its leading
+                                ;; newline). Otherwise the prefix was shared
+                                ;; by a real diagnostic → flush the pending
+                                ;; blank and forward the whole buffered line.
+                                :banner-candidate
+                                (let [remainder (subs (.toString buf) prefix-len)]
+                                  (if (banner-line-remainder? remainder)
+                                    (drop-pending-blank!)
+                                    (do (flush-pending-blank!)
+                                        (.write target (.toString buf))
+                                        (.write target (int \newline)))))
                                 ;; Diverged line — its chars already went
                                 ;; straight through; terminate it.
-                                :passthrough (.write target (int \newline))
-                                ;; The banner line — drop its newline too,
-                                ;; so no blank line is left behind.
-                                :dropping    nil)
+                                :passthrough (.write target (int \newline)))
                               (reset-line!))
 
                           (= @state :passthrough)
                           (.write target (int c))
 
-                          (= @state :dropping)
-                          nil ; swallow the rest of the banner line
+                          ;; A full-prefix candidate keeps accreting its
+                          ;; remainder; the drop/forward call is deferred to
+                          ;; the newline above.
+                          (= @state :banner-candidate)
+                          (.append buf c)
 
                           :else ; :watching — extend the candidate
                           (do
                             (.append buf c)
-                            (cond
-                              ;; Reached the full prefix → confirmed banner.
-                              ;; Any pending blank was its leading newline.
-                              (>= (.length buf) prefix-len)
-                              (do (drop-pending-blank!)
-                                  (.setLength buf 0)
-                                  (vreset! state :dropping))
-                              ;; Still on track to be the banner — keep
-                              ;; holding (and keep any pending blank held;
-                              ;; it stands or falls with this line).
-                              (.startsWith ^String discovery-banner-prefix
-                                           (.toString buf))
-                              nil
-                              ;; Diverged → this line is not the banner, so
-                              ;; the pending blank preceded real content;
-                              ;; flush it, then forward the diverged run.
-                              :else
-                              (do (flush-pending-blank!)
-                                  (emit! (.toString buf))
-                                  (.setLength buf 0)
-                                  (vreset! state :passthrough))))))
+                            (let [s (.toString buf)]
+                              (cond
+                                ;; Reached (or passed) the full prefix AND it
+                                ;; really IS the prefix → banner CANDIDATE
+                                ;; (not yet confirmed; the line might carry
+                                ;; trailing content). Keep the pending blank
+                                ;; held — it stands or falls with this line at
+                                ;; the newline decision.
+                                (and (>= (.length buf) prefix-len)
+                                     (.startsWith s ^String discovery-banner-prefix))
+                                (vreset! state :banner-candidate)
+                                ;; Still a viable prefix of the banner — keep
+                                ;; holding (and keep any pending blank held;
+                                ;; it stands or falls with this line).
+                                (.startsWith ^String discovery-banner-prefix s)
+                                nil
+                                ;; Diverged → this line is not the banner, so
+                                ;; the pending blank preceded real content;
+                                ;; flush it, then forward the diverged run.
+                                :else
+                                (do (flush-pending-blank!)
+                                    (emit! s)
+                                    (.setLength buf 0)
+                                    (vreset! state :passthrough)))))))
         consume-str! (fn [^String s]
                        (dotimes [i (.length s)]
                          (consume-char! (.charAt s i))))]

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
@@ -78,12 +78,24 @@
                          (contains? test-var-syms (symbol ns name)))))))))
 
 (defn execute-cli [{:keys [test-syms help list unknown-args] :as _opts}]
-  ;; Report any unknown args (the pure `cli/parse-args` collects them but
-  ;; does not print — so it can be unit-pinned without leaking a
-  ;; non-summary line on a green run; rf2-spzkgo).  Tolerated, not fatal:
-  ;; parsing continues and valid flags still take effect.
-  (doseq [arg unknown-args]
-    (println (str "Unknown arg: " arg)))
+  ;; Unknown args are a FATAL parse error (rf2-14nojy.1): the pure
+  ;; `cli/parse-args` collects them into `:unknown-args` (without printing,
+  ;; so it can be unit-pinned without leaking a non-summary line on a green
+  ;; run; rf2-spzkgo). Pre-fix `execute-cli` merely PRINTED them and then
+  ;; fell through — so a mistyped focused-run such as the space-separated
+  ;; `--test missing.ns` (both tokens unknown, no `--test=` selector) or a
+  ;; misspelled flag like `--tests=foo` ran NO requested tests, dropped into
+  ;; the `:else` `run-all-tests` branch, and exited GREEN if the full suite
+  ;; was green — a focused-run false green of the same class the
+  ;; `--test=<missing>` guard (rf2-lbo79.1) closes. Reject unknown args here:
+  ;; print them and `js/process.exit` NONZERO before running anything. This
+  ;; runs ahead of `--help`/`--list`, so those stay clean successful
+  ;; non-test commands ONLY when no unknown arg accompanies them.
+  (when (seq unknown-args)
+    (doseq [arg unknown-args]
+      (println (str "Unknown arg: " arg)))
+    (println "Use --help to see known options.")
+    (js/process.exit 1))
   (let [test-env (ct/empty-env)]
     (cond
       help

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -525,6 +525,65 @@
                    " must STILL be swallowed; got:\n" out)))))))
 
 ;; ----------------------------------------------------------------------
+;; Banner-prefix OVERDROP — rf2-14nojy.2.
+;;
+;; The earlier prefix-precision fix (rf2-pjlx6.1) still dropped a line as
+;; soon as it reached the EXACT prefix `Running tests in #{`, swallowing
+;; everything to the newline.  cognitect prints the banner with `println`,
+;; so the real banner is the WHOLE line and stops at the set literal's
+;; closing `}` — but a user/fixture diagnostic that merely SHARES that
+;; prefix and carries trailing content, e.g.
+;; `Running tests in #{:fixture :phase} MARKER`, was silently overdropped
+;; even though it is not the banner.  The fix treats a full-prefix match as
+;; a CANDIDATE and confirms it at the newline: drop only when the remainder
+;; is a balanced set literal followed by nothing but whitespace.  This pins
+;; that the overdrop line now SURVIVES while the real banner stays absent.
+
+(deftest banner-prefix-overdrop-survives
+  (testing "a line starting EXACTLY 'Running tests in #{' with trailing content survives (rf2-14nojy.2)"
+    (with-fixture-dir
+      (fn [dir]
+        (write-fixture! dir "overdrop_fixture_test" "overdrop-fixture-test"
+                        (str "(deftest an-overdrop-test"
+                             " (println \"Running tests in #{:fixture :phase} OVERDROP-MARKER\")"
+                             " (is (= 1 1)))"))
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (zero? exit)
+              (str "the overdrop suite is green; must exit 0; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          ;; The CORE of rf2-14nojy.2: a fixture line sharing the EXACT
+          ;; banner prefix but carrying trailing content after the set
+          ;; literal must NOT be swallowed.
+          (is (str/includes? out "Running tests in #{:fixture :phase} OVERDROP-MARKER")
+              (str "a fixture line that starts exactly 'Running tests in #{'"
+                   " but has trailing content after the set literal is NOT"
+                   " the banner and must survive (rf2-14nojy.2 overdrop);"
+                   " got:\n" out))
+          (is (str/includes? out "0 failures, 0 errors.")
+              (str "the green summary must still print; got:\n" out)))))))
+
+(deftest real-banner-still-dropped-alongside-overdrop-lookalike
+  (testing "the real `Running tests in #{...}` discovery banner is STILL dropped (rf2-14nojy.2 negative control)"
+    (with-fixture-dir
+      (fn [dir]
+        ;; A clean green fixture: the ONLY `Running tests in #{...}` line on
+        ;; stdout would be cognitect's own discovery banner. Proving it is
+        ;; absent confirms the narrowed candidate/confirm logic did not stop
+        ;; dropping the genuine banner while it gained the overdrop guard.
+        (write-fixture! dir "banner_still_dropped_test" "banner-still-dropped-test"
+                        "(deftest a-passing-test (is (= 1 1)))")
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (zero? exit)
+              (str "green suite must exit 0; got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (not (str/includes? out "Running tests in #{"))
+              (str "the genuine `Running tests in #{...}` banner must STILL"
+                   " be swallowed — the overdrop guard must not have made the"
+                   " filter forward the real banner; got:\n" out))
+          (is (not (str/includes? out discovery-banner-marker))
+              (str "no part of the banner may reach stdout; got:\n" out)))))))
+
+;; ----------------------------------------------------------------------
 ;; Unterminated-partial survival across System/exit — rf2-pjlx6.2.
 ;;
 ;; cognitect exits straight from the computed fail/error counts, so the

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -13,7 +13,10 @@
 
    - `--test=` SELECTION: comma-split into symbols, simple symbols are
      namespace selectors and qualified symbols are single-var
-     selectors; `--list` / `--help` flags; unknown args are tolerated.
+     selectors; `--list` / `--help` flags; unknown args are COLLECTED by
+     the pure parser (into `:unknown-args`) and rejected as a fatal parse
+     error by `execute-cli` (rf2-14nojy.1) — the process-level pins below
+     prove that boundary.
    - FAILURE EXIT: the `:end-run-tests` defmethod exits 0 iff the
      summary is `cljs.test/successful?`, 1 otherwise — pinned via the
      predicate the defmethod branches on (calling the defmethod itself
@@ -70,10 +73,12 @@
     (is (= {:test-syms [] :help true} (cli/parse-args ["--help"]))))
   (testing "no args yields the run-all default (empty test-syms, no flags)"
     (is (= {:test-syms []} (cli/parse-args []))))
-  (testing "unknown args are collected (not printed) and do not abort parsing"
+  (testing "unknown args are collected (not printed); the pure parser does not abort"
     ;; The pure parser must NOT print on an unknown arg — it collects
-    ;; them into `:unknown-args` and the real CLI path reports them. This
-    ;; keeps the green-run contract gate truly silent-on-success: a
+    ;; them into `:unknown-args` and the real CLI path (`execute-cli`)
+    ;; reports them and exits NONZERO (rf2-14nojy.1, pinned at the process
+    ;; boundary below). Keeping the PARSER pure-and-silent is what keeps
+    ;; the green-run contract gate truly silent-on-success: a
     ;; `(println \"Unknown arg: ...\")` here would leak a non-summary line
     ;; into every consolidated `npm run test:cljs` run (rf2-spzkgo).
     (is (= {:test-syms '[ok.ns] :unknown-args ["--bogus"]}
@@ -271,22 +276,35 @@
   lines.  `Ran N tests containing M assertions.` / `K failures, J errors.`"
   #"^(Ran \d+ tests containing \d+ assertions\.|\d+ failures, \d+ errors\.)$")
 
+(defn- spawn-runner
+  "Re-spawn the SAME built `out/node-test.js` shadow-node runner this
+  process is executing, with `argv` (a CLJS vector of string args), and
+  return `{:status :stdout :stderr :error}`.
+
+  `process.argv[1]` is the runner script path and `process.argv[0]` the
+  node binary, so this exercises the REAL `shadow-node/main` -> `parse-args`
+  -> `execute-cli` CLI path end-to-end across a process boundary — the only
+  way to observe the `js/process.exit` codes the false-green guards branch
+  on (calling `execute-cli` in-process would tear down this runner)."
+  [argv]
+  (let [self (aget js/process.argv 1)
+        res  (.spawnSync node-child-process
+                         (aget js/process.argv 0) ; the node binary
+                         (apply array self argv)
+                         #js {:encoding "utf8"})]
+    {:status (.-status res)
+     :stdout (or (.-stdout res) "")
+     :stderr (or (.-stderr res) "")
+     ;; cljs.test spawn errors (e.g. ENOENT) surface on res.error.
+     :error  (.-error res)}))
+
 (deftest real-shadow-node-green-run-is-quiet
   (testing "the real out/node-test.js entry point emits ONLY the canonical summary on a focused green run (rf2-spzkgo)"
-    ;; `process.argv[1]` is the path to the runner script THIS process is
-    ;; executing (out/node-test.js) — re-running it focused on the green
-    ;; fixture exercises the real CLI path end-to-end.
-    (let [self     (aget js/process.argv 1)
-          green-ns "re-frame.test-quiet-green-fixture-cljs-test"
-          res      (.spawnSync node-child-process
-                               (aget js/process.argv 0) ; the node binary
-                               #js [self (str "--test=" green-ns)]
-                               #js {:encoding "utf8"})
-          status   (.-status res)
-          stdout   (or (.-stdout res) "")
-          stderr   (or (.-stderr res) "")
-          ;; cljs.test spawn errors (e.g. ENOENT) surface on res.error.
-          err      (.-error res)]
+    ;; Re-running the runner focused on the green fixture exercises the real
+    ;; CLI path end-to-end.
+    (let [green-ns "re-frame.test-quiet-green-fixture-cljs-test"
+          {status :status stdout :stdout stderr :stderr err :error}
+          (spawn-runner [(str "--test=" green-ns)])]
       (is (nil? err)
           (str "spawning the real runner must not error; got: " (pr-str err)))
       (is (zero? status)
@@ -313,3 +331,94 @@
                  stdout))
         (is (some #(re-matches #"0 failures, 0 errors\." %) non-blank)
             (str "the green tally line must be present; got:\n" stdout))))))
+
+;; ----------------------------------------------------------------------
+;; Unknown-arg FALSE-GREEN guard (rf2-14nojy.1) — process-level.
+;;
+;; The pure-parser pins above lock that `parse-args` COLLECTS unknown args
+;; into `:unknown-args` (it no longer prints; rf2-spzkgo).  But the real
+;; FALSE-GREEN lived past the parser, in `execute-cli`: pre-fix it merely
+;; PRINTED the unknowns and then fell through to the `:else`
+;; `run-all-tests` branch whenever no `--test=` selector survived.  A
+;; mistyped focused run — the space-separated `--test missing.ns` (both
+;; tokens unknown, no `--test=` form), or a misspelled flag like
+;; `--tests=foo` — therefore ran the FULL suite and exited GREEN, silently
+;; ignoring the requested selection.  The fix makes unknown args a fatal
+;; parse error: print them and `js/process.exit` NONZERO before running
+;; anything.  These pins drive the REAL runner across a process boundary
+;; (the only place the exit code is observable) and prove the false-green
+;; is closed — with the green-fixture-still-passes negative control that a
+;; correct invocation continues to exit 0.
+
+(deftest unknown-arg-is-fatal-not-false-green
+  (testing "a misspelled selector flag (--tests=...) is fatal, NOT a green full-suite run (rf2-14nojy.1)"
+    ;; `--tests=` (note the typo'd plural) is an unknown arg, not the
+    ;; `--test=` selector. Pre-fix it printed `Unknown arg: --tests=...`
+    ;; then ran the whole suite and exited 0. It must now exit NONZERO.
+    (let [{status :status stdout :stdout stderr :stderr err :error}
+          (spawn-runner ["--tests=re-frame.test-quiet-green-fixture-cljs-test"])]
+      (is (nil? err)
+          (str "spawning the real runner must not error; got: " (pr-str err)))
+      (is (and (number? status) (not (zero? status)))
+          (str "a misspelled selector flag must exit NONZERO (not fall"
+               " through to a green full-suite run); got status " status
+               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
+      (is (str/includes? stdout "Unknown arg: --tests=re-frame.test-quiet-green-fixture-cljs-test")
+          (str "the offending unknown arg must be named; got:\n" stdout))
+      ;; It must NOT have run the suite: no canonical summary line.
+      (is (not (str/includes? stdout "Ran "))
+          (str "the suite must NOT have run on an unknown-arg parse error —"
+               " a `Ran ...` summary means it fell through to run-all-tests"
+               " (the false green); got:\n" stdout))))
+  (testing "space-separated --test <selector> (both tokens unknown) is fatal, NOT a green run (rf2-14nojy.1)"
+    ;; The plausible space-separated form: `--test` and `missing.ns` are
+    ;; BOTH unknown args (the parser only recognises the `--test=` glued
+    ;; form), so no selector survives. Pre-fix this ran the full suite green.
+    (let [{status :status stdout :stdout stderr :stderr err :error}
+          (spawn-runner ["--test" "missing.ns"])]
+      (is (nil? err)
+          (str "spawning the real runner must not error; got: " (pr-str err)))
+      (is (and (number? status) (not (zero? status)))
+          (str "space-separated --test <selector> must exit NONZERO; got "
+               status "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
+      (is (and (str/includes? stdout "Unknown arg: --test")
+               (str/includes? stdout "Unknown arg: missing.ns"))
+          (str "both unknown tokens must be named; got:\n" stdout))
+      (is (not (str/includes? stdout "Ran "))
+          (str "the suite must NOT have run; a `Ran ...` summary means the"
+               " false-green fall-through to run-all-tests; got:\n" stdout))))
+  (testing "a clean focused invocation still exits 0 (negative control)"
+    ;; The guard must reject ONLY malformed args — a correct `--test=`
+    ;; selector against a real green ns must still run and exit 0.
+    (let [{status :status stdout :stdout stderr :stderr err :error}
+          (spawn-runner ["--test=re-frame.test-quiet-green-fixture-cljs-test"])]
+      (is (nil? err)
+          (str "spawning the real runner must not error; got: " (pr-str err)))
+      (is (zero? status)
+          (str "a clean focused run must STILL exit 0 — the guard must not"
+               " reject valid args; got status " status
+               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
+      (is (not (str/includes? stdout "Unknown arg"))
+          (str "a clean invocation must emit no `Unknown arg`; got:\n" stdout)))))
+
+(deftest unmatched-selector-is-fatal-at-real-runner
+  (testing "--test=<missing> (a parsed-but-unmatched selector) exits NONZERO at the REAL runner, not just the pure helper (rf2-lbo79.1 boundary)"
+    ;; The unmatched-selector guard was previously pinned only via the pure
+    ;; `cli/unmatched-selectors` helper. This drives it across the REAL
+    ;; process boundary: a well-formed `--test=` selector that matches NO
+    ;; test var must print the ERROR + exit NONZERO, never a 0-test green.
+    (let [{status :status stdout :stdout stderr :stderr err :error}
+          (spawn-runner ["--test=definitely.absent.namespace"])]
+      (is (nil? err)
+          (str "spawning the real runner must not error; got: " (pr-str err)))
+      (is (and (number? status) (not (zero? status)))
+          (str "an unmatched --test= selector must exit NONZERO (not a"
+               " 0-test green); got status " status
+               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
+      (is (str/includes? stdout "no tests matched --test= selector")
+          (str "the unmatched-selector ERROR must reach stdout; got:\n" stdout))
+      (is (str/includes? stdout "definitely.absent.namespace")
+          (str "the offending selector must be named; got:\n" stdout))
+      (is (not (str/includes? stdout "Ran "))
+          (str "no suite may have run; a `Ran ...` summary is the false"
+               " green; got:\n" stdout)))))


### PR DESCRIPTION
Fixes rf2-14nojy (two correctness-review findings in implementation/test-quiet).

## 1 — CLJS arg false-green (rf2-14nojy.1)
execute-cli printed unknown args then fell through to run-all-tests, so a mistyped focused run (--tests=foo, or space-separated --test missing.ns) ran the whole suite and exited GREEN, silently ignoring the requested selection. Now unknown args are a fatal parse error: print them and process.exit nonzero before running anything. --help/--list stay clean successful non-test commands only when no unknown arg accompanies them. Added process-level pins (real out/node-test.js boundary) for misspelled flags, space-separated --test, and the unmatched --test= selector at the real runner, plus a clean-run negative control.

## 2 — JVM stdout overdrop (rf2-14nojy.2)
The banner filter dropped a line as soon as it reached the exact prefix Running tests in #{, swallowing fixture diagnostics that share the prefix but carry trailing content (e.g. Running tests in #{:fixture} MARKER). Now a full-prefix match is only a CANDIDATE, confirmed at the newline via banner-line-remainder? — dropped only when the remainder is a balanced set literal followed by nothing but whitespace; otherwise the whole line is forwarded. Added a subprocess regression that prints a line starting exactly Running tests in #{ and proves the marker survives while the genuine discovery banner stays absent. Also tightened the watching->candidate transition so a divergence at the prefix boundary (Running tests in #X) forwards rather than drops.

Builds on #3584 (rf2-spzkgo quiet-on-success + pipe-deadlock). Scope confined to implementation/test-quiet.

## Quality gates
- cd implementation && npm run test:cljs — green: Ran 6123 tests containing 21844 assertions. 0 failures, 0 errors. (exit 0)
- test-quiet JVM clojure -M:test — green: Ran 18 tests containing 65 assertions. 0 failures, 0 errors.
- Negative controls (both fixes proven load-bearing): reverting the CLJS guard makes the misspelled-flag run fall through to the full suite (false green); forcing banner-line-remainder? true makes banner-prefix-overdrop-survives fail (marker swallowed) while the real-banner control still passes.