### PR TITLE
docs(EP): tighten EP-0003/0006/0008/0009 per second critique round

### DIFF
--- a/docs/EP/EP-0003-resource-queries.md
+++ b/docs/EP/EP-0003-resource-queries.md
@@ -497,11 +497,6 @@ The ledger records the serializable attempt:
  :status         :running
  :owners         #{[:route :route/article nav-token]}
  :causes         [[:route-entry :route/article nav-token]]
- :stale-key      [:resource
-                  [[:rf.scope/session {:user-id "u-42" :tenant-id "acme"}]
-                   :article/by-slug
-                   {:slug "welcome"}]
-                  4]
  :cancellable?   true
  :started-at     1780752000100
  :deadline-at    1780752005100}
@@ -520,7 +515,7 @@ The durable/resource split is:
 - `:rf.runtime/resources` stores cache entries, tags, resource ownership
   indexes, timestamps, data, errors, and the current work id for each entry;
 - `:rf.runtime/work-ledger` stores serializable work records, status, owners,
-  causes, stale keys, attempts, deadlines, and outcomes;
+  causes, attempts, deadlines, and outcomes;
 - host side tables store non-serializable cancellation and timer handles keyed
   by frame id and work id.
 
@@ -772,7 +767,7 @@ V1 should include:
 - canonical params;
 - stale/fresh policy;
 - a resource-owned slice of the frame work ledger for in-flight attempts,
-  cancellation attempts, stale keys, blocking waits, and tool summaries;
+  cancellation attempts, blocking waits, and tool summaries;
 - in-flight dedupe;
 - stale reply suppression;
 - inactive-entry GC;
@@ -1830,7 +1825,7 @@ Xray should expose:
   tags,
   errors, data summary, and GC eligibility;
 - a live work-ledger table per frame: work id, kind, linked resource key,
-  generation, status, owners, causes, stale key, cancellable?, deadline, retry
+  generation, status, owners, causes, cancellable?, deadline, retry
   attempt, and outcome;
 - a route/resource graph: current route/nav-token, blocking vs non-blocking
   resources, SSR wait points, active work, hydrated/fresh/stale state;
@@ -2391,7 +2386,6 @@ Work records include:
 - status;
 - owners;
 - causes;
-- stale key;
 - cancellable?;
 - timestamps and deadlines;
 - outcome summary.
@@ -2848,7 +2842,7 @@ deferred follow-on phase (see
    feature probes, and `:resource` registrar metadata.
 3. Work-ledger substrate bead: add the resource-owned frame work ledger slice,
    serializable work records, host side tables keyed by work id, owner release
-   rules, cancellation attempts, stale-key suppression, frame-destroy cleanup,
+   rules, cancellation attempts, stale-reply suppression keyed by `:work/id`, frame-destroy cleanup,
    and tool/SSR summaries.
 4. Resource runtime bead: entries, cache scopes, canonical params, status
    transitions, structural sharing, passive subscriptions, and frame-local

--- a/docs/EP/EP-0006-runtime-subsystem-contract.md
+++ b/docs/EP/EP-0006-runtime-subsystem-contract.md
@@ -113,8 +113,10 @@ Two derived rules:
 
 `spec/Runtime-Subsystems.md` carries one row per subsystem × clause, citing the
 owning spec section for each cell. Initial instances: machines (005), routing
-(012), elision (015), ssr (011), then resources + work-ledger (EP-0003) at
-graduation. An empty or contested cell is a tracked gap, not prose.
+(012), elision (009, with 015 supplying the privacy-classification inputs —
+Conventions names instrumentation as the reserved-key owner), ssr (011), then
+resources + work-ledger (EP-0003) at graduation. An empty or contested cell is
+a tracked gap, not prose.
 
 ### Conformance
 
@@ -131,9 +133,16 @@ GraphQL/Hasura client cache, a persistence/sync engine, a collaboration
 presence layer, an analytics session model) becomes *a new graded instance of
 this contract*, not a special case. Concretely, a library:
 
-1. **reserves its sub-tree** — `:rf.runtime/<lib>`, where `<lib>` follows the
-   feature-modularity id-prefix convention (the library's own namespace, never
-   bare); collisions with the framework's reserved children are a registration
+1. **reserves its sub-tree** — a runtime-db child keyed by the **library's own
+   qualified keyword** (e.g. `:acme.sync/state`), per the existing rule that
+   library-owned prefixes live *outside* `:rf.*` (Conventions §Reserved
+   namespaces: "Third-party libraries MUST NOT reserve under `:rf.*`"). The
+   `:rf.runtime/*` spelling remains exclusively framework-owned. This amends
+   Conventions §Reserved runtime-db keys — today it says runtime-db's top-level
+   children are "each qualified under `:rf.runtime/*`" — to: *framework
+   children under `:rf.runtime/*`; registered extension children under the
+   library's own qualified namespace; bare/unqualified children are a
+   registration error.* Collisions with any reserved child are a registration
    error;
 2. **mints write authority** for its event handlers through the same
    registration mechanism the framework's own subsystems use (the general
@@ -157,15 +166,22 @@ needs it — see Open Issue 2.
 
 ## Backwards Compatibility
 
-Documentation + tests only; no runtime behavior changes. Pre-alpha: the
-contract constrains future subsystem shapes deliberately — six existing
-instances show the shape is empirical, not speculative.
+For the in-repo subsystems: documentation + tests only; no runtime behavior
+changes. The **extension seam** is not behavior-free and is not claimed to be:
+it specifies future registration-time validation (collision/shape errors for
+extension children) and tool surfaces (Xray/pair subsystem rows for extension
+children), which arrive with the Open-Issue-2 registration API, not with this
+EP's v1 beads. Pre-alpha: the contract constrains future subsystem shapes
+deliberately — six existing instances show the shape is empirical, not
+speculative.
 
 ## Reference Implementation / Bead Plan
 
 1. Spec bead: author `spec/Runtime-Subsystems.md` (contract + table), add the
-   Ownership row, cross-reference from Conventions. *(Hot-zone: Conventions
-   touch is one line.)*
+   Ownership row, cross-reference from Conventions — **including the
+   §Reserved-runtime-db-keys amendment** (framework children `:rf.runtime/*`;
+   extension children under the library's own qualified namespace).
+   *(Hot-zone: Conventions; sequential.)*
 2. Grading bead: fill the four existing rows from the owning specs; file gaps
    found as beads.
 3. Conformance bead: the drift test + the per-subsystem diagnostics sweep.
@@ -184,6 +200,14 @@ instances show the shape is empirical, not speculative.
    mint + declare + teardown-hook in one call) ship in core or in an optional
    extension artefact? Recommendation: decide with that consumer in hand;
    until then the documented four-step seam above is the contract.
+3. Extension-child key placement: this EP recommends **library-own-namespace
+   children** (`:acme.sync/state`), preserving "third parties never reserve
+   under `:rf.*`" with no exception. The alternative — a framework-mediated
+   `:rf.runtime/<lib>` exception, on the model of the canonical-devtools
+   `:rf.xray/*` carve-out in Conventions — keeps all subsystem children under
+   one prefix at the cost of weakening the single-root rule. Recommendation:
+   library-own-namespace; the devtools carve-out rides framework-distance-zero
+   status that third-party libraries by definition lack.
 
 ## Recommendation
 

--- a/docs/EP/EP-0008-production-observability-channels.md
+++ b/docs/EP/EP-0008-production-observability-channels.md
@@ -98,11 +98,20 @@ always-on axis carry structured data only (error id, ids/keys, frame) — never
 raw values; the axis is subject to the same egress redaction posture as all
 off-box surfaces.
 
+**Category kind follows the channel.** The always-on axis is contractually
+`:rf.error/*`-only (Ownership: "one tight record per production-reachable
+`:rf.error/*`"; Spec 009 §What is available in production builds). This EP does
+not widen that substrate to warnings. A `:rf.warning/*` category that meets the
+criterion was therefore **misclassified as a warning**: promotion includes
+recategorization to `:rf.error/*` with a typed per-category default `:recovery`
+(e.g. `:reported`), per the existing error-contract shape. Skipped teardown is
+an error the process cannot locally observe — not an advisory.
+
 ### The audit (initial known rows)
 
 | Category | Today | Under the criterion |
 |---|---|---|
-| `:rf.warning/teardown-hook-exception` | diagnostic (DCE'd) | **Promote** — production-possible, resource-leakage class, compounds in long-lived processes. The known C4 fix |
+| `:rf.warning/teardown-hook-exception` | diagnostic (DCE'd) | **Promote + recategorize** → `:rf.error/teardown-hook-exception`, default `:recovery :reported` (teardown continues best-effort; the failure ships) — production-possible, resource-leakage class, compounds in long-lived processes. The known C4 fix |
 | `:rf.error/sub-input-fn-exception` / `-bad-return` | always-on | Correct as-is (the precedent rows) |
 | `:rf.error/no-frame-context` | always-on | Correct (frameless errors need the frameless axis — EP-0002 R6) |
 | `:rf.warning/app-handler-runtime-effect` | diagnostic | Correct — dev-time teaching diagnostic; leg 2 fails (the write applies; nothing leaks) |
@@ -125,8 +134,10 @@ removed from the diagnostic channel. Apps with error shippers may see new
 
 1. Spec bead: the channel section + criterion + catalogue column (hot-zone
    Spec 009; sequential).
-2. Teardown bead: route `safe-call-hook!` failures through the always-on axis
-   (keep the dev trace breadcrumb), plus a teardown-report test.
+2. Teardown bead: recategorize `:rf.warning/teardown-hook-exception` →
+   `:rf.error/teardown-hook-exception` (catalogue row, `:recovery :reported`)
+   and route `safe-call-hook!` failures through the always-on axis (keep the
+   dev trace breadcrumb), plus a teardown-report test.
 3. Audit bead: grade the full catalogue; file promotion fixes found.
 4. Conformance bead: the catalogue/channel pin test.
 

--- a/docs/EP/EP-0009-the-ep-process.md
+++ b/docs/EP/EP-0009-the-ep-process.md
@@ -12,9 +12,13 @@ Type: process
 
 re-frame2 EPs follow the Python Enhancement Proposal model: **durable,
 numbered design records** that carry a decision from proposal through ruling
-into the normative spec, and then remain forever as the record of *why* — including
-when the answer was no. The spec (`spec/`) is always the authoritative contract;
-an EP is the design document behind it, never a second normative home.
+into a normative home, and then remain forever as the record of *why* — including
+when the answer was no. The authority rule is **per type**: a standards-track
+EP graduates into `spec/`, which is then the authoritative contract — the EP is
+the design document behind it, never a second normative home. A **process** EP
+graduates into its *named normative home*, which MAY be the active EP itself
+(the PEP-8 precedent: the style guide *is* the PEP). Every active process EP
+names its normative home explicitly so there is exactly one.
 
 ## When an EP is warranted
 
@@ -37,7 +41,7 @@ valuable record.
 | Type | Meaning | Terminal success status |
 |---|---|---|
 | **standards-track** | changes the framework's public contracts or runtime behavior; graduates into `spec/` + implementation beads | `final` |
-| **process** | rules about how the project itself works (conventions, lifecycle, review posture); graduates into its normative home (e.g. `Conventions.md`) but the rules may keep living here | `active` |
+| **process** | rules about how the project itself works (conventions, lifecycle, review posture); on acceptance it **names its normative home** — either an existing spec doc (EP-0007 names `Conventions.md` §Namespacing) or the active EP itself (this EP's home is this EP) — and that one home governs | `active` |
 
 EPs predating this one carry no `Type:` header and are standards-track.
 
@@ -56,13 +60,17 @@ any non-terminal EP may become: superseded-by EP-NNNN (kept)
 - **proposal** — under discussion. Normative-voiced text is permitted (it makes
   graduation a move, not a rewrite) but binds nothing; nothing may implement a
   proposal.
-- **accepted** — ruled by the operator; graduation into `spec/` + beads begins.
-  Implementation may start.
-- **final / active** — graduated. The spec is now authoritative; **where the EP
-  body and the spec differ, the spec governs** (the EP-0002 precedent). A final
-  EP MAY carry an **implementation-errata ledger** (the EP-0005 pattern):
-  *final means the decisions are settled; it does not assert the build is
-  gap-free.* Ledger rows cite live bead ids and are struck as they close.
+- **accepted** — ruled by the operator; graduation into the normative home +
+  beads begins. Implementation may start.
+- **final / active** — graduated. The named normative home is now
+  authoritative: for standards-track that is `spec/`, and **where the EP body
+  and the spec differ, the spec governs** (the EP-0002 precedent); for process
+  EPs it is the home the EP named — possibly the EP itself, in which case the
+  EP's §Specification *is* the rule and the rest of the document remains
+  rationale. A final EP MAY carry an **implementation-errata ledger** (the
+  EP-0005 pattern): *final means the decisions are settled; it does not assert
+  the build is gap-free.* Ledger rows cite live bead ids and are struck as they
+  close.
 - **rejected / withdrawn / deferred / superseded** — terminal or parked, and
   **always kept**: recording why something was not done is half an EP corpus's
   value.


### PR DESCRIPTION
Actions all five findings from the second EP critique. All touched EPs remain Status: proposal with no implementation in flight.

1. **High - EP-0008 axis contract**: the always-on error substrate is contractually one-record-per-\:rf.error/*\ (Ownership, Spec 009). Promotion of teardown failures now includes **recategorization** to \:rf.error/teardown-hook-exception\ (\:recovery :reported\), and a new rule is stated: *category kind follows the channel* - a \:rf.warning/*\ meeting the promotion criterion was misclassified, not grounds to widen the substrate.
2. **Medium - EP-0006 reserved-namespace conflict**: extension children now live under the **library's own qualified keyword** (e.g. \:acme.sync/state\), preserving Conventions' 'third parties MUST NOT reserve under :rf.*' with no new exception; \:rf.runtime/*\ stays exclusively framework-owned. The required Conventions §Reserved-runtime-db-keys amendment is named in the bead plan; the \:rf.runtime/<lib>\ carve-out (canonical-devtools model) is recorded as Open Issue 3 with a recommendation against. Backwards Compatibility no longer claims 'no runtime behavior changes' - the seam's registration errors + tool rows are scoped to the Open-Issue-2 API.
3. **Medium - EP-0009 authority contradiction**: the rule is now per-type - standards-track graduates into spec/ (spec governs); a process EP names its normative home, which MAY be the active EP itself (PEP-8 precedent). EP-0007 names Conventions; EP-0009 names itself.
4. **Medium/Low - EP-0003 stale-key residue**: the retired \:stale-key\ field removed from the early ledger example and five further residual mentions (the critique cited two sites; sweep found six); bead-plan wording now 'stale-reply suppression keyed by \:work/id\'.
5. **Low - EP-0006 elision ownership**: grading row cites 009 as owner with 015 privacy-classification inputs, matching Conventions.

Checks: check_ep_status_sync.py + check_doc_slugs.py green; docs/EP only.