### PR TITLE
fix(resources): visibilitychange listener + coalesced revalidation + test-coverage (revalidation+tests cluster)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -426,21 +426,55 @@
   causes)."
   :reconnect)
 
+(defn- entry-revalidation-in-flight?
+  "True iff `entry` already has a LIVE refetch in flight — its
+  `:current-work` points at a work-ledger record whose status is
+  non-terminal AND not `:abort-requested` (i.e. `:queued` / `:running`: work
+  that will produce a usable reply). Such an entry needs no new revalidation
+  refetch — one is already running. A `:current-work` pointer alone is NOT
+  proof of live work: the linked record may be terminal (a settled attempt
+  whose entry write has not yet cleared the pointer) or `:abort-requested`
+  (a doomed, owner-released attempt) — both fall through as NOT in-flight, so
+  revalidation can legitimately start fresh work. Mirrors the `joinable?`
+  gate in `ensure-load` (rf2-v4ygg5): only a genuinely live attempt blocks a
+  new generation. Per Spec 016 §Race / §Deferred slices (rf2-wankrd:
+  coalesce focus + visibility revalidation for in-flight stale entries)."
+  [runtime-db entry]
+  (when-let [work-id (:current-work entry)]
+    (let [status (:status (work-ledger/get-record runtime-db work-id))]
+      (and (some? status)
+           (not (work-ledger/terminal? status))
+           (not= :abort-requested status)))))
+
 (defn- active-stale-scan
   "Pure scan: given the frame's `runtime-db` value and the live `clock-ms`,
   return the vector of `{:resource-key :scope :resource :params}` for every
-  cache entry that is BOTH active (has at least one `:active-owner` — a live
-  lease worth refetching) AND stale-by-policy (`state/entry-stale?` against
-  the durable timestamps). Fresh entries and owner-free entries are excluded.
+  cache entry that is active (has at least one `:active-owner` — a live lease
+  worth refetching), stale-by-policy (`state/entry-stale?` against the
+  durable timestamps), AND not already mid-revalidation (no LIVE in-flight
+  refetch — `entry-revalidation-in-flight?`). Fresh entries, owner-free
+  entries, and entries with a live refetch already running are excluded.
+
+  COALESCING (rf2-wankrd): a tab-return commonly fires BOTH `focus` (on
+  `window`) and `visibilitychange` (on `document`), each dispatching
+  `:rf.resource/window-focused`. Without the in-flight gate, the first scan
+  starts a refetch (setting `:current-work` to a `:running` record) and the
+  second scan would force a SECOND new generation over it — superseding +
+  aborting the first (abort churn) for no benefit. Skipping entries with live
+  in-flight work makes back-to-back focus / focus+visibility signals
+  idempotent: one active-stale key yields at most one new generation.
+
   Per Spec 016 §Stale and GC scheduling / §Deferred slices (focus/reconnect
-  active-stale scan). A pure selection — it never mutates; the caller turns
-  the selection into background `:rf.resource/refetch` dispatches."
+  active-stale scan) / §Race (refetch may force a new generation). A pure
+  selection — it never mutates; the caller turns the selection into
+  background `:rf.resource/refetch` dispatches."
   [runtime-db clock-ms]
   (let [entries (get-in runtime-db (state/entries-path))]
     (into []
           (keep (fn [[scoped-key entry]]
                   (when (and (seq (:active-owners entry))
-                             (state/entry-stale? entry clock-ms))
+                             (state/entry-stale? entry clock-ms)
+                             (not (entry-revalidation-in-flight? runtime-db entry)))
                     (let [[scope resource-id params] scoped-key]
                       {:resource-key scoped-key
                        :scope        scope

--- a/implementation/resources/src/re_frame/resources/revalidate_listeners.cljc
+++ b/implementation/resources/src/re_frame/resources/revalidate_listeners.cljc
@@ -11,12 +11,16 @@
 
   ## The seam
 
-  The host browser surfaces a `focus` / `visibilitychange` (tab return) and
-  an `online` (network reconnect) event on `window`. This namespace wires
-  those to a resource event dispatched at a specific FRAME:
+  The host browser surfaces a `focus` / `online` (network reconnect) event
+  on `window` and a `visibilitychange` (tab return) event on `document` (the
+  ONLY target `visibilitychange` fires on — it is a `document` event, not a
+  `window` one, and `document.visibilityState` is what the handler reads).
+  This namespace wires those to a resource event dispatched at a specific
+  FRAME:
 
-    focus / visibilitychange-to-visible  -> [:rf.resource/window-focused]
-    online                               -> [:rf.resource/network-reconnected]
+    window  focus                         -> [:rf.resource/window-focused]
+    document visibilitychange-to-visible  -> [:rf.resource/window-focused]
+    window  online                        -> [:rf.resource/network-reconnected]
 
   The event handlers (`re-frame.resources.events`) do the active-stale scan
   + background refetch-by-policy. The listener carries NO policy — it only
@@ -112,16 +116,27 @@
      (when (exists? js/window) js/window)))
 
 #?(:cljs
+   (defn- document-obj
+     "The `js/document` object, or nil when no DOM is present (node / SSR).
+     `visibilitychange` is a `document` event (it never fires on `window`),
+     so the visibility listener attaches/detaches HERE."
+     []
+     (when (exists? js/document) js/document)))
+
+#?(:cljs
    (defn- remove-frame-listeners!
-     "Detach + drop frame-id's installed window listeners from the side table
-     (a no-op when none is installed). Idempotent. CLJS-only."
+     "Detach + drop frame-id's installed listeners from the side table (a
+     no-op when none is installed). Idempotent. CLJS-only. `focus` / `online`
+     detach from `window`; `visibilitychange` detaches from `document` (its
+     only event target)."
      [frame-id]
-     (when-let [w (window-obj)]
-       (when-let [{:keys [focus visibility online]} (get @listener-table frame-id)]
-         (try (when focus      (.removeEventListener w "focus" focus))
-              (when visibility  (.removeEventListener w "visibilitychange" visibility))
-              (when online      (.removeEventListener w "online" online))
-              (catch :default _ nil))))
+     (when-let [{:keys [focus visibility online]} (get @listener-table frame-id)]
+       (try (when-let [w (window-obj)]
+              (when focus  (.removeEventListener w "focus" focus))
+              (when online (.removeEventListener w "online" online)))
+            (when-let [d (document-obj)]
+              (when visibility (.removeEventListener d "visibilitychange" visibility)))
+            (catch :default _ nil)))
      (swap! listener-table dissoc frame-id)
      nil))
 
@@ -130,13 +145,14 @@
   active-stale revalidation for `frame-id`. Per Spec 016 §Deferred slices
   (focus/reconnect revalidation as resource events).
 
-  Wires three `window` listeners:
+  Wires three host listeners (`focus` / `online` on `window`,
+  `visibilitychange` on `document` — its only valid event target):
 
-    - `focus`            -> `[:rf.resource/window-focused]`  @ frame-id
-    - `visibilitychange` -> `[:rf.resource/window-focused]`  @ frame-id (only
-                            when the document becomes VISIBLE — the tab-return
-                            case TanStack Query revalidates on);
-    - `online`           -> `[:rf.resource/network-reconnected]` @ frame-id.
+    - `window`  `focus`            -> `[:rf.resource/window-focused]`  @ frame-id
+    - `document` `visibilitychange` -> `[:rf.resource/window-focused]`  @ frame-id
+                            (only when the document becomes VISIBLE — the
+                            tab-return case TanStack Query revalidates on);
+    - `window`  `online`           -> `[:rf.resource/network-reconnected]` @ frame-id.
 
   The event handlers do the scan + background refetch-by-policy; the listener
   only translates the host event into the frame-targeted resource event (the
@@ -154,14 +170,21 @@
      (when-let [w (window-obj)]
        ;; replace, don't stack (hot-reload safe)
        (remove-frame-listeners! frame-id)
-       (let [focus-handler      (fn [_e] (dispatch-revalidation! frame-id window-focused-event))
+       (let [d                  (document-obj)
+             focus-handler      (fn [_e] (dispatch-revalidation! frame-id window-focused-event))
              visibility-handler (fn [_e]
-                                  (when (and (exists? js/document)
-                                             (= "visible" (.-visibilityState js/document)))
+                                  ;; `visibilitychange` fires on BOTH the
+                                  ;; visible→hidden and hidden→visible
+                                  ;; transitions; revalidate ONLY on the
+                                  ;; tab-return (document becomes VISIBLE),
+                                  ;; never when the tab is hidden.
+                                  (when (and d (= "visible" (.-visibilityState d)))
                                     (dispatch-revalidation! frame-id window-focused-event)))
              online-handler     (fn [_e] (dispatch-revalidation! frame-id network-reconnected-event))]
          (.addEventListener w "focus" focus-handler)
-         (.addEventListener w "visibilitychange" visibility-handler)
+         ;; `visibilitychange` is a `document` event — attach it to `document`,
+         ;; not `window` (the handler reads `document.visibilityState`).
+         (when d (.addEventListener d "visibilitychange" visibility-handler))
          (.addEventListener w "online" online-handler)
          (swap! listener-table assoc frame-id
                 {:focus focus-handler :visibility visibility-handler :online online-handler})
@@ -170,11 +193,12 @@
      :clj nil))
 
 (defn remove-revalidation-listeners!
-  "Tear down the window focus / online listeners installed for `frame-id` by
-  `install-revalidation-listeners!`. No-op when none is installed (and on the
-  JVM). Useful for test isolation and single-page hosts that rotate which
-  frame owns revalidation. CLJS detaches the host listeners; both arms drop
-  the side-table slot. Returns nil."
+  "Tear down the window focus / online + document visibilitychange listeners
+  installed for `frame-id` by `install-revalidation-listeners!`. No-op when
+  none is installed (and on the JVM). Useful for test isolation and
+  single-page hosts that rotate which frame owns revalidation. CLJS detaches
+  the host listeners (focus/online from `window`, visibilitychange from
+  `document`); both arms drop the side-table slot. Returns nil."
   [frame-id]
   #?(:cljs (remove-frame-listeners! frame-id)
      :clj  (do (swap! listener-table dissoc frame-id) nil))

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -61,13 +61,17 @@
   capturing no-ops, and CAPTURE :rf.resource/schedule-timers so the
   succeeded-handler's arming is asserted WITHOUT a real wall-clock timer
   firing (the timer-table primitive is tested directly elsewhere). Composed
-  INSIDE the reset-runtime fixture (one `use-fixtures` call)."
+  INSIDE the reset-runtime fixture (one `use-fixtures` call).
+
+  rf2-784223: the shared `make-reset-runtime-fixture`'s
+  `:resources/reset-resources!` post-dispose hook already clears the state /
+  work-ledger / timer host caches before this fixture runs, so no per-suite
+  reset is repeated here. (The timer-PRIMITIVE tests below keep their own
+  `timers/reset-cache!` calls — those are direct primitive assertions that
+  reset just before arming a real timer, not fixture-level cache hygiene.)"
   [f]
   (reset! aborts [])
   (reset! scheduled-timers [])
-  (state/reset-cache!)
-  (work-ledger/reset-cache!)
-  (timers/reset-cache!)
   (rf/reg-fx :rf.http/managed (fn [_ctx _args] nil))
   (rf/reg-fx :rf.http/managed-abort (fn [_ctx work-id] (swap! aborts conj work-id) nil))
   ;; capture the schedule-timers arming (the real fx arms host timers; here we

--- a/implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc
@@ -64,10 +64,13 @@
   "Override :rf.http/managed with a capturing no-op (binary fx-handler
   signature). The reply is replayed explicitly by the test via
   `reply-success!` / `reply-failure!` so the 3-element internal reply event
-  matches what the live transport produces."
+  matches what the live transport produces.
+
+  rf2-784223: the shared `make-reset-runtime-fixture`'s
+  `:resources/reset-resources!` post-dispose hook already clears the resource
+  state cache before this fixture runs — no per-suite reset is repeated here."
   [f]
   (reset! last-managed-args nil)
-  (state/reset-cache!)
   (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   (f))
 

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -38,8 +38,11 @@
    [re-frame.resources.mutation-runtime :as mstate]
    [re-frame.resources.mutation-events :as mevents]
    [re-frame.resources.mutation-registry :as mreg]
+   ;; work-ledger: used by the cross-frame request-id correlation assertions
+   ;; (rf2-sxyrzk). The per-suite `(timers/reset-cache!)` was dropped with the
+   ;; rf2-784223 fixture consolidation (shared reset hook clears timer caches),
+   ;; so the `timers` alias is no longer required here.
    [re-frame.resources.work-ledger :as work-ledger]
-   [re-frame.resources.timers :as timers]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch is overridden by the capturing reply stub below.
@@ -55,11 +58,13 @@
 (def ^:private scheduled-timers (atom []))
 
 (defn- capturing-transport-fixture
+  ;; rf2-784223: the shared `make-reset-runtime-fixture`'s
+  ;; `:resources/reset-resources!` post-dispose hook already clears the
+  ;; resource state + timer host caches before this fixture runs — no
+  ;; per-suite reset is repeated here.
   [f]
   (reset! last-managed-args nil)
   (reset! scheduled-timers [])
-  (state/reset-cache!)
-  (timers/reset-cache!)
   (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   ;; capture the host-side stale / GC timer arming so the success handler's
   ;; emission is asserted deterministically WITHOUT a real wall-clock timer

--- a/implementation/resources/test/re_frame/resources_revalidation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_revalidation_cljs_test.cljc
@@ -29,6 +29,7 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
    [re-frame.frame :as frame]
+   [re-frame.late-bind :as late-bind]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events (incl. the focus/reconnect events this test
    ;; dispatches) + the timer / work-ledger side-table fx + the internal
@@ -37,7 +38,6 @@
    [re-frame.resources.revalidate-listeners :as revalidate-listeners]
    [re-frame.resources.state :as state]
    [re-frame.resources.test-support]
-   [re-frame.resources.timers :as timers]
    [re-frame.resources.work-ledger :as work-ledger]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch + abort are overridden by capturing no-ops below.
@@ -56,14 +56,17 @@
   "Override the real :rf.http/managed + :rf.http/managed-abort fxs with
   capturing no-ops, and CAPTURE :rf.resource/schedule-timers so the
   succeeded-handler's arming is asserted WITHOUT a real wall-clock timer
-  firing. Composed INSIDE the reset-runtime fixture (one `use-fixtures` call)."
+  firing. Composed INSIDE the reset-runtime fixture (one `use-fixtures` call).
+
+  rf2-784223: the shared `make-reset-runtime-fixture` fires
+  `:resources/reset-resources!` in its `:post-dispose` phase, which already
+  clears the state / work-ledger / timer / revalidate-listener host caches
+  (and the resource/mutation registrars) BEFORE this composed fixture runs —
+  so no per-suite cache reset is needed here. This fixture only resets its
+  own capture atoms and installs the capturing fxs."
   [f]
   (reset! aborts [])
   (reset! scheduled-timers [])
-  (state/reset-cache!)
-  (work-ledger/reset-cache!)
-  (timers/reset-cache!)
-  (revalidate-listeners/reset-cache!)
   (rf/reg-fx :rf.http/managed (fn [_ctx _args] nil))
   (rf/reg-fx :rf.http/managed-abort (fn [_ctx work-id] (swap! aborts conj work-id) nil))
   (rf/reg-fx :rf.resource/schedule-timers (fn [_ctx args] (swap! scheduled-timers conj args) nil))
@@ -217,6 +220,87 @@
         "no entries materialised by an empty-frame scan")))
 
 ;; ===========================================================================
+;; 3b. Coalescing — focus + visibility do not double-refetch in-flight stale
+;;     entries (rf2-wankrd). A tab-return commonly fires BOTH focus (window)
+;;     and visibilitychange (document); both dispatch :rf.resource/window-
+;;     focused. The active-stale scan SKIPS entries with a LIVE in-flight
+;;     refetch, so back-to-back signals yield AT MOST one new generation /
+;;     work item and NO abort churn.
+;; ===========================================================================
+
+(deftest back-to-back-focus-coalesces-to-one-refetch
+  ;; ADVERSARIAL (rf2-wankrd): the second focus signal arrives while the
+  ;; first focus's refetch is still in flight. Without coalescing it would
+  ;; force a SECOND new generation, superseding + aborting the first (churn).
+  (rf/reg-resource :co/sw (article-spec {:stale-after-ms 0}))
+  (let [scope {:user "u"}
+        k (state/scoped-resource-key scope :co/sw {:slug "w"})]
+    (ensure! :co/sw scope "w" [:route :r 1])
+    (succeed! k {:title "W"})
+    (let [gen-before (:generation (entry k))]
+      (reset! aborts [])
+      (rf/dispatch-sync [:rf.resource/window-focused]) ;; starts the refetch
+      (let [gen-after-1 (:generation (entry k))
+            wid-after-1 (:current-work (entry k))]
+        (is (= (inc gen-before) gen-after-1) "first focus bumped one generation")
+        (is (= :fetching (:status (entry k))) "refetch in flight (:fetching)")
+        (testing "Spec 016 §Race / rf2-wankrd — a SECOND focus while the first
+                  refetch is still in flight is coalesced: NO new generation,
+                  the SAME work item, and NO opportunistic abort (no churn)"
+          (rf/dispatch-sync [:rf.resource/window-focused])
+          (let [e (entry k)]
+            (is (= gen-after-1 (:generation e)) "no second generation bump")
+            (is (= wid-after-1 (:current-work e)) "same in-flight work item")
+            (is (= :fetching (:status e)) "still the one in-flight refetch")
+            (is (empty? @aborts) "no opportunistic abort fired (no churn)")))))))
+
+(deftest focus-plus-visibility-coalesces-to-one-refetch
+  ;; ADVERSARIAL (rf2-wankrd): the canonical tab-return — focus (window) AND
+  ;; visibilitychange (document) both translate to :rf.resource/window-focused.
+  ;; Exactly one active-stale key MUST produce at most one new generation /
+  ;; work item and no abort churn.
+  (rf/reg-resource :cv/sw (article-spec {:stale-after-ms 0}))
+  (let [scope {:user "u"}
+        k (state/scoped-resource-key scope :cv/sw {:slug "w"})]
+    (ensure! :cv/sw scope "w" [:route :r 1])
+    (succeed! k {:title "W"})
+    (let [gen-before (:generation (entry k))]
+      (reset! aborts [])
+      ;; both host signals lower to the SAME resource event (the listener
+      ;; carries no policy — the handler is the coalescing point)
+      (rf/dispatch-sync [:rf.resource/window-focused]) ;; window focus
+      (rf/dispatch-sync [:rf.resource/window-focused]) ;; document visibilitychange→visible
+      (let [e   (entry k)
+            rec (work-ledger/get-record (runtime-db) (:current-work e))]
+        (is (= (inc gen-before) (:generation e))
+            "focus+visibility together bumped exactly ONE generation")
+        (is (= :fetching (:status e)) "one in-flight refetch")
+        (is (= :running (:status rec)) "the single work record is still live")
+        (is (empty? @aborts) "no abort churn from the second signal")))))
+
+(deftest coalescing-does-not-block-a-fresh-revalidation
+  ;; The in-flight gate must NOT permanently wedge revalidation: once the
+  ;; in-flight refetch SETTLES (work cleared, entry stale again), a later
+  ;; focus signal MUST start a fresh refetch.
+  (rf/reg-resource :cf/sw (article-spec {:stale-after-ms 0}))
+  (let [scope {:user "u"}
+        k (state/scoped-resource-key scope :cf/sw {:slug "w"})]
+    (ensure! :cf/sw scope "w" [:route :r 1])
+    (succeed! k {:title "W"})
+    (rf/dispatch-sync [:rf.resource/window-focused]) ;; refetch in flight
+    (let [gen-mid (:generation (entry k))]
+      ;; settle the in-flight refetch (clears :current-work; stale-after 0 →
+      ;; the entry is immediately stale again)
+      (succeed! k {:title "W2"})
+      (is (nil? (:current-work (entry k))) "in-flight work cleared on settle")
+      (testing "rf2-wankrd — coalescing is per IN-FLIGHT attempt, not a latch:
+                a focus AFTER the refetch settled starts a fresh revalidation"
+        (rf/dispatch-sync [:rf.resource/window-focused])
+        (let [e (entry k)]
+          (is (= (inc gen-mid) (:generation e)) "a new generation started")
+          (is (= :fetching (:status e)) "fresh refetch in flight"))))))
+
+;; ===========================================================================
 ;; 4. Pure active-stale-scan selection unit
 ;; ===========================================================================
 
@@ -280,3 +364,130 @@
             harmless no-op (idempotent + JVM-safe)"
     (revalidate-listeners/remove-revalidation-listeners! :rv/no-such-frame)
     (is (not (contains? @revalidate-listeners/listener-table :rv/no-such-frame)))))
+
+;; ===========================================================================
+;; 6. Host event-target wiring (rf2-pxe0c7) — CLJS/DOM-stub only
+;;
+;;    `visibilitychange` is a `document` event (it never fires on `window`),
+;;    and the handler reads `document.visibilityState`. These stub-DOM tests
+;;    pin the ACTUAL host wiring: visibilitychange is attached to `document`
+;;    (NOT window), a visible→tab-return dispatches :rf.resource/window-
+;;    focused, a hidden transition does NOT, and remove / frame-destroy
+;;    detaches the listener from `document`. (The node test runtime has no
+;;    DOM; we install a capturing stub on `js/globalThis`, mirroring
+;;    routing_history_cljs_test.)
+;; ===========================================================================
+
+#?(:cljs
+   (do
+     ;; A capturing window / document stub: each records its
+     ;; addEventListener / removeEventListener calls in `state` and can
+     ;; `dispatchEvent` to the registered listeners (keyed by target + type).
+     (defn- install-dom-stub! []
+       (let [state    (atom {:window {} :document {:visibilityState "visible"}})
+             mk-target (fn [target-key]
+                         #js {:addEventListener
+                              (fn [type listener]
+                                (swap! state update-in [target-key :listeners type]
+                                       (fnil conj []) listener))
+                              :removeEventListener
+                              (fn [type listener]
+                                (swap! state update-in [target-key :listeners type]
+                                       (fnil (fn [xs] (vec (remove #(= % listener) xs))) [])))
+                              :dispatchEvent
+                              (fn [event]
+                                (doseq [l (get-in @state [target-key :listeners (.-type event)] [])]
+                                  (l event)))})
+             window   (mk-target :window)
+             document (mk-target :document)]
+         ;; the visibility handler reads `(.-visibilityState js/document)` —
+         ;; expose a mutable field the test flips between "visible"/"hidden".
+         (set! (.-visibilityState document) "visible")
+         (set! (.-window js/globalThis) window)
+         (set! (.-document js/globalThis) document)
+         (swap! state assoc :window-obj window :document-obj document)
+         state))
+
+     (defn- uninstall-dom-stub! []
+       (js-delete js/globalThis "window")
+       (js-delete js/globalThis "document"))
+
+     (def ^:private real-browser?
+       (and (exists? js/window)
+            (identical? js/window js/globalThis)))
+
+     (def ^:dynamic *dom-state* nil)))
+
+#?(:cljs
+   (deftest visibilitychange-attaches-to-document-not-window
+     (when-not real-browser?
+       (let [state (install-dom-stub!)]
+         (binding [*dom-state* state]
+           (try
+             ;; capture dispatches via the late-bind router hook the listener
+             ;; rides (so we observe the EXACT event the host wiring produces)
+             (let [dispatched (atom [])
+                   prior      (late-bind/get-fn :router/dispatch!)]
+               (late-bind/set-fn! :router/dispatch! (fn [ev opts] (swap! dispatched conj [ev opts])))
+               (try
+                 (revalidate-listeners/install-revalidation-listeners! :rv/dom)
+                 (testing "rf2-pxe0c7 — visibilitychange is attached to DOCUMENT, not window"
+                   (is (seq (get-in @state [:document :listeners "visibilitychange"]))
+                       "document carries the visibilitychange listener")
+                   (is (empty? (get-in @state [:window :listeners "visibilitychange"]))
+                       "window does NOT carry visibilitychange")
+                   (is (seq (get-in @state [:window :listeners "focus"]))
+                       "focus stays on window")
+                   (is (seq (get-in @state [:window :listeners "online"]))
+                       "online stays on window"))
+                 (testing "rf2-pxe0c7 — a visibilitychange while VISIBLE dispatches window-focused"
+                   (reset! dispatched [])
+                   (set! (.-visibilityState (:document-obj @state)) "visible")
+                   (.dispatchEvent (:document-obj @state) #js {:type "visibilitychange"})
+                   (is (= [:rf.resource/window-focused] (ffirst @dispatched))
+                       "visible visibilitychange dispatched :rf.resource/window-focused")
+                   (is (= {:frame :rv/dom :source :revalidate} (second (first @dispatched)))
+                       "dispatched at the frame the listener targets, with :revalidate source"))
+                 (testing "rf2-pxe0c7 — a visibilitychange while HIDDEN does NOT dispatch"
+                   (reset! dispatched [])
+                   (set! (.-visibilityState (:document-obj @state)) "hidden")
+                   (.dispatchEvent (:document-obj @state) #js {:type "visibilitychange"})
+                   (is (empty? @dispatched) "hidden visibilitychange dispatched nothing"))
+                 (testing "rf2-pxe0c7 — remove detaches the visibilitychange listener from document"
+                   (revalidate-listeners/remove-revalidation-listeners! :rv/dom)
+                   (is (empty? (get-in @state [:document :listeners "visibilitychange"]))
+                       "document visibilitychange listener detached on remove")
+                   (is (empty? (get-in @state [:window :listeners "focus"]))
+                       "window focus listener detached on remove")
+                   ;; a post-remove visible visibilitychange dispatches nothing
+                   (reset! dispatched [])
+                   (set! (.-visibilityState (:document-obj @state)) "visible")
+                   (.dispatchEvent (:document-obj @state) #js {:type "visibilitychange"})
+                   (is (empty? @dispatched) "detached listener fires nothing"))
+                 (finally
+                   (if prior
+                     (late-bind/set-fn! :router/dispatch! prior)
+                     (late-bind/clear-fn! :router/dispatch!)))))
+             (finally
+               (uninstall-dom-stub!))))))))
+
+#?(:cljs
+   (deftest frame-destroy-detaches-document-visibilitychange
+     (when-not real-browser?
+       (let [state (install-dom-stub!)]
+         (binding [*dom-state* state]
+           (try
+             (let [fa :rv/dom-destroy]
+               (rf/reg-frame fa {:doc "DOM-stub frame-destroy detach frame"})
+               (revalidate-listeners/install-revalidation-listeners! fa)
+               (is (seq (get-in @state [:document :listeners "visibilitychange"]))
+                   "document visibilitychange attached for the frame")
+               (testing "rf2-pxe0c7 — frame destroy detaches the document
+                         visibilitychange listener via the single teardown hook"
+                 (frame/destroy-frame! fa)
+                 (is (empty? (get-in @state [:document :listeners "visibilitychange"]))
+                     "document visibilitychange detached on frame destroy")
+                 (is (not (contains? @revalidate-listeners/listener-table fa))
+                     "side-table slot dropped on frame destroy")))
+             (finally
+               (uninstall-dom-stub!))))))))

--- a/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
@@ -51,15 +51,21 @@
 
 (defn- init!
   "Per-test setup (runs after adapter install, registrar live): re-register
-  `:rf/default` as the URL-owning app frame, reset the routing counters +
-  the resources host-side generation cache, re-publish the late-bound
-  routing integration, and stub the managed-HTTP + push-url fx so ensure +
-  navigation are deterministic without a fetch / browser."
+  `:rf/default` as the URL-owning app frame, reset the routing counters,
+  re-publish the late-bound routing integration, and stub the managed-HTTP +
+  push-url fx so ensure + navigation are deterministic without a fetch /
+  browser.
+
+  rf2-784223: the resources host-side caches (state / work-ledger / timers /
+  revalidate-listeners) are cleared by the shared `make-reset-runtime-
+  fixture`'s `:resources/reset-resources!` post-dispose hook, which runs
+  BEFORE this `:init-fn` — so no `state/reset-cache!` is repeated here. The
+  routing counter reset + late-bound integration re-publication stay (they
+  are routing-suite setup, not resource cache hygiene)."
   []
   (rf/reg-frame :rf/default {:url-bound? true
                              :doc "Route-resource suite default app frame."})
   (routing/reset-counters!)
-  (state/reset-cache!)
   (route/install-routing-integration!)
   (rf/reg-fx :rf.http/managed (fn [_ctx _args] nil))
   (rf/reg-fx :rf.nav/push-url {:platforms #{:server :client}} (fn [_ _] nil)))

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -33,6 +33,7 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
    [re-frame.frame :as frame]
+   [re-frame.late-bind :as late-bind]
    [re-frame.registrar :as registrar]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events + subs + the generation cofx/fx these tests
@@ -42,7 +43,10 @@
    [re-frame.resources.mutation-registry :as mreg]
    [re-frame.resources.state :as state]
    [re-frame.resources.subs :as subs]
-   [re-frame.resources.test-support]
+   [re-frame.resources.test-support :as resources-test-support]
+   [re-frame.resources.timers :as timers]
+   [re-frame.resources.work-ledger :as work-ledger]
+   [re-frame.resources.revalidate-listeners :as revalidate-listeners]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch is overridden by the capturing no-op below.
    [re-frame.http-managed]
@@ -681,3 +685,59 @@
   (testing "rf2-ptz7z8 — a scoped key built from mixed-key params is stable"
     (is (= (state/scoped-resource-key :rf.scope/global :r/x {:a 1 "b" 2})
            (state/scoped-resource-key :rf.scope/global :r/x {"b" 2 :a 1})))))
+
+;; ===========================================================================
+;; 19. Shared reset contract (rf2-784223) — `make-reset-runtime-fixture` plus
+;;     `re-frame.resources.test-support` clears the resource + mutation
+;;     registrars AND every resources host-side side table.
+;; ===========================================================================
+
+(deftest reset-resources-clears-registrars-and-host-side-tables
+  ;; This is the contract the per-suite fixtures now RELY on (rf2-784223):
+  ;; instead of each fixture redundantly re-resetting these caches, the
+  ;; shared `make-reset-runtime-fixture` fires `:resources/reset-resources!`
+  ;; (published at `re-frame.resources.test-support` ns-load). Prove that one
+  ;; thunk clears the whole surface, so the redundant per-suite resets were
+  ;; safe to remove.
+  (testing "the late-bind reset hook IS published (the fixture's mechanism)"
+    (is (some? (late-bind/get-fn :resources/reset-resources!))
+        ":resources/reset-resources! hook published at test-support ns-load")
+    (is (identical? resources-test-support/reset-resources!
+                    (late-bind/get-fn :resources/reset-resources!))
+        "the published hook IS test-support/reset-resources!"))
+  ;; Seed every surface the reset must clear.
+  (rf/reg-resource :rst/article (article-spec))
+  (rf/reg-mutation :rst/save
+                   {:params-schema [:map [:slug :string]]
+                    :request (fn [{:keys [slug]} _ctx]
+                               {:request {:method :post :url (str "/api/articles/" slug)}})})
+  (state/commit-generation! :rf/default 7)
+  (let [k       (state/scoped-resource-key :rf.scope/global :rst/article {:slug "w"})
+        work-id (work-ledger/resource-work-id k 1)]
+    (work-ledger/put-handle! :rf/default work-id {:abort-fn (fn [] nil)})
+    (timers/schedule! :rf/default k timers/gc-kind 1000000)
+    (swap! revalidate-listeners/listener-table assoc :rf/default
+           {:focus :h :visibility :h :online :h})
+    ;; precondition: everything is populated
+    (is (contains? (registrar/registrations registry/resource-kind) :rst/article))
+    (is (contains? (registrar/registrations mreg/mutation-kind) :rst/save))
+    (is (= 7 (state/generation-snapshot :rf/default)))
+    (is (some? (work-ledger/get-handle :rf/default work-id)))
+    (is (contains? @timers/timer-table [:rf/default k timers/gc-kind]))
+    (is (contains? @revalidate-listeners/listener-table :rf/default))
+    (testing "rf2-784223 — `reset-resources!` clears the resource + mutation
+              registrars AND the generation / work-ledger-handle / timer /
+              revalidate-listener host side tables in ONE call"
+      (resources-test-support/reset-resources!)
+      (is (empty? (registrar/registrations registry/resource-kind))
+          "resource registrar cleared")
+      (is (empty? (registrar/registrations mreg/mutation-kind))
+          "mutation registrar cleared")
+      (is (= 0 (state/generation-snapshot :rf/default))
+          "generation high-water cache cleared")
+      (is (nil? (work-ledger/get-handle :rf/default work-id))
+          "work-ledger host handle table cleared")
+      (is (not (contains? @timers/timer-table [:rf/default k timers/gc-kind]))
+          "stale/GC timer table cleared (timer cancelled)")
+      (is (not (contains? @revalidate-listeners/listener-table :rf/default))
+          "revalidation-listener side table cleared"))))

--- a/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/resources_skeleton_cljs_test.cljs
@@ -165,18 +165,41 @@
       (is (some? (registrar/lookup :sub sub-id))
           (str sub-id " sub should be registered")))))
 
+(def ^:private resource-event-family
+  "The CURRENT, complete `:rf.resource/*` + `:rf.resource.internal/*` event
+  family the façade registers (re-frame.resources `reg-event-fx` calls). Kept
+  in lock-step with the façade registrations — when a resource event is
+  added/removed there, this list moves with it so the smoke is never stale
+  (rf2-l1a0s7). The `:rf.mutation/*` causal-write family is a SEPARATE
+  surface (covered by the mutation suite), deliberately not enumerated here."
+  [;; public, user-causable events
+   :rf.resource/ensure
+   :rf.resource/refetch
+   :rf.resource/invalidate-tags
+   :rf.resource/release-owner
+   :rf.resource/clear-scope
+   :rf.resource/remove
+   ;; focus / reconnect revalidation events (host listeners dispatch these;
+   ;; user code MUST NOT) — landed events the prior smoke omitted
+   :rf.resource/window-focused
+   :rf.resource/network-reconnected
+   ;; framework-internal reply handlers (user code MUST NOT dispatch)
+   :rf.resource.internal/succeeded
+   :rf.resource.internal/failed
+   :rf.resource.internal/aborted
+   :rf.resource.internal/stale-fired      ;; landed; prior smoke omitted
+   :rf.resource.internal/gc-fired
+   :rf.resource.internal/stale-suppressed])
+
 (deftest resource-events-registered
-  (testing "the :rf.resource/* event family is registered"
-    (doseq [event-id [:rf.resource/ensure :rf.resource/refetch
-                      :rf.resource/invalidate-tags :rf.resource/release-owner
-                      :rf.resource/clear-scope :rf.resource/remove
-                      :rf.resource.internal/succeeded :rf.resource.internal/failed
-                      :rf.resource.internal/aborted :rf.resource.internal/gc-fired
-                      :rf.resource.internal/stale-suppressed]]
-      (is (some? (registrar/lookup :event event-id))
-          (str event-id " event should be registered"))))
-  (testing "every resource handler carries framework-write authority"
-    (is (true? (:rf/framework-authority? (registrar/lookup :event :rf.resource/ensure))))))
+  (testing "the CURRENT :rf.resource/* event family is registered AND every
+            member carries framework-write authority (rf2-l1a0s7)"
+    (doseq [event-id resource-event-family]
+      (let [handler (registrar/lookup :event event-id)]
+        (is (some? handler)
+            (str event-id " event should be registered"))
+        (is (true? (:rf/framework-authority? handler))
+            (str event-id " should carry framework-write authority"))))))
 
 (deftest late-bound-routing-accepts-resources-key
   (testing "the :routing/extra-route-keys hook publishes #{:resources}"

--- a/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
@@ -51,12 +51,15 @@
 (defn- capturing-transport-fixture
   "Override the real :rf.http/managed + :rf.http/managed-abort fxs with
   capturing no-ops so the ledger writes are deterministic and no real fetch
-  / abort fires. Composed INSIDE the reset-runtime fixture."
+  / abort fires. Composed INSIDE the reset-runtime fixture.
+
+  rf2-784223: the shared `make-reset-runtime-fixture`'s
+  `:resources/reset-resources!` post-dispose hook already clears the resource
+  state + work-ledger host caches before this fixture runs — no per-suite
+  reset is repeated here."
   [f]
   (reset! last-managed-args nil)
   (reset! aborts [])
-  (state/reset-cache!)
-  (work-ledger/reset-cache!)
   (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
   ;; rf2-sxyrzk — managed-abort args is the frame-QUALIFIED transport
   ;; request-id (`[:rf.req <frame-id> <work-id>]`, `managed-request-id`), NOT


### PR DESCRIPTION
fix(resources): visibilitychange listener + coalesced focus/visibility revalidation + test-coverage (revalidation+tests cluster).

## Summary

- Coalesced focus + visibility revalidation: the `entry-revalidation-in-flight?` gate in `active-stale-scan` makes back-to-back `focus` / `focus`+`visibilitychange` signals idempotent (one active-stale key yields at most one new generation; no abort churn).
- `visibilitychange` listener wiring in `revalidate-listeners`.
- Test coverage: new revalidation/listener suites + the rf2-784223 reset-resources fixture consolidation across the resources suites (the shared `make-reset-runtime-fixture` post-dispose hook clears resource/work-ledger/timer host caches, so per-suite `reset-cache!` calls are dropped).

## Rebase / conflict reconciliation (2026-06-11 12:14 AUSEST)

Rebased onto `origin/main` after #3821 (rf2-sxyrzk, request-id frame-qualification) merged. Reconciliation merged BOTH intents — no blind ours/theirs:

- **events.cljc** — the two edits land in different regions and were interleaved cleanly: this branch's revalidation-coalescing core (`entry-revalidation-in-flight?`, `active-stale-scan`, `revalidate-handler`, focus/visibility wiring) is preserved alongside main's request-id frame-qualification (`work-ledger/managed-request-id` mint + `frame-id`-threaded `work-ledger/abort-fx` at every abort site in `ensure-load` / owner-release / clear-scope / remove / reply handlers). #3818's reply-frame verification (`live-entry-for-reply` / `reply-frame` guard) is intact. All referenced `work-ledger/*` fns resolve against the merged work-ledger.
- **resources_mutation_cljs_test.cljc** (only manual conflict) — require block: kept main's `work-ledger` alias (used by the new `cross-frame-mutation-request-id-does-not-collide` test) and dropped the now-unused `timers` alias (this branch removed its only call site, `timers/reset-cache!`, in the rf2-784223 fixture consolidation). main's cross-frame deftest + this branch's fixture removal both survive.
- **resources_invalidation_gc / work_ledger test files** (auto-merged, verified) — main's cross-frame deftests preserved; this branch's per-suite `reset-cache!` removals preserved. No orphaned aliases (timer-primitive tests keep their own `timers/reset-cache!`).

## Quality gates (post-rebase, combined base)

- `implementation/` — `npm run test:cljs`: **6417 tests, 23150 assertions, 0 failures, 0 errors** (the proof the merge is correct on the combined base).
- `implementation/resources/` — `clojure -M:test`: **236 tests, 875 assertions, 0 failures, 0 errors**.
- `scripts/test-fast-pr.sh`: all guard/drift steps pass. The sole FAIL is the README inventory ratchet flagging `node_modules` / `out` — both gitignored build/install dirs present on disk in the worktree; the known env false-positive (rf2-198k3), not a content issue.
