### PR TITLE
fix(core): :dispatched-at dispatch-opt is a hard error naming the replacement (rf2-lj39cn)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -203,6 +203,16 @@
         world-inputs       (if (contains? supplied-world :time-ms)
                              supplied-world
                              (assoc supplied-world :time-ms (interop/epoch-now-ms)))
+        ;; EP-0010 disposition 5 (rf2-lj39cn): the RETIRED `:dispatched-at`
+        ;; dispatch opt gets the STANDARD RETIREMENT TREATMENT — a HARD
+        ;; ERROR naming the replacement, NOT the generic warn-on-unknown-opt
+        ;; below. Checked FIRST so a caller still passing `:dispatched-at`
+        ;; gets the specific, actionable retirement error (naming
+        ;; `(:time-ms (:rf.world/inputs envelope))`) rather than a vague
+        ;; "key outside the known set" warning. Always-on (not dev-gated):
+        ;; a retirement hard error is a correctness contract that must fire
+        ;; in production too — see `reject-retired-dispatch-opts!`.
+        _                  (diag/reject-retired-dispatch-opts! opts event)
         ;; Per rf2-jbzhj: surface unrecognised opts keys (typically a typo'd
         ;; opt like `:fram` for `:frame`) rather than silently swallowing
         ;; them. Emitted HERE — BEFORE the frame resolution below — so a

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -122,6 +122,58 @@
     :source-detail :origin :rf.world/inputs :rf.trace/call-site
     :rf.machine/internal?})
 
+(defn reject-retired-dispatch-opts!
+  "Throw `:rf.error/dispatched-at-retired` when a `dispatch` /
+  `dispatch-sync` opts map carries the RETIRED `:dispatched-at` key.
+
+  EP-0010 disposition 5 / rider b retired `:dispatched-at` under the
+  STANDARD RETIREMENT TREATMENT (EP-0007 one-name-per-fact rule 2): a hard
+  error NAMING the replacement, never a silent alias and never a soft
+  warn-on-unknown-opt. Two spellings of \"when was this dispatched\" violate
+  one-name-per-fact, so a caller still passing `:dispatched-at` must be told
+  the canonical replacement, not left to a generic unknown-opt warning that
+  merely lists the known set (which would let the soft path become the
+  de-facto spelling — the cg7llv deterrent precedent).
+
+  The durable causal-time fact is `(:time-ms (:rf.world/inputs envelope))`
+  — stamped by the framework at the dispatch causal boundary, NOT supplied
+  by the caller. (The diagnostic dispatch-time need is the trace event's own
+  ambient `:time` stamp, Spec 009.) The error names `:rf.world/inputs`'s
+  `:time-ms` as the replacement so the programmer rewrites rather than
+  retries.
+
+  ALWAYS-ON — NOT gated on `interop/debug-enabled?`: a retirement hard error
+  is a correctness contract that must fire in `:advanced` +
+  `goog.DEBUG=false` production too (mirrors the `:rf.error/redirect-retired-
+  target-key` SSR precedent), unlike the dev-only unknown-opt warn. The
+  `contains?` check is the only always-on cost on the dispatch path — a
+  single map lookup, no allocation unless the retired key is present.
+
+  Per Spec 002 §`:dispatched-at` is retired + EP-0010 disposition 5."
+  [opts event]
+  (when (contains? opts :dispatched-at)
+    (throw (ex-info ":rf.error/dispatched-at-retired"
+                    {:rf.error/id :rf.error/dispatched-at-retired
+                     :where       're-frame.router/build-envelope
+                     :event-id    (first event)
+                     :event       event
+                     :retired-key :dispatched-at
+                     :replacement '(:time-ms (:rf.world/inputs envelope))
+                     :reason      (str "Dispatch opt `:dispatched-at` is RETIRED "
+                                       "(EP-0010 disposition 5 / EP-0007 "
+                                       "one-name-per-fact). There is no "
+                                       "caller-supplied dispatch-time field. "
+                                       "The durable causal-time fact is "
+                                       "`(:time-ms (:rf.world/inputs envelope))` "
+                                       "— the framework stamps `:time-ms` into "
+                                       "`:rf.world/inputs` at the dispatch causal "
+                                       "boundary; durable code reads it from there. "
+                                       "For a diagnostic dispatch-time, use the "
+                                       "trace event's own ambient `:time` stamp "
+                                       "(Spec 009). Remove `:dispatched-at`; there "
+                                       "is no back-compat alias.")
+                     :recovery    :no-recovery}))))
+
 (defn unknown-dispatch-opts
   "Return the seq of keys in `opts` that fall OUTSIDE
   `known-dispatch-opts`, or nil when every key is known (so callers can

--- a/implementation/core/test/re_frame/world_inputs_test.clj
+++ b/implementation/core/test/re_frame/world_inputs_test.clj
@@ -196,6 +196,44 @@
         (is (number? (get-in env [:rf.world/inputs :time-ms]))
             ":time-ms is the replacement for the retired :dispatched-at")))))
 
+(deftest dispatched-at-supplied-is-a-hard-error
+  ;; EP-0010 disposition 5 (rf2-lj39cn): SUPPLYING the retired :dispatched-at
+  ;; dispatch opt is the STANDARD RETIREMENT TREATMENT — a HARD ERROR naming
+  ;; the replacement, not the soft generic unknown-opt warn. The error carries
+  ;; the canonical-replacement category id and a message naming
+  ;; (:time-ms (:rf.world/inputs envelope)).
+  (testing "EP-0010 disposition 5 / EP-0007 rule 2: supplying :dispatched-at throws"
+    (rf/reg-frame :wi/retired-supply {:doc "ctx"})
+    (testing "build-envelope throws on the retired key (always-on, even with the dev gate OFF)"
+      (with-redefs [interop/debug-enabled? false]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (build-envelope [:noop] {:frame :wi/retired-supply
+                                              :dispatched-at 123}))
+            "supplying :dispatched-at is a hard error, not a warn (prod-survivable)")))
+    (testing "the error names the canonical replacement (:time-ms / :rf.world/inputs)"
+      (let [ex   (try
+                   (build-envelope [:noop] {:frame :wi/retired-supply
+                                            :dispatched-at 123})
+                   nil
+                   (catch clojure.lang.ExceptionInfo e e))
+            data (ex-data ex)]
+        (is (some? ex) "an exception was thrown")
+        (is (= :rf.error/dispatched-at-retired (:rf.error/id data))
+            "the error category is the retired-spelling :rf.error/* id")
+        (is (= :dispatched-at (:retired-key data)) "names the retired key")
+        (is (re-find #":time-ms" (:reason data))
+            "the message references :time-ms as the replacement")
+        (is (re-find #":rf\.world/inputs" (:reason data))
+            "the message references :rf.world/inputs as the replacement carrier")
+        (is (= :no-recovery (:recovery data)) "no back-compat alias / recovery")))
+    (testing "the full dispatch path (not just build-envelope) raises it"
+      (rf/reg-event-db :wi/retired-noop (fn [db _] db))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (rf/dispatch-sync [:wi/retired-noop]
+                                     {:frame :wi/retired-supply
+                                      :dispatched-at 123}))
+          "dispatch-sync surfaces the retirement hard error synchronously"))))
+
 ;; ===========================================================================
 ;; rf2-sppf0m: a handler READS :uuid / :random from the :rf.world/inputs
 ;; coeffect and WRITES the supplied values into a durable app-db entity.

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -878,6 +878,8 @@ Like the other framework coeffects, `:rf.world/inputs` is **filtered out of the 
 
 The earlier optional `:dispatched-at` envelope field is **gone** — retired in the same change that landed the envelope stamp (no coexistence window), per [EP-0010 disposition 5](../docs/EP/EP-0010-causal-world-inputs.md#open-issues). Two spellings of "when was this dispatched" violate one-name-per-fact ([EP-0007](../docs/EP/EP-0007-one-name-per-fact.md)); the *durable* causal-time fact is now `(:time-ms (:rf.world/inputs envelope))`, and the *diagnostic* dispatch-time need is the trace event's own `:time` stamp (Spec 009 — ambient by design). Durable code reads `:rf.world/inputs`.
 
+Per the standard retirement treatment (EP-0007 rule 2 — a hard error naming the replacement, never a silent alias), supplying `:dispatched-at` in a `dispatch` / `dispatch-sync` opts map is a **hard error** (`:rf.error/dispatched-at-retired`) that names `(:time-ms (:rf.world/inputs envelope))` as the replacement — not the generic unknown-opt warning. The error fires in production too (it is a correctness contract, not a dev diagnostic).
+
 ## View ergonomics (the hard part)
 
 > **Pattern vs. CLJS reference:**


### PR DESCRIPTION
## What

EP-0010 disposition 5 / rider b retired the `:dispatched-at` dispatch opt under the **standard retirement treatment** (EP-0007 one-name-per-fact rule 2): *a hard error naming the replacement, never a silent alias.* What shipped only removed the field; a caller still passing `:dispatched-at` fell through to the generic dev-only `:rf.warning/unknown-dispatch-opt` WARN — DCE'd in production, and naming neither the retirement nor the replacement. That is softer than the ruled treatment (rf2-lj39cn, filed by EP-0010 review rf2-cc25b9).

This makes supplying `:dispatched-at` a **hard error** that names the canonical replacement.

## How

- `re-frame.router.diagnostics/reject-retired-dispatch-opts!` — throws `:rf.error/dispatched-at-retired` (ex-info) when `opts` contains `:dispatched-at`. The message names `(:time-ms (:rf.world/inputs envelope))` as the durable causal-time replacement and points at the trace event's ambient `:time` for the diagnostic need (Spec 009). `:recovery :no-recovery`; no back-compat alias.
- Called **first** in `build-envelope` — ahead of the generic unknown-opt warn — so the specific retirement error wins over the vague "key outside the known set" message.
- **Always-on** (not gated on `interop/debug-enabled?`): a retirement hard error is a correctness contract that must fire in `:advanced` + `goog.DEBUG=false` production too. Mirrors the `:rf.error/redirect-retired-target-key` SSR precedent. The only always-on cost is one `contains?` lookup; no allocation unless the retired key is present.
- Spec 002 §`:dispatched-at` is retired documents the supply-side hard error.

## Error shape

```clojure
(ex-info ":rf.error/dispatched-at-retired"
  {:rf.error/id :rf.error/dispatched-at-retired
   :where       're-frame.router/build-envelope
   :event-id    <first event>
   :event       <event>
   :retired-key :dispatched-at
   :replacement '(:time-ms (:rf.world/inputs envelope))
   :reason      "... durable causal-time fact is `(:time-ms (:rf.world/inputs envelope))` ... no back-compat alias."
   :recovery    :no-recovery})
```

## Tests

`world_inputs_test/dispatched-at-supplied-is-a-hard-error`: supplying `:dispatched-at` throws at both `build-envelope` and the full `dispatch-sync` path (and with the dev gate OFF — prod-survivable); the error carries `:rf.error/dispatched-at-retired` and its message references `:time-ms` and `:rf.world/inputs`.

## Quality gates

- `scripts/check_retired_spellings.py` — exit 0 (green)
- `scripts/check_ambient_durable_reads.py` (EP-0010 ambient-read lint) — exit 0 (green)
- core `clojure -M:test` — 1191 tests / 5276 assertions, 0 failures, 0 errors
- `npm run test:cljs` — 6572 tests / 24016 assertions, 0 failures, 0 errors
