### PR TITLE
fix(story): URL substrate omission restores :reagent default, not stale (rf2-dxz4sg)

### DIFF
--- a/tools/story/spec/022-Story-UI-Docs-And-Share.md
+++ b/tools/story/spec/022-Story-UI-Docs-And-Share.md
@@ -215,11 +215,17 @@ Share semantics:
   slot, not just overrides (rf2-fkmnh): once URL hydration is in play
   (`apply-parsed-to-state` runs on a populated mount or any popstate), an
   omitted `modes=` clears `:active-modes` to `[]`, an omitted `tag-filter=`
-  clears `:tag-filter` to `#{}`, and an omitted (or present-but-invalid)
+  clears `:tag-filter` to `#{}`, an omitted (or present-but-invalid)
   `viewport=`/`background=` clears the slot to its neutral default (`:full`
-  / no background). A no-query popstate (back/forward to a bare URL) likewise
-  clears the URL-owned selection / modes / framing / filter rather than
-  no-op'ing. So a share link like `?variant=story.counter/loaded` restores
+  / no background), and an omitted (or present-but-unregistered) `substrate=`
+  clears `:substrate` to the `:reagent` default (rf2-dxz4sg). The substrate is
+  the one slot whose default is itself the omission token — `build-params`
+  emits `substrate=` only for a non-default substrate — so an omitted param
+  carries the SAME default-restore meaning as the other URL-owned slots and is
+  validated against the live substrate registry. A no-query popstate
+  (back/forward to a bare URL) likewise clears the URL-owned selection / modes
+  / framing / filter / substrate rather than no-op'ing. So a share link like
+  `?variant=story.counter/loaded` restores
   the DEFAULT view for the recipient instead of keeping their prior
   localStorage-seeded chrome — the address bar is the source of truth for the
   full share surface. The intentional localStorage fallback survives ONLY for

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -75,6 +75,7 @@
             [re-frame.story.ui.help :as help]
             [re-frame.story.ui.keybindings :as keybindings]
             [re-frame.story.ui.mode-tabs :as mode-tabs]
+            [re-frame.story.ui.multi-substrate :as multi-substrate]
             [re-frame.story.ui.panels :as panels]
             [re-frame.story.ui.play-status :as play-status]
             [re-frame.story.ui.promotion :as promotion]
@@ -510,7 +511,16 @@
                     :viewport?   (fn [v]
                                    (or (nil? v) (viewport/valid-selection? v)))
                     :background? (fn [b]
-                                   (or (nil? b) (backgrounds/valid-selection? b)))}]
+                                   (or (nil? b) (backgrounds/valid-selection? b)))
+                    ;; rf2-dxz4sg: validate the URL substrate against the live
+                    ;; substrate registry so a stale/unregistered `substrate=`
+                    ;; degrades to the `:reagent` default rather than pinning a
+                    ;; substrate the host app never registered. nil (omitted)
+                    ;; is accepted here and resolved to `:reagent` inside
+                    ;; apply-parsed-to-state.
+                    :substrate?  (fn [s]
+                                   (or (nil? s)
+                                       (contains? (multi-substrate/registered-substrates) s)))}]
     (fn [state parsed]
       (url-state/apply-parsed-to-state state parsed validators))))
 

--- a/tools/story/src/re_frame/story/ui/url_state.cljc
+++ b/tools/story/src/re_frame/story/ui/url_state.cljc
@@ -170,6 +170,7 @@
     :workspace?  fn   — registered? predicate for workspace ids
     :viewport?   fn   — recognised? for preset kw / custom map
     :background? fn   — recognised? for preset kw / colour string
+    :substrate?  fn   — registered? predicate for substrate ids
 
   Per rf2-hscut: workspace + variant are mutually exclusive in the
   sidebar (selecting one clears the other). If the URL carries both
@@ -202,6 +203,14 @@
     - omitted `tag-filter=` clears `:tag-filter`   to `#{}`
     - omitted (or invalid) `viewport=`/`background=` clear the slot to nil
       so the chrome falls back to its neutral default (`:full` / no bg).
+    - omitted (or invalid) `substrate=` clears `:substrate` to the default
+      `:reagent` (rf2-dxz4sg). The build side omits `substrate=` precisely
+      to encode the `:reagent` default (`share/build-params` only emits it
+      for a non-default substrate), so an omitted param MUST hydrate as
+      `:reagent` rather than preserving the recipient's stale in-memory
+      `:uix`/`:helix`. A present-but-unregistered substrate (rejected by the
+      `:substrate?` validator) likewise degrades to `:reagent` so a stale URL
+      can't pin a substrate the host app never registered.
   This means a share URL like `?variant=story.counter/loaded` restores the
   DEFAULT framing / filter / modes for the recipient rather than keeping
   their prior localStorage-seeded chrome, and back/forward from a populated
@@ -222,6 +231,16 @@
                         ((:viewport? validators) viewport))
         bg-ok?      (or (nil? (:background? validators))
                         ((:background? validators) background))
+        ;; rf2-dxz4sg: an omitted `substrate=` (nil) encodes the `:reagent`
+        ;; default on the build side, so it MUST hydrate as `:reagent`, not
+        ;; preserve the recipient's stale in-memory substrate. A
+        ;; present-but-unregistered substrate (rejected by the validator)
+        ;; likewise degrades to `:reagent`. With no `:substrate?` validator
+        ;; the layer can't reach the substrate registry, so any present id is
+        ;; accepted (the registrar-aware shell wiring supplies the validator).
+        sub-ok?     (or (nil? (:substrate? validators))
+                        ((:substrate? validators) substrate))
+        substrate*  (if (and substrate sub-ok?) substrate :reagent)
         ;; Variant wins over workspace when both are present (rf2-hscut).
         keep-variant?   (and variant-id variant-ok?)
         keep-workspace? (and (not keep-variant?) workspace-id ws-ok?)]
@@ -273,14 +292,17 @@
       ;; the chrome falls back to its default rather than keeping a stale
       ;; localStorage / prior-session value — the address bar stays the
       ;; source of truth for the full share surface.
+      ;; rf2-dxz4sg: `:substrate` joins the unconditional authoritative-clear
+      ;; — omitted/invalid ⇒ `:reagent` (computed as `substrate*` above), a
+      ;; registered non-default id ⇒ that id. This mirrors the build-side
+      ;; default-omission (`share/build-params`) so the address bar stays the
+      ;; source of truth for the substrate on both mount and back/forward.
       :always
       (-> (assoc :active-modes (vec active-modes))
           (assoc :viewport   (when vp-ok? viewport))
           (assoc :background (when bg-ok? background))
-          (assoc :tag-filter (set tag-filter)))
-
-      substrate
-      (assoc :substrate substrate))))
+          (assoc :tag-filter (set tag-filter))
+          (assoc :substrate  substrate*)))))
 
 ;; ---- CLJS-only: window.history + popstate -------------------------------
 

--- a/tools/story/test/re_frame/story/ui/url_state_test.cljc
+++ b/tools/story/test/re_frame/story/ui/url_state_test.cljc
@@ -245,6 +245,71 @@
               {} {:substrate :uix} {})]
     (is (= :uix (:substrate out)))))
 
+;; ---- rf2-dxz4sg: substrate authoritative-clear --------------------------
+;;
+;; The build side omits `substrate=` to encode the `:reagent` default
+;; (`share/build-params` emits it only for a non-default substrate). So
+;; an omitted/nil parsed substrate MUST hydrate as `:reagent`, not preserve
+;; the recipient's stale in-memory `:uix`/`:helix`. This mirrors the
+;; authoritative-clear discipline the other URL-owned chrome slots already
+;; get (rf2-fkmnh). The same single fn drives mount-time hydration AND
+;; no-query popstate (via `parse-current-url-or-empty`), so both paths heal.
+
+(deftest apply-parsed-empty-url-clears-stale-substrate-to-reagent
+  (testing "rf2-dxz4sg — an all-nil parsed URL (no-query popstate / a share
+            URL that omits everything) clears a stale `:substrate :uix` back
+            to the `:reagent` default rather than preserving it. Before the
+            fix `:substrate` only wrote when truthy, so the stale value leaked."
+    (let [stale        {:substrate :uix}
+          empty-parsed {:variant-id nil :workspace-id nil :mode-tab nil
+                        :active-modes nil :viewport nil :background nil
+                        :tag-filter nil :cell-overrides nil :substrate nil}
+          out          (us/apply-parsed-to-state stale empty-parsed {})]
+      (is (= :reagent (:substrate out))
+          "omitted substrate= hydrates as the :reagent default, not stale :uix"))))
+
+(deftest apply-parsed-default-share-link-clears-stale-substrate
+  (testing "rf2-dxz4sg — the bead's concrete scenario: a recipient with stale
+            in-memory `:substrate :helix` opens a DEFAULT share link
+            `?variant=story.counter/loaded` that carries NO substrate= (the
+            sender omitted it precisely to mean `:reagent`). The recipient
+            must render the default `:reagent`, not their stale `:helix`."
+    (let [recipient-local {:substrate :helix}
+          ;; share/parse-params of just ?variant=story.counter/loaded —
+          ;; substrate parses absent as nil.
+          shared          {:variant-id :story.counter/loaded :substrate nil}
+          out             (us/apply-parsed-to-state recipient-local shared {})]
+      (is (= :story.counter/loaded (:selected-variant out)))
+      (is (= :reagent (:substrate out))
+          "recipient's stale :helix is cleared to the :reagent default"))))
+
+(deftest apply-parsed-explicit-non-default-substrate-round-trips
+  (testing "rf2-dxz4sg — an explicit non-default substrate still hydrates to
+            that substrate (the fix only changes omitted/invalid handling).
+            With a :substrate? validator that registers :uix it is kept; with
+            no validator any present id is accepted (registry unreachable)."
+    (let [with-validator (us/apply-parsed-to-state
+                           {:substrate :reagent} {:substrate :uix}
+                           {:substrate? #{:reagent :uix :helix}})
+          no-validator   (us/apply-parsed-to-state
+                           {:substrate :reagent} {:substrate :helix} {})]
+      (is (= :uix (:substrate with-validator))
+          "registered non-default substrate is kept")
+      (is (= :helix (:substrate no-validator))
+          "with no validator a present substrate is accepted as-is"))))
+
+(deftest apply-parsed-invalid-substrate-degrades-to-reagent
+  (testing "rf2-dxz4sg — a present-but-UNREGISTERED substrate (rejected by the
+            :substrate? validator) degrades to the :reagent default rather than
+            preserving the prior local substrate, so a stale URL can't pin a
+            substrate the host app never registered."
+    (let [stale {:substrate :uix}
+          out   (us/apply-parsed-to-state
+                  stale {:substrate :ghost-substrate}
+                  {:substrate? #{:reagent :uix :helix}})]
+      (is (= :reagent (:substrate out))
+          "unregistered substrate= clears to :reagent, not the stale :uix"))))
+
 ;; ---- rf2-j0hwf: cell-overrides hydration --------------------------------
 
 (deftest apply-parsed-installs-cell-overrides-under-focused-variant
@@ -424,7 +489,8 @@
                  :active-modes     [:m/dark]
                  :viewport         :tablet
                  :background       :dark
-                 :tag-filter       #{:tag/a}}
+                 :tag-filter       #{:tag/a}
+                 :substrate        :uix}
           ;; the shape share/parse-params produces for an empty getter:
           empty-parsed {:variant-id nil :workspace-id nil :mode-tab nil
                         :active-modes nil :viewport nil :background nil
@@ -435,7 +501,10 @@
       (is (= [] (:active-modes out)))
       (is (nil? (:viewport out)))
       (is (nil? (:background out)))
-      (is (= #{} (:tag-filter out))))))
+      (is (= #{} (:tag-filter out)))
+      ;; rf2-dxz4sg — substrate is a URL-owned slot too: a bare URL clears it
+      ;; to the :reagent default rather than leaking the stale :uix.
+      (is (= :reagent (:substrate out))))))
 
 (deftest apply-parsed-share-counter-link-restores-default-chrome
   (testing "rf2-fkmnh — the bead's concrete scenario: a recipient with prior
@@ -446,7 +515,8 @@
     (let [recipient-local {:active-modes [:m/dark]
                            :viewport     :phone
                            :background   :light
-                           :tag-filter   #{:tag/legacy}}
+                           :tag-filter   #{:tag/legacy}
+                           :substrate    :helix}
           ;; share/parse-params of just ?variant=story.counter/loaded
           shared {:variant-id :story.counter/loaded}
           out    (us/apply-parsed-to-state recipient-local shared {})]
@@ -454,7 +524,10 @@
       (is (= [] (:active-modes out)) "recipient's local modes cleared")
       (is (nil? (:viewport out))     "recipient's local viewport cleared")
       (is (nil? (:background out))   "recipient's local background cleared")
-      (is (= #{} (:tag-filter out))  "recipient's local tag-filter cleared"))))
+      (is (= #{} (:tag-filter out))  "recipient's local tag-filter cleared")
+      ;; rf2-dxz4sg — the omitted substrate= means :reagent, so the
+      ;; recipient's stale :helix is cleared to the default.
+      (is (= :reagent (:substrate out)) "recipient's local substrate cleared"))))
 
 (deftest apply-parsed-full-round-trip-through-state
   (testing "URL → parsed → state, then state → URL produces equivalent


### PR DESCRIPTION
## Summary

Fixes rf2-dxz4sg (P2 bug, correctness-review). Story share/URL hydration preserved a stale non-default substrate when the substrate URL param was omitted — but omission is exactly how the build side encodes the default :reagent substrate. A recipient with a stale in-memory :substrate of :uix/:helix opening a default-share URL kept rendering the stale substrate; back/forward to a bare URL had the same leak.

## Root cause

apply-parsed-to-state wrote :substrate only when the parsed value was truthy, unlike the other URL-owned slots (modes / viewport / background / tag-filter) which write unconditionally in the rf2-fkmnh authoritative-clear block. That asymmetry was the bug — confirmed against the bead evidence.

## Fix

- url_state.cljc: :substrate joins the unconditional authoritative-clear. Omitted/nil or a present-but-unregistered id degrades to the :reagent default; a registered non-default id is kept. Computed once as substrate* and written in the :always block alongside the other URL-owned slots. The same fn drives mount-time hydration AND no-query popstate, so both paths heal with one change.
- shell.cljs: new :substrate? validator wired against the live substrate registry (multi-substrate/registered-substrates), mirroring the existing :viewport? / :background? validator pattern. With no validator (registry unreachable at the portable CLJC layer) any present id is accepted.

## Tests (tools/story/test/re_frame/story/ui/url_state_test.cljc)

1. empty parsed URL clears stale :substrate :uix to :reagent
2. default-share URL with no substrate param clears recipient stale :helix to :reagent
3. explicit non-default substrates still round-trip (with and without a validator)
4. present-but-unregistered substrate degrades to :reagent, not the stale local value

The two existing empty/default-share tests now also seed and assert substrate clearing.

## Spec

Spec 022 already documented authoritative-clear for every URL-owned chrome slot and listed substrate as part of the share URL surface. Extended the explicit enumeration at the rf2-fkmnh clause to name substrate — the one slot whose default is itself the omission token. Contract unchanged; the impl now matches the documented authoritative-clear discipline.

## Gates

- npm run test:cljs — 6129 tests / 21885 assertions, 0 failures, 0 errors (run twice, stable)
- clj-kondo on changed files — 0 errors; the 2 warnings are pre-existing and outside the diff

Closes rf2-dxz4sg.
