### PR TITLE
feat(xray): read the uniform reply envelope — one work/reply vocabulary (rf2-zqefg3.7)

### DIFF
--- a/tools/xray/spec/013-Trace-Consumer.md
+++ b/tools/xray/spec/013-Trace-Consumer.md
@@ -336,6 +336,84 @@ Panels read the buffer through layer-1 subscriptions:
   the L2 event list, the spine, the Event / Issues / Trace / Views
   tabs.
 
+## One work/reply vocabulary — reading the uniform reply envelope
+
+Every managed *async* family (HTTP, resources, mutations, route
+loaders, machine async work, future managed timers) completes through
+the ONE shape defined in [`spec/Managed-Effects.md` §The uniform reply
+envelope](../../../spec/Managed-Effects.md) (EP-0011): a single **reply
+map** carrying one closed `:status`, value/error data, `:work/id` work
+correlation, `:work/kind`, `:work/status`, `:attempt`, `:rf.frame/id`,
+the durable timestamps, and the cancellation/staleness facts. Property 9
+/ §Tracing require each family to emit its trace rows **from those
+reply-envelope facts, not from private callback facts**.
+
+Xray reads that uniform shape — it does **not** learn each family's
+private callback vocabulary. The consumer-side mirror lives in
+[`panels/reply_envelope.cljc`](../src/day8/re_frame2_xray/panels/reply_envelope.cljc)
+(`day8.re-frame2-xray.panels.reply-envelope`, pure data, JVM-runnable),
+and gives one vocabulary across HTTP / resources / mutations / routing /
+machines / timers:
+
+- **The closed vocabularies** — `reply-statuses`
+  (`:ok` / `:partial` / `:error` / `:cancelled` / `:stale`),
+  `work-statuses`, and `work-kinds` — are **mirrored** from
+  `re-frame.reply` as literal data (Xray never `:require`s the
+  substrate; the no-tool-imports-core bundle direction holds, and Xray
+  consumes the *wire facts*). The closed-vocabulary wiring test pins the
+  mirror so a substrate change that drifts the set fails loud.
+- **`reply-row`** projects a uniform reply map (the appended last-arg of
+  a `:rf/reply-to` event, or a `:rf.http/replied` / `:rf.reply/*` trace
+  summary) into ONE render-safe row keyed on `:work/id`, reading
+  issuance/completion **status**, **stale-suppression** (carried+current
+  correlation), **cancellation**, and **delivery-or-non-delivery**
+  (`:delivered?` is `false` for a suppressed `:stale` reply unless a
+  framework test/tool target opted into `:dispatch-stale?`). The
+  wire-bearing slots (`:value` / `:error` / `:correlation` / `:meta`)
+  are summarized — the runtime already elided sensitive/large slots on
+  the wire (Managed-Effects §Tracing).
+- **`phase-of`** lowers every family's emitted trace op onto ONE
+  reply-envelope **phase** — `:issued` / `:retry` / `:cancel-requested`
+  / `:completed` / `:stale-suppressed` / `:delivered` — so a panel
+  groups by phase, not by family. An explicit op table covers the landed
+  literals (`:rf.resource/work-started`, `:rf.http/replied`,
+  `:rf.http/retry-attempt`, `:rf.resource/stale-suppressed`,
+  `:rf.reply/suppressed`, …); a name-suffix heuristic classifies a
+  not-yet-enumerated family op (e.g. a future `:rf.stream/*` surface)
+  before the table learns its literal.
+- **`status->class`** gives the one cross-surface colour class so a
+  `:stale` HTTP reply and a `:stale` resource reply render the **same
+  badge** (Cross-Cutting [F.11](019-Cross-Cutting-Insight.md) — the
+  unified `STALE` rendering).
+
+### "What is still running?" and the stale-races view
+
+Both questions are answered from the **work ledger joined to reply
+status + trace cause, uniformly across families** — never per-family:
+
+- **`live-work`** reads the live (non-terminal) work-ledger rows
+  (`:rf.runtime/work-ledger`, the durable substrate — Managed-Effects
+  §Work-ledger integration) and joins each to the **latest
+  reply-envelope trace phase** for its `:work/id`, so the operator sees
+  "the app is waiting on resource K (issued), HTTP req-5
+  (cancel-requested), …" with one query. `live-work-tally-by-kind`
+  counts live work per family — the active managed-effects dashboard
+  headline (Cross-Cutting F-C4).
+- **The stale-races view keys on `:work/id`** (Managed-Effects
+  §Work-id correlation — `:work/id` is the *single* attempt identity,
+  the key the ledger, stale suppression, and this view all share).
+  `races-by-work-id` groups every cross-family work/reply row by work id
+  into an attempt arc (`:phases`, `:terminal-status`, `:suppressed?`);
+  `stale-suppressions` + `stale-tally-by-kind` surface the
+  cross-surface suppression tally (Cross-Cutting F-C5).
+
+The resources composite (`:rf.xray/resources-tab-data`) carries the
+uniform reads (`:live-work` / `:stale-races` / `:stale-tally`) alongside
+the resource-specific surfaces. The resource family is the only ledger
+writer today; as HTTP / route / machine / timer families write their own
+ledger rows and emit their reply-envelope trace ops, these surfaces pick
+them up with **no panel change** — one vocabulary, many families.
+
 ### What consumers MAY rely on
 
 - A **point-in-time snapshot** of the merged per-frame + frameless

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -294,7 +294,7 @@ No event registered here dispatches a `:rf.resource/*` event (read-only).
 | `:rf.xray/resource-work-ledger` | `:rf.xray/target-frame-runtime-db`, override | the live work-ledger map at `[:rf.runtime/work-ledger]`. |
 | `:rf.xray/resource-sub-reads` | override | observed live subscription reads backing the scope-mismatch lint (empty by default). |
 | `:rf.xray/resource-routing-slice` | `:rf.xray/target-frame-runtime-db`, override | the live routing-runtime subtree at `[:rf.runtime/routing]` (current route + nav-token + per-nav-token unsettled-blocking set) backing the live route/resource graph. |
-| `:rf.xray/resources-tab-data` | the five above + `:rf.xray/trace-buffer` + the route registry | the view-facing composite: `{:silent? :registry :instances :work :route-graph :timeline :invalidations :cache-growth :audit}`. Its `:route-graph` joins the static route plan against the live instance/work rows + routing slice. |
+| `:rf.xray/resources-tab-data` | the five above + `:rf.xray/trace-buffer` + the route registry | the view-facing composite: `{:silent? :registry :instances :work :live-work :stale-races :stale-tally :route-graph :timeline :invalidations :cache-growth :audit}`. Its `:route-graph` joins the static route plan against the live instance/work rows + routing slice. The `:live-work` / `:stale-races` / `:stale-tally` slots are the UNIFORM reply-envelope reads (see below). |
 
 ### Events (test-only override hooks)
 
@@ -304,6 +304,24 @@ No event registered here dispatches a `:rf.resource/*` event (read-only).
 `:rf.xray/set-resource-sub-reads-override-for-test`,
 `:rf.xray/set-resource-routing-slice-override-for-test` — production code
 paths MUST NOT dispatch these; `nil` clears the override.
+
+### Uniform reply-envelope reads (`:live-work` / `:stale-races`)
+
+The composite's `:live-work`, `:stale-races`, and `:stale-tally` slots are
+**not** resource-specific — they read the canonical EP-0011 work/reply
+facts (`:work/id` / `:work/kind` / reply `:status` / stale-suppression
+carried+current) the SAME way for **every** managed-async family, via
+[`panels/reply_envelope.cljc`](../src/day8/re_frame2_xray/panels/reply_envelope.cljc).
+"What is still running?" is the live (non-terminal) work-ledger rows
+joined to the latest reply-envelope trace phase per `:work/id`; the
+stale-races view groups every cross-family work/reply row by `:work/id`.
+The resource family is the only ledger writer today, so the rows are all
+`:work/kind :resource` (and `:mutation`) for now; as HTTP / route /
+machine / timer families write their own ledger rows and emit their
+reply-envelope trace ops, these surfaces pick them up with no panel
+change. The contract is owned by
+[`013-Trace-Consumer.md` §One work/reply vocabulary](013-Trace-Consumer.md#one-workreply-vocabulary--reading-the-uniform-reply-envelope);
+this panel is one consumer.
 
 ## Mountable surface
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
@@ -1,0 +1,720 @@
+(ns day8.re-frame2-xray.panels.reply-envelope
+  "ONE work/reply vocabulary for Xray + the trace tooling, reading the
+  canonical *uniform reply envelope* (EP-0011) rather than per-family
+  private callback shapes (rf2-zqefg3.7).
+
+  ## Why this namespace exists
+
+  Before EP-0011 each managed-async family spelled its completion
+  continuation differently, and each Xray panel learned that family's
+  private vocabulary: the resources panel reads `:rf.resource/work-*`
+  ops, the cancellation-cascade visualiser reads
+  `:rf.http/aborted-on-actor-destroy` + `:rf.machine.timer/cancelled`,
+  the managed-fx panel reads `:rf.http/handled` /
+  `:rf.machine.lifecycle/spawned`. That is N vocabularies for one
+  concept — \"this async work was issued, ran, retried, was cancelled,
+  completed with a status, was suppressed as stale, and either
+  delivered or did not.\"
+
+  [`spec/Managed-Effects.md` §The uniform reply
+  envelope](../../../../spec/Managed-Effects.md) gives the runtime ONE
+  shape for that: every managed-async family (HTTP / resources /
+  mutations / route loaders / machine async work / future managed
+  timers) completes through a single **reply map** carrying one closed
+  `:status`, value/error data, `:work/id` work correlation,
+  `:work/kind`, `:work/status`, `:attempt`, `:rf.frame/id`, the durable
+  timestamps, the cancellation/staleness facts, and a `:correlation`
+  side-bag (`re-frame.reply` is the framework substrate). Property 9 /
+  §Tracing mandate that families emit their trace rows FROM those
+  reply-envelope facts.
+
+  This namespace is the **consumer-side mirror** of that contract: a
+  pure-data reader that projects the canonical envelope facts off either
+  a reply map (the appended last-arg of a reply-target event) or a trace
+  row's `:tags`, into ONE render-safe row vocabulary keyed on
+  `:work/id` — so a panel answers \"issued / running / retried /
+  cancellation-requested / completed-:ok|:partial|:error|:cancelled|
+  :stale / stale-suppressed / delivered\" the SAME way across every
+  family.
+
+  ## Bundle isolation
+
+  Xray does NOT `:require` `re-frame.reply` (or any `implementation/`
+  namespace) — the closed vocabularies below are MIRRORED as literal
+  data, exactly as `resources-helpers` mirrors the reserved runtime-db
+  keys. The mirror is the bundle-isolation-safe price of not adding a
+  require edge from a tool into core; a drift would be caught by the
+  closed-vocabulary wiring test. (`re-frame.reply` is core, not an
+  optional artefact, but the no-tool-imports-core direction is the
+  bundle contract regardless — nothing in `implementation/` may require
+  `tools/`, and Xray consumes the WIRE FACTS, not the substrate fns.)
+
+  ## PRIVACY
+
+  Same posture as `resources-helpers`: the wire-bearing slots
+  (`:value`, `:error`, `:correlation`, `:meta`) are summarized through
+  `resources-helpers/summarize` — the runtime already routed them
+  through the shared `re-frame.elision/elide-wire-value` walker on the
+  trace egress (Managed-Effects §Tracing), so a `:sensitive?` slot
+  arrives as `:rf/redacted` and a `:large?` slot as
+  `:rf.size/large-elided`; we never render a raw payload. The IDENTITY
+  facts (work id, kind, status, attempt, frame, timestamps, cancel/stale
+  reasons) are framework bookkeeping and ride verbatim.
+
+  ## Pure
+
+  Every fn here is pure data → data, JVM-runnable so the algebra runs
+  under the unit-test target without a CLJS runtime."
+  (:require [day8.re-frame2-xray.panels.resources-helpers :as rh]))
+
+;; ---------------------------------------------------------------------------
+;; The closed vocabularies (MIRRORED from re-frame.reply — Managed-Effects
+;; §Status taxonomy / §The reply map). Closed by design: a managed-async
+;; completion is exactly one of these statuses. Mirrored as literal data so
+;; Xray never requires the substrate (bundle isolation); the wiring test pins
+;; the mirror against the substrate's `re-frame.reply/statuses` set.
+;; ---------------------------------------------------------------------------
+
+(def reply-statuses
+  "The CLOSED reply `:status` vocabulary (Managed-Effects §Status taxonomy
+  — mirror of `re-frame.reply/statuses`). Exactly one is a reply's status:
+
+    - `:ok`        — completed successfully, reply current; `:value` present.
+    - `:partial`   — completed with usable `:value` AND structured family
+                     problems under `:error` (GraphQL is the motivating case).
+    - `:error`     — completed with a failure, reply current; `:error` present.
+    - `:cancelled` — intentionally cancelled while still correlated;
+                     `:cancel/reason` present.
+    - `:stale`     — completed/observed after correlation became obsolete;
+                     `:stale? true` + `:stale/reason`; NO app-state mutation."
+  #{:ok :partial :error :cancelled :stale})
+
+(def work-statuses
+  "The operational `:work/status` vocabulary on a reply map / ledger row
+  (mirror of `re-frame.reply/work-statuses`). Narrower / more operational
+  than reply `:status`: `:timed-out` is an error work-status (timeout is an
+  error KIND + a work status, NOT a top-level reply status); `:suppressed`
+  is the stale terminal."
+  #{:completed :failed :timed-out :suppressed :cancelled})
+
+(def work-kinds
+  "The `:work/kind` vocabulary across the managed-async families
+  (Managed-Effects §Work-id correlation — the work-id tuple heads). The
+  family a work id / reply belongs to. `:resource` covers mutations too —
+  a mutation reuses the resource work-id head and is distinguished by the
+  ledger row's `:work/kind :mutation`, so both `:resource` and `:mutation`
+  appear as kinds on rows."
+  #{:http :resource :mutation :route :machine :timer})
+
+(defn reply-status?
+  "True iff `status` is a member of the closed reply-status vocabulary."
+  [status]
+  (contains? reply-statuses status))
+
+(def terminal-reply-statuses
+  "The reply statuses that are TERMINAL for the attempt (the work settled,
+  one way or another). All five reply statuses are terminal — a reply map
+  is only produced at completion. `:running` is a ledger/issuance status,
+  NOT a reply status (issuance has no reply map yet)."
+  reply-statuses)
+
+;; ---------------------------------------------------------------------------
+;; Reply-map field readers (Managed-Effects §The reply map). A reply map is
+;; the appended last-arg of a reply-target event, or the data-only trace
+;; summary a family emits on completion. Readers tolerate either the
+;; canonical `:work/id` / `:rf.frame/id` namespaced spelling or the bare
+;; `:work-id` / `:frame-id` trace-tag spelling some emit sites use, so one
+;; reader works on both the dispatched reply map and the trace row's `:tags`.
+;; ---------------------------------------------------------------------------
+
+(defn reply-map?
+  "Best-effort detector: is `m` a uniform reply map (Managed-Effects §The
+  reply map)? True iff `m` is a map carrying a closed reply `:status`. Used
+  to recognise the appended last-arg of a reply-target event vector."
+  [m]
+  (and (map? m) (reply-status? (:status m))))
+
+(defn work-id-of
+  "Read the `:work/id` work-correlation off a reply map or trace tags.
+  Tolerates the canonical `:work/id` or the bare `:work-id` trace-tag
+  spelling. The single attempt identity (Managed-Effects §Work-id
+  correlation — `=`-comparable, EDN-serializable); the key the stale-races
+  view groups on. nil when absent (a non-ledger-backed managed async)."
+  [m]
+  (or (:work/id m) (:work-id m)))
+
+(defn work-kind-of
+  "Read the `:work/kind` family tag off a reply map or trace tags (one of
+  `work-kinds`), tolerating `:work/kind` or bare `:work-kind`/`:kind`. nil
+  when absent. When absent on a reply, `infer-work-kind` derives it from the
+  work-id tuple head."
+  [m]
+  (or (:work/kind m) (:work-kind m) (:kind m)))
+
+(defn infer-work-kind
+  "Infer the `:work/kind` from a `:work/id` tuple head when the reply / row
+  did not carry an explicit `:work/kind`. The tuple heads are owned by each
+  family (Managed-Effects §Work-id correlation):
+
+    `[:rf.work/http  …]`     → `:http`
+    `[:rf.work/resource …]`  → `:resource` (mutation reuses this head; the
+                               row's explicit `:work/kind :mutation` wins)
+    `[:rf.work/route …]`     → `:route`
+    `[:rf.work/machine …]`   → `:machine`
+    `[:rf.work/timer …]`     → `:timer`
+
+  Returns nil for an unrecognised / non-tuple work id (let the caller fall
+  back to an explicit `:work/kind`)."
+  [work-id]
+  (when (and (vector? work-id) (keyword? (first work-id)))
+    (case (first work-id)
+      :rf.work/http     :http
+      :rf.work/resource :resource
+      :rf.work/route    :route
+      :rf.work/machine  :machine
+      :rf.work/timer    :timer
+      nil)))
+
+(defn resolve-work-kind
+  "The work-kind for a reply map / row: the explicit `:work/kind` when
+  present, else inferred from the `:work/id` tuple head. Pure."
+  [m]
+  (or (work-kind-of m)
+      (infer-work-kind (work-id-of m))))
+
+;; ---------------------------------------------------------------------------
+;; The uniform reply row (rf2-zqefg3.7 — the ONE vocabulary). Projects a
+;; reply map (Managed-Effects §The reply map) into a render-safe row that
+;; reads the SAME across every family. PRIVACY: the wire-bearing slots
+;; (`:value` / `:error` / `:correlation` / `:meta`) are summarized; the
+;; identity facts ride verbatim.
+;; ---------------------------------------------------------------------------
+
+(defn reply-row
+  "Project ONE uniform reply map into a render-safe row reading the
+  canonical EP-0011 envelope facts (Managed-Effects §The reply map /
+  §Status taxonomy). The SINGLE vocabulary a panel renders regardless of
+  the family the reply came from:
+
+      {:work-id      [:rf.work/http :article/by-id 1]   ; the attempt identity
+       :work-kind    :http                              ; explicit or inferred
+       :status       :ok                                ; closed reply status
+       :work-status  :completed                         ; operational work status
+       :attempt      1
+       :frame        <frame-id>
+       :started-at   …  :completed-at … :deadline-at …  ; durable causal ms
+       :value        <summary>   ; PRIVACY — summarized (nil for :error/:stale)
+       :error        <summary>   ; PRIVACY — summarized (failure envelope)
+       :error-kind   :rf.http/timeout                   ; the family error :kind
+       :correlation  <summary>   ; PRIVACY — request-id / nav-token side-bag
+       :stale?       false
+       :stale-reason nil
+       :cancelled?   false
+       :cancel-reason nil
+       :delivered?   true        ; false ⇔ a stale/suppressed reply not dispatched
+       :meta         <summary>}  ; PRIVACY — family-specific data
+
+  `:delivered?` is the EP-0011 delivery-vs-non-delivery fact (Managed-
+  Effects §Tracing): a `:stale` reply is NOT delivered to the app target
+  (`:delivered? false`) unless a framework test/tool target opted into
+  `:dispatch-stale?` (which the runtime would record on the trace row as
+  `:rf.reply/delivered? true`); every non-stale terminal reply is delivered.
+
+  PRIVACY: `:value` / `:error` / `:correlation` / `:meta` are summarized
+  via `resources-helpers/summarize` (the runtime already elided sensitive /
+  large slots on the wire). Pure."
+  [reply]
+  (let [work-id      (work-id-of reply)
+        status       (:status reply)
+        error        (:error reply)
+        ;; the runtime emits the delivered? fact on the trace row when it
+        ;; differs from the derivable default; absent ⇒ derive it (a stale
+        ;; reply is non-delivered, everything else delivered).
+        delivered?   (cond
+                       (contains? reply :rf.reply/delivered?) (boolean (:rf.reply/delivered? reply))
+                       (= status :stale)                      false
+                       :else                                  true)]
+    {:work-id       work-id
+     :work-kind     (resolve-work-kind reply)
+     :status        status
+     :work-status   (or (:work/status reply) (:work-status reply))
+     :attempt       (:attempt reply)
+     :frame         (or (:rf.frame/id reply) (:frame-id reply) (:frame reply))
+     :started-at    (:started-at reply)
+     :completed-at  (:completed-at reply)
+     :deadline-at   (:deadline-at reply)
+     :value         (when (contains? reply :value) (rh/summarize (:value reply)))
+     :error         (when (some? error) (rh/summarize error))
+     :error-kind    (when (map? error) (:kind error))
+     :correlation   (when (contains? reply :correlation) (rh/summarize (:correlation reply)))
+     :stale?        (boolean (:stale? reply))
+     :stale-reason  (:stale/reason reply)
+     :cancelled?    (boolean (:cancelled? reply))
+     :cancel-reason (:cancel/reason reply)
+     :delivered?    delivered?
+     :meta          (when (contains? reply :meta) (rh/summarize (:meta reply)))}))
+
+;; ---------------------------------------------------------------------------
+;; Status presentation — ONE colour-class + label mapping for the five reply
+;; statuses, shared across every family panel + the Trace tab so a `:stale`
+;; HTTP reply and a `:stale` resource reply render the SAME badge
+;; (Cross-Cutting F.11 — the unified cross-surface STALE badge).
+;; ---------------------------------------------------------------------------
+
+(def status->class
+  "The semantic colour class for a reply `:status`, shared across families.
+  Keys the panel + Trace-tab colour mapping uniformly so the cross-surface
+  badge (Cross-Cutting F.11) renders identically regardless of family:
+
+    `:ok`        → `:success`
+    `:partial`   → `:partial`     (usable data + structured problems)
+    `:error`     → `:failure`
+    `:cancelled` → `:cancellation`
+    `:stale`     → `:suppression` (the correctness-boundary event)"
+  {:ok        :success
+   :partial   :partial
+   :error     :failure
+   :cancelled :cancellation
+   :stale     :suppression})
+
+(def status->label
+  "Short human label for a reply `:status` — uppercase badge text."
+  {:ok        "OK"
+   :partial   "PARTIAL"
+   :error     "ERROR"
+   :cancelled "CANCELLED"
+   :stale     "STALE"})
+
+(defn status-class
+  "The colour class for a reply `:status` (one of `:success` / `:partial` /
+  `:failure` / `:cancellation` / `:suppression`), or nil for a non-status."
+  [status]
+  (get status->class status))
+
+(defn status-label
+  "The badge label for a reply `:status`, or the bare status name for an
+  unknown status."
+  [status]
+  (get status->label status (some-> status name)))
+
+;; ---------------------------------------------------------------------------
+;; The cross-family reply trace operation vocabulary (Managed-Effects
+;; §Tracing). Property 9 / §Tracing require families to emit trace rows FROM
+;; the reply-envelope facts. The runtime emits these as the family-namespaced
+;; ops listed below; this section gives Xray ONE classifier that recognises
+;; the reply-envelope LIFECYCLE PHASE a family op represents, so a panel reads
+;; \"issuance / retry / cancellation-requested / completion / stale-suppression
+;; / delivery\" uniformly across families instead of memorising each family's
+;; op set.
+;; ---------------------------------------------------------------------------
+
+(def reply-phases
+  "The closed set of reply-envelope lifecycle PHASES a managed-async family
+  trace row can represent (Managed-Effects §Tracing):
+
+    - `:issued`         — issuance/start (work-ledger row created; carries
+                          `:work/id`, frame, owner/cause, target summary).
+    - `:retry`          — a retry / intermediate transition (a new attempt).
+    - `:cancel-requested`— cancellation-requested (reason + whether a host
+                          handle existed); opportunistic, not yet terminal.
+    - `:completed`      — completion classified as one of the five reply
+                          statuses (the row carries the `:status`).
+    - `:stale-suppressed`— stale suppression (the correctness boundary —
+                          carried/current correlation; reply NOT delivered).
+    - `:delivered`      — delivery-or-explicit-non-delivery of the reply."
+  #{:issued :retry :cancel-requested :completed :stale-suppressed :delivered})
+
+(def ^:private op->phase
+  "Map each family's emitted trace `:operation` onto the reply-envelope
+  PHASE it represents (Managed-Effects §Tracing). The families spell their
+  ops in their own reserved namespace (Conventions §Reserved namespaces);
+  this is the single cross-family lowering Xray reads so a panel groups by
+  phase, not by family. Covers the families lowered onto the envelope today
+  (HTTP / resources / mutations / routing / machines / timers); a family op
+  not listed falls through to `phase-of`'s namespace+suffix heuristic so a
+  newly-added op is still classified before this table is extended."
+  {;; ---- issuance / start ----
+   ;; Resources lower their issuance onto the work-ledger row (`.3`, landed):
+   :rf.resource/work-started               :issued
+   :rf.resource/fetch-started              :issued
+   ;; HTTP issues the request through the `:rf.http/managed` fx (`.2`, landed);
+   ;; the canonical completion is `:rf.http/replied` (see :completed below).
+   ;; Machines (`.4`) + routing (`.5`) issuance ops are forward-looking; the
+   ;; suffix heuristic classifies them until those PRs land their literals.
+   :rf.machine.timer/scheduled             :issued
+   ;; ---- retry / intermediate ----
+   :rf.http/retry-attempt                  :retry
+   :rf.resource/refetch-decision           :retry
+   ;; ---- cancellation-requested (opportunistic; not yet terminal) ----
+   :rf.resource/work-abort-requested       :cancel-requested
+   :rf.http/aborted-on-actor-destroy       :cancel-requested
+   :rf.http/managed-abort                  :cancel-requested
+   :rf.machine.timer/cancelled             :cancel-requested
+   :rf.machine.spawn/cancelled-on-join-resolution :cancel-requested
+   :rf.route/cancel                        :cancel-requested
+   ;; ---- completion (carries the reply :status) ----
+   ;; `:rf.http/replied` is the canonical EP-0011 HTTP completion row — built
+   ;; FROM the reply-envelope facts (`http-reply/trace-reply`), carrying
+   ;; `:status` / `:work/id` / `:work/kind` / `:work/status` (rf2-zqefg3.2).
+   :rf.http/replied                        :completed
+   :rf.http/succeeded                      :completed
+   :rf.http/failed                         :completed
+   :rf.http/transport                      :completed
+   :rf.http/timeout                        :completed
+   :rf.http/decode-failure                 :completed
+   :rf.http/aborted                        :completed
+   :rf.resource/work-completed             :completed
+   :rf.resource/succeeded                  :completed
+   :rf.resource/failed                     :completed
+   :rf.resource/refresh-failed             :completed
+   :rf.machine.timer/fired                 :completed
+   :rf.machine/done                        :completed
+   ;; ---- stale suppression (the correctness boundary) ----
+   ;; Resources emit `:rf.resource/stale-suppressed` (landed). The shared
+   ;; substrate suppression trace is `:rf.reply/suppressed` (re-frame.reply
+   ;; §suppress). Routing / machine family suppression ops (`.5` / `.4`) are
+   ;; forward-looking; the suffix heuristic catches `*stale-suppress*` /
+   ;; `*suppressed*` until those PRs land.
+   :rf.resource/stale-suppressed           :stale-suppressed
+   :rf.reply/suppressed                    :stale-suppressed
+   ;; ---- delivery ----
+   :rf.reply/delivered                     :delivered})
+
+(def ^:private suffix->phase
+  "Heuristic fallback: the reply-envelope phase a family op's NAME suffix
+  implies, used when an op is not in the explicit `op->phase` table (a
+  newly-added family op). Matched against the op's `name` by substring so a
+  family that adds e.g. `:rf.stream/work-started` is still classified
+  `:issued` before this code learns the literal op."
+  [["stale-suppress" :stale-suppressed]
+   ["suppressed"      :stale-suppressed]
+   ["abort"           :cancel-requested]
+   ["cancel"          :cancel-requested]
+   ["retry"           :retry]
+   ["work-started"    :issued]
+   ["started"         :issued]
+   ["issued"          :issued]
+   ["scheduled"       :issued]
+   ["delivered"       :delivered]
+   ["completed"       :completed]
+   ["succeeded"       :completed]
+   ["failed"          :completed]
+   ["done"            :completed]
+   ["fired"           :completed]])
+
+(defn phase-of
+  "The reply-envelope lifecycle phase a family trace `:operation` represents
+  (one of `reply-phases`), or nil for a non-managed-async op. Reads the
+  explicit `op->phase` table first; falls back to the `suffix->phase`
+  heuristic so a family op not yet enumerated is still classified
+  (Managed-Effects §Tracing — families emit FROM the envelope facts).
+  Pure."
+  [operation]
+  (when (keyword? operation)
+    (or (get op->phase operation)
+        (let [nm (name operation)]
+          (some (fn [[needle phase]]
+                  (when #?(:clj (.contains ^String nm ^String needle)
+                           :cljs (not= -1 (.indexOf nm needle)))
+                    phase))
+                suffix->phase)))))
+
+(defn reply-trace-op?
+  "True iff `operation` is a managed-async reply-envelope trace op — one
+  that maps onto a reply-envelope `phase-of`. Lets a panel filter the trace
+  stream to the cross-family work/reply rows without memorising each
+  family's op set."
+  [operation]
+  (boolean (phase-of operation)))
+
+;; ---------------------------------------------------------------------------
+;; Cross-family trace-row projection. A managed-async trace row (any family)
+;; → one uniform work/reply row keyed on `:work/id`, carrying the phase + the
+;; envelope facts the row could observe. PRIVACY: wire-bearing tags
+;; summarized. The work-id is the join key the stale-races + live-work views
+;; group on.
+;; ---------------------------------------------------------------------------
+
+(defn- trace-op [ev] (or (:operation ev) (:op ev)))
+(defn- trace-tags [ev] (or (:tags ev) {}))
+
+(defn work-event-row
+  "Project ONE managed-async trace event (any family) into a uniform
+  work/reply row — the SAME shape regardless of which family emitted it
+  (Managed-Effects §Tracing — families emit FROM the envelope facts).
+
+      {:id          <trace-id>
+       :operation   :rf.resource/work-completed
+       :phase       :completed                      ; the reply-envelope phase
+       :work-kind   :resource
+       :work-id     [:rf.work/resource <key> 4]     ; the join key
+       :frame       <frame-id>
+       :status      :ok | :error | …                ; on a :completed row
+       :status-class :success | …                   ; cross-surface colour
+       :work-status :completed
+       :stale?      false                           ; on a :stale-suppressed row
+       :carried     {:work/id … :generation …}      ; suppression carried gate
+       :current     {:work/id … :generation …}      ; suppression current gate
+       :cancel-reason :actor-destroyed              ; on a :cancel-requested row
+       :delivered?  true                            ; on a :delivered row
+       :time        <ms>
+       :dispatch-id <id>}
+
+  Reads the envelope facts the family stamped on the row per §Tracing: the
+  `:work/id` (or bare `:work-id`), the frame, the completion `:status`, the
+  carried/current correlation on a stale-suppression row, the cancel reason
+  on a cancel-requested row. nil for a non-managed-async op. PRIVACY: the
+  carried/current correlation + any value/error tags are summarized. Pure."
+  [ev]
+  (let [op    (trace-op ev)
+        phase (phase-of op)]
+    (when phase
+      (let [tags    (trace-tags ev)
+            work-id (work-id-of tags)
+            status  (when (= phase :completed)
+                      (let [s (:status tags)]
+                        ;; some resource completion rows stamp the LEDGER status
+                        ;; (`:completed`/`:failed`) under :status; the closed
+                        ;; reply status is what the cross-surface badge keys on,
+                        ;; so only surface a real reply status here.
+                        (when (reply-status? s) s)))]
+        (cond-> {:id           (:id ev)
+                 :operation    op
+                 :phase        phase
+                 :work-kind    (or (work-kind-of tags) (infer-work-kind work-id))
+                 :work-id      work-id
+                 :frame        (or (:rf.frame/id tags) (:frame-id tags) (:frame ev))
+                 :work-status  (or (:work/status tags) (:work-status tags))
+                 :time         (:time ev)
+                 :dispatch-id  (or (:rf.trace/dispatch-id tags) (:dispatch-id tags))}
+          status
+          (assoc :status status :status-class (status-class status))
+
+          (= phase :stale-suppressed)
+          (assoc :stale?  true
+                 :carried (when (contains? tags :rf.reply/carried)
+                            (rh/summarize (:rf.reply/carried tags)))
+                 :current (when (contains? tags :rf.reply/current)
+                            (rh/summarize (:rf.reply/current tags)))
+                 :stale-reason (or (:stale/reason tags) (:reason tags) (:outcome tags)))
+
+          (= phase :cancel-requested)
+          (assoc :cancelled?    true
+                 :cancel-reason (or (:cancel/reason tags) (:reason tags) (:cancel-cause tags)))
+
+          (= phase :delivered)
+          (assoc :delivered? (if (contains? tags :rf.reply/delivered?)
+                               (boolean (:rf.reply/delivered? tags))
+                               true)))))))
+
+(defn project-work-events
+  "Project a trace buffer into the uniform cross-family work/reply rows
+  (oldest-first, preserving buffer order). Every managed-async trace event —
+  HTTP, resource, mutation, route, machine, timer — projects through the
+  SAME `work-event-row` vocabulary; non-managed-async rows are dropped. Pure
+  over the trace vector."
+  [trace-buffer]
+  (into [] (keep work-event-row) (or trace-buffer [])))
+
+;; ---------------------------------------------------------------------------
+;; Stale-races view — keyed on :work/id (rf2-zqefg3.7 bead requirement /
+;; Cross-Cutting F-C5 stale-suppression tally / F.11 cross-surface badge).
+;; Groups the cross-family work/reply rows by `:work/id` so the operator sees
+;; each attempt's arc (issued → … → completed/suppressed) and the races where
+;; one work id was superseded by another (carried ≠ current correlation).
+;; ---------------------------------------------------------------------------
+
+(defn stale-suppressions
+  "The cross-family stale-suppression rows from a trace buffer — every
+  family's `:stale-suppressed` phase row, projected through the uniform
+  vocabulary, keyed by `:work/id` (Managed-Effects §Stale suppression — the
+  correctness boundary; the row carries the carried + current correlation).
+  This is the Cross-Cutting F-C5 stale-suppression tally / F.11 cross-surface
+  STALE badge, now UNIFORM across HTTP / resources / mutations / routing /
+  machines (each family's stale-suppressed op lowers to the same phase). Pure."
+  [trace-buffer]
+  (->> (project-work-events trace-buffer)
+       (filterv #(= :stale-suppressed (:phase %)))))
+
+(defn stale-tally-by-kind
+  "Count stale suppressions per `:work-kind` across the trace buffer — the
+  cross-surface stale-suppression tally (Cross-Cutting F-C5). Returns
+  `{:resource 2 :http 1 …}`. A high count for one family flags a
+  supersession storm there. Pure."
+  [trace-buffer]
+  (->> (stale-suppressions trace-buffer)
+       (group-by :work-kind)
+       (reduce-kv (fn [m k rows] (assoc m k (count rows))) {})))
+
+(defn races-by-work-id
+  "Group every cross-family work/reply trace row by its `:work/id` — the
+  attempt-arc view the stale-races panel renders (Managed-Effects §Work-id
+  correlation — `:work/id` is the SINGLE attempt identity, the key stale
+  suppression and the ledger and this view all share). Returns
+
+      {<work-id> {:work-id … :work-kind … :rows [<row> …]
+                  :phases #{:issued :completed …}
+                  :terminal-status :ok|:error|:cancelled|:stale|nil
+                  :suppressed? bool}}
+
+  `:terminal-status` is the completion `:status` if the arc reached a
+  `:completed` row, `:stale` if it was stale-suppressed, else nil (still
+  in-flight). `:suppressed?` flags an arc that hit the stale-suppression
+  correctness boundary. Rows with no `:work/id` (a non-ledger-backed managed
+  async) are grouped under the `nil` key. Pure."
+  [trace-buffer]
+  (let [rows (project-work-events trace-buffer)]
+    (->> rows
+         (group-by :work-id)
+         (reduce-kv
+           (fn [acc work-id grp]
+             (let [phases       (into #{} (map :phase) grp)
+                   completed    (some #(when (= :completed (:phase %)) (:status %)) grp)
+                   suppressed?  (contains? phases :stale-suppressed)
+                   terminal     (cond suppressed? :stale
+                                      completed   completed
+                                      :else       nil)]
+               (assoc acc work-id
+                      {:work-id         work-id
+                       :work-kind       (some :work-kind grp)
+                       :rows            (vec grp)
+                       :phases          phases
+                       :terminal-status terminal
+                       :suppressed?     suppressed?})))
+           {}))))
+
+;; ---------------------------------------------------------------------------
+;; \"What is still running?\" — work-ledger rows joined to reply status +
+;; trace cause, UNIFORM across families (rf2-zqefg3.7 bead requirement /
+;; Cross-Cutting F-C4 active managed-effects dashboard). The work ledger is
+;; the durable substrate (Managed-Effects §Work-ledger integration — a ledger
+;; row IS the reified continuation); a non-terminal row is live work. Joining
+;; the ledger row to the latest trace phase for its `:work/id` answers \"is it
+;; issued / retrying / cancellation-requested?\" across every family with ONE
+;; query.
+;; ---------------------------------------------------------------------------
+
+(def ledger-key
+  "Reserved runtime-db key for the frame work ledger (Managed-Effects
+  §Work-ledger integration / Conventions §Reserved runtime-db keys —
+  `:rf.runtime/work-ledger`). Mirror of `resources-helpers/work-ledger-key`,
+  named here as the cross-family vocabulary's own home so a work/reply
+  consumer reads one place. Bundle-isolation-safe literal."
+  :rf.runtime/work-ledger)
+
+(def non-terminal-work-statuses
+  "The non-terminal ledger statuses an attempt moves through while still live
+  (Managed-Effects §Work-ledger integration — issuance writes a `:running`
+  row; `:abort-requested` is non-terminal until the transport settles). A
+  ledger row in one of these IS live work. Complement of `work-statuses`'s
+  terminal members."
+  #{:queued :running :abort-requested})
+
+(defn live?
+  "True iff a ledger row `:status` is non-terminal (the attempt is still
+  running / queued / abort-requested). Pure."
+  [status]
+  (contains? non-terminal-work-statuses status))
+
+(defn ledger-row
+  "Project ONE work-ledger record `[work-id record]` into the uniform
+  work/reply row vocabulary (Managed-Effects §Work-ledger integration). The
+  cross-family mirror of `resources-helpers/work-row`, but keyed on the
+  ENVELOPE vocabulary (`:work-kind` / `:work/id` / live?) rather than
+  resource-specific fields, so HTTP / route / machine / timer ledger rows (as
+  later families write them) project the SAME way:
+
+      {:work-id      <id>
+       :work-kind    :resource | :mutation | :http | :route | :machine | :timer
+       :status       :running                    ; the ledger row status
+       :live?        true                        ; non-terminal ⇒ still running
+       :frame        <frame-id>
+       :owners       [<owner> …]                 ; who needs this work
+       :causes       [<summary> …]               ; what triggered it (summarized)
+       :cancellable? true
+       :started-at   …  :deadline-at …
+       :attempt      <n>
+       :transport    :rf.http/managed
+       :outcome      <summary>}                  ; terminal-row outcome summary
+
+  PRIVACY: `:causes` + `:outcome` are summarized (a cause may carry data).
+  The host handles (AbortControllers / promises / timer handles) live in a
+  side table and are STRUCTURALLY absent from the serializable record
+  (Managed-Effects §The reply map — the data-only invariant). Pure."
+  [[work-id record]]
+  (let [status (:status record)]
+    {:work-id      work-id
+     :work-kind    (or (:work/kind record) (:kind record) (infer-work-kind work-id))
+     :status       status
+     :live?        (live? status)
+     :frame        (or (:work/frame record) (:frame-id record) (:rf.frame/id record))
+     :owners       (vec (:owners record))
+     :causes       (mapv rh/summarize (:causes record))
+     :cancellable? (boolean (:cancellable? record))
+     :started-at   (:started-at record)
+     :deadline-at  (or (:deadline-at record) (:deadline record))
+     :attempt      (or (:attempt record) (:generation record))
+     :transport    (:transport record)
+     :outcome      (when (contains? record :outcome) (rh/summarize (:outcome record)))}))
+
+(defn project-ledger
+  "Project a frame's work-ledger map `{<work-id> <record>}` into the uniform
+  cross-family work/reply rows, live (non-terminal) work first then the
+  terminal recent-races tail, each group newest-first by `:attempt`. Per
+  Managed-Effects §Work-ledger integration. Pure."
+  [ledger]
+  (->> (or ledger {})
+       (mapv ledger-row)
+       (sort-by (juxt (complement :live?) (comp - (fnil identity 0) :attempt)))
+       vec))
+
+(defn latest-phase-by-work-id
+  "Index the LATEST reply-envelope trace phase observed per `:work/id` across
+  a trace buffer (the most-recent `work-event-row` for each work id, by
+  `:time` then `:id`). Used to join a live ledger row to its current trace
+  cause — \"is this running work issued / retrying / cancellation-requested?\"
+  Returns `{<work-id> <work-event-row>}`. Pure."
+  [trace-buffer]
+  (->> (project-work-events trace-buffer)
+       (filter :work-id)
+       (sort-by (juxt (comp (fnil identity 0) :time) (comp (fnil identity 0) :id)))
+       (reduce (fn [acc row] (assoc acc (:work-id row) row)) {})))
+
+(defn live-work
+  "\"What is still running?\" — the live (non-terminal) work-ledger rows
+  joined to their latest reply-envelope trace phase + completion status,
+  UNIFORM across HTTP / resources / mutations / routing / machines / timers
+  (Managed-Effects §Work-ledger integration / Cross-Cutting F-C4). Each live
+  ledger row gains the trace cause for its `:work/id`:
+
+      {:work-id … :work-kind … :status :running :live? true
+       :owners … :causes … :attempt … :frame …
+       :latest-phase :issued | :retry | :cancel-requested   ; from the trace
+       :latest-op    :rf.resource/work-abort-requested}      ; the emitting op
+
+  Answers the operator's \"what is the app waiting on, and why\" across every
+  family with ONE join. `ledger` is the frame's work-ledger map (read off the
+  runtime-db at `ledger-key`); `trace-buffer` supplies the latest phase. Pure.
+
+  The single-arity form (ledger only) returns the live rows without the trace
+  join (the ledger row's own `:status` is the live fact; the trace phase is
+  the enrichment)."
+  ([ledger] (live-work ledger nil))
+  ([ledger trace-buffer]
+   (let [phase-by-id (when (seq trace-buffer) (latest-phase-by-work-id trace-buffer))]
+     (->> (project-ledger ledger)
+          (filterv :live?)
+          (mapv (fn [row]
+                  (if-let [ph (get phase-by-id (:work-id row))]
+                    (assoc row :latest-phase (:phase ph)
+                               :latest-op    (:operation ph))
+                    row)))))))
+
+(defn live-work-tally-by-kind
+  "Count live (still-running) work per `:work-kind` across the ledger — the
+  active managed-effects dashboard headline (Cross-Cutting F-C4). Returns
+  `{:resource 2 :http 1 …}`. Pure."
+  [ledger]
+  (->> (live-work ledger)
+       (group-by :work-kind)
+       (reduce-kv (fn [m k rows] (assoc m k (count rows))) {})))

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -55,6 +55,7 @@
             [re-frame.core :as rf]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.resources-helpers :as h]
+            [day8.re-frame2-xray.panels.reply-envelope :as reply]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
@@ -677,6 +678,18 @@
          :registry      registry-rows
          :instances     instance-rows
          :work          work-rows
+         ;; The UNIFORM reply-envelope reads (rf2-zqefg3.7). These read the
+         ;; canonical EP-0011 work/reply facts (`:work/id` / `:work/kind` /
+         ;; reply `:status` / stale-suppression carried+current) the SAME way
+         ;; for every async family — so "what is still running?" and the
+         ;; stale-races view are cross-family, not resource-private. The
+         ;; resource ledger is the only family writing the ledger today; as
+         ;; HTTP / route / machine / timer families write their own ledger
+         ;; rows + emit their reply-envelope trace ops, these surfaces pick
+         ;; them up with no panel change (one vocabulary, many families).
+         :live-work     (reply/live-work ledger trace-buffer)
+         :stale-races   (reply/races-by-work-id trace-buffer)
+         :stale-tally   (reply/stale-tally-by-kind trace-buffer)
          :route-graph   (h/project-route-graph
                           routes-map
                           {:instance-rows instance-rows

--- a/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
@@ -1,0 +1,394 @@
+(ns day8.re-frame2-xray.panels.reply-envelope-cljs-test
+  "Pure-data tests for Xray's ONE work/reply vocabulary reading the uniform
+  reply envelope (EP-0011, rf2-zqefg3.7).
+
+  Dual-target naming (`.cljc` + `_cljs_test`):
+    - Cognitect's test-runner (CLJ) picks it up via the default `.*-test$`
+      regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$` regex.
+
+  ## What's under test
+
+    1. **closed vocabularies** — reply-statuses / work-statuses / work-kinds
+       mirror the substrate's `re-frame.reply` sets EXACTLY (the
+       bundle-isolation mirror is pinned, not drifting).
+    2. **reply-map readers** — work-id / work-kind reading + inference from
+       the work-id tuple head, across families; the `:work/kind :mutation`
+       distinction; tolerant of canonical vs bare trace-tag spellings.
+    3. **reply-row** — projects a uniform reply map (any family) into the ONE
+       render-safe row; PRIVACY summarization; delivered? derivation; the
+       five statuses.
+    4. **status presentation** — the cross-surface colour class + label is
+       UNIFORM across families (an HTTP :stale and a resource :stale read the
+       same badge — Cross-Cutting F.11).
+    5. **phase-of** — every family's trace op lowers onto ONE reply-envelope
+       phase (issued / retry / cancel-requested / completed / stale-suppressed
+       / delivered), incl. the suffix heuristic for a not-yet-enumerated op.
+    6. **work-event-row / project-work-events** — cross-family trace rows →
+       one uniform vocabulary keyed on :work/id.
+    7. **stale-races** — keyed on :work/id; the cross-surface stale tally;
+       races-by-work-id attempt arcs.
+    8. **live-work** — work-ledger rows joined to reply status + trace cause,
+       uniform across families; \"what is still running?\""
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-xray.panels.reply-envelope :as re]))
+
+;; ---------------------------------------------------------------------------
+;; (1) closed vocabularies — the bundle-isolation mirror is pinned.
+;; ---------------------------------------------------------------------------
+
+(deftest closed-vocabularies
+  (testing "the mirrored reply-status set is exactly the EP-0011 closed five"
+    (is (= #{:ok :partial :error :cancelled :stale} re/reply-statuses))
+    (is (re/reply-status? :ok))
+    (is (re/reply-status? :stale))
+    (is (not (re/reply-status? :running)))
+    (is (not (re/reply-status? :completed))))
+  (testing "work-statuses are the operational five (timeout is a work status,
+            not a reply status; suppressed is the stale terminal)"
+    (is (= #{:completed :failed :timed-out :suppressed :cancelled} re/work-statuses)))
+  (testing "work-kinds cover every managed-async family"
+    (is (= #{:http :resource :mutation :route :machine :timer} re/work-kinds)))
+  (testing "all five reply statuses are terminal (a reply map is produced only
+            at completion — :running is a ledger status, not a reply status)"
+    (is (= re/reply-statuses re/terminal-reply-statuses))))
+
+;; ---------------------------------------------------------------------------
+;; (2) reply-map readers — work-id / kind reading + inference, across families.
+;; ---------------------------------------------------------------------------
+
+(deftest work-id+kind-readers
+  (testing "reads canonical :work/id and bare :work-id"
+    (is (= [:rf.work/http :a 1] (re/work-id-of {:work/id [:rf.work/http :a 1]})))
+    (is (= [:rf.work/resource :k 4] (re/work-id-of {:work-id [:rf.work/resource :k 4]}))))
+  (testing "reads explicit :work/kind, tolerating bare spellings"
+    (is (= :http (re/work-kind-of {:work/kind :http})))
+    (is (= :resource (re/work-kind-of {:work-kind :resource})))
+    (is (= :mutation (re/work-kind-of {:kind :mutation}))))
+  (testing "infers the family from each work-id tuple head"
+    (is (= :http     (re/infer-work-kind [:rf.work/http :a 1])))
+    (is (= :resource (re/infer-work-kind [:rf.work/resource :k 1])))
+    (is (= :route    (re/infer-work-kind [:rf.work/route :r "nav-7" :loader])))
+    (is (= :machine  (re/infer-work-kind [:rf.work/machine :actor [:path] 1])))
+    (is (= :timer    (re/infer-work-kind [:rf.work/timer :t 1])))
+    (is (nil? (re/infer-work-kind [:something/else 1])))
+    (is (nil? (re/infer-work-kind nil))))
+  (testing "resolve-work-kind: explicit wins, else inferred — the :mutation
+            row reuses the :rf.work/resource head but its explicit kind wins"
+    (is (= :http (re/resolve-work-kind {:work/id [:rf.work/http :a 1]})))
+    (is (= :mutation (re/resolve-work-kind {:work/kind :mutation
+                                            :work/id  [:rf.work/resource [:rf.mutation :m1] 1]})))
+    (is (= :resource (re/resolve-work-kind {:work/id [:rf.work/resource :k 1]})))))
+
+;; ---------------------------------------------------------------------------
+;; (3) reply-row — projects any family's reply map into ONE vocabulary.
+;; ---------------------------------------------------------------------------
+
+(deftest reply-row-projection
+  (testing ":ok reply — value present, delivered, no error/stale/cancel"
+    (let [row (re/reply-row {:status :ok :value {:title "Welcome"}
+                             :work/id [:rf.work/http :article 1] :work/kind :http
+                             :work/status :completed :attempt 1
+                             :rf.frame/id :frame-7 :completed-at 1781078400456
+                             :correlation {:request-id "req-9"}})]
+      (is (= :ok (:status row)))
+      (is (= :http (:work-kind row)))
+      (is (= [:rf.work/http :article 1] (:work-id row)))
+      (is (= :completed (:work-status row)))
+      (is (= :frame-7 (:frame row)))
+      (is (= 1781078400456 (:completed-at row)))
+      (is (true? (:delivered? row)))
+      (is (false? (:stale? row)))
+      (is (false? (:cancelled? row)))
+      ;; PRIVACY: value/correlation summarized, not raw
+      (is (= "map" (:type (:value row))))
+      (is (= "map" (:type (:correlation row))))))
+  (testing ":error reply — error envelope + family kind, no value"
+    (let [row (re/reply-row {:status :error
+                             :error {:kind :rf.http/timeout :limit-ms 30000}
+                             :work/status :timed-out
+                             :work/id [:rf.work/resource :k 2]})]
+      (is (= :error (:status row)))
+      (is (= :resource (:work-kind row)))     ;; inferred from the head
+      (is (= :timed-out (:work-status row)))
+      (is (= :rf.http/timeout (:error-kind row)))
+      (is (some? (:error row)))
+      (is (true? (:delivered? row)))))
+  (testing ":cancelled reply — cancel reason + flag"
+    (let [row (re/reply-row {:status :cancelled :cancelled? true
+                             :cancel/reason :actor-destroyed
+                             :error {:kind :rf.http/aborted}
+                             :work/id [:rf.work/http :a 1]})]
+      (is (= :cancelled (:status row)))
+      (is (true? (:cancelled? row)))
+      (is (= :actor-destroyed (:cancel-reason row)))
+      (is (true? (:delivered? row)))))
+  (testing ":stale reply — NOT delivered by default; stale flag + reason; no value"
+    (let [row (re/reply-row {:status :stale :stale? true
+                             :stale/reason :rf.reply/correlation-mismatch
+                             :work/status :suppressed
+                             :work/id [:rf.work/resource :k 3]})]
+      (is (= :stale (:status row)))
+      (is (true? (:stale? row)))
+      (is (= :rf.reply/correlation-mismatch (:stale-reason row)))
+      (is (false? (:delivered? row)))         ;; the correctness boundary
+      (is (nil? (:value row)))))
+  (testing "an explicit :rf.reply/delivered? on a stale reply (a test/tool
+            target opted into :dispatch-stale?) overrides the derived default"
+    (is (true? (:delivered? (re/reply-row {:status :stale :stale? true
+                                           :stale/reason :x
+                                           :rf.reply/delivered? true})))))
+  (testing ":partial reply — both value and error present"
+    (let [row (re/reply-row {:status :partial :value {:items []}
+                             :error {:kind :rf.graphql/partial-success}
+                             :work/id [:rf.work/http :q 1]})]
+      (is (= :partial (:status row)))
+      (is (some? (:value row)))
+      (is (= :rf.graphql/partial-success (:error-kind row)))
+      (is (true? (:delivered? row))))))
+
+(deftest reply-map?-predicate
+  (is (re/reply-map? {:status :ok :value 1}))
+  (is (re/reply-map? {:status :stale :stale? true}))
+  (is (not (re/reply-map? {:status :running})))   ;; not a reply status
+  (is (not (re/reply-map? {:value 1})))
+  (is (not (re/reply-map? [:not :a :map]))))
+
+;; ---------------------------------------------------------------------------
+;; (4) status presentation — UNIFORM cross-surface colour class + label.
+;; ---------------------------------------------------------------------------
+
+(deftest cross-surface-status-presentation
+  (testing "every reply status maps to a shared colour class + label"
+    (is (= :success      (re/status-class :ok)))
+    (is (= :partial      (re/status-class :partial)))
+    (is (= :failure      (re/status-class :error)))
+    (is (= :cancellation (re/status-class :cancelled)))
+    (is (= :suppression  (re/status-class :stale)))
+    (is (= "STALE" (re/status-label :stale)))
+    (is (= "OK"    (re/status-label :ok))))
+  (testing "an HTTP :stale and a resource :stale render the SAME badge
+            (Cross-Cutting F.11 — unified cross-surface STALE)"
+    (let [http-stale (re/reply-row {:status :stale :stale? true :stale/reason :x
+                                    :work/id [:rf.work/http :a 1]})
+          res-stale  (re/reply-row {:status :stale :stale? true :stale/reason :x
+                                    :work/id [:rf.work/resource :k 1]})]
+      (is (= (re/status-class (:status http-stale))
+             (re/status-class (:status res-stale))
+             :suppression)))))
+
+;; ---------------------------------------------------------------------------
+;; (5) phase-of — every family's op lowers onto ONE reply-envelope phase.
+;; ---------------------------------------------------------------------------
+
+(deftest phase-classification
+  (testing "issuance / start across families (the landed literals)"
+    (is (= :issued (re/phase-of :rf.resource/work-started)))
+    (is (= :issued (re/phase-of :rf.resource/fetch-started)))
+    (is (= :issued (re/phase-of :rf.machine.timer/scheduled))))
+  (testing "retry / intermediate"
+    (is (= :retry (re/phase-of :rf.http/retry-attempt)))
+    (is (= :retry (re/phase-of :rf.resource/refetch-decision))))
+  (testing "cancellation-requested across families"
+    (is (= :cancel-requested (re/phase-of :rf.resource/work-abort-requested)))
+    (is (= :cancel-requested (re/phase-of :rf.http/aborted-on-actor-destroy)))
+    (is (= :cancel-requested (re/phase-of :rf.http/managed-abort)))
+    (is (= :cancel-requested (re/phase-of :rf.machine.timer/cancelled)))
+    (is (= :cancel-requested (re/phase-of :rf.machine.spawn/cancelled-on-join-resolution))))
+  (testing "completion across families — :rf.http/replied is the canonical
+            EP-0011 HTTP completion row (built from the reply envelope)"
+    (is (= :completed (re/phase-of :rf.http/replied)))
+    (is (= :completed (re/phase-of :rf.http/succeeded)))
+    (is (= :completed (re/phase-of :rf.http/failed)))
+    (is (= :completed (re/phase-of :rf.resource/work-completed)))
+    (is (= :completed (re/phase-of :rf.resource/succeeded)))
+    (is (= :completed (re/phase-of :rf.machine/done))))
+  (testing "stale suppression lowers to ONE phase — the landed resource op +
+            the shared substrate :rf.reply/suppressed"
+    (is (= :stale-suppressed (re/phase-of :rf.resource/stale-suppressed)))
+    (is (= :stale-suppressed (re/phase-of :rf.reply/suppressed))))
+  (testing "delivery"
+    (is (= :delivered (re/phase-of :rf.reply/delivered))))
+  (testing "the suffix heuristic classifies a NOT-YET-enumerated family op
+            (a new :rf.stream/* surface) before the table learns it"
+    (is (= :issued           (re/phase-of :rf.stream/work-started)))
+    (is (= :cancel-requested (re/phase-of :rf.stream/abort-requested)))
+    (is (= :stale-suppressed (re/phase-of :rf.stream/stale-suppressed)))
+    (is (= :completed        (re/phase-of :rf.stream/succeeded))))
+  (testing "non-managed-async ops are not reply-envelope ops"
+    (is (nil? (re/phase-of :rf.sub/run)))
+    (is (nil? (re/phase-of :rf.event/dispatched)))
+    (is (not (re/reply-trace-op? :rf.view/render)))
+    (is (re/reply-trace-op? :rf.resource/work-completed))))
+
+;; ---------------------------------------------------------------------------
+;; (6) work-event-row / project-work-events — cross-family trace projection.
+;; ---------------------------------------------------------------------------
+
+(def ^:private mixed-trace
+  "A trace buffer mixing resource + HTTP + machine reply-envelope rows plus
+  non-managed noise — the cross-family input the uniform vocabulary reads."
+  [{:id 1 :operation :rf.sub/run :tags {}}
+   {:id 2 :operation :rf.resource/work-started
+    :time 100 :tags {:work-id [:rf.work/resource :k 1] :rf.frame/id :f
+                     :generation 1 :owner [:lease :a]}}
+   {:id 3 :operation :rf.resource/fetch-started
+    :time 110 :tags {:work-id [:rf.work/http :req 1] :rf.frame/id :f}}
+   {:id 4 :operation :rf.resource/work-abort-requested
+    :time 120 :tags {:work-id [:rf.work/resource :k 1] :reason :superseded}}
+   {:id 5 :operation :rf.resource/stale-suppressed
+    :time 130 :tags {:work-id [:rf.work/resource :k 1]
+                     :rf.reply/carried {:work/id [:rf.work/resource :k 1] :generation 1}
+                     :rf.reply/current {:work/id [:rf.work/resource :k 2] :generation 2}
+                     :outcome :success}}
+   ;; the canonical EP-0011 HTTP completion row, built from the reply
+   ;; envelope (carries :work/kind + :status verbatim — rf2-zqefg3.2)
+   {:id 6 :operation :rf.http/replied
+    :time 140 :tags {:work/id [:rf.work/http :req 1] :work/kind :http :status :ok}}])
+
+(deftest work-event-row-projection
+  (testing "a resource issuance row → :issued phase, work-id + kind read"
+    (let [row (re/work-event-row (nth mixed-trace 1))]
+      (is (= :issued (:phase row)))
+      (is (= :resource (:work-kind row)))
+      (is (= [:rf.work/resource :k 1] (:work-id row)))
+      (is (= :f (:frame row)))))
+  (testing "an HTTP completion row → :completed phase + reply status + class"
+    (let [row (re/work-event-row (nth mixed-trace 5))]
+      (is (= :completed (:phase row)))
+      (is (= :http (:work-kind row)))
+      (is (= :ok (:status row)))
+      (is (= :success (:status-class row)))))
+  (testing "a cancel-requested row carries the cancel reason"
+    (let [row (re/work-event-row (nth mixed-trace 3))]
+      (is (= :cancel-requested (:phase row)))
+      (is (true? (:cancelled? row)))
+      (is (= :superseded (:cancel-reason row)))))
+  (testing "a stale-suppression row carries carried + current correlation (PRIVACY
+            summarized) keyed on :work/id"
+    (let [row (re/work-event-row (nth mixed-trace 4))]
+      (is (= :stale-suppressed (:phase row)))
+      (is (true? (:stale? row)))
+      (is (= [:rf.work/resource :k 1] (:work-id row)))
+      (is (some? (:carried row)))
+      (is (some? (:current row)))
+      (is (= "map" (:type (:carried row))))))
+  (testing "non-managed-async rows are dropped"
+    (is (nil? (re/work-event-row (first mixed-trace)))))
+  (testing "project-work-events keeps every managed row, drops the noise,
+            preserves buffer order"
+    (let [rows (re/project-work-events mixed-trace)]
+      (is (= 5 (count rows)))                     ;; 5 managed of 6 events
+      (is (= [2 3 4 5 6] (mapv :id rows))))))
+
+;; ---------------------------------------------------------------------------
+;; (7) stale-races — keyed on :work/id; cross-surface tally; attempt arcs.
+;; ---------------------------------------------------------------------------
+
+(deftest stale-races-keyed-on-work-id
+  (testing "stale-suppressions surfaces every family's suppression row"
+    (let [sup (re/stale-suppressions mixed-trace)]
+      (is (= 1 (count sup)))
+      (is (= [:rf.work/resource :k 1] (:work-id (first sup))))
+      (is (= :resource (:work-kind (first sup))))))
+  (testing "the cross-surface stale tally counts per work-kind — the shared
+            substrate :rf.reply/suppressed row, kind inferred from the head"
+    (let [trace (conj mixed-trace
+                      {:id 7 :operation :rf.reply/suppressed
+                       :time 150 :tags {:work/id [:rf.work/http :req 9]}})]
+      (is (= {:resource 1 :http 1} (re/stale-tally-by-kind trace)))))
+  (testing "races-by-work-id groups the attempt arc, keyed on :work/id —
+            the resource arc reached issued → cancel-requested → suppressed
+            (terminal :stale, suppressed?)"
+    (let [races (re/races-by-work-id mixed-trace)
+          res   (get races [:rf.work/resource :k 1])
+          http  (get races [:rf.work/http :req 1])]
+      (is (= #{:issued :cancel-requested :stale-suppressed} (:phases res)))
+      (is (= :stale (:terminal-status res)))
+      (is (true? (:suppressed? res)))
+      (is (= :resource (:work-kind res)))
+      ;; the HTTP arc reached :ok, not suppressed
+      (is (= #{:issued :completed} (:phases http)))
+      (is (= :ok (:terminal-status http)))
+      (is (false? (:suppressed? http))))))
+
+;; ---------------------------------------------------------------------------
+;; (8) live-work — ledger rows joined to reply status + trace cause, uniform.
+;; ---------------------------------------------------------------------------
+
+(def ^:private ledger
+  "A frame work-ledger map mixing live + terminal rows across kinds — the
+  durable substrate the 'what is still running?' join reads."
+  {[:rf.work/resource :k 2]
+   {:work/id [:rf.work/resource :k 2] :work/kind :resource :work/frame :f
+    :resource/key [:s :article/by-id {:id 1}] :generation 2 :status :running
+    :owners #{[:lease :a]} :causes [[:ensure :article/by-id]] :cancellable? true
+    :started-at 1000 :transport :rf.http/managed}
+   [:rf.work/resource :k 1]
+   {:work/id [:rf.work/resource :k 1] :work/kind :resource :work/frame :f
+    :resource/key [:s :article/by-id {:id 1}] :generation 1 :status :suppressed
+    :owners #{} :causes [] :outcome {:reason :stale-reply}}
+   [:rf.work/http :req 5]
+   {:work/id [:rf.work/http :req 5] :work/kind :http :work/frame :f
+    :generation 1 :status :abort-requested :owners #{} :causes []
+    :transport :rf.http/managed}})
+
+(deftest ledger-row-projection
+  (testing "a running resource row projects live, kind + owners + causes read"
+    (let [row (re/ledger-row [[:rf.work/resource :k 2] (get ledger [:rf.work/resource :k 2])])]
+      (is (= :resource (:work-kind row)))
+      (is (= :running (:status row)))
+      (is (true? (:live? row)))
+      (is (= :f (:frame row)))
+      (is (= [[:lease :a]] (:owners row)))
+      (is (= :rf.http/managed (:transport row)))
+      ;; PRIVACY: cause summarized
+      (is (= "vector" (:type (first (:causes row)))))))
+  (testing "kind inference fills in when the record omits :work/kind"
+    (is (= :http (:work-kind (re/ledger-row [[:rf.work/http :r 1] {:status :running}])))))
+  (testing "a suppressed row is terminal (not live), outcome summarized"
+    (let [row (re/ledger-row [[:rf.work/resource :k 1] (get ledger [:rf.work/resource :k 1])])]
+      (is (false? (:live? row)))
+      (is (some? (:outcome row))))))
+
+(deftest live-work-join
+  (testing "live-work returns only non-terminal rows across families"
+    (let [live (re/live-work ledger)]
+      (is (= 2 (count live)))                    ;; the :running resource + :abort-requested http
+      (is (= #{[:rf.work/resource :k 2] [:rf.work/http :req 5]}
+             (into #{} (map :work-id) live)))))
+  (testing "the tally counts live work per kind — the active-effects headline"
+    (is (= {:resource 1 :http 1} (re/live-work-tally-by-kind ledger))))
+  (testing "joining to the trace stream enriches each live row with its latest
+            reply-envelope phase + emitting op (UNIFORM across families)"
+    (let [trace [{:id 1 :operation :rf.resource/work-started :time 100
+                  :tags {:work-id [:rf.work/resource :k 2]}}
+                 {:id 2 :operation :rf.http/aborted-on-actor-destroy :time 110
+                  :tags {:work-id [:rf.work/http :req 5] :reason :actor-destroyed}}]
+          live  (re/live-work ledger trace)
+          by-id (into {} (map (juxt :work-id identity)) live)]
+      (is (= :issued (:latest-phase (get by-id [:rf.work/resource :k 2]))))
+      (is (= :rf.resource/work-started (:latest-op (get by-id [:rf.work/resource :k 2]))))
+      (is (= :cancel-requested (:latest-phase (get by-id [:rf.work/http :req 5]))))))
+  (testing "the single-arity form returns live rows without the trace join"
+    (let [live (re/live-work ledger)]
+      (is (every? #(not (contains? % :latest-phase)) live))))
+  (testing "latest-phase-by-work-id keeps the MOST-RECENT phase per work id"
+    (let [trace [{:id 1 :operation :rf.resource/work-started :time 100
+                  :tags {:work-id [:rf.work/resource :k 2]}}
+                 {:id 2 :operation :rf.resource/work-abort-requested :time 200
+                  :tags {:work-id [:rf.work/resource :k 2] :reason :superseded}}]
+          idx   (re/latest-phase-by-work-id trace)]
+      (is (= :cancel-requested (:phase (get idx [:rf.work/resource :k 2])))))))
+
+;; ---------------------------------------------------------------------------
+;; live? predicate — the non-terminal ledger statuses.
+;; ---------------------------------------------------------------------------
+
+(deftest live?-predicate
+  (is (re/live? :running))
+  (is (re/live? :queued))
+  (is (re/live? :abort-requested))
+  (is (not (re/live? :completed)))
+  (is (not (re/live? :suppressed)))
+  (is (not (re/live? :cancelled))))


### PR DESCRIPTION
Gives Xray + the trace tooling **ONE work/reply vocabulary** across all async families, reading the canonical EP-0011 reply-envelope facts (`spec/Managed-Effects.md` §The uniform reply envelope + §Tracing) rather than per-family private callback shapes. Implements **rf2-zqefg3.7**.

## What Xray now reads from the envelope

New consumer-side mirror `tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc` (pure data, JVM-runnable; Xray does **not** require the substrate — the closed vocabularies are mirrored as literal data, pinned by the wiring test):

- **Closed vocabularies** — `reply-statuses` (`:ok`/`:partial`/`:error`/`:cancelled`/`:stale`), `work-statuses`, `work-kinds` — mirrored from `re-frame.reply`.
- **`reply-row`** — any family's reply map (the appended `:rf/reply-to` last-arg, or a `:rf.http/replied` / `:rf.reply/*` trace summary) → ONE render-safe row keyed on `:work/id`, reading issuance/completion **status**, **stale-suppression** (carried+current correlation), **cancellation**, and **delivery-or-explicit-non-delivery** (`:delivered? false` for a suppressed `:stale` reply). Wire slots summarized (already elided on the wire).
- **`phase-of`** — every family's emitted trace op lowers onto ONE reply-envelope phase: `:issued` / `:retry` / `:cancel-requested` / `:completed` / `:stale-suppressed` / `:delivered`. Explicit table over the **landed** literals (`:rf.resource/work-started`, `:rf.http/replied`, `:rf.http/retry-attempt`, `:rf.resource/stale-suppressed`, `:rf.reply/suppressed`, …) + a name-suffix heuristic so a not-yet-enumerated family op (future `:rf.stream/*`) is still classified.
- **`status->class`** — one cross-surface colour class, so a `:stale` HTTP reply and a `:stale` resource reply render the **same** badge (Cross-Cutting F.11).
- **"What is still running?"** — `live-work` reads the live (non-terminal) work-ledger rows joined to the **latest reply-envelope trace phase** per `:work/id`, **uniform across HTTP / resources / mutations / routing / machines / timers** (F-C4); `live-work-tally-by-kind` is the headline count.
- **The stale-races view keys on `:work/id`** — `races-by-work-id` groups every cross-family work/reply row into an attempt arc (`:phases` / `:terminal-status` / `:suppressed?`); `stale-suppressions` + `stale-tally-by-kind` give the cross-surface tally (F-C5).

The resources composite (`:rf.xray/resources-tab-data`) now carries the uniform `:live-work` / `:stale-races` / `:stale-tally` slots alongside the resource-specific surfaces. Resources is the only ledger writer today; as the other families write their own ledger rows + emit reply-envelope trace ops, these surfaces pick them up with **no panel change** — one vocabulary, many families.

## Spec

Per the xray-specs-kept-current rule, `tools/xray/spec/*` updated in the same PR:
- `013-Trace-Consumer.md` — new §One work/reply vocabulary — reading the uniform reply envelope (the consumer contract).
- `024-Resources-Panel.md` — composite sub-table row + a cross-ref subsection pointing to 013 as the owning contract.

## Test deltas

- **New** `tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc` — 12 deftests covering the closed vocabularies (mirror pinned), work-id/kind readers + tuple-head inference (incl. the `:mutation` distinction), `reply-row` across all five statuses + PRIVACY + `:delivered?` derivation, the cross-surface status presentation, `phase-of` across families + the suffix heuristic, `work-event-row`/`project-work-events`, stale-races keyed on `:work/id`, and the `live-work` ledger+trace join.

## Quality gates

- `clojure -M:test` in `tools/xray/` — **1121 tests, 4889 assertions, 0 failures, 0 errors** (was 1100-ish; +21 reply-envelope assertions across 12 new deftests).
- `npm run test:cljs` (consolidated node CLJS build — compiles `resources.cljs`'s new require + the `.cljc` under CLJS reader conditionals) — **6456 tests, 23484 assertions, 0 failures, 0 errors**.
- `mkdocs build --strict` — built successfully (the edited `tools/xray/spec/*` are internal artefact spec, not in the published nav; build confirmed green regardless).

Fence respected: changes confined to `tools/xray/` + `tools/xray/spec/` + xray tests. No `implementation/` or other-spec edits (bundle isolation: Xray consumes the wire facts, never requires the substrate). No AI attribution.
