### PR TITLE
fix(machines): EP-0011 spawn-stale emits canonical :status :stale via substrate + production test (rf2-lohbfg rf2-tkisxm)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -229,21 +229,19 @@
                      :parent-id         parent-id
                      :work-bearing-path invoke-id
                      :frame             frame-id}
-        reply       (if error-leaf?
-                      (m-reply/error-reply reply-ctx result)
-                      (m-reply/success-reply reply-ctx result))
         ;; (1) Find parent's `:on-done` / `:on-error`, if this is a `:spawn`-
         ;; spawned actor. The parent's spec carries the `:spawn` map at
         ;; `invoke-id`. Per rf2-a2sn1 — resolve the parent's spec from the
         ;; registrar (a singleton parent) OR, for a NESTED spawn whose
         ;; parent is itself a spawned actor (no per-instance registration),
         ;; from the parent's own snapshot `:rf/machine-type`.
+        parent-path (paths/snapshot-path parent-id)
+        parent-snap (when parent-id (get-in runtime-db parent-path))
+        parent-reg  (when parent-id (registrar/lookup :event parent-id))
         parent-meta (when parent-id
-                      (let [m (registrar/lookup :event parent-id)]
-                        (cond
-                          (:rf/machine? m) (:rf/machine m)
-                          :else            (resolver/spec-from-snapshot
-                                             (get-in runtime-db (paths/snapshot-path parent-id))))))
+                      (cond
+                        (:rf/machine? parent-reg) (:rf/machine parent-reg)
+                        :else                     (resolver/spec-from-snapshot parent-snap)))
         spawn-spec  (when (and parent-meta invoke-id)
                       (find-spawn-spec-at parent-meta invoke-id))
         on-done-fn  (:on-done spawn-spec)
@@ -256,39 +254,108 @@
         on-error?   (and error-leaf?
                          parent-id
                          (some? (:on-error spawn-spec)))
-        parent-path (paths/snapshot-path parent-id)
+        ;; Per EP-0011 §Machine Completion / Managed-Effects §Stale
+        ;; suppression (rf2-lohbfg): the one reachable machine-supersession
+        ;; case is a `:spawn`-spawned child reaching `:final?` AFTER its
+        ;; spawning parent was already DESTROYED. The completion is then
+        ;; STALE — its `:on-done` / `:on-error` routing has no live parent to
+        ;; drive, so per §Stale suppression the app target MUST NOT run and
+        ;; the completion is recorded `:status :stale` / `:work/status
+        ;; :suppressed` via the shared substrate (rather than silently
+        ;; reducing `:on-done` to identity, which emitted only an `:ok`
+        ;; reply + no stale vocabulary).
+        ;;
+        ;; LIVENESS is the gate (not `on-done-fn` resolvability): when the
+        ;; parent was destroyed BOTH its snapshot AND — for a singleton
+        ;; parent — its registrar handler are gone, so the `:spawn` spec
+        ;; (and thus `on-done-fn`) is no longer resolvable AT ALL. Keying off
+        ;; `on-done-fn` would miss the case entirely. The robust gate is: a
+        ;; declaratively-spawned child (it carries both `:rf/parent-id` and
+        ;; `:rf/spawn-id`) whose parent is NO LONGER LIVE (no snapshot AND no
+        ;; registered handler). `:on-error` routing (the error-leaf control-
+        ;; flow case) is left to its own dispatch path — a stale error leaf
+        ;; with a dead parent simply dispatches into the void, harmlessly.
+        parent-live?  (or (some? parent-snap) (some? parent-reg))
+        stale-spawn?  (and parent-id invoke-id (not on-error?)
+                           (not parent-live?))
+        ;; The carried generation is parsed off THIS finishing actor's id;
+        ;; the CURRENT generation is the LIVE counterpart — the generation of
+        ;; the actor currently occupying the spawn slot at
+        ;; `[:rf.runtime/machines :spawned parent-id invoke-id]`, read ONLY
+        ;; when the parent is still live. With the parent gone there is no
+        ;; live counterpart, so `:current` is nil — exactly the supersession
+        ;; the gate records (the parity counterpart of the `:after` path's
+        ;; exited-node → nil declaring path). The carried/current pair rides
+        ;; the trace via `stale-spawn-reply`'s correlation.
+        current-generation
+        (when (and parent-live? parent-id invoke-id)
+          (m-reply/actor-generation
+            (get-in runtime-db (paths/spawned-path parent-id invoke-id))))
+        reply       (cond
+                      stale-spawn?
+                      (m-reply/stale-spawn-reply
+                        (assoc reply-ctx :current-generation current-generation))
+                      error-leaf?
+                      (m-reply/error-reply reply-ctx result)
+                      :else
+                      (m-reply/success-reply reply-ctx result))
         ;; (2) Emit `:rf.machine/done` trace BEFORE the destroy cascade
-        ;; (D6 ordering). Fired for EVERY finish (success or error leaf) —
+        ;; (D6 ordering). Fired for EVERY finish (success / error / STALE) —
         ;; `:on-error` is additive, the done trace is the actor-finality
         ;; signal regardless of which spawn hook routes the result. Per
         ;; EP-0011 the reply-envelope facts (`:rf.reply/status`,
         ;; `:rf.reply/work-id`, `:rf.reply/work-status`) ride ADDITIVELY so
         ;; the trace stream classifies the completion the same way HTTP /
         ;; resources do; the public `:output` / `:parent-id` / `:error?`
-        ;; shape is preserved. Wire-bearing slots (`:value` / `:error`)
-        ;; route through the shared elision walker via `m-reply/trace-reply`.
-        done-summary (m-reply/trace-reply reply {:frame frame-id})
+        ;; shape is preserved. Wire-bearing slots (`:value` / `:error` /
+        ;; `:correlation`) route through the shared elision walker via
+        ;; `m-reply/trace-reply`.
+        ;;
+        ;; (rf2-lohbfg) A STALE late completion (parent destroyed before the
+        ;; child finished) additionally rides `:rf.reply/stale-reason`
+        ;; (`:rf.machine/actor-not-live`) and `:rf.reply/correlation` (the
+        ;; carried/current generation gate) — the parity counterpart of the
+        ;; `:after` path's `:rf.machine.timer/stale-after` stale-suppression
+        ;; trace. The summary is built via `m-reply/stale-spawn-trace` for a
+        ;; stale reply so the spawn-stale path reads as the spawn analogue of
+        ;; `after-stale-reply` → `trace-reply`.
+        done-summary (if stale-spawn?
+                       (m-reply/stale-spawn-trace reply {:frame frame-id})
+                       (m-reply/trace-reply reply {:frame frame-id}))
         _ (trace/emit! :rf.machine :rf.machine/done
-                       {:machine-id machine-id
-                        :output     result
-                        :parent-id  parent-id
-                        :error?     error-leaf?
-                        :frame      frame-id
-                        ;; reply-envelope vocabulary (Managed-Effects §9)
-                        :rf.reply/status      (:status done-summary)
-                        :rf.reply/work-id     (:work/id done-summary)
-                        :rf.reply/work-status (:work/status done-summary)})
+                       (cond-> {:machine-id machine-id
+                                :output     result
+                                :parent-id  parent-id
+                                :error?     error-leaf?
+                                :frame      frame-id
+                                ;; reply-envelope vocabulary (Managed-Effects §9)
+                                :rf.reply/status      (:status done-summary)
+                                :rf.reply/work-id     (:work/id done-summary)
+                                :rf.reply/work-status (:work/status done-summary)}
+                         ;; stale-suppression vocabulary (rf2-lohbfg) — carried
+                         ;; ADDITIVELY only for a stale late completion, joined
+                         ;; to `:work/id` via the shared `:rf.reply/*` facts.
+                         stale-spawn? (assoc :rf.reply/stale-reason (:stale/reason done-summary)
+                                             :rf.reply/correlation  (:correlation done-summary))))
         ;; (3) Apply :on-done to the parent's `:data`. The parent's
         ;; snapshot lives at [:rf.runtime/machines :snapshots <parent-id>]; we read it,
         ;; pass the unified context-map (`{:data :result}`) to
         ;; `:on-done`, and write the new `:data` back. Per Spec 005
         ;; §Final states / rf2-grw4i / rf2-v0rrr the callback receives
-        ;; one context-map arg and returns the new `:data` map. If the
-        ;; parent has no snapshot (spawned a child but was itself
-        ;; destroyed) or no `:on-done`, this reduces to identity. An ERROR
+        ;; one context-map arg and returns the new `:data` map. An ERROR
         ;; leaf routing to `:on-error` SKIPS `:on-done` — the two spawn hooks
         ;; are mutually exclusive per finish (error-leaf → transition,
         ;; success-leaf → `:data` callback).
+        ;;
+        ;; (rf2-lohbfg) When the parent was destroyed before the child
+        ;; finished (`stale-spawn?` — no live `parent-snap`), the completion
+        ;; is STALE: per Managed-Effects §Stale suppression the app target
+        ;; (the `:on-done` callback) MUST NOT run, and there is nothing to
+        ;; mutate. We suppress it explicitly here (rather than calling
+        ;; `on-done-fn` against a nil parent `:data` and discarding the
+        ;; result) so the suppression is a positive fact: the canonical
+        ;; `:status :stale` reply was emitted on the done trace above, and
+        ;; `runtime-db` rides through untouched.
         ;;
         ;; Per EP-0011 §Machine Completion the callback's `:result` is now
         ;; driven from the canonical reply's `:value` — the public callback
@@ -299,9 +366,8 @@
         ;; the one canonical reply map so the value the trace/ledger see and
         ;; the value the callback receives are the SAME fact.
         db-after-on-done
-        (if (and on-done-fn parent-id (not on-error?))
-          (let [parent-snap     (get-in runtime-db parent-path)
-                parent-data     (:data parent-snap)
+        (if (and on-done-fn parent-id (not on-error?) (not stale-spawn?))
+          (let [parent-data     (:data parent-snap)
                 new-parent-data (try
                                   (on-done-fn {:data parent-data :result (:value reply)})
                                   (catch #?(:clj Throwable :cljs :default) e

--- a/implementation/machines/src/re_frame/machines/reply.cljc
+++ b/implementation/machines/src/re_frame/machines/reply.cljc
@@ -79,22 +79,27 @@
 ;;                         no `#n` suffix carries generation 1.
 ;; ---------------------------------------------------------------------------
 
-(defn- actor-generation
+(defn actor-generation
   "Parse the spawn generation off an `actor-id` of the form
   `<type>#<n>` (the instance id the spawn-counter mints — see
   `lifecycle-fx.spawn/allocate-actor-id-in-runtime-db`). Returns the
   integer `n`, or 1 when the id carries no `#n` suffix (an explicit
-  per-state-singleton `:spawn-id` actor — one attempt, generation 1)."
+  per-state-singleton `:spawn-id` actor — one attempt, generation 1).
+  nil-safe: returns nil for a nil id (no live counterpart). Public so the
+  finalize path can read the LIVE spawn-slot occupant's generation as the
+  `:current` counterpart of the stale-spawn carried/current gate."
   [actor-id]
-  (let [nm (when (keyword? actor-id) (name actor-id))
-        i  (when nm #?(:clj  (.lastIndexOf ^String nm "#")
-                       :cljs (.lastIndexOf nm "#")))]
-    (if (and i (nat-int? i) (pos? i))
-      (let [suffix (subs nm (inc i))
-            n      #?(:clj  (try (Long/parseLong suffix) (catch Exception _ nil))
-                      :cljs (let [x (js/parseInt suffix 10)] (when-not (js/isNaN x) x)))]
-        (or n 1))
-      1)))
+  (if (nil? actor-id)
+    nil
+    (let [nm (when (keyword? actor-id) (name actor-id))
+          i  (when nm #?(:clj  (.lastIndexOf ^String nm "#")
+                         :cljs (.lastIndexOf nm "#")))]
+      (if (and i (nat-int? i) (pos? i))
+        (let [suffix (subs nm (inc i))
+              n      #?(:clj  (try (Long/parseLong suffix) (catch Exception _ nil))
+                        :cljs (let [x (js/parseInt suffix 10)] (when-not (js/isNaN x) x)))]
+          (or n 1))
+        1))))
 
 (defn spawn-work-id
   "Build the machine work-id for one spawned-actor attempt:
@@ -185,17 +190,33 @@
   app mutation. `:stale/reason :rf.machine/actor-not-live`,
   `:work/status :suppressed`.
 
-  `ctx` keys mirror `success-reply`'s. The carried/current correlation
-  facts ride the trace via `stale-spawn-trace`."
+  `ctx` keys mirror `success-reply`'s (`:actor-id`, `:parent-id`,
+  `:work-bearing-path`, `:frame`, `:completed-at`) plus an optional
+  `:current-generation` — the generation currently occupying the spawn
+  slot at completion (the LIVE counterpart), or nil when the slot is gone
+  (the parent was destroyed, or the slot was never reused). Mirroring the
+  `:after` path's carried/current gate, the correlation carries the
+  carried-vs-current generation pair under
+  `:generation {:carried <n> :current <m-or-nil>}` — `:carried` is the
+  generation parsed off the finishing actor's id (the `<type>#<n>` suffix),
+  `:current` is `:current-generation`. The pair is the data-only
+  supersession gate: `:carried` != `:current` (including a nil `:current`
+  — no live counterpart) is exactly why the completion is stale. The
+  whole correlation map elides through the shared trace summary
+  (`stale-spawn-trace`)."
   [ctx]
-  (let [{:keys [actor-id parent-id work-bearing-path frame completed-at]} ctx]
+  (let [{:keys [actor-id parent-id work-bearing-path frame completed-at
+                current-generation]} ctx
+        carried-generation (actor-generation actor-id)]
     (cond-> {:status       :stale
              :stale?       true
              :stale/reason :rf.machine/actor-not-live
              :work/id      (spawn-work-id actor-id work-bearing-path)
              :work/kind    :machine
              :work/status  :suppressed
-             :correlation  (cond-> {:actor-id actor-id}
+             :correlation  (cond-> {:actor-id   actor-id
+                                    :generation {:carried carried-generation
+                                                 :current current-generation}}
                              (some? parent-id)         (assoc :parent-id parent-id)
                              (some? work-bearing-path) (assoc :spawn-id (vec work-bearing-path)))}
       (some? frame)        (assoc :rf.frame/id frame)
@@ -268,3 +289,16 @@
   `:frame`)."
   ([reply] (trace-reply reply nil))
   ([reply opts] (reply/trace-summary reply opts)))
+
+(defn stale-spawn-trace
+  "Build a DATA-ONLY trace summary of a `stale-spawn-reply` for the
+  managed-async trace row that records a suppressed late spawned-actor
+  completion — the spawn-path counterpart of the `:after` path's
+  `after-stale-reply` → `trace-reply`. The wire-bearing slots (here
+  `:correlation`, carrying the carried/current generation gate) elide
+  through the single shared `re-frame.elision/elide-wire-value` walker via
+  `trace-reply`; the identity facts (`:status`, `:work/id`, `:work/kind`,
+  `:work/status`, `:stale/reason`, `:rf.frame/id`) ride verbatim. `opts`
+  is forwarded to the walker (e.g. `:frame`)."
+  ([reply] (stale-spawn-trace reply nil))
+  ([reply opts] (trace-reply reply opts)))

--- a/implementation/machines/test/re_frame/machine_reply_lowering_test.clj
+++ b/implementation/machines/test/re_frame/machine_reply_lowering_test.clj
@@ -207,3 +207,121 @@
             (is (= :error (:rf.reply/status tags)))
             (is (= :failed (:rf.reply/work-status tags)))))
         (finally (trace/unregister-listener! ::done-err))))))
+
+;; ===========================================================================
+;; (3) spawn-stale — parent destroyed BEFORE the child finishes (rf2-lohbfg /
+;;     rf2-tkisxm). The PRODUCTION path (not the pure builder): a child reaches
+;;     its :final? leaf AFTER its spawning parent was already destroyed. The
+;;     :on-done callback MUST NOT run (no live parent to mutate), the ledger /
+;;     trace MUST classify the late completion :status :stale / :work/status
+;;     :suppressed via the shared substrate, and the carried/current generation
+;;     gate MUST ride the :rf.machine/done trace. This is the spawn-path
+;;     analogue of (1)'s :after epoch-mismatch production test.
+;; ===========================================================================
+
+(deftest spawn-stale-parent-destroyed-before-child-suppresses-with-reply-vocabulary
+  (testing "a child reaching :final? AFTER its parent was destroyed is STALE: :on-done does NOT run, and the :rf.machine/done trace carries :status :stale / :work/status :suppressed / :rf.machine/actor-not-live + the carried/current generation gate"
+    (let [traces (capture-traces ::spawn-stale)]
+      (try
+        ;; A child that does NOT auto-finish on spawn — it sits in :running
+        ;; until an explicit :finish, so we can destroy the parent while the
+        ;; child is genuinely mid-flight.
+        (rf/reg-machine :rl/schild
+          {:initial :running
+           :data    {}
+           :states  {:running {:on {:finish {:target :done
+                                             :action (fn [{data :data ev :event}]
+                                                       {:data (assoc data :token (second ev))})}}}
+                     :done    {:final? true :output-key :token}}})
+        ;; A parent that spawns the child on :go (declarative :spawn with an
+        ;; :on-done that WOULD set a sentinel) and destroys ITSELF
+        ;; imperatively on :drop. The imperative `[:rf.machine/destroy
+        ;; <parent>]` tears down only the parent (it runs the parent's active
+        ;; :exit actions + clears its snapshot); the independently-spawned
+        ;; child survives — exactly the parent-destroyed-before-child case.
+        (rf/reg-machine :rl/sparent
+          {:initial :idle
+           :data    {:token-from-child :untouched}
+           :states  {:idle {:on {:go :working}}
+                     :working
+                     {:on    {:drop {:action (fn [_]
+                                               {:fx [[:rf.machine/destroy :rl/sparent]]})}}
+                      :spawn {:machine-id :rl/schild
+                              :on-done    (fn [{data :data result :result}]
+                                            ;; If this EVER runs for the stale
+                                            ;; case the assertion below fails.
+                                            (assoc data :token-from-child result))}}}})
+        (rf/dispatch-sync [:rl/sparent [:go]])
+        ;; Child spawned as :rl/schild#1 under [:working], still mid-flight.
+        (is (some? (snapshot :rl/schild#1)) "child spawned and alive")
+        (is (= :running (:state (snapshot :rl/schild#1))) "child mid-flight")
+        ;; Destroy the parent BEFORE the child finishes.
+        (rf/dispatch-sync [:rl/sparent [:drop]])
+        (is (nil? (snapshot :rl/sparent)) "parent destroyed (snapshot gone)")
+        (is (some? (snapshot :rl/schild#1))
+            "child survives the parent's imperative destroy (independent actor)")
+        (reset! traces [])
+        ;; Now the child finishes — reaches :done (:final?). finalize-machine
+        ;; runs with on-done-fn + parent-id present, but parent-snap nil.
+        (rf/dispatch-sync [:rl/schild#1 [:finish :secret-token]])
+        ;; The child auto-destroyed on :final? (the late completion is still
+        ;; behaviourally safe — the actor tears down).
+        (is (nil? (snapshot :rl/schild#1)) "stale-completing child auto-destroyed")
+        ;; Conformance (2)/(5): the app target did NOT run + NO app mutation.
+        ;; The parent is gone, so there is nothing to mutate — and we never
+        ;; called :on-done. (Were :on-done to have run against a resurrected
+        ;; parent, this would surface; it does not run at all.)
+        (is (nil? (snapshot :rl/sparent))
+            ":on-done did NOT resurrect or mutate the destroyed parent")
+        ;; Conformance (2)/(4): the :rf.machine/done trace carries the
+        ;; canonical stale reply vocabulary via the shared substrate.
+        (let [done (->> @traces
+                        (filter #(= :rf.machine/done (:operation %)))
+                        first)]
+          (is (some? done) ":rf.machine/done trace fired for the stale completion")
+          (let [tags (:tags done)]
+            ;; public shape preserved
+            (is (= :rl/schild#1 (:machine-id tags)))
+            (is (false? (:error? tags)) "a plain final leaf is not an error leaf")
+            ;; reply-envelope vocabulary (Managed-Effects §9) — records STALE/suppressed
+            (is (= :stale (:rf.reply/status tags))
+                "the canonical :status :stale reply IS produced via the substrate")
+            (is (= :suppressed (:rf.reply/work-status tags))
+                "the ledger terminal for a stale late completion")
+            (is (= :rf.machine/actor-not-live (:rf.reply/stale-reason tags)))
+            (is (= [:rf.work/machine :rl/schild#1 [:working] 1]
+                   (:rf.reply/work-id tags))
+                "canonical machine work-id (carried generation 1 off #1)")
+            ;; the carried/current generation pair IS the supersession gate —
+            ;; carried (off the finishing actor's id) vs current (the live
+            ;; spawn-slot occupant, gone now the parent was destroyed → nil).
+            (let [corr (:rf.reply/correlation tags)]
+              (is (= 1 (-> corr :generation :carried))
+                  "carried generation parsed off :rl/schild#1")
+              (is (nil? (-> corr :generation :current))
+                  "current generation is nil — the spawn slot is gone (no live counterpart)")
+              (is (= :rl/schild#1 (:actor-id corr))))))
+        (finally (trace/unregister-listener! ::spawn-stale))))))
+
+(deftest spawn-live-parent-still-drives-on-done
+  (testing "behavioural parity: with the parent STILL alive, the child's completion is :ok and :on-done runs (the rf2-lohbfg stale detection did not perturb the live path)"
+    (rf/reg-machine :rl/schild-live
+      {:initial :running
+       :data    {}
+       :states  {:running {:on {:finish {:target :done
+                                         :action (fn [{data :data ev :event}]
+                                                   {:data (assoc data :token (second ev))})}}}
+                 :done    {:final? true :output-key :token}}})
+    (rf/reg-machine :rl/sparent-live
+      {:initial :idle
+       :data    {:token-from-child :untouched}
+       :states  {:idle {:on {:go :working}}
+                 :working
+                 {:spawn {:machine-id :rl/schild-live
+                          :on-done    (fn [{data :data result :result}]
+                                        (assoc data :token-from-child result))}}}})
+    (rf/dispatch-sync [:rl/sparent-live [:go]])
+    ;; Parent stays alive; the child finishes.
+    (rf/dispatch-sync [:rl/schild-live#1 [:finish :live-token]])
+    (is (= :live-token (get-in (snapshot :rl/sparent-live) [:data :token-from-child]))
+        "live parent: :on-done ran with the canonical reply's :value (not suppressed)")))


### PR DESCRIPTION
## What

EP-0011 post-graduation errata for the machine spawn-stale path. A `:spawn`-spawned child reaching `:final?` **after its spawning parent was already destroyed** suppressed safely (no app mutation, `:on-done` never ran) but did NOT produce the canonical `:status :stale` reply through the shared `re-frame.reply` substrate, and its trace omitted the current generation. Same defect class as the resources stale-reply errata (`rf2-mn4j89`, a separate held worker). The machine `:after` epoch-stale path was already fully wired — only the spawn path was unwired.

## rf2-lohbfg — wire the canonical stale reply via the substrate

`finalize.cljc` (`finalize-machine`):

- **Detects the stale late completion by LIVENESS, not `on-done-fn` resolvability.** When a singleton parent is destroyed, BOTH its snapshot and its registrar handler are gone, so the parent's `:spawn` spec (and thus `on-done-fn`) is no longer resolvable at all — keying off `on-done-fn` would miss the case entirely. The robust gate: a declaratively-spawned child (carries `:rf/parent-id` + `:rf/spawn-id`) whose parent is no longer live (no snapshot AND no registered handler).
- Builds `m-reply/stale-spawn-reply` and rides `:rf.reply/status :stale` + `:rf.reply/work-status :suppressed` + `:rf.reply/stale-reason :rf.machine/actor-not-live` + `:rf.reply/correlation` **additively** on the existing `:rf.machine/done` trace — the same additive shape the `:after` path uses on `:rf.machine.timer/stale-after`.
- `:on-done` is suppressed **explicitly** for the stale case (a positive fact), not called against a nil parent `:data` and discarded.

`reply.cljc`:

- `stale-spawn-reply` now carries the **carried-vs-current generation pair** under `:correlation :generation {:carried <n> :current <m-or-nil>}`, mirroring the `:after` path's carried/current gate. `:carried` = generation off the finishing actor's id; `:current` = the live spawn-slot occupant's generation (nil when the parent is gone — no live counterpart).
- New `stale-spawn-trace` helper — the spawn-path counterpart of `after-stale-reply` → `trace-reply` (the doc-comment already referenced it; it now exists).
- `actor-generation` made public + nil-safe (so the finalize path can read the live counterpart's generation).

**Behaviour preserved:** still suppressed, no app mutation; the live path (parent alive) drives `:on-done` unchanged; a singleton reaching `:final?` (no parent-id) is unaffected.

## rf2-tkisxm — production-path test

`machine_reply_lowering_test.clj`: drives the REAL parent-destroyed-before-child production path (not the pure builder) — parent spawns child, parent is imperatively destroyed mid-flight, child then reaches its `:final?` leaf — and asserts:

- the canonical `:status :stale` reply IS produced via the substrate (`:rf.reply/status :stale`),
- the app target did NOT run (parent not resurrected/mutated),
- the ledger is `:suppressed` (`:rf.reply/work-status :suppressed`, `:stale-reason :rf.machine/actor-not-live`),
- the carried/current generation gate rides the `:rf.machine/done` trace (carried 1, current nil — no live counterpart).

Mirrors the existing `:after` epoch-mismatch production test. Plus a live-parent parity test. This replaces the builder-only coverage — the unwired-builder gap passed silently before (the builder is green in isolation; no runtime test drove the late path).

The test was confirmed RED before the fix (5 failing assertions — status came back `:ok`/`:completed`) and GREEN after — it hits the actual production finalize path, not a routed-around stub.

## Xray spec

No change required. No new trace op landed — the stale facts ride additively on the existing `:rf.machine/done` op via the established `:rf.reply/*` tag family, exactly as the `:after` path's reply-vocabulary already does (those reply tags are likewise not enumerated in the Xray op tables). The dispatch did not touch `tools/xray/` or `tools/machines-viz/`.

## Quality gates

- `cd implementation/machines && clojure -M:test` → **629 tests, 2035 assertions, 0 failures, 0 errors** (was 627/2018 — +2 deftests).
- `cd implementation && npm run test:cljs` → **6547 tests, 23905 assertions, 0 failures, 0 errors**.