### PR TITLE
docs(comments): EP-0008 code-comment completeness+accuracy pass (rf2-e51ivu)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1084,9 +1084,9 @@
   substrate sits above frame in the load order — a static require closes a
   cycle), so the always-on emission rides the published
   `:error-emit/dispatch-on-error` late-bind hook (the same hook
-  `emit-no-frame-context!` uses at `:262`). The producer always loads at
-  boot, so the lookup never misses in production. The dev trace below keeps
-  the in-process tooling surface (DCE'd in production)."
+  `emit-no-frame-context!` uses). The producer always loads at boot, so the
+  lookup never misses in production. The dev trace below keeps the in-process
+  tooling surface (DCE'd in production)."
   [id on-destroy exception extra-tags]
   ;; Always-on listener registry (survives prod elision). Default
   ;; `:recovery :ignored` — teardown continues best-effort.


### PR DESCRIPTION
Wave-end **CODE-COMMENTS** review of the merged EP-0008 (Production Observability Channels) wave — reviews the prose IN the code (comments + docstrings), not the tests or the behaviour. Complements the testing-coverage + correctness review tails.

Scope reviewed (the merged EP-0008 source + test prose):
- `implementation/core/src/re_frame/frame.cljc` — teardown accumulator dynamic binding, `safe-call-hook!`, the finally-shaped flush, `emit-on-destroy-handler-exception!`, `fire-on-destroy-event!`
- `implementation/core/src/re_frame/error_emit.cljc` — `dispatch-frame-teardown-report!` + the late-bind registration
- `implementation/core/src/re_frame/late_bind/directory.cljc` — the new `:error-emit/dispatch-frame-teardown-report` entry
- `implementation/core/src/re_frame/substrate/adapter.cljc` — the `replace-container!` nil-guard write-after-destroy promotion
- `spec/009-Instrumentation.md` — catalogue rows + always-on enumeration prose
- the EP-0008 test docstrings (teardown-report, write-after-destroy always-on, on-destroy-handler-exception always-on, catalogue↔channel conformance)

## Verdict

**Complete + accurate**, with one trivial inline fix.

Completeness is strong: the finally-shaped-flush rationale, the per-destroy accumulator dynamic binding, the always-on-vs-DCE'd-diagnostic split, R1/R2, the load-cycle (`error-emit → elision → frame`) justification for the late-bind hop, and the SSR per-request-destroy × M-req/s flood motivation for the single-report-vs-per-hook shape are all documented. New fns carry docstrings. The `:hook-failures` entry shape `{:hook <late-bind-hook-key> :exception <ex> :where :safe-call-hook!}` is described consistently in every site (frame.cljc accumulator comment, error_emit.cljc docstring, directory.cljc, spec/009 catalogue rows, and the test asserts).

## Fix applied

The `emit-on-destroy-handler-exception!` docstring referenced the twin `emit-no-frame-context!` hook lookup by **hardcoded line number** (`":262"`). The number was in fact correct at HEAD, but a hardcoded source line in a docstring is an accuracy hazard that silently drifts on any edit above it. Replaced with the symbolic function reference (the function name alone is unambiguous).

## Follow-up filed (out of this PR's named scope)

**rf2-x56s2h** — two genuine stale references to the **retired** `:rf.warning/write-after-destroy` survive in files outside the EP-0008 implementation set (the EP-0008 wave updated spec/009 but not these):
- `spec/006-ReactiveSubstrate.md` (hot-zone) still says the `replace-container!` nil-guard emits `:warning :rf.warning/write-after-destroy` with `:recovery :no-recovery` — should be `:rf.error/write-after-destroy` / `:recovery :ignored`.
- `implementation/epoch/src/re_frame/epoch/tool_pair.cljc:511` comment references the old `:rf.warning/write-after-destroy` name.

(The promotion-narrative references in `write_after_destroy_*_test` docstrings — "`:rf.warning/...` promoted to `:rf.error/...`" — are correct historical FROM-state descriptions, not drift; left as-is.)

## Quality gates

- `npm run test:cljs` — **PASS** (6507 tests, 23754 assertions, 0 failures, 0 errors). Comment-only edit compile-checked.
- `mkdocs build --strict` — not run; no spec/docs prose changed in this PR (the spec drift is a filed follow-up, not edited here).
