### PR TITLE
docs(resources): document hybrid mutation scope (execution fail-open, invalidation fail-closed) (rf2-nx8ip6)

### DIFF
--- a/docs/EP/EP-0003-resource-queries.md
+++ b/docs/EP/EP-0003-resource-queries.md
@@ -2045,7 +2045,11 @@ The landed minimal mutation slice includes:
 - `reg-mutation`, `clear-mutation`, and `:rf.mutation/execute`;
 - mutation pending/error/result state;
 - a generated or caller-supplied mutation instance id;
-- scoped execution, using the same cache-scope rules as resources;
+- scoped execution under a hybrid scope model — the mutation's *execution*
+  scope is fail-open (payload `:scope`, else spec `:scope`, else
+  `:rf.scope/global`, since a causal write has no cached-read leak boundary),
+  while its *invalidation* scope is fail-closed (`:rf.resource/invalidate-tags`
+  requires an explicit scope, `:cross-scope? true` being the only opt-out);
 - concurrency semantics for multiple submissions of the same mutation id;
 - tag invalidation from success and, when useful, failure;
 - explicit invalidation timing: before request, after success, after failure, or

--- a/implementation/resources/src/re_frame/resources/mutation_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_registry.cljc
@@ -240,10 +240,16 @@
 (defn resolve-scope
   "Resolve the cache scope a mutation's invalidation / patch defaults to,
   in precedence order: the execute payload `:scope`, else the mutation
-  spec's `:scope`, else `:rf.scope/global`. A mutation has NO fail-closed
-  scope requirement (it is a causal write, not a cached read with a leak
-  boundary) — the invalidation it triggers is scoped, so the scope just
-  decides which cache scope the success-time `:invalidate-tags` /
+  spec's `:scope`, else `:rf.scope/global`. A mutation's EXECUTION scope has
+  NO fail-closed scope requirement (it is a causal write, not a cached read
+  with a leak boundary), so defaulting to `:rf.scope/global` is correct here.
+  This is distinct from the mutation's INVALIDATION scope, which IS
+  fail-closed: `:rf.resource/invalidate-tags` throws
+  `:rf.error/resource-invalidate-scope-required` without an explicit scope
+  (rf2-pvdae1), `:cross-scope? true` being the only scope-agnostic opt-out.
+  The resolved scope below is what the success-time invalidation supplies, so
+  the two compose: this fail-open execution default decides which cache scope
+  the success-time `:invalidate-tags` /
   patch / populate target.
 
   Routes the resolved concrete scope through the SAME shared validation
@@ -253,8 +259,8 @@
   `[:rf.scope/global]` singleton-vector spelling normalizes to bare
   `:rf.scope/global` (rf2-vv87xz) — so a mutation can never invalidate /
   patch a silent WRONG (or second, distinct global) cache scope. Returns
-  the canonical scope. Per EP-0003 §Mutations (scoped execution, same
-  cache-scope rules as resources)."
+  the canonical scope. Per EP-0003 §Mutations (hybrid scope: fail-open
+  execution default, fail-closed invalidation)."
   [mutation-id spec payload-scope]
   (let [scope (or payload-scope (:scope spec) :rf.scope/global)]
     (state/canonicalize-scope scope 'rf.mutation/execute mutation-id)))

--- a/spec/016-Resources.md
+++ b/spec/016-Resources.md
@@ -573,6 +573,17 @@ A `:mutation` registrar kind is added (the causal-write counterpart of `:resourc
 - **Failure settles `:error`** (no `:refresh-error` analogue — a write has no last-known-good to keep); `:rf.mutation/clear` is the causal reset that clears the runtime instance (and best-effort aborts in-flight work).
 - **Trace-visible instance ids** — the `:rf.mutation/*` trace family (`started` / `succeeded` / `failed` / `cleared` / `stale-suppressed`) carries the instance id; the success trace reserves the optimistic-rollback shape (affected keys, patch summary; snapshot/rollback/reconciliation slots) — **optimistic rollback itself is DEFERRED**.
 
+#### Mutation scope is two distinct scopes (hybrid)
+
+Unlike a resource — whose single scope policy is uniformly fail-closed (§[Scope resolution](#scope-resolution)) — a mutation carries **two distinct scopes** with **opposite default policies**, because a causal write and a cached read have different safety boundaries.
+
+- **Execution scope is FAIL-OPEN.** The scope a mutation's invalidation / patch / populate *defaults to* resolves in precedence order **execute-payload `:scope` → mutation-spec `:scope` → `:rf.scope/global`**. A mutation is a causal write, not a cached read, so it has **no cached-read leak boundary of its own** — defaulting to `:rf.scope/global` leaks nothing, so `:scope` is OPTIONAL at `reg-mutation` and on the execute payload. (The resolved concrete scope is still routed through the shared scope-canonicalization path, so a misspelled `:rf.scope/*` keyword or an opaque host value is still rejected loudly — fail-open on *absence*, not on a *wrong* value.)
+- **Invalidation scope is FAIL-CLOSED.** The success-time invalidation a mutation triggers composes with `:rf.resource/invalidate-tags`, which **requires an explicit scope**: it throws `:rf.error/resource-invalidate-scope-required` when none is supplied, and `:cross-scope? true` is the **only** scope-agnostic opt-out (which MUST be visible and lintable in Xray, as for any broad invalidation). A blind invalidation across all scopes would stale or refetch data for other users, tenants, story frames, or SSR requests — exactly the leak boundary the read path protects.
+
+Because the mutation supplies its resolved execution scope as the invalidation scope, the two compose: the fail-open execution default *becomes* the concrete scope the fail-closed invalidation runs in.
+
+> **Scope-match guidance (the footgun).** A mutation's resolved scope MUST match the scope of the resources it intends to invalidate. `:invalidates` matches only entries **in the resolved scope**; if a `:rf.scope/global`-defaulted mutation invalidates tags owned by a `:rf.scope/session`-scoped resource (or vice versa), the invalidation **silently misses** — no entry matches, the cached read is never refreshed, and no error is raised (it is a legitimate "no match in this scope"). When a write affects session- (or tenant-) scoped reads, the mutation MUST explicitly declare the matching invalidation scope (typically via the execute payload `:scope`). [EP-0016](../docs/EP/EP-0016-resource-mutation-completion.md) is the forward mechanism for per-target / named-scope invalidation, which lets a single mutation invalidate across more than one named scope target without resorting to a blanket cross-scope sweep.
+
 ## Transport
 
 The initial scope ships a **single built-in transport**:


### PR DESCRIPTION
@
Spec/doc alignment to Mikes **(3) HYBRID** ruling on rf2-nx8ip6. The mechanism already shipped (rf2-pvdae1 / #3818 made `invalidate-tags` fail-closed); this PR is **doc/spec/docstring alignment only — no runtime change**.

## The hybrid model

A mutation carries **two distinct scopes** with **opposite default policies**:

- **Execution scope = FAIL-OPEN** — resolves payload `:scope` → spec `:scope` → `:rf.scope/global`. A causal write has no cached-read leak boundary, so defaulting is correct; `:scope` stays OPTIONAL.
- **Invalidation scope = FAIL-CLOSED** — `:rf.resource/invalidate-tags` throws `:rf.error/resource-invalidate-scope-required` without an explicit scope; `:cross-scope? true` is the only scope-agnostic opt-out.

The mutation supplies its resolved execution scope as the invalidation scope, so the two compose.

## The 3 edits

1. **`spec/016-Resources.md` §Mutations** — adds a normative `Mutation scope is two distinct scopes (hybrid)` subsection: execution-fail-open + write-vs-read rationale, invalidation-fail-closed (citing `:rf.error/resource-invalidate-scope-required`), the scope-match footgun guidance (a scope mismatch makes `:invalidates` silently miss — the em5ab8 footgun), and an EP-0016 cross-link as the per-target / named-scope forward mechanism.
2. **`docs/EP/EP-0003-resource-queries.md`** — rewords the landed-slice bullet `scoped execution, using the same cache-scope rules as resources` (which implied fully fail-closed) to the hybrid model.
3. **`implementation/resources/src/re_frame/resources/mutation_registry.cljc`** — scopes the `resolve-scope` docstrings `NO fail-closed scope requirement` claim to **execution** scope only (invalidation IS fail-closed). Docstring-only; no code/behavior change.

## Quality gates

- `python -m mkdocs build --strict` — clean (no warnings/errors)
- `python scripts/check_doc_slugs.py --verbose` — no broken links (427 files)
- `python scripts/check_ep_status_sync.py --verbose` — EP index in sync (16 files)
- `implementation/resources/` `clojure -M:test` — 239 tests, 885 assertions, 0 failures / 0 errors (docstring change compiles)
- API-manifest `clojure -M -m re-frame.api-manifest.gen --check` — in sync (504 public vars); `mutation_registry` is internal, no facade drift

Closes rf2-nx8ip6.
@