### PR TITLE
fix(resources): route-resource fail-closed + blocking-slot + after semantics (routing cluster)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -583,12 +583,21 @@
   [{rt :rf.db/runtime, frame-id :rf.frame/id} [_event-id {:keys [owner]}]]
   (let [runtime-db (or rt {})
         owned      (get-in runtime-db (conj (state/owner-index-path) owner))
+        ;; rf2-l2gofj: releasing a ROUTE owner ([:route route-id nav-token])
+        ;; happens on every route leave / supersession (route-resource-plan
+        ;; dispatches it). Deterministically clear that nav-token's blocking
+        ;; slot here so a superseded token's blocking state cannot accumulate
+        ;; — reply-driven drain misses it (the owner is already gone from the
+        ;; entries, and an orphaned/aborted in-flight resource never replies).
+        rdb0       (if (and (vector? owner) (= :route (first owner)))
+                     (route/clear-blocking-slot runtime-db (nth owner 2))
+                     runtime-db)
         ;; drop the owner from each owned entry + the index
         rdb1       (-> (reduce
                          (fn [db k]
                            (update-in db (state/entry-path k)
                                       (fn [e] (when e (update e :active-owners disj owner)))))
-                         runtime-db (or owned #{}))
+                         rdb0 (or owned #{}))
                        (update-in (state/owner-index-path) dissoc owner))
         ;; for each owned entry that is still in flight, drop the owner from
         ;; the work record; collect the work ids whose owners are now empty

--- a/implementation/resources/src/re_frame/resources/route.cljc
+++ b/implementation/resources/src/re_frame/resources/route.cljc
@@ -106,6 +106,36 @@
   []
   [routing-key :current])
 
+(defn blocking-slots-map-path
+  "Runtime-db-relative path to the WHOLE per-nav-token blocking-slots map
+  (`[:rf.runtime/routing :resource-blocking]`), keyed by nav-token. Used to
+  drop a superseded token's slot wholesale (rf2-l2gofj)."
+  []
+  [routing-key :resource-blocking])
+
+(defn clear-blocking-slot
+  "Pure: dissoc the ENTIRE blocking slot for a superseded `nav-token`
+  (`[:rf.runtime/routing :resource-blocking <nav-token>]`). Returns the
+  updated runtime-db (a no-op when no slot exists). Per Spec 016 §Route
+  integration (rf2-l2gofj).
+
+  WHY this is needed even though `drain-blocking` already clears stale-token
+  slots: drain is REPLY-driven — it only fires when a route-owned resource
+  actually settles AND that resource still lists the old nav-token among its
+  `:active-owners`. On supersession the prior owner is RELEASED from every
+  entry's `:active-owners` immediately, so a subsequent reply no longer
+  carries the old token and `drain-blocking` never visits the stale slot.
+  Worse, a resource that is aborted / never replies (orphaned in-flight) on
+  supersession leaves its old-token blocking entry permanently. Clearing the
+  whole slot deterministically at the route transition (when the prior owner
+  is released) guarantees old-token blocking state cannot accumulate or be
+  mistaken for live blocking. The CURRENT nav-token's slot is never the
+  target here — only a superseded token's."
+  [runtime-db nav-token]
+  (if (contains? (get-in runtime-db (blocking-slots-map-path)) nav-token)
+    (update-in runtime-db (blocking-slots-map-path) dissoc nav-token)
+    runtime-db))
+
 ;; ---- blocking drain (Spec 016 §Route integration / §SSR wait point) -------
 ;;
 ;; The resource reply handlers call these PURE helpers when a route-owned
@@ -136,16 +166,41 @@
               (map #(nth % 2)))
         (:active-owners entry)))
 
+(defn- route-blocking-error
+  "Build the structured `:rf.error/resource-route-blocking` error for a
+  BLOCKING route resource that failed its first load. ONE source of truth
+  for both the route-slice `:error` (read by the `:rf/route` sub + Xray)
+  and the error-trace tags (rf2-u5aj91) — they MUST agree. The tags
+  conform to `ResourceRouteBlockingTags` (Spec-Schemas): `:resource-id`,
+  `:nav-token`, `:error` (the resource's first-load failure envelope),
+  `:reason`; `:category` is stamped from the operation by the trace
+  envelope. Per Spec 016 §Route integration + Spec 009 §Error catalogue."
+  [entry nav-token]
+  {:rf.error/id :rf.error/resource-route-blocking
+   :operation   :rf.error/resource-route-blocking
+   :resource-id (:resource/id entry)
+   :nav-token   nav-token
+   :recovery    :no-recovery
+   :error       (:error entry)
+   :reason      "A blocking route resource failed its first load."})
+
 (defn drain-blocking
-  "Pure: a route-owned resource `scoped-key` (with durable `entry`) just
-  SETTLED (`:settled` `:success` | `:failure`). Drop it from every
-  nav-token blocking slot it belongs to; when a slot empties for the
-  CURRENT nav-token land the route `:transition` at `:idle`; a blocking
-  FIRST-load `:failure` flips the current route's `:transition` to
-  `:error` and populates `:rf.route/error` (mirroring the `:on-match`
-  trap). A settle for a SUPERSEDED nav-token (its slot already released on
-  route leave) is a structural no-op. Returns the updated runtime-db. Per
-  Spec 016 §Route integration."
+  "A route-owned resource `scoped-key` (with durable `entry`) just SETTLED
+  (`:settled` `:success` | `:failure`). Drop it from every nav-token
+  blocking slot it belongs to; when a slot empties for the CURRENT
+  nav-token land the route `:transition` at `:idle`; a blocking FIRST-load
+  `:failure` flips the current route's `:transition` to `:error` and
+  populates `:rf.route/error` (mirroring the `:on-match` trap). A settle
+  for a SUPERSEDED nav-token (its slot already released on route leave) is
+  a structural no-op. Returns the updated runtime-db.
+
+  Pure DATA transform over runtime-db, PLUS one out-of-band observability
+  side effect: a blocking FIRST-load failure additionally emits the
+  `:rf.error/resource-route-blocking` error trace (rf2-u5aj91) so a failed
+  required server-state read is visible on the trace/error stream and in
+  Xray, not only in route state. Same emit-inside-planner discipline
+  `route-resource-plan` uses for `:rf.error/resource-route-plan`. Per Spec
+  016 §Route integration."
   [runtime-db scoped-key entry settled]
   (let [tokens       (owner-nav-tokens entry)
         current      (get-in runtime-db (conj (current-path) :nav-token))]
@@ -160,18 +215,18 @@
                 ;; only the live transition is affected; a stale token's
                 ;; drain just clears its (released) slot.
                 (not= nav-token current) db'
-                ;; blocking FIRST-load failure → route :error
+                ;; blocking FIRST-load failure → route :error + error trace
                 (and (= :failure settled) (= :error (:status entry)))
-                (-> db'
-                    (assoc-in (conj (current-path) :transition) :error)
-                    (assoc-in (conj (current-path) :error)
-                              {:rf.error/id :rf.error/resource-route-blocking
-                               :operation   :rf.error/resource-route-blocking
-                               :resource-id (:resource/id entry)
-                               :nav-token   nav-token
-                               :recovery    :no-recovery
-                               :error       (:error entry)
-                               :reason      "A blocking route resource failed its first load."}))
+                (let [err (route-blocking-error entry nav-token)]
+                  ;; rf2-u5aj91: emit the error trace alongside the route-slice
+                  ;; write — the route slice carries the structured :error AND
+                  ;; the trace/error stream sees `:rf.error/resource-route-
+                  ;; blocking` (tags conform to ResourceRouteBlockingTags).
+                  (trace/emit-error! :rf.error/resource-route-blocking
+                                     (dissoc err :rf.error/id :operation))
+                  (-> db'
+                      (assoc-in (conj (current-path) :transition) :error)
+                      (assoc-in (conj (current-path) :error) err)))
                 ;; last blocking resource settled (success, or a
                 ;; refresh-failure that kept data) → land :idle, but only
                 ;; while still mid-load (don't clobber an :error a sibling
@@ -183,64 +238,171 @@
       runtime-db
       tokens)))
 
-;; ---- plan execution (Spec 016 §Route integration) -------------------------
+;; ---- plan execution + the route-resource planning ctx seam (rf2-ac71vm) ---
+;;
+;; A route-resource `:scope` / `:when` resolver is `(fn [route ctx] …)`; the
+;; spec example (Spec 016 §Route integration) resolves session scope FROM the
+;; ctx (`(fn [_route ctx] (:current-session-scope ctx))`). The ctx is the
+;; entry context routing threads through its `:routing/on-route-entry` hook.
+;; The seam is REAL (not a placeholder): the planner fails CLOSED when a
+;; resolver needs the ctx but planning was handed no ctx (a `nil`), rather
+;; than silently feeding the resolver `nil` and letting it collapse to an
+;; empty-param / fallback-scope read.
+
+(defn- planning-error
+  "Throw the canonical route-resource PLANNING ex-info (the fail-closed
+  boundary `route-resource-plan` catches and surfaces on the route slice +
+  Xray, never a silent cache miss). `reason` explains; `extra` carries the
+  structured ex-data. Per Spec 016 §Route integration (a failed params /
+  scope resolution is a planning error, NOT a silent fallback)."
+  [reason extra]
+  (ex-info reason (merge {:rf.error/id :rf.error/resource-route-plan
+                          :reason      reason}
+                         extra)))
 
 (defn- when-passes?
   "Evaluate a route-resource entry's `:when` predicate. Absent `:when`
   passes. The predicate is `(fn [route ctx] …)`; truthy admits the
   resource. Per Spec 016 §Route integration (conditional resources use
-  `:when`, NOT sentinel nil params)."
-  [{when-fn :when} route ctx]
-  (if when-fn (boolean (when-fn route ctx)) true))
+  `:when`, NOT sentinel nil params). Fails CLOSED: a `:when` predicate that
+  THROWS is a planning error surfaced on the route slice, never a silent
+  admit/deny (rf2-ac71vm)."
+  [{when-fn :when :keys [resource]} route ctx]
+  (if when-fn
+    (try
+      (boolean (when-fn route ctx))
+      (catch #?(:clj Throwable :cljs :default) ex
+        (throw (planning-error
+                 (str "route resource " resource " :when predicate threw — "
+                      "a route/resource planning error, not a silent gate. "
+                      "Per Spec 016 §Route integration.")
+                 {:resource-id resource :recovery :fix-when :cause (ex-data ex)}))))
+    true))
 
 (defn- resolve-entry-params
-  "Resolve a route-resource entry's params via its `:params`
-  `(fn [route] …)` (or `{}` when absent). Per Spec 016 §Route
-  integration."
-  [{params-fn :params} route]
-  (if params-fn (or (params-fn route) {}) {}))
+  "Resolve a route-resource entry's params via its `:params` `(fn [route]
+  …)`. An ABSENT `:params` resolver legitimately yields `{}` (the resource
+  takes no params). A PRESENT `:params` resolver that returns `nil` is a
+  fail-closed PLANNING error — it INTENDED to compute params and could not,
+  which must NOT silently collapse to an empty-param read of a different
+  cache key (rf2-ac71vm). Per Spec 016 §Route integration."
+  [{params-fn :params :keys [resource]} route]
+  (if params-fn
+    (let [p (params-fn route)]
+      (if (nil? p)
+        (throw (planning-error
+                 (str "route resource " resource " :params resolver returned "
+                      "nil — a planning error, not a silent empty-param read. "
+                      "Gate a conditional resource with :when (NOT nil params). "
+                      "Per Spec 016 §Route integration.")
+                 {:resource-id resource :recovery :fix-params}))
+        p))
+    {}))
 
 (defn- resolve-entry-scope
-  "Resolve a route-resource entry's scope via its `:scope`
-  `(fn [route ctx] …)` resolver, or nil when the entry declares none (the
-  spec policy then governs — `resolve-scope-for-event` with no route
-  scope). Per Spec 016 §Scope resolution (precedence tier 2)."
-  [{scope-fn :scope} route ctx]
-  (when scope-fn (scope-fn route ctx)))
+  "Resolve a route-resource entry's scope via its `:scope` `(fn [route ctx]
+  …)` resolver, or nil when the entry declares NO route resolver (the spec
+  scope policy then governs — `resolve-scope-for-event` with no route
+  scope). A PRESENT `:scope` resolver that returns `nil` is a fail-closed
+  PLANNING error — it INTENDED to resolve a scope (the tenant / user / leak
+  boundary) and could not, which must NOT silently fall through to the
+  resource's spec policy or a `:rf.scope/global` read (rf2-ac71vm). Per
+  Spec 016 §Scope resolution (precedence tier 2)."
+  [{scope-fn :scope :keys [resource]} route ctx]
+  (when scope-fn
+    (let [s (scope-fn route ctx)]
+      (if (nil? s)
+        (throw (planning-error
+                 (str "route resource " resource " :scope resolver returned "
+                      "nil — a planning error, not a silent fallback to the "
+                      "resource's spec scope policy or a global read. The "
+                      "scope is the tenant / user / leak boundary and MUST "
+                      "fail closed. Per Spec 016 §Scope resolution.")
+                 {:resource-id resource :recovery :fix-scope}))
+        s))))
+
+;; ---- :after — DISPATCH-ORDER waterfall, fail-closed (rf2-xeb4l1) ----------
+;;
+;; DECISION (rf2-xeb4l1): `:after` is DISPATCH-ORDER ONLY, not a runtime
+;; data-waterfall. The route plan is a PURE synchronous planner: it resolves
+;; every entry's params + scope at route entry, BEFORE any resource can
+;; settle, so a later entry's params CANNOT depend on an earlier entry's
+;; loaded DATA (that would require re-running the plan after each settle — a
+;; different architecture, out of scope for this slice). What `:after` DOES
+;; guarantee is ENSURE-DISPATCH ORDER: a dependent entry's
+;; `:rf.resource/ensure` is dispatched AFTER every entry it names, so the
+;; dependency's fetch is kicked off first (the params themselves still come
+;; from the ROUTE, not the dependency's data). Xray reads the declared
+;; `:after` edges to show the dependency graph.
+;;
+;; This is NARROWER than the aspirational Spec 016 §Route integration wording
+;; ("when its params depend on the first resource's data"); the spec line is
+;; flagged for reconciliation to "dispatch-order" (a true data-waterfall is a
+;; deferred slice). The validation below is the part both agree on and is now
+;; FAIL-CLOSED: a missing or cyclic `:after` target is a PLANNING error (the
+;; route slice's `:error` + Xray), NOT silent degradation to declaration
+;; order — a typo'd dependency id is a real authoring bug.
 
 (defn- order-by-after
-  "Stable topological order of the admitted entries by their `:after`
+  "Stable topological order of route-resource `entries` by their `:after`
   route-local-id dependencies (Spec 016 §Route integration — `:after`
   targets route-local `:id`s, NOT resource ids; the same resource may
   appear more than once with different params/ids). Entries with no
   `:after` keep declaration order; a dependent entry sorts after every
-  local id it names. A missing / cyclic `:after` target degrades to
-  declaration order (defensive — the waterfall is advisory, not a hard
-  gate in this slice). Returns the ordered vector."
+  local id it names.
+
+  FAIL-CLOSED (rf2-xeb4l1): a `:after` target naming an id no entry
+  declares, or an `:after` cycle, throws a route-resource `planning-error`
+  (surfaced on the route slice + Xray, never silent declaration-order
+  degradation). Returns the ordered vector."
   [entries]
-  (let [local-id (fn [e] (:id e))
-        deps     (fn [e] (set (:after e)))
-        ;; iterative stable settle: emit any entry whose unmet deps are
-        ;; all already emitted (or unknown), declaration order within a
-        ;; pass. Bounded by entry count to defend against a cycle.
-        n        (count entries)]
+  (let [local-id  (fn [e] (:id e))
+        deps      (fn [e] (set (:after e)))
+        known-ids (into #{} (keep local-id) entries)
+        ;; missing-target validation: every :after id MUST name a declared
+        ;; route-local :id (the same resource may appear under several ids).
+        _ (doseq [e entries]
+            (when-let [missing (seq (remove known-ids (deps e)))]
+              (throw (planning-error
+                       (str "route resource " (:resource e) " (local id "
+                            (pr-str (local-id e)) ") declares :after " (pr-str (set missing))
+                            " — no route-local :id matches. `:after` MUST target a "
+                            "route-local :id declared on another entry. A typo'd "
+                            "dependency is a planning error, not silent ordering. "
+                            "Per Spec 016 §Route integration.")
+                       {:resource-id (:resource e) :recovery :fix-after
+                        :missing-after (vec missing) :local-id (local-id e)}))))
+        ;; iterative stable settle: emit any entry whose deps are all already
+        ;; emitted, declaration order within a pass. A pass that emits nothing
+        ;; while entries REMAIN means a cycle (every remaining dep is unmet) —
+        ;; fail closed.
+        n         (count entries)]
     (loop [remaining (vec entries)
            emitted   []
            seen-ids  #{}
            guard     0]
       (cond
         (empty? remaining) emitted
-        (> guard n)        (into emitted remaining) ;; cycle / bad ref — degrade
+        (> guard n)
+        (throw (planning-error
+                 (str "route resources have a cyclic :after dependency among "
+                      (pr-str (into #{} (keep local-id) remaining))
+                      " — a planning error, not silent declaration-order "
+                      "fallthrough. Per Spec 016 §Route integration.")
+                 {:recovery :fix-after
+                  :cycle (into #{} (keep local-id) remaining)}))
         :else
         (let [{ready true held false}
-              (group-by (fn [e]
-                          (every? (fn [d] (or (contains? seen-ids d)
-                                              ;; unknown local id — don't block
-                                              (not (some #(= d (local-id %)) entries))))
-                                  (deps e)))
+              (group-by (fn [e] (every? #(contains? seen-ids %) (deps e)))
                         remaining)]
           (if (empty? ready)
-            (into emitted remaining) ;; nothing ready (cycle) — degrade
+            (throw (planning-error
+                     (str "route resources have a cyclic :after dependency among "
+                          (pr-str (into #{} (keep local-id) remaining))
+                          " — a planning error, not silent declaration-order "
+                          "fallthrough. Per Spec 016 §Route integration.")
+                     {:recovery :fix-after
+                      :cycle (into #{} (keep local-id) remaining)}))
             (recur (vec held)
                    (into emitted ready)
                    (into seen-ids (keep local-id ready))
@@ -252,21 +414,29 @@
   params schema is a route/resource planning error visible in route state
   + Xray, NOT a silent cache miss). `ex` is the canonicalization /
   validation throw caught from the resource runtime's fail-closed
-  boundary. The error is recorded on the route slice's `:error` by
-  `commit-navigation` (visible to the `:rf/route` sub + Xray) and emitted
-  as a `:rf.error/resource-route-plan` error trace."
+  boundary — OR a `route`-side `planning-error` (nil params / nil scope /
+  a throwing `:when`, rf2-ac71vm). The error is recorded on the route
+  slice's `:error` by `commit-navigation` (visible to the `:rf/route` sub +
+  Xray) and emitted as a `:rf.error/resource-route-plan` error trace.
+
+  When the caught ex carries a route-side `planning-error` ex-data, its
+  specific `:reason` / `:recovery` are surfaced (so a nil-scope vs
+  nil-params vs invalid-params failure stays self-explaining); otherwise
+  the generic params/scope-did-not-resolve message stands."
   [route-id nav-token resource-id ex]
-  {:rf.error/id :rf.error/resource-route-plan
-   :operation   :rf.error/resource-route-plan
-   :route-id    route-id
-   :resource-id resource-id
-   :nav-token   nav-token
-   :recovery    :fix-params
-   :reason      (str "route " route-id " resource " resource-id
-                     " failed planning (params / scope did not resolve) — a "
-                     "route/resource planning error, not a silent cache miss. "
-                     "Per Spec 016 §Route integration.")
-   :cause       (ex-data ex)})
+  (let [data (ex-data ex)]
+    {:rf.error/id :rf.error/resource-route-plan
+     :operation   :rf.error/resource-route-plan
+     :route-id    route-id
+     :resource-id resource-id
+     :nav-token   nav-token
+     :recovery    (get data :recovery :fix-params)
+     :reason      (or (:reason data)
+                      (str "route " route-id " resource " resource-id
+                           " failed planning (params / scope did not resolve) — a "
+                           "route/resource planning error, not a silent cache miss. "
+                           "Per Spec 016 §Route integration."))
+     :cause       data}))
 
 (defn route-resource-plan
   "Build the resource ensure/release plan for a route's `:resources`
@@ -276,27 +446,55 @@
   scoped-key set. Per Spec 016 §Route integration.
 
   `route` is the resolved route value
-  (`{:id :params :query :fragment …}`), `ctx` the entry context (carries
-  e.g. `:current-session-scope`), `entry-ctx` carries `:nav-token`,
-  `:prev-id`, `:prev-nav-token`. Returns
-  `{:fx [...] :blocking #{<scoped-key> …}}`.
+  (`{:id :params :query :fragment …}`), `ctx` the entry context (the seam
+  routing threads through `:routing/on-route-entry`; a `:scope` / `:when`
+  resolver reads it, e.g. `(fn [_route ctx] (:current-session-scope ctx))`).
+  `entry-ctx` carries `:nav-token`, `:prev-id`, `:prev-nav-token`. Returns
+  `{:fx [...] :blocking #{<scoped-key> …} :plan-error err?}`.
 
-  Per entry: eval `:when` (a not-sentinel-nil guard); resolve scope +
-  canonical params (fail-closed — a failure is a PLANNING error, surfaced
-  on the route slice, not a silent miss); order by `:after` route-local
-  dependencies; emit `:rf.resource/ensure` with owner `[:route route-id
-  nav-token]` + cause `[:route-entry route-id nav-token]`; classify
-  blocking (recorded under the nav-token so the transition stays
-  `:loading`) vs background. `:keep-previous?` is threaded onto the
-  ensure payload so the runtime projects the previous key's data while the
-  new key first-loads. The previous route's owner token is released."
+  FAIL-CLOSED structural inputs (rf2-ac71vm): a `nil` `ctx` or a missing
+  `nav-token` is a planning bug, not a silently-defaulted read — the owner
+  token (`[:route route-id nav-token]`) IS the route's ownership identity,
+  so planning with no nav-token would mint an unreleasable owner. Both
+  throw at the boundary (a programming error in the routing↔resources seam,
+  surfaced loudly rather than swallowed).
+
+  Per entry: eval `:when` (a not-sentinel-nil guard — a falsey `:when`
+  gates the resource out, a THROWING `:when` is a planning error); resolve
+  scope + canonical params (fail-closed — a nil/invalid scope or params is
+  a PLANNING error surfaced on the route slice, NOT a silent global /
+  empty-param fallback); order by `:after` route-local dependencies (a
+  missing / cyclic target is a planning error); emit `:rf.resource/ensure`
+  with owner `[:route route-id nav-token]` + cause `[:route-entry route-id
+  nav-token]`; classify blocking (recorded under the nav-token so the
+  transition stays `:loading`) vs background. `:keep-previous?` is threaded
+  onto the ensure payload so the runtime projects the previous key's data
+  while the new key first-loads. The previous route's owner token is
+  released."
   [route ctx {:keys [nav-token prev-id prev-nav-token]}]
+  ;; rf2-ac71vm — fail closed on missing/invalid structural planning inputs.
+  ;; These are seam-contract bugs (routing must thread a ctx + nav-token),
+  ;; surfaced loudly rather than collapsing into an empty-ctx / no-owner read.
+  (when (nil? ctx)
+    (throw (planning-error
+             (str "route-resource-plan was handed a nil ctx for route "
+                  (pr-str (:id route)) " — the entry ctx seam MUST be a map "
+                  "(empty is fine; nil is a routing↔resources seam bug). A "
+                  ":scope / :when resolver reads it. Per Spec 016 §Route "
+                  "integration.")
+             {:route-id (:id route) :recovery :fix-route-integration})))
+  (when (nil? nav-token)
+    (throw (planning-error
+             (str "route-resource-plan was handed no nav-token for route "
+                  (pr-str (:id route)) " — the nav-token IS the route owner "
+                  "identity ([:route route-id nav-token]); planning without "
+                  "one would mint an unreleasable owner. Per Spec 016 §Route "
+                  "integration.")
+             {:route-id (:id route) :recovery :fix-route-integration})))
   (let [route-id  (:id route)
         resources (:resources route)
         owner     [:route route-id nav-token]
         cause     [:route-entry route-id nav-token]
-        admitted  (filterv #(when-passes? % route ctx) resources)
-        ordered   (order-by-after admitted)
         ;; release the PREVIOUS route's owner (route leave / supersession):
         ;; the resource runtime drops the owner from every entry's
         ;; :active-owners; abort-when-no-owner + stale suppression by
@@ -305,49 +503,69 @@
                               (not= [prev-id prev-nav-token] [route-id nav-token]))
                      [[:dispatch [:rf.resource/release-owner
                                   {:owner [:route prev-id prev-nav-token]}]]])
+        ;; `:after` is validated + ordered against the FULL declared set
+        ;; (route-local ids of EVERY entry, not just the `:when`-admitted
+        ;; ones) so a missing / cyclic target is a PLANNING error regardless
+        ;; of `:when` (rf2-xeb4l1). The order-by-after throw is a plan-level
+        ;; failure (no single resource id), caught here.
+        ordered-or-err
+        (try {:ordered (order-by-after resources)}
+             (catch #?(:clj Throwable :cljs :default) ex
+               (let [err (plan-error route-id nav-token nil ex)]
+                 (trace/emit-error! :rf.error/resource-route-plan err)
+                 {:plan-error err})))
         ;; reduce the ordered entries into ensure fx + the blocking set +
-        ;; the FIRST planning error (a fail-closed scope/params throw).
+        ;; the FIRST planning error (a fail-closed when / scope / params
+        ;; throw). A plan-level `:after` error (above) short-circuits the
+        ;; reduce — no entry is ensured (FIRST-error-wins, route still
+        ;; commits).
         {:keys [fx blocking plan-error]}
         (reduce
           (fn [acc entry]
             (let [resource-id (:resource entry)]
               (try
-                (let [spec       (registry/require-resource-spec!
-                                   resource-id 'rf.resource/route-entry)
-                      raw-params (resolve-entry-params entry route)
-                      route-scope (resolve-entry-scope entry route ctx)
-                      ;; fail-closed resolution: throws a PLANNING error on
-                      ;; a missing / invalid scope or non-conforming params.
-                      scope      (registry/resolve-scope-for-event
-                                   resource-id spec {:route-scope route-scope}
-                                   'rf.resource/route-entry)
-                      cparams    (registry/validate+canonicalize-params
-                                   resource-id spec raw-params
-                                   'rf.resource/route-entry)
-                      scoped-key (state/scoped-resource-key scope resource-id cparams)
-                      blocking?  (boolean (:blocking? entry))
-                      ensure-ev  [:rf.resource/ensure
-                                  (cond-> {:resource resource-id
-                                           :scope    scope
-                                           :params   cparams
-                                           :owner    owner
-                                           :cause    cause}
-                                    (:keep-previous? entry)
-                                    (assoc :keep-previous? true))]]
-                  (-> acc
-                      (update :fx conj [:dispatch ensure-ev])
-                      (cond-> blocking?
-                        (update :blocking conj scoped-key))))
+                ;; `:when` is evaluated HERE (inside the fail-closed boundary)
+                ;; so a throwing predicate is a planning error, not an escape
+                ;; (rf2-ac71vm). A falsey `:when` gates the resource out — no
+                ;; ensure, no sentinel nil params.
+                (if-not (when-passes? entry route ctx)
+                  acc
+                  (let [spec       (registry/require-resource-spec!
+                                     resource-id 'rf.resource/route-entry)
+                        raw-params (resolve-entry-params entry route)
+                        route-scope (resolve-entry-scope entry route ctx)
+                        ;; fail-closed resolution: throws a PLANNING error on
+                        ;; a missing / invalid scope or non-conforming params.
+                        scope      (registry/resolve-scope-for-event
+                                     resource-id spec {:route-scope route-scope}
+                                     'rf.resource/route-entry)
+                        cparams    (registry/validate+canonicalize-params
+                                     resource-id spec raw-params
+                                     'rf.resource/route-entry)
+                        scoped-key (state/scoped-resource-key scope resource-id cparams)
+                        blocking?  (boolean (:blocking? entry))
+                        ensure-ev  [:rf.resource/ensure
+                                    (cond-> {:resource resource-id
+                                             :scope    scope
+                                             :params   cparams
+                                             :owner    owner
+                                             :cause    cause}
+                                      (:keep-previous? entry)
+                                      (assoc :keep-previous? true))]]
+                    (-> acc
+                        (update :fx conj [:dispatch ensure-ev])
+                        (cond-> blocking?
+                          (update :blocking conj scoped-key)))))
                 (catch #?(:clj Throwable :cljs :default) ex
-                  ;; params / scope PLANNING failure — surface on the route
-                  ;; slice + Xray, never a silent cache miss. FIRST error wins
-                  ;; (mirrors the :on-match first-error-wins discipline).
+                  ;; when / params / scope PLANNING failure — surface on the
+                  ;; route slice + Xray, never a silent cache miss. FIRST error
+                  ;; wins (mirrors the :on-match first-error-wins discipline).
                   (let [err (plan-error route-id nav-token resource-id ex)]
                     (trace/emit-error! :rf.error/resource-route-plan err)
                     (cond-> acc
                       (nil? (:plan-error acc)) (assoc :plan-error err)))))))
-          {:fx [] :blocking #{} :plan-error nil}
-          ordered)]
+          {:fx [] :blocking #{} :plan-error (:plan-error ordered-or-err)}
+          (:ordered ordered-or-err))]
     (trace/emit! :rf.event :rf.resource/route-plan
                  {:route-id route-id :nav-token nav-token
                   :ensured (count fx) :blocking (vec blocking)})
@@ -373,7 +591,11 @@
   into the nav-token's blocking slot, and records `:plan-error` on the
   slice — all atomic with the commit. `entry` is the hook arg
   `{:route-meta :route-id :params :query :fragment :nav-token :prev-id
-  :prev-nav-token :ctx}`. Per Spec 016 §Route integration."
+  :prev-nav-token :ctx}`. The `:ctx` is passed through to the planner
+  UNCHANGED (no silent nil→`{}` default): an absent ctx is a routing↔
+  resources seam bug the planner fails closed on, not a silently-empty read
+  (rf2-ac71vm). Routing's `commit-navigation` always threads an (at-least-
+  empty) `:ctx`. Per Spec 016 §Route integration."
   [{:keys [route-meta route-id params query fragment nav-token
            prev-id prev-nav-token ctx]}]
   (when (or (seq (:resources route-meta)) prev-id)
@@ -382,7 +604,7 @@
                  :query     query
                  :fragment  fragment
                  :resources (:resources route-meta)}]
-      (route-resource-plan route (or ctx {})
+      (route-resource-plan route ctx
                            {:nav-token      nav-token
                             :prev-id        prev-id
                             :prev-nav-token prev-nav-token}))))

--- a/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
@@ -42,6 +42,7 @@
    [re-frame.schemas]
    [re-frame.http-managed]
    [re-frame.test-support :as core-test-support]
+   [re-frame.trace.tooling :as trace-tooling]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
 
@@ -104,6 +105,23 @@
                         :work-id      (:current-work e)
                         :generation   (:generation e)
                         :error        error}])))
+
+(defn- record-error-traces!
+  "Run `body-fn` with a trace listener installed; return the vector of every
+  `:op-type :error` trace event emitted during it (capture order). The
+  listener is unregistered in a `finally`. Used by the rf2-u5aj91 +
+  rf2-ac71vm / rf2-xeb4l1 planning-error assertions (the structured error
+  must reach the trace/error stream, not only route state)."
+  [body-fn]
+  (let [seen (atom [])
+        k    ::route-error-recorder]
+    (trace-tooling/register-listener!
+      k (fn [ev] (when (= :error (:op-type ev)) (swap! seen conj ev))))
+    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    @seen))
+
+(defn- errors-of [traces op]
+  (filterv #(= op (:operation %)) traces))
 
 ;; ===========================================================================
 ;; 1. Accepted-key extension
@@ -360,3 +378,252 @@
     (testing "previous data does NOT pollute the new key's cache entry or tags"
       (is (nil? (:data (entry k2))) "the new entry's :data is NOT the previous data")
       (is (empty? (:tags (entry k2))) "the new entry borrows none of the prior key's tags"))))
+
+;; ===========================================================================
+;; 10. rf2-u5aj91 — a blocking first-load failure ALSO emits an error trace
+;; ===========================================================================
+
+(deftest blocking-first-load-failure-emits-error-trace
+  ;; The route slice already carries the structured :error (section 4); this
+  ;; proves the SAME failure is ALSO published on the trace/error stream as
+  ;; `:rf.error/resource-route-blocking` with ResourceRouteBlockingTags shape.
+  (rf/reg-resource :article/by-slug (article-spec {}))
+  (rf/reg-route :route/article
+                {:path      "/articles/:slug"
+                 :params    [:map [:slug :string]]
+                 :resources [{:resource  :article/by-slug
+                              :params    (fn [route] {:slug (get-in route [:params :slug])})
+                              :blocking? true}]})
+  (rf/dispatch-sync [:rf.route/navigate :route/article {:slug "intro"}])
+  (let [scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})
+        nav-token  (:nav-token (slice))
+        traces     (record-error-traces!
+                     #(settle-failure! scoped-key {:status 503 :message "upstream down"}))
+        evs        (errors-of traces :rf.error/resource-route-blocking)]
+    (testing "exactly one :rf.error/resource-route-blocking error trace is emitted"
+      (is (= 1 (count evs)) "one blocking-failure error trace on the stream"))
+    (testing "the error-trace tags conform to ResourceRouteBlockingTags"
+      (let [ev   (first evs)
+            tags (:tags ev)]
+        (is (= :error (:op-type ev)) "it rides the error channel")
+        (is (= :rf.error/resource-route-blocking (:category tags))
+            ":category is stamped from the operation")
+        (is (= :article/by-slug (:resource-id tags)) ":resource-id tag present")
+        (is (= nav-token (:nav-token tags)) ":nav-token tag present")
+        (is (= {:status 503 :message "upstream down"} (:error tags))
+            ":error carries the resource's first-load failure envelope")
+        (is (string? (:reason tags)) ":reason present")))
+    (testing "route state STILL carries the structured error (both surfaces)"
+      (is (= :error (:transition (slice))))
+      (is (= :rf.error/resource-route-blocking (:rf.error/id (:error (slice))))))))
+
+;; ===========================================================================
+;; 11. rf2-l2gofj — superseded route-resource blocking slots are cleared
+;; ===========================================================================
+
+(deftest superseded-blocking-slot-is-cleared-on-route-leave
+  ;; A BLOCKING route resource that NEVER settles (no reply — e.g. aborted /
+  ;; orphaned in-flight on supersession) used to leave its old-nav-token
+  ;; blocking entry forever, because reply-driven drain only fires on a
+  ;; settle that still names the old owner. Leaving the route releases the
+  ;; prior owner, which MUST now deterministically clear the stale slot.
+  (rf/reg-resource :article/by-slug (article-spec {}))
+  (rf/reg-route :route/article
+                {:path      "/articles/:slug"
+                 :params    [:map [:slug :string]]
+                 :resources [{:resource  :article/by-slug
+                              :params    (fn [route] {:slug (get-in route [:params :slug])})
+                              :blocking? true}]})
+  (rf/reg-route :route/home {:path "/"})
+  (rf/dispatch-sync [:rf.route/navigate :route/article {:slug "intro"}])
+  (let [token-1    (:nav-token (slice))
+        scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
+    (testing "the blocking slot is populated on entry (resource never settles)"
+      (is (contains? (blocking-slot token-1) scoped-key)))
+    ;; leave WITHOUT the blocking resource ever settling
+    (rf/dispatch-sync [:rf.route/navigate :route/home])
+    (testing "the superseded nav-token's blocking slot is fully cleared on leave"
+      (is (empty? (blocking-slot token-1))
+          "old-token blocking state did not accumulate / leak"))))
+
+(deftest superseded-blocking-slot-does-not-block-future-navigation
+  ;; Prove the stale slot cannot bleed into the LIVE route-blocking? predicate
+  ;; for a later navigation — old-token state must not gate new transitions.
+  (rf/reg-resource :article/by-slug (article-spec {}))
+  (rf/reg-route :route/article
+                {:path      "/articles/:slug"
+                 :params    [:map [:slug :string]]
+                 :resources [{:resource  :article/by-slug
+                              :params    (fn [route] {:slug (get-in route [:params :slug])})
+                              :blocking? true}]})
+  ;; a plain (no-resources) route — its entry has nothing blocking
+  (rf/reg-route :route/home {:path "/"})
+  (rf/dispatch-sync [:rf.route/navigate :route/article {:slug "a"}])
+  (let [token-1 (:nav-token (slice))]
+    ;; supersede WITHOUT settling — then land on the plain route
+    (rf/dispatch-sync [:rf.route/navigate :route/home])
+    (let [token-2 (:nav-token (slice))]
+      (testing "the plain route lands :idle — the stale token's slot does not block it"
+        (is (not= token-1 token-2) "a new nav-token was minted")
+        (is (= :idle (:transition (slice)))
+            "the plain route is :idle; superseded blocking state is gone")
+        (is (empty? (blocking-slot token-1)) "stale slot cleared")
+        (is (false? (route/route-blocking? (rf/runtime-db-value :rf/default)))
+            "route-blocking? is false for the live token")))))
+
+;; ===========================================================================
+;; 12. rf2-ac71vm — fail-closed ctx + nil planning inputs
+;; ===========================================================================
+
+(deftest scope-resolved-from-ctx-uses-the-ctx-seam
+  ;; The ctx seam is REAL: a :scope resolver reads (:current-session-scope ctx)
+  ;; and the resolved scope is used as the cache scope (not a global fallback).
+  (rf/reg-resource :secret/doc (article-spec {:scope :rf.scope/from-caller}))
+  (let [plan (route/route-resource-plan
+               {:id :route/secret :params {:slug "x"}
+                :resources [{:resource :secret/doc
+                             :params   (fn [route] {:slug (get-in route [:params :slug])})
+                             :scope    (fn [_route ctx] (:current-session-scope ctx))}]}
+               {:current-session-scope {:tenant "acme" :user 7}}
+               {:nav-token 1 :prev-id nil :prev-nav-token nil})]
+    (testing "the ctx-resolved session scope is threaded into the ensure"
+      (is (nil? (:plan-error plan)) "no planning error — the ctx resolved a scope")
+      (let [ensure (->> (:fx plan)
+                        (some (fn [[fx-id ev]] (when (= :dispatch fx-id) ev))))]
+        (is (= :rf.resource/ensure (first ensure)))
+        (is (= {:tenant "acme" :user 7} (:scope (second ensure)))
+            "the cache scope came from ctx, NOT a global / spec fallback")))))
+
+(deftest nil-ctx-fails-closed
+  ;; A nil ctx (a routing↔resources seam bug) must throw — not silently
+  ;; proceed with an empty ctx that a session-scope resolver would read as nil.
+  (rf/reg-resource :secret/doc (article-spec {:scope :rf.scope/from-caller}))
+  (testing "route-resource-plan throws on a nil ctx"
+    (is (thrown? #?(:clj Throwable :cljs :default)
+                 (route/route-resource-plan
+                   {:id :route/secret :resources []}
+                   nil
+                   {:nav-token 1})))))
+
+(deftest missing-nav-token-fails-closed
+  ;; The nav-token IS the route owner identity; planning without one would
+  ;; mint an unreleasable owner — fail closed.
+  (testing "route-resource-plan throws on a missing nav-token"
+    (is (thrown? #?(:clj Throwable :cljs :default)
+                 (route/route-resource-plan
+                   {:id :route/x :resources []}
+                   {}
+                   {:nav-token nil})))))
+
+(deftest nil-params-resolver-is-a-planning-error
+  ;; A PRESENT :params resolver returning nil is NOT a silent empty-param read
+  ;; — it is a fail-closed planning error (conditional resources use :when).
+  (rf/reg-resource :article/by-slug (article-spec {}))
+  (rf/reg-route :route/article
+                {:path      "/articles/:slug"
+                 :params    [:map [:slug :string]]
+                 :resources [{:resource :article/by-slug
+                              ;; resolver INTENDS params but returns nil
+                              :params   (fn [_route] nil)}]})
+  (let [traces (record-error-traces!
+                 #(rf/dispatch-sync [:rf.route/navigate :route/article {:slug "x"}]))]
+    (testing "the nil-params resolver surfaces a route planning error"
+      (is (= :rf.error/resource-route-plan (:rf.error/id (:error (slice))))
+          "route slice carries the planning error, not a silent empty-param read")
+      (is (= :fix-params (:recovery (:error (slice)))) "carries :fix-params recovery")
+      (is (seq (errors-of traces :rf.error/resource-route-plan))
+          "the planning error is ALSO on the trace/error stream")
+      (is (empty? (entries)) "no entry was ensured for the unplannable resource"))))
+
+(deftest nil-scope-resolver-is-a-planning-error
+  ;; A PRESENT :scope resolver returning nil must NOT silently fall through to
+  ;; the spec policy / a global read — the scope is the leak boundary.
+  (rf/reg-resource :secret/doc (article-spec {:scope :rf.scope/from-caller}))
+  (rf/reg-route :route/secret
+                {:path      "/secret/:slug"
+                 :params    [:map [:slug :string]]
+                 :resources [{:resource :secret/doc
+                              :params   (fn [route] {:slug (get-in route [:params :slug])})
+                              :scope    (fn [_route _ctx] nil)}]})  ;; resolver returns nil
+  (rf/dispatch-sync [:rf.route/navigate :route/secret {:slug "x"}])
+  (testing "a nil :scope resolver result is a fail-closed planning error"
+    (is (= :rf.error/resource-route-plan (:rf.error/id (:error (slice))))
+        "no silent fallback to spec scope / global read")
+    (is (= :fix-scope (:recovery (:error (slice)))) "carries :fix-scope recovery")
+    (is (empty? (entries)) "no entry was ensured")))
+
+(deftest throwing-when-predicate-is-a-planning-error
+  ;; A :when predicate that THROWS must be a planning error caught at the
+  ;; fail-closed boundary, not an escape that crashes the whole commit.
+  (rf/reg-resource :article/by-slug (article-spec {}))
+  (rf/reg-route :route/article
+                {:path      "/articles/:slug"
+                 :params    [:map [:slug :string]]
+                 :resources [{:resource :article/by-slug
+                              :params   (fn [route] {:slug (get-in route [:params :slug])})
+                              :when     (fn [_route _ctx] (throw (ex-info "boom" {})))}]})
+  (rf/dispatch-sync [:rf.route/navigate :route/article {:slug "x"}])
+  (testing "a throwing :when is a route planning error"
+    (is (= :rf.error/resource-route-plan (:rf.error/id (:error (slice)))))
+    (is (= :fix-when (:recovery (:error (slice)))) "carries :fix-when recovery")
+    (is (empty? (entries)) "no entry was ensured")))
+
+;; ===========================================================================
+;; 13. rf2-xeb4l1 — :after is dispatch-order, fail-closed on missing/cyclic
+;; ===========================================================================
+
+(deftest after-missing-target-is-a-planning-error
+  ;; :after naming an id no entry declares is a typo'd dependency — a
+  ;; planning error, NOT silent declaration-order fallthrough.
+  (rf/reg-resource :comments/list (article-spec {}))
+  (rf/reg-route :route/article
+                {:path      "/articles/:slug"
+                 :params    [:map [:slug :string]]
+                 :resources [{:resource :comments/list
+                              :id       :comments
+                              :params   (fn [route] {:slug (get-in route [:params :slug])})
+                              :after    #{:nope}}]})  ;; :nope is declared by no entry
+  (let [traces (record-error-traces!
+                 #(rf/dispatch-sync [:rf.route/navigate :route/article {:slug "x"}]))]
+    (testing "a missing :after target surfaces a planning error"
+      (is (= :rf.error/resource-route-plan (:rf.error/id (:error (slice)))))
+      (is (= :fix-after (:recovery (:error (slice)))) "carries :fix-after recovery")
+      (is (seq (errors-of traces :rf.error/resource-route-plan))
+          "also on the trace/error stream")
+      (is (empty? (entries)) "no entry ensured — the plan failed closed"))))
+
+(deftest after-cycle-is-a-planning-error
+  ;; A cyclic :after dependency degrades NEITHER silently nor into an infinite
+  ;; loop — it is a fail-closed planning error.
+  (rf/reg-resource :a/res (article-spec {}))
+  (rf/reg-resource :b/res (article-spec {}))
+  (rf/reg-route :route/cyc
+                {:path      "/cyc"
+                 :resources [{:resource :a/res :id :a :params (fn [_] {:slug "a"}) :after #{:b}}
+                             {:resource :b/res :id :b :params (fn [_] {:slug "b"}) :after #{:a}}]})
+  (rf/dispatch-sync [:rf.route/navigate :route/cyc])
+  (testing "a cyclic :after is a planning error (no hang, no silent fallthrough)"
+    (is (= :rf.error/resource-route-plan (:rf.error/id (:error (slice)))))
+    (is (= :fix-after (:recovery (:error (slice)))))
+    (is (empty? (entries)) "no entry ensured")))
+
+(deftest after-orders-multiple-deps-by-local-id
+  ;; The kept dispatch-order semantics: a dependent's ensure is dispatched
+  ;; AFTER every id it names (a 3-node chain, declared out of order).
+  (let [order (atom [])]
+    (rf/reg-resource :a/res (article-spec {:request (fn [_ _] (swap! order conj :a)
+                                                      {:request {:method :get :url "/a"}})}))
+    (rf/reg-resource :b/res (article-spec {:request (fn [_ _] (swap! order conj :b)
+                                                      {:request {:method :get :url "/b"}})}))
+    (rf/reg-resource :c/res (article-spec {:request (fn [_ _] (swap! order conj :c)
+                                                      {:request {:method :get :url "/c"}})}))
+    (rf/reg-route :route/chain
+                  {:path "/chain"
+                   ;; declared c, a, b — :after must reorder to a → b → c
+                   :resources [{:resource :c/res :id :c :params (fn [_] {:slug "c"}) :after #{:b}}
+                               {:resource :a/res :id :a :params (fn [_] {:slug "a"})}
+                               {:resource :b/res :id :b :params (fn [_] {:slug "b"}) :after #{:a}}]})
+    (rf/dispatch-sync [:rf.route/navigate :route/chain])
+    (testing ":after topologically orders the ensure dispatches by local id"
+      (is (nil? (:error (slice))) "no planning error — all :after targets are valid")
+      (is (= [:a :b :c] @order) "a (no dep) → b (after a) → c (after b)"))))


### PR DESCRIPTION
Resolves four `[resources][routing]` beads on the `route.cljc` surface in one PR.

## Beads

- **rf2-ac71vm** (P2) — fail closed on route-resource ctx + nil planning inputs. `route-resource-plan` throws on a nil ctx / missing nav-token (seam-contract bugs surfaced loudly, not empty-ctx / no-owner reads); `on-route-entry-fx` passes `:ctx` through unchanged. A PRESENT `:params` resolver returning nil → planning error (`:fix-params`); a PRESENT `:scope` resolver returning nil → planning error (`:fix-scope`); a THROWING `:when` → planning error (`:fix-when`, now evaluated inside the fail-closed per-entry boundary). No silent global / empty-param fallback.
- **rf2-u5aj91** (P2) — emit `:rf.error/resource-route-blocking` on the trace/error stream when a blocking first-load resource fails (tags conform to `ResourceRouteBlockingTags`), alongside the existing route-slice `:error` write (one source-of-truth builder).
- **rf2-l2gofj** (P3) — clear superseded route-resource blocking slots. New pure `route/clear-blocking-slot`; the resources `release-owner-handler` deterministically clears a released `[:route _ nav-token]` owner's blocking slot at the route transition, so an orphaned/aborted blocking resource that never replies cannot leave stale old-token blocking state (reply-driven drain misses it).
- **rf2-xeb4l1** (P3) — narrow route-resource `:after` semantics. DECISION: `:after` is **dispatch-order only** (the pure synchronous planner cannot feed an earlier resource's loaded DATA into a later resource's params — a true data-waterfall is a deferred slice). `order-by-after` is now FAIL-CLOSED: a missing or cyclic `:after` target is a planning error (`:fix-after`), not silent declaration-order degradation.

## Shared-file edit (merge-ordering)

- `implementation/resources/events.cljc` — `release-owner-handler` gains a ~6-line route-owner blocking-slot clear (calls `route/clear-blocking-slot`). This is the only file outside `route.cljc` + tests. `state.cljc` / `registry.cljc` / `ssr.cljc` / `mutation_runtime.cljc` and the routing artefact are untouched. Sequence after any other in-flight `events.cljc`/`state.cljc` worker if conflict arises.

## Spec note

Spec 016 §Route integration (~line 648) still carries the aspirational data-waterfall wording for `:after`; flagged for the graduation worker to reconcile to "dispatch-order" (spec/016 is out of this fence).

## Quality gates

- `npm run test:cljs` (from `implementation/`): **6361 tests, 22892 assertions, 0 failures, 0 errors** (full cross-host suite; confirms the `events.cljc` change is non-regressing framework-wide).
- `clojure -M:test` (from `implementation/resources/`): **182 tests, 646 assertions, 0 failures, 0 errors** (+12 new adversarial deftests, was 170/607).
- API-manifest drift-check (`clojure -M -m re-frame.api-manifest.gen --check` from `implementation/scripts/api-manifest`): **OK — in sync (504 public vars)**. No new facade exports; the new `route` vars are internal-to-artefact.

New tests cover (≥1 negative case per bead): ctx-resolved session scope; nil ctx / missing nav-token fail-closed; nil params; nil scope; throwing `:when`; the blocking-failure error trace + `ResourceRouteBlockingTags` shape; superseded-slot clearing + non-interference with future navigation; `:after` missing-target + cycle planning errors; and a 3-node `:after` ordering chain.
