### PR TITLE
docs(EP): resolve review caveats in draft EPs

### DIFF
--- a/docs/EP/EP-0010-causal-world-inputs.md
+++ b/docs/EP/EP-0010-causal-world-inputs.md
@@ -150,8 +150,8 @@ repaired by silently asking the host again.
   under this EP.
 - **EP-0011 (uniform async reply envelope)** defines the reply shape that
   carries this EP's completion world facts. This EP requires the facts;
-  EP-0011 standardizes the carrier. EP-0011 defers the final spelling of
-  causal time keys to this EP (see Open Issues).
+  EP-0011 standardizes the carrier and uses this EP's suffixless durable
+  timestamp vocabulary (`:started-at`, `:completed-at`, and `:deadline-at`).
 - **EP-0012 (path optics and canonical forms)** supplies the canonical-form
   vocabulary world-input maps should reuse wherever fixture equality or
   projection comparison matters.
@@ -466,9 +466,10 @@ An illustrative reply token:
    :rf.world/inputs {:time-ms 1781078400456}}}]
 ```
 
-EP-0011 standardizes the outer reply shape and may rename its keys. This EP's
-requirement is narrower: completion facts that affect durable state are carried
-on the reply token and are not re-read in the reply handler.
+EP-0011 standardizes the outer reply shape and uses the same suffixless durable
+timestamp keys. This EP's requirement is narrower: completion facts that affect
+durable state are carried on the reply token and are not re-read in the reply
+handler.
 
 ### Resources And Work-Ledger Timestamps
 
@@ -981,14 +982,6 @@ recorded before this EP graduates.
   spellings of "when was this dispatched" violates one-name-per-fact (EP-0007),
   and the diagnostic need is already covered by the trace event's own `:time`
   stamp (Spec 009).
-- Key spelling: EP-0011 provisionally spells reply completion keys
-  `:started-at-ms` / `:completed-at-ms` / `:deadline-at-ms` and defers the
-  final spelling to this EP, while Spec 016's ledger rows and resource entries
-  already use `:started-at` / `:deadline-at` / `:loaded-at`.
-  **Recommendation:** adopt the suffixless Spec 016 spellings for durable
-  fields, and have EP-0011 lower its provisional `-ms` names at graduation; the
-  unit is epoch milliseconds either way.
-
 ## Recommendation
 
 Adopt. Causal world inputs make the frame fold honest: durable state is a

--- a/docs/EP/EP-0011-uniform-async-reply-envelope.md
+++ b/docs/EP/EP-0011-uniform-async-reply-envelope.md
@@ -86,7 +86,7 @@ should be:
 - Tracing and error promotion need to classify completion status without
   decoding every effect family's private callback shape.
 - EP-0010 causal world inputs need one place to carry completion facts such as
-  `:started-at-ms`, `:completed-at-ms`, and `:deadline-at-ms`.
+  `:started-at`, `:completed-at`, and `:deadline-at`.
 
 Large SPA architecture benefits when the remaining ambient concepts are values
 with laws. The continuation of managed async work is one of those concepts.
@@ -121,8 +121,8 @@ and turns completion into an ordinary reply map:
  :work/id         [:rf.work/http :article/by-id 42 7]
  :attempt         1
  :rf.frame/id     :app/main
- :started-at-ms   1781078400123
- :completed-at-ms 1781078400456
+ :started-at      1781078400123
+ :completed-at    1781078400456
  :correlation     {:request-id [:article/by-id 42]
                    :generation 7}
  :stale?          false}
@@ -166,8 +166,10 @@ day one.
   shape.
 - This EP does not make cancellation reliable. Hosts may fail to cancel work
   already in flight; stale suppression remains the correctness rule.
-- This EP does not settle every EP-0010 timestamp key spelling. It requires
-  causal completion metadata and uses provisional names.
+- This EP does not define a new time representation. `:started-at`,
+  `:completed-at`, and `:deadline-at` carry EP-0010 causal time values; the
+  current recommended representation is epoch milliseconds supplied by the
+  triggering or reply token, not fresh ambient clock reads.
 
 ## Relationships
 
@@ -181,8 +183,8 @@ day one.
   slice and MUST NOT introduce a parallel correlation store.
 - **[EP-0010](EP-0010-causal-world-inputs.md) (proposal).** Replies are causal
   tokens under EP-0010; completion facts that affect durable state ride the
-  reply map. EP-0010 owns the final spelling and precision of the time keys
-  this EP uses provisionally.
+  reply map. This EP uses EP-0010's suffixless durable timestamp vocabulary:
+  `:started-at`, `:completed-at`, and `:deadline-at`.
 - **[Managed-Effects](../../spec/Managed-Effects.md).** This EP adds the ninth
   property to the existing eight-property managed-effect checklist; conforming
   surfaces inherit it the same way they inherit the other eight.
@@ -340,7 +342,7 @@ appended as the final event argument:
  {:status          :ok
   :value           {:title "Welcome"}
   :work/id         [:rf.work/http :article/by-id 42 1]
-  :completed-at-ms 1781078400456}]
+  :completed-at 1781078400456}]
 ```
 
 The descriptor form is available for framework internals and future public
@@ -379,9 +381,9 @@ AbortControllers, timer handles, DOM nodes, or other host resources.
  :work/status     :completed | :failed | :timed-out | :suppressed | :cancelled
  :attempt         positive-int-or-nil
  :rf.frame/id     frame-id
- :started-at-ms   started-at-ms-or-nil
- :completed-at-ms completed-at-ms-or-nil
- :deadline-at-ms  deadline-at-ms-or-nil
+ :started-at      started-at-or-nil
+ :completed-at    completed-at-or-nil
+ :deadline-at     deadline-at-or-nil
  :correlation     data-only-map
  :stale?          boolean
  :stale/reason    keyword-or-nil
@@ -400,7 +402,7 @@ Required fields:
 - `:value` is present for `:status :ok`.
 - `:error` is present for `:status :error` and MAY also carry compatibility
   failure data for `:status :cancelled`.
-- `:started-at-ms`, `:completed-at-ms`, and `:deadline-at-ms` are causal
+- `:started-at`, `:completed-at`, and `:deadline-at` are causal
   metadata when those facts affect durable state. If the effect family does not
   use a field durably, it may omit it.
 
@@ -494,8 +496,8 @@ When a work-ledger row exists, issuance writes or joins a non-terminal row:
  :owners        #{[:route :route/article "nav-12"]}
  :causes        [[:route-entry :route/article "nav-12"]]
  :cancellable?  true
- :started-at-ms 1781078400123
- :deadline-at-ms 1781078405123
+ :started-at    1781078400123
+ :deadline-at   1781078405123
  :reply-to      {:event [:rf.resource.internal/replied
                          {:resource/key scoped-resource-key
                           :generation   4
@@ -504,17 +506,17 @@ When a work-ledger row exists, issuance writes or joins a non-terminal row:
 
 The `:reply-to` field is where the ledger row and the reply envelope visibly
 become one fact: the durable row carries the continuation that this EP's
-completion path consumes. (Timestamp field spellings above follow this EP's
-provisional EP-0010 names; the graduated ledger row in Spec 016 currently
-spells `:started-at` / `:deadline-at` — see Open Issues for the convergence
-rule.)
+completion path consumes. Timestamp field spellings intentionally match
+EP-0010 and the graduated Spec 016 ledger row; the values remain causal epoch
+millisecond readings unless a later accepted EP changes the time representation
+for the whole durable timestamp family.
 
 Completion updates that row before, or atomically with, delivery:
 
 ```clojure
 {:work/id          [:rf.work/resource scoped-resource-key 4]
  :status           :completed
- :completed-at-ms  1781078400456
+ :completed-at     1781078400456
  :outcome          {:status :ok}}
 ```
 
@@ -548,7 +550,7 @@ Correct:
       :ok
       {:db (assoc-in db [:articles id]
                      {:data      (:value reply)
-                      :loaded-at (:completed-at-ms reply)})}
+                      :loaded-at (:completed-at reply)})}
 
       :error
       {:db (assoc-in db [:articles id :error] (:error reply))}
@@ -564,7 +566,7 @@ Incorrect:
 ```
 
 The event envelope that dispatches the reply may also carry an enqueue time.
-That time is distinct from `:completed-at-ms` when the host completion happened
+That time is distinct from `:completed-at` when the host completion happened
 before the runtime enqueued the reply. Specs may decide which timestamp a
 durable field uses, but the value must be causal data.
 
@@ -606,7 +608,7 @@ Explicit user cancellation that is still live may dispatch:
   :cancelled?    true
   :cancel/reason :user
   :work/id       [:rf.work/http :search "abc" 8]
-  :completed-at-ms 1781078400999}]
+  :completed-at 1781078400999}]
 ```
 
 Supersession cancellation should usually suppress the old app reply:
@@ -678,7 +680,7 @@ The compatibility handler receives the canonical reply:
  {:status          :ok
   :value           session
   :work/id         [:rf.work/http :auth/login login-attempt]
-  :completed-at-ms 1781078400456}]
+  :completed-at 1781078400456}]
 ```
 
 and preserves the public HTTP event shape promised by Spec 014:
@@ -701,7 +703,7 @@ For route resources:
 - server route handling enqueues blocking resource work;
 - SSR waits for ledger rows associated with the current route/nav-token to
   become terminal;
-- successful replies update resource entries with causal `:completed-at-ms`;
+- successful replies update resource entries with causal `:completed-at`;
 - failures settle as structured resource or route errors;
 - stale or superseded replies are suppressed by work id/generation/nav-token;
 - hydration serializes the allowed resource projection and non-terminal work
@@ -823,8 +825,8 @@ Canonical completion:
   :work/status     :completed
   :attempt         1
   :rf.frame/id     :app/main
-  :started-at-ms   1781078400123
-  :completed-at-ms 1781078400456
+  :started-at   1781078400123
+  :completed-at 1781078400456
   :correlation     {:request-id [:article/by-id 42]}}]
 ```
 
@@ -889,7 +891,7 @@ failure, cancellation, or stale suppression:
   :work/id         work-id
   :work/kind       :resource
   :work/status     :completed
-  :completed-at-ms 1781078400456
+  :completed-at 1781078400456
   :correlation     {:scope      [:rf.scope/session {:tenant-id "acme"}]
                     :generation 4
                     :owner      [:route :route/article "nav-12"]}}]
@@ -944,7 +946,7 @@ Live completion:
   :value           nil
   :work/id         [:rf.work/timer :search/debounce 8]
   :work/kind       :timer
-  :completed-at-ms 1781078400300
+  :completed-at 1781078400300
   :correlation     {:generation 8}}]
 ```
 
@@ -1057,7 +1059,7 @@ When the child reaches a successful top-level final state, the runtime can form:
  :work/id         [:rf.work/machine :auth/flow#1 [:authenticating] 1]
  :work/kind       :machine
  :work/status     :completed
- :completed-at-ms 1781078400888
+ :completed-at 1781078400888
  :correlation     {:actor-id  :auth/flow#1
                    :parent-id :auth/main
                    :spawn-id  [:authenticating]}}
@@ -1082,7 +1084,7 @@ A single reply handler can branch on the common status taxonomy:
       {:db (assoc-in db [:uploads upload-id]
                      {:status :done
                       :result (:value reply)
-                      :done-at (:completed-at-ms reply)})}
+                      :done-at (:completed-at reply)})}
 
       :error
       {:db (assoc-in db [:uploads upload-id]
@@ -1278,12 +1280,6 @@ Conformance should include fixtures or tests for:
 
 ## Open Issues
 
-- EP-0010 owns the final spelling and precision of causal time keys. This EP
-  uses `:started-at-ms`, `:completed-at-ms`, and `:deadline-at-ms`
-  provisionally, while the graduated ledger row in Spec 016 spells
-  `:started-at` / `:deadline-at` today. **Recommendation:** adopt whatever
-  EP-0010 rules, and converge the reply map and the Spec 016 ledger row in the
-  same graduation bead so two spellings of one timestamp fact never ship.
 - `:rf.runtime/work-ledger` is a multi-writer subsystem. Resources can mint
   authority today; the first non-resource writer must settle the general
   authority path for timers, route loaders, machine work, and future async

--- a/docs/EP/EP-0012-path-optics-and-canonical-forms.md
+++ b/docs/EP/EP-0012-path-optics-and-canonical-forms.md
@@ -204,9 +204,10 @@ Plain `get-in` cannot distinguish this from missing; the shared path algebra
 MUST provide or internally use a presence-aware lookup where the distinction
 matters.
 
-**Canonical EDN identity**: A deterministic normalized value or byte/string
-encoding derived from portable EDN such that equal facts produce identical
-identity and unsupported host values fail closed.
+**Canonical EDN identity**: A deterministic normalized value plus a versioned
+byte encoding derived from portable EDN such that equal facts produce identical
+identity and unsupported host values fail closed. This EP names the first
+encoding `CEDN-1`.
 
 **Route data**: The route id plus path params, query params, and optional
 fragment represented as EDN:
@@ -567,11 +568,11 @@ The function may return a normalized value, canonical bytes, or a digest over
 canonical bytes. The contract is the same: equal facts produce the same
 identity across CLJ/CLJS hosts, and unsupported values fail closed.
 
-The canonical EDN domain is:
+The `CEDN-1` canonical EDN domain is:
 
 - `nil`, booleans, strings, keywords, symbols;
-- integers and finite numbers that the host can print and parse
-  unambiguously under the chosen encoder;
+- portable integers in the ECMAScript safe-integer range
+  `[-9007199254740991, 9007199254740991]`;
 - UUIDs and instants when represented as EDN values or explicit tagged data;
 - vectors, lists, maps, and sets whose nested values are canonical EDN values.
 
@@ -581,7 +582,8 @@ The canonicalizer MUST reject by default:
 - atoms, refs, volatile cells, promises, futures;
 - DOM nodes, React elements, AbortControllers, request handles, timers;
 - arbitrary JS objects or host class instances;
-- NaN and infinities unless a future spec explicitly encodes them;
+- floating point values, ratios, arbitrary precision decimals, NaN, and
+  infinities unless a future spec explicitly encodes the numeric class;
 - mutable objects whose identity is by reference rather than value.
 
 APIs that need to carry such values MUST encode them explicitly into portable
@@ -600,13 +602,56 @@ EDN before they reach an identity boundary:
 (rf.identity/canonical {:at #inst "2026-06-10T00:00:00.000-00:00"})
 ```
 
+Raw host dates are rejected for the same reason as other host objects. A route,
+resource, or adapter boundary MAY explicitly coerce an accepted host date into
+an EDN instant before canonicalization; after that coercion the value is an
+instant fact, not a host object fact.
+
+### Canonical Byte Encoding (`CEDN-1`)
+
+`CEDN-1` is the reference byte encoding for canonical identity. It is an
+internal comparison and digest format, not a display format and not a URL
+format. Implementations MAY store a normalized EDN projection or a digest over
+these bytes, but equality-sensitive comparisons MUST be equivalent to comparing
+the `CEDN-1` bytes.
+
+`CEDN-1` encodes a UTF-8 token stream with a type tag before every value:
+
+| EDN value | Canonical token |
+|---|---|
+| `nil` | `n` |
+| Boolean | `b:0` or `b:1` |
+| String | `s:` plus a canonical EDN string literal over Unicode scalar values |
+| Keyword | `k:` plus the canonical EDN keyword token, without auto-resolved `::` shorthand |
+| Symbol | `y:` plus the canonical EDN symbol token |
+| Portable integer | `i:` plus base-10 digits inside the safe-integer range, no leading `+`, no leading zero except `0` |
+| UUID | `u:` plus lower-case RFC 4122 text |
+| Instant | `t:` plus RFC 3339 UTC text with millisecond precision |
+| Vector | `v[` elements in order `]` |
+| List | `l(` elements in order `)` |
+| Set | `q#{` elements sorted by their `CEDN-1` bytes `}` |
+| Map | `m{` key/value pairs sorted by key `CEDN-1` bytes `}` |
+
+Composite encodings separate adjacent element tokens, and each map key token
+from its value token, with a single ASCII space. String, keyword, and symbol
+encoders MUST reject names that cannot be round-tripped through portable EDN
+readers on both CLJ and CLJS. Instant encoding normalizes equivalent instants
+to UTC before printing; timezone text from the source literal is not identity.
+
+The type tag is part of the bytes. That keeps distinct EDN values distinct:
+the string `"42"`, the integer `42`, the keyword `:42`, the vector `[1 2]`,
+and the list `(1 2)` cannot collide. Heterogeneous map keys are therefore
+allowed within the supported domain: the sort key is the complete key byte
+sequence, including the type tag. If a value is outside the supported domain,
+the whole identity fails closed rather than falling back to host comparison.
+
 ### Map Key Canonicalization
 
 Map entries MUST be ordered deterministically by the canonical encoding of
 their keys, not by insertion order, hash-map iteration order, locale, or host
-object identity. The reference rule should match the existing schema digest
-discipline: compare the stable printed/canonical byte representation of the
-canonicalized keys, and then encode entries in that order.
+object identity. The reference rule is direct: compute each key's `CEDN-1`
+bytes, sort lexicographically by those bytes, and then encode entries in that
+order.
 
 Examples:
 
@@ -620,9 +665,10 @@ Examples:
 ;; => true
 ```
 
-Heterogeneous keys are legal only when the canonical encoder defines a total
-order for them. If a port cannot order two key values reproducibly, it MUST
-reject the identity value rather than fall back to host iteration.
+Heterogeneous keys inside the `CEDN-1` domain are legal because their complete
+type-tagged key bytes define the total order. If a key value falls outside that
+domain, the map identity MUST fail closed rather than fall back to host
+iteration or comparison.
 
 Duplicate canonical keys are invalid. A reader or adapter that can produce a
 map with duplicate keys after canonicalization MUST reject it before it becomes
@@ -1335,15 +1381,6 @@ Public/internal conformance:
   **Recommendation:** internal-first. The semantics are normative immediately;
   the public names graduate only after the flows/schemas/routing/resources
   consumers have proven them, per §Internal And Public Helper Surface.
-- What exact canonical byte encoding should be named for UUIDs, instants,
-  bigints, ratios, decimals, and heterogeneous numeric keys across CLJ/CLJS
-  hosts?
-  **Recommendation:** pin it in the Conventions graduation bead, reusing the
-  Spec 010 schema-digest discipline (stable printed bytes, SHA-256) as the
-  base. If a total order for exotic numeric keys proves contentious, restrict
-  v1 canonical map keys to keywords, strings, integers, booleans, and UUIDs
-  and fail closed on the rest — narrowing later is impossible; widening is
-  cheap.
 - Should path templates reserve only `'?name` symbols, or should they use an
   explicit data form such as `[:rf.path/param :invoice-id]` to avoid any chance
   of confusing a literal symbol segment with a template variable?
@@ -1366,13 +1403,6 @@ Public/internal conformance:
   tool/debugging projection (Xray rows stay readable), the digest is the
   storage/lookup key, and the digest is always derived from the normalized
   value — one fact, one identity, two encodings.
-- Spec 016 currently lists "dates" among the host values rejected from
-  resource params, while this EP's canonical domain admits instants as EDN
-  values or tagged data — and in CLJS an `#inst` *is* a `js/Date`.
-  **Recommendation:** reconcile at graduation: raw host date objects are
-  rejected at identity boundaries unless the accepting surface explicitly
-  coerces them to `#inst` tagged EDN, whose canonical encoding is the RFC 3339
-  UTC instant string; Spec 016's wording narrows to "raw host date objects".
 - The flow path validator today restricts segments to
   keyword/string/integer/symbol/boolean — narrower than this EP's segment
   domain (no UUID, instant, or `nil` segments), even though UUID-keyed entity

--- a/docs/EP/EP-0013-app-values-and-runtime-realms.md
+++ b/docs/EP/EP-0013-app-values-and-runtime-realms.md
@@ -291,6 +291,13 @@ The §Specification subsections map onto the decisions as follows:
 | D2 — app value | App Values; Registration Descriptors; Installation; Default Realm And `reg-*` Sugar; Hot Reload And Reinstall; Source Coordinates |
 | D3 — manifests | Module Values And Feature Ownership; Composition |
 
+A valid ruling on this EP MUST record a disposition for each decision:
+`adopt`, `defer`, or `reject`. Adopting D1 does not adopt D2 or D3; adopting
+D2 does not adopt D3. If a later graduation PR promotes only D1, the remaining
+D2/D3 text stays in this EP as deferred rationale and examples, not as an
+implicitly accepted public surface. If D1 is rejected, D2 and D3 cannot
+graduate from this EP without a replacement container story.
+
 §Public API Staging spans all three: stages 1–4 land D1 internally, stages 5
 and 7 land D2, stage 6 spans D2/D3 (the app constructor is D2, the module
 constructor is D3), and stages 8–9 close the realm-targeted query surface and
@@ -1527,10 +1534,6 @@ Conformance should be tested at three levels.
 - Which registrar query arities become public at the first realm-aware stage?
 - How should active resources, route transitions, and machines participate in a
   realm reinstall beyond the existing per-kind hot-reload rules?
-- Should D1/D2/D3 graduate as one spec change or be split into separate EPs at
-  ruling time, per EP-0009's one-decision-surface rule? Recommendation: rule
-  them as three decisions inside this EP (the vocabulary is shared and the
-  layering is explicit), splitting only if the rulings diverge.
 - Does the host-transient subsystem descriptor live here or as an extension row
   in EP-0006's grading table? Recommendation: EP-0006 owns the contract; this
   EP contributes realm ownership and lifecycle as the host-transient grading
@@ -1543,7 +1546,9 @@ capabilities live in explicit realms. Keep current `reg-*` APIs as default-realm
 sugar, but stop treating process-global registration, single adapter per
 process, and global late-bind lookup as the long-term architecture.
 
-Rule the three decisions separately:
+Rule the three decisions separately. The final disposition should be recorded
+as a small D1/D2/D3 matrix so reviewers can accept the container without
+accidentally accepting the whole public app/module surface:
 
 - **D1 (realm container): adopt.** It is the hermetic-test and tenancy layer,
   it can be implemented internal-first behind the default realm with no public

--- a/docs/EP/EP-0014-derivation-and-process-algebra.md
+++ b/docs/EP/EP-0014-derivation-and-process-algebra.md
@@ -1305,8 +1305,9 @@ in machine definitions; selectors and view-models become graph-visible facts.
    route-owned resource activation edges.
 6. Map machine definitions, snapshots, spawned actors, and machine selectors
    into process and derivation nodes.
-7. Add a graph-inspection helper for static and live graphs. Xray may consume it
-   first; public API naming can follow after the shape proves stable.
+7. Add an internal graph-inspection helper for static and live graphs. Xray may
+   consume it first; no public authoring primitive or stable graph accessor
+   ships in this first slice.
 8. Add documentation examples that show source forms and algebra views side by
    side.
 9. Add conformance fixtures for lowering, storage/evaluation/lifecycle
@@ -1338,6 +1339,9 @@ A conforming implementation should satisfy these checks:
   resource leases and timers.
 - **Tool redaction:** graph inspection can summarize or redact sensitive
   params, scopes, and values without losing graph structure.
+- **Public API staging:** the first slice does not export a new public
+  authoring primitive or stable graph accessor; any public API requires a later
+  recorded ruling after the internal shape proves stable.
 - **Delta law:** any provided `:step-delta` passes the commuting law against
   whole-value recomputation. Implementations with no delta support still
   conform.


### PR DESCRIPTION
Summary
- Converges EP-0010 and EP-0011 on suffixless durable timestamp keys.
- Pins EP-0012 canonical identity with a CEDN-1 reference encoding and raw-host-date boundary.
- Makes EP-0013 D1/D2/D3 dispositions explicitly separable.
- Strengthens EP-0014 vocabulary-now/API-later staging in the implementation plan.

Validation
- git diff --check over EP-0010 through EP-0014
- python scripts\check_ep_status_sync.py --verbose
- python scripts\check_doc_slugs.py --verbose
- python -m mkdocs build --strict