### PR TITLE
refactor(pair-mcp): pure two-output fold in slice-app-db-in-snapshot (rf2-k7otmg)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot_pipeline.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot_pipeline.cljs
@@ -97,39 +97,47 @@
   [snapshot path app-db-mode]
   (if-not (map? snapshot)
     [snapshot {}]
-    (let [status* (atom {})
-          missing (js-obj)
+    (let [missing (js-obj)
           full?   (= :full app-db-mode)
+          ;; Pure two-output transform: returns `[new-frame-map
+          ;; status-entry-or-nil]`. The status entry is non-nil only on
+          ;; a path miss; the fold below threads it into the `:status`
+          ;; map. No side-channel atom — both outputs flow through the
+          ;; accumulator (rf2-k7otmg).
           process-frame
-          (fn [frame-id frame-map]
+          (fn [frame-map]
             (if-not (and (map? frame-map) (contains? frame-map :app-db))
-              frame-map
+              [frame-map nil]
               (let [db (:app-db frame-map)]
                 (cond
                   ;; No path + summary mode (rf2-tygdv default): summarise.
                   (and (nil? path) (not full?))
-                  (update frame-map :app-db summary/tree-summary)
+                  [(update frame-map :app-db summary/tree-summary) nil]
                   ;; No path + full mode: full slice (rf2-u2029 opt-in).
                   (nil? path)
-                  frame-map
+                  [frame-map nil]
                   ;; Root path (`[]`): return full db (agent opted in
                   ;; explicitly). Equivalent to legacy default behaviour.
                   (empty? path)
-                  frame-map
+                  [frame-map nil]
                   ;; Path supplied: get-in with missing sentinel.
                   :else
                   (let [v (get-in db path missing)]
                     (if (identical? v missing)
-                      (do (swap! status* assoc frame-id
-                                 {:exists? false
-                                  :deepest-valid-prefix
-                                  (summary/deepest-valid-prefix db path)})
-                          (assoc frame-map :app-db nil))
-                      (assoc frame-map :app-db v)))))))
-          processed (reduce-kv (fn [m fid fmap]
-                                 (assoc m fid (process-frame fid fmap)))
-                               {} snapshot)]
-      [processed @status*])))
+                      [(assoc frame-map :app-db nil)
+                       {:exists? false
+                        :deepest-valid-prefix
+                        (summary/deepest-valid-prefix db path)}]
+                      [(assoc frame-map :app-db v) nil]))))))
+          {:keys [processed status]}
+          (reduce-kv (fn [acc fid fmap]
+                       (let [[new-fmap status-entry] (process-frame fmap)
+                             acc' (assoc-in acc [:processed fid] new-fmap)]
+                         (if status-entry
+                           (assoc-in acc' [:status fid] status-entry)
+                           acc')))
+                     {:processed {} :status {}} snapshot)]
+      [processed status])))
 
 (defn summarise-other-slices-in-snapshot
   "Apply `tree-summary` to every frame's non-app-db slice whose


### PR DESCRIPTION
## What

Refactor `slice-app-db-in-snapshot` in `tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot_pipeline.cljs` to eliminate the parallel `status*` atom side-channel. From the rf2-a91135 atom-usage audit (finding S1).

## Why

The fn built `:processed` via a pure `reduce-kv` but `swap!`'d a parallel `status*` atom as a hidden side-effect inside the inner `process-frame` whenever a path did not resolve. Two outputs — one threaded purely, one through an atom — read less clearly and were harder to test in isolation.

## Change

- `process-frame` now returns a tuple `[new-frame-map status-entry-or-nil]` instead of writing status as a side-effect.
- The `reduce-kv` threads a single accumulator `{:processed {} :status {}}`, assoc'ing both outputs. No atom — one pure two-output fold.
- Return shape is unchanged (`[processed status]`); callers and tests are unaffected.

Pure-internal elegance refactor, no behavior change.

## Verification

`npm test` (pair-mcp `server-test` build): 1018 tests, 3112 assertions, 0 failures, 0 errors. The path-slicing tests that exercise this fn (`path_slicing_test.cljs`) pass unchanged.

Closes rf2-k7otmg.
