### PR TITLE
docs(skills): re-frame2-xray tighten skill-body ownership + eval coverage (rf2-bpj8dp)

### DIFF
--- a/skills/re-frame2-xray/README.md
+++ b/skills/re-frame2-xray/README.md
@@ -18,11 +18,13 @@ Xray is the **human-facing** panel; for an AI agent surface against the running 
 
 ## Repo contents
 
-- `SKILL.md` — the skill itself
+- `SKILL.md` — the compact tour/router (launch quick-reference, mode/tab chooser, chrome one-liners, and the leaf-loading guide)
 - `references/launch-modes.md` — full launch-mode decision tree (preload vs `init!`, suppress-auto-open, `:rf.xray/layout-host-selector`, host-CSS-variable resize, the `open-overlay!` no-layout-host fallback, pop-out lifecycle, wired hotkeys)
-- `references/panels.md` — the full tab tour in depth (6 Dynamic event-spine tabs + 5 Static registry-browse tabs, deeper "open it when…" guidance)
+- `references/panels.md` — the full tab tour in depth (6 Dynamic event-spine tabs + 5 Static registry-browse tabs, deeper "open it when…" guidance, the retired-panel content-home mapping)
+- `references/chrome.md` — the first-screen chrome inventory in depth (LIVE/RETRO, time-travel rewind, filter pills, command-palette sources, the Settings-popup tabs, the Snapshot app-db redaction contract)
 - `references/shared-components.md` — the components every L4 panel reuses (`edn-inspector/render-node`, `film_strip/header`, `focus_resolver`) + the tab-icon / L2-badge / cross-panel-arrow glyph reference
-- `evals/evals.json` — trigger-eval fixtures (should-trigger + should-not-trigger entries, per skill-creator's description-optimisation contract)
+- `evals/evals.json` — eval fixtures (trigger accuracy + answer-quality assertions for the high-drift launch / chrome / tab-routing prompts)
+- `evals/README.md` — the eval harness: coverage table, schema, and how to run the answer-quality checks
 - `.claude-plugin/plugin.json` — Claude Code Plugin packaging metadata
 - `package.json` — npm packaging metadata (skill is also distributable as an Agent Skill)
 

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -53,9 +53,12 @@ Anchor on that, then note the deliberate divergences.
 | React DevTools Profiler "why did this render?" | The **Views** tab — render-cause chips (`← :sub-id` vs `← props`) on every re-render leaf | Built into the same panel and tied to the epoch, not a separate profiler tab |
 | *(no Redux equivalent)* | **Static mode** — event-INDEPENDENT browse of what's *registered* (machines / routes / schemas / flows / interceptors) | Redux has no "what's registered?" surface; this is the registry-catalogue half Xray adds |
 
-(Xray is also the structural successor to re-frame-10x — re-frame2's own
-v1-internal predecessor — but it does not depend on or reference it; that
-lineage note matters mainly to v1-migrating users.)
+Xray is also the structural successor to **re-frame-10x** — re-frame2's
+v1-internal predecessor — and depends on or references neither. The single
+home for that fact (and the surface-by-surface "what replaces what") is
+[`../shared/tool-pair-surfaces.md` §Supersedes re-frame-10x](../shared/tool-pair-surfaces.md#supersedes-re-frame-10x);
+cite it rather than restating the lineage here. It matters mainly to
+v1-migrating users.
 
 This skill answers three questions, and only three:
 
@@ -75,6 +78,21 @@ Deep workflow recipes (find-wrong-sub, redaction-marker grammar,
 click-to-source / open-in-editor internals) are **out of scope** in this
 iteration — see the *Out of scope* section below for what to do when one
 comes up.
+
+### Which reference leaf to load
+
+This body is a **compact tour/router**: it carries the launch
+quick-reference, the mode/tab chooser, and the chrome one-liners. The
+maintained detail lives in the reference leaves — load the matching one
+when the question needs more than the router gives:
+
+| The question is about… | Load |
+|---|---|
+| Launch in depth — preload vs `init!`, the `[data-rf-xray-host]` contract, suppress-auto-open, CSS-variable / drag-handle resize, the `open-overlay!` fallback, pop-out lifecycle, the full wired-hotkey contract | [`references/launch-modes.md`](references/launch-modes.md) |
+| A tab in depth — per-tab layout, iconography, stripe tokens, the Epoch cascade steps, "open it when…" guidance | [`references/panels.md`](references/panels.md) |
+| First-screen chrome in depth — Settings-popup tabs, command-palette sources, the rewind detail, the Snapshot redaction contract | [`references/chrome.md`](references/chrome.md) |
+| The components every L4 panel reuses + the glyph/icon reference | [`references/shared-components.md`](references/shared-components.md) |
+| The re-frame-10x lineage / surface-by-surface "what replaces what" | [`../shared/tool-pair-surfaces.md`](../shared/tool-pair-surfaces.md#supersedes-re-frame-10x) |
 
 ---
 
@@ -140,127 +158,65 @@ see [`references/launch-modes.md`](references/launch-modes.md).
 
 ### Wired hotkeys
 
-Four hotkey families have global keydown listeners installed in
-`keybinding.cljs` today. Spec
-[`007-UX-IA.md` §Keyboard](../../tools/xray/spec/007-UX-IA.md#keyboard)
+Four hotkey families have keydown listeners installed in `keybinding.cljs`
+today (three global, one focus-gated) — this is the quick-reference; the
+full per-key contract + suppression knob lives in
+[`references/launch-modes.md` §Wired hotkeys](references/launch-modes.md#wired-hotkeys).
+Spec [`007-UX-IA.md` §Keyboard](../../tools/xray/spec/007-UX-IA.md#keyboard)
 catalogues a richer map; these are what is actually wired:
 
 | Key | Scope | Action |
 |---|---|---|
-| `Ctrl+Shift+C` | global | Toggle the Xray shell (mount on first press; CSS show/hide after). `Ctrl+Shift` deliberately avoids Safari's `Cmd+Shift+C` Inspect collision. |
-| `Cmd/Ctrl+Shift+M` | global | Toggle mode — Dynamic ↔ Static (`:rf.xray/toggle-mode`). Cmd on macOS, Ctrl elsewhere. |
-| `Cmd/Ctrl+K` | global | Open the command palette (`:rf.xray/palette-toggle`); opens the shell first if hidden. Cmd on macOS, Ctrl elsewhere. |
-| `Space` `L` `j` `k` `G` `,`/`s` | focus-gated | Spine + chrome shortcuts. These bare keys fire **only** when the Xray shell is visible AND the keydown target is inside the shell AND not an editable field (and not inside a modal). Space = pause/resume LIVE · `L` = snap to LIVE · `j`/`k` = step the focused event back/forward · `G` (Shift+G) = fast-forward to head · `,` or `s` = Settings popup. (`Esc` is **not** a wired spine key — it is a modal-local close handler owned by the palette / Settings popup, per `keybinding.cljs`.) |
+| `Ctrl+Shift+C` | global | Toggle the Xray shell (`Ctrl+Shift` avoids Safari's `Cmd+Shift+C` Inspect collision). |
+| `Cmd/Ctrl+Shift+M` | global | Toggle mode — Dynamic ↔ Static (`:rf.xray/toggle-mode`). |
+| `Cmd/Ctrl+K` | global | Open the command palette (`:rf.xray/palette-toggle`); opens the shell first if hidden. |
+| `Space` `L` `j` `k` `G` `,`/`s` | focus-gated | Spine + chrome shortcuts — fire only when the shell is visible and focused (non-editable, non-modal). Space = pause/resume LIVE · `L` = snap to LIVE · `j`/`k` = step focused event · `G` = fast-forward to head · `,`/`s` = Settings popup. |
 
-`Cmd/Ctrl+K` **is** wired — do not say it was struck. The pop-out has no
-hotkey; the canonical chrome path is the visible **`⛶` pop-out button** in
-the panel top-bar's right-icons cluster (dispatches `:rf.xray/popout-shell`),
-with `(xray/popout!)` / `window.day8.re_frame2_xray.popout_BANG_()` as the
-secondary programmatic/devtools path. Embed hosts (Story RHS, third-party tool surfaces) can
-suppress Xray's global listeners via `:rf.xray/keybinding-enabled?`.
-
-Source of truth:
+`Cmd/Ctrl+K` **is** wired — do not say it was struck. `Esc` is modal-local,
+not a wired spine key. The **pop-out has no hotkey** — its canonical path is
+the visible **`⛶` pop-out button** (above), with `(xray/popout!)` as the
+secondary programmatic path. Source of truth:
 [`keybinding.cljs`](../../tools/xray/src/day8/re_frame2_xray/keybinding.cljs).
 
 ---
 
 ## The chrome around the tabs
 
-Beyond the tabs, the first screen carries navigation primitives the user
-meets immediately. One line each — cite the spec/source, don't reproduce
-it.
+<a id="the-chrome-around-the-tabs"></a>
 
-- **LIVE vs RETRO spine.** The L2 spine live-tails new events at the head
- (**LIVE**) until you pick a historical event or pause, which drops to
- **RETRO** (inspecting a past epoch). `Space` pauses/resumes LIVE; `L`
- snaps back to LIVE; the head row pulses while live. Spec
- [`007-UX-IA.md` §L1](../../tools/xray/spec/007-UX-IA.md).
-- **Time-travel: passive inspect vs explicit rewind.** The ribbon
- `[◀ ▶ ⏭]` nav cluster + the L2 list walk history **without disturbing
- the live app** — picking an epoch is *passive INSPECTION* (panels
- rebase; `app-db` does NOT move). Rewind is the *separate, explicit*
- **`Reset` button** on the far-right of the L3 tab-bar ribbon (rf2-hga49):
- it dispatches `:rf.xray/reset-to-epoch` against the *observed* app frame
- + the focused epoch, rewinding that frame's live `app-db` to the epoch's
- `:db-after` via `(rf/restore-epoch …)` — disabled when no epoch is
- focused; on the rare framework failure (epoch aged out) it shows a brief
- inline flash, never a modal. This passive-inspect-by-default /
- rewind-opt-in posture is the load-bearing inversion from re-frame-10x
- v1. (Spec [`002-Time-Travel.md`](../../tools/xray/spec/002-Time-Travel.md)
- catalogues a richer keymap — `r` rewind, `R` re-dispatch, `*` pin — that
- is **normative for the future, not yet wired**; the `Reset` button is
- what works today.)
+Beyond the tabs, the first screen carries navigation primitives the user
+meets immediately. One line each below — **load
+[`references/chrome.md`](references/chrome.md) for the control-by-control
+inventory** (Settings-popup tabs, command-palette sources, the Snapshot
+redaction contract, the rewind detail) whenever the question needs more
+than the one-liner.
+
+- **LIVE vs RETRO spine.** The L2 spine live-tails at the head (**LIVE**)
+ until you pick a historical event or pause (**RETRO**); `Space`
+ pauses/resumes, `L` snaps back. (chrome.md §LIVE vs RETRO spine.)
+- **Time-travel: passive inspect vs explicit rewind.** Picking an epoch is
+ *passive INSPECTION* — panels rebase, `app-db` does NOT move; live rewind
+ is the *separate, explicit* **`Reset` button** on the L3 ribbon (rf2-hga49,
+ `restore-epoch` to the focused epoch's `:db-after`). No wired `r`/`R`/`*`
+ keys — those are spec-future only. (chrome.md §Time-travel.)
 - **Filter pills.** The L1.5 events ribbon carries IN / OUT pills, a mute
- set, an `N events hidden by filters` count, and `Clear Filters`. Pills
- are transient and reset on load. Each pill is a typed predicate
- (`:event-id-pattern` / `:machine` / `:http-correlation` / `:fx`). Spec
- [`020-Filter-Predicates.md`](../../tools/xray/spec/020-Filter-Predicates.md);
- source `src/filters/`. *(These are L1-ribbon filters — distinct from the
- Trace panel, which has no filtering.)*
+ set, an `N hidden by filters` count, and `Clear Filters`; transient,
+ reset on load. (chrome.md §Filter pills.)
 - **Command palette (`Cmd/Ctrl+K`).** A fuzzy-ranked surface over six
- source kinds — **panel jumps · recent events · frame switch · registered
- handlers · settings · command verbs**. Mode-aware (Dynamic vs Static),
- recency-boosted; `Ctrl+Enter` pops out a poppable item. Command verbs
- include Clear trace buffer, Clear epoch history, Reset redacted-events
- counter, Snapshot app-db, Toggle theme, Cycle reduced-motion, Jump to
- Settings, Toggle mode, Open pop-out (Cycle display density rides the
- separate `settings` source). Source
- [`palette/sources.cljc`](../../tools/xray/src/day8/re_frame2_xray/palette/sources.cljc).
-- **Settings popup (`,` / `s`).** A 4-tab modal — **General ·
- Keybindings · Buffer · Diff**. The current popup controls are:
- **General** — panel position (right-rail inline / fullscreen overlay),
- auto-open-on-error, epoch-history depth (slider), the per-operator
- editor-override picker, and the show-`:ungrouped` toggle; **Buffer** —
- cascades-retained + app-db inspector-collapse-threshold + a destructive
- Clear-buffer button; **Diff** — the hiccup-diff fn-ref-changes toggle;
- **Keybindings** — a read-only chord catalogue + the master "Handle keys?"
- switch. **Density is NOT a popup control** — the density radio was removed
- (2026-05-27); density stays a config / `init!` / `configure!` concern (the
- `:general :density` slot + `:rf.xray/density` sub read the boot default).
- **Panel width is NOT a popup control** — the width numeric input + reset
- were removed; width is driven by the **drag handle** on the panel's outer
- edge (double-click to reset), persisted via `:general :panel-width-px`.
- (The Theme tab was removed, rf2-ou3pn — the ribbon theme icon is
- canonical; the Filters tab was removed, rf2-wknb3 — filter UI lives on
- the L1.5 events ribbon.) For the layered config story: `init!` /
- `configure!` set the **boot-time defaults** for `:theme` / `:density` /
- `:buffer-depths` (each supplied opt is written to the persisted Settings
- shape and applied immediately at boot, no reload); for the slots the popup
- *does* expose (theme via the ribbon icon, epoch-history, buffer knobs) the
- popup is the **runtime user-mutable override** layer. Merge order is
- `defaults < configure! < Settings` (rf2-g2a5v). Source
- [`settings/view.cljs`](../../tools/xray/src/day8/re_frame2_xray/settings/view.cljs).
-- **Sharing state with a teammate.** The Share-URL affordance (button +
- modal + `share.cljs` infra) and the per-cascade EDN export were
- **removed** (rf2-nugvv, 2026-06-04 — `share.cljs` and `export/cascade.cljc`
- are deleted). The surviving on-box helper is the **Snapshot app-db**
- command palette verb (`Cmd/Ctrl+K` → "Snapshot app-db"): it puts the
- focused frame's `app-db` on the JS console + clipboard so a developer can
- capture the state they're looking at. **The console and the clipboard are
- off-box egress sinks** — the same trust boundary the rest of the Xray /
- tool egress story treats as sensitive — so the payload goes through the
- runtime's safe-egress projection (`runtime/egress-value`), the same
- fail-closed, default-redaction path `get-app-db` uses: `include-sensitive?`
- and `include-large?` both default **`false`**, so sensitive slots ship as
- `:rf/redacted` and large slots as `:rf.size/large-elided` (per
- [`runtime.cljs`](../../tools/xray/src/day8/re_frame2_xray/runtime.cljs)
- `egress-value` / `get-app-db`, hardened in rf2-a96xq). Do **not** tell a
- user this command drops the *raw* `app-db`, and do not present it as a way
- to copy a secret-bearing value off-box: a focused frame holding
- `{:auth {:token "secret"}}` (or any schema-/path-declared sensitive value)
- is redacted in the snapshot by default. Raw capture is only available
- through an explicit opt-in consistent with the privacy vocabulary — the
- same `--allow-sensitive-reads` (default **OFF**) plus per-call
- `:include-sensitive true` posture the AI/MCP read surfaces use (the
- re-frame2-pair-mcp boundary; see `tools/re-frame2-pair-mcp/`), never the
- command's default. Source
- [`palette/sources.cljc`](../../tools/xray/src/day8/re_frame2_xray/palette/sources.cljc)
- (`:snapshot-app-db` command).
- *(Status: shipped. The palette command routes the snapshot through
- `runtime/egress-value` by default — sensitive ⇒ `:rf/redacted`, large ⇒
- `:rf.size/large-elided`, pinned to the focused frame, fail-closed, no
- command-level raw opt-in (rf2-mxzgg, PR #3155). The contract prose above
- is what the share path honours today, not an in-flight target.)*
+ source kinds (panel jumps · recent events · frame switch · registered
+ handlers · settings · command verbs), mode-aware. (chrome.md §Command
+ palette — for the full command-verb list.)
+- **Settings popup (`,` / `s`).** A 4-tab modal (General · Keybindings ·
+ Buffer · Diff). **Density and panel-width are NOT popup controls** —
+ density is a boot/`configure!` concern; width is the drag handle. Merge
+ order is `defaults < configure! < Settings`. (chrome.md §Settings popup —
+ for the per-tab control inventory + the layered-config story.)
+- **Snapshot app-db (the on-box share helper).** Share-URL + EDN export were
+ removed (rf2-nugvv); the surviving helper is the **Snapshot app-db**
+ palette verb — and it is **redacted by default** (sensitive ⇒
+ `:rf/redacted`, large ⇒ `:rf.size/large-elided`, via
+ `runtime/egress-value`). Do **not** present it as a raw-`app-db` /
+ secret-egress path. (chrome.md §Snapshot app-db — for the egress contract.)
 
 ---
 
@@ -346,27 +302,23 @@ tabs only ever show the focused event.
 
 ### Retired pre-rebuild panels — where their content lives now
 
-Several panels from the pre-rebuild inventory (Subscriptions, Effects,
-Flows, Performance, Schemas, Hydration, and the old standalone Issues
-tab) are **not** separate Dynamic tabs. Their content is surfaced through
-the Dynamic 6 (per
+Several pre-rebuild panels (Subscriptions, Effects, Flows, Performance,
+Schemas, Hydration, and the old standalone Issues tab) are **not** separate
+Dynamic tabs. The four high-drift routes worth keeping in the body:
+
+- **Schemas** (violations) → **Epoch** inline + the L2 pink-wash; the
+  *registry* catalogue → **Static → Schemas**.
+- **Hydration** (SSR mismatches) → **Epoch** inline + the issues-ribbon
+  signal — there is **no** standalone Hydration tab.
+- **Flows** → **Epoch** FLOW step; the registry → **Static → Flows**.
+- **Effects** (`fx`) → **Epoch** EFFECT HANDLERS step + **Trace** raw ops.
+
+For the full retired-panel → content-home mapping (Subscriptions,
+Performance, the rest), see
 [`references/panels.md` §What's deliberately NOT here](references/panels.md#whats-deliberately-not-here)
-+ spec/021 §15) — and the registry catalogues live in Static mode:
-
-| Retired panel | Where its content lives now |
-|---|---|
-| **Subscriptions** | **Views** (cascade tree, SUBSCRIPTIONS step) + **app-db** (downstream-subs hover popover on changed paths) |
-| **Effects** (`fx`) | **Epoch** EFFECT HANDLERS step (flat per-effect ledger) + **Trace** (raw `:rf.fx/*` ops) |
-| **Flows** | **Epoch** FLOW step (one numbered step per flow that fired) · **Static → Flows** for the registry catalogue |
-| **Performance** | L2 row stripe colours (cross-epoch budget signal) + per-step duration chips in **Epoch** + per-row `:time` inside **Trace** |
-| **Schemas** | **Epoch** (schema violations attach inline to the owning step) + the L2 pink-wash · **Static → Schemas** for the registry catalogue |
-| **Hydration** *(SSR)* | **Epoch** inline + the issues-ribbon signal (hydration mismatches are `:rf.error/*` / `:rf.ssr/*` issues) |
-| **Issues** *(standalone tab)* | **Epoch** (per-step ✓/✗ + Exception card) + L2 pink-wash + the `:rf.xray/issues-ribbon` signal — no separate tab (rf2-gbz39) |
-
-The hero on first open is **Epoch** (Dynamic mode, `:order -1` claims the
-leftmost / default-landing slot the retired Event tab held). AI
-integration lives in the separate `tools/re-frame2-pair-mcp/` jar — Xray
-itself is the human surface only.
+(the single maintained home; + spec/021 §15). The hero on first open is
+**Epoch** (`:order -1`). AI integration lives in the separate
+`tools/re-frame2-pair-mcp/` jar — Xray itself is the human surface only.
 
 ---
 
@@ -383,8 +335,10 @@ short of improvising.
  and the per-panel specs (`tools/xray/spec/00N-*.md`). A future
  iteration may codify these as recipes; today the spec is the answer.
  (First-screen chrome — time-travel inspect / `Reset`-rewind, filter
- pills, the command palette, Settings — is **in scope**: see §The chrome
- around the tabs above.)
+ pills, the command palette, Settings — is **in scope**: §The chrome
+ around the tabs above is the router; load
+ [`references/chrome.md`](references/chrome.md) for the control-by-control
+ detail.)
 - **Driving Xray programmatically** (hot-swap a sub via REPL, time-
  travel from CLJS, dispatch into the runtime from a tool). Route to
  the [`re-frame2-pair`](../re-frame2-pair/SKILL.md) skill — Xray

--- a/skills/re-frame2-xray/evals/README.md
+++ b/skills/re-frame2-xray/evals/README.md
@@ -1,0 +1,115 @@
+# `re-frame2-xray` skill — eval harness
+
+This directory holds the evaluation fixtures for the `re-frame2-xray` tour
+skill (`skills/re-frame2-xray/SKILL.md` and its reference leaves). The
+fixtures gate two things at once:
+
+1. **Trigger accuracy** — the skill fires on Xray launch / tab-routing /
+   chrome prompts (positives) and stays quiet on adjacent surfaces
+   (negatives). This is the `skill-creator` description-optimisation
+   signal.
+2. **Answer quality** — for the highest-drift Xray facts, the skill's
+   answer names the *currently shipped* control and rejects stale
+   guidance. Trigger-only evals can prove the skill fired; they cannot
+   prove the answer is still correct as the Xray UI churns. The
+   `expectations[]` layer is the guardrail that closes that gap (rf2-bpj8dp).
+
+## Two-layer fixture shape
+
+A single `evals.json` holds the eval list. Per Anthropic's `skill-creator`
+schema ([SKILL.md](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md),
+[schemas.md](https://github.com/anthropics/skills/blob/main/skills/skill-creator/references/schemas.md)),
+each entry has an `id`, a kebab-case `name`, and a `prompt`. On top of that
+base, this harness uses two layers:
+
+- **Layer 1 — trigger (every entry).** `should_trigger` (`true` /
+  `false`) drives the description-optimisation loop's train/held-out
+  scoring. Negatives also carry a `rationale` naming the sibling skill
+  that *should* own the prompt.
+- **Layer 2 — answer quality (high-drift positives only).** The positives
+  that carry volatile UI facts also carry:
+  - `expected_output` — a human-readable description of a correct answer
+    (not parsed; makes manual review fast).
+  - `expectations[]` — objectively gradeable statements. Each is checked
+    against the run's answer; this is the pass/fail signal. They mix
+    **positive** assertions (name the right control) with **negative**
+    assertions (reject the stale one).
+
+`schema_version` is `"2"` (the `"1"` fixture was trigger-only). Bump it
+when the eval shape changes in a way that breaks readers.
+
+## Coverage
+
+27 evals — **19 positives** (skill should fire) and **8 negatives** (skill
+should stay quiet). **11 positives** carry the Layer-2 answer-quality
+`expectations[]`; they target the prompts whose answer drifts fastest as
+the Xray UI moves:
+
+| ID | Name | Layer 2? | What the answer-quality assertions pin |
+|---:|---|:---:|---|
+| 1 | `launch-default` | yes | True-inline (preload + `[data-rf-xray-host]`) is the canonical launch; overlay is NOT the default. |
+| 2 | `launch-popout` | yes | `(xray/popout!)` with call-parens; the visible `⛶` button is the canonical chrome path; no wired pop-out hotkey. |
+| 27 | `launch-popout-button` | yes | YES there is a visible `⛶` pop-out button (rf2-limfd4) — not programmatic-only, not an invented right-click path. |
+| 3 | `launch-programmatic` | yes | `init!` installs but does NOT open; a mount verb is still required; runs after `rf/init!`. |
+| 8 | `panel-route-machine-canvas` | yes | Full topology → Static Machines tab, not the event-driven Dynamic Machine tab; no standalone Machines-Canvas tab. |
+| 11 | `panel-route-schema` | yes | Schema violations → Epoch inline + L2 pink-wash; registry → Static Schemas; no Issues tab, no Dynamic Schemas tab. |
+| 12 | `panel-route-hydration` | yes | No standalone Hydration tab; mismatches → Epoch inline + issues-ribbon signal. |
+| 21 | `chrome-rewind` | yes | Passive inspect (app-db unmoved) vs explicit `Reset` button (restore-epoch); `r`/`R`/`*` are NOT wired. |
+| 23 | `chrome-palette` | yes | Palette source kinds + representative command verbs; `Cmd/Ctrl+K` is wired (not struck). |
+| 24 | `launch-overlay` | yes | `open-overlay!` is the supported FALLBACK for no-layout-host; floats above `document.body`; not the primary path. |
+| 26 | `config-init-vs-settings` | yes | Settings popup wins over the `init!` boot default; merge order `defaults < configure! < Settings`; density is NOT a popup control. |
+| 4, 5, 6, 7, 9, 10, 22, 25 | `launch-hotkey` … `config-init-boot` | no | Trigger-only positives (lower drift; covered by the body's quick-reference). |
+| 13–20 | `neg-*` | no | Negatives — adjacent surfaces (drive→pair, implement→spec, author→re-frame2, setup, migration, implementor, vocab-only). |
+
+The Layer-2 set is exactly the high-drift list the bead called for:
+launch-default, launch-overlay, launch-popout-button, launch-programmatic,
+config-init-vs-settings, chrome-rewind, chrome-palette,
+panel-route-machine-canvas, panel-route-schema, panel-route-hydration —
+plus launch-popout (the paired programmatic counterpart to the button
+prompt).
+
+## How to run
+
+There is **no scripted runner** in-tree for these — the answer-quality
+layer needs a live Claude session, so the harness is manual, following the
+skill-creator workflow ([SKILL.md §"Running and evaluating test
+cases"](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md)).
+The short version:
+
+1. **Trigger layer (every entry).** Run the description-optimisation loop /
+   the skill-creator scorer over `evals.json` to confirm the positives fire
+   and the negatives stay quiet. `should_trigger` is the only field that
+   layer reads.
+2. **Answer-quality layer (the Layer-2 entries).** For each entry that
+   carries `expectations[]`, spawn a fresh Claude session with
+   `skills/re-frame2-xray/SKILL.md` loaded, send the `prompt`, and capture
+   the answer + the tool-call transcript (which leaves it read).
+3. **Grade.** Check each `expectations[]` statement against the captured
+   answer — pass / fail with one-line evidence. Most are grep-able for the
+   load-bearing token (e.g. `Reset`, `open-overlay!`, `Static`, the `⛶`
+   button); the negative assertions need a short read to confirm the stale
+   control is *absent*.
+4. **Act on failures.** A failing answer-quality assertion almost always
+   means the **skill drifted behind the shipped Xray UI**, not that the
+   assertion is wrong — re-verify against the current
+   `tools/xray/src/.../` + `tools/xray/spec/*`, fix the skill body or the
+   matching reference leaf, and re-run. Only weaken an assertion if the
+   *product* contract genuinely changed (then update both the skill and the
+   assertion in the same PR).
+
+The harness is intentionally tool-agnostic — `evals.json` is just data, so
+any runner that respects the schema works.
+
+## Keeping evals + skill in sync
+
+Whenever an Xray UI change lands that touches one of the high-drift facts
+(a launch verb, a chrome control, a tab route), update the skill body / the
+matching reference leaf **and** the corresponding `expectations[]` in the
+same PR. The Layer-2 assertions are the contract that the tour skill keeps
+describing the *shipped* Xray, not a stale snapshot — they are only as good
+as the discipline of updating them alongside the product.
+
+> Note: the repo's `scripts/check_skill_eval_docs.py` drift gate is wired to
+> the `skills/re-frame2/` harness specifically; this README has no
+> automated count/coverage gate, so the table above is maintained by hand —
+> keep it in step with `evals.json` when you add or rename an entry.

--- a/skills/re-frame2-xray/evals/evals.json
+++ b/skills/re-frame2-xray/evals/evals.json
@@ -1,28 +1,149 @@
 {
  "skill_name": "re-frame2-xray",
- "schema_version": "1",
- "convention": "anthropics/skills/skill-creator evals.json — trigger-only fixture per references/schemas.md. Each entry carries `should_trigger` so skill-creator's description-optimisation loop can score train/held-out trigger accuracy.",
- "notes": "Positives (should_trigger: true) target the launch + tab-routing surface of skill SKILL.md across both modes (Dynamic event-spine + Static registry browse), the wired hotkeys (incl. the Dynamic <-> Static mode toggle), and the first-screen chrome around the tabs (time-travel inspect/Reset-rewind, filter pills, command palette, Settings). The launch-surface positives exercise the FULL public mount-verb set — the default true-inline panel (launch-default), the open-overlay! no-layout-host fallback (launch-overlay), the popout! pop-out window via both the visible chrome `⛶` top-bar button (launch-popout-button — a no-code question whose answer must name the shipped button, not a programmatic-only or future-right-click path; rf2-limfd4) and the programmatic API (launch-popout), and the programmatic init! (launch-programmatic) — plus the init!/configure!-vs-Settings boot-config contract (config-init-boot, config-init-vs-settings: init! sets boot defaults for :density / :buffer-depths, the Settings popup is the runtime override for the slots it exposes — e.g. epoch-history depth — merge order defaults < configure! < Settings). These guard against drift that omits an overlay/pop-out mount verb or conflates init! boot-config with the runtime Settings popup (rf2-3ppsg.1 / .2). NB: density is NOT a Settings-popup control (the radio was removed 2026-05-27); the config-init-vs-settings eval exercises the boot-default-vs-runtime-override contract through epoch-history, a slot the popup actually surfaces. Negatives target adjacent surfaces (re-frame2-pair drives Xray; re-frame2 authors host apps; spec discussion belongs to SKILL-REDIRECT) so the loop catches over-triggering.",
+ "schema_version": "2",
+ "convention": "anthropics/skills/skill-creator evals.json — per references/schemas.md. Two-layer fixture (rf2-bpj8dp): every entry carries `should_trigger` so skill-creator's description-optimisation loop can score train/held-out trigger accuracy; the high-drift positives ALSO carry `expected_output` + `expectations[]` (answer-quality assertions) so a description-optimisation pass that keeps the skill firing cannot mask an answer that has drifted behind the shipped Xray UI. Negatives keep `rationale` (no answer-quality layer — there is no right answer to assert).",
+ "notes": "Positives (should_trigger: true) target the launch + tab-routing + first-screen-chrome surface of SKILL.md across both modes (Dynamic event-spine + Static registry browse). The launch positives exercise the FULL public mount-verb set — the default true-inline panel (launch-default), the open-overlay! no-layout-host fallback (launch-overlay), the popout! pop-out window via both the visible chrome `⛶` top-bar button (launch-popout-button — a no-code question whose answer must name the shipped button, not a programmatic-only or future-right-click path; rf2-limfd4) and the programmatic API (launch-popout), and the programmatic init! (launch-programmatic) — plus the init!/configure!-vs-Settings boot-config contract (config-init-boot, config-init-vs-settings). The high-drift entries carry expectations[] that PIN current elegant-v2 guidance (visible pop-out button canonical / open-overlay! fallback-only / init! installs-but-does-not-open / Settings override order / passive inspect vs explicit Reset / Static Machines for full topology / redacted-by-default Snapshot / no standalone Issues|Hydration|Schemas Dynamic tab) AND reject stale guidance (wired r/R/* rewind keys, density radio in Settings, raw app-db snapshot by default, a re-frame-10x compatibility path). Negatives target adjacent surfaces (re-frame2-pair drives Xray; re-frame2 authors host apps; spec discussion belongs to SKILL-REDIRECT) so the loop catches over-triggering. NB: density is NOT a Settings-popup control (the radio was removed 2026-05-27); config-init-vs-settings exercises the boot-default-vs-runtime-override contract through epoch-history, a slot the popup actually surfaces.",
  "evals": [
- {"id": 1, "name": "launch-default", "should_trigger": true, "prompt": "How do I open Xray in my re-frame2 dev build?"},
- {"id": 2, "name": "launch-popout", "should_trigger": true, "prompt": "I want Xray on a second monitor — what's the call to pop it out into its own window?"},
- {"id": 27, "name": "launch-popout-button", "should_trigger": true, "prompt": "Is there a button in the Xray panel to pop it out to a second window without typing any code?"},
- {"id": 3, "name": "launch-programmatic", "should_trigger": true, "prompt": "How do I mount Xray from code? My app doesn't use shadow-cljs :preloads."},
+ {
+ "id": 1,
+ "name": "launch-default",
+ "should_trigger": true,
+ "prompt": "How do I open Xray in my re-frame2 dev build?",
+ "expected_output": "The agent names the default true-inline path: add the Xray preload to shadow-cljs :devtools/preloads AND a [data-rf-xray-host] column in the app layout, and Xray auto-opens on page load. It does NOT lead with open-overlay! / the overlay as the default. It may mention Ctrl+Shift+C toggles the shell.",
+ "expectations": [
+ "The output names the default true-inline panel (preload + a [data-rf-xray-host] layout column) as the canonical path, and says Xray auto-opens on page load.",
+ "The output does NOT present (xray/open-overlay!) / the overlay as the default launch path — at most it names it as a fallback for hosts with no layout column.",
+ "The output does NOT invent a launch hotkey other than the wired Ctrl+Shift+C shell toggle."
+ ]
+ },
+ {
+ "id": 2,
+ "name": "launch-popout",
+ "should_trigger": true,
+ "prompt": "I want Xray on a second monitor — what's the call to pop it out into its own window?",
+ "expected_output": "The agent gives (xray/popout!) (or window.day8.re_frame2_xray.popout_BANG_() from a console, with the call parens) as the programmatic path, AND notes that the canonical chrome path is the visible `⛶` top-bar pop-out button. It does not present popout! as the only / canonical path.",
+ "expectations": [
+ "The output names the programmatic call as (xray/popout!) — and if it gives the JS console form it includes the call parens (popout_BANG_()).",
+ "The output also mentions the visible `⛶` top-bar pop-out button as the canonical chrome path (not only the programmatic call).",
+ "The output does NOT claim a wired pop-out hotkey (there is none)."
+ ]
+ },
+ {
+ "id": 27,
+ "name": "launch-popout-button",
+ "should_trigger": true,
+ "prompt": "Is there a button in the Xray panel to pop it out to a second window without typing any code?",
+ "expected_output": "The agent answers YES and names the visible `⛶` pop-out button in the panel top-bar's right-icons cluster (dispatches :rf.xray/popout-shell) as the canonical no-code path. It does NOT answer that pop-out is programmatic-only, and does NOT invent a right-click / context-menu path.",
+ "expectations": [
+ "The output answers YES — there IS a visible pop-out button (the `⛶` top-bar / chrome-ribbon icon).",
+ "The output does NOT say pop-out is only available programmatically / only via (xray/popout!).",
+ "The output does NOT invent an unshipped affordance (right-click menu, a future hotkey) as the no-code path."
+ ]
+ },
+ {
+ "id": 3,
+ "name": "launch-programmatic",
+ "should_trigger": true,
+ "prompt": "How do I mount Xray from code? My app doesn't use shadow-cljs :preloads.",
+ "expected_output": "The agent says to call (xray/init! opts) after rf/init! to install the foundation, THEN call a mount verb — (xray/open!) / (xray/open-overlay!) / (xray/popout!) — because init! installs but does NOT open a panel. It notes init! is idempotent.",
+ "expectations": [
+ "The output uses (xray/init! ...) for the install step and calls it AFTER rf/init!.",
+ "The output explicitly states init! installs the foundation but does NOT open/show a panel by itself — a separate mount verb (open! / open-overlay! / popout!) is required to make it visible.",
+ "The output does NOT claim init! auto-opens the panel (only the preload schedules the page-load auto-open)."
+ ]
+ },
  {"id": 4, "name": "launch-hotkey", "should_trigger": true, "prompt": "What's the Ctrl+Shift+C hotkey wired to?"},
  {"id": 5, "name": "hotkey-mode-toggle", "should_trigger": true, "prompt": "Is there a keyboard shortcut to switch Xray between its Dynamic and Static modes?"},
  {"id": 6, "name": "panel-route-state", "should_trigger": true, "prompt": "Which Xray panel shows me when [:cart :items] last changed in app-db?"},
  {"id": 7, "name": "panel-route-machine", "should_trigger": true, "prompt": "Where in Xray do I see the current state of my checkout state machine?"},
- {"id": 8, "name": "panel-route-machine-canvas", "should_trigger": true, "prompt": "Which Xray tab shows my machine's full state-chart topology, not just what happened in this one event?"},
+ {
+ "id": 8,
+ "name": "panel-route-machine-canvas",
+ "should_trigger": true,
+ "prompt": "Which Xray tab shows my machine's full state-chart topology, not just what happened in this one event?",
+ "expected_output": "The agent routes to Static mode's Machines tab (the spine-INDEPENDENT topology browse — picker + zoom/pan/fit), NOT the Dynamic Machine tab (which is event-driven and blank on a non-machine epoch). It may note there is no standalone Dynamic 'Machines Canvas' tab (rf2-ga16q).",
+ "expectations": [
+ "The output routes the 'full topology, not just this event' question to Static mode's Machines tab.",
+ "The output distinguishes that from the Dynamic Machine tab (which is the event-driven, focused-epoch lens, blank when the focused event had no machine activity).",
+ "The output does NOT route this to a standalone Dynamic 'Machines Canvas' tab (it was removed)."
+ ]
+ },
  {"id": 9, "name": "static-browse-registry", "should_trigger": true, "prompt": "Where in Xray do I see ALL my registered machines, routes, and schemas at once — not just the focused event?"},
  {"id": 10, "name": "static-mode-name", "should_trigger": true, "prompt": "What is Xray's Static mode and how is it different from the normal event view?"},
- {"id": 11, "name": "panel-route-schema", "should_trigger": true, "prompt": "I'm getting schema violations — which Xray panel surfaces them and when did each one start?"},
- {"id": 12, "name": "panel-route-hydration", "should_trigger": true, "prompt": "My SSR hydration is mismatching — does Xray have a panel for that?"},
- {"id": 21, "name": "chrome-rewind", "should_trigger": true, "prompt": "How do I go back in time in Xray — scrub through history and rewind to an earlier epoch?"},
+ {
+ "id": 11,
+ "name": "panel-route-schema",
+ "should_trigger": true,
+ "prompt": "I'm getting schema violations — which Xray panel surfaces them and when did each one start?",
+ "expected_output": "The agent routes schema VIOLATIONS to the Epoch tab (they attach inline to the owning step) plus the L2 pink-wash for 'which epochs are broken'. It does NOT route them to a standalone Dynamic 'Schemas' tab (there is none) — though it may note the registered-schema CATALOGUE lives in Static mode's Schemas tab. It must not claim a dedicated Issues tab exists.",
+ "expectations": [
+ "The output routes schema violations to the Epoch tab (inline on the owning step) and/or the L2 pink-wash — the inline channels.",
+ "The output does NOT claim a standalone Dynamic 'Schemas' tab surfaces violations (the registry catalogue is Static-mode-only; violations are inline).",
+ "The output does NOT claim a dedicated Issues tab exists (it was removed, rf2-gbz39)."
+ ]
+ },
+ {
+ "id": 12,
+ "name": "panel-route-hydration",
+ "should_trigger": true,
+ "prompt": "My SSR hydration is mismatching — does Xray have a panel for that?",
+ "expected_output": "The agent says there is NO standalone Hydration tab; SSR hydration mismatches surface inline in the Epoch cascade plus the issues-ribbon / auto-open-on-error signal (they are :rf.error/* / :rf.ssr/* issues). It must not invent a Hydration Dynamic tab.",
+ "expectations": [
+ "The output states there is NO dedicated/standalone Hydration tab.",
+ "The output routes hydration mismatches to the Epoch tab (inline) + the issues-ribbon / auto-open-on-error signal.",
+ "The output does NOT invent a Dynamic 'Hydration' tab or a 'Chrome A11y' tab."
+ ]
+ },
+ {
+ "id": 21,
+ "name": "chrome-rewind",
+ "should_trigger": true,
+ "prompt": "How do I go back in time in Xray — scrub through history and rewind to an earlier epoch?",
+ "expected_output": "The agent distinguishes passive INSPECTION (picking an epoch in the L2 list / the ribbon nav rebases the panels but does NOT move the live app-db) from explicit REWIND (the `Reset` button on the L3 tab-bar ribbon, which calls restore-epoch to roll the live app-db to the focused epoch's :db-after). It does NOT teach r / R / * as wired rewind/re-dispatch/pin keys (those are spec-future only).",
+ "expectations": [
+ "The output explains that scrubbing / picking an epoch is passive inspection — panels rebase but the live app-db does NOT move.",
+ "The output names the explicit `Reset` button (L3 tab-bar ribbon) as the live rewind (restore-epoch to the focused epoch's :db-after).",
+ "The output does NOT present r / R / * as wired rewind / re-dispatch / pin keys (it may note they are spec-future / not yet wired)."
+ ]
+ },
  {"id": 22, "name": "chrome-filters", "should_trigger": true, "prompt": "Some of my events are missing from the Xray list and it says 'N hidden by filters' — how do I clear the filters?"},
- {"id": 23, "name": "chrome-palette", "should_trigger": true, "prompt": "What can I type into Xray's command palette when I press Cmd+K?"},
- {"id": 24, "name": "launch-overlay", "should_trigger": true, "prompt": "My app is a full-screen canvas with no right column for a [data-rf-xray-host] — how do I still open Xray?"},
+ {
+ "id": 23,
+ "name": "chrome-palette",
+ "should_trigger": true,
+ "prompt": "What can I type into Xray's command palette when I press Cmd+K?",
+ "expected_output": "The agent describes the fuzzy-ranked palette over its source kinds (panel jumps, recent events, frame switch, registered handlers, settings, command verbs) and names representative command verbs (e.g. Snapshot app-db, Clear trace buffer, Toggle mode, Open pop-out, Toggle theme). It confirms Cmd/Ctrl+K is wired (not struck).",
+ "expectations": [
+ "The output names the palette source kinds (at least: panel jumps / recent events / frame switch / registered handlers / settings / command verbs) or a clear superset.",
+ "The output names representative command verbs (e.g. Snapshot app-db, Clear trace buffer, Toggle mode/theme, Open pop-out).",
+ "The output confirms Cmd/Ctrl+K opens the palette (it is wired) — it does NOT say the K binding was struck/removed."
+ ]
+ },
+ {
+ "id": 24,
+ "name": "launch-overlay",
+ "should_trigger": true,
+ "prompt": "My app is a full-screen canvas with no right column for a [data-rf-xray-host] — how do I still open Xray?",
+ "expected_output": "The agent gives (xray/open-overlay!) (or window.day8.re_frame2_xray.open_overlay_BANG_()) as the supported FALLBACK for hosts that can't accommodate a layout column — it floats the shell above document.body. It frames overlay as the non-default fallback (the inline panel is canonical), not as the primary path.",
+ "expectations": [
+ "The output names (xray/open-overlay!) (or the JS console equivalent) as the way to open Xray with no [data-rf-xray-host] column.",
+ "The output frames the overlay as the supported FALLBACK / non-default path for hosts that can't host a layout column — not as the primary/canonical launch.",
+ "The output does NOT claim the overlay needs a layout column (it floats above document.body)."
+ ]
+ },
  {"id": 25, "name": "config-init-boot", "should_trigger": true, "prompt": "How do I set Xray's display density and epoch-history depth at startup from code, before anyone touches the Settings popup?"},
- {"id": 26, "name": "config-init-vs-settings", "should_trigger": true, "prompt": "If I set the epoch-history depth via (xray/init! {:buffer-depths {:epoch 50}}) but the user later changes it with the Settings popup slider, which one wins?"},
+ {
+ "id": 26,
+ "name": "config-init-vs-settings",
+ "should_trigger": true,
+ "prompt": "If I set the epoch-history depth via (xray/init! {:buffer-depths {:epoch 50}}) but the user later changes it with the Settings popup slider, which one wins?",
+ "expected_output": "The agent says the Settings popup wins — init!/configure! set the boot-time DEFAULT and the Settings popup is the runtime user-mutable OVERRIDE for the slots it exposes (epoch-history is one). It states the merge order defaults < configure! < Settings. It does NOT claim init! locks the value or that density is a Settings-popup control.",
+ "expectations": [
+ "The output says the Settings popup value wins over the init!/configure! boot default for epoch-history depth.",
+ "The output states (or clearly implies) the layered merge order: defaults < configure! < Settings.",
+ "The output does NOT claim density is a Settings-popup control (the density radio was removed 2026-05-27 — density is a boot/configure! concern only)."
+ ]
+ },
  {"id": 13, "name": "neg-drive-xray", "should_trigger": false, "prompt": "Use Xray to dispatch [:cart/apply-coupon \"SPRING25\"] and tell me what happens.", "rationale": "Driving Xray from a REPL is re-frame2-pair's surface, not the read-only tour."},
  {"id": 14, "name": "neg-implement-panel", "should_trigger": false, "prompt": "I want to add a new Xray panel for WebSocket connection lifecycle — walk me through the panel-facade/leaf split.", "rationale": "Implementing Xray is out of scope; route to tools/xray/spec/."},
  {"id": 15, "name": "neg-author-app", "should_trigger": false, "prompt": "Write a re-frame2 reg-event-fx that posts a login form and dispatches :login-success / :login-failure.", "rationale": "Authoring application code is re-frame2's job."},

--- a/skills/re-frame2-xray/references/chrome.md
+++ b/skills/re-frame2-xray/references/chrome.md
@@ -1,0 +1,144 @@
+# chrome — the first-screen navigation primitives around the tabs
+
+Companion to [`panels.md`](panels.md) (the tabs) and
+[`launch-modes.md`](launch-modes.md) (getting Xray visible). This leaf
+owns the **detailed inventory** of the chrome the operator meets before
+they pick a tab: the LIVE/RETRO spine, time-travel (passive inspect vs
+explicit rewind), the filter-pill cluster, the command palette, and the
+Settings popup. [`SKILL.md` §The chrome around the tabs](../SKILL.md#the-chrome-around-the-tabs)
+carries the one-line router; this leaf carries the control-by-control
+detail. When a chrome question needs more than the one-liner, load this.
+
+Source of truth for chrome layout / tokens / animation:
+[`007-UX-IA.md`](../../../tools/xray/spec/007-UX-IA.md).
+
+## LIVE vs RETRO spine
+
+The L2 spine live-tails new events at the head (**LIVE**) until you pick a
+historical event or pause, which drops to **RETRO** (inspecting a past
+epoch). `Space` pauses/resumes LIVE; `L` snaps back to LIVE; the head row
+pulses while live. Spec
+[`007-UX-IA.md` §L1](../../../tools/xray/spec/007-UX-IA.md).
+
+## Time-travel: passive inspect vs explicit rewind
+
+The ribbon `[◀ ▶ ⏭]` nav cluster + the L2 list walk history **without
+disturbing the live app** — picking an epoch is *passive INSPECTION*
+(panels rebase; `app-db` does NOT move). Rewind is the *separate, explicit*
+**`Reset` button** on the far-right of the L3 tab-bar ribbon (rf2-hga49):
+it dispatches `:rf.xray/reset-to-epoch` against the *observed* app frame +
+the focused epoch, rewinding that frame's live `app-db` to the epoch's
+`:db-after` via `(rf/restore-epoch …)` — disabled when no epoch is focused;
+on the rare framework failure (epoch aged out) it shows a brief inline
+flash, never a modal.
+
+This passive-inspect-by-default / rewind-opt-in posture is the load-bearing
+inversion from re-frame-10x v1 (the lineage fact lives once in
+[`../../shared/tool-pair-surfaces.md` §Supersedes re-frame-10x](../../shared/tool-pair-surfaces.md#supersedes-re-frame-10x)).
+Spec [`002-Time-Travel.md`](../../../tools/xray/spec/002-Time-Travel.md)
+catalogues a richer keymap — `r` rewind, `R` re-dispatch, `*` pin — that is
+**normative for the future, not yet wired**; the `Reset` button is what
+works today. Do not teach `r` / `R` / `*` as live keys.
+
+## Filter pills
+
+The L1.5 events ribbon carries IN / OUT pills, a mute set, an `N events
+hidden by filters` count, and `Clear Filters`. Pills are transient and
+reset on load. Each pill is a typed predicate (`:event-id-pattern` /
+`:machine` / `:http-correlation` / `:fx`). Spec
+[`020-Filter-Predicates.md`](../../../tools/xray/spec/020-Filter-Predicates.md);
+source `src/filters/`. *(These are L1-ribbon filters — distinct from the
+Trace panel, which has no filtering.)*
+
+## Command palette (`Cmd/Ctrl+K`)
+
+A fuzzy-ranked surface over six source kinds — **panel jumps · recent
+events · frame switch · registered handlers · settings · command verbs**.
+Mode-aware (Dynamic vs Static), recency-boosted; `Ctrl+Enter` pops out a
+poppable item. Command verbs include Clear trace buffer, Clear epoch
+history, Reset redacted-events counter, Snapshot app-db, Toggle theme,
+Cycle reduced-motion, Jump to Settings, Toggle mode, Open pop-out (Cycle
+display density rides the separate `settings` source). Source
+[`palette/sources.cljc`](../../../tools/xray/src/day8/re_frame2_xray/palette/sources.cljc).
+
+## Settings popup (`,` / `s`)
+
+A 4-tab modal — **General · Keybindings · Buffer · Diff**. The current
+popup controls are:
+
+- **General** — panel position (right-rail inline / fullscreen overlay),
+  auto-open-on-error, epoch-history depth (slider), the per-operator
+  editor-override picker, and the show-`:ungrouped` toggle.
+- **Buffer** — cascades-retained + app-db inspector-collapse-threshold + a
+  destructive Clear-buffer button.
+- **Diff** — the hiccup-diff fn-ref-changes toggle.
+- **Keybindings** — a read-only chord catalogue + the master "Handle
+  keys?" switch.
+
+**Density is NOT a popup control** — the density radio was removed
+(2026-05-27); density stays a config / `init!` / `configure!` concern (the
+`:general :density` slot + `:rf.xray/density` sub read the boot default).
+**Panel width is NOT a popup control** — the width numeric input + reset
+were removed; width is driven by the **drag handle** on the panel's outer
+edge (double-click to reset), persisted via `:general :panel-width-px`.
+(The Theme tab was removed, rf2-ou3pn — the ribbon theme icon is canonical;
+the Filters tab was removed, rf2-wknb3 — filter UI lives on the L1.5 events
+ribbon.)
+
+For the layered config story: `init!` / `configure!` set the **boot-time
+defaults** for `:theme` / `:density` / `:buffer-depths` (each supplied opt
+is written to the persisted Settings shape and applied immediately at boot,
+no reload); for the slots the popup *does* expose (theme via the ribbon
+icon, epoch-history, buffer knobs) the popup is the **runtime
+user-mutable override** layer. Merge order is `defaults < configure! <
+Settings` (rf2-g2a5v). Source
+[`settings/view.cljs`](../../../tools/xray/src/day8/re_frame2_xray/settings/view.cljs).
+
+## Snapshot app-db (the surviving on-box share helper)
+
+The Share-URL affordance (button + modal + `share.cljs` infra) and the
+per-cascade EDN export were **removed** (rf2-nugvv, 2026-06-04 —
+`share.cljs` and `export/cascade.cljc` are deleted). The surviving on-box
+helper is the **Snapshot app-db** command-palette verb (`Cmd/Ctrl+K` →
+"Snapshot app-db"): it puts the focused frame's `app-db` on the JS console +
+clipboard so a developer can capture the state they're looking at.
+
+**The console and the clipboard are off-box egress sinks** — the same trust
+boundary the rest of the Xray / tool egress story treats as sensitive — so
+the payload goes through the runtime's safe-egress projection
+(`runtime/egress-value`), the same fail-closed, default-redaction path
+`get-app-db` uses: `include-sensitive?` and `include-large?` both default
+**`false`**, so sensitive slots ship as `:rf/redacted` and large slots as
+`:rf.size/large-elided` (per
+[`runtime.cljs`](../../../tools/xray/src/day8/re_frame2_xray/runtime.cljs)
+`egress-value` / `get-app-db`, hardened in rf2-a96xq).
+
+Do **not** tell a user this command drops the *raw* `app-db`, and do not
+present it as a way to copy a secret-bearing value off-box: a focused frame
+holding `{:auth {:token "secret"}}` (or any schema-/path-declared sensitive
+value) is redacted in the snapshot by default. Raw capture is only available
+through an explicit opt-in consistent with the privacy vocabulary — the same
+`--allow-sensitive-reads` (default **OFF**) plus per-call
+`:include-sensitive true` posture the AI/MCP read surfaces use (the
+re-frame2-pair-mcp boundary; see `tools/re-frame2-pair-mcp/`), never the
+command's default. Source
+[`palette/sources.cljc`](../../../tools/xray/src/day8/re_frame2_xray/palette/sources.cljc)
+(`:snapshot-app-db` command).
+
+*(Status: shipped. The palette command routes the snapshot through
+`runtime/egress-value` by default — sensitive ⇒ `:rf/redacted`, large ⇒
+`:rf.size/large-elided`, pinned to the focused frame, fail-closed, no
+command-level raw opt-in (rf2-mxzgg, PR #3155). The contract prose above is
+what the share path honours today, not an in-flight target.)*
+
+## Wired hotkeys
+
+The same four globally/focus-gated hotkey families are catalogued in
+[`launch-modes.md` §Wired hotkeys](launch-modes.md#wired-hotkeys) (the
+single home for the keydown contract). In one line: `Ctrl+Shift+C` toggles
+the shell, `Cmd/Ctrl+Shift+M` toggles mode, `Cmd/Ctrl+K` opens the palette,
+and the focus-gated bare keys `Space`/`L`/`j`/`k`/`G`/`,`/`s` drive the
+spine + Settings. `Cmd/Ctrl+K` **is** wired (not struck); `Esc` is
+modal-local, not a wired spine key; there are no wired `r`/`R`/`*` rewind
+keys. Source of truth
+[`keybinding.cljs`](../../../tools/xray/src/day8/re_frame2_xray/keybinding.cljs).


### PR DESCRIPTION
Tightens `skills/re-frame2-xray` per rf2-bpj8dp's two findings.

**Finding 1 — skill-body ownership.** Slims always-loaded `SKILL.md` (435 -> 389 lines, 30.8K -> 27K bytes) to a compact tour/router and gives each volatile claim one maintained home. New `references/chrome.md` owns the control-by-control first-screen-chrome inventory (LIVE/RETRO, time-travel rewind, filter pills, command-palette sources, the 4-tab Settings popup, the Snapshot app-db redaction contract); `SKILL.md` keeps one-liner routers + the high-drift answer facts and points at the leaf. Trims the duplicated wired-hotkey prose (full contract in `launch-modes.md`) and the retired-panel mapping table (full mapping in `panels.md`). Adds a 'which reference leaf to load' router table. Reconciles the re-frame-10x rule: `SKILL.md` + `chrome.md` now cite `../shared/tool-pair-surfaces.md` §Supersedes re-frame-10x instead of restating the lineage, matching what the README already claimed.

**Finding 2 — eval coverage.** `evals.json` moves from trigger-only to a two-layer fixture (schema_version 2): every entry keeps `should_trigger`, and the 11 high-drift positives gain `expected_output` + `expectations[]` answer-quality assertions. They pin current elegant-v2 guidance (visible pop-out button canonical, `open-overlay!` fallback-only, `init!` installs-but-does-not-open, Settings override order, passive inspect vs explicit `Reset`, Static Machines for full topology, redacted-by-default Snapshot, no standalone Issues/Hydration/Schemas Dynamic tab) and reject stale guidance (wired `r`/`R`/`*` keys, density radio in Settings, raw app-db snapshot, a re-frame-10x compatibility path). New `evals/README.md` documents the manual trigger + answer-quality harness and the keep-in-sync discipline.

Scope: all changes are inside `skills/re-frame2-xray/`. No retired `:rf/runtime` paths. Builds on merged #3593 (limfd4 pop-out button).

## Quality gates

- `python scripts/check_doc_slugs.py` — pass
- `python scripts/check_skill_mcp_drift.py` — pass
- `python scripts/check_skill_redirect_anchors.py` — pass
- `python scripts/check_skill_package_refs.py` — pass (re-frame2-xray in the ok list; caveat present)
- `python scripts/check_skill_eval_docs.py` — pass
- `python -m mkdocs build --strict` — pass (exit 0)
- `sh scripts/check-no-hardcoded-paths.sh` — pass
- `evals.json` validated as JSON (27 evals: 19 positive / 8 negative; 11 with answer-quality expectations)