### PR TITLE
feat(conformance): data-classification fixture category + flow-output-inherits-from-input (rf2-s2s3xv)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -151,7 +151,14 @@
     ;; frames' flows do not walk on cross-frame dispatches. Claimed so
     ;; `flow-frame-scoped.edn` runs on CLJS too (rf2-29ovh).
     :flow/frame-scoped
-    :rf.http/managed})
+    :rf.http/managed
+    ;; Spec 015 §Data classification (rf2-s2s3xv) — the `data-classification/`
+    ;; fixture category exercises path-marks redaction through the t2
+    ;; pending-db trace egress (`add-marks` / `set-marks` via
+    ;; `:fixture/app-marks`). Matches the JVM runner's claim so
+    ;; `data-classification-flow-output-inherits-from-input.edn` (Spec 015:568)
+    ;; runs on CLJS too.
+    :data-classification/marks})
 
 (def claimed-spec-versions
   "Fixture spec versions this CLJS build claims to conform against."
@@ -540,6 +547,27 @@
           (rf/reg-flow (-> flow-meta
                            (assoc :id flow-id)
                            (assoc :output output-fn))))))))
+
+(defn- realise-app-marks!
+  "Apply a fixture's `:fixture/app-marks` data-classification declarations
+  against the established frame scope (Spec 015 §App-db marks; rf2-s2s3xv).
+  Mirror of the JVM runner.
+
+  `:fixture/app-marks` is an ORDERED vector of op-maps so a fixture can pin
+  the `add-marks` / `set-marks` sequencing the spec's category fixtures care
+  about. Each op-map carries exactly one of:
+
+    {:add-marks {path mark, ...}}   — additively merge into the frame mark-set
+    {:set-marks {path mark, ...}}   — replace the frame mark-set wholesale
+
+  Called AFTER `reg-frame` and BEFORE `realise-flows!` so a flow whose
+  `:inputs` overlap a marked path inherits the propagated output mark at
+  `reg-flow` time. `add-marks` / `set-marks` take an explicit `frame-id`."
+  [fixture scope-frame]
+  (doseq [op (or (:fixture/app-marks fixture) [])]
+    (cond
+      (contains? op :add-marks) (rf/add-marks scope-frame (:add-marks op))
+      (contains? op :set-marks) (rf/set-marks scope-frame (:set-marks op)))))
 
 (defn- collect-traces [fixture-id]
   (let [traces (atom [])]
@@ -969,6 +997,12 @@
                            (rf/reg-frame (:id f) (dissoc f :id)))
                          :else
                          (rf/reg-frame :rf/default frame-config))
+          ;; Data-classification path-marks (Spec 015 §App-db marks;
+          ;; rf2-s2s3xv) run AFTER reg-frame and BEFORE realise-flows! so a
+          ;; flow input that overlaps a marked path inherits the propagated
+          ;; output mark at reg-flow time. `add-marks` / `set-marks` are
+          ;; frame-scoped.
+          _            (realise-app-marks! fixture scope-frame)
           ;; Flow registration runs AFTER reg-frame: per Spec 013 flows
           ;; are frame-scoped, and the rf2-wbtjn destroy-frame! teardown
           ;; hook would wipe any flows registered before the destroy.

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -139,7 +139,14 @@
     ;; `flow-frame-scoped.edn` runs through the core corpus too (rf2-29ovh).
     :flow/frame-scoped
     ;; Spec 014 — :rf.http/managed (rf2-z1mw)
-    :rf.http/managed})
+    :rf.http/managed
+    ;; Spec 015 §Data classification (rf2-s2s3xv) — the `data-classification/`
+    ;; fixture category exercises the path-marks redaction contract through
+    ;; the t2 pending-db trace egress (`add-marks` / `set-marks` declaring
+    ;; sensitive / large paths via `:fixture/app-marks`). Claimed so
+    ;; `data-classification-flow-output-inherits-from-input.edn` (Spec 015:568)
+    ;; runs through the core corpus.
+    :data-classification/marks})
 
 ;; ---- claimed fixture spec version(s) -------------------------------------
 ;;
@@ -573,6 +580,31 @@
           (rf/reg-flow (-> flow-meta
                            (assoc :id flow-id)
                            (assoc :output output-fn))))))))
+
+(defn- realise-app-marks!
+  "Apply a fixture's `:fixture/app-marks` data-classification declarations
+  against the established frame scope (Spec 015 §App-db marks; rf2-s2s3xv).
+
+  `:fixture/app-marks` is an ORDERED vector of op-maps so a fixture can pin
+  the `add-marks` / `set-marks` sequencing the spec's category fixtures care
+  about (`set-marks-replaces-not-merges`, `add-marks-merges-not-replaces`).
+  Each op-map carries exactly one of:
+
+    {:add-marks {path mark, ...}}   — additively merge into the frame mark-set
+    {:set-marks {path mark, ...}}   — replace the frame mark-set wholesale
+
+  `path` is a `get-in`-shaped vector; `mark` is `:sensitive` or `:large`.
+
+  Called AFTER `reg-frame` (the frame's runtime-db elision slot exists) and
+  BEFORE `realise-flows!` — so a flow whose `:inputs` overlap a marked path
+  inherits the propagated output mark at `reg-flow` time (the realistic
+  ordering: mark the input, then register the flow). `add-marks` / `set-marks`
+  take an explicit `frame-id`, so we pass the scope frame directly."
+  [fixture scope-frame]
+  (doseq [op (or (:fixture/app-marks fixture) [])]
+    (cond
+      (contains? op :add-marks) (rf/add-marks scope-frame (:add-marks op))
+      (contains? op :set-marks) (rf/set-marks scope-frame (:set-marks op)))))
 
 (defn- collect-traces [fixture-id]
   (let [traces (atom [])]
@@ -1103,6 +1135,12 @@
                            (rf/reg-frame (:id f) (dissoc f :id)))
                          :else
                          (rf/reg-frame :rf/default frame-config))
+          ;; Data-classification path-marks (Spec 015 §App-db marks;
+          ;; rf2-s2s3xv) run AFTER reg-frame (the frame's runtime-db elision
+          ;; slot exists) and BEFORE realise-flows! so a flow input that
+          ;; overlaps a marked path inherits the propagated output mark at
+          ;; reg-flow time. `add-marks` / `set-marks` are frame-scoped.
+          _            (realise-app-marks! fixture scope-frame)
           ;; Flow registration runs AFTER reg-frame: per Spec 013 flows
           ;; are frame-scoped, and the rf2-wbtjn destroy-frame! teardown
           ;; hook would wipe any flows registered before the destroy.

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -407,8 +407,21 @@ See `fixtures/` for the actual files. Each fixture is one EDN file; each exercis
 | `cross-spec-dispatch-sync-in-handler.edn` | `:cross-spec/dispatch-sync-in-handler` | Cross-Spec #14 (Drain loop × Substrate): a handler that triggers `dispatch-sync` mid-drain (directly or transitively via a naive fx-side chain) trips the router's `:in-drain?` guard and emits `:rf.error/dispatch-sync-in-handler` with `:no-recovery`; the would-be leaf handler does NOT run. Pins the substrate-level ban; render-time observables are out-of-scope so the fx path is the corpus's testable seam |
 | `cross-spec-server-error-projection.edn` | `:cross-spec/server-error-projection` | Cross-Spec #16 (Errors × SSR): an fx handler throws on a server frame; the runtime emits `:rf.error/fx-handler-exception` with the original exception detail; the active error projector maps it to the locked generic-500 public-error on the request frame's response accumulator. The trace stream preserves full detail; the public-error is sanitised — the projector IS the sanitisation seam |
 | `cross-spec-hot-reload-sub-mid-cascade.edn` | `:cross-spec/hot-reload-sub-mid-cascade` | Cross-Spec #18 (Subscriptions × Hot-reload): re-registering a sub via the harness's `{:reg-sub <id> :body <body>}` step disposes the per-frame cache slot for that query-id; subsequent subscribes build against the new body. The registrar emits `:rf.registry/handler-replaced` with `:kind :sub` + `:id` + `:different-fn?`; the post-replacement sub-value confirms the cache was invalidated and the new body is active |
+| `data-classification-flow-output-inherits-from-input.edn` | `:data-classification/flow-output-inherits-from-input` | Spec 015:568 (Data Classification × Flows): the `:fixture/app-marks` harness step declares `[:user :ssn]` sensitive (`add-marks`); a `reg-flow` reading that input copies it to `[:derived :ssn-copy]`. The flow output INHERITS the input's data-classification by default, so the same event's `:rf.event/db-pending-post-flow` (t2) trace redacts both the input slot AND the propagated output slot to `:rf/redacted` while leaving the unmarked sibling `[:user :name]` raw — the path-precise trace-egress redaction contract |
 
-Coverage spans the main categories: handlers, frames, envelope, subs, fx, errors, machines, routing, SSR, hydration, epoch, trace bus, view registration, and HTTP request interceptors.
+Coverage spans the main categories: handlers, frames, envelope, subs, fx, errors, machines, routing, SSR, hydration, epoch, trace bus, view registration, HTTP request interceptors, and data-classification path-marks.
+
+### The `:fixture/app-marks` harness step — data-classification path-marks
+
+The `data-classification/` category exercises the Spec 015 path-marks redaction contract. A fixture declares app-db path-marks via the optional top-level `:fixture/app-marks` key — an ORDERED vector of declaration op-maps the harness applies against the established frame scope (after `reg-frame`, before static `reg-flow` registration, so a flow whose `:inputs` overlap a marked path inherits the propagated output mark at registration time):
+
+```clojure
+:fixture/app-marks
+[{:add-marks {[:user :ssn] :sensitive}}    ;; additively merge into the frame mark-set
+ {:set-marks {[:auth :token] :sensitive}}]  ;; OR replace the frame mark-set wholesale
+```
+
+Each op-map carries exactly one of `:add-marks` (additive merge) or `:set-marks` (wholesale replace); the value is a `{path mark}` map where `path` is a `get-in`-shaped vector and `mark` is `:sensitive` or `:large`. The ordered-vector form lets a fixture pin the `add-marks` / `set-marks` sequencing (e.g. the spec's `set-marks-replaces-not-merges` / `add-marks-merges-not-replaces` cases). The declarations feed the emit-time trace-tag projection — sensitive slots render `:rf/redacted` and large slots render `:rf.size/large-elided` inside the relevant trace `:tags` (e.g. the `:rf.event/db` slot on the t1 / t2 pending-db trace events) before any listener observes them. Fixtures using `:fixture/app-marks` declare the `:data-classification/marks` capability.
 
 ## Render-time observables (out of scope)
 

--- a/spec/conformance/fixtures/data-classification-flow-output-inherits-from-input.edn
+++ b/spec/conformance/fixtures/data-classification-flow-output-inherits-from-input.edn
@@ -1,0 +1,76 @@
+;; Conformance fixture: data-classification/flow-output-inherits-from-input
+;; Per Spec 015:568 §Tests — a `reg-flow` whose `:inputs` include a
+;; SENSITIVE app-db path produces a flow `:path` write whose value is
+;; marked sensitive in the SAME event's post-flow pending snapshot:
+;; the `:rf.event/db` slot on that event's `:rf.event/db-pending-post-flow`
+;; (t2) trace event.
+;;
+;; A flow OUTPUT inherits the data-classification of its INPUT
+;; (Spec 015:313 + rf2-ihfz9o, Mike RULED (a) PROPAGATE 2026-06-09) — a
+;; flow reading a sensitive input emits a sensitive output BY DEFAULT
+;; (taint by default, declassify explicitly). Flows transform the pending
+;; `:db` effect BEFORE the single deferred install, so the propagated flow
+;; output rides the t2 snapshot of that one event (not a separate
+;; downstream event).
+;;
+;; The fixture marks `[:user :ssn]` sensitive (the flow's input), then a
+;; flow copies it to `[:derived :ssn-copy]`. The redaction is path-precise:
+;; the input slot AND the derived output slot both redact to `:rf/redacted`
+;; on the t2 snapshot, while the unmarked sibling `[:user :name]` rides raw.
+;;
+;; Harness note: `:fixture/app-marks` is an ordered vector of mark-declaration
+;; ops (`{:add-marks {path mark, ...}}` / `{:set-marks {path mark, ...}}`)
+;; applied against the established frame scope BEFORE the static flows are
+;; registered — so the input→output propagation installs at `reg-flow` time
+;; (the realistic ordering: mark the input, then register the flow).
+
+{:fixture/id           :data-classification/flow-output-inherits-from-input
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/trace :flow/basic
+                         :data-classification/marks}
+ :fixture/doc          "A reg-flow whose :inputs include a sensitive app-db path produces a flow :path write that is marked sensitive in the SAME event's post-flow pending snapshot — the :rf.event/db slot on that event's :rf.event/db-pending-post-flow (t2) trace event. The flow output inherits the data-classification of its input by default; the path-precise redaction leaves an unmarked sibling slot raw."
+
+ :fixture/registry
+ {:event {:dc/init {:doc "Seed a sensitive :ssn and an unmarked :name."}}
+  :flow  {:dc/ssn-echo
+          {:doc    "Copies the sensitive :user :ssn input into :derived :ssn-copy — the output inherits the input's sensitivity."
+           :inputs [[:user :ssn]]
+           :path   [:derived :ssn-copy]}}}
+
+ :fixture/handlers
+ {:event {:dc/init [[:set [:user :ssn]  "123-45-6789"]
+                    [:set [:user :name] "Ada"]]}}
+
+ ;; The :output fn is realised as `(fn [ssn] {:copy ssn})`. The literal map
+ ;; value walks through the value DSL so `[:event-arg 0]` (the flow's first
+ ;; positional input) resolves to the :ssn input.
+ :fixture/flow-bodies
+ {:dc/ssn-echo [{:copy [:event-arg 0]}]}
+
+ ;; Mark the flow's INPUT path sensitive BEFORE the flow registers, so the
+ ;; propagated whole-output declaration installs at the flow's :path.
+ :fixture/app-marks
+ [{:add-marks {[:user :ssn] :sensitive}}]
+
+ :fixture/frame-config
+ {:on-create [:dc/init]}
+
+ :fixture/dispatches
+ [[:dc/init]]
+
+ :fixture/expect
+ ;; The committed app-db is the RAW value — redaction is a trace-egress
+ ;; concern only, so :final-app-db carries the unredacted state. The
+ ;; data-classification contract lives entirely on the t2 trace slot.
+ {:final-app-db
+  {:user    {:ssn "123-45-6789" :name "Ada"}
+   :derived {:ssn-copy {:copy "123-45-6789"}}}
+
+  ;; The load-bearing assertion: the post-flow pending snapshot redacts the
+  ;; sensitive input AND the propagated flow output, and leaves the unmarked
+  ;; sibling raw. The full :rf.event/db map is asserted literally (the
+  ;; fixture's app-db is small and deterministic).
+  :trace-emissions
+  [{:operation :rf.event/db-pending-post-flow
+    :tags      {:rf.event/db {:user    {:ssn :rf/redacted :name "Ada"}
+                              :derived {:ssn-copy :rf/redacted}}}}]}}


### PR DESCRIPTION
Closes rf2-s2s3xv.

## What

Adds the data-classification/ conformance fixture category to the shared core conformance harness, with the trace-tag redaction support it needs, giving the Spec 015:568 flow-output-inherits-from-input fixture a home.

## Premise verdict

CONFIRMED ABSENT. No data-classification fixtures existed under spec/conformance/fixtures/, and neither conformance runner had any path to declare app-db path-marks from a fixture. The redaction machinery itself (add-marks / set-marks, project-trace-event, flow input to output mark propagation) already lives in core and is covered by the host-gate tests in implementation/flows/test/re_frame/flows_output_marks_test.clj (the propagation-t2-pending-post-flow-redacts-output deftest is the exact behavioural counterpart of this fixture). What was missing was the CONFORMANCE-fixture coverage plus the harness wiring to declare marks.

## What I added

1. New optional :fixture/app-marks harness key — an ordered vector of declaration op-maps, each carrying exactly one of {:add-marks {path mark}} (additive merge) or {:set-marks {path mark}} (wholesale replace). The harness applies them against the established frame scope AFTER reg-frame and BEFORE static reg-flow registration, so a flow whose :inputs overlap a marked path inherits the propagated output mark at reg-flow time (the realistic ordering). Wired byte-for-byte across both runners; both claim a new :data-classification/marks capability.

2. New fixture data-classification-flow-output-inherits-from-input.edn — marks [:user :ssn] sensitive, a flow copies it into [:derived :ssn-copy], and the same event's :rf.event/db-pending-post-flow (t2) trace redacts both the sensitive input slot AND the propagated flow output slot to :rf/redacted while leaving the unmarked sibling [:user :name] raw. The committed app-db (:final-app-db) carries the raw value — redaction is a trace-egress concern only.

3. conformance/README.md — documents the new category, the :fixture/app-marks harness step, and a coverage row.

## Files

- spec/conformance/fixtures/data-classification-flow-output-inherits-from-input.edn (new)
- implementation/core/test/re_frame/conformance_test.clj (JVM runner)
- implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs (CLJS runner)
- spec/conformance/README.md

## Slice gates

- JVM core conformance corpus (clojure -M:test -n re-frame.conformance-test): 163 runnable, all pass incl. the new fixture.
- CLJS suite incl. the conformance corpus runner (npm run test:cljs): 6128 tests / 21882 assertions / 0 failures.
- npm run test:mcp-conformance: all 6 gates green.
