### PR TITLE
fix(xray): thread sim sub values from detail reg-view into sim plain fns (rf2-jholrb)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/definition_detail.cljs
@@ -161,8 +161,15 @@
 (defn- body
   "Dispatch to the per-mode body renderer. Topology + Sim render a
   body; Instances + Cascade do not (Instances is a JUMP affordance,
-  Cascade is dimmed). `dispatch` (rf2-nesy9) is threaded from `detail`."
-  [dispatch {:keys [sub-mode machine-id definition source-coord fit-signal]}]
+  Cascade is dimmed). `dispatch` (rf2-nesy9) is threaded from `detail`.
+
+  rf2-jholrb — the Sim sub-mode's plain-fn subtree (`sim/body` →
+  `SimChart` / `SimRail`) cannot recover the `:rf/xray` frame to
+  subscribe (Spec 004), so its sub values (`sim-values`) are derefed in
+  the `detail` reg-view and threaded down through here (mirrors the
+  rf2-wxu4l3 browse-list fix)."
+  [dispatch {:keys [sub-mode machine-id definition source-coord fit-signal
+                    sim-values]}]
   (case sub-mode
     :topology
     [topology/body dispatch {:machine-id   machine-id
@@ -171,8 +178,9 @@
                              :fit-signal   fit-signal}]
 
     :sim
-    [sim/body dispatch {:machine-id machine-id
-                        :definition definition}]
+    [sim/body dispatch (merge {:machine-id machine-id
+                               :definition definition}
+                              sim-values)]
 
     ;; :instances + :cascade — no body. Render an explanatory placeholder
     ;; so the user understands the strip click landed.
@@ -227,7 +235,27 @@
         ;; select-tab :machines`). Threaded down to the Topology body's
         ;; `machine-canvas/Chart` `:fit-signal` so entering the Static
         ;; Machines tab re-frames the topology to view.
-        fit-signal @(rf/subscribe [:rf.xray/machine-tab-fit-signal])]
+        fit-signal @(rf/subscribe [:rf.xray/machine-tab-fit-signal])
+        ;; rf2-jholrb — the Sim sub-mode's plain-fn subtree (`sim/body` →
+        ;; `SimChart` / `SimRail`) renders in its OWN React cycle and so
+        ;; cannot recover the `:rf/xray` frame to `rf/subscribe` itself
+        ;; (Spec 004). Deref the sim sub family HERE (in this reg-view,
+        ;; where the frame IS in context) and thread the values down —
+        ;; mirroring the rf2-wxu4l3 browse-list fix. Only derefed on the
+        ;; `:sim` sub-mode so the Topology/Instances/Cascade modes don't
+        ;; subscribe to sim state. The subs short-circuit to nil when sim
+        ;; isn't active for the selected machine, so this is cheap.
+        sim-values (when (= sub-mode :sim)
+                     {:sim         @(rf/subscribe
+                                      [:rf.xray.static.machines/sim-state])
+                      :transitions @(rf/subscribe
+                                      [:rf.xray.static.machines/sim-available-transitions])
+                      :suggestions @(rf/subscribe
+                                      [:rf.xray.static.machines/sim-event-suggestions])
+                      :current     @(rf/subscribe
+                                      [:rf.xray.static.machines/sim-current-state])
+                      :last-trans  @(rf/subscribe
+                                      [:rf.xray.static.machines/sim-last-transition])})]
     (if (nil? row)
       (empty-detail)
       (let [{:keys [machine-id state-count live-count source-coord]} row
@@ -255,4 +283,5 @@
                           :machine-id   machine-id
                           :definition   definition
                           :source-coord source-coord
-                          :fit-signal   fit-signal}]]]))))
+                          :fit-signal   fit-signal
+                          :sim-values   sim-values}]]]))))

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/sim.cljs
@@ -612,9 +612,7 @@
 (defn SimRail
   "The Sim sub-mode's content rail — banner + current state + event
   picker + Step / Reset / Exit + available transitions + audit trail.
-  Pure hiccup (per Xray's rf2-tijr convention) — every subscribe /
-  dispatch resolves against `:rf/xray` via the enclosing
-  frame-provider in `shell.cljs`.
+  Pure hiccup (per Xray's rf2-tijr convention).
 
   Returns nil when sim is not active for the currently-selected
   machine (the caller is expected to dispatch `:sim-start` BEFORE
@@ -622,16 +620,20 @@
   during the auto-start microtask gap).
 
   `dispatch` (rf2-nesy9) is the frame-aware dispatcher threaded from
-  `body` — fanned out to every control helper (a plain fn invoked as a
-  Reagent component renders in its own cycle, so render-time frame
-  recovery is unavailable)."
-  [dispatch]
-  (let [sim          @(rf/subscribe [:rf.xray.static.machines/sim-state])
-        transitions  @(rf/subscribe
-                        [:rf.xray.static.machines/sim-available-transitions])
-        suggestions  @(rf/subscribe
-                        [:rf.xray.static.machines/sim-event-suggestions])
-        machine-id   (:machine-id sim)]
+  `body` — fanned out to every control helper.
+
+  `sim` / `transitions` / `suggestions` (rf2-jholrb) are the derefed sub
+  values threaded down from the `detail` reg-view (`definition_detail`),
+  via `body`. SimRail is a plain fn invoked as a Reagent component, so it
+  renders in its OWN cycle and CANNOT recover the surrounding `:rf/xray`
+  frame to `rf/subscribe` itself (Spec 004 §Plain Reagent fns do not pick
+  up the surrounding frame; a bare `subscribe` here throws
+  `:rf.error/no-frame-context` and crashes the whole Static surface).
+  The reg-view body derefs `:sim-state` / `:sim-available-transitions` /
+  `:sim-event-suggestions` where the frame IS in context and passes the
+  values down."
+  [dispatch {:keys [sim transitions suggestions]}]
+  (let [machine-id (:machine-id sim)]
     (when sim
       [:section
        {:data-testid "rf-xray-static-machines-sim-rail"
@@ -692,49 +694,53 @@
   Returns nil when sim is inactive (the auto-start gap) so the host's
   `when sim` guard keeps the render safe.
 
-  Pure hiccup (Xray rf2-tijr convention) — subscribes/dispatches
-  resolve against `:rf/xray` via the shell's frame-provider. `dispatch`
-  (rf2-nesy9) is the frame-aware dispatcher threaded from `body`."
-  [dispatch {:keys [machine-id definition]}]
-  (let [current     @(rf/subscribe
-                       [:rf.xray.static.machines/sim-current-state])
-        last-trans  @(rf/subscribe
-                       [:rf.xray.static.machines/sim-last-transition])]
-    [:div {:data-testid "rf-xray-static-machines-sim-chart"
-           :data-machine-id (str machine-id)
-           :data-current-state (sim-h/format-state-display current)
-           :style {:position   "relative"
-                   :flex       "1 1 auto"
-                   :min-height "260px"
-                   :background (:bg-1 tokens)
-                   :border-top (str "1px solid " (:yellow tokens))
-                   :overflow   "hidden"}}
-     [machine-canvas/Chart
-      {:definition             definition
-       :machine-id             machine-id
-       :current-state          current
-       ;; rf2-eao0s0 — surface the STATIC context shape so the root
-       ;; Context band renders on the Static Sim chart too (the Dynamic
-       ;; topology + focused-event + Static Topology charts already do).
-       ;; Shape + provenance come from the shared machines-viz-backed
-       ;; helpers; nil shape → the chart hides the panel.
-       :machine-data           (topology-view/static-context-shape definition)
-       :machine-data-inferred? (topology-view/static-context-inferred? definition)
-       :from-highlight         (:from last-trans)
-       :to-highlight           (:to last-trans)
-       :sim?                   true
-       :show-after-rings?      false
-       :inner-testid           "rf-xray-static-machines-sim-chart-svg"
-       :on-edge-click
-       (fn [payload]
-         ;; The chart hands a JS payload `#js {:eventId :fromPath
-         ;; :toPath}`; read the fireable event-id off it and dispatch
-         ;; the on-chart step. nil/inert edges produce a no-op event.
-         (let [event-id (some-> payload (aget "eventId"))]
-           (dispatch
-             [:rf.xray.static.machines/sim-chart-edge-clicked
-              {:machine-id machine-id
-               :event-id   event-id}])))}]]))
+  Pure hiccup (Xray rf2-tijr convention). `dispatch` (rf2-nesy9) is the
+  frame-aware dispatcher threaded from `body`.
+
+  `current` / `last-trans` (rf2-jholrb) are the derefed sub values
+  threaded down from the `detail` reg-view (`definition_detail`), via
+  `body`. SimChart is a plain fn invoked as a Reagent component, so it
+  renders in its OWN cycle and CANNOT recover the surrounding `:rf/xray`
+  frame to `rf/subscribe` itself (Spec 004; a bare `subscribe` here
+  throws `:rf.error/no-frame-context` and crashes the Static surface).
+  The reg-view body derefs `:sim-current-state` / `:sim-last-transition`
+  where the frame IS in context and passes the values down."
+  [dispatch {:keys [machine-id definition current last-trans]}]
+  [:div {:data-testid "rf-xray-static-machines-sim-chart"
+         :data-machine-id (str machine-id)
+         :data-current-state (sim-h/format-state-display current)
+         :style {:position   "relative"
+                 :flex       "1 1 auto"
+                 :min-height "260px"
+                 :background (:bg-1 tokens)
+                 :border-top (str "1px solid " (:yellow tokens))
+                 :overflow   "hidden"}}
+   [machine-canvas/Chart
+    {:definition             definition
+     :machine-id             machine-id
+     :current-state          current
+     ;; rf2-eao0s0 — surface the STATIC context shape so the root
+     ;; Context band renders on the Static Sim chart too (the Dynamic
+     ;; topology + focused-event + Static Topology charts already do).
+     ;; Shape + provenance come from the shared machines-viz-backed
+     ;; helpers; nil shape → the chart hides the panel.
+     :machine-data           (topology-view/static-context-shape definition)
+     :machine-data-inferred? (topology-view/static-context-inferred? definition)
+     :from-highlight         (:from last-trans)
+     :to-highlight           (:to last-trans)
+     :sim?                   true
+     :show-after-rings?      false
+     :inner-testid           "rf-xray-static-machines-sim-chart-svg"
+     :on-edge-click
+     (fn [payload]
+       ;; The chart hands a JS payload `#js {:eventId :fromPath
+       ;; :toPath}`; read the fireable event-id off it and dispatch
+       ;; the on-chart step. nil/inert edges produce a no-op event.
+       (let [event-id (some-> payload (aget "eventId"))]
+         (dispatch
+           [:rf.xray.static.machines/sim-chart-edge-clicked
+            {:machine-id machine-id
+             :event-id   event-id}])))}]])
 
 ;; ---- body (mounted from definition_detail.cljs) ------------------------
 
@@ -760,69 +766,90 @@
   the controls + diagnostics that don't belong on the canvas: the
   payload input, Reset / Exit, guard pass/fail error toast, and the
   audit trail. The chart and rail read the SAME sim-state, so clicking
-  an edge and clicking a Step button are interchangeable."
-  [dispatch {:keys [machine-id definition]}]
-  (let [sim @(rf/subscribe [:rf.xray.static.machines/sim-state])]
-    (when (and (some? machine-id)
-               (some? definition)
-               (nil? sim))
-      ;; rf2-nesy9 — auto-start dispatches through the threaded
-      ;; frame-aware `dispatch` (sim/body is invoked as a Reagent
-      ;; component, so render-time frame recovery is unavailable).
-      (dispatch [:rf.xray.static.machines/sim-start
-                 {:machine-id machine-id
-                  :definition definition}]))
-    (cond
-      ;; No machine to drive sim against.
-      (nil? machine-id)
-      [:section {:data-testid "rf-xray-static-machines-sim-no-machine"
-                 :style {:padding "16px"
-                         :color (:text-tertiary tokens)
-                         :font-family sans-stack
-                         :font-size (:body type-scale)}}
-       "No machine selected."]
+  an edge and clicking a Step button are interchangeable.
 
-      ;; Machine selected but no introspectable definition — Sim can't
-      ;; clone what isn't there.
-      (nil? definition)
-      [:section {:data-testid "rf-xray-static-machines-sim-no-definition"
-                 :data-machine-id (str machine-id)
-                 :style {:padding "16px"
-                         :color (:text-tertiary tokens)
-                         :font-family sans-stack
-                         :font-size (:body type-scale)}}
-       "No introspectable definition for "
-       [:code {:style {:font-family mono-stack
-                       :color (:accent tokens)}}
-        (str machine-id)]
-       " — Sim cannot clone what isn't there."]
+  ## Frame recovery (rf2-jholrb)
 
-      ;; Sim-state has landed (or the auto-start dispatch just queued).
-      ;; rf2-u422r — two-pane split: the on-chart sim surface is primary,
-      ;; the rail is the side detail/controls column. Both guard the
-      ;; auto-start gap (`SimChart` returns its wrapper unconditionally
-      ;; but the chart degrades on a nil definition; `SimRail`'s `when
-      ;; sim` keeps the gap render safe).
-      :else
-      [:section {:data-testid "rf-xray-static-machines-sim-body"
-                 :data-machine-id (str machine-id)
-                 :style {:display "flex"
-                         :flex-direction "row"
-                         :height "100%"
-                         :min-height "0"}}
-       [:div {:data-testid "rf-xray-static-machines-sim-chart-pane"
-              :style {:display "flex"
-                      :flex-direction "column"
-                      :flex "1 1 auto"
-                      :min-width "0"
-                      :min-height "0"}}
-        [SimChart dispatch {:machine-id machine-id :definition definition}]]
-       [:div {:data-testid "rf-xray-static-machines-sim-rail-pane"
-              :style {:flex "0 0 320px"
-                      :max-width "360px"
-                      :overflow "auto"
-                      :border-left (str "1px solid " (:border-subtle tokens))}}
-        [SimRail dispatch]]])))
+  `body` is mounted by `definition_detail/body` as a plain-fn Reagent
+  component, so it renders in its OWN cycle and CANNOT recover the
+  surrounding `:rf/xray` frame to `rf/subscribe` itself (Spec 004; a bare
+  `subscribe` here throws `:rf.error/no-frame-context` and crashes the
+  Static surface). All sim sub values — `sim` (`:sim-state`),
+  `transitions`, `suggestions`, `current`, `last-trans` — are derefed in
+  the `detail` reg-view (where the frame IS in context) and threaded down
+  through `definition_detail/body` to here, then fanned out to `SimChart`
+  / `SimRail` (themselves plain-fn components). This mirrors the
+  rf2-wxu4l3 browse-list fix exactly."
+  [dispatch {:keys [machine-id definition sim transitions suggestions
+                    current last-trans]}]
+  ;; Side-effecting auto-start, then the render. The `defn` body is an
+  ;; implicit `do`, so the discarded `when` runs for its dispatch effect
+  ;; and the `cond` is the returned hiccup.
+  (when (and (some? machine-id)
+             (some? definition)
+             (nil? sim))
+    ;; rf2-nesy9 — auto-start dispatches through the threaded
+    ;; frame-aware `dispatch` (sim/body is invoked as a Reagent
+    ;; component, so render-time frame recovery is unavailable).
+    (dispatch [:rf.xray.static.machines/sim-start
+               {:machine-id machine-id
+                :definition definition}]))
+  (cond
+    ;; No machine to drive sim against.
+    (nil? machine-id)
+    [:section {:data-testid "rf-xray-static-machines-sim-no-machine"
+               :style {:padding "16px"
+                       :color (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size (:body type-scale)}}
+     "No machine selected."]
+
+    ;; Machine selected but no introspectable definition — Sim can't
+    ;; clone what isn't there.
+    (nil? definition)
+    [:section {:data-testid "rf-xray-static-machines-sim-no-definition"
+               :data-machine-id (str machine-id)
+               :style {:padding "16px"
+                       :color (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size (:body type-scale)}}
+     "No introspectable definition for "
+     [:code {:style {:font-family mono-stack
+                     :color (:accent tokens)}}
+      (str machine-id)]
+     " — Sim cannot clone what isn't there."]
+
+    ;; Sim-state has landed (or the auto-start dispatch just queued).
+    ;; rf2-u422r — two-pane split: the on-chart sim surface is primary,
+    ;; the rail is the side detail/controls column. Both guard the
+    ;; auto-start gap (`SimChart` returns its wrapper unconditionally
+    ;; but the chart degrades on a nil definition; `SimRail`'s `when
+    ;; sim` keeps the gap render safe).
+    :else
+    [:section {:data-testid "rf-xray-static-machines-sim-body"
+               :data-machine-id (str machine-id)
+               :style {:display "flex"
+                       :flex-direction "row"
+                       :height "100%"
+                       :min-height "0"}}
+     [:div {:data-testid "rf-xray-static-machines-sim-chart-pane"
+            :style {:display "flex"
+                    :flex-direction "column"
+                    :flex "1 1 auto"
+                    :min-width "0"
+                    :min-height "0"}}
+      [SimChart dispatch {:machine-id  machine-id
+                          :definition  definition
+                          :current     current
+                          :last-trans  last-trans}]]
+     [:div {:data-testid "rf-xray-static-machines-sim-rail-pane"
+            :style {:flex "0 0 320px"
+                    :max-width "360px"
+                    :overflow "auto"
+                    :border-left (str "1px solid " (:border-subtle tokens))}}
+      [SimRail dispatch {:sim         sim
+                         :transitions transitions
+                         :suggestions suggestions}]]]))
 
 ;; ---- public install entry -----------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/sim_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/sim_cljs_test.cljs
@@ -128,6 +128,34 @@
 (defn- select-static-machine! [machine-id]
   (rf/dispatch-sync [:rf.xray.static.machines/select machine-id]))
 
+;; rf2-jholrb — the sim plain-fn subtree (`body` / `SimRail` / `SimChart`)
+;; no longer self-subscribes; it receives the derefed sub values from the
+;; enclosing `detail` reg-view. These helpers deref the sim sub family
+;; (under `:rf/xray`, where the frame is in context) so the tests can
+;; thread the same values the reg-view would. This mirrors the production
+;; threading exactly — the tests no longer rely on the plain fns
+;; recovering a frame they cannot reach.
+
+(defn- sim-rail-values
+  "The values `SimRail` reads, derefed where the frame is in context."
+  []
+  {:sim         @(rf/subscribe [:rf.xray.static.machines/sim-state])
+   :transitions @(rf/subscribe
+                   [:rf.xray.static.machines/sim-available-transitions])
+   :suggestions @(rf/subscribe
+                   [:rf.xray.static.machines/sim-event-suggestions])})
+
+(defn- sim-chart-values
+  "The values `SimChart` reads, derefed where the frame is in context."
+  []
+  {:current    @(rf/subscribe [:rf.xray.static.machines/sim-current-state])
+   :last-trans @(rf/subscribe [:rf.xray.static.machines/sim-last-transition])})
+
+(defn- sim-body-values
+  "All sim sub values threaded into `body` (chart + rail)."
+  []
+  (merge (sim-rail-values) (sim-chart-values)))
+
 (def ^:private ok-result
   {:re-frame.machines.result/tag :ok
    :re-frame.machines.result/snap {:state :authing :data {:counter 1}}
@@ -400,7 +428,7 @@
 (deftest rail-renders-nothing-when-sim-inactive
   (setup-xray-frame!)
   (rf/with-frame :rf/xray
-    (is (nil? (sim/SimRail rf/dispatch*))
+    (is (nil? (sim/SimRail rf/dispatch* (sim-rail-values)))
         "rail returns nil when sim is inactive")))
 
 (deftest rail-mounts-when-sim-active
@@ -412,7 +440,7 @@
     (rf/dispatch-sync [:rf.xray.static.machines/sim-start
                        {:machine-id :auth/login
                         :definition fixture-definition}])
-    (let [tree (sim/SimRail rf/dispatch*)]
+    (let [tree (sim/SimRail rf/dispatch* (sim-rail-values))]
       (is (some? (find-by-testid tree "rf-xray-static-machines-sim-rail"))
           "rail present when sim is on")
       (is (some? (find-by-testid tree "rf-xray-static-machines-sim-banner")))
@@ -432,7 +460,7 @@
     (rf/dispatch-sync [:rf.xray.static.machines/sim-start
                        {:machine-id :auth/login
                         :definition fixture-definition}])
-    (let [tree (sim/SimRail rf/dispatch*)
+    (let [tree (sim/SimRail rf/dispatch* (sim-rail-values))
           available (find-all-by-testid-prefix
                       tree "rf-xray-static-machines-sim-available-")]
       (is (some? (find-by-testid
@@ -451,7 +479,7 @@
     (rf/dispatch-sync [:rf.xray.static.machines/sim-start
                        {:machine-id :auth/login
                         :definition fixture-definition}])
-    (let [tree (sim/SimRail rf/dispatch*)]
+    (let [tree (sim/SimRail rf/dispatch* (sim-rail-values))]
       (is (some? (find-by-testid
                    tree "rf-xray-static-machines-sim-audit-empty"))
           "empty audit message before any steps"))
@@ -459,7 +487,7 @@
       (rf/dispatch-sync [:rf.xray.static.machines/sim-step
                          {:machine-id :auth/login
                           :event [:start]}]))
-    (let [tree (sim/SimRail rf/dispatch*)]
+    (let [tree (sim/SimRail rf/dispatch* (sim-rail-values))]
       (is (some? (find-by-testid
                    tree "rf-xray-static-machines-sim-audit-list")))
       (is (some? (find-by-testid
@@ -479,7 +507,7 @@
       (rf/dispatch-sync [:rf.xray.static.machines/sim-step
                          {:machine-id :auth/login
                           :event [:bad]}]))
-    (let [tree (sim/SimRail rf/dispatch*)]
+    (let [tree (sim/SimRail rf/dispatch* (sim-rail-values))]
       (is (some? (find-by-testid
                    tree "rf-xray-static-machines-sim-error"))
           "error toast surfaces inline"))))
@@ -498,8 +526,9 @@
       ;; Pre-condition: no sim-state for the machine.
       (is (nil? @(rf/subscribe [:rf.xray.static.machines/sim-state])))
       ;; Render the body — auto-start fires via rf/dispatch (async).
-      (let [_tree (sim/body rf/dispatch* {:machine-id :auth/login
-                             :definition fixture-definition})]
+      (let [_tree (sim/body rf/dispatch* (merge {:machine-id :auth/login
+                                                 :definition fixture-definition}
+                                                (sim-body-values)))]
         ;; Drain the event queue so the dispatched :sim-start lands.
         (rf/dispatch-sync [:rf.xray.static.machines/sim-set-pending-data
                            {:machine-id :auth/login :text ""}]))
@@ -521,8 +550,10 @@
       (rf/dispatch-sync [:rf.xray.static.machines/sim-start
                          {:machine-id :auth/login
                           :definition fixture-definition}])
-      (let [tree (sim/SimChart rf/dispatch* {:machine-id :auth/login
-                                :definition fixture-definition})]
+      (let [tree (sim/SimChart rf/dispatch*
+                               (merge {:machine-id :auth/login
+                                       :definition fixture-definition}
+                                      (sim-chart-values)))]
         (is (= "rf-xray-static-machines-sim-chart"
                (:data-testid (second tree)))
             "the on-chart sim wrapper mounts")
@@ -548,8 +579,10 @@
       (with-redefs [rf/machine-transition (fn [_d _s _e] ok-result)]
         (rf/dispatch-sync [:rf.xray.static.machines/sim-chart-edge-clicked
                            {:machine-id :auth/login :event-id :start}]))
-      (let [tree        (sim/SimChart rf/dispatch* {:machine-id :auth/login
-                                       :definition fixture-definition})
+      (let [tree        (sim/SimChart rf/dispatch*
+                                      (merge {:machine-id :auth/login
+                                              :definition fixture-definition}
+                                             (sim-chart-values)))
             chart-node  (some (fn [node]
                                 (when (and (vector? node)
                                            (= machine-canvas/Chart (first node)))
@@ -592,8 +625,10 @@
   machine-canvas/Chart props (via the RAW walker so the chart survives
   as data)."
   [definition]
-  (let [tree       (sim/SimChart rf/dispatch* {:machine-id :auth/login
-                                  :definition definition})
+  (let [tree       (sim/SimChart rf/dispatch*
+                                 (merge {:machine-id :auth/login
+                                         :definition definition}
+                                        (sim-chart-values)))
         chart-node (some (fn [node]
                            (when (and (vector? node)
                                       (= machine-canvas/Chart (first node)))
@@ -648,8 +683,9 @@
       (rf/dispatch-sync [:rf.xray.static.machines/sim-start
                          {:machine-id :auth/login
                           :definition fixture-definition}])
-      (let [tree (sim/body rf/dispatch* {:machine-id :auth/login
-                            :definition fixture-definition})]
+      (let [tree (sim/body rf/dispatch* (merge {:machine-id :auth/login
+                                                :definition fixture-definition}
+                                               (sim-body-values)))]
         (is (some? (find-by-testid tree "rf-xray-static-machines-sim-body")))
         (is (some? (find-by-testid tree "rf-xray-static-machines-sim-chart-pane"))
             "chart pane present")
@@ -664,16 +700,64 @@
   (setup-xray-frame!)
   (rf/with-frame :rf/xray
     (select-static-machine! :auth/login)
-    (let [tree (sim/body rf/dispatch* {:machine-id :auth/login :definition nil})]
+    (let [tree (sim/body rf/dispatch* (merge {:machine-id :auth/login
+                                              :definition nil}
+                                             (sim-body-values)))]
       (is (some? (find-by-testid tree
                                  "rf-xray-static-machines-sim-no-definition"))))))
 
 (deftest body-renders-no-machine-hint-when-missing
   (setup-xray-frame!)
   (rf/with-frame :rf/xray
-    (let [tree (sim/body rf/dispatch* {:machine-id nil :definition fixture-definition})]
+    (let [tree (sim/body rf/dispatch* (merge {:machine-id nil
+                                              :definition fixture-definition}
+                                             (sim-body-values)))]
       (is (some? (find-by-testid tree
                                  "rf-xray-static-machines-sim-no-machine"))))))
+
+;; ---- (8c) no-ambient-frame regression (rf2-jholrb) ----------------------
+;;
+;; The sim sub-mode's `body` / `SimRail` / `SimChart` are plain fns
+;; mounted as Reagent components from `definition_detail/body`. A plain
+;; fn renders in its OWN React cycle and so CANNOT recover the
+;; surrounding `:rf/xray` frame (Spec 004). The pre-fix code self-
+;; subscribed inside these fns; with NO frame in dynamic context a bare
+;; `rf/subscribe` throws `:rf.error/no-frame-context` and crashes the
+;; whole Static surface. The fix threads the derefed sub values DOWN from
+;; the `detail` reg-view, so the plain fns never subscribe.
+;;
+;; These tests render the three fns WITHOUT any `with-frame` wrapper —
+;; matching the React render cycle the components actually run in — and
+;; assert they no longer throw. (Pre-fix, every one of these threw.)
+
+(deftest sim-plain-fns-do-not-self-subscribe-without-a-frame
+  (testing "rf2-jholrb — body / SimRail / SimChart render without an
+            ambient :rf/xray frame (no :rf.error/no-frame-context). The
+            sub values are threaded in as args, not self-subscribed."
+    (setup-xray-frame!)
+    ;; Seed a live sim slot under :rf/xray so the threaded values carry
+    ;; real data — but render the plain fns OUTSIDE any `with-frame`.
+    (let [vals (rf/with-frame :rf/xray
+                 (override-machines!    [:auth/login])
+                 (override-definitions! {:auth/login fixture-definition})
+                 (select-static-machine! :auth/login)
+                 (rf/dispatch-sync [:rf.xray.static.machines/sim-start
+                                    {:machine-id :auth/login
+                                     :definition fixture-definition}])
+                 {:body  (merge {:machine-id :auth/login
+                                 :definition fixture-definition}
+                                (sim-body-values))
+                  :rail  (sim-rail-values)
+                  :chart (merge {:machine-id :auth/login
+                                 :definition fixture-definition}
+                                (sim-chart-values))})]
+      ;; NO `with-frame` here — these run in their own render cycle.
+      (is (some? (sim/body rf/dispatch* (:body vals)))
+          "body renders without a frame in context")
+      (is (some? (sim/SimRail rf/dispatch* (:rail vals)))
+          "SimRail renders without a frame in context")
+      (is (some? (sim/SimChart rf/dispatch* (:chart vals)))
+          "SimChart renders without a frame in context"))))
 
 ;; ---- (9) frame isolation -----------------------------------------------
 
@@ -737,7 +821,7 @@
       (rf/dispatch-sync [:rf.xray.static.machines/sim-start
                          {:machine-id :auth/login
                           :definition fixture-definition}])
-      (let [tree      (sim/SimRail rf/dispatch*)
+      (let [tree      (sim/SimRail rf/dispatch* (sim-rail-values))
             available (raw-find-all-by-testid-prefix
                         tree "rf-xray-static-machines-sim-available-")
             ;; Drop the container <ul> (testid `…-available-list`); we
@@ -770,7 +854,7 @@
                            {:machine-id :auth/login :event [:start]}])
         (rf/dispatch-sync [:rf.xray.static.machines/sim-step
                            {:machine-id :auth/login :event [:ok]}]))
-      (let [tree (sim/SimRail rf/dispatch*)
+      (let [tree (sim/SimRail rf/dispatch* (sim-rail-values))
             rows (raw-find-all-by-testid-prefix
                    tree "rf-xray-static-machines-sim-audit-")
             ;; Drop the container <ol> (testid `…-audit-list`).


### PR DESCRIPTION
Fixes rf2-jholrb.

## Problem

The Static Machines Sim sub-mode's body / SimRail / SimChart were plain fns
that called rf/subscribe directly. A plain fn mounted as a Reagent component
renders in its OWN React cycle and cannot recover the surrounding :rf/xray
frame (Spec 004), so the self-subscribe throws :rf.error/no-frame-context and
crashes the Static surface. This is the identical latent defect rf2-wxu4l3
fixed in browse_list (search-box / sort-button, PR #3686).

Latent only because no feature-gate scenario opens the :sim sub-mode, and the
CLJS tests rendered inside (with-frame :rf/xray), masking the missing
render-cycle frame.

## Premise verdict

CONFIRMED. body (sim.cljs:741), SimRail (612), SimChart (661) were plain defns
self-subscribing the sim sub family. body is mounted as a plain-fn component
from definition_detail/body, transitively from the detail reg-view.

## Fix

Mirrors the rf2-wxu4l3 browse-list pattern exactly: deref the sim sub family in
the enclosing detail reg-view (where the frame IS in context) and thread the
values down through definition_detail/body into sim/body, then fan them out to
SimChart / SimRail.

Threaded subs (derefed in detail, only on the :sim sub-mode):
- :rf.xray.static.machines/sim-state               -> sim   (body + SimRail)
- :rf.xray.static.machines/sim-available-transitions -> transitions (SimRail)
- :rf.xray.static.machines/sim-event-suggestions   -> suggestions (SimRail)
- :rf.xray.static.machines/sim-current-state        -> current (SimChart)
- :rf.xray.static.machines/sim-last-transition      -> last-trans (SimChart)

sim.cljs no longer calls rf/subscribe anywhere (only reg-sub / reg-event-db /
machine-transition remain).

## Tests

- Updated all sim_cljs_test call sites to thread the derefed values (the tests
  no longer rely on the plain fns recovering a frame they cannot reach).
- New regression test sim-plain-fns-do-not-self-subscribe-without-a-frame:
  renders body / SimRail / SimChart OUTSIDE any with-frame wrapper (matching the
  real render cycle) and asserts they no longer throw. Pre-fix, each threw.

## Xray spec

Unchanged. Implementation-internal threading; rendered output, testids, events,
subs and user-facing behavior are all identical. Same posture rf2-wxu4l3 took.

## Slice gates

- npm run test:cljs        -> 6129 tests / 21885 assertions, 0 failures, 0 errors
- npm run test:xray-feature-gate -> 16 scenarios, 0 failures, 13 matrix rows (unchanged); 0 compile warnings across all 14 surfaces
