### PR TITLE
docs(guide): fix teardown-report example key :error -> :exception (rf2-p3vmb6)

### DIFF
--- a/docs/guide/16-observability.md
+++ b/docs/guide/16-observability.md
@@ -179,8 +179,8 @@ But *how* it's promoted is the instructive part, and it's a pattern you'll see a
  :op-type      :error
  :frame        :app/per-request-42
  :recovery     :ignored                 ;; teardown stays best-effort
- :hook-failures [{:hook :http/abort-inflight :error #object[...]}
-                 {:hook :timers/clear       :error #object[...]}]}}
+ :hook-failures [{:hook :http/abort-inflight :exception #object[...] :where :safe-call-hook!}
+                 {:hook :timers/clear       :exception #object[...] :where :safe-call-hook!}]}}
 ```
 
 One record names the higher-level fact ("this destroy had teardown failures"), and the vector preserves the *which-hooks-failed-together* correlation an external shipper would never reliably re-group. The recovery stays `:ignored` — teardown is still best-effort; promotion changed the *channel*, not the behaviour.


### PR DESCRIPTION
## Summary

`docs/guide/16-observability.md` (~line 182) showed the
`:rf.error/frame-teardown-failed` teardown-report example keying each
`:hook-failures` entry as `:error`. The shipped shape — per the Spec 009
catalogue row, `implementation/core/src/re_frame/error_emit.cljc`
(`dispatch-frame-teardown-report!`), and `frame.cljc` (`safe-call-hook!`)
— is `{:hook <key> :exception <ex> :where :safe-call-hook!}`.

This corrects the guide example to the real key (`:exception`) and adds
the carried `:where :safe-call-hook!` slot so the documented payload
matches what production actually emits. Doc-accuracy drift only; spec and
implementation are correct and unchanged.

Verified key construction against source: `safe-call-hook!` in
`frame.cljc` conj's `{:hook hook-key :exception ex :where :safe-call-hook!}`
onto the per-destroy accumulator, flushed by `dispatch-frame-teardown-report!`.

## Quality gates

- `python -m mkdocs build --strict` (repo root) — clean, exit 0.

Closes rf2-p3vmb6.