### PR TITLE
feat(resources): EP-0016 slice-4 — mutation completion continuation (rf2-6bff0q)

### DIFF
--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -61,6 +61,7 @@
   half without a shape change."
   (:require [clojure.set :as set]
             [re-frame.frame :as frame]
+            [re-frame.reply :as reply]
             [re-frame.resources.mutation-registry :as mreg]
             [re-frame.resources.mutation-runtime :as mstate]
             [re-frame.resources.registry :as registry]
@@ -224,6 +225,75 @@
                  :tags  tags
                  :cause [:mutation mutation-id instance-id]}]]))
 
+;; ---- mutation completion continuation — call-site :reply-to (D1) -----------
+;;
+;; EP-0016 Decision 1 / Spec 016 §Mutation completion continuations. A
+;; `:rf.mutation/execute` MAY carry an optional `:reply-to` event target. When
+;; the runtime ACCEPTS a reply as current (the live-instance gate matched —
+;; frame + work-id + generation), the runtime dispatches that target with one
+;; CANONICAL reply map appended as the final argument (the `:rf/reply-target`
+;; `:append` delivery — the shared `re-frame.reply/complete`, NOT a
+;; family-private callback contract). A STALE / superseded reply never fires
+;; the continuation (the mandatory stale-suppression boundary the reply
+;; envelope already enforces, inherited for free).
+;;
+;; The continuation is a CAUSAL EVENT TARGET, not a callback (First Principles
+;; §A verified mutation reply is a causal token): the accepted reply drives
+;; durable app state only by dispatching an ordinary event through the event
+;; tape / interceptor chain / replay. The reply target is DATA-ONLY (a public
+;; event-vector prefix or descriptor — `re-frame.reply` rejects host handles),
+;; so it rides the verification reply-payload safely through durable reply
+;; addressing.
+
+(defn- continuation-reply
+  "Augment the canonical uniform reply map (`re-frame.resources.reply`,
+  `:work/kind :mutation`) with the mutation-specific facts a `:reply-to`
+  continuation needs (Spec 016 §Mutation completion continuations, the reply
+  table). The canonical reply already carries `:status`, `:value` / `:error`,
+  `:work/id`, `:work/kind`, `:work/status`, `:rf.frame/id`, `:completed-at`,
+  and `:correlation`; this layers on the TOP-LEVEL mutation facts the
+  continuation handler reads directly:
+
+  - `:mutation`      — the mutation id;
+  - `:params`        — the canonical params used for the accepted attempt;
+  - `:instance`      — the mutation instance id;
+  - `:scope`         — the resolved (execution) mutation scope;
+  - `:affected-keys` — the resource keys the accepted reply populated /
+                       patched / invalidated (a `:rf/scoped-resource-key`
+                       set — empty when the reply touched no cache);
+  - `:cause`         — `[:mutation <mutation-id> <instance-id>]`, the data
+                       explaining what caused the continuation.
+
+  Pure — no clock, no dispatch. The reply map is data-only (the egress policy
+  walks it on the way to the trace bus / dispatch)."
+  [reply {:keys [mutation-id params instance-id scope affected-keys]}]
+  (assoc reply
+         :mutation      mutation-id
+         :params        params
+         :instance      instance-id
+         :scope         scope
+         :affected-keys (set affected-keys)
+         :cause         [:mutation mutation-id instance-id]))
+
+(defn- continuation-fx
+  "Build the `[:dispatch <completed-event>]` fx that delivers the continuation
+  reply to the call-site `:reply-to` target, or nil when no target was
+  supplied. Uses the shared `re-frame.reply/complete` to append the reply map
+  as the final argument (the `:append` delivery — static call-site args are
+  preserved, the reply lands after them), so the continuation rides the SAME
+  reply substrate every managed-async family uses (NOT a family-private
+  callback contract). A nil / blank target yields nil (no continuation).
+  Emits the `:rf.mutation/replied` trace evidence as a side effect when a
+  continuation is dispatched (D1; never on a stale/suppressed reply — that
+  path does not call this)."
+  [reply-to reply {:keys [frame-id mutation-id instance-id work-id status]}]
+  (when-let [completed (reply/complete reply-to reply)]
+    (trace/emit! :rf.event :rf.mutation/replied
+                 {:rf.frame/id frame-id :mutation mutation-id :instance instance-id
+                  :work-id work-id :status status :target reply-to
+                  :cause [:mutation mutation-id instance-id]})
+    [:dispatch completed]))
+
 ;; ---- :rf.mutation/execute -------------------------------------------------
 
 (defn execute-handler
@@ -246,7 +316,7 @@
   Returns the event-fx map (`:rf.db/runtime` + `:fx`)."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, gen-snapshot :rf.resource/generation
     world :rf.world/inputs}
-   [_event-id {:keys [mutation params instance scope cause] :as _payload}]]
+   [_event-id {:keys [mutation params instance scope cause reply-to] :as _payload}]]
   (let [where      'rf.mutation/execute
         runtime-db (or rt {})
         spec       (mreg/require-mutation-spec! mutation where)
@@ -317,11 +387,20 @@
                       ;; EP-0007: the verification work identity is `:work/id`
                       ;; (the ledger / instance `:current-work` / reply-
                       ;; envelope spelling), one attempt one name.
-                      :reply-payload {:instance-id instance-id
-                                      :mutation-id mutation
-                                      :work/id     work-id
-                                      :scope       cscope
-                                      :generation  generation}
+                      ;; the verification payload also CARRIES the optional
+                      ;; call-site `:reply-to` continuation target (D1): it
+                      ;; rides the internal reply event to the success/failure
+                      ;; handler, which delivers it (via the shared reply
+                      ;; substrate) ONLY for an accepted reply. The target is
+                      ;; data-only (a public event-vector prefix / descriptor),
+                      ;; so it is durable-reply-addressing safe. Omitted when
+                      ;; the caller supplied none.
+                      :reply-payload (cond-> {:instance-id instance-id
+                                              :mutation-id mutation
+                                              :work/id     work-id
+                                              :scope       cscope
+                                              :generation  generation}
+                                       (some? reply-to) (assoc :reply-to reply-to))
                       :work-id      work-id
                       :resource-key [:rf.mutation instance-id]
                       :scope        cscope
@@ -477,7 +556,7 @@
 
   Event shape: `[_ <verification-payload> <http-result>]`."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
-   [_event-id {work-id :work/id :keys [instance-id mutation-id generation scope] :as payload} http-result]]
+   [_event-id {work-id :work/id :keys [instance-id mutation-id generation scope reply-to] :as payload} http-result]]
   (let [runtime-db (or rt {})
         ;; EP-0010 §Managed Effects And Reply Tokens / §Resources, Mutations,
         ;; And Work-Ledger Timestamps: the reply is a CAUSAL TOKEN; the host
@@ -569,14 +648,33 @@
                                   :stale-delay-ms stale-delay-ms
                                   :gc-delay-ms    gc-delay-ms
                                   :server?        server?}])
-                              timer-policies)]
+                              timer-policies)
+            ;; PHASE 6 (Spec 016 §Phase order) — the mutation completion
+            ;; continuation. The instance + work-ledger row are now settled
+            ;; (`inst'` / `rdb'`) and the cache consequences are computed, so a
+            ;; handler reached by `:reply-to` observes both already-settled for
+            ;; this ACCEPTED reply. The continuation reply is the canonical
+            ;; uniform reply map plus the mutation-specific facts; it is
+            ;; dispatched LAST (after the cache-consequence fx) so the
+            ;; continuation runs after the invalidation it composes with.
+            cont-fx     (continuation-fx
+                          reply-to
+                          (continuation-reply
+                            reply {:mutation-id mutation-id :params params
+                                   :instance-id instance-id :scope scope
+                                   :affected-keys patch-affected})
+                          {:frame-id frame-id :mutation-id mutation-id
+                           :instance-id instance-id :work-id work-id
+                           :status (:status reply)})]
         (work-ledger/clear-handle! frame-id work-id)
         (trace/emit! :rf.event :rf.mutation/succeeded
                      {:rf.frame/id frame-id :instance instance-id :mutation mutation-id
                       :work-id work-id :generation generation
                       :affected-keys affected :patch-summary patch-summary})
         {:rf.db/runtime rdb'
-         :fx (cond-> (vec timer-fx) inv-fx (conj inv-fx))}))))
+         :fx (cond-> (vec timer-fx)
+               inv-fx  (conj inv-fx)
+               cont-fx (conj cont-fx))}))))
 
 (defn failed-handler
   "`:rf.mutation.internal/failed` — a mutation write failed. Verifies frame
@@ -596,7 +694,7 @@
 
   Event shape: `[_ <verification-payload> <http-result>]`."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
-   [_event-id {work-id :work/id :keys [instance-id mutation-id generation scope] :as payload} http-result]]
+   [_event-id {work-id :work/id :keys [instance-id mutation-id generation scope reply-to] :as payload} http-result]]
   (let [runtime-db (or rt {})
         ;; EP-0010 §Managed Effects And Reply Tokens / §Resources, Mutations,
         ;; And Work-Ledger Timestamps: a terminal mutation reply writes
@@ -643,11 +741,31 @@
                          (assoc-in (mstate/instance-path instance-id) inst')
                          (work-ledger/update-record
                            work-id work-ledger/mark-terminal
-                           :failed {:error error}))]
+                           :failed {:error error}))
+            ;; PHASE 6 — the continuation fires for ANY accepted terminal reply
+            ;; (D1 delivery rule: keyed on acceptance, not a status
+            ;; enumeration), so an accepted `:error` (and an accepted terminal
+            ;; `:cancelled`) reply dispatches `:reply-to` too — the handler folds
+            ;; validation errors / form state / notifications off the reply
+            ;; `:status`. A failed write touches no EXACT cache key, so
+            ;; `:affected-keys` is empty (the invalidate-on-failure timing marks
+            ;; TAGS stale, not exact keys). Dispatched LAST, after the optional
+            ;; failure-time invalidation it composes with.
+            cont-fx  (continuation-fx
+                       reply-to
+                       (continuation-reply
+                         reply {:mutation-id mutation-id :params params
+                                :instance-id instance-id :scope scope
+                                :affected-keys #{}})
+                       {:frame-id frame-id :mutation-id mutation-id
+                        :instance-id instance-id :work-id work-id
+                        :status (:status reply)})]
         (work-ledger/clear-handle! frame-id work-id)
         (trace/emit! :rf.event :rf.mutation/failed
                      {:rf.frame/id frame-id :instance instance-id :mutation mutation-id
                       :work-id work-id :generation generation :error error
                       :invalidated-tags (vec (or inv-tags #{}))})
         {:rf.db/runtime rdb'
-         :fx (cond-> [] inv-fx (conj inv-fx))}))))
+         :fx (cond-> []
+               inv-fx  (conj inv-fx)
+               cont-fx (conj cont-fx))}))))

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -915,3 +915,250 @@
           (is (= :success (:status (instance fa :form/save-1))) "frame A settled")
           (is (= :pending (:status (instance fb :form/save-1)))
               "frame B's instance still pending — untouched by frame A's reply"))))))
+
+;; ===========================================================================
+;; 14. rf2-6bff0q / EP-0016 D1 — mutation completion continuation (:reply-to)
+;;
+;; A `:rf.mutation/execute` may carry a call-site `:reply-to` event target. On
+;; an ACCEPTED terminal reply the runtime dispatches that target with the
+;; canonical uniform reply map appended (the shared reply substrate, NOT a
+;; family-private callback), AFTER cache consequences + instance settlement
+;; (phase 6). A STALE / superseded reply never fires the continuation.
+;; ===========================================================================
+
+(def ^:private replied (atom []))
+
+(defn- reg-capture-continuation!
+  "Register an app event that records the reply map the continuation appends
+  (the LAST arg) plus the full event vector (so static-arg preservation is
+  observable)."
+  []
+  (reset! replied [])
+  (rf/reg-event-fx :test/save-replied
+                   (fn [_ event] (swap! replied conj event) {})))
+
+(deftest reply-to-fires-on-accepted-success-and-carries-the-reply-map
+  ;; Validation rule 2 + 5: the continuation fires exactly once for an accepted
+  ;; reply and carries mutation id, params, instance, scope, status, value,
+  ;; affected keys, work id, frame id, completion time, and cause.
+  (reg-capture-continuation!)
+  (rf/reg-resource :r/article (article-resource-spec))
+  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})
+        completed-at 1781078400777]
+    (rf/reg-mutation :m/save
+                     {:params-schema [:map [:slug :string]]
+                      :request   (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+                      :populates (fn [_params result] {rkey result})})
+    (rf/dispatch-sync [:rf.mutation/execute
+                       {:mutation :m/save :params {:slug "w"} :instance :rc1
+                        :reply-to [:test/save-replied]}])
+    (reply-success! @last-managed-args {:slug "w" :title "Fresh"}
+                    {:rf.world/inputs {:time-ms completed-at}})
+    (testing "the continuation fired exactly once"
+      (is (= 1 (count @replied))))
+    (testing "EP-0016 — the appended reply map carries the full continuation contract"
+      (let [[ev-id reply] (first @replied)]
+        (is (= :test/save-replied ev-id))
+        (is (= :ok (:status reply)))
+        (is (= :m/save (:mutation reply)))
+        (is (= {:slug "w"} (:params reply)))
+        (is (= :rc1 (:instance reply)))
+        (is (= :rf.scope/global (:scope reply)))
+        (is (= {:slug "w" :title "Fresh"} (:value reply)) "decoded result rides as :value")
+        (is (= :mutation (:work/kind reply)))
+        (is (some? (:work/id reply)))
+        (is (= :rf/default (:rf.frame/id reply)))
+        (is (= completed-at (:completed-at reply)) "EP-0010 causal completion time")
+        (is (= [:mutation :m/save :rc1] (:cause reply)))
+        (is (contains? (:affected-keys reply) rkey)
+            "the populated key is in :affected-keys")))))
+
+(deftest reply-to-reconciles-the-list-on-settle
+  ;; SCOPE: the continuation runs on settle + the mutation reconciles the
+  ;; affected list. Here the mutation invalidates the list tag (cache
+  ;; consequence), and the continuation observes the post-reconcile state.
+  (reg-capture-continuation!)
+  (rf/reg-resource :r/article
+                   {:scope :rf.scope/global
+                    :params-schema [:map [:slug :string]]
+                    :request (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}})
+                    :tags (fn [{:keys [slug]} _] #{[:article slug] [:article-list]})})
+  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+    (rf/reg-mutation :m/save (save-article-spec))
+    ;; own + load the list-tagged article so the invalidation refetches it
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :r/article :scope :rf.scope/global
+                        :params {:slug "w"} :owner [:view :a]}])
+    (reply-success! @last-managed-args {:title "old"})
+    (reset! last-managed-args nil)
+    (rf/dispatch-sync [:rf.mutation/execute
+                       {:mutation :m/save :params {:slug "w"} :instance :lc1
+                        :reply-to [:test/save-replied]}])
+    (reply-success! @last-managed-args {:title "new"})
+    (testing "the list reconciled — the active-owner entry refetched (back in flight)"
+      (is (contains? #{:loading :fetching} (:status (entry rkey)))))
+    (testing "the continuation fired after the reconcile (phase 6)"
+      (is (= 1 (count @replied)))
+      (is (= :ok (:status (second (first @replied))))))))
+
+(deftest reply-to-preserves-static-call-site-args
+  ;; Spec 016 §Mutation completion continuations — `:reply-to [:e {:kind :x}]`
+  ;; dispatches `[:e {:kind :x} reply]` (the reply appended AFTER static args).
+  (reg-capture-continuation!)
+  (rf/reg-mutation :m/save (save-article-spec))
+  (rf/dispatch-sync [:rf.mutation/execute
+                     {:mutation :m/save :params {:slug "w"} :instance :sc1
+                      :reply-to [:test/save-replied {:kind :article} 7]}])
+  (reply-success! @last-managed-args {:ok true})
+  (testing "static call-site args are preserved; the reply is the FINAL arg"
+    (let [ev (first @replied)]
+      (is (= 4 (count ev)) "event-id + 2 static args + reply")
+      (is (= [:test/save-replied {:kind :article} 7] (subvec ev 0 3)))
+      (is (map? (last ev)))
+      (is (= :ok (:status (last ev)))))))
+
+(deftest reply-to-observes-settled-instance-and-cache-consequences
+  ;; Validation rule 3: the continuation fires AFTER cache consequences and
+  ;; mutation instance settlement — a handler reached by `:reply-to` sees both
+  ;; already settled for the accepted reply.
+  (let [seen (atom nil)]
+    (reset! replied [])
+    (rf/reg-resource :r/article
+                     {:scope :rf.scope/global
+                      :params-schema [:map [:slug :string]]
+                      :request (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}})
+                      :tags (fn [{:keys [slug]} _] #{[:article slug]})})
+    (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+      (rf/reg-mutation :m/save
+                       {:params-schema [:map [:slug :string]]
+                        :request   (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+                        :populates (fn [_params result] {rkey result})})
+      ;; the continuation handler reads the runtime-db AT continuation time:
+      ;; both the instance settle AND the populated entry must already be in.
+      (rf/reg-event-fx :test/save-replied
+                       (fn [_ [_ reply]]
+                         (reset! seen {:instance-status (:status (instance :pc1))
+                                       :entry-status    (:status (entry rkey))
+                                       :entry-data      (:data (entry rkey))
+                                       :reply-status    (:status reply)})
+                         {}))
+      (rf/dispatch-sync [:rf.mutation/execute
+                         {:mutation :m/save :params {:slug "w"} :instance :pc1
+                          :reply-to [:test/save-replied]}])
+      (reply-success! @last-managed-args {:slug "w" :title "Fresh"})
+      (testing "the continuation observed the instance ALREADY settled :success"
+        (is (= :success (:instance-status @seen))))
+      (testing "and the populate cache consequence ALREADY applied"
+        (is (= :loaded (:entry-status @seen)))
+        (is (= {:slug "w" :title "Fresh"} (:entry-data @seen))))
+      (testing "the reply status is :ok"
+        (is (= :ok (:reply-status @seen)))))))
+
+(deftest reply-to-fires-on-accepted-error
+  ;; D1 delivery rule: keyed on ACCEPTANCE, not a status enumeration — an
+  ;; accepted `:error` reply fires the continuation too (the handler folds
+  ;; validation errors / form state off the reply `:status`).
+  (reg-capture-continuation!)
+  (rf/reg-mutation :m/save (save-article-spec))
+  (rf/dispatch-sync [:rf.mutation/execute
+                     {:mutation :m/save :params {:slug "w"} :instance :ec1
+                      :reply-to [:test/save-replied]}])
+  (reply-failure! @last-managed-args {:kind :rf.http/http-5xx :status 503})
+  (testing "the continuation fired for the accepted error reply"
+    (is (= 1 (count @replied)))
+    (let [reply (second (first @replied))]
+      (is (= :error (:status reply)))
+      (is (= {:kind :rf.http/http-5xx :status 503} (:error reply)))
+      (is (= :m/save (:mutation reply)))
+      (is (= :ec1 (:instance reply)))
+      (is (= #{} (:affected-keys reply)) "a failed write touches no exact key")
+      (is (= [:mutation :m/save :ec1] (:cause reply))))))
+
+(deftest reply-to-fires-on-accepted-cancellation
+  ;; D1 delivery rule — an accepted TERMINAL cancellation (an `:rf.http/aborted`
+  ;; envelope, which the reply substrate lowers to `:status :cancelled`) is an
+  ;; accepted terminal reply, so it fires the continuation.
+  (reg-capture-continuation!)
+  (rf/reg-mutation :m/save (save-article-spec))
+  (rf/dispatch-sync [:rf.mutation/execute
+                     {:mutation :m/save :params {:slug "w"} :instance :cc1
+                      :reply-to [:test/save-replied]}])
+  (reply-failure! @last-managed-args {:kind :rf.http/aborted :reason :user-abort})
+  (testing "the accepted terminal cancellation fired the continuation"
+    (is (= 1 (count @replied)))
+    (is (= :cancelled (:status (second (first @replied)))))))
+
+(deftest stale-reply-does-not-fire-the-continuation
+  ;; Validation rule 4: a STALE / superseded mutation reply fires NO
+  ;; continuation — the mandatory stale-suppression boundary the reply envelope
+  ;; enforces is inherited for free.
+  (reg-capture-continuation!)
+  (rf/reg-mutation :m/save (save-article-spec))
+  ;; two executes under the SAME instance id → the gen-1 reply is now stale.
+  (rf/dispatch-sync [:rf.mutation/execute
+                     {:mutation :m/save :params {:slug "w"} :instance :i
+                      :reply-to [:test/save-replied]}])
+  (let [gen1-args @last-managed-args]
+    (rf/dispatch-sync [:rf.mutation/execute
+                       {:mutation :m/save :params {:slug "w"} :instance :i
+                        :reply-to [:test/save-replied]}])
+    (is (= 2 (:generation (instance :i))))
+    (testing "the STALE gen-1 reply does NOT fire the continuation"
+      (reply-success! gen1-args {:stale "result"})
+      (is (= 0 (count @replied)) "no continuation for the superseded reply"))
+    (testing "the CURRENT gen-2 reply DOES fire the continuation exactly once"
+      (reply-success! @last-managed-args {:fresh "result"})
+      (is (= 1 (count @replied)))
+      (is (= {:fresh "result"} (:value (second (first @replied))))))))
+
+(deftest cleared-instance-reply-does-not-fire-the-continuation
+  ;; A `:rf.mutation/clear` removes the instance row; a late reply for the
+  ;; cleared instance is stale-suppressed (no live instance), so it fires no
+  ;; continuation — the same suppression gate, via the clear path.
+  (reg-capture-continuation!)
+  (rf/reg-mutation :m/save (save-article-spec))
+  (rf/dispatch-sync [:rf.mutation/execute
+                     {:mutation :m/save :params {:slug "w"} :instance :clr1
+                      :reply-to [:test/save-replied]}])
+  (let [args @last-managed-args]
+    (rf/dispatch-sync [:rf.mutation/clear {:instance :clr1}])
+    (is (nil? (instance :clr1)))
+    (testing "a reply for the cleared instance fires no continuation"
+      (reply-success! args {:late "result"})
+      (is (= 0 (count @replied))))))
+
+(deftest no-reply-to-fires-no-continuation
+  ;; Backwards compatibility — an execute WITHOUT `:reply-to` behaves exactly
+  ;; as before (no continuation dispatched).
+  (reg-capture-continuation!)
+  (rf/reg-mutation :m/save (save-article-spec))
+  (rf/dispatch-sync [:rf.mutation/execute
+                     {:mutation :m/save :params {:slug "w"} :instance :nc1}])
+  (reply-success! @last-managed-args {:ok true})
+  (testing "no :reply-to → no continuation, instance settles normally"
+    (is (= 0 (count @replied)))
+    (is (= :success (:status (instance :nc1))))))
+
+(deftest reply-to-fires-after-failure-invalidation
+  ;; phase-6 ordering on the failure path: the continuation composes AFTER the
+  ;; optional failure-time invalidation (it is dispatched last).
+  (reg-capture-continuation!)
+  (rf/reg-resource :r/article
+                   {:scope :rf.scope/global
+                    :params-schema [:map [:slug :string]]
+                    :request (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}})
+                    :tags (fn [{:keys [slug]} _] #{[:article slug]})})
+  (let [rkey (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"})]
+    (rf/reg-mutation :m/save (save-article-spec {:invalidate-timing :after-failure}))
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :r/article :scope :rf.scope/global :params {:slug "w"}}])
+    (reply-success! @last-managed-args {:title "x"})
+    (rf/dispatch-sync [:rf.mutation/execute
+                       {:mutation :m/save :params {:slug "w"} :instance :fi1
+                        :reply-to [:test/save-replied]}])
+    (reply-failure! @last-managed-args {:kind :rf.http/http-5xx :status 503})
+    (testing "the failure-time invalidation marked the tag stale"
+      (is (some? (:invalidated-at (entry rkey)))))
+    (testing "AND the continuation fired for the accepted error reply"
+      (is (= 1 (count @replied)))
+      (is (= :error (:status (second (first @replied))))))))


### PR DESCRIPTION
Implements EP-0016 Reference Implementation Plan **slice 4** (mutation completion continuation), per `docs/EP/EP-0016-resource-mutation-completion.md` Decision 1 + the D1 ruling. Slices 1–3 (spec, resolver registry, route/event/sub scope integration) are already on main.

## What

`:rf.mutation/execute` accepts an optional call-site `:reply-to` event target. When the mutation runtime **accepts** a reply as current — the existing live-instance gate (frame + `:work/id` + generation) — it dispatches that target with the canonical uniform reply map appended, in **phase 6** (after cache consequences and instance settlement). A **stale / superseded / cleared** reply never fires the continuation.

### Continuation contract

The continuation reply is the canonical `:work/kind :mutation` reply map (`:status`, `:value`/`:error`, `:work/id`, `:rf.frame/id`, `:completed-at`, `:correlation`) **plus** the mutation-specific facts the spec table requires:

| Field | Meaning |
|---|---|
| `:mutation` | mutation id |
| `:params` | canonical params for the accepted attempt |
| `:instance` | mutation instance id |
| `:scope` | resolved (execution) scope |
| `:affected-keys` | set of resource keys the accepted reply populated/patched/invalidated (`#{}` on failure — a failed write touches no exact key) |
| `:cause` | `[:mutation <id> <instance>]` |

### Key design points

- **Causal event target, not a callback.** Delivery is the shared `re-frame.reply/complete` (`:rf/reply-target` `:append` mode), NOT a family-private callback contract. Static call-site args are preserved; the reply lands after them (`:reply-to [:e {:k :v}]` → `[:e {:k :v} reply]`).
- **Stale-reply discipline inherited for free.** The `(nil? inst)` suppression branch returns before the continuation code runs, so the mandatory stale-suppression boundary the reply envelope already enforces gates the continuation — no new suppression logic, and the EP-0011 resources-stale branches are untouched.
- **Delivery keyed on acceptance** (D1 ruling, not a status enumeration): an accepted `:ok`, accepted `:error`, and accepted terminal `:cancelled` all fire; `:stale` never does.
- **Reserved `:rf.mutation/replied` trace** emitted on dispatch.
- The `:reply-to` target rides the verification reply-payload (data-only, durable-reply-addressing safe).

## Test deltas (+10 tests, +45 assertions)

`implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc` §14:
- continuation fires once on accepted success + carries the full reply contract
- list reconciliation on settle (active-owner refetch observed)
- static call-site args preserved (reply is the final arg)
- handler observes settled instance + populate cache-consequence (phase order)
- accepted `:error` fires the continuation
- accepted terminal `:cancelled` fires the continuation
- stale/superseded reply does **not** fire it (and the current reply does, once)
- cleared-instance reply does **not** fire it
- no `:reply-to` → no continuation (back-compat)
- failure-path continuation composes after failure-time invalidation

## Quality gates

- `npm run test:cljs` — **6557 tests, 23950 assertions, 0 failures, 0 errors**
- resources `clojure -M:test` — **268 tests, 1003 assertions, 0 failures, 0 errors** (was 258/958)
- `mkdocs build --strict` — not run; no spec cross-ref touched (slice-1 already documents `:reply-to` + reserves `:rf.mutation/replied`). Changes are confined to `implementation/resources`.

## Fence

Touched only `implementation/resources/src/re_frame/resources/mutation_events.cljc` + its test. No `implementation/machines`, no `tools/`, no spec, no hot-zone files. EP-0011 resources-stale suppression branches untouched.
