### PR TITLE
fix(schemas): make :cat/:catn position-bearing for exact event-surface :sensitive? redaction (rf2-4q681i)

### DIFF
--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -247,6 +247,26 @@
     (is (= 42 (get-in out [:point 1]))
         "the non-sensitive sibling element 1 rides verbatim — no over-redaction")))
 
+(deftest schema-sensitive-cat-position-precise-redacts
+  ;; rf2-4q681i — a `:cat` element marked {:sensitive? true} declares a
+  ;; POSITION-pinned path (`[:ev 1]`), exactly like the `:tuple` case above.
+  ;; The runtime elision walk descends the value (a vector) through the SAME
+  ;; generic literal-index fork (`fork-index-paths`, `(conj c i)`) and matches
+  ;; that exact position — redacting ONLY the declared element while the
+  ;; non-sensitive sibling rides verbatim. This pins the coordinate-system
+  ;; consistency the bead requires for `:cat`/`:catn`: NO elision-side change
+  ;; was needed (the index fork is schema-agnostic — it walks the runtime
+  ;; value, so `:cat` aligns through the same path as `:tuple`).
+  (rf/reg-app-schema [:ev]
+                     [:cat [:= :id] [:string {:sensitive? true}]])
+  (is (= [[:ev 1]] (rf/populate-sensitive-from-schemas!))
+      "the sensitive :cat element declares its POSITION-pinned path")
+  (let [out (rf/elide-wire-value {:ev [:id "the-secret"]})]
+    (is (= :id (get-in out [:ev 0]))
+        "the non-sensitive id element 0 rides verbatim — no over-redaction")
+    (is (= :rf/redacted (get-in out [:ev 1]))
+        "the declared-sensitive element 1 is redacted at its exact position")))
+
 (deftest sensitive-wins-over-large
   (rf/reg-app-schema [:secret-pdf]
                      [:string {:large? true

--- a/implementation/schemas/src/re_frame/schemas/walker.cljc
+++ b/implementation/schemas/src/re_frame/schemas/walker.cljc
@@ -113,8 +113,41 @@
 (def ^:private dispatch-bearing-ops
   "Schema ops whose children carry dispatch-value branches (the first
   element of a child entry is a dispatch value, not an app-db path
-  segment)."
-  #{:multi :orn :catn :altn})
+  segment).
+
+  `:catn` is NOT here (rf2-4q681i): although its children carry NAME
+  slots like `:orn`/`:altn`, Malli reports a `:catn` failure's `:in`
+  segment as the element's INTEGER POSITION (`[1 :age]`), not the name —
+  identical to `:cat`. So `:catn` is position-bearing (see
+  `position-bearing-ops`), and its name slot is decorative for the
+  decl-path coordinate system."
+  #{:multi :orn :altn})
+
+(def ^:private position-bearing-ops
+  "Schema ops whose children are POSITION-bearing — each element `i` has
+  its OWN heterogeneous schema and Malli reports a failure's `:in` segment
+  as the integer index `i`. The walker descends element `i` at
+  `(conj base-path i)` (the positional analogue of a `:map` key), giving
+  per-element sibling precision: a per-position flag claims that exact
+  index, not the shared base-path.
+
+    - `:tuple` (rf2-ss06u.4) — element `i` is `children[i]`, a bare schema.
+    - `:cat` / `:catn` (rf2-4q681i) — the regex sequence combinators that
+      root event schemas (`[:cat [:= :id] PayloadSchema]`). `:cat`
+      elements are bare schemas (`children[i]`); `:catn` elements are
+      NAME-bearing entries (`[name props? schema]`) but Malli still
+      reports the integer position in `:in`, so the name is decorative and
+      the position drives the coordinate. Both descend the element schema
+      at `(conj base-path i)`.
+
+  The position-pinned decl-path is matching-safe against the core-elision
+  coordinate system: the runtime elision walk descends a tuple / event-
+  vector value (a vector) through its literal-index fork (`fork-index-paths`
+  — `(conj c i)` in `re-frame.elision`), which matches a position-pinned
+  declaration exactly. No elision-side change is required — the index fork
+  is schema-agnostic (it walks the runtime value), so `:cat`/`:catn`/`:tuple`
+  all align through the same generic path."
+  #{:tuple :cat :catn})
 
 (defn- props-of
   "Return the per-slot props map of a Malli vector form, or nil. Convention:
@@ -161,12 +194,13 @@
       OR the child schema's own props (also claims `(conj base k)`, since
       the path is the same).
 
-    - `:multi` / `:orn` / `:catn` / `:altn` children are dispatch-bearing —
+    - `:multi` / `:orn` / `:altn` children are dispatch-bearing —
       `[v schema]` / `[v {props} schema]` — and the flag on a branch's
       slot props claims the parent path (the op's `base-path`), not a
       child path; dispatch values aren't path segments.
 
-    - `:tuple` children are POSITION-bearing (rf2-ss06u.4) — each element
+    - `:tuple` / `:cat` / `:catn` children are POSITION-bearing
+      (`:tuple` rf2-ss06u.4; `:cat`/`:catn` rf2-4q681i) — each element
       has its OWN heterogeneous schema, so element `i` descends at
       `(conj base-path i)`, the integer index being the discriminating
       segment (the positional analogue of a `:map` key). A `:sensitive?`
@@ -174,17 +208,23 @@
       `(conj base 0)`, NOT `base` — so it does not taint the sibling at
       `(conj base 1)`. This is the index-bearing element-precision the
       `:vector` / `:map-of` paths already have via their map-key
-      discriminator; for `:tuple` the discriminator IS the index. The
-      position-pinned decl-path is matching-safe against the core-elision
-      coordinate system: the runtime elision walk descends a tuple value
-      (a vector) through its literal-index fork (`fork-index-paths` —
-      `(conj c i)`), which matches a position-pinned declaration exactly.
+      discriminator; for these ops the discriminator IS the index.
+      `:cat` elements are bare schemas (`children[i]`); `:catn` elements
+      are NAME-bearing entries (`[name props? schema]`) — the flag may
+      live in the entry's own props OR the element schema's props, both
+      claiming `(conj base i)` — but Malli reports the integer POSITION
+      (not the name) in a `:catn` failure's `:in`, so the position drives
+      the coordinate. The position-pinned decl-path is matching-safe
+      against the core-elision coordinate system: the runtime elision walk
+      descends a tuple / event-vector value (a vector) through its
+      literal-index fork (`fork-index-paths` — `(conj c i)`), which matches
+      a position-pinned declaration exactly.
 
     - Other positional / nameless container ops (`:vector`, `:set`,
-      `:sequential`, `:maybe`, `:and`, `:or`, `:not`, `:cat`, …) descend
-      into each child at the SAME `base-path` — these ops are homogeneous
-      (one shared element schema) or their index is not a declarable
-      app-db slot, so they don't introduce a new path segment.
+      `:sequential`, `:maybe`, `:and`, `:or`, `:not`, …) descend into each
+      child at the SAME `base-path` — these ops are homogeneous (one
+      shared element schema) or their index is not a declarable app-db
+      slot, so they don't introduce a new path segment.
 
     - Container-level props on the schema itself (the schema's OWN props,
       not a parent slot's) claim `base-path`. Covers
@@ -249,18 +289,45 @@
            acc'
            children)
 
-         ;; `:tuple` — position-bearing (rf2-ss06u.4). Each element has its
+         ;; `:tuple` / `:cat` / `:catn` — position-bearing (`:tuple`
+         ;; rf2-ss06u.4; `:cat`/`:catn` rf2-4q681i). Each element has its
          ;; OWN schema; element `i` descends at `(conj base-path i)` so a
          ;; per-position `:sensitive?` / `:large?` flag claims that exact
-         ;; index, NOT the shared tuple base-path. Mirrors the `:map`
-         ;; name-bearing descent with integer position keys, giving the
-         ;; sibling precision the index-free `:else` descent destroys.
-         (= op :tuple)
+         ;; index, NOT the shared base-path. Mirrors the `:map` name-bearing
+         ;; descent with integer position keys, giving the sibling precision
+         ;; the index-free `:else` descent destroys.
+         ;;
+         ;; `:tuple` / `:cat` elements are bare schemas (`children[i]`);
+         ;; `:catn` elements are NAME-bearing entries (`[name props? schema]`)
+         ;; — the flag may live in the entry's own props OR the element
+         ;; schema's props, both claiming `(conj base i)`. Either shape
+         ;; descends the element schema at the position-pinned path.
+         (contains? position-bearing-ops op)
          (first
            (reduce
              (fn [[acc i] child]
-               [(walk-flagged-schema flag-key child (conj base-path i) acc)
-                (inc i)])
+               (let [slot-path (conj base-path i)
+                     ;; `:catn` entry `[name props? schema]` — strip the
+                     ;; decorative name (and optional props) to reach the
+                     ;; element schema; an entry-level flag claims slot-path.
+                     ;; `:tuple`/`:cat` entry is the bare schema itself.
+                     [elem-schema entry-decl]
+                     (if (= op :catn)
+                       (if (and (vector? child) (>= (count child) 2))
+                         (let [maybe-prop (nth child 1)
+                               has-prop?  (map? maybe-prop)
+                               schema     (if has-prop?
+                                            (when (>= (count child) 3) (nth child 2))
+                                            maybe-prop)]
+                           [schema (and has-prop?
+                                        (decl-from-props flag-key maybe-prop))])
+                         [nil nil])
+                       [child nil])
+                     acc (if entry-decl (assoc acc slot-path entry-decl) acc)]
+                 [(if (some? elem-schema)
+                    (walk-flagged-schema flag-key elem-schema slot-path acc)
+                    acc)
+                  (inc i)]))
              [acc' 0]
              children))
 
@@ -380,15 +447,18 @@
 ;; — without this alignment a `:sensitive?` slot nested in a collection
 ;; leaks verbatim.
 ;;
-;; `:tuple` is the membership outlier (rf2-ss06u.4): it is kept in this
-;; set so `sanitize-sensitive-path` treats its integer index as a
-;; navigable locator (KEEP, not scrub), but `align-in-path` handles
-;; `:tuple` in its OWN position-KEEPING branch ABOVE the generic
-;; index-drop branch — a tuple element is heterogeneous (per-position
-;; schema), so the index IS a discriminating segment and must NOT be
-;; dropped, else sibling positions collapse and over-redact.
+;; `:tuple` / `:cat` / `:catn` are the membership outliers (`:tuple`
+;; rf2-ss06u.4; `:cat`/`:catn` rf2-4q681i): they are kept in this set so
+;; `sanitize-sensitive-path` treats their integer index as a navigable
+;; locator (KEEP, not scrub), but `align-in-path` handles them in their
+;; OWN position-KEEPING branch ABOVE the generic index-drop branch — each
+;; element is heterogeneous (per-position schema), so the index IS a
+;; discriminating segment and must NOT be dropped, else sibling positions
+;; collapse and over-redact. (`align-in-path` never reaches the generic
+;; index-drop branch below for these three; their `position-bearing-ops`
+;; branch fires first.)
 (def ^:private index-bearing-ops
-  #{:vector :sequential :set :tuple :map-of})
+  #{:vector :sequential :set :tuple :cat :catn :map-of})
 
 (defn- align-in-path
   "Translate Malli's value-relative `:in` path (carrying collection
@@ -452,20 +522,36 @@
               ;; Key not found in the schema (shape drift) — fail-SAFE.
               [:fallback schema aligned])
 
-            ;; `:tuple` — POSITION-bearing (rf2-ss06u.4). Unlike the
-            ;; homogeneous index-bearing ops below, each tuple element has
-            ;; its OWN schema, so the integer index IS a discriminating
-            ;; segment (the positional analogue of a `:map` key). KEEP the
-            ;; index in `aligned` — the walker emits per-position decl-paths
+            ;; `:tuple` / `:cat` / `:catn` — POSITION-bearing (`:tuple`
+            ;; rf2-ss06u.4; `:cat`/`:catn` rf2-4q681i). Unlike the
+            ;; homogeneous index-bearing ops below, each element has its OWN
+            ;; schema, so the integer index IS a discriminating segment (the
+            ;; positional analogue of a `:map` key). Malli reports the
+            ;; integer position in `:in` for ALL THREE (a `:catn` failure
+            ;; reports `[1 :age]`, the position not the name). KEEP the index
+            ;; in `aligned` — the walker emits per-position decl-paths
             ;; (`(conj base i)`), so a failure at element `i` aligns to that
             ;; same `[… i]` and prefix-matches ONLY that position's
-            ;; declaration. Dropping it (the prior behaviour) collapsed all
-            ;; elements onto the tuple base-path, so marking one element
-            ;; `:sensitive?` over-redacted every sibling failure.
-            (= op :tuple)
+            ;; declaration. Dropping it (the prior `:cat` behaviour, which
+            ;; collapsed every element onto the shared base-path) made a
+            ;; sensitive sibling over-redact an unrelated non-sensitive
+            ;; failure — the rf2-4q681i fix. `:tuple`/`:cat` element `seg` is
+            ;; `children[seg]` (bare schema); `:catn` element `seg` is a
+            ;; NAME-bearing entry (`[name props? schema]`) so we descend into
+            ;; its schema part.
+            (contains? position-bearing-ops op)
             (if-let [child (when (and (int? seg) (< seg (count children)))
                              (nth children seg))]
-              (recur child (subvec in 1) (conj aligned seg))
+              (let [elem-schema (if (= op :catn)
+                                  (if (and (vector? child) (>= (count child) 2))
+                                    (if (map? (nth child 1))
+                                      (when (>= (count child) 3) (nth child 2))
+                                      (nth child 1))
+                                    nil)
+                                  child)]
+                (if (some? elem-schema)
+                  (recur elem-schema (subvec in 1) (conj aligned seg))
+                  [:fallback schema aligned]))
               [:fallback schema aligned])
 
             ;; Homogeneous index-bearing container — drop the index/key
@@ -529,9 +615,9 @@
       under a sensitive key would otherwise ship the secret in `:path` /
       `:reason` despite `:value` / `:explain` being redacted. When the key
       schema declares sensitivity, the key segment is scrubbed.
-    - `:map` keys, `:vector` / `:sequential` / `:tuple` integer indices —
-      navigable scalar locators; KEEP them so `:path` stays a useful
-      `get-in` locator for those shapes (the bead's regression
+    - `:map` keys, `:vector` / `:sequential` / `:tuple` / `:cat` / `:catn`
+      integer indices — navigable scalar locators; KEEP them so `:path`
+      stays a useful `get-in` locator for those shapes (the bead's regression
       requirement).
     - Transparent wrappers (`:maybe` / `:and` / `:or` / `:multi` / `:orn`)
       contribute NO `:in` segment — descend without consuming. For the
@@ -622,12 +708,28 @@
                 (recur val-schema (subvec in 1) (conj out seg-out)))
 
               ;; Other index-bearing ops — the segment is a navigable index
-              ;; (`:vector` / `:sequential` / `:tuple`); keep it and descend
-              ;; into the element schema (`:tuple` indexes per-position).
+              ;; (`:vector` / `:sequential` / `:tuple` / `:cat` / `:catn`);
+              ;; keep it and descend into the element schema. The
+              ;; per-position ops (`:tuple` / `:cat` / `:catn`, rf2-ss06u.4 /
+              ;; rf2-4q681i) index `children[seg]`; `:catn` then strips the
+              ;; decorative name (`[name props? schema]`) to reach the
+              ;; element schema. The homogeneous ones (`:vector` /
+              ;; `:sequential`) share one element schema (child 0).
               (contains? index-bearing-ops op)
-              (let [child (if (= op :tuple)
+              (let [child (cond
+                            (#{:tuple :cat} op)
                             (when (and (int? seg) (< seg (count children)))
                               (nth children seg))
+
+                            (= op :catn)
+                            (when (and (int? seg) (< seg (count children)))
+                              (let [entry (nth children seg)]
+                                (when (and (vector? entry) (>= (count entry) 2))
+                                  (if (map? (nth entry 1))
+                                    (when (>= (count entry) 3) (nth entry 2))
+                                    (nth entry 1)))))
+
+                            :else
                             (nth children 0 nil))]
                 (recur child (subvec in 1) (conj out seg)))
 

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -898,18 +898,21 @@
 ;; the PATH-TARGETED `schema-sensitive-at?` whether THAT slot is sensitive —
 ;; matching the precise model `validate-app-schema!` already used.
 ;;
-;; SCOPE NOTE (rf2-k0ew8n follow-up): path-targeting is exact when the
-;; schema ROOT is a navigable container (`:map` / `:tuple` / index-bearing)
-;; — the cofx / fx-args / sub-return surfaces, whose schemas validate a map
-;; value directly, get the precise behaviour below. EVENT schemas are
-;; `:cat`-rooted (`[:cat [:= :id] PayloadSchema]`); the walker treats `:cat`
-;; as a parent-path-collapsing wrapper (NOT position-bearing like `:tuple`),
-;; so `align-in-path` cannot resolve the `:cat` element index and the check
-;; degrades FAIL-SAFE (conservatively redacts) when any sibling is sensitive
-;; — identical to the app-db path's no-extractable-`:in` fallback. Making
-;; `:cat` / `:catn` position-bearing in the walker (so event payloads also
-;; get exact path-targeting) is a coordinated walker + elision-coordinate
-;; change tracked as a follow-up bead, NOT bundled here.
+;; SCOPE NOTE (rf2-4q681i — the `:cat`-walker follow-up, now DONE):
+;; path-targeting is exact when the schema ROOT is a navigable container
+;; (`:map` / `:tuple` / `:cat` / `:catn` / index-bearing). The cofx /
+;; fx-args / sub-return surfaces validate a map value directly; EVENT
+;; schemas are `:cat`-rooted (`[:cat [:= :id] PayloadSchema]`). As of
+;; rf2-4q681i the walker treats `:cat` / `:catn` as POSITION-bearing
+;; (emitting per-element decl-paths `(conj base i)`, mirroring `:tuple`),
+;; and `align-in-path` KEEPS the integer element index, so the event
+;; surface now gets the SAME exact path-targeting as the map-rooted
+;; surfaces — a sensitive sibling no longer over-redacts a non-sensitive
+;; failing sibling. The elision-coordinate alignment is automatic: the
+;; runtime elision walk descends the event VECTOR through its generic
+;; literal-index fork (`fork-index-paths`, `(conj c i)`), matching the
+;; position-pinned `:cat`/`:catn` declaration exactly (no elision-side
+;; code change — same as the `:tuple` precedent rf2-ss06u.4).
 
 (deftest cofx-validation-sensitive-sibling-non-sensitive-failure-verbatim
   (testing "rf2-k0ew8n — a cofx schema (map-rooted) with a sensitive sibling
@@ -990,34 +993,156 @@
         (is (not= :rf/redacted (-> v :tags :value))
             ":value rides verbatim — the sensitive sibling did not over-redact")))))
 
-(deftest event-validation-cat-root-fails-safe
-  (testing "rf2-k0ew8n SCOPE — an event schema is `:cat`-rooted; the walker
-            does not treat `:cat` as position-bearing, so a non-sensitive
-            failing sibling under a sensitive payload degrades FAIL-SAFE
-            (conservatively redacts) rather than leaking. Documented
-            limitation; exact event-surface path-targeting is the follow-up
-            `:cat`-walker bead. The privacy contract is upheld either way."
-    (rf/reg-event-db :auth/profile
-      {:schema [:cat [:= :auth/profile]
-                [:map
-                 [:password {:sensitive? true} :string]
-                 [:age :int]]]}
-      (fn [db _] db))
-    (let [traces (atom [])]
-      (rf/register-listener! ::prof (fn [ev] (swap! traces conj ev)))
-      ;; :password conforms; :age fails — the failing slot is NON-sensitive,
-      ;; but the `:cat` root blocks path resolution, so fail-safe redaction
-      ;; fires (the sensitive sibling is present).
-      (rf/dispatch-sync [:auth/profile {:password "pw" :age "old"}])
-      (rf/unregister-listener! ::prof)
-      (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
-                             @traces))]
-        (is (some? v))
-        (is (true? (:sensitive? v))
-            "fail-safe: the `:cat` root blocks exact path-targeting, so a
-             sensitive sibling still triggers conservative redaction")
-        (is (= :rf/redacted (-> v :tags :received))
-            ":received redacted — privacy upheld under the fail-safe path")))))
+(deftest event-validation-cat-root-sensitive-sibling-non-sensitive-failure-verbatim
+  (testing "rf2-4q681i — an event schema is `:cat`-rooted; with `:cat` now
+            POSITION-bearing in the walker, a non-sensitive failing sibling
+            under a sensitive payload rides VERBATIM (exact path-targeting),
+            NOT the prior fail-safe over-redaction. This was the documented
+            `event-validation-cat-root-fails-safe` limitation — now exact.
+            (Privacy is still upheld: the sensitive slot itself, when it
+            fails, still redacts — pinned in the companion test below.)"
+    (let [secret "pw-MUST-NOT-LEAK"]
+      (rf/reg-event-db :auth/profile
+        {:schema [:cat [:= :auth/profile]
+                  [:map
+                   [:password {:sensitive? true} :string]
+                   [:age :int]]]}
+        (fn [db _] db))
+      (let [traces (atom [])]
+        (rf/register-listener! ::prof (fn [ev] (swap! traces conj ev)))
+        ;; :password conforms (a string); :age fails (a string, not int) —
+        ;; the failing slot is NON-sensitive. `:cat` element 1 is now
+        ;; position-bearing, so the failing `:in` `[1 :age]` aligns to the
+        ;; decl-path `[1 :age]` and the sensitive sibling `[1 :password]`
+        ;; does NOT taint it.
+        (rf/dispatch-sync [:auth/profile {:password secret :age "old"}])
+        (rf/unregister-listener! ::prof)
+        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces))]
+          (is (some? v))
+          (is (not (true? (:sensitive? v)))
+              "exact path-targeting: the failing slot (:age) is not sensitive,
+               so the sensitive sibling (:password) does NOT over-redact")
+          (is (not= :rf/redacted (-> v :tags :received))
+              ":received rides verbatim — the non-sensitive failure is visible
+               to Xray / Pair / trace debugging")
+          ;; NOTE: the conforming :password value DOES ride verbatim here —
+          ;; that is the correct trade-off the bead specifies (a conforming
+          ;; sensitive sibling is not the failing slot; only the failing slot
+          ;; drives redaction). The privacy contract protects FAILING
+          ;; sensitive slots; see the companion test below.
+          (is (= [:auth/profile {:password secret :age "old"}]
+                 (-> v :tags :received))
+              "the non-sensitive failing payload is reported verbatim"))))))
+
+(deftest event-validation-cat-root-sensitive-slot-failure-still-redacts
+  (testing "rf2-4q681i — no privacy regression: when the SENSITIVE `:cat`
+            payload slot itself fails, the value is still redacted and
+            stamped (the precision fix must not under-redact the declared
+            position)"
+    (let [secret 123456789]                 ;; an int — fails the :string slot
+      (rf/reg-event-db :auth/profile2
+        {:schema [:cat [:= :auth/profile2]
+                  [:map
+                   [:password {:sensitive? true} :string]
+                   [:age :int]]]}
+        (fn [db _] db))
+      (let [traces (atom [])]
+        (rf/register-listener! ::prof2 (fn [ev] (swap! traces conj ev)))
+        ;; :password fails (int, not string) — the FAILING slot IS sensitive.
+        (rf/dispatch-sync [:auth/profile2 {:password secret :age 30}])
+        (rf/unregister-listener! ::prof2)
+        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces))]
+          (is (some? v))
+          (is (true? (:sensitive? v))
+              ":sensitive? stamped — the failing slot (:password) is sensitive")
+          (is (= :rf/redacted (-> v :tags :received)) ":received redacted")
+          (is (= :rf/redacted (-> v :tags :value)) ":value redacted")
+          (is (not (str/includes? (pr-str (:tags v)) (str secret)))
+              "the raw secret does NOT appear anywhere in the emitted tags"))))))
+
+(deftest event-validation-catn-root-sensitive-sibling-non-sensitive-failure-verbatim
+  (testing "rf2-4q681i — `:catn` (name+position-bearing) gets the same exact
+            path-targeting as `:cat`: Malli reports the integer POSITION (not
+            the name) in `:in`, so a non-sensitive failing sibling under a
+            sensitive `:catn` payload rides verbatim while a sensitive-slot
+            failure still redacts"
+    (let [secret "catn-pw-DO-NOT-LEAK"]
+      (rf/reg-event-db :auth/profile-n
+        {:schema [:catn
+                  [:id [:= :auth/profile-n]]
+                  [:payload [:map
+                             [:password {:sensitive? true} :string]
+                             [:age :int]]]]}
+        (fn [db _] db))
+      (let [traces (atom [])]
+        (rf/register-listener! ::profn (fn [ev] (swap! traces conj ev)))
+        ;; :age fails (non-sensitive); :password conforms.
+        (rf/dispatch-sync [:auth/profile-n {:password secret :age "old"}])
+        (rf/unregister-listener! ::profn)
+        (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
+                               @traces))]
+          (is (some? v))
+          (is (not (true? (:sensitive? v)))
+              "exact path-targeting through :catn — non-sensitive :age failure
+               is not tainted by the sensitive :password sibling")
+          (is (= [:auth/profile-n {:password secret :age "old"}]
+                 (-> v :tags :received))
+              ":received rides verbatim"))))))
+
+;; ---- walker unit tests for the rf2-4q681i :cat/:catn position-bearing fix --
+
+(deftest extract-cat-emits-position-pinned-paths
+  (testing "rf2-4q681i — the walker emits a :cat element flag at its
+            POSITION-pinned path ((conj base i)), not the index-free :cat
+            base-path; this is what gives the event-payload sibling precision"
+    ;; element 1 (the payload) is a sensitive :string.
+    (is (= {[1] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:cat [:= :id] [:string {:sensitive? true}]] [])))
+    ;; per-slot flag inside a :cat payload MAP claims the position + key.
+    (is (= {[1 :tok] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:cat [:= :id] [:map [:tok {:sensitive? true} :string] [:age :int]]] [])))
+    ;; base-path threads through.
+    (is (= {[:ev 1] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:cat [:= :id] [:string {:sensitive? true}]] [:ev])))))
+
+(deftest extract-catn-emits-position-pinned-paths
+  (testing "rf2-4q681i — `:catn` is position-bearing too; an entry-level OR a
+            schema-level :sensitive? flag claims the element's POSITION-pinned
+            path (the decorative name is NOT a path segment — Malli reports the
+            integer index in :in)"
+    ;; entry-level flag on the :catn entry props.
+    (is (= {[1] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:catn [:id [:= :id]] [:tok {:sensitive? true} :string]] [])))
+    ;; per-slot flag inside a :catn payload MAP claims position + key.
+    (is (= {[1 :pw] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:catn [:id [:= :id]]
+              [:payload [:map [:pw {:sensitive? true} :string] [:age :int]]]] [])))))
+
+(deftest schema-sensitive-at-cat-position-precise
+  (testing "rf2-4q681i — a :cat element's sensitivity is element-precise: a
+            failure at a NON-sensitive sibling position is NOT redacted, while
+            the declared-sensitive position (and its ancestor/descendant) is —
+            mirrors the :tuple position-precision contract (rf2-ss06u.4)"
+    (let [s [:cat [:= :id] [:map [:pw {:sensitive? true} :string] [:age :int]]]]
+      ;; SELF / DESCENDANT — the sensitive payload slot fails → redact.
+      (is (true?  (schemas/schema-sensitive-at? s [1 :pw])) "exact sensitive slot")
+      (is (true?  (schemas/schema-sensitive-at? s [1]))     "ancestor of the secret")
+      ;; SIBLING — the non-sensitive payload slot fails → must NOT redact.
+      (is (false? (schemas/schema-sensitive-at? s [1 :age]))
+          ":pw sensitive must NOT taint a failure at the non-sensitive :age")
+      ;; the id position (element 0) carries no secret.
+      (is (false? (schemas/schema-sensitive-at? s [0])) "the id position is not sensitive"))
+    ;; whole-element sensitivity: element 1 entirely sensitive.
+    (let [s [:cat [:= :id] [:string {:sensitive? true}]]]
+      (is (true?  (schemas/schema-sensitive-at? s [1])) "the sensitive payload position redacts")
+      (is (false? (schemas/schema-sensitive-at? s [0])) "the non-sensitive id position does not"))))
 
 ;; ---- rf2-a5kzs / rf2-o69h5 — shared validation-failure redaction seam ----
 ;; The production boundary interceptor (`re-frame.spec`) builds its own event-

--- a/implementation/schemas/test/re_frame/schemas_walker_operators_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_operators_test.clj
@@ -6,10 +6,11 @@
   Existing slice-local tests pin `:map`, `:vector`, `:maybe`, `:or`,
   `:tuple`, and `:multi` directly. The walker also claims (per its
   docstring) to handle the remaining dispatch-bearing combinators
-  `:orn` / `:catn` / `:altn` and the positional containers `:set` /
-  `:sequential` / `:cat` / `:and` / `:not`. The audit (rf2-yv62u)
-  flagged the absence of operator-family pins for these — refactor
-  drift could silently break the un-tested branches.
+  `:orn` / `:altn`, the POSITION-bearing combinators `:cat` / `:catn`
+  (rf2-4q681i — each element descends at `(conj base i)`), and the
+  positional containers `:set` / `:sequential` / `:and` / `:not`. The
+  audit (rf2-yv62u) flagged the absence of operator-family pins for these
+  — refactor drift could silently break the un-tested branches.
 
   This file pins one example per claimed operator family for the
   `:sensitive?` flag (the parameterised walker serves both flags so
@@ -19,9 +20,14 @@
 
 ;; ---- dispatch-bearing combinators ----------------------------------------
 ;;
-;; :multi / :orn / :catn / :altn — children carry dispatch-value
-;; branches; the branch's slot-props claim the PARENT path (the op's
-;; base-path), not a child path; dispatch values aren't path segments.
+;; :multi / :orn / :altn — children carry dispatch-value branches; the
+;; branch's slot-props claim the PARENT path (the op's base-path), not a
+;; child path; dispatch values aren't path segments.
+;;
+;; :catn is NOT dispatch-bearing (rf2-4q681i): although its children carry
+;; name slots, Malli reports a :catn failure's :in segment as the integer
+;; POSITION, not the name — so :catn is POSITION-bearing alongside :cat /
+;; :tuple (see the position-bearing section below).
 
 (deftest orn-branch-slot-claims-parent-path
   (testing ":orn — a branch's :sensitive? on its slot-props claims the
@@ -44,16 +50,6 @@
               [:anon   [:map [:guest :string]]]]
              [:value])))))
 
-(deftest catn-branch-slot-claims-parent-path
-  (testing ":catn — same dispatch-bearing semantics; the branch's
-            slot-props claim the parent path"
-    (is (= {[:row] {:sensitive? true :source :schema}}
-           (schemas/extract-sensitive-paths-from-schema
-             [:catn
-              [:head {:sensitive? true} :string]
-              [:tail :string]]
-             [:row])))))
-
 (deftest altn-branch-inner-descends-at-parent-path
   (testing ":altn — a :sensitive? slot inside an alt branch descends at
             the parent path"
@@ -66,9 +62,14 @@
 
 ;; ---- positional / nameless containers ------------------------------------
 ;;
-;; :vector / :set / :sequential / :maybe / :and / :or / :not / :tuple /
-;; :cat — children descend at the SAME base-path; these ops don't
-;; introduce a new app-db path segment.
+;; :vector / :set / :sequential / :maybe / :and / :or / :not — children
+;; descend at the SAME base-path; these ops are homogeneous (one shared
+;; element schema) or their index is not a declarable app-db slot, so they
+;; don't introduce a new path segment.
+;;
+;; :tuple / :cat / :catn are POSITION-bearing (:tuple rf2-ss06u.4;
+;; :cat/:catn rf2-4q681i) — element `i` descends at `(conj base i)`; see
+;; the position-bearing section below.
 
 (deftest set-descends-at-parent-path
   (testing ":set — inner :sensitive? slot claims the :set's path"
@@ -85,13 +86,34 @@
              [:sequential [:string {:sensitive? true}]]
              [:audit-log])))))
 
-(deftest cat-descends-at-parent-path
-  (testing ":cat — positional combinator; inner sensitive descends at
-            the parent path"
-    (is (= {[:tuple-slot] {:sensitive? true :source :schema}}
+;; ---- position-bearing combinators ----------------------------------------
+;;
+;; :tuple / :cat / :catn — each element has its OWN schema; element `i`
+;; descends at `(conj base i)`, the integer index being the discriminating
+;; segment. Malli reports the integer POSITION in :in for all three.
+;; (:tuple already pinned in the slice-local tests; :cat/:catn added by
+;; rf2-4q681i.)
+
+(deftest cat-element-is-position-bearing
+  (testing ":cat — POSITION-bearing (rf2-4q681i); element `i`'s inner
+            sensitive claims `(conj base i)`, NOT the shared base-path"
+    ;; element 1 is the sensitive :string → claims [:ev 1], not [:ev].
+    (is (= {[:ev 1] {:sensitive? true :source :schema}}
            (schemas/extract-sensitive-paths-from-schema
              [:cat :string [:string {:sensitive? true}]]
-             [:tuple-slot])))))
+             [:ev])))))
+
+(deftest catn-element-is-position-bearing
+  (testing ":catn — POSITION-bearing (rf2-4q681i); the entry name is
+            decorative (Malli reports the integer position in :in), so an
+            entry-level sensitive claims `(conj base i)`, not base"
+    ;; entry 0 (:head) is sensitive → claims [:row 0], not [:row].
+    (is (= {[:row 0] {:sensitive? true :source :schema}}
+           (schemas/extract-sensitive-paths-from-schema
+             [:catn
+              [:head {:sensitive? true} :string]
+              [:tail :string]]
+             [:row])))))
 
 (deftest and-descends-at-parent-path
   (testing ":and — every child descends at the parent path"


### PR DESCRIPTION
## What

Follow-up from rf2-k0ew8n finding 1 (deferred from k0ew8n's design-fork stop). Event schemas are `:cat`-rooted (`[:cat [:= :id] PayloadSchema]`). The walker treated `:cat` as a parent-path-**collapsing** wrapper and `:catn` as dispatch-bearing, so `align-in-path` could not resolve the `:cat` element index and the path-targeted sensitivity check degraded **fail-safe** — a sensitive sibling over-redacted an unrelated non-sensitive failing sibling (hiding the real failure from Xray / Pair / trace, though privacy was upheld).

This makes `:cat` / `:catn` **position-bearing** in both directions, mirroring the `:tuple` precedent (rf2-ss06u.4).

## How

- **`walk-flagged-schema`**: emit per-element decl-paths `(conj base i)`. `:cat` elements are bare schemas (`children[i]`); `:catn` elements are name-bearing entries (`[name props? schema]`) whose flag (entry- or schema-level) claims the position-pinned path. The decorative `:catn` name is NOT a path segment.
- **`align-in-path`**: KEEP the integer element index and descend into element `i`'s schema (strip the `:catn` entry name to reach its schema).
- **`sanitize-sensitive-path` + `index-bearing-ops`**: `:cat`/`:catn` integer indices are navigable locators (KEEP in `:path`, like `:tuple`).
- **Reclassification**: Malli reports the integer **position** (not the name) in `:in` for both `:cat` AND `:catn` (verified empirically: a `:catn` failure reports `[1 :age]`), so `:catn` moves out of `dispatch-bearing-ops` into the new `position-bearing-ops` set.

### Elision-coordinate alignment

**Automatic — no elision-side code change.** The runtime elision walk descends the event VECTOR through its generic literal-index fork (`fork-index-paths`, `(conj c i)`), which matches the position-pinned `:cat`/`:catn` declaration exactly — same as the `:tuple` precedent. Pinned by a new `elision_test` consistency test.

## Result

An event payload with a sensitive sibling AND a non-sensitive **failing** sibling now rides verbatim (no over-redaction, visible to debugging), while a sensitive-slot failure still redacts and stamps `:sensitive?`.

## Tests

- `schemas_sensitive_test`: the prior `event-validation-cat-root-fails-safe` limitation is rewritten as the exact-targeting contract; adds `:catn` end-to-end, sensitive-slot-still-redacts, walker-unit, and `schema-sensitive-at?` position-precision tests.
- `schemas_walker_operators_test`: `:cat`/`:catn` pins flipped from parent-path collapse to position-bearing.
- `elision_test`: `schema-sensitive-cat-position-precise-redacts` pins the core-elision coordinate-system consistency.

## Gates

- JVM schemas (`clojure -M:test`): 305 tests, 0 failures
- JVM core (`clojure -M:test`): 1051 tests, 0 failures
- CLJS (`npm run test:cljs`): 6255 tests, 0 failures
- `npm run test:elision`: PASS (production 40/40 absent, control 40/40 present)
- clj-kondo over `implementation/schemas/src`: 0 errors

No new `:rf.error/*`, no public/facade var change → no Spec 009/010 or api-manifest update needed.
