### PR TITLE
fix(http): clear-http-interceptor facade fails closed; harden no-rf-default lint (rf2-vl5xsp + rf2-tc5rxm)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -305,9 +305,12 @@
        interceptor-map)` — per rf2-uheqq the surface mirrors the
        event-interceptor `{:id :before :after}` shape: a single map
        carrying at least one of `:before (fn [ctx] ctx')` or
-       `:after (fn [ctx response] response')`, plus optional
-       `:frame` (default `:rf/default`) and any
-       `:rf/registration-metadata` slots."
+       `:after (fn [ctx response] response')`, plus an optional
+       `:frame` (the EP-0002 *override*) and any
+       `:rf/registration-metadata` slots. Absent an explicit `:frame`
+       the carried-invariant scope chain resolves the target; under no
+       scope the call raises `:rf.error/no-frame-context` (no
+       `:rf/default` is synthesised)."
        {:arglists '([id interceptor-map])})))
 
 ;; ---- reg-machine (bespoke — per-element coord stamping) -----------------
@@ -1734,10 +1737,14 @@
   with-managed-request-stubs*      rf-http/with-managed-request-stubs*)
 
 (def ^{:doc "Clear an HTTP interceptor by `id` from a frame's
-  `:rf.http/managed` middleware chain. Single-arity clears on
-  `:rf/default`; two-arity targets the named frame. Implementation ships
-  in `day8/re-frame2-http`. Per Spec 014 §Middleware. Late-bound via
-  `:http/clear-http-interceptor`."}
+  `:rf.http/managed` middleware chain. EP-0002 context-required
+  frame-local: the single-arity `(clear-http-interceptor id)` resolves
+  the frame through the carried-invariant scope chain; the two-arity
+  `(clear-http-interceptor frame id)` names the frame explicitly (the
+  *override*). Under no scope and no explicit frame the call raises
+  `:rf.error/no-frame-context` — it does NOT synthesise a `:rf/default`
+  target. Implementation ships in `day8/re-frame2-http`. Per Spec 014
+  §Middleware. Late-bound via `:http/clear-http-interceptor`."}
   clear-http-interceptor           rf-http/clear-http-interceptor)
 
 ;; reg-http-interceptor is a macro (per the defreg-macro form above) so

--- a/implementation/core/src/re_frame/core_http.cljc
+++ b/implementation/core/src/re_frame/core_http.cljc
@@ -61,9 +61,12 @@
     `:before` — `(fn [ctx] ctx')`            request-side transform
     `:after`  — `(fn [ctx response] response')` response-side transform
 
-  plus optional `:frame` (default `:rf/default`) and any
+  plus an optional `:frame` (the EP-0002 *override*) and any
   `:rf/registration-metadata` keys (`:doc` / `:tags` / `:schema` /
-  `:sensitive?`). The two slots mirror the event-interceptor
+  `:sensitive?`). Absent an explicit `:frame`, the carried-invariant
+  scope chain resolves the target; under no scope the call raises
+  `:rf.error/no-frame-context` (no `:rf/default` is synthesised). The
+  two slots mirror the event-interceptor
   `{:id :before :after}` shape (Spec 002).
 
   The `:before` chain runs in REGISTRATION ORDER before the request
@@ -87,11 +90,17 @@
 
 (defwrapper clear-http-interceptor
   "Spec 014 §Middleware — clear an HTTP interceptor by id from a frame's
-  chain. Single-arity clears on `:rf/default`; two-arity targets the
-  named frame.
+  chain. EP-0002 context-required frame-local: the single-arity
+  `(clear-http-interceptor id)` resolves the frame through the
+  carried-invariant scope chain (a `with-frame` / frame-provider scope);
+  the two-arity `(clear-http-interceptor frame id)` names the frame
+  explicitly (the *override*). Under no scope and no explicit frame the
+  call raises `:rf.error/no-frame-context` — it does NOT synthesise a
+  `:rf/default` target. Both arities delegate to the late-bound impl,
+  which performs the frame resolution.
 
   Late-bound via `:http/clear-http-interceptor`. When the http artefact
   is absent the call raises `:rf.error/http-artefact-missing`."
   {:hook :http/clear-http-interceptor :artefact http-artefact :on-absent :throw}
-  ([id]       [:rf/default id])
+  ([id]       :delegate)
   ([frame id] :delegate))

--- a/implementation/core/test/re_frame/no_rf_default_floor_lint_test.clj
+++ b/implementation/core/test/re_frame/no_rf_default_floor_lint_test.clj
@@ -12,8 +12,13 @@
   absence is `:rf.error/no-frame-context`, NEVER repaired by synthesising
   `:rf/default`. The runtime must therefore carry NO
 
-    - `:or {frame-id :rf/default}` destructuring default, and
-    - `(or … :rf/default)` resolution floor
+    - `:or {frame-id :rf/default}` destructuring default,
+    - `[:rf/default <sym>]` POSITIONAL floor — synthesising `:rf/default`
+      as the frame argument of a delegated/recursive call (e.g. a
+      `defwrapper` single-arity that recurses `([id] [:rf/default id])`,
+      injecting the default the impl would otherwise resolve from the
+      carried scope — the rf2-vl5xsp floor), and
+    - `(or… :rf/default)` resolution floor
 
   in PRODUCTION source. `:rf/default` remains a perfectly legal EXPLICIT
   frame id (a migration may pick it, a test may register + select it) — the
@@ -91,6 +96,20 @@
   absence repair expressed through a `:keys` / `:or` binding."
   #":or\s*\{[^}]*:rf/default[^}]*\}")
 
+(def ^:private positional-default-re
+  "A `[:rf/default <sym>]` POSITIONAL floor — `:rf/default` synthesised as
+  the leading (frame) element of a vector literal that is then passed
+  positionally to a delegated/recursive call, ahead of one or more
+  further args. This is the rf2-vl5xsp shape: a `defwrapper` single-arity
+  whose recursion body is `[:rf/default id]`, injecting the default frame
+  the late-bound impl would otherwise resolve from the carried scope.
+
+  Requires `:rf/default` to be FOLLOWED by further content before the
+  closing `]` (a trailing arg), so a bare `[:rf/default]` — an explicit
+  one-element frame-id vector, not an absence repair of a frame ARGUMENT —
+  is not flagged. The `[^]\\n]+` tail keeps the match on one line."
+  #"\[\s*:rf/default\s+[^]\n]+\]")
+
 (defn- offending-lines
   "Return `[line-no line]` pairs in `content` that carry a live (non-
   comment, non-prose) `:rf/default` absence-repair floor."
@@ -102,13 +121,15 @@
                  (when (and (str/includes? code ":rf/default")
                             (not (backtick-quoted-mention? code))
                             (or (re-find or-default-re code)
-                                (re-find destructure-default-re code)))
+                                (re-find destructure-default-re code)
+                                (re-find positional-default-re code)))
                    [n (str/trim raw)]))))))
 
 (deftest no-rf-default-absence-repair-in-production-source
   (testing "no production source synthesises `:rf/default` from missing
-            frame context — neither `(or … :rf/default)` nor
-            `:or {frame-id :rf/default}`. EP-0002 carried invariant: absence
+            frame context — none of `(or … :rf/default)`,
+            `:or {frame-id :rf/default}`, or the positional
+            `[:rf/default <sym>]` floor. EP-0002 carried invariant: absence
             is `:rf.error/no-frame-context`, never an invented default
             (Appendix G — shift detection left into a CI lint)."
     (let [offenders

--- a/implementation/http/test/re_frame/http_interceptors_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_interceptors_cljs_test.cljs
@@ -50,6 +50,29 @@
     (let [chain (http-managed/interceptors-snapshot :rf/default)]
       (is (zero? (count chain))))))
 
+;; ---- 1a. rf2-vl5xsp — single-arity clear FAILS CLOSED under no scope ------
+;;
+;; The fixture pins an ambient `*current-frame* :rf/default`, which MASKS the
+;; old facade floor (the single-arity used to recurse `[:rf/default id]`,
+;; synthesising the default before delegating). Clear the ambient scope
+;; (`*current-frame* nil`) and assert the single-arity facade raises the
+;; always-on `:rf.error/no-frame-context` — proving the public surface fails
+;; closed and the :rf/default floor is gone.
+
+(deftest clear-http-interceptor-single-arity-fails-closed-under-no-scope
+  (testing "rf2-vl5xsp — single-arity `rf/clear-http-interceptor` under NO
+            ambient frame raises :rf.error/no-frame-context; it does NOT
+            synthesise a :rf/default target."
+    (binding [frame/*current-frame* nil]
+      (let [thrown (try (rf/clear-http-interceptor :some-id)
+                        nil
+                        (catch :default e e))]
+        (is (some? thrown)
+            "single-arity clear with no carried frame must throw")
+        (is (= :rf.error/no-frame-context
+               (:rf.error/id (ex-data thrown)))
+            "the throw is the always-on :rf.error/no-frame-context — no :rf/default floor")))))
+
 ;; ---- 2. registration order is preserved -----------------------------------
 
 (deftest registration-order-preserved

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -352,6 +352,33 @@
             "after clear, the second request did NOT carry the auth header")
         (finally (stop-server! srv))))))
 
+;; ---- 5a. rf2-vl5xsp — single-arity clear FAILS CLOSED under no scope ------
+;;
+;; The fixture pins an ambient `*current-frame* :rf/default`, which MASKS the
+;; old facade floor (`clear-http-interceptor` single-arity used to recurse
+;; `[:rf/default id]`, synthesising the default before delegating). This test
+;; clears the ambient scope (`*current-frame* nil`) so NO frame is carried,
+;; then invokes the single-arity facade and asserts it raises the always-on
+;; `:rf.error/no-frame-context` rather than silently clearing against a
+;; synthesised `:rf/default` chain. Proves the EP-0002 carried invariant is
+;; live on the public `rf/clear-http-interceptor` surface — the floor is gone.
+
+(deftest clear-http-interceptor-single-arity-fails-closed-under-no-scope
+  (testing "rf2-vl5xsp — single-arity `rf/clear-http-interceptor` under NO
+            ambient frame raises :rf.error/no-frame-context (fails closed);
+            it does NOT synthesise a :rf/default target. The facade must
+            delegate frame resolution to the impl's require-current-frame!,
+            never inject :rf/default from absence."
+    (binding [frame/*current-frame* nil]
+      (let [thrown (try (rf/clear-http-interceptor :some-id)
+                        nil
+                        (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? thrown)
+            "single-arity clear with no carried frame must throw")
+        (is (= :rf.error/no-frame-context
+               (:rf.error/id (ex-data thrown)))
+            "the throw is the always-on :rf.error/no-frame-context — no :rf/default floor")))))
+
 ;; ---- 6. re-registering an id replaces in place ---------------------------
 
 (deftest re-registering-id-replaces-slot


### PR DESCRIPTION
## Summary

EP-0002 wave-end review (rf2-rimcm3) found a residual :rf/default absence-repair floor on the public clear-http-interceptor surface. Fixes rf2-vl5xsp (P2 bug) and folds in rf2-tc5rxm (P3 hardening, same change-set).

## The floor

The core-http facade single-arity `([id] [:rf/default id])` hard-coded :rf/default as the frame target before delegating to the 2-arity. So `(rf/clear-http-interceptor :id)` under no scope silently cleared the :rf/default chain instead of failing closed — the impl's require-current-frame! single-arity (http_middleware) was unreachable because the facade injected the default first. This contradicts EP-0002 §Resolved Decisions and spec/002-Frames.md §Frame target resolution.

## Fix

- Facade single-arity now delegates (drops the positional :rf/default) so it reaches the impl's require-current-frame! fail-closed path. Frame resolution lives in the impl; the facade no longer synthesises a target from absence. :rf/default remains legal as an EXPLICIT caller-supplied id.

## Folded in (rf2-tc5rxm)

- Hardened the no-rf-default-floor lint: added a positional `[:rf/default <sym>]` detector (positional-default-re) so the recursion-arity floor shape this fixes cannot regress. The bare `[:rf/default]` explicit one-element vector, route/data vectors, and explicit `:frame :rf/default` keys are NOT flagged; comment/docstring-aware like the existing or/destructure checks.
- No-scope acceptance tests (JVM + CLJS): both http interceptor fixtures pin an ambient *current-frame* :rf/default that masked the floor. The new tests clear the ambient scope (*current-frame* nil) and assert single-arity clear raises :rf.error/no-frame-context — proving the public surface fails closed and the floor is gone.
- Fixed stale docstrings teaching the removed default (core_http.cljc:64,90; core.cljc:309,1738).

## Slice gates

- core JVM (clojure -M:test): 1036 tests, 0 failures (includes the hardened lint test)
- http JVM (clojure -M:test): 380 tests, 0 failures (includes the JVM no-scope acceptance test)
- http CLJS namespaces in isolation: 30 tests, 0 failures (includes the CLJS no-scope acceptance test)
- Full node test:cljs exits green (a trailing async-reject artifact in the unchanged http_cljs_test.cljs is pre-existing on main, identical there)

## Disjointness

Files touched (core_http.cljc, core.cljc facade alias/docstrings, the lint test, the two http interceptor tests) are disjoint from u1kdvg (PR #3665, events.cljc + router.cljc); any merge-time rebase will be clean.
