### PR TITLE
fix(xray): green the 3 behavioral xray-feature-gate scenarios (rf2-wxu4l3)

### DIFF
--- a/tools/xray/spec/017-Test-Coverage-Matrix.md
+++ b/tools/xray/spec/017-Test-Coverage-Matrix.md
@@ -215,8 +215,12 @@ clean scrubbable arc in its own ring — switching switches WHICH
 isolated arc Xray shows, never interleaving, including across
 switch-and-return (pick A → step → pick B → step → return to A: A's
 ring is intact and resumes). The browser feature gate asserts this with
-a cross-frame flip + a per-track frame-snapshot read
-(`:machine/<track>` app-db, not `:rf/default`).
+a cross-frame flip + a per-track frame-snapshot read off the
+`:machine/<track>` frame's **runtime-db** partition (machine snapshots
+are durable framework runtime-db state at `[:rf.runtime/machines
+:snapshots <machine-id>]` per EP-0001 / `re-frame.machines.paths`, read
+via `re-frame.core/runtime-db-value` — NOT app-db, and not
+`:rf/default`).
 
 **Localized runner.** The multi-track / frame-per-machine machinery is
 machine-epochs-LOCAL (the deck's own ns); the shared `runner.core`

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/browse_list.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/browse_list.cljs
@@ -38,29 +38,45 @@
   `dispatch` (rf2-nesy9) is the frame-aware dispatcher threaded from the
   `browse-list` reg-view (a plain fn invoked as a Reagent component
   renders in its own cycle, so it cannot recover the frame itself).
+
+  `query` is the current search string, threaded from the `browse-list`
+  reg-view's own subscribe (rf2-wxu4l3) — this helper is a plain fn
+  invoked as a Reagent component, so it renders in its OWN cycle and
+  CANNOT recover the `:rf/xray` frame to `rf/subscribe` itself (Spec 004
+  §Plain Reagent fns do not pick up the surrounding frame; a bare
+  `subscribe` here throws `:rf.error/no-frame-context` and crashes the
+  whole Static surface). The reg-view body already derefs the same
+  `:rf.xray.static.machines/search` sub — pass that value down.
   rf2-1keg3 — the markup lives in the shared `search-box` component's
   `:pane` variant."
-  [dispatch]
-  (let [query @(rf/subscribe [:rf.xray.static.machines/search])]
-    [search-box/search-box
-     {:variant          :pane
-      :testid-prefix    "rf-xray-static-machines"
-      :dispatch         dispatch
-      :set-query-event  :rf.xray.static.machines/set-search
-      :on-clear-event   :rf.xray.static.machines/clear-search
-      :placeholder      "Search machines…"
-      :input-aria-label "Search registered machines"
-      :value            query}]))
+  [dispatch query]
+  [search-box/search-box
+   {:variant          :pane
+    :testid-prefix    "rf-xray-static-machines"
+    :dispatch         dispatch
+    :set-query-event  :rf.xray.static.machines/set-search
+    :on-clear-event   :rf.xray.static.machines/clear-search
+    :placeholder      "Search machines…"
+    :input-aria-label "Search registered machines"
+    :value            query}])
 
 ;; ---- sort cycle button --------------------------------------------------
 
 (defn- sort-button
   "Single-button sort cycle. Clicking cycles `Name → States → Live →
   Name…`. The label shows the current axis so the affordance is self-
-  describing."
-  [dispatch]
-  (let [k     @(rf/subscribe [:rf.xray.static.machines/sort-key])
-        label (get h/sort-key-labels k "Name")]
+  describing.
+
+  `sort-key` is the current sort axis, threaded from the `browse-list`
+  reg-view's own subscribe (rf2-wxu4l3) — this helper is a plain fn
+  invoked as a Reagent component, so it renders in its OWN cycle and
+  CANNOT recover the `:rf/xray` frame to `rf/subscribe` itself (Spec 004
+  §Plain Reagent fns do not pick up the surrounding frame; a bare
+  `subscribe` here throws `:rf.error/no-frame-context` and crashes the
+  whole Static surface). The reg-view body derefs the sub and passes the
+  value down."
+  [dispatch sort-key]
+  (let [label (get h/sort-key-labels sort-key "Name")]
     [:button
      {:data-testid "rf-xray-static-machines-sort"
       :on-click    (fn [_]
@@ -259,13 +275,18 @@
   []
   (let [{:keys [rows total visible selected-id]}
         @(rf/subscribe [:rf.xray.static.machines/data])
-        query @(rf/subscribe [:rf.xray.static.machines/search])]
+        query    @(rf/subscribe [:rf.xray.static.machines/search])
+        ;; rf2-wxu4l3 — deref the sort axis HERE (in the reg-view body, where
+        ;; the `:rf/xray` frame is in context) and thread it into the plain-fn
+        ;; `sort-button` helper, which renders in its own cycle and cannot
+        ;; recover the frame to subscribe itself.
+        sort-key @(rf/subscribe [:rf.xray.static.machines/sort-key])]
     [:div {:data-testid "rf-xray-static-machines-browse-list"
            :style {:display        "flex"
                    :flex-direction "column"
                    :height         "100%"
                    :background     (:bg-1 tokens)}}
-     [search-box dispatch]
+     [search-box dispatch query]
      [:div {:data-testid "rf-xray-static-machines-toolbar"
             :style {:display       "flex"
                     :align-items   "center"
@@ -276,7 +297,7 @@
                     :font-family   sans-stack
                     :font-size     (:caption type-scale)
                     :color         (:text-tertiary tokens)}}
-      [sort-button dispatch]
+      [sort-button dispatch sort-key]
       [:span {:data-testid "rf-xray-static-machines-count"
               :style {:margin-left "auto"}}
        (if (= total visible)

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -2872,37 +2872,50 @@ async function runRoutesEpochs(page, state) {
       snap.currentId && snap.currentId.includes('routes-epochs/settings'),
     { timeoutMs: 10000, description: '#11 try-leave → guard blocked, CURRENT ROUTE stays :settings' },
   );
-  const pendingProbe = await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="routes-epochs-current-strip"]');
-    const stripText = el ? (el.textContent || '') : null;
-    // Direct app-db probe of the pending-navigation slot — the canonical
-    // blocked-nav signal per Spec 012, independent of the strip render.
-    let pendingNav = null;
-    try {
-      const cljs = window.cljs && window.cljs.core;
-      const rf = window.re_frame && window.re_frame.core;
-      // `re-frame.core/app-db-value` returns the plain db VALUE (no deref)
-      // for the named frame (rf2-003ce renamed the former get-frame-db
-      // container accessor; the value accessor is the public read seam).
-      if (cljs && rf && typeof rf.app_db_value === 'function') {
-        const kw = (s) => {
-          const t = String(s).replace(/^:/, '');
-          const p = t.split('/');
-          return p.length === 2
-            ? (cljs.keyword.call ? cljs.keyword.call(null, p[0], p[1]) : cljs.keyword(p[0], p[1]))
-            : (cljs.keyword.call ? cljs.keyword.call(null, t) : cljs.keyword(t));
-        };
-        const db = rf.app_db_value(kw('rf/default'));
-        const path = cljs.PersistentVector.fromArray(
-          [kw('rf/runtime'), kw('routing'), kw('pending-navigation')], true);
-        const pn = db ? cljs.get_in(db, path) : null;
-        pendingNav = pn ? cljs.pr_str(pn) : null;
+  // rf2-wxu4l3 — the `afterBlocked` wait above resolves IMMEDIATELY because
+  // CURRENT ROUTE was already on :settings from rung #10, so a bare read of
+  // the pending-nav slot here races the #11 block cascade's runtime-db
+  // commit (the slice-stayed-put invariant proves nothing changed, but the
+  // commit that WRITES `:rf/pending-navigation` lands a tick later). Poll
+  // until the slot fills. The probe also reads the CORRECT location: per
+  // EP-0001 (rf2-vzld77) the pending-nav slot is durable routing RUNTIME-DB
+  // state at `[:rf.runtime/routing :pending-navigation]` — read via the
+  // public `re-frame.core/runtime-db-value` seam, NOT app-db (the former
+  // `app-db-value` probe at `[:rf/runtime :routing ...]` read the stale
+  // pre-EP-0001 partition + key and always saw nil). The deck strip
+  // (`:rf/pending-navigation` runtime-sub) is the secondary cross-check.
+  const pendingProbe = await waitForValue(
+    () => page.evaluate(() => {
+      const el = document.querySelector('[data-testid="routes-epochs-current-strip"]');
+      const stripText = el ? (el.textContent || '') : null;
+      let pendingNav = null;
+      try {
+        const cljs = window.cljs && window.cljs.core;
+        const rf = window.re_frame && window.re_frame.core;
+        if (cljs && rf && typeof rf.runtime_db_value === 'function') {
+          const kw = (s) => {
+            const t = String(s).replace(/^:/, '');
+            const p = t.split('/');
+            return p.length === 2
+              ? (cljs.keyword.call ? cljs.keyword.call(null, p[0], p[1]) : cljs.keyword(p[0], p[1]))
+              : (cljs.keyword.call ? cljs.keyword.call(null, t) : cljs.keyword(t));
+          };
+          const rdb = rf.runtime_db_value(kw('rf/default'));
+          const path = cljs.PersistentVector.fromArray(
+            [kw('rf.runtime/routing'), kw('pending-navigation')], true);
+          const pn = rdb ? cljs.get_in(rdb, path) : null;
+          pendingNav = pn ? cljs.pr_str(pn) : null;
+        }
+      } catch (err) {
+        pendingNav = `probe-error:${String(err)}`;
       }
-    } catch (err) {
-      pendingNav = `probe-error:${String(err)}`;
-    }
-    return { stripText, pendingNav };
-  });
+      return { stripText, pendingNav };
+    }),
+    (probe) =>
+      Boolean(probe.pendingNav && probe.pendingNav !== 'null') ||
+      /pending-navigation/.test(probe.stripText || ''),
+    { timeoutMs: 10000, description: '#11 try-leave → :rf/pending-navigation fills in runtime-db' },
+  );
   const pendingNavSet =
     Boolean(pendingProbe.pendingNav && pendingProbe.pendingNav !== 'null') ||
     /pending-navigation/.test(pendingProbe.stripText || '');
@@ -2990,10 +3003,21 @@ async function restartMachineTrack(page) {
 }
 
 // Read one machine's snapshot directly from its OWN `:machine/<track>` frame
-// app-db (rf2-q3lfm — per-machine frame isolation; snapshots no longer live
-// in `:rf/default`). Reconstructs the same `state … · tags …` text the old
-// `:rf/default` strip produced, scoped to the given track's frame, so the
+// RUNTIME-DB (rf2-q3lfm — per-machine frame isolation; snapshots no longer
+// live in `:rf/default`). Reconstructs the same `state … · tags …` text the
+// old `:rf/default` strip produced, scoped to the given track's frame, so the
 // per-machine assertions below read robustly. Returns `{ mounted, ... }`.
+//
+// rf2-wxu4l3 — machine snapshots are durable framework RUNTIME-DB state per
+// EP-0001 (rf2-vzld77; re-frame.machines.paths/snapshot-path): they live at
+// `[:rf.runtime/machines :snapshots <machine-id>]` in the runtime-db
+// PARTITION, read via the public `re-frame.core/runtime-db-value` seam — NOT
+// in app-db. The former `app-db-value` read at `[:rf/runtime :machines
+// :snapshots …]` looked at the stale pre-EP-0001 partition + key spelling and
+// always saw nil, so every track snapshot read back as `nil` (the door track
+// "booted to nil" symptom). The boot itself is correct (the door frame's
+// epoch ring shows :machine-epochs/boot-door → :door/main and runtime-db
+// carries `{:state :locked …}`); only this read seam was stale.
 //
 // `trackId` is the track name (e.g. 'door', 'media'); the frame id is
 // `:machine/<trackId>`. `machineIds` is the set of machine-ids the track
@@ -3002,8 +3026,8 @@ async function readTrackSnapshots(page, trackId, machineIds) {
   return page.evaluate(({ trackId, machineIds }) => {
     const cljs = window.cljs && window.cljs.core;
     const rf = window.re_frame && window.re_frame.core;
-    if (!cljs || !rf || typeof rf.app_db_value !== 'function') {
-      return { mounted: false, reason: 'cljs.core / re_frame.core.app_db_value unavailable' };
+    if (!cljs || !rf || typeof rf.runtime_db_value !== 'function') {
+      return { mounted: false, reason: 'cljs.core / re_frame.core.runtime_db_value unavailable' };
     }
     function keyword(s) {
       const trimmed = String(s).replace(/^:/, '');
@@ -3017,11 +3041,11 @@ async function readTrackSnapshots(page, trackId, machineIds) {
         ? cljs.keyword.call(null, trimmed)
         : cljs.keyword(trimmed);
     }
-    const db = rf.app_db_value(keyword(`:machine/${trackId}`));
-    if (db == null) return { mounted: false, reason: `no :machine/${trackId} app-db` };
+    const db = rf.runtime_db_value(keyword(`:machine/${trackId}`));
+    if (db == null) return { mounted: false, reason: `no :machine/${trackId} runtime-db` };
     function snapshot(machineId) {
       const path = cljs.PersistentVector.fromArray([
-        keyword(':rf/runtime'), keyword(':machines'),
+        keyword(':rf.runtime/machines'),
         keyword(':snapshots'), keyword(machineId),
       ], true);
       return cljs.get_in ? cljs.get_in(db, path) : null;

--- a/tools/xray/testbeds/machine_epochs/core.cljs
+++ b/tools/xray/testbeds/machine_epochs/core.cljs
@@ -220,8 +220,17 @@
          to its :final? state. The child fires :on-done (reporting the token to
          the parent) and auto-destroys. Asserts the child id is present — a
          missing spawn slot fails loud rather than silently no-opping."}
-  (fn handler-finish-login [{:keys [db]} _ev]
-    (let [child-id (get-in db (machine-paths/spawned-path :session/flow [:authenticating]))]
+  ;; EP-0001 (rf2-vzld77 / rf2-wxu4l3): the machines runtime — `:snapshots`
+  ;; AND the parent→child `:spawned` join-state map — is durable framework
+  ;; RUNTIME-DB state at `[:rf.runtime/machines …]`, NOT app-db. Read the
+  ;; spawned child id off the `:rf.db/runtime` coeffect every `reg-event-fx`
+  ;; receives (the canonical idiom — mirrors the routing `:on-match` loader
+  ;; reading the route slice off `:rf.db/runtime`). The former app-db read
+  ;; resolved nil (app-db never holds `:spawned`), so the assert no-op'd /
+  ;; the child was never driven to :final, and the parent's :on-done never
+  ;; stamped :session-token.
+  (fn handler-finish-login [{:keys [db] rt :rf.db/runtime} _ev]
+    (let [child-id (get-in rt (machine-paths/spawned-path :session/flow [:authenticating]))]
       (assert child-id
               (str "machine-epochs/finish-login: no spawned :session/login child at "
                    (machine-paths/spawned-path :session/flow [:authenticating])


### PR DESCRIPTION
Greens the 3 remaining RED xray-feature-gate behavioral scenarios (rf2-wxu4l3, EP-0002 follow-up). All three were REAL behavioral gaps, not Windows/Playwright flakes — each reproduces identically on a fresh compile, and the gate is now 16/16 green.

## Per-scenario verdict

- static mode chrome and chord — REAL fix. The Cmd-Shift-M chord flipped to Static, then the Static Machines browse-list crashed the whole surface with an uncaught :rf.error/no-frame-context. The plain-fn helpers search-box and sort-button (invoked as Reagent components, so they render in their own cycle) called rf/subscribe directly, but a plain fn cannot recover the surrounding :rf/xray frame (Spec 004 — plain Reagent fns do not pick up the surrounding frame). Fix: thread the already-derefed sub values (query, sort-key) down from the browse-list reg-view body, matching the routes/schemas/flows/interceptors search-box pattern (those already pass query as an arg).

- routes-epochs routing ladder — REAL fix (stale read seam + race). The #11 try-leave probe read the pending-navigation slot from app-db at the stale pre-EP-0001 partition and raced the block cascade commit. Fix: read it from runtime-db at the EP-0001 location via runtime-db-value, and poll until it fills (the afterBlocked wait resolves immediately because CURRENT ROUTE was already on :settings from rung #10). The framework behavior is correct — the guard blocks and the slot fills, the probe was just reading the wrong place.

- machine-epochs stepper — REAL fix (stale read seam + deck bug). readTrackSnapshots read machine snapshots from app-db (stale pre-EP-0001), so every track booted to nil; the boot is correct (snapshots are durable runtime-db state per re-frame.machines.paths). Fix: read via runtime-db-value at the runtime-db machines path. Also fixed the deck's :machine-epochs/finish-login, which read the spawned child id from app-db (always nil post-EP-0001) instead of the :rf.db/runtime coeffect, so the session child never reached :final and the parent on-done never stamped :session-token.

## Why CLJS tests missed the static crash

The browse_list CLJS render tests run inside (with-frame :rf/xray ...), so the plain-fn subscribe saw the ambient frame and passed. In the real React render the plain-fn child renders in its own cycle with no ambient binding — only the browser gate exercised the real path.

## Xray spec sync

Updated tools/xray/spec/017-Test-Coverage-Matrix.md (machine-epochs section): the per-track snapshot read is off the frame runtime-db partition at the machines snapshots path, not app-db. The static browse_list change is implementation-internal (no contract/testid/behavior change; the frame-correctness invariant is already documented in the shared search-box ns and static shell docstrings).

## Gate result

npm run test:xray-feature-gate — 16 scenarios, 0 failures (was 3). The lone npm run test:cljs async :rf.error/no-frame-context flake is the pre-existing rf2-ofzxh9 isolation flake (websocket fixture), unrelated to these surfaces; the suite exits 0.

Closes rf2-wxu4l3.
