### PR TITLE
fix(examples): migrate example boots to the EP-0002 carried-frame invariant (rf2-3n9rvu)

### DIFF
--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -92,11 +92,26 @@
 
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in the Helix `frame-provider` so the
+;; `use-subscribe` hook and the render-time `(rf/frame-handle)` capture resolve
+;; to the app frame via React context. There is no `:rf/default` floor: a Helix
+;; tree rendered with NO provider observes the no-provider sentinel and any
+;; `use-subscribe` / `frame-handle` raises `:rf.error/no-frame-context`.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! helix-adapter/adapter)
-  (rf/dispatch-sync [:counter/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:counter/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
-    (.render @react-root ($ counter-app))))
+    (.render @react-root
+             ($ helix-adapter/frame-provider {:frame app-frame}
+                ($ counter-app)))))

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -351,4 +351,11 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
-    (.render @react-root ($ root-view))))
+    ;; EP-0002 (rf2-9o48ih): wrap the render in the Helix `frame-provider` so the
+    ;; `use-subscribe` hook + the render-time `(rf/frame-handle)` capture in
+    ;; `login-form` resolve to `:rf/default` via React context. With NO provider
+    ;; the tree observes the no-provider sentinel and those reads raise
+    ;; `:rf.error/no-frame-context` (there is no `:rf/default` floor).
+    (.render @react-root
+             ($ helix-adapter/frame-provider {:frame :rf/default}
+                ($ root-view)))))

--- a/examples/helix/process_monitor_helix/core.cljs
+++ b/examples/helix/process_monitor_helix/core.cljs
@@ -322,15 +322,29 @@
 ;; This matches the sibling notebook / dashboard_uix mount shape.
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in the Helix `frame-provider` so the
+;; `use-subscribe` hook and the render-time `(rf/frame-handle)` capture inside
+;; `monitor` (the tick-loop arm/stop dispatches) resolve to the app frame via
+;; React context. There is no `:rf/default` floor.
+(def app-frame :rf/default)
+
 (defn run []
   (rf/init! helix-adapter/adapter)
+  (rf/reg-frame app-frame {})
   ;; Seed synchronously so the very first paint shows a populated UI rather
   ;; than a flash of empty panes. This also arms the first tick; the `monitor`
   ;; component's mount `use-effect` re-arms (idempotently, via the
   ;; `:monitor/tick-gen` guard) so the loop is owned by the component
   ;; lifecycle from then on — unmount stops it (see `:monitor/stop`).
-  (rf/dispatch-sync [:monitor/initialise])
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:monitor/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (react-dom-client/createRoot (js/document.getElementById "app"))))
-    (.render @react-root ($ monitor))))
+    (.render @react-root
+             ($ helix-adapter/frame-provider {:frame app-frame}
+                ($ monitor)))))

--- a/examples/reagent-slim/counter_slim_and_fast/core.cljs
+++ b/examples/reagent-slim/counter_slim_and_fast/core.cljs
@@ -62,20 +62,35 @@
 
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch + the pure-CLJS SSR
+;; fixture render run under `with-frame`, and the client render is wrapped in
+;; a `frame-provider` so every in-tree `dispatch`/`subscribe` resolves to the
+;; app frame. Matches the canonical mount in examples/reagent/counter/core.cljs.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Slim adapter — the difference from `examples/reagent/counter` is
   ;; right here. Same `rf/init!` signature; different adapter Var.
   (rf/init! reagent-slim-adapter/adapter)
-  (rf/dispatch-sync [:counter/initialise])
-  ;; Bundle-isolation fixture, not app practice. The slim adapter's
-  ;; pure-CLJS SSR seam is the contract this build exists to prove; the
-  ;; sentinel exercise that makes that proof non-vacuous — and its
-  ;; sub-cache teardown — is isolated in
-  ;; `counter-slim-and-fast.bundle-isolation-fixture`. It runs before the
-  ;; client mount so the browser mount below starts from a clean
-  ;; sub-cache and owns the only live `[:counter/value]` reaction.
-  (fixture/prove-pure-cljs-ssr! [counter-app])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:counter/initialise])
+    ;; Bundle-isolation fixture, not app practice. The slim adapter's
+    ;; pure-CLJS SSR seam is the contract this build exists to prove; the
+    ;; sentinel exercise that makes that proof non-vacuous — and its
+    ;; sub-cache teardown — is isolated in
+    ;; `counter-slim-and-fast.bundle-isolation-fixture`. It runs before the
+    ;; client mount so the browser mount below starts from a clean
+    ;; sub-cache and owns the only live `[:counter/value]` reaction. The
+    ;; static render derefs `[:counter/value]`, so it runs inside the frame
+    ;; scope established above.
+    (fixture/prove-pure-cljs-ssr! [counter-app]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [counter-app])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [counter-app]])))

--- a/examples/reagent/flows/core.cljs
+++ b/examples/reagent/flows/core.cljs
@@ -296,11 +296,23 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from absence —
+;; register the app frame explicitly, seed under `with-frame`, and wrap the
+;; render in a `frame-provider` so the `reg-view`-injected `dispatch`/`subscribe`
+;; resolve to it (a no-provider render reads the no-provider sentinel and raises
+;; :rf.error/no-frame-context). The frame id is `:rf/default` — the same id the
+;; ns-load `reg-app-schema` is scoped to above.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:cart/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:cart/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [cart-app])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [cart-app]])))

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -491,4 +491,11 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [root-view])))
+    ;; EP-0002 (rf2-9o48ih): wrap the render in a `frame-provider` so the
+    ;; `reg-view`-injected `dispatch`/`subscribe` (and the login machine reads)
+    ;; resolve to `:rf/default` via React context. With NO provider a `reg-view`
+    ;; reads the no-provider sentinel and those calls raise
+    ;; `:rf.error/no-frame-context` (there is no `:rf/default` floor).
+    (rdc/render @react-root
+                [rf/frame-provider {:frame :rf/default}
+                 [root-view]])))

--- a/examples/reagent/long_running_work/core.cljs
+++ b/examples/reagent/long_running_work/core.cljs
@@ -99,11 +99,27 @@
 
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in a `frame-provider` so every
+;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
+;; canonical mount in examples/reagent/counter/core.cljs. The work-bench
+;; wrapper's `r/with-let` cleanup (views.cljs) dispatches `[:work/flow
+;; [:cancel]]` from within render scope, so it resolves to this frame via
+;; the provider above.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:app/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:app/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [views/root-view])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [views/root-view]])))

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -212,24 +212,33 @@
                the proven seed-in-flight pattern in
                tools/xray/testbeds/managed_http/core.cljs."
    :platforms #{:client}}
-  (fn fx-seed-long-request [_frame-ctx {:keys [request-id]}]
-    (http-registry/record-in-flight!
-      request-id nil
-      {:url      long-pending-url
-       ;; The abort-fn IS the in-flight request's cancellation hook. The
-       ;; live :rf.http/managed-abort handler resolves this handle by
-       ;; request-id and calls this fn with the abort `reason` (`:user`
-       ;; here). We clear the registry slot and dispatch the canonical
-       ;; :rf.http/aborted reply — the exact shape the live transport's
-       ;; abort path emits (Spec 014 §Failure categories) — back through
-       ;; default reply addressing to :counter/start-long.
-       :abort-fn (fn [reason]
-                   (http-registry/clear-in-flight! request-id)
-                   (rf/dispatch [:counter/start-long
-                                 {:rf/reply {:kind    :failure
-                                             :failure {:kind       :rf.http/aborted
-                                                       :request-id request-id
-                                                       :reason     reason}}}]))})
+  (fn fx-seed-long-request [frame-ctx {:keys [request-id]}]
+    ;; EP-0002 (rf2-9o48ih): the abort-fn fires later (when the LIVE
+    ;; :rf.http/managed-abort fx resolves this handle), so it carries no
+    ;; ambient frame of its own — a bare `rf/dispatch` inside it would raise
+    ;; :rf.error/no-frame-context. Capture the fx-context's frame and pass it
+    ;; explicitly on the deferred dispatch (Spec 002 §async fx capture the
+    ;; frame — the same `{:frame (:frame frame-ctx)}` pattern the boot example
+    ;; uses for its deferred reply).
+    (let [frame (:frame frame-ctx)]
+      (http-registry/record-in-flight!
+        request-id nil
+        {:url      long-pending-url
+         ;; The abort-fn IS the in-flight request's cancellation hook. The
+         ;; live :rf.http/managed-abort handler resolves this handle by
+         ;; request-id and calls this fn with the abort `reason` (`:user`
+         ;; here). We clear the registry slot and dispatch the canonical
+         ;; :rf.http/aborted reply — the exact shape the live transport's
+         ;; abort path emits (Spec 014 §Failure categories) — back through
+         ;; default reply addressing to :counter/start-long.
+         :abort-fn (fn [reason]
+                     (http-registry/clear-in-flight! request-id)
+                     (rf/dispatch [:counter/start-long
+                                   {:rf/reply {:kind    :failure
+                                               :failure {:kind       :rf.http/aborted
+                                                         :request-id request-id
+                                                         :reason     reason}}}]
+                                  {:frame frame}))}))
     nil))
 
 (rf/reg-event-fx :counter/start-long
@@ -302,11 +311,24 @@
 
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in a `frame-provider` so every
+;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
+;; canonical mount in examples/reagent/counter/core.cljs.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:counter/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:counter/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [counter-app])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [counter-app]])))

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -703,11 +703,19 @@
   ;; Install the demo override so `:rf.http/managed` calls route to the
   ;; in-process canned-stub fxs above. The example runs standalone — no
   ;; backend required.
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from absence —
+  ;; register the app frame explicitly, seed under `with-frame`, and wrap the
+  ;; render in a `frame-provider` so the `reg-view`-injected
+  ;; `dispatch`/`subscribe` resolve to it (a no-provider render reads the
+  ;; no-provider sentinel and raises :rf.error/no-frame-context).
   (rf/reg-frame :rf/default
     {:doc          "Nine-states demo frame."
      :fx-overrides {:rf.http/managed :nine-states.http/managed-demo}})
-  (rf/dispatch-sync [:nine-states.app/initialise])
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [:nine-states.app/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [root-view])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame :rf/default}
+                 [root-view]])))

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -314,10 +314,23 @@
 
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in a `frame-provider` so every
+;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
+;; canonical mount in examples/reagent/counter/core.cljs.
+(def app-frame :rf/default)
+
 (defn run []
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:notebook/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:notebook/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [notebook])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [notebook]])))

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -404,7 +404,13 @@
   ;; 012 §Redirects and guards). This is what makes the `:requires-auth`
   ;; tags on :realworld.user/settings / :realworld.editor/new / :realworld.editor/edit actually
   ;; protect those routes.
+  ;; EP-0002 (rf2-9o48ih + rf2-nn0jqa): the runtime never synthesises a frame
+  ;; from absence, and URL ownership is an EXPLICIT declaration — this frame
+  ;; carries `:url-bound? true` so it owns the browser URL (Spec 012
+  ;; §Multi-frame routing). The boot dispatch runs under `with-frame` and the
+  ;; render is wrapped in a `frame-provider` below.
   (rf/reg-frame :rf/default {:doc          "Realworld demo frame."
+                             :url-bound?   true
                              :interceptors [routing/auth-guard]
                              :fx-overrides {:rf.http/managed :realworld.demo/http-stub}})
   ;; Register the Bearer-auth interceptor at app boot. Order matters:
@@ -416,9 +422,15 @@
   ;; prefix before the route matcher sees the URL so :realworld/home (path "/")
   ;; matches.
   (routing/set-base-path! "/realworld")
-  (rf/dispatch-sync [:app/initialise])
-  (routing/install-router!)
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [:app/initialise])
+    ;; install-router! does the initial URL→slice sync (a dispatch-sync) and
+    ;; wires the popstate listener; the sync runs under the frame scope, and
+    ;; the listener captures the URL owner per dispatch (see routing.cljs).
+    (routing/install-router!))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [root-view])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame :rf/default}
+                 [root-view]])))

--- a/examples/reagent/realworld/routing.cljs
+++ b/examples/reagent/realworld/routing.cljs
@@ -20,7 +20,10 @@
             ;; Requiring re-frame.routing here triggers its load-time
             ;; hook + reg-sub registrations; without it, the rf/reg-route
             ;; calls below throw :rf.error/routing-artefact-missing.
-            [re-frame.routing]))
+            ;; Aliased so the popstate handler can resolve the URL owner via
+            ;; `routing/url-owner-frame-id` (Spec 012 §popstate drives the
+            ;; URL-owner frame) — the EP-0002 owner-targeted dispatch.
+            [re-frame.routing :as routing]))
 
 ;; ============================================================================
 ;; ROUTES
@@ -237,11 +240,24 @@
 ;; mirroring the `when-not @react-root` mount guard. We remove-then-add
 ;; the same Var so the registration is deduped even when the Var is
 ;; redefined on reload.
+;;
+;; EP-0002 (rf2-9o48ih + rf2-nn0jqa): the URL-change dispatch is targeted at
+;; the explicitly-declared URL owner resolved AT CALL TIME via
+;; `routing/url-owner-frame-id` (Spec 012 §popstate drives the URL-owner
+;; frame) — NOT a frameless `(rf/dispatch …)`, which would raise
+;; `:rf.error/no-frame-context`. This example serves from a `/realworld/`
+;; sub-path and strips it in `current-url`, so it keeps its own base-path-aware
+;; listener rather than the framework's `rf/install-history-listener!` (which
+;; reads the unstripped browser URL); the owner-targeting is the same contract
+;; that listener implements. The owner is the `:url-bound? true` demo frame
+;; registered in `core/run`.
 (defn- on-popstate [_]
-  (rf/dispatch [:rf.route/handle-url-change (current-url)]))
+  (when-let [owner (routing/url-owner-frame-id)]
+    (rf/dispatch [:rf.route/handle-url-change (current-url)] {:frame owner})))
 
 (defn install-router! []
   (.removeEventListener js/window "popstate" on-popstate)
   (.addEventListener js/window "popstate" on-popstate)
-  (rf/dispatch-sync [:rf.route/handle-url-change (current-url)]))
+  (when-let [owner (routing/url-owner-frame-id)]
+    (rf/dispatch-sync [:rf.route/handle-url-change (current-url)] {:frame owner})))
 

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -133,24 +133,6 @@
 ;; ROUTER WIRING
 ;; ============================================================================
 
-(defn current-url []
-  (str (.. js/window -location -pathname)
-       (.. js/window -location -search)
-       (.. js/window -location -hash)))
-
-;; Named handler so the listener install is idempotent: repeated `run`
-;; (shadow hot reload, or a co-required test host invoking run twice)
-;; must not stack duplicate popstate listeners, mirroring the
-;; `when-not @react-root` mount guard. We remove-then-add the same Var so
-;; the registration is deduped even when the Var is redefined on reload.
-(defn- on-popstate [_]
-  (rf/dispatch [:rf.route/handle-url-change (current-url)]))
-
-(defn install-router! []
-  (.removeEventListener js/window "popstate" on-popstate)
-  (.addEventListener js/window "popstate" on-popstate)
-  (rf/dispatch-sync [:rf.route/handle-url-change (current-url)]))
-
 ;; ============================================================================
 ;; MOUNT
 ;; ============================================================================
@@ -162,12 +144,38 @@
 ;; (`reg-view` defs `root-view`, which is what we render.)
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih + rf2-nn0jqa): under the carried invariant the runtime
+;; never synthesises a frame from absence, and URL ownership is an EXPLICIT
+;; declaration — a frame owns the browser URL only by carrying
+;; `:url-bound? true` (Spec 012 §Multi-frame routing). So the app frame:
+;;   1. is registered explicitly (`init!` installs only the adapter),
+;;   2. declares `:url-bound? true` so it owns the URL, and
+;;   3. seeds its app-db under `with-frame`.
+;; The render is wrapped in a `frame-provider` so every in-tree
+;; `dispatch`/`subscribe` resolves to it.
+;;
+;; The popstate listener is the framework's `rf/install-history-listener!`
+;; (Spec 012 §popstate drives the URL-owner frame) — NOT a hand-rolled
+;; frameless `(rf/dispatch [:rf.route/handle-url-change …])`. It resolves the
+;; URL owner AT POP TIME via `url-owner-frame-id` and dispatches the URL-change
+;; to THAT frame, so Back/Forward restores the owner's `:rf/route` slice. It
+;; also does the initial URL→slice sync and is idempotent (hot-reload safe).
+;; A hand-rolled frameless route dispatch would raise
+;; `:rf.error/no-frame-context`; the framework listener is the canonical,
+;; owner-resolving surface.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:routing.app/initialise])
-  (install-router!)
+  (rf/reg-frame app-frame {:doc "Routing demo frame." :url-bound? true})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:routing.app/initialise]))
+  ;; Framework popstate listener + initial URL sync, targeted at the URL owner.
+  (rf/install-history-listener!)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [root-view])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [root-view]])))

--- a/examples/reagent/seven_guis/cells/core.cljs
+++ b/examples/reagent/seven_guis/cells/core.cljs
@@ -316,11 +316,24 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in a `frame-provider` so every
+;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
+;; canonical mount in examples/reagent/counter/core.cljs.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:cells/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:cells/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [cells-grid])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [cells-grid]])))

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -231,11 +231,24 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in a `frame-provider` so every
+;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
+;; canonical mount in examples/reagent/counter/core.cljs.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:drawer/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:drawer/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [drawer-view])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [drawer-view]])))

--- a/examples/reagent/seven_guis/crud/core.cljs
+++ b/examples/reagent/seven_guis/crud/core.cljs
@@ -207,11 +207,24 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in a `frame-provider` so every
+;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
+;; canonical mount in examples/reagent/counter/core.cljs.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:crud/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:crud/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [crud-view])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [crud-view]])))

--- a/examples/reagent/seven_guis/flight_booker/core.cljs
+++ b/examples/reagent/seven_guis/flight_booker/core.cljs
@@ -212,11 +212,24 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in a `frame-provider` so every
+;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
+;; canonical mount in examples/reagent/counter/core.cljs.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:flight/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:flight/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [flight-booker])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [flight-booker]])))

--- a/examples/reagent/seven_guis/temperature/core.cljs
+++ b/examples/reagent/seven_guis/temperature/core.cljs
@@ -151,11 +151,24 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in a `frame-provider` so every
+;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
+;; canonical mount in examples/reagent/counter/core.cljs.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:temp/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:temp/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [temperature-converter])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [temperature-converter]])))

--- a/examples/reagent/seven_guis/timer/core.cljs
+++ b/examples/reagent/seven_guis/timer/core.cljs
@@ -189,11 +189,24 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in a `frame-provider` so every
+;; in-tree `dispatch`/`subscribe` resolves to the app frame. Matches the
+;; canonical mount in examples/reagent/counter/core.cljs.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:timer/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:timer/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [timer-view])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [timer-view]])))

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -110,10 +110,18 @@
   ;; Install the canned-failure override on the default frame so every
   ;; `:rf.http/managed` request resolves :failure. The chapter's
   ;; lockout scenario depends on three consecutive failures.
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from absence —
+  ;; register the app frame explicitly and wrap the render in a `frame-provider`
+  ;; so the `reg-view`-injected `dispatch`/`subscribe` (and the login machine
+  ;; reads) resolve to it (a no-provider render reads the no-provider sentinel
+  ;; and raises :rf.error/no-frame-context). The login machine is
+  ;; self-initialising, so there is no boot `dispatch-sync` to scope here.
   (rf/reg-frame :rf/default
     {:doc          "State-machines walkthrough demo frame."
      :fx-overrides {:rf.http/managed :auth.login/canned-failure}})
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [root-view])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame :rf/default}
+                 [root-view]])))

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -36,23 +36,42 @@
 (defn- current-path []
   (hash->path (.. js/window -location -hash)))
 
+;; EP-0002 (rf2-9o48ih + rf2-nn0jqa): under the carried invariant the runtime
+;; never synthesises a frame from absence, and URL ownership is an EXPLICIT
+;; declaration — the app frame is registered with `:url-bound? true` so it owns
+;; the URL (Spec 012 §Multi-frame routing), seeds under `with-frame`, and the
+;; render is wrapped in a `frame-provider`.
+(def app-frame :rf/default)
+
 ;; Named handler so the listener install is idempotent: repeated `run`
 ;; (shadow hot reload, or a co-required test host invoking run twice)
 ;; must not stack duplicate hashchange listeners, mirroring the
 ;; `when-not @react-root` mount guard below. We remove-then-add the same
 ;; Var so the registration is deduped even when the Var is redefined on
 ;; reload.
+;;
+;; EP-0002: the URL-change dispatch is targeted at the URL-owning `app-frame`
+;; with an explicit `{:frame app-frame}` — NOT a frameless `(rf/dispatch …)`,
+;; which would raise `:rf.error/no-frame-context`. This example is HASH-based
+;; (`#/active`), so it keeps its own `hashchange` listener rather than the
+;; framework's popstate-driven `rf/install-history-listener!`; targeting the
+;; owner frame is the same contract that listener implements (Spec 012
+;; §popstate drives the URL-owner frame).
 (defn- on-hashchange [_]
-  (rf/dispatch [:rf.route/handle-url-change (current-path)]))
+  (rf/dispatch [:rf.route/handle-url-change (current-path)] {:frame app-frame}))
 
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:todo/initialise])
-  (rf/dispatch-sync [:rf.route/handle-url-change (current-path)])
+  (rf/reg-frame app-frame {:doc "TodoMVC demo frame." :url-bound? true})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:todo/initialise])
+    (rf/dispatch-sync [:rf.route/handle-url-change (current-path)]))
   (.removeEventListener js/window "hashchange" on-hashchange)
   (.addEventListener js/window "hashchange" on-hashchange)
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [views/root-view])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [views/root-view]])))

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -76,10 +76,25 @@
 
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in a `frame-provider` so every
+;; in-tree `dispatch`/`subscribe` resolves to the app frame. The frame id is
+;; `:rf/default` — the same id `schema.cljs` scopes its `reg-app-schema`
+;; registration to. Matches the canonical mount in
+;; examples/reagent/counter/core.cljs.
+(def app-frame :rf/default)
+
 (defn run []
   (rf/init! reagent-adapter/adapter)
-  (rf/dispatch-sync [:ws.app/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:ws.app/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-    (rdc/render @react-root [views/root-view])))
+    (rdc/render @react-root
+                [rf/frame-provider {:frame app-frame}
+                 [views/root-view]])))

--- a/examples/reagent/websocket/messages.cljs
+++ b/examples/reagent/websocket/messages.cljs
@@ -110,10 +110,19 @@
 (defn- deliver-to-actor!
   "Dispatch an inbound transport event into the spawned actor. The
    actor's machine handler translates the event into a parent-bound
-   `[:ws/connection [:ws/<kind> ...]]` dispatch."
-  [actor-id kind payload]
+   `[:ws/connection [:ws/<kind> ...]]` dispatch.
+
+   EP-0002 (rf2-9o48ih): inbound deliveries fire from the mock transport's
+   `later` callback — a detached `setTimeout` in async (browser) mode that
+   carries NO ambient frame, so a bare `rf/dispatch` here would raise
+   `:rf.error/no-frame-context`. The caller (`mock-socket-for-actor`) is
+   created inside the `:open-socket` action — i.e. under the actor's drain
+   frame — so it captures that frame's `dispatch` operation and threads it in
+   here. Passing the captured `dispatch` honours the carried invariant across
+   the async boundary (Spec 002 §frame-handle)."
+  [dispatch actor-id kind payload]
   (when actor-id
-    (rf/dispatch [actor-id [kind payload]])))
+    (dispatch [actor-id [kind payload]])))
 
 (defn- mock-encode-auth-reply [token]
   ;; A real server would validate the JWT; the mock accepts any
@@ -129,7 +138,14 @@
    and `:request` (→ correlated reply via the `:type :reply` echo)."
   [actor-id _url _auth-token]
   (let [id   (next-mock-socket-id)
-        open? (atom true)]
+        open? (atom true)
+        ;; EP-0002 (rf2-9o48ih): this fn runs inside the `:open-socket` action
+        ;; — i.e. under the actor's drain frame — so capture that frame's
+        ;; `dispatch` now and thread it into every (async, `later`-deferred)
+        ;; inbound delivery below. The detached `setTimeout` callback carries
+        ;; no ambient frame; the captured operation does (Spec 002
+        ;; §frame-handle).
+        dispatch (:dispatch (rf/frame-handle))]
     (swap! mock-server-state assoc-in [:sockets id]
            {:actor-id actor-id
             :open?    open?})
@@ -142,7 +158,7 @@
                   ;; Auth — produce :auth-ok / :auth-failed on the same
                   ;; channel after a microtask.
                   (later
-                    #(deliver-to-actor! actor-id :received
+                    #(deliver-to-actor! dispatch actor-id :received
                                         (mock-encode-auth-reply (:token msg))))
 
                   :request
@@ -151,7 +167,7 @@
                   ;; request-id round-trips so the connection machine's
                   ;; request-reply correlation lights up.
                   (later
-                    #(deliver-to-actor! actor-id :received
+                    #(deliver-to-actor! dispatch actor-id :received
                                         {:type       :reply
                                          :request-id (:request-id msg)
                                          :ok         true
@@ -162,7 +178,7 @@
                   ;; the example demonstrates server-pushed events
                   ;; arriving after the subscribe round-trip.
                   (later
-                    #(deliver-to-actor! actor-id :received
+                    #(deliver-to-actor! dispatch actor-id :received
                                         {:type :push
                                          :topic (:topic msg)
                                          :note  "subscribed"}))
@@ -174,7 +190,7 @@
               (reset! open? false)
               (swap! mock-server-state update :sockets dissoc id)
               (later
-                #(deliver-to-actor! actor-id :closed {:code 1000})))}))
+                #(deliver-to-actor! dispatch actor-id :closed {:code 1000})))}))
 
 ;; Exposed seams the views (and the headless tests) use to drive the
 ;; mock without dispatching through the actor.
@@ -184,30 +200,43 @@
    a running drain (i.e. test bodies, view click handlers). In sync
    mode it uses `dispatch-sync` so the chain runs to fixed point
    before returning; in async mode it falls back to the queued
-   `dispatch`."
-  [actor-id kind payload]
+   `dispatch`.
+
+   EP-0002 (rf2-9o48ih): a view click handler fires outside React render
+   scope and outside any drain, so the caller must supply a frame-bound
+   `dispatch` / `dispatch-sync` pair (the operations a `reg-view`-injected
+   `dispatch` / a captured `(rf/frame-handle)` provides). A bare ambient
+   `rf/dispatch` here would raise `:rf.error/no-frame-context`."
+  [{:keys [dispatch dispatch-sync]} actor-id kind payload]
   (when actor-id
     (if (:sync? @mock-server-state)
-      (rf/dispatch-sync [actor-id [kind payload]])
-      (rf/dispatch       [actor-id [kind payload]]))))
+      (dispatch-sync [actor-id [kind payload]])
+      (dispatch      [actor-id [kind payload]]))))
 
 (defn send-server-push!
   "Deliver a synthetic server push to every live mock socket. Used by
    the headless tests and the example's 'Trigger server push' button
-   to demonstrate the inbound translation path."
-  [body]
+   to demonstrate the inbound translation path.
+
+   `handle` is a `(rf/frame-handle)` operation bundle carrying the caller's
+   frame (the view passes its injected handle; tests pass an explicit one) —
+   EP-0002 requires the deferred dispatch carry a frame across the
+   click-handler / async boundary."
+  [handle body]
   (doseq [[_ {:keys [actor-id open?]}] (:sockets @mock-server-state)]
     (when @open?
-      (deliver-external! actor-id :received body))))
+      (deliver-external! handle actor-id :received body))))
 
 (defn simulate-disconnect!
   "Force every live mock socket closed, triggering the reconnect
-   cascade in the parent. Used by the 'Drop connection' button."
-  []
+   cascade in the parent. Used by the 'Drop connection' button. `handle`
+   is the caller's `(rf/frame-handle)` operation bundle (see
+   `send-server-push!`)."
+  [handle]
   (doseq [[_ {:keys [actor-id open?]}] (:sockets @mock-server-state)]
     (when @open?
       (reset! open? false)
-      (deliver-external! actor-id :closed {:code 1006 :reason "simulated"}))))
+      (deliver-external! handle actor-id :closed {:code 1006 :reason "simulated"}))))
 
 ;; ============================================================================
 ;; THE SOCKET ACTOR — :websocket/socket

--- a/examples/reagent/websocket/views.cljs
+++ b/examples/reagent/websocket/views.cljs
@@ -80,7 +80,14 @@
   (let [connected?    @(subscribe [:ws/connected?])
         reconnecting? @(subscribe [:ws/reconnecting?])
         failed?       @(subscribe [:ws/failed?])
-        any-active?   (or connected? reconnecting?)]
+        any-active?   (or connected? reconnecting?)
+        ;; EP-0002 (rf2-9o48ih): the Drop button calls a module-level
+        ;; mock-server seam that dispatches outside any drain / render scope.
+        ;; Capture this view's frame handle at render time and hand it to the
+        ;; seam so the deferred dispatch carries the frame (Spec 002
+        ;; §frame-handle) — a bare ambient dispatch would raise
+        ;; :rf.error/no-frame-context.
+        handle        (rf/frame-handle)]
     [:div.lifecycle
      [:button {:data-testid "ws-connect"
                :on-click    #(dispatch [:ws/connection
@@ -90,7 +97,7 @@
                :disabled    any-active?}
       "Connect"]
      [:button {:data-testid "ws-drop"
-               :on-click    #(websocket.messages/simulate-disconnect!)
+               :on-click    #(websocket.messages/simulate-disconnect! handle)
                :disabled    (not connected?)}
       "Drop connection (transport error)"]
      [:button {:data-testid "ws-disconnect"
@@ -139,7 +146,12 @@
                   client server-pushed event)."}
           demo-buttons []
   (let [connected?  @(subscribe [:ws/connected?])
-        last-reply  @(subscribe [:messages/last-reply])]
+        last-reply  @(subscribe [:messages/last-reply])
+        ;; EP-0002 (rf2-9o48ih): the server-push button calls a module-level
+        ;; mock-server seam that dispatches outside any drain / render scope.
+        ;; Capture this view's frame handle and pass it so the deferred
+        ;; dispatch carries the frame (see `lifecycle-buttons`).
+        handle      (rf/frame-handle)]
     [:div.demo-buttons
      [:button {:data-testid "ws-subscribe"
                :on-click    #(dispatch [:ws.app/subscribe-demo])
@@ -151,6 +163,7 @@
       "Request-reply (hello)"]
      [:button {:data-testid "ws-server-push"
                :on-click    #(websocket.messages/send-server-push!
+                              handle
                               {:type :push
                                :note "Manual server push"
                                :at   (.toISOString (js/Date.))})

--- a/examples/uix/counter_uix/core.cljs
+++ b/examples/uix/counter_uix/core.cljs
@@ -64,11 +64,27 @@
 
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in the UIx `frame-provider` so the
+;; `use-subscribe` hook and the render-time `(rf/frame-handle)` capture resolve
+;; to the app frame via React context. There is no `:rf/default` floor: a UIx
+;; tree rendered with NO provider observes the no-provider sentinel and any
+;; `use-subscribe` / `frame-handle` raises `:rf.error/no-frame-context`.
+(def app-frame :rf/default)
+
 (defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! uix-adapter/adapter)
-  (rf/dispatch-sync [:counter/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:counter/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
-    (uix-dom/render-root ($ counter-app) @react-root)))
+    (uix-dom/render-root
+      ($ uix-adapter/frame-provider {:frame app-frame}
+         ($ counter-app))
+      @react-root)))

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -278,10 +278,26 @@
 ;; This matches the sibling notebook / process_monitor_helix mount shape.
 (defonce react-root (atom nil))
 
+;; EP-0002 (rf2-9o48ih): under the carried invariant the runtime never
+;; synthesises a frame from absence — an app must establish its frame
+;; explicitly. `init!` installs the adapter (it does NOT create the frame),
+;; `reg-frame` registers the app frame, the boot dispatch runs under
+;; `with-frame`, and the render is wrapped in the UIx `frame-provider` so the
+;; `use-subscribe` hook and the render-time `(rf/frame-handle)` capture resolve
+;; to the app frame via React context. There is no `:rf/default` floor: a UIx
+;; tree rendered with NO provider observes the no-provider sentinel and any
+;; `use-subscribe` / `frame-handle` raises `:rf.error/no-frame-context`.
+(def app-frame :rf/default)
+
 (defn run []
   (rf/init! uix-adapter/adapter)
-  (rf/dispatch-sync [:dashboard/initialise])
+  (rf/reg-frame app-frame {})
+  (rf/with-frame app-frame
+    (rf/dispatch-sync [:dashboard/initialise]))
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
-    (uix-dom/render-root ($ dashboard) @react-root)))
+    (uix-dom/render-root
+      ($ uix-adapter/frame-provider {:frame app-frame}
+         ($ dashboard))
+      @react-root)))

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -362,4 +362,12 @@
   (when (exists? js/document)
     (when-not @react-root
       (reset! react-root (uix-dom/create-root (js/document.getElementById "app"))))
-    (uix-dom/render-root ($ root-view) @react-root)))
+    ;; EP-0002 (rf2-9o48ih): wrap the render in the UIx `frame-provider` so the
+    ;; `use-subscribe` hook + the render-time `(rf/frame-handle)` capture in
+    ;; `login-form` resolve to `:rf/default` via React context. With NO provider
+    ;; the tree observes the no-provider sentinel and those reads raise
+    ;; `:rf.error/no-frame-context` (there is no `:rf/default` floor).
+    (uix-dom/render-root
+      ($ uix-adapter/frame-provider {:frame :rf/default}
+         ($ root-view))
+      @react-root)))

--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -313,8 +313,9 @@
           (is (some? pre-socket))
           ;; Simulate a transport-level drop. The mock fires :ws/closed
           ;; (with the source-socket-id) into the actor, which forwards
-          ;; to the parent.
-          (messages/simulate-disconnect!)
+          ;; to the parent. EP-0002 (rf2-9o48ih): the seam now takes a
+          ;; frame-handle so its deferred dispatch carries the frame.
+          (messages/simulate-disconnect! (rf/frame-handle f))
           (let [s (snapshot (rf/runtime-db-value f))]
             (is (= :reconnecting (:state s))
                 (str "expected :reconnecting got " (:state s)))
@@ -513,7 +514,8 @@
                                          :auth-token "demo"}]]
                           {:frame f})
         (let [pre-count (count (get-in (rf/app-db-value f) [:messages :received]))]
-          (messages/send-server-push! {:type :push
+          (messages/send-server-push! (rf/frame-handle f)
+                                      {:type :push
                                        :note "from the server"})
           (let [post (get-in (rf/app-db-value f) [:messages :received])]
             (is (= (inc pre-count) (count post)))


### PR DESCRIPTION
## What

EP-0002 review follow-up (rf2-3n9rvu). EP-0002 removed the `:rf/default` floor: the runtime never synthesises a frame from absence, so an app must establish its frame explicitly or every dispatch / subscribe / use-subscribe / frame-handle raises `:rf.error/no-frame-context`. The example migration named in EP §11 was substantially incomplete — the candidate examples (and several siblings the same defect hit) booted with a bare `init!` then frameless `dispatch-sync` and rendered with no `reg-frame` / `with-frame` / `frame-provider`. Build-only CI masked the boot-fail (examples are test-free, rf2-8cevm).

## Migration

Boot migrated to the canonical `examples/reagent/counter` shape — `reg-frame app-frame` then seed under `with-frame` then render wrapped in `frame-provider` — per substrate idiom.

- Reagent (counter-pattern verbatim): notebook, long_running_work, managed_http_counter, counter_slim_and_fast, websocket, flows, nine_states, state_machine_walkthrough, login, and the six seven_guis (cells, circle_drawer, crud, flight_booker, temperature, timer).
- UIx / Helix (render wrapped in the substrate `frame-provider` so the `use-subscribe` hook + render-time `frame-handle` capture resolve via React context — matches the adapter testbeds, the canonical mount): counter_uix, dashboard_uix, login_uix, counter_helix, process_monitor_helix, login_helix.

## Popstate / hashchange decision

The review flagged a genuine architecture fork. Resolved from the spec: the routing subsystem IS designed for URL-owner-resolved route dispatch (Spec 012 §popstate drives the URL-owner frame; URL ownership is an explicit `:url-bound?` declaration, EP-0002 rf2-nn0jqa). So NOT a forced frame-handle:

- routing/core.cljs replaces its hand-rolled frameless `install-router!` with the framework `rf/install-history-listener!` (targets `url-owner-frame-id` at pop time); frame declares `:url-bound? true`.
- todomvc (hash-based, so the popstate-driven framework listener does not fit) keeps its own hashchange listener but targets the `:url-bound?` owner frame explicitly.
- realworld serves from a `/realworld/` sub-path (base-path strip), so it keeps its base-path-aware listener but targets `routing/url-owner-frame-id` and declares `:url-bound? true`.

## Async-loss callback sites

The EP-0002 "ambient lookup does not survive setTimeout / onmessage" case, given a captured frame:

- managed_http_counter abort-fn dispatches with `{:frame (:frame frame-ctx)}`.
- websocket mock-server seams (deliver-to-actor!, send-server-push!, simulate-disconnect!, deliver-external!) take a captured frame / handle; the actor captures `(rf/frame-handle)` in `:open-socket`, views pass their render-time handle. `websocket_cljs_test.cljs` updated for the new seam signatures.

## Beyond the candidate list

The same defect hit login (Reagent), login_uix, login_helix, flows, nine_states, state_machine_walkthrough, and realworld — fixed here for completeness (the migration is otherwise still "substantially incomplete").

## Verification

All 28 affected example builds compile clean (`shadow-cljs compile`, 0 warnings). node-test: the websocket suite passes; the one remaining failure is the pre-existing, unrelated http `cljs-fetch` `:rf.error/no-frame-context` async reject already tracked by rf2-4775uc. No per-example tests added (examples are test-free by policy).

## Deferred

SSR examples (ssr, ssr_streaming) are NOT migrated here — filed as rf2-9ba11z. Their `hydrate!` client boot path is a distinct subsystem (`:frame` now required, `:client`-platform frame, payload frame-id validation) needing the hydration contract applied carefully, not the plain recipe.
