### PR TITLE
test(core): run make-reset-runtime-fixture :init-fn under the body's ambient frame (rf2-4775uc)

### DIFF
--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -463,7 +463,6 @@
          ;; is not on the classpath.
          (when (and clear-app-schemas? clear-fn)
            (clear-fn))
-         (when init-fn (init-fn))
          ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`,
          ;; and the framework operation surfaces (dispatch / subscribe /
          ;; machine + http + routing fxs) now require a carried frame stamp.
@@ -490,10 +489,33 @@
          ;; scope models the genuine top-level boot those tests intend; their
          ;; in-body dispatches carry explicit `{:frame …}` or run inside a
          ;; `with-new-frame` scope, so they do not rely on the ambient frame.
+         ;;
+         ;; rf2-4775uc — the `:init-fn` runs UNDER the same ambient scope as the
+         ;; test body. `:init-fn` is per-suite setup that needs the registrar /
+         ;; adapter live (step 7) — e.g. re-running an app's `register-all!` /
+         ;; `install!` thunks. Those thunks can perform context-required
+         ;; frame-local ops (`reg-app-schema` / `reg-flow` / a bare `dispatch`),
+         ;; which resolve `*current-frame*` and raise `:rf.error/no-frame-context`
+         ;; under no scope (rf2-5q7um6). Pre-fix, `:init-fn` fired OUTSIDE this
+         ;; binding, so a bare frame-local op in setup threw frameless — and
+         ;; because the `:node-test` build runs every `*_cljs_test` ns in ONE
+         ;; shared JS runtime, that throw, landing during a concurrently-pending
+         ;; async test's `done` window, surfaced as the intermittent
+         ;; `unexpected reject: :rf.error/no-frame-context` +
+         ;; `Async test called done more than one time` suite-abort flake. Run
+         ;; `:init-fn` under the same carried-frame floor as the body so setup
+         ;; gets the same ambient scope the test does. (rf2-ofzxh9 patched one
+         ;; such call site, the websocket fixture's `reg-app-schema`; this
+         ;; closes the whole class at the fixture seam.) The `:ambient-frame nil`
+         ;; / adapter-less branch keeps `:init-fn` frameless — those tests own
+         ;; their frame creation and must not run setup under a synthetic scope.
          (if (and adapter ambient-frame)
            (binding [frame/*current-frame* ambient-frame]
+             (when init-fn (init-fn))
              (test-fn))
-           (test-fn))
+           (do
+             (when init-fn (init-fn))
+             (test-fn)))
          (finally
            (restore-registrar! snap)
            (when restore-fn (restore-fn schemas-snap))

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -306,6 +306,71 @@
         (finally
           (reset! late-bind/hooks snapshot))))))
 
+;; ---- rf2-4775uc — `:init-fn` runs under the body's ambient frame ----------
+;;
+;; The fixture's `:init-fn` is per-suite setup that needs the registrar /
+;; adapter live (docstring step 7) — e.g. re-running an app's
+;; `register-all!` / `install!` thunks, which can perform context-required
+;; frame-local ops (`reg-app-schema` / `reg-flow` / a bare `dispatch`). Those
+;; resolve `*current-frame*` and raise `:rf.error/no-frame-context` under no
+;; scope (rf2-5q7um6). Pre-fix the `:init-fn` ran OUTSIDE the ambient
+;; `*current-frame*` binding the fixture establishes around the body, so a
+;; bare frame-local op in setup threw frameless — surfacing (in the shared
+;; `:node-test` JS runtime) as the intermittent double-`done` suite-abort
+;; flake rf2-ofzxh9 / rf2-4775uc closed. Pin that the `:init-fn` now runs
+;; under the same carried-frame floor as the body.
+
+(deftest make-reset-runtime-fixture-runs-init-fn-under-ambient-frame
+  (testing "an adapter fixture runs `:init-fn` under the ambient `:rf/default`
+            scope, so a context-required frame-local op in setup does NOT
+            raise `:rf.error/no-frame-context` (rf2-4775uc)"
+    ;; Neutralise the enclosing `reset-runtime` fixture's ambient
+    ;; `(with-frame :rf/default …)` so the `:rf/default` we observe is the
+    ;; one THIS fixture binds around `:init-fn`, not the outer fixture's —
+    ;; mirroring the real flake context (cljs.test has no enclosing
+    ;; `with-frame`, so a frameless `:init-fn` would otherwise see nil).
+    (binding [frame/*current-frame* nil]
+      (let [seen-frame (atom :unset)
+            threw      (atom nil)]
+        (try
+          (let [fixture (ts/make-reset-runtime-fixture
+                          {:adapter plain-atom/adapter
+                           :init-fn (fn []
+                                      ;; A frame-local op the way an app's
+                                      ;; setup thunk would run it — bare, no
+                                      ;; explicit `{:frame …}`.
+                                      (reset! seen-frame (frame/current-frame))
+                                      (rf/reg-app-schema [:counter] :int))})]
+            (fixture (fn [] :ran)))
+          (catch Throwable t (reset! threw t)))
+        (is (nil? @threw)
+            "the bare `reg-app-schema` in `:init-fn` did not throw frameless")
+        (is (= :rf/default @seen-frame)
+            "`:init-fn` observed the ambient `:rf/default` scope (same as the
+             test body)")))))
+
+(deftest make-reset-runtime-fixture-init-fn-frameless-when-ambient-opted-out
+  (testing "`:ambient-frame nil` keeps `:init-fn` frameless — tests that own
+            their frame creation must not run setup under a synthetic scope
+            (rf2-4775uc / rf2-9o48ih)"
+    ;; Neutralise the enclosing `reset-runtime` fixture's ambient
+    ;; `(with-frame :rf/default …)` so we observe THIS fixture's scope
+    ;; decision (not the outer one's) — in the real flake context cljs.test
+    ;; has no such enclosing `with-frame`.
+    (binding [frame/*current-frame* nil]
+      (let [seen-frame (atom :unset)]
+        (let [fixture (ts/make-reset-runtime-fixture
+                        {:adapter       plain-atom/adapter
+                         :ambient-frame nil
+                         :init-fn       (fn []
+                                          (reset! seen-frame
+                                                  (frame/current-frame)))})]
+          (fixture (fn [] :ran)))
+        (is (nil? @seen-frame)
+            "no ambient frame was bound around `:init-fn` when
+             `:ambient-frame nil` opts out (the fixture leaves
+             `*current-frame*` unbound, so `current-frame` is nil)")))))
+
 ;; ---- rf2-j9phb (TE-R2.3) — destroy-frame! hook-cascade coverage -----------
 ;;
 ;; The other half of the round-2 audit finding. `destroy-frame!`'s


### PR DESCRIPTION
## What

Fixes rf2-4775uc — the intermittent tools/story CLJS node-test suite-abort flake (an async :rf.error/no-frame-context reject that double-calls done and aborts the runner before the summary prints).

## Root cause

re-frame.test-support/make-reset-runtime-fixture invoked its :init-fn OUTSIDE the ambient *current-frame* binding it establishes around the test body. The :init-fn is per-suite setup that needs the registrar / adapter live (docstring step 7) — e.g. re-running an app's register-all! / install! thunks. Those thunks can perform context-required frame-local ops (reg-app-schema / reg-flow / a bare dispatch), which resolve *current-frame* and raise :rf.error/no-frame-context under no scope (rf2-5q7um6).

Because the :node-test build runs every *_cljs_test namespace in ONE shared JS runtime, a frameless throw in setup — landing during a concurrently-pending cljs.test async test's done() window — surfaced as the intermittent "unexpected reject: :rf.error/no-frame-context" + "Async test called done more than one time" suite-abort. This is the same class rf2-ofzxh9 (#3684) patched at one Story call site (the websocket fixture's reg-app-schema); this PR closes the whole class at the fixture seam.

## Fix

Run :init-fn under the same carried-frame floor as the test body: fold the :init-fn invocation into the (binding [frame/*current-frame* ambient-frame] ...) branch. The :ambient-frame nil / adapter-less branch keeps :init-fn frameless — tests that own their frame creation (make-frame / with-new-frame) must not run setup under a synthetic scope.

## Tests

Two JVM regression tests in re-frame.test-support-test:
- make-reset-runtime-fixture-runs-init-fn-under-ambient-frame — a bare reg-app-schema in :init-fn no longer throws frameless and observes the ambient :rf/default scope.
- make-reset-runtime-fixture-init-fn-frameless-when-ambient-opted-out — :ambient-frame nil keeps :init-fn frameless.

Verified the first test reproduces the exact :rf.error/no-frame-context throw when the fix is reverted (red), and passes with the fix (green).

## Verification

- Full core JVM suite: 1052 tests, 0 failures, 0 errors.
- node-test (npm run test:cljs build): 6128 tests / 21882 assertions, 0 failures, 5 consecutive green runs, zero flake-signature hits.
