### PR TITLE
feat(core): EP-0008 frame-teardown report — single always-on :rf.error/frame-teardown-failed (rf2-ini4wr)

### DIFF
--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -221,6 +221,65 @@
     ((:fan-out registry) record))
   nil)
 
+;; ---- frame-teardown report (EP-0008 promotion criterion) ------------------
+;;
+;; The frame-destroy teardown recipe runs many optional cleanup hooks. A
+;; hook throwing is production-reachable (long-lived SSR / tooling), is a
+;; resource-leakage class (skipped teardown the next operation cannot see
+;; locally), and compounds with process lifetime — all three legs of the
+;; Spec 009 §promotion criterion hold. Rather than fan ONE always-on
+;; emission out per failed hook (an SSR per-request-destroy × M req/s flood
+;; of the production error shipper), the runtime accumulates the per-hook
+;; failures and emits ONE bounded `:rf.error/frame-teardown-failed` record
+;; carrying a `:hook-failures` vector (Spec 009 §Channel-promotion catalogue
+;; rows — the report-vs-per-item idiom). The dev per-hook diagnostic
+;; (`:rf.warning/teardown-hook-exception`, DCE'd in prod) stays at its
+;; causal positions inside `frame/safe-call-hook!`.
+
+(defn dispatch-frame-teardown-report!
+  "Surface ONE always-on `:rf.error/frame-teardown-failed` report through
+  the corpus-wide error-emit listener registry (surface #4). Always-on
+  (NOT gated by `re-frame.interop/debug-enabled?`) — fires in CLJS
+  production builds where the dev per-hook trace is DCE'd.
+
+  Per Spec 009 §Observability channels §Channel-promotion catalogue rows
+  (EP-0008 Open Issue 1, ruled): the frame-destroy case satisfies the
+  promotion criterion with a SINGLE bounded report naming the higher-
+  level fact, with the per-hook detail carried as the `hook-failures`
+  payload vector — NOT one record per failed hook. The destroy IS the
+  fact; the hooks are detail rows, and one record preserves the
+  which-hooks-failed-together correlation external shippers will not
+  reliably re-group.
+
+  Builds the catalogue-shaped record (`:tags` keys `:frame`,
+  `:hook-failures`, `:reason`; `:recovery :ignored` — teardown is
+  best-effort) and fans it out. Called at most once per destroy
+  (whether teardown completes or aborts) via the
+  `:error-emit/dispatch-frame-teardown-report` late-bind hook from
+  `frame.cljc`'s finally-shaped flush boundary (`frame` cannot static-
+  require this ns — `error-emit` → `elision` → `frame` is a load cycle).
+
+  `hook-failures` is a non-empty vector of
+  `{:hook <late-bind-hook-key> :exception <ex> :where :safe-call-hook!}`
+  entries — one per failed hook, accumulated during the teardown walk.
+  Returns nil; a no-op when `hook-failures` is empty (no failures, no
+  report)."
+  [frame-id hook-failures time]
+  (when (seq hook-failures)
+    (let [record {:error          :rf.error/frame-teardown-failed
+                  :frame          frame-id
+                  :hook-failures  (vec hook-failures)
+                  :recovery       :ignored
+                  :reason         (str (count hook-failures)
+                                       " frame-teardown cleanup hook(s) threw"
+                                       " during destroy; teardown continued"
+                                       " best-effort (skipped cleanup may have"
+                                       " leaked resources)")
+                  :time           time}]
+      ;; Corpus-wide listeners fan out.
+      ((:fan-out registry) record)))
+  nil)
+
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
 ;; `router.cljc` already statically `:require`s this namespace (per
@@ -232,3 +291,10 @@
 ;; records without static-requiring this ns.
 
 (late-bind/set-fn! :error-emit/dispatch-on-error dispatch-on-error!)
+
+;; The frame-teardown report fires from `frame/destroy-frame!`'s finally-
+;; shaped flush. `frame` MUST reach it via late-bind: a static
+;; `re-frame.frame` → `re-frame.error-emit` require closes a load cycle
+;; (`error-emit` → `elision` → `frame`). Per EP-0008 / rf2-ini4wr.
+(late-bind/set-fn! :error-emit/dispatch-frame-teardown-report
+                   dispatch-frame-teardown-report!)

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -974,6 +974,21 @@
 ;; take no frame arg). Per rf2-x3m8c.
 (def ^:dynamic *destroying-frame-id* nil)
 
+;; Per-destroy accumulator of cleanup-hook failures, bound to a fresh atom
+;; by `destroy-frame!` for the duration of the teardown walk. Each
+;; `safe-call-hook!` failure conj's one entry
+;; (`{:hook <key> :exception <ex> :where :safe-call-hook!}`); the
+;; finally-shaped flush at the bottom of `destroy-frame!` ships them as the
+;; single always-on `:rf.error/frame-teardown-failed` report's
+;; `:hook-failures` vector. ACCUMULATING into a side atom (rather than
+;; emitting per-hook on the always-on axis) is what makes the flush
+;; FINALLY-shaped: if a downstream teardown step aborts the walk mid-recipe,
+;; the entries collected so far are already in the atom and the `finally`
+;; boundary still flushes them (EP-0008 R1 / Spec 009 §Emit-safety —
+;; finally-shaped flush). nil outside a destroy (defensive — `safe-call-hook!`
+;; only conj's when bound). Per rf2-ini4wr.
+(def ^:dynamic *teardown-hook-failures* nil)
+
 ;; Pre-cascade frame-state snapshot of the in-flight dequeued event, bound by
 ;; the router around `process-event!` (see `re-frame.router/run-one-pass!`).
 ;; A handler that calls `destroy-frame!` on its own frame mid-drain runs
@@ -991,19 +1006,43 @@
 (defn- safe-call-hook!
   "Fire a late-bound cleanup hook by key. No-op when unbound. Exceptions
   are caught so one bad hook can't block the rest of teardown — but the
-  failure is NOT silent (rf2-x3m8c): before continuing we emit a
-  `:rf.warning/teardown-hook-exception` trace carrying the hook key, the
-  in-flight frame id (when known via `*destroying-frame-id*`), and the
-  exception, so a leaked optional-artefact cleanup (stale schemas, flow
-  rows, side-channel atoms, trace rings) leaves a causal breadcrumb in
-  long-lived SSR / test / tooling processes. Best-effort teardown
-  semantics are preserved — the throw is swallowed and teardown
-  continues. The emit rides `interop/debug-enabled?` (inside
-  `trace/emit-error!`) so production CLJS bundles DCE it."
+  failure is NOT silent. On a throw we do TWO things, on two distinct
+  Spec 009 observability channels:
+
+    1. ALWAYS-ON axis (EP-0008 R1, rf2-ini4wr) — conj the failure entry
+       (`{:hook <key> :exception <ex> :where :safe-call-hook!}`) onto the
+       per-destroy `*teardown-hook-failures*` accumulator. `destroy-frame!`
+       flushes the accumulated entries as ONE bounded
+       `:rf.error/frame-teardown-failed` report through a finally-shaped
+       boundary, so even a mid-teardown abort ships the entries gathered
+       so far. Accumulating here (rather than emitting per-hook on the
+       always-on axis) collapses the SSR per-request-destroy × M req/s
+       per-hook flood to one record per destroy while preserving the
+       which-hooks-failed-together correlation (Spec 009 §Channel-
+       promotion catalogue rows).
+
+    2. DIAGNOSTIC channel (EP-0008 R2, rf2-x3m8c) — emit the per-hook
+       `:rf.warning/teardown-hook-exception` trace at its CAUSAL position
+       carrying the hook key, the in-flight frame id (`*destroying-frame-
+       id*`), and the exception, so a leaked optional-artefact cleanup
+       (stale schemas, flow rows, side-channel atoms, trace rings) leaves
+       a dev breadcrumb in long-lived SSR / test / tooling processes. This
+       emit rides `interop/debug-enabled?` (inside `trace/emit-error!`) so
+       production CLJS bundles DCE it — the per-hook dev visibility is KEPT
+       (only the always-on emission collapsed to the single report).
+
+  Best-effort teardown semantics are preserved — the throw is swallowed
+  and teardown continues (`:recovery :ignored`)."
   [hook-key & args]
   (when-let [f (late-bind/get-fn hook-key)]
     (try (apply f args)
          (catch #?(:clj Throwable :cljs :default) ex
+           ;; Always-on axis: accumulate (flushed once by destroy-frame!).
+           (when-let [acc *teardown-hook-failures*]
+             (swap! acc conj {:hook      hook-key
+                              :exception ex
+                              :where     :safe-call-hook!}))
+           ;; Diagnostic channel: per-hook dev trace at its causal position.
            (trace/emit-error! :rf.warning/teardown-hook-exception
                               {:category  :rf.warning/teardown-hook-exception
                                :hook      hook-key
@@ -1308,8 +1347,17 @@
       ;; Both are passed to `notify-epoch-listeners!` (step 8). EP-0001
       ;; (rf2-3aizt1, decision #2): the whole frame-state, both partitions.
       (let [cascade-fs-before *cascade-frame-state-before*
-            fs-at-destroy     (frame-state-value id)]
-       (binding [*destroying-frame-id* id]
+            fs-at-destroy     (frame-state-value id)
+            ;; EP-0008 R1 (rf2-ini4wr): per-destroy accumulator for
+            ;; cleanup-hook failures. `safe-call-hook!` conj's an entry per
+            ;; failed hook; the finally-shaped flush below ships them as ONE
+            ;; always-on `:rf.error/frame-teardown-failed` report. Held in a
+            ;; side atom so a mid-teardown abort still flushes the entries
+            ;; gathered so far (the entries are already in the atom when the
+            ;; `finally` runs).
+            hook-failures     (atom [])]
+       (binding [*destroying-frame-id*    id
+                 *teardown-hook-failures* hook-failures]
         (try
         (fire-on-destroy-event! id f)
         (notify-machine-destruction! id)
@@ -1381,6 +1429,27 @@
         (notify-epoch-listeners! id cascade-fs-before fs-at-destroy)
         nil
         (finally
+          ;; EP-0008 R1 (rf2-ini4wr) — FINALLY-shaped flush of the always-on
+          ;; teardown report. If any cleanup hook threw (entries accumulated
+          ;; in `hook-failures`), ship ONE bounded
+          ;; `:rf.error/frame-teardown-failed` record carrying the
+          ;; `:hook-failures` vector. Running this in the `finally` is the
+          ;; emit-safety contract: even if a downstream teardown step aborts
+          ;; the walk mid-recipe (after, say, hook 3 of 7), the entries
+          ;; collected so far are already in the atom and STILL flush — the
+          ;; single-report shape does not sacrifice incremental delivery
+          ;; against a mid-teardown collapse (Spec 009 §Emit-safety). Reached
+          ;; via late-bind (`error-emit` → `elision` → `frame` is a load
+          ;; cycle); no-op when no hook failed (the report fn short-circuits
+          ;; on an empty vector). The flush itself is wrapped so a fault in
+          ;; the always-on substrate can never strand the in-flight marker.
+          (let [failures @hook-failures]
+            (when (seq failures)
+              (when-let [emit-report (late-bind/get-fn
+                                       :error-emit/dispatch-frame-teardown-report)]
+                (try
+                  (emit-report id failures (interop/now-ms))
+                  (catch #?(:clj Throwable :cljs :default) _ nil)))))
           ;; Always clear the in-flight marker — even if a downstream step
           ;; throws unexpectedly, future `destroy-frame!` calls for `id`
           ;; (after a fresh `reg-frame`) must not see a stale entry.

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -718,6 +718,10 @@
     :producer-ns 're-frame.error-emit
     :design-bead "rf2-bacs4"
     :description "Always-on per-`:rf.error/*` fan-out: builds the tight error-record once (elided), then fans it out to the corpus-wide listener registry (rf2-bacs4 — Sentry / Honeybadger / Rollbar shippers), ALWAYS fired. Per-listener invocations try/catch wrapped (a buggy listener cannot block siblings). Recovery is framework-owned (the per-category typed defaults); the per-frame `:on-error` recovery policy was REMOVED (rf2-hiqtk8, superseding the rf2-2hvga axis-2 / recovery-policy-eligible column). Survives `:advanced` + `goog.DEBUG=false`. Invoked from EVERY production-reachable `:rf.error/*` site: router (handler-exception, flow-eval, frame-destroyed), fx (reserved-fx typed throws), subs/memo + subs (reactive + compute-sub exceptions), subs (frame-destroyed, no-such-sub on subscribe), router/diagnostics (no-such-handler)."}
+   {:key         :error-emit/dispatch-frame-teardown-report
+    :producer-ns 're-frame.error-emit
+    :design-bead "rf2-ini4wr"
+    :description "Always-on ONE-bounded-record-per-destroy frame-teardown report (EP-0008 promotion criterion / Spec 009 §Channel-promotion catalogue rows). `frame/destroy-frame!` accumulates per-hook failures during the best-effort teardown walk and, through a FINALLY-shaped flush boundary, fires this hook once with the `:frame` + the collected `:hook-failures` vector — so a mid-teardown abort still ships the entries gathered so far. Builds the catalogue-shaped `:rf.error/frame-teardown-failed` record (`:recovery :ignored`) and fans it out to the corpus-wide error listeners. NOT one record per failed hook (the per-hook detail stays on the dev-only `:rf.warning/teardown-hook-exception` trace, DCE'd in prod). `frame` reaches it via late-bind because a static require closes a `error-emit` → `elision` → `frame` load cycle. Survives `:advanced` + `goog.DEBUG=false`. No-op when no hook failed."}
 
    ;; ===========================================================================
    ;; GROUP 3 — ADAPTER-INJECTION

--- a/implementation/core/test/re_frame/frame_teardown_report_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_teardown_report_cljs_test.cljc
@@ -1,0 +1,284 @@
+(ns re-frame.frame-teardown-report-cljs-test
+  "EP-0008 / rf2-ini4wr — the frame-teardown report. On frame destroy,
+  the best-effort teardown recipe runs many optional late-bound cleanup
+  hooks (`:ssr/on-frame-destroyed`, `:schemas/on-frame-destroyed!`,
+  `:flows/teardown-on-frame-destroy!`, …). When one or more throw, the
+  runtime emits ONE bounded always-on `:rf.error/frame-teardown-failed`
+  record carrying a `:hook-failures` vector — NOT one always-on emission
+  per hook (Spec 009 §Observability channels §Channel-promotion catalogue
+  rows; the promotion of the EP-0008 C4 prod-silence bug off the DCE'd
+  `:rf.warning/teardown-hook-exception`).
+
+  Pins the four acceptance legs:
+
+    (a) N hook failures → exactly ONE always-on report carrying N
+        `:hook-failures` entries (single report, not per-hook flood).
+    (b) Partial-teardown-abort still flushes the collected entries — the
+        FINALLY boundary (EP-0008 R1): a downstream teardown step throws
+        AFTER some hooks failed; the report still ships the entries
+        gathered so far.
+    (c) The report rides the ALWAYS-ON axis — exercised via the
+        `register-error-listener!` substrate that survives a production
+        build path (`error-emit/dispatch-frame-teardown-report!` is NOT
+        gated by `interop/debug-enabled?`).
+    (d) The dev per-hook DIAGNOSTIC rows still emit at their causal
+        positions (EP-0008 R2 — per-hook visibility is KEPT on the
+        diagnostic axis; only the always-on emission collapsed).
+
+  Dual-runtime: named `*_cljs_test.cljc` so the shadow-cljs `:node-test`
+  build (`npm run test:cljs`, `:ns-regexp \"cljs-test$\"`) AND the JVM
+  `clojure -M:test` runner both pick it up. The teardown path is plain
+  CLJC; no DOM dependency."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+;; ---------------------------------------------------------------------------
+;; Fixture — fresh registrar + plain-atom adapter per test; the always-on
+;; error-listener registry (a `defonce` atom) cleared so a listener from one
+;; test cannot leak into the next.
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn []
+                (error-emit/clear-error-listeners!))}))
+
+;; ---------------------------------------------------------------------------
+;; Cleanup-hook-key install helper.
+;;
+;; The teardown cleanup hooks are late-bound (optional artefacts). In a
+;; core-only build they are usually UNBOUND. We install a throwing fn under
+;; a hook key for the duration of `f`, snapshotting + restoring the prior
+;; binding so the install never leaks across tests (set-fn! to the original,
+;; or to nil when there was none — get-fn returns nil for both, the unbound
+;; state).
+;; ---------------------------------------------------------------------------
+
+(defn- with-hooks*
+  "Install each `hook-key -> fn` from `hook-map` via `late-bind/set-fn!`
+  for the dynamic extent of `f`, restoring the prior bindings after."
+  [hook-map f]
+  (let [originals (into {} (map (fn [k] [k (late-bind/get-fn k)]) (keys hook-map)))]
+    (try
+      (doseq [[k v] hook-map] (late-bind/set-fn! k v))
+      (f)
+      (finally
+        (doseq [[k orig] originals] (late-bind/set-fn! k orig))))))
+
+(defn- throwing-hook
+  "A cleanup-hook fn that always throws — models a leaked optional-artefact
+  cleanup. Accepts any arity (the cache-reset hooks take no frame arg; the
+  per-frame hooks take an id)."
+  [label]
+  (fn [& _] (throw (ex-info (str "teardown hook threw: " label) {:hook label}))))
+
+;; ===========================================================================
+;; (a) N hook failures → exactly ONE always-on report with N entries
+;; ===========================================================================
+
+(deftest n-hook-failures-yield-one-report-with-n-entries
+  (testing "Per rf2-ini4wr / Spec 009 §Channel-promotion catalogue rows:
+            N cleanup hooks throwing during destroy produce EXACTLY ONE
+            always-on `:rf.error/frame-teardown-failed` record carrying N
+            `:hook-failures` entries — NOT one record per failed hook."
+    (let [seen (atom [])]
+      (rf/register-error-listener! :test/recorder
+                                   (fn [record] (swap! seen conj record)))
+      (rf/reg-frame :teardown/n-failures {:doc "three hooks will throw"})
+      (with-hooks*
+        {:ssr/on-frame-destroyed         (throwing-hook :ssr)
+         :schemas/on-frame-destroyed!    (throwing-hook :schemas)
+         :flows/teardown-on-frame-destroy! (throwing-hook :flows)}
+        (fn [] (rf/destroy-frame! :teardown/n-failures)))
+      (let [reports (filter #(= :rf.error/frame-teardown-failed (:error %)) @seen)]
+        (is (= 1 (count reports))
+            "exactly ONE always-on report per destroy — not three (one per hook)")
+        (let [r (first reports)]
+          (is (= :teardown/n-failures (:frame r))
+              ":frame names the destroyed frame")
+          (is (= 3 (count (:hook-failures r)))
+              "the report carries one :hook-failures entry per failed hook")
+          (is (= #{:ssr/on-frame-destroyed
+                   :schemas/on-frame-destroyed!
+                   :flows/teardown-on-frame-destroy!}
+                 (set (map :hook (:hook-failures r))))
+              "every failed hook key is represented in :hook-failures")
+          (is (every? #(= :safe-call-hook! (:where %)) (:hook-failures r))
+              "each entry carries :where :safe-call-hook!")
+          (is (every? #(some? (:exception %)) (:hook-failures r))
+              "each entry carries the thrown exception")
+          (is (= :ignored (:recovery r))
+              ":recovery :ignored — teardown is best-effort")
+          (is (string? (:reason r)) ":reason is a human-readable sentence")
+          (is (number? (:time r)) ":time is a wall-clock millis number"))))))
+
+(deftest clean-destroy-emits-no-report
+  (testing "Per rf2-ini4wr: a destroy with NO failing hook emits NO
+            `:rf.error/frame-teardown-failed` report (the report fn
+            short-circuits on an empty :hook-failures vector)."
+    (let [seen (atom [])]
+      (rf/register-error-listener! :test/recorder
+                                   (fn [record] (swap! seen conj record)))
+      (rf/reg-frame :teardown/clean {:doc "no hooks throw"})
+      (rf/destroy-frame! :teardown/clean)
+      (is (empty? (filter #(= :rf.error/frame-teardown-failed (:error %)) @seen))
+          "no report when teardown completes cleanly"))))
+
+;; ===========================================================================
+;; (b) Partial-teardown-abort still flushes — the FINALLY boundary (R1)
+;; ===========================================================================
+
+(deftest partial-teardown-abort-still-flushes-collected-entries
+  (testing "Per rf2-ini4wr EP-0008 R1 / Spec 009 §Emit-safety (finally-
+            shaped flush): if teardown ABORTS mid-recipe after some hooks
+            have already failed, the entries collected so far MUST still
+            ship. We make two cleanup hooks throw (accumulating two
+            entries) and then force a downstream teardown step
+            (`emit-frame-destroyed-trace!`, which runs AFTER the cleanup
+            hooks) to throw unrecoverably — the throw propagates out of
+            `destroy-frame!`, yet the finally-shaped flush still emits the
+            report with the two gathered entries."
+    (let [seen (atom [])]
+      (rf/register-error-listener! :test/recorder
+                                   (fn [record] (swap! seen conj record)))
+      (rf/reg-frame :teardown/abort {:doc "aborts mid-teardown"})
+      (with-hooks*
+        ;; These two run BEFORE emit-frame-destroyed-trace! in the recipe,
+        ;; so both accumulate before the abort.
+        {:ssr/on-frame-destroyed      (throwing-hook :ssr)
+         :schemas/on-frame-destroyed! (throwing-hook :schemas)}
+        (fn []
+          ;; Force a mid-teardown collapse: a downstream NON-hook step
+          ;; throws. `safe-call-hook!` swallows hook throws, so to model a
+          ;; genuine abort we redef a later teardown step to throw.
+          (with-redefs [frame/emit-frame-destroyed-trace!
+                        (fn [_id]
+                          (throw (ex-info "mid-teardown collapse" {})))]
+            (is (thrown? #?(:clj Throwable :cljs js/Error)
+                         (rf/destroy-frame! :teardown/abort))
+                "the downstream teardown step's throw propagates"))))
+      (let [reports (filter #(= :rf.error/frame-teardown-failed (:error %)) @seen)]
+        (is (= 1 (count reports))
+            "the report STILL flushed despite the mid-teardown abort")
+        (let [r (first reports)]
+          (is (= 2 (count (:hook-failures r)))
+              "the report carries the TWO entries gathered before the abort
+               (the finally boundary flushed the partial accumulation)")
+          (is (= #{:ssr/on-frame-destroyed :schemas/on-frame-destroyed!}
+                 (set (map :hook (:hook-failures r))))
+              "the gathered hook keys are exactly the ones that ran + threw
+               before the collapse"))))))
+
+;; ===========================================================================
+;; (c) The report rides the ALWAYS-ON axis (survives the production path)
+;; ===========================================================================
+
+(deftest report-rides-the-always-on-axis
+  (testing "Per rf2-ini4wr EP-0008: the report is delivered through the
+            corpus-wide `register-error-listener!` substrate
+            (`error-emit/dispatch-frame-teardown-report!`), which is NOT
+            gated by `interop/debug-enabled?` and so survives `:advanced`
+            + `goog.DEBUG=false`. Exercising the listener directly proves
+            the report is on the always-on axis, not the DCE'd diagnostic
+            trace. (Companion to the dispatch-on-error always-on contract
+            in on-error-test.)"
+    (let [seen (atom [])]
+      ;; Direct substrate exercise — the same fn frame.cljc reaches via
+      ;; the :error-emit/dispatch-frame-teardown-report late-bind hook.
+      (rf/register-error-listener! :test/recorder
+                                   (fn [record] (swap! seen conj record)))
+      (error-emit/dispatch-frame-teardown-report!
+        :prod/frame
+        [{:hook :ssr/on-frame-destroyed :exception (ex-info "x" {}) :where :safe-call-hook!}]
+        12345)
+      (is (= 1 (count @seen)) "the always-on listener received the report")
+      (let [r (first @seen)]
+        (is (= :rf.error/frame-teardown-failed (:error r)))
+        (is (= :prod/frame (:frame r)))
+        (is (= 1 (count (:hook-failures r))))
+        (is (= 12345 (:time r))))))
+
+  (testing "Per rf2-ini4wr: the report fn is a no-op on an empty
+            :hook-failures vector (no failures, no always-on flood)."
+    (let [seen (atom [])]
+      (rf/register-error-listener! :test/recorder
+                                   (fn [record] (swap! seen conj record)))
+      (error-emit/dispatch-frame-teardown-report! :prod/frame [] 1)
+      (is (empty? @seen) "empty :hook-failures → no record fanned out"))))
+
+(deftest report-late-bind-hook-is-published
+  (testing "Per rf2-ini4wr: error-emit publishes the
+            `:error-emit/dispatch-frame-teardown-report` late-bind hook
+            (frame.cljc reaches it via late-bind to avoid the
+            error-emit → elision → frame load cycle)."
+    (is (some? (late-bind/get-fn :error-emit/dispatch-frame-teardown-report))
+        "the hook is registered at error-emit ns-load")))
+
+;; ===========================================================================
+;; (d) Dev per-hook DIAGNOSTIC rows still emit at causal positions (R2)
+;; ===========================================================================
+
+(deftest dev-per-hook-diagnostic-rows-still-emit
+  (testing "Per rf2-ini4wr EP-0008 R2 / Spec 009: the per-hook
+            `:rf.warning/teardown-hook-exception` DIAGNOSTIC trace still
+            emits at its causal position inside `safe-call-hook!` (dev
+            visibility KEPT — only the always-on emission collapsed to the
+            single report). One diagnostic row per failed hook, carrying
+            the hook key + frame."
+    (let [traces (atom [])]
+      (rf/register-listener! ::rec (fn [ev] (swap! traces conj ev)))
+      (rf/reg-frame :teardown/diagnostic {:doc "two hooks throw"})
+      (with-hooks*
+        {:ssr/on-frame-destroyed      (throwing-hook :ssr)
+         :schemas/on-frame-destroyed! (throwing-hook :schemas)}
+        (fn []
+          (try
+            (rf/destroy-frame! :teardown/diagnostic)
+            (finally (rf/unregister-listener! ::rec)))))
+      (let [warns (filter #(= :rf.warning/teardown-hook-exception (:operation %))
+                          @traces)]
+        ;; The trace surface is live in dev (this runner), so the per-hook
+        ;; rows are present. (Under :advanced + goog.DEBUG=false they DCE —
+        ;; the contract is that they ride the DIAGNOSTIC channel, not that
+        ;; they survive prod.)
+        (is (= 2 (count warns))
+            "one diagnostic row per failed hook at its causal position")
+        (is (= #{:ssr/on-frame-destroyed :schemas/on-frame-destroyed!}
+               (set (map #(get-in % [:tags :hook]) warns)))
+            "each diagnostic row names the hook that threw")
+        (is (every? #(= :teardown/diagnostic (get-in % [:tags :frame])) warns)
+            "each diagnostic row is frame-attributed")))))
+
+(deftest both-channels-fire-together
+  (testing "Per rf2-ini4wr: a single destroy with failing hooks fires
+            BOTH channels — the dev per-hook diagnostic rows (one each)
+            AND the one always-on report (carrying both). The two axes are
+            independent and complementary (Spec 009 §Observability
+            channels)."
+    (let [traces (atom [])
+          reports (atom [])]
+      (rf/register-error-listener! :test/recorder
+                                   (fn [record] (swap! reports conj record)))
+      (rf/register-listener! ::rec (fn [ev] (swap! traces conj ev)))
+      (rf/reg-frame :teardown/both {:doc "two hooks throw"})
+      (with-hooks*
+        {:ssr/on-frame-destroyed      (throwing-hook :ssr)
+         :schemas/on-frame-destroyed! (throwing-hook :schemas)}
+        (fn []
+          (try
+            (rf/destroy-frame! :teardown/both)
+            (finally (rf/unregister-listener! ::rec)))))
+      (let [warns   (filter #(= :rf.warning/teardown-hook-exception (:operation %))
+                            @traces)
+            reps    (filter #(= :rf.error/frame-teardown-failed (:error %)) @reports)]
+        (is (= 2 (count warns)) "diagnostic channel: one per-hook row each")
+        (is (= 1 (count reps)) "always-on channel: ONE bounded report")
+        (is (= 2 (count (:hook-failures (first reps))))
+            "the single report carries both hook failures")))))


### PR DESCRIPTION
## What

Implements **rf2-ini4wr** (EP-0008 bead B): the **frame-teardown report**. On frame destroy, the best-effort teardown recipe runs many optional late-bound cleanup hooks (`:ssr/on-frame-destroyed`, `:schemas/on-frame-destroyed!`, `:flows/teardown-on-frame-destroy!`, …). When one or more throw, the runtime now emits **ONE** bounded always-on `:rf.error/frame-teardown-failed` record carrying a `:hook-failures` vector — **not** one always-on emission per failed hook.

This promotes the EP-0008 C4 prod-silence bug off the DCE'd `:rf.warning/teardown-hook-exception` (which vanished under `:advanced` + `goog.DEBUG=false`) onto the production-survivable error axis, per the Spec 009 graduated channel contract (bead A, merged).

## How

- **`error-emit.cljc`** — new `dispatch-frame-teardown-report!`: builds the catalogue-shaped record (`:frame`, `:hook-failures`, `:reason`, `:recovery :ignored`, `:time`) and fans it out through the same corpus-wide listener registry as `dispatch-on-error!`. No-op on an empty failure vector. Published as the `:error-emit/dispatch-frame-teardown-report` late-bind hook (a static `frame` → `error-emit` require would close a load cycle: `error-emit` → `elision` → `frame`).
- **`frame.cljc`**:
  - `*teardown-hook-failures*` — per-destroy accumulator atom, bound for the teardown walk.
  - `safe-call-hook!` — on a hook throw, conj's `{:hook :exception :where :safe-call-hook!}` onto the accumulator (always-on axis) **and** keeps emitting the per-hook `:rf.warning/teardown-hook-exception` diagnostic trace at its causal position (dev-only, DCE'd in prod — **R2** preserved).
  - `destroy-frame!` — binds the accumulator; a **finally-shaped flush** ships the single report. Running the flush in the `finally` is the emit-safety contract (**R1**): even if a downstream teardown step aborts the walk mid-recipe, the entries gathered so far are already in the atom and still flush.
- **`late_bind/directory.cljc`** — directory entry for the new hook (drift-test invariant).

## Tests

New `frame_teardown_report_cljs_test.cljc` (CLJC, dual-runtime; outside `examples/` per rf2-8cevm) pins all four acceptance legs:
- **(a)** N hook failures → exactly ONE report carrying N `:hook-failures` entries (+ a clean-destroy-emits-no-report case).
- **(b)** Partial-teardown-abort still flushes the collected entries — a downstream step throws after two hooks failed; the report still ships those two via the finally boundary.
- **(c)** The report rides the always-on axis (exercised via the `register-error-listener!` substrate / `dispatch-frame-teardown-report!`, which is not `interop/debug-enabled?`-gated and survives the production build path) + the late-bind hook is published.
- **(d)** The dev per-hook `:rf.warning/teardown-hook-exception` diagnostic rows still emit at causal positions; both channels fire together.

## Scope

Touched only the `implementation/` frame-teardown/destroy path + its test. No `spec/009` edit (bead A owns it, merged). No dispatch/coeffect/router edits (s9ss0t / EP-0010 owns those — rebased cleanly onto the merged EP-0010 main).

## Quality gates

- `npm run test:cljs` (from `implementation/`) — **6431 tests, 23244 assertions, 0 failures, 0 errors** (covers the teardown path + the new suite). The single compile warning is a pre-existing `late-bind/clear-fn!` undeclared-var in `resources_revalidation_cljs_test.cljc`, unrelated to this change.
- JVM focused run `clojure -M:test -d core/test -n re-frame.frame-teardown-report-cljs-test` — **7 tests, 27 assertions, 0 failures, 0 errors**.
- JVM late-bind drift test (`core/test`) — the new `:error-emit/dispatch-frame-teardown-report` directory entry matches its `set-fn!` site (not flagged; the only pre-existing orphan is `:subs/resolve-sub-override`, unrelated to this change).
