### PR TITLE
docs(skills): formalize per-EP slice-gate as implementor-scoped by design (rf2-jgylrh)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -179,6 +179,29 @@ distinction in the **title + body**:
 
 **Labels are optional taxonomy, not a filing precondition.** A `--label` (e.g. `pair-mcp`) is added only after confirming the target repo defines it (detect with `gh label list`); on a repo/fork without that label, `gh issue create --label` fails the whole command, so filing falls back to a no-label `gh issue create` and lands regardless. The operational label/filing rules live in [`re-frame2-pair-retro/SKILL.md` §Filing improvements](./re-frame2-pair-retro/SKILL.md#filing-improvements) — this index points there rather than restating them.
 
+## Verification posture — follows role, by design
+
+Each skill's verification posture (what the agent runs, what gates "done")
+follows from the **role cell** the skill occupies, not from a uniform
+family rule. The postures differ deliberately; uniform wording would buy
+incoherence of principle. The single source for the spread:
+
+| Skill | Role | Who executes | What gates "done" | Why |
+|---|---|---|---|---|
+| `re-frame2-pair` | drive a live runtime | the agent, against the live app | a grounding live read after every change (Pillar 4) | the role *is* driving a runtime — executing against it is the point |
+| `re-frame2-implementor` | implementation driver (build the runtime) | the agent, narrowly | a per-EP slice gate from the **port's own** scripts, before calling an EP landed | acceptance criterion *is* spec-conformance; the slice gate operationalises it |
+| `re-frame-migration` | migrate v1 code on an existing reference | the **author** in their own env | the author's own build / test / smoke | hard trust boundary — the skill bars the agent from running build/test/smoke in the author's app env |
+| `re-frame2` (authoring) | emit authoring recipes | the **human** who pastes the recipe | the human's project gates | Pillar-4 / Q14 lock: no runtime the agent drives, no conformance corpus |
+| `re-frame2-setup` | scaffold greenfield | the **author**, following steps | the counter mounts under `shadow-cljs watch` | greenfield bootstrap; no agent-driven runtime |
+| `re-frame2-improver` | critique existing code | nobody runs; static critique | findings cross-linked to canonical idioms | review-only; proposes `Edit`s, runs no suite |
+| `re-frame2-xray` | read-only tour of the devtools panel | nobody runs; read-only | n/a (read-only tour) | owns the *seeing*, not the *driving* |
+| `re-frame2-pair-retro` | retro on a pair session | nobody runs the app; files issues | a filed GitHub issue (tool- vs framework-shaped) | meta-skill over `re-frame2-pair`; no runtime of its own |
+
+The takeaway: **only `re-frame2-implementor` carries a per-EP slice gate**,
+and that scoping is by design — it is the only implementation driver whose
+acceptance is spec-conformance. The other skills' postures are correct
+under "posture follows role", not inconsistent.
+
 ## Layout convention
 
 Each skill subdir contains, at minimum:

--- a/skills/re-frame2-implementor/spec/design.md
+++ b/skills/re-frame2-implementor/spec/design.md
@@ -48,7 +48,13 @@ This is the distinction between **generic build mechanics** (not taught — Pill
 
 **Why**: a code-writing skill that walks multi-day runtime changes and leaves the first real feedback to the human or a later full-suite gate is weaker workflow than the rest of the repo's worker discipline. The elegant path for a pre-alpha implementation guide is to teach the intended slice gate without becoming a generic testing tutorial.
 
-**Family-consistency note**: the original L3 cited cross-family consistency with the `re-frame2` and `re-frame-migration` skills (which also lock NO verification module). Those siblings are *not* implementation drivers in the same sense — they author apps / migrate code on an existing reference rather than building the runtime itself, so the per-EP slice gate is specific to this skill's implementation-driver role. Whether the same narrowing should propagate to the siblings is a separate cross-skill decision (filed as a follow-up); this lock revision is scoped to `re-frame2-implementor`.
+**Family-consistency note (resolved: posture follows role; the divergence is by design)**: the original L3 cited cross-family consistency with the `re-frame2` and `re-frame-migration` skills (which also lock NO verification module). Those siblings are *not* implementation drivers in the same sense — they author apps / migrate code on an existing reference rather than building the runtime itself, so the per-EP slice gate is specific to this skill's implementation-driver role. The cross-skill question — whether the slice gate should propagate to the siblings — has been **resolved: it stays strictly scoped to `re-frame2-implementor`, and the divergence is by design, not drift.** Each skill occupies a different role cell, and verification posture follows role:
+
+- **`re-frame-migration`** carries a hard trust boundary (its cardinal rule bars the agent from running build / test / smoke in the author's app environment). Propagating the slice gate would *violate* that boundary.
+- **`re-frame2` authoring** is locked at Pillar 4 / Q14 to emit recipes a human pastes — there is no runtime the agent drives and no EP conformance corpus, so a slice gate is vacuous there (or manufactures the very violation Q14 prevents).
+- **`re-frame2-implementor`** is the only implementation driver whose acceptance criterion *is* spec-conformance, which the per-EP slice gate operationalises.
+
+Uniform wording across the family would buy incoherence of principle: the right invariant is "verification posture follows the skill's role", and under that invariant these postures are correct, not inconsistent.
 
 ### L4 — Substrate-agnostic phrasing throughout
 

--- a/skills/re-frame2-pair/spec/design.md
+++ b/skills/re-frame2-pair/spec/design.md
@@ -10,6 +10,8 @@ Help an AI **pair-program with a live, running re-frame2 application**. The app 
 
 Crucially, the skill consumes **re-frame2's own Tool-Pair contract** (per `spec/Tool-Pair.md` and `spec/009-Instrumentation.md`). There is **no re-frame-10x dependency** — time-travel, trace streams, and epoch records are first-class re-frame2 surfaces. The skill is one of the principal downstream consumers of those surfaces.
 
+**Verification posture — agent-executes-against-live-runtime (by design).** Among the skill family, `re-frame2-pair` is the one skill whose posture is *the agent itself executes operations against a live runtime* — it dispatches events, mutates `app-db`, hot-swaps handlers, and reads back the resulting epoch / trace state, all through the Tool-Pair contract. Feedback is immediate and first-class: the agent grounds every claim in a live read (Pillar 4). This is the deliberate counterpart to the per-skill posture spread across the family — `re-frame-migration` runs nothing in the author's env (trust boundary), `re-frame2` authoring emits recipes a human pastes (no runtime the agent drives), and `re-frame2-implementor` runs only a narrow per-EP slice gate against the port's own scripts. Posture follows role; `re-frame2-pair`'s role *is* driving a live runtime, so executing against it is the whole point, not an exception.
+
 ## 2. Pillars (locked)
 
 1. **Correctness — structured ops over `repl/eval`.** Every operation is a named structured call that returns edn (`{:ok? true ...}` / `{:ok? false :reason ...}`). The skill teaches the AI to compose forms and read structured results; the raw `repl/eval` escape hatch exists for probes that don't fit the catalogue.


### PR DESCRIPTION
Resolves rf2-jgylrh (RULING = (a): keep the per-EP slice-gate strictly scoped to `re-frame2-implementor`; formalize the divergence as BY DESIGN, not drift).

Doc-only, 3 files, no hot-zone:

1. **`skills/re-frame2-implementor/spec/design.md`** (L3 footnote) — replaced the dangling family-consistency follow-up note with the ruling: the slice gate stays implementor-scoped; verification posture follows role (migration trust boundary; authoring Pillar-4/Q14 lock; implementor is the only spec-conformance-accepted implementation driver). Expressed conceptually — no bead id in skill prose.
2. **`skills/re-frame2-pair/spec/design.md`** — added one posture line naming pair's previously-undeclared posture: agent-executes-against-live-runtime, by design.
3. **`skills/README.md`** — added a compact family posture table (skill | role | who executes | what gates done | why) as the single source for the spread.

**Acceptance:** implementor footnote no longer dangles; pair posture named; no sibling gained a slice-gate; no `rf2-` ids in skill prose (the only `rf2-XXXX` tokens in the edited design.md files are the pre-existing L7 lock text describing the no-bead-id rule).

**Gates:** no skill drift-check is scoped to the edited files (`re-frame2-setup` drift-check + `shared/` tests are unaffected); mkdocs builds from `docs/` only and these meta-docs are not in nav.