### PR TITLE
fix(http): cancel pending timers in clear-all-in-flight! + stub managed HTTP in realworld test frames (rf2-adcmk8)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -251,7 +251,8 @@
     (is (false? (rf/compute-sub [:editor/dirty?] (rf/frame-state-value f))))))
 
 (defn- editor-can-leave-test []
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+                                 :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:editor/initialise] {:frame f})
     (is (true? (rf/compute-sub [:editor/can-leave?] (rf/frame-state-value f))))
     (rf/dispatch-sync [:editor/edit-field :title "Changed"] {:frame f})
@@ -347,7 +348,8 @@
   ;; or a concurrent delete), a stale index can point past the current
   ;; vector. The rollback's `subvec` must NOT throw IndexOutOfBounds — it
   ;; clamps the index to the current length and re-inserts at the tail.
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+                                 :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:comments/initialise] {:frame f})
     ;; Seed a single comment (the list is now length 1).
     (rf/dispatch-sync
@@ -570,7 +572,8 @@
   ;; when the draft failed validation, matching Pattern-Forms'
   ;; §Standard events table.
   (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
-                                 :fx-overrides {:auth.session/persist :rf/no-op}})]
+                                 :fx-overrides {:rf.http/managed       :realworld.test/canned-success-empty
+                                                :auth.session/persist :rf/no-op}})]
     (rf/dispatch-sync [:auth/store-session {:email "alice@example.com"
                                             :token "jwt-1"
                                             :username "alice"
@@ -616,7 +619,8 @@
                   (rf/frame-state-value frame)))
 
 (defn- tag-query-test []
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+                                 :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:tags/apply-filter "clojure"] {:frame f})
     (is (= "clojure" (:tag (rf/compute-sub [:rf.route/query] (rf/frame-state-value f)))))
     (rf/dispatch-sync [:home/show-your-feed] {:frame f})
@@ -686,7 +690,8 @@
 ;; ============================================================================
 
 (defn- routing-tests []
-  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]})]
+  (with-new-frame [f (rf/make-frame {:on-create [:app/initialise]
+                                 :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}})]
     (rf/dispatch-sync [:rf.route/navigate :realworld.article/show {:slug "hello"}] {:frame f})
     (is (= :realworld.article/show (rf/compute-sub [:rf.route/id] (rf/frame-state-value f))))
     (is (= "hello" (:slug (rf/compute-sub [:rf.route/params] (rf/frame-state-value f)))))
@@ -709,6 +714,7 @@
   ;; (core.cljs). Configure the test frame with the same interceptor so
   ;; the guard is exercised end-to-end.
   (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+                                 :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
                                  :interceptors [routing/auth-guard]})]
     ;; Unauthenticated: navigating to a :requires-auth route
     ;; (:realworld.user/settings) is redirected to :realworld.auth/login.
@@ -752,6 +758,7 @@
 
   ;; --- direct-URL / reload / popstate (`:rf.route/handle-url-change`) ---
   (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+                                 :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
                                  :interceptors [routing/auth-guard]})]
     ;; Logged-out direct URL (or reload) to a :requires-auth route.
     (rf/dispatch-sync [:rf.route/handle-url-change "/settings"] {:frame f})
@@ -777,6 +784,7 @@
 
   ;; --- anchor click (`:rf/url-requested`) ---
   (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+                                 :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
                                  :interceptors [routing/auth-guard]})]
     ;; An anchor whose href targets a :requires-auth route. The
     ;; framework `rf/route-link` dispatches `:rf/url-requested` with the
@@ -805,6 +813,7 @@
 
   ;; --- authenticated: every entry point now PASSES through ---
   (with-new-frame [f (rf/make-frame {:on-create    [:app/initialise]
+                                 :fx-overrides {:rf.http/managed :realworld.test/canned-success-empty}
                                  :interceptors [routing/auth-guard]})]
     (rf/dispatch-sync [:auth/store-session {:username "eve" :token "t"}] {:frame f})
     ;; direct-URL / reload to a guarded route proceeds when logged in.

--- a/implementation/http/src/re_frame/http_registry.cljc
+++ b/implementation/http/src/re_frame/http_registry.cljc
@@ -143,9 +143,47 @@
       (catch #?(:clj Throwable :cljs :default) _ nil))))
 
 (defn clear-all-in-flight!
-  "Test-time helper: drop the in-flight registry. Test fixtures use this
-  between runs."
+  "Test-time helper: cancel every in-flight managed request, then drop the
+  registry. Test fixtures use this between runs.
+
+  rf2-adcmk8 — symmetric with `:machines/reset-timers!` (0-arity): a
+  request sleeping in a `schedule-backoff-handle!` retry window holds an
+  armed `js/setTimeout` / `ScheduledFuture` backoff timer that would
+  otherwise outlive the synchronous test, fire `run-attempt!`, and
+  dispatch into a runtime the next test owns. Firing each handle's
+  `:abort-fn` runs the once-only cancel cascade (`interop/clear-timeout!`
+  / `AbortController.abort` → `clear-in-flight!`), releasing the host-
+  clock handle so no timer is left armed. Each abort-fn also clears its
+  own slot from both indexes; the trailing `reset!`s mop up any handle
+  that was unindexed or that an abort-fn left behind, and guarantee a
+  clean registry regardless.
+
+  Walk BOTH indexes: an anonymous-from-actor request (request-id nil) is
+  indexed only in `actor-in-flight`, so iterating `in-flight` alone would
+  miss its armed timer. Dedupe by identity (the same stamped handle sits
+  in both indexes when it carries request-id + actor-id) so each abort-fn
+  fires once — the once-only CAS inside the abort-fn already makes a
+  double-fire a harmless no-op, but the dedupe keeps the work minimal.
+
+  Snapshot the handles before firing so an abort-fn's own
+  `swap!`/`clear-in-flight!` cannot trip a concurrent-modification on the
+  iteration. Each abort-fn is fired defensively — a throwing one must not
+  strand the remaining handles or leave the registry undropped. The abort
+  reason `:test-reset` marks these as fixture-teardown cancellations
+  rather than real runtime aborts."
   []
+  (let [handles (->> (concat (vals @in-flight)
+                             (mapcat val @actor-in-flight))
+                     (reduce (fn [acc h]
+                               (if (some #(identical? % h) acc)
+                                 acc
+                                 (conj acc h)))
+                             []))]
+    (doseq [handle handles]
+      (when-let [abort-fn (:abort-fn handle)]
+        (try
+          (abort-fn :test-reset)
+          (catch #?(:clj Throwable :cljs :default) _ nil)))))
   (reset! in-flight {})
   (reset! actor-in-flight {})
   nil)


### PR DESCRIPTION
Closes rf2-adcmk8. Two latent (not currently flaking, but fragile) HTTP test-isolation fixes.

## 1. clear-all-in-flight! now cancels pending backoff timers (production)

`re-frame.http-registry/clear-all-in-flight!` previously only `reset!`-ed the in-flight atoms. A request sleeping in a `schedule-backoff-handle!` retry window kept its armed `js/setTimeout` / `ScheduledFuture` backoff timer, which could outlive the synchronous test, fire `run-attempt!`, and dispatch into a runtime the next test owns (the same shape as the rf2-ofzxh9 leaked-timer flake).

It now walks BOTH indexes (request-id + actor-id, identity-deduped so anonymous-from-actor handles are covered without double-firing), fires each handle's `:abort-fn` defensively (the once-only cancel cascade: `interop/clear-timeout!` / `AbortController.abort` then `clear-in-flight!`), then drops the registry. This is symmetric with `:machines/reset-timers!` (0-arity).

## 2. realworld test frames stub :rf.http/managed (test-only)

Several `realworld_cljs_test` frames booted `:app/initialise` and then drove route changes (`:rf.route/navigate` / `:rf.route/handle-url-change`) whose `:on-match` drains auto-load via a real `:rf.http/managed` (`:home/load`, `:article/load`, `:comments/load`, `:profile/load`, `:settings/load`). Un-stubbed, those hit the real Fetch transport, fail in node, retry, and arm backoff timers that leak past the test. Every `:app/initialise` frame now stubs `:rf.http/managed` (`:realworld.test/canned-success-empty`), so no real HTTP escapes a test that is not asserting HTTP. Aligns with the clean-test-surface principle.

Frames stubbed: editor-can-leave, comment-delete-rollback, settings-validation, tag-query, routing-tests, auth-guard, and the three auth-guard-all-access-paths frames.

## Slice gates
- JVM http artefact: 380 tests / 1737 assertions, 0 failures/errors (exercises `clear-all-in-flight!` in fixtures + the abort-fn cascade).
- node CLJS suite (`npm run test:cljs`): 6128 tests / 21882 assertions, 0 failures/errors, run twice — no flake.
