### PR TITLE
fix(resources): reconcile resources runtime-db on epoch restore (rf2-7r5mc2)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -516,6 +516,10 @@
     :producer-ns 're-frame.resources.ssr
     :design-bead "rf2-ctk2av"
     :description "Cross-feature LATE-BOUND SSR hydration RECONCILE hook (Spec 016 §SSR and hydration / §Restore and replay) — the client-side counterpart of :ssr/extend-runtime-db-projection. Takes the runtime-db the :rf/hydrate handler is about to install (+ the carried frame id) and returns it with the :rf.runtime/resources subtree reconciled: reverse indexes recomputed from entries (never trusted from the wire), SSR owners orphaned, transient :current-work cleared, server clock skew surfaced. Resources is the first consumer; consulted by re-frame.ssr.hydrate/hydrate-event-handler*. Absent hook (no resources artefact) leaves the runtime-db unchanged."}
+   {:key         :resources/reconcile-on-restore
+    :producer-ns 're-frame.resources.ssr
+    :design-bead "rf2-7r5mc2"
+    :description "Cross-feature LATE-BOUND epoch-restore RECONCILE hook (Spec 016 §Restore and replay parts 2/4/5) — the time-travel counterpart of :resources/hydrate-runtime-db. Epoch restore installs the UNPROJECTED captured snapshot (still carrying :current-work + non-terminal work-ledger rows), so this does everything the hydration reconcile does (recompute reverse indexes from entries, orphan SSR / stale-nav owners, clear transient :current-work) PLUS two restore-specific settles the SSR wire projection had already applied: it settles every mid-flight :loading/:fetching entry to its last STABLE status (:loaded if data, :error if a failed first load, :idle if never loaded) and records every restored NON-terminal work-ledger row as DANGLING (terminal :suppressed / :dangling) so a pre-restore in-flight reply is suppressed by the work-id + generation check. Resources is the first consumer; consulted by re-frame.epoch.tool-pair/reconcile-runtime-db-on-restore inside perform-restore!. Absent hook (no resources artefact) installs the runtime-db verbatim (the pre-rf2-7r5mc2 behaviour)."}
 
    ;; ---- re-frame.http-managed (rf2-5kpd / rf2-6y3q / rf2-wvkn / rf2-ijm7) ----
    ;; The three stub-family hooks publish from `re-frame.http-test-support`

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -535,6 +535,44 @@
      :tags    {:kind  :frame
                :frame frame-id}}))
 
+;; ---- runtime-db subsystem reconcile on restore (rf2-7r5mc2) ---------------
+;;
+;; Epoch restore installs the captured frame-state WHOLESALE — it does not run
+;; ordinary `:db`-effect semantics, so a runtime SUBSYSTEM whose durable
+;; snapshot is not safe to install verbatim (its transient host world has moved
+;; on) must be reconciled against the live world BEFORE the atomic install.
+;; This is the SAME install path SSR hydration uses (Spec 016 §Restore and
+;; replay): hydration reconciles the SERVER PROJECTION via the
+;; `:resources/hydrate-runtime-db` hook; restore reconciles the UNPROJECTED
+;; captured snapshot via the `:resources/reconcile-on-restore` hook (which
+;; ALSO settles mid-flight entries to last-stable + marks restored non-terminal
+;; work-ledger rows dangling — the two settles the wire projection had already
+;; done but the unprojected snapshot still carries).
+;;
+;; Late-bound so epoch never statically depends on the optional Resources
+;; artefact — absent the artefact the hook is nil and the runtime-db installs
+;; verbatim (the pre-rf2-7r5mc2 behaviour, correct for an app with no resources).
+
+(defn reconcile-runtime-db-on-restore
+  "Reconcile the runtime-db partition of a `frame-state` value about to be
+  installed by `perform-restore!`, consulting the late-bound
+  `:resources/reconcile-on-restore` hook (Spec 016 §Restore and replay). Returns
+  the frame-state with its `:rf.db/runtime` partition reconciled — or
+  `frame-state` unchanged when no resources artefact is loaded (the hook is nil),
+  or when the frame-state carries no runtime-db partition (a legacy / app-db-only
+  record). The runtime-db value is passed with the carried `frame-id` so the
+  reconcile can stamp its trace. Other runtime subsystems (machines, routing)
+  reconcile their own snapshots through their own contracts; this seam is the
+  resources-first extension point, mirroring SSR hydration's single
+  `:resources/hydrate-runtime-db` consult."
+  [frame-id frame-state]
+  (if-let [reconcile (late-bind/get-fn :resources/reconcile-on-restore)]
+    (if (contains? frame-state frame/runtime-partition-key)
+      (update frame-state frame/runtime-partition-key
+              (fn [rdb] (when (some? rdb) (reconcile rdb frame-id))))
+      frame-state)
+    frame-state))
+
 (defn perform-restore!
   "Carry out the actual frame-state rewind once preconditions have passed.
   Replaces the frame's whole frame-state with `epoch`'s `:frame-state-after`
@@ -566,7 +604,19 @@
   (a non-nil — possibly EMPTY — changed-key-set for a live frame, even a
   no-op write), so we check that return: a `nil` return is the destroyed-
   frame signal, surfaced as the same `:rf.error/no-such-handler` (kind
-  `:frame`) failure / `false` return BEFORE any success telemetry."
+  `:frame`) failure / `false` return BEFORE any success telemetry.
+
+  Per rf2-7r5mc2 (resources runtime-db reconcile on restore): a runtime-db
+  partition carrying a runtime SUBSYSTEM whose durable snapshot is not safe to
+  install verbatim must be reconciled against the live transient world BEFORE
+  the install (Spec 016 §Restore and replay — restore shares the SSR-hydration
+  install path). Resources is the first such subsystem: `reconcile-runtime-db-on-
+  restore` consults the late-bound `:resources/reconcile-on-restore` hook, which
+  settles mid-flight `:loading` / `:fetching` entries to last-stable, clears each
+  entry's vanished `:current-work`, orphans SSR / stale-nav owners, recomputes
+  the reverse indexes from `:entries`, and records restored non-terminal
+  work-ledger rows as dangling so a pre-restore in-flight reply is suppressed.
+  No-op (passes the runtime-db through) when no resources artefact is loaded."
   [frame-id epoch]
   (let [{:keys [outcome op tags]} (live-container-or-fail frame-id)]
     (if (= :fail outcome)
@@ -577,6 +627,14 @@
                 ;; Legacy / synthetic record with only the app-db projection:
                 ;; install it as the app-db partition; runtime-db installs nil.
                 {frame/app-partition-key (:db-after epoch)})
+            ;; rf2-7r5mc2: reconcile the runtime-db partition's runtime
+            ;; subsystems (Resources, first writer) BEFORE the atomic install,
+            ;; the same way SSR hydration reconciles its installed slice — so a
+            ;; mid-flight captured snapshot does not install stranded
+            ;; `:loading` / `:fetching` entries pointing at vanished attempts,
+            ;; and a pre-restore reply cannot write stale data into a restored
+            ;; entry.
+            frame-state-target (reconcile-runtime-db-on-restore frame-id frame-state-target)
             ;; EP-0001 (rf2-3aizt1): write the WHOLE frame-state — both
             ;; partitions in ONE atomic install through the one physical
             ;; frame-state container. `frame/app-db-container` /

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -687,6 +687,116 @@
       (is (= {:phase :machine-alive} (rf/app-db-value :test/main))
           "restore also rewound the app-db partition"))))
 
+;; ---- runtime-db subsystem reconcile on restore (rf2-7r5mc2) ----------------
+;;
+;; perform-restore! installs the captured frame-state WHOLESALE — a runtime
+;; subsystem whose durable snapshot is not safe to install verbatim must be
+;; reconciled BEFORE the install, via the late-bound :resources/reconcile-on-
+;; restore hook (Spec 016 §Restore and replay). The epoch artefact has no
+;; static dep on the optional Resources artefact, so these tests stub the hook
+;; (late-bind/set-fn!) and assert the WIRING: the hook is consulted with the
+;; runtime-db partition, its return value is installed, and absence is a clean
+;; verbatim pass-through. The reconcile LOGIC itself (settle-to-last-stable,
+;; dangling-marking, index recompute, owner orphaning) is pinned in the
+;; resources artefact's resources-restore-cljs-test.
+
+(deftest reconcile-runtime-db-on-restore-consults-hook-and-installs-result
+  (testing "rf2-7r5mc2 — reconcile-runtime-db-on-restore passes the runtime-db
+            partition + frame-id to the :resources/reconcile-on-restore hook and
+            returns the frame-state with the hook's reconciled runtime-db installed."
+    (let [hook-key :resources/reconcile-on-restore
+          original (late-bind/get-fn hook-key)
+          seen     (atom nil)]
+      (try
+        ;; Stub a reconcile that records its inputs and rewrites the runtime-db
+        ;; (the resources artefact's real reconcile does the settle/dangling work).
+        (late-bind/set-fn! hook-key
+                           (fn [rdb frame-id]
+                             (reset! seen {:rdb rdb :frame-id frame-id})
+                             (assoc rdb :rf.runtime/reconciled? true)))
+        (let [fs {:rf.db/app     {:n 1}
+                  :rf.db/runtime {:rf.runtime/resources {:entries {}}}}
+              out (tool-pair/reconcile-runtime-db-on-restore :test/x fs)]
+          (is (= {:rf.runtime/resources {:entries {}}} (:rdb @seen))
+              "the hook receives the runtime-db PARTITION value")
+          (is (= :test/x (:frame-id @seen)) "the hook receives the carried frame-id")
+          (is (true? (get-in out [:rf.db/runtime :rf.runtime/reconciled?]))
+              "the hook's reconciled runtime-db is installed back into the frame-state")
+          (is (= {:n 1} (:rf.db/app out)) "the app-db partition is untouched"))
+        (finally
+          (late-bind/set-fn! hook-key original))))))
+
+(deftest reconcile-runtime-db-on-restore-noop-without-hook
+  (testing "rf2-7r5mc2 — absent the :resources/reconcile-on-restore hook (no
+            resources artefact), the frame-state installs verbatim (the
+            pre-rf2-7r5mc2 behaviour)."
+    (let [hook-key :resources/reconcile-on-restore
+          original (late-bind/get-fn hook-key)]
+      (try
+        (late-bind/set-fn! hook-key nil)
+        (let [fs {:rf.db/app {:n 1} :rf.db/runtime {:rf.runtime/resources {:entries {:k :v}}}}]
+          (is (= fs (tool-pair/reconcile-runtime-db-on-restore :test/x fs))
+              "no hook → frame-state passes through unchanged"))
+        (finally
+          (late-bind/set-fn! hook-key original))))))
+
+(deftest reconcile-runtime-db-on-restore-noop-on-app-db-only-record
+  (testing "rf2-7r5mc2 — a legacy / synthetic frame-state with only the app-db
+            partition (no :rf.db/runtime key) passes through unchanged even when
+            the hook is present (nothing to reconcile)."
+    (let [hook-key :resources/reconcile-on-restore
+          original (late-bind/get-fn hook-key)
+          called?  (atom false)]
+      (try
+        (late-bind/set-fn! hook-key (fn [rdb _] (reset! called? true) rdb))
+        (let [fs {:rf.db/app {:n 1}}]
+          (is (= fs (tool-pair/reconcile-runtime-db-on-restore :test/x fs))
+              "app-db-only frame-state is unchanged")
+          (is (false? @called?) "the hook is not consulted when there is no runtime-db partition"))
+        (finally
+          (late-bind/set-fn! hook-key original))))))
+
+(deftest perform-restore!-reconciles-installed-runtime-db
+  (testing "rf2-7r5mc2 — end-to-end: perform-restore! runs the
+            :resources/reconcile-on-restore hook over the runtime-db it is about
+            to install, so the FRAME's restored runtime-db carries the reconciled
+            value (a mid-flight slice never installs verbatim)."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-fx :put-resource
+      (fn [{rt :rf.db/runtime} _]
+        {:db {:phase :mid-flight}
+         :rf.db/runtime (assoc-in (or rt {})
+                                  [:rf.runtime/resources :entries :k]
+                                  {:status :loading :current-work [:w 1]})}))
+    (rf/reg-event-db :clear (fn [_ _] {:phase :cleared}))
+
+    (let [hook-key :resources/reconcile-on-restore
+          original (late-bind/get-fn hook-key)]
+      (try
+        ;; Stub the reconcile: settle the mid-flight entry (loading → loaded-ish)
+        ;; + clear current-work, standing in for the resources artefact's real
+        ;; reconcile so the epoch wiring is exercised without a resources dep.
+        (late-bind/set-fn! hook-key
+                           (fn [rdb _frame-id]
+                             (-> rdb
+                                 (assoc-in [:rf.runtime/resources :entries :k :status] :idle)
+                                 (assoc-in [:rf.runtime/resources :entries :k :current-work] nil)
+                                 (assoc :rf.runtime/restore-reconciled? true))))
+        (rf/dispatch-sync [:put-resource] {:frame :test/main})
+        (let [mid-epoch (:epoch-id (last (rf/epoch-history :test/main)))]
+          (rf/dispatch-sync [:clear] {:frame :test/main})
+          (is (true? (rf/restore-epoch :test/main mid-epoch))
+              "restore to the mid-flight epoch succeeded")
+          (let [rdb (rf/runtime-db-value :test/main)]
+            (is (true? (:rf.runtime/restore-reconciled? rdb))
+                "perform-restore! ran the reconcile hook over the installed runtime-db")
+            (is (= :idle (get-in rdb [:rf.runtime/resources :entries :k :status]))
+                "the mid-flight :loading entry was settled by the reconcile, not installed verbatim")
+            (is (nil? (get-in rdb [:rf.runtime/resources :entries :k :current-work]))
+                "the vanished current-work pointer was cleared during the reconcile")))
+        (finally
+          (late-bind/set-fn! hook-key original))))))
+
 ;; ---- restore failure modes -------------------------------------------------
 
 (deftest restore-failure-unknown-frame

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -64,6 +64,7 @@
             [re-frame.privacy :as privacy]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.state :as state]
+            [re-frame.resources.work-ledger :as work-ledger]
             [re-frame.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -495,6 +496,177 @@
                                             "ambiguous; refetch will resolve it.")}))
          rdb')))))
 
+;; ---- epoch-restore reconcile (Spec 016 §Restore and replay parts 2/4/5) ---
+;;
+;; Restore (the EP-0001 epoch restore / time travel) shares the SSR-hydration
+;; install path, but with ONE load-bearing asymmetry: SSR hydration installs
+;; the SERVER PROJECTION (the wire shape `project-entry` already produced — it
+;; STRIPPED `:current-work` on the wire and never ships non-terminal work-ledger
+;; rows), whereas epoch restore installs the UNPROJECTED captured snapshot —
+;; the live frame-state value as of the restored epoch. That snapshot still
+;; carries:
+;;
+;;   - entries left mid-flight in `:loading` / `:fetching` whose `:current-work`
+;;     points at an attempt the restored timeline no longer owns (the host
+;;     handle was never serialized — Spec 016 §Restore and replay part 2), and
+;;   - non-terminal work-ledger rows (`:queued` / `:running` / `:abort-requested`)
+;;     for those vanished attempts.
+;;
+;; So restore needs everything `hydrate-runtime-db` does (recompute indexes —
+;; part 5; orphan SSR + stale-nav route owners — part 4; clear `:current-work`)
+;; AND TWO restore-specific settles the hydration projection had already done on
+;; the wire:
+;;
+;;   1. settle every `:loading` / `:fetching` entry to its last STABLE status
+;;      (`:loaded` if it has usable `:data`, `:error` if it was a failed first
+;;      load with no data, `:idle` if it never loaded) — never left stranded
+;;      pointing at a vanished attempt (part 2);
+;;   2. record every restored NON-terminal work-ledger row as DANGLING — settle
+;;      it to the terminal `:suppressed` status with a `:dangling` outcome so a
+;;      pre-restore in-flight reply that lands post-restore is suppressed by the
+;;      ordinary work-id + generation check (the entry no longer points at it and
+;;      its row is terminal). The generation allocator is host-side + monotonic
+;;      (part 1, `state/generation-cache`), so the dangling `:work/id` can never
+;;      re-match a live entry — collision is structurally impossible.
+;;
+;; Whether a settled entry then re-fetches is a freshness decision (part 3) — it
+;; refetches only on the next live-owner `ensure`; restore never eagerly continues
+;; old work.
+
+(defn settle-entry-to-last-stable
+  "Settle one restored cache `entry` to its last STABLE status (Spec 016
+  §Restore and replay part 2). A `:loading` / `:fetching` entry references an
+  attempt the restored timeline no longer owns, so it MUST NOT stay stranded
+  in an in-flight status pointing at a vanished `:current-work`:
+
+    - `:loaded`  when it has usable `:data`  (a refresh was in flight — keep the
+      last-known-good data; a refetch is a later freshness decision);
+    - `:error`   when it has a first-load `:error` envelope and no data;
+    - `:idle`    when it never loaded (no data, no error).
+
+  A `:loaded` / `:error` / `:idle` entry is ALREADY stable — returned unchanged
+  (besides the `:current-work` clear the caller applies). PURE."
+  [entry]
+  (if (contains? #{:loading :fetching} (:status entry))
+    (let [next (cond
+                 (state/has-data? entry) :loaded
+                 (some? (:error entry))  :error
+                 :else                   :idle)]
+      (assoc entry :status next))
+    entry))
+
+(defn dangle-non-terminal-work!
+  "Settle every NON-terminal work-ledger row in `runtime-db` to the terminal
+  `:suppressed` status with a `:dangling` outcome (Spec 016 §Restore and replay
+  part 2). A restored non-terminal row (`:queued` / `:running` /
+  `:abort-requested`) names a request the restored timeline no longer owns —
+  its host handle was never serialized. Marking it terminal-suppressed means a
+  pre-restore in-flight reply carrying its `:work/id` lands against a row that is
+  no longer live and an entry that no longer points at it, so the ordinary
+  work-id + generation check suppresses it (`live-entry-for-reply` — no stale
+  reply may mutate a post-restore entry).
+
+  Returns `[runtime-db' dangled-work-ids]`. Terminal rows ride through unchanged
+  (they already carry an outcome). PURE w.r.t. the host side table — host
+  handles are dropped by the resources frame-destroy / restore teardown, not
+  here (this only moves the durable serializable row forward)."
+  [runtime-db]
+  (let [ledger (get runtime-db state/work-ledger-key)
+        non-terminal (into []
+                           (comp (filter (fn [[_ r]]
+                                           (contains? work-ledger/non-terminal-statuses
+                                                      (:status r))))
+                                 (map key))
+                           ledger)]
+    (if (empty? non-terminal)
+      [runtime-db []]
+      [(reduce (fn [rdb work-id]
+                 (work-ledger/update-record rdb work-id
+                                            work-ledger/mark-terminal
+                                            :suppressed
+                                            {:reason :dangling
+                                             :recovery :restore-reconcile}))
+               runtime-db non-terminal)
+       non-terminal])))
+
+(defn reconcile-on-restore
+  "Reconcile a freshly-INSTALLED resource subtree on `restore-epoch` (the body
+  behind the `:resources/reconcile-on-restore` hook epoch `perform-restore!`
+  consults). `runtime-db` is the runtime-db partition the epoch restore is about
+  to install (the UNPROJECTED captured snapshot, both `:rf.runtime/resources` and
+  `:rf.runtime/work-ledger`). Returns the runtime-db with the resource +
+  work-ledger slices reconciled — or `runtime-db` unchanged when it carries no
+  resource entries AND no work-ledger rows (a no-op for a resource-free restore).
+
+  Unlike `hydrate-runtime-db` (which reconciles the SERVER PROJECTION — already
+  `:current-work`-stripped on the wire, no non-terminal rows), restore installs
+  the UNPROJECTED snapshot, so reconciliation does everything hydration does PLUS
+  the two settles the wire projection had already done (Spec 016 §Restore and
+  replay parts 2/4/5):
+
+    1. for every entry — orphan SSR owners (part 4), clear the transient
+       `:current-work` pointer (part 2), AND settle a `:loading` / `:fetching`
+       entry to its last STABLE status (`settle-entry-to-last-stable`, part 2);
+    2. recompute `:tag-index` / `:owner-index` from the reconciled `:entries`
+       (never trust the snapshot — part 5);
+    3. settle every NON-terminal work-ledger row to terminal `:suppressed` /
+       `:dangling` (`dangle-non-terminal-work!`, part 2) so a pre-restore in-flight
+       reply is suppressed;
+    4. emit a `:rf.resource/restored` trace summarising reconciled / orphaned /
+       dangled counts, and a clock-skew diagnostic when a restored `:stale-at` is
+       implausible against the live clock.
+
+  NEVER crosses scopes (it only reconciles entries under their own scoped keys).
+  Part 1 (the monotone host-side generation allocator) is restore-safe by
+  construction — it is NOT frame-state, so restore cannot rewind it; nothing here
+  touches it."
+  ([runtime-db] (reconcile-on-restore runtime-db nil))
+  ([runtime-db frame-id]
+   (let [resources (get runtime-db state/resources-key)
+         entries   (:entries resources)
+         ledger    (get runtime-db state/work-ledger-key)]
+     (if-not (or (seq entries) (seq ledger))
+       runtime-db
+       (let [clock-ms (now-ms)
+             ;; reconcile each entry: orphan SSR owners + clear current-work
+             ;; (hydration parity) + settle a mid-flight status to last-stable
+             ;; (restore-specific — the wire projection never carried an
+             ;; in-flight entry, but the unprojected snapshot can).
+             reconciled (reduce-kv
+                          (fn [acc k entry]
+                            (let [[entry' ssr] (reconcile-entry-owners entry)
+                                  entry''      (settle-entry-to-last-stable entry')
+                                  skew         (clock-skew-ms entry clock-ms)]
+                              (-> acc
+                                  (assoc-in [:entries k] entry'')
+                                  (update :orphaned into (map (fn [o] [k o])) ssr)
+                                  (cond-> skew (update :skews assoc k skew)))))
+                          {:entries {} :orphaned [] :skews {}}
+                          entries)
+             entries'  (:entries reconciled)
+             subtree'  (state/recompute-indexes
+                         (assoc resources :entries entries'))
+             rdb'      (cond-> runtime-db
+                         (seq entries) (assoc state/resources-key subtree'))
+             ;; settle the dangling non-terminal work-ledger rows (restore-specific)
+             [rdb'' dangled] (dangle-non-terminal-work! rdb')]
+         (trace/emit! :rf.epoch :rf.resource/restored
+                      {:rf.frame/id     frame-id
+                       :reconciled      (count entries')
+                       :orphaned-owners (vec (:orphaned reconciled))
+                       :dangled-work    (vec dangled)
+                       :clock-skews     (:skews reconciled)})
+         (doseq [[k skew] (:skews reconciled)]
+           (trace/emit! :warning :rf.resource/restore-clock-skew
+                        {:rf.frame/id  frame-id
+                         :resource-key k
+                         :skew-ms      skew
+                         :reason       (str "restored entry's absolute :stale-at is "
+                                            skew "ms ahead of the live clock — clock "
+                                            "skew makes freshness ambiguous; the next "
+                                            "live-owner ensure will resolve it.")}))
+         rdb'')))))
+
 ;; ---- client refetch decision (Spec 016 §SSR and hydration) ----------------
 ;;
 ;; After install, a hydrated entry either renders its data immediately
@@ -566,17 +738,24 @@
       on the hydration payload;
     - `:resources/hydrate-runtime-db` — the SSR `:rf/hydrate` handler
       reconciles the installed resource subtree (recompute indexes, orphan
-      SSR owners, surface clock skew).
+      SSR owners, surface clock skew);
+    - `:resources/reconcile-on-restore` — epoch `restore-epoch`'s
+      `perform-restore!` reconciles the UNPROJECTED captured snapshot it is
+      about to install (everything the hydrate reconcile does PLUS settling
+      mid-flight `:loading` / `:fetching` entries to last-stable and recording
+      restored non-terminal work-ledger rows as dangling so a pre-restore reply
+      is suppressed — Spec 016 §Restore and replay parts 2/4/5).
 
-  No-op effect on an app that never SSRs — the hooks simply sit unread.
-  Both are no-op on an SSR app WITHOUT resources (the projection contributes
-  nothing for an empty entries map; the reconcile is a no-op for a
-  resource-free runtime-db). Published from the `re-frame.resources` façade
-  so a `:reload` re-wires them."
+  No-op effect on an app that never SSRs / time-travels — the hooks simply sit
+  unread. All are no-op on an app WITHOUT resources (the projection contributes
+  nothing for an empty entries map; the reconciles are no-ops for a resource-free
+  runtime-db). Published from the `re-frame.resources` façade so a `:reload`
+  re-wires them."
   []
   (late-bind/set-fns!
     {:ssr/extend-runtime-db-projection project-resources-runtime-db
-     :resources/hydrate-runtime-db     hydrate-runtime-db})
+     :resources/hydrate-runtime-db     hydrate-runtime-db
+     :resources/reconcile-on-restore   reconcile-on-restore})
   nil)
 
 (defn hydrate-resources!

--- a/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
@@ -1,0 +1,329 @@
+(ns re-frame.resources-restore-cljs-test
+  "Epoch-restore reconcile for the Resources artefact (rf2-7r5mc2, Spec 016
+  §Restore and replay parts 2/4/5 — EP-0003 slice 8 / §9 restore conformance
+  fixtures).
+
+  Epoch restore installs the UNPROJECTED captured frame-state snapshot
+  WHOLESALE — unlike SSR hydration, which installs the server PROJECTION
+  (`:current-work` already stripped on the wire, no non-terminal work-ledger
+  rows). So `reconcile-on-restore` does everything the SSR hydrate reconcile
+  does (recompute reverse indexes from `:entries`, orphan SSR owners, clear the
+  transient `:current-work` pointer) PLUS the two restore-specific settles the
+  wire projection had already applied:
+
+    1. settle every mid-flight `:loading` / `:fetching` entry to its last
+       STABLE status (`:loaded` if data, `:error` if a failed first load,
+       `:idle` if it never loaded) — never left stranded pointing at a vanished
+       attempt (part 2);
+    2. record every restored NON-terminal work-ledger row as DANGLING (terminal
+       `:suppressed` / `:dangling`) so a pre-restore in-flight reply is
+       suppressed by the ordinary work-id + generation check (part 2).
+
+  These JVM+CLJS unit tests pin the restore reconcile contract. They map onto
+  the EP-0003 §9 restore conformance fixtures:
+
+    - epoch restore settles non-terminal restored work-ledger rows to dangling,
+      clears the entry's `:current-work`, and settles the entry to its last
+      stable status;
+    - the generation allocator is monotonic across restore (a post-restore
+      allocation strictly exceeds any pre-restore generation — the host-side
+      allocator part 1, exercised here against `state/generation-cache`);
+    - a pre-restore in-flight reply that lands after restore is suppressed by
+      the work-id + generation check (the dangled terminal row + cleared
+      `:current-work` are what make the suppression structural);
+    - owner reconciliation revives route owners the restored routing names live
+      and orphans SSR / stale-nav owners;
+    - the `:tag-index` / `:owner-index` are recomputed from `:entries` and never
+      trusted from the snapshot;
+    - restore does not eagerly refetch (a settled entry's freshness is a later
+      live-owner decision — nothing here re-fetches)."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.late-bind :as late-bind]
+   ;; load-bearing side-effecting require: the façade publishes the restore
+   ;; reconcile hook + registers the resource registrar kind.
+   [re-frame.resources]
+   [re-frame.resources.ssr :as ssr]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.test-support :as core-test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter})))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- entry
+  "A durable entry under a scoped key, mirroring the runtime's durable shape."
+  [{:keys [resource-id status data error loaded-at stale-at invalidated-at
+           generation current-work tags owners refresh-error]
+    :or   {status :loaded generation 1 tags #{} owners #{}}}]
+  (merge (state/empty-entry resource-id)
+         {:status         status
+          :data           data
+          :error          error
+          :loaded-at      loaded-at
+          :stale-at       stale-at
+          :invalidated-at invalidated-at
+          :generation     generation
+          :current-work   current-work
+          :tags           tags
+          :active-owners  owners
+          :refresh-error  refresh-error}))
+
+(defn- runtime-db-with
+  "A runtime-db carrying a `:rf.runtime/resources :entries` map (and optional
+  `:rf.runtime/work-ledger`)."
+  ([entries] (runtime-db-with entries nil))
+  ([entries ledger]
+   (cond-> {state/resources-key {:entries entries :tag-index {} :owner-index {}}}
+     ledger (assoc state/work-ledger-key ledger))))
+
+(def ^:private gkey
+  (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"}))
+
+;; ===========================================================================
+;; 1. Settle mid-flight entries to last stable (Spec 016 §Restore part 2)
+;; ===========================================================================
+
+(deftest settle-loading-entry-with-no-data-to-idle
+  (testing "a restored :loading entry that never loaded (no data, no error) settles to :idle"
+    (let [e   (entry {:resource-id :article/by-slug :status :loading :data nil
+                      :current-work [:rf.work/resource gkey 3]})
+          out (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
+          se  (get-in out [state/resources-key :entries gkey])]
+      (is (= :idle (:status se)) "loading-with-no-data → :idle, never stranded :loading")
+      (is (nil? (:current-work se)) "the vanished current-work pointer is cleared"))))
+
+(deftest settle-fetching-entry-with-data-to-loaded
+  (testing "a restored :fetching entry (background refresh in flight) keeps its
+            last-known-good data and settles to :loaded"
+    (let [e   (entry {:resource-id :article/by-slug :status :fetching
+                      :data {:title "kept"} :loaded-at 1000 :stale-at 9.0e15
+                      :current-work [:rf.work/resource gkey 4]})
+          out (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
+          se  (get-in out [state/resources-key :entries gkey])]
+      (is (= :loaded (:status se)) "fetching-with-data → :loaded (keep last-known-good)")
+      (is (= {:title "kept"} (:data se)) "the last-known-good data is preserved")
+      (is (nil? (:current-work se)) "the vanished current-work pointer is cleared"))))
+
+(deftest settle-loading-entry-with-error-to-error
+  (testing "a restored :loading entry carrying a first-load :error envelope (no
+            data) settles to :error"
+    (let [err {:kind :rf.http/http-5xx}
+          e   (entry {:resource-id :article/by-slug :status :loading :data nil
+                      :error err :current-work [:rf.work/resource gkey 5]})
+          out (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
+          se  (get-in out [state/resources-key :entries gkey])]
+      (is (= :error (:status se)) "loading-with-error-and-no-data → :error")
+      (is (= err (:error se)) "the first-load error envelope is retained")
+      (is (nil? (:current-work se))))))
+
+(deftest already-stable-entries-keep-status
+  (testing "a :loaded / :error / :idle entry is already stable — its status is
+            unchanged (only :current-work is cleared)"
+    (let [loaded (entry {:resource-id :a :status :loaded :data {:x 1}
+                         :loaded-at 1000 :stale-at 9.0e15})
+          errd   (entry {:resource-id :b :status :error :error {:kind :x}})
+          idle   (entry {:resource-id :c :status :idle})
+          ka (state/scoped-resource-key :rf.scope/global :a {})
+          kb (state/scoped-resource-key :rf.scope/global :b {})
+          kc (state/scoped-resource-key :rf.scope/global :c {})
+          out (ssr/reconcile-on-restore (runtime-db-with {ka loaded kb errd kc idle}) :app/main)
+          es  (get-in out [state/resources-key :entries])]
+      (is (= :loaded (:status (es ka))))
+      (is (= :error  (:status (es kb))))
+      (is (= :idle   (:status (es kc)))))))
+
+(deftest settle-entry-to-last-stable-is-pure
+  (testing "settle-entry-to-last-stable: the three in-flight resolutions + pass-through"
+    (is (= :idle   (:status (ssr/settle-entry-to-last-stable
+                              (entry {:resource-id :a :status :loading :data nil})))))
+    (is (= :loaded (:status (ssr/settle-entry-to-last-stable
+                              (entry {:resource-id :a :status :fetching :data {:x 1}})))))
+    (is (= :loaded (:status (ssr/settle-entry-to-last-stable
+                              (entry {:resource-id :a :status :loading :data {:x 1}})))))
+    (is (= :error  (:status (ssr/settle-entry-to-last-stable
+                              (entry {:resource-id :a :status :loading :data nil
+                                      :error {:kind :x}})))))
+    (is (= :loaded (:status (ssr/settle-entry-to-last-stable
+                              (entry {:resource-id :a :status :loaded :data {:x 1}})))))))
+
+;; ===========================================================================
+;; 2. Dangle non-terminal work-ledger rows (Spec 016 §Restore part 2)
+;; ===========================================================================
+
+(defn- work-row
+  [work-id status]
+  (-> (work-ledger/work-record
+        {:work-id work-id :frame-id :app/main :resource-key gkey
+         :generation (nth work-id 2) :transport :rf.http/managed
+         :started-at 1000})
+      (assoc :status status)))
+
+(deftest non-terminal-rows-settled-to-dangling-suppressed
+  (testing "every restored non-terminal work-ledger row settles to terminal
+            :suppressed with a :dangling outcome (so a late reply is suppressed)"
+    (let [w-running [:rf.work/resource gkey 3]
+          w-queued  [:rf.work/resource gkey 4]
+          w-abort   [:rf.work/resource gkey 5]
+          ledger    {w-running (work-row w-running :running)
+                     w-queued  (work-row w-queued :queued)
+                     w-abort   (work-row w-abort :abort-requested)}
+          rdb (runtime-db-with {gkey (entry {:resource-id :article/by-slug
+                                             :status :loading :data nil})}
+                               ledger)
+          out (ssr/reconcile-on-restore rdb :app/main)
+          out-ledger (get out state/work-ledger-key)]
+      (doseq [wid [w-running w-queued w-abort]]
+        (let [row (get out-ledger wid)]
+          (is (= :suppressed (:status row))
+              (str wid " settled to terminal :suppressed"))
+          (is (work-ledger/terminal? (:status row))
+              (str wid " is now terminal"))
+          (is (= :dangling (get-in row [:outcome :reason]))
+              (str wid " outcome marks it dangling")))))))
+
+(deftest terminal-rows-ride-through-unchanged
+  (testing "already-terminal work-ledger rows are not re-touched by restore"
+    (let [w-done [:rf.work/resource gkey 2]
+          row    (work-ledger/mark-terminal (work-row w-done :completed)
+                                            :completed {:ok true})
+          rdb (runtime-db-with {gkey (entry {:resource-id :article/by-slug
+                                             :status :loaded :data {:x 1}
+                                             :loaded-at 1 :stale-at 9.0e15})}
+                               {w-done row})
+          out (ssr/reconcile-on-restore rdb :app/main)]
+      (is (= row (get-in out [state/work-ledger-key w-done]))
+          "a completed row is unchanged"))))
+
+(deftest dangle-non-terminal-work-returns-dangled-ids
+  (testing "dangle-non-terminal-work! returns the dangled work-ids + leaves
+            terminal rows alone"
+    (let [w1 [:rf.work/resource gkey 3]
+          w2 [:rf.work/resource gkey 2]
+          ledger {w1 (work-row w1 :running)
+                  w2 (work-ledger/mark-terminal (work-row w2 :completed) :completed {})}
+          [rdb' dangled] (ssr/dangle-non-terminal-work!
+                          {state/work-ledger-key ledger})]
+      (is (= [w1] dangled) "only the non-terminal row is dangled")
+      (is (= :suppressed (get-in rdb' [state/work-ledger-key w1 :status])))
+      (is (= :completed (get-in rdb' [state/work-ledger-key w2 :status]))))))
+
+;; ===========================================================================
+;; 3. Owner reconciliation: orphan SSR, keep route (Spec 016 §Restore part 4)
+;; ===========================================================================
+
+(deftest restore-orphans-ssr-owners-keeps-route-owners
+  (testing "SSR owners orphan on restore (a settled server render); route /
+            machine / lease owners ride through to their own subsystem reconcile"
+    (let [e   (entry {:resource-id :article/by-slug :status :loaded :data {:x 1}
+                      :loaded-at 1 :stale-at 9.0e15
+                      :owners #{[:ssr "req-9" "nav-1"]
+                                [:route :route/article "nav-1"]
+                                [:machine :checkout/flow "inst-1"]}})
+          out (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
+          owners (get-in out [state/resources-key :entries gkey :active-owners])]
+      (is (not (contains? owners [:ssr "req-9" "nav-1"])) "SSR owner orphaned")
+      (is (contains? owners [:route :route/article "nav-1"]) "route owner survives")
+      (is (contains? owners [:machine :checkout/flow "inst-1"]) "machine owner survives")
+      (is (not (contains? (get-in out [state/resources-key :owner-index])
+                          [:ssr "req-9" "nav-1"]))
+          "the orphaned SSR owner is absent from the recomputed owner-index"))))
+
+;; ===========================================================================
+;; 4. Indexes recomputed from entries, never trusted (Spec 016 §Restore part 5)
+;; ===========================================================================
+
+(deftest restore-recomputes-indexes-from-entries
+  (testing "the reverse indexes are rebuilt from the reconciled entries, the
+            (deliberately wrong) snapshot indexes discarded"
+    (let [e   (entry {:resource-id :article/by-slug :status :loaded :data {:x 1}
+                      :loaded-at 1 :stale-at 9.0e15
+                      :tags #{[:article "x"]}
+                      :owners #{[:route :route/article "nav-1"]}})
+          rdb {state/resources-key {:entries     {gkey e}
+                                    :tag-index   {[:bogus] #{:nope}}
+                                    :owner-index {[:bogus] #{:nope}}}}
+          out (ssr/reconcile-on-restore rdb :app/main)
+          sub (get out state/resources-key)]
+      (is (= {[:article "x"] #{gkey}} (:tag-index sub))
+          "tag-index recomputed from the entry's :tags; bogus snapshot index discarded")
+      (is (= {[:route :route/article "nav-1"] #{gkey}} (:owner-index sub))
+          "owner-index recomputed from the entry's owners; bogus snapshot index discarded"))))
+
+;; ===========================================================================
+;; 5. The generation allocator is monotonic across restore (part 1)
+;; ===========================================================================
+
+(deftest generation-allocator-monotonic-across-restore
+  (testing "the host-side generation allocator is NOT frame-state — restore
+            cannot rewind it, so a post-restore allocation strictly exceeds any
+            pre-restore generation (anti-recycling, part 1)"
+    ;; Pre-restore: the live timeline minted up to generation 7.
+    (state/commit-generation! :app/main 7)
+    ;; The captured snapshot is from an earlier epoch where generation was 3.
+    ;; reconcile-on-restore touches ONLY durable frame-state — never the host
+    ;; allocator — so the high-water mark stays at 7.
+    (let [snapshot-entry (entry {:resource-id :article/by-slug :status :fetching
+                                 :data {:x 1} :loaded-at 1 :stale-at 9.0e15
+                                 :generation 3
+                                 :current-work [:rf.work/resource gkey 3]})]
+      (ssr/reconcile-on-restore (runtime-db-with {gkey snapshot-entry}) :app/main)
+      (is (= 7 (state/generation-snapshot :app/main))
+          "restore did not rewind the host-side allocator")
+      ;; the next allocation strictly exceeds the pre-restore generation 7 AND
+      ;; the restored snapshot's generation 3 → a pre-restore reply carrying
+      ;; generation 3 can never match a freshly-minted live entry.
+      (is (= 8 (state/next-generation (state/generation-snapshot :app/main)))
+          "the next minted generation strictly exceeds every pre-restore generation"))))
+
+;; ===========================================================================
+;; 6. Restore does not eagerly refetch / no-op cases / hook published
+;; ===========================================================================
+
+(deftest restore-does-not-eagerly-refetch
+  (testing "reconcile-on-restore settles entries but issues NO refetch fx —
+            freshness is a later live-owner decision (part 3)"
+    (let [stale (entry {:resource-id :article/by-slug :status :loaded
+                        :data {:x 1} :loaded-at 1 :stale-at 2})  ;; stale
+          out (ssr/reconcile-on-restore (runtime-db-with {gkey stale}) :app/main)]
+      ;; the reconcile returns a runtime-db, never an fx vector / dispatch plan
+      (is (map? out))
+      (is (contains? out state/resources-key))
+      (is (= {:x 1} (get-in out [state/resources-key :entries gkey :data]))
+          "the stale entry keeps its data; restore double-fetches nothing"))))
+
+(deftest restore-noop-without-resources
+  (testing "a runtime-db with no resource entries AND no work-ledger rows is
+            returned unchanged (a resource-free restore)"
+    (let [rdb {:rf.runtime/machines {:snapshots {}}}]
+      (is (= rdb (ssr/reconcile-on-restore rdb :app/main))))))
+
+(deftest restore-never-crosses-scopes
+  (testing "entries under different scopes stay isolated through the restore reconcile"
+    (let [ka (state/scoped-resource-key [:rf.scope/session {:user "a"}] :article/by-slug {:slug "x"})
+          kb (state/scoped-resource-key [:rf.scope/session {:user "b"}] :article/by-slug {:slug "x"})
+          ea (entry {:resource-id :article/by-slug :status :fetching :data {:owner "a"}
+                     :loaded-at 1 :stale-at 9.0e15 :tags #{[:article "x"]}
+                     :current-work [:rf.work/resource ka 2]})
+          eb (entry {:resource-id :article/by-slug :status :loaded :data {:owner "b"}
+                     :loaded-at 1 :stale-at 9.0e15 :tags #{[:article "x"]}})
+          out (ssr/reconcile-on-restore (runtime-db-with {ka ea kb eb}) :app/main)
+          es  (get-in out [state/resources-key :entries])]
+      (is (= {:owner "a"} (:data (es ka))) "scope-a data stays under scope-a's key")
+      (is (= :loaded (:status (es ka))) "scope-a fetching → loaded (kept data)")
+      (is (= {:owner "b"} (:data (es kb))) "scope-b data stays under scope-b's key")
+      (is (= #{ka kb} (get-in out [state/resources-key :tag-index [:article "x"]]))
+          "the shared tag maps to both scoped keys, never collapsed"))))
+
+(deftest reconcile-on-restore-hook-published
+  (testing "the :resources/reconcile-on-restore hook is published by the façade"
+    (is (some? (late-bind/get-fn :resources/reconcile-on-restore)))
+    (is (= ssr/reconcile-on-restore
+           (late-bind/get-fn :resources/reconcile-on-restore)))))


### PR DESCRIPTION
## rf2-7r5mc2 — epoch restore now reconciles the resources runtime-db (Spec 016 §Restore and replay parts 2/4/5)

### Problem
`re-frame.epoch.tool-pair/perform-restore!` installed `:frame-state-after` **verbatim** via `frame/replace-frame-state!` — a pure container install with **no resources reconcile fan-out**. The resources reconcile (`re-frame.resources.ssr/hydrate-runtime-db`) was wired ONLY to the SSR `:rf/hydrate` path; `restore-epoch` never invoked it. After a restore to an epoch captured mid-flight:

- a restored entry stayed `:loading`/`:fetching` with a `:current-work` pointer to a vanished attempt — a permanent skeleton;
- a pre-restore in-flight reply (uncancellable, on the wire) whose work-id+generation still matched the reinstalled entry could be **accepted** and write stale data into the restored entry;
- `:tag-index`/`:owner-index` + SSR/stale-route owners were trusted from the snapshot rather than reconciled.

### Fix
A new late-bound `:resources/reconcile-on-restore` hook, wired into `perform-restore!` via `re-frame.epoch.tool-pair/reconcile-runtime-db-on-restore`. It reconciles the runtime-db partition **before** the atomic install (same install path SSR hydration uses). Because restore installs the **unprojected** captured snapshot (still carrying `:current-work` + non-terminal work-ledger rows — unlike the SSR wire projection), the restore reconcile does everything the hydrate reconcile does **plus** the two settles the wire projection had already applied:

1. recompute reverse indexes from `:entries` (part 5), orphan SSR owners (part 4), clear transient `:current-work` (part 2);
2. settle every mid-flight `:loading`/`:fetching` entry to its **last stable** status — `:loaded` if it has data, `:error` if a failed first load, `:idle` if never loaded (part 2);
3. record every restored **non-terminal** work-ledger row as **dangling** (terminal `:suppressed` / `:dangling`) so a pre-restore reply is suppressed by the ordinary work-id + generation check (part 2).

**Part 1** (monotone host-side generation allocator) is already restore-safe — it is not frame-state, so restore can't rewind it; left untouched. The hook is late-bound **both ways**: epoch carries no static resources dep, and absent the resources artefact the runtime-db installs verbatim (the pre-fix behaviour, correct for a resource-free app). The new hook is an internal cross-artefact late-bind seam, not a facade var (API manifest unchanged).

### Files
- `implementation/resources/src/re_frame/resources/ssr.cljc` — `reconcile-on-restore` + `settle-entry-to-last-stable` + `dangle-non-terminal-work!`; publishes the `:resources/reconcile-on-restore` hook.
- `implementation/epoch/src/re_frame/epoch/tool_pair.cljc` — `reconcile-runtime-db-on-restore` helper + consult in `perform-restore!`.
- `implementation/core/src/re_frame/late_bind/directory.cljc` — directory entry for the new hook.
- `implementation/resources/test/re_frame/resources_restore_cljs_test.cljc` — **new** EP-0003 §9 restore conformance fixtures (15 tests).
- `implementation/epoch/test/re_frame/epoch_test.clj` — epoch-side wiring tests (4 tests).

### Gates
- clj-kondo: **0 errors** (2 pre-existing unrelated warnings).
- JVM resources (`clojure -M:test`): 129 tests / 437 assertions, **0 failures** (incl. the 15 new restore fixtures).
- JVM epoch (`clojure -M:test`): the 4 new wiring tests pass. The suite's 8 fail + 6 error are **pre-existing on origin/main** (identical baseline confirmed on the unmodified mayor checkout) — a schemas-late-bind test-isolation issue, filed as **rf2-eig68k**. This PR adds +4 tests / +11 assertions with no new regression.
- late-bind drift: 566 assertions, **0 failures**.
- API manifest `--check`: **in sync** (503 public vars; no facade var added).
- node CLJS gate (`npm run test:cljs`): **6288 tests / 22574 assertions, 0 failures**.

Design fork: none.
