### PR TITLE
feat(resources): invalidation/GC/owners + stale-GC timers (rf2-nbjewi)

### DIFF
--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -62,6 +62,7 @@
             [re-frame.resources.ssr :as ssr]
             [re-frame.resources.state :as state]
             [re-frame.resources.subs :as resource-subs]
+            [re-frame.resources.timers :as timers]
             [re-frame.resources.work-ledger :as work-ledger]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -147,6 +148,24 @@
            work-ledger/clear-work-handle-meta
            work-ledger/clear-work-handle-handler)
 
+;; Stale / GC timer side-table write fx (rf2-nbjewi). The stale / GC timer
+;; handles are host-side transient state (NOT runtime-db), so their writes
+;; ride fx exactly as the generation high-water bump + work-handle side-table
+;; writes do. The success reply handler emits :rf.resource/schedule-timers
+;; once an entry settles :loaded (arming the advisory stale / GC timers from
+;; the durable :loaded-at + policy); remove / clear-scope / a fired GC emit
+;; :rf.resource/cancel-timers. Both are `:platforms #{:client}` — the runtime
+;; platform gate skips them under SSR (which uses the blocking-drain wait
+;; point + lazy client revalidation, never wall-clock background timers). Per
+;; Spec 016 §Stale and GC scheduling. Registered in the façade so a `:reload`
+;; re-wires them.
+(fx/reg-fx :rf.resource/schedule-timers
+           timers/schedule-timers-meta
+           timers/schedule-timers-handler)
+(fx/reg-fx :rf.resource/cancel-timers
+           timers/cancel-timers-meta
+           timers/cancel-timers-handler)
+
 ;; The interceptor injected into the load-causing events (ensure / refetch)
 ;; so their handlers read the host-side generation high-water snapshot under
 ;; `:coeffects :rf.resource/generation` and mint the next monotone
@@ -187,6 +206,9 @@
 (events/reg-event-fx :rf.resource.internal/aborted
                      framework-authority-meta
                      resource-events/aborted-handler)
+(events/reg-event-fx :rf.resource.internal/stale-fired
+                     framework-authority-meta
+                     resource-events/stale-fired-handler)
 (events/reg-event-fx :rf.resource.internal/gc-fired
                      framework-authority-meta
                      resource-events/gc-fired-handler)
@@ -204,25 +226,29 @@
 (route/install-routing-integration!)
 (ssr/install-ssr-integration!)
 
-;; rf2-afpdkn: release the destroyed frame's host-side TRANSIENT resource
-;; caches — the work-ledger host handles (AbortControllers / timer handles,
-;; `re-frame.resources.work-ledger/handle-table`) AND the generation
-;; high-water mark (`re-frame.resources.state/generation-cache`). Neither is
-;; runtime-db state — both live in module-level atoms (host-derived,
+;; rf2-afpdkn / rf2-nbjewi: release the destroyed frame's host-side TRANSIENT
+;; resource caches — the work-ledger host handles (AbortControllers,
+;; `re-frame.resources.work-ledger/handle-table`), the stale / GC timer
+;; handles (`re-frame.resources.timers/timer-table`, rf2-nbjewi), AND the
+;; generation high-water mark (`re-frame.resources.state/generation-cache`).
+;; None is runtime-db state — all live in module-level atoms (host-derived,
 ;; ephemeral, off the epoch / SSR egress wire; the generation host-side so an
 ;; epoch restore cannot rewind + recycle a generation). `frame/destroy-frame!`
-;; invokes this single hook by key (no static dep on resources — the artefact
-;; is optional). The durable serializable work records + cache entries ride
-;; the frame value and are released atomically when the frame is dropped; this
-;; hook touches ONLY the host side tables. Per Spec 016 [Runtime-Subsystems]
-;; clause 5 / §Stale and GC scheduling. Composed here (one late-bind key →
-;; one fn) mirroring routing's `:routing/on-frame-destroyed!`.
+;; invokes this SINGLE hook by key (no static dep on resources — the artefact
+;; is optional; ONE teardown path, not three). The durable serializable work
+;; records + cache entries ride the frame value and are released atomically
+;; when the frame is dropped; this hook touches ONLY the host side tables. Per
+;; Spec 016 [Runtime-Subsystems] clause 5 / §Stale and GC scheduling (frame
+;; destroy cancels all resource timers for that frame). Composed here (one
+;; late-bind key → one fn) mirroring routing's `:routing/on-frame-destroyed!`.
 (defn- release-resources-host-caches!
   "Release ALL of the destroyed frame's host-side transient resource caches
-  (work-ledger host handles + generation high-water mark). The
-  `:resources/on-frame-destroyed!` teardown body."
+  (work-ledger host handles + stale / GC timer handles + generation
+  high-water mark). The `:resources/on-frame-destroyed!` teardown body — one
+  composed hook, no second teardown path."
   [frame-id]
   (work-ledger/on-frame-destroyed! frame-id)
+  (timers/on-frame-destroyed! frame-id)
   (state/release-frame! frame-id)
   nil)
 

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -54,6 +54,7 @@
   `live-entry-for-reply`). Terminal rows are pruned on the linked entry's
   next successful transition, retaining a bounded per-key tail for Xray."
   (:require [clojure.set :as set]
+            [re-frame.frame :as frame]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.route :as route]
             [re-frame.resources.state :as state]
@@ -80,6 +81,23 @@
   [spec loaded-at]
   (when-let [ms (:stale-after-ms spec)]
     (+ loaded-at ms)))
+
+(defn- positive-or-nil
+  "Return `ms` when it is a positive number, else nil (a non-positive /
+  absent policy never arms a timer). Guards a timer delay derived from an
+  absolute timestamp comparison so a clock-skewed or already-elapsed deadline
+  yields nil rather than a negative wall-clock delay."
+  [ms]
+  (when (and (number? ms) (pos? ms)) ms))
+
+(defn- server-frame?
+  "True iff `frame-id` is an SSR / server frame (its `:config :platform` is
+  `:server`, set by the `:ssr-server` preset). Reads ONLY the FRAME's
+  platform — NOT the host-wide `active-platform` default (which is `:server`
+  on the JVM, so a JVM client-mode unit test must still arm timers). Per Spec
+  016 §Stale and GC scheduling (no wall-clock background timers under SSR)."
+  [frame-id]
+  (= :server (:platform (frame/frame-meta frame-id))))
 
 ;; ---- ensure / refetch — the load-causing events ---------------------------
 
@@ -242,46 +260,95 @@
 
 (defn invalidate-tags-handler
   "`:rf.resource/invalidate-tags` — exact tag invalidation (Spec 016
-  §Invalidation). Scoped by default: marks every entry whose provided tags
-  intersect `:tags` AND whose scope matches `:scope` as stale (sets
-  `:invalidated-at`); active-owner entries are refetched, inactive entries
-  are left stale / GC-eligible. Emits one decision summary + per-entry
-  details. Payload: `{:scope :tags :cause}`.
+  §Invalidation). Payload: `{:scope :tags :cause :cross-scope?}`.
 
-  This slice marks entries stale + records the invalidation, and dispatches
-  a `:rf.resource/refetch` for each active-owner entry. The refetch-vs-
-  leave-stale decision keys on `:active-owners` presence."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id} [_event-id {:keys [scope tags cause]}]]
+  Algorithm (Spec 016 §Invalidation):
+    1. find entries whose produced `:tags` intersect the invalidated `:tags`;
+    2. mark each matched entry stale (durable `:invalidated-at` fact);
+    3. refetch the matched entries that have ACTIVE OWNERS (a live lease
+       needs fresh data now) — by dispatching `:rf.resource/refetch`;
+    4. leave the matched OWNERLESS entries stale / GC-eligible (their stale?
+       sub derives true from `:invalidated-at`; their GC timer reaps them);
+    5. emit ONE decision summary + per-entry detail (so Xray shows a
+       broad-tag storm without flooding the trace).
+
+  **Scoped by DEFAULT** (Spec 016 §clear-scope is causal / §Invalidation): a
+  match requires the entry's scope to equal `:scope`. A CROSS-SCOPE
+  invalidation (`:cross-scope? true`) opts in explicitly — it ignores the
+  scope filter (matching the tags in every scope) and is loudly Xray-visible
+  (the summary carries `:cross-scope? true` so a broad multi-tenant /
+  multi-user storm is observable + lintable). A cross-scope invalidation with
+  no `:scope` is permitted (it is scope-agnostic by construction).
+
+  **No-match distinction** (Spec 016 §Invalidation): the summary carries
+  `:matched` (the matched keys), `:any-tag-match-other-scope?` (whether the
+  tags match an entry in ANOTHER scope — \"no match HERE\" vs \"no resource
+  provides this tag in any scope\"), so Xray can tell the two apart."
+  [{rt :rf.db/runtime, frame-id :rf.frame/id}
+   [_event-id {:keys [scope tags cause cross-scope?]}]]
   (let [runtime-db (or rt {})
-        cscope     (state/canonicalize scope)
+        cscope     (when (some? scope) (state/canonicalize scope))
+        tag-set    (set tags)
         invalidated-at (now-ms)
         entries    (get-in runtime-db (state/entries-path))
-        ;; matched: scope matches AND tags intersect (exact tag match)
+        tags-hit?  (fn [entry] (seq (set/intersection (set (:tags entry)) tag-set)))
+        in-scope?  (fn [k] (or cross-scope? (= cscope (first k))))
+        ;; matched: tags intersect AND (cross-scope OR scope matches)
         matched    (into {}
-                         (filter (fn [[k entry]]
-                                   (and (= cscope (first k))
-                                        (seq (set/intersection
-                                               (set (:tags entry)) (set tags))))))
+                         (filter (fn [[k entry]] (and (in-scope? k) (tags-hit? entry))))
                          entries)
+        ;; tag matches that fell OUTSIDE the requested scope (the
+        ;; "no match HERE, but the tag exists in another scope" signal — only
+        ;; meaningful for a scoped invalidation)
+        other-scope-hit?
+        (and (not cross-scope?)
+             (boolean
+               (some (fn [[k entry]] (and (not= cscope (first k)) (tags-hit? entry)))
+                     entries)))
         ;; mark each matched entry stale (durable :invalidated-at fact)
         rdb'       (reduce-kv
                      (fn [db k entry]
                        (assoc-in db (state/entry-path k)
                                  (assoc entry :invalidated-at invalidated-at)))
                      runtime-db matched)
-        ;; refetch only the active-owner entries (Spec 016 §Invalidation 3)
+        ;; per-entry decision: active-owner entries refetch (Spec 016
+        ;; §Invalidation 3); ownerless entries are left stale / GC-eligible
+        ;; (§Invalidation 4). Collected once for both the dispatches and the
+        ;; per-entry trace detail.
+        decisions  (mapv (fn [[k entry]]
+                           {:resource-key k
+                            :active? (boolean (seq (:active-owners entry)))
+                            :decision (if (seq (:active-owners entry))
+                                        :refetch :left-stale)
+                            :tags (vec (:tags entry))})
+                         matched)
         refetches  (into []
                          (comp
-                           (filter (fn [[_ entry]] (seq (:active-owners entry))))
-                           (map (fn [[k _]]
+                           (filter :active?)
+                           (map (fn [{k :resource-key}]
                                   (let [[s rid p] k]
                                     [:dispatch [:rf.resource/refetch
                                                 {:resource rid :scope s :params p
                                                  :cause [:invalidate {:tags tags}]}]]))))
-                         matched)]
+                         decisions)]
+    ;; ONE decision summary (broad-tag storms stay readable) ...
     (trace/emit! :rf.event :rf.resource/invalidated
                  {:rf.frame/id frame-id :scope cscope :tags tags :cause cause
-                  :matched (vec (keys matched)) :refetched (count refetches)})
+                  :cross-scope? (boolean cross-scope?)
+                  :matched (mapv :resource-key decisions)
+                  :refetched (count refetches)
+                  :left-stale (count (remove :active? decisions))
+                  ;; no-match distinction: no match in this scope vs no resource
+                  ;; provides this tag in any scope (Spec 016 §Invalidation)
+                  :any-tag-match-other-scope? other-scope-hit?})
+    ;; ... PLUS one per-entry detail trace (the refetch-vs-leave-stale
+    ;; decision per matched key — Spec 016 §Invalidation 5 / the Xray
+    ;; invalidation graph)
+    (doseq [{:keys [resource-key active? decision tags] :as _d} decisions]
+      (trace/emit! :rf.event :rf.resource/refetch-decision
+                   {:rf.frame/id frame-id :resource-key resource-key
+                    :scope (first resource-key) :active? active?
+                    :decision decision :tags tags :cause cause}))
     {:rf.db/runtime rdb'
      :fx refetches}))
 
@@ -382,8 +449,16 @@
                   :removed (vec in-scope) :reason :clear-scope
                   :aborted (mapv first in-flight)})
     {:rf.db/runtime rdb'
-     :fx (into [] (keep (fn [[wid transport]] (work-ledger/abort-fx transport wid)))
-               in-flight)}))
+     ;; best-effort abort of each in-scope in-flight attempt PLUS cancel the
+     ;; cleared entries' advisory stale / GC timers (their durable facts are
+     ;; gone — release the host handles promptly rather than waiting for frame
+     ;; destroy). Stale suppression by work-id + generation remains the
+     ;; correctness boundary; the abort + timer-cancel are the optimisation.
+     :fx (cond-> (into [] (keep (fn [[wid transport]] (work-ledger/abort-fx transport wid)))
+                       in-flight)
+           (seq in-scope)
+           (conj [:rf.resource/cancel-timers
+                  {:frame-id frame-id :resource-keys (vec in-scope)}]))}))
 
 ;; ---- remove — single-instance cache removal --------------------------------
 
@@ -413,8 +488,11 @@
                   :aborted (when wid [wid])})
     {:rf.db/runtime rdb'
      ;; best-effort abort of the removed instance's in-flight attempt
-     ;; (opportunistic; stale suppression protects correctness)
-     :fx (if-let [fx (and wid (work-ledger/abort-fx transport wid))] [fx] [])}))
+     ;; (opportunistic; stale suppression protects correctness) PLUS cancel
+     ;; its advisory stale / GC timers (the entry's durable facts are gone).
+     :fx (conj (if-let [fx (and wid (work-ledger/abort-fx transport wid))] [fx] [])
+               [:rf.resource/cancel-timers
+                {:frame-id frame-id :resource-keys [scoped-key]}])}))
 
 ;; ---- framework-internal reply handlers ------------------------------------
 ;;
@@ -512,6 +590,15 @@
       (let [spec      (registry/resource-meta (:resource/id entry))
             loaded-at (now-ms)
             stale-at  (stale-at-for spec loaded-at)
+            ;; arm the advisory stale / GC timers from the resource's policy
+            ;; (Spec 016 §Stale and GC scheduling). The DELAYS are relative
+            ;; from now (the durable absolute :stale-at / :loaded-at remain the
+            ;; freshness facts the re-check derives against; the timer is only
+            ;; an advisory nudge). A resource declaring no :stale-after-ms /
+            ;; :gc-after-ms arms neither. nil when this resource arms no timers
+            ;; (no schedule-timers fx emitted).
+            stale-delay-ms (positive-or-nil (:stale-after-ms spec))
+            gc-delay-ms    (positive-or-nil (:gc-after-ms spec))
             tags-fn   (:tags spec)
             ;; tags are produced from the params + decoded data; the canonical
             ;; params are the third element of the scoped key
@@ -546,7 +633,23 @@
                      {:rf.frame/id frame-id :resource-key resource-key
                       :work-id work-id :generation generation
                       :status-before (:status entry) :status-after :loaded})
-        {:rf.db/runtime rdb'}))))
+        ;; arm the advisory stale / GC timers (host-side side table) for this
+        ;; freshly-loaded entry — the WRITE rides an fx exactly as the
+        ;; generation high-water bump + work-handle side-table writes do.
+        ;; Cancel-then-arm so a re-load reschedules a single live timer per
+        ;; [key kind]. Skipped under SSR by the fx's `:platforms #{:client}`
+        ;; gate (the re-check handler re-derives freshness from the durable
+        ;; :stale-at, so a never-fired server timer is harmless). Only emitted
+        ;; when the resource declares at least one policy. Per Spec 016 §Stale
+        ;; and GC scheduling.
+        (cond-> {:rf.db/runtime rdb'}
+          (or stale-delay-ms gc-delay-ms)
+          (assoc :fx [[:rf.resource/schedule-timers
+                       {:frame-id       frame-id
+                        :resource-key   resource-key
+                        :stale-delay-ms stale-delay-ms
+                        :gc-delay-ms    gc-delay-ms
+                        :server?        (server-frame? frame-id)}]]))))))
 
 (defn failed-handler
   "`:rf.resource.internal/failed` — a transport read failed. Verifies frame
@@ -622,14 +725,60 @@
                       runtime-db work-id work-ledger/mark-terminal
                       :cancelled {:reason :aborted})}))
 
+(defn stale-fired-handler
+  "`:rf.resource.internal/stale-fired` — a stale timer fired. The timer is
+  ADVISORY: freshness is computed from the entry's DURABLE `:stale-at`
+  (the `:rf.resource/stale?` sub already derives it against the live clock),
+  so this handler does NOT need to flip a stored boolean — it RE-CHECKS the
+  live entry and records the freshness fact for tools, never writing a stale
+  decision. Per Spec 016 §Stale and GC scheduling (\"a stale timer may
+  enqueue a resource event, but the handler MUST re-check the current entry
+  before writing\").
+
+  The re-check (against the LIVE durable facts, not the timer's wake-time
+  assumptions):
+    - the entry is gone (removed / GC'd / cleared) — no-op (a superseded
+      timer);
+    - the entry has been re-loaded to a NEWER generation since the timer
+      armed (its `:loaded-at` moved past the timer's basis) — no-op; a fresh
+      schedule-timers fx already re-armed it;
+    - otherwise the entry IS now stale-by-policy — the durable `:stale-at`
+      already makes the `:stale?` sub true (no write needed); emit a trace so
+      Xray's lifecycle timeline shows the staleness boundary crossed. Refetch
+      is NOT forced on a stale timer — staleness is orthogonal to refetch (a
+      stale entry refreshes on its next live cause; the focus/reconnect
+      active-stale scan is rf2-vtblcq, not this slice)."
+  [{rt :rf.db/runtime, frame-id :rf.frame/id}
+   [_event-id {:keys [resource-key]}]]
+  (let [runtime-db (or rt {})
+        entry      (get-in runtime-db (state/entry-path resource-key))
+        ;; re-derive staleness from the DURABLE :stale-at (the timer is
+        ;; advisory — never trust "the timer fired on time"). An entry
+        ;; re-loaded since the timer armed has a future :stale-at and is not
+        ;; yet stale, so the re-check naturally no-ops. Shared derivation
+        ;; (`state/entry-stale?`) so it never drifts from the subs / SSR view.
+        stale?     (state/entry-stale? entry (now-ms))]
+    (trace/emit! :rf.event :rf.resource/stale-fired
+                 {:rf.frame/id frame-id :resource-key resource-key
+                  :decision (cond (nil? entry) :no-entry
+                                  stale?       :now-stale
+                                  :else        :still-fresh)})
+    ;; durable :stale-at is the freshness fact; no write needed.
+    {:rf.db/runtime runtime-db}))
+
 (defn gc-fired-handler
   "`:rf.resource.internal/gc-fired` — an inactive-GC timer fired. Re-check
   owner sets + entry generation after wake (timers are advisory); remove
   the entry only if still GC-eligible. Per Spec 016 §Stale and GC
-  scheduling.
+  scheduling (\"inactive GC may use host timers, but GC MUST re-check owner
+  sets and entry generation after wake\").
 
-  SKELETON: GC timer scheduling lands in the stale/GC slice; the handler
-  here performs the advisory re-check + removal of a still-inactive entry."
+  GC-eligibility re-check (against the LIVE durable facts):
+    - the entry is gone — no-op (`:no-entry`);
+    - the entry has an active owner — pinned alive, no GC (`:has-owner`);
+    - the entry has work in flight (`:current-work`) — no GC (`:in-flight`);
+    - otherwise the entry is owner-free + idle — REMOVE it (recompute the
+      reverse indexes) and cancel its advisory timers."
   [{rt :rf.db/runtime, frame-id :rf.frame/id}
    [_event-id {:keys [resource-key]}]]
   (let [runtime-db (or rt {})
@@ -640,7 +789,12 @@
                      (update state/resources-key state/recompute-indexes))]
         (trace/emit! :rf.event :rf.resource/gc-fired
                      {:rf.frame/id frame-id :resource-key resource-key})
-        {:rf.db/runtime rdb'})
+        {:rf.db/runtime rdb'
+         ;; the entry is gone — cancel its (now orphaned) stale / GC timer
+         ;; handles so they don't leak (the GC timer that fired is already
+         ;; one-shot, but the paired stale timer may still be armed).
+         :fx [[:rf.resource/cancel-timers
+               {:frame-id frame-id :resource-keys [resource-key]}]]})
       (do (trace/emit! :rf.event :rf.resource/gc-skipped
                        {:rf.frame/id frame-id :resource-key resource-key
                         :reason (cond (nil? entry) :no-entry

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -311,6 +311,22 @@
   [entry]
   (some? (:data entry)))
 
+(defn entry-stale?
+  "Derived freshness fact: true iff `entry` is stale against `clock-ms` —
+  it has been explicitly invalidated (`:invalidated-at` set) OR its
+  `:stale-after-ms` window has elapsed (`:stale-at` set and
+  `clock-ms >= :stale-at`). Freshness is computed from the DURABLE absolute
+  timestamps, NOT from trusting a timer fired on time, and is ORTHOGONAL to
+  load status (a `:loaded` entry may be stale). The SINGLE home for the
+  staleness derivation so the subs projection, the SSR projection, and the
+  stale-timer re-check never drift. Per Spec 016 §Status semantics / §Stale
+  and GC scheduling. A computed value, never a stored fact."
+  [entry clock-ms]
+  (boolean
+    (and entry
+         (or (some? (:invalidated-at entry))
+             (when-let [sa (:stale-at entry)] (>= clock-ms sa))))))
+
 ;; ---- entry transitions (Spec 016 §Status semantics / §Structural sharing) -
 ;;
 ;; Pure functions `(entry, …) -> entry`. They transition through

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -77,12 +77,11 @@
   (`:stale-at` set and `now >= :stale-at`). Freshness is ORTHOGONAL to load
   status — a `:loaded` entry may be stale; a `:fetching` entry may be
   refreshing stale data. Per Spec 016 §Status semantics. A computed value,
-  never a stored fact."
+  never a stored fact. Delegates to the single shared `state/entry-stale?`
+  derivation (the same one the SSR projection + the stale-timer re-check
+  use) so freshness never drifts between readers."
   [entry]
-  (boolean
-    (and entry
-         (or (some? (:invalidated-at entry))
-             (when-let [sa (:stale-at entry)] (>= (now-ms) sa))))))
+  (state/entry-stale? entry (now-ms)))
 
 ;; ---- the projections (public derived sub values) -------------------------
 

--- a/implementation/resources/src/re_frame/resources/test_support.cljc
+++ b/implementation/resources/src/re_frame/resources/test_support.cljc
@@ -30,6 +30,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.state :as state]
+            [re-frame.resources.timers :as timers]
             [re-frame.resources.work-ledger :as work-ledger]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -48,6 +49,10 @@
   ;; drop the host-side work-ledger handles too (rf2-afpdkn) — also
   ;; host-side transient state not cleared by the runtime / frames reset.
   (work-ledger/reset-cache!)
+  ;; and the host-side stale / GC timer handles (rf2-nbjewi) — likewise
+  ;; host-side transient state; cancels any armed timers so a leftover timer
+  ;; cannot fire into a later test's frame.
+  (timers/reset-cache!)
   nil)
 
 ;; Publish the reset hook from this test-support ns-load — the shared CLJS

--- a/implementation/resources/src/re_frame/resources/timers.cljc
+++ b/implementation/resources/src/re_frame/resources/timers.cljc
@@ -1,0 +1,296 @@
+(ns re-frame.resources.timers
+  "The resource STALE / GC timer side-table substrate (rf2-nbjewi, EP-0003
+  slice 6). Per Spec 016 §Stale and GC scheduling.
+
+  `:stale-after-ms` and `:gc-after-ms` are v1 features, so their scheduling
+  is v1. The scheduling discipline (Spec 016 §Stale and GC scheduling, MUST):
+
+  - **freshness is computed from DURABLE timestamps** (`:loaded-at` /
+    `:stale-at`), NOT from trusting a timer fired exactly on time — a timer
+    is only an advisory nudge; the freshness fact lives on the entry
+    (`re-frame.resources.subs/stale?` reads `:invalidated-at` / `:stale-at`
+    against the live clock);
+  - **a stale timer may enqueue a resource event, but the handler MUST
+    re-check the current entry before writing** — the timer thunk dispatches
+    a re-checking internal event (`:rf.resource.internal/stale-fired` /
+    `:rf.resource.internal/gc-fired`); the handler verifies the entry /
+    owners / generation against the LIVE durable facts and writes nothing
+    when they have moved on (a superseded reschedule, a re-load, an owner
+    re-attach);
+  - **inactive GC re-checks owner sets + entry generation after wake** — a
+    GC timer removes the entry ONLY if it is still owner-free and not in
+    flight (the `gc-fired-handler` re-check);
+  - **timers + host handles live in side tables, NOT in frame-state** — this
+    module-level `timer-table` mirrors the work-ledger `handle-table` and the
+    host-side generation allocator (`re-frame.resources.state/generation-cache`):
+    a transient host cache an epoch restore cannot rewind, never on the
+    SSR / hydration / epoch wire, cleared per-frame on frame destroy;
+  - **frame destroy cancels all resource timers for that frame** — wired
+    into the SINGLE `:resources/on-frame-destroyed!` teardown hook the façade
+    publishes (composed with the work-ledger + generation host-cache release;
+    one hook, no second teardown path — rf2-afpdkn established it);
+  - **a hidden tab can delay timers without corrupting correctness** — the
+    timer is advisory; the re-check against durable timestamps makes a late /
+    coalesced / never-fired timer harmless. The focus/reconnect active-stale
+    scan (rf2-vtblcq) is the public-beta belt-and-braces, not this slice.
+
+  ## Two halves (mirrors the work-ledger split)
+
+  - **Durable freshness facts** ride the entry (`:loaded-at` / `:stale-at` /
+    `:invalidated-at` / `:active-owners` / `:generation`) in runtime-db —
+    serializable, on the SSR / hydration / epoch wire.
+  - **Host timer handles** live HERE, keyed by `[frame-id resource-key kind]`
+    (`kind` ∈ `#{:stale :gc}`) → an opaque host handle from
+    `re-frame.interop/schedule-after!`. NOT runtime-db, NOT serialized.
+
+  ## Scheduling is host-side, so it rides an fx (mirrors commit-generation)
+
+  The runtime emits `:rf.resource/schedule-timers` from the success reply
+  handler once an entry settles `:loaded` with a `:loaded-at` (so the timers
+  arm against the durable load timestamp). It carries a `:server?` flag read
+  from the cascade frame's platform; on the SERVER the fx is a no-op (SSR
+  uses the blocking-drain wait point + lazy client-side revalidation, never
+  wall-clock background timers — mirrors the machine `:after`
+  `:skipped-on-server` posture). The skip is by the FRAME's platform, not a
+  `:platforms` registration gate, because the host-wide platform default is
+  `:server` and a JVM client-mode unit test must still arm timers. A re-load
+  reschedules (cancel-then-arm) so a single live timer per `[key kind]`
+  survives."
+  (:require [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.trace :as trace]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- timer kinds ----------------------------------------------------------
+
+(def stale-kind
+  "The `:stale` timer kind — arms `:stale-after-ms` after `:loaded-at`; on
+  fire it nudges a re-checking `:rf.resource.internal/stale-fired` event
+  whose handler re-derives staleness from durable timestamps (the timer is
+  advisory). Per Spec 016 §Stale and GC scheduling."
+  :stale)
+
+(def gc-kind
+  "The `:gc` timer kind — arms `:gc-after-ms` after `:loaded-at`; on fire it
+  nudges a re-checking `:rf.resource.internal/gc-fired` event whose handler
+  removes the entry ONLY if it is still owner-free + not in flight. Per Spec
+  016 §Stale and GC scheduling."
+  :gc)
+
+;; ---- reserved internal re-check event ids ---------------------------------
+
+(def stale-fired-event
+  "The internal re-check event a fired stale timer dispatches. The handler
+  re-checks the live durable entry before writing (the timer is advisory).
+  User code MUST NOT dispatch it. Per Spec 016 §Stale and GC scheduling."
+  :rf.resource.internal/stale-fired)
+
+(def gc-fired-event
+  "The internal re-check event a fired GC timer dispatches. The handler
+  re-checks owner sets + generation before removing. User code MUST NOT
+  dispatch it. Per Spec 016 §Stale and GC scheduling."
+  :rf.resource.internal/gc-fired)
+
+;; ---- host-side timer side table (Spec 016 §Stale and GC scheduling) -------
+;;
+;; Module-level transient host cache keyed by `[frame-id resource-key kind]`
+;; → an opaque host timer handle. NOT runtime-db, NOT serialized, off the
+;; epoch / SSR egress wire. Mirrors the work-ledger `handle-table` and the
+;; host-side generation allocator. Cleared per-frame on frame destroy.
+
+(defonce
+  ^{:doc "Host-side side table of NON-serializable stale / GC timer handles,
+   keyed by `[frame-id resource-key kind]` (`kind` ∈ `#{:stale :gc}`) → an
+   opaque host handle from `re-frame.interop/schedule-after!`. Transient host
+   state (NOT runtime-db), so an epoch restore cannot rewind / recycle it,
+   and it never rides the SSR / hydration / epoch wire — freshness is
+   re-derived from the durable entry timestamps, and a timer is only an
+   advisory nudge whose handler re-checks the live facts. Cleared per-frame
+   on frame destroy (`release-frame!`). Per Spec 016 §Stale and GC
+   scheduling / [Runtime-Subsystems] clause 5."}
+  timer-table
+  (atom {}))
+
+(defn- timer-key
+  "The side-table key for `[frame-id resource-key kind]`."
+  [frame-id resource-key kind]
+  [frame-id resource-key kind])
+
+(defn cancel!
+  "Cancel + drop the host timer for `[frame-id resource-key kind]` (a no-op
+  when none is armed). Idempotent. Returns nil. The durable freshness facts
+  are untouched (a cancelled timer never means an entry became fresh — only
+  that the advisory nudge will not fire). Per Spec 016 §Stale and GC
+  scheduling."
+  [frame-id resource-key kind]
+  (let [k (timer-key frame-id resource-key kind)]
+    (when-let [handle (get @timer-table k)]
+      (interop/cancel-scheduled! handle))
+    (swap! timer-table dissoc k))
+  nil)
+
+(defn cancel-for-key!
+  "Cancel BOTH the stale + GC timers for a resource `[frame-id resource-key]`
+  (used on entry removal — remove / clear-scope / GC). Idempotent. Returns
+  nil."
+  [frame-id resource-key]
+  (cancel! frame-id resource-key stale-kind)
+  (cancel! frame-id resource-key gc-kind)
+  nil)
+
+(defn- dispatch-recheck!
+  "Schedule the re-checking internal event for a fired timer of `kind`. The
+  thunk fires through the published `:router/dispatch!` late-bind hook (the
+  resources artefact never statically `:require`s the router) stamping
+  `:source :after-timer` so Xray's timeline + the Epoch panel label the
+  timer-fired cascade, and `:frame frame-id` so it lands in the right frame.
+  The event handler does the DURABLE re-check — the timer never writes
+  itself. No-op when no dispatcher is bound (a stripped runtime)."
+  [frame-id resource-key kind]
+  (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+    (let [event-id (if (= kind stale-kind) stale-fired-event gc-fired-event)]
+      (dispatch! [event-id {:resource-key resource-key}]
+                 {:frame frame-id :source :after-timer}))))
+
+(defn schedule!
+  "Arm a host timer of `kind` for `[frame-id resource-key]` to fire in
+  `delay-ms`. Cancel-then-arm: any prior timer for the same `[key kind]` is
+  cancelled first, so a re-load reschedules rather than accumulating zombie
+  timers (the machine `:after` cancel-and-reschedule discipline). On fire the
+  timer dispatches the re-checking internal event (`dispatch-recheck!`) — the
+  HANDLER re-checks the durable entry before writing (the timer is advisory).
+  No-op for a non-positive `delay-ms` (a resource declaring no policy never
+  arms that kind). Returns the host handle (or nil when not armed). Per Spec
+  016 §Stale and GC scheduling."
+  [frame-id resource-key kind delay-ms]
+  ;; cancel any prior timer for this [key kind] (reschedule, not accumulate)
+  (cancel! frame-id resource-key kind)
+  (when (and (number? delay-ms) (pos? delay-ms))
+    (let [handle (interop/schedule-after!
+                   (fn [] (dispatch-recheck! frame-id resource-key kind))
+                   delay-ms)]
+      (swap! timer-table assoc (timer-key frame-id resource-key kind) handle)
+      handle)))
+
+(defn release-frame!
+  "Cancel + drop EVERY stale / GC timer for a destroyed `frame-id` from the
+  side table. Invoked from the single `:resources/on-frame-destroyed!`
+  teardown hook (composed in the façade with the work-ledger host-handle +
+  generation host-cache release — one hook, no second teardown path). The
+  durable entries ride the frame value and are released atomically when the
+  frame is dropped; this touches ONLY the host timer side table. Idempotent.
+  Per Spec 016 §Stale and GC scheduling (frame destroy cancels all resource
+  timers) / [Runtime-Subsystems] clause 5. Returns nil."
+  [frame-id]
+  (doseq [[[fid rkey kind] handle] @timer-table]
+    (when (= fid frame-id)
+      (interop/cancel-scheduled! handle)
+      (swap! timer-table dissoc [fid rkey kind])))
+  nil)
+
+(defn reset-cache!
+  "Cancel + drop EVERY frame's stale / GC timers (test isolation). Published
+  via the resources test-support reset hook so the shared CLJS
+  `make-reset-runtime-fixture` clears it per test (host-side transient state,
+  NOT cleared by the runtime / frames reset). Returns nil."
+  []
+  (doseq [[_ handle] @timer-table]
+    (interop/cancel-scheduled! handle))
+  (reset! timer-table {})
+  nil)
+
+;; ---- the host-side scheduling fx (mirrors :rf.resource/commit-generation) -
+;;
+;; The timer side table is host-side transient state, so its WRITES ride an
+;; fx (not a runtime-db effect) — exactly as the host-side generation
+;; high-water bump rides `:rf.resource/commit-generation` and the work-handle
+;; side-table writes ride `:rf.resource/record-work-handle`. The success
+;; reply handler emits `:rf.resource/schedule-timers` once an entry settles
+;; `:loaded`, arming the stale + GC timers from the entry's DURABLE
+;; `:loaded-at` + the resource's `:stale-after-ms` / `:gc-after-ms` policy.
+
+(def schedule-timers-meta
+  "Metadata for the `:rf.resource/schedule-timers` fx registration. The
+  WRITE half of the host-side stale / GC timer side table — arms the
+  advisory timers for `[frame-id resource-key]` from the durable load
+  timestamp + policy. SKIPPED under SSR via the carried `:server?` flag
+  (mirrors the machine `:after` skip-on-server), so the timer table never
+  arms a wall-clock timer on a server render — NOT via a `:platforms` gate,
+  because a JVM CLIENT-mode runtime (the resources unit tests) must still arm
+  timers, and the host-wide platform default is `:server`. fx handlers are
+  binary `(fn [ctx args] …)` (Spec 002)."
+  {:doc "Arm the host-side stale / GC timers for a settled resource entry,
+keyed by `[frame-id resource-key kind]`. Args:
+`{:frame-id … :resource-key … :stale-delay-ms … :gc-delay-ms … :server? …}`.
+Emitted by the success reply handler once an entry settles `:loaded` (the
+delays are derived from the durable `:loaded-at` + the resource's
+`:stale-after-ms` / `:gc-after-ms`; `:server?` is read from the cascade
+frame's platform). Cancel-then-arm — a re-load reschedules. No-op under
+`:server? true` (SSR uses the blocking-drain wait point + lazy client
+revalidation, never wall-clock background timers). The fired timer dispatches
+a re-checking internal event; the handler re-checks the durable entry before
+writing (the timer is advisory). Per Spec 016 §Stale and GC scheduling."})
+
+(defn schedule-timers-handler
+  "`:rf.resource/schedule-timers` fx handler. Arms the host-side stale + GC
+  timers for `[frame-id resource-key]` from the supplied durable delays. A
+  non-positive / nil delay leaves that kind disarmed (a resource declaring no
+  `:stale-after-ms` / `:gc-after-ms` arms only the other / neither). No-op
+  under SSR (`:server? true`) — a server render never arms a wall-clock
+  background timer. Emits a `:rf.resource/gc-scheduled` / `:rf.resource/stale-
+  scheduled` trace (gc-class — the Xray lifecycle timeline pairs them with
+  `:rf.resource/gc-fired` / `gc-skipped` / `stale-fired`) when a timer arms.
+  Per Spec 016 §Stale and GC scheduling."
+  [_ctx {:keys [frame-id resource-key stale-delay-ms gc-delay-ms server?]}]
+  (when-not server?
+    (let [stale-h (schedule! frame-id resource-key stale-kind stale-delay-ms)
+          gc-h    (schedule! frame-id resource-key gc-kind gc-delay-ms)]
+      (when gc-h
+        (trace/emit! :rf.event :rf.resource/gc-scheduled
+                     {:rf.frame/id frame-id :resource-key resource-key
+                      :delay-ms gc-delay-ms}))
+      (when stale-h
+        (trace/emit! :rf.event :rf.resource/stale-scheduled
+                     {:rf.frame/id frame-id :resource-key resource-key
+                      :delay-ms stale-delay-ms}))))
+  nil)
+
+;; ---- the cancel fx (entry removed — remove / clear-scope / GC) ------------
+
+(def cancel-timers-meta
+  "Metadata for the `:rf.resource/cancel-timers` fx registration. Cancels
+  the host-side stale + GC timers for one or more removed resource entries
+  (their durable facts are gone, so an advisory nudge would no-op anyway —
+  but the host handles must be released so they don't leak)."
+  {:doc "Cancel the host-side stale / GC timers for removed resource entries,
+keyed by `[frame-id resource-key]`. Args:
+`{:frame-id … :resource-keys [<scoped-key> …]}`. Emitted when entries are
+removed (`:rf.resource/remove` / `:rf.resource/clear-scope` / a fired GC) so
+their advisory timer handles are released promptly rather than waiting for
+frame destroy. Runs on every platform (a server render with no armed timers
+no-ops harmlessly; cancellation must never be platform-gated). Per Spec 016
+§Stale and GC scheduling."})
+
+(defn cancel-timers-handler
+  "`:rf.resource/cancel-timers` fx handler. Cancels BOTH timers for every
+  supplied `[frame-id resource-key]`. Args: `{:frame-id … :resource-keys
+  […]}`."
+  [_ctx {:keys [frame-id resource-keys]}]
+  (doseq [rkey resource-keys]
+    (cancel-for-key! frame-id rkey))
+  nil)
+
+;; ---- frame teardown (Spec 016 [Runtime-Subsystems] clause 5) --------------
+
+(defn on-frame-destroyed!
+  "The stale / GC timer half of the `:resources/on-frame-destroyed!`
+  teardown body. `destroy-frame!` invokes the single composed hook by key
+  with the destroyed `frame-id`; the façade composes THIS with the
+  work-ledger host-handle release + the generation host-cache release (one
+  hook, no second teardown path). Cancels every stale / GC timer for the
+  frame (`release-frame!`). Per Spec 016 §Stale and GC scheduling / [Runtime-
+  Subsystems] clause 5. Returns nil."
+  [frame-id]
+  (release-frame! frame-id)
+  nil)

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -1,0 +1,426 @@
+(ns re-frame.resources-invalidation-gc-cljs-test
+  "Invalidation / owner-liveness / GC / stale-timer behaviour for the
+  Resources artefact (rf2-nbjewi, Spec 016 §EP-0003 slice 6).
+
+  These JVM+CLJS unit tests pin the slice-6 contract:
+
+    1. EXACT TAG INVALIDATION — scoped by DEFAULT (a match needs the entry's
+       scope to equal :scope); CROSS-SCOPE is opt-in (:cross-scope? true) and
+       Xray-visible; matched active-owner entries refetch, matched ownerless
+       entries are left stale / GC-eligible; on a successful (re)load the tag
+       index for the key is REPLACED (old tags removed); one decision summary
+       + per-entry detail; no-match distinction (match in another scope vs no
+       tag anywhere);
+    2. ACTIVE OWNERS (liveness leases) + owner-index + :rf.resource/release-
+       owner — release drops the owner from the entry + index + work record;
+       an in-flight attempt is aborted ONLY when NO owner remains (a shared
+       request is not cancelled because one lease went away); causes never
+       create liveness;
+    3. CLEAR-SCOPE — removes the scope's entries, recomputes indexes,
+       cancels their timers, and SUPPRESSES a late reply by the entry-vanish
+       + monotone-generation boundary (a recreated entry gets a higher
+       generation so the old reply's work-id can never re-match);
+    4. STALE / GC TIMERS — freshness is derived from DURABLE timestamps (not
+       \"the timer fired on time\"); the timer handler RE-CHECKS the live
+       entry / owners / generation before writing (never writes a stale
+       decision); timers live in a host SIDE TABLE (not frame-state); a fired
+       GC removes an entry ONLY if still owner-free + idle; frame destroy
+       cancels all the frame's timers (composed into the single
+       :resources/on-frame-destroyed! hook); inactive entries GC after
+       :gc-after-ms;
+    5. :rf.resource/remove cancels the removed instance's timers."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.frame :as frame]
+   ;; load-bearing side-effecting require: the façade registers the
+   ;; :rf.resource/* events + the timer / work-ledger side-table fx + the
+   ;; internal re-check events these tests dispatch through.
+   [re-frame.resources]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.timers :as timers]
+   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.test-support]
+   ;; production HTTP fx surface (so the transport feature probe resolves);
+   ;; the actual fetch + abort are overridden by capturing no-ops below.
+   [re-frame.http-managed]
+   [re-frame.schemas]
+   [re-frame.test-support :as core-test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+;; ---- capturing transport + abort + timer-schedule (deterministic) ---------
+
+(def ^:private aborts (atom []))
+(def ^:private scheduled-timers (atom []))
+
+(defn- capturing-fixture
+  "Override the real :rf.http/managed + :rf.http/managed-abort fxs with
+  capturing no-ops, and CAPTURE :rf.resource/schedule-timers so the
+  succeeded-handler's arming is asserted WITHOUT a real wall-clock timer
+  firing (the timer-table primitive is tested directly elsewhere). Composed
+  INSIDE the reset-runtime fixture (one `use-fixtures` call)."
+  [f]
+  (reset! aborts [])
+  (reset! scheduled-timers [])
+  (state/reset-cache!)
+  (work-ledger/reset-cache!)
+  (timers/reset-cache!)
+  (rf/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf/reg-fx :rf.http/managed-abort (fn [_ctx work-id] (swap! aborts conj work-id) nil))
+  ;; capture the schedule-timers arming (the real fx arms host timers; here we
+  ;; record the args so the test stays deterministic — no wall clock)
+  (rf/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
+  (f))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  capturing-fixture)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- runtime-db
+  ([] (runtime-db :rf/default))
+  ([frame-id] (rf/runtime-db-value frame-id)))
+
+(defn- entry
+  ([scoped-key] (entry :rf/default scoped-key))
+  ([frame-id scoped-key]
+   (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
+
+(defn- article-spec
+  ([] (article-spec {}))
+  ([overrides]
+   (merge {:scope         :rf.scope/from-caller
+           :params-schema [:map [:slug :string]]
+           :request       (fn [{:keys [slug]} _ctx]
+                            {:request {:method :get :url (str "/api/articles/" slug)}})
+           :tags          (fn [{:keys [slug]} _data] #{[:article slug]})}
+          overrides)))
+
+(defn- ensure! [resource scope slug owner]
+  (rf/dispatch-sync [:rf.resource/ensure
+                     {:resource resource :scope scope :params {:slug slug}
+                      :owner owner}]))
+
+(defn- succeed!
+  "Feed an internal success reply for a scoped key, reading the LIVE entry's
+  current work-id + generation (the per-frame generation allocator is
+  monotone, so a hardcoded generation would be stale-suppressed once more
+  than one resource has loaded in the frame)."
+  [scoped-key data]
+  (let [e (entry scoped-key)]
+    (rf/dispatch-sync [:rf.resource.internal/succeeded
+                       {:resource-key scoped-key :work-id (:current-work e)
+                        :generation (:generation e) :data data}])))
+
+;; ===========================================================================
+;; 1. Exact tag invalidation — scoped default + cross-scope opt-in
+;; ===========================================================================
+
+(deftest invalidate-tags-is-scoped-by-default
+  (rf/reg-resource :iv/article (article-spec))
+  (let [sa {:user "a"} sb {:user "b"}
+        ka (state/scoped-resource-key sa :iv/article {:slug "w"})
+        kb (state/scoped-resource-key sb :iv/article {:slug "w"})]
+    (ensure! :iv/article sa "w" [:lease :a 1])
+    (succeed! ka {:title "A"})
+    (ensure! :iv/article sb "w" [:lease :b 1])
+    (succeed! kb {:title "B"})
+    ;; release both owners so the invalidation marks stale WITHOUT refetching
+    ;; (a refetch would satisfy + clear the invalidation, masking the test)
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :a 1]}])
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :b 1]}])
+    (rf/dispatch-sync [:rf.resource/invalidate-tags
+                       {:scope sa :tags #{[:article "w"]}}])
+    (testing "Spec 016 §Invalidation — scoped by DEFAULT: only the in-scope
+              entry is marked stale; the other scope is untouched (no
+              cross-scope leak)"
+      (is (some? (:invalidated-at (entry ka))) "scope A entry marked stale")
+      (is (nil?  (:invalidated-at (entry kb))) "scope B entry NOT invalidated"))))
+
+(deftest invalidate-tags-cross-scope-opt-in
+  (rf/reg-resource :ivx/article (article-spec))
+  (let [sa {:user "a"} sb {:user "b"}
+        ka (state/scoped-resource-key sa :ivx/article {:slug "w"})
+        kb (state/scoped-resource-key sb :ivx/article {:slug "w"})]
+    (ensure! :ivx/article sa "w" [:lease :a 1])
+    (succeed! ka {:title "A"})
+    (ensure! :ivx/article sb "w" [:lease :b 1])
+    (succeed! kb {:title "B"})
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :a 1]}])
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :b 1]}])
+    (rf/dispatch-sync [:rf.resource/invalidate-tags
+                       {:scope sa :tags #{[:article "w"]} :cross-scope? true}])
+    (testing "Spec 016 §Invalidation — :cross-scope? true matches the tag in
+              EVERY scope (the explicit, Xray-visible opt-in)"
+      (is (some? (:invalidated-at (entry ka))) "scope A entry marked stale")
+      (is (some? (:invalidated-at (entry kb))) "scope B entry ALSO marked stale"))))
+
+(deftest invalidate-tags-refetches-active-leaves-inactive-stale
+  (rf/reg-resource :ivr/article (article-spec))
+  (let [scope {:user "u"}
+        kact  (state/scoped-resource-key scope :ivr/article {:slug "active"})
+        kin   (state/scoped-resource-key scope :ivr/article {:slug "inactive"})]
+    ;; active-owner entry
+    (ensure! :ivr/article scope "active" [:route :r 1])
+    (succeed! kact {:title "Active"})
+    ;; inactive entry (owner released)
+    (ensure! :ivr/article scope "inactive" [:lease :x 1])
+    (succeed! kin {:title "Inactive"})
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :x 1]}])
+    (rf/dispatch-sync [:rf.resource/invalidate-tags
+                       {:scope scope :tags #{[:article "active"] [:article "inactive"]}}])
+    (testing "Spec 016 §Invalidation 3-4 — the active-owner entry refetches
+              (→ :fetching, prior data kept); the inactive entry is left
+              stale / GC-eligible (NOT refetched)"
+      (is (= :fetching (:status (entry kact))) "active entry refetched")
+      (is (= {:title "Active"} (:data (entry kact))) "prior data kept on refetch")
+      (is (= :loaded (:status (entry kin))) "inactive entry NOT refetched")
+      (is (some? (:invalidated-at (entry kin))) "inactive entry left stale"))))
+
+(deftest successful-load-replaces-tag-index
+  (rf/reg-resource :tagrep/article
+                   (article-spec {:tags (fn [{:keys [slug]} data]
+                                          ;; tags depend on the DATA's version
+                                          #{[:article slug] [:rev (:rev data)]})}))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :tagrep/article {:slug "w"})]
+    (ensure! :tagrep/article scope "w" [:lease :t 1])
+    (succeed! k {:rev 1})
+    (testing "first load produces version-1 tags"
+      (is (= #{[:article "w"] [:rev 1]} (:tags (entry k))))
+      (is (= #{k} (get-in (runtime-db) (conj (state/tag-index-path) [:rev 1])))))
+    ;; refetch → data now rev 2 → tags REPLACED
+    (rf/dispatch-sync [:rf.resource/refetch {:resource :tagrep/article :scope scope
+                                             :params {:slug "w"}}])
+    (succeed! k {:rev 2})
+    (testing "Spec 016 §Invalidation — on a successful (re)load the tag index
+              for the key is REPLACED with the new data's tags; the OLD tag is
+              removed (stale list/detail relationships stop receiving
+              invalidations)"
+      (is (= #{[:article "w"] [:rev 2]} (:tags (entry k))) "entry tags replaced")
+      (is (= #{k} (get-in (runtime-db) (conj (state/tag-index-path) [:rev 2])))
+          "new tag indexed")
+      (is (nil? (get-in (runtime-db) (conj (state/tag-index-path) [:rev 1])))
+          "OLD tag removed from the index (not accumulated)"))))
+
+;; ===========================================================================
+;; 2. Active owners — release aborts ONLY orphaned in-flight work
+;; ===========================================================================
+
+(deftest release-owner-does-not-abort-shared-in-flight
+  (rf/reg-resource :sh/article (article-spec))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :sh/article {:slug "w"})]
+    ;; two owners ensure the SAME in-flight key (dedupe joins)
+    (ensure! :sh/article scope "w" [:route :r 1])
+    (ensure! :sh/article scope "w" [:lease :x 1])
+    (is (= #{[:route :r 1] [:lease :x 1]} (:active-owners (entry k))))
+    (let [wid (:current-work (entry k))]
+      (reset! aborts [])
+      (rf/dispatch-sync [:rf.resource/release-owner {:owner [:route :r 1]}])
+      (testing "Spec 016 §Race — releasing ONE owner of a shared in-flight
+                request does NOT abort it (a remaining owner still needs it)"
+        (is (= #{[:lease :x 1]} (:active-owners (entry k))) "one owner dropped")
+        (is (= [] @aborts) "no abort emitted (work still owned)")
+        (is (= #{[:lease :x 1]} (:owners (work-ledger/get-record (runtime-db) wid)))
+            "work record owners updated"))
+      (testing "releasing the LAST owner orphans the in-flight attempt →
+                opportunistic abort (best-effort; stale suppression is the
+                real boundary)"
+        (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :x 1]}])
+        (is (empty? (:active-owners (entry k))) "entry now owner-free")
+        (is (= [wid] @aborts) "orphaned in-flight attempt aborted")
+        (is (= :abort-requested
+               (:status (work-ledger/get-record (runtime-db) wid)))
+            "work row moved to :abort-requested")))))
+
+;; ===========================================================================
+;; 3. clear-scope — suppress late reply by entry-vanish + generation
+;; ===========================================================================
+
+(deftest clear-scope-suppresses-late-reply
+  (rf/reg-resource :clr/article (article-spec))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :clr/article {:slug "w"})]
+    (ensure! :clr/article scope "w" [:lease :c 1])
+    (let [stale-wid (:current-work (entry k))]
+      (rf/dispatch-sync [:rf.resource/clear-scope {:scope scope :cause :logout}])
+      (is (nil? (entry k)) "entry removed by clear-scope")
+      (testing "Spec 016 §clear-scope — a late reply for the cleared entry's
+                work-id is SUPPRESSED (the entry it would write into is gone;
+                the generation/work-id check finds no live entry)"
+        (rf/dispatch-sync [:rf.resource.internal/succeeded
+                           {:resource-key k :work-id stale-wid :generation 1
+                            :data {:title "Late"}}])
+        (is (nil? (entry k)) "late reply did NOT resurrect / write the entry"))
+      (testing "a recreated entry in the same scope gets a HIGHER generation
+                (monotone host-side allocator), so the old reply's work-id can
+                never re-match (anti-recycling)"
+        (ensure! :clr/article scope "w" [:lease :c 2])
+        (is (= 2 (:generation (entry k))) "recreated entry on a fresh generation")
+        (rf/dispatch-sync [:rf.resource.internal/succeeded
+                           {:resource-key k :work-id stale-wid :generation 1
+                            :data {:title "ZombieLate"}}])
+        (is (not= {:title "ZombieLate"} (:data (entry k)))
+            "the pre-clear reply never writes the recreated entry")))))
+
+;; ===========================================================================
+;; 4. Stale / GC timers — side table + re-check before write + frame destroy
+;; ===========================================================================
+
+(deftest succeeded-arms-stale-and-gc-timers
+  (rf/reg-resource :tm/article (article-spec {:stale-after-ms 60000 :gc-after-ms 300000}))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :tm/article {:slug "w"})]
+    (reset! scheduled-timers [])
+    (ensure! :tm/article scope "w" [:lease :tm 1])
+    (succeed! k {:title "W"})
+    (testing "Spec 016 §Stale and GC scheduling — a successful load emits one
+              :rf.resource/schedule-timers fx carrying the durable delays
+              derived from the resource policy"
+      (is (= 1 (count @scheduled-timers)))
+      (let [args (first @scheduled-timers)]
+        (is (= k (:resource-key args)))
+        (is (= 60000 (:stale-delay-ms args)))
+        (is (= 300000 (:gc-delay-ms args)))))))
+
+(deftest no-policy-arms-no-timers
+  (rf/reg-resource :np/article (article-spec)) ;; no :stale-after-ms / :gc-after-ms
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :np/article {:slug "w"})]
+    (reset! scheduled-timers [])
+    (ensure! :np/article scope "w" [:lease :np 1])
+    (succeed! k {:title "W"})
+    (testing "a resource declaring no stale / GC policy arms NO timers (no
+              schedule-timers fx)"
+      (is (= [] @scheduled-timers)))))
+
+(deftest timer-side-table-is-host-side-not-frame-state
+  (testing "Spec 016 §Stale and GC scheduling — timers live in a host SIDE
+            TABLE keyed by [frame-id resource-key kind], NOT in frame-state"
+    (timers/reset-cache!)
+    (let [k [:rf.scope/global :t/x {:id 1}]]
+      ;; arm a real (long) timer so it does not fire during the test
+      (timers/schedule! :rf/default k timers/gc-kind 1000000)
+      (is (contains? @timers/timer-table [:rf/default k timers/gc-kind])
+          "the timer handle lives in the module-level side table")
+      ;; the durable runtime-db carries NO timer handle
+      (is (not (contains? (runtime-db) :rf.runtime/resources-timers))
+          "no timer state leaked into runtime-db")
+      (timers/cancel! :rf/default k timers/gc-kind)
+      (is (not (contains? @timers/timer-table [:rf/default k timers/gc-kind]))
+          "cancel! drops the handle"))))
+
+(deftest timer-reschedule-cancels-prior
+  (testing "Spec 016 — a re-load reschedules (cancel-then-arm), not accumulate"
+    (timers/reset-cache!)
+    (let [k [:rf.scope/global :t/y {:id 1}]]
+      (timers/schedule! :rf/default k timers/stale-kind 1000000)
+      (let [h1 (get @timers/timer-table [:rf/default k timers/stale-kind])]
+        (timers/schedule! :rf/default k timers/stale-kind 1000000)
+        (let [h2 (get @timers/timer-table [:rf/default k timers/stale-kind])]
+          (is (not= h1 h2) "a fresh handle replaced the prior one")
+          (is (= 1 (count (filter (fn [[[_ rk kind] _]]
+                                    (and (= rk k) (= kind timers/stale-kind)))
+                                  @timers/timer-table)))
+              "exactly one live stale timer per [key kind]")))
+      (timers/cancel-for-key! :rf/default k))))
+
+(deftest gc-fired-rechecks-before-removing
+  (rf/reg-resource :gc/article (article-spec {:gc-after-ms 1000}))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :gc/article {:slug "w"})]
+    ;; load + release owner → owner-free + idle → GC-eligible
+    (ensure! :gc/article scope "w" [:lease :gc 1])
+    (succeed! k {:title "W"})
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :gc 1]}])
+    (testing "Spec 016 §Stale and GC scheduling — a fired GC timer RE-CHECKS:
+              an owner-free + idle entry is removed"
+      (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource-key k}])
+      (is (nil? (entry k)) "GC removed the inactive entry"))))
+
+(deftest gc-fired-skips-when-owner-reattached
+  (rf/reg-resource :gck/article (article-spec {:gc-after-ms 1000}))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :gck/article {:slug "w"})]
+    (ensure! :gck/article scope "w" [:lease :gck 1])
+    (succeed! k {:title "W"})
+    (testing "Spec 016 §Stale and GC scheduling — a fired GC timer RE-CHECKS
+              owner sets after wake; an entry with a live owner is NOT removed
+              (the timer is advisory — it never writes a stale decision)"
+      (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource-key k}])
+      (is (some? (entry k)) "owned entry kept (GC skipped)")
+      (is (= :loaded (:status (entry k)))))))
+
+(deftest gc-fired-skips-when-in-flight
+  (rf/reg-resource :gcf/article (article-spec {:gc-after-ms 1000}))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :gcf/article {:slug "w"})]
+    ;; ensure without ever succeeding → in flight (owner released, still
+    ;; :current-work)
+    (ensure! :gcf/article scope "w" [:lease :gcf 1])
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :gcf 1]}])
+    (is (some? (:current-work (entry k))) "still in flight")
+    (testing "Spec 016 §Stale and GC scheduling — a fired GC timer RE-CHECKS
+              the generation / in-flight pointer; an in-flight entry is NOT
+              removed even when owner-free"
+      (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource-key k}])
+      (is (some? (entry k)) "in-flight entry kept (GC skipped)"))))
+
+(deftest stale-fired-rechecks-durable-fact-no-write
+  (rf/reg-resource :sf/article (article-spec {:stale-after-ms 60000}))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :sf/article {:slug "w"})]
+    (ensure! :sf/article scope "w" [:lease :sf 1])
+    (succeed! k {:title "W"})
+    (let [before (entry k)]
+      (testing "Spec 016 §Stale and GC scheduling — the stale-timer re-check
+                derives freshness from the DURABLE :stale-at; it writes NO
+                durable change (the :stale? sub derives staleness; the timer
+                is advisory)"
+        (rf/dispatch-sync [:rf.resource.internal/stale-fired {:resource-key k}])
+        (is (= before (entry k)) "stale-fired made no durable entry change")))))
+
+(deftest frame-destroy-cancels-resource-timers
+  (rf/reg-resource :fd/article (article-spec {:stale-after-ms 60000 :gc-after-ms 300000}))
+  (let [fa :fd/frame-a
+        k  (state/scoped-resource-key {:user "u"} :fd/article {:slug "w"})]
+    (rf/reg-frame fa {:doc "frame-destroy timer frame"})
+    ;; arm two long timers in frame A directly via the side-table primitive
+    (timers/schedule! fa k timers/stale-kind 1000000)
+    (timers/schedule! fa k timers/gc-kind 1000000)
+    (is (= 2 (count (filter (fn [[[fid _ _] _]] (= fid fa)) @timers/timer-table)))
+        "two timers armed for frame A")
+    (testing "Spec 016 §Stale and GC scheduling — frame destroy cancels ALL
+              of the frame's resource timers (composed into the single
+              :resources/on-frame-destroyed! teardown hook, not a second
+              teardown path)"
+      (frame/destroy-frame! fa)
+      (is (= 0 (count (filter (fn [[[fid _ _] _]] (= fid fa)) @timers/timer-table)))
+          "frame A's timers cancelled + dropped on destroy"))))
+
+;; ===========================================================================
+;; 5. remove cancels the instance's timers
+;; ===========================================================================
+
+(deftest remove-cancels-instance-timers
+  (rf/reg-resource :rmt/article (article-spec {:gc-after-ms 1000}))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :rmt/article {:slug "w"})]
+    (ensure! :rmt/article scope "w" [:lease :rmt 1])
+    (succeed! k {:title "W"})
+    ;; arm a real long timer so remove has something to cancel
+    (timers/schedule! :rf/default k timers/gc-kind 1000000)
+    (is (contains? @timers/timer-table [:rf/default k timers/gc-kind]))
+    (testing "Spec 016 §Events / §Stale and GC scheduling — :rf.resource/remove
+              evicts the instance AND cancels its advisory timers"
+      (rf/dispatch-sync [:rf.resource/remove {:resource :rmt/article :scope scope
+                                              :params {:slug "w"}}])
+      (is (nil? (entry k)) "instance removed")
+      (is (not (contains? @timers/timer-table [:rf/default k timers/gc-kind]))
+          "its GC timer cancelled"))))

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -176,6 +176,7 @@ The operation set + semantic class:
 | `:rf.resource/work-completed` | success | `:rf.resource/gc-skipped` | gc |
 | `:rf.resource/work-suppressed` | suppression | `:rf.resource/removed` | lifecycle |
 | `:rf.resource/stale-suppressed` | suppression | `:rf.resource/hydrated` | hydration |
+| `:rf.resource/stale-scheduled` | gc | `:rf.resource/stale-fired` | gc |
 | `:rf.resource/hydrate-refetch` | hydration | | |
 
 Each row carries, where applicable: frame, work id, scope, resource

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -131,6 +131,8 @@
    :rf.resource/invalidated          {:class :invalidation :label "invalidated"}
    :rf.resource/refetch-decision     {:class :lifecycle    :label "refetch decision"}
    :rf.resource/owner-released       {:class :lifecycle    :label "owner released"}
+   :rf.resource/stale-scheduled      {:class :gc           :label "stale scheduled"}
+   :rf.resource/stale-fired          {:class :gc           :label "stale fired"}
    :rf.resource/gc-scheduled         {:class :gc           :label "gc scheduled"}
    :rf.resource/gc-fired             {:class :gc           :label "gc fired"}
    :rf.resource/gc-skipped           {:class :gc           :label "gc skipped"}


### PR DESCRIPTION
EP-0003 slice 6 (rf2-nbjewi) — invalidation / GC / owners / stale-GC timers. Builds on the landed runtime (entries + tag/owner indexes + work-ledger + generation allocator); composes, does not duplicate.

## Invalidation
- :rf.resource/invalidate-tags is scoped by DEFAULT (a match needs entry-scope == :scope); :cross-scope? true is the explicit, Xray-visible opt-in (matches the tags in every scope).
- Matched active-owner entries refetch; matched ownerless entries are left stale / GC-eligible.
- One decision summary + per-entry detail trace (:rf.resource/refetch-decision); no-match distinction via :any-tag-match-other-scope?.
- On a successful (re)load the tag index for the key is REPLACED — old tags removed (already via recompute over the new entry tags; covered by a test that mutates data-derived tags across a refetch).

## Active owners
- :rf.resource/release-owner drops the owner from entry + owner-index + work record; the in-flight attempt is aborted ONLY when no owner remains (a shared request is not cancelled because one lease went away). Causes never create liveness.

## clear-scope
- Removes scoped entries, recomputes indexes, cancels their timers, aborts orphan in-flight (opportunistic). Late replies are suppressed by the entry-vanish + monotone-generation boundary (a recreated entry gets a higher generation, so the pre-clear reply's work-id can never re-match) — the structural correctness boundary, tested directly.

## Stale / GC timers (the main new surface)
- New host side-table namespace re-frame.resources.timers (mirrors the work-ledger handle-table + the host-side generation allocator): timers live OUTSIDE frame-state, keyed by [frame-id resource-key kind].
- Freshness is derived from DURABLE timestamps (shared state/entry-stale?), never from "the timer fired on time". The fired timer dispatches a re-checking internal event; the handler RE-CHECKS the live entry / owners / generation before writing and never writes a stale decision (gc-fired removes only an owner-free + idle entry; stale-fired writes nothing — the durable :stale-at is the fact).
- Armed via :rf.resource/schedule-timers from the success reply (skipped under SSR via the frame's :server? flag — by frame platform, NOT a :platforms gate, because the host-wide default is :server and JVM client-mode unit tests must still arm). Cancelled on remove / clear-scope / fired-GC via :rf.resource/cancel-timers.
- Frame destroy cancels all the frame's timers through the SINGLE composed :resources/on-frame-destroyed! hook (work-ledger + timers + generation cache — one teardown path; no second teardown).
- Inactive entries GC after :gc-after-ms.

## remove
- :rf.resource/remove evicts the instance, aborts its in-flight attempt (opportunistic), and cancels its advisory timers.

## Specs / errors
- No new :rf.error rows; durable entry shape unchanged (no Spec-Schemas change).
- Added :rf.resource/stale-scheduled + :rf.resource/stale-fired trace ops to the Xray panel spec (024-Resources-Panel.md) and the panel helper enum (gc-class), aligned with the 0xljxy :rf.resource/* trace family.

## Gates (all green)
- npm run test:cljs — 6247 tests, 0 failures / 0 errors
- npm run test:bundle-isolation — PASS (counter / uix / helix; sentinels absent)
- clojure -M:test (resources JVM suite) — 88 tests, 305 assertions, 0 failures / 0 errors (incl. the new 14-test slice-6 suite)
- clj-kondo — 0 errors over implementation/resources (2 pre-existing warnings in an untouched skeleton test file)

Closes rf2-nbjewi.
