### PR TITLE
docs(EP-0001): record two resolved premises + graduate accepted->final (rf2-gn7rtt)

### DIFF
--- a/docs/EP/EP-0001-frame-partitions.md
+++ b/docs/EP/EP-0001-frame-partitions.md
@@ -1,6 +1,45 @@
 # EP-0001: Frame App/Runtime Partitions
 
-Status: accepted
+Status: final
+
+> **`final` means the decisions are settled.** The fourteen deferred calls were
+> ruled by Mike on 2026-06-08 (see [Resolved Decisions](#resolved-decisions)),
+> the two design-review premises Appendices A and B left open were closed on
+> 2026-06-10 (Resolved Decisions [15](#resolved-decisions) and the §Partition
+> Keys naming note), and the partition is locked. The two implementation gaps
+> tracked against those settled rulings have now also shipped — see
+> [Implementation errata](#implementation-errata). Finalizing the *decisions*
+> did not, on its own, assert the *implementation* was gap-free; the errata
+> ledger below tracked that separately to its close.
+
+## Implementation errata
+
+The EP decisions are final and the implementation has shipped in full: **every
+tracked erratum below is closed.** This section is kept as a closed record of the
+build-completion work that followed the decision-freeze; none of it reopens any
+ruling. These were implementation gaps against settled rulings, not open
+decisions. The EP is implementation-complete.
+
+### Resolved errata
+
+The two build-gaps-against-settled-rulings below are **fixed**; they are kept here
+as a closed record and no longer reopen any ruling:
+
+- **`rf2-3939ig`** *(fixed — PR #3707)* — framework-authority minting was wired
+  only off `:rf/machine?`, so routing/SSR framework-authority handlers (which
+  legitimately write runtime-db) tripped the `:rf.warning/app-handler-runtime-effect`
+  ownership diagnostic on every navigation. The fix generalized minting to a
+  reserved `:rf/framework-authority?` registration-meta key that the routing and
+  SSR facades stamp, honouring Resolved Decision 4's convention-plus-diagnostics
+  stance (the diagnostic now fires only on genuine app-handler runtime writes).
+- **`rf2-1m6rf1`** *(fixed — PR #3714)* — the EP-0002 R3 frame-stamp rename folded
+  into this partition (`:frame` → `:rf.frame/id` for runtime context) had landed
+  additively: `assemble-initial-ctx` injected the bare `:frame` coeffect alongside
+  `:rf.frame/id`, and internal consumers still read the retired spelling. The fix
+  dropped the bare `:frame` coeffect, migrated the internal consumers to
+  `:rf.frame/id`, and pinned the exact coeffect key set with a conformance test
+  (the sanctioned `:frame` survivors — public dispatch/subscribe opt, fx-handler
+  ctx, trace tags — are kept, per §Namespacing).
 
 ## Abstract
 
@@ -184,6 +223,14 @@ The full-frame projection uses:
 `:rf.db/app` is not the ordinary app handler key. Ordinary handlers continue to
 use `:db`. `:rf.db/app` exists so full-frame snapshots can name both
 partitions without overloading `:db`.
+
+Naming note: this table trades CLARITY's one-concept-one-name principle — app-db
+now has two spellings, `:db` in handler context and `:rf.db/app` in the
+frame-state projection — for reserved-namespace discipline (the frame-state
+projection is a new framework-owned structure, so its keys are qualified). The
+cost is real and accepted; the surviving asymmetry (`:db` unqualified,
+`:rf.db/runtime` qualified) deliberately mirrors the ownership asymmetry the
+partition is built on.
 
 ### Namespacing
 
@@ -1210,6 +1257,15 @@ ruling here is the binding form.
     **redacted or omitted off-box by default**. A **trusted-local** caller may request
     richer diagnostics explicitly. This is the fail-closed default in §Security And
     Privacy Considerations and §6.
+
+15. **Handler contract — whole-db return retained, knowingly.** Appendix B asked for
+    the scoped/change-describing handler-contract question to be settled before the
+    partition locked. Ruled: re-frame2 keeps `reg-event-db`'s whole-db return. The
+    re-frame mental model is the product; the general clobber-co-located-owners hazard
+    *inside* app-db is accepted as the price of `(fn [db event] …)`, and this partition
+    fences only the framework's slice. This is a decision, not a default — a future
+    `scoped-event-handlers` EP may reopen it, but the partition was built knowing what
+    it does not fix.
 
 ## Bead Plan
 

--- a/docs/EP/README.md
+++ b/docs/EP/README.md
@@ -12,7 +12,7 @@ In brief: an EP is warranted for **feature-level or public-contract decisions wi
 
 | EP       | Title | Status | Summary |
 |----------|-------|--------|---------|
-| [EP-0001](EP-0001-frame-partitions.md) | Frame App/Runtime Partitions | accepted | A frame owns two durable partitions — user-owned **app-db** (`:db`) and framework-owned **runtime-db** (`:rf.db/runtime`) — committed coherently by one cascade, removing the footgun where a fresh `:db` return clobbers runtime state. |
+| [EP-0001](EP-0001-frame-partitions.md) | Frame App/Runtime Partitions | final | A frame owns two durable partitions — user-owned **app-db** (`:db`) and framework-owned **runtime-db** (`:rf.db/runtime`) — committed coherently by one cascade, removing the footgun where a fresh `:db` return clobbers runtime state. |
 | [EP-0002](EP-0002-frame-target-resolution.md) | Explicit Frame Target Resolution | final | Remove the ambient `:rf/default` fallback; frame-scoped operations resolve their target from explicit frame context, and missing context fails instead of touching the wrong frame. |
 | [EP-0003](EP-0003-resource-queries.md) | Resource Queries | proposal | An optional `day8/re-frame2-resources` artefact for declarative server-state — the re-frame2 answer to TanStack Query / RTK Query / SWR — with resource identity, caching, invalidation, a frame work-ledger substrate, lifecycle/GC, and route + SSR preload. |
 | [EP-0004](EP-0004-subscription-inputs.md) | Parametric Subscription Inputs | final | Restore v1's two-function `reg-sub` shape via input functions that return a vector of query vectors, keeping `:<-` as static-input sugar and dependencies pure, inspectable, JVM-runnable, and Xray-visible. |


### PR DESCRIPTION
Graduates EP-0001 (Frame App/Runtime Partitions) from accepted to final, per Mike's ruling on rf2-gn7rtt (record both silently-resolved premises, then graduate EP-0005-style with an implementation-errata ledger, no gating).

## Three edits

**D1 — Resolved Decision 15 (handler contract).** Records the Appendix B premise as a deliberate choice: re-frame2 keeps reg-event-db's whole-db return; the general clobber-co-located-owners hazard inside app-db is accepted as the price of (fn [db event] ...), and the partition fences only the framework's slice. A decision, not a default; a future scoped-event-handlers EP may reopen it.

**D2 — Partition Keys naming note.** Owns the CLARITY cost the partition trades: app-db now has two spellings (:db in handler context, :rf.db/app in the frame-state projection) for reserved-namespace discipline. The surviving asymmetry mirrors the ownership asymmetry the partition is built on.

**D3 — graduate to final, EP-0005-style.** Status accepted to final; added the final-means-decisions-settled header blockquote and an Implementation-errata section. Updated the EP-0001 row in docs/EP/README.md to final.

## Errata premise finding

The worker brief assumed rf2-3939ig + rf2-1m6rf1 were still OPEN (open ledger). On verification both are CLOSED: rf2-3939ig (framework-authority minting) closed via PR #3707, rf2-1m6rf1 (bare :frame coeffect drop) closed via PR #3714. Per the brief's verification instruction, they are recorded as resolved-errata with their PR numbers (mirroring how EP-0005 handles closed errata), not as an open gating ledger.

## Scope

docs/EP/EP-0001-frame-partitions.md + docs/EP/README.md only. No spec/ or implementation/ changes.

## Gates

- mkdocs build --strict: clean (exit 0, INFO only; CI spec/+migration staging replicated then removed).
- scripts/check_ep_status_sync.py: in sync (EP-0001 reads final in both the doc and the index).

Closes rf2-gn7rtt.
