### PR TITLE
fix(resources): scope typo/validation + clear-resource disposal + param canonicalization (scope-registry cluster)

### DIFF
--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -121,10 +121,32 @@
   `:frame` introspection target `{:resource :scope :params :frame}` (Spec
   016 §Introspection), or nil when no entry exists for that scoped key in
   that frame. Per EP-0002 the frame target is carried explicitly; a
-  frameless call with no resolvable context fails closed. Resolves the
-  scoped key the same way a subscription does (canonical scope + params,
-  sub-side scope precedence, fail-closed)."
+  frameless call FAILS CLOSED (rf2-c8lgy3): an absent / nil `:frame` raises
+  the structured `:rf.error/no-frame-context` rather than passing nil through
+  to a runtime-db lookup that returns nil — a nil that is INDISTINGUISHABLE
+  from a genuinely absent entry. Resolves the scoped key the same way a
+  subscription does (canonical scope + params, sub-side scope precedence,
+  fail-closed).
+
+  Frame existence is NOT a precondition: an explicit but unknown / destroyed
+  `:frame` reads as `nil` runtime-db and returns `nil` (no entry) — the same
+  result as a live frame with no entry for the key. The fail-closed boundary
+  is the MISSING explicit target, not a vanished one; a valid explicit frame
+  lookup returns `nil` only for a genuinely absent entry."
   [{:keys [frame] :as opts}]
+  (when (nil? frame)
+    (throw (ex-info ":rf.error/no-frame-context"
+                    {:rf.error/id :rf.error/no-frame-context
+                     :where       'rf/resource-state
+                     :recovery    :pass-frame
+                     :reason      (str "resource-state requires an explicit :frame "
+                                       "introspection target. A frameless call would "
+                                       "pass nil through to the runtime-db lookup and "
+                                       "return nil — indistinguishable from a genuinely "
+                                       "absent entry. Pass {:resource … :scope … "
+                                       ":params … :frame <frame-id>}. Per Spec 016 "
+                                       "§Introspection / EP-0002.")
+                     :opts        (dissoc opts :frame)})))
   (let [scoped-key (resource-subs/resolve-scoped-key opts)
         runtime-db (frame/frame-runtime-db-value frame)]
     (get-in runtime-db (state/entry-path scoped-key))))

--- a/implementation/resources/src/re_frame/resources/mutation_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_registry.cljc
@@ -214,8 +214,17 @@
   scope requirement (it is a causal write, not a cached read with a leak
   boundary) — the invalidation it triggers is scoped, so the scope just
   decides which cache scope the success-time `:invalidate-tags` /
-  patch / populate target. Returns the canonical scope. Per EP-0003
-  §Mutations (scoped execution, same cache-scope rules as resources)."
-  [_mutation-id spec payload-scope]
+  patch / populate target.
+
+  Routes the resolved concrete scope through the SAME shared validation
+  path resources use (`state/canonicalize-scope`, rf2-lzv9xc): a host /
+  opaque scope value is rejected, a misspelled reserved `:rf.scope/*`
+  keyword is rejected fail-closed (rf2-pd7akw), and the historical
+  `[:rf.scope/global]` singleton-vector spelling normalizes to bare
+  `:rf.scope/global` (rf2-vv87xz) — so a mutation can never invalidate /
+  patch a silent WRONG (or second, distinct global) cache scope. Returns
+  the canonical scope. Per EP-0003 §Mutations (scoped execution, same
+  cache-scope rules as resources)."
+  [mutation-id spec payload-scope]
   (let [scope (or payload-scope (:scope spec) :rf.scope/global)]
-    (state/canonicalize scope)))
+    (state/canonicalize-scope scope 'rf.mutation/execute mutation-id)))

--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -12,17 +12,24 @@
   (distinct from the data-lifecycle `:rf.resource/invalidate-tags` /
   `:rf.resource/remove` / `:rf.resource/clear-scope` events).
 
-  This namespace owns the registration lifecycle only: validation + the
-  registry write/read (so an app can register a resource and Xray can
-  enumerate the static registry). `clear-resource` removes the registrar
-  entry; the per-frame runtime disposal of cached data (owner-index
-  release, host-handle cancel, in-flight abort, late-reply suppression,
-  tag-index prune, trace) is the app's job via the data-lifecycle events
-  (`:rf.resource/remove` / `:rf.resource/release-owner` /
-  `:rf.resource/clear-scope`), not a side effect of `clear-resource`."
-  (:require [re-frame.late-bind :as late-bind]
+  This namespace owns the registration lifecycle: validation + the registry
+  write/read (so an app can register a resource and Xray can enumerate the
+  static registry) PLUS, for `clear-resource`, the per-frame runtime
+  disposal of that resource id's live cache state. Per Spec 016
+  §clear-resource MUST-dispose (rf2-m9h5iq) `clear-resource` removes the
+  registrar entry AND disposes every live `:rf.runtime/resources` entry for
+  the id across registered frames (entries + reverse indexes recomputed,
+  stale / GC timers cancelled, in-flight work marked terminal + best-effort
+  aborted) so a late reply cannot recreate the cleared entries. The
+  data-lifecycle events (`:rf.resource/remove` / `:rf.resource/release-owner`
+  / `:rf.resource/clear-scope`) remain the in-cascade, scope/instance-grained
+  disposal surfaces."
+  (:require [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.resources.state :as state]
+            [re-frame.resources.timers :as timers]
+            [re-frame.resources.work-ledger :as work-ledger]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
@@ -51,23 +58,16 @@
   resource resolver MUST."
   :rf.scope/from-caller)
 
-(def ^:private reserved-scope-ns
-  "The framework-reserved scope namespace (`:rf.scope/*`, per Conventions
-  §Reserved namespaces / the `:rf.<spec-area>/*` scheme). A *bare keyword*
-  in this namespace is a CLOSED reserved enum (`#{:rf.scope/global
-  :rf.scope/from-caller}`); any other `:rf.scope/*` bare keyword is a typo
-  and a loud registration error, NOT a literal scope. Note a scope VALUE
-  like `[:rf.scope/session {…}]` is a vector tuple, not a bare keyword —
-  the reserved namespace governs only the bare-keyword *policy* slot."
-  "rf.scope")
-
 (defn- reserved-scope-namespace?
   "True when `scope` is a bare keyword in the framework-reserved
   `:rf.scope/*` namespace — i.e. a candidate for the closed scope-policy
   enum. A non-keyword (a `[:rf.scope/session …]` tuple, a map, a string)
-  is NOT in the bare-keyword reserved slot."
+  is NOT in the bare-keyword reserved slot. Reuses the shared
+  `state/reserved-scope-ns` constant (one source of truth for the reserved
+  namespace across the policy gate here and the concrete-scope gate in
+  `state`)."
   [scope]
-  (and (keyword? scope) (= reserved-scope-ns (namespace scope))))
+  (and (keyword? scope) (= state/reserved-scope-ns (namespace scope))))
 
 (defn- valid-scope-policy?
   "A scope policy is one of the reserved enum keywords
@@ -199,20 +199,93 @@
                     :gc-after-ms    (:gc-after-ms resource-spec)})))
   resource-id)
 
+(defn- entry-keys-for-resource
+  "The scoped keys in `runtime-db`'s `:entries` whose resource id (the
+  SECOND element of `[scope resource-id params]`) is `resource-id`."
+  [runtime-db resource-id]
+  (into []
+        (comp (map key) (filter (fn [[_scope rid _params]] (= rid resource-id))))
+        (get-in runtime-db (state/entries-path))))
+
+(defn- dispose-resource-runtime!
+  "Dispose every live runtime entry for `resource-id` in ONE frame (Spec 016
+  §clear-resource MUST-dispose, rf2-m9h5iq). Atomically (through
+  `frame/swap-runtime-db!`, the framework-authority out-of-cascade runtime-db
+  write surface routing / machine spawn use): removes the resource's
+  `:entries`, marks each in-flight work record terminal `:suppressed` (so a
+  late reply's `live-entry-for-reply` existence check finds nothing to write
+  into — the entry is gone — and the ledger row is settled), and recomputes
+  `:tag-index` / `:owner-index` from what remains. Then, host-side: cancels
+  each entry's advisory stale / GC timers and best-effort aborts each
+  in-flight attempt (opportunistic; stale suppression by removed-entry is the
+  correctness boundary). Emits a `:rf.resource/removed` trace row
+  (`:reason :clear-resource`) for the frame when anything was disposed.
+  Returns the disposed scoped keys (possibly empty)."
+  [frame-id resource-id]
+  (let [runtime-db (or (frame/frame-runtime-db-value frame-id) {})
+        keys'      (entry-keys-for-resource runtime-db resource-id)]
+    (when (seq keys')
+      (let [in-flight (into []
+                            (keep (fn [k]
+                                    (let [e   (get-in runtime-db (state/entry-path k))
+                                          wid (:current-work e)]
+                                      (when wid
+                                        [wid (:transport (work-ledger/get-record runtime-db wid))]))))
+                            keys')]
+        ;; durable disposal — atomic on the frame's runtime-db partition
+        (frame/swap-runtime-db!
+          frame-id
+          (fn [rdb]
+            (-> (or rdb {})
+                (update-in (state/entries-path) (fn [es] (reduce dissoc es keys')))
+                (as-> db (reduce (fn [d [wid _]]
+                                   (work-ledger/update-record
+                                     d wid work-ledger/mark-terminal
+                                     :suppressed {:reason :clear-resource}))
+                                 db in-flight))
+                (update state/resources-key state/recompute-indexes))))
+        ;; host-side disposal — release advisory timers + opportunistically
+        ;; abort each in-flight attempt. Correctness rests on the removed
+        ;; entry (a late reply's existence check finds nothing), NOT on the
+        ;; abort landing; `opportunistic-abort!` fires any direct host handle
+        ;; and drops the side-table slot — the SAME best-effort path the
+        ;; frame-destroy teardown uses (Spec 016 §Cancellation is
+        ;; opportunistic).
+        (doseq [k keys']
+          (timers/cancel-for-key! frame-id k))
+        (doseq [[wid _transport] in-flight]
+          (work-ledger/opportunistic-abort! frame-id wid))
+        (trace/emit! :rf.event :rf.resource/removed
+                     {:rf.frame/id frame-id :resource-id resource-id
+                      :reason :clear-resource :removed (vec keys')
+                      :aborted (mapv first in-flight)})))
+    keys'))
+
 (defn clear-resource
-  "Remove a registered resource (registration-lifecycle, NOT data
-  invalidation). Per Spec 016 §Public API §Registration.
+  "Remove a registered resource AND dispose its live per-frame runtime state.
+  Per Spec 016 §Public API §Registration / §clear-resource MUST-dispose
+  (rf2-m9h5iq).
 
-  Clears the registrar entry. This is registration-lifecycle only: it does
-  NOT dispose the per-frame resource-runtime state for the id (owner
-  indexes, timers / host handles, in-flight requests, cached rows). Cached
-  data is managed through the data-lifecycle events
+  Clears the registrar entry, then for every registered frame disposes the
+  resource id's live cache state: removes its `:rf.runtime/resources`
+  `:entries`, recomputes the reverse `:tag-index` / `:owner-index`, cancels
+  its stale / GC timers and host handles, marks any in-flight work terminal
+  `:suppressed`, and best-effort aborts those attempts. A late reply cannot
+  recreate the cleared entries — its existence check finds the entry gone.
+
+  The scope/instance-grained data-lifecycle events
   (`:rf.resource/invalidate-tags` / `:rf.resource/remove` /
-  `:rf.resource/clear-scope`) instead.
+  `:rf.resource/clear-scope`) remain the in-cascade disposal surfaces;
+  `clear-resource` is the process-level registration removal that ALSO
+  disposes (the registration is gone, so leaving live entries would strand a
+  permanent unrefreshable cache).
 
-  No-op (returns `resource-id`) when the id is not registered."
+  No-op (returns `resource-id`) when the id is not registered and no frame
+  holds a live entry for it."
   [resource-id]
   (registrar/unregister! resource-kind resource-id)
+  (doseq [frame-id (frame/frame-ids)]
+    (dispose-resource-runtime! frame-id resource-id))
   resource-id)
 
 ;; ---- registry-side introspection -----------------------------------------
@@ -295,12 +368,17 @@
 ;; either path.
 
 (defn- canonical-scope!
-  "Reject a non-EDN scope value (host / opaque) and return the canonical
-  scope. Per Spec 016 §Resource identity (a scope map gets the SAME
-  canonicalization as params)."
+  "Route a CONCRETE resolved scope through the single shared concrete-scope
+  validation path (`state/canonicalize-scope`, rf2-lzv9xc): reject a
+  reserved-namespace typo fail-closed (rf2-pd7akw), reject a host / opaque
+  value, normalize the historical `[:rf.scope/global]` singleton-vector
+  spelling to bare `:rf.scope/global` (rf2-vv87xz), then canonicalize. Per
+  Spec 016 §Resource identity / §Scope resolution. Used by both event and
+  sub scope resolution, so a misspelled reserved `:rf.scope/*` in a payload /
+  route-resolver / fn-of-nothing / pure-data policy is caught at the concrete
+  boundary, not silently accepted as a literal scope."
   [resource-id scope where]
-  (state/reject-non-edn! scope where :scope resource-id)
-  (state/canonicalize scope))
+  (state/canonicalize-scope scope where resource-id))
 
 (defn resolve-scope-for-event
   "Resolve the concrete cache scope for a resource EVENT, fail-closed, in

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -176,21 +176,63 @@
     (sequential? x) (every? serializable-edn? x)
     :else        false))
 
+(defn- type-rank
+  "Total type ordering used by `total-edn-compare` so a map with MIXED key
+  types (e.g. a keyword key and a string key) sorts deterministically rather
+  than throwing a raw `ClassCastException` (rf2-ptz7z8). The rank groups
+  values by their EDN kind; WITHIN a kind the natural / string ordering
+  breaks ties. Covers exactly the serializable-EDN kinds the cache key may
+  carry (`serializable-edn?`)."
+  [x]
+  (cond
+    (nil? x)        0
+    (boolean? x)    1
+    (number? x)     2
+    (string? x)     3
+    (keyword? x)    4
+    (symbol? x)     5
+    :else           6))
+
+(defn- total-edn-compare
+  "A TOTAL comparator over the serializable-EDN key shapes a canonical map
+  may carry (rf2-ptz7z8). Orders first by `type-rank` (so mixed
+  keyword/string/number/nil keys are orderable instead of throwing), then
+  WITHIN a kind by the kind's natural order — numbers numerically, strings /
+  keywords / symbols by their printed form. A deterministic total order is
+  all canonicalization needs: it only has to be stable + order-independent,
+  not semantically meaningful across kinds. Returns a negative / zero /
+  positive int."
+  [a b]
+  (let [ra (type-rank a) rb (type-rank b)]
+    (if (not= ra rb)
+      (compare ra rb)
+      ;; same kind — compare within it. numbers compare numerically; every
+      ;; other comparable kind compares by its printed form (keywords /
+      ;; symbols carry namespace + name; strings are themselves), which is a
+      ;; total order within the kind.
+      (if (number? a)
+        (compare a b)
+        (compare (str a) (str b))))))
+
 (defn canonicalize
   "Pure canonicalization of an EDN value for use in a cache key (Spec 016
-  §Canonicalization rule). A map is normalized into a sorted-by-key array
-  map so two spellings (key order) collapse to one identity and `=`; nested
-  maps recurse; sets and vectors keep value semantics (their elements
-  recurse). Reject non-EDN / host values loudly via `reject-non-edn!`
+  §Canonicalization rule). A map is normalized into a sorted-by-key map under
+  a TOTAL comparator so two spellings (key order) collapse to one identity
+  and `=`; nested maps recurse; sets and vectors keep value semantics (their
+  elements recurse). Reject non-EDN / host values loudly via `reject-non-edn!`
   upstream — this fn assumes its input is already serializable EDN.
 
   The sorted-map normalization makes member ORDER irrelevant to BOTH
   equality and hashing, so `{:a 1 :b 2}` and `{:b 2 :a 1}` produce the
   identical canonical value (and therefore the identical scoped resource
-  key). Returns the canonical value."
+  key). The comparator is TOTAL over the accepted EDN key shapes
+  (rf2-ptz7z8): a map mixing keyword and string keys canonicalizes
+  deterministically (ordered by `total-edn-compare`) instead of throwing a
+  raw `ClassCastException` from the default sorted-map comparator. Returns
+  the canonical value."
   [x]
   (cond
-    (map? x)        (into (sorted-map)
+    (map? x)        (into (sorted-map-by total-edn-compare)
                           (map (fn [[k v]] [k (canonicalize v)]))
                           x)
     (set? x)        (into #{} (map canonicalize) x)
@@ -223,6 +265,126 @@
                      :kind        kind
                      :value       (pr-str value)})))
   value)
+
+;; ---- concrete-scope validation (Spec 016 §Scope resolution) ---------------
+;;
+;; The SINGLE shared validation path for a CONCRETE scope value — the value
+;; a resolved scope actually carries into the cache key (a payload `:scope`,
+;; a route-resolver result, a fn-of-nothing result, a pure-data policy, or a
+;; mutation invalidation default). Distinct from the registration-time scope
+;; POLICY gate (`registry/valid-scope-policy?`), which validates the
+;; declared policy slot. Every scope-bearing operation — event resolution,
+;; sub resolution, route planning, mutation invalidation default — routes
+;; its concrete scope through `canonicalize-scope` so the same three
+;; guarantees hold everywhere (rf2-lzv9xc):
+;;
+;;   1. host / opaque scope values are rejected (`reject-non-edn!`);
+;;   2. a BARE unknown `:rf.scope/*` keyword (a reserved-namespace typo such
+;;      as `:rf.scope/glabal`) is rejected fail-closed (rf2-pd7akw) — it can
+;;      NEVER become a silent wrong cache scope;
+;;   3. the singleton-vector `[:rf.scope/global]` global-scope spelling is
+;;      normalized to the canonical bare `:rf.scope/global` (rf2-vv87xz) so a
+;;      payload copied from historical prose cannot create a SECOND, distinct
+;;      global cache key.
+
+(def reserved-scope-ns
+  "The framework-reserved scope namespace (`:rf.scope/*`, per Conventions
+  §Reserved namespaces / the `:rf.<spec-area>/*` scheme). A *bare keyword*
+  in this namespace is a CLOSED reserved enum (`#{:rf.scope/global
+  :rf.scope/from-caller}`); any other `:rf.scope/*` bare keyword is a typo,
+  NOT a literal scope. Note a scope VALUE like `[:rf.scope/session {…}]` is a
+  vector tuple, not a bare keyword — the reserved namespace governs only the
+  bare-keyword slot."
+  "rf.scope")
+
+(def reserved-concrete-scopes
+  "The closed set of bare `:rf.scope/*` keywords that are VALID as a concrete
+  resolved scope. Only `:rf.scope/global` is a concrete cache scope —
+  `:rf.scope/from-caller` is a registration POLICY (it never resolves to a
+  concrete value; the use site supplies one) and so is NOT a valid concrete
+  scope. Any other `:rf.scope/*` bare keyword is a typo. Per Spec 016 §Scope
+  resolution."
+  #{:rf.scope/global})
+
+(defn reserved-scope-typo?
+  "True when `scope` is a BARE keyword in the framework-reserved
+  `:rf.scope/*` namespace that is NOT a valid concrete scope (rf2-pd7akw) —
+  i.e. a misspelled reserved scope like `:rf.scope/glabal`, or the
+  policy-only `:rf.scope/from-caller` reaching a concrete boundary. A
+  non-keyword scope (a `[:rf.scope/session …]` tuple, a map, a string) is
+  NOT in the bare-keyword reserved slot and is never a typo here."
+  [scope]
+  (and (keyword? scope)
+       (= reserved-scope-ns (namespace scope))
+       (not (contains? reserved-concrete-scopes scope))))
+
+(def ^:private global-scope
+  "The canonical CONCRETE global cache scope — the bare keyword the
+  implementation stores as the first element of a scoped key for an explicit
+  global resource (rf2-vv87xz). The historical singleton-vector spelling
+  `[:rf.scope/global]` normalizes to this."
+  :rf.scope/global)
+
+(defn- normalize-global-scope
+  "Normalize the historical singleton-vector global spelling
+  `[:rf.scope/global]` to the canonical concrete `:rf.scope/global` bare
+  keyword (rf2-vv87xz), so a payload that copied the singleton-vector form
+  from older prose collapses to the SAME global cache key the implementation
+  resolves an explicit-global policy to — it can never silently create a
+  second, distinct global key. Every other value passes through unchanged."
+  [scope]
+  (if (= scope [global-scope]) global-scope scope))
+
+(defn reject-reserved-scope-typo!
+  "Throw `:rf.error/resource-invalid-scope` when `scope` is a reserved-
+  namespace typo (`reserved-scope-typo?`) reaching a CONCRETE scope boundary
+  (rf2-pd7akw). A bare `:rf.scope/*` keyword outside the concrete enum is a
+  framework-namespace typo, never a literal app scope — accepting it would
+  resolve to a silent WRONG cache scope (a tenant / user / permission leak),
+  exactly the failure the fail-closed scope contract exists to prevent.
+  `where` / `resource-id` name the offending boundary. Returns `scope`
+  unchanged when it conforms."
+  [scope where resource-id]
+  (when (reserved-scope-typo? scope)
+    (throw (ex-info ":rf.error/resource-invalid-scope"
+                    {:rf.error/id :rf.error/resource-invalid-scope
+                     :where       where
+                     :recovery    :fix-scope
+                     :reason      (str "resource " resource-id " was reached with a "
+                                       "scope " (pr-str scope) " in the framework-"
+                                       "reserved :rf.scope/* namespace that is not a "
+                                       "valid concrete scope. The only concrete "
+                                       "reserved scope is :rf.scope/global; "
+                                       ":rf.scope/from-caller is a registration "
+                                       "policy (the use site supplies the concrete "
+                                       "scope), and any other :rf.scope/* keyword is "
+                                       "a typo. A framework-namespace typo MUST fail "
+                                       "closed rather than become a silent wrong "
+                                       "cache scope. Per Spec 016 §Scope resolution.")
+                     :resource-id resource-id
+                     :scope       scope})))
+  scope)
+
+(defn canonicalize-scope
+  "The SINGLE shared concrete-scope validation + canonicalization path
+  (rf2-lzv9xc). Given a CONCRETE resolved scope value, in order:
+
+    1. reject a reserved-namespace typo fail-closed
+       (`reject-reserved-scope-typo!`, rf2-pd7akw);
+    2. reject a host / opaque value (`reject-non-edn!`);
+    3. normalize the historical `[:rf.scope/global]` singleton-vector
+       spelling to the canonical bare `:rf.scope/global` (rf2-vv87xz);
+    4. canonicalize the EDN (`canonicalize`).
+
+  Every scope-bearing operation routes its concrete scope through this fn so
+  the typo / host / global-spelling guarantees hold uniformly across event
+  resolution, sub resolution, route planning, and mutation invalidation
+  defaults. `where` / `resource-id` name the boundary for the structured
+  errors. Returns the canonical scope."
+  [scope where resource-id]
+  (reject-reserved-scope-typo! scope where resource-id)
+  (reject-non-edn! scope where :scope resource-id)
+  (canonicalize (normalize-global-scope scope)))
 
 ;; ---- scoped resource key (Spec 016 §Resource identity) --------------------
 

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -39,6 +39,7 @@
    ;; dispatch / subscribe to.
    [re-frame.resources]
    [re-frame.resources.registry :as registry]
+   [re-frame.resources.mutation-registry :as mreg]
    [re-frame.resources.state :as state]
    [re-frame.resources.subs :as subs]
    [re-frame.resources.test-support]
@@ -492,3 +493,191 @@
   (testing "the :resource registrar kind is valid (skeleton invariant held)"
     (is (registrar/valid-kind? :resource))
     (is (not (registrar/valid-kind? :query)))))
+
+;; ===========================================================================
+;; 13. Concrete-scope typo rejection at resolution boundaries (rf2-pd7akw)
+;; ===========================================================================
+
+(deftest reserved-scope-typo-rejected-at-concrete-boundaries
+  (rf/reg-resource :tp/article (article-spec {:scope :rf.scope/from-caller}))
+  (let [spec (registry/resource-meta :tp/article)]
+    (testing "rf2-pd7akw — a misspelled reserved :rf.scope/* keyword on an
+              EVENT payload is rejected fail-closed (never a silent wrong
+              cache scope)"
+      (is (thrown-with-msg?
+            #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
+            (registry/resolve-scope-for-event
+              :tp/article spec {:payload-scope :rf.scope/glabal} 'test))))
+    (testing "rf2-pd7akw — a misspelled reserved :rf.scope/* keyword on a
+              SUBSCRIPTION payload is rejected fail-closed too"
+      (is (thrown-with-msg?
+            #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
+            (registry/resolve-scope-for-sub
+              :tp/article spec :rf.scope/sesssion 'test))))
+    (testing "rf2-pd7akw — :rf.scope/from-caller reaching a CONCRETE boundary
+              as a payload value (not a policy) is a typo-class rejection"
+      (is (thrown-with-msg?
+            #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
+            (registry/resolve-scope-for-event
+              :tp/article spec {:payload-scope :rf.scope/from-caller} 'test))))
+    (testing "an APP-namespaced keyword scope is a legitimate literal scope
+              (only the framework-reserved namespace is fail-closed)"
+      (is (= :my.app/tenant
+             (registry/resolve-scope-for-event
+               :tp/article spec {:payload-scope :my.app/tenant} 'test))))
+    (testing "a vector-tuple scope [:rf.scope/session {…}] is a value, not a
+              bare-keyword typo — accepted"
+      (is (= [:rf.scope/session {:tenant "acme"}]
+             (registry/resolve-scope-for-event
+               :tp/article spec {:payload-scope [:rf.scope/session {:tenant "acme"}]}
+               'test))))))
+
+;; ===========================================================================
+;; 14. Singleton-vector [:rf.scope/global] cannot create a 2nd global key
+;;     (rf2-vv87xz, impl/guard half)
+;; ===========================================================================
+
+(deftest singleton-vector-global-normalizes-to-bare-global
+  (testing "rf2-vv87xz — a [:rf.scope/global] payload normalizes to the bare
+            :rf.scope/global so it collapses to the SAME global cache key the
+            implementation resolves an explicit-global policy to (it cannot
+            silently create a second, distinct global key)"
+    (let [k-bare      (state/canonicalize-scope :rf.scope/global 'test :r/x)
+          k-singleton (state/canonicalize-scope [:rf.scope/global] 'test :r/x)]
+      (is (= :rf.scope/global k-bare))
+      (is (= :rf.scope/global k-singleton)
+          "singleton-vector spelling collapses to the bare canonical scope")
+      (is (= k-bare k-singleton) "both spellings produce ONE global cache key")))
+  (testing "rf2-vv87xz — end-to-end: an ensure under :rf.scope/global and a
+            sub under [:rf.scope/global] read the SAME entry (no second key)"
+    (rf/reg-resource :gv/article (article-spec))
+    (let [bare-key (state/scoped-resource-key :rf.scope/global :gv/article {:slug "w"})]
+      (rf/dispatch-sync [:rf.resource/ensure {:resource :gv/article :scope :rf.scope/global
+                                              :params {:slug "w"} :owner [:lease 1]}])
+      (let [wid (:current-work (entry bare-key))]
+        (rf/dispatch-sync [:rf.resource.internal/succeeded
+                           {:resource-key bare-key :work-id wid :generation 1
+                            :data {:title "W"}}]))
+      ;; a sub payload using the historical singleton-vector spelling resolves
+      ;; to the SAME bare key — it reads the loaded entry, not a fresh skeleton.
+      (is (= bare-key
+             (subs/resolve-scoped-key {:resource :gv/article
+                                       :scope [:rf.scope/global]
+                                       :params {:slug "w"}}))))))
+
+;; ===========================================================================
+;; 15. clear-resource disposes live runtime state (rf2-m9h5iq)
+;; ===========================================================================
+
+(deftest clear-resource-disposes-runtime-state
+  (rf/reg-resource :cr/article (article-spec))
+  (let [loaded-key  (state/scoped-resource-key :rf.scope/global :cr/article {:slug "loaded"})
+        inflight-key (state/scoped-resource-key :rf.scope/global :cr/article {:slug "inflight"})]
+    ;; one LOADED entry (with tags + an active owner → indexed)
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :cr/article :scope :rf.scope/global
+                                            :params {:slug "loaded"} :owner [:lease :cr 1]}])
+    (let [wid (:current-work (entry loaded-key))]
+      (rf/dispatch-sync [:rf.resource.internal/succeeded
+                         {:resource-key loaded-key :work-id wid :generation 1
+                          :data {:title "L"} :tags #{[:article "loaded"]}}]))
+    ;; one IN-FLIGHT entry (still :loading, has :current-work)
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :cr/article :scope :rf.scope/global
+                                            :params {:slug "inflight"} :owner [:lease :cr 2]}])
+    (is (= :loaded (:status (entry loaded-key))))
+    (is (some? (:current-work (entry inflight-key))) "in-flight entry has live work")
+    (is (seq (get-in (runtime-db) (state/tag-index-path))) "tag index populated")
+    (is (seq (get-in (runtime-db) (state/owner-index-path))) "owner index populated")
+    (let [inflight-wid (:current-work (entry inflight-key))]
+      ;; CLEAR the resource (registration-lifecycle + runtime disposal)
+      (registry/clear-resource :cr/article)
+      (testing "rf2-m9h5iq — clear-resource removes the registrar entry"
+        (is (nil? (registry/resource-meta :cr/article))))
+      (testing "rf2-m9h5iq — every live entry for the id is removed from
+                :rf.runtime/resources :entries"
+        (is (nil? (entry loaded-key)))
+        (is (nil? (entry inflight-key))))
+      (testing "rf2-m9h5iq — reverse indexes are recomputed/pruned"
+        (is (empty? (get-in (runtime-db) (state/tag-index-path))))
+        (is (empty? (get-in (runtime-db) (state/owner-index-path)))))
+      (testing "rf2-m9h5iq — the in-flight work record is settled terminal
+                (:suppressed) so the ledger row is not left in-flight"
+        (let [rec (get-in (runtime-db) (state/work-record-path inflight-wid))]
+          ;; record may be pruned or marked terminal; if present it must be
+          ;; the terminal :suppressed status, never still in-flight.
+          (when rec
+            (is (= :suppressed (:status rec))))))
+      (testing "rf2-m9h5iq — a LATE reply for a cleared in-flight entry cannot
+                recreate it (its existence check finds the entry gone)"
+        (rf/dispatch-sync [:rf.resource.internal/succeeded
+                           {:resource-key inflight-key :work-id inflight-wid
+                            :generation 1 :data {:title "late"}}])
+        (is (nil? (entry inflight-key))
+            "late reply suppressed — no resurrected entry")))))
+
+;; ===========================================================================
+;; 16. mutation scope routes through shared validation (rf2-lzv9xc)
+;; ===========================================================================
+
+(deftest mutation-scope-routes-through-shared-validation
+  (testing "rf2-lzv9xc — a mutation execute-payload scope that is a reserved
+            :rf.scope/* typo is rejected through the same path resources use"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
+          (mreg/resolve-scope :m/x {} :rf.scope/glabal))))
+  (testing "rf2-lzv9xc — a host / opaque mutation scope value is rejected"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
+          (mreg/resolve-scope :m/x {} {:fn (fn [])}))))
+  (testing "rf2-lzv9xc — the default global scope still resolves, and the
+            [:rf.scope/global] spelling normalizes to bare (no 2nd key)"
+    (is (= :rf.scope/global (mreg/resolve-scope :m/x {} nil)))
+    (is (= :rf.scope/global (mreg/resolve-scope :m/x {} [:rf.scope/global])))))
+
+;; ===========================================================================
+;; 17. resource-state fails closed without an explicit frame (rf2-c8lgy3)
+;; ===========================================================================
+
+(deftest resource-state-fails-closed-without-frame
+  (rf/reg-resource :rs/article (article-spec))
+  (testing "rf2-c8lgy3 — a frameless resource-state call raises
+            :rf.error/no-frame-context (never a silent nil that is
+            indistinguishable from an absent entry)"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"no-frame-context"
+          (re-frame.resources/resource-state
+            {:resource :rs/article :scope :rf.scope/global :params {:slug "w"}}))))
+  (testing "rf2-c8lgy3 — a valid explicit frame returns nil ONLY for a
+            genuinely absent entry"
+    (is (nil? (re-frame.resources/resource-state
+                {:resource :rs/article :scope :rf.scope/global
+                 :params {:slug "absent"} :frame :rf/default}))))
+  (testing "rf2-c8lgy3 — a valid explicit frame returns the entry when present"
+    (let [k (state/scoped-resource-key :rf.scope/global :rs/article {:slug "w"})]
+      (rf/dispatch-sync [:rf.resource/ensure {:resource :rs/article :scope :rf.scope/global
+                                              :params {:slug "w"} :owner [:lease 1]}])
+      (let [wid (:current-work (entry k))]
+        (rf/dispatch-sync [:rf.resource.internal/succeeded
+                           {:resource-key k :work-id wid :generation 1
+                            :data {:title "W"}}]))
+      (is (some? (re-frame.resources/resource-state
+                   {:resource :rs/article :scope :rf.scope/global
+                    :params {:slug "w"} :frame :rf/default}))))))
+
+;; ===========================================================================
+;; 18. param canonicalization is total over mixed EDN key types (rf2-ptz7z8)
+;; ===========================================================================
+
+(deftest param-canonicalization-total-over-mixed-keys
+  (testing "rf2-ptz7z8 — a params map mixing keyword and string keys
+            canonicalizes deterministically (no raw ClassCastException)"
+    (let [c1 (state/canonicalize {:b 1 "a" 2 :a 3 "z" 4})
+          c2 (state/canonicalize {"z" 4 :a 3 "a" 2 :b 1})]
+      (is (= c1 c2) "key-order-independent over mixed key types")
+      (is (= {:b 1 "a" 2 :a 3 "z" 4} c1) "values preserved")))
+  (testing "rf2-ptz7z8 — mixed nil / number / boolean / keyword / string keys
+            all order deterministically"
+    (let [m {nil 0 1 :one true :t :kw :k "s" :str}]
+      (is (= (state/canonicalize m) (state/canonicalize (into {} (shuffle (seq m))))))))
+  (testing "rf2-ptz7z8 — a scoped key built from mixed-key params is stable"
+    (is (= (state/scoped-resource-key :rf.scope/global :r/x {:a 1 "b" 2})
+           (state/scoped-resource-key :rf.scope/global :r/x {"b" 2 :a 1})))))


### PR DESCRIPTION
Resolves 6 beads on the **resources scope + registry + validation** surface. This lane OWNS `state.cljc` + `registry.cljc` for the wave (sibling resources clusters deferred those files here), so the diff is kept clean as their source of truth.

## What changed

The core move is a **single shared concrete-scope validation path** — `re-frame.resources.state/canonicalize-scope` — that every scope-bearing operation routes through. It (1) rejects misspelled reserved `:rf.scope/*` keywords fail-closed, (2) rejects host/opaque scope values, (3) normalizes the historical `[:rf.scope/global]` singleton-vector spelling to bare `:rf.scope/global`, then (4) canonicalizes.

- **rf2-pd7akw** (P2) — `state/reject-reserved-scope-typo!` rejects a bare unknown `:rf.scope/*` keyword (e.g. `:rf.scope/glabal`, or policy-only `:rf.scope/from-caller`) at concrete scope-resolution boundaries (event/sub payloads, route-resolver results, fn-of-nothing/pure-data policies). Reserved-namespace typos can no longer become a silent wrong cache scope. App-namespaced keywords + vector-tuple scopes stay valid.
- **rf2-lzv9xc** (P2) — `registry/canonical-scope!` (used by `resolve-scope-for-event` / `resolve-scope-for-sub`) and `mutation_registry/resolve-scope` now delegate to `state/canonicalize-scope` — one validation path, not ad-hoc `canonicalize`. *The two scope sites in `events.cljc` (invalidate-tags, clear-scope) were fenced to the routing lane this wave (it edits events.cljc for rf2-l2gofj) → tracked as follow-up **rf2-hosnba**.*
- **rf2-m9h5iq** (P2) — `clear-resource` now disposes live runtime state per Spec 016 §clear-resource MUST-dispose: for every registered frame it removes the id's `:entries` (via `frame/swap-runtime-db!`, the framework-authority out-of-cascade write surface), recomputes the reverse `:tag-index`/`:owner-index`, cancels stale/GC timers + host handles, marks in-flight work terminal `:suppressed` + best-effort aborts it, and emits a `:rf.resource/removed` (`:reason :clear-resource`) trace. Late replies cannot recreate cleared entries (their existence check finds them gone).
- **rf2-vv87xz** (P2, impl/guard half) — `[:rf.scope/global]` singleton-vector normalizes to bare `:rf.scope/global` so a payload copied from historical prose cannot create a second, distinct global cache key. Docs half verified against main: still owned by the docs cluster — **untouched** here.
- **rf2-ptz7z8** (P3) — `state/canonicalize` is now TOTAL over accepted EDN key shapes (`sorted-map-by` a total `type-rank`-then-printed-form comparator). A params map mixing keyword + string keys canonicalizes deterministically instead of throwing a raw `ClassCastException`.
- **rf2-c8lgy3** (P3) — `resource-state` fails closed without an explicit `:frame` (raises `:rf.error/no-frame-context`) instead of passing nil through to a runtime-db lookup that returns a nil indistinguishable from an absent entry. A valid explicit (even unknown/destroyed) frame still returns nil only for a genuinely absent entry.

## Quality gates

- **rf2-pd7akw** — `reserved-scope-typo-rejected-at-concrete-boundaries` (event/sub typo → `:rf.error/resource-invalid-scope`; `:rf.scope/from-caller` as concrete value rejected; app-namespaced + vector-tuple scopes accepted).
- **rf2-lzv9xc** — `mutation-scope-routes-through-shared-validation` (mutation payload typo → reject; host scope → reject; default global + `[:rf.scope/global]` normalize).
- **rf2-m9h5iq** — `clear-resource-disposes-runtime-state` (loaded + indexed entry removed, indexes pruned, in-flight work `:suppressed`, late reply suppressed — cannot resurrect).
- **rf2-vv87xz** — `singleton-vector-global-normalizes-to-bare-global` (both spellings → one global key; end-to-end ensure/sub read the same entry).
- **rf2-ptz7z8** — `param-canonicalization-total-over-mixed-keys` (mixed keyword/string/nil/number/boolean keys order deterministically; no ClassCastException; stable scoped key).
- **rf2-c8lgy3** — `resource-state-fails-closed-without-frame` (frameless → `:rf.error/no-frame-context`; valid frame → nil only for absent entry; present entry returned).

Commands + counts:
- `implementation/resources` → `clojure -M:test`: **176 tests, 638 assertions, 0 failures, 0 errors** (+6 new deftests, +31 assertions).
- `implementation` → `npm run test:cljs`: **6355 tests, 22884 assertions, 0 failures, 0 errors**.

No new public `re-frame.core` facade export (`resource-state` pre-existed; only a fail-closed guard added) → no API-manifest regeneration needed. New vars are artefact-internal (`re-frame.resources.state`).

## Risks
- `clear-resource` now does per-frame runtime work (iterates `frame/frame-ids`, one `swap-runtime-db!` per affected frame). Opportunistic abort uses the host-side `work-ledger/opportunistic-abort!` path (same as frame-destroy teardown); correctness rests on entry removal + stale suppression, not on the abort landing.
- This PR is intended to merge **first** among the resources lanes (owns `state.cljc`/`registry.cljc`); routing/mutations/ssr lanes rebase over it. routing lane's `events.cljc` change (rf2-l2gofj) is in a different region — no expected textual conflict.
