### PR TITLE
docs(spec): Pattern-ReusableComponents EP-0004 input-fn (rf2-orgq0q)

### DIFF
--- a/spec/Pattern-ReusableComponents.md
+++ b/spec/Pattern-ReusableComponents.md
@@ -37,12 +37,12 @@ Three rules, each illustrated by one form.
 
 The id is part of the **sub's identity** — `(subscribe [:customer 42])` and `(subscribe [:customer 43])` cache as distinct entries in the sub-cache. Two instances of `customer-card` rendered with different ids run two independent computations against two distinct app-db slices.
 
-For derived data, the same destructure pattern composes with signal-vector subs:
+For derived data, the same id is threaded into the sub's inputs via a v2 **`input-fn`** (per [006-ReactiveSubstrate.md](006-ReactiveSubstrate.md#subscription-input-producers--app-db-reader-static-parametric-input-fn)). The `input-fn` takes only the outer query vector and returns a **vector of query vectors**; the runtime resolves each in the outer sub's frame and delivers the resolved input *values* (always a vector for a parametric `input-fn`, including the single-input case) to the computation fn:
 
 ```clojure
 (rf/reg-sub :customer/display-name
-  (fn [[_ id] _] (rf/subscribe [:customer id]))
-  (fn [customer _]
+  (fn [[_ id]] [[:customer id]])
+  (fn [[customer] _]
     (str (:first-name customer) " " (:last-name customer))))
 ```
 


### PR DESCRIPTION
## What

`spec/Pattern-ReusableComponents.md` taught the **v1 signal-fn** `reg-sub` form for the derived-data example (lines 40-47). Under landed **EP-0004** that registers cleanly then throws `:rf.error/sub-input-fn-bad-return` at first materialization. This rewrites it to the v2 two-function `input-fn` form.

The old form violated the input-fn contract three ways:
- input-fn took an extra second arg (v2 receives only the outer query vector);
- returned a live `rf/subscribe` reaction instead of a vector of query vectors;
- compute-fn destructured a scalar `customer` rather than the resolved-input vector.

Corrected to mirror `spec/006-ReactiveSubstrate.md` §Subscription input producers exactly:

```clojure
(rf/reg-sub :customer/display-name
  (fn [[_ id]] [[:customer id]])
  (fn [[customer] _]
    (str (:first-name customer) " " (:last-name customer))))
```

A parametric `input-fn` always delivers its resolved inputs as a **vector**, including the single-input case — hence `[[customer] _]`. Also dropped the "signal-vector subs" prose framing and cross-linked spec/006.

## Pattern-*.md sweep

The EP-0004 numbered-spec verification (API.md + 006 + 008) never swept `spec/Pattern-*.md`. I grepped all of them for the same idiom: **only this file carried it.** The others use either the `:<-` declarative sugar (correct EP-0004 literal producer) or single-arg `(fn [db _] ...)` base readers — no v1 signal-fn returning a live reaction. Only `Pattern-ReusableComponents.md` fixed.

## Quality gates

Spec-doc only — no code/test gates apply (no `implementation/` or test changes).

- `python scripts/check_doc_slugs.py --verbose` → **PASS** (426 files scanned, no broken links — confirms the new spec/006 anchor resolves)
- `python -m mkdocs build --strict` → **PASS** (exit 0; built in ~10s)

Closes rf2-orgq0q.
