### PR TITLE
docs(EP-0009): guide-impact assessment at graduation (rf2-6txusr)

### DIFF
--- a/docs/EP/EP-0009-the-ep-process.md
+++ b/docs/EP/EP-0009-the-ep-process.md
@@ -98,6 +98,14 @@ The `Status:` line is machine-readable. Its value MUST be one of:
    updates are always fine.)
 4. **One EP, one decision surface.** Bundling independent decisions invites
    all-or-nothing rulings; prefer narrow EPs and cross-references.
+5. **Graduation includes a guide-impact assessment:** the graduating EP names
+   which `docs/guide` chapters change and which payoffs become newly teachable;
+   the docs bead of the EP's wave carries those edits (e.g. EP-0010 upgrades
+   guide ch.07's clock section from the cofx idiom to the envelope stamp;
+   EP-0011 rewrites ch.10's no-await box around the reply envelope; EP-0008
+   extends ch.16's production section with the always-on error axis; EP-0013
+   eventually warrants a realms chapter). An EP may conclude "no human-facing
+   guide change yet" and record why.
 
 ### Document conventions
 


### PR DESCRIPTION
Institutionalizes the guide-capture loop in EP-0009 by adding Durability rule 5: graduation includes a guide-impact assessment naming which docs/guide chapters change and which payoffs become newly teachable, carried by the EP wave's docs bead. Includes worked examples (EP-0010/0011/0008/0013) and the explicit "no guide change yet" escape valve.

One-file change to docs/EP/EP-0009-the-ep-process.md. Status:/Type: lines untouched (amendment is legal per EP-0009's own pre-implementation rule, since it is Status: proposal).

Gates: check_ep_status_sync.py + check_doc_slugs.py both pass. EP-0009 is not in mkdocs nav, so --strict is not gating this change.

Closes rf2-6txusr.