### PR TITLE
docs(skills): re-frame2 Story-MCP loop + verification + eval metadata (rf2-r2xswa)

### DIFF
--- a/scripts/check_skill_eval_docs.py
+++ b/scripts/check_skill_eval_docs.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Eval-docs drift gate: `skills/re-frame2/evals/README.md` vs `evals.json` (rf2-r2xswa).
+
+The eval harness README carries a human-readable coverage table, a total
+eval count, and a per-dimension breakdown. Those are hand-maintained prose
+that silently fell behind the JSON once before (a seventh eval —
+`recipe-correctness-story-recorder-sensitive-login` — landed in `evals.json`
+while the README still said "Six evals … two evals per dimension"). A stale
+coverage table makes the validation story less trustworthy than the skill it
+guards: a maintainer can miss an eval, misread the dimension balance, or
+trust a count that no longer holds.
+
+This gate makes that drift impossible to ship. It parses `evals.json` as the
+source of truth and asserts the README agrees on three axes:
+
+  A1  TOTAL COUNT      — the README's "<N> evals" sentence matches
+                         `len(evals)`.
+  A2  EVAL NAMES       — every eval `name` in the JSON appears in the README
+                         coverage table, and the table names no eval the JSON
+                         lacks (set equality). IDs are matched too so a row
+                         can't point at the wrong id.
+  A3  DIMENSION TALLY  — the README's per-dimension breakdown sentence states
+                         the same counts the JSON produces (e.g. "three
+                         recipe-correctness … two each for discovery and
+                         routing-correctness"). Counts are read as
+                         number-words OR digits.
+
+The gate is pure-Python-stdlib (no PyYAML / Node) to stay fast and
+CI-portable, mirroring the sibling `scripts/check_skill_*.py` gates. It does
+NOT validate `evals.json` schema beyond what it needs (id / name / dimension)
+— that is the harness runner's job.
+
+Exit code:
+    0  no drift
+    1  drift detected (printed; `::error::` under CI)
+    2  invocation / setup error
+
+Usage:
+    python scripts/check_skill_eval_docs.py
+    python scripts/check_skill_eval_docs.py --verbose
+    python scripts/check_skill_eval_docs.py --ci          # CI-shaped
+    python scripts/check_skill_eval_docs.py --self-test    # built-in fixtures
+
+rf2-r2xswa (finding 3).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EVALS_DIR = REPO_ROOT / "skills" / "re-frame2" / "evals"
+EVALS_JSON = EVALS_DIR / "evals.json"
+EVALS_README = EVALS_DIR / "README.md"
+
+# Force UTF-8 on output streams — the corpus carries → / em-dash etc. and the
+# default Windows console codec (cp1252) would crash on them.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+    except (AttributeError, ValueError):  # pragma: no cover
+        pass
+
+# Number-words 0..20 (the eval counts live well within this range). Used for
+# both the total-count and the per-dimension-tally axes.
+_WORD_TO_INT = {
+    "zero": 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
+    "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11,
+    "twelve": 12, "thirteen": 13, "fourteen": 14, "fifteen": 15,
+    "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19,
+    "twenty": 20,
+}
+_INT_TO_WORD = {v: k for k, v in _WORD_TO_INT.items()}
+
+
+def _count_token(n: int) -> str:
+    """Regex alternation matching either the digit or the number-word for n."""
+    word = _INT_TO_WORD.get(n)
+    if word is None:
+        return str(n)
+    return rf"(?:{n}|{word})"
+
+
+# ---------------------------------------------------------------------------
+# JSON source-of-truth extraction.
+# ---------------------------------------------------------------------------
+
+
+def load_evals(path: Path) -> list[dict]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    evals = data.get("evals")
+    if not isinstance(evals, list):
+        raise ValueError(f"{path}: top-level 'evals' is not a list")
+    return evals
+
+
+# ---------------------------------------------------------------------------
+# README parsing.
+# ---------------------------------------------------------------------------
+
+# Coverage-table rows: `| 7 | \`recipe-correctness-story-recorder-...\` | ... |`.
+# Capture the id (first cell) and the name (second cell, backtick-wrapped).
+_TABLE_ROW_RE = re.compile(
+    r"^\|\s*(\d+)\s*\|\s*`([^`]+)`\s*\|", re.MULTILINE
+)
+
+
+def parse_readme_table(text: str) -> dict[int, str]:
+    """Return {id: name} for every coverage-table row found in the README."""
+    rows: dict[int, str] = {}
+    for m in _TABLE_ROW_RE.finditer(text):
+        rows[int(m.group(1))] = m.group(2)
+    return rows
+
+
+def find_total_count(text: str) -> int | None:
+    """Pull the README's '<N> evals, covering ...' total-count assertion."""
+    m = re.search(
+        r"\b([A-Za-z]+|\d+)\s+evals,\s+covering",
+        text,
+    )
+    if not m:
+        return None
+    tok = m.group(1).lower()
+    if tok.isdigit():
+        return int(tok)
+    return _WORD_TO_INT.get(tok)
+
+
+def dimension_tally(evals: list[dict]) -> Counter:
+    return Counter(e.get("dimension", "?") for e in evals)
+
+
+def _strip_table_rows(text: str) -> str:
+    """Drop markdown table rows so the per-dimension PROSE check doesn't read
+    a coverage-table row (e.g. `| 2 | … | discovery | …`) as the count
+    statement. A row is any line whose first non-space char is `|`.
+    """
+    return "\n".join(
+        ln for ln in text.splitlines() if not ln.lstrip().startswith("|")
+    )
+
+
+def check_dimension_sentence(text: str, tally: Counter) -> list[str]:
+    """Return a list of human-readable problems with the per-dimension prose.
+
+    For each dimension present in the JSON, require the README to state its
+    count adjacent to the dimension name (digit or number-word). Phrasing is
+    free as long as `<count> ... <dimension>` co-occurs within a short window.
+    The coverage TABLE is stripped first — its rows carry both an id digit and
+    a dimension name and would otherwise satisfy this check vacuously.
+    """
+    problems: list[str] = []
+    low = _strip_table_rows(text).lower()
+    for dim, n in sorted(tally.items()):
+        tok = _count_token(n)
+        # `<count>` then up to ~40 chars then the dimension name. The window
+        # absorbs phrasing like "three recipe-correctness evals" and
+        # "two each for discovery and routing-correctness".
+        pat = re.compile(rf"{tok}\b[^.]{{0,60}}?{re.escape(dim)}", re.IGNORECASE)
+        if not pat.search(low):
+            problems.append(
+                f"dimension '{dim}' has {n} eval(s) in evals.json but the "
+                f"README's per-dimension breakdown does not state a count of "
+                f"{n} for it (looked for '{n}'/'{_INT_TO_WORD.get(n, n)}' "
+                f"near '{dim}')"
+            )
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# Cross-check.
+# ---------------------------------------------------------------------------
+
+
+def check(evals_json: Path, readme: Path) -> list[str]:
+    """Return a list of drift findings (empty == clean)."""
+    findings: list[str] = []
+    evals = load_evals(evals_json)
+    text = readme.read_text(encoding="utf-8")
+
+    # A1 — total count.
+    json_total = len(evals)
+    readme_total = find_total_count(text)
+    if readme_total is None:
+        findings.append(
+            "A1 total-count: could not find the README's '<N> evals, "
+            "covering …' sentence — the gate cannot verify the count."
+        )
+    elif readme_total != json_total:
+        findings.append(
+            f"A1 total-count: README says {readme_total} evals but "
+            f"evals.json has {json_total}."
+        )
+
+    # A2 — eval names (and ids) set-equality between table and JSON.
+    json_by_id = {e.get("id"): e.get("name") for e in evals}
+    table = parse_readme_table(text)
+    json_names = {e.get("name") for e in evals}
+    table_names = set(table.values())
+
+    for missing in sorted(json_names - table_names):
+        findings.append(
+            f"A2 names: eval '{missing}' is in evals.json but absent from the "
+            f"README coverage table."
+        )
+    for extra in sorted(table_names - json_names):
+        findings.append(
+            f"A2 names: README coverage table lists '{extra}' but evals.json "
+            f"has no eval by that name."
+        )
+    # id↔name agreement for rows whose id exists in both.
+    for rid, rname in sorted(table.items()):
+        jname = json_by_id.get(rid)
+        if jname is not None and jname != rname:
+            findings.append(
+                f"A2 ids: README row id={rid} names '{rname}' but evals.json "
+                f"id={rid} is '{jname}'."
+            )
+
+    # A3 — dimension tally.
+    findings.extend(
+        f"A3 dimension: {p}" for p in check_dimension_sentence(text, dimension_tally(evals))
+    )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Self-test — synthetic README/JSON pairs exercising each axis.
+# ---------------------------------------------------------------------------
+
+
+def _run_self_test() -> int:
+    import tempfile
+
+    failures = 0
+
+    good_json = {
+        "evals": [
+            {"id": 1, "name": "a-disc", "dimension": "discovery"},
+            {"id": 2, "name": "b-disc", "dimension": "discovery"},
+            {"id": 3, "name": "c-recipe", "dimension": "recipe-correctness"},
+        ]
+    }
+    good_readme = (
+        "## Coverage\n\nThree evals, covering the dimensions:\n\n"
+        "| ID | Name | Dimension | What |\n|---:|---|---|---|\n"
+        "| 1 | `a-disc` | discovery | x |\n"
+        "| 2 | `b-disc` | discovery | y |\n"
+        "| 3 | `c-recipe` | recipe-correctness | z |\n\n"
+        "Two discovery evals and one recipe-correctness eval.\n"
+    )
+
+    def run(jobj: dict, rtext: str) -> list[str]:
+        with tempfile.TemporaryDirectory() as td:
+            jp = Path(td) / "evals.json"
+            rp = Path(td) / "README.md"
+            jp.write_text(json.dumps(jobj), encoding="utf-8")
+            rp.write_text(rtext, encoding="utf-8")
+            return check(jp, rp)
+
+    cases: list[tuple[str, dict, str, bool]] = [
+        ("clean pair", good_json, good_readme, True),
+        # Stale total count.
+        ("bad total", good_json,
+         good_readme.replace("Three evals", "Four evals"), False),
+        # Missing eval name in table (drop the recipe row).
+        ("missing name", good_json,
+         good_readme.replace("| 3 | `c-recipe` | recipe-correctness | z |\n", ""), False),
+        # Phantom name in table.
+        ("phantom name", good_json,
+         good_readme.replace("| 3 | `c-recipe`", "| 3 | `c-ghost`"), False),
+        # Wrong dimension tally (claim one discovery eval).
+        ("bad tally", good_json,
+         good_readme.replace("Two discovery evals", "One discovery eval"), False),
+    ]
+
+    for label, jobj, rtext, want_clean in cases:
+        findings = run(jobj, rtext)
+        is_clean = not findings
+        if is_clean != want_clean:
+            failures += 1
+            print(
+                f"SELF-TEST FAIL: {label!r} expected "
+                f"{'clean' if want_clean else 'drift'}, got "
+                f"{'clean' if is_clean else findings}"
+            )
+
+    if failures:
+        print(f"\n{failures} self-test failure(s).")
+        return 1
+    print("self-test: all fixtures pass.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def _is_ci() -> bool:
+    return os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+def main(argv: Iterable[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify skills/re-frame2/evals/README.md coverage table, total "
+            "count, and per-dimension breakdown agree with evals.json "
+            "(rf2-r2xswa)."
+        ),
+    )
+    parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument("--ci", action="store_true",
+                        help="Emit GitHub-Actions ::error:: lines (auto-on under GITHUB_ACTIONS).")
+    parser.add_argument("--self-test", action="store_true",
+                        help="Run built-in fixtures and exit.")
+    args = parser.parse_args(list(argv))
+
+    if args.self_test:
+        return _run_self_test()
+
+    ci = args.ci or _is_ci()
+
+    for p in (EVALS_JSON, EVALS_README):
+        if not p.is_file():
+            msg = f"required file not found: {p}"
+            print(f"::error::{msg}" if ci else f"ERROR: {msg}", file=sys.stderr)
+            return 2
+
+    try:
+        findings = check(EVALS_JSON, EVALS_README)
+    except (ValueError, json.JSONDecodeError) as e:
+        msg = f"failed to parse evals.json: {e}"
+        print(f"::error::{msg}" if ci else f"ERROR: {msg}", file=sys.stderr)
+        return 2
+
+    if findings:
+        print(
+            f"Eval-docs drift detected ({len(findings)} "
+            f"finding{'' if len(findings) == 1 else 's'}):",
+            file=sys.stderr,
+        )
+        for f in findings:
+            print(f"::error::{f}" if ci else f"ERROR: {f}", file=sys.stderr)
+        print(
+            "\nFix: update skills/re-frame2/evals/README.md (coverage table, "
+            "the '<N> evals' count, and the per-dimension breakdown) to match "
+            "skills/re-frame2/evals/evals.json. (rf2-r2xswa)",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.verbose:
+        print("No eval-docs drift detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -130,6 +130,18 @@ run "implementor order-guard self-test" "python scripts/check_skill_implementor_
 run "implementor foundation-order" "python scripts/check_skill_implementor_order.py --verbose --ci" \
   python "$repo_root/scripts/check_skill_implementor_order.py" --verbose --ci
 
+# Eval-docs drift guard (rf2-r2xswa): the re-frame2 eval harness README carries
+# a hand-maintained coverage table, total count, and per-dimension breakdown
+# that silently fell behind evals.json once (a 7th eval landed while the README
+# still said "Six evals … two per dimension").  Self-test first (proves it fires
+# on count/name/tally drift), then the live scan asserts the README agrees with
+# the JSON.
+run "eval-docs guard self-test" "python scripts/check_skill_eval_docs.py --self-test" \
+  python "$repo_root/scripts/check_skill_eval_docs.py" --self-test
+
+run "re-frame2 eval-docs match evals.json" "python scripts/check_skill_eval_docs.py --verbose --ci" \
+  python "$repo_root/scripts/check_skill_eval_docs.py" --verbose --ci
+
 # README inventory ratchet (rf2-198k3): layout-map<->disk bijection +
 # 'N <noun>' count-numeral claims.  Runs unconditionally (not gated on a
 # markdown diff) because the drift it catches can be triggered by a *dir*

--- a/skills/re-frame2/README.md
+++ b/skills/re-frame2/README.md
@@ -72,7 +72,7 @@ The skill's `description` triggers on natural-language references to re-frame2 s
 
 ## Status
 
-**Alpha.** All scaffolding and leaves are populated: `references/fundamentals/` (including the Flows leaf), `references/state-machines/`, `references/tooling/`, `references/cross-cutting/`, the nine canonical patterns under `patterns/`, and both decision trees (`pick-a-pattern`, `slice-or-machine`). The loading map is reconciled and the derived-from-implementation footers are pinned at main `89bd9c3`. All worked examples the leaves cite — including `examples/reagent/{websocket,long_running_work,flows}/` — have shipped, and the evals harness has landed under `evals/` (`README.md` + `evals.json`). No in-flight items remain.
+**Alpha.** All scaffolding and leaves are populated: `references/fundamentals/` (including the Flows leaf), `references/state-machines/`, `references/tooling/`, `references/cross-cutting/`, the nine canonical patterns under `patterns/`, and both decision trees (`pick-a-pattern`, `slice-or-machine`). The loading map is reconciled and the derived-from-implementation footers are pinned at main `89bd9c3`. All worked examples the leaves cite — including `examples/reagent/{websocket,long_running_work,flows}/` — have shipped, and the evals harness has landed under `evals/` (`README.md` + `evals.json`) as a **repo-maintenance artifact** (it is deliberately not in the published package — see [`evals/README.md` §Repo-maintenance artifact](evals/README.md), and `package.json`'s `files` list omits it; run the harness from a monorepo clone). No in-flight items remain.
 
 ## License
 

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -23,10 +23,29 @@ allowed-tools:
   - Write
   - Grep
   - Glob
+  # Verification surface (see SKILL.md §Verify what you changed): run the
+  # nearest relevant test / compiler / lint gate after changing code or
+  # tests. Narrow command shapes, generic to any consumer re-frame2 project
+  # (clojure CLI test aliases, shadow-cljs compile/test, the npm test:*
+  # script family, clj-kondo lint). Discover the project's actual gate
+  # names from deps.edn / shadow-cljs.edn / package.json before invoking.
+  - Bash(clojure -M:test)
+  - Bash(clojure -M:test:*)
+  - Bash(clojure -M:*:test)
+  - Bash(npm test)
+  - Bash(npm run test:*)
+  - Bash(npx shadow-cljs compile *)
+  - Bash(shadow-cljs compile *)
+  - Bash(clj-kondo --lint *)
   # story-mcp authoring-side tools (HYBRID split): re-frame2 owns the
-  # authoring loop (write/refine variant); re-frame2-pair owns the run side
-  # (run-variant / read-failures / record-as-variant). Per
-  # tools/story-mcp/spec/002-Tool-Registry.md.
+  # AUTHOR/REFINE side — write/refine a variant body (register/unregister),
+  # preview one render (preview-variant), and read it back (get-variant /
+  # explain-variant). re-frame2-pair owns the RUN side — execute against a
+  # live runtime and self-heal off the failures (run-variant / read-failures
+  # / record-as-variant / run-a11y / snapshot-identity). The run loop is a
+  # HANDOFF to re-frame2-pair, not a loop this skill executes. Per
+  # tools/story-mcp/spec/002-Tool-Registry.md; pinned by
+  # scripts/check_skill_mcp_drift.py.
   - mcp__re-frame2-story-mcp__get-story-instructions
   - mcp__re-frame2-story-mcp__list-stories
   - mcp__re-frame2-story-mcp__get-story
@@ -112,7 +131,7 @@ Load at most two leaves per task. If a task seems to need three, it likely spans
 
 **State machines — `references/state-machines/`**: `reg-machine.md` (declaration + the xstate→re-frame2 translation key), `regions.md` (parallel), `tags.md`, `spawn.md` (child machines), `history.md` (`:type :history` re-entry), `cancellation.md`. Standing mental model across all of these: think in xstate, then map onto re-frame2 — see `reg-machine.md` for the full mapping table and deliberate-divergence flags.
 
-**Tooling — `references/tooling/`**: `stories.md`, `routing.md`, `story-recorder.md` (record canvas interactions as a `:script` body), `story-mcp-loop.md` (agent self-healing loop over MCP), `xray.md` (the devtools panel — mount strategy, launch modes, host-CSS-variable resize contract, popout, suppress-auto-open). For anything Story, the standing bridge is **think in Storybook JS, then map onto Story** — `stories.md` carries the verified concept map.
+**Tooling — `references/tooling/`**: `stories.md`, `routing.md`, `story-recorder.md` (record canvas interactions as a `:script` body), `story-mcp-loop.md` (the story-mcp **author/refine** side this skill owns — write/preview/read-back a variant — and the **handoff** to `re-frame2-pair` for the run/self-heal loop), `xray.md` (the devtools panel — mount strategy, launch modes, host-CSS-variable resize contract, popout, suppress-auto-open). For anything Story, the standing bridge is **think in Storybook JS, then map onto Story** — `stories.md` carries the verified concept map.
 
 **Cross-cutting — `references/cross-cutting/`**: `testing.md` (with-frame, dispatch-sync, compute-sub), `api-cheatsheet.md`, `privacy-and-elision.md` (schema `:sensitive?` / `:large?` / `elide-wire-value`), `production-observability.md` (`register-event-listener!` / `register-error-listener!`), `ssr-authoring.md` (`reg-head` / `render-head` / `active-head` / `head-model->html` and the `:rf.ssr/check-version` + `:rf.ssr/check-schema-digest` fxs).
 
@@ -139,8 +158,19 @@ Load at most two leaves per task. If a task seems to need three, it likely spans
 - [ ] Cut-test passed on comments.
 - [ ] Shape matches the canonical declaration in the leaf.
 - [ ] If a worked example exists, the new code's shape matches it.
+- [ ] **Verified** — when you have shell/tool access and changed code or tests, you ran the nearest relevant gate (test / compiler / lint) and recorded what passed; note anything you deliberately skipped and why.
 
-The user runs tests / compiler / app; this skill does not.
+## Verify what you changed
+
+If you have shell/tool access and you changed code or tests, **run the nearest relevant gate** before declaring done — do not hand off unverified changes. "Nearest relevant" means the narrowest gate that exercises the path you touched, not the whole suite:
+
+- Touched a single artefact's source/tests → run that artefact's test alias (e.g. `clojure -M:test` from the artefact dir, or the project's `npm run test:<thing>`), not the full matrix.
+- Want a fast compile/type signal without the full suite → the project's shadow-cljs / `clj-kondo` lint or a focused `cljs.test` namespace run.
+- Prefer a narrow slice gate over full-suite churn; a green slice on the changed path beats a slow full run.
+
+**Discover the project's gates first** — don't guess command names. Check, in order: nearby `deps.edn` `:aliases` (the `:test` alias), `shadow-cljs.edn` build/test ids, `package.json` `scripts` (the `test:*` family), and any gate notes in the nearest `README.md`. The testing leaf's [§Discovering a project's gates](references/cross-cutting/testing.md) carries the recipe.
+
+**No-tool / chat-only fallback.** When you have no shell access (a chat-only session), you cannot run anything — say so, and ask the user to run the specific gate you'd have run (name it concretely, e.g. "run `clojure -M:test` in `src/app/`"). That fallback is for tool-less sessions only; it is **not** the default for a tool-capable agent.
 
 ## How re-frame2 differs from re-frame v1
 

--- a/skills/re-frame2/evals/README.md
+++ b/skills/re-frame2/evals/README.md
@@ -5,6 +5,20 @@ This directory holds the evaluation harness for the `re-frame2` authoring skill
 skill: before we publish, every eval here should pass against a fresh Claude
 session loaded with the skill.
 
+## Repo-maintenance artifact, not shipped
+
+`evals/` is a **repo-maintenance artifact** — it is deliberately **not** part of
+the distributable skill package. `skills/re-frame2/package.json`'s `files`
+allow-list omits `evals/` on purpose: a packaged-skill consumer runs the skill,
+they do not re-run its gate suite, so shipping the harness would only bloat the
+tarball with material that points back at the monorepo's test infrastructure.
+The harness lives and runs from a full re-frame2 clone (where
+`scripts/check_skill_eval_docs.py` and any future runner can reach it). The
+top-level `skills/re-frame2/README.md` §Status notes the harness has landed
+"under `evals/`" as a repo fact — that link resolves in a clone, which is the
+only supported way to run the evals. It is intentionally absent from the
+published package.
+
 ## Convention
 
 The harness follows Anthropic's `skill-creator` convention, documented in
@@ -39,7 +53,7 @@ Two harness extensions on top of the base schema:
 
 ## Coverage
 
-Six evals, covering the three dimensions the bead called for:
+Eight evals, covering the three dimensions the bead called for:
 
 | ID | Name | Dimension | What it probes |
 |---:|---|---|---|
@@ -49,9 +63,22 @@ Six evals, covering the three dimensions the bead called for:
 | 4 | `recipe-correctness-state-machine-http-region` | recipe-correctness | "Register a state machine for an HTTP request lifecycle." Does the output use `reg-machine` with the five canonical states (`:idle :loading :fetching :loaded :error`), `:tags` for an `:in-flight` query, keyword-referenced actions in the top-level table (inspectability bias), action effect-maps `{:data ...}`, and the `re-frame.machines` artefact require? |
 | 5 | `routing-correctness-v1-migration` | routing-correctness | Prompt is a v1→v2 migration question. Does the agent hand off to the dedicated `re-frame-migration` skill (per the single-source routing table in `skills/README.md` and this skill's SKILL.md disqualifier) rather than improvising migration deltas from training memory? |
 | 6 | `routing-correctness-greenfield-scaffold` | routing-correctness | Prompt is "start a new re-frame2 project from scratch". Does the agent defer to the sibling `re-frame2-setup` skill rather than improvising `deps.edn` / `shadow-cljs.edn` from the authoring skill? |
+| 7 | `recipe-correctness-story-recorder-sensitive-login` | recipe-correctness | Story-recorder privacy prompt (login + 2FA into a `:script`). Does the agent teach the CURRENT contract — recorder filters off the emitted trace event's `:sensitive?` (path/schema-based, NOT handler metadata), schema `{:sensitive? true}` on the app-db slot for the password, `rf/redact-interceptor` for the transient 2FA payload — and EXPLICITLY REJECT handler-meta `{:sensitive? true}` as the redaction mechanism? |
+| 8 | `recipe-correctness-story-variant-authoring-handoff` | recipe-correctness | Story variant authoring through the hybrid split. The prompt asks to author a variant AND "run it and keep iterating against the running library". Does the agent author with only the tools `re-frame2` is allow-listed for (`register-variant` / `preview-variant` / `get-variant` / `explain-variant`), and **hand off** the run/self-heal loop (`run-variant` / `read-failures`) to `re-frame2-pair` rather than claiming to call tools it cannot reach? Fails if the documented loop requires run-side tools unavailable to this skill. |
 
-Three is Anthropic's minimum. Six gives two evals per dimension, so any single
-eval can flake without the dimension going dark.
+Three is Anthropic's minimum. Eight gives **four** recipe-correctness evals
+and **two** each for discovery and routing-correctness, so every dimension keeps
+multi-eval coverage and any single eval can flake without the dimension going
+dark. The skew toward recipe-correctness is deliberate: that dimension carries
+the highest defect risk (idiom drift in produced code, including the
+Story-recorder privacy contract eval 7 guards and the Story authoring/run
+boundary eval 8 guards).
+
+> **Staying in sync.** The table above, the eval count in this paragraph, and
+> the per-dimension breakdown are checked against `evals.json` by
+> `scripts/check_skill_eval_docs.py` (run it after adding or renaming an eval).
+> The gate fails if the README count, the dimension tallies, or the set of eval
+> names drifts from the JSON — so a new eval cannot silently stale these docs.
 
 ## How to run
 

--- a/skills/re-frame2/evals/evals.json
+++ b/skills/re-frame2/evals/evals.json
@@ -122,6 +122,22 @@
         "For a transient payload-only secret (the one-time 2FA code that need not land at an app-db slot), the output reaches for rf/redact-interceptor with the named payload path(s), and notes it scrubs payload keys on the trace surface but does NOT by itself stamp :sensitive? / suppress the whole row.",
         "The output does NOT claim that registering a handler :sensitive? true causes Story / MCP record-as-variant to redact the event."
       ]
+    },
+    {
+      "id": 8,
+      "name": "recipe-correctness-story-variant-authoring-handoff",
+      "dimension": "recipe-correctness",
+      "prompt": "Using the re-frame2 Story MCP tools, write a new variant `:story.todos/delete-confirmed` that extends `:story.todos/list-with-items`, dispatches a delete-then-confirm, and asserts the item list is empty. Then run it and keep iterating against the running library until the assertions pass.",
+      "expected_output": "The agent recognises two halves. AUTHORING (this skill owns it): it authors the variant body and uses ONLY the story-mcp tools re-frame2 is allow-listed for — register-variant to write the body, preview-variant to eyeball the render, get-variant/explain-variant to read it back. RUNNING (re-frame2-pair owns it): the 'run it and keep iterating against the running library' half is the self-healing loop — run-variant / read-failures — which requires a live runtime and is NOT in this skill's allow-list. The agent hands that off to a re-frame2-pair session rather than claiming to call run-variant / read-failures itself. It loads references/tooling/story-mcp-loop.md, which documents exactly this author/refine vs run-side split. The eval FAILS if the agent claims to drive the run loop from the re-frame2 skill using tools it cannot reach.",
+      "files": [],
+      "expectations": [
+        "Skill skills/re-frame2/ is invoked and references/tooling/story-mcp-loop.md is read.",
+        "For the authoring half, the agent uses only tools the re-frame2 skill allow-lists: register-variant (write the body), preview-variant (render one variant), get-variant / explain-variant (read it back) — and it authors a body with :extends :story.todos/list-with-items plus a :script that dispatches the delete/confirm and a :rf.assert/* check.",
+        "The agent does NOT claim to call mcp__re-frame2-story-mcp__run-variant or mcp__re-frame2-story-mcp__read-failures from inside the re-frame2 skill — those are NOT in this skill's allowed-tools (they are owned by re-frame2-pair).",
+        "For the 'run it and keep iterating against the running library' half, the agent HANDS OFF to the re-frame2-pair skill (it names re-frame2-pair as the owner of the run/self-heal loop against a live runtime behind shadow-cljs watch) rather than fabricating a run-variant call.",
+        "The agent's explanation of the boundary matches the shipped hybrid split: authoring (register/preview/read-back) is static and owned here; running (run-variant / read-failures / record-as-variant) is runtime-bound and owned by re-frame2-pair — consistent with scripts/check_skill_mcp_drift.py's intentional_server_only partition.",
+        "The agent does NOT propose adding run-variant / read-failures to the re-frame2 skill's allowed-tools as a workaround, nor does it hallucinate a successful run result it never executed."
+      ]
     }
   ]
 }

--- a/skills/re-frame2/references/cross-cutting/testing.md
+++ b/skills/re-frame2/references/cross-cutting/testing.md
@@ -2,7 +2,7 @@
 
 Load when the task is **authoring a `deftest` / `cljs.test` test** against re-frame2 application code: an event-fx handler, a sub graph, a machine snapshot, a tag query, a view that reads from a frame. This leaf teaches only the **re-frame2-specific binding** — `clojure.test` / `cljs.test` themselves are assumed.
 
-This skill does **not** teach the AI to *run* tests; that is the user's job. It teaches how to **write** them so they pass when the user runs the suite.
+This leaf teaches how to **write** re-frame2 tests so they pass when the suite runs. It is not a `cljs.test` tutorial. **Verifying** what you wrote is in scope: when you have shell/tool access and changed code or tests, run the nearest relevant gate before declaring done (see [§Discovering a project's gates](#discovering-a-projects-gates) below and SKILL.md §Verify what you changed). Only a chat-only / no-tool session hands the run off to the user — and then it names the exact gate to run.
 
 ## The single import
 
@@ -277,6 +277,17 @@ For HTTP stubs, the fn form lets the test return a canned response shape without
 
 Per-frame `:fx-overrides` in `reg-frame` accepts the same fn-value form, so a test frame can install a stub once for every dispatch routed to it. The id-keyword form (`{:rf.http/managed :rf.http/managed-canned-success}`) is the portable pattern-level form — use it when the stub is shared across many tests or when SSR / serialisation is in play; reach for the fn form when one test wants a bespoke response.
 
+## Discovering a project's gates
+
+Before running anything, find the project's *actual* gate commands — don't guess names. Run the narrowest gate that exercises the path you touched, not the full matrix. Check, in order:
+
+- **`deps.edn` `:aliases`** — the `:test` alias is the per-artefact runner (`clojure -M:test` from that artefact's dir). A consumer monorepo often has one `deps.edn` per artefact; run the alias from the dir whose source you changed.
+- **`shadow-cljs.edn`** — `:builds` keys and any `:test` build id reveal the CLJS compile/test targets (`npx shadow-cljs compile <id>`, or the project's test build).
+- **`package.json` `scripts`** — the `test:*` family (e.g. `test:cljs`, `test:browser`) is the canonical entry-point set for shadow-cljs projects; prefer the one scoped to your change.
+- **The nearest `README.md`** — examples and feature dirs often note their gate commands inline ("run `npm run test:foo`"). An example app's README is the authority for that example's gate.
+
+Pick the tightest match and run it. A green slice on the changed path is the signal; reach for a wider gate only when the change genuinely spans artefacts. If no runnable gate exists for the surface you touched (or you lack shell access), say which gate you *would* have run and ask the user to run it.
+
 ## Checklist before declaring a test done
 
 - The ns uses `re-frame.test-support` and `re-frame.core` only — no reach into internal namespaces.
@@ -285,6 +296,7 @@ Per-frame `:fx-overrides` in `reg-frame` accepts the same fn-value form, so a te
 - Sub assertions go through `compute-sub` (preferred) or `subscribe-once`; no bare `@(rf/subscribe ...)` left subscribed at test exit.
 - Machine assertions use `sub-machine` / `machine-has-tag?` or `(get-in (rf/runtime-db-value frame-id) [:rf.runtime/machines :snapshots id])` — runtime-db partition, not internal machine namespaces, and not `db`/app-db.
 - Schema-validation, fx-stubs, and frame-scoping each use the public surface above. No fixture lifts `registrar/clear-all!`.
+- **Verified, or said why not** — with shell/tool access, the nearest relevant gate (the new test's artefact `:test` alias / `npm run test:*` / a focused namespace run) was run and recorded; record any gate deliberately skipped and why. No-tool sessions name the gate for the user to run.
 
 ---
 

--- a/skills/re-frame2/references/tooling/stories.md
+++ b/skills/re-frame2/references/tooling/stories.md
@@ -26,7 +26,7 @@
 
 Sketch in Storybook mentally, then translate.
 
-> **One-liner for the next leaf:** the same "think in Storybook, map onto Story" bridge applies to the recorder (`story-recorder.md`) and the agent loop (`story-mcp-loop.md`).
+> **One-liner for the next leaf:** the same "think in Storybook, map onto Story" bridge applies to the recorder (`story-recorder.md`) and the story-mcp author/refine side (`story-mcp-loop.md`, which also points at the `re-frame2-pair` run-side handoff).
 
 ## When to load
 
@@ -186,7 +186,7 @@ The dev shell's Test pane and recorder ship ergonomic affordances that consume w
 - The seven `:rf.assert/*` events, semantics + source-stamping → `SKILL-REDIRECT.md` → *EP — Stories (007)* §Assertions.
 - Render shell, panel placement, multi-substrate pane → `tools/story/spec/003-Render-Shell.md` §UI shell substrate, §Workspace layouts, §Multi-substrate side-by-side rendering.
 - Test Codegen (record canvas interactions into a `:script` body; the codegen emits the PUBLIC `:script` slot — the recorder no longer emits the transitional `:play-script` spelling) → `story-recorder.md` (sibling leaf).
-- Agent self-healing loop over MCP (variant authoring → run → assert → refine) → `story-mcp-loop.md` (sibling leaf).
+- Story-MCP author/refine side (write/preview/read-back a variant body with the tools this skill owns) + the handoff to `re-frame2-pair` for the run/self-heal loop (`run-variant` → assert → `read-failures` → refine) → `story-mcp-loop.md` (sibling leaf).
 - MCP write surface (programmatic registration via `reg-*` helpers) → `SKILL-REDIRECT.md` → *EP — Stories (007)* §MCP Surface.
 
 ---

--- a/skills/re-frame2/references/tooling/story-mcp-loop.md
+++ b/skills/re-frame2/references/tooling/story-mcp-loop.md
@@ -1,52 +1,53 @@
-# Story-MCP self-healing loop
+# Story-MCP author/refine — and the run-side handoff
 
-> The agent loop pattern: write a variant → run it via story-mcp → assert via `:rf.assert/*` → refine on failure. Assumes you already know what MCP is — this leaf covers the four-step loop and the story-mcp tools that wire each step.
+> **What this leaf owns.** The *authoring* half of the Story variant workflow: write a variant body, preview its rendered state, read it back, and refine it — all with the story-mcp tools THIS skill (`re-frame2`) is allowed to call. The *run* half — execute a variant against a live runtime, accumulate `:rf.assert/*` records, read the full failure set, and iterate to `:status :pass` — is a **separate, runtime-bound surface owned by the `re-frame2-pair` skill**. This is a deliberate hybrid split (`tools/story-mcp/spec/002-Tool-Registry.md`): authoring is static; running needs a browser tab behind `shadow-cljs watch`. This leaf teaches the authoring side and tells you exactly how to hand the run side off.
 
-> **Mental model: think in Storybook, map onto Story.** When authoring a variant in step 1, sketch it as a Storybook story first (which args, which play steps?), then translate to the EDN `reg-variant` body — see `stories.md` §Mental model for the full concept map. The loop's distinctive twist over a Storybook play function: `:rf.assert/*` events *record* (they don't throw), so `read-failures` returns **every** mismatch in one pass — the agent refines against the complete failure set, not just the first thrown assertion.
+> **Mental model: think in Storybook, map onto Story.** When authoring a variant, sketch it as a Storybook story first (which args, which play steps?), then translate to the EDN `reg-variant` body — see `stories.md` §Mental model for the full concept map. Story's distinctive twist over a Storybook play function: `:rf.assert/*` events *record* (they don't throw), so a single run returns **every** mismatch at once — but that recording-and-reading is the run side, which `re-frame2-pair` drives.
 
 ## When to load
 
-- An agent (Claude Code, Cursor, Copilot) is generating variants against a re-frame2 codebase and needs to iterate against the running Story library.
-- You're hand-driving the loop yourself via the MCP tool palette to debug a flaky variant.
-- You're explaining why the agent never needs to read source files to refine — `read-failures` returns enough.
+- An agent (Claude Code, Cursor, Copilot) is **writing or refining** variant bodies against a re-frame2 codebase and wants the story-mcp authoring surface (register / preview / read-back / explain).
+- You need to know the ownership boundary — which story-mcp tools this skill can call vs. what has to move to a `re-frame2-pair` session.
+- You're explaining why "run the variant and self-heal off the failures" is a `re-frame2-pair` operation, not something the authoring skill executes itself.
 
-Do **not** load this leaf to learn how to author a variant — see `stories.md`. Load it for: the tools in the loop, the step boundaries, and one worked iteration.
+Do **not** load this leaf to learn how to author a variant body's *contents* — see `stories.md`. Load it for: the authoring tools, the author↔run boundary, and the handoff recipe.
 
-## The four steps
+## The two halves
 
 ```
-   ┌──────────────────────────────────────────────────────────────┐
-   │  1. Author     2. Run         3. Assert        4. Refine     │
-   │  variant   →   via MCP    →   via :rf.assert/*  →   on fail  │
-   │  (or edit)     run-variant    read-failures        update    │
-   └──────────────────────────────────────────────────────────────┘
-                              ↑                            │
-                              └────────────────────────────┘
-                                  loop until :status :pass
+   AUTHOR / REFINE  (this skill: re-frame2)        RUN / SELF-HEAL  (re-frame2-pair)
+   ┌──────────────────────────────────────┐        ┌──────────────────────────────────────┐
+   │ register-variant   write the body     │        │ run-variant      execute, get :status │
+   │ preview-variant    eyeball one render │  ───▶  │ read-failures    full :rf.assert/* set │
+   │ get-variant        read it back        │  hand  │ (loop until :status :pass)             │
+   │ explain-variant    why did it resolve  │  off   │ record-as-variant  capture a cascade   │
+   │ unregister-variant tear down            │        │ run-a11y / snapshot-identity           │
+   └──────────────────────────────────────┘        └──────────────────────────────────────┘
 ```
 
-Each step has a story-mcp tool. The loop terminates when `run-variant` returns `:status :pass` or the agent hits its retry ceiling. `run-variant` / `read-failures` / `preview-variant` all speak the SAME unified run-result the human Story UI reads (spec/017 §Run result) — there is no agent-only result vocabulary. The headline is the top-level `:status` ∈ `{:pass :fail :cannot-run :error}`. `:cannot-run` is a distinct THIRD outcome (the runner could not even attempt the plan, e.g. a causal assertion run under a non-reactive runner) — handle it as "not runnable here", **not** as a fail; refining the assertion won't help, the runner needs to change.
+The boundary is the **runtime**. `preview-variant` (this skill) renders one variant and returns its canvas state — enough to confirm the body parses, mounts, and shows the right thing. But the self-healing *loop* — execute, accumulate the assertion records, read the **complete** failure set, refine, re-run — runs each iteration against the live library and is owned by `re-frame2-pair`. Trying to drive that loop from this skill would call tools the skill is not allow-listed for; the agent host blocks them.
 
-## Tool catalogue — by step
+## Authoring tools this skill can call — by step
 
-Per `tools/story-mcp/spec/002-Tool-Registry.md`, twenty tools across four categories. The seven that participate in the loop:
+Per `tools/story-mcp/spec/002-Tool-Registry.md`, the story-mcp catalogue is twenty tools across four categories. The authoring subset `re-frame2` is allow-listed for:
 
 | Step | Tool | Category | What it does |
 |---|---|---|---|
-| 1 | `register-variant` | Write (gated) | `re-frame.story/reg-variant*` with the agent's body |
-| 1 | `unregister-variant` | Write (gated) | symmetric tear-down between iterations |
-| 2 | `run-variant` | Testing | full four-phase lifecycle; returns the unified run-result (headline `:status`) |
-| 2 | `preview-variant` | Dev | "show me what this looks like" — same unified run-result plus the share URL + rendered view |
-| 3 | `read-failures` | Testing | diagnostic over `:rf.story/assertions` accumulator (no re-run); unified records + aggregate `:status` |
-| 4 | `get-variant` | Docs | full variant body as canonical EDN, for the agent to read before editing |
-| 4 | `explain-variant` | Docs | "why did the plan resolve this way" — the variant-plan `:explain` (source chain, merge, runner requirements); the agent's mirror of the human Explain panel |
-| 4 | `register-variant` | Write (gated) | re-registration with the refined body (overwrites) |
+| Write | `register-variant` | Write (gated) | `re-frame.story/reg-variant*` with the agent's body |
+| Write | `unregister-variant` | Write (gated) | symmetric tear-down between iterations |
+| Preview | `preview-variant` | Dev | render one variant; returns the unified run-result PLUS the share URL + rendered view ("show me what this looks like") |
+| Read | `get-variant` | Docs | full variant body as canonical EDN, for the agent to read before editing |
+| Read | `explain-variant` | Docs | "why did the plan resolve this way" — the variant-plan `:explain` (source chain, merge, runner requirements); the agent's mirror of the human Explain panel |
+| Onboard | `get-story-instructions` | Dev | the EDN-first constraint, canonical body keys, the seven `:rf.assert/*` events, the four-phase lifecycle, the inclusion-tag vocabulary — one self-contained string. Call once per session, before authoring. |
+| Enumerate | `list-stories` / `get-story` / `variant->edn` / `list-tags` / `list-modes` / `list-decorators` / `list-assertions` / `list-substrates` | Docs / Dev | navigate an unfamiliar Story registry while authoring |
 
-`get-story-instructions` (Dev) is the agent's onboarding read — it returns the EDN-first constraint, the canonical variant body keys, the seven `:rf.assert/*` events, the four-phase lifecycle, and the inclusion-tag vocabulary as one self-contained string. Agents call it once per session, before authoring. When a run resolves `:cannot-run` or merges/composes in a surprising way, `explain-variant` is the read that shows the resolved plan — source/parent chain, composed fragments/checks, strict-conflict winners, the selected runner + what it required.
+What this subset is **missing** (and why): `run-variant`, `read-failures`, `snapshot-identity`, `run-a11y`, and `record-as-variant` are the **Testing**-category run tools (plus the recorder bridge). They surface the live runtime's verdict and captured values, so they live in `re-frame2-pair`'s allow-list — not here. The drift gate (`scripts/check_skill_mcp_drift.py`) pins this split: it marks exactly those five as `intentional_server_only` for `re-frame2`, so an attempt to add them here fails the gate.
 
-## Worked loop
+`preview-variant`, `run-variant`, and `read-failures` all speak the SAME unified run-result the human Story UI reads (spec/017 §Run result) — there is no agent-only result vocabulary. The headline is the top-level `:status` ∈ `{:pass :fail :cannot-run :error}`. You'll see that `:status` on a `preview-variant` here; the *verdict-driven loop* over it is the run side.
 
-The agent has been asked to add a "user clicks delete then confirms" variant for `:story.todos/list-with-items`. Iteration one:
+## Worked authoring pass — then the handoff
+
+The agent has been asked to add a "user clicks delete then confirms" variant for `:story.todos/list-with-items`. Authoring side (this skill):
 
 ```
 agent → register-variant
@@ -54,59 +55,42 @@ agent → register-variant
    :body {:extends :story.todos/list-with-items
           :script [[:dispatch-sync [:todo/delete-pressed 3]]
                    [:dispatch-sync [:todo/confirm-pressed]]
-                   [:dispatch-sync [:rf.assert/path-equals [:todos :items] []]]]}}
+                   [:dispatch-sync [:rf.assert/path-equals [:todos :items] [{:id 1} {:id 2}]]]]}}
 
-agent → run-variant {:variant-id :story.todos/delete-confirmed}
-  ← {:status :fail :assertions [...] :checks [] :elapsed-ms 18 ...}
-
-agent → read-failures {:variant-id :story.todos/delete-confirmed}
-  ← {:status :fail :total 1
-     :failures [{:assertion :rf.assert/path-equals
-                 :path [:todos :items]
-                 :expected []
-                 :actual  [{:id 1 :text "buy milk"} {:id 2 :text "..."}]
-                 :passed? false :status :fail
-                 :source {:file ".../todos.cljs" :line 47}}]}
+agent → preview-variant {:variant-id :story.todos/delete-confirmed}
+  ← {:status :pass :share-url "..." :rendered-hiccup [...] :app-db {...} ...}
 ```
 
-The agent reads the failure: two items still remain because the parent variant seeded *three* todos and the delete only removed id `3`. The assertion was wrong. The agent refines:
+`preview-variant` confirms the body parses, the parent `:extends` resolves, the script mounts, and the rendered canvas looks right. If the preview shows the wrong render or `explain-variant` reveals a bad merge/runner, the agent refines the body and re-registers — still entirely on the authoring side.
 
-```
-agent → register-variant   ; overwrites
-  {:variant-id :story.todos/delete-confirmed
-   :body {:extends :story.todos/list-with-items
-          :script [[:dispatch-sync [:todo/delete-pressed 3]]
-                   [:dispatch-sync [:todo/confirm-pressed]]
-                   [:dispatch-sync [:rf.assert/path-equals [:todos :items] [{:id 1} {:id 2}]]]
-                   [:dispatch-sync [:rf.assert/dispatched? [:todo/deleted 3]]]]}}
+When the developer wants to **execute the assertions and self-heal against the running library** — the loop where `run-variant` returns `:status :fail`, `read-failures` returns the complete `:rf.assert/*` mismatch set, and the agent iterates to `:status :pass` — hand off to a `re-frame2-pair` session:
 
-agent → run-variant {:variant-id :story.todos/delete-confirmed}
-  ← {:status :pass ...}
-```
+> "The variant body is registered and previews correctly. To run the assertions and iterate against the live runtime, switch to the **re-frame2-pair** skill (it owns `run-variant` / `read-failures` against a running app behind `shadow-cljs watch`) and run the self-healing loop there — it'll see every `:rf.assert/*` mismatch in one pass because the assertions record rather than throw."
 
-Loop terminates. The agent reports the final variant body back to the user.
+The agent reports the registered body + preview result back, and names the run-side surface for the next step. It does **not** pretend to call `run-variant` from here.
 
-## Gates and prerequisites
+## Gates and prerequisites (authoring side)
 
-- **Write surface is gated.** `register-variant` / `unregister-variant` require `re-frame.story-mcp.config/allow-writes?` truthy — set via `--allow-writes` flag, `RF_STORY_MCP_ALLOW_WRITES=true` env, or `-Drf.story-mcp.allow-writes=true` JVM property. Without it the loop is read-only (`run-variant` + `read-failures` still work against existing variants).
+- **Write surface is gated.** `register-variant` / `unregister-variant` require `re-frame.story-mcp.config/allow-writes?` truthy — set via `--allow-writes` flag, `RF_STORY_MCP_ALLOW_WRITES=true` env, or `-Drf.story-mcp.allow-writes=true` JVM property. Without it, authoring is read-only (`preview-variant` + the enumerations still work against existing variants).
 - **`register-variant`'s parent story must already exist.** v1.1 omits `register-story` deliberately. The agent fails into a documented error when the `:story.<path>` parent isn't registered; the user lands the parent inline.
-- **`read-failures` does not re-run.** It reads the last-run accumulator. Pair with `run-variant` per iteration; do not assume an old `:status :fail` reflects the current body.
+- **Source-coord stamping survives MCP registration.** `register-variant` stamps `{:file <agent-supplied> :line <n>}` if provided in the body; without it, `:source` is omitted and downstream failure records carry no jump-to-line affordance. Agents that want clickable failures (on the run side) supply `:source` from the file they'll write the variant back into.
 
-## Common gotchas — loop-specific
+## Common gotchas
 
-- **`:rf.assert/*` events record, they do not throw.** A failing assertion does not abort the script. `read-failures` returns the full failure list per iteration — the agent sees every mismatch at once, not just the first. Assertion events ride the `:dispatch-sync` rail in `:script` (the public phase-4 play surface — spec/017 §Public vocabulary; `:play-script` is the transitional spelling the registrar still lowers, but author against `:script`).
-- **`:status :pass` is the loop terminator.** The top-level `:status` ∈ `{:pass :fail :cannot-run :error}` is the unified verdict `run-variant` returns (spec/017 §Run result). Distinguish `:fail` (an assertion mismatched — refine the variant) from `:cannot-run` (the runner could not attempt the plan — change the runner, refining won't help) from `:error` (a handler / fx / step threw).
-- **Snapshot-identity for skip-when-unchanged.** `snapshot-identity` returns a content hash of `(variant × args × decorators × loaders × substrate × modes)`. Agents that iterate across N variants skip cells whose identity matches a previous run.
-- **Source-coord stamping survives MCP registration.** `register-variant` stamps `{:file <agent-supplied> :line <n>}` if provided in the body; without it, `:source` is omitted and failure records carry no jump-to-line affordance. Agents that want clickable failures supply `:source` from the file they'll write the variant back into.
+- **The run loop is not this skill's to drive.** `run-variant` / `read-failures` are owned by `re-frame2-pair`. If the task is "run it and fix the failures," that is the handoff — don't infer access to tools the skill isn't allow-listed for.
+- **`:rf.assert/*` events record, they do not throw.** A failing assertion does not abort the script — the run side reads the full failure list per iteration. Assertion events ride the `:dispatch-sync` rail in `:script` (the public phase-4 play surface — spec/017 §Public vocabulary; `:play-script` is the transitional spelling the registrar still lowers, but author against `:script`).
+- **`:status :pass` is the loop terminator (on the run side).** The top-level `:status` ∈ `{:pass :fail :cannot-run :error}` is the unified verdict (spec/017 §Run result). Distinguish `:fail` (an assertion mismatched — refine the variant) from `:cannot-run` (the runner could not attempt the plan, e.g. a causal assertion under a non-reactive runner — change the runner, refining won't help) from `:error` (a handler / fx / step threw). You may see `:status` on a `preview-variant` here; the verdict-driven *iteration* is the run side.
+- **`explain-variant` is the authoring-side read for surprises.** When a preview renders unexpectedly or a plan merges/composes oddly, `explain-variant` shows the resolved plan — source/parent chain, composed fragments/checks, strict-conflict winners, the selected runner + what it required — the agent's mirror of the human Explain panel.
 
 ## Deeper material
 
 - Full tool registry + per-tool I/O schemas → `tools/story-mcp/spec/002-Tool-Registry.md` and `tools/story-mcp/spec/API.md`.
 - Wire protocol (JSON-RPC over stdio, `initialize` handshake) → `tools/story-mcp/spec/001-Wire-Protocol.md`.
 - Write-surface gating → `tools/story-mcp/spec/003-Write-Surface-Gating.md`.
-- Recorder integration (`record-as-variant`) → `story-recorder.md` (sibling leaf).
+- The **run-side** loop (`run-variant` / `read-failures` / `record-as-variant`) → the `re-frame2-pair` skill (it owns the live-runtime Story tools).
+- Recorder integration (`record-as-variant`) → `story-recorder.md` (sibling leaf — recording is a run-side capture).
 - Variant body shape, `:rf.assert/*` vocabulary → `stories.md` (sibling leaf).
 
 ---
 
-*Derived from `tools/story-mcp/spec/` @ main. Re-verify after MCP tool-registry changes or write-surface gating updates.*
+*Derived from `tools/story-mcp/spec/` @ main. Re-verify after MCP tool-registry changes, write-surface gating updates, or any change to the `re-frame2` ↔ `re-frame2-pair` authoring/run split (`scripts/check_skill_mcp_drift.py`).*

--- a/skills/re-frame2/references/tooling/story-recorder.md
+++ b/skills/re-frame2/references/tooling/story-recorder.md
@@ -114,7 +114,7 @@ Paste into the stories namespace. Done. (The bare-vector shorthand `:script [[:d
 
 ## MCP — `record-as-variant`
 
-The story-mcp `record-as-variant` tool calls the same public surface through the Tool-Pair bridge: `start-recording!` → drive interactions (programmatic dispatches or human-in-canvas) → `stop-recording!` → `gen-play-snippet` → snippet returned as the tool's structured output. See `story-mcp-loop.md` for the agent self-healing loop that uses this.
+The story-mcp `record-as-variant` tool calls the same public surface through the Tool-Pair bridge: `start-recording!` → drive interactions (programmatic dispatches or human-in-canvas) → `stop-recording!` → `gen-play-snippet` → snippet returned as the tool's structured output. `record-as-variant` is a **run-side tool owned by the `re-frame2-pair` skill** (it captures a cascade against a live runtime) — this authoring skill is not allow-listed for it. Author the recorded `:script` body here; drive the capture from a `re-frame2-pair` session. See `story-mcp-loop.md` for the author/refine vs run-side split and the handoff recipe.
 
 **The MCP path inherits the same four-filter pipeline, including layer 4 (sensitivity).** `record-as-variant` does not — and must not — bypass `:sensitive?` redaction: the tool's structured output is shipped over an MCP transport to an agent process, which is a wire boundary, so sensitive payloads must never appear in the returned `:script` body. The tool also never accepts a `:rf.privacy/show-sensitive? true` override at call time. If a recording session captured any sensitive events, the response carries the same `[:rf/redacted]` placeholders the in-canvas overlay shows, plus a metadata count of redactions for the agent to surface to the human.
 
@@ -125,7 +125,7 @@ Authoring rule for tools that consume `gen-play-snippet` output (or call `record
 - Capture boundary, public API, MCP wiring rationale → `tools/story/spec/005-SOTA-Features.md` §Test Codegen.
 - Trace-bus listener primitive → `tools/story/spec/003-Render-Shell.md` §Trace bus, and Spec 009 §Listener contract.
 - Variant body shape (where the recorded `:script` lands) → `stories.md` (sibling leaf).
-- MCP self-healing loop → `story-mcp-loop.md` (sibling leaf).
+- Story-MCP author/refine side + the run-side handoff to `re-frame2-pair` (which owns `record-as-variant` / `run-variant` / `read-failures`) → `story-mcp-loop.md` (sibling leaf).
 
 ---
 


### PR DESCRIPTION
Aligns `skills/re-frame2` per rf2-r2xswa (best-practice review), three findings.

**Finding 1 — Story-MCP author/run boundary.** The shipped hybrid split (`scripts/check_skill_mcp_drift.py` marks `run-variant`/`read-failures`/`record-as-variant`/`run-a11y`/`snapshot-identity` as `intentional_server_only` for `re-frame2`) makes the run loop a `re-frame2-pair` surface. Resolution is option (b): rewrote `story-mcp-loop.md` from an executable self-healing loop the authoring skill cannot run into an author/refine recipe (register / preview / get / explain — the tools this skill owns) plus an explicit handoff to `re-frame2-pair` for the run/self-heal loop. Fixed the SKILL.md hybrid-split comment + tooling summary and the stale self-healing-loop references in `stories.md` and `story-recorder.md`.

**Finding 2 — verification.** Replaced the blanket 'the user runs tests; this skill does not' with scoped guidance: with shell/tool access, run the nearest relevant gate after changing code/tests; chat-only sessions name the gate for the user. Added a narrow Bash verification surface to the frontmatter, a SKILL.md 'Verify what you changed' section, a `testing.md` 'Discovering a project's gates' recipe (deps.edn / shadow-cljs.edn / package.json / README), and a done-checklist item recording what was run vs skipped.

**Finding 3 — eval-docs drift.** Corrected the eval README count (six -> eight) + per-dimension breakdown, documented `evals/` as a repo-maintenance artifact deliberately not in the package (and clarified the top-level README Status link), and added `scripts/check_skill_eval_docs.py` (self-test, wired into `test-fast-pr.sh`) so the README count/names/tally cannot silently stale from `evals.json`. Added eval 8 exercising the Story authoring/run boundary (fails if the documented loop needs tools unavailable to the active skill).

## Quality gates
- `python scripts/check_skill_eval_docs.py --self-test` — pass (new gate)
- `python scripts/check_skill_eval_docs.py --ci` — no drift
- `python scripts/check_skill_mcp_drift.py --ci` — no drift (run-side tools stay out of re-frame2's allow-list)
- `python scripts/check_skill_package_refs.py --ci` — pass
- `python scripts/check_skill_redirect_anchors.py` — pass
- `python scripts/check_doc_slugs.py` — pass
- `python scripts/check_skill_migration_cites.py --ci` — pass
- `bash scripts/check-no-hardcoded-paths.sh` — pass
- `python -m mkdocs build --strict` — built (exit 0)
- `evals.json` valid JSON — 8 evals (4 recipe-correctness, 2 discovery, 2 routing-correctness)