### PR TITLE
docs(guide): carried-frame test snippets + error catalogue + ch.27 completeness + harness disclosure (guide cluster)

### DIFF
--- a/docs/guide/01-introduction.md
+++ b/docs/guide/01-introduction.md
@@ -57,7 +57,7 @@ Okay. That's the theory. I promised you'd run something. Let's run something.
 
 The smallest program worth writing is a counter: a number, a plus button, a minus button. Click plus, number goes up. It is *aggressively* unimpressive, and that's deliberate, because the shape we use to build this trivial thing is the *exact same shape* we'd use for a trading desk. If the small case feels clean, the large case will too. (And if the small case feels like ceremony — well, hold that thought, we'll come back to it.)
 
-Here's the whole thing, live. This is a real re-frame2 program running in your browser right now — there's no toolchain, no install, nothing hidden off-screen. Click into the cell, then hit **`Ctrl-Enter`** (or **`Cmd-Enter`** on a Mac) to evaluate it. The first run takes a second while the engine wakes up; after that it's instant. Then click the buttons.
+Here's the whole thing, live. This is a real re-frame2 program running in your browser right now — there's no toolchain, no install, and every line of the *program* is on the page. (The playground does one small thing for you off-screen: it supplies the runtime scaffolding to mount the cell, the same way a `main` would in a real app — [chapter 03](03-first-app.md) shows exactly what it does.) Click into the cell, then hit **`Ctrl-Enter`** (or **`Cmd-Enter`** on a Mac) to evaluate it. The first run takes a second while the engine wakes up; after that it's instant. Then click the buttons.
 
 ```cljs-rf2
 (require '[reagent2.core :as r]

--- a/docs/guide/13-testing.md
+++ b/docs/guide/13-testing.md
@@ -331,9 +331,9 @@ One boundary to respect: these patterns are for a **single application frame** â
 
 ```clojure
 (deftest counter-walk
-  (rf/dispatch-sync [:counter/init])
-  (let [final (ts/dispatch-sequence [[:counter/inc] [:counter/inc] [:counter/dec]])]
-    (is (= 1 (:n final)))))
+  (rf/with-new-frame [f (rf/make-frame {:on-create [:counter/init]})]
+    (let [final (ts/dispatch-sequence [[:counter/inc] [:counter/inc] [:counter/dec]])]
+      (is (= 1 (:n final))))))
 ```
 
 It takes an `:after-each` callback if you want to snapshot the intermediate states:
@@ -349,12 +349,13 @@ It's a `doseq` of `dispatch-sync` calls; it just reads as one intention instead 
 **`assert-path-equals` / `assert-db-equals`** are `clojure.test`-aware assertions in two shapes. The path form is the common case; the full-db form is for "the whole thing should equal this" in small fixtures:
 
 ```clojure
-(rf/dispatch-sync [:auth/login-pressed])
+(rf/with-new-frame [f (rf/make-frame {:on-create [:auth/init-idle]})]
+  (rf/dispatch-sync [:auth/login-pressed])
 
-(ts/assert-path-equals [:auth :state] :validating)     ;; the common case
-(ts/assert-db-equals   {:auth {:state :validating}})   ;; full-db form
+  (ts/assert-path-equals [:auth :state] :validating)     ;; the common case
+  (ts/assert-db-equals   {:auth {:state :validating}}))  ;; full-db form
 
-;; against a non-default frame
+;; addressing a frame explicitly, when the body isn't the current one
 (ts/assert-path-equals [:auth :state] :validating {:frame :test/auth-flow})
 ```
 
@@ -443,23 +444,25 @@ Or one-shot, scoped to a single dispatch:
 The per-request shape redirects to a canned success or failure:
 
 ```clojure
-(rf/dispatch-sync [:counter/load]
-                  {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
+(rf/with-new-frame [f (rf/make-frame {})]
+  (rf/dispatch-sync [:counter/load]
+                    {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
 
-(rf/dispatch-sync [:counter/load]
-                  {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}})
+  (rf/dispatch-sync [:counter/load]
+                    {:fx-overrides {:rf.http/managed :rf.http/managed-canned-failure}}))
 ```
 
 And for a suite that hits many endpoints, `with-managed-request-stubs` routes by method + URL:
 
 ```clojure
-(rf/with-managed-request-stubs
-  {[:get  "/api/counter"]        {:reply {:ok {:count 5}}}
-   [:get  "/api/does-not-exist"] {:reply {:failure {:kind :rf.http/http-4xx :status 404}}}
-   [:post "/api/counter"]        {:reply {:ok {:count 6}}}}
-  (rf/dispatch-sync [:counter/load])
-  (rf/dispatch-sync [:counter/load-bad])
-  (rf/dispatch-sync [:counter/save]))
+(rf/with-new-frame [f (rf/make-frame {})]
+  (rf/with-managed-request-stubs
+    {[:get  "/api/counter"]        {:reply {:ok {:count 5}}}
+     [:get  "/api/does-not-exist"] {:reply {:failure {:kind :rf.http/http-4xx :status 404}}}
+     [:post "/api/counter"]        {:reply {:ok {:count 6}}}}
+    (rf/dispatch-sync [:counter/load])
+    (rf/dispatch-sync [:counter/load-bad])
+    (rf/dispatch-sync [:counter/save])))
 ```
 
 Wrap, dispatch, assert against the resulting `app-db`. No browser, no network. One rule: **production and SSR code must not require `re-frame.http-test-support`** â€” under that constraint the canned-stub ids are unregistered on every host (absent from the classpath on the JVM, dead-code-eliminated on advanced CLJS) and the re-exports raise `:rf.error/http-artefact-missing` rather than silently shipping test scaffolding to users. The tests cost production exactly nothing. (The full managed-HTTP story is [chapter 10](10-http.md).)

--- a/docs/guide/14-errors.md
+++ b/docs/guide/14-errors.md
@@ -66,7 +66,8 @@ The framework emits errors from a fixed-but-additive set of categories. You don'
 | Cofx | `:rf.error/no-such-cofx` | An `inject-cofx` referenced an unregistered cofx-id. |
 | Interceptor | `:rf.error/unwrap-bad-event-shape` | The `:rf/unwrap` interceptor saw a non-`[id payload-map]` shape. |
 | Schema | `:rf.error/schema-validation-failure` | A `:spec`-validated value failed Malli validation. |
-| Frame | `:rf.error/frame-destroyed` | A dispatch / subscribe arrived against a destroyed frame. |
+| Frame | `:rf.error/no-frame-context` | A `dispatch` / `subscribe` ran with **no frame in scope** — no `with-frame` / `with-new-frame` region, no carried `frame-handle`, no explicit `{:frame ...}`. The absence of a target, raised *before* any registry lookup; the runtime does not synthesise a default. |
+| Frame | `:rf.error/frame-destroyed` | A dispatch / subscribe arrived against a destroyed frame — a *bad* target, distinct from no target at all. |
 | Router | `:rf.error/drain-depth-exceeded` | The run-to-completion drain hit its depth limit. |
 | Machine | `:rf.error/machine-action-exception` | A machine action body threw. |
 | Routing | `:rf.error/no-such-route` / `:rf.error/missing-route-param` | A route op referenced an unknown id or omitted a required param. |
@@ -196,6 +197,22 @@ Client-side error UX is a different thing and does *not* go through the projecto
 ## The failures you'll actually meet
 
 Reference material, the lot of it — skim on a first read, and come back to the relevant one when you hit it in the wild. Each is a real `:rf.error/*` category, and every one of them is JVM-runnable, which means every one of them is something you can write a test for (see [§Testing error paths](#testing-error-paths) below and the full surface in [chapter 13](13-testing.md)).
+
+### A dispatch with no frame in scope
+
+*You wrote a quick `(rf/dispatch [:counter/inc])` at the REPL, or in a fresh test, or in a plain Reagent fn you forgot to mount inside a `frame-provider` — and instead of the cascade you expected, you got an error. This is the single most common first stumble: `dispatch` and `subscribe` are frame-scoped, and you ran one with no frame around it.*
+
+A bare `(rf/dispatch [:counter/inc])` resolves its target frame from the surrounding scope — a `with-frame` / `with-new-frame` region, a carried `frame-handle`, an enclosing `frame-provider`, or an explicit `{:frame ...}` opt. With *none* of those present, there is nothing to resolve against, and the runtime does **not** invent a default. It emits:
+
+```clojure
+{:operation :rf.error/no-frame-context
+ :op-type   :error
+ :recovery  :supply-frame
+ :tags      {:event    [:counter/inc]
+             :reason   "No frame in scope for `dispatch` of `:counter/inc`."}}
+```
+
+This is the absence of a target, and the runtime reports it *before* any registry lookup — so a missing context is never mis-reported as a destroyed-frame error for a synthesised default. The fix is always the same: establish a frame. In a view, render under a `frame-provider` (a `reg-view` does this for you); at the REPL or in a test, wrap the work in `with-new-frame` or pass `{:frame ...}` explicitly. (The full carried-frame contract is [chapter 18](18-frames.md); the test shapes are [chapter 13](13-testing.md).)
 
 ### A malformed event vector
 
@@ -334,7 +351,8 @@ Errors are data on a wire, which makes asserting them as boring as asserting any
         (fn [_ _]
           (reset! fired? true)
           {}))
-      (rf/dispatch-sync [:test/run-no-cofx])
+      (rf/with-new-frame [f (rf/make-frame {})]
+        (rf/dispatch-sync [:test/run-no-cofx]))
       (rf/unregister-listener! ::no-cofx)
 
       (is (true? @fired?)

--- a/docs/guide/25-from-re-frame-v1.md
+++ b/docs/guide/25-from-re-frame-v1.md
@@ -60,6 +60,8 @@ Inside that tree, every bare `dispatch` / `subscribe` you already wrote works un
 
 **View-rendering boundary.** Plain Reagent fns keep working when they render *under an established frame scope* — inside a `frame-provider`, they inherit the frame ambiently like any other call. What no longer works is a plain fn that dispatches or subscribes with *no* scope at all: that fails loudly with `:rf.error/no-frame-context` rather than the silent default-frame routing v1 allowed. `reg-view` adoption is opt-in modernisation (it injects frame-bound `dispatch` / `subscribe` and survives more boundaries cleanly), not a migration requirement — the requirement is simply that a frame scope exist above the view.
 
+**Subscription input functions.** The two-function `reg-sub` form changes shape, not spirit. A v1 *signal function* returned live signals — `(rf/subscribe ...)` calls. A v2 *input function* returns plain **query vectors** (a vector *of* query vectors), and the runtime does the subscribing — which is what keeps the input function pure and the subscription graph inspectable without running the app. The mechanical tell is the bracket count on the single-input case: v2 wants `[[:item/by-id id]]`, not `[:item/by-id id]`. [Chapter 05](05-subscriptions.md#the-input-functions-one-rule-about-its-return-value) carries the full grammar and the why; the migration skill rewrites the common shapes and flags the rest.
+
 When a failure matches none of the above, the skill surfaces it for human review rather than guessing. That's the cardinal rule again, and it's what keeps an automated migration trustworthy: it does the things it's sure of and asks about the rest.
 
 ## The two changes worth understanding in depth

--- a/docs/guide/27-resources.md
+++ b/docs/guide/27-resources.md
@@ -266,10 +266,25 @@ Resource events take **map payloads**, not positional argument vectors:
 
 The race semantics are normative and worth knowing:
 
+- **`ensure` of an entry that is already `:loaded` and still fresh-by-policy is a cache hit** — it serves the cached value, attaches any supplied owner, and starts **no** fetch. It neither dedupes (there's no in-flight work to join) nor refetches; it emits a `:rf.resource/cache-hit` trace and, for a blocking route slot, settles the navigation immediately (a route blocked on a fresh resource never hangs). This is the fresh-skip path that lets [§Route-driven loading](#route-driven-loading) say "if hydrated data is already fresh, it doesn't block at all." A *stale* `:loaded` entry is not a cache hit — its next `ensure` refetches per policy — and a `refetch` is never a cache hit (it always forces a new generation).
 - **`ensure` while the same scoped key is already in flight** *joins* the existing work — it attaches any supplied owner to both the entry and the ledger row, records the new cause, and emits a dedupe trace. Two screens asking for the same article fire one request.
 - **`refetch` may force a new generation.** If a prior request is still in flight, the old work record is marked superseded, aborted when possible, otherwise suppressed by work-id + generation.
 - **Owner release while in flight** aborts only when *no remaining owner* needs the work. A shared request isn't cancelled just because one of its owners went away.
 - **Stale/GC timers are advisory.** A timer handler re-reads the current entry, owners, and generation before writing — a newer event may already have refreshed, invalidated, or removed it. Freshness is computed from durable timestamps, not from trusting a timer fired on time.
+
+Freshness and lifetime are policy, declared on the resource. Two optional `reg-resource` keys arm the timers above:
+
+```clojure
+(rf/reg-resource :article/by-slug
+  {:params-schema  [:map [:slug :string]]
+   :scope          :rf.scope/global
+   :stale-after-ms 60000        ;; after 60s a :loaded entry is stale — the next ensure refetches
+   :gc-after-ms    300000       ;; after 5min with no active owner the entry is GC-eligible
+   :request        (fn [{:keys [slug]} _ctx]
+                     {:request {:method :get :url (str "/api/articles/" slug)} :decode :json})})
+```
+
+`:stale-after-ms` is what makes a fresh ensure a cache hit and a later one a refetch; `:gc-after-ms` reclaims an inactive entry. Omit them and the entry is fresh until explicitly invalidated and never GC'd on a timer — fine for small, long-lived caches; set them for data that ages.
 
 The lowering to transport is the framework's job. Internally an ensure creates or joins a work-ledger record, then lowers to `:rf.http/managed` — supplying the `:request-id`, `:on-success`, and `:on-failure` itself from the scoped key and generation. Your `:request` fn returns a [Spec 014](../../spec/014-HTTPRequests.md) args map (the nested `:request`, `:decode`, `:retry`, sensitivity metadata) but **must not** supply `:request-id` / `:on-success` / `:on-failure` — those are how stale-suppression is wired, and an app that bypasses them is rejected.
 

--- a/docs/guide/OUTLINE.md
+++ b/docs/guide/OUTLINE.md
@@ -44,6 +44,7 @@ The guide is not the spec and should not read like the spec. It should teach eno
 | 24 | `24-config-and-safety.md` | Teach configuration, safety knobs, and production posture. |
 | 25 | `25-from-re-frame-v1.md` | Map v1 habits to v2 and explain why migration is worth it. |
 | 26 | `26-operating-well.md` | Provide the operating map: examples, API, spec, patterns, tools, skills. |
+| 27 | `27-resources.md` | Teach declarative server-state: cached reads, scopes, owners, invalidation, and mutations. |
 
 ## Live Cell Policy
 

--- a/docs/guide/interactive-tutorials.md
+++ b/docs/guide/interactive-tutorials.md
@@ -25,7 +25,7 @@ For a guide chapter, the answer is almost always ` ```cljs-rf2 `. You're teachin
 
 A teaching cell is not a screenshot. It's an invitation to experiment. Three conventions keep that invitation honest:
 
-**1. The cell must run as written.** Whatever you put between the fences is what the reader sees, edits, and evaluates. There's no hidden setup. If the counter needs its `app-db` seeded before the view renders, the seeding form is *in the cell* where the reader can see it. A cell that only works because of state left behind by an earlier cell is a trap — write each interactive cell to stand alone.
+**1. The cell must run as written.** Whatever you put between the fences is what the reader sees, edits, and evaluates — no hidden *application* code. If the counter needs its `app-db` seeded before the view renders, the seeding form is *in the cell* where the reader can see it. (The one thing the harness supplies off-screen is the runtime scaffolding that mounts the cell — substrate plus a default frame — disclosed where it first matters in [chapter 03](03-first-app.md#the-counter-live-and-in-pieces); the cell body never hides app logic.) A cell that only works because of state left behind by an earlier cell is a trap — write each interactive cell to stand alone.
 
 **2. Tell the reader what to change.** After a cell, name the edit you want them to try and what they should expect. "Change `inc` to `(partial + 10)`, press the eval shortcut, and click `+` — the counter now jumps by ten." A live cell with no suggested experiment is just a slow screenshot.
 


### PR DESCRIPTION
Guide-cluster worker resolving three `docs/guide` beads in one PR. Surface fenced to `docs/guide/*` + the OUTLINE only.

## rf2-lbxu0r — carried-frame test snippets + error catalogue
- **ch.13** — wrapped the three rootless test snippets in `with-new-frame` so `dispatch-sync` / `dispatch-sequence` resolve a real frame instead of raising `:rf.error/no-frame-context`: the `counter-walk` deftest, the `assert-path-equals` "common case", and the canned-HTTP-stub recipes (`managed-canned-*` + `with-managed-request-stubs`). Reworded the default-frame-fallback residue comment ("against a non-default frame" → "addressing a frame explicitly, when the body isn't the current one").
- **ch.14** — added `:rf.error/no-frame-context` to the taxonomy table (paired with `frame-destroyed`, with the absent-vs-bad-target distinction the spec emphasizes) and a "failures you'll actually meet" section framed as the most common newcomer stumble. Fixed the rootless `dispatch-sync` in the worked no-cofx test by wrapping it in `with-new-frame`.

## rf2-8jeeun — completeness minors
- **ch.27** — taught the fresh-skip / `:rf.resource/cache-hit` ensure path in the race-semantics list (a fresh `:loaded` ensure serves cache, attaches owner, starts no fetch, settles a blocking route immediately) and introduced the `:stale-after-ms` / `:gc-after-ms` policy keys via a `reg-resource` example.
- **ch.25** — named the v1 signal-fn → v2 input-fn semantic change as a migration category with a pointer to ch.05's grammar section.
- **OUTLINE** — added the missing ch.27 row to the chapter-set table.

## rf2-4xy0no — harness-frame disclosure consistency
**Judgment: minimal note, no flag needed.** The bead offered a minimal-note-vs-larger-restructure choice. The minimal note was sufficient and coherent — no editorial escalation required.
- **ch.01:60** — scoped "nothing hidden off-screen" to "every line of the *program* is on the page" plus a one-clause parenthetical that the playground supplies mount scaffolding ("the same way a `main` would"), pointing to ch.03. Deliberately frame-free in the reader-facing intro — frames stay ch.18's job.
- **ch.01:93** — "every line is on the page" now reads consistently (scoped to the program by the ch.01:60 carve-out); no edit needed.
- **interactive-tutorials.md:28** — qualified "no hidden setup" to "no hidden *application* code", disclosing the substrate-plus-default-frame scaffolding with a pointer to ch.03. This is an authoring meta-doc, so naming "a default frame" here matches ch.03's disclosure without leaking the concept into the intro.

## Quality gates
- `python -m mkdocs build --strict` — exit 0, no WARNING/ERROR (the one INFO note about `the-mayor-method.md` is pre-existing and unrelated).
- `python scripts/check_doc_slugs.py --verbose` — "no broken links" across 425 files; validates anchor slugs, so all new fragment links (`#the-counter-live-and-in-pieces`, `#the-input-functions-one-rule-about-its-return-value`, `#route-driven-loading`) resolve.
- OUTLINE matches the chapters (01–27); no broken cross-links.

Note: ch.05 was just fixed (#3824 frame-handle) — this PR's ch.05 reference is a fragment link only, no content change there.
