### PR TITLE
refactor(test-quiet): reporter + harness maintainability (rf2-8dfq5j)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet.cljc
+++ b/implementation/test-quiet/src/re_frame/test_quiet.cljc
@@ -42,10 +42,22 @@
   The reporter is BUFFERLESS — we don't capture failure-message bytes
   and replay them.  Instead, the first `:fail` / `:error` inside an
   unprinted namespace prints the namespace banner immediately, then
-  delegates to the default method via direct re-entry.  This means the
+  DELEGATES to the captured default `report` method.  This means the
   failure output shape (the precise text clojure.test or cljs.test
   emits for `FAIL in (...)`, the `expected:` / `actual:` lines, the
-  stack) is byte-for-byte unchanged.
+  stack) is owned by the test library, not forked here — any upstream
+  change to failure formatting, formatter handling, or stack-depth
+  behaviour is inherited automatically.
+
+  Delegation mechanism: at namespace-load time — BEFORE we install our
+  own overrides — we capture the library's default `:fail` / `:error`
+  methods via `get-method`.  Our override then prints the withheld
+  banner and invokes that captured method.  The default already wraps
+  its body in `with-test-out` (JVM) / writes through `*out*` (CLJS), so
+  the banner is emitted into the same stream by forcing it under the
+  same `with-test-out` on the JVM and by a plain `println` on CLJS.
+  Capturing the methods rather than re-`defmethod`-ing inline keeps the
+  failure path a thin banner-prefix over the real reporter.
 
   Loading this namespace MULTIPLE TIMES is idempotent — `defmethod`
   silently replaces the existing dispatch entry.
@@ -67,8 +79,7 @@
   failure, regardless of nesting."
   (:require
     #?(:clj  [clojure.test]
-       :cljs [cljs.test])
-    #?(:clj  [clojure.stacktrace])))
+       :cljs [cljs.test])))
 
 ;; ----------------------------------------------------------------------
 ;; Banner state.
@@ -150,6 +161,19 @@
        (when-let [ns (:ns (meta v))]
          (ns-name ns)))))
 
+;; `defonce` (not `def`) so a namespace RELOAD does not re-capture: on a
+;; first load `get-method` returns clojure.test's default (our override is
+;; not installed yet); on a reload our override is already installed, so a
+;; plain `def` would capture OUR method and recurse infinitely.  `defonce`
+;; pins the original default for the lifetime of the runtime.
+#?(:clj
+   (defonce ^:private jvm-default-fail
+     (get-method clojure.test/report :fail)))
+
+#?(:clj
+   (defonce ^:private jvm-default-error
+     (get-method clojure.test/report :error)))
+
 #?(:clj
    (do
      (defmethod clojure.test/report :begin-test-ns [_m]
@@ -173,30 +197,20 @@
        )
 
      (defmethod clojure.test/report :fail [m]
+       ;; Flush the withheld banner, then DELEGATE to clojure.test's
+       ;; default `:fail` reporter so the FAIL block + expected/actual
+       ;; lines stay byte-for-byte the library's own output (failure
+       ;; formatting is not forked here).  The banner `println` runs
+       ;; under the SAME `with-test-out` the default uses, so both land
+       ;; on `*test-out*` in order.
        (clojure.test/with-test-out
-         (print-banner! (failing-ns))
-         (clojure.test/inc-report-counter :fail)
-         (println "\nFAIL in" (clojure.test/testing-vars-str m))
-         (when (seq clojure.test/*testing-contexts*)
-           (println (clojure.test/testing-contexts-str)))
-         (when-let [message (:message m)] (println message))
-         (println "expected:" (pr-str (:expected m)))
-         (println "  actual:" (pr-str (:actual m)))))
+         (print-banner! (failing-ns)))
+       (jvm-default-fail m))
 
      (defmethod clojure.test/report :error [m]
        (clojure.test/with-test-out
-         (print-banner! (failing-ns))
-         (clojure.test/inc-report-counter :error)
-         (println "\nERROR in" (clojure.test/testing-vars-str m))
-         (when (seq clojure.test/*testing-contexts*)
-           (println (clojure.test/testing-contexts-str)))
-         (when-let [message (:message m)] (println message))
-         (println "expected:" (pr-str (:expected m)))
-         (print "  actual: ")
-         (let [actual (:actual m)]
-           (if (instance? Throwable actual)
-             (clojure.stacktrace/print-cause-trace actual clojure.test/*stack-trace-depth*)
-             (prn actual)))))))
+         (print-banner! (failing-ns)))
+       (jvm-default-error m))))
 
 ;; ----------------------------------------------------------------------
 ;; CLJS overrides — cljs.test/report dispatches on
@@ -213,6 +227,17 @@
      (when-let [v (first (:testing-vars (cljs.test/get-current-env)))]
        (let [ns (:ns (meta v))]
          (when ns (symbol (name ns)))))))
+
+;; `defonce` for the same reload-safety reason as the JVM capture above:
+;; pin cljs.test's ORIGINAL default reporters so a reload (e.g. shadow
+;; hot-reload) never re-captures our own installed override and recurses.
+#?(:cljs
+   (defonce ^:private cljs-default-fail
+     (get-method cljs.test/report [:cljs.test/default :fail])))
+
+#?(:cljs
+   (defonce ^:private cljs-default-error
+     (get-method cljs.test/report [:cljs.test/default :error])))
 
 #?(:cljs
    (do
@@ -235,23 +260,14 @@
        )
 
      (defmethod cljs.test/report [:cljs.test/default :fail] [m]
+       ;; Flush the withheld banner, then DELEGATE to cljs.test's default
+       ;; `:fail` reporter so the FAIL block + expected/actual lines stay
+       ;; the library's own output (formatter handling, counters, etc. are
+       ;; not forked here).  Both write through `*out*`, so the banner and
+       ;; the delegated block stay in order.
        (print-banner! (failing-ns))
-       (cljs.test/inc-report-counter! :fail)
-       (println "\nFAIL in" (cljs.test/testing-vars-str m))
-       (when (seq (:testing-contexts (cljs.test/get-current-env)))
-         (println (cljs.test/testing-contexts-str)))
-       (when-let [message (:message m)] (println message))
-       (let [formatter-fn (or (:formatter (cljs.test/get-current-env)) pr-str)]
-         (println "expected:" (formatter-fn (:expected m)))
-         (println "  actual:" (formatter-fn (:actual m)))))
+       (cljs-default-fail m))
 
      (defmethod cljs.test/report [:cljs.test/default :error] [m]
        (print-banner! (failing-ns))
-       (cljs.test/inc-report-counter! :error)
-       (println "\nERROR in" (cljs.test/testing-vars-str m))
-       (when (seq (:testing-contexts (cljs.test/get-current-env)))
-         (println (cljs.test/testing-contexts-str)))
-       (when-let [message (:message m)] (println message))
-       (let [formatter-fn (or (:formatter (cljs.test/get-current-env)) pr-str)]
-         (println "expected:" (formatter-fn (:expected m)))
-         (println "  actual:" (formatter-fn (:actual m)))))))
+       (cljs-default-error m))))

--- a/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
+++ b/implementation/test-quiet/src/re_frame/test_quiet/shadow_node.cljs
@@ -10,15 +10,23 @@
   CLJS `defmethod`s install at load time.  By the time shadow's
   `run-all-tests` walks namespaces, the overrides are in place.
 
-  Also stubs `js/console.warn` so first-time runtime warnings
-  (`reg-view non-DOM root`, `reagent-slim keyword-on-non-HTML-prop`,
-  etc.) don't leak to test stdout on the success path.  Tests that
-  assert warning content all use the local `with-captured-console-warn`
-  pattern — they save `(.-warn js/console)`, install a recording shim,
-  run the body, then restore.  When our stub is in place, the saved
-  value IS the stub; the recording shim still receives the calls; the
-  restored value reverts to the stub.  Net effect: in-test capture
-  works unchanged; out-of-test side-effect warnings are silenced."
+  Also installs a BUFFERING `js/console.warn` stub so first-time
+  runtime warnings (`reg-view non-DOM root`, `reagent-slim
+  keyword-on-non-HTML-prop`, etc.) don't leak to test stdout on the
+  SUCCESS path — but are NOT lost on a RED run.  The stub holds back
+  warning text in a bounded ring (`warn-buffer`) instead of discarding
+  it; the `:end-run-tests` reporter replays that buffer to stderr when
+  the run fails or errors, so a failing CLJS run keeps the diagnostic
+  context that may explain the failure.  Green runs stay quiet (the
+  buffer is simply dropped at the green exit).
+
+  Tests that assert warning content all use the local
+  `with-captured-console-warn` pattern — they save `(.-warn js/console)`,
+  install a recording shim, run the body, then restore.  When our stub
+  is in place, the saved value IS the stub; the recording shim still
+  receives the calls; the restored value reverts to the stub.  Net
+  effect: in-test capture works unchanged; out-of-test side-effect
+  warnings are buffered (replayed on red, dropped on green)."
   {:dev/always true}
   (:require
     [clojure.string :as str]
@@ -28,10 +36,51 @@
     [shadow.test :as st]
     [cljs.test :as ct]))
 
-;; Silence stray runtime warnings on green. See ns docstring for the
-;; capture-compatibility rationale.  Installed at ns-load time so it's
-;; in place before shadow's `run-all-tests` walks the test ns set.
-;;
+;; Buffer stray runtime warnings instead of discarding them: quiet on
+;; green, but replayed on red so a failing run keeps the diagnostic
+;; context. See ns docstring for the capture-compatibility rationale.
+;; Installed at ns-load time so it's in place before shadow's
+;; `run-all-tests` walks the test ns set.
+
+(def ^:private warn-buffer-cap
+  "Bounded warning ring size.  Caps memory + replay volume on a red run
+  while keeping enough recent context to explain a failure (the newest
+  `warn-buffer-cap` warnings are retained; older ones are dropped)."
+  256)
+
+(defonce ^:private warn-buffer
+  ;; A bounded ring of buffered warning arg-vectors. `defonce` so a
+  ;; hot-reload of this `:dev/always` ns does not clobber warnings
+  ;; already captured this run.
+  (atom []))
+
+(defn- buffer-warning!
+  "Append `args` (one `console.warn` call's arguments) to the bounded
+  ring, dropping the oldest entries past `warn-buffer-cap`."
+  [args]
+  (swap! warn-buffer
+         (fn [buf]
+           (let [buf' (conj buf args)
+                 n    (count buf')]
+             (if (> n warn-buffer-cap)
+               (subvec buf' (- n warn-buffer-cap))
+               buf')))))
+
+(defn- replay-buffered-warnings!
+  "Replay the buffered warnings to stderr, prefixed so they are
+  distinguishable from the test reporter's own stdout output.  Called
+  from the `:end-run-tests` reporter ONLY on a red run, restoring the
+  diagnostic context the green-path quieting withheld."
+  []
+  (let [buffered @warn-buffer]
+    (when (seq buffered)
+      (binding [*print-fn* (fn [s] (js/process.stderr.write s))]
+        (println (str "[test-quiet] " (count buffered)
+                      " console.warn message(s) buffered during this run"
+                      " (replayed because the run was RED):"))
+        (doseq [args buffered]
+          (apply println "[test-quiet] console.warn:" args))))))
+
 ;; The stub carries a `re-frame.test-quiet/silenced` marker property so it
 ;; is IDENTIFIABLE: a contract test can assert the live `console.warn` is
 ;; this stub (and so fail if a regression leaves native `console.warn` —
@@ -39,19 +88,24 @@
 ;; `:dev/always` ns (which would form a compile cycle).
 (when (and (exists? js/console)
            (fn? (.-warn js/console)))
-  (let [stub (fn [& _])]
+  ;; Return `nil` (like native `console.warn`) so callers that observe the
+  ;; return value see no behavioural change from the buffering.
+  (let [stub (fn [& args] (buffer-warning! (vec args)) nil)]
     (set! (.-rf-test-quiet-silenced stub) true)
     (set! (.-warn js/console) stub)))
 
 ;; ----------------------------------------------------------------------
 ;; The single override shadow.test.node ships — exit the node process
 ;; with the appropriate code.  Stays here because removing it would
-;; break CI's pass/fail signal.
+;; break CI's pass/fail signal.  On a RED run we first replay any
+;; buffered `console.warn` diagnostics (the green-path stub withheld
+;; them) so a failing run keeps the context that may explain it.
 
 (defmethod ct/report [:cljs.test/default :end-run-tests] [m]
   (if (ct/successful? m)
     (js/process.exit 0)
-    (js/process.exit 1)))
+    (do (replay-buffered-warnings!)
+        (js/process.exit 1))))
 
 ;; ----------------------------------------------------------------------
 ;; Test-data reset (mirrors shadow.test.node/reset-test-data!).

--- a/implementation/test-quiet/test/re_frame/test_quiet_red_warn_fixture_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_red_warn_fixture_cljs_test.cljs
@@ -1,0 +1,32 @@
+(ns re-frame.test-quiet-red-warn-fixture-cljs-test
+  "A CLJS fixture suite for the warning-buffer red-replay regression in
+  `re-frame.test-quiet-shadow-node-cljs-test` (rf2-8dfq5j.2).
+
+  The buffered-`console.warn` contract (quiet on green, replayed on red)
+  can only be observed across a process boundary: the buffer is replayed
+  from the `:end-run-tests` reporter just before `js/process.exit`, which
+  would tear down the in-process runner.  So that regression spawns the
+  REAL built `out/node-test.js` runner focused on this ns.
+
+  This suite must NOT make the consolidated `npm run test:cljs`
+  (`run-all-tests`) run RED — so its fail-and-warn behaviour is GATED on
+  the `RF2_TQ_RED_WARN_FIXTURE` env var.  Unset (the default for the
+  whole-suite run) it is trivially GREEN and emits nothing.  The
+  process-level regression spawns the runner with that env var set, so
+  ONLY then does the fixture emit a `console.warn` and fail — proving the
+  withheld warning is replayed on the red exit while the warning stays
+  quiet on every green run."
+  (:require [cljs.test :refer-macros [deftest is]]))
+
+(def ^:private armed?
+  (boolean (some-> (.. js/process -env -RF2_TQ_RED_WARN_FIXTURE)
+                   (= "1"))))
+
+(deftest warns-then-fails-when-armed
+  (when armed?
+    ;; A stray runtime warning of exactly the class the green-path stub
+    ;; withholds. It must survive to the RED output via the buffer replay.
+    (js/console.warn "RED-WARN-FIXTURE-MARKER diagnostic context"))
+  ;; GREEN unless armed: the consolidated whole-suite run keeps passing.
+  (is (or (not armed?) (= :expected :actual))
+      "armed fixture fails so the run is RED and the buffer replays"))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -68,20 +68,45 @@
     (.mkdirs pkg-dir)
     (spit (io/file pkg-dir (str file-stem ".clj")) (str source "\n"))))
 
+(def ^:private default-drain-timeout-ms
+  "Shared ceiling for a drained subprocess.  A correctly-exiting child
+  returns in well under a second; this generous bound makes a wedged
+  child FAIL with a structured `:timed-out?` diagnostic instead of
+  hanging the whole JVM suite (rf2-8dfq5j.3)."
+  60000)
+
 (defn- drain-process
-  "Drain `proc`'s stdout AND stderr concurrently, then `waitFor`.
-  Returns {:exit :out :err}.  The concurrent drain is what
-  `run-runner` relies on to avoid the pipe deadlock (rf2-spzkgo); this
-  helper is the shared primitive both it and the deadlock regression
-  use, so the regression proves the EXACT drain order the real harness
-  ships."
-  [^Process proc]
-  (let [out-f (future (slurp (.getInputStream proc)))
-        err-f (future (slurp (.getErrorStream proc)))
-        out   @out-f
-        err   @err-f
-        exit  (.waitFor proc)]
-    {:exit exit :out out :err err}))
+  "Drain `proc`'s stdout AND stderr concurrently, then `waitFor` UNDER A
+  TIMEOUT.  Returns {:exit :out :err :timed-out?}.  The concurrent drain
+  is what `run-runner` relies on to avoid the pipe deadlock (rf2-spzkgo);
+  this helper is the shared primitive every subprocess path uses, so the
+  deadlock regression proves the EXACT drain order the real harness
+  ships.
+
+  The timeout/kill policy lives HERE (rf2-8dfq5j.3) so EVERY subprocess
+  test inherits fail-fast behaviour: on expiry the child is force-killed
+  (`destroyForcibly`), the drain threads are interrupted, and the result
+  carries `:timed-out? true` plus whatever stdout/stderr drained before
+  the kill — so an assertion sees a structured failure with command
+  context, not a hung suite.  `:exit` is -1 on a timeout (no real exit
+  code).  Pass `timeout-ms` to override the default ceiling."
+  ([^Process proc] (drain-process proc default-drain-timeout-ms))
+  ([^Process proc timeout-ms]
+   (let [out-f (future (slurp (.getInputStream proc)))
+         err-f (future (slurp (.getErrorStream proc)))
+         done? (.waitFor proc timeout-ms java.util.concurrent.TimeUnit/MILLISECONDS)]
+     (if done?
+       {:exit (.exitValue proc) :out @out-f :err @err-f :timed-out? false}
+       (do
+         ;; The child outlived the ceiling — force-kill it and interrupt
+         ;; the drain threads so neither this helper nor the futures hang.
+         (.destroyForcibly proc)
+         (future-cancel out-f)
+         (future-cancel err-f)
+         {:exit       -1
+          :out        (try @out-f (catch Throwable _ ""))
+          :err        (try @err-f (catch Throwable _ ""))
+          :timed-out? true})))))
 
 (defn- run-runner
   "Relaunch a fresh JVM that runs `re-frame.test-quiet.runner/-main` with
@@ -676,7 +701,9 @@
                      " sequential (stdout-then-stderr) drain hangs forever"
                      " (rf2-spzkgo) — it must drain both streams concurrently"))
             (when (not= ::timed-out result)
-              (let [{:keys [exit out err]} result]
+              (let [{:keys [exit out err timed-out?]} result]
+                (is (false? timed-out?)
+                    "the flood child exits, so the helper must NOT time out")
                 (is (= 3 exit)
                     (str "the child's nonzero exit code must be captured; got "
                          exit "\n--- stderr head ---\n"
@@ -688,3 +715,50 @@
                     (str "the full stderr flood must be captured, not truncated"
                          " by a partial drain; got " (count err)
                          " bytes, expected >= " big-stderr-bytes))))))))))
+
+;; ----------------------------------------------------------------------
+;; Shared drain timeout/kill policy — rf2-8dfq5j.3.
+;;
+;; `drain-process` carries the timeout/kill policy so EVERY subprocess
+;; path (the real `run-runner`, the deadlock regression, future helpers)
+;; fails fast on a wedged child instead of hanging the suite.  This pins
+;; that fail-fast behaviour directly: a child that NEVER exits must be
+;; force-killed at the ceiling and the helper must return `:timed-out?
+;; true` promptly — so a future change that drops the `.waitFor` timeout
+;; cannot silently reintroduce an unbounded hang.
+
+(deftest drain-process-kills-and-flags-a-hanging-child
+  (testing "a child that never exits is force-killed and flagged timed-out (rf2-8dfq5j.3)"
+    (with-fixture-dir
+      (fn [dir]
+        ;; A child that blocks forever with no output and no exit path —
+        ;; the worst case the finding describes.  Written to a file for
+        ;; the same cross-platform arg-quoting reason as the flood child.
+        (let [hang-file (io/file dir "hang_forever.clj")]
+          (spit hang-file "@(promise)\n") ; deref an unfulfilled promise → blocks forever
+          (let [os-win   (str/includes? (str/lower-case (System/getProperty "os.name")) "win")
+                java-bin (str (io/file (System/getProperty "java.home") "bin"
+                                       (if os-win "java.exe" "java")))
+                cmd      [java-bin "-cp" (System/getProperty "java.class.path")
+                          "clojure.main" (.getAbsolutePath hang-file)]
+                proc     (-> (ProcessBuilder. ^java.util.List cmd)
+                             (.redirectErrorStream false)
+                             (.start))
+                ;; A SHORT explicit ceiling keeps the test fast; the outer
+                ;; deref is the belt-and-suspenders so even a regressed
+                ;; helper fails as a TIMEOUT, never an infinite hang.
+                result-f (future (drain-process proc 1500))
+                result   (deref result-f 30000 ::outer-timeout)]
+            (is (not= ::outer-timeout result)
+                (str "the helper itself hung: `drain-process` must enforce its"
+                     " own `.waitFor` timeout and return promptly (rf2-8dfq5j.3)"))
+            (when (not= ::outer-timeout result)
+              (is (true? (:timed-out? result))
+                  (str "a never-exiting child must be flagged `:timed-out? true`;"
+                       " got " (pr-str (dissoc result :out :err))))
+              (is (= -1 (:exit result))
+                  "a timed-out drain reports exit -1 (no real exit code)")
+              (is (not (.isAlive proc))
+                  "the child must be force-killed on the timeout, not left alive"))
+            ;; Cleanup belt: ensure the child is gone regardless.
+            (.destroyForcibly proc)))))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
+++ b/implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs
@@ -276,27 +276,63 @@
   lines.  `Ran N tests containing M assertions.` / `K failures, J errors.`"
   #"^(Ran \d+ tests containing \d+ assertions\.|\d+ failures, \d+ errors\.)$")
 
+(def ^:private spawn-timeout-ms
+  "Hard ceiling for a spawned focused runner.  A correctly-exiting child
+  returns in well under a second; this generous bound makes a child that
+  stops exiting FAIL with a structured `:timed-out?` diagnostic instead
+  of hanging the whole CLJS suite (rf2-8dfq5j.3)."
+  60000)
+
+(def ^:private spawn-max-buffer-bytes
+  "Output cap for a spawned focused runner — `spawnSync` kills the child
+  and surfaces an ENOBUFS-class error once either stream exceeds this,
+  so a runaway child cannot exhaust this process's memory."
+  (* 8 1024 1024))
+
 (defn- spawn-runner
   "Re-spawn the SAME built `out/node-test.js` shadow-node runner this
   process is executing, with `argv` (a CLJS vector of string args), and
-  return `{:status :stdout :stderr :error}`.
+  return `{:status :stdout :stderr :error :signal :timed-out?}`.
 
   `process.argv[1]` is the runner script path and `process.argv[0]` the
   node binary, so this exercises the REAL `shadow-node/main` -> `parse-args`
   -> `execute-cli` CLI path end-to-end across a process boundary — the only
   way to observe the `js/process.exit` codes the false-green guards branch
-  on (calling `execute-cli` in-process would tear down this runner)."
-  [argv]
-  (let [self (aget js/process.argv 1)
-        res  (.spawnSync node-child-process
-                         (aget js/process.argv 0) ; the node binary
-                         (apply array self argv)
-                         #js {:encoding "utf8"})]
-    {:status (.-status res)
-     :stdout (or (.-stdout res) "")
-     :stderr (or (.-stderr res) "")
-     ;; cljs.test spawn errors (e.g. ENOENT) surface on res.error.
-     :error  (.-error res)}))
+  on (calling `execute-cli` in-process would tear down this runner).
+
+  `opts` is an optional CLJS map:
+   - `:env` — extra environment entries (merged over the parent env) the
+     child runs with;
+  A shared `:timeout`/`:maxBuffer` policy is applied to EVERY spawn so a
+  wedged or runaway child fails fast with a diagnostic rather than
+  stranding the suite (rf2-8dfq5j.3).  On a `spawnSync` timeout the child
+  is sent SIGTERM and `res.signal` is `\"SIGTERM\"`; `:timed-out?`
+  surfaces that for assertions."
+  ([argv] (spawn-runner argv {}))
+  ([argv {:keys [env]}]
+   (let [self     (aget js/process.argv 1)
+         child-env (when env
+                     (let [merged (js/Object.assign #js {} js/process.env)]
+                       (doseq [[k v] env]
+                         (aset merged (name k) v))
+                       merged))
+         res  (.spawnSync node-child-process
+                          (aget js/process.argv 0) ; the node binary
+                          (apply array self argv)
+                          (cond-> #js {:encoding  "utf8"
+                                       :timeout   spawn-timeout-ms
+                                       :maxBuffer spawn-max-buffer-bytes}
+                            child-env (doto (aset "env" child-env))))
+         signal (.-signal res)]
+     {:status     (.-status res)
+      :stdout     (or (.-stdout res) "")
+      :stderr     (or (.-stderr res) "")
+      ;; cljs.test spawn errors (e.g. ENOENT, ETIMEDOUT, ENOBUFS) surface
+      ;; on res.error.
+      :error      (.-error res)
+      :signal     signal
+      ;; spawnSync kills the child with SIGTERM on a :timeout expiry.
+      :timed-out? (= signal "SIGTERM")})))
 
 (deftest real-shadow-node-green-run-is-quiet
   (testing "the real out/node-test.js entry point emits ONLY the canonical summary on a focused green run (rf2-spzkgo)"
@@ -422,3 +458,99 @@
       (is (not (str/includes? stdout "Ran "))
           (str "no suite may have run; a `Ran ...` summary is the false"
                " green; got:\n" stdout)))))
+
+;; ----------------------------------------------------------------------
+;; console.warn buffer red-replay (rf2-8dfq5j.2).
+;;
+;; The shadow-node `console.warn` stub no longer DISCARDS warnings on the
+;; success path — it buffers them in a bounded ring and the
+;; `:end-run-tests` reporter replays the buffer to stderr ONLY on a RED
+;; run, restoring the diagnostic context a failing CLJS run needs.  This
+;; can only be observed across a process boundary (the replay fires just
+;; before `js/process.exit`).  We drive the REAL runner against
+;; `re-frame.test-quiet-red-warn-fixture-cljs-test`, whose warn-then-fail
+;; behaviour is gated on `RF2_TQ_RED_WARN_FIXTURE=1` (so the whole-suite
+;; run stays green): with the env var set the fixture warns + fails, and
+;; the buffered warning must surface in the red output; with it UNSET the
+;; same fixture is green and emits no warning.
+
+(deftest red-run-replays-buffered-console-warn
+  (testing "a RED run replays the buffered console.warn diagnostic (rf2-8dfq5j.2)"
+    (let [red-ns "re-frame.test-quiet-red-warn-fixture-cljs-test"
+          {status :status stdout :stdout stderr :stderr err :error
+           timed-out? :timed-out?}
+          (spawn-runner [(str "--test=" red-ns)]
+                        {:env {:RF2_TQ_RED_WARN_FIXTURE "1"}})]
+      (is (nil? err)
+          (str "spawning the real runner must not error; got: " (pr-str err)))
+      (is (not timed-out?)
+          "the armed fixture run must not time out")
+      (is (and (number? status) (not (zero? status)))
+          (str "the armed fixture is RED; must exit NONZERO; got " status
+               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
+      ;; The CORE pin: the warning the green-path stub withholds is
+      ;; replayed on red, so its marker text must appear in the combined
+      ;; output (the replay targets stderr).
+      (is (str/includes? (str stdout stderr) "RED-WARN-FIXTURE-MARKER")
+          (str "the buffered console.warn must be replayed on a RED run"
+               " (rf2-8dfq5j.2); got\n--- stdout ---\n" stdout
+               "\n--- stderr ---\n" stderr))
+      (is (str/includes? (str stdout stderr) "[test-quiet] console.warn:")
+          (str "the replay must label the buffered warnings; got\n"
+               "--- stderr ---\n" stderr))))
+  (testing "the SAME fixture is GREEN + quiet when unarmed (negative control)"
+    ;; Without the env arming flag the fixture passes and emits no
+    ;; warning, so the green-path quiet contract holds and the marker is
+    ;; ABSENT from stdout — proving the warning is genuinely withheld on
+    ;; green, not merely always printed.
+    (let [red-ns "re-frame.test-quiet-red-warn-fixture-cljs-test"
+          {status :status stdout :stdout stderr :stderr err :error}
+          (spawn-runner [(str "--test=" red-ns)])]
+      (is (nil? err)
+          (str "spawning the real runner must not error; got: " (pr-str err)))
+      (is (zero? status)
+          (str "the unarmed fixture is GREEN; must exit 0; got " status
+               "\n--- stdout ---\n" stdout "\n--- stderr ---\n" stderr))
+      (is (not (str/includes? stdout "RED-WARN-FIXTURE-MARKER"))
+          (str "an unarmed (green) run must NOT emit the warning marker on"
+               " stdout — green stays quiet; got:\n" stdout))
+      (let [non-blank (->> (str/split-lines stdout)
+                           (map str/trim)
+                           (remove str/blank?))]
+        (is (every? #(re-matches allowed-green-line-re %) non-blank)
+            (str "a green run must emit ONLY the canonical summary lines;"
+                 " got:\n" (str/join "\n" non-blank)))))))
+
+;; ----------------------------------------------------------------------
+;; Shared spawn timeout/output policy (rf2-8dfq5j.3).
+;;
+;; The process-level pins above all route through `spawn-runner`, which
+;; applies a single `:timeout` + `:maxBuffer` policy to every spawn so a
+;; wedged or runaway child fails fast with a diagnostic rather than
+;; hanging the whole CLJS suite.  This pins the fail-fast behaviour itself
+;; via a deliberately-hanging child so a future change cannot silently
+;; drop the timeout: a child that never exits must surface a SIGTERM
+;; timeout, not block forever.  We spawn the node binary directly on a
+;; tiny inline program (no runner needed) with a SHORT explicit timeout so
+;; the test stays fast.
+
+(deftest spawn-timeout-kills-a-hanging-child
+  (testing "spawnSync timeout terminates a child that never exits (rf2-8dfq5j.3)"
+    (let [;; A child that blocks forever: an idle interval keeps the event
+          ;; loop alive with no exit path.
+          res (.spawnSync node-child-process
+                          (aget js/process.argv 0) ; node binary
+                          #js ["-e" "setInterval(function(){}, 1000)"]
+                          #js {:encoding  "utf8"
+                               :timeout   1500
+                               :maxBuffer (* 1024 1024)})]
+      ;; The CORE pin: spawnSync must have KILLED the child on timeout
+      ;; (SIGTERM), proving the shared policy fails fast instead of
+      ;; hanging. A regression that dropped `:timeout` would block here
+      ;; forever (the child never exits on its own).
+      (is (= "SIGTERM" (.-signal res))
+          (str "a hanging child must be SIGTERM-killed on the spawnSync"
+               " timeout (rf2-8dfq5j.3); got signal " (pr-str (.-signal res))
+               " status " (pr-str (.-status res))))
+      (is (some? (.-error res))
+          "spawnSync must surface an ETIMEDOUT-class error on the timeout"))))


### PR DESCRIPTION
Addresses the three best-practice findings on the `implementation/test-quiet` infra component (rf2-8dfq5j).

**1. Reporter failure path no longer forks the defaults.** The JVM and CLJS `:fail`/`:error` overrides were byte-for-byte copies of clojure.test / cljs.test default formatting. They now capture the library defaults (via `defonce get-method`, before installing the overrides) and delegate after the banner flush, so failure formatting stays owned by the test libraries and inherits upstream changes. Matches what docs/quiet-tests.md already describes.

**2. CLJS console.warn is buffered, not discarded.** The unconditional no-op stub is replaced by a bounded warning ring (cap 256). Quiet on green (buffer dropped at the green exit); replayed to stderr from the `:end-run-tests` reporter on a red run, so a failing CLJS run keeps the diagnostic context that may explain it. Stub still returns nil and keeps the `rf-test-quiet-silenced` marker + save/shim/restore capture-compat. New gated red fixture + process-level pins prove replay-on-red and quiet-on-green.

**3. Shared subprocess timeout/kill policy.** The timeout policy now lives in the shared JVM `drain-process` helper (force-kill + `:timed-out?` flag on expiry, exit -1) and in the CLJS `spawn-runner` (`:timeout` + `:maxBuffer`). New helper-level + spawnSync hang fixtures pin the fail-fast behaviour so the policy can't be silently dropped.

Builds on #3584 (quiet-on-success + pipe deadlock) and #3634 (CLJS-arg false-green + stdout overdrop) — quiet-on-success, the fatal-unknown-arg guard, and the balanced-banner-remainder forwarding are all preserved.

## Quality gates
- `cd implementation && npm run test:cljs` (consolidated gate test-quiet feeds): green + quiet-on-success — Ran 6139 tests containing 21891 assertions. 0 failures, 0 errors.
- test-quiet JVM `clojure -M:test`: Ran 19 tests containing 70 assertions. 0 failures, 0 errors.