### PR TITLE
refactor(core): remove orphaned schema-sensitive-handler? predicate (rf2-abkc3k)

### DIFF
--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -65,12 +65,6 @@
                   sensitive-paths))
           (handler-db-paths interceptors))))))
 
-(defn schema-sensitive-handler?
-  "True when a handler's path-scoped db slice overlaps a schema-declared
-  sensitive app-db slot."
-  [frame-id interceptors]
-  (boolean (seq (schema-redaction-paths frame-id interceptors))))
-
 (defn- redact-path
   [payload path]
   (let [path (vec path)]


### PR DESCRIPTION
Vestigial-review finding rf2-abkc3k: remove the one confirmed orphan in implementation/core.

## What

Removed the public defn schema-sensitive-handler? from re-frame.privacy (privacy.cljc). It had zero references anywhere in the tracked tree.

## Why it is safe

- git grep across all tracked source/test/.edn/.cjs/.md files: the only hit for the symbol was its own definition.
- Not facade-exported from re-frame.core (only redact-interceptor and sensitive? re-export from privacy).
- re-frame.privacy carries no entries in spec/api-manifest.edn or spec/api-manifest-metadata.edn, so removal cannot cause API-manifest drift. Not a public/contract surface.
- It was a thin predicate wrapper over schema-redaction-paths; the actual consumer router.cljc computes :schema-sensitive? inline via (boolean (seq redaction-paths)) and never reaches the wrapper.
- schema-redaction-paths itself stays live: one real caller at router.cljc:1396.
- Note: re-frame.schemas/schema-sensitive-at? is a distinct, live symbol in a different namespace and is untouched.

## Slice gate

- Core JVM (cd implementation/core && clojure -M:test): 1050 tests, 4525 assertions, 0 failures / 0 errors.
- API-manifest drift-check: N/A — removed symbol is not in the manifest and not public-adjacent.
