### PR TITLE
fix(examples): realworld_resources auth header + restore route + read retry (rf2-j4kbro)

### DIFF
--- a/examples/reagent/realworld_resources/README.md
+++ b/examples/reagent/realworld_resources/README.md
@@ -77,21 +77,24 @@ The save-success continuation (navigate to the saved article) is **off the rende
 
 Login / register / session-restore / logout are a Spec 005 state machine issuing managed HTTP — auth is a *command*, not a cached read, and is deliberately **not** contorted into a read-resource (Spec 016 §Scope). The one auth-adjacent **write** that *is* a mutation is the settings update (it invalidates the profile read). On **logout** the machine clears the session **and** the session-scoped resource cache via `:rf.resource/clear-scope` — the causal operation for exactly that — so the next user never reads the prior user's feed. The public `:rf.scope/global` reads are untouched.
 
+- **One Bearer header for the whole API — a Spec 014 HTTP interceptor.** Resources, mutations, and the auth machine all lower onto `:rf.http/managed`, so a single frame-wide `:before` interceptor (`:realworld/bearer-auth`, registered in `core.cljs`) injects `Authorization: Token <jwt>` from the auth slice onto **every** outbound request — the authenticated reads (`/articles/feed`), the writes (favourite / follow / comment / settings / save-article), and the restore `GET /user`. No `:request` fn threads the token per-call; the auth slice is the single source of truth and the interceptor is the single read site. It reads the token from the **carried** frame (`(:frame ctx)`, EP-0002), so the header tracks a renamed / multi-frame mount, and returns the ctx unchanged when no token is present (login / register / logged-out public reads are unaffected). This is the cross-cutting-decoration story the resources surface otherwise leaves untold.
+- **Session-restore preserves the route; only interactive login bounces.** Cold-booting with a saved JWT runs the `:restoring → :authed` transition through the `:restore-session` action, which stores the session **without** navigating — a logged-in user who deep-links to `/article/x` stays there once restore settles. Only an **interactive** login / register (`:store-session`) dispatches `:auth/post-login-redirect` to bounce to the guard-stashed `:return-to` (or home).
+
 ## Files
 
 | File | What it holds |
 |---|---|
-| `core.cljs` | Entry point, app shell, route switch, mount; installs the demo `:rf.http/managed` backend stub + the revalidation listeners. |
+| `core.cljs` | Entry point, app shell, route switch, mount; installs the demo `:rf.http/managed` backend stub + the revalidation listeners + the frame-wide `:realworld/bearer-auth` HTTP interceptor. |
 | `resources.cljs` | Every RealWorld read as `reg-resource` (identity / scope / `:request` / `:tags` / stale + GC policy). |
 | `mutations.cljs` | Every RealWorld write as `reg-mutation` (`:invalidates` / `:populates`). |
 | `scope.cljs` | The fail-closed session cache scope + the `:session/scope` sub the view passes on session-scoped reads. |
 | `routing.cljs` | Routes with `:resources` metadata + the `auth-guard` interceptor; the home `:on-match` ensures the session feed. |
-| `auth.cljs` | The `:auth/flow` auth machine (login / register / restore / logout-with-clear-scope) + the login/register forms. |
+| `auth.cljs` | The `:auth/flow` auth machine (login / register / restore-without-navigating / logout-with-clear-scope) + the login/register forms. |
 | `settings.cljs` | The settings page as a mutation instance (`:rf.mutation/state`); the save-success continuation is off the render path (Form-3 settle reaction). |
 | `article_editor.cljs` | Create / edit / delete an article: the `:realworld/save-article` + `:realworld/delete-article` mutations, the `:editor/can-submit?` Spec 013 flow, the `:editor/can-leave?` guard, and the Form-3 settle reactions (seed-on-load + save/delete continuation). |
 | `views.cljs` | Passive pages (home / article / profile) + the small UI event glue (favourite / follow / comment). |
 | `schema.cljs` | Malli wire shapes + the small app-db schemas (auth + form drafts only — the reads live in runtime-db). |
-| `http.cljs` | The demo backend stub (resources + mutations lower onto `:rf.http/managed`, so one stub serves the whole API) + the `:rf.http/*` failure projection. |
+| `http.cljs` | The demo backend stub (resources + mutations lower onto `:rf.http/managed`, so one stub serves the whole API) + the shared `data-fetch-retry` read policy + the `:rf.http/*` failure projection. |
 | `index.html` | Static host page. |
 
 ## How to run

--- a/examples/reagent/realworld_resources/auth.cljs
+++ b/examples/reagent/realworld_resources/auth.cljs
@@ -74,10 +74,14 @@
                                          {:scope old-scope :cause :logout}]]))})))
 
 (rf/reg-event-fx :auth/post-login-redirect
-  {:doc "Bounce the freshly-authenticated user to the route the auth guard
-         intercepted (`[:auth :return-to]`), or home. Machine actions can't
-         navigate or read `:db` directly (Spec 005), so this is an ordinary
-         event. Reads AND clears the slot so a later login can't re-bounce."}
+  {:doc "Bounce the user who INTERACTIVELY logged in / registered to the route
+         the auth guard intercepted (`[:auth :return-to]`), or home. Dispatched
+         ONLY by the `:store-session` action (the interactive `:submitting →
+         :authed` transition) — NOT by `:restore-session` (cold-boot
+         session-restore preserves the restored route, never force-navigates).
+         Machine actions can't navigate or read `:db` directly (Spec 005), so
+         this is an ordinary event. Reads AND clears the slot so a later login
+         can't re-bounce."}
   (fn [{:keys [db]} _]
     (let [return-to (get-in db [:auth :return-to])]
       {:db (update db :auth dissoc :return-to)
@@ -133,13 +137,31 @@
 
     :store-session
     (fn [{[_ {:keys [value]}] :event}]
-      ;; Machine actions see no `:db` and emit no `:db` (Spec 005), so the
-      ;; session store + bounce-back run as ordinary events.
+      ;; INTERACTIVE login / register success: store the session, persist the
+      ;; JWT, AND bounce to the guard-stashed `:return-to` (or home). The
+      ;; bounce is the right behaviour ONLY for an interactive submit — the
+      ;; user just clicked Sign-in from the login page and expects to land
+      ;; somewhere. Machine actions see no `:db` and emit no `:db` (Spec 005),
+      ;; so the session store + bounce-back run as ordinary events.
       (let [user (:user value)]
         {:data {:error nil}
          :fx [[:dispatch [:auth/store-session user]]
               [:realworld-resources.session/persist {:token (:token user)}]
               [:dispatch [:auth/post-login-redirect]]]}))
+
+    :restore-session
+    (fn [{[_ {:keys [value]}] :event}]
+      ;; SESSION-RESTORE success (cold boot with a saved JWT): store the
+      ;; session WITHOUT navigating. A logged-in user cold-booting on a deep
+      ;; link (`/article/x`) must stay on that route — restore only re-hydrates
+      ;; the session; it must NOT force-navigate home (the bug this action
+      ;; fixes). Only an INTERACTIVE login/register bounces (`:store-session`).
+      ;; The token is already in app-db + localStorage from `:auth/initialise`;
+      ;; we re-persist defensively in case the server rotated it on `GET /user`.
+      (let [user (:user value)]
+        {:data {:error nil}
+         :fx [[:dispatch [:auth/store-session user]]
+              [:realworld-resources.session/persist {:token (:token user)}]]}))
 
     :record-error
     (fn [{[_ {:keys [failure]}] :event}]
@@ -161,7 +183,7 @@
     {:on {:auth/success {:target :authed :action :store-session}
           :auth/failure {:target :error  :action :record-error}}}
     :restoring
-    {:on {:auth/success        {:target :authed :action :store-session}
+    {:on {:auth/success        {:target :authed :action :restore-session}
           :auth/restore-failed {:target :idle   :action :clear-session}}}
     :authed
     {:on {:auth/logout {:target :idle :action :clear-session}

--- a/examples/reagent/realworld_resources/core.cljs
+++ b/examples/reagent/realworld_resources/core.cljs
@@ -149,6 +149,34 @@
    [footer]])
 
 ;; ============================================================================
+;; BEARER-AUTH HTTP INTERCEPTOR  (Spec 014 §Middleware)
+;; ============================================================================
+;;
+;; The cross-cutting decoration the resources/mutations variant was missing
+;; (fable.md F4): a single `:before` fn injects the Bearer token from the auth
+;; slice, so EVERY outbound `:rf.http/managed` request that crosses this frame
+;; picks the header up automatically. Resources AND mutations lower onto
+;; `:rf.http/managed`, so this one interceptor decorates the WHOLE Conduit API
+;; — the route-caused reads (`/articles/feed`, the lists, detail), the writes
+;; (favorite / follow / comment / settings / save-article), and the auth
+;; machine's session-restore `GET /user`. No `:request` fn threads the token
+;; per-call; the auth slice is the single source of truth and this is the
+;; single read site.
+;;
+;; CARRIED-FRAME-CORRECT (EP-0002 rf2-9o48ih): the token is read from
+;; `(:frame ctx)` — the frame the cascade actually runs under — not a
+;; hard-coded `:rf/default`, so the header tracks a renamed / multi-frame
+;; mount. The interceptor returns ctx unchanged when no token is present, so
+;; login / register / the public reads (logged-out) are unaffected.
+
+(defn- bearer-auth-interceptor [ctx]
+  (let [token (some-> (rf/app-db-value (:frame ctx))
+                      :auth :token)]
+    (cond-> ctx
+      token (assoc-in [:request :headers "Authorization"]
+                      (str "Token " token)))))
+
+;; ============================================================================
 ;; MOUNT  (CLJS reference; client-only)
 ;; ============================================================================
 
@@ -167,6 +195,11 @@
      :url-bound?   true
      :interceptors [routing/auth-guard]
      :fx-overrides {:rf.http/managed :realworld-resources.demo/http-stub}})
+  ;; Register the Bearer-auth interceptor at app boot, BEFORE :app/initialise
+  ;; dispatches — session-restore fires an authenticated `GET /user` as soon as
+  ;; the JWT is hydrated, so the header must already be wired.
+  (rf/reg-http-interceptor :realworld/bearer-auth
+                           {:before bearer-auth-interceptor})
   ;; The orchestrator serves this example at /realworld-resources/; strip that
   ;; prefix before the matcher sees the URL so :realworld/home (path "/") matches.
   (routing/set-base-path! "/realworld-resources")

--- a/examples/reagent/realworld_resources/http.cljs
+++ b/examples/reagent/realworld_resources/http.cljs
@@ -34,6 +34,26 @@
   (str api-base path))
 
 ;; ============================================================================
+;; RETRY POLICY (Spec 014 §Retry and backoff)
+;; ============================================================================
+;;
+;; Reads retry / writes don't (Spec 014). Each read resource's `:request`
+;; returns a Spec 014 managed-HTTP args map, and `:retry` passes through the
+;; resource lowering UNCHANGED (Spec 016 §Transport), so a resource arms retry
+;; simply by including this policy in its return. Writes (mutations) stay
+;; retry-free — a write's intent is one submission per click; a 5xx surfaces
+;; as `:error` so the user retries themselves.
+
+(def data-fetch-retry
+  "Standard retry policy for read-only data fetches (lists, article detail,
+   comments, profiles, tags, the feed). Retries transport blips, 5xx, and
+   timeouts — NOT 4xx (the request shape was valid; retrying won't help).
+   Three attempts total with exponential backoff + jitter."
+  {:on           #{:rf.http/transport :rf.http/http-5xx :rf.http/timeout}
+   :max-attempts 3
+   :backoff      {:base-ms 200 :factor 2 :max-ms 2000 :jitter true}})
+
+;; ============================================================================
 ;; FAILURE PROJECTION
 ;; ============================================================================
 

--- a/examples/reagent/realworld_resources/resources.cljs
+++ b/examples/reagent/realworld_resources/resources.cljs
@@ -53,6 +53,12 @@
    inactive (Spec 016 §Stale and GC scheduling)."
   (* 5 60 1000))
 
+;; Reads retry / writes don't (Spec 014). Each read's `:request` returns the
+;; shared `rh/data-fetch-retry` policy in its managed-HTTP args; `:retry`
+;; passes through the resource lowering UNCHANGED (Spec 016 §Transport), so a
+;; transport blip / 5xx / timeout retries with backoff+jitter (NOT a 4xx — the
+;; request shape was valid). Mutations (writes) stay retry-free.
+
 ;; ============================================================================
 ;; PUBLIC READS — :scope :rf.scope/global (same for every viewer)
 ;; ============================================================================
@@ -77,7 +83,8 @@
                                 :url    (rh/full-url (if tag
                                                        (str "/articles?tag=" tag)
                                                        "/articles"))}
-                      :decode  schema/ArticlesResponse})
+                      :decode  schema/ArticlesResponse
+                      :retry   rh/data-fetch-retry})
    :stale-after-ms stale-after-ms
    :gc-after-ms    gc-after-ms
    ;; Tag the list identity AND every article it contains, so favoriting an
@@ -93,7 +100,8 @@
    :scope          :rf.scope/global
    :request        (fn [{:keys [slug]} _ctx]
                      {:request {:method :get :url (rh/full-url (str "/articles/" slug))}
-                      :decode  schema/ArticleResponse})
+                      :decode  schema/ArticleResponse
+                      :retry   rh/data-fetch-retry})
    :stale-after-ms stale-after-ms
    :gc-after-ms    gc-after-ms
    ;; Tag BOTH the per-article identity and the list identity so a save /
@@ -110,7 +118,8 @@
    :scope          :rf.scope/global
    :request        (fn [{:keys [slug]} _ctx]
                      {:request {:method :get :url (rh/full-url (str "/articles/" slug "/comments"))}
-                      :decode  schema/CommentsResponse})
+                      :decode  schema/CommentsResponse
+                      :retry   rh/data-fetch-retry})
    :stale-after-ms stale-after-ms
    :gc-after-ms    gc-after-ms
    :tags           (fn [{:keys [slug]} _data] #{[:comments slug]})})
@@ -122,7 +131,8 @@
    :scope          :rf.scope/global
    :request        (fn [{:keys [username]} _ctx]
                      {:request {:method :get :url (rh/full-url (str "/profiles/" username))}
-                      :decode  schema/ProfileResponse})
+                      :decode  schema/ProfileResponse
+                      :retry   rh/data-fetch-retry})
    :stale-after-ms stale-after-ms
    :gc-after-ms    gc-after-ms
    :tags           (fn [{:keys [username]} _data] #{[:profile username]})})
@@ -134,7 +144,8 @@
    :scope          :rf.scope/global
    :request        (fn [{:keys [username]} _ctx]
                      {:request {:method :get :url (rh/full-url (str "/articles?author=" username))}
-                      :decode  schema/ArticlesResponse})
+                      :decode  schema/ArticlesResponse
+                      :retry   rh/data-fetch-retry})
    :stale-after-ms stale-after-ms
    :gc-after-ms    gc-after-ms
    :tags           (fn [{:keys [username]} data]
@@ -148,7 +159,8 @@
    :scope          :rf.scope/global
    :request        (fn [_params _ctx]
                      {:request {:method :get :url (rh/full-url "/tags")}
-                      :decode  schema/TagsResponse})
+                      :decode  schema/TagsResponse
+                      :retry   rh/data-fetch-retry})
    :stale-after-ms stale-after-ms
    :gc-after-ms    gc-after-ms
    :tags           (fn [_params _data] #{[:tags]})})
@@ -175,7 +187,8 @@
    :scope          :rf.scope/from-caller
    :request        (fn [_params _ctx]
                      {:request {:method :get :url (rh/full-url "/articles/feed")}
-                      :decode  schema/ArticlesResponse})
+                      :decode  schema/ArticlesResponse
+                      :retry   rh/data-fetch-retry})
    :stale-after-ms stale-after-ms
    :gc-after-ms    gc-after-ms
    :tags           (fn [_params data]


### PR DESCRIPTION
Fixes three defects in the just-merged `examples/reagent/realworld_resources/` example (rf2-j4kbro), found during the side-by-side analysis in `ai/findings/realworld/fable.md §Addendum`.

## Bug 1 — No Authorization header on any request
No bearer-auth interceptor was installed and no `:request` fn added one, so against the real Conduit API every authenticated call would 401 (the restore `GET /user`, `GET /articles/feed`, favorite/follow/comment/settings writes) — masked only by the demo stub that ignores auth.

**Fix:** register a frame-wide `:realworld/bearer-auth` HTTP interceptor in `core.cljs` (mirroring the managed-HTTP sibling `realworld/core.cljs:385-417`). Its `:before` fn injects `Authorization: Token <jwt>` from the auth slice, read from the **carried** frame `(:frame ctx)` (EP-0002), and returns ctx unchanged when no token is present. Resources, mutations, and the auth machine all lower onto `:rf.http/managed`, so the one interceptor decorates the whole API — the cross-cutting-decoration teaching story the resources surface otherwise left untold (fable.md F4).

## Bug 2 — Session-restore force-navigated home
The shared `:store-session` machine action unconditionally dispatched `:auth/post-login-redirect`, so a logged-in user cold-booting on a deep link (`/article/x`) got bounced home when restore settled.

**Fix:** split the restore path. The `:restoring → :authed` transition now uses a new `:restore-session` action that stores the session + persists the JWT **without** navigating; only an **interactive** login/register (`:submitting → :authed`, `:store-session`) bounces to the guard-stashed `:return-to` (or home).

## Bug 3 — Reads lost the retry policy
The ported read resources returned bare `{:request … :decode …}` with no `:retry`, dropping the original's data-fetch retry.

**Fix:** add a shared `data-fetch-retry` policy in `http.cljs` (transport / 5xx / timeout, 3 attempts, backoff+jitter — not 4xx) and arm it on all 7 read resources' `:request` returns. `:retry` passes through the resource lowering unchanged (Spec 016 §Transport). Writes (mutations) stay retry-free.

Demo stub behaviour is unchanged (it routes by URL + method and ignores headers).

## Files
- `examples/reagent/realworld_resources/core.cljs` — `:realworld/bearer-auth` interceptor + boot registration
- `examples/reagent/realworld_resources/auth.cljs` — `:restore-session` action; `:restoring` transition repointed; doc updates
- `examples/reagent/realworld_resources/http.cljs` — `data-fetch-retry` policy
- `examples/reagent/realworld_resources/resources.cljs` — `:retry` on all 7 reads + policy note
- `examples/reagent/realworld_resources/README.md` — bearer-interceptor + restore-route notes; Files-table rows

## Quality gates
- `npm run test:examples-compile` — PASS: all 42 example builds compiled with **0 warnings** (`:examples/realworld-resources` 237 files, 236 compiled, 0 warnings)
- `shadow-cljs release :examples/realworld-resources` — PASS: Build completed, **0 warnings** (236 files, 176 compiled)
- `npm run test:script-policy` (incl. `check-examples-assets` layout↔disk bijection, no `*.spec.cjs`) — PASS
- `scripts/test-fast-pr.sh` — PASS: 6420 tests / 23187 assertions, 0 failures, 0 errors; README link/anchor + README-inventory + EP/runtime-grading gates green (mkdocs soft-skipped locally — not on PATH; CI runs it)
