### PR TITLE
test(core): EP-0010 durable-id + diagnostic-differs coverage (rf2-sppf0m rf2-zq5zj2)

### DIFF
--- a/implementation/core/test/re_frame/world_inputs_test.clj
+++ b/implementation/core/test/re_frame/world_inputs_test.clj
@@ -31,7 +31,19 @@
             [re-frame.registrar :as registrar]
             [re-frame.router :as router]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as trace]
+            ;; rf2-zq5zj2 / rf2-qwm0a — load the tooling sibling so the
+            ;; late-bind hooks behind the listener API resolve (the
+            ;; diagnostic-differs test registers a trace listener).
+            [re-frame.trace.tooling]
+            ;; rf2-zq5zj2 — side-effect require: `re-frame.epoch` publishes
+            ;; the `:epoch/settle!` + `:epoch/epoch-history` +
+            ;; `:epoch/clear-history!` late-bind hooks at ns-load, so each
+            ;; drain-settle commits a `:rf/epoch-record` whose durable
+            ;; `:committed-at` the diagnostic-differs test reads via
+            ;; `rf/epoch-history`. Available on the core test classpath as the
+            ;; epoch test-only dep (core/deps.edn :test alias, rf2-lt4e).
+            [re-frame.epoch]))
 
 ;; ---- fixtures -------------------------------------------------------------
 
@@ -40,6 +52,11 @@
   (reset! frame/frames {})
   (when-let [clear-schemas! (late-bind/get-fn :schemas/clear-by-frame!)]
     (clear-schemas!))
+  ;; rf2-zq5zj2 — clear the per-frame epoch rings so the diagnostic-differs
+  ;; test reads only its own freshly-committed records (the `:epoch/settle!`
+  ;; hook is published once `re-frame.epoch` is loaded, above).
+  (when-let [clear-history! (late-bind/get-fn :epoch/clear-history!)]
+    (clear-history!))
   (trace/clear-listeners!)
   (rf/init! plain-atom/adapter)
   (test-fn))
@@ -178,3 +195,175 @@
       (let [env (build-envelope [:noop] {:frame :wi/no-dispatched-at})]
         (is (number? (get-in env [:rf.world/inputs :time-ms]))
             ":time-ms is the replacement for the retired :dispatched-at")))))
+
+;; ===========================================================================
+;; rf2-sppf0m: a handler READS :uuid / :random from the :rf.world/inputs
+;; coeffect and WRITES the supplied values into a durable app-db entity.
+;;
+;; This is the EP-0010 §Validation/Conformance bullet — "random/UUID values
+;; supplied by fixtures become durable ids exactly as supplied" — executed
+;; against an actual durable WRITE, not merely the envelope pass-through that
+;; `preserves-caller-supplied-extra-keys-and-fills-time-ms` (above) pins. The
+;; EP §Examples "Correct Generated Values From The Token" shows the shape: a
+;; `:todo/create` handler reads `(get-in inputs [:uuid :todo/id])` +
+;; `(get-in inputs [:random :todo/color])` and folds them into app-db so the
+;; replay log explains every durable value. The deferred `:rf.world/uuid` /
+;; `:rf.world/random` framework cofx (EP disposition 2 / rider a) are NOT
+;; involved here — the test scripts the slots directly, exactly as a fixture /
+;; replay / SSR-hydration dispatch would, and the handler reads them straight
+;; from the coeffect map.
+;; ===========================================================================
+
+(deftest supplied-uuid-random-become-durable-ids-exactly
+  (testing "a handler reads :uuid / :random from the :rf.world/inputs coeffect
+            and the supplied values land in app-db EXACTLY as supplied"
+    (rf/reg-frame :wi/todos {:doc "ctx"})
+    ;; The durable handler: reads the causal token's scripted id + colour from
+    ;; the world-input coeffect (NOT an ambient `random-uuid` / `rand-nth`) and
+    ;; folds them into a durable app-db entity. `reg-event-fx` so we can read
+    ;; the `:rf.world/inputs` framework coeffect off the cofx map.
+    (rf/reg-event-fx :todo/create
+      (fn [{:keys [db rf.world/inputs]} [_ text]]
+        (let [id    (get-in inputs [:uuid :todo/id])
+              color (get-in inputs [:random :todo/color])]
+          {:db (assoc-in db [:todos id]
+                         {:todo/id id :todo/color color :todo/text text})})))
+    (let [id    #uuid "018ff2b4-9bbd-7a0a-a4df-cf2a91cbe86d"
+          color :green]
+      (rf/dispatch-sync [:todo/create "buy milk"]
+                        {:frame :wi/todos
+                         :rf.world/inputs {:uuid   {:todo/id id}
+                                           :random {:todo/color color}}})
+      (let [entity (get-in (rf/app-db-value :wi/todos) [:todos id])]
+        (is (some? entity)
+            "the entity is keyed in app-db under the EXACT supplied uuid")
+        (is (= id (:todo/id entity))
+            "the durable :todo/id equals the supplied uuid exactly — the
+             replay log explains the durable id (EP-0010 §Conformance)")
+        (is (= color (:todo/color entity))
+            "the durable :todo/color equals the supplied :random value exactly")
+        (is (= "buy milk" (:todo/text entity))
+            "the event arg rides through alongside the world-input ids")))))
+
+(deftest supplied-uuid-replay-stable-where-ambient-would-diverge
+  (testing "re-running the SAME causal token reproduces the SAME durable id
+            (replay-stable), where an ambient random-uuid / rand-nth would have
+            diverged run-to-run (EP-0010 §Restore, Replay, And Hydration)"
+    (rf/reg-frame :wi/replay {:doc "ctx"})
+    (rf/reg-event-fx :todo/create-from-token
+      (fn [{:keys [db rf.world/inputs]} _]
+        (let [id    (get-in inputs [:uuid :todo/id])
+              color (get-in inputs [:random :todo/color])]
+          {:db (assoc db :entity {:todo/id id :todo/color color})})))
+    ;; The scripted causal token — the SAME map supplied on both runs, exactly
+    ;; as a replay / restore would re-feed it.
+    (let [token {:uuid   {:todo/id #uuid "018ff2b4-9bbd-7a0a-a4df-cf2a91cbe86d"}
+                 :random {:todo/color :blue}}
+          run!  (fn []
+                  (rf/dispatch-sync [:todo/create-from-token]
+                                    {:frame :wi/replay :rf.world/inputs token})
+                  (:entity (rf/app-db-value :wi/replay)))
+          first-entity  (run!)
+          second-entity (run!)]
+      (is (= first-entity second-entity)
+          "two runs of the same token produce IDENTICAL durable entities —
+           replay-stable")
+      (is (= (get-in token [:uuid :todo/id]) (:todo/id second-entity))
+          "the reproduced durable id is the token's id, not a fresh draw")
+      ;; Contrast: an ambient generator (random-uuid / rand-nth) folded into a
+      ;; durable write would have produced two DIFFERENT ids across the two
+      ;; runs. Pin that this is the failure mode the token-read design avoids —
+      ;; two independent ambient draws are (with overwhelming probability)
+      ;; distinct, so a handler that read ambient instead of the token would
+      ;; NOT be replay-stable.
+      (let [ambient-1 (random-uuid)
+            ambient-2 (random-uuid)]
+        (is (not= ambient-1 ambient-2)
+            "two ambient random-uuid draws diverge — the very property a
+             durable write must NOT depend on; reading the token avoids it")))))
+
+;; ===========================================================================
+;; rf2-zq5zj2: ambient DIAGNOSTIC timestamps may differ without changing
+;; durable state.
+;;
+;; This is the positive half of the EP-0008 / EP-0010 causal-vs-diagnostic
+;; split (§Validation/Conformance bullet: "ambient diagnostic timestamps may
+;; differ without changing durable state"). The runtime records BOTH a durable
+;; CAUSAL time (the token's `:rf.world/inputs` `:time-ms` → the epoch record's
+;; `:committed-at`, read ONCE at the causal boundary from `epoch-now-ms`) AND
+;; ambient DIAGNOSTIC times (the trace event `:time`, stamped from the elapsed
+;; `interop/now-ms` at every emit). The bullet asserts the ambient ones are
+;; free to vary run-to-run while the durable projection stays EQUAL.
+;;
+;; We run the SAME scripted token (same supplied `:time-ms`) twice under two
+;; DIFFERENT ambient clocks and assert:
+;;   (a) the durable :committed-at is EQUAL across both runs (it folds the
+;;       supplied token time, never the ambient clock), AND
+;;   (b) a diagnostic trace `:time` (captured via a trace listener) DIFFERS
+;;       across the two runs (it legitimately reads the ambient clock).
+;; That EXECUTES the invariant instead of documenting it (the prose at the
+;; top of this ns + the inverse-only `:committed-at` clock tests in
+;; epoch_test.clj are the prior coverage). `rf/epoch-history` is available on
+;; the core test classpath as the epoch test-only dep.
+;; ===========================================================================
+
+(deftest ambient-diagnostic-time-differs-while-durable-committed-at-holds
+  (testing "same causal token under two different ambient clocks → durable
+            :committed-at EQUAL while the diagnostic trace :time DIFFERS"
+    (rf/reg-frame :wi/split {:doc "ctx"})
+    (rf/reg-event-db :wi/note (fn [db _] (update db :n (fnil inc 0))))
+    (let [token-time   1781078400123     ; the supplied causal token :time-ms
+          ;; capture the diagnostic trace :time of THIS frame's :wi/note event
+          ;; per run — the trace `:time` is stamped from the ambient
+          ;; `interop/now-ms` (re-frame.trace/build-event), the diagnostic
+          ;; surface the bullet says is free to vary.
+          trace-times  (atom [])
+          run!         (fn [ambient-clock]
+                         (let [seen (atom nil)]
+                           (rf/register-listener! ::split-probe
+                             (fn [ev]
+                               ;; Capture the diagnostic :time of THIS frame's
+                               ;; :wi/note dispatched event — a deterministic
+                               ;; single emit per run. The event vector rides
+                               ;; under (:rf.event/v :tags) as [event-id args]
+                               ;; (re-frame.marks §project-event-tags).
+                               (when (and (nil? @seen)
+                                          (= :rf.event (:op-type ev))
+                                          (= :rf.event/dispatched (:operation ev))
+                                          (= :wi/note (first (get-in ev [:tags :rf.event/v]))))
+                                 (reset! seen (:time ev)))))
+                           ;; Pin BOTH host clocks to the SAME per-run ambient
+                           ;; value so the trace :time is deterministic within
+                           ;; the run yet DIFFERENT between the two runs, while
+                           ;; the SUPPLIED token :time-ms rides through
+                           ;; unchanged (the router only fills :time-ms when
+                           ;; absent — see preserves-caller-supplied-time-ms).
+                           (with-redefs [interop/now-ms       (constantly ambient-clock)
+                                         interop/epoch-now-ms (constantly ambient-clock)]
+                             (rf/dispatch-sync [:wi/note]
+                                               {:frame :wi/split
+                                                :rf.world/inputs {:time-ms token-time}}))
+                           (rf/unregister-listener! ::split-probe)
+                           (swap! trace-times conj @seen)
+                           ;; the durable :committed-at of the just-settled epoch
+                           (:committed-at (last (rf/epoch-history :wi/split)))))
+          committed-1  (run! 1000)
+          committed-2  (run! 9999999)]
+      ;; (a) DURABLE side — equal across the two ambient clocks.
+      (is (= token-time committed-1)
+          "run 1: durable :committed-at folds the supplied token :time-ms")
+      (is (= token-time committed-2)
+          "run 2: durable :committed-at folds the SAME supplied token :time-ms")
+      (is (= committed-1 committed-2)
+          "durable :committed-at is EQUAL across runs — wall-clock drift
+           between the two commits did not change durable state")
+      ;; (b) DIAGNOSTIC side — differs across the two ambient clocks.
+      (let [[t1 t2] @trace-times]
+        (is (= 1000 t1)
+            "run 1: the diagnostic trace :time read the ambient clock (1000)")
+        (is (= 9999999 t2)
+            "run 2: the diagnostic trace :time read the DIFFERENT ambient clock")
+        (is (not= t1 t2)
+            "the ambient diagnostic trace :time DIFFERS run-to-run — free to
+             vary, exactly as the EP-0010 causal/diagnostic split permits,
+             while the durable :committed-at above held equal")))))


### PR DESCRIPTION
@
Closes the two EP-0010 testing-rigour gaps filed by the audit (rf2-bkp3ik). Test-only additions to `implementation/core/test/re_frame/world_inputs_test.clj`; no source changes.

## rf2-sppf0m — uuid/random supplied values become durable ids exactly
Prior coverage proved only that `:uuid`/`:random` ride through the router *envelope* (`preserves-caller-supplied-extra-keys-and-fills-time-ms`), never that a handler reads them into a durable write. Two new tests:

- `supplied-uuid-random-become-durable-ids-exactly` — a `:todo/create` handler reads `(get-in inputs [:uuid :todo/id])` + `(get-in inputs [:random :todo/color])` from the `:rf.world/inputs` coeffect and folds them into an app-db entity; asserts the durable `:todo/id` / `:todo/color` equal the supplied values EXACTLY (entity keyed under the exact uuid).
- `supplied-uuid-replay-stable-where-ambient-would-diverge` — re-running the SAME causal token reproduces an IDENTICAL durable entity (replay-stable), and pins the contrast that two ambient `random-uuid` draws diverge — the property a durable write must not depend on.

Executes the EP-0010 §Conformance bullet "random/UUID values supplied by fixtures become durable ids exactly as supplied" against an actual durable write. The deferred `:rf.world/uuid` / `:rf.world/random` framework cofx (rider a) are not involved — the test scripts the slots directly, exactly as a fixture/replay/SSR dispatch would.

## rf2-zq5zj2 — ambient diagnostic timestamps may differ without changing durable state
One new test:

- `ambient-diagnostic-time-differs-while-durable-committed-at-holds` — runs the same scripted token (same `:time-ms`) twice under two different pinned ambient clocks (1000 vs 9999999) and asserts (a) the durable epoch `:committed-at` is EQUAL across both runs (folds the supplied token time), AND (b) the diagnostic trace event `:time` (captured via a trace listener) DIFFERS across the two runs (legitimately reads the ambient `interop/now-ms`).

Executes the EP-0008/0010 causal-vs-diagnostic split that was previously asserted only in prose. The existing `:committed-at` clock tests in `epoch_test.clj` pin the inverse ("durable does not read ambient"); this pins the positive half ("diagnostic is free to vary").

## Mechanics
- New tests live in the existing `world_inputs_test.clj` (the cohesive core world-inputs surface).
- Loads `re-frame.epoch` (test-only dep on the core test classpath, rf2-lt4e) so `:epoch/settle!` + `:epoch/epoch-history` publish and each drain-settle commits a record; clears the epoch ring in the reset fixture.
- Requires `re-frame.trace.tooling` so the listener delivery hook resolves.

## Quality gates
- `clojure -M:test` (core JVM): 1169 tests, 5162 assertions, 0 failures, 0 errors.
- `npm run test:cljs` (node-runtime CLJS): 6536 tests, 23876 assertions, 0 failures, 0 errors.
- New-test focused run (`clojure -M:test -n re-frame.world-inputs-test`): 10 tests, 31 assertions, 0 failures.
@