### PR TITLE
feat(epoch): :committed-at from causal token :time-ms, not ambient clock (rf2-bh56rc)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1003,6 +1003,18 @@
 ;; is moot there).
 (def ^:dynamic *cascade-frame-state-before* nil)
 
+;; rf2-bh56rc: the in-flight dequeued event's causal `:time-ms` (the
+;; `:rf.world/inputs` `:time-ms` stamped on its envelope at the causal
+;; boundary), bound by the router around `process-event!` alongside
+;; `*cascade-frame-state-before*`. A handler that calls `destroy-frame!`
+;; on its own frame mid-drain runs INSIDE this binding, so the
+;; `:halted-destroy` epoch record's `:committed-at` is the DESTROYING
+;; event's causal time — replayable — rather than an ambient host-clock
+;; read at assembly time (per EP-0010 §Time / Spec 002 §The World-Input
+;; Rule). nil outside a drain — the moot out-of-cascade destroy commits no
+;; record, so the epoch surface's nil-tolerant fallback applies.
+(def ^:dynamic *cascade-time-ms* nil)
+
 (defn- safe-call-hook!
   "Fire a late-bound cleanup hook by key. No-op when unbound. Exceptions
   are caught so one bad hook can't block the rest of teardown — but the
@@ -1284,9 +1296,15 @@
   Both snapshots are captured BEFORE the frame is removed and passed
   explicitly so the epoch surface (which fires AFTER `dissoc-frame!`,
   step 6) does not have to read a container that is already gone — the
-  root cause of the prior nil-`:db-before` / nil-`:db-after` records."
-  [id fs-before fs-after]
-  (safe-call-hook! :epoch/on-frame-destroyed id fs-before fs-after))
+  root cause of the prior nil-`:db-before` / nil-`:db-after` records.
+
+  `committed-at` (rf2-bh56rc) is the destroying event's causal `:time-ms`
+  (the router-bound `*cascade-time-ms*`), threaded so the `:halted-destroy`
+  record's `:committed-at` is replayable per EP-0010 §Time rather than an
+  ambient host-clock read. nil outside a drain (the moot out-of-cascade
+  destroy commits no record)."
+  [id fs-before fs-after committed-at]
+  (safe-call-hook! :epoch/on-frame-destroyed id fs-before fs-after committed-at))
 
 (defn destroy-frame!
   "Tear down a frame. Per Spec 002 §Destroy, the ordered steps are:
@@ -1395,6 +1413,11 @@
       ;; Both are passed to `notify-epoch-listeners!` (step 8). EP-0001
       ;; (rf2-3aizt1, decision #2): the whole frame-state, both partitions.
       (let [cascade-fs-before *cascade-frame-state-before*
+            ;; rf2-bh56rc: the destroying event's causal `:time-ms`, bound by
+            ;; the router alongside `*cascade-frame-state-before*`. Threaded to
+            ;; the epoch hook so the `:halted-destroy` record's `:committed-at`
+            ;; is replayable (per EP-0010 §Time). nil outside a drain.
+            cascade-time-ms   *cascade-time-ms*
             fs-at-destroy     (frame-state-value id)
             ;; EP-0008 R1 (rf2-ini4wr): per-destroy accumulator for
             ;; cleanup-hook failures. `safe-call-hook!` conj's an entry per
@@ -1474,7 +1497,7 @@
         (safe-call-hook! :trace.tooling/release-frame-ring! id)
         (dissoc-frame! id)
         (unregister-frame! id)
-        (notify-epoch-listeners! id cascade-fs-before fs-at-destroy)
+        (notify-epoch-listeners! id cascade-fs-before fs-at-destroy cascade-time-ms)
         nil
         (finally
           ;; EP-0008 R1 (rf2-ini4wr) — FINALLY-shaped flush of the always-on

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1913,7 +1913,16 @@
         ;; `last-event` (the most-recently-run event) if the queue is empty
         ;; at the halt seam (defensive — the depth-exceed path always has a
         ;; pending child under the runaway-cascade pattern that trips it).
-        halting-event   (or (:event (peek queue)) last-event)
+        halting-envelope (peek queue)
+        halting-event   (or (:event halting-envelope) last-event)
+        ;; rf2-bh56rc: the halting event's causal `:time-ms` (stamped on its
+        ;; envelope at the causal boundary). Threaded into the synthesised
+        ;; `:halted-depth` record's `:committed-at` so even this never-ran
+        ;; marker carries a replayable causal time per EP-0010 §Time / Spec
+        ;; 002 §The World-Input Rule, not an ambient assembly-time read. nil
+        ;; only on the defensive empty-queue fallback (no envelope to read);
+        ;; the epoch surface tolerates a nil `:committed-at` there.
+        halting-time-ms (-> halting-envelope :rf.world/inputs :time-ms)
         ;; Current durable frame-state value — the state the last-settled
         ;; event left behind. The halting event makes no write, so
         ;; :frame-state-before equals :frame-state-after on its record.
@@ -1939,8 +1948,10 @@
       ;; The halting event never ran, so the capture buffer is empty and
       ;; `settle!` would skip; `commit-halt-record!` commits regardless,
       ;; pinning the halting event's trigger. :frame-state-before equals
-      ;; :frame-state-after — the halting event made no write.
-      (commit-halt! frame-id fs-now fs-now :halted-depth halt-reason
+      ;; :frame-state-after — the halting event made no write. rf2-bh56rc:
+      ;; `:committed-at` is the halting event's causal `:time-ms`, not an
+      ;; ambient read.
+      (commit-halt! frame-id fs-now fs-now halting-time-ms :halted-depth halt-reason
                     halting-event))))
 
 (defn- settle-event-epoch!
@@ -1962,10 +1973,16 @@
 
   EP-0001 (rf2-3aizt1, decision #2): `frame-state-before` / `frame-state-after`
   are whole frame-state values (both partitions); `build-record` derives the
-  `:db-before` / `:db-after` app-db projections from them."
-  [frame-id frame-state-before frame-state-after]
+  `:db-before` / `:db-after` app-db projections from them.
+
+  rf2-bh56rc: `committed-at` is the settling event's causal `:time-ms` (its
+  envelope's `:rf.world/inputs` `:time-ms`, stamped at the causal boundary).
+  Threaded into the epoch record's `:committed-at` so the durable
+  causal-time fact is replayable per EP-0010 §Time / Spec 002 §The
+  World-Input Rule, not an ambient assembly-time host-clock read."
+  [frame-id frame-state-before frame-state-after committed-at]
   (when-let [settle! (late-bind/get-fn-cached :epoch/settle!)]
-    (settle! frame-id frame-state-before frame-state-after)))
+    (settle! frame-id frame-state-before frame-state-after committed-at)))
 
 ;; ---- drain-loop! phases ---------------------------------------------------
 ;;
@@ -2120,18 +2137,28 @@
         ;; the whole frame-state (both partitions — app-db + runtime-db), so
         ;; an epoch carries (and `restore-epoch` rewinds to) machine snapshots
         ;; / the route slice / SSR metadata, not just app-db.
-        (let [fs-before (frame/frame-state-value frame-id)]
+        (let [fs-before (frame/frame-state-value frame-id)
+              ;; rf2-bh56rc: this event's causal `:time-ms` — the
+              ;; `:rf.world/inputs` `:time-ms` stamped on the envelope at the
+              ;; causal boundary (`build-envelope`). Threaded into the epoch
+              ;; record's `:committed-at` (per EP-0010 §Time / Spec 002 §The
+              ;; World-Input Rule) so the durable causal-time fact is
+              ;; replayable rather than an ambient assembly-time clock read.
+              time-ms   (-> envelope :rf.world/inputs :time-ms)]
           ;; Per rf2-9neiq: expose this event's pre-cascade frame-state to a
           ;; handler that calls `destroy-frame!` on its OWN frame mid-drain.
           ;; `destroy-frame!`'s epoch hook reads `frame/*cascade-frame-state-before*`
           ;; for the `:halted-destroy` record's pre-cascade snapshot — the
           ;; value the frame-state held before this in-flight event's cascade
           ;; began, which is otherwise gone by the time the (post-dissoc)
-          ;; epoch hook fires.
-          (binding [frame/*cascade-frame-state-before* fs-before]
+          ;; epoch hook fires. rf2-bh56rc: `*cascade-time-ms*` is bound the
+          ;; same way so the mid-drain `:halted-destroy` record's
+          ;; `:committed-at` is THIS event's causal time, not an ambient read.
+          (binding [frame/*cascade-frame-state-before* fs-before
+                    frame/*cascade-time-ms*            time-ms]
             (process-event! envelope))
           (let [fs-after (frame/frame-state-value frame-id)]
-            (settle-event-epoch! frame-id fs-before fs-after))
+            (settle-event-epoch! frame-id fs-before fs-after time-ms))
           (recur (inc depth) (:event envelope)))
         ::settled))))
 

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -254,7 +254,7 @@
   ;; `re-frame.epoch` facade publishes through the
   ;; `:epoch/on-frame-destroyed` late-bind hook only (per rf2-e0lva the
   ;; facade-side wrapper is private).
-  (epoch.listeners/on-frame-destroyed! :rf/default nil nil))
+  (epoch.listeners/on-frame-destroyed! :rf/default nil nil nil))
 
 ;; ---- Spec 004 §Render-tree primitives — reg-view* wrapper (rf2-piag) -----
 

--- a/implementation/core/test/re_frame/frame_destroy_composed_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_composed_test.clj
@@ -176,11 +176,12 @@
         (late-bind/set-fn! :flows/teardown-on-frame-destroy!
                            (fn [_id]
                              (swap! other-hooks-called conj :flows-ran)))
-        ;; rf2-9neiq: the :epoch/on-frame-destroyed hook now takes
-        ;; (frame-id db-before db-after) — the two snapshots destroy-frame!
-        ;; threads for the :halted-destroy record.
+        ;; rf2-9neiq: the :epoch/on-frame-destroyed hook takes
+        ;; (frame-id db-before db-after committed-at) — the two snapshots
+        ;; destroy-frame! threads for the :halted-destroy record plus the
+        ;; destroying event's causal :time-ms (rf2-bh56rc).
         (late-bind/set-fn! :epoch/on-frame-destroyed
-                           (fn [_id _db-before _db-after]
+                           (fn [_id _db-before _db-after _committed-at]
                              (swap! other-hooks-called conj :epoch-ran)))
 
         ;; Destroy must not re-throw.

--- a/implementation/core/test/re_frame/test_support_test.clj
+++ b/implementation/core/test/re_frame/test_support_test.clj
@@ -422,9 +422,11 @@
   (testing "cleanup hooks that take the destroyed frame's id receive it
             correctly — :ssr / :machines / :epoch all pass the id"
     ;; :ssr / :machines take the destroyed id. :epoch/on-frame-destroyed
-    ;; takes (id db-before db-after) since rf2-9neiq (the two snapshots for
-    ;; the :halted-destroy record). Pin each arg shape so a future refactor
-    ;; that swaps positional → varargs (or drops the id) breaks loudly.
+    ;; takes (id db-before db-after committed-at) since rf2-9neiq (the two
+    ;; snapshots for the :halted-destroy record) + rf2-bh56rc (the
+    ;; destroying event's causal :time-ms). Pin each arg shape so a future
+    ;; refactor that swaps positional → varargs (or drops the id) breaks
+    ;; loudly.
     (let [snapshot   @late-bind/hooks
           captured-args (atom {})]
       (try
@@ -432,14 +434,16 @@
                    :machines/on-frame-destroyed!]]
           (late-bind/set-fn! k (fn [id]
                                  (swap! captured-args assoc k id))))
-        ;; rf2-9neiq: the epoch hook's three-arg shape — record the id
-        ;; AND that the snapshot args arrive (nil here: an out-of-cascade
-        ;; destroy carries no pre-cascade snapshot).
+        ;; rf2-9neiq / rf2-bh56rc: the epoch hook's four-arg shape — record
+        ;; the id AND that the snapshot args + committed-at arrive (all nil
+        ;; here: an out-of-cascade destroy carries no pre-cascade snapshot
+        ;; and no in-flight causal token).
         (late-bind/set-fn! :epoch/on-frame-destroyed
-                           (fn [id db-before db-after]
+                           (fn [id db-before db-after committed-at]
                              (swap! captured-args assoc
                                     :epoch/on-frame-destroyed id
-                                    :epoch/snapshot-args [db-before db-after])))
+                                    :epoch/snapshot-args [db-before db-after]
+                                    :epoch/committed-at committed-at)))
         (rf/reg-frame :rf2-j9phb/arg-target {})
         (frame/destroy-frame! :rf2-j9phb/arg-target)
 
@@ -464,6 +468,15 @@
             "epoch hook receives (fs-before fs-after): nil pre-cascade
              (out-of-cascade destroy) + the destroy-time frame-state
              {:rf.db/app {} :rf.db/runtime {}} (rf2-9neiq / rf2-3aizt1)")
+        ;; rf2-bh56rc: an out-of-cascade destroy has no in-flight causal
+        ;; token, so frame/*cascade-time-ms* is unbound (nil) and the hook's
+        ;; committed-at arrives nil. (No :halted-destroy record is committed
+        ;; on this path, so the value is moot — the assertion pins the arg
+        ;; shape, not a committed timestamp.)
+        (is (contains? @captured-args :epoch/committed-at)
+            "epoch hook receives a fourth committed-at arg (rf2-bh56rc)")
+        (is (nil? (get @captured-args :epoch/committed-at))
+            "committed-at is nil for an out-of-cascade destroy (no token)")
         (finally
           (reset! late-bind/hooks snapshot))))))
 

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -213,9 +213,11 @@
   `re-frame.epoch.listeners/on-frame-destroyed!`, whose docstring is the
   canonical pin. `db-before` / `db-after` are the pre-cascade and
   destroy-time snapshots `destroy-frame!` captured before the frame was
-  removed (both nil for an out-of-cascade destroy)."
-  [frame-id db-before db-after]
-  (listeners/on-frame-destroyed! frame-id db-before db-after))
+  removed (both nil for an out-of-cascade destroy). `committed-at`
+  (rf2-bh56rc) is the destroying event's causal `:time-ms`, used for the
+  `:halted-destroy` record's replayable `:committed-at`."
+  [frame-id db-before db-after committed-at]
+  (listeners/on-frame-destroyed! frame-id db-before db-after committed-at))
 
 ;; ---- per-cascade trace capture --------------------------------------------
 ;;
@@ -246,8 +248,14 @@
   explicit `[event-id …]` vector to pin the record's trigger when the
   buffer carries no `:event/run-start` (the depth-exceed halting event,
   per rf2-nj6p7), or nil to let `build-record` derive the trigger from
-  the buffer (the normal `:ok` path)."
-  [frame-id frame-state-before frame-state-after events outcome halt-reason trigger-event]
+  the buffer (the normal `:ok` path).
+
+  `committed-at` is the record's durable causal time — per EP-0010 §Time
+  and Spec 002 §The World-Input Rule (rf2-bh56rc) the committing causal
+  token's `:rf.world/inputs` `:time-ms`, threaded down from the router's
+  per-event settle / depth-halt seam, NOT an ambient host-clock read at
+  assembly time. This makes `:committed-at` replayable."
+  [frame-id frame-state-before frame-state-after events committed-at outcome halt-reason trigger-event]
   ;; Per rf2-wp70d / Tool-Pair §Time-travel §Redaction hook:
   ;; `maybe-redact` runs ONCE per record between `build-record` and
   ;; ring-append / listener fan-out so the ring and listeners see the
@@ -260,7 +268,7 @@
   ;; `:frame-state-before` / `:frame-state-after` and derives the
   ;; `:db-before` / `:db-after` app-db projections.
   (let [base   (assembly/build-record frame-id frame-state-before frame-state-after
-                                      events outcome halt-reason)
+                                      events committed-at outcome halt-reason)
         ;; Pin the explicit trigger when supplied AND the buffer didn't
         ;; already resolve one (the halting event never ran, so no
         ;; `:event/run-start` was buffered). Per Spec-Schemas
@@ -321,13 +329,22 @@
   emits ride the triggering event's buffer and settle as ONE epoch (per
   Spec 005 §macrostep); they do not allocate a new epoch.
 
+  `committed-at` is the record's durable causal time — per EP-0010 §Time
+  (epoch record causal time) and Spec 002 §The World-Input Rule
+  (rf2-bh56rc) the committing causal token's `:rf.world/inputs` `:time-ms`,
+  read ONCE at the causal boundary (envelope construction) and threaded
+  down here by the router's per-event settle seam (`settle-event-epoch!`),
+  NOT an ambient host-clock read at assembly time. This makes the record's
+  `:committed-at` replayable: the same event log replayed with the same
+  supplied `:time-ms` values yields records with equal `:committed-at`.
+
   Arities:
-    (settle! frame-id frame-state-before frame-state-after)
+    (settle! frame-id frame-state-before frame-state-after committed-at)
       Clean per-event settle. `:outcome` is `:ok`. Equivalent to passing
       `:ok` as `outcome` explicitly. Skips recording when the captured
       buffer is empty (a truly empty cascade — likely a rejected
       dispatch — is degenerate and would emit a misleading record).
-    (settle! frame-id frame-state-before frame-state-after outcome halt-reason)
+    (settle! frame-id frame-state-before frame-state-after committed-at outcome halt-reason)
       Drain-boundary commit with explicit outcome. The runtime commits
       one of three outcomes: `:ok` / `:halted-depth` / `:halted-destroy`
       (`:halted-handler-exception` is a schema-reserved value the
@@ -363,9 +380,9 @@
   Both fns share the private `commit-record!` helper; `commit-halt-record!`
   synthesises the halting event's trigger explicitly while `settle!` lets
   `build-record` derive it from the harvested buffer."
-  ([frame-id frame-state-before frame-state-after]
-   (settle! frame-id frame-state-before frame-state-after :ok nil))
-  ([frame-id frame-state-before frame-state-after outcome halt-reason]
+  ([frame-id frame-state-before frame-state-after committed-at]
+   (settle! frame-id frame-state-before frame-state-after committed-at :ok nil))
+  ([frame-id frame-state-before frame-state-after committed-at outcome halt-reason]
    (when interop/debug-enabled?
      ;; Per rf2-nj6p7: scoped harvest — take only the settling event's
      ;; traces (its `:dispatch-id` + pre-cascade tagalongs), LEAVING any
@@ -384,8 +401,8 @@
        ;; per rf2-nj6p7) use `commit-halt-record!` instead, which
        ;; synthesises the halting event's trigger explicitly.
        (when (seq events)
-         (commit-record! frame-id frame-state-before frame-state-after events outcome
-                         halt-reason nil))))))
+         (commit-record! frame-id frame-state-before frame-state-after events
+                         committed-at outcome halt-reason nil))))))
 
 (defn- commit-halt-record!
   "Commit a `:halted-*` epoch record for a drain halt whose halting event
@@ -409,16 +426,24 @@
   (there should be none under per-event settling) can't leak into the
   next cascade for this frame.
 
+  `committed-at` is the record's durable causal time — per EP-0010 §Time
+  and Spec 002 §The World-Input Rule (rf2-bh56rc) the halting causal
+  token's `:rf.world/inputs` `:time-ms`, threaded down from the router's
+  `handle-depth-exceeded!` seam, NOT an ambient host-clock read. The
+  halting event never ran, but its envelope carries a `:time-ms` stamped
+  at its dispatch (the causal boundary); using it keeps even this
+  synthesised `:halted-depth` marker replayable.
+
   See also `settle!` — the clean-path sibling that handles every per-
   event `:ok` settle. Both fns share the private `commit-record!`
   helper; `settle!` lets `build-record` derive the trigger from the
   harvested buffer (an `:event/run-start` is always present on the
   clean path) and skips on an empty buffer."
-  [frame-id frame-state-before frame-state-after outcome halt-reason trigger-event]
+  [frame-id frame-state-before frame-state-after committed-at outcome halt-reason trigger-event]
   (when interop/debug-enabled?
     (let [events (state/harvest-buffer! frame-id)]
-      (commit-record! frame-id frame-state-before frame-state-after events outcome
-                      halt-reason trigger-event))))
+      (commit-record! frame-id frame-state-before frame-state-after events
+                      committed-at outcome halt-reason trigger-event))))
 
 ;; ---- restore --------------------------------------------------------------
 ;;
@@ -555,8 +580,18 @@
             ;; Per rf2-wp70d: `maybe-redact` runs once between assembly and
             ;; the record!/notify-listeners! split so ring + listeners see
             ;; the SAME redacted shape on this synthetic record too.
+            ;;
+            ;; rf2-bh56rc: this synthetic `:rf.epoch/db-replaced` record is a
+            ;; pair-tool injection — NO application event (and therefore no
+            ;; causal token) is in flight, so there is no `:time-ms` to fold.
+            ;; The honest `:committed-at` is the wall-clock of the tool action
+            ;; itself, so the ambient `interop/now-ms` read happens HERE, at
+            ;; the call site, rather than inside the pure `build-record`
+            ;; builder (per EP-0010 §Time — ambient time remains allowed for a
+            ;; tool action's own wall-clock).
             (let [record (assembly/maybe-redact
-                           (assoc (assembly/build-record frame-id fs-before fs-after [])
+                           (assoc (assembly/build-record frame-id fs-before fs-after []
+                                                          (interop/now-ms))
                                   :event-id      :rf.epoch/db-replaced
                                   :trigger-event [:rf.epoch/db-replaced]))]
               (state/record! record)
@@ -583,10 +618,17 @@
   record!/notify-listeners! split so ring + listeners see the SAME
   redacted shape. Per rf2-qs6dl: stamps the synthetic epoch as the
   frame's last-settled so post-settle re-renders attribute back to it
-  rather than the next real cascade."
+  rather than the next real cascade.
+
+  rf2-bh56rc: a pair-tool injection — no application event / causal token
+  is in flight, so `:committed-at` is the tool action's own wall-clock; the
+  ambient `interop/now-ms` read happens HERE rather than inside the pure
+  `build-record` builder (per EP-0010 §Time — ambient time stays allowed
+  for a tool action's wall-clock)."
   [frame-id fs-before fs-after]
   (let [record (assembly/maybe-redact
-                 (assoc (assembly/build-record frame-id fs-before fs-after [])
+                 (assoc (assembly/build-record frame-id fs-before fs-after []
+                                                (interop/now-ms))
                         :event-id      :rf.epoch/db-replaced
                         :trigger-event [:rf.epoch/db-replaced]))]
     (state/record! record)

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -31,7 +31,6 @@
             [re-frame.epoch.capture :as capture]
             [re-frame.epoch.state :as state]
             [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.privacy :as privacy]
             [re-frame.trace :as trace]))
@@ -357,9 +356,26 @@
 ;; ---- record assembly ------------------------------------------------------
 
 (defn build-record
-  ([frame-id frame-state-before frame-state-after events]
-   (build-record frame-id frame-state-before frame-state-after events :ok nil))
-  ([frame-id frame-state-before frame-state-after events outcome halt-reason]
+  "Assemble a `:rf/epoch-record`. `committed-at` is the record's durable
+  causal time — per EP-0010 §Time (epoch record causal time) and Spec 002
+  §The World-Input Rule it MUST be the committing causal token's
+  `:rf.world/inputs` `:time-ms`, threaded down from the router's settle /
+  halt seam, NOT an ambient host-clock read at assembly time. Threading
+  the token's `:time-ms` makes `:committed-at` replayable: replaying the
+  same event log with the same supplied `:time-ms` values produces records
+  with equal `:committed-at`, and a restored frame-state's recorded
+  timestamps are not silently reinterpreted against a new ambient clock.
+
+  `build-record` is a pure data builder — it performs NO clock read of its
+  own. The two-arg-fewer arity defaults `outcome` to `:ok` and `halt-reason`
+  to nil; both arities require `committed-at` (callers without a token — the
+  pair-tool synthetic db-replace injections, which run with no application
+  event in flight — pass `(interop/now-ms)` explicitly at the call site,
+  where the ambient read is the honest answer for a tool action's
+  wall-clock, per EP-0010 §Time `Ambient time remains allowed for ...`)."
+  ([frame-id frame-state-before frame-state-after events committed-at]
+   (build-record frame-id frame-state-before frame-state-after events committed-at :ok nil))
+  ([frame-id frame-state-before frame-state-after events committed-at outcome halt-reason]
    ;; EP-0001 (rf2-3aizt1, decision #2): the CANONICAL snapshot unit is the
    ;; whole frame-state (`{:rf.db/app … :rf.db/runtime …}`) — both partitions.
    ;; `restore-epoch` rewinds to `:frame-state-after`, reviving machines /
@@ -424,7 +440,16 @@
                                    frame-id db-before db-after)]
      (cond-> {:epoch-id           (state/next-epoch-id)
               :frame              frame-id
-              :committed-at       (interop/now-ms)
+              ;; EP-0010 §Time (epoch record causal time) + Spec 002 §The
+              ;; World-Input Rule (rf2-bh56rc): the durable causal-time fact
+              ;; is the committing token's `:rf.world/inputs` `:time-ms`,
+              ;; threaded in via `committed-at` — NOT an ambient
+              ;; `interop/now-ms` read at assembly time. The one `now-ms`
+              ;; read happens ONCE at the causal boundary (envelope
+              ;; construction, `re-frame.router/build-envelope`); it is not
+              ;; re-read in the commit path. This makes the record replayable:
+              ;; the same token replays to the same `:committed-at`.
+              :committed-at       committed-at
               ;; CANONICAL (decision #2): the whole frame-state both before
               ;; and after — restore rewinds to `:frame-state-after`.
               :frame-state-before frame-state-before

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -308,13 +308,20 @@
   (rf2-3aizt1, decision #2): the canonical snapshot unit is the whole
   frame-state; `build-record` derives the `:db-*` app-db projections.
 
+  `committed-at` (rf2-bh56rc) is the destroying event's causal `:time-ms`
+  (the router-bound `frame/*cascade-time-ms*`, threaded through
+  `destroy-frame!`), used for the `:halted-destroy` record's
+  `:committed-at` so it is replayable per EP-0010 §Time rather than an
+  ambient host-clock read at assembly time. nil outside a drain (no
+  `:halted-destroy` record is committed there, so the value is moot).
+
   Called from `re-frame.frame/destroy-frame!` via the
   `:epoch/on-frame-destroyed` late-bind hook. Idempotent across
   repeated destroys of the same frame — once a cb's entry no longer
   contains the frame-id, no further trace fires for that pair, and
   the (already-cleared) ring-buffer / capture-buffer entries stay
   absent."
-  [frame-id fs-before fs-after]
+  [frame-id fs-before fs-after committed-at]
   (when interop/debug-enabled?
     ;; Step 1: mid-drain destroy detection. The capture-buffer holds
     ;; every emit tagged with this frame, including non-cascade emits
@@ -344,6 +351,7 @@
         ;; redacted shape they would see for an :ok cascade record.
         (let [record (assembly/maybe-redact
                        (assembly/build-record frame-id fs-before fs-after buffered-events
+                                              committed-at
                                               :halted-destroy
                                               {:operation :rf.frame/destroyed-mid-drain}))]
           ;; Per rf2-18g1w / rf2-jppad — the cascade-trailer pair (detailed

--- a/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
@@ -161,5 +161,5 @@
             observed-frames-by-cb bookkeeping side-effect is dead too.
             Frame-destroy paths that route through this hook do not
             crash."
-    (is (nil? (epoch.listeners/on-frame-destroyed! :rf/default nil nil))
+    (is (nil? (epoch.listeners/on-frame-destroyed! :rf/default nil nil nil))
         "on-frame-destroyed! returns nil under prod even for unknown frames")))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -41,7 +41,9 @@
             ;; rf2-bh56rc: `with-redefs`'d in the :committed-at causal-time
             ;; tests to a sentinel clock, proving the durable :committed-at
             ;; comes from the committing token's :time-ms, not an ambient
-            ;; `interop/now-ms` read at assembly time.
+            ;; clock read at assembly time. Both `now-ms` (elapsed clock) and
+            ;; `epoch-now-ms` (wall-clock, the surface the router stamps fresh
+            ;; tokens from — rf2-n1rh0f / EP-0010 §Time) are pinned.
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
@@ -183,10 +185,12 @@
 ;; Per EP-0010 §Time (epoch record causal time) + Spec 002 §The World-Input
 ;; Rule: the durable :committed-at fact MUST come from the committing causal
 ;; token's `:rf.world/inputs` :time-ms (read ONCE at the causal boundary,
-;; envelope construction), NOT an ambient `interop/now-ms` read at epoch
-;; assembly time. These tests pin that conversion: they stub `interop/now-ms`
-;; to a sentinel clock so a regression that re-reads the ambient clock at
-;; assembly would stamp the sentinel and fail loudly.
+;; envelope construction, from `interop/epoch-now-ms` per rf2-n1rh0f), NOT an
+;; ambient clock read at epoch assembly time. These tests pin that conversion:
+;; they stub BOTH host clocks (`interop/now-ms` + `interop/epoch-now-ms`) to a
+;; sentinel so a regression that re-reads the ambient clock at assembly would
+;; stamp the sentinel and fail loudly. The fresh-child test additionally
+;; relies on the `epoch-now-ms` pin to script the freshly-stamped token time.
 
 (deftest committed-at-comes-from-supplied-token-time-ms
   (testing "the durable :committed-at on a clean settle is the committing
@@ -196,10 +200,15 @@
     (rf/reg-event-db :seed (fn [_ _] {:n 0}))
     (let [token-time 1781078400123      ; the supplied causal token time
           clock-time 9999999999999]     ; the (wrong) ambient clock sentinel
-      ;; Stub the host clock to a value NOTHING legitimate should stamp into
+      ;; Stub BOTH host clocks (the elapsed `interop/now-ms` AND the
+      ;; wall-clock `interop/epoch-now-ms` the router stamps fresh tokens
+      ;; from — rf2-n1rh0f) to a value NOTHING legitimate should stamp into
       ;; the record. The router preserves a caller-supplied :time-ms (it only
-      ;; fills :time-ms when absent), so the token time below rides through.
-      (with-redefs [interop/now-ms (constantly clock-time)]
+      ;; fills :time-ms when absent), so the token time below rides through;
+      ;; pinning both clocks makes a regression that re-reads either ambient
+      ;; surface at assembly time stamp the sentinel and fail loudly.
+      (with-redefs [interop/now-ms       (constantly clock-time)
+                    interop/epoch-now-ms (constantly clock-time)]
         (rf/dispatch-sync [:seed] {:frame            :test/main
                                    :rf.world/inputs {:time-ms token-time}}))
       (let [r (last (rf/epoch-history :test/main))]
@@ -219,10 +228,15 @@
     (let [token-time 1781078400123]
       ;; First commit under one wall-clock, second under a DIFFERENT one —
       ;; both supply the SAME causal token :time-ms (the replay scenario).
-      (with-redefs [interop/now-ms (constantly 100)]
+      ;; Pin BOTH clock surfaces (elapsed `now-ms` + wall-clock
+      ;; `epoch-now-ms`, rf2-n1rh0f) so neither ambient read can leak into
+      ;; :committed-at across the drift.
+      (with-redefs [interop/now-ms       (constantly 100)
+                    interop/epoch-now-ms (constantly 100)]
         (rf/dispatch-sync [:seed] {:frame            :test/main
                                    :rf.world/inputs {:time-ms token-time}}))
-      (with-redefs [interop/now-ms (constantly 8888888888888)]
+      (with-redefs [interop/now-ms       (constantly 8888888888888)
+                    interop/epoch-now-ms (constantly 8888888888888)]
         (rf/dispatch-sync [:inc]  {:frame            :test/main
                                    :rf.world/inputs {:time-ms token-time}}))
       (let [history (rf/epoch-history :test/main)]
@@ -248,10 +262,14 @@
     (rf/reg-event-db :child (fn [db _] (update db :order conj :child)))
     (let [parent-time 1781078400123
           ;; The child has no supplied token, so the router stamps its
-          ;; :time-ms from `now-ms` — pinned to this sentinel by the redef.
+          ;; :time-ms fresh at the causal boundary (envelope construction) from
+          ;; `interop/epoch-now-ms` — the wall-clock-epoch surface for durable
+          ;; causal time (rf2-n1rh0f / EP-0010 §Time), NOT `interop/now-ms`
+          ;; (which is the elapsed-measurement clock: `performance.now()` on
+          ;; CLJS). Pinned to this sentinel by the redef below.
           child-clock 5550000000000]
       (rf/dispatch-sync [:seed] {:frame :test/main})
-      (with-redefs [interop/now-ms (constantly child-clock)]
+      (with-redefs [interop/epoch-now-ms (constantly child-clock)]
         (rf/dispatch-sync [:parent] {:frame            :test/main
                                      :rf.world/inputs {:time-ms parent-time}}))
       (let [history    (rf/epoch-history :test/main)

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -38,6 +38,11 @@
             ;; fixture no longer touches the private flows atoms (the
             ;; reset-hook table owns flows reset).
             [re-frame.flows]
+            ;; rf2-bh56rc: `with-redefs`'d in the :committed-at causal-time
+            ;; tests to a sentinel clock, proving the durable :committed-at
+            ;; comes from the committing token's :time-ms, not an ambient
+            ;; `interop/now-ms` read at assembly time.
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             ;; rf2-eig68k — require the schemas FAÇADE, not the `.malli`
@@ -172,6 +177,91 @@
       (is (= (:dispatch-id r)
              (some #(get-in % [:tags :rf.trace/dispatch-id]) (:trace-events r)))
           ":dispatch-id slot equals the cascade's trace :rf.trace/dispatch-id tag"))))
+
+;; ---- rf2-bh56rc: :committed-at is the committing token's causal time -------
+;;
+;; Per EP-0010 §Time (epoch record causal time) + Spec 002 §The World-Input
+;; Rule: the durable :committed-at fact MUST come from the committing causal
+;; token's `:rf.world/inputs` :time-ms (read ONCE at the causal boundary,
+;; envelope construction), NOT an ambient `interop/now-ms` read at epoch
+;; assembly time. These tests pin that conversion: they stub `interop/now-ms`
+;; to a sentinel clock so a regression that re-reads the ambient clock at
+;; assembly would stamp the sentinel and fail loudly.
+
+(deftest committed-at-comes-from-supplied-token-time-ms
+  (testing "the durable :committed-at on a clean settle is the committing
+            token's `:rf.world/inputs` :time-ms — NOT an ambient now-ms
+            read at assembly time (rf2-bh56rc / EP-0010 §Time)"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (let [token-time 1781078400123      ; the supplied causal token time
+          clock-time 9999999999999]     ; the (wrong) ambient clock sentinel
+      ;; Stub the host clock to a value NOTHING legitimate should stamp into
+      ;; the record. The router preserves a caller-supplied :time-ms (it only
+      ;; fills :time-ms when absent), so the token time below rides through.
+      (with-redefs [interop/now-ms (constantly clock-time)]
+        (rf/dispatch-sync [:seed] {:frame            :test/main
+                                   :rf.world/inputs {:time-ms token-time}}))
+      (let [r (last (rf/epoch-history :test/main))]
+        (is (= token-time (:committed-at r))
+            ":committed-at is the supplied token :time-ms — replayable")
+        (is (not= clock-time (:committed-at r))
+            ":committed-at is NOT the ambient host clock — assembly performs
+             no clock read of its own")))))
+
+(deftest committed-at-replay-stable-across-wall-clock-drift
+  (testing "replaying the same event with the same supplied :time-ms yields
+            equal :committed-at even as the wall clock advances — the
+            replay-stability EP-0010 §Time guarantees (rf2-bh56rc)"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+    (let [token-time 1781078400123]
+      ;; First commit under one wall-clock, second under a DIFFERENT one —
+      ;; both supply the SAME causal token :time-ms (the replay scenario).
+      (with-redefs [interop/now-ms (constantly 100)]
+        (rf/dispatch-sync [:seed] {:frame            :test/main
+                                   :rf.world/inputs {:time-ms token-time}}))
+      (with-redefs [interop/now-ms (constantly 8888888888888)]
+        (rf/dispatch-sync [:inc]  {:frame            :test/main
+                                   :rf.world/inputs {:time-ms token-time}}))
+      (let [history (rf/epoch-history :test/main)]
+        (is (= 2 (count history)))
+        (is (= [token-time token-time]
+               (mapv :committed-at history))
+            "both records carry the supplied token time — wall-clock drift
+             between the two commits did not leak into :committed-at")))))
+
+(deftest committed-at-each-child-event-reads-its-own-token
+  (testing "in a multi-event drain, each dequeued event's :committed-at is
+            ITS OWN token's :time-ms — an :fx-dispatched child gets a fresh
+            token (the router does NOT inherit the parent's :time-ms), so the
+            child's :committed-at is the freshly-stamped clock value, while
+            the parent's is its supplied token time (rf2-bh56rc / EP-0010
+            §Dispatch Envelope Stamping — children are distinct causal tokens)"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:order []}))
+    (rf/reg-event-fx :parent
+      (fn [{:keys [db]} _]
+        {:db (update db :order conj :parent)
+         :fx [[:dispatch [:child]]]}))
+    (rf/reg-event-db :child (fn [db _] (update db :order conj :child)))
+    (let [parent-time 1781078400123
+          ;; The child has no supplied token, so the router stamps its
+          ;; :time-ms from `now-ms` — pinned to this sentinel by the redef.
+          child-clock 5550000000000]
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (with-redefs [interop/now-ms (constantly child-clock)]
+        (rf/dispatch-sync [:parent] {:frame            :test/main
+                                     :rf.world/inputs {:time-ms parent-time}}))
+      (let [history    (rf/epoch-history :test/main)
+            by-event   (into {} (map (juxt :event-id :committed-at)) history)]
+        (is (= parent-time (get by-event :parent))
+            "the parent's :committed-at is its supplied token time")
+        (is (= child-clock (get by-event :child))
+            "the :fx-dispatched child reads ITS OWN fresh token (stamped from
+             now-ms here) — NOT inherited from the parent, NOT a separate
+             assembly-time clock read")))))
 
 (deftest record-multi-event-cascade
   (testing "per rf2-nj6p7 (Spec 002 §Drain versus event): each dequeued
@@ -1552,6 +1642,41 @@
             "the :halted-destroy cause projects to :blocked at the consumer
              tier per rf2-18g1w / rf2-jppad")))))
 
+(deftest committed-at-on-halted-destroy-is-destroying-token-time
+  (testing "the :halted-destroy partial record committed when a handler
+            destroys its OWN frame mid-drain carries the DESTROYING event's
+            causal token :time-ms as :committed-at — threaded via the
+            router-bound frame/*cascade-time-ms*, NOT an ambient now-ms read
+            at assembly time (rf2-bh56rc / EP-0010 §Time). The ring is
+            dropped in the same destroy step, so the record is observed via
+            a register-epoch-listener! callback."
+    (rf/reg-frame :test/short-lived {})
+    (rf/reg-event-fx :self-destruct
+      (fn [_ _]
+        (rf/destroy-frame! :test/short-lived)
+        {}))
+    (let [token-time 1781078400123
+          clock-time 7777777777777
+          halted     (atom [])]
+      (rf/register-epoch-listener! ::watch-committed-at
+                                   (fn [r]
+                                     (when (= :halted-destroy (:outcome r))
+                                       (swap! halted conj r))))
+      ;; Stub the ambient clock to a sentinel; supply the destroying event's
+      ;; causal token time. A regression that re-read now-ms at assembly
+      ;; would stamp the sentinel.
+      (with-redefs [interop/now-ms (constantly clock-time)]
+        (rf/dispatch-sync [:self-destruct]
+                          {:frame            :test/short-lived
+                           :rf.world/inputs {:time-ms token-time}}))
+      (is (= 1 (count @halted))
+          "exactly one :halted-destroy record reached the listener")
+      (let [r (first @halted)]
+        (is (= token-time (:committed-at r))
+            ":committed-at is the destroying event's token :time-ms")
+        (is (not= clock-time (:committed-at r))
+            ":committed-at is NOT the ambient host clock")))))
+
 ;; ---- :halted-handler-exception is schema-reserved, never emitted ---------
 ;;
 ;; Per Spec-Schemas §`:rf/epoch-record` §Outcomes (rf2-v0jwt) and Spec 009
@@ -1746,8 +1871,10 @@
     (reset! @#'state/capture-buffers {})
 
     ;; settle! fires at the abort boundary with no buffered cascade
-    ;; context — the empty-buffer skip suppresses the commit.
-    (epoch/settle! :test/main {} {})
+    ;; context — the empty-buffer skip suppresses the commit. (rf2-bh56rc:
+    ;; the clean arity now takes committed-at; nil here — nothing commits,
+    ;; so the value is unused.)
+    (epoch/settle! :test/main {} {} nil)
 
     (is (empty? (rf/epoch-history :test/main))
         "no epoch record committed for an empty-buffer drain boundary —
@@ -3113,9 +3240,10 @@
     ;; Call on-frame-destroyed! DIRECTLY — without going through
     ;; frame/destroy-frame!. The frame record still exists in
     ;; frames-atom; only the epoch ring is dropped. (rf2-9neiq: the
-    ;; hook now takes (frame-id db-before db-after); this seam tests the
-    ;; ring-drop with no in-flight cascade, so nil/nil snapshots apply.)
-    (epoch.listeners/on-frame-destroyed! :test/other nil nil)
+    ;; hook takes (frame-id db-before db-after committed-at) — rf2-bh56rc
+    ;; added the causal :time-ms; this seam tests the ring-drop with no
+    ;; in-flight cascade, so nil snapshots + nil committed-at apply.)
+    (epoch.listeners/on-frame-destroyed! :test/other nil nil nil)
 
     ;; The frame's ring is gone.
     (is (= [] (rf/epoch-history :test/other))
@@ -3134,13 +3262,14 @@
     (rf/dispatch-sync [:seed] {:frame :test/repeat})
     (is (= 1 (count (rf/epoch-history :test/repeat))))
 
-    ;; First call — clears the buffer. (rf2-9neiq: hook arity is now
-    ;; (frame-id db-before db-after); nil/nil for this ring-drop pin.)
-    (epoch.listeners/on-frame-destroyed! :test/repeat nil nil)
+    ;; First call — clears the buffer. (rf2-9neiq / rf2-bh56rc: hook arity
+    ;; is (frame-id db-before db-after committed-at); nil snapshots + nil
+    ;; committed-at for this ring-drop pin.)
+    (epoch.listeners/on-frame-destroyed! :test/repeat nil nil nil)
     (is (= [] (rf/epoch-history :test/repeat)))
 
     ;; Second call — no-op.
-    (epoch.listeners/on-frame-destroyed! :test/repeat nil nil)
+    (epoch.listeners/on-frame-destroyed! :test/repeat nil nil nil)
     (is (= [] (rf/epoch-history :test/repeat))
         "ring stays empty across repeated calls")))
 
@@ -3152,7 +3281,7 @@
     ;; The observable contract is "no throw, no side effects on
     ;; unrelated state".
     (let [traces (record-trace!)]
-      (epoch.listeners/on-frame-destroyed! :test/no-such-frame nil nil)
+      (epoch.listeners/on-frame-destroyed! :test/no-such-frame nil nil nil)
       (is (empty? @traces)
           "no traces emitted — nothing observed to silence"))))
 
@@ -3251,12 +3380,14 @@
       (is (some? (get @buffers-atom :test/main))
           "sanity: the synthetic capture-buffer entry is present pre-destroy")
 
-      ;; rf2-9neiq: on-frame-destroyed! now takes (frame-id db-before
-      ;; db-after) — the two snapshots destroy-frame! threads. This test
-      ;; exercises the buffer-drop (step 4), so nil/nil snapshots are fine
-      ;; (the synthetic run-start carries no :event-id, so no halted record
-      ;; commits — and this test does not assert one).
-      (epoch.listeners/on-frame-destroyed! :test/main nil nil)
+      ;; rf2-9neiq / rf2-bh56rc: on-frame-destroyed! takes (frame-id
+      ;; db-before db-after committed-at) — the two snapshots destroy-frame!
+      ;; threads plus the destroying event's causal :time-ms. This test
+      ;; exercises the buffer-drop (step 4), so nil snapshots + nil
+      ;; committed-at are fine (the synthetic run-start carries no
+      ;; :event-id, so no halted record commits — and this test does not
+      ;; assert one).
+      (epoch.listeners/on-frame-destroyed! :test/main nil nil nil)
 
       (is (nil? (get @buffers-atom :test/main))
           "the capture-buffer entry was dropped on destroy — no
@@ -3445,6 +3576,7 @@
                                         :rf.trace/phase :run-start}}]
           record          (#'assembly/build-record
                             :test/main nil nil tag-less-events
+                            1700000000000  ; rf2-bh56rc: committed-at (token :time-ms)
                             :halted-destroy
                             {:operation :rf.frame/destroyed-mid-drain})]
       (is (not (contains? record :event-id))
@@ -3473,11 +3605,16 @@
                                :rf.trace/phase    :run-start
                                :rf.trace/event-id :seed
                                :rf.event/v        [:seed 1 2 3]}}]
-          record (#'assembly/build-record :test/main {} {:n 0} events)]
+          record (#'assembly/build-record :test/main {} {:n 0} events 1700000000000)]
       (is (= :seed (:event-id record))
           ":event-id is the resolved event keyword")
       (is (= [:seed 1 2 3] (:trigger-event record))
-          ":trigger-event is the full event vector — payload preserved"))))
+          ":trigger-event is the full event vector — payload preserved")
+      ;; rf2-bh56rc: :committed-at is the supplied causal time verbatim —
+      ;; build-record performs NO clock read of its own.
+      (is (= 1700000000000 (:committed-at record))
+          ":committed-at is the supplied committed-at (token :time-ms),
+           not an ambient now-ms read"))))
 
 ;; ---- rf2-7kxxx: find-trigger-event must not synthesise [eid] when
 ;; ---- :event tag is absent on the fallback arm ----------------------------
@@ -3517,6 +3654,7 @@
                                         :rf.trace/event-id :foo}}]
           record          (#'assembly/build-record
                             :test/main nil nil tag-less-events
+                            1700000000000  ; rf2-bh56rc: committed-at (token :time-ms)
                             :halted-destroy
                             {:operation :rf.frame/destroyed-mid-drain})]
       (is (= :foo (:event-id record))
@@ -3578,6 +3716,7 @@
                                :rf.trace/dispatch-id 99}}]
           record (#'assembly/build-record
                   :test/main nil nil events
+                  1700000000000  ; rf2-bh56rc: committed-at (token :time-ms)
                   :halted-destroy
                   {:operation :rf.frame/destroyed-mid-drain})]
       (is (not (contains? record :dispatch-id))


### PR DESCRIPTION
## What

Per EP-0010 §Time (epoch record causal time) + Spec 002 §The World-Input Rule, the durable `:committed-at` fact on an `:rf/epoch-record` MUST come from the **committing causal token's** `:rf.world/inputs` `:time-ms` (read once at the causal boundary — envelope construction), not an ambient `interop/now-ms` read at epoch-assembly time. `epoch/assembly.cljc` previously stamped `:committed-at (interop/now-ms)` inside `build-record`, re-reading the host clock in the commit path — a World-Input-Rule violation that made `:committed-at` non-replayable.

## How `:time-ms` is threaded

`build-record` is now a **pure data builder**: it takes `committed-at` as a parameter and performs no clock read of its own (the now-unused `interop` require is dropped, aligning the require list with the Phase-2 seam-D docstring). The committing token's `:time-ms` flows down all three commit paths:

- **Clean settle**: router `run-one-pass!` reads the dequeued envelope's `(:time-ms (:rf.world/inputs envelope))` → `settle-event-epoch!` → `settle!` → `commit-record!` → `build-record`.
- **Depth halt**: `handle-depth-exceeded!` reads the halting envelope's `:time-ms` → `commit-halt-record!` (the halting event never ran, but its envelope carries a boundary-stamped `:time-ms`, so even the synthesised `:halted-depth` marker is replayable).
- **Mid-drain destroy** (`:halted-destroy`): the in-flight event's `:time-ms` is bound on a new `frame/*cascade-time-ms*` dynamic var (parallel to the existing `*cascade-frame-state-before*`), threaded through `destroy-frame!` → `notify-epoch-listeners!` → the `:epoch/on-frame-destroyed` hook → `listeners/on-frame-destroyed!`.

The two **pair-tool synthetic db-replace injections** (`perform-replace-app-db!`, `record-synthetic-replace-epoch!`) run with **no application event / causal token** in flight, so they pass `(interop/now-ms)` explicitly at the call site — the honest wall-clock for a tool action, kept out of the pure builder (EP-0010 §Time explicitly allows ambient time for "a tool action's wall-clock"). An out-of-cascade `destroy-frame!` (hot-reload / `reset-frame!` / REPL) has no token, so `*cascade-time-ms*` is nil and no `:halted-destroy` record is committed there — the nil is moot.

## Scope note (core touched, per brief)

The fence is `implementation/epoch/`, but the brief anticipated that the commit path may need to pass `:time-ms` down. The router (`run-one-pass!`, `settle-event-epoch!`, `handle-depth-exceeded!`) and `frame/destroy-frame!` are the *callers* of the epoch late-bind hooks — the only place the committing envelope's token is in scope — so the threading is necessarily there. No resources/machines/routing or spec hot-zone files touched. **Spec unchanged**: Spec 002 §828 + EP-0010 §Time already pin "epoch record causal time" reads from `:time-ms`; this change brings the implementation into conformance with the existing normative text (no spec edit needed).

## Tests

New `:committed-at` causal-time suite in `epoch_test.clj`:
- `committed-at-comes-from-supplied-token-time-ms` — stubs `interop/now-ms` to a sentinel, dispatches with a supplied token `:time-ms`, asserts `:committed-at` is the token time and **not** the ambient clock.
- `committed-at-replay-stable-across-wall-clock-drift` — two commits under different stubbed clocks but the same supplied token time → equal `:committed-at`.
- `committed-at-each-child-event-reads-its-own-token` — an `:fx`-dispatched child gets a fresh token (router does not inherit the parent's `:time-ms`), so its `:committed-at` is the freshly-stamped clock, the parent's is its supplied token time.
- `committed-at-on-halted-destroy-is-destroying-token-time` — a real mid-drain self-destroy, observed via a listener (the ring is dropped); `:committed-at` is the destroying token's time, not the stubbed ambient clock.

A focused assertion was also added to `build-record-emits-event-id-and-trigger-event-when-trigger-resolves` pinning that `build-record` returns the supplied `committed-at` verbatim. Existing hook-arity pins (`test_support_test.clj`, `frame_destroy_composed_test.clj`) and direct `build-record` / `settle!` / `on-frame-destroyed!` call sites updated to the new signatures.

## Quality gates

- `npm run test:cljs` — **6424 tests, 23217 assertions, 0 failures, 0 errors** (exercises the `.cljs` test edits + full CLJS spine)
- epoch artefact `clojure -M:test` (`implementation/epoch`) — **315 tests, 1248 assertions, 0 failures, 0 errors**
- core artefact `clojure -M:test` (`implementation/core`) — **1092 tests, 4768 assertions, 0 failures, 0 errors** (router + frame changes; updated hook-arity pins)


### Rebase note (2026-06-11)

Rebased onto current `origin/main` to clear a conflict in `implementation/core/src/re_frame/frame.cljc` against the since-merged EP-0008 changes (B teardown-report `rf2-ini4wr` + on-destroy-handler-promotion `rf2-7b9r4l`), and to re-trigger CI (the prior push registered 0 checks). **Both intents merged** — this branch's epoch causal-time threading (the `*cascade-time-ms*` dynamic var, its router binding, and the `:time-ms` flow through `destroy-frame!` → `notify-epoch-listeners!`) and main's EP-0008 teardown changes (the `:rf.error/frame-teardown-failed` finally-flush + `*teardown-hook-failures*` accumulator in `destroy-frame!`, and the always-on `:rf.error/on-destroy-handler-exception` promotion via `emit-on-destroy-handler-exception!`) all survive. The single overlapping region was the `destroy-frame!` `let`/`binding` block, resolved by combining all four bindings (`cascade-fs-before`, `cascade-time-ms`, `fs-at-destroy`, `hook-failures`) and binding both `*destroying-frame-id*` + `*teardown-hook-failures*`. Re-ran all gates green post-rebase:

- `npm run test:cljs` — **6464 tests, 23512 assertions, 0 failures, 0 errors**
- epoch artefact `clojure -M:test` (`implementation/epoch`) — **315 tests, 1248 assertions, 0 failures, 0 errors** (`:committed-at` causal-time suite)
- core artefact `clojure -M:test` (`implementation/core`) — **1107 tests, 4826 assertions, 0 failures, 0 errors** (epoch threading + EP-0008 teardown-report/on-destroy tests pass together)


### CI-failure fix (2026-06-11) — clean-build root cause

The post-rebase "JVM epoch (clojure -M:test)" check failed twice on fresh CI (~28 s each). The prior local "green" was against a **stale `.cpcache`** that masked the real failure; a clean local rebuild (`rm -rf implementation/epoch/.cpcache target` then `clojure -M:test`) reproduced it exactly — **not** a compile/load error, a single failing assertion:

```
FAIL in (committed-at-each-child-event-reads-its-own-token) (epoch_test.clj:261)
expected: (= child-clock (get by-event :child))
  actual: (not (= 5550000000000 1781176835195))
```

**Root cause.** The merged resource-cluster PR (rf2-n1rh0f) moved the router's **fresh-token `:time-ms` stamping** from `interop/now-ms` to `interop/epoch-now-ms` (`router.cljc:205` — `(assoc supplied-world :time-ms (interop/epoch-now-ms))`), because durable causal time must be wall-clock-meaningful on both hosts (`now-ms` is `performance.now()` on CLJS). The `:committed-at` causal-time tests were authored against the **old** `now-ms` stamping and only `with-redefs`'d `interop/now-ms`. On a clean classpath the `committed-at-each-child-event-reads-its-own-token` test's `:fx`-dispatched child therefore got its fresh token stamped from the **un-redefd** `epoch-now-ms` = the real ambient wall clock (`1781176835195`) instead of the pinned sentinel `child-clock` (`5550000000000`). `now-ms` and `epoch-now-ms` are independent `defn`s, so redefing one does not affect the other.

**Fix (test-only, surgical).** Pin **both** clock surfaces (`interop/now-ms` + `interop/epoch-now-ms`) in all three causal-time tests. The fresh-child test now scripts the freshly-stamped token time via `epoch-now-ms`; the two supplied-`:time-ms` guards stay sharp against an assembly-time read of **either** ambient surface. No production code changed — EP-0008 teardown behaviour and the epoch causal-time threading both survive untouched.

**Clean-build gate proof** (each preceded by `rm -rf .cpcache target`):
- epoch `clojure -M:test` (`implementation/epoch`) — **315 tests, 1248 assertions, 0 failures, 0 errors**
- core `clojure -M:test` (`implementation/core`) — **1107 tests, 4826 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **6470 tests, 23526 assertions, 0 failures, 0 errors**