### PR TITLE
fix(story): green the story-feature-load expensive sweep (rf2-aq61uq)

### DIFF
--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -921,25 +921,38 @@
            (let [flat-open? (contains? @expanded flat-expanded-sentinel)
                  {:keys [shown hidden]} (bound-arg-rows (sort-by key eff-args)
                                                         flat-open?)]
-             [:div
-              (for [[k v] shown]
-                ^{:key k}
-                (args-row variant-id k v (get argtypes k {:widget :text})
-                          {:violation   (get viols-by-key k)
-                           :changed?    (arg-changed? eff-args saved-args k)
-                           :overridden? (contains? overrides k)
-                           :opts        opts}))
-              (when (pos? hidden)
-                [:button {:style       (:more styles)
-                          :type        "button"
-                          :data-controls-more "true"
-                          :data-controls-hidden (str hidden)
-                          :aria-label  (str "Show " hidden
-                                            " more control rows")
-                          :on-click    (fn [_]
-                                         (swap! expanded conj
-                                                flat-expanded-sentinel))}
-                 (str "+" hidden " more…")])]))
+             ;; Materialise the rows into the parent `[:div]` vector with
+             ;; `into` rather than nesting a bare `(for …)` lazy seq:
+             ;; the row widgets deref the shell-state ratom, and a lazy
+             ;; seq that derefs during render trips Reagent's "Reactive
+             ;; deref not supported in lazy seq" warning AND leaves nested
+             ;; group rows unrealised. `args-row` is a plain hiccup-
+             ;; returning fn (not a component), so reader `^{:key …}`
+             ;; metadata would land on the call form and be discarded —
+             ;; stamp the key onto the RETURNED vector via `with-meta`.
+             (cond-> (into [:div]
+                           (map (fn [[k v]]
+                                  (with-meta
+                                    (args-row variant-id k v
+                                              (get argtypes k {:widget :text})
+                                              {:violation   (get viols-by-key k)
+                                               :changed?    (arg-changed? eff-args saved-args k)
+                                               :overridden? (contains? overrides k)
+                                               :opts        opts})
+                                    {:key k})))
+                           shown)
+               (pos? hidden)
+               (conj
+                 [:button {:style       (:more styles)
+                           :type        "button"
+                           :data-controls-more "true"
+                           :data-controls-hidden (str hidden)
+                           :aria-label  (str "Show " hidden
+                                             " more control rows")
+                           :on-click    (fn [_]
+                                          (swap! expanded conj
+                                                 flat-expanded-sentinel))}
+                  (str "+" hidden " more…")]))))
          (when (seq overrides)
            [:button {:style    (:button styles)
                      :data-controls-action "reset-all"

--- a/tools/story/test/story_browser_scenarios.cjs
+++ b/tools/story/test/story_browser_scenarios.cjs
@@ -241,8 +241,13 @@ module.exports = {
         '/counter-with-stories/?variant=story.missing%2Fghost&modes=Mode.app%2Fghost&overrides=label%3A%22Ghost%22#/stories',
       );
 
+      // The canvas-first shell rework (rf2-ba86n.3) renders the calm
+      // empty state under [data-test="story-canvas-empty"] with the copy
+      // "Pick a story, variant, or workspace from the sidebar to render
+      // it here." A stale share URL pointing at an unregistered variant
+      // must degrade to this empty state — no canvas mounts.
       await expectVisible(
-        page.getByText(/Select a variant or workspace from the sidebar|select a variant from the sidebar/i, { exact: false }).first(),
+        page.locator('[data-test="story-canvas-empty"]'),
         10000,
       );
       const selectedVariants = await page.locator('[data-test-variant]').count();
@@ -973,6 +978,24 @@ module.exports = {
       const aside = page.getByRole('complementary');
       const settingsGroup = aside.locator('[data-controls-arg=":settings"]').first();
       await settingsGroup.waitFor({ state: 'visible', timeout: 5000 });
+
+      // Summarise-before-expand (rf2-ba86n.5, spec/019 §4): a :map group
+      // renders collapsed by default (a ▸ disclosure header + a one-line
+      // summary), so the nested child rows are NOT in the DOM until the
+      // group is expanded. Click the group's toggle-expand disclosure
+      // before asserting on the nested :title / :enabled? rows.
+      const settingsToggle = settingsGroup
+        .locator('[data-controls-action="toggle-expand"]')
+        .first();
+      await settingsToggle.waitFor({ state: 'visible', timeout: 5000 });
+      if ((await settingsToggle.getAttribute('aria-expanded')) !== 'true') {
+        await settingsToggle.click();
+        await waitForValue(
+          () => settingsToggle.getAttribute('aria-expanded'),
+          (value) => value === 'true',
+          { timeoutMs: 5000, description: ':settings group expanded' },
+        );
+      }
 
       // The :settings group MUST surface its two child keys via the
       // nested-row data-controls-key attribute.

--- a/tools/story/test/story_feature_load.cjs
+++ b/tools/story/test/story_feature_load.cjs
@@ -248,6 +248,18 @@ async function assertTestPaneStatus(page, pattern, description) {
   );
 }
 
+// A run whose tape-floor verdict is an exception lands as the distinct
+// :error run-status (rf2-ba86n.11, spec/021 §1), not a plain assertion
+// :fail. Anchor on the pill's data-status attribute (text would read the
+// CSS-uppercased "ERROR") and accept either :error or :fail.
+async function assertTestPaneErrorOrFail(page, description) {
+  await waitForValue(
+    () => page.locator('[data-test="story-test-status-pill"]').getAttribute('data-status').catch(() => ''),
+    (value) => value === 'error' || value === 'fail',
+    { timeoutMs: 10000, description },
+  );
+}
+
 async function setMode(page, mode) {
   const chip = page.locator(`[data-test="story-mode-tabs"] [data-mode-tab="${mode}"]`);
   await chip.waitFor({ state: 'visible', timeout: 5000 });
@@ -542,9 +554,14 @@ async function assertDiagnostics(page, phase) {
       ':story.counter-diagnostics/failing-event-throws',
       5000,
     );
+    // An event-handler exception is a tape-floor :error — the unified
+    // run-result UX (rf2-ba86n.11, spec/021 §1) surfaces it as the
+    // distinct :error run-status, not a plain assertion :fail. The pill
+    // stamps data-status="error" (text "error"); anchor on data-status
+    // rather than the CSS-uppercased innerText.
     await waitForValue(
-      () => page.locator('[data-test="story-test-status-pill"]').innerText().catch(() => ''),
-      (text) => /failed/i.test(text),
+      () => page.locator('[data-test="story-test-status-pill"]').getAttribute('data-status').catch(() => ''),
+      (value) => value === 'error' || value === 'fail',
       { timeoutMs: 10000, description: 'event exception failure status' },
     );
     const detail = await expandFirstFailDetail(page, 'event exception detail expands');
@@ -562,7 +579,7 @@ async function assertDiagnostics(page, phase) {
     await waitForValue(
       () =>
         page
-          .locator('[data-test="story-test-row"][data-status="fail"]')
+          .locator('[data-test="story-test-row"][data-status="error"]')
           .first()
           .getAttribute('data-assertion'),
       (value) => value === ':rf.error/exception',
@@ -578,9 +595,11 @@ async function assertDiagnostics(page, phase) {
       ':story.counter-diagnostics/loader-throws',
       5000,
     );
+    // A loader-phase exception is a tape-floor :error (rf2-ba86n.11,
+    // spec/021 §1), surfaced via data-status="error" on the pill.
     await waitForValue(
-      () => page.locator('[data-test="story-test-status-pill"]').innerText().catch(() => ''),
-      (text) => /failed/i.test(text),
+      () => page.locator('[data-test="story-test-status-pill"]').getAttribute('data-status').catch(() => ''),
+      (value) => value === 'error' || value === 'fail',
       { timeoutMs: 10000, description: 'loader exception failure status' },
     );
     const detail = await expandFirstFailDetail(page, 'loader exception detail expands');
@@ -598,7 +617,7 @@ async function assertDiagnostics(page, phase) {
     await waitForValue(
       () =>
         page
-          .locator('[data-test="story-test-row"][data-status="fail"]')
+          .locator('[data-test="story-test-row"][data-status="error"]')
           .first()
           .getAttribute('data-assertion'),
       (value) => value === ':rf.error/exception',
@@ -694,9 +713,18 @@ async function assertCommandPalette(page) {
 
   await page.keyboard.press('Control+K');
   await expectVisible(page.locator('[data-test="story-command-palette"]'), 5000);
-  await page.locator('[data-test="story-command-palette-input"]').fill('clicked three');
-  await page.keyboard.press('Enter');
-  await waitForCanvasVariant(page, ':story.counter/clicked-three-times');
+  // Navigate to a deterministic, play-script-free variant. The prior
+  // `/clicked-three-times` target runs three `:dispatch-sync` increments
+  // from its `:play-script` on every (re)mount, and the variant frame
+  // re-mounts under React StrictMode — so `[data-test-variant]` churns
+  // and `waitFor({state:'visible'})` flakes. `:story.counter/events-only
+  // -loaded` settles from `:setup [[:counter/initialise 5]]` alone (no
+  // play-script, no loaders → fast-path to `:ready`), so the canvas is
+  // stable the moment it mounts. Same precedent as the sidebar-nav step,
+  // which deliberately skips `/clicked-three-times` for this reason.
+  await page.locator('[data-test="story-command-palette-input"]').fill('events only loaded');
+  await page.locator('[data-test="story-command-palette-result"][data-id=":story.counter/events-only-loaded"]').click();
+  await waitForCanvasVariant(page, ':story.counter/events-only-loaded');
 
   await page.keyboard.press('Control+K');
   await page.locator('[data-test="story-command-palette-input"]').fill('auto grid');
@@ -858,7 +886,17 @@ async function assertLoaderSuccess(page) {
 }
 
 async function expandFirstFailDetail(page, description) {
-  const row = page.locator('[data-test="story-test-row"][data-status="fail"]').first();
+  // The actionable, disclosure-bearing rows are :fail / :error /
+  // :cannot-run (rf2-ba86n.11 — the view discloses detail for all three).
+  // An event-handler / loader exception lands as an :error row, not a
+  // plain assertion :fail, so match any of the three.
+  const row = page
+    .locator(
+      '[data-test="story-test-row"][data-status="fail"], ' +
+        '[data-test="story-test-row"][data-status="error"], ' +
+        '[data-test="story-test-row"][data-status="cannot-run"]',
+    )
+    .first();
   await row.waitFor({ state: 'visible', timeout: 10000 });
   await row.getByRole('button', { name: /show detail/i }).click();
   return waitForValue(
@@ -944,7 +982,9 @@ async function assertLoaderCompletion(page) {
   // :loader-rejection marker + the throw-loader-rejection source event.
   await assertMatrixVariant(page, '/loader-rejects', ':story.counter-matrix/loader-rejects');
   await setMode(page, 'test');
-  await assertTestPaneStatus(page, /failed/i, 'loader rejection completion status');
+  // A loader rejection is recorded via the exception path (record-error!)
+  // so its tape-floor verdict is :error, not :fail.
+  await assertTestPaneErrorOrFail(page, 'loader rejection completion status');
   detail = await expandFirstFailDetail(page, 'loader rejection completion detail expands');
   await assertFailureDetailIncludes(
     detail,

--- a/tools/story/testbeds/login_form/core.cljs
+++ b/tools/story/testbeds/login_form/core.cljs
@@ -113,6 +113,12 @@
   ;; :initial state and :data seed the snapshot on first dispatch.
   ;; Without this, the live page's state-pill renders "state: "
   ;; (nil) until the user submits.
-  (rf/dispatch-sync [:login/flow [:login/dismiss]])
+  ;;
+  ;; EP-0002 (rf2-9o48ih): `init!` installs the adapter only and a
+  ;; frameless `dispatch-sync` raises `:rf.error/no-frame-context`.
+  ;; Run the seed dispatch inside the testbed's `:rf/default` frame
+  ;; scope — symmetric to counter-with-stories' migrated boot.
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [:login/flow [:login/dismiss]]))
   ;; Wire the live-app↔Story-shell hash router (shared helper).
   (story-host/mount-with-hash-routing! login-app))


### PR DESCRIPTION
Greens the occasional `npm run test:story-feature-load` expensive sweep (rf2-aq61uq). The sweep failed on a chain of latent issues, each masking the next; the bead reported two checks but fixing the first failure in each spec exposed downstream ones in the same spec. Two real source bugs plus several stale test assertions left over from the May-30 canvas-first shell + unified-run-result UX reworks.

## Source fixes

- **args-editor key/lazy-seq (controls.cljs)** — the flat-rows `(for …)` attached `^{:key k}` to the `args-row` CALL form. `args-row` is a plain hiccup-returning fn (not a component), so reader metadata landed on the discarded call form and the rows rendered keyless (React unique-key warning, 8x in the baseline run). Materialise the rows into the parent div with `into` + `with-meta` so keys land on the returned vectors and the bare lazy seq (which derefs the shell-state ratom) no longer trips Reagent's "Reactive deref not supported in lazy seq" warning or leaves nested `:map` group rows unrealised.

- **login-form testbed EP-0002 (login_form/core.cljs)** — `run` did a frameless `(dispatch-sync [:login/flow …])` after EP-0002 (rf2-9o48ih) made `init!` adapter-only, raising `:rf.error/no-frame-context` on boot; the Story shell never mounted. Wrap the seed dispatch in `(with-frame :rf/default …)`, matching the already-migrated counter-with-stories boot. (Confirmed via a throwaway browser probe: the thrown ex-info was `:rf.error/no-frame-context` at `login-form.core/run`.)

## Stale test assertions

- `stale-share-url-degrades` — anchor on the stable `data-test="story-canvas-empty"` (empty-state copy changed in the canvas-first rework).
- `diagnostics/event-handler-exception` + `loader-exception` + `loader-rejects` — an exception is now the distinct `:error` run-status, not `:fail`; anchor on the pill's `data-status` (accept `error`/`fail`) and read the exception row via `data-status="error"`.
- `controls-nested-edit-by-path` — expand the `:settings` `:map` group disclosure first (summarise-before-expand renders nested rows only when expanded).
- `Command palette` — navigate to the deterministic `:story.counter/events-only-loaded` rather than the known-brittle `:story.counter/clicked-three-times` (its play-script re-runs and the frame remounts under StrictMode, churning `[data-test-variant]`); same precedent the sidebar-nav step already follows.

## Gates

- `npm run test:story-feature-load` — green: 2 specs, 0 failures, 0 browser errors, 0 key/lazy-deref warnings.
- story JVM suite (`clojure -M:test`) — 1670 tests, 6180 assertions, 0 failures, 0 errors.
- clj-kondo clean on changed files (2 pre-existing unrelated unused-private-var warnings).
