### PR TITLE
fix(resources): fail-closed reject :rf.scope/* typo at reg-resource (rf2-y7lcqy)

### DIFF
--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -49,25 +49,54 @@
   resource resolver MUST."
   :rf.scope/from-caller)
 
+(def ^:private reserved-scope-ns
+  "The framework-reserved scope namespace (`:rf.scope/*`, per Conventions
+  §Reserved namespaces / the `:rf.<spec-area>/*` scheme). A *bare keyword*
+  in this namespace is a CLOSED reserved enum (`#{:rf.scope/global
+  :rf.scope/from-caller}`); any other `:rf.scope/*` bare keyword is a typo
+  and a loud registration error, NOT a literal scope. Note a scope VALUE
+  like `[:rf.scope/session {…}]` is a vector tuple, not a bare keyword —
+  the reserved namespace governs only the bare-keyword *policy* slot."
+  "rf.scope")
+
+(defn- reserved-scope-namespace?
+  "True when `scope` is a bare keyword in the framework-reserved
+  `:rf.scope/*` namespace — i.e. a candidate for the closed scope-policy
+  enum. A non-keyword (a `[:rf.scope/session …]` tuple, a map, a string)
+  is NOT in the bare-keyword reserved slot."
+  [scope]
+  (and (keyword? scope) (= reserved-scope-ns (namespace scope))))
+
 (defn- valid-scope-policy?
   "A scope policy is one of the reserved enum keywords
-  (`:rf.scope/global`, `:rf.scope/from-caller`) or a resolver (a fn, a
-  pure data value, or a fn-of-nothing). Per Spec 016 §Scope resolution.
-  `nil` / missing is NOT valid — it is a loud registration error."
+  (`:rf.scope/global`, `:rf.scope/from-caller`), a resolver (a fn), or a
+  literal scope value (any non-keyword EDN data value, or an
+  app-namespaced keyword). Per Spec 016 §Scope resolution. `nil` /
+  missing is NOT valid — it is a loud registration error.
+
+  FAIL-CLOSED reserved-namespace gate (rf2-y7lcqy): a bare keyword in the
+  framework-reserved `:rf.scope/*` namespace that is NOT one of the closed
+  enum is a TYPO (e.g. `:rf.scope/glabal`), and a typo in the framework
+  namespace is a registration error — it MUST NOT be silently accepted as
+  a literal scope (which would resolve to `[:rf.scope/glabal]`, a silent
+  wrong scope). App-namespaced keywords (`:my.app/whatever`) and
+  data-value scopes (`[:rf.scope/session {…}]`, maps, strings) remain
+  valid literal scopes."
   [scope]
   (and (some? scope)
-       (or (= scope global-scope-policy)
-           (= scope from-caller-scope-policy)
-           ;; A resolver — a fn (route/spec resolver) or a data value /
-           ;; fn-of-nothing (sub-resolvable). The runtime slice
-           ;; distinguishes route-ctx resolvers from sub-resolvable ones;
-           ;; at registration any non-nil value other than an unknown
-           ;; bare `:rf.scope/*` keyword is accepted as a resolver.
-           (fn? scope)
-           (not (keyword? scope))
-           ;; A namespaced keyword resolver alias is permitted; only a
-           ;; bare `nil` (handled above) fails.
-           (keyword? scope))))
+       (cond
+         ;; the closed reserved enum
+         (= scope global-scope-policy)      true
+         (= scope from-caller-scope-policy) true
+         ;; a bare `:rf.scope/*` keyword outside the enum is a typo —
+         ;; reject (fail closed), do NOT accept as a literal scope.
+         (reserved-scope-namespace? scope)  false
+         ;; a fn resolver (route/spec/fn-of-nothing)
+         (fn? scope)                        true
+         ;; any other value — an app-namespaced keyword or a non-keyword
+         ;; data value — is a legitimate literal scope / data-value
+         ;; resolver.
+         :else                              true)))
 
 (defn- registration-error
   "Build the canonical thrown-error shape (Spec 009 §The thrown-error

--- a/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
@@ -86,6 +86,55 @@
           (resources/reg-resource :test/no-request
                                   (dissoc (valid-spec) :request))))))
 
+(deftest reserved-scope-namespace-typo-rejected-fail-closed
+  ;; rf2-y7lcqy — a bare keyword in the framework-reserved :rf.scope/*
+  ;; namespace that is NOT one of the closed enum (:rf.scope/global,
+  ;; :rf.scope/from-caller) is a TYPO. It MUST be rejected loudly at
+  ;; registration (fail-closed) rather than silently accepted as a literal
+  ;; scope that would resolve to the wrong [:rf.scope/glabal] cache scope.
+  (testing "a :rf.scope/* typo throws :rf.error/resource-missing-scope-policy"
+    (is (thrown-with-msg?
+          js/Error #"resource-missing-scope-policy"
+          (resources/reg-resource :test/typo
+                                  (assoc (valid-spec) :scope :rf.scope/glabal))))
+    (is (thrown-with-msg?
+          js/Error #"resource-missing-scope-policy"
+          (resources/reg-resource :test/typo2
+                                  (assoc (valid-spec) :scope :rf.scope/sesssion)))))
+  ;; The closed enum members stay valid.
+  (testing ":rf.scope/global and :rf.scope/from-caller remain valid"
+    (is (= :test/global
+           (resources/reg-resource :test/global
+                                   (assoc (valid-spec) :scope :rf.scope/global))))
+    (is (= :test/from-caller
+           (resources/reg-resource :test/from-caller
+                                   (assoc (valid-spec) :scope :rf.scope/from-caller)))))
+  ;; An app-namespaced keyword is a legitimate literal scope — NOT in the
+  ;; reserved :rf.scope/* namespace, so it is accepted unchanged.
+  (testing "an app-namespaced keyword scope is accepted as a literal scope"
+    (is (= :test/app-ns
+           (resources/reg-resource :test/app-ns
+                                   (assoc (valid-spec) :scope :my.app/whatever)))))
+  ;; Data-value scopes (the legitimate data-value-resolver feature) stay
+  ;; valid: a [:rf.scope/session {…}] tuple is a value, not a bare keyword,
+  ;; and a map / string scope is likewise a literal data value.
+  (testing "data-value scopes (tuple / map / string) remain valid"
+    (is (= :test/tuple
+           (resources/reg-resource :test/tuple
+                                   (assoc (valid-spec)
+                                          :scope [:rf.scope/session {:user-id "u-1"}]))))
+    (is (= :test/map
+           (resources/reg-resource :test/map
+                                   (assoc (valid-spec) :scope {:tenant-id "acme"}))))
+    (is (= :test/string
+           (resources/reg-resource :test/string
+                                   (assoc (valid-spec) :scope "tenant-acme")))))
+  ;; A fn resolver is valid.
+  (testing "a fn resolver scope is accepted"
+    (is (= :test/fn
+           (resources/reg-resource :test/fn
+                                   (assoc (valid-spec) :scope (fn [] [:rf.scope/global])))))))
+
 (deftest resource-kind-in-closed-set
   (testing ":resource is a valid registrar kind"
     (is (registrar/valid-kind? :resource))


### PR DESCRIPTION
## What

EP-0003 FINAL-review finding (rf2-2wzk6g). `re-frame.resources.registry/valid-scope-policy?` had a final `(keyword? scope)` clause that accepted **any** keyword as a "namespaced-keyword resolver alias". Combined with the data-value resolver `:else` branch in `resolve-scope-for-event`/`-sub` (a data-value policy resolves to itself), a typo'd reserved keyword like `:scope :rf.scope/glabal` **passed** `reg-resource` validation and then resolved to the literal scope `[:rf.scope/glabal]` — a silent **wrong** cache scope, instead of the loud `:rf.error/resource-missing-scope-policy` the fail-closed scope contract (Spec 016 §Scope resolution) intends for an unrecognised reserved-namespace keyword.

## Fix (narrow)

A **bare keyword** in the framework-reserved `:rf.scope/*` namespace that is **not** one of the closed enum (`:rf.scope/global`, `:rf.scope/from-caller`) is now rejected at registration — a typo in the framework namespace is a registration error, raising the already-catalogued `:rf.error/resource-missing-scope-policy` (spec/009 §Error event catalogue; no new error id added).

Preserved legitimate paths (all still valid):
- the closed enum: `:rf.scope/global`, `:rf.scope/from-caller`
- a fn resolver
- an **app-namespaced** keyword (`:my.app/whatever`) as a literal scope
- **data-value** scopes — a `[:rf.scope/session {…}]` tuple, a map, a string (the bare-keyword reserved gate does not touch non-keyword values)

## Tests

New regression fixture `reserved-scope-namespace-typo-rejected-fail-closed` in `resources_skeleton_cljs_test.cljs`: `:rf.scope/<typo>` rejected loudly; enum members, app-ns keyword, tuple/map/string data values, and fn resolver all still accepted.

## Gates

- `clojure -M:test` (JVM resources): 114 tests, 390 assertions, 0 failures / 0 errors
- CLJS suite (shadow-cljs node-test): 6274 tests, 22536 assertions, 0 failures / 0 errors
- clj-kondo across `implementation/resources`: 0 errors (pre-existing warnings only, none introduced)

## Scope

Touches only `implementation/resources/src/re_frame/resources/registry.cljc` + `implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs`. No spec / ssr / tool_pair / epoch changes.

Closes rf2-y7lcqy.
