### PR TITLE
docs(resources): EP-0003 wave-end /docs sweep + mutation-with-invalidation example (rf2-lqpwki)

### DIFF
--- a/docs/api/16-resources.md
+++ b/docs/api/16-resources.md
@@ -4,7 +4,7 @@ A resource is a named, cached read of remote state — re-frame2's answer to Tan
 
 Resources are an **optional, post-v1 capability** — they ship in `day8/re-frame2-resources` (`re-frame.resources`), require `day8/re-frame2-http` for the transport, and are wired by one `(:require [re-frame.resources])` at app boot. An app that omits the artefact sees the `reg-resource` wrapper throw a clean `:rf.error/resources-artefact-missing`. This chapter covers the registration shape, the events, the subs, and introspection. The tutorial is [Guide ch.27 — Server-state and resources](../guide/27-resources.md); the normative source is [016-Resources.md](../../spec/016-Resources.md).
 
-> **Scope is HTTP-only; mutations and GraphQL are deferred.** `reg-mutation` / `:rf.mutation/execute` and focus/reconnect revalidation land with the next slice; GraphQL is a later phase. See [Guide ch.27 §What's deferred](../guide/27-resources.md#whats-deferred).
+> **Scope is HTTP-only.** The read-resource MVP **and mutations** (`reg-mutation` / `:rf.mutation/execute`, the causal-write counterpart — see [Mutations](#mutations)) are landed. Focus/reconnect revalidation, optimistic rollback, and GraphQL are deferred to later slices. See [Guide ch.27 §What's deferred](../guide/27-resources.md#whats-deferred).
 
 ## Registration
 
@@ -153,6 +153,92 @@ The `:rf.resource/state` view-model — facts plus **derived** booleans:
 
 Status invariants: `:loading` = first load, no usable data; `:fetching` = refresh in flight while prior data stays visible; `:error` = first load failed, no usable data; a failed *background* refresh stays `:loaded`, keeps prior `:data`, records `:refresh-error`. `:stale?` / `:loading?` / `:fetching?` / `:has-data?` are derived sub values, never stored. See [Guide ch.27 §Status](../guide/27-resources.md#status--facts-not-derived-booleans).
 
+## Mutations
+
+A **mutation** is the causal-WRITE counterpart of a resource: a named write to remote state that, on success, invalidates / patches / populates cached resource reads. The write lowers through the **same** `:rf.http/managed` transport as resources, and the runtime owns reply addressing + stale-suppression (work-id + generation) exactly as for reads. Runtime state is keyed by mutation **instance** id, so concurrent submissions of the same mutation never clobber each other. The tutorial is [Guide ch.27 §Mutations](../guide/27-resources.md#mutations--the-causal-write); the normative source is [016-Resources.md §Mutations](../../spec/016-Resources.md#mutations-first-public-beta-gate-rf2-dwme29).
+
+### `reg-mutation`
+
+- **Kind**: macro (post-v1 lib)
+- **Signature**:
+  ```clojure
+  (reg-mutation mutation-id mutation-spec)
+  ```
+- **Description**: Register a mutation as data under `mutation-id`. Validates the spec and writes a `:mutation`-kind registrar entry (the causal-write counterpart of `:resource`). Returns `mutation-id`. An app that omits the resources artefact sees the wrapper throw `:rf.error/resources-artefact-missing`.
+
+```clojure
+(rf/reg-mutation :article/save
+  {:params-schema :app/article          ;; REQUIRED — validates + canonicalizes params
+   :request                             ;; REQUIRED — a Spec 014 managed-HTTP write
+   (fn [{:keys [slug] :as article} _ctx]
+     {:request {:method :put :url (str "/api/articles/" slug) :body article}
+      :decode  :app/article})
+   :invalidates  (fn [{:keys [slug]} _result] #{[:article slug] [:article-list]})
+   :patches      (fn [params result] {scoped-key (fn [old result] (merge old result))})
+   :populates    (fn [params result] {scoped-key result})
+   :scope        :rf.scope/global       ;; the cache scope invalidation/patch defaults to
+   :invalidate-timing :after-success})  ;; | :before-request | :after-failure | :after-settle
+```
+
+**Required keys**:
+
+| Key | Notes |
+|---|---|
+| `:params-schema` | Validates and canonicalizes the write's params. |
+| `:request` | Returns a [Spec 014](../../spec/014-HTTPRequests.md) managed-HTTP args map (the write). MUST NOT supply `:request-id` / `:on-success` / `:on-failure` — the runtime supplies those from the instance + generation (rejected if present). **Write retries are OPT-IN** — `:retry` arms only when the `:request` declares it. |
+
+**Optional keys**: `:invalidates` (`(fn [params result] → #{tag …})` — the tags made stale on success, composed with `:rf.resource/invalidate-tags`, scoped), `:patches` / `:populates` (controlled resource-entry transforms / seeds applied on success **before** invalidation, keyed by scoped key, via the same durable entry shape + structural sharing the read path uses), `:scope` (the cache scope invalidation/patch defaults to), `:invalidate-timing` (`:after-success` (default) | `:before-request` | `:after-failure` | `:after-settle`), `:retry`, `:transport`, `:doc`.
+
+**Reserved / deferred**: `:optimistic` / `:rollback` — optimistic rollback's snapshot/rollback/reconciliation shape is *reserved* in the success trace but not yet implemented.
+
+### `clear-mutation`
+
+- **Kind**: function (post-v1 lib)
+- **Signature**:
+  ```clojure
+  (clear-mutation mutation-id)
+  ```
+- **Description**: Remove a registered mutation — a **registration-lifecycle** operation, NOT a form-error reset. For the causal runtime-instance reset use the `[:rf.mutation/clear …]` event. Returns `mutation-id`.
+
+### Events (map payloads)
+
+#### `[:rf.mutation/execute {…}]`
+
+- **Kind**: event
+- **Payload**: `{:mutation :params :instance :scope :cause}`
+- **Description**: Run a mutation. `:instance` is the caller-supplied (or generated) **instance** id all runtime state is keyed by — two concurrent submissions keep distinct rows. On success the runtime patches/populates resource entries then invalidates tags (per `:invalidate-timing`). A superseded reply (a re-execute under the same instance, or an `:rf.mutation/clear`) never overwrites a newer instance (work-id + generation suppression).
+
+```clojure
+[:rf.mutation/execute
+ {:mutation :article/save
+  :params   article
+  :instance :form/save-1
+  :scope    [:rf.scope/session {:user-id "u-42"}]
+  :cause    [:form-submit :article/save]}]
+```
+
+#### `[:rf.mutation/clear {…}]`
+
+- **Kind**: event
+- **Payload**: `{:instance …}`
+- **Description**: The **causal** reset of a runtime mutation instance — clears its row and best-effort aborts in-flight work. Distinct from `clear-mutation` (which removes the *registration*).
+
+### Subscriptions (passive)
+
+A `:rf.mutation/*` subscription is a pure passive read keyed by **instance** id — it never executes a write.
+
+```clojure
+[:rf.mutation/state    {:instance :form/save-1}]   ;; {:status :result :error :pending? :success? :error? :settled?}
+[:rf.mutation/status   {:instance :form/save-1}]
+[:rf.mutation/pending? {:instance :form/save-1}]
+[:rf.mutation/result   {:instance :form/save-1}]
+[:rf.mutation/error    {:instance :form/save-1}]
+```
+
+A failure settles `:error` — there is **no `:refresh-error` analogue** (a write has no last-known-good to keep).
+
+> **Internal replies — do not dispatch.** The `:rf.mutation.internal/*` replies (and the `:rf.mutation/*` trace family — `started` / `succeeded` / `failed` / `cleared` / `stale-suppressed`, carrying the instance id) are framework-internal; user code MUST NOT dispatch them.
+
 ## Introspection
 
 `:frame` is an explicit, app-registered frame id ([EP-0002](../EP/EP-0002-frame-target-resolution.md) — no ambient `:rf/default` fallback; a frameless call with no resolvable context fails closed).
@@ -184,6 +270,34 @@ Status invariants: `:loading` = first load, no usable data; `:fetching` = refres
   (resources {:frame …}) → {:resource-ids [...] :entries {<scoped-key> <entry>}}
   ```
 - **Description**: Resource introspection for a frame target — the static registry (every registered id) plus, with `:frame`, the live per-frame resource-instance entries.
+
+### `mutation-meta`
+
+- **Kind**: function (post-v1 lib)
+- **Signature**:
+  ```clojure
+  (mutation-meta mutation-id) → spec-map or nil
+  ```
+- **Description**: The registered mutation's spec map (`:request`, `:params-schema`, `:invalidates`, `:patches`, `:populates`, `:scope`, `:invalidate-timing`, `:transport`, `:doc`, source coords), or nil.
+
+### `mutation-state`
+
+- **Kind**: function (post-v1 lib)
+- **Signature**:
+  ```clojure
+  (mutation-state {:instance … :frame …}) → row or nil
+  ```
+- **Description**: A mutation **instance**'s durable runtime row (`{:status :result :error …}`) for an explicit-frame target, or nil. Per [EP-0002](../EP/EP-0002-frame-target-resolution.md) the frame is carried explicitly.
+
+### `mutations`
+
+- **Kind**: function (post-v1 lib)
+- **Signature**:
+  ```clojure
+  (mutations)            → {:mutation-ids [...] :instances {}}
+  (mutations {:frame …}) → {:mutation-ids [...] :instances {<instance-id> <row>}}
+  ```
+- **Description**: Mutation introspection for a frame target — the registered mutation ids plus, with `:frame`, the live per-frame mutation-instance table (Xray groups instances under their registered mutation id).
 
 Xray exposes the same shapes plus the tool accessors (`list-resources`, `list-resource-instances`, `get-resource-state`, `get-resource-history`, `list-resource-invalidations`), the route/resource graph, the work-ledger table, and the **scope audit surface** (the standing enumeration of every `:rf.scope/global` resource). Tool accessors prefer summaries over raw values; params/scopes get the same privacy/size elision as data.
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -34,7 +34,7 @@ The core surfaces live in `re-frame.core`. Per-feature artefacts ship their own 
 | `re-frame.ssr.ring` | `day8/re-frame2-ssr-ring` | Ring host-adapter for SSR. |
 | `re-frame.epoch` | `day8/re-frame2-epoch` | Time-travel surfaces — `epoch-history`, `restore-epoch`, `replace-app-db!`. Re-exported through `re-frame.core` via late-bind. |
 | `re-frame.adapter.uix` / `re-frame.adapter.helix` | `day8/re-frame2-uix` / `-helix` | The per-substrate adapter surfaces and hooks. |
-| `re-frame.resources` | `day8/re-frame2-resources` | Declarative server-state — `reg-resource`, the `:rf.resource/*` events and subs, route `:resources` metadata. Optional, post-v1. |
+| `re-frame.resources` | `day8/re-frame2-resources` | Declarative server-state — `reg-resource` + `reg-mutation`, the `:rf.resource/*` and `:rf.mutation/*` events and subs, route `:resources` metadata. Optional, post-v1. |
 
 The dependency direction is one-way: adapters and feature artefacts depend on core; core never depends on them. Apps load whatever subset they need.
 

--- a/docs/guide/27-resources.md
+++ b/docs/guide/27-resources.md
@@ -2,7 +2,7 @@
 
 Server state is the state your app doesn't own. The truth lives on a server, you hold a cache of it, and that cache goes stale the moment you read it. Every SPA grows a private answer to the same questions: where does the cached copy live, how do I know it's stale, who's allowed to refetch it, what happens when two screens want the same data, and how do I stop a logged-out user from seeing the previous user's dashboard. TanStack Query, RTK Query, SWR, and `shipclojure/re-frame-query` are all answers to exactly that. This chapter is re-frame2's answer, and it's re-frame2-shaped: **views read server state passively through subscriptions; route entry, events, and machines *cause* it to fetch; and the cache lives in the framework-owned runtime partition, not in your `app-db`.**
 
-> **Status: optional, post-v1 artefact.** Resources ship in `day8/re-frame2-resources` — an optional capability per the [capability matrix](../../spec/000-Vision.md). An app that doesn't want declarative server-state expresses it with [Pattern-RemoteData](../../spec/Pattern-RemoteData.md) plus managed HTTP ([chapter 10](10-http.md)) directly; that keeps working. The normative contract is [Spec 016 — Resources](../../spec/016-Resources.md); this chapter is the tutorial. **Scope is HTTP-only** — GraphQL is a deferred later phase. Mutations (`reg-mutation`) and focus/reconnect revalidation are named here but land with the next slice (see [Deferred](#whats-deferred)).
+> **Status: optional, post-v1 artefact.** Resources ship in `day8/re-frame2-resources` — an optional capability per the [capability matrix](../../spec/000-Vision.md). An app that doesn't want declarative server-state expresses it with [Pattern-RemoteData](../../spec/Pattern-RemoteData.md) plus managed HTTP ([chapter 10](10-http.md)) directly; that keeps working. The normative contract is [Spec 016 — Resources](../../spec/016-Resources.md); this chapter is the tutorial. **Scope is HTTP-only** — GraphQL is a deferred later phase. The read-resource MVP **and mutations** (`reg-mutation` / `:rf.mutation/execute`, the causal-write counterpart — see [Mutations](#mutations--the-causal-write)) are landed; focus/reconnect revalidation and optimistic rollback are named here but land with later slices (see [Deferred](#whats-deferred)).
 
 ## The one-line thesis
 
@@ -282,7 +282,8 @@ Resources tag their data, and invalidation is by tag:
 (rf/reg-resource :article/by-slug
   {... :tags (fn [{:keys [slug]} _data] #{[:article slug]})})
 
-;; A cause (today, an explicit dispatch; with the mutation slice, a mutation) invalidates them:
+;; A cause invalidates them — an explicit dispatch, or (more commonly) a mutation's
+;; success-time :invalidates (see the Mutations section below):
 [:rf.resource/invalidate-tags
  {:scope [:rf.scope/session {:user-id "u-42" :tenant-id "acme"}]
   :tags  #{[:article "welcome"] [:article-list]}
@@ -292,6 +293,122 @@ Resources tag their data, and invalidation is by tag:
 The algorithm: find entries whose tags intersect; mark them stale; refetch entries with active owners; leave inactive entries stale or GC-eligible; emit a decision summary plus per-entry detail (so a broad-tag storm shows in Xray without flooding the trace). On a successful load the entry's tag index is *replaced* with the new data's tags, so stale list/detail relationships don't keep receiving invalidations after the data changed.
 
 **Scoped invalidation is the default** — a cross-scope invalidation must opt in explicitly and is visible in Xray, because it can refetch or stale data across multiple users, tenants, or SSR requests.
+
+## Mutations — the causal write
+
+Reads are half the story. A real app also *writes* — save the article, add the comment, toggle the favourite — and a write almost always means "and now the cached read of that thing is wrong." A **mutation** is the causal-write counterpart of a resource: a named write to remote state that, on success, invalidates (or patches, or populates) the cached resource reads it affected. You stop hand-wiring "POST, then on success dispatch an invalidate" on every form; you declare the write→invalidate→refetch loop once.
+
+If a resource is "a sub you read and a cause you fire," a mutation is "**a cause you fire and an instance you watch**."
+
+### Register the write, declare what it invalidates
+
+```clojure
+(rf/reg-mutation :article/save
+  {:params-schema :app/article                ;; REQUIRED — validates + canonicalizes params
+   :request                                    ;; REQUIRED — a Spec 014 managed-HTTP write
+   (fn [{:keys [slug] :as article} _ctx]
+     {:request {:method :put :url (str "/api/articles/" slug) :body article}
+      :decode  :app/article})
+   :scope        :rf.scope/global              ;; the cache scope invalidation/patch defaults to
+   :invalidates  (fn [{:keys [slug]} _result]  ;; the tags the write makes stale on success
+                   #{[:article slug] [:article-list]})})
+```
+
+`:invalidates` is the heart of it: on success the runtime invalidates those tags through the *same* `:rf.resource/invalidate-tags` machinery the previous section described — scoped by default, owner-aware (entries with active owners refetch; inactive ones go stale or GC-eligible). The detail and list views re-render with fresh data with no further wiring. The same `:tags` your resource produced from its data are the join key — that's why tagging is set up before mutations.
+
+The `:request` follows the resource rule exactly: it returns a [Spec 014](../../spec/014-HTTPRequests.md) args map and **must not** supply `:request-id` / `:on-success` / `:on-failure` — the runtime owns reply addressing from the mutation instance + generation, which is how stale-suppression is wired. Note the **reads-retry / writes-don't** discipline carries over: write retries are **opt-in** — a mutation arms `:retry` only when its `:request` declares it ([chapter 10](10-http.md#retry-backoff-and-the-discipline-of-not-retrying)). Re-submitting a `PUT` because a reply was merely slow is exactly the double-charge bug you don't want.
+
+### Fire the write, watch the instance
+
+Run a mutation with `:rf.mutation/execute`, and observe it through passive `:rf.mutation/*` subs keyed by an **instance** id — *not* the mutation id:
+
+```clojure
+;; The submit handler (or the view) fires the write:
+(rf/dispatch [:rf.mutation/execute
+              {:mutation :article/save
+               :params   article
+               :instance :form/save-1          ;; caller-supplied (or generated) instance id
+               :cause    [:form-submit :article/save]}])
+
+;; The form watches that instance passively — no execution in a sub:
+(rf/reg-view save-button [article]
+  (let [{:keys [pending? error?]} @(rf/subscribe [:rf.mutation/state {:instance :form/save-1}])]
+    [:button {:disabled pending?
+              :on-click #(rf/dispatch [:rf.mutation/execute
+                                       {:mutation :article/save :params article
+                                        :instance :form/save-1
+                                        :cause [:form-submit :article/save]}])}
+     (cond pending? "Saving…" error? "Retry save" :else "Save")]))
+```
+
+The full instance view-model and sub family:
+
+```clojure
+[:rf.mutation/state    {:instance :form/save-1}]   ;; {:status :result :error :pending? :success? :error? :settled?}
+[:rf.mutation/status   {:instance :form/save-1}]
+[:rf.mutation/pending? {:instance :form/save-1}]
+[:rf.mutation/result   {:instance :form/save-1}]
+[:rf.mutation/error    {:instance :form/save-1}]
+
+[:rf.mutation/clear    {:instance :form/save-1}]   ;; the causal instance reset (NOT clear-mutation)
+```
+
+The instance-keyed model is load-bearing: **two concurrent submissions of the same mutation never clobber each other.** Fire `:comment/add` twice (instances `:c-1` and `:c-2`) and each keeps its own `:pending` / `:success` / `:error` row. A caller-supplied instance id makes the relationship between a form and its submission explicit; an omitted instance id is generated (and closes over the monotone generation, so concurrent generated submissions still differ). `:rf.mutation/clear` is the **causal** reset of a runtime instance (best-effort aborting in-flight work) — distinct from `clear-mutation`, which is the registration-lifecycle removal of the mutation definition itself, not a form reset.
+
+### The write→invalidate→refetch loop, end to end
+
+Putting the two halves together — this is the loop the deferred placeholder used to point at:
+
+```clojure
+;; READ: the article detail, tagged by slug.
+(rf/reg-resource :article/by-slug
+  {:params-schema [:map [:slug :string]]
+   :scope         :rf.scope/global
+   :request (fn [{:keys [slug]} _ctx]
+              {:request {:method :get :url (str "/api/articles/" slug)} :decode :app/article})
+   :tags    (fn [{:keys [slug]} _data] #{[:article slug]})})
+
+;; READ: the article list, tagged so a save can stale it too.
+(rf/reg-resource :article/list
+  {:params-schema [:map]
+   :scope         :rf.scope/global
+   :request (fn [_ _ctx] {:request {:method :get :url "/api/articles"} :decode :app/article-list})
+   :tags    (fn [_ articles] (into #{[:article-list]} (map (fn [a] [:article (:slug a)]) articles)))})
+
+;; WRITE: saving invalidates both the edited article AND the list, by tag.
+(rf/reg-mutation :article/save
+  {:params-schema :app/article
+   :request (fn [{:keys [slug] :as article} _ctx]
+              {:request {:method :put :url (str "/api/articles/" slug) :body article} :decode :app/article})
+   :invalidates (fn [{:keys [slug]} _result] #{[:article slug] [:article-list]})})
+
+;; The view: read passively, fire the write, watch the instance.
+(rf/reg-view article-editor [article]
+  (let [save @(rf/subscribe [:rf.mutation/state {:instance :form/article-save}])]
+    [:<>
+     [editor-fields article]
+     [:button {:disabled (:pending? save)
+               :on-click #(rf/dispatch [:rf.mutation/execute
+                                        {:mutation :article/save :params article
+                                         :instance :form/article-save
+                                         :cause [:form-submit :article/save]}])}
+      (if (:pending? save) "Saving…" "Save")]
+     (when (:error? save) [save-error (:error save)])]))
+```
+
+When the save succeeds, the runtime invalidates `#{[:article slug] [:article-list]}`. Any mounted detail view (owned by its route) and the list (if a route still owns it) refetch automatically; inactive entries are simply marked stale and refetch the next time something ensures them. The form never touches `app-db`, never dispatches a manual invalidate, and never re-implements "which reads did this write break?" — the mutation declared that once.
+
+### What a mutation refines beyond a plain managed-HTTP write
+
+You *can* write with an ordinary `:rf.http/managed` event whose success handler dispatches `:rf.resource/invalidate-tags` (that was the only path before mutations landed). A mutation adds, on top of that:
+
+- **Instance-keyed lifecycle** — `:pending?` / `:success?` / `:error?` / `:settled?` per submission, concurrency-safe, with no `app-db` slice to maintain. (A write has no last-known-good, so there's no `:refresh-error` analogue — failure simply settles `:error`.)
+- **Stale-suppression on writes** — a superseded reply (a re-execute under the same instance, or an `:rf.mutation/clear`) can never overwrite a newer instance, by the same work-id + generation check resources use.
+- **Patch / populate before invalidate** — `:patches` and `:populates` (controlled transforms / seeds keyed by scoped key) update resource entries *before* the success-time invalidation, so a saved article can appear in the cache immediately without waiting for the refetch round-trip.
+- **Invalidation timing** — `:invalidate-timing` is explicit: `:after-success` (default), `:before-request`, `:after-failure`, or `:after-settle`.
+- **Trace-visible instance ids** — the `:rf.mutation/*` trace family (`started` / `succeeded` / `failed` / `cleared` / `stale-suppressed`) carries the instance id, so Xray groups submissions under their mutation and shows the write→invalidate→refetch causality.
+
+(Optimistic rollback — the snapshot/rollback/reconciliation shape — is reserved in the success trace but **deferred**; until it lands, patch/populate are forward-only.)
 
 ## Route-driven loading
 
@@ -346,13 +463,14 @@ Resources are a trace/accessor contract, not just panel UI. Xray exposes a stati
 
 ## What's deferred
 
-Some surfaces are named in this chapter but land with later slices:
+The read-resource MVP and mutations (the [Mutations](#mutations--the-causal-write) section above) are landed. Some surfaces named in this chapter still land with later slices:
 
-- **Mutations** — `reg-mutation` / `:rf.mutation/execute` (causal writes that invalidate/patch/refetch resources, keyed by mutation *instance* id), plus focus/reconnect revalidation for active stale resources. These are the next slice; until they land, you invalidate explicitly with `:rf.resource/invalidate-tags`. *(A mutation-with-invalidation example will ship with that slice.)*
-- **GraphQL** — a deferred later phase, out of this contract. `:rf.http/managed` is the single built-in read transport; the lifecycle is kept transport-neutral so a GraphQL transport can plug in later without weakening the core semantics.
-- **Later still** — optimistic rollback, a generic transport-extension protocol, polling/interval revalidation, infinite resources, normalized entity caches, automatic graph-derived invalidation, subscription-driven fetching, offline persistence, and cross-tab broadcast.
+- **Focus/reconnect revalidation** — automatic background refetch of active stale resources when the window regains focus or the network reconnects. Until it lands, you revalidate with an explicit `:rf.resource/refetch` (or `:rf.resource/invalidate-tags`) from a cause of your own.
+- **Optimistic rollback** — the snapshot / rollback / reconciliation shape is *reserved* in the mutation success trace but not yet implemented. Until it lands, mutation `:patches` / `:populates` are forward-only (no automatic rollback on failure).
+- **GraphQL** — a deferred later phase, out of this contract. `:rf.http/managed` is the single built-in transport for both reads and writes; the lifecycle is kept transport-neutral so a GraphQL transport can plug in later without weakening the core semantics.
+- **Later still** — a generic transport-extension protocol, polling/interval revalidation, infinite resources, normalized entity caches, automatic graph-derived invalidation, subscription-driven fetching, offline persistence, and cross-tab broadcast.
 
-The artefact isn't "complete server-state management" until mutation invalidation and active-stale revalidation land — but the read-resource MVP is a complete, locked contract on its own.
+The artefact isn't "complete server-state management" until focus/reconnect revalidation lands — but the read-resource MVP plus mutations is a complete, locked contract on its own.
 
 ## What resources actually buy you
 


### PR DESCRIPTION
MANDATORY EP-0003 wave-end /docs review (rf2-lqpwki). Sweeps the resources teaching across `docs/` for consistency with EP-0003 12/12 (now on `main`, including the landed mutation surface), and adds the mutation-with-invalidation worked example that was deferred until `reg-mutation` landed.

## What changed

**`docs/guide/27-resources.md`** (the tutorial chapter)
- New **Mutations — the causal write** section: `reg-mutation` (with `:invalidates` / `:patches` / `:populates` / `:scope` / `:invalidate-timing`), `:rf.mutation/execute`, the instance-keyed `:rf.mutation/*` subs, `:rf.mutation/clear` vs `clear-mutation`, and a full **write → invalidate → refetch worked example** (two tagged read resources + a mutation whose `:invalidates` stales both). Closes with what a mutation refines over a plain managed-HTTP-write + manual invalidate.
- Flipped the top status note and the **What's deferred** list from "mutations are the next slice" to landed; focus/reconnect revalidation + optimistic rollback remain deferred; GraphQL still clearly **DEFERRED** as the single-transport later phase.
- Updated the invalidation-section comment to point at the new Mutations section.

**`docs/api/16-resources.md`** (API reference)
- New **Mutations** section: `reg-mutation` (macro), `clear-mutation`, the `:rf.mutation/execute` / `:rf.mutation/clear` events, the passive `:rf.mutation/*` subs, and the `mutation-meta` / `mutation-state` / `mutations` introspection accessors. Top status callout updated.

**`docs/api/README.md`** — resources artefact inventory row now notes `reg-mutation` + `:rf.mutation/*`.

## Confirmations
- **No subscription-driven fetching taught as the default** anywhere — the passive-read / explicit-causal-fetch model is consistent across ch.27, the API ref, and the (already-correct) `where-state-lives.md` page (which lists "a subscription that does IO" as an antipattern). Sub-driven fetch stays in the deferred "later still" list.
- **GraphQL clearly DEFERRED** in both the guide and API ref; `:rf.http/managed` named as the single built-in transport for reads and writes.
- Surface verified against `spec/016-Resources.md §Mutations` and the landed facade exports in `implementation/core/src/re_frame/core_resources.cljc` (`reg-mutation`, `clear-mutation`, `mutation-meta`, `mutation-state`, `mutations`).

## Gates
- `scripts/check_doc_slugs.py` — clean (fixed one anchor: the new retry cross-ref now points at the real `10-http.md` heading slug).
- `scripts/check_readme_inventories.py` — clean.
- `mkdocs build --strict` (spec/ + migration/ staged then removed per the docs.yml recipe) — clean, exit 0.

Spec/ and implementation/ deliberately untouched (sibling workers own those). The `migration/from-re-frame-v1/re-frame-query-to-resources.md` note still describes mutations as deferred — out of this bead's `docs/` scope; flagged for a follow-up.

Closes rf2-lqpwki.