### PR TITLE
feat(reply): EP-0011 substrate hardening — data-contract fail-loud + :dispatch-stale? authority (rf2-r16hfc rf2-636pkr)

### DIFF
--- a/implementation/core/src/re_frame/reply.cljc
+++ b/implementation/core/src/re_frame/reply.cljc
@@ -71,11 +71,12 @@
 ;; and the internal descriptor form (Managed-Effects §The reply target).
 ;;
 ;; A normalized target is a map:
-;;   {:event          [:event-id arg ...]   ;; the prefix to complete
-;;    :delivery       :append               ;; the only public delivery mode
-;;    :suppress       {...}                  ;; optional data-only gates
-;;    :dispatch-stale? false                 ;; framework test/tool opt-in only
-;;    ::post          (fn [event] event)}    ;; the composed event-transform
+;;   {:event             [:event-id arg ...] ;; the prefix to complete
+;;    :delivery          :append             ;; the only public delivery mode
+;;    :suppress          {...}               ;; optional data-only gates
+;;    :dispatch-stale?   false               ;; framework test/tool opt-in only
+;;    ::post             (fn [event] event)  ;; the composed event-transform
+;;    ::stale-authority  true}               ;; framework/tool capability marker
 ;;
 ;; `::post` is the functor's accumulator: a pure event→event transform that
 ;; `complete` applies AFTER appending the reply map. It is namespaced-private
@@ -83,9 +84,35 @@
 ;; only on a normalized target while a family is assembling/relocating a
 ;; continuation, exactly the role Elm's `Cmd.map` plays. Identity target
 ;; carries no `::post` (treated as identity); composition composes them.
+;;
+;; `::stale-authority` is the framework/tool CAPABILITY marker for stale
+;; delivery (Managed-Effects §The reply target: `:dispatch-stale?` is
+;; "restricted to framework test and tool targets"). It is namespaced-private
+;; — only framework/tool code reaches it (via `with-stale-authority`); an app
+;; target built from `:rf/reply-to` data cannot name it, so it cannot grant
+;; itself stale-delivery authority. Like `::post`, it is EPHEMERAL: it rides a
+;; normalized target while a family/tool assembles a continuation and MUST NOT
+;; be serialized into an effect map or a durable reply target.
+;;
+;; EPHEMERAL vs DURABLE. `::post` and `::stale-authority` are the two
+;; ephemeral, host-/capability-bearing slots a normalized target may carry
+;; while in-flight. A target that could become DURABLE (persisted to a ledger
+;; row, a stored continuation, a replay log) MUST be data-only: see
+;; `durable-target` (strips ephemerals + asserts data-only) and
+;; `data-only-target?` (the predicate conformance pins).
 ;; ---------------------------------------------------------------------------
 
 (def ^:private post-key ::post)
+
+(def ^:private stale-authority-key ::stale-authority)
+
+(def ^:private ephemeral-target-keys
+  "The namespaced-private slots a normalized target may carry while in-flight
+  that MUST NOT survive into a durable target: the functor accumulator
+  (`::post`, a fn) and the stale-delivery capability marker
+  (`::stale-authority`). `durable-target` strips these; their presence makes a
+  target non-data-only."
+  #{post-key stale-authority-key})
 
 (defn descriptor?
   "True when `target` is the descriptor (map) form rather than the
@@ -126,17 +153,20 @@
 (defn target->short-form
   "Project a normalized target back to its public short form when it has no
   non-default descriptor fields (no `:suppress`, no `:dispatch-stale?`, no
-  accumulated `::post`, `:delivery :append`). Otherwise returns the
-  descriptor unchanged. Lets a family expose the bare vector publicly while
-  using the descriptor internally (Managed-Effects: \"A family MAY expose
-  only the short vector form publicly while using the descriptor form
-  internally\")."
+  accumulated `::post`, no `::stale-authority`, `:delivery :append`).
+  Otherwise returns the descriptor unchanged. Lets a family expose the bare
+  vector publicly while using the descriptor internally (Managed-Effects: \"A
+  family MAY expose only the short vector form publicly while using the
+  descriptor form internally\"). The ephemeral capability slot
+  (`::stale-authority`) keeps the descriptor too — projecting must never
+  silently drop a framework/tool capability."
   [target]
   (let [{:keys [event delivery suppress dispatch-stale?] :as d} (normalize-target target)]
     (if (and (= delivery :append)
              (nil? suppress)
              (not dispatch-stale?)
-             (nil? (get d post-key)))
+             (nil? (get d post-key))
+             (nil? (get d stale-authority-key)))
       event
       d)))
 
@@ -210,14 +240,46 @@
     (assoc d post-key composed)))
 
 ;; ---------------------------------------------------------------------------
-;; Reply-map schema validation (Managed-Effects §The reply map / §Status
-;; taxonomy). Validates the closed-status invariant, the value/error
-;; conventions per status, and the data-only invariant (no host handles).
-;;
-;; Returns nil when valid; otherwise a vector of problem maps
-;; `{:rf.reply/problem <kw> :path <path> :detail ...}`. `valid?` is the
-;; boolean sugar. Pure — does not throw on a malformed reply (a malformed
-;; reply is data the caller classifies), only on a non-map argument.
+;; Stale-delivery authority — the framework/tool capability (Managed-Effects
+;; §The reply target). `:dispatch-stale?` is "restricted to framework test and
+;; tool targets"; the substrate is pure and has no caller-identity context, so
+;; the restriction is enforced STRUCTURALLY by a namespaced-private capability
+;; marker that only framework/tool code can attach. An app target built from
+;; `:rf/reply-to` data cannot name `::stale-authority`, so it cannot grant
+;; itself stale delivery — and `suppress` fails LOUD if it tries.
+;; ---------------------------------------------------------------------------
+
+(defn with-stale-authority
+  "Stamp a reply `target` as a FRAMEWORK/TOOL target authorised to opt into
+  stale delivery via `:dispatch-stale? true` (Managed-Effects §The reply
+  target). Returns the normalized descriptor carrying the namespaced-private
+  `::stale-authority` capability marker.
+
+  This is the ONLY way `:dispatch-stale? true` is honoured: `suppress` throws
+  on a target that sets `:dispatch-stale? true` WITHOUT this marker (an app
+  target cannot reach the private key, so it cannot grant itself the
+  capability). Framework test/tool callers wrap their target with this helper;
+  app code — which builds a target from public `:rf/reply-to` data — never
+  does, and so an app reply is never delivered stale.
+
+  Like `::post`, the marker is EPHEMERAL: it rides an in-flight normalized
+  target and MUST NOT be serialized into an effect map or a durable target
+  (`durable-target` strips it)."
+  [target]
+  (assoc (normalize-target target) stale-authority-key true))
+
+(defn stale-authority?
+  "True when `target` carries the framework/tool `::stale-authority`
+  capability marker (set via `with-stale-authority`)."
+  [target]
+  (true? (get (normalize-target target) stale-authority-key)))
+
+;; ---------------------------------------------------------------------------
+;; Host-handle detection — the shared data-only walker (Managed-Effects §The
+;; reply map / §The reply target: the data-only invariant). Used by BOTH the
+;; durable-target guard and `validate-reply` — a single definition of "what a
+;; host handle is" so the reply map and the reply target enforce the same
+;; data-only contract.
 ;; ---------------------------------------------------------------------------
 
 (defn- host-handle?
@@ -249,6 +311,60 @@
      (set? v)         (some #(walk-find-host-handle % (conj path '*)) v)
      :else            nil)))
 
+;; ---------------------------------------------------------------------------
+;; Data-only / durable target invariant (Managed-Effects §The reply target —
+;; the reply-target-as-data contract). A normalized target may carry the
+;; ephemeral, non-data slots `::post` (a fn) and `::stale-authority` (a
+;; capability) WHILE IN-FLIGHT, but a target that can become DURABLE (a stored
+;; continuation, a ledger row, a replay log) MUST be data-only. These helpers
+;; make that boundary explicit and fail LOUD rather than letting a
+;; non-serializable function or a capability marker leak into durable reply
+;; data.
+;; ---------------------------------------------------------------------------
+
+(defn data-only-target?
+  "True when `target` is DATA-ONLY — safe to persist into a durable reply
+  target. False when it carries an ephemeral, non-data slot: the functor
+  accumulator `::post` (an arbitrary fn) or the `::stale-authority` capability
+  marker. (The public data fields `:event` / `:delivery` / `:suppress` /
+  `:dispatch-stale?` are all data and pass.) A nil target is data-only
+  (nothing to persist)."
+  [target]
+  (let [d (normalize-target target)]
+    (not (some #(contains? d %) ephemeral-target-keys))))
+
+(defn durable-target
+  "Project `target` to a DURABLE, data-only normalized descriptor — stripping
+  the ephemeral non-data slots (`::post`, `::stale-authority`) — and assert
+  the result carries no host handle anywhere. Use before a target could be
+  persisted (a stored continuation, a ledger row, a replay log).
+
+  Fails LOUD (throws `ex-info` `:rf.reply/non-data-target`) if, after
+  stripping the framework-private slots, the descriptor STILL contains a host
+  handle (a fn, Promise, AbortController, …) in a public field — that would be
+  an app/family bug smuggling a non-serializable value through `:event` /
+  `:suppress`. A nil target yields nil (no continuation to persist)."
+  [target]
+  (when-let [d (normalize-target target)]
+    (let [stripped (apply dissoc d ephemeral-target-keys)]
+      (when-let [handle-path (walk-find-host-handle stripped)]
+        (throw (ex-info "Durable reply target must be data-only — it carries a host handle (fn / Promise / AbortController / …) in a public field."
+                        {:rf.error/kind :rf.reply/non-data-target
+                         :path          handle-path
+                         :target        stripped})))
+      stripped)))
+
+;; ---------------------------------------------------------------------------
+;; Reply-map schema validation (Managed-Effects §The reply map / §Status
+;; taxonomy). Validates the closed-status invariant, the value/error
+;; conventions per status, and the data-only invariant (no host handles).
+;;
+;; Returns nil when valid; otherwise a vector of problem maps
+;; `{:rf.reply/problem <kw> :path <path> :detail ...}`. `valid?` is the
+;; boolean sugar. Pure — does not throw on a malformed reply (a malformed
+;; reply is data the caller classifies), only on a non-map argument.
+;; ---------------------------------------------------------------------------
+
 (defn validate-reply
   "Validate a reply map against the Managed-Effects reply-map contract.
   Returns nil when valid, else a vector of problem maps. Checks:
@@ -256,13 +372,25 @@
     - `:status` present and in the CLOSED `statuses` set;
     - per-status value/error conventions:
         `:ok`        — `:value` present, `:error` absent;
-        `:partial`   — `:value` present AND `:error` present (with a
-                       family `:kind` when `:error` is a map);
-        `:error`     — `:error` present (with a family `:kind` when a map);
-        `:cancelled` — `:cancel/reason` present;
+        `:partial`   — `:value` present AND `:error` present as a family
+                       error MAP carrying a `:kind`;
+        `:error`     — `:error` present as a family error MAP carrying a
+                       `:kind`;
+        `:cancelled` — `:cancel/reason` present AND `:cancelled? true`
+                       (the intentional-cancellation marker);
         `:stale`     — `:stale? true` AND `:stale/reason` present;
     - `:work/status` (when present) in the `work-statuses` set;
     - the data-only invariant: no host handles anywhere in the map.
+
+  The `:error`/`:partial` error shape is TIGHT: the spec status taxonomy
+  requires `:error` \"present with a family `:kind`\", so a loose scalar
+  `:error` (a bare keyword/string) is rejected — every family error rides a
+  structured `{:kind … …}` map so downstream classification, tracing, and
+  cross-family error handling have a uniform shape to dispatch on (a scalar
+  would force each consumer to special-case it). Likewise a `:cancelled`
+  reply MUST carry the `:cancelled? true` marker, not merely a
+  `:cancel/reason`, so cancellation is an explicit positive fact rather than
+  inferred from the presence of a reason.
 
   Pure; throws only on a non-map argument."
   [reply]
@@ -270,7 +398,10 @@
     (throw (ex-info "Reply must be a map." {:rf.error/kind :rf.reply/non-map-reply :reply reply})))
   (let [{:keys [status value error]} reply
         problem (fn [kind path detail] {:rf.reply/problem kind :path path :detail detail})
-        kind-ok? (fn [e] (or (not (map? e)) (some? (:kind e))))
+        ;; A family error MUST be a structured map carrying a :kind. A loose
+        ;; scalar (bare keyword/string/number) is NOT a valid family error —
+        ;; the closed contract demands the uniform {:kind …} shape.
+        error-map-with-kind? (fn [e] (and (map? e) (some? (:kind e))))
         ps (cond-> []
              (not (contains? reply :status))
              (conj (problem :rf.reply/missing-status [:status] nil))
@@ -284,23 +415,29 @@
              (and (= status :ok) (some? error))
              (conj (problem :rf.reply/ok-has-error [:error] error))
 
-             ;; :partial — both value and error present; error carries a family :kind.
+             ;; :partial — both value and error present; :error is a family
+             ;; error MAP carrying a :kind (a loose scalar is rejected).
              (and (= status :partial) (not (contains? reply :value)))
              (conj (problem :rf.reply/partial-missing-value [:value] nil))
              (and (= status :partial) (nil? error))
              (conj (problem :rf.reply/partial-missing-error [:error] nil))
-             (and (= status :partial) (some? error) (not (kind-ok? error)))
-             (conj (problem :rf.reply/error-missing-kind [:error :kind] error))
+             (and (= status :partial) (some? error) (not (error-map-with-kind? error)))
+             (conj (problem :rf.reply/error-not-family-map [:error] error))
 
-             ;; :error — error present, carries a family :kind.
+             ;; :error — :error present as a family error MAP carrying a :kind
+             ;; (a loose scalar is rejected).
              (and (= status :error) (nil? error))
              (conj (problem :rf.reply/error-missing-error [:error] nil))
-             (and (= status :error) (some? error) (not (kind-ok? error)))
-             (conj (problem :rf.reply/error-missing-kind [:error :kind] error))
+             (and (= status :error) (some? error) (not (error-map-with-kind? error)))
+             (conj (problem :rf.reply/error-not-family-map [:error] error))
 
-             ;; :cancelled — :cancel/reason present.
+             ;; :cancelled — :cancel/reason present AND the :cancelled? true
+             ;; intentional-cancellation marker (cancellation is a positive
+             ;; fact, not inferred from a stray reason).
              (and (= status :cancelled) (nil? (:cancel/reason reply)))
              (conj (problem :rf.reply/cancelled-missing-reason [:cancel/reason] nil))
+             (and (= status :cancelled) (not (true? (:cancelled? reply))))
+             (conj (problem :rf.reply/cancelled-missing-marker [:cancelled?] (:cancelled? reply)))
 
              ;; :stale — :stale? true and :stale/reason present; MUST NOT carry :value.
              (and (= status :stale) (not (true? (:stale? reply))))
@@ -395,13 +532,24 @@
   "Produce the stale-suppression outcome for a superseded completion WITHOUT
   dispatching the app target. This is the correctness boundary made
   concrete: the returned `:reply` is `:status :stale` (no `:value`, no app
-  mutation), and `:deliver?` is `false` (unless the target explicitly opted
-  into stale delivery via `:dispatch-stale?` — restricted to framework test
-  / tool targets).
+  mutation), and `:deliver?` is `false` (unless the target is a FRAMEWORK/TOOL
+  target that explicitly opted into stale delivery via `:dispatch-stale? true`
+  — see the authority rule below).
+
+  AUTHORITY (Managed-Effects §The reply target — `:dispatch-stale?` is
+  \"restricted to framework test and tool targets\"). `:dispatch-stale? true`
+  is honoured ONLY when the target also carries the framework/tool
+  `::stale-authority` capability marker (stamped via `with-stale-authority`).
+  An APP target — built from public `:rf/reply-to` data, which has no way to
+  name the namespaced-private marker — cannot grant itself stale delivery: if
+  it sets `:dispatch-stale? true` WITHOUT authority this FAILS LOUD (throws
+  `ex-info` `:rf.reply/unauthorized-stale-delivery`) rather than silently
+  delivering a stale envelope to app state. The default (no `:dispatch-stale?`)
+  is non-delivery for every target, app or framework.
 
   Arguments:
     `target`  — the (optionally normalized) reply target; consulted only for
-                its `:dispatch-stale?` opt-in.
+                its `:dispatch-stale?` opt-in and `::stale-authority`.
     `carried` — the data-only correlation captured at issuance.
     `current` — the data-only correlation read from live frame-state now.
     `extra`   — optional reply fields to carry verbatim (`:work/id`,
@@ -425,7 +573,17 @@
   ([target carried current extra]
    (let [reason   (or (:stale/reason extra) :rf.reply/correlation-mismatch)
          d        (when target (normalize-target target))
-         opt-in?  (true? (:dispatch-stale? d))
+         wants?   (true? (:dispatch-stale? d))
+         authorised? (true? (get d stale-authority-key))
+         ;; FAIL LOUD: a target asking for stale delivery without the
+         ;; framework/tool capability is an app target overreaching. The
+         ;; substrate is pure (no caller identity), so the marker IS the
+         ;; authority — its absence means "not framework/tool".
+         _        (when (and wants? (not authorised?))
+                    (throw (ex-info "Stale delivery (:dispatch-stale? true) is restricted to framework test/tool targets — this target lacks the stale-delivery authority. App reply targets MUST NOT receive stale envelopes."
+                                    {:rf.error/kind :rf.reply/unauthorized-stale-delivery
+                                     :target        d})))
+         opt-in?  (and wants? authorised?)
          carry    (dissoc extra :stale/reason)
          reply    (merge {:status       :stale
                           :stale?       true

--- a/implementation/core/test/re_frame/reply_test.cljc
+++ b/implementation/core/test/re_frame/reply_test.cljc
@@ -45,15 +45,23 @@
               (reply/validate-reply {:status :ok :value 1 :error {:kind :x}})))))
 
 (deftest error-conventions
-  (testing ":error requires :error with a family :kind"
+  (testing ":error requires :error as a family error MAP carrying a :kind"
     (is (reply/valid-reply? {:status :error :error {:kind :rf.http/http-5xx}}))
     (is (some #(= :rf.reply/error-missing-error (:rf.reply/problem %))
               (reply/validate-reply {:status :error})))
-    (is (some #(= :rf.reply/error-missing-kind (:rf.reply/problem %))
-              (reply/validate-reply {:status :error :error {:no :kind}})))))
+    (is (some #(= :rf.reply/error-not-family-map (:rf.reply/problem %))
+              (reply/validate-reply {:status :error :error {:no :kind}}))
+        "a map without :kind is not a family error"))
+  (testing "a LOOSE SCALAR :error is rejected — every family error is a structured {:kind …} map"
+    (is (some #(= :rf.reply/error-not-family-map (:rf.reply/problem %))
+              (reply/validate-reply {:status :error :error :rf.http/http-5xx}))
+        "a bare keyword :error fails loud — the closed contract demands the {:kind …} shape")
+    (is (some #(= :rf.reply/error-not-family-map (:rf.reply/problem %))
+              (reply/validate-reply {:status :error :error "boom"}))
+        "a bare string :error fails loud too")))
 
 (deftest partial-conventions
-  (testing ":partial carries BOTH usable :value AND structured :error with a family :kind"
+  (testing ":partial carries BOTH usable :value AND a structured family :error MAP with a :kind"
     (is (reply/valid-reply?
           {:status :partial
            :value  {:user {:name "Ada"}}
@@ -63,18 +71,27 @@
               (reply/validate-reply {:status :partial :error {:kind :x}})))
     (is (some #(= :rf.reply/partial-missing-error (:rf.reply/problem %))
               (reply/validate-reply {:status :partial :value 1})))
-    (is (some #(= :rf.reply/error-missing-kind (:rf.reply/problem %))
-              (reply/validate-reply {:status :partial :value 1 :error {:no :kind}})))))
+    (is (some #(= :rf.reply/error-not-family-map (:rf.reply/problem %))
+              (reply/validate-reply {:status :partial :value 1 :error {:no :kind}})))
+    (is (some #(= :rf.reply/error-not-family-map (:rf.reply/problem %))
+              (reply/validate-reply {:status :partial :value 1 :error :loose-scalar}))
+        "a loose scalar :error on a :partial is rejected just like on :error")))
 
 (deftest cancelled-conventions
-  (testing ":cancelled requires :cancel/reason; :error MAY carry compatibility data"
-    (is (reply/valid-reply? {:status :cancelled :cancel/reason :user}))
+  (testing ":cancelled requires :cancel/reason AND the :cancelled? true marker; :error MAY carry compatibility data"
+    (is (reply/valid-reply? {:status :cancelled :cancel/reason :user :cancelled? true}))
     (is (reply/valid-reply? {:status        :cancelled
                              :cancel/reason :actor-destroyed
                              :cancelled?    true
                              :error         {:kind :rf.http/aborted :reason :actor-destroyed}}))
     (is (some #(= :rf.reply/cancelled-missing-reason (:rf.reply/problem %))
-              (reply/validate-reply {:status :cancelled})))))
+              (reply/validate-reply {:status :cancelled :cancelled? true})))
+    (is (some #(= :rf.reply/cancelled-missing-marker (:rf.reply/problem %))
+              (reply/validate-reply {:status :cancelled :cancel/reason :user}))
+        "a :cancel/reason alone is NOT enough — cancellation is a positive :cancelled? true fact")
+    (is (some #(= :rf.reply/cancelled-missing-marker (:rf.reply/problem %))
+              (reply/validate-reply {:status :cancelled :cancel/reason :user :cancelled? false}))
+        ":cancelled? false on a :cancelled reply is contradictory and fails loud")))
 
 (deftest stale-conventions
   (testing ":stale requires :stale? true + :stale/reason and carries NO :value"
@@ -139,6 +156,51 @@
     (is (map? (reply/target->short-form {:event [:x] :suppress {:g 1}}))))
   (testing "nil target ⇒ nil (no continuation)"
     (is (nil? (reply/normalize-target nil)))))
+
+;; ---------------------------------------------------------------------------
+;; Group 1b' — the reply-target-as-data contract (rf2-r16hfc item 1). A
+;; normalized target may carry the EPHEMERAL non-data slots (`::post`, the
+;; functor accumulator fn; `::stale-authority`, the capability marker) while
+;; in-flight, but a target that could become DURABLE must be data-only.
+;; `durable-target` strips the ephemerals and asserts no host handle leaks
+;; into a persisted target; `data-only-target?` is the predicate.
+;; ---------------------------------------------------------------------------
+
+(deftest durable-target-is-data-only
+  (testing "a plain data target is data-only and survives durable projection unchanged"
+    (is (true? (reply/data-only-target? [:x 1])))
+    (is (true? (reply/data-only-target? {:event [:x] :suppress {:g 1} :dispatch-stale? false})))
+    (is (= {:event [:x] :delivery :append :suppress {:g 1}}
+           (reply/durable-target {:event [:x] :suppress {:g 1}})))
+    (is (nil? (reply/durable-target nil)) "nil target ⇒ nil (nothing to persist)"))
+  (testing "a MAPPED target carries the ::post fn — NOT data-only — and durable projection strips it"
+    (let [mapped (reply/map-target (fn [e] e) [:x 1])]
+      (is (false? (reply/data-only-target? mapped))
+          "the functor accumulator is a fn — a mapped target is not safe to persist")
+      (let [durable (reply/durable-target mapped)]
+        (is (true? (reply/data-only-target? durable)) "stripping ::post restores data-only")
+        (is (not (reply/stale-authority? durable))))))
+  (testing "an AUTHORISED target carries the capability marker — NOT data-only — and is stripped"
+    (let [authd (reply/with-stale-authority {:event [:x] :dispatch-stale? true})]
+      (is (false? (reply/data-only-target? authd))
+          "the ::stale-authority capability must not persist into a durable target")
+      (is (false? (reply/stale-authority? (reply/durable-target authd)))
+          "durable projection strips the capability — a persisted target re-acquires no authority")
+      (is (= {:event [:x] :delivery :append :dispatch-stale? true}
+             (reply/durable-target authd)))))
+  (testing "durable-target FAILS LOUD when a host handle hides in a PUBLIC field (an app/family bug)"
+    ;; A function smuggled into :suppress (or any public slot) would leak a
+    ;; non-serializable value into a durable reply target — reject it loudly.
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #"must be data-only"
+          (reply/durable-target {:event [:x] :suppress {:cb (fn [] 1)}})))
+    (try
+      (reply/durable-target {:event [:x] :suppress {:cb (fn [] 1)}})
+      (is false "expected durable-target to throw")
+      (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+        (is (= :rf.reply/non-data-target (:rf.error/kind (ex-data e))))
+        (is (= [:suppress :cb] (:path (ex-data e))) "the failure reports the exact path to the handle")))))
 
 ;; ---------------------------------------------------------------------------
 ;; Group 1c — completion appends the reply as the final arg.
@@ -280,10 +342,56 @@
            (:stale/reason (:reply (reply/suppress [:x] {:g 1} {:g 2})))))))
 
 (deftest suppress-dispatch-stale-opt-in
-  (testing "framework test/tool targets MAY opt into stale delivery via :dispatch-stale?"
-    (is (false? (:deliver? (reply/suppress {:event [:x]} {:g 1} {:g 2}))))
-    (is (true?  (:deliver? (reply/suppress {:event [:x] :dispatch-stale? true} {:g 1} {:g 2})))
-        "the explicit framework-only opt-in lets a test/tool target receive the stale envelope")))
+  (testing "the default — every target, app or framework — is NON-delivery of a stale reply"
+    (is (false? (:deliver? (reply/suppress {:event [:x]} {:g 1} {:g 2})))
+        "no :dispatch-stale? ⇒ not delivered")
+    (is (false? (:deliver? (reply/suppress (reply/with-stale-authority {:event [:x]}) {:g 1} {:g 2})))
+        "authority WITHOUT :dispatch-stale? ⇒ still not delivered (the capability alone does not opt in)"))
+  (testing "a FRAMEWORK/TOOL target — :dispatch-stale? true stamped with stale-authority — IS delivered"
+    (is (true? (:deliver? (reply/suppress (reply/with-stale-authority {:event [:x] :dispatch-stale? true})
+                                          {:g 1} {:g 2})))
+        "the framework/tool capability + the explicit opt-in lets a test/tool target receive the stale envelope")
+    (is (false? (:deliver? (reply/suppress (reply/with-stale-authority {:event [:x] :dispatch-stale? false})
+                                           {:g 1} {:g 2})))
+        ":dispatch-stale? false on an authorised target ⇒ not delivered")))
+
+;; ---------------------------------------------------------------------------
+;; Group 3b — :dispatch-stale? AUTHORITY: framework/tool-only (rf2-636pkr).
+;; The substrate is pure (no caller identity), so stale-delivery authority is
+;; a namespaced-private capability marker only framework/tool code can attach
+;; via `with-stale-authority`. An APP target — built from public `:rf/reply-to`
+;; data, which cannot name the private marker — cannot grant itself stale
+;; delivery; trying to (`:dispatch-stale? true` with no authority) FAILS LOUD.
+;; ---------------------------------------------------------------------------
+
+(deftest dispatch-stale-app-target-cannot-opt-in
+  (testing "an APP target (:dispatch-stale? true, NO authority) cannot enable stale delivery — fails loud"
+    ;; This is the security boundary: an app's :rf/reply-to descriptor can set
+    ;; :dispatch-stale? true (it is plain data), but it CANNOT carry the
+    ;; framework-private authority marker, so suppress must refuse it loudly
+    ;; rather than silently deliver a stale envelope into app state.
+    (let [app-target {:event [:app/replied] :dispatch-stale? true}]
+      (is (thrown-with-msg?
+            #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+            #"restricted to framework"
+            (reply/suppress app-target {:g 1} {:g 2}))
+          "an app target that sets :dispatch-stale? true is rejected — it has no stale-delivery authority")
+      (try
+        (reply/suppress app-target {:g 1} {:g 2})
+        (is false "expected suppress to throw")
+        (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+          (is (= :rf.reply/unauthorized-stale-delivery (:rf.error/kind (ex-data e)))
+              "the failure carries the closed error kind")))))
+  (testing "the SAME descriptor, once stamped with framework/tool authority, IS allowed"
+    (is (true? (:deliver?
+                 (reply/suppress (reply/with-stale-authority {:event [:app/replied] :dispatch-stale? true})
+                                 {:g 1} {:g 2})))
+        "wrapping with with-stale-authority is the ONLY way to legitimately opt in"))
+  (testing "stale-authority? reports the capability; the public descriptor never carries it"
+    (is (false? (reply/stale-authority? {:event [:x] :dispatch-stale? true}))
+        "a plain (app) descriptor has no authority")
+    (is (true? (reply/stale-authority? (reply/with-stale-authority {:event [:x]})))
+        "with-stale-authority stamps the capability")))
 
 ;; ---------------------------------------------------------------------------
 ;; Group 4 — data-only trace summaries route through the shared elision walker.

--- a/implementation/core/test/re_frame/timer_probe_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/timer_probe_conformance_cljs_test.cljc
@@ -209,8 +209,12 @@
   (testing "a framework test/tool target MAY opt into stale delivery; app targets MUST NOT"
     (is (false? (:deliver? (probe/suppress base-args 2 {} [:t]))) "no opt-in → not delivered")
     (is (false? (:deliver? (probe/suppress base-args 2 {} {:event [:t] :dispatch-stale? false}))))
-    (is (true?  (:deliver? (probe/suppress base-args 2 {} {:event [:t] :dispatch-stale? true})))
-        ":dispatch-stale? true (framework test/tool only) → delivered")))
+    (is (true?  (:deliver? (probe/suppress base-args 2 {}
+                                           (reply/with-stale-authority {:event [:t] :dispatch-stale? true}))))
+        ":dispatch-stale? true on a framework/tool-authorised target → delivered")
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+                 (probe/suppress base-args 2 {} {:event [:t] :dispatch-stale? true}))
+        "an APP target setting :dispatch-stale? true without framework authority FAILS LOUD")))
 
 ;; ===========================================================================
 ;; Property 9 — the reply-target functor law (Managed-Effects §Reply mapping

--- a/implementation/routing/test/re_frame/routing_reply_test.clj
+++ b/implementation/routing/test/re_frame/routing_reply_test.clj
@@ -101,8 +101,12 @@
                                                  {:event [:t] :dispatch-stale? false})))
         ":dispatch-stale? false → not delivered")
     (is (true? (:deliver? (route-reply/suppress {:nav-token "nav-1"} "nav-2"
-                                                {:event [:t] :dispatch-stale? true})))
-        ":dispatch-stale? true (framework test/tool only) → delivered")))
+                                                (reply/with-stale-authority {:event [:t] :dispatch-stale? true}))))
+        ":dispatch-stale? true on a framework/tool-authorised target → delivered")
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (route-reply/suppress {:nav-token "nav-1"} "nav-2"
+                                       {:event [:t] :dispatch-stale? true}))
+        "an APP route target setting :dispatch-stale? true without framework authority FAILS LOUD")))
 
 ;; ---- §Tracing -------------------------------------------------------------
 

--- a/spec/Managed-Effects.md
+++ b/spec/Managed-Effects.md
@@ -163,9 +163,9 @@ The reply `:status` vocabulary is **closed**:
 | Reply status | Meaning | Value / error convention |
 |---|---|---|
 | `:ok` | Work completed successfully and the reply is current. | `:value` present; `:error` absent. |
-| `:partial` | Work completed with usable value data **and** structured family-specific problems; the reply is current and the family decides how partial data installs. | `:value` present; `:error` present with a family `:kind` (e.g. `:rf.graphql/partial-success`). |
-| `:error` | Work completed with a failure and the reply is current. | `:error` present with a family `:kind`. |
-| `:cancelled` | Work was intentionally cancelled while still correlated with the target. | `:cancel/reason` present; `:error` MAY carry compatibility failure data. |
+| `:partial` | Work completed with usable value data **and** structured family-specific problems; the reply is current and the family decides how partial data installs. | `:value` present; `:error` present as a family error **map** carrying a `:kind` (e.g. `:rf.graphql/partial-success`) — a loose scalar error is rejected. |
+| `:error` | Work completed with a failure and the reply is current. | `:error` present as a family error **map** carrying a `:kind` — a loose scalar error is rejected. |
+| `:cancelled` | Work was intentionally cancelled while still correlated with the target. | `:cancelled? true` (the intentional-cancellation marker) **and** `:cancel/reason` present; `:error` MAY carry compatibility failure data. |
 | `:stale` | Work completed or was observed after its correlation became obsolete. | `:stale? true`; `:stale/reason` present; **no app-state mutation**. |
 
 `:partial` keeps the envelope transport-neutral: a protocol that can return both data and errors in one completion (GraphQL is the motivating case) must not be forced to pretend it is plain `:ok` or plain `:error`. Plain managed HTTP does not emit `:partial` — an HTTP response is decoded as `:ok` or projected as `:error`/`:cancelled`/`:stale`.

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2585,7 +2585,7 @@ The canonical shape every managed *async* surface — HTTP ([014](014-HTTPReques
   [:map
    [:status        ReplyStatus]                              ;; ALWAYS required
    [:value         {:optional true} :any]                    ;; present for :ok / :partial; absent for :stale
-   [:error         {:optional true} :any]                    ;; present for :error / :partial (with a family :kind); MAY carry compat data for :cancelled
+   [:error         {:optional true} :any]                    ;; for :error / :partial a family error MAP carrying a :kind (loose scalar rejected); MAY carry compat data for :cancelled
    [:work/id       {:optional true} :any]                    ;; required for ledger-backed work; =-comparable EDN attempt identity
    [:work/kind     {:optional true} :keyword]                ;; :http / :resource / :mutation / :timer / :route / :machine / …
    [:work/status   {:optional true} ReplyWorkStatus]
@@ -2595,9 +2595,9 @@ The canonical shape every managed *async* surface — HTTP ([014](014-HTTPReques
    [:completed-at  {:optional true} [:maybe :int]]
    [:deadline-at   {:optional true} [:maybe :int]]
    [:correlation   {:optional true} :map]                    ;; data-only correlation metadata (request-id, scope, generation, owner, …)
-   [:stale?        {:optional true} :boolean]
+   [:stale?        {:optional true} :boolean]               ;; required true for :status :stale
    [:stale/reason  {:optional true} [:maybe :keyword]]
-   [:cancelled?    {:optional true} :boolean]
+   [:cancelled?    {:optional true} :boolean]               ;; required true for :status :cancelled — the intentional-cancellation marker
    [:cancel/reason {:optional true} [:maybe :keyword]]
    [:trace         {:optional true} :any]                    ;; data-only trace summary (wire slots elided via rf/elide-wire-value)
    [:meta          {:optional true} :any]])                  ;; effect-family data
@@ -2609,14 +2609,20 @@ The canonical shape every managed *async* surface — HTTP ([014](014-HTTPReques
   ;; runtime appends the reply map as the final event argument on :append
   ;; (the only public delivery mode). :suppress carries data-only stale
   ;; gates; :dispatch-stale? (framework test/tool targets only) opts into
-  ;; receiving stale envelopes. Per [Managed-Effects §The reply target].
+  ;; receiving stale envelopes. The framework/tool AUTHORITY for stale
+  ;; delivery is a namespaced-private capability marker (not a public field
+  ;; here) stamped via re-frame.reply/with-stale-authority — an app target
+  ;; built from this public data cannot name it, so :dispatch-stale? true
+  ;; without authority FAILS LOUD (:rf.reply/unauthorized-stale-delivery)
+  ;; rather than delivering a stale envelope to app state. Per
+  ;; [Managed-Effects §The reply target].
   [:or
    [:vector :any]                                            ;; short form: an event-vector prefix [:event-id arg …]
    [:map
     [:event           [:vector :any]]                        ;; the event-vector prefix to complete
     [:delivery        {:optional true} [:enum :append]]      ;; :append is the only PUBLIC delivery mode
     [:suppress        {:optional true} :map]                 ;; data-only gates that must still match before delivery
-    [:dispatch-stale? {:optional true} :boolean]]])          ;; framework test/tool opt-in to stale delivery; app targets MUST NOT set it
+    [:dispatch-stale? {:optional true} :boolean]]])          ;; framework test/tool opt-in to stale delivery; app targets MUST NOT set it (enforced: needs the framework-private stale-authority capability)
 ```
 
 `:rf/reply-map` and `:rf/reply-target` are the schema ids for `ReplyMap` and `ReplyTarget`. The closed `:status` taxonomy, the value/error conventions per status (`:value` on `:ok`/`:partial`; `:error` with a family `:kind` on `:error`/`:partial`; `:cancel/reason` on `:cancelled`; `:stale? true` + `:stale/reason` and no `:value` on `:stale`), the `:work/id` correlation rule (one attempt has one work id — no `:stale-key` synonym, per [EP-0007](../docs/EP/EP-0007-one-name-per-fact.md)), and the data-only invariant are all owned normatively by [Managed-Effects §The uniform reply envelope](Managed-Effects.md#the-uniform-reply-envelope); this catalogue carries the shape. The `:error` envelope on a `:status :error`/`:partial` reply carries the closed `:rf.http/*` (or family-specific) failure-map shapes owned by the per-family spec. A `:status :stale` reply's `:work/status` is `:suppressed` and the linked `WorkLedger` row (above) reaches `:suppressed` — the reply target and a ledger row are the same fact, the ledger's `:reply-to` being this target made durable.


### PR DESCRIPTION
Post-graduation hardening of the shared `re-frame.reply` substrate (EP-0011 is graduated `final`). Pre-alpha masterpiece stance: CORRECTNESS + GOOD PRACTICE, fail-loud. Functor laws + stale-suppression behaviour unchanged.

## rf2-r16hfc — data contracts fail loud (best-practice)

- **Reply-target-as-data contract.** A normalized target may carry the ephemeral, non-data slots `::post` (the functor accumulator fn) and the new `::stale-authority` capability marker *while in-flight*, but a target that could become **durable** (a stored continuation / ledger row / replay log) must be data-only. New `data-only-target?` predicate + `durable-target` projection strip the ephemeral slots and **fail loud** (`:rf.reply/non-data-target`) if a host handle (fn / Promise / AbortController / …) is smuggled into a public field. This closes the item-1 concern that `::post` could leak a non-serializable value into a durable target.
- **`validate-reply` tightened.** `:error` / `:partial` now require a family error **map** carrying a `:kind` — a loose scalar `:error` is rejected (`:rf.reply/error-not-family-map`). `:cancelled` now requires the `:cancelled? true` intentional-cancellation marker, not merely a `:cancel/reason` (`:rf.reply/cancelled-missing-marker`). Both match what every production family already emits (verified against http / resources cancelled+error constructors).

Items 3 (resources/mutation stale-helper reconciliation) and 4 (http `reply->public-payload` unsupported-status throw) live in the **family-consumer** artefacts (`implementation/resources/`, `implementation/http/`) — out of this substrate-only PR's scope (separate held cluster); not touched.

## rf2-636pkr — `:dispatch-stale?` framework/tool authority (completeness, BUG)

The substrate is pure (no caller identity), so the spec's "restricted to framework test and tool targets" is enforced **structurally** by a namespaced-private `::stale-authority` capability marker stamped via the new `with-stale-authority` helper. `suppress` honours `:dispatch-stale? true` **only** when the target carries that marker; an app target — built from public `:rf/reply-to` data, which cannot name the private key — that sets `:dispatch-stale? true` now **fails loud** (`:rf.reply/unauthorized-stale-delivery`) instead of silently delivering a stale envelope into app state. Default (no opt-in) stays non-delivery for every target. Negative + positive tests pin the boundary.

## Spec (HOT-ZONE — flagged)

- `spec/Managed-Effects.md` — status-taxonomy rows: `:error`/`:partial` now say "family error **map** carrying a `:kind` (loose scalar rejected)"; `:cancelled` now requires `:cancelled? true` + `:cancel/reason`.
- `spec/Spec-Schemas.md` — `ReplyMap` `:error`/`:cancelled?`/`:stale?` comments tightened; `ReplyTarget` comment documents the framework-private stale-authority capability enforcement.

## Test deltas

- `reply_test.cljc`: 20 → 22 tests, 75 → 100 assertions. New groups: durable-target / data-only invariant (item 1, incl. fail-loud host-handle-in-public-field); `:dispatch-stale?` authority (app target cannot opt in — fails loud; same descriptor with `with-stale-authority` is allowed). Tightened error/partial (scalar rejected) + cancelled (marker required) cases.
- `timer_probe_conformance_cljs_test.cljc` + `routing_reply_test.clj` (framework test/tool surfaces): opt-in path now stamps `with-stale-authority`; each adds a negative assertion that an unauthorised app target throws.

## Quality gates

- `npm run test:cljs` (full CLJS node-runtime gate, covers reply + timer-probe conformance under the CLJS reader): **6533 tests / 23860 assertions — 0 failures, 0 errors**.
- core `clojure -M:test`: **1165 tests / 5158 assertions — 0/0**.
- Consumer-artefact regression check (substrate tightening): routing **209/957 — 0/0**, http **395/1828 — 0/0**, resources **249/937 — 0/0**.
- `mkdocs build --strict` (Spec-Schemas + Managed-Effects touched): clean — no errors/warnings.

Closes rf2-r16hfc (items 1 + 2). Closes rf2-636pkr.