### PR TITLE
fix(xray): resource accessor metadata + canonical scope lint + route-resource graph (xray-resources cluster)

### DIFF
--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -478,7 +478,9 @@ registers NO `:rf.resource/*` event (observing pins no resource, Spec 016
 | `:rf.xray/resource-work-ledger-override` | Test override slot. |
 | `:rf.xray/resource-sub-reads` | Observed live subscription reads (`[{:resource-id :params :scope} …]`) backing the scope-mismatch lint. Empty by default. Test override. |
 | `:rf.xray/resource-sub-reads-override` | Test override slot. |
-| `:rf.xray/resources-tab-data` | View-facing composite — `{:silent? :registry :instances :work :route-graph :timeline :invalidations :cache-growth :audit}` over the registry + entries + ledger + route registry + trace buffer. PRIVACY: every param/scope/data/cause/outcome value is summarized (never raw). |
+| `:rf.xray/resource-routing-slice` | The live routing-runtime subtree at `[:rf.runtime/routing]` (current route + nav-token + per-nav-token unsettled-blocking set) backing the live route/resource graph. Test override. |
+| `:rf.xray/resource-routing-slice-override` | Test override slot. |
+| `:rf.xray/resources-tab-data` | View-facing composite — `{:silent? :registry :instances :work :route-graph :timeline :invalidations :cache-growth :audit}` over the registry + entries + ledger + route registry + trace buffer + routing slice. The `:route-graph` joins the static route plan against the live instance/work rows + routing slice (per-resource freshness rollup; the active route flagged `:current?`). PRIVACY: every param/scope/data/cause/outcome value is summarized (never raw). |
 
 ### Events
 
@@ -488,6 +490,7 @@ registers NO `:rf.resource/*` event (observing pins no resource, Spec 016
 | `:rf.xray/set-resource-entries-override-for-test` | `[_ ov]` | Test-only override hook. `nil` clears. |
 | `:rf.xray/set-resource-work-ledger-override-for-test` | `[_ ov]` | Test-only override hook. `nil` clears. |
 | `:rf.xray/set-resource-sub-reads-override-for-test` | `[_ ov]` | Test-only override hook. `nil` clears. |
+| `:rf.xray/set-resource-routing-slice-override-for-test` | `[_ ov]` | Test-only override hook. `nil` clears. |
 
 ### Tool accessors (the AI / MCP read API)
 

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -79,13 +79,31 @@ Two elision layers compose:
    `:sensitive?` / `:large?` slots via `elide-wire-value`) keeps its
    sentinel status and renders `[redacted]` / `[large — elided]` with no
    raw preview.
-2. **Off-box egress** (the tool accessors). The raw runtime-db values an
-   accessor surfaces route through the framework `egress-runtime-db-value`
-   / `egress-value` walker on top of the summaries. The resource cache is
-   runtime-db state, so the off-box default REDACTS the partition (Spec
-   011 §Off-box redaction, ruling #14); a trusted-local caller opts in
-   with `:include-runtime-db? true`, and even then per-slot `:sensitive?`
-   / `:large?` declarations still elide.
+2. **Off-box egress** (the tool accessors). Per-slot, NOT per-entry. A
+   resource cache entry mixes **payload-bearing** slots (`:data` /
+   `:error` / `:refresh-error`, and the key's scope/params — the only
+   slots that can carry PII or a large blob) with **metadata** slots
+   (`:status`, `:generation`, `:attempt`, `:request-id`, `:current-work`,
+   `:active-owners`, `:tags`, `:loaded-at` / `:stale-at` /
+   `:invalidated-at`) — non-PII runtime bookkeeping. The accessors project
+   the **metadata BEFORE egress redaction** and route **only the payload
+   values** through the framework `egress-runtime-db-value` walker (the
+   resource cache is runtime-db state, so the off-box default REDACTS those
+   payload values per Spec 011 §Off-box redaction, ruling #14; a
+   trusted-local caller opts in with `:include-runtime-db? true`, and even
+   then per-slot `:sensitive?` / `:large?` declarations still elide, and a
+   value already redacted/elided upstream keeps its sentinel). **A redacted
+   summary therefore STILL exposes the metadata** (the EP-0003 tool
+   contract; Spec 016 §Xray, "Xray sees redacted summaries, not raw
+   values"): the `:status` / `:tag` / `:owner` / `:request-id` filters
+   (which filter the projected rows) work on the default path **without**
+   `:include-runtime-db?`, and the rows are useful even when the payload is
+   redacted. The **raw scoped key is the row identity** (never egressed in
+   place) so two entries whose scope/params redact to the same sentinel
+   cannot collapse into one. `get-resource-state` requires the **full**
+   scoped key (`:resource-id` + `:scope` + `:params`); any missing part
+   fails closed with `:reason :missing-key` (a partial key cannot address
+   an entry).
 
 Resource **history is bounded** (the accessor `:limit`, default 50).
 

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -159,8 +159,12 @@ stacked sections:
    for the old `/me` heuristic), the **suspicious-explicit-global**
    warnings (defense-in-depth: an explicit-global resource whose id/doc
    looks session-dependent), the **scope-mismatch lint** (an entry under
-   scope A while a live sub reads the same R+P under a different scope B),
-   and the **orphaned-owner lint** (an app-minted `[:lease …]` owner
+   scope A while a live sub reads the same R+P under a different scope B —
+   matched on the **canonical** `[resource-id params]` + `scope` identities
+   read off each row's raw `:scoped-key`, NOT the truncated/redacted display
+   previews, so long-or-colliding params and distinct redacted scopes
+   cannot false-trip or be missed; the surfaced output is summarized for
+   privacy), and the **orphaned-owner lint** (an app-minted `[:lease …]` owner
    pinning an entry with no observed release; route / machine / ssr
    owners are framework-released and not linted).
 

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -142,7 +142,16 @@ stacked sections:
    non-blocking** split (blocking = **SSR wait point**), keep-previous
    flags, and any `:after` dependency waterfall. Resolvers
    (`:params` / `:scope` fns) are recorded as declared without being
-   invoked.
+   invoked. The graph is **live, not just static** (rf2-m5u3gt): it joins
+   the static route plan against the live instance rows, work ledger, and
+   routing slice — each resource node carries a `:live` freshness rollup
+   (`:fresh` / `:stale` / `:loading` / `:idle` / `:none`, plus the active
+   work count) over its cache entries, and the **currently-active route** is
+   flagged `:current?` with its live `:nav-token` and `:blocking-live` (the
+   declared blocking resources whose scoped keys are still in the
+   per-nav-token unsettled-blocking set — the SSR/route wait points that
+   have not yet settled). The bare static projection (no live inputs)
+   remains available for the SSR/JVM path.
 5. **Lifecycle timeline** — the ordered `:rf.resource/*` trace rows
    (oldest-first), each carrying op label + semantic class colour,
    resource id, summarized resource key, generation, owner, summarized
@@ -253,14 +262,16 @@ No event registered here dispatches a `:rf.resource/*` event (read-only).
 | `:rf.xray/resource-entries` | `:rf.xray/target-frame-runtime-db`, override | the live cache entries map at `[:rf.runtime/resources :entries]`. |
 | `:rf.xray/resource-work-ledger` | `:rf.xray/target-frame-runtime-db`, override | the live work-ledger map at `[:rf.runtime/work-ledger]`. |
 | `:rf.xray/resource-sub-reads` | override | observed live subscription reads backing the scope-mismatch lint (empty by default). |
-| `:rf.xray/resources-tab-data` | the four above + `:rf.xray/trace-buffer` + the route registry | the view-facing composite: `{:silent? :registry :instances :work :route-graph :timeline :invalidations :cache-growth :audit}`. |
+| `:rf.xray/resource-routing-slice` | `:rf.xray/target-frame-runtime-db`, override | the live routing-runtime subtree at `[:rf.runtime/routing]` (current route + nav-token + per-nav-token unsettled-blocking set) backing the live route/resource graph. |
+| `:rf.xray/resources-tab-data` | the five above + `:rf.xray/trace-buffer` + the route registry | the view-facing composite: `{:silent? :registry :instances :work :route-graph :timeline :invalidations :cache-growth :audit}`. Its `:route-graph` joins the static route plan against the live instance/work rows + routing slice. |
 
 ### Events (test-only override hooks)
 
 `:rf.xray/set-registered-resources-override-for-test`,
 `:rf.xray/set-resource-entries-override-for-test`,
 `:rf.xray/set-resource-work-ledger-override-for-test`,
-`:rf.xray/set-resource-sub-reads-override-for-test` — production code
+`:rf.xray/set-resource-sub-reads-override-for-test`,
+`:rf.xray/set-resource-routing-slice-override-for-test` — production code
 paths MUST NOT dispatch these; `nil` clears the override.
 
 ## Mountable surface

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -288,6 +288,15 @@
 
 ;; ---- §4 ROUTE / RESOURCE GRAPH -----------------------------------------
 
+(defn- freshness-colour [freshness]
+  ;; rf2-m5u3gt — the per-resource live freshness chip colour.
+  (case freshness
+    :fresh   (:success tokens)
+    :stale   (:warning tokens)
+    :loading mode-accent
+    :error   (:error tokens)
+    (:text-tertiary tokens)))   ; :idle / :none / unknown
+
 (defn- route-graph-row-view [node]
   (let [testid (str "rf-xray-resources-route-row-"
                     (when (:route-id node) (-> node :route-id str (subs 1))))]
@@ -300,9 +309,19 @@
        (str (:route-id node))]
       (when (:path node)
         [:span {:style {:color (:text-tertiary tokens)}} (:path node)])
+      ;; rf2-m5u3gt — the LIVE active-route badge.
+      (when (:current? node)
+        [:span {:data-testid (str testid "-current")
+                :style {:color (:success tokens) :font-weight 600}}
+         "● active"])
       (when (:ssr-wait? node)
         [:span {:data-testid (str testid "-ssr-wait")
-                :style {:color (:warning tokens)}} "SSR wait point"])]
+                :style {:color (:warning tokens)}} "SSR wait point"])
+      ;; rf2-m5u3gt — the live unsettled blocking wait points on the active route.
+      (when (seq (:blocking-live node))
+        [:span {:data-testid (str testid "-blocking-live")
+                :style {:color (:warning tokens)}}
+         (str "waiting: " (str/join "," (map str (:blocking-live node))))])]
      (into [:div {:style {:display "flex" :flex-wrap "wrap" :gap "8px"
                           :padding-left "12px" :font-family mono-stack
                           :font-size "11px"}}]
@@ -314,7 +333,15 @@
               (str (:resource res))
               (if (:blocking? res) " [blocking]" " [non-blocking]")
               (when (:keep-previous? res) " keep-prev")
-              (when (seq (:after res)) (str " after " (str/join "," (map str (:after res)))))]))]))
+              (when (seq (:after res)) (str " after " (str/join "," (map str (:after res)))))
+              ;; rf2-m5u3gt — the per-resource live freshness chip.
+              (when-let [live (:live res)]
+                (when (not= :none (:freshness live))
+                  [:span {:style {:color (freshness-colour (:freshness live))
+                                  :margin-left "4px"}}
+                   (str "· " (name (:freshness live))
+                        (when (pos? (:active-work live))
+                          (str " (" (:active-work live) " work)")))]))]))]))
 
 (defn- route-graph-section [nodes]
   (section
@@ -535,9 +562,16 @@
       (`[{:resource-id :params :scope} …]`) backing the scope-mismatch
       lint. Empty by default; the host/runtime populates it (test
       override slot).
+    - `:rf.xray/resource-routing-slice` — the live routing-runtime subtree
+      (`[:rf.runtime/routing]`) from `:rf.xray/target-frame-runtime-db`,
+      backing the LIVE route/resource graph (current route + nav-token +
+      unsettled-blocking set — rf2-m5u3gt). Test override.
     - `:rf.xray/resources-tab-data` — the view-facing composite over the
-      registry + entries + ledger + route registry + trace buffer; the
-      single read the Panel subscribes.
+      registry + entries + ledger + route registry + trace buffer + routing
+      slice; the single read the Panel subscribes. Its `:route-graph` joins
+      the static route plan against the live instance/work rows + routing
+      slice (per-resource freshness rollup, the active route flagged
+      `:current?` with its live `:blocking-live` wait points).
 
   Read-only: NO event registered here dispatches a `:rf.resource/*`
   event — inspection never becomes an owner (Spec 016)."
@@ -573,6 +607,13 @@
   (rf/reg-sub :rf.xray/resource-sub-reads-override
     (fn [db _] (get db :resource-sub-reads-override)))
 
+  (rf/reg-event-db :rf.xray/set-resource-routing-slice-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov) (dissoc db :resource-routing-slice-override)
+          (assoc db :resource-routing-slice-override ov))))
+  (rf/reg-sub :rf.xray/resource-routing-slice-override
+    (fn [db _] (get db :resource-routing-slice-override)))
+
   ;; Production data subs --------------------------------------------------
 
   (rf/reg-sub :rf.xray/registered-resources
@@ -603,6 +644,20 @@
     :<- [:rf.xray/resource-sub-reads-override]
     (fn [override _] (or override [])))
 
+  ;; The routing-runtime slice backing the LIVE route/resource graph
+  ;; (rf2-m5u3gt). Reads `[:rf.runtime/routing]` off the target frame's
+  ;; runtime-db (decoupled, like the Routing tab's current-route sub) and
+  ;; surfaces the live `:current` route slice (carrying `:id` + `:nav-token`)
+  ;; + the per-nav-token unsettled-blocking set. Test override slot.
+  (rf/reg-sub :rf.xray/resource-routing-slice
+    :<- [:rf.xray/target-frame-runtime-db]
+    :<- [:rf.xray/resource-routing-slice-override]
+    (fn [[target-runtime-db override] _]
+      (cond
+        (some? override)         override
+        (map? target-runtime-db) (get target-runtime-db h/routing-key)
+        :else                    nil)))
+
   ;; View-facing composite -------------------------------------------------
 
   (rf/reg-sub :rf.xray/resources-tab-data
@@ -611,7 +666,8 @@
     :<- [:rf.xray/resource-work-ledger]
     :<- [:rf.xray/trace-buffer]
     :<- [:rf.xray/resource-sub-reads]
-    (fn [[registrations entries ledger trace-buffer sub-reads] _]
+    :<- [:rf.xray/resource-routing-slice]
+    (fn [[registrations entries ledger trace-buffer sub-reads routing-slice] _]
       (let [now-ms        (.now js/Date)
             routes-map    (rf/registrations :route)
             registry-rows (h/project-registry registrations routes-map)
@@ -621,7 +677,12 @@
          :registry      registry-rows
          :instances     instance-rows
          :work          work-rows
-         :route-graph   (h/project-route-graph routes-map)
+         :route-graph   (h/project-route-graph
+                          routes-map
+                          {:instance-rows instance-rows
+                           :work-rows     work-rows
+                           :current       (h/routing-current routing-slice)
+                           :blocking-keys (h/routing-blocking-keys routing-slice)})
          :timeline      (h/lifecycle-timeline trace-buffer)
          :invalidations (h/invalidation-graph trace-buffer)
          :cache-growth  (h/cache-growth instance-rows work-rows)

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -403,12 +403,22 @@
   [entry]
   (empty? (:active-owners entry)))
 
+(defn- entry-has-data?
+  "Derived `:has-data?` (Spec 016 §Status semantics — derived, not stored):
+  the entry currently carries usable last-known-good `:data`. A `nil`
+  `:data` is no-data; a value already redacted/elided UPSTREAM (`:rf/redacted`
+  / `:rf.size/large-elided`) means data WAS present (the sentinel replaced a
+  real value), so it counts as has-data (rf2-tgm1xu — the egress redaction
+  of a payload must not flip the derived `:has-data?` fact)."
+  [data]
+  (some? data))
+
 (defn instance-row
   "Project ONE live cache entry `[scoped-key entry]` into a render-safe
   instance-table row (Spec 016 §Xray and AI tooling — the live
   resource-instance table). PRIVACY: scope + params + data summarized.
 
-      {:scoped-key      <opaque-id-for-react-key>
+      {:scoped-key      <opaque-id-for-react-key>   ; the RAW key (identity)
        :scope           <summary>     ; PII — summarized
        :resource-id     :article/by-slug
        :params          <summary>     ; identity — summarized
@@ -426,41 +436,67 @@
        :active-owners   [<owner> …]   ; owners are tokens, not PII
        :owner-count     1
        :tags            [<tag> …]
-       :gc-eligible?    false}"
-  [[scoped-key entry] now-ms]
-  (let [{:keys [scope resource-id params]} (scoped-key-summary scoped-key)]
-    {:scoped-key     scoped-key
-     :scope          scope
-     :resource-id    (or resource-id (:resource/id entry))
-     :params         params
-     :status         (:status entry)
-     :stale?         (derive-stale? entry now-ms)
-     :has-data?      (some? (:data entry))
-     :data           (summarize (:data entry))
-     :error          (when (:error entry) (summarize (:error entry)))
-     :refresh-error  (when (:refresh-error entry) (summarize (:refresh-error entry)))
-     :loaded-at      (:loaded-at entry)
-     :stale-at       (:stale-at entry)
-     :invalidated-at (:invalidated-at entry)
-     :generation     (:generation entry)
-     :attempt        (:attempt entry)
-     :request-id     (:request-id entry)
-     :current-work   (:current-work entry)
-     :active-owners  (vec (:active-owners entry))
-     :owner-count    (count (:active-owners entry))
-     :tags           (vec (:tags entry))
-     :gc-eligible?   (gc-eligible? entry)}))
+       :gc-eligible?    false}
+
+  Optional `egress-fn` (rf2-tgm1xu): `(fn [value slot-key] -> egressed)`
+  applied to the PAYLOAD-bearing values (the key's scope/params + the
+  entry's `:data`/`:error`/`:refresh-error`) BEFORE `summarize`, so a
+  `:sensitive?` slot summarizes as `[redacted]` and a `:large?` slot as
+  `[large — elided]` on the off-box path. The METADATA (status, owners,
+  tags, request-id, generation, timestamps) is projected from the raw entry
+  and NEVER routed through egress — a redacted summary STILL exposes the
+  metadata. The RAW `scoped-key` is kept verbatim as `:scoped-key` (the
+  identity / react key), so per-row egress can never collapse two entries
+  whose scope/params redact to the same sentinel. A `nil` slot is left as
+  nil (nothing to redact) so the derived `:has-data?` fact survives."
+  ([entry+key now-ms] (instance-row entry+key now-ms nil))
+  ([[scoped-key entry] now-ms egress-fn]
+   (let [egress       (or egress-fn (fn [v _slot] v))
+         eg           (fn [v slot] (when (some? v) (egress v slot)))
+         [raw-scope raw-rid raw-params]
+                      (if (and (vector? scoped-key) (= 3 (count scoped-key)))
+                        scoped-key
+                        [scoped-key nil nil])
+         raw-data     (:data entry)]
+     {:scoped-key     scoped-key
+      :scope          (summarize (eg raw-scope :scope))
+      :resource-id    (or raw-rid (:resource/id entry))
+      :params         (summarize (eg raw-params :params))
+      :status         (:status entry)
+      :stale?         (derive-stale? entry now-ms)
+      :has-data?      (entry-has-data? raw-data)
+      :data           (summarize (eg raw-data :data))
+      :error          (when (:error entry) (summarize (eg (:error entry) :error)))
+      :refresh-error  (when (:refresh-error entry) (summarize (eg (:refresh-error entry) :refresh-error)))
+      :loaded-at      (:loaded-at entry)
+      :stale-at       (:stale-at entry)
+      :invalidated-at (:invalidated-at entry)
+      :generation     (:generation entry)
+      :attempt        (:attempt entry)
+      :request-id     (:request-id entry)
+      :current-work   (:current-work entry)
+      :active-owners  (vec (:active-owners entry))
+      :owner-count    (count (:active-owners entry))
+      :tags           (vec (:tags entry))
+      :gc-eligible?   (gc-eligible? entry)})))
 
 (defn project-instances
   "Project a frame's live resource entries map `{<scoped-key> <entry>}`
   into sorted render-safe instance rows. Sorted by resource-id then
   generation (descending) so the most-recent attempt leads. `now-ms` is
   the freshness clock (the panel passes the current ms; tests pass a
-  fixed clock). Per Spec 016 §Xray and AI tooling."
-  ([entries] (project-instances entries nil))
-  ([entries now-ms]
+  fixed clock). Per Spec 016 §Xray and AI tooling.
+
+  Optional `egress-fn` (rf2-tgm1xu) is threaded to `instance-row` so the
+  off-box accessors redact the payload values (scope/params/data) BEFORE
+  summarization while the metadata projects from the raw entry. The in-panel
+  caller omits it — the in-panel `summarize` is sufficient for human
+  rendering and the runtime-db never leaves the box."
+  ([entries] (project-instances entries nil nil))
+  ([entries now-ms] (project-instances entries now-ms nil))
+  ([entries now-ms egress-fn]
    (->> (or entries {})
-        (mapv #(instance-row % now-ms))
+        (mapv #(instance-row % now-ms egress-fn))
         (sort-by (juxt (comp str :resource-id) (comp - (fnil identity 0) :generation)))
         vec)))
 
@@ -855,6 +891,36 @@
   (into {}
         (filter (fn [[k _]] (scoped-key-matches? k key-filter)))
         (or entries {})))
+
+;; ---------------------------------------------------------------------------
+;; Per-slot value egress contract (rf2-tgm1xu). Spec 016 §Xray, line 314:
+;; "Params, scopes, and data carry :sensitive? / :large? classification
+;; through the shared elide-wire-value walker; Xray sees REDACTED SUMMARIES,
+;; NOT raw values."
+;; ---------------------------------------------------------------------------
+;;
+;; A resource cache entry mixes two kinds of slot:
+;;   - VALUE-bearing slots (`:data` / `:error` / `:refresh-error`) + the
+;;     key's scope/params carry the remote payload, failure envelopes, and
+;;     the caller identity — the only slots that can hold PII or a large
+;;     blob, so the only ones routed through the off-box egress walker
+;;     (a `:sensitive?` slot redacts, a `:large?` slot elides);
+;;   - METADATA slots (`:status`, `:generation`, `:attempt`, `:request-id`,
+;;     `:current-work`, `:active-owners`, `:tags`, `:loaded-at`, `:stale-at`,
+;;     `:invalidated-at`, `:resource/id`) are runtime BOOKKEEPING — non-PII
+;;     facts the operator needs to answer "is it stale, who owns it, what's
+;;     the request id". They ALWAYS project, never routed through egress.
+;;
+;; `instance-row` takes an optional `egress-fn` `(fn [value slot-key])` and
+;; applies it to ONLY the value-bearing slots before `summarize`, keeping
+;; the RAW scoped-key as the row identity. The PRIOR design routed the WHOLE
+;; entry through `egress-runtime-db-value` BEFORE projection: with the
+;; off-box runtime-db default the entry collapsed to the bare `:rf/redacted`
+;; sentinel, so the projection read nil for status/owners/tags/request-id —
+;; the default rows were USELESS and the metadata filters (which filter the
+;; projected rows) could never match. Egressing the KEY ITSELF would also
+;; collapse two entries whose scope/params redact to the same sentinel; the
+;; row keeps the raw key as identity to avoid that.
 
 (defn filter-work-rows
   "Filter projected work-ledger rows by the accessor axes: `:resource-id`,

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -82,6 +82,23 @@
   "Runtime-db-relative path to the reverse owner index."
   [resources-key :owner-index])
 
+(def routing-key
+  "Reserved runtime-db key for the routing slice subtree
+  (`:rf.runtime/routing`). The route/resource graph reads the live
+  `:current` route + the per-nav-token unsettled-blocking set from here
+  (Spec 016 §Route integration). Duplicated literal — Xray does not require
+  the routing artefact (bundle isolation); mirrors the literal the resources
+  route integration uses (rf2-m5u3gt)."
+  :rf.runtime/routing)
+
+(def routing-blocking-key
+  "The per-nav-token unsettled-blocking subtree key under the routing slice
+  (`:resource-blocking`). `[:rf.runtime/routing :resource-blocking
+  <nav-token>]` holds the set of scoped keys whose blocking ensure has NOT
+  yet settled for that navigation (Spec 016 §Route integration — the SSR /
+  route wait points)."
+  :resource-blocking)
+
 ;; ---------------------------------------------------------------------------
 ;; The `:rf.resource/*` trace family (Spec 016 §Xray and AI tooling).
 ;; ---------------------------------------------------------------------------
@@ -569,13 +586,82 @@
 ;; Route / resource graph (Spec 016 §Route integration / §Xray).
 ;; ---------------------------------------------------------------------------
 
+(defn routing-current
+  "Extract the live `:current` route slice from the routing-runtime subtree
+  (`{:rf.runtime/routing {:current {:id … :nav-token … :params … :path …}}}`
+  shape, read decoupled off the target frame's runtime-db). Returns the
+  `:current` map (carrying `:id` + `:nav-token`) or nil when no route is
+  active (rf2-m5u3gt). Pure — accepts the already-extracted routing slice."
+  [routing-slice]
+  (when (map? routing-slice)
+    (:current routing-slice)))
+
+(defn routing-blocking-keys
+  "Extract the live UNSETTLED-blocking scoped keys from the routing-runtime
+  subtree. `[:resource-blocking <nav-token>]` is a map of per-nav-token sets
+  of scoped keys whose blocking ensure has not yet settled; this flattens
+  them to a single vector of scoped keys (the live SSR/route wait points the
+  graph flags on the current route — rf2-m5u3gt). Pure; nil/missing ⇒ `[]`."
+  [routing-slice]
+  (let [by-token (when (map? routing-slice)
+                   (get routing-slice routing-blocking-key))]
+    (into [] (mapcat seq) (vals (or by-token {})))))
+
+(defn- resource-liveness
+  "Aggregate the LIVE state of one declared resource-id across the projected
+  `instance-rows` + `work-rows` (rf2-m5u3gt). The route graph node is static
+  (a registry declaration), but the operator's bug-class question is whether
+  THIS route's read is stale, fresh, or just fetching — so each node carries
+  a `:live` rollup over the cache entries + work ledger for its resource-id:
+
+      {:entry-count 2      ; cached entries for this resource-id (any scope/params)
+       :has-data?   true   ; ≥1 cached entry currently carries data
+       :stale?      false  ; ≥1 cached entry is derived-stale
+       :statuses    #{:loaded}   ; the set of live entry statuses
+       :active-work 1      ; non-terminal work-ledger rows for this resource-id
+       :freshness   :fresh}  ; :fresh / :stale / :loading / :idle / :none
+
+  `:freshness` is the headline: `:loading` (active work and no usable data
+  yet — checked first so a mid-fetch read with no cache entry still reads
+  loading), `:none` (no cached entry AND no active work), `:stale` (≥1 stale
+  entry), `:fresh` (cached, has data, not stale), else `:idle`. Pure over the
+  already-projected rows; nil live inputs ⇒ a `:none` rollup so the static
+  graph still renders."
+  [resource-id instance-rows work-rows]
+  (let [rows  (filterv #(= resource-id (:resource-id %)) (or instance-rows []))
+        works (filterv #(and (= resource-id (:resource-id %))
+                             (not (:terminal? %)))
+                       (or work-rows []))
+        has-data?    (boolean (some :has-data? rows))
+        stale?       (boolean (some :stale? rows))
+        active-work  (count works)
+        statuses     (into #{} (keep :status) rows)
+        freshness    (cond
+                       ;; active work without usable data yet ⇒ :loading
+                       ;; (checked BEFORE :none so a route whose resource is
+                       ;; mid-fetch with no cache entry surfaces as loading,
+                       ;; not "nothing here")
+                       (and (pos? active-work) (not has-data?)) :loading
+                       (and (empty? rows) (zero? active-work)) :none
+                       stale?                                :stale
+                       has-data?                             :fresh
+                       :else                                 :idle)]
+    {:entry-count (count rows)
+     :has-data?   has-data?
+     :stale?      stale?
+     :statuses    statuses
+     :active-work active-work
+     :freshness   freshness}))
+
 (defn- route-resource-node
   "Project ONE `:resources` entry on a route into a graph node. The
   `:params` / `:scope` resolvers are fns (opaque), so the node records
   THAT they are declared, the blocking flag (SSR wait point), the
   keep-previous flag, the local `:id` + `:after` dependency, and any
-  `:when` guard — the structure Xray draws without parsing handlers."
-  [entry]
+  `:when` guard — the structure Xray draws without parsing handlers. When
+  live inputs are supplied (rf2-m5u3gt) the node also carries a `:live`
+  rollup of the resource-id's current cache/work state."
+  [entry instance-rows work-rows]
   {:resource        (:resource entry)
    :blocking?       (boolean (:blocking? entry))
    :keep-previous?  (boolean (:keep-previous? entry))
@@ -583,7 +669,8 @@
    :after           (vec (:after entry))
    :when?           (boolean (:when entry))
    :params-fn?      (boolean (:params entry))
-   :scope-resolver? (boolean (:scope entry))})
+   :scope-resolver? (boolean (:scope entry))
+   :live            (resource-liveness (:resource entry) instance-rows work-rows)})
 
 (defn project-route-graph
   "Project the route registry into the route/resource graph (Spec 016
@@ -594,30 +681,72 @@
 
       [{:route-id     :route/article
         :path         \"/articles/:slug\"
-        :resources    [{:resource :article/by-slug :blocking? true …} …]
+        :resources    [{:resource :article/by-slug :blocking? true
+                        :live {:freshness :fresh …} …} …]
         :blocking     [:article/by-slug]   ; SSR wait points
         :non-blocking [:comments/list]
-        :ssr-wait?    true}                 ; route has ≥1 blocking resource
+        :ssr-wait?    true                  ; route has ≥1 blocking resource
+        :current?     true                  ; this is the active route (live)
+        :nav-token    <token>               ; the active nav-token (live)
+        :blocking-live [:article/by-slug]}  ; blocking resources still unsettled
        …]
 
-  Routes WITHOUT `:resources` are omitted (the graph is the resource
-  view of the route table). Per Spec 016 §Route integration."
-  [routes-map]
-  (->> (or routes-map {})
-       (keep (fn [[route-id route-meta]]
-               (let [resources (:resources route-meta)]
-                 (when (seq resources)
-                   (let [nodes        (mapv route-resource-node resources)
-                         blocking     (into [] (comp (filter :blocking?) (map :resource)) nodes)
-                         non-blocking (into [] (comp (remove :blocking?) (map :resource)) nodes)]
-                     {:route-id     route-id
-                      :path         (:path route-meta)
-                      :resources    nodes
-                      :blocking     blocking
-                      :non-blocking non-blocking
-                      :ssr-wait?    (boolean (seq blocking))})))))
-       (sort-by (comp str :route-id))
-       vec))
+  Routes WITHOUT `:resources` are omitted (the graph is the resource view
+  of the route table).
+
+  ## Live state join (rf2-m5u3gt)
+
+  EP-0003 asks the route graph to surface the CURRENT route/nav-token,
+  active work, and fresh/stale state — not just static declarations. The
+  optional `live` map joins the runtime state the panel reads decoupled:
+
+      {:instance-rows  <projected live instances>
+       :work-rows      <projected work-ledger rows>
+       :current        {:id <route-id> :nav-token <token>}   ; routing slice
+       :blocking-keys  [<scoped-key> …]}  ; the live unsettled-blocking set
+
+  Each resource node gains a `:live` freshness rollup; the active route's
+  node is flagged `:current? true` with its `:nav-token`, and its
+  `:blocking-live` lists the declared blocking resources whose scoped keys
+  are still in the live unsettled-blocking set (the SSR/route wait points
+  that have NOT yet settled for the current nav-token). The bare
+  `(project-route-graph routes-map)` arity stays a pure STATIC projection
+  (nil live inputs ⇒ `:live` rollups are `:none`, no `:current?` flag) so
+  the SSR/JVM path and existing callers are unchanged. Per Spec 016 §Route
+  integration / §Xray and AI tooling."
+  ([routes-map] (project-route-graph routes-map nil))
+  ([routes-map {:keys [instance-rows work-rows current blocking-keys]}]
+   (let [current-route-id (:id current)
+         nav-token        (:nav-token current)
+         blocking-key-rid (into #{}
+                                (keep (fn [k]
+                                        (when (and (vector? k) (= 3 (count k)))
+                                          (second k))))
+                                blocking-keys)]
+     (->> (or routes-map {})
+          (keep (fn [[route-id route-meta]]
+                  (let [resources (:resources route-meta)]
+                    (when (seq resources)
+                      (let [nodes        (mapv #(route-resource-node % instance-rows work-rows)
+                                               resources)
+                            blocking     (into [] (comp (filter :blocking?) (map :resource)) nodes)
+                            non-blocking (into [] (comp (remove :blocking?) (map :resource)) nodes)
+                            current?     (and (some? current-route-id)
+                                              (= route-id current-route-id))]
+                        (cond-> {:route-id     route-id
+                                 :path         (:path route-meta)
+                                 :resources    nodes
+                                 :blocking     blocking
+                                 :non-blocking non-blocking
+                                 :ssr-wait?    (boolean (seq blocking))}
+                          current? (assoc :current?      true
+                                          :nav-token     nav-token
+                                          ;; the declared blocking resources whose
+                                          ;; scoped key is still in the live
+                                          ;; unsettled-blocking set for this nav-token
+                                          :blocking-live (filterv blocking-key-rid blocking))))))))
+          (sort-by (comp str :route-id))
+          vec))))
 
 ;; ---------------------------------------------------------------------------
 ;; Lifecycle timeline + invalidation graph + cache-growth (from trace rows).

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -776,6 +776,20 @@
                                       "identical for every user/tenant.")}))))
        vec))
 
+(defn- row-canonical-key
+  "The CANONICAL `[scope resource-id params]` identity of an instance row,
+  read from its RAW `:scoped-key` (kept verbatim by `instance-row` as the
+  row identity — never summarized/redacted). Falls back to the row's
+  projected `:resource-id` when the key is malformed (the scope/params are
+  then nil — a malformed key cannot participate in a scope-mismatch). Per
+  rf2-hbq635 — the lint compares canonical identities, not display
+  previews."
+  [row]
+  (let [k (:scoped-key row)]
+    (if (and (vector? k) (= 3 (count k)))
+      k
+      [nil (:resource-id row) nil])))
+
 (defn scope-mismatch-lint
   "Scope-mismatch lint (Spec 016 §Xray — two lints): a cache ENTRY exists
   for resource R + params P under scope A while a LIVE subscription reads
@@ -783,37 +797,54 @@
   never-resolving `:loading`). The runtime tripwire for the cases the
   fail-closed scope rules don't catch.
 
-  `instance-rows` is the projected live instances; `sub-reads` is a
-  vector of `{:resource-id R :params <raw-params> :scope <raw-scope>}`
-  observed live subscription reads. Returns mismatch pairs:
+  `instance-rows` is the projected live instances (each carrying its RAW
+  `:scoped-key`); `sub-reads` is a vector of `{:resource-id R :params
+  <raw-params> :scope <raw-scope>}` observed live subscription reads.
+  Returns mismatch pairs:
 
       [{:resource-id R
         :sub-scope <summary> :sub-params <summary>
         :entry-scope <summary>}]
 
-  PRIVACY: the surfaced scopes/params are summarized. Matching is on
-  resource-id + params identity (a sub reading params P that an entry
-  caches under a DIFFERENT scope). Pure."
+  ## Canonical-identity matching (rf2-hbq635)
+
+  Matching is on the CANONICAL `[resource-id params]` + `scope` values —
+  the RAW key parts (off the entry's `:scoped-key` and the sub-read's raw
+  `:params` / `:scope`), NOT the SUMMARIZED display previews. The previous
+  impl indexed entries by `[resource-id <params-preview>]` → set of
+  `<scope-preview>`s; previews are `pr-str` truncated at the 120-char
+  budget and may be the `[redacted]` sentinel, so:
+
+    - two DIFFERENT long params whose first 120 chars coincide collided to
+      the same preview → a FALSE mismatch (or a missed one), and
+    - every sensitive/redacted scope summarized to the SAME `[redacted]`
+      preview, so distinct redacted scopes were indistinguishable → a
+      redacted sub-scope wrongly looked equal to a redacted entry-scope (a
+      MISSED mismatch).
+
+  Comparing the canonical raw values is exact: full params identity (no
+  truncation collision) and full scope identity (a redacted scope is
+  compared as its raw value, not the lossy `[redacted]` preview). PRIVACY
+  is preserved by summarizing ONLY the surfaced OUTPUT scopes/params — the
+  raw values never leave this fn. Pure."
   [instance-rows sub-reads]
-  (let [;; index entries by [resource-id params-preview] → set of scope previews
+  (let [;; index entries by CANONICAL [resource-id params] → set of
+        ;; CANONICAL scopes (raw values, not previews — rf2-hbq635)
         entry-index
         (reduce (fn [acc row]
-                  (update acc [(:resource-id row) (get-in row [:params :preview])]
-                          (fnil conj #{}) (get-in row [:scope :preview])))
+                  (let [[scope rid params] (row-canonical-key row)]
+                    (update acc [rid params] (fnil conj #{}) scope)))
                 {} instance-rows)]
     (->> (or sub-reads [])
          (keep (fn [{:keys [resource-id params scope]}]
-                 (let [params-sum (summarize params)
-                       scope-sum  (summarize scope)
-                       k          [resource-id (:preview params-sum)]
-                       entry-scopes (get entry-index k)]
+                 (let [entry-scopes (get entry-index [resource-id params])]
                    ;; mismatch iff an entry exists for this R+P but under
-                   ;; NO scope matching the sub's scope.
+                   ;; NO scope canonically equal to the sub's scope.
                    (when (and (seq entry-scopes)
-                              (not (contains? entry-scopes (:preview scope-sum))))
+                              (not (contains? entry-scopes scope)))
                      {:resource-id resource-id
-                      :sub-scope   scope-sum
-                      :sub-params  params-sum
+                      :sub-scope   (summarize scope)
+                      :sub-params  (summarize params)
                       :entry-scope (summarize (first entry-scopes))}))))
          vec)))
 

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -872,7 +872,7 @@
   always `summarize`s scope/params/data (type + bounded size + a
   redaction-aware preview, never the raw value). On top of that the
   PAYLOAD slots — `:data`/`:error`/`:refresh-error` in the entry and the
-  scope/params in the key — route through the off-box `egress-resource-value`
+  scope/params in the key — route through the off-box `resource-egress-fn`
   walker so a `:sensitive?` declaration egresses them as `:rf/redacted` and
   a `:large?` slot as `:rf.size/large-elided`. The non-PII metadata
   (status, generation, attempt, request-id, current-work, active-owners,
@@ -944,7 +944,7 @@
 
   PRIVACY (rf2-tgm1xu): the projection always `summarize`s scope/params/
   data; on top, the PAYLOAD slots (`:data`/`:error`/`:refresh-error` + the
-  key's scope/params) route through `egress-resource-value` (runtime-db
+  key's scope/params) route through `resource-egress-fn` (runtime-db
   default-redacted off-box; `:include-runtime-db? true` to opt in to the
   raw payload). The non-PII metadata (status / owners / tags / request-id /
   generation / timestamps) is NEVER redacted — a redacted summary STILL

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -381,6 +381,47 @@
      :rf/redacted)))
 
 ;; ---------------------------------------------------------------------------
+;; Per-slot resource-payload egress (rf2-tgm1xu)
+;; ---------------------------------------------------------------------------
+;;
+;; A resource cache entry is RUNTIME-DB state, but the EP-0003 tool contract
+;; (Spec 016 §Xray, line 314) is that a REDACTED SUMMARY STILL EXPOSES
+;; METADATA: the operator must always see status / owners / tags / request-id
+;; / generation / timestamps to answer "is it stale, who owns it, what's the
+;; request id" — those are non-PII bookkeeping facts. Only the PAYLOAD slots
+;; (`:data` / `:error` / `:refresh-error`) and the key's scope/params carry
+;; PII or a large blob, so ONLY they follow the off-box egress posture.
+;;
+;; `resource-egress-fn` builds the `(fn [value slot-key])` closure
+;; `resources-helpers/project-instances` / `instance-row` call on each
+;; payload value (scope / params / data / error / refresh-error) BEFORE
+;; summarizing. It routes the value through `egress-runtime-db-value` so the
+;; runtime-db PARTITION default holds (ruling #14 — a raw runtime-db payload
+;; does NOT cross off-box unless the trusted-local `:include-runtime-db?
+;; true` opt-in is set), and under the opt-in the value walks through the
+;; per-slot `:sensitive?` / `:large?` posture (a value already redacted/
+;; elided upstream keeps its sentinel). The in-panel
+;; `resources-helpers/summarize` always wraps the result, so even an
+;; opted-in raw payload renders as a bounded summary, never a flood. The
+;; helper threads the slot's relative runtime-db path so a per-slot
+;; declaration (e.g. all `:data` payloads) can match under the opt-in.
+
+(defn- resource-egress-fn
+  "Return the `(fn [value slot-key] -> egressed)` payload-egress closure for
+  the resource accessors (rf2-tgm1xu). Each value routes through
+  `egress-runtime-db-value` with `egress-opts` — the runtime-db partition
+  default (redact unless `:include-runtime-db? true`) composed with the
+  per-slot value posture under the opt-in. The slot's relative runtime-db
+  path (`[:rf.runtime/resources :entries <slot>]`) is threaded so a
+  declaration keyed by that path still matches under the opt-in."
+  [egress-opts]
+  (fn [value slot-key]
+    (egress-runtime-db-value
+      value
+      (assoc egress-opts
+             :path (conj (vec resources-helpers/entries-rel-path) slot-key)))))
+
+;; ---------------------------------------------------------------------------
 ;; Event-level default-suppress gate (rf2-to36uj)
 ;; ---------------------------------------------------------------------------
 ;;
@@ -824,10 +865,22 @@
 
   Reads the cache entries from the frame's RUNTIME-DB partition at
   `[:rf.runtime/resources :entries]` (EP-0001 — resource cache is
-  framework-owned runtime-db state). PRIVACY: scope/params/data are
-  summarized AND the raw entry values route through
-  `egress-runtime-db-value` (default-redacted off-box; opt in with
-  `:include-runtime-db? true`).
+  framework-owned runtime-db state).
+
+  PRIVACY (rf2-tgm1xu — the EP-0003 contract that a redacted summary STILL
+  exposes metadata; Spec 016 §Xray, line 314): the projection algebra
+  always `summarize`s scope/params/data (type + bounded size + a
+  redaction-aware preview, never the raw value). On top of that the
+  PAYLOAD slots — `:data`/`:error`/`:refresh-error` in the entry and the
+  scope/params in the key — route through the off-box `egress-resource-value`
+  walker so a `:sensitive?` declaration egresses them as `:rf/redacted` and
+  a `:large?` slot as `:rf.size/large-elided`. The non-PII metadata
+  (status, generation, attempt, request-id, current-work, active-owners,
+  tags, timestamps) is NEVER redacted — it projects so the status / tag /
+  owner / request-id filters (which filter the PROJECTED rows) work without
+  `:include-runtime-db?`. The trusted-local `:include-runtime-db? true`
+  opt-in lifts even a non-declared payload to its raw value (still capped
+  by the in-panel summary).
 
   Returns `{:ok? true :frame <id> :instances [<row> …] :count N}` or
   `{:ok? false :reason :no-frame-resolved}`."
@@ -845,20 +898,21 @@
              entries     (resources-helpers/select-raw-entries
                            all-entries
                            {:scope scope :resource-id resource-id :params params})
-             rt-egress   {:include-sensitive?  include-sensitive?
+             egress-opts {:include-sensitive?  include-sensitive?
                           :include-large?      include-large?
                           :include-runtime-db? include-runtime-db?}
-             ;; off-box raw-value egress on the runtime-db entries (the
-             ;; summaries the rows carry are belt; this is braces — a
-             ;; :sensitive? data/scope slot egresses redacted)
-             entries*    (into {}
-                               (map (fn [[k entry]]
-                                      [k (egress-runtime-db-value
-                                           entry
-                                           (assoc rt-egress
-                                                  :path (conj resources-helpers/entries-rel-path k)))]))
-                               (or entries {}))
-             rows        (-> (resources-helpers/project-instances entries* (.now js/Date))
+             ;; PER-SLOT egress (rf2-tgm1xu): the projection redacts ONLY the
+             ;; payload values (scope/params/data/error) BEFORE summarizing,
+             ;; while the metadata projects from the raw entry — so the rows
+             ;; are USEFUL and the status/tag/owner/request-id filters (which
+             ;; filter the projected rows) match. The RAW key is kept as the
+             ;; row identity so two entries whose scope/params redact to the
+             ;; same sentinel never collapse. Each value egresses at its
+             ;; ABSOLUTE runtime-db slot path so per-slot :sensitive? /
+             ;; :large? declarations match.
+             rows        (-> (resources-helpers/project-instances
+                               entries (.now js/Date)
+                               (resource-egress-fn egress-opts))
                              (resources-helpers/filter-instance-rows
                                {:resource-id resource-id :status status :stale? stale?
                                 :tag tag :owner owner :request-id request-id}))]
@@ -877,13 +931,24 @@
   EP-0002 the frame target is carried explicitly (`:frame`); a frameless
   call with no resolvable context fails closed.
 
+  Required scoped-key parts: `:resource-id` AND `:scope` AND `:params`.
+  Any missing part fails closed with `:reason :missing-key` (a partial key
+  cannot address an entry — Spec 016 §Introspection: the scoped key is the
+  full `[scope resource-id params]` triple).
+
   Returns `{:ok? true :frame <id> :state <instance-row>}` (the row
   carries the PRIVACY-summarized status/data/error projection — Spec 016
   §Status semantics: `:stale?`/`:has-data?` are derived, not stored) or
   `{:ok? false :reason :no-such-instance ...}` / `:no-frame-resolved` /
-  `:missing-key`. The raw entry routes through `egress-runtime-db-value`
-  before projection (default-redacted off-box; `:include-runtime-db?
-  true` to opt in)."
+  `:missing-key`.
+
+  PRIVACY (rf2-tgm1xu): the projection always `summarize`s scope/params/
+  data; on top, the PAYLOAD slots (`:data`/`:error`/`:refresh-error` + the
+  key's scope/params) route through `egress-resource-value` (runtime-db
+  default-redacted off-box; `:include-runtime-db? true` to opt in to the
+  raw payload). The non-PII metadata (status / owners / tags / request-id /
+  generation / timestamps) is NEVER redacted — a redacted summary STILL
+  exposes the metadata (the EP-0003 contract)."
   [{:keys [frame resource-id scope params
            include-sensitive? include-large? include-runtime-db?]}]
   (let [fid (resolve-frame frame)]
@@ -892,9 +957,12 @@
       {:ok? false :reason :no-frame-resolved
        :hint "Pass :frame :foo or register at least one frame."}
 
-      (nil? resource-id)
+      ;; A scoped key is the full [scope resource-id params] triple — any
+      ;; missing part cannot address an entry (rf2-tgm1xu: missing scope or
+      ;; params reports :missing-key, not a silent nil-key probe).
+      (or (nil? resource-id) (nil? scope) (nil? params))
       {:ok? false :reason :missing-key
-       :hint "Pass :resource-id + :scope + :params (the scoped key)."}
+       :hint "Pass :resource-id + :scope + :params (the full scoped key)."}
 
       :else
       (let [scoped-key  [scope resource-id params]
@@ -904,15 +972,18 @@
         (if (nil? entry)
           {:ok? false :reason :no-such-instance
            :frame fid :resource-id resource-id}
-          (let [entry* (egress-runtime-db-value
-                         entry
-                         {:include-sensitive?  include-sensitive?
-                          :include-large?      include-large?
-                          :include-runtime-db? include-runtime-db?
-                          :path                entry-path})]
+          (let [egress-opts {:include-sensitive?  include-sensitive?
+                             :include-large?      include-large?
+                             :include-runtime-db? include-runtime-db?}]
+            ;; PER-SLOT egress (rf2-tgm1xu): the projection redacts only the
+            ;; payload values (scope/params/data/error) before summarizing;
+            ;; the metadata projects from the raw entry. The RAW scoped-key
+            ;; is the row identity.
             {:ok?   true
              :frame fid
-             :state (resources-helpers/instance-row [scoped-key entry*] (.now js/Date))}))))))
+             :state (resources-helpers/instance-row
+                      [scoped-key entry] (.now js/Date)
+                      (resource-egress-fn egress-opts))}))))))
 
 (defn get-resource-history
   "Tool: `get-resource-history`. The BOUNDED lifecycle history for a

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
@@ -124,12 +124,15 @@
                :rf.xray/resource-work-ledger-override
                :rf.xray/resource-sub-reads
                :rf.xray/resource-sub-reads-override
+               :rf.xray/resource-routing-slice
+               :rf.xray/resource-routing-slice-override
                :rf.xray/resources-tab-data]]
       (is (some? (registrar/handler :sub s)) (str s " sub registered")))
     (doseq [e [:rf.xray/set-registered-resources-override-for-test
                :rf.xray/set-resource-entries-override-for-test
                :rf.xray/set-resource-work-ledger-override-for-test
-               :rf.xray/set-resource-sub-reads-override-for-test]]
+               :rf.xray/set-resource-sub-reads-override-for-test
+               :rf.xray/set-resource-routing-slice-override-for-test]]
       (is (some? (registrar/handler :event e)) (str e " event registered")))))
 
 (deftest read-only-no-resource-events
@@ -146,7 +149,8 @@
     (doseq [e [:rf.xray/set-registered-resources-override-for-test
                :rf.xray/set-resource-entries-override-for-test
                :rf.xray/set-resource-work-ledger-override-for-test
-               :rf.xray/set-resource-sub-reads-override-for-test]]
+               :rf.xray/set-resource-sub-reads-override-for-test
+               :rf.xray/set-resource-routing-slice-override-for-test]]
       (is (some? (registrar/handler :event e))
           (str e " is registered under the :rf.xray*/ prefix"))
       (is (= "rf.xray" (namespace e))
@@ -200,6 +204,38 @@
             status (find-by-testid tree "rf-xray-resources-instance-row-article/by-slug-g4-status")]
         (is (some? status))
         (is (re-find #"loaded" (node-text status)) "status reads loaded")))))
+
+(deftest route-graph-shows-live-active-route
+  (testing "rf2-m5u3gt — with a live routing slice override, the route/resource
+            graph flags the active route (● active) and surfaces the live
+            unsettled-blocking wait point off the runtime routing slice"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-overrides!)
+      ;; Register the route declaring :resources so the graph has a node.
+      ;; Via the registrar directly (the routing artefact's reg-route macro
+      ;; is not on the xray test classpath); the graph reads the registry map
+      ;; decoupled via (rf/registrations :route).
+      (registrar/register! :route :route/article
+                           {:path "/articles/:slug"
+                            :resources [{:resource :article/by-slug :blocking? true}]})
+      ;; Seed the live routing slice: :route/article active under nav-1, with
+      ;; the article scoped key still in the unsettled-blocking set.
+      (rf/dispatch-sync
+        [:rf.xray/set-resource-routing-slice-override-for-test
+         {:current {:id :route/article :nav-token "nav-1"}
+          :resource-blocking
+          {"nav-1" #{[session-scope :article/by-slug {:slug "welcome"}]}}}]
+        {:frame :rf/xray})
+      (let [tree (resources/Panel)
+            row  (find-by-testid tree "rf-xray-resources-route-row-route/article")]
+        (is (some? row) "the route row renders")
+        (is (some? (find-by-testid tree "rf-xray-resources-route-row-route/article-current"))
+            "the active route is flagged ● active off the live routing slice")
+        (is (some? (find-by-testid tree "rf-xray-resources-route-row-route/article-blocking-live"))
+            "the live unsettled-blocking wait point surfaces")
+        (is (re-find #"fresh" (node-text row))
+            "the blocking :article/by-slug reads :fresh from its live cache entry")))))
 
 ;; ---- (4) PRIVACY --------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
@@ -247,7 +247,80 @@
       (let [res (first (:resources (first nodes)))]
         (is (:blocking? res))
         (is (:params-fn? res))
-        (is (:scope-resolver? res))))))
+        (is (:scope-resolver? res))))
+    (testing "the bare 1-arity stays STATIC — :live rollups are :none, no :current?"
+      (let [res (first (:resources (first nodes)))]
+        (is (= :none (get-in res [:live :freshness]))
+            "no live inputs ⇒ the resource node's freshness is :none")
+        (is (not (:current? (first nodes)))
+            "no live inputs ⇒ no route is flagged active")))))
+
+;; ---- (6b) LIVE route/resource graph join (rf2-m5u3gt) -------------------
+;;
+;; EP-0003 asks the route graph to surface the CURRENT route/nav-token,
+;; active work, and fresh/stale state — not just static declarations. The
+;; optional `live` arg joins the projected instance/work rows + the routing
+;; slice onto the static plan.
+
+(def ^:private m5-nav-token "nav-7")
+(def ^:private m5-article-key [session-scope :article/by-slug {:slug "welcome"}])
+
+(def ^:private m5-routing-slice
+  {:current {:id :route/article :nav-token m5-nav-token
+             :params {:slug "welcome"} :path "/articles/welcome"}
+   :resource-blocking {m5-nav-token #{m5-article-key}}})
+
+(deftest project-route-graph-live-test
+  (let [;; a FRESH cached :article/by-slug entry (loaded, stale-at in future)
+        live-entries  {m5-article-key
+                       {:resource/id :article/by-slug :status :loaded
+                        :data {:title "Welcome"} :generation 4
+                        :loaded-at (- now 1000) :stale-at (+ now 50000)
+                        :active-owners #{[:route :route/article m5-nav-token]}}}
+        instance-rows (h/project-instances live-entries now)
+        ;; one non-terminal work row for :comments/list (the non-blocking sibling)
+        work-rows     (h/project-work-ledger
+                        {[:rf.work/resource [session-scope :comments/list {}] 1]
+                         {:work/id [:rf.work/resource [session-scope :comments/list {}] 1]
+                          :work/kind :resource :resource/key [session-scope :comments/list {}]
+                          :generation 1 :status :running}})
+        nodes (h/project-route-graph
+                routes-map
+                {:instance-rows instance-rows
+                 :work-rows     work-rows
+                 :current       (h/routing-current m5-routing-slice)
+                 :blocking-keys (h/routing-blocking-keys m5-routing-slice)})
+        article-node (first (filter #(= :route/article (:route-id %)) nodes))]
+    (testing "the active route is flagged :current? with its live nav-token"
+      (is (:current? article-node))
+      (is (= m5-nav-token (:nav-token article-node))))
+    (testing "the live unsettled blocking wait point surfaces on the active route"
+      (is (= [:article/by-slug] (:blocking-live article-node))
+          ":blocking-live lists the blocking resource still in the unsettled set"))
+    (testing "per-resource live freshness rollup joins the cache/work state"
+      (let [article-res (first (filter #(= :article/by-slug (:resource %))
+                                       (:resources article-node)))
+            comments-res (first (filter #(= :comments/list (:resource %))
+                                        (:resources article-node)))]
+        (is (= :fresh (get-in article-res [:live :freshness]))
+            "the cached, has-data, non-stale article reads :fresh")
+        (is (= 1 (get-in article-res [:live :entry-count])))
+        (is (get-in article-res [:live :has-data?]))
+        (is (= :loading (get-in comments-res [:live :freshness]))
+            "the non-blocking comments resource with active work + no cache reads :loading")
+        (is (= 1 (get-in comments-res [:live :active-work])))))))
+
+(deftest routing-slice-extractors-test
+  (testing "routing-current pulls the :current slice; nil-safe"
+    (is (= {:id :route/article :nav-token m5-nav-token
+            :params {:slug "welcome"} :path "/articles/welcome"}
+           (h/routing-current m5-routing-slice)))
+    (is (nil? (h/routing-current nil)))
+    (is (nil? (h/routing-current {}))))
+  (testing "routing-blocking-keys flattens the per-nav-token unsettled sets; nil-safe"
+    (is (= [m5-article-key] (h/routing-blocking-keys m5-routing-slice)))
+    (is (= [] (h/routing-blocking-keys nil)))
+    (is (= [] (h/routing-blocking-keys {})))))
 
 ;; ---- (7) timeline / invalidation / cache-growth ------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
@@ -349,6 +349,78 @@
         (is (empty? (h/orphaned-owner-lint instance-rows trace-buffer))
             "the route-owned fresh entry is not an app-kind owner")))))
 
+;; ---- (8b) scope-mismatch lint compares CANONICAL identities (rf2-hbq635) ----
+;;
+;; The lint must index + compare the RAW canonical [resource-id params] +
+;; scope values, NOT the summarized display previews. Previews are pr-str
+;; truncated at the 120-char budget and collapse every redacted value to the
+;; same `[redacted]` sentinel, so the preview-keyed impl false-tripped /
+;; missed on long-or-colliding params and on redacted scopes.
+
+(deftest scope-mismatch-canonical-identity
+  (testing "two DIFFERENT long params whose first 120 chars COINCIDE do not
+            collide — the lint keys on the canonical params, not the
+            truncated preview (rf2-hbq635)"
+    ;; Both params share a >120-char common prefix; they differ only in the
+    ;; tail, so their pr-str previews (budget 120) are identical while the
+    ;; canonical values are distinct.
+    (let [prefix     (apply str (repeat 200 "x"))
+          params-a   {:q (str prefix "-AAA")}
+          params-b   {:q (str prefix "-BBB")}
+          entries*   {[session-scope :search/run params-a]
+                      {:resource/id :search/run :status :loaded :data {}
+                       :active-owners #{} :generation 1}}
+          rows       (h/project-instances entries* now)]
+      ;; sanity: the two params DO summarize to the same truncated preview
+      (is (= (:preview (h/summarize params-a)) (:preview (h/summarize params-b)))
+          "the two long params share a truncated preview (the collision the old impl tripped on)")
+      ;; A sub reading params-b under a DIFFERENT scope: there is NO entry
+      ;; for params-b (only params-a is cached), so canonically there is NO
+      ;; mismatch — the preview-keyed impl would have FALSE-matched it to the
+      ;; params-a entry because the previews collide.
+      (is (empty? (h/scope-mismatch-lint
+                    rows
+                    [{:resource-id :search/run :params params-b :scope global-scope}]))
+          "no entry exists for params-b → no mismatch (preview collision is NOT a match)")
+      ;; A sub reading params-a (the actually-cached params) under a different
+      ;; scope IS a real mismatch.
+      (is (= 1 (count (h/scope-mismatch-lint
+                        rows
+                        [{:resource-id :search/run :params params-a :scope global-scope}])))
+          "the real params-a entry under a different scope is a true mismatch")))
+
+  (testing "distinct REDACTED scopes do not false-match — the lint compares
+            the canonical scope, not the lossy [redacted] preview (rf2-hbq635)"
+    ;; Two entries cached under DIFFERENT sensitive scopes that both
+    ;; summarize to the [redacted] preview. A sub reading the SAME params
+    ;; under one of those exact scopes must NOT mismatch (the scope IS in the
+    ;; canonical set), while a sub under a THIRD distinct scope must mismatch.
+    (let [scope-1   :rf/redacted                  ; an upstream-redacted scope
+          scope-2   [:rf.scope/session {:tenant "t-1"}]
+          scope-3   [:rf.scope/session {:tenant "t-9"}]
+          entries*  {[scope-2 :doc/get {:id 1}]
+                     {:resource/id :doc/get :status :loaded :data {}
+                      :active-owners #{} :generation 1}}
+          rows      (h/project-instances entries* now)]
+      ;; A sub reading the SAME canonical scope as the entry → NO mismatch,
+      ;; even though scope-2 summarizes to a redaction-aware preview.
+      (is (empty? (h/scope-mismatch-lint
+                    rows
+                    [{:resource-id :doc/get :params {:id 1} :scope scope-2}]))
+          "the sub's scope canonically EQUALS the entry scope → no false mismatch")
+      ;; A sub reading a DIFFERENT scope (third tenant) → real mismatch.
+      (is (= 1 (count (h/scope-mismatch-lint
+                        rows
+                        [{:resource-id :doc/get :params {:id 1} :scope scope-3}])))
+          "a canonically-different scope is a true mismatch")
+      ;; A sub reading the upstream-redacted scope while the entry is under
+      ;; scope-2 → mismatch (the canonical :rf/redacted ≠ scope-2; the old
+      ;; preview-keyed impl could mis-compare a [redacted] preview).
+      (is (= 1 (count (h/scope-mismatch-lint
+                        rows
+                        [{:resource-id :doc/get :params {:id 1} :scope scope-1}])))
+          "a redacted sub-scope is compared canonically, not as the [redacted] preview"))))
+
 ;; ---- (9) filters --------------------------------------------------------
 
 (deftest filters-test

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -276,6 +276,9 @@
    :rf.xray/resource-work-ledger-override
    :rf.xray/resource-sub-reads
    :rf.xray/resource-sub-reads-override
+   ;; rf2-m5u3gt — the live route/resource graph reads the routing slice.
+   :rf.xray/resource-routing-slice
+   :rf.xray/resource-routing-slice-override
    :rf.xray/resources-tab-data
    ;; rf2-o5f5f.3 — Routes browse + Simulate-URL state lives under
    ;; the Static Routes panel (promoted from `:rf.xray.routing/*` per
@@ -653,6 +656,8 @@
    :rf.xray/set-resource-entries-override-for-test
    :rf.xray/set-resource-work-ledger-override-for-test
    :rf.xray/set-resource-sub-reads-override-for-test
+   ;; rf2-m5u3gt — live route/resource graph routing-slice override.
+   :rf.xray/set-resource-routing-slice-override-for-test
    ;; rf2-o5f5f.3 — Static Routes UI-state events (search input,
    ;; Simulate-URL input, expand-row toggle, hermetic Simulate-nav
    ;; toggle, cross-link to Dynamic Routing). Promoted from the

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -1086,3 +1086,183 @@
           "the source-coord resolves for the registered handler")
       (is (= "leak-me" (get-in result [:source-coord :auth :password]))
           ":include-sensitive? true ⇒ the raw value passes through"))))
+
+;; ---------------------------------------------------------------------------
+;; (15) Resource accessors expose METADATA on the redacted-summary default
+;;      path; only payload values follow the off-box egress (rf2-tgm1xu).
+;; ---------------------------------------------------------------------------
+;;
+;; BEFORE the fix, `list-resource-instances` / `get-resource-state` routed
+;; the WHOLE runtime-db entry through `egress-runtime-db-value` BEFORE
+;; projection, so the default (no `:include-runtime-db?`) collapsed every
+;; entry to the bare `:rf/redacted` sentinel — the projection then read nil
+;; for status / owners / tags / request-id and the rows were USELESS (and
+;; the status/tag/owner/request-id filters, which filter the projected
+;; rows, could never match). The EP-0003 tool contract (Spec 016 §Xray,
+;; line 314) is that a REDACTED SUMMARY STILL EXPOSES METADATA. AFTER the
+;; fix the metadata always projects; only the payload slots (data / error /
+;; refresh-error + the key's scope/params) follow the runtime-db egress.
+;;
+;; The resources RUNTIME artefact is not on the xray test classpath, so we
+;; seed the live entries directly into the runtime-db partition (the slot
+;; the resources runtime writes) via a framework-authority `:rf/machine?`
+;; event returning the reserved `:rf.db/runtime` effect — the same seeding
+;; idiom the machine-state tests use.
+
+(def ^:private tgm1xu-scope [:rf.scope/session {:user-id "u-42"}])
+(def ^:private tgm1xu-key   [tgm1xu-scope :article/by-slug {:slug "welcome"}])
+(def ^:private tgm1xu-key-2 [tgm1xu-scope :article/by-slug {:slug "old"}])
+
+(def ^:private tgm1xu-entry
+  {:resource/id    :article/by-slug
+   :status         :loaded
+   :data           {:title "Welcome"}
+   :error          nil
+   :generation     4
+   :attempt        2
+   :request-id     [:w 4]
+   :current-work   [:rf.work/resource tgm1xu-key 4]
+   :active-owners  #{[:route :route/article "nav-1"]}
+   :tags           #{[:article "welcome"]}
+   :loaded-at      900000
+   :stale-at       9999999999999})
+
+(def ^:private tgm1xu-entry-2
+  {:resource/id   :article/by-slug
+   :status        :error
+   :data          nil
+   :error         {:message "boom"}
+   :generation    1
+   :request-id    [:w 1]
+   :active-owners #{}
+   :tags          #{[:article "old"]}})
+
+(defn- seed-resource-entries! [entries]
+  (rf/reg-event-fx :test/seed-resources
+    {:rf/machine? true}
+    (fn [_ _]
+      {:rf.db/runtime {:rf.runtime/resources {:entries entries}}}))
+  (rf/dispatch-sync [:test/seed-resources]))
+
+(deftest list-resource-instances-exposes-metadata-on-default-path
+  (testing "rf2-tgm1xu — the DEFAULT (no :include-runtime-db?) list returns
+            USEFUL redacted-summary rows: status / owners / tags / request-id
+            / generation all project (metadata is never redacted), while the
+            payload :data is redacted off-box"
+    (seed-resource-entries! {tgm1xu-key tgm1xu-entry})
+    (let [result (runtime/list-resource-instances)]
+      (is (true? (:ok? result)))
+      (is (= 1 (:count result)))
+      (let [row (first (:instances result))]
+        (is (= :article/by-slug (:resource-id row)) "resource-id projects")
+        (is (= :loaded (:status row)) "status projects (metadata not redacted)")
+        (is (= 4 (:generation row)) "generation projects")
+        (is (= 2 (:attempt row)) "attempt projects")
+        (is (= [:w 4] (:request-id row)) "request-id projects")
+        (is (= [[:route :route/article "nav-1"]] (:active-owners row))
+            "active-owners project")
+        (is (= 1 (:owner-count row)) "owner-count derived from metadata")
+        (is (= [[:article "welcome"]] (:tags row)) "tags project")
+        (is (not (:stale? row)) "derived :stale? works (stale-at in the future)")
+        ;; The PAYLOAD is the only thing redacted off-box by default.
+        (is (:redacted? (:data row))
+            "the payload :data is redacted off-box on the default path")
+        (is (= "[redacted]" (:preview (:data row)))
+            "the redacted payload renders the [redacted] preview, not the raw value")))))
+
+(deftest list-resource-instances-metadata-filters-work-without-runtime-db
+  (testing "rf2-tgm1xu — the status / tag / owner / request-id filters
+            (which filter the PROJECTED rows) match on the default path,
+            because metadata is projected, NOT redacted"
+    (seed-resource-entries! {tgm1xu-key   tgm1xu-entry
+                             tgm1xu-key-2 tgm1xu-entry-2})
+    (testing ":status filter"
+      (is (= 1 (:count (runtime/list-resource-instances {:status :loaded}))))
+      (is (= 1 (:count (runtime/list-resource-instances {:status :error})))))
+    (testing ":tag filter"
+      (is (= 1 (:count (runtime/list-resource-instances
+                         {:tag [:article "welcome"]})))))
+    (testing ":owner filter"
+      (is (= 1 (:count (runtime/list-resource-instances
+                         {:owner [:route :route/article "nav-1"]})))))
+    (testing ":request-id filter"
+      (is (= 1 (:count (runtime/list-resource-instances {:request-id [:w 4]})))))))
+
+(deftest list-resource-instances-opts-into-raw-payload
+  (testing "rf2-tgm1xu — the trusted-local :include-runtime-db? true opt-in
+            lifts the payload redaction; :data then summarizes the raw value
+            (still bounded), while metadata is unchanged"
+    (seed-resource-entries! {tgm1xu-key tgm1xu-entry})
+    (let [row (first (:instances (runtime/list-resource-instances
+                                   {:include-runtime-db? true})))]
+      (is (= :loaded (:status row)) "metadata still projects under the opt-in")
+      (is (not (:redacted? (:data row)))
+          ":include-runtime-db? true ⇒ the payload is not redacted")
+      (is (= "map" (:type (:data row)))
+          "the raw payload is summarized (type surfaced), never flooded raw")
+      (is (= 1 (:size (:data row))) "the payload summary carries the bounded size"))))
+
+(deftest list-resource-instances-preserves-upstream-redacted-payload-metadata-rides
+  (testing "rf2-tgm1xu adversarial — a payload value already redacted upstream
+            (the resources runtime emits the framework :rf/redacted sentinel
+            for a :sensitive? slot via elide-wire-value) keeps its redacted
+            status under :include-runtime-db? true, while the entry's METADATA
+            still rides — the value redacts, the metadata does not"
+    (seed-resource-entries! {tgm1xu-key (assoc tgm1xu-entry :data :rf/redacted)})
+    (let [row (first (:instances (runtime/list-resource-instances
+                                   {:include-runtime-db? true})))]
+      (is (= :loaded (:status row)) "metadata rides while the value redacts")
+      (is (= [:w 4] (:request-id row)) "request-id metadata rides")
+      (is (= [[:article "welcome"]] (:tags row)) "tags metadata rides")
+      (is (:redacted? (:data row))
+          "the upstream-redacted payload keeps its redacted status even under the opt-in")
+      (is (= "[redacted]" (:preview (:data row)))
+          "the redacted payload renders [redacted], not a raw preview"))))
+
+(deftest get-resource-state-exposes-metadata-on-default-path
+  (testing "rf2-tgm1xu — get-resource-state returns a USEFUL redacted summary
+            on the default path: status / owners / tags / request-id project
+            while the payload redacts"
+    (seed-resource-entries! {tgm1xu-key tgm1xu-entry})
+    (let [result (runtime/get-resource-state
+                   {:resource-id :article/by-slug
+                    :scope       tgm1xu-scope
+                    :params      {:slug "welcome"}})]
+      (is (true? (:ok? result)))
+      (let [row (:state result)]
+        (is (= :loaded (:status row)) "status projects")
+        (is (= [:w 4] (:request-id row)) "request-id projects")
+        (is (= [[:route :route/article "nav-1"]] (:active-owners row))
+            "owners project")
+        (is (:redacted? (:data row)) "payload redacted off-box by default")))))
+
+(deftest get-resource-state-missing-key-parts-fail-closed
+  (testing "rf2-tgm1xu — a partial scoped key (missing scope OR params OR
+            resource-id) fails closed with :missing-key — a partial key
+            cannot address an entry"
+    (seed-resource-entries! {tgm1xu-key tgm1xu-entry})
+    (testing "missing :resource-id"
+      (let [r (runtime/get-resource-state {:scope tgm1xu-scope :params {:slug "x"}})]
+        (is (false? (:ok? r)))
+        (is (= :missing-key (:reason r)))))
+    (testing "missing :scope"
+      (let [r (runtime/get-resource-state {:resource-id :article/by-slug
+                                           :params {:slug "x"}})]
+        (is (false? (:ok? r)))
+        (is (= :missing-key (:reason r)))))
+    (testing "missing :params"
+      (let [r (runtime/get-resource-state {:resource-id :article/by-slug
+                                           :scope tgm1xu-scope})]
+        (is (false? (:ok? r)))
+        (is (= :missing-key (:reason r)))))))
+
+(deftest get-resource-state-no-such-instance
+  (testing "rf2-tgm1xu — a full key that does not address a cached entry
+            surfaces :no-such-instance (distinct from :missing-key)"
+    (seed-resource-entries! {tgm1xu-key tgm1xu-entry})
+    (let [r (runtime/get-resource-state
+              {:resource-id :article/by-slug
+               :scope       tgm1xu-scope
+               :params      {:slug "does-not-exist"}})]
+      (is (false? (:ok? r)))
+      (is (= :no-such-instance (:reason r))))))


### PR DESCRIPTION
Cluster worker resolving 3 `[xray][resources]` beads against the `tools/xray/` surface — one worktree, one PR, one commit per bead.

## Beads

### rf2-tgm1xu (P1) — resource accessors expose metadata on the redacted-summary path
`list-resource-instances` / `get-resource-state` routed the **whole** runtime-db entry through `egress-runtime-db-value` **before** projection, so the off-box default (no `:include-runtime-db?`) collapsed every entry to the bare `:rf/redacted` sentinel — the projection then read nil for status / owners / tags / request-id and the rows were useless (the metadata filters, which filter the projected rows, could never match). This contradicted the EP-0003 tool contract (Spec 016 §Xray line 314: "Xray sees redacted summaries, not raw values").

Fix — project metadata **before** egress redaction, redact only the payload values **per-slot**:
- `instance-row` / `project-instances` take an optional `egress-fn` applied to the payload values (scope / params / data / error / refresh-error) before `summarize`; the metadata projects from the raw entry and is never redacted.
- the **raw scoped-key** is kept as the row identity, so two entries whose scope/params redact to the same sentinel can never collapse.
- `:has-data?` is derived so an upstream-redacted payload counts as has-data while a nil payload does not (a nil slot is left nil, nothing to redact).
- `get-resource-state` requires the **full** scoped key; a missing scope OR params OR resource-id fails closed with `:missing-key`.

### rf2-hbq635 (P2) — scope-mismatch lint compares canonical identities
The lint indexed entries by `[resource-id <params-preview>]` → set of `<scope-preview>`s. Previews are `pr-str` truncated at the 120-char budget and collapse every redacted value to the same `[redacted]` sentinel, so long-or-colliding params false-tripped/missed and distinct redacted scopes were indistinguishable. Now compares the **canonical** `[resource-id params]` + `scope` values (raw key parts off each row's verbatim `:scoped-key` + the sub-read's raw params/scope); PRIVACY preserved by summarizing only the surfaced output.

### rf2-m5u3gt (P2) — live route/resource graph projection
`project-route-graph` was purely static. Now joins the static route plan against the live instance rows, work ledger, and routing slice: each resource node carries a `:live` freshness rollup (`:fresh`/`:stale`/`:loading`/`:idle`/`:none` + active-work count); the active route is flagged `:current?` with its live `:nav-token` + `:blocking-live` (unsettled SSR/route wait points). New `:rf.xray/resource-routing-slice` sub (decoupled `[:rf.runtime/routing]` read) wires the routing slice into the composite; panel view surfaces the active-route badge + freshness chips. The bare 1-arity stays a pure static projection (SSR/JVM path unchanged).

## Surface

`tools/xray/` only (src + spec). Spec updated in the same PR per the standing rule: `tools/xray/spec/024-Resources-Panel.md` (PRIVACY per-slot contract + canonical-lint note + live-graph §4 + sub/event tables) and `tools/xray/spec/014-Registry-Catalogue.md` (routing-slice sub/override/event).

## Quality gates

| Gate | Command | Result |
|---|---|---|
| xray JVM helper tests | `clojure -M:test` (from `tools/xray/`) | **1110 tests / 4713 assertions / 0 failures** |
| CLJS node tests | `npm run test:cljs` (from `implementation/`) | **6324 tests / 22750 assertions / 0 failures** |
| Xray feature gate | `npm run test:xray-feature-gate` | **16 scenarios / 0 failures / 13 matrix rows** |
| Fast PR spine | `scripts/test-fast-pr.sh` | **green** (lockstep / skill-MCP drift / migration cite-integrity / foundation-order / eval-docs / README links all pass) |

Adversarial/negative coverage added per bead: sensitive/upstream-redacted payload whose metadata rides while the value redacts; metadata filters work without `:include-runtime-db?`; missing-key fail-closed + no-such-instance; preview-colliding long params do not false-match; canonically-equal redacted scope is not a false mismatch; live-graph freshness rollup + slice extractors + active-route render.

### Note on the fast-pr README-inventory guard

Running the full spine locally produced one transient FAIL — `README inventory ratchet` flagging `implementation/{node_modules,out}` as on-disk dirs absent from the layout map. Both are **gitignored, untracked build/dependency artifacts** present only because this worker junctioned `node_modules` and ran the release-build gates locally; they do not exist on the CI docs job (fresh checkout, no `npm install` before that step). Re-running `python scripts/check_readme_inventories.py` after removing the local junction + `out/` returns **exit 0**. No README was touched and no real directory was added by this PR.
