### PR TITLE
fix(resources/mutation): arm stale/GC timers for populated/patched entries (rf2-h4cv5e)

### DIFF
--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -55,6 +55,7 @@
   refetches\") so the later optimistic slice fills the symmetric rollback
   half without a shape change."
   (:require [clojure.set :as set]
+            [re-frame.frame :as frame]
             [re-frame.resources.mutation-registry :as mreg]
             [re-frame.resources.mutation-runtime :as mstate]
             [re-frame.resources.registry :as registry]
@@ -81,6 +82,35 @@
   [resource-spec loaded-at]
   (when-let [ms (:stale-after-ms resource-spec)]
     (+ loaded-at ms)))
+
+(defn- positive-or-nil
+  "Return `ms` when it is a positive number, else nil (a non-positive /
+  absent policy never arms a timer). Mirrors `events/positive-or-nil` so a
+  patched / populated entry arms exactly the timers a fetched one would."
+  [ms]
+  (when (and (number? ms) (pos? ms)) ms))
+
+(defn- server-frame?
+  "True iff `frame-id` is an SSR / server frame (its `:config :platform` is
+  `:server`). Reads ONLY the FRAME's platform — NOT the host-wide
+  `active-platform` default (which is `:server` on the JVM, so a JVM
+  client-mode unit test must still arm timers). Mirrors
+  `events/server-frame?`. Per Spec 016 §Stale and GC scheduling (no
+  wall-clock background timers under SSR)."
+  [frame-id]
+  (= :server (:platform (frame/frame-meta frame-id))))
+
+(defn- timer-delays
+  "The advisory stale / GC timer delays for a patched / populated entry from
+  the resource spec's `:stale-after-ms` / `:gc-after-ms` policy, or nil when
+  the resource declares neither (so no `:rf.resource/schedule-timers` fx is
+  emitted for that key). Mirrors the read path's
+  `positive-or-nil`-guarded delay derivation."
+  [resource-spec]
+  (let [stale-delay-ms (positive-or-nil (:stale-after-ms resource-spec))
+        gc-delay-ms    (positive-or-nil (:gc-after-ms resource-spec))]
+    (when (or stale-delay-ms gc-delay-ms)
+      {:stale-delay-ms stale-delay-ms :gc-delay-ms gc-delay-ms})))
 
 ;; ---- instance-id minting --------------------------------------------------
 
@@ -110,18 +140,21 @@
   [runtime-db patches-fn params result clock-ms]
   (if-let [patches (when patches-fn (patches-fn params result))]
     (reduce-kv
-      (fn [[db ks] scoped-key patch-fn]
+      (fn [[db ks policies] scoped-key patch-fn]
         (let [entry (get-in db (state/entry-path scoped-key))]
           (if (and entry (state/has-data? entry))
             (let [rspec    (registry/resource-meta (:resource/id entry))
                   stale-at (stale-at-for rspec clock-ms)
                   entry'   (mstate/patch-entry entry patch-fn result
-                                               {:clock-ms clock-ms :stale-at stale-at})]
-              [(assoc-in db (state/entry-path scoped-key) entry') (conj ks scoped-key)])
-            [db ks])))
-      [runtime-db #{}]
+                                               {:clock-ms clock-ms :stale-at stale-at})
+                  delays   (timer-delays rspec)]
+              [(assoc-in db (state/entry-path scoped-key) entry')
+               (conj ks scoped-key)
+               (cond-> policies delays (assoc scoped-key delays))])
+            [db ks policies])))
+      [runtime-db #{} {}]
       patches)
-    [runtime-db #{}]))
+    [runtime-db #{} {}]))
 
 (defn- apply-populates
   "Apply the mutation spec's `:populates` to the resource cache.
@@ -134,7 +167,7 @@
   [runtime-db populates-fn params result clock-ms]
   (if-let [populates (when populates-fn (populates-fn params result))]
     (reduce-kv
-      (fn [[db ks] scoped-key value]
+      (fn [[db ks policies] scoped-key value]
         (let [[_scope resource-id rparams] scoped-key
               rspec    (registry/resource-meta resource-id)
               stale-at (stale-at-for rspec clock-ms)
@@ -142,11 +175,14 @@
               tags     (when tags-fn (set (tags-fn rparams value)))
               entry    (get-in db (state/entry-path scoped-key))
               entry'   (mstate/populate-entry entry resource-id value
-                                              {:clock-ms clock-ms :stale-at stale-at :tags tags})]
-          [(assoc-in db (state/entry-path scoped-key) entry') (conj ks scoped-key)]))
-      [runtime-db #{}]
+                                              {:clock-ms clock-ms :stale-at stale-at :tags tags})
+              delays   (timer-delays rspec)]
+          [(assoc-in db (state/entry-path scoped-key) entry')
+           (conj ks scoped-key)
+           (cond-> policies delays (assoc scoped-key delays))]))
+      [runtime-db #{} {}]
       populates)
-    [runtime-db #{}]))
+    [runtime-db #{} {}]))
 
 (defn- invalidation-fx
   "Build the `:rf.resource/invalidate-tags` dispatch fx (or nil) for the
@@ -391,10 +427,17 @@
             params      (:params inst)
             timing      (or (:invalidate-timing spec) :after-success)
             clock-ms    (now-ms)
-            ;; 1. controlled patch / populate (BEFORE invalidation)
-            [rdb1 patched-ks]   (apply-patches runtime-db (:patches spec) params result clock-ms)
-            [rdb2 populated-ks] (apply-populates rdb1 (:populates spec) params result clock-ms)
+            ;; 1. controlled patch / populate (BEFORE invalidation). Each
+            ;; arm also returns the per-key advisory stale / GC timer policy
+            ;; (the third value) so this handler arms timers exactly as the
+            ;; resource read path does (a populate seeds a fresh, ownerless
+            ;; entry that otherwise has a durable :stale-at / :gc-after-ms
+            ;; policy but NO armed reaper). populate wins on a key written by
+            ;; both (it ran last, so its entry — and policy — is current).
+            [rdb1 patched-ks patch-policies]     (apply-patches runtime-db (:patches spec) params result clock-ms)
+            [rdb2 populated-ks populate-policies] (apply-populates rdb1 (:populates spec) params result clock-ms)
             patch-affected      (set/union patched-ks populated-ks)
+            timer-policies      (merge patch-policies populate-policies)
             ;; the success-time invalidation tags (scoped). The patch already
             ;; freshened the keys it touched; the invalidation reaches the
             ;; OTHER tagged entries (lists, siblings) the patch did not seed.
@@ -420,14 +463,33 @@
                               :completed {:settled-at clock-ms})
                             ;; recompute indexes — patch/populate may have
                             ;; changed entries' tags / created entries.
-                            (update state/resources-key state/recompute-indexes))]
+                            (update state/resources-key state/recompute-indexes))
+            ;; arm the advisory stale / GC timers (host-side side table) for
+            ;; every patched / populated key carrying a policy — one
+            ;; `:rf.resource/schedule-timers` fx per key, mirroring the
+            ;; resource read path's emission (cancel-then-arm; SSR-gated by
+            ;; the carried `:server?` flag; the re-check handlers re-derive
+            ;; freshness / GC-eligibility from the durable facts, so a
+            ;; never-fired server timer is harmless). Without this, a
+            ;; populated ownerless entry would carry a durable :stale-at /
+            ;; :gc-after-ms policy but NO armed reaper. Per Spec 016 §Stale
+            ;; and GC scheduling.
+            server?     (server-frame? frame-id)
+            timer-fx    (mapv (fn [[scoped-key {:keys [stale-delay-ms gc-delay-ms]}]]
+                                [:rf.resource/schedule-timers
+                                 {:frame-id       frame-id
+                                  :resource-key   scoped-key
+                                  :stale-delay-ms stale-delay-ms
+                                  :gc-delay-ms    gc-delay-ms
+                                  :server?        server?}])
+                              timer-policies)]
         (work-ledger/clear-handle! frame-id work-id)
         (trace/emit! :rf.event :rf.mutation/succeeded
                      {:rf.frame/id frame-id :instance instance-id :mutation mutation-id
                       :work-id work-id :generation generation
                       :affected-keys affected :patch-summary patch-summary})
         {:rf.db/runtime rdb'
-         :fx (cond-> [] inv-fx (conj inv-fx))}))))
+         :fx (cond-> (vec timer-fx) inv-fx (conj inv-fx))}))))
 
 (defn failed-handler
   "`:rf.mutation.internal/failed` — a mutation write failed. Verifies frame

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -37,6 +37,7 @@
    [re-frame.resources.state :as state]
    [re-frame.resources.mutation-runtime :as mstate]
    [re-frame.resources.mutation-registry :as mreg]
+   [re-frame.resources.timers :as timers]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch is overridden by the capturing reply stub below.
@@ -49,12 +50,20 @@
 ;; ---- capturing transport that REPLAYS the real reply-append shape ----------
 
 (def ^:private last-managed-args (atom nil))
+(def ^:private scheduled-timers (atom []))
 
 (defn- capturing-transport-fixture
   [f]
   (reset! last-managed-args nil)
+  (reset! scheduled-timers [])
   (state/reset-cache!)
+  (timers/reset-cache!)
   (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  ;; capture the host-side stale / GC timer arming so the success handler's
+  ;; emission is asserted deterministically WITHOUT a real wall-clock timer
+  ;; firing (the timer-table primitive is tested directly in the
+  ;; invalidation/GC suite).
+  (rf/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
   (f))
 
 (use-fixtures :each
@@ -278,6 +287,95 @@
         (is (= :loaded (:status e)))
         (is (= {:slug "w" :title "Fresh"} (:data e)))
         (is (= #{[:article "w"]} (:tags e)))))))
+
+(deftest success-populate-arms-stale-and-gc-timers
+  ;; rf2-h4cv5e — a mutation :populates seeds a fresh, OWNERLESS :loaded entry
+  ;; with a durable :stale-at / :gc-after-ms policy. The success handler MUST
+  ;; arm the advisory stale / GC timers for it (mirroring the resource read
+  ;; path) — otherwise the populated entry would carry a GC policy but NO armed
+  ;; reaper, lingering past :gc-after-ms (a cache-growth completeness gap).
+  (rf/reg-resource :r/article
+                   {:scope :rf.scope/global
+                    :params-schema [:map [:slug :string]]
+                    :request (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}})
+                    :tags (fn [{:keys [slug]} _] #{[:article slug]})
+                    :stale-after-ms 60000
+                    :gc-after-ms    300000})
+  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+    (rf/reg-mutation :m/save
+                     {:params-schema [:map [:slug :string]]
+                      :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+                      :populates (fn [_params result] {rkey result})})
+    (reset! scheduled-timers [])
+    ;; no prior ensure — the populate SEEDS an ownerless entry
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :pgc1}])
+    (reply-success! @last-managed-args {:slug "w" :title "Fresh"})
+    (testing "the populated entry is ownerless (no liveness lease)"
+      (is (empty? (:active-owners (entry rkey)))))
+    (testing "rf2-h4cv5e — the success handler armed the advisory stale / GC
+              timers for the populated key, mirroring the resource read path's
+              :rf.resource/schedule-timers emission"
+      (is (= 1 (count @scheduled-timers)))
+      (let [args (first @scheduled-timers)]
+        (is (= rkey (:resource-key args)))
+        (is (= :rf/default (:frame-id args)))
+        (is (= 60000 (:stale-delay-ms args)))
+        (is (= 300000 (:gc-delay-ms args)) "a GC timer is armed for the populated entry")
+        (is (false? (:server? args)) "client frame — not SSR-gated")))
+    (testing "rf2-h4cv5e — the populated ownerless entry is GC-eligible: a
+              fired GC timer (re-checking owners + generation) removes it"
+      (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource-key rkey}])
+      (is (nil? (entry rkey)) "GC removed the inactive populated entry"))))
+
+(deftest success-patch-arms-timers-for-policy-keys
+  ;; rf2-h4cv5e — a :patches refresh of an existing entry re-arms its advisory
+  ;; timers from the resource policy too (the patch moved :loaded-at /
+  ;; :stale-at forward, so the prior timer's basis is stale).
+  (rf/reg-resource :r/article
+                   {:scope :rf.scope/global
+                    :params-schema [:map [:slug :string]]
+                    :request (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}})
+                    :tags (fn [{:keys [slug]} _] #{[:article slug]})
+                    :stale-after-ms 60000
+                    :gc-after-ms    300000})
+  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+    (rf/reg-mutation :m/patch
+                     {:params-schema [:map [:slug :string]]
+                      :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+                      :patches (fn [_params result]
+                                 {rkey (fn [old _result] (merge old result))})})
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :r/article :scope :rf.scope/global
+                        :params {:slug "w"} :owner [:view :a]}])
+    (reply-success! @last-managed-args {:title "old" :views 1})
+    (reset! scheduled-timers [])
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/patch :params {:slug "w"} :instance :pat-gc1}])
+    (reply-success! @last-managed-args {:title "new"})
+    (testing "rf2-h4cv5e — the patch re-armed the entry's stale / GC timers"
+      (is (= 1 (count @scheduled-timers)))
+      (let [args (first @scheduled-timers)]
+        (is (= rkey (:resource-key args)))
+        (is (= 60000 (:stale-delay-ms args)))
+        (is (= 300000 (:gc-delay-ms args)))))))
+
+(deftest success-populate-no-policy-arms-no-timers
+  ;; rf2-h4cv5e — a populate of a resource declaring NO stale / GC policy arms
+  ;; NO timers (no schedule-timers fx) — exactly as the read path.
+  (rf/reg-resource :r/article
+                   {:scope :rf.scope/global
+                    :params-schema [:map [:slug :string]]
+                    :request (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}})
+                    :tags (fn [{:keys [slug]} _] #{[:article slug]})})
+  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+    (rf/reg-mutation :m/save
+                     {:params-schema [:map [:slug :string]]
+                      :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+                      :populates (fn [_params result] {rkey result})})
+    (reset! scheduled-timers [])
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :pnp1}])
+    (reply-success! @last-managed-args {:slug "w" :title "Fresh"})
+    (testing "no policy → no schedule-timers fx"
+      (is (= [] @scheduled-timers)))))
 
 ;; ===========================================================================
 ;; 5. Failure settles :error


### PR DESCRIPTION
## rf2-h4cv5e — mutation populate/patch arms no GC timer

A mutation `:populates` seeds a fresh, **ownerless** `:loaded` resource entry with a durable `:stale-at` / `:gc-after-ms` policy; a `:patches` refreshes an existing entry's timestamps. But the mutation success handler emitted **no** `:rf.resource/schedule-timers` fx — only the resource read-path `succeeded-handler` did. Effect: a populated ownerless entry carried a GC policy but **no armed reaper**, so it could linger past `:gc-after-ms` until a later ensure/refetch on that exact key armed one, or frame destroy.

Correctness was intact (stale/GC are advisory — freshness re-derived from the durable `:stale-at`, `gc-fired` re-checks owners+generation). This is a **cache-growth completeness gap** vs the read path.

## Fix

`succeeded-handler` (`mutation_events.cljc`) now emits one `:rf.resource/schedule-timers` fx **per patched/populated scoped-key** that carries a stale/GC policy, mirroring the read path's emission:
- delays read from the resource spec's `:stale-after-ms` / `:gc-after-ms`, `positive-or-nil`-guarded (helpers ported from `events.cljc`);
- `:server?`-gated on the frame's platform (`server-frame?`, read off the frame meta — NOT the host-wide default), exactly as the read path;
- cancel-then-arm semantics (the existing fx handler).

`apply-patches` / `apply-populates` now return the per-key timer policy as a third value; populate wins on a key written by both arms (it runs last, so its entry — and policy — is current).

## Tests (resources mutation suite)

- `success-populate-arms-stale-and-gc-timers` — a populated ownerless entry arms a GC timer (asserts the captured fx args) **and** is GC-eligible (a fired `:rf.resource.internal/gc-fired` removes it);
- `success-patch-arms-timers-for-policy-keys` — a patch re-arms the entry's stale/GC timers;
- `success-populate-no-policy-arms-no-timers` — a resource with no policy arms nothing.

## Gates

- `clj-kondo` — 0 errors, 0 warnings
- `clojure -M:test` (JVM resources) — 132 tests, 450 assertions, 0 failures
- `npm run test:cljs` — 6300 tests, 22620 assertions, 0 failures

Scope: `mutation_events.cljc` + the resources mutation test only. `ssr.cljc` (rf2-ditent) and `spec/` untouched. No design fork.
