### PR TITLE
docs(spec): reserve :rf.realm/id in envelope + reply-map shapes (rf2-n92kjm)

### DIFF
--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -730,8 +730,12 @@ The hybrid `[<id> <map>]` shape for non-trivial events is canonical. Subscribe t
  :trace-id     "..."                   ;; tooling/agent fields
  :source       :ui                     ;; trigger kind — the canonical enum is `:rf/dispatch-envelope`'s `:source` in [Spec-Schemas](Spec-Schemas.md#rfdispatch-envelope) (`:ui :frame-init :machine-spawn :machine-action :always :after-timer :fx-dispatch :fx-dispatch-later :http :repl :ssr-hydration :test :unknown :other`); defaults to `:unknown` per [rf2-hxj0d](https://github.com/day8/re-frame2/issues/rf2-hxj0d) (previously `:ui`); substrate-internal dispatch sites stamp the matching value (`:after-timer`, `:machine-spawn`, `:machine-action`, `:fx-dispatch`, `:fx-dispatch-later`) per [rf2-ejtpd](https://github.com/day8/re-frame2/issues/rf2-ejtpd) + [rf2-c3990](https://github.com/day8/re-frame2/issues/rf2-c3990)
  :origin       :pair                   ;; actor identity — open vocabulary, defaults to `:app`; e.g. `:pair`, `:claude`, `:story`, `:test`
- :rf.world/inputs {:time-ms 1781078400123}} ;; EP-0010 causal world inputs — see §The World-Input Rule
+ :rf.world/inputs {:time-ms 1781078400123} ;; EP-0010 causal world inputs — see §The World-Input Rule
+ ;; :rf.realm/id :rf.realm/default     ;; RESERVED (EP-0013) — not stamped in v1; absent = the default realm
+ }
 ```
+
+> **`:rf.realm/id` is reserved, not yet stamped (EP-0013).** [EP-0013](../docs/EP/EP-0013-app-values-and-runtime-realms.md) (accepted, ruling [rf2-1vj3b6](https://github.com/day8/re-frame2/issues/rf2-1vj3b6)) rules the realm stamp as `:rf.realm/id`, carried **beside** `:rf.frame/id` — never a realm-qualified frame tuple. The slot is reserved on the envelope now so its later addition is non-breaking (the `:rf.timer/*` precedent — reserve where the surface will land). v1 does **not** stamp it and the runtime exhibits no realm behaviour; **its absence is the default realm**, an explicit documented rule. A future multi-realm runtime always stamps `:rf.realm/id`.
 
 The envelope is just a map. Any field can be set by:
 

--- a/spec/Managed-Effects.md
+++ b/spec/Managed-Effects.md
@@ -131,6 +131,7 @@ The reply map is **data only**. It MUST NOT contain functions, promises, `AbortC
  :work/status  :completed | :failed | :timed-out | :suppressed | :cancelled
  :attempt      positive-int-or-nil
  :rf.frame/id  frame-id
+ ;; :rf.realm/id :rf.realm/default  ;; RESERVED (EP-0013) — not emitted in v1; absent = the default realm
  :started-at   started-at-or-nil
  :completed-at completed-at-or-nil
  :deadline-at  deadline-at-or-nil
@@ -149,6 +150,7 @@ Required / conditional fields:
 - `:value` carries the decoded successful result for `:status :ok` and `:status :partial`. **One-name-per-fact note ([EP-0007](../docs/EP/EP-0007-one-name-per-fact.md)):** the decoded result on the *reply map* is `:value` everywhere, across every family (HTTP, resource, mutation, machine, timer, route) — there is no per-family synonym for it. A *mutation-instance state* sub may store that same decoded result under a different key (`:result`) as a deliberately distinct fact: the instance sub is a durable, queryable status record (`{:pending? :success? :error? :settled? :result :error}`), not the transient causal reply, so the two spellings name two facts living in two layers. Spec 016 reconciles that pairing on its own surface; the reply-map spelling is `:value`, full stop.
 - `:work/id` is required for ledger-backed work and SHOULD be present for any managed async effect that can be correlated.
 - `:rf.frame/id` is required when the effect is frame-scoped. This is the canonical carried frame stamp ([EP-0002](../docs/EP/EP-0002-frame-target-resolution.md)); there is no second frame spelling.
+- `:rf.realm/id` is **reserved, not yet emitted** ([EP-0013](../docs/EP/EP-0013-app-values-and-runtime-realms.md), accepted — ruling [rf2-1vj3b6](https://github.com/day8/re-frame2/issues/rf2-1vj3b6)). The realm stamp is carried **beside** `:rf.frame/id`, never as a realm-qualified frame tuple. The slot is reserved on the reply map now (it likewise rides EP-0011 reply maps and EP-0016 continuation payloads, which cite this shape) so its later addition is non-breaking — the `:rf.timer/*` precedent of reserving where the surface will land. v1 reply maps do **not** carry it; **its absence is the default realm**, an explicit documented rule. A future multi-realm runtime always stamps `:rf.realm/id`.
 - `:error` is present for `:status :error`; present with structured partial diagnostics for `:status :partial`; and MAY carry compatibility failure data for `:status :cancelled`.
 - `:started-at`, `:completed-at`, and `:deadline-at` are causal completion metadata ([EP-0010](../docs/EP/EP-0010-causal-world-inputs.md) — suffixless durable timestamps; the values are causal epoch-millisecond readings supplied by the triggering or reply token, **not** fresh ambient clock reads). Carry them when the fact affects durable state; omit a field a family does not durably use.
 


### PR DESCRIPTION
## What

The EARLY, ungated EP-0013 forward-compat reservation slice (per EP-0013 §Open Issues disposition 2). [EP-0013](docs/EP/EP-0013-app-values-and-runtime-realms.md) (ACCEPTED 2026-06-11, ruling rf2-1vj3b6) rules the realm stamp as `:rf.realm/id`, carried **beside** `:rf.frame/id` — never a realm-qualified frame tuple. To make the later addition non-breaking, the shipped/accepted record-shape surfaces RESERVE the key now (the `:rf.timer/*` precedent: reserve where the surface will land).

**Reservation rows only — no runtime behaviour change, no emission.**

## Changes

1. **`spec/002-Frames.md`** dispatch envelope — reserved `:rf.realm/id` line in the envelope map literal + a note: not stamped in v1, **absent = the default realm** (an explicit documented rule per EP-0013); a multi-realm runtime always stamps it.
2. **`spec/Managed-Effects.md`** §Property 9 reply-map field shape — the same reserved row in the reply-map literal + a conditional-field bullet. Covers EP-0011 reply maps and EP-0016 continuation payloads, which cite this shape.

## EP-0010 table — no separate row needed

Item 3 of the bead asked whether the EP-0010 `:rf.world/inputs` / epoch-record docs carry their OWN envelope table that would need a reserved row. **They do not.** `docs/EP/EP-0010-causal-world-inputs.md` carries *illustrative* envelope/coeffect Clojure map snippets (the `:event`/`:frame`/`:rf.world/inputs` example), not a normative field table; it defers to spec/002 for the canonical envelope shape. So the 002 row suffices and no EP-0010 row was added.

Note (out of scope): the formal Malli `:rf/dispatch-envelope` schema in `spec/Spec-Schemas.md` is the third normative envelope surface, but it is a HOT-ZONE file explicitly outside this bead's three-item scope. Reserving the Malli row there is a candidate follow-up if/when the EP-0013 implementation wave lands.

## Quality gates

- `python scripts/check_doc_slugs.py --self-test --verbose` — all 11 self-tests passed
- `python scripts/check_doc_slugs.py --verbose` — 428 files scanned, no broken links
- `python scripts/check_ep_status_sync.py` — exit 0, no drift (no EP doc touched)
- CI staging reproduced (`cp -r spec docs/spec && cp -r migration docs/migration`) + `python -m mkdocs build --strict` — exit 0, no WARNING/ERROR (staged copies removed, gitignored)

Closes rf2-n92kjm.