### PR TITLE
docs(testbeds): flip epoch slot names to :db-before/:db-after (rf2-rofkmo)

### DIFF
--- a/testbeds/large_dispatcher/README.md
+++ b/testbeds/large_dispatcher/README.md
@@ -94,7 +94,7 @@ needs:
 - **`:large?` value arrives as `:rf.size/large-elided` marker** —
   the load-bearing scenario this surface unblocks. Xray's trace
   panel must show the `[:declared-large-value]` slot replaced with
-  the marker shape under `:tags :app-db-after` on the first emit
+  the marker shape under `:tags :db-after` on the first emit
   after button B.
 - `:rf.warning/large-value-unschema'd` highlighted in trace stream —
   button A's first emit fires the advisory; subsequent button-A

--- a/testbeds/non_trivial_app_db/README.md
+++ b/testbeds/non_trivial_app_db/README.md
@@ -85,8 +85,8 @@ leaves is the smallest count that exercises:
 
 **Xray (26)**:
 - Trace panel populates on first dispatch — each button produces a
-  visible `:event/db-changed` trace with `:tags :app-db-before` and
-  `:tags :app-db-after` carrying the 55-leaf shape.
+  visible `:event/db-changed` trace with `:tags :db-before` and
+  `:tags :db-after` carrying the 55-leaf shape.
 - Time-travel scrub forward/back mutates visible UI — scrubbing 6
   clicks back-and-forth exercises the diff renderer at every depth.
 - `:event/db-changed` trace event for app-db changes — the surface
@@ -121,6 +121,6 @@ lands in `implementation/out/testbeds/non-trivial-app-db/`.
 
 ## Cross-references
 
-- [`spec/009-Instrumentation.md` §Trace event for app-db changes](../../spec/009-Instrumentation.md) — the `:event/db-changed` shape this surface's clicks emit, with `:tags :app-db-before` / `:tags :app-db-after` consumers diff against.
+- [`spec/009-Instrumentation.md` §Trace event for app-db changes](../../spec/009-Instrumentation.md) — the `:event/db-changed` shape this surface's clicks emit, with `:tags :db-before` / `:tags :db-after` consumers diff against.
 - [`spec/Spec-Schemas.md` §`:rf/epoch-record`](../../spec/Spec-Schemas.md) — the epoch record's `:db-before` / `:db-after` slots carrying the 55-leaf shape per cascade.
 - [`spec/Tool-Pair.md` §Time-travel](../../spec/Tool-Pair.md) — the re-frame2-pair-mcp time-travel contract a diff visualisation rides.


### PR DESCRIPTION
@
Tiny residue closure from the cg7llv epoch-slot re-rule (#3840, merged). cg7llv blessed `:db-before`/`:db-after` as the canonical epoch app-db-projection slot names (EP-0001 Decision 2 amended). Two testbed READMEs still carried the old `:app-db-before`/`:app-db-after` names — flipped for one-name-per-fact (EP-0007) closure.

## Changes
- `testbeds/non_trivial_app_db/README.md` — Xray-26 `:event/db-changed` trace tags (L88-89) + Cross-references entry (L124)
- `testbeds/large_dispatcher/README.md` — large-elided marker trace tag (L97)

Pure prose rename. Grep-confirmed: no `:app-db-before`/`:app-db-after` remain anywhere in `testbeds/`; the only surviving occurrences repo-wide are the EP-0001 Decision-2 historical note (intentionally excluded) and `.beads/issues.jsonl` (tracker).

## Quality gates
- `mkdocs build --strict` — **N/A**. `mkdocs.yml` sets `docs_dir: docs`; testbed READMEs are not referenced in nav and live outside the docs build tree.
- `python scripts/check_doc_slugs.py --verbose` — PASS (427 files scanned, no broken links).
- `scripts/test-fast-pr.sh` — README-inventory ratchet, doc-slug, link, and title-safety gates PASS. The CLJS node-integration step did not run (`shadow-cljs` not installed in the fresh worktree — `npm install` not run); orthogonal to a prose-only README rename.
@