### PR TITLE
fix(scripts): make README-inventory ratchet gitignore-aware (rf2-wv7d7z)

### DIFF
--- a/scripts/check_readme_inventories.py
+++ b/scripts/check_readme_inventories.py
@@ -205,14 +205,51 @@ def _layout_top_level_dirs(block: FencedBlock) -> set[str]:
     }
 
 
+# Gitignored build-artifact directory names that may appear on disk after a
+# local `npm install` + CLJS build but are NOT part of the documented layout
+# map (rf2-wv7d7z).  The bijection must skip these or every post-build local
+# fast-pr run fails the README-inventory check ("node_modules missing from
+# README") — a false failure CI dodged only by running the check before
+# `npm install`, which is fragile job-ordering luck.
+#
+# These mirror the gitignored entries in the repo-root and per-artefact
+# `.gitignore` files (`/node_modules/`, `/out/`, `/target/`, `/classes/`).
+# Dotdir build state (`.cpcache/`, `.shadow-cljs/`) is already excluded by the
+# leading-dot filter in `_disk_dirs`, so only the non-dot names need listing.
+#
+# An explicit, deterministic skip-set is used rather than shelling out to
+# `git check-ignore`: the latter reads the *working-tree* `.gitignore` files,
+# which on Windows checkouts carry CRLF line terminators that defeat git's
+# pattern match (the trailing `\r` becomes part of the pattern) — exactly the
+# environment-dependent fragility this fix exists to remove.  The set is tiny,
+# toolchain-bound, and keeps the script stdlib-only / no-shell-out (its
+# original portability promise).
+_GITIGNORED_BUILD_DIRS = frozenset({
+    "node_modules",  # npm install
+    "out",           # shadow-cljs / cljs build output
+    "target",        # lein / tools.build output
+    "classes",       # AOT-compiled class output
+})
+
+
 def _disk_dirs(base: Path) -> set[str]:
-    """Directory names directly under *base* (excluding dotfiles)."""
+    """Directory names directly under *base* (excluding dotfiles + gitignored
+    build artefacts).
+
+    Dotfiles (``.cpcache`` / ``.shadow-cljs`` / …) are skipped by the
+    leading-dot filter; gitignored build-output dirs that have no leading dot
+    (``node_modules`` / ``out`` / …) are skipped via ``_GITIGNORED_BUILD_DIRS``
+    so the layout-map bijection holds regardless of local build state
+    (rf2-wv7d7z).
+    """
     if not base.is_dir():
         return set()
     return {
         p.name
         for p in base.iterdir()
-        if p.is_dir() and not p.name.startswith(".")
+        if p.is_dir()
+        and not p.name.startswith(".")
+        and p.name not in _GITIGNORED_BUILD_DIRS
     }
 
 
@@ -671,6 +708,22 @@ def _run_self_tests(verbose: bool = False) -> int:
     if sec is not None:
         blocks = _iter_fenced_blocks(sec[1])
         expect("section-block-count", len(blocks), 1)
+
+    # _disk_dirs skips gitignored build artefacts + dotdirs but keeps real
+    # source dirs (rf2-wv7d7z): a post-build local tree carries node_modules/
+    # out/ .shadow-cljs/ .cpcache/ alongside the documented source dirs, and
+    # only the latter must show up in the bijection.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        base = Path(tmp)
+        for d in ("core", "adapters",            # documented source dirs
+                  "node_modules", "out",          # gitignored build artefacts
+                  "target", "classes",            # gitignored build artefacts
+                  ".shadow-cljs", ".cpcache"):     # gitignored dotdirs
+            (base / d).mkdir()
+        expect("disk-dirs-skips-build-artefacts",
+               _disk_dirs(base), {"core", "adapters"})
 
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")


### PR DESCRIPTION
@
## What

The README-inventory ratchet (`scripts/check_readme_inventories.py`, invoked unconditionally from `scripts/test-fast-pr.sh`s spine) enumerated on-disk dirs under `implementation/` and compared them to `implementation/README.md`s layout map **without consulting `.gitignore`**. A local run after `npm install` + a CLJS build leaves gitignored `node_modules/` + `out/` (+ dotdir `.shadow-cljs/`) on disk, which the ratchet reported as "missing from README" -> a **false failure on every post-build local fast-pr run**. CI dodged it only via job ordering (README check before `npm install`), which is fragile.

## Where / fix approach

Single-surface change to `scripts/check_readme_inventories.py` (no `test-fast-pr.sh` edit needed -- the fix lives entirely in the checker). `_disk_dirs` now skips a small, documented `_GITIGNORED_BUILD_DIRS` skip-set (`node_modules` / `out` / `target` / `classes`) in addition to the pre-existing leading-dot filter (which already excludes `.cpcache` / `.shadow-cljs`).

An explicit deterministic skip-set is used rather than shelling out to `git check-ignore`: the latter reads the *working-tree* `.gitignore` files, which on Windows checkouts carry CRLF line terminators that defeat gits pattern match (the trailing `\r` becomes part of the pattern) -- exactly the environment-dependent fragility this fix exists to remove. The set is tiny, toolchain-bound, and keeps the script stdlib-only / no-shell-out (its original portability promise). The guard is **not** neutered: a genuinely-undocumented new *source* dir still fails it.

A self-test case (`disk-dirs-skips-build-artefacts`) pins the `_disk_dirs` skip behaviour via a tempdir fixture.

`implementation/README.md` layout map was verified current (clean run passes) -- no content change needed.

## Quality gates

**README-inventory check both ways (acceptance):**

- PASS with build artifacts present -- created `implementation/{node_modules,out,.shadow-cljs,classes,target}/`, ran `python scripts/check_readme_inventories.py` -> **exit 0** (git status confirmed all correctly ignored).
- FAIL on new undocumented source dir -- added `implementation/widgets/src/` (alongside the build artifacts) -> **exit 1**, message: `implementation/README.md:36  layout map under implementation/ omits on-disk dir(s): widgets` (only `widgets`, NOT node_modules/out/etc.). Removed the dummy dir -> check **exit 0** again with artifacts still present.

**Self-test:** `python scripts/check_readme_inventories.py --self-test -v` -> all 16 pass (incl. new `disk-dirs-skips-build-artefacts`).

**Live ratchet (clean tree):** `python scripts/check_readme_inventories.py -v` -> no violations, exit 0.

**`bash -n scripts/test-fast-pr.sh`** -> exit 0.

**Markdown-gate block validators** (the gates the spine runs around the ratchet) all green: `check_readme_links.py --ci`, `check_doc_slugs.py`, `check_ep_status_sync.py` (+ `--self-test`), `check_runtime_subsystem_grading.py` (+ `--self-test`) -- all exit 0. (Full `test-fast-pr.sh` additionally runs CLJS/Clojure suites requiring `npm install` + clojure; those are untouched by this Python-only diff.)

Closes rf2-wv7d7z.
@