### PR TITLE
feat(core): EP-0011 reply substrate — rf.reply ns + reply-map schema + functor law (rf2-zqefg3.1)

### DIFF
--- a/implementation/core/src/re_frame/reply.cljc
+++ b/implementation/core/src/re_frame/reply.cljc
@@ -1,0 +1,442 @@
+(ns re-frame.reply
+  "Internal substrate for the uniform async reply envelope (EP-0011).
+
+  This is the shared, host-handle-free substrate every managed *async*
+  effect family lowers its completion onto — HTTP ([014]), resources +
+  mutations ([016]), machine async work ([005]), route loaders ([012]),
+  and any future managed timer / background-job surface. The canonical
+  normative contract is `spec/Managed-Effects.md` §The uniform reply
+  envelope; EP-0011 is the rationale record. This namespace is the CLJS
+  reference realisation of that contract's *pure* core:
+
+    - target normalization (vector-prefix ↔ descriptor form),
+    - completion (append the reply map to the target per `:delivery`),
+    - reply-target mapping — the functor law (`map-target` changes ONLY
+      the completed event, never issuance / `:work/id` / status /
+      cancellation / staleness / tracing),
+    - reply-map schema validation (the closed `:status` taxonomy +
+      value/error conventions + the data-only invariant),
+    - data-only trace summaries (every wire-bearing slot routes through
+      the shared `re-frame.elision/elide-wire-value` walker — never a
+      family-private elider),
+    - the stale-suppression helper (the correctness boundary: validate
+      carried-vs-current correlation, and on mismatch produce a
+      `:status :stale` reply WITHOUT dispatching the app target).
+
+  INTERNAL. Nothing here is a `re-frame.core` façade export. The public
+  surface is `:rf/reply-to` (the target key) and the reply map a reducer
+  receives; families consume these helpers to build that surface
+  uniformly. Pure — no host handles, no runtime state, no I/O. Host
+  resources (AbortControllers, timer handles, transport promises, DOM
+  nodes) live in a host-transient side-table keyed by `[frame-id
+  work-id]`, NEVER in a reply map or a target.
+
+  Why core. The reply substrate is shared by HTTP (`day8/re-frame2-http`),
+  resources (`day8/re-frame2-resources`), machines, routing, and future
+  surfaces; pushing it to core lets every feature artefact `:require` it
+  without inverting the dependency direction (Spec 006 §Adapter shipping
+  convention). It carries no Malli dependency: schema validation routes
+  through `re-frame.spec`'s best-effort `(resolve 'malli.core/validate)`
+  seam, which no-ops when the schemas artefact is absent (same posture as
+  `re-frame.epoch` / `re-frame.http-managed`)."
+  (:require [re-frame.elision :as elision]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; The closed status + work-status vocabularies (Managed-Effects §Status
+;; taxonomy). Closed by design — a managed async completion is exactly one of
+;; these five statuses. Exposed as data so families and conformance pin the
+;; same set without re-spelling it.
+;; ---------------------------------------------------------------------------
+
+(def statuses
+  "The CLOSED reply `:status` vocabulary (Managed-Effects §Status taxonomy).
+  Exactly one of these is the reply's status. `:ok`/`:partial` carry
+  `:value`; `:error`/`:partial` carry `:error`; `:cancelled` carries
+  `:cancel/reason`; `:stale` carries `:stale? true` + `:stale/reason` and
+  MUST NOT mutate app state."
+  #{:ok :partial :error :cancelled :stale})
+
+(def work-statuses
+  "The operational `:work/status` vocabulary on a reply map. Narrower /
+  more operational than reply `:status` (the ledger row may carry the same
+  value). `:suppressed` is the stale terminal; `:timed-out` is an error
+  work-status (timeout is an error KIND + a work status, never a top-level
+  reply status)."
+  #{:completed :failed :timed-out :suppressed :cancelled})
+
+;; ---------------------------------------------------------------------------
+;; Reply target — normalization between the public vector-prefix short form
+;; and the internal descriptor form (Managed-Effects §The reply target).
+;;
+;; A normalized target is a map:
+;;   {:event          [:event-id arg ...]   ;; the prefix to complete
+;;    :delivery       :append               ;; the only public delivery mode
+;;    :suppress       {...}                  ;; optional data-only gates
+;;    :dispatch-stale? false                 ;; framework test/tool opt-in only
+;;    ::post          (fn [event] event)}    ;; the composed event-transform
+;;
+;; `::post` is the functor's accumulator: a pure event→event transform that
+;; `complete` applies AFTER appending the reply map. It is namespaced-private
+;; and is NEVER serialized into an effect map or a durable reply — it exists
+;; only on a normalized target while a family is assembling/relocating a
+;; continuation, exactly the role Elm's `Cmd.map` plays. Identity target
+;; carries no `::post` (treated as identity); composition composes them.
+;; ---------------------------------------------------------------------------
+
+(def ^:private post-key ::post)
+
+(defn descriptor?
+  "True when `target` is the descriptor (map) form rather than the
+  vector-prefix short form."
+  [target]
+  (map? target))
+
+(defn normalize-target
+  "Normalize a reply target to the canonical descriptor map.
+
+  Accepts either:
+    - the public short form: an event-vector prefix `[:event-id arg ...]`;
+    - the descriptor form: `{:event [...] :delivery :append :suppress {...}
+      :dispatch-stale? bool}`.
+
+  Returns `{:event <vector> :delivery <kw> ...}` with `:delivery` defaulted
+  to `:append`. Idempotent: normalizing an already-normalized target is the
+  identity (it preserves any accumulated `::post` transform and the gate
+  fields). A nil/blank target yields nil (no continuation)."
+  [target]
+  (cond
+    (nil? target) nil
+
+    (vector? target)
+    {:event target :delivery :append}
+
+    (descriptor? target)
+    (let [{:keys [event delivery]} target]
+      (cond-> target
+        (nil? delivery) (assoc :delivery :append)
+        true            (assoc :event event)))
+
+    :else
+    (throw (ex-info "Invalid :rf/reply-to target — expected an event-vector prefix or a descriptor map."
+                    {:rf.error/kind :rf.reply/invalid-target
+                     :target        target}))))
+
+(defn target->short-form
+  "Project a normalized target back to its public short form when it has no
+  non-default descriptor fields (no `:suppress`, no `:dispatch-stale?`, no
+  accumulated `::post`, `:delivery :append`). Otherwise returns the
+  descriptor unchanged. Lets a family expose the bare vector publicly while
+  using the descriptor internally (Managed-Effects: \"A family MAY expose
+  only the short vector form publicly while using the descriptor form
+  internally\")."
+  [target]
+  (let [{:keys [event delivery suppress dispatch-stale?] :as d} (normalize-target target)]
+    (if (and (= delivery :append)
+             (nil? suppress)
+             (not dispatch-stale?)
+             (nil? (get d post-key)))
+      event
+      d)))
+
+;; ---------------------------------------------------------------------------
+;; Completion — append the reply map to the target's event, then apply the
+;; composed event-transform (Managed-Effects §The reply target: "the reply
+;; map appended as the final argument").
+;; ---------------------------------------------------------------------------
+
+(defn complete
+  "Build the completed event for `target` carrying `reply`.
+
+  For `:delivery :append` (the only public mode) the reply map is appended
+  as the final argument of the target's event vector; then the target's
+  composed event-transform (`::post`, identity when absent) is applied. The
+  result is the event vector ready to dispatch.
+
+  This is the pure core the functor law is stated over:
+
+      (complete (map-target f target) reply) == (f (complete target reply))
+
+  `complete` does NOT dispatch, validate, or suppress — issuance, stale
+  checks, ledger writes, and tracing are the family/runtime's job and are
+  unaffected by `map-target` (the functor law). A nil target yields nil (no
+  delivery)."
+  [target reply]
+  (when-let [{:keys [event delivery] :as d} (normalize-target target)]
+    (let [base (case delivery
+                 :append (conj (vec event) reply)
+                 ;; A non-:append delivery is a compatibility-adapter mode
+                 ;; that lowers internally; an unknown one is a contract
+                 ;; error rather than a silent fall-through.
+                 (throw (ex-info "Unknown :rf/reply-to :delivery mode."
+                                 {:rf.error/kind :rf.reply/unknown-delivery
+                                  :delivery      delivery
+                                  :target        d})))
+          post (get d post-key)]
+      (if post (post base) base))))
+
+;; ---------------------------------------------------------------------------
+;; Reply-target mapping — the functor (Managed-Effects §Reply mapping and the
+;; functor law). `map-target` rewrites ONLY the completed event; it never
+;; touches issuance, `:work/id`, status, cancellation, stale checks, or
+;; tracing — those are not stored on the target at all, so the law holds
+;; structurally.
+;; ---------------------------------------------------------------------------
+
+(defn map-target
+  "Map the reply target through an event-transform `f` (an event→event pure
+  fn). Returns a normalized target whose completion equals `f` applied to
+  the original completion:
+
+      (complete (map-target f target) reply) == (f (complete target reply))
+
+  `f` receives the fully-completed event (the target event with the reply
+  map already appended) and returns the relocated/rewrapped event. Mapping
+  composes by composing `::post` accumulators, so the functor laws hold:
+
+      (map-target identity target)        == target          ;; identity
+      (map-target f (map-target g target)) == (map-target (comp f g) target)
+
+  Mapping a target changes ONLY the completed event — never issuance, work
+  id, status classification, cancellation, stale checks, or tracing (none
+  of those live on the target). This is the role `Cmd.map` plays in Elm's
+  command algebra: relocating or wrapping a continuation is a pure data
+  transform."
+  [f target]
+  (let [d        (normalize-target target)
+        existing (get d post-key)
+        composed (if existing (comp f existing) f)]
+    (assoc d post-key composed)))
+
+;; ---------------------------------------------------------------------------
+;; Reply-map schema validation (Managed-Effects §The reply map / §Status
+;; taxonomy). Validates the closed-status invariant, the value/error
+;; conventions per status, and the data-only invariant (no host handles).
+;;
+;; Returns nil when valid; otherwise a vector of problem maps
+;; `{:rf.reply/problem <kw> :path <path> :detail ...}`. `valid?` is the
+;; boolean sugar. Pure — does not throw on a malformed reply (a malformed
+;; reply is data the caller classifies), only on a non-map argument.
+;; ---------------------------------------------------------------------------
+
+(defn- host-handle?
+  "Best-effort detector for a host resource that MUST NOT appear in a
+  data-only reply map: a fn (callback), or a known host object (Promise,
+  AbortController, AbortSignal, a DOM node, a JS Date / RegExp). Plain EDN
+  data — maps, vectors, sets, keywords, strings, numbers, booleans, nil,
+  symbols, instants represented as longs — passes."
+  [v]
+  (or (fn? v)
+      #?(:cljs (or (instance? js/Promise v)
+                   (and (exists? js/AbortController) (instance? js/AbortController v))
+                   (and (exists? js/AbortSignal) (instance? js/AbortSignal v))
+                   ;; A DOM node exposes a numeric nodeType.
+                   (and (object? v) (number? (.-nodeType v))))
+         :clj  (or (instance? java.util.concurrent.Future v)
+                   (instance? java.lang.Thread v)))))
+
+(defn- walk-find-host-handle
+  "Walk `v` (maps / vectors / sets) and return the path to the first host
+  handle found, or nil. Bounded by the reply-map shape (replies are small
+  data); guards against cyclic refs are unnecessary for EDN data."
+  ([v] (walk-find-host-handle v []))
+  ([v path]
+   (cond
+     (host-handle? v) path
+     (map? v)         (some (fn [[k vv]] (walk-find-host-handle vv (conj path k))) v)
+     (vector? v)      (first (keep-indexed (fn [i vv] (walk-find-host-handle vv (conj path i))) v))
+     (set? v)         (some #(walk-find-host-handle % (conj path '*)) v)
+     :else            nil)))
+
+(defn validate-reply
+  "Validate a reply map against the Managed-Effects reply-map contract.
+  Returns nil when valid, else a vector of problem maps. Checks:
+
+    - `:status` present and in the CLOSED `statuses` set;
+    - per-status value/error conventions:
+        `:ok`        — `:value` present, `:error` absent;
+        `:partial`   — `:value` present AND `:error` present (with a
+                       family `:kind` when `:error` is a map);
+        `:error`     — `:error` present (with a family `:kind` when a map);
+        `:cancelled` — `:cancel/reason` present;
+        `:stale`     — `:stale? true` AND `:stale/reason` present;
+    - `:work/status` (when present) in the `work-statuses` set;
+    - the data-only invariant: no host handles anywhere in the map.
+
+  Pure; throws only on a non-map argument."
+  [reply]
+  (when-not (map? reply)
+    (throw (ex-info "Reply must be a map." {:rf.error/kind :rf.reply/non-map-reply :reply reply})))
+  (let [{:keys [status value error]} reply
+        problem (fn [kind path detail] {:rf.reply/problem kind :path path :detail detail})
+        kind-ok? (fn [e] (or (not (map? e)) (some? (:kind e))))
+        ps (cond-> []
+             (not (contains? reply :status))
+             (conj (problem :rf.reply/missing-status [:status] nil))
+
+             (and (contains? reply :status) (not (contains? statuses status)))
+             (conj (problem :rf.reply/invalid-status [:status] status))
+
+             ;; :ok — value present, error absent.
+             (and (= status :ok) (not (contains? reply :value)))
+             (conj (problem :rf.reply/ok-missing-value [:value] nil))
+             (and (= status :ok) (some? error))
+             (conj (problem :rf.reply/ok-has-error [:error] error))
+
+             ;; :partial — both value and error present; error carries a family :kind.
+             (and (= status :partial) (not (contains? reply :value)))
+             (conj (problem :rf.reply/partial-missing-value [:value] nil))
+             (and (= status :partial) (nil? error))
+             (conj (problem :rf.reply/partial-missing-error [:error] nil))
+             (and (= status :partial) (some? error) (not (kind-ok? error)))
+             (conj (problem :rf.reply/error-missing-kind [:error :kind] error))
+
+             ;; :error — error present, carries a family :kind.
+             (and (= status :error) (nil? error))
+             (conj (problem :rf.reply/error-missing-error [:error] nil))
+             (and (= status :error) (some? error) (not (kind-ok? error)))
+             (conj (problem :rf.reply/error-missing-kind [:error :kind] error))
+
+             ;; :cancelled — :cancel/reason present.
+             (and (= status :cancelled) (nil? (:cancel/reason reply)))
+             (conj (problem :rf.reply/cancelled-missing-reason [:cancel/reason] nil))
+
+             ;; :stale — :stale? true and :stale/reason present; MUST NOT carry :value.
+             (and (= status :stale) (not (true? (:stale? reply))))
+             (conj (problem :rf.reply/stale-missing-flag [:stale?] (:stale? reply)))
+             (and (= status :stale) (nil? (:stale/reason reply)))
+             (conj (problem :rf.reply/stale-missing-reason [:stale/reason] nil))
+             (and (= status :stale) (contains? reply :value))
+             (conj (problem :rf.reply/stale-has-value [:value] value))
+
+             ;; :work/status closed vocabulary.
+             (and (contains? reply :work/status)
+                  (not (contains? work-statuses (:work/status reply))))
+             (conj (problem :rf.reply/invalid-work-status [:work/status] (:work/status reply))))
+        ;; Data-only invariant — no host handles anywhere.
+        handle-path (walk-find-host-handle reply)
+        ps (cond-> ps
+             (some? handle-path)
+             (conj (problem :rf.reply/host-handle handle-path :host-handle)))]
+    (when (seq ps) (vec ps))))
+
+(defn valid-reply?
+  "Boolean sugar over `validate-reply`."
+  [reply]
+  (nil? (validate-reply reply)))
+
+;; ---------------------------------------------------------------------------
+;; Data-only trace summaries (Managed-Effects §Tracing). Every wire-bearing
+;; slot (`:value`, `:error`, `:correlation`, `:meta`) routes through the
+;; shared `re-frame.elision/elide-wire-value` walker — never a family-private
+;; elider — so privacy (`:sensitive?`) and size (`:large?`) elision compose
+;; uniformly with the rest of the trace stream. The summary keeps the
+;; data-only correlation facts verbatim (work id, frame, status, timestamps)
+;; and elides only the user-data slots.
+;; ---------------------------------------------------------------------------
+
+(def ^:private wire-slots
+  "Reply-map slots that carry user/wire data and so must be elided for trace
+  egress. Identity facts (work id, frame, status, timestamps, cancellation /
+  staleness reasons) are framework data and ride verbatim."
+  [:value :error :correlation :meta])
+
+(defn trace-summary
+  "Build a DATA-ONLY trace summary of `reply` for a managed-async trace row.
+
+  Identity / correlation facts (`:status`, `:work/id`, `:work/kind`,
+  `:work/status`, `:attempt`, `:rf.frame/id`, the durable timestamps, the
+  cancellation / staleness facts) ride verbatim. The wire-bearing slots
+  (`:value`, `:error`, `:correlation`, `:meta`) route through the single
+  shared `elide-wire-value` walker so `:sensitive?` / `:large?` compose
+  exactly as elsewhere — no family-private elision.
+
+  `opts` is forwarded to `elide-wire-value` (e.g. `:frame`, size-threshold
+  overrides); the carried-frame default applies when omitted. Returns a map
+  safe to place under a trace event's `:tags`."
+  ([reply] (trace-summary reply nil))
+  ([reply opts]
+   (reduce (fn [m slot]
+             (if (contains? m slot)
+               (update m slot #(elision/elide-wire-value % opts))
+               m))
+           reply
+           wire-slots)))
+
+;; ---------------------------------------------------------------------------
+;; Stale suppression — THE correctness boundary (Managed-Effects §Stale
+;; suppression). A family supplies the CARRIED correlation (captured at
+;; issuance, riding the reply token) and the CURRENT correlation (read from
+;; live frame-state at completion). When they diverge the app target MUST NOT
+;; run: this helper produces the `:status :stale` reply + the trace facts and
+;; signals non-delivery. Cancellation is only an optimization; suppression is
+;; the safety rule.
+;; ---------------------------------------------------------------------------
+
+(defn stale?
+  "Pure correlation-gate check. Returns true when `carried` does NOT match
+  `current` (the work was superseded), so its app reply must be suppressed.
+
+  `carried` and `current` are the data-only gate maps a family validates
+  (e.g. `{:work/id ... :generation ...}`, `{:route/nav-token ...}`,
+  `{:rf/after-epoch ... :path ...}`). Both nil ⇒ not stale (no gate ⇒
+  nothing to supersede). Matching is by value equality over the carried
+  keys: every key present in `carried` must equal its counterpart in
+  `current`. Extra keys in `current` are ignored (the family decides the
+  gate's key set; `current` may carry more facts than the gate checks)."
+  [carried current]
+  (cond
+    (nil? carried) false
+    (nil? current) true
+    :else (not (every? (fn [[k v]] (= v (get current k))) carried))))
+
+(defn suppress
+  "Produce the stale-suppression outcome for a superseded completion WITHOUT
+  dispatching the app target. This is the correctness boundary made
+  concrete: the returned `:reply` is `:status :stale` (no `:value`, no app
+  mutation), and `:deliver?` is `false` (unless the target explicitly opted
+  into stale delivery via `:dispatch-stale?` — restricted to framework test
+  / tool targets).
+
+  Arguments:
+    `target`  — the (optionally normalized) reply target; consulted only for
+                its `:dispatch-stale?` opt-in.
+    `carried` — the data-only correlation captured at issuance.
+    `current` — the data-only correlation read from live frame-state now.
+    `extra`   — optional reply fields to carry verbatim (`:work/id`,
+                `:work/kind`, `:rf.frame/id`, `:completed-at`, `:meta`, …);
+                `:stale/reason` defaults to `:rf.reply/correlation-mismatch`
+                when not supplied.
+
+  Returns:
+    {:deliver? <bool>           ;; false ⇒ DO NOT dispatch the app target
+     :reply    <stale reply>    ;; :status :stale, data-only, app-state-safe
+     :work/status :suppressed   ;; the ledger terminal for a stale completion
+     :trace    <data-only trace facts carrying CARRIED + CURRENT>}
+
+  The caller's contract: when `:deliver?` is false it MUST NOT run the app
+  reply target, MUST mark any ledger row `:suppressed`, and SHOULD emit the
+  `:trace` facts onto the trace bus (routing wire slots through
+  `trace-summary` / `elide-wire-value`). The stale reply MUST NOT produce
+  any user-visible app-db / runtime-db mutation beyond framework-owned
+  ledger / trace bookkeeping."
+  ([target carried current] (suppress target carried current nil))
+  ([target carried current extra]
+   (let [reason   (or (:stale/reason extra) :rf.reply/correlation-mismatch)
+         d        (when target (normalize-target target))
+         opt-in?  (true? (:dispatch-stale? d))
+         carry    (dissoc extra :stale/reason)
+         reply    (merge {:status       :stale
+                          :stale?       true
+                          :stale/reason reason
+                          :work/status  :suppressed}
+                         carry)]
+     {:deliver?    opt-in?
+      :reply       reply
+      :work/status :suppressed
+      :trace       {:rf.reply/suppressed?  true
+                    :stale/reason          reason
+                    :work/id               (:work/id reply)
+                    :rf.reply/carried      carried
+                    :rf.reply/current      current}})))

--- a/implementation/core/test/re_frame/reply_test.cljc
+++ b/implementation/core/test/re_frame/reply_test.cljc
@@ -1,0 +1,319 @@
+(ns re-frame.reply-test
+  "Conformance for the EP-0011 uniform-reply-envelope substrate
+  (`re-frame.reply`). Pins the three conformance groups EP-0011
+  §Validation requires of the shared substrate slice:
+
+    1. reply-map SCHEMA — exactly one valid `:status`; the per-status
+       value/error conventions incl `:partial` (usable value AND
+       structured error); the data-only invariant (NO host handles).
+    2. functor LAWS for reply-target mapping — identity + composition,
+       plus the naturality law `(complete (map-target f t) r) ==
+       (f (complete t r))`, and the proof that mapping changes ONLY the
+       completed event (not work id / status / cancellation / stale /
+       tracing).
+    3. STALE SUPPRESSION — the helper suppresses the app target (does NOT
+       deliver) AND records the suppressed ledger/trace outcome carrying
+       the carried + current correlation.
+
+  Canonical contract: `spec/Managed-Effects.md` §The uniform reply
+  envelope. Pure substrate — no runtime fixture needed."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.reply :as reply]))
+
+;; ---------------------------------------------------------------------------
+;; Group 1 — reply-map schema.
+;; ---------------------------------------------------------------------------
+
+(deftest closed-status-vocabulary
+  (testing "exactly the five statuses are valid"
+    (is (= #{:ok :partial :error :cancelled :stale} reply/statuses)))
+  (testing "a reply with no :status is invalid"
+    (is (some #(= :rf.reply/missing-status (:rf.reply/problem %))
+              (reply/validate-reply {:value 1}))))
+  (testing "a reply with an out-of-vocabulary :status is invalid"
+    (is (some #(= :rf.reply/invalid-status (:rf.reply/problem %))
+              (reply/validate-reply {:status :done :value 1}))))
+  (testing "exactly one valid :status passes"
+    (is (reply/valid-reply? {:status :ok :value {:title "Welcome"}}))))
+
+(deftest ok-conventions
+  (testing ":ok requires :value and forbids :error"
+    (is (reply/valid-reply? {:status :ok :value 42}))
+    (is (some #(= :rf.reply/ok-missing-value (:rf.reply/problem %))
+              (reply/validate-reply {:status :ok})))
+    (is (some #(= :rf.reply/ok-has-error (:rf.reply/problem %))
+              (reply/validate-reply {:status :ok :value 1 :error {:kind :x}})))))
+
+(deftest error-conventions
+  (testing ":error requires :error with a family :kind"
+    (is (reply/valid-reply? {:status :error :error {:kind :rf.http/http-5xx}}))
+    (is (some #(= :rf.reply/error-missing-error (:rf.reply/problem %))
+              (reply/validate-reply {:status :error})))
+    (is (some #(= :rf.reply/error-missing-kind (:rf.reply/problem %))
+              (reply/validate-reply {:status :error :error {:no :kind}})))))
+
+(deftest partial-conventions
+  (testing ":partial carries BOTH usable :value AND structured :error with a family :kind"
+    (is (reply/valid-reply?
+          {:status :partial
+           :value  {:user {:name "Ada"}}
+           :error  {:kind :rf.graphql/partial-success
+                    :errors [{:message "field x denied"}]}}))
+    (is (some #(= :rf.reply/partial-missing-value (:rf.reply/problem %))
+              (reply/validate-reply {:status :partial :error {:kind :x}})))
+    (is (some #(= :rf.reply/partial-missing-error (:rf.reply/problem %))
+              (reply/validate-reply {:status :partial :value 1})))
+    (is (some #(= :rf.reply/error-missing-kind (:rf.reply/problem %))
+              (reply/validate-reply {:status :partial :value 1 :error {:no :kind}})))))
+
+(deftest cancelled-conventions
+  (testing ":cancelled requires :cancel/reason; :error MAY carry compatibility data"
+    (is (reply/valid-reply? {:status :cancelled :cancel/reason :user}))
+    (is (reply/valid-reply? {:status        :cancelled
+                             :cancel/reason :actor-destroyed
+                             :cancelled?    true
+                             :error         {:kind :rf.http/aborted :reason :actor-destroyed}}))
+    (is (some #(= :rf.reply/cancelled-missing-reason (:rf.reply/problem %))
+              (reply/validate-reply {:status :cancelled})))))
+
+(deftest stale-conventions
+  (testing ":stale requires :stale? true + :stale/reason and carries NO :value"
+    (is (reply/valid-reply? {:status :stale :stale? true :stale/reason :generation-mismatch}))
+    (is (some #(= :rf.reply/stale-missing-flag (:rf.reply/problem %))
+              (reply/validate-reply {:status :stale :stale/reason :x})))
+    (is (some #(= :rf.reply/stale-missing-reason (:rf.reply/problem %))
+              (reply/validate-reply {:status :stale :stale? true})))
+    (is (some #(= :rf.reply/stale-has-value (:rf.reply/problem %))
+              (reply/validate-reply {:status :stale :stale? true :stale/reason :x :value 1}))
+        "a stale reply MUST NOT mutate app state — carrying :value would invite it")))
+
+(deftest work-status-vocabulary
+  (testing ":work/status, when present, is in the closed operational set"
+    (is (reply/valid-reply? {:status :error :error {:kind :rf.http/timeout} :work/status :timed-out}))
+    (is (some #(= :rf.reply/invalid-work-status (:rf.reply/problem %))
+              (reply/validate-reply {:status :ok :value 1 :work/status :weird})))))
+
+(deftest data-only-invariant-no-host-handles
+  (testing "a fn anywhere in the reply is a host handle"
+    (is (some #(= :rf.reply/host-handle (:rf.reply/problem %))
+              (reply/validate-reply {:status :ok :value (fn [] 1)})))
+    (is (some #(= :rf.reply/host-handle (:rf.reply/problem %))
+              (reply/validate-reply {:status :ok :value {:a {:b (fn [] 1)}}}))
+        "host handles are found at any depth")
+    (let [probs (reply/validate-reply {:status :ok :value {:a {:cb (fn [] 1)}}})
+          path  (some #(when (= :rf.reply/host-handle (:rf.reply/problem %)) (:path %)) probs)]
+      (is (= [:value :a :cb] path) "the problem reports the exact path to the handle")))
+  (testing "a plain-data reply has no host-handle problem"
+    (is (reply/valid-reply?
+          {:status       :ok
+           :value        {:title "Welcome"}
+           :work/id      [:rf.work/http :article/by-id 42 1]
+           :work/kind    :http
+           :work/status  :completed
+           :attempt      1
+           :rf.frame/id  :app/main
+           :started-at   1781078400123
+           :completed-at 1781078400456
+           :correlation  {:request-id [:article/by-id 42]}}))))
+
+;; ---------------------------------------------------------------------------
+;; Group 1b — target normalization.
+;; ---------------------------------------------------------------------------
+
+(deftest target-normalization
+  (testing "the public short form normalizes to a :delivery :append descriptor"
+    (is (= {:event [:article/load-replied {:id 42}] :delivery :append}
+           (reply/normalize-target [:article/load-replied {:id 42}]))))
+  (testing "the descriptor form defaults :delivery to :append"
+    (is (= :append (:delivery (reply/normalize-target
+                                {:event [:x] :suppress {:generation 1}})))))
+  (testing "normalization is idempotent and preserves gate fields"
+    (let [d (reply/normalize-target {:event [:x] :delivery :append
+                                     :suppress {:route/nav-token "nav-7"}
+                                     :dispatch-stale? true})]
+      (is (= d (reply/normalize-target d)))))
+  (testing "short-form projection round-trips a plain target"
+    (is (= [:x 1] (reply/target->short-form [:x 1])))
+    (is (= [:x 1] (reply/target->short-form {:event [:x 1] :delivery :append}))))
+  (testing "short-form projection keeps the descriptor when gates are present"
+    (is (map? (reply/target->short-form {:event [:x] :suppress {:g 1}}))))
+  (testing "nil target ⇒ nil (no continuation)"
+    (is (nil? (reply/normalize-target nil)))))
+
+;; ---------------------------------------------------------------------------
+;; Group 1c — completion appends the reply as the final arg.
+;; ---------------------------------------------------------------------------
+
+(deftest completion-appends-reply
+  (let [reply {:status :ok :value {:title "Welcome"}
+               :work/id [:rf.work/http :article/by-id 42 1]
+               :completed-at 1781078400456}]
+    (testing "the reply map is appended as the final event argument"
+      (is (= [:article/load-replied {:id 42} reply]
+             (reply/complete [:article/load-replied {:id 42}] reply))))
+    (testing "completion works through the descriptor form too"
+      (is (= [:article/load-replied {:id 42} reply]
+             (reply/complete {:event [:article/load-replied {:id 42}] :delivery :append} reply))))
+    (testing "nil target ⇒ nil (no delivery)"
+      (is (nil? (reply/complete nil reply))))))
+
+;; ---------------------------------------------------------------------------
+;; Group 2 — the functor laws for reply-target mapping.
+;; ---------------------------------------------------------------------------
+
+(def ^:private target {:event [:article/replied {:id 42}] :delivery :append})
+
+(def ^:private a-reply
+  {:status  :ok
+   :value   {:article {:id 42 :title "Welcome"}}
+   :work/id [:rf.work/http :article/by-id 42 1]})
+
+(defn- select-article-event
+  "An event-transform: rewrite the appended reply's :value to its :article.
+  Preserves the appended-reply event shape, so it composes in any order."
+  [event]
+  (let [r (peek event)]
+    (conj (pop event) (update r :value :article))))
+
+(defn- retarget-event-id
+  "An event-transform: rename the event id (the head of the event vector),
+  leaving the appended reply map untouched. Preserves the appended-reply
+  event shape, so it composes with `select-article-event` in any order."
+  [event]
+  (assoc event 0 :parent/relay))
+
+(defn- wrap-in-parent
+  "An event-transform that relocates the continuation onto a parent event.
+  Used for the naturality law (where it is applied once on both sides)."
+  [event]
+  [:parent/relay event])
+
+(deftest functor-identity-law
+  (testing "(map-target identity target) completes identically to target — identity law"
+    (is (= (reply/complete target a-reply)
+           (reply/complete (reply/map-target identity target) a-reply)))))
+
+(deftest functor-naturality-law
+  (testing "(complete (map-target f t) r) == (f (complete t r)) — the mapping law"
+    (is (= (reply/complete (reply/map-target select-article-event target) a-reply)
+           (select-article-event (reply/complete target a-reply))))
+    (is (= (reply/complete (reply/map-target wrap-in-parent target) a-reply)
+           (wrap-in-parent (reply/complete target a-reply))))))
+
+(deftest functor-composition-law
+  (testing "(map-target f (map-target g t)) == (map-target (comp f g) t) — composition law"
+    ;; Both transforms preserve the appended-reply event shape, so they
+    ;; compose in either order — exercising composition both ways.
+    (let [f select-article-event
+          g retarget-event-id]
+      (is (= (reply/complete (reply/map-target f (reply/map-target g target)) a-reply)
+             (reply/complete (reply/map-target (comp f g) target) a-reply)))
+      (is (= (reply/complete (reply/map-target g (reply/map-target f target)) a-reply)
+             (reply/complete (reply/map-target (comp g f) target) a-reply)))
+      ;; And the composed result is the expected event: renamed id + selected value.
+      (is (= [:parent/relay {:id 42} {:status :ok :value {:id 42 :title "Welcome"}
+                                      :work/id [:rf.work/http :article/by-id 42 1]}]
+             (reply/complete (reply/map-target (comp f g) target) a-reply))))))
+
+(deftest mapping-changes-only-the-event
+  (testing "mapping the target does NOT change the reply's work id / status / correlation"
+    (let [mapped    (reply/map-target select-article-event target)
+          completed (reply/complete mapped a-reply)
+          delivered (peek completed)]
+      ;; The COMPLETED EVENT changed (value→article); the reply's identity facts did not.
+      (is (= [:rf.work/http :article/by-id 42 1] (:work/id delivered)))
+      (is (= :ok (:status delivered)))
+      ;; And issuance/correlation are unaffected — `map-target` stores no work-id /
+      ;; status / suppression on the target (the functor law's structural guarantee):
+      ;; the only difference between mapped and unmapped completion is the event payload.
+      (is (= {:article {:id 42 :title "Welcome"}}
+             (:value (peek (reply/complete target a-reply)))))
+      (is (= {:id 42 :title "Welcome"}
+             (:value (peek completed)))))))
+
+;; ---------------------------------------------------------------------------
+;; Group 3 — stale suppression: the correctness boundary.
+;; ---------------------------------------------------------------------------
+
+(deftest stale-gate-check
+  (testing "matching correlation ⇒ not stale; superseded ⇒ stale"
+    (is (false? (reply/stale? {:generation 4} {:generation 4})))
+    (is (true?  (reply/stale? {:generation 4} {:generation 5})))
+    (is (false? (reply/stale? {:work/id :w :generation 4}
+                              {:work/id :w :generation 4 :extra :ignored}))
+        "extra current keys are ignored — the carried gate's key set governs")
+    (is (false? (reply/stale? nil nil)) "no gate ⇒ nothing to supersede")
+    (is (true?  (reply/stale? {:generation 4} nil)) "current gone ⇒ stale")))
+
+(deftest suppress-does-not-deliver-app-target
+  (testing "suppression produces :status :stale, marks :suppressed, and does NOT deliver"
+    (let [carried {:work/id [:rf.work/resource [:a/k] 4] :generation 4}
+          current {:work/id [:rf.work/resource [:a/k] 5] :generation 5}
+          {:keys [deliver? reply] :as out}
+          (reply/suppress [:article/route-replied {:slug "welcome"}] carried current
+                          {:work/id      (:work/id carried)
+                           :work/kind    :resource
+                           :rf.frame/id  :app/main
+                           :stale/reason :resource/generation-mismatch})]
+      (is (false? deliver?) "the app reply target MUST NOT run")
+      (is (= :stale (:status reply)))
+      (is (true? (:stale? reply)))
+      (is (= :resource/generation-mismatch (:stale/reason reply)))
+      (is (= :suppressed (:work/status reply)) "ledger terminal for a stale completion")
+      (is (= :suppressed (:work/status out)))
+      (is (not (contains? reply :value)) "a stale reply carries NO value — no app-state mutation"))))
+
+(deftest suppress-records-carried-and-current-trace-facts
+  (testing "the trace facts carry BOTH the carried and current correlation"
+    (let [carried {:route/nav-token "nav-1"}
+          current {:route/nav-token "nav-2"}
+          {:keys [trace]} (reply/suppress [:x] carried current
+                                          {:stale/reason :route/nav-token-mismatch})]
+      (is (true? (:rf.reply/suppressed? trace)))
+      (is (= :route/nav-token-mismatch (:stale/reason trace)))
+      (is (= carried (:rf.reply/carried trace)))
+      (is (= current (:rf.reply/current trace))))))
+
+(deftest suppress-default-reason
+  (testing "a default :stale/reason is supplied when the family does not name one"
+    (is (= :rf.reply/correlation-mismatch
+           (:stale/reason (:reply (reply/suppress [:x] {:g 1} {:g 2})))))))
+
+(deftest suppress-dispatch-stale-opt-in
+  (testing "framework test/tool targets MAY opt into stale delivery via :dispatch-stale?"
+    (is (false? (:deliver? (reply/suppress {:event [:x]} {:g 1} {:g 2}))))
+    (is (true?  (:deliver? (reply/suppress {:event [:x] :dispatch-stale? true} {:g 1} {:g 2})))
+        "the explicit framework-only opt-in lets a test/tool target receive the stale envelope")))
+
+;; ---------------------------------------------------------------------------
+;; Group 4 — data-only trace summaries route through the shared elision walker.
+;; ---------------------------------------------------------------------------
+
+(deftest trace-summary-keeps-identity-facts-elides-wire-slots
+  (testing "identity facts ride verbatim; wire slots route through elide-wire-value"
+    ;; Frameless egress: opt into the identity walk so we exercise the wiring
+    ;; deterministically (the carried-frame policy is tested in framed suites).
+    (let [reply {:status       :ok
+                 :value        {:title "Welcome"}
+                 :error        nil
+                 :work/id      [:rf.work/http :article/by-id 42 1]
+                 :work/kind    :http
+                 :rf.frame/id  :app/main
+                 :completed-at 1781078400456
+                 :correlation  {:request-id [:article/by-id 42]}}
+          summary (reply/trace-summary reply {:rf.size/include-sensitive? true})]
+      (is (= :ok (:status summary)))
+      (is (= [:rf.work/http :article/by-id 42 1] (:work/id summary)))
+      (is (= :http (:work/kind summary)))
+      (is (= :app/main (:rf.frame/id summary)))
+      (is (= 1781078400456 (:completed-at summary)))
+      ;; With the identity opt-out the wire slots survive verbatim (no marks
+      ;; declared), proving the slots were WALKED through elide-wire-value
+      ;; rather than copied raw or dropped.
+      (is (= {:title "Welcome"} (:value summary)))
+      (is (= {:request-id [:article/by-id 42]} (:correlation summary)))))
+  (testing "frameless egress with no opt-out FAILS CLOSED — wire slots redact"
+    (let [summary (reply/trace-summary {:status :ok :value {:secret "x"}})]
+      (is (= :ok (:status summary)) "identity facts still ride verbatim")
+      (is (= :rf/redacted (:value summary))
+          "the shared walker fails closed when no frame policy is reachable"))))

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2404,6 +2404,78 @@ The Resources artefact owns three runtime-db children — `:rf.runtime/resources
 
 `:rf/scoped-resource-key`, `:rf/resource-entry`, and `:rf/resource-work-record` are the schema ids for `ScopedResourceKey`, `ResourceEntry`, and `ResourceWorkRecord`. The `:error` / `:refresh-error` entry envelopes (and a failed work record's `:outcome`) carry the closed `:rf.http/*` failure-map shapes owned by [014-HTTPRequests.md](014-HTTPRequests.md). When the Resources artefact is loaded, `:rf.runtime/resources` (`ResourcesRuntime`) and `:rf.runtime/work-ledger` (`WorkLedger`) are present as additional runtime-db children alongside the four v1 subsystems; when the app also registers a mutation, `:rf.runtime/mutations` (`MutationsRuntime`, the mutation-instance rows, rf2-dwme29) joins them.
 
+### `:rf/reply-map`, `:rf/reply-target` (uniform reply envelope, EP-0011)
+
+> **Layer:** Runtime
+> **Owner:** [Managed-Effects §The uniform reply envelope](Managed-Effects.md#the-uniform-reply-envelope)
+> **Status:** v1-required
+> **Conformance:** `implementation/core/test/re_frame/reply_test.cljc` (the `re-frame.reply` substrate — schema validity, the functor laws, and stale suppression)
+
+The canonical shape every managed *async* surface — HTTP ([014](014-HTTPRequests.md)), resources + mutations ([016](016-Resources.md)), machine async work ([005](005-StateMachines.md)), route loaders ([012](012-Routing.md)), and any future managed timer / background-job surface — completes through ([EP-0011](../docs/EP/EP-0011-uniform-async-reply-envelope.md) is the rationale record). One standard **reply map** delivered to one standard **reply target**. The shared `re-frame.reply` substrate (`implementation/core`) realises the pure core: target normalization, completion (append per `:delivery`), the reply-mapping functor law, this schema's validation, and the stale-suppression helper. The reply map is **data only** — it MUST NOT carry functions, promises, `AbortController`s, timer handles, DOM nodes, or any host resource (those live in a host-transient side-table keyed by `[frame-id work-id]`, never in durable reply data).
+
+```clojure
+(def ReplyStatus
+  ;; The CLOSED reply status taxonomy (Managed-Effects §Status taxonomy).
+  ;; Exactly ONE of these is a reply's :status. Timeout is NOT here — it is
+  ;; an :error status + a :timed-out work status. Stale wins over the
+  ;; natural completion status for delivery purposes.
+  [:enum :ok :partial :error :cancelled :stale])
+
+(def ReplyWorkStatus
+  ;; The operational :work/status on a reply map — narrower / more
+  ;; operational than the reply :status. :suppressed is the stale terminal;
+  ;; :timed-out is an error work-status. Mirrors the ledger row's terminal
+  ;; statuses (WorkLedger above), minus the non-terminal :queued/:running.
+  [:enum :completed :failed :timed-out :suppressed :cancelled])
+
+(def ReplyMap
+  ;; The data delivered when managed async work completes. CLOSED on :status
+  ;; (the only always-required field); the per-status value/error conventions
+  ;; are enforced by `re-frame.reply/validate-reply` (a closed-Malli :map
+  ;; cannot express the cross-field conditionals, so the contract lives in
+  ;; the validator and is pinned by reply_test.cljc). Open map otherwise per
+  ;; the catalogue convention — families add :meta and family-specific facts
+  ;; additively. NO HOST HANDLES anywhere in the map (the data-only
+  ;; invariant). Per [Managed-Effects §The reply map].
+  [:map
+   [:status        ReplyStatus]                              ;; ALWAYS required
+   [:value         {:optional true} :any]                    ;; present for :ok / :partial; absent for :stale
+   [:error         {:optional true} :any]                    ;; present for :error / :partial (with a family :kind); MAY carry compat data for :cancelled
+   [:work/id       {:optional true} :any]                    ;; required for ledger-backed work; =-comparable EDN attempt identity
+   [:work/kind     {:optional true} :keyword]                ;; :http / :resource / :mutation / :timer / :route / :machine / …
+   [:work/status   {:optional true} ReplyWorkStatus]
+   [:attempt       {:optional true} [:maybe :int]]
+   [:rf.frame/id   {:optional true} :any]                    ;; required when frame-scoped — the canonical carried frame stamp (EP-0002)
+   [:started-at    {:optional true} [:maybe :int]]           ;; EP-0010 causal epoch-ms — NOT a fresh ambient read
+   [:completed-at  {:optional true} [:maybe :int]]
+   [:deadline-at   {:optional true} [:maybe :int]]
+   [:correlation   {:optional true} :map]                    ;; data-only correlation metadata (request-id, scope, generation, owner, …)
+   [:stale?        {:optional true} :boolean]
+   [:stale/reason  {:optional true} [:maybe :keyword]]
+   [:cancelled?    {:optional true} :boolean]
+   [:cancel/reason {:optional true} [:maybe :keyword]]
+   [:trace         {:optional true} :any]                    ;; data-only trace summary (wire slots elided via rf/elide-wire-value)
+   [:meta          {:optional true} :any]])                  ;; effect-family data
+
+(def ReplyTarget
+  ;; Where a completion is dispatched. The public short form is an
+  ;; event-vector prefix; the descriptor form is for framework internals
+  ;; and future public surfaces needing explicit delivery options. The
+  ;; runtime appends the reply map as the final event argument on :append
+  ;; (the only public delivery mode). :suppress carries data-only stale
+  ;; gates; :dispatch-stale? (framework test/tool targets only) opts into
+  ;; receiving stale envelopes. Per [Managed-Effects §The reply target].
+  [:or
+   [:vector :any]                                            ;; short form: an event-vector prefix [:event-id arg …]
+   [:map
+    [:event           [:vector :any]]                        ;; the event-vector prefix to complete
+    [:delivery        {:optional true} [:enum :append]]      ;; :append is the only PUBLIC delivery mode
+    [:suppress        {:optional true} :map]                 ;; data-only gates that must still match before delivery
+    [:dispatch-stale? {:optional true} :boolean]]])          ;; framework test/tool opt-in to stale delivery; app targets MUST NOT set it
+```
+
+`:rf/reply-map` and `:rf/reply-target` are the schema ids for `ReplyMap` and `ReplyTarget`. The closed `:status` taxonomy, the value/error conventions per status (`:value` on `:ok`/`:partial`; `:error` with a family `:kind` on `:error`/`:partial`; `:cancel/reason` on `:cancelled`; `:stale? true` + `:stale/reason` and no `:value` on `:stale`), the `:work/id` correlation rule (one attempt has one work id — no `:stale-key` synonym, per [EP-0007](../docs/EP/EP-0007-one-name-per-fact.md)), and the data-only invariant are all owned normatively by [Managed-Effects §The uniform reply envelope](Managed-Effects.md#the-uniform-reply-envelope); this catalogue carries the shape. The `:error` envelope on a `:status :error`/`:partial` reply carries the closed `:rf.http/*` (or family-specific) failure-map shapes owned by the per-family spec. A `:status :stale` reply's `:work/status` is `:suppressed` and the linked `WorkLedger` row (above) reaches `:suppressed` — the reply target and a ledger row are the same fact, the ledger's `:reply-to` being this target made durable.
+
 <a id="rfelision-registry"></a>
 
 <!-- legacy anchor — points readers at the new :rf/runtime-db schema above for the elision sub-container. -->


### PR DESCRIPTION
First slice of the EP-0011 chain (rf2-zqefg3.1): the shared, host-handle-free **reply substrate** every later managed-async family slice lowers its completion onto. Canonical contract: `spec/Managed-Effects.md` §The uniform reply envelope; EP-0011 is the rationale record.

## What landed

**Internal `re-frame.reply` namespace** (`implementation/core` — pure helpers, no host handles, no runtime state; NOT a `re-frame.core` facade export):
- **Target normalization** — vector-prefix `[:event arg…]` ↔ descriptor `{:event … :delivery :append :suppress … :dispatch-stale? …}`; idempotent; short-form projection round-trips a plain target.
- **Completion** — `complete` appends the reply map as the final event argument per `:delivery :append` (the only public mode).
- **Reply-target mapping (the functor)** — `map-target` composes a pure event→event transform that `complete` applies after appending. Mapping changes **only the completed event** — never issuance, `:work/id`, status, cancellation, stale checks, or tracing (none live on the target, so the law holds structurally). Identity + composition + naturality.
- **Reply-map schema validation** — `validate-reply` enforces the closed `:status` enum `{:ok :partial :error :cancelled :stale}`, the per-status value/error conventions (incl `:partial` = usable `:value` AND structured `:error` with a family `:kind`), the `:work/status` operational vocabulary, and the **data-only invariant** (no host handles at any depth, with the exact path reported).
- **Data-only trace summaries** — `trace-summary` keeps identity/correlation facts verbatim and routes wire-bearing slots (`:value`/`:error`/`:correlation`/`:meta`) through the single shared `re-frame.elision/elide-wire-value` walker — never a family-private elider.
- **Stale-suppression helper** — `stale?` (pure carried-vs-current gate) + `suppress` (the correctness boundary): on mismatch produces a `:status :stale`/`:suppressed` reply carrying **no `:value`** and `:deliver? false` (so the caller MUST NOT dispatch the app target), plus trace facts carrying both the carried and current correlation. `:dispatch-stale?` opt-in is restricted to framework test/tool targets.

**Schema registration** — `:rf/reply-map` + `:rf/reply-target` added to `spec/Spec-Schemas.md` (HOT-ZONE; sole toucher), owned normatively by Managed-Effects §The uniform reply envelope.

## Conformance (EP-0011 §Validation — `reply_test.cljc`, 20 tests / 75 assertions)
- **reply-map schema** — exactly one valid `:status`; ok/error/partial/cancelled/stale value-and-error conventions; no host handles (path-reported).
- **functor laws** — identity, composition (both orders), naturality `(complete (map-target f t) r) == (f (complete t r))`, and the proof that mapping changes only the event.
- **stale suppression** — suppresses the app target (`:deliver? false`), produces `:status :stale` with no value, marks `:suppressed`, and records carried+current trace facts; `:dispatch-stale?` framework opt-in.

## Quality gates
- `npm run test:cljs` (from `implementation/`) — **6420 tests / 23187 assertions, 0 failures / 0 errors** (includes the new `re-frame.reply-test`).
- `clojure -M:test -n re-frame.reply-test` (core) — **20 tests / 75 assertions, 0 failures / 0 errors**.
- `scripts/test-fast-pr.sh` — **PASS** (core JVM + CLJS + JS harness helpers + README/doc-slug/EP-status/runtime-subsystem markdown gates; mkdocs soft-skipped on Windows PATH).
- `mkdocs build --strict` — **PASS** (run manually; exit 0).
- `python scripts/check_doc_slugs.py` — **PASS** (exit 0).
- API-manifest drift-check — **OK: in sync (504 public vars)**. `re-frame.reply` is INTERNAL — not enumerated in the manifest allowlist, not a `re-frame.core` facade export; **no facade drift**.

## Fence
Touched only the new `re-frame.reply` ns, its test, and `spec/Spec-Schemas.md`. Read-only on `spec/Managed-Effects.md`. Did NOT touch 014/016/005/012 (later family slices own those) or `implementation/resources|http|machines|routing`.