### PR TITLE
fix(machines): thread :rf.world/inputs into callback contexts (rf2-g0m4p5)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -346,18 +346,36 @@
   initial-state derivative (with `:rf/bootstrap-pending? true` so
   `:entry` fires this same handler call) and emits the named
   `:rf.error/machine-state-not-in-definition` or
-  `:rf.error/machine-snapshot-version-mismatch` event."
-  [db runtime-db frame event machine base-initial]
+  `:rf.error/machine-snapshot-version-mismatch` event.
+
+  Per EP-0010 (rf2-g0m4p5): the event handler's causal world-input token
+  (`world-inputs` — the router's `:rf.world/inputs` coeffect, Spec 002
+  §Event Context And Coeffects) is stamped onto the machine def under
+  `:rf/world-inputs` alongside `:rf/frame` / `:rf/platform` / `:rf/parent-id`,
+  so the transition engine's `callback-ctx` can surface it to guards /
+  actions / entry / exit under `:rf.world/inputs`. A durable machine
+  decision (time / random / UUID host fact) reads the causal token rather
+  than an ambient clock, so the decision and any snapshot write replay
+  deterministically. `nil` (the router always supplies the coeffect, but a
+  REPL `reg-machine*` dispatch through a non-router path may not) leaves the
+  slot absent — `callback-ctx` then surfaces no key and the pure-fn callers
+  (conformance corpus) are unaffected."
+  [db runtime-db frame world-inputs event machine base-initial]
   (let [machine-id    (first event)
         ;; EP-0002 — `frame` is the cascade-threaded envelope frame the
         ;; calling machine handler already asserted via
         ;; `require-frame-stamp!`; no `:rf/default` repair here.
         frame-id      frame
         platform      (or (:platform (frame/frame-meta frame-id)) :client)
-        machine       (assoc machine
-                             :rf/frame     frame-id
-                             :rf/platform  platform
-                             :rf/parent-id machine-id)
+        machine       (cond-> (assoc machine
+                                     :rf/frame     frame-id
+                                     :rf/platform  platform
+                                     :rf/parent-id machine-id)
+                        ;; EP-0010 (rf2-g0m4p5): thread the causal world-input
+                        ;; token onto the machine def so `callback-ctx` exposes
+                        ;; it as `:rf.world/inputs`. Stamp only when present so
+                        ;; the absent-token path stays clean for pure-fn callers.
+                        (some? world-inputs) (assoc :rf/world-inputs world-inputs))
         path          (paths/snapshot-path machine-id)
         existing-snap (get-in runtime-db path)
         snapshot      (cond
@@ -653,7 +671,8 @@
   ;; nil); only the spawn path needs it stamped here.
   (let [base-initial (delay (parallel/build-initial-snapshot
                               machine {:bootstrap-pending? false}))]
-    (fn [{:keys [db] frame :rf.frame/id rt :rf.db/runtime :as _cofx} event]
+    (fn [{:keys [db] frame :rf.frame/id rt :rf.db/runtime
+          world-inputs :rf.world/inputs :as _cofx} event]
       ;; EP-0002 carried invariant: a machine handler is invoked inside an
       ;; event cascade, so the cofx ALWAYS carries the frame stamp under
       ;; `:rf.frame/id` (the HELD stamp). A nil stamp is an invariant
@@ -677,7 +696,7 @@
       ;; is still threaded for the spawn-`:on-error` parent lookup +
       ;; action-failure diagnostics.
       (let [runtime-db  (or rt {})
-            ctx         (prepare-machine-ctx db runtime-db frame event machine base-initial)
+            ctx         (prepare-machine-ctx db runtime-db frame world-inputs event machine base-initial)
             intercepted (join/intercept-spawn-all-event
                           (:machine ctx) runtime-db (:path ctx) (:snapshot ctx)
                           (:machine-id ctx) (:inner-event ctx))]

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -131,6 +131,11 @@
         (assoc :rf/parent-id      (:rf/parent-id parent-machine))
         (assoc :rf/platform       (:rf/platform parent-machine))
         (assoc :rf/frame          (:rf/frame parent-machine))
+        ;; EP-0010 (rf2-g0m4p5): inherit the causal world-input token so a
+        ;; region's guard / action reads `:rf.world/inputs` causally too. The
+        ;; cached spec's value is overlaid live in `region-spec-overlaid`
+        ;; (the token is dynamic, stamped per dispatch by `prepare-machine-ctx`).
+        (assoc :rf/world-inputs   (:rf/world-inputs parent-machine))
         (assoc :rf/region         region-name))))
 
 (defn region-machine
@@ -347,7 +352,14 @@
       ;; live parent is still the correct current value (a `:client` / nil-frame
       ;; runtime) and must replace any stale cached value.
       true (assoc :rf/platform (:rf/platform parent-machine)
-                  :rf/frame    (:rf/frame parent-machine)))))
+                  :rf/frame    (:rf/frame parent-machine))
+      ;; EP-0010 (rf2-g0m4p5): overlay the live causal world-input token so a
+      ;; region guard / action reads the CURRENT dispatch's `:rf.world/inputs`
+      ;; (the cache was populated at registration time, before the token was
+      ;; stamped). Only when present so the absent path leaves the cached spec
+      ;; free of a stale slot — `callback-ctx` keys off presence.
+      (contains? parent-machine :rf/world-inputs)
+      (assoc :rf/world-inputs (:rf/world-inputs parent-machine)))))
 
 (defn- reduce-regions
   "Apply `step-fn` to each region of `parent-machine` in declaration

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -233,30 +233,49 @@
   map (threaded by `parallel/reduce-regions`) — the cross-region
   coordination keys (XState v5 `stateIn` / SCXML `In()`). `:all-state` is
   the parallel-region marker: present iff this is a region snapshot, so
-  flat / compound machines surface neither key and their ctx is unchanged."
-  [snapshot event]
+  flat / compound machines surface neither key and their ctx is unchanged.
+
+  Per EP-0010 (rf2-g0m4p5): when the event handler's causal world-input
+  token (the router's `:rf.world/inputs` coeffect — Spec 002 §Event Context
+  And Coeffects) has been threaded onto the machine def under `:rf/world-inputs`
+  (stamped by `prepare-machine-ctx` alongside `:rf/frame` / `:rf/platform` /
+  `:rf/parent-id`, and propagated to region specs), surface it on the ctx
+  under the SAME `:rf.world/inputs` key. A durable guard / action that
+  decides on time / random / UUID host facts then reads
+  `(:time-ms (:rf.world/inputs ctx))` — the causal token — instead of an
+  ambient `interop/now-ms`, so machine decisions and snapshot writes replay
+  deterministically. Absent for pure-fn callers (conformance corpus / JVM
+  fixtures) that drive the engine without a router coeffect — the key is
+  simply not present and the destructure binds nil."
+  [machine snapshot event]
   (cond-> {:data  (:data snapshot)
            :event event
            :state (:state snapshot)
            :meta  (:meta snapshot)}
     (contains? snapshot :all-state) (assoc :all-state (:all-state snapshot)
-                                           :tags      (:tags snapshot))))
+                                           :tags      (:tags snapshot))
+    (contains? machine :rf/world-inputs) (assoc :rf.world/inputs
+                                                (:rf/world-inputs machine))))
 
 (defn- call-guard
   "Invoke a resolved guard fn against a snapshot + event with the unified
   context-map contract — `(fn [{:keys [data event state meta]}] boolean)`.
   Per Spec 005 §Guards (rf2-grw4i / rf2-v0rrr); a parallel region's guard
-  additionally receives `:tags` + `:all-state` (rf2-46ly6 / rf2-69d1n)."
-  [g snapshot event]
-  (g (callback-ctx snapshot event)))
+  additionally receives `:tags` + `:all-state` (rf2-46ly6 / rf2-69d1n), and —
+  per EP-0010 (rf2-g0m4p5) — the causal `:rf.world/inputs` token when the
+  handler threaded it onto the machine def."
+  [machine g snapshot event]
+  (g (callback-ctx machine snapshot event)))
 
 (defn- call-action
   "Invoke a resolved action fn against a snapshot + event with the unified
   context-map contract — `(fn [{:keys [data event state meta]}] effects)`.
   Per Spec 005 §Actions (rf2-grw4i / rf2-v0rrr); a parallel region's action
-  additionally receives `:tags` + `:all-state` (rf2-46ly6 / rf2-69d1n)."
-  [f snapshot event]
-  (f (callback-ctx snapshot event)))
+  additionally receives `:tags` + `:all-state` (rf2-46ly6 / rf2-69d1n), and —
+  per EP-0010 (rf2-g0m4p5) — the causal `:rf.world/inputs` token when the
+  handler threaded it onto the machine def."
+  [machine f snapshot event]
+  (f (callback-ctx machine snapshot event)))
 
 ;; ---- guard / action evaluation traces -------------------------------------
 ;;
@@ -318,7 +337,7 @@
           state      (:state snapshot)
           input      {:data (:data snapshot) :event event}]
       (try
-        (let [outcome (boolean (call-guard g snapshot event))]
+        (let [outcome (boolean (call-guard machine g snapshot event))]
           (trace/emit! :rf.machine :rf.machine/guard-evaluated
                        {:machine-id machine-id
                         :guard-id   guard-ref
@@ -1660,7 +1679,7 @@
                              :frame      frame-id}
                       transition-slot (assoc :transition-slot transition-slot))]
       (try
-        (let [r (call-action f snap event)]
+        (let [r (call-action machine f snap event)]
           (trace/emit! :rf.machine :rf.machine/action-ran
                        (assoc base-tags :outcome (if (nil? r) :ok r)))
           (or r {}))

--- a/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
+++ b/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
@@ -222,8 +222,11 @@
 ;; ---- (e) flat / compound guard ctx is UNAFFECTED (regression) -------------
 
 (deftest flat-guard-ctx-has-no-cross-region-keys
-  (testing "a FLAT machine's guard ctx is exactly {:data :event :state :meta}
-            — no :tags, no :all-state"
+  (testing "a FLAT machine's guard ctx carries the four base keys — no :tags,
+            no :all-state (the parallel-region keys never leak to a flat
+            machine). A router-driven dispatch ALSO carries the EP-0010 causal
+            :rf.world/inputs token (rf2-g0m4p5); the cross-region keys stay
+            absent."
     (let [captured (atom nil)
           m {:initial :idle
              :data    {:ok true}
@@ -236,8 +239,10 @@
       (rf/reg-machine :flat/ctx m)
       (rf/dispatch-sync [:flat/ctx [:go]])
       (is (= :done (:state (snapshot :flat/ctx))))
-      (is (= #{:data :event :state :meta} (set (keys @captured)))
-          "flat guard ctx carries ONLY the four base keys")
+      (is (= #{:data :event :state :meta}
+             (set (keys (dissoc @captured :rf.world/inputs))))
+          "flat guard ctx carries the four base keys (+ the EP-0010 causal
+           token a router dispatch always stamps — rf2-g0m4p5)")
       (is (not (contains? @captured :tags))
           "flat guard ctx has no :tags (the committed :tags slot does NOT leak)")
       (is (not (contains? @captured :all-state))
@@ -246,7 +251,9 @@
       (is (= {:ok true} (:data @captured)) "flat guard still sees :data"))))
 
 (deftest compound-guard-ctx-has-no-cross-region-keys
-  (testing "a COMPOUND machine's guard ctx is also exactly the four base keys"
+  (testing "a COMPOUND machine's guard ctx also carries the four base keys and
+            none of the parallel-region keys (a router dispatch additionally
+            carries the EP-0010 :rf.world/inputs token — rf2-g0m4p5)"
     (let [captured (atom nil)
           m {:initial :parent
              :data    {}
@@ -257,8 +264,12 @@
                                           :sibling {}}}}}]
       (rf/reg-machine :compound/ctx m)
       (rf/dispatch-sync [:compound/ctx [:go]])
-      (is (= #{:data :event :state :meta} (set (keys @captured)))
-          "compound guard ctx carries ONLY the four base keys")
+      (is (= #{:data :event :state :meta}
+             (set (keys (dissoc @captured :rf.world/inputs))))
+          "compound guard ctx carries the four base keys (+ the EP-0010 causal
+           token a router dispatch always stamps — rf2-g0m4p5)")
+      (is (not (contains? @captured :tags))
+          "compound guard ctx has no :tags (parallel-region key absent)")
       (is (not (contains? @captured :all-state))))))
 
 ;; ---- (f) action ctx gets the same :tags + :all-state threading ------------

--- a/implementation/machines/test/re_frame/machine_world_inputs_ctx_test.clj
+++ b/implementation/machines/test/re_frame/machine_world_inputs_ctx_test.clj
@@ -1,0 +1,219 @@
+(ns re-frame.machine-world-inputs-ctx-test
+  "Per EP-0010 §The World-Input Rule + Spec 005 §Guards / §Actions
+  (rf2-g0m4p5).
+
+  EP-0010 requires that durable machine decisions and snapshot writes
+  depending on time / random / UUID-style host facts fold the CAUSAL
+  world-input token (the router's `:rf.world/inputs` coeffect, stamped at
+  the dispatch envelope's causal boundary — Spec 002 §The World-Input
+  Rule) rather than reading an ambient clock (`interop/now-ms`). Folding
+  the token is what makes the decision deterministic under restore /
+  replay / SSR hydration: the SAME token replays the SAME decision.
+
+  Before this fix the machine transition path built the guard / action /
+  entry / exit callback ctx as `{:data :event :state :meta}` (+ the
+  parallel-region `:tags` / `:all-state`) — the causal token was injected
+  into event coeffects by the router but NOT exposed to machine callbacks,
+  so a durable machine guard / action had no causal way to read host facts
+  and fell back to ambient reads.
+
+  The fix threads the handler's `:rf.world/inputs` coeffect onto the
+  machine def (`prepare-machine-ctx`, alongside `:rf/frame` /
+  `:rf/platform` / `:rf/parent-id`, propagated to region specs) and
+  surfaces it on the callback ctx under the SAME `:rf.world/inputs` key.
+
+  Coverage:
+    (a) a flat-machine GUARD reads exactly the scripted `:time-ms` from
+        `(:rf.world/inputs ctx)` — no ambient clock — and decides on it.
+    (b) a flat-machine ACTION reads exactly the scripted `:time-ms` and
+        folds it into a `:data` write (a durable snapshot write).
+    (c) an :entry action (on the initial-entry boot cascade) reads the
+        scripted token.
+    (d) a PARALLEL-REGION guard reads the scripted token (proving the
+        token propagates through the synthetic region-spec).
+    (e) a non-time fact (random / UUID-style) supplied in the SAME token
+        map is readable verbatim — the token carries arbitrary host facts.
+    (f) the absent-token path: a pure `machine-transition` call (no router
+        coeffect) surfaces NO `:rf.world/inputs` ctx key — the key keys
+        off presence, so pure-fn callers (conformance corpus) are
+        unaffected."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines :as machines]
+            [re-frame.machines.test-support :as mtest]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(use-fixtures :each
+  (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private snapshot mtest/snapshot)
+
+;; A clearly-non-ambient sentinel: a fixed wall-clock epoch ms that the
+;; host clock will never spontaneously return. If a callback read the
+;; ambient clock instead of the causal token, it would NOT equal this.
+(def ^:private SCRIPTED-TIME-MS 1234500000)
+
+;; ---- (a) a flat-machine GUARD reads the scripted :time-ms -----------------
+
+(deftest guard-reads-causal-time-ms
+  (testing "a guard reads exactly the dispatch's :rf.world/inputs :time-ms —
+            the causal token, not an ambient clock"
+    (let [seen (atom nil)
+          ;; The guard fires the transition iff the causal :time-ms equals
+          ;; the scripted sentinel. An ambient-clock read would never match.
+          m {:initial :idle
+             :data    {}
+             :guards  {:at-scripted-time?
+                       (fn [{inputs :rf.world/inputs}]
+                         (reset! seen (:time-ms inputs))
+                         (= SCRIPTED-TIME-MS (:time-ms inputs)))}
+             :states  {:idle {:on {:go {:target :done :guard :at-scripted-time?}}}
+                       :done {}}}]
+      (rf/reg-machine :world/guard m)
+      (rf/dispatch-sync [:world/guard [:go]]
+                        {:rf.world/inputs {:time-ms SCRIPTED-TIME-MS}})
+      (is (= SCRIPTED-TIME-MS @seen)
+          "the guard read the scripted :time-ms off (:rf.world/inputs ctx)")
+      (is (= :done (:state (snapshot :world/guard)))
+          "the guard fired the transition on the causal :time-ms"))))
+
+(deftest guard-blocks-on-wrong-causal-time-ms
+  (testing "the same guard BLOCKS when the scripted :time-ms differs — proving
+            the decision folds the token's value, not an ambient read"
+    (let [m {:initial :idle
+             :data    {}
+             :guards  {:at-scripted-time?
+                       (fn [{inputs :rf.world/inputs}]
+                         (= SCRIPTED-TIME-MS (:time-ms inputs)))}
+             :states  {:idle {:on {:go {:target :done :guard :at-scripted-time?}}}
+                       :done {}}}]
+      (rf/reg-machine :world/guard-block m)
+      (rf/dispatch-sync [:world/guard-block [:go]]
+                        {:rf.world/inputs {:time-ms (inc SCRIPTED-TIME-MS)}})
+      (is (= :idle (:state (snapshot :world/guard-block)))
+          ":go blocked — the causal :time-ms did not match the guard's predicate"))))
+
+;; ---- (b) a flat-machine ACTION folds the scripted :time-ms into :data ------
+
+(deftest action-folds-causal-time-ms-into-data
+  (testing "an action reads the causal :time-ms and folds it into a durable
+            :data write (a snapshot write that must replay deterministically)"
+    (let [m {:initial :idle
+             :data    {}
+             :actions {:stamp-time
+                       (fn [{inputs :rf.world/inputs}]
+                         {:data {:stamped-at (:time-ms inputs)}})}
+             :states  {:idle {:on {:go {:target :done :action :stamp-time}}}
+                       :done {}}}]
+      (rf/reg-machine :world/action m)
+      (rf/dispatch-sync [:world/action [:go]]
+                        {:rf.world/inputs {:time-ms SCRIPTED-TIME-MS}})
+      (is (= SCRIPTED-TIME-MS (:stamped-at (:data (snapshot :world/action))))
+          "the action wrote the causal :time-ms into :data — folded from the
+           token, not from an ambient clock"))))
+
+;; ---- (c) an :entry action (boot cascade) reads the causal token -----------
+
+(deftest entry-action-reads-causal-time-ms
+  (testing "the initial-state :entry action — running on the boot cascade of
+            the first dispatch — reads the causal :time-ms"
+    (let [m {:initial :ready
+             :data    {}
+             :actions {:stamp-birth
+                       (fn [{inputs :rf.world/inputs}]
+                         {:data {:born-at (:time-ms inputs)}})}
+             :states  {:ready {:entry :stamp-birth}}}]
+      (rf/reg-machine :world/entry m)
+      ;; First real dispatch boots the machine; the :entry cascade runs under
+      ;; the same handler call and so reads this dispatch's causal token.
+      (rf/dispatch-sync [:world/entry [:noop]]
+                        {:rf.world/inputs {:time-ms SCRIPTED-TIME-MS}})
+      (is (= SCRIPTED-TIME-MS (:born-at (:data (snapshot :world/entry))))
+          "the :entry action read the causal :time-ms on the boot cascade"))))
+
+;; ---- (d) a PARALLEL-REGION guard reads the causal token --------------------
+
+(deftest region-guard-reads-causal-time-ms
+  (testing "a guard running inside a parallel REGION reads the causal :time-ms
+            — proving the token propagates through the synthetic region-spec"
+    (let [m {:type    :parallel
+             :data    {}
+             :guards  {:at-scripted-time?
+                       (fn [{inputs :rf.world/inputs}]
+                         (= SCRIPTED-TIME-MS (:time-ms inputs)))}
+             :regions
+             {:a {:initial :idle
+                  :states  {:idle {:on {:go {:target :done
+                                             :guard  :at-scripted-time?}}}
+                            :done {}}}
+              :b {:initial :x :states {:x {}}}}}]
+      (rf/reg-machine :world/region m)
+      (rf/dispatch-sync [:world/region [:go]]
+                        {:rf.world/inputs {:time-ms SCRIPTED-TIME-MS}})
+      (is (= :done (get-in (snapshot :world/region) [:state :a]))
+          "the region guard fired on the causal :time-ms — the token reached
+           the region callback ctx")))
+  (testing "and the same region guard blocks on a non-matching causal :time-ms"
+    (let [m {:type    :parallel
+             :data    {}
+             :guards  {:at-scripted-time?
+                       (fn [{inputs :rf.world/inputs}]
+                         (= SCRIPTED-TIME-MS (:time-ms inputs)))}
+             :regions
+             {:a {:initial :idle
+                  :states  {:idle {:on {:go {:target :done
+                                             :guard  :at-scripted-time?}}}
+                            :done {}}}
+              :b {:initial :x :states {:x {}}}}}]
+      (rf/reg-machine :world/region-block m)
+      (rf/dispatch-sync [:world/region-block [:go]]
+                        {:rf.world/inputs {:time-ms (inc SCRIPTED-TIME-MS)}})
+      (is (= :idle (get-in (snapshot :world/region-block) [:state :a]))
+          "the region guard blocked — wrong causal :time-ms"))))
+
+;; ---- (e) arbitrary host facts (random / uuid-style) ride the token --------
+
+(deftest action-reads-arbitrary-host-facts-from-token
+  (testing "the token carries arbitrary host facts (a random seed / uuid-style
+            value), readable verbatim by an action — not just :time-ms"
+    (let [seed     987654321
+          gen-uuid "11111111-2222-3333-4444-555555555555"
+          m {:initial :idle
+             :data    {}
+             :actions {:stamp-facts
+                       (fn [{inputs :rf.world/inputs}]
+                         {:data {:seed (:rng-seed inputs)
+                                 :id   (:new-uuid inputs)}})}
+             :states  {:idle {:on {:go {:target :done :action :stamp-facts}}}
+                       :done {}}}]
+      (rf/reg-machine :world/facts m)
+      (rf/dispatch-sync [:world/facts [:go]]
+                        {:rf.world/inputs {:time-ms  SCRIPTED-TIME-MS
+                                           :rng-seed seed
+                                           :new-uuid gen-uuid}})
+      (let [d (:data (snapshot :world/facts))]
+        (is (= seed (:seed d))
+            "the action read the causal random seed off the token")
+        (is (= gen-uuid (:id d))
+            "the action read the causal uuid-style fact off the token")))))
+
+;; ---- (f) absent token — pure-fn caller surfaces no :rf.world/inputs key ----
+
+(deftest pure-fn-callback-ctx-has-no-world-inputs-key
+  (testing "a pure machine-transition (no router coeffect, the conformance /
+            JVM-fixture path) surfaces NO :rf.world/inputs ctx key — the key
+            is presence-gated, so pure-fn callers are unaffected"
+    (let [captured (atom nil)
+          m {:initial :idle
+             :data    {}
+             :guards  {:capture (fn [ctx] (reset! captured ctx) true)}
+             :states  {:idle {:on {:go {:target :done :guard :capture}}}
+                       :done {}}}]
+      ;; Drive the PURE engine directly — no dispatch, no handler, so the
+      ;; machine def carries no :rf/world-inputs stamp.
+      (machines/machine-transition m {:state :idle :data {}} [:go])
+      (is (some? @captured) "the guard ran")
+      (is (not (contains? @captured :rf.world/inputs))
+          "no :rf.world/inputs key when the engine is driven without a token")
+      (is (= #{:data :event :state :meta} (set (keys @captured)))
+          "the pure-fn guard ctx is exactly the four base keys"))))

--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -377,6 +377,21 @@ Guards or actions that need to branch on the discrete FSM state name or on any u
 
 The context-map shape is uniform across every callback slot — `:state` and `:meta` are always present alongside `:data` and `:event` for `:guard` / `:action` / `:entry` / `:exit`. There is no opt-in flag and no separate 3-arity variant; the runtime delivers the full map and the user's destructure pattern decides what's bound.
 
+#### Causal host facts — `:rf.world/inputs` (EP-0010)
+
+A `:guard` / `:action` / `:entry` / `:exit` callback whose decision depends on a host fact — the wall-clock time, a random draw, a generated UUID — reads it from the context map's **`:rf.world/inputs`** key, **not** from an ambient host read (`(js/Date.now)`, `(rand)`, `(random-uuid)`). `:rf.world/inputs` is the dispatch's **causal world-input token** — the same `{:time-ms N …}` map the router stamps onto the event coeffects at the dispatch envelope's causal boundary ([Spec 002 §The World-Input Rule](002-Frames.md#the-world-input-rule)). Folding the token (rather than reading the ambient clock) is what makes a durable machine decision — and any `:data` it writes into the snapshot — **replay deterministically**: the same token replays the same decision under `restore-epoch` / SSR hydration / replay.
+
+```clojure
+;; a guard / action that needs "now" reads the causal token, NOT (js/Date.now)
+:guard  (fn [{inputs :rf.world/inputs}]
+          (> (- (:time-ms inputs) (:started-at data)) timeout-ms))
+
+:action (fn [{inputs :rf.world/inputs}]
+          {:data {:completed-at (:time-ms inputs)}})   ;; durable, replayable
+```
+
+The key is present whenever the machine is driven through the normal dispatch path (the router always stamps `:time-ms`). It is **absent** when the engine is driven as a pure function with no router coeffect (the conformance corpus / JVM fixtures); a destructure of `:rf.world/inputs` then binds `nil`, so pure-fn callers are unaffected. Region callbacks (inside a parallel machine) receive the same token.
+
 For a guard / action running **inside a parallel region**, the context map additionally carries `:tags` (the machine-wide active-configuration tag union) and `:all-state` (the full region-name → active-state map) — the cross-region `stateIn` substitute. These two keys are present only for region callbacks; flat / compound machines never carry them. See [§Cross-region coordination — tags as `stateIn`](#cross-region-coordination--tags-as-statein).
 
 Compound logic is expressed via function composition or as a named entry in the machine's `:guards` map — the name carries semantic content visualisers and AIs read. Resolution is machine-scoped per [§Registration — the machine IS the event handler](#registration--the-machine-is-the-event-handler); unresolved references fail registration with `:rf.error/machine-unresolved-guard`.
@@ -633,7 +648,7 @@ A machine *almost never* needs to write `app-db` directly; it acts on its own st
 
 - **Action signature:** `(fn [{:keys [data event state meta]}] effects)` — single context-map argument; user destructures the keys it needs.
 - **Guard signature:** `(fn [{:keys [data event state meta]}] boolean)` — single context-map argument, same shape as `:action`.
-- **What the fn sees:** the keys it destructures from the context map — `:data` (the snapshot's `:data` slot), `:event` (the inbound event vector), `:state` (the discrete FSM-keyword), `:meta` (any user `:meta` on the snapshot). Never `app-db`; never cofx.
+- **What the fn sees:** the keys it destructures from the context map — `:data` (the snapshot's `:data` slot), `:event` (the inbound event vector), `:state` (the discrete FSM-keyword), `:meta` (any user `:meta` on the snapshot), and `:rf.world/inputs` (the dispatch's causal world-input token — EP-0010; see [§Causal host facts](#causal-host-facts--rfworldinputs-ep-0010)). Never `app-db`; never cofx (`:rf.world/inputs` is the one host-fact channel, threaded causally — not a general cofx surface).
 
 The impure plumbing (reading the snapshot from runtime-db at `[:rf.runtime/machines :snapshots <id>]`, writing `:data` back as a `:rf.db/runtime` write, lowering `:fx` / `:raise` / `:rf.machine/spawn` into standard re-frame effects) lives in the *handler boundary* — the fn returned by `make-machine-handler`. **Inside the boundary: pure. Outside: standard re-frame.**
 
@@ -669,9 +684,9 @@ every machine callback receives a SINGLE context-map argument; the keys present 
 
 | Slot | Signature | Ctx keys | What it returns |
 |---|---|---|---|
-| `:guard` | `(fn [{:keys [data event state meta]}] boolean)` | `:data :event :state :meta` | a boolean |
-| `:action` | `(fn [{:keys [data event state meta]}] effects)` | `:data :event :state :meta` | `{:data ... :fx ...}` (or `nil`) |
-| `:entry` / `:exit` | same as `:action` | `:data :event :state :meta` | `{:data ... :fx ...}` (or `nil`) |
+| `:guard` | `(fn [{:keys [data event state meta] inputs :rf.world/inputs}] boolean)` | `:data :event :state :meta :rf.world/inputs` | a boolean |
+| `:action` | `(fn [{:keys [data event state meta] inputs :rf.world/inputs}] effects)` | `:data :event :state :meta :rf.world/inputs` | `{:data ... :fx ...}` (or `nil`) |
+| `:entry` / `:exit` | same as `:action` | `:data :event :state :meta :rf.world/inputs` | `{:data ... :fx ...}` (or `nil`) |
 | `:on-spawn` | `(fn [{:keys [data id]}] _)` — **advisory** | `:data :id` | ignored (return is dropped; runtime tracks the spawn-id at `[:rf.runtime/machines :spawned <parent> <invoke-id>]`) |
 | `:on-done` | `(fn [{:keys [data result]}] new-data)` | `:data :result` | the parent's new `:data` map |
 | `:after` delay-fn | `(fn [{:keys [snapshot]}] ms)` | `:snapshot` | a positive-int millisecond delay |


### PR DESCRIPTION
## Summary

EP-0010 bug fix (rf2-g0m4p5). Machine `:guard` / `:action` / `:entry` / `:exit` callback contexts omitted the causal world-input token, so durable machine decisions and snapshot writes that depend on time / random / UUID host facts had no causal way to read them and fell back to ambient reads — breaking deterministic replay under `restore-epoch` / SSR hydration / replay.

The router injects `:rf.world/inputs` into event coeffects (`router.cljc`), but the machine transition path did not expose it to callbacks. This threads the handler's `:rf.world/inputs` coeffect onto the machine def and surfaces it on the callback ctx under the same key.

## How it's threaded

- **`lifecycle_fx/registration.cljc`** — the machine handler-fn destructures `:rf.world/inputs` from its cofx and passes it to `prepare-machine-ctx`, which stamps it onto the machine def under `:rf/world-inputs` alongside the existing `:rf/frame` / `:rf/platform` / `:rf/parent-id` runtime stamps. Presence-gated (`some?`), so the absent-token path stays clean.
- **`parallel.cljc`** — `build-region-machine` inherits `:rf/world-inputs` onto the synthetic region spec, and `region-spec-overlaid` overlays the live token (the region-spec cache is populated at registration time, before the per-dispatch token is stamped). So a parallel-region guard / action reads the same causal token.
- **`transition.cljc`** — `callback-ctx` (the unified ctx for guards/actions/entry/exit) reads `:rf/world-inputs` off the machine and surfaces it under `:rf.world/inputs` when present. `call-guard` / `call-action` now take `machine` and pass it through; both call sites (`evaluate-guard`, `run-action`) already had `machine` in scope.

A guard / action now reads `(:time-ms (:rf.world/inputs ctx))` — the causal token — instead of an ambient `interop/now-ms`, so the decision and any `:data` it writes replay deterministically. Pure-fn callers (conformance corpus / JVM fixtures) that drive the engine with no router coeffect surface no `:rf.world/inputs` key — the key is presence-gated, so they are unaffected.

## Test

New `machine_world_inputs_ctx_test.clj`: a scripted `dispatch-sync` supplies `{:rf.world/inputs {:time-ms N}}` and asserts a guard / action / `:entry` reads **exactly N** (no ambient clock) — fires when it matches, blocks when it doesn't. Also covers a parallel-region guard reading N, arbitrary host facts (random seed / uuid-style) riding the same token, and the absent-token pure-fn path (no `:rf.world/inputs` key, ctx is the four base keys). Updated two pre-existing cross-region ctx-key-set assertions in `cross_region_guard_ctx_test.clj` that now (correctly) also see the router-stamped token, keeping their real intent — the parallel-region `:tags` / `:all-state` keys stay absent for flat / compound machines.

## Spec

`spec/005-StateMachines.md` (hot-zone; sole toucher this PR): new §Causal host facts subsection documenting the `:rf.world/inputs` ctx key, plus the §What the fn sees bullet and the ctx-keys table updated to list it. Links to Spec 002 §The World-Input Rule.

## Quality gates

- `clojure -M:test` (machines artefact, JVM): **627 tests, 2018 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **6508 tests, 23761 assertions, 0 failures, 0 errors**
- `mkdocs build --strict`: clean (new anchor + cross-doc link resolve)
