### PR TITLE
feat(test-support): wire :resources/reset-resources! into core reset-hook-table (rf2-yuc8o0)

### DIFF
--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -236,6 +236,24 @@
                                        them; without this a prior test's
                                        counter leaks and the nav-N / pn-N
                                        id assertions drift.
+    :resources/reset-resources!      — reset the resources artefact's
+                                       host-side transient state (Spec 016):
+                                       clear the `:resource` + `:mutation`
+                                       registrar kinds, the generation
+                                       high-water cache
+                                       (re-frame.resources.state/generation-cache),
+                                       and the host work-ledger / timer /
+                                       revalidation-listener handles
+                                       (rf2-afpdkn / rf2-nbjewi / rf2-vtblcq).
+                                       Like the routing nav-counters, the
+                                       generation cache is host-side transient
+                                       state now, so the `frames` reset above
+                                       no longer clears it; without this a
+                                       prior test's generation high-water mark
+                                       leaks across tests. Published from
+                                       `re-frame.resources.test-support`, so the
+                                       row no-ops when that test-support require
+                                       is absent (production builds).
     :http/clear-all-in-flight!       — drop the in-flight managed-request
                                        registry.
     :epoch/clear-history!            — drop the per-frame epoch ring buffer.
@@ -265,6 +283,7 @@
    {:hook :machines/reset-spawn-order!     :phase :post-dispose}
    {:hook :routing/reset-counters!         :phase :post-dispose}
    {:hook :routing/reset-nav-counters!     :phase :post-dispose}
+   {:hook :resources/reset-resources!      :phase :post-dispose}
    {:hook :http/clear-all-in-flight!       :phase :post-dispose}
    {:hook :epoch/clear-history!            :phase :post-dispose}
    {:hook :epoch/clear-epoch-listeners!          :phase :post-dispose}

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -226,6 +226,7 @@
    :machines/reset-timers!          1
    :routing/reset-counters!         1
    :routing/reset-nav-counters!     1  ;; rf2-oosjmh — host-side counters
+   :resources/reset-resources!      1  ;; rf2-yuc8o0 — host-side resources state
    :http/clear-all-in-flight!       1
    :epoch/clear-history!            1
    :epoch/clear-epoch-listeners!          1

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -61,10 +61,10 @@
   second `use-fixtures :each` would REPLACE, not accumulate)."
   [f]
   (reset! last-managed-args nil)
-  ;; the resources reset hook is not yet in the core reset-hook-table, so
-  ;; clear the host-side generation high-water marks here for per-test
-  ;; isolation (otherwise generations leak across tests).
-  (state/reset-cache!)
+  ;; rf2-yuc8o0: the shared `make-reset-runtime-fixture` reset-hook-table now
+  ;; fires `:resources/reset-resources!` (which clears the host-side
+  ;; generation high-water marks) in its `:post-dispose` phase before each
+  ;; test body, so no per-suite generation-cache reset is needed here.
   ;; fx handlers are BINARY `(fn [ctx args] …)` (Spec 002 §binary
   ;; fx-handler signature) — capture the args (second arg).
   (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))


### PR DESCRIPTION
## What

Add a `:post-dispose` row for `:resources/reset-resources!` to the shared `make-reset-runtime-fixture` reset-hook-table in `implementation/core/src/re_frame/test_support.cljc`, mirroring the existing `:routing/reset-nav-counters!` row (same host-side-allocator class).

The resources artefact publishes the `:resources/reset-resources!` late-bind hook from `re-frame.resources.test-support` (clears the `:resource` + `:mutation` registrar kinds, the host-side generation high-water cache `re-frame.resources.state/generation-cache`, and the work-ledger / timer / revalidation-listener handles), but the shared reset-hook-table did not consult it. So resource-event-dispatching suites had to reset the generation cache themselves.

## Changes

- `core/src/re_frame/test_support.cljc` — new `{:hook :resources/reset-resources! :phase :post-dispose}` row + per-row prose mirroring `:routing/reset-nav-counters!`.
- `core/test/re_frame/test_support_test.clj` — pin `:resources/reset-resources! 1` in `reset-hook-expected-counts` (table-coverage gate).
- `resources/test/re_frame/resources_runtime_cljs_test.cljc` (rf2-pbxj48) — drop the now-redundant per-suite `(state/reset-cache!)` workaround; the shared table covers it.

## Gates

- clj-kondo: 0 errors (1 pre-existing unrelated `do-report` warning)
- JVM core (`clojure -M:test`): 1061 tests, 4635 assertions, 0 failures/errors
- JVM resources (`clojure -M:test`): 114 tests, 390 assertions, 0 failures/errors
- CLJS corpus (`npm run test:cljs`): 6273 tests, 22527 assertions, 0 failures/errors (workaround removed, still green)

Closes rf2-yuc8o0.