### PR TITLE
feat(schemas): bundle snapshot/restore for validator/explainer/printer; migrate hand-rolled raw-atom snapshots (rf2-l4ljvr)

### DIFF
--- a/implementation/routing/test/re_frame/routing_test_support.clj
+++ b/implementation/routing/test/re_frame/routing_test_support.clj
@@ -71,14 +71,19 @@
   "Install a tiny stub validator + explainer that interprets schemas as
   Clojure predicates `(fn [v] truthy?)`. Lets the schema-validation tests
   assert the validation path without dragging in Malli / spec.alpha.
-  Returns a cleanup fn for the caller to invoke."
+  Returns a cleanup fn for the caller to invoke.
+
+  Captures the prior bundle through the encapsulated
+  `snapshot-schema-fns` / `restore-schema-fns!` pair (rf2-l4ljvr) rather
+  than reaching the raw `validator-fn` / `explainer-fn` atoms — the
+  snapshot also preserves the printer, so the cleanup restores the full
+  prior bundle."
   []
-  (let [prev-v   @schemas/validator-fn
-        prev-e   @schemas/explainer-fn
+  (let [snap     (schemas/snapshot-schema-fns)
         validate (fn [schema value] (boolean (schema value)))
         explain  (fn [_schema value] {:reason :stub-explainer :value value})]
     (schemas/set-schema-fns! {:validate validate :explain explain})
-    (fn [] (schemas/set-schema-fns! {:validate prev-v :explain prev-e}))))
+    (fn [] (schemas/restore-schema-fns! snap))))
 
 (defn over-cap-url
   "Build a `/search?...` URL one unique query-key OVER

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -112,6 +112,18 @@
 (def set-schema-fns!         validator/set-schema-fns!)
 (def reset-schema-validator! validator/reset-schema-validator!)
 
+;; Bundle-level snapshot / restore (rf2-l4ljvr). The validator/explainer/
+;; printer companion to the registry's `snapshot-schemas-by-frame` /
+;; `restore-schemas-by-frame!` (below). `snapshot-schema-fns` captures the
+;; live bundle as one opaque value; `restore-schema-fns!` reinstalls it
+;; (coercing a nil `:print` to the default like `set-schema-fns!`, so the
+;; printer-never-nil invariant holds). Together with the registry pair they
+;; let test-support capture+restore the WHOLE schema runtime through the
+;; encapsulated API rather than reaching the raw `validator-fn` /
+;; `explainer-fn` / `printer-fn` atoms.
+(def snapshot-schema-fns     validator/snapshot-schema-fns)
+(def restore-schema-fns!     validator/restore-schema-fns!)
+
 ;; Printer / walker memo clear hooks (rf2-17sqc). Test-support: the
 ;; printer + sensitive-walker memos are process-lifetime caches bounded
 ;; by the registered-schema cardinality (schemas register once at boot).

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -351,6 +351,52 @@
   (reset! explainer-fn default-malli-explain)
   (reset! printer-fn   default-edn-print))
 
+(defn snapshot-schema-fns
+  "Capture the currently-installed validator / explainer / printer bundle
+  as one opaque value (rf2-l4ljvr). The bundle-level companion to the
+  registry's `snapshot-schemas-by-frame` (storage.cljc) — together they
+  let a test capture+restore the WHOLE schema runtime (the per-frame
+  registry AND the pluggable validation bundle) through the encapsulated
+  API, never reaching the raw `validator-fn` / `explainer-fn` /
+  `printer-fn` atoms.
+
+  Returns a map in the SAME shape `set-schema-fns!` accepts and returns
+  (rf2-13meg / rf2-qdtcx2):
+
+    {:validate @validator-fn   ;; may be nil (validation disabled)
+     :explain  @explainer-fn   ;; may be nil (no explanation)
+     :print    @printer-fn}    ;; never nil (always at least default-edn-print)
+
+  so the value round-trips losslessly through `restore-schema-fns!`.
+  This is the missing capture half: before rf2-l4ljvr only
+  `reset-schema-validator!` existed (resets to the framework DEFAULT),
+  so a test that wanted to install a custom bundle and later restore the
+  PRIOR custom bundle had to hand-roll the snapshot via raw `@validator-fn`
+  derefs. Reads each atom under no lock — these are framework-wide defonce
+  atoms read at the test seam, mirroring `set-schema-fns!`'s own returns."
+  []
+  {:validate @validator-fn
+   :explain  @explainer-fn
+   :print    @printer-fn})
+
+(defn restore-schema-fns!
+  "Reinstall a validator / explainer / printer bundle captured by
+  `snapshot-schema-fns` (rf2-l4ljvr). The bundle-level companion to the
+  registry's `restore-schemas-by-frame!` (storage.cljc).
+
+  Restoring is a FULL bundle install — all three atoms are reset from the
+  snapshot map's `:validate` / `:explain` / `:print` keys. Delegates to
+  `set-schema-fns!` so a snapshot's keys land through the SAME write path
+  the public setter uses: in particular a `nil` `:print` coerces to
+  `default-edn-print` exactly like `set-schema-fns!` / `set-schema-printer!`
+  (rf2-ee38b.6), so the printer-never-nil invariant `run-printer` relies on
+  holds after a restore without a read-site guard — a `snapshot-schema-fns`
+  value always carries a non-nil `:print`, but routing the restore through
+  the coercing setter keeps the invariant true even for a hand-built bundle
+  map. Returns the installed bundle map (the `set-schema-fns!` return)."
+  [bundle]
+  (set-schema-fns! bundle))
+
 (defn using-default-validator?
   "True when `validator-fn` is still the framework-default
   `default-malli-validate`. Used by the

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -1424,6 +1424,99 @@
       (is (= "::FROM-PUBLIC-BUNDLE::" (validator/run-printer :int))
           "the printer installed via the bundle setter reaches the hot path"))))
 
+;; ---- rf2-l4ljvr — bundle snapshot / restore ------------------------------
+;;
+;; The validator/explainer/printer BUNDLE companion to the registry's
+;; snapshot-schemas-by-frame / restore-schemas-by-frame! (tested below).
+;; Before rf2-l4ljvr only `reset-schema-validator!` existed (resets to the
+;; framework DEFAULT), so a test wanting to capture a custom bundle and
+;; later restore the PRIOR custom bundle hand-rolled the snapshot via raw
+;; `@validator-fn` derefs (the routing/ssr/ssr-ring `with-stub-validator`
+;; fixtures). `snapshot-schema-fns` / `restore-schema-fns!` close that
+;; asymmetry so consumers never touch the raw atoms.
+
+(deftest snapshot-schema-fns-captures-live-bundle
+  (testing "rf2-l4ljvr — snapshot-schema-fns returns the live
+            validator/explainer/printer triple in set-schema-fns! shape"
+    (let [v-fn (fn [_ _] true)
+          e-fn (fn [_ _] {:explained true})
+          p-fn (fn [_] "::SNAPSHOT-ME::")]
+      (rf/set-schema-fns! {:validate v-fn :explain e-fn :print p-fn})
+      (let [snap (schemas/snapshot-schema-fns)]
+        (is (= #{:validate :explain :print} (set (keys snap)))
+            "snapshot is the {:validate :explain :print} bundle shape")
+        (is (= v-fn (:validate snap)) "captures the live validator")
+        (is (= e-fn (:explain snap))  "captures the live explainer")
+        (is (= p-fn (:print snap))    "captures the live printer")))))
+
+(deftest restore-schema-fns-reinstates-custom-bundle
+  (testing "rf2-l4ljvr — restore-schema-fns! faithfully round-trips a
+            custom validator+explainer+printer bundle: snapshot a custom
+            bundle, mutate to a different bundle, restore reinstates the
+            captured one (all three fns + the run-printer hot path)"
+    (let [v1 (fn [_ _] true)
+          e1 (fn [_ _] {:reason :first})
+          p1 (fn [_] "::FIRST::")]
+      ;; Install bundle 1 and snapshot it.
+      (rf/set-schema-fns! {:validate v1 :explain e1 :print p1})
+      (let [snap (schemas/snapshot-schema-fns)]
+        ;; Mutate to a completely different bundle.
+        (rf/set-schema-fns! {:validate (fn [_ _] false)
+                             :explain  (fn [_ _] {:reason :second})
+                             :print    (fn [_] "::SECOND::")})
+        (is (= "::SECOND::" (validator/run-printer :int))
+            "mid-state: the second bundle is live")
+        ;; Restore bundle 1.
+        (let [ret (schemas/restore-schema-fns! snap)]
+          (is (= v1 @schemas/validator-fn) "validator restored")
+          (is (= e1 @schemas/explainer-fn) "explainer restored")
+          (is (= p1 @schemas/printer-fn)   "printer restored")
+          (is (= "::FIRST::" (validator/run-printer :int))
+              "run-printer's hot path observes the restored printer")
+          (is (= snap ret)
+              "restore-schema-fns! returns the installed bundle (set-schema-fns! return)"))))))
+
+(deftest restore-schema-fns-coerces-nil-print-to-default
+  (testing "rf2-l4ljvr + rf2-ee38b.6 — restoring a bundle whose :print is
+            nil coerces it to default-edn-print (the printer-never-nil
+            invariant run-printer relies on), exactly like set-schema-fns!"
+    ;; A hand-built bundle with an explicit nil :print (snapshot-schema-fns
+    ;; never produces nil :print, but the restore path must stay safe).
+    (schemas/restore-schema-fns! {:validate (fn [_ _] true)
+                             :explain  nil
+                             :print    nil})
+    (is (some? @schemas/printer-fn)
+        "printer-fn is never nil after restore — coerced to the default")
+    (is (= ":int" (validator/run-printer :int))
+        "run-printer reaches the default EDN canonicaliser, no read-site guard")))
+
+(deftest snapshot-restore-bundle-composes-with-registry-pair
+  (testing "rf2-l4ljvr — the bundle snapshot/restore pair composes with
+            the registry snapshot/restore pair: capturing+restoring BOTH
+            reinstates the whole schema runtime (per-frame registry AND the
+            pluggable bundle) through the encapsulated API, no raw atoms"
+    (let [v-fn (fn [_ _] true)
+          p-fn (fn [_] "::COMPOSED::")]
+      ;; Establish a known runtime: a custom bundle + a registered schema.
+      (rf/set-schema-fns! {:validate v-fn :print p-fn})
+      (rf/reg-app-schema [:n] [:int])
+      ;; Capture BOTH the bundle and the registry.
+      (let [bundle-snap   (schemas/snapshot-schema-fns)
+            registry-snap (schemas/snapshot-schemas-by-frame)]
+        ;; Tear the whole runtime down to a different state.
+        (schemas/reset-schema-validator!)
+        (schemas/clear-schemas-by-frame!)
+        (is (not= v-fn @schemas/validator-fn) "bundle was reset away")
+        (is (= {} @schemas/schemas-by-frame)  "registry was cleared")
+        ;; Restore BOTH through the encapsulated API.
+        (schemas/restore-schema-fns! bundle-snap)
+        (schemas/restore-schemas-by-frame! registry-snap)
+        (is (= v-fn @schemas/validator-fn) "bundle validator restored")
+        (is (= "::COMPOSED::" (validator/run-printer :int))
+            "bundle printer restored on the hot path")
+        (is (= [:int] (rf/app-schema-at [:n]))
+            "registry schema restored — the two pairs compose")))))
+
 ;; ---- rf2-r2uh — :rf.schema/at-boundary interceptor ---------------------
 ;;
 ;; Per Spec 010 §Production builds — the boundary-validation interceptor

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj
@@ -123,12 +123,11 @@
 ;; ===========================================================================
 
 (defn- with-stub-validator []
-  (let [prev-v   @schemas/validator-fn
-        prev-e   @schemas/explainer-fn
+  (let [snap     (schemas/snapshot-schema-fns)
         validate (fn [schema value] (boolean (schema value)))
         explain  (fn [_schema value] {:reason :stub-explainer :value value})]
     (schemas/set-schema-fns! {:validate validate :explain explain})
-    (fn [] (schemas/set-schema-fns! {:validate prev-v :explain prev-e}))))
+    (fn [] (schemas/restore-schema-fns! snap))))
 
 ;; ===========================================================================
 ;; Test 1 — drain-time :rf.error/no-such-handler → projected 404 on the wire

--- a/implementation/ssr/test/re_frame/ssr_error_two_frame_attribution_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_two_frame_attribution_test.clj
@@ -59,12 +59,11 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- with-stub-validator []
-  (let [prev-v   @schemas/validator-fn
-        prev-e   @schemas/explainer-fn
+  (let [snap     (schemas/snapshot-schema-fns)
         validate (fn [schema value] (boolean (schema value)))
         explain  (fn [_schema value] {:reason :stub-explainer :value value})]
     (schemas/set-schema-fns! {:validate validate :explain explain})
-    (fn [] (schemas/set-schema-fns! {:validate prev-v :explain prev-e}))))
+    (fn [] (schemas/restore-schema-fns! snap))))
 
 (def ^:private frame-a :ssr/req-a)
 (def ^:private frame-b :ssr/req-b)

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -592,6 +592,29 @@ This recommendation is normative-soft: ports that ship a different default-absen
 
 What the extension point does NOT cover: a *mix* of validators in one process. The runtime resolves one validator and uses it for every `:schema` everywhere; a hybrid setup (one schema language for app schemas, a different one for boundary handlers) requires the user to register a *composite* validator that dispatches internally on schema shape.
 
+### Test-support: snapshot / restore the validator bundle
+
+The validator/explainer/printer surface carries an **encapsulated snapshot/restore pair** so a test (or fixture) can capture the live bundle, install a custom one, and reinstate the prior bundle without reaching the framework-internal validator atoms:
+
+These two hooks live on the `re-frame.schemas` namespace (they are `:internal-public` test-support surface, not part of the `re-frame.core` front-porch facade — unlike the `set-schema-*!` setters, which ARE re-exported into `re-frame.core`):
+
+```clojure
+(require '[re-frame.schemas :as schemas])
+
+;; Capture the currently-installed bundle as one opaque value
+;; (the same {:validate :explain :print} shape set-schema-fns! takes).
+(def snap (schemas/snapshot-schema-fns))
+
+(rf/set-schema-fns! {:validate stub-validate :explain stub-explain})
+;; ... exercise the validation path against the stub ...
+
+;; Reinstall the captured bundle. A nil :print coerces to the default
+;; EDN canonicaliser, so the printer-never-nil invariant holds.
+(schemas/restore-schema-fns! snap)
+```
+
+This is the **bundle-level** companion to the per-frame registry's `snapshot-schemas-by-frame` / `restore-schemas-by-frame!` test-support hooks (the registry side captures *which schemas are registered per frame*; the bundle side captures *which validator/explainer/printer is installed*). The two pairs compose: capturing+restoring both reinstates the whole schema runtime through the encapsulated API. `reset-schema-validator!` remains the shortcut for restoring the framework **defaults** specifically; `snapshot-schema-fns` / `restore-schema-fns!` are for capturing and reinstating an **arbitrary** prior bundle. All four are `:internal-public` test-support hooks rowed in [API.md §Schemas](API.md#schemas) — not part of the `re-frame.core` front-porch facade.
+
 ### Schema implies validation on CLJS (Malli wired by the artefact)
 
 On the CLJS reference, **requiring the schemas artefact wires the default Malli validator automatically** — there is nothing extra to opt into. The `re-frame.schemas` facade `:require`s the `re-frame.schemas.malli` adapter ns, whose only job is to publish `malli.core/validate` / `malli.core/explain` / `malli.error/humanize` into the framework's late-bind hook table on ns-load (`:schemas/malli-validate` / `:schemas/malli-explain` / `:schemas/humanize-explain!`). The schemas artefact's default validator consults these hooks on every call:

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -511,6 +511,13 @@
   ["re-frame.schemas" "schemas-by-frame"]        {:tier :internal-public :owner "010" :status "v1"}
   ["re-frame.schemas" "snapshot-schemas-by-frame"] {:tier :internal-public :owner "010" :status "v1"}
   ["re-frame.schemas" "restore-schemas-by-frame!"] {:tier :internal-public :owner "010" :status "v1"}
+  ;; rf2-l4ljvr — bundle-level snapshot/restore for the validator/explainer/
+  ;; printer triple, the companion to the registry pair above. Internal-public
+  ;; test-support hooks (NOT a re-frame.core facade export): they are consumed
+  ;; by cross-artefact test-support (routing/ssr/ssr-ring fixtures) to capture
+  ;; and restore the pluggable schema bundle without reaching the raw atoms.
+  ["re-frame.schemas" "snapshot-schema-fns"]       {:tier :internal-public :owner "010" :status "v1"}
+  ["re-frame.schemas" "restore-schema-fns!"]       {:tier :internal-public :owner "010" :status "v1"}
   ["re-frame.schemas" "clear-schemas-by-frame!"]   {:tier :internal-public :owner "010" :status "v1"}
   ["re-frame.schemas" "frame-schema-entries"]      {:tier :internal-public :owner "010" :status "v1"}
   ["re-frame.schemas" "on-frame-destroyed!"]       {:tier :internal-public :owner "010" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 487,
+ :var-count 489,
  :tier-vocab
  [:front-porch
   :advanced
@@ -307,6 +307,7 @@
   {:namespace "re-frame.schemas", :var "reg-app-schema", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "reg-app-schemas", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "reset-schema-validator!", :tier :advanced, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.schemas", :var "restore-schema-fns!", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "restore-schemas-by-frame!", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "schema-has-sensitive?", :tier :internal-public, :kind :fn, :owner "015", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "schema-sensitive-at?", :tier :internal-public, :kind :fn, :owner "015", :status "v1", :facade? false, :runtime-verified? true}
@@ -315,6 +316,7 @@
   {:namespace "re-frame.schemas", :var "set-schema-fns!", :tier :advanced, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "set-schema-printer!", :tier :advanced, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "set-schema-validator!", :tier :advanced, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.schemas", :var "snapshot-schema-fns", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "snapshot-schemas-by-frame", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "validate-app-schema!", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.schemas", :var "validate-cofx!", :tier :internal-public, :kind :fn, :owner "010", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
## What

PR1 (option c) of the rf2-l5r974 ruling — the encapsulated bundle snapshot/restore that must exist before the raw schema atoms can be privatised (PR2, rf2-btdpqn, blocked on this). Does NOT privatise the atoms.

Adds the missing validator/explainer/printer **bundle** snapshot/restore, the companion to the schemas **registry**'s `snapshot-schemas-by-frame` / `restore-schemas-by-frame!`. Before this the only restore primitive was `reset-schema-validator!` (resets to the framework DEFAULT), so a test wanting to install a custom bundle and reinstate the PRIOR custom bundle hand-rolled the snapshot via raw `@validator-fn` / `@explainer-fn` derefs.

## API shape and rationale

- `snapshot-schema-fns` — returns the live `{:validate :explain :print}` triple in the SAME shape `set-schema-fns!` takes and returns (rf2-13meg / rf2-qdtcx2), so the value round-trips losslessly.
- `restore-schema-fns!` — reinstalls a captured bundle by delegating to `set-schema-fns!`, so a `nil` `:print` coerces to `default-edn-print` exactly like the public setter (rf2-ee38b.6). The printer-never-nil invariant `run-printer` relies on holds after restore with no read-site guard, even for a hand-built bundle map. Returns the installed bundle.

Naming mirrors the registry pair for consistency. Both are re-exported from `re-frame.schemas` next to the registry snapshot/restore block. They are deliberately NOT re-exported into the `re-frame.core` facade — they are `:internal-public` test-support hooks, not front-porch surface (unlike the `set-schema-*!` setters which ARE in core).

## Migrated sites (raw-atom snapshot → encapsulated API)

- `implementation/routing/test/re_frame/routing_test_support.clj` — `with-stub-validator`
- `implementation/ssr-ring/test/re_frame/ssr/ring_draintime_error_test.clj` — `with-stub-validator`
- `implementation/ssr/test/re_frame/ssr_error_two_frame_attribution_test.clj` — `with-stub-validator`

Each previously captured `@validator-fn` + `@explainer-fn` and restored via `set-schema-fns!`; they now use `snapshot-schema-fns` / `restore-schema-fns!`, which also preserve the printer across the snapshot (a strict improvement).

(The `(reset! schemas/schemas-by-frame {})` registry raw-atom reset in routing_test_support is the PR2/btdpqn sweep — out of scope here.)

## Manifest classification

Both rowed `:tier :internal-public`, `:owner "010"`, `:kind :fn`, `:facade? false`, `:status "v1"` — mirroring `snapshot-schemas-by-frame`. Classified per the facade-export rule: internal-public test-support hooks, not facade-documented. Sidecar entry added to `spec/api-manifest-metadata.edn`; `spec/api-manifest.edn` regenerated (487 → 489 vars).

## Spec

`spec/010-Schemas.md` gains a "Test-support: snapshot / restore the validator bundle" subsection next to the pluggable-validator surface, noting it is the bundle-level companion to the registry pair and that the two compose.

## Tests (schemas_test.clj)

1. `snapshot-schema-fns` captures the live bundle in `set-schema-fns!` shape.
2. `restore-schema-fns!` round-trips a custom validator+explainer+printer (all three atoms + the `run-printer` hot path + return value).
3. nil `:print` coercion preserved across restore (printer-never-nil invariant).
4. composition with the registry `snapshot/restore` pair reinstates the whole schema runtime through the encapsulated API.

## Gates

- JVM schemas `clojure -M:test`: 289 tests, 0 failures
- JVM routing / ssr / ssr-ring (migrated sites): 190 / 324 / 150 tests, 0 failures
- CLJS `npm run test:cljs`: 6132 tests, 0 failures
- api-manifest `--check`: OK (489 vars) — drift gate green
- clj-kondo: 0 errors (4 pre-existing warnings, none introduced)
- `mkdocs build --strict`: clean

Closes rf2-l4ljvr.
