### PR TITLE
refactor(story): centralize active-modes URL ownership outside the toolbar (rf2-96y71s)

### DIFF
--- a/tools/story/spec/010-Toolbar.md
+++ b/tools/story/spec/010-Toolbar.md
@@ -303,16 +303,29 @@ that no longer resolve at the registrar (stale storage after a
 shows an unknown chip for at most one render cycle before re-render
 prunes it.
 
-### URL deep-link — already wired
+### URL deep-link — owned by the url-state engine (rf2-96y71s)
 
-`re-frame.story.share/build-params` already encodes `:active-modes`
-into the share URL as the `modes=` query param (per
-[`share.cljc`](../src/re_frame/story/share.cljc) lines 65-96). The
-inverse hydrate (parse `?modes=...` on shell mount, seed
-`:active-modes`) is implementation scope for the impl bead — the
-contract from this spec is "if the URL carries `modes=`, the toolbar
-opens with those chips active." The URL takes precedence over
-localStorage on hydrate (last-shared wins over last-used).
+`re-frame.story.share/build-params` encodes `:active-modes` into the
+share URL as the `modes=` query param;
+`re-frame.story.share/parse-modes-param` (reached via
+`share/parse-params`) is the inverse, and
+`re-frame.story.ui.url-state/apply-parsed-to-state` is the SINGLE
+authoritative writer that folds the parsed `:active-modes` back into
+shell-state on mount and on every popstate. The toolbar does NOT read
+or parse the URL — it owns rendering, toggles, and the localStorage
+fallback only.
+
+The contract from this spec is unchanged: "if the URL carries `modes=`,
+the toolbar opens with those chips active," and the URL takes precedence
+over localStorage (last-shared wins over last-used). The precedence is
+realised by mount ORDER: `toolbar/hydrate-modes-from-storage!` seeds the
+localStorage fallback FIRST, then the url-state hydrator authoritatively
+overrides it — a present `modes=` writes the parsed modes, an omitted
+`modes=` (alongside any other params) clears `:active-modes` to `[]`
+(spec/022 §Share semantics — the URL is authoritative for every URL-owned
+chrome slot), and a fully bare URL leaves the localStorage seed intact.
+See [`022-Story-UI-Docs-And-Share.md`](022-Story-UI-Docs-And-Share.md)
+§Share semantics for the full URL-owned-slot ownership story.
 
 ## Interaction with Storybook addons — confirmed mappings
 

--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -112,6 +112,24 @@
   [s]
   (parse-keyword-token s))
 
+(defn prune-unregistered-modes
+  "Drop mode ids from `modes` that no longer resolve at the registrar
+  (stale localStorage / a share-URL pointing at a renamed mode). Pure
+  data → data; JVM-testable via an injected `registered?` predicate.
+
+  `registered?` is a `(mode-id → boolean)` predicate — the production
+  caller (`re-frame.story.ui.toolbar`) closes it over the live
+  `re-frame.story.registrar`; tests pass a set / fn. Returns a vector
+  (never nil); a nil/empty `modes` yields `[]`.
+
+  Only the stored-modes (localStorage) hydration path prunes — URL-
+  derived `:active-modes` ride the canonical `apply-parsed-to-state`
+  writer verbatim (like every other URL-owned slot), so this helper is
+  shared by `share.cljc`'s mode codec rather than duplicated in the
+  toolbar or its tests."
+  [modes registered?]
+  (vec (filter registered? (or modes []))))
+
 ;; ---- rf2-o4u18: workspace / mode-tab / viewport / background / tag-filter
 
 (defn parse-workspace-param

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -845,15 +845,21 @@
          ;; prefers-contrast more / when config/enabled? is false.
          ;; Idempotent.
          (depth/inject-grain-css!)
-         ;; rf2-xi9zk: hydrate chrome-wide :active-modes from URL +
-         ;; localStorage before the first render of the toolbar /
-         ;; canvas. URL wins over localStorage per spec/010 §URL deep-
-         ;; link. Idempotent and one-shot.
-         (toolbar/hydrate!)
+         ;; rf2-96y71s: seed chrome-wide :active-modes from the
+         ;; localStorage FALLBACK only. The toolbar no longer reads the
+         ;; URL — URL-derived :active-modes hydration is owned solely by
+         ;; the url-state engine (hydrate-url-state! below, via
+         ;; apply-parsed-to-state). This localStorage seed runs FIRST so
+         ;; the URL hydrator can authoritatively override it when the
+         ;; URL carries params, and leave it intact on a fresh no-URL
+         ;; mount — the URL-over-localStorage precedence (spec/022
+         ;; §Share semantics). Idempotent and one-shot.
+         (toolbar/hydrate-modes-from-storage!)
          ;; rf2-zll4h: hydrate the chrome-wide viewport + background
          ;; selections from localStorage. Both are idempotent and
          ;; one-shot; they no-op when the slot is already populated
-         ;; (e.g. a programmatic test fixture seeded them).
+         ;; (e.g. a programmatic test fixture seeded them). Same
+         ;; localStorage-first / URL-authoritative discipline as modes.
          (viewport-switcher/hydrate!)
          (backgrounds-switcher/hydrate!)
          (start-hot-reload-poll!)

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -13,9 +13,9 @@
                                    horizontal strip with chips per
                                    registered mode + a `[reset]` button.
   - `toggle-mode!`               — programmatic toggle for tests.
-  - `hydrate-modes-from-storage!`/`hydrate-modes-from-url!` — idempotent
-                                   one-shot hydrators run at shell
-                                   mount.
+  - `hydrate-modes-from-storage!` — idempotent one-shot localStorage
+                                   fallback hydrator, run at shell mount
+                                   BEFORE the URL hydrator.
   - `save-modes-to-storage!`     — persist after every change.
 
   ## Selection semantics
@@ -29,8 +29,23 @@
   - `:axis` absent → multi-select. Any subset can be active.
 
   The pure logic lives in `re-frame.story.ui.state/toggle-mode` (JVM-
-  testable); this ns wires the impure surfaces — localStorage,
-  `js/window.location.search`, and the Reagent ratom — around it.
+  testable); this ns wires the impure surfaces — localStorage and the
+  Reagent ratom — around it.
+
+  ## URL ownership boundary (rf2-96y71s)
+
+  This ns owns ONLY rendering, toggles, and localStorage persistence.
+  It does NOT read or parse `js/window.location` — all `modes=` URL
+  parsing lives in `re-frame.story.share` (`parse-modes-param`,
+  `parse-params`) and all URL-derived `:active-modes` hydration runs
+  through `re-frame.story.ui.url-state/apply-parsed-to-state`, the
+  single authoritative URL writer (spec/022 §Share semantics). The
+  toolbar's localStorage fallback (`hydrate-modes-from-storage!`) runs
+  FIRST on mount; the URL hydrator then either authoritatively-clears
+  `:active-modes` (when the URL carries query params) or — on a fresh
+  mount with no URL state at all — leaves the localStorage seed intact.
+  That ordering is the URL-over-localStorage precedence (last-shared
+  wins over last-used).
 
   ## Persistence
 
@@ -41,15 +56,14 @@
       re-frame.story/active-modes → \"[:Mode.app/dark :Mode.app/mobile]\"
 
   Stored as a `pr-str`-encoded vector of mode ids; `read-string` on
-  load. The URL deep-link (`?modes=...`) takes precedence over
-  localStorage on hydrate (last-shared wins over last-used).
-
-  Mode ids that no longer resolve at the registrar (stale storage after
-  a `reg-mode` rename) are silently dropped at hydrate time."
+  load. Mode ids that no longer resolve at the registrar (stale storage
+  after a `reg-mode` rename) are silently dropped at hydrate time via
+  `re-frame.story.share/prune-unregistered-modes`."
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
             [re-frame.story.local-storage :refer [safe-local-storage]]
             [re-frame.story.registrar :as registrar]
+            [re-frame.story.share :as share]
             [re-frame.story.ui.backgrounds-switcher :as backgrounds-switcher]
             [re-frame.story.ui.element-inspector :as element-inspector]
             [re-frame.story.ui.play-status :as play-status]
@@ -91,62 +105,38 @@
     (try (.setItem ls ls-key (pr-str (vec modes)))
          (catch :default _ nil))))
 
-;; ---- URL deep-link -------------------------------------------------------
-
-(defn parse-modes-param
-  "Parse a `modes=` URL query-param value into a vector of mode-id
-  keywords. Each id arrives as `\"<ns>/<name>\"` (the canonical
-  `(name kw)` form share.cljc emits via `kw->str`) — split on `,` and
-  reconstruct via `keyword`. Pure data → data; JVM-testable.
-
-  Returns nil if `s` is blank, an empty vector if no ids parse."
-  [s]
-  (when (and (string? s) (seq (str/trim s)))
-    (->> (str/split s #",")
-         (map str/trim)
-         (remove str/blank?)
-         (map (fn [part]
-                (if-let [slash (str/index-of part "/")]
-                  (keyword (subs part 0 slash) (subs part (inc slash)))
-                  (keyword part))))
-         vec)))
-
-(defn modes-from-current-url
-  "Extract the `modes=` deep-link from `js/window.location.search`, if
-  any. Returns a vector of mode-id keywords or nil. CLJS-only — the
-  pure parsing fn `parse-modes-param` does the heavy lifting and is
-  JVM-testable."
-  []
-  (when (exists? js/window)
-    (let [search (some-> js/window .-location .-search)]
-      (when (and (string? search) (seq search))
-        (try
-          (let [params (js/URLSearchParams. search)
-                raw   (.get params "modes")]
-            (when (some? raw)
-              (parse-modes-param raw)))
-          (catch :default _ nil))))))
-
 ;; ---- registrar-pruning ---------------------------------------------------
 
 (defn prune-unregistered
-  "Drop mode ids from `modes` that no longer resolve at the
-  registrar (stale storage / share-URL pointing at a renamed mode).
-  Pure data → data; JVM-testable. `registered?` defaults to the live
-  registrar; tests may inject."
-  ([modes]
-   (prune-unregistered modes (fn [mid] (registrar/registered? :mode mid))))
-  ([modes registered?]
-   (vec (filter registered? (or modes [])))))
+  "Drop mode ids from `modes` that no longer resolve at the live
+  registrar (stale localStorage after a `reg-mode` rename). Delegates
+  to the CLJC production helper `share/prune-unregistered-modes` with
+  the live registrar predicate injected — the pure logic is JVM-tested
+  against `share/prune-unregistered-modes` directly, not a copy here."
+  [modes]
+  (share/prune-unregistered-modes
+    modes (fn [mid] (registrar/registered? :mode mid))))
 
 ;; ---- hydration -----------------------------------------------------------
+;;
+;; rf2-96y71s: the toolbar owns ONLY the localStorage FALLBACK. URL-
+;; derived `:active-modes` hydration is the url-state engine's job
+;; (`url-state/apply-parsed-to-state`, the single authoritative URL
+;; writer). This fallback runs FIRST on mount; the URL hydrator then
+;; either authoritatively-clears `:active-modes` (URL carries params)
+;; or leaves this seed intact (fresh mount, no URL state) — the
+;; URL-over-localStorage precedence (spec/022 §Share semantics).
 
 (defn hydrate-modes-from-storage!
   "Seed the shell-state's `:active-modes` from localStorage on first
   shell mount. Idempotent: only writes when the slot is the default
-  empty vector — so an already-populated state (deep-link, programmatic
-  test fixture) is never clobbered. Spec/010 §Persistence — chrome-wide
-  localStorage."
+  empty vector — so an already-populated state (programmatic test
+  fixture) is never clobbered. Stale ids are pruned against the live
+  registrar. Spec/010 §Persistence — chrome-wide localStorage.
+
+  Mirrors the `viewport-switcher/hydrate!` / `backgrounds-switcher/
+  hydrate!` shape: a localStorage-only seed that the URL hydrator may
+  later override."
   []
   (let [shell @state/shell-state-atom]
     (when (empty? (:active-modes shell))
@@ -154,29 +144,6 @@
         (let [pruned (prune-unregistered persisted)]
           (when (seq pruned)
             (state/swap-state! state/set-active-modes pruned)))))))
-
-(defn hydrate-modes-from-url!
-  "Seed the shell-state's `:active-modes` from the `?modes=...` query
-  param, if present. URL beats localStorage — spec/010 §URL deep-link
-  'last-shared wins over last-used'. Idempotent and one-shot at shell
-  mount."
-  []
-  (when-let [from-url (modes-from-current-url)]
-    (let [pruned (prune-unregistered from-url)]
-      (when (seq pruned)
-        (state/swap-state! state/set-active-modes pruned)))))
-
-(defn hydrate!
-  "One-shot hydration entry-point: URL takes precedence over storage.
-  Called from the shell's `:component-did-mount`. Spec/010 §URL deep-
-  link — already wired."
-  []
-  ;; URL first — clobbers localStorage on hydrate per spec/010.
-  (let [url-modes (modes-from-current-url)
-        pruned    (when (seq url-modes) (prune-unregistered url-modes))]
-    (if (seq pruned)
-      (state/swap-state! state/set-active-modes pruned)
-      (hydrate-modes-from-storage!))))
 
 ;; ---- programmatic toggle -------------------------------------------------
 

--- a/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/toolbar_cljs_test.cljc
@@ -8,19 +8,20 @@
   ## Coverage layers
 
   - **Pure data** (JVM + CLJS): `toggle-mode` axis semantics,
-    `group-modes-by-axis` layout, `parse-modes-param` URL parsing,
-    `prune-unregistered` registrar-pruning, schema additivity for the
-    new `:axis` slot.
+    `group-modes-by-axis` layout, `share/parse-modes-param` URL
+    parsing, `share/prune-unregistered-modes` registrar-pruning (the
+    CLJC PRODUCTION helpers — rf2-96y71s removed the JVM copies that
+    used to shadow the live impl), schema additivity for the new
+    `:axis` slot.
   - **CLJS-only side-effects**: localStorage round-trip via
     `save-modes-to-storage!` + `load-modes-from-storage`,
-    `toggle-mode!` mutation against `shell-state-atom`, hydration
-    precedence (URL beats localStorage), the rendered hiccup carries
-    chip elements per registered mode."
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest is testing use-fixtures]]
+    `toggle-mode!` mutation against `shell-state-atom`, the rendered
+    hiccup carries chip elements per registered mode."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.story :as story]
             [re-frame.story.registrar :as story-registrar]
             [re-frame.story.schemas :as schemas]
+            [re-frame.story.share :as share]
             [re-frame.story.ui.state :as state]
             #?@(:cljs [[re-frame.story.ui.cofx :as ui-cofx]
                        [re-frame.story.ui.toolbar :as toolbar]])))
@@ -33,35 +34,14 @@
      []
      (and (exists? js/window) (.-localStorage js/window))))
 
-;; The full `toolbar` ns is CLJS-only — it depends on `js/window`,
-;; `js/URLSearchParams`, and `localStorage`. The JVM arm of this test
-;; exercises the pure helpers that live in `state.cljc` (those run
-;; on both runtimes) and inlines duplicates of the pure parsing
-;; helpers below so the JVM corpus can exercise them without
-;; requiring the CLJS ns. The CLJS arm tests the live impure
-;; surfaces.
-
-#?(:clj
-   (defn ^:no-doc parse-modes-param-jvm
-     "JVM duplicate of `toolbar/parse-modes-param`. Tracks the live
-     CLJS impl byte-for-byte; if the live impl changes shape, this
-     copy must update."
-     [s]
-     (when (and (string? s) (seq (str/trim s)))
-       (->> (str/split s #",")
-            (map str/trim)
-            (remove str/blank?)
-            (map (fn [part]
-                   (if-let [slash (str/index-of part \/)]
-                     (keyword (subs part 0 slash) (subs part (inc slash)))
-                     (keyword part))))
-            vec))))
-
-#?(:clj
-   (defn ^:no-doc prune-unregistered-jvm
-     "JVM duplicate of `toolbar/prune-unregistered` (registered? arity)."
-     [modes registered?]
-     (vec (filter registered? (or modes [])))))
+;; rf2-96y71s: the `:active-modes` URL contract lives in ONE place.
+;; The pure `modes=` parser and the registrar-pruning helper are now
+;; the CLJC PRODUCTION fns `re-frame.story.share/parse-modes-param`
+;; and `re-frame.story.share/prune-unregistered-modes` — exercised
+;; directly on both runtimes below. The JVM arm no longer inlines
+;; copies of the toolbar parser (those copies asserted duplicated code
+;; rather than the live impl). The CLJS-only arm tests the live impure
+;; toolbar surfaces (localStorage, the Reagent ratom, chip hiccup).
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -171,38 +151,50 @@
       (is (= [:theme] (mapv first axes)))
       (is (= [] unaxed)))))
 
-;; ---- pure: URL parsing --------------------------------------------------
+;; ---- pure: URL parsing (the CLJC production helper) ---------------------
+;;
+;; rf2-96y71s: these exercise `share/parse-modes-param` directly — the
+;; SAME fn `share/parse-params` (and thus the url-state hydrator) uses.
+;; No JVM copy to drift out of sync.
 
 (deftest parse-modes-param-roundtrip
   (testing "single qualified mode id"
     (is (= [:Mode.app/dark]
-           (#?(:clj parse-modes-param-jvm :cljs toolbar/parse-modes-param)
-             "Mode.app/dark"))))
+           (share/parse-modes-param "Mode.app/dark"))))
   (testing "comma-separated list of ids"
     (is (= [:Mode.app/dark :Mode.app/mobile]
-           (#?(:clj parse-modes-param-jvm :cljs toolbar/parse-modes-param)
-             "Mode.app/dark,Mode.app/mobile"))))
+           (share/parse-modes-param "Mode.app/dark,Mode.app/mobile"))))
   (testing "whitespace around commas survives"
     (is (= [:Mode.app/a :Mode.app/b]
-           (#?(:clj parse-modes-param-jvm :cljs toolbar/parse-modes-param)
-             " Mode.app/a , Mode.app/b "))))
+           (share/parse-modes-param " Mode.app/a , Mode.app/b "))))
   (testing "blank input → nil"
-    (is (nil? (#?(:clj parse-modes-param-jvm :cljs toolbar/parse-modes-param)
-                "")))
-    (is (nil? (#?(:clj parse-modes-param-jvm :cljs toolbar/parse-modes-param)
-                "   "))))
+    (is (nil? (share/parse-modes-param "")))
+    (is (nil? (share/parse-modes-param "   "))))
   (testing "unqualified ids parse without a namespace"
-    (is (= [:bare] (#?(:clj parse-modes-param-jvm :cljs toolbar/parse-modes-param)
-                     "bare")))))
+    (is (= [:bare] (share/parse-modes-param "bare"))))
+  (testing "printed-keyword form (`:ns/name`) from a hand-copied URL"
+    (is (= [:Mode.app/dark]
+           (share/parse-modes-param ":Mode.app/dark")))))
 
-;; ---- pure: prune-unregistered -------------------------------------------
+;; ---- pure: prune-unregistered-modes (the CLJC production helper) --------
+;;
+;; rf2-96y71s: `share/prune-unregistered-modes` is the single registrar-
+;; pruning helper; the toolbar's `prune-unregistered` closes the live
+;; registrar predicate over it. Tested here with an injected set so the
+;; pure logic runs on both runtimes without the registrar.
 
-(deftest prune-unregistered-drops-stale
+(deftest prune-unregistered-modes-drops-stale
   (testing "ids not present in the registrar are dropped"
     (let [registered? #{:Mode.app/dark :Mode.app/light}]
       (is (= [:Mode.app/dark]
-             (#?(:clj prune-unregistered-jvm :cljs toolbar/prune-unregistered)
-               [:Mode.app/dark :Mode.app/sepia] registered?))))))
+             (share/prune-unregistered-modes
+               [:Mode.app/dark :Mode.app/sepia] registered?)))))
+  (testing "nil / empty modes coll yields []"
+    (is (= [] (share/prune-unregistered-modes nil (constantly true))))
+    (is (= [] (share/prune-unregistered-modes [] (constantly true)))))
+  (testing "every id stale → empty vector (not nil)"
+    (is (= [] (share/prune-unregistered-modes
+                [:Mode.app/gone :Mode.app/also-gone] #{})))))
 
 ;; ---- CLJS-only: live toolbar surfaces ----------------------------------
 ;;

--- a/tools/story/test/re_frame/story/ui/toolbar_persistence_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/toolbar_persistence_cljs_test.cljs
@@ -13,9 +13,12 @@
     `hydrate-modes-from-storage!`, assert the active modes are
     rehydrated from localStorage.
 
-  - **URL deep-link beats localStorage on reload** — set theme in
-    localStorage, simulate a reload with a different mode in the URL
-    via `hydrate-modes-from-url!`, assert the URL's modes win.
+  - **URL beats localStorage on mount** — the mount-hydration order
+    (`hydrate-modes-from-storage!` then the url-state engine's
+    `apply-parsed-to-state`) is exercised through the SINGLE canonical
+    ownership path (rf2-96y71s): the localStorage seed lands first, the
+    URL parse (`share/parse-params`) + apply then authoritatively
+    overrides it. The toolbar no longer reads the URL itself.
 
   - **Unknown mode id in localStorage is dropped at hydrate** — write
     a stale id (referring to a `reg-mode` that no longer exists) into
@@ -33,10 +36,12 @@
   variant). The CLJS tests gate on a working `js/window.localStorage`
   via the same `browser?` predicate the sibling toolbar test uses."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.story            :as story]
-            [re-frame.story.registrar  :as story-registrar]
-            [re-frame.story.ui.state   :as state]
-            [re-frame.story.ui.toolbar :as toolbar]))
+            [re-frame.story             :as story]
+            [re-frame.story.registrar   :as story-registrar]
+            [re-frame.story.share        :as share]
+            [re-frame.story.ui.state     :as state]
+            [re-frame.story.ui.toolbar   :as toolbar]
+            [re-frame.story.ui.url-state :as url-state]))
 
 ;; ---- fixtures ------------------------------------------------------------
 
@@ -78,6 +83,52 @@
   in the side-table, not in the shell state)."
   []
   (state/reset-shell-state!))
+
+(defn- modes-url-search
+  "Build the canonical `?modes=...` search string for `mode-ids` via the
+  PRODUCTION encoder `share/build-params` — the same wire form the live
+  share URL emits — so the test round-trips through the real codec rather
+  than hand-assembling tokens (and avoids the `(name kw)`-drops-namespace
+  trap)."
+  [mode-ids]
+  (str "?" (first (share/build-params {:active-modes mode-ids}))))
+
+(defn- mount-hydrate-modes!
+  "Compose the shell-mount `:active-modes` hydration through the SINGLE
+  documented ownership path (rf2-96y71s), exactly as `shell/shell`'s
+  `:component-did-mount` does, but with the URL search supplied as data
+  (`url-search`, e.g. \"?modes=Mode.app%2Fdark\" or \"\") so the test
+  drives both the localStorage seed and the URL authority without
+  touching `js/window.location`:
+
+    1. `toolbar/hydrate-modes-from-storage!` — localStorage FALLBACK
+       seeds `:active-modes` (idempotent, pruned against the registrar).
+    2. The url-state engine then folds the parsed `share/parse-params`
+       shape via `url-state/apply-parsed-to-state` — the SINGLE
+       authoritative URL writer. A present `modes=` overwrites the seed;
+       an omitted `modes=` (but other params present) authoritatively
+       CLEARS `:active-modes` to []; a fully-empty search (`\"\"`) means
+       no URL state — `apply-parsed-to-state` is NOT run, so the
+       localStorage seed survives (the URL-over-localStorage precedence).
+
+  `url-search` is the raw `location.search` string; `\"\"` / nil ⇒ no
+  URL params at all (fresh mount). Mirrors `shell/hydrate-url-state!`'s
+  `parse-current-url` gate: empty search ⇒ skip the apply."
+  [url-search]
+  (toolbar/hydrate-modes-from-storage!)
+  (when (and (string? url-search) (seq url-search))
+    (let [usp    (js/URLSearchParams. url-search)
+          getter {"variant"    (.get usp "variant")
+                  "workspace"  (.get usp "workspace")
+                  "mode-tab"   (.get usp "mode-tab")
+                  "modes"      (.get usp "modes")
+                  "viewport"   (.get usp "viewport")
+                  "background" (.get usp "background")
+                  "tag-filter" (.get usp "tag-filter")
+                  "overrides"  (.get usp "overrides")
+                  "substrate"  (.get usp "substrate")}
+          parsed (share/parse-params getter)]
+      (state/swap-state! url-state/apply-parsed-to-state parsed {}))))
 
 ;; ===========================================================================
 ;; rf2-jpi7n — mode persistence across reload (the marquee scenario)
@@ -147,42 +198,83 @@
           "empty active set survives reload"))))
 
 ;; ===========================================================================
-;; rf2-jpi7n — URL deep-link beats localStorage on reload
+;; rf2-96y71s — modes=, omitted modes=, and localStorage fallback all
+;; compose through ONE documented ownership path.
 ;;
-;; Per spec/010 §URL deep-link 'last-shared wins over last-used'.
-;; The hydration entry point (hydrate!) reads URL first; if present,
-;; URL wins. If no URL, falls back to localStorage. We test the
-;; URL-via-hydrate-modes-from-url! arm directly (the live
-;; modes-from-current-url reads js/window.location which we can't
-;; easily mock; the pure parse-modes-param is JVM-tested by the sibling
-;; toolbar_cljs_test).
+;; The toolbar no longer reads the URL. Mount hydration is:
+;;   1. toolbar/hydrate-modes-from-storage!  (localStorage FALLBACK)
+;;   2. url-state/apply-parsed-to-state       (the SINGLE URL authority)
+;; `mount-hydrate-modes!` composes exactly that with the URL search
+;; supplied as data. These three tests pin the precedence end-to-end
+;; against the canonical share/url-state path — no manual simulation of
+;; the parser, no second URL reader.
 ;; ===========================================================================
 
-(deftest hydrate-from-url-overwrites-non-empty-state
-  (testing "hydrate-modes-from-url! unconditionally writes when URL
-            params are present. Pin the precedence: even a populated
-            in-memory slot is replaced (per spec/010 §URL deep-link —
-            'last-shared wins')"
+(deftest mount-url-modes-beat-localstorage
+  (testing "rf2-96y71s — a URL carrying `modes=` overrides the
+            localStorage seed: the localStorage hydrator seeds :dark
+            first, then apply-parsed-to-state writes the URL's :light.
+            Last-shared wins over last-used — through ONE path."
     (when (browser?)
       (story/reg-mode :Mode.persist.theme/dark  {:axis :theme :args {:theme :dark}})
       (story/reg-mode :Mode.persist.theme/light {:axis :theme :args {:theme :light}})
-      ;; Pre-condition: localStorage seeded with :dark.
-      (toolbar/toggle-mode! :Mode.persist.theme/dark)
-      (is (= [:Mode.persist.theme/dark]
-             (:active-modes (state/get-state))))
-      ;; Simulate the URL-driven hydrate path by directly invoking
-      ;; the underlying state mutation hydrate-modes-from-url! would
-      ;; perform (we can't safely mutate js/window.location.search in
-      ;; the test runner). Per spec/010 the URL precedence is checked
-      ;; in `hydrate!` — pinning the data-shape contract: the URL
-      ;; modes overwrite, not append.
-      (let [url-modes [:Mode.persist.theme/light]
-            pruned    (toolbar/prune-unregistered url-modes)]
-        (state/swap-state! state/set-active-modes pruned))
+      ;; localStorage seeded with :dark (last-used).
+      (toolbar/save-modes-to-storage! [:Mode.persist.theme/dark])
+      (simulate-reload!)
+      ;; Mount with a URL that carries modes=...light (last-shared).
+      (mount-hydrate-modes! (modes-url-search [:Mode.persist.theme/light]))
       (is (= [:Mode.persist.theme/light]
              (:active-modes (state/get-state)))
-          "URL modes (light) replaced the localStorage seed (dark) —
-           last-shared wins over last-used"))))
+          "URL modes (light) replaced the localStorage seed (dark)"))))
+
+(deftest mount-omitted-modes-clears-localstorage-seed
+  (testing "rf2-96y71s / rf2-fkmnh — a URL that carries OTHER params but
+            OMITS `modes=` is authoritative: it CLEARS the localStorage
+            seed to [] (the URL is the source of truth for the full
+            share surface). A share link like ?variant=foo restores the
+            DEFAULT (no modes) chrome for the recipient."
+    (when (browser?)
+      (story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
+      (toolbar/save-modes-to-storage! [:Mode.persist.theme/dark])
+      (simulate-reload!)
+      ;; Mount with a populated URL that has NO modes= param.
+      (mount-hydrate-modes! "?variant=story.counter/loaded")
+      (is (= [] (:active-modes (state/get-state)))
+          "omitted modes= cleared the localStorage seed — URL authoritative"))))
+
+(deftest mount-no-url-falls-back-to-localstorage
+  (testing "rf2-96y71s — a fresh mount with NO URL state at all preserves
+            the localStorage seed (apply-parsed-to-state is not run when
+            the search is empty). This is the intentional last-used
+            fallback that survives ONLY when the URL carries nothing."
+    (when (browser?)
+      (story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
+      (story/reg-mode :Mode.persist.vp/mobile  {:axis :viewport :args {:viewport :mobile}})
+      (toolbar/save-modes-to-storage!
+        [:Mode.persist.theme/dark :Mode.persist.vp/mobile])
+      (simulate-reload!)
+      ;; Mount with NO URL params — localStorage is the only source.
+      (mount-hydrate-modes! "")
+      (is (= #{:Mode.persist.theme/dark :Mode.persist.vp/mobile}
+             (set (:active-modes (state/get-state))))
+          "no URL state ⇒ localStorage seed survives (last-used fallback)"))))
+
+(deftest mount-url-modes-prune-is-url-authoritative
+  (testing "rf2-96y71s — URL-derived modes ride apply-parsed-to-state
+            verbatim (the canonical writer does not prune against the
+            registrar — same discipline as every other URL-owned slot).
+            A stale localStorage seed, by contrast, IS pruned by the
+            localStorage hydrator before the URL apply overrides it."
+    (when (browser?)
+      (story/reg-mode :Mode.persist.theme/dark {:axis :theme :args {:theme :dark}})
+      ;; localStorage seed carries a stale id; the storage hydrator prunes it.
+      (toolbar/save-modes-to-storage!
+        [:Mode.persist.theme/dark :Mode.persist.removed/zzz])
+      (simulate-reload!)
+      ;; URL carries the live :dark only.
+      (mount-hydrate-modes! (modes-url-search [:Mode.persist.theme/dark]))
+      (is (= [:Mode.persist.theme/dark] (:active-modes (state/get-state)))
+          "URL modes win; the stale localStorage id never surfaces"))))
 
 ;; ===========================================================================
 ;; rf2-jpi7n — unknown mode id in localStorage is dropped at hydrate


### PR DESCRIPTION
Centralizes active-modes URL ownership outside the Story toolbar (rf2-96y71s).

## Problem

The toolbar owned a duplicate modes= URL parser and read js/window.location itself, even though Story already has a share/url-state ownership boundary. shell.cljs called toolbar/hydrate! before hydrate-url-state!, so two URL readers wrote the same :active-modes slot on one mount. The JVM tests inlined copies of the toolbar parser instead of exercising the live one — three places (toolbar, share, url-state) plus a test copy could drift apart.

## What moved out of the toolbar

Removed from re-frame.story.ui.toolbar: parse-modes-param, modes-from-current-url, hydrate-modes-from-url!, hydrate!. The toolbar now owns rendering, toggles, and the localStorage fallback only — it no longer reads the URL.

## The single ownership path

- share.cljc/parse-modes-param + parse-params parse the modes= wire form.
- url-state/apply-parsed-to-state is the single authoritative writer that folds :active-modes back into shell-state (mount + every popstate).
- Mount order in shell.cljs realises the URL-over-localStorage precedence: toolbar/hydrate-modes-from-storage! seeds the localStorage fallback FIRST, then hydrate-url-state! overrides it. Present modes= wins; omitted modes= alongside other params clears :active-modes to [] (the rf2-fkmnh authoritative-clear); a fully bare URL leaves the localStorage seed intact.

## The CLJC pruning helper

Added share/prune-unregistered-modes — a pure data to data helper with an injected registered? predicate. The toolbar's prune-unregistered closes the live registrar over it; tests exercise it directly. The stored-modes (localStorage) path prunes stale ids; URL-derived modes ride apply-parsed-to-state verbatim, like every other URL-owned slot.

## Test replacements

- toolbar_cljs_test.cljc: dropped the JVM duplicates (parse-modes-param-jvm, prune-unregistered-jvm); the parse and prune tests now call share/parse-modes-param + share/prune-unregistered-modes directly on both runtimes.
- toolbar_persistence_cljs_test.cljs: replaced the manual URL-precedence simulation with a mount-hydration helper that composes the real path (storage seed then share/parse-params then url-state/apply-parsed-to-state), and added three tests proving modes= URL, omitted modes=, and localStorage fallback all compose through ONE ownership path (plus a stale-id prune-vs-URL-authority test).

## Spec

spec/010-Toolbar.md §URL deep-link reworded to credit url-state as the single authoritative writer; cross-refs spec/022 §Share semantics (which already documented the ownership and is unchanged).

## Gates

- Story JVM tests: 1670 tests, 6184 assertions, 0 failures.
- npm run test:cljs (node-test): 6132 tests, 21889 assertions, 0 failures.
- clj-kondo on changed files: 0 errors; remaining warnings are pre-existing on origin/main (registrar required-but-never-used CLJC reader-conditional quirk; an unrelated shell.cljs unused private var).

Closes rf2-96y71s.
