### PR TITLE
feat(http): lower :rf.http/managed onto the uniform reply envelope (rf2-zqefg3.2)

### DIFF
--- a/implementation/http/src/re_frame/http_reply.cljc
+++ b/implementation/http/src/re_frame/http_reply.cljc
@@ -1,0 +1,269 @@
+(ns re-frame.http-reply
+  "Spec 014 — lower `:rf.http/managed` onto the uniform reply envelope
+  (EP-0011 §Managed HTTP Lowering / §Public Compatibility Sugar; the
+  canonical contract is `spec/Managed-Effects.md` §The uniform reply
+  envelope).
+
+  ## What this namespace is
+
+  The internal seam that turns a managed-HTTP completion into the ONE
+  canonical reply map every managed *async* family produces — and then
+  reshapes that canonical reply back into the PUBLIC Spec 014 event
+  payload, so `:on-success` / `:on-failure` and the co-located
+  `(:rf/reply msg)` merge stay valid sugar with the exact shapes Spec 014
+  promises. The public API does NOT change; the lowering is internal.
+
+  Three concerns:
+
+   1. **Work-id correlation** (`work-id`). One HTTP attempt has one
+      `:work/id` head `[:rf.work/http logical-id args... generation]`
+      (Managed-Effects §Work-id correlation). The HTTP `:request-id` is
+      NOT a second stale-suppression key — it rides as `:correlation`
+      metadata on the reply map. The frame-qualified transport
+      request-id `[:rf.req frame-id work-id]` (landed in Spec 016) is the
+      sanctioned second identity for process-global transport
+      correlation; `transport-request-id` builds it.
+
+   2. **Canonical reply map** (`success-reply` / `failure-reply` /
+      `aborted-reply`). The transport's success / failure / abort facts
+      become a single `re-frame.reply`-conformant reply map with one
+      closed `:status`, value-or-error, `:work/id`, `:work/kind :http`,
+      `:work/status`, `:attempt`, `:rf.frame/id`, `:completed-at` (read
+      ONCE from the host completion — never re-read in the reply
+      handler), and `:correlation {:request-id …}`. Timeout lowers to
+      `:status :error` + `:work/status :timed-out` (NOT a top-level
+      status); abort lowers to `:status :cancelled` with an
+      `:rf.http/aborted` `:error`.
+
+   3. **Public compatibility reshape** (`reply->public-payload`). The
+      inverse projection: the canonical reply map → the Spec 014
+      `{:kind :success :value v}` / `{:kind :failure :failure f}`
+      payload. This is the `:rf.http/compat-reply` body — it reshapes the
+      uniform reply back into the promised public event shape, so a
+      handler branching on `(:rf/reply msg)` or reading the appended
+      last-arg sees exactly what Spec 014 §Reply payload shape documents.
+
+  Pure — no atoms, no dispatch, no I/O. `:completed-at` is supplied by the
+  caller (the transport reads the host clock once at finalisation and
+  threads it in); this namespace never reads a clock. Trace summaries
+  route every wire-bearing slot through the shared
+  `re-frame.reply/trace-summary` (which calls `re-frame.elision/
+  elide-wire-value`) — never a family-private elider (Managed-Effects
+  §Tracing)."
+  (:require [re-frame.privacy :as privacy]
+            [re-frame.reply :as reply]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; Work-id correlation (Managed-Effects §Work-id correlation).
+;;
+;; HTTP head: `[:rf.work/http logical-id args... generation]`. The logical
+;; identity is the caller's `:request-id` when supplied (a stable, =-
+;; comparable handle the caller already chose for supersede/abort), else
+;; the originating event-id (the default reply target's identity). HTTP has
+;; no generation counter of its own — supersession is keyed on `:request-id`
+;; equality, not a monotonic generation — so the generation slot carries the
+;; attempt number, which is what discriminates retries of the same logical
+;; request. One ATTEMPT, one `:work/id` (the EP-0007 rule): attempt 1 and
+;; attempt 2 of the same request are distinct work ids.
+;; ---------------------------------------------------------------------------
+
+(defn work-id
+  "Build the HTTP work-id head for one attempt.
+
+  `[:rf.work/http logical-id attempt]` where `logical-id` is the caller's
+  `:request-id` (when non-nil) else the originating event-id. The trailing
+  `attempt` is the generation slot — HTTP discriminates retries by attempt
+  number, not a separate monotonic generation. `=`-comparable and EDN-
+  serializable (Managed-Effects §Work-id correlation)."
+  [{:keys [request-id origin-event attempt]}]
+  (let [logical-id (if (some? request-id) request-id (first origin-event))]
+    [:rf.work/http logical-id (or attempt 1)]))
+
+(defn transport-request-id
+  "Build the frame-qualified transport request-id `[:rf.req frame-id
+  work-id]` (Managed-Effects §Work-id correlation — the sanctioned second
+  identity for process-global transport-level in-flight correlation, landed
+  in Spec 016). The frame-local `:work/id` carries no frame id, so it is not
+  a safe process-global transport token on its own; this qualified form is.
+  Intra-frame stale suppression still keys on `:work/id`, not this."
+  [frame-id wid]
+  [:rf.req frame-id wid])
+
+;; ---------------------------------------------------------------------------
+;; Canonical reply map (Managed-Effects §The reply map / §Status taxonomy).
+;;
+;; The transport's success / failure / abort facts → one reply-map-
+;; conformant map. `:correlation` carries the HTTP `:request-id` as metadata
+;; (NOT a second stale key). `:completed-at` is supplied by the caller; this
+;; ns never reads a clock.
+;; ---------------------------------------------------------------------------
+
+(defn- base-reply
+  "The correlation/identity facts every HTTP reply carries, independent of
+  status. `:work/id`, `:work/kind :http`, `:attempt`, `:rf.frame/id`,
+  `:completed-at`, and `:correlation {:request-id …}`. Optional facts
+  (`:completed-at`, `:correlation`) are omitted when absent rather than
+  filled with nil sentinels (Managed-Effects §The reply map)."
+  [{:keys [request-id origin-event attempt frame completed-at] :as ctx}]
+  (let [wid (work-id ctx)]
+    (cond-> {:work/id     wid
+             :work/kind   :http
+             :attempt     (or attempt 1)}
+      (some? frame)        (assoc :rf.frame/id frame)
+      (some? completed-at) (assoc :completed-at completed-at)
+      ;; `:request-id` is correlation metadata, NOT a second stale key
+      ;; (EP-0007 / Managed-Effects §Work-id correlation). Carry it only
+      ;; when the caller supplied one.
+      (some? request-id)   (assoc :correlation {:request-id request-id}))))
+
+(defn success-reply
+  "Build the canonical `:status :ok` reply map for a successful HTTP
+  completion. `value` is the decoded-and-`:accept`-projected payload.
+  `:work/status :completed`."
+  [ctx value]
+  (assoc (base-reply ctx)
+         :status      :ok
+         :work/status :completed
+         :value       value))
+
+(defn- timed-out?
+  "A `:rf.http/timeout` failure lowers to `:work/status :timed-out` (NOT a
+  top-level reply status — timeout is an error KIND + a work status per
+  Managed-Effects §Status taxonomy)."
+  [failure]
+  (= :rf.http/timeout (:kind failure)))
+
+(defn failure-reply
+  "Build the canonical reply map for a failed HTTP completion. `failure` is
+  the closed-set `:rf.http/*` failure map the transport classified.
+
+  Status mapping (Managed-Effects §Status taxonomy):
+   - `:rf.http/aborted`  → `:status :cancelled` (see `aborted-reply` for the
+     dedicated builder; this fn handles it too for completeness);
+   - `:rf.http/timeout`  → `:status :error` + `:work/status :timed-out`
+     (timeout is NOT a top-level status);
+   - everything else     → `:status :error` + `:work/status :failed`.
+
+  The classified `:rf.http/*` failure map rides verbatim as `:error` (it
+  already carries the family `:kind` the reply-map contract requires)."
+  [ctx failure]
+  (let [aborted? (= :rf.http/aborted (:kind failure))]
+    (if aborted?
+      (assoc (base-reply ctx)
+             :status        :cancelled
+             :work/status   :cancelled
+             :cancelled?    true
+             :cancel/reason (:reason failure)
+             :error         failure)
+      (assoc (base-reply ctx)
+             :status      :error
+             :work/status (if (timed-out? failure) :timed-out :failed)
+             :error       failure))))
+
+(defn aborted-reply
+  "Build the canonical `:status :cancelled` reply map for a cancelled HTTP
+  request (Managed-Effects §Cancellation). `failure` is the
+  `:rf.http/aborted` shape (`:kind` / `:reason` / `:request-id` /
+  `:actor-id`). Carries `:cancelled? true`, `:cancel/reason`, and the
+  abort failure under `:error` (Managed-Effects: `:error` MAY carry
+  compatibility failure data for `:status :cancelled`). `:work/status
+  :cancelled`."
+  [ctx failure]
+  (assoc (base-reply ctx)
+         :status        :cancelled
+         :work/status   :cancelled
+         :cancelled?    true
+         :cancel/reason (:reason failure)
+         :error         failure))
+
+;; ---------------------------------------------------------------------------
+;; Public compatibility reshape (Managed-Effects §Public Compatibility
+;; Sugar; EP-0011 §Public Compatibility Sugar). The inverse projection:
+;; canonical reply map → the Spec 014 public reply payload. This is the
+;; `:rf.http/compat-reply` body — it preserves the public HTTP contract
+;; (Spec 014 §Reply payload shape) while the runtime / ledger / trace /
+;; cancellation / stale paths all see the same canonical reply map.
+;; ---------------------------------------------------------------------------
+
+(defn reply->public-payload
+  "Reshape a canonical HTTP reply map back into the PUBLIC Spec 014 reply
+  payload (`{:kind :success :value v}` or `{:kind :failure :failure f}`).
+
+  The compat layer that keeps `:on-success` / `:on-failure` and the
+  co-located `(:rf/reply msg)` merge spelling their documented shapes
+  (Spec 014 §Reply payload shape) even though the request lowered through
+  the uniform reply envelope internally:
+
+   - `:status :ok`        → `{:kind :success :value (:value reply)}`;
+   - `:status :error`     → `{:kind :failure :failure (:error reply)}`;
+   - `:status :cancelled` → `{:kind :failure :failure (:error reply)}`
+     (Spec 014 surfaces an abort as a `:rf.http/aborted` FAILURE reply);
+   - `:status :stale`     → nil (a suppressed reply is never delivered to
+     the app target — the caller MUST NOT dispatch it).
+
+  Pure projection over the canonical reply; the inverse of `success-reply`
+  / `failure-reply` / `aborted-reply` at the public boundary."
+  [reply]
+  (case (:status reply)
+    :ok        {:kind :success :value (:value reply)}
+    :error     {:kind :failure :failure (:error reply)}
+    :cancelled {:kind :failure :failure (:error reply)}
+    :stale     nil
+    ;; :partial is not emitted by plain managed HTTP (Managed-Effects
+    ;; §Status taxonomy) — defensive nil if it ever appears.
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; Trace summary (Managed-Effects §Tracing). A data-only summary of the
+;; canonical reply for a managed-async trace row, routing every wire-bearing
+;; slot through the shared `re-frame.reply/trace-summary` → `re-frame.
+;; elision/elide-wire-value` walker. Never a family-private elider.
+;; ---------------------------------------------------------------------------
+
+(def ^:private wire-slots
+  "Reply-map slots carrying user/wire data — redacted wholesale for a
+  per-call-sensitive request (Spec 014 §Privacy). Identity / correlation-
+  free facts ride verbatim. Mirrors `re-frame.reply`'s private slot set."
+  [:value :error :correlation :meta])
+
+(defn trace-reply
+  "Build a DATA-ONLY trace summary of a canonical HTTP reply map for a
+  managed-async trace row. The wire-bearing slots (`:value`, `:error`,
+  `:correlation`, `:meta`) elide through the single shared
+  `re-frame.elision/elide-wire-value` walker (via
+  `re-frame.reply/trace-summary`) — never a family-private elider
+  (Managed-Effects §Tracing); the identity facts (`:status`, `:work/id`,
+  `:work/kind`, `:work/status`, `:attempt`, `:rf.frame/id`,
+  `:completed-at`) ride verbatim.
+
+  `opts`:
+   - `:frame`      — the carried wire-egress frame (EP-0002); forwarded to
+                     the elider so a known frame's policy applies and the
+                     walker does not fail closed.
+   - `:sensitive?` — Spec 014 §Privacy per-call sensitivity. When true,
+                     EVERY wire slot is redacted to the framework sentinel
+                     BEFORE the shared walker runs (the coarse escape hatch
+                     for an ad-hoc sensitive request whose payload is not
+                     schema-declared), matching the existing `:rf.http/*`
+                     trace redaction posture. When false/absent the shared
+                     walker applies the frame's schema-declared
+                     `:sensitive?` / `:large?` policy as usual."
+  ([reply] (trace-reply reply nil))
+  ([reply {:keys [sensitive?] :as opts}]
+   (let [;; Per-call sensitivity is the coarse escape hatch — redact every
+         ;; wire slot wholesale before the schema-policy walk (Spec 014
+         ;; §Privacy: a sensitive request redacts all payload slots).
+         reply (if sensitive?
+                 (reduce (fn [m slot]
+                           (if (contains? m slot)
+                             (assoc m slot privacy/redacted-sentinel)
+                             m))
+                         reply
+                         wire-slots)
+                 reply)]
+     ;; The shared walker still runs (the EP mandate): on a non-sensitive
+     ;; reply it applies the frame's schema-declared elision; on a
+     ;; pre-redacted one the sentinel passes through untouched.
+     (reply/trace-summary reply (dissoc opts :sensitive?)))))

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -31,6 +31,7 @@
             [re-frame.http-middleware   :as middleware]
             [re-frame.http-privacy      :as privacy]
             [re-frame.http-registry     :as registry]
+            [re-frame.http-reply        :as http-reply]
             [re-frame.http-transport-cljs :as transport-cljs]
             [re-frame.http-transport-jvm  :as transport-jvm]
             [re-frame.interop           :as interop]
@@ -78,6 +79,33 @@
        :explicit-on    explicit
        :reply-payload  reply-payload
        :kind           kind})))
+
+;; rf2-zqefg3.2 — the canonical-reply lowering seam (EP-0011 §Managed HTTP
+;; Lowering). Every completion (success / failure / abort) now flows through
+;; ONE canonical reply map built in `re-frame.http-reply` — `:status`,
+;; `:work/id` `[:rf.work/http logical-id attempt]`, `:work/kind :http`,
+;; `:work/status`, `:attempt`, `:rf.frame/id`, `:completed-at`, and
+;; `:correlation {:request-id …}` (the `:request-id` is correlation metadata,
+;; NOT a second stale-suppression key). The canonical reply is the single
+;; internal artefact; the PUBLIC Spec 014 `{:kind …}` payload is recovered
+;; from it by `http-reply/reply->public-payload` (the `:rf.http/compat-reply`
+;; reshape), so `:on-success` / `:on-failure` and the co-located
+;; `(:rf/reply msg)` merge keep their documented shapes (Spec 014 §Reply
+;; payload shape). The public API does NOT change — only the internal
+;; continuation is unified.
+
+(defn- reply-ctx
+  "Project the transport ctx onto the data-only correlation/identity facts
+  `re-frame.http-reply` consumes to build a canonical reply map. Reads the
+  host completion clock ONCE here, at finalisation, and threads it as
+  `:completed-at` (the reply handler MUST NOT re-read the clock —
+  Managed-Effects §Causal completion metadata)."
+  [ctx]
+  {:request-id   (:request-id ctx)
+   :origin-event (:origin-event ctx)
+   :attempt      (:attempt ctx)
+   :frame        (:frame ctx)
+   :completed-at (interop/now-ms)})
 
 ;; rf2-ee38b.7 — the failure-reply and success-reply dispatch shapes were
 ;; spelled out inline at four / two sites across finalise-success!,
@@ -137,8 +165,41 @@
   (let [explicit (:explicit-on-failure ctx)]
     (and (:supplied? explicit) (nil? (:value explicit)))))
 
+(defn- emit-reply-trace!
+  "rf2-zqefg3.2 — emit a managed-async completion trace row built from the
+  CANONICAL reply-envelope facts (Managed-Effects §Tracing), not the
+  private callback payload. The wire-bearing slots (`:value` / `:error` /
+  `:correlation`) route through the shared `http-reply/trace-reply` →
+  `re-frame.reply/trace-summary` → `re-frame.elision/elide-wire-value`
+  walker (never a family-private elider); the identity facts (`:status`,
+  `:work/id`, `:work/kind`, `:work/status`, `:attempt`, `:rf.frame/id`,
+  `:completed-at`) ride verbatim. Gated on `debug-enabled?` like the other
+  `:rf.http/*` trace rows."
+  [ctx reply]
+  (when interop/debug-enabled?
+    ;; Thread the CARRIED frame into the elider opts (EP-0002 — wire-egress
+    ;; frame resolves from the carried stamp; HTTP completions fire from the
+    ;; transport callback, OUTSIDE any `with-frame` scope, so without an
+    ;; explicit `:frame` the elider fails closed and redacts every wire slot).
+    ;; The per-call `:sensitive?` flag (Spec 014 §Privacy) is forwarded so a
+    ;; sensitive request redacts its payload slots wholesale, matching the
+    ;; existing `:rf.http/*` trace posture.
+    (trace/emit! :info :rf.http/replied
+                 (http-reply/trace-reply reply (cond-> {:sensitive? (true? (:sensitive? ctx))}
+                                                 (:frame ctx) (assoc :frame (:frame ctx)))))))
+
 (defn- dispatch-failure!
   "Dispatch a `:failure` reply carrying `failure` as its `:failure` slot.
+
+  rf2-zqefg3.2 — the failure lowers through the canonical reply envelope:
+  the `:rf.http/*` failure map becomes a `:status :error` (or
+  `:status :cancelled` for an abort, `:work/status :timed-out` for a
+  timeout) canonical reply (`http-reply/failure-reply`), a completion trace
+  row is emitted from those canonical facts, and the PUBLIC Spec 014
+  `{:kind :failure :failure …}` payload is recovered by
+  `http-reply/reply->public-payload` (the compat-reply reshape) before it
+  threads through the `:after` chain + late-bind dispatch. The public event
+  shape is unchanged.
 
   rf2-rl5tt — when the reply is silenced by an explicit `:on-failure nil`
   AND the failure is not an abort, surface it once via
@@ -146,18 +207,27 @@
   [ctx failure]
   (when (on-failure-silenced? ctx)
     (warn-failure-swallowed! failure (:url ctx) (:sensitive? ctx)))
-  (dispatch-reply! (assoc ctx
-                          :kind          :failure
-                          :reply-payload {:kind    :failure
-                                          :failure failure})))
+  (let [reply (http-reply/failure-reply (reply-ctx ctx) failure)]
+    (emit-reply-trace! ctx reply)
+    (dispatch-reply! (assoc ctx
+                            :kind          :failure
+                            :reply-payload (http-reply/reply->public-payload reply)))))
 
 (defn- dispatch-success!
-  "Dispatch a `:success` reply carrying `value` as its `:value` slot."
+  "Dispatch a `:success` reply carrying `value` as its `:value` slot.
+
+  rf2-zqefg3.2 — the success lowers through the canonical reply envelope:
+  `value` becomes a `:status :ok` / `:work/status :completed` canonical
+  reply (`http-reply/success-reply`), a completion trace row is emitted
+  from those canonical facts, and the PUBLIC Spec 014 `{:kind :success
+  :value …}` payload is recovered by `http-reply/reply->public-payload`
+  before dispatch. The public event shape is unchanged."
   [ctx value]
-  (dispatch-reply! (assoc ctx
-                          :kind          :success
-                          :reply-payload {:kind  :success
-                                          :value value})))
+  (let [reply (http-reply/success-reply (reply-ctx ctx) value)]
+    (emit-reply-trace! ctx reply)
+    (dispatch-reply! (assoc ctx
+                            :kind          :success
+                            :reply-payload (http-reply/reply->public-payload reply)))))
 
 (defn- dispatch-aborted!
   "Emit the `:rf.http/aborted` trace + dispatch the abort reply for a

--- a/implementation/http/test/re_frame/http_reply_lowering_cljs_test.cljc
+++ b/implementation/http/test/re_frame/http_reply_lowering_cljs_test.cljc
@@ -1,0 +1,91 @@
+(ns re-frame.http-reply-lowering-cljs-test
+  "Host-symmetric (CLJS + JVM) conformance for the PURE core of the
+  managed-HTTP lowering (rf2-zqefg3.2): the canonical reply map, the
+  work-id head, and the public-compatibility reshape in
+  `re-frame.http-reply`. Runs on the `npm run test:cljs` node gate (its
+  ns matches the `cljs-test$` regexp) so the lowering's pure functor /
+  schema core is exercised on the CLJS runtime too — the end-to-end
+  real-transport groups live in the JVM-only
+  `http-reply-lowering-test`.
+
+  Canonical contract: `spec/Managed-Effects.md` §The uniform reply
+  envelope; EP-0011 §Managed HTTP Lowering / §Public Compatibility Sugar."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.http-reply :as http-reply]
+            [re-frame.reply :as reply]))
+
+(def ^:private ctx
+  {:request-id   :article/by-id
+   :origin-event [:article/load {:id 42}]
+   :attempt      1
+   :frame        :app/main
+   :completed-at 1781078400456})
+
+(deftest work-id-and-transport-id
+  (testing "HTTP work-id head [:rf.work/http logical-id attempt]"
+    (is (= [:rf.work/http :article/by-id 1] (http-reply/work-id ctx)))
+    (is (= [:rf.work/http :article/load 1]
+           (http-reply/work-id (dissoc ctx :request-id)))
+        "logical-id falls back to origin event-id")
+    (is (= [:rf.work/http :article/by-id 2]
+           (http-reply/work-id (assoc ctx :attempt 2)))
+        "attempt is the generation slot — retries are distinct"))
+  (testing "frame-qualified transport request-id [:rf.req frame-id work-id]"
+    (is (= [:rf.req :app/main [:rf.work/http :article/by-id 1]]
+           (http-reply/transport-request-id :app/main (http-reply/work-id ctx))))))
+
+(deftest canonical-replies-validate
+  (testing ":status :ok success"
+    (let [r (http-reply/success-reply ctx {:title "Welcome"})]
+      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (= :ok (:status r)))
+      (is (= :completed (:work/status r)))
+      (is (= :http (:work/kind r)))
+      (is (= {:request-id :article/by-id} (:correlation r)))
+      (is (not (contains? r :request-id))
+          ":request-id is correlation metadata, not a second stale key")))
+  (testing ":status :error failure"
+    (let [r (http-reply/failure-reply ctx {:kind :rf.http/http-5xx :status 503})]
+      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (= :error (:status r)))
+      (is (= :failed (:work/status r)))))
+  (testing "timeout → :status :error + :work/status :timed-out (not a top-level status)"
+    (let [r (http-reply/failure-reply ctx {:kind :rf.http/timeout :limit-ms 30000 :elapsed-ms 30012})]
+      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (= :error (:status r)))
+      (is (= :timed-out (:work/status r)))))
+  (testing "abort → :status :cancelled with :rf.http/aborted :error"
+    (let [r (http-reply/aborted-reply ctx {:kind :rf.http/aborted :reason :user})]
+      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (= :cancelled (:status r)))
+      (is (= :cancelled (:work/status r)))
+      (is (true? (:cancelled? r)))
+      (is (= :user (:cancel/reason r)))
+      (is (= :rf.http/aborted (get-in r [:error :kind]))))))
+
+(deftest reshape-preserves-public-spec-014-shapes
+  (testing ":ok → {:kind :success :value v}"
+    (is (= {:kind :success :value {:title "Welcome"}}
+           (http-reply/reply->public-payload
+             (http-reply/success-reply ctx {:title "Welcome"})))))
+  (testing ":error → {:kind :failure :failure f}"
+    (let [f {:kind :rf.http/http-4xx :status 404}]
+      (is (= {:kind :failure :failure f}
+             (http-reply/reply->public-payload (http-reply/failure-reply ctx f))))))
+  (testing ":cancelled → {:kind :failure :failure {:kind :rf.http/aborted …}}"
+    (let [f {:kind :rf.http/aborted :reason :user}]
+      (is (= {:kind :failure :failure f}
+             (http-reply/reply->public-payload (http-reply/aborted-reply ctx f))))))
+  (testing ":stale → nil (suppressed reply never delivered to the app target)"
+    (is (nil? (http-reply/reply->public-payload
+                {:status :stale :stale? true :stale/reason :x})))))
+
+(deftest trace-summary-elides-wire-slots
+  (testing "the canonical trace summary keeps identity facts verbatim"
+    (let [r       (http-reply/success-reply ctx {:secret "x"})
+          summary (http-reply/trace-reply r {:sensitive? true})]
+      (is (= :ok (:status summary)))
+      (is (= [:rf.work/http :article/by-id 1] (:work/id summary)))
+      (is (= :http (:work/kind summary)))
+      (testing "a sensitive request redacts the wire slots wholesale"
+        (is (= :rf/redacted (:value summary)))))))

--- a/implementation/http/test/re_frame/http_reply_lowering_test.clj
+++ b/implementation/http/test/re_frame/http_reply_lowering_test.clj
@@ -1,0 +1,315 @@
+(ns re-frame.http-reply-lowering-test
+  "Conformance for the EP-0011 managed-HTTP lowering (rf2-zqefg3.2): Spec 014
+  `:rf.http/managed` lowered onto the uniform reply envelope
+  (`spec/Managed-Effects.md` §The uniform reply envelope). Pins the
+  EP-0011 §Validation groups for the HTTP slice:
+
+    1. CANONICAL reply map — the transport's success / failure / abort facts
+       become a single `re-frame.reply`-conformant reply map: one closed
+       `:status`, `:work/id` `[:rf.work/http logical-id attempt]`,
+       `:work/kind :http`, `:work/status`, `:correlation {:request-id …}`
+       (the `:request-id` is correlation metadata, NOT a second stale key),
+       `:completed-at` from the reply token. Timeout → `:status :error` +
+       `:work/status :timed-out`; abort → `:status :cancelled` with an
+       `:rf.http/aborted` `:error`.
+    2. PUBLIC compatibility reshape — `:on-success` / `:on-failure` and the
+       co-located `(:rf/reply msg)` merge keep the exact Spec 014 §Reply
+       payload shapes (`{:kind :success :value v}` / `{:kind :failure
+       :failure f}`) even though the request lowered through the envelope.
+    3. SUPERSESSION — a same-`:request-id` supersede suppresses the prior
+       request's app reply target (the supersede semantic is trace-only).
+
+  Group 2 is exercised end-to-end through the real
+  `java.net.http.HttpClient` transport (a tiny com.sun.net.httpserver test
+  server); groups 1 + 3 are pinned at the pure / transport altitude.
+
+  Canonical contract: `spec/Managed-Effects.md` §The uniform reply
+  envelope; EP-0011 §Managed HTTP Lowering / §Public Compatibility Sugar."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.flows :as flows]
+            [re-frame.http-managed :as http-managed]
+            [re-frame.http-reply :as http-reply]
+            [re-frame.http-test-support]
+            [re-frame.registrar :as registrar]
+            [re-frame.reply :as reply]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace])
+  (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
+           [java.net InetSocketAddress]))
+
+;; ---- per-test reset (mirrors http_managed_test.clj) -----------------------
+
+(defn- reset-runtime [t]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (schemas/clear-schemas-by-frame!)
+  (rf/init! plain-atom/adapter)
+  (frame/ensure-default-frame!)
+  (require 're-frame.http-managed :reload)
+  (require 're-frame.http-test-support :reload)
+  (rf/with-frame :rf/default
+    (t)))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- real-transport server harness ---------------------------------------
+
+(defn- start-server! [handler]
+  (let [server (HttpServer/create (InetSocketAddress. "127.0.0.1" 0) 0)
+        ctx    (.createContext server "/")]
+    (.setHandler ctx (reify HttpHandler (handle [_ ex] (handler ex))))
+    (.setExecutor server nil)
+    (.start server)
+    {:server server :port (.getPort (.getAddress server))}))
+
+(defn- stop-server! [{:keys [server]}] (.stop server 0))
+
+(defn- write-response! [^HttpExchange exchange status content-type body]
+  (let [bytes (.getBytes (str body) "UTF-8")]
+    (when content-type
+      (-> exchange .getResponseHeaders (.set "Content-Type" content-type)))
+    (.sendResponseHeaders exchange status (long (count bytes)))
+    (with-open [os (.getResponseBody exchange)]
+      (.write os bytes))))
+
+(defn- await-reply!
+  ([pred] (await-reply! pred 5000))
+  ([pred timeout-ms]
+   (test-support/poll-until
+     #(let [db (rf/app-db-value :rf/default)] (when (pred db) db))
+     {:timeout-ms timeout-ms :label "http-reply-lowering"})))
+
+;; ===========================================================================
+;; Group 1 — the CANONICAL reply map (pure).
+;; ===========================================================================
+
+(def ^:private base-ctx
+  {:request-id   :article/by-id
+   :origin-event [:article/load {:id 42}]
+   :attempt      1
+   :frame        :app/main
+   :completed-at 1781078400456})
+
+(deftest work-id-head
+  (testing "HTTP work-id head is [:rf.work/http logical-id attempt]"
+    (is (= [:rf.work/http :article/by-id 1] (http-reply/work-id base-ctx)))
+    (testing "logical-id falls back to the origin event-id when :request-id is absent"
+      (is (= [:rf.work/http :article/load 1]
+             (http-reply/work-id (dissoc base-ctx :request-id)))))
+    (testing "the attempt is the generation slot — retries are distinct work ids"
+      (is (= [:rf.work/http :article/by-id 3]
+             (http-reply/work-id (assoc base-ctx :attempt 3))))))
+  (testing "the frame-qualified transport request-id is [:rf.req frame-id work-id]"
+    (is (= [:rf.req :app/main [:rf.work/http :article/by-id 1]]
+           (http-reply/transport-request-id :app/main (http-reply/work-id base-ctx))))))
+
+(deftest success-reply-is-canonical
+  (testing "a success completion builds a schema-valid :status :ok reply"
+    (let [r (http-reply/success-reply base-ctx {:title "Welcome"})]
+      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (= :ok (:status r)))
+      (is (= {:title "Welcome"} (:value r)))
+      (is (= :completed (:work/status r)))
+      (is (= :http (:work/kind r)))
+      (is (= [:rf.work/http :article/by-id 1] (:work/id r)))
+      (is (= :app/main (:rf.frame/id r)))
+      (is (= 1781078400456 (:completed-at r)))
+      (testing ":request-id rides as :correlation metadata, NOT a top-level stale key"
+        (is (= {:request-id :article/by-id} (:correlation r)))
+        (is (not (contains? r :request-id)))))))
+
+(deftest failure-reply-maps-to-error
+  (testing "a transport failure builds a schema-valid :status :error reply"
+    (let [r (http-reply/failure-reply
+              base-ctx {:kind :rf.http/http-5xx :status 503 :body "down"})]
+      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (= :error (:status r)))
+      (is (= :failed (:work/status r)))
+      (is (= :rf.http/http-5xx (get-in r [:error :kind])))
+      (is (= 503 (get-in r [:error :status]))))))
+
+(deftest timeout-maps-to-error-plus-timed-out-work-status
+  (testing "timeout is :status :error + :work/status :timed-out (NOT a top-level status)"
+    (let [r (http-reply/failure-reply
+              base-ctx {:kind :rf.http/timeout :limit-ms 30000 :elapsed-ms 30012})]
+      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (= :error (:status r)) "timeout is NOT a top-level :status")
+      (is (= :timed-out (:work/status r)))
+      (is (= :rf.http/timeout (get-in r [:error :kind]))))))
+
+(deftest abort-maps-to-cancelled
+  (testing "an abort is :status :cancelled with an :rf.http/aborted :error"
+    (let [failure {:kind :rf.http/aborted :reason :user :request-id :article/by-id}
+          r       (http-reply/aborted-reply base-ctx failure)]
+      (is (reply/valid-reply? r) (str (reply/validate-reply r)))
+      (is (= :cancelled (:status r)))
+      (is (= :cancelled (:work/status r)))
+      (is (true? (:cancelled? r)))
+      (is (= :user (:cancel/reason r)))
+      (is (= :rf.http/aborted (get-in r [:error :kind])))))
+  (testing "an aborted failure routed through failure-reply also lowers to :cancelled"
+    (let [r (http-reply/failure-reply
+              base-ctx {:kind :rf.http/aborted :reason :actor-destroyed})]
+      (is (= :cancelled (:status r)))
+      (is (= :actor-destroyed (:cancel/reason r))))))
+
+;; ===========================================================================
+;; Group 2a — public compatibility reshape (pure inverse projection).
+;; ===========================================================================
+
+(deftest reshape-preserves-public-shapes
+  (testing ":ok reshapes to {:kind :success :value v}"
+    (is (= {:kind :success :value {:title "Welcome"}}
+           (http-reply/reply->public-payload
+             (http-reply/success-reply base-ctx {:title "Welcome"})))))
+  (testing ":error reshapes to {:kind :failure :failure f} carrying the :rf.http/* failure"
+    (let [failure {:kind :rf.http/http-4xx :status 404 :body "nope"}]
+      (is (= {:kind :failure :failure failure}
+             (http-reply/reply->public-payload
+               (http-reply/failure-reply base-ctx failure))))))
+  (testing ":cancelled reshapes to a {:kind :failure …} reply carrying :rf.http/aborted"
+    (let [failure {:kind :rf.http/aborted :reason :user}]
+      (is (= {:kind :failure :failure failure}
+             (http-reply/reply->public-payload
+               (http-reply/aborted-reply base-ctx failure))))))
+  (testing ":stale reshapes to nil — a suppressed reply is never delivered to the app target"
+    (is (nil? (http-reply/reply->public-payload
+                {:status :stale :stale? true :stale/reason :x})))))
+
+;; ===========================================================================
+;; Group 2b — public shape preserved END-TO-END through the real transport.
+;; ===========================================================================
+
+(deftest real-transport-default-reply-preserves-public-shape
+  (testing "co-located (:rf/reply msg) default still receives {:kind :success :value v}"
+    (let [srv (start-server!
+                (fn [^HttpExchange ex]
+                  (write-response! ex 200 "application/json"
+                                   "{\"title\":\"hello\",\"id\":42}")))]
+      (try
+        (rf/reg-event-fx :article/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" (:port srv) "/a")}
+                      :decode  :json}]]})))
+        (rf/dispatch-sync [:article/load {}])
+        (let [db (await-reply! #(some? (:reply %)))]
+          ;; The PUBLIC Spec 014 §Reply payload shape — unchanged by the
+          ;; internal lowering.
+          (is (= :success (get-in db [:reply :kind])))
+          (is (= "hello"  (get-in db [:reply :value :title])))
+          ;; The canonical envelope facts (:status / :work/id / :completed-at)
+          ;; are INTERNAL — they MUST NOT leak into the public payload.
+          (is (not (contains? (:reply db) :status)))
+          (is (not (contains? (:reply db) :work/id))))
+        (finally (stop-server! srv))))))
+
+(deftest real-transport-explicit-on-failure-preserves-public-shape
+  (testing "explicit :on-failure still receives {:kind :failure :failure {:kind :rf.http/http-5xx …}}"
+    (let [srv (start-server!
+                (fn [^HttpExchange ex]
+                  (write-response! ex 503 "text/plain" "down")))]
+      (try
+        (rf/reg-event-fx :svc/call
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url (str "http://127.0.0.1:" (:port srv) "/x")}
+                    :on-failure [:svc/failed]}]]}))
+        (rf/reg-event-db :svc/failed (fn [db [_ payload]] (assoc db :got payload)))
+        (rf/dispatch-sync [:svc/call])
+        (let [db (await-reply! #(some? (:got %)))]
+          (is (= :failure (get-in db [:got :kind])))
+          (is (= :rf.http/http-5xx (get-in db [:got :failure :kind])))
+          (is (= 503 (get-in db [:got :failure :status])))
+          (is (not (contains? (:got db) :status)) "no canonical envelope leak"))
+        (finally (stop-server! srv))))))
+
+(deftest real-transport-emits-canonical-replied-trace
+  (testing "completion emits a :rf.http/replied trace row built from the canonical envelope facts"
+    (let [srv     (start-server!
+                    (fn [^HttpExchange ex]
+                      (write-response! ex 200 "application/json" "{\"ok\":true}")))
+          traces  (atom [])
+          lid     ::replied-trace]
+      (try
+        (trace/register-listener! lid (fn [ev] (swap! traces conj ev)))
+        (rf/reg-event-fx :t/load
+          (fn [{:keys [db]} [_ msg]]
+            (if (:rf/reply msg)
+              {:db (assoc db :done true)}
+              {:fx [[:rf.http/managed
+                     {:request    {:url (str "http://127.0.0.1:" (:port srv) "/t")}
+                      :request-id :t/load
+                      :decode     :json}]]})))
+        (rf/dispatch-sync [:t/load {}])
+        (await-reply! #(:done %))
+        (let [replied (filter #(= :rf.http/replied (:operation %)) @traces)]
+          (is (seq replied) "a :rf.http/replied trace row was emitted")
+          (let [tags (:tags (first replied))]
+            ;; identity facts ride verbatim on the canonical trace summary
+            (is (= :ok (:status tags)))
+            (is (= :http (:work/kind tags)))
+            (is (= [:rf.work/http :t/load 1] (:work/id tags)))
+            ;; :request-id is correlation metadata, not a second stale key
+            (is (= {:request-id :t/load} (:correlation tags)))))
+        (finally
+          (trace/unregister-listener! lid)
+          (stop-server! srv))))))
+
+;; ===========================================================================
+;; Group 3 — supersession suppresses the prior request's app target.
+;; ===========================================================================
+
+(deftest supersede-suppresses-prior-app-reply
+  (testing "a same-:request-id supersede suppresses the FIRST request's :on-failure app target"
+    ;; A slow server keeps request #1 in flight; issuing request #2 with the
+    ;; same :request-id supersedes #1. Per Spec 014 §`:request-id` (internal)
+    ;; the superseded request's reply is trace-only — its app target MUST NOT
+    ;; fire. #2 completes normally and IS delivered.
+    (let [gate (java.util.concurrent.CountDownLatch. 1)
+          srv  (start-server!
+                 (fn [^HttpExchange ex]
+                   ;; Block the FIRST connection until the gate opens; the
+                   ;; SECOND request opens the gate so both eventually drain.
+                   (.countDown gate)
+                   (try (.await gate 2 java.util.concurrent.TimeUnit/SECONDS)
+                        (catch InterruptedException _ nil))
+                   (write-response! ex 200 "application/json" "{\"v\":1}")))
+          replies (atom [])]
+      (try
+        (rf/reg-event-db :search/replied
+          (fn [db [_ payload]]
+            (swap! replies conj payload)
+            db))
+        (rf/reg-event-fx :search/go
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url (str "http://127.0.0.1:" (:port srv) "/s")}
+                    :request-id :search
+                    :decode     :json
+                    :on-success [:search/replied]
+                    :on-failure [:search/replied]}]]}))
+        ;; Fire #1, then #2 (supersedes #1). dispatch-sync drains each event.
+        (rf/dispatch-sync [:search/go])
+        (rf/dispatch-sync [:search/go])
+        ;; Open the gate so any in-flight transport drains, then wait for at
+        ;; least one delivered reply.
+        (.countDown gate)
+        (test-support/poll-until
+          #(when (seq @replies) true)
+          {:timeout-ms 5000 :label "supersede"})
+        (Thread/sleep 200) ;; quiescence window for any (wrongly) delivered #1 reply
+        ;; The superseded request #1's app target is NOT dispatched: exactly
+        ;; one delivered reply (request #2's), never the supersede of #1.
+        (is (= 1 (count @replies))
+            "only the surviving request's reply is delivered; the superseded one is suppressed")
+        (is (= :success (:kind (first @replies)))
+            "the surviving reply is request #2's success")
+        (finally (stop-server! srv))))))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -6,7 +6,7 @@
 >
 > **Code samples are in ClojureScript** (the CLJS reference). The contract is host-agnostic; the spec calls out per-host divergences (CLJS Fetch / JVM `java.net.http.HttpClient`) explicitly per row.
 >
-> `:rf.http/managed` is a **managed external effect** — per [Managed-Effects](Managed-Effects.md), the surface MUST satisfy the eight properties (effect-as-data, framework-owned lifecycle, structured failure taxonomy under `:rf.http/*`, trace-bus observability, `:sensitive?` / `:large?` composition, built-in retry / abort / teardown, in-flight registry, per-frame interceptor scoping).
+> `:rf.http/managed` is a **managed external effect** — per [Managed-Effects](Managed-Effects.md), the surface MUST satisfy the nine properties (effect-as-data, framework-owned lifecycle, structured failure taxonomy under `:rf.http/*`, trace-bus observability, `:sensitive?` / `:large?` composition, built-in retry / abort / teardown, in-flight registry, per-frame interceptor scoping, and — property 9 — the [uniform reply envelope](Managed-Effects.md#the-uniform-reply-envelope) for async completions, onto which managed HTTP [lowers its replies](#lowering-onto-the-uniform-reply-envelope)).
 
 ## Abstract
 
@@ -522,6 +522,36 @@ A success reply lands as:
 ```
 
 The two outer-`:kind` values (`:success` / `:failure`) discriminate the reply branch; the inner `:kind` (under `:failure`) names the failure category. Both `:kind`s are framework-owned and unqualified — they live inside `:rf/reply`, where the framework is the sole writer.
+
+### Lowering onto the uniform reply envelope
+
+The `{:kind …}` payload above is the **public** shape, and it is unchanged. Internally, every managed-HTTP completion lowers onto the framework-wide [uniform reply envelope](Managed-Effects.md#the-uniform-reply-envelope) (Managed-Effects property 9; [EP-0011](../docs/EP/EP-0011-uniform-async-reply-envelope.md) §Managed HTTP Lowering is the rationale record). One HTTP attempt produces one **canonical reply map** with a single closed `:status`:
+
+```clojure
+{:status       :ok            ;; one of :ok | :error | :cancelled
+ :value        <decoded-and-accepted-payload>   ;; on :ok
+ :error        {:kind <one of :rf.http/*> …}     ;; on :error / :cancelled
+ :work/id      [:rf.work/http logical-id attempt] ;; the attempt identity
+ :work/kind    :http
+ :work/status  :completed | :failed | :timed-out | :cancelled
+ :attempt      1
+ :rf.frame/id  :app/main
+ :completed-at 1781078400456   ;; read ONCE from the host completion
+ :correlation  {:request-id <the :request-id>}}  ;; correlation metadata
+```
+
+Status mapping (per [Managed-Effects §Status taxonomy](Managed-Effects.md#status-taxonomy)):
+
+- a successful, decoded-and-`:accept`-projected response → `:status :ok` (`:work/status :completed`);
+- any `:rf.http/*` failure → `:status :error`, the classified failure map riding verbatim as `:error`;
+- a **timeout** → `:status :error` with `:work/status :timed-out` — **timeout is not a top-level status**, it is an error kind (`:rf.http/timeout`) plus a work status;
+- an **abort** → `:status :cancelled` with `:cancelled? true`, `:cancel/reason`, and the `:rf.http/aborted` shape under `:error`.
+
+The HTTP `:request-id` is **correlation metadata** under `:correlation` — it is **not** a second stale-suppression key ([Managed-Effects §Work-id correlation](Managed-Effects.md#work-id-correlation); [EP-0007](../docs/EP/EP-0007-one-name-per-fact.md): one attempt, one `:work/id`). The single `:work/id` head is `[:rf.work/http logical-id attempt]` (the `logical-id` is the caller's `:request-id` when supplied, else the originating event-id; the trailing `attempt` is the generation slot, so retries of the same logical request are distinct work ids). The frame-qualified transport request-id `[:rf.req frame-id work-id]` (landed in [Spec 016](016-Resources.md#ledger-row-retention-and-identity)) is the sanctioned second identity for process-global transport correlation; intra-frame stale suppression still keys on `:work/id`.
+
+`:completed-at` is causal completion metadata ([EP-0010](../docs/EP/EP-0010-causal-world-inputs.md)) read **once** from the host completion at finalisation and carried on the reply — a reply handler derives a durable timestamp from `(:completed-at reply)`, never from a fresh ambient clock read. Completion trace rows (`:rf.http/replied`) are emitted from these canonical reply facts, routing every wire-bearing slot through the shared [`rf/elide-wire-value`](API.md#elide-wire-value-the-wire-boundary-walker) walker (property 5).
+
+**Public compatibility sugar.** `:on-success` / `:on-failure` and the co-located `(:rf/reply msg)` merge are public compatibility sugar that lower to one internal `:rf.http/compat-reply` target; the compat-reply handler reshapes the canonical reply back into the `{:kind :success :value v}` / `{:kind :failure :failure f}` payload above, so the public event shapes promised here are preserved exactly. A `:status :stale` (suppressed) reply is never delivered to the app target.
 
 ## Reply addressing
 


### PR DESCRIPTION
Lowers managed HTTP completions onto the framework-wide uniform reply envelope (EP-0011 §Managed HTTP Lowering / §Public Compatibility Sugar; `spec/Managed-Effects.md` §The uniform reply envelope). **The public Spec 014 API does not change** — `:on-success` / `:on-failure` and the co-located `(:rf/reply msg)` merge stay valid sugar with the exact shapes Spec 014 promises.

## What changed

- **New `re-frame.http-reply`** (pure): the lowering seam.
  - `work-id` — the HTTP work-id head `[:rf.work/http logical-id attempt]` (logical-id = caller `:request-id` else origin event-id; attempt is the generation slot, so retries are distinct work ids).
  - `transport-request-id` — the frame-qualified `[:rf.req frame-id work-id]` (the landed Spec 016 second identity for process-global transport correlation).
  - `success-reply` / `failure-reply` / `aborted-reply` — build the canonical reply map (one closed `:status`, `:work/id`, `:work/kind :http`, `:work/status`, `:attempt`, `:rf.frame/id`, `:completed-at`, `:correlation {:request-id …}`). `:request-id` is **correlation metadata, not a second stale key**. Timeout → `:status :error` + `:work/status :timed-out` (not a top-level status); abort → `:status :cancelled` with `:rf.http/aborted` under `:error`.
  - `reply->public-payload` — the `:rf.http/compat-reply` reshape: canonical reply → public `{:kind :success :value v}` / `{:kind :failure :failure f}`; `:stale` → nil (suppressed, never delivered).
  - `trace-reply` — data-only trace summary routing every wire slot through the shared `re-frame.reply/trace-summary` → `rf/elide-wire-value` walker.

- **`re-frame.http-transport`**: success / failure / abort now flow through ONE canonical reply built in `http-reply`, emit a `:rf.http/replied` trace row from the canonical facts, then recover the public payload before the existing `:after`-chain + late-bind dispatch. `:completed-at` is read **once** at finalisation (never re-read in the reply handler). The carried frame + per-call `:sensitive?` are threaded into the elider so the trace egress applies the right policy.

- **`spec/014-HTTPRequests.md`**: adds the deferred `§Lowering onto the uniform reply envelope` subsection (the 014↔Managed-Effects cross-reference) and updates the intro from eight to nine managed-effect properties.

## Conformance (EP-0011 §Validation)

- `http_reply_lowering_test` (JVM, real `java.net.http.HttpClient` transport): `:on-success`/`:on-failure` and the co-located default preserve the public event shapes; canonical replies validate against `re-frame.reply/validate-reply`; timeout → `:work/status :timed-out`; abort → `:status :cancelled`; a `:rf.http/replied` trace row carries the canonical facts; a same-`:request-id` supersede suppresses the prior request's app target (trace-only).
- `http_reply_lowering_cljs_test` (host-symmetric, runs on the node gate): the pure canonical-reply / reshape / work-id core on the CLJS runtime.

## Quality gates

- `npm run test:cljs` (from `implementation/`) — **6424 tests, 23217 assertions, 0 failures, 0 errors** (covers http + reply, incl. the new CLJS conformance ns).
- `implementation/http` JVM suite (`clojure -M:test`) — **391 tests, 1798 assertions, 0 failures, 0 errors** (+10 over baseline 381 from the new JVM conformance ns).
- `mkdocs build --strict` — **EXIT 0, no warnings** (with `spec/` staged into `docs/spec/` as the docs CI does). `python scripts/check_doc_slugs.py --verbose` — **no broken links**.
