### PR TITLE
fix(resources): mutation target validation + invalidation ordering + serializable ids (mutations cluster)

### DIFF
--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -138,7 +138,15 @@
   no entry / no data is a no-op (a patch transforms existing data; populate
   seeds). Per EP-0003 §Mutations (controlled resource patch APIs)."
   [runtime-db patches-fn params result clock-ms]
-  (if-let [patches (when patches-fn (patches-fn params result))]
+  (if-let [patches (when patches-fn
+                     ;; rf2-3yyaur — validate + canonicalize EVERY patch target
+                     ;; scoped key BEFORE any cache mutation (fail-closed: one
+                     ;; bad target rejects the whole patch arm, never a partial
+                     ;; write). Re-keys by the canonical scoped key so the
+                     ;; write lands under the canonical identity.
+                     (mstate/validate-target-map!
+                       (patches-fn params result) registry/resource-meta
+                       :patches 'rf.mutation.internal/succeeded))]
     (reduce-kv
       (fn [[db ks policies] scoped-key patch-fn]
         (let [entry (get-in db (state/entry-path scoped-key))]
@@ -165,7 +173,14 @@
   invalidation can reach it). Returns `[runtime-db' affected-keys]`. Per
   EP-0003 §Mutations (controlled resource populate APIs)."
   [runtime-db populates-fn params result clock-ms]
-  (if-let [populates (when populates-fn (populates-fn params result))]
+  (if-let [populates (when populates-fn
+                       ;; rf2-3yyaur — validate + canonicalize EVERY populate
+                       ;; target scoped key BEFORE any cache mutation
+                       ;; (fail-closed: one bad target rejects the whole
+                       ;; populate arm, never a partial write).
+                       (mstate/validate-target-map!
+                         (populates-fn params result) registry/resource-meta
+                         :populates 'rf.mutation.internal/succeeded))]
     (reduce-kv
       (fn [[db ks policies] scoped-key value]
         (let [[_scope resource-id rparams] scoped-key
@@ -228,6 +243,12 @@
         spec       (mreg/require-mutation-spec! mutation where)
         cparams    (mreg/validate+canonicalize-params mutation spec params where)
         cscope     (mreg/resolve-scope mutation spec scope)
+        ;; rf2-e8wj5t — reject a non-serializable caller-supplied instance id
+        ;; BEFORE any runtime-db / work-ledger write or HTTP lowering (the
+        ;; instance id is durable + trace-visible + epoch-restore-safe). A nil
+        ;; instance falls through to the generated id (serializable by
+        ;; construction).
+        _          (mstate/validate-instance-id! instance where)
         generation (state/next-generation gen-snapshot)
         instance-id (mint-instance-id mutation instance generation)
         ;; the work-id reuses the resource work-id shape, but keyed by the
@@ -290,12 +311,20 @@
                   :work-id work-id :generation generation :scope cscope
                   :cause cause :invalidate-timing invalidate-timing})
     {:rf.db/runtime rdb'
+     ;; rf2-agrjvk — `:before-request` invalidation must precede the request
+     ;; being lowered to transport. fx run in order, so the invalidation
+     ;; dispatch is placed BEFORE `lower-fx` (not appended after it). The
+     ;; generation commit + work-handle record stay first (they establish the
+     ;; stale-suppression identity the lowered request rides); the invalidation
+     ;; then fires; only THEN does the write lower. Without the reorder the
+     ;; contract ("before-request invalidation happens before the request is
+     ;; lowered") was violated — the request lowered first.
      :fx (cond-> [[:rf.resource/commit-generation {:value generation}]
                   [:rf.resource/record-work-handle
                    {:frame-id frame-id :work-id work-id
-                    :transport transport-id :request-id request-id}]
-                  lower-fx]
-           before-fx (conj before-fx))}))
+                    :transport transport-id :request-id request-id}]]
+           before-fx (conj before-fx)
+           true      (conj lower-fx))}))
 
 ;; ---- :rf.mutation/clear — causal instance reset ---------------------------
 

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -285,3 +285,194 @@
            :stale-at       stale-at
            :invalidated-at nil
            :tags           (or tags (:tags base) #{}))))
+
+;; ---- fail-closed boundary validation (Spec 016 §Resource identity / -------
+;;       EP-0003 §Mutations)
+;;
+;; Mutation runtime state is durable and trace-visible, so the identities it
+;; writes — the mutation INSTANCE id and the patch / populate TARGET scoped
+;; keys — must follow the SAME serializable-EDN discipline the resource cache
+;; key and the resource params already enforce (`state/serializable-edn?` /
+;; `state/reject-non-edn!`). These predicates / validators are PURE so they
+;; sit in the runtime layer (this namespace, the home of the instance shape +
+;; the controlled patch / populate transition); the impure handler boundary
+;; (`mutation-events`) CALLS them before any runtime-db / work-ledger write or
+;; HTTP lowering, so an invalid identity fails CLOSED — before any partial
+;; cache mutation. Resource-registration lookup is injected as a predicate
+;; (`registered-resource?`) so the runtime stays free of a registry require.
+
+(def reserved-scope-ns
+  "The framework-reserved scope namespace (`:rf.scope/*`, per Conventions
+  §Reserved namespaces). A BARE keyword in this namespace is a CLOSED reserved
+  enum (`reserved-scope-policies`); any other `:rf.scope/*` bare keyword is a
+  TYPO, not a literal scope (mirrors `registry`'s reserved-scope gate). A
+  non-keyword scope VALUE (`[:rf.scope/session {…}]` tuple, a map, a string)
+  is NOT in the bare-keyword reserved slot."
+  "rf.scope")
+
+(def reserved-scope-policies
+  "The closed reserved bare-keyword scope-policy enum (mirrors `registry`).
+  A canonicalized scoped key may carry a literal SCOPE that is one of these
+  reserved policies (`:rf.scope/global` is a legitimate literal scope), an
+  app-namespaced keyword, or a data-value (tuple / map / string). Any OTHER
+  bare `:rf.scope/*` keyword is a typo and rejected."
+  #{:rf.scope/global :rf.scope/from-caller})
+
+(defn reserved-scope-typo?
+  "True iff `scope` is a BARE keyword in the framework-reserved `:rf.scope/*`
+  namespace that is NOT one of the closed `reserved-scope-policies` — i.e. a
+  typo (`:rf.scope/glabal`) that must NOT be silently accepted as a literal
+  scope (which would write the cache under a wrong scope). Mirrors the
+  fail-closed reserved-namespace gate `registry/valid-scope-policy?` applies
+  at resource registration. A non-keyword scope value is never a typo."
+  [scope]
+  (and (keyword? scope)
+       (= reserved-scope-ns (namespace scope))
+       (not (contains? reserved-scope-policies scope))))
+
+(defn target-key-error
+  "Build the canonical thrown-error shape (Spec 009 §The thrown-error shape)
+  for an invalid mutation patch / populate TARGET scoped key. `arm`
+  (`:patches` | `:populates`) names the offending mutation-spec arm."
+  [where arm reason target extra]
+  (ex-info ":rf.error/mutation-invalid-target"
+           (merge {:rf.error/id :rf.error/mutation-invalid-target
+                   :where       where
+                   :arm         arm
+                   :recovery    :fix-mutation-target
+                   :reason      reason
+                   :target      (pr-str target)}
+                  extra)))
+
+(defn validate-target-key!
+  "Fail-closed validation of a SINGLE mutation patch / populate TARGET scoped
+  key, BEFORE any cache mutation (EP-0003 §Mutations / Spec 016 §Resource
+  identity). A target key is the canonical scoped resource key
+  `[scope resource-id params]` — the SAME shape `state/scoped-resource-key`
+  produces and the read path writes under. Rejects, loudly:
+
+  - a malformed key (not a 3-element `[scope resource-id params]` vector);
+  - a non-keyword `resource-id`;
+  - an UNREGISTERED resource id (`registered-resource?` returns falsey) — a
+    patch / populate must target a resource the read path also knows, or the
+    seeded / patched entry is unreachable by any subscription;
+  - a reserved-scope TYPO (a bare `:rf.scope/*` keyword outside the closed
+    enum — `:rf.scope/glabal`), which would silently write under a wrong
+    scope;
+  - a non-EDN / host scope or params (the cache key MUST be serializable EDN —
+    the same boundary `state/reject-non-edn!` enforces for resource params).
+
+  `registered-resource?` is `(fn [resource-id] -> truthy)` — the injected
+  registry-lookup predicate (so this PURE validator carries no registry
+  require). `where` names the call-site public surface; `arm`
+  (`:patches` | `:populates`) names the offending mutation-spec arm. Returns
+  the CANONICALIZED scoped key `[canonical-scope resource-id canonical-params]`
+  on success (so the caller writes under the canonical identity, never a
+  caller's alternate spelling). Throws `:rf.error/mutation-invalid-target`
+  otherwise."
+  [target registered-resource? where arm]
+  (when-not (and (vector? target) (= 3 (count target)))
+    (throw (target-key-error
+             where arm
+             (str "a mutation " (name arm) " target must be a canonical "
+                  "scoped resource key [scope resource-id params] (a "
+                  "3-element vector); got " (pr-str target) ". Per EP-0003 "
+                  "§Mutations / Spec 016 §Resource identity.")
+             target {})))
+  (let [[scope resource-id params] target]
+    (when-not (keyword? resource-id)
+      (throw (target-key-error
+               where arm
+               (str "a mutation " (name arm) " target's resource id must be "
+                    "a keyword; got " (pr-str resource-id) ".")
+               target {:resource-id resource-id})))
+    (when (reserved-scope-typo? scope)
+      (throw (target-key-error
+               where arm
+               (str "a mutation " (name arm) " target carries the bare "
+                    "framework-reserved scope " (pr-str scope) ", which is "
+                    "not one of the closed reserved policies "
+                    (pr-str reserved-scope-policies) " — a typo would "
+                    "silently write the cache under a wrong scope. Per "
+                    "Conventions §Reserved namespaces.")
+               target {:scope scope})))
+    (when-not (state/serializable-edn? scope)
+      (throw (target-key-error
+               where arm
+               (str "a mutation " (name arm) " target's scope is not "
+                    "serializable EDN — host / opaque values are rejected at "
+                    "the cache-key boundary. Per Spec 016 §Resource identity.")
+               target {:scope (pr-str scope)})))
+    (when-not (state/serializable-edn? params)
+      (throw (target-key-error
+               where arm
+               (str "a mutation " (name arm) " target's params are not "
+                    "serializable EDN — host / opaque values are rejected at "
+                    "the cache-key boundary. Per Spec 016 §Resource identity.")
+               target {:params (pr-str params)})))
+    (when-not (registered-resource? resource-id)
+      (throw (target-key-error
+               where arm
+               (str "a mutation " (name arm) " targets the UNREGISTERED "
+                    "resource " (pr-str resource-id) " — a controlled patch / "
+                    "populate must target a resource the read path also "
+                    "knows, or the seeded / patched entry is unreachable by "
+                    "any subscription. Call rf/reg-resource first. Per "
+                    "EP-0003 §Mutations.")
+               target {:resource-id resource-id})))
+    (state/scoped-resource-key scope resource-id params)))
+
+(defn validate-target-map!
+  "Fail-closed validation + canonicalization of a WHOLE mutation `:patches` /
+  `:populates` target map `{scoped-key value}` BEFORE any cache mutation
+  (EP-0003 §Mutations). Validates EVERY target key via `validate-target-key!`
+  (so one bad target rejects the whole success-time patch / populate — no
+  partial cache mutation) and returns a NEW map re-keyed by the CANONICAL
+  scoped key, values preserved. `kind` (`:patches` | `:populates`) names the
+  offending arm in the error. A nil / empty map returns itself."
+  [target-map registered-resource? kind where]
+  (when (seq target-map)
+    (reduce-kv
+      (fn [m target value]
+        (assoc m (validate-target-key! target registered-resource? where kind) value))
+      {}
+      target-map)))
+
+;; ---- mutation INSTANCE id validation (Spec 016 §Resource identity) --------
+
+(defn instance-id-error
+  "Build the canonical thrown-error shape (Spec 009 §The thrown-error shape)
+  for a non-serializable mutation INSTANCE id."
+  [instance-id where]
+  (ex-info ":rf.error/mutation-non-serializable-instance-id"
+           {:rf.error/id :rf.error/mutation-non-serializable-instance-id
+            :where       where
+            :recovery    :fix-instance-id
+            :reason      (str "a mutation instance id must be serializable EDN "
+                              "(a scalar — keyword / string / number — or an "
+                              "EDN collection recursively built from such); got "
+                              (pr-str instance-id) ". The instance id is stored "
+                              "in runtime-db, the work-ledger work id, and the "
+                              "reply payloads — all durable + trace-visible + "
+                              "epoch / restore-safe — so it follows the same "
+                              "serializable-identity discipline as resource "
+                              "params and scopes. Host / opaque values "
+                              "(functions, promises, dates, DOM nodes, "
+                              "AbortControllers, JS objects, atoms) are "
+                              "rejected. Per EP-0003 §Mutations / Spec 016 "
+                              "§Resource identity.")
+            :instance-id (pr-str instance-id)}))
+
+(defn validate-instance-id!
+  "Fail-closed: reject a non-serializable mutation INSTANCE id BEFORE it is
+  stored in runtime-db / the work-ledger work id / the reply payloads (all
+  durable + trace-visible + epoch-restore-safe), mirroring the resource
+  params / scope EDN discipline. A caller MAY supply nil (the events layer
+  then mints a generated id) — nil passes here; the GENERATED id is itself
+  serializable by construction. Returns `instance-id` unchanged when it
+  conforms; throws `:rf.error/mutation-non-serializable-instance-id`
+  otherwise. Per EP-0003 §Mutations."
+  [instance-id where]
+  (when (and (some? instance-id) (not (state/serializable-edn? instance-id)))
+    (throw (instance-id-error instance-id where)))
+  instance-id)

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -36,6 +36,7 @@
    [re-frame.resources]
    [re-frame.resources.state :as state]
    [re-frame.resources.mutation-runtime :as mstate]
+   [re-frame.resources.mutation-events :as mevents]
    [re-frame.resources.mutation-registry :as mreg]
    [re-frame.resources.timers :as timers]
    [re-frame.resources.test-support]
@@ -528,3 +529,237 @@
           (mreg/validate+canonicalize-params
             :m/save (rf/mutation-meta :m/save) {:slug "w" :cb (fn [])}
             'test)))))
+
+;; ===========================================================================
+;; 11. rf2-3yyaur — patch / populate TARGET scoped key validation (fail-closed)
+;; ===========================================================================
+
+(defn- article-resource-spec []
+  {:scope :rf.scope/global
+   :params-schema [:map [:slug :string]]
+   :request (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}})
+   :tags (fn [{:keys [slug]} _] #{[:article slug]})})
+
+;; The validation boundary itself is asserted via DIRECT calls (the
+;; re-frame event loop catches a handler throw and surfaces it as
+;; :rf.error/handler-exception rather than rethrowing to dispatch-sync's
+;; caller — so a thrown-with-msg? around dispatch never sees it; the
+;; codebase asserts validation throws at the fn boundary, exactly as
+;; `mutation-registry-rejects-non-edn-params` does, and proves the
+;; dispatch-path fail-closed behavior by OBSERVING no partial cache mutation).
+
+(deftest validate-target-key-rejects-unregistered-resource
+  ;; rf2-3yyaur — a controlled patch / populate targeting an UNREGISTERED
+  ;; resource fails CLOSED (the patched / seeded entry would be unreachable by
+  ;; any subscription).
+  (testing "an unregistered resource id is rejected"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
+          (mstate/validate-target-key!
+            [:rf.scope/global :r/never-registered {:slug "w"}]
+            (fn [_] false) 'test :patches)))))
+
+(deftest validate-target-key-rejects-malformed-key
+  ;; rf2-3yyaur — a target that is not a 3-element scoped key is rejected.
+  (testing "a 1-element key is malformed"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
+          (mstate/validate-target-key! [:r/article] (constantly true) 'test :populates))))
+  (testing "a non-vector target is malformed"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
+          (mstate/validate-target-key! :r/article (constantly true) 'test :patches))))
+  (testing "a non-keyword resource id is rejected"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
+          (mstate/validate-target-key! [:rf.scope/global "article" {}] (constantly true) 'test :patches)))))
+
+(deftest validate-target-key-rejects-reserved-scope-typo
+  ;; rf2-3yyaur — a bare framework-reserved :rf.scope/* keyword outside the
+  ;; closed enum (a typo) would silently write under a wrong scope — rejected.
+  (testing ":rf.scope/glabal (a typo) is rejected"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
+          (mstate/validate-target-key!
+            [:rf.scope/glabal :r/article {:slug "w"}] (constantly true) 'test :patches))))
+  (testing "the closed reserved policy :rf.scope/global is a legitimate literal scope"
+    (is (= [:rf.scope/global :r/article {:slug "w"}]
+           (mstate/validate-target-key!
+             [:rf.scope/global :r/article {:slug "w"}] (constantly true) 'test :patches)))))
+
+(deftest validate-target-key-rejects-non-edn-params
+  ;; rf2-3yyaur — a host value in the target's params / scope reaches the
+  ;; cache-key boundary and is rejected (the EDN discipline resource params
+  ;; follow).
+  (testing "non-EDN params rejected"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
+          (mstate/validate-target-key!
+            [:rf.scope/global :r/article {:slug "w" :cb (fn [])}] (constantly true) 'test :patches))))
+  (testing "non-EDN scope rejected"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
+          (mstate/validate-target-key!
+            [(fn []) :r/article {:slug "w"}] (constantly true) 'test :patches)))))
+
+(deftest validate-target-map-canonicalizes-and-rejects-whole-map
+  ;; rf2-3yyaur — one bad target rejects the WHOLE arm (no partial write), and
+  ;; valid targets are re-keyed by the canonical scoped key.
+  (testing "a single bad target rejects the whole map"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
+          (mstate/validate-target-map!
+            {[:rf.scope/global :r/article {:slug "w"}] :ok
+             [:rf.scope/glabal :r/article {:slug "x"}] :bad}
+            (constantly true) :patches 'test))))
+  (testing "an all-valid map is re-keyed by the canonical scoped key"
+    (is (= {[:rf.scope/global :r/article {:slug "w"}] :v}
+           (mstate/validate-target-map!
+             {[:rf.scope/global :r/article {:slug "w"}] :v}
+             (constantly true) :populates 'test))))
+  (testing "an empty / nil map returns nil (no-op arm)"
+    (is (nil? (mstate/validate-target-map! {} (constantly true) :patches 'test)))
+    (is (nil? (mstate/validate-target-map! nil (constantly true) :patches 'test)))))
+
+(deftest bad-patch-target-fails-closed-no-partial-cache-mutation
+  ;; rf2-3yyaur — end-to-end: a mutation whose :patches targets an unregistered
+  ;; resource fails on the success path BEFORE any cache mutation. The event
+  ;; loop catches the throw, so we observe the fail-closed EFFECT: the bad
+  ;; target's entry was never (partially) written, and the second VALID patch
+  ;; in the same arm also did not land (one bad target rejects the whole arm).
+  (rf/reg-resource :r/article (article-resource-spec))
+  (let [good-key (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})
+        bad-key  [:rf.scope/global :r/never-registered {:slug "w"}]]
+    (rf/reg-mutation :m/save
+                     {:params-schema [:map [:slug :string]]
+                      :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+                      :patches (fn [_p _r] {good-key (fn [old r] (merge old r))
+                                            bad-key  (fn [old _] old)})})
+    ;; seed the good entry so a (wrongly) partial patch would be observable
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :r/article :scope :rf.scope/global
+                        :params {:slug "w"} :owner [:view :a]}])
+    (reply-success! @last-managed-args {:title "old"})
+    (reset! last-managed-args nil)
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :bad1}])
+    (reply-success! @last-managed-args {:title "new"})
+    (testing "fail-closed: the good entry was NOT patched (the whole arm was rejected
+              before any cache mutation), and the unregistered key was never written"
+      (is (= {:title "old"} (:data (entry good-key))) "good entry unchanged")
+      (is (nil? (entry bad-key)) "no partial write of the bad target"))))
+
+(deftest valid-patch-target-still-applies
+  ;; rf2-3yyaur — the happy path is UNCHANGED: a well-formed, registered,
+  ;; serializable target patches normally (validation is transparent on valid
+  ;; input, and canonicalizes the key so an alternate spelling still lands).
+  (rf/reg-resource :r/article (article-resource-spec))
+  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+    (rf/reg-mutation :m/patch
+                     {:params-schema [:map [:slug :string]]
+                      :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+                      ;; target params spelled in a different key order — must
+                      ;; canonicalize to the same identity the read path stored.
+                      :patches (fn [_p _r] {[:rf.scope/global :r/article {:slug "w"}]
+                                            (fn [old result] (merge old result))})})
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :r/article :scope :rf.scope/global
+                        :params {:slug "w"} :owner [:view :a]}])
+    (reply-success! @last-managed-args {:title "old" :views 1})
+    (reset! last-managed-args nil)
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/patch :params {:slug "w"} :instance :ok1}])
+    (reply-success! @last-managed-args {:title "new"})
+    (testing "the valid patch applied to the canonical entry"
+      (is (= {:title "new" :views 1} (:data (entry rkey))))
+      (is (= [rkey] (:affected-keys (instance :ok1)))))))
+
+;; ===========================================================================
+;; 12. rf2-agrjvk — before-request invalidation PRECEDES request lowering
+;; ===========================================================================
+
+(deftest before-request-invalidation-precedes-lowering
+  ;; rf2-agrjvk — the contract says :before-request invalidation fires BEFORE
+  ;; the request is lowered to transport. Prove it on the returned :fx VECTOR
+  ;; (fx run in order): the :rf.resource/invalidate-tags dispatch must sit at a
+  ;; LOWER index than the :rf.http/managed lower fx.
+  (rf/reg-resource :r/article (article-resource-spec))
+  (rf/reg-mutation :m/save (save-article-spec {:invalidate-timing :before-request}))
+  (let [cofx   {:rf.db/runtime {} :rf.frame/id :rf/default :rf.resource/generation 0}
+        out    (mevents/execute-handler
+                 cofx [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :ord1}])
+        fx     (:fx out)
+        fx-ids (mapv first fx)
+        inv-ix (->> fx (keep-indexed (fn [i [id sub]]
+                                       (when (and (= :dispatch id)
+                                                  (= :rf.resource/invalidate-tags (first sub))) i)))
+                    first)
+        low-ix (->> fx-ids (keep-indexed (fn [i id] (when (= :rf.http/managed id) i))) first)]
+    (testing "both the invalidation dispatch and the managed-HTTP lower are present"
+      (is (some? inv-ix) "a before-request invalidation dispatch was emitted")
+      (is (some? low-ix) "the managed-HTTP request was lowered"))
+    (testing "EP-0003 §Mutations / rf2-agrjvk — invalidation is ordered BEFORE
+              the request lowering in the fx vector"
+      (is (< inv-ix low-ix)
+          (str "invalidation (index " inv-ix ") must precede lowering (index "
+               low-ix "); got fx ids " (pr-str fx-ids))))))
+
+(deftest no-before-request-invalidation-leaves-order-intact
+  ;; rf2-agrjvk — a default (:after-success) timing emits NO before-request
+  ;; dispatch; the lower fx is still present and the reorder is a no-op.
+  (rf/reg-mutation :m/save (save-article-spec)) ;; default :after-success
+  (let [cofx {:rf.db/runtime {} :rf.frame/id :rf/default :rf.resource/generation 0}
+        out  (mevents/execute-handler
+               cofx [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :ord2}])
+        fx-ids (mapv first (:fx out))]
+    (testing "no before-request invalidation dispatch is emitted on the default timing"
+      (is (not-any? (fn [[id sub]] (and (= :dispatch id)
+                                        (= :rf.resource/invalidate-tags (first sub))))
+                    (:fx out))))
+    (testing "the managed-HTTP lower fx is still present"
+      (is (some #{:rf.http/managed} fx-ids)))))
+
+;; ===========================================================================
+;; 13. rf2-e8wj5t — serializable mutation INSTANCE ids (reject host values)
+;; ===========================================================================
+
+(deftest execute-rejects-non-serializable-instance-id-fails-closed
+  ;; rf2-e8wj5t — a non-serializable caller-supplied instance id is rejected
+  ;; BEFORE any runtime-db / work-ledger write or HTTP lowering (the id is
+  ;; durable + trace-visible + epoch-restore-safe). The event loop catches the
+  ;; throw, so we observe the fail-closed EFFECT: nothing lowered to transport,
+  ;; and no instance row written. (The throw itself is asserted directly in
+  ;; `validate-instance-id-accepts-scalars-and-vectors`.)
+  (rf/reg-mutation :m/save (save-article-spec))
+  (reset! last-managed-args nil)
+  (rf/dispatch-sync [:rf.mutation/execute
+                     {:mutation :m/save :params {:slug "w"} :instance (fn [])}])
+  (testing "nothing was lowered to transport (fail-closed BEFORE the write)"
+    (is (nil? @last-managed-args)))
+  (testing "no instance row was written"
+    (is (empty? (:instances (rf/mutations {:frame :rf/default}))))))
+
+(deftest validate-instance-id-accepts-scalars-and-vectors
+  ;; rf2-e8wj5t — valid scalar / vector instance ids pass (they ARE
+  ;; epoch / restore-safe serializable EDN).
+  (testing "scalar ids pass"
+    (is (= :form/save-1 (mstate/validate-instance-id! :form/save-1 'test)))
+    (is (= "inst-7" (mstate/validate-instance-id! "inst-7" 'test)))
+    (is (= 42 (mstate/validate-instance-id! 42 'test))))
+  (testing "a vector id (e.g. a row-keyed form instance) passes"
+    (is (= [:row 7] (mstate/validate-instance-id! [:row 7] 'test))))
+  (testing "nil passes (the events layer then mints a generated id)"
+    (is (nil? (mstate/validate-instance-id! nil 'test))))
+  (testing "a host value is rejected"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"mutation-non-serializable-instance-id"
+          (mstate/validate-instance-id! (fn []) 'test)))))
+
+(deftest execute-with-valid-vector-instance-id
+  ;; rf2-e8wj5t — a vector instance id (a common row-keyed form shape) is
+  ;; accepted end-to-end and stored on the durable instance.
+  (rf/reg-mutation :m/save (save-article-spec))
+  (rf/dispatch-sync [:rf.mutation/execute
+                     {:mutation :m/save :params {:slug "w"} :instance [:row 7]}])
+  (testing "the instance is keyed + stored under the serializable vector id"
+    (let [i (instance [:row 7])]
+      (is (= :pending (:status i)))
+      (is (= [:row 7] (:instance/id i))))))


### PR DESCRIPTION
Resolves three `[resources][mutations]` correctness gaps in the mutation runtime (one worktree, one PR). All three enforce the same serializable-EDN / fail-closed discipline the resource cache key already follows.

## Beads

- **rf2-3yyaur** (P2) — validate patch/populate TARGET scoped keys. New pure validators in `mutation_runtime.cljc` (`validate-target-key!` / `validate-target-map!`) reject a malformed key, a non-keyword resource id, an UNREGISTERED resource, a reserved-scope typo (a bare `:rf.scope/*` outside the closed enum), and non-EDN scope/params. The success handler's `apply-patches` / `apply-populates` validate the WHOLE arm up-front and re-key by the canonical scoped key BEFORE any reduce — so one bad target rejects the arm with **no partial cache mutation**. `registry/resource-meta` is injected as the `registered?` predicate, so the runtime layer stays free of a registry require.
- **rf2-agrjvk** (P2) — before-request invalidation precedes request lowering. `execute-handler` previously appended the `:before-request` invalidation fx AFTER `lower-fx`; fx run in order, so the request lowered first, violating the contract. The `:fx` vector now places the invalidation dispatch BEFORE the managed-HTTP lower (`commit-generation` + `record-work-handle` stay first — they establish the stale-suppression identity the lowered request rides).
- **rf2-e8wj5t** (P2) — require serializable mutation INSTANCE ids. New `validate-instance-id!` rejects a non-serializable caller-supplied instance id BEFORE any runtime-db / work-ledger write or HTTP lowering (the id is durable + trace-visible + epoch-restore-safe). `nil` passes through to the generated id (serializable by construction).

## Design notes

- The PURE validators live in `mutation_runtime.cljc` (the home of the instance shape + the controlled patch/populate transition); the impure handler boundary `mutation_events.cljc` CALLS them. This keeps validation logic in the runtime layer and wires it in at the handler.
- **No `registry.cljc` touch.** `e8wj5t` did not require any registry edit — instance-id validation is a pure runtime-layer concern. The reserved-scope-typo gate is a small self-contained predicate in `mutation_runtime.cljc` mirroring `registry/valid-scope-policy?` (no shared private export). No merge-ordering flag needed.
- **No new public-API var.** The added vars are internal helpers in `re-frame.resources.mutation-runtime` / `.mutation-events`, not facade exports — they are not in the api-manifest generator's scanned namespace list, so the manifest drift-check is unaffected (no regeneration / classification needed).
- **Coordination note:** three other in-flight branches (docs-resources, o3d1uf-restore-mutation-reconcile, xray-resources) each REMOVE the `dangling-on-restore-error` / `pending?` / `instance-dangled` block (lines ~170-219) from `mutation_runtime.cljc`. My additions are appended AFTER `populate-entry` (untouched region), so a clean merge is expected regardless of ordering. My `mutation_events.cljc` edits are isolated to `execute-handler` + the `apply-patches`/`apply-populates` heads.

## Changed files

- `implementation/resources/src/re_frame/resources/mutation_runtime.cljc` — new validation section (target-key + instance-id validators, reserved-scope predicate).
- `implementation/resources/src/re_frame/resources/mutation_events.cljc` — call validators in `execute-handler` (instance id) + `apply-patches`/`apply-populates` (targets); reorder `:fx` so before-request invalidation precedes lowering.
- `implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc` — 12 new cases (1 require added).

## Quality gates

- `clojure -M:test` (from `implementation/resources/`): **182 tests, 638 assertions, 0 failures, 0 errors** (was 170/607 — +12 tests / +31 assertions).
- `npm run test:cljs` (from `implementation/`): **6361 tests, 22884 assertions, 0 failures, 0 errors**.
- `scripts/test-fast-pr.sh` (from root): all guards PASS except the README inventory ratchet, which flagged `node_modules` / `out` — both gitignored local build artefacts created by `npm install` + the CLJS build, NOT a source/layout change (confirmed via `git check-ignore`; would not fire on a clean CI checkout).
- API-manifest drift-check: **N/A** — no public facade export added (internal namespaces not in the generator scan list).

Adversarial/negative coverage per bead: unregistered/malformed/reserved-typo/non-EDN target keys + whole-map fail-closed + happy-path canonicalization (3yyaur); fx-order proof that invalidation index < lower index, plus default-timing no-op (agrjvk); instance-id scalar/vector/nil accept + host-value reject + end-to-end fail-closed (e8wj5t).
