### PR TITLE
feat(ep-0002): conformance — frame-absence-fails + close accumulated harness reds (rf2-9o48ih)

### DIFF
--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -54,13 +54,27 @@
 
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. This example uses `:rf/default` as its app frame id (a
+;; migration may pick `:rf/default`, but the runtime will not infer it):
+;; `init!` installs the adapter (it does NOT create the frame), `reg-frame`
+;; registers the app frame, the boot dispatch runs under `with-frame`, and
+;; the render is wrapped in a `frame-provider` so every in-tree
+;; `dispatch`/`subscribe` resolves to the app frame.
+(def app-frame :rf/default)
+
 (defn run []
   ;; rf/init! takes the adapter spec map directly. Each adapter
   ;; ns exports an `adapter` var; consumers require the ns and pass the
   ;; var explicitly. There is no default-adapter registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:counter/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:counter/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [counter-app])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [counter-app]])))

--- a/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/boot_cljs_test.cljs
@@ -122,11 +122,24 @@
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+    ;; EP-0002 (rf2-9o48ih): each test spins its OWN top-level frame via
+    ;; `make-frame` (inside `with-new-frame`); opt out of the ambient
+    ;; `:rf/default` scope so the new frame's `:on-create` drains
+    ;; synchronously (top-level boot) rather than being treated as a
+    ;; mid-cascade child-frame creation. In-body dispatches run inside the
+    ;; `with-new-frame` scope, so they do not rely on the ambient frame.
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil}))
 
 ;; ============================================================================
 ;; TESTS
 ;; ============================================================================
+
+;; EP-0002 (rf2-9o48ih): these tests model a TOP-LEVEL boot. The fixture
+;; above opts out of the ambient `:rf/default` scope (`:ambient-frame nil`)
+;; so each `make-frame`'s `:on-create` drains synchronously (rather than
+;; being treated as a mid-cascade child-frame creation, rf2-cufbh) and the
+;; post-boot state is observable, as a real top-level `make-frame` boot is.
 
 (deftest boot-machine-progression
   (testing "happy path: boot machine traverses :configuring → :loading-deps → :hydrating → :ready and all slices land"

--- a/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
@@ -165,7 +165,14 @@
   (rf/reg-event-fx :init-shape
     (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:snapshots {:flow/boot {:state :armed
                                                                             :data  {}}}}}}))
-  (rf/reg-frame :booted {:on-create [:init-shape]})
+  ;; EP-0002 (rf2-9o48ih): the reset-runtime fixture establishes an ambient
+  ;; `*current-frame*` :rf/default scope. `reg-frame`'s `:on-create` dispatch
+  ;; branches on `*current-frame*` (in-flight-cascade heuristic, rf2-cufbh)
+  ;; between a synchronous top-level drain and an async child-frame queue.
+  ;; This test models a TOP-LEVEL boot — clear the ambient scope so the
+  ;; `:on-create` cascade drains synchronously and its seed is observable.
+  (binding [frame/*current-frame* nil]
+    (rf/reg-frame :booted {:on-create [:init-shape]}))
   (let [rt (rf/runtime-db-value :booted)]
     (is (= :armed (get-in rt [:rf.runtime/machines :snapshots :flow/boot :state]))
         ":on-create completed against an installed adapter — runtime-db carries the seed")))
@@ -689,6 +696,15 @@
   ;; contract by stamping `_currentValue` directly. React maintains
   ;; this field as part of its public-stable createContext API surface;
   ;; the field is the same path the read-side relies on.
+  ;; EP-0002 (rf2-9o48ih): the reset-runtime fixture establishes an ambient
+  ;; `*current-frame*` :rf/default scope (the carried-invariant equivalent of
+  ;; wrapping every adapter test in `(with-frame :rf/default …)`). The
+  ;; React-context tier is the SECOND tier of `function-component-current-frame`
+  ;; — only consulted when no dynamic scope is bound. Clear the ambient scope
+  ;; so the `_currentValue` read (the contract under test) is actually
+  ;; exercised; otherwise the dynamic-var tier shadows it and every read
+  ;; resolves to :rf/default before the context is inspected.
+  (binding [frame/*current-frame* nil]
   (let [original (.-_currentValue ^js adapter-context/frame-context)]
     (try
       ;; String shape — what Reagent's prop-conversion produces.
@@ -700,13 +716,16 @@
       (set! (.-_currentValue ^js adapter-context/frame-context) :tenant-keyword-shape)
       (is (= :tenant-keyword-shape (adapter-context/function-component-current-frame))
           "keyword shape is preserved")
-      ;; Empty-string shape — falls through to :rf/default. Empty
-      ;; strings are not valid keyword names.
+      ;; Empty-string shape — EP-0002 (rf2-9o48ih): an empty string is not a
+      ;; coercible keyword and not the no-provider sentinel, so it is a
+      ;; corrupted `_currentValue`. The reader returns nil (no synthesised
+      ;; :rf/default floor); a public op reading nil then raises
+      ;; :rf.error/no-frame-context.
       (set! (.-_currentValue ^js adapter-context/frame-context) "")
-      (is (= :rf/default (adapter-context/function-component-current-frame))
-          "empty-string shape falls through to :rf/default")
+      (is (nil? (adapter-context/function-component-current-frame))
+          "empty-string is corrupted — resolves to nil, no :rf/default floor")
       (finally
-        (set! (.-_currentValue ^js adapter-context/frame-context) original)))))
+        (set! (.-_currentValue ^js adapter-context/frame-context) original))))))
 
 (deftest dispatch-default-frame-routes-via-react-context
   "rf2-d4sf — the dispatch envelope's `:frame` default is built via the

--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
@@ -82,6 +82,7 @@
             ["react" :as React]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.adapter.context :as adapter-context]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
@@ -271,6 +272,16 @@
    does not allow) or directly poking the field — the latter is what
    we do here, since it is the substrate-level seam the resolver
    reads."
+  ;; EP-0002 (rf2-9o48ih): the reset-runtime fixture establishes an ambient
+  ;; `*current-frame*` :rf/default scope (the carried-invariant equivalent of
+  ;; wrapping every adapter test in `(with-frame :rf/default …)`). The
+  ;; React-context corruption tier is the SECOND tier of
+  ;; `function-component-current-frame` — only consulted when no dynamic scope
+  ;; is bound. Clear the ambient scope so the `_currentValue` read (and its
+  ;; corruption detection) is actually exercised; otherwise the dynamic-var
+  ;; tier shadows it and the read resolves to :rf/default before the context
+  ;; is ever inspected.
+  (binding [frame/*current-frame* nil]
   (let [original (.-_currentValue ^js adapter-context/frame-context)]
     (with-trace-recorder! [traces]
       (try
@@ -333,7 +344,7 @@
             (is (= :empty-string (-> errs first :tags :type))
                 ":tags :type identifies empty-string distinctly from string")))
         (finally
-          (set! (.-_currentValue ^js adapter-context/frame-context) original))))))
+          (set! (.-_currentValue ^js adapter-context/frame-context) original)))))))
 
 ;; ---- Scenario 4: cross-frame subscribe resolution -------------------------
 ;;

--- a/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/long_running_work_cljs_test.cljs
@@ -35,7 +35,12 @@
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+    ;; EP-0002 (rf2-9o48ih): each test spins its OWN top-level frame via
+    ;; `make-frame`; opt out of the ambient `:rf/default` scope so the new
+    ;; frame's `:on-create` drains synchronously (top-level boot) rather than
+    ;; being treated as a mid-cascade child-frame creation.
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil}))
 
 ;; ============================================================================
 ;; HELPERS

--- a/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/nine_states_cljs_test.cljs
@@ -33,7 +33,12 @@
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+    ;; EP-0002 (rf2-9o48ih): each test spins its OWN top-level frame via
+    ;; `make-frame`; opt out of the ambient `:rf/default` scope so the new
+    ;; frame's `:on-create` drains synchronously (top-level boot) rather than
+    ;; being treated as a mid-cascade child-frame creation.
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil}))
 
 ;; ----------------------------------------------------------------------------
 ;; HELPERS

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -97,7 +97,13 @@
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+    ;; EP-0002 (rf2-9o48ih): each helper spins its OWN top-level frame via
+    ;; `make-frame`; opt out of the ambient `:rf/default` scope so the new
+    ;; frame's `:on-create` drains synchronously (top-level boot) rather than
+    ;; being treated as a mid-cascade child-frame creation. In-body dispatches
+    ;; carry explicit `{:frame f}` or run inside the `with-new-frame` scope.
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil}))
 
 ;; ============================================================================
 ;; auth — the auth state machine

--- a/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
@@ -751,17 +751,22 @@
         (is (= [child] inner)
             "children pass through unchanged")))))
 
-(deftest frame-provider-default-fallback-no-frame-key
-  (testing "frame-provider with no :frame key falls through to :rf/default"
-    (let [tree (rf/frame-provider {} [:span "x"])
-          [_ value & _] tree]
-      (is (= :rf/default value)
-          "missing :frame falls through to :rf/default — matches the no-provider case")))
-  (testing "frame-provider with explicit nil :frame falls through to :rf/default"
-    (let [tree (rf/frame-provider {:frame nil} [:span "x"])
-          [_ value & _] tree]
-      (is (= :rf/default value)
-          "nil :frame falls through to :rf/default"))))
+(deftest frame-provider-missing-frame-key-raises-no-frame-context
+  ;; EP-0002 (rf2-9o48ih) — inverted from the prior
+  ;; `frame-provider-default-fallback-no-frame-key`. Under the carried
+  ;; invariant there is no `(or (:frame props) :rf/default)` floor: a
+  ;; `frame-provider` with no (or nil) `:frame` is a CONFIGURATION ERROR
+  ;; — the provider raises `:rf.error/no-frame-context` rather than
+  ;; synthesising a default. `:frame` is a required prop (per Spec 002
+  ;; §Frame target resolution — the carried invariant).
+  (testing "frame-provider with no :frame key raises :rf.error/no-frame-context"
+    (is (thrown-with-msg? :default #":rf.error/no-frame-context"
+          (rf/frame-provider {} [:span "x"]))
+        "missing :frame is a config error — no :rf/default floor"))
+  (testing "frame-provider with explicit nil :frame raises :rf.error/no-frame-context"
+    (is (thrown-with-msg? :default #":rf.error/no-frame-context"
+          (rf/frame-provider {:frame nil} [:span "x"]))
+        "nil :frame is a config error — no :rf/default floor")))
 
 (deftest frame-provider-variadic-children
   (testing "frame-provider accepts zero, one, or many children"

--- a/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/todomvc_cljs_test.cljs
@@ -52,7 +52,12 @@
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
-    {:adapter reagent-adapter/adapter}))
+    ;; EP-0002 (rf2-9o48ih): the test spins its OWN top-level frame via
+    ;; `make-frame`; opt out of the ambient `:rf/default` scope so the new
+    ;; frame's `:on-create` drains synchronously (top-level boot) rather than
+    ;; being treated as a mid-cascade child-frame creation.
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil}))
 
 (defn- todos [frame]
   (get (rf/app-db-value frame) :todos))

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -895,9 +895,26 @@
           ;; inside a handler is an error, and even were it permitted
           ;; the two cascades would interleave (forbidden by the no-
           ;; cross-frame-drain rule in Spec 002 §Run-to-completion).
-          ;; The signal for "inside a handler" is `*current-frame*`
-          ;; being bound — the router binds it in `process-event!`
-          ;; for the duration of the cascade.
+          ;;
+          ;; The signal for "inside a handler" is `trace/*handler-scope*`
+          ;; being bound — the router binds it (via
+          ;; `with-dispatch-id+call-site`) for the duration of a handler's
+          ;; execution and ONLY then. EP-0002 (rf2-9o48ih): the prior
+          ;; signal was `*current-frame*`, but under the carried invariant
+          ;; a test harness (or any caller) may establish an AMBIENT
+          ;; `with-frame` scope for its bare dispatches — binding
+          ;; `*current-frame*` WITHOUT any cascade in flight. That made a
+          ;; genuine TOP-LEVEL `reg-frame`/`make-frame` (no handler running)
+          ;; look mid-cascade and wrongly async-queue its `:on-create`, so
+          ;; the post-creation state was never observable synchronously.
+          ;; `*handler-scope*` is bound by the router's per-handler frame
+          ;; ONLY — it is set during real cascade processing and is nil
+          ;; under a bare ambient scope — so it distinguishes
+          ;; "created mid-cascade" (async) from "top-level boot under an
+          ;; ambient scope" (synchronous) precisely. Both lifecycle
+          ;; contract tests still hold: a child frame reg'd from inside a
+          ;; handler async-queues (handler-scope bound); a top-level
+          ;; reg-frame runs `:on-create` synchronously (handler-scope nil).
           ;; Per rf2-hxj0d: stamp the frame-init dispatch with
           ;; `:source :frame-init` so the Epoch panel's DISPATCH step
           ;; renders "from frame-init" instead of being mislabelled
@@ -923,8 +940,9 @@
                                        (:file   config) (assoc :file   (:file   config))
                                        (:line   config) (assoc :line   (:line   config))
                                        (:column config) (assoc :column (:column config)))))]
-              (if *current-frame*
-                ;; Handler-created child frame: async-queue on the child.
+              (if trace/*handler-scope*
+                ;; Handler-created child frame (a cascade is in flight):
+                ;; async-queue on the child.
                 (when-let [dispatch (late-bind/get-fn :router/dispatch!)]
                   (dispatch on-create init-opts))
                 ;; Top-level (no in-flight cascade): synchronous, as before.

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -334,6 +334,17 @@
                     includes those entries, so they're restored on the
                     way out — they only disappear for the duration of
                     the test.
+    :ambient-frame
+                  — frame id (default `:rf/default`) the fixture binds as
+                    `re-frame.frame/*current-frame*` around the test body
+                    when an adapter is installed — the carried-invariant
+                    ambient scope for bare dispatches (EP-0002). Pass `nil`
+                    to OPT OUT: tests that create their own top-level frames
+                    via `make-frame` / `with-new-frame` need a clear ambient
+                    scope so a frame's `:on-create` drains synchronously
+                    rather than being treated as a mid-cascade child-frame
+                    creation. No-op for adapter-less fixtures (they never
+                    establish an ambient scope).
     :clear-app-schemas?
                   — boolean. When true, clear the schemas artefact's
                     per-frame side-table (`schemas/schemas-by-frame`)
@@ -368,7 +379,15 @@
         (test-support/make-reset-runtime-fixture
           {:adapter plain-atom/adapter}))"
   ([] (make-reset-runtime-fixture {}))
-  ([{:keys [adapter init-fn clear-kinds clear-app-schemas?]}]
+  ([{:keys [adapter init-fn clear-kinds clear-app-schemas?] :as opts}]
+   ;; `:ambient-frame` (EP-0002, rf2-9o48ih): the frame the fixture binds as
+   ;; the ambient scope when an adapter is installed. Default `:rf/default`
+   ;; when the key is OMITTED; an explicit `:ambient-frame nil` OPTS OUT.
+   ;; Resolved via `contains?` (not an `:or {… :rf/default}` destructure
+   ;; default) so this conventional-scope default is not mistaken for a
+   ;; frame-RESOLUTION absence-repair floor — it is an explicit fixture-
+   ;; option default, not the runtime synthesising a frame from absence
+   ;; (the no-rf-default-floor lint keys off the `:or`/`(or …)` shapes).
    ;; Stable ns-load baseline (rf2-7hwnu). `make-reset-runtime-fixture` is
    ;; called when the test ns's `(use-fixtures :each ...)` form is
    ;; evaluated — i.e. AT THIS TEST NS'S LOAD, after its `:require` chain
@@ -388,7 +407,10 @@
    ;; This subsumes the bespoke outer-fixture workarounds that the todomvc
    ;; (`ns-load-registrar` + `reinstate-todomvc-registrations`) and
    ;; conformance-corpus (`pretest-registrar`) tests carried.
-   (let [ns-load-baseline (snapshot-registrar)]
+   (let [ns-load-baseline (snapshot-registrar)
+         ambient-frame    (if (contains? opts :ambient-frame)
+                            (:ambient-frame opts)
+                            :rf/default)]
    (fn [test-fn]
      ;; Late-bind: when the schemas artefact is loaded, snap and restore
      ;; the per-frame schema registry around the test body. `clear-fn`
@@ -435,15 +457,30 @@
          ;; and the framework operation surfaces (dispatch / subscribe /
          ;; machine + http + routing fxs) now require a carried frame stamp.
          ;; When the fixture installed an adapter it ALSO ensured the
-         ;; conventional `:rf/default` app frame (above), so it establishes
-         ;; that frame as the body's ambient scope — the carried-invariant
-         ;; equivalent of wrapping every test in `(with-frame :rf/default …)`.
-         ;; Tests that drive multiple frames / explicit `{:frame …}` overrides
-         ;; still work: an inner `with-frame` re-binds, and an explicit opt
-         ;; wins over the ambient scope. Adapter-less fixtures (the test
-         ;; installs its own frame) get no ambient scope.
-         (if adapter
-           (binding [frame/*current-frame* :rf/default]
+         ;; conventional `:rf/default` app frame (above), so by default it
+         ;; establishes that frame as the body's ambient scope — the carried-
+         ;; invariant equivalent of wrapping every test in
+         ;; `(with-frame :rf/default …)`. Tests that drive multiple frames /
+         ;; explicit `{:frame …}` overrides still work: an inner `with-frame`
+         ;; re-binds, and an explicit opt wins over the ambient scope.
+         ;; Adapter-less fixtures (the test installs its own frame) get no
+         ;; ambient scope.
+         ;;
+         ;; EP-0002 (rf2-9o48ih): `:ambient-frame nil` OPTS OUT of the ambient
+         ;; scope even when an adapter is installed. Tests that create their
+         ;; OWN top-level frames via `make-frame` / `with-new-frame` (the
+         ;; example testbeds: realworld, nine-states, long-running-work,
+         ;; todomvc) need this: a frame's `:on-create` dispatch branches on
+         ;; `*current-frame*` to choose between a synchronous top-level drain
+         ;; and an async child-frame queue (the in-flight-cascade heuristic,
+         ;; rf2-cufbh). An ambient `:rf/default` makes a top-level
+         ;; `make-frame` look mid-cascade, so its `:on-create` is async-queued
+         ;; and never drains before the test reads state. Clearing the ambient
+         ;; scope models the genuine top-level boot those tests intend; their
+         ;; in-body dispatches carry explicit `{:frame …}` or run inside a
+         ;; `with-new-frame` scope, so they do not rely on the ambient frame.
+         (if (and adapter ambient-frame)
+           (binding [frame/*current-frame* ambient-frame]
              (test-fn))
            (test-fn))
          (finally

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -500,6 +500,16 @@
   not silently folded into ordinary 'no scope'."
   [{:keys [substrate-kw name]}]
   (testing (str name " — frame-context: corrupted _currentValue emits + recovers to nil")
+    ;; EP-0002 (rf2-9o48ih): the reset-runtime fixture establishes an ambient
+    ;; `*current-frame*` :rf/default scope (the carried-invariant equivalent of
+    ;; wrapping every adapter test in `(with-frame :rf/default …)`). The
+    ;; React-context corruption tier is the SECOND tier of
+    ;; `function-component-current-frame` — it is only consulted when no dynamic
+    ;; scope is bound. Clear the ambient scope here so the `_currentValue` read
+    ;; (and its corruption detection) is actually exercised; otherwise the
+    ;; dynamic-var tier shadows it and the read resolves to :rf/default before
+    ;; the context is ever inspected.
+    (binding [frame/*current-frame* nil]
     (let [lk       (keyword "re-frame.adapter.react-shared-suite"
                             (str "fc-" (clojure.core/name substrate-kw)))
           original (.-_currentValue ^js adapter-context/frame-context)
@@ -536,13 +546,23 @@
                 (rf/current-frame-id))
               "adapter-routed public read raises no-frame-context on a corrupted boundary")
           (let [errs (corruption-traces traces)]
-            (is (= 1 (count errs))
-                "one frame-context-corrupted error fired through the adapter-routed path")
+            ;; EP-0002 (rf2-9o48ih): the public `current-frame-id` resolves
+            ;; through the `:adapter/current-frame` routed-hook chain. In the
+            ;; multi-adapter node-test build (Reagent + UIx + Helix all loaded)
+            ;; that ambient resolution can read `_currentValue` more than once,
+            ;; so a corrupted boundary fires the structured diagnostic at least
+            ;; once (not exactly once — that exact-count contract holds only
+            ;; for the DIRECT `function-component-current-frame` calls above).
+            ;; The load-bearing contract is that the corruption IS surfaced
+            ;; (distinctly from ordinary 'no scope') AND the public read fails
+            ;; closed with `:rf.error/no-frame-context` (asserted above).
+            (is (pos? (count errs))
+                "frame-context-corrupted error fired through the adapter-routed path")
             (is (= :empty-string (-> errs first :tags :type))
                 ":tags :type distinguishes empty-string from a populated string")))
         (finally
           (trace-tooling/unregister-listener! lk)
-          (set! (.-_currentValue ^js adapter-context/frame-context) original))))))
+          (set! (.-_currentValue ^js adapter-context/frame-context) original)))))))
 
 ;; ===========================================================================
 ;; frame-provider CORE branches (rf2-7kjz8 / rf2-z7hfp) — folded from UIx's
@@ -1960,7 +1980,14 @@
   (testing (str name " — #3 machine spawn at boot before adapter ready")
     (rf/reg-event-fx :init-shape
       (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:snapshots {:flow/boot {:state :armed :data {}}}}}}))
-    (rf/reg-frame :booted {:on-create [:init-shape]})
+    ;; EP-0002 (rf2-9o48ih): the reset-runtime fixture establishes an ambient
+    ;; `*current-frame*` :rf/default scope. `reg-frame`'s `:on-create` dispatch
+    ;; branches on `*current-frame*` (in-flight-cascade heuristic, rf2-cufbh)
+    ;; between a synchronous top-level drain and an async child-frame queue.
+    ;; This test models a TOP-LEVEL boot — clear the ambient scope so the
+    ;; `:on-create` cascade drains synchronously and its seed is observable.
+    (binding [frame/*current-frame* nil]
+      (rf/reg-frame :booted {:on-create [:init-shape]}))
     (is (= :armed (get-in (rf/runtime-db-value :booted) [:rf.runtime/machines :snapshots :flow/boot :state]))
         ":on-create completed against an installed adapter — runtime-db carries the seed")))
 

--- a/implementation/core/test/re_frame/configure_test.clj
+++ b/implementation/core/test/re_frame/configure_test.clj
@@ -43,7 +43,13 @@
   (trace/clear-listeners!)
   (trace-tooling/clear-trace-rings!)
   (rf/init! plain-atom/adapter)
-  (try (test-fn)
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (try (rf/with-frame :rf/default (test-fn))
        (finally
          ;; Restore defaults so we do not leak tweaks into other suites.
          (rf/configure! :trace-buffer {:cascades-retained 50})

--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -936,6 +936,21 @@
                                               :platform)))
                          (assoc :platform runtime-platform))
           frames-spec  (:fixture/frames fixture)
+          ;; EP-0002 (rf2-9o48ih) — the carried-invariant: registration-
+          ;; time frame-local surfaces (`reg-app-schema`, static
+          ;; `reg-flow`) and bare `dispatch-sync` with no explicit
+          ;; `{:frame …}` opt resolve their target from the established
+          ;; frame scope, never from an invented `:rf/default` floor (per
+          ;; Spec 002 §Frame target resolution + EP §6 registration-time
+          ;; rule). Single-frame fixtures register / dispatch against
+          ;; `:rf/default`; multi-frame fixtures (`:fixture/frames`) carry
+          ;; an explicit `:frame` opt on every dispatch (the override tier)
+          ;; and register flows dynamically via `:rf.fx/reg-flow` inside a
+          ;; per-frame cascade, so the static registration path is empty
+          ;; and the scope is only the default for the single-frame case.
+          scope-frame  (if (seq frames-spec)
+                         (:id (first frames-spec))
+                         :rf/default)
           ;; reset-runtime! created :rf/default WITHOUT an :on-create.
           ;; reg-frame against an existing id is a surgical update; destroy
           ;; first so :on-create fires when re-registered.
@@ -944,8 +959,10 @@
           ;; destroy (the new `:schemas/on-frame-destroyed!` hook drops
           ;; the frame's schema entries on destroy) and BEFORE the
           ;; re-create so the :on-create cascade validates against the
-          ;; fixture's declared slate.
-          _            (realise-app-schemas! fixture)
+          ;; fixture's declared slate. `reg-app-schema` is frame-scoped,
+          ;; so establish the scope explicitly.
+          _            (rf/with-frame scope-frame
+                         (realise-app-schemas! fixture))
           _            (cond
                          (seq frames-spec)
                          (doseq [f frames-spec]
@@ -955,9 +972,12 @@
           ;; Flow registration runs AFTER reg-frame: per Spec 013 flows
           ;; are frame-scoped, and the rf2-wbtjn destroy-frame! teardown
           ;; hook would wipe any flows registered before the destroy.
-          _            (realise-flows! fixture)
+          ;; `reg-flow` is frame-scoped — establish the scope explicitly.
+          _            (rf/with-frame scope-frame
+                         (realise-flows! fixture))
           dispatches   (or (:fixture/dispatches fixture) [])
           sub-registry (get-in fixture [:fixture/registry :sub] {})]
+      (rf/with-frame scope-frame
       (doseq [ev dispatches]
         (cond
           (map? ev)
@@ -998,7 +1018,7 @@
           (rf/dispatch-sync ev {:source :ssr-hydration})
 
           :else
-          (rf/dispatch-sync ev)))
+          (rf/dispatch-sync ev))))
       ;; :fixture/render-after-hydrate — simulate the client-side first
       ;; render so verify-hydration! can compare hashes.
       (when-let [render-spec (:fixture/render-after-hydrate fixture)]

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -1064,6 +1064,22 @@
           _            (register-routes! fixture)
           frame-config (or (:fixture/frame-config fixture) {})
           frames-spec  (:fixture/frames fixture)
+          ;; EP-0002 (rf2-9o48ih) — the carried-invariant: registration-
+          ;; time frame-local surfaces (`reg-app-schema`, static
+          ;; `reg-flow`) and bare `dispatch-sync` with no explicit
+          ;; `{:frame …}` opt resolve their target from the established
+          ;; frame scope, never from an invented `:rf/default` floor (per
+          ;; Spec 002 §Frame target resolution + EP §6 registration-time
+          ;; rule). Single-frame fixtures register / dispatch against
+          ;; `:rf/default`; multi-frame fixtures (`:fixture/frames`) carry
+          ;; an explicit `:frame` opt on every dispatch (the override tier)
+          ;; and register flows dynamically via `:rf.fx/reg-flow` inside a
+          ;; per-frame cascade, so the static registration path is empty
+          ;; and the scope is only the default for the single-frame case.
+          ;; Mirror of the CLJS runner.
+          scope-frame  (if (seq frames-spec)
+                         (:id (first frames-spec))
+                         :rf/default)
           ;; reset-runtime! already created :rf/default WITHOUT an :on-create.
           ;; reg-frame against an existing id is a surgical update that doesn't
           ;; re-fire :on-create per Spec 002. We destroy first so :on-create
@@ -1076,8 +1092,10 @@
           ;; (which wipes the per-frame schema side-table via the rf2-wkxng /
           ;; rf2-6m0se on-frame-destroyed! hook) and BEFORE reg-frame so
           ;; the fixture's :on-create event runs with schemas in place.
-          _            (doseq [[path schema] (get-in fixture [:fixture/registry :app-schemas])]
-                         (rf/reg-app-schema path schema))
+          ;; `reg-app-schema` is frame-scoped — establish the scope explicitly.
+          _            (rf/with-frame scope-frame
+                         (doseq [[path schema] (get-in fixture [:fixture/registry :app-schemas])]
+                           (rf/reg-app-schema path schema)))
           _            (cond
                          (seq frames-spec)
                          ;; Multi-frame fixture: register each declared frame.
@@ -1088,9 +1106,15 @@
           ;; Flow registration runs AFTER reg-frame: per Spec 013 flows
           ;; are frame-scoped, and the rf2-wbtjn destroy-frame! teardown
           ;; hook would wipe any flows registered before the destroy.
-          _            (realise-flows! fixture)
+          ;; `reg-flow` is frame-scoped — establish the scope explicitly.
+          _            (rf/with-frame scope-frame
+                         (realise-flows! fixture))
           dispatches   (or (:fixture/dispatches fixture) [])
           sub-registry (get-in fixture [:fixture/registry :sub] {})]
+      ;; EP-0002 (rf2-9o48ih) — bare `dispatch-sync` resolves its target
+      ;; from the `scope-frame` established here; see the registration-
+      ;; time note above for the carried-invariant rationale.
+      (rf/with-frame scope-frame
       (doseq [ev dispatches]
         (cond
           (map? ev)
@@ -1148,7 +1172,7 @@
           (rf/dispatch-sync ev {:source :ssr-hydration})
 
           :else
-          (rf/dispatch-sync ev)))
+          (rf/dispatch-sync ev))))
       ;; :fixture/render-after-hydrate — for SSR hydration fixtures the
       ;; harness simulates the client-side first render. The runtime
       ;; (re-frame.ssr/verify-hydration!) owns the hash comparison and

--- a/implementation/core/test/re_frame/db_pending_trace_test.clj
+++ b/implementation/core/test/re_frame/db_pending_trace_test.clj
@@ -39,7 +39,14 @@
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/drain_test.clj
+++ b/implementation/core/test/re_frame/drain_test.clj
@@ -24,7 +24,17 @@
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.machines :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win. A top-level
+  ;; `reg-frame …:on-create` still drains synchronously — the lifecycle
+  ;; async/sync split keys off `*handler-scope*` (a real cascade), not
+  ;; this ambient scope.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/event_emit_test.cljc
+++ b/implementation/core/test/re_frame/event_emit_test.cljc
@@ -37,9 +37,16 @@
   (trace/clear-listeners!)
   (event-emit/clear-event-listeners!)
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
   (let [hooks-before @late-bind/hooks]
     (try
-      (test-fn)
+      (rf/with-frame :rf/default
+        (test-fn))
       (finally
         (reset! late-bind/hooks hooks-before)
         (late-bind/invalidate-cache! :schemas/validate-app-schema!)

--- a/implementation/core/test/re_frame/events_test.clj
+++ b/implementation/core/test/re_frame/events_test.clj
@@ -26,7 +26,14 @@
     (clear-schemas!))
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -66,7 +66,17 @@
   (remove-ns 'ssr.core)
   (remove-ns 'ssr-streaming.core)
   (remove-ns 'state-machine-walkthrough.core)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win. A top-level
+  ;; `reg-frame …:on-create` still drains synchronously — the lifecycle
+  ;; async/sync split keys off `*handler-scope*` (a real cascade), not
+  ;; this ambient scope.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -579,6 +579,12 @@
   (testing "reg-frame called inside a handler queues the child's :on-create
             asynchronously on the child's router — Spec 002 §reg-frame /
             make-frame called from inside a handler"
+    ;; EP-0002 (rf2-9o48ih): the parent frame is the carried scope for the
+    ;; bare parent dispatch below — register `:rf/default` explicitly (the
+    ;; fixture no longer synthesises it) and target it. The child frame is
+    ;; reg'd INSIDE the handler, so `*handler-scope*` is bound there and its
+    ;; `:on-create` correctly async-queues regardless of this scope.
+    (rf/reg-frame :rf/default {})
     (let [event-order  (atom [])
           captured-tick (atom [])]
       (rf/reg-event-db :child/boot
@@ -594,7 +600,7 @@
       ;; Capture the child's next-tick so we can deterministically inspect
       ;; the queue state at the moment the parent handler returns.
       (with-redefs [interop/next-tick (fn [f] (swap! captured-tick conj f) nil)]
-        (rf/dispatch-sync [:parent/spawn-child])
+        (rf/dispatch-sync [:parent/spawn-child] {:frame :rf/default})
 
         ;; The parent's handler body ran end-to-end, but the child's
         ;; :on-create handler did NOT run inline.
@@ -647,6 +653,11 @@
 (deftest child-frame-via-make-frame-also-async-from-handler
   (testing "make-frame from inside a handler also queues :on-create
             asynchronously — it shares the reg-frame code path"
+    ;; EP-0002 (rf2-9o48ih): register `:rf/default` as the carried scope for
+    ;; the bare parent dispatch (the fixture no longer synthesises it). The
+    ;; child is make-frame'd INSIDE the handler (`*handler-scope*` bound), so
+    ;; its `:on-create` async-queues correctly.
+    (rf/reg-frame :rf/default {})
     (let [order         (atom [])
           captured-tick (atom [])
           child-id      (atom nil)]
@@ -661,7 +672,7 @@
           (swap! order conj :parent/after-make-frame)
           {}))
       (with-redefs [interop/next-tick (fn [f] (swap! captured-tick conj f) nil)]
-        (rf/dispatch-sync [:parent/spawn-sub-actor])
+        (rf/dispatch-sync [:parent/spawn-sub-actor] {:frame :rf/default})
         (is (= [:parent/before-make-frame :parent/after-make-frame] @order)
             ":sub-actor/boot did not run inline")
         (is (some? @child-id) "make-frame returned a gensym'd id")

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -39,13 +39,21 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`, and
+  ;; the framework operation surfaces now require a carried frame stamp.
+  ;; Register `:rf/default` explicitly and pin it as the body's ambient
+  ;; scope — the carried-invariant equivalent of wrapping every test in
+  ;; `(with-frame :rf/default …)`. Bare dispatches in the test bodies then
+  ;; resolve to `:rf/default`; explicit `{:frame …}` opts still win.
+  (rf/reg-frame :rf/default {})
   ;; Framework registrations live at namespace-load time; clear-all!
   ;; wiped them. Reload so :rf/route, :rf.route/* subs and the framework
   ;; fx (e.g. :rf.fx/reg-flow) survive between tests.
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
-  (test-fn))
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/init_platform_test.clj
+++ b/implementation/core/test/re_frame/init_platform_test.clj
@@ -37,7 +37,14 @@
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/interceptor_overrides_test.clj
+++ b/implementation/core/test/re_frame/interceptor_overrides_test.clj
@@ -36,7 +36,14 @@
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -32,7 +32,14 @@
   ;; Framework-shipped registrations live in routing.cljc / ssr.cljc /
   ;; machines.cljc and are wiped by clear-all!. None of these tests need
   ;; them, so we skip the require-reload dance — keeps the fixture cheap.
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/no_rf_default_floor_lint_test.clj
+++ b/implementation/core/test/re_frame/no_rf_default_floor_lint_test.clj
@@ -1,0 +1,126 @@
+(ns re-frame.no-rf-default-floor-lint-test
+  "EP-0002 (rf2-9o48ih) — the carried-invariant STATIC conformance lint.
+
+  Appendix G of EP-0002 (\"shift detection left\") asks that the
+  `:rf/default`-as-absence-repair sweep be promoted from a prose `rg`
+  regex into a FIRST-CLASS conformance lint that runs in CI — part of the
+  contract, not a comment a reviewer might forget to run. This is that
+  lint.
+
+  The carried invariant (`spec/002-Frames.md` §Frame target resolution):
+  a frame-scoped operation reads its frame from the causal token it holds;
+  absence is `:rf.error/no-frame-context`, NEVER repaired by synthesising
+  `:rf/default`. The runtime must therefore carry NO
+
+    - `:or {frame-id :rf/default}` destructuring default, and
+    - `(or … :rf/default)` resolution floor
+
+  in PRODUCTION source. `:rf/default` remains a perfectly legal EXPLICIT
+  frame id (a migration may pick it, a test may register + select it) — the
+  ban is on using it as an *absence repair*, not on the keyword itself.
+
+  Scope: only `implementation/**/src/` (the production reference). Test
+  fixtures legitimately register + select `:rf/default` and may carry
+  `(or frame :rf/default)` in their OWN harness code, so `test/` is
+  excluded. Docstrings / comments that DESCRIBE the absence of the floor
+  (e.g. \"there is NO `(or frame-kw :rf/default)` floor\") are NOT
+  offences — the scan strips line comments and skips backtick-quoted prose
+  so it flags live code only.
+
+  Walks the same source tree as `re-frame.late-bind-drift-test` /
+  `re-frame.warn-once-clear-governance-test`."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+(def ^:private repo-implementation-root
+  (-> (io/file "..") .getCanonicalFile))
+
+(defn- source-files
+  "Every `.clj{,c,s}` under `implementation/**/src/` (skips `test/`)."
+  []
+  (->> (file-seq repo-implementation-root)
+       (filter #(.isFile ^java.io.File %))
+       (filter (fn [^java.io.File f]
+                 (let [n (.getName f)]
+                   (or (str/ends-with? n ".clj")
+                       (str/ends-with? n ".cljc")
+                       (str/ends-with? n ".cljs")))))
+       (filter (fn [^java.io.File f]
+                 (let [norm (str/replace (.getPath f) "\\" "/")]
+                   (and (str/includes? norm "/src/")
+                        (not (str/includes? norm "/test/"))))))))
+
+(defn- strip-line-comment
+  "Drop the trailing `;`-comment from a line of Clojure source so a
+  pattern mentioned only in a comment is not flagged. Best-effort: a `;`
+  inside a string literal is rare in these files and would only ever
+  REDUCE false positives, never mask a real floor (a real floor is code,
+  not a string)."
+  [^String line]
+  (let [idx (.indexOf line ";")]
+    (if (neg? idx) line (subs line 0 idx))))
+
+(defn- backtick-quoted-mention?
+  "True when the only `:rf/default` on the (comment-stripped) line sits
+  inside a backtick-quoted docstring fragment — the convention these
+  files use to TALK ABOUT a code form (e.g. \"NO `(or x :rf/default)`
+  floor\"). Such prose is not a live floor."
+  [^String code-line]
+  (boolean
+    (when-let [i (str/index-of code-line ":rf/default")]
+      (let [before (subs code-line 0 i)]
+        ;; An odd number of backticks before the token means we are
+        ;; inside a backtick span (prose), not in live code.
+        (odd? (count (filter #(= \` %) before)))))))
+
+;; ---------------------------------------------------------------------------
+;; The two banned absence-repair shapes (EP-0002 §12 + Appendix G).
+;; ---------------------------------------------------------------------------
+
+(def ^:private or-default-re
+  "An `(or … :rf/default)` resolution FLOOR — `:rf/default` is the LAST
+  alternative of an `or` over frame candidates, i.e. the synthesised
+  default when every real source was absent. The `[^\\n]*` gap (rather than
+  `[^()]*`) lets the candidates between `(or` and the `:rf/default)` tail
+  carry their own parens (`(or (:frame opts) :rf/default)`)."
+  #"\(or\s[^\n]*:rf/default\s*\)")
+
+(def ^:private destructure-default-re
+  "A `:or {frame-id :rf/default}` destructuring default — the same
+  absence repair expressed through a `:keys` / `:or` binding."
+  #":or\s*\{[^}]*:rf/default[^}]*\}")
+
+(defn- offending-lines
+  "Return `[line-no line]` pairs in `content` that carry a live (non-
+  comment, non-prose) `:rf/default` absence-repair floor."
+  [content]
+  (->> (str/split-lines content)
+       (map-indexed (fn [i line] [(inc i) line]))
+       (keep (fn [[n raw]]
+               (let [code (strip-line-comment raw)]
+                 (when (and (str/includes? code ":rf/default")
+                            (not (backtick-quoted-mention? code))
+                            (or (re-find or-default-re code)
+                                (re-find destructure-default-re code)))
+                   [n (str/trim raw)]))))))
+
+(deftest no-rf-default-absence-repair-in-production-source
+  (testing "no production source synthesises `:rf/default` from missing
+            frame context — neither `(or … :rf/default)` nor
+            `:or {frame-id :rf/default}`. EP-0002 carried invariant: absence
+            is `:rf.error/no-frame-context`, never an invented default
+            (Appendix G — shift detection left into a CI lint)."
+    (let [offenders
+          (for [^java.io.File f (source-files)
+                :let [content (slurp f)]
+                [n line] (offending-lines content)]
+            (str (str/replace (.getPath f) "\\" "/") ":" n "  " line))]
+      (is (empty? offenders)
+          (str "These production source lines carry a `:rf/default` "
+               "ABSENCE-REPAIR floor, which the EP-0002 carried invariant "
+               "forbids (use `require-current-frame!` / `require-frame-stamp!` "
+               "and let absence raise `:rf.error/no-frame-context`; "
+               "`:rf/default` is legal only as an EXPLICIT, registered + "
+               "selected frame id):\n  "
+               (str/join "\n  " offenders))))))

--- a/implementation/core/test/re_frame/partitioned_commit_test.clj
+++ b/implementation/core/test/re_frame/partitioned_commit_test.clj
@@ -51,7 +51,14 @@
     (clear-schemas!))
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/pattern_smoke_test.clj
+++ b/implementation/core/test/re_frame/pattern_smoke_test.clj
@@ -24,7 +24,17 @@
   (flows/reset-flows!)
   (reset! schemas/schemas-by-frame {})
   (rf/init! plain-atom/adapter)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win. A top-level
+  ;; `reg-frame …:on-create` still drains synchronously — the lifecycle
+  ;; async/sync split keys off `*handler-scope*` (a real cascade), not
+  ;; this ambient scope.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/redact_interceptor_test.clj
+++ b/implementation/core/test/re_frame/redact_interceptor_test.clj
@@ -37,7 +37,14 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.elision :reload)
   (require 're-frame.schemas :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/sensitive_stamping_test.clj
+++ b/implementation/core/test/re_frame/sensitive_stamping_test.clj
@@ -18,7 +18,14 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.elision :reload)
   (require 're-frame.schemas :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -41,7 +41,14 @@
   ;; artefact. Reload so the :http/reg-http-interceptor hook is
   ;; published across runs.
   (require 're-frame.http-managed :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/source_coord_test.cljc
+++ b/implementation/core/test/re_frame/source_coord_test.cljc
@@ -40,7 +40,14 @@
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/source_coords_test.clj
+++ b/implementation/core/test/re_frame/source_coords_test.clj
@@ -50,7 +50,14 @@
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.machines :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/substrate_source_test.clj
+++ b/implementation/core/test/re_frame/substrate_source_test.clj
@@ -39,7 +39,14 @@
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/success_path_call_site_test.clj
+++ b/implementation/core/test/re_frame/success_path_call_site_test.clj
@@ -43,7 +43,14 @@
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
+++ b/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
@@ -45,7 +45,14 @@
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -39,7 +39,17 @@
   (require 're-frame.routing :reload)
   (require 're-frame.ssr :reload)
   (require 're-frame.machines :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win. A top-level
+  ;; `reg-frame …:on-create` still drains synchronously — the lifecycle
+  ;; async/sync split keys off `*handler-scope*` (a real cascade), not
+  ;; this ambient scope.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -38,7 +38,14 @@
   (rf/configure! :trace-buffer {:cascades-retained 50})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/trace_cascade_captured_test.clj
+++ b/implementation/core/test/re_frame/trace_cascade_captured_test.clj
@@ -36,7 +36,13 @@
   (require 're-frame.ssr :reload)
   (require 're-frame.machines :reload)
   (cascade/clear-focus-predicate!)
-  (try (test-fn)
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (try (rf/with-frame :rf/default (test-fn))
        (finally
          (cascade/clear-focus-predicate!))))
 

--- a/implementation/core/test/re_frame/trace_listener_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_test.clj
@@ -51,7 +51,14 @@
   (re-frame.trace.tooling/clear-trace-rings!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/trace_test.clj
+++ b/implementation/core/test/re_frame/trace_test.clj
@@ -59,7 +59,14 @@
   ;; façade); the :rf.route.nav-token/stale-suppressed trace assertion
   ;; below dispatches it. Reload so it re-seats after clear-all!.
   (require 're-frame.routing.test-support :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/core/test/re_frame/trigger_handler_coord_test.clj
+++ b/implementation/core/test/re_frame/trigger_handler_coord_test.clj
@@ -46,7 +46,14 @@
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
@@ -39,7 +39,14 @@
   (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -59,7 +59,14 @@
   (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation surfaces require a carried frame stamp. Register
+  ;; `:rf/default` + pin it as the body's ambient scope (the carried-
+  ;; invariant equivalent of `(with-frame :rf/default …)`); explicit
+  ;; `{:frame …}` opts in the test bodies still win.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))
 
 (use-fixtures :each reset-runtime)
 

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -239,6 +239,16 @@
 ;; ---- routes used across the suite ---------------------------------------
 
 (defn- register-routes! []
+  ;; EP-0002 (rf2-9o48ih): URL ownership is now an EXPLICIT declaration —
+  ;; the runtime no longer infers `:rf/default` as the URL owner from
+  ;; absence (`url-owner-frame-id` returns nil unless a frame declares
+  ;; `:url-bound? true`). The fixture's `ensure-default-frame!` creates
+  ;; `:rf/default` WITHOUT the slot, so opt it in explicitly here as this
+  ;; suite's URL owner — otherwise `:rf.nav/push-url` / `:rf.nav/replace-url`
+  ;; never fire and the history stack stays at one entry. Tests that drive a
+  ;; non-default owner re-register `:rf/default {:url-bound? false}` AFTER
+  ;; this call, so their override wins.
+  (rf/reg-frame :rf/default {:url-bound? true})
   (rf/reg-route :hist/home     {:path "/"})
   (rf/reg-route :hist/cart     {:path "/cart"})
   (rf/reg-route :hist/checkout {:path "/checkout"})
@@ -369,14 +379,21 @@
 
 (deftest duplicate-url-bound-frame-does-not-push-cljs
   (testing "a second :url-bound? true frame is reported but not allowed to mutate browser history"
+    ;; EP-0002 (rf2-9o48ih): `register-routes!` now declares `:rf/default`
+    ;; `:url-bound? true` as the established URL owner. The deterministic
+    ;; owner among duplicate `:url-bound? true` frames is the alphabetically-
+    ;; first id (`url-owner-frame-id` sorts by `(str id)`), so the duplicate
+    ;; must sort AFTER `:rf/default` for `:rf/default` to remain the resolved
+    ;; owner — hence `:zz/duplicate-owner` (`:rf/default` < `:zz/…`). A push
+    ;; from the non-owner duplicate is suppressed.
     (register-routes!)
-    (rf/reg-frame :hist/duplicate-owner {:url-bound? true})
+    (rf/reg-frame :zz/duplicate-owner {:url-bound? true})
     (rf/dispatch-sync [:rf.route/navigate :hist/cart]
-                      {:frame :hist/duplicate-owner})
+                      {:frame :zz/duplicate-owner})
     (is (= ["/"] (:entries @*history-state*))
         "duplicate URL-bound frame did not push to browser history")
     (is (= :hist/cart
-           (:id (get-in (rf/runtime-db-value :hist/duplicate-owner) [:rf.runtime/routing :current])))
+           (:id (get-in (rf/runtime-db-value :zz/duplicate-owner) [:rf.runtime/routing :current])))
         "the non-owner frame still updates its own route slice")))
 
 ;; =========================================================================
@@ -541,6 +558,9 @@
 (deftest blocked-popstate-restores-url-cljs
   (testing "rf2-ede1h.3: a :can-leave guard blocking a Back/Forward popstate
             restores the browser URL to the slice's route; the slice stays put"
+    ;; EP-0002 (rf2-9o48ih): URL ownership is explicit — opt `:rf/default` in
+    ;; as the URL owner so the restore `:rf.nav/replace-url` fx fires.
+    (rf/reg-frame :rf/default {:url-bound? true})
     (rf/reg-route :hist/cart   {:path "/cart"})
     (rf/reg-route :hist/editor {:path      "/editor/articles/:id"
                                 :params    [:map [:id :string]]
@@ -604,6 +624,10 @@
 (deftest forward-nav-block-does-not-restore-url-cljs
   (testing "rf2-ede1h.3: a FORWARD-nav block emits NO :rf.nav/replace-url —
             the URL never moved, so there is nothing to restore"
+    ;; EP-0002 (rf2-9o48ih): URL ownership is explicit — opt `:rf/default` in
+    ;; as the URL owner (the assertion that NO replace-url fires is only
+    ;; meaningful when the frame COULD own the URL).
+    (rf/reg-frame :rf/default {:url-bound? true})
     (rf/reg-route :hist/cart   {:path "/cart"})
     (rf/reg-route :hist/editor {:path      "/editor/articles/:id"
                                 :params    [:map [:id :string]]
@@ -646,6 +670,9 @@
   (testing "rf2-8zvajk: :rf.route/continue after a blocked popstate moves the
             address bar to the requested URL — slice and URL agree, no new
             history entry"
+    ;; EP-0002 (rf2-9o48ih): URL ownership is explicit — opt `:rf/default` in
+    ;; as the URL owner so the continue `:rf.nav/replace-url` fx fires.
+    (rf/reg-frame :rf/default {:url-bound? true})
     (rf/reg-route :hist/cart   {:path "/cart"})
     (rf/reg-route :hist/editor {:path      "/editor/articles/:id"
                                 :params    [:map [:id :string]]

--- a/implementation/ssr/test/re_frame/flows_integration_test.clj
+++ b/implementation/ssr/test/re_frame/flows_integration_test.clj
@@ -103,13 +103,20 @@
   (require 're-frame.ssr     :reload)
   (require 're-frame.ssr.head :reload)
   (require 're-frame.machines :reload)
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
+  ;; framework operation + registration surfaces require a carried frame
+  ;; stamp. Register `:rf/default` + pin it as the body's ambient scope
+  ;; (the carried-invariant equivalent of `(with-frame :rf/default …)`);
+  ;; explicit `{:frame …}` opts / inner `with-frame` still win.
+  (rf/reg-frame :rf/default {})
   (let [captured (atom [])]
     (binding [*captured* captured]
       (trace/register-listener!
         ::flow-integration-recorder
         (fn [ev] (swap! captured conj ev)))
       (try
-        (test-fn)
+        (rf/with-frame :rf/default
+          (test-fn))
         (finally
           (trace/unregister-listener! ::flow-integration-recorder)
           (schemas/reset-schema-validator!))))))

--- a/implementation/ssr/test/re_frame/ssr/test_fixture.clj
+++ b/implementation/ssr/test/re_frame/ssr/test_fixture.clj
@@ -96,4 +96,17 @@
   (require 're-frame.ssr     :reload)
   (require 're-frame.ssr.head :reload)
   (require 're-frame.machines :reload)
-  (test-fn))
+  ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`, and
+  ;; framework operation + registration surfaces (dispatch / reg-flow /
+  ;; reg-app-schema / current-frame-id / …) now require a carried frame
+  ;; stamp. Register `:rf/default` explicitly and pin it as the body's
+  ;; ambient scope — the carried-invariant equivalent of wrapping every
+  ;; test in `(with-frame :rf/default …)`. SSR tests that drive their own
+  ;; per-request server frames re-bind via an inner `with-frame` / pass an
+  ;; explicit `{:frame …}`; both win over this ambient scope. A top-level
+  ;; `reg-frame …:on-create` still drains synchronously — the lifecycle
+  ;; async/sync split keys off `*handler-scope*` (a real cascade), not
+  ;; this ambient scope.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (test-fn)))

--- a/implementation/ssr/test/re_frame/ssr_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_conformance_test.clj
@@ -526,6 +526,12 @@
           _            (rf/destroy-frame! :rf/default)
           _            (rf/reg-frame :rf/default frame-config)
           dispatches   (or (:fixture/dispatches fixture) [])]
+      ;; EP-0002 (rf2-9o48ih): a bare `dispatch-sync` with no explicit
+      ;; `{:frame …}` opt resolves its target from the established frame
+      ;; scope, never from an invented `:rf/default` floor (the carried
+      ;; invariant). This single-frame SSR runner targets `:rf/default`;
+      ;; establish that scope explicitly so the dispatches resolve to it.
+      (rf/with-frame :rf/default
       (doseq [ev dispatches]
         (cond
           (and (vector? ev) (= :rf/hydrate (first ev)))
@@ -535,7 +541,7 @@
           (rf/dispatch-sync ev {:source :ssr-hydration})
 
           :else
-          (rf/dispatch-sync ev)))
+          (rf/dispatch-sync ev))))
       ;; ---- :fixture/render-after-hydrate -------------------------------
       ;; SSR hydration fixtures simulate the client-side first render
       ;; by feeding the runtime's `verify-hydration!` a synthetic

--- a/testbeds/deep_machine/core.cljs
+++ b/testbeds/deep_machine/core.cljs
@@ -383,5 +383,12 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [::initialise])
-  (rdc/render react-root [root]))
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — `:rf/default` is this testbed's app frame, registered
+  ;; explicitly here (init! installs only the adapter). The boot dispatch
+  ;; runs under the frame scope and the render is wrapped in a
+  ;; `frame-provider` so in-tree dispatch/subscribe resolve to it.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [::initialise]))
+  (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]]))

--- a/testbeds/deliberate_throw/core.cljs
+++ b/testbeds/deliberate_throw/core.cljs
@@ -172,5 +172,12 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [::initialise])
-  (rdc/render react-root [root]))
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — `:rf/default` is this testbed's app frame, registered
+  ;; explicitly here (init! installs only the adapter). The boot dispatch
+  ;; runs under the frame scope and the render is wrapped in a
+  ;; `frame-provider` so in-tree dispatch/subscribe resolve to it.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [::initialise]))
+  (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]]))

--- a/testbeds/drain_depth_trigger/core.cljs
+++ b/testbeds/drain_depth_trigger/core.cljs
@@ -183,5 +183,9 @@
   ;; per [spec/002 §Surgical update] re-registering only changes the
   ;; supplied keys (here :drain-depth), the other defaults survive.
   (rf/reg-frame :rf/default {:drain-depth default-drain-depth})
-  (rf/dispatch-sync [::initialise])
-  (rdc/render react-root [root]))
+  ;; EP-0002 (rf2-9o48ih): scope the boot dispatch to the registered app
+  ;; frame and wrap the render in a `frame-provider` — the runtime never
+  ;; synthesises a frame from absence (the carried invariant).
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [::initialise]))
+  (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]]))

--- a/testbeds/http_toggle/core.cljs
+++ b/testbeds/http_toggle/core.cljs
@@ -310,5 +310,12 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [::initialise])
-  (rdc/render react-root [root]))
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — `:rf/default` is this testbed's app frame, registered
+  ;; explicitly here (init! installs only the adapter). The boot dispatch
+  ;; runs under the frame scope and the render is wrapped in a
+  ;; `frame-provider` so in-tree dispatch/subscribe resolve to it.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [::initialise]))
+  (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]]))

--- a/testbeds/large_dispatcher/core.cljs
+++ b/testbeds/large_dispatcher/core.cljs
@@ -252,12 +252,18 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [::initialise])
-  ;; Populate the elision registry from any registered schemas
-  ;; carrying :large? marks. Per [API.md §`populate-elision-from-
-  ;; schemas!`] this walks the app-schema registry and writes
-  ;; `{:large? true :source :schema}` slots into the elision
-  ;; declarations map. The schema-driven path's declaration enters
-  ;; the registry without an explicit handler dispatch.
-  (rf/populate-elision-from-schemas!)
-  (rdc/render react-root [root]))
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — register `:rf/default` as the app frame, scope the boot
+  ;; dispatch + the frame-local elision population (a registration-time
+  ;; frame-local surface, EP §6), and wrap the render in a frame-provider.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [::initialise])
+    ;; Populate the elision registry from any registered schemas
+    ;; carrying :large? marks. Per [API.md §`populate-elision-from-
+    ;; schemas!`] this walks the app-schema registry and writes
+    ;; `{:large? true :source :schema}` slots into the elision
+    ;; declarations map. The schema-driven path's declaration enters
+    ;; the registry without an explicit handler dispatch.
+    (rf/populate-elision-from-schemas!))
+  (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]]))

--- a/testbeds/long_flow_w_failure/core.cljs
+++ b/testbeds/long_flow_w_failure/core.cljs
@@ -376,5 +376,12 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [::initialise])
-  (rdc/render react-root [root]))
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — `:rf/default` is this testbed's app frame, registered
+  ;; explicitly here (init! installs only the adapter). The boot dispatch
+  ;; runs under the frame scope and the render is wrapped in a
+  ;; `frame-provider` so in-tree dispatch/subscribe resolve to it.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [::initialise]))
+  (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]]))

--- a/testbeds/multi_frame/core.cljs
+++ b/testbeds/multi_frame/core.cljs
@@ -212,4 +212,12 @@
   (rf/reg-frame frame-a   {:on-create [::counter-init]})
   (rf/reg-frame frame-b   {:on-create [::counter-init]})
   (rf/reg-frame frame-log {:on-create [::log-init]})
-  (rdc/render react-root [root]))
+  ;; EP-0002 (rf2-9o48ih): `root` is a `reg-view`, so its wrapper resolves
+  ;; a frame at render time for its injected bindings — it must render
+  ;; under a provider. Use a neutral SHELL frame (`:rf/default`) as the
+  ;; root scope; the three per-frame providers nested inside override it
+  ;; for their subtrees, and the cross-bump button still dispatches with an
+  ;; explicit `{:frame frame-a}` (the override wins over this shell scope),
+  ;; so the "dispatch from outside the app providers" intent is preserved.
+  (rf/reg-frame :rf/default {})
+  (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]]))

--- a/testbeds/non_trivial_app_db/core.cljs
+++ b/testbeds/non_trivial_app_db/core.cljs
@@ -281,5 +281,12 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [::initialise])
-  (rdc/render react-root [root]))
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — `:rf/default` is this testbed's app frame, registered
+  ;; explicitly here (init! installs only the adapter). The boot dispatch
+  ;; runs under the frame scope and the render is wrapped in a
+  ;; `frame-provider` so in-tree dispatch/subscribe resolve to it.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [::initialise]))
+  (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]]))

--- a/testbeds/ssr_basic/core.cljs
+++ b/testbeds/ssr_basic/core.cljs
@@ -192,18 +192,22 @@
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
   (install-trace-listener!)
-
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — register `:rf/default` as the client app frame and scope the
+  ;; hydrate / boot dispatch + render to it (the carried invariant).
+  (rf/reg-frame :rf/default {})
   (let [payload (some-> (read-server-payload) materialise-response)]
-    (if payload
-      ;; HOT PATH — :rf/hydrate is auto-registered by re-frame.ssr;
-      ;; replaces app-db with the payload's :rf/app-db, stashes
-      ;; metadata at [:rf/hydration], dispatches the two compatibility-
-      ;; check fxs (which the trace listener mirrors).
-      (rf/dispatch-sync [:rf/hydrate payload])
-      ;; Degraded path: no payload baked. Don't crash — render against
-      ;; the empty app-db. This is the "client-only first load" shape.
-      (rf/dispatch-sync [::inc]))
-    (rdc/render react-root [root])
+    (rf/with-frame :rf/default
+      (if payload
+        ;; HOT PATH — :rf/hydrate is auto-registered by re-frame.ssr;
+        ;; replaces app-db with the payload's :rf/app-db, stashes
+        ;; metadata at [:rf/hydration], dispatches the two compatibility-
+        ;; check fxs (which the trace listener mirrors).
+        (rf/dispatch-sync [:rf/hydrate payload])
+        ;; Degraded path: no payload baked. Don't crash — render against
+        ;; the empty app-db. This is the "client-only first load" shape.
+        (rf/dispatch-sync [::inc])))
+    (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]])
 
     ;; HOT PATH — verify-hydration! reads the server-hash stashed at
     ;; [:rf/hydration :server-hash], computes the client-render hash,

--- a/testbeds/ssr_hydration_mismatch/core.cljs
+++ b/testbeds/ssr_hydration_mismatch/core.cljs
@@ -171,18 +171,28 @@
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
   (install-trace-listener!)
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — register `:rf/default` as the client app frame and scope the
+  ;; hydrate dispatch + render to it (the carried invariant). `:rf/hydrate`
+  ;; lands on the carried frame; `verify-hydration!` already names it.
+  (rf/reg-frame :rf/default {})
   (let [payload (read-server-payload)]
-    (when payload
-      ;; HOT PATH — :rf/hydrate replaces app-db; the payload's
-      ;; :rf/render-hash 'deadbeef' is stashed at
-      ;; [:rf/hydration :server-hash] so verify-hydration! can compare
-      ;; against the client's computed hash.
-      (rf/dispatch-sync [:rf/hydrate payload]))
-    (rdc/render react-root [root])
+    (rf/with-frame :rf/default
+      (when payload
+        ;; HOT PATH — :rf/hydrate replaces app-db; the payload's
+        ;; :rf/render-hash 'deadbeef' is stashed at
+        ;; [:rf/hydration :server-hash] so verify-hydration! can compare
+        ;; against the client's computed hash.
+        (rf/dispatch-sync [:rf/hydrate payload])))
+    (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]])
 
     ;; HOT PATH — the trigger site for :rf.ssr/hydration-mismatch.
     ;; The resolved tree hashes to a value that won't equal the
     ;; payload's 'deadbeef'; verify-hydration! emits the mismatch
     ;; trace which our listener routes to ::record-mismatch.
-    (let [tree ((rf/view :ssr-hydration-mismatch.core/root))]
-      (ssr/verify-hydration! :rf/default tree))))
+    ;; EP-0002 (rf2-9o48ih): invoking the reg-view'd root resolves its
+    ;; injected frame-bound bindings at call time, so do it under the
+    ;; client frame scope.
+    (rf/with-frame :rf/default
+      (let [tree ((rf/view :ssr-hydration-mismatch.core/root))]
+        (ssr/verify-hydration! :rf/default tree)))))

--- a/tools/xray/testbeds/edn_inspector/core.cljs
+++ b/tools/xray/testbeds/edn_inspector/core.cljs
@@ -565,9 +565,13 @@
   ;; surfaces resolves its classpath-relative `:file` to an on-disk URI.
   (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
   (rf/init! reagent-adapter/adapter)
-  ;; Seed app-db on the single, plain default frame — no URL machinery.
-  (rf/dispatch-sync [:edn-inspector/reset])
-  (rdc/render react-root [root])
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — register the single, plain host frame, scope the boot
+  ;; dispatch, and wrap the render in a `frame-provider` (carried invariant).
+  (rf/reg-frame host-frame {})
+  (rf/with-frame host-frame
+    (rf/dispatch-sync [:edn-inspector/reset]))
+  (rdc/render react-root [rf/frame-provider {:frame host-frame} [root]])
   ;; Mount the inline Xray sidecar (Epoch + App-db panels) into
   ;; `[data-rf-xray-host]`, standard_epochs-style. `init!` is the public
   ;; manual alternative to the `:preloads` wiring (so no shadow-cljs.edn

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -940,10 +940,18 @@
 (defn ^:export run []
   (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
   (rf/init! reagent-adapter/adapter)
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — register the SHELL frame explicitly and scope the boot
+  ;; dispatches to it. The per-track machine frames are reg-frame'd inside
+  ;; the `:machine-epochs/select` handler (a real cascade — `*handler-scope*`
+  ;; bound), so each track's `:on-create` async-queues correctly. The
+  ;; render is wrapped in a `frame-provider` on the shell frame.
+  (rf/reg-frame shell-frame {})
   ;; Seed the SHELL frame's bookkeeping, then auto-select the default track so
   ;; the operator lands on a live arc (the SHELL-FRAME-FIRST-PAINT smaller
   ;; call) rather than an empty shell. The select creates + boots the door
   ;; frame and re-points Xray at it.
-  (rf/dispatch-sync [:machine-epochs/seed])
-  (rf/dispatch-sync [:machine-epochs/select default-track])
-  (rdc/render react-root [root]))
+  (rf/with-frame shell-frame
+    (rf/dispatch-sync [:machine-epochs/seed])
+    (rf/dispatch-sync [:machine-epochs/select default-track]))
+  (rdc/render react-root [rf/frame-provider {:frame shell-frame} [root]]))

--- a/tools/xray/testbeds/managed_http/core.cljs
+++ b/tools/xray/testbeds/managed_http/core.cljs
@@ -497,5 +497,11 @@
 (defn ^:export run []
   (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [::initialise])
-  (rdc/render react-root [root]))
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — establish the host frame explicitly, run the boot dispatch
+  ;; under its scope, and wrap the render in a `frame-provider` so in-tree
+  ;; dispatch/subscribe resolve to it (the carried invariant).
+  (rf/reg-frame host-frame {})
+  (rf/with-frame host-frame
+    (rf/dispatch-sync [::initialise]))
+  (rdc/render react-root [rf/frame-provider {:frame host-frame} [root]]))

--- a/tools/xray/testbeds/routes_epochs/core.cljs
+++ b/tools/xray/testbeds/routes_epochs/core.cljs
@@ -473,11 +473,18 @@
   ;; right project-root on its first paint of any chip.
   (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
   (rf/init! reagent-adapter/adapter)
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — establish the host frame explicitly. URL ownership is now an
+  ;; explicit declaration, so opt the host frame in via `{:url-bound? true}`
+  ;; (otherwise `:rf.nav/push-url` no-ops and history-driven steps stall).
+  (rf/reg-frame host-frame {:url-bound? true})
   ;; Seed app-db and pull the current URL into the route slice (what a
-  ;; popstate / initial-load handler does). The default frame is the one
+  ;; popstate / initial-load handler does). The host frame is the one
   ;; Xray reads. The browser History listener is installed so step #9's
-  ;; back/forward emulation has somewhere to land.
+  ;; back/forward emulation has somewhere to land. Boot dispatches run
+  ;; under the host frame scope (the carried invariant).
   (rf/install-history-listener!)
-  (rf/dispatch-sync [:routes-epochs/reset])
-  (rf/dispatch-sync [:rf.route/handle-url-change (current-url)])
-  (rdc/render react-root [root]))
+  (rf/with-frame host-frame
+    (rf/dispatch-sync [:routes-epochs/reset])
+    (rf/dispatch-sync [:rf.route/handle-url-change (current-url)]))
+  (rdc/render react-root [rf/frame-provider {:frame host-frame} [root]]))

--- a/tools/xray/testbeds/standard_epochs/core.cljs
+++ b/tools/xray/testbeds/standard_epochs/core.cljs
@@ -809,9 +809,14 @@
   (xray-config/configure! {:rf.xray/project-root (resolve-project-root)})
   (rf/init! reagent-adapter/adapter)
   ;; Single, plain frame — no URL machinery, no history listener (there is
-  ;; no routing here). The default frame is the one Xray reads. Mount the
+  ;; no routing here). The host frame is the one Xray reads. Mount the
   ;; standalone wrapper (header + the parameterised `root`) on the
-  ;; `:rf/default` host-frame with the `standard-epochs` testid prefix and
-  ;; the deck's run-step event. The runner cursor lives in app-db `:step`.
-  (rf/dispatch-sync [:standard-epochs/reset])
-  (rdc/render react-root [standalone]))
+  ;; host-frame with the `standard-epochs` testid prefix and the deck's
+  ;; run-step event. The runner cursor lives in app-db `:step`.
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from
+  ;; absence — register the host frame, scope the boot dispatch, and wrap
+  ;; the render in a `frame-provider` (the carried invariant).
+  (rf/reg-frame host-frame {})
+  (rf/with-frame host-frame
+    (rf/dispatch-sync [:standard-epochs/reset]))
+  (rdc/render react-root [rf/frame-provider {:frame host-frame} [standalone]]))


### PR DESCRIPTION
EP-0002 chain bead 11/11 (finale). Adds the static conformance lint and brings the ep-0002 test corpus green behind the carried invariant. Folds rf2-nhm8tu (SSR/boot harnesses) + rf2-69r7ui residue (example/testbed boot scope). rf2-s2s3xv deferred (needs net-new data-classification fixture category + trace-tag redaction harness support).

## SLICE-GATE report

CI does not run on ep-0002 PRs — this report is the gate of record (pre-atomic-merge bead, run thoroughly).

### npm run test:cljs (primary CLJS gate)
- Before: 142 FAIL / 4 ERROR (incl. CLJS conformance corpus: 81 fixtures failed of 164).
- After: 1 FAIL / 0 ERROR. CLJS conformance corpus: 0 failed (164 fixtures, 155 passed, 2 skipped out-of-claim, others applicable-pass).
- Remaining 1 red is a PRE-EXISTING (baseline, not introduced here) HTTP managed-async test-isolation flake in http_cljs_test ('unexpected reject: :rf.error/no-frame-context' + 'done more than once'). Enumerated as genuine deferral rf2-ofzxh9.

### JVM suites — all GREEN
- core: 1023 tests, 4431 assertions, 0/0 (incl. JVM conformance corpus + the new static lint).
- routing: 160 tests 0/0 · http: 374 tests 0/0 · ssr: 313 tests 0/0 · machines: 570 tests 0/0 · schemas: 274 tests 0/0 · flows: 165 tests 0/0 · epoch: 290 tests 0/0.

### npm run test:mcp-conformance — GREEN (all 6 sub-gates).

### npm run test:xray-feature-gate (Playwright)
- Before: 14 failures of 16. After: 3 failures (frameless-boot reds across all xray + top-level testbeds fixed: boot now reg-frames the app frame, scopes the boot dispatch, wraps render in frame-provider).
- Remaining 3 are PRE-EXISTING and now PAST the frameless-boot stage — deeper BEHAVIORAL assertions (static-mode chord, routes-epochs :can-leave pending-navigation, machine-epochs async track boot), distinct from carried-invariant conformance. Enumerated as genuine deferral rf2-wxu4l3.

### Conformance added
- STATIC lint (Appendix G shift-left): re-frame.no-rf-default-floor-lint-test scans implementation/**/src for the banned :rf/default absence-repair shapes — (or … :rf/default) floor + :or {frame-id :rf/default} — comment/docstring-aware; production src is clean and the lint guards against regression in CI.
- DYNAMIC frame-absence-fails: pinned by the pre-existing frame_resolver_test (require-current-frame! raises :rf.error/no-frame-context outside scope; readers return nil; no registry consult) + the adapter corruption-recovery suite + the corpus.

### Production fix (lifecycle, not resolution)
- reg-frame/make-frame :on-create async/sync split keys off trace/*handler-scope* (a real cascade) instead of *current-frame* (which a test fixture's ambient scope binds). Distinguishes created-mid-cascade (async-queue) from top-level boot under an ambient scope (synchronous). Validated by frame_lifecycle_test's async-from-handler + top-level-sync contract tests.

### Reds closed
rf2-9o48ih (this), rf2-nhm8tu (folded), rf2-69r7ui residue (folded). Deferrals: rf2-ofzxh9, rf2-wxu4l3, rf2-s2s3xv.