### PR TITLE
fix(testbed): deliberate-throw reg-flow after init! not at ns-load (rf2-7gvnmy)

### DIFF
--- a/testbeds/deliberate_throw/core.cljs
+++ b/testbeds/deliberate_throw/core.cljs
@@ -72,11 +72,14 @@
 ;; Button C — throw inside flow :output
 ;; ----------------------------------------------------------------------------
 ;;
-;; The flow is registered once at ns-load (registration order doesn't
-;; matter — the runtime topsorts before the first drain). Button C's
-;; handler bumps :flow-input; on the post-handler flows pass, the
-;; runtime walks this flow, calls :output with the new input, and the
-;; throw fires there.
+;; The flow is registered once at boot, inside `run` AFTER `rf/init!` has
+;; made the `:rf/default` frame live (registration order relative to the
+;; events/fx/subs above doesn't matter — the runtime topsorts before the
+;; first drain). `reg-flow` targets the current frame and rejects a
+;; non-live frame (rf2-zbxvqj guard), so it must NOT run at ns-load —
+;; init! has not run yet there. Button C's handler bumps :flow-input; on
+;; the post-handler flows pass, the runtime walks this flow, calls
+;; :output with the new input, and the throw fires there.
 ;;
 ;; Per [spec/013 §Failure semantics]: two trace events fire in order —
 ;; :rf.flow/failed (per-flow attribution) followed by the cascade-level
@@ -84,14 +87,19 @@
 ;; `:db` is preserved (prior writes survive); the failing flow's
 ;; `last-inputs` is NOT advanced.
 
-(rf/reg-flow
-  {:id     ::throws
-   :inputs [[:flow-input]]
-   :output (fn [_input]
-             ;; HOT PATH — the throw site for :rf.error/flow-eval-exception.
-             (throw (ex-info "deliberate-throw / flow" {:where :flow})))
-   :path   [:flow-output]
-   :doc    "Flow :output that throws every recompute."})
+(defn- register-throwing-flow!
+  "Register the Button-C flow against the live `:rf/default` frame.
+  Called from `run` after `rf/init!` — a frame must be live or the
+  rf2-zbxvqj guard in `reg-flow` rejects with :rf.error/flow-frame-not-live."
+  []
+  (rf/reg-flow
+    {:id     ::throws
+     :inputs [[:flow-input]]
+     :output (fn [_input]
+               ;; HOT PATH — the throw site for :rf.error/flow-eval-exception.
+               (throw (ex-info "deliberate-throw / flow" {:where :flow})))
+     :path   [:flow-output]
+     :doc    "Flow :output that throws every recompute."}))
 
 (rf/reg-event-db ::throw-in-flow
   (fn [db _ev]
@@ -168,5 +176,8 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
+  ;; reg-flow must run AFTER init! — it targets the live :rf/default
+  ;; frame, which ensure-default-frame! (inside init!) establishes.
+  (register-throwing-flow!)
   (rf/dispatch-sync [::initialise])
   (rdc/render react-root [root]))


### PR DESCRIPTION
Fixes rf2-7gvnmy.

The deliberate-throw shared framework-behavior testbed registered its Button-C flow at ns-load time, before rf/init! runs inside its exported run. The rf2-zbxvqj guard merged in PR 3627 rejects flow registration against a non-live frame, so at ns-load with no live default frame the guard threw :rf.error/flow-frame-not-live, aborting the namespace load. run was never defined, the testbed never mounted, and the Xray feature-gate scenario for deterministic exceptions and inline/trace surfacing timed out waiting for trace rows.

Fix option A from the bead: move the reg-flow call out of the top-level ns-load position into a register-throwing-flow bang fn, called from run AFTER rf/init! establishes the live default frame via ensure-default-frame. Observable behavior is identical -- the same flow registers and still deliberately throws on every recompute.

The registry guard is correct and is NOT touched. This is a testbed-local fix.

Authoritative gate: the story-xray-browser PR-smoke gate runs on this Story/Xray surface change and validates the previously-timing-out scenario.