### PR TITLE
test(observability): EP-0008 catalogue<->channel conformance pin (rf2-sgz1zq)

### DIFF
--- a/implementation/core/test/re_frame/always_on_axis_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/always_on_axis_conformance_cljs_test.cljc
@@ -1,0 +1,238 @@
+(ns re-frame.always-on-axis-conformance-cljs-test
+  "EP-0008 / rf2-sgz1zq — the always-on EXERCISE leg of the channel
+  conformance pin. The companion catalogue-side leg lives in
+  `re-frame.error-catalogue-channel-conformance-test` (JVM; parses the
+  Spec 009 catalogue markdown).
+
+  Per Spec 009 §Error event catalogue: every `always-on` category MUST be
+  exercised through the `register-error-listener!` error-emit substrate in
+  at least one test, \"so promotion is real, not documentary.\" This file
+  is that exercise — DATA-DRIVEN over the full always-on set so it stays
+  green as categories are added (add the category to the catalogue +
+  `always-on-categories` below and it is automatically exercised here).
+
+  ## What this proves (and what it deliberately does NOT)
+
+  The bead asks that every always-on category be \"exercised through
+  `dispatch-on-error!` (the always-on axis) in at least one test.\" The
+  always-on axis IS `re-frame.error-emit/dispatch-on-error!` (and the
+  bounded-report sibling `dispatch-frame-teardown-report!` for the
+  frame-teardown row, per Spec 009 §Channel-promotion catalogue rows). So
+  this test drives EACH always-on category THROUGH that substrate fn and
+  asserts the `register-error-listener!` registry fans the record out
+  carrying that exact category.
+
+  This is the CONTRACT-level pin: it proves the always-on axis carries
+  every always-on category end-to-end (the fan-out, the category slot, the
+  production-survivable surface). It is intentionally NOT a re-derivation
+  of each real emit SITE — those per-site integration tests already exist
+  and are cross-referenced below (`on-error-test`, the per-category
+  `*_always_on_cljs_test` suites, the machines / flows artefact tests).
+  Re-driving every emit site here would duplicate that coverage and pull
+  the optional machines / flows / routing artefacts into the core test ns
+  for no added contract assurance. The axis is the thing this conformance
+  bead pins; the literal `always-on-categories` is held honest against the
+  catalogue by the JVM companion's
+  `parsed-always-on-set-equals-the-exercise-literal` test.
+
+  Dual-runtime: named `*_cljs_test.cljc` so the shadow-cljs `:node-test`
+  build (`npm run test:cljs`, `:ns-regexp \"cljs-test$\"`) AND the JVM
+  `clojure -M:test` runner both pick it up. `error-emit` is plain CLJC; no
+  DOM dependency."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [clojure.set :as set]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+;; ---------------------------------------------------------------------------
+;; The always-on set — the SINGLE literal this leg iterates.
+;;
+;; This set is PINNED against the Spec 009 catalogue's `always-on` rows by
+;; the JVM companion test
+;; (`re-frame.error-catalogue-channel-conformance-test/parsed-always-on-set-
+;; equals-the-exercise-literal`). Adding a category here without graduating
+;; it in the catalogue (or vice versa) fails that test. So this literal is
+;; not a fragile hand-maintained duplicate: the catalogue is authoritative
+;; and the companion enforces equality.
+;; ---------------------------------------------------------------------------
+
+(def always-on-categories
+  "Every `:rf.error/*` category Spec 009 §Error event catalogue marks
+  `always-on` — the production-survivable error-emit axis (surface #4).
+  Pinned == the parsed catalogue always-on set by the JVM companion."
+  #{:rf.error/handler-exception
+    :rf.error/coeffect-exception
+    :rf.error/interceptor-exception
+    :rf.error/machine-action-exception
+    :rf.error/fx-handler-exception
+    :rf.error/sub-exception
+    :rf.error/no-such-sub
+    :rf.error/sub-input-fn-exception
+    :rf.error/sub-input-fn-bad-return
+    :rf.error/no-such-handler
+    :rf.error/no-frame-context
+    :rf.error/override-fallthrough
+    :rf.error/reserved-fx-override
+    :rf.error/no-such-fx
+    :rf.error/no-such-cofx
+    :rf.error/frame-destroyed
+    :rf.error/write-after-destroy
+    :rf.error/flow-eval-exception
+    ;; The two-arg report fn (not dispatch-on-error!) carries this row —
+    ;; the bounded single-report idiom (Spec 009 §Channel-promotion
+    ;; catalogue rows). Exercised through its own report path below.
+    :rf.error/frame-teardown-failed
+    :rf.error/on-destroy-handler-exception})
+
+;; The frame-teardown report is the ONE always-on category that does NOT
+;; ride `dispatch-on-error!` (the per-event axis) — it rides the bounded
+;; `dispatch-frame-teardown-report!` sibling instead (Spec 009: one record
+;; per destroy carrying a `:hook-failures` vector, NOT one per item). The
+;; data-driven loop below routes it to the report fn; every other category
+;; goes through `dispatch-on-error!`.
+(def ^:private report-categories
+  #{:rf.error/frame-teardown-failed})
+
+;; ---------------------------------------------------------------------------
+;; Fixture — fresh registrar + plain-atom adapter per test; the always-on
+;; error-listener registry (a `defonce` atom) cleared so a listener from one
+;; test cannot leak into the next.
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (error-emit/clear-error-listeners!))}))
+
+;; ---------------------------------------------------------------------------
+;; Per-category driver: push ONE record for `cat` through the always-on
+;; axis. The teardown-report row uses its bounded-report fn; every other
+;; category uses `dispatch-on-error!` (the per-event always-on surface).
+;; ---------------------------------------------------------------------------
+
+(defn- drive-category!
+  "Surface one always-on record for `cat` through the always-on substrate.
+  Returns nil. The exact payload is not the contract under test here (the
+  per-site integration tests pin payload shapes); this drives the category
+  through the axis so the listener fan-out can be asserted."
+  [cat]
+  (if (contains? report-categories cat)
+    ;; The bounded teardown report — a non-empty :hook-failures vector so
+    ;; the report fn does not short-circuit (it no-ops on empty).
+    (error-emit/dispatch-frame-teardown-report!
+      :conformance/frame
+      [{:hook :ssr/on-frame-destroyed
+        :exception (ex-info "teardown hook threw" {})
+        :where :safe-call-hook!}]
+      0)
+    ;; The per-event always-on axis. Arity:
+    ;; [error-kw event event-id frame-id exception elapsed-ms time].
+    (error-emit/dispatch-on-error!
+      cat
+      [:conformance/event]
+      :conformance/event
+      :conformance/frame
+      (ex-info "conformance" {})
+      0
+      0)))
+
+;; ===========================================================================
+;; The conformance pin: EVERY always-on category fans out through the
+;; corpus-wide `register-error-listener!` substrate.
+;; ===========================================================================
+
+(deftest every-always-on-category-fans-out-through-the-error-listener
+  (testing "Per Spec 009 §Error event catalogue (the rf2-sgz1zq pin):
+            every catalogued `always-on` category is exercised through the
+            `register-error-listener!` substrate — proving promotion is
+            real, not documentary. Data-driven over the full
+            `always-on-categories` set (pinned == the catalogue's
+            always-on rows by the JVM companion), so it stays green as
+            categories are added: each new always-on category is driven
+            through the axis the moment it joins the set."
+    (let [seen (atom #{})]
+      (rf/register-error-listener!
+        :conformance/recorder
+        (fn [record] (swap! seen conj (:error record))))
+      (doseq [cat always-on-categories]
+        (drive-category! cat))
+      ;; Every always-on category must have appeared on the listener as the
+      ;; record's :error slot. A category that did NOT fan out (a substrate
+      ;; that dropped it, a report fn that short-circuited) is a gap.
+      (let [missing (set/difference always-on-categories @seen)]
+        (is (empty? missing)
+            (str "always-on categories that did NOT fan out through "
+                 "register-error-listener!: " (pr-str (sort missing)))))
+      (is (= always-on-categories @seen)
+          "the listener received EXACTLY the always-on set (no extras, no
+           gaps) — the always-on axis carries every always-on category"))))
+
+(deftest each-category-fans-out-exactly-once-and-carries-its-category
+  (testing "Per Spec 009: a single drive of category `cat` through the
+            always-on axis produces EXACTLY ONE listener record whose
+            `:error` slot is `cat`. Pins the 1:1 fan-out (no duplicate
+            emission, no category mislabelling) for every always-on
+            category individually — the data-driven per-category
+            counterpart to the aggregate test above."
+    (doseq [cat always-on-categories]
+      (error-emit/clear-error-listeners!)
+      (let [seen (atom [])]
+        (rf/register-error-listener!
+          :conformance/recorder
+          (fn [record] (swap! seen conj record)))
+        (drive-category! cat)
+        (let [for-cat (filter #(= cat (:error %)) @seen)]
+          (is (= 1 (count for-cat))
+              (str cat ": exactly one always-on record fanned out"))
+          (is (= 1 (count @seen))
+              (str cat ": only that one record fanned out (no stray "
+                   "emission)")))))))
+
+(deftest report-category-rides-the-bounded-report-not-per-event-axis
+  (testing "Per Spec 009 §Channel-promotion catalogue rows: the
+            `:rf.error/frame-teardown-failed` row is the bounded
+            single-report idiom — it rides `dispatch-frame-teardown-report!`
+            (one record per destroy with a `:hook-failures` vector), NOT
+            the per-event `dispatch-on-error!`. Pins that the report fn is
+            a no-op on an empty `:hook-failures` (no flood) yet fans the
+            bounded record out when failures are present."
+    (let [seen (atom [])]
+      (rf/register-error-listener!
+        :conformance/recorder
+        (fn [record] (swap! seen conj record)))
+      ;; Empty failures → no record (the no-flood contract).
+      (error-emit/dispatch-frame-teardown-report! :conformance/frame [] 0)
+      (is (empty? @seen) "empty :hook-failures → no always-on report")
+      ;; Non-empty → one bounded record carrying the failures vector.
+      (error-emit/dispatch-frame-teardown-report!
+        :conformance/frame
+        [{:hook :ssr/on-frame-destroyed :exception (ex-info "x" {})
+          :where :safe-call-hook!}]
+        0)
+      (is (= 1 (count @seen)) "non-empty :hook-failures → one bounded report")
+      (let [r (first @seen)]
+        (is (= :rf.error/frame-teardown-failed (:error r)))
+        (is (vector? (:hook-failures r))
+            "the bounded report carries the per-hook detail as a vector")))))
+
+;; ===========================================================================
+;; Late-bind hooks the substrate publishes (so other artefacts can reach
+;; the always-on axis without static-requiring error-emit — load-cycle
+;; avoidance). Pinned here because they are part of the always-on axis's
+;; addressable surface (Spec 009 §What IS available in production).
+;; ===========================================================================
+
+(deftest always-on-late-bind-hooks-are-published
+  (testing "Per EP-0008 (rf2-500ech / rf2-ini4wr): `error-emit` publishes
+            its always-on entry points as late-bind hooks at ns-load, so
+            substrate / frame layers that cannot static-require it (load
+            cycle) still reach the always-on axis in production. Both the
+            per-event and the bounded-report hooks must be present."
+    (is (some? (late-bind/get-fn :error-emit/dispatch-on-error))
+        ":error-emit/dispatch-on-error hook is published")
+    (is (some? (late-bind/get-fn :error-emit/dispatch-frame-teardown-report))
+        ":error-emit/dispatch-frame-teardown-report hook is published")))

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -1,0 +1,207 @@
+(ns re-frame.error-catalogue-channel-conformance-test
+  "EP-0008 / rf2-sgz1zq — the conformance PIN that makes the Spec 009
+  channel assignment REAL, not documentary.
+
+  Spec 009 §Error event catalogue graduated a `Channel` column from
+  EP-0008: every emitted `:rf.error/*` / `:rf.warning/*` category rides
+  exactly one of two observability channels — `always-on` (the
+  production-survivable `register-error-listener!` error-emit axis,
+  surface #4) or `diagnostic` (the dev-only trace surface, DCE'd under
+  CLJS `:advanced` + `goog.DEBUG=false`). The catalogue's own §note
+  names this bead as the test that pins the contract:
+
+    > Every emitted category therefore carries a `Channel`; a
+    > conformance test (EP-0008 bead `rf2-sgz1zq`) pins it — every
+    > emitted category appears in this catalogue with a channel, and
+    > every always-on category is exercised through the error-emit
+    > listener in at least one test (so promotion is real, not
+    > documentary).
+
+  This file is the FIRST leg (the catalogue-side structural pin); the
+  always-on exercise leg lives in
+  `re-frame.always-on-axis-conformance-cljs-test` (dual-runtime, drives
+  every always-on category through `error-emit/dispatch-on-error!`).
+
+  ## Why data-driven against the catalogue markdown
+
+  The catalogue is the SINGLE SOURCE OF TRUTH for category names and
+  channels (Spec 009 §Error event catalogue). Rather than hardcode a
+  fragile fixed list that drifts as categories are added, this test
+  PARSES the catalogue table out of `spec/009-Instrumentation.md` and
+  asserts structural invariants over the parsed rows:
+
+    1. Every catalogue row carries a `Channel` value, and that value is
+       one of the two graduated channels (`always-on` / `diagnostic`).
+       A new row added WITHOUT a channel (an empty cell, or a typo'd
+       channel name) fails here — the co-edit invariant made testable.
+    2. No category appears twice (the vocabulary is a set, not a bag).
+    3. The three EP-0008-promoted categories are present and `always-on`
+       (`:rf.error/frame-teardown-failed` — the teardown report;
+       `:rf.error/write-after-destroy` — the suppressed-write partner of
+       frame-destroyed; `:rf.error/on-destroy-handler-exception` — the
+       dedicated teardown-throw discriminator).
+    4. The parsed always-on set EQUALS the literal the dual-runtime
+       exercise test iterates (`always-on-axis-conformance-cljs-test`'s
+       `always-on-categories`). This couples the two legs: a category
+       graduated to `always-on` in the catalogue but NOT added to the
+       exercise literal fails HERE, and once added the exercise test
+       automatically drives it through the listener. Promotion stays
+       real, not documentary, with no fragile fixed list.
+
+  JVM-only (`.clj`, NOT `*-cljs-test`): it `slurp`s a repo markdown file,
+  which only the JVM `clojure -M:test` runner can do. The exercise leg is
+  the dual-runtime half."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            ;; The dual-runtime exercise leg's always-on literal — Test A
+            ;; pins it against the parsed catalogue (invariant #4), Test B
+            ;; iterates it. Requiring it here closes the coupling in code.
+            [re-frame.always-on-axis-conformance-cljs-test :as exercise]))
+
+;; ---------------------------------------------------------------------------
+;; Catalogue location + parser
+;; ---------------------------------------------------------------------------
+
+(def ^:private spec-009-file
+  "`spec/009-Instrumentation.md` resolved from the JVM test CWD. Per
+  rf2-0hxm the core JVM tests run from `implementation/core/`, so the
+  catalogue is at `../../spec/009-Instrumentation.md`; fall back to the
+  pre-split `../spec/...` layout for a transitional REPL run from
+  `implementation/`. Mirrors `re-frame.conformance-test/fixtures-dir`."
+  (let [nested (io/file "../../spec/009-Instrumentation.md")
+        legacy (io/file "../spec/009-Instrumentation.md")]
+    (if (.exists nested) nested legacy)))
+
+(def ^:private catalogue-row-re
+  "Matches one catalogue table row, capturing the `:operation` category
+  keyword (group 1) and the `Channel` column value (group 2). The table
+  shape (Spec 009 §Error event catalogue):
+
+    | `:operation` | `:op-type` | Channel | Trigger / meaning | … |
+
+  Group 1 is the back-ticked `:rf.<area>/<category>` in column 1; the
+  `:op-type` in column 2 is skipped; group 2 is the bare lowercase
+  channel token in column 3. Anchored at `^|` so it only matches genuine
+  table rows, not prose mentions of a category."
+  #"^\|\s*`(:rf\.[^`]+)`\s*\|\s*`?:[^|`]+`?\s*\|\s*([a-z-]+)\s*\|")
+
+(defn- parse-catalogue
+  "Parse the Spec 009 error-event catalogue into a vector of
+  `{:category <kw> :channel <string>}` maps, in table order. Reads the
+  markdown fresh each call (cheap; one file)."
+  []
+  (->> (slurp spec-009-file)
+       (str/split-lines)
+       (keep (fn [line]
+               (when-let [[_ cat-str chan] (re-find catalogue-row-re line)]
+                 {:category (keyword (subs cat-str 1)) ;; drop leading ':'
+                  :channel  chan})))
+       vec))
+
+(def ^:private allowed-channels
+  "The two graduated EP-0008 channel values (Spec 009 §Error event
+  catalogue: \"Its value is one of two\"). The causal channel is data, not
+  a catalogue row, so it is not a `Channel` cell value."
+  #{"always-on" "diagnostic"})
+
+;; ---------------------------------------------------------------------------
+;; Tests
+;; ---------------------------------------------------------------------------
+
+(deftest catalogue-parses-to-a-nonempty-set-of-rows
+  (testing "Sanity: the parser finds the catalogue table. A zero-row
+            parse means the table shape changed out from under this test
+            (a column reorder, a fence change) — fail loudly rather than
+            vacuously pass every downstream invariant."
+    (let [rows (parse-catalogue)]
+      (is (.exists spec-009-file)
+          (str "spec/009-Instrumentation.md not found at " spec-009-file))
+      (is (seq rows) "catalogue parse yielded at least one row")
+      ;; A floor well below today's 163 rows — catches a broken parse
+      ;; without pinning an exact count (the vocabulary grows).
+      (is (>= (count rows) 100)
+          "catalogue parse yielded the full table (>= 100 rows), not a
+           partial match from a shape change"))))
+
+(deftest every-emitted-category-carries-a-channel
+  (testing "Per Spec 009 §Error event catalogue (the rf2-sgz1zq pin):
+            EVERY catalogue row carries a `Channel` value, and that value
+            is exactly one of the two graduated channels. The parser only
+            captures group 2 when a non-empty lowercase token sits in the
+            Channel column, so a row with an EMPTY channel cell would not
+            be captured as a row at all — to catch that, we assert the
+            row is well-formed AND its channel is in the allowed set. A
+            typo'd channel (e.g. `always_on`, `diag`) lands a row with an
+            out-of-set channel and fails here."
+    (let [rows (parse-catalogue)
+          bad  (remove (comp allowed-channels :channel) rows)]
+      (is (empty? bad)
+          (str "every catalogue row's Channel must be one of "
+               allowed-channels "; offending rows: " (pr-str bad))))))
+
+(deftest catalogue-categories-are-unique
+  (testing "The category vocabulary is a SET — each `:rf.<area>/<category>`
+            appears in exactly one catalogue row. A duplicate row (e.g. a
+            category re-listed under a different channel) is a contract
+            bug: a consumer reading the catalogue as a map would silently
+            take one binding."
+    (let [rows (parse-catalogue)
+          dups (->> (map :category rows)
+                    frequencies
+                    (filter (fn [[_ n]] (> n 1)))
+                    (map first))]
+      (is (empty? dups)
+          (str "categories appearing in more than one catalogue row: "
+               (pr-str dups))))))
+
+(deftest ep0008-promoted-categories-are-present-and-always-on
+  (testing "Per Spec 009 §Channel-promotion catalogue rows + the EP-0008
+            wave (rf2-ini4wr / rf2-500ech / rf2-7b9r4l): the three
+            promoted categories appear in the catalogue and ride the
+            always-on axis. This is the explicit acceptance leg the bead
+            calls out — the newly-promoted rows must be classified, not
+            just emitted."
+    (let [by-cat (into {} (map (juxt :category :channel)) (parse-catalogue))]
+      (doseq [cat [:rf.error/frame-teardown-failed
+                   :rf.error/write-after-destroy
+                   :rf.error/on-destroy-handler-exception]]
+        (is (contains? by-cat cat)
+            (str cat " is catalogued"))
+        (is (= "always-on" (get by-cat cat))
+            (str cat " rides the always-on channel"))))))
+
+(deftest parsed-always-on-set-equals-the-exercise-literal
+  (testing "Per the rf2-sgz1zq pin (invariant #4): the set of always-on
+            categories PARSED from the catalogue equals the literal
+            `always-on-axis-conformance-cljs-test/always-on-categories`
+            that the dual-runtime exercise test iterates. This couples the
+            two legs WITHOUT a fragile hand-maintained duplicate:
+
+              - A category graduated to `always-on` in the catalogue but
+                NOT added to the exercise literal fails HERE — surfacing
+                the missing always-on coverage.
+              - A category in the literal that is NOT always-on in the
+                catalogue (a stale entry, or one demoted) also fails here.
+
+            Once the literal is corrected to match, the exercise test
+            automatically drives the new category through
+            `register-error-listener!`. Promotion is therefore enforced
+            end-to-end, never documentary, and stays green as the
+            always-on set grows."
+    (let [catalogue-always-on
+          (->> (parse-catalogue)
+               (filter #(= "always-on" (:channel %)))
+               (map :category)
+               set)]
+      (is (= catalogue-always-on exercise/always-on-categories)
+          (str "catalogue always-on set vs exercise literal — "
+               "only-in-catalogue: "
+               (pr-str (sort (set/difference
+                               catalogue-always-on
+                               exercise/always-on-categories)))
+               " ; only-in-literal: "
+               (pr-str (sort (set/difference
+                               exercise/always-on-categories
+                               catalogue-always-on))))))))


### PR DESCRIPTION
## Summary

EP-0008 **conformance pin** (the last EP-0008 impl slice) — makes the Spec 009 `Channel` assignment **real, not documentary**, against the now-final catalogue (A graduated, the teardown report + write-after-destroy + on-destroy-handler promotions all merged to main).

Two complementary, coupled legs:

### `error_catalogue_channel_conformance_test.clj` (JVM)
Parses the Spec 009 error-event catalogue out of `spec/009-Instrumentation.md` and pins structural invariants over the parsed rows:
- **Every catalogue row carries a `Channel` value**, and that value is one of the two graduated channels (`always-on` / `diagnostic`) — the co-edit invariant made testable (163 rows today).
- Categories are unique (the vocabulary is a set, not a bag).
- The three EP-0008-promoted rows are present **and `always-on`**: `:rf.error/frame-teardown-failed`, `:rf.error/write-after-destroy`, `:rf.error/on-destroy-handler-exception`.
- The **parsed always-on set EQUALS** the dual-runtime exercise literal.

### `always_on_axis_conformance_cljs_test.cljc` (dual-runtime)
Data-driven over the full always-on set — drives **every** always-on category through the `register-error-listener!` substrate (`dispatch-on-error!` for the per-event axis; `dispatch-frame-teardown-report!` for the bounded teardown report per Spec 009 §Channel-promotion catalogue rows) and asserts each fans out exactly once carrying its category. Also pins the no-flood report contract and the published late-bind hooks.

### Why it stays green as categories are added
The catalogue is the source of truth. The JVM companion pins the exercise literal `==` the catalogue's `always-on` rows, so a newly-promoted category **fails the equality** until added to the literal — and once added, the exercise test automatically drives it through the listener. Promotion is enforced end-to-end with no fragile fixed list.

## Coverage / gaps
**No gaps found.** All 20 always-on categories are catalogued with a channel and exercised through the always-on axis; every catalogue row carries a valid channel; no duplicate categories. No follow-up bead needed.

Fence respected: test dirs only. `spec/009-Instrumentation.md` read, not edited. No `implementation/` source or `frame.cljc` touched.

## Quality gates
- `npm run test:cljs` — **6468 tests, 23560 assertions, 0 failures, 0 errors** (includes the new dual-runtime `*_cljs_test.cljc`)
- `clojure -M:test` (core artefact, full suite) — **1116 tests, 4884 assertions, 0 failures, 0 errors** (includes both new tests)

Closes rf2-sgz1zq.