### PR TITLE
test(machines): migrate remaining tests to re-frame.machines.test-support (rf2-kjmtbq)

### DIFF
--- a/implementation/machines/test/re_frame/actor_liveness_test.cljc
+++ b/implementation/machines/test/re_frame/actor_liveness_test.cljc
@@ -29,21 +29,20 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
    [re-frame.frame :as frame]
+   [re-frame.machines.test-support :as mtest]
    [re-frame.registrar :as registrar]
    [re-frame.substrate.adapter :as adapter]
-   [re-frame.test-support :as test-support]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
        :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     #?(:clj  {:adapter plain-atom/adapter}
        :cljs {:adapter reagent-adapter/adapter})))
 
-(defn- snapshot
-  ([machine-id] (snapshot :rf/default machine-id))
-  ([frame-id machine-id]
-   (get-in (rf/runtime-db-value frame-id) [:rf.runtime/machines :snapshots machine-id])))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (defn- registrar-event-snapshot
   "A value-snapshot of every registered :event id — the bit we assert is

--- a/implementation/machines/test/re_frame/after_delay_validation_test.clj
+++ b/implementation/machines/test/re_frame/after_delay_validation_test.clj
@@ -16,11 +16,11 @@
   `re-frame.after-test`)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- registration-throws?
   "Try registering `machine` under `machine-id`. Returns the

--- a/implementation/machines/test/re_frame/birth_always_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/birth_always_cljs_test.cljc
@@ -42,9 +42,9 @@
    [re-frame.core :as rf]
    [re-frame.machines.parallel :as parallel]
    [re-frame.machines.result :as result]
+   [re-frame.machines.test-support :as mtest]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate-adapter]
-      :cljs [re-frame.adapter.reagent :as substrate-adapter])
-   [re-frame.test-support :as test-support]))
+      :cljs [re-frame.adapter.reagent :as substrate-adapter])))
 
 ;; ===========================================================================
 ;; PURE — birth eventless settle via `apply-initial-entry-cascade`
@@ -286,12 +286,11 @@
 ;; ===========================================================================
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter substrate-adapter/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter substrate-adapter/adapter}))
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (deftest live-eager-start-settles-birth-always
   (testing "(a) eager `[:rf.machine/start]` — a transient initial leaf whose

--- a/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
+++ b/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
@@ -40,14 +40,15 @@
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]
             [re-frame.machines.parallel :as parallel]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(defn- snapshot [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 ;; ---- (a) region guard reads a sibling region's tag ------------------------
 

--- a/implementation/machines/test/re_frame/destroy_exit_cascade_test.clj
+++ b/implementation/machines/test/re_frame/destroy_exit_cascade_test.clj
@@ -30,11 +30,11 @@
       reading the db between `:exit` and `:rf.machine/destroyed`)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- (1) explicit [:rf.machine/destroy actor-id] -------------------------
 

--- a/implementation/machines/test/re_frame/destroy_silent_idempotent_test.cljc
+++ b/implementation/machines/test/re_frame/destroy_silent_idempotent_test.cljc
@@ -33,23 +33,28 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
+   [re-frame.machines.test-support :as mtest]
    ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`
    ;; (production-DCE split).
    [re-frame.trace.tooling :as trace-tooling]
    [re-frame.registrar :as registrar]
-   [re-frame.test-support :as test-support]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
        :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     #?(:clj  {:adapter plain-atom/adapter}
        :cljs {:adapter reagent-adapter/adapter})))
 
-(defn- snapshot
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
+;; Intentional RAW register-only listener (not mtest/with-trace-capture):
+;; returns the live capture atom for the caller to read across multiple
+;; macrosteps; the per-test fixture reset clears the listener table — a fresh
+;; capture scope per call would lose the cross-step accumulation the silent-
+;; idempotent tests assert on.
 (defn- record-traces!
   [k]
   (let [a (atom [])]

--- a/implementation/machines/test/re_frame/destroyed_exit_order_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_exit_order_test.clj
@@ -25,13 +25,18 @@
   the observable ordering."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
+;; `record-order!` intentionally uses a RAW listener (not
+;; `mtest/with-trace-capture`): it conjes its `:destroyed` sentinel onto the
+;; SAME caller-supplied ordering log the machine `:exit` action writes to, so
+;; the interleaved marker order is the observable — a fresh capture atom
+;; could not share that log.
 (defn- record-order!
   "Register a `:rf.machine/destroyed` listener that conjes `:destroyed`
   onto `log`; returns an unregister thunk."

--- a/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_trace_shape_test.clj
@@ -35,12 +35,12 @@
       those slots (no nil-stamping)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; Canonical key-set that the destroyed-trace emission sites are
 ;; responsible for assembling. The trace framework auto-stamps
@@ -59,6 +59,11 @@
 (defn- destroyed-traces [captured]
   (filter #(= :rf.machine/destroyed (:operation %)) @captured))
 
+;; Intentional RAW manual-stop listener (not mtest/with-trace-capture): this
+;; is the destroyed-trace SHAPE probe — it returns a [capture-atom
+;; unregister-fn] pair so a test can inspect the raw envelope key-set and
+;; control exactly when it stops capturing (the scope-macro form cannot
+;; express the manual-stop). Per rf2-kjmtbq this site is left as raw by design.
 (defn- record!
   []
   (let [a  (atom [])

--- a/implementation/machines/test/re_frame/dispatch_to_system_fx_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/dispatch_to_system_fx_cljs_test.cljc
@@ -37,17 +37,18 @@
    ;; late-bind registry so `rf/reg-machine` resolves AND registers the
    ;; `:rf.machine/dispatch-to-system` fx under test.
    [re-frame.machines]
-   [re-frame.test-support :as test-support]
+   [re-frame.machines.test-support :as mtest]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
        :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     #?(:clj  {:adapter plain-atom/adapter}
        :cljs {:adapter reagent-adapter/adapter})))
 
-(defn- snapshot [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (deftest dispatch-to-system-fx-reaches-spawned-actor
   (testing "a machine action's [:rf.machine/dispatch-to-system [<sys> [:msg]]]

--- a/implementation/machines/test/re_frame/done_signal_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/done_signal_cljs_test.cljc
@@ -26,19 +26,20 @@
    ;; late-bind registry so `rf/reg-machine` resolves (mirrors
    ;; `final_state_cljs_test`).
    [re-frame.machines]
+   [re-frame.machines.test-support :as mtest]
    [re-frame.trace.tooling :as trace-tooling]
    [re-frame.registrar :as registrar]
-   [re-frame.test-support :as test-support]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
        :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     #?(:clj  {:adapter plain-atom/adapter}
        :cljs {:adapter reagent-adapter/adapter})))
 
-(defn- snapshot [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (defn- record-traces! [k]
   (let [a (atom [])]

--- a/implementation/machines/test/re_frame/dropped_snapshot_diagnostic_test.clj
+++ b/implementation/machines/test/re_frame/dropped_snapshot_diagnostic_test.clj
@@ -24,12 +24,16 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.machines :as machines]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]
             [re-frame.trace.tooling]))
 
+;; This ns keeps a bespoke reset-runtime fixture (it ALSO clears listeners
+;; and reloads the machines ns) rather than reusing the shared
+;; make-reset-runtime-fixture.
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
@@ -48,20 +52,19 @@
    :states  {:off {:on {:flip :on}}
              :on  {:on {:flip :off}}}})
 
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4).
 (defn- live-snapshot?
   [machine-id]
-  (some? (get-in (rf/runtime-db-value :rf/default)
-                 [:rf.runtime/machines :snapshots machine-id])))
+  (some? (mtest/snapshot machine-id)))
 
 (defn- with-recorder
   "Register a recorder, run `body-fn`, return captured
-  :rf.warning/runtime-state-dropped events."
+  :rf.warning/runtime-state-dropped events. Routed through the shared
+  `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
+  unregister in a `finally`."
   [body-fn]
-  (let [recorded (atom [])
-        id       (gensym "dropped-snap-rec")]
-    (trace/register-listener! id (fn [ev] (swap! recorded conj ev)))
-    (try (body-fn)
-         (finally (trace/unregister-listener! id)))
+  (mtest/with-trace-capture recorded
+    (body-fn)
     (->> @recorded
          (filter #(= :rf.warning/runtime-state-dropped (:operation %)))
          vec)))

--- a/implementation/machines/test/re_frame/final_state_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/final_state_cljs_test.cljc
@@ -34,19 +34,19 @@
    ;; tooling sibling must be referenced directly.
    [re-frame.trace.tooling :as trace-tooling]
    [re-frame.machines :as machines]
+   [re-frame.machines.test-support :as mtest]
    [re-frame.registrar :as registrar]
-   [re-frame.test-support :as test-support]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
        :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     #?(:clj  {:adapter plain-atom/adapter}
        :cljs {:adapter reagent-adapter/adapter})))
 
-(defn- snapshot
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (defn- traces-for
   [traces operation]

--- a/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
+++ b/implementation/machines/test/re_frame/frame_destroy_cascade_test.clj
@@ -29,12 +29,12 @@
             ;; when the test ns doesn't reach `machines/...` directly.
             [re-frame.machines]
             [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- spawn-order channel — record / forget / clear ----------------------
 
@@ -166,8 +166,7 @@
 (deftest frame-destroy-emits-lifecycle-trace-per-active-machine
   (testing "destroy-frame! emits :rf.machine.lifecycle/destroyed per active actor with :reason :parent-frame-destroyed"
     (rf/reg-frame :lt/auth {:doc "lifecycle-trace frame"})
-    (let [traces (atom [])
-          child  {:initial :running :data {} :states {:running {}}}
+    (let [child  {:initial :running :data {} :states {:running {}}}
           boot   {:initial :idle
                   :data    {}
                   :states
@@ -181,22 +180,23 @@
       (rf/reg-machine :lt/child child)
       (rf/reg-machine :lt/boot boot)
       (rf/dispatch-sync [:lt/boot [:start]] {:frame :lt/auth})
-      (rf/register-listener! ::lt (fn [ev] (swap! traces conj ev)))
-      (rf/destroy-frame! :lt/auth)
-      (rf/unregister-listener! ::lt)
-      (let [destroyed (filter #(= :rf.machine.lifecycle/destroyed (:operation %))
-                              @traces)]
-        ;; Two spawned actors PLUS the singleton :lt/boot snapshot
-        ;; that lives in [:rf.runtime/machines :snapshots] of this frame — three traces.
-        (is (= 3 (count destroyed))
-            "one trace per actor with a [:rf.runtime/machines :snapshots <id>] snapshot")
-        (is (every? #(= :parent-frame-destroyed (:reason (:tags %))) destroyed)
-            "every trace carries :reason :parent-frame-destroyed")
-        (is (every? #(= :lt/auth (:frame (:tags %))) destroyed)
-            "every trace carries the destroyed frame id")
-        (is (= #{:lt/child#1 :lt/child#2 :lt/boot}
-               (set (map #(:machine-id (:tags %)) destroyed)))
-            "trace covers every active machine — spawned actors + the singleton boot machine")))))
+      ;; Shared `with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
+      ;; unregister in a `finally`.
+      (mtest/with-trace-capture traces
+        (rf/destroy-frame! :lt/auth)
+        (let [destroyed (filter #(= :rf.machine.lifecycle/destroyed (:operation %))
+                                @traces)]
+          ;; Two spawned actors PLUS the singleton :lt/boot snapshot
+          ;; that lives in [:rf.runtime/machines :snapshots] of this frame — three traces.
+          (is (= 3 (count destroyed))
+              "one trace per actor with a [:rf.runtime/machines :snapshots <id>] snapshot")
+          (is (every? #(= :parent-frame-destroyed (:reason (:tags %))) destroyed)
+              "every trace carries :reason :parent-frame-destroyed")
+          (is (every? #(= :lt/auth (:frame (:tags %))) destroyed)
+              "every trace carries the destroyed frame id")
+          (is (= #{:lt/child#1 :lt/child#2 :lt/boot}
+                 (set (map #(:machine-id (:tags %)) destroyed)))
+              "trace covers every active machine — spawned actors + the singleton boot machine"))))))
 
 ;; ---- HTTP abort preserved for every active actor -------------------------
 

--- a/implementation/machines/test/re_frame/frozen_region_select_test.clj
+++ b/implementation/machines/test/re_frame/frozen_region_select_test.clj
@@ -36,14 +36,15 @@
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]
             [re-frame.machines.parallel :as parallel]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(defn- snapshot [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 ;; ---- (1) :data write in A is NOT visible to B's same-event guard -----------
 ;;

--- a/implementation/machines/test/re_frame/grammar_parity_test.clj
+++ b/implementation/machines/test/re_frame/grammar_parity_test.clj
@@ -27,12 +27,12 @@
             [re-frame.machines :as machines]
             [re-frame.machines.grammar :as grammar]
             [re-frame.machines.result :as result]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.machines.transition :as transition]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- registration-error-id
   "Register `machine` and return the thrown `:rf.error/id` discriminator,

--- a/implementation/machines/test/re_frame/guard_action_traces_test.clj
+++ b/implementation/machines/test/re_frame/guard_action_traces_test.clj
@@ -33,21 +33,20 @@
       `:outcome :rf.error/action-threw` AND carries the exception"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- record-traces!
   "Register a trace listener for the duration of `body-fn`, returning
-  the captured trace vec."
+  the captured trace vec. Routed through the shared
+  `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
+  unregister in a `finally`."
   [body-fn]
-  (let [seen (atom [])]
-    (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
-    (try (body-fn)
-         (finally (rf/unregister-listener! ::rec)))
+  (mtest/with-trace-capture seen
+    (body-fn)
     @seen))
 
 (defn- ops [evs op]

--- a/implementation/machines/test/re_frame/initial_entry_test.clj
+++ b/implementation/machines/test/re_frame/initial_entry_test.clj
@@ -30,16 +30,16 @@
       shallowest-first (per Spec 005 §Initial cascading)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(defn- snapshot
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 ;; ---- (1) singleton-machine initial :entry firing -------------------------
 

--- a/implementation/machines/test/re_frame/initial_snapshot_unification_test.clj
+++ b/implementation/machines/test/re_frame/initial_snapshot_unification_test.clj
@@ -24,9 +24,14 @@
             [re-frame.frame :as frame]
             [re-frame.machines :as machines]
             [re-frame.machines.parallel :as parallel]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
+;; This ns keeps a bespoke reset-runtime fixture (clear-all! + frame reset +
+;; machines :reload + reset-timers!) — it exercises registration-time
+;; snapshot unification, so it deliberately reloads the machines ns rather
+;; than reusing the shared make-reset-runtime-fixture.
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
   (reset! frame/frames {})
@@ -37,10 +42,9 @@
 
 (use-fixtures :each reset-runtime)
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 ;; ---- (1) `parallel/build-initial-snapshot` unit contract -------------------
 ;;

--- a/implementation/machines/test/re_frame/lifecycle_composed_corners_test.clj
+++ b/implementation/machines/test/re_frame/lifecycle_composed_corners_test.clj
@@ -26,17 +26,20 @@
             [re-frame.frame :as frame]
             [re-frame.machines]
             [re-frame.machines.spawn-order :as spawn-order]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.machines.timer :as timer]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- helpers --------------------------------------------------------------
 
+;; Intentional RAW manual-stop listener (not mtest/with-trace-capture): hands
+;; the caller a [observation-atom unregister-fn] pair so the test controls
+;; exactly WHEN it stops listening — the scope-macro form cannot express that.
 (defn- record!
   "Attach a trace listener and return [observation-atom unreg-fn]."
   [id]

--- a/implementation/machines/test/re_frame/machine_actor_concurrency_stress_test.clj
+++ b/implementation/machines/test/re_frame/machine_actor_concurrency_stress_test.clj
@@ -86,13 +86,13 @@
             ;; first `rf/reg-machine` call would otherwise raise
             ;; `:rf.error/machines-artefact-missing`.
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support])
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom])
   (:import [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicLong]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; Per-thread iteration count. Kept at the rf2-ynk7 / rf2-35rgj standard
 ;; 5000 so CI stays under ~60s wall-clock with the default thread count.

--- a/implementation/machines/test/re_frame/machine_cascade_instrumentation_test.cljc
+++ b/implementation/machines/test/re_frame/machine_cascade_instrumentation_test.cljc
@@ -29,17 +29,17 @@
   this bead removes the need for it)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
+;; Routed through the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4)
+;; — guaranteed unregister in a `finally`.
 (defn- record-traces! [body-fn]
-  (let [seen (atom [])]
-    (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
-    (try (body-fn) (finally (rf/unregister-listener! ::rec)))
+  (mtest/with-trace-capture seen
+    (body-fn)
     @seen))
 
 (defn- ops [evs op] (filterv #(= op (:operation %)) evs))

--- a/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
+++ b/implementation/machines/test/re_frame/machine_data_schema_redaction_test.clj
@@ -40,13 +40,13 @@
             ;; late-bind (`extract-sensitive-paths-from-schema` /
             ;; `extract-large-paths-from-schema`); the `.malli` adapter ns
             ;; publishes the default validator.
+            [re-frame.machines.test-support :as mtest]
             [re-frame.schemas]
             [re-frame.schemas.malli]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- fixtures -------------------------------------------------------------
 
@@ -410,8 +410,8 @@
 
 (def ^:private spawn-type-id :rf.machine-redaction/spawn-worker)
 
-(defn- frame-db []
-  (rf/runtime-db-value :rf/default))
+;; runtime-db lookup via the shared machines test-support (rf2-3l8lqe finding #4).
+(def ^:private frame-db mtest/runtime-db)
 
 (deftest spawned-instance-gets-schema-marks-keyed-under-instance-id
   (testing "spawning an actor whose TYPE carries a :sensitive? / :large?

--- a/implementation/machines/test/re_frame/machine_front_of_queue_test.cljc
+++ b/implementation/machines/test/re_frame/machine_front_of_queue_test.cljc
@@ -20,11 +20,11 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (def ^:private run-log (atom []))
 

--- a/implementation/machines/test/re_frame/machine_history_smoke_test.clj
+++ b/implementation/machines/test/re_frame/machine_history_smoke_test.clj
@@ -30,30 +30,23 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.test-support :as mtest]))
 
 ;; ---- trace capture (spec/009 shape proof) --------------------------------
+;;
+;; Trace capture via the shared machines test-support (rf2-3l8lqe finding #4):
+;; the `:each` `trace-capture-fixture` feeds `mtest/*captured*` with guaranteed
+;; unregister in a `finally`; `events-of` / `reset-captured!` read + clear it.
 
-(def ^:dynamic *captured* nil)
-
-(defn- capture-fixture
-  "Register a trace listener that appends every emitted event to `*captured*`
-  for the duration of one test, then unregisters."
-  [f]
-  (binding [*captured* (atom [])]
-    (trace/register-listener! ::history-smoke #(swap! *captured* conj %))
-    (try (f)
-      (finally (trace/unregister-listener! ::history-smoke)))))
-
-(use-fixtures :each capture-fixture)
+(use-fixtures :each mtest/trace-capture-fixture)
 
 (defn- history-events
   "The captured events for the given history `operation`
   (`:rf.machine.history/restored` | `:rf.machine.history/recorded`)."
   [operation]
-  (filterv #(= operation (:operation %)) @*captured*))
+  (mtest/events-of operation))
 
-(defn- reset-capture! [] (reset! *captured* []))
+(defn- reset-capture! [] (mtest/reset-captured!))
 
 (defn- step
   "Apply one macrostep and return the post-transition snapshot. Asserts the

--- a/implementation/machines/test/re_frame/machine_noop_signal_test.clj
+++ b/implementation/machines/test/re_frame/machine_noop_signal_test.clj
@@ -32,17 +32,17 @@
             ;; throws `:rf.error/machines-artefact-missing` when run in
             ;; isolation via `-n`).
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
+;; Routed through the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4)
+;; — guaranteed unregister in a `finally`.
 (defn- record-traces! [body-fn]
-  (let [seen (atom [])]
-    (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
-    (try (body-fn) (finally (rf/unregister-listener! ::rec)))
+  (mtest/with-trace-capture seen
+    (body-fn)
     @seen))
 
 (defn- ops [evs op] (filterv #(= op (:operation %)) evs))

--- a/implementation/machines/test/re_frame/machine_pure_error_contract_test.clj
+++ b/implementation/machines/test/re_frame/machine_pure_error_contract_test.clj
@@ -52,8 +52,8 @@
             [re-frame.machines :as machines]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.result :as result]
-            [re-frame.machines.transition :as transition]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.machines.transition :as transition]))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-ugdas + rf2-t4582 — the BENIGN unhandled-event no-op (xstate-v5
@@ -71,13 +71,12 @@
 (defn- capture-events!
   "Drive a pure `machine-transition` while a tooling listener records every
   emitted trace event (full envelope). Returns the vector of events
-  (deterministic — no wall-clock / random)."
+  (deterministic — no wall-clock / random). Routed through the shared
+  `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed unregister
+  in a `finally`."
   [definition snapshot event]
-  (let [seen (atom [])]
-    (trace/register-listener! ::ops (fn [ev] (swap! seen conj ev)))
-    (try
-      (machines/machine-transition definition snapshot event)
-      (finally (trace/unregister-listener! ::ops)))
+  (mtest/with-trace-capture seen
+    (machines/machine-transition definition snapshot event)
     @seen))
 
 (defn- capture-ops!
@@ -178,25 +177,25 @@
   (testing "the initial-entry cascade emits the :initial-entry-phase action-ran
    and installs the initial state — NOT an unhandled-no-op for
    [:rf.machine/start]"
-    (let [seen (atom [])
-          _    (trace/register-listener! ::boot (fn [ev] (swap! seen conj ev)))
-          r    (try (parallel/apply-initial-entry-cascade
-                      boot-entry-spec {:state :a :data {}})
-                    (finally (trace/unregister-listener! ::boot)))
-          evs  @seen
-          ops  (mapv :operation evs)
-          no-op-evs (filter #(= :rf.machine.event/unhandled-no-op %) ops)
-          entry-evs (filter #(and (= :rf.machine/action-ran (:operation %))
-                                  (= :initial-entry (:phase (:tags %))))
-                            evs)]
-      (is (result/ok? r) "the bootstrap cascade succeeds")
-      (is (= :a (:state (::result/snap r))) "the initial state is installed")
-      (is (zero? (count no-op-evs))
-          "the bootstrap does NOT emit an unhandled-no-op (it is the machine's
-           BIRTH, not an ignored event)")
-      (is (pos? (count entry-evs))
-          "the entry action ran with :phase :initial-entry — the :initial-entry
-           cascade rendered"))))
+    ;; Shared `with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
+    ;; unregister in a `finally`.
+    (mtest/with-trace-capture seen
+      (let [r    (parallel/apply-initial-entry-cascade
+                   boot-entry-spec {:state :a :data {}})
+            evs  @seen
+            ops  (mapv :operation evs)
+            no-op-evs (filter #(= :rf.machine.event/unhandled-no-op %) ops)
+            entry-evs (filter #(and (= :rf.machine/action-ran (:operation %))
+                                    (= :initial-entry (:phase (:tags %))))
+                              evs)]
+        (is (result/ok? r) "the bootstrap cascade succeeds")
+        (is (= :a (:state (::result/snap r))) "the initial state is installed")
+        (is (zero? (count no-op-evs))
+            "the bootstrap does NOT emit an unhandled-no-op (it is the machine's
+             BIRTH, not an ignored event)")
+        (is (pos? (count entry-evs))
+            "the entry action ran with :phase :initial-entry — the :initial-entry
+             cascade rendered")))))
 
 ;; ---------------------------------------------------------------------------
 ;; :rf.error/machine-bad-state-form — state-path throws on a malformed

--- a/implementation/machines/test/re_frame/machine_remediation_ee38b_test.clj
+++ b/implementation/machines/test/re_frame/machine_remediation_ee38b_test.clj
@@ -32,17 +32,17 @@
             [re-frame.core :as rf]
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
+;; Routed through the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4)
+;; — guaranteed unregister in a `finally`.
 (defn- record-traces! [body-fn]
-  (let [seen (atom [])]
-    (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
-    (try (body-fn) (finally (rf/unregister-listener! ::rec)))
+  (mtest/with-trace-capture seen
+    (body-fn)
     @seen))
 
 (defn- ops [evs op] (filterv #(= op (:operation %)) evs))

--- a/implementation/machines/test/re_frame/machine_schema_test.clj
+++ b/implementation/machines/test/re_frame/machine_schema_test.clj
@@ -39,22 +39,22 @@
             ;; path the new `:where :machine-data` boundary routes
             ;; through; the `.malli` adapter ns publishes Malli's
             ;; validate/explain into the late-bind table.
+            [re-frame.machines.test-support :as mtest]
             [re-frame.schemas]
             [re-frame.schemas.malli]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- collect-traces!
   "Run `f` while collecting every `:rf.error/schema-validation-failure`
-  trace event. Returns the captured trace events as a vector."
+  trace event. Returns the captured trace events as a vector. Routed through
+  the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
+  unregister in a `finally`."
   [f]
-  (let [traces (atom [])]
-    (rf/register-listener! ::collect (fn [ev] (swap! traces conj ev)))
-    (try (f)
-         (finally (rf/unregister-listener! ::collect)))
+  (mtest/with-trace-capture traces
+    (f)
     (filterv #(= :rf.error/schema-validation-failure (:operation %))
              @traces)))
 

--- a/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machine_source_coord_cljs_test.cljs
@@ -25,10 +25,10 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
 (defn- element-coords [machine-id slot id]

--- a/implementation/machines/test/re_frame/machine_source_coord_test.clj
+++ b/implementation/machines/test/re_frame/machine_source_coord_test.clj
@@ -37,11 +37,11 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; Helper: read a co-located element entry's source-coords off a
 ;; registered machine. `slot` is :guards / :actions / :on-spawn-actions.

--- a/implementation/machines/test/re_frame/machine_trace_frame_tag_sweep_test.clj
+++ b/implementation/machines/test/re_frame/machine_trace_frame_tag_sweep_test.clj
@@ -31,23 +31,22 @@
   notice the absent trace events."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
 (defn- record-traces!
   "Register a trace listener for the duration of `body-fn`, returning
-  the captured trace vec."
+  the captured trace vec. Routed through the shared
+  `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed unregister
+  in a `finally`."
   [body-fn]
-  (let [seen (atom [])]
-    (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
-    (try (body-fn)
-         (finally (rf/unregister-listener! ::rec)))
+  (mtest/with-trace-capture seen
+    (body-fn)
     @seen))
 
 (defn- of-op [evs op]

--- a/implementation/machines/test/re_frame/machine_transition_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_purity_test.clj
@@ -52,6 +52,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.trace :as trace]))
 
 (def auth-flow-spec
@@ -164,6 +165,11 @@
           r-no-listener (machines/machine-transition m input [:go])
           ;; A listener registered: same call, listener observes the
           ;; emitted diagnostics; assert the RETURNED Result is unchanged.
+          ;; Intentional RAW register/unregister (not mtest/with-trace-capture):
+          ;; this test's whole point is to compare the reduction WITH a raw
+          ;; listener present vs WITHOUT one, binding `r-with-listener` from the
+          ;; guarded call and reading `@seen` in the surrounding `let` — the
+          ;; scope-macro form cannot express the with/without comparison.
           seen          (atom [])
           r-with-listener
           (do (trace/register-listener! ::purity-probe (fn [ev] (swap! seen conj ev)))
@@ -250,13 +256,12 @@
 (defn- capture-error-depth!
   "Drive a pure `machine-transition` while a tooling listener records traces,
   returning the `:depth` tag of the first error trace whose `:operation`
-  matches `error-op` (or nil if none fired)."
+  matches `error-op` (or nil if none fired). Routed through the shared
+  `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed unregister
+  in a `finally`."
   [error-op definition snapshot event]
-  (let [seen (atom [])]
-    (trace/register-listener! ::depth-probe (fn [ev] (swap! seen conj ev)))
-    (try
-      (machines/machine-transition definition snapshot event)
-      (finally (trace/unregister-listener! ::depth-probe)))
+  (mtest/with-trace-capture seen
+    (machines/machine-transition definition snapshot event)
     (->> @seen
          (filter #(= error-op (:operation %)))
          first

--- a/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj
@@ -25,19 +25,18 @@
   JVM-only — the dynamic-var binding is platform-agnostic."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
+;; Routed through the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4)
+;; — guaranteed unregister in a `finally`.
 (defn- record-traces
   [body-fn]
-  (let [seen (atom [])]
-    (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
-    (try (body-fn)
-         (finally (rf/unregister-listener! ::rec)))
+  (mtest/with-trace-capture seen
+    (body-fn)
     @seen))
 
 (defn- transitions-of [evs]

--- a/implementation/machines/test/re_frame/machines_after_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_after_cljs_test.cljs
@@ -26,16 +26,16 @@
             ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path. Inline trace
+;; captures below keep their raw trace.tooling register/unregister.
+(def ^:private snapshot mtest/snapshot)
 
 (deftest machine-after-cljs
   (testing ":after schedules with current epoch on entry; fires on synthetic timer event"

--- a/implementation/machines/test/re_frame/machines_always_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_always_cljs_test.cljs
@@ -13,16 +13,16 @@
             ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path. Inline trace
+;; captures below keep their raw trace.tooling register/unregister.
+(def ^:private snapshot mtest/snapshot)
 
 (deftest machine-always-cljs
   (testing ":always fires once after the resolving event under a true guard"

--- a/implementation/machines/test/re_frame/machines_forbidden_transition_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_forbidden_transition_cljs_test.cljs
@@ -28,16 +28,15 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (defn- seed-snapshot!
   "Force the snapshot for `machine-id` to a known value via an event-db so a

--- a/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
@@ -19,16 +19,15 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (defn- seed-snapshot!
   "Force the snapshot for `machine-id` to a known value via an event-db.

--- a/implementation/machines/test/re_frame/machines_initial_cascade_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_initial_cascade_cljs_test.cljs
@@ -9,16 +9,15 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (deftest machine-initial-cascade-on-first-dispatch
   (testing "compound :initial chain descends to a leaf on first-dispatch snapshot synthesis (rf2-m1tv)"

--- a/implementation/machines/test/re_frame/machines_ns_wildcard_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_ns_wildcard_cljs_test.cljs
@@ -18,16 +18,15 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (defn- seed-snapshot!
   "Force the snapshot for `machine-id` to a known value via an event-db, so

--- a/implementation/machines/test/re_frame/machines_on_error_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machines_on_error_cljs_test.cljc
@@ -49,19 +49,19 @@
    ;; resolves through (without it, `rf/reg-machine` throws
    ;; `:rf.error/machines-artefact-missing`).
    [re-frame.machines]
+   [re-frame.machines.test-support :as mtest]
    [re-frame.trace.tooling :as trace-tooling]
-   [re-frame.test-support :as test-support]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
        :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     #?(:clj  {:adapter plain-atom/adapter}
        :cljs {:adapter reagent-adapter/adapter})))
 
-(defn- snapshot
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (defn- spawned-id-for
   [parent-id invoke-id]

--- a/implementation/machines/test/re_frame/machines_raise_chain_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_raise_chain_cljs_test.cljs
@@ -17,16 +17,15 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (deftest machine-raise-chain-cljs
   (testing "an action's [:raise <event>] re-enters machine-transition and fires the chained transition (rf2-c0nt)"

--- a/implementation/machines/test/re_frame/machines_spawn_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_spawn_cljs_test.cljs
@@ -32,16 +32,18 @@
             ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path. The per-section
+;; trace captures below keep their raw trace.tooling register/unregister: they
+;; reset and re-scope the capture mid-test (interleaved with assertions), which
+;; the scope-macro / :each-fixture forms cannot express.
+(def ^:private snapshot mtest/snapshot)
 
 (deftest machine-spawn-cljs
   (testing ":spawn spawns child on entry and destroys it on exit"

--- a/implementation/machines/test/re_frame/machines_system_id_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_system_id_cljs_test.cljs
@@ -18,10 +18,10 @@
             ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
 (deftest machine-system-id-cljs

--- a/implementation/machines/test/re_frame/machines_tags_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_tags_cljs_test.cljs
@@ -19,16 +19,15 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (deftest machine-tags-flat-active-state-cljs
   (testing "flat machine — snapshot's :tags is the active state's tag set"

--- a/implementation/machines/test/re_frame/machines_wildcard_fallthrough_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_wildcard_fallthrough_cljs_test.cljs
@@ -21,16 +21,15 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture
+  (mtest/make-reset-runtime-fixture
     {:adapter reagent-adapter/adapter}))
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 (defn- seed-snapshot!
   "Force the snapshot for `machine-id` to a known value via an event-db, so

--- a/implementation/machines/test/re_frame/nested_validation_test.clj
+++ b/implementation/machines/test/re_frame/nested_validation_test.clj
@@ -24,11 +24,11 @@
   unambiguous."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (defn- registration-throws?
   "Try registering `machine` under `machine-id`. Returns the

--- a/implementation/machines/test/re_frame/parallel_region_runtime_overlay_test.clj
+++ b/implementation/machines/test/re_frame/parallel_region_runtime_overlay_test.clj
@@ -32,7 +32,7 @@
             [re-frame.core :as rf]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.result :as result]
-            [re-frame.trace]))
+            [re-frame.machines.test-support :as mtest]))
 
 ;; ---- helpers ---------------------------------------------------------------
 
@@ -40,11 +40,11 @@
   "Register a trace listener for the duration of `body-fn`; return the
   captured trace vec. (`trace/emit!` delivers to listeners synchronously,
   so a PURE `machine-transition` call surfaces its traces here without a
-  dispatch cycle.)"
+  dispatch cycle.) Routed through the shared `mtest/with-trace-capture`
+  (rf2-3l8lqe finding #4) — guaranteed unregister in a `finally`."
   [body-fn]
-  (let [seen (atom [])]
-    (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
-    (try (body-fn) (finally (rf/unregister-listener! ::rec)))
+  (mtest/with-trace-capture seen
+    (body-fn)
     @seen))
 
 (defn- of-op [evs op] (filterv #(= op (:operation %)) evs))

--- a/implementation/machines/test/re_frame/parallel_root_on_test.clj
+++ b/implementation/machines/test/re_frame/parallel_root_on_test.clj
@@ -31,14 +31,15 @@
             [re-frame.core :as rf]
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(defn- snapshot [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 ;; A two-region machine. Each region: :one -> :two on :go. No region handles
 ;; :all (only the root will). Used by several cases.

--- a/implementation/machines/test/re_frame/parallel_test.clj
+++ b/implementation/machines/test/re_frame/parallel_test.clj
@@ -32,14 +32,15 @@
             [re-frame.core :as rf]
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(defn- snapshot [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 ;; ---- 1. flat two-region parallel machine — initial state map ------------
 

--- a/implementation/machines/test/re_frame/spawn_data_fn_form_test.clj
+++ b/implementation/machines/test/re_frame/spawn_data_fn_form_test.clj
@@ -26,19 +26,16 @@
   the same fn-form per Spec 005 §Spec-spec keys (line 1818)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(defn- snapshot
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
-
-(defn- frame-db []
-  (rf/runtime-db-value :rf/default))
+;; runtime-db / snapshot lookup via the shared machines test-support
+;; (rf2-3l8lqe finding #4) — no hardcoded `[:rf.runtime/machines …]` path.
+(def ^:private snapshot mtest/snapshot)
+(def ^:private frame-db mtest/runtime-db)
 
 ;; ---- (1) literal-map :data — back-compat regression -----------------------
 
@@ -135,8 +132,7 @@
 
 (deftest fn-form-data-throw-routes-to-machine-action-exception
   (testing "fn-form `:data` throw halts the cascade and emits :rf.error/machine-action-exception (Spec 005:1597)"
-    (let [traces (atom [])
-          child  {:initial :running :data {} :states {:running {}}}
+    (let [child  {:initial :running :data {} :states {:running {}}}
           parent {:initial :idle
                   :states
                   {:idle    {:on {:start :working}}
@@ -145,9 +141,9 @@
                                                     (throw (ex-info "boom" {:why :test})))}}}}]
       (rf/reg-machine :worker/proc child)
       (rf/reg-machine :sup/throwing parent)
-      (try
-        (trace/register-listener! ::h131-error
-                                  (fn [ev] (swap! traces conj ev)))
+      ;; Shared `with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
+      ;; unregister in a `finally`, no hand-rolled register/try/finally.
+      (mtest/with-trace-capture traces
         (rf/dispatch-sync [:sup/throwing [:start]])
         ;; The cascade halted: no actor was spawned. Per Spec 005 §Errors,
         ;; the snapshot does NOT commit — the parent's lazy initial snapshot
@@ -163,8 +159,7 @@
         (is (some #(and (= :error (:op-type %))
                         (= :rf.error/machine-action-exception (:operation %)))
                   @traces)
-            "an :rf.error/machine-action-exception trace was emitted")
-        (finally (trace/unregister-listener! ::h131-error))))))
+            "an :rf.error/machine-action-exception trace was emitted")))))
 
 ;; ---- (5) :spawn-all child :data fn-form is materialised ------------------
 

--- a/implementation/machines/test/re_frame/spawn_on_spawn_throw_test.clj
+++ b/implementation/machines/test/re_frame/spawn_on_spawn_throw_test.clj
@@ -27,28 +27,27 @@
   the full lifecycle handler (the path where the bug surfaced)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(defn- snapshot
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default)
-          [:rf.runtime/machines :snapshots machine-id]))
-
-(defn- frame-db []
-  (rf/runtime-db-value :rf/default))
+;; runtime-db / snapshot lookup via the shared machines test-support
+;; (rf2-3l8lqe finding #4) — no hardcoded `[:rf.runtime/machines …]` path.
+(def ^:private snapshot mtest/snapshot)
+(def ^:private frame-db mtest/runtime-db)
 
 (defn- capture-traces!
-  "Drive `thunk` while recording every emitted trace envelope. Returns the
-  vector of envelopes (deterministic on the JVM — no wall-clock / random)."
+  "Drive `thunk` while recording every emitted trace envelope; return the
+  vector of envelopes (deterministic on the JVM — no wall-clock / random).
+  The VALUE-returning counterpart to `mtest/with-trace-capture` (which is a
+  scope macro, not a value-producing call) — kept local because the call
+  sites below bind the returned vector in a `let`. Still guarantees
+  unregister in a `finally` via the shared helper's listener."
   [thunk]
-  (let [seen (atom [])]
-    (trace/register-listener! ::on-spawn-throw (fn [ev] (swap! seen conj ev)))
-    (try (thunk) (finally (trace/unregister-listener! ::on-spawn-throw)))
+  (mtest/with-trace-capture seen
+    (thunk)
     @seen))
 
 (defn- action-exceptions

--- a/implementation/machines/test/re_frame/spawn_registry_test.clj
+++ b/implementation/machines/test/re_frame/spawn_registry_test.clj
@@ -38,20 +38,16 @@
   the in-app-db slot directly."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(defn- snapshot
-  "Read the snapshot for `machine-id` from the default frame's app-db."
-  [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
-
-(defn- frame-db []
-  (rf/runtime-db-value :rf/default))
+;; runtime-db / snapshot lookup via the shared machines test-support
+;; (rf2-3l8lqe finding #4) — no hardcoded `[:rf.runtime/machines …]` path.
+(def ^:private snapshot mtest/snapshot)
+(def ^:private frame-db mtest/runtime-db)
 
 ;; ---- (1) spawn writes [:rf.runtime/machines :spawned <parent> <invoke-id>] ------------------
 
@@ -302,12 +298,14 @@
 
 (defn- capture-warn-ops!
   "Run `thunk` while a trace listener records every emitted `:operation`.
-  Returns the vector of operations seen during the body."
+  Returns the vector of operations seen during the body. Routed through the
+  shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4) — guaranteed
+  unregister in a `finally` — then projects each envelope to its
+  `:operation`."
   [thunk]
-  (let [seen (atom [])]
-    (trace/register-listener! ::on-spawn-warn (fn [ev] (swap! seen conj (:operation ev))))
-    (try (thunk) (finally (trace/unregister-listener! ::on-spawn-warn)))
-    @seen))
+  (mtest/with-trace-capture seen
+    (thunk)
+    (mapv :operation @seen)))
 
 (deftest on-spawn-returning-a-value-warns-exactly-once
   (testing "an :on-spawn callback that returns a non-nil (dropped) value

--- a/implementation/machines/test/re_frame/spawned_marks_lifecycle_test.clj
+++ b/implementation/machines/test/re_frame/spawned_marks_lifecycle_test.clj
@@ -47,14 +47,14 @@
             [re-frame.frame :as frame]
             [re-frame.machines]
             [re-frame.machines.paths :as paths]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.marks :as marks]
             [re-frame.schemas]
             [re-frame.schemas.malli]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- fixtures -------------------------------------------------------------
 

--- a/implementation/machines/test/re_frame/substrate_source_machine_test.clj
+++ b/implementation/machines/test/re_frame/substrate_source_machine_test.clj
@@ -28,12 +28,17 @@
             ;; `rf/reg-machine`, the `:rf.machine/spawn` / `:rf.machine/destroy`
             ;; reserved fxs, and the `:after`-timer surface register at ns load.
             [re-frame.machines]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
+            ;; Source-axis tests register listeners through `trace.tooling`
+            ;; directly (not mtest/with-trace-capture): each listener FILTERS
+            ;; on a specific :operation at capture time and the test reads
+            ;; `@seen` in the surrounding `let` — kept as inline try/finally
+            ;; blocks (which already guarantee unregister).
             [re-frame.trace.tooling :as trace-tooling]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- :after-timer --------------------------------------------------------
 

--- a/implementation/machines/test/re_frame/tags_test.clj
+++ b/implementation/machines/test/re_frame/tags_test.clj
@@ -23,14 +23,15 @@
             [re-frame.core :as rf]
             [re-frame.machines :as machines]
             [re-frame.machines.result :as result]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(defn- snapshot [machine-id]
-  (get-in (rf/runtime-db-value :rf/default) [:rf.runtime/machines :snapshots machine-id]))
+;; snapshot lookup via the shared machines test-support (rf2-3l8lqe finding #4)
+;; — no hardcoded `[:rf.runtime/machines :snapshots …]` path.
+(def ^:private snapshot mtest/snapshot)
 
 ;; ---- 1. flat machine, tags on each state ---------------------------------
 

--- a/implementation/machines/test/re_frame/timer_frame_scope_test.clj
+++ b/implementation/machines/test/re_frame/timer_frame_scope_test.clj
@@ -29,12 +29,12 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines :as machines]
+            [re-frame.machines.test-support :as mtest]
             [re-frame.machines.timer :as timer]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- the machine under test -----------------------------------------------
 ;;

--- a/implementation/machines/test/re_frame/trace_enhancements_rf2_82a0u_test.clj
+++ b/implementation/machines/test/re_frame/trace_enhancements_rf2_82a0u_test.clj
@@ -18,21 +18,20 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- helpers ---------------------------------------------------------------
 
+;; Routed through the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4)
+;; — guaranteed unregister in a `finally`.
 (defn- record-traces!
   [body-fn]
-  (let [seen (atom [])]
-    (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
-    (try (body-fn)
-         (finally (rf/unregister-listener! ::rec)))
+  (mtest/with-trace-capture seen
+    (body-fn)
     @seen))
 
 (defn- ops [evs op]

--- a/implementation/machines/test/re_frame/transition_frame_tag_test.clj
+++ b/implementation/machines/test/re_frame/transition_frame_tag_test.clj
@@ -22,11 +22,11 @@
   drops the tag fails at this site test first (clear cause)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- shared spec ----------------------------------------------------------
 
@@ -36,6 +36,10 @@
              :green  {:on {:tick {:target :yellow}}}
              :yellow {:on {:tick {:target :red}}}}})
 
+;; Intentional RAW manual-stop listener (not mtest/with-trace-capture): this
+;; helper hands the caller a [capture-atom unregister-thunk] pair so the test
+;; controls exactly WHEN it stops listening — a behaviour the scope-macro form
+;; (which unregisters at body exit) cannot express.
 (defn- record-traces!
   []
   (let [seen (atom [])]

--- a/implementation/machines/test/re_frame/transition_slot_spec_path_test.clj
+++ b/implementation/machines/test/re_frame/transition_slot_spec_path_test.clj
@@ -17,18 +17,17 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines]
-            [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.test-support :as test-support]
-            [re-frame.trace]))
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 (use-fixtures :each
-  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
+;; Routed through the shared `mtest/with-trace-capture` (rf2-3l8lqe finding #4)
+;; — guaranteed unregister in a `finally`.
 (defn- record-traces! [body-fn]
-  (let [seen (atom [])]
-    (rf/register-listener! ::rec (fn [ev] (swap! seen conj ev)))
-    (try (body-fn)
-         (finally (rf/unregister-listener! ::rec)))
+  (mtest/with-trace-capture seen
+    (body-fn)
     @seen))
 
 (defn- action-ran-slot


### PR DESCRIPTION
Mechanical, behaviour-preserving migration of the remaining ~32 machines test sites onto the shared re-frame.machines.test-support ns (rf2-3l8lqe finding #4 / #3622). 59 test files re-pointed: the reset-runtime fixture re-export (so each test requires ONE support ns), snapshot/frame-db lookups routed through mtest/snapshot + mtest/runtime-db (no hardcoded [:rf.runtime/machines :snapshots ...] vectors), and hand-rolled trace-capture register/try/finally blocks routed through mtest/with-trace-capture (JVM) or mtest/trace-capture-fixture (dual-runtime). Intentional raw sites left as-is with a justifying comment: the destroyed-trace SHAPE probe, manual-stop [atom unreg] listeners, the register-only cross-step capture in destroy_silent_idempotent, the with/without-listener purity comparison, the shared-ordering-log listener in destroyed_exit_order, and the reduce_regions synthetic-snapshot constructor (not a runtime-db lookup). No source files touched; .beads/issues.jsonl not committed.

## Quality gates
- clojure -M:test in implementation/machines: 597 tests, 1888 assertions, 0 failures, 0 errors (exact parity with pre-migration baseline).
- npm run test:cljs in implementation: 6123 tests, 21841 assertions, 0 failures, 0 errors.