### PR TITLE
fix(resources): validate mutation invalidate-timing at registration (rf2-t8j7oj)

### DIFF
--- a/implementation/resources/src/re_frame/resources/mutation_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_registry.cljc
@@ -33,6 +33,14 @@
 
 ;; ---- spec validation (fail-closed at the authoring boundary) -------------
 
+(def invalidate-timings
+  "The CLOSED enum of valid `:invalidate-timing` values (Spec 016
+  §Mutations). `nil` is also valid at registration — it defaults to
+  `:after-success` at runtime. Any non-nil value outside this set is a typo
+  (e.g. `:after-succes`) that would silently skip every invalidation timing
+  branch — rejected fail-closed by `validate-mutation-spec!`."
+  #{:before-request :after-success :after-failure :after-settle})
+
 (defn- registration-error
   "Build the canonical thrown-error shape (Spec 009 §The thrown-error
   shape) for a `reg-mutation` validation failure."
@@ -81,6 +89,28 @@
                   "the write's params (which the :request / :invalidates / "
                   ":patches fns close over). Per EP-0003 §Mutations.")
              {:mutation-id mutation-id})))
+  ;; :invalidate-timing is a CLOSED four-value enum (Spec 016 §Mutations). It
+  ;; is OPTIONAL (nil defaults to :after-success at runtime), but a non-nil
+  ;; value outside the enum is a typo (e.g. :after-succes) that would register
+  ;; cleanly and then SILENTLY skip every invalidation timing branch at
+  ;; runtime (`(or (:invalidate-timing spec) :after-success)` defaults nil,
+  ;; but a typo is neither nil nor matched by the `#{…}` timing guards). Reject
+  ;; it loudly here so the failure is at the authoring boundary, not a silent
+  ;; runtime no-op (rf2-t8j7oj). Fails in dev AND prod (a caller bug).
+  (let [timing (:invalidate-timing spec)]
+    (when (and (some? timing) (not (contains? invalidate-timings timing)))
+      (throw (registration-error
+               :rf.error/invalid-mutation-spec
+               'rf/reg-mutation
+               (str "mutation " mutation-id " declares an :invalidate-timing of "
+                    (pr-str timing) " outside the closed enum "
+                    (pr-str (sort invalidate-timings)) ". A typo (e.g. "
+                    ":after-succes) would register cleanly and then silently "
+                    "skip every invalidation timing branch at runtime. Per "
+                    "Spec 016 §Mutations.")
+               {:mutation-id       mutation-id
+                :invalidate-timing timing
+                :valid             invalidate-timings}))))
   nil)
 
 ;; ---- reg-mutation / clear-mutation ---------------------------------------

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -130,6 +130,34 @@
           #?(:clj Throwable :cljs js/Error) #"invalid-mutation-spec"
           (rf/reg-mutation :m/no-schema {:request (fn [_ _] {:request {:url "/x"}})})))))
 
+(deftest reg-mutation-rejects-invalidate-timing-typo
+  ;; rf2-t8j7oj — :invalidate-timing is a CLOSED four-value enum (Spec 016
+  ;; §Mutations). A typo (`:after-succes`) would register cleanly and then
+  ;; silently skip every invalidation timing branch at runtime
+  ;; (`(or (:invalidate-timing spec) :after-success)` only defaults nil; a
+  ;; typo is neither nil nor matched by the `#{…}` timing guards). Reject it
+  ;; loudly AT REGISTRATION rather than as a silent runtime no-op.
+  (testing "a typo'd :invalidate-timing is rejected at reg-mutation"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"invalid-mutation-spec"
+          (rf/reg-mutation :m/typo
+                           (save-article-spec {:invalidate-timing :after-succes})))))
+  (testing "a non-keyword :invalidate-timing is rejected"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"invalid-mutation-spec"
+          (rf/reg-mutation :m/non-kw
+                           (save-article-spec {:invalidate-timing "after-success"})))))
+  (testing "every value in the closed enum registers cleanly"
+    (doseq [timing mreg/invalidate-timings]
+      (rf/reg-mutation :m/ok (save-article-spec {:invalidate-timing timing}))
+      (is (= timing (:invalidate-timing (rf/mutation-meta :m/ok)))
+          (str "valid timing " timing " registered"))
+      (rf/clear-mutation :m/ok)))
+  (testing "an OMITTED :invalidate-timing is valid (nil → :after-success at runtime)"
+    (rf/reg-mutation :m/default (save-article-spec))
+    (is (nil? (:invalidate-timing (rf/mutation-meta :m/default))))
+    (rf/clear-mutation :m/default)))
+
 (deftest execute-unregistered-is-loud
   (testing "EP-0003 §Mutations — :rf.mutation/execute on an unregistered
             mutation never reaches the transport"


### PR DESCRIPTION
## What

`reg-mutation` did not validate `:invalidate-timing` even though Spec 016 §Mutations defines a CLOSED four-value enum (`:before-request` / `:after-success` / `:after-failure` / `:after-settle`). A typo such as `:after-succes` registered cleanly and then **silently skipped every invalidation timing branch** at runtime — the runtime reads `(or (:invalidate-timing spec) :after-success)`, which defaults `nil` but leaves a typo neither nil nor matched by the `#{…}` timing guards.

`validate-mutation-spec!` (in `implementation/resources/src/re_frame/resources/mutation_registry.cljc`) now rejects a non-nil `:invalidate-timing` outside the closed enum with a structured `:rf.error/invalid-mutation-spec` registration error (`:recovery :fix-registration`), fail-closed in dev AND prod — matching the existing `:request` / `:params-schema` authoring-boundary checks and the family's scope-typo style (rf2-pd7akw). `nil` remains valid (defaults to `:after-success` at runtime).

The enum is the new internal `mutation-registry/invalidate-timings` set — single source of truth for the guard. It is NOT a `re-frame.core` facade export, so no API-manifest row (the manifest governs only the `rf/` facade; `re-frame.resources.*` internals are not introspected — see `spec/api-manifest-metadata.edn:309`).

## Tests

New `reg-mutation-rejects-invalidate-timing-typo` (adversarial + positive) in `implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc`:
- the `:after-succes` typo is rejected at `reg-mutation` (the bead's named regression);
- a non-keyword timing is rejected;
- every value in the closed enum registers cleanly + round-trips through `mutation-meta`;
- an omitted timing (nil) stays valid.

## Quality gates

- `implementation/resources/` — `clojure -M:test`: **201 tests, 715 assertions, 0 failures, 0 errors**
- `implementation/` — `npm run test:cljs`: **6380 tests, 22961 assertions, 0 failures, 0 errors**
- clj-kondo on both changed files: **0 errors, 0 warnings**
- Root `scripts/test-fast-pr.sh`: all gates pass EXCEPT the README inventory ratchet, which trips on the locally-junctioned `node_modules` + the `out/` CLJS build dir under `implementation/` (both gitignored, untracked, present only because the gates were run locally). Environmental — not introduced by this diff (the diff is `.cljc`-only); passes clean on CI.

## Risks

Low. Tightens an authoring-boundary check only; no runtime-path change. Existing specs already register valid timings, so no existing registration breaks (the full CLJS + resources suites confirm).

Closes rf2-t8j7oj.
