### PR TITLE
fix(resources): events-core fail-closed invalidate + abort/GC/correlation (events-core cluster)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -1169,11 +1169,25 @@
   sets and entry generation after wake\").
 
   GC-eligibility re-check (against the LIVE durable facts):
-    - the entry is gone — no-op (`:no-entry`);
+    - the entry is gone — no-op (`:no-entry`); nothing to GC or reschedule;
     - the entry has an active owner — pinned alive, no GC (`:has-owner`);
     - the entry has work in flight (`:current-work`) — no GC (`:in-flight`);
     - otherwise the entry is owner-free + idle — REMOVE it (recompute the
-      reverse indexes) and cancel its advisory timers."
+      reverse indexes) and cancel its advisory timers.
+
+  RESCHEDULE-ON-SKIP (rf2-07693y): a GC timer that fires while the entry is
+  still OWNED or IN-FLIGHT must NOT just skip and leave the entry uncollectable
+  — if the owner later releases or the work settles AFTER the original
+  `:gc-after-ms` deadline, nothing would re-fire and the now-inactive entry
+  would linger indefinitely. So a `:has-owner` / `:in-flight` skip RE-ARMS a
+  fresh GC timer (via `schedule-timers`, which cancel-then-arms — this also
+  cleans up the FIRED one-shot handle still sitting in the side table). The
+  re-armed timer fires another re-check after `:gc-after-ms`; once the entry is
+  owner-free + idle that re-check collects it deterministically. A `:no-entry`
+  skip does NOT reschedule (there is nothing left to collect; `cancel-timers`
+  on the removal path already released the handles). A resource declaring no
+  `:gc-after-ms` never armed a GC timer in the first place, so it never skips
+  here — but the reschedule fx is gated on a positive delay for safety."
   [{rt :rf.db/runtime, frame-id :rf.frame/id}
    [_event-id {:keys [resource-key]}]]
   (let [runtime-db (or rt {})
@@ -1190,12 +1204,31 @@
          ;; one-shot, but the paired stale timer may still be armed).
          :fx [[:rf.resource/cancel-timers
                {:frame-id frame-id :resource-keys [resource-key]}]]})
-      (do (trace/emit! :rf.event :rf.resource/gc-skipped
-                       {:rf.frame/id frame-id :resource-key resource-key
-                        :reason (cond (nil? entry) :no-entry
-                                      (seq (:active-owners entry)) :has-owner
-                                      :else :in-flight)})
-          {:rf.db/runtime runtime-db}))))
+      (let [reason   (cond (nil? entry)                  :no-entry
+                           (seq (:active-owners entry))  :has-owner
+                           :else                         :in-flight)
+            ;; rf2-07693y: a still-owned / in-flight skip RE-ARMS the GC timer
+            ;; so a later release / work-settle is followed by another GC
+            ;; re-check (and the fired one-shot handle is replaced). A
+            ;; :no-entry skip has nothing to reschedule. The delay is the
+            ;; resource's own :gc-after-ms (positive-guarded — a resource with
+            ;; no GC policy never armed one, so it never reaches this branch).
+            gc-delay (when (not= :no-entry reason)
+                       (positive-or-nil (:gc-after-ms (registry/resource-meta (:resource/id entry)))))]
+        (trace/emit! :rf.event :rf.resource/gc-skipped
+                     {:rf.frame/id frame-id :resource-key resource-key
+                      :reason reason
+                      :rescheduled? (some? gc-delay)})
+        (cond-> {:rf.db/runtime runtime-db}
+          gc-delay
+          (assoc :fx [[:rf.resource/schedule-timers
+                       {:frame-id       frame-id
+                        :resource-key   resource-key
+                        ;; reschedule the GC re-check ONLY (leave stale as-is —
+                        ;; nil disarms that kind in schedule-timers-handler)
+                        :stale-delay-ms nil
+                        :gc-delay-ms    gc-delay
+                        :server?        (server-frame? frame-id)}]]))))))
 
 (defn stale-suppressed-handler
   "`:rf.resource.internal/stale-suppressed` — a late reply carrying a

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -793,18 +793,36 @@
 
 (defn- live-entry-for-reply
   "Look the live entry up for an internal reply and verify it is still the
-  one the reply belongs to: the entry exists AND its `:current-work` equals
-  the reply's `:work-id` AND its `:generation` equals the reply's
-  `:generation`. Returns the entry on a match, nil on a stale / superseded /
-  vanished reply (which MUST be suppressed — Spec 016 §Cancellation is
-  opportunistic; stale suppression is mandatory). The work-id is the single
-  identity (it embeds the generation); the generation check is belt-and-
-  braces for a future transport that reuses a work-id."
-  [runtime-db {:keys [resource-key work-id generation]}]
-  (when-let [entry (get-in runtime-db (state/entry-path resource-key))]
-    (when (and (= work-id (:current-work entry))
-               (= generation (:generation entry)))
-      entry)))
+  one the reply belongs to: the reply's stamped `:rf.frame/id` equals the
+  RECEIVING frame (`receiving-frame-id`), the entry exists, its
+  `:current-work` equals the reply's `:work-id`, AND its `:generation`
+  equals the reply's `:generation`. Returns the entry on a match, nil on a
+  cross-frame / stale / superseded / vanished reply (which MUST be suppressed
+  — Spec 016 §Cancellation is opportunistic; stale suppression is mandatory).
+
+  FRAME VERIFICATION (rf2-eu2ifi): the runtime stamps the qualified
+  `:rf.frame/id` into every reply payload at lowering; the reply handler runs
+  in the RECEIVING frame's cofx. A reply whose payload frame does not match
+  the receiving frame is REJECTED without touching this frame's entry or
+  ledger — a misrouted reply (a cross-frame request-id collision, or a reply
+  re-dispatched into the wrong frame) can never mutate the wrong frame's
+  cache. The frame stamp is checked FIRST (before the per-frame entry lookup)
+  so a cross-frame reply is rejected even when both frames happen to hold the
+  same scoped key at the same generation.
+
+  The work-id is the single intra-frame identity (it embeds the generation);
+  the generation check is belt-and-braces for a future transport that reuses
+  a work-id. A reply with no stamped frame (a direct-dispatch test payload
+  that omits `:rf.frame/id`) skips the frame check (nil never collides with a
+  concrete frame id) and is verified by work-id + generation alone — the
+  runtime-slice tests stay deterministic."
+  [runtime-db receiving-frame-id {:keys [resource-key work-id generation] :as payload}]
+  (let [reply-frame (:rf.frame/id payload)]
+    (when (or (nil? reply-frame) (= reply-frame receiving-frame-id))
+      (when-let [entry (get-in runtime-db (state/entry-path resource-key))]
+        (when (and (= work-id (:current-work entry))
+                   (= generation (:generation entry)))
+          entry)))))
 
 ;; ---- transport reply payload extraction -----------------------------------
 ;;
@@ -885,7 +903,7 @@
    [_event-id {:keys [resource-key work-id generation] :as payload} http-result]]
   (let [runtime-db (or rt {})
         data       (reply-success-data payload http-result)
-        entry      (live-entry-for-reply runtime-db payload)]
+        entry      (live-entry-for-reply runtime-db frame-id payload)]
     (if (nil? entry)
       ;; STALE SUPPRESSION (mandatory): a superseded / vanished reply never
       ;; mutates a newer entry. Settle its (already-superseded) work row to a
@@ -1012,7 +1030,7 @@
   (let [runtime-db (or rt {})
         error      (reply-failure-error payload http-result)
         aborted?   (abort-failure? error)
-        entry      (live-entry-for-reply runtime-db payload)]
+        entry      (live-entry-for-reply runtime-db frame-id payload)]
     (cond
       ;; STALE SUPPRESSION (mandatory): a superseded / vanished reply (failure
       ;; OR abort) never mutates a newer entry. Settle its work row terminal +

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -821,6 +821,27 @@
     (:failure http-result)
     (:error verification-payload)))
 
+(def ^:private http-aborted-kind
+  "The managed-HTTP failure `:kind` for an intentional abort/cancellation
+  (Spec 014 §Aborts — the transport classifies a `:rf.http/managed-abort`,
+  an actor-destroy cancellation, or a timeout teardown to this kind). A
+  failure envelope carrying this kind is a CANCELLATION, not a user-visible
+  resource error (rf2-z70ujl). Note a `:request-id-superseded` abort never
+  even dispatches a reply (the transport suppresses it, Spec 014 §Abort
+  precedence) — so a superseded supersession is handled by the missing reply
+  + stale-suppression, not here."
+  :rf.http/aborted)
+
+(defn- abort-failure?
+  "True iff `error` is a managed-HTTP ABORT failure envelope
+  (`{:kind :rf.http/aborted …}`) — an intentional cancellation that must NOT
+  become a user-visible resource `:error` / `:refresh-error` or a failed
+  ledger row (rf2-z70ujl, Spec 016 §Cancellation is opportunistic). Every
+  other `:rf.http/*` category (transport / 5xx / 4xx / timeout-as-failure /
+  decode / accept) is a genuine failure and flows the ordinary failed path."
+  [error]
+  (= http-aborted-kind (:kind error)))
+
 (defn succeeded-handler
   "`:rf.resource.internal/succeeded` — a transport read succeeded. Verifies
   frame + work-id + generation against the live entry; on match installs the
@@ -916,12 +937,45 @@
                         :gc-delay-ms    gc-delay-ms
                         :server?        (server-frame? frame-id)}]]))))))
 
+(defn- entry-abort-settled
+  "Settle a LIVE entry whose current attempt was ABORTED (a cancellation, NOT
+  a failure — rf2-z70ujl). An abort must NEVER populate `:error` /
+  `:refresh-error` or leave the entry stranded mid-flight:
+
+    - a REFRESH abort (the entry was `:fetching` — it has prior data) returns
+      to `:loaded` and KEEPS the prior `:data` (the cancelled background
+      refresh leaves the last-known-good value intact, no `:refresh-error`);
+    - a FIRST-load abort (the entry was `:loading` — no usable data) settles
+      to a non-error stable `:idle` state (the load was cancelled, not
+      failed; a subsequent live cause re-ensures it cleanly).
+
+  Either way `:current-work` is cleared (the attempt settled) and no error
+  facts are written. Per Spec 016 §Cancellation is opportunistic / §Status
+  semantics. (Distinct from `state/entry-failed`, which records the failure
+  envelope; an abort is the no-error settlement.)"
+  [entry]
+  (if (state/has-data? entry)
+    (assoc entry :status :loaded :current-work nil)
+    (assoc entry :status :idle  :current-work nil)))
+
 (defn failed-handler
   "`:rf.resource.internal/failed` — a transport read failed. Verifies frame
   + work-id + generation; a first-load failure settles `:error` (no usable
   data); a background-refresh failure returns to `:loaded`, keeps prior
   `:data`, and records `:refresh-error`. A stale / superseded reply is
   suppressed. Per Spec 016 §Status semantics.
+
+  An ABORT reply (`{:kind :rf.http/aborted}`, rf2-z70ujl) is NOT a failure:
+  the managed-HTTP transport routes an intentional cancellation (owner-loss
+  orphan abort, actor-destroy, timeout teardown) through this same
+  `:on-failure` reply, but it must NOT become a user-visible resource error
+  or a `:failed` ledger row. It is branched into CANCELLATION semantics —
+  the live attempt settles to a non-error stable state (`entry-abort-settled`)
+  WITHOUT `:error` / `:refresh-error`, the work row settles terminal
+  `:cancelled`, and a route-owned blocking resource drains its slot like a
+  non-error settle (the route un-blocks rather than flipping to `:error`).
+  A stale / superseded abort reply is suppressed by the same
+  `live-entry-for-reply` boundary (it can never mutate a newer entry).
 
   Event shape: `[_ <verification-payload> <http-result>]` — the managed-HTTP
   transport appends `{:kind :failure :failure <:rf.http/* envelope>}` as the
@@ -931,18 +985,49 @@
    [_event-id {:keys [resource-key work-id generation] :as payload} http-result]]
   (let [runtime-db (or rt {})
         error      (reply-failure-error payload http-result)
+        aborted?   (abort-failure? error)
         entry      (live-entry-for-reply runtime-db payload)]
-    (if (nil? entry)
-      ;; STALE SUPPRESSION (mandatory): a superseded / vanished failure
-      ;; reply never mutates a newer entry. Settle its work row terminal +
-      ;; clear the handle.
+    (cond
+      ;; STALE SUPPRESSION (mandatory): a superseded / vanished reply (failure
+      ;; OR abort) never mutates a newer entry. Settle its work row terminal +
+      ;; clear the handle. An aborted stale reply settles :cancelled (it was a
+      ;; cancellation); a failed stale reply settles :suppressed.
+      (nil? entry)
       (do (trace/emit! :rf.event :rf.resource/stale-suppressed
                        {:rf.frame/id frame-id :resource-key resource-key
-                        :work-id work-id :generation generation :outcome :failure})
+                        :work-id work-id :generation generation
+                        :outcome (if aborted? :aborted :failure)})
           (work-ledger/clear-handle! frame-id work-id)
           {:rf.db/runtime (work-ledger/update-record
                             runtime-db work-id work-ledger/mark-terminal
-                            :suppressed {:reason :stale-reply :outcome :failure})})
+                            (if aborted? :cancelled :suppressed)
+                            (if aborted?
+                              {:reason :aborted}
+                              {:reason :stale-reply :outcome :failure}))})
+
+      ;; ABORT (rf2-z70ujl): an intentional cancellation reached the failure
+      ;; reply seam. Settle the LIVE attempt to a non-error stable state, mark
+      ;; the work row terminal :cancelled, drain any route blocking slot like a
+      ;; non-error settle (status :success keeps drain-blocking off the
+      ;; route-:error branch — a cancelled blocking first-load un-blocks the
+      ;; route rather than surfacing a spurious error). NO :error /
+      ;; :refresh-error write. The host handle is cleared.
+      aborted?
+      (let [entry' (entry-abort-settled entry)
+            rdb'   (-> runtime-db
+                       (assoc-in (state/entry-path resource-key) entry')
+                       (work-ledger/update-record
+                         work-id work-ledger/mark-terminal
+                         :cancelled {:reason :aborted})
+                       (route/drain-blocking resource-key entry' :success))]
+        (work-ledger/clear-handle! frame-id work-id)
+        (trace/emit! :rf.event :rf.resource/work-abort-requested
+                     {:rf.frame/id frame-id :resource-key resource-key
+                      :work-id work-id :generation generation
+                      :status-before (:status entry) :status-after (:status entry')})
+        {:rf.db/runtime rdb'})
+
+      :else
       (let [entry' (state/entry-failed entry {:error error})
             op     (if (= :error (:status entry'))
                      :rf.resource/failed :rf.resource/refresh-failed)

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -492,6 +492,17 @@
   multi-user storm is observable + lintable). A cross-scope invalidation with
   no `:scope` is permitted (it is scope-agnostic by construction).
 
+  **Fail closed without a scope** (rf2-pvdae1, Spec 016 §Invalidation): a
+  SCOPED invalidation (the default, `:cross-scope?` false / absent) with NO
+  `:scope` is a loud `:rf.error/resource-invalidate-scope-required` — never
+  a silent `(= nil entry-scope)` match that quietly invalidates nothing (or,
+  worse, only the entries that happen to live in a nil scope). Cross-scope is
+  the ONLY scope-agnostic path; it must be requested explicitly. The concrete
+  `:scope` is routed through the shared `state/canonicalize-scope` validation
+  path (rf2-hosnba) so a reserved-namespace typo (`:rf.scope/glabal`) or a
+  host / non-EDN scope value fails closed through the SAME single path every
+  other scope-bearing operation uses.
+
   **No-match distinction** (Spec 016 §Invalidation): the summary carries
   `:matched` (the matched keys), `:any-tag-match-other-scope?` (whether the
   tags match an entry in ANOTHER scope — \"no match HERE\" vs \"no resource
@@ -499,7 +510,33 @@
   [{rt :rf.db/runtime, frame-id :rf.frame/id}
    [_event-id {:keys [scope tags cause cross-scope?]}]]
   (let [runtime-db (or rt {})
-        cscope     (when (some? scope) (state/canonicalize scope))
+        ;; FAIL CLOSED (rf2-pvdae1): a scoped (default) invalidation MUST
+        ;; carry an explicit :scope — a missing scope would otherwise match
+        ;; `(= nil (first k))` and silently invalidate nothing (or the wrong
+        ;; set). Cross-scope is the only scope-agnostic path and must be
+        ;; opted into explicitly. Per Spec 016 §Invalidation.
+        _          (when (and (not cross-scope?) (nil? scope))
+                     (throw (ex-info ":rf.error/resource-invalidate-scope-required"
+                                     {:rf.error/id :rf.error/resource-invalidate-scope-required
+                                      :where       'rf.resource/invalidate-tags
+                                      :recovery    :fix-scope
+                                      :reason      (str "a scoped :rf.resource/invalidate-tags MUST "
+                                                        "supply an explicit :scope. A missing scope "
+                                                        "is fail-closed (it would silently match "
+                                                        "nothing — or the wrong nil-scope set — "
+                                                        "rather than the intended scope). To "
+                                                        "invalidate the tags in EVERY scope, opt in "
+                                                        "explicitly with :cross-scope? true. Per Spec "
+                                                        "016 §Invalidation.")
+                                      :tags        tags})))
+        ;; route the concrete scope through the SHARED validation path
+        ;; (rf2-hosnba, rf2-lzv9xc): rejects reserved-namespace typos +
+        ;; host / non-EDN scope values, normalizes [:rf.scope/global] → bare,
+        ;; canonicalizes — the SAME single path event/sub resolution, route
+        ;; planning, and clear-scope use. No resource-id (a tag invalidation
+        ;; spans resources); nil when scope-agnostic cross-scope.
+        cscope     (when (some? scope)
+                     (state/canonicalize-scope scope 'rf.resource/invalidate-tags nil))
         tag-set    (set tags)
         invalidated-at (now-ms)
         entries    (get-in runtime-db (state/entries-path))
@@ -637,10 +674,17 @@
   emits an explaining trace. Stale suppression by work-id + generation
   remains the correctness boundary — the entry a late reply would write
   into is gone, so the reply handler's existence check suppresses it; the
-  abort is the optimisation. Payload: `{:scope :cause}`."
+  abort is the optimisation. Payload: `{:scope :cause}`.
+
+  The concrete `:scope` is routed through the shared
+  `state/canonicalize-scope` validation path (rf2-hosnba, rf2-lzv9xc) so a
+  reserved-namespace typo (`:rf.scope/glabal`) or a host / non-EDN scope
+  value fails closed through the SAME single path every other scope-bearing
+  operation uses — a typo can never silently clear the WRONG scope (a
+  cross-tenant data wipe)."
   [{rt :rf.db/runtime, frame-id :rf.frame/id} [_event-id {:keys [scope cause]}]]
   (let [runtime-db (or rt {})
-        cscope     (state/canonicalize scope)
+        cscope     (state/canonicalize-scope scope 'rf.resource/clear-scope nil)
         entries    (get-in runtime-db (state/entries-path))
         in-scope   (into #{} (comp (filter (fn [[k _]] (= cscope (first k))))
                                    (map key))

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -139,6 +139,27 @@
                        (state/empty-entry resource))
         prior-work (:current-work entry)
         in-flight? (some? prior-work)
+        ;; JOINABLE work (rf2-v4ygg5): an `ensure` may DEDUPE onto the prior
+        ;; attempt ONLY when that attempt is genuinely LIVE — its work record
+        ;; exists and its status is `:queued` / `:running`. A record that has
+        ;; been marked `:abort-requested` (the last owner released it, an
+        ;; opportunistic abort was issued) or that has reached a TERMINAL
+        ;; status (`:cancelled` / `:suppressed` / …) is DOOMED — joining it
+        ;; would leave the new owner attached to dead / dying work that will
+        ;; never produce a usable reply (the only reply it can produce is a
+        ;; suppressed/aborted one). Such a stale `:current-work` pointer can
+        ;; survive a route supersession (release-owner marks the record
+        ;; `:abort-requested` but leaves the entry's `:current-work` set) or a
+        ;; direct/internal aborted settlement (the `:rf.resource.internal/
+        ;; aborted` handler settles the row terminal but makes no entry write),
+        ;; so the pointer alone is NOT proof of joinable work — the LINKED
+        ;; RECORD'S status is. A non-joinable prior pointer falls through to a
+        ;; fresh load (a new generation), which is the correct re-ensure.
+        prior-record (when prior-work (work-ledger/get-record runtime-db prior-work))
+        prior-status (:status prior-record)
+        joinable?  (and (some? prior-record)
+                        (not (work-ledger/terminal? prior-status))
+                        (not= :abort-requested prior-status))
         ;; FRESH-SKIP gate (Spec 016 §Lifecycle is an FSM / §Restore and
         ;; replay): an `ensure` (never a `refetch`) of an already-`:loaded`
         ;; entry that is NOT in flight and is still fresh-by-policy serves
@@ -213,8 +234,13 @@
       ;; Attach any supplied owner to the existing entry + record the cause;
       ;; do NOT start a new generation. Join the SAME work-ledger record
       ;; (attach owner / append cause). Per Spec 016 §Race (ensure while in
-      ;; flight joins the existing current work record).
-      (and in-flight? (not force-new?))
+      ;; flight joins the existing current work record). Gated on `joinable?`
+      ;; (rf2-v4ygg5): only a LIVE (:queued / :running) prior attempt is
+      ;; joinable — an `:abort-requested` (owner-released, doomed) or terminal
+      ;; (`:cancelled` / suppressed) prior record falls through to a fresh
+      ;; load below, so a route supersession + immediate re-ensure never joins
+      ;; dead work.
+      (and joinable? (not force-new?))
       (let [joined (cond-> entry
                      owner (update :active-owners (fnil conj #{}) owner))
             rdb'   (-> runtime-db

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -532,6 +532,74 @@
       (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource-key k}])
       (is (some? (entry k)) "in-flight entry kept (GC skipped)"))))
 
+;; ---- rf2-07693y: a GC skip RESCHEDULES so a later release/settle is GC'd ---
+
+(deftest gc-skip-while-owned-reschedules-and-collects-after-release
+  (rf/reg-resource :gcr/article (article-spec {:gc-after-ms 1000}))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :gcr/article {:slug "w"})]
+    (ensure! :gcr/article scope "w" [:lease :gcr 1])
+    (succeed! k {:title "W"})
+    (reset! scheduled-timers [])
+    (testing "rf2-07693y — a GC timer firing while the entry is still OWNED
+              skips collection but RE-ARMS a fresh GC re-check (so a later
+              release after the original deadline does not strand the entry)"
+      (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource-key k}])
+      (is (some? (entry k)) "owned entry kept (GC skipped)")
+      (is (= 1 (count @scheduled-timers)) "exactly one reschedule fx emitted")
+      (let [args (first @scheduled-timers)]
+        (is (= k (:resource-key args)))
+        (is (= 1000 (:gc-delay-ms args)) "rescheduled with the resource's :gc-after-ms")
+        (is (nil? (:stale-delay-ms args)) "stale timer NOT re-armed on a GC skip")))
+    (testing "the owner releases AFTER the original deadline; the rescheduled
+              GC re-check now finds the entry owner-free + idle and collects it"
+      (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :gcr 1]}])
+      (is (empty? (:active-owners (entry k))) "entry now owner-free")
+      (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource-key k}])
+      (is (nil? (entry k)) "the rescheduled GC re-check collected the now-inactive entry"))))
+
+(deftest gc-skip-while-in-flight-reschedules-and-collects-after-settle
+  (rf/reg-resource :gci/article (article-spec {:gc-after-ms 1000}))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :gci/article {:slug "w"})]
+    ;; in flight + owner-free (owner released while loading)
+    (ensure! :gci/article scope "w" [:lease :gci 1])
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :gci 1]}])
+    (is (some? (:current-work (entry k))) "in flight, owner-free")
+    (reset! scheduled-timers [])
+    (testing "rf2-07693y — a GC timer firing while the entry is IN-FLIGHT skips
+              but RE-ARMS a fresh GC re-check"
+      (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource-key k}])
+      (is (some? (entry k)) "in-flight entry kept (GC skipped)")
+      (is (= 1 (count @scheduled-timers)) "one reschedule fx emitted")
+      (is (= 1000 (:gc-delay-ms (first @scheduled-timers)))))
+    (testing "the in-flight work settles (a stale/aborted reply clears
+              :current-work via the work-row terminal); once owner-free + idle
+              the rescheduled GC re-check collects it"
+      ;; settle the work to a non-error idle state via an abort reply (clears
+      ;; :current-work without re-attaching an owner) — the entry is now
+      ;; owner-free + idle (GC-eligible)
+      (let [wid (:current-work (entry k))]
+        (rf/dispatch-sync [:rf.resource.internal/failed
+                           {:resource-key k :work-id wid
+                            :generation (:generation (entry k))
+                            :rf.frame/id :rf/default}
+                           {:kind :failure :failure {:kind :rf.http/aborted :reason :user}}]))
+      (is (nil? (:current-work (entry k))) "work settled — no longer in flight")
+      (is (empty? (:active-owners (entry k))) "owner-free")
+      (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource-key k}])
+      (is (nil? (entry k)) "the rescheduled GC re-check collected the now-idle entry"))))
+
+(deftest gc-skip-no-entry-does-not-reschedule
+  (rf/reg-resource :gcn/article (article-spec {:gc-after-ms 1000}))
+  (let [k (state/scoped-resource-key {:user "u"} :gcn/article {:slug "gone"})]
+    (reset! scheduled-timers [])
+    (testing "rf2-07693y — a GC timer firing for an entry that no longer exists
+              (removed / cleared) does NOT reschedule (nothing to collect)"
+      (rf/dispatch-sync [:rf.resource.internal/gc-fired {:resource-key k}])
+      (is (nil? (entry k)))
+      (is (empty? @scheduled-timers) "no reschedule fx for a vanished entry"))))
+
 (deftest stale-fired-rechecks-durable-fact-no-write
   (rf/reg-resource :sf/article (article-spec {:stale-after-ms 60000}))
   (let [scope {:user "u"}

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -38,6 +38,7 @@
    ;; :rf.resource/* events + the timer / work-ledger side-table fx + the
    ;; internal re-check events these tests dispatch through.
    [re-frame.resources]
+   [re-frame.resources.events :as events]
    [re-frame.resources.state :as state]
    [re-frame.resources.timers :as timers]
    [re-frame.resources.work-ledger :as work-ledger]
@@ -159,6 +160,111 @@
               EVERY scope (the explicit, Xray-visible opt-in)"
       (is (some? (:invalidated-at (entry ka))) "scope A entry marked stale")
       (is (some? (:invalidated-at (entry kb))) "scope B entry ALSO marked stale"))))
+
+;; ---- rf2-pvdae1: scoped invalidate-tags fails closed without a scope -------
+;; The re-frame event loop catches a handler throw and surfaces it as
+;; :rf.error/handler-exception (it does NOT rethrow to dispatch-sync's
+;; caller), so the throw is asserted at the fn boundary (calling
+;; invalidate-tags-handler directly), exactly as the mutation suite asserts
+;; its validation throws. The dispatch-path no-mutation is observed
+;; separately.
+
+(defn- invalidate-cofx
+  "A minimal cofx for a direct invalidate-tags-handler call: a runtime-db
+  value under :rf.db/runtime + a frame id."
+  [runtime-db]
+  {:rf.db/runtime runtime-db :rf.frame/id :rf/default})
+
+(deftest invalidate-tags-scoped-without-scope-fails-closed
+  (testing "rf2-pvdae1 / Spec 016 §Invalidation — a SCOPED (default)
+            invalidate-tags with NO :scope is a loud
+            :rf.error/resource-invalidate-scope-required (never a silent
+            nil-scope match that invalidates nothing or the wrong set)"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-invalidate-scope-required"
+          (events/invalidate-tags-handler
+            (invalidate-cofx {})
+            [:rf.resource/invalidate-tags {:tags #{[:article "w"]}}]))))
+  (testing "an explicitly nil :scope (not merely absent) is ALSO rejected
+            — fail-closed is about the absence of a concrete scope"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-invalidate-scope-required"
+          (events/invalidate-tags-handler
+            (invalidate-cofx {})
+            [:rf.resource/invalidate-tags {:scope nil :tags #{[:article "w"]}}])))))
+
+(deftest invalidate-tags-cross-scope-without-scope-allowed
+  ;; the ONLY scope-agnostic path: :cross-scope? true with no :scope is
+  ;; permitted (scope-agnostic by construction). Proven end-to-end through
+  ;; the dispatch path (no throw → the matched entries are marked stale).
+  (rf/reg-resource :ivxn/article (article-spec))
+  (let [sa {:user "a"} sb {:user "b"}
+        ka (state/scoped-resource-key sa :ivxn/article {:slug "w"})
+        kb (state/scoped-resource-key sb :ivxn/article {:slug "w"})]
+    (ensure! :ivxn/article sa "w" [:lease :a 1])
+    (succeed! ka {:title "A"})
+    (ensure! :ivxn/article sb "w" [:lease :b 1])
+    (succeed! kb {:title "B"})
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :a 1]}])
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :b 1]}])
+    (testing "rf2-pvdae1 — cross-scope? true with NO :scope is allowed
+              (scope-agnostic) and invalidates the tag in every scope"
+      (rf/dispatch-sync [:rf.resource/invalidate-tags
+                         {:tags #{[:article "w"]} :cross-scope? true}])
+      (is (some? (:invalidated-at (entry ka))) "scope A entry marked stale")
+      (is (some? (:invalidated-at (entry kb))) "scope B entry marked stale"))))
+
+;; ---- rf2-hosnba: invalidate-tags scope routes through canonicalize-scope ---
+
+(deftest invalidate-tags-rejects-reserved-scope-typo
+  (testing "rf2-hosnba / rf2-lzv9xc — a reserved-namespace scope typo
+            (:rf.scope/glabal) reaching invalidate-tags fails closed through
+            the shared state/canonicalize-scope path (never a silent wrong
+            cache scope), surfaced as :rf.error/resource-invalid-scope"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
+          (events/invalidate-tags-handler
+            (invalidate-cofx {})
+            [:rf.resource/invalidate-tags
+             {:scope :rf.scope/glabal :tags #{[:article "w"]}}])))))
+
+(deftest invalidate-tags-rejects-host-scope
+  (testing "rf2-hosnba / rf2-lzv9xc — a host / non-EDN scope value reaching
+            invalidate-tags is rejected through the shared path
+            (:rf.error/resource-non-edn-params)"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
+          (events/invalidate-tags-handler
+            (invalidate-cofx {})
+            [:rf.resource/invalidate-tags
+             {:scope {:cb (fn [])} :tags #{[:article "w"]}}])))))
+
+(deftest invalidate-tags-normalizes-singleton-global-scope
+  ;; rf2-hosnba / rf2-vv87xz — the historical [:rf.scope/global] singleton
+  ;; spelling normalizes to the canonical bare :rf.scope/global so it matches
+  ;; the SAME entries an explicit-global resource stored under.
+  (rf/reg-resource :ivg/article (article-spec)) ;; :rf.scope/global policy
+  (let [k (state/scoped-resource-key :rf.scope/global :ivg/article {:slug "w"})]
+    (ensure! :ivg/article :rf.scope/global "w" [:lease :g 1])
+    (succeed! k {:title "G"})
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :g 1]}])
+    (testing "the singleton-vector global spelling matches the bare-global key"
+      (rf/dispatch-sync [:rf.resource/invalidate-tags
+                         {:scope [:rf.scope/global] :tags #{[:article "w"]}}])
+      (is (some? (:invalidated-at (entry k)))
+          "entry under bare :rf.scope/global was matched via the normalized
+           singleton-vector scope"))))
+
+(deftest clear-scope-rejects-reserved-scope-typo
+  (testing "rf2-hosnba / rf2-lzv9xc — clear-scope routes its scope through
+            the shared state/canonicalize-scope path; a reserved-namespace
+            typo (:rf.scope/glabal) fails closed (a typo can never silently
+            clear the WRONG scope — a cross-tenant data wipe)"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-invalid-scope"
+          (events/clear-scope-handler
+            (invalidate-cofx {})
+            [:rf.resource/clear-scope {:scope :rf.scope/glabal :cause :logout}])))))
 
 (deftest invalidate-tags-refetches-active-leaves-inactive-stale
   (rf/reg-resource :ivr/article (article-spec))

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -345,6 +345,60 @@
                (:status (work-ledger/get-record (runtime-db) wid)))
             "work row moved to :abort-requested")))))
 
+;; ---- rf2-v4ygg5: abort-requested / terminal work is NON-joinable ----------
+;; A re-ensure after the last owner released (→ :abort-requested) or after a
+;; direct/internal aborted settle (→ terminal :cancelled) must NOT dedupe onto
+;; the doomed/dead prior attempt — it must start a FRESH generation. (Stale
+;; :current-work pointers survive both paths; the LINKED RECORD'S status is
+;; the joinability boundary, not the pointer.)
+
+(deftest re-ensure-after-owner-release-does-not-join-abort-requested
+  (rf/reg-resource :nj/article (article-spec))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :nj/article {:slug "w"})]
+    ;; load attempt in flight, single owner
+    (ensure! :nj/article scope "w" [:route :r 1])
+    (let [wid1 (:current-work (entry k))
+          gen1 (:generation (entry k))]
+      (is (= :running (:status (work-ledger/get-record (runtime-db) wid1))))
+      ;; the LAST owner releases → the work record is marked :abort-requested
+      ;; (opportunistic abort issued) but the entry still POINTS at wid1.
+      (rf/dispatch-sync [:rf.resource/release-owner {:owner [:route :r 1]}])
+      (is (= :abort-requested (:status (work-ledger/get-record (runtime-db) wid1)))
+          "released-last-owner work is abort-requested")
+      (is (= wid1 (:current-work (entry k)))
+          "entry still points at the abort-requested work (stale pointer)")
+      (testing "rf2-v4ygg5 — an immediate re-ensure does NOT join the
+                abort-requested work; it starts a FRESH generation + work id"
+        (ensure! :nj/article scope "w" [:route :r 2])
+        (let [e (entry k)]
+          (is (= (inc gen1) (:generation e)) "fresh generation (no dedupe onto dead work)")
+          (is (not= wid1 (:current-work e)) "a new work id, not the abort-requested one")
+          (is (= :running (:status (work-ledger/get-record (runtime-db) (:current-work e))))
+              "the new attempt is live")
+          (is (contains? (:active-owners e) [:route :r 2])
+              "the new owner is attached to the fresh attempt"))))))
+
+(deftest re-ensure-after-internal-aborted-settle-does-not-join-terminal
+  (rf/reg-resource :njt/article (article-spec))
+  (let [scope {:user "u"}
+        k     (state/scoped-resource-key scope :njt/article {:slug "w"})]
+    (ensure! :njt/article scope "w" [:lease :a 1])
+    (let [wid1 (:current-work (entry k))
+          gen1 (:generation (entry k))]
+      ;; a direct internal aborted settle marks the work TERMINAL :cancelled
+      ;; (the aborted-handler makes no entry write — the pointer dangles).
+      (rf/dispatch-sync [:rf.resource.internal/aborted
+                         {:resource-key k :work-id wid1 :generation gen1}])
+      (is (= :cancelled (:status (work-ledger/get-record (runtime-db) wid1)))
+          "the directly-aborted work row is terminal :cancelled")
+      (testing "rf2-v4ygg5 — a subsequent ensure does NOT join the terminal
+                work; it starts a fresh generation"
+        (ensure! :njt/article scope "w" [:lease :a 2])
+        (let [e (entry k)]
+          (is (= (inc gen1) (:generation e)) "fresh generation")
+          (is (not= wid1 (:current-work e)) "a new live work id"))))))
+
 ;; ===========================================================================
 ;; 3. clear-scope — suppress late reply by entry-vanish + generation
 ;; ===========================================================================

--- a/implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc
@@ -37,6 +37,7 @@
    [re-frame.resources]
    [re-frame.resources.state :as state]
    [re-frame.resources.transport.http :as http]
+   [re-frame.resources.work-ledger :as work-ledger]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch is overridden by the capturing reply stub below.
@@ -275,6 +276,116 @@
         (testing "the CURRENT gen-2 reply lands normally"
           (reply-success! @last-managed-args {:fresh "data"})
           (is (= {:fresh "data"} (:data (entry scoped-key)))))))))
+
+;; ===========================================================================
+;; 4b. managed-HTTP ABORT replies are CANCELLATION, not failure (rf2-z70ujl)
+;;     — an intentional abort routes through the same :on-failure reply but
+;;     must NOT populate :error / :refresh-error or a :failed ledger row; the
+;;     work row settles :cancelled and the entry settles to a non-error state.
+;;     Tests use the REAL managed-HTTP failure shape ({:kind :rf.http/aborted}).
+;; ===========================================================================
+
+(defn- aborted-failure
+  "The real managed-HTTP abort failure envelope (Spec 014 §Aborts) the
+  transport dispatches through the :on-failure reply for an intentional
+  cancellation (`:user` / `:actor-destroyed` / `:timeout`). `:request-id-
+  superseded` is NOT used here — the transport suppresses that reply entirely."
+  [request-id reason]
+  {:kind :rf.http/aborted :request-id request-id :reason reason :actor-id nil})
+
+(deftest first-load-abort-settles-non-error-not-failure
+  (rf/reg-resource :ab1/article (article-spec))
+  (let [k (state/scoped-resource-key :rf.scope/global :ab1/article {:slug "w"})]
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :ab1/article :scope :rf.scope/global
+                        :params {:slug "w"} :owner [:lease :ab1 1]}])
+    (is (= :loading (:status (entry k))))
+    (let [wid (:current-work (entry k))]
+      (testing "rf2-z70ujl — a FIRST-load abort reply (the real
+                {:kind :rf.http/aborted} envelope) settles to a non-error
+                stable state: NOT :error, NO :error envelope, no usable data"
+        (reply-failure! @last-managed-args (aborted-failure wid :user))
+        (let [e (entry k)]
+          (is (not= :error (:status e)) "aborted first-load did NOT settle :error")
+          (is (= :idle (:status e)) "settled to a non-error stable :idle state")
+          (is (nil? (:error e)) "no error envelope written")
+          (is (nil? (:refresh-error e)) "no refresh-error written")
+          (is (nil? (:data e)) "no data (the load was cancelled)")
+          (is (nil? (:current-work e)) "current-work cleared")))
+      (testing "the work row settles terminal :cancelled (not :failed)"
+        (let [rec (work-ledger/get-record (runtime-db) wid)]
+          (is (= :cancelled (:status rec)) "work row :cancelled")
+          (is (= :aborted (:reason (:outcome rec)))))))))
+
+(deftest refresh-abort-preserves-prior-loaded-data
+  (rf/reg-resource :ab2/article (article-spec))
+  (let [k (state/scoped-resource-key :rf.scope/global :ab2/article {:slug "w"})]
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :ab2/article :scope :rf.scope/global
+                        :params {:slug "w"} :owner [:lease :ab2 1]}])
+    (reply-success! @last-managed-args {:title "Loaded"})
+    (rf/dispatch-sync [:rf.resource/refetch
+                       {:resource :ab2/article :scope :rf.scope/global
+                        :params {:slug "w"}}])
+    (is (= :fetching (:status (entry k))))
+    (let [wid (:current-work (entry k))]
+      (testing "rf2-z70ujl — a background-REFRESH abort returns to :loaded,
+                PRESERVES prior :data, and records NO :refresh-error (a
+                cancelled refresh leaves the last-known-good value intact)"
+        (reply-failure! @last-managed-args (aborted-failure wid :actor-destroyed))
+        (let [e (entry k)]
+          (is (= :loaded (:status e)) "returned to :loaded")
+          (is (= {:title "Loaded"} (:data e)) "prior data preserved")
+          (is (nil? (:refresh-error e)) "no refresh-error (abort is not a failure)")
+          (is (nil? (:error e)))
+          (is (nil? (:current-work e)) "current-work cleared")))
+      (testing "the work row settles terminal :cancelled"
+        (is (= :cancelled (:status (work-ledger/get-record (runtime-db) wid))))))))
+
+(deftest stale-abort-reply-cannot-mutate-newer-entry
+  (rf/reg-resource :ab3/article (article-spec))
+  (let [k (state/scoped-resource-key :rf.scope/global :ab3/article {:slug "w"})]
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :ab3/article :scope :rf.scope/global
+                        :params {:slug "w"} :owner [:lease :ab3 1]}])
+    (let [gen1-args @last-managed-args
+          gen1-wid  (:current-work (entry k))]
+      ;; supersede with a forced refetch → gen 2 is the live work
+      (rf/dispatch-sync [:rf.resource/refetch
+                         {:resource :ab3/article :scope :rf.scope/global
+                          :params {:slug "w"}}])
+      (is (= 2 (:generation (entry k))))
+      (testing "rf2-z70ujl — a STALE (gen-1) abort reply NEVER mutates the
+                newer gen-2 entry (the live-entry-for-reply boundary
+                suppresses it); the gen-2 in-flight attempt is untouched"
+        (reply-failure! gen1-args (aborted-failure gen1-wid :user))
+        (let [e (entry k)]
+          (is (= 2 (:generation e)) "entry still on gen 2")
+          (is (= :loading (:status e)) "gen-2 attempt still in flight")
+          (is (some? (:current-work e)) "gen-2 work pointer intact"))
+        (testing "the STALE gen-1 work row settles :cancelled (it was a
+                  cancellation), not :suppressed-as-failure"
+          (is (= :cancelled (:status (work-ledger/get-record (runtime-db) gen1-wid)))))))))
+
+(deftest owner-release-orphan-abort-does-not-set-entry-error
+  ;; the end-to-end orphan path: an in-flight first load whose last owner is
+  ;; released emits a best-effort abort; when that abort reply lands it must
+  ;; NOT surface as a resource error (rf2-z70ujl acceptance).
+  (rf/reg-resource :ab4/article (article-spec))
+  (let [k (state/scoped-resource-key :rf.scope/global :ab4/article {:slug "w"})]
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :ab4/article :scope :rf.scope/global
+                        :params {:slug "w"} :owner [:lease :ab4 1]}])
+    (let [args @last-managed-args
+          wid  (:current-work (entry k))]
+      (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :ab4 1]}])
+      (testing "rf2-z70ujl — when the orphaned in-flight attempt's abort reply
+                lands it settles cancellation, NOT a user-visible error"
+        (reply-failure! args (aborted-failure wid :user))
+        (let [e (entry k)]
+          (is (not= :error (:status e)) "orphan abort did not set :error status")
+          (is (nil? (:error e)) "no error envelope on the entry")
+          (is (empty? (:active-owners e)) "still owner-free"))))))
 
 ;; ===========================================================================
 ;; 5. ensure dedupe / join while in flight (attach owner, no new generation)

--- a/implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc
@@ -32,6 +32,7 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
+   [re-frame.frame :as frame]
    ;; load-bearing side-effecting requires: register the :rf.resource/*
    ;; events + subs + the generation cofx/fx these tests dispatch.
    [re-frame.resources]
@@ -386,6 +387,71 @@
           (is (not= :error (:status e)) "orphan abort did not set :error status")
           (is (nil? (:error e)) "no error envelope on the entry")
           (is (empty? (:active-owners e)) "still owner-free"))))))
+
+;; ===========================================================================
+;; 4c. cross-frame reply isolation (rf2-eu2ifi) — a reply whose stamped
+;;     :rf.frame/id does not match the RECEIVING frame is rejected without
+;;     mutating that frame's entry or ledger; the verification payload carries
+;;     the qualified frame stamp the reply handlers compare against.
+;; ===========================================================================
+
+(defn- reply-into-frame!
+  "Dispatch a success reply (the real 3-element transport shape) INTO
+  `frame-id`, with the verification `payload` (which carries `:rf.frame/id`)."
+  [frame-id payload data]
+  (rf/dispatch-sync (conj [(nth (:on-success @last-managed-args) 0) payload]
+                          {:kind :success :value data})
+                    {:frame frame-id}))
+
+(deftest lowering-stamps-receiving-frame-into-reply-payload
+  (rf/reg-resource :ff/article (article-spec))
+  (let [fa :ff/frame-a]
+    (rf/reg-frame fa {:doc "frame stamp frame A"})
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :ff/article :scope :rf.scope/global
+                        :params {:slug "w"} :owner [:lease :ff 1]}]
+                      {:frame fa})
+    (testing "rf2-eu2ifi — the reply verification payload stamps the issuing
+              frame's qualified :rf.frame/id (so the receiving handler can
+              compare it)"
+      (let [vp (nth (:on-success @last-managed-args) 1)]
+        (is (= fa (:rf.frame/id vp)) "payload carries the issuing frame stamp")))
+    (frame/destroy-frame! fa)))
+
+(deftest cross-frame-reply-rejected-without-mutating-receiving-frame
+  (rf/reg-resource :xf/article (article-spec))
+  (let [fa :xf/frame-a
+        fb :xf/frame-b
+        k  (state/scoped-resource-key :rf.scope/global :xf/article {:slug "w"})]
+    (rf/reg-frame fa {:doc "xframe A"})
+    (rf/reg-frame fb {:doc "xframe B"})
+    ;; both frames issue the SAME resource at the SAME generation (gen 1) —
+    ;; the collision case the bare-work-id correlation could not tell apart.
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :xf/article :scope :rf.scope/global
+                                            :params {:slug "w"} :owner [:lease :a 1]}]
+                      {:frame fa})
+    (let [a-payload (nth (:on-success @last-managed-args) 1)]
+      (rf/dispatch-sync [:rf.resource/ensure {:resource :xf/article :scope :rf.scope/global
+                                              :params {:slug "w"} :owner [:lease :b 1]}]
+                        {:frame fb})
+      (is (= 1 (:generation (entry fa k))) "frame A entry on gen 1")
+      (is (= 1 (:generation (entry fb k))) "frame B entry on gen 1 (same gen — collision case)")
+      (testing "rf2-eu2ifi — frame A's reply (payload stamped :rf.frame/id = A)
+                dispatched INTO frame B is REJECTED: frame B's entry is not
+                mutated (no cross-frame write even at the same work-id/gen)"
+        (reply-into-frame! fb a-payload {:title "A-data"})
+        (let [eb (entry fb k)]
+          (is (not= {:title "A-data"} (:data eb)) "frame B entry NOT written by frame A's reply")
+          (is (= :loading (:status eb)) "frame B still in flight (reply rejected)")
+          (is (nil? (:data eb)) "frame B has no data")))
+      (testing "frame A's reply dispatched into its OWN frame settles normally
+                (the frame stamp matches the receiving frame)"
+        (reply-into-frame! fa a-payload {:title "A-data"})
+        (is (= {:title "A-data"} (:data (entry fa k))) "frame A settled by its own reply")
+        (is (= :loaded (:status (entry fa k))))
+        (is (= :loading (:status (entry fb k))) "frame B still independently in flight")))
+    (frame/destroy-frame! fa)
+    (frame/destroy-frame! fb)))
 
 ;; ===========================================================================
 ;; 5. ensure dedupe / join while in flight (attach owner, no new generation)

--- a/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
@@ -37,6 +37,7 @@
    [re-frame.resources]
    [re-frame.resources.route :as route]
    [re-frame.resources.state :as state]
+   [re-frame.resources.work-ledger :as work-ledger]
    [re-frame.resources.test-support]
    [re-frame.routing :as routing]
    [re-frame.schemas]
@@ -281,6 +282,75 @@
       (is (not (contains? (:active-owners (entry scoped-key))
                           [:route :route/article token-1]))
           "the prior route owner was released on leave"))))
+
+;; ---- rf2-v4ygg5: route A→B (same scoped key) does not join abort-requested -
+;; A route leave releases the prior nav-token owner, which marks an in-flight
+;; attempt :abort-requested while the entry still points at it. An immediate
+;; re-entry of the SAME scoped key must NOT join that doomed work — it starts
+;; a fresh attempt, and a blocking re-entry must drain on the FRESH reply (not
+;; hang waiting on a reply the aborted work will never send).
+
+(defn- work-record-for [scoped-key]
+  (work-ledger/get-record (rf/runtime-db-value :rf/default) (:current-work (entry scoped-key))))
+
+(deftest route-resupersede-same-key-does-not-join-abort-requested-non-blocking
+  (rf/reg-resource :article/by-slug (article-spec {}))
+  (rf/reg-route :route/article
+                {:path      "/articles/:slug"
+                 :params    [:map [:slug :string]]
+                 :resources [{:resource :article/by-slug
+                              :params   (fn [route] {:slug (get-in route [:params :slug])})}]})
+  (rf/reg-route :route/home {:path "/"})
+  (let [scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
+    ;; enter route A: the resource is in flight under token-1's route owner
+    (rf/dispatch-sync [:rf.route/navigate :route/article {:slug "intro"}])
+    (let [token-1 (:nav-token (slice))
+          wid1    (:current-work (entry scoped-key))
+          gen1    (:generation (entry scoped-key))]
+      (is (= :running (:status (work-record-for scoped-key))))
+      ;; leave (route B = home): releases token-1's route owner → wid1 becomes
+      ;; :abort-requested; the entry still points at wid1.
+      (rf/dispatch-sync [:rf.route/navigate :route/home])
+      (is (= :abort-requested (:status (work-ledger/get-record (rf/runtime-db-value :rf/default) wid1)))
+          "the superseded route's in-flight work is abort-requested")
+      ;; re-enter the SAME route + same slug → re-ensure the same scoped key
+      (rf/dispatch-sync [:rf.route/navigate :route/article {:slug "intro"}])
+      (testing "rf2-v4ygg5 — the re-entry started a FRESH attempt, not a join
+                onto the abort-requested work"
+        (let [e (entry scoped-key)]
+          (is (= (inc gen1) (:generation e)) "fresh generation on re-entry")
+          (is (not= wid1 (:current-work e)) "a new work id (not the abort-requested one)")
+          (is (= :running (:status (work-record-for scoped-key))) "the new attempt is live")
+          (is (contains? (:active-owners e) [:route :route/article (:nav-token (slice))])
+              "the re-entry nav-token owns the fresh attempt"))))))
+
+(deftest route-resupersede-same-key-blocking-transition-drains
+  (rf/reg-resource :article/by-slug (article-spec {}))
+  (rf/reg-route :route/article
+                {:path      "/articles/:slug"
+                 :params    [:map [:slug :string]]
+                 :resources [{:resource  :article/by-slug
+                              :params    (fn [route] {:slug (get-in route [:params :slug])})
+                              :blocking? true}]})
+  (rf/reg-route :route/home {:path "/"})
+  (let [scoped-key (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "intro"})]
+    (rf/dispatch-sync [:rf.route/navigate :route/article {:slug "intro"}])
+    (let [wid1 (:current-work (entry scoped-key))]
+      (rf/dispatch-sync [:rf.route/navigate :route/home])
+      (is (= :abort-requested (:status (work-ledger/get-record (rf/runtime-db-value :rf/default) wid1))))
+      ;; re-enter the blocking route on the SAME key
+      (rf/dispatch-sync [:rf.route/navigate :route/article {:slug "intro"}])
+      (let [token-2 (:nav-token (slice))]
+        (testing "rf2-v4ygg5 — the blocking re-entry holds :loading on a FRESH
+                  attempt (it did not join the abort-requested work)"
+          (is (= :loading (:transition (slice))) "blocking transition is loading on a fresh attempt")
+          (is (not= wid1 (:current-work (entry scoped-key))) "fresh work id, not the aborted one")
+          (is (contains? (blocking-slot token-2) scoped-key) "the new token's blocking slot tracks the key"))
+        (testing "the FRESH attempt's reply drains the blocking slot → :idle
+                  (the route does not hang on the aborted work's missing reply)"
+          (settle-success! scoped-key {:title "Intro"})
+          (is (= :idle (:transition (slice))) "blocking transition drained on the fresh reply")
+          (is (empty? (blocking-slot token-2)) "the blocking slot drained"))))))
 
 ;; ===========================================================================
 ;; 6. :when gates the resource out


### PR DESCRIPTION
Events-core cluster: 6 `[resources]` beads, one worktree → one PR, all on `implementation/resources/src/re_frame/resources/events.cljc` + its tests. Pre-alpha, no back-compat; XState-grade correctness; no gold-plating.

## Beads

- **rf2-pvdae1** (P2, DONE) — `invalidate-tags` fails closed without an explicit scope. A scoped (default) invalidation with no `:scope` now throws `:rf.error/resource-invalidate-scope-required` instead of silently matching the nil scope; `:cross-scope? true` remains the only scope-agnostic path.
- **rf2-hosnba** (P2, DONE) — `invalidate-tags-handler` + `clear-scope-handler` route their concrete scope through the shared `state/canonicalize-scope` (rejects reserved-namespace typos + host/non-EDN scopes, normalizes `[:rf.scope/global]` to bare) instead of bare `state/canonicalize`.
- **rf2-z70ujl** (P2, DONE) — managed-HTTP abort replies (`{:kind :rf.http/aborted}`) are treated as cancellation in `failed-handler`: settle to a non-error stable state (`:loaded` keeping prior data for a refresh abort, `:idle` for a first-load abort), no `:error`/`:refresh-error`, work row `:cancelled`, route blocking slot drained as a non-error settle. Stale abort replies suppressed by the existing frame/work/gen boundary.
- **rf2-v4ygg5** (P2, DONE) — `ensure-load` dedupe is gated on `joinable?` (the linked work record is genuinely live — not terminal, not `:abort-requested`) instead of the bare `:current-work` pointer, so a route supersession + immediate re-ensure never joins doomed/dead work; it starts a fresh generation.
- **rf2-eu2ifi** (P2, PARTIAL — reply-frame verification landed; request-id frame-qualification deferred) — `live-entry-for-reply` now rejects a reply whose stamped `:rf.frame/id` does not equal the receiving frame, without mutating that frame's entry/ledger (cross-frame isolation even at the same work-id/generation). The request-id frame-qualification half is cross-surface (work-ledger `abort-fx` + its tests, `mutation_events`, spec/016 — all outside this lane's edit fence; a prototype was implemented + reverted because it broke 5 work_ledger tests pinning abort-arg == bare work-id) and is filed as **rf2-sxyrzk** for a single cross-surface worker. eu2ifi left in_progress pending that follow-up.
- **rf2-07693y** (P2, DONE) — `gc-fired-handler` re-arms a fresh GC re-check on a `:has-owner`/`:in-flight` skip (cancel-then-arm also cleans the fired one-shot handle), so a post-deadline release/settle is followed by deterministic collection; a `:no-entry` skip does not reschedule.

## Quality gates

- **resources JVM** (`cd implementation/resources && clojure -M:test`): **219 tests, 787 assertions, 0 failures, 0 errors** (was 206 — new beads tests + assertions).
- **CLJS node integration** (`cd implementation && npm run test:cljs`): **6398 tests, 23033 assertions, 0 failures, 0 errors**.
- **core JVM** (`cd implementation/core && clojure -M:test`): **1065 tests, 4667 assertions, 0 failures, 0 errors**.
- **JS harness** (`npm run test:script-policy` + `test:script-helpers`): pass.
- **fast-PR Python guards** (lockstep, skill/MCP drift, migration cites, implementor order, eval-docs): pass.
- **README inventory ratchet**: local-only false positive — `npm install`/shadow created gitignored `implementation/node_modules` + `out` build dirs the guard reads off disk; not in the diff, will not trip CI.
- At least one adversarial/negative case per bead (scope-required reject, reserved-typo reject, host-scope reject, first-load/refresh/stale/orphan abort, non-joinable re-ensure x2 + route A to B x2, cross-frame reply reject, GC reschedule-then-collect x2 + no-entry).
- No public var added, so no API-manifest drift.
