### PR TITLE
refactor(template): strict flags + generated docs drift (rf2-qck7t7)

### DIFF
--- a/tools/template/README.md
+++ b/tools/template/README.md
@@ -101,9 +101,14 @@ variants follow once those adapters' Story coverage matches Reagent's.
 `:css` (e.g. `:tailwind`) and `:include-ssr?` are reserved in the v1
 flag set but **not yet implemented** — they are gated on rf2-gthro
 (Tailwind v4 verification) and rf2-0m5ea (SSR validation)
-respectively. They are not accepted as live command flags today;
-passing them has no effect. See [`spec/API.md`](./spec/API.md#args-reference)
-for the flag-set status.
+respectively. Passing one today **fails closed** with
+`:rf.error/template-unsupported-flag` (naming the flag and its gating
+bead) rather than silently scaffolding a vanilla app that lacks the
+feature. Any other unrecognised template flag — including a typo such
+as `:include-story` (missing the `?`) — fails closed with
+`:rf.error/template-unknown-flag`. See
+[`spec/API.md`](./spec/API.md#args-reference) for the flag-set status
+and the error table.
 
 ### Post-split (future)
 

--- a/tools/template/resources/day8/re_frame2_template/_helix/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_helix/deps.edn
@@ -24,7 +24,7 @@
          ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
          day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
-         ;; [data-rf-xray-host] left layout column. Wired via
+         ;; [data-rf-xray-host] right-side layout host. Wired via
          ;; :devtools/preloads in shadow-cljs.edn.
          ;; Lockstep with the core coord.
          day8/re-frame2-xray      {:mvn/version "{{rf2-version}}"}

--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps.edn
@@ -25,7 +25,7 @@
          ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
          day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
-         ;; [data-rf-xray-host] left layout column. Wired via
+         ;; [data-rf-xray-host] right-side layout host. Wired via
          ;; :devtools/preloads in shadow-cljs.edn. Lockstep with
          ;; the core coord — Xray publishes at the same version.
          day8/re-frame2-xray      {:mvn/version "{{rf2-version}}"}

--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_story.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_story.edn
@@ -31,7 +31,7 @@
          ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
          day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
-         ;; [data-rf-xray-host] left layout column. Wired via
+         ;; [data-rf-xray-host] right-side layout host. Wired via
          ;; :devtools/preloads in shadow-cljs.edn. Lockstep with
          ;; the core coord — Xray publishes at the same version.
          day8/re-frame2-xray      {:mvn/version "{{rf2-version}}"}

--- a/tools/template/resources/day8/re_frame2_template/_shared/shadow-cljs.edn
+++ b/tools/template/resources/day8/re_frame2_template/_shared/shadow-cljs.edn
@@ -24,7 +24,7 @@
    ;; hot reload by default — no :after-load hook needed.
    ;; :devtools/preloads loads Xray in dev watch/compile builds.
    ;; Once rf/init! installs the adapter, Xray auto-mounts into
-   ;; resources/public/index.html's [data-rf-xray-host] left column.
+   ;; resources/public/index.html's [data-rf-xray-host] right-side host.
    ;; Cut from release builds automatically.
    :devtools   {:preloads [day8.re-frame2-xray.preload]}}
 

--- a/tools/template/resources/day8/re_frame2_template/_uix/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_uix/deps.edn
@@ -25,7 +25,7 @@
          ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
          day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
-         ;; [data-rf-xray-host] left layout column. Wired via
+         ;; [data-rf-xray-host] right-side layout host. Wired via
          ;; :devtools/preloads in shadow-cljs.edn.
          ;; Lockstep with the core coord.
          day8/re-frame2-xray      {:mvn/version "{{rf2-version}}"}

--- a/tools/template/spec/API.md
+++ b/tools/template/spec/API.md
@@ -109,7 +109,15 @@ absence would force the user into hand-wiring known idioms.
 Future toggles (`:css`, `:include-ssr?`) slot in here. The v1 set
 is locked at three flags total (`:include-story?`, `:css`,
 `:include-ssr?`); the latter two are gated on rf2-gthro (Tailwind
-v4 verification) and rf2-0m5ea (SSR validation) respectively.
+v4 verification) and rf2-0m5ea (SSR validation) respectively. Until
+those gates clear, passing `:css` or `:include-ssr?` **fails closed**
+with `:rf.error/template-unsupported-flag` (the flag and its gating
+bead are named in the message) — it is not silently dropped. Any
+other unrecognised template key, including a typo of a live flag
+(e.g. `:include-story` for `:include-story?`), fails closed with
+`:rf.error/template-unknown-flag`. The gate distinguishes template
+keys from deps-new's own harness keys via a pinned allowlist (the
+deps-new coord is pinned in the template's `deps.edn`).
 Resist further proliferation — every additional flag requires
 explicit DESIGN-RATIONALE justification.
 
@@ -170,6 +178,8 @@ mirror the chosen `:substrate` + `:include-story?` flags.
 | `:substrate` not one of `#{:reagent :uix :helix}` | `:rf.error/template-substrate-must-be-one-of` (keyword arg outside the valid set) / `:rf.error/template-substrate-must-be-keyword` (non-keyword shape — string, symbol, number, …) | `ex-info` thrown; message names the valid set; `ex-data` carries `{:substrate <bad-value> :valid #{...}}`. |
 | `:include-story?` not `true` / `false` / `nil` | `:rf.error/template-bad-include-story-flag` | `ex-info` thrown; message gives the offending value. |
 | `:include-story? true` with non-Reagent substrate | `:rf.error/template-include-story-reagent-only` | `ex-info` thrown; message says "Reagent-only in v1" and names the chosen substrate. |
+| Reserved-but-unimplemented flag passed (`:css`, `:include-ssr?`) | `:rf.error/template-unsupported-flag` | `ex-info` thrown; message names the flag and its gating bead (rf2-gthro / rf2-0m5ea). Fails closed — does **not** silently scaffold a vanilla app. |
+| Unknown template flag (incl. typos like `:include-story`, `:include-stories?`) | `:rf.error/template-unknown-flag` | `ex-info` thrown; message lists the unknown key(s) and the accepted flag set. Distinguished from deps-new harness keys via a pinned allowlist. |
 | `:name` missing | n/a (deps-new) | deps-new's harness rejects before template is invoked. |
 | `:name` not group-qualified | n/a (deps-new) | **Not rejected.** deps-new doubles a bare name (`my-app` → the symbol `my-app/my-app`), so the generated namespace is `my-app.my-app` and the source nests under `src/my_app/my_app/`. Always pass a group-qualified `:name` (`acme/my-app`); an unqualified one scaffolds, but with a doubled, almost-certainly-unintended namespace. |
 | Target directory already exists | n/a (deps-new) | deps-new's harness aborts to avoid clobbering (unless `:overwrite` is passed). |

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -16,7 +16,10 @@
      - Substrates: Reagent / UIx / Helix (full matrix).
      - Flags: `:include-story?` (Reagent-only in v1; UIx + Helix variants
        follow once Story's adapter coverage matches Reagent's).
-     - Pending flags (deferred to later stages): `:css`, `:include-ssr?`.
+     - Pending flags (reserved, gated to later stages): `:css`,
+       `:include-ssr?`. Passing one today fails closed with
+       `:rf.error/template-unsupported-flag` (it is NOT silently dropped)
+       — see `gate-arg-keys!`.
 
    ## Substitution engine note
 
@@ -36,7 +39,8 @@
    The steady-state shape (see tools/template/spec/003-DepsNew-Rebuild-Plan.md
    §1) is the same matrix; additional flags (`:css`, `:include-ssr?`)
    slot in here once their upstream gates clear (rf2-gthro, rf2-0m5ea)."
-  (:require [clojure.string :as string]))
+  (:require [clojure.set :as set]
+            [clojure.string :as string]))
 
 ;; -- substrate registry -----------------------------------------------------
 ;;
@@ -97,6 +101,90 @@
                        :substrate substrate-kw
                        :valid     valid-substrates})))
     substrate-kw))
+
+;; -- argument-key gate -------------------------------------------------------
+;;
+;; deps-new hands `data-fn` a single map that merges its own harness keys
+;; (the project-name derivations + run metadata) with whatever top-level
+;; k/v args the caller passed. We accept exactly two template-specific
+;; flags today (`:substrate`, `:include-story?`); the `:css` / `:include-ssr?`
+;; flags are reserved-but-unimplemented (gated on rf2-gthro / rf2-0m5ea).
+;;
+;; The substrate posture already fails closed on bad values; this gate
+;; extends that strictness to the *key set* so a flag typo
+;; (`:include-story`) or a documented-future flag (`:css :tailwind`) can't
+;; fail open into a misleading vanilla scaffold (rf2-qck7t7 Finding #1).
+;;
+;; HOW WE DISTINGUISH HARNESS KEYS FROM TEMPLATE KEYS: deps-new's
+;; `preprocess-options` (org.corfield.new.impl) populates a fixed, known
+;; set of harness keys before `data-fn` runs. We pin the deps-new coord in
+;; this template's deps.edn (and the §3 release install), so that set is
+;; deterministic — we allowlist it and reject anything outside it. If the
+;; pinned deps-new version is bumped and adds a harness key, this list must
+;; grow in lockstep (the gate would otherwise false-reject the new key);
+;; `arg-key-gate-rejects-unknown-test` exercises a representative harness
+;; key to keep that coupling honest.
+
+(def ^:private deps-new-harness-keys
+  "The keys deps-new injects into the `data` map before `data-fn` runs
+   (deps-new pinned at v0.12.1 in deps.edn): the `preprocess-options`
+   project-name derivations + run metadata, the `:template-dir`
+   `apply-template-fns` adds just before invoking `data-fn`, plus the
+   caller-supplied harness opts that survive `preprocess-options`'
+   `dissoc` (`:src-dirs`, `:overwrite`). Verified against the pinned
+   coord's source (org.corfield.new.impl)."
+  #{:artifact/id :developer :git-dir :group/id :main :name :now/date
+    :now/year :overwrite :raw-name :scm/domain :scm/repo :scm/user
+    :src-dirs :target-dir :template :template-dir :top :user :version})
+
+(def ^:private template-flag-keys
+  "The template-specific flags we accept today."
+  #{:substrate :include-story?})
+
+(def ^:private reserved-flag-gates
+  "Reserved-but-unimplemented flags → the gating bead that must clear
+   before they go live. Passing one today fails closed rather than
+   scaffolding a vanilla app that silently lacks the feature."
+  {:css          "rf2-gthro (Tailwind v4 verification)"
+   :include-ssr? "rf2-0m5ea (SSR validation)"})
+
+(defn- gate-arg-keys!
+  "Fail closed on reserved or unknown template arguments.
+
+   - A reserved flag (`:css`, `:include-ssr?`) throws
+     `:rf.error/template-unsupported-flag`, naming the flag and its
+     gating bead — it is not silently dropped.
+   - Any key that is neither a deps-new harness key nor a live
+     template flag throws `:rf.error/template-unknown-flag` (catches
+     typos like `:include-story` / `:include-stories?`)."
+  [data]
+  (doseq [[flag gate] reserved-flag-gates]
+    (when (contains? data flag)
+      (throw (ex-info ":rf.error/template-unsupported-flag"
+                      {:rf.error/id :rf.error/template-unsupported-flag
+                       :where    'template/gate-arg-keys!
+                       :recovery :remove-flag
+                       :reason   (str (pr-str flag) " is reserved in the v1 "
+                                      "flag set but not yet implemented "
+                                      "(gated on " gate "). Remove it; "
+                                      "the scaffold can't honour it today.")
+                       :flag     flag
+                       :gate     gate}))))
+  (let [known   (set/union deps-new-harness-keys template-flag-keys)
+        unknown (remove known (keys data))]
+    (when (seq unknown)
+      (throw (ex-info ":rf.error/template-unknown-flag"
+                      {:rf.error/id :rf.error/template-unknown-flag
+                       :where    'template/gate-arg-keys!
+                       :recovery :fix-registration
+                       :reason   (str "Unknown template argument(s): "
+                                      (pr-str (vec unknown))
+                                      ". The accepted template flags are "
+                                      (pr-str template-flag-keys)
+                                      " (check for a typo, e.g. "
+                                      ":include-story -> :include-story?).")
+                       :unknown  (vec unknown)
+                       :accepted template-flag-keys})))))
 
 ;; -- :include-story? coercion ----------------------------------------------
 
@@ -190,6 +278,10 @@
    `:include-story?` for `template-fn`'s switch (`->subst-map` would
    otherwise coerce the keyword to a string)."
   [data]
+  ;; Fail closed on reserved + unknown arguments BEFORE any coercion, so a
+  ;; flag typo or a documented-future flag never produces a misleading
+  ;; vanilla scaffold (rf2-qck7t7 Finding #1).
+  (gate-arg-keys! data)
   (let [substrate       (coerce-substrate (:substrate data))
         include-story?  (coerce-include-story? (:include-story? data))]
     ;; Reagent-only guard — hoisted above the name-derivation `let` so the

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -563,6 +563,44 @@
                  "collapse so release builds (no Xray preload) don't ship "
                  "a blank gutter."))))))
 
+;; --- Stale Xray-layout-wording scan (rf2-qck7t7 Finding #2) ----------------
+;;
+;; `assert-xray-host-contract!` above pins the RUNTIME shape (DOM order +
+;; resize CSS var) for index.html / app.css only. The prose in the other
+;; emitted text files (deps.edn / shadow-cljs.edn comments) escaped that
+;; net: they kept describing the host as a "left layout column" / "left
+;; column" long after the runtime moved to the right-side layout-host
+;; contract. This guard scans EVERY emitted text file for the stale
+;; left-side wording so a future prose regression can't ship green while
+;; the narrow runtime tests stay happy.
+
+(def ^:private stale-xray-wording-re
+  #"(?i)left[- ]?(layout )?column")
+
+(defn- assert-no-stale-xray-wording!
+  "Walk the whole emitted tree and fail on any text file that still
+   describes the Xray host as a left column. The host is a RIGHT-side
+   layout host (README/CSS contract); the deps/shadow comments must say
+   so too. Only files that actually mention Xray/`data-rf-xray-host` are
+   checked, so the scan can't false-fire on unrelated app prose that
+   happens to use the phrase 'left column'."
+  [substrate ^java.io.File root]
+  (doseq [^java.io.File f (file-seq root)
+          :when (.isFile f)
+          ;; Restrict to the scaffold's text artefacts; defensive against
+          ;; anything binary a stray build step might leave behind.
+          :when (re-find #"(?i)\.(edn|cljs?|clj|md|html?|css|json|ya?ml|txt|js|cjs)$"
+                         (.getName f))]
+    (let [text (slurp f)]
+      (when (re-find #"(?i)data-rf-xray-host|xray" text)
+        (is (not (re-find stale-xray-wording-re text))
+            (str "emitted file " (.getName f) " (" substrate
+                 ") still describes the Xray host with stale left-side "
+                 "wording (\"left layout column\" / \"left column\"). The "
+                 "host is a RIGHT-side layout host — match the README/CSS "
+                 "contract (tools/xray/spec/011-Launch-Modes.md §Layout "
+                 "host contract)."))))))
+
 (defn- run-for-substrate!
   [substrate]
   (let [tmp  (tmp-dir (str "rf2-emission-" (name substrate) "-"))
@@ -572,6 +610,7 @@
         (assert-events-test-shape! substrate proj)
         (assert-scratch-with-frame-shape! substrate proj)
         (assert-xray-host-contract! substrate proj)
+        (assert-no-stale-xray-wording! substrate proj)
         (doseq [rel ["test/acme/my_app/events_test.cljs"
                      "src/acme/my_app/events.cljs"
                      "src/acme/my_app/schema.cljs"

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -25,7 +25,7 @@
             [clojure.string :as string]
             [day8.re-frame2-template.test-support
              :refer [tmp-dir delete-recursively run-template!
-                     read-edn file-exists?]]))
+                     run-template-opts! read-edn file-exists?]]))
 
 ;; --- Test helpers ----------------------------------------------------------
 ;;
@@ -851,5 +851,90 @@
                               #":rf\.error/template-bad-include-story-flag"
                               (run-template! tmp "acme/my-app" :reagent "yes"))
             "non-boolean :include-story? is rejected")
+        (finally
+          (delete-recursively tmp))))))
+
+;; --- argument-key gate (rf2-qck7t7 Finding #1) ----------------------------
+;;
+;; The substrate posture fails closed on bad VALUES; these tests pin the
+;; complementary strictness on the KEY set. Reserved-but-unimplemented
+;; flags and likely typos must fail closed rather than fail open into a
+;; misleading vanilla scaffold. Each asserts the emitted dir does NOT
+;; exist after the throw — the gate fires before any file is written.
+
+(defn- assert-no-scaffold-emitted!
+  [^java.nio.file.Path tmp]
+  (is (zero? (count (.listFiles (clojure.java.io/file (.toString tmp)))))
+      "the gate fired before any scaffold was emitted (tmp dir is empty)"))
+
+(deftest reserved-css-flag-rejected-test
+  (testing ":css :tailwind is reserved (gated on rf2-gthro) and fails
+            closed — it does NOT silently emit the default scaffold"
+    (let [tmp (tmp-dir "rf2-template-css-")]
+      (try
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #":rf\.error/template-unsupported-flag"
+                              (run-template-opts! tmp "acme/my-app"
+                                                  {:css :tailwind}))
+            ":css :tailwind is rejected as an unsupported reserved flag")
+        (assert-no-scaffold-emitted! tmp)
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest reserved-include-ssr-flag-rejected-test
+  (testing ":include-ssr? true is reserved (gated on rf2-0m5ea) and fails
+            closed — it does NOT silently emit the default scaffold"
+    (let [tmp (tmp-dir "rf2-template-ssr-")]
+      (try
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #":rf\.error/template-unsupported-flag"
+                              (run-template-opts! tmp "acme/my-app"
+                                                  {:include-ssr? true}))
+            ":include-ssr? true is rejected as an unsupported reserved flag")
+        (assert-no-scaffold-emitted! tmp)
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest misspelled-story-flag-rejected-test
+  (testing "a one-character Story-flag typo (:include-story, dropping the
+            ?) fails closed rather than scaffolding a Story-less app the
+            user believes has Story"
+    (let [tmp (tmp-dir "rf2-template-typo-")]
+      (try
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #":rf\.error/template-unknown-flag"
+                              (run-template-opts! tmp "acme/my-app"
+                                                  {:include-story true}))
+            ":include-story (typo for :include-story?) is rejected")
+        (assert-no-scaffold-emitted! tmp)
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest pluralised-story-flag-rejected-test
+  (testing "the :include-stories? plural typo also fails closed"
+    (let [tmp (tmp-dir "rf2-template-typo2-")]
+      (try
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #":rf\.error/template-unknown-flag"
+                              (run-template-opts! tmp "acme/my-app"
+                                                  {:include-stories? true}))
+            ":include-stories? (plural typo) is rejected")
+        (assert-no-scaffold-emitted! tmp)
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest harness-keys-not-rejected-test
+  (testing "the gate's allowlist does not false-reject deps-new harness
+            keys — a representative harness key (:overwrite) plus the
+            valid template flags scaffold cleanly"
+    (let [tmp (tmp-dir "rf2-template-harness-")]
+      (try
+        ;; :overwrite + :src-dirs are harness keys run-template-opts!
+        ;; already injects; add an explicit :substrate to confirm the
+        ;; happy path still emits with the gate in place.
+        (let [proj (run-template-opts! tmp "acme/my-app"
+                                       {:substrate :reagent})]
+          (is (file-exists? proj "deps.edn")
+              "a valid invocation still scaffolds with the gate active"))
         (finally
           (delete-recursively tmp))))))

--- a/tools/template/test/day8/re_frame2_template/test_support.clj
+++ b/tools/template/test/day8/re_frame2_template/test_support.clj
@@ -172,3 +172,23 @@
                      (some? include-story?) (assoc :include-story? include-story?))]
      (deps-new/create opts)
      proj-dir)))
+
+(defn run-template-opts!
+  "Like `run-template!`, but merges `extra-opts` straight onto the
+  deps-new opts map — so a test can pass arbitrary template arguments
+  (reserved flags, typo keys, …) that the positional `run-template!`
+  arity can't express. Used by the argument-gate negative tests
+  (rf2-qck7t7): they assert reserved / unknown keys fail closed before
+  any scaffold is emitted."
+  [tmp project-name extra-opts]
+  (let [dir-str   (.toString ^Path tmp)
+        dir-name  (-> project-name name (string/replace #"^.*?/" ""))
+        proj-dir  (io/file dir-str dir-name)
+        opts      (merge {:template   'day8/re-frame2-template
+                          :name       (symbol project-name)
+                          :target-dir (.getCanonicalPath proj-dir)
+                          :src-dirs   [(template-resource-dir)]
+                          :overwrite  :delete}
+                         extra-opts)]
+    (deps-new/create opts)
+    proj-dir))


### PR DESCRIPTION
Closes rf2-qck7t7. Two best-practice findings in `tools/template`.

**Finding #1 (P2) — reserved/unknown template flags fail closed.** `data-fn` now gates its argument keys before any coercion. `:css` / `:include-ssr?` throw `:rf.error/template-unsupported-flag` naming the flag and its gating bead (rf2-gthro / rf2-0m5ea); unrecognised keys (the `:include-story` typo, `:include-stories?`) throw `:rf.error/template-unknown-flag`. The gate distinguishes template flags from deps-new's harness keys via a pinned allowlist (deps-new coord pinned in deps.edn; includes `:template-dir`, which `apply-template-fns` injects). README + spec/API.md now document the deferred flags as rejected with new error-table rows. Negative tests assert the reserved + misspelled flags emit no scaffold; a positive test confirms harness keys aren't false-rejected.

**Finding #2 (P4) — stale 'left column' Xray wording in generated comments.** Replaced `left layout column` / `left column` with the right-side layout-host wording (matching README/CSS) across the four substrate `deps.edn` variants and the shared `shadow-cljs.edn`. Added a generated-output guard that scans every emitted text file for stale left-side wording, closing the gap the narrow runtime tests left open.

## Quality gates
- `tools/template`: `clojure -M:test` — 37 tests, 421 assertions, 0 failures, 0 errors (was 32 / 397).
- All changes scoped to `tools/template`; no `.github/workflows` touch; no `.beads` change.