### PR TITLE
refactor(machines-viz): fold elk-result->positions atoms into a pure recursive reduce (rf2-crvxff)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -467,42 +467,39 @@
   map — the projector / edge component then falls back to the bezier
   path."
   [elk-result]
-  (let [positions   (atom {})
-        edge-points (atom {})
-        ;; rf2-rlq97 — elk's COMPUTED edge-label positions (keyed by elk
-        ;; edge id), the label analogue of `:edge-points`. Empty under
-        ;; events-as-nodes (the transition text is on the event-node so
-        ;; edges carry no label for elk to place); populated for any
-        ;; labelled edge so the renderer reads elk's position rather than
-        ;; the geometric midpoint heuristic.
-        edge-labels (atom {})]
-    (letfn [(collect-edges! [^js node]
-              (let [edges (or (.-edges node) #js [])
-                    n     (alength edges)]
-                (dotimes [i n]
-                  (let [e   (aget edges i)
-                        pts (elk-edge-points e)
-                        lp  (elk-edge-label-pos e)]
-                    (when pts
-                      (swap! edge-points assoc (.-id e) pts))
-                    (when lp
-                      (swap! edge-labels assoc (.-id e) lp))))))
-            (walk! [^js node]
-              (collect-edges! node)
-              (let [children (or (.-children node) #js [])
-                    n        (alength children)]
-                (dotimes [i n]
-                  (let [c (aget children i)]
-                    (swap! positions assoc (.-id c)
-                           {:x      (or (.-x c) 0)
-                            :y      (or (.-y c) 0)
-                            :width  (or (.-width c) projection/state-node-min-width)
-                            :height (or (.-height c) projection/state-node-min-height)})
-                    (walk! c)))))]
-      (walk! elk-result))
-    {:positions   @positions
-     :edge-points @edge-points
-     :edge-labels @edge-labels}))
+  ;; Pure recursive walk threading a 3-key accumulator (rf2-crvxff —
+  ;; folded out three parallel `swap!`-accumulator atoms). `acc` carries
+  ;; `:positions` (node-id → box), `:edge-points` (edge-id → routed
+  ;; bend-points), and `:edge-labels` (edge-id → elk's COMPUTED label
+  ;; position; the label analogue of `:edge-points`, empty under
+  ;; events-as-nodes since the transition text rides on the event-NODE).
+  ;; `array-seq` lifts elk's JS `.children`/`.edges` arrays in index
+  ;; order so `assoc` last-write-wins ordering matches the old walk.
+  (letfn [(collect-edges [acc ^js node]
+            (reduce (fn [acc ^js e]
+                      (let [pts (elk-edge-points e)
+                            lp  (elk-edge-label-pos e)]
+                        (cond-> acc
+                          pts (assoc-in [:edge-points (.-id e)] pts)
+                          lp  (assoc-in [:edge-labels (.-id e)] lp))))
+                    acc
+                    (array-seq (or (.-edges node) #js []))))
+          (walk [acc ^js node]
+            ;; node's own edges first (matches the old walk!'s
+            ;; collect-edges!-then-recurse order), then each child:
+            ;; record its position, then walk it (which collects that
+            ;; child's edges + descends).
+            (reduce (fn [acc ^js c]
+                      (-> acc
+                          (assoc-in [:positions (.-id c)]
+                                    {:x      (or (.-x c) 0)
+                                     :y      (or (.-y c) 0)
+                                     :width  (or (.-width c) projection/state-node-min-width)
+                                     :height (or (.-height c) projection/state-node-min-height)})
+                          (walk c)))
+                    (collect-edges acc node)
+                    (array-seq (or (.-children node) #js []))))]
+    (walk {:positions {} :edge-points {} :edge-labels {}} elk-result)))
 
 ;; ---- error reporting (rf2-4lyvh) ----------------------------------------
 ;;


### PR DESCRIPTION
## What

Refactors `elk-result->positions` in `tools/machines-viz/.../chart.cljs` (audit finding S2 from rf2-a91135). The function walked the elkjs result tree with a `dotimes`/`aget` imperative walk that accumulated three parallel atoms (`positions`, `edge-points`, `edge-labels`) via `swap! assoc`, then derefed them into the result map.

It now uses a pure recursive walk threading a `{:positions :edge-points :edge-labels}` accumulator via `reduce` over `array-seq` of the JS `.children`/`.edges` arrays. No atoms; the data flow is explicit.

## Why

P4 nice-to-have from the atom-usage audit. The audit flagged S2 as BORDERLINE — the JS-array interop is the natural elkjs shape. On inspection the pure fold reads as clearly as the old walk while making accumulation explicit, and `array-seq` is the idiomatic CLJS lift of a JS array, so the transform is an elegance win rather than a fight with the interop.

## Behaviour preservation

Output is identical:

- Same result shape (`:positions` node-id to box, `:edge-points` / `:edge-labels` edge-id keyed).
- Same `assoc` last-write-wins ordering (index-order `array-seq` matches the old index `dotimes`).
- Same walk order: a node's own edges collected first, then each child's position recorded, then the child walked (collecting its edges + descendants).
- Same empty-array handling (`array-seq` of `#js []` is `nil`; `reduce` over `nil` is a no-op, like `dotimes` with `n=0`).
- The rf2-rlq97 `:edge-labels` rationale comment is preserved.

## Verification

- `npm run test:cljs` — green (exit 0). The three chart namespaces that pin `elk-result->positions` output (`edges_cljs_test`, `auto_fit_view_cljs_test`, `compute_layout_error_cljs_test`) are compiled into the node-test build and ran.
- `npm run test:xray-feature-gate:smoke` — `Ran 4 Xray feature scenarios (PR-smoke tier). 0 failures.`

Spec unchanged: the machines-viz spec describes the function's output contract (unchanged here), not the internal accumulator mechanism.

Closes rf2-crvxff.
