### PR TITLE
docs(EP-0009): clarify proposal authority (rf2-w574vy)

### DIFF
--- a/docs/EP/EP-0009-the-ep-process.md
+++ b/docs/EP/EP-0009-the-ep-process.md
@@ -87,10 +87,13 @@ The `Status:` line is machine-readable. Its value MUST be one of:
 `deferred`, or `superseded-by EP-NNNN`.
 
 - **proposal** — under discussion. Normative-voiced text is permitted (it makes
-  graduation a move, not a rewrite) but binds nothing; nothing may implement a
-  proposal.
+  graduation a move, not a rewrite) but binds nothing; the proposal itself is
+  not implementation authority. Independently settled work may still land by
+  bead/spec/operator ruling and be recorded in the proposal as evidence or an
+  already-resolved dependency, but any decision that relies on the EP waits for
+  acceptance.
 - **accepted** — ruled by the operator; graduation into the normative home +
-  beads begins. Implementation may start.
+  beads begins. EP-authorized implementation may start.
 - **final / active** — graduated. The named normative home is now
   authoritative: for standards-track that is `spec/`, and **where the EP body
   and the spec differ, the spec governs** (the EP-0002 precedent); for process


### PR DESCRIPTION
Review finding: EP-0009 said nothing may implement a proposal, but the current EP corpus has proposal-tier documents recording independently settled bead/spec/operator work. This clarifies that proposals are non-authoritative while allowing independently ruled work to land and be recorded. Checks run locally: python scripts/check_readme_links.py --ci; python scripts/check_doc_slugs.py; python scripts/check_ep_status_sync.py --self-test; python scripts/check_ep_status_sync.py; git diff --check; python -m mkdocs build --strict.