### PR TITLE
docs(EP-0007): sync resolved naming sweep items

### DIFF
--- a/docs/EP/EP-0007-one-name-per-fact.md
+++ b/docs/EP/EP-0007-one-name-per-fact.md
@@ -16,10 +16,11 @@ current instances from this review cycle: the frame stamp rode event contexts
 as both `:frame` and `:rf.frame/id`; the runtime partition is
 `:rf.db/runtime` while its children are `:rf.runtime/*`; the work-ledger draft
 carried `:work/id` and `:stale-key` as near-duplicate composite identities;
-the SSR redirect target accepts `:location` / `:url` / `:to`; the
-registration API splits into `reg-*` and `register-*` families; and "schema"
-names four different validators across the `reg-*` surface. Each instance is
-small. The class is permanent, because the project has naming *conventions*
+the SSR redirect target accepted `:location` / `:url` / `:to` before
+`rf2-vngir` pruned the retired spellings; the registration API splits into
+`reg-*` and `register-*` families; and "schema" names four different
+validators across the `reg-*` surface. Each instance is small. The class is
+permanent, because the project has naming *conventions*
 (reserved namespaces, attribute-shaped keys) but no naming *rules* for
 synonyms, layers, and carriers.
 
@@ -41,9 +42,9 @@ Three of this review cycle's findings were instances of one defect:
    beside it on every event, and ~40 internal sites consume the retired
    spelling. The rename was additive, not a rename — and EP-0002 R3's "one
    carrier, one name" is contradicted on the hot path it was written for.
-2. **The redirect synonyms (rf2-vngir).** Three accepted keys for one value —
-   deliberately widened, now permanent surface sprawl awaiting an API-freeze
-   that has no normative home.
+2. **The redirect synonyms (rf2-vngir, now pruned).** Three accepted keys for
+   one value were deliberately widened and then had to be removed by a
+   targeted follow-up once this rule named the defect class.
 3. **The work-ledger near-duplicates (PR #3703 review).** `:work/id` and
    `:stale-key` encode the same `[kind resource-key generation]` facts under
    two heads, plus the same facts denormalized as fields — three spellings of
@@ -126,14 +127,14 @@ class that dominated this review cycle.
    stated here because it is a *naming* discipline too — the projection should
    not mint a new key for the same fact.)
 
-### The sweep (current instances, each one bead-sized)
+### The sweep (review-cycle instances, each one bead-sized)
 
 | # | Instance | Resolution |
 |---|---|---|
 | 1 | `:frame` coeffect beside `:rf.frame/id` | **Done** — `rf2-1m6rf1` merged 2026-06-10 (the `:frame` coeffect dropped, internal consumers migrated); retained here as the sweep's precedent row |
 | 2 | `:rf.db/runtime` parent vs `:rf.runtime/*` children | **Keep, as a recorded rule**: `:rf.db/*` names partition *slots* of frame-state (`:rf.db/app`, `:rf.db/runtime`); `:rf.runtime/*` names *subsystem children* inside the runtime partition — globally greppable when detached from context. EP-0001 Appendix A asked for the split to be justified or aligned; this justifies it as a layer rule (rule 3) |
-| 3 | Work-ledger `:work/id` vs `:stale-key` | One identity: stale suppression keys on the work id (or EP-0003 must justify the distinction as transport-facing); the denormalized fields are declared projections (rule 4). Folded into `rf2-uh3pbx`'s notes; resolved at EP-0003 acceptance |
-| 4 | Redirect `:location`/`:url`/`:to` | Canonical key is `:location` per rule 3's vocabulary rule. **Timing is `rf2-vngir`'s standing disposition, unchanged by this EP**: a one-line "preferred spelling" docs steer may land any time; the breaking narrowing lands at API-freeze — or earlier only by explicit ruling on that bead |
+| 3 | Work-ledger `:work/id` vs `:stale-key` | **Done** — EP-0003 acceptance / Spec 016 resolved one identity: stale suppression keys on `:work/id`; the separate `:stale-key` synonym is dropped, and denormalized fields are projections (rule 4) |
+| 4 | Redirect `:location`/`:url`/`:to` | **Done** — `rf2-vngir` merged 2026-06-10. Canonical key is `:location` per rule 3's vocabulary rule; `:url` / `:to` are retired spellings rejected with `:rf.error/redirect-retired-target-key`, not compatibility aliases |
 | 5 | `reg-*` vs `register-*` families | Audit: `reg-*` = registrar-kind registrations; `register-*` = listener/side-table attachments (`register-listener!`, `register-marks!`, `register-error-listener!`). If the split is principled, record it as a rule; align any stragglers |
 | 6 | The `:schema` family | Record the map: `reg-event-*` `:schema` validates *event args*; machine `:data-schema` validates machine `:data` (EP-0005's rename — the precedent: qualify where a visible sibling creates ambiguity); `reg-app-schema` validates app-db paths; runtime-db schemas are framework-owned. One Conventions table; no renames expected beyond what EP-0005 already did |
 
@@ -147,21 +148,21 @@ class that dominated this review cycle.
 
 ## Backwards Compatibility
 
-Pre-alpha, in-repo only. Sweep item 1 is done (merged); item 4 is a breaking
-narrowing whose temporary alias window stays with `rf2-vngir`; 2, 5, 6 are
-documentation; 3 lands inside EP-0003's own pre-acceptance amendments.
+Pre-alpha, in-repo only. Sweep items 1, 3, and 4 are done: item 1 removed the
+bare `:frame` coeffect; item 3 graduated through EP-0003 / Spec 016; item 4
+pruned the redirect aliases immediately, with no compatibility window. Items
+2, 5, and 6 are documentation / convention-recording work.
 
 ## Bead Plan
 
 1. Conventions bead: add the rules + the vocabulary tables (hot-zone;
    sequential). This is the graduation bead.
 2. ~~`rf2-1m6rf1`: the frame-stamp completion~~ — **merged** (item 1 done).
-3. `rf2-vngir` (existing, parked): the redirect narrowing, on its own standing
-   timing (API-freeze, or earlier by explicit ruling); the optional
-   preferred-spelling docs steer is dispatchable any time.
+3. ~~`rf2-vngir`: the redirect narrowing~~ — **merged** (item 4 done; retired
+   spellings fail loudly and name `:location`).
 4. `reg-`/`register-` audit bead (doc-only unless stragglers found).
-5. Lint bead: retired-spelling checks for items 1 and 4 (item-1 lint can land
-   now that the rename is merged).
+5. Lint bead: retired-spelling checks for items 1 and 4 (both renames have
+   merged, so the lint can land when the no-floor check is written).
 
 ## Recommendation
 


### PR DESCRIPTION
Updates EP-0007 to reflect resolved rf2-vngir redirect pruning and EP-0003/Spec 016 work-ledger identity resolution. Checks: check_readme_links, check_doc_slugs, check_ep_status_sync self-test and normal, git diff --check, mkdocs strict.