### PR TITLE
feat(resources): artefact skeleton — day8/re-frame2-resources, facade, :resource kind (rf2-p10npe)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -141,6 +141,14 @@ implementation/
                                    walker for sub-runs / renders / effects.
     test/re_frame/                 JVM epoch tests.
 
+  resources/                 day8/re-frame2-resources — managed resource queries
+                             (Spec 016, EP-0003, rf2-p10npe).
+    deps.edn                 :local/root dep on ../core.
+    src/re_frame/resources.cljc    reg-resource / clear-resource / resource-meta /
+                                   resource-state / resources, :rf.resource/* events
+                                   + passive subs, :resource registrar kind, work-ledger.
+    test/re_frame/                 CLJS resources skeleton tests.
+
   ssr-ring/                  day8/re-frame2-ssr-ring — Ring host adapter for the SSR pipeline
                              (rf2-ny6v7).
     deps.edn                 :local/root deps on ../core and ../ssr (Ring is test-only).

--- a/implementation/core/deps.edn
+++ b/implementation/core/deps.edn
@@ -101,6 +101,13 @@
                        day8/re-frame2-http       {:local/root "../http"}
                        day8/re-frame2-ssr        {:local/root "../ssr"}
                        day8/re-frame2-epoch      {:local/root "../epoch"}
+                       ;; rf2-p10npe — the optional Resources artefact
+                       ;; (Spec 016). Pulled in as a TEST-ONLY dep so the
+                       ;; JVM core test build can require re-frame.resources
+                       ;; (conformance_test.clj) and populate the
+                       ;; `:resources` feature probe that features-cljs-test
+                       ;; asserts; the published core jar carries none of it.
+                       day8/re-frame2-resources  {:local/root "../resources"}
                        ;; rf2-try1x — silent-on-success reporter.
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -62,6 +62,7 @@
             [re-frame.core-routing  :as rf-routing]
             [re-frame.core-schemas  :as rf-schemas]
             [re-frame.core-machines :as rf-machines]
+            [re-frame.core-resources :as rf-resources]
             [re-frame.core-ssr      :as rf-ssr]
             [re-frame.core-epoch    :as rf-epoch]
             [re-frame.core-http     :as rf-http]
@@ -93,6 +94,7 @@
              [re-frame.core :refer [reg-event-db reg-event-fx reg-event-ctx
                                     reg-sub reg-fx reg-cofx reg-frame
                                     reg-flow reg-route reg-app-schema reg-app-schemas
+                                    reg-resource
                                     reg-error-projector reg-head
                                     reg-http-interceptor
                                     reg-view reg-machine defmachine
@@ -160,6 +162,14 @@
   `day8/re-frame2-routing`; require `re-frame.routing` at boot. See
   `re-frame.core-routing/reg-route` and spec/API.md §Registration."}
        reg-route       rf-routing/reg-route)
+     (def ^{:doc "Fn-alias of the `reg-resource` macro for HoF / programmatic
+  registration (no source-coord capture). Register a resource — a named,
+  cached read of remote/external state — under `resource-id`;
+  `resource-spec` carries the REQUIRED fail-closed `:scope` policy plus
+  `:params-schema` / `:request`. Implementation ships in
+  `day8/re-frame2-resources`; require `re-frame.resources` at boot. See
+  `re-frame.core-resources/reg-resource` and spec/API.md §Registration."}
+       reg-resource    rf-resources/reg-resource)
      (def ^{:doc "Fn-alias of the `reg-app-schema` macro for HoF / programmatic
   registration (no source-coord capture). Register a Malli schema at a
   path inside app-db (frame-scoped per Spec 010). Implementation ships
@@ -267,6 +277,19 @@
        boot. See `re-frame.core-routing/reg-route` for the full
        signature."
        {:arglists '([id metadata])})
+
+     (rm/defreg-macro reg-resource rf-resources/reg-resource
+       "Register a resource under `resource-id` — a named, cached read of
+       remote/external state. `resource-spec` carries the REQUIRED
+       fail-closed `:scope` policy (`:rf.scope/global` | resolver |
+       `:rf.scope/from-caller`), `:params-schema`, `:request`, and
+       optional `:data-schema` / `:stale-after-ms` / `:gc-after-ms` /
+       `:tags`. Captures source-coords (Spec 001) at this call site.
+       Implementation ships in `day8/re-frame2-resources` (rf2-p10npe);
+       apps must add the artefact and require `re-frame.resources` at
+       boot. See `re-frame.core-resources/reg-resource` for the full
+       signature."
+       {:arglists '([resource-id resource-spec])})
 
      (rm/defreg-macro reg-app-schema rf-schemas/reg-app-schema
        "Register a Malli schema at a path inside app-db (frame-scoped
@@ -1230,6 +1253,39 @@
   — returns a reaction whose value is `true` iff the current snapshot's
   `:tags` set contains `tag`. Per Spec 005 §State tags."}
   machine-has-tag?               rf-machines/machine-has-tag?)
+
+;; ---- resource helpers (Spec 016) ------------------------------------------
+;;
+;; The optional resources artefact (`day8/re-frame2-resources`). `reg-resource`
+;; is a macro (above, for source-coord capture) + a CLJS fn-alias; the
+;; non-registration surface is plain re-exports below. Each delegates
+;; through the late-bind table and throws `:rf.error/resources-artefact-missing`
+;; when the artefact is absent. Per Spec 016 §Public API.
+
+(def ^{:doc "Remove a registered resource (a registration-lifecycle
+  operation — NOT cache invalidation; for data lifecycle use
+  `:rf.resource/invalidate-tags` / `:rf.resource/remove` /
+  `:rf.resource/clear-scope`). Per Spec 016 §Registration. Implementation
+  ships in `day8/re-frame2-resources`."}
+  clear-resource  rf-resources/clear-resource)
+
+(def ^{:doc "Return the registered resource's spec map (`:params-schema`,
+  `:data-schema`, `:request`, `:scope`, `:transport`, `:stale-after-ms`,
+  `:gc-after-ms`, `:tags`, `:doc`), or `nil`. Per Spec 016 §Introspection.
+  Implementation ships in `day8/re-frame2-resources`."}
+  resource-meta   rf-resources/resource-meta)
+
+(def ^{:doc "Return a resource instance's runtime state for an
+  explicit-frame target `{:resource :scope :params :frame}`. Per EP-0002
+  the frame is carried explicitly. Per Spec 016 §Introspection.
+  Implementation ships in `day8/re-frame2-resources`."}
+  resource-state  rf-resources/resource-state)
+
+(def ^{:doc "Return resource introspection for a frame target `{:frame …}`
+  — the registered resources and the live per-frame resource-instance
+  table. Per Spec 016 §Introspection. Implementation ships in
+  `day8/re-frame2-resources`."}
+  resources       rf-resources/resources)
 
 ;; ---- introspection (Spec 002 §The public registrar query API) -----------
 

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1300,8 +1300,8 @@
   source-jump) read to find a (kind, id)'s definition. Per Spec 002 §The
   public registrar query API.
 
-  For the ten registrar kinds (`:event :sub :fx :cofx :view :frame :route
-  :head :error-projector :flow`) this is `registrar/lookup`.
+  For the registrar kinds (`:event :sub :fx :cofx :view :frame :route
+  :head :error-projector :flow :resource`) this is `registrar/lookup`.
 
   The two machine kinds `:machine-guard` / `:machine-action` are NOT
   registrar kinds (rf2-ftrcv, supersedes rf2-ypu5i / rf2-npvsx) — `id` is

--- a/implementation/core/src/re_frame/core_resources.cljc
+++ b/implementation/core/src/re_frame/core_resources.cljc
@@ -1,0 +1,72 @@
+(ns re-frame.core-resources
+  "Public-API wrappers for the optional resources artefact (Spec 016).
+  Implementation ships in `day8/re-frame2-resources` (`re-frame.resources`).
+  See [Conventions §Optional-artefact wrapper convention](../../../../../spec/Conventions.md#optional-artefact-wrapper-convention).
+
+  Resources is a POST-V1 OPTIONAL capability: declarative server-state as
+  a runtime-managed read model. These wrappers look the producing impl up
+  through the late-bind hook registry at call time; an app that omits the
+  artefact sees a structured `:rf.error/resources-artefact-missing`
+  ex-info naming the exact Maven coordinate + require form."
+  (:require [re-frame.core-artefact #?@(:clj  [:refer        [defwrapper]]
+                                        :cljs [:refer-macros [defwrapper]])]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(def ^:private resources-artefact
+  {:error-keyword :rf.error/resources-artefact-missing
+   :maven         "day8/re-frame2-resources"
+   :require-ns    "re-frame.resources"})
+
+(defwrapper reg-resource
+  "Per Spec 016 §Public API §Registration. Register a resource — a named,
+  cached read of remote/external state — under `resource-id` with
+  `resource-spec`. The spec carries the REQUIRED, fail-closed `:scope`
+  policy (`:rf.scope/global` | a resolver | `:rf.scope/from-caller`),
+  `:params-schema`, `:request`, and optional `:data-schema` /
+  `:stale-after-ms` / `:gc-after-ms` / `:tags` / `:sensitive?`. Views read
+  the resource through passive `[:rf.resource/*]` subscriptions; route
+  entry / events / machines cause it to fetch. Late-bound via
+  `:resources/reg-resource`."
+  {:hook :resources/reg-resource :artefact resources-artefact :on-absent :throw
+   :ex-data {:resource-id resource-id}}
+  ([resource-id resource-spec] :delegate))
+
+(defwrapper clear-resource
+  "Per Spec 016 §Public API §Registration. Remove a registered resource
+  (a registration-lifecycle operation — NOT the normal cache-invalidation
+  API; for data lifecycle use `:rf.resource/invalidate-tags` /
+  `:rf.resource/remove` / `:rf.resource/clear-scope`). Also disposes the
+  resource-runtime state for the id in each affected frame. Late-bound via
+  `:resources/clear-resource`."
+  {:hook :resources/clear-resource :artefact resources-artefact :on-absent :throw
+   :ex-data {:resource-id resource-id}}
+  ([resource-id] :delegate))
+
+(defwrapper resource-meta
+  "Per Spec 016 §Introspection. Return the registered resource's spec map
+  (`:params-schema`, `:data-schema`, `:request`, `:scope`, `:transport`,
+  `:stale-after-ms`, `:gc-after-ms`, `:tags`, `:doc`, source coords) for
+  `resource-id`, or nil. Late-bound via `:resources/resource-meta`."
+  {:hook :resources/resource-meta :artefact resources-artefact :on-absent :throw
+   :ex-data {:resource-id resource-id}}
+  ([resource-id] :delegate))
+
+(defwrapper resource-state
+  "Per Spec 016 §Introspection. Return a resource instance's runtime
+  state for an explicit-frame target `{:resource :scope :params :frame}`.
+  Per EP-0002 the frame is carried explicitly — a frameless call with no
+  resolvable context fails closed rather than inspecting the wrong frame.
+  Late-bound via `:resources/resource-state`."
+  {:hook :resources/resource-state :artefact resources-artefact :on-absent :throw}
+  ([opts] :delegate))
+
+(defwrapper resources
+  "Per Spec 016 §Introspection. Return resource introspection for a frame
+  target `{:frame …}` — the registered resources and (with the runtime
+  slice) the live per-frame resource-instance table. Late-bound via
+  `:resources/resources`."
+  {:hook :resources/resources :artefact resources-artefact :on-absent :throw
+   :arglists '([] [opts])}
+  ([]     :delegate)
+  ([opts] :delegate))

--- a/implementation/core/src/re_frame/features.cljc
+++ b/implementation/core/src/re_frame/features.cljc
@@ -103,7 +103,11 @@
    :epoch    {:maven     "day8/re-frame2-epoch"
               :require   "re-frame.epoch"
               :spec      "Tool-Pair (Time-travel / epoch)"
-              :probe-key :epoch/settle!}})
+              :probe-key :epoch/settle!}
+   :resources {:maven     "day8/re-frame2-resources"
+               :require   "re-frame.resources"
+               :spec      "Spec 016 (Resources)"
+               :probe-key :resources/reg-resource}})
 
 (defn feature-loaded?
   "Return `true` when the optional feature `feature`'s implementation
@@ -118,8 +122,8 @@
   break bundle-isolation). Ships to production — NOT elided.
 
   Known feature keywords are the keys of `feature-registry`: `:schemas`,
-  `:machines`, `:routing`, `:flows`, `:http`, `:ssr`, `:epoch`. Per
-  spec/API.md §Feature inspection."
+  `:machines`, `:routing`, `:flows`, `:http`, `:ssr`, `:epoch`,
+  `:resources`. Per spec/API.md §Feature inspection."
   [feature]
   (if-let [{:keys [probe-key]} (get feature-registry feature)]
     (some? (late-bind/get-fn probe-key))

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -428,6 +428,45 @@
     :design-bead "rf2-1hncp2"
     :description "Release the destroyed frame's host-side transient routing caches — the scroll-position cache (re-frame.routing.scroll/scroll-positions-cache, rf2-1hncp2) AND the nav-token / pending-nav counter high-water marks (re-frame.routing.nav-counters/nav-counters-cache, rf2-oosjmh). Neither is runtime-db state — they live in module-level atoms (host-derived, ephemeral, off the epoch/SSR egress wire; the counters host-side specifically so an epoch restore cannot rewind + recycle a token), so they need explicit per-frame teardown like the other transient caches. Invoked by frame/destroy-frame! symmetric with the ssr / machines / flows / schemas teardown hooks; no-op when re-frame.routing is absent (the artefact is optional)."}
 
+   ;; ---- re-frame.resources (rf2-p10npe — EP-0003 slice 2) -------------------
+   ;; The optional Resources artefact (Spec 016) publishes its public-API
+   ;; surface here so re-frame.core reaches it without a static :require.
+   ;; The routing / SSR integrations are published as cross-feature
+   ;; extension hooks the host artefacts (routing / ssr) CONSULT —
+   ;; late-bound both ways so neither side carries the other.
+   {:key         :resources/reg-resource
+    :producer-ns 're-frame.resources
+    :design-bead "rf2-p10npe"
+    :description "Register a resource — a named, cached read of remote/external state (Spec 016 §Registration). Doubles as the feature-inspection PROBE key for the :resources feature (re-frame.features)."}
+   {:key         :resources/clear-resource
+    :producer-ns 're-frame.resources
+    :design-bead "rf2-p10npe"
+    :description "Remove a registered resource (registration-lifecycle, NOT data invalidation). Per Spec 016 §Registration."}
+   {:key         :resources/resource-meta
+    :producer-ns 're-frame.resources
+    :design-bead "rf2-p10npe"
+    :description "Return the registered resource's spec map for a resource id, or nil. Per Spec 016 §Introspection."}
+   {:key         :resources/resource-state
+    :producer-ns 're-frame.resources
+    :design-bead "rf2-p10npe"
+    :description "Return a resource instance's runtime state for an explicit-frame target {:resource :scope :params :frame}. Per Spec 016 §Introspection."}
+   {:key         :resources/resources
+    :producer-ns 're-frame.resources
+    :design-bead "rf2-p10npe"
+    :description "Return resource introspection for a frame target — registered resources + the live per-frame resource-instance table. Per Spec 016 §Introspection."}
+   {:key         :resources/reset-resources!
+    :producer-ns 're-frame.resources.test-support
+    :design-bead "rf2-p10npe"
+    :description "Test-isolation reset: clear the :resource-kind registrar entries + the host-side generation high-water marks. Published from re-frame.resources.test-support (kept behind an explicit test-support require, rf2-dbiv8 posture); fired by the shared CLJS make-reset-runtime-fixture reset-hooks table, no-op when test-support is absent."}
+   {:key         :routing/extra-route-keys
+    :producer-ns 're-frame.resources.route
+    :design-bead "rf2-p10npe"
+    :description "Cross-feature LATE-BOUND route-metadata accepted-key extension (Spec 016 §Route integration). Returns a SET of extra bare route-metadata keys routing unions into its accepted set; the Resources artefact publishes #{:resources} so routing accepts the :resources route key (mirrors how :head is a cross-feature key owned by SSR). Resources is the first publisher; consumed by re-frame.routing.registry/accepted-route-keys."}
+   {:key         :ssr/extend-runtime-db-projection
+    :producer-ns 're-frame.resources.ssr
+    :design-bead "rf2-p10npe"
+    :description "Cross-feature LATE-BOUND SSR hydration-payload runtime-db projection extension (Spec 016 §SSR and hydration). Takes the full runtime-db value, returns a {subsystem-key durable-projection} map SSR's project-runtime-db merges into its allowlist-shaped slice; the Resources artefact projects ONLY the durable :entries of :rf.runtime/resources (the reverse indexes are recomputable-from-entries). Resources is the first publisher; consumed by re-frame.ssr.payload-policy/project-runtime-db."}
+
    ;; ---- re-frame.http-managed (rf2-5kpd / rf2-6y3q / rf2-wvkn / rf2-ijm7) ----
    ;; The three stub-family hooks publish from `re-frame.http-test-support`
    ;; per rf2-lwmgw — single discoverable home for HTTP test surfaces.

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -6,7 +6,7 @@
 
   Reserved kinds (closed v1 set, per Spec 001 §Registry model):
     :event :sub :fx :cofx :view :frame :route :head
-    :error-projector :flow
+    :error-projector :flow :resource
 
   Machine guards and actions are NOT a registrar kind (rf2-ftrcv,
   supersedes rf2-ypu5i / rf2-npvsx). Per Spec 005 the machine spec's
@@ -54,9 +54,15 @@
 
   App-db schemas (rf2-cq1ak) are NOT a registrar kind — they live in the
   schemas artefact's per-frame side-table (`schemas/schemas-by-frame`).
-  Introspect via `schemas/app-schemas` / `schemas/app-schema-meta-at`."
+  Introspect via `schemas/app-schemas` / `schemas/app-schema-meta-at`.
+
+  `:resource` (rf2-p10npe, Spec 016 §Registration) is the resources
+  artefact's registrar kind — `reg-resource` registers a resource spec
+  under it. Deliberately `:resource`, NOT `:query` (which would collide
+  with route query-params + prior-art names). Reserved whether or not the
+  Resources artefact ships."
   #{:event :sub :fx :cofx :view :frame :route :head
-    :error-projector :flow})
+    :error-projector :flow :resource})
 
 (defn valid-kind? [k]
   (contains? kinds k))

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -66,7 +66,16 @@
             ;; the require the hooks are nil, the router's halt paths
             ;; degrade to no-op, and `:epoch-records` fixture assertions
             ;; can't observe the halted-cascade contract.
-            [re-frame.epoch]))
+            [re-frame.epoch]
+            ;; rf2-p10npe — the optional Resources artefact (Spec 016)
+            ;; publishes its public-API + feature-probe late-bind hooks
+            ;; (`:resources/reg-resource`, …) at ns-load time. Required
+            ;; here so the `:resources` feature probe is populated in the
+            ;; JVM core test build — `features-cljs-test` asserts every
+            ;; registry feature is loaded, and (unlike the CLJS node-test
+            ;; build, where the resources `*-cljs-test` suite requires it)
+            ;; nothing else on the JVM test path loads the artefact.
+            [re-frame.resources]))
 
 ;; ---- claimed capability set -----------------------------------------------
 

--- a/implementation/core/test/re_frame/machine_handler_meta_test.clj
+++ b/implementation/core/test/re_frame/machine_handler_meta_test.clj
@@ -52,14 +52,14 @@
 
 (use-fixtures :each reset-runtime)
 
-;; ---- the registrar kind set is the clean ten -----------------------------
+;; ---- the registrar kind set is the clean set -----------------------------
 
 (deftest registrar-kinds-are-the-clean-ten
   (testing "rf2-ftrcv: `:machine-guard` / `:machine-action` are NOT registrar kinds"
     (is (= #{:event :sub :fx :cofx :view :frame :route :head
-             :error-projector :flow}
+             :error-projector :flow :resource}
            registrar/kinds)
-        "registrar/kinds is the canonical ten — no machine *registration* kinds")
+        "registrar/kinds is the canonical reserved set — no machine *registration* kinds; `:resource` (rf2-p10npe, Spec 016) is the resources artefact's kind")
     (is (not (registrar/valid-kind? :machine-guard))
         "(valid-kind? :machine-guard) = false")
     (is (not (registrar/valid-kind? :machine-action))
@@ -87,7 +87,7 @@
   (testing "rf2-ftrcv acceptance: (rf/handler-meta :machine-guard [mid gid]) returns
   :rf.handler/source in dev — the UNCHANGED surface Xray's GUARDS RUN lens +
   pair-MCP source-jump read. The two machine kinds dispatch to the
-  machine-spec-derived source; the ten registrar kinds fall through to the
+  machine-spec-derived source; the registrar kinds fall through to the
   registrar lookup."
     (rf/reg-machine :rf2-ftrcv/addressing
       {:initial :idle
@@ -100,7 +100,7 @@
           "dev: :machine-guard handler-meta carries :rf.handler/source")
       (is (string? (:rf.handler/source a))
           "dev: :machine-action handler-meta carries :rf.handler/source"))
-    (testing "the ten registrar kinds still fall through to the registrar lookup"
+    (testing "the registrar kinds still fall through to the registrar lookup"
       (rf/reg-event-db :rf2-ftrcv/plain-event (fn [db _] db))
       (is (= (registrar/lookup :event :rf2-ftrcv/plain-event)
              (rf/handler-meta :event :rf2-ftrcv/plain-event))

--- a/implementation/deps.edn
+++ b/implementation/deps.edn
@@ -46,7 +46,11 @@
          day8/re-frame2-http     {:local/root "http"}
          day8/re-frame2-ssr      {:local/root "ssr"}
          day8/re-frame2-ssr-ring {:local/root "ssr-ring"}
-         day8/re-frame2-epoch    {:local/root "epoch"}}
+         day8/re-frame2-epoch    {:local/root "epoch"}
+         ;; rf2-p10npe — the optional Resources artefact (Spec 016,
+         ;; EP-0003 slice 2). Skeleton slice; runtime logic lands in
+         ;; later slices.
+         day8/re-frame2-resources {:local/root "resources"}}
 
  :aliases
  {;; Combined CLJS-test path: convenient for ad-hoc REPL work that wants
@@ -72,6 +76,8 @@
                  "ssr/test"
                  "ssr-ring/test"
                  "epoch/test"
+                 ;; rf2-p10npe — Resources artefact test tree.
+                 "resources/test"
                  ;; Per rf2-kx74 examples are grouped per substrate. The
                  ;; combined :test alias loads every example tree onto
                  ;; the classpath so JVM tests can `require` the example

--- a/implementation/resources/LICENSE
+++ b/implementation/resources/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2026 Michael Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/implementation/resources/deps.edn
+++ b/implementation/resources/deps.edn
@@ -1,0 +1,87 @@
+;; day8/re-frame2-resources — resources artefact (rf2-p10npe, EP-0003
+;; slice 2; per-feature split per rf2-5vjj Strategy B).
+;;
+;; Per Spec 016 §Resources the declarative server-state grammar
+;; (`reg-resource`, `clear-resource`, `resource-meta`, `resource-state`,
+;; `resources`, the `:rf.resource/*` events and passive subs, the
+;; `:resource` registrar kind, the `:rf.runtime/resources` + the
+;; `:rf.runtime/work-ledger` runtime-db slots, managed-HTTP lowering,
+;; route `:resources` metadata, and SSR preload/hydration) ships as a
+;; separate Maven artefact so apps that don't register any resources
+;; don't drag the namespace, the resource lifecycle FSM, the work-
+;; ledger machinery, or any of the `:rf.resource/*` / `:rf.scope/*` /
+;; `:rf.work/*` trace strings onto the classpath.
+;;
+;; This is the SKELETON slice (rf2-p10npe): the namespaces + the public
+;; surface compile and load cleanly, but the runtime logic lands in
+;; later slices (rf2-afpdkn work-ledger substrate, rf2-pbxj48 resource
+;; runtime, …). Stub bodies raise `:rf.error/resource-not-implemented`
+;; where the behaviour is a later slice, so a premature call fails
+;; loudly rather than silently no-opping.
+;;
+;; Consumers add this artefact alongside the core artefact:
+;;
+;;   {:deps {day8/re-frame2           {:mvn/version "..."}
+;;           day8/re-frame2-resources {:mvn/version "..."}}}
+;;
+;; And require `re-frame.resources` in any namespace that calls
+;; `rf/reg-resource` or relies on the `:rf.resource/*` subs / events —
+;; loading the namespace registers its late-bind hooks, the `:resource`
+;; registrar kind, and the `:rf.resource/*` reg-event / reg-sub family.
+;;
+;; Per Spec 006 §Adapter shipping convention (and the rf2-p7va
+;; extension to per-feature splits): this artefact depends on core; core
+;; never depends on this artefact. The cross-references from core to
+;; resources (e.g. `re-frame.core`'s `reg-resource` / `clear-resource`
+;; / `resource-meta` / `resource-state` / `resources` re-exports) flow
+;; through `re-frame.late-bind` exactly as the schemas / machines /
+;; routing / http hooks already do.
+;;
+;; The HTTP transport (`:rf.http/managed`, Spec 014) and the routing /
+;; SSR integrations are LATE-BOUND: resources reaches them through the
+;; same late-bind hook registry rather than a static `:require`, so an
+;; app that loads resources but not routing / ssr / http carries none
+;; of their code. They are therefore test-only deps here.
+{:paths ["src"]
+ :deps  {day8/re-frame2 {:local/root "../core"}}
+
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps  {;; rf2-try1x — silent-on-success reporter.
+                       day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                       ;; Late-bound integration surfaces — pulled in as
+                       ;; TEST-ONLY deps so the artefact's production
+                       ;; classpath stays routing/ssr/http/schemas-free
+                       ;; (resources reaches them through late-bind, not
+                       ;; a static :require). Mirrors the routing
+                       ;; deps.edn test-extra-deps pattern.
+                       day8/re-frame2-schemas    {:local/root "../schemas"}
+                       day8/re-frame2-routing    {:local/root "../routing"}
+                       day8/re-frame2-ssr        {:local/root "../ssr"}
+                       day8/re-frame2-http       {:local/root "../http"}
+                       io.github.cognitect-labs/test-runner
+                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :main-opts   ["-m" "re-frame.test-quiet.runner"]}
+
+  ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
+  ;; The release workflow runs `clojure -M:clein deploy` from this
+  ;; artefact's directory, which builds pom + jar and pushes to Clojars.
+  ;;
+  ;; IMPORTANT: when this artefact is published, the `day8/re-frame2`
+  ;; core dep above is replaced by an :mvn/version coordinate — clein
+  ;; reads :deps and writes them into pom.xml, and a :local/root entry
+  ;; would resolve to nothing for downstream consumers. The release
+  ;; workflow swaps :local/root → :mvn/version before invoking clein.
+  :clein {:extra-deps {io.github.noahtheduke/clein
+                       {:git/url "https://github.com/day8/clein.git"
+                        :git/sha "2b83503246e8291fc023d688574640a9b23d8c50"}}
+          :main-opts  ["-m" "noahtheduke.clein"]}
+
+  :clein/build
+  {:lib      day8/re-frame2-resources
+   :main     re-frame.resources
+   :url      "https://github.com/day8/re-frame2"
+   :version  "../../VERSION"
+   :license  {:name "MIT"
+              :url  "https://opensource.org/licenses/MIT"}
+   :src-dirs ["src"]}}}

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -1,0 +1,187 @@
+(ns re-frame.resources
+  "Resources — declarative server-state as a runtime-managed read model
+  over a frame work ledger. Per Spec 016.
+
+  A resource is a named, cached read of remote or external state.
+  `reg-resource` registers it; views read it through PASSIVE subscriptions
+  (`[:rf.resource/state …]`); route entry, events, and machines CAUSE it
+  to fetch. The resource runtime owns identity, cache scope, staleness,
+  dedupe, invalidation, GC, in-flight ownership, SSR hydration, and tool
+  metadata, so an app stops re-implementing that bookkeeping per feature.
+
+  This namespace is the **public boot point and façade** for the
+  resources artefact: apps boot it with `(:require [re-frame.resources])`.
+  Doing so transitively loads every concern sibling under
+  `re-frame.resources.*` and runs the registrations at the bottom of this
+  file:
+
+  - `re-frame.resources.state`           — reserved runtime-db paths, durable shapes, the host-side generation allocator, framework-write-authority stamp
+  - `re-frame.resources.registry`        — `reg-resource` / `clear-resource` + the `:resource` registrar kind + registry introspection
+  - `re-frame.resources.transport`       — the transport-neutral lower seam
+  - `re-frame.resources.transport.http`  — the `:rf.http/managed` lowering (late-bound HTTP)
+  - `re-frame.resources.events`          — the `:rf.resource/*` causal event handlers (+ internal replies)
+  - `re-frame.resources.subs`            — the `:rf.resource/*` passive subs
+  - `re-frame.resources.route`           — LATE-BOUND routing integration (`:resources` route-metadata key)
+  - `re-frame.resources.ssr`             — LATE-BOUND SSR/hydration projection
+
+  The registrations live HERE (not in the siblings) so a
+  `(require 're-frame.resources :reload)` on a fresh registrar
+  (`clear-all!` test fixture) re-wires every handler — the long-
+  established consumer-test pattern, mirroring `re-frame.routing` /
+  `re-frame.machines`.
+
+  ## Optionality + bundle isolation
+
+  Per Spec 016 §Implementation status this is a POST-V1 OPTIONAL artefact
+  (`day8/re-frame2-resources`). `re-frame.core` MUST NOT `:require` it; the
+  public-API surface is published through the late-bind table, so an app
+  that omits the artefact sees the wrappers throw a clean
+  `:rf.error/resources-artefact-missing`. The routing + SSR integrations
+  are LATE-BOUND (resources never statically `:require`s routing / ssr /
+  http), so an app that loads resources but not those optional artefacts
+  carries none of their code. Nothing here `:require`s from `tools/`.
+
+  ## Slice status
+
+  This is the rf2-p10npe artefact SKELETON (EP-0003 slice 2). The public
+  surface, the registrar kind, the late-bind wiring, and the
+  routing/SSR-projection extensions are real and load cleanly; the runtime
+  LOGIC (entry transition function, work-ledger join/dedupe, stale
+  suppression, GC, invalidation, route-plan execution, hydration install)
+  lands in later slices (rf2-afpdkn / rf2-pbxj48 / …). The event handlers
+  are registered but their bodies raise `:rf.error/resource-not-implemented`
+  so a premature call fails loudly."
+  (:require [re-frame.events :as events]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.resources.events :as resource-events]
+            [re-frame.resources.registry :as registry]
+            [re-frame.resources.route :as route]
+            [re-frame.resources.ssr :as ssr]
+            [re-frame.resources.state :as state]
+            [re-frame.resources.subs :as resource-subs]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- public-surface re-exports --------------------------------------------
+;; These `def`s make the sibling fns reachable as
+;; `re-frame.resources/<name>` so consumers (the `re-frame.core` late-bind
+;; bridge, conformance, tests, examples) see one surface.
+
+(def reg-resource    registry/reg-resource)
+(def clear-resource  registry/clear-resource)
+(def resource-meta   registry/resource-meta)
+(def resource-ids    registry/resource-ids)
+
+(defn resources
+  "Return resource introspection for a frame target (Spec 016
+  §Introspection). The static registry half — every registered resource id
+  — is real now; the per-frame live resource-instance table lands with the
+  runtime slice (rf2-pbxj48).
+
+  SKELETON: returns `{:resource-ids [...]}` (the static registry). The
+  `:frame`-scoped live-instance enumeration is filled in by the runtime
+  slice."
+  ([] {:resource-ids (resource-ids)})
+  ([_opts] {:resource-ids (resource-ids)}))
+
+(defn resource-state
+  "Return a resource instance's runtime state for an explicit `:frame`
+  introspection target `{:resource :scope :params :frame}` (Spec 016
+  §Introspection). Per EP-0002 there is no ambient `:rf/default` fallback.
+
+  SKELETON: the live per-frame entry read lands with the runtime slice
+  (rf2-pbxj48); raises until then so a premature call is obvious."
+  [_opts]
+  (throw (ex-info ":rf.error/resource-not-implemented"
+                  {:rf.error/id :rf.error/resource-not-implemented
+                   :where       'rf/resource-state
+                   :recovery    :no-recovery
+                   :reason      (str "resource-state's live per-frame entry read "
+                                     "lands with the EP-0003 resource runtime "
+                                     "slice (rf2-pbxj48). This is the rf2-p10npe "
+                                     "artefact skeleton.")})))
+
+;; ---- event / sub / hook registrations -------------------------------------
+;; Keeping the registrations in this façade means a `(require
+;; 're-frame.resources :reload)` re-wires every handler on a fresh
+;; registrar (the `clear-all!` test-fixture recovery pattern).
+
+;; Every resource event handler stamps the reserved
+;; `:rf/framework-authority? true` registration-meta (Spec 016 §Write
+;; authority) so a returned `:rf.db/runtime` effect is recognised as a
+;; framework write — the runtime's `:rf.warning/app-handler-runtime-effect`
+;; ownership diagnostic treats these as in-bounds. Applied uniformly so a
+;; new resource handler that touches the slice inherits authority by
+;; sitting in this façade. (Mirrors routing's framework-authority-meta.)
+(def ^:private framework-authority-meta state/framework-authority-meta)
+
+;; Public resource events (map payloads). Per Spec 016 §Events.
+(events/reg-event-fx :rf.resource/ensure
+                     framework-authority-meta
+                     resource-events/ensure-handler)
+(events/reg-event-fx :rf.resource/refetch
+                     framework-authority-meta
+                     resource-events/refetch-handler)
+(events/reg-event-fx :rf.resource/invalidate-tags
+                     framework-authority-meta
+                     resource-events/invalidate-tags-handler)
+(events/reg-event-fx :rf.resource/release-owner
+                     framework-authority-meta
+                     resource-events/release-owner-handler)
+(events/reg-event-fx :rf.resource/clear-scope
+                     framework-authority-meta
+                     resource-events/clear-scope-handler)
+(events/reg-event-fx :rf.resource/remove
+                     framework-authority-meta
+                     resource-events/remove-handler)
+
+;; Framework-internal reply handlers. Per Spec 016 §Events / §Transport.
+;; User code MUST NOT dispatch these.
+(events/reg-event-fx :rf.resource.internal/succeeded
+                     framework-authority-meta
+                     resource-events/succeeded-handler)
+(events/reg-event-fx :rf.resource.internal/failed
+                     framework-authority-meta
+                     resource-events/failed-handler)
+(events/reg-event-fx :rf.resource.internal/aborted
+                     framework-authority-meta
+                     resource-events/aborted-handler)
+(events/reg-event-fx :rf.resource.internal/gc-fired
+                     framework-authority-meta
+                     resource-events/gc-fired-handler)
+(events/reg-event-fx :rf.resource.internal/stale-suppressed
+                     framework-authority-meta
+                     resource-events/stale-suppressed-handler)
+
+;; Passive resource subs. Per Spec 016 §Subscriptions.
+(resource-subs/register-subs!)
+
+;; LATE-BOUND cross-feature integrations (Spec 016 §Route integration /
+;; §SSR and hydration). Wired here so they re-install on a `:reload`. Each
+;; publishes a late-bind hook the host artefact (routing / ssr) CONSULTS;
+;; both are no-op-effect on an app that never loads the host artefact.
+(route/install-routing-integration!)
+(ssr/install-ssr-integration!)
+
+;; ---- late-bind hook registration ------------------------------------------
+;; `re-frame.core` MUST NOT `:require [re-frame.resources]` — the artefact
+;; is optional. Public-API re-exports are published through the late-bind
+;; table; consumers without the artefact see the hooks unregistered and the
+;; wrappers throw `:rf.error/resources-artefact-missing`. The
+;; `:resources/reg-resource` key doubles as the feature-inspection PROBE
+;; (re-frame.features) — its presence in the late-bind table is the
+;; loaded?-signal for the `:resources` feature.
+
+;; The test-isolation reset hook (`:resources/reset-resources!`) is NOT
+;; published here — it lives behind an explicit
+;; `re-frame.resources.test-support` require (the rf2-dbiv8 posture: keep
+;; test fixtures out of the always-on production façade), which publishes
+;; it from its own ns-load. The shared CLJS make-reset-runtime-fixture
+;; reset-hooks table consults it by key and no-ops when test-support is
+;; absent.
+(late-bind/set-fns!
+  {:resources/reg-resource   reg-resource
+   :resources/clear-resource clear-resource
+   :resources/resource-meta  resource-meta
+   :resources/resource-state resource-state
+   :resources/resources      resources})

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -1,0 +1,181 @@
+(ns re-frame.resources.events
+  "The resource event handlers — the causal write surface over the
+  resource cache + work ledger. Per Spec 016 §Public API §Events.
+
+  The public resource events take MAP payloads (not positional argument
+  vectors):
+
+    [:rf.resource/ensure          {:resource … :scope … :params … :owner … :cause …}]
+    [:rf.resource/refetch         {:resource … :scope … :params … :cause …}]
+    [:rf.resource/invalidate-tags {:scope … :tags … :cause …}]
+    [:rf.resource/release-owner   {:owner …}]
+    [:rf.resource/clear-scope     {:scope … :cause …}]
+    [:rf.resource/remove          {:resource … :scope … :params …}]
+
+  Plus the framework-INTERNAL replies (`:rf.resource.internal/*`) that
+  carry the verification payload (`:work-id` / `:resource-key` / `:scope`
+  / `:generation` / `:rf.frame/id`) — user code MUST NOT dispatch them.
+
+  Every handler carries framework-write authority
+  (`state/framework-authority-meta`) so a returned `:rf.db/runtime`
+  effect is in-bounds (Spec 016 §Write authority); the registrations live
+  in the `re-frame.resources` façade so a `(require … :reload)` on a
+  fresh registrar re-wires them.
+
+  SKELETON slice (rf2-p10npe): the handler FNS are defined here with
+  their payload contract documented, but their bodies are stubs that
+  raise `:rf.error/resource-not-implemented` — the entry transition
+  function, work-ledger join/dedupe, stale suppression, GC, and
+  invalidation land with the runtime slices (rf2-afpdkn / rf2-pbxj48 /
+  …). A stub fails LOUDLY rather than silently no-opping, so a premature
+  call is obvious. The handler IDS, payload shapes, and authority stamp
+  are pinned now."
+  (:require [re-frame.resources.transport :as transport]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn- not-implemented
+  "Raise the canonical not-yet-implemented error for a skeleton handler
+  body (rf2-p10npe). The handler is REGISTERED (so the registry surface,
+  Xray's static view, and the late-bind wiring are real) but its runtime
+  logic lands in a later slice; a premature dispatch fails loudly here."
+  [event-id slice]
+  (throw (ex-info ":rf.error/resource-not-implemented"
+                  {:rf.error/id :rf.error/resource-not-implemented
+                   :where       event-id
+                   :recovery    :no-recovery
+                   :reason      (str event-id " is registered but its runtime "
+                                     "logic lands in a later EP-0003 slice ("
+                                     slice "). This is the rf2-p10npe artefact "
+                                     "skeleton.")
+                   :event-id    event-id
+                   :slice       slice})))
+
+;; ---- public resource events ----------------------------------------------
+
+(defn ensure-handler
+  "`:rf.resource/ensure` — ensure a resource instance is loaded (load it
+  if absent / stale per policy; join the in-flight work record if one
+  exists; attach `:owner` to entry + ledger row; record `:cause`). Per
+  Spec 016 §Events and §Race and in-flight semantics. Payload:
+  `{:resource :scope :params :owner :cause}`.
+
+  SKELETON: runtime lands in rf2-pbxj48 (resource runtime — entries,
+  scopes, canonical params, status transitions, structural sharing)."
+  [_cofx [_event-id _payload]]
+  (not-implemented :rf.resource/ensure "rf2-pbxj48 resource runtime"))
+
+(defn refetch-handler
+  "`:rf.resource/refetch` — force a refresh of a resource instance (may
+  force a new generation; supersede + suppress any in-flight prior
+  request). Per Spec 016 §Events and §Race and in-flight semantics.
+  Payload: `{:resource :scope :params :cause}`.
+
+  SKELETON: runtime lands in rf2-pbxj48."
+  [_cofx [_event-id _payload]]
+  (not-implemented :rf.resource/refetch "rf2-pbxj48 resource runtime"))
+
+(defn invalidate-tags-handler
+  "`:rf.resource/invalidate-tags` — exact tag invalidation (mark matched
+  entries stale; refetch the active-owner ones; leave inactive ones stale
+  / GC-eligible; emit one decision summary + per-entry details). Scoped by
+  default. Per Spec 016 §Invalidation. Payload: `{:scope :tags :cause}`.
+
+  SKELETON: runtime lands in rf2-pbxj48 / the invalidation+GC slice."
+  [_cofx [_event-id _payload]]
+  (not-implemented :rf.resource/invalidate-tags "rf2-pbxj48 / invalidation slice"))
+
+(defn release-owner-handler
+  "`:rf.resource/release-owner` — release a liveness lease (drop the owner
+  from every entry's `:active-owners` + the owner-index; abort in-flight
+  work only when no remaining owner needs it). Per Spec 016 §Active owners
+  and causes and §Race and in-flight semantics. Payload: `{:owner …}`.
+
+  SKELETON: runtime lands in rf2-pbxj48."
+  [_cofx [_event-id _payload]]
+  (not-implemented :rf.resource/release-owner "rf2-pbxj48 resource runtime"))
+
+(defn clear-scope-handler
+  "`:rf.resource/clear-scope` — causal scope clear (remove/mark-unusable
+  every entry in the scope; release its owners; abort in-flight requests
+  with no remaining owner outside the scope; suppress late replies by
+  scope + generation; emit explaining trace rows). The logout / account-
+  switch / tenant-switch / impersonation-change boundary. Per Spec 016
+  §clear-scope is causal. Payload: `{:scope :cause}`.
+
+  SKELETON: runtime lands in rf2-pbxj48."
+  [_cofx [_event-id _payload]]
+  (not-implemented :rf.resource/clear-scope "rf2-pbxj48 resource runtime"))
+
+(defn remove-handler
+  "`:rf.resource/remove` — remove a single resource instance from the
+  cache by its scoped key. Per Spec 016 §Events. Payload:
+  `{:resource :scope :params}`.
+
+  SKELETON: runtime lands in rf2-pbxj48."
+  [_cofx [_event-id _payload]]
+  (not-implemented :rf.resource/remove "rf2-pbxj48 resource runtime"))
+
+;; ---- framework-internal reply handlers -----------------------------------
+;;
+;; These carry the verification payload and MUST verify frame + work-id +
+;; generation before writing (Spec 016 §Transport — stale suppression is
+;; the correctness boundary). User code MUST NOT dispatch them.
+
+(defn succeeded-handler
+  "`:rf.resource.internal/succeeded` — a transport read succeeded. Verify
+  frame + work-id + generation against the live entry; on match, install
+  the decoded data (`:loaded`), preserving the old `:data` value when the
+  new data is `=` (structural sharing); prune the terminal work row. Per
+  Spec 016 §Transport / §Structural sharing / §Ledger row retention.
+
+  SKELETON: runtime lands in rf2-pbxj48."
+  [_cofx [_event-id _payload]]
+  (not-implemented :rf.resource.internal/succeeded "rf2-pbxj48 resource runtime"))
+
+(defn failed-handler
+  "`:rf.resource.internal/failed` — a transport read failed. Verify
+  frame + work-id + generation; a first-load failure settles `:error`
+  (no usable data); a background-refresh failure returns to `:loaded`,
+  keeps prior `:data`, and records `:refresh-error`. Per Spec 016 §Status
+  semantics.
+
+  SKELETON: runtime lands in rf2-pbxj48."
+  [_cofx [_event-id _payload]]
+  (not-implemented :rf.resource.internal/failed "rf2-pbxj48 resource runtime"))
+
+(defn aborted-handler
+  "`:rf.resource.internal/aborted` — a transport read was aborted (owner
+  exit / scope clear / route supersession / newer generation). Reconcile
+  the work row to `:cancelled`; the entry settles to its last stable
+  status. Per Spec 016 §Cancellation is opportunistic; stale suppression
+  is mandatory.
+
+  SKELETON: runtime lands in rf2-afpdkn (work-ledger substrate)."
+  [_cofx [_event-id _payload]]
+  (not-implemented :rf.resource.internal/aborted "rf2-afpdkn work-ledger substrate"))
+
+(defn gc-fired-handler
+  "`:rf.resource.internal/gc-fired` — an inactive-GC timer fired. Re-check
+  owner sets + entry generation after wake (timers are advisory); remove
+  the entry only if still GC-eligible. Per Spec 016 §Stale and GC
+  scheduling.
+
+  SKELETON: runtime lands in the stale/GC slice."
+  [_cofx [_event-id _payload]]
+  (not-implemented :rf.resource.internal/gc-fired "stale/GC slice"))
+
+(defn stale-suppressed-handler
+  "`:rf.resource.internal/stale-suppressed` — a late reply carrying a
+  superseded work-id / generation was suppressed (it MUST NEVER mutate a
+  newer entry). Records the suppression in trace / ledger. Per Spec 016
+  §Cancellation is opportunistic; stale suppression is mandatory.
+
+  SKELETON: runtime lands in rf2-afpdkn (work-ledger substrate)."
+  [_cofx [_event-id _payload]]
+  (not-implemented :rf.resource.internal/stale-suppressed "rf2-afpdkn work-ledger substrate"))
+
+;; A load-bearing reference to the transport seam so the require is honest
+;; in the skeleton (the runtime slice's ensure/refetch handlers lower
+;; through `transport/lower-ensure`).
+(def ^:private _transport-seam transport/lower-ensure)

--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -1,0 +1,187 @@
+(ns re-frame.resources.registry
+  "Resource registration — `reg-resource` / `clear-resource` and the
+  registry-side introspection accessors. Per Spec 016 §Public API
+  §Registration and §Resource registration spec.
+
+  A resource is a registrar entry under the `:resource` kind (Spec 016
+  §Registration: \"A `:resource` registrar kind is added; do NOT add a
+  `:query` public kind\"). `reg-resource` validates the spec — crucially
+  the REQUIRED, fail-closed `:scope` policy (Spec 016 §Scope resolution:
+  no policy is a loud `:rf.error/resource-missing-scope-policy`) — and
+  writes the entry; `clear-resource` is a registration-lifecycle removal
+  (distinct from the data-lifecycle `:rf.resource/invalidate-tags` /
+  `:rf.resource/remove` / `:rf.resource/clear-scope` events).
+
+  SKELETON slice (rf2-p10npe): registration validation + the registry
+  write/read are real (so an app can register a resource and Xray can
+  enumerate the static registry); the per-frame runtime disposal
+  `clear-resource` performs (owner-index release, host-handle cancel,
+  in-flight abort, late-reply suppression, tag-index prune, trace) lands
+  with the runtime slices (rf2-afpdkn / rf2-pbxj48) — until then it
+  clears the registrar entry only."
+  (:require [re-frame.registrar :as registrar]
+            [re-frame.source-coords :as source-coords]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- the :resource registrar kind ----------------------------------------
+
+(def resource-kind
+  "The registrar kind for resources (`:resource`). Per Spec 016
+  §Registration. Added to the core registrar's closed kind set (a Spec
+  change); resources register their spec under this kind."
+  :resource)
+
+;; ---- scope-policy validation (fail-closed) -------------------------------
+
+(def ^:private global-scope-policy
+  "The explicit, auditable global-scope claim. Per Spec 016 §Scope
+  resolution: `:scope :rf.scope/global` is a CLAIM (\"same params produce
+  the same data for every user/tenant/permission/locale/impersonation\"),
+  never a framework default."
+  :rf.scope/global)
+
+(def ^:private from-caller-scope-policy
+  "Scope required from the use site. Per Spec 016 §Scope resolution:
+  every ensure/refetch/state call MUST supply `:scope`, or a route-
+  resource resolver MUST."
+  :rf.scope/from-caller)
+
+(defn- valid-scope-policy?
+  "A scope policy is one of the reserved enum keywords
+  (`:rf.scope/global`, `:rf.scope/from-caller`) or a resolver (a fn, a
+  pure data value, or a fn-of-nothing). Per Spec 016 §Scope resolution.
+  `nil` / missing is NOT valid — it is a loud registration error."
+  [scope]
+  (and (some? scope)
+       (or (= scope global-scope-policy)
+           (= scope from-caller-scope-policy)
+           ;; A resolver — a fn (route/spec resolver) or a data value /
+           ;; fn-of-nothing (sub-resolvable). The runtime slice
+           ;; distinguishes route-ctx resolvers from sub-resolvable ones;
+           ;; at registration any non-nil value other than an unknown
+           ;; bare `:rf.scope/*` keyword is accepted as a resolver.
+           (fn? scope)
+           (not (keyword? scope))
+           ;; A namespaced keyword resolver alias is permitted; only a
+           ;; bare `nil` (handled above) fails.
+           (keyword? scope))))
+
+(defn- registration-error
+  "Build the canonical thrown-error shape (Spec 009 §The thrown-error
+  shape) for a `reg-resource` validation failure."
+  [error-id where reason extra]
+  (ex-info (str error-id)
+           (merge {:rf.error/id error-id
+                   :where       where
+                   :recovery    :fix-registration
+                   :reason      reason}
+                  extra)))
+
+(defn- validate-resource-spec!
+  "Fail loudly at the authoring boundary when a resource spec omits the
+  REQUIRED keys (Spec 016 §Resource registration spec). The fail-closed
+  `:scope` policy is the load-bearing one: a `reg-resource` with no scope
+  policy throws `:rf.error/resource-missing-scope-policy` so \"I forgot
+  this read is user-scoped\" is unrepresentable at registration rather
+  than an Xray heuristic. Fails in dev AND prod (caller bug)."
+  [resource-id spec]
+  (when-not (map? spec)
+    (throw (registration-error
+             :rf.error/invalid-resource-spec
+             'rf/reg-resource
+             (str "resource " resource-id "'s spec must be a map, got "
+                  (pr-str (type spec)))
+             {:resource-id resource-id :value spec})))
+  ;; `:scope` is REQUIRED, fail-closed (rf2-6rrz53). No silent global default.
+  (when-not (valid-scope-policy? (:scope spec))
+    (throw (registration-error
+             :rf.error/resource-missing-scope-policy
+             'rf/reg-resource
+             (str "resource " resource-id " declares no valid :scope policy. "
+                  ":scope is REQUIRED (fail-closed) — one of :rf.scope/global "
+                  "(an explicit, auditable global claim), a resolver, or "
+                  ":rf.scope/from-caller. There is no implicit default; a "
+                  "user-scoped read must say so. Per Spec 016 §Scope resolution.")
+             {:resource-id resource-id :scope (:scope spec)})))
+  ;; `:params-schema` is REQUIRED — validates + canonicalizes params.
+  (when-not (contains? spec :params-schema)
+    (throw (registration-error
+             :rf.error/invalid-resource-spec
+             'rf/reg-resource
+             (str "resource " resource-id " declares no :params-schema. "
+                  ":params-schema is REQUIRED — it validates and canonicalizes "
+                  "params (the resource's identity). Per Spec 016 §Resource "
+                  "registration spec.")
+             {:resource-id resource-id})))
+  ;; `:request` is REQUIRED for the only initial-scope transport.
+  (when-not (contains? spec :request)
+    (throw (registration-error
+             :rf.error/invalid-resource-spec
+             'rf/reg-resource
+             (str "resource " resource-id " declares no :request. For "
+                  ":transport :rf.http/managed (the only initial-scope "
+                  "transport) :request returns a Spec 014 managed-HTTP args "
+                  "map. Per Spec 016 §Resource registration spec.")
+             {:resource-id resource-id})))
+  nil)
+
+;; ---- reg-resource / clear-resource ---------------------------------------
+
+(defn reg-resource
+  "Register a resource under `resource-id` with `resource-spec`. Per
+  Spec 016 §Public API §Registration.
+
+  Validates the spec (the REQUIRED, fail-closed `:scope` policy first;
+  then `:params-schema` and `:request`) and writes a `:resource`-kind
+  registrar entry carrying the spec plus any captured source coords.
+
+  Returns `resource-id` per the `reg-*` return-value convention
+  ([Conventions §reg-* return-value convention])."
+  [resource-id resource-spec]
+  (validate-resource-spec! resource-id resource-spec)
+  (registrar/register!
+    resource-kind
+    resource-id
+    (source-coords/merge-coords
+      (merge {:doc (:doc resource-spec)}
+             {:rf/resource resource-spec
+              :handler-fn  (:request resource-spec)})))
+  resource-id)
+
+(defn clear-resource
+  "Remove a registered resource (registration-lifecycle, NOT data
+  invalidation). Per Spec 016 §Public API §Registration.
+
+  SKELETON slice (rf2-p10npe): clears the registrar entry. The full
+  contract — also dispose resource-runtime state for the id in each
+  affected frame (release owner indexes, cancel timers / host handles,
+  abort in-flight where possible, suppress late replies by generation,
+  remove tag-index rows, emit a trace) — lands with the runtime slices
+  (rf2-afpdkn / rf2-pbxj48). Application data-lifecycle work uses
+  `:rf.resource/invalidate-tags` / `:rf.resource/remove` /
+  `:rf.resource/clear-scope` instead.
+
+  No-op (returns `resource-id`) when the id is not registered."
+  [resource-id]
+  (registrar/unregister! resource-kind resource-id)
+  resource-id)
+
+;; ---- registry-side introspection -----------------------------------------
+
+(defn resource-meta
+  "Return the registered resource's spec map (`:params-schema`,
+  `:data-schema`, `:request`, `:scope`, `:transport`, `:stale-after-ms`,
+  `:gc-after-ms`, `:tags`, `:doc`, source coords) for `resource-id`, or
+  nil if no resource is registered under that id. Per Spec 016
+  §Introspection."
+  [resource-id]
+  (:rf/resource (registrar/lookup resource-kind resource-id)))
+
+(defn resource-ids
+  "Return a vector of every registered resource id. The registry-side
+  half of `resources` (the runtime-side per-frame instance table lands
+  with the runtime slice). Per Spec 016 §Xray and AI tooling (the static
+  resource registry)."
+  []
+  (vec (registrar/ids resource-kind)))

--- a/implementation/resources/src/re_frame/resources/route.cljc
+++ b/implementation/resources/src/re_frame/resources/route.cljc
@@ -1,0 +1,77 @@
+(ns re-frame.resources.route
+  "LATE-BOUND routing integration for resources. Per Spec 016 §Route
+  integration.
+
+  Routing rejects unknown bare route-metadata keys at registration (Spec
+  012 §Reserved route-metadata keys). The Resources artefact therefore
+  extends the routing accepted-key set — via a LATE-BOUND framework
+  extension — so `:resources` is treated like the existing cross-feature
+  `:head` key. Resources publishes the `:routing/extra-route-keys` hook
+  (returning `#{:resources}`); routing's `accepted-route-keys` consults
+  it at registration. The wiring is late-bound BOTH ways: resources never
+  statically `:require`s routing, and routing never statically `:require`s
+  resources — an app that loads resources but not routing carries no
+  route code, and a routing-only app sees no resources behaviour. (And a
+  route containing `:resources` in an app that omits the Resources
+  artefact is correctly rejected by routing, per Spec 016.)
+
+  On route entry, routing resolves the route + nav-token, evaluates
+  `:when` predicates, computes + validates scopes and params, marks each
+  resource active with owner `[:route route-id nav-token]`, ensures each
+  with cause `[:route-entry route-id nav-token]`, tracks blocking
+  resources under the nav-token, and lets non-blocking ones fetch in the
+  background; route leave / supersession releases route-owned resources by
+  owner token. Per Spec 016 §Route integration.
+
+  SKELETON slice (rf2-p10npe): the accepted-key extension is REAL (so an
+  app can `(reg-route … {:resources [...]})` once both artefacts are
+  loaded); the on-route-entry resource-plan execution + route-leave
+  release land with the route slice (a later EP-0003 slice). The hook
+  publication lives in the `re-frame.resources` façade (see
+  `install-routing-integration!`)."
+  (:require [re-frame.late-bind :as late-bind]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(def resources-route-key
+  "The route-metadata key the Resources artefact owns (`:resources`). Per
+  Spec 016 §Route integration."
+  :resources)
+
+(def extra-route-keys
+  "The cross-feature route-metadata keys this artefact contributes to the
+  routing accepted set (`#{:resources}`). Published under
+  `:routing/extra-route-keys`; routing's `accepted-route-keys` unions it
+  in. Per Spec 016 §Route integration."
+  #{resources-route-key})
+
+(defn install-routing-integration!
+  "Publish the LATE-BOUND routing integration: register the
+  `:routing/extra-route-keys` hook so routing accepts the `:resources`
+  route-metadata key. Idempotent (the hook is a pure data thunk). No-op
+  effect on an app that never loads routing — the hook simply sits unread.
+  Per Spec 016 §Route integration.
+
+  SKELETON: wires the accepted-key extension only. The on-route-entry
+  resource-plan hook (`:routing/on-route-entry` analogue) + route-leave
+  owner release land with the route slice."
+  []
+  (late-bind/set-fn! :routing/extra-route-keys (fn extra-route-keys-thunk [] extra-route-keys))
+  nil)
+
+(defn route-resource-plan
+  "Build the resource ensure/release plan for a route's `:resources`
+  metadata on entry (resolve scopes + params, evaluate `:when`, order by
+  `:after` dependencies, classify blocking vs background). Per Spec 016
+  §Route integration.
+
+  SKELETON: lands with the route slice. Named so the façade's
+  late-bind wiring and Xray's route/resource graph have a stable home."
+  [_route _ctx]
+  (throw (ex-info ":rf.error/resource-not-implemented"
+                  {:rf.error/id :rf.error/resource-not-implemented
+                   :where       're-frame.resources.route/route-resource-plan
+                   :recovery    :no-recovery
+                   :reason      (str "route :resources plan execution lands with "
+                                     "the EP-0003 route slice. This is the "
+                                     "rf2-p10npe artefact skeleton.")})))

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -1,0 +1,98 @@
+(ns re-frame.resources.ssr
+  "LATE-BOUND SSR / hydration integration for resources. Per Spec 016
+  §SSR and hydration and §Restore and replay.
+
+  SSR MUST use request-local frames — a process-global resource cache
+  would leak data between users. On a server render the runtime resolves
+  the route, computes route resources, enqueues blocking ensures, drains
+  until blocking resources for the current nav-token settle, renders with
+  the settled state, and serializes ONLY the allowed resource-runtime
+  projection. On client hydration the allowed projection installs into the
+  target frame-state's `:rf.runtime/resources` slice in runtime-db;
+  hydrated entries are preserved, fresh ones avoid a duplicate fetch,
+  stale ones background-refetch by event.
+
+  Resource hydration uses an EXPLICIT projection hook — the
+  allowlist-by-subsystem-child `project-runtime-db` of [011-SSR]. Rather
+  than statically `:require`ing SSR (which would drag the SSR body into
+  every resources app), resources publishes the LATE-BOUND
+  `:ssr/extend-runtime-db-projection` hook; SSR's `project-runtime-db`
+  consults it. The wiring is late-bound BOTH ways — an app that loads
+  resources but does not SSR carries none of this code path, and an SSR
+  app without resources sees no behaviour change.
+
+  Only the durable resource projection (`:rf.runtime/resources` →
+  `:entries`) rides the wire; `:tag-index` / `:owner-index` are
+  recomputable-from-`:entries` (rebuilt on install, never trusted from the
+  snapshot — Spec 016 §Restore and replay part 5) and need not ride. Per
+  Spec 016 §Runtime-subsystem graduation clause 4.
+
+  SKELETON slice (rf2-p10npe): the projection-extension wiring is REAL
+  (the durable `:entries` slice projects onto the hydration payload once
+  both artefacts are loaded); the blocking-drain wait point, the
+  client-side hydration install (preserve / avoid-dup-fetch /
+  background-refetch-stale), the per-entry projection metadata
+  (serialized / redacted / omitted / fresh / stale / refetch-on-client),
+  and the index recompute land with the SSR slice (a later EP-0003
+  slice)."
+  (:require [re-frame.late-bind :as late-bind]
+            [re-frame.resources.state :as state]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn project-resources-runtime-db
+  "Project the durable resource-runtime slice that rides the
+  `:rf/hydration-payload`'s `:rf/runtime-db` slice. Returns a
+  `{:rf.runtime/resources {:entries …}}` map (the durable cache facts)
+  for a runtime-db carrying resource entries, or `{}` otherwise. The
+  reverse indexes (`:tag-index` / `:owner-index`) are deliberately
+  EXCLUDED — they are recomputable-from-`:entries` and rebuilt on install.
+  Per Spec 016 §SSR and hydration / §Runtime-subsystem graduation clause 4.
+
+  This is the body behind the `:ssr/extend-runtime-db-projection` hook.
+
+  SKELETON: ships the `:entries` whole. Per-entry redaction / omission
+  (`:sensitive?` / `:large?` classification through `rf/elide-wire-value`)
+  + the projection metadata land with the SSR slice; until then a resource
+  whose data is sensitive should not yet be SSR-projected (the runtime
+  slice gates that)."
+  [runtime-db]
+  (let [resources (get runtime-db state/resources-key)
+        entries   (:entries resources)]
+    (if (seq entries)
+      {state/resources-key {:entries entries}}
+      {})))
+
+(defn install-ssr-integration!
+  "Publish the LATE-BOUND SSR projection extension: register the
+  `:ssr/extend-runtime-db-projection` hook so SSR's `project-runtime-db`
+  rides the durable resource `:entries` on the hydration payload. No-op
+  effect on an app that never SSRs — the hook simply sits unread. Per
+  Spec 016 §SSR and hydration.
+
+  SKELETON: wires the projection extension only. The client-side
+  hydration install + blocking-drain wait point land with the SSR slice."
+  []
+  (late-bind/set-fn! :ssr/extend-runtime-db-projection project-resources-runtime-db)
+  nil)
+
+(defn hydrate-resources!
+  "Install the allowed resource projection into the target frame-state's
+  `:rf.runtime/resources` slice on client hydration: preserve hydrated
+  entries, recompute `:tag-index` / `:owner-index` from `:entries`, avoid
+  duplicate fetches for fresh entries, background-refetch stale ones by
+  event, maintain frame + nav-token isolation, and surface server clock
+  skew in trace when freshness is ambiguous. Per Spec 016 §SSR and
+  hydration (client hydration) / §Restore and replay.
+
+  SKELETON: lands with the SSR slice. Named so the install path and the
+  restore/replay reconciliation (which shares the same install path) have
+  a stable home."
+  [_frame-id _projection]
+  (throw (ex-info ":rf.error/resource-not-implemented"
+                  {:rf.error/id :rf.error/resource-not-implemented
+                   :where       're-frame.resources.ssr/hydrate-resources!
+                   :recovery    :no-recovery
+                   :reason      (str "resource hydration install lands with the "
+                                     "EP-0003 SSR slice. This is the rf2-p10npe "
+                                     "artefact skeleton.")})))

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -1,0 +1,183 @@
+(ns re-frame.resources.state
+  "Resource runtime-db paths + the durable entry / work-record shapes.
+  Per Spec 016 §Cache home and write authority and §Frame work ledger.
+
+  SKELETON slice (rf2-p10npe): this namespace fixes the reserved
+  runtime-db key paths and the canonical durable shapes the runtime
+  reads/writes, plus the framework-write-authority registration-meta
+  stamp every resource event handler carries. The actual swaps over
+  these paths (entry transition function, work-ledger join/dedupe, host
+  side-table bookkeeping) land in the runtime slices (rf2-afpdkn /
+  rf2-pbxj48). The paths and shapes are pinned here so siblings agree on
+  one home.
+
+  Cache lives ONLY at `:rf.runtime/resources` inside the runtime-db
+  partition (`:rf.db/runtime`); the work ledger lives at
+  `:rf.runtime/work-ledger`. Both are reserved runtime-db keys (per
+  [Conventions §Reserved runtime-db keys]) — allocated lazily, per-frame
+  isolated, never an app-db location."
+  (:require [re-frame.late-bind :as late-bind]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- reserved runtime-db paths -------------------------------------------
+;;
+;; Inside runtime-db itself, framework code reads/writes the bare
+;; `[:rf.runtime/resources …]` paths; inside a full frame-state
+;; projection the resource subtree is at
+;; `[:rf.db/runtime :rf.runtime/resources …]`. Per Spec 016 §Cache home.
+
+(def resources-key
+  "The reserved runtime-db key for the resource cache subtree
+  (`:rf.runtime/resources`). Per Spec 016 §Cache home and write authority."
+  :rf.runtime/resources)
+
+(def work-ledger-key
+  "The reserved runtime-db key for the frame work ledger subtree
+  (`:rf.runtime/work-ledger`). Named neutrally — resources are its first
+  writer, later slices extend it to timers / streams / route loaders /
+  spawned actors / machine async work. Per Spec 016 §Frame work ledger."
+  :rf.runtime/work-ledger)
+
+(defn entries-path
+  "Runtime-db-relative path to the cache entries map
+  `{<scoped-resource-key> <entry>}`. Per Spec 016 §Cache home."
+  []
+  [resources-key :entries])
+
+(defn tag-index-path
+  "Runtime-db-relative path to the reverse tag index
+  `{<tag> #{<scoped-resource-key> …}}`. Recomputable-from-`:entries`
+  (rebuilt on restore/hydration, never trusted from the snapshot). Per
+  Spec 016 §Cache home / §Restore and replay."
+  []
+  [resources-key :tag-index])
+
+(defn owner-index-path
+  "Runtime-db-relative path to the reverse owner index
+  `{<owner> #{<scoped-resource-key> …}}`. Recomputable-from-`:entries`.
+  Per Spec 016 §Cache home / §Restore and replay."
+  []
+  [resources-key :owner-index])
+
+(defn entry-path
+  "Runtime-db-relative path to a single cache entry by its scoped
+  resource key `[cache-scope resource-id canonical-params]`. Per Spec 016
+  §Resource identity."
+  [scoped-resource-key]
+  [resources-key :entries scoped-resource-key])
+
+(defn work-record-path
+  "Runtime-db-relative path to a single work record by its `:work/id`.
+  Per Spec 016 §Frame work ledger."
+  [work-id]
+  [work-ledger-key work-id])
+
+;; ---- framework-write authority -------------------------------------------
+;;
+;; `:rf.runtime/resources` and `:rf.runtime/work-ledger` are framework-
+;; owned runtime-db children, so resource writes MUST mint framework-write
+;; authority — ordinary app authority is not enough. Every resource
+;; `reg-event-fx` registration site stamps this reserved registration-meta
+;; key so the runtime recognises a returned `:rf.db/runtime` effect from a
+;; resource handler as in-bounds (it governs only the
+;; `:rf.warning/app-handler-runtime-effect` ownership diagnostic — a
+;; convention, not a capability gate; Spec 002 Mike ruling #4). Mirrors
+;; routing's `framework-authority-meta`. Per Spec 016 §Write authority.
+
+(def framework-authority-meta
+  "Reserved registration-meta map (`{:rf/framework-authority? true}`)
+  stamped on every resource event handler so a returned runtime-db effect
+  is recognised as a framework write. Per Spec 016 §Write authority."
+  {:rf/framework-authority? true})
+
+;; ---- durable shapes (documentation-grade defaults) -----------------------
+;;
+;; These constructors fix the canonical durable shapes the runtime slices
+;; fill in. They allocate plain EDN — no host handles, which live OUTSIDE
+;; durable frame-state in side tables keyed by `[frame-id work-id]`.
+
+(def lifecycle-states
+  "The five resource lifecycle FSM states (cache-entry status). The
+  transition function over these states lands in the runtime slice
+  (rf2-pbxj48); pinned here so siblings agree on the closed set. Per
+  Spec 016 §Lifecycle is an FSM."
+  #{:idle :loading :fetching :loaded :error})
+
+(def terminal-work-statuses
+  "The terminal work-ledger statuses an attempt may reach. Terminal rows
+  are pruned on the linked entry's next successful transition (a small
+  bounded per-resource-key tail is retained for Xray). Per Spec 016
+  §Ledger row retention and identity."
+  #{:completed :failed :timed-out :suppressed :cancelled})
+
+(defn empty-entry
+  "Construct an empty `:idle` durable cache entry for `resource-id`. The
+  durable entry stores FACTS, not derived booleans (`:stale?` /
+  `:loading?` / `:has-data?` are public derived sub values, computed in
+  the subs layer, never stored). Per Spec 016 §Status semantics.
+
+  SKELETON: the runtime slices populate / transition this shape; this
+  constructor pins the canonical key set so an entry written by one
+  sibling reads correctly in another."
+  [resource-id]
+  {:resource/id    resource-id
+   :status         :idle
+   :data           nil
+   :error          nil
+   :refresh-error  nil
+   :loaded-at      nil
+   :stale-at       nil
+   :invalidated-at nil
+   :attempt        0
+   :generation     0
+   :request-id     nil
+   :current-work   nil
+   :tags           #{}
+   :active-owners  #{}})
+
+;; ---- host-side transient generation allocator (skeleton) ------------------
+;;
+;; Per Spec 016 §Restore and replay part 1: the generation allocator is a
+;; per-frame, HOST-SIDE monotonic high-water mark — never rewound by epoch
+;; restore, so a pre-restore in-flight reply's generation can never match a
+;; post-restore live entry (stale-suppression is structurally safe). This
+;; is deliberately the OPPOSITE discipline from machine spawn-ids (which
+;; never escape the frame and so may be snapshot-local).
+;;
+;; SKELETON: the allocator table + monotone bump land with the runtime
+;; slice (rf2-pbxj48). The host-side home is pinned here (a per-frame
+;; module-level atom, like routing's nav-counter cache) so the runtime and
+;; the frame-destroy teardown agree on where it lives.
+
+(defonce
+  ^{:doc "Per-frame host-side generation high-water marks
+   `{<frame-id> <int>}`. Host-side transient state (NOT runtime-db), so an
+   epoch restore cannot rewind it and recycle a generation — the
+   anti-recycling correctness boundary (Spec 016 §Restore and replay part
+   1). Populated by the runtime slice (rf2-pbxj48)."}
+  generation-cache
+  (atom {}))
+
+(defn release-frame!
+  "Drop the destroyed frame's host-side generation high-water mark.
+  Invoked by the resources frame-destroy teardown hook. Per Spec 016
+  §Stale and GC scheduling (frame destroy cancels all resource timers /
+  clears host handles for that frame) and §Restore and replay part 5."
+  [frame-id]
+  (swap! generation-cache dissoc frame-id)
+  nil)
+
+(defn reset-cache!
+  "Drop EVERY frame's host-side generation high-water mark (test
+  isolation). Published as a reset hook so the shared CLJS
+  `make-reset-runtime-fixture` reset-hooks table clears it per test (it is
+  host-side transient state, not cleared by the runtime/frames reset)."
+  []
+  (reset! generation-cache {})
+  nil)
+
+;; A no-op consult of late-bind so the require is load-bearing even in the
+;; skeleton (the runtime slice will consult `:router/dispatch!` etc. from
+;; here). Keeps the ns honest about its dependency surface.
+(defn ^:private _late-bind-touch [] (late-bind/get-fn :router/dispatch!))

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -1,0 +1,181 @@
+(ns re-frame.resources.subs
+  "The passive resource subscriptions — the read API over the resource
+  cache. Per Spec 016 §Public API §Subscriptions (passive) and §Status
+  semantics.
+
+  Subscriptions are PURE passive reads (Spec 016: \"No v1 subscription
+  fetches\"): a view reads a resource through `[:rf.resource/state …]` (or
+  a narrower projection like `[:rf.resource/data …]`); route entry,
+  events, and machines CAUSE the fetch. A resource sub resolves its scope
+  per Spec 016 §Subscription-side scope resolution (payload `:scope`, or a
+  sub-resolvable spec policy) and raises
+  `:rf.error/resource-sub-unresolved-scope` rather than reading global or
+  returning a silent `:idle` — the read-side counterpart of the write-side
+  fail-closed gate.
+
+  The framework resource subs read the frame's RUNTIME-DB projection
+  (`reg-runtime-sub`) — the durable cache lives at
+  `[:rf.runtime/resources :entries <scoped-resource-key>]` in runtime-db.
+  The derived booleans (`:stale?` / `:loading?` / `:fetching?` /
+  `:has-data?`) are PUBLIC DERIVED SUB VALUES computed here from the
+  durable entry facts, NOT stored on the entry (Spec 016 §Status
+  semantics).
+
+  SKELETON slice (rf2-p10npe): the sub registrations are real and the
+  projection shapes are pinned, but scope resolution + params
+  canonicalization (which compute the scoped resource key the entry is
+  looked up under) land with the runtime slice (rf2-pbxj48). Until then
+  `resolve-scoped-key` returns nil and the projections degrade to the
+  documented empty-state shape — the subs compile, load, and read cleanly;
+  they just have no live entry to project yet."
+  (:require [re-frame.resources.state :as state]
+            [re-frame.subs :as subs]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- scoped-key resolution (skeleton) ------------------------------------
+
+(defn resolve-scoped-key
+  "Resolve the `{:resource :scope :params}` sub payload to the scoped
+  resource key `[cache-scope resource-id canonical-params]` the cache
+  entry is stored under — canonicalizing the scope + params maps (Spec
+  016 §Canonicalization rule) and applying the sub-side scope-resolution
+  precedence (Spec 016 §Subscription-side scope resolution).
+
+  SKELETON: returns nil (no live key resolution yet). The runtime slice
+  (rf2-pbxj48) supplies canonicalization + sub-side scope resolution and
+  the fail-closed `:rf.error/resource-sub-unresolved-scope` raise. With a
+  nil key the projections below return the documented empty-state shape."
+  [_payload]
+  nil)
+
+(defn- entry-for
+  "Look up the durable cache entry for a sub payload, or nil when no
+  scoped key resolves yet (skeleton) or no entry exists."
+  [runtime-db payload]
+  (when-let [k (resolve-scoped-key payload)]
+    (get-in runtime-db (state/entry-path k))))
+
+;; ---- the projections (public derived sub values) -------------------------
+
+(defn state-sub-fn
+  "Project the public `:rf.resource/state` view-model from a durable
+  entry: the stored facts plus the DERIVED booleans (`:loading?` /
+  `:fetching?` / `:stale?` / `:has-data?`) computed here, never stored.
+  Per Spec 016 §Status semantics. Empty-state shape when no entry."
+  [runtime-db [_id payload]]
+  (let [e (entry-for runtime-db payload)]
+    (if (nil? e)
+      ;; No entry yet — the documented idle empty-state projection.
+      {:status :idle :data nil :error nil :refresh-error nil
+       :loading? false :fetching? false :stale? false :has-data? false}
+      {:status        (:status e)
+       :data          (:data e)
+       :error         (:error e)
+       :refresh-error (:refresh-error e)
+       ;; Derived (Spec 016 §Status semantics): :loading? = first load
+       ;; with no usable data; :fetching? = refresh in flight; :has-data? =
+       ;; usable data present; :stale? = freshness vs :stale-at (runtime
+       ;; slice computes the live clock comparison — pinned shape here).
+       :loading?      (= :loading (:status e))
+       :fetching?     (= :fetching (:status e))
+       :stale?        false
+       :has-data?     (some? (:data e))})))
+
+(defn data-sub-fn
+  "Project `:rf.resource/data` — the entry's last-known-good `:data` (or
+  nil). Per Spec 016 §Subscriptions."
+  [runtime-db [_id payload]]
+  (:data (entry-for runtime-db payload)))
+
+(defn status-sub-fn
+  "Project `:rf.resource/status` — the entry's `:status` keyword (or
+  `:idle` when no entry). Per Spec 016 §Subscriptions."
+  [runtime-db [_id payload]]
+  (or (:status (entry-for runtime-db payload)) :idle))
+
+(defn loading?-sub-fn
+  "Project `:rf.resource/loading?` — first load with no usable data. Per
+  Spec 016 §Status semantics."
+  [runtime-db [_id payload]]
+  (= :loading (:status (entry-for runtime-db payload))))
+
+(defn fetching?-sub-fn
+  "Project `:rf.resource/fetching?` — work in flight while prior data
+  stays visible. Per Spec 016 §Status semantics."
+  [runtime-db [_id payload]]
+  (= :fetching (:status (entry-for runtime-db payload))))
+
+(defn stale?-sub-fn
+  "Project `:rf.resource/stale?` — freshness orthogonal to load status
+  (a `:loaded` entry may be stale). Per Spec 016 §Status semantics.
+  SKELETON: returns false until the runtime slice computes the live
+  `:stale-at` comparison."
+  [_runtime-db [_id _payload]]
+  false)
+
+(defn error-sub-fn
+  "Project `:rf.resource/error` — the first-load error envelope (or nil).
+  Per Spec 016 §Status semantics."
+  [runtime-db [_id payload]]
+  (:error (entry-for runtime-db payload)))
+
+(defn refresh-error-sub-fn
+  "Project `:rf.resource/refresh-error` — a failed background refresh
+  (prior data kept). Per Spec 016 §Status semantics."
+  [runtime-db [_id payload]]
+  (:refresh-error (entry-for runtime-db payload)))
+
+(defn has-data?-sub-fn
+  "Project `:rf.resource/has-data?` — usable data present. Per Spec 016
+  §Status semantics."
+  [runtime-db [_id payload]]
+  (some? (:data (entry-for runtime-db payload))))
+
+(defn previous-data-sub-fn
+  "Project `:rf.resource/previous-data` — the prior key's data projected
+  while a new page/filter resource first-loads under `:keep-previous?`.
+  NOT inserted into the new entry. Per Spec 016 §Paginated and previous
+  data. SKELETON: returns nil until the runtime slice tracks previous
+  keys."
+  [_runtime-db [_id _payload]]
+  nil)
+
+;; ---- registration helper -------------------------------------------------
+
+(defn register-subs!
+  "Register the `:rf.resource/*` passive sub family. Called from the
+  `re-frame.resources` façade so a `(require … :reload)` on a fresh
+  registrar re-wires them. Per Spec 016 §Subscriptions."
+  []
+  (subs/reg-runtime-sub :rf.resource/state
+    {:doc "Passive read of a resource instance's full view-model `{:status :data :error :refresh-error :loading? :fetching? :stale? :has-data?}`. Resolves scope per Spec 016 §Subscription-side scope resolution; raises :rf.error/resource-sub-unresolved-scope rather than reading global / returning a silent :idle. Per Spec 016 §Subscriptions."}
+    state-sub-fn)
+  (subs/reg-runtime-sub :rf.resource/data
+    {:doc "Passive read of a resource instance's last-known-good :data (or nil). Per Spec 016 §Subscriptions."}
+    data-sub-fn)
+  (subs/reg-runtime-sub :rf.resource/status
+    {:doc "Passive read of a resource instance's :status keyword (:idle / :loading / :fetching / :loaded / :error). Per Spec 016 §Subscriptions."}
+    status-sub-fn)
+  (subs/reg-runtime-sub :rf.resource/loading?
+    {:doc "Passive read: true iff a resource instance is on its first load with no usable data. Per Spec 016 §Status semantics."}
+    loading?-sub-fn)
+  (subs/reg-runtime-sub :rf.resource/fetching?
+    {:doc "Passive read: true iff a resource instance is refreshing while prior data stays visible. Per Spec 016 §Status semantics."}
+    fetching?-sub-fn)
+  (subs/reg-runtime-sub :rf.resource/stale?
+    {:doc "Passive read: true iff a resource instance is stale (freshness is orthogonal to load status). Per Spec 016 §Status semantics."}
+    stale?-sub-fn)
+  (subs/reg-runtime-sub :rf.resource/error
+    {:doc "Passive read of a resource instance's first-load error envelope (or nil). Per Spec 016 §Status semantics."}
+    error-sub-fn)
+  (subs/reg-runtime-sub :rf.resource/refresh-error
+    {:doc "Passive read of a resource instance's background-refresh error envelope (or nil); the prior :data is kept. Per Spec 016 §Status semantics."}
+    refresh-error-sub-fn)
+  (subs/reg-runtime-sub :rf.resource/has-data?
+    {:doc "Passive read: true iff a resource instance currently has usable :data. Per Spec 016 §Status semantics."}
+    has-data?-sub-fn)
+  (subs/reg-runtime-sub :rf.resource/previous-data
+    {:doc "Passive read of the prior key's data, projected while a new page/filter resource first-loads under :keep-previous? (not inserted into the new entry). Per Spec 016 §Paginated and previous data."}
+    previous-data-sub-fn)
+  nil)

--- a/implementation/resources/src/re_frame/resources/test_support.cljc
+++ b/implementation/resources/src/re_frame/resources/test_support.cljc
@@ -1,0 +1,54 @@
+(ns re-frame.resources.test-support
+  "Test-support namespace for the resources artefact (Spec 016).
+
+  This namespace is the home for resources test-only fixtures and reset
+  helpers — kept OUT of the always-on `re-frame.resources` production
+  façade so a test-runner-internal surface never reaches a production
+  registry (the rf2-dbiv8 / rf2-cdmle posture: test fixtures live behind
+  an explicit test-support require, mirroring
+  `re-frame.routing.test-support` and `re-frame.http-test-support`).
+
+  Production posture: this namespace is unreferenced from any production
+  module, so CLJS `:advanced` trims it wholesale and JVM/SSR sees
+  classpath absence through the normal artefact-require boundary.
+
+  ## What lives here
+
+  - `reset-resources!` — the per-test reset thunk the shared CLJS
+    `make-reset-runtime-fixture` reset-hooks table fires (via the
+    `:resources/reset-resources!` late-bind hook the façade publishes):
+    clears the `:resource`-kind registrar entries and the host-side
+    transient generation high-water marks (which are NOT runtime-db
+    state, so a runtime/frames reset does not clear them).
+
+  SKELETON slice (rf2-p10npe): the reset helper clears the registrar +
+  host-side generation cache; the canned-transport stub fixtures (the
+  resources analogue of the managed-HTTP canned stubs — for deterministic
+  ensure/refetch replay without a live Fetch) land with the runtime +
+  managed-HTTP slices, behind this same test-support require."
+  (:require [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.resources.registry :as registry]
+            [re-frame.resources.state :as state]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn reset-resources!
+  "Per-test reset: clear every `:resource`-kind registrar entry and the
+  host-side transient generation high-water marks. Fired by the shared
+  CLJS `make-reset-runtime-fixture` reset-hooks table via the
+  `:resources/reset-resources!` late-bind hook this namespace publishes
+  at ns-load (kept behind this explicit test-support require so the
+  production façade carries no test-fixture surface — rf2-dbiv8). Per
+  Spec 016 (test isolation)."
+  []
+  (registrar/clear-kind! registry/resource-kind)
+  (state/reset-cache!)
+  nil)
+
+;; Publish the reset hook from this test-support ns-load — the shared CLJS
+;; make-reset-runtime-fixture reset-hooks table consults
+;; `:resources/reset-resources!` by key and no-ops when this namespace is
+;; absent (production builds never load it). Mirrors the
+;; re-frame.routing.test-support / re-frame.http-test-support posture.
+(late-bind/set-fn! :resources/reset-resources! reset-resources!)

--- a/implementation/resources/src/re_frame/resources/transport.cljc
+++ b/implementation/resources/src/re_frame/resources/transport.cljc
@@ -1,0 +1,60 @@
+(ns re-frame.resources.transport
+  "Transport-neutral seam between the resource runtime and the concrete
+  read transport. Per Spec 016 §Transport.
+
+  The initial scope ships a SINGLE built-in transport — `:rf.http/managed`
+  (Spec 014). The resource lifecycle, cache identity, owner model,
+  stale/fresh policy, invalidation, SSR hydration, and Xray surfaces are
+  nonetheless transport-NEUTRAL: the core assumes no URL, HTTP method,
+  status code, or body, so the deferred GraphQL transport (and any later
+  transport) can plug in without weakening the core semantics. This
+  namespace holds that neutral seam; the HTTP lowering itself lives in the
+  sibling `re-frame.resources.transport.http`.
+
+  SKELETON slice (rf2-p10npe): the transport dispatch is named; the
+  ensure/refetch → work-ledger-record → managed-HTTP lowering lands with
+  the runtime + managed-HTTP slices."
+  (:require [re-frame.resources.transport.http :as http]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(def managed-http-transport
+  "The only initial-scope transport id (`:rf.http/managed`, Spec 014).
+  Per Spec 016 §Transport."
+  :rf.http/managed)
+
+(def default-transport
+  "The default `:transport` for a resource that does not declare one —
+  managed HTTP. Per Spec 016 §Resource registration spec (optional
+  `:transport`, initial scope: `:rf.http/managed`, the only built-in)."
+  managed-http-transport)
+
+(defn lower-ensure
+  "Lower an ensure/refetch into the resource's declared transport — the
+  transport-neutral entry point the runtime calls after it has created or
+  joined a work-ledger record. Dispatches on `transport`; the only
+  initial-scope target is `:rf.http/managed` (delegates to
+  `re-frame.resources.transport.http/lower`).
+
+  Per Spec 016 §Transport: the runtime owns reply addressing and request
+  correlation; the internal reply payloads stamp the qualified
+  `:rf.frame/id`, `:work-id`, `:resource-key`, `:scope`, and
+  `:generation`, and success/failure handlers MUST verify frame + work-id
+  + generation before writing (cancellation is an optimization; stale
+  suppression is the correctness boundary).
+
+  SKELETON: delegates the shape; the runtime slice supplies the live
+  ensure-context."
+  [transport ensure-ctx]
+  (let [transport (or transport default-transport)]
+    (if (= transport managed-http-transport)
+      (http/lower ensure-ctx)
+      (throw (ex-info ":rf.error/resource-unknown-transport"
+                      {:rf.error/id :rf.error/resource-unknown-transport
+                       :where       're-frame.resources.transport/lower-ensure
+                       :recovery    :fix-registration
+                       :reason      (str "unknown resource transport " transport
+                                         " — the only initial-scope transport is "
+                                         managed-http-transport
+                                         " (Spec 016 §Transport).")
+                       :transport   transport})))))

--- a/implementation/resources/src/re_frame/resources/transport/http.cljc
+++ b/implementation/resources/src/re_frame/resources/transport/http.cljc
@@ -1,0 +1,107 @@
+(ns re-frame.resources.transport.http
+  "The managed-HTTP read transport for resources — the single built-in
+  transport in the initial scope. Per Spec 016 §Transport.
+
+  The resource runtime first creates or joins a work-ledger record, then
+  lowers an ensure/refetch into managed HTTP (`:rf.http/managed`, Spec
+  014), supplying `:request-id` / `:on-success` / `:on-failure` itself
+  from the scoped resource key and current generation:
+
+      [:rf.http/managed
+       (assoc http-args
+              :request-id  request-id
+              :on-success  [:rf.resource.internal/succeeded
+                            {:work-id … :resource-key … :scope …
+                             :rf.frame/id … :generation …}]
+              :on-failure  [:rf.resource.internal/failed
+                            {:work-id … :resource-key … :scope …
+                             :rf.frame/id … :generation …}])]
+
+  The managed-HTTP artefact (`day8/re-frame2-http`, `re-frame.http-managed`)
+  is reached LATE-BOUND — resources never statically `:require`s it, so an
+  app that loads resources but issues no HTTP-backed reads (or supplies a
+  later transport) does not drag the HTTP body. The runtime emits the
+  `:rf.http/managed` fx through the ordinary effect path; this namespace
+  builds the args map (request-id + reply addressing).
+
+  SKELETON slice (rf2-p10npe): the lowering shape is named; the live
+  request-id minting + work-ledger correlation land with the managed-HTTP
+  + runtime slices."
+  (:require [re-frame.late-bind :as late-bind]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(def managed-http-fx
+  "The reserved fx-id the resource runtime emits to issue a managed-HTTP
+  read (`:rf.http/managed`, Spec 014). Per Spec 016 §Transport."
+  :rf.http/managed)
+
+(def succeeded-reply
+  "The framework-internal success reply event id. Per Spec 016 §Events
+  (the internal replies) — user code MUST NOT dispatch it."
+  :rf.resource.internal/succeeded)
+
+(def failed-reply
+  "The framework-internal failure reply event id. Per Spec 016 §Events —
+  user code MUST NOT dispatch it."
+  :rf.resource.internal/failed)
+
+(defn build-managed-args
+  "Build the `:rf.http/managed` args map for a resource ensure/refetch:
+  the resource's `:request` (a Spec 014 managed-HTTP args map) with the
+  runtime-owned `:request-id` and the `:on-success` / `:on-failure`
+  internal reply addressing assoc'd in. Per Spec 016 §Transport.
+
+  The reply payloads stamp the qualified `:rf.frame/id` (the canonical
+  carried frame stamp, EP-0002 R3) — matching the `:work/frame` stamp on
+  the ledger record — plus `:work-id`, `:resource-key`, `:scope`, and
+  `:generation` so the reply handlers can verify frame + work-id +
+  generation before writing (stale suppression is the correctness
+  boundary). An app `:request` that supplies `:request-id` / `:on-success`
+  / `:on-failure` itself is rejected (it would bypass stale suppression).
+
+  SKELETON: builds the args shape; the live request-id + work correlation
+  are supplied by the runtime slice via `ensure-ctx`."
+  [{:keys [http-args request-id work-id resource-key scope frame-id generation]}]
+  (let [reply-payload {:work-id      work-id
+                       :resource-key resource-key
+                       :scope        scope
+                       :rf.frame/id  frame-id
+                       :generation   generation}]
+    (assoc http-args
+           :request-id request-id
+           :on-success [succeeded-reply reply-payload]
+           :on-failure [failed-reply reply-payload])))
+
+(defn lower
+  "Lower a resource ensure/refetch into managed HTTP. Builds the
+  `:rf.http/managed` args (`build-managed-args`) and returns the fx pair
+  `[:rf.http/managed args]` the runtime threads into its `:fx` vector.
+
+  Per Spec 016 §Transport. The managed-HTTP artefact is reached
+  late-bound (a require-time check) so resources carries no static dep on
+  it; an app that omits `day8/re-frame2-http` while issuing an HTTP-backed
+  resource read gets a structured artefact-missing error rather than an
+  opaque no-handler.
+
+  SKELETON slice (rf2-p10npe): returns the fx-pair SHAPE from the
+  ensure-context; the live ensure-context (request-id, work-id, scoped
+  key, generation) is assembled by the runtime slice (rf2-pbxj48). Until
+  the runtime lands, calling this directly with an incomplete ctx is a
+  programming error."
+  [ensure-ctx]
+  ;; Defense-in-depth: surface the managed-HTTP feature presence through
+  ;; the always-published feature probe (consult ≠ static require). The
+  ;; runtime slice will use this to fail-closed with a clear
+  ;; artefact-missing error when an HTTP-backed read is issued without
+  ;; the HTTP artefact on the classpath.
+  (when-not (late-bind/get-fn :http/abort-on-actor-destroy)
+    (throw (ex-info ":rf.error/http-artefact-missing"
+                    {:rf.error/id :rf.error/http-artefact-missing
+                     :where       're-frame.resources.transport.http/lower
+                     :recovery    :no-recovery
+                     :reason      (str "an HTTP-backed resource read requires "
+                                       "day8/re-frame2-http on the classpath; "
+                                       "add it to deps and require "
+                                       "re-frame.http-managed at app boot.")})))
+  [managed-http-fx (build-managed-args ensure-ctx)])

--- a/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
@@ -1,0 +1,148 @@
+(ns re-frame.resources-skeleton-cljs-test
+  "Skeleton smoke tests for the Resources artefact (rf2-p10npe, Spec 016
+  §EP-0003 slice 2 — the artefact SKELETON).
+
+  This slice ships the public surface + the wiring, NOT the runtime logic.
+  These tests lock what the skeleton GUARANTEES:
+
+    1. the artefact ns loads cleanly (the require itself is the smoke);
+    2. `reg-resource` registers under the `:resource` registrar kind, and
+       the registry introspection accessors read it back;
+    3. the REQUIRED, fail-closed `:scope` policy is enforced at
+       registration (`:rf.error/resource-missing-scope-policy`);
+    4. the `:resource` registrar kind is in the core registrar's closed
+       kind set, and `:query` is NOT;
+    5. the feature probe (`:resources/reg-resource`) is published, so
+       `(rf/feature-loaded? :resources)` is true;
+    6. the public-API late-bind hooks are published;
+    7. the passive `:rf.resource/*` subs are registered;
+    8. the resource event handlers are registered (their skeleton bodies
+       raise `:rf.error/resource-not-implemented` — a later slice fills
+       them in);
+    9. the late-bound routing accepted-key extension accepts `:resources`.
+
+  Runtime BEHAVIOUR (entry transitions, work ledger, stale suppression,
+  GC, invalidation, hydration) is out of scope here — those land with the
+  runtime slices."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.features :as features]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.resources :as resources]
+            ;; The route + ssr siblings carry the late-bound integration
+            ;; publication; the façade transitively loads them, but require
+            ;; them explicitly so a hostile load-order can't hide a miss.
+            [re-frame.resources.route :as route]
+            [re-frame.resources.registry :as registry]
+            [re-frame.routing.registry :as routing-registry]))
+
+(defn- valid-spec
+  "A minimal, valid resource spec — the three REQUIRED keys (Spec 016
+  §Resource registration spec)."
+  []
+  {:doc           "test resource"
+   :scope         :rf.scope/global
+   :params-schema [:map [:slug :string]]
+   :request       (fn [_params _ctx]
+                    {:request {:method :get :url "/api/x"}})})
+
+(use-fixtures :each
+  {:before (fn [] (registrar/clear-kind! :resource))
+   :after  (fn [] (registrar/clear-kind! :resource))})
+
+(deftest artefact-loads
+  (testing "the resources façade ns loaded (the require is the smoke)"
+    (is (fn? resources/reg-resource))
+    (is (fn? resources/clear-resource))
+    (is (fn? resources/resource-meta))
+    (is (fn? resources/resources))))
+
+(deftest reg-resource-registers-under-resource-kind
+  (testing "reg-resource writes a :resource-kind registrar entry"
+    (resources/reg-resource :test/article (valid-spec))
+    (is (contains? (registrar/registrations :resource) :test/article))
+    (is (= :test/article (first (resources/resource-ids))))
+    (testing "resource-meta reads the spec back"
+      (is (= "test resource" (:doc (resources/resource-meta :test/article))))
+      (is (= :rf.scope/global (:scope (resources/resource-meta :test/article)))))
+    (testing "clear-resource removes the entry"
+      (resources/clear-resource :test/article)
+      (is (not (contains? (registrar/registrations :resource) :test/article))))))
+
+(deftest scope-policy-is-required-fail-closed
+  (testing "reg-resource with no :scope throws :rf.error/resource-missing-scope-policy"
+    (is (thrown-with-msg?
+          js/Error #"resource-missing-scope-policy"
+          (resources/reg-resource :test/no-scope
+                                  (dissoc (valid-spec) :scope)))))
+  (testing "reg-resource with no :params-schema throws"
+    (is (thrown-with-msg?
+          js/Error #"invalid-resource-spec"
+          (resources/reg-resource :test/no-params
+                                  (dissoc (valid-spec) :params-schema)))))
+  (testing "reg-resource with no :request throws"
+    (is (thrown-with-msg?
+          js/Error #"invalid-resource-spec"
+          (resources/reg-resource :test/no-request
+                                  (dissoc (valid-spec) :request))))))
+
+(deftest resource-kind-in-closed-set
+  (testing ":resource is a valid registrar kind"
+    (is (registrar/valid-kind? :resource))
+    (is (contains? registrar/kinds :resource)))
+  (testing ":query is NOT a registrar kind (deliberate — Spec 016)"
+    (is (not (registrar/valid-kind? :query)))
+    (is (not (contains? registrar/kinds :query)))))
+
+(deftest feature-probe-published
+  (testing "the :resources feature is loaded? (the probe key is published)"
+    (is (some? (late-bind/get-fn :resources/reg-resource)))
+    (is (true? (features/feature-loaded? :resources)))
+    (is (= "day8/re-frame2-resources" (:maven (:resources (features/features)))))))
+
+(deftest public-api-hooks-published
+  (testing "every public-API late-bind hook resolves"
+    (doseq [k [:resources/reg-resource :resources/clear-resource
+               :resources/resource-meta :resources/resource-state
+               :resources/resources]]
+      (is (some? (late-bind/get-fn k)) (str k " should be published")))))
+
+(deftest resource-subs-registered
+  (testing "the passive :rf.resource/* sub family is registered"
+    (doseq [sub-id [:rf.resource/state :rf.resource/data :rf.resource/status
+                    :rf.resource/loading? :rf.resource/fetching?
+                    :rf.resource/stale? :rf.resource/error
+                    :rf.resource/refresh-error :rf.resource/has-data?
+                    :rf.resource/previous-data]]
+      (is (some? (registrar/lookup :sub sub-id))
+          (str sub-id " sub should be registered")))))
+
+(deftest resource-events-registered
+  (testing "the :rf.resource/* event family is registered"
+    (doseq [event-id [:rf.resource/ensure :rf.resource/refetch
+                      :rf.resource/invalidate-tags :rf.resource/release-owner
+                      :rf.resource/clear-scope :rf.resource/remove
+                      :rf.resource.internal/succeeded :rf.resource.internal/failed
+                      :rf.resource.internal/aborted :rf.resource.internal/gc-fired
+                      :rf.resource.internal/stale-suppressed]]
+      (is (some? (registrar/lookup :event event-id))
+          (str event-id " event should be registered"))))
+  (testing "every resource handler carries framework-write authority"
+    (is (true? (:rf/framework-authority? (registrar/lookup :event :rf.resource/ensure))))))
+
+(deftest late-bound-routing-accepts-resources-key
+  (testing "the :routing/extra-route-keys hook publishes #{:resources}"
+    (is (= #{:resources} ((late-bind/get-fn :routing/extra-route-keys)))))
+  (testing "routing's accepted-key extension lets a route carry :resources"
+    ;; routing.registry/reg-route validates bare metadata keys; with the
+    ;; resources extension loaded, :resources is accepted (it would
+    ;; otherwise throw :rf.error/invalid-route-metadata).
+    (registrar/clear-kind! :route)
+    (is (= :test/route
+           (routing-registry/reg-route
+             :test/route
+             {:path      "/x/:slug"
+              :params    [:map [:slug :string]]
+              :resources [{:resource :test/article
+                           :params   (fn [route] {:slug (get-in route [:params :slug])})}]})))
+    (registrar/clear-kind! :route)))

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -148,6 +148,25 @@
     ;; cross-feature: SSR head selection (Spec 011 §Head/meta contract)
     :head})
 
+(defn- accepted-route-keys
+  "The full set of accepted bare route-metadata keys: the routing-owned
+  `reserved-route-keys` UNIONed with any LATE-BOUND cross-feature
+  extension keys published under `:routing/extra-route-keys`.
+
+  Per Spec 012 §Reserved route-metadata keys, routing rejects unknown
+  bare route-metadata keys at registration. A cross-feature artefact
+  (e.g. the Resources artefact's `:resources` key, Spec 016 §Route
+  integration) extends the accepted set via this late-bound framework
+  extension — exactly as `:head` is a cross-feature key owned by SSR.
+  The hook publishes a SET of extra keys; resources is the first
+  publisher (rf2-p10npe). When no extension artefact is loaded the hook
+  is absent and the set is exactly the routing-owned reserved keys, so an
+  app without resources/SSR sees no behaviour change."
+  []
+  (if-let [extra (late-bind/get-fn :routing/extra-route-keys)]
+    (into reserved-route-keys (extra))
+    reserved-route-keys))
+
 (defn- validate-route-metadata!
   "Authoring-boundary guardrail for `reg-route` (rf2-45b95). Throws
   `:rf.error/invalid-route-metadata` (canonical thrown-error shape, per
@@ -169,10 +188,11 @@
              'rf/reg-route
              (str "route " id "'s metadata must be a map, got " (pr-str (type metadata)))
              {:route-id id :value metadata})))
-  (let [bad (into []
+  (let [accepted (accepted-route-keys)
+        bad (into []
                   (comp (map key)
                         (remove qualified-keyword?)
-                        (remove reserved-route-keys))
+                        (remove accepted))
                   metadata)]
     (when (seq bad)
       (throw (route-error
@@ -183,11 +203,11 @@
                     (str/join ", " (map pr-str bad))
                     " — bare keys outside the reserved set are rejected as likely "
                     "typos (e.g. :on-matched for :on-match). Reserved keys: "
-                    (str/join ", " (map pr-str (sort reserved-route-keys)))
+                    (str/join ", " (map pr-str (sort accepted)))
                     ". Host/app extension keys must be namespaced (e.g. :myapp/analytics-id).")
                {:route-id id
                 :keys     bad
-                :reserved reserved-route-keys})))))
+                :reserved accepted})))))
 
 ;; ---- registration --------------------------------------------------------
 

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -103,6 +103,15 @@
                 "ssr-ring/test"
                 "epoch/src"
                 "epoch/test"
+                ;; rf2-p10npe — the optional Resources artefact (Spec 016,
+                ;; EP-0003 slice 2). Source + test paths added so the
+                ;; consolidated :node-test build picks up the resources
+                ;; ns's + any `*-cljs-test` suites under resources/test/.
+                ;; Skeleton slice; runtime logic lands in later slices.
+                ;; Bundle-isolation holds: nothing under tools/ is
+                ;; required, and core never :requires re-frame.resources.
+                "resources/src"
+                "resources/test"
                 ;; rf2-3cfvt — adversarial-property SECURITY tier. A small
                 ;; cross-artefact test tree probing the three security
                 ;; boundaries the pin-and-assert regime missed: SSR escaping

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -363,7 +363,23 @@
                   (assoc :rf.runtime/elision (:rf.runtime/elision runtime-db))
 
                   (contains? runtime-db :rf.runtime/ssr)
-                  (assoc :rf.runtime/ssr (:rf.runtime/ssr runtime-db)))]
+                  (assoc :rf.runtime/ssr (:rf.runtime/ssr runtime-db)))
+          ;; LATE-BOUND cross-subsystem projection extension. A
+          ;; cross-feature artefact (e.g. Resources, Spec 016 §SSR and
+          ;; hydration) contributes its OWN durable runtime-db slice
+          ;; projection — the allowlist-by-subsystem-child hook the spec
+          ;; names — without SSR statically `:require`ing it. The hook
+          ;; takes the full runtime-db value and returns a `{subsystem-key
+          ;; durable-projection}` map merged into the slice; absent hook
+          ;; (no extension artefact loaded) contributes nothing, so an
+          ;; app without resources sees no behaviour change. Resources is
+          ;; the first publisher (rf2-p10npe): it projects ONLY the
+          ;; durable `:entries` of `:rf.runtime/resources` (the
+          ;; `:tag-index` / `:owner-index` are recomputable-from-entries
+          ;; and need not ride the wire — Spec 016 §Restore and replay).
+          slice (if-let [extend-fn (late-bind/get-fn :ssr/extend-runtime-db-projection)]
+                  (merge slice (extend-fn runtime-db))
+                  slice)]
       (when (seq slice) slice))))
 
 ;; ---- version resolution + payload assembly -------------------------------

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -297,6 +297,21 @@
   ["re-frame.core" "reg-head"]            {:tier :advanced    :owner "011" :status "v1"}
   ["re-frame.core" "reg-error-projector"] {:tier :advanced    :owner "011" :status "v1"}
   ["re-frame.core" "reg-http-interceptor"] {:tier :advanced   :owner "014" :status "v1 (optional capability)"}
+  ;; Resources — optional-artefact public-API wrappers (rf2-p10npe, Spec
+  ;; 016, EP-0003 slice 2). The `re-frame.core` façade exports delegate
+  ;; through the late-bind table to `day8/re-frame2-resources`; an app
+  ;; that omits the artefact sees a clean
+  ;; `:rf.error/resources-artefact-missing`. Registration (`reg-resource`)
+  ;; + registration-lifecycle (`clear-resource`) + introspection
+  ;; (`resource-meta` / `resource-state` / `resources`). The producing
+  ;; `re-frame.resources` namespace is not yet introspected by the
+  ;; generator (its runtime surface lands with the later slices); these
+  ;; façade rows govern the public wrappers that ship now.
+  ["re-frame.core" "reg-resource"]        {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.core" "clear-resource"]      {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.core" "resource-meta"]       {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.core" "resource-state"]      {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.core" "resources"]           {:tier :advanced :owner "016" :status "v1 (optional capability)"}
   ;; Clearing registrations (spec/API.md §Clearing registrations).
   ["re-frame.core" "clear-event"]         {:tier :advanced :owner "002" :status "v1 (preserved)"}
   ["re-frame.core" "clear-sub"]           {:tier :advanced :owner "002" :status "v1 (preserved)"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 488,
+ :var-count 493,
  :tier-vocab
  [:front-porch
   :advanced
@@ -84,6 +84,7 @@
   {:namespace "re-frame.core", :var "clear-fx", :tier :advanced, :kind :fn, :owner "002", :status "v1 (preserved)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "clear-http-interceptor", :tier :advanced, :kind :fn, :owner "014", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "clear-listeners!", :tier :tooling, :kind :fn, :owner "009", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "clear-resource", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "clear-sub", :tier :advanced, :kind :fn, :owner "002", :status "v1 (preserved)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "clear-sub-cache!", :tier :advanced, :kind :fn, :owner "002", :status "v1 (preserved)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "clear-trace-buffer!", :tier :tooling, :kind :fn, :owner "009", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
@@ -160,6 +161,7 @@
   {:namespace "re-frame.core", :var "reg-http-interceptor", :tier :advanced, :kind :macro, :owner "014", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reg-machine", :tier :advanced, :kind :macro, :owner "005", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reg-machine*", :tier :advanced, :kind :fn, :owner "005", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "reg-resource", :tier :advanced, :kind :macro, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reg-route", :tier :advanced, :kind :macro, :owner "012", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reg-sub", :tier :front-porch, :kind :macro, :owner "002", :status "v1 (preserved + extended)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reg-view", :tier :front-porch, :kind :macro, :owner "004", :status "v1", :facade? true, :runtime-verified? true}
@@ -179,6 +181,9 @@
   {:namespace "re-frame.core", :var "require-feature!", :tier :advanced, :kind :fn, :owner "Conventions", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reset-app-db!", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reset-frame!", :tier :advanced, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "resource-meta", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "resource-state", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "resources", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "restore-epoch", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "route-link", :tier :advanced, :kind :fn, :owner "012", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "route-url", :tier :advanced, :kind :fn, :owner "012", :status "v1", :facade? true, :runtime-verified? true}


### PR DESCRIPTION
## rf2-p10npe — Resources artefact SKELETON (EP-0003 slice 2)

First real-code slice for Spec 016 Resources. Ships the public surface, the registrar kind, the feature probe, and the late-bound routing/SSR/HTTP wiring — **not** the runtime logic. Later slices (rf2-afpdkn work-ledger substrate, rf2-pbxj48 resource runtime, …) fill the runtime; skeleton stub bodies raise `:rf.error/resource-not-implemented` so a premature call fails loudly rather than silently no-opping.

### Artefact layout (new `implementation/resources/`)

`deps.edn` (depends on core only; routing/ssr/http/schemas are test-only deps), `LICENSE`, plus `src/re_frame/`:

- `resources.cljc` — public boot point / façade; re-exports, event/sub registrations, late-bound integration installs, late-bind hook publication
- `resources/state.cljc` — reserved runtime-db paths (`:rf.runtime/resources` / `:rf.runtime/work-ledger`), durable entry/work shapes, the host-side monotonic generation allocator, the framework-write-authority stamp
- `resources/registry.cljc` — `reg-resource` / `clear-resource` + the `:resource` registrar kind + fail-closed `:scope`-policy validation + registry introspection
- `resources/events.cljc` — the `:rf.resource/*` causal event handlers + `:rf.resource.internal/*` reply handlers (registered, bodies stubbed)
- `resources/subs.cljc` — the 10 passive `:rf.resource/*` subs (real projections over the durable entry; derived booleans computed, not stored)
- `resources/transport.cljc` + `resources/transport/http.cljc` — transport-neutral lower seam + the `:rf.http/managed` lowering (HTTP reached late-bound)
- `resources/route.cljc` — late-bound routing integration (publishes `:routing/extra-route-keys` → `#{:resources}`)
- `resources/ssr.cljc` — late-bound SSR projection (publishes `:ssr/extend-runtime-db-projection`; durable `:entries` ride the wire, indexes recomputed)
- `resources/test_support.cljc` — test-isolation reset behind an explicit require (rf2-dbiv8 posture)

### Facade exports + classifications (standing facade rule, diff-time)

`implementation/core/src/re_frame/core_resources.cljc` exposes 5 exports, all classified **optional-artefact public API wrapper (Spec 016 §Public API)** — the established `defwrapper` shape shared by flows/routing/schemas/machines/ssr/epoch/http; each delegates through the late-bind table and throws `:rf.error/resources-artefact-missing` when the artefact is absent:

| Export | Classification / justification |
|---|---|
| `reg-resource` | Registration surface — Spec 016 §Public API §Registration. Macro (source-coord capture) + CLJS fn-alias, mirrors `reg-route`. |
| `clear-resource` | Registration-lifecycle removal — Spec 016 §Registration. |
| `resource-meta` | Introspection — Spec 016 §Introspection (read the registered spec). |
| `resource-state` | Introspection — Spec 016 §Introspection (per-frame instance state; explicit-frame, EP-0002). |
| `resources` | Introspection — Spec 016 §Introspection (registered + per-frame instance table). |

All five are spec-named public API for the optional artefact (Spec 016 §Public API §Registration / §Introspection) — none is a convenience alias; the surface matches the spec's named API exactly.

### Registrar kind

`:resource` added to the core registrar's closed kind set (a Spec change, per Spec 016 §Registration). Deliberately **not** `:query` (collides with route query-params + prior-art names — the bead is explicit). A skeleton test asserts `:resource` is valid and `:query` is not.

### Feature probe

`:resources` added to `re-frame.features/feature-registry` with `:probe-key :resources/reg-resource` — `(rf/feature-loaded? :resources)` is true once the artefact loads.

### Late-bind (both ways — no static cross-artefact require)

- **Routing:** `re-frame.routing.registry` now unions a late-bound `:routing/extra-route-keys` set into its accepted route-metadata keys; resources publishes `#{:resources}` so `(reg-route … {:resources [...]})` is accepted (mirrors how `:head` is a cross-feature key owned by SSR). Absent the resources artefact, a route with `:resources` is correctly rejected.
- **SSR:** `re-frame.ssr.payload-policy/project-runtime-db` now merges a late-bound `:ssr/extend-runtime-db-projection` map into its allowlist; resources projects only the durable `:entries` of `:rf.runtime/resources` (reverse indexes are recomputable-from-entries, off the wire).
- **HTTP:** the managed-HTTP transport is reached via the late-bind table; no static `:require` on `re-frame.http-managed`.

Both extension points are no-op-effect for an app that does not load the host artefact.

### Build wiring (HOT-ZONE — sole toucher)

Top-level `implementation/shadow-cljs.edn` (`resources/src` + `resources/test` source paths), top-level `implementation/deps.edn` (`day8/re-frame2-resources` dep + combined `:test` path), and the artefact's own `resources/deps.edn` — mirrored exactly on machines/routing.

### Bundle isolation

Nothing in `implementation/` requires from `tools/`; core never statically `:require`s `re-frame.resources`. Verified green by `test:bundle-isolation`.

### Gates (slice)

- `npm run test:cljs` — **green** (6141 tests / 21943 assertions, 0 failures, 0 errors), including the new `resources_skeleton_cljs_test` smoke suite (ns-load, registrar kind, fail-closed scope policy, feature probe, public-API hooks, subs/events registration, late-bound routing accepted-key).
- `npm run test:bundle-isolation` — **green**.
- late-bind drift test (JVM) — **green** (all 8 published keys carry directory entries).
- routing-registry JVM tests — **green** (accepted-key extension change).

### Design forks

None — Spec 016 settled every decision encountered.

Closes rf2-p10npe.
