### PR TITLE
docs(guide): ch.05 live cell captures the frame in setInterval (rf2-9qiiq5)

### DIFF
--- a/docs/guide/05-subscriptions.md
+++ b/docs/guide/05-subscriptions.md
@@ -154,8 +154,14 @@ Click into the cell and hit **`Ctrl-Enter`** (or **`Cmd-Enter`** on a Mac) to ru
     "  (recomputed " @static-recomputes " times)"]])
 
 ;; --- Seed, then tick once a second forever ---
+;; The setInterval callback fires later, on a bare timer turn with no frame in
+;; scope — so it must CARRY the frame. Capture (rf/frame-handle) here, while the
+;; frame is still ambient, and close over its :dispatch in the callback. A bare
+;; (rf/dispatch [:graph/tick]) inside the timer would raise
+;; :rf.error/no-frame-context. (See chapter 18.)
 (rf/dispatch-sync [:graph/initialise])
-(js/setInterval #(rf/dispatch [:graph/tick]) 1000)
+(let [{:keys [dispatch]} (rf/frame-handle)]
+  (js/setInterval #(dispatch [:graph/tick]) 1000))
 [graph-demo]
 ```
 


### PR DESCRIPTION
## What

`docs/guide/05-subscriptions.md` ch.05 "see it prune" cell did a **bare dispatch from a top-level `setInterval`**:

```clojure
(js/setInterval #(rf/dispatch [:graph/tick]) 1000)
```

This only "worked" because the playground SCI harness hard-binds cell dispatch to `:rf/default` (`docs/tools/playground/sci/src/rf2_playground/sci.cljs:75-94`). Copied into a real app, the deferred timer callback fires on a bare turn with no frame in scope and raises `:rf.error/no-frame-context`. It contradicted the guide's own teaching at `06-views.md:167-173` ("raw `js/setTimeout` … fails loudly") and the correct frame-carrying pattern at `11-forms.md:59-73`.

## Fix — idiom used: `frame-handle`

Capture `(rf/frame-handle)` at the cell top level and close over its `:dispatch` in the `setInterval` callback:

```clojure
(let [{:keys [dispatch]} (rf/frame-handle)]
  (js/setInterval #(dispatch [:graph/tick]) 1000))
```

This is the documented tool for a top-level async callback (ch.18:219-246 — the WebSocket / raw-`addEventListener` drag idiom; ch.18:285 explicitly: "`frame-handle` is for the cases `:fx` can't reach … or one set up directly in a view body"). I used `frame-handle` rather than ch.11's `(:frame frame-ctx)` because ch.11's pattern is for a **`reg-fx` handler** (which receives `frame-ctx`); the ch.05 timer is at **cell top level** with no fx handler, so `frame-handle` is the correct idiom.

Verified against the harness: `renderLast` evaluates the cell under `(rf/with-frame :rf/default …)` (`sci.cljs:223`), so the top-level `(rf/frame-handle)` captures `:rf/default` ambiently; the returned bundle's `:dispatch` is locked to that frame, so the timer routes correctly without relying on the harness's default-injection. `frame-handle` is copied into the cell's `re-frame.core` namespace (`sci.cljs:105`). The cell stays working in the playground **and** is correct if copied into a real app with a root `frame-provider`.

## Disclosure judgment call — follow-up bead filed (rf2-4xy0no)

The bead flagged a related coherence issue: `01-introduction.md:60,93` claims "nothing hidden off-screen" / "every line is on the page" and `interactive-tutorials.md:28` says "no hidden setup", yet the harness-established `:rf/default` frame is disclosed only in ch.03:208. I **did not fold this in** — the intro chapter deliberately defers the frames concept entirely (frames are ch.18's job), so a consistent disclosure needs editorial tuning across two flagship passages to avoid introducing frames 17 chapters early or creating a new inconsistency. That is a separate editorial decision, not a mechanical fold-in, so per the bead's own guidance I filed **rf2-4xy0no (P3)** and kept this PR to the ch.05 cell fix.

## Quality gates

- `python -m mkdocs build --strict` — PASS (exit 0)
- `python scripts/check_doc_slugs.py --verbose` — PASS (no broken links, 425 files scanned)
- Playground smoke (`docs/tools/playground/test/smoke.test.mjs`) — N/A: it uses its own hardcoded test page, not the guide's ch.05 cell, so it would not exercise this edit. Instead verified by source inspection that (a) `frame-handle` resolves in the cell namespace and (b) the cell evaluates under `with-frame :rf/default`, so the captured handle dispatches into the right frame.

Closes rf2-9qiiq5.
