### PR TITLE
feat(core): EP-0014 slice-2 — subscriptions expose algebra views (rf2-gge6mf)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
@@ -685,6 +685,109 @@
           "static sub-topology reports the :parametric sentinel, not the realized edges")
       (rf/unsubscribe [:article/page :a1]))))
 
+;; ---- live sub-cache algebra view (EP-0014 slice-2, rf2-gge6mf) -------------
+;;
+;; Per [spec/Derivations.md] §Static and live graphs + the
+;; `:rf/derivation-node` shape in [spec/Spec-Schemas.md]. The LIVE
+;; counterpart to `sub-algebra-view` (the static, JVM-runnable view): one
+;; algebra node per concrete cached entry, keyed by its query vector, with
+;; the REALIZED `[:sub query-vector]` input edges the static graph cannot
+;; enumerate. CLJS-only / dev-only (DCE'd in production), mirroring
+;; `sub-cache-snapshot`.
+
+(deftest sub-cache-algebra-view-exposes-the-live-node
+  (testing "a live sub-cache entry exposes the full ephemeral / on-demand /
+           cache-entry algebra node, keyed by its concrete query vector"
+    (rf/reg-event-db :seed-av (fn [_ _] {:n 7 :name "ada"}))
+    (rf/reg-sub :n     (fn [db _] (:n db)))
+    (rf/reg-sub :name* (fn [db _] (:name db)))
+    (rf/dispatch-sync [:seed-av])
+    ;; Empty cache is the {} baseline.
+    (is (= {} (subs-tooling/sub-cache-algebra-view :rf/default))
+        "no subs materialised yet → empty map")
+    (let [r1   (rf/subscribe [:n])
+          r2   (rf/subscribe [:n])
+          r3   (rf/subscribe [:name*])
+          view (subs-tooling/sub-cache-algebra-view :rf/default)]
+      (is (= 2 (count view))
+          "one algebra node per materialised query-v")
+      (let [node-n (get view [:n])]
+        (is (= [:n] (:id node-n))
+            "the live node's id is its concrete query vector")
+        (is (= :derivation (:kind node-n)))
+        (is (= :ephemeral (:storage node-n)))
+        (is (= :on-demand (:evaluation node-n)))
+        (is (= :subscription-cache-entry (:lifecycle node-n)))
+        (is (= false (:materialized? node-n)))
+        (is (= [:fact [:n]] (:output node-n))
+            "the output fact is addressed by the concrete query vector")
+        (is (= {:kind :reg-sub :id :n} (:source-form node-n)))
+        (is (= [] (:inputs node-n))
+            "a layer-1 reader has no realized [:sub …] edges")
+        (is (= :db (:input-kind node-n)))
+        (is (= 7 (:value node-n))
+            "the node carries the live deref of the cached reaction")
+        (is (= 2 (:ref-count node-n))
+            "ref-count is the lifecycle evidence the cache-entry owner is kept alive")))
+    ;; No-arg-by-id parity with the active frame.
+    (is (= (subs-tooling/sub-cache-algebra-view :rf/default)
+           (subs-tooling/sub-cache-algebra-view (rf/current-frame-id)))
+        "the named-frame view equals the active-frame view")
+    (rf/unsubscribe [:n])
+    (rf/unsubscribe [:n])
+    (rf/unsubscribe [:name*])
+    (is (nil? (subs-tooling/sub-cache-algebra-view :no-such-frame))
+        "missing frame returns nil")))
+
+(deftest sub-cache-algebra-view-lowers-static-realized-edges
+  (testing "a static :<- entry lowers its literal realized inputs to [:sub q] edges"
+    (rf/reg-event-db :seed-av2 (fn [_ _] {:items [1 2 3] :filter :all}))
+    (rf/reg-sub :items  (fn [db _] (:items db)))
+    (rf/reg-sub :filter (fn [db _] (:filter db)))
+    (rf/reg-sub :visible-items
+                :<- [:items]
+                :<- [:filter]
+                (fn [[items _filter] _] items))
+    (rf/dispatch-sync [:seed-av2])
+    (let [r    (rf/subscribe [:visible-items])
+          view (subs-tooling/sub-cache-algebra-view :rf/default)
+          node (get view [:visible-items])]
+      (is (= :static (:input-kind node)))
+      (is (= [[:sub [:items]] [:sub [:filter]]] (:inputs node))
+          "the static entry's realized edges are its literal :<- query-vectors, lowered to [:sub q]")
+      (rf/unsubscribe [:visible-items]))))
+
+(deftest sub-cache-algebra-view-lowers-parametric-realized-edges
+  (testing "a parametric entry lowers its REALIZED (input-fn query-v) result to [:sub q] edges"
+    ;; This is the load-bearing static/live distinction: the static
+    ;; `sub-algebra-view` reports the :parametric marker; the live view
+    ;; reports the concrete realized [:sub …] edges for THIS query vector.
+    (rf/reg-event-db :seed-av3 (fn [_ _] {:articles {:a1 {:title "T"}}
+                                          :comments {:a1 [:c1]}}))
+    (rf/reg-sub :article/by-id        (fn [db [_ id]] (get-in db [:articles id])))
+    (rf/reg-sub :comments/for-article (fn [db [_ id]] (get-in db [:comments id])))
+    (rf/reg-sub :article/page
+                (fn [[_ id]]
+                  [[:article/by-id id]
+                   [:comments/for-article id]])
+                (fn [[article comments] _]
+                  {:article article :comments comments}))
+    (rf/dispatch-sync [:seed-av3])
+    (let [r    (rf/subscribe [:article/page :a1])
+          view (subs-tooling/sub-cache-algebra-view :rf/default)
+          node (get view [:article/page :a1])]
+      (is (= [:article/page :a1] (:id node))
+          "the live node id is the concrete parametric query vector")
+      (is (= :parametric (:input-kind node)))
+      (is (= [[:sub [:article/by-id :a1]]
+              [:sub [:comments/for-article :a1]]]
+             (:inputs node))
+          "the live view reports the REALIZED [:sub …] edges for :a1")
+      ;; The static view reports the marker, never these realized edges.
+      (is (= :parametric (:inputs (subs-tooling/sub-algebra-view :article/page)))
+          "the static algebra view reports the :parametric marker, not the realized edges")
+      (rf/unsubscribe [:article/page :a1]))))
+
 ;; ---- epoch history (Tool-Pair §Time-travel, rf2-shjf) ---------------------
 ;;
 ;; CLJS smoke test — JVM-side epoch_test.clj covers the broad surface; this

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -1453,4 +1453,11 @@
 #?(:clj
    (do
      (def sub-topology       subs-tooling/sub-topology)
-     (def sub-cache-snapshot subs-tooling/sub-cache-snapshot)))
+     (def sub-cache-snapshot subs-tooling/sub-cache-snapshot)
+     ;; EP-0014 slice-2: the derivation/process algebra views. The static
+     ;; view is JVM-runnable (registrar-derived, partition-agnostic); the
+     ;; live cache view is CLJS-only (returns nil on the JVM, like
+     ;; `sub-cache-snapshot`). Both live in the tooling sibling so
+     ;; production CLJS bundles DCE the bodies.
+     (def sub-algebra-view       subs-tooling/sub-algebra-view)
+     (def sub-cache-algebra-view subs-tooling/sub-cache-algebra-view)))

--- a/implementation/core/src/re_frame/subs/tooling.cljc
+++ b/implementation/core/src/re_frame/subs/tooling.cljc
@@ -182,6 +182,272 @@
      :clj
      nil))
 
+;; ---- algebra views (EP-0014 slice-2) -------------------------------------
+;;
+;; Per [Derivations.md] (graduated from EP-0014) and the projected Malli
+;; shapes in [Spec-Schemas §`:rf/derivation-node`]. Every subscription —
+;; `reg-sub` (layer-1 `:db`, static `:<-`, parametric input-fn),
+;; `reg-runtime-sub`, `reg-frame-state-sub`, and each live sub-cache entry —
+;; is an instance of the derivation/process algebra: a `:derivation`
+;; (subscriptions and flows are derivations, never processes), whose output
+;; is an ephemeral fact, evaluated on-demand, owned by its
+;; subscription-cache entry.
+;;
+;; This is the *registrar-derived* slice (Derivations §The EP-0013
+;; relocation seam): the algebra view is assembled from registration
+;; metadata at the surface that registers each source form, NOT (yet) from
+;; an EP-0013 app value. It feeds the later internal graph-inspection helper
+;; (EP-0014 bead-plan item 7); slice-2 ships NO public accessor — these
+;; functions live in the bundle-isolated tooling sibling, consumed by Xray
+;; and conformance fixtures.
+;;
+;; The five fixed classifications for EVERY subscription node (the worked
+;; equivalence in Derivations §Worked equivalence — subscriptions are the
+;; canonical `:ephemeral` / `:on-demand` / `:subscription-cache-entry`
+;; member):
+;;   :kind       :derivation
+;;   :storage    :ephemeral            (a cache/reaction value, not durable)
+;;   :evaluation :on-demand            (evaluated when a reader subscribes)
+;;   :lifecycle  :subscription-cache-entry
+;;   :materialized? false              (an ephemeral output has no durable address)
+;; The per-sub axes that vary are the declared INPUTS and the OUTPUT fact id.
+;;
+;; A subscription consumes the slice-1 vocabulary verbatim — it does NOT
+;; redefine the `:rf/storage-class` / `:rf/evaluation-policy` /
+;; `:rf/lifecycle` enums or the `:rf/derivation-node` shape (those are owned
+;; by Spec-Schemas / Derivations).
+
+(defn- declared-inputs
+  "Project a sub's registration metadata into the algebra view's declared
+  inputs (Derivations §Declared input). The input-kind discriminator drives
+  the projection:
+
+    :db          → [[:db []]]        — a layer-1 reader hands the WHOLE
+                                       app-db value to the body, so the
+                                       conservative declared input is the
+                                       app-db projection root (Derivations
+                                       §Subscription source form, the
+                                       layer-1 example). NOT enumerable down
+                                       to a path without a path-aware source
+                                       form; correctness does not depend on
+                                       the narrowing.
+    :runtime-db  → [[:runtime []]]   — same, over the runtime-db partition
+                                       (the framework `reg-runtime-sub`).
+    :frame-state → [[:frame-state []]] — the framework-internal whole
+                                       frame-state reader (reads across both
+                                       partitions; reserved for internals).
+    :static      → [[:sub q] ...]    — the literal `:<-` query-vectors, each
+                                       lowered to a `[:sub query-vector]`
+                                       declared input in declaration order.
+    :parametric  → :parametric       — the realized edge set depends on the
+                                       concrete outer query vector and is NOT
+                                       statically enumerable (the don't-
+                                       execute rule, Derivations §Static and
+                                       live graphs). The static graph reports
+                                       the `:parametric` marker; the live
+                                       graph (sub-cache-algebra-view) reports
+                                       realized `[:sub …]` edges.
+
+  `:realized` (optional) supplies the realized input query-vectors for a
+  concrete live cache entry — used by `sub-cache-algebra-view` to lower a
+  parametric (or static) entry's actual edges to `[:sub query-vector]`."
+  ([input-kind input-signals] (declared-inputs input-kind input-signals nil))
+  ([input-kind input-signals realized]
+   (cond
+     ;; Live entry — realized query-vectors known; lower each to [:sub q].
+     (some? realized)
+     (mapv (fn [q] [:sub q]) realized)
+
+     :else
+     (case input-kind
+       :db          [[:db []]]
+       :runtime-db  [[:runtime []]]
+       :frame-state [[:frame-state []]]
+       :static      (mapv (fn [q] [:sub q]) input-signals)
+       :parametric  :parametric
+       ;; Legacy / pre-discriminator registration — conservative app-db read.
+       [[:db []]]))))
+
+(defn- node-base
+  "The fixed-classification spine shared by every subscription algebra node
+  (Derivations §The node shape): a `:derivation` whose ephemeral output is
+  evaluated on-demand and owned by its subscription-cache entry. `id` is the
+  node's canonical fact identity (Derivations §Fact identity) — the sub id
+  for a static node, the concrete query vector for a live cache entry."
+  [id output]
+  {:id            id
+   :kind          :derivation
+   :output        output
+   :storage       :ephemeral
+   :evaluation    :on-demand
+   :lifecycle     :subscription-cache-entry
+   :materialized? false})
+
+(defn- with-source-coords
+  "Attach the registrar's source-coordinate / schema / doc metadata to a
+  node when present — the `:source` map (Derivations §Errors and
+  diagnostics) and the `:schema` fact. Functions stay opaque tokens; we
+  never serialize the executable body."
+  [node meta]
+  (let [source (cond-> {}
+                 (contains? meta :ns)   (assoc :ns   (:ns   meta))
+                 (contains? meta :file) (assoc :file (:file meta))
+                 (contains? meta :line) (assoc :line (:line meta)))]
+    (cond-> node
+      (seq source)             (assoc :source source)
+      (contains? meta :schema) (assoc :schema (:schema meta))
+      (contains? meta :doc)    (assoc :doc (:doc meta))
+      ;; The body fn is an opaque token — surfaced under :derive so a tool
+      ;; can show the function source/identity without it being serialized.
+      (contains? meta :handler-fn) (assoc :derive (:handler-fn meta)))))
+
+(defn- static-node-for
+  "Build the static algebra view for one registered sub from its registrar
+  metadata. Pure data over the registrar — the same registration-known
+  facts `sub-topology` reports, lowered into the `:rf/derivation-node`
+  shape. `:source-form {:kind :reg-sub :id <id>}` records which source form
+  it lowered from; a parametric sub additionally carries `:input-producer`
+  (the opaque input-fn token)."
+  [sub-id meta]
+  (let [input-kind (or (:input-kind meta) :db)
+        inputs     (declared-inputs input-kind (:input-signals meta))]
+    (-> (node-base sub-id [:fact sub-id])
+        (assoc :source-form {:kind :reg-sub :id sub-id}
+               :inputs      inputs)
+        (cond-> (= :parametric input-kind)
+          (assoc :input-producer (:input-fn meta)))
+        (with-source-coords meta))))
+
+(defn sub-algebra-view
+  "Return the STATIC derivation/process algebra view of every registered
+  subscription (EP-0014 slice-2; [Derivations.md], [Spec-Schemas
+  §`:rf/derivation-node`]).
+
+  Pure data over the registrar — no app-db, no per-frame cache, no reactive
+  runtime. The algebra-view companion to `sub-topology`: where `sub-topology`
+  reports the raw `{:input-kind :inputs …}` projection, this lowers every
+  subscription into the normalized `:rf/derivation-node` shape the
+  derivation/process algebra names, so a tool can show subscriptions, flows,
+  resources, route facts, and machine selectors as ONE family.
+
+  Shape: `{sub-id <derivation-node>}` where each node carries:
+
+  - `:id`          — the sub id (its canonical fact identity when static).
+  - `:kind`        — `:derivation` (subscriptions are derivations, never
+                     processes — Derivations §Derivation).
+  - `:source-form` — `{:kind :reg-sub :id <sub-id>}`.
+  - `:inputs`      — the declared inputs (Derivations §Declared input):
+                     `[[:db []]]` for a layer-1 `:db` reader, `[[:runtime []]]`
+                     for a framework `reg-runtime-sub`, `[[:frame-state []]]`
+                     for a `reg-frame-state-sub`, the literal `[:sub q]`
+                     edges for a static `:<-` sub, or the `:parametric`
+                     marker for an input-fn sub (whose realized edges are
+                     per-concrete-query-v live state — the don't-execute
+                     rule).
+  - `:input-producer` — the opaque input-fn token, present only for a
+                     `:parametric` node (Derivations §Static and live graphs).
+  - `:output`      — `[:fact <sub-id>]` (an ephemeral fact, no durable address).
+  - `:storage`     — `:ephemeral`.
+  - `:evaluation`  — `:on-demand`.
+  - `:lifecycle`   — `:subscription-cache-entry`.
+  - `:materialized?` — `false`.
+  - `:derive`      — the opaque body-fn token (never serialized).
+  - `:source` / `:schema` / `:doc` — present when the registration carried
+                     them (source coords auto-captured by `reg-sub`).
+
+  Zero-arity returns the map for every registered sub (`{}` when none). The
+  one-arity form returns the single node for `sub-id`, or `nil` if it is not
+  registered. JVM-runnable — the registration metadata is partition-agnostic.
+
+  Slice-2 ships NO public accessor (EP-0014 issue-1 disposition): this lives
+  in the bundle-isolated tooling sibling and is consumed by Xray + the
+  conformance fixtures; the public name is deferred until a third consumer
+  needs it."
+  ([]
+   (let [subs-meta (registrar/registrations :sub)]
+     (reduce-kv
+       (fn [acc sub-id meta]
+         (assoc acc sub-id (static-node-for sub-id meta)))
+       {}
+       subs-meta)))
+  ([sub-id]
+   (when-let [meta (registrar/lookup :sub sub-id)]
+     (static-node-for sub-id meta))))
+
+(defn sub-cache-algebra-view
+  "Return the LIVE derivation/process algebra view of a frame's sub-cache —
+  one `:rf/derivation-node` per concrete cached entry (EP-0014 slice-2;
+  [Derivations.md] §Static and live graphs).
+
+  The live counterpart to `sub-algebra-view`: where the static view reports
+  the `:parametric` marker for an input-fn sub, the live view reports the
+  REALIZED `[:sub query-vector]` input edges for each concrete entry (the
+  edges the static graph cannot enumerate), keyed by the entry's query
+  vector — its canonical fact identity when concrete (Derivations §Fact
+  identity).
+
+  Per-entry node:
+
+  - `:id`          — the concrete query vector (the live fact identity).
+  - `:kind`        — `:derivation`.
+  - `:source-form` — `{:kind :reg-sub :id <sub-id>}`.
+  - `:inputs`      — the realized `[[:sub q] …]` edges for THIS entry (the
+                     literal `:<-` list for a static sub, the
+                     `(input-fn query-v)` result for a parametric sub, `[]`
+                     for a layer-1 / runtime-db / frame-state reader). Stored
+                     on the entry at materialization, so the topology is
+                     fixed for the entry's lifetime.
+  - `:output`      — `[:fact <query-v>]`.
+  - `:storage` / `:evaluation` / `:lifecycle` / `:materialized?` — the same
+                     fixed classifications as the static node.
+  - `:value`       — the current deref of the cached reaction (a value
+                     summary; redaction is the graph-inspection helper's job
+                     per Derivations §Redaction metadata — `nil` when the
+                     reaction throws on deref).
+  - `:ref-count`   — the entry's live consumer ref-count, the lifecycle
+                     evidence the `:subscription-cache-entry` owner is kept
+                     alive by its readers.
+  - `:input-kind`  — the registered input-producer discriminator, for tools
+                     that want the source-form kind alongside the realized
+                     edges.
+
+  CLJS-only and dev-only — gated on `interop/debug-enabled?` (the
+  `goog.DEBUG` mirror) so production builds DCE the cache walk. Returns
+  `nil` for a missing/destroyed frame, and `nil` on the JVM + in production
+  (the cached reactions are not deref-able on the JVM)."
+  [frame-id]
+  #?(:cljs
+     (when interop/debug-enabled?
+       (when-let [cache (:sub-cache (frame/frame frame-id))]
+         (let [subs-meta (registrar/registrations :sub)]
+           (reduce-kv
+             (fn [acc query-v entry]
+               (let [sub-id     (when (vector? query-v) (first query-v))
+                     meta       (get subs-meta sub-id)
+                     input-kind (or (:input-kind meta) :db)
+                     ;; The cache entry's `:inputs` slot holds the realized
+                     ;; input query-vectors for this concrete outer query-v
+                     ;; (the literal `:<-` list for `:static`, the
+                     ;; `(input-fn query-v)` result for `:parametric`,
+                     ;; `[]` for a single-source reader) — see
+                     ;; `re-frame.subs/compute-and-cache!`.
+                     realized   (vec (:inputs entry))
+                     node       (-> (node-base query-v [:fact query-v])
+                                    (assoc :source-form {:kind :reg-sub :id sub-id}
+                                           :inputs      (declared-inputs input-kind
+                                                                         (:input-signals meta)
+                                                                         realized)
+                                           :input-kind  input-kind
+                                           :ref-count   (or (:ref-count entry) 0)
+                                           :value       (when-let [r (:reaction entry)]
+                                                          (try @r (catch :default _ nil))))
+                                    (with-source-coords meta))]
+                 (assoc acc query-v node)))
+             {}
+             @cache))))
+     :clj
+     nil))
+
 ;; ---- bundle-isolation sentinel ------------------------------------------
 ;;
 ;; Per rf2-bmzq0: `implementation/scripts/check-bundle-isolation.cjs`

--- a/implementation/core/test/re_frame/sub_algebra_view_test.clj
+++ b/implementation/core/test/re_frame/sub_algebra_view_test.clj
@@ -1,0 +1,243 @@
+(ns re-frame.sub-algebra-view-test
+  "Tests for the STATIC derivation/process algebra view of subscriptions
+  (EP-0014 slice-2, rf2-gge6mf). Per [spec/Derivations.md] (graduated from
+  EP-0014) and the `:rf/derivation-node` shape in [spec/Spec-Schemas.md].
+
+  `re-frame.subs.tooling/sub-algebra-view` lowers every registered
+  subscription — a layer-1 `:db` reader, a static `:<-` sub, a parametric
+  input-fn sub, the framework `reg-runtime-sub`, and the framework
+  `reg-frame-state-sub` — into the normalized algebra node every declared
+  fact/process shares: a `:derivation` whose ephemeral output fact is
+  evaluated `:on-demand` and owned by its `:subscription-cache-entry`.
+
+  These tests pin the registrar-derived projection: the fixed
+  classifications (`:kind` / `:storage` / `:evaluation` / `:lifecycle` /
+  `:materialized?`), the per-kind declared-input lowering, the output fact
+  id, the source-form metadata, the opaque `:derive` body token, and the
+  source coordinates. The live cache-entry view (the realized parametric
+  edges) is the CLJS counterpart, pinned in the reagent runtime suite.
+
+  Slice-2 ships NO public accessor (EP-0014 issue-1 disposition): the view
+  lives in the bundle-isolated `re-frame.subs.tooling` sibling, reached on
+  JVM through the `re-frame.subs/sub-algebra-view` convenience alias, and
+  consumed by Xray + the conformance fixtures. There is no
+  `re-frame.core/sub-algebra-view` public facade export."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            [re-frame.subs.tooling :as subs-tooling]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (schemas/clear-schemas-by-frame!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; The five fixed classifications EVERY subscription algebra node carries
+;; (Derivations §Worked equivalence — the subscription is the canonical
+;; ephemeral / on-demand / cache-entry member of the algebra).
+(def fixed-classifications
+  {:kind          :derivation
+   :storage       :ephemeral
+   :evaluation    :on-demand
+   :lifecycle     :subscription-cache-entry
+   :materialized? false})
+
+(defn- has-fixed-classifications? [node]
+  (= fixed-classifications (select-keys node (keys fixed-classifications))))
+
+;; ---- empty / shape contract ----------------------------------------------
+
+(deftest empty-registry-returns-empty-map
+  (testing "(sub-algebra-view) returns {} (not nil) when no subs are registered"
+    (registrar/clear-all!)
+    (is (= {} (subs-tooling/sub-algebra-view)))
+    (is (map? (subs-tooling/sub-algebra-view)))))
+
+(deftest jvm-alias-mirrors-the-tooling-fn
+  (testing "the JVM `re-frame.subs/sub-algebra-view` alias is the tooling fn"
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (is (= (subs-tooling/sub-algebra-view)
+           (subs/sub-algebra-view))
+        "the JVM convenience alias projects identically to the tooling sibling")))
+
+;; ---- reg-sub :db (layer-1) -----------------------------------------------
+
+(deftest layer-1-sub-exposes-its-algebra-view
+  (testing "a layer-1 reg-sub exposes the full ephemeral / on-demand / cache-entry node"
+    (rf/reg-sub :cart/items (fn [db _] (get-in db [:cart :items])))
+    (let [node ((subs-tooling/sub-algebra-view) :cart/items)]
+      (is (some? node))
+      (is (has-fixed-classifications? node)
+          "layer-1 sub carries the fixed derivation / ephemeral / on-demand / cache-entry classifications")
+      (is (= :cart/items (:id node)))
+      (is (= {:kind :reg-sub :id :cart/items} (:source-form node)))
+      (is (= [:fact :cart/items] (:output node))
+          "the output is an ephemeral fact addressed by the sub id")
+      (is (= [[:db []]] (:inputs node))
+          "a layer-1 reader hands the WHOLE app-db to the body — conservative declared input is [:db []]")
+      (is (not (contains? node :input-producer))
+          "a :db reader has no input producer")
+      (is (fn? (:derive node))
+          "the body fn is surfaced as an opaque :derive token"))))
+
+(deftest single-arity-returns-one-node
+  (testing "(sub-algebra-view id) returns the single node, nil when unregistered"
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (is (= ((subs-tooling/sub-algebra-view) :n)
+           (subs-tooling/sub-algebra-view :n))
+        "the one-arity form equals the entry in the all-subs map")
+    (is (nil? (subs-tooling/sub-algebra-view :ghost))
+        "an unregistered sub id projects to nil")))
+
+;; ---- reg-sub static :<- --------------------------------------------------
+
+(deftest static-sub-lowers-each-input-to-a-sub-edge
+  (testing "a static :<- sub lowers each literal input query-vector to a [:sub q] declared input"
+    (rf/reg-sub :cart/items      (fn [db _] (:items db)))
+    (rf/reg-sub :pricing/discounts (fn [db _] (:discounts db)))
+    (rf/reg-sub :cart/total
+                :<- [:cart/items]
+                :<- [:pricing/discounts]
+                (fn [[items discounts] _] [items discounts]))
+    (let [node ((subs-tooling/sub-algebra-view) :cart/total)]
+      (is (has-fixed-classifications? node))
+      (is (= [:fact :cart/total] (:output node)))
+      (is (= [[:sub [:cart/items]]
+              [:sub [:pricing/discounts]]]
+             (:inputs node))
+          "each :<- input is a [:sub query-vector] declared input, in declaration order")
+      (is (not (contains? node :input-producer))))))
+
+(deftest static-sub-preserves-query-vector-args
+  (testing "static declared inputs preserve the full :<- query-vector args"
+    (rf/reg-sub :upstream (fn [db [_ _arg]] (:n db)))
+    (rf/reg-sub :downstream :<- [:upstream :some-arg] (fn [u _] u))
+    (is (= [[:sub [:upstream :some-arg]]]
+           (:inputs ((subs-tooling/sub-algebra-view) :downstream)))
+        "the declared input carries the full :<- query-vector, args and all")))
+
+;; ---- reg-sub parametric input-fn -----------------------------------------
+
+(deftest parametric-sub-reports-the-parametric-marker
+  (testing "a parametric input-fn sub reports the :parametric inputs marker + an opaque :input-producer"
+    ;; The realized edge set depends on the concrete outer query-v and is
+    ;; NOT statically enumerable — the static graph reports the :parametric
+    ;; marker (the don't-execute rule, Derivations §Static and live graphs);
+    ;; the live cache view reports the realized [:sub …] edges.
+    (rf/reg-sub :article/by-id        (fn [db [_ id]] (get-in db [:articles id])))
+    (rf/reg-sub :comments/for-article (fn [db [_ id]] (get-in db [:comments id])))
+    (rf/reg-sub :article/page
+                (fn [[_ id]]
+                  [[:article/by-id id]
+                   [:comments/for-article id]])
+                (fn [[article comments] [_ id]]
+                  {:id id :article article :comments comments}))
+    (let [node ((subs-tooling/sub-algebra-view) :article/page)]
+      (is (has-fixed-classifications? node))
+      (is (= [:fact :article/page] (:output node)))
+      (is (= :parametric (:inputs node))
+          "the static graph reports the :parametric marker, never fabricated edges")
+      (is (not (vector? (:inputs node)))
+          "the parametric edge set must NOT be presented as a static vector")
+      (is (fn? (:input-producer node))
+          "a parametric node surfaces the input-fn as an opaque :input-producer token"))))
+
+;; ---- reg-runtime-sub -----------------------------------------------------
+
+(deftest runtime-sub-declares-a-runtime-partition-input
+  (testing "a framework reg-runtime-sub lowers to a [:runtime []] declared input"
+    ;; reg-runtime-sub is framework-internal (not on the rf/ facade) — call
+    ;; through re-frame.subs directly. Its signal source is the runtime-db
+    ;; projection, so its conservative declared input is [:runtime []].
+    (subs/reg-runtime-sub :rf.route/params
+                          (fn [runtime-db _] (get-in runtime-db [:rf.runtime/routing :current :params])))
+    (let [node ((subs-tooling/sub-algebra-view) :rf.route/params)]
+      (is (some? node))
+      (is (has-fixed-classifications? node)
+          "a runtime sub is still an ephemeral / on-demand / cache-entry derivation")
+      (is (= [:fact :rf.route/params] (:output node)))
+      (is (= [[:runtime []]] (:inputs node))
+          "the runtime sub reads the runtime-db partition — declared input is [:runtime []]")
+      (is (= {:kind :reg-sub :id :rf.route/params} (:source-form node))))))
+
+;; ---- reg-frame-state-sub -------------------------------------------------
+
+(deftest frame-state-sub-declares-a-frame-state-input
+  (testing "a framework reg-frame-state-sub lowers to a [:frame-state []] declared input"
+    ;; A :frame-state sub reads across BOTH partitions (the whole frame-state
+    ;; value); the input vocabulary reserves [:frame-state path] for exactly
+    ;; this framework-internal cross-partition read.
+    (subs/reg-frame-state-sub :rf/whole-state
+                              (fn [frame-state _] frame-state))
+    (let [node ((subs-tooling/sub-algebra-view) :rf/whole-state)]
+      (is (some? node))
+      (is (has-fixed-classifications? node))
+      (is (= [:fact :rf/whole-state] (:output node)))
+      (is (= [[:frame-state []]] (:inputs node))
+          "the frame-state sub reads across partitions — declared input is [:frame-state []]"))))
+
+;; ---- source-coords / schema / doc passthrough ----------------------------
+
+(deftest source-coords-surface-in-the-node
+  (testing ":ns / :line / :file captured by reg-sub surface under :source"
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (let [node ((subs-tooling/sub-algebra-view) :n)
+          source (:source node)]
+      (is (some? source) ":source map is present when the registration carried coords")
+      (is (some? (:ns source))     ":ns captured at the call site")
+      (is (number? (:line source)) ":line captured at the call site")
+      (is (some? (:file source))   ":file captured at the call site"))))
+
+(deftest schema-and-doc-pass-through
+  (testing ":schema and :doc supplied on the registration meta surface in the node"
+    (rf/reg-sub :priced
+                {:doc    "a priced item"
+                 :schema :app.money/amount}
+                (fn [db _] (:price db)))
+    (let [node ((subs-tooling/sub-algebra-view) :priced)]
+      (is (= :app.money/amount (:schema node))
+          "the declared output :schema surfaces as a node fact")
+      (is (= "a priced item" (:doc node))))))
+
+(deftest no-schema-or-doc-when-absent
+  (testing ":schema / :doc are absent when the registration didn't supply them"
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (let [node ((subs-tooling/sub-algebra-view) :n)]
+      (is (not (contains? node :schema)))
+      (is (not (contains? node :doc))))))
+
+;; ---- registry semantics --------------------------------------------------
+
+(deftest reregistration-replaces-the-node
+  (testing "re-registering a sub replaces its algebra node (last-write-wins)"
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (is (= [[:db []]] (:inputs ((subs-tooling/sub-algebra-view) :a))))
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    (rf/reg-sub :a :<- [:b] (fn [b _] b))
+    (let [node ((subs-tooling/sub-algebra-view) :a)]
+      (is (= [[:sub [:b]]] (:inputs node))
+          "the re-registered :<- chain replaces the prior :db reader's inputs")
+      (is (has-fixed-classifications? node)))))
+
+(deftest cleared-sub-is-removed
+  (testing "(clear-sub id) removes the sub from the algebra view"
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    (is (contains? (subs-tooling/sub-algebra-view) :a))
+    (subs/clear-sub :a)
+    (let [view (subs-tooling/sub-algebra-view)]
+      (is (not (contains? view :a)))
+      (is (contains? view :b)))))

--- a/spec/Derivations.md
+++ b/spec/Derivations.md
@@ -447,6 +447,34 @@ Their algebra views differ only in output, storage, evaluation, and lifecycle:
 
 `sum-cart` is one whole-value function. The difference between the subscription and the flow is **not the mathematical function; it is policy over the same dependency graph.** That is the whole point of naming the algebra. Full worked source-form/algebra-view pairs for every member — parametric subscriptions, runtime subscriptions, resources (static + live), route facts, machine processes and selectors — live in [EP-0014 §Examples](../docs/EP/EP-0014-derivation-and-process-algebra.md#examples).
 
+## Subscriptions expose algebra views
+
+Subscriptions are the first concrete algebra member to expose its view. Every subscription registration — `reg-sub` (the layer-1 `:db` reader, the static `:<-` chain, and the parametric input-fn form), the framework-internal `reg-runtime-sub` and `reg-frame-state-sub`, and every live sub-cache entry — projects to the [node shape](#the-node-shape). The projection is **registrar-derived** (see [§The EP-0013 relocation seam](#the-ep-0013-relocation-seam)): the reactive substrate ([006](006-ReactiveSubstrate.md)) keeps the cache, ref-counting, and disposal semantics; the algebra view is assembled from the registration metadata that already exists, never from re-executing a source form.
+
+A subscription is always a **`:derivation`** (never a process — [§Derivation](#derivation)), and every subscription node carries the same five fixed classifications, because a subscription is the canonical ephemeral member of the algebra:
+
+| Axis | Value | Why |
+|---|---|---|
+| `:kind` | `:derivation` | a pure whole-value computation; no durable private state |
+| `:storage` | `:ephemeral` | a cache/reaction value, never written to durable frame state |
+| `:evaluation` | `:on-demand` | evaluated when a reader subscribes — a read never causes a durable write ([§Evaluation policy](#evaluation-policy) rule 1) |
+| `:lifecycle` | `:subscription-cache-entry` | the concrete query vector's readers keep it alive; ref-count disposal releases it |
+| `:materialized?` | `false` | an ephemeral output has a fact identity but no durable address |
+
+The two axes that **vary** per subscription are the declared **inputs** and the **output** fact id:
+
+- **`:output`** is `[:fact <id>]` — the sub id for a static node, the concrete query vector for a live cache entry.
+- **`:inputs`** lowers from the registered input-producer kind ([§Declared input](#declared-input); the [006](006-ReactiveSubstrate.md) input-producer discriminator):
+  - a layer-1 `:db` reader hands the *whole* `app-db` value to its body, so the conservative declared input is the app-db projection root `[[:db []]]` (a future path-aware source form MAY narrow it; correctness does not depend on the narrowing);
+  - a `reg-runtime-sub` reads the runtime-db partition — `[[:runtime []]]`;
+  - a `reg-frame-state-sub` reads across both partitions (framework-internal) — `[[:frame-state []]]`;
+  - a static `:<-` sub lowers each literal input query-vector to a `[:sub query-vector]` edge, in declaration order (args preserved);
+  - a parametric input-fn sub reports the **`:parametric`** marker plus an opaque `:input-producer` token — its realized edge set depends on a concrete query vector and is *not statically enumerable* (the [don't-execute rule](#the-dont-execute-rule-ep-0014-issue-3-disposition); the static graph never runs the input-fn). The **live** sub-cache view reports the realized `[:sub query-vector]` edges per concrete entry — exactly the edges the static graph cannot enumerate.
+
+The node additionally carries the opaque `:derive` body token (never serialized — [§The node shape](#the-node-shape)), the `:source-form` `{:kind :reg-sub :id <id>}`, and the `:source` coordinates / `:schema` / doc when the registration carried them. A live cache-entry node also carries its current `:value` (a value summary, redacted by the graph-inspection helper before egress — [§Redaction metadata](#redaction-metadata-ep-0014-issue-1-disposition-ep-0015)) and its `:ref-count` (the lifecycle evidence the cache-entry owner is kept alive by its readers).
+
+This exposure is *internal registration metadata*, consistent with the slice scope: it ships **no public accessor**. The static and live subscription views live in the bundle-isolated subscription tooling sibling (`re-frame.subs.tooling/sub-algebra-view` and `…/sub-cache-algebra-view` in the reference implementation; production CLJS bundles DCE the bodies), consumed by [Xray](../tools/xray/spec/README.md) and the conformance fixtures — the two named first consumers. They feed the later internal graph-inspection helper ([EP-0014 §Reference Implementation / Bead Plan](../docs/EP/EP-0014-derivation-and-process-algebra.md#reference-implementation--bead-plan) item 7); the public name is deferred until a third consumer needs it (the [graduation gate](#one-accessor-two-projections-ep-0014-issue-1-disposition)).
+
 ## The EP-0013 relocation seam
 
 In slice-1 the algebra view is **registrar-derived** — assembled from registration metadata at the surface that registers each source form. The normalized node this doc defines is deliberately the per-fact/per-process row an app value would carry, so a future move to [EP-0013](../docs/EP/EP-0013-app-values-and-runtime-realms.md) app values/runtime realms is a *relocation, not a redesign*.


### PR DESCRIPTION
@
## What

EP-0014 action-wave **slice-2** (bead `rf2-gge6mf`, epic `rf2-k0meap`, Reference Implementation Plan item 2). Extends subscription registration metadata so every subscription source form exposes the EP-0014 **derivation/process algebra** node shape (`:rf/derivation-node`, owned by `spec/Derivations.md` + `spec/Spec-Schemas.md`, merged in slice-1).

A subscription is the canonical *ephemeral* member of the algebra: a `:derivation` whose ephemeral output fact is evaluated `:on-demand` and owned by its `:subscription-cache-entry`. This slice lowers `reg-sub` (layer-1 `:db`, static `:<-`, parametric input-fn), the framework `reg-runtime-sub` and `reg-frame-state-sub`, and every live sub-cache entry into that node.

## How

Two **registrar-derived** projections added to the bundle-isolated `re-frame.subs.tooling` sibling (production CLJS bundles DCE the bodies, same as the existing `sub-topology` / `sub-cache-snapshot`):

- **`sub-algebra-view`** (static, JVM-runnable) — every registered sub → a `:derivation` node with the five fixed classifications (`:kind`/`:storage`/`:evaluation`/`:lifecycle`/`:materialized?`), declared inputs lowered per input-kind (`[[:db []]]` / `[[:runtime []]]` / `[[:frame-state []]]` / `[:sub q]` edges / the `:parametric` marker + opaque `:input-producer`), `:output [:fact id]`, `:source-form {:kind :reg-sub :id …}`, opaque `:derive` body token, `:source` coords + `:schema`/`:doc` when present.
- **`sub-cache-algebra-view`** (live, CLJS/dev-only) — one node per concrete cache entry, keyed by its query vector, carrying the **realized** `[:sub query-vector]` edges the static graph cannot enumerate (the static/live distinction), plus `:value` + `:ref-count`.

The algebra view shape (subscription node):

```clojure
{:id            :cart/total
 :kind          :derivation
 :source-form   {:kind :reg-sub :id :cart/total}
 :inputs        [[:sub [:cart/items]] [:sub [:pricing/discounts]]]  ;; or [[:db []]] / :parametric / …
 :output        [:fact :cart/total]
 :storage       :ephemeral
 :evaluation    :on-demand
 :lifecycle     :subscription-cache-entry
 :materialized? false
 :derive        <opaque-body-token>
 :source        {:ns … :file … :line …}}   ;; :schema / :doc when registered
```

**Consumes** the slice-1 vocabulary — does NOT redefine the `:rf/storage-class` / `:rf/evaluation-policy` / `:rf/lifecycle` enums or the node schema (those stay owned by Spec-Schemas / Derivations; not touched). **No public accessor** ships (EP-0014 issue-1 disposition): reached via `re-frame.subs.tooling/*` directly (CLJS: Xray + conformance) or the `#?(:clj …)` `re-frame.subs/*` aliases; **no `re-frame.core` facade export added**. Feeds the later internal graph-inspection helper (plan item 7).

`spec/Derivations.md`: new **§Subscriptions expose algebra views** documents the exposure — the fixed-classification table, per-kind input lowering, and the internal-only / no-public-accessor staging.

## Tests

- **`implementation/core/test/re_frame/sub_algebra_view_test.clj`** (NEW, 14 tests / 46 assertions, JVM): static view for `:db` / static `:<-` / parametric input-fn / `reg-runtime-sub` / `reg-frame-state-sub`; fixed classifications; output fact; source-form; opaque `:derive`; source coords / schema / doc passthrough; re-registration + clear semantics; the JVM alias parity.
- **`implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs`** (+3 tests, CLJS): live sub-cache node (id = query vector, fixed classifications, `:value` + `:ref-count`, named-vs-active-frame parity, missing-frame → nil); static `:<-` realized-edge lowering; parametric realized-edge lowering vs the static `:parametric` marker.

## Quality gates

- `npm run test:cljs` (core, node-runtime): **6575 tests / 24038 assertions, 0 failures, 0 errors** (incl. the 3 new live-view tests).
- core `clojure -M:test` (full core JVM suite): **1204 tests / 5314 assertions, 0 failures, 0 errors**.
- new JVM test focused: **14 tests / 46 assertions, 0 failures, 0 errors**.
- `python -m mkdocs build --strict` (Derivations.md touched): **exit 0**.
- `npm run test:bundle-isolation`: **PASS** — tooling-sibling bodies confirmed absent from production bundles.
@