### PR TITLE
fix(pair-mcp): close reserved-frame operating-pin bypass + MCP false-greens (rf2-wdxyx3)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -302,7 +302,7 @@ load-bearing: each carries different recovery semantics.
 
 | Dialect       | Meaning                                                            | Example reasons                                                                              |
 |---------------|--------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| **Bare**      | Per-call validation / runtime failure (the normal tool body ran)   | `:invalid-kind`, `:missing-path`, `:not-an-event-vector`, `:path-not-found`, `:unknown-tool`, `:runtime-not-preloaded`, `:nrepl-unreachable`, `:build-not-running`, `:no-runtime-connected`, `:runtime-loaded-but-preload-missing`, `:port-unresolved`, `:eval-error`, `:timed-out`, `:probe-errored`, `:<verb>-failed` (e.g. `:snapshot-failed`, `:dispatch-failed`) |
+| **Bare**      | Per-call validation / runtime failure (the normal tool body ran)   | `:invalid-kind`, `:missing-path`, `:not-an-event-vector`, `:path-not-found`, `:no-such-frame`, `:reserved-tool-frame`, `:no-new-epoch`, `:unknown-tool`, `:runtime-not-preloaded`, `:nrepl-unreachable`, `:build-not-running`, `:no-runtime-connected`, `:runtime-loaded-but-preload-missing`, `:port-unresolved`, `:eval-error`, `:timed-out`, `:probe-errored`, `:<verb>-failed` (e.g. `:snapshot-failed`, `:dispatch-failed`) |
 | `:rf.error/*` | Operator-gated denial OR shared cross-MCP error vocabulary — the server refused **without touching nREPL** because a boot-flag / resource cap rejected the call before the tool body ran, OR the call ran but failed in a way that warrants the shared cross-MCP error vocabulary (rf2-xn4f9: `:rf.error/eval-cljs-rejected` + `:rf.error/eval-cljs-timeout` are bare-shaped per-call failures but adopt the namespace so an agent host can pattern-match the eval-cljs error cluster as one family) | `:rf.error/eval-cljs-disabled`, `:rf.error/eval-cljs-rejected`, `:rf.error/eval-cljs-timeout`, `:rf.error/concurrent-stream-limit`, `:rf.error/stream-abuse-detected` |
 | `:rf.mcp/*`   | Wire-replacement-marker family (otherwise reserved for substitution markers like `:rf.mcp/overflow`, `:rf.mcp/dedup-table`, `:rf.mcp/cache-hit`, `:rf.mcp/summary`, `:rf.mcp/diff-from`). One carve-out as a `:reason` value: `:rf.mcp/cursor-stale` — cursor-staleness is detected at the wire boundary itself (the cursor envelope), not via tool body or boot gate, so it shares the `:rf.mcp/*` prefix with the rest of the wire-boundary vocabulary | `:rf.mcp/cursor-stale` (the only `:rf.mcp/*` `:reason` value) |
 
@@ -1265,7 +1265,8 @@ redacted unless the operator opted in. The `:elision` slot echoes the
 effective walker state; `:elided-large` reports the marker count when
 non-zero.
 
-**Returns** (failure):
+**Returns** (failure — all `isError: true`, the dry-run did NOT land,
+rf2-wdxyx3 finding 2):
 
 - `:reason :no-epoch-recorded` — epoch-history empty / frame
   unregistered / `interop/debug-enabled?` false. No rollback needed.
@@ -1886,7 +1887,9 @@ correlates hits without re-deriving order. An unresolved path carries
 `:exists? false` (never a `:path-not-found` envelope — the batch is a
 whole-or-nothing success).
 
-When the path doesn't resolve:
+When the path doesn't resolve, the failure rides as an **`isError`
+result** (`:ok? false`, per §Result envelopes — a known-tool execution
+failure is never a silent success, rf2-wdxyx3):
 
 ```clojure
 {:ok?                  false
@@ -1897,9 +1900,12 @@ When the path doesn't resolve:
 ```
 
 `:exists?` distinguishes a path that legitimately points at a `nil`
-value (`:exists? true :value nil`) from a path that doesn't resolve
-(`:ok? false :reason :path-not-found`). The deepest-valid-prefix lets
-the agent re-aim without a binary search.
+value (`:exists? true :value nil`, an `isError: false` success) from a
+path that doesn't resolve (`:ok? false :reason :path-not-found`,
+`isError: true`). The deepest-valid-prefix lets the agent re-aim without
+a binary search. Because the miss surfaces through the error channel it
+is never response-cached (cache eligibility keys off `isError`), so a
+later successful read of the same path is not masked by a stale failure.
 
 When `elision` is enabled (default), a declared / schema-`:large?`
 path or an over-threshold leaf returns a `:rf.size/large-elided`
@@ -3005,13 +3011,26 @@ Pin the session's operating frame.
 `":stories"`), `build` (string, optional).
 
 Per Tool-Pair §Tool-surface obligations, set **validates** that `frame`
-names a currently-registered frame; an unknown frame returns
-`{:ok? false :reason :no-such-frame :frame <id> :frames [...]}` (the
-registered list rides along so the agent can retarget). Validation and
-the pin write are one eval form — the membership check reads
-`(re-frame2-pair.runtime/frames-list)` and, on a hit, calls
-`(select-frame! <id>)` and returns the fresh triple; no check-then-act
-race across round-trips.
+names a currently-registered frame; an unknown frame returns the
+`isError` envelope `{:ok? false :reason :no-such-frame :frame <id>
+:frames [...]}` (the registered list rides along so the agent can
+retarget). Validation and the pin write are one eval form — the
+membership check reads `(re-frame2-pair.runtime/frames-list)` and, on a
+hit, calls `(select-frame! <id>)` and returns the fresh triple; no
+check-then-act race across round-trips.
+
+A **reserved `:rf/*` tool frame** (Xray's `:rf/xray`, an SSR slot — see
+Tool-Pair §Reserved tool frames) is **refused as an operating-frame
+pin** with `{:ok? false :reason :reserved-tool-frame :frame <id>}`,
+short-circuiting before any nREPL round-trip (rf2-wdxyx3 finding 1). A
+reserved frame is a devtool surface, not the app the operator pairs
+against; were it pinnable, the runtime's `current-frame` resolver would
+return it at tier 2 and a later no-`:frame` root read would resolve a
+wholesale read through it — re-opening the context-window overflow the
+wholesale-read guard closes. Closing the pin removes the bypass at its
+source: a reserved frame is never the operating frame. Targeted (sliced)
+reads of a tool frame remain available via the per-call `:frame` arg.
+`:rf/default` is an app frame and is pinnable normally.
 
 **Returns** the resolved triple on success:
 
@@ -3022,9 +3041,10 @@ race across round-trips.
  :operating <frame-id>}        ;; full resolution — now the pinned frame
 ```
 
-**Error envelopes**:
+**Error envelopes** (all `isError: true`):
 
 - `{:ok? false :reason :missing-frame :hint "..."}` — no `frame` arg.
+- `{:ok? false :reason :reserved-tool-frame :frame <id> :hint "..."}` — `frame` is a reserved `:rf/*` tool frame (refused before nREPL; rf2-wdxyx3).
 - `{:ok? false :reason :no-such-frame :frame <id> :frames [...] :hint "..."}` — `frame` not registered.
 - `{:ok? false :reason :set-operating-frame-failed :message "..."}` — runtime threw.
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch_dry_run.cljs
@@ -244,11 +244,24 @@
                      ;; runtime answered — surface it as `:unexpected-shape`.
                      (let [new-shape? (and (map? resp) (contains? resp :elided-count))
                            env        (if new-shape? (:value resp) resp)
-                           elided     (when new-shape? (:elided-count resp))]
-                       (wire/ok-text
-                         (if (map? env)
-                           (wire/with-indicators
-                             (assoc env :elision elision?)
-                             {:elided (or elided 0)})
-                           {:ok? false :reason :unexpected-shape :value env})))))
+                           elided     (when new-shape? (:elided-count resp))
+                           result     (if (map? env)
+                                        (wire/with-indicators
+                                          (assoc env :elision elision?)
+                                          {:elided (or elided 0)})
+                                        {:ok? false :reason :unexpected-shape :value env})]
+                       ;; rf2-wdxyx3 finding 2 — a known-tool runtime
+                       ;; failure (`:ok? false`, e.g. the reducer rejected
+                       ;; the event / an interceptor early-returned →
+                       ;; `:no-new-epoch`, or a degraded runtime →
+                       ;; `:unexpected-shape`) MUST ride back as an
+                       ;; `isError` envelope, matching the dispatch /
+                       ;; read-sub no-silent-success parity model and the
+                       ;; published wire contract. The old `ok-text` shape
+                       ;; let a non-landed dry-run read as green. The
+                       ;; structured `:reason`/`:hint` rides through
+                       ;; verbatim so the caller still sees why.
+                       (if (false? (:ok? result))
+                         (wire/err-text result)
+                         (wire/ok-text result)))))
             (.catch (fn [err] (probe/err->result :dispatch-dry-run-failed err))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
@@ -176,11 +176,26 @@
                                (pluck envelope)
                                {:kind :scalar-value
                                 :server-elided server-elided})
-                             {:keys [elided]} indicators]
-                         (wire/ok-text
-                           (wire/with-indicators
-                             (rebuild (dissoc envelope :elided-count) value)
-                             {:elided elided})))))
+                             {:keys [elided]} indicators
+                             rebuilt (wire/with-indicators
+                                       (rebuild (dissoc envelope :elided-count) value)
+                                       {:elided elided})]
+                         ;; rf2-wdxyx3 finding 2 — a known-tool runtime
+                         ;; failure (`:ok? false`, e.g. a singular
+                         ;; `:path-not-found` miss) MUST ride back as an
+                         ;; `isError` envelope, per the published wire
+                         ;; contract (spec/001-Wire-Protocol.md, API.md
+                         ;; §isError) and the dispatch/read-sub
+                         ;; no-silent-success parity model. An `ok-text`
+                         ;; wrapper let the failure cache as a normal success
+                         ;; (cache eligibility keys off `isError`, not
+                         ;; `:ok?`) and read as green by the MCP host. The
+                         ;; `:wholesale-read-of-reserved-frame` refusal is
+                         ;; built upstream as its own `err-text` and never
+                         ;; reaches this tail.)
+                         (if (false? (:ok? rebuilt))
+                           (wire/err-text rebuilt)
+                           (wire/ok-text rebuilt)))))
               (.catch (fn [err] (probe/err->result :get-path-failed err)))))]
     (cond
       ;; rf2-qef58 — server-side backstop: refuse a WHOLESALE root read

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/operating_frame.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/operating_frame.cljs
@@ -71,7 +71,8 @@
   (:require [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
-            [re-frame2-pair-mcp.tools.probe :as probe]))
+            [re-frame2-pair-mcp.tools.probe :as probe]
+            [re-frame2-pair-mcp.tools.reserved-frame-guard :as guard]))
 
 ;; rf2-olvr5 finding 3 — the response cache key is `(tool, build,
 ;; args-fingerprint)`; it deliberately can NOT include the resolved
@@ -124,7 +125,8 @@
   (let [frame-str (wire/arg raw-args :frame)
         frame     (some-> frame-str args/->frame-keyword)
         build-id  (wire/arg-build conn raw-args)]
-    (if (nil? frame)
+    (cond
+      (nil? frame)
       (js/Promise.resolve
         (wire/err-text
           {:ok?    false
@@ -135,28 +137,68 @@
                         "subscribe, …) resolve to it instead of refusing "
                         "with :ambiguous-frame. Call get-operating-frame "
                         "to see the registered frames.")}))
+
+      ;; rf2-wdxyx3 finding 1 — refuse pinning a reserved `:rf/*` TOOL frame
+      ;; as the session's operating frame BEFORE any nREPL round-trip. A
+      ;; tool frame (Xray's `:rf/xray`, an SSR slot) is a devtool surface,
+      ;; NOT the app the operator is pairing against (Tool-Pair §Reserved
+      ;; tool frames are excluded from the ambiguity count). Were a pin
+      ;; allowed, the runtime's `current-frame` resolver would return the
+      ;; tool frame at tier 2, and a later no-`:frame` `get-path {path []}`
+      ;; would resolve the wholesale read through it — re-opening the exact
+      ;; context-window overflow the rf2-qef58 guard was introduced to
+      ;; close (the guard fires on the explicit `:frame` arg; an omitted
+      ;; `:frame` resolves runtime-side, where the client guard can't see
+      ;; the reserved pin). Closing the pin here removes the bypass at its
+      ;; source: a reserved frame is never the operating frame, so the
+      ;; nil-`:frame` resolution can never land on one. Sliced/explicit
+      ;; reads of a tool frame stay available via the per-call `:frame`
+      ;; arg. `:rf/default` is an app frame (the predicate's carve-out) and
+      ;; is allowed.
+      (guard/reserved-tool-frame? frame)
+      (js/Promise.resolve
+        (wire/err-text
+          {:ok?    false
+           :reason :reserved-tool-frame
+           :frame  frame
+           :hint   (str "Refusing to pin the reserved :rf/* TOOL frame " frame
+                        " as the operating frame. Reserved :rf/* frames are devtool "
+                        "surfaces (e.g. Xray's :rf/xray), not the app frame you pair "
+                        "against — pinning one would resolve every omitted-:frame read "
+                        "against it and re-open the wholesale-read overflow. Pin an APP "
+                        "frame instead (call get-operating-frame to list :app-frames), "
+                        "or pass :frame " frame " on a single call for a TARGETED "
+                        "(sliced) read of the tool frame.")}))
+
+      :else
       (let [form (set-form frame)]
         (probe/eval-after-runtime!
           conn build-id form :set-operating-frame-failed
           (fn [v]
-            ;; Two runtime shapes resolve into one the agent can rely on:
+            ;; rf2-wdxyx3 finding 2 — a known-tool execution failure
+            ;; (`:ok? false`) MUST ride back as an `isError` envelope so the
+            ;; MCP host routes recovery through the error channel and the
+            ;; invoke chokepoint does not treat a non-pin as a cache-flushing
+            ;; success. Two runtime shapes resolve into one the agent can
+            ;; rely on:
             ;;   - success: `frames-list`'s {:ok? true :frames :selected
-            ;;     :operating} triple. Pass through — `:selected` now
-            ;;     equals the just-pinned frame.
+            ;;     :operating} triple → `ok-text`; `:selected` now equals
+            ;;     the just-pinned frame.
             ;;   - unknown frame: {:ok? false :reason :no-such-frame
-            ;;     :frame :frames}. Add a corrective hint.
-            (wire/ok-text
-              (cond
-                (not (map? v))
-                {:ok? false :reason :unexpected-shape :frame frame :value v}
+            ;;     :frame :frames} → `err-text` with a corrective hint.
+            ;;   - degraded runtime (non-map) → `err-text` :unexpected-shape.
+            (cond
+              (not (map? v))
+              (wire/err-text {:ok? false :reason :unexpected-shape :frame frame :value v})
 
-                (false? (:ok? v))
+              (false? (:ok? v))
+              (wire/err-text
                 (assoc v :hint
                        (str "frame " frame " is not currently registered. "
                             "Pick one of " (vec (:frames v))
-                            " — call get-operating-frame to list them."))
+                            " — call get-operating-frame to list them.")))
 
-                :else v))))))))
+              :else (wire/ok-text v))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; reset-operating-frame

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/reserved_frame_guard.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/reserved_frame_guard.cljs
@@ -153,10 +153,17 @@
   explicit root `[]` of a reserved frame is refused.
 
   `frame` is the resolved frame keyword (may be nil when the agent let it
-  default to the operating frame — in that case the server can't know it
-  is reserved, so the guard does not fire; the snapshot/orient steer plus
-  the wire cap remain the backstop). `path` is the parsed singular path;
-  `paths` is the parsed batch vector-of-paths (`nil` when not a batch)."
+  default to the operating frame — in that case the server can't know the
+  resolved frame here, so this client-side guard does not fire on the
+  omitted-`:frame` path). That omitted-`:frame` case is NOT an escape
+  hatch: `set-operating-frame` refuses to PIN a reserved `:rf/*` tool
+  frame (rf2-wdxyx3 finding 1), so the runtime's `current-frame` resolver
+  can never return a reserved frame at tier 2 — an omitted-`:frame` read
+  resolves to an APP frame (or refuses with `:ambiguous-frame`), never a
+  tool frame. So the only way to address a reserved frame is the explicit
+  `:frame` arg, which this guard sees and refuses at root path. `path` is
+  the parsed singular path; `paths` is the parsed batch vector-of-paths
+  (`nil` when not a batch)."
   [frame path paths]
   (when (and (reserved-tool-frame? frame)
              (or (root-path? path)

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -821,6 +821,21 @@
     {:isError? false
      :edn-submap {:ok? true :elision false}}}
 
+   {:fixture/id    :dispatch-dry-run/no-new-epoch
+    :fixture/doc   "dispatch-dry-run surfaces the runtime's {:ok? false :reason :no-new-epoch} as an isError envelope (rf2-wdxyx3 finding 2 — a non-landed dry-run is never a silent success; parity with dispatch/no-new-epoch)."
+    :fixture/tool  "dispatch-dry-run"
+    :fixture/args  {:event "[:noop]"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["configure-raw-state!"      nil]
+     ["dispatch-dry-run"          {:value {:ok? false :reason :no-new-epoch
+                                           :event [:noop] :frame :rf/default}
+                                   :elided-count 0}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? true
+     :edn-submap {:ok? false :reason :no-new-epoch}}}
+
    ;; ---------- restore-epoch (rf2-ee38b.18 — gated write) ----------------
    ;; The --allow-writes gate ships DEFAULT-OFF. The disabled fixture pins
    ;; the gate-closed envelope (no nREPL round-trip); the happy fixture
@@ -1006,7 +1021,7 @@
      :reason :missing-path}}
 
    {:fixture/id    :get-path/path-not-found
-    :fixture/doc   "get-path forwards the runtime's :path-not-found envelope."
+    :fixture/doc   "get-path surfaces the runtime's :path-not-found failure as an isError envelope (rf2-wdxyx3 finding 2 — a known-tool :ok? false is never a silent success)."
     :fixture/tool  "get-path"
     :fixture/args  {:path "[:no-such :key]"}
     :fixture/eval-script
@@ -1015,7 +1030,7 @@
                                    :path [:no-such :key]
                                    :deepest-valid-prefix []}]]
     :fixture/expect
-    {:isError? false
+    {:isError? true
      :edn-submap {:ok? false :reason :path-not-found}}}
 
    ;; ---------- read-dom (rf2-nfjil — raw DOM plane read) -----------------
@@ -1157,7 +1172,7 @@
      :edn-contains-keys #{:frames :selected :operating}}}
 
    {:fixture/id    :set-operating-frame/no-such-frame
-    :fixture/doc   "set-operating-frame on an unregistered frame refuses with :no-such-frame and lists the registered frames (Tool-Pair §Tool-surface obligations validation)."
+    :fixture/doc   "set-operating-frame on an unregistered frame refuses with :no-such-frame as an isError envelope (Tool-Pair §Tool-surface obligations + rf2-wdxyx3 finding 2 — the failed pin is not a silent success, so the invoke chokepoint won't flush the cache)."
     :fixture/tool  "set-operating-frame"
     :fixture/args  {:frame ":nope"}
     :fixture/eval-script
@@ -1168,8 +1183,19 @@
                                    :frame :nope
                                    :frames [:rf/default :stories]}]]
     :fixture/expect
-    {:isError? false
+    {:isError? true
      :edn-submap {:ok? false :reason :no-such-frame :frame :nope}}}
+
+   {:fixture/id    :set-operating-frame/reserved-tool-frame
+    :fixture/doc   "set-operating-frame refuses to pin a reserved :rf/* TOOL frame as the operating frame (rf2-wdxyx3 finding 1). Refused BEFORE any nREPL round-trip — a reserved frame is never the operating frame, so an omitted-:frame read can never resolve to it. :rf/default (an app frame) is allowed."
+    :fixture/tool  "set-operating-frame"
+    :fixture/args  {:frame ":rf/xray"}
+    ;; No eval expected — the refusal short-circuits before the round-trip.
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :edn-submap {:ok? false :reason :reserved-tool-frame :frame :rf/xray}}}
 
    {:fixture/id    :set-operating-frame/missing-frame
     :fixture/doc   "set-operating-frame without :frame surfaces :missing-frame before any nREPL round-trip."

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_dry_run_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_dry_run_test.cljs
@@ -366,11 +366,13 @@
                          "the elided-large indicator surfaces the marker count"))
                    (done)))))))
 
-(deftest no-new-epoch-failure-passes-through
-  ;; The reducer rejected the event or an interceptor early-returned.
-  ;; The runtime envelope's :reason :no-new-epoch passes through; no
-  ;; rollback was needed and none was performed. (Soft-failure
-  ;; envelopes carry no egress slots, so the walker is a no-op.)
+(deftest no-new-epoch-failure-rides-as-iserror
+  ;; rf2-wdxyx3 finding 2 — the reducer rejected the event or an
+  ;; interceptor early-returned, so the dry-run did NOT land. A known-tool
+  ;; runtime failure (`:ok? false`) MUST ride back as an isError envelope,
+  ;; matching the dispatch/read-sub no-silent-success parity model: the old
+  ;; ok-text shape let a non-landed dry-run read as green and be cache-
+  ;; eligible. The structured :reason/:hint rides through verbatim.
   (async done
     (let [env {:ok?    false
                :reason :no-new-epoch
@@ -381,7 +383,7 @@
             (fn []
               (dry-run/dispatch-dry-run-tool (fresh-conn) #js {:event "[:noop]"})))
           (.then (fn [r]
-                   (is (not (err? r)) "soft-failure rides as ok-text, not isError")
+                   (is (err? r) ":ok? false dry-run rides as isError, not a silent ok-text")
                    (let [edn (read-result-text r)]
                      (is (false? (:ok? edn)))
                      (is (= :no-new-epoch (:reason edn))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/invoke_test.cljs
@@ -51,6 +51,7 @@
             [cljs.reader :as edn]
             [applied-science.js-interop :as j]
             [re-frame2-pair-mcp.cache :as cache]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools :as tools]
             [re-frame2-pair-mcp.tools.precheck :as precheck]
             [re-frame2-pair-mcp.tools.wire :as wire]
@@ -75,12 +76,14 @@
 (def ^:private orig-get-path-tool       get-path/get-path-tool)
 (def ^:private orig-snapshot-tool       snapshot/snapshot-tool)
 (def ^:private orig-reset-operating-frame-tool operating-frame/reset-operating-frame-tool)
+(def ^:private orig-cljs-eval-value     nrepl/cljs-eval-value)
 
 (defn- restore-stubs! []
   (set! precheck/fetch-precheck-hash orig-fetch-precheck-hash)
   (set! get-path/get-path-tool       orig-get-path-tool)
   (set! snapshot/snapshot-tool       orig-snapshot-tool)
-  (set! operating-frame/reset-operating-frame-tool orig-reset-operating-frame-tool))
+  (set! operating-frame/reset-operating-frame-tool orig-reset-operating-frame-tool)
+  (set! nrepl/cljs-eval-value        orig-cljs-eval-value))
 
 (use-fixtures :each
   {:before (fn [] (cache/clear!))
@@ -657,4 +660,66 @@
                        "the mutation errored")
                    (is (= 1 (cache/size))
                        "an errored operating-frame call leaves the cache intact")
+                   (done)))))))
+
+;; rf2-wdxyx3 finding 2 — the REAL set-operating-frame :no-such-frame path.
+;; The prior test stubbed an `:isError true` reset; this one runs the
+;; actual `set-operating-frame-tool` against a stubbed nREPL that answers
+;; :no-such-frame, then drives THAT real result through `invoke`'s
+;; chokepoint. It proves the failure now rides as `isError` (no silent
+;; ok-text) AND that the chokepoint's `(not (isError? result))` flush
+;; guard therefore preserves the cache — the pin did NOT change, so a
+;; no-`:frame` cached read stays valid.
+(defn- probed-conn []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{:app})
+    conn))
+
+(deftest real-set-operating-frame-no-such-frame-is-error-and-preserves-cache
+  (async done
+    (let [conn    (probed-conn)
+          gp-args (args-js {:cache "true" :path "[:k]"})]
+      (cache/apply-cache (mcp-result "{:k :frame-a}")
+                         {:tool "get-path"
+                          :args gp-args
+                          :enabled? true
+                          :build (wire/arg-build conn gp-args)
+                          :precheck-hash 42})
+      (is (= 1 (cache/size)) "cache primed")
+      ;; Stub nREPL so the REAL set-form runs and the runtime answers
+      ;; :no-such-frame (the requested frame isn't registered). The conn is
+      ;; pre-probed so ensure-runtime! short-circuits; the validate-then-pin
+      ;; form resolves to the failure envelope.
+      (set! nrepl/cljs-eval-value
+            (fn
+              ([_c _b _form]
+               (js/Promise.resolve {:ok? false :reason :no-such-frame
+                                    :frame :nope
+                                    :frames [:rf/default :stories]}))
+              ([_c _b _form _o]
+               (js/Promise.resolve {:ok? false :reason :no-such-frame
+                                    :frame :nope
+                                    :frames [:rf/default :stories]}))))
+      ;; Run the REAL tool to capture its actual result shape, then have
+      ;; `invoke` dispatch that exact result through the chokepoint flush
+      ;; guard. (Stubbing the entry-point with the real result keeps the
+      ;; flush decision under test while sidestepping the pipeline's
+      ;; build-resolution round-trips.)
+      (-> (operating-frame/set-operating-frame-tool
+            conn (args-js {:frame ":nope"}))
+          (.then (fn [real-result]
+                   (is (true? (j/get real-result :isError))
+                       "a real :no-such-frame set-operating-frame rides as isError")
+                   (set-stubs!
+                     {:reset-operating-frame-tool
+                      (fn [_conn _args] (js/Promise.resolve real-result))})
+                   ;; reset-operating-frame is also operating-frame-mutating;
+                   ;; feeding it the real isError result exercises the SAME
+                   ;; `(not (isError? result))` chokepoint guard.
+                   (tools/invoke conn "reset-operating-frame" (args-js {}) nil)))
+          (.then (fn [result]
+                   (is (true? (j/get result :isError))
+                       "the chokepoint sees the failed mutation as isError")
+                   (is (= 1 (cache/size))
+                       "the failed pin did not change the operating frame, so the cache is preserved")
                    (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/reserved_frame_guard_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/reserved_frame_guard_test.cljs
@@ -21,7 +21,8 @@
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.reserved-frame-guard :as guard]
             [re-frame2-pair-mcp.tools.snapshot :as snapshot]
-            [re-frame2-pair-mcp.tools.get-path :as get-path]))
+            [re-frame2-pair-mcp.tools.get-path :as get-path]
+            [re-frame2-pair-mcp.tools.operating-frame :as op-frame]))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: the reserved-frame predicate (server-side mirror of the runtime's).
@@ -102,7 +103,14 @@
   (testing "a user frame / :rf/default at path [] is allowed"
     (is (nil? (guard/get-path-refusal :stories [] nil)))
     (is (nil? (guard/get-path-refusal :rf/default [] nil))))
-  (testing "a nil frame (defaulted operating frame) does not fire the guard"
+  (testing "a nil frame (defaulted operating frame) does not fire this client-side guard"
+    ;; rf2-wdxyx3 finding 1 — this is NOT an escape hatch. The client guard
+    ;; can't see the runtime-resolved frame for an omitted-:frame call, but
+    ;; set-operating-frame refuses to PIN a reserved :rf/* frame, so the
+    ;; runtime's current-frame resolver can never return one at tier 2 — an
+    ;; omitted-:frame read resolves to an APP frame (or refuses
+    ;; :ambiguous-frame), never a tool frame. See
+    ;; set-operating-frame-refuses-reserved-tool-frame below.
     (is (nil? (guard/get-path-refusal nil [] nil)))))
 
 ;; ---------------------------------------------------------------------------
@@ -252,4 +260,75 @@
                    (is (not (tu/error? r)) "root get-path of a user frame is allowed")
                    (is (true? (:ok? (tu/extract-edn r))))
                    (is (seq @seen) "the read eval WAS reached")
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-wdxyx3 finding 1 — the operating-frame bypass. The client-side
+;; get-path guard fires on the explicit `:frame` arg; an omitted `:frame`
+;; resolves runtime-side via `current-frame`, which returns the session
+;; pin at tier 2. If `set-operating-frame` let a reserved `:rf/*` TOOL
+;; frame be pinned, a later `get-path {path "[]"}` with no `:frame` would
+;; resolve the wholesale read through it — re-opening the overflow the
+;; guard was built to close. The fix refuses the reserved-frame PIN at its
+;; source, so the resolver can never return a tool frame for an
+;; omitted-:frame call.
+;; ---------------------------------------------------------------------------
+
+(deftest set-operating-frame-refuses-reserved-tool-frame
+  ;; The bypass entry point: pinning :rf/xray as the operating frame is now
+  ;; refused BEFORE any nREPL round-trip (a reserved :rf/* frame is a
+  ;; devtool surface, never the app the operator pairs against). With the
+  ;; pin closed, an omitted-:frame read can never resolve to :rf/xray.
+  (async done
+    (let [seen (atom [])]
+      ;; `select-frame!`'s validate-then-pin form is the only non-prelude
+      ;; eval set-operating-frame would issue; `seen` staying empty proves
+      ;; the refusal short-circuited before the round-trip (no pin written).
+      (stub-eval! seen {:ok? true :frames [:rf/default :rf/xray]
+                        :selected :rf/xray :operating :rf/xray})
+      (-> (op-frame/set-operating-frame-tool (fresh-conn)
+                                             (tu/args->js {:frame ":rf/xray"}))
+          (.then (fn [r]
+                   (is (tu/error? r) "pinning a reserved :rf/* tool frame is refused")
+                   (let [edn (tu/extract-edn r)]
+                     (is (false? (:ok? edn)))
+                     (is (= :reserved-tool-frame (:reason edn)))
+                     (is (= :rf/xray (:frame edn)))
+                     (is (re-find #"get-operating-frame|app" (:hint edn))
+                         "redirects to an app frame / sliced :frame read"))
+                   (is (empty? @seen)
+                       "no select-frame! eval — the reserved pin was never written")
+                   (done)))))))
+
+(deftest set-operating-frame-allows-rf-default-and-app-frames
+  ;; Negative guard: :rf/default is an APP frame (the predicate's carve-out)
+  ;; and an ordinary user frame both pin normally — the refusal is scoped to
+  ;; reserved :rf/* TOOL frames only.
+  (async done
+    (let [seen (atom [])]
+      (stub-eval! seen {:ok? true :frames [:rf/default :stories]
+                        :selected :stories :operating :stories})
+      (-> (op-frame/set-operating-frame-tool (fresh-conn)
+                                             (tu/args->js {:frame ":stories"}))
+          (.then (fn [r]
+                   (is (not (tu/error? r)) "pinning an app frame succeeds")
+                   (is (true? (:ok? (tu/extract-edn r))))
+                   (is (seq @seen) "the validate-then-pin eval WAS reached")
+                   (done)))))))
+
+(deftest sliced-reserved-frame-read-still-succeeds-via-explicit-frame
+  ;; With the reserved-frame PIN closed, a TARGETED (sliced) read of a tool
+  ;; frame stays available through the explicit per-call :frame arg — the
+  ;; "preserve allowed targeted reads of reserved frames" acceptance
+  ;; criterion. (The "pinned :rf/xray + sliced read" example is moot: a
+  ;; reserved frame is never the operating frame.)
+  (async done
+    (let [seen (atom [])]
+      (stub-eval! seen {:ok? true :exists? true :value [1 2 3] :elided-count 0})
+      (-> (get-path/get-path-tool (fresh-conn)
+                                  (tu/args->js {:frame ":rf/xray" :path "[:rf.xray/epochs]"}))
+          (.then (fn [r]
+                   (is (not (tu/error? r)) "explicit :frame :rf/xray + non-root path is allowed")
+                   (is (true? (:ok? (tu/extract-edn r))))
+                   (is (seq @seen) "the sliced read eval WAS reached")
                    (done)))))))


### PR DESCRIPTION
Closes rf2-wdxyx3 (P1, correctness-review). Premise verified against current main (post EP-0002 + a0kxsb): both findings still hold — EP-0002 left the operating-frame resolution chain unchanged, and the false-green wrappers are present.

## Finding 1 — reserved-frame operating-pin bypass

The wholesale-read guard (rf2-qef58) fires on the explicit :frame arg. With :frame omitted, get-path resolves the frame runtime-side via current-frame, which returns the session pin at tier 2. set-operating-frame validated only registration, so :rf/xray could be pinned; a later get-path with path "[]" and no :frame then resolved the whole devtool app-db — the exact overflow path the guard exists to prevent.

Fix (acceptance option 1, the root cause): set-operating-frame refuses to pin a reserved :rf/* tool frame (except :rf/default) before any nREPL round-trip, with reason :reserved-tool-frame. A reserved frame is never the operating frame, so an omitted-:frame read can never resolve to one. Targeted/sliced reads of a tool frame stay available via the explicit per-call :frame arg.

## Finding 2 — known-tool failures returned MCP success envelopes

get-path :path-not-found, set-operating-frame :no-such-frame, and dispatch-dry-run :no-new-epoch / :unexpected-shape wrapped their :ok? false payloads in ok-text. They read as green to the MCP host and were response-cache-eligible (cache + the operating-frame flush chokepoint key off isError, not :ok?). Normalized all three to wire/err-text (isError true), matching the published wire contract (001-Wire-Protocol.md, API.md) and the existing dispatch/read-sub no-silent-success parity model.

## Tests + spec

- Conformance fixtures flipped to isError true for the three failure paths; added set-operating-frame/reserved-tool-frame and dispatch-dry-run/no-new-epoch fixtures.
- Focused regression in reserved_frame_guard_test: operating-frame pin refusal, :rf/default + app-frame pin still succeed, sliced reserved-frame read via explicit :frame still succeeds. Updated the nil-frame negative-guard comment so it no longer documents an escape hatch.
- invoke_test: a real set-operating-frame :no-such-frame invocation proving the result is isError and the chokepoint preserves the cache (the pin did not change).
- 003-Tool-Catalogue.md documents the isError contract and the :reserved-tool-frame reason.

## Slice gates (local)

- tools/re-frame2-pair-mcp npm test: 1018 tests, 3112 assertions, 0 failures.
- mcp-conformance npm run test:re-frame2-pair: GREEN.
- check:descriptors: in sync (29 tools).

No hot-zone files touched; all changes isolated to tools/re-frame2-pair-mcp/.
