### PR TITLE
refactor(resources): retire vestigial SKELETON docstrings + dead error refs (rf2-4hboqi)

### DIFF
--- a/implementation/resources/deps.edn
+++ b/implementation/resources/deps.edn
@@ -12,12 +12,11 @@
 ;; ledger machinery, or any of the `:rf.resource/*` / `:rf.scope/*` /
 ;; `:rf.work/*` trace strings onto the classpath.
 ;;
-;; This is the SKELETON slice (rf2-p10npe): the namespaces + the public
-;; surface compile and load cleanly, but the runtime logic lands in
-;; later slices (rf2-afpdkn work-ledger substrate, rf2-pbxj48 resource
-;; runtime, …). Stub bodies raise `:rf.error/resource-not-implemented`
-;; where the behaviour is a later slice, so a premature call fails
-;; loudly rather than silently no-opping.
+;; The full runtime ships here (EP-0003 complete): the namespaces + the
+;; public surface, the work-ledger substrate, the resource runtime
+;; (entries, scopes, status transitions, dedupe), the managed-HTTP
+;; transport, invalidation / GC / owners, focus/reconnect revalidation,
+;; mutations, and the routing + SSR/hydration integrations.
 ;;
 ;; Consumers add this artefact alongside the core artefact:
 ;;

--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -41,16 +41,14 @@
   http), so an app that loads resources but not those optional artefacts
   carries none of their code. Nothing here `:require`s from `tools/`.
 
-  ## Slice status
+  ## Runtime
 
-  This is the rf2-p10npe artefact SKELETON (EP-0003 slice 2). The public
-  surface, the registrar kind, the late-bind wiring, and the
-  routing/SSR-projection extensions are real and load cleanly; the runtime
-  LOGIC (entry transition function, work-ledger join/dedupe, stale
-  suppression, GC, invalidation, route-plan execution, hydration install)
-  lands in later slices (rf2-afpdkn / rf2-pbxj48 / …). The event handlers
-  are registered but their bodies raise `:rf.error/resource-not-implemented`
-  so a premature call fails loudly."
+  The full runtime ships here (EP-0003 complete): the public surface, the
+  registrar kind, and the late-bind wiring sit alongside the live runtime
+  LOGIC — the entry transition function, work-ledger join/dedupe, stale
+  suppression, GC, invalidation, route-plan execution, and hydration
+  install. The `:rf.resource/*` event handlers carry the behaviour;
+  loading this namespace registers the whole family."
   (:require [re-frame.cofx :as cofx]
             [re-frame.events :as events]
             [re-frame.frame :as frame]

--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -12,13 +12,14 @@
   (distinct from the data-lifecycle `:rf.resource/invalidate-tags` /
   `:rf.resource/remove` / `:rf.resource/clear-scope` events).
 
-  SKELETON slice (rf2-p10npe): registration validation + the registry
-  write/read are real (so an app can register a resource and Xray can
-  enumerate the static registry); the per-frame runtime disposal
-  `clear-resource` performs (owner-index release, host-handle cancel,
-  in-flight abort, late-reply suppression, tag-index prune, trace) lands
-  with the runtime slices (rf2-afpdkn / rf2-pbxj48) — until then it
-  clears the registrar entry only."
+  This namespace owns the registration lifecycle only: validation + the
+  registry write/read (so an app can register a resource and Xray can
+  enumerate the static registry). `clear-resource` removes the registrar
+  entry; the per-frame runtime disposal of cached data (owner-index
+  release, host-handle cancel, in-flight abort, late-reply suppression,
+  tag-index prune, trace) is the app's job via the data-lifecycle events
+  (`:rf.resource/remove` / `:rf.resource/release-owner` /
+  `:rf.resource/clear-scope`), not a side effect of `clear-resource`."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.resources.state :as state]
@@ -184,14 +185,12 @@
   "Remove a registered resource (registration-lifecycle, NOT data
   invalidation). Per Spec 016 §Public API §Registration.
 
-  SKELETON slice (rf2-p10npe): clears the registrar entry. The full
-  contract — also dispose resource-runtime state for the id in each
-  affected frame (release owner indexes, cancel timers / host handles,
-  abort in-flight where possible, suppress late replies by generation,
-  remove tag-index rows, emit a trace) — lands with the runtime slices
-  (rf2-afpdkn / rf2-pbxj48). Application data-lifecycle work uses
-  `:rf.resource/invalidate-tags` / `:rf.resource/remove` /
-  `:rf.resource/clear-scope` instead.
+  Clears the registrar entry. This is registration-lifecycle only: it does
+  NOT dispose the per-frame resource-runtime state for the id (owner
+  indexes, timers / host handles, in-flight requests, cached rows). Cached
+  data is managed through the data-lifecycle events
+  (`:rf.resource/invalidate-tags` / `:rf.resource/remove` /
+  `:rf.resource/clear-scope`) instead.
 
   No-op (returns `resource-id`) when the id is not registered."
   [resource-id]
@@ -211,8 +210,8 @@
 
 (defn resource-ids
   "Return a vector of every registered resource id. The registry-side
-  half of `resources` (the runtime-side per-frame instance table lands
-  with the runtime slice). Per Spec 016 §Xray and AI tooling (the static
+  half of `resources` (the runtime-side per-frame instance table lives in
+  the runtime). Per Spec 016 §Xray and AI tooling (the static
   resource registry)."
   []
   (vec (registrar/ids resource-kind)))

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -2,14 +2,13 @@
   "Resource runtime-db paths + the durable entry / work-record shapes.
   Per Spec 016 §Cache home and write authority and §Frame work ledger.
 
-  SKELETON slice (rf2-p10npe): this namespace fixes the reserved
-  runtime-db key paths and the canonical durable shapes the runtime
-  reads/writes, plus the framework-write-authority registration-meta
-  stamp every resource event handler carries. The actual swaps over
-  these paths (entry transition function, work-ledger join/dedupe, host
-  side-table bookkeeping) land in the runtime slices (rf2-afpdkn /
-  rf2-pbxj48). The paths and shapes are pinned here so siblings agree on
-  one home.
+  This namespace fixes the reserved runtime-db key paths and the canonical
+  durable shapes the runtime reads/writes, plus the framework-write-
+  authority registration-meta stamp every resource event handler carries.
+  The runtime swaps over these paths (entry transition function, work-
+  ledger join/dedupe, host side-table bookkeeping) live in the sibling
+  runtime / work-ledger namespaces; the paths and shapes are pinned here
+  so every sibling agrees on one home.
 
   Cache lives ONLY at `:rf.runtime/resources` inside the runtime-db
   partition (`:rf.db/runtime`); the work ledger lives at
@@ -93,14 +92,14 @@
 
 ;; ---- durable shapes (documentation-grade defaults) -----------------------
 ;;
-;; These constructors fix the canonical durable shapes the runtime slices
-;; fill in. They allocate plain EDN — no host handles, which live OUTSIDE
+;; These constructors fix the canonical durable shapes the runtime fills
+;; in. They allocate plain EDN — no host handles, which live OUTSIDE
 ;; durable frame-state in side tables keyed by `[frame-id work-id]`.
 
 (def lifecycle-states
   "The five resource lifecycle FSM states (cache-entry status). The
-  transition function over these states lands in the runtime slice
-  (rf2-pbxj48); pinned here so siblings agree on the closed set. Per
+  transition function over these states lives in the runtime; the closed
+  set is pinned here so siblings agree on it. Per
   Spec 016 §Lifecycle is an FSM."
   #{:idle :loading :fetching :loaded :error})
 
@@ -117,9 +116,9 @@
   `:loading?` / `:has-data?` are public derived sub values, computed in
   the subs layer, never stored). Per Spec 016 §Status semantics.
 
-  SKELETON: the runtime slices populate / transition this shape; this
-  constructor pins the canonical key set so an entry written by one
-  sibling reads correctly in another."
+  The runtime populates / transitions this shape; this constructor pins
+  the canonical key set so an entry written by one sibling reads correctly
+  in another."
   [resource-id]
   {:resource/id    resource-id
    :status         :idle

--- a/implementation/resources/src/re_frame/resources/test_support.cljc
+++ b/implementation/resources/src/re_frame/resources/test_support.cljc
@@ -21,11 +21,12 @@
     transient generation high-water marks (which are NOT runtime-db
     state, so a runtime/frames reset does not clear them).
 
-  SKELETON slice (rf2-p10npe): the reset helper clears the registrar +
-  host-side generation cache; the canned-transport stub fixtures (the
-  resources analogue of the managed-HTTP canned stubs — for deterministic
-  ensure/refetch replay without a live Fetch) land with the runtime +
-  managed-HTTP slices, behind this same test-support require."
+  The reset helper clears the registrar (resource + mutation kinds), the
+  host-side generation cache, the runtime cache, and the host-side work-
+  ledger handles. Deterministic ensure/refetch replay without a live Fetch
+  rides on the managed-HTTP canned-stub fixtures (`re-frame.http-test-
+  support`), reached through the same managed-HTTP transport the runtime
+  uses."
   (:require [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.resources.mutation-registry :as mutation-registry]

--- a/implementation/resources/src/re_frame/resources/transport.cljc
+++ b/implementation/resources/src/re_frame/resources/transport.cljc
@@ -11,9 +11,9 @@
   namespace holds that neutral seam; the HTTP lowering itself lives in the
   sibling `re-frame.resources.transport.http`.
 
-  SKELETON slice (rf2-p10npe): the transport dispatch is named; the
-  ensure/refetch → work-ledger-record → managed-HTTP lowering lands with
-  the runtime + managed-HTTP slices."
+  The transport dispatch lives here; the runtime's ensure/refetch →
+  work-ledger-record → managed-HTTP lowering routes through `lower-ensure`
+  into the sibling `re-frame.resources.transport.http`."
   (:require [re-frame.resources.transport.http :as http]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -43,8 +43,8 @@
   + generation before writing (cancellation is an optimization; stale
   suppression is the correctness boundary).
 
-  SKELETON: delegates the shape; the runtime slice supplies the live
-  ensure-context."
+  The runtime supplies the live ensure-context; this fn delegates to the
+  transport's lowering."
   [transport ensure-ctx]
   (let [transport (or transport default-transport)]
     (if (= transport managed-http-transport)

--- a/implementation/resources/src/re_frame/resources/transport/http.cljc
+++ b/implementation/resources/src/re_frame/resources/transport/http.cljc
@@ -24,9 +24,9 @@
   `:rf.http/managed` fx through the ordinary effect path; this namespace
   builds the args map (request-id + reply addressing).
 
-  SKELETON slice (rf2-p10npe): the lowering shape is named; the live
-  request-id minting + work-ledger correlation land with the managed-HTTP
-  + runtime slices."
+  The lowering ships here: `lower` mints the request-id and stamps the
+  work-ledger correlation (`:work-id` / `:resource-key` / `:scope` /
+  `:rf.frame/id` / `:generation`) into the reply addressing."
   (:require [re-frame.late-bind :as late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -148,10 +148,9 @@
   reserved reply keys are rejected (`build-managed-args`)."
   [ensure-ctx]
   ;; Defense-in-depth: surface the managed-HTTP feature presence through
-  ;; the always-published feature probe (consult ≠ static require). The
-  ;; runtime slice will use this to fail-closed with a clear
-  ;; artefact-missing error when an HTTP-backed read is issued without
-  ;; the HTTP artefact on the classpath.
+  ;; the always-published feature probe (consult ≠ static require). This
+  ;; fails closed with a clear artefact-missing error when an HTTP-backed
+  ;; read is issued without the HTTP artefact on the classpath.
   (when-not (late-bind/get-fn :http/abort-on-actor-destroy)
     (throw (ex-info ":rf.error/http-artefact-missing"
                     {:rf.error/id :rf.error/http-artefact-missing

--- a/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
@@ -1,9 +1,9 @@
 (ns re-frame.resources-skeleton-cljs-test
-  "Skeleton smoke tests for the Resources artefact (rf2-p10npe, Spec 016
-  §EP-0003 slice 2 — the artefact SKELETON).
+  "Surface + wiring smoke tests for the Resources artefact (rf2-p10npe,
+  Spec 016 §EP-0003).
 
-  This slice ships the public surface + the wiring, NOT the runtime logic.
-  These tests lock what the skeleton GUARANTEES:
+  These tests lock the artefact's public surface and registration wiring —
+  the load-time guarantees that the runtime behaviour tests then build on:
 
     1. the artefact ns loads cleanly (the require itself is the smoke);
     2. `reg-resource` registers under the `:resource` registrar kind, and
@@ -16,14 +16,13 @@
        `(rf/feature-loaded? :resources)` is true;
     6. the public-API late-bind hooks are published;
     7. the passive `:rf.resource/*` subs are registered;
-    8. the resource event handlers are registered (their skeleton bodies
-       raise `:rf.error/resource-not-implemented` — a later slice fills
-       them in);
+    8. the `:rf.resource/*` event family is registered (and carries
+       framework-write authority);
     9. the late-bound routing accepted-key extension accepts `:resources`.
 
   Runtime BEHAVIOUR (entry transitions, work ledger, stale suppression,
-  GC, invalidation, hydration) is out of scope here — those land with the
-  runtime slices."
+  GC, invalidation, hydration) is exercised by the sibling runtime tests
+  (`resources_runtime_cljs_test`, `resources_work_ledger_cljs_test`, …)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.features :as features]
             [re-frame.late-bind :as late-bind]


### PR DESCRIPTION
@
Closes rf2-4hboqi.

The resources runtime is fully implemented (EP-0003 12/12 complete), but several `re-frame.resources*` ns/fn docstrings plus the `deps.edn` header still described the artefact as the rf2-p10npe SKELETON slice whose stub bodies raise the now-dead `:rf.error/resource-not-implemented` error. This updates those docstrings to describe the shipped runtime and removes the dead error references.

Docstring/comment cleanup only — no runtime behaviour change.

## Sites cleaned (grep-confirmed complete)

Dead `:rf.error/resource-not-implemented` refs (all 3 — none in live code):
- `deps.edn` header comment
- `src/re_frame/resources.cljc` `## Slice status` section
- `test/re_frame/resources_skeleton_cljs_test.cljs` event-family guarantee

Stale `SKELETON slice (rf2-p10npe)` / `lands in later/runtime slice` framing:
- `resources.cljc` — `## Slice status` -> `## Runtime`
- `resources/registry.cljc` — ns + `clear-resource` (clarified registration-lifecycle-only; runtime disposal via `:rf.resource/remove` / `release-owner` / `clear-scope`) + `resource-ids`
- `resources/state.cljc` — ns + `lifecycle-states` + `empty-entry` + durable-shapes comment
- `resources/transport.cljc` — ns + `lower-ensure`
- `resources/transport/http.cljc` — ns + the feature-probe defense comment
- `resources/test_support.cljc` — ns (reset helper described accurately; canned stubs via `re-frame.http-test-support`)
- `resources_skeleton_cljs_test.cljs` — ns docstring -> surface+wiring smoke

Left intact (legitimate, not vestigial): `ssr.cljc` "error / skeleton / fallback" (SSR loading-skeleton UI mode), the `runtime_cljs_test` "skeleton invariant held" assertion + its own coverage-scope note, and `work_ledger.cljc` "later slices extend it to timers / streams" (genuine forward-extensibility design language).

## Gates
- `clj-kondo --lint resources/src resources/test`: 0 errors (3 pre-existing warnings, none introduced)
- JVM resources (`clojure -M:test`): 114 tests / 390 assertions, 0 failures / 0 errors
- `npm run test:cljs`: 6274 tests / 22536 assertions, 0 failures / 0 errors
@