### PR TITLE
docs(guide): EP-0003 Resources guide-gap pass — ch.10↔ch.27 cross-link + drop stale placeholder phrasing (rf2-rn257l)

### DIFF
--- a/docs/guide/10-http.md
+++ b/docs/guide/10-http.md
@@ -2,6 +2,8 @@
 
 Network calls are where naive apps go to die. Not because a single fetch is hard — `fetch('/api/thing')` is one line a child could write — but because a *real* request has eight states, not two, and the seven you didn't think about are the ones that ship. This chapter is about one managed-effect shape that already thought about all eight, so you don't have to re-think them on every screen, in every project, for the rest of your career.
 
+> **Reading the same server-state repeatedly?** This chapter is the *transport* — how one request is issued, decoded, retried, and replied to. If the same remote data is read on several screens and needs caching, staleness, dedupe, and invalidation, that's a **resource** layered over this transport — see [27 - Server-state and resources](27-resources.md) (and [Where should this value live?](where-state-lives.md) for when to reach for one).
+
 ## The fetch you write, and the fetch you wish you'd written
 
 Let me show you the request everyone writes the first time, because it's instructive in exactly how it's wrong.

--- a/docs/guide/27-resources.md
+++ b/docs/guide/27-resources.md
@@ -357,7 +357,7 @@ The instance-keyed model is load-bearing: **two concurrent submissions of the sa
 
 ### The write→invalidate→refetch loop, end to end
 
-Putting the two halves together — this is the loop the deferred placeholder used to point at:
+Putting the two halves together — this is the write→invalidate→refetch loop, end to end:
 
 ```clojure
 ;; READ: the article detail, tagged by slug.


### PR DESCRIPTION
EP-0003 graduation-gate 3 of 3 (rf2-rn257l): stepped back and assessed whether `docs/guide` tells the Resources story completely and well for a human reader now that EP-0003 has shipped end to end.

## Assessment outcome

The Resources story in the guide is in strong shape. ch.27 (Server-state and resources) teaches the passive-read / causal-fetch mental model up front (the one-line thesis precedes all mechanics), lands mutations + invalidation + cache scopes + SSR/hydration + stale/GC + restore/time-travel each where a reader expects, and closes with a payoff section ("What resources actually buy you"). The four-questions page (`where-state-lives.md`) points Q3 correctly at ch.27. The README index and the rj68xn "where should this value live?" callouts (top of ch.02/05/12/21) are all current. The "What's deferred" section correctly scopes focus/reconnect, optimistic rollback, and GraphQL as genuinely-deferred (not stale).

Two clear, in-scope, low-risk fixes were warranted (made here); nothing substantive needed a follow-up bead.

## Edits

- **ch.10 (HTTP)** — added a top callout pointing at ch.27 + `where-state-lives`. ch.27 already cross-referenced ch.10, but the link was one-way; HTTP is exactly where a reader doing repeated server reads asks "how do I cache / refetch / invalidate this?", and there was no pointer to resources from there. The callout matches the established "where should this value live?" device used at the top of ch.02/05/12/21.
- **ch.27** — replaced the retrospective phrasing "this is the loop the deferred placeholder used to point at" (a reference to a now-removed placeholder) with "this is the write→invalidate→refetch loop, end to end". `AUTHORING.md` requires chapter prose to state current truth, not the historical trace.

## Gates

- `python scripts/check_doc_slugs.py --self-test --verbose` — all 11 self-tests pass
- `python scripts/check_doc_slugs.py --verbose` — 424 files, no broken links
- `python scripts/check_readme_inventories.py --verbose` — no violations
- `mkdocs build --strict` (spec/ + migration/ staged per `docs.yml`, then removed) — exit 0
