### PR TITLE
fix(core): police final effects after :after/ctx mutation (rf2-u1kdvg)

### DIFF
--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -232,6 +232,61 @@
                             :recovery          :logged-and-skipped})
         false))))
 
+;; ---- final-effects boundary policing (rf2-u1kdvg) -------------------------
+;;
+;; `commit-fx-effects` (below) polices the effect-map shape + the whole-`:fx`
+;; value for a `reg-event-fx` HANDLER RETURN — at the moment of the fx-kind
+;; `:commit`, i.e. inside the handler-wrapping interceptor's `:before`. That
+;; is BEFORE the `:after` interceptor pass runs (`execute-chain` runs every
+;; `:before` then every `:after` — see `re-frame.interceptor/execute-chain`).
+;;
+;; So the per-handler-return checks DO NOT cover effects that arrive at the
+;; commit boundary by any OTHER route:
+;;   - a `reg-event-ctx` handler returns a context directly (the `:ctx`
+;;     `:commit` is `(or new-ctx ctx)` — no effect-map validation);
+;;   - a framework / user `:after` interceptor mutates `[:effects …]` after
+;;     the handler-return checks have already run (docs/guide §09 documents
+;;     `:after` interceptors adding/modifying `:effects`/`:fx`).
+;;
+;; The router consumes the FINAL `(:effects final-ctx)` after the whole chain
+;; (every `:before` AND every `:after`) has run. `police-final-effects!` is
+;; the single authoritative shape gate applied THERE, so the closed
+;; effect-map + whole-`:fx` contract holds uniformly regardless of how an
+;; effect reached the final context (reg-event-fx, reg-event-ctx, framework
+;; interceptors, or user `:after`). It returns the CLEANED effects map —
+;; foreign top-level keys dropped, a non-sequential `:fx` dropped — so a
+;; malformed final effect never reaches `commit-frame-effects!` (silent
+;; ignore of a foreign key) nor `fx/do-fx` (a raw host throw after the db
+;; commit). Both drops emit `:rf.error/effect-map-shape`
+;; (`:logged-and-skipped`) exactly like the per-handler-return path.
+
+(defn police-final-effects!
+  "Police the FINAL effects map the router is about to consume against the
+  closed effect-map contract (per Spec-Schemas §:rf/effect-map + EP-0001):
+  top-level keys are `#{:db :rf.db/runtime :fx}` and the `:fx` value is a
+  sequential of `[fx-id args]` pairs. Returns the CLEANED effects map with
+  any offending top-level key and a non-sequential `:fx` value dropped;
+  each drop emits `:rf.error/effect-map-shape` (`:logged-and-skipped`).
+
+  This is the boundary gate covering effects that bypass the
+  `commit-fx-effects` per-handler-return checks — a `reg-event-ctx` return
+  or an `:after`-interceptor mutation (rf2-u1kdvg). `nil` / a non-map
+  effects value (no effects produced) passes through untouched.
+
+  Hot-path short-circuit: when the effects map is already well-shaped (the
+  overwhelming majority — `{}`, `{:db …}`, `{:fx [...]}`, `{:db … :fx …}`),
+  `police-effect-map-shape!` allocates nothing and `fx-value-ok?` is a
+  single `sequential?` check, so the map is returned unchanged with no
+  reconstruction."
+  [effects event]
+  (if-not (map? effects)
+    effects
+    (let [offending (police-effect-map-shape! effects event)
+          cleaned   (if (seq offending) (apply dissoc effects offending) effects)]
+      (if (fx-value-ok? cleaned event)
+        cleaned
+        (dissoc cleaned :fx)))))
+
 ;; ---- handler-as-interceptor wrappers --------------------------------------
 ;;
 ;; The three reg-event-* forms share a single :before shape:
@@ -304,6 +359,39 @@
   legacy-shaped write this guard rejects."
   :rf/runtime)
 
+(defn legacy-runtime-root?
+  "True iff `app-db` carries the retired `:rf/runtime` root key at its top
+  level (per Conventions §The legacy `:rf/runtime` root + decision #8). The
+  pure detector both `reject-legacy-runtime-root!` (the in-chain throw) and
+  the router's final-effects boundary (rf2-u1kdvg, the in-band abort) share
+  so the rejection rule has a single definition. Cheap on the hot path — a
+  single `contains?` over the top-level keys."
+  [app-db]
+  (and (map? app-db) (contains? app-db legacy-runtime-root-key)))
+
+(defn legacy-runtime-root-ex-data
+  "The shared `:rf.error/legacy-runtime-root` ex-data / error-trace tag map
+  for the offending `event`. Used both by `reject-legacy-runtime-root!`
+  (carried on the thrown ex-info) and by the router's final-effects
+  boundary emit (rf2-u1kdvg) so the two rejection sites surface an identical
+  payload."
+  [event]
+  (let [event-id (when (vector? event) (first event))]
+    {:rf.error/id   :rf.error/legacy-runtime-root
+     :where         'rf/reg-event-db
+     :event-id      event-id
+     :event         event
+     :recovery      :no-recovery
+     :reason
+     (str "Event `" event-id "` returned a `:db` value carrying the "
+          "retired `:rf/runtime` app-db root. Framework runtime state "
+          "now lives in the runtime-db partition (the reserved "
+          "`:rf.db/runtime` effect, addressed by `:rf.runtime/*` "
+          "children) — NOT under an app-db `:rf/runtime` root, which "
+          "is retired. Move framework/runtime writes to the "
+          "`:rf.db/runtime` effect; keep application data under `:db`.")
+     :offending-key legacy-runtime-root-key}))
+
 (defn reject-legacy-runtime-root!
   "Throw `:rf.error/legacy-runtime-root` (ex-info) when `app-db` carries the
   retired `:rf/runtime` root key at its top level. Per Conventions §The
@@ -313,26 +401,18 @@
   does not carry the legacy key, so it is cheap on the hot path.
 
   Always-on (NOT dev-gated): a legacy-shaped write is a structural contract
-  violation that must surface in every build, not a dev-only advisory."
+  violation that must surface in every build, not a dev-only advisory.
+
+  This is the IN-CHAIN guard (runs in the handler-wrapping interceptor's
+  `:before`, so a handler-RETURN legacy root is captured by the interceptor
+  machinery and surfaced as `:rf.error/handler-exception`). The symmetric
+  FINAL-effects boundary check — covering a legacy root inserted by an
+  `:after` interceptor AFTER this ran — lives in the router (rf2-u1kdvg) and
+  emits in-band rather than throwing, so the drain is not aborted."
   [app-db event]
-  (when (and (map? app-db) (contains? app-db legacy-runtime-root-key))
-    (let [event-id (when (vector? event) (first event))]
-      (throw (ex-info
-               ":rf.error/legacy-runtime-root"
-               {:rf.error/id :rf.error/legacy-runtime-root
-                :where       'rf/reg-event-db
-                :event-id    event-id
-                :event       event
-                :recovery    :no-recovery
-                :reason
-                (str "Event `" event-id "` returned a `:db` value carrying the "
-                     "retired `:rf/runtime` app-db root. Framework runtime state "
-                     "now lives in the runtime-db partition (the reserved "
-                     "`:rf.db/runtime` effect, addressed by `:rf.runtime/*` "
-                     "children) — NOT under an app-db `:rf/runtime` root, which "
-                     "is retired. Move framework/runtime writes to the "
-                     "`:rf.db/runtime` effect; keep application data under `:db`.")
-                :offending-key legacy-runtime-root-key}))))
+  (when (legacy-runtime-root? app-db)
+    (throw (ex-info ":rf.error/legacy-runtime-root"
+                    (legacy-runtime-root-ex-data event))))
   app-db)
 
 (defn- commit-fx-effects

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -12,6 +12,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
             [re-frame.error-emit :as error-emit]
+            [re-frame.events :as events]
             [re-frame.fx :as fx]
             [re-frame.router.diagnostics :as diag]
             [re-frame.substrate.adapter :as adapter]
@@ -1188,6 +1189,50 @@
     (trace/emit-error! :rf.error/flow-eval-exception
                        {:frame frame :event event :exception e})))
 
+(defn- emit-legacy-runtime-root!
+  "Surface `:rf.error/legacy-runtime-root` through BOTH the always-on
+  error-emit substrate AND the dev-only trace surface — the FINAL-effects
+  boundary counterpart (rf2-u1kdvg) of the in-chain
+  `events/reject-legacy-runtime-root!` throw.
+
+  Why a SEPARATE in-band emit rather than re-throwing: the in-chain guard
+  runs inside the handler-wrapping interceptor's `:before`, so a
+  handler-RETURNED legacy root is caught by `execute-chain` and surfaced as
+  `:rf.error/handler-exception`. But a legacy `:rf/runtime` root inserted
+  into `[:effects :db]` by a user / framework `:after` interceptor lands
+  AFTER that guard has run, in the FINAL effects map the router consumes.
+  Detecting it here and THROWING would escape `process-event!` into
+  `drain-emergency-release!` — which re-throws, abandoning the rest of the
+  drained queue (the very `:on-error`-bypass / queue-abandonment footgun the
+  bead closes). So we emit in-band and abort THIS event only (`:error`
+  outcome, NO commit, NO `:fx`), preserving the no-partial-commit promise
+  while keeping the drain alive.
+
+  Always-on per rf2-hqbeh / rf2-bacs4: axis-1 listeners observe the
+  rejection in production where the trace surface DCEs. LISTENER-ONLY (axis
+  2 not invoked): a legacy-root write is `:no-recovery` — there is no
+  `{:swallow | :replacement | :default}` choice — so the per-frame
+  `:on-error` policy is bypassed by passing nil for the policy-event,
+  mirroring the other no-recovery categories."
+  [event event-id frame start-ms]
+  (let [end-ms     (interop/now-ms)
+        elapsed-ms (long (max 0 (- end-ms start-ms)))
+        tags       (events/legacy-runtime-root-ex-data event)]
+    ;; Axis 1 — always-on listener (survives prod elision). No exception
+    ;; object: this is an invalid-write rejection, not a host throw.
+    (error-emit/dispatch-on-error!
+      :rf.error/legacy-runtime-root
+      event
+      event-id
+      frame
+      nil
+      elapsed-ms
+      end-ms
+      nil)                                  ;; LISTENER-ONLY — :no-recovery
+    ;; Dev-only trace path — DCEs under `:advanced` + `goog.DEBUG=false`.
+    (trace/emit-error! :rf.error/legacy-runtime-root
+                       (assoc tags :frame frame))))
+
 (defn- run-fx-effects!
   "Walk :fx in source order, threading fx-overrides through so per-frame
   / per-call overrides take effect. Per-frame :platform overrides the
@@ -1488,9 +1533,24 @@
   of any downstream rollback — it is the proximate, most-actionable
   signal."
   [final-ctx event-id event frame frame-record fx-overrides envelope start-ms]
-  (let [effects        (:effects final-ctx)
-        error          (:rf/interceptor-error final-ctx)
+  (let [error          (:rf/interceptor-error final-ctx)
         flow-error     (:rf/flow-error final-ctx)
+        ;; FINAL-effects boundary policing (rf2-u1kdvg). `commit-fx-effects`
+        ;; polices a `reg-event-fx` HANDLER RETURN during the chain's
+        ;; `:before` pass — BEFORE the `:after` interceptors run. By the
+        ;; time the router consumes `(:effects final-ctx)` the whole chain
+        ;; (every `:before` AND every `:after`) has run, so an effect can
+        ;; arrive here malformed by a route the per-handler-return checks
+        ;; never saw: a `reg-event-ctx` return (no effect-map validation) or
+        ;; an `:after`-interceptor mutation. `police-final-effects!` is the
+        ;; single authoritative shape gate applied to the FINAL map — it
+        ;; drops foreign top-level keys (so a foreign key is no longer
+        ;; SILENTLY ignored at the partition commit) and drops a
+        ;; non-sequential `:fx` (so it never reaches `fx/do-fx` to throw a
+        ;; raw host exception AFTER the db commit), emitting
+        ;; `:rf.error/effect-map-shape` (`:logged-and-skipped`) for each.
+        ;; Runs BEFORE any commit, preserving the no-partial-commit promise.
+        effects        (events/police-final-effects! (:effects final-ctx) event)
         db-before      (get-in final-ctx [:coeffects :db])
         ;; Pre-handler runtime-db partition (EP-0001 rf2-adwcv6): the
         ;; `:rf.db/runtime` coeffect `assemble-initial-ctx` injected by
@@ -1515,6 +1575,21 @@
       (do
         (emit-flow-eval-exception! flow-error event event-id frame start-ms)
         :flow-error)
+      ;; FINAL-effects boundary legacy-root rejection (rf2-u1kdvg, EP-0001
+      ;; decision #8). `events/reject-legacy-runtime-root!` ran in-chain
+      ;; (during the handler-wrapper's `:before`) so a handler-RETURNED
+      ;; `:rf/runtime` root surfaces as `:rf.error/handler-exception`. But an
+      ;; `:after` interceptor can insert the retired `:rf/runtime` root into
+      ;; the FINAL `[:effects :db]` AFTER that guard ran — bypassing it and
+      ;; landing legacy-shaped data in app-db. Enforce the rejection on the
+      ;; FINAL db effect immediately BEFORE commit. In-band (NO throw) so the
+      ;; rejection aborts THIS event only without escaping to the drain's
+      ;; emergency release: no commit, no `:fx`, the rest of the queue keeps
+      ;; draining. Mirrors the no-partial-commit promise of the in-chain guard.
+      (events/legacy-runtime-root? (:db effects))
+      (do
+        (emit-legacy-runtime-root! event event-id frame start-ms)
+        :error)
       ;; Per Spec 010 §Per-step recovery row 4: `commit-frame-effects!`
       ;; returns false when post-commit app-db schema validation rejected
       ;; the new state and rolled the WHOLE frame-state transition back to

--- a/implementation/core/test/re_frame/event_context_partition_test.clj
+++ b/implementation/core/test/re_frame/event_context_partition_test.clj
@@ -21,6 +21,7 @@
             [re-frame.core :as rf]
             [re-frame.events :as events]
             [re-frame.frame :as frame]
+            [re-frame.interceptor :as interceptor]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -260,3 +261,154 @@
           "writing the :rf.db/runtime partition is legitimate — no legacy-root throw")
       (is (= {:rf.runtime/machines {:m 1}} (rf/runtime-db-value :ctx/new-runtime))
           "the runtime-db partition committed normally"))))
+
+;; ===========================================================================
+;; rf2-u1kdvg — FINAL-effects boundary shape policing
+;; ===========================================================================
+;;
+;; `commit-fx-effects` polices a `reg-event-fx` HANDLER RETURN during the
+;; chain's `:before` pass — BEFORE the `:after` interceptors run. The router
+;; consumes the FINAL `(:effects final-ctx)` AFTER the whole chain ran, so an
+;; effect can arrive malformed by a route the per-handler-return checks never
+;; saw: a `reg-event-ctx` return (no effect-map validation) or an `:after`-
+;; interceptor mutation. `events/police-final-effects!` + the router's final
+;; legacy-root check close that gap:
+;;   - a foreign top-level effect key is DROPPED (not silently ignored at the
+;;     partition commit) with `:rf.error/effect-map-shape`;
+;;   - a non-sequential whole `:fx` is DROPPED before `fx/do-fx` can throw a
+;;     raw host exception AFTER the :db commit;
+;;   - a legacy `:rf/runtime` root inserted into the final `[:effects :db]`
+;;     is REJECTED (`:rf.error/legacy-runtime-root`) before commit.
+;; All run BEFORE any commit (no partial commit) and in-band (the drain is
+;; not aborted — downstream queued events keep draining).
+
+(defn- after-icpt
+  "A user `:after` interceptor (id `::mutate`) applying `f` to the context."
+  [f]
+  (interceptor/->interceptor*
+    :id     ::mutate
+    :after  (fn [ctx] (f ctx))))
+
+;; ---- :after interceptor mutating the final effects ------------------------
+
+(deftest after-interceptor-malformed-fx-is-policed-not-thrown
+  (testing "an :after interceptor replacing [:effects :fx] with a non-sequential value is policed (dropped), not a raw host throw after the :db commit"
+    (rf/reg-frame :ctx/after-bad-fx {:doc "ctx"})
+    (let [recorded (record-traces! ::after-bad-fx)
+          ;; The :after runs AFTER the handler-wrapper's :before checks, so
+          ;; `commit-fx-effects`/`fx-value-ok?` never saw this value.
+          bad-fx   (after-icpt (fn [ctx]
+                                 (interceptor/assoc-effect ctx :fx :oops)))]
+      (rf/reg-event-fx :ctx/writes-db [bad-fx]
+        (fn [{:keys [db]} _] {:db (assoc db :committed? true)
+                              :fx []}))
+      ;; A downstream event proves the drain was not abandoned by a raw throw.
+      (rf/reg-event-db :ctx/downstream (fn [db _] (assoc db :downstream? true)))
+      (rf/dispatch-sync [:ctx/writes-db] {:frame :ctx/after-bad-fx})
+      (rf/dispatch-sync [:ctx/downstream] {:frame :ctx/after-bad-fx})
+      (let [errs (error-events recorded :rf.error/effect-map-shape)]
+        (is (= 1 (count errs))
+            "exactly one shape error for the non-sequential :fx value")
+        (is (= :fx (:offending-key (:tags (first errs)))))
+        (is (= :logged-and-skipped (:recovery (first errs)))))
+      (let [db (rf/app-db-value :ctx/after-bad-fx)]
+        (is (true? (:committed? db))
+            "the :db effect still committed — the bad :fx was dropped, no host throw aborted the event")
+        (is (true? (:downstream? db))
+            "the downstream event still drained — the malformed :fx did not abandon the queue")))))
+
+(deftest after-interceptor-foreign-effect-key-is-policed
+  (testing "an :after interceptor inserting a foreign top-level effect key is policed (dropped) — not silently ignored at the partition commit"
+    (rf/reg-frame :ctx/after-foreign {:doc "ctx"})
+    (let [recorded (record-traces! ::after-foreign)
+          foreign  (after-icpt (fn [ctx]
+                                 (interceptor/assoc-effect ctx :http {:url "/api"})))]
+      (rf/reg-event-fx :ctx/writes-db2 [foreign]
+        (fn [{:keys [db]} _] {:db (assoc db :ok? true)}))
+      (rf/dispatch-sync [:ctx/writes-db2] {:frame :ctx/after-foreign})
+      (let [errs (error-events recorded :rf.error/effect-map-shape)]
+        (is (= 1 (count errs))
+            "exactly one shape error for the foreign :http key")
+        (is (= :http (:offending-key (:tags (first errs)))))
+        (is (= :logged-and-skipped (:recovery (first errs)))))
+      (is (true? (:ok? (rf/app-db-value :ctx/after-foreign)))
+          "the legal :db still committed; only the foreign :http key was dropped"))))
+
+(deftest after-interceptor-legacy-runtime-root-is-rejected
+  (testing "an :after interceptor inserting :rf/runtime into [:effects :db] is rejected at the final boundary — never lands in app-db, drain survives"
+    (rf/reg-frame :ctx/after-legacy {:doc "ctx"})
+    (let [recorded (record-traces! ::after-legacy)
+          ;; Insert the retired :rf/runtime root into the FINAL :db effect,
+          ;; AFTER the in-chain `reject-legacy-runtime-root!` :before guard ran.
+          legacy   (after-icpt (fn [ctx]
+                                 (let [db (interceptor/get-effect ctx :db)]
+                                   (interceptor/assoc-effect
+                                     ctx :db (assoc db :rf/runtime {:rf.runtime/machines {}})))))]
+      (rf/reg-event-db :ctx/clean-db [legacy]
+        (fn [db _] (assoc db :user/id 7)))
+      (rf/reg-event-db :ctx/after-legacy-downstream (fn [db _] (assoc db :downstream? true)))
+      (rf/dispatch-sync [:ctx/clean-db] {:frame :ctx/after-legacy})
+      (rf/dispatch-sync [:ctx/after-legacy-downstream] {:frame :ctx/after-legacy})
+      (let [errs (error-events recorded :rf.error/legacy-runtime-root)]
+        (is (= 1 (count errs))
+            "exactly one legacy-runtime-root error at the final boundary")
+        (is (= :rf/runtime (:offending-key (:tags (first errs))))))
+      (let [db (rf/app-db-value :ctx/after-legacy)]
+        (is (not (contains? db :rf/runtime))
+            "the legacy :rf/runtime root never lands in app-db — the whole :db effect is rejected (no commit)")
+        (is (not (contains? db :user/id))
+            "no partial commit — the rejected :db effect is dropped entirely")
+        (is (true? (:downstream? db))
+            "the drain survived the in-band rejection — downstream event still ran")))))
+
+;; ---- reg-event-ctx final-effects policing ---------------------------------
+
+(deftest reg-event-ctx-malformed-fx-is-policed
+  (testing "a reg-event-ctx handler whose returned context carries a non-sequential :fx is policed at the boundary"
+    (rf/reg-frame :ctx/ctx-bad-fx {:doc "ctx"})
+    (let [recorded (record-traces! ::ctx-bad-fx)]
+      (rf/reg-event-ctx :ctx/ctx-writes
+        (fn [ctx]
+          (-> ctx
+              (interceptor/assoc-effect :db (assoc (interceptor/get-coeffect ctx :db) :committed? true))
+              (interceptor/assoc-effect :fx {:dispatch [:nope]}))))
+      (rf/dispatch-sync [:ctx/ctx-writes] {:frame :ctx/ctx-bad-fx})
+      (let [errs (error-events recorded :rf.error/effect-map-shape)]
+        (is (= 1 (count errs))
+            "the reg-event-ctx malformed :fx is policed — reg-event-fx is not the only path that gets shape policing")
+        (is (= :fx (:offending-key (:tags (first errs))))))
+      (is (true? (:committed? (rf/app-db-value :ctx/ctx-bad-fx)))
+          "the :db effect still committed; only the bad :fx was dropped"))))
+
+(deftest reg-event-ctx-foreign-key-is-policed
+  (testing "a reg-event-ctx handler whose returned context carries a foreign top-level effect key is policed at the boundary"
+    (rf/reg-frame :ctx/ctx-foreign {:doc "ctx"})
+    (let [recorded (record-traces! ::ctx-foreign)]
+      (rf/reg-event-ctx :ctx/ctx-foreign-writes
+        (fn [ctx]
+          (-> ctx
+              (interceptor/assoc-effect :db (assoc (interceptor/get-coeffect ctx :db) :ok? true))
+              (interceptor/assoc-effect :dispatch [:legacy/event]))))
+      (rf/dispatch-sync [:ctx/ctx-foreign-writes] {:frame :ctx/ctx-foreign})
+      (let [errs (error-events recorded :rf.error/effect-map-shape)]
+        (is (= 1 (count errs))
+            "the reg-event-ctx foreign :dispatch key is policed")
+        (is (= :dispatch (:offending-key (:tags (first errs))))))
+      (is (true? (:ok? (rf/app-db-value :ctx/ctx-foreign)))
+          "the legal :db still committed; the foreign top-level key was dropped"))))
+
+;; ---- the well-shaped hot path stays clean ---------------------------------
+
+(deftest well-shaped-final-effects-emit-no-shape-error
+  (testing "a clean reg-event-fx return ({:db .. :fx [..]}) emits NO :rf.error/effect-map-shape from the final boundary (no double-policing)"
+    (rf/reg-frame :ctx/clean-final {:doc "ctx"})
+    (let [recorded (record-traces! ::clean-final)]
+      (rf/reg-fx :ctx/noop-fx (fn [_ _]))
+      (rf/reg-event-fx :ctx/clean
+        (fn [{:keys [db]} _] {:db (assoc db :n 1)
+                              :fx [[:ctx/noop-fx {}]]}))
+      (rf/dispatch-sync [:ctx/clean] {:frame :ctx/clean-final})
+      (is (empty? (error-events recorded :rf.error/effect-map-shape))
+          "well-shaped effects pass the final boundary untouched — no spurious / double shape error")
+      (is (= 1 (:n (rf/app-db-value :ctx/clean-final)))
+          "the :db effect committed normally"))))


### PR DESCRIPTION
Closes rf2-u1kdvg (P1, correctness-review).

## Premise (verified against current main / EP-0002)

The effect-map shape policing (closed top-level keys + whole-:fx value) and the legacy :rf/runtime-root rejection ran only on a reg-event-fx HANDLER RETURN, inside the handler-wrapping interceptor's :before pass (events.cljc commit-fx-effects + reject-legacy-runtime-root!). The router consumes the FINAL (:effects final-ctx) after the whole chain — every :before AND every :after — has run, so effects that arrive by another route bypassed every check:

- a reg-event-ctx handler returns a context directly (the :ctx commit is (or new-ctx ctx) — no effect-map validation);
- a user / framework :after interceptor mutates [:effects ...] AFTER the handler-return checks ran.

Consequences this allowed:

- a non-sequential :fx reached fx/do-fx as a raw host throw AFTER the :db commit — escaping process-event! into the drain emergency-release, which re-throws and abandons the rest of the queued events;
- a foreign top-level effect key was silently ignored at the partition commit (commit-frame-effects! reads only :db / :rf.db/runtime / :fx) despite the closed effect-map contract;
- a :rf/runtime root placed under final [:effects :db] bypassed the EP-0001 legacy-root hard-error guard and landed legacy-shaped data in app-db.

## Fix

A single authoritative boundary gate in router commit-and-flow! (before any commit):

- events/police-final-effects! drops foreign top-level keys and a non-sequential :fx, each emitting :rf.error/effect-map-shape (:logged-and-skipped) — no partial commit, no raw host throw;
- events/legacy-runtime-root? on the final :db effect rejects a stray :rf/runtime root in-band (:rf.error/legacy-runtime-root via the always-on error-emit substrate + dev trace, :error outcome, no commit, no :fx) so the drain keeps running rather than aborting via a re-thrown emergency release.

The in-chain reject-legacy-runtime-root! is unchanged — handler-return roots still surface as :rf.error/handler-exception. The boundary gate is symmetric and does not double-police: commit-fx-effects never assocs a bad slot, so the well-shaped path emits nothing twice. Coverage spans reg-event-fx, reg-event-ctx, framework interceptors, and user :after. EP-0002 fx/runtime behavior (carried frame; pre-commit transactional / post-commit best-effort fx atomicity) is preserved.

## Files

- implementation/core/src/re_frame/events.cljc — police-final-effects!; legacy-runtime-root? + legacy-runtime-root-ex-data extracted (shared by the in-chain throw and the boundary emit).
- implementation/core/src/re_frame/router.cljc — require events; emit-legacy-runtime-root!; police + legacy-root branch in commit-and-flow!.
- implementation/core/test/re_frame/event_context_partition_test.clj — 6 new tests.

## Tests

New cases: :after-interceptor malformed :fx (policed, not thrown; downstream event still drains) / foreign key / legacy root; reg-event-ctx malformed :fx / foreign key; well-shaped hot path emits no spurious/double shape error. Core JVM suite green (1042 tests, 4492 assertions, 0 failures). Node CLJS suite exits 0 (the lone async :rf.error/no-frame-context log is a pre-existing http-artefact async-callback artifact, unrelated to this change).
