### PR TITLE
fix(schemas): per-slot decision scoping for validation redaction (rf2-3qam7b)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/validate.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validate.cljc
@@ -140,54 +140,139 @@
 (def ^:private value-bearing-slots
   [:value :received :explain :explain-humanized :rf.fx/args :rf.sub/query-v])
 
-(defn- redact-tags
-  "Replace value-bearing slots in a tags map with the `:rf/redacted`
-  sentinel. Per Spec 010 §`:sensitive?` — privacy in schema-validation
-  error traces. Stamps `:sensitive? true` so consumers filter
-  correctly. Idempotent — safe to call on an already-redacted map.
+;; ---- PER-SLOT DECISION SCOPING (rf2-3qam7b / the rf2-me69cb principle) ----
+;;
+;; THE PRINCIPLE: the SCOPE of a slot's `:sensitive?` redaction decision MUST
+;; MATCH the SCOPE of the value that slot actually carries.
+;;
+;;   - A slot that carries a LEAF-NARROWED value (only the failing leaf — e.g.
+;;     `:value` on the app-db path, which is `(get-in reg-slice in-path)`) may
+;;     use the LEAF-PRECISE check `walker/schema-sensitive-at?`: a sensitive
+;;     SIBLING of the failing leaf is genuinely not present in the carried
+;;     value, so it must not force redaction (the rf2-oh4se / rf2-k0ew8n
+;;     precise-narrowing win).
+;;
+;;   - A slot that carries the WHOLE PAYLOAD verbatim (`:explain` /
+;;     `:explain-humanized` / `:received` / `:rf.fx/args` / `:rf.sub/query-v`,
+;;     and `:value` on every surface EXCEPT the app-db leaf) MUST use the
+;;     ROOT / whole-schema check `walker/schema-has-sensitive?`. The whole
+;;     payload carries every CONFORMING sibling too, so a conforming
+;;     `:sensitive?` sibling (e.g. a valid `:jwt` next to a failing `:name`)
+;;     rides INSIDE that slot — a leaf-precise decision keyed on the failing
+;;     `:name` would (wrongly) clear it and the jwt would egress to Xray /
+;;     pair-MCP unredacted. This was the rf2-3qam7b leak: a leaf-precise
+;;     decision was gating whole-payload slots (sibling-blind).
+;;
+;; `schema-sensitive-at?` is a SUBSET of `schema-has-sensitive?` — a sensitive
+;; leaf ancestor/descendant implies the schema declares something sensitive —
+;; so the whole-payload decision (`schema-has-sensitive?`) also governs the
+;; `:sensitive?` top-level stamp (a redaction of ANY value-bearing slot stamps
+;; the trace so Xray routing + the MCP egress gate see it).
+;;
+;; The app-db path is the ONLY surface that narrows a slot (`:value` to the
+;; failing leaf); every meta-bearing surface (event / cofx / fx / sub) carries
+;; the WHOLE checked value in EVERY value-bearing slot, so its whole decision
+;; is the root check. The off-namespace seam `redact-validation-tags` is
+;; already whole-only (the coarse root check; rf2-me69cb=(a)) and is unchanged.
+(def ^:private app-db-narrowed-slots
+  "The value-bearing slots the app-db hot path NARROWS to the failing leaf
+  (`:value` = `(get-in reg-slice in-path)`). These — and ONLY these — use the
+  leaf-precise `schema-sensitive-at?` decision; every other value-bearing slot
+  on that surface carries the whole reg-slice and uses the root check."
+  #{:value})
 
-  The six redacted slots (`:value`, `:received`, `:explain`,
-  `:explain-humanized`, `:rf.fx/args`, `:rf.sub/query-v`) are the
-  canonical set per the Spec 010 §`:sensitive?` redaction-shape list.
-  Three of them are per-surface / conditional names carried only on a
-  subset of emit-sites (`:rf.fx/args` on `:where :fx-args`;
-  `:rf.sub/query-v` on `:where :sub-return`; `:explain-humanized` only
-  when the `:schemas/humanize-explain!` hook is installed); the
-  `contains?` guards make those clauses no-ops on the surfaces whose
-  tag maps don't carry the slot.
-  Per rf2-nijom this replaces the previous fx-only `extra-redact`
-  lambda — the redaction is now symmetric across every value-bearing
-  slot, and the schema lists them canonically.
+(defn- scrub-slots
+  "Replace each slot of `slots` present in `tags` with the `:rf/redacted`
+  sentinel. `contains?`-guarded so a slot a surface doesn't carry is a no-op."
+  [tags slots]
+  (reduce (fn [t slot]
+            (cond-> t (contains? t slot) (assoc slot redacted-sentinel)))
+          tags
+          slots))
+
+(defn- redact-tags
+  "Scrub the value-bearing slots of a tags map to the `:rf/redacted` sentinel
+  under the WHOLE-PAYLOAD (root) decision, stamping `:sensitive? true`. Per
+  Spec 010 §`:sensitive?` — privacy in schema-validation error traces.
+  Idempotent — safe to call on an already-redacted map.
+
+  This is the WHOLE-PAYLOAD redactor: it treats EVERY value-bearing slot as
+  carrying the whole checked value, so it is the correct shape for the
+  meta-bearing surfaces (event / cofx / fx / sub via `run-validation`, where
+  no slot is leaf-narrowed) and for the off-namespace seam
+  `redact-validation-tags` (already coarse + root-checked, rf2-me69cb=(a)). The
+  app-db hot path, which DOES narrow `:value` to the failing leaf, uses
+  `redact-tags-per-slot` below to apply the leaf-precise decision to that one
+  slot while keeping the root decision on the whole-payload slots.
+
+  The six candidate slots (`:value`, `:received`, `:explain`,
+  `:explain-humanized`, `:rf.fx/args`, `:rf.sub/query-v`) are the canonical set
+  per the Spec 010 §`:sensitive?` redaction-shape list. Three are per-surface /
+  conditional names carried only on a subset of emit-sites (`:rf.fx/args` on
+  `:where :fx-args`; `:rf.sub/query-v` on `:where :sub-return`;
+  `:explain-humanized` only when the `:schemas/humanize-explain!` hook is
+  installed); the `contains?` guards make those clauses no-ops on the surfaces
+  whose tag maps don't carry the slot.
 
   Per rf2-adtp2 / rf2-p2adl Q2 — `:rf.sub/query-v` (the caller-supplied
-  subscription query vector on `:where :sub-return` emissions) is
-  the lookup key, not just an id, and on `:sensitive?`-marked subs
-  typically carries the same secret material the registered schema
-  is gating (user ids, auth tokens, document ids). Without
-  redaction the failure trace re-leaks it alongside the failing
-  return value the other clauses just scrubbed.
+  subscription query vector on `:where :sub-return` emissions) is the lookup
+  key, not just an id, and on `:sensitive?`-marked subs typically carries the
+  same secret material the registered schema is gating (user ids, auth tokens,
+  document ids). Without redaction the failure trace re-leaks it alongside the
+  failing return value the other clauses just scrubbed.
 
-  Per rf2-qhq3f — `:explain-humanized` (the operator-readable
-  decomposition of the explainer's output, per Spec 010 §Humanize-hook)
-  is itself value-bearing: Malli's `malli.error/humanize` carries the
-  failing value verbatim under its path-shaped output. Spec 010
-  §Humanize-hook §Composition with `:sensitive?` requires BOTH
-  `:explain` AND `:explain-humanized` to redact symmetrically — a
-  redacted-raw / leaked-humanized split would re-leak the value the
-  `:explain` clause just scrubbed. The slot is built from the
-  pre-redaction explanation at the emit-sites (so it carries the real
-  humanized payload on non-sensitive failures) and this clause scrubs
-  it to the sentinel on sensitive failures — the sentinel is present
-  (not omitted), so the trace shape is symmetric across sensitive and
-  non-sensitive surfaces and Xray's violation block, which prefers
-  `:explain-humanized`, reads `:rf/redacted` rather than falling through
-  to a missing slot."
+  Per rf2-qhq3f — `:explain-humanized` (the operator-readable decomposition of
+  the explainer's output, per Spec 010 §Humanize-hook) is itself value-bearing:
+  Malli's `malli.error/humanize` carries the failing value verbatim under its
+  path-shaped output. Spec 010 §Humanize-hook §Composition with `:sensitive?`
+  requires BOTH `:explain` AND `:explain-humanized` to redact symmetrically — a
+  redacted-raw / leaked-humanized split would re-leak the value the `:explain`
+  clause just scrubbed. The slot is built from the pre-redaction explanation at
+  the emit-sites (so it carries the real humanized payload on non-sensitive
+  failures) and this clause scrubs it to the sentinel on sensitive failures —
+  the sentinel is present (not omitted), so the trace shape is symmetric across
+  sensitive and non-sensitive surfaces and Xray's violation block, which prefers
+  `:explain-humanized`, reads `:rf/redacted` rather than falling through to a
+  missing slot."
   [tags]
-  (-> (reduce (fn [t slot]
-                (cond-> t (contains? t slot) (assoc slot redacted-sentinel)))
-              tags
-              value-bearing-slots)
+  (-> (scrub-slots tags value-bearing-slots)
       (assoc :sensitive? true)))
+
+(defn- redact-tags-per-slot
+  "PER-SLOT DECISION SCOPING (rf2-3qam7b). Scrub value-bearing slots under TWO
+  decisions matched to the scope of the value each slot carries:
+
+    - `whole-sensitive?`    the ROOT / whole-schema decision
+                            (`walker/schema-has-sensitive?`) — governs every
+                            WHOLE-PAYLOAD slot (every value-bearing slot NOT in
+                            `narrowed-slots`) and the `:sensitive?` stamp.
+    - `narrowed-sensitive?` the LEAF-PRECISE decision
+                            (`walker/schema-sensitive-at?` on the failing leaf)
+                            — governs ONLY the slots in `narrowed-slots`, which
+                            the surface has narrowed to that exact leaf.
+
+  A WHOLE-PAYLOAD slot carries every conforming sibling, so a conforming
+  `:sensitive?` sibling rides inside it; gating it on the leaf-precise decision
+  (sibling-blind) leaked the sibling (rf2-3qam7b). A leaf-narrowed slot carries
+  ONLY the failing leaf, so the leaf-precise decision is exact there — keeping
+  the rf2-oh4se no-sibling-taint precision for that one slot.
+
+  Because `schema-sensitive-at?` ⊆ `schema-has-sensitive?` (a sensitive leaf
+  ancestor/descendant implies the schema declares something sensitive),
+  `whole-sensitive?` is the broader condition: whenever a leaf-narrowed slot is
+  scrubbed the whole-payload slots are too, so `:sensitive?` is stamped (under
+  `whole-sensitive?`) and `:explain` / `:received` are never left verbatim
+  beside a redacted `:value`. Idempotent.
+
+  Only the app-db hot path uses this (with `narrowed-slots` =
+  `app-db-narrowed-slots`); the meta-bearing surfaces narrow nothing and use
+  the whole-only `redact-tags`."
+  [tags whole-sensitive? narrowed-sensitive? narrowed-slots]
+  (let [whole-slots (remove narrowed-slots value-bearing-slots)]
+    (cond-> tags
+      whole-sensitive?    (-> (scrub-slots whole-slots)
+                              (assoc :sensitive? true))
+      narrowed-sensitive? (scrub-slots narrowed-slots))))
 
 (defn- common-prefix
   "Return the longest common prefix of two sequential collections (as a
@@ -391,10 +476,18 @@
                      value, sub return value, fx args).
     - `walk-schema?` boolean — when true AND the validator fails,
                      consult the schema's per-slot `:sensitive?` walker
-                     before emitting. Event vectors are not schema-walked
-                     (event vectors aren't `:map`-shaped, so per-slot
-                     `:sensitive?` props don't apply) so wrappers
-                     pass `false`; cofx / fx / sub-return pass `true`.
+                     before emitting. Per rf2-a5kzs (finding 1) all four
+                     meta-bearing surfaces now pass `true`: an event vector
+                     isn't itself `:map`-shaped but its `:cat`/`:catn` payload
+                     commonly is (a login schema marks `:password` sensitive),
+                     and cofx / fx / sub-return validate a map value directly.
+                     Per rf2-3qam7b the decision here is the WHOLE-schema
+                     `schema-has-sensitive?` (NOT the leaf-precise
+                     `schema-sensitive-at?`): every value-bearing slot on these
+                     surfaces carries the WHOLE checked value, so a conforming
+                     sensitive sibling rides inside it and the redaction scope
+                     must match the carried-value scope (see the `:else`
+                     branch's PER-SLOT DECISION SCOPING note).
     - `build-base-tags`  `(fn [schema explanation] -> map)` — produces
                      the per-fn tag map (`:where`, `:reason`, etc.)
                      EXCLUDING any sensitivity stamping. Also the source
@@ -494,19 +587,29 @@
                 ;; `safe-explain` so a throwing explainer can't unwind past
                 ;; this false and become a catch-as-pass at the call-site.
                 explanation (safe-explain schema value)
-                ;; Per rf2-k0ew8n (finding 1) — path-TARGETED sensitivity,
-                ;; matching the precise model `validate-app-schema!` already
-                ;; uses. Derive the failing leaf path from the explainer's
-                ;; `:in` and ask `schema-sensitive-at?` whether THAT slot is
-                ;; sensitive, rather than the coarse `schema-has-sensitive?`
-                ;; which over-redacts a non-sensitive failing sibling whenever
-                ;; ANY unrelated sibling in the schema is sensitive. Fail-SAFE:
-                ;; when the explainer yields no extractable `:in` path,
-                ;; `schema-sensitive-at?` degrades to the whole-schema check
-                ;; (redact if the schema carries sensitivity anywhere).
-                in-path     (failing-in-path explanation)
+                ;; PER-SLOT DECISION SCOPING (rf2-3qam7b). The meta-bearing
+                ;; surfaces (event / cofx / fx / sub) carry the WHOLE checked
+                ;; value in EVERY value-bearing slot — `:value` / `:received` /
+                ;; `:explain` / `:explain-humanized` / `:rf.fx/args` /
+                ;; `:rf.sub/query-v` are all the whole event-vector / cofx /
+                ;; fx-args / sub-return value (nothing here is narrowed to the
+                ;; failing leaf the way the app-db path narrows `:value`). So
+                ;; the redaction decision MUST be scoped to the WHOLE schema
+                ;; (`schema-has-sensitive?`), NOT the leaf-precise
+                ;; `schema-sensitive-at?`. A leaf-precise decision was the
+                ;; rf2-3qam7b leak: a failing NON-sensitive sibling (e.g.
+                ;; `:age`) cleared redaction while a CONFORMING sensitive
+                ;; sibling (e.g. `:password` / `:jwt`) rode unredacted inside
+                ;; every whole-payload slot, egressing to Xray + pair-MCP. The
+                ;; earlier rf2-k0ew8n / rf2-4q681i "don't over-redact a
+                ;; non-sensitive failing sibling" win does NOT apply here
+                ;; precisely because there is no narrowed slot to apply it to —
+                ;; the whole payload carries the sibling. (It DOES still apply
+                ;; to the app-db `:value` slot, which is genuinely leaf-narrowed
+                ;; — see `validate-app-schema!`.) `walk-schema?` stays the knob
+                ;; for whether to consult the walker at all.
                 sensitive?  (and walk-schema?
-                                 (walker/schema-sensitive-at? schema in-path))
+                                 (walker/schema-has-sensitive? schema))
                 ;; Per rf2-qhq3f — humanize from the RAW explanation here,
                 ;; before redaction, and fold the slot into base-tags so
                 ;; `redact-tags` scrubs it symmetrically with `:explain`
@@ -647,14 +750,21 @@
                  ;; regardless of whether path narrowing succeeded.
                  ;;
                  ;; Per Spec 010 §`:sensitive?` — privacy in schema-
-                 ;; validation error traces (rf2-kj51z). The path-
-                 ;; targeted check (`schema-sensitive-at?`) replaces
-                 ;; the coarse whole-schema check: a failure at a
-                 ;; non-sensitive slot in a schema that also declares
-                 ;; a sibling slot sensitive no longer suffers
-                 ;; redaction. Conservative semantics preserved —
-                 ;; ancestor-sensitive OR descendant-sensitive at the
-                 ;; failing path counts.
+                 ;; validation error traces (rf2-kj51z / rf2-3qam7b).
+                 ;; The redaction decision is PER-SLOT-SCOPED (see the
+                 ;; `let` below): the path-targeted check
+                 ;; (`schema-sensitive-at?`) governs only the slots this
+                 ;; surface NARROWS to the failing leaf — `:value`, plus
+                 ;; the `:path` / `:reason` leaf coordinates — so a
+                 ;; failure at a non-sensitive leaf whose SIBLING is
+                 ;; sensitive does not redact THOSE (the precise-narrowing
+                 ;; win; ancestor- OR descendant-sensitive at the leaf
+                 ;; counts). The WHOLE-PAYLOAD slots (`:explain` /
+                 ;; `:explain-humanized`, which carry the whole reg-slice)
+                 ;; stay under the coarse `schema-has-sensitive?` root
+                 ;; check, because a conforming sensitive sibling rides
+                 ;; inside them — gating them on the leaf decision was the
+                 ;; rf2-3qam7b leak.
                  ;;
                  ;; Per rf2-wkxng / rf2-6m0se the trace's tag carries
                  ;; `:rollback? true` (consistent with depth-exceeded;
@@ -677,9 +787,42 @@
                        leaf-value  (if in-path
                                      (get-in reg-slice in-path)
                                      reg-slice)
-                       sensitive?  (if in-path
-                                     (walker/schema-sensitive-at? schema in-path)
-                                     (walker/schema-has-sensitive? schema))
+                       ;; PER-SLOT DECISION SCOPING (rf2-3qam7b). The app-db
+                       ;; hot path is the ONLY surface that NARROWS a slot:
+                       ;; `:value` is `(get-in reg-slice in-path)` — just the
+                       ;; failing leaf. So it carries TWO redaction decisions
+                       ;; scoped to the two value-scopes it ships:
+                       ;;
+                       ;;   - `leaf-sensitive?` — the LEAF-PRECISE check
+                       ;;     (`schema-sensitive-at?` at the failing `:in`;
+                       ;;     whole-schema fallback when no `:in` extractable).
+                       ;;     Per rf2-oh4se / rf2-kj51z a failure at a
+                       ;;     non-sensitive leaf whose SIBLING is sensitive is
+                       ;;     NOT redacted — the leaf value genuinely doesn't
+                       ;;     contain the sibling. This decision governs the
+                       ;;     NARROWED `:value` slot AND the `:path` / `:reason`
+                       ;;     sanitization (both keyed to the failing leaf).
+                       ;;
+                       ;;   - `whole-sensitive?` — the ROOT / whole-schema check
+                       ;;     (`schema-has-sensitive?`). This governs the
+                       ;;     WHOLE-PAYLOAD slots `:explain` /
+                       ;;     `:explain-humanized`, which carry the WHOLE
+                       ;;     `reg-slice` verbatim (Malli's explanation root
+                       ;;     `:value` is the whole input map / the humanized
+                       ;;     decomposition is path-shaped over it). A
+                       ;;     CONFORMING sensitive sibling (the rf2-3qam7b leak:
+                       ;;     `[:name]` fails, `[:jwt {:sensitive?}]` conforms)
+                       ;;     rides inside `:explain`; gating `:explain` on the
+                       ;;     leaf-precise `[:name]` decision (sibling-blind)
+                       ;;     leaked the live jwt to Xray + pair-MCP. The root
+                       ;;     check catches it because the schema declares the
+                       ;;     jwt slot sensitive. `whole-sensitive?` also stamps
+                       ;;     the top-level `:sensitive?` (it is the broader
+                       ;;     decision — `leaf-sensitive?` ⊆ `whole-sensitive?`).
+                       leaf-sensitive?  (if in-path
+                                          (walker/schema-sensitive-at? schema in-path)
+                                          (walker/schema-has-sensitive? schema))
+                       whole-sensitive? (walker/schema-has-sensitive? schema)
                        ;; Per rf2-ss06u.1 / rf2-612mri — some `:in`
                        ;; segments are value-bearing, not structural: a
                        ;; `:set` failure's segment is the failing ELEMENT
@@ -691,13 +834,17 @@
                        ;; `:path` tag would ship those verbatim — defeating
                        ;; the redaction the `:value` / `:explain` slots
                        ;; apply, and re-leaking through `:reason` (built from
-                       ;; the same path). When the slot is sensitive, scrub
-                       ;; the value-bearing segments out of `:path` via
-                       ;; `sanitize-sensitive-path` (navigable `:vector` /
-                       ;; `:tuple` / `:map` segments + NON-sensitive `:map-of`
-                       ;; keys are kept so `:path` stays a useful locator for
-                       ;; those shapes — the bead regression).
-                       path-in     (if (and in-path sensitive?)
+                       ;; the same path). The `:path` / `:reason` sanitization
+                       ;; is keyed to the failing leaf, so it scopes to
+                       ;; `leaf-sensitive?` (the path segments are the failing
+                       ;; leaf's coordinates — a conforming sibling's secret
+                       ;; never appears in THIS leaf's path). When the leaf is
+                       ;; sensitive, scrub the value-bearing segments out of
+                       ;; `:path` via `sanitize-sensitive-path` (navigable
+                       ;; `:vector` / `:tuple` / `:map` segments + NON-sensitive
+                       ;; `:map-of` keys are kept so `:path` stays a useful
+                       ;; locator for those shapes — the bead regression).
+                       path-in     (if (and in-path leaf-sensitive?)
                                      (walker/sanitize-sensitive-path schema in-path)
                                      in-path)
                        leaf-path   (if path-in
@@ -724,7 +871,13 @@
                                             :recovery        :no-recovery}
                                      event-id          (assoc :failing-id event-id)
                                      (some? humanized) (assoc :explain-humanized humanized))
-                       tags        (if sensitive? (redact-tags base-tags) base-tags)]
+                       ;; PER-SLOT DECISION SCOPING: `:value` (narrowed) under
+                       ;; the leaf decision; `:explain` / `:explain-humanized`
+                       ;; (whole reg-slice) under the root decision.
+                       tags        (redact-tags-per-slot base-tags
+                                                         whole-sensitive?
+                                                         leaf-sensitive?
+                                                         app-db-narrowed-slots)]
                    (emit-validation-failure! tags)
                    (recur (next entries) false)))))
            ok?))

--- a/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
@@ -37,7 +37,8 @@
   Backward-compat: `:explain` and the structural slots
   (`:failing-id`, `:where`, `:frame`, `:recovery`, `:reason`) ride
   the trace verbatim under both the precise and fallback paths."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
             [re-frame.schemas.malli]
@@ -118,35 +119,47 @@
 
 ;; ---- sensitivity is path-targeted, not whole-schema ----------------------
 
-(deftest non-sensitive-sibling-failure-not-redacted
-  (testing "rf2-oh4se — a failure at a non-sensitive sibling does NOT
-            trigger redaction merely because another slot in the same
-            schema is :sensitive?. The over-broad redaction was the
-            symptom the bead fix targets."
+(deftest non-sensitive-sibling-failure-narrowed-value-verbatim-whole-explain-redacted
+  (testing "rf2-oh4se + rf2-3qam7b — PER-SLOT DECISION SCOPING on the app-db
+            path. A failure at a non-sensitive leaf (:name) whose CONFORMING
+            sibling (:password) is sensitive: the LEAF-NARROWED `:value` slot
+            (just the failing leaf, 42) rides VERBATIM — the precise-narrowing
+            win the leaf-precise check buys — but the WHOLE-PAYLOAD `:explain`
+            slot (which carries the whole :user map, conforming secret
+            included) MUST redact under the root check, else the live
+            `secret-pw` egresses. This is the bead's repro: [:name] fails,
+            [:password {:sensitive?}] conforms."
     (rf/reg-app-schema [:user]
                        [:map
                         [:name     :string]
                         [:password {:sensitive? true} :string]])
-    ;; :name is the failing leaf (int, not string); :password is
-    ;; correct. The failing leaf [:user :name] is NOT sensitive; the
-    ;; sibling [:user :password] is sensitive but does not appear in
-    ;; the failing value. No redaction.
+    ;; :name is the failing leaf (int, not string); :password "secret-pw"
+    ;; CONFORMS — a sensitive sibling that does NOT appear in the narrowed
+    ;; failing leaf value, but DOES ride inside the whole-map :explain slot.
     (let [traces (capture-trace
                    #(schemas/validate-app-schema!
                       {:user {:name 42 :password "secret-pw"}}
                       :u/bad-name))
           v      (first traces)]
-      (is (not (contains? v :sensitive?))
-          "no top-level :sensitive? stamp — failing leaf is non-sensitive")
-      (is (not (contains? (:tags v) :sensitive?))
-          ":tags :sensitive? also absent")
+      ;; The leaf-narrowed slot is scoped to the failing leaf — verbatim.
       (is (= 42 (-> v :tags :value))
-          ":value rides verbatim — sibling-sensitive does not redact a
-          non-sensitive leaf")
-      (is (= [:user :name] (-> v :tags :path)))
-      (is (some? (-> v :tags :explain))
-          ":explain rides verbatim — the explainer output is the leaf's,
-          not the whole schema's"))))
+          ":value (narrowed to the failing leaf [:user :name]) rides verbatim —
+           the leaf-precise check keeps the precise-narrowing win for the
+           narrowed slot")
+      (is (= [:user :name] (-> v :tags :path))
+          ":path stays the navigable leaf locator (the failing leaf is not
+           sensitive, so no path sanitization)")
+      ;; The whole-payload :explain slot carries the conforming sensitive
+      ;; sibling — it redacts under the ROOT check (rf2-3qam7b).
+      (is (= :rf/redacted (-> v :tags :explain))
+          ":explain (whole reg-slice) redacted — it carries the conforming
+           sensitive :password sibling")
+      (is (true? (:sensitive? v))
+          "top-level :sensitive? stamp present — a whole-payload slot redacted")
+      ;; The conforming secret never egresses anywhere in the trace.
+      (is (not (str/includes? (pr-str (:tags v)) "secret-pw"))
+          "the conforming sensitive sibling's value does NOT appear anywhere in
+           the emitted tags (the rf2-3qam7b leak this fix closes)"))))
 
 (deftest sensitive-leaf-failure-redacted
   (testing "the failing leaf IS the sensitive slot — redaction fires"

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -340,24 +340,34 @@
       (is (not= :rf/redacted (-> v :tags :value))
           ":value rides verbatim — alignment didn't spuriously redact"))))
 
-(deftest app-db-validation-collection-sibling-sensitive-not-over-redacted
-  (testing "rf2-g5auo + rf2-oh4se — a failure at a NON-sensitive slot inside
-            a collection element must NOT inherit a sibling slot's
-            sensitivity (the precise-narrowing win still holds through
-            collections)"
-    ;; :secret is sensitive, :age is not; only :age fails (string, not int).
+(deftest app-db-validation-collection-sibling-narrowed-value-verbatim-whole-explain-redacted
+  (testing "rf2-g5auo + rf2-oh4se + rf2-3qam7b — PER-SLOT DECISION SCOPING
+            through a collection. A failure at a NON-sensitive slot (:age)
+            inside a collection element whose CONFORMING sibling (:secret) is
+            sensitive: the LEAF-NARROWED `:value` slot (the failing :age leaf,
+            \"no\") rides verbatim — the precise-narrowing win — but the
+            WHOLE-PAYLOAD `:explain` slot (the whole vector, conforming :secret
+            included) redacts under the root check, else the conforming
+            sensitive sibling egresses"
+    ;; :secret is sensitive AND conforms; :age is non-sensitive AND fails.
     (let [v (app-db-failure-trace
               [:people]
               [:vector [:map
                         [:secret {:sensitive? true} :string]
                         [:age :int]]]
-              {:people [{:secret "ok" :age "no"}]}
+              {:people [{:secret "SECRET-OK-9f3a" :age "no"}]}
               :people/bad)]
       (is (some? v))
-      (is (not (contains? v :sensitive?))
-          "the failing :age slot is not sensitive; its sibling :secret doesn't taint it")
-      (is (not= :rf/redacted (-> v :tags :value))
-          ":value rides verbatim — only the failing :age leaf is in the path"))))
+      ;; Narrowed slot — only the failing :age leaf, verbatim.
+      (is (= "no" (-> v :tags :value))
+          ":value (narrowed to the failing [:people 0 :age] leaf) rides verbatim")
+      ;; Whole-payload slot — carries the conforming :secret; redacts.
+      (is (= :rf/redacted (-> v :tags :explain))
+          ":explain (whole vector) redacted — it carries the conforming sensitive :secret")
+      (is (true? (:sensitive? v))
+          "top-level :sensitive? stamp present — a whole-payload slot redacted")
+      (is (not (str/includes? (pr-str (:tags v)) "SECRET-OK-9f3a"))
+          "the conforming sensitive sibling does NOT egress anywhere in the tags"))))
 
 ;; ---- :set-element value leaks via the :path tag (rf2-ss06u.1) -------------
 ;; Malli reports a :set failure's :in segment as the failing ELEMENT VALUE
@@ -716,23 +726,30 @@
            (schemas/extract-sensitive-paths-from-schema
              [:tuple [:string {:sensitive? true}] :int] [:pt])))))
 
-(deftest app-db-validation-tuple-sibling-not-over-redacted
-  (testing "rf2-ss06u.4 + rf2-oh4se — END-TO-END: a :tuple with one sensitive
-            and one non-sensitive element, where ONLY the non-sensitive sibling
-            fails, must ride VERBATIM (no :sensitive? stamp, no :rf/redacted) —
-            mirrors the g5auo :vector no-sibling-taint contract"
-    ;; element 0 is {:sensitive?} :string (valid value "ok");
-    ;; element 1 is :int but supplied a string → only element 1 fails.
+(deftest app-db-validation-tuple-sibling-narrowed-value-verbatim-whole-explain-redacted
+  (testing "rf2-ss06u.4 + rf2-oh4se + rf2-3qam7b — PER-SLOT DECISION SCOPING on
+            a :tuple. element 0 is {:sensitive?} :string (CONFORMING \"ok\");
+            element 1 is :int supplied a string → only element 1 fails. The
+            LEAF-NARROWED `:value` slot (the failing element 1, \"not-an-int\")
+            rides verbatim — the position-precise narrowing win — but the
+            WHOLE-PAYLOAD `:explain` slot (the whole tuple, conforming element 0
+            included) redacts under the root check"
     (let [v (app-db-failure-trace
               [:point]
               [:tuple [:string {:sensitive? true}] :int]
-              {:point ["ok" "not-an-int"]}
+              {:point ["SECRET-TUP-ok" "not-an-int"]}
               :point/bad)]
       (is (some? v) "a trace fired")
-      (is (not (contains? v :sensitive?))
-          "the failing element 1 is not sensitive; its sensitive sibling at element 0 doesn't taint it")
-      (is (not= :rf/redacted (-> v :tags :value))
-          ":value rides verbatim — only the non-sensitive element 1 failed"))))
+      ;; Narrowed slot — only the failing element 1, verbatim.
+      (is (= "not-an-int" (-> v :tags :value))
+          ":value (narrowed to the failing element 1) rides verbatim")
+      ;; Whole-payload slot — carries the conforming element 0; redacts.
+      (is (= :rf/redacted (-> v :tags :explain))
+          ":explain (whole tuple) redacted — it carries the conforming sensitive element 0")
+      (is (true? (:sensitive? v))
+          "top-level :sensitive? stamp present — a whole-payload slot redacted")
+      (is (not (str/includes? (pr-str (:tags v)) "SECRET-TUP-ok"))
+          "the conforming sensitive element does NOT egress anywhere in the tags"))))
 
 (deftest app-db-validation-tuple-sensitive-element-still-redacts
   (testing "rf2-ss06u.4 — no regression: when the SENSITIVE tuple element fails,
@@ -889,44 +906,44 @@
         (is (= [:user/update {:name "bob" :age "old"}] (-> v :tags :received))
             ":received rides verbatim — the walk did not spuriously redact")))))
 
-;; ---- path-targeted sensitivity: sensitive SIBLING, non-sensitive failure --
-;; rf2-k0ew8n (finding 1). BEFORE: the shared run-validation path decided
-;; redaction with the COARSE `schema-has-sensitive?` (true if ANY slot in the
-;; schema is sensitive), so adding one sensitive field to a payload hid an
-;; UNRELATED non-sensitive failure from Xray / Pair / trace debugging. AFTER:
-;; run-validation derives the failing `:in` path from the explainer and asks
-;; the PATH-TARGETED `schema-sensitive-at?` whether THAT slot is sensitive —
-;; matching the precise model `validate-app-schema!` already used.
+;; ---- per-slot scoping: sensitive SIBLING, non-sensitive failure ----------
+;; rf2-k0ew8n / rf2-4q681i / rf2-3qam7b. The shared `run-validation` path
+;; (event / cofx / fx / sub) carries the WHOLE checked value in EVERY
+;; value-bearing slot — `:value` / `:received` / `:explain` / `:rf.fx/args` /
+;; `:rf.sub/query-v` are all the whole event-vector / cofx / fx-args /
+;; sub-return value; NOTHING here is narrowed to the failing leaf (only the
+;; app-db `:value` slot narrows). So a CONFORMING `:sensitive?` SIBLING (a
+;; valid token next to a failing :count) rides INSIDE those whole-payload
+;; slots.
 ;;
-;; SCOPE NOTE (rf2-4q681i — the `:cat`-walker follow-up, now DONE):
-;; path-targeting is exact when the schema ROOT is a navigable container
-;; (`:map` / `:tuple` / `:cat` / `:catn` / index-bearing). The cofx /
-;; fx-args / sub-return surfaces validate a map value directly; EVENT
-;; schemas are `:cat`-rooted (`[:cat [:= :id] PayloadSchema]`). As of
-;; rf2-4q681i the walker treats `:cat` / `:catn` as POSITION-bearing
-;; (emitting per-element decl-paths `(conj base i)`, mirroring `:tuple`),
-;; and `align-in-path` KEEPS the integer element index, so the event
-;; surface now gets the SAME exact path-targeting as the map-rooted
-;; surfaces — a sensitive sibling no longer over-redacts a non-sensitive
-;; failing sibling. The elision-coordinate alignment is automatic: the
-;; runtime elision walk descends the event VECTOR through its generic
-;; literal-index fork (`fork-index-paths`, `(conj c i)`), matching the
-;; position-pinned `:cat`/`:catn` declaration exactly (no elision-side
-;; code change — same as the `:tuple` precedent rf2-ss06u.4).
+;; The earlier rf2-k0ew8n / rf2-4q681i shape decided redaction with the
+;; LEAF-PRECISE `schema-sensitive-at?` (sibling-blind), so a non-sensitive
+;; failing sibling cleared redaction and the CONFORMING sensitive sibling
+;; egressed verbatim to Xray / Pair / off-box — the rf2-3qam7b leak. Per
+;; PER-SLOT DECISION SCOPING (Mike's rf2-me69cb ruling) the redaction scope
+;; MUST match the carried-value scope: a whole-payload slot uses the ROOT
+;; `schema-has-sensitive?` check. So on these surfaces a sensitive sibling
+;; ANYWHERE in the schema redacts the WHOLE value — the price of not
+;; narrowing. (The app-db `:value` slot, which IS narrowed, keeps the
+;; leaf-precise no-sibling-taint win — see `validate-app-schema!`'s tests
+;; above.) These tests assert the conforming sensitive sibling is ABSENT
+;; from every egressed slot.
 
-(deftest cofx-validation-sensitive-sibling-non-sensitive-failure-verbatim
-  (testing "rf2-k0ew8n — a cofx schema (map-rooted) with a sensitive sibling
-            (:token) AND a non-sensitive failing sibling (:count) rides the
-            non-sensitive failure VERBATIM — path-targeting at a navigable
-            root no longer over-redacts the unrelated failure"
+(deftest cofx-validation-conforming-sensitive-sibling-redacted-whole-value
+  (testing "rf2-3qam7b — a cofx schema with a CONFORMING sensitive sibling
+            (:token) AND a non-sensitive failing sibling (:count): every
+            value-bearing slot on this surface carries the WHOLE cofx value
+            (the conforming :token included), so the redaction scopes to the
+            ROOT check and the WHOLE value redacts. The conforming sensitive
+            sibling must be ABSENT from every egressed slot"
     (rf/reg-cofx :auth/ctx
       {:schema [:map
                 [:token {:sensitive? true} :string]
                 [:count :int]]}
-      ;; :token conforms; :count fails (string, not int) — failing slot is
-      ;; the NON-sensitive sibling.
+      ;; :token "SECRET-COFX-tok" CONFORMS (sensitive sibling); :count fails
+      ;; (string, not int) — the failing slot is the NON-sensitive sibling.
       (fn [ctx] (assoc-in ctx [:coeffects :auth/ctx]
-                          {:token "t" :count "not-an-int"})))
+                          {:token "SECRET-COFX-tok" :count "not-an-int"})))
     (rf/reg-event-fx :auth/use-ctx
       [(rf/inject-cofx :auth/ctx)]
       (fn [_ _] {}))
@@ -938,12 +955,12 @@
                                    (= :cofx (-> % :tags :where)))
                              @traces))]
         (is (some? v) "a cofx validation failure was traced")
-        (is (not (true? (:sensitive? v)))
-            "no :sensitive? stamp — the failing slot (:count) is not sensitive")
-        (is (not= :rf/redacted (-> v :tags :value))
-            ":value rides verbatim — the sensitive sibling did not over-redact")
-        (is (= {:token "t" :count "not-an-int"} (-> v :tags :value))
-            "the non-sensitive failing value is reported verbatim for debugging")))))
+        (is (true? (:sensitive? v))
+            ":sensitive? stamped — a whole-payload slot carries the conforming sensitive sibling")
+        (is (= :rf/redacted (-> v :tags :value)) ":value (whole cofx) redacted")
+        (is (= :rf/redacted (-> v :tags :received)) ":received (whole cofx) redacted")
+        (is (not (str/includes? (pr-str (:tags v)) "SECRET-COFX-tok"))
+            "the conforming sensitive sibling :token is ABSENT from every egressed slot")))))
 
 (deftest cofx-validation-sensitive-slot-failure-still-redacts
   (testing "rf2-k0ew8n — the path-targeted check still REDACTS when the
@@ -970,16 +987,18 @@
             ":sensitive? stamped — the failing slot (:token) is sensitive")
         (is (= :rf/redacted (-> v :tags :value)) ":value redacted")))))
 
-(deftest sub-validation-sensitive-sibling-non-sensitive-failure-verbatim
-  (testing "rf2-k0ew8n — a sub-return schema (map-rooted) with a sensitive
-            sibling AND a non-sensitive failing sibling rides the
-            non-sensitive failure verbatim (path-targeting at a navigable
-            root)"
+(deftest sub-validation-conforming-sensitive-sibling-redacted-whole-value
+  (testing "rf2-3qam7b — a sub-return schema with a CONFORMING sensitive
+            sibling (:token) AND a non-sensitive failing sibling (:count):
+            the sub-return surface carries the WHOLE return value in every
+            value-bearing slot, so the redaction scopes to the ROOT check and
+            the WHOLE value redacts; the conforming sensitive sibling must be
+            ABSENT from every egressed slot"
     (rf/reg-sub :auth/view
       {:schema [:map
                 [:token {:sensitive? true} :string]
                 [:count :int]]}
-      (fn [_ _] {:token "t" :count "not-an-int"}))
+      (fn [_ _] {:token "SECRET-SUB-tok" :count "not-an-int"}))
     (let [traces (atom [])]
       (rf/register-listener! ::view (fn [ev] (swap! traces conj ev)))
       @(rf/subscribe [:auth/view])
@@ -988,19 +1007,23 @@
                                    (= :sub-return (-> % :tags :where)))
                              @traces))]
         (is (some? v) "a sub-return validation failure was traced")
-        (is (not (contains? v :sensitive?))
-            "no :sensitive? stamp — the failing slot (:count) is not sensitive")
-        (is (not= :rf/redacted (-> v :tags :value))
-            ":value rides verbatim — the sensitive sibling did not over-redact")))))
+        (is (true? (:sensitive? v))
+            ":sensitive? stamped — a whole-payload slot carries the conforming sensitive sibling")
+        (is (= :rf/redacted (-> v :tags :value)) ":value (whole return) redacted")
+        (is (= :rf/redacted (-> v :tags :received)) ":received (whole return) redacted")
+        (is (not (str/includes? (pr-str (:tags v)) "SECRET-SUB-tok"))
+            "the conforming sensitive sibling :token is ABSENT from every egressed slot")))))
 
-(deftest event-validation-cat-root-sensitive-sibling-non-sensitive-failure-verbatim
-  (testing "rf2-4q681i — an event schema is `:cat`-rooted; with `:cat` now
-            POSITION-bearing in the walker, a non-sensitive failing sibling
-            under a sensitive payload rides VERBATIM (exact path-targeting),
-            NOT the prior fail-safe over-redaction. This was the documented
-            `event-validation-cat-root-fails-safe` limitation — now exact.
-            (Privacy is still upheld: the sensitive slot itself, when it
-            fails, still redacts — pinned in the companion test below.)"
+(deftest event-validation-cat-root-conforming-sensitive-sibling-redacted-whole-received
+  (testing "rf2-4q681i + rf2-3qam7b — an event schema is `:cat`-rooted, and
+            the event surface carries the WHOLE event vector in every
+            value-bearing slot (`:received` / `:value` / `:explain`). When a
+            CONFORMING sensitive payload slot (:password) rides next to a
+            non-sensitive failing slot (:age), the whole-payload slots redact
+            under the ROOT check — the conforming secret rides INSIDE the whole
+            event vector, so the leaf-precise `[1 :age]` decision (sibling-blind)
+            would have leaked it (the rf2-3qam7b leak this fix closes). The
+            conforming sensitive sibling MUST be absent from every egressed slot."
     (let [secret "pw-MUST-NOT-LEAK"]
       (rf/reg-event-db :auth/profile
         {:schema [:cat [:= :auth/profile]
@@ -1010,30 +1033,23 @@
         (fn [db _] db))
       (let [traces (atom [])]
         (rf/register-listener! ::prof (fn [ev] (swap! traces conj ev)))
-        ;; :password conforms (a string); :age fails (a string, not int) —
-        ;; the failing slot is NON-sensitive. `:cat` element 1 is now
-        ;; position-bearing, so the failing `:in` `[1 :age]` aligns to the
-        ;; decl-path `[1 :age]` and the sensitive sibling `[1 :password]`
-        ;; does NOT taint it.
+        ;; :password conforms (a string, the sensitive sibling); :age fails
+        ;; (a string, not int). The failing slot is NON-sensitive, but the
+        ;; whole event vector (carrying the conforming :password) rides every
+        ;; value-bearing slot.
         (rf/dispatch-sync [:auth/profile {:password secret :age "old"}])
         (rf/unregister-listener! ::prof)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v))
-          (is (not (true? (:sensitive? v)))
-              "exact path-targeting: the failing slot (:age) is not sensitive,
-               so the sensitive sibling (:password) does NOT over-redact")
-          (is (not= :rf/redacted (-> v :tags :received))
-              ":received rides verbatim — the non-sensitive failure is visible
-               to Xray / Pair / trace debugging")
-          ;; NOTE: the conforming :password value DOES ride verbatim here —
-          ;; that is the correct trade-off the bead specifies (a conforming
-          ;; sensitive sibling is not the failing slot; only the failing slot
-          ;; drives redaction). The privacy contract protects FAILING
-          ;; sensitive slots; see the companion test below.
-          (is (= [:auth/profile {:password secret :age "old"}]
-                 (-> v :tags :received))
-              "the non-sensitive failing payload is reported verbatim"))))))
+          (is (true? (:sensitive? v))
+              ":sensitive? stamped — a whole-payload slot carries the conforming sensitive :password")
+          (is (= :rf/redacted (-> v :tags :received))
+              ":received (whole event vector) redacted")
+          (is (= :rf/redacted (-> v :tags :value))
+              ":value (whole event vector) redacted")
+          (is (not (str/includes? (pr-str (:tags v)) secret))
+              "the conforming sensitive :password is ABSENT from every egressed slot"))))))
 
 (deftest event-validation-cat-root-sensitive-slot-failure-still-redacts
   (testing "rf2-4q681i — no privacy regression: when the SENSITIVE `:cat`
@@ -1062,12 +1078,12 @@
           (is (not (str/includes? (pr-str (:tags v)) (str secret)))
               "the raw secret does NOT appear anywhere in the emitted tags"))))))
 
-(deftest event-validation-catn-root-sensitive-sibling-non-sensitive-failure-verbatim
-  (testing "rf2-4q681i — `:catn` (name+position-bearing) gets the same exact
-            path-targeting as `:cat`: Malli reports the integer POSITION (not
-            the name) in `:in`, so a non-sensitive failing sibling under a
-            sensitive `:catn` payload rides verbatim while a sensitive-slot
-            failure still redacts"
+(deftest event-validation-catn-root-conforming-sensitive-sibling-redacted-whole-received
+  (testing "rf2-4q681i + rf2-3qam7b — `:catn` behaves like `:cat`: the whole
+            event vector rides every value-bearing slot, so a CONFORMING
+            sensitive payload slot (:password) next to a non-sensitive failing
+            slot (:age) redacts under the ROOT check; the conforming secret is
+            absent from every egressed slot"
     (let [secret "catn-pw-DO-NOT-LEAK"]
       (rf/reg-event-db :auth/profile-n
         {:schema [:catn
@@ -1078,18 +1094,18 @@
         (fn [db _] db))
       (let [traces (atom [])]
         (rf/register-listener! ::profn (fn [ev] (swap! traces conj ev)))
-        ;; :age fails (non-sensitive); :password conforms.
+        ;; :age fails (non-sensitive); :password conforms (sensitive sibling).
         (rf/dispatch-sync [:auth/profile-n {:password secret :age "old"}])
         (rf/unregister-listener! ::profn)
         (let [v (first (filter #(= :rf.error/schema-validation-failure (:operation %))
                                @traces))]
           (is (some? v))
-          (is (not (true? (:sensitive? v)))
-              "exact path-targeting through :catn — non-sensitive :age failure
-               is not tainted by the sensitive :password sibling")
-          (is (= [:auth/profile-n {:password secret :age "old"}]
-                 (-> v :tags :received))
-              ":received rides verbatim"))))))
+          (is (true? (:sensitive? v))
+              ":sensitive? stamped — a whole-payload slot carries the conforming sensitive :password")
+          (is (= :rf/redacted (-> v :tags :received))
+              ":received (whole event vector) redacted")
+          (is (not (str/includes? (pr-str (:tags v)) secret))
+              "the conforming sensitive :password is ABSENT from every egressed slot"))))))
 
 ;; ---- walker unit tests for the rf2-4q681i :cat/:catn position-bearing fix --
 

--- a/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/validation_redaction_invariant_security_cljs_test.cljc
@@ -170,6 +170,41 @@
   [:auth/login {:password [sentinel]}])
 
 ;; ---------------------------------------------------------------------------
+;; CONFORMING SENSITIVE SIBLING (rf2-3qam7b) — the secret rides at a slot that
+;; CONFORMS, while a DIFFERENT, non-sensitive slot FAILS. The whole-payload
+;; slots (`:value` / `:received` / `:explain`) ship the WHOLE checked value,
+;; so the conforming sensitive sibling rides inside them. A leaf-precise
+;; decision keyed on the (non-sensitive) failing slot is sibling-blind and
+;; leaked the conforming secret — the rf2-3qam7b leak. Per PER-SLOT DECISION
+;; SCOPING the whole-payload slots redact under the ROOT check, so the
+;; conforming sibling must never egress.
+;;   schema: [:map [:jwt {:sensitive? true} :string] [:count :int]]
+;;   value:  {:jwt sentinel :count "not-an-int"}   ;; :jwt conforms, :count fails
+;; ---------------------------------------------------------------------------
+
+(def ^:private sibling-sensitive-map-schema
+  [:map
+   [:jwt   {:sensitive? true} :string]
+   [:count :int]])
+
+(def ^:private failing-sibling-value
+  ;; :jwt CONFORMS (a string) and carries the sentinel; :count FAILS (a string
+  ;; where an :int is required). The failing slot is the NON-sensitive sibling.
+  {:jwt sentinel :count "not-an-int"})
+
+;; An EVENT schema where the `:cat` payload map carries a CONFORMING sensitive
+;; sibling next to a non-sensitive failing one (the bead's event-surface pin).
+(def ^:private sibling-sensitive-event-schema
+  [:cat [:= :auth/profile]
+   [:map
+    [:password {:sensitive? true} :string]
+    [:age      :int]]])
+
+(def ^:private failing-sibling-event
+  ;; :password CONFORMS (carries the sentinel); :age FAILS (string, not int).
+  [:auth/profile {:password sentinel :age "old"}])
+
+;; ---------------------------------------------------------------------------
 ;; PER-KIND CORPUS — drive every framework validation surface that emits
 ;; `:rf.error/schema-validation-failure` and assert no value-bearing slot
 ;; ships the sentinel for the `:sensitive?`-marked schema.
@@ -241,6 +276,98 @@
       (assert-no-leak ":where :machine-data" trace)
       (is (= :rf/redacted (-> trace :tags :value)) ":value redacted")
       (is (= :rf/redacted (-> trace :tags :received)) ":received redacted")
+      (is (= :rf/redacted (-> trace :tags :explain)) ":explain redacted"))))
+
+;; ---------------------------------------------------------------------------
+;; CONFORMING SENSITIVE SIBLING CORPUS (rf2-3qam7b) — for each kind, the
+;; sentinel rides at a CONFORMING sensitive slot while a DIFFERENT non-sensitive
+;; slot fails. Because every kind's whole-payload slots carry the whole checked
+;; value, the conforming sibling rides inside them and must NOT egress. The
+;; leaf-precise (sibling-blind) decision the pre-rf2-3qam7b run-validation /
+;; app-db paths used leaked it; per PER-SLOT DECISION SCOPING the whole-payload
+;; slots redact under the ROOT check. Verify-by-revert: restoring the
+;; leaf-precise `schema-sensitive-at?` decision on `run-validation` /
+;; `validate-app-schema!`'s whole-payload slots makes these RED (the sentinel
+;; surfaces in :received / :explain / :value).
+;; ---------------------------------------------------------------------------
+
+(deftest event-validation-redacts-conforming-sensitive-sibling
+  (testing "rf2-3qam7b — :where :event: a CONFORMING sensitive :password rides
+            next to a non-sensitive failing :age; the whole event vector (every
+            value-bearing slot) redacts under the root check and the conforming
+            sibling never egresses"
+    (let [trace (capture-failure
+                  #(schemas/validate-event!
+                     :auth/profile failing-sibling-event
+                     {:schema sibling-sensitive-event-schema}))]
+      (assert-no-leak ":where :event (conforming sibling)" trace)
+      (is (= :rf/redacted (-> trace :tags :received)) ":received redacted")
+      (is (= :rf/redacted (-> trace :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> trace :tags :explain)) ":explain redacted"))))
+
+(deftest cofx-validation-redacts-conforming-sensitive-sibling
+  (testing "rf2-3qam7b — :where :cofx: a CONFORMING sensitive :jwt rides next to
+            a non-sensitive failing :count; the whole cofx value redacts"
+    (let [trace (capture-failure
+                  #(schemas/validate-cofx!
+                     :rf.cofx/ctx :some/event failing-sibling-value
+                     {:schema sibling-sensitive-map-schema}))]
+      (assert-no-leak ":where :cofx (conforming sibling)" trace)
+      (is (= :rf/redacted (-> trace :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> trace :tags :received)) ":received redacted"))))
+
+(deftest fx-validation-redacts-conforming-sensitive-sibling
+  (testing "rf2-3qam7b — :where :fx-args: a CONFORMING sensitive :jwt rides next
+            to a non-sensitive failing :count; the whole fx args redact (incl.
+            :rf.fx/args)"
+    (let [trace (capture-failure
+                  #(schemas/validate-fx!
+                     :fx/effect :some/event failing-sibling-value
+                     {:schema sibling-sensitive-map-schema}))]
+      (assert-no-leak ":where :fx-args (conforming sibling)" trace)
+      (is (= :rf/redacted (-> trace :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> trace :tags :rf.fx/args)) ":rf.fx/args redacted"))))
+
+(deftest sub-return-validation-redacts-conforming-sensitive-sibling
+  (testing "rf2-3qam7b — :where :sub-return: a CONFORMING sensitive :jwt rides
+            next to a non-sensitive failing :count; the whole return value
+            redacts"
+    (let [trace (capture-failure
+                  #(schemas/validate-sub!
+                     :sub/view [:sub/view] failing-sibling-value
+                     {:schema sibling-sensitive-map-schema}))]
+      (assert-no-leak ":where :sub-return (conforming sibling)" trace)
+      (is (= :rf/redacted (-> trace :tags :value)) ":value redacted")
+      (is (= :rf/redacted (-> trace :tags :received)) ":received redacted"))))
+
+(deftest app-db-validation-redacts-conforming-sensitive-sibling-whole-explain
+  (testing "rf2-3qam7b — :where :app-db: a CONFORMING sensitive :jwt rides next
+            to a non-sensitive failing :count. The NARROWED `:value` slot (the
+            failing :count leaf) rides verbatim — the precise-narrowing win for
+            the genuinely narrowed slot — but the WHOLE-PAYLOAD `:explain` slot
+            (the whole reg-slice, conforming :jwt included) redacts under the
+            root check, so the conforming sibling never egresses"
+    (rf/reg-app-schema [:root] sibling-sensitive-map-schema)
+    (let [trace (capture-failure
+                  #(schemas/validate-app-schema!
+                     {:root failing-sibling-value} :root/bad))]
+      (assert-no-leak ":where :app-db (conforming sibling)" trace)
+      ;; The narrowed :value is the failing non-sensitive :count leaf, verbatim.
+      (is (= "not-an-int" (-> trace :tags :value))
+          ":value (narrowed to the failing :count leaf) rides verbatim")
+      ;; The whole-payload :explain carries the conforming :jwt — redacted.
+      (is (= :rf/redacted (-> trace :tags :explain)) ":explain redacted"))))
+
+(deftest machine-data-validation-redacts-conforming-sensitive-sibling
+  (testing "rf2-3qam7b — :where :machine-data: a CONFORMING sensitive :jwt rides
+            next to a non-sensitive failing :count in the :data map; the whole
+            :data redacts via the shared seam (root check)"
+    (let [trace (capture-failure
+                  #(machine-data/validate-snapshot-data!
+                     :my/machine {:data failing-sibling-value}
+                     sibling-sensitive-map-schema :macrostep))]
+      (assert-no-leak ":where :machine-data (conforming sibling)" trace)
+      (is (= :rf/redacted (-> trace :tags :value)) ":value redacted")
       (is (= :rf/redacted (-> trace :tags :explain)) ":explain redacted"))))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## SECURITY (P2) — rf2-3qam7b

Path-precise validation-failure redaction leaked **conforming sensitive siblings** through whole-payload trace slots that egress to Xray + pair-MCP.

### Root cause — scope mismatch
The leaf-precise `schema-sensitive-at?` decision (keyed on the failing leaf, sibling-blind by design) was gating slots that carry the **whole payload** verbatim. Repro: schema `[:map [:name :string] [:jwt {:sensitive? true} :string]]`, value `{:name <wrong> :jwt "<live-token>"}` — `[:name]` fails, `[:jwt]` conforms. The leaf-precise decision on `[:name]` cleared redaction, and the live jwt rode unredacted inside `:explain` / `:received` / `:value` / `:rf.fx/args`.

### Fix — PER-SLOT DECISION SCOPING (Mike's rf2-me69cb principle)
The scope of the `:sensitive?` check MUST match the scope of the carried value.

- **`run-validation` (event / cofx / fx / sub)** — every value-bearing slot carries the whole checked value (nothing narrowed), so the decision is now the ROOT check `schema-has-sensitive?`.
- **`validate-app-schema!` (app-db)** — `:value` is genuinely narrowed to the failing leaf, so it keeps the leaf-precise check (the rf2-oh4se no-sibling-taint win); the whole-payload `:explain` / `:explain-humanized` redact under the ROOT check. New private `redact-tags-per-slot` applies both decisions.

### Per-surface audit
| Surface | Slots | Verdict |
|---|---|---|
| app-db (`validate-app-schema!`) | `:value` narrowed; `:explain`/`:explain-humanized` whole | **FIXED** — per-slot scoping |
| event/cofx/fx/sub (`run-validation`) | all slots whole-payload | **FIXED** — root check |
| boundary interceptor (`re-frame.spec`) | whole, via `redact-validation-tags` (root check) | no leak — unchanged |
| machine `:data` | whole, via seam (root check) | no leak — unchanged |
| `:sub-override` (`re-frame.subs`) | whole, via seam (root check) | no leak — unchanged |
| flow-output (`re-frame.flows`) | whole, via seam (root check) | no leak — unchanged |
| `redact-validation-tags` seam | coarse root check (rf2-me69cb=(a)) | excluded — unchanged |

### Tests that pinned the bug as policy (corrected)
Five tests explicitly asserted a **conforming** sensitive sibling rides verbatim into a whole-payload slot — that assertion is wrong per Mike's ruling:
- `cofx-validation-sensitive-sibling-non-sensitive-failure-verbatim` → now `...-conforming-sensitive-sibling-redacted-whole-value`
- `sub-validation-sensitive-sibling-non-sensitive-failure-verbatim` → same
- `event-validation-cat-root-...-verbatim` / `event-validation-catn-root-...-verbatim` → `...-redacted-whole-received`
- `schemas_failure_paths_test/non-sensitive-sibling-failure-not-redacted` → `...-narrowed-value-verbatim-whole-explain-redacted` (asserts `:value` precise-verbatim, `:explain` redacted)
- app-db collection / tuple sibling tests → same narrowed-`:value` / whole-`:explain` shape

### Security corpus
Extended `validation_redaction_invariant` with a conforming-sensitive-sibling case across every kind (event / cofx / fx / sub / app-db / machine-data). Verify-by-revert: restoring the leaf-precise decision makes the new corpus RED (sentinel surfaces in `:received` / `:explain` / `:value` / `:rf.fx/args`). Both security-corpus gates stay green.

### Principle recorded
The PER-SLOT DECISION SCOPING principle is documented as comments at both decision sites in `validate.cljc` (per the bead: not added to spec/Conventions.md or spec/009 — in-flight PR owns them).

### Gates
- `npm run test:cljs` — 6295 tests, 0 failures
- JVM schemas / security / machines / flows / core — all green
- `npm run test:elision` — production 40/40 absent, control 40/40 present (DCE intact)
- clj-kondo — 0 errors (2 pre-existing warnings, unchanged)

No design fork — per-slot scoping was sufficient; no contract change.

Closes rf2-3qam7b.
