### PR TITLE
fix(conformance): correct stale runtime-db path spelling in docstring (rf2-r8c6rt)

### DIFF
--- a/implementation/core/src/re_frame/conformance.cljc
+++ b/implementation/core/src/re_frame/conformance.cljc
@@ -535,7 +535,7 @@
 
   The on-spawn callback receives the parent machine's `:data` and the
   just-allocated actor id; the return value is advisory only — the
-  runtime tracks the spawned id at `[:rf/runtime :machines :spawned <parent> <invoke-id>]`
+  runtime tracks the spawned id at `[:rf.runtime/machines :spawned <parent> <invoke-id>]`
   regardless. The DSL body's `:set` ops are realised here for body
   inspection / trace symmetry with regular actions; the resulting map is
   RETURNED for compatibility with corpus authors who want to observe


### PR DESCRIPTION
Fixes rf2-r8c6rt (P4 nit). The on-spawn callback docstring at implementation/core/src/re_frame/conformance.cljc:538 still spelled the spawned-id path as [:rf/runtime :machines :spawned ...], a pre-EP-0001 runtime-db-fold spelling. The canonical path everywhere else (paths.cljc spawned-path helper, transition.cljc, all machines tests) is [:rf.runtime/machines :spawned ...]. Docstring-only one-line fix. clj-kondo on the changed file: 0 errors (1 pre-existing unrelated warning at line 346).