### PR TITLE
fix(epoch): pair-tool :committed-at uses epoch-now-ms wall-clock (rf2-czwwf4)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -585,13 +585,23 @@
             ;; pair-tool injection — NO application event (and therefore no
             ;; causal token) is in flight, so there is no `:time-ms` to fold.
             ;; The honest `:committed-at` is the wall-clock of the tool action
-            ;; itself, so the ambient `interop/now-ms` read happens HERE, at
-            ;; the call site, rather than inside the pure `build-record`
-            ;; builder (per EP-0010 §Time — ambient time remains allowed for a
-            ;; tool action's own wall-clock).
+            ;; itself, so the ambient read happens HERE, at the call site,
+            ;; rather than inside the pure `build-record` builder (per EP-0010
+            ;; §Time — ambient time remains allowed for a tool action's own
+            ;; wall-clock).
+            ;;
+            ;; rf2-czwwf4: `:committed-at` is a DURABLE epoch field, so the
+            ;; ambient read uses `interop/epoch-now-ms` (wall-clock epoch ms,
+            ;; `js/Date.now()` on CLJS) — NOT `interop/now-ms`, which on CLJS is
+            ;; `performance.now()` (origin-relative, NOT for durable facts).
+            ;; This keeps a tool-injected epoch's `:committed-at` in the same
+            ;; wall-clock CLASS as the router-stamped epochs (whose committed-at
+            ;; folds the token's `epoch-now-ms` :time-ms), so the Epoch panel
+            ;; shows comparable timestamps across tool-injected and normal
+            ;; epochs (EP-0010 §Time durable-timestamp rule).
             (let [record (assembly/maybe-redact
                            (assoc (assembly/build-record frame-id fs-before fs-after []
-                                                          (interop/now-ms))
+                                                          (interop/epoch-now-ms))
                                   :event-id      :rf.epoch/db-replaced
                                   :trigger-event [:rf.epoch/db-replaced]))]
               (state/record! record)
@@ -622,13 +632,20 @@
 
   rf2-bh56rc: a pair-tool injection — no application event / causal token
   is in flight, so `:committed-at` is the tool action's own wall-clock; the
-  ambient `interop/now-ms` read happens HERE rather than inside the pure
-  `build-record` builder (per EP-0010 §Time — ambient time stays allowed
-  for a tool action's wall-clock)."
+  ambient read happens HERE rather than inside the pure `build-record`
+  builder (per EP-0010 §Time — ambient time stays allowed for a tool
+  action's wall-clock).
+
+  rf2-czwwf4: `:committed-at` is a DURABLE epoch field, so the ambient read
+  uses `interop/epoch-now-ms` (wall-clock epoch ms, `js/Date.now()` on
+  CLJS) — NOT `interop/now-ms`, which on CLJS is `performance.now()`
+  (origin-relative, NOT for durable facts). This keeps a tool-injected
+  epoch's `:committed-at` in the same wall-clock CLASS as the
+  router-stamped epochs (EP-0010 §Time durable-timestamp rule)."
   [frame-id fs-before fs-after]
   (let [record (assembly/maybe-redact
                  (assoc (assembly/build-record frame-id fs-before fs-after []
-                                                (interop/now-ms))
+                                                (interop/epoch-now-ms))
                         :event-id      :rf.epoch/db-replaced
                         :trigger-event [:rf.epoch/db-replaced]))]
     (state/record! record)

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -370,9 +370,12 @@
   own. The two-arg-fewer arity defaults `outcome` to `:ok` and `halt-reason`
   to nil; both arities require `committed-at` (callers without a token — the
   pair-tool synthetic db-replace injections, which run with no application
-  event in flight — pass `(interop/now-ms)` explicitly at the call site,
-  where the ambient read is the honest answer for a tool action's
-  wall-clock, per EP-0010 §Time `Ambient time remains allowed for ...`)."
+  event in flight — pass `(interop/epoch-now-ms)` explicitly at the call
+  site, where the ambient wall-clock read is the honest answer for a tool
+  action, per EP-0010 §Time `Ambient time remains allowed for ...`. It is
+  the wall-clock surface, NOT `interop/now-ms` — `:committed-at` is a
+  durable field, kept wall-clock-class for cross-epoch comparison;
+  rf2-czwwf4)."
   ([frame-id frame-state-before frame-state-after events committed-at]
    (build-record frame-id frame-state-before frame-state-after events committed-at :ok nil))
   ([frame-id frame-state-before frame-state-after events committed-at outcome halt-reason]


### PR DESCRIPTION
## Summary

EP-0010 cleanup (filed by the cc25b9 review). The two synthetic pair-tool `db-replace` injection sites in `implementation/epoch/src/re_frame/epoch.cljc` stamped the **durable** epoch `:committed-at` from `interop/now-ms`. On CLJS `now-ms` is `performance.now()` (origin-relative, ~1e4), so a tool-injected epoch's `:committed-at` was a small perf-clock value sitting among the wall-clock (`js/Date.now()`, ~1.78e12) `:committed-at` values that router-stamped epochs carry — cosmetically inconsistent in the Epoch panel and contrary to the EP-0010 §Time durable-timestamp rule (`now-ms`'s own docstring: "Do NOT use it for durable wall-clock facts; use `epoch-now-ms`").

## Sites changed

Both pass `committed-at` positionally to `assembly/build-record` (which stores it as the durable `:committed-at`). Confirmed durable stamps (not diagnostic/elapsed measurements):

- `epoch.cljc` — `perform-replace-app-db!` inline synthetic-record copy (was `:594`, now `:604`): `(interop/now-ms)` -> `(interop/epoch-now-ms)`.
- `epoch.cljc` — `record-synthetic-replace-epoch!` (was `:631`, now `:648`): `(interop/now-ms)` -> `(interop/epoch-now-ms)`.
- `epoch/assembly.cljc` — `build-record` docstring updated to say callers without a token pass `(interop/epoch-now-ms)` (wall-clock), with the rf2-czwwf4 rationale.

Comments at both call sites updated to record why the durable ambient read is the wall-clock surface. Still the honest ambient wall-clock for a tool action with no causal token in flight (EP-0010 §Time allows ambient time for a tool action), just the epoch-meaningful one.

### Not changed (verified in scope)

- The router-boundary `:committed-at` path already reads `interop/epoch-now-ms` (`router.cljc` `build-envelope`, line 205); `build-record`'s `commit-record!` caller threads the token's `:time-ms` (no ambient read). No other ambient-read durable `:committed-at` site exists in the epoch source. The `now-ms` mentions remaining in epoch source are elapsed/diagnostic or descriptive prose, left as-is.

## Quality gates

- `npm run test:cljs` — 6538 tests, 23884 assertions, 0 failures, 0 errors (includes the rf2-1t30y7 epoch `:committed-at` wall-clock regression test, which stays green — the router path it exercises is unchanged).
- epoch `clojure -M:test` — 315 tests, 1248 assertions, 0 failures, 0 errors.