### PR TITLE
docs(ep): corpus consistency audit — EP-0003 graduation ripples + EP-0016 integration

### DIFF
--- a/docs/EP/EP-0001-frame-partitions.md
+++ b/docs/EP/EP-0001-frame-partitions.md
@@ -14,10 +14,11 @@ Status: final
 > [Implementation errata](#implementation-errata). Finalizing the *decisions*
 > did not, on its own, assert the *implementation* was gap-free; the errata
 > ledger below tracked that separately to its close. Historical proposal
-> sections below still preserve rejected alternatives such as `:db-before` /
-> `:db-after` and multi-container representations; the Resolved Decisions and
-> the graduated specs are authoritative where they conflict with earlier
-> proposal voice.
+> sections below still preserve superseded alternatives such as the
+> multi-container representations; the Resolved Decisions — including the
+> 2026-06-11 `rf2-cg7llv` errata on Decision 2, which blessed `:db-before` /
+> `:db-after` as the canonical projection slot names — and the graduated specs
+> are authoritative where they conflict with earlier proposal voice.
 
 ## Implementation errata
 

--- a/docs/EP/EP-0003-resource-queries.md
+++ b/docs/EP/EP-0003-resource-queries.md
@@ -294,6 +294,14 @@ This EP builds on three other EPs whose contracts have already landed. It is
 written against those final/implemented contracts, not against pending
 dependencies.
 
+- **Post-final amendments arrive via [EP-0016](EP-0016-resource-mutation-completion.md)
+  (proposal).** Per EP-0009's amendment rule, substantive changes to this final
+  contract go through a new EP. EP-0016 proposes mutation completion
+  continuations, per-target scoped invalidation, and named scope resolvers;
+  where it is accepted, its changes land in `spec/016-Resources.md` (which
+  governs) and this EP remains the unamended design record of the original
+  scope.
+
 - **Builds on the app/runtime partition (landed).** Resource Queries stores its
   cache in the framework-owned runtime partition (`:rf.runtime/resources`) of the
   [App/Runtime Partition EP](EP-0001-frame-partitions.md). That partition has

--- a/docs/EP/EP-0006-runtime-subsystem-contract.md
+++ b/docs/EP/EP-0006-runtime-subsystem-contract.md
@@ -122,11 +122,12 @@ third-party-registration API.
 
 - **Builds on EP-0001** (the partition that created the children) and adopts
   its Appendix A item 5, which the fourteen rulings never addressed.
-- **Informs EP-0003 graduation** (by recommendation, not hard dependency):
+- **Informed EP-0003 graduation** (by recommendation, not hard dependency):
   `:rf.runtime/resources`, `:rf.runtime/work-ledger`, and
-  `:rf.runtime/mutations` graduate against this checklist. EP-0003 is already
-  accepted and its HTTP-only Spec 016 scope has graduated; this relationship is
-  now conformance/status hygiene, not an acceptance gate.
+  `:rf.runtime/mutations` graduated against this checklist. EP-0003 is now
+  **final** (graduated 2026-06-11, `rf2-9l9xs2`) with those grading rows
+  shipped; this relationship is settled history plus ongoing conformance
+  hygiene (the drift test, `rf2-ba5acq`).
 - **Sequenced with rf2-3939ig, not coupled to it:** the authority *mechanism*
   (general framework-authority registration meta) has shipped as a bug fix;
   this contract is the *policy* layer that cites it as clause 2's

--- a/docs/EP/EP-0011-uniform-async-reply-envelope.md
+++ b/docs/EP/EP-0011-uniform-async-reply-envelope.md
@@ -176,7 +176,7 @@ day one.
 ## Relationships
 
 - **[EP-0003](EP-0003-resource-queries.md) / [Spec 016](../../spec/016-Resources.md)
-  (accepted; HTTP-only spec graduated).** The frame work ledger is this EP's durable
+  (final).** The frame work ledger is this EP's durable
   substrate: a ledger row *is* the reified continuation of a managed async
   effect, and the row's `:reply-to` field is this EP's reply target made
   durable. This EP rides that design — same `:work/id`, same
@@ -186,6 +186,14 @@ day one.
   `:work/kind :mutation`, and their internal replies verify frame, work id, and
   generation before settling. This EP MUST land with or after the EP-0003
   work-ledger slice and MUST NOT introduce a parallel correlation store.
+- **[EP-0016](EP-0016-resource-mutation-completion.md) (proposal).** EP-0016's
+  call-site mutation `:reply-to` is the concrete resources/mutations slice of
+  this envelope: its reply map is designed to *be* (or trivially lower to) this
+  EP's reply shape, delivered to an event target after stale suppression. The
+  two proposals must converge on one reply vocabulary (one-name-per-fact) —
+  whichever graduates first, the other cites its shape rather than forking.
+  This EP remains the cross-family envelope proposal (HTTP, timers, routing,
+  machines); EP-0016 covers only the mutation instance.
 - **[EP-0010](EP-0010-causal-world-inputs.md) (proposal).** Replies are causal
   tokens under EP-0010; completion facts that affect durable state ride the
   reply map. This EP uses EP-0010's suffixless durable timestamp vocabulary:

--- a/docs/EP/EP-0014-derivation-and-process-algebra.md
+++ b/docs/EP/EP-0014-derivation-and-process-algebra.md
@@ -147,7 +147,7 @@ mental model.
 
 ## Relationships
 
-- [EP-0003](EP-0003-resource-queries.md) (accepted; HTTP-only spec graduated) and
+- [EP-0003](EP-0003-resource-queries.md) (final) and
   [Spec 016](../../spec/016-Resources.md) define resource identity, cache
   scope, owners, the work ledger, and runtime-db storage for server-state
   processes. Resources are a family member of this algebra; this EP reuses

--- a/docs/EP/EP-0016-resource-mutation-completion.md
+++ b/docs/EP/EP-0016-resource-mutation-completion.md
@@ -2,7 +2,6 @@
 
 Status: proposal
 Type: standards-track
-Created: 2026-06-11
 
 > This EP proposes a narrow post-EP-0003 amendment to Spec 016:
 > mutation completion continuations, per-target scoped invalidation, named
@@ -377,8 +376,10 @@ and inspect.
   scope resolver inputs and map-form resource targets should use canonical
   params/scope identity rules defined there where applicable.
 - **[EP-0014](EP-0014-derivation-and-process-algebra.md) (proposal).** Named
-  scope resolvers are declared pure derivations with inputs, output, storage
-  policy, and lifecycle. This EP uses that model for a concrete Spec 016 gap.
+  scope resolvers are shaped consistently with EP-0014's derivation vocabulary
+  (declared inputs, output, lifecycle), so if EP-0014 is accepted they slot
+  into its algebra unchanged — but this EP specifies them independently and
+  carries no dependency on that proposal.
 - **[EP-0015](EP-0015-frame-owned-egress-policy.md) (proposal).** Resource
   scope values, params, reply values, mutation payloads, and trace evidence
   produced by this EP must pass through the eventual egress projection policy.
@@ -522,6 +523,13 @@ Each descriptor has its own scope. Descriptor `:scope` may be:
 - a future route/frame resolver reference if accepted by a later EP.
 
 Missing descriptor scope defaults to `:rf.scope/same`.
+
+"The mutation's resolved scope" here is the scope defined by Spec 016
+§Mutation scope is two distinct scopes (hybrid): the fail-open *execution*
+scope (execute-payload `:scope` → spec `:scope` → `:rf.scope/global`), which
+the mutation supplies as the fail-closed *invalidation* scope. This EP's
+descriptors refine that composition — each target names its own invalidation
+scope explicitly instead of inheriting the execution scope for every tag.
 
 Bare shorthand and descriptor form both lower to the same scoped invalidation
 engine. There is one invalidation implementation. The descriptor is only the


### PR DESCRIPTION
## What

Fresh consistency/cohesion audit of all 16 docs/EP documents, focused on the deltas since the last corpus pass: EP-0003's graduation to final, the rf2-cg7llv epoch-naming errata, the rf2-nx8ip6 hybrid mutation-scope rule landing in Spec 016, and EP-0016's integration into the cross-reference web.

## Amendments (8, across 6 files)

1. **EP-0001 header** — contradicted its own 2026-06-11 errata: still called `:db-before`/`:db-after` "rejected alternatives" after rf2-cg7llv blessed them as canonical. Header now cites the errata.
2. **EP-0011 Relationships** — EP-0003 status parenthetical updated "(accepted; HTTP-only spec graduated)" → "(final)".
3. **EP-0011 Relationships** — new EP-0016 row: records that EP-0016's mutation `:reply-to` is the concrete mutations slice of the envelope, with the converge-don't-fork vocabulary rule (one-name-per-fact).
4. **EP-0014 Relationships** — same EP-0003 status fix → "(final)".
5. **EP-0006 Relationships** — "Informs EP-0003 graduation … is already accepted" reworded to settled history (final, 2026-06-11, rf2-9l9xs2) + the ongoing drift-test hygiene (rf2-ba5acq).
6. **EP-0003 Relationships** — new pointer: post-final amendments arrive via EP-0016 per EP-0009's amendment rule; spec governs; this EP stays the unamended original design record.
7. **EP-0016 header** — dropped the non-standard `Created:` line (EP-0009 preamble grammar is `Status:` + `Type:`; no other EP carries a date line).
8. **EP-0016** — (a) EP-0014 relationship reworded to avoid implying dependency on an unaccepted proposal ("shaped consistently with … carries no dependency"); (b) Decision 2 now grounds its load-bearing "mutation's resolved scope" term by citing Spec 016 §Mutation scope is two distinct scopes (hybrid) — the rule rf2-nx8ip6 landed — and states how descriptors refine the fail-open-execution/fail-closed-invalidation composition.

Items 7+8a are the two "nits" from rf2-9i32wt (partial progress; the substantive items of that bead — ctx parameter definitions, full scope-resolution absorption, related-bead web — remain open). The substantive EP-0016 example fixes stay with rf2-0j9qoa.

## Gates

- `python scripts/check_ep_status_sync.py` — pass
- `python scripts/check_doc_slugs.py` — pass
- `python -m mkdocs build --strict` — pass

## Verified-clean (no change needed)

EP-0003 header/README row (graduation edit was complete and correct, incl. errata ledger); EP-0016's "(final)" claim for EP-0003 (correct); EP-0002/0004/0005/0007/0008/0009/0010/0012/0013/0015 cross-references and statuses; README index ↔ headers (checker-enforced).