### PR TITLE
docs(guide): "Where Should This Value Live?" decision page + CT-callout device (rf2-1artjc)

### DIFF
--- a/docs/guide/02-app-db.md
+++ b/docs/guide/02-app-db.md
@@ -2,6 +2,8 @@
 
 Where does the data actually live? In one place. That's the whole answer, and it's so short you might be tempted to skip past it — don't. This chapter is that one sentence and every consequence that falls out of it, and the consequences are the reason the rest of the framework gets to be as simple as it is.
 
+> **Deciding where a particular value should live?** Not everything belongs *directly* in `app-db` — derived values, server-state caches, and process bookkeeping each have a better home. See [Where should this value live?](where-state-lives.md) for the four questions that sort a value into a subscription, a flow, a resource, or a machine.
+
 ## The one-sentence answer
 
 **Your application's state lives in a single immutable map called `app-db`.**

--- a/docs/guide/05-subscriptions.md
+++ b/docs/guide/05-subscriptions.md
@@ -2,6 +2,8 @@
 
 Your view needs to read state. But it must *not* know where in `app-db` that state lives, and it must *not* recompute its slice every time some unrelated corner of the map twitches. A subscription is the answer to both demands at once — a named derivation that views ask for by id — and the graph those derivations form, quietly, behind your back, is where almost all of re-frame2's performance comes from. This chapter is that graph. The next chapter, [06 — Views](06-views.md), is the boring render functions that sit on top of it; this one is the machinery underneath that makes them cheap.
 
+> **Deciding where a value should live?** A subscription is the cheapest home and the one to reach for first — see [Where should this value live?](where-state-lives.md) for the four questions that sort a value into a sub, a flow, a resource, or a machine.
+
 ## The problem nobody tells you is a problem
 
 Let's start, as is tradition, with a complaint.

--- a/docs/guide/12-machines.md
+++ b/docs/guide/12-machines.md
@@ -2,6 +2,8 @@
 
 Some flows in your app aren't "set a flag." They're "what state are we even *in*?" A login that can be idle, submitting, authed, error-shown, or locked-out. A wizard with five steps and rules about which one can follow which. A websocket that's connecting, connected, dropped, reconnecting. For those, the load-bearing question isn't what's in app-db — it's which of a fixed set of named states you're sitting in, and which events move you to which other state. That shape has a name, and the moment you notice you're writing one, your scattered `cond` clauses stop being the natural way to express the flow and start being a way of *hiding* it.
 
+> **Deciding where a value should live?** A machine is the right home when a value has a *lifecycle* — named states, timers, retries, cancellation — rather than just a value you read. See [Where should this value live?](where-state-lives.md) for the four questions that distinguish a machine from a subscription, a flow, or a resource.
+
 ## You've been writing these the whole time
 
 Here's the uncomfortable bit: you already write state machines. You just call them other things. The `cond` at the top of your login handler that branches on `(:auth/state db)`. The `case` in your video player deciding what `:pause` means depending on whether you're `:loading` or `:playing` or `:buffering`. The `if-let` that checks "are we already submitting? then swallow this click." The keyword you stuffed into app-db two years ago — `:idle`, `:submitting`, `:authed`, `:error-shown`, `:locked-out` — and have been quietly growing ever since, along with a set of *unwritten rules in your head* about which of those states can legally follow which.

--- a/docs/guide/21-dynamic-model.md
+++ b/docs/guide/21-dynamic-model.md
@@ -91,6 +91,8 @@ And for flows you don't write the output at all — you write the *inputs*, and 
 
 ## Flows — derived state that lives in app-db
 
+> **Deciding where a value should live?** The sub-versus-flow choice below is two of the four questions in [Where should this value live?](where-state-lives.md) — the page that sorts any value into a subscription, a flow, a resource, or a machine, and shows a value graduating from a sub to a flow at the exact moment a handler needs to read it.
+
 Subscriptions ([chapter 05](05-subscriptions.md)) are the default tool for derived values, and you should reach for them first — a sub's value lives in the per-frame cache, costs nothing to declare, and is consumed by views. But there's a specific case where you want a derived value to be *part of the application's state* rather than just a view-render input: where downstream event handlers need to read it as plain `app-db` data, where it must survive SSR hydration and time-travel revert, where a registered schema should cover it. That case is a **flow**.
 
 A flow is a registered rule: *"when these `app-db` paths change, run this pure function and write the result to that `app-db` path."*

--- a/docs/guide/AUTHORING.md
+++ b/docs/guide/AUTHORING.md
@@ -64,6 +64,49 @@ the explanation in chapter prose. Future chapter authors who skip this
 policy will reintroduce the same drift — keep the tutorial track
 self-sufficient.
 
+## The "for the categorically curious" callout
+
+re-frame2's design is grounded in functional and category-theoretic ideas
+(folds, lattices, lenses, derivation algebras). Those ideas are real and they
+earn the framework its shape — but they are *design tools*, not *teaching
+vocabulary*. The guide's rule is **translate, don't transplant**: the chapter
+body explains an idea in plain language, framed as a payoff for the reader; the
+category-theory vocabulary appears *only* inside an optional, collapsible
+callout for the reader who enjoys the deeper unifying frame.
+
+The device is an mkdocs-material collapsible admonition (the `pymdownx.details`
+extension, already enabled), titled **"For the categorically curious"**:
+
+```markdown
+<details markdown="1">
+<summary>For the categorically curious</summary>
+
+All four homes are the same thing seen four ways: a node in one dependency
+graph, distinguished by its storage policy and its evaluation policy. ...
+</details>
+```
+
+The rules — non-negotiable, so the device stays a treat and never a tax:
+
+- **Always collapsible and always skippable.** Use the `<details>`/`<summary>`
+  form (collapsed by default), never a plain `> **Note:**` block or an
+  always-expanded admonition. A reader who never opens it must lose nothing.
+- **The surrounding prose must stand alone.** The chapter has to make complete
+  sense to a reader who skips every callout. The callout *adds* a frame; it
+  never *carries* a load-bearing fact. If the body can't be understood without
+  it, the body is incomplete — fix the body, don't lean on the box.
+- **At most one per concept.** One callout illuminating one idea. A page with
+  three of them has turned the treat into the meal.
+- **Max ~6 lines.** It's a glimpse, not a lecture. No proofs, no derivations,
+  no chains of definitions.
+- **Every symbol gets a plain-English gloss.** If you write "catamorphism" or
+  "lens," say in the same breath what it means here. A term the reader can't
+  decode is noise, not insight.
+
+First user: [Where Should This Value Live?](where-state-lives.md), whose body
+teaches the sub/flow/resource/machine decision in plain language and offers one
+callout framing the four as storage-and-evaluation policies over one graph.
+
 ## No bead references in chapter prose
 
 User-facing docs state the **current truth** of the framework, not the

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -18,6 +18,7 @@ Read chapters 01-08 in order if you are new. They teach the core loop: event, ap
 
 After that, use the guide by problem:
 
+- Not sure where a value belongs — a sub, a flow, a resource, or a machine? Read [Where should this value live?](where-state-lives.md).
 - Building real forms? Read [11 - Forms](11-forms.md).
 - Talking to a server? Read [10 - HTTP](10-http.md).
 - Caching server-state (TanStack-Query-style reads)? Read [27 - Server-state and resources](27-resources.md).

--- a/docs/guide/where-state-lives.md
+++ b/docs/guide/where-state-lives.md
@@ -1,0 +1,147 @@
+# Where Should This Value Live?
+
+This is the question you'll face every afternoon you work in re-frame2. You've got a value — a cart total, an article you fetched, the step a checkout is sitting in — and the framework hands you four different places it could live: a subscription, a flow, a resource, a machine. Pick wrong and the value fights you: it goes stale, it lies to your handlers, it leaks between users, it scatters across three booleans nobody can keep in sync. Pick right and it just *behaves* — it's fresh when you read it, it's where your code expects it, it survives time-travel and SSR, and the bug you were bracing for never shows up.
+
+The good news is that you don't have to develop a feel for this over six months of mistakes. There are four questions, and you ask them in order, and the first one that says *yes* is your answer. This page is those four questions, threaded through one worked example so you can watch a single value — a shopping cart — find each of the four homes as its obligations grow.
+
+You won't need to know how the four mechanisms work under the hood to use this page. Each question is about what the value *needs*, not about machinery; the chapter links are there for when you want the full story on whichever home you landed in. (There's also one optional box near the end for readers who like the deeper unifying idea. The page makes complete sense if you never open it.)
+
+## The four questions
+
+Ask them top to bottom. Stop at the first *yes*.
+
+1. **Can you recompute it, every time, from state you already have?** → It's a **subscription**. [(chapter 05)](05-subscriptions.md)
+2. **Must it live *in* `app-db` — read by event handlers, covered by your schema, riding SSR and time-travel?** → It's a **flow**. [(chapter 21)](21-dynamic-model.md#flows--derived-state-that-lives-in-app-db)
+3. **Does it come from a server, where it can go stale and needs caching, refetch, and invalidation?** → It's a **resource**. [(chapter 27)](27-resources.md)
+4. **Does it have a lifecycle of its own — named states, timers, retries, cancellation?** → It's a **machine**. [(chapter 12)](12-machines.md)
+
+The order matters, because the cheapest home that fits is the right one. A subscription costs nothing to declare and is gone after the render; a flow pays an `app-db` write; a resource brings a whole cache; a machine brings a whole transition table. Reach for the heavier homes only when the value genuinely needs what they buy. When two answers seem to fit, the earlier one usually wins — and the worked example below shows exactly the moments where a value *graduates* from one home to the next, and what each graduation costs.
+
+## One value, four homes: the cart
+
+Let's follow a single value as a feature grows up. We'll start with the most modest thing in the app — a cart total — and watch it acquire obligations until it has visited all four homes.
+
+### Question 1 — can you recompute it? Then it's a subscription
+
+The cart total is the sum of the line items' prices. The line items already live in `app-db` (you put them there when the user added them). So the total is *derivable*: given the items, you can compute it, every single time, with no extra stored state. That's the signature of a **subscription** — a named derivation that reads existing state and hands a view the slice it wants.
+
+```clojure
+(rf/reg-sub :cart/total
+  :<- [:cart/items]
+  (fn [items _]
+    (reduce + (map :price items))))
+```
+
+What this buys you: the total is **never wrong**. There's no second copy of it that can drift from the items it's derived from, because there's no second copy at all — it's recomputed from the items whenever the items change, and it recomputes for nobody when nothing's looking. You never wrote an "update the total" handler, and you never will, because there's nothing to update. A view reads `@(rf/subscribe [:cart/total])` and the framework keeps it in lockstep with the items for free. This is the default, the cheapest home, the one you should *want* the answer to be. Most derived values in your app are this. ([Chapter 05](05-subscriptions.md) is the whole graph these chain into.)
+
+### Question 2 — must a handler read it? Then promote it to a flow
+
+Now a requirement lands: the moment the cart total crosses $50, the user qualifies for free shipping, and the *checkout event handler* needs to know that when it builds its order payload. A handler — not a view. And here's the wall: **handlers can't read subscriptions.** A subscription is a view-side derivation; it isn't *in* `app-db`, so an event handler, which sees only `db`, has no way to ask for it. You could recompute the total inside the handler, but now the formula lives in two places and they'll drift the first time pricing rules change.
+
+This is the exact moment the total wants to *be part of the application's state* rather than just a view-render input — and that's a **flow**: a registered rule that says "when these `app-db` paths change, recompute this and write the result to *this* `app-db` path." Here are the two registrations side by side so you can see precisely what changed:
+
+```clojure
+;; BEFORE — a subscription. Lives in the sub-cache; views only; gone after the render.
+(rf/reg-sub :cart/total
+  :<- [:cart/items]
+  (fn [items _]
+    (reduce + (map :price items))))
+
+;; AFTER — a flow. The same formula, but the result is WRITTEN to app-db at [:cart/total],
+;; where event handlers read it as plain data, schema covers it, and it rides SSR + time-travel.
+(rf/reg-flow
+  {:id     :cart/total
+   :inputs [[:cart :items]]
+   :output (fn [items] (reduce + (map :price items)))
+   :path   [:cart/total]})
+```
+
+The formula is identical. What changed is *where the value lives*: the flow writes it into `app-db` at `[:cart/total]`, so your checkout handler reads `(:cart/total db)` like any other piece of state, your registered schema can cover it, and it survives SSR hydration and a time-travel revert because it's part of the frame's state value now.
+
+What it cost: a flow pays an `app-db` write on every recompute and adds a small piece of registered runtime — so this isn't a free upgrade, it's a deliberate trade you make *because a handler needs the value as data*. If no handler ever needed to read it, you'd leave it a subscription. The rule of thumb, straight from the framework's own design: a typical app has dozens of subscriptions and only a *handful* of flows. If you're reaching for a flow and no handler reads the output, you've over-paid — go back to a sub. ([Chapter 21](21-dynamic-model.md#flows--derived-state-that-lives-in-app-db) covers flows in full, including why you write the *inputs* and never the output.)
+
+### Question 3 — does it come from a server and go stale? Then it's a resource
+
+The cart so far is all *local* state — the user built it, it lives in `app-db`, it's true by construction. But now the checkout page needs to show the article the user is buying: its title, its price, its stock level. That data isn't yours. It lives on a server, you hold a *cache* of it, and that cache is stale the instant you read it. The moment a value has those properties — remote origin, an identity that says *which* thing you fetched, staleness, the need to refetch and invalidate — it's a **resource**, and trying to cram it into `app-db` by hand is the classic mistake the next section catalogues.
+
+A resource is "a sub you read and a cause you fire": you register it once, a *cause* (a route opening, an event, a machine entering a state) makes it fetch, and your view reads it passively through a subscription. The runtime owns everything painful in between — identity, caching, staleness, dedupe, invalidation, and the leak boundary that stops one user seeing another's data.
+
+```clojure
+;; Register the article resource once: its identity (params), its leak boundary (scope), its request.
+(rf/reg-resource :article/by-slug
+  {:params-schema [:map [:slug :string]]
+   :scope         :rf.scope/global
+   :request (fn [{:keys [slug]} _ctx]
+              {:request {:method :get :url (str "/api/articles/" slug)}
+               :decode  :json})})
+
+;; A CAUSE fires the fetch (here, an event; a route opening is the most common cause).
+(rf/dispatch [:rf.resource/ensure {:resource :article/by-slug :params {:slug "widget"}}])
+
+;; A view READS it passively — it never fetches.
+@(rf/subscribe [:rf.resource/state {:resource :article/by-slug :params {:slug "widget"}}])
+;; → {:status :loaded :data {:title "Widget" :price 1200} :has-data? true ...}
+```
+
+The two ideas that make a resource a resource, in two sentences: its **identity** is the params — `{:slug "widget"}` says *which* article, so two screens asking for the same one share a single cache entry and a single request — plus a **scope** that decides *whose* cache it is and fails closed so a logged-out user can never see the previous user's data. And **staleness and invalidation** are first-class: the entry knows when it was loaded, a stale read can trigger a background refetch while the old data stays on screen, and a write elsewhere can invalidate it by tag so it refetches with fresh data. You stop hand-rolling that bookkeeping per feature. ([Chapter 27](27-resources.md) is the full server-state story; the underlying transport is managed HTTP, [chapter 10](10-http.md).)
+
+### Question 4 — does it have its own lifecycle? Then it's a machine
+
+The cart is built, the article is loaded, the user clicks **Checkout**. Now what you're modelling isn't a *value* at all — it's a *process*. Checkout is idle, then validating the cart, then awaiting payment, then confirming, then either done or failed-and-retrying. There are rules about which state can follow which (you can't confirm before payment), there's a timer (cancel if payment doesn't come back in 30s), and there's cancellation (the user backs out). The load-bearing question stopped being "what's the value?" and became "**what state are we in, and what moves us to the next one?**" That's a **machine**.
+
+You can always tell you've grown into a machine by the smell that precedes it. You'll have started with booleans:
+
+```clojure
+;; THE SMELL — three booleans pretending to be one state.
+{:checkout/validating? false
+ :checkout/awaiting-payment? true
+ :checkout/error? false}
+```
+
+Three booleans encode eight combinations, but checkout has maybe five *legal* states — which means three of those eight are nonsense the code has to keep defending against (`validating?` and `awaiting-payment?` both true at once should be impossible, but nothing stops it). Every handler that touches checkout grows a `cond` that re-derives "which state are we really in" from the boolean soup, and the rules about legal transitions live as unwritten lore in your head. The moment you notice you're maintaining three booleans and a mental rulebook about their combinations, the value wants to be a machine: one named state, an explicit transition table, and per-state timers and actions.
+
+```clojure
+;; THE FIX — one named state, transitions as data. The illegal combinations are unrepresentable.
+(rf/reg-machine :checkout/flow
+  {:initial :idle
+   :states
+   {:idle             {:on {:checkout/start    {:target :validating}}}
+    :validating       {:on {:checkout/valid    {:target :awaiting-payment}
+                            :checkout/invalid  {:target :idle}}}
+    :awaiting-payment {:after {30000 {:target :failed}}
+                       :on {:checkout/paid     {:target :confirming}
+                            :checkout/cancel   {:target :idle}}}
+    :confirming       {:on {:checkout/done     {:target :complete}
+                            :checkout/error    {:target :failed}}}
+    :complete         {}
+    :failed           {:on {:checkout/retry    {:target :validating}}}}})
+```
+
+What it buys: the checkout can now only be in a state it can legally reach, the timer is part of the state that owns it (and is cancelled automatically when you leave that state), and "what happens on payment?" has *one* answer that depends on the current state, not a `cond` smeared across five handlers. The snapshot lives in the framework's runtime-db partition, so undo, time-travel, and SSR extend to your checkout for free. ([Chapter 12](12-machines.md) is machines in full; if you know xstate, you already know 80% of the grammar.)
+
+<details markdown="1">
+<summary>For the categorically curious</summary>
+
+All four homes are the same thing seen four ways: a node in **one dependency graph rooted at your state**, distinguished only by its *storage policy* (where the value is kept) and its *evaluation policy* (when it's recomputed). A **subscription** is *no storage, recompute on demand*. A **flow** is *stored in app-db, recompute after each event*. A **resource** is *stored in a runtime cache, recompute on cause and staleness*. A **machine** is *stored as a snapshot, recompute on transition*. Same graph, four policies — which is why "where should this value live?" is really "which storage-and-evaluation policy does this value need?"
+</details>
+
+## Signs you picked the wrong home
+
+The four questions get you to the right home the first time. This table is for the second time — when something's misbehaving and the cause is a value living somewhere it shouldn't. Each row is a smell, what it means, and where the value actually wants to be.
+
+| The smell | What it really means | Move it to |
+|---|---|---|
+| A **subscription that does IO** — fetches, writes `localStorage`, reads the clock. | A subscription is a *pure read* of existing state. If it reaches into the world, it isn't a derivation — it's a fetch (a resource) or an effect (a handler). | A **resource** if it's remote data; an **event handler + effect** if it's a side effect. |
+| A **flow whose output no handler ever reads.** | You paid for an `app-db` write to materialize a value only views consume. That's a subscription wearing a flow's costume. | A **subscription** — drop the flow, recompute on demand. |
+| A **machine that wraps a single fetch** — two states, `:loading` and `:loaded`, and nothing else. | A lifecycle with no real branching, timers, or cancellation isn't a process; it's a remote read with a status. | A **resource** — its five-status model already *is* the loading/loaded/error lifecycle, for free. |
+| **Remote data hand-rolled into `app-db`** with `:loading?` / `:error?` booleans you set in `:on-success` / `:on-failure`. | You're re-implementing the resource cache — identity, staleness, dedupe, the leak boundary — by hand, per feature, and getting the races wrong. | A **resource** — register it once and let the runtime own the bookkeeping. |
+
+The common thread: each wrong home is a value being asked to do a job its home isn't shaped for. The subscription is asked to touch the world; the flow is asked to store something nobody reads from storage; the machine is asked to be a process when it's just a value with a status; `app-db` is asked to be a server-state cache. Move the value to the home shaped for its job and the defending-against-impossible-states code you'd been writing simply evaporates.
+
+## The rule, stated once
+
+When a value appears, walk the four questions in order and stop at the first *yes*:
+
+> **Recompute it from existing state?** → subscription. **Must a handler read it as `app-db` data?** → flow. **Remote, cached, can go stale?** → resource. **A process with states and timers?** → machine.
+
+The cheapest home that fits is the right one, and a value graduates to a heavier home only when it earns the upgrade — a handler that needs to read it, a server it comes from, a lifecycle of its own. Get the home right and the value behaves; get it wrong and you'll find it again in the misuse table above.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,6 +184,7 @@ nav:
     - "25 - From re-frame v1": guide/25-from-re-frame-v1.md
     - "26 - Operating well": guide/26-operating-well.md
     - "27 - Server-state and resources": guide/27-resources.md
+    - "Where should this value live?": guide/where-state-lives.md
 
   - CLJS:
     - "ClojureScript for non-Clojurians": cljs/index.md


### PR DESCRIPTION
## What

New flagship guide page **`docs/guide/where-state-lives.md`** — "Where Should This Value Live?" — the human-facing capture of the sub/flow/resource/machine value-placement decision (rf2-1artjc).

### The page
- **Un-numbered** (like `interactive-tutorials.md`); chapters are not renumbered.
- **Four questions, asked in order**, stop at the first yes:
  1. Recompute from existing state? → **subscription** (ch.05)
  2. Must a handler read it as `app-db` data (schema, SSR, time-travel)? → **flow** (ch.21 flows section)
  3. Remote, cached, can go stale (refetch, invalidation)? → **resource** (ch.27, transport ch.10)
  4. Lifecycle of its own — states, timers, retries, cancellation? → **machine** (ch.12)
- **One worked example threaded through all four**: the cart total as a subscription; promoted to a flow the moment a handler needs to read it (both registrations shown side by side, with what changed and what it cost); the article as a resource (identity + scope + staleness in two sentences); checkout as a machine (the three-boolean smell → one named state).
- Closes with a **"signs you picked the wrong home" misuse table** (a sub doing IO; a flow no handler reads; a machine wrapping a single fetch; remote data hand-rolled into `app-db` with `:loading?` booleans).

### Three binding rules, honoured
1. **Translate, don't transplant** — body is plain language; category-theory vocabulary lives *only* in one optional, collapsible "For the categorically curious" callout that the prose stands alone without.
2. **Teach payoffs, not mechanisms** — every home is framed as what it buys (never wrong; readable by handlers; cache for free; illegal states unrepresentable).
3. **Ship-now truths only** — subs, flows, Spec 016 resources, and machines are all shipped on `main`; no EP-0010..0014 proposal surfaces are taught.

### Supporting changes
- **`AUTHORING.md`**: defines the "For the categorically curious" callout device (collapsible + skippable; prose stands alone; max one per concept; ~6 lines; no proofs; every symbol glossed) — this page is its first user.
- **`mkdocs.yml`**: page wired into the Guide nav after ch.27.
- **Cross-links**: one-line "Deciding where a value should live?" pointer added to `02-app-db`, `05-subscriptions`, `12-machines`, `21-dynamic-model` (flows section, *extends* the existing managed-slices/flows material rather than duplicating it), and a problem-oriented pointer in the guide `README`.

## Gates
- `python scripts/check_doc_slugs.py` — clean (fixed an em-dash double-hyphen anchor to `#flows--derived-state-that-lives-in-app-db`).
- `mkdocs build --strict` (spec/ + migration/ staged per the docs recipe, then removed) — exit 0.
- `python scripts/check_readme_inventories.py` — clean.

Closes rf2-1artjc.
