### PR TITLE
feat(xray): Resources tab — registry/instance/work-ledger panels, :rf.resource/* trace family, redacted accessors (rf2-0xljxy)

### DIFF
--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -66,6 +66,7 @@
             [day8.re-frame2-xray.panels.trace]
             [day8.re-frame2-xray.panels.machine-inspector]
             [day8.re-frame2-xray.panels.routing]
+            [day8.re-frame2-xray.panels.resources]
             [day8.re-frame2-xray.static.flows.panel]
             [day8.re-frame2-xray.static.interceptors.panel]
             [day8.re-frame2-xray.static.routes.panel]
@@ -93,6 +94,7 @@
    "day8.re-frame2-xray.panels.trace"                (emit-ns-publics day8.re-frame2-xray.panels.trace)
    "day8.re-frame2-xray.panels.machine-inspector"    (emit-ns-publics day8.re-frame2-xray.panels.machine-inspector)
    "day8.re-frame2-xray.panels.routing"              (emit-ns-publics day8.re-frame2-xray.panels.routing)
+   "day8.re-frame2-xray.panels.resources"            (emit-ns-publics day8.re-frame2-xray.panels.resources)
    "day8.re-frame2-xray.static.flows.panel"          (emit-ns-publics day8.re-frame2-xray.static.flows.panel)
    "day8.re-frame2-xray.static.interceptors.panel"   (emit-ns-publics day8.re-frame2-xray.static.interceptors.panel)
    "day8.re-frame2-xray.static.routes.panel"         (emit-ns-publics day8.re-frame2-xray.static.routes.panel)

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -110,6 +110,7 @@
   {:namespace "day8.re-frame2-xray.panels" :var "mount-machine-inspector!"             :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels" :var "mount-managed-fx!"                     :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels" :var "mount-reactive-panel!"                 :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels" :var "mount-resources!"                      :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels" :var "mount-routing!"                        :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels" :var "mount-segment-inspector!"             :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels" :var "mount-shell!"                          :kind :fn :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
@@ -124,6 +125,7 @@
   {:namespace "day8.re-frame2-xray.panels.epoch-panel"          :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels.machine-inspector"    :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels.reactive-panel"       :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.resources"            :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels.routing"              :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels.trace"                :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.static.flows.panel"          :var "Panel" :kind :var :facade? false :tier :internal-public :owner "tools/xray" :status "post-v1 lib" :runtime-verified? true}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 493,
+ :var-count 495,
  :tier-vocab
  [:front-porch
   :advanced
@@ -32,6 +32,7 @@
   {:namespace "day8.re-frame2-xray.panels", :var "mount-machine-inspector!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels", :var "mount-managed-fx!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels", :var "mount-reactive-panel!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels", :var "mount-resources!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels", :var "mount-routing!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels", :var "mount-segment-inspector!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels", :var "mount-shell!", :tier :internal-public, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
@@ -40,6 +41,7 @@
   {:namespace "day8.re-frame2-xray.panels.epoch-panel", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels.machine-inspector", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels.reactive-panel", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
+  {:namespace "day8.re-frame2-xray.panels.resources", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels.routing", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.panels.trace", :var "Panel", :tier :internal-public, :kind :var, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "day8.re-frame2-xray.runtime", :var "egress-record", :tier :tooling, :kind :fn, :owner "tools/xray", :status "post-v1 lib", :facade? false, :runtime-verified? true}

--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -1687,12 +1687,12 @@ only opt is `:frame`) — the v1.0 host-facing embed contract is the
 > Adding / removing / renaming a panel starts with a one-line edit to
 > the enum; this table follows. See the `panel-enum` ns docstring.
 
-The Xray panel-surface inventory totals **14 surfaces** across five
-tiers — **12 are independently mountable** via a `mount-<panel>!` fn
+The Xray panel-surface inventory totals **15 surfaces** across five
+tiers — **13 are independently mountable** via a `mount-<panel>!` fn
 (the panel-enum set), and **2 are internal sub-components** that render
 under their owning panel and expose no standalone mount fn. The split:
 
-- **Tier 1 — L3 tab panels (6):** one per L3 detail-panel tab.
+- **Tier 1 — L3 tab panels (7):** one per L3 detail-panel tab.
 - **Spine — embeddable event spine (1):** the L2 event list mounted
   standalone (`008-Embedding-Contract.md` §Embeddable event spine).
 - **Tier 2 — overlay / popup surfaces (3):** modal-light surfaces
@@ -1706,20 +1706,24 @@ under their owning panel and expose no standalone mount fn. The split:
   geometry-coupled to `machine-inspector/Panel` (after-rings
   overlay, sim side-rail) — NOT in the panel-enum set.
 
-The 6 + 1 + 3 + 1 + 1 mountable surfaces sum to the **12** entries of
+The 7 + 1 + 3 + 1 + 1 mountable surfaces sum to the **13** entries of
 `panel-enum`; adding Tier 4's 2 internal sub-components reaches the
-**14-surface** total. Modal overlays managed by the shell (Settings
+**15-surface** total. Modal overlays managed by the shell (Settings
 dialog, command palette, share modal) are NOT counted here — they are
 shell chrome, not panel content.
 
-**Tier 1 — L3 tab panels (6):** one per `:rf.xray/selected-tab`
+**Tier 1 — L3 tab panels (7):** one per `:rf.xray/selected-tab`
 value. (Post rf2-5gl5r the Event/Handler tab was retired in favour
 of the Epoch tab; post rf2-gbz39 the Issues tab was removed per Mike's
 Option (c) ruling — issues surface inline in the Epoch panel + the L2
 event-row pink-wash + the always-on issues ribbon signal. The Epoch
 panel renders the focused epoch's full computational timeline as a
 numbered vertical cascade per
-[`021-Dynamic-Panel-Designs.md` §9.1](./021-Dynamic-Panel-Designs.md#91-the-epoch-panel-numbered-cascade--rf2-sc3r1).)
+[`021-Dynamic-Panel-Designs.md` §9.1](./021-Dynamic-Panel-Designs.md#91-the-epoch-panel-numbered-cascade--rf2-sc3r1).
+The Resources tab — the declarative-server-state lens (Spec 016 §Xray
+and AI tooling) — earns its own L3 tab after Routing per Mike's
+cohesive-sub-domain ruling; server-state is a sub-domain, not an
+App-db section.)
 
 | Panel | View | Mount fn |
 |---|---|---|
@@ -1729,6 +1733,7 @@ numbered vertical cascade per
 | Trace tab    | `trace/Panel`            | `mount-trace!` |
 | Machines tab | `machine-inspector/Panel`| `mount-machine-inspector!` |
 | Routing tab  | `routing/Panel`          | `mount-routing!` |
+| Resources tab | `resources/Panel`       | `mount-resources!` |
 
 **Spine — embeddable event spine (1):** the L2 event list mounted
 standalone — the SAME `shell/event-list` reg-view the full shell

--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -453,6 +453,52 @@ rf2-lq0ef (audit verdict B).
 | `:rf.xray/set-registered-routes-override-for-test` | `[_ ov]` | Test-only override hook. |
 | `:rf.xray/set-current-route-slice-override-for-test` | `[_ ov]` | Test-only slice override. |
 
+## Resources panel
+
+Spec: [`024-Resources-Panel.md`](./024-Resources-Panel.md) (Xray-side
+lens) + [`spec/016-Resources.md`](../../../spec/016-Resources.md)
+(framework substrate). Declarative-server-state lens: the static resource
+registry, the live per-frame instance + work-ledger tables, the
+route/resource graph, the lifecycle timeline, the invalidation graph, the
+cache-growth view, and the scope audit + lints. Read-only — the panel
+registers NO `:rf.resource/*` event (observing pins no resource, Spec 016
+§Active owners and causes). Decoupled from the optional Resources artefact
+(reads `(rf/registrations :resource)` + the runtime-db slice; Xray never
+`:require`s `re-frame.resources`).
+
+### Subscriptions
+
+| Sub | Returns |
+|---|---|
+| `:rf.xray/registered-resources` | `(rf/registrations :resource)` — the static registry. Test override via `:registered-resources-override`. |
+| `:rf.xray/registered-resources-override` | Test override slot. |
+| `:rf.xray/resource-entries` | The live cache entries map from the target frame's runtime-db at `[:rf.runtime/resources :entries]`. Test override. |
+| `:rf.xray/resource-entries-override` | Test override slot. |
+| `:rf.xray/resource-work-ledger` | The live work-ledger map at `[:rf.runtime/work-ledger]`. Test override. |
+| `:rf.xray/resource-work-ledger-override` | Test override slot. |
+| `:rf.xray/resource-sub-reads` | Observed live subscription reads (`[{:resource-id :params :scope} …]`) backing the scope-mismatch lint. Empty by default. Test override. |
+| `:rf.xray/resource-sub-reads-override` | Test override slot. |
+| `:rf.xray/resources-tab-data` | View-facing composite — `{:silent? :registry :instances :work :route-graph :timeline :invalidations :cache-growth :audit}` over the registry + entries + ledger + route registry + trace buffer. PRIVACY: every param/scope/data/cause/outcome value is summarized (never raw). |
+
+### Events
+
+| Event | Vector shape | Behaviour |
+|---|---|---|
+| `:rf.xray/set-registered-resources-override-for-test` | `[_ ov]` | Test-only override hook. `nil` clears. |
+| `:rf.xray/set-resource-entries-override-for-test` | `[_ ov]` | Test-only override hook. `nil` clears. |
+| `:rf.xray/set-resource-work-ledger-override-for-test` | `[_ ov]` | Test-only override hook. `nil` clears. |
+| `:rf.xray/set-resource-sub-reads-override-for-test` | `[_ ov]` | Test-only override hook. `nil` clears. |
+
+### Tool accessors (the AI / MCP read API)
+
+Five read-only accessors on `day8.re-frame2-xray.runtime` (the Xray↔MCP
+read seam), per [`024-Resources-Panel.md` §Tool accessors](./024-Resources-Panel.md):
+`list-resources`, `list-resource-instances`, `get-resource-state`,
+`get-resource-history`, `list-resource-invalidations` — filterable by
+frame / scope / resource-id / params / tag / owner / status / stale? /
+request-id / nav-token, with bounded history and the two-layer privacy
+elision (in-panel summary + off-box `egress-*` walker).
+
 ## Machine inspector
 
 Spec: [`003-Machine-Inspector.md`](./003-Machine-Inspector.md). Reads

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -1,0 +1,260 @@
+# 024-Resources-Panel
+
+The Xray surface for **declarative server-state** — the consumer-side
+panel + tool-accessor + trace-family contract for the framework's
+optional Resources artefact ([`spec/016-Resources.md`](../../../spec/016-Resources.md)
+§Xray and AI tooling). The "where is my server state, what owns it, and
+is it stale?" lens.
+
+> **Owning framework spec.** [`spec/016-Resources.md`](../../../spec/016-Resources.md)
+> is the normative source for *what a resource IS* (identity, scope
+> policy, status FSM, owners vs causes, the work ledger, invalidation,
+> GC, SSR/restore). This doc is the Xray-side consumer contract: the
+> panel sections, the `:rf.xray/*` registry surface, the `:rf.resource/*`
+> trace family Xray colours/filters, the five tool accessors, and the
+> privacy posture Xray applies. Where this doc and Spec 016 differ, Spec
+> 016 governs the server-state semantics; this doc governs Xray's
+> presentation of them.
+
+## Bug class
+
+> **Bug class:** "My page shows a stale article / a permanent skeleton /
+> a refetch storm and I cannot see WHY. Which route owns this read? Is it
+> stale or just fetching? Did the last background refresh fail? Is this
+> cache growing without bound? Is a `/me` read accidentally global?"
+> **Insight Xray provides:** the resource cache, the in-flight work
+> ledger, the route/resource ownership graph, the lifecycle timeline, the
+> invalidation graph, the cache-growth view, and the scope audit — all as
+> data, all summarized (never raw), all read-only.
+
+## Decoupling — Resources is optional; Xray does not require it
+
+Resources is a **post-v1 OPTIONAL artefact** (Spec 016 §Implementation
+status) and is **NOT a hard dep of Xray** (`tools/xray/deps.edn` does not
+list `day8/re-frame2-resources`). The panel reads everything **decoupled**
+— exactly the posture the Routing tab uses for the route slice and the
+Machine Inspector uses for machine snapshots:
+
+- the **static registry** via `(rf/registrations :resource)` (the
+  process-global registrar);
+- the **live per-frame instance table** from the runtime-db partition
+  slice at `[:rf.runtime/resources :entries]` (EP-0001 — the resource
+  cache is framework-owned runtime-db state, never app-db), sourced from
+  `:rf.xray/target-frame-runtime-db`;
+- the **live per-frame work ledger** from `[:rf.runtime/work-ledger]`;
+- the **trace stream** (`:rf.resource/*` rows) from
+  `:rf.xray/trace-buffer`.
+
+Nothing in `tools/xray/` `:require`s `re-frame.resources.*`. The reserved
+runtime-db key paths are small duplicated literals in
+`panels/resources_helpers.cljc` — the bundle-isolation-safe price of not
+adding a require edge from a tool into an optional artefact. An app that
+omits the Resources artefact sees the panel render its silent-by-default
+caption.
+
+## Read-only — Xray MUST NOT become an owner by observing
+
+Per Spec 016 §Active owners and causes, opening this panel pins
+**nothing**. Every section is a pure read; the panel registers **no**
+`:rf.resource/*` event and dispatches none. Inspection never attaches an
+owner, refetches, extends GC, or alters polling. (A future explicit "pin
+this resource" debug action would be its own traced tool mutation, not
+normal inspection.)
+
+## PRIVACY — summaries, never raw values
+
+Spec 016 §Xray and AI tooling is load-bearing here: tool surfaces
+**prefer summaries over raw values**, and **params, scopes, AND data get
+the SAME privacy + size elision** — a scope carries user ids, tenant ids,
+locale, and impersonation markers, so it is exactly as sensitive as data.
+
+Two elision layers compose:
+
+1. **In-panel summary** (`resources-helpers/summarize`, always applied).
+   Every param / scope / data / cause / outcome value renders as a
+   `{:type :size :preview :elided? :redacted? :large?}` shape — a bounded
+   `pr-str` preview (tail elided past the budget), never the raw value. A
+   value the runtime already redacted/elided upstream (the framework
+   `:rf/redacted` / `:rf.size/large-elided` sentinels emitted for
+   `:sensitive?` / `:large?` slots via `elide-wire-value`) keeps its
+   sentinel status and renders `[redacted]` / `[large — elided]` with no
+   raw preview.
+2. **Off-box egress** (the tool accessors). The raw runtime-db values an
+   accessor surfaces route through the framework `egress-runtime-db-value`
+   / `egress-value` walker on top of the summaries. The resource cache is
+   runtime-db state, so the off-box default REDACTS the partition (Spec
+   011 §Off-box redaction, ruling #14); a trusted-local caller opts in
+   with `:include-runtime-db? true`, and even then per-slot `:sensitive?`
+   / `:large?` declarations still elide.
+
+Resource **history is bounded** (the accessor `:limit`, default 50).
+
+## Panel sections (top → bottom)
+
+The Resources tab is a Dynamic L3 tab (`:rf.xray/selected-tab`
+`:resources`, mnemonic `s`, order 7 — after Routing). The view
+(`panels/resources.cljs`) is pure hiccup over the single composite sub
+`:rf.xray/resources-tab-data`; the projection algebra is pure data in
+`panels/resources_helpers.cljc` (JVM-portable, unit-tested). Eight
+stacked sections:
+
+1. **Static resource registry** — per registered resource: id, source
+   coords, params/data schemas (summarized — schemas can be large),
+   request summary (transport + that the request is fn-derived), stale /
+   GC policy, tag-producer presence, scope policy, sensitivity/large
+   class, and the **declaring routes** (cross-joined from the route
+   registry's `:resources` metadata).
+2. **Live instances** (per frame) — per cache entry: resource key
+   (scope + params summarized), status, derived `:stale?`, `:has-data?`,
+   data summary, error / refresh-error summaries, `:loaded-at` /
+   `:stale-at` / `:invalidated-at`, generation, attempt, request id,
+   current work id, active owners, owner count, tags, GC eligibility.
+   `:stale?` / `:has-data?` are **derived** here (Spec 016 §Status
+   semantics — never stored facts).
+3. **Work ledger** (per frame) — per work record: work id, kind, linked
+   resource key, generation, status (+ terminal flag), owners, causes
+   (summarized), stale-key (= work id — one identity per record, Spec 016
+   §Ledger row retention), cancellable?, deadline, attempt, transport,
+   outcome. **Raw host handles** (AbortControllers, timeout handles,
+   promises) are structurally inaccessible — they live in side tables
+   outside durable frame-state. Non-terminal (live) rows lead; the
+   terminal recent-races tail trails dimmed.
+4. **Route / resource graph** — per route declaring `:resources`: the
+   route id + path, its declared resources, the **blocking vs
+   non-blocking** split (blocking = **SSR wait point**), keep-previous
+   flags, and any `:after` dependency waterfall. Resolvers
+   (`:params` / `:scope` fns) are recorded as declared without being
+   invoked.
+5. **Lifecycle timeline** — the ordered `:rf.resource/*` trace rows
+   (oldest-first), each carrying op label + semantic class colour,
+   resource id, summarized resource key, generation, owner, summarized
+   cause, and status before/after.
+6. **Invalidation / mutation graph** — the `:rf.resource/invalidated`
+   rows: summarized scope, the invalidated tags, summarized cause, the
+   matched scoped keys, the match count (distinguishes a broad-tag storm
+   and a zero-match "no match in this scope"), and the refetch count.
+7. **Cache growth** — per-resource aggregate of entry count, owned
+   count, and GC-eligible count, plus the totals + live-work count.
+   Surfaces unbounded list-param growth (many entries, few owners).
+8. **Scope audit + lints** — the **standing global-scope security-review
+   list** (every `:rf.scope/global` resource — the structural replacement
+   for the old `/me` heuristic), the **suspicious-explicit-global**
+   warnings (defense-in-depth: an explicit-global resource whose id/doc
+   looks session-dependent), the **scope-mismatch lint** (an entry under
+   scope A while a live sub reads the same R+P under a different scope B),
+   and the **orphaned-owner lint** (an app-minted `[:lease …]` owner
+   pinning an entry with no observed release; route / machine / ssr
+   owners are framework-released and not linted).
+
+When the host has **no resources registered AND no live instances**, the
+panel renders the silent-by-default caption.
+
+## The `:rf.resource/*` trace family
+
+The framework Resources runtime **emits** the `:rf.resource/*` trace rows
+(`:rf.event`-op-type events; the emit seams live in
+`re-frame.resources.events`). Xray **defines the family** — its closed
+operation set, per-op semantic class, and a human label — in
+`panels/resources_helpers.cljc` (`trace-ops` / `resource-trace-op?` /
+`op-class` / `op-label`) so the Resources tab and the Trace tab colour,
+group, and filter resource rows without re-deriving the vocabulary. Any
+keyword in the reserved `rf.resource` namespace is recognised as a family
+member even before the enum is extended.
+
+The operation set + semantic class:
+
+| Operation | Class | Operation | Class |
+|---|---|---|---|
+| `:rf.resource/registered` | lifecycle | `:rf.resource/succeeded` | success |
+| `:rf.resource/ensure` | lifecycle | `:rf.resource/failed` | failure |
+| `:rf.resource/owner-attached` | lifecycle | `:rf.resource/refresh-failed` | failure |
+| `:rf.resource/cache-hit` | dedupe | `:rf.resource/invalidated` | invalidation |
+| `:rf.resource/deduped` | dedupe | `:rf.resource/refetch-decision` | lifecycle |
+| `:rf.resource/fetch-started` | lifecycle | `:rf.resource/owner-released` | lifecycle |
+| `:rf.resource/work-started` | lifecycle | `:rf.resource/gc-scheduled` | gc |
+| `:rf.resource/work-abort-requested` | lifecycle | `:rf.resource/gc-fired` | gc |
+| `:rf.resource/work-completed` | success | `:rf.resource/gc-skipped` | gc |
+| `:rf.resource/work-suppressed` | suppression | `:rf.resource/removed` | lifecycle |
+| `:rf.resource/stale-suppressed` | suppression | `:rf.resource/hydrated` | hydration |
+| `:rf.resource/hydrate-refetch` | hydration | | |
+
+Each row carries, where applicable: frame, work id, scope, resource
+key/id, params summary, generation, request id, owner, cause, status
+before/after, work status, resource/invalidated tags, freshness
+timestamps, and redaction/size markers (Spec 016 §Xray and AI tooling).
+Sensitive trace events are default-suppressed at the Xray consumer seam
+(Spec 009 §Privacy — the whole-envelope gate); the surviving values are
+summarized.
+
+## Tool accessors (the AI / MCP read API)
+
+Five accessors on `day8.re-frame2-xray.runtime` (the Xray↔MCP read seam),
+matching the candidate set in Spec 016 §Xray and AI tooling. All are
+**read-only** and apply the two-layer privacy elision above.
+
+| Accessor | Returns | Filter axes |
+|---|---|---|
+| `list-resources` | the static registry rows | `:resource-id` |
+| `list-resource-instances` | the live per-frame instance rows | `:frame` `:scope` `:resource-id` `:params` `:status` `:stale?` `:tag` `:owner` `:request-id` |
+| `get-resource-state` | one instance's durable state row | `:frame` `:resource-id` `:scope` `:params` (the scoped key) |
+| `get-resource-history` | bounded lifecycle rows | `:frame` `:resource-id` `:nav-token` `:limit` (default 50) |
+| `list-resource-invalidations` | the invalidation graph rows | `:frame` `:tag` |
+
+`:scope` / `:resource-id` / `:params` filter against the raw cache key
+**before** projection (so an accessor can scope its read by the cache
+key); the remaining axes filter the already-projected rows. Per EP-0002
+the frame target is carried explicitly — a frameless call with no
+resolvable context fails closed (`{:ok? false :reason
+:no-frame-resolved}`).
+
+## `:rf.xray/*` registry surface
+
+Installed by `panels/resources.cljs`'s `install!` under the `:rf.xray/*`
+isolation prefix (the registry-key isolation contract,
+[`008-Embedding-Contract.md` §Registry-key isolation](./008-Embedding-Contract.md)).
+No event registered here dispatches a `:rf.resource/*` event (read-only).
+
+### Subscriptions
+
+| Sub | Inputs | Returns |
+|---|---|---|
+| `:rf.xray/registered-resources` | `:rf.xray/trace-buffer`, override | `(rf/registrations :resource)` — the static registry map. |
+| `:rf.xray/resource-entries` | `:rf.xray/target-frame-runtime-db`, override | the live cache entries map at `[:rf.runtime/resources :entries]`. |
+| `:rf.xray/resource-work-ledger` | `:rf.xray/target-frame-runtime-db`, override | the live work-ledger map at `[:rf.runtime/work-ledger]`. |
+| `:rf.xray/resource-sub-reads` | override | observed live subscription reads backing the scope-mismatch lint (empty by default). |
+| `:rf.xray/resources-tab-data` | the four above + `:rf.xray/trace-buffer` + the route registry | the view-facing composite: `{:silent? :registry :instances :work :route-graph :timeline :invalidations :cache-growth :audit}`. |
+
+### Events (test-only override hooks)
+
+`:rf.xray/set-registered-resources-override-for-test`,
+`:rf.xray/set-resource-entries-override-for-test`,
+`:rf.xray/set-resource-work-ledger-override-for-test`,
+`:rf.xray/set-resource-sub-reads-override-for-test` — production code
+paths MUST NOT dispatch these; `nil` clears the override.
+
+## Mountable surface
+
+The Resources tab is independently mountable per the
+[`007-UX-IA.md`](./007-UX-IA.md) §Mountable surface inventory contract:
+
+```clojure
+(day8.re-frame2-xray.panels/mount-resources! mount-point opts) → unmount-fn
+```
+
+enumerated in `day8.re-frame2-xray.panel-enum/panel-enum` (the
+single-source-of-truth guarded by `panel_enum_guard_cljs_test.cljs`).
+
+## Cross-references
+
+- [`spec/016-Resources.md`](../../../spec/016-Resources.md) — the owning
+  framework contract (§Xray and AI tooling, §Status semantics, §Frame
+  work ledger, §Scope resolution, §Active owners and causes,
+  §Invalidation, §Route integration).
+- [`007-UX-IA.md`](./007-UX-IA.md) §Mountable surface inventory — the
+  panel's tier-1 L3-tab row + mount fn.
+- [`014-Registry-Catalogue.md`](./014-Registry-Catalogue.md) §Resources
+  panel — the `:rf.xray/*` registration enumeration.
+- [`013-Trace-Consumer.md`](./013-Trace-Consumer.md) — the consumer
+  pipeline + privacy gate the `:rf.resource/*` family rides.
+- [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) — the
+  registry-key isolation + frame-provider contract.

--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -294,9 +294,12 @@ day8.re-frame2-xray.panels.reactive-panel/Panel
 day8.re-frame2-xray.panels.trace/Panel
 day8.re-frame2-xray.panels.machine-inspector/Panel
 day8.re-frame2-xray.panels.routing/Panel
+day8.re-frame2-xray.panels.resources/Panel
 ;; (rf2-gbz39 — issues-ribbon/Panel removed with the Issues tab per
 ;; Mike's Option (c) ruling; issues surface inline in the Epoch panel +
 ;; the L2 event-row pink-wash + the always-on issues ribbon signal.)
+;; (Resources/Panel — the declarative-server-state lens, Spec 016 §Xray
+;; and AI tooling — is the Dynamic L3 tab after Routing; read-only.)
 ```
 
 (rf2-qy0nu — the 8-panel dead-code sweep removed `causality-graph`,

--- a/tools/xray/spec/README.md
+++ b/tools/xray/spec/README.md
@@ -105,6 +105,16 @@ main read**.
   colour/visual encoding delegated to Figma (§8). Supersedes
   [021 §5](021-Dynamic-Panel-Designs.md#5-the-trace-panel-per-epoch-raw-ops)
   (v1-shipped layout) as the direction-setter.
+- **[024-Resources-Panel.md](024-Resources-Panel.md)** — The Resources
+  tab: the Xray-side consumer contract for declarative server-state
+  (framework [`spec/016-Resources.md`](../../../spec/016-Resources.md)).
+  The eight panel sections (static registry · live instances · work
+  ledger · route/resource graph · lifecycle timeline · invalidation graph
+  · cache growth · scope audit + lints), the `:rf.resource/*` trace
+  family Xray colours/filters, the five read-only tool accessors, and the
+  privacy posture (params/scopes get the SAME summary + size elision as
+  data; read-only — observing pins no resource). Decoupled from the
+  optional Resources artefact.
 
 ### Reference
 

--- a/tools/xray/src/day8/re_frame2_xray/panel_enum.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panel_enum.cljc
@@ -93,6 +93,7 @@
    {:id :trace             :mount "mount-trace!"            :view "trace/Panel"            :tier :l3-tab}
    {:id :machine-inspector :mount "mount-machine-inspector!" :view "machine-inspector/Panel" :tier :l3-tab}
    {:id :routing           :mount "mount-routing!"          :view "routing/Panel"          :tier :l3-tab}
+   {:id :resources         :mount "mount-resources!"        :view "resources/Panel"        :tier :l3-tab}
    ;; The embeddable L2 event spine (008 §Embeddable event spine).
    {:id :event-spine       :mount "mount-event-spine!"      :view "shell/event-list"       :tier :spine}
    ;; Tier 2 — overlay / popup surfaces.

--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -34,6 +34,7 @@
       (mount-trace!            mount-point opts) → unmount-fn
       (mount-machine-inspector! mount-point opts) → unmount-fn
       (mount-routing!          mount-point opts) → unmount-fn
+      (mount-resources!        mount-point opts) → unmount-fn
 
       ;; Spine surface — the L2 event list in isolation (rf2-9k43e).
       ;; The SAME `shell/event-list` reg-view the full 4-layer shell
@@ -110,6 +111,7 @@
   | **trace** | `:rf.xray/trace-feed` (epoch-scoped — projects the focused epoch's `:trace-events` into a flat list of rows, each with a stage column + colour-coded left edge, spec/023 · rf2-aqusw) | `:rf.xray/toggle-trace-row-expand` · `:rf.xray/open-in-editor` |
   | **machine-inspector** | `:rf.xray/machine-chart-data` · `:rf.xray/active-timers-for-focused-machine` · `:rf.xray/machine-scrubber-position` | scrubber events · `:rf.xray/focus-cascade` |
   | **routing** | `:rf.xray/registered-routes` · `:rf.xray/current-route-slice` · `:rf.xray/routing-tab-data` | route-simulation events |
+  | **resources** | `:rf.xray/resources-tab-data` (composite over `:rf.xray/registered-resources` · `:rf.xray/resource-entries` · `:rf.xray/resource-work-ledger` · the route registry · the trace buffer) | (read-only — no dispatch; observing pins no resource) |
   | **segment-inspector** | `:rf.xray/segment-inspector-open?` · `:rf.xray/segment-inspector-value` | `:rf.xray/close-segment-inspector` |
   | **cancellation-cascade** (side-panel + popover) | `:rf.xray/cancellation-cascade-for-focused-machine` · `:rf.xray/cancellation-cascade-for-focused-event` · `:rf.xray/cancellation-cascade-popover-open?` · `:rf.xray/modal-positioning` | `:rf.xray/cancellation-cascade-close` |
   | **managed-fx** | `:rf.xray/managed-fx-for-focused-event` | `:rf.xray/focus-event` |
@@ -156,6 +158,7 @@
             [day8.re-frame2-xray.panels.machine-inspector :as machine-inspector]
             [day8.re-frame2-xray.panels.managed-fx-template :as managed-fx]
             [day8.re-frame2-xray.panels.routing :as routing]
+            [day8.re-frame2-xray.panels.resources :as resources]
             [day8.re-frame2-xray.panels.trace :as trace]
             [day8.re-frame2-xray.panels.reactive-panel :as reactive-panel]
             [day8.re-frame2-xray.shell :as shell]))
@@ -270,6 +273,15 @@
   the registered-routes lens + simulate-URL surface."
   ([mount-point]      (mount-routing! mount-point nil))
   ([mount-point opts] (render-panel! routing/Panel mount-point opts)))
+
+(defn mount-resources!
+  "Mount Xray's Resources tab in isolation at `mount-point` (Spec 016
+  §Xray and AI tooling). Renders the static resource registry, the live
+  per-frame instance + work-ledger tables, the route/resource graph, the
+  lifecycle timeline, the invalidation graph, the cache-growth view, and
+  the scope audit + lints. Read-only — observing pins no resource."
+  ([mount-point]      (mount-resources! mount-point nil))
+  ([mount-point opts] (render-panel! resources/Panel mount-point opts)))
 
 (defn mount-event-spine!
   "Mount Xray's L2 event spine in isolation at `mount-point` (rf2-9k43e).

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -1,0 +1,647 @@
+(ns day8.re-frame2-xray.panels.resources
+  "Resources tab — the Xray surface for declarative server-state (Spec
+  016 §Xray and AI tooling). The 'where is my server state, what owns
+  it, and is it stale?' lens.
+
+  ## Sections (top → bottom, per Spec 016 §Xray and AI tooling)
+
+      │ STATIC RESOURCE REGISTRY                                        │
+      │   :article/by-slug  scope=global  stale 60s  gc 5m  routes…     │
+      │ ─────────────────────────────────────────────────────────────  │
+      │ LIVE INSTANCES  (per frame · scope/params SUMMARIZED)          │
+      │   :article/by-slug  loaded  gen 4  owners 1  fresh             │
+      │ ─────────────────────────────────────────────────────────────  │
+      │ WORK LEDGER  (live attempts · host handles inaccessible)       │
+      │   [resource …4]  running  cancellable  deadline                │
+      │ ─────────────────────────────────────────────────────────────  │
+      │ ROUTE / RESOURCE GRAPH  (blocking = SSR wait point)           │
+      │ LIFECYCLE TIMELINE · INVALIDATION GRAPH · CACHE GROWTH        │
+      │ SCOPE AUDIT  (every :rf.scope/global) + LINTS                  │
+
+  ## Read-only — Xray MUST NOT become an owner by observing
+
+  Spec 016 §Active owners and causes: opening this panel pins NOTHING.
+  Every section is a pure read of `(rf/registrations …)` + the runtime-db
+  cache/ledger slices + the trace buffer. The panel dispatches no
+  `:rf.resource/ensure`, attaches no owner, refetches nothing, and
+  extends no GC. (A future explicit 'pin this resource' debug action
+  would be its own traced tool mutation, not normal inspection.)
+
+  ## PRIVACY — summaries, never raw values
+
+  Spec 016: params, scopes, AND data get the SAME privacy + size elision.
+  Every value in every row is a `resources-helpers/summarize` shape (type
+  + bounded size + redaction-aware preview), never the raw value. Scopes
+  carry user/tenant/locale/impersonation ids and are summarized exactly
+  like data.
+
+  ## Decoupled from the resources artefact (bundle isolation)
+
+  Xray does NOT `:require` `re-frame.resources.*` — resources is a
+  post-v1 OPTIONAL artefact and not a hard Xray dep. The panel reads
+  decoupled: the static registry via `(rf/registrations :resource)`, the
+  live cache/ledger from the runtime-db partition slice the spine already
+  publishes (`:rf.xray/target-frame-runtime-db`), and the trace family
+  from `:rf.xray/trace-buffer`. Identical posture to the Routing tab
+  (route slice) + Machine Inspector (machine snapshots).
+
+  ## Pure hiccup
+
+  Same contract as every Xray panel — the view is pure hiccup, no
+  Reagent/UIx/Helix references. Frame isolation comes from the enclosing
+  `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`. Projection
+  algebra lives in `resources_helpers.cljc` (JVM-portable)."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.panels.resources-helpers :as h]
+            [day8.re-frame2-xray.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- accent -------------------------------------------------------------
+;;
+;; The Resources panel's accent is the cyan-leaning `:info` token —
+;; distinct from Routing's GitHub-blue `:accent` so the two server-state
+;; sub-domain tabs read apart at a glance.
+
+(def ^:private mode-accent (:info tokens))
+
+;; ---- status colour ------------------------------------------------------
+
+(defn- status-colour
+  "Resource-status → token (Spec 016 §Status semantics). `:loaded` green,
+  `:loading`/`:fetching` accent (in flight), `:error` red, `:idle`
+  muted."
+  [status]
+  (case status
+    :loaded   (:green tokens)
+    :loading  mode-accent
+    :fetching mode-accent
+    :error    (:error tokens)
+    (:text-tertiary tokens)))
+
+;; ---- shared primitives --------------------------------------------------
+
+(defn- section-caption
+  [label testid]
+  [:div {:data-testid testid
+         :style       {:color          (:text-tertiary tokens)
+                       :font-family    sans-stack
+                       :font-size      "10px"
+                       :font-weight    600
+                       :text-transform "uppercase"
+                       :letter-spacing "0.5px"
+                       :margin-bottom  "8px"}}
+   label])
+
+(defn- section
+  [{:keys [first? testid]} caption body]
+  [:section {:data-testid testid
+             :style       (cond-> {:padding "12px 16px"}
+                            (not first?)
+                            (assoc :border-top
+                                   (str "1px solid " (:border-subtle tokens))))}
+   caption
+   body])
+
+(defn- summary-chip
+  "Render a `resources-helpers/summarize` shape as a compact, render-safe
+  chip — NEVER the raw value. Redacted → muted `[redacted]`; large →
+  amber `[large]`; else the bounded preview + a `(N)` size badge for
+  collections."
+  [{:keys [type size preview redacted? large?]} testid]
+  [:span {:data-testid testid
+          :style       {:font-family mono-stack
+                        :font-size   "11px"
+                        :color       (cond
+                                       redacted? (:text-tertiary tokens)
+                                       large?    (:warning tokens)
+                                       :else     (:text-primary tokens))}}
+   (str preview
+        (when (and size (#{"map" "set" "vector" "seq"} type))
+          (str " (" size ")")))])
+
+(defn- empty-caption [text testid]
+  [:div {:data-testid testid
+         :style       {:color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-style  "italic"
+                       :font-size   "11px"}}
+   text])
+
+;; ---- §1 STATIC RESOURCE REGISTRY ---------------------------------------
+
+(defn- registry-row-view [row]
+  (let [rid (:resource-id row)
+        testid (str "rf-xray-resources-registry-row-"
+                    (when rid (-> rid str (subs 1))))]
+    [:div {:data-testid testid
+           :data-resource-id (str rid)
+           :style {:display       "flex"
+                   :align-items   "baseline"
+                   :gap           "10px"
+                   :flex-wrap     "wrap"
+                   :padding       "3px 0"
+                   :font-family   mono-stack
+                   :font-size     "12px"
+                   :color         (:text-primary tokens)}}
+     [:span {:data-testid (str testid "-id")
+             :style       {:color mode-accent :font-weight 600 :min-width "10rem"}}
+      (str rid)]
+     [:span {:data-testid (str testid "-scope")
+             :style       {:color (if (get-in row [:scope :global?])
+                                    (:warning tokens)
+                                    (:text-tertiary tokens))}}
+      "scope=" (get-in row [:scope :label])]
+     [:span {:style {:color (:text-tertiary tokens)}}
+      (get-in row [:request :label])]
+     (when-let [ms (:stale-after-ms row)]
+       [:span {:style {:color (:text-tertiary tokens)}} "stale " ms "ms"])
+     (when-let [ms (:gc-after-ms row)]
+       [:span {:style {:color (:text-tertiary tokens)}} "gc " ms "ms"])
+     (when (:tags? row)
+       [:span {:style {:color (:text-tertiary tokens)}} "tags-fn"])
+     (when (:sensitive? row)
+       [:span {:data-testid (str testid "-sensitive")
+               :style {:color (:warning tokens)}} "sensitive"])
+     (when (seq (:declaring-routes row))
+       [:span {:data-testid (str testid "-routes")
+               :style {:color (:text-tertiary tokens)}}
+        "routes: " (str/join " " (map str (:declaring-routes row)))])]))
+
+(defn- registry-section [rows]
+  (section
+    {:first? true :testid "rf-xray-resources-registry"}
+    (section-caption "Static resource registry" "rf-xray-resources-registry-caption")
+    (if (seq rows)
+      (into [:div {:data-testid "rf-xray-resources-registry-body"
+                   :style {:display "flex" :flex-direction "column" :gap "2px"}}]
+            (for [row rows]
+              ^{:key (str (:resource-id row))} (registry-row-view row)))
+      (empty-caption "No resources registered in the host app."
+                     "rf-xray-resources-registry-empty"))))
+
+;; ---- §2 LIVE INSTANCES --------------------------------------------------
+
+(defn- instance-row-view [row]
+  (let [testid (str "rf-xray-resources-instance-row-"
+                    (when (:resource-id row) (-> row :resource-id str (subs 1)))
+                    "-g" (:generation row))]
+    [:div {:data-testid testid
+           :style {:display       "flex"
+                   :align-items   "baseline"
+                   :gap           "10px"
+                   :flex-wrap     "wrap"
+                   :padding       "3px 0"
+                   :font-family   mono-stack
+                   :font-size     "12px"}}
+     [:span {:style {:color mode-accent :font-weight 600 :min-width "10rem"}}
+      (str (:resource-id row))]
+     [:span {:data-testid (str testid "-status")
+             :style {:color (status-colour (:status row)) :font-weight 600}}
+      (str (some-> (:status row) name))]
+     (when (:stale? row)
+       [:span {:data-testid (str testid "-stale")
+               :style {:color (:warning tokens)}} "stale"])
+     [:span {:style {:color (:text-tertiary tokens)}} "gen " (:generation row)]
+     [:span {:style {:color (:text-tertiary tokens)}}
+      "owners " (:owner-count row)]
+     (when (:gc-eligible? row)
+       [:span {:data-testid (str testid "-gc")
+               :style {:color (:text-tertiary tokens)}} "gc-eligible"])
+     [:span {:style {:color (:text-tertiary tokens)}} "scope"]
+     (summary-chip (:scope row) (str testid "-scope"))
+     [:span {:style {:color (:text-tertiary tokens)}} "params"]
+     (summary-chip (:params row) (str testid "-params"))
+     [:span {:style {:color (:text-tertiary tokens)}} "data"]
+     (summary-chip (:data row) (str testid "-data"))
+     (when (:error row)
+       [:span {:data-testid (str testid "-error")
+               :style {:color (:error tokens)}}
+        "error " (get-in row [:error :preview])])
+     (when (:refresh-error row)
+       [:span {:data-testid (str testid "-refresh-error")
+               :style {:color (:warning tokens)}}
+        "refresh-error " (get-in row [:refresh-error :preview])])]))
+
+(defn- instances-section [rows]
+  (section
+    {:first? false :testid "rf-xray-resources-instances"}
+    (section-caption "Live instances" "rf-xray-resources-instances-caption")
+    (if (seq rows)
+      (into [:div {:data-testid "rf-xray-resources-instances-body"
+                   :style {:display "flex" :flex-direction "column" :gap "2px"}}]
+            (for [row rows]
+              ^{:key (str (:scoped-key row))} (instance-row-view row)))
+      (empty-caption "No live resource instances in this frame."
+                     "rf-xray-resources-instances-empty"))))
+
+;; ---- §3 WORK LEDGER -----------------------------------------------------
+
+(defn- work-row-view [row]
+  (let [testid (str "rf-xray-resources-work-row-"
+                    (hash (:work-id row)))]
+    [:div {:data-testid testid
+           :data-terminal (str (:terminal? row))
+           :style {:display     "flex"
+                   :align-items "baseline"
+                   :gap         "10px"
+                   :flex-wrap   "wrap"
+                   :padding     "3px 0"
+                   :font-family mono-stack
+                   :font-size   "12px"
+                   :opacity     (if (:terminal? row) 0.6 1)}}
+     [:span {:style {:color mode-accent :font-weight 600}}
+      (str (get-in row [:resource-key :resource-id]))]
+     [:span {:data-testid (str testid "-status")
+             :style {:color (if (:terminal? row)
+                              (:text-tertiary tokens)
+                              (:green tokens))
+                     :font-weight 600}}
+      (str (some-> (:status row) name))]
+     [:span {:style {:color (:text-tertiary tokens)}} "gen " (:generation row)]
+     (when (:cancellable? row)
+       [:span {:style {:color (:text-tertiary tokens)}} "cancellable"])
+     (when (:deadline-at row)
+       [:span {:style {:color (:text-tertiary tokens)}}
+        "deadline " (:deadline-at row)])
+     (when (:attempt row)
+       [:span {:style {:color (:text-tertiary tokens)}} "attempt " (:attempt row)])
+     (when (seq (:owners row))
+       [:span {:style {:color (:text-tertiary tokens)}}
+        "owners " (count (:owners row))])
+     (when (:outcome row)
+       [:span {:style {:color (:text-tertiary tokens)}}
+        "outcome " (get-in row [:outcome :preview])])]))
+
+(defn- work-ledger-section [rows]
+  (section
+    {:first? false :testid "rf-xray-resources-work"}
+    (section-caption "Work ledger" "rf-xray-resources-work-caption")
+    (if (seq rows)
+      (into [:div {:data-testid "rf-xray-resources-work-body"
+                   :style {:display "flex" :flex-direction "column" :gap "2px"}}]
+            (for [row rows]
+              ^{:key (str (:work-id row))} (work-row-view row)))
+      (empty-caption "No in-flight or recent resource work in this frame."
+                     "rf-xray-resources-work-empty"))))
+
+;; ---- §4 ROUTE / RESOURCE GRAPH -----------------------------------------
+
+(defn- route-graph-row-view [node]
+  (let [testid (str "rf-xray-resources-route-row-"
+                    (when (:route-id node) (-> node :route-id str (subs 1))))]
+    [:div {:data-testid testid
+           :style {:display "flex" :flex-direction "column" :gap "2px"
+                   :padding "4px 0"}}
+     [:div {:style {:display "flex" :gap "10px" :align-items "baseline"
+                    :font-family mono-stack :font-size "12px"}}
+      [:span {:style {:color mode-accent :font-weight 600}}
+       (str (:route-id node))]
+      (when (:path node)
+        [:span {:style {:color (:text-tertiary tokens)}} (:path node)])
+      (when (:ssr-wait? node)
+        [:span {:data-testid (str testid "-ssr-wait")
+                :style {:color (:warning tokens)}} "SSR wait point"])]
+     (into [:div {:style {:display "flex" :flex-wrap "wrap" :gap "8px"
+                          :padding-left "12px" :font-family mono-stack
+                          :font-size "11px"}}]
+           (for [res (:resources node)]
+             ^{:key (str (:resource res) (:local-id res))}
+             [:span {:style {:color (if (:blocking? res)
+                                     (:warning tokens)
+                                     (:text-tertiary tokens))}}
+              (str (:resource res))
+              (if (:blocking? res) " [blocking]" " [non-blocking]")
+              (when (:keep-previous? res) " keep-prev")
+              (when (seq (:after res)) (str " after " (str/join "," (map str (:after res)))))]))]))
+
+(defn- route-graph-section [nodes]
+  (section
+    {:first? false :testid "rf-xray-resources-route-graph"}
+    (section-caption "Route / resource graph" "rf-xray-resources-route-graph-caption")
+    (if (seq nodes)
+      (into [:div {:data-testid "rf-xray-resources-route-graph-body"
+                   :style {:display "flex" :flex-direction "column" :gap "4px"}}]
+            (for [node nodes]
+              ^{:key (str (:route-id node))} (route-graph-row-view node)))
+      (empty-caption "No routes declare :resources."
+                     "rf-xray-resources-route-graph-empty"))))
+
+;; ---- §5 LIFECYCLE TIMELINE ---------------------------------------------
+
+(defn- timeline-row-view [row]
+  [:div {:data-testid (str "rf-xray-resources-timeline-row-" (:id row))
+         :data-op     (str (:operation row))
+         :style {:display "flex" :gap "8px" :align-items "baseline"
+                 :padding "2px 0" :font-family mono-stack :font-size "11px"}}
+   [:span {:style {:color (case (:class row)
+                            :success      (:green tokens)
+                            :failure      (:error tokens)
+                            :suppression  (:warning tokens)
+                            :invalidation (:orange tokens)
+                            :gc           (:text-tertiary tokens)
+                            :dedupe       (:info tokens)
+                            :hydration    (:purple tokens)
+                            (:text-primary tokens))
+                   :font-weight 600 :min-width "9rem"}}
+    (:label row)]
+   [:span {:style {:color mode-accent}} (str (:resource-id row))]
+   (when (:generation row)
+     [:span {:style {:color (:text-tertiary tokens)}} "gen " (:generation row)])])
+
+(defn- timeline-section [rows]
+  (section
+    {:first? false :testid "rf-xray-resources-timeline"}
+    (section-caption "Lifecycle timeline" "rf-xray-resources-timeline-caption")
+    (if (seq rows)
+      (into [:div {:data-testid "rf-xray-resources-timeline-body"
+                   :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+            (for [row rows]
+              ^{:key (str (:id row))} (timeline-row-view row)))
+      (empty-caption "No resource lifecycle events in this epoch."
+                     "rf-xray-resources-timeline-empty"))))
+
+;; ---- §6 INVALIDATION GRAPH ----------------------------------------------
+
+(defn- invalidation-row-view [row]
+  [:div {:data-testid (str "rf-xray-resources-invalidation-row-" (:id row))
+         :style {:display "flex" :gap "8px" :align-items "baseline"
+                 :padding "2px 0" :font-family mono-stack :font-size "11px"}}
+   [:span {:style {:color (:orange tokens) :font-weight 600}} "invalidate"]
+   [:span {:style {:color (:text-primary tokens)}}
+    (str/join " " (map pr-str (:tags row)))]
+   [:span {:data-testid (str "rf-xray-resources-invalidation-match-" (:id row))
+           :style {:color (if (zero? (:match-count row))
+                           (:text-tertiary tokens)
+                           (:text-primary tokens))}}
+    (:match-count row) " matched"]
+   [:span {:style {:color (:text-tertiary tokens)}}
+    (:refetched row) " refetched"]])
+
+(defn- invalidation-section [rows]
+  (section
+    {:first? false :testid "rf-xray-resources-invalidation"}
+    (section-caption "Invalidation / mutation graph" "rf-xray-resources-invalidation-caption")
+    (if (seq rows)
+      (into [:div {:data-testid "rf-xray-resources-invalidation-body"
+                   :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+            (for [row rows]
+              ^{:key (str (:id row))} (invalidation-row-view row)))
+      (empty-caption "No invalidations in this epoch."
+                     "rf-xray-resources-invalidation-empty"))))
+
+;; ---- §7 CACHE GROWTH ----------------------------------------------------
+
+(defn- cache-growth-section [growth]
+  (section
+    {:first? false :testid "rf-xray-resources-cache-growth"}
+    (section-caption "Cache growth" "rf-xray-resources-cache-growth-caption")
+    [:div {:style {:font-family mono-stack :font-size "11px"
+                   :color (:text-primary tokens)}}
+     [:div {:data-testid "rf-xray-resources-cache-growth-totals"
+            :style {:color (:text-tertiary tokens) :margin-bottom "4px"}}
+      (:total-entries growth) " entries · "
+      (:total-gc-eligible growth) " gc-eligible · "
+      (:live-work growth) " live work"]
+     (into [:div {:style {:display "flex" :flex-direction "column" :gap "1px"}}]
+           (for [r (:by-resource growth)]
+             ^{:key (str (:resource-id r))}
+             [:div {:style {:display "flex" :gap "8px"}}
+              [:span {:style {:color mode-accent :min-width "10rem"}}
+               (str (:resource-id r))]
+              [:span {:style {:color (:text-tertiary tokens)}}
+               (:entry-count r) " entries"]
+              [:span {:style {:color (:text-tertiary tokens)}}
+               (:owned-count r) " owned"]
+              (when (pos? (:gc-eligible r))
+                [:span {:style {:color (:warning tokens)}}
+                 (:gc-eligible r) " gc-eligible"])]))]))
+
+;; ---- §8 SCOPE AUDIT + LINTS --------------------------------------------
+
+(defn- audit-section [{:keys [global-audit suspicious mismatches orphans]}]
+  (section
+    {:first? false :testid "rf-xray-resources-audit"}
+    (section-caption "Scope audit + lints" "rf-xray-resources-audit-caption")
+    [:div {:style {:display "flex" :flex-direction "column" :gap "6px"
+                   :font-family mono-stack :font-size "11px"}}
+     ;; the standing global-scope security-review list
+     [:div {:data-testid "rf-xray-resources-audit-global"}
+      [:span {:style {:color (:text-tertiary tokens)}} ":rf.scope/global resources: "]
+      (if (seq global-audit)
+        [:span {:style {:color (:text-primary tokens)}}
+         (str/join " " (map (comp str :resource-id) global-audit))]
+        [:span {:style {:color (:text-tertiary tokens) :font-style "italic"}} "none"])]
+     ;; suspicious explicit-global warnings (defense-in-depth)
+     (when (seq suspicious)
+       (into [:div {:data-testid "rf-xray-resources-audit-suspicious"
+                    :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+             (for [w suspicious]
+               ^{:key (str (:resource-id w))}
+               [:div {:style {:color (:warning tokens)}}
+                "⚠ " (str (:resource-id w)) " — " (:hint w)])))
+     ;; scope-mismatch lint
+     (when (seq mismatches)
+       (into [:div {:data-testid "rf-xray-resources-audit-mismatch"
+                    :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+             (for [m mismatches]
+               ^{:key (str (:resource-id m) (get-in m [:sub-scope :preview]))}
+               [:div {:style {:color (:error tokens)}}
+                "scope mismatch on " (str (:resource-id m))
+                " — sub scope " (get-in m [:sub-scope :preview])
+                " ≠ entry scope " (get-in m [:entry-scope :preview])])))
+     ;; orphaned-owner lint
+     (when (seq orphans)
+       (into [:div {:data-testid "rf-xray-resources-audit-orphan"
+                    :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+             (for [o orphans]
+               ^{:key (str (:owner o))}
+               [:div {:style {:color (:warning tokens)}}
+                "orphaned owner " (pr-str (:owner o))
+                " pins " (str (:resource-id o))])))]))
+
+;; ---- empty (no resources artefact / no resources registered) -----------
+
+(defn- silent-state []
+  [:div {:data-testid "rf-xray-resources-silent"
+         :style       {:padding        "16px"
+                       :display        "flex"
+                       :flex-direction "column"
+                       :gap            "8px"
+                       :color          (:text-tertiary tokens)
+                       :font-family    sans-stack
+                       :font-size      "11px"}}
+   [:span {:style {:font-style "italic"}}
+    "No resources registered in the host app."]
+   [:span {:style {:color (:text-tertiary tokens)}}
+    "Register resources via "
+    [:code {:style {:color mode-accent :font-family mono-stack}}
+     "re-frame.resources/reg-resource"]
+    " — the registry + live-instance tables render once the host installs them."]])
+
+;; ---- public view --------------------------------------------------------
+
+(rf/reg-view Panel
+  "The Resources tab's root view (Spec 016 §Xray and AI tooling).
+  Subscribes to `:rf.xray/resources-tab-data` and renders the eight
+  sections top → bottom: static registry, live instances, work ledger,
+  route/resource graph, lifecycle timeline, invalidation graph, cache
+  growth, scope audit + lints. When the host has no resources registered
+  AND no live instances, renders the silent-by-default caption."
+  []
+  (let [{:keys [silent? registry instances work route-graph timeline
+                invalidations cache-growth audit]}
+        @(rf/subscribe [:rf.xray/resources-tab-data])]
+    [:section {:data-testid "rf-xray-resources"
+               :style {:height         "100%"
+                       :display        "flex"
+                       :flex-direction "column"
+                       :background     (:bg-2 tokens)
+                       :color          (:text-primary tokens)
+                       :font-family    sans-stack
+                       :font-size      "14px"
+                       :overflow       "auto"}}
+     (if silent?
+       (silent-state)
+       [:<>
+        (registry-section registry)
+        (instances-section instances)
+        (work-ledger-section work)
+        (route-graph-section route-graph)
+        (timeline-section timeline)
+        (invalidation-section invalidations)
+        (cache-growth-section cache-growth)
+        (audit-section audit)])]))
+
+;; ---- registration entry --------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Resources panel's Xray-side registrations.
+
+  Registers (all under the `:rf.xray/*` isolation prefix):
+
+    - `:rf.xray/registered-resources` — `(rf/registrations :resource)`
+      (process-global, frame-agnostic; the static registry). Test
+      override via `:registered-resources-override`.
+    - `:rf.xray/resource-entries` — the live cache entries map from the
+      observed frame's RUNTIME-DB partition at
+      `[:rf.runtime/resources :entries]` (EP-0001 — resource cache is
+      framework-owned runtime-db state, never app-db). Sourced from
+      `:rf.xray/target-frame-runtime-db`. Test override.
+    - `:rf.xray/resource-work-ledger` — the live work-ledger map from
+      `[:rf.runtime/work-ledger]`. Test override.
+    - `:rf.xray/resource-sub-reads` — observed live subscription reads
+      (`[{:resource-id :params :scope} …]`) backing the scope-mismatch
+      lint. Empty by default; the host/runtime populates it (test
+      override slot).
+    - `:rf.xray/resources-tab-data` — the view-facing composite over the
+      registry + entries + ledger + route registry + trace buffer; the
+      single read the Panel subscribes.
+
+  Read-only: NO event registered here dispatches a `:rf.resource/*`
+  event — inspection never becomes an owner (Spec 016)."
+  []
+
+  ;; Test-only override slots ---------------------------------------------
+
+  (rf/reg-event-db :rf.xray/set-registered-resources-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov) (dissoc db :registered-resources-override)
+          (assoc db :registered-resources-override ov))))
+  (rf/reg-sub :rf.xray/registered-resources-override
+    (fn [db _] (get db :registered-resources-override)))
+
+  (rf/reg-event-db :rf.xray/set-resource-entries-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov) (dissoc db :resource-entries-override)
+          (assoc db :resource-entries-override ov))))
+  (rf/reg-sub :rf.xray/resource-entries-override
+    (fn [db _] (get db :resource-entries-override)))
+
+  (rf/reg-event-db :rf.xray/set-resource-work-ledger-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov) (dissoc db :resource-work-ledger-override)
+          (assoc db :resource-work-ledger-override ov))))
+  (rf/reg-sub :rf.xray/resource-work-ledger-override
+    (fn [db _] (get db :resource-work-ledger-override)))
+
+  (rf/reg-event-db :rf.xray/set-resource-sub-reads-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov) (dissoc db :resource-sub-reads-override)
+          (assoc db :resource-sub-reads-override ov))))
+  (rf/reg-sub :rf.xray/resource-sub-reads-override
+    (fn [db _] (get db :resource-sub-reads-override)))
+
+  ;; Production data subs --------------------------------------------------
+
+  (rf/reg-sub :rf.xray/registered-resources
+    :<- [:rf.xray/trace-buffer]
+    :<- [:rf.xray/registered-resources-override]
+    (fn [[_buffer override] _]
+      (or override (rf/registrations :resource))))
+
+  (rf/reg-sub :rf.xray/resource-entries
+    :<- [:rf.xray/target-frame-runtime-db]
+    :<- [:rf.xray/resource-entries-override]
+    (fn [[target-runtime-db override] _]
+      (cond
+        (some? override)         override
+        (map? target-runtime-db) (get-in target-runtime-db h/entries-rel-path)
+        :else                    nil)))
+
+  (rf/reg-sub :rf.xray/resource-work-ledger
+    :<- [:rf.xray/target-frame-runtime-db]
+    :<- [:rf.xray/resource-work-ledger-override]
+    (fn [[target-runtime-db override] _]
+      (cond
+        (some? override)         override
+        (map? target-runtime-db) (get target-runtime-db h/work-ledger-key)
+        :else                    nil)))
+
+  (rf/reg-sub :rf.xray/resource-sub-reads
+    :<- [:rf.xray/resource-sub-reads-override]
+    (fn [override _] (or override [])))
+
+  ;; View-facing composite -------------------------------------------------
+
+  (rf/reg-sub :rf.xray/resources-tab-data
+    :<- [:rf.xray/registered-resources]
+    :<- [:rf.xray/resource-entries]
+    :<- [:rf.xray/resource-work-ledger]
+    :<- [:rf.xray/trace-buffer]
+    :<- [:rf.xray/resource-sub-reads]
+    (fn [[registrations entries ledger trace-buffer sub-reads] _]
+      (let [now-ms        (.now js/Date)
+            routes-map    (rf/registrations :route)
+            registry-rows (h/project-registry registrations routes-map)
+            instance-rows (h/project-instances entries now-ms)
+            work-rows     (h/project-work-ledger ledger)]
+        {:silent?       (and (empty? registry-rows) (empty? instance-rows))
+         :registry      registry-rows
+         :instances     instance-rows
+         :work          work-rows
+         :route-graph   (h/project-route-graph routes-map)
+         :timeline      (h/lifecycle-timeline trace-buffer)
+         :invalidations (h/invalidation-graph trace-buffer)
+         :cache-growth  (h/cache-growth instance-rows work-rows)
+         :audit         {:global-audit (h/global-scope-audit registry-rows)
+                         :suspicious   (h/suspicious-global-warnings registry-rows)
+                         :mismatches   (h/scope-mismatch-lint instance-rows sub-reads)
+                         :orphans      (h/orphaned-owner-lint instance-rows trace-buffer)}})))
+
+  ;; Register the Dynamic Resources tab with the internal L4 tab registry.
+  ;; Per Mike's cohesive-sub-domain ruling (server-state earns its own L4
+  ;; tab rather than piling into App-db). Order 7 — after Routes (order 6),
+  ;; keeping the two cross-feature runtime-db tabs adjacent. Display label
+  ;; is the plural domain noun "Resources" (all-plural-domain-noun
+  ;; convention).
+  (panel-registry/reg-l4-tab!
+    {:id    :resources
+     :label "Resources"
+     :mnem  "s"
+     :modes #{:dynamic}
+     :order 7
+     :panel Panel})
+
+  nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -1,0 +1,883 @@
+(ns day8.re-frame2-xray.panels.resources-helpers
+  "Pure-data projection + the `:rf.resource/*` trace-family declaration
+  for Xray's Resources tab (Spec 016 §Xray and AI tooling).
+
+  ## Why a `.cljc` helpers split
+
+  Same contract as every other panel's `*_helpers.cljc`: the projection
+  algebra (registry rows, live-instance rows, work-ledger rows, the
+  route/resource graph, the lifecycle timeline, the invalidation graph,
+  the cache-growth view, and the two lints) is PURE data — no substrate,
+  no Reagent/UIx/Helix, no DOM. Keeping it here means the algebra runs
+  under the JVM unit-test target and the CLJS view (`resources.cljs`)
+  stays a thin hiccup renderer over these projections.
+
+  ## Bundle isolation + decoupling from the resources artefact
+
+  Xray does NOT `:require` anything under `implementation/resources/`.
+  Resources is a POST-V1 OPTIONAL artefact (Spec 016 §Implementation
+  status) and is NOT a hard dep of Xray. The panel reads everything
+  decoupled, exactly the way the Routing tab reads the route slice and
+  the Machine Inspector reads machine snapshots:
+
+    - the STATIC resource registry via `(rf/registrations :resource)`
+      (process-global registrar) — no require;
+    - the LIVE per-frame instance table from the runtime-db partition
+      slice at `[:rf.runtime/resources :entries]` — no require;
+    - the LIVE per-frame work ledger from `[:rf.runtime/work-ledger]`;
+    - the trace stream (`:rf.resource/*` op rows) from the trace buffer.
+
+  The reserved key paths below are duplicated as small literal constants
+  rather than read from `re-frame.resources.state` — duplicating three
+  reserved keywords is the bundle-isolation-safe price of not adding a
+  require edge from a tool into an optional artefact. They are the
+  reserved runtime-db keys fixed in [Conventions §Reserved runtime-db
+  keys]; a drift would be caught by the panel's CLJS wiring test.
+
+  ## PRIVACY (Spec 016 §Xray and AI tooling — load-bearing)
+
+  Tool surfaces PREFER SUMMARIES over raw values. Params, scopes, AND
+  data get the SAME privacy + size elision — scopes carry user ids,
+  tenant ids, locale, and impersonation markers, so a scope is exactly
+  as sensitive as data. The panel NEVER renders a raw param/scope/data
+  value; it renders a `summarize`d shape (type + bounded size + a small
+  redaction-aware preview). Off-box egress (the MCP/AI tool accessors)
+  routes the same values through the framework `egress-value` walker in
+  `runtime.cljs`; this ns supplies the IN-PANEL summary that is safe to
+  render to a human operator and bounded so a huge data blob never
+  floods the panel.
+
+  Xray MUST NOT become an owner by observing (Spec 016 §Active owners
+  and causes): every projection here is a PURE READ. Nothing in this ns
+  dispatches `:rf.resource/ensure`, attaches an owner, refetches, or
+  extends GC — inspection has zero side effects on resource liveness."
+  #?(:cljs (:require [clojure.string :as str])
+     :clj  (:require [clojure.string :as str])))
+
+;; ---------------------------------------------------------------------------
+;; Reserved runtime-db paths (decoupled literals — see ns docstring).
+;; ---------------------------------------------------------------------------
+
+(def resources-key
+  "Reserved runtime-db key for the resource cache subtree
+  (`:rf.runtime/resources`). Per Spec 016 §Cache home and write
+  authority. Duplicated literal — Xray does not require the resources
+  artefact (bundle isolation)."
+  :rf.runtime/resources)
+
+(def work-ledger-key
+  "Reserved runtime-db key for the frame work ledger subtree
+  (`:rf.runtime/work-ledger`). Per Spec 016 §Frame work ledger."
+  :rf.runtime/work-ledger)
+
+(def entries-rel-path
+  "Runtime-db-relative path to the cache entries map. Per Spec 016."
+  [resources-key :entries])
+
+(def tag-index-rel-path
+  "Runtime-db-relative path to the reverse tag index."
+  [resources-key :tag-index])
+
+(def owner-index-rel-path
+  "Runtime-db-relative path to the reverse owner index."
+  [resources-key :owner-index])
+
+;; ---------------------------------------------------------------------------
+;; The `:rf.resource/*` trace family (Spec 016 §Xray and AI tooling).
+;; ---------------------------------------------------------------------------
+;;
+;; The runtime EMITS these `:rf.event`-op-type rows (the emit seams
+;; already exist in `re-frame.resources.events` — `:rf.resource/deduped`,
+;; `:fetch-started`, `:invalidated`, `:owner-released`, `:removed`,
+;; `:succeeded`/`:failed`/`:refresh-failed`, `:stale-suppressed`,
+;; `:gc-fired`/`:gc-skipped`, `:work-abort-requested`, …). Xray DEFINES
+;; the family (its closed operation set, per-op colour class, and a
+;; human label) so the Resources tab + the Trace tab can colour, group,
+;; and filter resource rows without re-deriving the vocabulary.
+;;
+;; Each op carries, where applicable: frame, work id, scope, resource
+;; key/id, params summary, generation, request id, owner, cause, status
+;; before/after, work status, resource/invalidated tags, freshness
+;; timestamps, and redaction/size markers (Spec 016).
+
+(def trace-family-prefix
+  "The reserved trace-family namespace prefix for resource trace rows.
+  An operation keyword whose namespace is `\"rf.resource\"` belongs to
+  the resource family. Per [Conventions §Reserved namespaces]."
+  "rf.resource")
+
+(def trace-ops
+  "The closed `:rf.resource/*` trace-family operation set with the
+  per-op semantic class + a short human label, ordered roughly by
+  lifecycle. The `:class` keys the panel + Trace-tab colour mapping
+  (`op-class->token`): `:lifecycle` (neutral progress), `:success`,
+  `:failure`, `:dedupe` (a join/cache-hit, no new work), `:invalidation`,
+  `:gc`, `:suppression` (stale reply suppressed — a correctness event),
+  and `:hydration`. Per Spec 016 §Xray and AI tooling (the trace-family
+  enumeration)."
+  {:rf.resource/registered           {:class :lifecycle    :label "registered"}
+   :rf.resource/ensure               {:class :lifecycle    :label "ensure"}
+   :rf.resource/owner-attached       {:class :lifecycle    :label "owner attached"}
+   :rf.resource/cache-hit            {:class :dedupe       :label "cache hit"}
+   :rf.resource/deduped              {:class :dedupe       :label "deduped"}
+   :rf.resource/fetch-started        {:class :lifecycle    :label "fetch started"}
+   :rf.resource/work-started         {:class :lifecycle    :label "work started"}
+   :rf.resource/work-abort-requested {:class :lifecycle    :label "abort requested"}
+   :rf.resource/work-completed       {:class :success      :label "work completed"}
+   :rf.resource/work-suppressed      {:class :suppression  :label "work suppressed"}
+   :rf.resource/succeeded            {:class :success      :label "succeeded"}
+   :rf.resource/failed               {:class :failure      :label "failed"}
+   :rf.resource/refresh-failed       {:class :failure      :label "refresh failed"}
+   :rf.resource/invalidated          {:class :invalidation :label "invalidated"}
+   :rf.resource/refetch-decision     {:class :lifecycle    :label "refetch decision"}
+   :rf.resource/owner-released       {:class :lifecycle    :label "owner released"}
+   :rf.resource/gc-scheduled         {:class :gc           :label "gc scheduled"}
+   :rf.resource/gc-fired             {:class :gc           :label "gc fired"}
+   :rf.resource/gc-skipped           {:class :gc           :label "gc skipped"}
+   :rf.resource/removed              {:class :lifecycle    :label "removed"}
+   :rf.resource/stale-suppressed     {:class :suppression  :label "stale suppressed"}
+   :rf.resource/hydrated             {:class :hydration    :label "hydrated"}
+   :rf.resource/hydrate-refetch      {:class :hydration    :label "hydrate refetch"}})
+
+(defn resource-trace-op?
+  "True iff `operation` (a trace event's `:operation`) is a member of the
+  `:rf.resource/*` trace family — either an explicitly-enumerated op in
+  `trace-ops` OR any keyword in the reserved `rf.resource` namespace (so
+  a future op the runtime adds is still recognised as family-member for
+  colouring/filtering before this enum is extended)."
+  [operation]
+  (boolean
+    (and (keyword? operation)
+         (or (contains? trace-ops operation)
+             (= trace-family-prefix (namespace operation))))))
+
+(defn op-class
+  "The semantic class keyword for a resource trace `operation` (one of
+  `:lifecycle` / `:success` / `:failure` / `:dedupe` / `:invalidation` /
+  `:gc` / `:suppression` / `:hydration`), or `:lifecycle` for an
+  in-namespace op not yet enumerated. nil for a non-family op."
+  [operation]
+  (when (resource-trace-op? operation)
+    (get-in trace-ops [operation :class] :lifecycle)))
+
+(defn op-label
+  "A short human label for a resource trace `operation`. Falls back to
+  the bare op name for an in-namespace op not yet enumerated."
+  [operation]
+  (when (keyword? operation)
+    (get-in trace-ops [operation :label] (name operation))))
+
+;; ---------------------------------------------------------------------------
+;; PRIVACY — summarization with size + redaction elision (Spec 016).
+;; ---------------------------------------------------------------------------
+
+(def ^:private default-preview-budget
+  "Max characters of a value's `pr-str` rendered as the in-panel
+  preview before the `:elided?` marker replaces the tail. Bounded so a
+  large data blob never floods the panel; the off-box (AI/MCP) path uses
+  the framework `egress-value` size walker instead."
+  120)
+
+(def redacted-sentinel
+  "The framework sensitive-redaction sentinel. A value already redacted
+  upstream (the runtime emits `:rf/redacted` for `:sensitive?` slots via
+  `elide-wire-value`) renders as `[redacted]`, not as a raw preview."
+  :rf/redacted)
+
+(def large-elided-sentinel
+  "The framework size-elision sentinel — a `:large?` slot the runtime
+  elided on the wire."
+  :rf.size/large-elided)
+
+(defn- value-type-tag
+  "A short, render-safe type tag for a value — used as the summary head
+  so the operator sees the SHAPE without the raw contents."
+  [v]
+  (cond
+    (nil? v)        "nil"
+    (map? v)        "map"
+    (set? v)        "set"
+    (vector? v)     "vector"
+    (sequential? v) "seq"
+    (string? v)     "string"
+    (keyword? v)    "keyword"
+    (number? v)     "number"
+    (boolean? v)    "boolean"
+    :else           "value"))
+
+(defn- value-size
+  "A bounded count for a value — element count for a collection, char
+  count for a string, else nil (scalars have no size)."
+  [v]
+  (cond
+    (string? v) (count v)
+    (coll? v)   (count v)
+    :else       nil))
+
+(defn summarize
+  "PRIVACY-PRESERVING summary of a param / scope / data value for
+  IN-PANEL rendering (Spec 016 §Xray and AI tooling — \"prefer summaries
+  over raw values\"). Params, scopes, and data ALL flow through this same
+  fn — a scope is exactly as sensitive as data (it carries user/tenant/
+  locale/impersonation ids).
+
+  Returns a render-safe map:
+
+      {:type      \"map\"            ; the value's shape
+       :size      2                  ; element / char count (nil for scalars)
+       :preview   \"{:slug \\\"welc…\"  ; bounded pr-str, tail elided past budget
+       :elided?   true              ; preview was truncated
+       :redacted? false             ; value is the :rf/redacted sentinel
+       :large?    false}            ; value is the :rf.size/large-elided sentinel
+
+  A value already redacted/elided upstream (the runtime emits the
+  framework sentinels for `:sensitive?` / `:large?` slots) keeps its
+  sentinel status and renders no raw preview. NEVER returns the raw
+  value — the caller renders the summary map, not the value."
+  ([v] (summarize v nil))
+  ([v {:keys [budget] :or {budget default-preview-budget}}]
+   (let [redacted? (= v redacted-sentinel)
+         large?    (= v large-elided-sentinel)
+         pr        (when-not (or redacted? large?) (pr-str v))
+         elided?   (and pr (> (count pr) budget))
+         preview   (cond
+                     redacted? "[redacted]"
+                     large?    "[large — elided]"
+                     elided?   (str (subs pr 0 budget) "…")
+                     :else     pr)]
+     {:type      (value-type-tag v)
+      :size      (value-size v)
+      :preview   preview
+      :elided?   (boolean elided?)
+      :redacted? redacted?
+      :large?    large?})))
+
+(defn scoped-key-summary
+  "Summarize a scoped resource key `[scope resource-id params]` for a
+  table row. The scope and params each go through `summarize` (PRIVACY:
+  scope carries PII, params identify the remote read), while the
+  resource-id is a plain keyword (a registry name, never PII). Returns
+  `{:scope <summary> :resource-id <kw> :params <summary>}`. A malformed
+  key (not a 3-vector) summarizes the whole key as a single value."
+  [scoped-key]
+  (if (and (vector? scoped-key) (= 3 (count scoped-key)))
+    (let [[scope rid params] scoped-key]
+      {:scope       (summarize scope)
+       :resource-id rid
+       :params      (summarize params)})
+    {:scope       (summarize scoped-key)
+     :resource-id nil
+     :params      (summarize nil)}))
+
+;; ---------------------------------------------------------------------------
+;; Static resource registry projection (Spec 016 §Xray and AI tooling).
+;; ---------------------------------------------------------------------------
+
+(defn- describe-scope-policy
+  "A human description of a resource's `:scope` POLICY (not a resolved
+  scope value — the registry carries the policy). `:rf.scope/global` is
+  the audit-surface flag (Spec 016 §scope audit surface)."
+  [scope]
+  (cond
+    (= scope :rf.scope/global)      {:policy :global      :label "global (explicit claim)" :global? true}
+    (= scope :rf.scope/from-caller) {:policy :from-caller :label "from caller"             :global? false}
+    (fn? scope)                     {:policy :resolver    :label "resolver (fn)"           :global? false}
+    (keyword? scope)                {:policy :resolver    :label (str "resolver " scope)   :global? false}
+    (some? scope)                   {:policy :resolver    :label "resolver (data)"         :global? false}
+    :else                           {:policy :missing     :label "MISSING"                 :global? false}))
+
+(defn- request-summary
+  "A one-line, render-safe summary of a resource's `:request` (a fn that
+  lowers params → a Spec 014 managed-HTTP args map). The fn body is
+  opaque, so the summary names the transport + that the request is
+  fn-derived; the live wire details surface per-instance via the work
+  ledger's `:transport`."
+  [spec]
+  (let [transport (or (:transport spec) :rf.http/managed)]
+    {:transport transport
+     :fn?       (boolean (:request spec))
+     :label     (str (name transport)
+                     (when (:request spec) " · request fn"))}))
+
+(defn registry-row
+  "Project ONE static registry entry `[resource-id meta]` (a
+  `(rf/registrations :resource)` row, whose `:rf/resource` slot carries
+  the registration spec) into a render-safe registry row. Per Spec 016
+  §Xray and AI tooling (the static resource registry):
+
+      {:resource-id    :article/by-slug
+       :doc            \"Article detail by slug.\"
+       :params-schema  <summary>   ; schemas can be large — summarized
+       :data-schema    <summary>
+       :request        {:transport :rf.http/managed :fn? true :label …}
+       :scope          {:policy :global :label … :global? true}
+       :stale-after-ms 60000
+       :gc-after-ms    300000
+       :tags?          true        ; a :tags producer fn is declared
+       :sensitive?     false
+       :large?         false
+       :source-coord   {:file … :line …}}
+
+  `declaring-routes` is injected by the composite (it is a cross-source
+  join over the route registry — see `attach-declaring-routes`)."
+  [[resource-id meta]]
+  (let [spec (:rf/resource meta)]
+    {:resource-id    resource-id
+     :doc            (or (:doc spec) (:doc meta))
+     :params-schema  (summarize (:params-schema spec))
+     :data-schema    (summarize (:data-schema spec))
+     :request        (request-summary spec)
+     :scope          (describe-scope-policy (:scope spec))
+     :stale-after-ms (:stale-after-ms spec)
+     :gc-after-ms    (:gc-after-ms spec)
+     :tags?          (boolean (:tags spec))
+     :sensitive?     (boolean (:sensitive? spec))
+     :large?         (boolean (:large? spec))
+     :source-coord   (when (or (:file meta) (:line meta))
+                       {:file (:file meta) :line (:line meta)})
+     :declaring-routes []}))
+
+(defn- route-resource-ids
+  "The set of resource-ids a route declares via its `:resources`
+  metadata vector (each entry is a `{:resource <id> …}` map)."
+  [route-meta]
+  (into #{}
+        (keep :resource)
+        (:resources route-meta)))
+
+(defn attach-declaring-routes
+  "Cross-join the registry rows against the route registry: for each
+  registry row, attach the vector of route-ids whose `:resources`
+  metadata declares that resource (Spec 016 §Route integration — Xray
+  can display which routes own a resource). `routes-map` is
+  `(rf/registrations :route)` (`{<route-id> <meta>}`); pure, no require
+  on the routing artefact."
+  [rows routes-map]
+  (let [rid->routes (reduce-kv
+                      (fn [acc route-id route-meta]
+                        (reduce (fn [acc rid]
+                                  (update acc rid (fnil conj []) route-id))
+                                acc (route-resource-ids route-meta)))
+                      {} (or routes-map {}))]
+    (mapv (fn [row]
+            (assoc row :declaring-routes
+                   (vec (sort-by str (get rid->routes (:resource-id row) [])))))
+          rows)))
+
+(defn project-registry
+  "Project the full static resource registry into sorted render-safe
+  rows with declaring-routes joined. `registrations` is
+  `(rf/registrations :resource)`; `routes-map` is `(rf/registrations
+  :route)` (or nil). Per Spec 016 §Xray and AI tooling."
+  [registrations routes-map]
+  (-> (mapv registry-row (or registrations {}))
+      (attach-declaring-routes routes-map)
+      (->> (sort-by (comp str :resource-id)) vec)))
+
+;; ---------------------------------------------------------------------------
+;; Live instance table projection (Spec 016 §Xray and AI tooling).
+;; ---------------------------------------------------------------------------
+
+(defn- derive-stale?
+  "Pure freshness derivation (Spec 016 §Status semantics — `:stale?` is a
+  derived value, never a stored fact): an entry is stale iff it was
+  invalidated, or `now-ms` has passed its `:stale-at`. nil `now-ms` or a
+  nil `:stale-at` falls back to the invalidation flag alone."
+  [entry now-ms]
+  (boolean
+    (or (some? (:invalidated-at entry))
+        (and now-ms (:stale-at entry) (>= now-ms (:stale-at entry))))))
+
+(defn- gc-eligible?
+  "An entry is GC-eligible (Spec 016 §Invalidation / §Stale and GC) when
+  it has NO active owners — an inactive entry is left stale / eligible
+  for `:gc-after-ms` cleanup. Owners keep a resource alive."
+  [entry]
+  (empty? (:active-owners entry)))
+
+(defn instance-row
+  "Project ONE live cache entry `[scoped-key entry]` into a render-safe
+  instance-table row (Spec 016 §Xray and AI tooling — the live
+  resource-instance table). PRIVACY: scope + params + data summarized.
+
+      {:scoped-key      <opaque-id-for-react-key>
+       :scope           <summary>     ; PII — summarized
+       :resource-id     :article/by-slug
+       :params          <summary>     ; identity — summarized
+       :status          :loaded
+       :stale?          false
+       :has-data?       true
+       :data            <summary>     ; payload — summarized
+       :error           <summary>     ; failure envelope — summarized
+       :refresh-error   <summary>
+       :loaded-at       …  :stale-at … :invalidated-at …
+       :generation      4
+       :attempt         2
+       :request-id      <id>
+       :current-work    <work-id>
+       :active-owners   [<owner> …]   ; owners are tokens, not PII
+       :owner-count     1
+       :tags            [<tag> …]
+       :gc-eligible?    false}"
+  [[scoped-key entry] now-ms]
+  (let [{:keys [scope resource-id params]} (scoped-key-summary scoped-key)]
+    {:scoped-key     scoped-key
+     :scope          scope
+     :resource-id    (or resource-id (:resource/id entry))
+     :params         params
+     :status         (:status entry)
+     :stale?         (derive-stale? entry now-ms)
+     :has-data?      (some? (:data entry))
+     :data           (summarize (:data entry))
+     :error          (when (:error entry) (summarize (:error entry)))
+     :refresh-error  (when (:refresh-error entry) (summarize (:refresh-error entry)))
+     :loaded-at      (:loaded-at entry)
+     :stale-at       (:stale-at entry)
+     :invalidated-at (:invalidated-at entry)
+     :generation     (:generation entry)
+     :attempt        (:attempt entry)
+     :request-id     (:request-id entry)
+     :current-work   (:current-work entry)
+     :active-owners  (vec (:active-owners entry))
+     :owner-count    (count (:active-owners entry))
+     :tags           (vec (:tags entry))
+     :gc-eligible?   (gc-eligible? entry)}))
+
+(defn project-instances
+  "Project a frame's live resource entries map `{<scoped-key> <entry>}`
+  into sorted render-safe instance rows. Sorted by resource-id then
+  generation (descending) so the most-recent attempt leads. `now-ms` is
+  the freshness clock (the panel passes the current ms; tests pass a
+  fixed clock). Per Spec 016 §Xray and AI tooling."
+  ([entries] (project-instances entries nil))
+  ([entries now-ms]
+   (->> (or entries {})
+        (mapv #(instance-row % now-ms))
+        (sort-by (juxt (comp str :resource-id) (comp - (fnil identity 0) :generation)))
+        vec)))
+
+;; ---------------------------------------------------------------------------
+;; Live work-ledger table projection (Spec 016 §Frame work ledger —
+;; the 2026-06-10 EP amendment: per-frame work-ledger table joined to
+;; resource entries).
+;; ---------------------------------------------------------------------------
+
+(def terminal-work-statuses
+  "Terminal work-ledger statuses (Spec 016 §Ledger row retention). A
+  terminal row is pruned on the linked entry's next successful
+  transition; the panel marks them so the operator distinguishes live
+  work from a recent-races tail."
+  #{:completed :failed :timed-out :suppressed :cancelled})
+
+(defn work-row
+  "Project ONE work-ledger record `[work-id record]` into a render-safe
+  row (Spec 016 §Frame work ledger / 2026-06-10 EP amendment). Raw host
+  handles (AbortControllers, timeout handles, promises) live OUTSIDE
+  durable frame-state in side tables and are STRUCTURALLY inaccessible to
+  this projection — the ledger record carries only serializable facts:
+
+      {:work-id      <id>
+       :kind         :resource
+       :resource-key <scoped-key-summary>  ; PRIVACY: scope/params summarized
+       :resource-id  :article/by-slug
+       :generation   4
+       :status       :running
+       :terminal?    false
+       :owners       [<owner> …]
+       :causes       [<cause> …]            ; causes are summarized (may carry data)
+       :stale-key    <work-id>             ; one identity per record (= :work/id)
+       :cancellable? true
+       :deadline-at  1780752005100
+       :attempt      2
+       :transport    :rf.http/managed
+       :outcome      <summary>}"
+  [[work-id record]]
+  (let [rkey (or (:resource/key record) (:resource-key record))
+        {:keys [scope resource-id params]} (scoped-key-summary rkey)]
+    {:work-id      work-id
+     :kind         (or (:work/kind record) (:kind record))
+     :resource-key {:scope scope :resource-id resource-id :params params}
+     :resource-id  resource-id
+     :generation   (:generation record)
+     :status       (:status record)
+     :terminal?    (contains? terminal-work-statuses (:status record))
+     :owners       (vec (:owners record))
+     :causes       (mapv summarize (:causes record))
+     :stale-key    work-id
+     :cancellable? (boolean (:cancellable? record))
+     :deadline-at  (or (:deadline-at record) (:deadline record))
+     :attempt      (or (:attempt record) (:retry-attempt record))
+     :transport    (:transport record)
+     :outcome      (when (contains? record :outcome) (summarize (:outcome record)))}))
+
+(defn project-work-ledger
+  "Project a frame's work-ledger map `{<work-id> <record>}` into sorted
+  render-safe rows — non-terminal (live) work first, then the terminal
+  recent-races tail; within each group sorted by generation descending.
+  Per Spec 016 §Frame work ledger."
+  [ledger]
+  (->> (or ledger {})
+       (mapv work-row)
+       (sort-by (juxt :terminal? (comp - (fnil identity 0) :generation)))
+       vec))
+
+;; ---------------------------------------------------------------------------
+;; Route / resource graph (Spec 016 §Route integration / §Xray).
+;; ---------------------------------------------------------------------------
+
+(defn- route-resource-node
+  "Project ONE `:resources` entry on a route into a graph node. The
+  `:params` / `:scope` resolvers are fns (opaque), so the node records
+  THAT they are declared, the blocking flag (SSR wait point), the
+  keep-previous flag, the local `:id` + `:after` dependency, and any
+  `:when` guard — the structure Xray draws without parsing handlers."
+  [entry]
+  {:resource        (:resource entry)
+   :blocking?       (boolean (:blocking? entry))
+   :keep-previous?  (boolean (:keep-previous? entry))
+   :local-id        (:id entry)
+   :after           (vec (:after entry))
+   :when?           (boolean (:when entry))
+   :params-fn?      (boolean (:params entry))
+   :scope-resolver? (boolean (:scope entry))})
+
+(defn project-route-graph
+  "Project the route registry into the route/resource graph (Spec 016
+  §Route integration): for every route declaring `:resources`, a node
+  carrying its declared resources, blocking-vs-non-blocking split, SSR
+  wait points (the blocking nodes), and any `:after` dependency waterfall.
+  `routes-map` is `(rf/registrations :route)`.
+
+      [{:route-id     :route/article
+        :path         \"/articles/:slug\"
+        :resources    [{:resource :article/by-slug :blocking? true …} …]
+        :blocking     [:article/by-slug]   ; SSR wait points
+        :non-blocking [:comments/list]
+        :ssr-wait?    true}                 ; route has ≥1 blocking resource
+       …]
+
+  Routes WITHOUT `:resources` are omitted (the graph is the resource
+  view of the route table). Per Spec 016 §Route integration."
+  [routes-map]
+  (->> (or routes-map {})
+       (keep (fn [[route-id route-meta]]
+               (let [resources (:resources route-meta)]
+                 (when (seq resources)
+                   (let [nodes        (mapv route-resource-node resources)
+                         blocking     (into [] (comp (filter :blocking?) (map :resource)) nodes)
+                         non-blocking (into [] (comp (remove :blocking?) (map :resource)) nodes)]
+                     {:route-id     route-id
+                      :path         (:path route-meta)
+                      :resources    nodes
+                      :blocking     blocking
+                      :non-blocking non-blocking
+                      :ssr-wait?    (boolean (seq blocking))})))))
+       (sort-by (comp str :route-id))
+       vec))
+
+;; ---------------------------------------------------------------------------
+;; Lifecycle timeline + invalidation graph + cache-growth (from trace rows).
+;; ---------------------------------------------------------------------------
+
+(defn- trace-op
+  "The `:operation` of a trace event, tolerating either the canonical
+  `:operation` key or a bare `:op`."
+  [ev]
+  (or (:operation ev) (:op ev)))
+
+(defn- trace-tags [ev] (or (:tags ev) {}))
+
+(defn lifecycle-timeline
+  "Project the resource trace rows in a trace buffer into a lifecycle
+  TIMELINE — an ordered, render-safe row per `:rf.resource/*` event
+  (Spec 016 §Xray and AI tooling — the lifecycle timeline). Each row:
+
+      {:id          <trace-id>      ; stable per-process trace event id
+       :operation   :rf.resource/fetch-started
+       :label       \"fetch started\"
+       :class       :lifecycle
+       :resource-id :article/by-slug
+       :resource-key <scoped-key-summary>  ; PRIVACY-summarized
+       :generation  4
+       :work-id     <id>
+       :owner       <owner>
+       :cause       <summary>        ; cause may carry data — summarized
+       :status      {:before … :after …}}
+
+  Pure over the trace vector; preserves buffer order (oldest-first). The
+  panel renders this as the per-resource lifecycle strip; filtering by
+  resource-id happens in the composite. Per Spec 016."
+  [trace-buffer]
+  (->> (or trace-buffer [])
+       (filter #(resource-trace-op? (trace-op %)))
+       (mapv (fn [ev]
+               (let [op   (trace-op ev)
+                     tags (trace-tags ev)
+                     rkey (or (:resource-key tags) (:resource/key tags))]
+                 {:id           (:id ev)
+                  :operation    op
+                  :label        (op-label op)
+                  :class        (op-class op)
+                  :resource-id  (or (:resource-id tags)
+                                    (when (vector? rkey) (second rkey)))
+                  :resource-key (when rkey (scoped-key-summary rkey))
+                  :generation   (:generation tags)
+                  :work-id      (or (:work-id tags) (:work/id tags))
+                  :owner        (:owner tags)
+                  :cause        (when (contains? tags :cause) (summarize (:cause tags)))
+                  :status       {:before (:status-before tags)
+                                 :after  (or (:status-after tags) (:status tags))}})))))
+
+(defn invalidation-graph
+  "Project the `:rf.resource/invalidated` trace rows into the
+  invalidation / mutation graph (Spec 016 §Invalidation / §Xray — the
+  invalidation/mutation graph). One row per invalidation event:
+
+      {:id        <trace-id>
+       :scope     <summary>          ; PRIVACY — scope summarized
+       :tags      [<tag> …]          ; the invalidated tags (identity, not PII)
+       :cause     <summary>          ; e.g. [:mutation :article/save id] — summarized
+       :matched   [<scoped-key-summary> …]  ; entries hit
+       :match-count N
+       :refetched N}                 ; active-owner entries refetched
+
+  Distinguishes a broad-tag storm (high `:match-count`) without flooding;
+  a zero-match invalidation surfaces `:match-count 0` so 'no match in
+  this scope' is visible. Pure over the trace vector. Per Spec 016."
+  [trace-buffer]
+  (->> (or trace-buffer [])
+       (filter #(= :rf.resource/invalidated (trace-op %)))
+       (mapv (fn [ev]
+               (let [tags    (trace-tags ev)
+                     matched (or (:matched tags) [])]
+                 {:id          (:id ev)
+                  :scope       (summarize (:scope tags))
+                  :tags        (vec (:tags tags))
+                  :cause       (when (contains? tags :cause) (summarize (:cause tags)))
+                  :matched     (mapv scoped-key-summary matched)
+                  :match-count (count matched)
+                  :refetched   (or (:refetched tags) 0)})))))
+
+(defn cache-growth
+  "Project the live instance rows + the work ledger into the cache-growth
+  view (Spec 016 §Paginated and previous data / §Xray — the cache-growth
+  view). Aggregates per-resource-id:
+
+      {:by-resource [{:resource-id :articles/list
+                      :entry-count 12       ; cached entries (e.g. list pages)
+                      :owned-count 1        ; entries with ≥1 active owner
+                      :gc-eligible 11}      ; inactive → GC-eligible
+                     …]
+       :total-entries 14
+       :total-gc-eligible 12
+       :live-work 2}                        ; non-terminal ledger rows
+
+  Surfaces unbounded list-param growth (many entries, few owners) so the
+  operator sees a cache that is growing without owners pinning it. Pure
+  over the projected instance + work rows. Per Spec 016."
+  [instance-rows work-rows]
+  (let [by-resource
+        (->> instance-rows
+             (group-by :resource-id)
+             (mapv (fn [[rid rows]]
+                     {:resource-id rid
+                      :entry-count (count rows)
+                      :owned-count (count (filter (comp pos? :owner-count) rows))
+                      :gc-eligible (count (filter :gc-eligible? rows))}))
+             (sort-by (comp - :entry-count))
+             vec)]
+    {:by-resource       by-resource
+     :total-entries     (count instance-rows)
+     :total-gc-eligible (count (filter :gc-eligible? instance-rows))
+     :live-work         (count (remove :terminal? work-rows))}))
+
+;; ---------------------------------------------------------------------------
+;; Lints (Spec 016 §Xray and AI tooling — the two lints + the audit list).
+;; ---------------------------------------------------------------------------
+
+(defn global-scope-audit
+  "The STANDING scope audit surface (Spec 016 §Xray scope diagnostics):
+  enumerate every `:rf.scope/global` resource — the structural
+  security-review list that replaces the old `/me` heuristic. Returns the
+  registry rows whose scope policy is the explicit-global claim. Pure
+  over the projected registry rows."
+  [registry-rows]
+  (->> registry-rows
+       (filter (comp :global? :scope))
+       vec))
+
+(def ^:private session-ish-tokens
+  "Substrings that make an explicit-global request look session-dependent
+  — the downgraded-to-defense-in-depth heuristic (Spec 016: warn about
+  SUSPICIOUS explicit-global, not compensate for a missing scope)."
+  ["/me" "/current-user" "/current_user" "current-session" "/profile"
+   "/account" "impersonat"])
+
+(defn suspicious-global-warnings
+  "Defense-in-depth lint (Spec 016 §Xray scope diagnostics): from the
+  `:rf.scope/global` audit list, flag any whose registered doc /
+  resource-id LOOKS session-dependent (`/me`, `/current-user`, profile/
+  account/impersonation hints). NOT the boundary (a missing scope is a
+  loud runtime error now); a hint the operator should re-examine an
+  explicit-global claim. Returns `[{:resource-id … :hint \"…\"}]`."
+  [registry-rows]
+  (->> (global-scope-audit registry-rows)
+       (keep (fn [row]
+               (let [hay (str/lower-case
+                           (str (:resource-id row) " " (:doc row)))]
+                 (when (some #(str/includes? hay %) session-ish-tokens)
+                   {:resource-id (:resource-id row)
+                    :hint        (str "explicit :rf.scope/global on a resource that "
+                                      "looks session-dependent — confirm the data is "
+                                      "identical for every user/tenant.")}))))
+       vec))
+
+(defn scope-mismatch-lint
+  "Scope-mismatch lint (Spec 016 §Xray — two lints): a cache ENTRY exists
+  for resource R + params P under scope A while a LIVE subscription reads
+  the same R + P under a DIFFERENT scope B and gets `:idle` (or a
+  never-resolving `:loading`). The runtime tripwire for the cases the
+  fail-closed scope rules don't catch.
+
+  `instance-rows` is the projected live instances; `sub-reads` is a
+  vector of `{:resource-id R :params <raw-params> :scope <raw-scope>}`
+  observed live subscription reads. Returns mismatch pairs:
+
+      [{:resource-id R
+        :sub-scope <summary> :sub-params <summary>
+        :entry-scope <summary>}]
+
+  PRIVACY: the surfaced scopes/params are summarized. Matching is on
+  resource-id + params identity (a sub reading params P that an entry
+  caches under a DIFFERENT scope). Pure."
+  [instance-rows sub-reads]
+  (let [;; index entries by [resource-id params-preview] → set of scope previews
+        entry-index
+        (reduce (fn [acc row]
+                  (update acc [(:resource-id row) (get-in row [:params :preview])]
+                          (fnil conj #{}) (get-in row [:scope :preview])))
+                {} instance-rows)]
+    (->> (or sub-reads [])
+         (keep (fn [{:keys [resource-id params scope]}]
+                 (let [params-sum (summarize params)
+                       scope-sum  (summarize scope)
+                       k          [resource-id (:preview params-sum)]
+                       entry-scopes (get entry-index k)]
+                   ;; mismatch iff an entry exists for this R+P but under
+                   ;; NO scope matching the sub's scope.
+                   (when (and (seq entry-scopes)
+                              (not (contains? entry-scopes (:preview scope-sum))))
+                     {:resource-id resource-id
+                      :sub-scope   scope-sum
+                      :sub-params  params-sum
+                      :entry-scope (summarize (first entry-scopes))}))))
+         vec)))
+
+(defn orphaned-owner-lint
+  "Orphaned-owner lint (Spec 016 §Xray — two lints / §Release authority):
+  an app-minted `[:lease …]` (or other app-kind) owner pinning an entry
+  with no observed `:rf.resource/owner-released` for that owner in the
+  trace. Route / machine / ssr owners are framework-released (route on
+  nav supersession, machine on actor destroy, ssr on request teardown),
+  so only APP-kind owners are linted here.
+
+  `instance-rows` supplies the live `:active-owners`; `trace-buffer`
+  supplies the observed `:rf.resource/owner-released` events. Returns
+  `[{:owner <owner> :resource-id R}]` for each app-kind owner still
+  pinning an entry with no release seen. Pure."
+  [instance-rows trace-buffer]
+  (let [released (->> (or trace-buffer [])
+                      (filter #(= :rf.resource/owner-released (trace-op %)))
+                      (keep #(:owner (trace-tags %)))
+                      (into #{}))
+        app-kind? (fn [owner]
+                    (and (vector? owner)
+                         (not (contains? #{:route :machine :ssr} (first owner)))))]
+    (->> instance-rows
+         (mapcat (fn [row]
+                   (for [owner (:active-owners row)
+                         :when (and (app-kind? owner)
+                                    (not (contains? released owner)))]
+                     {:owner owner :resource-id (:resource-id row)})))
+         distinct
+         vec)))
+
+;; ---------------------------------------------------------------------------
+;; Tool-accessor filtering (Spec 016 §Xray and AI tooling — the
+;; list-resources / list-resource-instances / get-resource-state /
+;; get-resource-history / list-resource-invalidations filter axes).
+;; ---------------------------------------------------------------------------
+
+(defn- scoped-key-matches?
+  "Does a scoped key `[scope rid params]` match the supplied filter
+  axes? `scope` / `resource-id` / `params` are compared against the RAW
+  key parts (the accessor receives the raw runtime-db key); a nil filter
+  axis is a wildcard."
+  [scoped-key {:keys [scope resource-id params]}]
+  (let [[ks krid kparams] (if (and (vector? scoped-key) (= 3 (count scoped-key)))
+                            scoped-key
+                            [nil nil nil])]
+    (and (or (nil? scope)       (= scope ks))
+         (or (nil? resource-id) (= resource-id krid))
+         (or (nil? params)      (= params kparams)))))
+
+(defn filter-instance-rows
+  "Filter projected instance rows by the tool-accessor axes (Spec 016):
+  `:resource-id`, `:status`, `:stale?`, `:tag`, `:owner`, `:request-id`.
+  Each nil axis is a wildcard. (Scope/params/frame are applied upstream
+  against the raw key; this filters the already-projected rows.) Pure."
+  [rows {:keys [resource-id status stale? tag owner request-id]}]
+  (->> rows
+       (filter (fn [row]
+                 (and (or (nil? resource-id) (= resource-id (:resource-id row)))
+                      (or (nil? status)      (= status (:status row)))
+                      (or (nil? stale?)      (= (boolean stale?) (:stale? row)))
+                      (or (nil? tag)         (some #{tag} (:tags row)))
+                      (or (nil? owner)       (some #{owner} (:active-owners row)))
+                      (or (nil? request-id)  (= request-id (:request-id row))))))
+       vec))
+
+(defn select-raw-entries
+  "Select the RAW runtime-db entries (`{<scoped-key> <entry>}`) matching
+  the scope / resource-id / params key axes — the upstream filter the
+  accessors apply BEFORE projection/elision (so an accessor can scope its
+  read by the cache key before summarizing). Pure; the accessor still
+  routes selected values through the off-box elision walker afterwards."
+  [entries key-filter]
+  (into {}
+        (filter (fn [[k _]] (scoped-key-matches? k key-filter)))
+        (or entries {})))
+
+(defn filter-work-rows
+  "Filter projected work-ledger rows by the accessor axes: `:resource-id`,
+  `:status`, `:owner`, `:request-id` (= work-id), `:nav-token`. Pure."
+  [rows {:keys [resource-id status owner request-id nav-token]}]
+  (->> rows
+       (filter (fn [row]
+                 (and (or (nil? resource-id) (= resource-id (:resource-id row)))
+                      (or (nil? status)      (= status (:status row)))
+                      (or (nil? owner)       (some #{owner} (:owners row)))
+                      (or (nil? request-id)  (= request-id (:work-id row)))
+                      (or (nil? nav-token)
+                          (some (fn [o] (and (vector? o) (some #{nav-token} o)))
+                                (:owners row))))))
+       vec))
+
+(defn filter-history-rows
+  "Filter projected lifecycle-timeline rows by the accessor axes:
+  `:resource-id`, `:nav-token` (matches an owner carrying the token), and
+  bound the result to the last `:limit` rows (bounded history — Spec 016:
+  resource history MUST be bounded). Pure."
+  [rows {:keys [resource-id nav-token limit]}]
+  (let [filtered (->> rows
+                      (filter (fn [row]
+                                (and (or (nil? resource-id)
+                                         (= resource-id (:resource-id row)))
+                                     (or (nil? nav-token)
+                                         (let [o (:owner row)]
+                                           (and (vector? o)
+                                                (some #{nav-token} o)))))))
+                      vec)]
+    (if (and limit (> (count filtered) limit))
+      (vec (take-last limit filtered))
+      filtered)))

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -83,6 +83,7 @@
             [day8.re-frame2-xray.panels.machine-inspector :as machine-inspector]
             [day8.re-frame2-xray.panels.managed-fx-subs :as managed-fx-subs]
             [day8.re-frame2-xray.panels.routing :as routing]
+            [day8.re-frame2-xray.panels.resources :as resources]
             [day8.re-frame2-xray.panels.reactive-panel :as reactive-panel]
             [day8.re-frame2-xray.panels.trace :as trace]))
 
@@ -945,6 +946,17 @@
     ;; order is intentional, though re-frame's `:<-` resolution is
     ;; lazy and the order is purely cosmetic.
     (routing/install!)
+    ;; Resources tab (Spec 016 §Xray and AI tooling) — Dynamic L3 tab
+    ;; for declarative server-state. Installs the registered-resources /
+    ;; resource-entries / resource-work-ledger / resource-sub-reads subs
+    ;; + the `:rf.xray/resources-tab-data` composite + test-only
+    ;; overrides. Reads the static registry via `(rf/registrations
+    ;; :resource)` and the live cache/ledger off
+    ;; `:rf.xray/target-frame-runtime-db` (registered by
+    ;; `app-db-diff/install!` above) — decoupled from the optional
+    ;; resources artefact (Xray does not :require it; bundle isolation).
+    ;; Read-only: no `:rf.resource/*` dispatch (observing pins nothing).
+    (resources/install!)
     ;; Static Routes panel (rf2-o5f5f.3) — Static-surface browse +
     ;; Simulate-URL + per-row inline expand + hermetic Simulate-
     ;; navigation preview. Installs the UI-state slots under

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -87,7 +87,16 @@
             ;; get-app-db-diff to project the changed-paths slice diff its
             ;; docstring promises ({:added :removed :changed}) instead of
             ;; egressing two whole app-db snapshots.
-            [day8.re-frame2-xray.diff.engine :as diff-engine]))
+            [day8.re-frame2-xray.diff.engine :as diff-engine]
+            ;; Spec 016 §Xray and AI tooling — the resource-accessor
+            ;; projection algebra (registry rows, instance/work-ledger
+            ;; rows, lifecycle timeline, invalidation graph, and the
+            ;; filter axes). Pure-data + JVM-portable; carries the
+            ;; in-panel privacy summaries. The off-box egress here adds
+            ;; the framework `egress-value` walker on top. Decoupled from
+            ;; the optional resources artefact (reads via the registrar +
+            ;; runtime-db slice; Xray never :requires re-frame.resources).
+            [day8.re-frame2-xray.panels.resources-helpers :as resources-helpers]))
 
 ;; ---------------------------------------------------------------------------
 ;; Session sentinel
@@ -748,6 +757,217 @@
                                                  :include-large?     include-large?})]))
                       ids)
       :count    (count ids)})))
+
+;; ---------------------------------------------------------------------------
+;; Resource accessors (Spec 016 §Xray and AI tooling — 5 tool accessors)
+;; ---------------------------------------------------------------------------
+;;
+;; list-resources / list-resource-instances / get-resource-state /
+;; get-resource-history / list-resource-invalidations. Filter axes:
+;; frame / scope / resource-id / tag / owner / status / stale? /
+;; request-id / nav-token (Spec 016).
+;;
+;; PRIVACY (Spec 016, load-bearing): tool surfaces PREFER SUMMARIES over
+;; raw values; params + scopes get the SAME privacy + size elision as
+;; data (scopes carry user/tenant/locale/impersonation ids); history is
+;; BOUNDED. Two elision layers compose:
+;;   1. the in-panel `resources-helpers/summarize` shape (always applied
+;;      — type + bounded size + a redaction-aware preview, never raw);
+;;   2. the framework off-box `egress-runtime-db-value` / `egress-value`
+;;      walker on the raw runtime-db values an accessor surfaces, so a
+;;      `:sensitive?` data/scope slot egresses as `:rf/redacted` and a
+;;      `:large?` slot as `:rf.size/large-elided` on the off-box default
+;;      path. The resource cache is RUNTIME-DB state, so the raw-value
+;;      egress default-redacts the partition (ruling #14) — a trusted-
+;;      local caller opts in with `:include-runtime-db? true`.
+;;
+;; READ-ONLY (Spec 016 §Active owners and causes): an accessor NEVER
+;; dispatches `:rf.resource/ensure`, attaches an owner, refetches, or
+;; extends GC. Inspection has zero side effects on resource liveness —
+;; Xray (and the AI/MCP boundary it serves) MUST NOT become an owner by
+;; observing.
+
+(def ^:private resource-kind
+  "The `:resource` registrar kind (Spec 016 §Registration). A duplicated
+  literal — the runtime does not :require the optional resources artefact
+  (bundle isolation), reading the static registry process-globally via
+  `(rf/registrations :resource)`."
+  :resource)
+
+(defn list-resources
+  "Tool: `list-resources`. The STATIC resource registry (Spec 016 §Xray
+  and AI tooling — the static resource registry): id, source coords,
+  params/data schemas (summarized), request summary, stale/GC policy, tag
+  producer, scope policy, sensitivity/large class, and declaring routes.
+  Filter axis: `:resource-id` (a single id) — nil lists all.
+
+  Returns `{:ok? true :resources [<registry-row> …] :count N}`. The rows
+  carry only static REGISTRY facts (no live values), so they egress
+  freely; param/data schemas are summarized in case they are large."
+  ([] (list-resources nil))
+  ([{:keys [resource-id]}]
+   (let [registrations (rf/registrations resource-kind)
+         routes-map    (rf/registrations :route)
+         rows          (cond->> (resources-helpers/project-registry registrations routes-map)
+                         (some? resource-id) (filter #(= resource-id (:resource-id %))))]
+     {:ok?       true
+      :resources (vec rows)
+      :count     (count rows)})))
+
+(defn list-resource-instances
+  "Tool: `list-resource-instances`. The LIVE per-frame resource-instance
+  table (Spec 016 §Xray and AI tooling): resource key, scope, status,
+  timestamps, generation, request id, attempt, active owners, tags, data
+  summary, GC eligibility. Filter axes: `:frame`, `:scope`,
+  `:resource-id`, `:params`, `:status`, `:stale?`, `:tag`, `:owner`,
+  `:request-id`.
+
+  Reads the cache entries from the frame's RUNTIME-DB partition at
+  `[:rf.runtime/resources :entries]` (EP-0001 — resource cache is
+  framework-owned runtime-db state). PRIVACY: scope/params/data are
+  summarized AND the raw entry values route through
+  `egress-runtime-db-value` (default-redacted off-box; opt in with
+  `:include-runtime-db? true`).
+
+  Returns `{:ok? true :frame <id> :instances [<row> …] :count N}` or
+  `{:ok? false :reason :no-frame-resolved}`."
+  ([] (list-resource-instances nil))
+  ([{:keys [frame scope resource-id params status stale? tag owner request-id
+            include-sensitive? include-large? include-runtime-db?] :as _opts}]
+   (let [fid (resolve-frame frame)]
+     (if (nil? fid)
+       {:ok? false :reason :no-frame-resolved
+        :hint "Pass :frame :foo or register at least one frame."}
+       (let [runtime-db  (rf/runtime-db-value fid)
+             all-entries (get-in runtime-db resources-helpers/entries-rel-path)
+             ;; upstream key-filter BEFORE projection (scope/resource-id/params
+             ;; against the raw cache key)
+             entries     (resources-helpers/select-raw-entries
+                           all-entries
+                           {:scope scope :resource-id resource-id :params params})
+             rt-egress   {:include-sensitive?  include-sensitive?
+                          :include-large?      include-large?
+                          :include-runtime-db? include-runtime-db?}
+             ;; off-box raw-value egress on the runtime-db entries (the
+             ;; summaries the rows carry are belt; this is braces — a
+             ;; :sensitive? data/scope slot egresses redacted)
+             entries*    (into {}
+                               (map (fn [[k entry]]
+                                      [k (egress-runtime-db-value
+                                           entry
+                                           (assoc rt-egress
+                                                  :path (conj resources-helpers/entries-rel-path k)))]))
+                               (or entries {}))
+             rows        (-> (resources-helpers/project-instances entries* (.now js/Date))
+                             (resources-helpers/filter-instance-rows
+                               {:resource-id resource-id :status status :stale? stale?
+                                :tag tag :owner owner :request-id request-id}))]
+         {:ok?       true
+          :frame     fid
+          :instances rows
+          :count     (count rows)})))))
+
+(defn get-resource-state
+  "Tool: `get-resource-state`. The LIVE durable state of ONE resource
+  instance addressed by its scoped key (Spec 016 §Introspection /
+  §Status semantics). Resolves the entry at `[:rf.runtime/resources
+  :entries [scope resource-id params]]` in the frame's runtime-db.
+
+  Required: `:resource-id` + `:scope` + `:params` (the scoped key). Per
+  EP-0002 the frame target is carried explicitly (`:frame`); a frameless
+  call with no resolvable context fails closed.
+
+  Returns `{:ok? true :frame <id> :state <instance-row>}` (the row
+  carries the PRIVACY-summarized status/data/error projection — Spec 016
+  §Status semantics: `:stale?`/`:has-data?` are derived, not stored) or
+  `{:ok? false :reason :no-such-instance ...}` / `:no-frame-resolved` /
+  `:missing-key`. The raw entry routes through `egress-runtime-db-value`
+  before projection (default-redacted off-box; `:include-runtime-db?
+  true` to opt in)."
+  [{:keys [frame resource-id scope params
+           include-sensitive? include-large? include-runtime-db?]}]
+  (let [fid (resolve-frame frame)]
+    (cond
+      (nil? fid)
+      {:ok? false :reason :no-frame-resolved
+       :hint "Pass :frame :foo or register at least one frame."}
+
+      (nil? resource-id)
+      {:ok? false :reason :missing-key
+       :hint "Pass :resource-id + :scope + :params (the scoped key)."}
+
+      :else
+      (let [scoped-key  [scope resource-id params]
+            runtime-db  (rf/runtime-db-value fid)
+            entry-path  (conj (vec resources-helpers/entries-rel-path) scoped-key)
+            entry       (get-in runtime-db entry-path)]
+        (if (nil? entry)
+          {:ok? false :reason :no-such-instance
+           :frame fid :resource-id resource-id}
+          (let [entry* (egress-runtime-db-value
+                         entry
+                         {:include-sensitive?  include-sensitive?
+                          :include-large?      include-large?
+                          :include-runtime-db? include-runtime-db?
+                          :path                entry-path})]
+            {:ok?   true
+             :frame fid
+             :state (resources-helpers/instance-row [scoped-key entry*] (.now js/Date))}))))))
+
+(defn get-resource-history
+  "Tool: `get-resource-history`. The BOUNDED lifecycle history for a
+  resource (Spec 016 §Xray and AI tooling — the lifecycle timeline;
+  history MUST be bounded). Projects the `:rf.resource/*` trace family
+  out of the frame's trace ring into ordered lifecycle rows. Filter axes:
+  `:resource-id`, `:nav-token`, `:limit` (default 50 — the bound).
+
+  Returns `{:ok? true :frame <id> :history [<timeline-row> …] :count N}`
+  or `{:ok? false :reason :no-frame-resolved}`. The rows carry the
+  PRIVACY-summarized scope/params/cause projection (a cause may carry
+  data); whole `:sensitive? true` trace events are default-suppressed at
+  the off-box seam."
+  ([] (get-resource-history nil))
+  ([{:keys [frame resource-id nav-token limit include-sensitive?]
+     :or   {limit 50} :as _opts}]
+   (let [fid (resolve-frame frame)]
+     (if (nil? fid)
+       {:ok? false :reason :no-frame-resolved
+        :hint "Pass :frame :foo or register at least one frame."}
+       (let [events  (-> (trace-tooling/trace-buffer fid {:flat true})
+                         (drop-sensitive-events include-sensitive?))
+             rows    (-> (resources-helpers/lifecycle-timeline events)
+                         (resources-helpers/filter-history-rows
+                           {:resource-id resource-id :nav-token nav-token :limit limit}))]
+         {:ok?     true
+          :frame   fid
+          :history (vec rows)
+          :count   (count rows)})))))
+
+(defn list-resource-invalidations
+  "Tool: `list-resource-invalidations`. The invalidation / mutation graph
+  (Spec 016 §Invalidation / §Xray and AI tooling). Projects the
+  `:rf.resource/invalidated` trace rows — each carrying the scope
+  (summarized), the invalidated tags, the cause (summarized), the matched
+  scoped keys, and the refetch count. Distinguishes a broad-tag storm
+  (high `:match-count`) and a zero-match invalidation (`:match-count 0`).
+  Filter axis: `:tag` (only invalidations touching the tag).
+
+  Returns `{:ok? true :frame <id> :invalidations [<row> …] :count N}` or
+  `{:ok? false :reason :no-frame-resolved}`."
+  ([] (list-resource-invalidations nil))
+  ([{:keys [frame tag include-sensitive?] :as _opts}]
+   (let [fid (resolve-frame frame)]
+     (if (nil? fid)
+       {:ok? false :reason :no-frame-resolved
+        :hint "Pass :frame :foo or register at least one frame."}
+       (let [events (-> (trace-tooling/trace-buffer fid {:flat true})
+                        (drop-sensitive-events include-sensitive?))
+             rows   (cond->> (resources-helpers/invalidation-graph events)
+                      (some? tag) (filter #(some #{tag} (:tags %))))]
+         {:ok?           true
+          :frame         fid
+          :invalidations (vec rows)
+          :count         (count rows)})))))
 
 (defn get-issues
   "Tool: `get-issues`. Recent errors / warnings / schema violations /

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
@@ -1,0 +1,250 @@
+(ns day8.re-frame2-xray.panels.resources-cljs-test
+  "CLJS-side wiring + view tests for Xray's Resources tab (Spec 016 §Xray
+  and AI tooling).
+
+  ## What's under test
+
+    1. **Registry wires the subs** — `register-xray-handlers!` installs
+       every sub/event the panel reads + the test-only override slots.
+    2. **Tab inventory** — the palette's Dynamic panel list now carries
+       `:resources` (and the count grew Routing→Resources).
+    3. **Sections render** — registry / live-instances / work-ledger /
+       route-graph / lifecycle-timeline / invalidation / cache-growth /
+       audit all render when data is present.
+    4. **PRIVACY** — a `:sensitive?` data value the runtime redacted to
+       `:rf/redacted` renders `[redacted]`, never the raw value.
+    5. **Read-only** — no `:rf.resource/*` event is registered by the
+       panel (observing pins nothing).
+    6. **Silent state** — no resources + no instances → silent caption.
+    7. **Decoupled** — the panel reads the registry + the runtime-db
+       slice via override hooks; no `re-frame.resources` require."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]
+            [day8.re-frame2-xray.palette.subs :as palette-subs]
+            [day8.re-frame2-xray.panels.resources :as resources]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- xray-init! []
+  (xray-test-support/reset-all!)
+  (trace-collector/reset-for-test!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn xray-init!}))
+
+;; ---- hiccup walkers (mirror routing_cljs_test) --------------------------
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- node-text [node]
+  (->> (hiccup-seq node) (filter string?) (apply str)))
+
+(defn- setup-xray-frame! []
+  (registry/register-xray-handlers!)
+  (frame/reg-frame :rf/xray {}))
+
+;; ---- fixtures: registry + entries + ledger ------------------------------
+
+(def session-scope [:rf.scope/session {:user-id "u-42"}])
+
+(def resource-regs
+  {:article/by-slug
+   {:doc "Article by slug."
+    :rf/resource {:doc "Article by slug."
+                  :params-schema [:map [:slug :string]]
+                  :data-schema :app/article
+                  :scope :rf.scope/global
+                  :transport :rf.http/managed
+                  :stale-after-ms 60000 :gc-after-ms 300000
+                  :tags (fn [_ _] #{}) :request (fn [_ _] {})}}})
+
+(def live-entries
+  {[session-scope :article/by-slug {:slug "welcome"}]
+   {:resource/id :article/by-slug :status :loaded
+    :data {:title "Welcome"} :generation 4
+    :stale-at (+ (.now js/Date) 60000)
+    :active-owners #{[:route :route/article "nav-1"]}
+    :tags #{[:article "welcome"]} :request-id [:w 4]}})
+
+(def live-ledger
+  {[:rf.work/resource [session-scope :article/by-slug {:slug "welcome"}] 4]
+   {:work/id [:rf.work/resource [session-scope :article/by-slug {:slug "welcome"}] 4]
+    :work/kind :resource :resource/key [session-scope :article/by-slug {:slug "welcome"}]
+    :generation 4 :status :running :cancellable? true :deadline-at 5100}})
+
+(defn- seed-overrides! []
+  (rf/dispatch-sync [:rf.xray/set-registered-resources-override-for-test resource-regs]
+                    {:frame :rf/xray})
+  (rf/dispatch-sync [:rf.xray/set-resource-entries-override-for-test live-entries]
+                    {:frame :rf/xray})
+  (rf/dispatch-sync [:rf.xray/set-resource-work-ledger-override-for-test live-ledger]
+                    {:frame :rf/xray}))
+
+;; ---- (1) registry wiring ------------------------------------------------
+
+(deftest registry-installs-resources-subs
+  (testing "register-xray-handlers! installs the resources tab subs + overrides"
+    (registry/register-xray-handlers!)
+    (doseq [s [:rf.xray/registered-resources
+               :rf.xray/registered-resources-override
+               :rf.xray/resource-entries
+               :rf.xray/resource-entries-override
+               :rf.xray/resource-work-ledger
+               :rf.xray/resource-work-ledger-override
+               :rf.xray/resource-sub-reads
+               :rf.xray/resource-sub-reads-override
+               :rf.xray/resources-tab-data]]
+      (is (some? (registrar/handler :sub s)) (str s " sub registered")))
+    (doseq [e [:rf.xray/set-registered-resources-override-for-test
+               :rf.xray/set-resource-entries-override-for-test
+               :rf.xray/set-resource-work-ledger-override-for-test
+               :rf.xray/set-resource-sub-reads-override-for-test]]
+      (is (some? (registrar/handler :event e)) (str e " event registered")))))
+
+(deftest read-only-no-resource-events
+  (testing "Spec 016 — the Xray registry surface carries NO :rf.resource/*
+            event (observing pins nothing; Xray never becomes an owner).
+            The :rf.resource/* events that DO exist are registered by the
+            resources ARTEFACT's own façade, not by any Xray panel — so
+            the read-only contract is checked against the Xray-owned
+            registry surface (every event Xray registers is :rf.xray*/)."
+    (registry/register-xray-handlers!)
+    ;; The panel's install! must register every event under the :rf.xray*/
+    ;; isolation prefix and NONE under :rf.resource/* — the structural
+    ;; guarantee that inspection never dispatches a resource event.
+    (doseq [e [:rf.xray/set-registered-resources-override-for-test
+               :rf.xray/set-resource-entries-override-for-test
+               :rf.xray/set-resource-work-ledger-override-for-test
+               :rf.xray/set-resource-sub-reads-override-for-test]]
+      (is (some? (registrar/handler :event e))
+          (str e " is registered under the :rf.xray*/ prefix"))
+      (is (= "rf.xray" (namespace e))
+          (str e " lives under the Xray isolation prefix, not :rf.resource/*")))))
+
+;; ---- (2) tab inventory --------------------------------------------------
+
+(deftest palette-includes-resources
+  (testing "the palette's canonical Dynamic panel list carries :resources"
+    (let [panels (palette-subs/palette-panels)
+          ids    (set (map :id panels))]
+      (is (contains? ids :resources) ":resources in palette-panels")
+      (is (= 7 (count panels))
+          "7 Dynamic tabs — Epoch / App DB / Views / Trace / Machines / Routing / Resources"))))
+
+;; ---- (3) sections render ------------------------------------------------
+
+(deftest panel-renders-sections-when-data-present
+  (testing "registry + instances + work + route-graph + timeline render"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-overrides!)
+      (let [tree (resources/Panel)]
+        (is (some? (find-by-testid tree "rf-xray-resources")) "panel root")
+        (is (some? (find-by-testid tree "rf-xray-resources-registry")) "registry section")
+        (is (some? (find-by-testid tree "rf-xray-resources-instances")) "instances section")
+        (is (some? (find-by-testid tree "rf-xray-resources-work")) "work section")
+        (is (some? (find-by-testid tree "rf-xray-resources-route-graph")) "route-graph section")
+        (is (some? (find-by-testid tree "rf-xray-resources-timeline")) "timeline section")
+        (is (some? (find-by-testid tree "rf-xray-resources-invalidation")) "invalidation section")
+        (is (some? (find-by-testid tree "rf-xray-resources-cache-growth")) "cache-growth section")
+        (is (some? (find-by-testid tree "rf-xray-resources-audit")) "audit section")
+        ;; a registry row for the article resource
+        (is (some? (find-by-testid tree "rf-xray-resources-registry-row-article/by-slug"))
+            "registry row rendered")
+        ;; a live instance row (gen 4)
+        (is (some? (find-by-testid tree "rf-xray-resources-instance-row-article/by-slug-g4"))
+            "live instance row rendered")
+        ;; the audit lists the explicit-global resource
+        (let [audit (find-by-testid tree "rf-xray-resources-audit-global")]
+          (is (some? audit))
+          (is (re-find #":article/by-slug" (node-text audit))
+              "global-scope audit lists the explicit-global resource"))))))
+
+(deftest instance-row-shows-status-and-owners
+  (testing "the instance row surfaces status + owner-count, derived not stored"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-overrides!)
+      (let [tree   (resources/Panel)
+            status (find-by-testid tree "rf-xray-resources-instance-row-article/by-slug-g4-status")]
+        (is (some? status))
+        (is (re-find #"loaded" (node-text status)) "status reads loaded")))))
+
+;; ---- (4) PRIVACY --------------------------------------------------------
+
+(deftest privacy-redacted-data-never-raw
+  (testing "a :sensitive? value the runtime redacted to :rf/redacted renders
+            [redacted] — the panel only ever receives the sentinel for a
+            sensitive slot (the runtime elides it BEFORE Xray sees it), so
+            the underlying value never reaches the panel"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/set-registered-resources-override-for-test resource-regs]
+                        {:frame :rf/xray})
+      ;; The runtime emits :rf/redacted for a :sensitive? data AND scope slot
+      ;; (scopes carry PII and get the SAME elision as data). The panel must
+      ;; render both sentinels as [redacted], never a raw preview.
+      (rf/dispatch-sync [:rf.xray/set-resource-entries-override-for-test
+                         {[:rf/redacted :article/by-slug {:slug "welcome"}]
+                          {:resource/id :article/by-slug :status :loaded
+                           :data :rf/redacted :generation 1
+                           :active-owners #{}}}]
+                        {:frame :rf/xray})
+      (let [tree (resources/Panel)
+            data (find-by-testid tree "rf-xray-resources-instance-row-article/by-slug-g1-data")
+            scope (find-by-testid tree "rf-xray-resources-instance-row-article/by-slug-g1-scope")]
+        (is (some? data))
+        (is (re-find #"\[redacted\]" (node-text data))
+            "redacted data renders [redacted]")
+        (is (some? scope))
+        (is (re-find #"\[redacted\]" (node-text scope))
+            "a redacted scope (PII) renders [redacted] — same elision as data")))))
+
+;; ---- (6) silent state ---------------------------------------------------
+
+(deftest panel-silent-when-no-resources
+  (testing "no resources + no instances → silent caption, no sections"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/set-registered-resources-override-for-test {}]
+                        {:frame :rf/xray})
+      (rf/dispatch-sync [:rf.xray/set-resource-entries-override-for-test {}]
+                        {:frame :rf/xray})
+      (let [tree (resources/Panel)]
+        (is (some? (find-by-testid tree "rf-xray-resources")) "panel root present")
+        (is (some? (find-by-testid tree "rf-xray-resources-silent")) "silent caption")
+        (is (nil? (find-by-testid tree "rf-xray-resources-registry"))
+            "no registry section when silent")
+        (is (nil? (find-by-testid tree "rf-xray-resources-instances"))
+            "no instances section when silent")))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
@@ -1,0 +1,377 @@
+(ns day8.re-frame2-xray.panels.resources-helpers-cljs-test
+  "Pure-data tests for Xray's Resources tab helpers (Spec 016 §Xray and
+  AI tooling).
+
+  Dual-target naming (`.cljc` + `_cljs_test`):
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    1. **trace family** — `resource-trace-op?` / `op-class` / `op-label`
+       over the closed `:rf.resource/*` enum + an in-namespace op not yet
+       enumerated; non-family ops reject.
+    2. **summarize (PRIVACY)** — type + bounded size + redaction-aware
+       preview; the framework sentinels (`:rf/redacted` /
+       `:rf.size/large-elided`) keep their status and render no raw
+       preview; a large value is bounded with `:elided?`. Params, scopes,
+       AND data go through the SAME fn.
+    3. **project-registry** — registrar map → sorted rows; scope policy
+       described; declaring-routes joined from the route registry;
+       schemas summarized.
+    4. **project-instances** — entries map → rows; derived `:stale?` /
+       `:gc-eligible?`; scope/params/data summarized (never raw).
+    5. **project-work-ledger** — ledger map → rows; terminal split; host
+       handles structurally absent.
+    6. **project-route-graph** — routes with `:resources` → graph nodes;
+       blocking = SSR wait point.
+    7. **lifecycle-timeline / invalidation-graph / cache-growth**.
+    8. **lints** — global-scope audit, suspicious-global, scope-mismatch,
+       orphaned-owner.
+    9. **filters** — instance / work / history filter axes; bounded
+       history."
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-xray.panels.resources-helpers :as h]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(def ^:private global-scope :rf.scope/global)
+(def ^:private session-scope [:rf.scope/session {:user-id "u-42" :tenant-id "acme"}])
+
+(def ^:private registrations
+  "A `(rf/registrations :resource)` shape — `{<id> <meta>}` where meta
+  carries the registration spec under `:rf/resource` + source coords."
+  {:article/by-slug
+   {:doc  "Article detail by slug."
+    :file "app/articles.cljs" :line 12
+    :rf/resource {:doc "Article detail by slug."
+                  :params-schema [:map [:slug :string]]
+                  :data-schema   :app/article
+                  :scope         :rf.scope/global
+                  :transport     :rf.http/managed
+                  :stale-after-ms 60000
+                  :gc-after-ms    300000
+                  :tags          (fn [_ _] #{})
+                  :request       (fn [_ _] {})}}
+   :me/profile
+   {:doc "The current user's profile."
+    :rf/resource {:doc "The current user's profile."
+                  :params-schema [:map]
+                  :scope         :rf.scope/global  ; suspicious — /me-ish
+                  :request       (fn [_ _] {})}}
+   :dashboard/summary
+   {:rf/resource {:params-schema [:map [:user-id :string]]
+                  :scope         :rf.scope/from-caller
+                  :request       (fn [_ _] {})}}})
+
+(def ^:private routes-map
+  {:route/article
+   {:path "/articles/:slug"
+    :resources [{:resource :article/by-slug :blocking? true
+                 :params (fn [_] {}) :scope (fn [_ _] nil)}
+                {:resource :comments/list :blocking? false :keep-previous? true}]}
+   :route/home {:path "/"}})
+
+;; ---- (1) trace family ---------------------------------------------------
+
+(deftest trace-family
+  (testing "enumerated ops are family members with class + label"
+    (is (h/resource-trace-op? :rf.resource/fetch-started))
+    (is (= :success (h/op-class :rf.resource/succeeded)))
+    (is (= :failure (h/op-class :rf.resource/failed)))
+    (is (= :suppression (h/op-class :rf.resource/stale-suppressed)))
+    (is (= :invalidation (h/op-class :rf.resource/invalidated)))
+    (is (= :gc (h/op-class :rf.resource/gc-fired)))
+    (is (= :dedupe (h/op-class :rf.resource/deduped)))
+    (is (= :hydration (h/op-class :rf.resource/hydrated)))
+    (is (= "fetch started" (h/op-label :rf.resource/fetch-started))))
+  (testing "an in-namespace op not yet enumerated is still a family member"
+    (is (h/resource-trace-op? :rf.resource/some-future-op))
+    (is (= :lifecycle (h/op-class :rf.resource/some-future-op)))
+    (is (= "some-future-op" (h/op-label :rf.resource/some-future-op))))
+  (testing "non-family ops reject"
+    (is (not (h/resource-trace-op? :rf.event/dispatched)))
+    (is (not (h/resource-trace-op? :rf.route/navigate)))
+    (is (nil? (h/op-class :rf.event/dispatched)))))
+
+;; ---- (2) summarize (PRIVACY) -------------------------------------------
+
+(deftest summarize-privacy
+  (testing "a map value summarizes to type + size + preview, never raw"
+    (let [s (h/summarize {:slug "welcome"})]
+      (is (= "map" (:type s)))
+      (is (= 1 (:size s)))
+      (is (not (:redacted? s)))
+      (is (not (:large? s)))))
+  (testing "scopes go through the SAME fn as data (scope carries PII)"
+    (let [s (h/summarize session-scope)]
+      (is (= "vector" (:type s)))
+      ;; the preview is bounded text, NOT a structured leak of the raw value
+      (is (string? (:preview s)))))
+  (testing "the framework redaction sentinel keeps redacted status, no raw preview"
+    (let [s (h/summarize :rf/redacted)]
+      (is (:redacted? s))
+      (is (= "[redacted]" (:preview s)))))
+  (testing "the framework large-elision sentinel keeps large status"
+    (let [s (h/summarize :rf.size/large-elided)]
+      (is (:large? s))
+      (is (= "[large — elided]" (:preview s)))))
+  (testing "a large value is bounded with :elided?"
+    (let [big (apply str (repeat 500 "x"))
+          s   (h/summarize big {:budget 20})]
+      (is (:elided? s))
+      (is (<= (count (:preview s)) 21))   ; budget + the … glyph
+      (is (not (:redacted? s)))))
+  (testing "scoped-key-summary summarizes scope + params, plain resource-id"
+    (let [s (h/scoped-key-summary [session-scope :article/by-slug {:slug "x"}])]
+      (is (= :article/by-slug (:resource-id s)))
+      (is (= "vector" (get-in s [:scope :type])))
+      (is (= "map" (get-in s [:params :type]))))))
+
+;; ---- (3) project-registry ----------------------------------------------
+
+(deftest project-registry-test
+  (let [rows (h/project-registry registrations routes-map)]
+    (testing "one row per registered resource, sorted by id"
+      (is (= 3 (count rows)))
+      (is (= [:article/by-slug :dashboard/summary :me/profile]
+             (mapv :resource-id rows))))
+    (testing "scope policy is described; global flagged"
+      (let [article (first (filter #(= :article/by-slug (:resource-id %)) rows))
+            dash    (first (filter #(= :dashboard/summary (:resource-id %)) rows))]
+        (is (= :global (get-in article [:scope :policy])))
+        (is (get-in article [:scope :global?]))
+        (is (= :from-caller (get-in dash [:scope :policy])))
+        (is (not (get-in dash [:scope :global?])))))
+    (testing "schemas summarized (never raw), policy/timestamps surfaced"
+      (let [article (first (filter #(= :article/by-slug (:resource-id %)) rows))]
+        (is (map? (:params-schema article)))   ; a summary map, not the raw schema
+        (is (= 60000 (:stale-after-ms article)))
+        (is (= 300000 (:gc-after-ms article)))
+        (is (:tags? article))
+        (is (= :rf.http/managed (get-in article [:request :transport])))
+        (is (= {:file "app/articles.cljs" :line 12} (:source-coord article)))))
+    (testing "declaring-routes joined from the route registry"
+      (let [article (first (filter #(= :article/by-slug (:resource-id %)) rows))]
+        (is (= [:route/article] (:declaring-routes article)))))))
+
+;; ---- (4) project-instances ---------------------------------------------
+
+(def ^:private now 1000000)
+
+(def ^:private entries
+  {[session-scope :article/by-slug {:slug "welcome"}]
+   {:resource/id :article/by-slug :status :loaded
+    :data {:title "Welcome"} :generation 4 :attempt 2
+    :loaded-at (- now 1000) :stale-at (+ now 50000)
+    :active-owners #{[:route :route/article "nav-1"]}
+    :tags #{[:article "welcome"]} :request-id [:w 4]}
+   [session-scope :article/by-slug {:slug "old"}]
+   {:resource/id :article/by-slug :status :loaded
+    :data {:title "Old"} :generation 2
+    :loaded-at (- now 99999) :stale-at (- now 1)   ; past stale-at → stale
+    :active-owners #{}                              ; no owner → gc-eligible
+    :tags #{[:article "old"]}}})
+
+(deftest project-instances-test
+  (let [rows (h/project-instances entries now)]
+    (testing "one row per entry; sorted by id then generation desc"
+      (is (= 2 (count rows)))
+      (is (= [4 2] (mapv :generation rows))))
+    (testing "scope/params/data summarized — NEVER raw"
+      (let [r (first rows)]
+        (is (= "vector" (get-in r [:scope :type])))   ; a summary, not the raw scope
+        (is (= "map" (get-in r [:params :type])))
+        (is (= "map" (get-in r [:data :type])))
+        (is (:has-data? r))))
+    (testing "derived :stale? (invalidated OR past stale-at) — not a stored fact"
+      (let [fresh (first (filter #(= 4 (:generation %)) rows))
+            stale (first (filter #(= 2 (:generation %)) rows))]
+        (is (not (:stale? fresh)) "loaded + stale-at in the future = fresh")
+        (is (:stale? stale) "past stale-at = stale")))
+    (testing "derived :gc-eligible? = no active owners"
+      (let [owned (first (filter #(= 4 (:generation %)) rows))
+            orphan (first (filter #(= 2 (:generation %)) rows))]
+        (is (not (:gc-eligible? owned)))
+        (is (:gc-eligible? orphan))
+        (is (= 1 (:owner-count owned)))))))
+
+;; ---- (5) project-work-ledger -------------------------------------------
+
+(def ^:private ledger
+  {[:rf.work/resource [session-scope :article/by-slug {:slug "welcome"}] 4]
+   {:work/id [:rf.work/resource [session-scope :article/by-slug {:slug "welcome"}] 4]
+    :work/kind :resource :resource/key [session-scope :article/by-slug {:slug "welcome"}]
+    :generation 4 :transport :rf.http/managed :status :running
+    :owners #{[:route :route/article "nav-1"]}
+    :causes [[:route-entry :route/article "nav-1"]]
+    :cancellable? true :started-at 100 :deadline-at 5100}
+   [:rf.work/resource [session-scope :article/by-slug {:slug "old"}] 1]
+   {:work/id [:rf.work/resource [session-scope :article/by-slug {:slug "old"}] 1]
+    :work/kind :resource :resource/key [session-scope :article/by-slug {:slug "old"}]
+    :generation 1 :status :completed :outcome {:ok true}}})
+
+(deftest project-work-ledger-test
+  (let [rows (h/project-work-ledger ledger)]
+    (testing "one row per work record; non-terminal (live) first"
+      (is (= 2 (count rows)))
+      (is (= [:running :completed] (mapv :status rows)))
+      (is (= [false true] (mapv :terminal? rows))))
+    (testing "host handles are structurally absent — only serializable facts"
+      (let [r (first rows)]
+        (is (= :resource (:kind r)))
+        (is (:cancellable? r))
+        (is (= 5100 (:deadline-at r)))
+        ;; resource-key scope/params summarized
+        (is (= "vector" (get-in r [:resource-key :scope :type])))
+        ;; one identity per record — stale-key = work-id (Spec 016)
+        (is (= (:work-id r) (:stale-key r)))))
+    (testing "causes summarized (may carry data)"
+      (is (vector? (:causes (first rows)))))))
+
+;; ---- (6) project-route-graph -------------------------------------------
+
+(deftest project-route-graph-test
+  (let [nodes (h/project-route-graph routes-map)]
+    (testing "only routes with :resources appear"
+      (is (= 1 (count nodes)))
+      (is (= :route/article (:route-id (first nodes)))))
+    (testing "blocking = SSR wait point; non-blocking split"
+      (let [n (first nodes)]
+        (is (= [:article/by-slug] (:blocking n)))
+        (is (= [:comments/list] (:non-blocking n)))
+        (is (:ssr-wait? n))))
+    (testing "resource nodes record declared resolvers without invoking them"
+      (let [res (first (:resources (first nodes)))]
+        (is (:blocking? res))
+        (is (:params-fn? res))
+        (is (:scope-resolver? res))))))
+
+;; ---- (7) timeline / invalidation / cache-growth ------------------------
+
+(def ^:private trace-buffer
+  [{:id 1 :operation :rf.event/dispatched :tags {}}
+   {:id 2 :operation :rf.resource/fetch-started
+    :tags {:resource-key [session-scope :article/by-slug {:slug "welcome"}]
+           :generation 4 :status :loading
+           :owner [:route :route/article "nav-1"]}}
+   {:id 3 :operation :rf.resource/succeeded
+    :tags {:resource-key [session-scope :article/by-slug {:slug "welcome"}]
+           :generation 4 :status-after :loaded}}
+   {:id 4 :operation :rf.resource/invalidated
+    :tags {:scope session-scope :tags #{[:article "welcome"]}
+           :cause [:mutation :article/save "m-1"]
+           :matched [[session-scope :article/by-slug {:slug "welcome"}]]
+           :refetched 1}}
+   {:id 5 :operation :rf.resource/owner-released
+    :tags {:owner [:lease :dashboard/opened "u-42"]}}])
+
+(deftest lifecycle-timeline-test
+  (let [rows (h/lifecycle-timeline trace-buffer)]
+    (testing "only resource-family rows, in buffer order"
+      (is (= [:rf.resource/fetch-started :rf.resource/succeeded
+              :rf.resource/invalidated :rf.resource/owner-released]
+             (mapv :operation rows))))
+    (testing "resource-id derived; key summarized; class set"
+      (let [fs (first rows)]
+        (is (= :article/by-slug (:resource-id fs)))
+        (is (= :lifecycle (:class fs)))
+        (is (= "vector" (get-in fs [:resource-key :scope :type])))))))
+
+(deftest invalidation-graph-test
+  (let [rows (h/invalidation-graph trace-buffer)]
+    (testing "one row per invalidation; scope summarized, tags + counts surfaced"
+      (is (= 1 (count rows)))
+      (let [r (first rows)]
+        (is (= "vector" (get-in r [:scope :type])))   ; scope summarized
+        (is (= [[:article "welcome"]] (:tags r)))
+        (is (= 1 (:match-count r)))
+        (is (= 1 (:refetched r)))
+        (is (map? (:cause r)))))))                      ; cause summarized
+
+(deftest cache-growth-test
+  (let [instance-rows (h/project-instances entries now)
+        work-rows     (h/project-work-ledger ledger)
+        g             (h/cache-growth instance-rows work-rows)]
+    (testing "aggregates per-resource entry/owned/gc counts + live work"
+      (is (= 2 (:total-entries g)))
+      (is (= 1 (:total-gc-eligible g)))
+      (is (= 1 (:live-work g)))               ; one non-terminal ledger row
+      (let [article (first (filter #(= :article/by-slug (:resource-id %))
+                                   (:by-resource g)))]
+        (is (= 2 (:entry-count article)))
+        (is (= 1 (:owned-count article)))
+        (is (= 1 (:gc-eligible article)))))))
+
+;; ---- (8) lints ----------------------------------------------------------
+
+(deftest scope-audit+lints
+  (let [registry-rows (h/project-registry registrations routes-map)
+        instance-rows (h/project-instances entries now)]
+    (testing "global-scope audit enumerates every :rf.scope/global resource"
+      (let [audit (h/global-scope-audit registry-rows)]
+        (is (= #{:article/by-slug :me/profile}
+               (set (map :resource-id audit))))))
+    (testing "suspicious-global flags a /me-ish explicit-global"
+      (let [warns (h/suspicious-global-warnings registry-rows)]
+        (is (= [:me/profile] (mapv :resource-id warns)))))
+    (testing "scope-mismatch lint flags a sub reading a different scope"
+      ;; a sub reads :article/by-slug {:slug "welcome"} under GLOBAL scope
+      ;; while the entry is cached under the SESSION scope → mismatch.
+      (let [mismatches (h/scope-mismatch-lint
+                         instance-rows
+                         [{:resource-id :article/by-slug
+                           :params {:slug "welcome"}
+                           :scope  global-scope}])]
+        (is (= 1 (count mismatches)))
+        (is (= :article/by-slug (:resource-id (first mismatches))))
+        ;; surfaced scopes are summarized (PRIVACY)
+        (is (map? (:sub-scope (first mismatches)))))
+      ;; a sub reading the SAME scope as the entry → no mismatch
+      (is (empty? (h/scope-mismatch-lint
+                    instance-rows
+                    [{:resource-id :article/by-slug
+                      :params {:slug "welcome"} :scope session-scope}]))))
+    (testing "orphaned-owner lint flags an app-kind owner with no release"
+      ;; add an entry pinned by an app-minted [:lease …] owner with no
+      ;; owner-released event in the trace
+      (let [pinned (assoc entries
+                          [session-scope :dashboard/summary {:user-id "u-99"}]
+                          {:resource/id :dashboard/summary :status :loaded
+                           :data {} :active-owners #{[:lease :dashboard/opened "u-99"]}})
+            rows   (h/project-instances pinned now)
+            ;; trace has a release only for u-42, not u-99
+            orphans (h/orphaned-owner-lint rows trace-buffer)]
+        (is (= [[:lease :dashboard/opened "u-99"]] (mapv :owner orphans))))
+      (testing "a route/machine/ssr owner is framework-released — not linted"
+        (is (empty? (h/orphaned-owner-lint instance-rows trace-buffer))
+            "the route-owned fresh entry is not an app-kind owner")))))
+
+;; ---- (9) filters --------------------------------------------------------
+
+(deftest filters-test
+  (let [instance-rows (h/project-instances entries now)
+        work-rows     (h/project-work-ledger ledger)
+        timeline-rows (h/lifecycle-timeline trace-buffer)]
+    (testing "instance filter axes: resource-id / status / stale? / tag / owner"
+      (is (= 2 (count (h/filter-instance-rows instance-rows {:resource-id :article/by-slug}))))
+      (is (= 2 (count (h/filter-instance-rows instance-rows {:status :loaded}))))
+      (is (= 1 (count (h/filter-instance-rows instance-rows {:stale? true}))))
+      (is (= 1 (count (h/filter-instance-rows instance-rows {:stale? false}))))
+      (is (= 1 (count (h/filter-instance-rows instance-rows {:tag [:article "welcome"]}))))
+      (is (= 1 (count (h/filter-instance-rows instance-rows
+                        {:owner [:route :route/article "nav-1"]})))))
+    (testing "select-raw-entries key-axis filter (scope/resource-id/params)"
+      (is (= 2 (count (h/select-raw-entries entries {:resource-id :article/by-slug}))))
+      (is (= 1 (count (h/select-raw-entries entries {:params {:slug "welcome"}}))))
+      (is (= 2 (count (h/select-raw-entries entries {:scope session-scope})))))
+    (testing "work filter axes incl. nav-token (matches an owner carrying it)"
+      (is (= 1 (count (h/filter-work-rows work-rows {:status :running}))))
+      (is (= 1 (count (h/filter-work-rows work-rows {:nav-token "nav-1"})))))
+    (testing "history filter is BOUNDED by :limit"
+      (is (= 4 (count (h/filter-history-rows timeline-rows {}))))
+      (is (= 2 (count (h/filter-history-rows timeline-rows {:limit 2}))))
+      (is (= 1 (count (h/filter-history-rows timeline-rows
+                        {:resource-id :article/by-slug :limit 1})))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
@@ -175,8 +175,8 @@
     (let [panels (palette-subs/palette-panels)
           ids    (set (map :id panels))]
       (is (contains? ids :routing) ":routing in palette-panels")
-      (is (= 6 (count panels))
-          "exactly 6 entries — Epoch / App DB / Views / Trace / Machines / Routing (rf2-gbz39 removed the Issues tab per Mike's Option (c) ruling — issues surface inline + event-row pink-wash + the always-on issues ribbon signal. rf2-5gl5r retired the Event/Handler tab; the Epoch panel supersedes it. rf2-sc3r1 originally added Epoch at order 5; rf2-4v67l removed the Chrome A11y dogfood in favour of Story's shipped panel; rf2-ga16q removed the Machines Canvas tab — its browse-all canvas relocated to the Static Machines sub-tab.)"))))
+      (is (= 7 (count panels))
+          "exactly 7 entries — Epoch / App DB / Views / Trace / Machines / Routing / Resources (the Resources tab — Spec 016 §Xray and AI tooling — earns its own L4 tab per Mike's cohesive-sub-domain ruling; rf2-gbz39 removed the Issues tab per Mike's Option (c) ruling — issues surface inline + event-row pink-wash + the always-on issues ribbon signal. rf2-5gl5r retired the Event/Handler tab; the Epoch panel supersedes it. rf2-sc3r1 originally added Epoch at order 5; rf2-4v67l removed the Chrome A11y dogfood in favour of Story's shipped panel; rf2-ga16q removed the Machines Canvas tab — its browse-all canvas relocated to the Static Machines sub-tab.)"))))
 
 ;; ---- (2) three sections render (always-visible base layer) --------------
 

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -264,6 +264,19 @@
    :rf.xray/current-route-slice
    :rf.xray/current-route-slice-override
    :rf.xray/routing-tab-data
+   ;; Spec 016 §Xray and AI tooling — Resources tab (8th L3 tab) sub
+   ;; family. The static registry + the live runtime-db cache/ledger
+   ;; slices + the view-facing composite + the scope-mismatch-lint
+   ;; sub-reads slot, each with a test-only override.
+   :rf.xray/registered-resources
+   :rf.xray/registered-resources-override
+   :rf.xray/resource-entries
+   :rf.xray/resource-entries-override
+   :rf.xray/resource-work-ledger
+   :rf.xray/resource-work-ledger-override
+   :rf.xray/resource-sub-reads
+   :rf.xray/resource-sub-reads-override
+   :rf.xray/resources-tab-data
    ;; rf2-o5f5f.3 — Routes browse + Simulate-URL state lives under
    ;; the Static Routes panel (promoted from `:rf.xray.routing/*` per
    ;; the two-verbs-two-homes split). The Dynamic Routing lens narrows
@@ -632,6 +645,14 @@
    ;; rf2-nrbs9 — Routes tab test-only override events.
    :rf.xray/set-current-route-slice-override-for-test
    :rf.xray/set-registered-routes-override-for-test
+   ;; Spec 016 §Xray and AI tooling — Resources tab test-only override
+   ;; events (registry / entries / work-ledger / sub-reads). The panel
+   ;; registers NO :rf.resource/* event — it is read-only (observing
+   ;; pins no resource).
+   :rf.xray/set-registered-resources-override-for-test
+   :rf.xray/set-resource-entries-override-for-test
+   :rf.xray/set-resource-work-ledger-override-for-test
+   :rf.xray/set-resource-sub-reads-override-for-test
    ;; rf2-o5f5f.3 — Static Routes UI-state events (search input,
    ;; Simulate-URL input, expand-row toggle, hermetic Simulate-nav
    ;; toggle, cross-link to Dynamic Routing). Promoted from the

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -700,28 +700,30 @@
   shipped chrome-a11y dogfood per rf2-18t6p; a11y dogfooding is
   properly Story's domain. rf2-ga16q — the Machines Canvas tab was
   removed; its spine-INDEPENDENT browse-all canvas relocated to the
-  Static Machines sub-tab.)"
-  [:epoch :app-db :views :trace :machines :routing])
+  Static Machines sub-tab. Resources — Spec 016 §Xray and AI tooling —
+  earns its own L3 tab after Routing per Mike's cohesive-sub-domain
+  ruling.)"
+  [:epoch :app-db :views :trace :machines :routing :resources])
 
 (deftest tab-bar-renders-six-tabs
-  (testing "spec/018 §5 — six tabs (Epoch / App-db / Views / Trace /
-            Machines / Routing — Epoch supersedes the retired
+  (testing "spec/018 §5 — Epoch / App-db / Views / Trace / Machines /
+            Routing / Resources (Epoch supersedes the retired
             Event/Handler tab per rf2-5gl5r; rf2-gbz39 removed the
             Issues tab per Option (c)). rf2-4v67l removed the
             Chrome A11y dogfood in favour of Story's shipped panel;
             rf2-ga16q removed the Machines Canvas tab (relocated to
-            Static)."
+            Static); Resources added per Spec 016."
     (xray-setup!)
     (rf/with-frame :rf/xray
       (let [tree (shell/shell-view)
             tabs (find-all-by-testid-prefix tree "rf-xray-tab-")]
         ;; Need to filter out the L4 detail panel and tab-bar root.
-        (is (= 6 (count (filter (fn [n]
+        (is (= 7 (count (filter (fn [n]
                                   (let [t (:data-testid (second n))]
                                     (some #(= t (str "rf-xray-tab-" (name %)))
                                           expected-tab-ids)))
                                 tabs)))
-            "6 tab buttons render")
+            "7 tab buttons render")
         (doseq [tab-id expected-tab-ids]
           (is (some? (find-by-testid tree (str "rf-xray-tab-" (name tab-id))))
               (str "tab button for " tab-id)))))))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -34,6 +34,12 @@ const PANEL_HANDOFFS = [
   // rf2-lq0ef) is the focused-event navigation lens. Its root view
   // renders the `rf-xray-routing` testid (panels/routing.cljs).
   ['routing', 'rf-xray-routing'],
+  // The :resources tab (Spec 016 §Xray and AI tooling) is the
+  // declarative-server-state lens. Its root view renders the
+  // `rf-xray-resources` testid (panels/resources.cljs). On the counter
+  // testbed no resources are registered, so the panel renders its
+  // silent-by-default state under the same `rf-xray-resources` root.
+  ['resources', 'rf-xray-resources'],
   // rf2-gbz39 — the Issues tab was removed (Mike RULED Option (c));
   // issues surface inline in the Epoch panel + the L2 event-row pink-
   // wash + the always-on issues ribbon signal (the auto-open-on-error
@@ -188,11 +194,11 @@ async function openXray(page) {
 }
 
 // Post rf2-xy4yb: the L3 tab bar replaces the legacy sidebar. Tabs
-// expose `data-testid="rf-xray-tab-<id>"` for the 6 surviving panels
-// (epoch / app-db / views / trace / machines / routing —
+// expose `data-testid="rf-xray-tab-<id>"` for the 7 panels
+// (epoch / app-db / views / trace / machines / routing / resources —
 // spec/018 §5; rf2-5gl5r retired the Event/Handler tab in favour of
 // the Epoch panel; rf2-gbz39 removed the Issues tab per Mike's Option
-// (c) ruling).
+// (c) ruling; Resources added per Spec 016 §Xray and AI tooling).
 async function clickTab(page, id, canvasTestId) {
   await page.locator(`[data-testid="rf-xray-tab-${id}"]`).click();
   await expectVisible(page.locator(`[data-testid="${canvasTestId}"]`), 5000);


### PR DESCRIPTION
EP-0003 slice 9 — the Xray surface for declarative server-state (Spec 016 §Xray and AI tooling). Closes **rf2-0xljxy**.

## What landed

**Panel** (`panels/resources.cljs` + `resources_helpers.cljc` — JVM-portable projection algebra). A Dynamic L3 tab (`:resources`, order 7, after Routes) with eight sections:
- static resource registry (id, source coords, params/data schemas, request summary, stale/GC policy, tag producer, scope policy, sensitivity/large class, declaring routes)
- live per-frame instance table (key, scope, status, timestamps, generation, request id, attempt, active owners, tags, errors, data summary, derived `stale?`/GC-eligibility)
- live per-frame **work-ledger** table (work id, kind, resource key, generation, status, owners, causes, cancellable?, deadline, attempt, outcome — raw host handles structurally inaccessible)
- route/resource graph (blocking = SSR wait point; `:after` waterfall), lifecycle timeline, invalidation/mutation graph, cache-growth view
- scope audit (every `:rf.scope/global`) + scope-mismatch + orphaned-owner + suspicious-explicit-global lints

**`:rf.resource/*` trace family** — closed op set + per-op semantic class + labels; Xray colours/filters; any `rf.resource`-namespaced op is recognised even before the enum is extended.

**Tool accessors** (`runtime.cljs`) — `list-resources` / `list-resource-instances` / `get-resource-state` / `get-resource-history` (bounded) / `list-resource-invalidations`, filterable by frame / scope / resource-id / params / tag / owner / status / stale? / request-id / nav-token.

## Privacy (load-bearing)

Params, scopes, **and** data get the SAME elision — scopes carry user/tenant/locale/impersonation ids. Two layers: the always-on in-panel `summarize` shape (type + bounded size + redaction-aware preview, never raw; honours the `:rf/redacted` / `:rf.size/large-elided` sentinels) + the off-box `egress-runtime-db-value` walker on the accessors (runtime-db default-redacted; trusted-local opt-in). History is bounded.

## Read-only

The panel registers no `:rf.resource/*` event and dispatches none — **observing pins no resource** (Xray never becomes an owner by observing).

## Decoupling + bundle isolation

Xray does not `:require` `re-frame.resources.*` (post-v1 optional artefact, not a hard Xray dep). The panel reads the registry via `(rf/registrations :resource)` and the live cache/ledger off the runtime-db partition slice — same posture as the Routing tab + Machine Inspector. Reserved runtime-db keys are small duplicated literals. `tools/xray` stays out of production bundles.

## Spec (standing rule — same PR)

New `tools/xray/spec/024-Resources-Panel.md`; updated 007-UX-IA inventory (7 L3 tabs / 13 mountable / 15 total), 014-Registry-Catalogue (the `:rf.xray/*` surface + accessors), API.md panel list, README index.

## Gates (all green)
- `npm run test:cljs` — 0 failures (6179 tests)
- `npm run test:bundle-isolation` — PASS (xray absent from prod bundles)
- `npm run test:xray-feature-gate` — 0 failures (full nightly sweep; Resources tab handoff swept) + smoke 0 failures
- `clojure -M:test` (xray JVM) — 0 failures (the `.cljc` helpers test runs JVM too)
- api-manifest `gen --check` + `api-md-check` + `xray-spec-check` — all in sync
- clj-kondo — 0 errors

No design fork — Spec 016 §Xray and AI tooling fully settled the surface, trace family, accessor set, and privacy posture.
