### PR TITLE
fix(resources): EP-0011 resource/mutation stale emits canonical :status :stale via substrate + production tests (rf2-mn4j89 rf2-jzh5gq rf2-hh8nzd rf2-uwqs7l)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -866,6 +866,76 @@
 ;; generation before writing (Spec 016 §Transport — stale suppression is
 ;; the correctness boundary). User code MUST NOT dispatch them.
 
+(defn- entry-current-generation
+  "Read the LIVE counterpart generation for a stale-suppression gate: the
+  `:generation` of the entry currently occupying `resource-key` at
+  completion. nil when no entry occupies the slot (it was removed / GC'd /
+  cleared — no live counterpart, exactly the supersession the gate records).
+  This is the `:current` half of the carried-vs-current pair the canonical
+  stale reply carries; the `:carried` half is the generation stamped on the
+  reply token (`(:generation payload)`)."
+  [runtime-db resource-key]
+  (:generation (get-in runtime-db (state/entry-path resource-key))))
+
+(defn- stale-suppress-reply
+  "Build the canonical `:status :stale` reply outcome for a superseded /
+  vanished RESOURCE reply through the SHARED `re-frame.reply` substrate
+  (via `rreply/stale-reply`), so the resource family lowers its stale
+  outcome exactly as every other managed-async family does (Managed-Effects
+  §Stale suppression). The carried correlation is the reply token's
+  `:work/id` + `:generation`; the current correlation is the live entry's
+  `:generation` (nil when the slot is gone — no live counterpart). The
+  result rides `:rf.reply/status :stale` / `:rf.reply/work-status
+  :suppressed` / `:rf.reply/stale-reason` / the carried-vs-current
+  generation pair ADDITIVELY onto the existing `:rf.resource/stale-
+  suppressed` trace via `emit-resource-stale-suppressed!`.
+
+  Returns the `re-frame.reply/suppress` outcome map (`:deliver?` is false —
+  the app reply target MUST NOT run; `:reply` is the data-only `:status
+  :stale` reply; `:work/status :suppressed`). `extra` threads diagnostic
+  facts (e.g. `:outcome`) onto the stale reply."
+  [runtime-db resource-key {work-id :work/id :keys [generation scope] :as payload} extra]
+  (let [carried-gen (:generation payload)
+        current-gen (entry-current-generation runtime-db resource-key)]
+    (rreply/stale-reply
+      {:carried {:work/id work-id :generation carried-gen}
+       :current {:generation current-gen}
+       :extra   (merge {:work/id      work-id
+                        :work/kind    rreply/work-kind-resource
+                        :stale/reason :rf.resource/superseded
+                        :correlation  (cond-> {:generation {:carried carried-gen
+                                                             :current current-gen}}
+                                        (some? resource-key) (assoc :resource-key resource-key)
+                                        (some? scope)         (assoc :scope scope))}
+                       extra)})))
+
+(defn- emit-resource-stale-suppressed!
+  "Emit the `:rf.resource/stale-suppressed` trace for a suppressed late
+  resource reply, carrying its bespoke facts (`:resource-key` / `:work-id` /
+  `:generation` / `:outcome`) PLUS the canonical reply-envelope vocabulary
+  ADDITIVELY (joined to `:work/id` via the shared `:rf.reply/*` facts):
+  `:rf.reply/status :stale`, `:rf.reply/work-status :suppressed`,
+  `:rf.reply/stale-reason`, `:rf.reply/work-id`, and `:rf.reply/correlation`
+  (the carried-vs-current generation gate) — the SAME additive shape the
+  machine `:rf.machine/done` and HTTP / probe stale paths ride (Managed-
+  Effects §Tracing / EP-0011). `stale` is the `stale-suppress-reply`
+  outcome; its trace summary routes wire slots through the shared elider via
+  `rreply/trace-reply`."
+  [frame-id resource-key work-id generation outcome stale]
+  (let [summary (rreply/trace-reply (:reply stale))]
+    (trace/emit! :rf.event :rf.resource/stale-suppressed
+                 {:rf.frame/id frame-id :resource-key resource-key
+                  :work-id work-id :generation generation :outcome outcome
+                  ;; reply-envelope vocabulary (Managed-Effects §9) — the
+                  ;; canonical :status :stale reply produced via the shared
+                  ;; substrate, recorded ADDITIVELY (the bespoke facts above
+                  ;; are preserved).
+                  :rf.reply/status      (:status summary)
+                  :rf.reply/work-status (:work/status summary)
+                  :rf.reply/work-id     (:work/id summary)
+                  :rf.reply/stale-reason (:stale/reason summary)
+                  :rf.reply/correlation (:correlation summary)})))
+
 (defn- live-entry-for-reply
   "Look the live entry up for an internal reply and verify it is still the
   one the reply belongs to: the reply's stamped `:rf.frame/id` equals the
@@ -1021,17 +1091,25 @@
         entry      (live-entry-for-reply runtime-db frame-id payload)]
     (if (nil? entry)
       ;; STALE SUPPRESSION (mandatory): a superseded / vanished reply never
-      ;; mutates a newer entry. Settle its (already-superseded) work row to a
-      ;; terminal :suppressed outcome if it still exists, and clear the host
-      ;; handle. Per Spec 016 §Cancellation is opportunistic; stale
-      ;; suppression is mandatory.
-      (do (trace/emit! :rf.event :rf.resource/stale-suppressed
-                       {:rf.frame/id frame-id :resource-key resource-key
-                        :work-id work-id :generation generation :outcome :success})
-          (work-ledger/clear-handle! frame-id work-id)
-          {:rf.db/runtime (work-ledger/update-record
-                            runtime-db work-id work-ledger/mark-terminal
-                            :suppressed {:reason :stale-reply :outcome :success})})
+      ;; mutates a newer entry. Per Managed-Effects §Stale suppression the
+      ;; completion is recorded `:status :stale` / `:work/status :suppressed`
+      ;; through the SHARED `re-frame.reply` substrate (via
+      ;; `rreply/stale-reply`), exactly as every other managed-async family
+      ;; lowers its stale outcome — the canonical reply built above
+      ;; (`rreply/success-reply`) is the SUCCESS reply for the live path; the
+      ;; nil-entry path produces the canonical STALE reply instead. The app
+      ;; reply target MUST NOT run (no live entry to settle), the
+      ;; (already-superseded) work row settles terminal `:suppressed`, and the
+      ;; host handle is cleared. Per Spec 016 §Cancellation is opportunistic;
+      ;; stale suppression is mandatory.
+      (let [stale (stale-suppress-reply runtime-db resource-key payload
+                                        {:outcome :success})]
+        (emit-resource-stale-suppressed!
+          frame-id resource-key work-id generation :success stale)
+        (work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (work-ledger/update-record
+                          runtime-db work-id work-ledger/mark-terminal
+                          :suppressed {:reason :stale-reply :outcome :success})})
       (let [spec      (registry/resource-meta (:resource/id entry))
             ;; the durable entry stores the canonical reply's `:value` under
             ;; `:data` (the entry layer's spelling of the same fact — the
@@ -1168,21 +1246,29 @@
         entry      (live-entry-for-reply runtime-db frame-id payload)]
     (cond
       ;; STALE SUPPRESSION (mandatory): a superseded / vanished reply (failure
-      ;; OR abort) never mutates a newer entry. Settle its work row terminal +
-      ;; clear the handle. An aborted stale reply settles :cancelled (it was a
-      ;; cancellation); a failed stale reply settles :suppressed.
+      ;; OR abort) never mutates a newer entry. Per Managed-Effects §Stale
+      ;; suppression the completion is recorded `:status :stale` /
+      ;; `:work/status :suppressed` through the SHARED `re-frame.reply`
+      ;; substrate (via `stale-suppress-reply`), and the canonical reply-
+      ;; envelope vocabulary rides ADDITIVELY on the `:rf.resource/stale-
+      ;; suppressed` trace. STALE VALIDATION WINS OVER NATURAL STATUS
+      ;; (rf2-jzh5gq): once the reply no longer correlates with a live target
+      ;; the ledger row is ALWAYS `:suppressed` — never an accepted
+      ;; `:cancelled`. A stale abort can never be an accepted cancellation:
+      ;; there is no live target to cancel. The `:outcome` diagnostic still
+      ;; distinguishes `:aborted` from `:failure` for tooling.
       (nil? entry)
-      (do (trace/emit! :rf.event :rf.resource/stale-suppressed
-                       {:rf.frame/id frame-id :resource-key resource-key
-                        :work-id work-id :generation generation
-                        :outcome (if aborted? :aborted :failure)})
-          (work-ledger/clear-handle! frame-id work-id)
-          {:rf.db/runtime (work-ledger/update-record
-                            runtime-db work-id work-ledger/mark-terminal
-                            (if aborted? :cancelled :suppressed)
-                            (if aborted?
-                              {:reason :aborted}
-                              {:reason :stale-reply :outcome :failure}))})
+      (let [stale (stale-suppress-reply runtime-db resource-key payload
+                                        {:outcome (if aborted? :aborted :failure)})]
+        (emit-resource-stale-suppressed!
+          frame-id resource-key work-id generation
+          (if aborted? :aborted :failure) stale)
+        (work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (work-ledger/update-record
+                          runtime-db work-id work-ledger/mark-terminal
+                          :suppressed
+                          {:reason :stale-reply
+                           :outcome (if aborted? :aborted :failure)})})
 
       ;; ABORT (rf2-z70ujl): an intentional cancellation reached the failure
       ;; reply seam. Settle the LIVE attempt to a non-error stable state, mark
@@ -1373,8 +1459,9 @@
   the suppression in trace for tools. Per Spec 016 §Cancellation is
   opportunistic; stale suppression is mandatory."
   [{rt :rf.db/runtime, frame-id :rf.frame/id}
-   [_event-id {work-id :work/id :keys [resource-key generation]}]]
-  (trace/emit! :rf.event :rf.resource/stale-suppressed
-               {:rf.frame/id frame-id :resource-key resource-key
-                :work-id work-id :generation generation})
-  {:rf.db/runtime (or rt {})})
+   [_event-id {work-id :work/id :keys [resource-key generation] :as payload}]]
+  (let [runtime-db (or rt {})
+        stale      (stale-suppress-reply runtime-db resource-key payload nil)]
+    (emit-resource-stale-suppressed!
+      frame-id resource-key work-id generation nil stale)
+    {:rf.db/runtime runtime-db}))

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -487,17 +487,107 @@
 
 (defn- live-instance-for-reply
   "Look the live mutation instance up for an internal reply and verify it is
-  still the one the reply belongs to: the instance exists AND its
-  `:current-work` equals the reply's `:work/id` AND its `:generation`
+  still the one the reply belongs to: the reply's stamped `:rf.frame/id`
+  equals the RECEIVING frame (`receiving-frame-id`), the instance exists,
+  its `:current-work` equals the reply's `:work/id`, AND its `:generation`
   equals the reply's `:generation`. Returns the instance on a match, nil on
-  a stale / superseded / cleared reply (which MUST be suppressed). Mirrors
-  the resource `live-entry-for-reply`. The verification work identity is
-  `:work/id` (EP-0007 — one attempt, one work id, one name)."
-  [runtime-db {work-id :work/id :keys [instance-id generation]}]
-  (when-let [inst (get-in runtime-db (mstate/instance-path instance-id))]
-    (when (and (= work-id (:current-work inst))
-               (= generation (:generation inst)))
-      inst)))
+  a cross-frame / stale / superseded / cleared reply (which MUST be
+  suppressed). Mirrors the resource `live-entry-for-reply`.
+
+  FRAME VERIFICATION (rf2-jzh5gq, the mutation analogue of rf2-eu2ifi): the
+  managed-HTTP transport stamps the qualified `:rf.frame/id` into every
+  reply payload at lowering (`transport/http.cljc`); the reply handler runs
+  in the RECEIVING frame's cofx. A reply whose payload frame does not match
+  the receiving frame is REJECTED without touching this frame's instance or
+  ledger — with two frames using the same mutation instance / generation, a
+  misrouted reply can no longer settle the WRONG frame. The frame stamp is
+  checked FIRST (before the per-frame instance lookup), so a cross-frame
+  reply is rejected even when both frames happen to hold the same instance
+  at the same generation. A reply with no stamped frame (a direct-dispatch
+  test payload that omits `:rf.frame/id`) skips the frame check (nil never
+  collides with a concrete frame id) and is verified by work-id +
+  generation alone.
+
+  The verification work identity is `:work/id` (EP-0007 — one attempt, one
+  work id, one name)."
+  [runtime-db receiving-frame-id {work-id :work/id :keys [instance-id generation] :as payload}]
+  (let [reply-frame (:rf.frame/id payload)]
+    (when (or (nil? reply-frame) (= reply-frame receiving-frame-id))
+      (when-let [inst (get-in runtime-db (mstate/instance-path instance-id))]
+        (when (and (= work-id (:current-work inst))
+                   (= generation (:generation inst)))
+          inst)))))
+
+(defn- instance-current-generation
+  "Read the LIVE counterpart generation for a stale-suppression gate: the
+  `:generation` of the mutation instance currently occupying `instance-id`
+  at completion. nil when no instance occupies the slot (it was cleared —
+  no live counterpart, exactly the supersession the gate records). The
+  `:current` half of the carried-vs-current pair the canonical stale reply
+  carries; the `:carried` half is the generation stamped on the reply token
+  (`(:generation payload)`)."
+  [runtime-db instance-id]
+  (:generation (get-in runtime-db (mstate/instance-path instance-id))))
+
+(defn- stale-suppress-reply
+  "Build the canonical `:status :stale` reply outcome for a superseded /
+  cleared MUTATION reply through the SHARED `re-frame.reply` substrate (via
+  `rreply/stale-reply`), so the mutation family lowers its stale outcome
+  exactly as every other managed-async family does (Managed-Effects §Stale
+  suppression). The carried correlation is the reply token's `:work/id` +
+  `:generation`; the current correlation is the live instance's
+  `:generation` (nil when the slot is gone — no live counterpart). The
+  result rides `:rf.reply/status :stale` / `:rf.reply/work-status
+  :suppressed` / `:rf.reply/stale-reason` / the carried-vs-current
+  generation pair ADDITIVELY onto the existing `:rf.mutation/stale-
+  suppressed` trace via `emit-mutation-stale-suppressed!`.
+
+  Returns the `re-frame.reply/suppress` outcome map (`:deliver?` false — no
+  durable mutation write, no `:reply-to` continuation; `:reply` is the
+  data-only `:status :stale` reply; `:work/status :suppressed`). `extra`
+  threads diagnostic facts (e.g. `:outcome`) onto the stale reply."
+  [runtime-db {work-id :work/id :keys [instance-id generation scope mutation-id] :as payload} extra]
+  (let [carried-gen (:generation payload)
+        current-gen (instance-current-generation runtime-db instance-id)]
+    (rreply/stale-reply
+      {:carried {:work/id work-id :generation carried-gen}
+       :current {:generation current-gen}
+       :extra   (merge {:work/id      work-id
+                        :work/kind    rreply/work-kind-mutation
+                        :stale/reason :rf.mutation/superseded
+                        :correlation  (cond-> {:generation {:carried carried-gen
+                                                             :current current-gen}}
+                                        (some? instance-id)  (assoc :instance/id instance-id)
+                                        (some? mutation-id)  (assoc :mutation/id mutation-id)
+                                        (some? scope)         (assoc :scope scope))}
+                       extra)})))
+
+(defn- emit-mutation-stale-suppressed!
+  "Emit the `:rf.mutation/stale-suppressed` trace for a suppressed late
+  mutation reply, carrying its bespoke facts (`:instance` / `:work-id` /
+  `:generation` / `:outcome`) PLUS the canonical reply-envelope vocabulary
+  ADDITIVELY (joined to `:work/id` via the shared `:rf.reply/*` facts):
+  `:rf.reply/status :stale`, `:rf.reply/work-status :suppressed`,
+  `:rf.reply/stale-reason`, `:rf.reply/work-id`, and `:rf.reply/correlation`
+  (the carried-vs-current generation gate) — the SAME additive shape the
+  machine `:rf.machine/done` and the resource stale path ride (Managed-
+  Effects §Tracing / EP-0011). `stale` is the `stale-suppress-reply`
+  outcome; its trace summary routes wire slots through the shared elider via
+  `rreply/trace-reply`."
+  [frame-id instance-id work-id generation outcome stale]
+  (let [summary (rreply/trace-reply (:reply stale))]
+    (trace/emit! :rf.event :rf.mutation/stale-suppressed
+                 {:rf.frame/id frame-id :instance instance-id
+                  :work-id work-id :generation generation :outcome outcome
+                  ;; reply-envelope vocabulary (Managed-Effects §9) — the
+                  ;; canonical :status :stale reply produced via the shared
+                  ;; substrate, recorded ADDITIVELY (the bespoke facts above
+                  ;; are preserved).
+                  :rf.reply/status      (:status summary)
+                  :rf.reply/work-status (:work/status summary)
+                  :rf.reply/work-id     (:work/id summary)
+                  :rf.reply/stale-reason (:stale/reason summary)
+                  :rf.reply/correlation (:correlation summary)})))
 
 ;; The managed-HTTP transport APPENDS its PUBLIC reply payload as the LAST
 ;; arg of the internal reply event (Spec 014 §Reply addressing), exactly as
@@ -573,18 +663,23 @@
                                          {:work-kind rreply/work-kind-mutation
                                           :completed-at completed-at})
         result     (:value reply)
-        inst       (live-instance-for-reply runtime-db payload)]
+        inst       (live-instance-for-reply runtime-db frame-id payload)]
     (if (nil? inst)
-      ;; STALE SUPPRESSION (mandatory): a superseded / cleared reply never
-      ;; mutates a newer instance. Settle the (already-superseded) work row
-      ;; terminal + clear the host handle.
-      (do (trace/emit! :rf.event :rf.mutation/stale-suppressed
-                       {:rf.frame/id frame-id :instance instance-id
-                        :work-id work-id :generation generation :outcome :success})
-          (work-ledger/clear-handle! frame-id work-id)
-          {:rf.db/runtime (work-ledger/update-record
-                            runtime-db work-id work-ledger/mark-terminal
-                            :suppressed {:reason :stale-reply :outcome :success})})
+      ;; STALE SUPPRESSION (mandatory): a superseded / cleared / cross-frame
+      ;; reply never mutates a newer (or another frame's) instance — NO
+      ;; durable write. Per Managed-Effects §Stale suppression the completion
+      ;; is recorded `:status :stale` / `:work/status :suppressed` through the
+      ;; SHARED `re-frame.reply` substrate (via `stale-suppress-reply`), and
+      ;; the canonical reply-envelope vocabulary rides ADDITIVELY on the
+      ;; `:rf.mutation/stale-suppressed` trace. Settle the (already-superseded)
+      ;; work row terminal + clear the host handle.
+      (let [stale (stale-suppress-reply runtime-db payload {:outcome :success})]
+        (emit-mutation-stale-suppressed!
+          frame-id instance-id work-id generation :success stale)
+        (work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (work-ledger/update-record
+                          runtime-db work-id work-ledger/mark-terminal
+                          :suppressed {:reason :stale-reply :outcome :success})})
       (let [spec        (mreg/mutation-meta mutation-id)
             params      (:params inst)
             timing      (or (:invalidate-timing spec) :after-success)
@@ -711,15 +806,22 @@
                                          {:work-kind rreply/work-kind-mutation
                                           :completed-at completed-at})
         error      (:error reply)
-        inst       (live-instance-for-reply runtime-db payload)]
+        inst       (live-instance-for-reply runtime-db frame-id payload)]
     (if (nil? inst)
-      (do (trace/emit! :rf.event :rf.mutation/stale-suppressed
-                       {:rf.frame/id frame-id :instance instance-id
-                        :work-id work-id :generation generation :outcome :failure})
-          (work-ledger/clear-handle! frame-id work-id)
-          {:rf.db/runtime (work-ledger/update-record
-                            runtime-db work-id work-ledger/mark-terminal
-                            :suppressed {:reason :stale-reply :outcome :failure})})
+      ;; STALE SUPPRESSION (mandatory): a superseded / cleared / cross-frame
+      ;; failure reply never mutates a newer (or another frame's) instance —
+      ;; NO durable write, NO `:reply-to` continuation. The completion is
+      ;; recorded `:status :stale` / `:work/status :suppressed` through the
+      ;; SHARED `re-frame.reply` substrate (via `stale-suppress-reply`), with
+      ;; the canonical reply-envelope vocabulary riding ADDITIVELY on the
+      ;; `:rf.mutation/stale-suppressed` trace.
+      (let [stale (stale-suppress-reply runtime-db payload {:outcome :failure})]
+        (emit-mutation-stale-suppressed!
+          frame-id instance-id work-id generation :failure stale)
+        (work-ledger/clear-handle! frame-id work-id)
+        {:rf.db/runtime (work-ledger/update-record
+                          runtime-db work-id work-ledger/mark-terminal
+                          :suppressed {:reason :stale-reply :outcome :failure})})
       (let [spec     (mreg/mutation-meta mutation-id)
             params   (:params inst)
             timing   (or (:invalidate-timing spec) :after-success)

--- a/implementation/resources/test/re_frame/resources_lifecycle_trace_ops_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_lifecycle_trace_ops_cljs_test.cljc
@@ -35,6 +35,7 @@
    [re-frame.resources]
    [re-frame.resources.ssr :as ssr]
    [re-frame.resources.state :as state]
+   [re-frame.resources.work-ledger :as work-ledger]
    [re-frame.resources.test-support]
    [re-frame.http-managed]
    [re-frame.schemas]
@@ -259,6 +260,72 @@
             "the stale reply emitted :rf.resource/stale-suppressed")
         (is (not (contains? (ops traces) :rf.resource/work-suppressed))
             ":rf.resource/work-suppressed is never emitted")))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-mn4j89 / rf2-hh8nzd / rf2-uwqs7l — the canonical :status :stale reply
+;; envelope rides the PRODUCTION resource stale-suppression trace. The
+;; behaviour-only test above (and the work-ledger / invalidation-GC stale
+;; tests) PASSED SILENTLY while the production stale branch discarded the
+;; canonical reply: it emitted a bespoke trace with carried-generation ONLY
+;; and never lowered through the shared `re-frame.reply` substrate. These
+;; assertions FAIL before rf2-mn4j89 and pin the fix — the SAME envelope
+;; shape the machine `:rf.machine/done` stale path pins.
+;; ---------------------------------------------------------------------------
+
+(deftest stale-suppressed-trace-carries-canonical-reply-envelope
+  (rf/reg-resource :rev/article (article-spec))
+  (testing "rf2-mn4j89 — a superseded resource reply (carried gen 1 vs current
+            gen 2) is recorded :status :stale / :work/status :suppressed via
+            the shared substrate, with the carried-vs-current generation pair
+            on the production :rf.resource/stale-suppressed trace; the app
+            target does NOT run (no entry write) and the ledger is :suppressed"
+    (let [scoped-key (state/scoped-resource-key :rf.scope/global :rev/article {:slug "w"})]
+      (rf/dispatch-sync
+        [:rf.resource/ensure {:resource :rev/article :scope :rf.scope/global
+                              :params {:slug "w"} :owner [:lease :rev 1]}])
+      (let [wid1 (:current-work (entry scoped-key))
+            traces
+            (record-resource-traces!
+              (fn []
+                ;; supersede with a refetch (mints generation 2), then land the
+                ;; OLD (generation-1) reply — the REAL production stale path.
+                (rf/dispatch-sync
+                  [:rf.resource/refetch {:resource :rev/article :scope :rf.scope/global
+                                         :params {:slug "w"}}])
+                (rf/dispatch-sync
+                  [:rf.resource.internal/succeeded
+                   {:resource-key scoped-key :work/id wid1 :generation 1
+                    :data {:stale "data"}}])))
+            sup  (first (by-op traces :rf.resource/stale-suppressed))]
+        (is (some? sup) ":rf.resource/stale-suppressed fired for the stale reply")
+        (let [tags (:tags sup)]
+          ;; bespoke facts preserved (additive, not replaced)
+          (is (= scoped-key (:resource-key tags)))
+          (is (= wid1       (:work-id tags)))
+          (is (= :success   (:outcome tags)) "the stale reply's natural outcome diagnostic")
+          ;; CANONICAL reply-envelope vocabulary via the shared substrate
+          (is (= :stale (:rf.reply/status tags))
+              "the canonical :status :stale reply IS produced via re-frame.reply")
+          (is (= :suppressed (:rf.reply/work-status tags))
+              "the ledger terminal for a stale completion")
+          (is (= :rf.resource/superseded (:rf.reply/stale-reason tags)))
+          (is (= wid1 (:rf.reply/work-id tags)) "joined to :work/id")
+          ;; the carried-vs-current generation pair IS the supersession gate
+          (let [corr (:rf.reply/correlation tags)]
+            (is (= 1 (-> corr :generation :carried))
+                "carried generation off the stale reply token")
+            (is (= 2 (-> corr :generation :current))
+                "current generation is the LIVE entry's generation (gen 2)")
+            (is (= scoped-key (:resource-key corr)))))
+        ;; (2)/(5) the app target did NOT run — the entry was NOT overwritten by
+        ;; the stale reply (still on gen 2, not :loaded with {:stale "data"}).
+        (let [e (entry scoped-key)]
+          (is (= 2 (:generation e)) "the stale reply did not touch the newer entry")
+          (is (not= {:stale "data"} (:data e)) "stale data was NOT written"))
+        ;; (3) the ledger row settles terminal :suppressed.
+        (is (= :suppressed (:status (work-ledger/get-record
+                                      (rf/runtime-db-value :rf/default) wid1)))
+            "the work row settled terminal :suppressed")))))
 
 (deftest cache-hit-emitted-on-fresh-ensure
   ;; no :stale-after-ms → the entry is always fresh once loaded

--- a/implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc
@@ -367,9 +367,16 @@
           (is (= 2 (:generation e)) "entry still on gen 2")
           (is (= :loading (:status e)) "gen-2 attempt still in flight")
           (is (some? (:current-work e)) "gen-2 work pointer intact"))
-        (testing "the STALE gen-1 work row settles :cancelled (it was a
-                  cancellation), not :suppressed-as-failure"
-          (is (= :cancelled (:status (work-ledger/get-record (runtime-db) gen1-wid)))))))))
+        (testing "rf2-jzh5gq — STALE VALIDATION WINS over the natural status:
+                  once the reply no longer correlates with a live target the
+                  STALE gen-1 work row settles :suppressed, NOT an accepted
+                  :cancelled (a stale abort cannot be an accepted cancellation
+                  — there is no live target to cancel; the :aborted outcome is
+                  kept as a diagnostic)"
+          (let [rec (work-ledger/get-record (runtime-db) gen1-wid)]
+            (is (= :suppressed (:status rec)))
+            (is (= :aborted (:outcome (:outcome rec)))
+                "the abort nature is retained as a diagnostic outcome")))))))
 
 (deftest owner-release-orphan-abort-does-not-set-entry-error
   ;; the end-to-end orphan path: an in-flight first load whose last owner is

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -49,6 +49,7 @@
    [re-frame.http-managed]
    [re-frame.schemas]
    [re-frame.test-support :as core-test-support]
+   [re-frame.trace.tooling :as trace-tooling]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
        :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
 
@@ -105,6 +106,21 @@
 (defn- reply-failure!
   ([args failure] (rf/dispatch-sync (conj (:on-failure args) {:kind :failure :failure failure})))
   ([args failure opts] (rf/dispatch-sync (conj (:on-failure args) {:kind :failure :failure failure}) opts)))
+
+(defn- record-mutation-traces!
+  "Run `body-fn` with a trace listener installed; return the vector of every
+  `:rf.mutation/*`-operation trace event emitted during it (capture order)."
+  [body-fn]
+  (let [seen (atom [])
+        k    ::mutation-trace-recorder]
+    (trace-tooling/register-listener!
+      k (fn [ev]
+          (when (and (keyword? (:operation ev))
+                     (= "rf.mutation" (namespace (:operation ev))))
+            (swap! seen conj ev))))
+    (try (body-fn)
+         (finally (trace-tooling/unregister-listener! k)))
+    @seen))
 
 (defn- save-article-spec
   ([] (save-article-spec {}))
@@ -561,6 +577,90 @@
       (reply-success! @last-managed-args {:fresh "result"})
       (is (= :success (:status (instance :i))))
       (is (= {:fresh "result"} (:result (instance :i)))))))
+
+(deftest stale-mutation-suppressed-trace-carries-canonical-reply-envelope
+  ;; rf2-mn4j89 / rf2-hh8nzd / rf2-uwqs7l — the canonical :status :stale reply
+  ;; envelope rides the PRODUCTION mutation stale-suppression trace. The
+  ;; behaviour-only `stale-mutation-reply-suppressed` above PASSED SILENTLY
+  ;; while the production stale branch discarded the canonical reply; these
+  ;; assertions FAIL before rf2-mn4j89 and pin the fix.
+  (rf/reg-mutation :m/save (save-article-spec))
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :rv}])
+  (let [gen1-args @last-managed-args]
+    ;; supersede with a second execute under the SAME instance id → gen 2 live.
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :rv}])
+    (is (= 2 (:generation (instance :rv))))
+    (testing "rf2-mn4j89 — the STALE gen-1 reply is recorded :status :stale /
+              :work/status :suppressed via the shared substrate, with the
+              carried-vs-current (1 vs 2) generation pair on the production
+              :rf.mutation/stale-suppressed trace; NO durable write"
+      (let [wid1   (-> gen1-args :on-success (nth 1) :work/id)
+            traces (record-mutation-traces!
+                     #(reply-success! gen1-args {:stale "result"}))
+            sup    (first (filterv #(= :rf.mutation/stale-suppressed (:operation %)) traces))]
+        (is (some? sup) ":rf.mutation/stale-suppressed fired for the stale reply")
+        (let [tags (:tags sup)]
+          ;; bespoke facts preserved (additive, not replaced)
+          (is (= :rv      (:instance tags)))
+          (is (= :success (:outcome tags)))
+          ;; CANONICAL reply-envelope vocabulary via the shared substrate
+          (is (= :stale (:rf.reply/status tags))
+              "the canonical :status :stale reply IS produced via re-frame.reply")
+          (is (= :suppressed (:rf.reply/work-status tags)))
+          (is (= :rf.mutation/superseded (:rf.reply/stale-reason tags)))
+          (is (= wid1 (:rf.reply/work-id tags)) "joined to :work/id")
+          (let [corr (:rf.reply/correlation tags)]
+            (is (= 1 (-> corr :generation :carried)) "carried gen off the stale token")
+            (is (= 2 (-> corr :generation :current)) "current = the LIVE instance gen")
+            (is (= :rv (:instance/id corr)))))
+        ;; (2)/(5) the app target did NOT run — the instance was NOT settled
+        ;; by the stale reply (still :pending on gen 2, no :result written).
+        (let [i (instance :rv)]
+          (is (= :pending (:status i)) "instance still pending on the current gen")
+          (is (= 2 (:generation i)) "generation unchanged")
+          (is (nil? (:result i)) "stale reply did NOT write a result"))))))
+
+;; ===========================================================================
+;; 7b. rf2-jzh5gq — a mutation reply whose stamped :rf.frame/id does not match
+;;     the RECEIVING frame is REJECTED (the mutation analogue of the resource
+;;     cross-frame reply test). Two frames at the same instance/generation: a
+;;     misrouted reply must NOT durably settle the wrong frame.
+;; ===========================================================================
+
+(deftest cross-frame-mutation-reply-rejected-without-mutating-receiving-frame
+  (rf/reg-mutation :m/save (save-article-spec))
+  (let [all-args (atom [])]
+    (rf/reg-fx :rf.http/managed (fn [_ctx args] (swap! all-args conj args) nil))
+    (let [fa :xfm/frame-a
+          fb :xfm/frame-b]
+      (rf/reg-frame fa {:doc "frame A"})
+      (rf/reg-frame fb {:doc "frame B"})
+      ;; both frames execute the SAME mutation under the SAME instance id →
+      ;; the SAME frame-local work-id + generation in each frame.
+      (rf/dispatch-sync [:rf.mutation/execute
+                         {:mutation :m/save :params {:slug "w"} :instance :form/x}]
+                        {:frame fa})
+      (rf/dispatch-sync [:rf.mutation/execute
+                         {:mutation :m/save :params {:slug "w"} :instance :form/x}]
+                        {:frame fb})
+      (let [args-a (first @all-args)]
+        (testing "rf2-jzh5gq — frame A's reply (payload stamped :rf.frame/id = A)
+                  dispatched INTO frame B is rejected: frame B's pending
+                  instance is NOT settled (no cross-frame durable write even at
+                  the same instance/generation)"
+          ;; dispatch frame A's reply (its payload carries :rf.frame/id = A)
+          ;; into the WRONG frame B.
+          (rf/dispatch-sync (conj (:on-success args-a) {:kind :success :value {:ok true}})
+                            {:frame fb})
+          (is (= :pending (:status (instance fb :form/x)))
+              "frame B's instance untouched by frame A's misrouted reply")
+          (is (nil? (:result (instance fb :form/x))) "no cross-frame result written")
+          (is (= :pending (:status (instance fa :form/x)))
+              "frame A's own instance also still pending (its reply went to B)"))
+        (testing "frame A's reply dispatched into frame A DOES settle it"
+          (rf/dispatch-sync (conj (:on-success args-a) {:kind :success :value {:ok true}})
+                            {:frame fa})
+          (is (= :success (:status (instance fa :form/x))) "frame A settled by its own reply"))))))
 
 ;; ===========================================================================
 ;; 8. :rf.mutation/clear — causal instance reset

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -237,7 +237,19 @@ against [Spec 009 §Where trace emission lives](../../../spec/009-Instrumentatio
 `:rf.resource/stale-suppressed` is the single suppression op (entry +
 ledger stale/superseded-reply suppression); an earlier draft also named
 `:rf.resource/work-suppressed`, now folded into it (the runtime never
-emitted a distinct work-suppressed row). `:rf.resource/cache-hit` is a
+emitted a distinct work-suppressed row). It carries the canonical
+reply-envelope vocabulary ADDITIVELY (rf2-mn4j89) — `:rf.reply/status
+:stale`, `:rf.reply/work-status :suppressed`, `:rf.reply/work-id`,
+`:rf.reply/stale-reason` (`:rf.resource/superseded`), and
+`:rf.reply/correlation` (the carried-vs-current generation gate,
+`:generation {:carried N :current M}`) — produced through the shared
+`re-frame.reply` substrate, so a suppressed late resource reply classifies
+the SAME way the HTTP / mutation / machine stale paths do (the bespoke
+`:resource-key` / `:work-id` / `:generation` / `:outcome` facts are
+preserved alongside). The mutation analogue `:rf.mutation/stale-suppressed`
+carries the identical `:rf.reply/*` shape (`:rf.reply/stale-reason
+:rf.mutation/superseded`, correlation `:instance/id` + the generation
+gate). `:rf.resource/cache-hit` is a
 FRESH-SKIP ensure — an `ensure` of an already-`:loaded` entry still
 fresh-by-policy serves the cached value (no fetch, no in-flight join),
 which the panel colours `:dedupe`; distinct from `:rf.resource/deduped`


### PR DESCRIPTION
## Summary

The resources/mutations counterpart to the machines spawn-stale work (PR #3908). Both EP-0011 correctness/coverage audits (rf2-z987m3, rf2-h8xw2v) found that the resource/mutation stale branches suppress safely but **discard the canonical reply** on the nil-entry path — they emit a bespoke trace carrying the carried generation only, never lowering through the shared `re-frame.reply` substrate. The `rreply/stale-reply` builder was EP-blessed and unit-tested but had **no live production call site** (the same unwired-builder shape the machine spawn path had).

This wires the four production stale branches + the standalone notification handler through the shared substrate, hardens the mutation reply path, and adds production-path conformance tests.

### rf2-mn4j89 — canonical `:status :stale` via the shared substrate
- `events.cljc` (resource success-stale, failure/abort-stale, standalone `stale-suppressed-handler`) and `mutation_events.cljc` (mutation success/failure stale) now build the canonical `:status :stale` reply via `rreply/stale-reply` → `re-frame.reply/suppress`, riding `:rf.reply/status :stale` + `:rf.reply/work-status :suppressed` + `:rf.reply/stale-reason` + `:rf.reply/work-id` + `:rf.reply/correlation` **additively** on the existing stale-suppressed trace (the same additive shape the machine `:rf.machine/done` stale path rides).
- The trace now carries the **carried-vs-current generation pair** (`:correlation :generation {:carried N :current M}`) — carried = the reply token's generation; current = the LIVE entry/instance generation read from `runtime-db` (nil when the slot is gone). Previously only the carried generation rode the trace.
- `:stale/reason` is `:rf.resource/superseded` / `:rf.mutation/superseded`.
- **Behaviour preserved**: app reply target NOT run, ledger row terminal `:suppressed`, no durable entry/instance mutation, host handle cleared.

### rf2-jzh5gq — mutation reply path hardening
- `live-instance-for-reply` now verifies the reply's stamped `:rf.frame/id` against the RECEIVING frame **before any durable write** (the mutation analogue of the resource rf2-eu2ifi frame check). With two frames at the same instance/generation a misrouted reply can no longer settle the wrong frame.
- the nil-entry stale **abort** branch now settles the ledger row `:suppressed` (stale validation wins over natural status) instead of an accepted `:cancelled` — once a reply no longer correlates with a live target it is suppressed, not cancelled; the `:aborted` nature is kept as a diagnostic outcome.

### rf2-hh8nzd + rf2-uwqs7l — production-path conformance tests
Drive the REAL stale path (not the pure `rreply/stale-reply` builder) with a carried-vs-current generation mismatch and assert the canonical `:status :stale` reply IS produced, the app target is NOT run, and the ledger is `:suppressed` — these **FAIL before the fix** (RED→GREEN verified) where the prior behaviour-only tests passed silently:
- `stale-suppressed-trace-carries-canonical-reply-envelope` (resource)
- `stale-mutation-suppressed-trace-carries-canonical-reply-envelope` (mutation)
- `cross-frame-mutation-reply-rejected-without-mutating-receiving-frame`
- the rf2-jzh5gq stale-abort test updated to expect `:suppressed`.

Xray spec 024 updated to document the additive `:rf.reply/*` vocabulary. Framework spec 016 already required both the frame-verify (§885) and the carried-vs-current correlation trace (§952) — this brings the reference implementation into conformance with the existing spec.

## Quality gates
- `npm run test:cljs` — **6575 tests, 24049 assertions, 0 failures, 0 errors**
- resources `clojure -M:test` (JVM) — **271 tests, 1036 assertions, 0 failures, 0 errors** (up from 268 — 3 new conformance tests)
- RED→GREEN verified: reverting the resource emit helper to the old bespoke shape fails 7 assertions in `stale-suppressed-trace-carries-canonical-reply-envelope`; restored → green.

Closes rf2-mn4j89, rf2-jzh5gq, rf2-hh8nzd, rf2-uwqs7l.