### PR TITLE
docs(ep): clarify EP-0004 subscription input delivery (rf2-0f358j)

### DIFF
--- a/docs/EP/EP-0004-subscription-inputs.md
+++ b/docs/EP/EP-0004-subscription-inputs.md
@@ -244,6 +244,13 @@ It is equivalent to a constant input producer:
     (filter-items items filter)))
 ```
 
+That equivalence is about producing input query vectors. The existing static
+`:<-` handler delivery convention is preserved: a single static `:<-` input is
+delivered as the bare value, while multiple static `:<-` inputs are delivered as
+a vector. Parametric `input-fn` subscriptions are different: their computation
+function always receives a vector of resolved input values, even when the
+`input-fn` returns exactly one query vector.
+
 Use `:<-` for static inputs. Use `input-fn` only when the upstream query
 vectors need values from the outer query vector.
 
@@ -293,8 +300,9 @@ For `(subscribe [:article/page :a1])`:
    - `(input-fn [:article/page :a1])` for the parametric form.
 3. Validate that the result is a vector of query vectors.
 4. Subscribe to each input query vector in the same frame.
-5. Call the computation function with the vector of resolved input values and
-   the outer query-v.
+5. Call the computation function with the resolved input values and the outer
+   query-v. For this parametric form, the resolved input values are delivered
+   as a vector in producer order.
 6. Cache the derived node under the concrete outer query-v.
 
 The input function is not on the hot recompute path. It runs when a cache entry
@@ -488,7 +496,8 @@ v2:
 
 - Static `:<-` behavior remains unchanged.
 - Parametric input function receives the full outer query vector.
-- Vector-of-query-vectors input returns resolve to vectors of input values.
+- Parametric vector-of-query-vectors input returns resolve to vectors of input
+  values, including the single-input case.
 - Scalar returns such as `[:x :y]`, `:x`, maps, reactions, and derefables are
   rejected.
 - `compute-sub` and `subscribe-once` agree for parametric subscriptions.

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -615,7 +615,7 @@ Every subscription has one **input query-vector producer** — the thing that, a
 
 > A subscription has an input query-vector producer. Layer-1 has **no** producer (it reads `app-db` directly); `:<-` is the **literal** producer (a fixed list of input query vectors known at registration); and an `input-fn` is the **query-parametric** producer (it computes the input query vectors from the outer `query-v`).
 
-This is what `reg-sub`'s optional first function is. It is a v2 **`input-fn`**: a **pure** function from the outer subscription `query-v` to a vector of input query vectors — **not** a v1 reaction-returning signal function. The runtime resolves each returned query vector through the ordinary [§Lookup algorithm](#lookup-algorithm) in the same frame as the outer subscription, then calls the computation function with the resolved input *values* (in order) and the outer `query-v`.
+This is what `reg-sub`'s optional first function is. It is a v2 **`input-fn`**: a **pure** function from the outer subscription `query-v` to a vector of input query vectors — **not** a v1 reaction-returning signal function. The runtime resolves each returned query vector through the ordinary [§Lookup algorithm](#lookup-algorithm) in the same frame as the outer subscription, then calls the computation function with the resolved input *values* (in order) and the outer `query-v`. Input-production equivalence does not erase handler delivery shape: static `:<-` preserves the v1 convention (one input -> bare value, multiple inputs -> vector), while parametric `input-fn` subscriptions always deliver a vector of resolved input values, including the single-input case.
 
 ```clojure
 (rf/reg-sub
@@ -965,7 +965,15 @@ The per-frame **sub-cache** ([§Subscription cache invalidation](#subscription-c
         ;; entry's input topology is FIXED once materialized (the input-fn does
         ;; not re-run on recompute — fixed-topology-per-cache-entry invariant).
         r        (ratom/make-reaction
-                   (fn [] (apply body-fn (conj (mapv deref inputs) query-v))))]
+                   (fn []
+                     (let [body-arg (case (:input-kind meta)
+                                      :db         (adapter/read-container (frame-app-db frame))
+                                      :parametric (mapv deref inputs)
+                                      :static     (case (count inputs)
+                                                    0 nil
+                                                    1 @(first inputs)
+                                                    (mapv deref inputs)))]
+                       (body-fn body-arg query-v)))))]
     ;; Store the realized input QUERY-VECTORS (not the containers) so disposal,
     ;; trace, and Xray can read this entry's realized parametric edges.
     (swap! (:sub-cache frame) assoc k {:reaction r :inputs input-qs :ref-count 1})

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -336,23 +336,27 @@ compute-sub(query-v, db):
                                    ; vectors; a bad shape signals
                                    ; :rf.error/sub-input-fn-bad-return; a throw signals
                                    ; :rf.error/sub-input-fn-exception (per 009)
-  let inputs   = if reg.input-kind == :db
-                   then nil                                    ; body receives db, not inputs
-                   else map (q -> compute-sub(q, db)) input-qs
+  let values   = map (q -> compute-sub(q, db)) input-qs
+  let body-arg = match reg.input-kind:
+                   :db          -> db                          ; root sub: body reads db directly
+                   :parametric  -> vector(values)              ; always vector, even at one input
+                   :static      -> if count(values) == 0 then nil
+                                   else if count(values) == 1 then first(values)
+                                   else vector(values)          ; v1 :<- delivery convention
 
   ; Run the body with resolved input VALUES (or with db, for root subs).
-  return reg.computation-fn((if reg.input-kind == :db then db else inputs), query-v)
+  return reg.computation-fn(body-arg, query-v)
 ```
 
 Notes on the contract:
 
-- **Recursive resolution.** `compute-sub` recursively calls itself on each input `query-v`. Layered subs (`A` ← `B` ← `C`) resolve depth-first: `C` is computed first against `db`, then `B` against `[C-value]`, then `A` against `[B-value]`. Each layer's output is passed as a flat positional list to the next layer's `computation-fn`, exactly mirroring how Reagent's `make-reaction` chains compose `:<-` inputs.
+- **Recursive resolution.** `compute-sub` recursively calls itself on each input `query-v`. Layered subs (`A` ← `B` ← `C`) resolve depth-first: `C` is computed first against `db`, then `B` receives `C`'s value, then `A` receives `B`'s value. The argument shape handed to each `computation-fn` mirrors the runtime: app-db readers receive `db`; static `:<-` keeps the v1 convention (single input as a bare value, multiple inputs as a vector); parametric `input-fn` subscriptions receive a vector of resolved input values even when the vector has one element.
 - **No memoisation across calls.** `compute-sub` is a pure function over `(query-v, db)`. Implementations may memoise *within* a single call (the same input sub appearing twice in one tree is computed once and reused) but **must not** carry a cache between calls — it is not a substitute for the reactive runtime, and an `app-db` value that has changed must produce a fresh result. Per-call memoisation is an optimisation; tests must not depend on it.
 - **No cycles.** A cycle in the static `:<-` topology is a registration-time error (per [001](001-Registration.md)); `compute-sub` does not need to detect cycles at call time. If a host bypasses the registration-time check, `compute-sub` may stack-overflow — surface a structured error trace if cheap; otherwise let the host's stack overflow propagate.
 - **Errors.** If a sub's `computation-fn` throws, emit `:rf.error/sub-exception` per [009 §Error contract](009-Instrumentation.md#error-contract); default recovery `:replaced-with-default` returns `nil`. An unresolved input sub (`:rf.error/no-such-sub`) substitutes `nil` and the body still runs (default `:replaced-with-default`). For a parametric sub, an `input-fn` that throws emits `:rf.error/sub-input-fn-exception`, and an `input-fn` that returns a non-vector-of-query-vectors (a scalar, map, bare keyword, reaction, derefable, or malformed query vector) emits `:rf.error/sub-input-fn-bad-return` — both follow the same fail-loud posture (a bad input return is never silently treated as no inputs). Per [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue).
 - **Determinism.** `compute-sub` is JVM-runnable, deterministic, and free of side effects. It is the function the conformance corpus invokes for `:sub-values` assertions per [conformance/README.md](conformance/README.md).
 
-For both static `:<-` and parametric `input-fn` inputs, the resolved input *values* are passed positionally to the body (in producer order), not the input `query-v`s. The outer `query-v` (the one being computed) remains the second argument to `computation-fn`, identical to in-runtime behaviour.
+For both static `:<-` and parametric `input-fn` inputs, the body receives resolved input *values*, not input `query-v`s. Producer order is preserved. The outer `query-v` (the one being computed) remains the second argument to `computation-fn`, identical to in-runtime behaviour.
 
 For unit-testing a sub in pure isolation against a literal `db` (rare, but useful for very simple readers where the dispatch path adds no value), pass a literal map directly:
 


### PR DESCRIPTION
Clarifies EP-0004 and related specs so input query production is distinct from computation argument delivery. Static single :<- remains bare-value; parametric input-fn always delivers a vector, including one input. Checks: check_readme_links --ci; check_doc_slugs; check_ep_status_sync --self-test; check_ep_status_sync; git diff --check HEAD~1..HEAD; mkdocs build --strict.