### PR TITLE
fix(xray): stamp :rf.event/origin on runtime dispatch + repoint simulate-nav preview at runtime-db (rf2-sh7qq2)

### DIFF
--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -304,10 +304,12 @@ list browse-all surface with hermetic Simulate-URL preview.
   ranking algorithm.
 - **Per-row hermetic Simulate-navigation preview** — clicking the
   expanded row's `Simulate navigation` button renders an inline
-  preview of `:on-match`'s app-db slot + the matched params, **without
-  calling the host's navigation fx**. The host's current-route slice
-  (at `[:rf/runtime :routing :current]`) is unchanged; this is a lens,
-  not a verb. The preview match is **row-local**: it matches the
+  preview of `:on-match`'s runtime-db route slice + the matched params,
+  **without calling the host's navigation fx**. The host's current-route
+  slice (the framework-owned runtime-db state at
+  `[:rf.runtime/routing :current]`, EP-0001 rf2-vzld77 — NOT app-db) is
+  unchanged; this is a lens, not a verb. The preview match is
+  **row-local**: it matches the
   SELECTED row's own compiled pattern against the entered URL — NOT the
   global rank winner (rf2-m9rx6). For overlapping routes (e.g. an exact
   route plus a lower-ranked splat fallback that both match
@@ -338,10 +340,11 @@ list browse-all surface with hermetic Simulate-URL preview.
 
 The Simulate-navigation preview MUST NOT call the host's navigation
 fx (`:rf/url-requested`, `:rf.route/navigate`, `history.pushState`,
-etc.). It MUST NOT write the host's current-route slice (at
-`[:rf/runtime :routing :current]`). The preview is a pure-data
+etc.). It MUST NOT write the host's current-route slice (the
+framework-owned runtime-db state at `[:rf.runtime/routing :current]`,
+EP-0001 rf2-vzld77). The preview is a pure-data
 projection: given a route-id + a URL, return what `:on-match`'s
-app-db slot would look like if that URL navigated. The host stays
+runtime-db route slice would look like if that URL navigated. The host stays
 where it is; Xray is a lens, not a verb. (This is the load-bearing
 distinction from the host's `:rf.route/navigate` fx — the Dynamic
 lens picks that up if the user runs it; the Static preview never
@@ -374,8 +377,9 @@ signal.
 
 - `:rf.xray/registered-routes` — shared with Static Routes.
 - `:rf.xray/current-route-slice` — composite over
-  `:rf.xray/target-frame-db` reading the current-route slice at
-  `[:rf/runtime :routing :current]`. Switching the L1 frame picker
+  `:rf.xray/target-frame-runtime-db` reading the current-route slice at
+  `[:rf.runtime/routing :current]` (EP-0001 rf2-vzld77 — the route slice
+  is framework-owned runtime-db state). Switching the L1 frame picker
   re-binds the lens.
 - `:rf.xray/cascades` — the shared cascade projection. The composite
   scans the focused cascade's trace events for the routing-emit.

--- a/tools/xray/src/day8/re_frame2_xray/panels/routing.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/routing.cljs
@@ -467,8 +467,9 @@
       sourced from `(rf/registrations :route)`. The Static Routes
       panel also reads this sub — process-global, frame-agnostic.
     - `:rf.xray/current-route-slice` — composite over the spine's
-      target-frame app-db reading the routing slice at
-      `[:rf/runtime :routing :current]`.
+      target-frame RUNTIME-DB reading the routing slice at
+      `[:rf.runtime/routing :current]` (EP-0001 rf2-vzld77 — the route
+      slice is framework-owned runtime-db state, not app-db).
     - `:rf.xray/routing-tab-data` — view-facing topology-plus-overlay
       composite (focused-epoch scoped). Carries `:silent?`, `:topology`,
       `:activity`, `:from-id`, `:to-id`, `:navigated?`, `:current`.

--- a/tools/xray/src/day8/re_frame2_xray/panels/routing_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/routing_helpers.cljc
@@ -296,7 +296,11 @@
 ;; given route — WITHOUT actually dispatching any framework event.
 ;; That preview is structural: the matched params (derived from the
 ;; row's pattern + the chosen URL), the registered `:on-match` event
-;; vector, and the expected app-db slot (`[:rf/runtime :routing :current ...]`).
+;; vector, and the expected runtime-db slot
+;; (`[:rf.runtime/routing :current ...]`). EP-0001 (rf2-vzld77) moved
+;; the framework-owned route slice OUT of app-db and into the target
+;; frame's runtime-db; the preview must name that path so a developer
+;; following it inspects the place real navigation actually writes.
 
 (defn simulate-navigation-preview
   "Pure data → data. Given a registered-routes map + a `route-id`, plus
@@ -304,21 +308,23 @@
   surface), return a preview map describing what a real navigation
   would carry:
 
-      {:route-id    <keyword>
-       :path        <string-or-nil>     ;; the route's registered pattern
-       :url         <string-or-nil>     ;; the simulated URL (or nil)
-       :matched?    <bool>              ;; did url match this route's pattern?
-       :params      <map-or-nil>        ;; matched params (nil when no url)
-       :on-match    <vector-or-nil>     ;; registered :on-match event vector
-       :db-slot     [:rf/runtime :routing :current]  ;; where the slice would land
-       :slot-shape  <map>               ;; preview of the routing :current slice
-                                        ;; that would land in app-db
-       :unknown?    <bool>}             ;; true when route-id not registered
+      {:route-id        <keyword>
+       :path            <string-or-nil>  ;; the route's registered pattern
+       :url             <string-or-nil>  ;; the simulated URL (or nil)
+       :matched?        <bool>           ;; did url match this route's pattern?
+       :params          <map-or-nil>     ;; matched params (nil when no url)
+       :on-match        <vector-or-nil>  ;; registered :on-match event vector
+       :runtime-db-slot [:rf.runtime/routing :current]  ;; where the slice lands
+       :slot-shape      <map>            ;; preview of the routing :current slice
+                                         ;; that would land in runtime-db
+       :unknown?        <bool>}          ;; true when route-id not registered
 
-  Hermetic — no dispatch, no fx, no app-db mutation. The shape mirrors
-  what the framework's `:rf.route/navigate` handler would write into
-  `[:rf/runtime :routing :current]` so the user can reason about the cascade without
-  triggering it.
+  Hermetic — no dispatch, no fx, no runtime-db / app-db mutation. The
+  shape mirrors what the framework's `:rf.route/navigate` handler would
+  write into the target frame's runtime-db at
+  `[:rf.runtime/routing :current]` (EP-0001 rf2-vzld77 — the route slice
+  is framework-owned runtime-db state, NOT app data) so the user can
+  reason about the cascade without triggering it.
 
   When `route-id` is not in `routes-map` returns `{:unknown? true
   :route-id route-id}` — the view surfaces this as an unregistered
@@ -347,15 +353,15 @@
            slot     (cond-> {:id route-id}
                       (some? path)   (assoc :path path)
                       (some? params) (assoc :params params))]
-       {:route-id   route-id
-        :path       path
-        :url        url
-        :matched?   (boolean matched?)
-        :params     params
-        :on-match   on-match
-        :db-slot    [:rf/runtime :routing :current]
-        :slot-shape slot
-        :unknown?   false})
+       {:route-id        route-id
+        :path            path
+        :url             url
+        :matched?        (boolean matched?)
+        :params          params
+        :on-match        on-match
+        :runtime-db-slot [:rf.runtime/routing :current]
+        :slot-shape      slot
+        :unknown?        false})
      {:route-id route-id
       :unknown? true})))
 

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -29,8 +29,9 @@
     the runtime landed. A full page refresh wipes both — the next
     `discover-app` tool call reports `:reason :runtime-not-preloaded`
     with a setup hint.
-  - `*current-origin*` — `^:dynamic` var holding the `:tags :origin`
-    value the runtime stamps onto every mutation it performs;
+  - `*current-origin*` — `^:dynamic` var holding the dispatch `:origin`
+    opt the runtime stamps onto every mutation it performs (surfacing on
+    the trace bus as the `:rf.event/origin` tag);
     `current-origin` (no earmuffs) is the plain read accessor that
     returns it. The default `:xray-mcp` is grandfathered from the
     original xray-mcp design; revising the default to a more accurate
@@ -129,8 +130,12 @@
 ;; Origin dynamic var
 ;; ---------------------------------------------------------------------------
 ;;
-;; Convention: every MCP-driven side-effect on the trace bus carries a
-;; `:tags :origin <server-name>` tag. The MCP server renders a
+;; Convention: every MCP-driven side-effect on the trace bus carries an
+;; `:rf.event/origin <server-name>` tag. The runtime threads the value as
+;; the framework dispatch `:origin` OPT (`{:origin <server-name>}`); the
+;; router's `emit-dispatched-trace` projects that onto the
+;; `:rf.event/dispatched` row's `[:tags :rf.event/origin]` (Spec 009
+;; §Origin). The MCP server renders a
 ;; `binding` form that wraps the runtime's accessor call with
 ;; `(binding [*current-origin* <server-name>] ...)`; mutating accessors
 ;; read the bound value (via `*current-origin*` / `current-origin`) when
@@ -147,8 +152,9 @@
 ;; async-tagging gap per Lock #4 / I6).
 
 (def ^:dynamic *current-origin*
-  "The `:tags :origin` value stamped on every mutation the runtime
-  performs on behalf of the MCP server. Defaults to `:xray-mcp`; the
+  "The dispatch `:origin` opt value stamped on every mutation the runtime
+  performs on behalf of the MCP server (surfacing on the trace bus as the
+  `:rf.event/origin` tag). Defaults to `:xray-mcp`; the
   server's `eval-cljs` tool re-binds it for the synchronous extent of
   the user-supplied form."
   :xray-mcp)
@@ -869,9 +875,12 @@
 ;; ---------------------------------------------------------------------------
 
 (defn dispatch!
-  "Tool: `dispatch`. Fire `event-vec` tagged `:origin *current-origin*`
-  (defaults to `:xray-mcp`). Returns `{:ok? true :event-id <kw>
-  :origin <kw> :mode <kw>}`.
+  "Tool: `dispatch`. Fire `event-vec` through the framework dispatch
+  OPTS map as `{:origin *current-origin*}` (defaults to `:xray-mcp`), so
+  the emitted `:rf.event/dispatched` trace carries `[:tags
+  :rf.event/origin]` and `get-trace-buffer {:origin <origin>}` can
+  isolate the tool-dispatched cascade. Returns `{:ok? true :event-id <kw>
+  :frame <id> :origin <kw> :mode <kw>}`.
 
   Modes: `:queued` (default — non-blocking `rf/dispatch`); `:sync`
   (the synchronous variant). The MCP server picks the mode at the
@@ -891,11 +900,20 @@
         :hint "Pass :frame :foo or register at least one frame."}
 
        :else
-       (let [tagged (with-meta event-vec {:tags {:origin origin}})]
+       ;; Pass the bound origin through the framework's dispatch OPTS map
+       ;; (`{:origin origin}`) — NOT as event-vector metadata. The router's
+       ;; `build-envelope` reads `:origin` off the opts map (defaulting to
+       ;; `:app`) and `emit-dispatched-trace` stamps it onto the
+       ;; `:rf.event/dispatched` trace as `[:tags :rf.event/origin]` (Spec
+       ;; 002 §Frame target resolution / Spec 009 §Origin). A `{:tags
+       ;; {:origin …}}` event-meta path was NEVER read by the framework, so
+       ;; tool-dispatched cascades were indistinguishable from app-origin
+       ;; ones on the trace bus.
+       (do
          (rf/with-frame fid
            (if sync?
-             (rf/dispatch-sync tagged)
-             (rf/dispatch tagged)))
+             (rf/dispatch-sync event-vec {:origin origin})
+             (rf/dispatch event-vec {:origin origin})))
          {:ok?      true
           :event-id (first event-vec)
           :frame    fid

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_nav.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/simulate_nav.cljs
@@ -7,12 +7,14 @@
   Per the parent epic decision (option (a): two-verbs-two-homes) and
   the findings doc §4.3 option (a): the per-row 'Simulate navigation'
   button is HERMETIC — NO real dispatch into the host app, NO fx, NO
-  app-db mutation. It surfaces a preview of what would land:
+  runtime-db / app-db mutation. It surfaces a preview of what would land:
 
     - matched params (derived from the row's pattern + the optional
       URL from the row's simulate-URL input);
     - the registered `:on-match` event vector;
-    - the expected app-db slot (`[:rf/runtime :routing :current ...]`) shape.
+    - the expected runtime-db route slice
+      (`[:rf.runtime/routing :current ...]`, EP-0001 rf2-vzld77 — the
+      framework-owned route slice lives in runtime-db, not app-db) shape.
 
   The hermetic posture is the spec point — Xray is a lens, not a
   remote control. Real navigation lives behind `:rf.route/navigate`
@@ -85,7 +87,8 @@
                         :font-style  "italic"
                         :margin-bottom "4px"}}
          "Hermetic preview — nothing is dispatched. Shows what would land "
-         "in app-db if the host navigated to this route."]
+         "in the framework's runtime-db route slice if the host navigated "
+         "to this route."]
         (field-row {:label  "Path"
                     :value  (or (:path pv) "—")
                     :mono?  true
@@ -110,8 +113,8 @@
                               "—")
                     :mono?  true
                     :testid "rf-xray-static-routes-sim-nav-on-match"})
-        (field-row {:label  "DB slot"
-                    :value  (pr-str (:db-slot pv))
+        (field-row {:label  "Runtime-db slot"
+                    :value  (pr-str (:runtime-db-slot pv))
                     :mono?  true
                     :testid "rf-xray-static-routes-sim-nav-db-slot"})
         (field-row {:label  "Slot shape"

--- a/tools/xray/test/day8/re_frame2_xray/panels/routing_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/routing_helpers_cljs_test.cljc
@@ -565,7 +565,8 @@
       (is (= :route/audit (:route-id pv)))
       (is (= "/admin/audit" (:path pv)))
       (is (= [:audit/load] (:on-match pv)))
-      (is (= [:rf/runtime :routing :current] (:db-slot pv)))
+      ;; EP-0001 (rf2-vzld77): the route slice lands in runtime-db, not app-db.
+      (is (= [:rf.runtime/routing :current] (:runtime-db-slot pv)))
       (is (false? (:matched? pv)))
       (is (nil? (:params pv)))
       (is (= {:id :route/audit :path "/admin/audit"} (:slot-shape pv))))))
@@ -578,7 +579,7 @@
       (is (false? (:unknown? pv)))
       (is (true? (:matched? pv)))
       (is (= "/cart" (:url pv)))
-      (is (= [:rf/runtime :routing :current] (:db-slot pv)))
+      (is (= [:rf.runtime/routing :current] (:runtime-db-slot pv)))
       (is (contains? (:slot-shape pv) :id))
       (is (= :route/cart (-> pv :slot-shape :id))))))
 

--- a/tools/xray/test/day8/re_frame2_xray/panels_e2e/static_routes_panel_e2e_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels_e2e/static_routes_panel_e2e_cljs_test.cljs
@@ -10,7 +10,13 @@
     2. A synthetic 3-route catalogue injected via
        `:rf.xray/set-registered-routes-override-for-test`.
     3. Simulate-URL `/articles` resolves a WINNER candidate without
-       mutating the host's `[:rf/runtime :routing :current]` slot (hermetic preview).
+       mutating the host's runtime-db route slice at
+       `[:rf.runtime/routing :current]` (hermetic preview). EP-0001
+       (rf2-vzld77) moved the framework-owned route slice into
+       runtime-db; the guard compares that slice (via
+       `rf/runtime-db-value`) so a future accidental navigation /
+       runtime-db write can't slip past by leaving only the retired
+       app-db path untouched.
     4. The `:rf.xray.static.routes/jump-to-dynamic` cross-link flips
        mode → `:dynamic` and opens the Dynamic Routing tab.
 
@@ -90,12 +96,16 @@
       {:install-host counter/install-and-init!}
       (fn []
         (install-override!)
-        ;; Snapshot the host's current-route slot BEFORE simulating. The
-        ;; counter fixture does not write [:rf/runtime :routing :current],
-        ;; so we expect nil here — and the same nil afterwards.
+        ;; Snapshot the host's REAL current-route slice BEFORE simulating.
+        ;; EP-0001 (rf2-vzld77): real navigation writes the route slice to
+        ;; the host frame's RUNTIME-DB at [:rf.runtime/routing :current],
+        ;; not app-db. The counter fixture does not navigate, so we expect
+        ;; nil here — and the same nil afterwards. Reading the runtime-db
+        ;; path (not the retired app-db path) is what makes the guard
+        ;; catch a future accidental runtime-db write.
         (let [counter-before    (e2e/sub-host [:counter/value])
-              host-route-before (some-> (rf/app-db-value :rf/default)
-                                        (get-in [:rf/runtime :routing :current]))]
+              host-route-before (some-> (rf/runtime-db-value :rf/default)
+                                        (get-in [:rf.runtime/routing :current]))]
           (rf/dispatch-sync [:rf.xray.static.routes/set-sim-url "/articles"]
                             {:frame :rf/xray})
           (let [data       (e2e/sub-xray [:rf.xray.static.routes/tab-data])
@@ -111,11 +121,11 @@
                 "winner is not :route/articles — rank cascade picked the wrong row")
             (is (true? (:winner? winner))
                 "winner candidate not flagged :winner? true"))
-          ;; Hermetic — the host's current-route slot is unchanged.
-          (let [host-route-after (some-> (rf/app-db-value :rf/default)
-                                          (get-in [:rf/runtime :routing :current]))]
+          ;; Hermetic — the host's real runtime-db route slice is unchanged.
+          (let [host-route-after (some-> (rf/runtime-db-value :rf/default)
+                                          (get-in [:rf.runtime/routing :current]))]
             (is (= host-route-before host-route-after)
-                "Simulate-URL was NOT hermetic — host current-route slot changed"))
+                "Simulate-URL was NOT hermetic — host runtime-db route slice changed"))
           ;; Sanity — the host's counter app-db is also undisturbed.
           (is (= counter-before (e2e/sub-host [:counter/value]))
               "Simulate-URL leaked into the host's counter slot"))))))

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -357,33 +357,67 @@
 ;; (6) Dispatch tagging — events stamped with `:origin :xray-mcp`.
 ;; ---------------------------------------------------------------------------
 
-(deftest dispatch-tags-event-with-current-origin
-  (testing "`dispatch!` attaches `{:tags {:rf.event/origin <current-origin>}}` as
-            event metadata so the framework's trace bus carries the
-            Xray-MCP tag (Lock #4 / I1)"
+(defn- dispatched-rows-with-origin
+  "Read the per-frame trace ring (the same surface `get-trace-buffer`
+  egresses) and return the `:rf.event/dispatched` rows whose
+  `[:tags :rf.event/origin]` equals `origin`. End-to-end witness: a
+  green here means the framework's dispatch opts → envelope → trace tag
+  path actually stamped the tag — NOT merely that the accessor echoed an
+  origin in its return map."
+  [origin]
+  (->> (:events (runtime/get-trace-buffer {:origin origin}))
+       (filterv #(= :rf.event/dispatched (:operation %)))))
+
+(deftest dispatch-stamps-rf-event-origin-tag-on-trace
+  (testing "`dispatch!` passes the bound origin through the framework
+            dispatch OPTS map, so the emitted `:rf.event/dispatched`
+            trace carries `[:tags :rf.event/origin]` and
+            `get-trace-buffer {:origin <origin>}` isolates the
+            tool-dispatched cascade (Lock #4 / I1)"
     (let [captured (atom nil)]
       (rf/reg-event-db :test/capture-meta
         (fn [db [_ marker]]
           (reset! captured marker)
           (assoc db :marker marker)))
-      ;; sync? so the dispatch completes before we check.
+      (trace-tooling/clear-trace-buffer! :rf/default)
+      ;; sync? so the dispatch completes (and its trace lands) before we read.
       (let [result (runtime/dispatch! [:test/capture-meta :ok] {:sync? true})]
         (is (true? (:ok? result)))
         (is (= :xray-mcp (:origin result))
             "result echoes the bound origin"))
-      (is (= :ok @captured)
-          "handler ran"))))
+      (is (= :ok @captured) "handler ran")
+      ;; The load-bearing assertion: read it back off the trace bus.
+      (let [rows (dispatched-rows-with-origin :xray-mcp)]
+        (is (seq rows)
+            "`get-trace-buffer {:origin :xray-mcp}` returns the dispatched cascade")
+        (is (every? #(= :xray-mcp (get-in % [:tags :rf.event/origin])) rows)
+            "every returned :rf.event/dispatched row carries [:tags :rf.event/origin] :xray-mcp")
+        (is (some #(= :test/capture-meta (first (get-in % [:tags :rf.event/v])))
+                  rows)
+            "the dispatched row is the one we fired"))
+      ;; Negative control: a different origin filter must NOT return it.
+      (is (empty? (dispatched-rows-with-origin :some-other-tool))
+          "the cascade is attributed to :xray-mcp, not an arbitrary origin"))))
 
 (deftest dispatch-rebinds-origin-via-eval-cljs-extent
-  (testing "a `binding` around `dispatch!` re-tags the dispatch — this
-            is the synchronous-extent contract `eval-cljs` rides
-            (Lock #4 / I6)"
+  (testing "a `binding` around `dispatch!` re-tags the dispatch on the
+            trace bus — this is the synchronous-extent contract
+            `eval-cljs` rides (Lock #4 / I6)"
     (rf/reg-event-db :test/origin-marker
       (fn [db _] db))
+    (trace-tooling/clear-trace-buffer! :rf/default)
     (binding [runtime/*current-origin* :test-rebind]
       (let [result (runtime/dispatch! [:test/origin-marker] {:sync? true})]
         (is (= :test-rebind (:origin result))
-            "dispatch carries the re-bound origin, not the default")))))
+            "dispatch carries the re-bound origin, not the default")))
+    (let [rows (dispatched-rows-with-origin :test-rebind)]
+      (is (seq rows)
+          "`get-trace-buffer {:origin :test-rebind}` returns the re-tagged cascade")
+      (is (every? #(= :test-rebind (get-in % [:tags :rf.event/origin])) rows)
+          "the rebound origin reaches the trace tag, not just the return map"))
+    ;; The default origin filter must NOT pick up the rebound dispatch.
+    (is (empty? (dispatched-rows-with-origin :xray-mcp))
+        "rebinding fully replaced the default origin on the trace tag")))
 
 (deftest dispatch-refuses-non-vector
   (testing "non-vector `event` shapes refuse structurally — the same

--- a/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/routes/panel_cljs_test.cljs
@@ -310,13 +310,13 @@
         (is (some? (find-by-testid tree "rf-xray-static-routes-sim-nav-on-match"))
             "preview shows registered :on-match")
         (is (some? (find-by-testid tree "rf-xray-static-routes-sim-nav-db-slot"))
-            "preview shows the [:rf/runtime :routing :current] db slot")
+            "preview shows the [:rf.runtime/routing :current] runtime-db slot")
         (is (some? (find-by-testid tree "rf-xray-static-routes-sim-nav-slot-shape"))
             "preview shows the slot shape that would land"))
       ;; The current slice MUST still be the baseline — no real navigation.
       (let [slice @(rf/subscribe [:rf.xray/current-route-slice])]
         (is (= :route/cart (:id slice))
-            "current slice unchanged — preview did NOT mutate app-db")))))
+            "current slice unchanged — preview did NOT mutate the runtime-db route slice")))))
 
 ;; ---- (8) cross-link to Dynamic Routing ----------------------------------
 


### PR DESCRIPTION
Fixes rf2-sh7qq2 (P2 correctness-review). Two findings in tools/xray, both premise-verified against current main (EP-0002) before fixing.

## Finding 1 — runtime dispatch origin never reached the trace bus

runtime/dispatch! wrapped the event in event-vector metadata under tags origin. The framework router does NOT read event metadata for origin; build-envelope takes the origin from the dispatch OPTS map and defaults it to app. So every Xray/MCP tool dispatch was indistinguishable from an ordinary app-origin dispatch, and get-trace-buffer filtered by origin missed the tool-dispatched cascade.

Fix:
- Pass the bound origin through the framework dispatch opts map for both queued and sync paths; frame targeting preserved via with-frame.
- The emitted rf.event/dispatched trace now carries the rf.event/origin tag equal to current-origin, and get-trace-buffer filtered by that origin returns the cascade.
- Rewrote the false-green runtime test: it now reads the dispatched cascade back off the trace buffer for the default and rebound-origin cases, plus negative controls. The previous test only checked the accessor return map.
- Corrected docstrings/comments that described the non-normative event-meta origin path.

## Finding 2 — Simulate-navigation preview projected the retired app-db route slot

EP-0001 (rf2-vzld77) moved the framework-owned route slice into runtime-db. The Static Routes Simulate-navigation preview still reported the retired app-db path, giving developers a wrong mental model of where a real navigation writes.

Fix:
- Renamed the preview key db-slot to runtime-db-slot and repointed it at the runtime-db path.
- Updated the view copy and field label to say runtime-db route slice.
- Fixed the unit and panel tests that pinned or named the retired path.
- The E2E hermeticity guard now compares the host frame's real runtime-db route slice via runtime-db-value, so a future accidental runtime-db write cannot pass by leaving only the retired app-db path untouched.

## Xray spec sync

Updated 016-Auxiliary-Panels.md (the Simulate-navigation hermetic-preview contract and the Dynamic Routing current-route-slice input) to name the runtime-db path. The dispatch-origin contract in API.md was already correct (rf.event/origin), so only the runtime-side docstrings needed correcting.

## Slice gates

- Focused node-test run of the four changed namespaces: 105 tests, 481 assertions, 0 failures, 0 errors.
- Full node-runtime CLJS suite: green (exit 0).
- xray-feature-gate: 2 pre-existing Windows/Playwright timing flakes unrelated to this change (static-mode chord never produced the Static surface; machine-epochs door track never booted) — neither touches dispatch-origin or the simulate-nav db-slot, and my 9 changed files include none of the feature_matrix / static-mode / machine-inspector surfaces. CI runs the authoritative Linux matrix.
