### PR TITLE
feat(xray): surface :rf.world/inputs in the Event lens (rf2-9fyn40)

### DIFF
--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -194,6 +194,41 @@ A registered-flows-overview is reachable via the Cmd-K palette under
 the `:flow` source: flow-id, inputs, output path, last recompute. No
 standalone tab.
 
+## World inputs content — Epoch panel WORLD INPUTS section (rf2-9fyn40 · EP-0010)
+
+The dispatch envelope's causal `:rf.world/inputs` map surfaces as a
+dedicated **WORLD INPUTS section of the Epoch panel placed RIGHT AFTER
+DISPATCH SITE** — the EP-0010 "where did this state value come from?"
+answer (the explicit time / id / randomness / browser facts the fold
+consumed, so a durable write reads as a function of prior frame-state PLUS
+explicit tokens rather than ambient host reads). The canonical home for
+the per-cascade section is [`018-Event-Spine.md`](./018-Event-Spine.md)
+§5.1 (section 1a — the 9-section event lens). **Silent-by-default** when
+the focused cascade surfaced no world-input map.
+
+The runtime stamps the map onto the `:rf.event/dispatched` trace under
+`[:tags :rf.world/inputs]` (rf2-jt854w · `router/emit-dispatched-trace!`,
+DEBUG-gated so it rides the same whole-body production elision as the rest
+of the dispatched emit). The section reads it decoupled — no require on
+core; Xray consumes the WIRE FACTS.
+
+**PRIVACY** (EP-0010 §Privacy / Open Issue 4, ruled 2026-06-11):
+
+- `:time-ms` is **ALWAYS safe to surface** (a wall-clock fact, never PII)
+  and renders **verbatim**.
+- **Every other key is value-bearing and REDACTS BY DEFAULT** — its value
+  is routed through the same summarize/projection path the reply-envelope
+  consumer uses (`resources-helpers/summarize`, mirroring
+  `reply_envelope.cljc`'s wire-slot summarization), so the panel renders a
+  privacy-preserving summary (type + bounded size + a redaction-aware
+  preview; an upstream `:rf/redacted` / `:rf.size/large-elided` sentinel
+  keeps its sentinel status) and **NEVER a raw value**. The KEY itself
+  (`:uuid` / `:random` / `:browser/*` / `:storage` / …) is framework
+  vocabulary, not PII, so it rides verbatim as the row label.
+
+No standalone tab; no palette overview (a world-input map is per-cascade,
+not a registry).
+
 ## Issues — the dedicated tab was REMOVED (rf2-gbz39, Option (c))
 
 **Mike RULED Option (c) (2026-05-31): the dedicated Issues tab + its

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -617,17 +617,18 @@ L4 fills the remaining canvas (60% default; resizable via L2/L3 drag handle). Al
 
 The renderer does NOT depend on `binaryage/cljs-devtools` (that library targets the Chrome console; this is in-page hiccup). Pure hiccup, theme-token-driven, substrate-agnostic. See [`007-UX-IA.md`](007-UX-IA.md) §Detail panel renderer.
 
-### §5.1 Epoch panel content — the 8-section event lens (rf2-5gl5r)
+### §5.1 Epoch panel content — the 9-section event lens (rf2-5gl5r)
 
-Shipped layout per rf2-zh2qc + rf2-jhhqt + rf2-lo37i (rf2-jhhqt swaps
-DISPATCH SITE before EVENT per Mike's Q1 verbatim and adds the COEFFECTS
+Shipped layout per rf2-zh2qc + rf2-jhhqt + rf2-lo37i + rf2-9fyn40 (rf2-jhhqt
+swaps DISPATCH SITE before EVENT per Mike's Q1 verbatim and adds the COEFFECTS
 section; rf2-lo37i adds the FLOWS section as a peer surface to make the
-cascade's flow step first-class). FLOWS sits RIGHT AFTER the HANDLER —
-flows fire at the outermost `:after` interceptor, reshaping the pending
-`:db` before it commits, so the lens reads in true pipeline order
-(handler → flows → committed effects → fx-handlers). Top-of-panel: a
-single-line cascade-outcome summary; below: eight stacked sections that
-read top-to-bottom as the developer scans.
+cascade's flow step first-class; rf2-9fyn40 adds the WORLD INPUTS section
+right after DISPATCH SITE — the EP-0010 causal-provenance surface). FLOWS sits
+RIGHT AFTER the HANDLER — flows fire at the outermost `:after` interceptor,
+reshaping the pending `:db` before it commits, so the lens reads in true
+pipeline order (handler → flows → committed effects → fx-handlers).
+Top-of-panel: a single-line cascade-outcome summary; below: nine stacked
+sections that read top-to-bottom as the developer scans.
 
 ```
 ┌─ Event lens · :cart/add-item                              ✓ ok · 11ms · #347 · SSR✓ ┐
@@ -635,6 +636,10 @@ read top-to-bottom as the developer scans.
 │ ▼ DISPATCH SITE                                                                      │
 │   src/cart/views.cljs:127       [code]                                             │
 │   via :ui · origin :app                                                              │
+│                                                                                      │
+│ ▼ WORLD INPUTS                                                                       │
+│   time-ms  1781078400123                                                             │
+│   :uuid    [redacted]            (value-bearing keys redact by default)              │
 │                                                                                      │
 │ ▼ EVENT                                                                              │
 │   [:cart/add-item {:id 42 :qty 2}]                                                   │
@@ -688,7 +693,7 @@ read top-to-bottom as the developer scans.
   `:rf.ssr/hydrated` / `:rf.ssr/hydration-complete`; omitted for
   purely-client-side cascades.
 
-#### The 8 sections (Mike's verbatim order, rf2-jhhqt + rf2-lo37i)
+#### The 9 sections (Mike's verbatim order, rf2-jhhqt + rf2-lo37i + rf2-9fyn40)
 
 1. **DISPATCH SITE** — source-coord chip + `via :source · origin :origin`
    caption. Reads `:rf.trace/call-site` off the `:rf.event/dispatched`
@@ -696,6 +701,30 @@ read top-to-bottom as the developer scans.
    call-site was captured. **Comes FIRST** per Mike's Q1 — the
    developer's first instinct ("who fired this?") gets the most
    prominent slot.
+1a. **WORLD INPUTS** (rf2-9fyn40 · EP-0010) — the dispatch envelope's
+   causal `:rf.world/inputs` map, surfaced **RIGHT AFTER DISPATCH SITE**
+   (it answers the same orienting "where did this state value come from?"
+   question — the explicit time / id / randomness / browser facts the fold
+   consumed). **Silent-by-default** when the cascade surfaced no world-input
+   map (older runtimes / the production-elided emit arm). Reads the map off
+   the `:rf.event/dispatched` trace's `[:tags :rf.world/inputs]` slot (the
+   substrate stamps it per rf2-jt854w · `router/emit-dispatched-trace!`,
+   DEBUG-gated so it rides the same whole-body production elision as the
+   rest of the dispatched emit; see EP-0010 §Tooling). Each row reads
+   `<key>  <value>`.
+   - **PRIVACY** (EP-0010 §Privacy / Open Issue 4, ruled 2026-06-11):
+     `:time-ms` is **ALWAYS safe to surface** (a wall-clock fact, never PII)
+     and renders **verbatim**. **Every other key is value-bearing and
+     REDACTS BY DEFAULT** — its value is routed through the same
+     summarize/projection path the reply-envelope consumer uses
+     (`resources-helpers/summarize`, mirroring `reply_envelope.cljc`'s
+     wire-slot summarization), so the panel renders a privacy-preserving
+     summary (type + bounded size + a redaction-aware preview; an upstream
+     `:rf/redacted` / `:rf.size/large-elided` sentinel keeps its sentinel
+     status as `[redacted]` / `[large — elided]`) and **NEVER a raw value**.
+     The KEY itself (`:uuid` / `:random` / `:browser/location` / `:storage`
+     / …) is framework vocabulary, not PII, so it rides verbatim as the row
+     label; only the VALUE is summarized.
 2. **EVENT** — the dispatched event vector via `inspector/inspect`.
    Always present.
 3. **COEFFECTS** — user-injected coeffects only, **silent when zero**
@@ -765,6 +794,16 @@ read top-to-bottom as the developer scans.
 
 - **No call-site captured** — DISPATCH SITE shows
   `"source coord unavailable"`; no open chip rendered.
+- **No world-input map** — WORLD INPUTS section ABSENT entirely (silent-by-
+  default — older runtimes, the production-elided emit arm, or fixtures that
+  synthesise an epoch without the `:rf.world/inputs` tag).
+- **World-input map carries only `:time-ms`** — WORLD INPUTS renders the
+  single `time-ms <ms>` row (the time fact is worth surfacing on its own).
+- **Empty world-input map (`{}`)** — WORLD INPUTS section ABSENT (nothing to
+  show).
+- **A value-bearing key was redacted upstream** (`:rf/redacted` for a
+  `:sensitive?` slot) — the row renders `[redacted]`, never the raw value
+  (marks/projection redact by default; only `:time-ms` is exempt).
 - **No user coeffects** — COEFFECTS section ABSENT entirely.
 - **No user interceptors** — INTERCEPTORS section ABSENT entirely.
 - **No effects returned** — EFFECTS RETURNED section ABSENT.

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -1428,13 +1428,14 @@ empty-state line. This matches the §2.2 dynamic-numbering contract
 from the Event lens — both panels share the same "absence is
 silence" rhythm.
 
-### §9.1.4 Badge taxonomy (the 9-badge inventory)
+### §9.1.4 Badge taxonomy (the 10-badge inventory)
 
 Each step renders a uppercase badge pill at its numbered circle:
 
 | Badge | Token | Hue family |
 |-------|-------|------------|
 | `:DISPATCH`           | `:text-tertiary` | muted grey |
+| `:WORLD-INPUTS`       | `:text-secondary` | muted (a step lighter than DISPATCH — rf2-9fyn40; reads as orienting causal-context metadata, EP-0010 provenance, not a pipeline action) |
 | `:COEFFECT`           | `:magenta`       | purple |
 | `:INTERCEPTOR`        | `:accent`        | blue (rf2-yz57h — the chain WRAPS the handler; one identity family) |
 | `:HANDLER`            | `:accent`        | blue (single Xray accent) |

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/badge.cljc
@@ -1,7 +1,7 @@
 (ns day8.re-frame2-xray.panels.epoch.badge
   "Pure-data badge taxonomy for the Epoch panel (rf2-sc3r1).
 
-  Maps each of the 7 cascade step badges → its visual chrome (colour
+  Maps each cascade step badge → its visual chrome (colour
   token + label text). The colour resolver returns a CSS-variable
   string off `theme/tokens` so the panel's badges flow through the
   active theme like every other Xray chrome element.
@@ -58,7 +58,11 @@
 ;;                              couldn't separate them at a glance.)
 ;;     var(--devtools-success) — `:success` / `:green`
 ;;
-;; The 7-badge inventory is binding: the view never paints a badge
+;; rf2-9fyn40 — added :WORLD-INPUTS (EP-0010 causal provenance), pulling
+;; :text-secondary (a step lighter than DISPATCH's :text-tertiary — it
+;; reads as orienting causal-context metadata, not a pipeline action).
+;;
+;; The badge inventory is binding: the view never paints a badge
 ;; whose keyword is not in this map.
 
 (def ^:private badge->token-key
@@ -86,6 +90,13 @@
   the interceptor chain WRAPS the handler; they read as one identity
   family in the cascade, the chain around the handler body)."
   {:DISPATCH          :text-tertiary
+   ;; rf2-9fyn40 — WORLD INPUTS (EP-0010 causal provenance) sits right
+   ;; after DISPATCH SITE and reads as CONTEXT, not a pipeline action.
+   ;; `:text-secondary` (brighter muted) keeps it in the dispatch-site
+   ;; muted-family — a step lighter than DISPATCH's `:text-tertiary` —
+   ;; so the causal-input section reads as orienting metadata rather
+   ;; than competing with the action badges (HANDLER / FLOW accent, etc.).
+   :WORLD-INPUTS      :text-secondary
    :COEFFECT          :magenta
    :INTERCEPTOR       :accent
    :HANDLER           :accent
@@ -99,6 +110,7 @@
   "Map from badge keyword → uppercase label rendered in the badge
   pill. Pure data."
   {:DISPATCH          "DISPATCH"
+   :WORLD-INPUTS      "WORLD INPUTS"
    :COEFFECT          "COEFFECT"
    :INTERCEPTOR       "INTERCEPTOR"
    :HANDLER           "EVENT HANDLER"

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -45,7 +45,8 @@
   `tools/xray/spec/Conventions.md` §Pure-data helpers as `.cljc` — the
   projection is data-in / data-out and runs under both targets.
   `feedback_jvm_interop_must_work.md` is binding."
-  (:require [day8.re-frame2-xray.panels.common-helpers :as common]))
+  (:require [day8.re-frame2-xray.panels.common-helpers :as common]
+            [day8.re-frame2-xray.panels.resources-helpers :as rh]))
 
 ;; ---- trace-event lookups -------------------------------------------------
 
@@ -225,6 +226,96 @@
        :event fallback-event}
 
       :else nil)))
+
+;; ---- WORLD INPUTS row (rf2-9fyn40 · EP-0010) ----------------------------
+;;
+;; EP-0010 gives every dispatch envelope a CAUSAL `:rf.world/inputs` map —
+;; the explicit world facts (`:time-ms`, optional `:uuid` / `:random` /
+;; browser / storage) the fold consumed, so durable state is a function of
+;; prior frame-state PLUS explicit tokens (no ambient host reads). The
+;; runtime stamps that map onto the `:rf.event/dispatched` trace under
+;; `[:tags :rf.world/inputs]` (rf2-jt854w · `router/emit-dispatched-trace!`)
+;; — DEBUG-gated, so it rides the same whole-body production elision as the
+;; rest of the dispatched emit. The Event lens surfaces it so the operator
+;; can answer "where did this state value come from?" — the time / id /
+;; randomness that decided a durable write is visible at the dispatch site
+;; rather than reverse-engineered from the app-db diff.
+;;
+;; PRIVACY (EP-0010 §Privacy / Open Issue 4, ruled 2026-06-11). World inputs
+;; can carry user/tenant ids, URLs, query strings, storage values, locale,
+;; and permission facts — so they participate in the SAME marks/projection
+;; rules as event payloads and coeffects. The ruling splits the map:
+;;
+;;   - `:time-ms` is ALWAYS safe to surface (a wall-clock fact, never PII) —
+;;     it rides verbatim as `:time-ms` on the row;
+;;   - EVERY OTHER key is value-bearing and REDACTS BY DEFAULT — each value
+;;     is routed through `resources-helpers/summarize`, exactly as
+;;     `reply_envelope.cljc` summarizes its wire-bearing slots, so the panel
+;;     renders a privacy-preserving summary (type + bounded size + a
+;;     redaction-aware preview; an upstream `:rf/redacted` / `:rf.size/
+;;     large-elided` sentinel keeps its sentinel status) and NEVER a raw
+;;     value. The KEY itself is framework vocabulary (`:uuid` / `:random` /
+;;     `:browser/location` / …), not PII, so it rides verbatim as the row
+;;     label; only the VALUE is summarized.
+
+(def time-ms-key
+  "The one ALWAYS-SAFE-to-surface world-input key (EP-0010 §Time / Open
+  Issue 4). A wall-clock epoch-ms fact — never PII — so the Event lens
+  renders its value verbatim, outside the summarize/redact path the
+  value-bearing keys take."
+  :time-ms)
+
+(defn world-input-rows
+  "Project the value-bearing (NON-`:time-ms`) keys of a `:rf.world/inputs`
+  map into privacy-summarized rows (rf2-9fyn40). Each row carries the key
+  verbatim (framework vocabulary — `:uuid` / `:random` / `:browser/*` /
+  `:storage` / … — never PII) and the value SUMMARIZED through
+  `resources-helpers/summarize` (EP-0010 §Privacy / Open Issue 4 — redact
+  by default; mirrors `reply_envelope.cljc`'s wire-slot summarization).
+  Sorted by key name for stable rendering. Empty when the map carries only
+  `:time-ms` (or is nil/empty)."
+  [world-inputs]
+  (if (map? world-inputs)
+    (->> (dissoc world-inputs time-ms-key)
+         (mapv (fn [[k v]] {:key k :value (rh/summarize v)}))
+         (sort-by (comp str :key))
+         vec)
+    []))
+
+(defn world-inputs-row
+  "Build the WORLD INPUTS step from the epoch's `:rf.event/dispatched`
+  trace (rf2-9fyn40 · EP-0010). Reads the causal world-input map off
+  `[:tags :rf.world/inputs]` (the substrate-canonical slot
+  `router/emit-dispatched-trace!` stamps per rf2-jt854w; `common/tag-of`
+  is the canonical reader). Returns nil when the epoch carries no
+  dispatched trace OR no world-input map (older runtimes / fixtures /
+  the production-elided arm) — the step is silent-by-default, like
+  COEFFECTS, so a vanilla cascade with no surfaced world inputs renders
+  no section.
+
+  The row carries:
+
+      {:step      :world-inputs
+       :badge     :WORLD-INPUTS
+       :time-ms   <epoch-ms or nil>   ; ALWAYS-SAFE, surfaced verbatim
+       :inputs    [{:key :uuid   :value <summary>}
+                   {:key :random :value <summary>} …]}  ; PRIVACY-summarized
+
+  PRIVACY: `:time-ms` rides verbatim (always safe per Open Issue 4); every
+  other key's value is `summarize`d (redact-by-default — the same path
+  `reply_envelope.cljc` uses). A map carrying ONLY `:time-ms` still
+  produces a row (the time fact is worth surfacing on its own); a map with
+  no `:time-ms` AND no other keys (empty map) produces nil."
+  [events]
+  (when-let [ev (find-op events :rf.event/dispatched)]
+    (when-let [wi (common/tag-of ev :rf.world/inputs)]
+      (when (and (map? wi) (seq wi))
+        (let [time-ms (get wi time-ms-key)
+              inputs  (world-input-rows wi)]
+          (cond-> {:step  :world-inputs
+                   :badge :WORLD-INPUTS}
+            (some? time-ms) (assoc :time-ms time-ms)
+            (seq inputs)    (assoc :inputs inputs)))))))
 
 ;; ---- COEFFECT rows -------------------------------------------------------
 
@@ -3317,6 +3408,9 @@
   Steps emitted (in cascade order):
 
       :dispatch       — always present (every epoch starts here)
+      :world-inputs   — only when the dispatch envelope surfaced a
+                        `:rf.world/inputs` map (rf2-9fyn40 · EP-0010);
+                        sits right after DISPATCH SITE
       :coeffect…      — one row per user-injected coeffect (folded
                         into a single step group by the view layer)
       :handler        — always present; adapts to handler flavour
@@ -3471,7 +3565,17 @@
                              (exception-rows events))
             base-steps (vec
                         (concat
-                          [(dispatch-row events fallback)]
+                          [(dispatch-row events fallback)
+                           ;; rf2-9fyn40 — WORLD INPUTS sits RIGHT AFTER
+                           ;; DISPATCH SITE: the causal world-input map
+                           ;; (`:time-ms` + privacy-summarized id/random/
+                           ;; browser keys) is part of "who fired this and
+                           ;; with what world facts", so it reads next to
+                           ;; the dispatch site. Silent-by-default — nil
+                           ;; (filtered below) when the cascade surfaced no
+                           ;; world-input map (older runtimes / the prod-
+                           ;; elided arm).
+                           (world-inputs-row events)]
                           cofx-steps
                           cofx-placeholder-steps
                           ;; rf2-yz57h / rf2-vew2n — the INTERCEPTOR step is
@@ -3600,11 +3704,14 @@
   - rf2-zkiu5: CHILD-DISPATCHES + APP-DB-DIFF retired (pair-debug
     2026-05-26) — both redundant with existing steps (FX surfaces
     dispatch-family fx; HANDLER `:db` surfaces the post-handler diff).
+  - rf2-9fyn40: + WORLD-INPUTS (EP-0010 causal provenance, conditional —
+    present only when the dispatch envelope surfaced a `:rf.world/inputs`
+    map; sits right after DISPATCH SITE).
 
   The view's badge resolver bails to `:text-tertiary` on an unknown
   badge, so adding to this set is purely additive."
-  #{:DISPATCH :COEFFECT :INTERCEPTOR :HANDLER :FLOW :SIDE-EFFECTS
-    :SUBSCRIPTIONS :VIEWS
+  #{:DISPATCH :WORLD-INPUTS :COEFFECT :INTERCEPTOR :HANDLER :FLOW
+    :SIDE-EFFECTS :SUBSCRIPTIONS :VIEWS
     :SCHEMA-HOT-RELOAD})
 
 (defn valid-badge?

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/view.cljs
@@ -11,7 +11,11 @@
       ┌── ① DISPATCH      from ui ↗                    0.1ms
       │      [:counter-inc]
       │
-      ├── ② COEFFECT      :session ↗
+      ├── ② WORLD INPUTS  causal world inputs
+      │      time-ms  1781078400123
+      │      :uuid    {:todo/id #uuid …}   (or [redacted])
+      │
+      ├── ③ COEFFECT      :session ↗
       │      + [:session] {:user-id 42 …}
       │
       ├── ③ HANDLER       reg-event-db ↗               0.5ms
@@ -388,6 +392,56 @@
    :min-width  0
    :flex       1
    :word-break "break-word"})
+
+;; -- WORLD INPUTS (rf2-9fyn40 · EP-0010) -----------------------------------
+;;
+;; The causal world-input map (`:rf.world/inputs` off the dispatched trace).
+;; Reuses the COEFFECT body grammar (one `<key> <value>` row per input)
+;; since both surface "the inputs the fold consumed". PRIVACY: `:time-ms`
+;; rides verbatim (always safe per EP-0010 Open Issue 4); every other key's
+;; value renders as a `resources-helpers/summarize` chip (redact-by-default).
+
+(def ^:private world-input-row-style
+  {:padding     "3px 0"
+   :display     "flex"
+   :align-items "flex-start"
+   :gap         "8px"
+   :font-family mono-stack
+   :font-size   "12px"})
+
+(def ^:private world-input-key-style
+  {:color       text-tertiary-colour
+   :white-space "nowrap"})
+
+(def ^:private world-input-time-value-style
+  {:color      text-primary-colour
+   :min-width  0
+   :flex       1
+   :word-break "break-word"})
+
+;; A `summarize` shape that came back `:redacted?` renders muted (it carries
+;; no value — only the `[redacted]` sentinel preview); a `:large?` shape
+;; renders at the warning tone; everything else at the primary text colour.
+(def ^:private world-input-summary-redacted-style
+  {:color       text-tertiary-colour
+   :min-width   0
+   :flex        1
+   :word-break  "break-word"})
+
+(def ^:private world-input-summary-large-style
+  {:color       warning-colour
+   :min-width   0
+   :flex        1
+   :word-break  "break-word"})
+
+(def ^:private world-input-summary-plain-style
+  {:color       text-primary-colour
+   :min-width   0
+   :flex        1
+   :word-break  "break-word"})
+
+(def ^:private world-input-summary-size-style
+  {:color text-tertiary-colour})
 
 ;; -- db-diff / fx-entry ----------------------------------------------------
 ;;
@@ -2376,6 +2430,82 @@
      ;; rf2-xgeag — `:cofx` boundary violations attach to the matching
      ;; COEFFECT step by cofx-id.
      (violation-blocks :coeffect violations)]))
+
+;; ---- WORLD INPUTS step (rf2-9fyn40 · EP-0010) ---------------------------
+
+(defn- world-input-summary-view
+  "Render a `resources-helpers/summarize` shape (the privacy-summarized
+  value of a value-bearing world-input key) as a compact chip — NEVER the
+  raw value (EP-0010 §Privacy / Open Issue 4 — redact-by-default). Redacted
+  → muted `[redacted]`; large → amber `[large — elided]`; else the bounded
+  preview + a `(N)` size badge for collections. Mirrors the resources
+  panel's `summary-chip` grammar so the privacy summary reads identically
+  across surfaces."
+  [{:keys [type size preview redacted? large?]} testid]
+  [:span {:data-testid testid
+          :style       (cond
+                         redacted? world-input-summary-redacted-style
+                         large?    world-input-summary-large-style
+                         :else     world-input-summary-plain-style)}
+   preview
+   (when (and size (#{"map" "set" "vector" "seq"} type))
+     [:span {:style world-input-summary-size-style} (str " (" size ")")])])
+
+(defn render-world-inputs-step
+  "Render the WORLD INPUTS step (rf2-9fyn40 · EP-0010) — the dispatch
+  envelope's causal `:rf.world/inputs` map surfaced right after DISPATCH
+  SITE. The map answers 'where did this state value come from?' — the
+  explicit time / id / randomness / browser facts the fold consumed, so a
+  durable write reads as a function of prior state PLUS these tokens.
+
+  PRIVACY (EP-0010 §Privacy / Open Issue 4, ruled 2026-06-11):
+
+    - `:time-ms` is ALWAYS safe to surface (a wall-clock fact, never PII) —
+      it renders verbatim as `time-ms <ms>`;
+    - every other key is value-bearing and REDACTS BY DEFAULT — the
+      projection routed each value through `resources-helpers/summarize`
+      (the same path `reply_envelope.cljc` uses), so this view renders a
+      privacy-preserving summary chip, NEVER a raw value. The KEY itself is
+      framework vocabulary (`:uuid` / `:random` / `:browser/*` / `:storage`)
+      and rides verbatim as the row label.
+
+  Conditional (silent-by-default, like COEFFECTS): the projection emits
+  this step ONLY when the dispatch envelope surfaced a world-input map."
+  [{:keys [time-ms inputs step-number]}]
+  [:div {:data-testid "rf-xray-epoch-step-world-inputs"
+         :data-step-kw "world-inputs"}
+   (numbered-circle step-number :WORLD-INPUTS)
+   (step-header
+     {:step :world-inputs
+      :badge :WORLD-INPUTS
+      :verb [:span {:style coeffect-verb-plain-style
+                    :data-testid "rf-xray-epoch-world-inputs-verb"}
+             "causal world inputs"]
+      :expandable? false
+      :testid "rf-xray-epoch-world-inputs"}
+     nil)
+   ;; `:time-ms` — ALWAYS surfaced verbatim (always safe, Open Issue 4).
+   (when (some? time-ms)
+     [:div {:data-testid "rf-xray-epoch-world-inputs-time-ms"
+            :style world-input-row-style}
+      [:span {:style world-input-key-style} "time-ms"]
+      [:span {:data-testid "rf-xray-epoch-world-inputs-time-ms-value"
+              :style world-input-time-value-style}
+       (str time-ms)]])
+   ;; value-bearing keys — each rendered as a privacy summary chip
+   ;; (redact-by-default). The key rides verbatim (framework vocabulary,
+   ;; not PII); only the VALUE is summarized.
+   (for [[idx {:keys [key value]}] (map-indexed vector inputs)]
+     ^{:key (str "world-input-" idx)}
+     [:div {:data-testid (str "rf-xray-epoch-world-input-row-" (name key))
+            :data-world-input-key (name key)
+            :style world-input-row-style}
+      [:span {:data-testid (str "rf-xray-epoch-world-input-key-" (name key))
+              :style world-input-key-style}
+       (fmt/ns-keyword key)]
+      (world-input-summary-view
+        value
+        (str "rf-xray-epoch-world-input-value-" (name key)))])])
 
 ;; ---- INTERCEPTOR step (rf2-yz57h) ---------------------------------------
 ;;
@@ -5392,6 +5522,7 @@
   [step ctx]
   (case (:step step)
     :dispatch          (render-dispatch-step step (:dispatch-id->epoch-id ctx))
+    :world-inputs      (render-world-inputs-step step)
     :coeffect          (render-coeffect-step step)
     :interceptor       (render-interceptor-step step)
     :handler           (render-handler-step step)

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -272,6 +272,112 @@
       (is (nil? (:source-enrichment r))
           "no parent-dispatch-id → no enrichment map (graceful degrade)"))))
 
+;; ---- WORLD INPUTS (rf2-9fyn40 · EP-0010) --------------------------------
+;;
+;; The dispatch envelope's causal `:rf.world/inputs` map rides under
+;; `[:tags :rf.world/inputs]` on the `:rf.event/dispatched` trace (the
+;; substrate stamps it per rf2-jt854w). The Event lens surfaces it as a
+;; dedicated WORLD INPUTS step right after DISPATCH SITE.
+;;
+;; PRIVACY (EP-0010 §Privacy / Open Issue 4, ruled 2026-06-11): `:time-ms`
+;; is ALWAYS safe to surface (rides verbatim); every other key is value-
+;; bearing and REDACTS BY DEFAULT — routed through `resources-helpers/
+;; summarize` (the same path reply_envelope.cljc uses), so the row carries
+;; a privacy summary, never a raw value.
+
+(defn- dispatched-with-world-inputs
+  "A `:rf.event/dispatched` trace event carrying a `:rf.world/inputs` map
+  under `:tags` (the substrate-canonical placement per rf2-jt854w)."
+  [event world-inputs]
+  {:op-type   :rf.event
+   :operation :rf.event/dispatched
+   :tags      {:rf.event/v       event
+               :source           :ui
+               :rf.world/inputs  world-inputs}})
+
+(deftest world-inputs-row-time-ms-only-test
+  (testing "rf2-9fyn40 — a world-input map carrying only :time-ms produces a
+            WORLD INPUTS row surfacing :time-ms verbatim (always safe per
+            EP-0010 Open Issue 4), with no value-bearing input rows"
+    (let [ev (dispatched-with-world-inputs [:counter/inc] {:time-ms 1781078400123})
+          r  (proj/world-inputs-row [ev])]
+      (is (= :world-inputs (:step r)))
+      (is (= :WORLD-INPUTS (:badge r)))
+      (is (= 1781078400123 (:time-ms r)) ":time-ms rides verbatim")
+      (is (nil? (:inputs r)) "no value-bearing keys → no :inputs slot"))))
+
+(deftest world-inputs-row-value-bearing-keys-summarized-test
+  (testing "rf2-9fyn40 — value-bearing keys (:uuid / :random) are routed
+            through resources-helpers/summarize: the KEY rides verbatim
+            (framework vocabulary, not PII); the VALUE is a summary map,
+            never the raw value (EP-0010 §Privacy / Open Issue 4 —
+            redact-by-default for everything except :time-ms)"
+    (let [wi {:time-ms 1781078400123
+              :uuid    {:todo/id #uuid "00000000-0000-0000-0000-000000000001"}
+              :random  {:todo/color :green}}
+          ev (dispatched-with-world-inputs [:todo/create] wi)
+          r  (proj/world-inputs-row [ev])
+          inputs (:inputs r)
+          by-key (into {} (map (juxt :key identity) inputs))]
+      (is (= 1781078400123 (:time-ms r)) ":time-ms still surfaced verbatim")
+      (is (= 2 (count inputs)) "two value-bearing keys (:uuid + :random)")
+      (is (= [:random :uuid] (mapv :key inputs)) "sorted by key name")
+      ;; each value is a summarize SHAPE (a map with :type/:preview/…),
+      ;; never the raw value.
+      (is (map? (:value (by-key :uuid))))
+      (is (contains? (:value (by-key :uuid)) :preview)
+          ":uuid value is a summarize shape, not the raw map")
+      (is (= "map" (:type (:value (by-key :uuid)))))
+      (is (map? (:value (by-key :random))))
+      (is (= "map" (:type (:value (by-key :random)))))
+      ;; the keys ride verbatim — framework vocabulary, not summarized.
+      (is (= :uuid (:key (by-key :uuid))))
+      (is (= :random (:key (by-key :random)))))))
+
+(deftest world-inputs-row-redacted-value-stays-sentinel-test
+  (testing "rf2-9fyn40 — a value already redacted UPSTREAM (the framework
+            :rf/redacted sentinel for a :sensitive? slot) keeps its sentinel
+            status through summarize: the row renders [redacted], NEVER the
+            raw value (EP-0010 §Privacy — marks/projection redact by default)"
+    (let [wi {:time-ms 1781078400123
+              :storage :rf/redacted}   ;; runtime elided a sensitive storage read
+          ev (dispatched-with-world-inputs [:prefs/load] wi)
+          r  (proj/world-inputs-row [ev])
+          row (first (:inputs r))]
+      (is (= :storage (:key row)))
+      (is (true? (:redacted? (:value row))) "the sentinel summarizes as redacted")
+      (is (= "[redacted]" (:preview (:value row)))
+          "renders the redaction marker, not the raw value"))))
+
+(deftest world-inputs-row-absent-when-no-map-test
+  (testing "rf2-9fyn40 — silent-by-default: no :rf.world/inputs tag (older
+            runtimes / prod-elided arm / fixtures) → no WORLD INPUTS step"
+    (let [ev (dispatched-ev [:counter/inc] :ui)]  ;; builder stamps no world inputs
+      (is (nil? (proj/world-inputs-row [ev]))
+          "no world-input map → nil row")))
+  (testing "rf2-9fyn40 — no dispatched trace at all → nil row"
+    (is (nil? (proj/world-inputs-row []))))
+  (testing "rf2-9fyn40 — an EMPTY world-input map → nil row (nothing to show)"
+    (let [ev (dispatched-with-world-inputs [:counter/inc] {})]
+      (is (nil? (proj/world-inputs-row [ev]))))))
+
+(deftest project-places-world-inputs-after-dispatch-test
+  (testing "rf2-9fyn40 — `project` slots the WORLD INPUTS step RIGHT AFTER
+            DISPATCH SITE (before COEFFECTS), and numbers it as a first-class
+            cascade entry"
+    (let [ev    (dispatched-with-world-inputs [:counter/inc] {:time-ms 1781078400123})
+          steps (proj/project-numbered (record [ev]))
+          kinds (mapv :step steps)]
+      (is (= :dispatch (first kinds)) "DISPATCH first")
+      (is (= :world-inputs (second kinds)) "WORLD INPUTS immediately after DISPATCH")
+      (is (= 2 (:step-number (second steps))) "numbered as step 2")))
+  (testing "rf2-9fyn40 — no world-input map → no WORLD INPUTS step in the cascade"
+    (let [ev    (dispatched-ev [:counter/inc] :ui)
+          steps (proj/project (record [ev]))
+          kinds (mapv :step steps)]
+      (is (not (some #{:world-inputs} kinds))
+          "WORLD INPUTS is silent-by-default — absent when no map surfaced"))))
+
 ;; ---- COEFFECT ------------------------------------------------------------
 
 (deftest coeffect-rows-granular-test
@@ -2895,11 +3001,14 @@
                          (view-render-ev ::v [:s])])
           steps (proj/project rec)]
       (is (every? proj/valid-badge? (map :badge steps)))
-      (is (= 9 (count proj/badge-set))
+      (is (= 10 (count proj/badge-set))
           "rf2-sc3r1 7 + rf2-xgeag (SCHEMA-HOT-RELOAD, renamed from
-           SCHEMA-VIOLATIONS) + rf2-yz57h (INTERCEPTOR) = 9 badges.
+           SCHEMA-VIOLATIONS) + rf2-yz57h (INTERCEPTOR) = 9 badges, +
+           rf2-9fyn40 (WORLD-INPUTS, EP-0010 causal provenance) = 10.
            rf2-btt0s deleted :CHILD-DISPATCHES + :APP-DB-DIFF (retired
            steps the projection can no longer emit).")
+      (is (contains? proj/badge-set :WORLD-INPUTS)
+          "rf2-9fyn40 — WORLD-INPUTS badge is in the inventory")
       ;; rf2-btt0s — guard against step-level drift: badge-set must NOT
       ;; advertise a badge no step can produce. The conditional steps
       ;; (FLOW / SIDE-EFFECTS / SCHEMA-HOT-RELOAD / INTERCEPTOR) are

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/view_cljs_test.cljs
@@ -18,6 +18,7 @@
             [day8.re-frame2-xray.panels.epoch.badge :as badge]
             [day8.re-frame2-xray.panels.epoch.projection :as proj]
             [day8.re-frame2-xray.panels.epoch.view :as view]
+            [day8.re-frame2-xray.panels.resources-helpers :as rh]
             [day8.re-frame2-xray.panels.epoch-panel :as epoch-orchestrator]))
 
 ;; ---- fixtures -----------------------------------------------------------
@@ -411,6 +412,49 @@
           "the cofx-id is surfaced in the header")
       (is (string/includes? (or value-text "") "42")
           "the cofx value renders in the body"))))
+
+;; ---- rf2-9fyn40 — WORLD INPUTS step (EP-0010 causal provenance) ---------
+
+(deftest world-inputs-time-ms-renders-verbatim-test
+  (testing "rf2-9fyn40 — :time-ms is ALWAYS safe (EP-0010 Open Issue 4) and
+            renders verbatim in the WORLD INPUTS step body"
+    (let [step {:step :world-inputs :badge :WORLD-INPUTS :step-number 2
+                :time-ms 1781078400123}
+          tree (view/render-world-inputs-step step)]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-step-world-inputs"))
+          "the WORLD INPUTS step wrapper renders")
+      (is (string/includes?
+            (or (text-of tree "rf-xray-epoch-world-inputs-time-ms-value") "")
+            "1781078400123")
+          ":time-ms renders verbatim"))))
+
+(deftest world-inputs-value-bearing-key-renders-summary-test
+  (testing "rf2-9fyn40 — a value-bearing key renders the privacy summary
+            chip (preview), NOT the raw value. The KEY rides verbatim"
+    (let [step {:step :world-inputs :badge :WORLD-INPUTS :step-number 2
+                :time-ms 1781078400123
+                :inputs [{:key :uuid :value (rh/summarize {:todo/id 1})}]}
+          tree (view/render-world-inputs-step step)
+          key-text (text-of tree "rf-xray-epoch-world-input-key-uuid")
+          val-text (text-of tree "rf-xray-epoch-world-input-value-uuid")]
+      (is (some? (th/find-by-testid tree "rf-xray-epoch-world-input-row-uuid"))
+          "the value-bearing key row renders")
+      (is (string/includes? (or key-text "") ":uuid")
+          "the key rides verbatim (framework vocabulary)")
+      ;; the summarize preview is shown — a bounded pr-str, not a raw deref
+      (is (string/includes? (or val-text "") "todo/id")
+          "the bounded summary preview renders"))))
+
+(deftest world-inputs-redacted-value-renders-marker-test
+  (testing "rf2-9fyn40 — a value redacted upstream (:rf/redacted sentinel)
+            renders the [redacted] marker, NEVER the raw value (EP-0010
+            §Privacy — redact-by-default for non-:time-ms keys)"
+    (let [step {:step :world-inputs :badge :WORLD-INPUTS :step-number 2
+                :inputs [{:key :storage :value (rh/summarize :rf/redacted)}]}
+          tree (view/render-world-inputs-step step)
+          val-text (text-of tree "rf-xray-epoch-world-input-value-storage")]
+      (is (string/includes? (or val-text "") "[redacted]")
+          "the redaction marker renders, not the raw value"))))
 
 ;; ---- rf2-kfh1v — SUBSCRIPTIONS rows + filter -------------------------
 


### PR DESCRIPTION
## What

EP-0010 tooling (rf2-9fyn40). Xray's Event lens (the Epoch panel's 9-section event lens, `018-Event-Spine.md` §5.1) now surfaces the dispatch envelope's causal `:rf.world/inputs` map in a dedicated **WORLD INPUTS** section placed **right after DISPATCH SITE** — the EP-0010 "where did this state value come from?" answer (the explicit time / id / randomness / browser facts the fold consumed).

The runtime prereq is in place: `router/emit-dispatched-trace!` stamps `:rf.world/inputs` under `[:tags :rf.world/inputs]` on the `:rf.event/dispatched` trace (rf2-jt854w · PR #3903). This bead is the tooling consumer.

## Lens shape

```
┌─ Event lens · :cart/add-item                              ✓ ok · 11ms · #347 ┐
│ ▼ DISPATCH SITE                                                              │
│   src/cart/views.cljs:127  [code]   via :ui · origin :app                    │
│ ▼ WORLD INPUTS                                                               │
│   time-ms  1781078400123                                                     │
│   :uuid    [redacted]            (value-bearing keys redact by default)      │
│ ▼ EVENT  …                                                                   │
```

Per-step shape: `{:step :world-inputs :badge :WORLD-INPUTS :time-ms <ms> :inputs [{:key :uuid :value <summary>} …]}`. Silent-by-default (like COEFFECTS) — absent when the cascade surfaced no world-input map (older runtimes, the production-elided emit arm, or an empty map).

## Privacy projection (EP-0010 Open Issue 4, ruled 2026-06-11)

- **`:time-ms` is ALWAYS safe** (a wall-clock fact, never PII) → renders **verbatim**.
- **Every other key is value-bearing and REDACTS BY DEFAULT** — its value is routed through **`resources-helpers/summarize`**, the same summarize/projection path `reply_envelope.cljc` uses for its wire-bearing slots. The panel renders a privacy-preserving summary (type + bounded size + a redaction-aware preview); an upstream `:rf/redacted` / `:rf.size/large-elided` sentinel keeps its sentinel status (`[redacted]` / `[large — elided]`). A raw value is **never** rendered.
- The KEY itself (`:uuid` / `:random` / `:browser/*` / `:storage` / …) is framework vocabulary, not PII, so it rides verbatim as the row label; only the VALUE is summarized.

## Spec (same-PR update — standing rule)

- `018-Event-Spine.md` §5.1 — 8→9-section lens, new section 1a (WORLD INPUTS) right after DISPATCH SITE, wireframe + edge cases.
- `016-Auxiliary-Panels.md` — new "World inputs content" catalogue subsection (parallel to Effects / Flows content).
- `021-Dynamic-Panel-Designs.md` §9.1.4 — badge table (`:WORLD-INPUTS` → `:text-secondary`).

## Quality gates

- `clojure -M:test` (xray artefact JVM): **1127 tests, 4929 assertions, 0 failures, 0 errors** (post-rebase).
- `npm run test:cljs` (node CLJS, incl. new view tests): **6580 tests, 24052 assertions, 0 failures, 0 errors**.
- `npm run test:xray-feature-gate`: **16 scenarios over 14 surfaces, 0 failures** (all testbeds compiled, 0 warnings).
- `mkdocs build --strict`: built successfully (no errors).
