### PR TITLE
feat(routing): route-loader nav-token suppression as a reply-envelope gate (rf2-zqefg3.5)

### DIFF
--- a/implementation/routing/src/re_frame/routing/nav_token.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_token.cljc
@@ -10,6 +10,20 @@
       entry (`:do`) with a stale-result check: match → run; mismatch →
       suppress and emit `:rf.route.nav-token/stale-suppressed`.
 
+  ## Lowered onto the uniform reply envelope (EP-0011, rf2-zqefg3.5)
+
+  The receipt-side stale check is NOT a bespoke per-family token
+  comparison: it is an ORDINARY reply-envelope `:suppress` gate. The
+  carried `:nav-token` is the value of the ONE data-only suppression gate
+  `{:route/nav-token <token>}`, validated against the live
+  `[:rf.runtime/routing :current :nav-token]` via the shared
+  `re-frame.reply/stale?` (through `re-frame.routing.reply`). The route
+  work-id is `[:rf.work/route route-id nav-token loader-id]`; the
+  suppression trace is joined to `:work/id`. The PUBLIC API (the cofx and
+  the `:rf.route/with-nav-token` fx) is PRESERVED — internal lowering
+  only. See `spec/Managed-Effects.md` §The uniform reply envelope and
+  Spec 012 §Lowering onto the uniform reply envelope.
+
   The test-only `:rf.test/simulate-http-resolution` fixture analogue of
   this fx lives in `re-frame.routing.test-support` (rf2-dbiv8) — behind
   an explicit test-support require, so it never reaches a production
@@ -23,6 +37,7 @@
   (:require [re-frame.frame :as frame]
             [re-frame.fx :as fx]
             [re-frame.interop :as interop]
+            [re-frame.routing.reply :as route-reply]
             [re-frame.trace :as trace]))
 
 (def nav-token-cofx-meta
@@ -82,6 +97,42 @@ result. Per Spec 012 §Navigation tokens — stale-result suppression."})
         (first inner-event-vec)
         fx-id))))
 
+(defn emit-stale-suppressed!
+  "Emit the `:rf.route.nav-token/stale-suppressed` trace for a superseded
+  route-loader completion. The facts ride on top of the shared
+  `re-frame.reply/suppress` outcome (EP-0011 §Route Loader Completion):
+  the suppression trace is joined to `:work/id`, alongside the existing
+  carried-token / current-token / event-id tags. Shared by the
+  production `:rf.route/with-nav-token` handler and the test-only
+  `:rf.test/simulate-http-resolution` fixture so one conformance
+  assertion covers both paths.
+
+  `event-id` is the suppressed continuation's event-id (per
+  `inner-fx-event-id`); `frame-id` (when non-nil) frame-attributes the
+  suppression so it lands in the emitting frame's epoch / Xray
+  (rf2-7d30s). The work-id is built from the route context
+  (`{:route-id … :nav-token <carried> :loader-id …}`) — `route-reply/
+  suppress` carries it on the reply + trace."
+  [{:keys [carried-token current-token event-id frame-id route-id loader-id]}]
+  (let [{:keys [trace]} (route-reply/suppress
+                          {:route-id  route-id
+                           :nav-token carried-token
+                           :loader-id loader-id
+                           :frame     frame-id}
+                          current-token)]
+    (trace/emit-error! :rf.route.nav-token/stale-suppressed
+                       (cond-> {:carried-token     carried-token
+                                :current-token     current-token
+                                :rf.trace/event-id event-id
+                                ;; The suppression trace is joined to
+                                ;; `:work/id` per EP-0011 §Route Loader
+                                ;; Completion — the route-loader work-id
+                                ;; `[:rf.work/route route-id nav-token
+                                ;; loader-id]` the shared substrate built.
+                                :work/id           (:work/id trace)
+                                :recovery          :replaced-with-default}
+                         frame-id (assoc :frame frame-id)))))
+
 (def with-nav-token-meta
   "Metadata for the `:rf.route/with-nav-token` fx registration: the
   docstring + the inline Malli schema per Spec-Schemas.md
@@ -100,7 +151,15 @@ result. Per Spec 012 §Navigation tokens — stale-result suppression."})
 
 (defn with-nav-token-handler
   "`:rf.route/with-nav-token` fx handler. Registered by the façade so a
-  `:reload` re-wires it on a fresh registrar."
+  `:reload` re-wires it on a fresh registrar.
+
+  The stale check is an ordinary reply-envelope `:suppress` gate
+  (EP-0011, rf2-zqefg3.5): the carried `:nav-token` and the live route
+  slice token are compared through the shared `re-frame.reply/stale?`
+  (via `re-frame.routing.reply/suppress?`) — match runs the wrapped
+  `:do`; mismatch suppresses it and emits `:rf.route.nav-token/
+  stale-suppressed` joined to the route work-id. The public fx surface
+  (`{:do … :nav-token …}`) is unchanged."
   [{:keys [frame] :as _ctx} args]
   ;; Destructure `:do` via `get` rather than `:keys` so the binding name
   ;; doesn't shadow `clojure.core/do` inside the body. Per Spec 012
@@ -116,10 +175,10 @@ result. Per Spec 012 §Navigation tokens — stale-result suppression."})
         frame-record    (frame/frame frame-id)
         ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db state.
         rdb             (frame/frame-runtime-db-value frame-id)
-        current         (get-in rdb [:rf.runtime/routing :current :nav-token])]
-    (cond
-      (= nav-token current)
-      ;; Token matches — route the inner fx entry through
+        slice           (get-in rdb [:rf.runtime/routing :current])
+        current         (:nav-token slice)]
+    (if-not (route-reply/suppress? nav-token current)
+      ;; Gate matches (token current) — route the inner fx entry through
       ;; `fx/handle-one-fx`. Routing it through the same machinery means
       ;; `:dispatch`, `:dispatch-later`, `:rf.http/managed`, et al. all
       ;; work uniformly. `handle-one-fx` rather than `do-fx` so the
@@ -134,15 +193,16 @@ result. Per Spec 012 §Navigation tokens — stale-result suppression."})
                                 (interop/active-platform))]
         (fx/handle-one-fx frame-id do-entry active-platform {} nil))
 
-      :else
-      ;; Stale — suppress. Same trace shape as
-      ;; `:rf.test/simulate-http-resolution` so a single conformance
-      ;; assertion covers both production and test paths.
-      ;; rf2-7d30s — `frame-id` (resolved above) frame-attributes the
-      ;; suppression so it lands in the emitting frame's epoch / Xray.
-      (trace/emit-error! :rf.route.nav-token/stale-suppressed
-                         {:carried-token     nav-token
-                          :current-token     current
-                          :rf.trace/event-id (inner-fx-event-id do-entry)
-                          :frame             frame-id
-                          :recovery          :replaced-with-default}))))
+      ;; Stale — suppress through the shared reply-envelope correctness
+      ;; boundary. Same trace shape as `:rf.test/simulate-http-resolution`
+      ;; (now joined to `:work/id`) so a single conformance assertion
+      ;; covers both production and test paths. rf2-7d30s — `frame-id`
+      ;; frame-attributes the suppression so it lands in the emitting
+      ;; frame's epoch / Xray.
+      (emit-stale-suppressed!
+        {:carried-token nav-token
+         :current-token current
+         :event-id      (inner-fx-event-id do-entry)
+         :frame-id      frame-id
+         :route-id      (:id slice)
+         :loader-id     (inner-fx-event-id do-entry)}))))

--- a/implementation/routing/src/re_frame/routing/reply.cljc
+++ b/implementation/routing/src/re_frame/routing/reply.cljc
@@ -1,0 +1,190 @@
+(ns re-frame.routing.reply
+  "Spec 012 — lower route-loader async work onto the uniform reply
+  envelope (EP-0011 §Route Loader Completion; the canonical contract is
+  `spec/Managed-Effects.md` §The uniform reply envelope).
+
+  ## What this namespace is
+
+  The internal seam that expresses route-loader stale suppression as an
+  ORDINARY reply-envelope `:suppress` gate rather than a bespoke
+  per-family token mechanism. A route loader's async completion is keyed
+  by the route work-id `[:rf.work/route route-id nav-token loader-id]`
+  and gated by the data-only suppression map `{:route/nav-token
+  nav-token}`, validated against the live `[:rf.runtime/routing :current
+  :nav-token]` before the app reply target runs. The PUBLIC routing API
+  (the `:nav-token` cofx, `:rf.route/with-nav-token`, `:on-match` /
+  loaders) is PRESERVED — this is internal lowering only.
+
+  Two concerns, both consuming the shared `re-frame.reply` substrate:
+
+   1. **Work-id correlation** (`work-id`). One route-loader attempt has
+      one `:work/id` head `[:rf.work/route route-id nav-token loader-id]`
+      (Managed-Effects §Work-id correlation). The nav-token is NOT a
+      second stale-suppression key in its own right — it is the value of
+      the ONE suppression gate (`:route/nav-token`) AND a component of
+      the work-id tuple; the same fact, named once. Per EP-0007 there is
+      no `:stale-key`-style synonym.
+
+   2. **Stale-suppression gate** (`gate` / `current-gate` / `suppress?`
+      / `suppress`). The carried gate `{:route/nav-token <captured>}` is
+      matched against the current gate `{:route/nav-token <live>}` via
+      `re-frame.reply/stale?` — the shared correctness boundary. On
+      mismatch `re-frame.reply/suppress` produces the `:status :stale`
+      reply (no app mutation) and the data-only trace facts joined to
+      `:work/id`; the app reply target does NOT run. On match the live
+      reply (`:ok` / `:error`, and `:cancelled` for an explicit user
+      cancel) flows through to the handler unchanged.
+
+  Pure — no atoms, no dispatch, no I/O. The caller reads the live
+  `:nav-token` from frame runtime-db and hands it in; this namespace
+  never reaches into runtime state. Trace summaries route every
+  wire-bearing slot through the shared `re-frame.reply/trace-summary`
+  (which calls `re-frame.elision/elide-wire-value`) — never a
+  family-private elider (Managed-Effects §Tracing).
+
+  Internal namespace; the public facade is `re-frame.routing`."
+  (:require [re-frame.reply :as reply]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; Work-id correlation (Managed-Effects §Work-id correlation).
+;;
+;; Route head: `[:rf.work/route route-id nav-token loader-id]`. One ATTEMPT
+;; has one `:work/id` (the EP-0007 rule): a distinct nav-token (a fresh
+;; navigation epoch) is a distinct attempt, so the nav-token rides IN the
+;; work-id tuple. The nav-token is the same fact named once — it is the
+;; component that discriminates a superseded attempt AND the value of the
+;; sole `:route/nav-token` suppression gate; it is never a second
+;; stale-suppression key alongside the work-id.
+;; ---------------------------------------------------------------------------
+
+(defn work-id
+  "Build the route-loader work-id head for one attempt.
+
+  `[:rf.work/route route-id nav-token loader-id]` (Managed-Effects
+  §Work-id correlation — the Route-loader row). `=`-comparable and EDN-
+  serializable. `loader-id` identifies which `:on-match` loader within
+  the navigation produced this attempt; `route-id` is the matched route's
+  id; `nav-token` is the navigation epoch the attempt was scheduled in.
+  Any component may be nil when the caller has no finer identity (e.g. a
+  loader that did not name itself) — the tuple stays a valid, distinct
+  work id."
+  [{:keys [route-id nav-token loader-id]}]
+  [:rf.work/route route-id nav-token loader-id])
+
+;; ---------------------------------------------------------------------------
+;; The stale-suppression gate (Managed-Effects §Stale suppression). The
+;; nav-token is lowered to the ONE data-only suppression gate
+;; `{:route/nav-token <token>}` — exactly the gate shape EP-0011
+;; §Specification and the §The reply target descriptor example use
+;; (`:suppress {:route/nav-token "nav-7"}`). The carried gate is captured at
+;; scheduling time; the current gate is read from the live route slice at
+;; completion. They are compared by the shared `re-frame.reply/stale?` — no
+;; bespoke comparison.
+;; ---------------------------------------------------------------------------
+
+(defn gate
+  "Build the data-only suppression gate for a captured nav-token:
+  `{:route/nav-token <nav-token>}`. This is the ONE gate the route
+  family validates (Managed-Effects §Stale suppression: \"route
+  `:nav-token` still matches `[:rf.runtime/routing :current
+  :nav-token]`\"). Pure."
+  [nav-token]
+  {:route/nav-token nav-token})
+
+(defn current-gate
+  "Build the CURRENT gate from the live route-slice token (read by the
+  caller from `[:rf.runtime/routing :current :nav-token]`):
+  `{:route/nav-token <current>}`. The counterpart `gate` carries the
+  captured token; `re-frame.reply/stale?` compares the two. Pure."
+  [current-nav-token]
+  {:route/nav-token current-nav-token})
+
+(defn suppress?
+  "True when a completion carrying `carried-nav-token` is stale relative
+  to `current-nav-token` (a superseding navigation advanced the epoch),
+  so its app reply MUST be suppressed. Delegates to the shared
+  `re-frame.reply/stale?` over the `:route/nav-token` gate — the route
+  family does NOT re-implement the comparison; this is identity-equal to
+  the original `(= carried current)` check, just expressed as the shared
+  gate. A nil captured token under a live navigation is suppressed (the
+  present gate `{:route/nav-token nil}` never equals the active token —
+  the regression guard for the pre-fix nil-cofx bug); a nil captured
+  token against a nil current (no live navigation) matches."
+  [carried-nav-token current-nav-token]
+  (reply/stale? (gate carried-nav-token) (current-gate current-nav-token)))
+
+;; ---------------------------------------------------------------------------
+;; Stale suppression — THE correctness boundary, delegated to the shared
+;; `re-frame.reply/suppress` (Managed-Effects §Stale suppression). The route
+;; family supplies the carried + current gates and the route work-id; the
+;; substrate produces the `:status :stale` reply + the data-only trace facts
+;; joined to `:work/id`, and signals non-delivery.
+;; ---------------------------------------------------------------------------
+
+(def stale-reason
+  "The `:stale/reason` a superseded route completion carries: the
+  navigation epoch moved on. Named once (EP-0007)."
+  :rf.route/nav-token-stale)
+
+(defn suppress
+  "Produce the stale-suppression outcome for a route-loader completion
+  whose carried nav-token has been superseded — WITHOUT dispatching the
+  app reply target. Delegates to the shared `re-frame.reply/suppress`
+  (the correctness boundary made concrete): the returned `:reply` is
+  `:status :stale` (no `:value`, no app mutation) and `:deliver?` is
+  false.
+
+  Arguments:
+    `ctx`     — `{:route-id … :nav-token <carried> :loader-id … :frame …
+                 :completed-at …}`; supplies the route work-id and the
+                carried nav-token, plus any identity facts to ride the
+                stale reply verbatim.
+    `current` — the LIVE nav-token read from
+                `[:rf.runtime/routing :current :nav-token]` at completion.
+    `target`  — the (optional) reply target, consulted only for its
+                `:dispatch-stale?` opt-in (framework test / tool only).
+
+  Returns the `re-frame.reply/suppress` shape:
+    {:deliver?    <bool>          ;; false ⇒ DO NOT run the app reply target
+     :reply       <:status :stale reply, data-only, app-state-safe>
+     :work/status :suppressed     ;; the ledger terminal for a stale route load
+     :trace       <data-only facts carrying CARRIED + CURRENT gates, joined
+                   to :work/id>}
+
+  The trace facts are joined to `:work/id` per the Route-Loader-Completion
+  contract; the caller maps them onto the existing `:rf.route.nav-token/
+  stale-suppressed` trace operation (carried-token / current-token /
+  event-id ride alongside `:work/id`)."
+  ([ctx current] (suppress ctx current nil))
+  ([{:keys [nav-token frame completed-at] :as ctx} current target]
+   (let [wid (work-id ctx)]
+     (reply/suppress target
+                     (gate nav-token)
+                     (current-gate current)
+                     (cond-> {:status       :stale
+                              :work/id      wid
+                              :work/kind    :route
+                              :stale/reason stale-reason}
+                       (some? frame)        (assoc :rf.frame/id frame)
+                       (some? completed-at) (assoc :completed-at completed-at))))))
+
+;; ---------------------------------------------------------------------------
+;; Trace summary (Managed-Effects §Tracing). A data-only summary of a route
+;; reply map for a managed-async trace row, routing every wire-bearing slot
+;; through the shared `re-frame.reply/trace-summary` → `re-frame.elision/
+;; elide-wire-value` walker. Never a family-private elider.
+;; ---------------------------------------------------------------------------
+
+(defn trace-reply
+  "Build a DATA-ONLY trace summary of a route reply map for a
+  managed-async trace row. The wire-bearing slots (`:value`, `:error`,
+  `:correlation`, `:meta`) elide through the single shared
+  `re-frame.elision/elide-wire-value` walker (via
+  `re-frame.reply/trace-summary`) — never a family-private elider
+  (Managed-Effects §Tracing); the identity facts (`:status`, `:work/id`,
+  `:work/kind`, `:work/status`, `:rf.frame/id`, `:completed-at`) ride
+  verbatim. `opts` is forwarded to the walker (e.g. `:frame`)."
+  ([reply] (trace-reply reply nil))
+  ([reply opts] (reply/trace-summary reply opts)))

--- a/implementation/routing/src/re_frame/routing/test_support.cljc
+++ b/implementation/routing/src/re_frame/routing/test_support.cljc
@@ -54,7 +54,8 @@
   `(require 're-frame.routing.test-support :reload)` so the fixture event
   re-seats."
   (:require [re-frame.events :as events]
-            [re-frame.trace :as trace]))
+            [re-frame.routing.nav-token :as nav-token]
+            [re-frame.routing.reply :as route-reply]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -64,33 +65,36 @@
   re-wires it on a fresh registrar.
 
   Replays an async http completion that carries the `:carried-nav-token`
-  captured at request time. Match against the current
+  captured at request time. The stale check is the SAME ordinary
+  reply-envelope `:suppress` gate the production
+  `:rf.route/with-nav-token` handler uses (via
+  `re-frame.routing.reply/suppress?`): match against the current
   `[:rf.runtime/routing :current :nav-token]` → dispatch the
   `:on-success-event` continuation; mismatch → suppress and emit
-  `:rf.route.nav-token/stale-suppressed` (same trace shape as the
-  production `:rf.route/with-nav-token` handler, so a single conformance
-  assertion covers both paths)."
+  `:rf.route.nav-token/stale-suppressed` joined to the route work-id
+  (same trace shape as production, so a single conformance assertion
+  covers both paths)."
   [{frame :rf.frame/id rdb :rf.db/runtime} [_ {:keys [on-success-event carried-nav-token]}]]
   ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db state.
-  (let [current (get-in (or rdb {}) [:rf.runtime/routing :current :nav-token])]
-    (cond
-      (= carried-nav-token current)
-      ;; Token matches — dispatch the continuation.
+  (let [slice   (get-in (or rdb {}) [:rf.runtime/routing :current])
+        current (:nav-token slice)]
+    (if-not (route-reply/suppress? carried-nav-token current)
+      ;; Gate matches (token current) — dispatch the continuation.
       {:fx [[:dispatch on-success-event]]}
 
-      :else
-      ;; Stale — suppress.
-      ;; rf2-7d30s — frame-attribute the suppression (matches the
-      ;; production `with-nav-token-handler` path) so it lands in the
+      ;; Stale — suppress through the shared reply-envelope correctness
+      ;; boundary. rf2-7d30s — frame-attribute the suppression (matches
+      ;; the production `with-nav-token-handler` path) so it lands in the
       ;; emitting frame's epoch / Xray.
-      (do (trace/emit-error! :rf.route.nav-token/stale-suppressed
-                             (cond-> {:carried-token     carried-nav-token
-                                      :current-token     current
-                                      :rf.trace/event-id (when (vector? on-success-event)
-                                                           (first on-success-event))
-                                      :recovery          :replaced-with-default}
-                               frame (assoc :frame frame)))
-          {}))))
+      (let [event-id (when (vector? on-success-event) (first on-success-event))]
+        (nav-token/emit-stale-suppressed!
+          {:carried-token carried-nav-token
+           :current-token current
+           :event-id      event-id
+           :frame-id      frame
+           :route-id      (:id slice)
+           :loader-id     event-id})
+        {}))))
 
 ;; ---- test-only fixture event registration --------------------------------
 ;;

--- a/implementation/routing/test/re_frame/routing_nav_token_test.clj
+++ b/implementation/routing/test/re_frame/routing_nav_token_test.clj
@@ -64,7 +64,19 @@
                        (= "nav-2" (-> ev :tags :current-token))
                        (= :article/loaded (-> ev :tags :rf.trace/event-id))))
                 @traces)
-          "expected :rf.route.nav-token/stale-suppressed trace for the A response"))))
+          "expected :rf.route.nav-token/stale-suppressed trace for the A response")
+
+      ;; rf2-zqefg3.5 — the suppression trace is joined to the route
+      ;; work-id `[:rf.work/route route-id nav-token loader-id]`
+      ;; (EP-0011 §Route Loader Completion). The carried (stale) token
+      ;; rides in the work-id tuple, so the suppressed attempt is
+      ;; correlatable by `:work/id` in the trace stream.
+      (is (some (fn [ev]
+                  (and (= :rf.route.nav-token/stale-suppressed (:operation ev))
+                       (= [:rf.work/route :route/article "nav-1" :article/loaded]
+                          (-> ev :tags :work/id))))
+                @traces)
+          "the stale-suppressed trace is joined to the route :work/id (the carried nav-token rides in the tuple)"))))
 
 (deftest with-nav-token-fx-suppresses-stale-do-and-commits-fresh
   (testing ":rf.route/with-nav-token fx: stale `:do` is suppressed; fresh `:do` runs"
@@ -145,6 +157,18 @@
                        (= :article/loaded (-> ev :tags :rf.trace/event-id))))
                 @traces)
           "stale :do produced :rf.route.nav-token/stale-suppressed with the inner dispatch's event-id")
+
+      ;; rf2-zqefg3.5 — the production fx path joins the suppression
+      ;; trace to the route work-id. `route-id` is read from the live
+      ;; slice (`:route/article`, the route B is on); `nav-token` is the
+      ;; carried (stale) token "nav-1"; `loader-id` is the suppressed
+      ;; inner dispatch's event-id.
+      (is (some (fn [ev]
+                  (and (= :rf.route.nav-token/stale-suppressed (:operation ev))
+                       (= [:rf.work/route :route/article "nav-1" :article/loaded]
+                          (-> ev :tags :work/id))))
+                @traces)
+          "the production :rf.route/with-nav-token suppression is joined to the route :work/id")
 
       ;; Negative: no spurious suppressed-trace for the fresh path.
       (is (= 1 (count (filter (fn [ev]

--- a/implementation/routing/test/re_frame/routing_reply_test.clj
+++ b/implementation/routing/test/re_frame/routing_reply_test.clj
@@ -1,0 +1,118 @@
+(ns re-frame.routing-reply-test
+  "Unit tests for `re-frame.routing.reply` — route-loader async work
+  lowered onto the uniform reply envelope (EP-0011 §Route Loader
+  Completion; rf2-zqefg3.5).
+
+  Pins the route work-id tuple, the nav-token-as-`:suppress`-gate
+  delegation to the shared `re-frame.reply` correctness boundary, and the
+  data-only stale reply / trace facts joined to `:work/id`. These are
+  pure-fn tests over the lowering substrate — no runtime stand-up; the
+  end-to-end gate behaviour is exercised by
+  `re-frame.routing-nav-token-test`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.reply :as reply]
+            [re-frame.routing.reply :as route-reply]))
+
+;; ---- §Work-id correlation -------------------------------------------------
+
+(deftest route-work-id-tuple-shape
+  (testing "the route-loader work-id head is [:rf.work/route route-id nav-token loader-id]"
+    (is (= [:rf.work/route :route/article "nav-1" :article/loaded]
+           (route-reply/work-id {:route-id  :route/article
+                                 :nav-token "nav-1"
+                                 :loader-id :article/loaded}))
+        "the four-element route head per Managed-Effects §Work-id correlation")
+    (is (= [:rf.work/route nil nil nil]
+           (route-reply/work-id {}))
+        "nil components keep a valid, distinct work id (a loader that named nothing)"))
+  (testing "the work id is =-comparable and EDN-serializable"
+    (let [wid (route-reply/work-id {:route-id :r :nav-token "n" :loader-id :l})]
+      (is (= wid (read-string (pr-str wid)))
+          "round-trips through EDN unchanged"))))
+
+;; ---- §Stale suppression — the nav-token is the ONE :suppress gate ---------
+
+(deftest nav-token-gate-shape
+  (testing "the carried/current gates are the data-only {:route/nav-token <t>} map"
+    (is (= {:route/nav-token "nav-1"} (route-reply/gate "nav-1")))
+    (is (= {:route/nav-token "nav-2"} (route-reply/current-gate "nav-2")))))
+
+(deftest suppress?-delegates-to-shared-reply-stale?
+  (testing "suppress? is exactly re-frame.reply/stale? over the :route/nav-token gate
+            — the route family does NOT re-implement the comparison"
+    (doseq [[carried current] [["nav-1" "nav-2"] ["nav-2" "nav-2"] [nil "nav-2"] ["nav-1" nil]]]
+      (is (= (reply/stale? (route-reply/gate carried) (route-reply/current-gate current))
+             (route-reply/suppress? carried current))
+          (str "suppress? matches the shared stale? for carried=" carried " current=" current))))
+  (testing "stale when the epoch advanced; live when it matches"
+    (is (true?  (route-reply/suppress? "nav-1" "nav-2")) "superseded → stale")
+    (is (false? (route-reply/suppress? "nav-2" "nav-2")) "current → live")
+    ;; A nil CAPTURED token while a navigation is live is suppressed: the
+    ;; gate is present (`{:route/nav-token nil}`) with a nil value, which
+    ;; never equals the active token. This matches the original
+    ;; `(= nav-token current)` semantics and is the regression guard for
+    ;; the pre-fix bug where a cofx threaded nil and was silently eaten —
+    ;; nil is now suppressed (not committed) exactly as before.
+    (is (true? (route-reply/suppress? nil "nav-2"))
+        "a nil captured token under a live navigation is stale (never matches)")
+    (is (false? (route-reply/suppress? nil nil))
+        "nil captured against a nil current (no navigation) matches — both gates equal")))
+
+;; ---- §Stale suppression — the suppress outcome ----------------------------
+
+(deftest suppress-produces-stale-reply-joined-to-work-id
+  (testing "a superseded route completion produces a non-delivered :status :stale
+            reply carrying the route :work/id + :work/kind :route, and trace facts
+            joined to :work/id with both carried + current gates"
+    (let [{:keys [deliver? reply trace] :as outcome}
+          (route-reply/suppress {:route-id  :route/article
+                                 :nav-token "nav-1"
+                                 :loader-id :article/loaded
+                                 :frame     :rf/default}
+                                "nav-2")]
+      (is (false? deliver?) "the app reply target MUST NOT run for a stale completion")
+      (is (= :suppressed (:work/status outcome)) "ledger terminal for a stale route load")
+
+      (testing "the reply map is a valid, app-state-safe :status :stale reply"
+        (is (reply/valid-reply? reply) "conforms to the reply-map contract")
+        (is (= :stale (:status reply)))
+        (is (true? (:stale? reply)))
+        (is (= :rf.route/nav-token-stale (:stale/reason reply)))
+        (is (not (contains? reply :value)) "a stale reply carries no :value (no app mutation)")
+        (is (= :route (:work/kind reply)))
+        (is (= [:rf.work/route :route/article "nav-1" :article/loaded] (:work/id reply))
+            "the reply carries the route work-id")
+        (is (= :rf/default (:rf.frame/id reply)) "the carried frame stamp rides the reply"))
+
+      (testing "the trace facts are joined to :work/id and carry both correlation gates"
+        (is (true? (:rf.reply/suppressed? trace)))
+        (is (= [:rf.work/route :route/article "nav-1" :article/loaded] (:work/id trace))
+            "EP-0011 §Route Loader Completion: the suppression trace is joined to :work/id")
+        (is (= {:route/nav-token "nav-1"} (:rf.reply/carried trace)) "carried gate")
+        (is (= {:route/nav-token "nav-2"} (:rf.reply/current trace)) "current gate")
+        (is (= :rf.route/nav-token-stale (:stale/reason trace)))))))
+
+(deftest suppress-honours-dispatch-stale-opt-in
+  (testing "a framework test/tool target may opt into stale delivery via :dispatch-stale?
+            (app targets MUST NOT) — delegated to re-frame.reply/suppress"
+    (is (false? (:deliver? (route-reply/suppress {:nav-token "nav-1"} "nav-2" nil)))
+        "no opt-in → not delivered")
+    (is (false? (:deliver? (route-reply/suppress {:nav-token "nav-1"} "nav-2"
+                                                 {:event [:t] :dispatch-stale? false})))
+        ":dispatch-stale? false → not delivered")
+    (is (true? (:deliver? (route-reply/suppress {:nav-token "nav-1"} "nav-2"
+                                                {:event [:t] :dispatch-stale? true})))
+        ":dispatch-stale? true (framework test/tool only) → delivered")))
+
+;; ---- §Tracing -------------------------------------------------------------
+
+(deftest trace-reply-routes-wire-slots-through-shared-walker
+  (testing "trace-reply is the shared re-frame.reply/trace-summary — identity facts
+            ride verbatim; wire slots elide through the one shared walker"
+    (let [r {:status :ok :work/id [:rf.work/route :r "n" :l] :work/kind :route
+             :rf.frame/id :rf/default :value {:title "Welcome"}}
+          summary (route-reply/trace-reply r {:frame :rf/default})]
+      (is (= (reply/trace-summary r {:frame :rf/default}) summary)
+          "delegates to the shared trace-summary — never a family-private elider")
+      (is (= :ok (:status summary)) "identity facts ride verbatim")
+      (is (= [:rf.work/route :r "n" :l] (:work/id summary))))))

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -50,7 +50,7 @@ Audience column: **user** = an event apps dispatch or handle directly; **runtime
 | `:rf.nav/push-url` | `pushState` for the URL. | `:client` |
 | `:rf.nav/replace-url` | `replaceState` for the URL. | `:client` |
 | `:rf.nav/scroll` | Apply a scroll strategy. Args carry `{:strategy :from :to :saved-pos :fragment}`. | `:client` |
-| `:rf.route/with-nav-token` | Threads `:nav-token` into a downstream dispatch for stale-result suppression. | universal |
+| `:rf.route/with-nav-token` | Threads `:nav-token` into a downstream dispatch for stale-result suppression — the nav-token lowered to the [uniform reply envelope](Managed-Effects.md#the-uniform-reply-envelope)'s `{:route/nav-token …}` `:suppress` gate (see [§Lowering onto the uniform reply envelope](#lowering-onto-the-uniform-reply-envelope)). | universal |
 
 ### Subscriptions
 
@@ -714,13 +714,24 @@ Suppression alone fixes the user-visible bug — the older load *does* complete 
 Two trace events surround the nav-token lifecycle (added to the trace-op vocabulary per [Spec-Schemas.md](Spec-Schemas.md#rftrace-event)):
 
 - **`:rf.route.nav-token/allocated`** — emitted when a navigation cascade allocates a fresh token. `:tags {:route-id <id> :nav-token <token>}`.
-- **`:rf.route.nav-token/stale-suppressed`** — emitted when an async result arrives carrying a now-superseded token. `:tags {:carried-token <t1> :current-token <t2> :event-id <id>}`. The handler does NOT run.
+- **`:rf.route.nav-token/stale-suppressed`** — emitted when an async result arrives carrying a now-superseded token. `:tags {:carried-token <t1> :current-token <t2> :event-id <id> :work/id <route-work-id>}`. The handler does NOT run. The `:work/id` tag is the route-loader work-id `[:rf.work/route route-id nav-token loader-id]`, joining the suppression to the superseded attempt's identity (see [§Lowering onto the uniform reply envelope](#lowering-onto-the-uniform-reply-envelope) below).
 
 Naming follows the `<feature>/<reason>` convention used by `:rf.machine.timer/stale-after`. See [Pattern-StaleDetection.md](Pattern-StaleDetection.md) for the cross-cutting pattern.
 
 ### Conformance
 
 Fixture `route-stale-nav-token-suppression.edn` exercises the canonical race: load route A; navigate to route B before A finishes; A finishes; verify the late result is suppressed and the trace shows `:rf.route.nav-token/stale-suppressed`.
+
+### Lowering onto the uniform reply envelope
+
+Route-loader async work is one of the managed *async* surfaces that complete through the framework-wide [uniform reply envelope](Managed-Effects.md#the-uniform-reply-envelope) (property 9 of the [managed-effect contract](Managed-Effects.md#the-nine-properties); [EP-0011](../docs/EP/EP-0011-uniform-async-reply-envelope.md) is the rationale record). The nav-token mechanism above is **not** a bespoke per-family stale-detection scheme: it is exactly one instance of the envelope's mandatory [stale suppression](Managed-Effects.md#stale-suppression) — the same correctness boundary HTTP ([014](014-HTTPRequests.md)), resources and mutations ([016](016-Resources.md)), and machine async work ([005](005-StateMachines.md)) lower onto. The public routing surface — the `:nav-token` cofx, the `:rf.route/with-nav-token` fx, and `:on-match` loaders — is **preserved verbatim**; the lowering is internal.
+
+The two correlations the envelope requires:
+
+- **Work-id correlation.** A route loader's [work id](Managed-Effects.md#work-id-correlation) is `[:rf.work/route route-id nav-token loader-id]`. One attempt has one work id ([EP-0007](../docs/EP/EP-0007-one-name-per-fact.md)): a fresh navigation epoch (a new `:nav-token`) is a distinct attempt, so the nav-token rides *in* the work-id tuple. It is the **same fact named once** — the component that discriminates a superseded attempt *and* the value of the sole suppression gate (next bullet); it is never a second stale-suppression key alongside the work id.
+- **The nav-token is the suppression gate.** The [stale-suppression](Managed-Effects.md#stale-suppression) gate is the data-only map `{:route/nav-token <captured-token>}`, validated against the live `{:route/nav-token <current>}` read from `[:rf.runtime/routing :current :nav-token]`. The validation step 4 above (the `:rf.route/with-nav-token` check, or a handler comparing the cofx-injected token) is exactly this gate comparison — `carried` vs `current` by value equality. On match the **live** reply (`:ok` / `:error`, and `:cancelled` for an explicit user cancel) flows through to the app handler unchanged; on mismatch the completion is suppressed *before* the handler runs — its outcome is `:status :stale` with no app-db / runtime-db mutation, and the `:rf.route.nav-token/stale-suppressed` trace fires joined to the route `:work/id` (the carried + current gates ride in the trace facts). [§Cancellation as optimisation, not correctness](#cancellation-as-optimisation-not-correctness) above is the envelope's [cancellation-vs-suppression](Managed-Effects.md#cancellation) line: suppression is the correctness boundary; aborting the in-flight fetch is the optional optimisation.
+
+A route loader that fetches through managed HTTP (the common case — an `:on-match` handler emitting `:rf.http/managed`) therefore carries **two** correlated identities: the HTTP attempt's `[:rf.work/http …]` work id (014's gate is request-id + generation) and the route's `[:rf.work/route …]` nav-token gate. Both gates are checked independently before the app reply commits — the HTTP reply is delivered only if its own request is still current *and* the wrapping `:rf.route/with-nav-token` finds the nav-token current. This composition is the worked example in [EP-0011 §Route Loader Completion](../docs/EP/EP-0011-uniform-async-reply-envelope.md#route-loader-completion).
 
 ## Standard runtime events
 


### PR DESCRIPTION
## What

Lowers route-loader async work onto the uniform reply envelope (EP-0011 §Route Loader Completion; `spec/Managed-Effects.md` §The uniform reply envelope). The nav-token stale check is expressed as an **ordinary data-only `:suppress` gate** rather than a bespoke per-family token comparison — the same correctness boundary HTTP / resources / machines lower onto.

- **Work-id correlation.** Route loader work-id is `[:rf.work/route route-id nav-token loader-id]`. One attempt has one work id (EP-0007): a fresh navigation epoch is a distinct attempt, so the nav-token rides *in* the tuple — the same fact named once, never a second stale key.
- **Nav-token as the `:suppress` gate.** The carried `{:route/nav-token <captured>}` is validated against the live `{:route/nav-token <current>}` read from `[:rf.runtime/routing :current :nav-token]` via the shared `re-frame.reply/stale?`. Match → the live reply (`:ok`/`:error`, `:cancelled` for explicit user cancel) flows to the app handler; mismatch → suppressed *before* the handler runs (`:status :stale`, no app-db/runtime-db mutation), trace joined to `:work/id`.
- **Public API preserved.** The `:nav-token` cofx, `:rf.route/with-nav-token` fx, and `:on-match` loaders are unchanged — internal lowering only. The behavioral semantics are identity-equal to the prior `(= nav-token current)` check.

## Conformance

Navigate A→B before A completes suppresses A's reply (no app handler run) and records the suppressed trace joined to the route `:work/id`. Covered by both the production fx path (`with-nav-token-fx-suppresses-stale-do-and-commits-fresh`) and the simulate-http path (`routing-nav-token-staleness`), plus new pure-substrate unit tests (`routing_reply_test.clj`). The existing `route-stale-nav-token-suppression.edn` conformance fixture and the cross-feature `routing_http_composed_corners_test.clj` (both outside this fence) stay valid — the `:rf.route.nav-token/stale-suppressed` trace shape is preserved and the `:work/id` tag added additively.

## Changes

- New `re-frame.routing.reply` — route-loader lowering onto `re-frame.reply` (work-id, the `{:route/nav-token}` gate, `suppress?`, `suppress`, `trace-reply`), mirroring `re-frame.http-reply`.
- `re-frame.routing.nav-token` `with-nav-token-handler` + the `:rf.test/simulate-http-resolution` fixture consume the shared substrate; suppression trace joined to `:work/id`.
- `spec/012-Routing.md` — new §Lowering onto the uniform reply envelope + the 012↔Managed-Effects cross-reference + `:work/id` trace-tag note.

## Quality gates

- `npm run test:cljs` — 6424 tests / 23217 assertions, **0 failures, 0 errors**.
- routing artefact `clojure -M:test` — 209 tests / 956 assertions, **0 failures, 0 errors** (was 203/920; +6 tests).
- `mkdocs build --strict` — **exit 0** (no anchor warnings for 012-Routing.md).

Closes rf2-zqefg3.5.
