### PR TITLE
ci(lint): fail on retired spellings — :frame coeffect + redirect :url/:to (rf2-ziak6w)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,6 +244,29 @@ jobs:
       - name: Verify skill eval-packaging docs agree with package.json files
         run: python scripts/check_skill_eval_packaging.py --verbose --ci
 
+      # EP-0007 §Enforcement retired-spelling gate (rf2-ziak6w). EP-0007 rule 2
+      # ("no stable accepted synonyms") gets the no-floor-lint treatment "where
+      # shapes allow": a retired spelling reappearing in framework source is a
+      # CI failure, not a doc note. Two merged renames are lintable — the bare
+      # `:frame` event-context COEFFECT read (retired by rf2-1m6rf1 for
+      # `:rf.frame/id`) and the `:url` / `:to` redirect-TARGET key on an SSR
+      # redirect fx (retired by rf2-vngir for `:location`). The gate scopes to
+      # the retired SHAPES (the coeffect-read accessors; a `:url`/`:to` key in
+      # a `:rf.server/(safe-)redirect` form) so it NEVER fires on the
+      # sanctioned public `:frame` opt, the trace `:frame` tag, the fx-handler
+      # ctx `:frame`, or client-navigation `:url`. Pure Python stdlib (no extra
+      # deps). Self-test first (proves the gate fires on each retired shape +
+      # stays green on every sanctioned counterpart), then the live scan
+      # asserts implementation/ framework source is clean. Hosted in this
+      # always-on PR-spine python job so a retired spelling blocks the merge
+      # regardless of which surface a PR touches. See
+      # scripts/check_retired_spellings.py.
+      - name: Self-test the EP-0007 retired-spelling gate
+        run: python scripts/check_retired_spellings.py --self-test --verbose
+
+      - name: Verify framework source carries no retired spelling (EP-0007)
+        run: python scripts/check_retired_spellings.py --verbose
+
   # PR-time gate for README link drift (rf2-br5u7). Source: the
   # rf2-oavap README sweep used a local `ai/link-sweep-v2.py` audit
   # that flagged 5 issues — 3 real, 2 false-positives caused by GitHub

--- a/docs/EP/EP-0007-one-name-per-fact.md
+++ b/docs/EP/EP-0007-one-name-per-fact.md
@@ -180,8 +180,18 @@ pruned the redirect aliases immediately, with no compatibility window. Items
 3. ~~`rf2-vngir`: the redirect narrowing~~ — **merged** (item 4 done; retired
    spellings fail loudly and name `:location`).
 4. `reg-`/`register-` audit bead (doc-only unless stragglers found).
-5. Lint bead: retired-spelling checks for items 1 and 4 (both renames have
-   merged, so the lint can land when the no-floor check is written).
+5. ~~Lint bead: retired-spelling checks for items 1 and 4~~ — **done**
+   (`rf2-ziak6w`). `scripts/check_retired_spellings.py` fails on the retired
+   bare `:frame` event-context coeffect read (item 1) and the `:url` / `:to`
+   redirect-target key on an SSR redirect fx (item 4), scoped to the retired
+   *shapes* so the sanctioned public `:frame` opt / trace tag / fx-handler ctx
+   and client-navigation `:url` stay green. Wired into the always-on PR-spine
+   python job (`.github/workflows/test.yml`) and the local pre-checkin spine
+   (`scripts/test-fast-pr.sh`). The two shapes too ambiguous to lint without
+   noise (a `let`-bound redirect map far from the fx id; an exotic coeffect
+   accessor) are documented in the script header as deliberate non-targets —
+   the runtime guards (`reject-retired-redirect-keys!`, the
+   `event_context_coeffect_keys_test` conformance pin) are the backstop there.
 
 ## Recommendation
 

--- a/scripts/_test_fixtures/check_retired_spellings/negative/client_navigate_url.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/negative/client_navigate_url.cljc
@@ -1,0 +1,14 @@
+(ns fixture.negative.client-navigate-url
+  "NEGATIVE fixture: the SANCTIONED :url key on a CLIENT navigation surface
+  (routing / navigate). Per the HTTP-response-vs-navigation vocabulary rule
+  (spec/Conventions.md §The naming rules), client navigation uses :url —
+  different concept from the SSR redirect :location. No :rf.server/*redirect
+  tag is anywhere near these, so the (b) detector must stay GREEN.")
+
+(defn go-to [path]
+  ;; Sanctioned: :url is the canonical client-navigation key.
+  (dispatch [:routing/navigate {:url path}])
+  (navigate {:url path :replace? true}))
+
+(defn url-change-handler [{:keys [url]}]
+  (handle-url url))

--- a/scripts/_test_fixtures/check_retired_spellings/negative/frame_in_comment.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/negative/frame_in_comment.cljc
@@ -1,0 +1,12 @@
+(ns fixture.negative.frame-in-comment
+  "NEGATIVE fixture: the retired shapes appearing only in `;`-comments are
+  documentation, not reintroduced code. Comment masking must keep the gate
+  GREEN."
+  (:require [re-frame.interceptor :as interceptor]))
+
+(defn handler [ctx]
+  ;; Historical note: we used to do (interceptor/get-coeffect ctx :frame)
+  ;; and (:frame (:coeffects ctx)) and (get-in ctx [:coeffects :frame]) —
+  ;; all retired in favour of :rf.frame/id. We also dropped the redirect
+  ;; :url / :to keys on [:rf.server/redirect {:url ...}] in favour of :location.
+  (interceptor/get-coeffect ctx :rf.frame/id))

--- a/scripts/_test_fixtures/check_retired_spellings/negative/frame_in_docstring.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/negative/frame_in_docstring.cljc
@@ -1,0 +1,14 @@
+(ns fixture.negative.frame-in-docstring
+  "NEGATIVE fixture: the retired shapes appearing only inside \"...\"-string
+  literals (docstrings + prose) are documentation. String masking must keep
+  the gate GREEN — including a multi-line docstring that spans the shapes."
+  (:require [re-frame.interceptor :as interceptor]))
+
+(defn handler
+  "Reads the frame stamp. Historically this used the bare :frame coeffect via
+  (interceptor/get-coeffect ctx :frame), (:frame (:coeffects ctx)), and
+  (get-in ctx [:coeffects :frame]). The SSR redirect once accepted
+  [:rf.server/redirect {:url x}] / {:to x}; both are retired. The canonical
+  spellings are :rf.frame/id and :location respectively."
+  [ctx]
+  (interceptor/get-coeffect ctx :rf.frame/id))

--- a/scripts/_test_fixtures/check_retired_spellings/negative/frame_trace_tag.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/negative/frame_trace_tag.cljc
@@ -1,0 +1,12 @@
+(ns fixture.negative.frame-trace-tag
+  "NEGATIVE fixture: the SANCTIONED trace / error-record :frame tag. The
+  frame id is READ from the :rf.frame/id coeffect and STAMPED onto a trace
+  under the :frame tag — the value flows :rf.frame/id -> :frame tag. Must
+  stay GREEN (rf2-7d30s error-emit frame-stamp pass)."
+  (:require [re-frame.interceptor :as interceptor]
+            [re-frame.trace :as trace]))
+
+(defn emit-with-frame [ctx]
+  (let [frame-id (interceptor/get-coeffect ctx :rf.frame/id)]
+    ;; Sanctioned: :frame TAG on a trace event (value = the :rf.frame/id read).
+    (trace/emit! :warning :rf.warning/something {:frame frame-id})))

--- a/scripts/_test_fixtures/check_retired_spellings/negative/fx_handler_ctx_frame.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/negative/fx_handler_ctx_frame.cljc
@@ -1,0 +1,14 @@
+(ns fixture.negative.fx-handler-ctx-frame
+  "NEGATIVE fixture: the SANCTIONED binary fx-handler ctx :frame
+  destructuring (Spec 002 §The binary fx-handler signature) + the
+  HTTP-interceptor ctx :frame (Spec 014). This is an fx-CONTEXT read, not
+  an event coeffect — the spec is normative; it stays :frame. Must stay
+  GREEN (the rf2-1m6rf1 rename explicitly KEPT these survivors).")
+
+;; Sanctioned: binary fx-handler reads :frame from its fx-context arg.
+(defn scroll-fx [{:keys [frame]} args]
+  (do-scroll frame args))
+
+;; Sanctioned: HTTP-interceptor ctx carries :frame.
+(defn http-middleware [{:keys [frame] :as ctx}]
+  (assoc ctx :tagged frame))

--- a/scripts/_test_fixtures/check_retired_spellings/negative/public_frame_opt.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/negative/public_frame_opt.cljc
@@ -1,0 +1,13 @@
+(ns fixture.negative.public-frame-opt
+  "NEGATIVE fixture: the SANCTIONED public :frame dispatch/subscribe opt
+  and the dispatch envelope :frame key. Must stay GREEN — only the
+  COEFFECT read of :frame was retired, not the public opt.")
+
+(defn dispatch-on [frame-id]
+  ;; Sanctioned: :frame is the public dispatch opt (EP-0002 R3).
+  (dispatch [:save] {:frame frame-id})
+  (subscribe [:user] {:frame frame-id}))
+
+(defn build-envelope [frame-id event]
+  ;; Sanctioned: :frame is the dispatch-envelope key.
+  {:frame frame-id :event event :source :ui})

--- a/scripts/_test_fixtures/check_retired_spellings/negative/redirect_location_key.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/negative/redirect_location_key.cljc
@@ -1,0 +1,10 @@
+(ns fixture.negative.redirect-location-key
+  "NEGATIVE fixture: the CANONICAL :location redirect-target key on a
+  :rf.server/redirect / :rf.server/safe-redirect fx (rf2-vngir). This is
+  the correct spelling — it must NEVER fire the gate.")
+
+(defn save-handler [_ _]
+  {:fx [[:rf.server/redirect {:location "/dashboard" :status 302}]]})
+
+(defn login-handler [_ _]
+  {:fx [[:rf.server/safe-redirect {:location "/home" :relative-only? true}]]})

--- a/scripts/_test_fixtures/check_retired_spellings/negative/retired_keys_def.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/negative/retired_keys_def.cljc
@@ -1,0 +1,22 @@
+(ns fixture.negative.retired-keys-def
+  "NEGATIVE fixture: the actual runtime GUARD that names the retired keys.
+  Mirrors re-frame.ssr.response — the `retired-redirect-target-keys` def is
+  a VECTOR of bare keywords [:url :to] (not map-entry keys), used by the
+  reject! guard. The mention of :rf.server/redirect is in prose/strings.
+  Must stay GREEN: the gate must not flag the very guard that enforces the
+  rename. The keywords are not in `:key value` map-entry position, and the
+  fx-id references sit inside masked strings/comments.")
+
+;; The redirect fx (:rf.server/redirect / :rf.server/safe-redirect) writes a
+;; Location header; the retired :url / :to keys must be rejected.
+(def ^:private retired-redirect-target-keys
+  "Redirect-target spellings retired in favour of :location (rf2-vngir).
+  Detected on a :rf.server/redirect / :rf.server/safe-redirect args map."
+  [:url :to])
+
+(defn reject-retired-redirect-keys! [redirect-map]
+  (let [retired (filterv #(contains? redirect-map %) retired-redirect-target-keys)]
+    (when (seq retired)
+      (throw (ex-info "redirect-retired-target-key"
+                      {:retired-keys  retired
+                       :canonical-key :location})))))

--- a/scripts/_test_fixtures/check_retired_spellings/negative/rf_frame_id_coeffect.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/negative/rf_frame_id_coeffect.cljc
@@ -1,0 +1,14 @@
+(ns fixture.negative.rf-frame-id-coeffect
+  "NEGATIVE fixture: the CANONICAL :rf.frame/id event-context coeffect read
+  in all three accessor forms. This is the CORRECT spelling that replaced
+  the retired bare :frame coeffect — it must NEVER fire the gate."
+  (:require [re-frame.interceptor :as interceptor]))
+
+(defn handler-accessor [ctx]
+  (interceptor/get-coeffect ctx :rf.frame/id))
+
+(defn handler-kwfn [ctx]
+  (:rf.frame/id (:coeffects ctx)))
+
+(defn handler-getin [ctx]
+  (get-in ctx [:coeffects :rf.frame/id]))

--- a/scripts/_test_fixtures/check_retired_spellings/positive/frame_of_coeffects.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/positive/frame_of_coeffects.cljc
@@ -1,0 +1,8 @@
+(ns fixture.positive.frame-of-coeffects
+  "POSITIVE fixture: the retired (:frame (:coeffects ctx)) keyword-fn read
+  off the :coeffects map (rf2-1m6rf1).")
+
+(defn handler [ctx]
+  ;; RETIRED: keyword-fn read of the bare :frame coeffect.
+  (let [frame (:frame (:coeffects ctx))]
+    (assoc ctx :seen frame)))

--- a/scripts/_test_fixtures/check_retired_spellings/positive/get_coeffect_frame.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/positive/get_coeffect_frame.cljc
@@ -1,0 +1,11 @@
+(ns fixture.positive.get-coeffect-frame
+  "POSITIVE fixture: the retired (get-coeffect ctx :frame) accessor read.
+  The bare :frame event-context coeffect was retired by rf2-1m6rf1 in
+  favour of :rf.frame/id. This file plants the retired read so the gate
+  fires; the runtime no longer injects :frame so this read returns nil."
+  (:require [re-frame.interceptor :as interceptor]))
+
+(defn handler [ctx]
+  ;; RETIRED: should read :rf.frame/id, not :frame.
+  (let [frame (interceptor/get-coeffect ctx :frame)]
+    (assoc ctx :seen frame)))

--- a/scripts/_test_fixtures/check_retired_spellings/positive/get_in_coeffects_frame.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/positive/get_in_coeffects_frame.cljc
@@ -1,0 +1,8 @@
+(ns fixture.positive.get-in-coeffects-frame
+  "POSITIVE fixture: the retired (get-in ctx [:coeffects :frame]) path read
+  through the :coeffects map (rf2-1m6rf1).")
+
+(defn handler [ctx]
+  ;; RETIRED: get-in path read of the bare :frame coeffect.
+  (let [frame (get-in ctx [:coeffects :frame])]
+    (assoc ctx :seen frame)))

--- a/scripts/_test_fixtures/check_retired_spellings/positive/redirect_url_key.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/positive/redirect_url_key.cljc
@@ -1,0 +1,7 @@
+(ns fixture.positive.redirect-url-key
+  "POSITIVE fixture: the retired :url redirect-target key on a
+  :rf.server/redirect fx (rf2-vngir). Canonical key is :location.")
+
+(defn save-handler [_ _]
+  ;; RETIRED: :url is a client-nav key, never a redirect-target key.
+  {:fx [[:rf.server/redirect {:url "/dashboard" :status 302}]]})

--- a/scripts/_test_fixtures/check_retired_spellings/positive/redirect_url_multiline.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/positive/redirect_url_multiline.cljc
@@ -1,0 +1,10 @@
+(ns fixture.positive.redirect-url-multiline
+  "POSITIVE fixture: the retired :url redirect-target key where the
+  :rf.server/redirect tag and the :url key sit on different lines of the
+  same inline form (within the sliding window). Proves the window-based
+  (b) detector binds the key to the fx across a small wrap.")
+
+(defn save-handler [_ _]
+  {:fx [[:rf.server/redirect
+         {:url    "/dashboard"
+          :status 302}]]})

--- a/scripts/_test_fixtures/check_retired_spellings/positive/safe_redirect_to_key.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/positive/safe_redirect_to_key.cljc
@@ -1,0 +1,7 @@
+(ns fixture.positive.safe-redirect-to-key
+  "POSITIVE fixture: the retired :to redirect-target key on a
+  :rf.server/safe-redirect fx (rf2-vngir). Canonical key is :location.")
+
+(defn login-handler [_ _]
+  ;; RETIRED: :to is not a redirect-target key; rewrite as :location.
+  {:fx [[:rf.server/safe-redirect {:to "/home" :relative-only? true}]]})

--- a/scripts/check_retired_spellings.py
+++ b/scripts/check_retired_spellings.py
@@ -1,0 +1,574 @@
+#!/usr/bin/env python3
+"""EP-0007 (One Name Per Fact) §Enforcement — retired-spelling CI gate.
+
+EP-0007 rule 2 ("no stable accepted synonyms") gets the no-floor-lint
+treatment "where shapes allow": a *retired* spelling reappearing in
+framework source is a CI failure, not a doc note. Two renames have merged,
+so two retired spellings are now lintable:
+
+  (a) The bare `:frame` event-context COEFFECT (sweep item 1, rf2-1m6rf1).
+      EP-0002 R3 "one carrier, one name" retired the duplicate `:frame`
+      coeffect: the frame stamp travels in the event context under
+      `:rf.frame/id` ONLY. The framework once injected `:frame` beside it
+      and ~10 internal sites read it back.
+
+  (b) The redirect-target keys `:url` / `:to` on an SSR redirect effect
+      (sweep item 4, rf2-vngir). The `:rf.server/redirect` /
+      `:rf.server/safe-redirect` fx writes an HTTP `Location` response
+      header, so it uses header vocabulary — the canonical (and only)
+      target key is `:location`. `:url` / `:to` are retired and now throw
+      `:rf.error/redirect-retired-target-key`.
+
+WHY THE SHAPES ARE SCOPED PRECISELY (the "where shapes allow" caveat)
+
+`:frame` and `:url` are both heavily SANCTIONED elsewhere — a bare grep for
+either keyword fires on 100+ legitimate sites. EP-0007 rule 3 records the
+cross-layer vocabulary rules that make those uses correct:
+
+  * `:frame` is the public dispatch/subscribe opt, the dispatch envelope
+    key, the binary fx-handler ctx key (Spec 002 §The binary fx-handler
+    signature) + the HTTP-interceptor ctx key (Spec 014), and the
+    trace / error-record tag. ALL sanctioned. Only the *coeffect read* was
+    retired.
+
+  * `:url` is the canonical CLIENT-navigation key (routing / `navigate`
+    surfaces) per the HTTP-response-vs-navigation vocabulary rule in
+    spec/Conventions.md §The naming rules. Only its use as an SSR
+    redirect-TARGET key was retired.
+
+So this gate does NOT grep for the bare keyword. It scopes to the exact
+retired SHAPES:
+
+  (a) the coeffect-READ forms the rf2-1m6rf1 rename removed —
+        - (get-coeffect <ctx> :frame ...)        ;; the canonical accessor
+        - (:frame (:coeffects <x>))              ;; keyword-fn off :coeffects
+        - (get-in <ctx> [:coeffects :frame] ...) ;; get-in path via :coeffects
+      None of these can match the public opt, the trace tag, the dispatch
+      envelope, or the fx-handler `{:keys [frame]}` destructuring (which is
+      an fx-CONTEXT read, sanctioned). The framework reads coeffects through
+      these three forms and nothing else (verified against the rename diff).
+
+  (b) a `:url` / `:to` KEY appearing in a map that is — in the same form —
+      tagged as an SSR redirect: a literal `{... :url ...}` (or `:to`) whose
+      enclosing form also names `:rf.server/redirect` or
+      `:rf.server/safe-redirect`. This catches the
+      `(dispatch [... [:rf.server/redirect {:url "/x"}]])` /
+      `{:fx [[:rf.server/redirect {:to "/x"}]]}` reintroduction without
+      firing on `(navigate {:url "/x"})` client-nav, where no
+      `:rf.server/*redirect` tag is present.
+
+WHERE A SHAPE IS TOO AMBIGUOUS TO LINT WITHOUT NOISE (documented, not shipped)
+
+EP-0007 §Enforcement says "where shapes allow"; two shapes are deliberately
+NOT linted because they cannot be distinguished statically from sanctioned
+code without unacceptable false-positive noise:
+
+  * A redirect args map bound to a NAME far from the fx id, e.g.
+        (let [r {:url "/x"}] (dispatch [... [:rf.server/redirect r]]))
+    The `:url` key and the `:rf.server/redirect` tag are in different forms;
+    binding them requires dataflow analysis a regex gate can't do. The
+    RUNTIME guard (`reject-retired-redirect-keys!` in
+    re-frame.ssr.response) is the real backstop here — it throws on the
+    retired key regardless of how the map was constructed. This lint is a
+    fast static defence-in-depth for the common inline-literal shape, not a
+    replacement for the runtime throw.
+
+  * The bare `:frame` keyword as a coeffect read via an unusual accessor
+    (e.g. a user `(get (:coeffects ctx) :frame)`). The three canonical
+    forms above are what the framework uses; an exotic accessor is rare,
+    framework-author-only, and would need whole-form dataflow to bind the
+    map to `:coeffects`. Not worth the false-positive surface; the
+    `event_context_coeffect_keys_test` conformance test pins the exact
+    framework-injected coeffect key set so a `:frame` coeffect cannot ride
+    back IN even if a read of it slipped past this gate.
+
+SCAN SURFACE
+
+Framework source under `implementation/` — `.clj` / `.cljc` / `.cljs`. The
+default excludes `test/` trees: tests legitimately ASSERT the retired
+spelling is gone (the `event_context_coeffect_keys_test` checks
+`(not (contains? cofx :frame))`, and the SSR end-to-end test feeds `:url` /
+`:to` to assert the throw). A test fixture deliberately exercising a retired
+spelling is correct, not drift. Pass `--include-tests` to scan them too
+(used by the self-test fixtures, which live under a `test`-named dir).
+
+Exit code:
+    0  no retired spelling in framework source
+    1  at least one retired spelling (results printed file:line)
+    2  invocation / setup error
+
+Dependency-light — Python stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, NamedTuple
+
+# --------------------------------------------------------------------------
+# Scan surface
+# --------------------------------------------------------------------------
+
+# Framework reference implementation. `tools/` is bundle-isolated dev tooling
+# (NOT framework source) and `examples/` is consumer-shaped; the EP-0007
+# enforcement rule targets framework source, so the default surface is
+# `implementation/`. The runtime guards + this gate keep the framework clean;
+# consumer code reintroducing a retired spelling is caught by the runtime
+# throw at their call site.
+DEFAULT_SCAN_DIR = "implementation"
+
+_SOURCE_SUFFIXES = (".clj", ".cljc", ".cljs")
+
+# Directory names whose contents are never framework source for this gate.
+_EXCLUDE_DIR_NAMES = frozenset({
+    "node_modules",
+    "target",
+    ".shadow-cljs",
+    ".git",
+    ".beads",
+    ".cpcache",
+})
+
+# `test` / `tests` dirs are excluded by default (see module docstring): a test
+# that ASSERTS a retired spelling is gone, or feeds one to assert the runtime
+# throw, legitimately names it. `--include-tests` lifts the exclusion (the
+# self-test fixtures rely on this so their `*_test`-named files are scanned).
+_TEST_DIR_NAMES = frozenset({"test", "tests"})
+
+
+# --------------------------------------------------------------------------
+# Retired-shape patterns
+# --------------------------------------------------------------------------
+
+# (a) The retired `:frame` event-context COEFFECT read. Three forms, each of
+#     which the rf2-1m6rf1 rename removed. `\b` after `:frame` forbids
+#     matching `:frame/id` or `:frame-foo`; a `:rf.frame/id` read never
+#     matches because the keyword there is `:rf.frame/id`, not `:frame`.
+
+# 1. (get-coeffect <ctx> :frame)  — optionally namespace-qualified accessor
+#    (interceptor/get-coeffect, rf/get-coeffect, bare get-coeffect).
+_COEFFECT_GET_RE = re.compile(
+    r"\(\s*(?:[\w.+!*?<>=/-]+/)?get-coeffect\s+[^()]+?:frame\b(?!/)"
+)
+
+# 2. (:frame (:coeffects <x>))    — keyword-fn read off the :coeffects map.
+#    Whitespace-tolerant; the inner (:coeffects ...) is the load-bearing
+#    signal that this is a coeffect read, not a public-opt / trace-tag use.
+_COEFFECT_KWFN_RE = re.compile(
+    r"\(\s*:frame\b(?!/)\s*\(\s*:coeffects\b"
+)
+
+# 3. (get-in <ctx> [:coeffects :frame] ...) — get-in path through :coeffects.
+_COEFFECT_GETIN_RE = re.compile(
+    r"\[\s*:coeffects\s+:frame\b(?!/)\s*\]"
+)
+
+_COEFFECT_PATTERNS = (
+    ("get-coeffect-frame", _COEFFECT_GET_RE),
+    (":frame-of-:coeffects", _COEFFECT_KWFN_RE),
+    ("get-in-:coeffects-:frame", _COEFFECT_GETIN_RE),
+)
+
+# (b) The retired `:url` / `:to` redirect-TARGET key. Scoped to a form that
+#     also names an SSR redirect fx id, so client-navigation `:url` (no
+#     `:rf.server/*redirect` tag nearby) never matches. We detect, within a
+#     window that mentions `:rf.server/redirect` or `:rf.server/safe-redirect`,
+#     a `:url` or `:to` MAP KEY (a keyword immediately followed by whitespace
+#     and a value — the map-entry shape, distinguishing a key from a bare
+#     keyword used as a value).
+_SSR_REDIRECT_FX_RE = re.compile(r":rf\.server/(?:safe-)?redirect\b")
+
+# A retired redirect-target key in map-entry position: `:url <something>` or
+# `:to <something>` where the keyword opens a map entry. The trailing
+# `(?=\s)` + `\b` ensure `:url` not `:urls`/`:url/x`, and `:to` not
+# `:token`/`:to/x`. Matched only inside an SSR-redirect window (see below).
+_RETIRED_REDIRECT_KEY_RE = re.compile(r":(?:url|to)\b(?!/)\s")
+
+
+class Finding(NamedTuple):
+    path: Path
+    line: int
+    kind: str
+    snippet: str
+
+
+# --------------------------------------------------------------------------
+# Clojure-comment masking
+# --------------------------------------------------------------------------
+#
+# The retired spellings appear extensively in PROSE: docstrings, `;;` line
+# comments, and the rationale comments around the runtime guards (e.g. the
+# `retired-redirect-target-keys` def + its docstring in
+# re-frame.ssr.response). Those are documentation, not reintroduced code —
+# the gate must not fire on them. We mask:
+#
+#   * `;`-to-end-of-line comments (length-preserving so column offsets and
+#     the keyword `\b` boundaries are unchanged), AND
+#   * the contents of "..." string literals (docstrings + prose strings),
+#     again length-preserving.
+#
+# `#"..."` regex literals and `\"` escapes inside strings are handled by the
+# simple state machine below. The `retired-redirect-target-keys` DEF — the
+# vector literal `[:url :to]` that names the retired keys — is intentionally
+# NOT a redirect-fx form (it carries no `:rf.server/*redirect` tag in the same
+# window), so it does not match (b) regardless. And `[:url :to]` as bare
+# keywords are not in map-entry position (no value follows), so the
+# map-entry shape would not match them anyway.
+
+_LINE_COMMENT_RE = re.compile(r";.*$")
+
+
+def _mask_strings(line: str, in_string: bool) -> tuple[str, bool]:
+    """Replace "..."-string-literal contents with spaces (length-preserving).
+
+    Returns (masked-line, still-in-string?). Tracks multi-line strings via the
+    carried `in_string` flag. Backslash-escaped quotes inside a string do not
+    close it.
+    """
+    out = []
+    i = 0
+    n = len(line)
+    while i < n:
+        c = line[i]
+        if in_string:
+            if c == "\\" and i + 1 < n:
+                out.append("  ")
+                i += 2
+                continue
+            if c == '"':
+                in_string = False
+                out.append('"')
+                i += 1
+                continue
+            out.append(" ")
+            i += 1
+            continue
+        if c == '"':
+            in_string = True
+            out.append('"')
+            i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out), in_string
+
+
+def _mask_comment(line: str) -> str:
+    """Blank a `;`-to-EOL line comment, length-preserving.
+
+    Applied AFTER string masking so a `;` inside a (now-blanked) string is not
+    treated as a comment, and a `;` inside a real string is already gone.
+    """
+    m = _LINE_COMMENT_RE.search(line)
+    if not m:
+        return line
+    start = m.start()
+    return line[:start] + (" " * (len(line) - start))
+
+
+def _masked_lines(text: str) -> list[str]:
+    """Return per-line content with string-literals + `;` comments blanked.
+
+    Length-preserving so 1-based line numbers and reported snippets line up
+    with the source. Carries the in-string flag across newlines for multi-line
+    docstrings.
+    """
+    masked: list[str] = []
+    in_string = False
+    for raw in text.splitlines():
+        line, in_string = _mask_strings(raw, in_string)
+        line = _mask_comment(line)
+        masked.append(line)
+    return masked
+
+
+# --------------------------------------------------------------------------
+# File iteration
+# --------------------------------------------------------------------------
+
+
+def _iter_source_files(scan_root: Path, include_tests: bool) -> Iterable[Path]:
+    """Yield framework source files under scan_root.
+
+    Excludes generated/vendor dirs always, and `test`/`tests` dirs unless
+    `include_tests` is set.
+    """
+    if scan_root.is_file():
+        # Direct-file mode (used by --self-test fixtures pointing at one file).
+        if scan_root.suffix in _SOURCE_SUFFIXES:
+            yield scan_root
+        return
+    for path in sorted(scan_root.rglob("*")):
+        if path.suffix not in _SOURCE_SUFFIXES:
+            continue
+        parts = set(path.relative_to(scan_root).parts)
+        if parts & _EXCLUDE_DIR_NAMES:
+            continue
+        if not include_tests and (parts & _TEST_DIR_NAMES):
+            continue
+        yield path
+
+
+# --------------------------------------------------------------------------
+# Per-file scan
+# --------------------------------------------------------------------------
+
+
+def _scan_text(path: Path, text: str) -> list[Finding]:
+    """Return retired-spelling findings in `text` (already file-attributed).
+
+    Pattern-matching runs over the MASKED lines (string-literals + `;`
+    comments blanked) so prose never fires the gate, but the reported snippet
+    is the RAW source line so the diagnostic shows the actual offending text.
+    """
+    findings: list[Finding] = []
+    masked = _masked_lines(text)
+    raw = text.splitlines()
+
+    def raw_snippet(line_no: int) -> str:
+        # line_no is 1-based; raw may be shorter than masked only if the file
+        # ends without a trailing newline edge-case, so guard the index.
+        return raw[line_no - 1].strip() if 0 <= line_no - 1 < len(raw) else ""
+
+    # (a) Coeffect-read forms — line-local; none of the three spans lines.
+    for line_no, line in enumerate(masked, start=1):
+        for kind, pat in _COEFFECT_PATTERNS:
+            if pat.search(line):
+                findings.append(
+                    Finding(path, line_no, f"retired-frame-coeffect:{kind}",
+                            raw_snippet(line_no))
+                )
+
+    # (b) SSR-redirect retired target key. We work over a small sliding
+    #     window of masked lines: a retired `:url` / `:to` map-entry key counts
+    #     only when a `:rf.server/(safe-)redirect` tag appears within the same
+    #     window. The window is the enclosing top-level-ish form approximated
+    #     as +/- a few lines, which covers the realistic inline shapes
+    #     (`[:rf.server/redirect {:url ...}]`, possibly wrapped across 2-3
+    #     lines) without binding distant `let`-bound maps (documented
+    #     ambiguity limit).
+    _WINDOW = 3
+    for line_no, line in enumerate(masked, start=1):
+        if not _RETIRED_REDIRECT_KEY_RE.search(line):
+            continue
+        lo = max(0, line_no - 1 - _WINDOW)
+        hi = min(len(masked), line_no + _WINDOW)
+        window_text = "\n".join(masked[lo:hi])
+        if _SSR_REDIRECT_FX_RE.search(window_text):
+            findings.append(
+                Finding(path, line_no, "retired-redirect-target-key",
+                        raw_snippet(line_no))
+            )
+    return findings
+
+
+def scan(scan_root: Path, include_tests: bool = False) -> list[Finding]:
+    """Scan framework source under scan_root for retired spellings."""
+    findings: list[Finding] = []
+    for path in _iter_source_files(scan_root, include_tests):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        findings.extend(_scan_text(path, text))
+    return findings
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+_FIX_HINTS = {
+    "retired-frame-coeffect": (
+        "The bare `:frame` event-context coeffect was retired by EP-0002 R3 / "
+        "rf2-1m6rf1 (one carrier, one name). Read the frame stamp from the "
+        "`:rf.frame/id` coeffect instead — e.g. "
+        "`(interceptor/get-coeffect ctx :rf.frame/id)`. (The public `:frame` "
+        "dispatch/subscribe opt, the dispatch envelope key, the binary "
+        "fx-handler ctx `:frame`, and the trace `:frame` tag are all "
+        "sanctioned and unaffected.)"
+    ),
+    "retired-redirect-target-key": (
+        "The redirect-target keys `:url` / `:to` were retired by rf2-vngir / "
+        "EP-0007. The SSR redirect fx writes an HTTP `Location` header, so it "
+        "uses header vocabulary: the canonical (and only) redirect-target key "
+        "is `:location`. Rewrite the `:rf.server/redirect` / "
+        "`:rf.server/safe-redirect` arg as `{:location \"...\"}`. (`:url` is "
+        "still the canonical key on CLIENT navigation surfaces — different "
+        "concept, different word, per spec/Conventions.md §The naming rules.)"
+    ),
+}
+
+
+def _report(findings: list[Finding], repo_root: Path) -> None:
+    sys.stderr.write(
+        f"\n{len(findings)} retired spelling(s) found in framework source "
+        "(EP-0007 §Enforcement):\n\n"
+    )
+    for f in findings:
+        try:
+            rel = f.path.relative_to(repo_root)
+        except ValueError:
+            rel = f.path
+        sys.stderr.write(f"  {f.kind}: {rel}:{f.line}\n      {f.snippet}\n")
+    # Group fix hints by family so the message stays terse.
+    families = {k.split(":", 1)[0] for k in (f.kind for f in findings)}
+    sys.stderr.write("\nFix:\n")
+    for fam in sorted(families):
+        sys.stderr.write(f"  * {_FIX_HINTS[fam]}\n")
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "EP-0007 §Enforcement: fail on a retired spelling reappearing in "
+            "framework source (the bare :frame coeffect; redirect :url/:to)."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Path to the repo root. Defaults to the script's grandparent.",
+    )
+    parser.add_argument(
+        "--scan-dir",
+        default=None,
+        help=(
+            "Directory (relative to repo-root) to scan. Defaults to "
+            f"'{DEFAULT_SCAN_DIR}'."
+        ),
+    )
+    parser.add_argument(
+        "--include-tests",
+        action="store_true",
+        help=(
+            "Scan test/ trees too. Off by default — tests legitimately name "
+            "the retired spelling to assert it is gone / rejected."
+        ),
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Print progress to stderr."
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help=(
+            "Run the bundled fixture-based self-tests in "
+            "scripts/_test_fixtures/check_retired_spellings/ and exit."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _run_self_tests(verbose=args.verbose)
+
+    if args.repo_root:
+        repo_root = Path(args.repo_root).resolve()
+    else:
+        repo_root = Path(__file__).resolve().parent.parent
+
+    if not (repo_root / "mkdocs.yml").is_file():
+        sys.stderr.write(
+            f"error: {repo_root} does not look like the re-frame2 repo root "
+            "(no mkdocs.yml). Pass --repo-root explicitly.\n"
+        )
+        return 2
+
+    scan_root = repo_root / (args.scan_dir or DEFAULT_SCAN_DIR)
+    if not scan_root.exists():
+        sys.stderr.write(f"error: scan dir {scan_root} does not exist.\n")
+        return 2
+
+    if args.verbose:
+        n = sum(1 for _ in _iter_source_files(scan_root, args.include_tests))
+        sys.stderr.write(
+            f"scanning {n} framework source file(s) under "
+            f"{scan_root.relative_to(repo_root)} "
+            f"(tests {'included' if args.include_tests else 'excluded'})...\n"
+        )
+
+    findings = scan(scan_root, include_tests=args.include_tests)
+    if findings:
+        _report(findings, repo_root)
+        return 1
+    if args.verbose:
+        sys.stderr.write("no retired spellings in framework source.\n")
+    return 0
+
+
+# --------------------------------------------------------------------------
+# Self-tests (fixture-driven) — prove the gate FIRES on each retired shape
+# and stays GREEN on every sanctioned counterpart.
+# --------------------------------------------------------------------------
+
+_SELF_TEST_FIXTURE_ROOT = (
+    Path(__file__).resolve().parent / "_test_fixtures" / "check_retired_spellings"
+)
+
+
+def _run_self_tests(verbose: bool = False) -> int:
+    """Scan each fixture file and assert the expected finding count.
+
+    Each fixture is a single `.cljc` file. Positive fixtures plant ONE retired
+    shape (expected=1); negative fixtures exercise the sanctioned counterparts
+    that MUST stay green (expected=0). Fixtures live under a `negative`/`positive`
+    dir; we scan with --include-tests semantics (direct-file mode) so the
+    test-dir exclusion does not hide them.
+    """
+    cases: list[tuple[str, int]] = [
+        # (fixture-file relative to fixture-root, expected finding count)
+        # --- positives: each retired shape must FIRE ---
+        ("positive/get_coeffect_frame.cljc",        1),
+        ("positive/frame_of_coeffects.cljc",        1),
+        ("positive/get_in_coeffects_frame.cljc",    1),
+        ("positive/redirect_url_key.cljc",          1),
+        ("positive/safe_redirect_to_key.cljc",      1),
+        ("positive/redirect_url_multiline.cljc",    1),
+        # --- negatives: every sanctioned counterpart must stay GREEN ---
+        ("negative/public_frame_opt.cljc",          0),
+        ("negative/frame_trace_tag.cljc",           0),
+        ("negative/fx_handler_ctx_frame.cljc",      0),
+        ("negative/rf_frame_id_coeffect.cljc",      0),
+        ("negative/client_navigate_url.cljc",       0),
+        ("negative/redirect_location_key.cljc",     0),
+        ("negative/frame_in_comment.cljc",          0),
+        ("negative/frame_in_docstring.cljc",        0),
+        ("negative/retired_keys_def.cljc",          0),
+    ]
+
+    failures = 0
+    for fixture, expected in cases:
+        path = _SELF_TEST_FIXTURE_ROOT / fixture
+        if not path.is_file():
+            sys.stderr.write(
+                f"self-test FAIL: fixture {fixture!r} missing at {path}\n"
+            )
+            failures += 1
+            continue
+        # Direct-file scan (the fixture IS the surface).
+        got = len(scan(path, include_tests=True))
+        if got == expected:
+            if verbose:
+                sys.stderr.write(f"self-test PASS: {fixture} (findings={got})\n")
+        else:
+            sys.stderr.write(
+                f"self-test FAIL: {fixture} expected findings={expected}, "
+                f"got {got}\n"
+            )
+            failures += 1
+
+    if failures:
+        sys.stderr.write(f"\n{failures} self-test failure(s).\n")
+        return 1
+    if verbose:
+        sys.stderr.write(f"all {len(cases)} self-tests passed.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -149,6 +149,23 @@ run "re-frame2 eval-docs match evals.json" "python scripts/check_skill_eval_docs
 run "README inventory ratchet" "python scripts/check_readme_inventories.py" \
   python "$repo_root/scripts/check_readme_inventories.py"
 
+# EP-0007 §Enforcement retired-spelling gate (rf2-ziak6w): a retired spelling
+# reappearing in framework source is a CI failure, not a doc note.  Catches
+# the bare `:frame` event-context coeffect read (retired by rf2-1m6rf1 for
+# `:rf.frame/id`) and the `:url` / `:to` redirect-target key on an SSR
+# redirect fx (retired by rf2-vngir for `:location`).  Scoped precisely to
+# the retired SHAPES so it never fires on the sanctioned public `:frame` opt,
+# the trace `:frame` tag, the fx-handler ctx `:frame`, or client-navigation
+# `:url`.  Runs unconditionally (the surface is implementation/ source, not
+# markdown).  Self-test first (proves the gate fires on each retired shape and
+# stays green on every sanctioned counterpart), then the live scan asserts
+# framework source is clean.  See scripts/check_retired_spellings.py.
+run "retired-spelling gate self-test" "python scripts/check_retired_spellings.py --self-test" \
+  python "$repo_root/scripts/check_retired_spellings.py" --self-test
+
+run "retired-spelling gate (EP-0007)" "python scripts/check_retired_spellings.py --verbose" \
+  python "$repo_root/scripts/check_retired_spellings.py" --verbose
+
 run "core JVM" "cd implementation/core && clojure -M:test" \
   bash -lc "cd '$repo_root/implementation/core' && clojure -M:test"
 


### PR DESCRIPTION
EP-0007 (One Name Per Fact) §Enforcement: rule 2 ("no stable accepted synonyms") gets the no-floor-lint treatment **where shapes allow** — a retired spelling reappearing in framework source is a CI failure, not a doc note. Both renames have merged, so the lint can land now.

## What lands

`scripts/check_retired_spellings.py` — a fast, stdlib-only gate (the `check_*.py` + `--self-test` shape used by the other repo checks) that fails when framework source under `implementation/` reintroduces a retired spelling:

- **(a) the bare `:frame` event-context COEFFECT read** — retired by `rf2-1m6rf1` (EP-0002 R3 "one carrier, one name") in favour of `:rf.frame/id`. Scoped to the three coeffect-read forms the rename removed:
  - `(get-coeffect <ctx> :frame …)` (any ns-qualified accessor)
  - `(:frame (:coeffects <x>))` (keyword-fn off the `:coeffects` map)
  - `(get-in <ctx> [:coeffects :frame] …)`
- **(b) the `:url` / `:to` redirect-TARGET key** on a `:rf.server/redirect` / `:rf.server/safe-redirect` fx — retired by `rf2-vngir` in favour of `:location` (the fx writes an HTTP `Location` header → header vocabulary). Scoped to a `:url`/`:to` map-entry key appearing in a form that also names the redirect fx id (a sliding window covers the inline + 2–3-line-wrapped shapes).

### Precisely scoped — no false positives on sanctioned uses

`:frame` and `:url` are heavily sanctioned elsewhere (a bare grep fires on 100+ legitimate sites). The gate greps for the retired **shapes**, never the bare keyword, and masks `"…"` string-literals + `;`-comments so prose never fires:

- `:frame` — sanctioned: public dispatch/subscribe opt, dispatch envelope key, binary fx-handler ctx (Spec 002), HTTP-interceptor ctx (Spec 014), trace/error-record tag. Only the *coeffect read* was retired.
- `:url` — sanctioned: the canonical CLIENT-navigation key (per `spec/Conventions.md` §The naming rules, HTTP-response-vs-navigation vocabulary rule). Only its use as an SSR redirect-TARGET key was retired.

### Where a shape is too ambiguous to lint without noise (documented, not shipped)

Per the EP's "where shapes allow" wording, two shapes are deliberately **not** linted (documented in the script header as non-targets):
- a redirect args map bound to a name far from the fx id (`(let [r {:url …}] … [:rf.server/redirect r])`) — needs dataflow a regex can't do; the runtime `reject-retired-redirect-keys!` throw is the backstop.
- an exotic coeffect accessor (`(get (:coeffects ctx) :frame)`) — framework-author-only, rare; the `event_context_coeffect_keys_test` conformance test pins the exact framework coeffect key set so `:frame` can't ride back *in*.

### Wiring

- **CI** (`.github/workflows/test.yml`): two steps (self-test + live scan) in the always-on `verify-skill-mcp-drift` PR-spine python job, which already sets up Python and is in the `All required checks passed` aggregator's `needs:` — so a finding blocks the merge regardless of which surface a PR touches. **⚠️ HOT-ZONE: this is a `.github/workflows/*` edit** (flagged per dispatch rules; it adds two steps to an existing job, no new job/aggregator wiring).
- **Local** (`scripts/test-fast-pr.sh`): runs unconditionally (surface is `implementation/` source, not markdown).
- Marks EP-0007 Bead Plan item 5 done (`docs/EP/EP-0007-one-name-per-fact.md`).

## Quality gates

- `python scripts/check_retired_spellings.py --self-test --verbose` → **PASS** (15/15: 6 positives prove each retired shape fires; 9 negatives prove every sanctioned counterpart — public opt, trace tag, fx-handler ctx, `:rf.frame/id` coeffect, client-nav `:url`, `:location` redirect key, comment/docstring prose, the `retired-redirect-target-keys` def — stays green).
- `python scripts/check_retired_spellings.py --verbose` against current `implementation/` (217 source files) → **PASS, clean, exit 0** (both renames merged; framework source carries no retired spelling).
- **Planted-positive proof (real source, reverted after):**
  - reverted one `(get-coeffect ctx :rf.frame/id)` → `:frame` in `implementation/core/src/re_frame/cofx.cljc` → gate **FAILED** (exit 1), `retired-frame-coeffect:get-coeffect-frame` at `cofx.cljc:100`.
  - planted `[:rf.server/redirect {:url "/x"}]` in `implementation/ssr/src/re_frame/ssr/response.cljc` → gate **FAILED** (exit 1), `retired-redirect-target-key`. Both reverts confirmed clean (exit 0, zero diff).
- `python scripts/check_ep_status_sync.py --verbose` → PASS (EP doc edit changed no status line).
- `python scripts/check_doc_slugs.py` → PASS (EP doc edit added no links).
- `test.yml` parses as valid YAML; `bash -n scripts/test-fast-pr.sh` clean.
