### PR TITLE
feat(core): EP-0015 projection — project-egress + :rf.egress/* profiles (rf2-yjbr1w)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -56,6 +56,7 @@
             [re-frame.event-emit :as event-emit]
             [re-frame.error-emit :as error-emit]
             [re-frame.elision :as elision]
+            [re-frame.projection :as projection]
             [re-frame.marks   :as marks]
             ;; EP-0015 §3 (rf2-ueg1tn): required for its ns-load side-effect
             ;; only — it publishes the `:frame-classification/*` late-bind
@@ -1727,6 +1728,21 @@
   become `:rf.size/large-elided`. Per Spec 009 §Wire elision and
   Security.md §Off-box egress."}
   elide-wire-value                 elision/elide-wire-value)
+
+(def ^{:doc "Project a record or value for egress across a trust boundary
+  (EP-0015 §10/§11). The public, record-level boundary primitive — the
+  required step before any off-box sink. Dispatches on a record's `:kind`
+  (`:rf.observe/handled-event` / `:rf.observe/error`) to a private per-kind
+  projector, falling back to walking a kindless input as a tree-shaped
+  value (the direct-read path); for every tree-shaped slot it delegates to
+  `elide-wire-value` against the frame's classification. `opts` carries
+  `:rf.egress/profile` (the closed six-member enum), `:frame`, `:path`, and
+  the advanced `:rf.size/*` overrides (which compose on top of the
+  profile — the override wins). An unknown profile throws
+  `:rf.error/unknown-egress-profile`. Fail-closed: projects a tree slot
+  only when the frame is known; no `:rf/default` synthesis. Per Spec 015
+  §Projection and Security.md §Off-box egress."}
+  project-egress                   projection/project-egress)
 
 (def ^{:doc "Populate `[:rf.runtime/elision :declarations]` from
   `{:large? true}` schema-slot metadata for the frame. Returns the

--- a/implementation/core/src/re_frame/projection.cljc
+++ b/implementation/core/src/re_frame/projection.cljc
@@ -1,0 +1,342 @@
+(ns re-frame.projection
+  "Record-level egress projection — `project-egress` + the six ruled
+  `:rf.egress/*` profiles, layered over `re-frame.elision/elide-wire-value`.
+
+  EP-0015 §10 (Projection Profiles) + §11 (`elide-wire-value` stays the
+  value primitive). Graduated normatively into
+  [`spec/015-Data-Classification.md` §Projection]
+  (../../../../../spec/015-Data-Classification.md).
+
+  ## The three-layer model (Spec 015)
+
+      Classification names facts.   (frame config / registration metadata)
+      Projection applies them.      (THIS ns — `project-egress`)
+      Sink policy routes records.   (frame `:observability`)
+
+  Real egress surfaces emit RECORDS, not bare values: handled-event
+  records, error records, epoch records, MCP snapshots, sub-cache reads,
+  HTTP diagnostics, hydration payloads. `project-egress` is the public,
+  record-level boundary primitive — the required step before any off-box
+  sink. It knows which record slots are app-db-shaped / event-shaped /
+  exception-shaped / HTTP-shaped / public-summary-only, applies the merged
+  frame-owned classification (`re-frame.frame-classification`), and
+  DELEGATES to `elide-wire-value` for every tree-shaped slot where frame
+  policy applies. The per-record-kind projectors are PRIVATE (EP-0015
+  issue 2, ruled: `project-egress` names the BOUNDARY, not a record kind;
+  per-record-kind projectors stay private). There is no public
+  `project-record`.
+
+  ## Profiles (EP-0015 §10, ruled six-member CLOSED enum)
+
+  The normal public choice at a boundary is *\"which boundary is this?\"* —
+  a named egress profile under `:rf.egress/profile` — not *\"which
+  combination of booleans did I remember?\"* The boolean `:rf.size/*` flags
+  (`elide-wire-value`'s opt layer) remain the ADVANCED override beneath the
+  profiles. A profile resolves to a `:rf.size/*` opt-set; an explicit
+  `:rf.size/*` opt the caller also passes COMPOSES on top (the explicit
+  override WINS — `profile-opts` is the floor, the caller's opts the
+  overlay).
+
+  The six ruled profiles (EP-0015 issue 3, renamed for axis consistency —
+  `local-redacted` / `local-raw` replacing the EP's earlier
+  on-box-hidden-sensitive / trusted-local-raw spellings):
+
+  | Profile | Default behaviour |
+  |---|---|
+  | `:rf.egress/off-box-observability` | hosted monitoring; redact sensitive, elide large, omit digests. |
+  | `:rf.egress/off-box-tool` | MCP / AI / tool wire; redact sensitive, elide large, include structural indicators. |
+  | `:rf.egress/local-redacted` | on-box dev UI default; suppress sensitive display. |
+  | `:rf.egress/local-raw` | trusted local operator; include sensitive AND large. |
+  | `:rf.egress/ssr-hydration` | projection AFTER the §14 allowlist; defence-in-depth. |
+  | `:rf.egress/public-error` | client-safe error projection; never internal raw values. |
+
+  ## Fail-closed (EP-0002 / Spec 015 §Direct reads)
+
+  Egress policy is frame-scoped. A tree-shaped slot is projected only when
+  the frame is KNOWN (the explicit `:frame` opt, or the carried-invariant
+  scope). With no frame and no `:rf.size/include-sensitive? true` opt-out,
+  the underlying `elide-wire-value` redacts the whole value to
+  `:rf/redacted` rather than borrow another frame's policy — `project-egress`
+  inherits that fail-closed posture, it does NOT synthesise `:rf/default`."
+  (:require [re-frame.elision :as elision]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; The six ruled `:rf.egress/*` profiles (EP-0015 §10, issue 3).
+;;
+;; Each profile resolves to a `:rf.size/*` opt-set — the boolean override
+;; layer `elide-wire-value` already consumes. The set is a CLOSED enum;
+;; additions require a recorded ruling (Spec 015 §The graduation gate).
+;; ---------------------------------------------------------------------------
+
+(def ^:const profiles
+  "The closed six-member `:rf.egress/profile` vocabulary (EP-0015 §10)."
+  #{:rf.egress/off-box-observability
+    :rf.egress/off-box-tool
+    :rf.egress/local-redacted
+    :rf.egress/local-raw
+    :rf.egress/ssr-hydration
+    :rf.egress/public-error})
+
+(def ^:private profile->size-opts
+  "Resolve each profile to its default `:rf.size/*` opt-set (the §10
+  default-behaviour table). All six off-box / on-box-redacted boundaries
+  fail closed (`include-sensitive?`/`include-large?` both false, no
+  digests); `:rf.egress/local-raw` is the single trusted-local boundary
+  that opts sensitive AND large back in.
+
+  `:rf.egress/off-box-tool` additionally turns on `:rf.size/include-digests?`
+  so the marker carries the structural indicators / counters a tool needs
+  to reason about shape without seeing content (the §10 \"include
+  structural indicators\" clause)."
+  {:rf.egress/off-box-observability
+   {:rf.size/include-sensitive? false
+    :rf.size/include-large?     false
+    :rf.size/include-digests?   false}
+
+   :rf.egress/off-box-tool
+   {:rf.size/include-sensitive? false
+    :rf.size/include-large?     false
+    :rf.size/include-digests?   true}
+
+   :rf.egress/local-redacted
+   {:rf.size/include-sensitive? false
+    :rf.size/include-large?     false
+    :rf.size/include-digests?   false}
+
+   :rf.egress/local-raw
+   {:rf.size/include-sensitive? true
+    :rf.size/include-large?     true
+    :rf.size/include-digests?   false}
+
+   :rf.egress/ssr-hydration
+   {:rf.size/include-sensitive? false
+    :rf.size/include-large?     false
+    :rf.size/include-digests?   false}
+
+   :rf.egress/public-error
+   {:rf.size/include-sensitive? false
+    :rf.size/include-large?     false
+    :rf.size/include-digests?   false}})
+
+(defn profile-size-opts
+  "Return the `:rf.size/*` opt-set a profile resolves to, or `nil` for an
+  unknown / absent profile. Public so a tool can introspect the resolution
+  (Xray's egress-profile panel) without re-deriving the table."
+  [profile]
+  (get profile->size-opts profile))
+
+;; ---------------------------------------------------------------------------
+;; Opts resolution — profile floor + explicit `:rf.size/*` overlay.
+;;
+;; A profile resolves to a `:rf.size/*` opt-set; an explicit `:rf.size/*`
+;; key the caller ALSO passes composes ON TOP (the override wins). The
+;; non-size opts (`:frame`, `:path`, `:rf.size/threshold-bytes`,
+;; `:as-of-epoch`) flow through to `elide-wire-value` untouched.
+;; ---------------------------------------------------------------------------
+
+(def ^:private size-override-keys
+  "The `:rf.size/*` boolean keys a profile resolves but a caller may
+  explicitly override (the override wins). `:rf.size/threshold-bytes` is
+  NOT here — it is a pass-through tuning knob, not a profile-resolved
+  boolean."
+  [:rf.size/include-sensitive?
+   :rf.size/include-large?
+   :rf.size/include-digests?])
+
+(defn resolve-elision-opts
+  "Resolve an egress `opts` map to the `elide-wire-value` opts a
+  tree-shaped slot is walked under.
+
+  Composition (EP-0015 §10): the profile's `:rf.size/*` opt-set is the
+  FLOOR; any `:rf.size/*` boolean the caller passes explicitly OVERLAYS it
+  (the override wins). When no profile is given the opts pass through as-is
+  (the advanced raw-flags path). `:frame` / `:path` /
+  `:rf.size/threshold-bytes` / `:as-of-epoch` are preserved verbatim.
+
+  An UNKNOWN `:rf.egress/profile` value throws — the enum is closed
+  (Spec 015 §The graduation gate), so a typo is a loud error, never a
+  silent fall-through to a permissive walk."
+  [opts]
+  (let [opts    (or opts {})
+        profile (:rf.egress/profile opts)]
+    (cond
+      (nil? profile)
+      ;; No profile — the advanced raw-flags path. Pass the size opts
+      ;; through verbatim (minus the absent profile key).
+      (dissoc opts :rf.egress/profile)
+
+      (contains? profile->size-opts profile)
+      (let [floor    (profile->size-opts profile)
+            ;; Caller's explicit `:rf.size/*` booleans overlay the floor.
+            explicit (select-keys opts size-override-keys)]
+        (-> (dissoc opts :rf.egress/profile)
+            (merge floor)
+            (merge explicit)))
+
+      :else
+      (throw (ex-info (str "unknown :rf.egress/profile " profile)
+                      {:rf.error/id :rf.error/unknown-egress-profile
+                       :where       'rf/project-egress
+                       :recovery    :use-a-known-profile
+                       :profile     profile
+                       :valid       profiles})))))
+
+;; ---------------------------------------------------------------------------
+;; Per-record-kind slot classification (EP-0015 §11) — PRIVATE.
+;;
+;; The record projector knows which slots of each `:rf.observe/*` record
+;; kind are tree-shaped (frame policy applies — delegate to the walker),
+;; event-shaped, public-summary-only, or omit-by-default. `project-egress`
+;; dispatches on the record's `:kind`; an unknown / kindless record is
+;; treated as a tree-shaped VALUE and walked whole (the direct-read path —
+;; Spec 015 §Direct reads).
+;; ---------------------------------------------------------------------------
+
+(defn- walk-slot
+  "Project one tree-shaped slot through `elide-wire-value` against the
+  resolved elision opts (the profile-floor + override overlay), seeded at
+  the record's frame. Delegates entirely to the walker — the size /
+  sensitive policy is the frame's, NOT reimplemented here (EP-0015 §11)."
+  [v elision-opts]
+  (elision/elide-wire-value v elision-opts))
+
+;; ---- handled-event record (`:rf.observe/handled-event`) ------------------
+;;
+;; EP-0015 issue 4 (ruled, sharpened): the off-box default record omits the
+;; `:event` ARGS slot entirely. It carries only summary fields — frame,
+;; event id, status, elapsed, effect keys, work/correlation ids. Tools may
+;; opt into a richer PROJECTED payload (never raw): a `:rf.egress/local-raw`
+;; or any profile that opts `:rf.size/include-sensitive? true` keeps the
+;; `:event` slot, projected through the walker.
+;;
+;; "Summary-only" slots (`:event-id`, `:status`, `:elapsed-ms`, `:effects`,
+;; `:correlation`, `:kind`, `:frame`) are structural metadata, never raw
+;; user values, so they pass through unchanged.
+
+(def ^:private handled-event-summary-keys
+  #{:kind :frame :event-id :status :elapsed-ms :effects :correlation})
+
+(defn- include-event-args?
+  "Whether the off-box-default-omitted `:event` args slot is retained. Only
+  when the resolved walk explicitly opts sensitive content back in
+  (trusted-local) — the off-box default fails closed and omits it."
+  [elision-opts]
+  (true? (:rf.size/include-sensitive? elision-opts)))
+
+(defn- project-handled-event
+  [record elision-opts]
+  (let [base (select-keys record handled-event-summary-keys)]
+    (if (and (contains? record :event)
+             (include-event-args? elision-opts))
+      ;; Trusted-local opt-in: keep `:event`, PROJECTED (never raw).
+      (assoc base :event (walk-slot (:event record) elision-opts))
+      ;; Off-box default: the `:event` args slot is omitted entirely.
+      base)))
+
+;; ---- error record (`:rf.observe/error`) ----------------------------------
+;;
+;; The `:event` and `:tags` slots are tree-shaped (frame policy applies);
+;; `:exception` is an opaque host value the walker cannot prove the
+;; provenance of (Spec 015 §Author guidance for the exception-path
+;; residual) — under `:rf.egress/public-error` it is dropped entirely (a
+;; client-safe projection never carries internal raw values); otherwise it
+;; is walked like any other tree slot (a non-tree exception object passes
+;; through). Summary slots pass through.
+
+(def ^:private error-summary-keys
+  #{:kind :frame :error :event-id :status :elapsed-ms :correlation :time})
+
+(def ^:private error-tree-keys
+  #{:event :tags})
+
+(defn- public-error?
+  [opts]
+  (= :rf.egress/public-error (:rf.egress/profile opts)))
+
+(defn- project-error-record
+  [record opts elision-opts]
+  (let [base (select-keys record error-summary-keys)
+        ;; Tree-shaped slots → walker.
+        with-tree (reduce
+                    (fn [acc k]
+                      (if (contains? record k)
+                        (assoc acc k (walk-slot (get record k) elision-opts))
+                        acc))
+                    base
+                    error-tree-keys)]
+    ;; `:exception` is author-built; a public-error projection NEVER carries
+    ;; internal raw values, so it is dropped. Other profiles walk it (an
+    ;; opaque non-tree exception object passes through the walker unchanged).
+    (cond
+      (public-error? opts)
+      with-tree
+
+      (contains? record :exception)
+      (assoc with-tree :exception (walk-slot (:exception record) elision-opts))
+
+      :else
+      with-tree)))
+
+;; ---- dispatch ------------------------------------------------------------
+
+(defn- project-record-by-kind
+  "Dispatch a `:rf.observe/*` record to its private per-kind projector.
+  An unknown / kindless record is treated as a tree-shaped VALUE and walked
+  whole — the direct-read path (`app-db-value` / `sub-cache` / a bare
+  value at a `:path` offset, Spec 015 §Direct reads)."
+  [record opts elision-opts]
+  (case (and (map? record) (:kind record))
+    :rf.observe/handled-event
+    (project-handled-event record elision-opts)
+
+    :rf.observe/error
+    (project-error-record record opts elision-opts)
+
+    ;; No `:kind` (or unknown kind) ⇒ treat the whole input as a
+    ;; tree-shaped value and walk it. This is the direct-read / bare-value
+    ;; egress path the §13 examples use:
+    ;;   (rf/project-egress value {:frame :app/main :path [:auth]
+    ;;                             :rf.egress/profile :rf.egress/off-box-tool})
+    (walk-slot record elision-opts)))
+
+(defn project-egress
+  "Project `record-or-value` for egress across a trust boundary, returning
+  a value safe to ship under the resolved profile.
+
+  THE public, record-level boundary primitive (EP-0015 §10/§11). The
+  required step before any off-box sink. It dispatches on a record's
+  `:kind` (the `:rf.observe/*` record kinds — handled-event, error) to a
+  PRIVATE per-kind projector, and falls back to walking a kindless input as
+  a tree-shaped VALUE (the direct-read path). For every tree-shaped slot it
+  DELEGATES to `elide-wire-value` against the frame's classification — it
+  does NOT reimplement the walker (EP-0015 §11).
+
+  `opts` is a map:
+
+      {:rf.egress/profile <one of `profiles`>   ;; the named boundary
+       :frame             <frame-id>            ;; whose classification applies
+       :path              [...]                 ;; offset for a bare-value walk
+       :rf.size/include-sensitive? <bool>       ;; explicit override (wins)
+       :rf.size/include-large?     <bool>
+       :rf.size/include-digests?   <bool>
+       :rf.size/threshold-bytes    <int>        ;; pass-through tuning
+       :as-of-epoch                <epoch-id>}  ;; pass-through
+
+  Composition (EP-0015 §10): the profile's `:rf.size/*` opt-set is the
+  floor; any `:rf.size/*` boolean the caller passes explicitly overlays it
+  (the override wins). An unknown `:rf.egress/profile` throws
+  `:rf.error/unknown-egress-profile` — the enum is closed.
+
+  Fail-closed (EP-0002 / Spec 015 §Direct reads): a tree-shaped slot is
+  projected only when the frame is KNOWN; with no frame and no
+  `:rf.size/include-sensitive? true` opt-out the delegated walker redacts
+  the whole value to `:rf/redacted` rather than borrow another frame's
+  policy. `project-egress` does NOT synthesise `:rf/default`.
+
+  Per [Spec 015 §`project-egress`](../../../../../spec/015-Data-Classification.md#project-egress--the-record-level-boundary-primitive)."
+  ([record-or-value] (project-egress record-or-value nil))
+  ([record-or-value opts]
+   (let [elision-opts (resolve-elision-opts opts)]
+     (project-record-by-kind record-or-value opts elision-opts))))

--- a/implementation/core/test/re_frame/projection_cljs_test.cljc
+++ b/implementation/core/test/re_frame/projection_cljs_test.cljc
@@ -1,0 +1,313 @@
+(ns re-frame.projection-cljs-test
+  "EP-0015 §10/§11 (rf2-yjbr1w) — record-level egress projection.
+  `project-egress` + the six ruled `:rf.egress/*` profiles, layered over
+  `elide-wire-value`. Pins the acceptance legs the bead enumerates:
+
+    - each profile's default redaction / elision behaviour on a record
+      carrying sensitive + large + tree slots;
+    - profile + explicit `:rf.size/*` override COMPOSES (override wins);
+    - sensitive-wins (a both-marked path redacts, never large-elides);
+    - `:rf.egress/public-error` never includes raw internal values;
+    - delegation to `elide-wire-value` for tree slots (the walker, not a
+      reimplemented walk, does the substitution);
+    - off-box default omits the handled-event `:event` args slot entirely
+      (issue 4), trusted-local keeps it PROJECTED;
+    - unknown profile throws (the enum is closed);
+    - fail-closed with no frame (no `:rf/default` synthesis).
+
+  Dual-runtime: named `*_cljs_test.cljc` so the shadow-cljs `:node-test`
+  build (`npm run test:cljs`, `:ns-regexp \"cljs-test$\"`) AND the JVM
+  `clojure -M:test` runner both pick it up. Plain CLJC; no DOM dependency."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
+            [re-frame.projection :as projection]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter}))
+
+;; A frame classifying [:auth :token] sensitive and [:docs :blob] large.
+;; The app-db value under test carries a sensitive leaf, a large leaf, and
+;; an unmarked sibling — the three-axis record EP-0015 §10 names.
+(def ^:private big-string
+  ;; > the 16384-byte default threshold so an UNDECLARED large auto-detect
+  ;; would fire; here [:docs :blob] is DECLARED large, so the marker is
+  ;; deterministic regardless of threshold.
+  (apply str (repeat 40000 \x)))
+
+(defn- mk-frame! [frame-id]
+  (rf/reg-frame frame-id
+    {:sensitive {:app-db [[:auth :token]]}
+     :large     {:app-db [[:docs :blob]]}}))
+
+(defn- sample-value []
+  {:auth {:token "super-secret-token"}
+   :docs {:blob big-string}
+   :public {:count 3}})
+
+(defn- redacted? [v] (= :rf/redacted v))
+(defn- large-marker? [v]
+  (and (map? v) (contains? v :rf.size/large-elided)))
+
+;; ---------------------------------------------------------------------------
+;; Profile resolution — the §10 default opt-sets.
+;; ---------------------------------------------------------------------------
+
+(deftest profile-enum-is-the-closed-six
+  (is (= #{:rf.egress/off-box-observability
+           :rf.egress/off-box-tool
+           :rf.egress/local-redacted
+           :rf.egress/local-raw
+           :rf.egress/ssr-hydration
+           :rf.egress/public-error}
+         projection/profiles)
+      "the six ruled profiles are the closed enum (EP-0015 issue 3)"))
+
+(deftest profile-resolves-to-size-opts
+  (testing "each profile resolves to its §10 default :rf.size/* opt-set"
+    ;; off-box / on-box-redacted boundaries fail closed.
+    (doseq [p [:rf.egress/off-box-observability
+               :rf.egress/local-redacted
+               :rf.egress/ssr-hydration
+               :rf.egress/public-error]]
+      (let [o (projection/profile-size-opts p)]
+        (is (false? (:rf.size/include-sensitive? o)) (str p " redacts sensitive"))
+        (is (false? (:rf.size/include-large? o))     (str p " elides large"))))
+    ;; off-box-tool turns digests ON (structural indicators).
+    (let [o (projection/profile-size-opts :rf.egress/off-box-tool)]
+      (is (false? (:rf.size/include-sensitive? o)))
+      (is (false? (:rf.size/include-large? o)))
+      (is (true?  (:rf.size/include-digests? o))
+          "off-box-tool includes structural indicators (§10)"))
+    ;; local-raw opts sensitive + large back in.
+    (let [o (projection/profile-size-opts :rf.egress/local-raw)]
+      (is (true? (:rf.size/include-sensitive? o)) "local-raw includes sensitive")
+      (is (true? (:rf.size/include-large? o))     "local-raw includes large"))
+    ;; Unknown / absent → nil.
+    (is (nil? (projection/profile-size-opts :rf.egress/bogus)))
+    (is (nil? (projection/profile-size-opts nil)))))
+
+;; ---------------------------------------------------------------------------
+;; Per-profile projection of a sensitive + large + tree record/value.
+;; ---------------------------------------------------------------------------
+
+(deftest off-box-profiles-redact-sensitive-and-elide-large
+  (testing "off-box / redacted profiles project sensitive → :rf/redacted, large → marker"
+    (mk-frame! :proj/offbox)
+    (doseq [p [:rf.egress/off-box-observability
+               :rf.egress/off-box-tool
+               :rf.egress/local-redacted
+               :rf.egress/ssr-hydration
+               :rf.egress/public-error]]
+      (let [out (rf/project-egress (sample-value)
+                  {:frame :proj/offbox :rf.egress/profile p})]
+        (is (redacted? (get-in out [:auth :token]))
+            (str p ": sensitive leaf redacted"))
+        (is (large-marker? (get-in out [:docs :blob]))
+            (str p ": large leaf elided to a marker"))
+        (is (= 3 (get-in out [:public :count]))
+            (str p ": unmarked sibling passes through"))))))
+
+(deftest local-raw-includes-sensitive-and-large
+  (testing ":rf.egress/local-raw passes sensitive AND large through verbatim"
+    (mk-frame! :proj/raw)
+    (let [out (rf/project-egress (sample-value)
+                {:frame :proj/raw :rf.egress/profile :rf.egress/local-raw})]
+      (is (= "super-secret-token" (get-in out [:auth :token]))
+          "trusted-local sees the sensitive value")
+      (is (= big-string (get-in out [:docs :blob]))
+          "trusted-local sees the large value raw")
+      (is (= 3 (get-in out [:public :count]))))))
+
+;; ---------------------------------------------------------------------------
+;; Profile + explicit :rf.size/* override composes — override wins.
+;; ---------------------------------------------------------------------------
+
+(deftest profile-plus-override-composes
+  (testing "an explicit :rf.size/* boolean overlays the profile floor (override wins)"
+    (mk-frame! :proj/compose)
+    ;; off-box-observability floors include-sensitive? false, but the
+    ;; caller explicitly opts it back in — the override wins.
+    (let [out (rf/project-egress (sample-value)
+                {:frame :proj/compose
+                 :rf.egress/profile :rf.egress/off-box-observability
+                 :rf.size/include-sensitive? true})]
+      (is (= "super-secret-token" (get-in out [:auth :token]))
+          "explicit include-sensitive? true overrides the off-box floor")
+      ;; The non-overridden axis stays at the floor: large still elides.
+      (is (large-marker? (get-in out [:docs :blob]))
+          "the un-overridden large axis stays at the profile floor"))
+    ;; The reverse: local-raw floors include-large? true, override to false.
+    (let [out (rf/project-egress (sample-value)
+                {:frame :proj/compose
+                 :rf.egress/profile :rf.egress/local-raw
+                 :rf.size/include-large? false})]
+      (is (= "super-secret-token" (get-in out [:auth :token]))
+          "local-raw sensitive floor survives (not overridden)")
+      (is (large-marker? (get-in out [:docs :blob]))
+          "explicit include-large? false overrides the local-raw floor"))))
+
+(deftest resolve-elision-opts-overlay-order
+  (testing "resolve-elision-opts: explicit :rf.size/* beats profile floor; pass-throughs kept"
+    (let [o (projection/resolve-elision-opts
+              {:rf.egress/profile :rf.egress/off-box-observability
+               :rf.size/include-large? true
+               :frame :x
+               :path [:a]
+               :rf.size/threshold-bytes 99})]
+      (is (true?  (:rf.size/include-large? o)) "override wins over the false floor")
+      (is (false? (:rf.size/include-sensitive? o)) "un-overridden axis at floor")
+      (is (= :x (:frame o)) ":frame passes through")
+      (is (= [:a] (:path o)) ":path passes through")
+      (is (= 99 (:rf.size/threshold-bytes o)) ":threshold-bytes passes through")
+      (is (not (contains? o :rf.egress/profile)) "the profile key is consumed"))))
+
+;; ---------------------------------------------------------------------------
+;; Sensitive wins over large.
+;; ---------------------------------------------------------------------------
+
+(deftest sensitive-wins-over-large
+  (testing "a path declared BOTH sensitive and large redacts, never large-elides"
+    (rf/reg-frame :proj/both
+      {:sensitive {:app-db [[:secret]]}
+       :large     {:app-db [[:secret]]}})
+    (let [out (rf/project-egress {:secret big-string}
+                {:frame :proj/both
+                 :rf.egress/profile :rf.egress/off-box-observability})]
+      (is (redacted? (:secret out)) "the both-marked path is :rf/redacted")
+      (is (not (large-marker? (:secret out)))
+          "NO large marker is emitted — no path/size/digest can leak"))))
+
+;; ---------------------------------------------------------------------------
+;; Delegation to elide-wire-value — the walker, not a reimplemented walk.
+;; ---------------------------------------------------------------------------
+
+(deftest delegates-to-elide-wire-value-for-tree-slots
+  (testing "project-egress of a tree value equals elide-wire-value under the resolved opts"
+    (mk-frame! :proj/deleg)
+    (let [opts {:frame :proj/deleg :rf.egress/profile :rf.egress/off-box-tool}
+          via-project (rf/project-egress (sample-value) opts)
+          ;; The walker called directly under the RESOLVED opts must match —
+          ;; proving project-egress delegates rather than re-walking.
+          resolved (projection/resolve-elision-opts opts)
+          via-walker  (elision/elide-wire-value (sample-value) resolved)]
+      (is (= via-project via-walker)
+          "tree-slot projection is exactly elide-wire-value under resolved opts"))))
+
+;; ---------------------------------------------------------------------------
+;; Handled-event record (issue 4) — off-box omits :event args; raw keeps it.
+;; ---------------------------------------------------------------------------
+
+(defn- handled-event-record [frame-id]
+  {:kind        :rf.observe/handled-event
+   :frame       frame-id
+   :event-id    :auth/login
+   :event       [:auth/login {:password "secret"}]
+   :status      :ok
+   :elapsed-ms  12
+   :effects     [:db :rf.http/managed]
+   :correlation {:work-id "w-77" :dispatch-id "d-91"}})
+
+(deftest handled-event-off-box-omits-event-args
+  (testing "off-box default carries summary fields and OMITS the :event args slot"
+    (mk-frame! :proj/he)
+    (let [out (rf/project-egress (handled-event-record :proj/he)
+                {:frame :proj/he
+                 :rf.egress/profile :rf.egress/off-box-observability})]
+      (is (not (contains? out :event)) "the :event args slot is omitted entirely")
+      (is (= :rf.observe/handled-event (:kind out)))
+      (is (= :auth/login (:event-id out)))
+      (is (= :ok (:status out)))
+      (is (= 12 (:elapsed-ms out)))
+      (is (= [:db :rf.http/managed] (:effects out)))
+      (is (= {:work-id "w-77" :dispatch-id "d-91"} (:correlation out))
+          "correlation ids ride through"))))
+
+(deftest handled-event-trusted-local-keeps-projected-event
+  (testing "trusted-local keeps :event, PROJECTED through the walker (never raw)"
+    (mk-frame! :proj/he2)
+    (let [out (rf/project-egress (handled-event-record :proj/he2)
+                {:frame :proj/he2
+                 :rf.egress/profile :rf.egress/local-raw})]
+      (is (contains? out :event) "trusted-local retains the :event slot")
+      (is (= [:auth/login {:password "secret"}] (:event out))
+          "local-raw projects the event verbatim (sensitive opted in)"))))
+
+;; ---------------------------------------------------------------------------
+;; public-error never includes raw internal values.
+;; ---------------------------------------------------------------------------
+
+(deftest public-error-drops-internal-exception
+  (testing ":rf.egress/public-error never carries internal raw values"
+    (mk-frame! :proj/err)
+    (let [record {:kind      :rf.observe/error
+                  :frame     :proj/err
+                  :error     :rf.error/handler-exception
+                  :event-id  :auth/login
+                  :event     [:auth/login {:auth {:token "tok"}}]
+                  :exception {:internal "raw stacktrace + secret"}}
+          out (rf/project-egress record
+                {:frame :proj/err :rf.egress/profile :rf.egress/public-error})]
+      (is (not (contains? out :exception))
+          "public-error drops the internal :exception slot entirely")
+      (is (= :rf.error/handler-exception (:error out)) "summary fields survive")
+      (is (= :auth/login (:event-id out))))))
+
+(deftest error-record-redacts-event-tree-slot
+  (testing "error record :event tree slot is projected under the frame's policy"
+    (mk-frame! :proj/err2)
+    (let [record {:kind     :rf.observe/error
+                  :frame    :proj/err2
+                  :error    :rf.error/handler-exception
+                  :event    [:auth/login {:auth {:token "super-secret-token"}}]}
+          out (rf/project-egress record
+                {:frame :proj/err2 :rf.egress/profile :rf.egress/off-box-tool})]
+      (is (redacted? (get-in (:event out) [1 :auth :token]))
+          "the sensitive token inside the error's :event is redacted"))))
+
+;; ---------------------------------------------------------------------------
+;; Closed enum + fail-closed.
+;; ---------------------------------------------------------------------------
+
+(deftest unknown-profile-throws
+  (testing "an unknown :rf.egress/profile throws — the enum is closed"
+    (let [data (try (rf/project-egress {} {:rf.egress/profile :rf.egress/bogus})
+                    nil
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e
+                      (ex-data e)))]
+      (is (= :rf.error/unknown-egress-profile (:rf.error/id data)))
+      (is (= :rf.egress/bogus (:profile data))))))
+
+(deftest fails-closed-with-no-frame
+  (testing "no known frame + no opt-out → the delegated walker fails closed"
+    ;; The test fixture binds an ambient :rf/default frame; rebind it AWAY
+    ;; so the call site is genuinely frameless (the off-box egress posture a
+    ;; tool that reads outside any frame scope sees). project-egress must
+    ;; NOT synthesise :rf/default — the delegated walker redacts the WHOLE
+    ;; value (EP-0002 fail-closed).
+    (binding [frame/*current-frame* nil]
+      (let [out (rf/project-egress {:auth {:token "tok"}}
+                  {:rf.egress/profile :rf.egress/off-box-observability})]
+        (is (redacted? out)
+            "frameless egress fails closed to :rf/redacted (no :rf/default)"))
+      ;; The deliberate opt-out (include-sensitive? true) gets an identity
+      ;; walk against the no-frame policy.
+      (let [out (rf/project-egress {:auth {:token "tok"}}
+                  {:rf.size/include-sensitive? true})]
+        (is (= {:auth {:token "tok"}} out)
+            "explicit include-sensitive? true is the deliberate frameless opt-out")))))
+
+(deftest no-profile-is-the-advanced-raw-flags-path
+  (testing "with no profile, :rf.size/* flags pass through to the walker verbatim"
+    (mk-frame! :proj/noprof)
+    (let [out (rf/project-egress (sample-value)
+                {:frame :proj/noprof
+                 :rf.size/include-sensitive? false
+                 :rf.size/include-large? false})]
+      (is (redacted? (get-in out [:auth :token])))
+      (is (large-marker? (get-in out [:docs :blob]))))))

--- a/spec/API.md
+++ b/spec/API.md
@@ -629,6 +629,16 @@ The framework primitive that walks tree-shaped values at the wire boundary and s
 
 **Schema-only declaration path.** The `[:rf.runtime/elision]` registry has exactly two slots: `:declarations` (schema-derived `:large?` paths, populated by `populate-elision-from-schemas!`) and `:sensitive-declarations` (schema-derived `:sensitive?` paths). There is no runtime declaration API — apps declare `:large?` / `:sensitive?` on the Malli schema and `rf/reg-app-schema` it; the boot-time hydrator does the rest. Per [docs/guide/23-privacy-and-large-things.md](../docs/guide/23-privacy-and-large-things.md) — the canonical statement of "schemas are the only path" — and `implementation/core/src/re_frame/elision.cljc` L4-6.
 
+### Record-level egress projection (EP-0015 / Spec 015)
+
+> Cross-reference: [015 §Projection](015-Data-Classification.md#projection) is the normative home; `project-egress` is the public, record-level boundary primitive layered over `elide-wire-value`. The six-member `:rf.egress/*` profile enum is the named-boundary vocabulary; the boolean `:rf.size/*` flags remain the advanced override layer beneath it (EP-0015 §10/§11).
+
+`rf/project-egress` is the required projection step before any off-box sink. It dispatches on a record's `:kind` (the `:rf.observe/*` record kinds) to a **private** per-kind projector — only `project-egress` is public (EP-0015 issue 2: the name names the *boundary*, not a record kind) — and delegates every tree-shaped slot to [`rf/elide-wire-value`](#elide-wire-value-the-wire-boundary-walker). A profile resolves to a `:rf.size/*` opt-set; an explicit `:rf.size/*` boolean composes on top (the override wins).
+
+| API | M/Fn | Signature | Status | Tier | Spec |
+|---|---|---|---|---|---|
+| `project-egress` | Fn | `(project-egress record-or-value)` / `(project-egress record-or-value opts)` → a value safe to ship under the resolved profile. `opts` conforms to [`:rf/project-egress-opts`](Spec-Schemas.md#rfproject-egress-opts): `{:rf.egress/profile <closed six-member enum> :frame <frame-id> :path [...] :rf.size/include-sensitive? <bool> :rf.size/include-large? <bool> :rf.size/include-digests? <bool> :rf.size/threshold-bytes <int> :as-of-epoch <epoch>}`. Dispatches on a record's `:kind` (`:rf.observe/handled-event` / `:rf.observe/error`) to a private per-kind projector, falling back to walking a kindless input as a tree-shaped value (the direct-read path); delegates tree-shaped slots to `elide-wire-value`. Profile resolves to a `:rf.size/*` opt-set; explicit `:rf.size/*` booleans compose on top (override wins). Unknown profile raises `:rf.error/unknown-egress-profile` (closed enum). Fail-closed when no frame is known (no `:rf/default` synthesis). Per [015 §`project-egress`](015-Data-Classification.md#project-egress--the-record-level-boundary-primitive). | v1 | tooling | 015 |
+
 ### DOM source-coord annotations (mandatory)
 
 Per [Spec 006 §Source-coord annotation](006-ReactiveSubstrate.md#source-coord-annotation-mandatory) and [Tool-Pair §Source-mapping](Tool-Pair.md), every adapter whose host has a DOM-attribute concept MUST inject `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on the rendered root DOM element of each registered view. Format and exemptions (Fragments, non-DOM roots) are documented in Spec 006 §Source-coord annotation. Annotation is gated on `interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`); production `:advanced` builds elide the attribute via dead-code elimination — there is no DOM-bytes cost in shipped bundles. The JVM SSR emitter mirrors the same contract per [Spec 011 §Source-coord annotation under SSR](011-SSR.md#source-coord-annotation-under-ssr).
@@ -693,6 +703,7 @@ Per [Spec-Schemas.md](Spec-Schemas.md), the spec's own runtime shapes are descri
 | `:rf/pending-navigation` | Pending-navigation slot when `:can-leave` guard rejects | 012 |
 | `:rf/elision-registry` | Per-frame size-elision declaration registry in the reserved runtime-db child `[:rf.runtime/elision]` | 009 |
 | `:rf/elision-marker` | Wire shape `rf/elide-wire-value` substitutes for an elided large value (`:rf.size/large-elided`) | 009 |
+| `:rf/project-egress-opts` | The opts map `rf/project-egress` accepts (`:rf.egress/profile` + advanced `:rf.size/*` overrides) | 015 |
 
 Schemas are **open** by default (consumers tolerate unknown keys; producers grow shapes additively); `:closed true` is opt-in at boundary-validation sites and on the effect-map.
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2657,6 +2657,33 @@ Per-field MUST-level requirements (catalogued at [009 §Wire marker — `:rf.siz
 
 The reserved sentinel `:rf.elision/at` (under the `:rf.elision/*` namespace per [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned)) marks the handle as fetchable. Agents pattern-match on the leading `:rf.elision/at` keyword — no decoder needed.
 
+### `:rf/project-egress-opts`
+
+> **Layer:** Public
+> **Owner:** [015-Data-Classification §`project-egress`](015-Data-Classification.md#project-egress--the-record-level-boundary-primitive)
+> **Status:** v1-required
+
+The opts map `rf/project-egress` accepts (EP-0015 §10/§11). `project-egress` is the public, record-level egress boundary primitive; it dispatches on a record's `:kind` to a private per-kind projector and delegates every tree-shaped slot to `rf/elide-wire-value`. The opts carry the named `:rf.egress/profile` (the closed six-member `EgressProfile` enum above) plus the advanced `:rf.size/*` overrides `elide-wire-value` consumes — the profile resolves to a `:rf.size/*` opt-set, and an explicit `:rf.size/*` boolean **composes on top (the override wins)**. `:frame` / `:path` / `:rf.size/threshold-bytes` / `:as-of-epoch` flow through to the walker.
+
+```clojure
+(def ProjectEgressOpts
+  [:map {:closed false}
+   [:rf.egress/profile          {:optional true} EgressProfile]            ;; the named boundary; resolves to a :rf.size/* opt-set
+   [:frame                      {:optional true} :keyword]                 ;; whose classification applies; fail-closed when unknown
+   [:path                       {:optional true} [:vector :any]]           ;; offset for a bare-value walk (direct-read path)
+   [:rf.size/include-sensitive? {:optional true} :boolean]                 ;; explicit override (wins over the profile floor)
+   [:rf.size/include-large?     {:optional true} :boolean]
+   [:rf.size/include-digests?   {:optional true} :boolean]
+   [:rf.size/threshold-bytes    {:optional true} :int]                     ;; pass-through tuning knob (not profile-resolved)
+   [:as-of-epoch                {:optional true} :any]])                   ;; pass-through epoch handle
+```
+
+Semantics (normative in [015 §Projection](015-Data-Classification.md#projection)):
+
+- An **unknown** `:rf.egress/profile` raises `:rf.error/unknown-egress-profile` — the enum is closed (no silent fall-through to a permissive walk).
+- With **no profile**, the `:rf.size/*` flags pass through to `elide-wire-value` verbatim (the advanced raw-flags path).
+- **Fail-closed** (EP-0002): a tree-shaped slot is projected only when the frame is known; with no frame and no `:rf.size/include-sensitive? true` opt-out the delegated walker redacts the whole value to `:rf/redacted` — `project-egress` does **not** synthesise `:rf/default`.
+
 ### `:rf/route-pattern`
 
 > **Layer:** Public
@@ -3167,6 +3194,24 @@ Returned by `(frame-meta frame-id)`. The `:preset` field, when present, records 
   [:map
    [:app-db {:optional true} [:vector Path]]])                             ;; Path = :rf/path
 
+;; The closed six-member `:rf.egress/profile` enum (EP-0015 §10, issue 3;
+;; normative in [015 §Projection profiles](015-Data-Classification.md#projection-profiles--the-rfegress-enum-provisional)).
+;; The names are RENAMED for axis consistency (`local-redacted` / `local-raw`
+;; replacing the EP's earlier on-box-hidden-sensitive / trusted-local-raw
+;; spellings) and are PROVISIONAL until each profile is exercised by a real
+;; consumer surface (the graduation gate). Additions require a recorded
+;; ruling. Each profile resolves to a `:rf.size/*` opt-set (the §10
+;; default-behaviour table); an explicit `:rf.size/*` boolean COMPOSES on
+;; top (the override wins).
+(def EgressProfile
+  [:enum
+   :rf.egress/off-box-observability                                        ;; hosted monitoring; redact sensitive, elide large, omit digests
+   :rf.egress/off-box-tool                                                 ;; MCP / AI / tool wire; redact sensitive, elide large, structural indicators
+   :rf.egress/local-redacted                                               ;; on-box dev UI default; suppress sensitive display
+   :rf.egress/local-raw                                                    ;; trusted local operator; include sensitive AND large
+   :rf.egress/ssr-hydration                                                ;; projection AFTER the §14 allowlist; defence-in-depth
+   :rf.egress/public-error])                                               ;; client-safe error projection; never internal raw values
+
 ;; Production observation sink policy. Each entry names a user/library-owned
 ;; `:sink` keyword id; `:rf.egress/profile` and `:opts` are optional. The
 ;; sink ids are NOT framework-claimed (EP-0015 §2). Routing records through
@@ -3174,7 +3219,7 @@ Returned by `(frame-meta frame-id)`. The `:preset` field, when present, records 
 (def FrameSinkEntry
   [:map
    [:sink :keyword]                                                        ;; user/library-owned sink id, e.g. :my-app.sinks/datadog
-   [:rf.egress/profile {:optional true} :keyword]                          ;; e.g. :rf.egress/off-box-observability
+   [:rf.egress/profile {:optional true} EgressProfile]                     ;; the closed six-member egress-profile enum
    [:opts {:optional true} [:map-of :keyword :any]]])                      ;; vendor-specific, framework does not own the vocabulary
 
 (def FrameObservability

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -494,6 +494,8 @@
   ["re-frame.core" "projected-history"]          {:tier :tooling :owner "Tool-Pair" :status "v1 (dev-only)"}
   ;; Size-elision / privacy wire surfaces — §009.
   ["re-frame.core" "elide-wire-value"]                  {:tier :tooling  :owner "009" :status "v1"}
+  ;; Record-level egress projection (EP-0015 §10/§11 — rf2-yjbr1w).
+  ["re-frame.core" "project-egress"]                    {:tier :tooling  :owner "015" :status "v1"}
   ["re-frame.core" "elision-declarations"]              {:tier :tooling  :owner "009" :status "v1"}
   ["re-frame.core" "elision-sensitive-declarations"]    {:tier :tooling  :owner "009" :status "v1"}
   ["re-frame.core" "populate-elision-from-schemas!"]    {:tier :advanced :owner "009" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 507,
+ :var-count 508,
  :tier-vocab
  [:front-porch
   :advanced
@@ -151,6 +151,7 @@
   {:namespace "re-frame.core", :var "path", :tier :front-porch, :kind :fn, :owner "002", :status "v1 (preserved)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "populate-elision-from-schemas!", :tier :advanced, :kind :fn, :owner "009", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "populate-sensitive-from-schemas!", :tier :advanced, :kind :fn, :owner "009", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "project-egress", :tier :tooling, :kind :fn, :owner "015", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "project-error", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "projected-history", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "projected-record", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}


### PR DESCRIPTION
EP-0015 action-wave PROJECTION slice (bead-plan item 6, rf2-yjbr1w). Record-level egress projection per EP-0015 §10 (Projection Profiles) + §11 (`elide-wire-value` stays the value primitive), graduated normatively in `spec/015-Data-Classification.md` §Projection.

## What landed

- **`re-frame.projection` ns** — `project-egress`, the public record-level boundary primitive. Dispatches on a record's `:kind` (`:rf.observe/handled-event` / `:rf.observe/error`) to **private** per-kind projectors, falling back to walking a kindless input as a tree-shaped value (the direct-read path). Delegates every tree-shaped slot to `elide-wire-value` against the frame's classification — the walker is not reimplemented (§11).
- **The six ruled `:rf.egress/*` profiles** as the named-boundary vocabulary, each resolving to a `:rf.size/*` opt-set. A profile + an explicit `:rf.size/*` boolean **composes** (override wins). Closed enum; an unknown profile throws `:rf.error/unknown-egress-profile`.
- **Name disposition (issue 2, ruled):** only `project-egress` is a public facade export — the name names the *boundary*, not a record kind; per-record-kind projectors stay private. **No public `project-record`.**
- **`re-frame.core` facade:** `rf/project-egress` — a real export, live `:tier :tooling` / `:owner "015"` / `:facade? true` in the manifest (not `:api-md-known-unmanifested`).
- **`spec/Spec-Schemas.md` (HOT-ZONE, sole toucher):** the `EgressProfile` closed enum + the `:rf/project-egress-opts` arg schema; `FrameSinkEntry`'s `:rf.egress/profile` tightened from `:keyword` to the enum.
- **`spec/API.md` (HOT-ZONE):** `project-egress` var-row (facade classification) + `:rf/project-egress-opts` schema-index row.

### Profile → `:rf.size/*` opt-set mapping (§10 default-behaviour table)

| Profile | include-sensitive? | include-large? | include-digests? |
|---|---|---|---|
| `:rf.egress/off-box-observability` | false | false | false |
| `:rf.egress/off-box-tool` | false | false | **true** (structural indicators) |
| `:rf.egress/local-redacted` | false | false | false |
| `:rf.egress/local-raw` | **true** | **true** | false |
| `:rf.egress/ssr-hydration` | false | false | false |
| `:rf.egress/public-error` | false | false | false |

Names use the ruled axis-consistent spellings (`local-redacted` / `local-raw`, replacing the EP §10 table's `on-box-hidden-sensitive` / `trusted-local-raw`).

### Notes / scope
- Did **not** touch `router.cljc`, `implementation/resources`, or machines (in-flight beads `qiv160` / `jt854w`). Dispatched off `origin/main`; no Spec-Schemas conflict with PR #3895.
- The `:rf.egress/*` reserved-namespace catalogue entry belongs in `spec/Conventions.md` (a hot-zone file outside this bead's fence — not the sole-toucher there); Spec 015 already treats `:rf.egress/*` as reserved. Flagging for a follow-up Conventions touch if not already covered by another EP-0015 slice.

## Quality gates

- `clojure -M:test` (core JVM) — **1181 tests / 5215 assertions, 0 failures, 0 errors** (incl. the new `re-frame.projection-cljs-test`, 15 tests / 66 assertions; and the late-bind-drift gate).
- `npm run test:cljs` (node CLJS) — **6551 tests / 23942 assertions, 0 failures, 0 errors** (incl. the projection test + the api-manifest CLJS enumeration probe).
- `clojure -M -m re-frame.api-manifest.gen --check` — **OK, in sync (508 public vars)** (`project-egress` row present, `:facade? true`).
- `clojure -M -m re-frame.api-manifest.api-md-check` — **OK, in sync (204 var-rows checked)**.
- api-manifest unit tests (`clojure -M:test`) — **27 tests / 57 assertions, 0 failures**.
- `mkdocs build --strict` — **built clean, no warnings/errors**.