### PR TITLE
test(websocket): scope reg-app-schema to :rf/default in fixture init (rf2-ofzxh9)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/websocket_cljs_test.cljs
@@ -34,7 +34,7 @@
             [websocket.connection :as ws.connection]
             [websocket.messages :as messages]
             [websocket.core])
-  (:require-macros [re-frame.core :refer [with-new-frame]]))
+  (:require-macros [re-frame.core :refer [with-frame with-new-frame]]))
 
 ;; ============================================================================
 ;; TEST-ONLY RE-REGISTRATION SCAFFOLDING
@@ -110,7 +110,23 @@
   ;; machine's own `:data-schema` is the snapshot-validation surface; the
   ;; vestigial app-schema reg is dropped. Only the genuine app-db slice
   ;; (`[:messages]`) keeps its app-schema.
-  (rf/reg-app-schema [:messages]                   ws.schema/MessagesSlice)
+  ;;
+  ;; rf2-ofzxh9 — `reg-app-schema` is EP-0002 context-required frame-local
+  ;; (rf2-5q7um6): it resolves `*current-frame*` and raises
+  ;; `:rf.error/no-frame-context` under no scope. `register-all!` runs from
+  ;; the fixture's `:init-fn`, which fires OUTSIDE the fixture's ambient
+  ;; `*current-frame*` binding (`make-reset-runtime-fixture` invokes `:init-fn`
+  ;; before it `binding`s the ambient frame around the test body). Bare, this
+  ;; threw `:rf.error/no-frame-context` — and because the node-test build runs
+  ;; every `*_cljs_test` ns in ONE shared JS runtime, that throw, fired during
+  ;; a concurrently-pending async test's `done` window, surfaced as the
+  ;; intermittent `FAIL in () (:) unexpected reject: :rf.error/no-frame-context`
+  ;; + `Async test called done more than one time` flake. Name `:rf/default`
+  ;; explicitly here, mirroring the example's own `(with-frame :rf/default …)`
+  ;; ns-load idiom (examples/reagent/websocket/schema.cljs) — the fixture has
+  ;; already `ensure-default-frame!`'d it.
+  (with-frame :rf/default
+    (rf/reg-app-schema [:messages]                 ws.schema/MessagesSlice))
 
   ;; --- websocket.connection ----------------------------------------------
   (rf/reg-machine :ws/connection ws.connection/connection-machine)


### PR DESCRIPTION
## Summary

Fixes the single remaining intermittent red in `npm run test:cljs` (rf2-ofzxh9): the `FAIL in () (:) / unexpected reject: :rf.error/no-frame-context / Async test called done more than one time` flake.

## Root cause

The websocket CLJS integration test's `:each` fixture `:init-fn` calls `register-all!`, which re-registers the example surface — including `(reg-app-schema [:messages] ...)`. Per EP-0002 (rf2-5q7um6) `reg-app-schema` is context-required frame-local: it resolves `*current-frame*` and raises `:rf.error/no-frame-context` under no scope. `make-reset-runtime-fixture` invokes `:init-fn` BEFORE it binds the ambient `*current-frame*` around the test body, so the bare call ran frameless and threw.

The node-test build runs every `*_cljs_test` namespace in one shared JS runtime. That synchronous throw, fired during a concurrently-pending `cljs.test async` test's `done()` window, surfaced as the empty-named async failure + double-`done` flake.

The earlier diagnosis pointing at an HTTP managed-async retry/backoff timer leak (`http_cljs_test`) was a red herring — the example HTTP backoff timers print near the failure but the actual throw is the frameless `reg-app-schema`, confirmed via stack trace.

## Fix

Wrap the test's `reg-app-schema` in `(with-frame :rf/default ...)`, mirroring the example's own ns-load idiom (`examples/reagent/websocket/schema.cljs`). The fixture has already `ensure-default-frame!`'d `:rf/default`. Test-only change; no production source touched.

## Verification

`npm run test:cljs` (full suite: 6137 tests / 21886 assertions) run 8x post-fix — all green (0 failures, 0 errors). The flake reproduced on every run before the fix.
