### PR TITLE
docs(spec): add route-error tag-shapes to Spec-Schemas (rf2-ta7b81)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -1209,6 +1209,35 @@ Common keys (`:category`, `:failing-id`, `:reason`, `:frame`) are inherited from
    [:limit-ms  :int]                  ;; the render deadline (ms)
    [:reason    :string]])
 
+(def ResourceRoutePlanTags
+  ;; a route :resources entry could not be PLANNED on route entry — its
+  ;; :scope / :params did not resolve (a fail-closed scope/params throw caught
+  ;; at the route-resource planning boundary). Surfaced on the route slice's
+  ;; :error (visible to the :rf/route sub + Xray) and emitted as an error
+  ;; trace, NEVER a silent cache miss; FIRST-error-wins when several route
+  ;; resources fail to plan. Per Spec 016 §Route integration.
+  [:map
+   [:category    :keyword]
+   [:route-id    :keyword]
+   [:resource-id :keyword]
+   [:nav-token   :any]
+   [:cause       {:optional true} :any]   ;; the underlying canonicalization / validation ex-data
+   [:reason      :string]])
+
+(def ResourceRouteBlockingTags
+  ;; a BLOCKING route resource FAILED its first load — the runtime flips the
+  ;; route transition to :error and populates [:rf.runtime/routing :current
+  ;; :error] with this structured error (mirroring the :on-match error trap),
+  ;; so a failed required server-state read is observable in route state
+  ;; rather than a permanent skeleton. The envelope carries the resource's own
+  ;; first-load failure :error. Per Spec 016 §Route integration.
+  [:map
+   [:category    :keyword]
+   [:resource-id :keyword]
+   [:nav-token   :any]
+   [:error       {:optional true} :any]   ;; the resource's first-load failure envelope
+   [:reason      :string]])
+
 ;; --- runtime: mutation errors (per [016 §Deferred slices] / [EP-0003 §Mutations]) ---
 ;; The mutation slice's fail-closed authoring + use vocabulary (rf2-dwme29,
 ;; the first public-beta gate). A mutation is a causal write keyed by


### PR DESCRIPTION
Closes rf2-ta7b81.

## What
Spec-Schemas' runtime resource-errors block carried `*Tags` malli shapes for 12 of the 14 catalogued resource/mutation errors but was missing the two route-error shapes. This adds them:

- **`ResourceRoutePlanTags`** (`:rf.error/resource-route-plan`) — `:category`, `:route-id`, `:resource-id`, `:nav-token`, `:cause` (optional), `:reason`.
- **`ResourceRouteBlockingTags`** (`:rf.error/resource-route-blocking`) — `:category`, `:resource-id`, `:nav-token`, `:error` (optional), `:reason`.

Both mirror the format of the sibling resource-error `*Tags` shapes already in the block and the tag-key lists in the Spec 009 §Error event catalogue (rows 1691–1692).

## Why
Parity/completeness gap found in the rf2-dhdkdp per-PR review of the rf2-gzsyw3 009+Spec-Schemas backfill. The 009 catalogue is the normative error home and is already complete; this closes the Spec-Schemas shape-coverage gap. Spec-only change.

## Verification
Tag keys verified against the throw/record sites in `implementation/resources/src/re_frame/resources/route.cljc`:
- `plan-error` (lines 259–269) emits the `resource-route-plan` map carrying `:route-id`/`:resource-id`/`:nav-token`/`:cause`/`:reason` (plus envelope keys `:rf.error/id`/`:operation`/`:recovery`, which the catalogue Tags column does not list — consistent with siblings).
- The drain-blocking first-load-failure branch (lines 168–174) records the `resource-route-blocking` map carrying `:resource-id`/`:nav-token`/`:error`/`:reason`.

## Scope
`spec/Spec-Schemas.md` only (hot-zone, sole toucher this slice). No edits to 009 / Conventions / 016.

## Gates
- `mkdocs build --strict` (spec/+migration staged per docs.yml recipe, then removed) — clean.
- `scripts/check_doc_slugs.py` — clean.