### PR TITLE
fix(marks): reject malformed :sensitive/:large declarations loudly (rf2-y7l5t5)

### DIFF
--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -86,16 +86,92 @@
 (defonce ^:private machine-id->schema-marks
   (atom {}))
 
+;; ---- malformed-declaration rejection (rf2-y7l5t5) ------------------------
+;;
+;; A `:sensitive` / `:large` declaration is a vector of output-path vectors
+;; (`[[:user :ssn] [:auth :token]]`; `[[]]` marks the whole value). The prior
+;; `coerce-paths` SILENTLY `(filter vector?)`-DROPPED any non-vector entry and
+;; coerced a non-collection whole to `[]`, so a hand-written typo —
+;; `:sensitive :token` (bare keyword), `:sensitive "blob"` (string),
+;; `:sensitive {…}` (map), or `:sensitive [:token]` / `[[:a [:b]]]` (a
+;; non-vector / non-scalar-element entry) — registered with NO error and NO
+;; mark. The author believes a path is redacted and it is NOT: the EP-0005
+;; armed-trap shape on the marks-ingestion side, the worst failure mode for a
+;; safety surface.
+;;
+;; We now REJECT LOUDLY at the ingestion boundary (`register-marks!` /
+;; `union-marks!`, called from the reg-* paths), mirroring the flows-side fix
+;; (rf2-cgk0wb, which rejects malformed `reg-flow` classification metadata with
+;; `:rf.error/flow-bad-marks` before any state mutates). Per the k0ew8n
+;; warn-vs-reject principle: there are ZERO legitimate non-vector entries and a
+;; correct spelling always exists (`[[:token]]`), so REJECT, not warn. The
+;; ex-info carries the canonical thrown-error shape (Spec 009 §The thrown-error
+;; shape) and names the offending key + value/entry so the author can fix it
+;; without a stack-trace dig.
+
+(defn- valid-mark-element?
+  "A mark path element is a scalar map key: keyword / string / integer /
+  symbol / boolean. A collection element is never a valid `get-in` step and
+  signals a caller bug (e.g. a nested-vector path `[[:a [:b]]]`)."
+  [x]
+  (or (keyword? x) (string? x) (integer? x) (symbol? x) (boolean? x)))
+
+(defn- valid-mark-subpath?
+  "A `:sensitive` / `:large` entry is a vector of scalar path elements. Unlike
+  a flow `:inputs` path the EMPTY vector `[]` is legal — it marks the whole
+  value (the `[[]]` convention)."
+  [x]
+  (and (vector? x) (every? valid-mark-element? x)))
+
+(defn- marks-error
+  "Build the malformed-marks ex-info with the canonical thrown-error shape
+  (per Spec 009 §The thrown-error shape). Mirrors `re-frame.flows.registry`'s
+  `flow-error`: `:rf.error/bad-marks` is the message AND the `:rf.error/id`
+  discriminator; `:bad-key` names the offending classification key; `extras`
+  merges the offending-value slot (`:bad-value` for a non-vector whole,
+  `:bad-entries` for malformed entries)."
+  [mark-key reason extras]
+  (ex-info (str :rf.error/bad-marks)
+           (merge {:rf.error/id :rf.error/bad-marks
+                   :where       'rf/reg-marks
+                   :recovery    :fix-registration
+                   :reason      reason
+                   :bad-key     mark-key}
+                  extras)))
+
 (defn- coerce-paths
   "Normalise a `:sensitive` / `:large` declaration value to a vector of
-  path vectors. `nil` becomes `[]`; any non-vector entry is dropped
-  (the declaration is best-effort — we tolerate hand-written maps that
-  passed an empty literal but want to log via `[[]]` for whole-value
-  marks)."
-  [paths]
-  (if (nil? paths)
-    []
-    (vec (filter vector? paths))))
+  path vectors. `nil` becomes `[]`. The whole value must be a vector and
+  every entry a vector of scalar path elements (`[[]]` for whole-value
+  marks); a malformed value or entry is REJECTED with `:rf.error/bad-marks`
+  rather than silently dropped (rf2-y7l5t5 — fail-loud, not fail-open).
+
+  `mark-key` (`:sensitive` / `:large`) names the offending key in the thrown
+  ex-data. The 1-arity form is for internal re-normalisation of already-stored
+  (well-formed) entries during a union; it uses the same validation so a
+  corrupted stored entry can never slip through silently."
+  ([paths] (coerce-paths paths :sensitive))
+  ([paths mark-key]
+   (cond
+     (nil? paths)
+     []
+
+     (not (vector? paths))
+     (throw (marks-error mark-key
+                         (str mark-key ", when present, must be a vector of "
+                              "output paths (each a vector of scalar keys; "
+                              "[] marks the whole value)")
+                         {:bad-value paths}))
+
+     (not (every? valid-mark-subpath? paths))
+     (throw (marks-error mark-key
+                         (str mark-key " entries must each be a vector of "
+                              "scalar keys (keyword / string / integer / "
+                              "symbol / boolean); [] marks the whole value")
+                         {:bad-entries (vec (remove valid-mark-subpath? paths))}))
+
+     :else
+     paths)))
 
 (defn- normalise-marks
   "Extract the mark-relevant subset of a registration meta-map and
@@ -114,8 +190,8 @@
             (contains? meta :sensitive?)
             (contains? meta :large?))
     (cond-> {}
-      (contains? meta :sensitive)  (assoc :sensitive  (coerce-paths (:sensitive meta)))
-      (contains? meta :large)      (assoc :large      (coerce-paths (:large meta)))
+      (contains? meta :sensitive)  (assoc :sensitive  (coerce-paths (:sensitive meta) :sensitive))
+      (contains? meta :large)      (assoc :large      (coerce-paths (:large meta) :large))
       (contains? meta :sensitive?) (assoc :sensitive? (boolean (:sensitive? meta)))
       (contains? meta :large?)     (assoc :large?     (boolean (:large? meta))))))
 

--- a/implementation/core/test/re_frame/marks_test.clj
+++ b/implementation/core/test/re_frame/marks_test.clj
@@ -194,6 +194,131 @@
     (fn [ctx] ctx))
   (is (= [[]] (:sensitive (marks/marks-for :cofx :auth/jwt)))))
 
+;; ---- malformed :sensitive / :large rejection (rf2-y7l5t5) ----------------
+;;
+;; A `:sensitive` / `:large` declaration is a vector of output-path vectors
+;; (`[[:user :ssn]]`; `[[]]` marks the whole value). The prior `coerce-paths`
+;; SILENTLY `(filter vector?)`-DROPPED any non-vector entry and coerced a
+;; non-collection whole to `[]`, so a typo (`:sensitive :token`, `"blob"`, a
+;; map, or a bare-keyword / nested-non-vector entry) registered with NO error
+;; and NO mark — the author believed a path was protected when it was NOT
+;; (EP-0005 armed-trap, marks-ingestion side). It now REJECTS LOUDLY with
+;; `:rf.error/bad-marks` before the marks table mutates — mirroring the
+;; flows-side fix (rf2-cgk0wb / `:rf.error/flow-bad-marks`).
+
+(defn- bad-marks-data
+  "Return the ex-data of the throw from `(register-marks! :event :probe meta)`,
+  or nil if it did not throw. `:probe` is left UNREGISTERED on success so the
+  same probe id can be reused across cases."
+  [meta]
+  (try
+    (marks/register-marks! :event :probe meta)
+    nil
+    (catch clojure.lang.ExceptionInfo e (ex-data e))))
+
+(deftest register-marks-rejects-bare-keyword-whole
+  (testing ":sensitive :token (a bare keyword, not a vector-of-paths) is rejected"
+    (let [data (bad-marks-data {:sensitive :token})]
+      (is (some? data) "register-marks! threw")
+      (is (= :rf.error/bad-marks (:rf.error/id data)) ":rf.error/id discriminator")
+      (is (= 'rf/reg-marks (:where data)))
+      (is (= :fix-registration (:recovery data)))
+      (is (= :sensitive (:bad-key data)) ":bad-key names the offending key")
+      (is (= :token (:bad-value data)) ":bad-value names the non-vector whole")
+      (is (nil? (marks/marks-for :event :probe)) "no marks stashed on rejection"))))
+
+(deftest register-marks-rejects-string-whole
+  (testing ":large \"blob\" (a string) is rejected with :bad-value"
+    (let [data (bad-marks-data {:large "blob"})]
+      (is (= :rf.error/bad-marks (:rf.error/id data)))
+      (is (= :large (:bad-key data)))
+      (is (= "blob" (:bad-value data)))
+      (is (nil? (marks/marks-for :event :probe))))))
+
+(deftest register-marks-rejects-map-whole
+  (testing ":sensitive {…} (a map) is rejected with :bad-value"
+    (let [data (bad-marks-data {:sensitive {:user :ssn}})]
+      (is (= :rf.error/bad-marks (:rf.error/id data)))
+      (is (= :sensitive (:bad-key data)))
+      (is (= {:user :ssn} (:bad-value data)))
+      (is (nil? (marks/marks-for :event :probe))))))
+
+(deftest register-marks-rejects-bare-keyword-entry
+  (testing ":sensitive [:token] (a bare-keyword entry, not a subpath vector) is rejected"
+    (let [data (bad-marks-data {:sensitive [:token]})] ; should be [[:token]]
+      (is (= :rf.error/bad-marks (:rf.error/id data)))
+      (is (= :sensitive (:bad-key data)))
+      (is (= [:token] (:bad-entries data)) ":bad-entries names the malformed entry")
+      (is (nil? (marks/marks-for :event :probe))))))
+
+(deftest register-marks-rejects-nested-non-vector-entry
+  (testing ":large [[:a [:b]]] (a non-scalar path element) is rejected"
+    (let [data (bad-marks-data {:large [[:a [:b]]]})]
+      (is (= :rf.error/bad-marks (:rf.error/id data)))
+      (is (= :large (:bad-key data)))
+      (is (= [[:a [:b]]] (:bad-entries data)) ":bad-entries names the malformed entry")
+      (is (nil? (marks/marks-for :event :probe)))))
+  (testing ":large [{}] (a map entry) is rejected"
+    (let [data (bad-marks-data {:large [{}]})]
+      (is (= :rf.error/bad-marks (:rf.error/id data)))
+      (is (= [{}] (:bad-entries data))))))
+
+(deftest register-marks-names-only-the-malformed-entry
+  (testing ":bad-entries carries ONLY the malformed entries, not the well-formed ones"
+    (let [data (bad-marks-data {:sensitive [[:ok] :bad [:also :ok]]})]
+      (is (= :rf.error/bad-marks (:rf.error/id data)))
+      (is (= [:bad] (:bad-entries data))
+          "the two well-formed vector entries are not listed"))))
+
+(deftest reg-event-db-rejects-malformed-marks-no-stash
+  ;; The rejection fires through the PUBLIC reg-* boundary too (register-marks!
+  ;; is called from reg-event-* / reg-sub / reg-fx / reg-cofx).
+  (testing "reg-event-db with a malformed :sensitive throws and stashes nothing"
+    (let [ex (try (rf/reg-event-db :malformed/evt
+                    {:sensitive [:password]} ; should be [[:password]]
+                    (fn [db _] db))
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex) "reg-event-db threw")
+      (is (= :rf.error/bad-marks (:rf.error/id (ex-data ex))))
+      (is (nil? (marks/marks-for :event :malformed/evt))
+          "no marks entry stashed for the rejected registration"))))
+
+(deftest reg-sub-rejects-malformed-marks
+  (testing "reg-sub with a malformed :large throws"
+    (let [ex (try (rf/reg-sub :malformed/sub
+                    {:large "blob"}
+                    (fn [_ _] {}))
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :rf.error/bad-marks (:rf.error/id (ex-data ex))))
+      (is (nil? (marks/marks-for :sub :malformed/sub))))))
+
+(deftest register-marks-accepts-whole-value-and-empty
+  ;; Regression guard: the tightened validator must NOT reject the legitimate
+  ;; whole-value mark `[[]]`, an empty declaration `[]`, or well-formed paths.
+  (testing "[[]] whole-value, [] empty, and ordinary paths all register cleanly"
+    (marks/register-marks! :event :wv {:sensitive [[]] :large [[:docs :csv]]})
+    (let [m (marks/marks-for :event :wv)]
+      (is (= [[]] (:sensitive m)) "[[]] whole-value mark accepted")
+      (is (= [[:docs :csv]] (:large m)) "ordinary path accepted"))
+    (marks/register-marks! :event :empty {:sensitive []})
+    ;; An empty :sensitive normalises to [] (no paths); the entry is dropped on
+    ;; read because it carries no marks — but it did NOT throw.
+    (is (nil? (:sensitive (marks/marks-for :event :empty)))
+        "an empty :sensitive vector is accepted (no throw, no paths)")))
+
+(deftest union-marks-rejects-malformed
+  (testing "union-marks! shares the coerce-paths chokepoint, so a malformed
+            added declaration is rejected too"
+    (marks/register-marks! :event :um {:sensitive [[:ok]]})
+    (let [ex (try (marks/union-marks! :event :um {:sensitive [:bad]})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :rf.error/bad-marks (:rf.error/id (ex-data ex))))
+      (is (= [[:ok]] (:sensitive (marks/marks-for :event :um)))
+          "the pre-existing well-formed entry is untouched by the rejected union"))))
+
 ;; ---- union-marks! — additive merge (rf2-w46fpt / EP-0005) ----------------
 ;;
 ;; The per-(kind, id) marks-table analogue of `add-marks` merging into the


### PR DESCRIPTION
## Summary

`re-frame.marks/coerce-paths` silently `(filter vector?)`-dropped any non-vector entry from a `:sensitive` / `:large` declaration (and coerced a non-collection whole to `[]`). A privacy/size declaration typo — `:sensitive :token` (bare keyword), `:sensitive "blob"` (string), `:sensitive {...}` (map), or `:sensitive [:token]` / `[[:a [:b]]]` (a non-vector / non-scalar-element entry) — registered with **no error and no mark**, so the author believed a path was redacted when it was **not**. That is the EP-0005 armed-trap shape on the marks-ingestion side — the worst failure mode for a safety surface (fail-open in a privacy declaration).

## Change

`coerce-paths` now **rejects loudly** at the ingestion boundary (`register-marks!` / `union-marks!`, called from the reg-event-* / reg-sub / reg-fx / reg-cofx paths) with the canonical thrown-error shape and a `:rf.error/bad-marks` discriminator, naming the offending key (`:bad-key`) and either the offending value (`:bad-value`, non-vector whole) or the offending entries (`:bad-entries`). The rejection fires **before** the marks table mutates, so nothing is stashed for a rejected registration.

This **mirrors the flows-side fix** (rf2-cgk0wb / `:rf.error/flow-bad-marks`). Per the k0ew8n warn-vs-reject principle — zero legitimate non-vector entries + a correct spelling always exists (`[[:token]]`) — the disposition is **reject, not warn**.

The `[[]]` whole-value mark and an empty `[]` declaration stay valid (regression-guarded).

## Tests

New regression tests in `marks_test.clj` covering every malformed shape the bead named plus the boundaries:
- bare keyword whole (`:sensitive :token`), string whole (`:large "blob"`), map whole
- bare-keyword entry (`[:token]`), nested-non-vector entry (`[[:a [:b]]]`), map entry (`[{}]`)
- `:bad-entries` names ONLY the malformed entries, not the well-formed ones
- rejection through the public `reg-event-db` / `reg-sub` boundary, with no stash on rejection
- `union-marks!` shares the chokepoint and rejects too, leaving the pre-existing entry untouched
- `[[]]` whole-value, `[]` empty, and ordinary paths still register cleanly (regression guard)

## spec/009

**Not touched.** `:rf.error/bad-marks` is a registration-time / dev-only validation error (dev-trace-only per 009 — it does not ride the always-on production error-emit listener), mirroring how the sibling flows fix landed `:rf.error/flow-bad-marks` uncatalogued. No automated gate enforces 009-catalogue membership. This also sidesteps any rebase against the concurrent dwme29 `:rf.mutation/*` 009 edits.

## Gates

- JVM core (`clojure -M:test`): 1060 tests / 4615 assertions, 0 failures, 0 errors
- `npm run test:cljs`: 6255 tests / 22460 assertions, 0 failures, 0 errors
- machine data-schema redaction JVM test: 18 tests / 60 assertions, 0 failures (schema-marks bridge unaffected)
- clj-kondo: 0 errors (pre-existing warnings only)
- No public/facade var touched (all new helpers are `defn-`), so the api-manifest gate does not apply.

Closes rf2-y7l5t5.
