### PR TITLE
test(observability): prod-elision coverage for promoted always-on rows + teardown-hook diagnostic (rf2-9pxj70, rf2-inkdqh)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -922,17 +922,30 @@
           ;; map, no separate capture path needed. Gated on
           ;; `interop/debug-enabled?` so production CLJS builds DCE
           ;; the call-site read.
+          ;;
+          ;; rf2-inkdqh: the gate MUST be the OUTERMOST form (the canonical
+          ;; `(if interop/debug-enabled? <stamped> <plain>)` shape per Spec
+          ;; 009 §Production builds), NOT an `(and interop/debug-enabled?
+          ;; ...)` test in a `cond->` step. A `cond->` test-position gate
+          ;; leaves the `:rf.trace/call-site` keyword literal reachable in
+          ;; the assoc form — Closure does not constant-fold it away under
+          ;; `:advanced` + `goog.DEBUG=false`, so the keyword survived into
+          ;; production bundles (caught by the elision-probe once the frame-
+          ;; registration path was rooted — see
+          ;; `re-frame.elision-probe/touch-teardown!`). Splitting the gate
+          ;; to the outermost `if` lets DCE prove the whole dev arm dead.
           (when-let [on-create (:on-create config)]
-            (let [init-opts (cond-> {:frame  id
-                                     :source :frame-init}
-                              (and interop/debug-enabled?
-                                   (or (:file config) (:line config)))
-                              (assoc :rf.trace/call-site
-                                     (cond-> {}
-                                       (:ns     config) (assoc :ns     (:ns     config))
-                                       (:file   config) (assoc :file   (:file   config))
-                                       (:line   config) (assoc :line   (:line   config))
-                                       (:column config) (assoc :column (:column config)))))]
+            (let [init-opts (if interop/debug-enabled?
+                              (cond-> {:frame  id
+                                       :source :frame-init}
+                                (or (:file config) (:line config))
+                                (assoc :rf.trace/call-site
+                                       (cond-> {}
+                                         (:ns     config) (assoc :ns     (:ns     config))
+                                         (:file   config) (assoc :file   (:file   config))
+                                         (:line   config) (assoc :line   (:line   config))
+                                         (:column config) (assoc :column (:column config)))))
+                              {:frame id :source :frame-init})]
               (if trace/*handler-scope*
                 ;; Handler-created child frame (a cascade is in flight):
                 ;; async-queue on the child.

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -32,6 +32,15 @@
     (Spec 004 §Render-tree primitives, rf2-piag / rf2-t5tx). The
     instance-token mint, the `*render-key*` binding, and the late-
     bind emit must elide.
+  - `re-frame.frame/safe-call-hook!` — the EP-0008 R2 per-hook
+    `:rf.warning/teardown-hook-exception` DEV DIAGNOSTIC (rf2-inkdqh).
+    The diagnostic emit rides `trace/emit-error!` (gated on
+    `interop/debug-enabled?`), so its body — including the
+    `:rf.warning/teardown-hook-exception` operation keyword — must DCE
+    under `:advanced` + `goog.DEBUG=false`. Rooting a throwing-hook
+    `destroy-frame!` puts the gated emit in the reachability graph so the
+    control build (DEBUG=true) contains the sentinel and the production
+    build must not.
 
   Note the probe does NOT need to assert anything at runtime; it exists
   to root the dead-code-elimination graph at every surface. The grep
@@ -40,6 +49,7 @@
             [re-frame.registrar    :as registrar]
             [re-frame.schemas      :as schemas]
             [re-frame.trace        :as trace]
+            [re-frame.late-bind    :as late-bind]
             ;; rf2-qwm0a — listener + buffer surface lives in
             ;; `re-frame.trace.tooling` (production-DCE split). The
             ;; probe touches it to keep both surfaces reachable so
@@ -450,6 +460,49 @@
   (let [_v (rf/view :re-frame.elision-probe/probe-injected-view)]
     nil))
 
+;; ---- EP-0008 R2 teardown-hook DEV DIAGNOSTIC (rf2-inkdqh) -----------------
+;;
+;; `re-frame.frame/safe-call-hook!` runs the late-bound optional-artefact
+;; cleanup hooks during `destroy-frame!`. When a hook throws it does two
+;; things on two channels (Spec 009 §Observability channels):
+;;
+;;   1. ALWAYS-ON axis — accumulates a `:hook-failures` entry that
+;;      `destroy-frame!` flushes as ONE `:rf.error/frame-teardown-failed`
+;;      report (this survives production — it is NOT gated by
+;;      `interop/debug-enabled?`).
+;;   2. DIAGNOSTIC channel (EP-0008 R2) — emits a per-hook
+;;      `:rf.warning/teardown-hook-exception` trace AT ITS CAUSAL POSITION
+;;      via `trace/emit-error!`, which IS gated on `interop/debug-enabled?`,
+;;      so production CLJS bundles DCE it.
+;;
+;; Before rf2-inkdqh the probe never touched the destroy/teardown path, so
+;; the R2 diagnostic body was never in the DCE reachability graph and
+;; check-elision.cjs had no sentinel for it — its production absence was
+;; UNVERIFIED. This touch installs a throwing late-bound cleanup hook and
+;; calls `destroy-frame!`, rooting the `safe-call-hook!` catch arm + the
+;; gated warn emit so the control build (DEBUG=true) contains the
+;; `:rf.warning/teardown-hook-exception` keyword sentinel and the production
+;; build (DEBUG=false) must DCE it.
+
+(defn ^:export touch-teardown! []
+  ;; Install a throwing cleanup hook under a late-bound teardown hook key,
+  ;; snapshotting the prior binding so the install doesn't leak. The hook
+  ;; key (`:ssr/on-frame-destroyed`) is one safe-call-hook! fires during the
+  ;; teardown recipe; a throw routes through safe-call-hook!'s catch arm,
+  ;; which emits the gated `:rf.warning/teardown-hook-exception` diagnostic.
+  (let [hook-key :ssr/on-frame-destroyed
+        original (late-bind/get-fn hook-key)]
+    (late-bind/set-fn! hook-key
+                       (fn [& _] (throw (ex-info "probe teardown-hook throw"
+                                                 {:hook :probe}))))
+    (rf/reg-frame :rf.probe/teardown-frame {:doc "throwing teardown hook"})
+    (try
+      ;; The accumulated always-on report flushes (survives prod), and the
+      ;; per-hook DEV diagnostic emits at its causal position (DCEs in prod).
+      (rf/destroy-frame! :rf.probe/teardown-frame)
+      (finally
+        (late-bind/set-fn! hook-key original)))))
+
 ;; ---- entry point ----------------------------------------------------------
 
 (defn ^:export run []
@@ -462,6 +515,7 @@
   (touch-machines!)
   (touch-call-site-macros!)
   (touch-reg-view-injection!)
+  (touch-teardown!)
   ;; Reference trace/emit! directly through the trace ns alias so its
   ;; body, not just the public re-frame.core re-export, is reachable.
   (trace/emit! :event :rf.probe/direct-touch {:source :probe}))

--- a/implementation/core/test/re_frame/prod_elision_runner.cljs
+++ b/implementation/core/test/re_frame/prod_elision_runner.cljs
@@ -25,6 +25,16 @@
             [re-frame.adapter.uix-source-coord-dom-elision-prod-test]
             [re-frame.adapter.helix-source-coord-dom-elision-prod-test]
             [re-frame.on-error-elision-prod-test]
+            ;; Per rf2-9pxj70 — the three EP-0008-promoted always-on
+            ;; teardown / write-race rows
+            ;; (`:rf.error/frame-teardown-failed`,
+            ;; `:rf.error/write-after-destroy`,
+            ;; `:rf.error/on-destroy-handler-exception`) were exercised
+            ;; only by the DEV `:node-test` runner; this pins their
+            ;; production-survival under `:advanced` + `goog.DEBUG=false`,
+            ;; matching the older always-on rows in
+            ;; `on-error-elision-prod-test`.
+            [re-frame.teardown-always-on-elision-prod-test]
             [re-frame.event-emit-elision-prod-test]
             ;; Per rf2-gmrks — `:rf.error/flow-eval-exception` rides
             ;; the always-on error-emit substrate (Spec 013 §Failure

--- a/implementation/core/test/re_frame/teardown_always_on_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/teardown_always_on_elision_prod_test.cljs
@@ -1,0 +1,294 @@
+(ns re-frame.teardown-always-on-elision-prod-test
+  "EP-0008 prod-elision coverage gap — rf2-9pxj70.
+
+  EP-0008 promoted THREE teardown / write-race categories onto the
+  ALWAYS-ON error-emit axis:
+
+    :rf.error/frame-teardown-failed        (rf2-ini4wr — the bounded
+                                            teardown report)
+    :rf.error/write-after-destroy          (rf2-500ech — the dropped
+                                            nil-container write)
+    :rf.error/on-destroy-handler-exception (rf2-7b9r4l — the discriminable
+                                            :on-destroy throw signal)
+
+  Each was previously exercised ONLY by the DEV `:node-test` runner
+  (`*_always_on_cljs_test.cljc` / `frame_teardown_report_cljs_test.cljc`,
+  all matching `:ns-regexp \"cljs-test$\"`). The dev-mode tests assert the
+  always-on listener FIRES, but they run with the trace surface LIVE — they
+  cannot prove the central EP-0008 claim: that the always-on emission
+  SURVIVES `:advanced` + `goog.DEBUG=false` where the dev trace is DCE'd.
+
+  The sibling `re-frame.on-error-elision-prod-test` (rf2-2hvga / rf2-goum9x)
+  pins exactly that production-survival contract for the OLDER always-on
+  rows (handler-exception / frame-destroyed / no-such-* / fx). This file
+  closes the gap for the NEW EP-0008-promoted rows under the prod build.
+
+  NUANCE for `:rf.error/on-destroy-handler-exception` (rf2-7b9r4l): the
+  dedicated category has TWO producers with DIFFERENT prod-survival:
+
+    - COMMON path (the user `:on-destroy` handler throws): the dedicated
+      record is re-emitted by `fire-on-destroy-event!` OBSERVING the
+      router's `:rf.error/handler-exception` trace via
+      `:trace.tooling/register-listener!` — a dev-only surface that DCEs.
+      So the dedicated record does NOT survive prod for this path. The
+      PRODUCTION SOURCE OF RECORD is the router's
+      `:rf.error/handler-exception` (which DOES ride the always-on axis).
+      This is the documented PARTIAL-COVERAGE NUANCE — dev-discrimination
+      only by design, NOT a regression.
+
+    - DEFENCE-IN-DEPTH branch (`dispatch-sync!` itself faults, rf2-bxud9v):
+      `fire-on-destroy-event!` calls `emit-on-destroy-handler-exception!`
+      DIRECTLY (no trace capture), so the dedicated record DOES survive
+      prod — and this branch never produced a router handler-exception, so
+      the always-on emission is its ONLY production observability.
+
+  This file pins BOTH legs explicitly so the contract is unambiguous.
+
+  Naming convention: files ending in `-elision-prod-test.cljs` are picked
+  up ONLY by the `:browser-test-prod-elision` build (`:advanced` +
+  `{goog.DEBUG false}`, `:ns-regexp \"-elision-prod-test$\"`, runner
+  `re-frame.prod-elision-runner`). The default `:browser-test` / `:node-test`
+  runners use regexes that do NOT match this suffix, so these tests run only
+  under prod-mode compilation. (See `re-frame.on-error-elision-prod-test`
+  for the convention header.)"
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn (fn []
+                ;; Clear the always-on listener registry between tests —
+                ;; the `defonce` atom would otherwise leak a listener.
+                (error-emit/clear-error-listeners!))}))
+
+;; ---------------------------------------------------------------------------
+;; Cleanup-hook-key install helper (mirrors the dev-mode
+;; `frame-teardown-report-cljs-test/with-hooks*`). The teardown cleanup
+;; hooks are late-bound optional artefacts; we install a throwing fn under a
+;; hook key for the extent of `f`, snapshotting + restoring the prior binding
+;; so the install never leaks across tests.
+;; ---------------------------------------------------------------------------
+
+(defn- with-hooks*
+  [hook-map f]
+  (let [originals (into {} (map (fn [k] [k (late-bind/get-fn k)]) (keys hook-map)))]
+    (try
+      (doseq [[k v] hook-map] (late-bind/set-fn! k v))
+      (f)
+      (finally
+        (doseq [[k orig] originals] (late-bind/set-fn! k orig))))))
+
+(defn- throwing-hook [label]
+  (fn [& _] (throw (ex-info (str "teardown hook threw: " label) {:hook label}))))
+
+;; ===========================================================================
+;; (a) :rf.error/frame-teardown-failed — the bounded teardown report survives
+;; prod elision (rf2-ini4wr promotion).
+;; ===========================================================================
+
+(deftest frame-teardown-failed-report-survives-prod
+  (testing "Per rf2-ini4wr / EP-0008: under `:advanced` + `goog.DEBUG=false`,
+            N cleanup hooks throwing during `destroy-frame!` fan EXACTLY ONE
+            always-on `:rf.error/frame-teardown-failed` record (carrying N
+            `:hook-failures` entries) out through the corpus-wide
+            `register-error-listener!` substrate — the always-on axis is NOT
+            gated by `interop/debug-enabled?`, so the report survives where
+            the per-hook `:rf.warning/teardown-hook-exception` dev trace is
+            DCE'd. This is the production-build counterpart of the dev-mode
+            `frame-teardown-report-cljs-test` (a)/(c) legs."
+    (let [seen (atom [])]
+      (rf/register-error-listener! :prod/recorder
+                                   (fn [record] (swap! seen conj record)))
+      (rf/reg-frame :prod.teardown/n-failures {:doc "three hooks will throw"})
+      (with-hooks*
+        {:ssr/on-frame-destroyed           (throwing-hook :ssr)
+         :schemas/on-frame-destroyed!      (throwing-hook :schemas)
+         :flows/teardown-on-frame-destroy! (throwing-hook :flows)}
+        (fn [] (rf/destroy-frame! :prod.teardown/n-failures)))
+      (let [reports (filter #(= :rf.error/frame-teardown-failed (:error %)) @seen)]
+        (is (= 1 (count reports))
+            "exactly ONE always-on report under prod elision — not three")
+        (let [r (first reports)]
+          (is (= :rf.error/frame-teardown-failed (:error r)))
+          (is (= :prod.teardown/n-failures (:frame r))
+              ":frame names the destroyed frame")
+          (is (= 3 (count (:hook-failures r)))
+              "the report carries one :hook-failures entry per failed hook")
+          (is (= #{:ssr/on-frame-destroyed
+                   :schemas/on-frame-destroyed!
+                   :flows/teardown-on-frame-destroy!}
+                 (set (map :hook (:hook-failures r))))
+              "every failed hook key is represented under prod")
+          (is (= :ignored (:recovery r))
+              ":recovery :ignored — teardown is best-effort")
+          (is (number? (:time r)) ":time is a wall-clock millis number"))))))
+
+(deftest clean-destroy-emits-no-report-under-prod
+  (testing "Per rf2-ini4wr: a clean destroy (no failing hook) emits NO
+            `:rf.error/frame-teardown-failed` report under prod — the
+            always-on fan-out short-circuits on an empty :hook-failures
+            vector (no per-destroy flood in a `goog.DEBUG=false` SSR host)."
+    (let [seen (atom [])]
+      (rf/register-error-listener! :prod/recorder
+                                   (fn [record] (swap! seen conj record)))
+      (rf/reg-frame :prod.teardown/clean {:doc "no hooks throw"})
+      (rf/destroy-frame! :prod.teardown/clean)
+      (is (empty? (filter #(= :rf.error/frame-teardown-failed (:error %)) @seen))
+          "no report when teardown completes cleanly under prod"))))
+
+(deftest partial-teardown-abort-still-flushes-under-prod
+  (testing "Per rf2-ini4wr EP-0008 R1: the finally-shaped flush survives prod
+            elision too. Two cleanup hooks throw (accumulating two entries),
+            then a downstream NON-hook teardown step throws unrecoverably —
+            the throw propagates out of `destroy-frame!`, yet the always-on
+            report STILL flushes the two entries gathered before the abort.
+            Mirrors the dev-mode (b) leg under `:advanced` + `goog.DEBUG=
+            false`."
+    (let [seen (atom [])]
+      (rf/register-error-listener! :prod/recorder
+                                   (fn [record] (swap! seen conj record)))
+      (rf/reg-frame :prod.teardown/abort {:doc "aborts mid-teardown"})
+      (with-hooks*
+        {:ssr/on-frame-destroyed      (throwing-hook :ssr)
+         :schemas/on-frame-destroyed! (throwing-hook :schemas)}
+        (fn []
+          (with-redefs [frame/emit-frame-destroyed-trace!
+                        (fn [_id] (throw (ex-info "mid-teardown collapse" {})))]
+            (is (thrown? js/Error (rf/destroy-frame! :prod.teardown/abort))
+                "the downstream teardown step's throw propagates"))))
+      (let [reports (filter #(= :rf.error/frame-teardown-failed (:error %)) @seen)]
+        (is (= 1 (count reports))
+            "the report STILL flushed despite the mid-teardown abort under prod")
+        (is (= 2 (count (:hook-failures (first reports))))
+            "the report carries the TWO entries gathered before the abort")))))
+
+;; ===========================================================================
+;; (b) :rf.error/write-after-destroy — the dropped nil-container write rides
+;; the always-on axis under prod (rf2-500ech promotion).
+;; ===========================================================================
+
+(deftest write-after-destroy-survives-prod
+  (testing "Per rf2-500ech / EP-0008: under `:advanced` + `goog.DEBUG=false`,
+            a `replace-container!` against a nil container (the scheduled-
+            drain-vs-frame-destruction race) fans ONE
+            `:rf.error/write-after-destroy` record out through the always-on
+            `register-error-listener!` substrate — the promoted error
+            category survives where the retired `:rf.warning/write-after-
+            destroy` dev trace is DCE'd. This is the production-build
+            counterpart of the dev-mode `write-after-destroy-always-on-cljs-
+            test` (a)/(b) leg."
+    (let [seen (atom [])]
+      (rf/register-error-listener! :prod/recorder
+                                   (fn [record] (swap! seen conj record)))
+      ;; The real production path: every frame :db write flows through this
+      ;; choke point; a destroyed frame's container has gone nil.
+      (adapter/replace-container! nil {:dropped :write})
+      (let [reports (filter #(= :rf.error/write-after-destroy (:error %)) @seen)]
+        (is (= 1 (count reports))
+            "exactly ONE always-on record for the dropped write under prod")
+        (let [r (first reports)]
+          (is (= :rf.error/write-after-destroy (:error r))
+              "the promoted error category — not the retired warning")
+          (is (nil? (:event r))
+              "no event vector — a dropped write, not a throw on a dispatch")
+          (is (nil? (:frame r))
+              "no frame — it was destroyed (the whole point of the race)")
+          (is (nil? (:exception r))
+              "no exception — a suppressed write, not a throw")
+          (is (number? (:time r)) ":time is a wall-clock millis number"))))))
+
+;; ===========================================================================
+;; (c) :rf.error/on-destroy-handler-exception — the discriminable :on-destroy
+;; throw signal survives prod (rf2-7b9r4l promotion).
+;; ===========================================================================
+
+(deftest on-destroy-common-path-prod-coverage-is-handler-exception
+  (testing "Per rf2-7b9r4l PARTIAL-COVERAGE NUANCE: for the COMMON path (the
+            user `:on-destroy` handler itself throws), the DEDICATED
+            `:rf.error/on-destroy-handler-exception` category is
+            dev-discrimination-ONLY by design — it is re-emitted by
+            `fire-on-destroy-event!` observing the router's
+            `:rf.error/handler-exception` TRACE, and that trace-capture
+            mechanism (`:trace.tooling/register-listener!`) is a silent
+            no-op under `:advanced` + `goog.DEBUG=false` (the trace surface
+            is DCE'd). So under prod the dedicated record does NOT fire for
+            the common path. The PRODUCTION SOURCE OF RECORD for the throw
+            is the router's `:rf.error/handler-exception`, which DOES ride
+            the always-on axis and survives elision (per rf2-7b9r4l: 'the
+            underlying handler throw is ALSO caught by the router and emitted
+            as :rf.error/handler-exception, which DOES ride the always-on
+            axis -- so the failure is NOT fully silent in production'). This
+            test pins exactly that contract under the prod build: NO
+            dedicated record, but the handler-exception record survives. The
+            discriminable dedicated signal for a path with NO router
+            coverage — the dispatch-infra defence-in-depth branch — is pinned
+            by `dispatch-sync-infra-fault-survives-prod` below."
+    (let [seen (atom [])]
+      (rf/register-error-listener! :prod/recorder
+                                   (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :prod.ondestroy/blow-up
+                       (fn [_ _] (throw (ex-info "intentional :on-destroy throw"
+                                                 {:purpose :test-fixture}))))
+      (rf/reg-frame :prod.ondestroy/worker
+                    {:doc        "throwing :on-destroy"
+                     :on-destroy [:prod.ondestroy/blow-up]})
+      (is (nil? (rf/destroy-frame! :prod.ondestroy/worker))
+          "destroy-frame! returns nil even though :on-destroy threw under prod")
+      (is (empty? (filter #(= :rf.error/on-destroy-handler-exception (:error %)) @seen))
+          "the DEDICATED category does NOT survive prod for the common path
+           (it rides the DCE'd trace-capture mechanism — dev-discrimination
+           only, per rf2-7b9r4l)")
+      (let [hx (filter #(= :rf.error/handler-exception (:error %)) @seen)]
+        (is (= 1 (count hx))
+            "the router's :rf.error/handler-exception IS the production
+             source of record — it rides the always-on axis and survives
+             elision")
+        (let [r (first hx)]
+          (is (= [:prod.ondestroy/blow-up] (:event r))
+              ":event carries the :on-destroy event vector")
+          (is (= :prod.ondestroy/blow-up (:event-id r))
+              ":event-id is the event-vector head")
+          (is (= :prod.ondestroy/worker (:frame r))
+              ":frame names the frame being torn down")
+          (is (some? (:exception r))
+              ":exception carries the thrown object"))))
+    (is (nil? (frame/frame :prod.ondestroy/worker))
+        "the frame is fully torn down (teardown continued past the throw)")))
+
+(deftest dispatch-sync-infra-fault-survives-prod
+  (testing "Per rf2-7b9r4l / rf2-bxud9v: under `:advanced` + `goog.DEBUG=
+            false`, if `dispatch-sync!` ITSELF faults (a fault inside the
+            dispatch infrastructure, NOT the user handler),
+            `fire-on-destroy-event!`'s defence-in-depth catch arm still fans
+            a `:rf.error/on-destroy-handler-exception` record out on the
+            always-on axis. This branch NEVER produced a router
+            `:rf.error/handler-exception`, so the always-on emission here is
+            its ONLY production observability — and this is the only test
+            that proves it survives elision."
+    (let [seen     (atom [])
+          original (late-bind/get-fn :router/dispatch-sync!)]
+      (rf/register-error-listener! :prod/recorder
+                                   (fn [record] (swap! seen conj record)))
+      (rf/reg-frame :prod.ondestroy/infra-fault
+                    {:on-destroy [:prod.ondestroy/never-reached]})
+      (late-bind/set-fn! :router/dispatch-sync!
+                         (fn [& _] (throw (ex-info "dispatch infra fault" {}))))
+      (try
+        (is (nil? (rf/destroy-frame! :prod.ondestroy/infra-fault))
+            "teardown does not propagate the infra fault under prod")
+        (finally
+          (late-bind/set-fn! :router/dispatch-sync! original)))
+      (let [reports (filter #(= :rf.error/on-destroy-handler-exception (:error %)) @seen)]
+        (is (= 1 (count reports))
+            "the defence-in-depth branch fanned out on the always-on axis under prod")
+        (is (some? (:exception (first reports)))
+            ":exception carries the infra-fault throwable"))
+      (is (nil? (frame/frame :prod.ondestroy/infra-fault))
+          "the frame is still fully torn down despite the infra fault"))))

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -334,6 +334,20 @@ const DEV_ONLY_SENTINELS = [
   // `data-rf-view` (the real DOM API used by re-frame-pair and the
   // view-walker) ride the same wrapper unchanged and remain covered
   // by their own sentinels above.
+  // re-frame.frame/safe-call-hook! — :rf.warning/teardown-hook-exception
+  // per-hook DEV DIAGNOSTIC trace (EP-0008 R2, rf2-x3m8c / rf2-inkdqh).
+  // When a late-bound cleanup hook throws during destroy-frame!,
+  // safe-call-hook! emits this per-hook diagnostic AT ITS CAUSAL POSITION
+  // via trace/emit-error!, whose body is gated on
+  // `(when interop/debug-enabled? ...)`. The always-on side (the bounded
+  // :rf.error/frame-teardown-failed report) intentionally SURVIVES prod;
+  // this R2 per-hook diagnostic must DCE. The elision-probe's
+  // `touch-teardown!` installs a throwing hook and calls destroy-frame! so
+  // the gated emit body — including this operation keyword's string
+  // fragment — is in the reachability graph: the control build
+  // (DEBUG=true) contains it, the production build (DEBUG=false) must not.
+  { source: 're-frame.frame/safe-call-hook! (rf.warning/teardown-hook-exception)',
+    sentinel: 'rf.warning/teardown-hook-exception' },
   // re-frame.adapter.context — Context displayName for React DevTools'
   // Context inspector (Spec 006 §React DevTools support, rf2-fa4ly).
   // The "rf2-frame" literal sits inside `(when interop/debug-enabled?


### PR DESCRIPTION
## What

Closes two EP-0008 production-elision coverage gaps found by the testing-rigour audit (rf2-mnlj5p). Test-coverage work plus one minimal elision-shape fix the new coverage surfaced (rf2-7ynhyn). No intended behaviour change.

### rf2-9pxj70 — prod-build survival for the 3 new EP-0008 always-on rows

The three EP-0008-promoted always-on categories (`:rf.error/frame-teardown-failed`, `:rf.error/write-after-destroy`, `:rf.error/on-destroy-handler-exception`) were exercised only by the dev `:node-test` runner, so the central "survives `goog.DEBUG=false`" claim had no production-build assertion for the very rows EP-0008 promoted.

New `re-frame.teardown-always-on-elision-prod-test` (registered in `prod-elision-runner`) drives each category under `:advanced` + `goog.DEBUG=false` through `register-error-listener!`, matching how `on-error-elision-prod-test` pins the older rows:

- **frame-teardown-failed**: N throwing hooks -> exactly ONE bounded report (N `:hook-failures`); clean destroy -> none; partial-abort finally-flush still ships the gathered entries.
- **write-after-destroy**: nil-container `replace-container!` -> ONE record on the always-on axis.
- **on-destroy-handler-exception**: pins BOTH legs of the rf2-7b9r4l partial-coverage nuance under prod:
  - the COMMON path (user `:on-destroy` throws) does NOT survive prod for the dedicated category (it rides the DCE'd trace-capture mechanism) — the router's always-on `:rf.error/handler-exception` is the production source of record;
  - the dispatch-infra defence-in-depth branch (rf2-bxud9v) DOES survive (direct emit) — its ONLY production observability.

### rf2-inkdqh — verify the R2 teardown-hook dev-diagnostic IS elided in prod

The EP-0008 R2 per-hook `:rf.warning/teardown-hook-exception` dev diagnostic (`frame/safe-call-hook!`) was never in the elision-probe's DCE reachability graph, and `check-elision.cjs` had no sentinel for it — so its production absence was unverified.

- `elision_probe.cljs`: add `touch-teardown!` (installs a throwing late-bound cleanup hook + calls `destroy-frame!`) to root the gated emit.
- `check-elision.cjs`: add the `rf.warning/teardown-hook-exception` sentinel. Verified ABSENT in prod (DEBUG=false) and PRESENT in control (DEBUG=true).

### rf2-7ynhyn — fix the `:on-create` call-site leak the coverage exposed

Rooting the frame-registration path for the first time exposed a pre-existing latent leak: `frame.cljc` `register-frame!`'s `:on-create` block stamped `:rf.trace/call-site` via a `cond->` test-position gate (`(cond-> {...} (and interop/debug-enabled? ...) (assoc :rf.trace/call-site ...))`) instead of the canonical outermost `(if interop/debug-enabled? <stamped> <plain>)` gate Spec 009 requires. Closure did not fold the keyword literal away from the `cond->` step, so `:rf.trace/call-site` survived into `:advanced` + `goog.DEBUG=false` bundles for any `reg-frame` / `make-frame` consumer (origin: rf2-hxj0d / #2207). Fix: split the gate to the outermost `if`. Elision-only, zero behaviour change (dev arm byte-identical; the prod arm is the same plain `init-opts` the old `cond->` produced under `DEBUG=false`). This is exactly the regression class the elision probe exists to catch — the new teardown-hook coverage surfaced a different un-elided surface. rf2-7ynhyn is the audit trail; if you'd prefer it split out, say the word.

## Quality gates

- `npm run test:cljs` — 6507 tests, 23754 assertions, 0 failures, 0 errors. (One pre-existing `:undeclared-var` warning in `resources_revalidation_cljs_test.cljc` — not touched here.)
- `npm run test:elision` — production 41/41 absent (`goog.DEBUG=false`); control 41/41 present (`goog.DEBUG=true`). Includes the new `rf.warning/teardown-hook-exception` sentinel.
- `npm run test:browser-prod-elision` — 73 tests, 221 assertions, 0 failures, 0 errors. Includes the new `teardown-always-on-elision-prod-test`.
- `mkdocs build --strict` — not run; no docs touched.
