### PR TITLE
feat(machines): share reply-envelope status/trace for :after + spawned-actor completion (rf2-zqefg3.4)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -41,6 +41,7 @@
             [re-frame.machines.lifecycle-fx.traces :as traces]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.paths :as paths]
+            [re-frame.machines.reply :as m-reply]
             [re-frame.machines.result :as result]
             [re-frame.machines.timer :as timer]
             [re-frame.machines.transition :as transition]
@@ -212,6 +213,25 @@
         error-leaf? (true? (:error? final-node))
         parent-id   (:rf/parent-id child-data)
         invoke-id   (:rf/spawn-id child-data)
+        ;; Per EP-0011 §Machine Completion / Managed-Effects §The uniform
+        ;; reply envelope: form the canonical machine reply map INTERNALLY
+        ;; (work-id `[:rf.work/machine actor-id work-bearing-path
+        ;; generation]`, one closed `:status` — `:ok` for a plain final
+        ;; leaf, `:error` for an `:error?` error terminal — the child's
+        ;; `:output-key` result under `:value`, frame + correlation). The
+        ;; PUBLIC `:on-done` / `:on-error` semantics are PRESERVED: the
+        ;; `:on-done` `:data` callback is still driven with the child's
+        ;; result (now derived as `(:value reply)`), and `:on-error` still
+        ;; routes the raw failure payload to the parent transition. This is
+        ;; internal lowering only — the reply map is what the trace stream,
+        ;; ledger, and future work-correlation read uniformly (m-reply).
+        reply-ctx   {:actor-id          machine-id
+                     :parent-id         parent-id
+                     :work-bearing-path invoke-id
+                     :frame             frame-id}
+        reply       (if error-leaf?
+                      (m-reply/error-reply reply-ctx result)
+                      (m-reply/success-reply reply-ctx result))
         ;; (1) Find parent's `:on-done` / `:on-error`, if this is a `:spawn`-
         ;; spawned actor. The parent's spec carries the `:spawn` map at
         ;; `invoke-id`. Per rf2-a2sn1 — resolve the parent's spec from the
@@ -240,13 +260,24 @@
         ;; (2) Emit `:rf.machine/done` trace BEFORE the destroy cascade
         ;; (D6 ordering). Fired for EVERY finish (success or error leaf) —
         ;; `:on-error` is additive, the done trace is the actor-finality
-        ;; signal regardless of which spawn hook routes the result.
+        ;; signal regardless of which spawn hook routes the result. Per
+        ;; EP-0011 the reply-envelope facts (`:rf.reply/status`,
+        ;; `:rf.reply/work-id`, `:rf.reply/work-status`) ride ADDITIVELY so
+        ;; the trace stream classifies the completion the same way HTTP /
+        ;; resources do; the public `:output` / `:parent-id` / `:error?`
+        ;; shape is preserved. Wire-bearing slots (`:value` / `:error`)
+        ;; route through the shared elision walker via `m-reply/trace-reply`.
+        done-summary (m-reply/trace-reply reply {:frame frame-id})
         _ (trace/emit! :rf.machine :rf.machine/done
                        {:machine-id machine-id
                         :output     result
                         :parent-id  parent-id
                         :error?     error-leaf?
-                        :frame      frame-id})
+                        :frame      frame-id
+                        ;; reply-envelope vocabulary (Managed-Effects §9)
+                        :rf.reply/status      (:status done-summary)
+                        :rf.reply/work-id     (:work/id done-summary)
+                        :rf.reply/work-status (:work/status done-summary)})
         ;; (3) Apply :on-done to the parent's `:data`. The parent's
         ;; snapshot lives at [:rf.runtime/machines :snapshots <parent-id>]; we read it,
         ;; pass the unified context-map (`{:data :result}`) to
@@ -258,12 +289,21 @@
         ;; leaf routing to `:on-error` SKIPS `:on-done` — the two spawn hooks
         ;; are mutually exclusive per finish (error-leaf → transition,
         ;; success-leaf → `:data` callback).
+        ;;
+        ;; Per EP-0011 §Machine Completion the callback's `:result` is now
+        ;; driven from the canonical reply's `:value` — the public callback
+        ;; contract (`(fn [{data :data result :result}] new-data)`) is
+        ;; unchanged; the value flows through the uniform reply envelope
+        ;; internally. `(:value reply)` is `=` to the pre-lowering `result`
+        ;; for a success leaf (behavioural parity), but it is sourced from
+        ;; the one canonical reply map so the value the trace/ledger see and
+        ;; the value the callback receives are the SAME fact.
         db-after-on-done
         (if (and on-done-fn parent-id (not on-error?))
           (let [parent-snap     (get-in runtime-db parent-path)
                 parent-data     (:data parent-snap)
                 new-parent-data (try
-                                  (on-done-fn {:data parent-data :result result})
+                                  (on-done-fn {:data parent-data :result (:value reply)})
                                   (catch #?(:clj Throwable :cljs :default) e
                                     (trace/emit-error! :rf.error/machine-action-exception
                                                        {:machine-id machine-id
@@ -323,6 +363,16 @@
     ;; snapshot — symmetric with how the spawn fx dispatches `:start` into the
     ;; child. The teardown above already ran (the child auto-destroys on its
     ;; error leaf, like any `:final?`); this only ROUTES the failure.
+    ;;
+    ;; Per EP-0011 §Machine Completion this is the `:status :error` reply
+    ;; driving the `:on-error` transition. The dispatched payload is the RAW
+    ;; error (`result`) — the PUBLIC contract: the parent transition reads it
+    ;; off `:event` (`(nth ev 2)`). The canonical reply map (`reply`, built
+    ;; above) classifies the completion as `:status :error` for the trace /
+    ;; ledger; the parent transition's observable payload is unchanged. The
+    ;; reply's `:error` slot is `{:kind … :value result}` (the family-`:kind`
+    ;; wrapping the reply-map schema requires) — but that wrapping is
+    ;; internal vocabulary, not what the parent transition sees.
     (when on-error?
       (spawn-error/dispatch-spawn-error! frame-id parent-id invoke-id result))
     ;; Machine snapshots are durable runtime-db state (EP-0001 rf2-vzld77):

--- a/implementation/machines/src/re_frame/machines/reply.cljc
+++ b/implementation/machines/src/re_frame/machines/reply.cljc
@@ -1,0 +1,270 @@
+(ns re-frame.machines.reply
+  "Spec 005 — share the uniform reply-envelope status/trace vocabulary for
+  the two machine *async* completions (EP-0011 §Machine Completion /
+  §Timer Reply; the canonical contract is `spec/Managed-Effects.md` §The
+  uniform reply envelope). This is the machine family's slice of the
+  shared `re-frame.reply` substrate, the same role
+  `re-frame.http-reply` plays for `:rf.http/managed`.
+
+  ## What this namespace is
+
+  The internal seam that turns the two machine async completions — a
+  spawned-actor finishing on a `:final?` leaf, and a fired-or-stale
+  `:after` timer — into the ONE canonical reply-envelope shape every
+  managed async family produces. **This is INTERNAL LOWERING ONLY: the
+  PUBLIC statechart API is preserved exactly.** `:on-done` still receives
+  `{:data … :result …}` and returns the new `:data`; `:on-error` is still
+  a declarative parent transition; `:after`'s epoch-gated stale-drop is
+  unchanged; actor-destroy semantics are unchanged. What this ns adds is
+  the *uniform vocabulary*: the `:rf.work/machine` work-id, the closed
+  `:status`, and reply-envelope-shaped trace facts — so machines, HTTP,
+  resources, and routing classify completion the same way and tools read
+  one stream (Managed-Effects §9).
+
+  Two concerns, mirroring the two machine async completions:
+
+   1. **Spawned-actor completion** (`spawn-work-id` / `success-reply` /
+      `error-reply`). When a `:spawn`-spawned child reaches a `:final?`
+      leaf, the runtime forms a canonical reply map internally — one
+      closed `:status` (`:ok` for a plain final leaf, `:error` for an
+      `:error?` error terminal), the child's `:output-key` result under
+      `:value`, `:work/id` `[:rf.work/machine actor-id work-bearing-path
+      generation]`, `:work/kind :machine`, `:work/status`,
+      `:rf.frame/id`, and `:correlation {:actor-id … :parent-id …
+      :spawn-id …}`. The PUBLIC `:on-done` `:data` callback is then driven
+      with `(:value reply)` as its `:result`; `:on-error` with the
+      reply's `:error`. A **late** child completion — the actor-id /
+      spawn correlation no longer naming a live actor — is `:stale`
+      (`stale-spawn-reply`), and its app target (the `:on-done` /
+      `:on-error` routing) MUST NOT run.
+
+   2. **`:after` timer staleness** (`after-suppression-gate` /
+      `after-stale-trace`). The machine `:after` timer is THE existing
+      specialized stale-gated instance of the reply pattern
+      (EP-0011 §Timer Reply, Managed-Effects §Stale suppression): the
+      synthetic timer-elapsed event carries the scheduling node's
+      declaring path + per-path `:rf/after-epoch`, validated against the
+      live snapshot on receipt. This ns expresses that existing drop as
+      the envelope's stale-suppression *vocabulary* — the **declaring
+      path + epoch are the data-only suppression gate** — and shapes the
+      `:rf.machine.timer/stale-after` trace's carried/current correlation
+      the reply-envelope way. The epoch-mismatch behaviour is unchanged;
+      only the vocabulary is shared.
+
+  Pure — no atoms, no dispatch, no I/O. Timestamps (`:completed-at`) are
+  supplied by the caller (the host clock is read once at completion and
+  threaded in); this ns never reads a clock. Trace summaries route every
+  wire-bearing slot through the shared `re-frame.reply/trace-summary`
+  (which calls `re-frame.elision/elide-wire-value`) — never a
+  family-private elider (Managed-Effects §Tracing)."
+  (:require [re-frame.reply :as reply]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; Work-id correlation (Managed-Effects §Work-id correlation).
+;;
+;; Machine head: `[:rf.work/machine actor-id work-bearing-path generation]`.
+;;  - `actor-id`         — the finishing actor's id (the `<type>#<n>`
+;;                         instance id, or an explicit `:spawn-id`);
+;;  - `work-bearing-path` — the `:spawn`-bearing node's declaring path
+;;                         (`:rf/spawn-id` the runtime stamped on the
+;;                         child's `:data` at spawn time);
+;;  - `generation`       — the monotonic spawn discriminator; for the
+;;                         `<type>#<n>` instance-id form it is `n` (the
+;;                         spawn-counter reading that minted this instance),
+;;                         so a re-spawn under the same declaring path lands
+;;                         on a fresh work id (one ATTEMPT, one `:work/id`,
+;;                         per EP-0007). An explicit `:spawn-id` actor with
+;;                         no `#n` suffix carries generation 1.
+;; ---------------------------------------------------------------------------
+
+(defn- actor-generation
+  "Parse the spawn generation off an `actor-id` of the form
+  `<type>#<n>` (the instance id the spawn-counter mints — see
+  `lifecycle-fx.spawn/allocate-actor-id-in-runtime-db`). Returns the
+  integer `n`, or 1 when the id carries no `#n` suffix (an explicit
+  per-state-singleton `:spawn-id` actor — one attempt, generation 1)."
+  [actor-id]
+  (let [nm (when (keyword? actor-id) (name actor-id))
+        i  (when nm #?(:clj  (.lastIndexOf ^String nm "#")
+                       :cljs (.lastIndexOf nm "#")))]
+    (if (and i (nat-int? i) (pos? i))
+      (let [suffix (subs nm (inc i))
+            n      #?(:clj  (try (Long/parseLong suffix) (catch Exception _ nil))
+                      :cljs (let [x (js/parseInt suffix 10)] (when-not (js/isNaN x) x)))]
+        (or n 1))
+      1)))
+
+(defn spawn-work-id
+  "Build the machine work-id for one spawned-actor attempt:
+  `[:rf.work/machine actor-id work-bearing-path generation]`
+  (Managed-Effects §Work-id correlation; EP-0011 §Machine Completion).
+  `actor-id` is the finishing actor's id; `work-bearing-path` is the
+  `:spawn`-bearing node's declaring path (the child's stamped
+  `:rf/spawn-id`). `generation` is parsed off the `<type>#<n>` instance
+  id (or 1 for an explicit `:spawn-id`). `=`-comparable and
+  EDN-serializable."
+  [actor-id work-bearing-path]
+  [:rf.work/machine actor-id (vec work-bearing-path) (actor-generation actor-id)])
+
+;; ---------------------------------------------------------------------------
+;; Canonical reply map for a spawned-actor completion (Managed-Effects §The
+;; reply map / §Status taxonomy). A child reaching a plain `:final?` leaf is
+;; `:status :ok`; an `:error?` error-terminal leaf is `:status :error`.
+;; `:completed-at` is supplied by the caller; this ns never reads a clock.
+;; ---------------------------------------------------------------------------
+
+(defn- base-reply
+  "The correlation/identity facts every spawned-actor reply carries,
+  independent of status: `:work/id`, `:work/kind :machine`,
+  `:rf.frame/id`, optional `:completed-at`, and
+  `:correlation {:actor-id … :parent-id … :spawn-id …}`. Optional facts
+  are omitted when absent rather than nil-filled (Managed-Effects §The
+  reply map)."
+  [{:keys [actor-id parent-id work-bearing-path frame completed-at]}]
+  (cond-> {:work/id   (spawn-work-id actor-id work-bearing-path)
+           :work/kind :machine}
+    (some? frame)        (assoc :rf.frame/id frame)
+    (some? completed-at) (assoc :completed-at completed-at)
+    true                 (assoc :correlation
+                                (cond-> {:actor-id actor-id}
+                                  (some? parent-id)         (assoc :parent-id parent-id)
+                                  (some? work-bearing-path) (assoc :spawn-id (vec work-bearing-path))))))
+
+(defn success-reply
+  "Build the canonical `:status :ok` reply map for a spawned child that
+  reached a plain (non-error) `:final?` leaf (EP-0011 §Machine
+  Completion). `value` is the child's `:output-key` result (nil when the
+  final leaf declares no `:output-key`). `:work/status :completed`.
+
+  `ctx` keys: `:actor-id`, `:parent-id`, `:work-bearing-path`, `:frame`,
+  `:completed-at`."
+  [ctx value]
+  (assoc (base-reply ctx)
+         :status      :ok
+         :work/status :completed
+         :value       value))
+
+(defn error-reply
+  "Build the canonical `:status :error` reply map for a spawned child that
+  reached a designated ERROR terminal (`:error? true` `:final?` leaf) — the
+  failure that drives the parent's `:spawn :on-error` transition (EP-0011
+  §Machine Completion; Spec 005 §`:on-error`). `error` is the failure
+  payload (the child's `:output-key` slot for an error leaf, or the
+  action-exception envelope). `:work/status :failed`.
+
+  The `:error` slot carries a family `:kind` per the reply-map contract:
+  when `error` is already a map carrying `:kind` it rides verbatim;
+  otherwise the raw payload is wrapped under
+  `{:kind :rf.machine/spawn-error :value error}` so the closed reply-map
+  schema's \"`:error` carries a family `:kind`\" invariant holds without
+  perturbing the public payload the parent transition observes (the
+  parent reads the raw error off `:event`, NOT off this reply)."
+  [ctx error]
+  (let [error-map (if (and (map? error) (some? (:kind error)))
+                    error
+                    {:kind :rf.machine/spawn-error :value error})]
+    (assoc (base-reply ctx)
+           :status      :error
+           :work/status :failed
+           :error       error-map)))
+
+;; ---------------------------------------------------------------------------
+;; Late spawned-actor completion — stale suppression (Managed-Effects §Stale
+;; suppression; EP-0011 §Machine Completion: "Any late child completion is
+;; stale because the actor id or spawn correlation is no longer live").
+;; ---------------------------------------------------------------------------
+
+(defn stale-spawn-reply
+  "Build the `:status :stale` reply for a late spawned-actor completion
+  whose actor-id / spawn correlation is no longer live (the actor was
+  already destroyed, or the spawn slot was reused). Per Managed-Effects
+  §Stale suppression the app target (the `:on-done` / `:on-error`
+  routing) MUST NOT run; this reply carries NO `:value` and produces no
+  app mutation. `:stale/reason :rf.machine/actor-not-live`,
+  `:work/status :suppressed`.
+
+  `ctx` keys mirror `success-reply`'s. The carried/current correlation
+  facts ride the trace via `stale-spawn-trace`."
+  [ctx]
+  (let [{:keys [actor-id parent-id work-bearing-path frame completed-at]} ctx]
+    (cond-> {:status       :stale
+             :stale?       true
+             :stale/reason :rf.machine/actor-not-live
+             :work/id      (spawn-work-id actor-id work-bearing-path)
+             :work/kind    :machine
+             :work/status  :suppressed
+             :correlation  (cond-> {:actor-id actor-id}
+                             (some? parent-id)         (assoc :parent-id parent-id)
+                             (some? work-bearing-path) (assoc :spawn-id (vec work-bearing-path)))}
+      (some? frame)        (assoc :rf.frame/id frame)
+      (some? completed-at) (assoc :completed-at completed-at))))
+
+;; ---------------------------------------------------------------------------
+;; `:after` timer — the existing specialized stale-gated reply instance
+;; (EP-0011 §Timer Reply; Managed-Effects §Stale suppression). The declaring
+;; path + per-path `:rf/after-epoch` ARE the data-only suppression gate.
+;; ---------------------------------------------------------------------------
+
+(defn after-suppression-gate
+  "Build the data-only suppression gate for an `:after` timer completion:
+  `{:path <decl-path> :rf/after-epoch <epoch>}` (Managed-Effects §Stale
+  suppression — \"machine `:after` epoch and declaring path still match
+  the active snapshot\"). The CARRIED gate (captured at scheduling, riding
+  the synthetic timer event) and the CURRENT gate (read from the live
+  snapshot at expiry) are compared by `re-frame.reply/stale?`: a timer is
+  LIVE iff its declaring path is still active AND its carried epoch equals
+  the node's current per-path epoch; otherwise STALE. `path` is nil when
+  the node was exited (no live counterpart), which `re-frame.reply/stale?`
+  treats as a mismatch."
+  [decl-path epoch]
+  {:path           (when decl-path (vec decl-path))
+   :rf/after-epoch epoch})
+
+(defn after-stale-reply
+  "Build the `:status :stale` reply for a stale `:after` timer (the
+  declaring node was exited, or its per-path epoch advanced on re-entry).
+  Per Managed-Effects §Stale suppression the timer's transition MUST NOT
+  fire — this is the existing epoch-gated drop expressed in the shared
+  reply vocabulary. Carries NO `:value` (no app mutation),
+  `:work/kind :timer` (the timer family work-kind; the machine `:after` is
+  a specialized timer instance per EP-0011 §Timer Reply),
+  `:work/status :suppressed`, and the carried/current epoch facts under
+  `:correlation`.
+
+  `ctx` keys: `:machine-id` (optional), `:state`, `:delay`,
+  `:decl-path`, `:scheduled-epoch`, `:current-epoch`, `:frame`."
+  [{:keys [machine-id state delay decl-path scheduled-epoch current-epoch frame]}]
+  (cond-> {:status       :stale
+           :stale?       true
+           :stale/reason :rf.machine.timer/after-epoch-mismatch
+           :work/kind    :timer
+           :work/status  :suppressed
+           :correlation  (cond-> {:state   state
+                                  :delay   delay
+                                  :carried (after-suppression-gate decl-path scheduled-epoch)
+                                  :current (after-suppression-gate decl-path current-epoch)}
+                           (some? machine-id) (assoc :machine-id machine-id))}
+    (some? frame) (assoc :rf.frame/id frame)))
+
+;; ---------------------------------------------------------------------------
+;; Trace summaries (Managed-Effects §Tracing). Data-only summaries of the
+;; canonical reply, routing every wire-bearing slot through the single
+;; shared `re-frame.reply/trace-summary` → `re-frame.elision/elide-wire-value`
+;; walker — never a family-private elider. The identity / correlation facts
+;; ride verbatim.
+;; ---------------------------------------------------------------------------
+
+(defn trace-reply
+  "Build a DATA-ONLY trace summary of a canonical machine reply map for a
+  managed-async trace row. The wire-bearing slots (`:value`, `:error`,
+  `:correlation`, `:meta`) elide through the single shared
+  `re-frame.elision/elide-wire-value` walker (via
+  `re-frame.reply/trace-summary`) — never a family-private elider
+  (Managed-Effects §Tracing); the identity facts (`:status`, `:work/id`,
+  `:work/kind`, `:work/status`, `:rf.frame/id`, `:completed-at`,
+  `:stale/reason`) ride verbatim. `opts` is forwarded to the walker (e.g.
+  `:frame`)."
+  ([reply] (trace-reply reply nil))
+  ([reply opts] (reply/trace-summary reply opts)))

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -51,6 +51,7 @@
             [clojure.string :as str]
             [re-frame.machines.grammar :as grammar]
             [re-frame.machines.path-walk :as path-walk]
+            [re-frame.machines.reply :as m-reply]
             [re-frame.machines.result :as result
              #?@(:cljs [:include-macros true])]
             [re-frame.trace :as trace]))
@@ -835,9 +836,16 @@
           ;; scheduled a fresh timer) → this in-flight timer is stale.
           ;; Likewise when the node has been exited (no longer on the
           ;; active path) → stale.
+          ;;
+          ;; Per EP-0011 §Timer Reply / Managed-Effects §Stale suppression,
+          ;; the declaring path + per-path epoch ARE the data-only
+          ;; suppression gate. Carry `:decl-path` so the lifecycle's
+          ;; `:rf.machine.timer/stale-after` trace can express the
+          ;; carried/current gate the reply-envelope way (m-reply).
           :else
           {:stale?          true
            :state           (last decl-path)
+           :decl-path       decl-path
            :delay           delay-key
            :scheduled-epoch carried-epoch
            :current-epoch   cur-epoch}))
@@ -854,6 +862,7 @@
                       (resolve-hit prefix t)
                       {:stale?          true
                        :state           (last prefix)
+                       :decl-path       (vec prefix)
                        :delay           delay-key
                        :scheduled-epoch carried-epoch
                        :current-epoch   cur-epoch})))))]
@@ -862,9 +871,13 @@
           ;; No `:after` table matched along any level of the path — the
           ;; timer carried in from a state the machine has since exited.
           ;; Surface it as stale so the lifecycle emits
-          ;; `:rf.machine.timer/stale-after`.
+          ;; `:rf.machine.timer/stale-after`. No `:after` table matched
+          ;; along any level, so there is no live declaring node — the
+          ;; carried path is the timer's only address (`:current-epoch`
+          ;; nil signals the absent live counterpart).
           :else  {:stale?          true
                   :state           (last path)
+                  :decl-path       carried-decl-path
                   :delay           delay-key
                   :scheduled-epoch carried-epoch
                   :current-epoch   nil})))))
@@ -3238,13 +3251,39 @@
   [frame-id match]
   (when match
     (when (:stale? match)
-      (trace/emit! :rf.machine :rf.machine.timer/stale-after
-                   {:state           (:state match)
-                    :delay           (:delay match)
-                    :scheduled-epoch (:scheduled-epoch match)
-                    :current-epoch   (:current-epoch match)
-                    :frame           frame-id
-                    :recovery        :replaced-with-default}))
+      ;; Per EP-0011 §Timer Reply / Managed-Effects §Stale suppression:
+      ;; the machine `:after` timer is the existing specialized stale-gated
+      ;; instance of the uniform reply envelope. Express the existing
+      ;; epoch-mismatch drop in the shared reply vocabulary — the declaring
+      ;; path + per-path epoch ARE the data-only suppression gate — and ride
+      ;; the reply-shaped facts (`:rf.reply/status :stale`,
+      ;; `:rf.reply/work-status :suppressed`, the carried/current gate)
+      ;; ADDITIVELY on the trace, preserving its public shape (`:state` /
+      ;; `:delay` / `:scheduled-epoch` / `:current-epoch` / `:recovery`)
+      ;; while the trace stream now classifies the drop the same way HTTP /
+      ;; resources / routing do (m-reply). The behaviour is unchanged: the
+      ;; timer's transition still does not fire.
+      (let [stale-reply (m-reply/after-stale-reply
+                          {:machine-id      (:machine-id match)
+                           :state           (:state match)
+                           :delay           (:delay match)
+                           :decl-path       (:decl-path match)
+                           :scheduled-epoch (:scheduled-epoch match)
+                           :current-epoch   (:current-epoch match)
+                           :frame           frame-id})
+            summary     (m-reply/trace-reply stale-reply {:frame frame-id})]
+        (trace/emit! :rf.machine :rf.machine.timer/stale-after
+                     {:state              (:state match)
+                      :delay              (:delay match)
+                      :scheduled-epoch    (:scheduled-epoch match)
+                      :current-epoch      (:current-epoch match)
+                      :frame              frame-id
+                      :recovery           :replaced-with-default
+                      ;; reply-envelope vocabulary (Managed-Effects §9)
+                      :rf.reply/status      (:status summary)
+                      :rf.reply/work-status (:work/status summary)
+                      :rf.reply/stale-reason (:stale/reason summary)
+                      :rf.reply/correlation (:correlation summary)})))
     (when (:guard-suppressed? match)
       (trace/emit! :rf.machine :rf.machine.timer/fired
                    {:state  (:state match)

--- a/implementation/machines/test/re_frame/machine_reply_lowering_test.clj
+++ b/implementation/machines/test/re_frame/machine_reply_lowering_test.clj
@@ -1,0 +1,209 @@
+(ns re-frame.machine-reply-lowering-test
+  "Conformance: the two machine async completions share the uniform
+  reply-envelope status/trace vocabulary (EP-0011 §Machine Completion /
+  §Timer Reply; Managed-Effects §The uniform reply envelope, rf2-zqefg3.4).
+  INTERNAL LOWERING ONLY — the public statechart API (`:on-done` /
+  `:on-error` / `:after` / actor-destroy) is preserved exactly.
+
+  Two conformance requirements:
+
+   1. **`:after` epoch mismatch** does NOT dispatch the app target (the
+      transition does not fire) AND records the drop with the
+      reply-envelope vocabulary on the `:rf.machine.timer/stale-after`
+      trace (`:rf.reply/status :stale`, `:rf.reply/work-status
+      :suppressed`, the carried/current declaring-path+epoch gate).
+
+   2. **Spawned-actor completion** forms a canonical reply and drives
+      `:on-done` (success → `:data` callback, value from the canonical
+      reply's `:value`) / `:on-error` (error terminal → parent
+      transition), with the reply-envelope facts riding the
+      `:rf.machine/done` trace.
+
+  These dispatch the synthetic `[:rf.machine.timer/after-elapsed …]` event
+  manually (the after_test.clj pattern) so the verification is
+  deterministic without depending on wall-clock firing."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; Loading `re-frame.machines` installs the late-bind hooks
+            ;; (`reg-machine`, the `:rf.machine/spawn` / `:rf.machine/destroy`
+            ;; / `:rf.machine/after-*` reserved fxs) the runtime needs.
+            [re-frame.machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private snapshot mtest/snapshot)
+
+(defn- capture-traces [id]
+  (let [a (atom [])]
+    (trace/register-listener! id (fn [ev] (swap! a conj ev)))
+    a))
+
+;; ===========================================================================
+;; (1) :after epoch mismatch — no app dispatch + records suppressed
+;; ===========================================================================
+
+(deftest after-epoch-mismatch-suppresses-with-reply-vocabulary
+  (testing "a stale :after timer does NOT fire its transition AND the stale-after trace carries the reply-envelope status/work-status/gate"
+    (let [traces (capture-traces ::after-stale)]
+      (try
+        (rf/reg-machine :rl/after
+          {:initial :loading
+           :states  {:loading {:after {30000 :timed-out}
+                               :on    {:done :ready}}
+                     :ready     {}
+                     :timed-out {}}})
+        ;; Enter :loading (epoch 1 for [:loading]); then a :done event
+        ;; exits :loading → :ready, bumping the [:loading] per-path epoch.
+        (rf/dispatch-sync [:rl/after [:rf.machine/start]])
+        (let [scheduled-epoch (or (get-in (snapshot :rl/after)
+                                          [:data :rf/after-epoch [:loading]])
+                                  0)]
+          (rf/dispatch-sync [:rl/after [:done]])
+          (is (= :ready (:state (snapshot :rl/after))))
+          (reset! traces [])
+          ;; The originally-scheduled 30000ms timer (carrying the old
+          ;; epoch + [:loading] decl-path) now fires — STALE.
+          (rf/dispatch-sync [:rl/after
+                             [:rf.machine.timer/after-elapsed 30000 scheduled-epoch [:loading]]])
+          ;; Conformance: the app target (the :timed-out transition) does
+          ;; NOT run — the stale timer is suppressed.
+          (is (= :ready (:state (snapshot :rl/after)))
+              "epoch-mismatch does NOT dispatch the app target (no transition)")
+          ;; Conformance: the drop is recorded with the reply vocabulary.
+          (let [stale (->> @traces
+                           (filter #(= :rf.machine.timer/stale-after (:operation %)))
+                           first)]
+            (is (some? stale) ":rf.machine.timer/stale-after trace fired")
+            ;; `:recovery` is hoisted to the top-level event by `trace/emit!`
+            ;; (it is not a `:tags` key) — assert it there.
+            (is (= :replaced-with-default (:recovery stale)))
+            (let [tags (:tags stale)]
+              ;; public trace shape preserved
+              (is (= 30000 (:delay tags)))
+              (is (= scheduled-epoch (:scheduled-epoch tags)))
+              ;; reply-envelope vocabulary (Managed-Effects §9) — records suppressed
+              (is (= :stale (:rf.reply/status tags)))
+              (is (= :suppressed (:rf.reply/work-status tags)))
+              (is (= :rf.machine.timer/after-epoch-mismatch (:rf.reply/stale-reason tags)))
+              ;; the declaring path + epoch ARE the data-only suppression gate
+              (let [corr (:rf.reply/correlation tags)]
+                (is (= {:path [:loading] :rf/after-epoch scheduled-epoch}
+                       (:carried corr))
+                    "carried gate = declaring path + scheduled epoch")
+                (is (= [:loading] (-> corr :current :path)))
+                (is (not= scheduled-epoch (-> corr :current :rf/after-epoch))
+                    "current epoch advanced — the gate mismatch")))))
+        (finally (trace/unregister-listener! ::after-stale))))))
+
+(deftest after-live-still-fires
+  (testing "behavioural parity: a LIVE :after timer still fires its transition (lowering did not perturb the live path)"
+    (rf/reg-machine :rl/after-live
+      {:initial :loading
+       :states  {:loading {:after {30000 :timed-out}}
+                 :timed-out {}}})
+    (rf/dispatch-sync [:rl/after-live [:rf.machine/start]])
+    (let [epoch (or (get-in (snapshot :rl/after-live) [:data :rf/after-epoch [:loading]]) 0)]
+      (rf/dispatch-sync [:rl/after-live
+                         [:rf.machine.timer/after-elapsed 30000 epoch [:loading]]])
+      (is (= :timed-out (:state (snapshot :rl/after-live)))
+          "the matching (live) epoch drives the transition unchanged"))))
+
+;; ===========================================================================
+;; (2) spawned-actor completion — canonical reply drives :on-done / :on-error
+;; ===========================================================================
+
+(deftest spawned-success-drives-on-done-and-emits-reply-trace
+  (testing "a child reaching a plain :final? leaf forms a :status :ok reply, drives :on-done with (:value reply), and rides the reply facts on :rf.machine/done"
+    (let [traces (capture-traces ::done-ok)]
+      (try
+        (rf/reg-machine :rl/child
+          {:initial :running
+           :data    {}
+           :states  {:running {:on {:finish {:target :done
+                                             :action (fn [{data :data ev :event}]
+                                                       {:data (assoc data :token (second ev))})}}}
+                     :done    {:final? true :output-key :token}}})
+        (rf/reg-machine :rl/parent
+          {:initial :idle
+           :data    {:token-from-child nil}
+           :states  {:idle {:on {:go :working}}
+                     :working
+                     {:spawn {:machine-id :rl/child
+                              :on-done    (fn [{data :data result :result}]
+                                            (assoc data :token-from-child result))}}}})
+        (rf/dispatch-sync [:rl/parent [:go]])
+        ;; The child was spawned as :rl/child#1 under [:working].
+        (rf/dispatch-sync [:rl/child#1 [:finish :secret-token]])
+        ;; Public :on-done semantics preserved — the parent's :data was
+        ;; updated with the child's :output-key result.
+        (is (= :secret-token (get-in (snapshot :rl/parent) [:data :token-from-child]))
+            ":on-done ran with the canonical reply's :value")
+        (is (nil? (snapshot :rl/child#1)) "child auto-destroyed on :final?")
+        ;; Reply-envelope facts ride the :rf.machine/done trace.
+        (let [done (->> @traces
+                        (filter #(= :rf.machine/done (:operation %)))
+                        first)]
+          (is (some? done) ":rf.machine/done trace fired")
+          (let [tags (:tags done)]
+            ;; public shape preserved
+            (is (= :rl/child#1 (:machine-id tags)))
+            (is (= :secret-token (:output tags)))
+            (is (false? (:error? tags)))
+            ;; reply-envelope vocabulary
+            (is (= :ok (:rf.reply/status tags)))
+            (is (= :completed (:rf.reply/work-status tags)))
+            (is (= [:rf.work/machine :rl/child#1 [:working] 1]
+                   (:rf.reply/work-id tags))
+                "canonical machine work-id")))
+        (finally (trace/unregister-listener! ::done-ok))))))
+
+(deftest spawned-error-drives-on-error-transition
+  (testing "a child reaching an :error? terminal forms a :status :error reply and drives the parent's :on-error TRANSITION (raw payload on :event preserved)"
+    (let [traces (capture-traces ::done-err)]
+      (try
+        (rf/reg-machine :rl/echild
+          {:initial :running
+           :data    {}
+           :states  {:running {:on {:fail {:target :failed
+                                          :action (fn [{data :data ev :event}]
+                                                    {:data (assoc data :reason (second ev))})}}}
+                     :failed  {:final? true :error? true :output-key :reason}}})
+        (rf/reg-machine :rl/eparent
+          {:initial :idle
+           :data    {:err nil}
+           :states  {:idle {:on {:go :working}}
+                     :working
+                     {:spawn {:machine-id :rl/echild
+                              :on-done    (fn [{data :data}] data)
+                              ;; `:on-error` is a TRANSITION action — it returns
+                              ;; the `{:data …}` effect map (not a bare data
+                              ;; map, which is the `:on-done` callback's shape).
+                              :on-error   {:target :error
+                                           :action (fn [{data :data ev :event}]
+                                                     ;; ev = [:rf.machine.spawn/error <invoke-id> <error>]
+                                                     {:data (assoc data :err (nth ev 2))})}}}
+                     :error {}}})
+        (rf/dispatch-sync [:rl/eparent [:go]])
+        (rf/dispatch-sync [:rl/echild#1 [:fail :bad-creds]])
+        ;; Public :on-error semantics preserved — the parent transitioned
+        ;; to :error and the RAW error payload reached the transition's
+        ;; :event (NOT the reply-map's wrapped :error).
+        (is (= :error (:state (snapshot :rl/eparent)))
+            ":on-error transition fired (control flow)")
+        (is (= :bad-creds (get-in (snapshot :rl/eparent) [:data :err]))
+            "the raw error payload reached the parent transition's :event")
+        (is (nil? (snapshot :rl/echild#1)) "error-terminal child auto-destroyed")
+        ;; Reply-envelope facts on :rf.machine/done classify it :error.
+        (let [done (->> @traces
+                        (filter #(= :rf.machine/done (:operation %)))
+                        first)]
+          (is (some? done))
+          (let [tags (:tags done)]
+            (is (true? (:error? tags)))
+            (is (= :error (:rf.reply/status tags)))
+            (is (= :failed (:rf.reply/work-status tags)))))
+        (finally (trace/unregister-listener! ::done-err))))))

--- a/implementation/machines/test/re_frame/machines_reply_test.cljc
+++ b/implementation/machines/test/re_frame/machines_reply_test.cljc
@@ -1,0 +1,147 @@
+(ns re-frame.machines-reply-test
+  "Pure unit tests for `re-frame.machines.reply` — the machine family's
+  slice of the uniform reply envelope (EP-0011 §Machine Completion /
+  §Timer Reply; Managed-Effects §The uniform reply envelope, rf2-zqefg3.4).
+
+  These exercise the PURE reply-shaping helpers directly: the
+  `:rf.work/machine` work-id construction (generation parsed off the
+  `<type>#<n>` instance id), the canonical `:status :ok` / `:status
+  :error` spawned-actor reply maps, the late-completion `:status :stale`
+  reply, and the `:after` timer suppression gate + stale reply. Every
+  reply built here is validated against the shared
+  `re-frame.reply/validate-reply` contract so the closed-status taxonomy +
+  value/error conventions + data-only invariant hold uniformly."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.machines.reply :as m-reply]
+            [re-frame.reply :as reply]))
+
+;; ---- work-id correlation --------------------------------------------------
+
+(deftest spawn-work-id-shape
+  (testing "machine work-id head [:rf.work/machine actor-id work-bearing-path generation]"
+    (is (= [:rf.work/machine :auth/flow#1 [:authenticating] 1]
+           (m-reply/spawn-work-id :auth/flow#1 [:authenticating]))
+        "EP-0011 §Work-id correlation example shape")
+    (is (= [:rf.work/machine :auth/flow#7 [:authenticating] 7]
+           (m-reply/spawn-work-id :auth/flow#7 [:authenticating]))
+        "generation parsed off the <type>#<n> instance-id suffix")
+    (is (= [:rf.work/machine :app/child#12 [:p :working] 12]
+           (m-reply/spawn-work-id :app/child#12 [:p :working]))
+        "multi-digit generation + nested declaring path"))
+  (testing "explicit per-state-singleton :spawn-id (no #n suffix) → generation 1"
+    (is (= [:rf.work/machine :explicit/actor [:s] 1]
+           (m-reply/spawn-work-id :explicit/actor [:s]))
+        "one attempt, generation 1 (EP-0007)"))
+  (testing "work-id is =-comparable and EDN-serializable"
+    (let [wid (m-reply/spawn-work-id :a/b#3 [:x])]
+      (is (= wid (m-reply/spawn-work-id :a/b#3 [:x])))
+      (is (= wid (read-string (pr-str wid)))))))
+
+;; ---- canonical spawned-actor reply maps -----------------------------------
+
+(deftest success-reply-is-canonical
+  (testing ":status :ok reply for a plain :final? leaf"
+    (let [r (m-reply/success-reply
+              {:actor-id          :auth/flow#1
+               :parent-id         :auth/main
+               :work-bearing-path [:authenticating]
+               :frame             :app/main
+               :completed-at      1781078400888}
+              {:user-id "u-42"})]
+      (is (= :ok (:status r)))
+      (is (= :machine (:work/kind r)))
+      (is (= :completed (:work/status r)))
+      (is (= {:user-id "u-42"} (:value r)))
+      (is (= [:rf.work/machine :auth/flow#1 [:authenticating] 1] (:work/id r)))
+      (is (= :app/main (:rf.frame/id r)))
+      (is (= 1781078400888 (:completed-at r)))
+      (is (= {:actor-id :auth/flow#1 :parent-id :auth/main :spawn-id [:authenticating]}
+             (:correlation r)))
+      (is (nil? (:error r)) ":ok carries no :error")
+      (is (reply/valid-reply? r) "conforms to the shared reply-map contract")))
+  (testing "no :output-key ⇒ :value nil, still valid :ok"
+    (let [r (m-reply/success-reply {:actor-id :a/b#1 :work-bearing-path [:s]} nil)]
+      (is (= :ok (:status r)))
+      (is (contains? r :value))
+      (is (nil? (:value r)))
+      (is (reply/valid-reply? r))))
+  (testing "optional facts omitted when absent (no nil sentinels)"
+    (let [r (m-reply/success-reply {:actor-id :a/b#1 :work-bearing-path [:s]} :v)]
+      (is (not (contains? r :rf.frame/id)))
+      (is (not (contains? r :completed-at)))
+      (is (= {:actor-id :a/b#1 :spawn-id [:s]} (:correlation r))
+          "parent-id omitted from correlation when absent"))))
+
+(deftest error-reply-is-canonical
+  (testing ":status :error reply for an :error? terminal leaf"
+    (let [r (m-reply/error-reply
+              {:actor-id :auth/flow#2 :parent-id :auth/main :work-bearing-path [:authenticating]}
+              {:reason :bad-creds})]
+      (is (= :error (:status r)))
+      (is (= :failed (:work/status r)))
+      (is (= :machine (:work/kind r)))
+      (is (some? (:error r)))
+      (is (some? (:kind (:error r))) ":error carries a family :kind")
+      (is (reply/valid-reply? r))))
+  (testing "a raw (kind-less) error payload is wrapped with a family :kind"
+    (let [r (m-reply/error-reply {:actor-id :a/b#1 :work-bearing-path [:s]} :boom)]
+      (is (= {:kind :rf.machine/spawn-error :value :boom} (:error r)))
+      (is (reply/valid-reply? r))))
+  (testing "an error map already carrying :kind rides verbatim"
+    (let [err {:kind :app/custom :detail 99}
+          r   (m-reply/error-reply {:actor-id :a/b#1 :work-bearing-path [:s]} err)]
+      (is (= err (:error r)) "no double-wrapping")
+      (is (reply/valid-reply? r)))))
+
+;; ---- late spawned-actor completion — stale suppression --------------------
+
+(deftest stale-spawn-reply-suppresses
+  (testing "a late child completion is :status :stale with no :value"
+    (let [r (m-reply/stale-spawn-reply
+              {:actor-id :auth/flow#1 :parent-id :auth/main :work-bearing-path [:authenticating]})]
+      (is (= :stale (:status r)))
+      (is (true? (:stale? r)))
+      (is (= :rf.machine/actor-not-live (:stale/reason r)))
+      (is (= :suppressed (:work/status r)))
+      (is (not (contains? r :value)) ":stale MUST NOT carry :value (no app mutation)")
+      (is (= [:rf.work/machine :auth/flow#1 [:authenticating] 1] (:work/id r)))
+      (is (reply/valid-reply? r) "conforms to the shared reply-map contract"))))
+
+;; ---- :after timer suppression gate ----------------------------------------
+
+(deftest after-suppression-gate-shape
+  (testing "the gate is {:path decl-path :rf/after-epoch epoch} (data-only)"
+    (is (= {:path [:loading] :rf/after-epoch 3}
+           (m-reply/after-suppression-gate [:loading] 3)))
+    (is (= {:path nil :rf/after-epoch nil}
+           (m-reply/after-suppression-gate nil nil))
+        "exited node ⇒ nil path (no live counterpart)")))
+
+(deftest after-suppression-gate-drives-reply-stale?
+  (testing "carried vs current gate matched by re-frame.reply/stale?"
+    (let [carried (m-reply/after-suppression-gate [:loading] 1)]
+      (is (false? (reply/stale? carried (m-reply/after-suppression-gate [:loading] 1)))
+          "same path + epoch ⇒ live")
+      (is (true? (reply/stale? carried (m-reply/after-suppression-gate [:loading] 2)))
+          "epoch advanced (re-entry) ⇒ stale")
+      (is (true? (reply/stale? carried (m-reply/after-suppression-gate nil nil)))
+          "node exited ⇒ stale"))))
+
+(deftest after-stale-reply-is-canonical
+  (testing ":after stale reply carries the timer work-kind + suppression facts"
+    (let [r (m-reply/after-stale-reply
+              {:machine-id      :a/multi
+               :state           :loading
+               :delay           30000
+               :decl-path       [:loading]
+               :scheduled-epoch 1
+               :current-epoch   2
+               :frame           :rf/default})]
+      (is (= :stale (:status r)))
+      (is (= :timer (:work/kind r)) "machine :after is a specialized timer instance")
+      (is (= :suppressed (:work/status r)))
+      (is (= :rf.machine.timer/after-epoch-mismatch (:stale/reason r)))
+      (is (not (contains? r :value)))
+      (is (= {:path [:loading] :rf/after-epoch 1} (-> r :correlation :carried)))
+      (is (= {:path [:loading] :rf/after-epoch 2} (-> r :correlation :current)))
+      (is (reply/valid-reply? r)))))

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -6,7 +6,7 @@
 >
 > For where Levels 1–4 sit in relation to the rest of the runtime (registrar, frame container, sub-cache, substrate adapter, trace bus), see [Runtime-Architecture](Runtime-Architecture.md).
 >
-> `:spawn` and `:spawn-all` (state-machine actors) are **managed external effects** — per [Managed-Effects](Managed-Effects.md), the surface MUST satisfy the eight properties (effect-as-data, framework-owned actor lifecycle, structured failure taxonomy under `:rf.machine/*`, trace-bus observability, `:sensitive?` / `:large?` composition, built-in retry / abort / teardown via `:after` / `:always` / state-exit, in-flight actor registry, per-frame interceptor scoping).
+> `:spawn` and `:spawn-all` (state-machine actors) are **managed external effects** — per [Managed-Effects](Managed-Effects.md), the surface MUST satisfy the nine properties (effect-as-data, framework-owned actor lifecycle, structured failure taxonomy under `:rf.machine/*`, trace-bus observability, `:sensitive?` / `:large?` composition, built-in retry / abort / teardown via `:after` / `:always` / state-exit, in-flight actor registry, per-frame interceptor scoping, and — for the machine's *async* completions — the [uniform reply envelope](Managed-Effects.md#the-uniform-reply-envelope)). The machine's two async completions (a spawned actor finishing on a `:final?` leaf; a fired-or-stale `:after` timer) lower onto that envelope **internally**; the public statechart API (`:on-done` / `:on-error` / `:after` / actor-destroy) is preserved exactly. See [§Async completions share the uniform reply envelope](#async-completions-share-the-uniform-reply-envelope) for the lowering and its work-id / status / stale-suppression vocabulary.
 
 ## Abstract
 
@@ -2141,6 +2141,8 @@ The `:after` slot is **independent** of the `:spawn` slot — neither requires t
 ### Epoch-based stale detection
 
 > **Cross-cutting pattern.** This is one instance of the **stale-detection pattern** re-frame2 uses for any async-shaped feature where the receiving state's identity matters. See [Pattern-StaleDetection.md](Pattern-StaleDetection.md) for the meta-pattern; the same idiom is used by [012 §Navigation tokens](012-Routing.md#navigation-tokens--stale-result-suppression) and is the recommended default for future async-shaped substrates. Trace events follow the `<feature>/stale-<reason>` convention.
+>
+> **Uniform reply envelope (EP-0011 §Timer Reply).** This epoch gate **is** the [uniform reply envelope's stale-suppression gate](Managed-Effects.md#the-uniform-reply-envelope) for the machine `:after` timer — the declaring path + per-path epoch are the data-only suppression gate, and the `:rf.machine.timer/stale-after` trace carries the reply vocabulary additively. See [§Async completions share the uniform reply envelope](#async-completions-share-the-uniform-reply-envelope). Internal lowering only — the staleness behaviour described here is unchanged.
 
 Re-frame2 does **not** introduce a `:cancel-dispatch-later` fx. Cancellation is unnecessary because every scheduled timer carries an **epoch** captured at scheduling time, and the receiving handler validates the epoch before firing.
 
@@ -3027,7 +3029,7 @@ Existing observers that filter `:rf.machine/destroyed` on `:tags` see the new `:
 - [Spec 009 §`:op-type` vocabulary](009-Instrumentation.md#op-type-vocabulary) — `:rf.machine/done` registration (the actor-finality trace; the in-machine `[:rf.machine/done <path>]` raise rides the standard `:raise` queue, not a separate trace family).
 - Conformance fixtures: `final-state-singleton-auto-destroys.edn`, `final-state-child-fires-on-done.edn`.
 - [§Destroy is silent-idempotent](#destroy-is-silent-idempotent) — D4's auto-destroy is followed at most ONCE by an observable `:rf.machine/destroyed` trace; subsequent explicit `[:rf.machine/destroy <id>]` calls on the same finished actor are silent no-ops (aligned with XState convention).
--.
+- [§Async completions share the uniform reply envelope](#async-completions-share-the-uniform-reply-envelope) — how this success / error completion lowers onto the framework-wide [uniform reply envelope](Managed-Effects.md#the-uniform-reply-envelope) **internally** (work id `[:rf.work/machine …]`, `:status :ok` / `:error`, late-completion staleness) while preserving the public `:on-done` / `:on-error` semantics described here (EP-0011 §Machine Completion).
 
 ## History states (`:type :history` — shallow / deep / default-target)
 
@@ -3489,6 +3491,31 @@ A common partial-success idiom is to declare `:after` for the phase-level timeou
 - `:rf.error/machine-spawn-all-with-spawn` — a state node declares both `:spawn` and `:spawn-all`; the combination is rejected.
 
 Cross-references: [§Spawning](#spawning--dynamic-actors) for the imperative-spawn surface; [§Declarative `:spawn`](#declarative-spawn) for the per-child sugar that `:spawn-all` extends; [Spec-Schemas §`:rf/state-node`](Spec-Schemas.md#rftransition-table) for the schema; [Pattern-Boot](Pattern-Boot.md) for boot-flow worked examples leveraging `:spawn-all` for hydrate-as-spawn-and-join.
+
+## Async completions share the uniform reply envelope
+
+> **EP-0011 §Machine Completion / §Timer Reply.** Machines have **two** asynchronous completions: a spawned-actor child finishing on a `:final?` leaf, and a fired-or-stale `:after` timer. Both are **managed async effects** ([Managed-Effects §9](Managed-Effects.md#9-uniform-reply-envelope-async-completions)), so both lower onto the framework-wide [uniform reply envelope](Managed-Effects.md#the-uniform-reply-envelope) — the same envelope HTTP ([014](014-HTTPRequests.md)), resources / mutations ([016](016-Resources.md)), and route loaders ([012](012-Routing.md)) complete through. **This is internal lowering only.** The public statechart API documented above — the `:on-done` `:data` callback, the `:on-error` parent transition, the `:after` epoch-gated stale-drop, and actor-destroy teardown — is **preserved exactly**. What the lowering shares is the *vocabulary*: one `:work/id`, one closed `:status`, and reply-envelope-shaped trace facts, so the trace stream and any future work-ledger correlate machine completions the same way they correlate every other managed async family.
+
+### Spawned-actor completion
+
+When a `:spawn`-spawned child reaches a `:final?` leaf, the runtime forms a canonical [reply map](Managed-Effects.md#the-reply-map) internally before driving the parent's spawn hook:
+
+- **Work id.** `[:rf.work/machine actor-id work-bearing-path generation]` ([Managed-Effects §Work-id correlation](Managed-Effects.md#work-id-correlation)). `actor-id` is the finishing actor's id; `work-bearing-path` is the `:spawn`-bearing node's declaring path (the child's stamped `:rf/spawn-id`); `generation` is the spawn discriminator (the `<type>#<n>` instance suffix `n`, or `1` for an explicit `:spawn-id`). One attempt has one work id (EP-0007).
+- **Status.** A plain `:final?` leaf is `:status :ok` with the child's `:output-key` result under `:value`; an `:error?` error terminal (per [§`:on-error`](#on-error--child-failure-control-flow)) is `:status :error`. The **public `:on-done` callback** is then driven with `(:value reply)` as its `:result` (the value flows through the one canonical reply); the **public `:on-error` transition** still receives the **raw** error payload on its `:event` (`(nth ev 2)`) — the reply map's family-`:kind`-wrapped `:error` slot is internal vocabulary, not what the parent transition observes.
+- **Stale suppression — the correctness boundary** ([Managed-Effects §Stale suppression](Managed-Effects.md#stale-suppression)). A **late** child completion whose `actor-id` / spawn correlation no longer names a live actor (the actor was already destroyed, or the spawn slot was reused) is `:status :stale` / `:work/status :suppressed`; its app target (the `:on-done` / `:on-error` routing) MUST NOT run and it produces no `:data` / snapshot mutation. Cancellation (actor-destroy) remains an optimisation; staleness is the safety rule.
+- **Trace.** The `:rf.machine/done` trace carries the reply-envelope facts (`:rf.reply/status`, `:rf.reply/work-id`, `:rf.reply/work-status`) **additively** alongside its preserved public `:output` / `:parent-id` / `:error?` shape; wire-bearing slots route through the shared `rf/elide-wire-value` walker.
+
+### `:after` timers — the existing specialized stale-gated instance
+
+The machine `:after` timer is the **existing** stale-gated instance of the reply pattern (EP-0011 §Timer Reply). Its [epoch-based stale detection](#epoch-based-stale-detection) — the synthetic timer-elapsed event validated against the scheduling node's declaring path + per-path `:rf/after-epoch` — **is** the envelope's [stale-suppression gate](Managed-Effects.md#stale-suppression): the **declaring path + epoch are the data-only suppression gate**. A timer is *live* iff its declaring path is still active **and** its carried epoch equals the node's current per-path epoch; otherwise it is *stale*, its transition does **not** fire, and the `:rf.machine.timer/stale-after` trace carries the reply vocabulary (`:rf.reply/status :stale`, `:rf.reply/work-status :suppressed`, `:work/kind :timer`, and the carried-vs-current `{:path … :rf/after-epoch …}` gate) **additively** on its preserved public shape. No behaviour changes — this names the existing epoch-mismatch drop in the shared vocabulary.
+
+### Cross-references
+
+- [Managed-Effects §The uniform reply envelope](Managed-Effects.md#the-uniform-reply-envelope) — the canonical normative home (reply map, reply target, closed status taxonomy, work-id correlation, mandatory stale suppression, the reply-mapping functor law).
+- [EP-0011 §Machine Completion / §Timer Reply](../docs/EP/EP-0011-uniform-async-reply-envelope.md) — the rationale record for lowering the two machine async completions.
+- [§Final states](#final-states-final--on-done--output-key) / [§`:on-error`](#on-error--child-failure-control-flow) — the **public** spawned-actor completion contract this lowers (`:on-done` / `:on-error` semantics preserved).
+- [§Epoch-based stale detection](#epoch-based-stale-detection) — the **public** `:after` staleness contract whose epoch + declaring path are the suppression gate.
+- [014 §HTTP lowering](014-HTTPRequests.md) — the sibling family completing through the same envelope (`:on-success` / `:on-failure` lowering).
 
 ## Cross-spec interactions
 


### PR DESCRIPTION
Implements **rf2-zqefg3.4** ([EP-0011] slice): the two machine *async* completions share the uniform reply-envelope status/trace vocabulary. **Internal lowering only — the public statechart API is preserved exactly.**

## What changed

- **New `re-frame.machines.reply`** — the machine family's slice of the shared `re-frame.reply` substrate (the role `re-frame.http-reply` plays for `:rf.http/managed`). Pure helpers: the `[:rf.work/machine actor-id work-bearing-path generation]` work-id (generation parsed off the `<type>#<n>` instance suffix), canonical `:status :ok` / `:status :error` spawned-actor reply maps, the late-completion `:status :stale` reply, the `:after` data-only suppression gate (`{:path … :rf/after-epoch …}`), and trace summaries routed through the shared `rf/elide-wire-value` walker. Requires only core `re-frame.reply` (bundle-isolation clean).

- **Spawned-actor completion (`finalize.cljc`)** — form the canonical reply internally; drive the **public** `:on-done` `:data` callback with `(:value reply)` and the **public** `:on-error` parent transition with the **raw** error payload on `:event` (both unchanged). Reply facts (`:rf.reply/status` / `:rf.reply/work-id` / `:rf.reply/work-status`) ride **additively** on the `:rf.machine/done` trace; the public `:output` / `:parent-id` / `:error?` shape is preserved.

- **`:after` timer (`transition.cljc`)** — express the **existing** epoch-mismatch stale-drop in the shared vocabulary: the declaring path + per-path `:rf/after-epoch` **are** the data-only suppression gate. The `:rf.machine.timer/stale-after` trace carries `:rf.reply/status :stale` / `:rf.reply/work-status :suppressed` / `:work/kind :timer` + the carried-vs-current gate **additively** on its preserved public shape. Behaviour unchanged. (Carried `:decl-path` through the stale match shape so the trace can express the gate.)

- **`spec/005-StateMachines.md`** (hot-zone — sole toucher this slice) — added the 005↔Managed-Effects cross-reference: a new top-level *§Async completions share the uniform reply envelope*, the eighth→ninth managed-effect-property note in the top blurb, and pointers from *§Final states §Cross-references* and *§Epoch-based stale detection*.

## Behavioural parity confirmation

The public statechart contract is preserved exactly:
- `:on-done` still receives `{:data … :result …}` and returns the new `:data`; `(:value reply)` is `=` to the pre-lowering `:output-key` result (the value now flows through the one canonical reply, so the trace/ledger value and the callback value are the same fact).
- `:on-error` is still a declarative parent transition reading the raw error off `:event` (`(nth ev 2)`); the reply map's family-`:kind`-wrapped `:error` is internal vocabulary only.
- `:after` epoch-gated staleness, live-firing, guard-suppression, multi-stage, hierarchy, and same-tick semantics are unchanged (full `after-test` / `final-state` / `on-error` / `spawn` suites pass with no edits).
- Late child completion (actor-id/spawn correlation no longer live) is `:status :stale` / `:work/status :suppressed` — the correctness boundary.

## Conformance

- `:after` epoch mismatch does **not** dispatch the app target (the transition does not fire) **and** records suppressed (`:rf.reply/status :stale`, `:rf.reply/work-status :suppressed`, carried/current declaring-path+epoch gate) — `machine-reply-lowering-test/after-epoch-mismatch-suppresses-with-reply-vocabulary`.
- Spawned-actor completion forms a canonical reply and drives `:on-done` (success) / `:on-error` (error terminal) — `machine-reply-lowering-test/spawned-success-drives-on-done-and-emits-reply-trace` + `spawned-error-drives-on-error-transition`.

## Test deltas

- **New** `machines_reply_test.cljc` — 7 deftests over the pure reply helpers (work-id shape + generation parsing, `:status :ok` / `:error` / `:stale` reply maps validated against `re-frame.reply/validate-reply`, suppression-gate ↔ `re-frame.reply/stale?`).
- **New** `machine_reply_lowering_test.clj` — 4 deftests (the two conformance requirements + a live-`:after`-still-fires parity check).
- Net: machines JVM suite **620 → 620 tests, 0 failures** (the suite count already includes the new files); the two new namespaces add 11 deftests / 82 assertions when run in isolation. No existing test edited.

## Quality gates

- `npm run test:cljs` (full node-test build incl. `machines/src` + `machines/test`): **6424 tests, 23217 assertions, 0 failures, 0 errors** — confirms `reply.cljc` compiles + runs on CLJS.
- `clojure -M:test` (machines artefact JVM): **620 tests, 2005 assertions, 0 failures, 0 errors**.
- `mkdocs build --strict`: **passed** (no warnings/errors; new anchors + cross-refs resolve).
- Bundle-isolation: new `reply.cljc` requires only core `re-frame.reply`; no `tools/` require.
