### PR TITLE
feat(resources): EP-0010 durable timestamps from causal world inputs (6 beads)

### DIFF
--- a/implementation/core/src/re_frame/interop.clj
+++ b/implementation/core/src/re_frame/interop.clj
@@ -170,7 +170,22 @@
 
 ;; ---- clock ----------------------------------------------------------------
 
-(defn now-ms []
+(defn now-ms
+  "Clock for ELAPSED measurement (trace / perf timing spans, machines timer
+  relative delays). On the JVM this is already `System/currentTimeMillis`
+  (epoch ms) — but the CLJS counterpart is `performance.now()` (origin-
+  relative), so durable wall-clock facts MUST use `epoch-now-ms`, never this,
+  to stay cross-platform (rf2-n1rh0f / EP-0010 §Time)."
+  []
+  (System/currentTimeMillis))
+
+(defn epoch-now-ms
+  "Wall-clock epoch milliseconds — the canonical source for EP-0010 durable
+  causal time (`:rf.world/inputs` `:time-ms`). On the JVM this coincides with
+  `now-ms`; the CLJS counterpart diverges (`performance.now()` vs
+  `js/Date.now()`), which is why durable timestamps read this dedicated
+  surface."
+  []
   (System/currentTimeMillis))
 
 ;; ---- queue primitives -----------------------------------------------------

--- a/implementation/core/src/re_frame/interop.cljs
+++ b/implementation/core/src/re_frame/interop.cljs
@@ -108,10 +108,26 @@
 
 ;; ---- clock ----------------------------------------------------------------
 
-(defn now-ms []
+(defn now-ms
+  "Monotonic-ish high-resolution clock for ELAPSED measurement (trace / perf
+  timing spans, machines timer relative delays). On CLJS this is
+  `performance.now()` when available — a high-resolution timestamp relative
+  to the page/worker origin, NOT epoch wall-clock. Do NOT use it for durable
+  wall-clock facts; use `epoch-now-ms` (rf2-n1rh0f / EP-0010 §Time)."
+  []
   (if (and (exists? js/performance) (exists? js/performance.now))
     (js/performance.now)
     (js/Date.now)))
+
+(defn epoch-now-ms
+  "Wall-clock epoch milliseconds. The canonical source for EP-0010 durable
+  causal time (`:rf.world/inputs` `:time-ms`, EP-0010 §Time — \"wall-clock
+  epoch milliseconds\"). DISTINCT from `now-ms`: that is `performance.now()`
+  (origin-relative, for elapsed measurement) on CLJS, which is NOT comparable
+  with `js/Date`-based freshness checks. A durable timestamp folded from this
+  value is wall-clock-meaningful and serializable across hosts."
+  []
+  (js/Date.now))
 
 ;; ---- queue primitives -----------------------------------------------------
 

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -132,8 +132,9 @@
     :rf.world/inputs    EP-0010 causal world-input map (Spec 002 §The
                         World-Input Rule). The router ensures it exists
                         and carries `:time-ms` (epoch-ms wall clock)
-                        stamped from `interop/now-ms` HERE — the causal
-                        boundary — UNLESS the caller supplied a map, in
+                        stamped from `interop/epoch-now-ms` HERE — the
+                        causal boundary — UNLESS the caller supplied a map,
+                        in
                         which case it is preserved and only the missing
                         framework-required `:time-ms` is filled. This is
                         the durable causal-time contract: the read happens
@@ -187,13 +188,21 @@
         ;; Unlike `:dispatch-id` / the retired `:dispatched-at`, this is
         ;; NOT dev-gated: world inputs are DURABLE causal data, not a
         ;; diagnostic, so `:time-ms` must be present in production too
-        ;; (durable writes depend on it). The cost is one `now-ms` read +
-        ;; a small map on the dispatch path — the price of a deterministic
+        ;; (durable writes depend on it). The cost is one `epoch-now-ms` read
+        ;; + a small map on the dispatch path — the price of a deterministic
         ;; fold.
+        ;;
+        ;; rf2-n1rh0f: `:time-ms` is WALL-CLOCK EPOCH ms (EP-0010 §Time), so
+        ;; it is read from `interop/epoch-now-ms`, NOT `interop/now-ms`. On
+        ;; CLJS `now-ms` is `performance.now()` (origin-relative, for elapsed
+        ;; measurement) — a durable timestamp folded from it would be
+        ;; incomparable with `js/Date`-based freshness checks (resource
+        ;; `:stale-at`, invalidation, etc.). `epoch-now-ms` is `js/Date.now()`
+        ;; / `System/currentTimeMillis`, wall-clock-meaningful on both hosts.
         supplied-world     (:rf.world/inputs opts)
         world-inputs       (if (contains? supplied-world :time-ms)
                              supplied-world
-                             (assoc supplied-world :time-ms (interop/now-ms)))
+                             (assoc supplied-world :time-ms (interop/epoch-now-ms)))
         ;; Per rf2-jbzhj: surface unrecognised opts keys (typically a typo'd
         ;; opt like `:fram` for `:frame`) rather than silently swallowing
         ;; them. Emitted HERE — BEFORE the frame resolution below — so a

--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -257,12 +257,25 @@
   discriminate HTTP-completion cascades from user-origin events.
   Per rf2-1ve9h (Mike-approved 2026-05-28) the prior parallel
   `:rf/dispatch-origin :http` was collapsed — `:source :http` is now
-  the single axis."
+  the single axis.
+
+  EP-0010 (rf2-n1rh0f / rf2-40dqi6 / rf2-r65m41): the reply is a CAUSAL
+  TOKEN, and the host completion time (`:completed-at`, read ONCE at
+  finalisation in `reply-ctx`) is carried as the reply dispatch's
+  `:rf.world/inputs` `:time-ms`. The router PRESERVES a supplied
+  `:rf.world/inputs` that already carries `:time-ms` (it only fills a
+  missing one), so a reply reducer deriving a durable timestamp reads it
+  off the reply event's world inputs — the causal completion fact, never
+  a fresh ambient clock read in the handler. When `completed-at` is absent
+  (a synthetic / canned reply with no host clock read), the router stamps
+  the dispatch time as usual."
   [args frame]
   (when-let [ev (build-reply-event args)]
     (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
       (dispatch! ev (cond-> {:source :http}
-                      frame (assoc :frame frame))))))
+                      frame                  (assoc :frame frame)
+                      (:completed-at args)   (assoc :rf.world/inputs
+                                                    {:time-ms (:completed-at args)}))))))
 
 (defn build-reply-event
   "Per Spec 014 §Reply addressing. Returns the event vector to dispatch,

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -434,11 +434,13 @@
      path, which always produces a `:middleware-ctx` via
      `run-request-chain` and therefore always runs the `:after` chain.
 
-  `opts` carries `:frame`, `:middleware-ctx`, and the three keys
+  `opts` carries `:frame`, `:middleware-ctx`, the three keys
   `dispatch-reply-via-late-bind!` consumes (`:origin-event`,
-  `:explicit-on`, `:kind`). No-op when the router is absent / the reply
-  is silenced (delegated to `dispatch-reply-via-late-bind!`)."
-  [{:keys [frame middleware-ctx origin-event explicit-on reply-payload kind]}]
+  `:explicit-on`, `:kind`), and the EP-0010 `:completed-at` causal
+  completion time threaded onto the reply dispatch's `:rf.world/inputs`
+  (rf2-n1rh0f). No-op when the router is absent / the reply is silenced
+  (delegated to `dispatch-reply-via-late-bind!`)."
+  [{:keys [frame middleware-ctx origin-event explicit-on reply-payload kind completed-at]}]
   (let [final-payload (if middleware-ctx
                         (run-after-chain! frame middleware-ctx reply-payload)
                         reply-payload)]
@@ -446,5 +448,6 @@
       {:origin-event  origin-event
        :explicit-on   explicit-on
        :reply-payload final-payload
-       :kind          kind}
+       :kind          kind
+       :completed-at  completed-at}
       frame)))

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -63,7 +63,7 @@
   unchanged — the chain's contract is to see the `:before`'s ctx, not a
   synthesised one."
   [{:keys [origin-event explicit-on-success explicit-on-failure
-           kind reply-payload frame middleware-ctx]}]
+           kind reply-payload frame middleware-ctx completed-at]}]
   (let [explicit (case kind
                    :success explicit-on-success
                    :failure explicit-on-failure)]
@@ -78,7 +78,11 @@
        :origin-event   origin-event
        :explicit-on    explicit
        :reply-payload  reply-payload
-       :kind           kind})))
+       :kind           kind
+       ;; EP-0010 (rf2-n1rh0f): the host completion time rides the reply
+       ;; dispatch's `:rf.world/inputs` `:time-ms` so a reply reducer reads
+       ;; it as causal data, never a fresh clock.
+       :completed-at   completed-at})))
 
 ;; rf2-zqefg3.2 — the canonical-reply lowering seam (EP-0011 §Managed HTTP
 ;; Lowering). Every completion (success / failure / abort) now flows through
@@ -211,7 +215,8 @@
     (emit-reply-trace! ctx reply)
     (dispatch-reply! (assoc ctx
                             :kind          :failure
-                            :reply-payload (http-reply/reply->public-payload reply)))))
+                            :reply-payload (http-reply/reply->public-payload reply)
+                            :completed-at  (:completed-at reply)))))
 
 (defn- dispatch-success!
   "Dispatch a `:success` reply carrying `value` as its `:value` slot.
@@ -227,7 +232,8 @@
     (emit-reply-trace! ctx reply)
     (dispatch-reply! (assoc ctx
                             :kind          :success
-                            :reply-payload (http-reply/reply->public-payload reply)))))
+                            :reply-payload (http-reply/reply->public-payload reply)
+                            :completed-at  (:completed-at reply)))))
 
 (defn- dispatch-aborted!
   "Emit the `:rf.http/aborted` trace + dispatch the abort reply for a

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -133,7 +133,8 @@
   SETTLED fresh `:loaded` entry.
 
   Returns the event-fx map `{:rf.db/runtime :fx}`."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, gen-snapshot :rf.resource/generation}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, gen-snapshot :rf.resource/generation
+    world :rf.world/inputs}
    {:keys [resource params owner cause keep-previous?] :as payload} {:keys [force-new? where]}]
   (let [runtime-db (or rt {})
         spec       (registry/require-resource-spec! resource where)
@@ -281,8 +282,15 @@
             ;; and supersede/abort each other's in-flight request. Qualifying
             ;; with the frame id isolates them.
             request-id (work-ledger/managed-request-id frame-id work-id)
-            now        (now-ms)
-            deadline   (when-let [ms (:timeout-ms spec)] (+ now ms))
+            ;; EP-0010 §Resources, Mutations, And Work-Ledger Timestamps: the
+            ;; durable work-ledger `:started-at` is the TRIGGERING TOKEN'S
+            ;; `:time-ms` (the causal world input the router stamped once at
+            ;; the dispatch boundary), and `:deadline-at` is computed from it
+            ;; plus the configured timeout policy — NOT an ambient clock read
+            ;; in the reducer. Replay-stable: the same ensure/refetch token
+            ;; mints the same `:started-at` / `:deadline-at`.
+            started-at (:time-ms world)
+            deadline   (when-let [ms (:timeout-ms spec)] (+ started-at ms))
             entry'     (cond-> (state/entry-start-load
                                  entry {:generation generation :work-id work-id
                                         :request-id request-id :owner owner})
@@ -303,7 +311,7 @@
                           :transport    transport-id
                           :owner        owner
                           :cause        cause
-                          :started-at   now
+                          :started-at   started-at
                           :deadline-at  deadline})
             rdb'       (-> runtime-db
                            (assoc-in (state/entry-path scoped-key) entry')
@@ -583,7 +591,7 @@
   `:matched` (the matched keys), `:any-tag-match-other-scope?` (whether the
   tags match an entry in ANOTHER scope — \"no match HERE\" vs \"no resource
   provides this tag in any scope\"), so Xray can tell the two apart."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
    [_event-id {:keys [scope tags cause cross-scope?]}]]
   (let [runtime-db (or rt {})
         ;; FAIL CLOSED (rf2-pvdae1): a scoped (default) invalidation MUST
@@ -614,7 +622,13 @@
         cscope     (when (some? scope)
                      (state/canonicalize-scope scope 'rf.resource/invalidate-tags nil))
         tag-set    (set tags)
-        invalidated-at (now-ms)
+        ;; EP-0010 §Resources, Mutations, And Work-Ledger Timestamps: the
+        ;; durable `:invalidated-at` written by an invalidation event is that
+        ;; EVENT'S `:time-ms` (the causal world input the router stamped once
+        ;; at the dispatch boundary), NOT an ambient clock read in the
+        ;; reducer. Replay-stable: re-running the same invalidation token
+        ;; rewrites the SAME `:invalidated-at`.
+        invalidated-at (:time-ms world)
         entries    (get-in runtime-db (state/entries-path))
         tags-hit?  (fn [entry] (seq (set/intersection (set (:tags entry)) tag-set)))
         in-scope?  (fn [k] (or cross-scope? (= cscope (first k))))

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -993,16 +993,26 @@
   transport appends `{:kind :success :value <decoded-data>}` as the last arg
   (Spec 014 §Reply addressing); the decoded data is read from there
   (`reply-success-data`) and re-lifted into the canonical `:value`."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
    [_event-id {work-id :work/id :keys [resource-key generation] :as payload} http-result]]
   (let [runtime-db (or rt {})
         value      (reply-success-data payload http-result)
+        ;; EP-0010 §Managed Effects And Reply Tokens / §Resources, Mutations,
+        ;; And Work-Ledger Timestamps: the reply is a CAUSAL TOKEN. The host
+        ;; completion time (`:completed-at`, read ONCE at the transport
+        ;; finalisation boundary) rides the reply event's `:rf.world/inputs`
+        ;; `:time-ms` — the reply handler MUST NOT re-read the clock. It is
+        ;; carried onto the canonical reply map as `:completed-at` (the
+        ;; uniform-reply spelling) and is the source of the durable
+        ;; `:loaded-at`.
+        completed-at (:time-ms world)
         ;; the ONE canonical reply map every managed-async family produces
         ;; (Managed-Effects §The uniform reply envelope). The internal
         ;; resource reply target receives it DIRECTLY (no public `{:kind …}`
         ;; reshape). The decoded result is `:value` (EP-0007 / kh9jz6).
         reply      (rreply/success-reply payload value
-                                         {:work-kind rreply/work-kind-resource})
+                                         {:work-kind rreply/work-kind-resource
+                                          :completed-at completed-at})
         entry      (live-entry-for-reply runtime-db frame-id payload)]
     (if (nil? entry)
       ;; STALE SUPPRESSION (mandatory): a superseded / vanished reply never
@@ -1022,7 +1032,12 @@
             ;; `:data` (the entry layer's spelling of the same fact — the
             ;; reply-map spelling is `:value`, kh9jz6 / EP-0007).
             data      (:value reply)
-            loaded-at (now-ms)
+            ;; EP-0010 §Resources, Mutations, And Work-Ledger Timestamps:
+            ;; resource `:loaded-at` IS the successful reply's completion time
+            ;; (`(:completed-at reply)`, carried on the reply token), and
+            ;; `:stale-at` is computed from it + the resource's
+            ;; `:stale-after-ms` policy — never an ambient clock read here.
+            loaded-at (:completed-at reply)
             stale-at  (stale-at-for spec loaded-at)
             ;; arm the advisory stale / GC timers from the resource's policy
             ;; (Spec 016 §Stale and GC scheduling). The DELAYS are relative

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -72,14 +72,16 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- shared clock ---------------------------------------------------------
-
-(defn- now-ms
-  "Current epoch-ms — `:started-at` / `:settled-at` durable timestamps + the
-  patch / populate `:loaded-at`. Host-platform clock."
-  []
-  #?(:clj  (System/currentTimeMillis)
-     :cljs (.now js/Date)))
+;; ---- durable timestamps ---------------------------------------------------
+;;
+;; EP-0010: every durable mutation timestamp is a causal world input — the
+;; instance / work-ledger `:started-at` is the `:rf.mutation/execute` token's
+;; `:time-ms` (rf2-dsyqmz); the terminal `:settled-at` + any patch / populate
+;; `:loaded-at` is the reply token's completion time (`:completed-at`, carried
+;; on the reply event's `:rf.world/inputs`, rf2-40dqi6 / rf2-r65m41). No
+;; ambient clock is read at a durable write site, so this ns no longer defines
+;; a `now-ms` helper (the remaining timer DELAYS are advisory host transients
+;; computed from the durable absolute timestamps).
 
 (defn- stale-at-for
   "Compute `:stale-at` for a patched / populated resource entry from
@@ -474,14 +476,23 @@
   (the instance-layer spelling — kh9jz6 / EP-0007).
 
   Event shape: `[_ <verification-payload> <http-result>]`."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
    [_event-id {work-id :work/id :keys [instance-id mutation-id generation scope] :as payload} http-result]]
   (let [runtime-db (or rt {})
+        ;; EP-0010 §Managed Effects And Reply Tokens / §Resources, Mutations,
+        ;; And Work-Ledger Timestamps: the reply is a CAUSAL TOKEN; the host
+        ;; completion time (`:completed-at`, read ONCE at the transport
+        ;; finalisation boundary) rides the reply event's `:rf.world/inputs`
+        ;; `:time-ms`. The handler MUST NOT re-read the clock. It carries onto
+        ;; the canonical reply as `:completed-at` and is the source of the
+        ;; terminal `:settled-at` + any patch/populate `:loaded-at`.
+        completed-at (:time-ms world)
         ;; the ONE canonical reply map (Managed-Effects §The uniform reply
         ;; envelope), `:work/kind :mutation`. The internal mutation reply
         ;; target receives it directly; the decoded result is `:value`.
         reply      (rreply/success-reply payload (reply-success-result payload http-result)
-                                         {:work-kind rreply/work-kind-mutation})
+                                         {:work-kind rreply/work-kind-mutation
+                                          :completed-at completed-at})
         result     (:value reply)
         inst       (live-instance-for-reply runtime-db payload)]
     (if (nil? inst)
@@ -498,7 +509,11 @@
       (let [spec        (mreg/mutation-meta mutation-id)
             params      (:params inst)
             timing      (or (:invalidate-timing spec) :after-success)
-            clock-ms    (now-ms)
+            ;; EP-0010: the terminal mutation reply writes `:settled-at` from
+            ;; the reply completion time, and ANY resource patch/populate
+            ;; `:loaded-at` produced by the mutation uses that SAME causal
+            ;; completion time (off the reply token, never an ambient read).
+            clock-ms    completed-at
             ;; 1. controlled patch / populate (BEFORE invalidation). Each
             ;; arm also returns the per-key advisory stale / GC timer policy
             ;; (the third value) so this handler arms timers exactly as the
@@ -580,14 +595,23 @@
   `:error` stores) is read back from the canonical reply.
 
   Event shape: `[_ <verification-payload> <http-result>]`."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
    [_event-id {work-id :work/id :keys [instance-id mutation-id generation scope] :as payload} http-result]]
   (let [runtime-db (or rt {})
+        ;; EP-0010 §Managed Effects And Reply Tokens / §Resources, Mutations,
+        ;; And Work-Ledger Timestamps: a terminal mutation reply writes
+        ;; `:settled-at` from the reply completion time. The host
+        ;; `:completed-at` (read ONCE at the transport finalisation boundary)
+        ;; rides the reply event's `:rf.world/inputs` `:time-ms`; the handler
+        ;; MUST NOT re-read the clock. Carried onto the canonical reply as
+        ;; `:completed-at`.
+        completed-at (:time-ms world)
         ;; the ONE canonical reply map (Managed-Effects §The uniform reply
         ;; envelope), `:work/kind :mutation`. `:error` carries the closed
         ;; `:rf.http/*` envelope the instance `:error` also stores.
         reply      (rreply/failure-reply payload (reply-failure-error payload http-result)
-                                         {:work-kind rreply/work-kind-mutation})
+                                         {:work-kind rreply/work-kind-mutation
+                                          :completed-at completed-at})
         error      (:error reply)
         inst       (live-instance-for-reply runtime-db payload)]
     (if (nil? inst)
@@ -601,7 +625,10 @@
       (let [spec     (mreg/mutation-meta mutation-id)
             params   (:params inst)
             timing   (or (:invalidate-timing spec) :after-success)
-            clock-ms (now-ms)
+            ;; EP-0010: the terminal failure reply writes `:settled-at` from
+            ;; the reply completion time (off the reply token, never a fresh
+            ;; ambient read).
+            clock-ms completed-at
             ;; failure-time invalidation (only when the timing opts in):
             ;; some mutations invalidate on failure to force a re-read of
             ;; the authoritative server state after a rejected write.

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -242,7 +242,8 @@
   request is lowered (a rare timing for pessimistic stale-then-write).
 
   Returns the event-fx map (`:rf.db/runtime` + `:fx`)."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, gen-snapshot :rf.resource/generation}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, gen-snapshot :rf.resource/generation
+    world :rf.world/inputs}
    [_event-id {:keys [mutation params instance scope cause] :as _payload}]]
   (let [where      'rf.mutation/execute
         runtime-db (or rt {})
@@ -271,7 +272,13 @@
         ;; would collide on a bare work-id and abort/supersede each other's
         ;; in-flight write. Qualifying with the frame id isolates them.
         request-id (work-ledger/managed-request-id frame-id work-id)
-        now        (now-ms)
+        ;; EP-0010 §Resources, Mutations, And Work-Ledger Timestamps:
+        ;; `:rf.mutation/execute` writes the durable instance + work-ledger
+        ;; `:started-at` from the TRIGGERING TOKEN'S `:time-ms` (the causal
+        ;; world input the router stamped once at the dispatch boundary), NOT
+        ;; an ambient clock read in the reducer. Replay-stable: the same
+        ;; execute token mints the same `:started-at`.
+        started-at (:time-ms world)
         transport-id (or (:transport spec) transport/default-transport)
         ;; the mutation's :request returns the Spec 014 managed-HTTP args
         ;; (the causal write); the runtime owns reply addressing.
@@ -283,7 +290,7 @@
         instance'  (mstate/empty-instance
                      mutation instance-id
                      {:scope cscope :params cparams :cause cause
-                      :generation generation :work-id work-id :started-at now})
+                      :generation generation :work-id work-id :started-at started-at})
         record     (-> (work-ledger/work-record
                          {:work-id      work-id
                           :frame-id     frame-id
@@ -291,7 +298,7 @@
                           :generation   generation
                           :transport    transport-id
                           :cause        cause
-                          :started-at   now})
+                          :started-at   started-at})
                        ;; the work record's neutral :work/kind for a mutation
                        ;; attempt (the ledger is named neutrally; the resource
                        ;; writer uses :resource, the mutation writer :mutation).

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -165,6 +165,35 @@
       (is (some? (:invalidated-at (entry ka))) "scope A entry marked stale")
       (is (some? (:invalidated-at (entry kb))) "scope B entry ALSO marked stale"))))
 
+(deftest invalidate-tags-invalidated-at-is-the-event-time-ms
+  ;; rf2-258p1z / EP-0010 §Resources, Mutations, And Work-Ledger Timestamps:
+  ;; the durable :invalidated-at is the INVALIDATION EVENT'S :time-ms (the
+  ;; causal world input), NOT an ambient clock read in the reducer. Scripting
+  ;; the dispatch's :rf.world/inputs pins the value; replaying the SAME token
+  ;; rewrites the SAME :invalidated-at (replay-stable, not the live clock).
+  (rf/reg-resource :ivt/article (article-spec))
+  (let [sa {:user "a"}
+        ka (state/scoped-resource-key sa :ivt/article {:slug "w"})
+        t1 1781078400123
+        t2 1781078999999]
+    (ensure! :ivt/article sa "w" [:lease :a 1])
+    (succeed! ka {:title "A"})
+    (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :a 1]}])
+    (rf/dispatch-sync [:rf.resource/invalidate-tags
+                       {:scope sa :tags #{[:article "w"]}}]
+                      {:rf.world/inputs {:time-ms t1}})
+    (testing ":invalidated-at is EXACTLY the supplied token :time-ms (not now)"
+      (is (= t1 (:invalidated-at (entry ka)))))
+    ;; re-invalidate with a DIFFERENT scripted time — the durable fact tracks
+    ;; the causal token, so it moves to the new token's :time-ms (proving it
+    ;; is read off the token, not a fresh clock read).
+    (rf/dispatch-sync [:rf.resource/invalidate-tags
+                       {:scope sa :tags #{[:article "w"]}}]
+                      {:rf.world/inputs {:time-ms t2}})
+    (testing "replaying with a new scripted token rewrites :invalidated-at to
+              that token's :time-ms (read off the token, not the clock)"
+      (is (= t2 (:invalidated-at (entry ka)))))))
+
 ;; ---- rf2-pvdae1: scoped invalidate-tags fails closed without a scope -------
 ;; The re-frame event loop catches a handler throw and surfaces it as
 ;; :rf.error/handler-exception (it does NOT rethrow to dispatch-sync's

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -198,6 +198,21 @@
       (testing "the app :request body passes through unchanged"
         (is (= {:method :put :url "/api/articles/w" :body {:slug "w"}} (:request args)))))))
 
+(deftest execute-started-at-from-token-time-ms
+  ;; rf2-dsyqmz / EP-0010 §Resources, Mutations, And Work-Ledger Timestamps:
+  ;; :rf.mutation/execute writes the durable instance :started-at from the
+  ;; TRIGGERING TOKEN'S :time-ms (the causal world input), NOT an ambient
+  ;; clock read in the reducer. Scripting the dispatch's :rf.world/inputs
+  ;; pins it; the same execute token mints the same :started-at
+  ;; (replay-stable).
+  (rf/reg-mutation :m/save (save-article-spec))
+  (let [t1 1781078400123]
+    (rf/dispatch-sync [:rf.mutation/execute
+                       {:mutation :m/save :params {:slug "w"} :instance :st/save-1}]
+                      {:rf.world/inputs {:time-ms t1}})
+    (testing "the instance :started-at is EXACTLY the token :time-ms (not now)"
+      (is (= t1 (:started-at (instance :st/save-1)))))))
+
 (deftest execute-generates-instance-id-when-absent
   (rf/reg-mutation :m/save (save-article-spec))
   (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"}}])

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -95,11 +95,16 @@
   ([frame-id scoped-key]
    (get-in (runtime-db frame-id) (state/entry-path scoped-key))))
 
-(defn- reply-success! [args result]
-  (rf/dispatch-sync (conj (:on-success args) {:kind :success :value result})))
+(defn- reply-success!
+  ([args result] (rf/dispatch-sync (conj (:on-success args) {:kind :success :value result})))
+  ;; EP-0010: a fixture may script the reply token's :rf.world/inputs to pin
+  ;; the host :completed-at (the managed transport stamps it on the reply
+  ;; dispatch in live code).
+  ([args result opts] (rf/dispatch-sync (conj (:on-success args) {:kind :success :value result}) opts)))
 
-(defn- reply-failure! [args failure]
-  (rf/dispatch-sync (conj (:on-failure args) {:kind :failure :failure failure})))
+(defn- reply-failure!
+  ([args failure] (rf/dispatch-sync (conj (:on-failure args) {:kind :failure :failure failure})))
+  ([args failure opts] (rf/dispatch-sync (conj (:on-failure args) {:kind :failure :failure failure}) opts)))
 
 (defn- save-article-spec
   ([] (save-article-spec {}))
@@ -316,6 +321,51 @@
         (is (nil? (:invalidated-at e)) "patch freshened the entry")))
     (testing "the affected-keys trace reservation records the patched key"
       (is (= [rkey] (:affected-keys (instance :p1)))))))
+
+(deftest success-settled-at-and-populate-loaded-at-from-reply-completed-at
+  ;; rf2-40dqi6 / EP-0010 §Resources, Mutations: a terminal mutation success
+  ;; reply writes the instance :settled-at from the reply completion time,
+  ;; and ANY resource patch/populate :loaded-at the mutation produces uses
+  ;; that SAME causal completion time (off the reply token, never an ambient
+  ;; read in the handler). The host :completed-at rides the reply event's
+  ;; :rf.world/inputs :time-ms; scripting it pins both.
+  (rf/reg-resource :r/article
+                   {:scope :rf.scope/global
+                    :params-schema [:map [:slug :string]]
+                    :request (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}})
+                    :tags (fn [{:keys [slug]} _] #{[:article slug]})
+                    :stale-after-ms 60000})
+  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})
+        completed-at 1781078400456]
+    (rf/reg-mutation :m/save
+                     {:params-schema [:map [:slug :string]]
+                      :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+                      :populates (fn [_params result] {rkey result})})
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :ms1}])
+    (reply-success! @last-managed-args {:title "seed"} {:rf.world/inputs {:time-ms completed-at}})
+    (testing "the instance :settled-at is EXACTLY the reply completion time"
+      (is (= completed-at (:settled-at (instance :ms1)))))
+    (testing "the populated entry's :loaded-at is the SAME causal completion
+              time, and :stale-at = :loaded-at + :stale-after-ms"
+      (let [e (entry rkey)]
+        (is (= completed-at (:loaded-at e)))
+        (is (= (+ completed-at 60000) (:stale-at e)))))))
+
+(deftest failure-settled-at-from-reply-completed-at
+  ;; rf2-r65m41 / EP-0010 §Resources, Mutations + §Managed Effects: a terminal
+  ;; mutation FAILURE reply writes :settled-at from the reply completion time
+  ;; carried on the failure reply token — the handler MUST NOT re-read the
+  ;; clock. The host :completed-at rides the reply event's :rf.world/inputs
+  ;; :time-ms; scripting it pins :settled-at (replay-stable).
+  (rf/reg-mutation :m/save (save-article-spec))
+  (let [completed-at 1781078999999]
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :mf1}])
+    (reply-failure! @last-managed-args {:kind :rf.http/http-5xx :status 500}
+                    {:rf.world/inputs {:time-ms completed-at}})
+    (testing "the instance settles :error with :settled-at = the reply
+              completion time (not now)"
+      (is (= :error (:status (instance :mf1))))
+      (is (= completed-at (:settled-at (instance :mf1)))))))
 
 (deftest success-populates-resource-entry
   (rf/reg-resource :r/article

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -409,6 +409,32 @@
       (is (some? (:invalidated-at (entry scoped-key))) "durable fact set")
       (is (true? @(rf/subscribe [:rf.resource/stale? q]))))))
 
+(deftest succeeded-loaded-at-stale-at-from-reply-completed-at
+  ;; rf2-n1rh0f / EP-0010 §Resources, Mutations, And Work-Ledger Timestamps:
+  ;; the resource :loaded-at IS the successful reply's completion time
+  ;; (carried on the reply token as the host :completed-at, which the managed
+  ;; transport threads onto the reply event's :rf.world/inputs :time-ms), and
+  ;; :stale-at = :loaded-at + :stale-after-ms — NOT an ambient clock read in
+  ;; the reply handler. Scripting the reply dispatch's :rf.world/inputs pins
+  ;; both; the same reply token rewrites the same durable timestamps.
+  (rf/reg-resource :lra/article (article-spec {:stale-after-ms 60000}))
+  (let [scoped-key (state/scoped-resource-key :rf.scope/global :lra/article {:slug "w"})
+        completed-at 1781078400456]
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :lra/article :scope :rf.scope/global
+                                            :params {:slug "w"} :owner [:lease :lr 1]}])
+    (let [e (entry scoped-key)]
+      (rf/dispatch-sync [:rf.resource.internal/succeeded
+                         {:resource-key scoped-key :work/id (:current-work e)
+                          :generation (:generation e) :data {:title "W"}}]
+                        ;; the managed transport stamps the host :completed-at
+                        ;; here; a fixture scripts it directly on the reply
+                        ;; token's world inputs.
+                        {:rf.world/inputs {:time-ms completed-at}}))
+    (testing ":loaded-at is EXACTLY the reply completion time (not now)"
+      (is (= completed-at (:loaded-at (entry scoped-key)))))
+    (testing ":stale-at = :loaded-at + the :stale-after-ms policy"
+      (is (= (+ completed-at 60000) (:stale-at (entry scoped-key)))))))
+
 ;; ===========================================================================
 ;; 10. owner release / clear-scope / remove / tag invalidation
 ;; ===========================================================================

--- a/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
@@ -151,6 +151,40 @@
         (is (not (contains? r :promise)))
         (is (not (contains? r :abort-fn)))))))
 
+(deftest work-record-started-at-deadline-at-from-token-time-ms
+  ;; rf2-uuzj88 / EP-0010 §Resources, Mutations, And Work-Ledger Timestamps:
+  ;; the durable work-ledger `:started-at` is the TRIGGERING TOKEN'S
+  ;; `:time-ms` (the causal world input), and `:deadline-at` is
+  ;; `:started-at` + the configured `:timeout-ms` policy — NOT an ambient
+  ;; clock read in the reducer. Scripting the dispatch's `:rf.world/inputs`
+  ;; pins both; the same token mints the same row (replay-stable).
+  (rf/reg-resource :wlt/article (article-spec {:timeout-ms 5000}))
+  (let [scoped-key (state/scoped-resource-key :rf.scope/global :wlt/article {:slug "w"})
+        t1 1781078400123]
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :wlt/article :scope :rf.scope/global
+                        :params {:slug "w"} :owner [:route :r 1]}]
+                      {:rf.world/inputs {:time-ms t1}})
+    (let [r (record (:current-work (entry scoped-key)))]
+      (testing ":started-at is EXACTLY the triggering token :time-ms (not now)"
+        (is (= t1 (:started-at r))))
+      (testing ":deadline-at is :started-at + the :timeout-ms policy"
+        (is (= (+ t1 5000) (:deadline-at r))))))
+  ;; a resource declaring NO timeout policy has a nil :deadline-at, and its
+  ;; :started-at still tracks the token (replay-stable, no ambient read).
+  (rf/reg-resource :wlnt/article (article-spec))
+  (let [scoped-key (state/scoped-resource-key :rf.scope/global :wlnt/article {:slug "w"})
+        t2 1781079000000]
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :wlnt/article :scope :rf.scope/global
+                        :params {:slug "w"} :owner [:route :r 1]}]
+                      {:rf.world/inputs {:time-ms t2}})
+    (let [r (record (:current-work (entry scoped-key)))]
+      (testing ":started-at tracks the token even with no timeout policy"
+        (is (= t2 (:started-at r))))
+      (testing "no :timeout-ms policy => nil :deadline-at"
+        (is (nil? (:deadline-at r)))))))
+
 ;; ===========================================================================
 ;; 2. host handles live in the side table keyed by [frame-id work-id]
 ;; ===========================================================================


### PR DESCRIPTION
EP-0010 conversion cluster (audit rf2-x6xkhv): every durable resource / mutation / work-ledger timestamp now comes from a causal world input instead of an ambient `now-ms` read at the durable write site. Builds on the merged EP-0010 `:rf.world/inputs` core and the EP-0011 `.3` reply-map alignment.

## Beads

**Token-time (the load-causing / invalidation EVENT's `:rf.world/inputs :time-ms`):**
- **rf2-258p1z** — invalidate-tags `:invalidated-at` ← the invalidation event's `:time-ms`.
- **rf2-uuzj88** — work-ledger `:started-at` ← the ensure/refetch token's `:time-ms`; `:deadline-at` = `:started-at` + the `:timeout-ms` policy.
- **rf2-dsyqmz** — mutation instance + work-ledger `:started-at` ← the `:rf.mutation/execute` token's `:time-ms`.

**Reply-completion time (the reply token's host `:completed-at`):**
- **rf2-n1rh0f** — resource `:loaded-at` = the successful reply's `:completed-at`; `:stale-at` = `:loaded-at` + `:stale-after-ms`.
- **rf2-40dqi6** — mutation success `:settled-at` + any patch/populate `:loaded-at` = the reply `:completed-at`.
- **rf2-r65m41** — mutation failure `:settled-at` = the reply `:completed-at`.

## How the reply completion time reaches the handlers

The managed-HTTP transport reads the host completion clock once at finalisation (`reply-ctx`, the audit-blessed carrier) and now threads that `:completed-at` onto the **reply event's `:rf.world/inputs` `:time-ms`**. The router preserves a supplied `:rf.world/inputs` that already carries `:time-ms`, so the completion fact reaches the framework-internal resource/mutation reply handlers as causal data — **without changing the public Spec 014 `{:kind :success :value v}` payload** (unchanged; the pinned `reply->public-payload` tests still pass). The canonical reply map now also carries `:completed-at`, completing the `.3` plumbing.

## Core epoch-clock fix (root cause surfaced by this cluster)

The EP-0010 router stamped `:rf.world/inputs :time-ms` from `interop/now-ms`, which on **CLJS is `performance.now()`** — origin-relative, for elapsed measurement, NOT the wall-clock epoch ms EP-0010 §Time mandates. A durable timestamp folded from it was incomparable with `js/Date`-based freshness checks, so a freshly-loaded resource read as stale on CLJS. Added `interop/epoch-now-ms` (`js/Date.now()` / `System/currentTimeMillis`) and stamp `:time-ms` from it; `now-ms` stays the perf/timer clock. No spec change (the spec already mandates epoch ms — this makes the impl conform). JVM was already correct (`now-ms` = `currentTimeMillis`).

## Quality gates

- `npm run test:cljs` (full node-runtime CLJS suite): **6451 tests, 23349 assertions, 0 failures, 0 errors** (was 1 failure — `stale-sub-derives-from-facts` — before the epoch-clock fix; now green).
- resources artefact `clojure -M:test`: **249 tests, 937 assertions, 0 failures** (was 246; +3 replay-stability tests for the token-time beads, +3 for the reply beads — 6 new total across the suite).
- http artefact `clojure -M:test`: **395 tests, 1828 assertions, 0 failures** (carrier change; public payload unchanged).
- core artefact `clojure -M:test`: **1099 tests, 4796 assertions, 0 failures** (interop + router epoch-clock change).
- clj-kondo on changed files: 0 errors; the 4 warnings are all pre-existing (unused private `abort-failure?`, reader-conditional require-but-unused, `abort-signal` binding) — none introduced here.

## Tests added

Replay-stability tests prove each durable timestamp is **exactly** the scripted causal `:time-ms` / reply `:completed-at` (and the derived `:deadline-at` / `:stale-at` sums), never the live clock — i.e. the same token/reply re-applies to the same value.
