### PR TITLE
docs(consumers): EP-0008 propagation to skills/examples/tools/guide (3m9jtp 0p29ik rprbuh vt3ywc)

### DIFF
--- a/docs/guide/16-observability.md
+++ b/docs/guide/16-observability.md
@@ -172,15 +172,16 @@ Here's the criterion landing on a real case, because it's the one that shows why
 
 When a frame is destroyed, the runtime runs a best-effort recipe of cleanup hooks — late-bound teardown that frees whatever the frame's features acquired. Best-effort means a hook is *allowed* to throw without aborting the rest; the others still run. Historically, a throwing hook emitted a per-hook `:rf.warning/teardown-hook-exception` on the diagnostic channel — which DCE'd out of production entirely. Run the criterion over it and that's plainly the wrong channel. It's production-reachable (a per-request SSR frame destroys on every request). It's a resource leak the next operation can't see (skipped teardown — leaked request data, orphaned timers, cross-request contamination is exactly the failure mode the [SSR per-frame teardown](20-server-side.md) exists to prevent). And it compounds with process lifetime: a long-lived render host leaking one handle per request is a slow death you only diagnose from the leak, never from the symptom. All three legs hold. So teardown-hook failure is promoted onto the always-on axis.
 
-But *how* it's promoted is the instructive part, and it's a pattern you'll see again. A teardown recipe runs *many* hooks. The naive promotion — turn each per-hook warning into a per-hook always-on error — would fan out one production record per failed hook per destroy. Multiply by SSR request volume and you've flooded the very error shipper the promotion was supposed to make useful. So the promotion is **not a blind per-hook rename**. The runtime emits a **single bounded report** per destroy — one `:rf.error/frame-teardown-failed` — carrying the per-hook detail as a `:hook-failures` vector:
+But *how* it's promoted is the instructive part, and it's a pattern you'll see again. A teardown recipe runs *many* hooks. The naive promotion — turn each per-hook warning into a per-hook always-on error — would fan out one production record per failed hook per destroy. Multiply by SSR request volume and you've flooded the very error shipper the promotion was supposed to make useful. So the promotion is **not a blind per-hook rename**. The runtime emits a **single bounded report** per destroy — one `:rf.error/frame-teardown-failed` — carrying the per-hook detail as a `:hook-failures` vector. This is the record your `register-error-listener!` body receives, so `:error` (not `:operation`/`:op-type`) is the top-level discriminator — the same tight error-emit record shape as every other always-on category above:
 
 ```clojure
-{:operation    :rf.error/frame-teardown-failed
- :op-type      :error
- :frame        :app/per-request-42
- :recovery     :ignored                 ;; teardown stays best-effort
+{:error         :rf.error/frame-teardown-failed
+ :frame         :app/per-request-42
+ :recovery      :ignored                ;; teardown stays best-effort
+ :reason        "2 frame-teardown cleanup hook(s) threw during destroy; ..."
+ :time          1715600000000           ;; ms since epoch
  :hook-failures [{:hook :http/abort-inflight :exception #object[...] :where :safe-call-hook!}
-                 {:hook :timers/clear       :exception #object[...] :where :safe-call-hook!}]}}
+                 {:hook :timers/clear        :exception #object[...] :where :safe-call-hook!}]}
 ```
 
 One record names the higher-level fact ("this destroy had teardown failures"), and the vector preserves the *which-hooks-failed-together* correlation an external shipper would never reliably re-group. The recovery stays `:ignored` — teardown is still best-effort; promotion changed the *channel*, not the behaviour.

--- a/skills/re-frame2/references/cross-cutting/production-observability.md
+++ b/skills/re-frame2/references/cross-cutting/production-observability.md
@@ -4,6 +4,16 @@ Production observability rides **two always-on listener APIs** that survive `goo
 
 Authoring rule: in production, you wire two listeners — one for events (success + error outcomes), one for errors (exception payloads). The framework already runs `elide-wire-value` against each record's `:event` vector before fan-out — listeners do **not** re-walk for privacy / size.
 
+## The mental model: three channels, three production guarantees
+
+Frame everything below against the **three observability channels** the runtime has. They answer three different questions and survive production differently — naming all three is what makes "what survives to production?" precise:
+
+1. **The causal channel** — effects-as-data (`:dispatch`, `:fx`). It *is* the program, not a log line about it. **Never elided** — deleting it deletes the app.
+2. **The diagnostic channel** — `register-listener!` and the whole trace bus (every trace event, the per-frame rings, source-coord enrichment, correlation ids). Ambient, for dev eyes and tools. **Production-elided**: Closure-DCE'd under `:advanced` + `goog.DEBUG=false`; runtime-gated on the JVM (see below).
+3. **The always-on error axis** — `register-error-listener!`. Deliberately **production-survivable**: NOT gated by `debug-enabled?`, so it survives elision on purpose, fanning one tight `:rf.error/*` record per production-reachable failure to your shipper (Sentry / Rollbar / Honeybadger). `register-event-listener!` is the throughput/latency sibling on the same survives-production footing.
+
+The JS-ecosystem anchor: this is the equivalent of "Sentry/Rollbar SDK for the error axis, an APM SDK for the event axis, and a Redux-DevTools-style time-travel bus for the diagnostic channel" — except the diagnostic bus is compiled *out* of production rather than tree-shaken at the edges, and the error axis is a first-class framework substrate rather than a global `window.onerror` hook. **Divergence to flag:** unlike a JS error SDK, you do not steer recovery from the listener (see below); recovery is framework-owned.
+
 ## When to load
 
 Wiring a production observability shipper, writing a `register-event-listener!` / `register-error-listener!` body, or asking "what's the prod-survivable equivalent of `register-listener!`?".
@@ -68,7 +78,33 @@ Verified: `re-frame.error-emit/dispatch-on-error!`; record shape per the ns docs
 
 ### Recovery is framework-owned — there is no app-steering policy
 
-Error **recovery** is not an app-config concern. The runtime applies a **typed per-category default**: frame-destroyed recovers + emits, sub-exception returns `nil`, handler-exception fails loud without crashing the app, no-such-handler / no-such-sub no-op. There is no per-frame `:on-error` recovery policy — it was removed per rf2-hiqtk8 (errors are not generically recoverable by an app policy; the policy's return value was never read or applied). Genuine recovery for **expected** failures is handled at the source — managed-HTTP `:retry`, optional-read fallback — where "recovery" actually has meaning. Off-box **observability** is `register-error-listener!` (above). To re-run a failed event, dispatch a fresh one; the runtime never re-runs the failing handler.
+Error **recovery** is not an app-config concern. The runtime applies a **typed per-category default**: frame-destroyed recovers + emits, sub-exception returns `nil`, handler-exception fails loud without crashing the app, no-such-handler / no-such-sub no-op. There is no per-frame `:on-error` recovery policy — it was removed (errors are not generically recoverable by an app policy; the policy's return value was never read or applied). Genuine recovery for **expected** failures is handled at the source — managed-HTTP `:retry`, optional-read fallback — where "recovery" actually has meaning. Off-box **observability** is `register-error-listener!` (above). To re-run a failed event, dispatch a fresh one; the runtime never re-runs the failing handler.
+
+### What rides the always-on axis: the promotion criterion
+
+The error axis is deliberately small — an alert on it should *mean something*. Most failures stay diagnostic (dev-visible, production-elided); only a specific shape earns a production-survivable record. A category is on the axis only when **all three legs** hold:
+
+1. **Production-reachable** — it can fire in a production build, not just a dev-time misuse caught at the boundary (a malformed-registration shape, a dev-only schema check: those stay diagnostic).
+2. **A contract breach or resource leak the caller can't already see** — the load-bearing leg. A bad event vector throws at the call site; the caller sees it. A *leaked handle / skipped teardown / suppressed write / corrupted invariant* leaves the process in a state the next operation can't observe — that needs an off-box record.
+3. **Silence compounds** — the cost of nobody hearing grows with process lifetime / request volume / retries. A leaked timer per SSR request is cheap once and fatal at ten million.
+
+This is also the rule for *your own* domain failures: a failure your `register-error-listener!` consumer raises through a custom `:rf.error/*` category should pass the same three legs, or it belongs on a diagnostic/log path instead — that discipline is what keeps the error stream signal, not noise. The axis is `:rf.error/*`-only (never widened to `:rf.warning/*`), and carries **structured data only** (ids/keys/frame, never raw values — the egress redaction applies).
+
+### The first promoted category: `:rf.error/frame-teardown-failed`
+
+One always-on category beyond the per-failure errors is worth knowing because its record shape differs. When a frame is destroyed the runtime runs best-effort cleanup hooks; a throwing hook is a resource leak the next operation can't see and compounds per SSR request — all three legs hold. Rather than flood the shipper with one record per failed hook, the runtime emits **one bounded report per destroy** carrying a `:hook-failures` vector. Your `register-error-listener!` body must handle this shape (note `:hook-failures` + `:reason`, and `:error` — not `:operation` — as the discriminator, same as every error-emit record):
+
+```clojure
+{:error         :rf.error/frame-teardown-failed
+ :frame         :app/per-request-42
+ :recovery      :ignored                 ;; teardown stays best-effort
+ :reason        "2 frame-teardown cleanup hook(s) threw during destroy; ..."
+ :time          1715600000000
+ :hook-failures [{:hook :http/abort-inflight :exception #object[...] :where :safe-call-hook!}
+                 {:hook :timers/clear        :exception #object[...] :where :safe-call-hook!}]}
+```
+
+In **development** the per-hook detail still surfaces as `:rf.warning/teardown-hook-exception` traces on the diagnostic channel (at their causal positions, DCE'd in prod); the single always-on report is what a production shipper sees. A generic shipper body that maps `(:error record)` to the alert name and forwards the rest already handles this category without special-casing — the only gotcha is not assuming an `:event`/`:event-id` slot (a teardown report has neither; branch on `(:error record)` if you need the per-category shape).
 
 ## Triple-gate registration pattern
 


### PR DESCRIPTION
Wave-end consumer-propagation review of the four EP-0008 surfaces. EP-0008 (Production Observability Channels — the three channels, the always-on promotion criterion, and the single always-on `:rf.error/frame-teardown-failed` report) is fully merged; this cluster reviews each consumer surface and makes the warranted change.

## Per-surface verdicts

**`/skills` (rf2-3m9jtp) — CHANGED.** `skills/re-frame2/references/cross-cutting/production-observability.md` had the two always-on listeners well covered but was missing the EP-0008 model an AI pair-programmer needs:
- Added the **three-channel mental model** (causal / diagnostic / always-on error axis), anchored to the JS ecosystem (Sentry/Rollbar SDK, APM SDK, Redux-DevTools time-travel bus) with the deliberate divergence flagged (recovery is framework-owned, not steered from the listener).
- Added the **promotion criterion** (the three legs that gate the axis), extended to the consumer's own custom `:rf.error/*` categories — the discipline that keeps the error stream signal.
- Documented **`:rf.error/frame-teardown-failed`**: the bounded report shape (`:error` discriminator + `:hook-failures` vector + `:reason`) a `register-error-listener!` body must handle, with the dev-vs-prod split.
- Kept guidance generic to any consumer app; no `rf2-` bead ids in prose (also removed one pre-existing bead-id leak in the same file).
- The migration skill's `error-events.md` is catalogue-deferring by design (cross-references Spec 009, does not inline categories) so the new category flows through with no edit.

**`/examples` (rf2-0p29ik) — NO CHANGE NEEDED.** Searched all examples; zero references to the error-emit / teardown surface. The capability is framework-internal production error channels (off-box shippers), not an idiomatic in-app pattern. Examples are test-free (8cevm) and any regression check belongs in CLJS unit tests outside `examples/`. No example mis-models it; none should demonstrate it.

**`/tools` (rf2-rprbuh) — NO CHANGE NEEDED.** Xray / Story / pair-MCP all consume the **dev trace stream** (the diagnostic channel), where teardown failure surfaces as the per-hook `:rf.warning/teardown-hook-exception` traces. Those flow through Xray's issues-ribbon projection (`issues_ribbon_helpers.cljc`) which is **prefix-driven and category-agnostic** — it reads `:op-type` for severity and the `:operation` namespace for the category, so any new `:rf.error/*` or `:rf.warning/*` category flows through with zero code change (the ns docstring states this). The always-on `:rf.error/frame-teardown-failed` report rides the off-box error-emit *listener registry*, which is a production-shipper surface — not a tool-consumed dev surface. `machines-viz/spec/API.md` and `story/recorder.cljc` already correctly reference the always-on error-emit path. No `tools/xray/spec/*` change because no `tools/xray/` source changed.

**`/docs/guide` (rf2-vt3ywc) — CHANGED.** Verified ch.16 fully propagated EP-0008 (three channels, JVM caveat, promotion criterion, first-promotion narrative all present). Reviewed the rest of the guide: ch.14 (errors), ch.17 (tooling), ch.20 (server-side), ch.23 (privacy), ch.25 (migration) all reference `register-error-listener!` / the always-on axis correctly and don't restate the record shape — no further edits. Absorbed finding **rf2-lefgo5**: reconciled the ch.16 teardown example to the real `dispatch-frame-teardown-report!` record — top-level `:error` (not `:operation`/`:op-type`), added `:reason` + `:time`, dropped a stray trailing brace. (The per-hook `:hook`/`:exception`/`:where` shape was already correct from rf2-p3vmb6.)

## Quality gates

- `python -m mkdocs build --strict` — PASS (exit 0, no WARNING/ERROR; docs/guide touched).
- No `tools/xray/spec/*` touched (no xray source changed) — spec-unchanged-because no tools change warranted.
- Skill prose carries no `rf2-` bead ids (BEAD-ID-LEAK posture; also removed a pre-existing leak).
- No tests run for tools/examples (no tools or example source changed).