### PR TITLE
feat(examples): realworld_resources favorited tab + paginated resources (keep-previous dogfood)

### DIFF
--- a/examples/reagent/realworld_resources/README.md
+++ b/examples/reagent/realworld_resources/README.md
@@ -22,18 +22,37 @@ Every RealWorld read is `reg-resource`d once and read **passively** through `[:r
 
 | Resource | Read |
 |---|---|
-| `:realworld/articles` | the global article list, `:tag`-filtered when `?tag=` is set (the tag is in params, so a filtered list is a distinct cache entry) |
+| `:realworld/articles` | the global article list, `:tag`-filtered when `?tag=` is set and `:page`-paginated (tag AND page are in params, so a filtered list and each page are distinct cache entries) |
 | `:realworld/article` | article detail by slug |
 | `:realworld/comments` | an article's comments (a sub-resource: an ordinary resource whose params carry the parent slug) |
 | `:realworld/profile` | a user's public profile banner |
-| `:realworld/author-articles` | the articles a profile authored |
+| `:realworld/author-articles` | the articles a profile authored (paginated) — the profile's **My Articles** tab |
+| `:realworld/favorited-articles` | the articles a profile **favorited** (`GET /articles?favorited=username`, paginated) — the profile's **Favorited Articles** tab |
 | `:realworld/tags` | the popular-tags sidebar |
-| `:realworld/feed` | the authenticated user's personalised feed — **session-scoped** |
+| `:realworld/feed` | the authenticated user's personalised feed — **session-scoped**, paginated |
 
 - **Route entry CAUSES the load.** `routing.cljs` declares each page's reads as `:resources` route metadata (`:blocking?` / `:keep-previous?` / `:when`). On entry the runtime ensures them under owner `[:route route-id nav-token]`; on leave it releases the owner by token and suppresses any stale reply by generation. The views never fetch.
 - **`:loading` / `:fetching` / `:refresh-error` done right.** Views render the canonical resource shape: `:loading?` → skeleton; `:error` and not `:has-data?` → error; else render the data, plus a quiet refresh indicator while `:fetching?` and a "showing last-known data" warning on `:refresh-error` (a background refresh failed but prior data is kept). The framework owns stale-while-revalidate, not the view.
 - **`:stale-after-ms` / `:gc-after-ms`, dedupe, fresh-skip.** Reads go stale after a minute (a re-`ensure` then refetches into `:fetching`, keeping prior data visible); a fresh re-`ensure` is a cache-hit (no fetch); concurrent identical reads dedupe onto one request; inactive entries are GC-eligible after their window.
 - **Focus / reconnect revalidation** is wired (`install-revalidation-listeners!` in `core.cljs`): returning to the tab or reconnecting refetches the active-and-stale reads, expressed as causal events, not a subscription that fetches.
+
+### Pagination is declarative — params identity + `:keep-previous?` (`resources.cljs` / `routing.cljs` / `views.cljs`)
+
+The Conduit list endpoints page with `limit` / `offset`; the UI is 1-indexed with a fixed page size and renders numbered controls off the server's `articlesCount`. Resources make all of that **declarative** — and this is the missing Spec 016 dogfood: pagination is where canonical-params identity and `:keep-previous?` (the TanStack-parity surface) earn their keep, and it needs **no new spec surface**.
+
+- **The page is just another `:params` key.** `:realworld/articles`, `:realworld/author-articles`, `:realworld/favorited-articles`, and the session feed all carry `:page` in params (mapped to `limit`/`offset` by the one `page->limit-offset` helper). So **page N and page N+1 are DISTINCT cache entries** under the same params-identity rule a `?tag=` filter already used. Every server-visible list option participates in the cache key.
+- **Page state rides the route query.** `?page=N` flows into the route's `:resources` `:params` fn (and, for the session feed, into the `:home/on-match` ensure). Paging is a navigation that swaps only `?page=` and preserves the active feed/tag — no page-cache map, no `:status` field. Page 1 drops the param (the canonical first-page URL).
+- **Back-navigation is a cache-hit.** Returning to a previously-loaded page re-`ensure`s the same params-identity entry — no fetch (`:rf.resource/cache-hit`), as long as it's still within its stale window.
+- **`:keep-previous?` = no flicker.** The route `:resources` entries set `:keep-previous? true`, so while a NEW page key first-loads the public `:rf.resource/state` projection carries `:previous? true` + `:previous-data` (the prior page's articles). The list view renders that prior page (plus a quiet "Loading next page…" indicator) instead of a skeleton — the user never sees a flash of empty list on page change. The projection is **not** inserted into the new key and never provides its tags (Spec 016 §Paginated and previous data); the new entry becomes ordinary `:loaded` only after its own request succeeds.
+
+### The profile's two official tabs — My Articles / Favorited Articles (`routing.cljs` / `views.cljs`)
+
+The official Conduit profile has two tabs, and here they are **two routes**, each declaring its list read as route `:resources`:
+
+- `:realworld.profile/show` → `/profile/:username` → `:realworld/author-articles` (**My Articles**)
+- `:realworld.profile/favorites` → `/profile/:username/favorites` → `:realworld/favorited-articles` (**Favorited Articles**)
+
+The active tab is **just the current route id** — there is no tab state in `app-db`; the view reads `:rf.route/id` to pick which list resource to subscribe to. The tab links are plain `route-link`s. Favoriting / unfavoriting from the Favorited tab fires the same `:realworld/favorite` / `:realworld/unfavorite` mutations, whose `:invalidates` stales `[:article slug]` — a tag the favorited list **carries** for every article it contains — so the list refetches and the article drops out on unfavorite with no extra wiring. (No dedicated `[:favorited-articles username]` invalidation is needed for the toggle; the per-article tag already reaches it.)
 
 ### Scope is the fail-closed leak boundary (`scope.cljs`)
 
@@ -85,16 +104,16 @@ Login / register / session-restore / logout are a Spec 005 state machine issuing
 | File | What it holds |
 |---|---|
 | `core.cljs` | Entry point, app shell, route switch, mount; installs the demo `:rf.http/managed` backend stub + the revalidation listeners + the frame-wide `:realworld/bearer-auth` HTTP interceptor. |
-| `resources.cljs` | Every RealWorld read as `reg-resource` (identity / scope / `:request` / `:tags` / stale + GC policy). |
+| `resources.cljs` | Every RealWorld read as `reg-resource` (identity / scope / `:request` / `:tags` / stale + GC policy); the `page-size` + `page->limit-offset` pagination helpers. |
 | `mutations.cljs` | Every RealWorld write as `reg-mutation` (`:invalidates` / `:populates`). |
 | `scope.cljs` | The fail-closed session cache scope + the `:session/scope` sub the view passes on session-scoped reads. |
-| `routing.cljs` | Routes with `:resources` metadata + the `auth-guard` interceptor; the home `:on-match` ensures the session feed. |
+| `routing.cljs` | Routes with `:resources` metadata (incl. the `?page=` query → resource params + `:keep-previous?`, and the `:realworld.profile/favorites` tab route) + the `auth-guard` interceptor; the home `:on-match` ensures the session feed. |
 | `auth.cljs` | The `:auth/flow` auth machine (login / register / restore-without-navigating / logout-with-clear-scope) + the login/register forms. |
 | `settings.cljs` | The settings page as a mutation instance (`:rf.mutation/state`); the save-success continuation is off the render path (Form-3 settle reaction). |
 | `article_editor.cljs` | Create / edit / delete an article: the `:realworld/save-article` + `:realworld/delete-article` mutations, the `:editor/can-submit?` Spec 013 flow, the `:editor/can-leave?` guard, and the Form-3 settle reactions (seed-on-load + save/delete continuation). |
-| `views.cljs` | Passive pages (home / article / profile) + the small UI event glue (favourite / follow / comment). |
+| `views.cljs` | Passive pages (home / article / profile-with-two-tabs) + the numbered `pagination` control + the keep-previous list render + the small UI event glue (favourite / follow / comment / page navigation). |
 | `schema.cljs` | Malli wire shapes + the small app-db schemas (auth + form drafts only — the reads live in runtime-db). |
-| `http.cljs` | The demo backend stub (resources + mutations lower onto `:rf.http/managed`, so one stub serves the whole API) + the shared `data-fetch-retry` read policy + the `:rf.http/*` failure projection. |
+| `http.cljs` | The demo backend stub (resources + mutations lower onto `:rf.http/managed`, so one stub serves the whole API) — synthesises a multi-page article set + honours `limit`/`offset` + a distinct favorited subset — plus the shared `data-fetch-retry` read policy + the `:rf.http/*` failure projection. |
 | `index.html` | Static host page. |
 
 ## How to run

--- a/examples/reagent/realworld_resources/core.cljs
+++ b/examples/reagent/realworld_resources/core.cljs
@@ -143,7 +143,8 @@
      :realworld.article/show  [views/article-page]
      :realworld.editor/new    [editor/editor-page]
      :realworld.editor/edit   [editor/editor-page]
-     :realworld.profile/show  [views/profile-page]
+     :realworld.profile/show      [views/profile-page]
+     :realworld.profile/favorites [views/profile-page]
      :realworld.user/settings [settings-mount]
      [not-found-page])
    [footer]])

--- a/examples/reagent/realworld_resources/http.cljs
+++ b/examples/reagent/realworld_resources/http.cljs
@@ -102,28 +102,45 @@
    production value."
   20)
 
+;; A SYNTHESISED article set large enough that the official-size pagination
+;; (`page-size` = 10) spans several pages — so the paginated-resource +
+;; keep-previous dogfood is actually demonstrable in the browser. The first
+;; two carry the original stable slugs (referenced by the article-detail /
+;; mutation paths); the rest are generated. `demo-favorited` is a SUBSET so the
+;; profile Favorited-Articles tab differs from My Articles, and unfavoriting
+;; from the tab visibly drops the article on the next refetch.
+(def ^:private demo-article-count 23)
+
+(defn- gen-article [i]
+  (let [stable [{:slug "hello-conduit"
+                 :title "Hello, Conduit"
+                 :description "A short greeting from the realworld-resources stub."
+                 :body "This article is served by the demo :rf.http/managed override that
+                        resources + mutations lower onto."
+                 :tagList ["intro" "demo"]}
+                {:slug "second-article"
+                 :title "Second article"
+                 :description "A second short article."
+                 :body "More canned demo content."
+                 :tagList ["demo"]}]]
+    (merge {:slug           (str "article-" i)
+            :title          (str "Article " i)
+            :description    (str "Synthetic demo article #" i " (pagination set).")
+            :body           (str "Canned demo content for article " i ".")
+            :tagList        (if (even? i) ["demo" "clojure"] ["demo" "re-frame"])
+            :createdAt      "2026-01-01T00:00:00Z"
+            :updatedAt      "2026-01-01T00:00:00Z"
+            :favorited      false
+            :favoritesCount 0
+            :author         {:username "stub-bot" :bio "A friendly stub." :image "" :following false}}
+           (get stable i))))
+
 (def ^:private demo-articles
-  [{:slug "hello-conduit"
-    :title "Hello, Conduit"
-    :description "A short greeting from the realworld-resources stub."
-    :body "This article is served by the demo :rf.http/managed override that
-           resources + mutations lower onto."
-    :tagList ["intro" "demo"]
-    :createdAt "2026-01-01T00:00:00Z"
-    :updatedAt "2026-01-01T00:00:00Z"
-    :favorited false
-    :favoritesCount 0
-    :author {:username "stub-bot" :bio "A friendly stub." :image "" :following false}}
-   {:slug "second-article"
-    :title "Second article"
-    :description "A second short article."
-    :body "More canned demo content."
-    :tagList ["demo"]
-    :createdAt "2026-02-01T00:00:00Z"
-    :updatedAt "2026-02-01T00:00:00Z"
-    :favorited false
-    :favoritesCount 0
-    :author {:username "stub-bot" :bio "A friendly stub." :image "" :following false}}])
+  (mapv gen-article (range demo-article-count)))
+
+(def ^:private demo-favorited
+  "The favorited subset (every third article) — the profile Favorited tab read."
+  (vec (take-nth 3 demo-articles)))
 
 (def ^:private demo-tags ["intro" "demo" "clojure" "re-frame"])
 
@@ -136,6 +153,27 @@
 (defn- demo-article-by-slug [slug]
   (or (some #(when (= slug (:slug %)) %) demo-articles)
       (first demo-articles)))
+
+;; --- pagination ---
+;; The Conduit list endpoints page with `limit` / `offset` query params. The
+;; stub honours them so each page is a genuinely distinct slice of the article
+;; set, and always reports the FULL total in `articlesCount` (the pagination
+;; control derives the page count from it). This is what makes the
+;; paginated-resource identity + keep-previous behaviour real in the browser:
+;; page N and page N+1 return different data under distinct cache keys.
+
+(defn- query-int [u k]
+  (when-let [m (re-find (re-pattern (str "[?&]" k "=([0-9]+)")) u)]
+    (js/parseInt (second m) 10)))
+
+(defn- paged-response
+  "Slice `all` by the `limit` / `offset` in the URL `u` (defaults: whole list),
+   wrapped in the Conduit `{:articles … :articlesCount <full-total>}` envelope."
+  [u all]
+  (let [limit  (or (query-int u "limit") (count all))
+        offset (or (query-int u "offset") 0)]
+    {:articles      (vec (take limit (drop offset all)))
+     :articlesCount (count all)}))
 
 (defn- canned-comment [body]
   (let [id (+ 1000 (rand-int 100000))]
@@ -210,13 +248,19 @@
         {:profile {:username username :bio "" :image "" :following (= method :post)}})
 
       ;; --- resource reads --------------------------------------------------
+      ;; The feed is empty in the demo (no followed authors), but still a
+      ;; well-formed paged Conduit envelope.
       (str/includes? u "/articles/feed")        {:articles [] :articlesCount 0}
       (re-find #"/articles/[^/]+/comments" u)    {:comments []}
       (re-find #"/articles/[^/?]+$" u)           {:article (demo-article-by-slug
                                                             (second (re-find #"/articles/([^/?]+)" u)))}
+      ;; The profile Favorited-Articles tab — a DISTINCT subset so the tab
+      ;; differs from My Articles and unfavoriting visibly drops an item.
+      (re-find #"[?&]favorited=" u)              (paged-response u demo-favorited)
+      ;; All other list reads (global list, tag-filtered, author) page the full
+      ;; set; `limit` / `offset` make each page a genuinely different slice.
       (or (str/ends-with? u "/articles")
-          (str/includes? u "/articles?"))        {:articles demo-articles
-                                                   :articlesCount (count demo-articles)}
+          (str/includes? u "/articles?"))        (paged-response u demo-articles)
       (str/includes? u "/tags")                  {:tags demo-tags}
       (str/includes? u "/profiles/")             {:profile {:username "stub-bot" :bio ""
                                                             :image "" :following false}}

--- a/examples/reagent/realworld_resources/resources.cljs
+++ b/examples/reagent/realworld_resources/resources.cljs
@@ -26,7 +26,8 @@
    STATUS. Resources is a POST-V1 optional artefact and the read-resource
    runtime + mutations have LANDED (EP-0003, final on main 2026-06-11), so all
    of this runs live. The example tree is test-free (rf2-8cevm)."
-  (:require [re-frame.core :as rf]
+  (:require [clojure.string]
+            [re-frame.core :as rf]
             ;; Managed HTTP ships in day8/re-frame2-http — the single built-in
             ;; resource/mutation transport (Spec 016 §Transport). Loading the
             ;; ns registers the `:rf.http/managed` fx the runtime lowers each
@@ -53,6 +54,44 @@
    inactive (Spec 016 §Stale and GC scheduling)."
   (* 5 60 1000))
 
+;; ============================================================================
+;; PAGINATION — every server-visible list parameter lives in `:params`
+;; ============================================================================
+;;
+;; The Conduit list endpoints page with `limit` / `offset`; the UI is
+;; 1-indexed and the page size is fixed (Spec 016 §Paginated and previous
+;; data). The headline this exercises: pagination is DECLARATIVE on resources.
+;; The `:page` is just another `:params` key, so page N and page N+1 are
+;; DISTINCT cache entries (canonical-params identity) — back-navigating to a
+;; previously-loaded page is a cache-hit (no fetch), and `:keep-previous?` on
+;; the route entry keeps the prior page visible while the next first-loads
+;; (no flicker). No `:status` / `:loading?` app-db field, no manual page-cache
+;; map — the framework owns it.
+
+(def page-size
+  "The fixed Conduit list page size (the official client's value). The demo
+   stub synthesises enough articles that several pages exist (see
+   realworld-resources.http)."
+  10)
+
+(defn page->limit-offset
+  "Map a 1-indexed `:page` (nil → page 1) to the Conduit `limit` / `offset`
+   query pair. Pure — a page is just another canonical-params key, so this is
+   the only place page math lives."
+  [page]
+  (let [p (max 1 (or page 1))]
+    {:limit  page-size
+     :offset (* (dec p) page-size)}))
+
+(defn- with-pagination
+  "Append the `limit` / `offset` query pair derived from `:page` to a list URL
+   that already carries (or lacks) a query string. Keeps the resource
+   `:request` fns terse while every page stays a distinct cache key."
+  [url page]
+  (let [{:keys [limit offset]} (page->limit-offset page)
+        sep (if (clojure.string/includes? url "?") "&" "?")]
+    (str url sep "limit=" limit "&offset=" offset)))
+
 ;; Reads retry / writes don't (Spec 014). Each read's `:request` returns the
 ;; shared `rh/data-fetch-retry` policy in its managed-HTTP args; `:retry`
 ;; passes through the resource lowering UNCHANGED (Spec 016 §Transport), so a
@@ -71,18 +110,26 @@
 ;; security-review list.
 
 (rf/reg-resource :realworld/articles
-  {:doc            "The global article list, optionally filtered by `:tag`.
-                    Every server-visible option (the tag) is in params, so a
-                    tag-filtered list and the unfiltered list are DISTINCT
-                    cache entries (Spec 016 §Paginated and previous data)."
-   :params-schema  [:map [:tag {:optional true} [:maybe :string]]]
+  {:doc            "The global article list, optionally filtered by `:tag` and
+                    paginated by `:page` (1-indexed). EVERY server-visible
+                    option (the tag AND the page) is in params, so a
+                    tag-filtered list, the unfiltered list, and each page are
+                    DISTINCT cache entries (Spec 016 §Paginated and previous
+                    data). Back-navigating to a previously-loaded page is a
+                    cache-hit; the route's `:keep-previous?` keeps the prior
+                    page visible while the next first-loads."
+   :params-schema  [:map
+                    [:tag  {:optional true} [:maybe :string]]
+                    [:page {:optional true} [:maybe :int]]]
    :data-schema    schema/ArticlesResponse
    :scope          :rf.scope/global
-   :request        (fn [{:keys [tag]} _ctx]
+   :request        (fn [{:keys [tag page]} _ctx]
                      {:request {:method :get
-                                :url    (rh/full-url (if tag
-                                                       (str "/articles?tag=" tag)
-                                                       "/articles"))}
+                                :url    (-> (if tag
+                                              (str "/articles?tag=" tag)
+                                              "/articles")
+                                            rh/full-url
+                                            (with-pagination page))}
                       :decode  schema/ArticlesResponse
                       :retry   rh/data-fetch-retry})
    :stale-after-ms stale-after-ms
@@ -138,18 +185,51 @@
    :tags           (fn [{:keys [username]} _data] #{[:profile username]})})
 
 (rf/reg-resource :realworld/author-articles
-  {:doc            "Articles authored by a profile (public)."
-   :params-schema  [:map [:username :string]]
+  {:doc            "Articles authored by a profile (public). Paginated by
+                    `:page` — each page is a distinct cache entry."
+   :params-schema  [:map
+                    [:username :string]
+                    [:page {:optional true} [:maybe :int]]]
    :data-schema    schema/ArticlesResponse
    :scope          :rf.scope/global
-   :request        (fn [{:keys [username]} _ctx]
-                     {:request {:method :get :url (rh/full-url (str "/articles?author=" username))}
+   :request        (fn [{:keys [username page]} _ctx]
+                     {:request {:method :get
+                                :url    (-> (str "/articles?author=" username)
+                                            rh/full-url
+                                            (with-pagination page))}
                       :decode  schema/ArticlesResponse
                       :retry   rh/data-fetch-retry})
    :stale-after-ms stale-after-ms
    :gc-after-ms    gc-after-ms
    :tags           (fn [{:keys [username]} data]
                      (into #{[:author-articles username]}
+                           (map (fn [a] [:article (:slug a)]) (:articles data))))})
+
+(rf/reg-resource :realworld/favorited-articles
+  {:doc            "Articles a profile has FAVORITED (public). GET
+                    `/articles?favorited=:username` — the backing read for the
+                    profile's Favorited-Articles tab. Paginated by `:page`.
+                    Tags both its own list identity AND every article it
+                    contains, so the existing favorite / unfavorite mutations
+                    (which stale `[:article slug]`) refetch this list with no
+                    extra wiring — favoriting from the tab drops the article
+                    out of it on the next refetch."
+   :params-schema  [:map
+                    [:username :string]
+                    [:page {:optional true} [:maybe :int]]]
+   :data-schema    schema/ArticlesResponse
+   :scope          :rf.scope/global
+   :request        (fn [{:keys [username page]} _ctx]
+                     {:request {:method :get
+                                :url    (-> (str "/articles?favorited=" username)
+                                            rh/full-url
+                                            (with-pagination page))}
+                      :decode  schema/ArticlesResponse
+                      :retry   rh/data-fetch-retry})
+   :stale-after-ms stale-after-ms
+   :gc-after-ms    gc-after-ms
+   :tags           (fn [{:keys [username]} data]
+                     (into #{[:favorited-articles username]}
                            (map (fn [a] [:article (:slug a)]) (:articles data))))})
 
 (rf/reg-resource :realworld/tags
@@ -181,12 +261,16 @@
 (rf/reg-resource :realworld/feed
   {:doc            "The authenticated user's feed (`/articles/feed`). Session-
                     scoped: a logged-out user must never see a prior user's
-                    feed from cache."
-   :params-schema  [:map]
+                    feed from cache. Paginated by `:page` — the page rides the
+                    params on top of the session scope, so each (scope, page)
+                    is a distinct cache entry."
+   :params-schema  [:map [:page {:optional true} [:maybe :int]]]
    :data-schema    schema/ArticlesResponse
    :scope          :rf.scope/from-caller
-   :request        (fn [_params _ctx]
-                     {:request {:method :get :url (rh/full-url "/articles/feed")}
+   :request        (fn [{:keys [page]} _ctx]
+                     {:request {:method :get
+                                :url    (-> (rh/full-url "/articles/feed")
+                                            (with-pagination page))}
                       :decode  schema/ArticlesResponse
                       :retry   rh/data-fetch-retry})
    :stale-after-ms stale-after-ms

--- a/examples/reagent/realworld_resources/routing.cljs
+++ b/examples/reagent/realworld_resources/routing.cljs
@@ -51,21 +51,30 @@
 
 (rf/reg-route :realworld/home
   {:doc   "Home: the global article list + popular tags, plus (when signed in)
-           the personalised feed. The `:tag` query param filters the list — it
-           flows into the resource's params, so a tag-filtered list is a
-           distinct cache entry."
+           the personalised feed. The `:tag` query param filters the list and
+           `:page` paginates it — BOTH flow into the resource's params, so a
+           tag-filtered list and each page are distinct cache entries.
+           `:keep-previous?` keeps the prior page/filter visible while the next
+           first-loads (no flicker); back to a previously-loaded page is a
+           cache-hit."
    :path  "/"
    :query [:map
            [:tag  {:optional true} :string]
-           [:feed {:optional true} :string]]
+           [:feed {:optional true} :string]
+           [:page {:optional true} :int]]
    :scroll   :top
-   ;; The session-scoped feed is ensured from `:on-match` (it needs `:db`); the
-   ;; public reads are declarative route resources.
+   ;; The session-scoped feed is ensured from `:on-match` (it needs `:db` —
+   ;; including the page, since the page rides the params, not the route plan
+   ;; for a session-scoped read); the public reads are declarative route
+   ;; resources.
    :on-match [[:home/on-match]]
    :resources
    [{:resource  :realworld/articles
-     ;; Route query → resource params: the `?tag=` flows into identity.
-     :params    (fn [route] {:tag (get-in route [:query :tag])})
+     ;; Route query → resource params: the `?tag=` AND `?page=` flow into
+     ;; identity. Every server-visible list option participates in the cache
+     ;; key (Spec 016 §Paginated and previous data).
+     :params    (fn [route] {:tag  (get-in route [:query :tag])
+                             :page (get-in route [:query :page])})
      :blocking? true
      :keep-previous? true}
     {:resource  :realworld/tags
@@ -121,15 +130,39 @@
      :keep-previous? true}]})
 
 (rf/reg-route :realworld.profile/show
-  {:doc    "A user's profile banner + the articles they authored."
+  {:doc    "A user's profile banner + the articles they AUTHORED (the default
+            profile tab). The `?page=` query paginates the authored list."
    :path   "/profile/:username"
    :params [:map [:username :string]]
+   :query  [:map [:page {:optional true} :int]]
    :resources
    [{:resource  :realworld/profile
      :params    (fn [route] {:username (get-in route [:params :username])})
      :blocking? true}
     {:resource  :realworld/author-articles
+     :params    (fn [route] {:username (get-in route [:params :username])
+                             :page     (get-in route [:query :page])})
+     :blocking? false
+     :keep-previous? true}]})
+
+(rf/reg-route :realworld.profile/favorites
+  {:doc    "A user's profile banner + the articles they FAVORITED (the second
+            official profile tab — `/profile/:username/favorites`). Same banner
+            read as `:realworld.profile/show`; the list read is the
+            `:realworld/favorited-articles` resource. The `?page=` query
+            paginates it. Favoriting / unfavoriting from this tab invalidates
+            `[:article slug]`, which this list carries, so it refetches and the
+            article drops out on unfavorite (Spec 016 §Mutations)."
+   :path   "/profile/:username/favorites"
+   :params [:map [:username :string]]
+   :query  [:map [:page {:optional true} :int]]
+   :resources
+   [{:resource  :realworld/profile
      :params    (fn [route] {:username (get-in route [:params :username])})
+     :blocking? true}
+    {:resource  :realworld/favorited-articles
+     :params    (fn [route] {:username (get-in route [:params :username])
+                             :page     (get-in route [:query :page])})
      :blocking? false
      :keep-previous? true}]})
 

--- a/examples/reagent/realworld_resources/views.cljs
+++ b/examples/reagent/realworld_resources/views.cljs
@@ -24,7 +24,8 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.resources]
-            [realworld-resources.http :as rh])
+            [realworld-resources.http :as rh]
+            [realworld-resources.resources :as resources])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -46,17 +47,26 @@
 (rf/reg-event-fx :home/on-match
   {:doc "Home route entry: ensure the authenticated user's feed (session-
          scoped) under a releaseable lease. A no-op for a logged-out visitor —
-         no scope, no fetch (the feed never leaks across users)."}
-  (fn [{:keys [db]} _]
+         no scope, no fetch (the feed never leaks across users). The `?page=`
+         flows into the feed's `:params` (it rides the params, not the route
+         plan, for a session-scoped read), so each page is a distinct (scope,
+         page) cache entry just like the public lists."}
+  (fn [{:keys [db] rt :rf.db/runtime} _]
     (if-let [user (get-in db [:auth :user])]
-      (let [scope    [:rf.scope/session {:username (:username user)}]]
+      (let [scope [:rf.scope/session {:username (:username user)}]
+            page  (get-in rt [:rf.runtime/routing :current :query :page])]
         {:fx [[:dispatch [:rf.resource/ensure
                           {:resource :realworld/feed
                            :scope    scope
-                           :params   {}
+                           :params   {:page page}
                            :owner    [:lease :realworld/your-feed (:username user)]
                            :cause    [:route-entry :realworld/home]}]]]})
       {})))
+
+;; Switching feed / tab / tag RESETS pagination to page 1 (a new filter is a
+;; fresh list); paging KEEPS the current feed + tag and only changes `?page=`.
+;; The page lives in the route query, so it flows straight into the resource
+;; params — no page-cache map, no `:status` field.
 
 (rf/reg-event-fx :home/show-global-feed
   (fn [_ _] {:fx [[:dispatch [:rf.route/navigate :realworld/home {} {:query {}}]]]}))
@@ -70,9 +80,23 @@
 (rf/reg-event-fx :home/clear-tag
   (fn [_ _] {:fx [[:dispatch [:rf.route/navigate :realworld/home {} {:query {}}]]]}))
 
+;; Page navigation preserves the active feed + tag (read off the live route
+;; query) and swaps only `?page=` — so page N and N+1 share filter but are
+;; distinct cache keys. Page 1 drops the param entirely (the canonical
+;; first-page URL).
+(rf/reg-event-fx :home/go-to-page
+  (fn [{rt :rf.db/runtime} [_ page]]
+    (let [{:keys [tag feed]} (get-in rt [:rf.runtime/routing :current :query])
+          query (cond-> {}
+                  tag         (assoc :tag tag)
+                  feed        (assoc :feed feed)
+                  (> page 1)  (assoc :page page))]
+      {:fx [[:dispatch [:rf.route/navigate :realworld/home {} {:query query}]]]})))
+
 (rf/reg-sub :home/query :<- [:rf.route/query] (fn [q _] (or q {})))
 (rf/reg-sub :home/selected-tag :<- [:home/query] (fn [q _] (:tag q)))
 (rf/reg-sub :home/your-feed?   :<- [:home/query] (fn [q _] (= "your" (:feed q))))
+(rf/reg-sub :home/page         :<- [:home/query] (fn [q _] (or (:page q) 1)))
 
 ;; ============================================================================
 ;; FAVORITE / FOLLOW — fire a mutation, watch its instance
@@ -162,24 +186,73 @@
       [:span "Read more..."]
       (into [:ul.tag-list] (for [tag tagList] ^{:key tag} [:li.tag-default.tag-pill.tag-outline tag]))]]))
 
+;; ----------------------------------------------------------------------------
+;; PAGINATION CONTROL — official Conduit shape (numbered 1-indexed pages)
+;; ----------------------------------------------------------------------------
+;;
+;; Page count is derived from the server's `articlesCount` and the fixed
+;; `page-size` — the view never tracks "how many pages" in app-db; it's a pure
+;; function of the loaded data. Each page link is a navigation that swaps only
+;; `?page=`, so paging is declarative: the route plan re-ensures the list under
+;; the new page key (a distinct cache entry).
+
+(reg-view ^{:doc "Official-style numbered pagination. `:articles-count` is the
+                  server total (from the resource's `articlesCount`);
+                  `:current-page` is 1-indexed; `:on-page` is called with a page
+                  number to navigate. Renders nothing for a single page."}
+          pagination [{:keys [articles-count current-page on-page]}]
+  (let [total-pages (max 1 (js/Math.ceil (/ (or articles-count 0) resources/page-size)))]
+    (when (> total-pages 1)
+      (into [:nav [:ul.pagination {:data-testid "pagination"}]]
+            (for [p (range 1 (inc total-pages))]
+              ^{:key p}
+              [:li.page-item {:class (when (= p current-page) "active")}
+               [:a.page-link {:href "#" :data-testid (str "page-" p)
+                              :on-click #(do (.preventDefault %) (on-page p))}
+                p]])))))
+
 (reg-view ^{:doc "Render a list-resource state: skeleton / error / list, with a
-                  background-refresh indicator + warning."}
-          article-list [{:keys [state empty-msg]}]
+                  background-refresh indicator + warning, the keep-previous
+                  placeholder, and (when `:articles-count` + `:on-page` are
+                  given) numbered pagination.
+
+                  `:keep-previous?` projection: while a NEW page/filter key
+                  first-loads, the resource state carries `:previous? true` +
+                  `:previous-data` (the prior key's articles). We render those
+                  PLUS a placeholder indicator so the user sees the old page,
+                  not a skeleton, until the new page settles — no flicker
+                  (Spec 016 §Paginated and previous data)."}
+          article-list [{:keys [state empty-msg current-page on-page]}]
   (cond
-    (:loading? state) [:div.article-preview {:data-testid "list-skeleton"} "Loading articles…"]
-    (and (:error state) (not (:has-data? state)))
+    ;; First-ever load with no usable data AND no previous page to show.
+    (and (:loading? state) (not (:previous? state)))
+    [:div.article-preview {:data-testid "list-skeleton"} "Loading articles…"]
+
+    (and (:error state) (not (:has-data? state)) (not (:previous? state)))
     [:div.article-preview.error {:data-testid "list-error"}
      (str "Couldn't load articles: " (rh/failure->message (:error state)))]
+
     :else
-    (let [articles (:articles (:data state))]
+    ;; Prefer this key's own data; fall back to the kept-previous projection
+    ;; while the new page first-loads (no skeleton flash on page change).
+    (let [data           (or (:data state) (:previous-data state))
+          articles       (:articles data)
+          articles-count (:articlesCount data)]
       [:<>
+       (when (:previous? state)
+         [:div.refresh-indicator {:data-testid "list-keeping-previous"}
+          "Loading next page…"])
        (when (:fetching? state) [:div.refresh-indicator {:data-testid "list-refreshing"} "Refreshing…"])
        (when (:refresh-error state)
          [:div.refresh-warn {:data-testid "list-refresh-warn"} "Refresh failed; showing last-known data."])
        (if (seq articles)
          (into [:div {:data-testid "article-list"}]
                (for [a articles] ^{:key (:slug a)} [article-preview {:article a}]))
-         [:div.article-preview {:data-testid "list-empty"} (or empty-msg "No articles are here… yet.")])])))
+         [:div.article-preview {:data-testid "list-empty"} (or empty-msg "No articles are here… yet.")])
+       (when (and on-page articles-count)
+         [pagination {:articles-count articles-count
+                      :current-page   (or current-page 1)
+                      :on-page        on-page}])])))
 
 ;; ============================================================================
 ;; HOME PAGE
@@ -189,17 +262,21 @@
   (let [authed?      @(subscribe [:auth/authenticated?])
         your-feed?   @(subscribe [:home/your-feed?])
         selected-tag @(subscribe [:home/selected-tag])
+        page         @(subscribe [:home/page])
         session-scope @(subscribe [:session/scope])
         tags-state   @(subscribe [:rf.resource/state {:resource :realworld/tags :params {}}])
-        ;; The global list is keyed by the active `:tag` (nil when unfiltered).
+        ;; The global list is keyed by the active `:tag` AND `:page` — the SAME
+        ;; params the route ensured under, so the sub reads the right cache key
+        ;; (Spec 016 §Paginated and previous data).
         list-state   @(subscribe [:rf.resource/state {:resource :realworld/articles
-                                                       :params  {:tag selected-tag}}])
-        ;; The personalised feed reads under the SAME session scope the route
-        ;; ensured it under — passed explicitly so it isn't a silent
+                                                       :params  {:tag selected-tag :page page}}])
+        ;; The personalised feed reads under the SAME session scope AND page the
+        ;; route ensured it under — passed explicitly so it isn't a silent
         ;; cross-scope `:idle` (Spec 016 §Subscription-side scope resolution).
         feed-state   (when (and authed? session-scope)
                        @(subscribe [:rf.resource/state {:resource :realworld/feed
-                                                        :scope   session-scope :params {}}]))]
+                                                        :scope   session-scope
+                                                        :params  {:page page}}]))]
     [:div.home-page
      [:div.banner [:div.container [:h1.logo-font "conduit"] [:p "A place to share your knowledge."]]]
      [:div.container.page
@@ -224,8 +301,10 @@
                                   :on-click #(do (.preventDefault %) (dispatch [:home/clear-tag]))}
               [:i.ion-pound] " " selected-tag]])]]
         (if (and authed? your-feed?)
-          [article-list {:state feed-state :empty-msg "Your feed is empty — follow some authors."}]
-          [article-list {:state list-state}])]
+          [article-list {:state feed-state :empty-msg "Your feed is empty — follow some authors."
+                         :current-page page :on-page #(dispatch [:home/go-to-page %])}]
+          [article-list {:state list-state
+                         :current-page page :on-page #(dispatch [:home/go-to-page %])}])]
        [:div.col-md-3
         [:div.sidebar
          [:p "Popular Tags"]
@@ -327,14 +406,42 @@
      [:p [rf/route-link {:to :realworld/home :data-testid "back-home"} "← Back to feed"]]]))
 
 ;; ============================================================================
-;; PROFILE
+;; PROFILE  —  two official tabs: My Articles / Favorited Articles
 ;; ============================================================================
+;;
+;; The two tabs are two ROUTES (`:realworld.profile/show` for authored,
+;; `:realworld.profile/favorites` for favorited), each declaring its list read
+;; as route `:resources`. The active tab is just the current route id — no tab
+;; state in app-db. The view reads the route id to pick which list resource to
+;; subscribe to, and the page off the route query.
+
+(rf/reg-sub :profile/favorites-tab? :<- [:rf.route/id]
+  (fn [id _] (= id :realworld.profile/favorites)))
+(rf/reg-sub :profile/page :<- [:rf.route/query]
+  (fn [q _] (or (:page q) 1)))
+
+;; Page navigation on a profile tab preserves the current route + username and
+;; swaps only `?page=`. Page 1 drops the param (the canonical first-page URL).
+(rf/reg-event-fx :profile/go-to-page
+  (fn [{rt :rf.db/runtime} [_ page]]
+    (let [{:keys [current]} (get rt :rf.runtime/routing)
+          {:keys [id params]} current
+          query (cond-> {} (> page 1) (assoc :page page))]
+      {:fx [[:dispatch [:rf.route/navigate id params {:query query}]]]})))
 
 (reg-view profile-page []
   (let [username       (:username @(subscribe [:rf.route/params]))
+        favorites?     @(subscribe [:profile/favorites-tab?])
+        page           @(subscribe [:profile/page])
         current-user   @(subscribe [:auth/user])
         profile-state  @(subscribe [:rf.resource/state {:resource :realworld/profile :params {:username username}}])
-        articles-state @(subscribe [:rf.resource/state {:resource :realworld/author-articles :params {:username username}}])]
+        ;; The active tab picks which list resource (+ params) to read — the
+        ;; SAME (resource, params) the matching route ensured under.
+        list-state     (if favorites?
+                         @(subscribe [:rf.resource/state {:resource :realworld/favorited-articles
+                                                          :params  {:username username :page page}}])
+                         @(subscribe [:rf.resource/state {:resource :realworld/author-articles
+                                                          :params  {:username username :page page}}]))]
     [:div.profile-page
      (cond
        (:loading? profile-state)
@@ -365,4 +472,23 @@
           [:div.container
            [:div.row
             [:div.col-xs-12.col-md-10.offset-md-1
-             [article-list {:state articles-state :empty-msg "No articles here yet."}]]]]]))]))
+             ;; The two official profile tabs — each a route-link, the active
+             ;; one chosen by the current route id (no app-db tab state).
+             [:div.articles-toggle
+              [:ul.nav.nav-pills.outline-active
+               [:li.nav-item
+                [rf/route-link {:to :realworld.profile/show :params {:username username}
+                                :class (str "nav-link" (when-not favorites? " active"))
+                                :data-testid "profile-tab-authored"}
+                 "My Articles"]]
+               [:li.nav-item
+                [rf/route-link {:to :realworld.profile/favorites :params {:username username}
+                                :class (str "nav-link" (when favorites? " active"))
+                                :data-testid "profile-tab-favorited"}
+                 "Favorited Articles"]]]]
+             [article-list {:state list-state
+                            :empty-msg (if favorites?
+                                         "No favorited articles are here… yet."
+                                         "No articles here yet.")
+                            :current-page page
+                            :on-page #(dispatch [:profile/go-to-page %])}]]]]]))]))


### PR DESCRIPTION
Two feature beads for the `examples/reagent/realworld_resources/` EP-0003 resources+mutations RealWorld variant, resolved in one PR (they share `resources.cljs` / `routing.cljs` / `views.cljs`). Part of making the pair RealWorld-spec-conformant (match the official Conduit shapes).

## rf2-2xpmxe — profile Favorited-Articles tab + route + resource

- New `:realworld/favorited-articles` `reg-resource` — `GET /articles?favorited=:username`, `:rf.scope/global`, stale/GC policy like its siblings, tags `[:favorited-articles username]` (list) + per-contained-article `[:article slug]`.
- New `:realworld.profile/favorites` route (`/profile/:username/favorites`) with `:resources` metadata, wired into the `core.cljs` route switch.
- `profile-page` now renders both official tabs (My Articles / Favorited Articles). The active tab is **just the current route id** (`:rf.route/id`) — no tab state in `app-db`; tabs are plain `route-link`s.
- **Favorite/unfavorite invalidation reaches the list with no extra wiring**: the existing mutations stale `[:article slug]`, a tag the favorited list carries for every article — so the tab refetches and an unfavorited article drops out on the next refetch.
- Demo stub returns a distinct favorited subset so the tab differs from My Articles.

## rf2-zbadu9 — paginated article-list resources (params identity + keep-previous dogfood)

- `:page` added to canonical params of `:realworld/articles`, `:realworld/author-articles`, `:realworld/favorited-articles`, and the session feed (`page->limit-offset` helper, fixed Conduit `page-size` 10, 1-indexed). **Every page is a distinct cache entry**; back-navigation to a loaded page is a cache-hit.
- Route `:resources` set `:keep-previous? true`; `?page=` flows route query → resource params (and into `:home/on-match` for the session feed). Page nav preserves the active feed/tag.
- Numbered pagination control (official Conduit shape) derived from `articlesCount` + `page-size`.
- `article-list` renders the `:previous?` / `:previous-data` keep-previous projection — the prior page stays visible (with a quiet "Loading next page…" indicator) while the new page first-loads, **no skeleton flash**. The projection never pollutes the new key's cache/tags (Spec 016 §Paginated and previous data).
- Demo stub synthesises a multi-page article set (23 articles) and honours `limit`/`offset`, reporting the full total in `articlesCount`.

This is the resources-native counterpart to the managed-HTTP pagination landing in the `realworld/` sibling (#3836), and the missing Spec 016 dogfood for canonical-params identity + `:keep-previous?` — needing **no new spec surface**.

Examples stay test-free (no `*.spec.cjs`). README + Files table updated.

## Quality gates

- `shadow-cljs compile :examples/realworld-resources` — **Build completed, 0 warnings**.
- `shadow-cljs release :examples/realworld-resources` — **Build completed, 0 warnings** (the lone Closure `@extras` JSDoc parse note is from the pre-existing, untouched `implementation/http/src/re_frame/http_privacy_headers.cljc` and not in this PR's surface).
- `npm run test:script-policy` — **all passed** (12 sub-suites incl. `check-examples-assets`, `_examples-filter`, `_examples-staging`, `check-examples-compile`; layout↔disk bijection + no-`*.spec.cjs` hold).
- `scripts/test-fast-pr.sh` — **PASS** (6420 tests, 23187 assertions, 0 failures, 0 errors).

Closes rf2-2xpmxe, rf2-zbadu9.
