### PR TITLE
docs(examples): EP-0010 + EP-0011 propagation review (rf2-a8ljy8 rf2-seh3id)

### DIFF
--- a/examples/reagent/realworld/http.cljs
+++ b/examples/reagent/realworld/http.cljs
@@ -177,21 +177,38 @@
 ;; CLOCK COEFFECT — :realworld/now
 ;; ============================================================================
 ;;
-;; Reading wall-clock time inside a handler makes the handler impure;
-;; the same event applied to the same db at two moments produces two
-;; different `:loaded-at` stamps. Per Spec 002 §Cofx, side-effecting
-;; inputs belong in coeffects so handlers stay pure functions of
-;; `(coeffects, event) → effects`. Pulling the clock into a registered
-;; cofx (rather than calling `(.getTime (js/Date.))` directly) gives
-;; the example a single injection point that tests can override and
-;; SSR can hydrate.
+;; `:loaded-at` is a durable write — it rides epoch-restore, SSR/hydration,
+;; and replay. Per the EP-0010 World-Input Rule (Spec 002 §Causal world
+;; inputs), a durable write MUST read its wall-clock fact from the causal
+;; token, not from an ambient host read at the write site: replaying the
+;; same reply event must reproduce the same `:loaded-at`, which a fresh
+;; `(.getTime (js/Date.))` at handler-run time cannot guarantee.
+;;
+;; The framework stamps that fact once, at the causal boundary, onto every
+;; dispatch envelope as `:rf.world/inputs {:time-ms ...}`, and exposes it as
+;; a built-in event-context coeffect. Tests, SSR hydration, and replay
+;; fixtures supply an exact `:time-ms` via the dispatch opts; live code lets
+;; the router stamp it.
+;;
+;; The handlers below were written against an `:realworld/now` cofx, so this
+;; example keeps that recognizable source form (the EP-0010-sanctioned
+;; migration, §Backwards Compatibility) but moves its SOURCE from the host
+;; clock to the envelope: the cofx now reads `:time-ms` off `:rf.world/inputs`
+;; instead of calling `(.getTime (js/Date.))`. A greenfield handler would skip
+;; the cofx entirely and destructure `:rf.world/keys [inputs]` directly —
+;; `realworld_resources/` shows that path, where managed resources stamp
+;; `:loaded-at` from the same envelope time internally.
 
 (rf/reg-cofx :realworld/now
-  {:doc "Inject the current wall-clock time (ms since epoch) into
-         coeffects under `:realworld/now`. Use `(rf/inject-cofx
-         :realworld/now)` on any handler that stamps `:loaded-at`."}
+  {:doc "Inject the causal wall-clock time (ms since epoch) into coeffects
+         under `:realworld/now`, read from the dispatch envelope's
+         `:rf.world/inputs` `:time-ms` (EP-0010) rather than the host clock,
+         so `:loaded-at` durable writes are replay-deterministic. Use
+         `(rf/inject-cofx :realworld/now)` on any handler that stamps
+         `:loaded-at`."}
   (fn cofx-realworld-now [ctx]
-    (rf/assoc-coeffect ctx :realworld/now (.getTime (js/Date.)))))
+    (rf/assoc-coeffect ctx :realworld/now
+                       (:time-ms (rf/get-coeffect ctx :rf.world/inputs)))))
 
 ;; ============================================================================
 ;; FAILURE PROJECTION


### PR DESCRIPTION
Wave-end consumer-propagation review of `examples/` for two merged EPs. Read-only first; one small in-scope edit made, the other EP verdict is no-change.

## EP-0010 — causal world inputs (rf2-a8ljy8): one edit

The `examples/reagent/realworld/` slice variant ships a hand-rolled `:realworld/now` cofx that read `(.getTime (js/Date.))` at handler-run time and threaded the result into seven `:loaded-at` durable writes (feed, articles, comments, profile x2, tags, settings). `:loaded-at` rides epoch-restore / SSR-hydration / replay, so per the EP-0010 World-Input Rule (Spec 002 §Causal world inputs) it must read its wall-clock fact from the causal token, not from an ambient host read at the write site — the old form is non-deterministic on replay.

Fix is the EP-0010-sanctioned migration (EP-0010 §Backwards Compatibility): **keep the recognizable `:realworld/now` cofx name, move its source from the host clock to the envelope.** The cofx now reads `:time-ms` off the framework-stamped `:rf.world/inputs` coeffect. All seven handler call-sites are unchanged. Comment + docstring rewritten to explain the contract and point at `realworld_resources/` for the greenfield path (managed resources stamp `:loaded-at` from the same envelope time internally — already correct, no change there).

Scoped checks that found NO further EP-0010 issue:
- `seven_guis/timer` — delta-accumulation tick model, deliberately no wall-clock read (already replay-safe).
- `websocket/views.cljs` — `(.toISOString (js/Date.))` is a transient outgoing-message payload built in an `:on-click`, not a handler durable write.
- `seven_guis/flight_booker` — `js/Date` only parses user-entered date strings for validation; no durable host-clock stamp.
- `random-uuid` temp-ids left as-is — the `:rf.world/uuid` helper is DEFERRED, so they remain sanctioned.

## EP-0011 — uniform async reply envelope (rf2-seh3id): no change needed

The reply envelope (closed `:status` enum, `:rf/reply-to`, work-id correlation, stale suppression) is **framework-internal substrate** (`re-frame.reply`). EP-0011 explicitly preserves the public conveniences: HTTP `:on-success`/`:on-failure`, managed resources/mutations, machine reply actions, route loaders — these lower onto the envelope internally (EP-0011 §Public compatibility sugar; "this EP does not remove `:on-success`/`:on-failure`"). The realworld + realworld_resources examples already consume those conveniences; no example references the internal envelope keys. Surfacing the raw envelope would be non-idiomatic, so no example-level change is warranted — matching the bead's prior expectation.

## Quality gates

- `npx shadow-cljs compile examples/realworld` → **Build completed (287 files, 286 compiled, 0 warnings, 15.20s)**.
- Examples remain test-free (rf2-8cevm); change is comment/docstring + one cofx body line. No new test surface added.