### PR TITLE
feat(examples): realworld pair — feed-invalidation + contract shapes + social controls + markdown + API base

### DIFF
--- a/examples/reagent/realworld/README.md
+++ b/examples/reagent/realworld/README.md
@@ -39,6 +39,7 @@ The normative contract lives in [`spec/014-HTTPRequests.md`](../../../spec/014-H
 - **Routing** — route table, path params, query params, auth gating via the `auth-guard` interceptor (`routing.cljs`, wired into the demo frame's `:interceptors` in `core.cljs` — `:requires-auth`-tagged routes redirect unauthenticated users to login per Spec 012 §Redirects and guards), route-driven loads, and navigation blocking for the editor.
 - **Pagination** — every article list (the home global feed, the tag feed, the authenticated "Your Feed", and the profile authored / favorited lists) paginates with the official RealWorld `limit` / `offset` query params and consumes the response's grand `articlesCount` to size a 1-indexed page-number control. The page rides the **route query** (`?page=N`) so back/forward and bookmarking restore it; `:int` coercion turns the URL's `"2"` into `2` and `:query-defaults {:page 1}` fills page 1 when absent (`routing.cljs`). The page-number control renders the canonical Conduit `.pagination` / `.page-item.active` / `.page-link` markup (the shared `articles/pagination` view, reused by the home page and the profile pages). The 1-indexed page → 0-based `offset` math and the `(ceil articlesCount / page-size)` page count live in `http.cljs` (`page-size`, `page->offset`, `page-count`, `paginate-path`). Switching feed or tag resets to page 1 (a fresh query drops `?page=`); a page click re-fires the route `:on-match` with the new window (Spec 012 — same route, changed query). The demo stub (`core.cljs`) serves a 25-article corpus sliced by the request's `limit` / `offset` so all three pages are exercisable offline.
 - **Optimistic updates** — favorite toggle, comment delete, and follow/unfollow all show rollback-friendly event shapes against the managed-HTTP failure path.
+- **Article-detail contextual controls** — per the official Conduit article-page template, the detail page (`comments.cljs`) renders the author byline plus, for a non-author viewer, Follow/Unfollow the author (`:article/toggle-follow-author`, optimistic + rollback against the article's embedded `:author`), or, for the author, Edit Article (→ `/editor/:slug`) + Delete Article (`:article/delete`, navigate home on success). Logged-out viewers see the byline only. The editor's own Delete (`article_editor.cljs`) remains reachable too.
 - **Schemas** — wire payloads and app-db slices are attached with `reg-app-schemas` (the bulk plural form) — one `{path -> schema}` map registers all 22 slices in `schema.cljs`.
 - **SSR boundary** — the app-specific hydration payload helper lives alongside the generic SSR worked example in `examples/reagent/ssr/`.
 
@@ -53,7 +54,7 @@ The normative contract lives in [`spec/014-HTTPRequests.md`](../../../spec/014-H
 | `auth.cljs` | implemented | Auth machine plus login/register forms (managed-HTTP). |
 | `articles.cljs` | implemented | Home page, global feed, tag filter UI; managed-HTTP with retry + abort. Home page uses Pattern-NineStates — a `:realworld/articles-home` parallel machine with three regions (`:feed` × `:filter` × `:data`) + a render-priority table; the root view is a `case` over `:articles.home/render`. Popular-tags loading moved to `tags.cljs`. Hosts the shared `pagination` view (`.pagination` / `.page-item` / `.page-link`) reused by the profile pages, and the home pagination subs. |
 | `favorites.cljs` | implemented | Favorite toggle and followed-authors feed; optimistic updates with managed-HTTP rollback. The authenticated feed paginates via `?page=` like the global feed. |
-| `comments.cljs` | implemented | Article detail page, comments list, comment form, optimistic delete. **`:article/load` uses default reply addressing.** |
+| `comments.cljs` | implemented | Article detail page, comments list, comment form, optimistic delete, plus the article-detail contextual controls (author Follow/Unfollow for non-author viewers; Edit / Delete for the author — rf2-2xi8sr). **`:article/load` uses default reply addressing.** |
 | `article_editor.cljs` | implemented | New/edit/delete article plus unsaved-change guard. Hosts the `:editor/can-submit?` **flow** (Spec 013) — a materialised valid-AND-dirty boolean read by the submit handler and the submit button. |
 | `profile.cljs` | implemented | Profile banner, authored/favorited tabs, follow/unfollow. Uses Pattern-NineStates — a `:ui/profile` parallel machine with two regions (`:tab` × `:data`) + a render-priority table; the root view is a `case` over `:profile/render`. Each tab's article list paginates via `?page=` (reusing `articles/pagination`). |
 | `settings.cljs` | implemented | User settings form and logout affordance. Form lifecycle as the **`:form-region` machine** variant of Pattern-Forms — `:settings/form` is a single-region state machine whose state-keyword IS the Pattern-Forms lifecycle. |
@@ -80,14 +81,22 @@ The example's behaviour is verified by its CLJS test fixtures (see
 npm run test:cljs
 ```
 
-In production point `realworld.http/api-base` at <https://api.realworld.io/api>; for local development, the upstream spec ships a Node/Postgres reference backend that listens on `http://localhost:3000/api`. The demo entry installs an in-process `:rf.http/managed` override (`:realworld.demo/http-stub`) that synthesises canned responses for the common reads (global feed, tags, profile) — Spec 014 §Testing — so the fixtures run without a network.
-
 To view the app in a browser, build it under shadow-cljs id `examples/realworld` from `implementation/`:
 
 ```bash
 shadow-cljs watch examples/realworld
 # then open the example's index.html (served however you prefer).
 ```
+
+### Running against a real backend
+
+The app supports three backend modes; the default needs no network.
+
+1. **Canned demo stub (default).** The demo entry (`core.cljs`) installs an in-process `:rf.http/managed` override (`:realworld.demo/http-stub`) that synthesises canned Conduit-shaped responses (a 25-article corpus sliced by `limit`/`offset`, tags, profile, auth) — Spec 014 §Testing. `api-base` is **not contacted** in this mode; the stub matches on the URL path suffix. This is what the browser build and the CLJS fixtures use, so everything runs offline.
+
+2. **Official hosted API.** Point `realworld.http/api-base` at the current official hosted API — <https://api.realworld.show/api> (the old `api.realworld.io` host is stale) — and remove the `:fx-overrides {:rf.http/managed :realworld.demo/http-stub}` line from the demo frame in `core.cljs`. The Bearer token is injected by the frame-wide `:realworld/bearer-auth` HTTP interceptor (`core.cljs`), so authenticated calls (feed, favourite, follow, comment, settings, save) carry the header automatically.
+
+3. **Local reference backend.** The upstream spec ships a Node/Postgres reference backend that listens on `http://localhost:3000/api`; set `api-base` to that and drop the stub override as in mode 2.
 
 ## Headless tests
 

--- a/examples/reagent/realworld/comments.cljs
+++ b/examples/reagent/realworld/comments.cljs
@@ -258,6 +258,74 @@
       db)))
 
 ;; ============================================================================
+;; ARTICLE-DETAIL SOCIAL CONTROLS  (rf2-2xi8sr)
+;; ============================================================================
+;;
+;; The official Conduit article page puts contextual controls ON THE DETAIL
+;; PAGE: a non-author viewer can follow/unfollow the AUTHOR; the author sees
+;; Edit Article (→ /editor/:slug) and Delete Article. Logged-out viewers see
+;; neither (the controls are auth-gated like the favorite toggle). The follow
+;; here targets the article's OWN author profile (`[:article :data :author]`),
+;; distinct from profile.cljs's `:profile/follow` which targets the profile-page
+;; banner slice.
+
+(rf/reg-event-fx :article/toggle-follow-author
+  {:doc "Optimistically toggle following the article's author, then POST/DELETE
+         /profiles/:username/follow. On failure the prior flag is restored.
+         Auth-gated (same rationale as :article/toggle-favorite): a logged-out
+         click navigates to login rather than issuing a tokenless write the real
+         Conduit backend would 401."
+   :rf.http/decode-schemas [schema/ProfileResponse]}
+  (fn [{:keys [db]} _]
+    (if (nil? (get-in db [:auth :user]))
+      {:fx [[:dispatch [:rf.route/navigate :realworld.auth/login]]]}
+      (let [author    (get-in db [:article :data :author])
+            username  (:username author)
+            following? (:following author)]
+        (if (nil? username)
+          {}
+          {:db (assoc-in db [:article :data :author :following] (not following?))
+           :fx [[:rf.http/managed
+                 (rh/request {:method     (if following? :delete :post)
+                              :path       (str "/profiles/" username "/follow")
+                              :decode     schema/ProfileResponse
+                              :on-success [:article/author-follow-synced]
+                              :on-failure [:article/author-follow-rollback following?]})]]})))))
+
+(rf/reg-event-db :article/author-follow-synced
+  (fn [db [_ {:keys [value]}]]
+    (if-let [profile (:profile value)]
+      (assoc-in db [:article :data :author] profile)
+      db)))
+
+(rf/reg-event-db :article/author-follow-rollback
+  (fn [db [_ previous-following _failure-payload]]
+    (assoc-in db [:article :data :author :following] previous-following)))
+
+(rf/reg-event-fx :article/delete
+  {:doc "Delete the current article from the DETAIL page (author only). No
+         retry — destructive, one click. On success navigate home; the editor's
+         own Delete path (article_editor.cljs) remains reachable too."}
+  (fn [{:keys [db]} _]
+    (let [slug (get-in db [:article :data :slug])]
+      (if (nil? slug)
+        {}
+        {:fx [[:rf.http/managed
+               (rh/request {:method     :delete
+                            :path       (article-path slug)
+                            :decode     :auto
+                            :on-success [:article/delete-success]
+                            :on-failure [:article/delete-failed]})]]}))))
+
+(rf/reg-event-fx :article/delete-success
+  (fn [_ _]
+    {:fx [[:dispatch [:rf.route/navigate :realworld/home]]]}))
+
+(rf/reg-event-db :article/delete-failed
+  (fn [db [_ {:keys [failure]}]]
+    (assoc-in db [:article :error] (rh/failure->message failure))))
+
+;; ============================================================================
 ;; SUBSCRIPTIONS
 ;; ============================================================================
 
@@ -265,6 +333,18 @@
 (rf/reg-sub :article/data :<- [:article/slice] (fn [slice _] (:data slice)))
 (rf/reg-sub :article/status :<- [:article/slice] (fn [slice _] (:status slice)))
 (rf/reg-sub :article/error :<- [:article/slice] (fn [slice _] (:error slice)))
+
+(rf/reg-sub :article/author
+  {:doc "The current article's author profile (username, image, following)."}
+  :<- [:article/data]
+  (fn [article _] (:author article)))
+
+(rf/reg-sub :article/own?
+  {:doc "True when the signed-in viewer is the article's author — gates the
+         Edit / Delete controls on the detail page (rf2-2xi8sr)."}
+  (fn [db _]
+    (let [me (get-in db [:auth :user :username])]
+      (and me (= me (get-in db [:article :data :author :username]))))))
 
 (rf/reg-sub :comments/slice (fn [db _] (:comments db)))
 (rf/reg-sub :comments/data :<- [:comments/slice] (fn [slice _] (:data slice)))
@@ -319,6 +399,44 @@
           :on-click #(dispatch [:comment/delete (:id comment)])}
          [:i.ion-trash-a]])]]))
 
+(reg-view ^{:doc "The article-detail contextual controls (rf2-2xi8sr): the
+                  author byline plus, per the official Conduit template, the
+                  author's Follow/Unfollow for a non-author viewer OR Edit /
+                  Delete for the author. Logged-out viewers see the byline only.
+                  Rendered twice on the page (banner + footer) like the official
+                  template."}
+          article-meta []
+  (let [article @(subscribe [:article/data])
+        author  @(subscribe [:article/author])
+        own?    @(subscribe [:article/own?])
+        authed? @(subscribe [:auth/authenticated?])]
+    [:div.article-meta
+     [rf/route-link {:to :realworld.profile/show :params {:username (:username author)}}
+      [:img {:src (:image author)}]]
+     [:div.info
+      [rf/route-link {:to :realworld.profile/show :params {:username (:username author)} :class "author"}
+       (:username author)]
+      [:span.date (:createdAt article)]]
+     (cond
+       own?
+       [:span
+        [rf/route-link {:to :realworld.editor/edit :params {:slug (:slug article)}
+                        :class "btn btn-sm btn-outline-secondary"
+                        :data-testid "article-edit"}
+         [:i.ion-edit] " Edit Article"]
+        " "
+        [:button.btn.btn-sm.btn-outline-danger
+         {:type "button" :data-testid "article-delete"
+          :on-click #(dispatch [:article/delete])}
+         [:i.ion-trash-a] " Delete Article"]]
+
+       authed?
+       [:button.btn.btn-sm.btn-outline-secondary
+        {:type "button" :data-testid "article-follow-author"
+         :on-click #(dispatch [:article/toggle-follow-author])}
+        [:i.ion-plus-round] " "
+        (if (:following author) "Unfollow " "Follow ") (:username author)])]))
+
 (reg-view article-page []
   (let [article        @(subscribe [:article/data])
         article-status @(subscribe [:article/status])
@@ -352,13 +470,16 @@
          [:div.container
           [:h1 {:data-testid "article-title"} (:title article)]
           [:p {:data-testid "article-description"} (:description article)]
-          [:button.btn.btn-sm.btn-outline-primary
-           {:type        "button"
-            :data-testid "article-favorite"
-            :on-click    #(dispatch [:article/toggle-favorite (:slug article)])}
-           [:i.ion-heart] " "
-           [:span {:data-testid "article-favorites-count"}
-            (:favoritesCount article)]]]]
+          [:span.article-controls
+           [:button.btn.btn-sm.btn-outline-primary
+            {:type        "button"
+             :data-testid "article-favorite"
+             :on-click    #(dispatch [:article/toggle-favorite (:slug article)])}
+            [:i.ion-heart] " "
+            [:span {:data-testid "article-favorites-count"}
+             (:favoritesCount article)]]
+           " "
+           [article-meta]]]]
         [:div.container.page
          [:div.row.article-content
           [:div.col-md-12
@@ -369,6 +490,7 @@
               [:li.tag-default.tag-pill.tag-outline tag])]]]
          [:hr]
          [:div.article-actions
+          [article-meta]
           [rf/route-link {:to :realworld/home} "Back to feed"]]
          [:div.row
           [:div.col-xs-12.col-md-8.offset-md-2

--- a/examples/reagent/realworld/http.cljs
+++ b/examples/reagent/realworld/http.cljs
@@ -7,6 +7,15 @@
    retry-with-backoff, abort, and reply addressing; the example just
    composes request maps.
 
+   BACKEND MODES (see this example's README §Running against a real backend):
+   - canned demo stub (DEFAULT) — `core.cljs` overrides `:rf.http/managed` with
+     an in-process per-URL stub, so the app runs with NO network. `api-base` is
+     not contacted; the stub matches on the path suffix.
+   - official hosted API — point `api-base` at the current hosted Conduit API
+     `https://api.realworld.show/api` and drop the demo-stub override.
+   - local reference backend — the upstream Node/Postgres backend on
+     `http://localhost:3000/api`.
+
    This namespace ships TWO small helpers on top of `:rf.http/managed`:
 
    - `request` — build a request map (`{:request {...} :decode ... :retry ...}`)
@@ -23,9 +32,10 @@
      valid even when the server is sad).
 
    The RealWorld spec lives at https://github.com/gothinkster/realworld/tree/main/api.
-   Production points at https://api.realworld.io/api; locally the spec
-   ships a Node + Postgres reference backend on http://localhost:3000/api.
-   This file does not register any fx — the demo entry (`core.cljs`) wires
+   The current official hosted API is https://api.realworld.show/api; locally
+   the spec ships a Node + Postgres reference backend on
+   http://localhost:3000/api. This file does not register any fx — the demo
+   entry (`core.cljs`) wires
    `:rf.http/managed` to a canned-stub override so the CLJS test fixtures
    (in the framework test tree at
    `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs`;
@@ -38,9 +48,13 @@
 ;; ============================================================================
 
 (def api-base
-  "Default API base URL. In production set this from the build/env; for
-   local development the realworld reference backend runs on :3000."
-  "https://api.realworld.io/api")
+  "Default API base URL — the current official hosted Conduit API. The DEFAULT
+   run mode overrides `:rf.http/managed` with an in-process canned stub
+   (`core.cljs`), so this base is not actually contacted out of the box; it is
+   the base you keep when you drop the stub to run against the real hosted API.
+   For the local upstream reference backend, set it to
+   `http://localhost:3000/api`. See the README §Running against a real backend."
+  "https://api.realworld.show/api")
 
 (defn full-url [path]
   (str api-base path))

--- a/examples/reagent/realworld_resources/README.md
+++ b/examples/reagent/realworld_resources/README.md
@@ -54,6 +54,14 @@ The official Conduit profile has two tabs, and here they are **two routes**, eac
 
 The active tab is **just the current route id** — there is no tab state in `app-db`; the view reads `:rf.route/id` to pick which list resource to subscribe to. The tab links are plain `route-link`s. Favoriting / unfavoriting from the Favorited tab fires the same `:realworld/favorite` / `:realworld/unfavorite` mutations, whose `:invalidates` stales `[:article slug]` — a tag the favorited list **carries** for every article it contains — so the list refetches and the article drops out on unfavorite with no extra wiring. (No dedicated `[:favorited-articles username]` invalidation is needed for the toggle; the per-article tag already reaches it.)
 
+### Article-detail contextual controls (`views.cljs`)
+
+Per the official Conduit article-page template, the detail page renders the author byline plus contextual controls: a non-author viewer sees **Follow / Unfollow** the author (`:ui/follow-author` — fires the `:realworld/follow` / `:realworld/unfollow` mutation, then stales `[:article slug]` so the detail's embedded `:author.following` refetches, since the follow mutation itself only invalidates `[:profile username]`); the author sees **Edit Article** (a `route-link` to `/editor/:slug`) and **Delete Article** (`:ui/delete-article` → the `:realworld/delete-article` mutation, with a Form-3 settle reaction navigating home on success — the same off-render idiom the editor uses, since a mutation has no reply-side `:on-success`). Logged-out viewers see the byline only (rf2-2xi8sr).
+
+### Cross-scope feed invalidation — an interim seam (`views.cljs`)
+
+The favourite / unfavourite mutations are `:rf.scope/global` (matching the public reads they invalidate), so their `[:feed]` tag resolves in the **global** scope — but the personalised feed entry lives under a **session** scope, so the global invalidation is structurally unreachable from it (Spec 016 invalidation is scoped + fail-closed by default; the nx8ip6 HYBRID ruling makes invalidation scope fail-closed). The home page therefore fires an **explicit session-scoped** `[:feed]` invalidation (`:ui/invalidate-session-feed`, derived from the auth slice) when a favourite toggle settles, so Your Feed refreshes. This is the **interim** patch (rf2-em5ab8); the durable fix is EP-0016 per-target scoped invalidation descriptors (`{:scope … :tags #{[:feed]}}`), of which this bug is the minimal failing example.
+
 ### Scope is the fail-closed leak boundary (`scope.cljs`)
 
 This example reads two **kinds** of server-state, so it shows **both** scope policies (Spec 016 §Scope resolution):
@@ -69,7 +77,7 @@ Every RealWorld write is a `reg-mutation` whose `:invalidates` (and, where usefu
 
 | Mutation | Write | Invalidates / populates |
 |---|---|---|
-| `:realworld/favorite` / `:realworld/unfavorite` | POST/DELETE `/articles/:slug/favorite` | `:populates` the detail entry from the reply (heart flips immediately); `:invalidates` `[:article slug] [:article-list] [:feed]` |
+| `:realworld/favorite` / `:realworld/unfavorite` | POST/DELETE `/articles/:slug/favorite` | `:populates` the detail entry from the reply (heart flips immediately); `:invalidates` `[:article slug] [:article-list] [:feed]` (global scope). The personalised feed is **session-scoped**, so a global-scope invalidation can't reach it — `views.cljs` fires an explicit session-scoped `[:feed]` invalidation when a favourite settles (the rf2-em5ab8 interim patch; the durable per-target fix is EP-0016). |
 | `:realworld/follow` / `:realworld/unfollow` | POST/DELETE `/profiles/:username/follow` | `:populates` the profile banner; `:invalidates` `[:profile username]` |
 | `:realworld/post-comment` | POST `/articles/:slug/comments` | `:invalidates` `[:comments slug]` (the mounted page's comments refetch) |
 | `:realworld/delete-comment` | DELETE `/articles/:slug/comments/:id` | `:invalidates` `[:comments slug]` |
@@ -111,7 +119,7 @@ Login / register / session-restore / logout are a Spec 005 state machine issuing
 | `auth.cljs` | The `:auth/flow` auth machine (login / register / restore-without-navigating / logout-with-clear-scope) + the login/register forms. |
 | `settings.cljs` | The settings page as a mutation instance (`:rf.mutation/state`); the save-success continuation is off the render path (Form-3 settle reaction). |
 | `article_editor.cljs` | Create / edit / delete an article: the `:realworld/save-article` + `:realworld/delete-article` mutations, the `:editor/can-submit?` Spec 013 flow, the `:editor/can-leave?` guard, and the Form-3 settle reactions (seed-on-load + save/delete continuation). |
-| `views.cljs` | Passive pages (home / article / profile-with-two-tabs) + the numbered `pagination` control + the keep-previous list render + the small UI event glue (favourite / follow / comment / page navigation). |
+| `views.cljs` | Passive pages (home / article / profile-with-two-tabs) + the numbered `pagination` control + the keep-previous list render + the small UI event glue (favourite / follow / comment / page navigation); the article-detail contextual controls (author follow + author Edit/Delete — rf2-2xi8sr); and the explicit session-scoped feed invalidation on favourite-settle (rf2-em5ab8 interim patch). The `home-page` + `article-page` are Form-3 wrappers holding the off-render settle reactions. |
 | `schema.cljs` | Malli wire shapes + the small app-db schemas (auth + form drafts only — the reads live in runtime-db). |
 | `http.cljs` | The demo backend stub (resources + mutations lower onto `:rf.http/managed`, so one stub serves the whole API) — synthesises a multi-page article set + honours `limit`/`offset` + a distinct favorited subset — plus the shared `data-fetch-retry` read policy + the `:rf.http/*` failure projection. |
 | `index.html` | Static host page. |
@@ -125,7 +133,15 @@ shadow-cljs watch examples/realworld-resources
 # then stage this folder's index.html + _shared/ next to the built main.js and serve over HTTP.
 ```
 
-In production point `realworld-resources.http/api-base` at <https://api.realworld.io/api>; the demo entry installs an in-process `:rf.http/managed` override (`:realworld-resources.demo/http-stub`) that synthesises canned Conduit responses for both the reads (resources) and the writes (mutations), so it runs standalone without a backend.
+### Running against a real backend
+
+The app supports three backend modes; the default needs no network.
+
+1. **Canned demo stub (default).** The demo entry (`core.cljs`) installs an in-process `:rf.http/managed` override (`:realworld-resources.demo/http-stub`) that synthesises canned Conduit responses for both the reads (resources) and the writes (mutations), so it runs standalone without a backend. `api-base` is **not contacted** in this mode — the stub matches on the URL path suffix.
+
+2. **Official hosted API.** Point `realworld-resources.http/api-base` at the current official hosted API — <https://api.realworld.show/api> (the old `api.realworld.io` host is stale) — and remove the `:fx-overrides {:rf.http/managed :realworld-resources.demo/http-stub}` line from the demo frame in `core.cljs`. The frame-wide `:realworld/bearer-auth` HTTP interceptor (`core.cljs`) attaches the JWT to every outbound resource / mutation / restore request, so authenticated calls work against the real API (rf2-j4kbro); the read resources also carry the shared `data-fetch-retry` policy.
+
+3. **Local reference backend.** The upstream spec ships a Node/Postgres reference backend on `http://localhost:3000/api`; set `api-base` to that and drop the stub override as in mode 2.
 
 ## Verification posture
 

--- a/examples/reagent/realworld_resources/http.cljs
+++ b/examples/reagent/realworld_resources/http.cljs
@@ -17,18 +17,33 @@
    - `install-demo-backend!` — register the stub fx + wire it as the
      `:rf.http/managed` override on the demo frame.
 
-   The RealWorld spec lives at https://github.com/gothinkster/realworld.
-   Production points `api-base` at https://api.realworld.io/api; the upstream
+   BACKEND MODES (see this example's README §Running against a real backend):
+   - canned demo stub (DEFAULT) — `core.cljs` overrides `:rf.http/managed` with
+     an in-process per-URL stub, so the app runs with NO network and `api-base`
+     is not contacted (the stub matches on the path suffix).
+   - official hosted API — point `api-base` at `https://api.realworld.show/api`
+     and drop the demo-stub override. The frame-wide `:realworld/bearer-auth`
+     interceptor (core.cljs) already attaches the token, so authenticated calls
+     work against the real API (rf2-j4kbro).
+   - local reference backend — the upstream Node/Postgres backend on
+     `http://localhost:3000/api`.
+
+   The RealWorld spec lives at https://github.com/gothinkster/realworld; the
+   current official hosted API is https://api.realworld.show/api; the upstream
    spec ships a Node/Postgres reference backend on http://localhost:3000/api."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]))
 
 (def api-base
-  "Default API base URL. The resource / mutation `:request` fns build full
-   URLs from this; the demo stub matches on the path suffix so the base is a
-   demo-seam knob, not load-bearing here."
-  "https://api.realworld.io/api")
+  "Default API base URL — the current official hosted Conduit API. The resource
+   / mutation `:request` fns build full URLs from this; in the DEFAULT run mode
+   the demo stub overrides `:rf.http/managed` and matches on the path suffix, so
+   the base is not actually contacted (a demo-seam knob). Drop the stub to run
+   against the real hosted API, or set it to `http://localhost:3000/api` for the
+   local upstream reference backend. See the README §Running against a real
+   backend."
+  "https://api.realworld.show/api")
 
 (defn full-url [path]
   (str api-base path))

--- a/examples/reagent/realworld_resources/views.cljs
+++ b/examples/reagent/realworld_resources/views.cljs
@@ -24,8 +24,11 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.resources]
+            [reagent.core :as r]
+            [reagent.ratom :as ratom]
             [realworld-resources.http :as rh]
-            [realworld-resources.resources :as resources])
+            [realworld-resources.resources :as resources]
+            [realworld-resources.scope :as scope])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -126,6 +129,104 @@
                          :params   {:username username}
                          :instance [:follow username]
                          :cause    [:click :ui/follow username]}]]]})))
+
+;; ----------------------------------------------------------------------------
+;; FEED INVALIDATION ACROSS SCOPES — interim patch (rf2-em5ab8)
+;; ----------------------------------------------------------------------------
+;;
+;; The favorite / unfavorite mutations are `:rf.scope/global` (matching the
+;; PUBLIC reads they invalidate — `[:article slug]`, `[:article-list]`), so the
+;; `[:feed]` tag in their `:invalidates` resolves in the GLOBAL scope. But the
+;; personalised feed entry lives under a SESSION scope
+;; (`[:rf.scope/session {:username …}]`), so the global-scope invalidation is
+;; STRUCTURALLY UNREACHABLE from it: favoriting an article would never refresh
+;; Your Feed.
+;;
+;; Spec 016 invalidation is SCOPED + FAIL-CLOSED by default (rf2-pvdae1 /
+;; rf2-nx8ip6 HYBRID ruling: mutation EXECUTION scope is fail-open, but
+;; INVALIDATION scope is fail-closed — a scoped invalidate MUST name its
+;; scope, or opt into `:cross-scope?` explicitly). A single mutation
+;; `:invalidates` resolves under ONE scope, so it cannot reach BOTH the global
+;; article tags and the session feed.
+;;
+;; INTERIM PATCH: an EXPLICIT, fail-closed session-scoped invalidation of the
+;; `[:feed]` tag, fired when a favorite / unfavorite settles success — derived
+;; from the auth slice so it names the SAME session scope the feed entry lives
+;; under (never a silent cross-scope reach; never `:cross-scope?` storms). The
+;; mutation keeps its global `:invalidates` for the public reads; this names the
+;; session target the per-mutation single scope can't.
+;;
+;; The DURABLE fix is EP-0016 per-target scoped invalidation descriptors
+;; (`{:scope … :tags #{[:feed]}}`), of which this is the minimal failing
+;; example; this app-level patch retires when that lands.
+(rf/reg-event-fx :ui/invalidate-session-feed
+  {:doc "Stale the authenticated user's session-scoped feed so a favorite /
+         unfavorite (a global-scope mutation) is reflected in Your Feed. A
+         no-op for a logged-out visitor (no session scope, nothing to reach).
+         Fail-closed: the explicit `:scope` is REQUIRED by
+         `:rf.resource/invalidate-tags` — a missing scope throws rather than
+         silently matching nothing (Spec 016 §Invalidation, rf2-pvdae1)."}
+  (fn [{:keys [db]} _]
+    (when-let [session-scope (scope/session-scope (get-in db [:auth :user]))]
+      {:fx [[:dispatch [:rf.resource/invalidate-tags
+                        {:scope session-scope
+                         :tags  #{[:feed]}
+                         :cause [:mutation-feed-sync :realworld/favorite]}]]]})))
+
+;; ----------------------------------------------------------------------------
+;; ARTICLE-DETAIL SOCIAL CONTROLS  (rf2-2xi8sr)
+;; ----------------------------------------------------------------------------
+;;
+;; The official Conduit article page carries contextual controls: a non-author
+;; viewer follows/unfollows the AUTHOR; the author sees Edit (→ /editor/:slug)
+;; and Delete. Logged-out viewers see neither. Follow reuses the existing
+;; `:realworld/follow` / `:realworld/unfollow` mutations (which invalidate
+;; `[:profile username]`); to reflect the change on the DETAIL page — whose
+;; embedded `:author.following` lives inside the `[:article slug]` entry, not
+;; the profile resource — the article is additionally staled so its author
+;; refetches. Delete fires the `:realworld/delete-article` mutation; the success
+;; continuation (navigate home) rides the editor's settle-reaction idiom, since
+;; a mutation has no reply-side `:on-success` (until EP-0016 reply-to lands).
+
+(rf/reg-event-fx :ui/follow-author
+  {:doc "Follow / unfollow the article author from the detail page. Fires the
+         follow / unfollow mutation; the detail page's embedded `:author` lives
+         in the `[:article slug]` entry (not the `[:profile username]` resource
+         the follow mutation invalidates), so the article is re-staled when the
+         follow SETTLES — see the `article-page` Form-3 settle reaction. (Staling
+         eagerly here would refetch before the server processed the follow, so
+         the embedded flag would read its old value.) Auth-gated."}
+  (fn [{:keys [db]} [_ _slug username following?]]
+    (if (nil? (get-in db [:auth :user]))
+      {:fx [[:dispatch [:rf.route/navigate :realworld.auth/login]]]}
+      {:fx [[:dispatch [:rf.mutation/execute
+                        {:mutation (if following? :realworld/unfollow :realworld/follow)
+                         :params   {:username username}
+                         :instance [:follow username]
+                         :cause    [:click :ui/follow-author username]}]]]})))
+
+(rf/reg-event-fx :ui/sync-article-after-follow
+  {:doc "Stale the current article so its embedded `:author.following` refetches
+         after a follow/unfollow settled (fired from the article-page settle
+         reaction). Global scope — the article read is `:rf.scope/global`."}
+  (fn [_ [_ slug]]
+    {:fx [[:dispatch [:rf.resource/invalidate-tags
+                      {:scope :rf.scope/global
+                       :tags  #{[:article slug]}
+                       :cause [:follow-author-detail-sync slug]}]]]}))
+
+(rf/reg-event-fx :ui/delete-article
+  {:doc "Delete the current article from the detail page (author only). Fires
+         the `:realworld/delete-article` mutation under a stable instance the
+         page's settle reaction watches to navigate home on success."}
+  (fn [{:keys [db]} [_ slug]]
+    (if (nil? (get-in db [:auth :user]))
+      {:fx [[:dispatch [:rf.route/navigate :realworld.auth/login]]]}
+      {:fx [[:dispatch [:rf.mutation/execute
+                        {:mutation :realworld/delete-article
+                         :params   {:slug slug}
+                         :instance [:delete-article slug]
+                         :cause    [:click :ui/delete-article slug]}]]]})))
 
 ;; ============================================================================
 ;; COMMENT FORM — a tiny app-db draft + a post mutation
@@ -258,7 +359,11 @@
 ;; HOME PAGE
 ;; ============================================================================
 
-(reg-view home-page []
+(reg-view ^{:doc "Pure home-page render — a function of subs, never dispatches
+                  out of band. The session-feed invalidation continuation (the
+                  rf2-em5ab8 interim patch) lives in the `home-page` Form-3
+                  wrapper below."}
+          home-page-view []
   (let [authed?      @(subscribe [:auth/authenticated?])
         your-feed?   @(subscribe [:home/your-feed?])
         selected-tag @(subscribe [:home/selected-tag])
@@ -317,6 +422,69 @@
                     tag]))
            [:div.tag-list {:data-testid "tags-loading"} "Loading tags…"])]]]]]))
 
+(defn home-page
+  "The home page. A Reagent Form-3 component: the inner render is the pure
+   `home-page-view`; a mount-time reaction watches the favorite / unfavorite
+   instances of the articles currently shown in Your Feed and, when one settles
+   success, fires the EXPLICIT session-scoped `[:feed]` invalidation
+   (`:ui/invalidate-session-feed`) so the toggle is reflected in the
+   personalised feed (rf2-em5ab8 interim patch — the global-scope mutation's own
+   `:invalidates` can't reach the session-scoped feed entry; see the event
+   docstring). `rf/frame-handle` is captured at render so the reaction's
+   out-of-render dispatch carries the frame; unmount disposes the reaction."
+  []
+  (let [{:keys [dispatch subscribe]} (rf/frame-handle)
+        ;; settled favorite instances we've already reconciled, so a single
+        ;; settle fires exactly one feed invalidation (the instance stays
+        ;; `:success?` until the next toggle re-executes it).
+        seen     (atom #{})
+        watcher  (atom nil)]
+    (r/create-class
+     {:display-name "realworld-resources.views/home-page"
+      :component-did-mount
+      (fn [_this]
+        (reset!
+         watcher
+         (ratom/run!
+          (let [authed?      @(subscribe [:auth/authenticated?])
+                selected-tag @(subscribe [:home/selected-tag])
+                page         @(subscribe [:home/page])
+                ss           @(subscribe [:session/scope])
+                feed-state   (when (and authed? ss)
+                               @(subscribe [:rf.resource/state {:resource :realworld/feed
+                                                                :scope   ss
+                                                                :params  {:page page}}]))
+                list-state   @(subscribe [:rf.resource/state {:resource :realworld/articles
+                                                              :params  {:tag selected-tag :page page}}])
+                visible      (fn [state]
+                               (when state
+                                 (or (:articles (:data state))
+                                     (:articles (:previous-data state)))))
+                articles     (concat (visible feed-state) (visible list-state))]
+            ;; Watch the favorite instance of every article currently visible on
+            ;; the home page (Your Feed AND the global list — a favorite on
+            ;; either may belong to a followed author, so the feed could carry
+            ;; it). A page is bounded (≤ page-size each), so the watch set stays
+            ;; small. When a toggle settles success, stale the session feed
+            ;; ONCE; a re-pending of the same instance re-arms the next fire.
+            (when authed?
+              (doseq [a articles]
+                (let [slug  (:slug a)
+                      inst  [:favorite slug]
+                      state @(subscribe [:rf.mutation/state {:instance inst}])]
+                  (when (and (:success? state) (not (contains? @seen inst)))
+                    (swap! seen conj inst)
+                    (dispatch [:ui/invalidate-session-feed]))
+                  (when (and (:pending? state) (contains? @seen inst))
+                    (swap! seen disj inst)))))))))
+      :component-will-unmount
+      (fn [_this]
+        (when @watcher (ratom/dispose! @watcher))
+        (reset! watcher nil)
+        (reset! seen #{}))
+      :reagent-render
+      (fn [] [home-page-view])})))
+
 ;; ============================================================================
 ;; ARTICLE DETAIL + COMMENTS
 ;; ============================================================================
@@ -338,7 +506,47 @@
                               :on-click #(dispatch [:comment/delete slug (:id comment)])}
          [:i.ion-trash-a]])]]))
 
-(reg-view article-page []
+(reg-view ^{:doc "Article-detail contextual controls (rf2-2xi8sr): the author
+                  byline plus the author's Follow/Unfollow for a non-author
+                  viewer, OR Edit (→ /editor/:slug) + Delete for the author.
+                  Logged-out viewers see the byline only. `article` is the
+                  unwrapped article map; `del-state` the delete instance view."}
+          article-meta [{:keys [article del-state]}]
+  (let [author    (:author article)
+        username  (:username author)
+        slug      (:slug article)
+        me        @(subscribe [:auth/user])
+        authed?   @(subscribe [:auth/authenticated?])
+        own?      (and me (= (:username me) username))]
+    [:div.article-meta
+     [rf/route-link {:to :realworld.profile/show :params {:username username}}
+      [:img {:src (:image author)}]]
+     [:div.info
+      [rf/route-link {:to :realworld.profile/show :params {:username username} :class "author"}
+       username]
+      [:span.date (:createdAt article)]]
+     (cond
+       own?
+       [:span
+        [rf/route-link {:to :realworld.editor/edit :params {:slug slug}
+                        :class "btn btn-sm btn-outline-secondary"
+                        :data-testid "article-edit"}
+         [:i.ion-edit] " Edit Article"]
+        " "
+        [:button.btn.btn-sm.btn-outline-danger
+         {:type "button" :data-testid "article-delete"
+          :disabled (:pending? del-state)
+          :on-click #(dispatch [:ui/delete-article slug])}
+         [:i.ion-trash-a] " Delete Article"]]
+
+       authed?
+       [:button.btn.btn-sm.btn-outline-secondary
+        {:type "button" :data-testid "article-follow-author"
+         :on-click #(dispatch [:ui/follow-author slug username (:following author)])}
+        [:i.ion-plus-round] " "
+        (if (:following author) "Unfollow " "Follow ") username])]))
+
+(reg-view article-page-view []
   (let [slug          (:slug @(subscribe [:rf.route/params]))
         current-user  @(subscribe [:auth/user])
         article-state @(subscribe [:rf.resource/state {:resource :realworld/article :params {:slug slug}}])
@@ -355,8 +563,10 @@
         (str "Couldn't load article: " (rh/failure->message (:error article-state)))]
 
        :else
-       (let [{:keys [slug title description body tagList favoritesCount favorited]} (:article (:data article-state))
-             fav-state @(subscribe [:rf.mutation/state {:instance [:favorite slug]}])]
+       (let [article   (:article (:data article-state))
+             {:keys [slug title description body tagList favoritesCount favorited]} article
+             fav-state @(subscribe [:rf.mutation/state {:instance [:favorite slug]}])
+             del-state @(subscribe [:rf.mutation/state {:instance [:delete-article slug]}])]
          [:<>
           [:div.banner
            [:div.container
@@ -364,18 +574,23 @@
             [:p {:data-testid "article-description"} description]
             (when (:fetching? article-state)
               [:span {:data-testid "article-refreshing"} " (refreshing…)"])
-            [:button.btn.btn-sm.btn-outline-primary
-             {:type "button" :data-testid "article-favorite"
-              :disabled (:pending? fav-state)
-              :on-click #(dispatch [:ui/favorite slug favorited])}
-             [:i.ion-heart] " "
-             [:span {:data-testid "article-favorites-count"} favoritesCount]]]]
+            [:span.article-controls
+             [:button.btn.btn-sm.btn-outline-primary
+              {:type "button" :data-testid "article-favorite"
+               :disabled (:pending? fav-state)
+               :on-click #(dispatch [:ui/favorite slug favorited])}
+              [:i.ion-heart] " "
+              [:span {:data-testid "article-favorites-count"} favoritesCount]]
+             " "
+             [article-meta {:article article :del-state del-state}]]]]
           [:div.container.page
            [:div.row.article-content
             [:div.col-md-12
              [:p {:data-testid "article-body"} body]
              (into [:ul.tag-list] (for [tag tagList] ^{:key tag} [:li.tag-default.tag-pill.tag-outline tag]))]]
            [:hr]
+           [:div.article-actions
+            [article-meta {:article article :del-state del-state}]]
            [:div.row
             [:div.col-xs-12.col-md-8.offset-md-2
              (if current-user
@@ -404,6 +619,62 @@
                      (for [c (:comments (:data comments-state))]
                        ^{:key (:id c)} [comment-card {:comment c :slug slug :current-user current-user}])))]]]]))
      [:p [rf/route-link {:to :realworld/home :data-testid "back-home"} "← Back to feed"]]]))
+
+(defn article-page
+  "The article-detail page. A Reagent Form-3 component: the inner render is the
+   pure `article-page-view`; mount reactions watch two settle continuations the
+   mutations can't express on the reply side (rf2-2xi8sr) —
+   (1) the `:delete-article` instance: on settle-success clear it + navigate
+   home (the `:realworld/delete-article` mutation has no reply-side
+   `:on-success`, so this rides the editor's settle-reaction idiom);
+   (2) the author `:follow` instance: on settle, stale `[:article slug]` so the
+   detail's embedded `:author.following` refetches (the follow mutation
+   invalidates `[:profile username]`, not the article).
+   `rf/frame-handle` is captured at render so the out-of-render dispatches carry
+   the frame; unmount disposes the reactions."
+  []
+  (let [{:keys [dispatch subscribe]} (rf/frame-handle)
+        deleted?      (atom false)
+        follow-synced (atom false)
+        watcher       (atom nil)]
+    (r/create-class
+     {:display-name "realworld-resources.views/article-page"
+      :component-did-mount
+      (fn [_this]
+        (reset!
+         watcher
+         (ratom/run!
+          (let [slug          (:slug @(subscribe [:rf.route/params]))
+                article-state (when slug
+                                @(subscribe [:rf.resource/state {:resource :realworld/article
+                                                                 :params {:slug slug}}]))
+                author-name   (get-in article-state [:data :article :author :username])
+                del           (when slug @(subscribe [:rf.mutation/state {:instance [:delete-article slug]}]))
+                follow        (when author-name
+                                @(subscribe [:rf.mutation/state {:instance [:follow author-name]}]))]
+            ;; (1) delete settled → clear + go home.
+            (when (and del (:success? del) (not @deleted?))
+              (reset! deleted? true)
+              (dispatch [:rf.mutation/clear {:instance [:delete-article slug]}])
+              (dispatch [:rf.route/navigate :realworld/home]))
+            ;; (2) author follow settled → re-stale the article so the embedded
+            ;; author flag refetches. Re-arm on the next pending so a later
+            ;; toggle fires again.
+            (when (and follow slug)
+              (cond
+                (and (:success? follow) (not @follow-synced))
+                (do (reset! follow-synced true)
+                    (dispatch [:ui/sync-article-after-follow slug]))
+                (:pending? follow)
+                (reset! follow-synced false)))))))
+      :component-will-unmount
+      (fn [_this]
+        (when @watcher (ratom/dispose! @watcher))
+        (reset! watcher nil)
+        (reset! deleted? false)
+        (reset! follow-synced false))
+      :reagent-render
+      (fn [] [article-page-view])})))
 
 ;; ============================================================================
 ;; PROFILE  —  two official tabs: My Articles / Favorited Articles


### PR DESCRIPTION
RealWorld example pair (`examples/reagent/realworld/` managed-HTTP + `examples/reagent/realworld_resources/` EP-0003 resources). Resolves 3 of the 5 cluster beads; 2 surfaced-not-actioned with reasons. Fence: only the two realworld dirs touched.

## Beads

### rf2-em5ab8 (P2 bug, realworld_resources) — DONE
Favorite/unfavorite never refreshed the session-scoped **Your Feed**. The favorite/unfavorite mutations are `:rf.scope/global` (matching the public reads they invalidate), so their `[:feed]` tag resolves in the **global** scope — but the personalised feed entry lives under `[:rf.scope/session {:username …}]`, so the global-scope invalidation is structurally unreachable from it.

Interim patch per Mike's **(c) + HYBRID** ruling (rf2-nx8ip6: invalidation scope is fail-closed): a new `:ui/invalidate-session-feed` event fires an **explicit, fail-closed session-scoped** `[:feed]` invalidation (scope derived from the auth slice via `scope/session-scope`) when a favourite settles. It's wired through a `home-page` Form-3 settle watcher over the favorite instances of the articles currently visible on the home page (Your Feed **and** the global list). The durable fix is EP-0016 per-target scoped invalidation descriptors; this bug is its minimal failing example.

### rf2-0j9qoa (P2 bug) — SURFACED, NOT ACTIONED (no in-surface work)
The authoritative bead targets the **EP-0016 doc examples** (`docs/EP/EP-0016-resource-mutation-completion.md`), which is fenced as the operator's EP-0016 territory. Verified the **example apps already fully conform** to the landed Spec 014/016 contract: zero `:uri` in either tree; every request uses `:url` inside `{:request {…} :decode …}`; `:populates` stores the whole envelope; `:invalidates` uses `(fn [params result] …)`. So there is no in-surface fix here — the example apps are the source of truth the EP doc should be corrected to match. Documented on the bead.

### rf2-2xi8sr (P3, both) — DONE
Article-detail contextual controls per the official Conduit template: non-author viewers get author **Follow/Unfollow**; the author gets **Edit Article** (→ `/editor/:slug`) + **Delete Article**; logged-out viewers see the byline only. Both apps render an `article-meta` control row in the banner + footer.
- Managed app (`comments.cljs`): optimistic author-follow + rollback on the article's embedded `:author`; `:article/delete` navigates home on success (editor delete remains reachable too).
- Resources app (`views.cljs`): `:ui/follow-author` fires the follow mutation + a settle-reaction re-stales `[:article slug]` so the embedded `:author.following` refetches (the follow mutation only invalidates `[:profile username]`); `:ui/delete-article` fires the delete mutation + a settle-reaction navigates home. `article-page` becomes a Form-3 wrapper holding the settle reactions.

### rf2-ke9gtx (P3, both) — SURFACED, NOT ACTIONED (gated on a Mike decision)
The bead itself gates implementation on a dependency decision ("pick/vendor a markdown lib … surface before implementing; the choice sets precedent"). Held per the "surface before implementing" posture. Recommendation documented on the bead: a **zero-dep hand-rolled CLJS markdown→hiccup subset**, sanitized by construction (emit hiccup, never raw HTML / `dangerouslySetInnerHTML`, so React escapes all text → XSS-safe), which sidesteps the dependency-precedent concern; plus a shared-vs-per-app ns placement question (a shared ns would be a new surface outside this fence).

### rf2-tviyw2 (P3, both) — DONE
Updated the default `api-base` from the stale `https://api.realworld.io/api` to the current official hosted API `https://api.realworld.show/api` in both `http.cljs`. Both READMEs gain a **"Running against a real backend"** section documenting the three modes: canned demo stub (default, no network) / official hosted API / local reference backend (`localhost:3000/api`), including the bearer-auth + retry notes (coordinated with the closed rf2-j4kbro).

## Quality gates
- `shadow-cljs compile` `:examples/realworld` + `:examples/realworld-resources` — **0 warnings each**
- `shadow-cljs release` `:examples/realworld` + `:examples/realworld-resources` — **0 warnings each** (the unrelated `http_privacy_headers.cljc` JSDoc WARNING is pre-existing on main, outside this surface)
- `npm run test:script-policy` (incl. `check-examples-assets`, `check-examples-compile`) — **pass** (no `*.spec.cjs` under examples; layout↔disk bijection intact)
- `scripts/test-fast-pr.sh` — **6420 tests, 0 failures, 0 errors**; README link/anchor + EP status-sync gates pass; `mkdocs --strict` soft-skipped locally (no mkdocs on PATH; CI runs it)

Examples are test-free (rf2-8cevm) — no `*.spec.cjs` added.