### PR TITLE
tooling(check_doc_slugs): index blockquoted headings as anchor targets (rf2-869k9m)

### DIFF
--- a/scripts/_test_fixtures/check_doc_slugs/README.md
+++ b/scripts/_test_fixtures/check_doc_slugs/README.md
@@ -25,3 +25,7 @@ Fixtures:
 | `relative_dotdot_ok`               | 0               | `[text](../foo.md)` from a subdirectory                                            |
 | `inline_code_placeholder_ignored`  | 0               | Backticked link-syntax placeholders are masked; real link still validates (rf2-mqv8s) |
 | `inline_code_negative_control`     | 1               | Same-line broken link OUTSIDE an inline-code span is still flagged (rf2-mqv8s)     |
+| `ai_findings_link_flagged`         | 1               | Link into the gitignored `ai/findings/<file>.md` tree is flagged (rf2-l7yj8)       |
+| `ai_findings_dir_link_flagged`     | 1               | Link into the bare `ai/findings/` directory is flagged (rf2-l7yj8)                 |
+| `blockquoted_heading_ok`           | 0               | Link into a blockquoted heading (`> #### Foo`, incl. nested) resolves (rf2-869k9m) |
+| `indented_heading_not_indexed`     | 1               | Negative control: an *indented bare* `#` line still mints no anchor (rf2-869k9m)   |

--- a/scripts/_test_fixtures/check_doc_slugs/blockquoted_heading_ok/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/blockquoted_heading_ok/docs/index.md
@@ -1,0 +1,20 @@
+# Index
+
+This page links into a heading that lives *inside* a blockquote callout
+box.  python-markdown renders `> #### …` as a real `<h4 id="…">`, so the
+anchor resolves on the built site and the validator must index it too
+(rf2-869k9m).
+
+Jump to [the reply envelope](#the-uniform-reply-envelope) — the target is a
+blockquoted heading below, so this link must validate (0 broken).
+
+A nested-blockquote heading is also a real anchor:
+[deeper note](#a-deeper-note).
+
+> #### The uniform reply envelope
+>
+> Every managed async surface completes through one reply shape.
+
+> > ## A deeper note
+> >
+> > Nested blockquotes still mint heading anchors.

--- a/scripts/_test_fixtures/check_doc_slugs/blockquoted_heading_ok/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/blockquoted_heading_ok/mkdocs.yml
@@ -1,0 +1,2 @@
+# Self-test fixture marker.  Empty config is fine — the validator only
+# checks for this file's existence as the repo-root guard.

--- a/scripts/_test_fixtures/check_doc_slugs/indented_heading_not_indexed/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/indented_heading_not_indexed/docs/index.md
@@ -1,0 +1,13 @@
+# Index
+
+Negative control for rf2-869k9m: the blockquote-prefix relaxation must NOT
+start indexing *indented bare* `#` lines.  Markdown treats a `#` indented
+under a list/code context as ordinary text or code, not a heading, so it
+mints no anchor.  This link must therefore stay BROKEN (1 broken).
+
+Jump to [an indented pseudo-heading](#indented-pseudo-heading).
+
+Below, the `#` is indented four spaces with no blockquote marker, so it is
+not a heading and contributes no slug:
+
+    #### Indented pseudo-heading

--- a/scripts/_test_fixtures/check_doc_slugs/indented_heading_not_indexed/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/indented_heading_not_indexed/mkdocs.yml
@@ -1,0 +1,2 @@
+# Self-test fixture marker.  Empty config is fine — the validator only
+# checks for this file's existence as the repo-root guard.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -98,7 +98,22 @@ EXCLUDE_DIR_REL = frozenset({Path("docs/spec"), Path("docs/migration")})
 # to every heading regardless of `toc_depth` (which only controls which
 # headings appear in the rendered TOC).  Anchor links to H4-H6 therefore
 # resolve on the published site and must be validated here too.
-_HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$")
+#
+# An optional blockquote prefix is accepted: python-markdown (and therefore
+# the MkDocs build) renders a heading *inside* a blockquote — `> #### Foo` —
+# as a real `<h4 id="...">` and mints the same slug anchor it would for a
+# top-level heading.  Authors use blockquoted headings for "callout" teaching
+# boxes (e.g. docs/guide/10-http.md has ~7), and committed links target those
+# anchors.  Without this prefix the indexer never saw them and every such link
+# false-positived as a BROKEN ANCHOR (rf2-869k9m).  The prefix mirrors the
+# block-quote tokeniser: leading whitespace, then one or more `>` markers each
+# with an optional following space (nested quotes `> > #### Foo` included).
+# The title is captured *after* the prefix, so slugification is identical to
+# the non-quoted case — no loosening of the slug contract.  A *bare* heading
+# still must start at column 0 (the prefix group is only entered when a `>`
+# is present); we don't begin tolerating indented `#` lines, which markdown
+# treats as code, not headings.
+_HEADING_RE = re.compile(r"^(?:[ \t]*>[ \t]?)*(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$")
 
 # Custom heading id syntax: "## Title {#explicit-id}" — pymdownx.toc honours
 # this when the attr_list extension is enabled.  We're conservative and accept
@@ -553,6 +568,8 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("inline_code_negative_control",     1),  # rf2-mqv8s
         ("ai_findings_link_flagged",         1),  # rf2-l7yj8
         ("ai_findings_dir_link_flagged",     1),  # rf2-l7yj8
+        ("blockquoted_heading_ok",           0),  # rf2-869k9m
+        ("indented_heading_not_indexed",     1),  # rf2-869k9m (negative control)
     ]
 
     failures = 0


### PR DESCRIPTION
## Summary

`scripts/check_doc_slugs.py`'s `_HEADING_RE` anchored the `#` run at column 0, so it never indexed headings that live *inside* a blockquote (`> #### Foo`). python-markdown / the MkDocs build render those as real `<hN id="...">` and mint the usual slug anchor, so any committed link into one false-positived as a `BROKEN ANCHOR`. `docs/guide/10-http.md` alone has ~7 blockquoted teaching-callout headings at risk (the uniform-reply-envelope callout box and its sub-sections).

## The change

The heading regex gains an optional blockquote prefix:

```diff
-_HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$")
+_HEADING_RE = re.compile(r"^(?:[ \t]*>[ \t]?)*(#{1,6})[ \t]+(.+?)[ \t]*#*[ \t]*$")
```

- The prefix group `(?:[ \t]*>[ \t]?)*` is only entered when a `>` is present, so a **bare** heading still must start at column 0 — indented bare `#` lines (markdown code/text, not headings) remain unindexed. No loosening of the existing anchor contract.
- Title capture (group 2) is unchanged, so slugification stays byte-for-byte identical to the non-quoted case (same `pymdownx.slugs.slugify` call, same duplicate `_N` disambiguation).
- Nested blockquotes (`> > ## Foo`) are covered too — they also render as anchors.

Two self-test fixtures added:
- `blockquoted_heading_ok` — a link into a blockquoted heading (incl. a nested-blockquote heading) now resolves (0 broken).
- `indented_heading_not_indexed` — negative control: an *indented bare* `#` line still mints no anchor, so a link to it stays broken (1 broken). Proves column-0 anchoring is preserved.

Confirmed via the script's own `_slug_index` that all 7 of `10-http.md`'s blockquoted anchors (`the-uniform-reply-envelope`, `the-closed-status-set`, `stale-suppression-is-the-correctness-boundary`, `cancellation-is-data`, `completion-timestamps-ride-the-reply`, plus the H3 callout title and the `:on-success`/`:on-failure` sugar heading) now resolve.

## Quality gates

- `python scripts/check_doc_slugs.py --self-test` — **13/13 pass** (includes the two new fixtures).
- `python scripts/check_doc_slugs.py` (full corpus) — **exit 0**, no broken links. ch.10's blockquoted anchors now resolve.

Closes rf2-869k9m.
