### PR TITLE
docs(EP): EP-0010 example uses the qualified :work/id spelling

### DIFF
--- a/docs/EP/EP-0010-causal-world-inputs.md
+++ b/docs/EP/EP-0010-causal-world-inputs.md
@@ -455,7 +455,7 @@ An illustrative reply token:
 
 ```clojure
 [:rf.resource.internal/succeeded
- {:work-id [:rf.work/resource scoped-resource-key 4]
+ {:work/id [:rf.work/resource scoped-resource-key 4]
   :resource-key scoped-resource-key
   :generation 4
   :rf.frame/id frame-id


### PR DESCRIPTION
Consolidation sweep after the five parallel EP review agents (PRs #3737-#3741): the one cross-EP item left unowned. The EP-0011 review flagged the unqualified :work-id spelling drift (vs :work/id ledger keys) in Spec 016 and one EP-0010 example after the EP-0010 agent had already finished; this fixes the EP-side instance. Spec 016's internal payloads converge at EP-0011 graduation per its recorded open issue. Gates green.