### PR TITLE
docs: remove stale EP-0002 default-frame wording

### DIFF
--- a/skills/re-frame2/references/cross-cutting/api-cheatsheet.md
+++ b/skills/re-frame2/references/cross-cutting/api-cheatsheet.md
@@ -40,7 +40,7 @@ The `reg-event-*` metadata-map is the one **superset** middle slot — reflectio
 | `rf/frame-handle` | `()` / `(frame-id)` → `{:frame :dispatch :dispatch-sync :subscribe}` — operation bundle captured at creation; survives async |
 | `rf/frame-bound-fn` | `([args] body+)` — macro: fn that re-binds the captured frame in its body (async callbacks) |
 | `rf/frame-bound-fn*` | `(f)` / `(frame-id f)` — `*`-twin of the macro; wraps an existing fn value |
-| `rf/current-frame-id` | `()` — active frame id; `:rf/default` outside any binding |
+| `rf/current-frame-id` | `()` — active frame id; raises `:rf.error/no-frame-context` outside any frame scope |
 | `rf/app-db-value` | `(frame-id)` — value-form **app-db** partition read (plain map, no deref) |
 | `rf/runtime-db-value` | `(frame-id)` — value-form **runtime-db** partition read (framework state; tools / privileged runtime) |
 | `rf/frame-state-value` | `(frame-id)` → `{:rf.db/app … :rf.db/runtime …}` — the whole frame (SSR / epoch / tools) |
@@ -144,7 +144,7 @@ The view-tree assertion axis (commonly aliased `:as h`). Walk hiccup by `:data-t
 | `rf/get-coeffect` / `rf/assoc-coeffect` / `rf/get-effect` / `rf/assoc-effect` | inside an interceptor |
 | `rf/inject-cofx` | `(id)` / `(id value)` — cofx injector; `value` is the per-call arg passed to the cofx handler's 2-arity form |
 | `rf/path` / `rf/unwrap-interceptor` | std interceptors |
-| `rf/init!` | `(adapter-map)` — install adapter + ensure `:rf/default`. No registry. |
+| `rf/init!` | `(adapter-map)` — install adapter/runtime capabilities; creates no frame. No registry. |
 | `rf/install-adapter!` / `rf/destroy-adapter!` / `rf/current-adapter` / `rf/current-adapter-spec` | low-level adapter ops; `current-adapter` → discriminator keyword, `current-adapter-spec` → spec map |
 | `rf/clear-event` / `rf/clear-sub` / `rf/clear-fx` / `rf/clear-flow` / `rf/clear-sub-cache!` | targeted deregistration |
 | `rf/configure!` | `(:epoch-history\|:trace-buffer\|:elision opts)` — runtime knobs (`:elision` opts `{:rf.size/threshold-bytes N}`) |

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -426,10 +426,10 @@ The sibling slot lives under the shared `[:rf.runtime/elision]` runtime-db child
 
 ## Per-frame schemas
 
-`reg-app-schema` is per-frame — registered against the active frame at registration time. The public lookup APIs (`app-schemas`, `app-schema-at`) take an optional `frame-id` and default to the active frame (or `:rf/default`).
+`reg-app-schema` is per-frame — registered against the active frame at registration time. The public lookup APIs (`app-schemas`, `app-schema-at`) take an optional `frame-id`; without one they resolve the carried active frame and raise `:rf.error/no-frame-context` outside any established scope (EP-0002).
 
 ```clojure
-;; Registers against the active frame (or :rf/default when no active frame).
+;; Registers against the carried active frame; raises outside any frame scope.
 (rf/reg-app-schema [:user] UserSchema)
 
 ;; Registers explicitly against a named frame.

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -184,7 +184,7 @@ CLJS hosts that ship Reagent on the browser AND need SSR on the JVM use the appr
      ...))
 ```
 
-Per Spec 006 §Adapter selection at boot the `init!` call is idempotent — re-calling it after the adapter is installed is a no-op (modulo the `:rf/default` frame ensure step).
+Per Spec 006 §Adapter selection at boot the `init!` call is idempotent — re-calling it after the adapter is installed is a no-op. It installs the adapter/runtime capabilities only; it does not create or ensure any frame (EP-0002).
 
 ### `:platforms` metadata on `reg-fx`
 

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -343,10 +343,11 @@
      `frame-provider` scoped to the variant id, so the view's
      subscribe / dispatch (resolved via React context at render time)
      target the per-variant frame the runtime allocated. Without the
-     wrap, subscriptions fall through to `:rf/default` and every cell
-     reads the same app-db — which is why the four counter cards
-     previously rendered identically (or empty when `:rf/default`
-     carries no `:count`)."
+     wrap, subscriptions run under no carried frame and fail with
+     `:rf.error/no-frame-context` (EP-0002). Before EP-0002, this same
+     gap fell through to `:rf/default`, which is why the four counter
+     cards previously rendered identically (or empty when `:rf/default`
+     carried no `:count`)."
      [variant-id]
      (let [view-id        (variant-component-id variant-id)
            shell          @state/shell-state-atom


### PR DESCRIPTION
Summary: Sync a few stale docs/spec comments with EP-0002 carried-frame semantics. Checks: check_readme_links, check_doc_slugs, check_ep_status_sync self-test, check_ep_status_sync, git diff --check, mkdocs build --strict.