### PR TITLE
fix(ci+mcp-conformance): route epoch source to live redaction gate + derive story-mcp wire-vocab inventory (rf2-ribu5a)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -226,7 +226,36 @@ else
         adapter_testbed_smokes=true
         story_xray_browser=true
         ;;
-      implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/epoch/*|implementation/security/*|implementation/deps.edn)
+      implementation/epoch/*)
+        # rf2-ribu5a — false-green fix. Epoch is the ONLY per-feature
+        # artefact wired into a LIVE MCP conformance gate: the
+        # re-frame2-pair live fixture
+        # (skills/re-frame2-pair/tests/fixture/deps.edn) resolves
+        # `day8/re-frame2-epoch` as a :local/root, and the hermetic
+        # `mcp-conformance-re-frame2-pair` job's INNER_TESTS include
+        # `live-re-frame2-pair-redaction.cjs` — the egress-protection
+        # regression net for the pull-mode epoch tools (trace-window /
+        # watch-epochs) that asserts a declared-sensitive epoch is
+        # WHOLE-DROPPED gate-OFF / shipped gate-ON across the MCP wire
+        # (rf2-q4o83 / rf2-5613h). That job is gated on mcp_live='true'.
+        # Folded into the generic per-feature bucket below, an
+        # `implementation/epoch/src/...` change set NEITHER mcp_live NOR
+        # mcp_conformance — so a PR that broke the epoch egress/redaction
+        # contract merged GREEN at PR time (a conformance false-green on
+        # a DATA-LEAK guard), surfacing only in the nightly cron. Split
+        # out here so epoch source changes arm the live redaction gate.
+        # All the generic per-feature gates still fire (epoch is not in
+        # the scaffold, so no template_expensive; not baked into the SCI
+        # bundle, so no playground).
+        implementation_jvm=true
+        cljs_node_test=true
+        cljs_browser=true
+        cljs_prod=true
+        bundle_isolation=true
+        mcp_conformance=true
+        mcp_live=true
+        ;;
+      implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/security/*|implementation/deps.edn)
         # rf2-8jz9t — adapter_testbed_smokes NOT fired here. Per-feature
         # artefact changes are covered by their own JVM + CLJS unit
         # suites (implementation_jvm, cljs_browser, cljs_prod) and by
@@ -250,9 +279,10 @@ else
         # template_expensive for an implementation/schemas/* change so
         # jvm-tools-template runs the emitted-app compile at PR time.
         # (The other per-feature artefacts here — machines/routing/flows/
-        # http/ssr/ssr-ring/epoch — are NOT pulled into today's scaffold,
+        # http/ssr/ssr-ring — are NOT pulled into today's scaffold,
         # so they do not arm template_expensive; add them here if a future
-        # scaffold flag wires one in.)
+        # scaffold flag wires one in. epoch has its own case above,
+        # rf2-ribu5a.)
         case "$file" in
           implementation/schemas/*) template_expensive=true ;;
         esac

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -258,6 +258,73 @@ test('Other per-feature artefact (machines) does NOT arm template_expensive — 
   assert.equal(result.template_expensive, 'false');
 });
 
+// rf2-ribu5a — epoch live-MCP-redaction routing false-green fix. The
+// re-frame2-pair live fixture resolves day8/re-frame2-epoch as a
+// :local/root, and the hermetic mcp-conformance-re-frame2-pair job's
+// INNER_TESTS include live-re-frame2-pair-redaction.cjs (the
+// egress-protection regression for the pull-mode epoch tools
+// trace-window / watch-epochs). That job is gated on mcp_live='true'.
+// Folded into the generic per-feature bucket, an
+// implementation/epoch/src/... change set NEITHER mcp_live NOR
+// mcp_conformance — so a PR breaking the epoch egress/redaction contract
+// merged GREEN at PR time (a false-green on a data-leak guard). These
+// assertions lock the dedicated epoch case arming the live gate, while
+// keeping the OTHER per-feature artefacts off it (they have no live MCP
+// dependency) so the scope stays disciplined.
+
+test('implementation/epoch/src change arms mcp_live + mcp_conformance (live redaction gate) (rf2-ribu5a)', () => {
+  const result = classify('implementation/epoch/src/re_frame/epoch.cljc');
+  assert.equal(
+    result.mcp_live,
+    'true',
+    'an epoch source change must run the live re-frame2-pair redaction gate (its only PR-time epoch egress verifier)',
+  );
+  assert.equal(result.mcp_conformance, 'true');
+});
+
+test('implementation/epoch change still arms the generic per-feature gates (regression) (rf2-ribu5a)', () => {
+  const result = classify('implementation/epoch/src/re_frame/epoch.cljc');
+  assert.equal(result.implementation_jvm, 'true');
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'true');
+  assert.equal(result.cljs_prod, 'true');
+  assert.equal(result.bundle_isolation, 'true');
+});
+
+test('implementation/epoch is NOT in the scaffold — does NOT arm template_expensive (rf2-ribu5a)', () => {
+  const result = classify('implementation/epoch/src/re_frame/epoch.cljc');
+  assert.equal(result.template_expensive, 'false');
+});
+
+test('Other per-feature artefacts (machines/flows/ssr) do NOT arm mcp_live — no live MCP dep (rf2-ribu5a scope)', () => {
+  for (const file of [
+    'implementation/machines/src/re_frame/machines.cljc',
+    'implementation/flows/src/re_frame/flows.cljc',
+    'implementation/ssr/src/re_frame/ssr.cljc',
+  ]) {
+    const result = classify(file);
+    assert.equal(
+      result.mcp_live,
+      'false',
+      `${file} has no live MCP fixture dependency; it must NOT arm mcp_live`,
+    );
+    assert.equal(result.mcp_conformance, 'false', `${file} must NOT arm mcp_conformance`);
+  }
+});
+
+test('Epoch live-redaction job (mcp-conformance-re-frame2-pair) is gated on mcp_live (rf2-ribu5a)', () => {
+  // Workflow-shape pin: the job that runs live-re-frame2-pair-redaction.cjs
+  // must be job-level gated on the mcp_live output the classifier now
+  // arms for epoch source changes. If the gate output is renamed, this
+  // and the classifier routing must move together.
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'mcp-conformance-re-frame2-pair');
+  assert.match(block, /needs: detect_changed_surfaces/);
+  assert.match(
+    block,
+    /if: needs\.detect_changed_surfaces\.outputs\.mcp_live == 'true'/,
+  );
+});
+
 test('tools/template change still arms template_expensive (regression) (rf2-jdj17.1)', () => {
   const result = classify('tools/template/src/day8/re_frame2_template/hooks.clj');
   assert.equal(result.template_expensive, 'true');

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
@@ -115,24 +115,46 @@
 ;; others. Centralised here so "the files story-mcp ships" has one home.
 ;; ---------------------------------------------------------------------------
 
+;; rf2-ribu5a — filesystem-derived, NOT hand-maintained. The previous
+;; hand list ran through `recorder.cljc` but silently omitted
+;; `dedup.cljc` (emits the cross-MCP `:rf.mcp/dedup-table` marker) and
+;; `cursor.cljc` (routes the cross-MCP `:rf.mcp/cursor-stale` marker) —
+;; exactly the drift these absence-tripwires exist to prevent,
+;; reproduced inside the gate. A dropped/added tool file could escape
+;; the generic near-miss / uncontracted-marker sweeps because the
+;; inventory was edited by hand and fell behind the directory. Deriving
+;; the set from the directory listing makes "the files story-mcp ships"
+;; literally the files on disk: a new tool file is swept the moment it
+;; lands, with zero list maintenance.
+(def story-mcp-tools-dir
+  "Repo-relative path to story-mcp's `tools/` source directory — the
+  single home of the per-category tool handlers plus the shared
+  registry / wire-pipeline / result / args / egress / cljs-resolve /
+  schemas plumbing. `story-mcp-tool-source-files` is derived from a
+  filesystem listing of `*.cljc` files here."
+  "tools/story-mcp/src/re_frame/story_mcp/tools")
+
 (def story-mcp-tool-source-files
-  "The story-mcp `tools/*.cljc` source files — the per-category tool
-  handlers plus the registry / wire-pipeline / result / args / egress
-  / cljs-resolve / schemas plumbing they share. This is the surface
-  the slot-name and indicator near-miss tripwires grep (the slots
-  live in the tool bodies, not the wire framing)."
-  ["tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc"
-   "tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc"
-   "tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc"
-   "tools/story-mcp/src/re_frame/story_mcp/tools/args.cljc"
-   "tools/story-mcp/src/re_frame/story_mcp/tools/cljs_resolve.cljc"
-   "tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc"
-   "tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc"
-   "tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc"
-   "tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc"
-   "tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc"
-   "tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc"
-   "tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc"])
+  "The story-mcp `tools/*.cljc` source files — derived from a
+  filesystem listing of `story-mcp-tools-dir`, NOT a hand-maintained
+  list (rf2-ribu5a). This is the surface the slot-name and indicator
+  near-miss tripwires grep (the slots live in the tool bodies, not the
+  wire framing). Sorted for deterministic iteration order. Fails loudly
+  if the directory is missing or empty — a story-mcp source-tree move
+  must surface here, not silently shrink the sweep to nothing."
+  (let [dir (io/file repo-root story-mcp-tools-dir)
+        files (->> (.listFiles dir)
+                   (filter #(.isFile %))
+                   (map #(.getName %))
+                   (filter #(re-find #"\.cljc$" %))
+                   sort
+                   (mapv #(str story-mcp-tools-dir "/" %)))]
+    (when (empty? files)
+      (throw (ex-info (str "story-mcp tools dir yielded zero *.cljc files — "
+                           "the source tree moved or the path drifted: "
+                           story-mcp-tools-dir)
+                      {:dir (.getAbsolutePath dir)})))
+    files))
 
 (def story-mcp-source-files
   "Every story-mcp source file the cross-MCP-marker absence tripwires

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -84,7 +84,8 @@
   live server: the schemas are normative, the fixtures are authored
   from each server's spec/source, and the grep step pins those
   authored fixtures to the actual source/spec text."
-  (:require [clojure.string  :as str]
+  (:require [clojure.java.io :as io]
+            [clojure.string  :as str]
             [clojure.test    :refer [deftest is testing]]
             [de-dupe.core    :as dd]
             [malli.core      :as m]
@@ -1470,6 +1471,99 @@
                    "`canonical-markers` to include :story-mcp in "
                    ":servers, add a story-mcp fixture, and extend "
                    "`server-source-files`.")))))))
+
+;; ---------------------------------------------------------------------------
+;; story-mcp source inventory completeness (rf2-ribu5a).
+;;
+;; `fx/story-mcp-tool-source-files` is the single inventory the generic
+;; near-miss / uncontracted-marker / slot-name sweeps grep. Before
+;; rf2-ribu5a it was a HAND-MAINTAINED list that had silently fallen
+;; behind the directory: it ran through `recorder.cljc` but omitted
+;; `dedup.cljc` (emits the cross-MCP `:rf.mcp/dedup-table` marker) and
+;; `cursor.cljc` (routes the cross-MCP `:rf.mcp/cursor-stale` marker) —
+;; so a near-miss drift in EITHER file could escape the very gates that
+;; exist to catch it (only `cursor.cljc` had a bespoke compensating
+;; pin; `dedup.cljc` had none). The inventory is now derived from a
+;; filesystem listing; these tests pin that contract so the drift class
+;; cannot recur:
+;;
+;;   1. completeness — the derived inventory equals a fresh directory
+;;      listing of `tools/story_mcp/tools/*.cljc` (the historically
+;;      omitted files are necessarily present; any future tool file is
+;;      swept the moment it lands).
+;;   2. participation — `dedup.cljc` (the file with NO bespoke
+;;      compensating pin) is in the set the generic sweep iterates, so
+;;      its `:rf.mcp/dedup-table` emission and any near-miss are checked
+;;      generically, not only indirectly against `mcp-base/vocab.cljc`.
+;; ---------------------------------------------------------------------------
+
+(deftest story-mcp-tool-inventory-is-filesystem-complete
+  ;; The derived inventory MUST equal a fresh listing of the tools dir —
+  ;; a tool file added/removed on disk is reflected with zero list
+  ;; maintenance. A divergence here means the derivation drifted from
+  ;; the directory (it cannot, by construction — this pins that).
+  (let [dir            (io/file fx/repo-root fx/story-mcp-tools-dir)
+        fresh-listing  (->> (.listFiles dir)
+                            (filter #(.isFile %))
+                            (map #(.getName %))
+                            (filter #(re-find #"\.cljc$" %))
+                            (map #(str fx/story-mcp-tools-dir "/" %))
+                            set)]
+    (is (= fresh-listing (set fx/story-mcp-tool-source-files))
+        (str "story-mcp tool-source inventory diverged from the "
+             "filesystem listing of " fx/story-mcp-tools-dir
+             ". Derived: " (sort fx/story-mcp-tool-source-files)
+             "\nFresh: " (sort fresh-listing)))))
+
+(deftest story-mcp-inventory-includes-historically-omitted-tool-files
+  ;; Regression for rf2-ribu5a: the two files the hand list dropped MUST
+  ;; be in the inventory. dedup.cljc had NO bespoke compensating pin, so
+  ;; its omission was a genuine false-green hole on the generic
+  ;; uncontracted-marker / near-miss sweeps.
+  (let [inventory (set fx/story-mcp-tool-source-files)]
+    (is (contains? inventory
+                   "tools/story-mcp/src/re_frame/story_mcp/tools/dedup.cljc")
+        "dedup.cljc (emits :rf.mcp/dedup-table) MUST be in the central inventory")
+    (is (contains? inventory
+                   "tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc")
+        "cursor.cljc (routes :rf.mcp/cursor-stale) MUST be in the central inventory")))
+
+(deftest dedup-source-participates-in-generic-story-mcp-sweep
+  ;; Proves dedup.cljc is actually swept by the GENERIC story-mcp
+  ;; uncontracted-marker machinery — `story-mcp-still-emits-zero-
+  ;; uncontracted-cross-mcp-markers` iterates `fx/story-mcp-source-files`,
+  ;; so dedup.cljc must be a member. Before rf2-ribu5a it was NOT, and —
+  ;; unlike cursor.cljc — had NO bespoke compensating pin, so an
+  ;; accidental inline emission of any uncontracted canonical marker
+  ;; (e.g. `:rf.mcp/summary`) in dedup.cljc would have escaped every
+  ;; generic sweep.
+  ;;
+  ;; The participation is structural (membership in the swept set), NOT
+  ;; a literal-presence assertion: dedup.cljc emits its ONE contracted
+  ;; marker via the shared `base-vocab/dedup-table-key` SYMBOL — the
+  ;; `:rf.mcp/dedup-table` literal as DATA lives only in
+  ;; `mcp-base/vocab.cljc` (byte-identical across servers by design,
+  ;; same posture as cursor.cljc sourcing its reason from
+  ;; `vocab/cursor-stale-reason`). So the file correctly carries the
+  ;; literal only in docstrings, which the uncontracted sweep strips
+  ;; before grepping — and because `:rf.mcp/dedup-table` IS in
+  ;; story-mcp's `:servers`, the sweep skips it for dedup.cljc and fires
+  ;; only on genuinely uncontracted markers.
+  (let [dedup-rel "tools/story-mcp/src/re_frame/story_mcp/tools/dedup.cljc"]
+    (is (some #{dedup-rel} fx/story-mcp-source-files)
+        "dedup.cljc must be in the source set the uncontracted-marker sweep iterates")
+    ;; Belt-and-braces: dedup.cljc carries NO uncontracted canonical
+    ;; marker as inline data today (mirrors the green state the generic
+    ;; sweep asserts). If a future edit inline-emits one, BOTH this pin
+    ;; and the generic sweep flip RED.
+    (let [stripped          (fx/strip-comments-and-strings (fx/read-source dedup-rel))
+          uncontracted-keys (for [{:keys [key servers]} canonical-markers
+                                  :when (not (contains? servers :story-mcp))]
+                              key)]
+      (doseq [key uncontracted-keys]
+        (is (not (str/includes? stripped (marker-key->literal key)))
+            (str key " (uncontracted for story-mcp) found as inline data in "
+                 dedup-rel " — would be a cross-MCP vocabulary leak."))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Envelope indicator-field gate (rf2-2499j MUST-level pin).


### PR DESCRIPTION
Closes rf2-ribu5a (P2, correctness-review). Two findings, both verified against current main (post-EP-0002, post-#3667 tag30h) before fixing.

## Part 1 (P2) — epoch live-MCP-redaction routing false-green

The re-frame2-pair live fixture resolves day8/re-frame2-epoch as a :local/root, and the hermetic `mcp-conformance-re-frame2-pair` job's INNER_TESTS include `live-re-frame2-pair-redaction.cjs` (the egress-protection regression for the pull-mode epoch tools: trace-window / watch-epochs). That job is gated on `mcp_live == 'true'`.

Folded into the generic per-feature bucket, an `implementation/epoch/src/...` change set NEITHER `mcp_live` NOR `mcp_conformance` — so a PR breaking the epoch egress/redaction contract merged GREEN at PR time (a false-green on a data-leak guard), surfacing only in the nightly cron.

Fix: split `implementation/epoch/*` into a dedicated classifier case that arms `mcp_live` + `mcp_conformance` alongside the generic per-feature gates (implementation_jvm, cljs_node_test, cljs_browser, cljs_prod, bundle_isolation). Epoch is not in the scaffold (no template_expensive) and not baked into the SCI bundle (no playground). Regression coverage in `_changed-surfaces.test.cjs` proves an epoch src change selects the live gate, the other per-feature artefacts (machines/flows/ssr) stay off mcp_live, and the job stays gated on mcp_live.

## Part 2 (P3) — stale story-mcp wire-vocab inventory

The hand-maintained `story-mcp-tool-source-files` list had fallen behind the directory: it ran through recorder.cljc but omitted `dedup.cljc` (emits the cross-MCP `:rf.mcp/dedup-table` marker) and `cursor.cljc` (routes `:rf.mcp/cursor-stale`). A near-miss / uncontracted-marker drift in those files could escape the generic story-mcp sweeps — only cursor.cljc had a bespoke compensating pin; dedup.cljc had none.

Fix: replaced the hand list with a filesystem-derived inventory of `tools/story_mcp/tools/*.cljc` (fails loudly if the dir is empty/missing). Added regressions pinning inventory filesystem-completeness, the two historically-omitted files, and dedup.cljc's structural participation in the generic uncontracted-marker sweep (membership-based, since dedup.cljc emits via the shared base-vocab symbol, not an inline literal — same byte-identical-across-servers posture as cursor.cljc). The cursor-stale-specific bespoke checks are retained unchanged.

## Slice gates (local)

- wire-vocab JVM: 67 tests / 766 assertions, 0 failures
- story-mcp JVM: 259 tests / 1283 assertions, 0 failures
- changed-surfaces regression: 73 passed
- full `npm run test:mcp-conformance`: all 6 gates GREEN

Files: `.github/scripts/report-changed-surfaces.sh`, `implementation/scripts/_changed-surfaces.test.cjs`, `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj`, `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj`.
