### PR TITLE
fix(epoch): require schemas façade not .malli adapter in epoch JVM test (rf2-eig68k)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -40,16 +40,21 @@
             [re-frame.flows]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
-            ;; rf2-szbzei — the runtime-db schema-validation precondition on
-            ;; replace-runtime-db! / replace-frame-state! routes through the
-            ;; machine-data boundary's `:schemas/validate-with-registered-fn`
-            ;; hook, which in turn consults `:schemas/malli-validate` (published
-            ;; by this .malli adapter ns). Without it the registered-validator
-            ;; soft-passes and the runtime-db-validation-fires test can't drive
-            ;; a real schema failure. Side-effect require — alias unused.
-            ;; (Also transitively loads `re-frame.schemas` so the fixture's
-            ;; ns-load registrar snapshot includes the schemas surface.)
-            [re-frame.schemas.malli]
+            ;; rf2-eig68k — require the schemas FAÇADE, not the `.malli`
+            ;; validator adapter. The dependency runs ONE way:
+            ;; `re-frame.schemas` `:require`s `re-frame.schemas.malli`
+            ;; (publishing the Malli validate/explain hooks) — the reverse
+            ;; is NOT true. `re-frame.schemas.malli` only publishes
+            ;; `:schemas/malli-validate` / `:schemas/malli-explain`; it does
+            ;; NOT publish the `:schemas/reg-app-schema` /
+            ;; `:schemas/app-schemas-digest` / `:schemas/validate-with-
+            ;; registered-fn` registrar+digest hooks (those `set-fn!` forms
+            ;; live in `re-frame.schemas`). Requiring the façade installs
+            ;; BOTH layers: the registrar hooks the `reg-app-schema` tests
+            ;; need AND the Malli validate hook the runtime-db
+            ;; schema-mismatch precondition (rf2-szbzei) drives a real
+            ;; failure through. Side-effect require — alias unused.
+            [re-frame.schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]


### PR DESCRIPTION
## Problem (rf2-eig68k)

`re-frame.epoch-test` reported **8 failures + 6 errors** on `main`, reproducing in complete isolation (single `-v` test) — so not cross-ns contamination.

The 6 ERRORs threw `:rf.error/schemas-artefact-missing` at `late_bind.cljc:259` whenever the test body called `rf/reg-app-schema`: the `:schemas/reg-app-schema` late-bind hook was never installed. The 8 FAILs were the downstream effect — the runtime-db schema validator soft-passes when its validator hook (`:schemas/validate-with-registered-fn`) is absent, so an injection that should be rejected landed.

## Root cause

The epoch test ns required `re-frame.schemas.malli`, with a comment claiming it "also transitively loads `re-frame.schemas`". That is the **inverse** of the real dependency direction:

- `re-frame.schemas` (the façade) `:require`s `re-frame.schemas.malli` — never the reverse.
- `re-frame.schemas.malli` publishes ONLY `:schemas/malli-validate` / `:schemas/malli-explain` / `:schemas/humanize-explain!`.
- The `:schemas/reg-app-schema`, `:schemas/app-schemas-digest`, `:schemas/validate-with-registered-fn`, … `set-fn!` forms live in `re-frame.schemas` and were never loaded.

This is a **test-setup bug, not a product bug** — no source/contract change; the late-bind reset semantics are correct (`make-reset-runtime-fixture` never touches the late-bind hook table, only the registrar).

## Fix

Swap the require `[re-frame.schemas.malli]` → `[re-frame.schemas]` (the façade), which installs BOTH layers: the registrar+digest hooks the `reg-app-schema` tests need AND the Malli validate hook the runtime-db schema-mismatch precondition (rf2-szbzei) drives a real failure through. Mirrors the working pattern in `flows_schema_validation_test`, `ssr/test_fixture`, and the epoch **CLJS** test (which already requires the façade).

One-file change, JVM-test-only.

## Gates

- **Epoch JVM** (`clojure -M:test` in `implementation/epoch`): 305 tests / 1217 assertions — **0 fail / 0 error** (was 8 fail / 6 error). Targeted ns went 542 → 569 assertions as the previously-erroring tests now run their full bodies.
- **CLJS** (`npm run test:cljs`): 6274 tests / 22536 assertions — **0 fail / 0 error**. No regression.
- **clj-kondo**: 0 errors on the changed file (the one `re-frame.trace required but never used` warning is pre-existing, unrelated).

`make-reset-runtime-fixture` was NOT touched, so no corpus-wide sweep was required.

Closes rf2-eig68k.
