### PR TITLE
docs(guide): four mental-model sections distilling the fold model (rf2-rj68xn)

### DIFF
--- a/docs/guide/04-events-and-the-cascade.md
+++ b/docs/guide/04-events-and-the-cascade.md
@@ -160,6 +160,40 @@ Reagent re-runs the body. `@(subscribe [:counter/value])` now returns `6`. The n
 
 One event, six dominoes, the app stays consistent the whole way. That's the machine. Every event your app ever sees walks this exact path.
 
+## The ledger view
+
+Here's a way of seeing app-db that, once it clicks, reorganises how you think about the whole app. The reflex picture of state is a *whiteboard*: there's a current drawing, an event walks up and erases part of it and draws something new, and the old drawing is gone forever. That picture is wrong, and it's wrong in a way that costs you. The right picture is a **ledger**.
+
+A ledger doesn't get erased. Each line is an entry — a debit, a credit — appended to the ones before it, and the balance you read at the bottom is simply *what you get by adding every line up, in order*. Your app works exactly like that. Every event you dispatch is a ledger line. The app-db you see at any moment is not a thing that was edited in place; it's the **running total** — the result of starting from your initial state and applying every event since, one after another, in the order they happened. Domino 2 isn't "erase and redraw." It's "add the next line and re-total."
+
+That reframing comes with a promise precise enough to test:
+
+> **Two fresh apps, fed the same sequence of events, finish in identical states.** Start two copies from the same initial app-db, replay the same event log into each, and they land on the same value — byte for byte. The events *are* the state; the current app-db carries no information the log didn't put there.
+
+(That promise has one precondition, and it's important enough to be the subject of its own section in the next chapter: the handlers have to be honest about their inputs. A handler that secretly reads the clock or a random id smuggles in a value the ledger never recorded, and then replaying the ledger no longer reproduces the state. [Chapter 07 — Why handlers never read the clock](07-effects-and-coeffects.md#why-handlers-never-read-the-clock) is how you keep the promise true.)
+
+Once you see app-db as the sum of a ledger rather than the current whiteboard, a cluster of features stops looking like separate clever tricks and starts looking like one consequence stated three ways:
+
+- **Time-travel is just re-totalling fewer lines.** "Go back five events" isn't an undo command that has to reverse five mutations — there were no mutations to reverse. It's "re-total the ledger up to line *n−5*." The earlier state was always recoverable because the earlier state is just a shorter sum.
+- **A bug report is a ledger excerpt.** "It broke after I did these things" stops being a vague prose paragraph and becomes the literal list of events that produced the bad state. Hand that excerpt to a fresh app and you get the bug back, on demand. ([Chapter 13](13-testing.md#replay-is-a-test) turns exactly this into a regression test.)
+- **The Xray timeline *is* the ledger, drawn.** When a tool shows you "here's every event that fired, in order, and here's the app-db after each," it isn't inventing a new view of your app — it's just rendering the ledger you've been accumulating all along. ([Chapter 16](16-observability.md#epochs-as-state-over-time) is the surface that records it; [chapter 17](17-tooling.md#xray-answers-what-happened) is the tool that draws it.)
+
+None of these needed a special subsystem bolted on. They fell out, for free, the moment state became "the sum of an event log" instead of "the current contents of a box."
+
+<details markdown="1">
+<summary>For the categorically curious</summary>
+
+The whole app is a **left fold** (a `reduce`) over the event stream: a *step function* — `state' = step(state, event)` — applied once per event, threading the new state into the next call. Your handlers are that step function; the runtime is the `reduce`. In three lines:
+
+```clojure
+(defn step  [state event] (apply-handler state event))   ;; one domino-2 transition
+(defn app-state-at [initial events]
+  (reduce step initial events))                            ;; the whole app, summed
+```
+
+A machine of this exact shape — output a function of *current state and current input only* — is a **Moore machine**; "the state is the fold of the inputs" is the same statement said two ways.
+</details>
+
 ## The cascade, made visible
 
 The dominoes are easy to *say* and easy to nod along to. They land harder when you watch them fire. So here's a counter that keeps a running **log of its own cascade** in app-db — every event appends a row recording what it did — and a view that prints the log underneath the buttons. There's no special trace API in play here; this is just the chapter's own point turned into code: because every state change goes through a handler, and every handler is pure, you can record the cascade *as ordinary app-db state* and read it back like anything else.

--- a/docs/guide/07-effects-and-coeffects.md
+++ b/docs/guide/07-effects-and-coeffects.md
@@ -238,6 +238,43 @@ This is the payoff that makes the ceremony worth it. A handler that injects `:no
 
 The stubs aren't mocks — they live in the *same registry* as the production handlers, addressed by the *same keyword id*, and `inject-cofx` finds the re-registered version with no special test-mode flag. `with-fresh-registrar` snapshots the registrar around the body and restores on exit, so production `:now` is intact for the next test (skip it and you've got the classic "passes alone, fails together" bug). And the handler-under-test never knew it was being tested — same shape in production and in the test, only the injected value changed. [Chapter 13](13-testing.md) walks the full testing surface; this is the shape it's built on.
 
+### Why handlers never read the clock
+
+You now know the *mechanism* — `reg-cofx` quarantines an impure read, `inject-cofx` delivers its value. What's worth pinning down is the *reason*, because it's bigger than "purity is nice," and it reaches back into [chapter 04](04-events-and-the-cascade.md#the-ledger-view).
+
+That chapter made a promise: app-db is the running total of an event ledger, and **two fresh apps fed the same event log finish in identical states.** Re-read that and notice what it quietly requires. For the same log to reproduce the same state, *the only thing a handler is allowed to consult is its inputs* — the db and the event that the ledger recorded. The moment a handler calls `(js/Date.now)` in its body, it has consulted something the ledger *never wrote down*. The state it produces now depends on the wall clock, which isn't in the log. Replay the log tomorrow and you get a different answer. **The handler smuggled in an input the ledger never recorded, and so replaying the ledger lies.** The clock is the most common smuggler — random ids and `localStorage` reads are the same crime in a different coat.
+
+The fix is the cofx you already learned, seen now through the ledger lens: the clock stops being something the handler *reaches out and grabs* and becomes a **declared input** — a value the runtime puts on the way in, exactly as if it had ridden the event. Here is the same handler before and after, read for honesty rather than for testability:
+
+```clojure
+;; ❌ BROKEN REPLAY — the clock is an ambient read the ledger never recorded.
+;;    Replay this event tomorrow and :created-at is tomorrow's date. The log lies.
+(rf/reg-event-db :todo/add
+  (fn [db [_ title]]
+    (assoc-in db [:todos] {:title title :created-at (js/Date.)})))
+
+;; ✅ HONEST REPLAY — the clock is a declared input the runtime delivers.
+;;    Replay re-presents the same :now, so the same log reproduces the same state.
+(rf/reg-cofx :now
+  (fn [ctx] (assoc-in ctx [:coeffects :now] (js/Date.))))
+
+(rf/reg-event-fx :todo/add
+  [(rf/inject-cofx :now)]
+  (fn [{:keys [db now]} [_ title]]
+    {:db (assoc-in db [:todos] {:title title :created-at now})}))
+```
+
+The difference isn't style. The broken version *cannot* be replayed, restored, or reliably tested; the honest version can, because every fact it used to compute its output is a fact the runtime can re-supply. Two concrete things this buys, one each side of the seam:
+
+- **Time-travel actually travels.** Restore the app to an earlier point ([chapter 16](16-observability.md#epochs-as-state-over-time)) and re-run the log forward, and a handler that read the *ambient* clock makes a decision keyed to whatever `now` happened to be the first time — a decision the restored run can't reproduce, because that instant is gone. The cofx handler re-runs against the *same* injected `now` and lands in the *same* state. Restore stops being a best-effort approximation and becomes exact.
+- **The 23:59:59 test stops flaking.** A handler that reads `(js/Date.)` to decide "is this due today?" is green every afternoon you run it and red the one time CI happens to run it as the date rolls over at midnight — a failure nobody can reproduce because it depends on the second the suite ran. Inject the clock and the test *supplies* it; "due today" is computed against a fixed `now` you chose, and the test means the same thing at 14:00 and at 23:59:59. ([Chapter 13 — Replay is a test](13-testing.md#replay-is-a-test) tells that war story in full.)
+
+<details markdown="1">
+<summary>For the categorically curious</summary>
+
+A handler is a **pure function of an explicit world**: every input it depends on is a named argument it was handed, never a value it reached out and read. The clock is part of that world *value* — it arrives as a field the runtime supplies — never an *ambient* the function dips into behind the caller's back. "Ambient" is the word for a value read from outside the argument list; the whole cofx discipline is the rule that the world has no ambients, only declared inputs.
+</details>
+
 ### When the ceremony isn't worth it — the inline escape hatch
 
 `reg-cofx` + `inject-cofx` is the canonical path, and most of the time it's right. But it isn't the *only* legal way to put a value in the coeffects map. `inject-cofx` is just an interceptor, and the interceptor primitive ([chapter 09](09-interceptors.md)) is open — any map of the shape `{:id <id> :before (fn [ctx] ...)}` is a legal participant in an event's interceptor vector, and if its `:before` happens to `assoc-in` something under `[:coeffects k]`, the handler reads it identically.

--- a/docs/guide/10-http.md
+++ b/docs/guide/10-http.md
@@ -52,6 +52,20 @@ Two lines of fx and not one of them mentions the network. No decode (the default
 
 That co-location — request and reply living in one handler — is the reason `:rf.http/managed` exists at all instead of "register your own `:http` fx and invent your own conventions like everyone always did." It makes the shape *uniform across every app that uses it*. And uniformity, it turns out, is the entire point. Hold that thought; I'm going to earn it.
 
+> ### Why there is no `await`
+>
+> You may have noticed something missing. There is no `await` here, no resumed coroutine, no point where execution *pauses mid-handler* until the server answers and then picks up where it left off. That's not an oversight — it's the design, and it's worth one paragraph of *why*, because it explains the whole reply-as-event shape you just saw.
+>
+> In re-frame2 **a reply is an event, not a resumed stack frame.** An `await` would suspend the handler and hand it back the server's value *inside the same call* — and that value would arrive through the call stack, a place nothing else in your app can see. But [chapter 04](04-events-and-the-cascade.md#the-ledger-view) was firm that app-db is the sum of an event ledger, and the ledger has to contain *everything that ever influenced state*. An awaited value bypasses the ledger entirely: it slips into the handler through the stack, leaving no line. A **reply event lands in the ledger** like any other event — so it shows up in traces, it survives being serialized and shipped, it routes to the right frame, and replaying the log reproduces it.
+>
+> Read today's idiom through that lens and it stops looking like ceremony. The `:on-success` / `:on-failure` vectors (and the default co-located `:rf/reply`) are *the continuation expressed as data* — "when this finishes, dispatch this." Because the continuation is a value rather than a paused stack, it's visible on the trace stream, it can be recorded and replayed, and it carries its own frame. This is the same choice [Elm](https://elm-lang.org) makes with `Cmd msg`: the result of an effect comes back as a *message you handle*, never as a value you `await`. The continuation being data is exactly what lets the rest of this chapter's machinery — abort, retry, frame-aware reply addressing, stale-suppression — see and manage the in-flight work at all.
+>
+> <details markdown="1">
+> <summary>For the categorically curious</summary>
+>
+> Effects here are a **description the runtime interprets**, not commands the handler runs — your handler returns a value that *names* the work, and a separate interpreter performs it. Such effects **sequence but never bind**: you can ask for several in order (the `:fx` vector), but a handler can never write "do this effect, *then* feed its result into the next expression" — that would be monadic *binding*, the awaited-value shape. The result instead comes back as the next event. Continuations are events; binding is forbidden on purpose, and that's why there's no `await`.
+> </details>
+
 ## Why this exists at all (a short history of everybody reinventing the same thing)
 
 Here's the embarrassing part: we kept *rewriting this*. Every re-frame v1 app anyone shipped, every consulting codebase anyone audited, every open-source app anyone cribbed from — same five lines of homemade `:http` fx, registered fresh in every project, with subtly different opinions quietly baked in. [Chapter 07 sketches](07-effects-and-coeffects.md) how you'd register your own fx that calls `fetch` and dispatches a follow-up event. That works! It's a fine exercise! It is also the exact thing every single team reinvented, and every team's version drifted in a *slightly* different direction on the same handful of questions:

--- a/docs/guide/13-testing.md
+++ b/docs/guide/13-testing.md
@@ -219,6 +219,43 @@ Two things are quietly doing the heavy lifting.
 
 `:fx-overrides` **redirects an effect for the length of one dispatch.** And here's the subtle, important part: it is a *redirect*, not a mock. The exact same dispatch shape that the real `:rf.http/managed` would produce lands in your override fn. You're not faking the HTTP layer; you're intercepting the one effect that would have touched the network and answering it inline. No JSDOM, no fake fetch, no service-worker theatre. The seam, used exactly as designed.
 
+## Replay is a test
+
+There's a mental model hiding in everything above, and naming it makes a whole class of tests obvious. [Chapter 04](04-events-and-the-cascade.md#the-ledger-view) taught that app-db is the running total of an event ledger, and that *two fresh apps fed the same event log finish in identical states*. A test is just the second of those two apps. You start a fresh frame, you feed it a sequence of events, and you assert on the total. **Driving events through `dispatch-sync` and asserting on the result isn't merely *one way* to test — it's replaying the ledger and checking the sum.** That's why the dispatch-driven tests above feel so natural: they're the framework's own definition of state, run on demand.
+
+Two payoffs fall straight out of seeing it this way.
+
+**The flaky test that couldn't flake.** Here's the war story, and you've probably lived a version of it. A handler decides "is this item due?" by reading the ambient clock — `(js/Date.)` straight in the body. The test is green every afternoon for months. Then one night CI runs as the date rolls past midnight, the clock the handler read is now *tomorrow*, the "due today" branch flips, and the suite goes red — once, irreproducibly, in a way nobody can pin down because it depended on the wall-clock second the test happened to run. The fix is the cofx version from [chapter 07](07-effects-and-coeffects.md#why-handlers-never-read-the-clock): inject `:now` so the clock is a *declared input*, and then the test **supplies** it. The cofx version literally cannot flake on time, because there's no ambient time left to read — the test handed the handler a fixed `now`, and a fixed input gives a fixed answer at 14:00 and at 23:59:59 alike:
+
+```clojure
+(deftest due-today-is-deterministic
+  (ts/with-fresh-registrar
+    (rf/reg-cofx :now
+      (fn [ctx] (assoc-in ctx [:coeffects :now] #inst "2026-06-15T09:00:00.000Z")))
+    (rf/with-new-frame [f (rf/make-frame {})]
+      (rf/dispatch-sync [:item/add {:title "ship it" :due #inst "2026-06-15T17:00:00.000Z"}])
+      (rf/dispatch-sync [:item/recompute-due])
+      (is (true? (-> (rf/app-db-value f) :items first val :due-today?))))))
+```
+
+**The bug report that became the regression test.** A user reports a wrong state and tells you what they did: added two items, marked one done, undid it, filtered. That description *is* an event log — `[[:item/add ...] [:item/add ...] [:item/done 1] [:item/undo] [:filter/set :active]]`. To turn the report into a test you don't need a "capture API" or any special machinery: you write those event vectors into a fresh frame, dispatch them in order, and assert the final state is the *correct* one. The replay reproduces the bug today; once you fix the handler, the same replay reproduces the *fix*, and the report has become a permanent regression guard:
+
+```clojure
+(deftest issue-412-undo-leaves-stale-filter
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:app/init]})]
+    (ts/dispatch-sequence [[:item/add {:id 1 :title "a"}]
+                           [:item/add {:id 2 :title "b"}]
+                           [:item/done 1]
+                           [:item/undo]
+                           [:filter/set :active]]
+                          {:frame f})
+    ;; the bug: undo left the count stale. Assert the value it SHOULD be.
+    (is (= 2 (count (:items (rf/app-db-value f)))))
+    (is (= :active (:filter (rf/app-db-value f))))))
+```
+
+That's the whole technique, and it uses nothing you haven't already met: event vectors (the ledger lines), `dispatch-sync` / `dispatch-sequence` (the replay), and a `get-in` against the resulting app-db (the sum). A bug report is a ledger excerpt; a regression test is that excerpt replayed with the right answer pinned. The ledger view from chapter 04 wasn't a metaphor — it's the test you just wrote.
+
 ## The other seam: state-correct but view-broken
 
 Everything so far drove events and read `app-db`. That's the bulk of what you test, and it's where the bulk of the bugs are. But two species of bug live in the gap *between* a correct `app-db` and the screen, and no amount of state-assertion will catch them:


### PR DESCRIPTION
Adds four short mental-model sections to existing guide chapters (rf2-rj68xn), distilling the first-principles fold model into everyday developer payoffs. Each section teaches **why a shipped idiom exists**, not the mechanism the chapter already covers.

## The four sections

- **ch.04 — "The ledger view"** — app-db is the running total of an event ledger, not a whiteboard erased and redrawn. The testable promise: two fresh apps fed the same event log finish in identical states. Payoffs (one sentence each): time-travel is re-totalling fewer lines; a bug report is a ledger excerpt; the Xray timeline *is* the ledger drawn. CT callout: the left fold / Moore machine with `(reduce step initial events)`.
- **ch.07 — "Why handlers never read the clock"** — the ch.04 ledger promise only holds if handlers are functions of their recorded inputs; an ambient `(js/Date.)` smuggles in an input the ledger never wrote down, so replay lies. Teaches the **shipped** `reg-cofx :now` / `inject-cofx` idiom as the honest answer, before/after. Two consequences: time-travel restore becomes exact; the 23:59:59 flaky test stops flaking. CT callout: a handler is a pure function of an explicit world; the clock is part of the world value, never an ambient.
- **ch.10 — "Why there is no `await`" box** (shorter) — a reply is an EVENT, not a resumed stack frame; an awaited value bypasses the ledger, a reply event lands in it. Reads today's `:on-success` / `:rf/reply` idiom through the principle (continuation is data — serializes, traces, replays). Permitted body-prose Elm aside (`Cmd msg`). CT callout: effects are a description the runtime interprets; effects sequence but never bind.
- **ch.13 — "Replay is a test"** (short, links ch.04 + ch.07) — dispatch-driven tests *are* ledger replay. The flaky-clock war story, fixed because the test supplies the clock via cofx. Replay-a-bug: a bug report is an event log; write the event vectors into a fresh frame, `dispatch-sequence`, assert the correct final state. Uses only shipped surfaces (event vectors + `dispatch-sync`/`dispatch-sequence`); no capture API invented.

## Binding rules honoured

- **Translate, don't transplant** — category-theory vocabulary appears *only* inside the collapsible "For the categorically curious" callouts (reusing the existing AUTHORING.md device, not redefined); chapter bodies are plain-language payoff prose.
- **Payoffs, not mechanisms** — the chapters already teach cofx, managed HTTP, dispatch-testing; these sections add the *why-the-idiom-exists* reason and cross-link rather than re-teach (per the bead's overlap check).
- **Ship-now truths only** — no EP-0010..0014 vocabulary anywhere; every idiom shown is a shipped surface so future EP graduations are vocabulary swaps, not re-educations.

## Scope

- Edits exactly the four named chapter body files. **AUTHORING.md and the mkdocs nav are untouched** (1artjc landed both; this PR only reuses the CT-callout device). No new pages; no `spec/` or `implementation/` changes.

## Gates

- `python scripts/check_doc_slugs.py --verbose` — clean (424 files, no broken links/anchors).
- `python scripts/check_readme_inventories.py` — clean.
- `mkdocs build --strict` (spec/ + migration/ staged per the docs.yml recipe, then removed) — exit 0, zero warnings/errors.
