### PR TITLE
docs(xray): realign README headline-experiences table to the 6-tab/4-layer chrome (rf2-ch3gaz)

### DIFF
--- a/tools/xray/README.md
+++ b/tools/xray/README.md
@@ -34,17 +34,54 @@ dedicated xray-mcp jar is unnecessary; agents read the same trace bus
 
 ## Headline experiences
 
-| Surface | What it does |
-|---|---|
-| **Event-detail panel** (hero) | Lands on every open. The event vector, the diff, the inline mini-graph, fx fired, subs recomputed, renders, duration. Answers the canonical questions on first paint. |
-| **Time-travel scrubber** | Bottom rail. Passive scrubbing rebases the view of history; explicit rewind calls `restore-epoch` with the six failure modes surfaced. |
-| **Slice-centric app-db panel** | The slices that changed, the slices the user pinned. Read-only. |
-| **Machine inspector** | Stately-quality state-chart per machine. Embeds `tools/machines-viz/`. |
-| **Schema-violation timeline** | One row per registered schema; coloured dot per failure with recovery mode. |
-| **Hydration debugger** | Server vs client render-tree side-by-side. Only visible when SSR hydration runs. |
-| **Issues ribbon** | Unified feed: errors + warnings + schema violations + hydration mismatches. |
+The chrome is a **4-layer spine** (chrome ribbon · event list · tab bar ·
+detail panel) per [`spec/018-Event-Spine.md`](./spec/018-Event-Spine.md).
+Selecting an event in the L2 event list moves a single spine sub
+(`:rf.xray/focus`); every Dynamic tab is a *lens on that one focused
+event*. Time-travel is the spine itself — the events-ribbon nav cluster
+plus the event list are the scrubber; there is no bottom rail. Issues are
+not a tab — they surface inline in the Epoch panel, the L2 event-row
+pink-wash, and the always-on issues ribbon signal (per rf2-gbz39).
 
-Full panel inventory in [`spec/000-Vision.md`](./spec/000-Vision.md).
+### Dynamic mode — the 6 tabs (lenses on the focused event)
+
+| Tab | What it shows for the focused event |
+|---|---|
+| **Epoch** (`e`) | Lands on every open. The numbered cascade — dispatch · coeffects · handler · flow · fx · effects — plus inline issues (per-step pass/fail + the "Exception Thrown" block). Answers the canonical questions on first paint. |
+| **App-db** (`a`) | The slice-centric `:db-before → :db-after` diff for this event; pinned slices; full-tree escape hatch. Read-only. |
+| **Views** (`v`) | The subs recomputed because of this event + the components that re-rendered. |
+| **Trace** (`t`) | The raw trace stream filtered to this event's cascade, with the wall-clock axis for timers / retries / deferred dispatches. |
+| **Machine** (`m`) | The transitions this event triggered + spawn/destroy cascades. Stately-quality state-chart per machine; embeds `tools/machines-viz/`. |
+| **Routes** (`r`) | The matched route + params/query/fragment + Simulate-URL, for the focused event. |
+
+### Static mode — the 5 browse surfaces (registry catalogue, event-independent)
+
+A peer 3-layer surface (no spine) for browsing *everything that could
+fire*, not just what did — per Lock #14/#15 in
+[`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md). Toggle with
+`Ctrl+Shift+M`.
+
+| Tab | What it browses |
+|---|---|
+| **Machines** (`m`) | Every registered machine; topology chart + browse-list with a `→ Dynamic` jump chip. |
+| **Routes** (`r`) | Every registered route; substring search + hermetic Simulate-URL / Simulate-navigation preview + `→ Dynamic` jump. |
+| **Schemas** (`c`) | Every app-db / event / sub schema; the Malli EDN + jump-to-source. |
+| **Flows** (`f`) | Every `reg-flow` registration; inputs, output path, owning frame, doc-string. |
+| **Interceptors** (`i`) | Every registered interceptor. |
+
+Full canonical inventory in [`spec/000-Vision.md`](./spec/000-Vision.md)
+§The tab table and [`spec/018-Event-Spine.md`](./spec/018-Event-Spine.md).
+
+> **Maintainers — chrome-shape drift guard.** When a Dynamic/Static tab
+> is added, retired, folded, or renamed, update this Headline-experiences
+> table in the SAME change, alongside the canonical sources
+> ([`spec/000-Vision.md`](./spec/000-Vision.md) §tab table,
+> [`spec/018-Event-Spine.md`](./spec/018-Event-Spine.md) §5, and
+> [`testbeds/panel_gallery/core.cljs`](./testbeds/panel_gallery/core.cljs)).
+> The README is the first orientation surface; stale tab vocabulary here
+> teaches the wrong mental model. The authoritative tab inventory is the
+> `panel-registry/reg-l4-tab!` calls in `src/.../panels/*` (Dynamic) and
+> `src/.../static/*/panel.cljs` (Static).
 
 ## Quick start
 


### PR DESCRIPTION
## What

Realigns the tools/xray README "Headline experiences" table to the current 4-layer / 6-tab chrome, resolving the rf2-ch3gaz best-practice-review finding 1 (README documentation drift).

The table advertised legacy surfaces the current chrome/spec has folded or retired:
- "Event-detail panel" hero, "Time-travel scrubber" as a bottom rail
- standalone "Schema-violation timeline" and "Hydration debugger" headline surfaces
- an "Issues ribbon" as a headline experience

These contradicted the README's own "What it is" paragraph (which already says "6-tab Dynamic + 5-tab Static") and the canonical sources.

## Now teaches the canonical model

- **Dynamic mode** — the 6 lens-on-focused-event tabs: Epoch (e), App-db (a), Views (v), Trace (t), Machine (m), Routes (r).
- **Static mode** — the 5 registry browse surfaces: Machines, Routes, Schemas, Flows, Interceptors.
- Time-travel is the spine itself (no bottom rail); Issues fold inline (Epoch panel + L2 event-row pink-wash + ribbon signal) per rf2-gbz39.

Verified against the executable truth — the PANEL_HANDOFFS in tools/xray/testbeds/feature_matrix/scenarios.cjs (6 entries) and the panel-registry/reg-l4-tab! registrations in src/.../panels/* (Dynamic) and src/.../static/*/panel.cljs (Static) — plus spec/000-Vision.md, spec/018-Event-Spine.md, and DESIGN-RATIONALE Lock #14/#15.

## Drift guard (finding 1 acceptance criterion 3)

Adds a maintainer chrome-shape drift-guard note to the README so the table is updated in the SAME change whenever a tab is added/retired/folded/renamed, pointing at the authoritative reg-l4-tab! registrations and the canonical spec sources.

## Spec sync

Spec unchanged: the README was the drifted artefact; the spec docs it now points to already carry the canonical 6-tab / Issues-folded model.

## Finding 2 (visual-regression gate) — not implemented here

Premise verified (no toHaveScreenshot / pixelmatch / visual baseline anywhere under tools/xray; the only panel-gallery scenario is a CSS-variable boot probe; gate screenshots are diagnostic-on-failure only). Deliberately NOT landed in this PR: a screenshot/pixel-baseline gate locks the current rendering in as the golden reference and carries genuine unmade design decisions (cross-platform pixel parity — Windows-dev vs Linux-CI font AA flake; PR-smoke vs nightly cadence; baseline ownership/update flow; subset). Filed as decision bead **rf2-4pka2b** for a ruling. Visual baselines must be eyeballed by a human before becoming the golden reference.

## Also filed

**rf2-wghr82** — stale "7 tab" references across xray spec+src (Dynamic is 6 tabs post rf2-gbz39); several are in hot-zone files so kept out of this PR's scope.

## Slice gate

npm run test:xray-feature-gate — green: "Ran 16 Xray feature scenarios (nightly-full sweep). 0 failures." (16/16, includes the rf2-wxu4l3 fixes).

This is a doc-only change; no source/behavior/visual-layout impact.
