### PR TITLE
feat(conventions): EP-0012 path/identity algebra — :rf/path laws + CEDN-1 + internal helpers (rf2-nd7b3e)

### DIFF
--- a/implementation/core/src/re_frame/identity.cljc
+++ b/implementation/core/src/re_frame/identity.cljc
@@ -1,0 +1,273 @@
+(ns re-frame.identity
+  "Internal canonical-EDN-identity algebra (EP-0012, ACCEPTED ruling
+  rf2-s7xshi). The normative contract lives in [`spec/Conventions.md`
+  §Canonical EDN identity]; this namespace is the reference
+  implementation of the `CEDN-1` encoding.
+
+  ## Status — INTERNAL (EP-0012 disposition 1)
+
+  The *semantics* are normative immediately; the *names* are NOT public
+  API at this slice. No `re-frame.core` facade export, no classification.
+  Resources, routing, the work ledger, and schema digests are the
+  consumers that will graduate a public name once two-plus use it through
+  this namespace unchanged.
+
+  ## Why canonical identity, not stringification
+
+  `str`, `pr-str` over unordered host maps, `JSON.stringify`, and object
+  identity are NOT valid framework identity contracts — they differ by
+  host, leak insertion order, or depend on references. Resource caches,
+  work ids, route params, and epoch/replay records need an identity that
+  survives SSR, hydration, replay, Xray inspection, and multi-host
+  conformance. Canonical EDN is the smallest Clojure-native answer.
+
+  ## Identity vs digest (EP-0012 disposition 5)
+
+  The canonical EDN value IS the identity everywhere — storage, work
+  ledger, traces, epoch/replay. `canonical` returns that normalized
+  value. A *digest* is an OPTIONAL, versioned, always-recomputable
+  projection for size-constrained surfaces; it is never an independent
+  identity fact, never required for correctness, never the authoritative
+  stored key. This namespace ships `canonical` + `canonical-bytes`
+  (the CEDN-1 byte string the comparison/digest is defined over) and no
+  authoritative-digest store.
+
+  ## The CEDN-1 byte encoding
+
+  A UTF-8 token stream with a type tag before every value (Conventions
+  §Canonical byte encoding). The type tag keeps distinct EDN values
+  distinct — `\"42\"`, `42`, `:42`, `[1 2]`, and `(1 2)` cannot collide.
+  Maps order entries by their keys' CEDN-1 bytes; sets order elements by
+  their CEDN-1 bytes; vectors and lists preserve order and remain
+  distinct from each other. Out-of-domain values fail closed with
+  `:rf.error/non-edn-identity` rather than falling back to host
+  comparison.
+
+  Equality-sensitive comparison MUST be equivalent to comparing CEDN-1
+  bytes; `canonical` returns the normalized EDN value, and two values are
+  equal-as-identity iff their `canonical-bytes` are `=`.
+
+  Pure namespace — no runtime state, no trace. `.cljc` so the JVM test
+  sweep exercises the encoder cross-host."
+  (:require [clojure.string :as str])
+  #?(:clj (:import [java.util UUID]
+                   [java.util Date]
+                   [java.time Instant ZoneOffset]
+                   [java.time.format DateTimeFormatter])))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; A fixed UTC RFC 3339 formatter pinned to millisecond precision so an
+;; instant at a whole second renders `...T00:00:00.000Z`, not `...T00:00:00Z`
+;; — the encoding is deterministic either way, but the spec pins
+;; millisecond text, so we pin it.
+#?(:clj
+   (def ^:private ^DateTimeFormatter rfc3339-millis-utc
+     (-> (DateTimeFormatter/ofPattern "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+         (.withZone ZoneOffset/UTC))))
+
+;; ---- the fail-closed rejection -------------------------------------------
+
+(defn- reject!
+  "Throw the canonical `:rf.error/non-edn-identity` error. A value outside
+  the CEDN-1 domain fails the WHOLE identity closed — never a host-string
+  fallback (Conventions §Canonical EDN identity)."
+  [value reason]
+  (throw (ex-info (str :rf.error/non-edn-identity)
+                  {:rf.error/id :rf.error/non-edn-identity
+                   :where       'rf.identity/canonical
+                   :recovery    :encode-as-portable-edn
+                   :reason      reason
+                   :bad-value   value
+                   :bad-type    (str (type value))})))
+
+;; ---- safe-integer range --------------------------------------------------
+;;
+;; Portable integers live in the ECMAScript safe-integer range so identity
+;; survives the CLJS host. Outside it, fail closed.
+
+(def ^:private max-safe-integer 9007199254740991)
+(def ^:private min-safe-integer -9007199254740991)
+
+(defn- safe-integer?
+  [n]
+  (and (<= min-safe-integer n) (<= n max-safe-integer)))
+
+;; ---- host-type discrimination --------------------------------------------
+
+(defn- uuid-value?
+  [x]
+  #?(:clj  (instance? UUID x)
+     :cljs (uuid? x)))
+
+(defn- instant->utc-millis-string
+  "Render an instant as RFC 3339 UTC text with millisecond precision.
+  Equivalent instants in different source timezones normalize to the same
+  UTC text — timezone text from the source literal is not identity."
+  [x]
+  #?(:clj
+     (let [^Instant inst (cond
+                           (instance? Instant x) x
+                           (instance? Date x)    (.toInstant ^Date x)
+                           :else                 nil)]
+       (when inst
+         ;; Truncate to milliseconds, render with a fixed millisecond-
+         ;; precision UTC formatter.
+         (let [millis (.toEpochMilli inst)]
+           (.format rfc3339-millis-utc (Instant/ofEpochMilli millis)))))
+     :cljs
+     (when (instance? js/Date x)
+       ;; `toISOString` already emits `...T..:..:..\.SSSZ` (millisecond
+       ;; precision, UTC) — the JS counterpart of the JVM formatter above.
+       (.toISOString ^js x))))
+
+(defn- instant-value?
+  [x]
+  #?(:clj  (or (instance? Instant x) (instance? Date x))
+     :cljs (instance? js/Date x)))
+
+(defn- bad-number?
+  "A number outside the CEDN-1 numeric domain: floats, ratios, arbitrary-
+  precision decimals, NaN, and infinities. CEDN-1 admits only portable
+  integers in the safe range unless a future spec encodes a numeric class.
+  On CLJS a `js/Number` integer-valued double (`2.0`) reads as an integer
+  via `int?`/`integer?` so it is admitted iff it is integer-valued and in
+  range; a fractional or non-finite number is rejected."
+  [x]
+  #?(:clj
+     (or (float? x)        ; Double / Float
+         (ratio? x)
+         (decimal? x))
+     :cljs
+     ;; CLJS has one numeric type. `int?` is true for integer-valued
+     ;; doubles; reject non-integers and non-finite values.
+     (or (not (cljs.core/integer? x))
+         (not (js/isFinite x)))))
+
+;; ---- canonical token encoding (CEDN-1) -----------------------------------
+;;
+;; Encode into a UTF-8 token string. Strings/keywords/symbols use the EDN
+;; literal via `pr-str` (portable across CLJ/CLJS readers); the type tag
+;; preceding each value keeps distinct EDN kinds distinct.
+
+(declare encode)
+
+(defn- encode-string [s]
+  ;; `pr-str` produces a canonical EDN string literal over Unicode scalar
+  ;; values, identical across CLJ/CLJS.
+  (str "s:" (pr-str s)))
+
+(defn- encode-keyword [k]
+  ;; The canonical EDN keyword token, never auto-resolved `::` shorthand.
+  ;; `pr-str` on a keyword always prints the single-colon fully-qualified
+  ;; form.
+  (str "k:" (pr-str k)))
+
+(defn- encode-symbol [y]
+  (str "y:" (pr-str y)))
+
+(defn- encode-elements
+  "Encode a sequence of already-canonical-ordered elements, space-joined.
+  Composite encodings separate adjacent element tokens with a single
+  ASCII space (Conventions §Canonical byte encoding)."
+  [xs]
+  (str/join " " (map encode xs)))
+
+(defn- encode-map [m]
+  ;; Order entries by their keys' CEDN-1 bytes; each key token is separated
+  ;; from its value token, and entries from each other, by a single space.
+  ;; Duplicate canonical keys are impossible inside a Clojure map (the
+  ;; reader collapses them); a reader/adapter that could produce duplicates
+  ;; rejects them upstream before this boundary.
+  (let [entries (->> m
+                     (map (fn [[k v]] [(encode k) (encode v)]))
+                     (sort-by first))]
+    (str "m{"
+         (str/join " " (mapcat (fn [[ke ve]] [ke ve]) entries))
+         "}")))
+
+(defn- encode-set [s]
+  ;; Sort elements by their canonical element encoding.
+  (let [sorted (sort (map encode s))]
+    (str "q#{" (str/join " " sorted) "}")))
+
+(defn- encode
+  "Encode one EDN value to its CEDN-1 token string, or fail closed."
+  [x]
+  (cond
+    (nil? x)            "n"
+    (boolean? x)        (if x "b:1" "b:0")
+    (string? x)         (encode-string x)
+    (keyword? x)        (encode-keyword x)
+    ;; UUID / instant BEFORE the symbol/number branches (a host date is
+    ;; not a number; a UUID is not a symbol).
+    (uuid-value? x)     (str "u:" (str/lower-case (str x)))
+    (instant-value? x)  (str "t:" (instant->utc-millis-string x))
+    (symbol? x)         (encode-symbol x)
+    (integer? x)        (if (and (not (bad-number? x)) (safe-integer? x))
+                          (str "i:" x)
+                          (reject! x :integer-out-of-safe-range))
+    (number? x)         (reject! x :non-integer-number)
+    ;; Vectors before the generic sequential branch so vector-kind is
+    ;; preserved distinctly from list-kind.
+    (vector? x)         (str "v[" (encode-elements x) "]")
+    (set? x)            (encode-set x)
+    (map? x)            (encode-map x)
+    (seq? x)            (str "l(" (encode-elements x) ")")
+    (list? x)           (str "l(" (encode-elements x) ")")
+    :else               (reject! x :unsupported-host-value)))
+
+;; ---- public-internal surface ---------------------------------------------
+
+(defn canonical-bytes
+  "Return the CEDN-1 token string for `value` — the byte-level identity
+  the equality contract is defined over. Two values are equal-as-identity
+  iff their `canonical-bytes` are `=`. Throws `:rf.error/non-edn-identity`
+  for any value outside the CEDN-1 domain (functions, atoms, promises,
+  DOM nodes, host objects, floats / ratios / NaN / infinities, integers
+  outside the safe range)."
+  [value]
+  (encode value))
+
+(defn canonical
+  "Return the canonical normalized EDN identity of `value` — the storage,
+  work-ledger, trace, and replay identity (EP-0012 disposition 5: canonical
+  EDN IS the identity).
+
+  The normalization recursively reorders map entries and set elements into
+  CEDN-1 canonical order while preserving vector / list order and EDN kind,
+  so two map spellings that differ only in insertion order return an `=`
+  canonical value. Fails closed with `:rf.error/non-edn-identity` for any
+  out-of-domain value — the validation walk runs eagerly so a host handle
+  buried anywhere in the structure is rejected, never host-stringified.
+
+  Present `nil` stays distinct from a missing key: `(canonical {:page nil})`
+  is not `(canonical {})`. `nil` elision, if a surface wants it, is a
+  surface-specific policy applied BEFORE canonicalization."
+  [value]
+  (cond
+    (nil? value)       nil
+    (boolean? value)   value
+    (string? value)    value
+    (keyword? value)   value
+    (uuid-value? value)    value
+    (instant-value? value) value
+    (symbol? value)    value
+    (integer? value)   (if (and (not (bad-number? value)) (safe-integer? value))
+                         value
+                         (reject! value :integer-out-of-safe-range))
+    (number? value)    (reject! value :non-integer-number)
+    (vector? value)    (mapv canonical value)
+    (set? value)       (into #{} (map canonical) value)
+    (map? value)       (reduce-kv (fn [acc k v] (assoc acc (canonical k) (canonical v)))
+                                  {} value)
+    (seq? value)       (apply list (map canonical value))
+    (list? value)      (apply list (map canonical value))
+    :else              (reject! value :unsupported-host-value)))
+
+(defn identical-identity?
+  "True iff `a` and `b` denote the same canonical EDN fact — i.e. their
+  CEDN-1 bytes are `=`. Both are encoded (and so fail closed if either is
+  out of domain)."
+  [a b]
+  (= (canonical-bytes a) (canonical-bytes b)))

--- a/implementation/core/src/re_frame/path.cljc
+++ b/implementation/core/src/re_frame/path.cljc
@@ -1,0 +1,305 @@
+(ns re-frame.path
+  "Internal path algebra for `:rf/path` — the shared lightweight-optics
+  vocabulary every path-shaped re-frame2 fact inherits (EP-0012,
+  ACCEPTED ruling rf2-s7xshi). The normative contract lives in
+  [`spec/Conventions.md` §The `:rf/path` algebra]; this namespace is the
+  reference implementation.
+
+  ## Status — INTERNAL (EP-0012 disposition 1)
+
+  The *semantics* are normative immediately; the *names* are NOT public
+  API at this slice. There is no `re-frame.core` facade export of
+  `rf.path/*` yet, and none is classified. An op graduates to a public
+  name only once two or more consumers (flows / schemas / routing /
+  resources / EP-0015 frame-config maps / EP-0016 map-form targets) use
+  it through this internal namespace without requiring a shape change
+  (the concrete graduation gate). Subsystems MUST NOT keep private ad hoc
+  overlap / prefix logic once they cite these helpers — there is no
+  \"tool-only\" path semantics.
+
+  ## The algebra
+
+    (get value path)        -> focused value, or nil when missing
+    (get value path nf)     -> nf when missing
+    (lookup value path)     -> {:present? true :value v} | {:present? false}
+    (put value path x)      -> value with x installed at path
+    (over value path f)     -> value with f applied to the current focus
+    (compose p q)           -> the two paths appended
+    (prefix? p q)           -> true when p is a prefix of q
+    (overlap? p q)          -> true when either path is a prefix of the other
+
+  ## Laws (Conventions §Path laws — generatively tested)
+
+    lookup(put(s, p, x), p) = {:present? true, :value x}     ;; put-lookup
+    if lookup(s, p) present with x then put(s, p, x) = s      ;; lookup-put
+    put(put(s, p, x), p, y) = put(s, p, y)                    ;; put-put
+    compose(p, []) = p ; compose([], p) = p ; assoc.          ;; compose
+    get(s, compose(p, q)) = get(get(s, p), q)                 ;; get-compose
+    over(s, p, f) = put(s, p, f(get(s, p)))                   ;; over
+    overlap? is symmetric; overlap?([], p) = true             ;; overlap?
+
+  Root-path laws (the laws raw `assoc-in` famously violates — it
+  assoc's under key `nil` instead of replacing the root):
+
+    get(s, [], nf)  = s
+    lookup(s, [])   = {:present? true, :value s}
+    put(s, [], x)   = x
+    over(s, [], f)  = f(s)
+    overlap?([], p) = true
+
+  ## Intermediate-container policy
+
+  Missing intermediate values are treated as maps, matching Clojure's
+  `assoc-in` / `update-in` map-creation behaviour. `over` on a missing
+  path calls `f` with `nil` (matching `update-in`); a consumer that must
+  distinguish missing from present `nil` uses `lookup` first.
+
+  Pure namespace — no runtime state, no trace, no host coupling. `.cljc`
+  so the JVM test sweep exercises the algebra without the CLJS runtime."
+  (:refer-clojure :exclude [get])
+  (:require [clojure.core :as core]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- path shape / normalization ------------------------------------------
+
+(defn normalize
+  "Normalize a path input to the canonical vector form. The primary path
+  container is a vector; APIs MAY accept any sequential collection for
+  migration ergonomics, but every stored declaration MUST normalize to a
+  vector (Conventions §Path shape). A nil path normalizes to the root
+  path `[]`."
+  [p]
+  (cond
+    (nil? p)        []
+    (vector? p)     p
+    (sequential? p) (vec p)
+    :else           (throw (ex-info "rf.path: a path must be a sequential collection of segments"
+                                    {:rf.error/id :rf.error/bad-path
+                                     :where       'rf.path/normalize
+                                     :recovery    :fix-path
+                                     :bad-path    p}))))
+
+;; ---- the unique missing sentinel -----------------------------------------
+;;
+;; A private, reference-unique sentinel distinguishes "missing" from any
+;; possible present value (including `nil` itself). `get-in` cannot make
+;; this distinction; `lookup` must, so the missing-vs-present-nil law
+;; holds (Conventions §Missing versus present nil).
+
+(def ^:private missing
+  #?(:clj (Object.) :cljs (js-obj)))
+
+;; ---- lookup / get --------------------------------------------------------
+
+(defn lookup
+  "Presence-aware lookup. Returns `{:present? true :value v}` when the
+  focus exists (even when `v` is `nil`), else `{:present? false}`.
+
+  The root path `[]` is always present with the whole value. This is the
+  operation a subsystem uses when it must tell an absent key from a key
+  present with value `nil` — `get` alone cannot."
+  [value path]
+  (let [path (normalize path)]
+    (loop [v    value
+           segs (seq path)]
+      (if (nil? segs)
+        {:present? true :value v}
+        (let [seg (first segs)
+              nxt (if (associative? v)
+                    (core/get v seg missing)
+                    missing)]
+          (if (identical? nxt missing)
+            {:present? false}
+            (recur nxt (next segs))))))))
+
+(defn get
+  "Return the value focused by `path`, or `not-found` (default `nil`)
+  when the focus is missing. `(get s [])` is the whole value `s`."
+  ([value path] (get value path nil))
+  ([value path not-found]
+   (let [{:keys [present? value]} (lookup value path)]
+     (if present? value not-found))))
+
+;; ---- put / over ----------------------------------------------------------
+
+(defn- container-for
+  "Return a container for `value` that can hold an entry at `seg`,
+  preserving `value` when it is already a usable container for that
+  segment kind, else replacing it with a fresh map.
+
+  Container/segment compatibility (the explicit intermediate-container
+  policy — Conventions §Path laws):
+
+    - a map can hold any segment;
+    - a vector can hold ONLY an in-range non-negative integer index
+      (`assoc` on a vector with a non-integer or out-of-range index
+      throws on the JVM and is meaningless as a path step), so a vector
+      faced with a non-integer / out-of-range segment is replaced by a
+      fresh map;
+    - any non-associative value (nil, a scalar, a set, a seq) faced with
+      ANY segment is replaced by a fresh map (missing / mismatched
+      intermediate values become maps, matching `assoc-in`).
+
+  Replacing — rather than throwing — keeps `put` total so the put-lookup
+  law holds for every generated path, while never silently corrupting a
+  compatible existing container."
+  [value seg]
+  (cond
+    (map? value) value
+    (vector? value)
+    (if (and (integer? seg) (<= 0 seg) (< seg (count value)))
+      value
+      {})
+    :else {}))
+
+(defn put
+  "Return `value` with `x` installed at `path`. The root path replaces the
+  whole value: `(put s [] x) = x` — the law raw `assoc-in` violates (it
+  assoc's under key `nil`).
+
+  Missing or segment-incompatible intermediate values are created as maps
+  (see `container-for` for the explicit policy), matching `assoc-in`'s
+  map-creation behaviour and defining vector-index behaviour explicitly
+  rather than letting a host `assoc` throw. A present-`nil` write is
+  stored as `nil` (NOT dissoc'd) so the put-lookup law holds at `x = nil`."
+  [value path x]
+  (let [path (normalize path)]
+    (if (zero? (count path))
+      x
+      (let [seg  (nth path 0)
+            base (container-for value seg)]
+        (assoc base seg
+               (put (let [{:keys [present? value]} (lookup base [seg])]
+                      (if present? value nil))
+                    (subvec path 1)
+                    x))))))
+
+(defn over
+  "Return `value` with `f` applied to the current focus. `(over s [] f) =
+  (f s)`. On a missing path `f` is called with `nil` (matching
+  `update-in`); a consumer needing the missing/present-nil distinction
+  uses `lookup` first.
+
+  Law: `over(s, p, f) = put(s, p, f(get(s, p)))` for the public
+  nil-on-missing `get` semantics."
+  [value path f]
+  (put value path (f (get value path))))
+
+;; ---- compose / prefix? / overlap? ----------------------------------------
+
+(defn compose
+  "Append two paths. `(compose p [])` = `p`, `(compose [] p)` = `p`, and
+  compose is associative. The result is the canonical vector form."
+  [p q]
+  (into (normalize p) (normalize q)))
+
+(defn prefix?
+  "True iff `p` is a path-prefix of `q` (a prefix of itself included).
+  `[]` is a prefix of every path. Implementation note: `subvec` is O(1)
+  and allocates only a thin view — `prefix?` is hot in flow topo-sort."
+  [p q]
+  (let [p (normalize p)
+        q (normalize q)
+        n (count p)]
+    (and (<= n (count q))
+         (= p (subvec q 0 n)))))
+
+(defn overlap?
+  "True iff `p` and `q` may affect the same focused value — i.e. either is
+  a prefix of the other. Symmetric. `(overlap? [] p)` is always true (the
+  root path overlaps everything). This is the shared relation flows use
+  for dependency edges and output-collision detection; no subsystem keeps
+  a private overlap predicate."
+  [p q]
+  (or (prefix? p q)
+      (prefix? q p)))
+
+;; ---- path templates (EP-0012 disposition 2) ------------------------------
+;;
+;; The canonical STORED shape of a template variable is the explicit data
+;; form `[:rf.path/param :name]`. The `'?name` quote-symbol spelling is
+;; declaration-boundary SUGAR, normalized into the data form by
+;; `normalize-template`. The data form is what CEDN-1 encodes and what
+;; traces / Xray display — `'?name` never appears in any stored or
+;; serialized shape (one fact, one identity; disposition 2 rider). A
+;; concrete runtime path that literally contains the symbol `?name` is
+;; just a symbol segment and is NOT substituted unless it is processed as
+;; a template declaration.
+
+(defn param-segment?
+  "True iff `seg` is a canonical template-parameter segment, the data form
+  `[:rf.path/param :name]` (a 2-vector headed by `:rf.path/param` with a
+  keyword name). This is the ONLY template-variable shape that appears in
+  a stored or serialized path."
+  [seg]
+  (and (vector? seg)
+       (= 2 (count seg))
+       (= :rf.path/param (nth seg 0))
+       (keyword? (nth seg 1))))
+
+(defn- sugar-param-name
+  "When `seg` is the declaration sugar `'?name` (a simple symbol whose
+  name begins with `?`), return the parameter name as a keyword
+  (`'?invoice-id` -> `:invoice-id`); else nil. The marker is recognised
+  only on a symbol with no namespace whose name is longer than the bare
+  `?` and starts with `?`."
+  [seg]
+  (when (and (symbol? seg)
+             (nil? (namespace seg)))
+    (let [s (name seg)]
+      (when (and (> (count s) 1) (= \? (core/get s 0)))
+        (keyword (subs s 1))))))
+
+(defn normalize-template
+  "Normalize a path-template vector to its canonical stored shape: every
+  `'?name` sugar segment becomes the data form `[:rf.path/param :name]`;
+  already-canonical `[:rf.path/param :name]` segments pass through; every
+  other segment is a literal and passes through untouched. Returns a
+  vector. Idempotent — re-normalizing a canonical template is a no-op
+  (the rider guarantee that `'?name` never survives into storage)."
+  [path]
+  (mapv (fn [seg]
+          (cond
+            (param-segment? seg) seg
+            (sugar-param-name seg) [:rf.path/param (sugar-param-name seg)]
+            :else seg))
+        (normalize path)))
+
+(defn template?
+  "True iff `path` (after template normalization) contains at least one
+  `[:rf.path/param …]` segment — i.e. it is a template, not a concrete
+  path."
+  [path]
+  (boolean (some param-segment? (normalize-template path))))
+
+(defn instantiate
+  "Instantiate a path template into a concrete path by substituting each
+  `[:rf.path/param :name]` segment with `(core/get bindings :name)`. Accepts
+  either a raw path vector / template or a named-path-declaration map
+  carrying an `:rf/path`. `'?name` sugar in the template is normalized
+  first. Pure. Throws `:rf.error/missing-path-param` when a parameter has
+  no binding (fail-closed — an unbound param would silently produce a
+  `nil` segment).
+
+      (instantiate [:billing :invoices :by-id '?invoice-id :email]
+                   {:invoice-id #uuid \"…\"})
+      ;; => [:billing :invoices :by-id #uuid \"…\" :email]"
+  [path-or-decl bindings]
+  (let [path (normalize-template
+               (if (map? path-or-decl)
+                 (:rf/path path-or-decl)
+                 path-or-decl))]
+    (mapv (fn [seg]
+            (if (param-segment? seg)
+              (let [param (nth seg 1)]
+                (if (contains? bindings param)
+                  (core/get bindings param)
+                  (throw (ex-info (str :rf.error/missing-path-param)
+                                  {:rf.error/id :rf.error/missing-path-param
+                                   :where       'rf.path/instantiate
+                                   :recovery    :supply-binding
+                                   :param       param
+                                   :bad-path    path}))))
+              seg))
+          path)))

--- a/implementation/core/test/re_frame/identity_cedn1_cljs_test.cljc
+++ b/implementation/core/test/re_frame/identity_cedn1_cljs_test.cljc
@@ -1,0 +1,231 @@
+(ns re-frame.identity-cedn1-cljs-test
+  "Law / property tests for canonical EDN identity and the CEDN-1 byte
+  encoding (EP-0012, Conventions §Canonical EDN identity / §Canonical byte
+  encoding). Covers map-order invariance, set ordering, vector/list
+  distinctness, the nil-vs-missing distinction, heterogeneous keys, the
+  type-tag-keeps-distinct-kinds property, instant timezone normalization,
+  and the fail-closed rejection cases (floats / NaN / infinities / ratios /
+  out-of-range integers / host objects / functions / nested host values).
+
+  Same seeded-PRNG approach as `re-frame.path-laws-cljs-test` (no
+  `clojure.test.check` on the classpath). Named `*-cljs-test` so both the
+  shadow-cljs `:node-test` build and the JVM cognitect runner discover it."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [re-frame.identity :as id]))
+
+;; ---- deterministic PRNG (mirrors path-laws-cljs-test) --------------------
+
+(defn- lcg-next [state]
+  (-> (unchecked-multiply (long state) 1664525)
+      (unchecked-add 1013904223)
+      (bit-and 0x7fffffff)))
+
+(defn- rnd [state n] (mod (lcg-next state) n))
+
+(def ^:private key-pool [:a :b :c :x "k1" "k2" 0 1 'sym true false])
+(def ^:private scalar-pool [:kw "str" 0 1 2 42 -7 true false nil 'sy])
+
+(defn- gen-key [s] (nth key-pool (rnd s (count key-pool))))
+(defn- gen-scalar [s] (nth scalar-pool (rnd s (count scalar-pool))))
+
+(defn- gen-edn
+  "Generate a small canonical-domain EDN value to `depth`. Returns
+  `[value next-state]`. Uses only CEDN-1-admissible scalars."
+  [state depth]
+  (let [k (rnd state (if (zero? depth) 3 6))
+        s (lcg-next state)]
+    (case k
+      0 [(gen-scalar s) (lcg-next s)]
+      1 [(rnd s 1000) (lcg-next s)]
+      2 [(str "v" (rnd s 50)) (lcg-next s)]
+      3 (let [n (rnd s 4)]                ;; map
+          (loop [i 0, st (lcg-next s), acc {}]
+            (if (= i n)
+              [acc st]
+              (let [kk (gen-key st)
+                    [vv st'] (gen-edn (lcg-next st) (dec depth))]
+                (recur (inc i) st' (assoc acc kk vv))))))
+      4 (let [n (rnd s 3)]                ;; vector
+          (loop [i 0, st (lcg-next s), acc []]
+            (if (= i n)
+              [acc st]
+              (let [[vv st'] (gen-edn (lcg-next st) (dec depth))]
+                (recur (inc i) st' (conj acc vv))))))
+      5 (let [n (rnd s 3)]                ;; set
+          (loop [i 0, st (lcg-next s), acc #{}]
+            (if (= i n)
+              [acc st]
+              (let [[vv st'] (gen-edn (lcg-next st) (dec depth))]
+                (recur (inc i) st' (conj acc vv)))))))) )
+
+(defn- shuffle-coll
+  "Deterministically reorder a map/set/vector's entries using the PRNG —
+  enough to disturb insertion order for the order-invariance property.
+  Maps and sets are rebuilt entry-by-entry in a permuted order; the
+  resulting value is `=` to the input but has different internal insertion
+  order, which is exactly what canonical identity must collapse."
+  [v state]
+  (cond
+    (map? v) (let [ks (vec (keys v))
+                   perm (sort-by (fn [k] (rnd (+ state (hash k)) 1000000)) ks)]
+               (reduce (fn [m k] (assoc m k (get v k))) {} perm))
+    (set? v) (let [es (vec v)
+                   perm (sort-by (fn [e] (rnd (+ state (hash e)) 1000000)) es)]
+               (reduce conj #{} perm))
+    :else v))
+
+;; ---- map-order invariance ------------------------------------------------
+
+(deftest map-order-invariance
+  (testing "permuted map insertion order -> identical canonical bytes"
+    (is (= (id/canonical-bytes {:page 1 :tag "cljs"})
+           (id/canonical-bytes {:tag "cljs" :page 1})))
+    (is (= (id/canonical-bytes {:filter {:archived? false :tag "cljs"}})
+           (id/canonical-bytes {:filter {:tag "cljs" :archived? false}}))))
+  (testing "generated nested maps are order-invariant under reshuffle"
+    (is (nil?
+          (loop [i 0, s 31337]
+            (if (= i 400)
+              nil
+              (let [[v s1] (gen-edn s 3)]
+                (if (and (map? v) (seq v))
+                  (let [v' (shuffle-coll v s1)]
+                    (if (= (id/canonical-bytes v) (id/canonical-bytes v'))
+                      (recur (inc i) (lcg-next s1))
+                      [v v']))
+                  (recur (inc i) (lcg-next s1))))))))))
+
+;; ---- scope / params identity (the resource-key motivation) ---------------
+
+(deftest scope-and-params-identity
+  (let [scope-a [:rf.scope/session {:user-id "u-42" :tenant-id "acme"}]
+        scope-b [:rf.scope/session {:tenant-id "acme" :user-id "u-42"}]
+        params-a {:slug "welcome" :include-comments? true}
+        params-b {:include-comments? true :slug "welcome"}]
+    (is (id/identical-identity? scope-a scope-b))
+    (is (id/identical-identity? params-a params-b))
+    (testing "different scopes with same params do NOT collide"
+      (is (not (id/identical-identity?
+                 [:rf.scope/session {:user-id "u-1"}]
+                 [:rf.scope/session {:user-id "u-2"}]))))
+    (testing "work id embeds the canonical scoped resource key + generation"
+      (let [rkey [(id/canonical scope-a) :article/by-slug (id/canonical params-a)]
+            work-id [:rf.work/resource rkey 4]]
+        (is (= (id/canonical-bytes work-id)
+               (id/canonical-bytes [:rf.work/resource
+                                    [(id/canonical scope-b) :article/by-slug (id/canonical params-b)]
+                                    4])))))))
+
+;; ---- set ordering --------------------------------------------------------
+
+(deftest set-ordering
+  (testing "sets are order-invariant by canonical element bytes"
+    (is (= (id/canonical-bytes #{3 1 2}) (id/canonical-bytes #{2 3 1})))
+    (is (= (id/canonical-bytes #{:b :a :c}) (id/canonical-bytes #{:c :a :b}))))
+  (testing "generated sets are order-invariant under reshuffle"
+    (is (nil?
+          (loop [i 0, s 4242]
+            (if (= i 300)
+              nil
+              (let [[v s1] (gen-edn s 3)]
+                (if (and (set? v) (seq v))
+                  (if (= (id/canonical-bytes v) (id/canonical-bytes (shuffle-coll v s1)))
+                    (recur (inc i) (lcg-next s1))
+                    [v])
+                  (recur (inc i) (lcg-next s1))))))))))
+
+;; ---- vector/list/set distinctness + type tags ----------------------------
+
+(deftest edn-kind-distinctness
+  (testing "vector vs list are distinct EDN facts"
+    (is (not= (id/canonical-bytes [1 2]) (id/canonical-bytes (list 1 2)))))
+  (testing "vector vs set are distinct"
+    (is (not= (id/canonical-bytes [1 2 3]) (id/canonical-bytes #{1 2 3}))))
+  (testing "the type tag keeps scalar kinds distinct"
+    (let [bs [(id/canonical-bytes "42")
+              (id/canonical-bytes 42)
+              (id/canonical-bytes :42)
+              (id/canonical-bytes [1 2])
+              (id/canonical-bytes (list 1 2))]]
+      (is (= (count bs) (count (distinct bs))))))
+  (testing "heterogeneous map keys are legal and ordered by key bytes"
+    (is (string? (id/canonical-bytes {:a 1 "a" 2 0 3 true 4})))
+    (is (= (id/canonical-bytes {:a 1 "a" 2 0 3})
+           (id/canonical-bytes {0 3 "a" 2 :a 1}))))
+  (testing "vectors preserve order (not sorted)"
+    (is (not= (id/canonical-bytes [:a :b]) (id/canonical-bytes [:b :a])))))
+
+;; ---- nil vs missing ------------------------------------------------------
+
+(deftest nil-vs-missing
+  (testing "present-nil and absent key are distinct identities"
+    (is (not (id/identical-identity? {} {:page nil})))
+    (is (not= (id/canonical-bytes {}) (id/canonical-bytes {:page nil}))))
+  (testing "canonical preserves present-nil values"
+    (is (= {:page nil} (id/canonical {:page nil})))
+    (is (= nil (id/canonical nil)))))
+
+;; ---- canonical returns an = value, order-normalized ----------------------
+
+(deftest canonical-normalized-value
+  (testing "canonical of map is =-equal but key-order-normalized"
+    (is (= {:a 1 :b 2} (id/canonical {:b 2 :a 1}))))
+  (testing "canonical recurses, preserving vector order"
+    (is (= {:xs [3 1 2]} (id/canonical {:xs [3 1 2]}))))
+  (testing "canonical of a value equals the value for in-domain scalars"
+    (is (= "x" (id/canonical "x")))
+    (is (= 7 (id/canonical 7)))
+    (is (= :k (id/canonical :k)))))
+
+;; ---- instant + uuid ------------------------------------------------------
+
+(deftest instant-and-uuid
+  (testing "uuid encodes lower-case RFC 4122 text"
+    (is (= "u:11111111-1111-1111-1111-111111111111"
+           (id/canonical-bytes #uuid "11111111-1111-1111-1111-111111111111"))))
+  #?(:clj
+     (testing "equivalent instants in different source timezones normalize to one UTC identity"
+       (is (id/identical-identity?
+             #inst "2026-06-10T10:00:00.000+10:00"
+             #inst "2026-06-10T00:00:00.000-00:00"))
+       (is (= "t:2026-06-10T00:00:00.000Z"
+              (id/canonical-bytes #inst "2026-06-10T00:00:00.000-00:00"))))))
+
+;; ---- fail-closed rejection -----------------------------------------------
+
+(defn- non-edn-id-error?
+  "Run `thunk`; true iff it threw with `:rf.error/id
+  :rf.error/non-edn-identity` ex-data."
+  [thunk]
+  (try
+    (thunk)
+    false
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+      (= :rf.error/non-edn-identity (:rf.error/id (ex-data e))))))
+
+(deftest rejection-cases
+  (testing "floats / NaN / infinities / ratios fail closed"
+    (is (non-edn-id-error? #(id/canonical-bytes 1.5)))
+    #?(:clj (is (non-edn-id-error? #(id/canonical-bytes (/ 1 3)))))
+    #?(:cljs (is (non-edn-id-error? #(id/canonical-bytes js/NaN))))
+    #?(:cljs (is (non-edn-id-error? #(id/canonical-bytes js/Infinity)))))
+  (testing "integers outside the safe range fail closed"
+    (is (non-edn-id-error? #(id/canonical-bytes 9007199254740992)))
+    (is (non-edn-id-error? #(id/canonical-bytes -9007199254740992))))
+  (testing "the safe-range boundaries are admitted"
+    (is (= "i:9007199254740991"  (id/canonical-bytes 9007199254740991)))
+    (is (= "i:-9007199254740991" (id/canonical-bytes -9007199254740991))))
+  (testing "functions fail closed"
+    (is (non-edn-id-error? #(id/canonical-bytes inc))))
+  (testing "a nested host value fails the WHOLE identity closed (no host fallback)"
+    (is (non-edn-id-error? #(id/canonical {:a {:b inc}})))
+    (is (non-edn-id-error? #(id/canonical-bytes [1 2 inc]))))
+  #?(:cljs
+     (testing "a raw JS object fails closed"
+       (is (non-edn-id-error? #(id/canonical-bytes #js {:tenant "acme"})))
+       (testing "but its explicit EDN encoding is accepted"
+         (is (string? (id/canonical-bytes {:tenant "acme"}))))))
+  #?(:clj
+     (testing "an arbitrary host object fails closed"
+       (is (non-edn-id-error? #(id/canonical-bytes (java.lang.Object.)))))))

--- a/implementation/core/test/re_frame/path_laws_cljs_test.cljc
+++ b/implementation/core/test/re_frame/path_laws_cljs_test.cljc
@@ -1,0 +1,263 @@
+(ns re-frame.path-laws-cljs-test
+  "Law / property tests for the `:rf/path` algebra (EP-0012, Conventions
+  §Path laws). Covers the put-lookup family, compose associativity,
+  prefix?/overlap? symmetry, the root-path laws, the missing-vs-present-nil
+  distinction, and template normalization (sugar -> data form).
+
+  No `clojure.test.check` on the classpath — these use a small seeded
+  generator (`gen-edn` / `gen-path`) sampled over a fixed seed so the
+  property checks are deterministic and reproducible across CLJ/CLJS. The
+  hand-rolled generator emits the same value stream on both hosts because
+  it draws from a self-contained linear-congruential PRNG, not the host
+  RNG.
+
+  Named `*-cljs-test` so the shadow-cljs `:node-test` build (ns-regexp
+  `cljs-test$`) discovers it; the `-test` suffix also satisfies the JVM
+  cognitect test-runner, so this one `.cljc` file runs on both runtimes."
+  (:refer-clojure :exclude [])
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [re-frame.path :as path]))
+
+;; ---- a deterministic, host-portable PRNG ---------------------------------
+;;
+;; A 32-bit linear-congruential generator with the Numerical-Recipes
+;; constants. Identical sequence on CLJ and CLJS because every op stays in
+;; the int32 range under `unchecked` arithmetic emulation via `bit-and`.
+
+(defn- lcg-next [state]
+  (-> (unchecked-multiply (long state) 1664525)
+      (unchecked-add 1013904223)
+      (bit-and 0x7fffffff)))
+
+(defn- rnd [state n] (mod (lcg-next state) n))
+
+;; ---- generators ----------------------------------------------------------
+
+(def ^:private seg-pool
+  [:a :b :c :x :y 0 1 2 "k" 'sym true false nil])
+
+(defn- gen-seg [state]
+  (nth seg-pool (rnd state (count seg-pool))))
+
+(defn- gen-path
+  "Generate a path of 0..max-len segments drawn from `seg-pool`. Returns
+  `[path next-state]`. nil segments are allowed (a present-nil key path)."
+  [state max-len]
+  (let [len (rnd state (inc max-len))]
+    (loop [i 0, s (lcg-next state), acc []]
+      (if (= i len)
+        [acc s]
+        (recur (inc i) (lcg-next s) (conj acc (gen-seg s)))))))
+
+(defn- gen-edn
+  "Generate a small EDN value (maps/vectors of scalars) to `depth`.
+  Returns `[value next-state]`."
+  [state depth]
+  (let [k (rnd state (if (zero? depth) 4 7))
+        s (lcg-next state)]
+    (case k
+      0 [(nth seg-pool (rnd s (count seg-pool))) (lcg-next s)]
+      1 [(rnd s 1000) (lcg-next s)]
+      2 [(str "v" (rnd s 50)) (lcg-next s)]
+      3 [nil (lcg-next s)]
+      ;; composites only when depth remains
+      4 (let [n (rnd s 3)]
+          (loop [i 0, st (lcg-next s), acc {}]
+            (if (= i n)
+              [acc st]
+              (let [kk (gen-seg st)
+                    [vv st'] (gen-edn (lcg-next st) (dec depth))]
+                (recur (inc i) st' (assoc acc kk vv))))))
+      5 (let [n (rnd s 3)]
+          (loop [i 0, st (lcg-next s), acc []]
+            (if (= i n)
+              [acc st]
+              (let [[vv st'] (gen-edn (lcg-next st) (dec depth))]
+                (recur (inc i) st' (conj acc vv))))))
+      6 [(rnd s 1000) (lcg-next s)])))
+
+(defn- samples
+  "Run `f` over `n` deterministic draws of `[value path x]`. `f` returns
+  truthy on a passing case; returns the first failing `[value path x]` or
+  nil if all pass."
+  [n f]
+  (loop [i 0, s 12345]
+    (if (= i n)
+      nil
+      (let [[v s1]  (gen-edn s 3)
+            [p s2]  (gen-path s1 4)
+            [x s3]  (gen-edn s2 2)]
+        (if (f v p x)
+          (recur (inc i) (lcg-next s3))
+          [v p x])))))
+
+;; ---- root-path laws ------------------------------------------------------
+
+(deftest root-path-laws
+  (testing "get(s, []) = s"
+    (is (= {:a 1} (path/get {:a 1} [])))
+    (is (= 42 (path/get 42 []))))
+  (testing "lookup(s, []) = present s"
+    (is (= {:present? true :value {:a 1}} (path/lookup {:a 1} [])))
+    (is (= {:present? true :value nil} (path/lookup nil []))))
+  (testing "put(s, [], x) = x  (the law raw assoc-in violates)"
+    (is (= {:b 2} (path/put {:a 1} [] {:b 2})))
+    ;; raw assoc-in would give {:a 1, nil {:b 2}}
+    (is (not= (assoc-in {:a 1} [] {:b 2}) (path/put {:a 1} [] {:b 2}))))
+  (testing "over(s, [], f) = f(s)"
+    (is (= {:a 2} (path/over {:a 1} [] #(update % :a inc)))))
+  (testing "overlap?([], p) = true for every p"
+    (is (true? (path/overlap? [] [])))
+    (is (true? (path/overlap? [] [:anything :deep 3])))
+    (is (true? (path/overlap? [:anything] [])))))
+
+;; ---- put-lookup family ---------------------------------------------------
+
+(deftest put-lookup-law
+  (testing "lookup(put(s, p, x), p) = {:present? true :value x} for all p,x"
+    (is (nil? (samples 400
+                (fn [v p x]
+                  (= {:present? true :value x}
+                     (path/lookup (path/put v p x) p)))))))
+  (testing "explicitly at p=[] and x=nil (the nil-write trap)"
+    (is (= {:present? true :value nil}
+           (path/lookup (path/put {:page 1} [:page] nil) [:page])))
+    (is (= {:present? true :value nil}
+           (path/lookup (path/put {:a 1} [] nil) [])))))
+
+(deftest lookup-put-law
+  (testing "if lookup(s,p) present with x then put(s,p,x) = s"
+    (is (nil? (samples 400
+                (fn [v p _x]
+                  (let [{:keys [present? value]} (path/lookup v p)]
+                    (if present?
+                      (= v (path/put v p value))
+                      true))))))))
+
+(deftest put-put-law
+  (testing "put(put(s,p,x),p,y) = put(s,p,y)"
+    (is (nil? (samples 400
+                (fn [v p x]
+                  (= (path/put v p x)
+                     (path/put (path/put v p :first) p x))))))))
+
+;; ---- compose laws --------------------------------------------------------
+
+(deftest compose-laws
+  (testing "compose(p,[]) = p and compose([],p) = p"
+    (is (= [:a :b] (path/compose [:a :b] [])))
+    (is (= [:a :b] (path/compose [] [:a :b]))))
+  (testing "compose associativity over generated paths"
+    (is (nil?
+          (loop [i 0, s 999]
+            (if (= i 300)
+              nil
+              (let [[p s1] (gen-path s 3)
+                    [q s2] (gen-path s1 3)
+                    [r s3] (gen-path s2 3)]
+                (if (= (path/compose (path/compose p q) r)
+                       (path/compose p (path/compose q r)))
+                  (recur (inc i) (lcg-next s3))
+                  [p q r])))))))
+  (testing "get-compose: get(s, compose(p,q)) = get(get(s,p), q) when intermediate present"
+    (let [s {:cart {:items {42 {:qty 2}}}}
+          p [:cart :items]
+          q [42 :qty]]
+      (is (= (path/get s (path/compose p q))
+             (path/get (path/get s p) q)))
+      (is (= 2 (path/get s (path/compose p q)))))))
+
+;; ---- over law ------------------------------------------------------------
+
+(deftest over-law
+  (testing "over(s,p,identity) = s when present"
+    (is (nil? (samples 300
+                (fn [v p _x]
+                  (let [{:keys [present?]} (path/lookup v p)]
+                    (if present?
+                      (= v (path/over v p identity))
+                      true)))))))
+  (testing "over(s,p,f) = put(s,p,f(get(s,p))) (nil-on-missing get semantics)"
+    (is (nil? (samples 300
+                (fn [v p _x]
+                  (= (path/over v p (fn [x] [:wrapped x]))
+                     (path/put v p [:wrapped (path/get v p)]))))))))
+
+;; ---- prefix? / overlap? --------------------------------------------------
+
+(deftest prefix-and-overlap
+  (testing "prefix? basics"
+    (is (true? (path/prefix? [:cart] [:cart :items 42])))
+    (is (false? (path/prefix? [:cart :items 42] [:cart])))
+    (is (true? (path/prefix? [] [:anything])))
+    (is (true? (path/prefix? [:a] [:a]))))
+  (testing "overlap? examples from the spec"
+    (is (true? (path/overlap? [:cart :items] [:cart :items 42 :qty])))
+    (is (true? (path/overlap? [:cart :items 42 :qty] [:cart :items 42])))
+    (is (false? (path/overlap? [:cart :items 42] [:cart :items 43])))
+    (is (false? (path/overlap? [:cart :items] [:profile :display-name]))))
+  (testing "overlap? is symmetric over generated path pairs"
+    (is (nil?
+          (loop [i 0, s 7777]
+            (if (= i 400)
+              nil
+              (let [[p s1] (gen-path s 4)
+                    [q s2] (gen-path s1 4)]
+                (if (= (path/overlap? p q) (path/overlap? q p))
+                  (recur (inc i) (lcg-next s2))
+                  [p q]))))))))
+
+;; ---- missing vs present nil ----------------------------------------------
+
+(deftest missing-versus-present-nil
+  (testing "absent key vs present-nil are distinct under lookup"
+    (is (= {:present? false} (path/lookup {} [:page])))
+    (is (= {:present? true :value nil} (path/lookup {:page nil} [:page]))))
+  (testing "get returns not-found only when missing, never for present-nil"
+    (is (= ::nf (path/get {} [:page] ::nf)))
+    (is (= nil  (path/get {:page nil} [:page] ::nf)))))
+
+;; ---- template normalization (disposition 2) ------------------------------
+
+(deftest template-normalization
+  (testing "'?name sugar normalizes to the data form [:rf.path/param :name]"
+    (is (= [:billing :invoices :by-id [:rf.path/param :invoice-id] :email]
+           (path/normalize-template
+             [:billing :invoices :by-id '?invoice-id :email]))))
+  (testing "already-canonical data-form passes through unchanged (idempotent)"
+    (let [canon [:billing [:rf.path/param :invoice-id] :email]]
+      (is (= canon (path/normalize-template canon)))
+      (is (= canon (path/normalize-template (path/normalize-template canon))))))
+  (testing "'?name NEVER survives into the normalized shape"
+    (is (not (some symbol? (path/normalize-template [:a '?x :b '?y])))))
+  (testing "a literal symbol that is not a ?-marker passes through"
+    (is (= [:a 'plain :b] (path/normalize-template [:a 'plain :b])))
+    ;; a bare `?` symbol is not a marker (name length 1)
+    (is (= ['?] (path/normalize-template ['?]))))
+  (testing "template? detection"
+    (is (true? (path/template? [:a '?x])))
+    (is (true? (path/template? [:a [:rf.path/param :x]])))
+    (is (false? (path/template? [:a :b 3]))))
+  (testing "param-segment? recognises only the data form"
+    (is (true? (path/param-segment? [:rf.path/param :id])))
+    (is (false? (path/param-segment? '?id)))
+    (is (false? (path/param-segment? [:rf.path/param :id :extra])))
+    (is (false? (path/param-segment? [:rf.path/param "id"])))))
+
+;; ---- instantiate ---------------------------------------------------------
+
+(deftest instantiate-template
+  (testing "substitutes bound params, leaves literals"
+    (is (= [:billing :invoices :by-id "iid" :email]
+           (path/instantiate
+             [:billing :invoices :by-id '?invoice-id :email]
+             {:invoice-id "iid"}))))
+  (testing "accepts a named-path-declaration map"
+    (is (= [:profile :display-name]
+           (path/instantiate {:id :p :rf/path [:profile :display-name]} {}))))
+  (testing "a present-nil binding is a legal substitution"
+    (is (= [:a nil :c] (path/instantiate [:a '?x :c] {:x nil}))))
+  (testing "an unbound param fails closed"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+                 (path/instantiate [:a '?x] {})))))

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -15,7 +15,7 @@ The v2 prefix migration moved the per-feature trace surfaces (`:rf.machine/*`, `
 
 | Sub-namespace | Used for | Spec |
 |---|---|---|
-| `:rf/*` | Pattern-level events emitted or consumed by the framework (e.g. `:rf/hydrate`, `:rf/server-init`); pattern-level effect-map keys; reserved hiccup heads (`:rf/suspense-boundary` per [011 §Streaming SSR](011-SSR.md#streaming-ssr) — (a)). **`:rf/default`** sits in this `:rf/*` scheme but, per [EP-0002](../docs/EP/EP-0002-frame-target-resolution.md), it is an **ordinary frame id with no framework privilege** — not auto-created by `init!`, not a resolution fallback, not inferred from a missing frame; it is merely a legal id a small app or migration may **explicitly** register and select (the runtime never synthesises it). **Note:** the former reserved app-db root `:rf/runtime` is **retired** — framework durable state now lives in the **runtime-db** partition under the coeffect/effect key `:rf.db/runtime` (per [§Reserved partition keys](#reserved-partition-keys) and [§Reserved runtime-db keys](#reserved-runtime-db-keys)); a stray `:rf/runtime` root in app-db is a hard error in final form (per [§The legacy `:rf/runtime` root](#the-legacy-rfruntime-root-hard-error-in-final-form)). | 002 / 011 / 012 |
+| `:rf/*` | Pattern-level events emitted or consumed by the framework (e.g. `:rf/hydrate`, `:rf/server-init`); pattern-level effect-map keys; reserved hiccup heads (`:rf/suspense-boundary` per [011 §Streaming SSR](011-SSR.md#streaming-ssr) — (a)); the **named-path-declaration slot key `:rf/path`** (the path slot of a named-path-declaration map, per [EP-0012](../docs/EP/EP-0012-path-optics-and-canonical-forms.md) and [§The `:rf/path` algebra](#the-rfpath-algebra)). **`:rf/default`** sits in this `:rf/*` scheme but, per [EP-0002](../docs/EP/EP-0002-frame-target-resolution.md), it is an **ordinary frame id with no framework privilege** — not auto-created by `init!`, not a resolution fallback, not inferred from a missing frame; it is merely a legal id a small app or migration may **explicitly** register and select (the runtime never synthesises it). **Note:** the former reserved app-db root `:rf/runtime` is **retired** — framework durable state now lives in the **runtime-db** partition under the coeffect/effect key `:rf.db/runtime` (per [§Reserved partition keys](#reserved-partition-keys) and [§Reserved runtime-db keys](#reserved-runtime-db-keys)); a stray `:rf/runtime` root in app-db is a hard error in final form (per [§The legacy `:rf/runtime` root](#the-legacy-rfruntime-root-hard-error-in-final-form)). | 002 / 011 / 012 |
 | `:rf.db/*` | The two-partition frame-state vocabulary — `:rf.db/runtime` (the framework-owned **runtime-db** partition, a coeffect/effect key and the runtime-db slot inside a frame-state projection) and `:rf.db/app` (the app-db slot inside a frame-state projection; the *event-context* spelling of app-db stays the inherited bare `:db`). Per [002 §The two-partition frame contract](002-Frames.md#the-two-partition-frame-contract) and [§Reserved partition keys](#reserved-partition-keys). | 002 |
 | `:rf.runtime/*` | Runtime-db **subsystem children** — `:rf.runtime/machines`, `:rf.runtime/routing`, `:rf.runtime/elision`, `:rf.runtime/ssr`, and (the post-v1 Resources artefact) `:rf.runtime/resources` + `:rf.runtime/work-ledger` + `:rf.runtime/mutations`. Each is a reserved sub-tree of the runtime-db partition. Per [§Reserved runtime-db keys](#reserved-runtime-db-keys). | 002 / 005 / 009 / 011 / 012 / 016 |
 | `:rf.frame/id` | The current frame's id, threaded as a coeffect on every event context (the runtime-context spelling; distinct from the public `:frame` dispatch/subscribe opt, which is unchanged). Per [002 §Event context threads both partitions](002-Frames.md#event-context-threads-both-partitions). | 002 |
@@ -51,6 +51,7 @@ The v2 prefix migration moved the per-feature trace surfaces (`:rf.machine/*`, `
 | `:rf.scope/*` | Resource cache-scope policy keywords ([016-Resources §Scope resolution](016-Resources.md#scope-resolution)). Closed reserved members: `:rf.scope/global` (the explicit, auditable global-scope claim), `:rf.scope/from-caller` (scope required from the use site), and the scope-shape head keyword `:rf.scope/session` used in example session scopes (`[:rf.scope/session {…}]`). There is **no silent `:rf.scope/global` default** — `:scope` is required at `reg-resource` (fail-closed, rf2-6rrz53). Reserved whether or not the implementation ships the Resources artefact. | 016 |
 | `:rf.work/*` | Frame work-ledger work-id head keywords ([016-Resources §Frame work ledger](016-Resources.md#frame-work-ledger)). The resource writer's work-id head is `:rf.work/resource` (the `[:rf.work/resource resource-key generation]` shape); the mutation writer reuses the same `:rf.work/resource` shape keyed by the mutation instance (the `[:rf.work/resource [:rf.mutation instance-id] generation]` form), `:work/kind :mutation` (rf2-dwme29). Named neutrally so later work-ledger writers (timers, streams, route loaders, spawned actors, machine async work) add their own `:rf.work/<kind>` head under the same reserved segment. Reserved whether or not the implementation ships the Resources artefact. | 016 |
 | `:rf.schema/*` | Schema / validation namespace. Closed reserved set of two members: `:rf.schema/violation` (hot-reload schema-mismatch warning — fires when a file-save re-evaluates `reg-app-schema` with a different schema for the same path and the live app-db value at that path no longer validates against the **new** schema; `:op-type :warning`, recovery `:logged-and-skipped`; per [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue) and [010 §Schema migration on hot-reload](010-Schemas.md#schema-migration-on-hot-reload)) and `:rf.schema/at-boundary` (the boundary-validation interceptor's `:id` — per [API.md §`validate-at-boundary-interceptor`](API.md#schemas) and [010 §Production builds](010-Schemas.md#production-builds)). v1's `:spec` per-`reg-*` metadata key, the v2 `:rf.spec/*` trace namespace, and the bare `:spec/*` interceptor-id namespace are all collapsed into `:rf.schema/*` under the unified `schema` vocabulary. Migration: see [MIGRATION §M-54](../migration/from-re-frame-v1/README.md#m-54-schema-vocabulary-unification--spec--schema). | 009 / 010 |
+| `:rf.path/*` | Path-algebra namespace ([EP-0012](../docs/EP/EP-0012-path-optics-and-canonical-forms.md), [§The `:rf/path` algebra](#the-rfpath-algebra)). Closed reserved member at the segment level: the **template-parameter segment** data form `[:rf.path/param <name>]` — the canonical stored shape of a path-template variable (a 2-vector headed by `:rf.path/param` with a keyword name). This is the ONLY template-variable shape that appears in any stored or serialized path; the `'?name` quote-symbol spelling is declaration-boundary sugar normalized into it (one fact, one identity). Distinct from the path-slot declaration key **`:rf/path`** (under the bare `:rf/*` root, the named-path-declaration map's path slot — first row of this table's scheme). Reserved whether or not a port ships the named-declaration surface — ports MUST NOT register the namespace for any other purpose. | EP-0012 |
 
 ### Error-id and warning-id grammar
 
@@ -466,6 +467,170 @@ A *feature* is identified by its **id prefix**, not by a registry kind. By conve
 A feature does not reach into another feature's slice directly — it goes through the other feature's subs (to read) and dispatches the other feature's events (to write). Construction prompt CP-6 enforces this at scaffold time.
 
 Full rationale: [000-Vision §Pointers to per-area Specs (Features)](000-Vision.md#pointers-to-per-area-specs) and [Construction-Prompts.md §CP-6](Construction-Prompts.md).
+
+## The `:rf/path` algebra
+
+This is the normative home for one path algebra and one canonical-identity rule, stated once, with laws every consumer inherits ([EP-0012](../docs/EP/EP-0012-path-optics-and-canonical-forms.md), ACCEPTED — ruling rf2-s7xshi). app-db and runtime-db focus, schema paths, redaction-mark paths, flow inputs/outputs, route params, resource cache keys, work ids, and future feature-module declarations all cite this section instead of restating fragments. Plain vector paths stay valid and mechanically migratable from re-frame v1; this section names the algebra behind them, it does not add a public optics API.
+
+**Internal-first (EP-0012 disposition 1).** The *semantics below are normative immediately*. The reference helpers (conceptually `rf.path/{get,lookup,put,over,compose,prefix?,overlap?,instantiate}` and `rf.identity/{canonical,canonical-bytes}`) are **internal** at this slice — there is no `re-frame.core` facade export and no facade classification yet. An op graduates to a public name only once **two or more** consumers (flows / schemas / routing / resources / [EP-0015](../docs/EP/EP-0015-frame-owned-egress-policy.md) frame-config path maps / [EP-0016](../docs/EP/EP-0016-resource-mutation-completion.md) map-form targets) use it through the internal namespace without requiring a shape change; the facade-export classification rule applies to each name at its graduation. Subsystems MUST NOT keep private ad hoc overlap, canonicalization, or path-round-trip logic once these helpers exist — there is no "tool-only" path semantics, and public helpers (when exposed) obey the identical laws.
+
+### Path shape and segment domain
+
+A **concrete `:rf/path`** is a vector of EDN path segments that focuses a value inside an ordinary Clojure/EDN value:
+
+```clojure
+[]
+[:user]
+[:cart :items 42 :qty]
+[:rf.runtime/routing :current :params :slug]
+```
+
+The empty vector `[]` is the **root path** — it focuses the entire value. The primary container is a vector; APIs MAY accept any sequential collection for migration ergonomics, but the canonical form is a vector and **all stored declarations MUST normalize to a vector**.
+
+**Segment domain (the shared upper bound).** Concrete segments MUST be portable EDN identity values usable as associative keys or vector indexes: keywords, strings, symbols, integers (in the safe-integer range — see below), booleans, UUIDs, instants, and `nil` (when the host can represent them as EDN). Functions, atoms, promises, DOM nodes, AbortControllers, opaque host objects, and other host handles are **not** valid segments. This is the shared upper bound, not a requirement that every subsystem accept every type: a spec MAY deliberately *narrow* the domain for its surface (e.g. flows exclude `nil` output segments; SSR allowlists are single-segment) as long as it records the narrowing as a **stated policy over the shared definition**, never a private re-definition. Concrete runtime paths MUST NOT contain host values; such values are rejected at the boundary that accepts the path.
+
+**Partition-relative.** This algebra defines path *semantics*, not partition *ownership*. The owning spec still selects the root value (app-db, runtime-db, the sub/flow output, the event arg-map, the machine `:data` value); the shared algebra applies after that selection.
+
+### Path operations
+
+```clojure
+(get value path)        ;; the focused value, or nil when missing
+(get value path nf)     ;; nf when missing
+(lookup value path)     ;; {:present? true :value v} | {:present? false}
+(put value path x)      ;; value with x installed at path
+(over value path f)     ;; value with f applied to the current focus
+(compose p q)           ;; the two paths appended (canonical vector)
+(prefix? p q)           ;; true when p is a prefix of q
+(overlap? p q)          ;; true when either path is a prefix of the other
+```
+
+`over` on a missing path calls `f` with `nil`, matching `update-in`, unless a surface explicitly provides a not-found-aware operation. A subsystem that must distinguish missing from present `nil` uses `lookup` first.
+
+### Path laws
+
+For concrete paths and EDN values, conforming helpers MUST satisfy these laws:
+
+```text
+lookup(put(s, p, x), p) = {:present? true, :value x}            ;; put-lookup
+if lookup(s, p) = {:present? true, :value x}
+  then put(s, p, x) = s                                          ;; lookup-put
+put(put(s, p, x), p, y) = put(s, p, y)                           ;; put-put
+compose(p, []) = p ; compose([], p) = p                          ;; compose units
+compose(compose(p, q), r) = compose(p, compose(q, r))            ;; compose assoc.
+get(s, compose(p, q), nf) = get(get(s, p), q, nf)                ;; get-compose
+  when lookup(s, p) is present and the focus supports q
+over(s, p, identity) = s    when lookup(s, p) is present         ;; over identity
+over(s, p, f) = put(s, p, f(get(s, p)))                          ;; over (nil-on-missing get)
+```
+
+The root-path laws are:
+
+```text
+get(s, [], nf)  = s
+lookup(s, [])   = {:present? true, :value s}
+put(s, [], x)   = x
+over(s, [], f)  = f(s)
+overlap?([], p) = true
+```
+
+The laws are not decorative: raw `assoc-in` violates the root-path law — `(assoc-in {:a 1} [] {:b 2})` returns `{:a 1, nil {:b 2}}`, assoc'ing under the key `nil` instead of replacing the root. A `put` that delegates to `assoc-in` is therefore non-conforming; the required behaviour is `put(s, [], x) = x`. A second realistic violation: a `put` that "optimizes" `nil` writes by `dissoc`-ing breaks put-lookup at `x = nil` — exactly the missing-vs-present-`nil` ambiguity below.
+
+**Intermediate-container policy (stated once).** Missing or segment-incompatible intermediate values are created as **maps**, matching Clojure's `assoc-in` / `update-in` map-creation behaviour. Vector indexes are supported only for in-range non-negative integer segments; a vector faced with a non-integer or out-of-range segment is replaced by a fresh map (defining the vector-index case explicitly rather than letting a host `assoc` throw). This keeps `put` total so the put-lookup law holds for every path, while never corrupting a compatible existing container.
+
+### Missing versus present `nil`
+
+`nil` is a valid EDN value, and an absent key differs from a key present with value `nil`:
+
+```clojure
+(lookup {} [:page])        ;; => {:present? false}
+(lookup {:page nil} [:page]) ;; => {:present? true :value nil}
+```
+
+Canonical identity preserves this distinction: `(canonical {})` is **not** `(canonical {:page nil})`. A surface MAY intentionally elide `nil` before canonicalization, but that is a surface-specific policy (routing's query printing omits a `nil` query key; resource params get no such elision for free), never the canonical-identity rule.
+
+### Path prefix and overlap
+
+```clojure
+(prefix? [:cart] [:cart :items 42])        ;; => true
+(prefix? [:cart :items 42] [:cart])        ;; => false
+(overlap? [:cart :items] [:cart :items 42]) ;; => true (parent/child)
+(overlap? [:cart :items 42] [:cart :items 43]) ;; => false (siblings)
+(overlap? [] [:anything])                  ;; => true
+```
+
+`overlap?` is true exactly when either path is a prefix of the other, and it is **symmetric**. This is the relation flows already need: flow B depends on flow A when A's output overlaps one of B's inputs, and two output paths in one frame are invalid when they overlap. Flows MUST use the shared relation, not a private one. (Path *templates* need a separate `may-overlap?` relation because variables stand for many concrete values; that is tooling-only and not required for concrete runtime flow sorting.)
+
+### Named path declarations and templates (disposition 2)
+
+A named path declaration is a data map; this EP reserves **`:rf/path`** as the path slot:
+
+```clojure
+{:id      :invoice/customer-email
+ :rf/path [:billing :invoices :by-id [:rf.path/param :invoice-id] :customer :email]
+ :params  [:map [:invoice-id :uuid]]
+ :owner   :billing/invoices
+ :schema  :app/email
+ :privacy #{:sensitive}}
+```
+
+A **path template** is a declaration-time path with named variables. The **canonical stored shape** of a template variable is the explicit data form **`[:rf.path/param <name>]`** (under the reserved `:rf.path/*` namespace). The `'?name` quote-symbol spelling is **declaration-boundary sugar**, normalized into the data form. Per disposition 2's riders: the data form is what `CEDN-1` encodes and what traces/Xray display — **`'?name` never appears in any stored or serialized shape** (one fact, one identity); and EP-0015's frame-config path maps accept **concrete paths only** (no templates), a stated narrowing. A concrete runtime path that literally contains the symbol `?invoice-id` is just a symbol segment — it is not substituted unless processed as a template declaration. Instantiation is pure; an unbound parameter fails closed (an unbound param would silently produce a `nil` segment). Named paths are optional for application authors but SHOULD be preferred when a path carries ownership, schema, privacy, projection, or derivation metadata.
+
+### Canonical EDN identity
+
+Canonical identity is a pure function over portable EDN, used for every equality-sensitive runtime identity: resource params and scopes, scoped resource keys, work ids, route path/query params (after route-specific coercion), named path declarations and templates, schema digest path keys, and any future derivation/process identity. **Equal facts produce the same identity across CLJ/CLJS hosts, and unsupported values fail closed.**
+
+Canonical identity is **not** stringification. `str`, `pr-str` over unordered host maps, `JSON.stringify`, and object identity are not valid identity contracts — they differ by host, leak insertion order, or depend on references.
+
+**Identity vs digest (disposition 5).** The canonical EDN value **is the identity** everywhere — storage, work ledger, traces, epoch/replay records. A **digest** is an *optional, versioned, always-recomputable projection* for size-constrained surfaces (the existing `:rf.size/include-digests?` flag is the precedent); it is never an independent identity fact, never required for correctness, and never the authoritative stored key in v1. Tools SHOULD retain a human-readable EDN projection for debugging (Xray rows stay readable).
+
+The **`CEDN-1` canonical EDN domain** is: `nil`, booleans, strings, keywords, symbols; portable integers in the ECMAScript safe-integer range `[-9007199254740991, 9007199254740991]`; UUIDs and instants (as EDN values or explicit tagged data); and vectors, lists, maps, and sets whose nested values are canonical EDN values. A subsystem MAY choose a smaller input domain for safety, stated explicitly; that is not a fork of the encoding.
+
+The canonicalizer **MUST reject by default** (fail closed, error id `:rf.error/non-edn-identity` — under the reserved `:rf.error/*` namespace and grammar above): functions; atoms, refs, volatiles, promises, futures; DOM nodes, React elements, AbortControllers, request handles, timers; arbitrary host objects or class instances; floating-point values, ratios, arbitrary-precision decimals, NaN, and infinities (unless a future spec encodes the numeric class); and mutable by-reference objects. An out-of-domain value buried anywhere in a structure fails the **whole** identity closed, never a host-comparison fallback. APIs that need such values MUST encode them into portable EDN first (e.g. coerce a host date to an EDN `#inst` instant at the boundary, after which it is an instant fact, not a host object).
+
+### Canonical byte encoding (`CEDN-1`)
+
+`CEDN-1` is the reference byte encoding — an internal comparison/digest format, not a display or URL format. Implementations MAY store a normalized EDN projection or a digest over these bytes, but equality-sensitive comparison MUST be equivalent to comparing `CEDN-1` bytes. It encodes a UTF-8 token stream with a **type tag before every value**:
+
+| EDN value | Canonical token |
+|---|---|
+| `nil` | `n` |
+| Boolean | `b:0` or `b:1` |
+| String | `s:` plus a canonical EDN string literal over Unicode scalar values |
+| Keyword | `k:` plus the canonical EDN keyword token, without auto-resolved `::` shorthand |
+| Symbol | `y:` plus the canonical EDN symbol token |
+| Portable integer | `i:` plus base-10 digits in the safe range, no leading `+`, no leading zero except `0` |
+| UUID | `u:` plus lower-case RFC 4122 text |
+| Instant | `t:` plus RFC 3339 UTC text with millisecond precision |
+| Vector | `v[` elements in order `]` |
+| List | `l(` elements in order `)` |
+| Set | `q#{` elements sorted by their `CEDN-1` bytes `}` |
+| Map | `m{` key/value pairs sorted by key `CEDN-1` bytes `}` |
+
+Adjacent element tokens, and each map key from its value, are separated by a single ASCII space. String/keyword/symbol encoders MUST reject names that cannot round-trip through portable EDN readers on both CLJ and CLJS. Instant encoding normalizes equivalent instants to UTC before printing (timezone text from the source literal is not identity). The type tag is part of the bytes, so `"42"`, `42`, `:42`, `[1 2]`, and `(1 2)` cannot collide; **heterogeneous map keys are therefore legal** within the supported domain (the sort key is the complete type-tagged key byte sequence). If a value is outside the domain, the whole identity fails closed.
+
+**Map key canonicalization.** Map entries MUST be ordered deterministically by the `CEDN-1` bytes of their keys — not by insertion order, hash-map iteration order, locale, or host identity. Compute each key's bytes, sort lexicographically, encode entries in that order. Duplicate canonical keys are invalid and MUST be rejected before the value becomes a cache key, route identity, or work id.
+
+```clojure
+(= (canonical {:page 1 :tag "cljs"}) (canonical {:tag "cljs" :page 1})) ;; => true
+```
+
+**Sequences and sets.** Vectors and lists preserve their kind and element order and are distinct EDN facts (not silently collapsed). Sets are unordered — canonical encoding sorts elements by their canonical element encoding — and remain distinct from vectors/lists. Subsystems SHOULD prefer vectors for public identity tuples (idiomatic, order-preserving, already used for event vectors, resource keys, owner tokens, causes, and work ids).
+
+### Resource identity and work ids
+
+A **scoped resource key** is `[canonical-scope resource-id canonical-params]`, where scope and params use the shared canonical rule, so map insertion order cannot change the key:
+
+```clojure
+(def scope-a [:rf.scope/session {:user-id "u-42" :tenant-id "acme"}])
+(def scope-b [:rf.scope/session {:tenant-id "acme" :user-id "u-42"}])
+(= (canonical scope-a) (canonical scope-b)) ;; => true
+```
+
+**Work ids** build on the same identity (`[:rf.work/resource scoped-resource-key generation]`). One work record MUST have one canonical id — a subsystem MUST NOT carry a second near-duplicate stale-suppression key for the same facts under a different head keyword (EP-0007's one-name-per-fact rule applied to identity; the `:work/id`-vs-`:stale-key` near-duplicate is the motivating instance).
+
+### Routes are prisms (deferred to Spec 012)
+
+Registered route patterns define a lawful partial round trip (a *prism*) between URLs and route data — `match-url(route-url(...))` returns canonical route data, query keys are emitted in deterministic canonical order, `nil` query values are elided, and out-of-domain params fail closed. The prism laws are normative but their **conformance and consumer wiring live in [012-Routing.md](012-Routing.md)** (a tier-2 consumer sweep, epic `rf2-94o54l`); this foundation slice states only the shared path/identity definition they cite. A future data-form route pattern (disposition 4) MUST normalize into the canonical `[:rf.path/param …]` template shape — a second template grammar would be the per-subsystem redefinition this algebra exists to prevent.
 
 ## Canonical event-vector shape (best practice)
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2297,6 +2297,64 @@ Cross-reference: `:rf/machine-snapshot` (above) is the value type for each entry
 
 > **Further runtime-db children — `:rf.runtime/resources`, `:rf.runtime/work-ledger`, and (with the mutation slice) `:rf.runtime/mutations` — are added by the OPTIONAL post-v1 Resources artefact** (`day8/re-frame2-resources`, [016-Resources.md](016-Resources.md)), NOT by the v1-required `RuntimeDb` validator above. An app that omits the artefact carries none of them; `:rf.runtime/mutations` is present only once the app registers a mutation. Their shapes (`:rf/resource-entry`, `:rf/resource-work-record`, `:rf/scoped-resource-key`, and the `MutationInstance` row) are below.
 
+### `:rf/path`, `:rf/path-template` (the path algebra, EP-0012)
+
+> **Layer:** Value
+> **Owner:** [Conventions.md §The `:rf/path` algebra](Conventions.md#the-rfpath-algebra) (graduated from [EP-0012](../docs/EP/EP-0012-path-optics-and-canonical-forms.md))
+> **Status:** v1-required (semantics normative immediately; the helper namespaces are internal at this slice)
+
+The shared `:rf/path` shape every path-consuming surface (app-db / runtime-db focus, schema paths, redaction marks, flow inputs/outputs, route params, named declarations) normalizes to. A **concrete path** is a vector of portable-EDN segments; the root path is `[]`. A **path template** additionally admits the canonical template-parameter segment `[:rf.path/param <name>]` (the `'?name` quote-symbol spelling is declaration sugar normalized into this data form — it never appears in a stored shape). The segment schema is the **shared upper bound**: a subsystem MAY narrow it (a stated policy, never a private redefinition).
+
+```clojure
+(def PathSegment
+  ;; The shared segment domain (Conventions §Path shape and segment domain).
+  ;; Portable EDN identity values usable as associative keys / vector indexes.
+  ;; Host values (fns, atoms, promises, DOM nodes, opaque host objects) are
+  ;; NOT segments and are rejected at the boundary that accepts the path.
+  ;; A subsystem MAY narrow this (e.g. flows exclude nil output segments).
+  [:or
+   :keyword
+   :string
+   :symbol
+   :int           ;; portable integer (the canonical-identity safe range applies to identity use)
+   :boolean
+   :uuid
+   inst?          ;; instant
+   :nil])
+
+(def Path
+  ;; A CONCRETE :rf/path — a vector of segments. [] is the root path.
+  ;; The canonical container is a vector; sequential inputs normalize to one.
+  [:vector PathSegment])
+
+(def ParamSegment
+  ;; The canonical stored shape of a template variable (reserved :rf.path/*).
+  ;; This is the ONLY template-variable shape in any stored / serialized path
+  ;; or CEDN-1 encoding (EP-0012 disposition 2).
+  [:tuple [:= :rf.path/param] :keyword])
+
+(def PathTemplate
+  ;; A declaration-time path that MAY carry [:rf.path/param <name>] segments
+  ;; alongside literal segments. Instantiation substitutes bound params into
+  ;; a concrete Path (an unbound param fails closed).
+  [:vector [:or ParamSegment PathSegment]])
+
+(def NamedPathDeclaration
+  ;; A named path declaration map. :rf/path is the reserved path slot (under
+  ;; the :rf/* root). Optional metadata feeds schema / privacy / ownership /
+  ;; derivation consumers. Named paths are optional for app authors.
+  [:map
+   [:id      :keyword]
+   [:rf/path PathTemplate]
+   [:params  {:optional true} :any]     ;; a Malli schema for the template params
+   [:owner   {:optional true} :keyword]
+   [:schema  {:optional true} :keyword]
+   [:privacy {:optional true} [:set :keyword]]
+   [:doc     {:optional true} :string]])
+```
+
+`overlap?` (one path a prefix of the other, either direction) is the shared relation flows use for dependency edges and output-collision detection. Canonical EDN identity over path segments / declarations / params uses the `CEDN-1` rule (Conventions §Canonical byte encoding); out-of-domain values fail closed with `:rf.error/non-edn-identity`.
+
 ### `:rf/scoped-resource-key`, `:rf/resource-entry`, `:rf/resource-work-record` (Resources, Spec 016)
 
 > **Layer:** Runtime


### PR DESCRIPTION
Foundation slice of the EP-0012 action wave (ACCEPTED, ruling `rf2-s7xshi`). Graduates the shared path/identity algebra into its normative home and ships the internal reference helpers + law tests. **Semantics are normative immediately; the helper names are internal-only at this slice** (no facade export, no classification — EP-0012 disposition 1). Bead: `rf2-nd7b3e`.

## What landed

**`spec/Conventions.md` §The `:rf/path` algebra** (new normative home; HOT-ZONE — sole toucher this slice):
- The `:rf/path` vocabulary — concrete paths, the shared segment domain (the upper bound subsystems may narrow as a stated policy), root `[]` semantics.
- The path laws — put-lookup / lookup-put / put-put / compose units + associativity / get-compose / over; `overlap?` as the **symmetric** shared-prefix relation; the explicit intermediate-container policy; missing-vs-present-`nil`.
- Canonical EDN identity + the versioned **CEDN-1** byte encoding — the token table, map-key byte ordering, set/seq ordering, fail-closed `:rf.error/non-edn-identity` (floats / NaN / infinities / ratios / out-of-range integers / host objects).
- The template data form `[:rf.path/param :name]` as the canonical stored shape, with `'?name` as declaration sugar normalized into it (disposition 2 — `'?name` never survives into storage).
- The identity-vs-digest rule (disposition 5: canonical EDN **is** the identity; digests are optional recomputable projections, never authoritative).
- Reserved-namespace rows: `:rf.path/*` (the `[:rf.path/param …]` data form) and the `:rf/path` declaration-slot key under the `:rf/*` root.

**`spec/Spec-Schemas.md` §`:rf/path`, `:rf/path-template`** (also hot-zone — flagged; no other worker on it): the Malli value schemas `PathSegment` / `Path` / `ParamSegment` / `PathTemplate` / `NamedPathDeclaration`.

**Internal helpers** (no `re-frame.core` export):
- `re-frame.path` — `get` / `lookup` / `put` / `over` / `compose` / `prefix?` / `overlap?` / `normalize` / `normalize-template` / `param-segment?` / `template?` / `instantiate`.
- `re-frame.identity` — `canonical` / `canonical-bytes` / `identical-identity?` + the CEDN-1 encoder; cross-host CLJ/CLJS.

**Law/property tests** (`.cljc`, run on BOTH JVM + CLJS):
- `path_laws_cljs_test` — root-path laws, put-lookup / lookup-put / put-put (400-sample seeded generator), compose associativity, over-identity, `prefix?`/`overlap?` symmetry, missing-vs-present-`nil`, template normalization + `instantiate`.
- `identity_cedn1_cljs_test` — map-order invariance, scope/params/work-id identity, set ordering, vector/list/set distinctness + type tags, nil-vs-missing, instant timezone normalization, the fail-closed rejection cases (incl. CLJS `#js`/`NaN`/`Infinity`).

The put-lookup property test caught a real total-ness bug (`assoc` on a vector with a non-integer segment threw `Key must be integer`); fixed with an explicit `container-for` policy documented in both code and Conventions §Path laws.

## Quality gates

- `npm run test:cljs` — **6488 tests / 23616 assertions, 0 failures, 0 errors** (the two new `*_cljs_test.cljc` law suites run on the CLJS host alongside the full suite).
- `clojure -M:test` (core artefact, JVM) — new suites + `marks_test` neighbor: **83 tests / 234 assertions, 0 failures, 0 errors**.
- `python scripts/check_doc_slugs.py` — exit 0.
- `mkdocs build --strict` (CI staging reproduced: `cp -r spec docs/spec` + `cp -r migration docs/migration`) — exit 0.

## Non-goals (tier-2, epic `rf2-94o54l`)

No consumer spec sweeps (012/013/015/016 citations), no route-prism conformance, no public API.
