### PR TITLE
refactor(http,machines): invert spawned-actor ownership to a machines-owned late-bind hook (rf2-ma0wvq)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -387,6 +387,10 @@
     :producer-ns 're-frame.machines
     :design-bead "rf2-jbbp7"
     :description "Post-commit walker for the `:where :machine-data` boundary (Spec 005 §Schema validation, Spec 010 §Per-step recovery row 7). Iterates `[:rf.runtime/machines :snapshots]` in the runtime-db partition, validates each snapshot's `:data` against the registered machine's `:data-schema`. Router AND-conjoins with `:schemas/validate-app-schema!` to gate the `:rf.db/runtime` commit; a failure rolls the cascade back exactly like a `:where :app-db` violation."}
+   {:key         :machines/owning-actor-id
+    :producer-ns 're-frame.machines
+    :design-bead "rf2-ma0wvq"
+    :description "Spawned-actor ownership resolver `(fn [frame-id event-id]) -> actor-id|nil` (Spec 014 §Abort on actor destroy). Returns the spawned actor's address that owns `event-id` — i.e. `event-id` itself when it is registered in the frame's runtime-db spawn registry (`re-frame.machines.paths/spawned-path`) — else nil. The INVERSION of the old http→machines coupling (rf2-ma0wvq): the machines artefact OWNS the `:spawned` registry shape, so the structural membership walk lives next to it; re-frame.http-registry consults this hook (instead of re-stating the path + walking it itself) to decide whether a managed request belongs to a spawned actor, and falls back to nil when the machines artefact is absent. Step-1 set semantics = registry membership (declarative `:spawn` / `:spawn-all` only), set-identical to the pre-inversion walk; a separate step-2 bead widens it to imperative spawns under its own destroy-cancellation test."}
 
    ;; ---- re-frame.routing (rf2-k682) -----------------------------------------
    {:key         :routing/reg-route

--- a/implementation/http/src/re_frame/http_handlers.cljc
+++ b/implementation/http/src/re_frame/http_handlers.cljc
@@ -218,10 +218,13 @@
         ;; rf2-wvkn — when the originating event-id is a spawned actor's
         ;; address, capture it so the in-flight registry can index by
         ;; actor-id alongside :request-id. The destroy cascade then has
-        ;; a key to walk on actor-destroy. Detection is structural —
-        ;; we look up the id in the frame's [:rf.runtime/machines :spawned ...] runtime
-        ;; registry (per Spec 005 §Declarative :spawn); ordinary event
-        ;; handlers' dispatches yield nil and are not tracked.
+        ;; a key to walk on actor-destroy. Ownership is MACHINES-OWNED
+        ;; (rf2-ma0wvq): `compute-actor-id` asks the machines artefact via
+        ;; the `:machines/owning-actor-id` late-bind hook (per Spec 005
+        ;; §Declarative :spawn) rather than reading the spawn registry
+        ;; itself; ordinary event handlers' dispatches — and every request
+        ;; when the machines artefact is absent — yield nil and are not
+        ;; tracked.
         actor-id     (registry/compute-actor-id frame origin-event)
         ;; rf2-bma05 — compute the effective :sensitive? flag once and
         ;; thread it through the attempt-and-retry loop. Two sources

--- a/implementation/http/src/re_frame/http_registry.cljc
+++ b/implementation/http/src/re_frame/http_registry.cljc
@@ -26,9 +26,9 @@
   shape wrapper) because the operation is atomic state — it walks
   both atoms and mutates them under one `swap!` per slot. Keeping it
   next to the atoms makes the invariant local."
-  (:require [re-frame.frame        :as frame]
-            [re-frame.http-privacy :as privacy]
+  (:require [re-frame.http-privacy :as privacy]
             [re-frame.interop      :as interop]
+            [re-frame.late-bind    :as late-bind]
             [re-frame.trace        :as trace]))
 
 ;; ---- in-flight request registry -------------------------------------------
@@ -279,102 +279,45 @@
           (catch #?(:clj Throwable :cljs :default) _ nil)))))
   nil)
 
-;; ---- spawned-actor detection ----------------------------------------------
+;; ---- spawned-actor detection (rf2-ma0wvq inversion) -----------------------
 ;;
 ;; Per Spec 014 §Abort on actor destroy: a managed request "belongs to"
 ;; spawned actor `<spawned-id>` iff its originating event vector's first
-;; element is `<spawned-id>` AND that id appears as a value somewhere
-;; under [:rf.runtime/machines :spawned ...] in the frame's app-db (the runtime-owned
-;; spawn registry per Spec 005 §Declarative :spawn (sugar over spawn)).
-;; Detection is structural: walk the registry, look for the originating
-;; id as either a leaf value (declarative :spawn) or as a value under
-;; :children (declarative :spawn-all).
-
-(def ^:private spawned-registry-path
-  "The runtime-owned spawn-registry slot in a frame's **runtime-db** partition,
-  per Spec 005 §Declarative :spawn (mirrors `re-frame.machines.paths/spawned-path`
-  — the authoritative owner). Pinned here as a single named constant so the
-  structural coupling to the machines runtime's runtime-db layout has ONE site
-  rather than being inlined at each reader (rf2-b7h0q).
-
-  EP-0001 (rf2-vzld77): machine spawn-registry state is durable runtime-db
-  state, so the slot is `[:rf.runtime/machines :spawned]` in the runtime-db
-  partition (was the app-db `:rf/runtime` root).
-
-  NOTE on the late-bind boundary: the http artefact does not (and must not)
-  statically `:require` `re-frame.machines`, so it cannot reference
-  `machines.paths/spawned-path` directly — it re-states the path here. The
-  cleaner long-term shape is to invert the existing
-  `:http/abort-on-actor-destroy` hook direction and have machines PUBLISH a
-  `:machines/spawned-actor-id?` membership test (so the structural walk
-  lives next to the registry shape it depends on); that inversion is a
-  cross-artefact change tracked separately and out of scope for this
-  http-only fix."
-  [:rf.runtime/machines :spawned])
-
-(defn- read-spawned-registry
-  "Read ONLY the runtime-owned spawn-registry slot from `frame-id`'s
-  **runtime-db** — `(get-in runtime-db spawned-registry-path)` — without
-  retaining the whole map.
-
-  PERF (rf2-b7h0q): `frame/frame-runtime-db-value` is a substrate `deref` that
-  returns the persistent runtime-db map BY REFERENCE (no structural copy, no
-  scan), so the read is genuinely O(1) regardless of size; the `get-in` that
-  follows is a fixed two-key descent. This is the load-bearing assumption that
-  makes calling this once per managed request (`compute-actor-id`) cheap. Apps
-  with no state machines carry no `:rf.runtime/machines` slot, so this returns
-  nil and the caller's `(seq …)` test short-circuits before any structural walk.
-
-  EP-0001 (rf2-vzld77): machine snapshots / spawn-registry moved to the
-  runtime-db partition, so this reads the runtime-db value.
-
-  Returns the spawned registry map, or nil when the frame is unregistered /
-  carries no machines runtime."
-  [frame-id]
-  (let [rt (frame/frame-runtime-db-value frame-id)]
-    (when (map? rt)
-      (get-in rt spawned-registry-path))))
-
-(defn- spawned-actor-id?
-  "Return true if `event-id` is currently bound somewhere under
-  `[:rf.runtime/machines :spawned <parent> <invoke-id>]` in `spawned`
-  — either as the leaf value (declarative `:spawn`) or as a value in
-  the `:children` map of the join-state record (declarative
-  `:spawn-all`)."
-  [spawned event-id]
-  (some (fn [[_parent inner]]
-          (some (fn [[_invoke-id v]]
-                  (or (= v event-id)                      ;; :spawn leaf
-                      (and (map? v)                       ;; :spawn-all join state
-                           (some (fn [[_cid cid-val]]
-                                   (= cid-val event-id))
-                                 (:children v)))))
-                inner))
-        spawned))
+;; element is `<spawned-id>` AND that id is registered as a spawned actor
+;; in the frame's runtime-db spawn registry (per Spec 005 §Declarative
+;; :spawn). That ownership decision is MACHINES-OWNED: machines knows the
+;; registry shape, so it publishes the `:machines/owning-actor-id` late-
+;; bind hook `(fn [frame-id event-id]) -> actor-id|nil`. http no longer
+;; re-states the registry path or walks the registry itself — it asks
+;; machines through the hook and treats a nil/absent hook (no machines
+;; artefact on the classpath) as "not owned by any actor". This keeps the
+;; structural dependency on the `:spawned` runtime-db layout entirely
+;; inside the machines artefact that owns it (rf2-ma0wvq inverts the old
+;; coupling, where http peeked inside machines state to classify ownership
+;; while machines already called http through `:http/abort-on-actor-destroy`
+;; for the destroy side).
 
 (defn compute-actor-id
   "Resolve the spawned-actor-id for the request at hand, given the frame
   id and the originating event vector. Returns the actor-id (a keyword,
   the spawned actor's machine address) when the originating event-id is
-  currently registered in the frame's `[:rf.runtime/machines :spawned ...]` slot, otherwise
-  nil — meaning the request is NOT subject to actor-destroy cancellation
-  (it was dispatched from an ordinary event handler, not from inside a
-  spawned actor).
+  owned by a spawned actor, otherwise nil — meaning the request is NOT
+  subject to actor-destroy cancellation (it was dispatched from an
+  ordinary event handler, not from inside a spawned actor).
 
-  Per rf2-hzn1a — fast path for the common case (no spawned actors).
-  Apps that don't use state machines never carry a populated `:spawned`
-  registry; we read only that slot via `read-spawned-registry` (an O(1)
-  by-reference db deref + a fixed three-key descent — see that fn's PERF
-  note, rf2-b7h0q) and the `(seq …)` test short-circuits before the
-  O(parents × invokes) structural walk. This keeps the cost on the
-  no-machines hot path at one by-reference deref + one path lookup + one
-  seq-check, rather than a full structural walk against the (always
-  empty) registry."
+  Ownership is decided by the machines artefact via the
+  `:machines/owning-actor-id` late-bind hook (rf2-ma0wvq): http asks
+  machines whether the originating event-id belongs to a spawned actor
+  rather than re-stating the registry path and walking it itself. When
+  the machines artefact is absent the hook is unregistered, this returns
+  nil, and apps that don't use state machines pay nothing.
+
+  The `:rf.http/managed` guard short-circuits before the hook call: the
+  framework-stamped fx event-id is never an actor address, so there is no
+  point asking machines about it."
   [frame-id origin-event]
   (let [event-id (when (vector? origin-event) (first origin-event))]
     (when (and event-id
                (not= event-id :rf.http/managed))
-      (let [spawned (read-spawned-registry frame-id)]
-        (when (seq spawned)
-          (when (spawned-actor-id? spawned event-id)
-            event-id))))))
+      (when-let [owning-actor-id (late-bind/get-fn :machines/owning-actor-id)]
+        (owning-actor-id frame-id event-id)))))

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -298,6 +298,75 @@
   (fn [runtime-db [_ machine-id tag]]
     (contains? (get-in runtime-db (paths/snapshot-path machine-id :tags)) tag)))
 
+;; ---- spawned-actor ownership (rf2-ma0wvq) ---------------------------------
+;;
+;; Per Spec 014 §Abort on actor destroy: a managed `:rf.http/managed`
+;; request "belongs to" a spawned actor when its originating event-id is
+;; that actor's address. The http artefact USED to decide this itself by
+;; re-stating `paths/spawned-path` and structurally walking the registry —
+;; a hidden dependency on this artefact's private runtime-db shape. The
+;; ownership decision is now MACHINES-OWNED and published through the
+;; `:machines/owning-actor-id` hook (rf2-ma0wvq), so the structural walk
+;; lives next to the registry shape it depends on. http reaches it via
+;; `late-bind/get-fn` and falls back to nil when machines is absent.
+;;
+;; SET SEMANTICS (rf2-ma0wvq step 1): the owning set is REGISTRY
+;; MEMBERSHIP — declarative `:spawn` / `:spawn-all` actors only, set-
+;; identical to the pre-inversion http walk. This is declarative-only BY
+;; DECISION pending a step-2 follow-up (filed separately) that WIDENS the
+;; set to imperatively-spawned actors via the snapshot `:rf/machine-type`
+;; marker; that widening MUST land with its own imperative-spawn destroy-
+;; cancellation test, not ride this behaviour-preserving inversion.
+
+(defn- spawned-membership-actor-id
+  "Return `event-id` if it is currently registered as a spawned actor's
+  address somewhere under `[:rf.runtime/machines :spawned <parent>
+  <invoke-id>]` in `spawned` — either as the leaf value (declarative
+  `:spawn`) or as a value in the `:children` map of a `:spawn-all` join-
+  state record — otherwise nil."
+  [spawned event-id]
+  (when (some (fn [[_parent inner]]
+                (some (fn [[_invoke-id v]]
+                        (or (= v event-id)                   ;; :spawn leaf
+                            (and (map? v)                    ;; :spawn-all join state
+                                 (some (fn [[_cid cid-val]]
+                                         (= cid-val event-id))
+                                       (:children v)))))
+                      inner))
+              spawned)
+    event-id))
+
+(defn owning-actor-id
+  "Resolve the spawned-actor-id that OWNS `event-id` in `frame-id`, or nil.
+
+  Returns `event-id` (a keyword — the spawned actor's machine address)
+  when it is currently registered in the frame's runtime-db spawn
+  registry (`paths/spawned-path`), otherwise nil — meaning the event is
+  NOT owned by a spawned actor (it came from an ordinary event handler).
+
+  Published as the `:machines/owning-actor-id` late-bind hook (rf2-ma0wvq)
+  so the http artefact can ask machines \"who owns this request's
+  originating event?\" without statically `:require`ing this artefact or
+  re-stating its private runtime-db shape. When machines is absent the
+  hook is unregistered and http's caller falls back to nil.
+
+  Set semantics (rf2-ma0wvq step 1): REGISTRY MEMBERSHIP — declarative
+  `:spawn` / `:spawn-all` actors only, set-identical to the pre-inversion
+  http walk (see the section comment above; step 2 widens to imperative
+  spawns under its own test).
+
+  PERF: `frame/frame-runtime-db-value` is a substrate `deref` returning the
+  persistent runtime-db map BY REFERENCE (no copy, no scan), so reading the
+  one `:spawned` slot is O(1); the `(seq …)` short-circuit means an app
+  with no live spawns pays one by-reference deref + one path descent + one
+  seq-check before any structural walk."
+  [frame-id event-id]
+  (let [rt (frame/frame-runtime-db-value frame-id)]
+    (when (map? rt)
+      (let [spawned (get-in rt (paths/spawned-path))]
+        (when (seq spawned)
+          (spawned-membership-actor-id spawned event-id))))))
+
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
 ;; Per rf2-xbtj the machines surface ships in
@@ -373,6 +442,15 @@
 ;; `:where :machine-data` boundary (Spec 005 §Schema validation, Spec
 ;; 010 §Per-step recovery row 7).
 (late-bind/set-fn! :machines/validate-machine-data! validate-machine-data!)
+;; Per rf2-ma0wvq — spawned-actor ownership resolver. The http artefact
+;; consults this to classify whether a managed request's originating
+;; event-id belongs to a spawned actor (so an actor-destroy cascade can
+;; abort it). Machines OWNS the registry shape, so the structural walk
+;; lives here; http reaches it via late-bind and falls back to nil when
+;; machines is absent (apps without state machines pay nothing). See the
+;; `owning-actor-id` docstring for the set semantics (step-1 registry
+;; membership, declarative `:spawn` / `:spawn-all` only).
+(late-bind/set-fn! :machines/owning-actor-id        owning-actor-id)
 (late-bind/set-fn! :machines/spawn-all-init-fx      spawn-all-init-fx)
 (late-bind/set-fn! :machines/after-schedule-fx      after-schedule-fx)
 (late-bind/set-fn! :machines/after-cancel-fx        after-cancel-fx)

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -587,6 +587,9 @@
   ["re-frame.machines" "validate-machine-data!"] {:tier :internal-public :owner "005" :status "v1"}
   ["re-frame.machines" "validate-spawn-data!"]  {:tier :internal-public :owner "005" :status "v1"}
   ["re-frame.machines" "reset-timers!"]         {:tier :internal-public :owner "005" :status "v1"}
+  ;; rf2-ma0wvq — spawned-actor ownership resolver, published as the
+  ;; `:machines/owning-actor-id` late-bind hook the http artefact consults.
+  ["re-frame.machines" "owning-actor-id"]       {:tier :internal-public :owner "005" :status "v1"}
 
   ;; =========================================================================
   ;; re-frame.routing — optional artefact (day8/re-frame2-routing), §012.

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 497,
+ :var-count 498,
  :tier-vocab
  [:front-porch
   :advanced
@@ -264,6 +264,7 @@
   {:namespace "re-frame.machines", :var "machine-transition", :tier :advanced, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.machines", :var "machines", :tier :tooling, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.machines", :var "make-machine-handler", :tier :advanced, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.machines", :var "owning-actor-id", :tier :internal-public, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.machines", :var "reg-machine*", :tier :advanced, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.machines", :var "reset-timers!", :tier :internal-public, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.machines", :var "spawn-all-init-fx", :tier :internal-public, :kind :fn, :owner "005", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Inverts the HTTP to machines spawned-actor ownership coupling per the rf2-ma0wvq ruling.

## Problem

HTTP decided spawned-actor ownership by re-stating the machines runtime-db spawn-registry path and structurally walking it — a hidden structural dependency on an optional artefact's private runtime-db shape. The boundary was asymmetric: machines already called HTTP through the :http/abort-on-actor-destroy hook for the destroy side, while HTTP peeked inside machines state to classify ownership.

## Change

Machines owns the :spawned registry shape, so it now publishes the :machines/owning-actor-id late-bind hook with signature frame-id + event-id returning actor-id or nil. HTTP consults the hook and falls back to nil when the machines artefact is absent.

- machines: add re-frame.machines/owning-actor-id (the membership walk, moved verbatim from HTTP) and publish the :machines/owning-actor-id hook.
- core: register :machines/owning-actor-id in the late-bind directory; the late-bind-drift test stays green.
- http-registry: delete the duplicated spawned-registry-path constant, read-spawned-registry, and the spawned-actor-id? walker; compute-actor-id now resolves ownership through the hook.
- rewrite the two prose path-mentions in http_registry and http_handlers comments so the eventual zero-external-readers guard test is clean.

## Two-step set semantics

Step 1 (this PR) is a PURE inversion — the owning set is registry membership (declarative :spawn / :spawn-all only), set-identical to the pre-inversion walk, so the existing actor-destroy regression net suffices. The owning-actor-id docstring records that the set is declarative-only by decision pending step 2, not by accident.

Step 2 is filed as rf2-n877mb (a filed bead, not a prose promise): switch the hook to the snapshot-marker :rf/machine-type semantics, which widens cancellation to imperatively-spawned actors and MUST land with a new imperative-spawn managed-HTTP destroy-cancellation test. It may instead retire into the EP-0003 machine owner-kind if that lands first.

## Gates (all green)

- npm run test:cljs — 6247 tests, 22442 assertions, 0 failures, 0 errors
- npm run test:bundle-isolation — PASS
- http JVM clojure -M:test — 380 tests, 0 failures, 0 errors
- machines JVM clojure -M:test — 609 tests, 0 failures, 0 errors
- core late-bind-drift — 6 tests, 542 assertions, 0 failures, 0 errors
- clj-kondo — 0 errors over implementation/http + implementation/machines (0 errors and 0 warnings on the touched files)

Closes rf2-ma0wvq.
