### PR TITLE
fix(resources): SSR drain/hydration + epoch-restore reconcile (ssr-restore cluster)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -512,6 +512,10 @@
     :producer-ns 're-frame.resources.ssr
     :design-bead "rf2-p10npe"
     :description "Cross-feature LATE-BOUND SSR hydration-payload runtime-db projection extension (Spec 016 §SSR and hydration). Takes the full runtime-db value, returns a {subsystem-key durable-projection} map SSR's project-runtime-db merges into its allowlist-shaped slice; the Resources artefact projects ONLY the durable :entries of :rf.runtime/resources (per-entry redacted/omitted by the resource's :sensitive?/:large? classification; the reverse indexes are recomputable-from-entries). Resources is the first publisher; consumed by re-frame.ssr.payload-policy/project-runtime-db."}
+   {:key         :resources/drain-blocking-ssr!
+    :producer-ns 're-frame.resources.ssr
+    :design-bead "rf2-er7qx2"
+    :description "Cross-feature LATE-BOUND SSR blocking-resource DRAIN hook (Spec 016 §SSR and hydration steps 3-4). The SSR render path (re-frame.ssr/drain-blocking-resources!, called by the Ring / streaming host adapters AFTER frame setup + route resolution and BEFORE the render walk) consults it by key with the carried frame-id + {:deadline-ms :pump! :tick-ms}; the Resources artefact runs the drain LOOP — reads the live nav-token blocking set, pumps the event loop via the :pump! thunk so an in-flight reply lands, and on the wall-clock deadline settles every still-unsettled blocking entry to a first-load failure in the frame's runtime-db so the render sees a structured :error rather than a hung :loading skeleton — returning {:settled? :timed-out :route-blocking-failure}. No-op {:settled? true} when no Resources artefact is loaded (an SSR app without resources never blocks on them). Consumed by re-frame.ssr/drain-blocking-resources!."}
    {:key         :resources/hydrate-runtime-db
     :producer-ns 're-frame.resources.ssr
     :design-bead "rf2-ctk2av"

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -167,6 +167,57 @@
          :current-work  nil
          :affected-keys affected-keys))
 
+(def dangling-on-restore-error
+  "The structured failure envelope a PENDING mutation instance is terminally
+  settled to on epoch restore (Spec 016 §Restore and replay part 2). A
+  restored `:pending` instance's `:current-work` references an attempt the
+  restored timeline no longer owns — its host handle was never serialized and
+  a late pre-restore reply must be SUPPRESSED. The write's true outcome is
+  unknowable after a timeline rewind (it may have settled server-side, or
+  never been sent), so the instance is settled to a terminal `:error` carrying
+  this `:dangling-on-restore` envelope rather than left stranded `:pending`
+  forever — the app sees an explicit, re-submittable failure (XState-grade:
+  a dangling in-flight identity is surfaced, never silently stuck). Shares the
+  closed `:rf.http/*` failure taxonomy (`:rf.http/aborted` — the in-flight
+  request was effectively abandoned by the rewind)."
+  {:kind    :rf.http/aborted
+   :reason  :dangling-on-restore
+   :message (str "the mutation's in-flight request was abandoned by an epoch "
+                 "restore (the captured snapshot was :pending); its outcome is "
+                 "unknowable after the timeline rewind, so the instance is "
+                 "settled to a terminal :error and any late pre-restore reply is "
+                 "suppressed (Spec 016 §Restore and replay).")})
+
+(defn pending?
+  "True iff `instance` is a non-terminal `:pending` / `:idle` mutation instance
+  (a write still in flight, or created-not-yet-dispatched) — the restore
+  reconcile target. Terminal (`:success` / `:error`) instances ride through a
+  restore unchanged (they already carry a settled outcome). Per EP-0003
+  §Mutations / Spec 016 §Restore and replay part 2."
+  [instance]
+  (contains? #{:pending :idle} (:status instance)))
+
+(defn instance-dangled
+  "Terminally settle a restored PENDING mutation `instance` to `:error` with
+  the `dangling-on-restore-error` envelope and CLEAR its `:current-work`
+  pointer (Spec 016 §Restore and replay part 2). Clearing `:current-work` is
+  the load-bearing half: a late pre-restore reply's `live-instance-for-reply`
+  check (`(= work-id (:current-work inst))`) then fails, so the reply is
+  suppressed and CANNOT patch / populate / invalidate post-restore state — the
+  same work-id + generation stale-suppression gate the resource path uses. The
+  terminal `:error` settle is the visible half (no stuck `:pending`). Pure
+  `(instance, settled-at) -> instance`. A non-pending (already-terminal)
+  instance is returned unchanged."
+  [instance settled-at]
+  (if (pending? instance)
+    (assoc instance
+           :status       :error
+           :error        dangling-on-restore-error
+           :result       nil
+           :settled-at   settled-at
+           :current-work nil)
+    instance))
+
 ;; ---- controlled resource patch / populate (Spec 016 / EP-0003) ------------
 ;;
 ;; A mutation response can PATCH an existing resource entry (transform its

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -698,7 +698,7 @@
       (rf2-64bdnk)."
   [route-owner-policy owner]
   (and (route-owner? owner)
-       (not (identical? :ride-through route-owner-policy))
+       (not= :ride-through route-owner-policy)
        (not= (:restore-live-nav-token route-owner-policy)
              (nth owner 2 nil))))
 

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -69,6 +69,11 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
+;; `hydrate-runtime-db` (the reconcile) computes the client refetch plan via
+;; `hydrate-refetch-plan` (defined below) on the `:rf/hydrate` install path
+;; (rf2-fopuj9), so the latter is forward-declared.
+(declare hydrate-refetch-plan)
+
 ;; ---- shared clock ---------------------------------------------------------
 
 (defn- now-ms
@@ -636,7 +641,18 @@
        `:entries` (never trust the wire — part 5);
     3. emit a `:rf.resource/hydrated` trace summarising installed / orphaned
        counts, and a clock-skew diagnostic when a restored `:stale-at` is
-       implausible against the live clock.
+       implausible against the live clock;
+    4. COMPUTE the client refetch plan (`hydrate-refetch-plan`) over the
+       reconciled entries (rf2-fopuj9), emitting one `:rf.resource/hydrate-
+       refetch` decision row per entry that is NOT sufficient on its own —
+       stale (background refetch), omitted (`:no-data`), or redacted (the
+       `:rf/redacted` sentinel is metadata-only, NOT usable data, so it is
+       `:metadata-only`). Fresh-with-USABLE-data entries are absent from the
+       plan (no double-fetch). The plan rides the trace channel here; the
+       route slice consults `hydrate-refetch-plan` directly to ISSUE the
+       refetch under a live owner (it owns \"does the route still NEED it?\").
+       Wiring the COMPUTE into the reconcile means the per-entry decision is
+       never lost on the `:rf/hydrate` install path.
 
   NEVER crosses scopes: it only reconciles the entries the server projected
   under their own scoped keys (the scope is the first element of each key);
@@ -684,6 +700,14 @@
                                             skew "ms ahead of the live client clock "
                                             "— server clock skew makes freshness "
                                             "ambiguous; refetch will resolve it.")}))
+         ;; rf2-fopuj9 — COMPUTE the client refetch plan over the reconciled
+         ;; entries on the `:rf/hydrate` install path, emitting the per-entry
+         ;; `:rf.resource/hydrate-refetch` decision rows (stale / no-data /
+         ;; metadata-only). The route slice consults `hydrate-refetch-plan`
+         ;; directly to ISSUE the refetch under a live owner; computing it here
+         ;; ensures the decision (esp. that a REDACTED sentinel entry is
+         ;; metadata-only, not fresh-with-data) is never lost on hydrate.
+         (hydrate-refetch-plan rdb' clock-ms frame-id)
          rdb')))))
 
 ;; ---- epoch-restore reconcile (Spec 016 §Restore and replay parts 2/4/5) ---
@@ -902,33 +926,59 @@
 ;; (fresh serialized) or needs a client refetch. The decision (no double-
 ;; fetch is the load-bearing one):
 ;;
-;;   - FRESH + has data            -> no refetch (the win SSR exists for);
-;;   - STALE + has data            -> background-refetch by event (renders
+;;   - FRESH + has USABLE data     -> no refetch (the win SSR exists for);
+;;   - STALE + has USABLE data     -> background-refetch by event (renders
 ;;                                    stale data immediately, refreshes);
 ;;   - metadata-only (redacted /   -> refetch ONLY if the route still needs
-;;     omitted; no data)              it (a live owner / the route's plan).
+;;     omitted; no usable data)       it (a live owner / the route's plan).
+;;
+;; The load-bearing correctness boundary (rf2-fopuj9): a REDACTED entry rides
+;; the wire with its `:data` REPLACED by the redaction sentinel
+;; (`privacy/redacted-sentinel` = `:rf/redacted`) — it is METADATA ONLY, NOT
+;; usable data. A naive `(some? (:data entry))` would see the sentinel as
+;; present and misclassify a redacted entry as fresh-with-data → NEVER
+;; refetch, leaving the client rendering the `:rf/redacted` sentinel as if it
+;; were the real value. `hydrated-data-usable?` excludes the sentinel so a
+;; redacted entry is correctly treated as metadata-only and refetched.
+
+(defn hydrated-data-usable?
+  "True iff a HYDRATED `entry` carries USABLE last-known-good `:data` — i.e.
+  `:data` is present AND is NOT the redaction sentinel
+  (`privacy/redacted-sentinel`). A `:sensitive?` resource projects its data
+  as the sentinel (`project-entry` `:redact`), so on the wire the entry's
+  `:data` is `:rf/redacted` — metadata only, never usable. An `:large?`
+  resource OMITS the `:data` key entirely (nil — also not usable). This is the
+  hydration-side counterpart of `state/has-data?`, which does NOT know about
+  the wire sentinel because it only ever sees live durable data. Per Spec 016
+  §SSR and hydration (redacted entries hydrate as metadata only)."
+  [entry]
+  (let [d (:data entry)]
+    (and (some? d) (not= privacy/redacted-sentinel d))))
 
 (defn entry-needs-refetch?
   "Decide whether a hydrated `entry` needs a client refetch against
   `clock-ms`. Per Spec 016 §SSR and hydration:
 
-    - a FRESH entry WITH usable data does NOT refetch (avoid the duplicate
+    - a FRESH entry WITH USABLE data does NOT refetch (avoid the duplicate
       immediate fetch — the property SSR exists for);
-    - a STALE entry with usable data background-refetches by policy;
-    - a metadata-only entry (redacted / omitted — no `:data`, or settled to
-      `:error` on the server) refetches if the route still needs it.
+    - a STALE entry with USABLE data background-refetches by policy;
+    - a metadata-only entry (redacted → the `:rf/redacted` sentinel; omitted
+      → no `:data`; or settled to `:error` on the server) refetches if the
+      route still needs it.
 
-  Returns `false` only for the fresh-with-data case; the metadata-only /
-  stale / no-data cases return `true` so the route slice can issue the
+  Returns `false` only for the fresh-with-USABLE-data case; the metadata-only
+  / stale / no-data cases return `true` so the route slice can issue the
   refetch under a live owner (it is the route plan that decides whether the
-  route still NEEDS the entry; this predicate answers \"is the hydrated
-  value sufficient on its own?\")."
+  route still NEEDS the entry; this predicate answers \"is the hydrated value
+  sufficient on its own?\"). A REDACTED entry's sentinel `:data` is NOT usable
+  (`hydrated-data-usable?`), so it is treated as metadata-only — never as
+  fresh-with-data (rf2-fopuj9)."
   [entry clock-ms]
-  (let [has-data? (some? (:data entry))]
+  (let [usable? (hydrated-data-usable? entry)]
     (cond
-      (not has-data?)              true            ;; metadata-only / error
+      (not usable?)                true            ;; metadata-only / redacted / error
       (entry-stale? entry clock-ms) true           ;; stale-while-revalidate
-      :else                         false)))       ;; fresh + data → no dup-fetch
+      :else                         false)))       ;; fresh + usable data → no dup-fetch
 
 (defn hydrate-refetch-plan
   "Build the client refetch plan for a hydrated resource subtree: the
@@ -962,6 +1012,14 @@
                                 {:resource-key k
                                  :resource-id  (nth k 1)
                                  :reason       (cond
+                                                 ;; a REDACTED entry rides the
+                                                 ;; sentinel as `:data` — metadata
+                                                 ;; only, classified distinctly from
+                                                 ;; an OMITTED entry (`:no-data`) so
+                                                 ;; Xray / the route slice can tell a
+                                                 ;; sensitive-redaction refetch from a
+                                                 ;; large-omission one (rf2-fopuj9).
+                                                 (= privacy/redacted-sentinel (:data entry)) :metadata-only
                                                  (nil? (:data entry))         :no-data
                                                  (entry-stale? entry clock-ms) :stale
                                                  :else                         :metadata-only)})))

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -62,6 +62,7 @@
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.privacy :as privacy]
+            [re-frame.resources.mutation-runtime :as mutation-runtime]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.state :as state]
             [re-frame.resources.work-ledger :as work-ledger]
@@ -812,14 +813,57 @@
                runtime-db non-terminal)
        non-terminal])))
 
+(defn dangle-pending-mutations!
+  "Reconcile restored PENDING mutation INSTANCES on epoch restore (rf2-o3d1uf,
+  Spec 016 §Restore and replay part 2). A restored `:pending` (or `:idle`)
+  mutation instance at `:rf.runtime/mutations` retains its `:current-work` +
+  `:generation` — pointing at an attempt the restored timeline no longer owns
+  (the host handle was never serialized). Unlike a resource cache entry (whose
+  reply path checks the ENTRY's `:current-work`), a mutation reply checks the
+  INSTANCE's `:current-work` + `:generation` (`live-instance-for-reply`), so
+  WITHOUT reconciling the instance a late pre-restore mutation success/failure
+  reply would still match the restored instance and PATCH / POPULATE /
+  INVALIDATE post-restore resource state — the exact correctness leak this
+  closes.
+
+  Each restored pending/idle instance is TERMINALLY SETTLED to `:error` with
+  the `:dangling-on-restore` envelope and its `:current-work` is CLEARED
+  (`mutation-runtime/instance-dangled`). Clearing `:current-work` makes the
+  ordinary work-id + generation gate suppress the late reply (the
+  `(= work-id (:current-work inst))` check fails); the generation allocator is
+  host-side + monotonic (part 1), so the dangling work-id can never re-match a
+  live instance anyway — clearing the pointer is belt-and-braces on top of the
+  structural impossibility. Already-terminal (`:success` / `:error`) instances
+  ride through unchanged (a settled write's durable outcome is real).
+
+  Returns `[runtime-db' dangled-instance-ids]`. No-op (returns `[runtime-db
+  []]`) when the snapshot carries no mutation instances (a mutation-free
+  restore). PURE w.r.t. the host side table (the work-ledger host handles are
+  cleared separately — the mutation's work-ledger row is dangled by
+  `dangle-non-terminal-work!`, work-kind `:mutation`)."
+  [runtime-db settled-at]
+  (let [instances (get-in runtime-db (mutation-runtime/instances-path))
+        pending   (into []
+                        (comp (filter (fn [[_ inst]] (mutation-runtime/pending? inst)))
+                              (map key))
+                        instances)]
+    (if (empty? pending)
+      [runtime-db []]
+      [(reduce (fn [rdb instance-id]
+                 (update-in rdb (mutation-runtime/instance-path instance-id)
+                            mutation-runtime/instance-dangled settled-at))
+               runtime-db pending)
+       pending])))
+
 (defn reconcile-on-restore
   "Reconcile a freshly-INSTALLED resource subtree on `restore-epoch` (the body
   behind the `:resources/reconcile-on-restore` hook epoch `perform-restore!`
   consults). `runtime-db` is the runtime-db partition the epoch restore is about
-  to install (the UNPROJECTED captured snapshot, both `:rf.runtime/resources` and
-  `:rf.runtime/work-ledger`). Returns the runtime-db with the resource +
-  work-ledger slices reconciled — or `runtime-db` unchanged when it carries no
-  resource entries AND no work-ledger rows (a no-op for a resource-free restore).
+  to install (the UNPROJECTED captured snapshot — `:rf.runtime/resources`,
+  `:rf.runtime/work-ledger`, AND `:rf.runtime/mutations`). Returns the runtime-db
+  with the resource + work-ledger + mutation slices reconciled — or `runtime-db`
+  unchanged when it carries no resource entries, no work-ledger rows, AND no
+  mutation instances (a no-op for a resource-free restore).
 
   Unlike `hydrate-runtime-db` (which reconciles the SERVER PROJECTION — already
   `:current-work`-stripped on the wire, no non-terminal rows), restore installs
@@ -838,10 +882,18 @@
     3. settle every NON-terminal work-ledger row to terminal `:suppressed` /
        `:dangling` (`dangle-non-terminal-work!`, part 2) so a pre-restore in-flight
        reply is suppressed;
+    3b. settle every restored PENDING MUTATION INSTANCE to terminal `:error` /
+       `:dangling-on-restore` and CLEAR its `:current-work`
+       (`dangle-pending-mutations!`, part 2 — rf2-o3d1uf) so a late pre-restore
+       mutation reply cannot patch / populate / invalidate post-restore state
+       (the mutation reply gate checks the INSTANCE's `:current-work` +
+       `:generation`, not the resource entry's, so the resource-side dangle
+       alone does NOT suppress it);
     4. emit a `:rf.resource/restored` trace summarising reconciled / orphaned /
-       dangled counts, a `:rf.resource/owner-released` row per stale-nav route
-       owner released as an orphan (part 4), and a clock-skew diagnostic when a
-       restored `:stale-at` is implausible against the live clock.
+       dangled (work + mutation) counts, a `:rf.resource/owner-released` row per
+       stale-nav route owner released as an orphan (part 4), and a clock-skew
+       diagnostic when a restored `:stale-at` is implausible against the live
+       clock.
 
   The stale-nav route-owner orphan rule is RESTORE-specific: restore installs
   both partitions wholesale so the live nav-token IS present, whereas SSR
@@ -857,13 +909,14 @@
    (let [resources (get runtime-db state/resources-key)
          entries   (:entries resources)
          ledger    (get runtime-db state/work-ledger-key)
+         mutations (get-in runtime-db (mutation-runtime/instances-path))
          ;; the nav-token the restored routing slice currently considers live
          ;; — restore installs both partitions wholesale, so routing :current
          ;; is present in this same runtime-db (nil when the app carries no
          ;; routing slice). Route owners whose nav-token ≠ this are stale-nav
          ;; orphans (Spec 016 §Restore and replay part 4).
          live-nav-token (get-in runtime-db routing-current-nav-token-path)]
-     (if-not (or (seq entries) (seq ledger))
+     (if-not (or (seq entries) (seq ledger) (seq mutations))
        runtime-db
        (let [clock-ms (now-ms)
              ;; reconcile each entry: orphan SSR owners + STALE-NAV route
@@ -888,13 +941,20 @@
              rdb'      (cond-> runtime-db
                          (seq entries) (assoc state/resources-key subtree'))
              ;; settle the dangling non-terminal work-ledger rows (restore-specific)
-             [rdb'' dangled] (dangle-non-terminal-work! rdb')]
+             [rdb'' dangled] (dangle-non-terminal-work! rdb')
+             ;; settle the dangling PENDING mutation instances + clear their
+             ;; :current-work so a late pre-restore mutation reply is suppressed
+             ;; by the instance work-id + generation gate (rf2-o3d1uf). Runs on
+             ;; the resource-reconciled runtime-db; the mutation work-ledger row
+             ;; was already dangled by `dangle-non-terminal-work!` above.
+             [rdb''' dangled-mutations] (dangle-pending-mutations! rdb'' clock-ms)]
          (trace/emit! :rf.epoch :rf.resource/restored
-                      {:rf.frame/id     frame-id
-                       :reconciled      (count entries')
-                       :orphaned-owners (vec (:orphaned reconciled))
-                       :dangled-work    (vec dangled)
-                       :clock-skews     (:skews reconciled)})
+                      {:rf.frame/id       frame-id
+                       :reconciled        (count entries')
+                       :orphaned-owners   (vec (:orphaned reconciled))
+                       :dangled-work      (vec dangled)
+                       :dangled-mutations (vec dangled-mutations)
+                       :clock-skews       (:skews reconciled)})
          ;; per-owner row for every STALE-NAV route owner released as an orphan
          ;; (Spec 016 §Restore and replay part 4: "orphaned owners are dropped
          ;; with a trace row"). SSR orphans ride the summary above (they belong
@@ -918,7 +978,7 @@
                                             skew "ms ahead of the live clock — clock "
                                             "skew makes freshness ambiguous; the next "
                                             "live-owner ensure will resolve it.")}))
-         rdb'')))))
+         rdb''')))))
 
 ;; ---- client refetch decision (Spec 016 §SSR and hydration) ----------------
 ;;

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -560,20 +560,58 @@
   [owner]
   (and (vector? owner) (= :route (first owner))))
 
-(defn- stale-nav-route-owner?
-  "True iff `owner` is a route owner whose nav-token is NOT `live-nav-token`
-  (the nav-token the restored routing slice currently considers live). Such
-  an owner names a navigation the restored timeline has already left, so it
-  must be released as an orphan rather than pin its entry alive forever (Spec
-  016 §Restore and replay part 4). When `live-nav-token` is nil (no routing
-  slice present — the SSR-hydration path has no client routing yet) NO route
-  owner is treated as stale: route liveness is reconciled by routing's own
-  subsystem on the live client, so this returns false for every owner."
-  [live-nav-token owner]
-  (boolean
-    (and (some? live-nav-token)
-         (route-owner? owner)
-         (not= live-nav-token (nth owner 2 nil)))))
+;; ---- route-owner reconcile POLICY (the hydration↔restore split, rf2-64bdnk) -
+;;
+;; A nil live nav-token means TWO different things, so the route-owner orphan
+;; rule MUST distinguish the caller:
+;;
+;;   - HYDRATION (`:ride-through`): there is no client routing slice yet (the
+;;     server projection carries no `:current`), so route owners ride through
+;;     UNCHANGED — routing's own client subsystem reconciles their liveness
+;;     once it boots. A nil token here is "no comparison possible yet", NOT
+;;     "no owner is live".
+;;   - RESTORE (`{:restore-live-nav-token <token-or-nil>}`): epoch restore
+;;     installs BOTH partitions wholesale, so the restored routing slice's
+;;     `:current` nav-token IS present (or genuinely absent/nil). Per Spec 016
+;;     §Restore part 4 a route owner revives ONLY IF the restored routing
+;;     names the SAME live nav-token; ANY other token — including the case
+;;     where the restored routing has NO live nav-token at all (absent routing
+;;     slice / no `:current` / nil nav-token) — means NO route owner is live,
+;;     so EVERY route owner orphans (a nil live token here is "nothing is
+;;     live", the opposite of hydration's "can't compare yet").
+
+(def ^:private hydration-route-owner-policy
+  "The route-owner reconcile policy for the SSR-hydration path: route owners
+  ride through unchanged (routing's client subsystem owns their liveness; the
+  server projection carries no `:current` to compare against). Per Spec 016
+  §Restore and replay part 4 (the hydration no-comparison-yet case)."
+  :ride-through)
+
+(defn- restore-route-owner-policy
+  "The route-owner reconcile policy for the epoch-RESTORE path: a route owner
+  revives only if its nav-token EQUALS `live-nav-token` (the restored
+  `[:rf.runtime/routing :current :nav-token]`). A nil `live-nav-token` (absent
+  routing slice / no `:current` / nil nav-token) means NO route owner is live
+  → every route owner orphans (rf2-64bdnk). Per Spec 016 §Restore part 4."
+  [live-nav-token]
+  {:restore-live-nav-token live-nav-token})
+
+(defn- route-owner-orphan?
+  "True iff a route `owner` must be RELEASED as an orphan under
+  `route-owner-policy`:
+
+    - `:ride-through` (hydration) → false for every route owner (they ride
+      through; routing's client subsystem reconciles them);
+    - `{:restore-live-nav-token <t>}` (restore) → true iff the owner's
+      nav-token ≠ `<t>`. When `<t>` is nil (the restored routing names no live
+      nav-token) EVERY route owner orphans, because no owner's token can equal
+      nil (a real nav-token is never nil). Per Spec 016 §Restore part 4
+      (rf2-64bdnk)."
+  [route-owner-policy owner]
+  (and (route-owner? owner)
+       (not (identical? :ride-through route-owner-policy))
+       (not= (:restore-live-nav-token route-owner-policy)
+             (nth owner 2 nil))))
 
 (defn- reconcile-entry-owners
   "Reconcile a restored/hydrated entry's `:active-owners`, returning
@@ -582,23 +620,23 @@
     - SSR owners (`[:ssr …]`) — they belong to one settled server render and
       never survive as a live client lease (Spec 016 §Restore and replay
       part 4);
-    - STALE-NAV route owners (`[:route route-id nav-token]` whose nav-token ≠
-      `live-nav-token`) — a route owner the restored routing slice no longer
-      considers live is an orphan that would otherwise pin its entry alive
-      forever + refetch on focus/reconnect (part 4). Only applies on the
-      RESTORE path, where `live-nav-token` is the restored
-      `[:rf.runtime/routing :current :nav-token]`; on SSR hydration
-      `live-nav-token` is nil (no client routing yet) so route owners ride
-      through unchanged.
+    - ORPHANED route owners (`[:route route-id nav-token]`) per
+      `route-owner-policy` (`route-owner-orphan?`): on HYDRATION
+      (`:ride-through`) NONE — route owners ride through for routing's own
+      client reconcile; on RESTORE (`{:restore-live-nav-token <t>}`) every
+      route owner whose nav-token ≠ the restored live token, INCLUDING all of
+      them when the restored routing names no live token at all (rf2-64bdnk) —
+      such an owner would otherwise pin its entry alive forever + refetch on
+      focus/reconnect (part 4).
 
   Also clears the transient `:current-work` pointer (the attempt it pointed
   at did not cross the wire / no longer exists — part 2). Machine / lease /
   live-nav route owners ride through unchanged (their liveness is reconciled
   by their own subsystem)."
-  [entry live-nav-token]
+  [entry route-owner-policy]
   (let [owners  (:active-owners entry #{})
         orphan? (fn [o] (or (ssr-owner? o)
-                            (stale-nav-route-owner? live-nav-token o)))
+                            (route-owner-orphan? route-owner-policy o)))
         dropped (into #{} (filter orphan?) owners)
         kept    (into #{} (remove orphan?) owners)]
     [(-> entry
@@ -674,7 +712,8 @@
              ;; 016 §Restore and replay part 4); see `reconcile-on-restore`.
              reconciled (reduce-kv
                           (fn [acc k entry]
-                            (let [[entry' dropped] (reconcile-entry-owners entry nil)
+                            (let [[entry' dropped] (reconcile-entry-owners
+                                                     entry hydration-route-owner-policy)
                                   skew             (clock-skew-ms entry clock-ms)]
                               (-> acc
                                   (assoc-in [:entries k] entry')
@@ -924,9 +963,10 @@
              ;; mid-flight status to last-stable (restore-specific — the wire
              ;; projection never carried an in-flight entry, but the
              ;; unprojected snapshot can).
+             route-owner-policy (restore-route-owner-policy live-nav-token)
              reconciled (reduce-kv
                           (fn [acc k entry]
-                            (let [[entry' dropped] (reconcile-entry-owners entry live-nav-token)
+                            (let [[entry' dropped] (reconcile-entry-owners entry route-owner-policy)
                                   entry''          (settle-entry-to-last-stable entry')
                                   skew             (clock-skew-ms entry clock-ms)]
                               (-> acc

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -142,6 +142,86 @@
       (:large? spec)     :omit
       :else              :serialize)))
 
+;; ---- scoped-key privacy (Spec 016 clause 4, rf2-otms75) -------------------
+;;
+;; The scoped resource KEY (`[scope resource-id params]`) is the MAP KEY of the
+;; projected `{scoped-key wire-entry}` slice — so even when the entry's DATA is
+;; redacted/omitted, the raw scope + params still ride in the key. Spec 016
+;; §Runtime-subsystem graduation clause 4 / §Xray and AI tooling: "params,
+;; scopes, and data carry the same classification" — a `:sensitive?` resource's
+;; scope (user / tenant / impersonation markers) or a `:large?` resource's
+;; params MUST NOT ride raw on the hydration wire any more than its data does.
+;;
+;; The client refetch is ROUTE-DRIVEN: the route plan re-resolves params from
+;; the LIVE route on the client and re-ensures under a freshly-computed scoped
+;; key (route.cljc/route-resource-plan). So a redacted/omitted hydrated entry
+;; does NOT need its original raw scope/params to refetch — it only needs (a)
+;; the resource-id (position 1, never sensitive) so the refetch plan can name
+;; it, and (b) a DISTINCT key so the index recompute does not collapse two
+;; entries. We therefore project the sensitive/large scope + params to an
+;; OPAQUE, content-addressed DIGEST: distinct values stay distinct (no
+;; collision / lost entry), the raw identity never rides, and the digest is
+;; deliberately one-way (refetch is route-driven, not key-driven).
+
+(def ^:private fnv-offset-basis 2166136261)
+(def ^:private fnv-prime 16777619)
+
+(defn- fnv-1a-32
+  "A deterministic, cross-process-stable 32-bit FNV-1a hash of `s` (a string),
+  returned as an 8-char lower-case hex. Used to content-address a redacted
+  scope / params value so distinct keys stay distinct on the wire without the
+  raw value riding. Self-contained (no dep on the SSR artefact's hash)."
+  [^String s]
+  (let [bytes #?(:clj (.getBytes s "UTF-8") :cljs s)
+        n     #?(:clj (alength ^bytes bytes) :cljs (.-length bytes))]
+    (loop [i 0
+           h fnv-offset-basis]
+      (if (< i n)
+        (let [b #?(:clj (bit-and (aget ^bytes bytes i) 0xff)
+                   :cljs (bit-and (.charCodeAt bytes i) 0xff))
+              h' (-> (bit-xor h b)
+                     (* fnv-prime)
+                     (bit-and 0xffffffff))]
+          (recur (inc i) h'))
+        #?(:clj  (format "%08x" (bit-and h 0xffffffff))
+           :cljs (let [hx (.toString (bit-and h 0xffffffff) 16)]
+                   (str (subs "00000000" 0 (max 0 (- 8 (count hx)))) hx)))))))
+
+(defn- redact-key-component
+  "Project a scope or params `value` from a scoped key to its wire shape under
+  a metadata-only (`:redact` / `:omit`) classification: a `{:rf/redacted
+  <digest>}` token whose digest content-addresses the canonical value (Spec
+  016 clause 4 / rf2-otms75). Distinct values get distinct digests (so the
+  projected key stays unique — the index recompute never collapses two
+  entries), the raw scope / params never ride, and the token is opaque (the
+  client refetches route-driven, not from this digest). A nil / empty value
+  (the empty-scope / no-params case) projects to a stable `{:rf/redacted
+  nil}` — there is nothing sensitive to hide."
+  [value]
+  (if (or (nil? value) (and (coll? value) (empty? value)))
+    {:rf/redacted nil}
+    {:rf/redacted (fnv-1a-32 (pr-str value))}))
+
+(defn project-scoped-key
+  "Project a scoped resource KEY (`[scope resource-id params]`) to its wire
+  shape per the resource's `disposition` (Spec 016 clause 4 / rf2-otms75):
+
+    - `:serialize` — the key rides VERBATIM (a non-sensitive, non-large
+      resource: its scope / params are wire-safe, same as its data);
+    - `:redact` / `:omit` — the scope and params are replaced by opaque
+      content-addressed `{:rf/redacted <digest>}` tokens so the sensitive /
+      large raw identity does NOT ride, while the resource-id (position 1) and
+      key DISTINCTNESS are preserved (the digest differs per distinct value).
+
+  The wire key keeps the `[scope resource-id params]` SHAPE so the client's
+  index recompute + refetch plan parse it unchanged (resource-id at position
+  1). PURE."
+  [scoped-key disposition]
+  (if (= :serialize disposition)
+    scoped-key
+    (let [[scope resource-id params] scoped-key]
+      [(redact-key-component scope) resource-id (redact-key-component params)])))
+
 (defn- project-entry
   "Project a single durable cache `entry` (under `scoped-key`) to its wire
   shape per its classification, against the SSR `frame-id` (so the shared
@@ -253,7 +333,13 @@
   sensitive / large schema paths govern the per-entry projection. The
   projection NEVER ships all of `:rf.db/runtime` — only the
   `:rf.runtime/resources` `:entries` (Spec 016 §SSR and hydration: \"Do not
-  serialize all of `:rf.db/runtime` by default\")."
+  serialize all of `:rf.db/runtime` by default\").
+
+  rf2-otms75 — the projected MAP KEY is also privacy-aligned: a `:sensitive?` /
+  `:large?` resource's scope + params are redacted to opaque content-addressed
+  tokens in the wire key (`project-scoped-key`), so the raw identity never
+  rides any more than its data does (Spec 016 clause 4). A `:serialize`
+  resource's key rides verbatim."
   [runtime-db]
   (let [resources (get runtime-db state/resources-key)
         entries   (:entries resources)]
@@ -262,7 +348,9 @@
             clock-ms (now-ms)
             wired    (into {}
                            (map (fn [[k entry]]
-                                  [k (first (project-entry frame-id clock-ms k entry))]))
+                                  (let [disposition (entry-classification k entry)
+                                        wire-key    (project-scoped-key k disposition)]
+                                    [wire-key (first (project-entry frame-id clock-ms k entry))])))
                            entries)]
         {state/resources-key {:entries wired}})
       {})))

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -65,6 +65,7 @@
             [re-frame.resources.mutation-runtime :as mutation-runtime]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.state :as state]
+            [re-frame.resources.timers :as timers]
             [re-frame.resources.work-ledger :as work-ledger]
             [re-frame.trace :as trace]))
 
@@ -894,6 +895,45 @@
                runtime-db pending)
        pending])))
 
+(defn clear-host-transients-on-restore!
+  "Clear the restored `frame-id`'s HOST-SIDE transient resource caches that the
+  pre-restore timeline armed (rf2-nd1r9q, Spec 016 §Restore and replay part 5).
+  Epoch restore installs the durable snapshot wholesale, but host side tables
+  are NOT frame-state — they belong to the pre-restore timeline and must be
+  cleared so a stale timer / abandoned in-flight handle cannot fire against the
+  restored state:
+
+    - **stale / GC timer handles** (`timers/release-frame!`) — cancelled +
+      dropped for the frame; stale/GC scheduling re-arms LAZILY from the
+      restored entries' durable timestamps the next time the runtime touches
+      each entry (the timer is advisory, re-checked against durable facts), so
+      restore arms NO eager timer;
+    - **work-ledger host handles** (`work-ledger/release-frame!`) — the
+      AbortController / transport-promise slots for the frame's in-flight
+      attempts; best-effort aborted on the way out (the work is dangling per
+      part 2 — its durable row was already settled `:suppressed`).
+
+  DELIBERATELY does NOT touch (Spec 016 part 5 / the bead's explicit fence):
+
+    - the host-side GENERATION high-water mark (`state/generation-cache`) — it
+      is monotonic + must NOT rewind (part 1), or a pre-restore reply's
+      generation could re-match a post-restore entry; resetting it here would
+      reintroduce the exact anti-recycling hazard restore exists to prevent;
+    - the focus/reconnect REVALIDATION-LISTENER ownership — those host
+      listeners are frame-lifecycle-scoped (install on frame create, remove on
+      frame destroy), NOT epoch-scoped; a restore is not a frame teardown, so
+      their ownership rides through (re-installing them here would double-bind
+      or orphan the live listeners).
+
+  This is the restore-specific SUBSET of the frame-destroy teardown
+  (`release-resources-host-caches!`), which clears all four. Side-effecting
+  (mutates the module-level `timer-table` / `handle-table`); idempotent;
+  returns nil. No-op for a frame with no armed transients."
+  [frame-id]
+  (timers/release-frame! frame-id)
+  (work-ledger/release-frame! frame-id)
+  nil)
+
 (defn reconcile-on-restore
   "Reconcile a freshly-INSTALLED resource subtree on `restore-epoch` (the body
   behind the `:resources/reconcile-on-restore` hook epoch `perform-restore!`
@@ -1018,6 +1058,19 @@
                                             skew "ms ahead of the live clock — clock "
                                             "skew makes freshness ambiguous; the next "
                                             "live-owner ensure will resolve it.")}))
+         ;; rf2-nd1r9q — clear the restored frame's HOST-SIDE transients (stale /
+         ;; GC timer handles + work-ledger host handles) that the pre-restore
+         ;; timeline armed (Spec 016 §Restore and replay part 5). These are NOT
+         ;; frame-state, so the wholesale install does not touch them; a stale
+         ;; timer or abandoned in-flight handle must not fire against the
+         ;; restored state. Scheduling re-arms LAZILY from the restored durable
+         ;; timestamps on the next live-owner touch, so restore triggers no
+         ;; eager refetch. Skips the generation high-water mark (must not rewind
+         ;; — part 1) and the revalidation listeners (frame-lifecycle-scoped, not
+         ;; epoch-scoped). Guarded on `frame-id` (the host always passes one; the
+         ;; pure-unit 1-arity passes nil and has no live host tables to clear).
+         (when frame-id
+           (clear-host-transients-on-restore! frame-id))
          rdb''')))))
 
 ;; ---- client refetch decision (Spec 016 §SSR and hydration) ----------------

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -371,6 +371,154 @@
           :limit-ms    deadline-ms
           :error       error}}))))
 
+;; ---- routing slice literals (duplicated, not imported) --------------------
+;;
+;; Two SSR-slice consumers read the routing-runtime subtree:
+;;   - the BLOCKING DRAIN reads the current nav-token's blocking scoped-key
+;;     set the route slice wrote on entry (`route.cljc` §blocking-path), so it
+;;     knows which resources must settle before the render;
+;;   - RESTORE reconciliation compares a restored route owner's nav-token
+;;     against the nav-token the restored routing slice considers live (Spec
+;;     016 §Restore and replay part 4 — `[:rf.runtime/routing :current
+;;     :nav-token]`, present because restore installs both partitions
+;;     wholesale).
+;; We mirror the routing literals here rather than `:require` the route slice —
+;; the same duplication-not-import decoupling `route.cljc` itself uses
+;; (resources never statically depends on routing).
+
+(def ^:private routing-key
+  "The routing-runtime subtree key (`:rf.runtime/routing`). Mirrors the
+  literal routing + `route.cljc` use; duplicated (not imported) so the SSR
+  slice never statically `:require`s routing/route."
+  :rf.runtime/routing)
+
+(def ^:private routing-current-nav-token-path
+  "Runtime-db-relative path to the live route slice's nav-token
+  (`[:rf.runtime/routing :current :nav-token]`). The drain reads which
+  nav-token is live to pick its blocking slot; restore reads it to know which
+  nav-token the restored routing slice considers live."
+  [routing-key :current :nav-token])
+
+(def ^:private routing-resource-blocking-key
+  "The routing-runtime child holding per-nav-token blocking scoped-key sets
+  (`:resource-blocking`). The route slice writes `[:rf.runtime/routing
+  :resource-blocking <nav-token>]` on entry (`route.cljc/blocking-path`);
+  the SSR drain loop reads the CURRENT nav-token's slot."
+  :resource-blocking)
+
+(defn current-blocking-keys
+  "Read the set of blocking scoped resource keys the route slice enqueued for
+  the CURRENT nav-token from `runtime-db` (`[:rf.runtime/routing
+  :resource-blocking <current-nav-token>]`). Returns `#{}` when there is no
+  routing slice, no current nav-token, or no blocking resources for it — a
+  route with no blocking resources never blocks the render. Reads ONLY the
+  current nav-token's slot; a superseded navigation's stale slot never enters
+  the drain (the route slice releases it on leave). PURE. Per Spec 016 §SSR
+  and hydration step 3 / §Route integration."
+  [runtime-db]
+  (let [nav-token (get-in runtime-db routing-current-nav-token-path)]
+    (or (get-in runtime-db [routing-key routing-resource-blocking-key nav-token])
+        #{})))
+
+;; ---- the SSR blocking-drain LOOP (Spec 016 §SSR and hydration steps 3-4) ---
+;;
+;; `blocking-settled?` is the PREDICATE and `settle-blocking-timeout` is the
+;; TIMEOUT POLICY; `drain-blocking-resources!` is the LOOP that fuses them and
+;; INSTALLS the result, so the host render path (Ring / streaming) calls ONE
+;; late-bound entry point instead of re-implementing the wait. The host owns
+;; the event PUMP (it owns the drain pump + the wall clock); it supplies a
+;; `pump!` thunk the loop calls each tick to let the in-flight blocking-resource
+;; replies land, and a `clock-fn` + `deadline-ms` budget. This namespace owns
+;; reading the live blocking set, the settled check, and installing the timeout
+;; settle into the frame's runtime-db — so a never-settling blocking resource
+;; renders a SETTLED first-load failure, never a hung `:loading` / skeleton.
+
+(defn drain-blocking-resources!
+  "DRAIN the current nav-token's blocking resources for an SSR `frame-id`
+  until they settle or a wall-clock deadline fires (Spec 016 §SSR and
+  hydration steps 3-4). The body behind the `:resources/drain-blocking-ssr!`
+  late-bind hook the host render path (Ring / streaming) consults BEFORE it
+  renders, so the render walk always sees a SETTLED resource state — never an
+  unchecked `:loading` / skeleton an in-flight (or never-settling) blocking
+  resource would otherwise leave.
+
+  Opts (host-supplied — the host owns the pump + the clock):
+
+    :pump!       — 1-arity fn `(fn [tick-ms] …)` the loop calls each tick to
+                   advance the event pump so an in-flight blocking-resource
+                   reply lands and its `:rf.resource.internal/succeeded` /
+                   `failed` reply event drains (settling the entry). The arg
+                   is the `:tick-ms` poll-granularity hint (how long the host
+                   may yield this tick); a host that pumps synchronously may
+                   ignore it. For a synchronous / already-settled transport
+                   this is a no-op the loop rarely needs; for a real async
+                   transport it yields (e.g. a short sleep) so the reply
+                   thread makes progress. NIL → the loop re-checks without
+                   pumping (it still respects the deadline, so a never-settling
+                   resource still times out — useful for a sync test stub).
+    :deadline-ms — the wall-clock render-deadline budget in ms (the SSR
+                   blocking timeout). On elapse every still-unsettled blocking
+                   entry is settled to a structured first-load failure
+                   (`settle-blocking-timeout`). REQUIRED — an unbounded drain
+                   would let a never-settling resource hang the request.
+    :clock-fn    — 0-arity epoch-ms clock (defaults to the host platform
+                   clock); injectable so a test drives the deadline
+                   deterministically.
+    :tick-ms     — advisory poll-granularity hint passed as the `pump!` arg
+                   each tick (defaults to 0). The loop itself just re-checks
+                   after each `pump!`; the hint lets a host yield in bounded
+                   slices rather than busy-spinning.
+
+  Returns `{:settled? <bool> :timed-out <#{scoped-key}> :route-blocking-failure
+  <record-or-nil>}`. On a clean settle within budget: `:settled? true`,
+  `:timed-out #{}`, no failure record, and the frame's runtime-db is
+  UNCHANGED. On timeout: the still-unsettled blocking entries are settled to
+  first-load failures IN the frame's runtime-db (via `swap-runtime-db!`),
+  `:settled? false`, and `:route-blocking-failure` carries the record the host
+  hands the route slice / renderer. An empty blocking set (a route with no
+  blocking resources) returns `:settled? true` immediately without pumping.
+
+  PURE w.r.t. routing state — it touches only the resource `:entries` (the
+  route slice owns the route transition; the host hands it the failure
+  record). The drain reads the LIVE frame each tick (`frame-runtime-db-value`)
+  so a reply that lands mid-pump is observed."
+  [frame-id {:keys [pump! deadline-ms clock-fn tick-ms]}]
+  (let [clock-fn (or clock-fn now-ms)
+        rdb0     (frame/frame-runtime-db-value frame-id)
+        blocking (current-blocking-keys rdb0)]
+    (if (empty? blocking)
+      {:settled? true :timed-out #{} :route-blocking-failure nil}
+      (let [start    (clock-fn)
+            deadline (+ start deadline-ms)]
+        (loop []
+          (let [rdb     (frame/frame-runtime-db-value frame-id)
+                entries (get-in rdb [state/resources-key :entries])]
+            (cond
+              ;; every blocking entry settled within budget — render sees the
+              ;; settled state, runtime-db untouched.
+              (blocking-settled? entries blocking)
+              {:settled? true :timed-out #{} :route-blocking-failure nil}
+
+              ;; deadline elapsed — settle every still-unsettled blocking entry
+              ;; to a first-load failure and INSTALL it (the render then sees a
+              ;; structured :error, never a hung :loading).
+              (>= (clock-fn) deadline)
+              (let [{:keys [entries route-blocking-failure]}
+                    (settle-blocking-timeout entries blocking deadline-ms frame-id)]
+                (frame/swap-runtime-db! frame-id assoc-in
+                                        [state/resources-key :entries] entries)
+                {:settled?              false
+                 :timed-out             (unsettled-blocking-keys
+                                          (get-in rdb [state/resources-key :entries])
+                                          blocking)
+                 :route-blocking-failure route-blocking-failure})
+
+              ;; not yet settled, budget remains — pump the host event loop so
+              ;; an in-flight blocking reply lands, then re-check the live frame.
+              :else
+              (do (when pump! (pump! (or tick-ms 0)))
+                  (recur)))))))))
+
 ;; ---- client hydration (Spec 016 §SSR and hydration / §Restore and replay) -
 ;;
 ;; On `:rf/hydrate` the SSR handler installs the payload's `:rf/runtime-db`
@@ -391,29 +539,6 @@
 ;;   4. surface server CLOCK SKEW when a restored `:stale-at` is implausible
 ;;      against the live clock (Spec 016 §SSR and hydration: absolute
 ;;      timestamps; skew surfaced when it makes freshness ambiguous).
-
-;; ---- routing slice literals (duplicated, not imported) --------------------
-;;
-;; Restore reconciliation must compare a restored route owner's nav-token
-;; against the nav-token the restored routing slice currently considers live
-;; (Spec 016 §Restore and replay part 4). The live nav-token sits at
-;; `[:rf.runtime/routing :current :nav-token]` in the same runtime-db restore
-;; installs (both partitions land wholesale, so `:current` IS present). We
-;; mirror the routing literals here rather than `:require` the route slice —
-;; the same duplication-not-import decoupling `route.cljc` itself uses
-;; (resources never statically depends on routing).
-
-(def ^:private routing-key
-  "The routing-runtime subtree key (`:rf.runtime/routing`). Mirrors the
-  literal routing + `route.cljc` use; duplicated (not imported) so the SSR
-  slice never statically `:require`s routing/route."
-  :rf.runtime/routing)
-
-(def ^:private routing-current-nav-token-path
-  "Runtime-db-relative path to the live route slice's nav-token
-  (`[:rf.runtime/routing :current :nav-token]`). Restore reads this to know
-  which nav-token the restored routing slice considers live."
-  [routing-key :current :nav-token])
 
 (defn- ssr-owner?
   "True iff `owner` is an SSR owner token (`[:ssr request-id nav-token]`).
@@ -859,6 +984,11 @@
     - `:ssr/extend-runtime-db-projection` — SSR's `project-runtime-db`
       rides the durable resource `:entries` (per-entry redacted / omitted)
       on the hydration payload;
+    - `:resources/drain-blocking-ssr!` — the SSR render path (Ring /
+      streaming) drains the current nav-token's blocking resources until they
+      settle or the render deadline fires, settling a never-settling blocking
+      resource to a first-load failure so the render never hangs (Spec 016
+      §SSR and hydration steps 3-4);
     - `:resources/hydrate-runtime-db` — the SSR `:rf/hydrate` handler
       reconciles the installed resource subtree (recompute indexes, orphan
       SSR owners, surface clock skew);
@@ -877,6 +1007,7 @@
   []
   (late-bind/set-fns!
     {:ssr/extend-runtime-db-projection project-resources-runtime-db
+     :resources/drain-blocking-ssr!    drain-blocking-resources!
      :resources/hydrate-runtime-db     hydrate-runtime-db
      :resources/reconcile-on-restore   reconcile-on-restore})
   nil)

--- a/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
@@ -40,10 +40,13 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.frame :as frame]
    [re-frame.late-bind :as late-bind]
    ;; load-bearing side-effecting require: the façade publishes the restore
    ;; reconcile hook + registers the resource registrar kind.
    [re-frame.resources]
+   [re-frame.resources.mutation-runtime :as mstate]
    [re-frame.resources.ssr :as ssr]
    [re-frame.resources.state :as state]
    [re-frame.resources.work-ledger :as work-ledger]
@@ -222,6 +225,121 @@
       (is (= [w1] dangled) "only the non-terminal row is dangled")
       (is (= :suppressed (get-in rdb' [state/work-ledger-key w1 :status])))
       (is (= :completed (get-in rdb' [state/work-ledger-key w2 :status]))))))
+
+;; ===========================================================================
+;; 2b. Dangle PENDING mutation instances on restore (rf2-o3d1uf, part 2)
+;; ===========================================================================
+;;
+;; A restored :pending mutation instance retains :current-work + :generation.
+;; The mutation reply gate (`live-instance-for-reply`) checks the INSTANCE's
+;; :current-work (NOT the resource entry's), so WITHOUT reconciling the
+;; instance a late pre-restore mutation reply would still match and
+;; patch/populate/invalidate post-restore resource state. The reconcile
+;; terminally-settles the pending instance to :error/:dangling-on-restore and
+;; clears :current-work so the gate suppresses the late reply.
+
+(defn- mutation-instance
+  "A durable mutation instance under instance-id, mirroring empty-instance +
+  overrides (defaults to a :pending instance pointing at work-id)."
+  [{:keys [mutation-id instance-id status generation work-id scope params]
+    :or   {mutation-id :comment/add status :pending generation 3}}]
+  (-> (mstate/empty-instance mutation-id instance-id
+        {:scope scope :params params :generation generation
+         :work-id work-id :started-at 1000})
+      (assoc :status status)))
+
+(deftest instance-dangled-settles-pending-and-clears-current-work
+  (testing "instance-dangled: a :pending instance settles terminal :error with
+            the :dangling-on-restore envelope and CLEARS :current-work"
+    (let [inst (mutation-instance {:instance-id :inst-1
+                                   :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
+          out  (mstate/instance-dangled inst 9999)]
+      (is (= :error (:status out)) "pending → terminal :error")
+      (is (= :dangling-on-restore (:reason (:error out))))
+      (is (nil? (:current-work out)) ":current-work cleared (the suppression gate)")
+      (is (mstate/terminal? (:status out)) "the instance is now terminal")))
+  (testing "a TERMINAL instance rides through unchanged"
+    (let [done (mutation-instance {:instance-id :inst-2 :status :success})]
+      (is (= done (mstate/instance-dangled done 9999))))))
+
+(deftest dangle-pending-mutations-settles-and-returns-ids
+  (testing "dangle-pending-mutations! settles every pending instance + clears
+            current-work; terminal instances untouched; returns the dangled ids"
+    (let [pending (mutation-instance {:instance-id :inst-p
+                                      :work-id [:rf.work/resource [:rf.mutation :inst-p 3] 3]})
+          settled (mutation-instance {:instance-id :inst-s :status :success})
+          rdb {mstate/mutations-key {:inst-p pending :inst-s settled}}
+          [rdb' dangled] (ssr/dangle-pending-mutations! rdb 9999)]
+      (is (= [:inst-p] dangled) "only the pending instance is dangled")
+      (is (= :error (get-in rdb' [mstate/mutations-key :inst-p :status])))
+      (is (nil? (get-in rdb' [mstate/mutations-key :inst-p :current-work])))
+      (is (= :success (get-in rdb' [mstate/mutations-key :inst-s :status]))
+          "the terminal instance is untouched")))
+  (testing "no mutation instances → no-op"
+    (is (= [{} []] (ssr/dangle-pending-mutations! {} 9999)))))
+
+(deftest reconcile-on-restore-dangles-pending-mutation-instances
+  (testing "reconcile-on-restore reconciles the :rf.runtime/mutations slice too"
+    (let [pending (mutation-instance {:instance-id :inst-1
+                                      :work-id [:rf.work/resource [:rf.mutation :inst-1 3] 3]})
+          rdb {mstate/mutations-key {:inst-1 pending}}
+          out (ssr/reconcile-on-restore rdb :app/main)]
+      (is (= :error (get-in out [mstate/mutations-key :inst-1 :status])))
+      (is (nil? (get-in out [mstate/mutations-key :inst-1 :current-work]))))))
+
+(deftest late-pre-restore-mutation-reply-is-suppressed-end-to-end
+  (rf/reg-resource :article/by-slug
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}})
+     :tags    (fn [{:keys [slug]} _] #{[:article slug]})})
+  (testing "ADVERSARIAL acceptance (rf2-o3d1uf): a pre-restore mutation success
+            reply that lands AFTER restore is SUPPRESSED — it does NOT patch /
+            populate / invalidate the post-restore resource entry"
+    (let [fid       :restore/mutation-frame
+          ;; a loaded resource entry the (pre-restore) mutation would have patched
+          loaded    (entry {:resource-id :article/by-slug :status :loaded
+                            :data {:title "post-restore"} :loaded-at 1 :stale-at 9.0e15
+                            :generation 9})
+          instance-id [:rf.mutation/instance :article/edit 3]
+          work-id   (work-ledger/resource-work-id [:rf.mutation instance-id] 3)
+          ;; the captured snapshot: a PENDING mutation instance pointing at work-id
+          pending   (mutation-instance {:mutation-id :article/edit
+                                        :instance-id instance-id
+                                        :generation 3 :work-id work-id
+                                        :scope :rf.scope/global :params {:slug "x"}})
+          ;; the runtime-db that restore is about to install (reconciled first)
+          snapshot  (-> (runtime-db-with {gkey loaded})
+                        (assoc mstate/mutations-key {instance-id pending})
+                        (assoc-in (work-ledger/record-path work-id)
+                                  (-> (work-ledger/work-record
+                                        {:work-id work-id :frame-id fid
+                                         :resource-key [:rf.mutation instance-id]
+                                         :generation 3 :transport :rf.http/managed
+                                         :started-at 1000})
+                                      (assoc :work/kind :mutation))))
+          reconciled (ssr/reconcile-on-restore snapshot fid)]
+      (rf/reg-frame fid {:doc "restore mutation suppression frame"})
+      ;; install the reconciled snapshot as the live frame-state
+      (frame/replace-runtime-db! fid reconciled)
+      (testing "post-reconcile the pending instance is terminal + current-work cleared"
+        (is (= :error (get-in reconciled [mstate/mutations-key instance-id :status])))
+        (is (nil? (get-in reconciled [mstate/mutations-key instance-id :current-work]))))
+      ;; NOW the late pre-restore mutation SUCCESS reply lands (carrying the
+      ;; pre-restore work-id + generation that the snapshot instance held).
+      (rf/dispatch-sync
+        [:rf.mutation.internal/succeeded
+         {:instance-id instance-id :mutation-id :article/edit
+          :work-id work-id :generation 3 :scope :rf.scope/global}
+         {:kind :success :value {:title "STALE pre-restore write"}}]
+        {:frame fid})
+      (let [post (frame/frame-runtime-db-value fid)
+            e    (get-in post [state/resources-key :entries gkey])]
+        (is (= {:title "post-restore"} (:data e))
+            "the resource entry is UNCHANGED — the stale reply did not patch/populate it")
+        (is (= :error (get-in post [mstate/mutations-key instance-id :status]))
+            "the dangled instance stays terminal :error — the stale reply did not revive it"))
+      (frame/destroy-frame! fid))))
 
 ;; ===========================================================================
 ;; 3. Owner reconciliation: orphan SSR, keep route (Spec 016 §Restore part 4)

--- a/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
@@ -49,6 +49,7 @@
    [re-frame.resources.mutation-runtime :as mstate]
    [re-frame.resources.ssr :as ssr]
    [re-frame.resources.state :as state]
+   [re-frame.resources.timers :as timers]
    [re-frame.resources.work-ledger :as work-ledger]
    [re-frame.test-support :as core-test-support]
    [re-frame.trace.tooling :as trace-tooling]
@@ -489,6 +490,80 @@
           "tag-index recomputed from the entry's :tags; bogus snapshot index discarded")
       (is (= {[:route :route/article "nav-1"] #{gkey}} (:owner-index sub))
           "owner-index recomputed from the entry's owners; bogus snapshot index discarded"))))
+
+;; ===========================================================================
+;; 4b. Clear host transients on restore (rf2-nd1r9q, part 5)
+;; ===========================================================================
+;;
+;; Host side tables (stale/GC timer handles + work-ledger host handles) belong
+;; to the PRE-restore timeline and are NOT frame-state, so the wholesale
+;; install does not touch them. restore-reconcile must clear them for the
+;; restored frame so a stale timer / abandoned in-flight handle cannot fire
+;; against the restored state — WITHOUT rewinding the generation high-water
+;; mark or re-binding the revalidation listeners.
+
+(defn- frame-timer-keys
+  "The timer-table keys (`[frame-id resource-key kind]`) armed for `frame-id`."
+  [frame-id]
+  (filter (fn [[fid _ _]] (= fid frame-id)) (keys @timers/timer-table)))
+
+(defn- frame-handle-keys
+  "The work-ledger handle-table keys (`[frame-id work-id]`) for `frame-id`."
+  [frame-id]
+  (filter (fn [[fid _]] (= fid frame-id)) (keys @work-ledger/handle-table)))
+
+(deftest clear-host-transients-on-restore-clears-timers-and-handles
+  (testing "rf2-nd1r9q — restore clears the frame's armed stale/GC timer handles
+            and work-ledger host handles (host transients, not frame-state)"
+    (let [fid :restore/transients
+          rkey gkey
+          wid  [:rf.work/resource gkey 4]]
+      ;; arm a stale timer (long delay so it never fires during the test) and a
+      ;; work-ledger host handle for the frame.
+      (timers/schedule! fid rkey timers/stale-kind 600000)
+      (work-ledger/put-handle! fid wid {:transport :rf.http/managed :request-id wid})
+      (is (seq (frame-timer-keys fid)) "a stale timer is armed for the frame")
+      (is (seq (frame-handle-keys fid)) "a work handle is recorded for the frame")
+      ;; restore the frame's snapshot (a mid-flight fetching entry)
+      (let [e (entry {:resource-id :article/by-slug :status :fetching :data {:x 1}
+                      :loaded-at 1 :stale-at 9.0e15 :current-work wid})]
+        (ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid))
+      (is (empty? (frame-timer-keys fid))
+          "the frame's stale/GC timer handles are GONE after restore")
+      (is (empty? (frame-handle-keys fid))
+          "the frame's work-ledger host handles are GONE after restore")
+      ;; cleanup any stray timers (none expected)
+      (timers/cancel-for-key! fid rkey))))
+
+(deftest restore-host-clear-preserves-generation-high-water
+  (testing "rf2-nd1r9q — clearing host transients on restore does NOT rewind the
+            generation high-water mark (part 1 — it must stay monotonic)"
+    (let [fid :restore/gen-preserve]
+      (state/commit-generation! fid 11)
+      (timers/schedule! fid gkey timers/stale-kind 600000)
+      (let [e (entry {:resource-id :article/by-slug :status :fetching :data {:x 1}
+                      :loaded-at 1 :stale-at 9.0e15 :current-work [:rf.work/resource gkey 5]})]
+        (ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid))
+      (is (= 11 (state/generation-snapshot fid))
+          "the host-side generation high-water mark is UNTOUCHED by the host-transient clear")
+      (timers/cancel-for-key! fid gkey))))
+
+(deftest restore-host-clear-triggers-no-eager-refetch
+  (testing "rf2-nd1r9q — restore clears transients but arms NO eager refetch /
+            timer (scheduling re-arms lazily on the next live-owner touch)"
+    (let [fid :restore/no-eager
+          e   (entry {:resource-id :article/by-slug :status :loaded
+                      :data {:x 1} :loaded-at 1 :stale-at 2})] ;; stale
+      (ssr/reconcile-on-restore (runtime-db-with {gkey e}) fid)
+      (is (empty? (frame-timer-keys fid))
+          "no stale/GC timer is armed by restore (lazy re-arm on next ensure)")
+      (is (empty? (frame-handle-keys fid))
+          "no work handle is created by restore (no eager refetch)"))))
+
+(deftest clear-host-transients-on-restore-is-pure-subset
+  (testing "rf2-nd1r9q — clear-host-transients-on-restore! clears timers + work
+            handles but is a no-op on an unarmed frame (idempotent)"
+    (is (nil? (ssr/clear-host-transients-on-restore! :restore/unarmed)))))
 
 ;; ===========================================================================
 ;; 5. The generation allocator is monotonic across restore (part 1)

--- a/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
@@ -51,6 +51,7 @@
    [re-frame.resources.state :as state]
    [re-frame.resources.work-ledger :as work-ledger]
    [re-frame.test-support :as core-test-support]
+   [re-frame.trace.tooling :as trace-tooling]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
        :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
 
@@ -395,21 +396,74 @@
       (is (contains? (get-in out [state/resources-key :owner-index]) live)
           "the surviving live-nav route owner is present in the owner-index"))))
 
-(deftest restore-keeps-route-owners-without-routing-slice
-  (testing "with NO restored routing slice (a resources-only app / the SSR-
-            hydration parity case) route owners ride through unchanged — the
-            stale-nav orphan rule needs a live nav-token to compare against"
-    (let [e   (entry {:resource-id :article/by-slug :status :loaded :data {:x 1}
+;; rf2-64bdnk — on RESTORE, a missing/nil live nav-token means NO route owner
+;; is live (the OPPOSITE of hydration, where a nil token is "can't compare
+;; yet"). Spec 016 §Restore part 4: route owners revive ONLY IF the restored
+;; routing names the same live nav-token; absent routing slice / no :current /
+;; nil nav-token → every route owner orphans.
+
+(deftest restore-orphans-route-owners-when-no-live-nav-token
+  (testing "rf2-64bdnk — restore with no live nav-token orphans ALL route
+            owners across the three absent-token shapes; machine/lease owners
+            survive; the owner-index is recomputed without the orphans"
+    (doseq [[label rdb-fn]
+            [["absent routing slice"
+              (fn [rdb] rdb)] ;; runtime-db-with carries no :rf.runtime/routing
+             ["routing slice without :current"
+              (fn [rdb] (assoc rdb :rf.runtime/routing {:pending-navigation {:x 1}}))]
+             ["routing :current with nil nav-token"
+              (fn [rdb] (assoc-in rdb [:rf.runtime/routing :current :nav-token] nil))]]]
+      (testing label
+        (let [route-owner [:route :route/article "nav-anything"]
+              e   (entry {:resource-id :article/by-slug :status :loaded :data {:x 1}
+                          :loaded-at 1 :stale-at 9.0e15
+                          :owners #{[:ssr "req-9" "nav-1"]
+                                    route-owner
+                                    [:machine :checkout/flow "inst-1"]
+                                    [:lease :dashboard 7]}})
+              out (ssr/reconcile-on-restore (rdb-fn (runtime-db-with {gkey e})) :app/main)
+              owners (get-in out [state/resources-key :entries gkey :active-owners])]
+          (is (not (contains? owners route-owner))
+              "the route owner is ORPHANED (no live nav-token names it live)")
+          (is (not (contains? owners [:ssr "req-9" "nav-1"])) "SSR owner orphaned")
+          (is (contains? owners [:machine :checkout/flow "inst-1"]) "machine owner survives")
+          (is (contains? owners [:lease :dashboard 7]) "lease owner survives")
+          (is (not (contains? (get-in out [state/resources-key :owner-index]) route-owner))
+              "the orphaned route owner is absent from the recomputed owner-index"))))))
+
+(deftest restore-no-live-token-emits-owner-release-trace
+  (testing "rf2-64bdnk — a route owner released because no live nav-token names
+            it emits a :rf.resource/owner-released trace row (Spec 016 part 4)"
+    (let [route-owner [:route :route/article "nav-X"]
+          e   (entry {:resource-id :article/by-slug :status :loaded :data {:x 1}
+                      :loaded-at 1 :stale-at 9.0e15 :owners #{route-owner}})
+          seen (atom [])
+          k    ::owner-release-recorder]
+      (trace-tooling/register-listener!
+        k (fn [ev] (when (= :rf.resource/owner-released (:operation ev))
+                     (swap! seen conj ev))))
+      (try
+        (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
+        (finally (trace-tooling/unregister-listener! k)))
+      (is (some #(= route-owner (:owner (:tags %))) @seen)
+          "an owner-released row names the orphaned route owner")
+      (is (some #(= :stale-nav-orphan (:reason (:tags %))) @seen)
+          "the release reason is the stale-nav/no-live-token orphan"))))
+
+(deftest hydration-parity-route-owners-ride-through-without-routing
+  (testing "rf2-64bdnk parity — HYDRATION (the no-comparison-yet case) still
+            rides route owners through unchanged when there is no client routing
+            slice (the split: nil-token-on-hydrate ≠ nil-token-on-restore)"
+    (let [route-owner [:route :route/article "nav-anything"]
+          e   (entry {:resource-id :article/by-slug :status :loaded :data {:x 1}
                       :loaded-at 1 :stale-at 9.0e15
-                      :owners #{[:ssr "req-9" "nav-1"]
-                                [:route :route/article "nav-anything"]}})
-          ;; runtime-db-with carries no :rf.runtime/routing slice → nil live token
-          out (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
+                      :owners #{[:ssr "req-9" "nav-1"] route-owner}})
+          out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
           owners (get-in out [state/resources-key :entries gkey :active-owners])]
       (is (not (contains? owners [:ssr "req-9" "nav-1"]))
-          "SSR owner still orphans even without routing")
-      (is (contains? owners [:route :route/article "nav-anything"])
-          "route owner rides through when there is no live nav-token to compare against"))))
+          "SSR owner still orphans on hydration")
+      (is (contains? owners route-owner)
+          "route owner RIDES THROUGH on hydration (routing's client subsystem reconciles it)"))))
 
 ;; ===========================================================================
 ;; 4. Indexes recomputed from entries, never trusted (Spec 016 §Restore part 5)
@@ -422,9 +476,13 @@
                       :loaded-at 1 :stale-at 9.0e15
                       :tags #{[:article "x"]}
                       :owners #{[:route :route/article "nav-1"]}})
-          rdb {state/resources-key {:entries     {gkey e}
-                                    :tag-index   {[:bogus] #{:nope}}
-                                    :owner-index {[:bogus] #{:nope}}}}
+          ;; name nav-1 live so the route owner SURVIVES (rf2-64bdnk) — this
+          ;; test pins the index RECOMPUTE, not owner orphaning; without a live
+          ;; token the route owner would now correctly orphan.
+          rdb (-> {state/resources-key {:entries     {gkey e}
+                                        :tag-index   {[:bogus] #{:nope}}
+                                        :owner-index {[:bogus] #{:nope}}}}
+                  (with-live-nav-token "nav-1"))
           out (ssr/reconcile-on-restore rdb :app/main)
           sub (get out state/resources-key)]
       (is (= {[:article "x"] #{gkey}} (:tag-index sub))

--- a/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
@@ -35,6 +35,7 @@
    [re-frame.core :as rf]
    [re-frame.frame :as frame]
    [re-frame.late-bind :as late-bind]
+   [re-frame.privacy :as privacy]
    ;; load-bearing side-effecting requires: the façade publishes the SSR
    ;; projection + reconcile hooks + registers the resource registrar kind.
    [re-frame.resources]
@@ -475,6 +476,76 @@
     (is (true?  (ssr/entry-needs-refetch?
                   (entry {:resource-id :a :data nil}) 100))
         "no-data (metadata-only) → refetch")))
+
+;; ===========================================================================
+;; 4b. Hydration refetch: redacted sentinel is metadata-only (rf2-fopuj9)
+;; ===========================================================================
+;;
+;; The redaction sentinel (`:rf/redacted`) rides as `:data` on a `:sensitive?`
+;; resource's projected entry — it is METADATA ONLY, NOT usable data. A naive
+;; `(some? (:data entry))` would misclassify it as fresh-with-data → never
+;; refetch, leaving the client rendering the sentinel as if it were the value.
+
+(deftest redacted-sentinel-is-not-usable-data
+  (testing "hydrated-data-usable? excludes the redaction sentinel"
+    (is (true?  (ssr/hydrated-data-usable? (entry {:resource-id :a :data {:x 1}})))
+        "real data is usable")
+    (is (false? (ssr/hydrated-data-usable? (entry {:resource-id :a :data privacy/redacted-sentinel})))
+        "the :rf/redacted sentinel is NOT usable (metadata-only)")
+    (is (false? (ssr/hydrated-data-usable? (entry {:resource-id :a :data nil})))
+        "omitted (nil) is NOT usable")))
+
+(deftest redacted-fresh-entry-still-refetches
+  (testing "ADVERSARIAL: a FRESH (stale-at far ahead) entry whose data is the
+            redaction sentinel still needs a refetch — the sentinel must NOT be
+            mistaken for usable fresh data (rf2-fopuj9)"
+    (let [redacted-fresh (entry {:resource-id :secret/thing
+                                 :data privacy/redacted-sentinel
+                                 :loaded-at 1000 :stale-at 9.0e15 :status :loaded})]
+      (is (true? (ssr/entry-needs-refetch? redacted-fresh 5000))
+          "a fresh redacted entry refetches (the sentinel is metadata-only, not fresh data)"))))
+
+(deftest refetch-plan-classifies-redacted-vs-omitted-vs-stale-vs-fresh
+  (testing "the four hydration dispositions classify correctly (rf2-fopuj9 acceptance)"
+    (let [fresh    (entry {:resource-id :a :data {:x 1} :loaded-at 1000 :stale-at 9.0e15})
+          stale    (entry {:resource-id :b :data {:x 2} :loaded-at 1000 :stale-at 1500})
+          redacted (entry {:resource-id :c :data privacy/redacted-sentinel
+                           :loaded-at 1000 :stale-at 9.0e15 :status :loaded})  ;; sensitive → sentinel
+          omitted  (entry {:resource-id :d :data nil :status :loaded})          ;; large → no data key
+          plan     (->> (ssr/hydrate-refetch-plan (runtime-db-with {ka fresh kb stale kc redacted
+                                                                    (state/scoped-resource-key
+                                                                      :rf.scope/global :d {}) omitted})
+                                                  5000)
+                        (into {} (map (juxt :resource-key identity))))
+          kd       (state/scoped-resource-key :rf.scope/global :d {})]
+      (is (not (contains? plan ka)) "FRESH serialized → absent from the plan (no double-fetch)")
+      (is (= :stale         (:reason (plan kb))) "STALE serialized → background refetch")
+      (is (= :metadata-only (:reason (plan kc)))
+          "REDACTED (sentinel) → metadata-only refetch (NOT misclassified as fresh)")
+      (is (= :no-data       (:reason (plan kd))) "OMITTED (no data key) → no-data refetch"))))
+
+(deftest project-then-hydrate-roundtrip-sensitive-refetches
+  (reg! :secret/thing {:sensitive? true})
+  (testing "END-TO-END: a fresh :sensitive? entry PROJECTS to the redaction
+            sentinel, then on HYDRATION is classified metadata-only and
+            refetches — never rendered as if the sentinel were the real value
+            (rf2-fopuj9)"
+    (let [k    (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "s"})
+          ;; a FRESH sensitive entry on the server (stale-at far ahead)
+          e    (entry {:resource-id :secret/thing :data {:ssn "123-45-6789"}
+                       :loaded-at 1000 :stale-at 9.0e15})
+          ;; SERVER projection redacts the data to the sentinel
+          proj (ssr/project-resources-runtime-db (runtime-db-with {k e}))
+          we   (get-in proj [state/resources-key :entries k])]
+      (is (= privacy/redacted-sentinel (:data we))
+          "projection redacts the sensitive data to the sentinel")
+      ;; CLIENT hydration over the projected slice (a coherent runtime-db)
+      (let [installed {state/resources-key {:entries {k we}}}
+            plan      (->> (ssr/hydrate-refetch-plan installed 5000)
+                           (into {} (map (juxt :resource-key identity))))]
+        (is (contains? plan k)
+            "the redacted (fresh-on-server) entry IS in the refetch plan — the sentinel is not usable data")
+        (is (= :metadata-only (:reason (plan k))))))))
 
 ;; ===========================================================================
 ;; 5. SCOPE isolation

--- a/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
@@ -33,6 +33,7 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
+   [re-frame.frame :as frame]
    [re-frame.late-bind :as late-bind]
    ;; load-bearing side-effecting requires: the façade publishes the SSR
    ;; projection + reconcile hooks + registers the resource registrar kind.
@@ -239,6 +240,144 @@
           (ssr/settle-blocking-timeout {} #{kmiss} 100 :app/main)]
       (is (= :error (:status (get entries kmiss))))
       (is (= #{kmiss} (set (:timed-out route-blocking-failure)))))))
+
+;; ===========================================================================
+;; 2b. SERVER blocking-drain LOOP (rf2-er7qx2 — wired into the render path)
+;; ===========================================================================
+;;
+;; `drain-blocking-resources!` is the LOOP the host render path (Ring /
+;; streaming) calls before rendering: it reads the current nav-token's
+;; blocking set, pumps the event loop until they settle, and on the render
+;; deadline settles every still-unsettled blocking entry to a first-load
+;; failure IN the frame's runtime-db (so the render walk never sees a hung
+;; `:loading` / skeleton). These tests register a live frame and drive the
+;; loop with an injected pump / clock.
+
+(defn- seed-frame-runtime-db!
+  "Register `frame-id` (idempotent) and install `runtime-db` as its runtime-db
+  partition, returning frame-id. Used to stand up a live SSR-like frame the
+  drain loop reads/writes."
+  [frame-id runtime-db]
+  (rf/reg-frame frame-id {:doc "ssr blocking-drain test frame" :platform :server})
+  (frame/replace-runtime-db! frame-id runtime-db)
+  frame-id)
+
+(defn- with-blocking-slot
+  "Add a routing slice naming `nav-token` live + a `:resource-blocking` slot
+  holding `blocking-keys` for it, into `runtime-db` (mirrors what the route
+  slice writes on entry)."
+  [runtime-db nav-token blocking-keys]
+  (-> runtime-db
+      (assoc-in [:rf.runtime/routing :current :nav-token] nav-token)
+      (assoc-in [:rf.runtime/routing :resource-blocking nav-token] (set blocking-keys))))
+
+(deftest current-blocking-keys-reads-current-nav-token-slot
+  (testing "current-blocking-keys reads ONLY the current nav-token's blocking slot"
+    (let [rdb (-> (runtime-db-with {})
+                  (with-blocking-slot "nav-1" #{ka kb})
+                  ;; a superseded nav-token's stale slot must NOT leak in
+                  (assoc-in [:rf.runtime/routing :resource-blocking "nav-OLD"] #{kc}))]
+      (is (= #{ka kb} (ssr/current-blocking-keys rdb))))
+    (testing "no routing slice / no current nav-token → empty (never blocks)"
+      (is (= #{} (ssr/current-blocking-keys (runtime-db-with {}))))
+      (is (= #{} (ssr/current-blocking-keys {}))))))
+
+(deftest drain-noop-when-no-blocking-resources
+  (testing "a route with no blocking resources returns :settled? immediately, no pump"
+    (let [pumped (atom 0)
+          fid    (seed-frame-runtime-db! :ssr/drain-none
+                                         (runtime-db-with {ka (entry {:resource-id :a :status :loaded :data {:x 1}})}))
+          res    (ssr/drain-blocking-resources!
+                   fid {:pump! (fn [_] (swap! pumped inc)) :deadline-ms 1000})]
+      (is (true? (:settled? res)))
+      (is (= #{} (:timed-out res)))
+      (is (nil? (:route-blocking-failure res)))
+      (is (zero? @pumped) "no blocking set → the loop never pumps")
+      (frame/destroy-frame! fid))))
+
+(deftest drain-settles-when-blocking-entries-already-settled
+  (testing "blocking entries already settled → :settled? true, runtime-db untouched, no timeout"
+    (let [rdb (-> (runtime-db-with {ka (entry {:resource-id :a :status :loaded :data {:x 1}})
+                                    kb (entry {:resource-id :b :status :error})})
+                  (with-blocking-slot "nav-1" #{ka kb}))
+          fid (seed-frame-runtime-db! :ssr/drain-settled rdb)
+          res (ssr/drain-blocking-resources! fid {:pump! (fn [_] nil) :deadline-ms 1000})]
+      (is (true? (:settled? res)))
+      (is (nil? (:route-blocking-failure res)))
+      (is (= :loaded (get-in (frame/frame-runtime-db-value fid)
+                             [state/resources-key :entries ka :status]))
+          "the settled entry is untouched")
+      (frame/destroy-frame! fid))))
+
+(deftest drain-pumps-until-a-blocking-reply-lands
+  (testing "the loop pumps until an in-flight blocking entry settles; the pump
+            mutates the live frame so the loop observes the settle and does NOT time out"
+    (let [rdb (-> (runtime-db-with {ka (entry {:resource-id :a :status :loading :data nil})})
+                  (with-blocking-slot "nav-1" #{ka}))
+          fid (seed-frame-runtime-db! :ssr/drain-pump rdb)
+          ;; the pump simulates the async reply landing on the 2nd tick: it
+          ;; flips the blocking entry to :loaded in the live frame's runtime-db.
+          ticks (atom 0)
+          pump! (fn [_]
+                  (when (= 2 (swap! ticks inc))
+                    (frame/swap-runtime-db!
+                      fid assoc-in [state/resources-key :entries ka]
+                      (entry {:resource-id :a :status :loaded :data {:x 1}}))))
+          res   (ssr/drain-blocking-resources! fid {:pump! pump! :deadline-ms 60000})]
+      (is (true? (:settled? res)) "the loop settled once the reply landed")
+      (is (nil? (:route-blocking-failure res)) "no timeout — it settled in time")
+      (is (= {:x 1} (get-in (frame/frame-runtime-db-value fid)
+                            [state/resources-key :entries ka :data])))
+      (frame/destroy-frame! fid))))
+
+(deftest drain-times-out-a-never-settling-blocking-resource
+  (testing "ADVERSARIAL: a never-settling blocking resource is settled to a
+            structured first-load ERROR in the frame's runtime-db (not left a
+            hung :loading / skeleton) once the render deadline fires — the
+            acceptance criterion"
+    (let [rdb (-> (runtime-db-with {ka (entry {:resource-id :a :status :loading :data nil})})
+                  (with-blocking-slot "nav-1" #{ka}))
+          fid (seed-frame-runtime-db! :ssr/drain-timeout rdb)
+          ;; a deterministic clock that jumps past the deadline on the 1st
+          ;; re-check after start, so the test never actually sleeps; pump! is
+          ;; a no-op (the resource never settles).
+          clk (atom 0)
+          clock-fn (fn [] (let [v @clk] (swap! clk + 100) v))]
+      (let [res (ssr/drain-blocking-resources!
+                  fid {:pump! (fn [_] nil) :deadline-ms 50 :clock-fn clock-fn})]
+        (is (false? (:settled? res)) "the loop reported a timeout, not a settle")
+        (is (= #{ka} (:timed-out res)))
+        (let [se (get-in (frame/frame-runtime-db-value fid)
+                         [state/resources-key :entries ka])]
+          (is (= :error (:status se))
+              "the never-settling blocking entry is SETTLED to :error, not left :loading")
+          (is (= :rf.http/timeout (:kind (:error se))))
+          (is (= :ssr-blocking-timeout (:reason (:error se)))))
+        (is (= :rf.error/resource-ssr-blocking-timeout
+               (:rf.error/id (:route-blocking-failure res)))
+            "a route-blocking-failure record is produced for the renderer / route slice"))
+      (frame/destroy-frame! fid))))
+
+(deftest drain-times-out-with-nil-pump-sync-stub
+  (testing "a nil :pump! (a synchronous stub) still respects the deadline — a
+            blocking resource that never settles times out rather than looping forever"
+    (let [rdb (-> (runtime-db-with {ka (entry {:resource-id :a :status :loading :data nil})})
+                  (with-blocking-slot "nav-1" #{ka}))
+          fid (seed-frame-runtime-db! :ssr/drain-nilpump rdb)
+          clk (atom 0)
+          clock-fn (fn [] (let [v @clk] (swap! clk + 100) v))
+          res (ssr/drain-blocking-resources!
+                fid {:pump! nil :deadline-ms 50 :clock-fn clock-fn})]
+      (is (false? (:settled? res)))
+      (is (= :error (get-in (frame/frame-runtime-db-value fid)
+                            [state/resources-key :entries ka :status])))
+      (frame/destroy-frame! fid))))
+
+(deftest drain-hook-published
+  (testing "the :resources/drain-blocking-ssr! late-bind hook is published by the façade"
+    (is (some? (late-bind/get-fn :resources/drain-blocking-ssr!)))
+    (is (= ssr/drain-blocking-resources!
+           (late-bind/get-fn :resources/drain-blocking-ssr!)))))
 
 ;; ===========================================================================
 ;; 3. CLIENT hydration reconcile

--- a/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
@@ -32,6 +32,7 @@
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [clojure.string :as str]
    [re-frame.core :as rf]
    [re-frame.frame :as frame]
    [re-frame.late-bind :as late-bind]
@@ -122,6 +123,13 @@
     (is (= {} (ssr/project-resources-runtime-db {})))
     (is (= {} (ssr/project-resources-runtime-db (runtime-db-with {}))))))
 
+(defn- only-wire-entry
+  "The single projected wire entry `[wire-key wire-entry]` from a one-entry
+  projection (the projected key may be redacted, so callers can't look it up
+  by the raw key — rf2-otms75)."
+  [proj]
+  (first (get-in proj [state/resources-key :entries])))
+
 (deftest sensitive-resource-is-redacted
   (reg! :secret/thing {:sensitive? true})
   (testing "a :sensitive? resource ships METADATA ONLY — data redacted, refresh-error dropped"
@@ -130,12 +138,20 @@
                       :loaded-at 1000 :stale-at 9.0e15
                       :refresh-error {:kind :rf.http/http-5xx}})
           proj (ssr/project-resources-runtime-db (runtime-db-with {k e}))
-          we   (get-in proj [state/resources-key :entries k])]
+          [wk we] (only-wire-entry proj)]
       (is (not= {:ssn "123-45-6789"} (:data we))
           "the sensitive data must NOT ride verbatim")
       (is (nil? (:refresh-error we))
           "refresh-error is the same privacy class as data — dropped on a redacted entry")
-      (is (= :loaded (:status we)) "metadata (status / timestamps) still rides"))))
+      (is (= :loaded (:status we)) "metadata (status / timestamps) still rides")
+      (testing "rf2-otms75 — the scoped KEY's scope + params are redacted too"
+        (is (= :secret/thing (nth wk 1)) "the resource-id rides verbatim (position 1, never sensitive)")
+        (is (contains? (nth wk 0) :rf/redacted)
+            "the scope is redacted in the wire key (a redaction token, not the raw scope)")
+        (is (not= :rf.scope/global (nth wk 0)) "the raw scope does not ride in the key")
+        (is (map? (nth wk 2)) "the params component is a redaction token, not raw")
+        (is (contains? (nth wk 2) :rf/redacted) "the params are redacted in the wire key")
+        (is (not= {:slug "s"} (nth wk 2)) "the raw sensitive params do NOT ride in the key")))))
 
 (deftest large-resource-is-omitted
   (reg! :big/thing {:large? true})
@@ -144,9 +160,13 @@
           e   (entry {:resource-id :big/thing :data (vec (range 10000))
                       :loaded-at 1000 :stale-at 9.0e15})
           proj (ssr/project-resources-runtime-db (runtime-db-with {k e}))
-          we   (get-in proj [state/resources-key :entries k])]
+          [wk we] (only-wire-entry proj)]
       (is (not (contains? we :data)) "the large data key is omitted entirely")
-      (is (= :loaded (:status we))))))
+      (is (= :loaded (:status we)))
+      (testing "rf2-otms75 — the large resource's scope + params are redacted in the key"
+        (is (= :big/thing (nth wk 1)))
+        (is (contains? (nth wk 2) :rf/redacted) "the (large) params do not ride raw in the key")
+        (is (not= {:slug "b"} (nth wk 2)))))))
 
 (deftest projection-metadata-records-decisions
   (reg! :article/by-slug)
@@ -181,6 +201,76 @@
           "redacted → metadata-only refetch")
       (is (= :omitted    (:disposition (metas k-big))))
       (is (true?         (:refetch-on-client? (metas k-big)))))))
+
+;; ===========================================================================
+;; 1b. Scoped-KEY privacy: align key scope+params with classification (rf2-otms75)
+;; ===========================================================================
+;;
+;; A :sensitive? / :large? resource's scope + params must NOT ride RAW in the
+;; projected map KEY (Spec 016 clause 4: params, scopes, and data carry the
+;; same classification). They are projected to opaque content-addressed
+;; {:rf/redacted <digest>} tokens — distinct values stay distinct, the raw
+;; identity never rides, and the resource-id (position 1) is preserved.
+
+(deftest serialize-resource-key-rides-verbatim
+  (reg! :article/by-slug)
+  (testing "a non-sensitive, non-large resource's key rides VERBATIM (scope +
+            params are wire-safe, same class as its data)"
+    (let [k    (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "x"})
+          e    (entry {:resource-id :article/by-slug :data {:t "x"} :loaded-at 1000 :stale-at 9.0e15})
+          [wk _] (only-wire-entry (ssr/project-resources-runtime-db (runtime-db-with {k e})))]
+      (is (= k wk) "the serialized key is unchanged on the wire"))))
+
+(deftest sensitive-resource-key-scope-and-params-are-redacted
+  (reg! :secret/thing {:sensitive? true})
+  (testing "a :sensitive? resource's scope (user/tenant markers) + params are
+            redacted in the projected key — neither rides raw"
+    (let [scope [:rf.scope/session {:user "alice@example.com" :tenant "acme"}]
+          k    (state/scoped-resource-key scope :secret/thing {:account-id "secret-42"})
+          e    (entry {:resource-id :secret/thing :data {:ssn "x"} :loaded-at 1000 :stale-at 9.0e15})
+          [wk _] (only-wire-entry (ssr/project-resources-runtime-db (runtime-db-with {k e})))]
+      (is (= :secret/thing (nth wk 1)) "resource-id preserved")
+      (is (contains? (nth wk 0) :rf/redacted) "scope redacted")
+      (is (contains? (nth wk 2) :rf/redacted) "params redacted")
+      ;; the raw sensitive substrings must not appear anywhere in the wire key
+      (let [s (pr-str wk)]
+        (is (not (str/includes? s "alice@example.com")) "no raw user in the key")
+        (is (not (str/includes? s "acme")) "no raw tenant in the key")
+        (is (not (str/includes? s "secret-42")) "no raw param in the key")))))
+
+(deftest redacted-keys-stay-distinct-no-collision
+  (reg! :secret/thing {:sensitive? true})
+  (testing "ADVERSARIAL: two distinct sensitive entries (same scope+resource,
+            DIFFERENT params) project to DISTINCT wire keys — the redaction
+            never collapses them into one (no lost entry; rf2-otms75)"
+    (let [k1 (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "alpha"})
+          k2 (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "beta"})
+          e1 (entry {:resource-id :secret/thing :data {:s 1} :loaded-at 1000 :stale-at 9.0e15})
+          e2 (entry {:resource-id :secret/thing :data {:s 2} :loaded-at 1000 :stale-at 9.0e15})
+          proj (ssr/project-resources-runtime-db (runtime-db-with {k1 e1 k2 e2}))
+          wks  (set (keys (get-in proj [state/resources-key :entries])))]
+      (is (= 2 (count wks)) "two distinct entries → two distinct wire keys (no collision)")
+      (is (every? (fn [wk] (= :secret/thing (nth wk 1))) wks)
+          "both wire keys preserve the resource-id")
+      (is (every? (fn [wk] (and (contains? (nth wk 2) :rf/redacted)
+                                (not= {:slug "alpha"} (nth wk 2))
+                                (not= {:slug "beta"} (nth wk 2)))) wks)
+          "neither wire key carries the raw params"))))
+
+(deftest project-scoped-key-is-pure
+  (testing "project-scoped-key: :serialize rides verbatim; :redact/:omit redact
+            scope+params, preserve resource-id + distinctness"
+    (let [k1 (state/scoped-resource-key :rf.scope/global :r {:a 1})
+          k2 (state/scoped-resource-key :rf.scope/global :r {:a 2})]
+      (is (= k1 (ssr/project-scoped-key k1 :serialize)))
+      (let [r1 (ssr/project-scoped-key k1 :redact)
+            r2 (ssr/project-scoped-key k2 :redact)]
+        (is (= :r (nth r1 1)) "resource-id preserved")
+        (is (contains? (nth r1 2) :rf/redacted))
+        (is (not= r1 r2) "distinct params → distinct redacted keys")
+        (is (= r1 (ssr/project-scoped-key k1 :redact)) "deterministic (same input → same digest)")
+        (is (= (ssr/project-scoped-key k1 :redact) (ssr/project-scoped-key k1 :omit))
+            ":redact and :omit redact the key identically (both metadata-only)")))))
 
 ;; ===========================================================================
 ;; 2. SERVER blocking drain + timeout
@@ -534,18 +624,23 @@
           ;; a FRESH sensitive entry on the server (stale-at far ahead)
           e    (entry {:resource-id :secret/thing :data {:ssn "123-45-6789"}
                        :loaded-at 1000 :stale-at 9.0e15})
-          ;; SERVER projection redacts the data to the sentinel
+          ;; SERVER projection redacts the data to the sentinel AND the key
+          ;; (rf2-otms75) — look the wire entry up by the PROJECTED key.
           proj (ssr/project-resources-runtime-db (runtime-db-with {k e}))
-          we   (get-in proj [state/resources-key :entries k])]
+          [wk we] (only-wire-entry proj)]
       (is (= privacy/redacted-sentinel (:data we))
           "projection redacts the sensitive data to the sentinel")
+      (is (not= {:slug "s"} (nth wk 2)) "the sensitive params do not ride raw in the wire key (rf2-otms75)")
+      (is (= :secret/thing (nth wk 1)) "the resource-id is preserved for refetch identity")
       ;; CLIENT hydration over the projected slice (a coherent runtime-db)
-      (let [installed {state/resources-key {:entries {k we}}}
+      (let [installed {state/resources-key {:entries {wk we}}}
             plan      (->> (ssr/hydrate-refetch-plan installed 5000)
                            (into {} (map (juxt :resource-key identity))))]
-        (is (contains? plan k)
+        (is (contains? plan wk)
             "the redacted (fresh-on-server) entry IS in the refetch plan — the sentinel is not usable data")
-        (is (= :metadata-only (:reason (plan k))))))))
+        (is (= :metadata-only (:reason (plan wk))))
+        (is (= :secret/thing (:resource-id (plan wk)))
+            "the refetch plan still names the resource-id from the (redacted) key — enough to reconcile/refetch")))))
 
 ;; ===========================================================================
 ;; 5. SCOPE isolation

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -301,6 +301,16 @@
    {:keys [root-view emit-hash? version schema-digest payload
            html-shell content-type]
     :as   opts}]
+  ;; rf2-er7qx2 — SSR blocking-resource drain. AFTER the `:on-create` drain
+  ;; (which resolved the route + enqueued the route's blocking resource
+  ;; ensures) and BEFORE the render walk, drain the current nav-token's
+  ;; blocking resources until they settle or the render deadline fires. A
+  ;; never-settling blocking resource is settled to a structured first-load
+  ;; failure in the frame's runtime-db, so the render walk below sees a
+  ;; settled `:error` rather than an unchecked `:loading` / skeleton (Spec 016
+  ;; §SSR and hydration steps 3-4). A no-op when the resources artefact is
+  ;; absent (the `:resources/drain-blocking-ssr!` hook is nil).
+  (ssr/drain-blocking-resources! frame-id opts)
   (let [;; Single `with-frame` block covers the three frame-aware
         ;; stages: root-view resolution (a 0-arity fn may close over
         ;; subscribe-time reads), the render walk (subs on registered

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -207,6 +207,18 @@
   ;; emission of `:body-end` into the suffix is UNCHANGED — the scan is a
   ;; signal, never a block or rewrite.
   (shell/check-body-end-csp-hosts! body-end csp-script-src-allowlist)
+  ;; rf2-er7qx2 — SSR blocking-resource drain (streaming counterpart of the
+  ;; non-streaming `build-full-response*` drain). AFTER the `:on-create` drain
+  ;; resolved the route + enqueued the route's blocking resource ensures and
+  ;; BEFORE the shell render walk, drain the current nav-token's blocking
+  ;; resources until they settle or the render deadline fires; a never-settling
+  ;; blocking resource is settled to a first-load failure in the frame's
+  ;; runtime-db so the shell render sees a settled `:error`, never a hung
+  ;; `:loading` / skeleton (Spec 016 §SSR and hydration steps 3-4). A no-op
+  ;; when the resources artefact is absent. The streaming SUSPENSE-boundary
+  ;; deferral is a separate axis — blocking ROUTE resources still settle before
+  ;; the shell, exactly as in the non-streaming path.
+  (ssr/drain-blocking-resources! frame-id opts)
   (rf/with-frame frame-id
     (let [hiccup     (lifecycle/resolve-root-view root-view)
           head-bag   (if (:head opts)

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -177,6 +177,89 @@
 ;; pages skip it.
 #?(:cljs (def streaming-install!    streaming-client/install!))
 
+;; ---- SSR blocking-resource drain (Spec 016 §SSR and hydration steps 3-4) --
+;;
+;; rf2-er7qx2 — the resources artefact (optional) defines SSR blocking
+;; resources as SETTLED before render or TIMED OUT into a settled first-load
+;; failure. The drain LOOP + timeout POLICY live in the resources artefact
+;; (`re-frame.resources.ssr/drain-blocking-resources!`, published as the
+;; `:resources/drain-blocking-ssr!` late-bind hook); the SSR render path (Ring
+;; / streaming host adapters) consults it BEFORE rendering so the render walk
+;; never sees a hung `:loading` / skeleton an in-flight (or never-settling)
+;; blocking resource would otherwise leave. Late-bound BOTH ways — an SSR app
+;; without resources carries none of this code path (the hook is nil → no-op);
+;; a resources app that never SSRs never reaches it.
+
+(def ^:private default-ssr-blocking-timeout-ms
+  "Default wall-clock render-deadline budget for the SSR blocking-resource
+  drain (`drain-blocking-resources!`) when the host passes no
+  `:ssr-blocking-timeout-ms`. A bounded budget is structurally required — an
+  unbounded drain lets a never-settling blocking resource hang the request
+  (Spec 016 §SSR and hydration: a blocked SSR render MUST NOT hang
+  indefinitely). 5s matches a typical upstream HTTP read timeout; hosts tune
+  it per deployment."
+  5000)
+
+(defn default-blocking-pump!
+  "The default SSR blocking-drain event PUMP — a host-platform yield of
+  `tick-ms` so an in-flight blocking-resource reply (running on the managed-
+  HTTP transport thread) makes progress and dispatches its reply event
+  between the drain loop's re-checks. SSR runs on the JVM, so the yield is a
+  `Thread/sleep`; on CLJS (which never server-renders) it is a no-op. The
+  reply event itself drains synchronously when it lands on the frame's router,
+  so a single bounded yield per tick is enough; the drain loop's wall-clock
+  deadline caps the total wait (Spec 016 §SSR and hydration steps 3-4)."
+  [tick-ms]
+  #?(:clj  (when (and (number? tick-ms) (pos? tick-ms))
+             (Thread/sleep (long tick-ms)))
+     :cljs nil)
+  nil)
+
+(defn drain-blocking-resources!
+  "Drain the current nav-token's BLOCKING resources for SSR `frame-id` until
+  they settle or the render deadline fires, consulting the late-bound
+  `:resources/drain-blocking-ssr!` hook the resources artefact publishes
+  (Spec 016 §SSR and hydration steps 3-4). A no-op returning `{:settled? true}`
+  when the resources artefact is absent (the hook is nil) — an SSR app without
+  resources never blocks on them.
+
+  The host render path (the Ring `build-full-response*` / streaming
+  `render-streaming-shell!`) calls this AFTER frame setup + route resolution
+  and BEFORE the render walk, so the walk sees a SETTLED resource state. The
+  resources drain loop reads the live blocking set, pumps the event loop via
+  the supplied `:pump!` thunk so an in-flight reply lands, and on deadline
+  settles every still-unsettled blocking entry to a first-load failure in the
+  frame's runtime-db (so the render sees a structured `:error`, never a hung
+  `:loading`).
+
+  `opts` keys (all optional):
+    :ssr-blocking-timeout-ms — the wall-clock budget (default
+                               `default-ssr-blocking-timeout-ms`).
+    :pump!                   — the 1-arity `(fn [tick-ms] …)` event-pump
+                               thunk. Defaults to the host platform yield
+                               (`default-blocking-pump!`) so an async
+                               blocking reply thread makes progress between
+                               re-checks; a test may inject a deterministic
+                               pump (or nil to drive a sync stub to timeout).
+    :tick-ms                 — poll-granularity hint passed to `pump!`
+                               (default 5ms).
+
+  Returns the drain result map `{:settled? :timed-out :route-blocking-failure}`
+  (see `re-frame.resources.ssr/drain-blocking-resources!`)."
+  ([frame-id] (drain-blocking-resources! frame-id nil))
+  ([frame-id {:keys [ssr-blocking-timeout-ms tick-ms] :as opts}]
+   (if-let [drain (late-bind/get-fn :resources/drain-blocking-ssr!)]
+     (drain frame-id
+            {:deadline-ms (or ssr-blocking-timeout-ms default-ssr-blocking-timeout-ms)
+             ;; an EXPLICIT `:pump!` (even nil — a sync test stub that drives a
+             ;; never-settling resource straight to the deadline) wins; absence
+             ;; defaults to the host-platform yield so an async reply lands.
+             :pump!       (if (contains? opts :pump!)
+                            (:pump! opts)
+                            default-blocking-pump!)
+             :tick-ms     (or tick-ms 5)})
+     {:settled? true :timed-out #{} :route-blocking-failure nil})))
+
 ;; ---- :rf/hydrate event + :rf.ssr/check-* fxs ------------------------------
 ;;
 ;; Spec 011 §The :rf/hydrate event + §Hydration-mismatch detection +

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -200,7 +200,7 @@
   it per deployment."
   5000)
 
-(defn default-blocking-pump!
+(defn- default-blocking-pump!
   "The default SSR blocking-drain event PUMP — a host-platform yield of
   `tick-ms` so an in-flight blocking-resource reply (running on the managed-
   HTTP transport thread) makes progress and dispatches its reply event

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -702,6 +702,7 @@
   ["re-frame.ssr" "public-error-keys"]             {:tier :internal-public :owner "011" :status "v1"}
   ["re-frame.ssr" "fallback-public-error"]         {:tier :internal-public :owner "011" :status "v1"}
   ["re-frame.ssr" "on-frame-destroyed!"]           {:tier :internal-public :owner "011" :status "v1"}
+  ["re-frame.ssr" "drain-blocking-resources!"]     {:tier :internal-public :owner "011" :status "v1"}
   ["re-frame.ssr" "streaming-fallback-template"]   {:tier :internal-public :owner "011" :status "v1"}
   ["re-frame.ssr" "streaming-resolved-template"]   {:tier :internal-public :owner "011" :status "v1"}
   ["re-frame.ssr" "streaming-failed-template"]     {:tier :internal-public :owner "011" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 503,
+ :var-count 504,
  :tier-vocab
  [:front-porch
   :advanced
@@ -344,6 +344,7 @@
   {:namespace "re-frame.ssr", :var "clear-request!", :tier :internal-public, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "default-error-projector-fn", :tier :internal-public, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "default-response", :tier :internal-public, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.ssr", :var "drain-blocking-resources!", :tier :internal-public, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "fallback-public-error", :tier :internal-public, :kind :var, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "flush-response!", :tier :internal-public, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.ssr", :var "get-request", :tier :internal-public, :kind :fn, :owner "011", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Resolves 6 `[resources]` beads on the **SSR + epoch-restore** surface, one cluster → one PR. Each bead's commit is self-contained.

## Beads (P1s first)

- **rf2-er7qx2** (P1) — wire SSR blocking-resource drain + timeout into Ring AND streaming render paths. New `re-frame.resources.ssr/drain-blocking-resources!` fuses the existing `blocking-settled?` predicate + `settle-blocking-timeout` policy into a LOOP that reads the current nav-token's blocking set, pumps the host event loop until settled, and on the render deadline settles every still-unsettled blocking entry to a structured first-load `:error` in the frame's runtime-db. Published as `:resources/drain-blocking-ssr!`; `re-frame.ssr/drain-blocking-resources!` consults it (no-op when resources absent) with a default JVM `Thread/sleep` pump. Ring `build-full-response*` + streaming `render-streaming-shell!` call it after route resolution, before render — a never-settling blocking resource renders a settled timeout error, not a skeleton.
- **rf2-fopuj9** (P1) — treat the redaction sentinel as metadata-only on hydration + wire the refetch plan. New `hydrated-data-usable?` excludes `:rf/redacted`; `entry-needs-refetch?` + `hydrate-refetch-plan` route through it so a redacted entry is metadata-only (refetched), not misclassified as fresh-with-data. `hydrate-runtime-db` now computes the refetch plan on the `:rf/hydrate` install path (emitting per-entry `:rf.resource/hydrate-refetch` decision rows).
- **rf2-o3d1uf** (P1) — reconcile pending MUTATION instances on epoch restore. New `mutation-runtime/instance-dangled` terminally settles a `:pending`/`:idle` instance to `:error`/`:dangling-on-restore` and CLEARS `:current-work`; `reconcile-on-restore` now reconciles `:rf.runtime/mutations` (`dangle-pending-mutations!`). The mutation reply gate checks the INSTANCE's `:current-work`+`:generation` (not the resource entry's), so without this a late pre-restore mutation reply could still patch/populate/invalidate post-restore state.
- **rf2-64bdnk** (P2) — orphan route owners on restore when no live nav-token. Split the hydration `:ride-through` policy from the restore `{:restore-live-nav-token <t>}` policy: on restore a nil/absent routing `:current` nav-token means NO route owner is live → all route owners orphan (Spec 016 part 4); hydration still rides route owners through.
- **rf2-nd1r9q** (P2) — clear resource HOST transients during epoch restore. New `clear-host-transients-on-restore!` cancels the frame's stale/GC timer handles + work-ledger host handles; `reconcile-on-restore` invokes it. Deliberately does NOT rewind the generation high-water mark (part 1) or re-bind the revalidation listeners (frame-lifecycle-scoped). No eager refetch.
- **rf2-otms75** (P2) — align projected resource keys with scope+params privacy. New `project-scoped-key`: a `:redact`/`:omit` resource's scope + params are projected to opaque content-addressed `{:rf/redacted <digest>}` tokens (self-contained FNV-1a) so the raw identity never rides the wire, while the resource-id + key distinctness are preserved. Refetch is route-driven, so the one-way digest loses nothing.

## Shared-file edits (for merge-ordering)

- `implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj` (+10) and `.../streaming.clj` (+12) — one `ssr/drain-blocking-resources!` call each, before the render walk (er7qx2). NOT hot-zone files. No edits to `route.cljc` or `events.cljc` core handlers (drain reads the routing blocking-slot via mirrored literals, as `route.cljc` itself does).
- `implementation/ssr/src/re_frame/ssr.cljc` (+83) — the late-bound drain-consult helper + default pump.
- `spec/016-Resources.md` — UNCHANGED (otms75 realizes the existing clause-4 intent; no amendment warranted).

## Quality gates

All from the worktree:

| Gate | Command | Result |
|---|---|---|
| resources JVM (parity) | `cd implementation/resources && clojure -M:test` | **170 tests, 607 assertions, 0 failures 0 errors** |
| epoch JVM (consumes reconcile-on-restore) | `cd implementation/epoch && clojure -M:test` | **309 tests, 1228 assertions, 0/0** |
| ssr JVM | `cd implementation/ssr && clojure -M:test` | **331 tests, 1309 assertions, 0/0** |
| ssr-ring JVM | `cd implementation/ssr-ring && clojure -M:test` | **150 tests, 676 assertions, 0/0** |
| CLJS node integration | `cd implementation && npm run test:cljs` | **6338 tests, 22777 assertions, 0/0** |
| fast PR spine | `scripts/test-fast-pr.sh` | PASS (lockstep, skill-drift, cite-integrity, order-guards, eval-docs, core JVM, JS harness, CLJS). The README-inventory ratchet flags local `node_modules`/`out` — gitignored build artifacts from `npm install`, a known local-only false positive, not a code change. |
| Public-API manifest drift-check | `cd implementation/scripts/api-manifest && clojure -M -m re-frame.api-manifest.gen --check` | **OK: spec/api-manifest.edn in sync (504 public vars), exit 0** |
| JVM core late-bind drift | `cd implementation/core && clojure -M:test -n re-frame.late-bind-drift-test` | **6 tests, 569 assertions, 0/0** |

### CI follow-up (API governance + late-bind directory)

The first CI run was red on three gates because the er7qx2 SSR blocking-drain work added new public surface without the required sidecar classification + directory registration. Fixed on this branch:

- **`re-frame.ssr/drain-blocking-resources!`** — the genuine public SSR integration seam (Ring + streaming host adapters call it before the render walk). **Classified** in `spec/api-manifest-metadata.edn` as `:tier :internal-public :owner "011" :status "v1"`, matching its sibling `re-frame.ssr` render-path / streaming-template fns (host territory).
- **`re-frame.ssr/default-blocking-pump!`** — referenced **only** inside `re-frame.ssr` (the default `:pump!` arg of `drain-blocking-resources!`; confirmed by a tree-wide `git grep`). **Privatized** (`defn-`) rather than expose an internal default — minimal public surface is the masterpiece fix.
- **`:resources/drain-blocking-ssr!`** — the new late-bind hook key was published via `set-fns!` but had no `re-frame.late-bind.directory/hooks` entry (orphaned → `JVM core` `late-bind-drift-test` red). **Registered** alongside its three sibling SSR/restore hooks (producer `re-frame.resources.ssr`).
- `spec/api-manifest.edn` regenerated (504 public vars). The `Lint required` aggregator goes green automatically once the manifest drift-check (one of its `needs`) passes.

Each bead adds ≥1 adversarial/negative case: never-settling blocking resource → settled timeout error; fresh redacted entry still refetches; late pre-restore mutation reply suppressed end-to-end; restore with no nav-token orphans route owners across all three absent-token shapes; armed timers/handles gone after restore with generation preserved; distinct sensitive params → distinct (non-colliding) redacted wire keys.

A cross-platform defect was caught by the CLJS gate and fixed: `route-owner-orphan?` used `identical?` on the `:ride-through` keyword (JVM-interned but not CLJS-guaranteed) — switched to value `=`.

## Risks / deferred

- The drain `pump!` default is a JVM `Thread/sleep` yield; a host with a bespoke async-HTTP pump can inject its own via the (host-passed) `:pump!`. Synchronous test stubs and never-settling resources are both covered.
- `spec/016-Resources.md` left to the spec-coherence wave; no spec change is needed for these fixes (otms75 realizes existing clause-4 text).

