### PR TITLE
docs(skills): re-frame2-pair-retro package eval-fixture inclusion (rf2-myge8z)

### DIFF
--- a/skills/re-frame2-pair-retro/README.md
+++ b/skills/re-frame2-pair-retro/README.md
@@ -28,10 +28,12 @@ It is intentionally diagnosis-first: the default outcome is a better understandi
 - `references/issue-template.md` — GitHub-issue drafting structure (with the shell-safety pattern for transcript-derived bodies)
 - `references/working-style.md` — diagnostic-posture rules applied per finding (evidence over vibes, symptom vs cause, direct/indirect friction, positive gaps, creativity after diagnosis)
 - `spec/` — skill-internal meta-docs (`design.md`, `inputs.md`, `authoring-prompt.md`) for re-authoring the skill; not loaded during normal operation
-- `evals/evals.json` — trigger-accuracy fixtures (which prompts should and should not activate the skill)
+- `evals/evals.json` — trigger-accuracy fixtures (which prompts should and should not activate the skill); a repo-maintenance artifact, deliberately **excluded** from the npm package `files` array (see below)
 - `.claude-plugin/plugin.json` — plugin packaging metadata
 - `agents/openai.yaml` — UI metadata for skill lists and invocation
 - `package.json`, `LICENSE` — npm packaging metadata and the MIT licence
+
+`spec/` carries skill-internal design/authoring meta-docs (not loaded during normal operation), and `evals/` holds the trigger-accuracy fixtures. Both are **excluded from the npm `files` array by design** — they are repo-maintenance artifacts that run from a full re-frame2 clone (where the description-optimisation loop can reach `evals/evals.json`), not material a packaged-skill consumer re-runs. This mirrors the sibling `re-frame2`, `re-frame2-setup`, and `re-frame2-pair` skills; `npm pack --dry-run` from this directory lists no `spec/` or `evals/` files.
 
 ## Relationship to other repos
 

--- a/skills/re-frame2-pair-retro/evals/README.md
+++ b/skills/re-frame2-pair-retro/evals/README.md
@@ -1,0 +1,60 @@
+# `re-frame2-pair-retro` skill — eval harness
+
+This directory holds the trigger-accuracy fixtures for the `re-frame2-pair-retro`
+meta-skill (`skills/re-frame2-pair-retro/SKILL.md`). The single `evals.json`
+file scores the skill's **activation boundary**: which prompts should trigger a
+`re-frame2-pair` retrospective and which should route elsewhere (vocab-only
+retros, live `re-frame2-pair` debugging, the `re-frame2-improver` static
+critique, greenfield `re-frame2-setup`, Story-recorder retros, etc.).
+
+## Repo-maintenance artifact, not shipped
+
+`evals/` is a **repo-maintenance artifact** — it is deliberately **not** part of
+the distributable skill package. `skills/re-frame2-pair-retro/package.json`'s
+`files` allow-list omits `evals/` (and `spec/`) on purpose: a packaged-skill
+consumer runs the skill, they do not re-run its description-optimisation loop, so
+shipping the fixtures would only bloat the tarball with material that points back
+at the monorepo's maintenance workflow. The fixtures live and run from a full
+re-frame2 clone, alongside the sibling `skills/re-frame2/evals/` and
+`skills/re-frame2-setup/evals/` they mirror. `npm pack --dry-run` from the skill
+directory lists no `evals/` files — that is by design, and it matches the
+`re-frame2`, `re-frame2-setup`, and `re-frame2-pair` siblings. (The
+`re-frame2-improver` and `re-frame2-xray` siblings make the opposite, equally
+valid, choice — they carry `evals/` in `files` so a vendored copy can re-run its
+own gate; either stance is fine as long as the skill's docs and its `files` array
+agree. rf2-myge8z.)
+
+## Convention
+
+The fixtures follow Anthropic's `skill-creator` convention, documented in
+[`anthropics/skills/skills/skill-creator/SKILL.md`](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md)
+and the schema in
+[`anthropics/skills/skills/skill-creator/references/schemas.md`](https://github.com/anthropics/skills/blob/main/skills/skill-creator/references/schemas.md).
+The same shape is described in Anthropic's public best-practices guide:
+[*Skill authoring best practices — Build evaluations first*](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#build-evaluations-first).
+
+A single `evals.json` holds a **trigger-only** fixture list (`schema_version`
+`"1"`). Each entry carries:
+
+- `id` — unique integer.
+- `name` — short kebab-case slug; the per-run directory name when the harness
+  runs.
+- `should_trigger` — the expected activation decision (`true` for prompts that
+  should fire the skill, `false` for prompts that should route elsewhere).
+- `prompt` — a self-contained user message that exercises the boundary.
+- `rationale` — present on the interesting negatives, recording why the prompt
+  must NOT trigger (which sibling skill owns it instead).
+
+The positives target retro-on-a-pair-session prompts (including the harder
+post-error post-mortem branch); the negatives target vocab-only retros, the
+adjacent skills, the mid-pair error the user wants fixed (stays in
+`re-frame2-pair`), and out-of-scope Story-recorder retros.
+
+## How to run
+
+The skill-creator description-optimisation loop ([SKILL.md
+§"Running and evaluating test cases"](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md))
+is the reference: score the skill's activation decision against each entry's
+`should_trigger`, and tune the frontmatter `description` until train/held-out
+trigger accuracy holds. The harness is intentionally tool-agnostic —
+`evals.json` is just data; any runner that respects the schema works.

--- a/skills/re-frame2-pair-retro/spec/authoring-prompt.md
+++ b/skills/re-frame2-pair-retro/spec/authoring-prompt.md
@@ -28,7 +28,7 @@ A self-contained prompt that re-authors the `re-frame2-pair-retro` skill from th
 > ├── .claude-plugin/plugin.json (Claude Code plugin metadata)
 > ├── agents/
 > │ └── openai.yaml (alt-host config for non-Claude operation)
-> ├── evals/
+> ├── evals/                          # repo-maintenance artifact; excluded from the npm `files` array
 > │ └── evals.json (trigger-accuracy fixtures — which prompts should / should not activate)
 > ├── references/
 > │ ├── analysis-lenses.md (~140 lines; nine root-cause lenses)
@@ -43,7 +43,7 @@ A self-contained prompt that re-authors the `re-frame2-pair-retro` skill from th
 >
 > *Every reference is ≤250 lines (target ~120). SKILL.md is ~170 lines (well under Anthropic's 500-line ceiling).*
 >
-> ***Preserve the shipped load paths.** `SKILL.md` MUST cross-link `references/working-style.md` (the diagnostic-posture rules) and `references/issue-template.md` — both are packaged `references/` leaves that load during normal operation. Do NOT relegate the diagnostic-posture rules back into `spec/`: `spec/` is excluded from the npm package / plugin bundle and is not loaded during normal operation, so a `SKILL.md → spec/design.md §8` link breaks in every packaged / plugin / vendored install (this was the rf2-ia7qf finding-2 regression). `evals/evals.json` (the trigger fixtures), `.claude-plugin/plugin.json`, and `agents/openai.yaml` are shipped slice files — keep them; dropping `evals/` loses the activation-boundary trigger fixtures.*
+> ***Preserve the shipped load paths.** `SKILL.md` MUST cross-link `references/working-style.md` (the diagnostic-posture rules) and `references/issue-template.md` — both are packaged `references/` leaves that load during normal operation. Do NOT relegate the diagnostic-posture rules back into `spec/`: `spec/` is excluded from the npm package / plugin bundle and is not loaded during normal operation, so a `SKILL.md → spec/design.md §8` link breaks in every packaged / plugin / vendored install (this was the rf2-ia7qf finding-2 regression). `.claude-plugin/plugin.json` and `agents/openai.yaml` are shipped slice files — keep them in the package `files` array. `evals/evals.json` (the trigger fixtures) is a re-authoring slice too — keep it on disk so the description-optimisation loop can score the activation boundary — but, like `spec/`, it is a **repo-maintenance artifact deliberately excluded from the npm `files` array** (it runs from a full clone, not from a packaged consumer's install); do NOT add `evals/` to `files`. This matches the sibling `re-frame2` / `re-frame2-setup` / `re-frame2-pair` skills (rf2-myge8z).*
 >
 > *SKILL.md walks the six-step analysis workflow:*
 >

--- a/skills/re-frame2-pair-retro/spec/design.md
+++ b/skills/re-frame2-pair-retro/spec/design.md
@@ -122,7 +122,7 @@ skills/re-frame2-pair-retro/
 ├── .claude-plugin/plugin.json (Claude Code plugin metadata)
 ├── agents/
 │ └── openai.yaml (alt-host config — kept for cross-LLM operation)
-├── evals/
+├── evals/                          # repo-maintenance artifact; excluded from the npm `files` array
 │ └── evals.json (trigger-accuracy fixtures — which prompts should / should not activate)
 ├── references/
 │ ├── analysis-lenses.md (~140 lines; nine root-cause lenses + improvement shapes)


### PR DESCRIPTION
Reconciles the eval-fixture packaging stance for `skills/re-frame2-pair-retro`. `package.json` already omits `evals/` (and `spec/`) from the npm `files` array, but `README.md`, `spec/design.md`, and `spec/authoring-prompt.md` described `evals/evals.json` as a shipped slice file — package/documentation drift the existing `check_skill_package_refs.py` gate did not catch. Aligns the docs to the package: `evals/` is a repo-maintenance artifact deliberately excluded, matching the `re-frame2` / `re-frame2-setup` / `re-frame2-pair` sibling stance (`re-frame2-improver` / `re-frame2-xray` make the opposite, equally valid, choice and carry `evals/` in `files`). Adds `evals/README.md` declaring the stance, mirroring `skills/re-frame2/evals/README.md`. Verified with `npm pack --dry-run`: 10 entries, no `evals/` or `spec/` — payload and docs now agree. The repo-wide eval-packaging-consistency gate + the public-vs-private package-policy axis (rf2-6vxryj) are out of this slice's scope; filed as follow-up. ## Quality gates - check_doc_slugs.py: pass - check_skill_package_refs.py: pass - check_skill_mcp_drift.py: pass - check_skill_redirect_anchors.py: pass - check_skill_eval_docs.py: pass - mkdocs build --strict: pass - check-no-hardcoded-paths.sh: pass - npm pack --dry-run: 10 entries, no evals/ or spec/