### PR TITLE
fix(core): finish the frame-stamp rename — drop the bare :frame coeffect (rf2-1m6rf1)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -93,11 +93,11 @@
           ;; key they inject under.
           value    (get (:coeffects ctx) cofx-id)
           ;; rf2-9cm27 — pass the in-flight cascade's frame (seeded as the
-          ;; `:frame` coeffect) so the `:where :cofx` failure trace carries
-          ;; `:frame` and lands in the per-frame epoch `:trace-events`
+          ;; `:rf.frame/id` coeffect) so the `:where :cofx` failure trace
+          ;; carries `:frame` and lands in the per-frame epoch `:trace-events`
           ;; (epoch capture buffers only frame-tagged traces). Mirrors the
           ;; `:where :app-db` / `:where :event` traces.
-          frame    (interceptor/get-coeffect ctx :frame)
+          frame    (interceptor/get-coeffect ctx :rf.frame/id)
           ok?      (try (validate cofx-id event-id value cofx-meta frame)
                         (catch #?(:clj Throwable :cljs :default) _ true))]
       (if ok?
@@ -252,7 +252,7 @@
            ;; `:rf.cofx/skipped-on-platform` (warning, :recovery
            ;; :skipped) mirroring fx.cljc's gate. The handler chain
            ;; continues — the injection is skipped, not the event.
-           (let [frame-id        (interceptor/get-coeffect ctx :frame)
+           (let [frame-id        (interceptor/get-coeffect ctx :rf.frame/id)
                  active-platform (active-platform-for-frame frame-id)]
              (if (cofx-runs-on-platform? meta active-platform)
                ;; Publish the cofx handler's HandlerScope.
@@ -321,12 +321,12 @@
                                      (some-> trace/*handler-scope* :call-site))
              (let [event    (interceptor/get-coeffect ctx :event)
                    ;; rf2-fxlgi — the in-flight cascade's frame, read from
-                   ;; the `:frame` coeffect (same source as the
+                   ;; the `:rf.frame/id` coeffect (same source as the
                    ;; `:rf.cofx/run` / `:skipped-on-platform` siblings'
                    ;; `frame-id`). `frame-id` itself is bound in the
                    ;; cofx-found branch's `let`, out of scope here, so
                    ;; re-read it locally.
-                   frame-id (interceptor/get-coeffect ctx :frame)]
+                   frame-id (interceptor/get-coeffect ctx :rf.frame/id)]
                ;; rf2-fxlgi — stamp `:frame` so this dev-only misconfig
                ;; diagnostic is frame-attributed like its siblings above,
                ;; and so `re-frame.epoch.capture/capture-event!` (which

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -770,14 +770,16 @@
   COEFFECTS section shows only user-injected coeffects (mirrors the
   AFTER INTERCEPTORS section's filter-out-framework-defaults posture).
 
-  `:db` + `:event` are populated by `assemble-initial-ctx`; `:frame` ditto.
+  `:db` + `:event` are populated by `assemble-initial-ctx`.
   `:source` + `:trace-id` are envelope keys also surfaced on the cofx
   map by `assemble-initial-ctx` for handler-body convenience.
   `:rf.db/runtime` (the runtime-db partition) + `:rf.frame/id` (the
-  runtime-context frame id) are the EP-0001 partition coeffects, likewise
-  injected by `assemble-initial-ctx` — framework defaults, not user cofx
-  (rf2-bvwoi4)."
-  #{:db :event :frame :source :trace-id :rf.db/runtime :rf.frame/id})
+  runtime-context frame id, the event-context spelling of the frame
+  stamp per Spec 002 §Event context — the retired bare `:frame`
+  coeffect is gone, rf2-1m6rf1) are the EP-0001 partition coeffects,
+  likewise injected by `assemble-initial-ctx` — framework defaults, not
+  user cofx (rf2-bvwoi4)."
+  #{:db :event :source :trace-id :rf.db/runtime :rf.frame/id})
 
 (defn user-injected-coeffects
   "Project the user-injected subset of a coeffects map. Pure data → data.

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -470,7 +470,6 @@
         runtime-db  (frame/frame-runtime-db-value frame)]
     {:coeffects (cond-> {:db            db-value
                          :event         event
-                         :frame         frame
                          :rf.db/runtime runtime-db
                          :rf.frame/id   frame}
                   (:source envelope)   (assoc :source (:source envelope))
@@ -980,7 +979,7 @@
     :rf/default? true
     :after
     (fn [ctx]
-      (let [frame       (:frame (:coeffects ctx))
+      (let [frame       (:rf.frame/id (:coeffects ctx))
             effects     (:effects ctx)
             has-db?     (contains? effects :db)
             ;; EP-0001 §535-551 (rf2-4eisfr): a runtime-db write also lands as
@@ -1594,10 +1593,11 @@
 
     `:rf.event/coeffects`    — the USER-INJECTED subset of the
                                 handler's final coeffects map (framework
-                                defaults `:db` `:event` `:frame`
-                                `:source` `:trace-id` filtered out at
-                                this boundary). Absent entirely when
-                                zero user cofx were injected.
+                                defaults `:db` `:event` `:rf.frame/id`
+                                `:source` `:trace-id` `:rf.db/runtime`
+                                filtered out at this boundary). Absent
+                                entirely when zero user cofx were
+                                injected.
     `:rf.event/after-deltas` — vector of per-`:after` interceptor
                                 ctx-delta records `{:rf.icpt/id <id>
                                 :rf.icpt/ctx-delta {...}}` populated by

--- a/implementation/core/src/re_frame/spec.cljc
+++ b/implementation/core/src/re_frame/spec.cljc
@@ -154,7 +154,7 @@
             (let [event       (interceptor/get-coeffect ctx :event)
                   event-id    (when (vector? event) (first event))
                   ;; rf2-7d30s — the in-flight cascade's frame, seeded as the
-                  ;; `:frame` coeffect (mirrors cofx.cljc / the dev-time
+                  ;; `:rf.frame/id` coeffect (mirrors cofx.cljc / the dev-time
                   ;; `validate-event!` 4-arity). Stamped onto the failure
                   ;; trace below so `re-frame.epoch.capture/capture-event!`
                   ;; (which buffers only frame-tagged traces) attributes the
@@ -162,7 +162,7 @@
                   ;; — and so the SSR error-projection listener can route it
                   ;; per-frame under concurrent server frames without leaning
                   ;; on a single-active-frame guess.
-                  frame       (interceptor/get-coeffect ctx :frame)
+                  frame       (interceptor/get-coeffect ctx :rf.frame/id)
                   handler-meta (when event-id
                                  (registrar/lookup :event event-id))
                   schema      (:schema handler-meta)]

--- a/implementation/core/test/re_frame/event_context_coeffect_keys_test.clj
+++ b/implementation/core/test/re_frame/event_context_coeffect_keys_test.clj
@@ -1,0 +1,122 @@
+(ns re-frame.event-context-coeffect-keys-test
+  "rf2-1m6rf1 — the EXACT event-context coeffect key set.
+
+  EP-0002 R3 (one carrier, one name) retired the bare `:frame` coeffect:
+  the frame stamp travels in the event context under `:rf.frame/id` ONLY
+  (per Spec 002 §Event context threads both partitions). The duplicate
+  `:frame` injection that `assemble-initial-ctx` used to add is gone.
+
+  This is the framework-must-not-violate-its-own-contract guard: it pins
+  the framework-injected coeffect key set EXACTLY so a stray parallel
+  `:frame` (or any other key) cannot silently ride back in. It is the
+  coeffect-key sibling of the rf2-o4dmp8 framework-conformance test —
+  held in a DISTINCT file to keep the two assertions independent.
+
+  Sanctioned `:frame` survivors (NOT coeffects, NOT covered by this set):
+    - the public `:frame` dispatch / subscribe opt;
+    - the dispatch envelope `:frame` key;
+    - the binary fx-handler ctx `:frame` (Spec 002 §The binary fx-handler
+      signature) + the HTTP-interceptor ctx `:frame` (Spec 014 §Middleware);
+    - trace / error-record `:frame` tags."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.fx :as fx]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (when-let [clear-schemas! (late-bind/get-fn :schemas/clear-by-frame!)]
+    (clear-schemas!))
+  (trace/clear-listeners!)
+  (rf/init! plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- capture-coeffects
+  "Dispatch `[:capture]` on `frame-id` (optionally threading `opts`) and
+  return the coeffects map the handler saw."
+  ([frame-id] (capture-coeffects frame-id nil))
+  ([frame-id opts]
+   (let [captured (atom nil)]
+     (rf/reg-event-ctx :capture
+       (fn [ctx] (reset! captured (:coeffects ctx)) ctx))
+     (if opts
+       (rf/dispatch-sync [:capture] (merge {:frame frame-id} opts))
+       (rf/dispatch-sync [:capture] {:frame frame-id}))
+     @captured)))
+
+;; ===========================================================================
+;; The exact framework-injected coeffect key set
+;; ===========================================================================
+
+(deftest framework-coeffect-key-set-is-exact
+  (testing "a vanilla event with no user cofx sees EXACTLY the framework keys"
+    (rf/reg-frame :ck/exact {:doc "ctx"})
+    (let [cofx (capture-coeffects :ck/exact)]
+      (is (= #{:db :event :rf.db/runtime :rf.frame/id :source}
+             (set (keys cofx)))
+          "the coeffect key set is exactly the framework defaults — no bare :frame")
+      (is (not (contains? cofx :frame))
+          "the retired bare :frame coeffect is absent (one carrier, one name)")
+      (is (= :ck/exact (:rf.frame/id cofx))
+          ":rf.frame/id carries the running frame's id"))))
+
+(deftest no-frame-coeffect-even-with-trace-id
+  (testing "threading a :trace-id adds :trace-id but never re-introduces :frame"
+    (rf/reg-frame :ck/traced {:doc "ctx"})
+    (let [cofx (capture-coeffects :ck/traced {:trace-id "tid-1"})]
+      (is (= #{:db :event :rf.db/runtime :rf.frame/id :source :trace-id}
+             (set (keys cofx)))
+          ":trace-id appears when threaded; :frame still does not")
+      (is (not (contains? cofx :frame))
+          ":frame is absent regardless of envelope keys"))))
+
+(deftest user-injected-cofx-do-not-mask-the-absence-of-frame
+  (testing "a user inject-cofx adds its own key but :frame stays gone"
+    (rf/reg-frame :ck/user {:doc "ctx"})
+    (rf/reg-cofx :ck/now (fn [ctx] (assoc-in ctx [:coeffects :ck/now] 42)))
+    (let [captured (atom nil)]
+      (rf/reg-event-ctx :capture
+        [(rf/inject-cofx :ck/now)]
+        (fn [ctx] (reset! captured (:coeffects ctx)) ctx))
+      (rf/dispatch-sync [:capture] {:frame :ck/user})
+      (let [cofx @captured]
+        (is (contains? cofx :ck/now)
+            "the user-injected coeffect is present")
+        (is (= 42 (:ck/now cofx)))
+        (is (not (contains? cofx :frame))
+            "user cofx do not bring the bare :frame coeffect back")
+        (is (= :ck/user (:rf.frame/id cofx))
+            "the frame stamp is still :rf.frame/id only")))))
+
+;; ===========================================================================
+;; framework-coeffect-keys (the filter set) excludes the retired :frame
+;; ===========================================================================
+
+(deftest framework-coeffect-keys-excludes-frame
+  (testing "fx/framework-coeffect-keys no longer codifies the bare :frame duplicate"
+    (is (not (contains? fx/framework-coeffect-keys :frame))
+        ":frame is not a framework coeffect key (it was the retired duplicate)")
+    (is (contains? fx/framework-coeffect-keys :rf.frame/id)
+        ":rf.frame/id is the retained frame-stamp coeffect key")
+    (is (= #{:db :event :source :trace-id :rf.db/runtime :rf.frame/id}
+           fx/framework-coeffect-keys)
+        "the framework-coeffect-keys set is exactly the framework defaults")))
+
+(deftest user-injected-coeffects-projection-drops-all-framework-defaults
+  (testing "user-injected-coeffects strips every framework default incl. :rf.frame/id"
+    (let [cofx {:db {} :event [:e] :source :unknown :trace-id "t"
+                :rf.db/runtime {} :rf.frame/id :f
+                :my/cofx 1}]
+      (is (= {:my/cofx 1} (fx/user-injected-coeffects cofx))
+          "only the genuinely user-injected coeffect survives the projection"))))

--- a/implementation/core/test/re_frame/event_context_partition_test.clj
+++ b/implementation/core/test/re_frame/event_context_partition_test.clj
@@ -98,9 +98,12 @@
             ":rf.db/runtime coeffect equals runtime-db-value")
         (is (= :ctx/partitions (:rf.frame/id cofx))
             ":rf.frame/id is the running frame's id (runtime-context spelling)")
-        ;; The public `:frame` opt remains unchanged + distinct.
-        (is (= :ctx/partitions (:frame cofx))
-            ":frame coeffect still carries the resolved frame")))))
+        ;; rf2-1m6rf1 — the retired bare `:frame` coeffect is GONE. The
+        ;; frame stamp travels under `:rf.frame/id` only in the event
+        ;; context; `:frame` survives solely as the public dispatch/subscribe
+        ;; opt + the dispatch envelope key (per Spec 002 §Event context).
+        (is (not (contains? cofx :frame))
+            "the bare :frame coeffect is no longer injected (one carrier, one name)")))))
 
 ;; ===========================================================================
 ;; 3 — effect-map widening (closed set #{:db :rf.db/runtime :fx})

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -653,12 +653,12 @@
   ;; nil); only the spawn path needs it stamped here.
   (let [base-initial (delay (parallel/build-initial-snapshot
                               machine {:bootstrap-pending? false}))]
-    (fn [{:keys [db frame] rt :rf.db/runtime :as _cofx} event]
+    (fn [{:keys [db] frame :rf.frame/id rt :rf.db/runtime :as _cofx} event]
       ;; EP-0002 carried invariant: a machine handler is invoked inside an
-      ;; event cascade, so the cofx ALWAYS carries the envelope `:frame`
-      ;; (the HELD stamp). A nil stamp is an invariant failure — surface
-      ;; `:rf.error/no-frame-context`, never repair to a synthesised
-      ;; `:rf/default`.
+      ;; event cascade, so the cofx ALWAYS carries the frame stamp under
+      ;; `:rf.frame/id` (the HELD stamp). A nil stamp is an invariant
+      ;; failure — surface `:rf.error/no-frame-context`, never repair to a
+      ;; synthesised `:rf/default`.
       (frame/require-frame-stamp!
         frame :rf.machine/event-received
         {:where 'rf-machines/make-machine-handler :event-id (first event)})

--- a/implementation/routing/src/re_frame/routing/can_leave.cljc
+++ b/implementation/routing/src/re_frame/routing/can_leave.cljc
@@ -252,7 +252,7 @@
 (defn url-requested-handler
   "`:rf/url-requested` event-fx handler. Registered by the façade so a
   `:reload` re-wires it on a fresh registrar."
-  [{:keys [frame] rdb :rf.db/runtime}
+  [{frame :rf.frame/id rdb :rf.db/runtime}
    [_ {:keys [url bypass-leave-guard?] :as _request} :as event-vec]]
     ;; Per Spec 012 §Navigation blocking — pending-nav protocol the
     ;; runtime fires :can-leave for the active route on every
@@ -268,9 +268,9 @@
     ;; escape hatch :rf.route/continue uses to re-issue the original
     ;; navigation request without re-running the leave guard.
     (let [;; EP-0002 carried invariant — `:rf/url-requested` is a cascade
-          ;; event, so the cofx carries the envelope `:frame`; a nil stamp
-          ;; is an invariant failure (`:rf.error/no-frame-context`), never a
-          ;; synthesised `:rf/default`.
+          ;; event, so the cofx carries the frame stamp under `:rf.frame/id`;
+          ;; a nil stamp is an invariant failure
+          ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
           frame     (frame/require-frame-stamp!
                       frame :rf/url-requested
                       {:where 'rf.route/url-requested-handler})

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -119,7 +119,7 @@
   are durable framework runtime-db state, so the handler reads them from the
   `:rf.db/runtime` coeffect (`rdb`) and `commit-navigation` returns a
   `:rf.db/runtime` effect. The handler never touches user app-db."
-  [{:keys [frame] rdb-raw :rf.db/runtime} [_ target params opts :as event-vec]]
+  [{frame :rf.frame/id rdb-raw :rf.db/runtime} [_ target params opts :as event-vec]]
     ;; Per Spec 012 §Navigation is an event and §Fragments §Programmatic
     ;; navigation with fragments. Fragment may be supplied in opts
     ;; (`{:fragment "x"}`), on the target-map form (`{:url "/x"
@@ -134,8 +134,9 @@
     ;; the programmatic path matches the URL-driven path so async loaders
     ;; have a token to thread through stale-suppression.
     (let [;; EP-0002 carried invariant — `:rf.route/navigate` is a cascade
-          ;; event, so the cofx carries the envelope `:frame`; a nil stamp
-          ;; is an invariant failure (`:rf.error/no-frame-context`), never a
+          ;; event, so the cofx carries the frame stamp under `:rf.frame/id`;
+          ;; a nil stamp is an invariant failure
+          ;; (`:rf.error/no-frame-context`), never a
           ;; synthesised `:rf/default`. Validated once; the trace stamps and
           ;; the leave-guard call below all read this carried value.
           frame (frame/require-frame-stamp!

--- a/implementation/routing/src/re_frame/routing/test_support.cljc
+++ b/implementation/routing/src/re_frame/routing/test_support.cljc
@@ -70,7 +70,7 @@
   `:rf.route.nav-token/stale-suppressed` (same trace shape as the
   production `:rf.route/with-nav-token` handler, so a single conformance
   assertion covers both paths)."
-  [{:keys [frame] rdb :rf.db/runtime} [_ {:keys [on-success-event carried-nav-token]}]]
+  [{frame :rf.frame/id rdb :rf.db/runtime} [_ {:keys [on-success-event carried-nav-token]}]]
   ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db state.
   (let [current (get-in (or rdb {}) [:rf.runtime/routing :current :nav-token])]
     (cond

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -245,11 +245,11 @@
   strategy for forward nav is `:top` per Spec 012 §Scroll restoration;
   popstate / initial / SSR routes through `:rf.route/handle-url-change`
   (default `:restore`)."
-  [{:keys [frame] rdb :rf.db/runtime} [_ url opts :as event-vec]]
+  [{frame :rf.frame/id rdb :rf.db/runtime} [_ url opts :as event-vec]]
   (let [;; EP-0002 carried invariant — `:rf.route/transitioned` is a
-        ;; cascade event, so the cofx carries the envelope `:frame`; a nil
-        ;; stamp is an invariant failure (`:rf.error/no-frame-context`),
-        ;; never a synthesised `:rf/default`.
+        ;; cascade event, so the cofx carries the frame stamp under
+        ;; `:rf.frame/id`; a nil stamp is an invariant failure
+        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
         frame   (frame/require-frame-stamp!
                   frame :rf.route/transitioned
                   {:where 'rf.route/transitioned-handler})
@@ -282,11 +282,12 @@
   strategy is `:restore` so the saved position trumps. `:frame` is
   threaded through so the SSR error-projection listener can attribute
   the :no-such-handler trace per-frame."
-  [{:keys [frame] rdb :rf.db/runtime} [_ url opts :as event-vec]]
+  [{frame :rf.frame/id rdb :rf.db/runtime} [_ url opts :as event-vec]]
   (let [;; EP-0002 carried invariant — `:rf.route/handle-url-change` is a
         ;; cascade event (popstate / initial / SSR), so the cofx carries
-        ;; the envelope `:frame`; a nil stamp is an invariant failure
-        ;; (`:rf.error/no-frame-context`), never a synthesised `:rf/default`.
+        ;; the frame stamp under `:rf.frame/id`; a nil stamp is an invariant
+        ;; failure (`:rf.error/no-frame-context`), never a synthesised
+        ;; `:rf/default`.
         frame   (frame/require-frame-stamp!
                   frame :rf.route/handle-url-change
                   {:where 'rf.route/handle-url-change-handler})

--- a/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/error_slot_egress_security_cljs_test.cljc
@@ -257,7 +257,9 @@
     (try
       ;; :doc must be a value the schema rejects (schema wants :int). The
       ;; sentinel rides as the offending param value.
-      (navigate/navigate-handler {:db {} :frame :rf/default}
+      ;; The frame stamp reaches the event context under :rf.frame/id
+      ;; (rf2-1m6rf1 — the bare :frame coeffect is retired).
+      (navigate/navigate-handler {:db {} :rf.frame/id :rf/default}
                                  [:rf.route/navigate :sec/route {:doc sentinel}])
       (finally (trace-tooling/unregister-listener! kw)))
     (first (filter #(= :rf.error/schema-validation-failure (:operation %))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -801,7 +801,9 @@
     (let [captured-fid (atom nil)]
       (rf/reg-event-fx :init/capture-frame-id
         {:platforms #{:server}}
-        (fn [{:keys [frame]} _]
+        ;; The running frame's stamp reaches the event context under
+        ;; :rf.frame/id (rf2-1m6rf1 — the bare :frame coeffect is retired).
+        (fn [{frame :rf.frame/id} _]
           (reset! captured-fid frame)
           {}))
 
@@ -855,7 +857,9 @@
     (let [captured (atom :unset)]
       (rf/reg-event-fx :init/capture-ssr-meta
         {:platforms #{:server}}
-        (fn [{:keys [frame]} _]
+        ;; The running frame's stamp reaches the event context under
+        ;; :rf.frame/id (rf2-1m6rf1 — the bare :frame coeffect is retired).
+        (fn [{frame :rf.frame/id} _]
           (reset! captured (:ssr (rf/frame-meta frame)))
           {}))
 

--- a/implementation/ssr/src/re_frame/ssr/hydrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hydrate.cljc
@@ -116,7 +116,7 @@
   `:frame`). Hydration is best-effort by contract (Spec 011 §The
   :rf/hydrate event — degraded-but-running), so a corrupt payload must
   never silently install garbage as the whole app-db."
-  [{:keys [db frame] rt :rf.db/runtime} [_ payload]]
+  [{:keys [db] frame :rf.frame/id rt :rf.db/runtime} [_ payload]]
   (let [new-db (or (:rf/app-db payload) db)]
     (if-let [reason (malformed-hydration-payload! payload)]
       (do

--- a/implementation/ssr/src/re_frame/ssr/request.cljc
+++ b/implementation/ssr/src/re_frame/ssr/request.cljc
@@ -158,7 +158,7 @@
   and conformance harnesses that drive the drain without a host
   adapter)."
   ([ctx]
-   (let [frame-id (get-in ctx [:coeffects :frame])
+   (let [frame-id (get-in ctx [:coeffects :rf.frame/id])
          request  (get-request frame-id)]
      (assoc-in ctx [:coeffects :rf.server/request] request)))
   ([ctx request]

--- a/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
@@ -183,7 +183,9 @@
 
       (rf/reg-event-fx :req-test/read-isolated
         [(rf/inject-cofx :rf.server/request)]
-        (fn [{:keys [rf.server/request frame]} _]
+        ;; The running frame's stamp reaches the event context under
+        ;; :rf.frame/id (rf2-1m6rf1 — the bare :frame coeffect is retired).
+        (fn [{:keys [rf.server/request] frame :rf.frame/id} _]
           (cond
             (= frame frame-a) (reset! observed-a request)
             (= frame frame-b) (reset! observed-b request))

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -123,6 +123,15 @@ public spellings users type are unchanged: **`:frame`** is the dispatch/subscrib
 **opt**; **`:rf.frame/id`** is its event-context spelling. Both name the same
 stamp.
 
+The bare `:frame` spelling survives only at **sanctioned** sites: the public
+dispatch/subscribe **opt**, the dispatch **envelope** key, the binary
+**fx-handler ctx** (see [§The binary fx-handler signature](#the-binary-fx-handler-signature))
+and the HTTP-interceptor ctx (per [014-HTTPRequests.md](014-HTTPRequests.md)),
+and **trace / error-record tags**. It is *retired* as an **event-context
+coeffect**: the running frame reaches a handler body under `:rf.frame/id`
+only (see [§Event context threads both partitions](#event-context-threads-both-partitions)) —
+there is no parallel bare `:frame` coeffect.
+
 The genuinely distinct cases are **roles**, not unrelated keys, and they are
 expressed as **qualified** stamps:
 

--- a/spec/conformance/fixtures/dispatch-envelope.edn
+++ b/spec/conformance/fixtures/dispatch-envelope.edn
@@ -2,11 +2,15 @@
 ;; The dispatch envelope is an open map containing :event, :frame,
 ;; and optional :trace-id, :source, :fx-overrides, :interceptor-overrides.
 ;; Implementations must surface these to handler code via the cofx context.
+;; The frame stamp reaches the cofx context under :rf.frame/id (the
+;; event-context spelling, per Spec 002 §Event context); the bare :frame
+;; spelling is the dispatch OPT, not a cofx key. The runtime-db partition
+;; is threaded as :rf.db/runtime.
 
 {:fixture/id           :dispatch/envelope
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:core/event-handler :core/frame :core/trace}
- :fixture/doc          "An event dispatched with :source :ui surfaces in the cofx context map. Implementations expose :frame, :trace-id, and :source as additional keys on the cofx map for reg-event-fx handlers."
+ :fixture/doc          "An event dispatched with :source :ui surfaces in the cofx context map. Implementations expose :rf.frame/id (the event-context frame stamp), :rf.db/runtime (the runtime-db partition), :trace-id, and :source as additional keys on the cofx map for reg-event-fx handlers. The bare :frame is the dispatch opt, not a cofx key."
 
  :fixture/registry
  {:event {:probe/echo {:doc "Captures envelope keys into app-db for inspection."}}
@@ -25,10 +29,11 @@
 
  :fixture/expect
  {:final-app-db
-  {:envelope {:event    [:probe/echo]
-              :frame    :rf/default
-              :source   :ui
-              :trace-id "t-1"}}
+  {:envelope {:event         [:probe/echo]
+              :rf.db/runtime {}
+              :rf.frame/id   :rf/default
+              :source        :ui
+              :trace-id      "t-1"}}
 
   :trace-emissions
   [{:operation :rf.event/run-start

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -329,13 +329,14 @@
       nil))
 
 (defn- frame-id-from-cofx
-  "Return the frame the current dispatch targets. Per spec/002 §Routing
-  the cofx map's `:frame` slot is the canonical source (the router lifts
-  the envelope's frame onto cofx as the initial context's `:frame`
-  coeffect). The play-runner additionally stamps `:rf/play-frame` for
-  play-authored assertions that may run outside a `:frame` binding."
+  "Return the frame the current dispatch targets. Per spec/002 §Event
+  context the cofx map's `:rf.frame/id` slot is the canonical source (the
+  router threads the running frame's stamp onto the event context as the
+  `:rf.frame/id` coeffect — the bare `:frame` coeffect was retired,
+  rf2-1m6rf1). The play-runner additionally stamps `:rf/play-frame` for
+  play-authored assertions that may run outside a frame binding."
   [cofx]
-  (or (:frame cofx)
+  (or (:rf.frame/id cofx)
       (:rf/play-frame cofx)
       nil))
 


### PR DESCRIPTION
## Summary

EP-0002 R3 "one carrier, one name" — the frame-stamp rename was additive, not a rename: assemble-initial-ctx injected BOTH :frame and :rf.frame/id into every event context, and the framework ran on the retired bare :frame coeffect. This finishes the rename: stop injecting :frame, migrate every internal event-context (coeffect) consumer to :rf.frame/id (the only event-context spelling Spec 002 shows), and pin the exact coeffect key set so a parallel :frame cannot ride back in.

Fixes rf2-1m6rf1.

## Coeffect consumers migrated (10)

- core: cofx.cljc (3 read sites), spec.cljc boundary validator, router.cljc :rf/flows interceptor :after
- routing event handlers: navigate, url-change (transitioned + handle-url-change), url-requested (can-leave), test-support simulate-http-resolution
- machines: make-machine-handler
- ssr: :rf/hydrate event handler, request-cofx injector
- story tool: frame-id-from-cofx

## fx-context spelling decision

The binary (fn [ctx args]) fx-handler ctx KEEPS :frame. It is the documented public contract — Spec 002 §The binary fx-handler signature carries worked app / library-author / async-closure examples all reading (:frame m), and Spec 014 documents the HTTP-interceptor ctx :frame the same way. These are fx-context, not event coeffects; the spec is the normative artefact. So scroll / nav-token / nav-fx fxs, http_managed + http_middleware, all ssr response.cljc fxs, and ssr check-version/digest fxs stay :frame.

## Sanctioned :frame survivors kept

Public dispatch/subscribe opt, dispatch envelope key, trace + error-record tags, the binary fx-handler ctx, and the HTTP-interceptor ctx.

## Also

- fx.cljc framework-coeffect-keys drops :frame (keeps :rf.frame/id) — the single set the Xray run-end cofx filter (user-injected-coeffects) reads.
- New distinctly-named guard implementation/core/test/re_frame/event_context_coeffect_keys_test.clj asserts the framework coeffect key set is EXACTLY #{:db :event :rf.db/runtime :rf.frame/id :source} (+ :trace-id when threaded), that :frame is absent, and that framework-coeffect-keys excludes :frame. Held in a separate file from the sibling o4dmp8 conformance test.
- Updated the dispatch-envelope conformance fixture + the partition test to the new event-context shape.
- spec/002 SS-frame-stamp now enumerates sanctioned-vs-retired :frame; built on top of 3939ig's authority minting (not reverted).

## Gates (all green)

- JVM: core 1046/4501, routing 196/893, machines 609/1923, ssr 324/1283, http 380/1737, flows 186/4763 — 0 failures
- npm run test:cljs: 6132 tests / 21887 assertions — 0 failures, 0 errors
- clj-kondo: 0 errors (only pre-existing macro-expansion warnings)
- mkdocs build --strict: clean
