### PR TITLE
fix(testbed-support): Story-host examples project-root config (rf2-77wqzi)

### DIFF
--- a/examples/reagent/login/stories_host.cljs
+++ b/examples/reagent/login/stories_host.cljs
@@ -99,5 +99,11 @@
   ;; auto-installs the canonical Story vocabulary (rf2-p1ydc).
   (install-live-frame!)
   ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
-  ;; `#/stories` lands on the shell without a manual click-through.
-  (story-host/mount-with-hash-routing! login-app))
+  ;; `#/stories` lands on the shell without a manual click-through. The
+  ;; `:story-subdir` opt (rf2-77wqzi) tells the host this showcase's Story
+  ;; source-coords are classpath-relative to `examples/reagent`, so the host
+  ;; resolves the on-disk project-root (build-env define or `?project-root=`
+  ;; override, cross-platform) and calls `story/configure!` itself — that
+  ;; also bridges the root into Xray's slot. Without it the Story 'open in
+  ;; editor' chips would resolve `login/stories.cljs` against a nil root.
+  (story-host/mount-with-hash-routing! login-app {:story-subdir "examples/reagent"}))

--- a/examples/reagent/nine_states/stories_host.cljs
+++ b/examples/reagent/nine_states/stories_host.cljs
@@ -103,5 +103,11 @@
   ;; auto-installs the canonical Story vocabulary (rf2-p1ydc).
   (install-live-frame!)
   ;; Wire the live-app↔Story-shell hash router (shared helper) so reloading
-  ;; `#/stories` lands on the shell without a manual click-through.
-  (story-host/mount-with-hash-routing! nine-states-app))
+  ;; `#/stories` lands on the shell without a manual click-through. The
+  ;; `:story-subdir` opt (rf2-77wqzi) tells the host this showcase's Story
+  ;; source-coords are classpath-relative to `examples/reagent`, so the host
+  ;; resolves the on-disk project-root (build-env define or `?project-root=`
+  ;; override, cross-platform) and calls `story/configure!` itself — that
+  ;; also bridges the root into Xray's slot. Without it the Story 'open in
+  ;; editor' chips would resolve `nine_states/stories.cljs` against a nil root.
+  (story-host/mount-with-hash-routing! nine-states-app {:story-subdir "examples/reagent"}))

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1240,20 +1240,28 @@
   ;; Side Effects panels.
   ;;
   ;; The `nine-states.*` namespaces resolve via the `../examples/reagent`
-  ;; source-path (already on :source-paths near the top of this file); the
-  ;; example does NOT use `re-frame.testbed.config`, so this build omits
-  ;; the open-in-editor repo-root closure-define the counter-with-stories
-  ;; / login-form testbed builds carry (those live under
-  ;; tools/story/testbeds and need it).
+  ;; source-path (already on :source-paths near the top of this file). The
+  ;; showcase host declares `:story-subdir "examples/reagent"` to the shared
+  ;; `re-frame.testbed.story-host` helper, which resolves the open-in-editor
+  ;; project-root through `re-frame.testbed.config` (rf2-77wqzi) — so this
+  ;; build seeds the `repo-root` closure-define from the build env, exactly
+  ;; like the counter-with-stories / login-form testbed builds. Without the
+  ;; define the Story 'open in editor' chips resolve `nine_states/stories.cljs`
+  ;; against a nil root (the false-green rf2-77wqzi fixed).
   :examples/nine-states-with-stories
-  {:target     :browser
-   :output-dir "out/examples/nine-states-with-stories"
-   :asset-path "."
-   :modules    {:main {:init-fn nine-states.stories-host/run}}
+  {:target           :browser
+   :output-dir       "out/examples/nine-states-with-stories"
+   :asset-path       "."
+   ;; rf2-77wqzi — build-env project-root for open-in-editor (see
+   ;; :examples/login-form above for the mechanism).
+   :compiler-options {:closure-defines
+                      {re-frame.testbed.config/repo-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+   :modules          {:main {:init-fn nine-states.stories-host/run}}
    ;; rf2-qhhxp — re-frame2-pair.runtime preload added so pair-MCP can
    ;; probe this Story showcase's live runtime alongside Xray.
-   :devtools   {:preloads [re-frame2-pair.runtime
-                           day8.re-frame2-xray.preload]}}
+   :devtools         {:preloads [re-frame2-pair.runtime
+                                 day8.re-frame2-xray.preload]}}
 
   ;; Login Story + Xray showcase (rf2-p8v0q). The examples/reagent/login
   ;; example wired up as a Story showcase: `login.stories` registers one
@@ -1268,21 +1276,29 @@
   ;; schema-rejection / 401 paths light the Issues ribbon).
   ;;
   ;; The `login.*` namespaces resolve via the `../examples/reagent`
-  ;; source-path (already on :source-paths near the top of this file); the
-  ;; example does NOT use `re-frame.testbed.config`, so this build omits
-  ;; the open-in-editor repo-root closure-define the counter-with-stories
-  ;; / login-form testbed builds carry (those live under
-  ;; tools/story/testbeds and need it). Mirrors
+  ;; source-path (already on :source-paths near the top of this file). The
+  ;; showcase host declares `:story-subdir "examples/reagent"` to the shared
+  ;; `re-frame.testbed.story-host` helper, which resolves the open-in-editor
+  ;; project-root through `re-frame.testbed.config` (rf2-77wqzi) — so this
+  ;; build seeds the `repo-root` closure-define from the build env, exactly
+  ;; like the counter-with-stories / login-form testbed builds. Without the
+  ;; define the Story 'open in editor' chips resolve `login/stories.cljs`
+  ;; against a nil root (the false-green rf2-77wqzi fixed). Mirrors
   ;; :examples/nine-states-with-stories above.
   :examples/login-with-stories
-  {:target     :browser
-   :output-dir "out/examples/login-with-stories"
-   :asset-path "."
-   :modules    {:main {:init-fn login.stories-host/run}}
+  {:target           :browser
+   :output-dir       "out/examples/login-with-stories"
+   :asset-path       "."
+   ;; rf2-77wqzi — build-env project-root for open-in-editor (see
+   ;; :examples/login-form above for the mechanism).
+   :compiler-options {:closure-defines
+                      {re-frame.testbed.config/repo-root
+                       #shadow/env ["RF2_TESTBED_PROJECT_ROOT" ""]}}
+   :modules          {:main {:init-fn login.stories-host/run}}
    ;; rf2-qhhxp — re-frame2-pair.runtime preload added so pair-MCP can
    ;; probe this Story showcase's live runtime alongside Xray.
-   :devtools   {:preloads [re-frame2-pair.runtime
-                           day8.re-frame2-xray.preload]}}
+   :devtools         {:preloads [re-frame2-pair.runtime
+                                 day8.re-frame2-xray.preload]}}
 
   ;; (removed rf2-9jfo1.2) :examples/xray-rhs-smoke build target —
   ;; the original Playwright `spec.cjs` was deleted by rf2-piucm in

--- a/tools/testbed-support/README.md
+++ b/tools/testbed-support/README.md
@@ -59,14 +59,34 @@ six hosts (`counter_with_stories`, `login_form`, the `login` and
 scaffolding), already drifting in the per-testbed boot specifics they each add.
 
 `re-frame.testbed.story-host/mount-with-hash-routing!` owns that harness:
-the testbed does its own boot (Xray config, `rf/init!`, `story/configure!`,
-`:fx-overrides`, seed dispatches, CI hooks) and calls the helper LAST with
-its live-app root view. Five of the six hosts now call it (the four Story
-showcases above plus `panel_gallery`, which previously installed a bare
-per-`run` `hashchange` listener — rf2-x31vn); the **template copy stays
-standalone by design** — it is `resources/` scaffolding emitted into a fresh
-consumer project whose classpath has no access to this dev-repo-internal
-helper.
+the testbed does its own boot (Xray config, `rf/init!`, `:fx-overrides`,
+seed dispatches, CI hooks) and calls the helper LAST with its live-app root
+view. Five of the six hosts now call it (the four Story showcases above plus
+`panel_gallery`, which previously installed a bare per-`run` `hashchange`
+listener — rf2-x31vn); the **template copy stays standalone by design** — it
+is `resources/` scaffolding emitted into a fresh consumer project whose
+classpath has no access to this dev-repo-internal helper.
+
+### The open-in-editor project-root is a host responsibility (rf2-77wqzi)
+
+Story stamps each registered source-coord with a **classpath-relative**
+`:file` slot (e.g. `login/stories.cljs`); the 'open in editor' chip prepends
+an on-disk project-root to build a real editor URI. That config used to be
+left inline in every consuming `run` (`story/configure! {:rf.story/project-root …}`),
+and the two `examples/reagent` showcases silently forgot it — they mounted
+the shell fine but their Story source links resolved against a nil root, so
+OS editor handlers could not open the file (a false green).
+
+The optional second arg to `mount-with-hash-routing!` closes that gap: a
+consumer declares its tool-relative source subdir via `:story-subdir` (e.g.
+`{:story-subdir "examples/reagent"}`) and the host resolves the on-disk root
+through `resolve-project-root` (build-env define or `?project-root=` override,
+cross-platform) and calls `story/configure!` itself — which also bridges the
+root into Xray's slot. Omit the opt (or use the 1-arity call) when the
+consumer drives `story/configure!` itself. A blank subdir, or a checkout with
+no resolvable root, configures nothing (graceful no-op). Declaring the subdir
+means a Story-host consumer can no longer mount the shell while silently
+forgetting the project-root config.
 
 ## Layout
 

--- a/tools/testbed-support/src/re_frame/testbed/story_host.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/story_host.cljs
@@ -38,9 +38,38 @@
   Co-located with `re-frame.testbed.config` under `tools/testbed-support/
   src`, which is already on every testbed build's shadow-cljs source path —
   so consuming testbeds need no build-wiring change. Bundle-isolation holds:
-  nothing under `implementation/` `:require`s it (it lives under tools/)."
-  (:require [reagent.dom.client :as rdc]
-            [re-frame.story :as story]))
+  nothing under `implementation/` `:require`s it (it lives under tools/).
+
+  ## The open-in-editor project-root (rf2-77wqzi)
+
+  Story stamps each registered source-coord with a CLASSPATH-RELATIVE
+  `:file` slot (e.g. `login/stories.cljs`); the 'open in editor' chip
+  prepends an on-disk *project-root* to turn it into a real editor URI
+  (`re-frame.story.config/set-project-root!`). That root is per-build
+  (it differs per clone), so it cannot be baked in — the host must hand
+  it to `story/configure!` at boot. Leaving that call inline in every
+  consuming `run` invited exactly the omission rf2-77wqzi found: the
+  two `examples/reagent` Story showcases mounted the shell fine but
+  never configured a root, so their Story source links resolved against
+  a nil root and OS editor handlers could not open the file (a false
+  green — the shell loads, the chip shows, the link is dead).
+
+  To make that impossible to forget, the project-root config is now a
+  HOST responsibility: a consumer declares its tool-relative source
+  subdir via the `:story-subdir` opt and `mount-with-hash-routing!`
+  resolves the root (through the shared `re-frame.testbed.config`
+  cross-platform mechanism — build-env define or `?project-root=`
+  override) and calls `story/configure!` itself. `story/configure!`
+  with `:rf.story/project-root` also bridges the root into Xray's slot
+  (`xray-preset/propagate-project-root!`), so the Xray-as-RHS chips
+  resolve too. When no subdir is declared (or no root is resolvable),
+  the host configures nothing and open-in-editor degrades to a graceful
+  no-op — the same blank-input contract `set-project-root!` already
+  encodes."
+  (:require [clojure.string :as str]
+            [reagent.dom.client :as rdc]
+            [re-frame.story :as story]
+            [re-frame.testbed.config :as testbed-config]))
 
 ;; -- The live-app React root ----------------------------------------------
 ;;
@@ -104,6 +133,48 @@
       (mount-stories!)
       (mount-app!))))
 
+;; -- Open-in-editor project-root (rf2-77wqzi) ------------------------------
+;;
+;; A consumer declares its tool-relative source subdir (e.g.
+;; `"examples/reagent"` or `"tools/story/testbeds"`) and the host resolves
+;; the on-disk root through the shared cross-platform mechanism and hands it
+;; to `story/configure!`. Centralising it here means a Story-host consumer
+;; can no longer mount the shell while silently forgetting the project-root
+;; config — the omission rf2-77wqzi found in the two `examples/reagent`
+;; showcases. A blank subdir, or a checkout where neither the build-time
+;; define nor a `?project-root=` override is present, resolves to nil and
+;; configures no root (graceful no-op, matching `set-project-root!`).
+
+(defn- configure-story-project-root!
+  "Resolve the open-in-editor project-root for the given tool-relative
+  `story-subdir` and hand it to `story/configure!`. `story/configure!`
+  with `:rf.story/project-root` also bridges the root into Xray's slot, so
+  Xray-as-RHS source-coord chips resolve against the same root. A nil /
+  blank `story-subdir` skips configuration entirely; a resolved nil root
+  (no build-time define, no `?project-root=` override) is passed through
+  and `set-project-root!` clears it — open-in-editor degrades to a no-op."
+  [story-subdir]
+  (when (and (string? story-subdir) (not (str/blank? story-subdir)))
+    (story/configure!
+     {:rf.story/project-root (testbed-config/resolve-project-root story-subdir)})))
+
+;; -- The hash router -------------------------------------------------------
+
+(defn- mount-router!
+  "Install (remove-then-add) the single `hashchange` listener for
+  `root-view` and render the surface the current hash selects. The
+  remove-then-add discipline keeps exactly one listener active across
+  hot-reload re-`run`s (see the `mount-with-hash-routing!` docstring)."
+  [root-view]
+  (reset! root-view* root-view)
+  ;; Remove the listener we installed last time (if any) before installing
+  ;; the new one, so a hot-reload re-`run` never stacks a duplicate.
+  (when-let [prev @hash-listener*]
+    (.removeEventListener js/window "hashchange" prev))
+  (.addEventListener js/window "hashchange" on-hash-change!)
+  (reset! hash-listener* on-hash-change!)
+  (on-hash-change!))
+
 ;; -- The public host entry -------------------------------------------------
 
 (defn mount-with-hash-routing!
@@ -114,7 +185,24 @@
   URL hash selects: `#/stories…` mounts the Story shell, anything else
   mounts `root-view` as the live app. Call this at the END of a testbed's
   `run`, after the testbed has done its own boot specifics (Xray config,
-  `rf/init!`, `story/configure!`, `:fx-overrides`, seed dispatches, …).
+  `rf/init!`, `:fx-overrides`, seed dispatches, …).
+
+  ## opts
+
+  The optional second arg is a map. Recognised key:
+
+  - `:story-subdir` — the tool-relative source subdir whose
+    classpath-relative Story coords need an on-disk root prepended for
+    'open in editor' (e.g. `\"examples/reagent\"`,
+    `\"tools/story/testbeds\"`). When supplied, the host resolves the root
+    via `re-frame.testbed.config/resolve-project-root` (build-env define or
+    `?project-root=` override, cross-platform) and calls `story/configure!`
+    with `:rf.story/project-root` — which also bridges the root into Xray's
+    slot. This is the ONE host-owned contract for Story-host project-root
+    config (rf2-77wqzi): declare the subdir and the host wires the rest, so
+    a consumer can no longer mount the shell while silently forgetting it.
+    Omit the opt (or pass a 1-arity call) when the consumer configures
+    `story/configure!` itself.
 
   Idempotent across hot-reload: the React root is a `defonce` here, and the
   `hashchange` listener installed on the *previous* `run` is explicitly
@@ -125,12 +213,7 @@
   re-`run` would otherwise pass a different reference and STACK a second
   listener. Remove-then-add keeps exactly one listener active across any
   number of re-`run`s, however the listener fn's identity churns."
-  [root-view]
-  (reset! root-view* root-view)
-  ;; Remove the listener we installed last time (if any) before installing
-  ;; the new one, so a hot-reload re-`run` never stacks a duplicate.
-  (when-let [prev @hash-listener*]
-    (.removeEventListener js/window "hashchange" prev))
-  (.addEventListener js/window "hashchange" on-hash-change!)
-  (reset! hash-listener* on-hash-change!)
-  (on-hash-change!))
+  ([root-view] (mount-with-hash-routing! root-view nil))
+  ([root-view {:keys [story-subdir]}]
+   (configure-story-project-root! story-subdir)
+   (mount-router! root-view)))

--- a/tools/testbed-support/src/re_frame/testbed/story_host_cljs_test.cljs
+++ b/tools/testbed-support/src/re_frame/testbed/story_host_cljs_test.cljs
@@ -42,6 +42,9 @@
   touches React-DOM (there is no `#app` node, and no `js/document`, under
   `:node-test`)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.story.config :as story-config]
+            [re-frame.testbed.config :as testbed-config]
             [re-frame.testbed.story-host :as host]))
 
 ;; ---------------------------------------------------------------------------
@@ -102,12 +105,17 @@
   (reset! @#'host/root-view* nil))
 
 (use-fixtures :each
-  {:before (fn [] (reset-host-handles!))
+  {:before (fn []
+             (reset-host-handles!)
+             ;; The project-root tests below configure Story's project-root
+             ;; through the host; clear it before/after so neither leaks.
+             (story-config/set-project-root! nil))
    :after  (fn []
              ;; Remove the fake so it never leaks into another namespace's
              ;; tests; restore the node-test baseline (no `window`).
              (clear-window!)
-             (reset-host-handles!))})
+             (reset-host-handles!)
+             (story-config/set-project-root! nil))})
 
 ;; A trivial 0-arg root view stand-in (never rendered — mount-* are no-ops).
 (defn- dummy-view [] [:div "dummy"])
@@ -191,3 +199,130 @@
       (is (= 1 @switches)
           "one hash change runs the mount switch exactly once — proving a
            single active listener, not an N-deep stack"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-77wqzi — the host owns Story-host open-in-editor project-root config.
+;;
+;; Story stamps each registered source-coord with a CLASSPATH-RELATIVE
+;; `:file` slot (e.g. `login/stories.cljs`); the open-in-editor chip
+;; prepends an on-disk project-root to build a real editor URI. The two
+;; `examples/reagent` Story showcases previously mounted the shell fine but
+;; NEVER configured a root, so their Story source links resolved against a
+;; nil root and OS editor handlers could not open the file (a false green).
+;;
+;; The fix moved project-root config onto the host: a consumer declares its
+;; tool-relative source subdir via the `:story-subdir` opt and
+;; `mount-with-hash-routing!` resolves the on-disk root (through the shared
+;; `re-frame.testbed.config` build-env / `?project-root=` mechanism) and
+;; calls `story/configure!` itself. These tests pin that contract directly:
+;; the consumer can no longer mount the shell while silently forgetting the
+;; root. We exercise the private `configure-story-project-root!` (it carries
+;; no React-DOM / `js/window` dependency, so it runs under `:node-test`) and
+;; read Story's configured root back via `re-frame.story.config`.
+;; ---------------------------------------------------------------------------
+
+(deftest story-subdir-configures-absolute-project-root
+  (testing "rf2-77wqzi: declaring `:story-subdir` resolves the build-time
+            repo-root joined with that subdir and configures it as Story's
+            project-root — so a classpath-relative Story coord composes to an
+            ABSOLUTE on-disk path, not a nil-root relative one. Covers the
+            `examples/reagent` subdir the two example Story showcases use."
+    (with-redefs [testbed-config/repo-root "/home/dev/re-frame2"]
+      (#'host/configure-story-project-root! "examples/reagent")
+      (is (= "/home/dev/re-frame2/examples/reagent"
+             (story-config/get-project-root))
+          "Story's project-root is the absolute checkout/subdir join")
+      ;; The open-in-editor prepend is `(str root "/" file)`; reproduce that
+      ;; single join to prove a representative example Story coord reaches
+      ;; the intended on-disk file (under <checkout>/examples/reagent/...).
+      (let [composed (str (story-config/get-project-root) "/" "login/stories.cljs")]
+        (is (= "/home/dev/re-frame2/examples/reagent/login/stories.cljs"
+               composed)
+            "the composed editor path reaches the real example source file")
+        (is (str/includes? composed "/examples/reagent/")
+            "the example source-root segment is present (not missing)")))))
+
+(deftest example-story-builds-resolve-absolute-source-coords
+  (testing "rf2-77wqzi: the two example Story dev builds named in the bead —
+            `:examples/login-with-stories` and
+            `:examples/nine-states-with-stories` — both host their Story
+            sources under `examples/reagent`, so the host-owned config
+            resolves each build's representative Story coord to an ABSOLUTE
+            on-disk path under `<checkout>/examples/reagent/...`. This
+            enumerates the affected builds explicitly so a future regression
+            (dropping the `:story-subdir` opt or the build-env define) trips
+            here. Each entry is `[build-id story-coord expected-on-disk]`."
+    (with-redefs [testbed-config/repo-root "/home/dev/re-frame2"]
+      (doseq [[build coord expected]
+              [[:examples/login-with-stories
+                "login/stories.cljs"
+                "/home/dev/re-frame2/examples/reagent/login/stories.cljs"]
+               [:examples/nine-states-with-stories
+                "nine_states/stories.cljs"
+                "/home/dev/re-frame2/examples/reagent/nine_states/stories.cljs"]]]
+        (story-config/set-project-root! nil)
+        (#'host/configure-story-project-root! "examples/reagent")
+        (let [root     (story-config/get-project-root)
+              composed (str root "/" coord)]
+          (is (= "/home/dev/re-frame2/examples/reagent" root)
+              (str build " configures the absolute examples/reagent root"))
+          (is (= expected composed)
+              (str build " Story coord composes to the real on-disk file"))
+          (is (str/includes? composed "/examples/reagent/")
+              (str build " keeps the example source-root segment")))))))
+
+(deftest story-subdir-omitted-configures-no-root
+  (testing "rf2-77wqzi: a 1-arity call (no opts) and an explicitly nil/blank
+            `:story-subdir` configure NO project-root — the host leaves
+            Story's root untouched so a consumer that drives `story/configure!`
+            itself is not overridden, and the graceful-no-op contract holds"
+    (with-redefs [testbed-config/repo-root "/home/dev/re-frame2"]
+      ;; nil subdir → skip
+      (#'host/configure-story-project-root! nil)
+      (is (nil? (story-config/get-project-root))
+          "nil subdir configures nothing")
+      ;; blank subdir → skip
+      (#'host/configure-story-project-root! "   ")
+      (is (nil? (story-config/get-project-root))
+          "blank subdir configures nothing"))))
+
+(deftest story-subdir-with-no-resolvable-root-degrades-to-no-op
+  (testing "rf2-77wqzi: when a subdir is declared but NEITHER the build-time
+            define NOR a `?project-root=` override is present (the default
+            `:node-test` shape: blank repo-root, no js/window), the host
+            configures a nil root and open-in-editor degrades to a graceful
+            no-op rather than a broken relative link"
+    (with-redefs [testbed-config/repo-root ""]
+      (#'host/configure-story-project-root! "examples/reagent")
+      (is (nil? (story-config/get-project-root))
+          "no resolvable root → Story's root stays nil (no broken prefix)"))))
+
+(deftest mount-with-hash-routing-arity-2-configures-project-root
+  (testing "rf2-77wqzi: the public 2-arity entry threads `:story-subdir`
+            into the project-root config before wiring the router — the
+            exact call shape the two example Story hosts now use. We stub
+            the mount switch + a fake window so the router wiring is inert
+            and assert only that the project-root landed."
+    (let [{:keys [window]} (make-fake-window "#/")]
+      (install-window! window)
+      (with-redefs [testbed-config/repo-root "/home/dev/re-frame2"
+                    host/mount-app!     (constantly nil)
+                    host/mount-stories! (constantly nil)]
+        (host/mount-with-hash-routing! dummy-view {:story-subdir "examples/reagent"}))
+      (is (= "/home/dev/re-frame2/examples/reagent"
+             (story-config/get-project-root))
+          "the 2-arity call configured the resolved absolute root"))))
+
+(deftest mount-with-hash-routing-arity-1-leaves-root-untouched
+  (testing "rf2-77wqzi: the 1-arity entry (no opts) does NOT touch Story's
+            project-root — a consumer that calls `story/configure!` itself
+            keeps full control. We pre-set a root and confirm the host
+            leaves it intact."
+    (let [{:keys [window]} (make-fake-window "#/")]
+      (install-window! window)
+      (story-config/set-project-root! "/preset/by/consumer")
+      (with-redefs [host/mount-app!     (constantly nil)
+                    host/mount-stories! (constantly nil)]
+        (host/mount-with-hash-routing! dummy-view))
+      (is (= "/preset/by/consumer" (story-config/get-project-root))
+          "1-arity call left the consumer-set root untouched"))))


### PR DESCRIPTION
The two `examples/reagent` Story showcases (`:examples/login-with-stories`, `:examples/nine-states-with-stories`) mounted the Story shell fine but never configured an open-in-editor project-root, so their classpath-relative Story source coords resolved against a nil root and OS editor handlers could not open the file — a false green for the Story-host integration.

Fix moves project-root config onto the shared `re-frame.testbed.story-host` helper: a consumer declares its tool-relative source subdir via a new `:story-subdir` opt to `mount-with-hash-routing!`, and the host resolves the on-disk root through `re-frame.testbed.config` (build-env define or `?project-root=` override, cross-platform — building on rf2-d01s6s's `to-forward-slashes` normalization) and calls `story/configure!` itself, which also bridges the root into Xray's slot. Declaring the subdir means a consumer can no longer mount the shell while silently forgetting the config — one explicit host-owned contract.

Both example hosts now pass `{:story-subdir "examples/reagent"}`, the two matching shadow-cljs builds seed the `re-frame.testbed.config/repo-root` closure-define from the build env (with stale 'does NOT use re-frame.testbed.config' comments updated), and host-level regression tests enumerate the two builds and prove each composes its Story coord to an absolute `<checkout>/examples/reagent/...` path. rf2-d01s6s stays separate (Windows backslash/trailing-separator normalization).

## Quality gates
- `npm run test:cljs` (node-test, the testbed-support slice gate): 6136 tests, 21879 assertions, 0 failures, 0 errors — includes the new `story_host_cljs_test` project-root regression tests.
- `shadow-cljs compile node-test`: 0 warnings.
- `shadow-cljs compile :examples/login-with-stories :examples/nine-states-with-stories`: both build, 0 warnings.
- `python scripts/check_doc_slugs.py`: pass (README touched).