### PR TITLE
fix(examples/ssr): migrate ssr + ssr_streaming client boot to EP-0002 carried-frame (rf2-9ba11z)

### DIFF
--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -318,42 +318,73 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 #?(:cljs (defonce react-root (atom nil)))
 
+;; EP-0002 (rf2-9o48ih + rf2-acjknb): under the carried-frame invariant the
+;; runtime never synthesises a frame from absence — the SSR hydration target
+;; is CARRIED, established explicitly by the app and threaded through both
+;; `ssr/hydrate!` (the seed target) AND the root `frame-provider` (where every
+;; in-tree `dispatch`/`subscribe` resolves). This example uses `:rf/default`
+;; as its client app-frame id (a migration may pick `:rf/default`, but the
+;; runtime will not infer it). It MUST be a `:client`-platform frame so the
+;; `:rf.ssr/check-*` compatibility-check fxs the `:rf/hydrate` handler
+;; dispatches actually fire (Spec 011 §The :rf/hydrate event — a `:server`-
+;; platform frame skips them). The static `index.html` payload carries no
+;; `:rf/frame-id` (a real server stamps it via `handle-request` above), which
+;; is NOT a hydration-frame-id conflict — the explicit `:frame` stands; a
+;; present-but-different payload `:rf/frame-id` would surface a structured
+;; `:rf.error/hydration-frame-id-mismatch` (Spec 011 §The hydration payload).
+(def app-frame :rf/default)
+
 #?(:cljs
    (defn run []
      ;; Boot the runtime against the Reagent substrate. Idempotent — the
-     ;; first call installs the adapter and creates :rf/default; subsequent
-     ;; calls (e.g. shadow-cljs hot reloads) are no-ops.
+     ;; first call installs the adapter; subsequent calls (e.g. shadow-cljs
+     ;; hot reloads) are no-ops. `init!` installs the adapter but does NOT
+     ;; create a frame — EP-0002: the app establishes its frame explicitly
+     ;; (below) and the runtime never synthesises `:rf/default` from absence.
      ;;
      ;; Pass the adapter spec map directly. There is no
      ;; default-adapter registry — each adapter ns exports an `adapter`
      ;; var the consumer requires and passes here.
      (rf/init! reagent-adapter/adapter)
+     ;; Establish the carried client app-frame BEFORE hydrating into it.
+     ;; `reg-frame` is a surgical no-op on re-registration (hot-reload Just
+     ;; Works). `:platform :client` makes the hydrate compatibility-check
+     ;; fxs fire (Spec 011 §The :rf/hydrate event).
+     (rf/reg-frame app-frame {:doc      "ssr-example client app-frame"
+                              :platform :client})
      ;; `ssr/hydrate!` is the framework client-boot helper (Spec 011
      ;; §Client-side hydration boot helper). It READs the `__rf_payload`
      ;; script, dispatch-syncs `[:rf/hydrate payload]` to install the
-     ;; server's frame-state BEFORE first render (locked
-     ;; :replace-frame-state policy), and — given a `:render-tree-fn` — runs
-     ;; the post-hydrate VERIFY step: it hashes the client render-tree and
-     ;; compares it to the server's :rf/render-hash (stashed by the
+     ;; server's frame-state into the EXPLICIT `:frame` BEFORE first render
+     ;; (locked :replace-frame-state policy), and — given a `:render-tree-fn`
+     ;; — runs the post-hydrate VERIFY step: it hashes the client render-tree
+     ;; and compares it to the server's :rf/render-hash (stashed by the
      ;; framework `:rf/hydrate` handler at [:rf.runtime/ssr :hydration
      ;; :server-hash]), emitting :rf.ssr/hydration-mismatch on disagreement.
      ;; `:render-tree-fn` must return the SAME *resolved* hiccup tree the
      ;; server hashed — the server computed `(rf/render-tree-hash
      ;; ((rf/view :app/root)))`, so we CALL the view fn here, `((rf/view
      ;; :app/root))`, rather than the vector-wrapped component reference
-     ;; `[(rf/view :app/root)]` we hand Reagent to mount. The helper targets
-     ;; the default client frame. It returns the payload it applied (nil on
-     ;; a client-only first load with no payload script), so we can branch on
-     ;; "was this server-rendered?".
-     (let [payload (ssr/hydrate! {:render-tree-fn (fn [] ((rf/view :app/root)))})]
+     ;; `[(rf/view :app/root)]` we hand Reagent to mount. EP-0002: the
+     ;; hydration target is CARRIED — the same `app-frame` flows to
+     ;; `hydrate!` and the root `frame-provider`. It returns the payload it
+     ;; applied (nil on a client-only first load with no payload script), so
+     ;; we can branch on "was this server-rendered?".
+     (let [payload (ssr/hydrate! {:frame          app-frame
+                                  :render-tree-fn (fn [] ((rf/view :app/root)))})]
        (when-not payload
          ;; Client-only load (no server render): run the app's own
-         ;; bootstrap; the page renders the empty-articles fallback.
-         (rf/dispatch-sync [:ssr/client-bootstrap])))
+         ;; bootstrap against the carried frame; the page renders the
+         ;; empty-articles fallback.
+         (rf/dispatch-sync [:ssr/client-bootstrap] {:frame app-frame})))
      (when (exists? js/document)
        (when-not @react-root
          (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-       (rdc/render @react-root [(rf/view :app/root)]))))
+       ;; Wrap the mount in the carried frame's `frame-provider` so every
+       ;; in-tree `dispatch`/`subscribe` resolves to the hydrated frame.
+       (rdc/render @react-root
+                   [rf/frame-provider {:frame app-frame}
+                    [(rf/view :app/root)]]))))
 
 ;; The JVM-runnable headless tests for this example live in
 ;; re-frame.examples-test (implementation/core/test/), keeping this example

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -207,27 +207,53 @@
 ;; example namespaces don't race `create-root` onto the shared `#app`.
 #?(:cljs (defonce react-root (atom nil)))
 
+;; EP-0002 (rf2-9o48ih + rf2-acjknb): the SSR hydration target is CARRIED —
+;; established explicitly by the app and threaded through the streaming
+;; `install!`, `ssr/hydrate!`, AND the root `frame-provider`. The runtime
+;; never synthesises a frame from absence. This example uses `:rf/default`
+;; as its client app-frame id; it MUST be a `:client`-platform frame so the
+;; `:rf.ssr/check-*` compatibility-check fxs the `:rf/hydrate` handler
+;; dispatches actually fire (Spec 011 §The :rf/hydrate event). The static
+;; `index.html` payload carries no `:rf/frame-id` (a real streaming server
+;; stamps it via `handle-request`/`streaming-build-final-payload` above),
+;; which is NOT a hydration-frame-id conflict — the explicit `:frame` stands.
+#?(:cljs (def app-frame :rf/default))
+
 #?(:cljs
    (defn run []
+     ;; `init!` installs the adapter but does NOT create a frame — EP-0002:
+     ;; the app establishes its frame explicitly (below).
      (rf/init! reagent-adapter/adapter)
+     ;; Establish the carried client app-frame BEFORE installing the
+     ;; streaming runtime / hydrating into it. `reg-frame` is a surgical
+     ;; no-op on re-registration (hot-reload Just Works). `:platform :client`
+     ;; makes the hydrate compatibility-check fxs fire.
+     (rf/reg-frame app-frame {:doc      "ssr-streaming-example client app-frame"
+                              :platform :client})
      ;; Install the client-side streaming runtime BEFORE the first render
      ;; so it catches resolved-subtree chunks as they arrive (and sweeps
      ;; any already present). It swaps fallbacks + merges per-subtree
-     ;; deltas progressively, then disconnects on `__rf_payload`.
-     (ssr/streaming-install! {:frame :rf/default})
+     ;; deltas progressively into the carried frame, then disconnects on
+     ;; `__rf_payload`.
+     (ssr/streaming-install! {:frame app-frame})
      ;; Reconcile against the canonical payload: read `__rf_payload` +
-     ;; dispatch `:rf/hydrate` (:replace-app-db). The deltas were
-     ;; speculative; this is the correctness lock. (`:render-tree-fn` is
-     ;; omitted — the static demo shell carries a placeholder render-hash,
-     ;; so hash-mismatch verification would always warn here; a real
-     ;; streaming server stamps the genuine hash and a host then passes
-     ;; `:render-tree-fn` to enable mismatch detection.) Hydrate BEFORE
-     ;; first render so the initial render runs against the seeded app-db.
-     (ssr/hydrate! {:frame :rf/default})
+     ;; dispatch `:rf/hydrate` (:replace-app-db) into the EXPLICIT `:frame`.
+     ;; The deltas were speculative; this is the correctness lock.
+     ;; (`:render-tree-fn` is omitted — the static demo shell carries a
+     ;; placeholder render-hash, so hash-mismatch verification would always
+     ;; warn here; a real streaming server stamps the genuine hash and a host
+     ;; then passes `:render-tree-fn` to enable mismatch detection.) Hydrate
+     ;; BEFORE first render so the initial render runs against the seeded
+     ;; app-db.
+     (ssr/hydrate! {:frame app-frame})
      (when (exists? js/document)
        (when-not @react-root
          (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
-       (rdc/render @react-root [(rf/view :dashboard/root)]))))
+       ;; Wrap the mount in the carried frame's `frame-provider` so every
+       ;; in-tree `dispatch`/`subscribe` resolves to the hydrated frame.
+       (rdc/render @react-root
+                   [rf/frame-provider {:frame app-frame}
+                    [(rf/view :dashboard/root)]]))))
 
 ;; The JVM-runnable headless test that exercises the server stream
 ;; (shell → per-card resolved chunks → final payload) lives in


### PR DESCRIPTION
## rf2-9ba11z — EP-0002: migrate ssr + ssr_streaming client boot to the carried-frame invariant

EP-0002 review follow-up, sibling of rf2-3n9rvu (which migrated ~28 examples but deferred the SSR subsystem). Post-EP-0002 the SSR client boot path was left on the pre-EP shape and would boot-fail.

### Problem

- ssr/hydrate! now REQUIRES an explicit :frame; an absent :frame emits + throws :rf.error/no-frame-context. The runtime no longer synthesises :rf/default.
- The hydrated client render must be wrapped in a frame-provider for the hydrated frame so in-tree dispatch/subscribe resolve to it.
- examples/reagent/ssr called hydrate! with no :frame, rendered the root with no frame-provider, and dispatched :ssr/client-bootstrap frameless. examples/reagent/ssr_streaming passed :frame :rf/default to install! and hydrate! but never established that frame and rendered without a frame-provider.

### Fix (the carried-frame boot contract, applied to both run fns)

1. Establish the client app-frame explicitly via reg-frame with :platform :client. The :client platform is load-bearing: the :rf/hydrate handler only dispatches the :rf.ssr/check-version / :rf.ssr/check-schema-digest compatibility-check fxs when the resolved frame platform is :client (Spec 011 §The :rf/hydrate event; a :server-platform frame skips them per rf2-7bcn0).
2. Pass that same frame as the explicit :frame to hydrate! (ssr) and to streaming-install! + hydrate! (ssr_streaming). The payload :rf/frame-id is validated against this explicit target; the static index.html payload carries no :rf/frame-id, which is not a conflict, so the explicit target stands. A present-but-different payload frame-id would surface a structured :rf.error/hydration-frame-id-mismatch.
3. Thread the same frame to the bare :ssr/client-bootstrap dispatch (ssr).
4. Wrap the React mount in the carried frame's frame-provider.
5. Replaced the stale init!-creates-:rf/default boot comments with the carried-frame explanation.

Both examples use :rf/default as their client app-frame id (a migration may pick :rf/default; the runtime will not infer it). CLJS-only changes — the :clj server handle-request paths are untouched.

### Verification

- npx shadow-cljs compile examples/ssr examples/ssr-streaming — both build clean, 0 warnings.
- JVM headless re-frame.examples-test — 9 tests / 39 assertions / 0 failures (includes the four ssr-example-client-hydration-* tests and ssr-streaming-example-runs-end-to-end).

Closes rf2-9ba11z.
