### PR TITLE
ci(workflows): de-false-green Reagent/UIx/Helix JVM adapter probes (rf2-1s2mhh)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,9 +166,18 @@ jobs:
         working-directory: implementation/core
         run: clojure -M:test
 
+      # The Reagent/UIx/Helix adapter :test aliases have no JVM-runnable
+      # tests of their own (the adapter ns is :cljs-only). These steps are
+      # classpath/deps probes — the empty case needs no `|| echo`
+      # fallback because the cognitect test-runner returns 0 when there
+      # are no matching test namespaces. A non-zero exit means a REAL
+      # failure (a deps/classpath break) and MUST stop the release, so we
+      # do not swallow it — mirrors the per-adapter probe jobs in
+      # .github/workflows/test.yml (rf2-1s2mhh / follow-up rf2-xcyaei
+      # finding 4).
       - name: JVM tests (reagent artefact, classpath probe)
         working-directory: implementation/adapters/reagent
-        run: clojure -M:test || echo "no JVM-runnable tests in reagent artefact (expected)"
+        run: clojure -M:test
 
       # The reagent-slim artefact (rf2-5djt Stage 4, rf2-6hyy) ships a
       # JVM-runnable test namespace — reagent2.impl.component-test (the
@@ -182,11 +191,11 @@ jobs:
 
       - name: JVM tests (uix artefact, classpath probe)
         working-directory: implementation/adapters/uix
-        run: clojure -M:test || echo "no JVM-runnable tests in uix artefact (expected)"
+        run: clojure -M:test
 
       - name: JVM tests (helix artefact, classpath probe)
         working-directory: implementation/adapters/helix
-        run: clojure -M:test || echo "no JVM-runnable tests in helix artefact (expected)"
+        run: clojure -M:test
 
       - name: JVM tests (schemas artefact)
         working-directory: implementation/schemas

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -383,11 +383,15 @@ jobs:
       # The Reagent artefact's :test alias has no JVM-runnable tests of
       # its own (the adapter ns is :cljs-only). The job exists so the
       # artefact's deps + classpath wiring stay green and any future JVM
-      # adapter probe lands here. Skip-on-empty is acceptable; the
-      # cognitect test-runner returns 0 when there are no test
-      # namespaces matching its pattern.
+      # adapter probe lands here. The empty case needs no `|| echo`
+      # fallback: the cognitect test-runner returns 0 when there are no
+      # test namespaces matching its pattern (verified — `clojure -M:test`
+      # here reports "Ran 0 tests" and exits 0). A non-zero exit therefore
+      # means a REAL failure — a deps/classpath break or a future failing
+      # JVM probe ns — and MUST fail the step, so we do not swallow it
+      # (rf2-1s2mhh / follow-up rf2-xcyaei finding 4).
       - name: Run JVM tests (reagent artefact, classpath probe)
-        run: clojure -M:test || echo "no JVM-runnable tests in reagent artefact (expected)"
+        run: clojure -M:test
 
   jvm-reagent-slim:
     name: JVM reagent-slim (clojure -M:test)
@@ -473,13 +477,15 @@ jobs:
       # The UIx artefact's :test alias has no JVM-runnable tests of its
       # own (the adapter ns is :cljs-only — UIx is a CLJS-only library).
       # The job exists so the artefact's deps + classpath wiring stay
-      # green. Skip-on-empty is acceptable; the cognitect test-runner
-      # returns 0 when there are no test namespaces matching its
-      # pattern. Per rf2-3yij Decision 7 the substrate's smoke-test
-      # surface is the browser-side counter + login specs — see the
-      # adapter-testbed-smokes job below.
+      # green. The empty case needs no `|| echo` fallback: the cognitect
+      # test-runner returns 0 when there are no test namespaces matching
+      # its pattern. A non-zero exit therefore means a REAL failure (a
+      # deps/classpath break) and MUST fail the step, so we do not swallow
+      # it (rf2-1s2mhh / follow-up rf2-xcyaei finding 4). Per rf2-3yij
+      # Decision 7 the substrate's smoke-test surface is the browser-side
+      # counter + login specs — see the adapter-testbed-smokes job below.
       - name: Run JVM tests (uix artefact, classpath probe)
-        run: clojure -M:test || echo "no JVM-runnable tests in uix artefact (expected)"
+        run: clojure -M:test
 
   jvm-helix:
     name: Diagnostic skip-ok JVM helix-adapter classpath probe
@@ -519,13 +525,16 @@ jobs:
       # The Helix artefact's :test alias has no JVM-runnable tests of
       # its own (the adapter ns is :cljs-only — Helix is a CLJS-only
       # library). The job exists so the artefact's deps + classpath
-      # wiring stay green. Skip-on-empty is acceptable; the cognitect
-      # test-runner returns 0 when there are no test namespaces
-      # matching its pattern. Per rf2-2qit Decision 7 the substrate's
-      # smoke-test surface is the browser-side counter + login specs —
-      # see the adapter-testbed-smokes job below.
+      # wiring stay green. The empty case needs no `|| echo` fallback:
+      # the cognitect test-runner returns 0 when there are no test
+      # namespaces matching its pattern. A non-zero exit therefore means
+      # a REAL failure (a deps/classpath break) and MUST fail the step,
+      # so we do not swallow it (rf2-1s2mhh / follow-up rf2-xcyaei
+      # finding 4). Per rf2-2qit Decision 7 the substrate's smoke-test
+      # surface is the browser-side counter + login specs — see the
+      # adapter-testbed-smokes job below.
       - name: Run JVM tests (helix artefact, classpath probe)
-        run: clojure -M:test || echo "no JVM-runnable tests in helix artefact (expected)"
+        run: clojure -M:test
 
   jvm-schemas:
     name: JVM schemas (clojure -M:test)


### PR DESCRIPTION
## rf2-1s2mhh — de-false-green the adapter JVM probes (hot-zone CI)

Follow-up from rf2-xcyaei finding 4. The Reagent/UIx/Helix per-adapter
JVM probe steps wrapped the test command in a blanket
"|| echo \"no JVM-runnable tests...\"" fallback, converting ANY non-zero
exit into a green step — a false green that could hide a deps/classpath
break, a test-runner error, or a future failing JVM probe namespace, on
both PR CI and release preflight.

### Premise verified
- All three adapter "test/" trees contain only "*_cljs_test.cljs"
  (CLJS-only) namespaces — no JVM-runnable ".clj/.cljc" tests.
- The per-adapter ":test" alias delegates exit-code ownership to the
  cognitect test-runner via re-frame.test-quiet.runner (0 on green/empty,
  1 on any failure/error — see the runner docstring).
- Empirically: "clojure -M:test" in the reagent adapter reports
  "Ran 0 tests containing 0 assertions" and exits 0.

So the "|| echo" added nothing on the legitimate empty path and
exclusively masked real failures. This is genuine swallowing, not a
legitimate skip guard.

### Change
Removed the blanket "|| echo" from all six steps so a non-zero exit
fails the step:
- .github/workflows/test.yml — reagent, uix, helix classpath-probe jobs
- .github/workflows/release.yml — reagent, uix, helix preflight steps

Comments updated to explain why no fallback is needed (zero-on-empty)
and why a non-zero now correctly fails.

### Kept as-is (legit, not false-green)
- reagent-slim (test.yml + release.yml) — real JVM surface, already
  correctly omitted "|| echo".

### Gate
YAML validity confirmed (python yaml.safe_load on both files). No live
"run:" line carries "|| echo" anywhere in the workflows after the change;
remaining "|| echo" mentions are explanatory comments only. The CI-wrapper
change is verified by CI itself on this PR.
