### PR TITLE
fix(machines): widen owning-actor-id to imperatively-spawned actors (rf2-n877mb)

### DIFF
--- a/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
@@ -30,7 +30,16 @@
    6c. `schedule-backoff-handle!`'s abort-fn cleans an anonymous
        (request-id-less) backoff handle's actor slot when fired by a
        trigger that does NOT pre-clear the actor slot — the sibling of
-       (6b) at the second abort-fn site (rf2-meq28)"
+       (6b) at the second abort-fn site (rf2-meq28)
+   7.  IMPERATIVELY-spawned actor (`[:rf.machine/spawn …]` from an
+       ordinary event handler — NO `:spawned` registry slot) → its managed
+       request is aborted on imperative `[:rf.machine/destroy …]`. This is
+       the rf2-n877mb widening test: step 1's registry-membership
+       `owning-actor-id` classified such a request as unowned (the actor is
+       absent from `[:rf.runtime/machines :spawned]`); step 2 switches
+       ownership to the durable snapshot `:rf/machine-type` marker, so
+       imperative spawns are now owners. Tests 1–6c cover declarative
+       `:spawn` only and cannot catch this widening (rf2-n877mb)"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.flows :as flows]
@@ -560,3 +569,103 @@
           "the backoff abort-fn's handle-passing 2-arg clear-in-flight! removed the anonymous handle from the actor index — no stranded slot")
       (is (empty? (http-managed/in-flight-snapshot))
           "request-id index remains empty"))))
+
+;; ---- (7) IMPERATIVELY-spawned actor (rf2-n877mb) → managed HTTP aborts ----
+;; ----     on imperative destroy. This is the widening test the registry- ---
+;; ----     membership `owning-actor-id` (step 1) could NOT pass: an ---------
+;; ----     imperative `[:rf.machine/spawn …]` from an ordinary event handler -
+;; ----     installs a snapshot WITHOUT a `[:rf.runtime/machines :spawned …]` -
+;; ----     registry slot (that slot is gated on the declarative-desugar ------
+;; ----     `:rf/parent-id` + `:rf/spawn-id`), so the step-1 registry read ----
+;; ----     classified the actor's request as unowned and never aborted it. ---
+;; ----     Step 2 switches ownership to the durable snapshot `:rf/machine- ---
+;; ----     type` marker (the SAME discriminator the destroy side keys on), ---
+;; ----     widening the owning set to imperative spawns. The existing net ----
+;; ----     above (tests 1–6c) covers DECLARATIVE `:spawn` only, so it cannot -
+;; ----     catch this widening — hence this dedicated case.
+
+(deftest imperatively-spawned-actor-request-aborts-on-imperative-destroy
+  (testing "a managed :rf.http/managed request issued from an IMPERATIVELY-spawned actor (no :spawned registry slot) is aborted when the actor is imperatively destroyed — rf2-n877mb widens owning-actor-id to the snapshot :rf/machine-type marker"
+    (let [latch  (CountDownLatch. 1)
+          {:keys [port] :as srv} (start-blocking-server! latch 200 "application/json" "{\"too\":\"late\"}")
+          replies (atom [])
+          traces  (atom [])]
+      (try
+        (trace/register-listener! ::n877mb (fn [ev] (swap! traces conj ev)))
+        (rf/reg-event-fx :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        ;; Worker machine: on entry to :running its action fires an
+        ;; :rf.http/managed request at the slow server. Spawned IMPERATIVELY
+        ;; below via a hand-emitted [:rf.machine/spawn …] fx (NOT a
+        ;; declarative state-node :spawn) — so it gets a snapshot stamped
+        ;; with :rf/machine-type but NO [:rf.runtime/machines :spawned …]
+        ;; registry slot.
+        (rf/reg-machine :worker/imp
+          {:initial :idle
+           :data    {:port port}
+           :actions {:fire-request
+                     (fn [{data :data}]
+                       {:fx [[:rf.http/managed
+                              {:request    {:url    (str "http://127.0.0.1:" (:port data) "/slow")
+                                            :method :get}
+                               :decode     :json
+                               :request-id [:worker/imp :slow]
+                               :on-failure [:reply/recorder]}]]})}
+           :states  {:idle    {:on {:start :running}}
+                     :running {:entry :fire-request}}})
+        ;; Ordinary event handler emits the IMPERATIVE spawn fx. No parent
+        ;; machine, no declarative :spawn desugar — the canonical
+        ;; XState-`spawn`-equivalent imperative entry-point. The actor's
+        ;; deterministic id is :worker/imp#1 (runtime-db spawn-counter
+        ;; fallback). The :start event drives idle→running → :fire-request.
+        (rf/reg-event-fx :imp/spawn
+          (fn [_ _]
+            {:fx [[:rf.machine/spawn {:machine-id :worker/imp
+                                      :id-prefix  :worker/imp
+                                      :start      [:start]}]]}))
+        ;; Ordinary event handler emits the IMPERATIVE destroy fx — the
+        ;; canonical [:rf.machine/destroy <actor-id>] keyword form (re-frame2's
+        ;; stopChild). This is the destroy trigger that must cascade to the
+        ;; HTTP abort.
+        (rf/reg-event-fx :imp/destroy
+          (fn [_ _]
+            {:fx [[:rf.machine/destroy :worker/imp#1]]}))
+        (rf/dispatch-sync [:imp/spawn])
+        ;; Precondition: the imperatively-spawned actor's snapshot is live,
+        ;; carries the :rf/machine-type marker, and is ABSENT from the
+        ;; :spawned registry — the exact shape step 1 could not classify.
+        (let [rt (rf/runtime-db-value :rf/default)]
+          (is (some? (get-in rt [:rf.runtime/machines :snapshots :worker/imp#1 :rf/machine-type]))
+              "imperatively-spawned actor's snapshot carries the :rf/machine-type marker")
+          (is (nil? (get-in rt [:rf.runtime/machines :spawned]))
+              "imperative spawn installs NO :spawned registry slot — the step-1 registry read would have classified its request as unowned"))
+        ;; The request is in-flight, indexed under the actor's id — proof that
+        ;; the widened owning-actor-id classified the imperative actor as owner.
+        (await-condition! #(seq (http-managed/actor-in-flight-snapshot)))
+        (is (= 1 (count (http-managed/actor-in-flight-snapshot)))
+            "in-flight registry has one actor entry while the imperative actor's request is pending")
+        (is (contains? (http-managed/actor-in-flight-snapshot) :worker/imp#1)
+            "actor index keys on the imperatively-spawned actor's id — the widening this test pins")
+        ;; Imperatively destroy the actor mid-flight.
+        (rf/dispatch-sync [:imp/destroy])
+        (await-condition! #(seq @replies))
+        (let [reply (first @replies)]
+          (is (= :failure (:kind reply))
+              "the abort surfaces as a :failure reply on :on-failure")
+          (is (= :rf.http/aborted (get-in reply [:failure :kind])))
+          (is (= :actor-destroyed (get-in reply [:failure :reason]))
+              "the :reason discriminates actor-destroy from user-abort"))
+        (let [trace-evs (abort-traces @traces)]
+          (is (seq trace-evs)
+              ":rf.http/aborted-on-actor-destroy trace event fired for the imperative actor")
+          (let [tags (:tags (first trace-evs))]
+            (is (= :worker/imp#1 (:actor-id tags))
+                "trace tags carry the destroyed imperatively-spawned actor id")
+            (is (= [:worker/imp :slow] (:request-id tags))
+                "trace tags carry the user-supplied :request-id")))
+        (is (empty? (http-managed/actor-in-flight-snapshot))
+            "actor index is empty after the imperative-destroy abort")
+        (.countDown latch)
+        (finally
+          (trace/unregister-listener! ::n877mb)
+          (stop-server! srv))))))

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -306,43 +306,38 @@
 ;; re-stating `paths/spawned-path` and structurally walking the registry —
 ;; a hidden dependency on this artefact's private runtime-db shape. The
 ;; ownership decision is now MACHINES-OWNED and published through the
-;; `:machines/owning-actor-id` hook (rf2-ma0wvq), so the structural walk
-;; lives next to the registry shape it depends on. http reaches it via
+;; `:machines/owning-actor-id` hook (rf2-ma0wvq), so the structural read
+;; lives next to the runtime-db shape it depends on. http reaches it via
 ;; `late-bind/get-fn` and falls back to nil when machines is absent.
 ;;
-;; SET SEMANTICS (rf2-ma0wvq step 1): the owning set is REGISTRY
-;; MEMBERSHIP — declarative `:spawn` / `:spawn-all` actors only, set-
-;; identical to the pre-inversion http walk. This is declarative-only BY
-;; DECISION pending a step-2 follow-up (filed separately) that WIDENS the
-;; set to imperatively-spawned actors via the snapshot `:rf/machine-type`
-;; marker; that widening MUST land with its own imperative-spawn destroy-
-;; cancellation test, not ride this behaviour-preserving inversion.
-
-(defn- spawned-membership-actor-id
-  "Return `event-id` if it is currently registered as a spawned actor's
-  address somewhere under `[:rf.runtime/machines :spawned <parent>
-  <invoke-id>]` in `spawned` — either as the leaf value (declarative
-  `:spawn`) or as a value in the `:children` map of a `:spawn-all` join-
-  state record — otherwise nil."
-  [spawned event-id]
-  (when (some (fn [[_parent inner]]
-                (some (fn [[_invoke-id v]]
-                        (or (= v event-id)                   ;; :spawn leaf
-                            (and (map? v)                    ;; :spawn-all join state
-                                 (some (fn [[_cid cid-val]]
-                                         (= cid-val event-id))
-                                       (:children v)))))
-                      inner))
-              spawned)
-    event-id))
+;; SET SEMANTICS (rf2-n877mb, step 2 of rf2-ma0wvq): the owning set is
+;; SNAPSHOT MEMBERSHIP — `event-id` owns a request iff a SPAWNED actor's
+;; snapshot lives at `[:rf.runtime/machines :snapshots <event-id>]`, where
+;; "spawned" is the durable `:rf/machine-type`-at-root discriminator
+;; `install-spawn!` stamps on EVERY spawned actor (declarative `:spawn` /
+;; `:spawn-all` AND imperative `[:rf.machine/spawn ...]`), and a
+;; singleton's snapshot never carries. This WIDENS the step-1 set (which
+;; read the `:spawned` registry — declarative spawns only) to imperatively-
+;; spawned actors. Imperative spawns install a snapshot WITHOUT a `:spawned`
+;; registry slot (the slot is gated on the declarative-desugar
+;; `:rf/parent-id` + `:rf/spawn-id`, per `lifecycle-fx.spawn/spawn-fx`'s
+;; `track?`), so the registry read structurally MISSED them and their
+;; managed HTTP was never aborted on destroy. The destroy side already
+;; fired `:http/abort-on-actor-destroy` for imperative destroys (via
+;; `lifecycle-fx.finalize` / `lifecycle-fx.frame-destroy`, which key on the
+;; SAME `:rf/machine-type` marker); only this RECORDING side excluded them.
+;; This is the SAME discriminator `frame-destroy/spawned-snapshot?` uses,
+;; so recording and teardown agree on exactly which ids are actors.
 
 (defn owning-actor-id
   "Resolve the spawned-actor-id that OWNS `event-id` in `frame-id`, or nil.
 
   Returns `event-id` (a keyword — the spawned actor's machine address)
-  when it is currently registered in the frame's runtime-db spawn
-  registry (`paths/spawned-path`), otherwise nil — meaning the event is
-  NOT owned by a spawned actor (it came from an ordinary event handler).
+  when a SPAWNED actor's snapshot is currently installed at
+  `[:rf.runtime/machines :snapshots <event-id>]`, otherwise nil — meaning
+  the event is NOT owned by a spawned actor (it came from an ordinary
+  event handler, or from a singleton machine whose snapshot carries no
+  `:rf/machine-type` marker).
 
   Published as the `:machines/owning-actor-id` late-bind hook (rf2-ma0wvq)
   so the http artefact can ask machines \"who owns this request's
@@ -350,22 +345,27 @@
   re-stating its private runtime-db shape. When machines is absent the
   hook is unregistered and http's caller falls back to nil.
 
-  Set semantics (rf2-ma0wvq step 1): REGISTRY MEMBERSHIP — declarative
-  `:spawn` / `:spawn-all` actors only, set-identical to the pre-inversion
-  http walk (see the section comment above; step 2 widens to imperative
-  spawns under its own test).
+  Set semantics (rf2-n877mb, step 2): SNAPSHOT MEMBERSHIP via the durable
+  `:rf/machine-type`-at-root discriminator — declarative `:spawn` /
+  `:spawn-all` AND imperative `[:rf.machine/spawn ...]` actors, since
+  `install-spawn!` stamps that marker on every spawned actor's snapshot
+  and a singleton's snapshot never carries it. This is the SAME
+  discriminator the destroy side (`frame-destroy/spawned-snapshot?`) keys
+  on, so recording and teardown classify ids identically (see the section
+  comment above for why step 1's `:spawned`-registry read missed imperative
+  spawns).
 
   PERF: `frame/frame-runtime-db-value` is a substrate `deref` returning the
-  persistent runtime-db map BY REFERENCE (no copy, no scan), so reading the
-  one `:spawned` slot is O(1); the `(seq …)` short-circuit means an app
-  with no live spawns pays one by-reference deref + one path descent + one
-  seq-check before any structural walk."
+  persistent runtime-db map BY REFERENCE (no copy, no scan), so the lookup
+  is a direct `get-in` to the candidate id's snapshot root — O(1), no scan
+  of the snapshot table. An app with no live spawned actors pays one
+  by-reference deref + one path descent that misses."
   [frame-id event-id]
   (let [rt (frame/frame-runtime-db-value frame-id)]
     (when (map? rt)
-      (let [spawned (get-in rt (paths/spawned-path))]
-        (when (seq spawned)
-          (spawned-membership-actor-id spawned event-id))))))
+      (let [snapshot (get-in rt (paths/snapshot-path event-id))]
+        (when (some? (:rf/machine-type snapshot))
+          event-id)))))
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
@@ -448,8 +448,9 @@
 ;; abort it). Machines OWNS the registry shape, so the structural walk
 ;; lives here; http reaches it via late-bind and falls back to nil when
 ;; machines is absent (apps without state machines pay nothing). See the
-;; `owning-actor-id` docstring for the set semantics (step-1 registry
-;; membership, declarative `:spawn` / `:spawn-all` only).
+;; `owning-actor-id` docstring for the set semantics (rf2-n877mb step 2:
+;; snapshot `:rf/machine-type` membership — declarative AND imperative
+;; spawns).
 (late-bind/set-fn! :machines/owning-actor-id        owning-actor-id)
 (late-bind/set-fn! :machines/spawn-all-init-fx      spawn-all-init-fx)
 (late-bind/set-fn! :machines/after-schedule-fx      after-schedule-fx)


### PR DESCRIPTION
## What

Step 2 of the rf2-ma0wvq HTTP↔machines spawned-actor ownership inversion. Switches the `:machines/owning-actor-id` late-bind hook from **registry membership** to **snapshot-marker membership**, widening the owning set to imperatively-spawned actors.

## Why

`owning-actor-id` (`re-frame.machines/owning-actor-id`) classified ownership by walking `[:rf.runtime/machines :spawned]` — a registry that only carries **declarative** `:spawn` / `:spawn-all` actors. Imperatively-spawned actors (a hand-emitted `[:rf.machine/spawn …]` from an ordinary event handler) install a snapshot but **no** `:spawned` slot (that slot is gated on the declarative-desugar `:rf/parent-id` + `:rf/spawn-id`, per `lifecycle-fx.spawn/spawn-fx`'s `track?`). So a `:rf.http/managed` request issued from inside an imperative actor was classified as unowned and **never aborted on that actor's destroy**.

The destroy side already fired `:http/abort-on-actor-destroy` for imperative destroys (`lifecycle-fx.finalize` / `lifecycle-fx.frame-destroy`, keyed on the **same** `:rf/machine-type` marker); only the **recording** side excluded them — an accident of reading the `:spawned` registry, not a contract.

## Change

`owning-actor-id` now returns `event-id` iff a spawned actor's snapshot lives at `[:rf.runtime/machines :snapshots <event-id>]`, using the durable `:rf/machine-type`-at-root discriminator that `install-spawn!` stamps on **every** spawned actor (declarative AND imperative) and a singleton never carries. This is the **same** discriminator `frame-destroy/spawned-snapshot?` uses, so recording and teardown now classify ids identically. The removed `spawned-membership-actor-id` helper (registry walk) is gone; the lookup is now a direct O(1) `get-in` (no snapshot-table scan).

## Test

New **test 7** in `http_actor_destroy_cancellation_test.clj`: an ordinary event handler imperatively spawns `:worker/imp#1` (asserts the snapshot carries `:rf/machine-type` AND is absent from `:spawned` — the exact shape step 1 could not classify), the actor fires a managed request, and an imperative `[:rf.machine/destroy :worker/imp#1]` aborts it (`:reason :actor-destroyed`, `:rf.http/aborted-on-actor-destroy` trace, clean registry).

The existing net (tests 1–6c) covers **declarative** `:spawn` only, so it cannot catch this widening. Verified the new test **errors** (poll-until-timeout — request never tracked) against the reverted registry form and **passes** against the marker form; the declarative net stays green throughout.

## Gates

- `npm run test:cljs` — 6255 tests, 0 failures / 0 errors
- http JVM `clojure -M:test` — 381 tests, 0 / 0
- machines JVM `clojure -M:test` — 609 tests, 0 / 0
- clj-kondo on both changed files — 0 errors, 0 warnings
- `api-manifest.gen --check` — in sync (498 public vars; `owning-actor-id` signature/classification unchanged, only internal semantics widened)

Closes rf2-n877mb.
