### PR TITLE
feat(resources): EP-0016 slice-5 — scoped invalidation descriptors (rf2-hwc2ev)

### DIFF
--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -66,6 +66,7 @@
             [re-frame.resources.mutation-runtime :as mstate]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.reply :as rreply]
+            [re-frame.resources.scope-registry :as scope-registry]
             [re-frame.resources.state :as state]
             [re-frame.resources.transport :as transport]
             [re-frame.resources.work-ledger :as work-ledger]
@@ -208,22 +209,123 @@
       populates)
     [runtime-db #{} {}]))
 
-(defn- invalidation-fx
-  "Build the `:rf.resource/invalidate-tags` dispatch fx (or nil) for the
-  mutation's `:invalidates` result. `:invalidates` is
-  `(fn [params result] -> #{tag …})`. The invalidation is SCOPED to the
-  mutation's resolved scope (same cache-scope rules as resources); it
-  composes with the landed exact-tag invalidation (`:rf.resource/invalidate-
-  tags`) wholesale — the runtime does not re-implement the invalidation, it
-  causes it. Returns a `[:dispatch …]` fx pair, or nil when the mutation
-  invalidates nothing. Per EP-0003 §Mutations (tag invalidation from
-  success / failure)."
-  [invalidates-fn params result scope mutation-id instance-id]
-  (when-let [tags (when invalidates-fn (not-empty (set (invalidates-fn params result))))]
-    [:dispatch [:rf.resource/invalidate-tags
-                {:scope scope
-                 :tags  tags
-                 :cause [:mutation mutation-id instance-id]}]]))
+;; ---- scoped invalidation descriptors (EP-0016 D2 / slice 5) ---------------
+;;
+;; The mutation `:invalidates` arm now lowers TWO public forms — the bare
+;; tag-set shorthand AND the per-target descriptor form — into ONE canonical
+;; descriptor vector (the pure `mstate/normalize-invalidation-descriptors`),
+;; then resolves each descriptor's OWN scope and dispatches the SINGLE scoped
+;; invalidation engine (`:rf.resource/invalidate-tags`) once per descriptor.
+;; The runtime does not re-implement the invalidation — it causes it, once per
+;; resolved `(tags, scope)` pair (Spec 016 §Scoped invalidation descriptors).
+
+(defn- resolve-descriptor-scope
+  "Resolve ONE invalidation descriptor's `:scope` to a concrete cache scope at
+  settle time, against the mutation's resolved scope `mut-scope` and the
+  handler's app-db coeffect `db` (the EP-0010-coherent causal input). Returns
+  `[:resolved <concrete-scope>]`, `[:cross-scope]` (the audited escape — no
+  concrete scope, the engine ignores the scope filter), or `[:nil-resolved
+  <from-db-id>]` (a `{:from-db …}` reference that resolved nil — FAIL-CLOSED:
+  this descriptor produces NO invalidation, never an implicit global blast).
+  Per Spec 016 §Scoped invalidation descriptors / §Resolver references.
+
+    - `:rf.scope/same` (the default) -> the mutation's resolved scope;
+    - `:rf.scope/global` / a concrete value -> routed through the SHARED
+      `state/canonicalize-scope` (typo / host / global-spelling guarantees);
+    - `{:from-db <id>}` -> resolved against `db` at use time, nil fail-closed;
+    - a `:cross-scope? true` descriptor -> `[:cross-scope]` (scope-agnostic by
+      construction; its `:scope`, if any, is advisory only)."
+  [{:keys [scope cross-scope?]} mut-scope db where]
+  (cond
+    cross-scope?                                [:cross-scope]
+    (= scope mstate/same-scope-marker)          [:resolved mut-scope]
+    (scope-registry/from-db-reference? scope)   (if-let [s (scope-registry/resolve-from-db-reference scope db where)]
+                                                  [:resolved (state/canonicalize-scope s where nil)]
+                                                  [:nil-resolved (:from-db scope)])
+    :else                                       [:resolved (state/canonicalize-scope scope where nil)]))
+
+(defn- invalidation-plan
+  "Resolve the mutation's `:invalidates` result into the per-descriptor
+  invalidation plan at settle time. `:invalidates` is
+  `(fn [params result] -> <tag-set | descriptor | descriptor-vector>)`
+  (Spec 016 §Scoped invalidation descriptors / §Cache-consequence callback
+  signatures — the one canonical `(params result)` signature, NO `db`/`ctx`).
+
+  The raw result lowers (purely) into the canonical descriptor vector; each
+  descriptor's OWN scope is resolved against the mutation's resolved scope
+  `mut-scope` and the handler app-db `db` at settle time (the single use-time
+  rule for `{:from-db …}` references). A `:rf.scope/same` (default) descriptor
+  resolves to `mut-scope`; a concrete / `:rf.scope/global` scope is canonicalized;
+  a `:cross-scope? true` descriptor lowers to the audited scope-agnostic engine
+  path; a `{:from-db …}` reference that resolves NIL is FAIL-CLOSED — it is
+  recorded in `:unresolved` and produces NO dispatch (never an implicit global
+  blast).
+
+  Returns `nil` when the mutation has no `:invalidates` fn, else a plan map
+  `{:dispatches [<resolved-descriptor> …] :unresolved [<from-db-id> …]
+  :descriptor-count <n>}` — the caller turns `:dispatches` into the
+  per-descriptor `:rf.resource/invalidate-tags` fx and attaches the whole plan
+  (incl. the fail-closed `:unresolved` evidence) to the mutation settlement
+  trace (the descriptor-level invalidation evidence Spec 016 §Trace evidence
+  for invalidation prescribes, recorded on the existing `:rf.mutation/*`
+  settlement op rather than a new trace op). Per EP-0003 §Mutations / EP-0016 D2."
+  [invalidates-fn params result mut-scope db where]
+  (when invalidates-fn
+    (let [descriptors (mstate/normalize-invalidation-descriptors
+                        (invalidates-fn params result) where)]
+      (reduce
+        (fn [plan {:keys [tags cross-scope? refetch-populated?] :as descriptor}]
+          (if-not (seq tags)
+            plan
+            (let [[outcome scope-or-id] (resolve-descriptor-scope
+                                          descriptor mut-scope db where)]
+              (case outcome
+                :nil-resolved
+                (update plan :unresolved conj scope-or-id)
+                :cross-scope
+                (update plan :dispatches conj
+                        {:scope nil :cross-scope? true :tags tags
+                         :refetch-populated? refetch-populated?})
+                :resolved
+                (update plan :dispatches conj
+                        {:scope scope-or-id :cross-scope? false :tags tags
+                         :refetch-populated? refetch-populated?})))))
+        {:dispatches [] :unresolved [] :descriptor-count (count descriptors)}
+        descriptors))))
+
+(defn- plan->fx
+  "Turn an `invalidation-plan` `:dispatches` vector into the per-descriptor
+  `[:dispatch [:rf.resource/invalidate-tags …]]` fx — one dispatch into the
+  SINGLE scoped invalidation engine per resolved descriptor. Returns nil when
+  the plan dispatches nothing (so the caller's `cond->` skips it)."
+  [plan cause]
+  (not-empty
+    (mapv (fn [{:keys [scope cross-scope? tags]}]
+            [:dispatch [:rf.resource/invalidate-tags
+                        (cond-> {:tags tags :cause cause}
+                          (some? scope) (assoc :scope scope)
+                          cross-scope?  (assoc :cross-scope? true))]])
+          (:dispatches plan))))
+
+(defn- plan-tags
+  "The union of every dispatched descriptor's tags (the invalidated-tags trace
+  reservation / `:patch-summary` facet)."
+  [plan]
+  (into #{} (mapcat :tags) (:dispatches plan)))
+
+(defn- plan-trace
+  "The descriptor-level invalidation evidence facet for the mutation settlement
+  trace (Spec 016 §Trace evidence for invalidation): the descriptor count, the
+  per-descriptor resolved `(scope, cross-scope?, tags)`, and the fail-closed
+  `:unresolved` `{:from-db …}` ids (descriptors that resolved nil and produced
+  no invalidation). nil-safe (an absent plan yields nil)."
+  [plan]
+  (when plan
+    {:descriptor-count (:descriptor-count plan)
+     :dispatched (mapv (fn [{:keys [scope cross-scope? tags]}]
+                         {:scope scope :cross-scope? cross-scope? :tags (vec tags)})
+                       (:dispatches plan))
+     :unresolved (vec (:unresolved plan))}))
 
 ;; ---- mutation completion continuation — call-site :reply-to (D1) -----------
 ;;
@@ -315,7 +417,7 @@
 
   Returns the event-fx map (`:rf.db/runtime` + `:fx`)."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, gen-snapshot :rf.resource/generation
-    world :rf.world/inputs}
+    world :rf.world/inputs, app-db :db}
    [_event-id {:keys [mutation params instance scope cause reply-to] :as _payload}]]
   (let [where      'rf.mutation/execute
         runtime-db (or rt {})
@@ -357,8 +459,14 @@
         http-args  ((:request spec) cparams nil)
         invalidate-timing (or (:invalidate-timing spec) :after-success)
         before?    (= :before-request invalidate-timing)
-        before-fx  (when before?
-                     (invalidation-fx (:invalidates spec) cparams nil cscope mutation instance-id))
+        ;; EP-0016 D2: a `:before-request` invalidation resolves descriptor
+        ;; scopes (incl. `{:from-db …}`) against the EXECUTE-time app-db (the
+        ;; causal coeffect db), then lowers each descriptor into one dispatch
+        ;; of the single scoped invalidation engine.
+        before-plan (when before?
+                      (invalidation-plan (:invalidates spec) cparams nil cscope app-db where))
+        before-fxs  (when before-plan
+                      (plan->fx before-plan [:mutation mutation instance-id]))
         instance'  (mstate/empty-instance
                      mutation instance-id
                      {:scope cscope :params cparams :cause cause
@@ -411,9 +519,13 @@
                        (assoc-in (mstate/instance-path instance-id) instance')
                        (work-ledger/put-record work-id record))]
     (trace/emit! :rf.event :rf.mutation/started
-                 {:rf.frame/id frame-id :mutation mutation :instance instance-id
-                  :work-id work-id :generation generation :scope cscope
-                  :cause cause :invalidate-timing invalidate-timing})
+                 (cond-> {:rf.frame/id frame-id :mutation mutation :instance instance-id
+                          :work-id work-id :generation generation :scope cscope
+                          :cause cause :invalidate-timing invalidate-timing}
+                   ;; EP-0016 D2: a `:before-request` invalidation attaches its
+                   ;; descriptor-level evidence (resolved scopes + fail-closed
+                   ;; nil-resolved `{:from-db …}` ids) to the started trace.
+                   before-plan (assoc :invalidation (plan-trace before-plan))))
     {:rf.db/runtime rdb'
      ;; rf2-agrjvk — `:before-request` invalidation must precede the request
      ;; being lowered to transport. fx run in order, so the invalidation
@@ -427,8 +539,8 @@
                   [:rf.resource/record-work-handle
                    {:frame-id frame-id :work-id work-id
                     :transport transport-id :request-id request-id}]]
-           before-fx (conj before-fx)
-           true      (conj lower-fx))}))
+           before-fxs (into before-fxs)
+           true       (conj lower-fx))}))
 
 ;; ---- :rf.mutation/clear — causal instance reset ---------------------------
 
@@ -645,9 +757,10 @@
   (the instance-layer spelling — kh9jz6 / EP-0007).
 
   Event shape: `[_ <verification-payload> <http-result>]`."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs, app-db :db}
    [_event-id {work-id :work/id :keys [instance-id mutation-id generation scope reply-to] :as payload} http-result]]
-  (let [runtime-db (or rt {})
+  (let [where      'rf.mutation.internal/succeeded
+        runtime-db (or rt {})
         ;; EP-0010 §Managed Effects And Reply Tokens / §Resources, Mutations,
         ;; And Work-Ledger Timestamps: the reply is a CAUSAL TOKEN; the host
         ;; completion time (`:completed-at`, read ONCE at the transport
@@ -699,13 +812,20 @@
             [rdb2 populated-ks populate-policies] (apply-populates rdb1 (:populates spec) params result clock-ms)
             patch-affected      (set/union patched-ks populated-ks)
             timer-policies      (merge patch-policies populate-policies)
-            ;; the success-time invalidation tags (scoped). The patch already
-            ;; freshened the keys it touched; the invalidation reaches the
-            ;; OTHER tagged entries (lists, siblings) the patch did not seed.
-            inv-fx      (when (#{:after-success :after-settle} timing)
-                          (invalidation-fx (:invalidates spec) params result scope
-                                           mutation-id instance-id))
-            inv-tags    (when inv-fx (get-in inv-fx [1 1 :tags]))
+            ;; the success-time invalidation (EP-0016 D2: per-descriptor
+            ;; scoped). The patch already freshened the keys it touched; the
+            ;; invalidation reaches the OTHER tagged entries (lists, siblings)
+            ;; the patch did not seed. Each descriptor resolves its OWN scope
+            ;; (incl. `{:from-db …}` against this reply's app-db at settle time)
+            ;; and lowers into one dispatch of the single scoped invalidation
+            ;; engine; a nil-resolving `{:from-db …}` is fail-closed (recorded
+            ;; in the plan `:unresolved`, no dispatch).
+            inv-plan    (when (#{:after-success :after-settle} timing)
+                          (invalidation-plan (:invalidates spec) params result scope app-db where))
+            inv-fxs     (when inv-plan (plan->fx inv-plan [:mutation mutation-id instance-id]))
+            ;; the union of every dispatched descriptor's tags (the affected-key
+            ;; / patch-summary trace reservation records the invalidated tags).
+            inv-tags    (when inv-plan (plan-tags inv-plan))
             ;; the affected-key / patch-summary trace reservation (optimistic
             ;; rollback shape — DEFERRED; populated descriptively here)
             affected    (vec patch-affected)
@@ -763,12 +883,17 @@
                            :status (:status reply)})]
         (work-ledger/clear-handle! frame-id work-id)
         (trace/emit! :rf.event :rf.mutation/succeeded
-                     {:rf.frame/id frame-id :instance instance-id :mutation mutation-id
-                      :work-id work-id :generation generation
-                      :affected-keys affected :patch-summary patch-summary})
+                     (cond-> {:rf.frame/id frame-id :instance instance-id :mutation mutation-id
+                              :work-id work-id :generation generation
+                              :affected-keys affected :patch-summary patch-summary}
+                       ;; EP-0016 D2: the descriptor-level invalidation evidence
+                       ;; (resolved scope per descriptor + fail-closed
+                       ;; nil-resolved `{:from-db …}` ids) rides the settlement
+                       ;; trace (Spec 016 §Trace evidence for invalidation).
+                       inv-plan (assoc :invalidation (plan-trace inv-plan))))
         {:rf.db/runtime rdb'
          :fx (cond-> (vec timer-fx)
-               inv-fx  (conj inv-fx)
+               inv-fxs (into inv-fxs)
                cont-fx (conj cont-fx))}))))
 
 (defn failed-handler
@@ -788,9 +913,10 @@
   `:error` stores) is read back from the canonical reply.
 
   Event shape: `[_ <verification-payload> <http-result>]`."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs, app-db :db}
    [_event-id {work-id :work/id :keys [instance-id mutation-id generation scope reply-to] :as payload} http-result]]
-  (let [runtime-db (or rt {})
+  (let [where      'rf.mutation.internal/failed
+        runtime-db (or rt {})
         ;; EP-0010 §Managed Effects And Reply Tokens / §Resources, Mutations,
         ;; And Work-Ledger Timestamps: a terminal mutation reply writes
         ;; `:settled-at` from the reply completion time. The host
@@ -831,11 +957,13 @@
             clock-ms completed-at
             ;; failure-time invalidation (only when the timing opts in):
             ;; some mutations invalidate on failure to force a re-read of
-            ;; the authoritative server state after a rejected write.
-            inv-fx   (when (#{:after-failure :after-settle} timing)
-                       (invalidation-fx (:invalidates spec) params nil scope
-                                        mutation-id instance-id))
-            inv-tags (when inv-fx (get-in inv-fx [1 1 :tags]))
+            ;; the authoritative server state after a rejected write. EP-0016
+            ;; D2: per-descriptor scoped (the failure result is nil, so
+            ;; descriptor fns close over only `params`).
+            inv-plan (when (#{:after-failure :after-settle} timing)
+                       (invalidation-plan (:invalidates spec) params nil scope app-db where))
+            inv-fxs  (when inv-plan (plan->fx inv-plan [:mutation mutation-id instance-id]))
+            inv-tags (when inv-plan (plan-tags inv-plan))
             inst'    (mstate/instance-failed
                        inst {:error error :settled-at clock-ms
                              :affected-keys (when inv-tags [])})
@@ -864,10 +992,13 @@
                         :status (:status reply)})]
         (work-ledger/clear-handle! frame-id work-id)
         (trace/emit! :rf.event :rf.mutation/failed
-                     {:rf.frame/id frame-id :instance instance-id :mutation mutation-id
-                      :work-id work-id :generation generation :error error
-                      :invalidated-tags (vec (or inv-tags #{}))})
+                     (cond-> {:rf.frame/id frame-id :instance instance-id :mutation mutation-id
+                              :work-id work-id :generation generation :error error
+                              :invalidated-tags (vec (or inv-tags #{}))}
+                       ;; EP-0016 D2: descriptor-level failure-invalidation
+                       ;; evidence rides the failed-settlement trace.
+                       inv-plan (assoc :invalidation (plan-trace inv-plan))))
         {:rf.db/runtime rdb'
          :fx (cond-> []
-               inv-fx  (conj inv-fx)
+               inv-fxs (into inv-fxs)
                cont-fx (conj cont-fx))}))))

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -476,3 +476,139 @@
   (when (and (some? instance-id) (not (state/serializable-edn? instance-id)))
     (throw (instance-id-error instance-id where)))
   instance-id)
+
+;; ---- scoped invalidation descriptors (EP-0016 D2 / slice 5) ---------------
+;;
+;; The mutation `:invalidates` arm is `(fn [params result] -> <descriptors>)`.
+;; Two PUBLIC input forms lower to ONE canonical descriptor vector (and from
+;; there into the SINGLE scoped invalidation engine `:rf.resource/invalidate-
+;; tags`, never a second engine — Spec 016 §Scoped invalidation descriptors):
+;;
+;;   - the BARE tag-set shorthand `#{[:article slug] [:article-list]}` — means
+;;     "invalidate those tags in the mutation's resolved (execution) scope"
+;;     (`:rf.scope/same`, the default);
+;;   - the per-target DESCRIPTOR form — a single descriptor map
+;;     `{:scope … :tags #{…}}` or a vector of them, each naming its OWN scope
+;;     so one mutation can precisely invalidate global facts AND viewer-relative
+;;     facts without a blunt `:cross-scope?` blast.
+;;
+;; A descriptor `:scope` is one of: `:rf.scope/same` (default when omitted —
+;; the mutation's resolved scope), `:rf.scope/global`, a concrete canonical
+;; scope value, or a `{:from-db <id>}` named-resolver reference resolved
+;; against db at SETTLE time (phase 4, the single use-time rule). A descriptor
+;; MAY carry `:cross-scope? true` (the audited escape — invalidate the tag in
+;; every scope the cache holds, scopes the call site cannot enumerate) and
+;; `:refetch-populated? true` (the Rider-1 same-mutation refetch opt-in, parsed
+;; here and carried for the slice-6 populate-exempt pass).
+;;
+;; This namespace owns the PURE normalization (raw form -> canonical descriptor
+;; vector); the impure per-descriptor scope resolution + the engine dispatch fx
+;; live in `mutation-events` (it needs the registry + app-db + trace).
+
+(def same-scope-marker
+  "The descriptor `:scope` marker meaning \"the mutation's resolved
+  (execution) scope\" — the DEFAULT when a descriptor omits `:scope`, and the
+  meaning of the bare tag-set shorthand (Spec 016 §Scoped invalidation
+  descriptors). Resolved to the concrete mutation scope by the events layer at
+  settle time; it is NOT itself a literal cache scope (it never reaches the
+  cache key)."
+  :rf.scope/same)
+
+(defn invalidation-descriptor-error
+  "Build the canonical thrown-error shape (Spec 009 §The thrown-error shape)
+  for a malformed mutation `:invalidates` result. A malformed descriptor fails
+  CLOSED at settle time (before any invalidation dispatch), never a silent
+  no-op — an author who returns garbage from `:invalidates` learns loudly."
+  [where reason raw extra]
+  (ex-info ":rf.error/mutation-invalid-invalidation"
+           (merge {:rf.error/id :rf.error/mutation-invalid-invalidation
+                   :where       where
+                   :arm         :invalidates
+                   :recovery    :fix-invalidates
+                   :reason      reason
+                   :invalidates (pr-str raw)}
+                  extra)))
+
+(defn- normalize-one-descriptor
+  "Normalize ONE descriptor map into the canonical shape
+  `{:scope <scope-or-same-marker> :tags #{…} :cross-scope? bool
+  :refetch-populated? bool}`, validating fail-closed. `:scope` defaults to
+  `:rf.scope/same` (Spec 016 §Scoped invalidation descriptors). `:tags` must
+  be a non-nil collection of tags; the boolean flags default false. The
+  `:scope` VALUE is NOT canonicalized here (a `:rf.scope/same` marker and a
+  `{:from-db …}` reference are not concrete scopes yet) — the events layer
+  resolves + canonicalizes the concrete scope at settle time. Returns the
+  canonical descriptor map; throws `:rf.error/mutation-invalid-invalidation`
+  on a non-map descriptor or a non-collection `:tags`."
+  [descriptor raw where]
+  (when-not (map? descriptor)
+    (throw (invalidation-descriptor-error
+             where
+             (str "a mutation :invalidates descriptor must be a map "
+                  "{:scope … :tags #{…}}; got " (pr-str descriptor)
+                  ". Per Spec 016 §Scoped invalidation descriptors.")
+             raw {:descriptor (pr-str descriptor)})))
+  (let [{:keys [scope tags cross-scope? refetch-populated?]} descriptor]
+    (when-not (and (some? tags) (coll? tags))
+      (throw (invalidation-descriptor-error
+               where
+               (str "a mutation :invalidates descriptor must carry a non-nil "
+                    ":tags collection; got " (pr-str tags) " in "
+                    (pr-str descriptor) ". Per Spec 016 §Scoped invalidation "
+                    "descriptors.")
+               raw {:descriptor (pr-str descriptor) :tags (pr-str tags)})))
+    {:scope              (if (contains? descriptor :scope) scope same-scope-marker)
+     :tags               (set tags)
+     :cross-scope?       (boolean cross-scope?)
+     :refetch-populated? (boolean refetch-populated?)}))
+
+(defn normalize-invalidation-descriptors
+  "PURE: lower the raw `:invalidates` result into the canonical descriptor
+  vector `[{:scope … :tags #{…} :cross-scope? bool :refetch-populated? bool}]`
+  — the one shape the events layer resolves + dispatches into the single
+  scoped invalidation engine (Spec 016 §Scoped invalidation descriptors,
+  EP-0016 D2). Accepts the two PUBLIC input forms:
+
+    - the BARE tag-set shorthand (a set / sequential collection of TAGS, where
+      a tag is itself a vector like `[:article slug]`) — one descriptor at
+      `:rf.scope/same` carrying all the tags;
+    - the per-target DESCRIPTOR form — a single descriptor MAP, or a vector of
+      descriptor maps, each `{:scope … :tags #{…}}`.
+
+  A nil / empty raw result yields an empty vector (the mutation invalidates
+  nothing). The disambiguation: a MAP is a single descriptor; a sequential /
+  set collection whose first element is a MAP is a descriptor vector; any
+  other non-empty collection is the bare tag-set (its elements are tags). A
+  malformed result fails CLOSED (`:rf.error/mutation-invalid-invalidation`)
+  rather than silently invalidating nothing. The descriptor `:scope` values
+  are left UNRESOLVED here (the `:rf.scope/same` marker, a `{:from-db …}`
+  reference, a concrete scope) — the events layer resolves each at settle
+  time against the mutation scope / app-db."
+  [raw where]
+  (cond
+    (or (nil? raw) (and (coll? raw) (empty? raw)))
+    []
+
+    ;; a single descriptor map
+    (map? raw)
+    [(normalize-one-descriptor raw raw where)]
+
+    ;; a vector / list / set of descriptor maps
+    (and (coll? raw) (map? (first raw)))
+    (mapv #(normalize-one-descriptor % raw where) raw)
+
+    ;; the bare tag-set shorthand: a collection of TAGS at :rf.scope/same
+    (coll? raw)
+    [{:scope              same-scope-marker
+      :tags               (set raw)
+      :cross-scope?       false
+      :refetch-populated? false}]
+
+    :else
+    (throw (invalidation-descriptor-error
+             where
+             (str "a mutation :invalidates result must be a tag-set "
+                  "(`#{[:article slug] …}`) or a descriptor map / vector "
+                  "(`{:scope … :tags #{…}}`); got " (pr-str raw)
+                  ". Per Spec 016 §Scoped invalidation descriptors.")
+             raw {}))))

--- a/implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc
@@ -1,0 +1,465 @@
+(ns re-frame.resources-invalidation-descriptors-cljs-test
+  "Scoped invalidation descriptors (rf2-hwc2ev, EP-0016 D2 / slice 5 — Spec 016
+  §Scoped invalidation descriptors).
+
+  A mutation's `:invalidates` arm declares which resource `(tags, scope)` pairs
+  to mark stale after the write settles. Two PUBLIC input forms lower to ONE
+  scoped invalidation engine:
+
+    - the bare tag-set shorthand `#{[:article slug] …}` — invalidate those tags
+      in the mutation's resolved (execution) scope (`:rf.scope/same`);
+    - the per-target DESCRIPTOR form `{:scope … :tags #{…}}` (a single
+      descriptor or a vector) — each descriptor names its OWN scope, so one
+      mutation can precisely invalidate global facts AND viewer-relative
+      (session-scoped) facts in one execution, without a blunt cross-scope blast.
+
+  These JVM+CLJS unit tests pin the slice's semantics:
+
+    1. a bare tag-set still invalidates the mutation's resolved scope;
+    2. a descriptor invalidates EXACTLY the resolved scoped keys — a
+       `:rf.scope/global` descriptor + a `{:from-db …}` session descriptor in
+       ONE mutation reach both, and only the resolved scope (not a global blast);
+    3. re-fetch (active owner) vs mark-stale (ownerless) variants;
+    4. the descriptors compose with the slice-4 `:reply-to` completion
+       continuation (the continuation fires after the invalidation);
+    5. a stale / superseded settle does NOT invalidate (the mandatory
+       stale-suppression boundary the descriptor path inherits);
+    6. a `{:from-db …}` descriptor scope resolved against the SETTLE-time
+       app-db; a nil-resolving reference is FAIL-CLOSED (no invalidation, a loud
+       diagnostic — never an implicit global blast);
+    7. `:rf.scope/same` is the default when a descriptor omits `:scope`;
+    8. a malformed `:invalidates` result fails CLOSED at settle time.
+
+  The transport is exercised end-to-end by overriding `:rf.http/managed` with a
+  capturing stub that synthesises the transport's reply-event-append shape."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   ;; load-bearing side-effecting requires: register the :rf.resource/* +
+   ;; :rf.mutation/* events + subs + the generation cofx/fx.
+   [re-frame.resources]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.mutation-runtime :as mstate]
+   [re-frame.registrar :as registrar]
+   [re-frame.resources.test-support]
+   [re-frame.http-managed]
+   [re-frame.schemas]
+   [re-frame.test-support :as core-test-support]
+   [re-frame.trace.tooling :as trace-tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+;; ---- capturing transport ---------------------------------------------------
+
+(def ^:private last-managed-args (atom nil))
+
+(defn- init! []
+  (registrar/clear-kind! :resource-scope)
+  ;; the named db-derived viewer-session resolver (EP-0016 D3 canonical form)
+  (rf/reg-resource-scope :t/session
+    {:inputs  {:username [:db [:auth :user :username]]}
+     :resolve (fn [{:keys [username]} _ctx]
+                (when username [:rf.scope/session {:username username}]))})
+  ;; an app event that writes / removes the logged-in user (the resolver input)
+  (rf/reg-event-db :t/login (fn [db [_ username]] (assoc-in db [:auth :user :username] username)))
+  (rf/reg-event-db :t/logout (fn [db _] (update db :auth dissoc :user))))
+
+(defn- capturing-transport-fixture [f]
+  (reset! last-managed-args nil)
+  (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
+  (f))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter :init-fn init!}
+       :cljs {:adapter reagent-adapter/adapter :init-fn init!}))
+  capturing-transport-fixture)
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- runtime-db [] (rf/runtime-db-value :rf/default))
+(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+(defn- entries [] (get-in (runtime-db) (state/entries-path)))
+
+(defn- reply-success!
+  ([args result] (rf/dispatch-sync (conj (:on-success args) {:kind :success :value result})))
+  ([args result opts] (rf/dispatch-sync (conj (:on-success args) {:kind :success :value result}) opts)))
+
+(def ^:private global-key (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"}))
+(defn- session-feed-key [u] (state/scoped-resource-key [:rf.scope/session {:username u}] :r/feed {}))
+
+(defn- reg-article-resource! []
+  (rf/reg-resource :r/article
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}})
+     :tags (fn [{:keys [slug]} _] #{[:article slug] [:article-list]})}))
+
+(defn- reg-feed-resource! []
+  (rf/reg-resource :r/feed
+    {:scope {:from-db :t/session}
+     :params-schema [:map]
+     :request (fn [_p _] {:request {:method :get :url "/feed"}})
+     :tags (fn [_p _] #{[:feed] [:article-list]})}))
+
+(defn- own-loaded!
+  "Ensure + load an entry under `payload` so it has an ACTIVE owner (so a
+  subsequent invalidation REFETCHES it). Resets `last-managed-args` after."
+  [payload]
+  (rf/dispatch-sync [:rf.resource/ensure payload])
+  (reply-success! @last-managed-args {:seed true})
+  (reset! last-managed-args nil))
+
+(defn- ownerless-stale-load!
+  "Drive an entry to :loaded with NO active owner (ensure with an owner, then
+  release it) so an invalidation leaves it stale (observable via
+  :invalidated-at) rather than refetching it."
+  [{:keys [resource params scope] :as payload}]
+  (rf/dispatch-sync [:rf.resource/ensure payload])
+  (reply-success! @last-managed-args {:seed true})
+  (rf/dispatch-sync [:rf.resource/release-owner
+                     (select-keys (assoc payload :owner (:owner payload))
+                                  [:resource :params :scope :owner])])
+  (reset! last-managed-args nil))
+
+(defn- record-invalidations!
+  "Run `body-fn`; return the vector of every `:rf.resource/invalidated` trace
+  event emitted during it (one per descriptor dispatch)."
+  [body-fn]
+  (let [seen (atom [])
+        k    ::inv-recorder]
+    (trace-tooling/register-listener!
+      k (fn [ev] (when (= :rf.resource/invalidated (:operation ev)) (swap! seen conj ev))))
+    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    @seen))
+
+;; ===========================================================================
+;; 1. The bare tag-set shorthand invalidates the mutation's resolved scope
+;; ===========================================================================
+
+(deftest bare-tag-set-invalidates-resolved-scope
+  (reg-article-resource!)
+  (rf/reg-mutation :m/save
+    {:params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+     :invalidates (fn [{:keys [slug]} _result] #{[:article slug]})})
+  ;; ownerless article — the invalidation leaves it stale (observable)
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :r/article :scope :rf.scope/global
+                                          :params {:slug "w"} :owner [:v :a]}])
+  (reply-success! @last-managed-args {:title "old"})
+  (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/article :scope :rf.scope/global
+                                                 :params {:slug "w"} :owner [:v :a]}])
+  (reset! last-managed-args nil)
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :b1}])
+  (reply-success! @last-managed-args {:title "new"})
+  (testing "the bare tag-set invalidated the global article entry (the
+            mutation's resolved scope), marking it stale"
+    (is (some? (:invalidated-at (entry global-key))))))
+
+;; ===========================================================================
+;; 2. A descriptor reaches BOTH global and session scopes — exactly, no blast
+;; ===========================================================================
+
+(deftest descriptor-invalidates-global-and-session-exactly
+  ;; Validation rule 6: a mutation invalidates global AND session-scoped
+  ;; targets in ONE execution — and ONLY the resolved scoped keys (not a
+  ;; global blast across all scopes). This is the RealWorld favorite/feed case.
+  (reg-article-resource!)
+  (reg-feed-resource!)
+  (rf/dispatch-sync [:t/login "jake"])
+  ;; a DIFFERENT user's feed must NOT be touched (the precise-vs-blast proof)
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :r/feed :scope [:rf.scope/session {:username "abel"}]
+                                          :params {} :owner [:v :feed-abel]}])
+  (reply-success! @last-managed-args {:seed true})
+  (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/feed :scope [:rf.scope/session {:username "abel"}]
+                                                 :params {} :owner [:v :feed-abel]}])
+  ;; jake's feed (session) + the global article, both ownerless + stale-observable
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :r/feed :scope {:from-db :t/session}
+                                          :params {} :owner [:v :feed-jake]}])
+  (reply-success! @last-managed-args {:seed true})
+  (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/feed :scope {:from-db :t/session}
+                                                 :params {} :owner [:v :feed-jake]}])
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :r/article :scope :rf.scope/global
+                                          :params {:slug "w"} :owner [:v :a]}])
+  (reply-success! @last-managed-args {:title "old"})
+  (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/article :scope :rf.scope/global
+                                                 :params {:slug "w"} :owner [:v :a]}])
+  (reset! last-managed-args nil)
+  (rf/reg-mutation :m/favorite
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :post :url (str "/a/" slug "/fav")}})
+     :invalidates (fn [{:keys [slug]} _result]
+                    [{:scope :rf.scope/global :tags #{[:article slug]}}
+                     {:scope {:from-db :t/session} :tags #{[:feed]}}])})
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/favorite :params {:slug "w"} :instance :f1}])
+  (reply-success! @last-managed-args {:favorited true})
+  (testing "the GLOBAL article entry was invalidated by the global descriptor"
+    (is (some? (:invalidated-at (entry global-key)))))
+  (testing "jake's SESSION feed was invalidated by the {:from-db} descriptor
+            (resolved against the settle-time app-db)"
+    (is (some? (:invalidated-at (entry (session-feed-key "jake"))))))
+  (testing "abel's session feed was NOT touched — the descriptor invalidated
+            EXACTLY the resolved scoped keys, not a global blast across scopes"
+    (is (nil? (:invalidated-at (entry (session-feed-key "abel")))))))
+
+;; ===========================================================================
+;; 3. re-fetch (active owner) vs mark-stale (ownerless) variants
+;; ===========================================================================
+
+(deftest descriptor-refetches-active-owner-marks-stale-ownerless
+  (reg-article-resource!)
+  (reg-feed-resource!)
+  (rf/dispatch-sync [:t/login "jake"])
+  ;; the global article has an ACTIVE owner -> the descriptor must REFETCH it
+  (own-loaded! {:resource :r/article :scope :rf.scope/global :params {:slug "w"} :owner [:v :a]})
+  ;; jake's feed is OWNERLESS -> the descriptor must leave it stale (no refetch)
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :r/feed :scope {:from-db :t/session}
+                                          :params {} :owner [:v :feed]}])
+  (reply-success! @last-managed-args {:seed true})
+  (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/feed :scope {:from-db :t/session}
+                                                 :params {} :owner [:v :feed]}])
+  (reset! last-managed-args nil)
+  (rf/reg-mutation :m/save
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+     :invalidates (fn [{:keys [slug]} _result]
+                    [{:scope :rf.scope/global :tags #{[:article slug]}}
+                     {:scope {:from-db :t/session} :tags #{[:feed]}}])})
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :v1}])
+  (reply-success! @last-managed-args {:title "new"})
+  (testing "the ACTIVE-owner global article REFETCHED (back in flight, a fresh GET lowered)"
+    (is (contains? #{:loading :fetching} (:status (entry global-key))))
+    (is (some? @last-managed-args))
+    (is (= {:method :get :url "/a/w"} (:request @last-managed-args))))
+  (testing "the OWNERLESS session feed was left STALE (not refetched — its
+            :invalidated-at fact is set, no fetch started)"
+    (let [e (entry (session-feed-key "jake"))]
+      (is (some? (:invalidated-at e)))
+      (is (not (contains? #{:loading :fetching} (:status e)))))))
+
+;; ===========================================================================
+;; 4. Composes with the slice-4 :reply-to completion continuation
+;; ===========================================================================
+
+(deftest descriptor-composes-with-reply-to-continuation
+  (let [replied (atom [])]
+    (reg-article-resource!)
+    (reg-feed-resource!)
+    (rf/reg-event-fx :test/saved (fn [_ event] (swap! replied conj event) {}))
+    (rf/dispatch-sync [:t/login "jake"])
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :r/feed :scope {:from-db :t/session}
+                                            :params {} :owner [:v :feed]}])
+    (reply-success! @last-managed-args {:seed true})
+    (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/feed :scope {:from-db :t/session}
+                                                   :params {} :owner [:v :feed]}])
+    (reset! last-managed-args nil)
+    (rf/reg-mutation :m/save
+      {:scope :rf.scope/global
+       :params-schema [:map [:slug :string]]
+       :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+       :invalidates (fn [_p _r] [{:scope {:from-db :t/session} :tags #{[:feed]}}])})
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :c1
+                                             :reply-to [:test/saved]}])
+    (reply-success! @last-managed-args {:title "new"})
+    (testing "the {:from-db} descriptor invalidated jake's feed"
+      (is (some? (:invalidated-at (entry (session-feed-key "jake"))))))
+    (testing "the :reply-to continuation fired exactly once, after the invalidation"
+      (is (= 1 (count @replied)))
+      (is (= :ok (:status (second (first @replied))))))))
+
+;; ===========================================================================
+;; 5. A stale / superseded settle does NOT invalidate
+;; ===========================================================================
+
+(deftest stale-settle-does-not-invalidate
+  ;; Validation: a superseded mutation reply NEVER applies cache consequences —
+  ;; the descriptor invalidation is gated behind the live-instance acceptance.
+  (reg-article-resource!)
+  (rf/reg-mutation :m/save
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+     :invalidates (fn [{:keys [slug]} _result] #{[:article slug]})})
+  ;; ownerless article (stale-observable)
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :r/article :scope :rf.scope/global
+                                          :params {:slug "w"} :owner [:v :a]}])
+  (reply-success! @last-managed-args {:title "old"})
+  (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/article :scope :rf.scope/global
+                                                 :params {:slug "w"} :owner [:v :a]}])
+  (reset! last-managed-args nil)
+  ;; execute the mutation, CAPTURE its reply args, then SUPERSEDE it by a
+  ;; re-execute under the SAME instance id (a new generation / work-id) — the
+  ;; first reply is now stale.
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :s1}])
+  (let [stale-args @last-managed-args]
+    (reset! last-managed-args nil)
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :s1}])
+    ;; deliver the STALE first reply — it must be suppressed, no invalidation
+    (let [invs (record-invalidations! #(reply-success! stale-args {:title "stale"}))]
+      (testing "the superseded reply fired NO invalidation"
+        (is (empty? invs)))
+      (testing "the article entry was NOT marked stale by the suppressed reply"
+        (is (nil? (:invalidated-at (entry global-key))))))))
+
+;; ===========================================================================
+;; 6. {:from-db} resolved at settle time; nil-resolving is FAIL-CLOSED
+;; ===========================================================================
+
+(deftest from-db-descriptor-resolved-at-settle-time
+  ;; Validation rule 7: a descriptor referencing a named scope resolver
+  ;; resolves against db AT SETTLE TIME. We log in as "zed" only AFTER the
+  ;; execute but before the reply settles — the descriptor must resolve to
+  ;; zed's session at settle.
+  (reg-article-resource!)
+  (reg-feed-resource!)
+  (rf/reg-mutation :m/save
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+     :invalidates (fn [_p _r] [{:scope {:from-db :t/session} :tags #{[:feed]}}])})
+  (rf/dispatch-sync [:t/login "zed"])
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :r/feed :scope {:from-db :t/session}
+                                          :params {} :owner [:v :feed]}])
+  (reply-success! @last-managed-args {:seed true})
+  (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/feed :scope {:from-db :t/session}
+                                                 :params {} :owner [:v :feed]}])
+  (reset! last-managed-args nil)
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :z1}])
+  (reply-success! @last-managed-args {:title "new"})
+  (testing "the {:from-db} descriptor resolved zed's session at settle time and
+            invalidated zed's feed"
+    (is (some? (:invalidated-at (entry (session-feed-key "zed")))))))
+
+(deftest from-db-descriptor-nil-fails-closed
+  ;; A {:from-db} descriptor that resolves NIL (no logged-in user) produces NO
+  ;; invalidation and a loud diagnostic — never an implicit global blast.
+  (reg-article-resource!)
+  (reg-feed-resource!)
+  ;; NOT logged in — the resolver's :inputs are absent. A global article entry
+  ;; exists; a global-blast bug would wrongly invalidate it via the [:feed]/
+  ;; [:article-list] tag overlap.
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :r/article :scope :rf.scope/global
+                                          :params {:slug "w"} :owner [:v :a]}])
+  (reply-success! @last-managed-args {:title "old"})
+  (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/article :scope :rf.scope/global
+                                                 :params {:slug "w"} :owner [:v :a]}])
+  (reset! last-managed-args nil)
+  (rf/reg-mutation :m/save
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+     :invalidates (fn [_p _r] [{:scope {:from-db :t/session} :tags #{[:article-list]}}])})
+  (let [seen (atom [])
+        k    ::succeeded-recorder]
+    (trace-tooling/register-listener!
+      k (fn [ev] (when (= :rf.mutation/succeeded (:operation ev)) (swap! seen conj ev))))
+    (try
+      (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :n1}])
+      (reply-success! @last-managed-args {:title "new"})
+      (finally (trace-tooling/unregister-listener! k)))
+    (testing "the nil-resolving {:from-db} descriptor is recorded as fail-closed
+              :unresolved evidence on the settlement trace's :invalidation facet"
+      (is (= 1 (count @seen)))
+      (let [inv (:invalidation (:tags (first @seen)))]
+        (is (= [:t/session] (:unresolved inv)) "the unresolved resolver id is named")
+        (is (empty? (:dispatched inv)) "no descriptor dispatched")))
+    (testing "FAIL-CLOSED — the nil-resolving descriptor produced NO
+              invalidation (the global article entry was NOT blasted)"
+      (is (nil? (:invalidated-at (entry global-key)))))))
+
+(deftest descriptor-trace-evidence-records-resolved-scopes
+  ;; Validation rule 14 / Spec 016 §Trace evidence for invalidation: the
+  ;; settlement trace's :invalidation facet records the resolved scope per
+  ;; descriptor + the descriptor count.
+  (reg-article-resource!)
+  (reg-feed-resource!)
+  (rf/dispatch-sync [:t/login "jake"])
+  (rf/reg-mutation :m/favorite
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :post :url (str "/a/" slug "/fav")}})
+     :invalidates (fn [{:keys [slug]} _result]
+                    [{:scope :rf.scope/global :tags #{[:article slug]}}
+                     {:scope {:from-db :t/session} :tags #{[:feed]}}])})
+  (let [seen (atom [])
+        k    ::succeeded-recorder]
+    (trace-tooling/register-listener!
+      k (fn [ev] (when (= :rf.mutation/succeeded (:operation ev)) (swap! seen conj ev))))
+    (try
+      (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/favorite :params {:slug "w"} :instance :t1}])
+      (reply-success! @last-managed-args {:favorited true})
+      (finally (trace-tooling/unregister-listener! k)))
+    (testing "the :invalidation facet records both resolved descriptor scopes"
+      (let [inv (:invalidation (:tags (first @seen)))]
+        (is (= 2 (:descriptor-count inv)))
+        (is (= 2 (count (:dispatched inv))))
+        (is (= #{:rf.scope/global [:rf.scope/session {:username "jake"}]}
+               (set (map :scope (:dispatched inv))))
+            "the global descriptor + the {:from-db}-resolved session scope")
+        (is (empty? (:unresolved inv)))))))
+
+;; ===========================================================================
+;; 7. :rf.scope/same is the default when a descriptor omits :scope
+;; ===========================================================================
+
+(deftest descriptor-omitting-scope-defaults-to-same
+  (reg-article-resource!)
+  (rf/reg-mutation :m/save
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+     ;; a descriptor with NO :scope -> :rf.scope/same -> the mutation's
+     ;; resolved (:rf.scope/global) scope.
+     :invalidates (fn [{:keys [slug]} _result] [{:tags #{[:article slug]}}])})
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :r/article :scope :rf.scope/global
+                                          :params {:slug "w"} :owner [:v :a]}])
+  (reply-success! @last-managed-args {:title "old"})
+  (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/article :scope :rf.scope/global
+                                                 :params {:slug "w"} :owner [:v :a]}])
+  (reset! last-managed-args nil)
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :sm1}])
+  (reply-success! @last-managed-args {:title "new"})
+  (testing "a scopeless descriptor invalidated the mutation's resolved scope"
+    (is (some? (:invalidated-at (entry global-key))))))
+
+;; ===========================================================================
+;; 8. Pure normalization + fail-closed malformed result
+;; ===========================================================================
+
+(deftest normalize-lowers-the-public-forms
+  (testing "a bare tag-set lowers to ONE :rf.scope/same descriptor"
+    (let [[d & more] (mstate/normalize-invalidation-descriptors
+                       #{[:article "w"] [:article-list]} 'test)]
+      (is (nil? more))
+      (is (= :rf.scope/same (:scope d)))
+      (is (= #{[:article "w"] [:article-list]} (:tags d)))))
+  (testing "a single descriptor map lowers to a one-element vector"
+    (let [ds (mstate/normalize-invalidation-descriptors
+               {:scope :rf.scope/global :tags #{[:x]}} 'test)]
+      (is (= 1 (count ds)))
+      (is (= :rf.scope/global (:scope (first ds))))))
+  (testing "a vector of descriptors lowers each, defaulting omitted :scope to :rf.scope/same"
+    (let [ds (mstate/normalize-invalidation-descriptors
+               [{:scope :rf.scope/global :tags #{[:a]}}
+                {:tags #{[:b]} :cross-scope? true}] 'test)]
+      (is (= 2 (count ds)))
+      (is (= :rf.scope/global (:scope (first ds))))
+      (is (= :rf.scope/same (:scope (second ds))))
+      (is (true? (:cross-scope? (second ds))))))
+  (testing "a nil / empty result lowers to an empty vector (invalidates nothing)"
+    (is (= [] (mstate/normalize-invalidation-descriptors nil 'test)))
+    (is (= [] (mstate/normalize-invalidation-descriptors #{} 'test)))))
+
+(deftest normalize-fails-closed-on-malformed
+  (testing "a non-collection scalar result is a loud fail-closed error"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"mutation-invalid-invalidation"
+          (mstate/normalize-invalidation-descriptors :nonsense 'test))))
+  (testing "a descriptor missing :tags is a loud fail-closed error"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"mutation-invalid-invalidation"
+          (mstate/normalize-invalidation-descriptors {:scope :rf.scope/global} 'test)))))


### PR DESCRIPTION
EP-0016 action-wave **slice 5** (scoped invalidation descriptors), per epic rf2-fi6tda + `docs/EP/EP-0016` Reference Implementation Plan slice 5 + Decision 2 (and the issue-3 cross-scope lattice ruling). Slices 1–4 merged (spec, resolver registry, route/event/sub scope integration, mutation completion continuation). Fence: `implementation/resources` (the invalidation path) + tests.

## What this does

A mutation's `:invalidates` arm declares which resource `(tags, scope)` pairs to mark stale after the write settles. Two **public input forms** lower into **one** canonical descriptor vector and from there into the **single** scoped invalidation engine (`:rf.resource/invalidate-tags`) — one dispatch per descriptor, each resolved under its own named scope so one write can invalidate global facts **and** viewer-relative (session-scoped) facts without a blunt cross-scope blast.

### Descriptor shape

`:invalidates` is `(fn [params result] -> <form>)` (the one canonical `(params result)` signature — no `db`/`ctx`). Public forms:

- **bare tag-set** `#{[:article slug] [:article-list]}` → invalidate those tags in the mutation's resolved scope (`:rf.scope/same`).
- **descriptor** (single map or vector):
  ```clojure
  [{:scope :rf.scope/global         :tags #{[:article slug]}}
   {:scope {:from-db :realworld/session} :tags #{[:feed]}}]
  ```

Each descriptor's `:scope` is one of: `:rf.scope/same` (default when omitted → the mutation's resolved scope), `:rf.scope/global`, a concrete canonical scope, or a `{:from-db <id>}` named-resolver reference (resolved against the **settle-time app-db**, the single use-time rule). A descriptor MAY carry `:cross-scope? true` (the audited scope-agnostic escape, carrying `:cause`) and `:refetch-populated? true` (parsed + carried forward for the slice-6 populate-exempt pass).

Normalized descriptor (internal): `{:scope <scope|:rf.scope/same> :tags #{…} :cross-scope? bool :refetch-populated? bool}`.

### Fail-closed discipline

- a `{:from-db …}` reference resolving **nil** produces **no** invalidation (recorded as `:unresolved` evidence) — never an implicit global blast;
- a malformed `:invalidates` result throws `:rf.error/mutation-invalid-invalidation` at settle time (never a silent no-op);
- the descriptor invalidation is gated behind the existing live-instance acceptance — a **stale/superseded settle never invalidates**;
- the bare-no-scope floor (`:rf.error/resource-invalidate-scope-required`, rf2-pvdae1) and the `:cross-scope? true` audited escape are unchanged (the three-rung lattice).

### Trace evidence

The descriptor-level evidence (resolved scope per descriptor + fail-closed nil-resolved resolver ids) rides the existing `:rf.mutation/started`/`succeeded`/`failed` settlement traces as an `:invalidation` facet (`{:descriptor-count :dispatched :unresolved}`). Recorded on the mutation-pass settlement trace rather than the per-dispatch `:rf.resource/invalidated` op, because a nil-resolved descriptor produces no engine dispatch — the only coherent home for the `:resolved-nil?` evidence Spec 016 §Trace evidence for invalidation prescribes. No new trace ops; the `:rf.mutation/*` / `:rf.resource/*` op enums in `spec/Conventions.md` are unchanged.

## Files

- `mutation_runtime.cljc` — pure `normalize-invalidation-descriptors` + `same-scope-marker` + the fail-closed descriptor validator.
- `mutation_events.cljc` — `invalidation-plan` / `resolve-descriptor-scope` / `plan->fx` / `plan-trace`; the three call sites (`execute` before-request, `succeeded`, `failed`) thread the settle-time app-db and lower the plan into per-descriptor dispatch fx.
- `resources_invalidation_descriptors_cljs_test.cljc` (new) — 12 JVM+CLJS unit tests.

## Test deltas

New suite `re-frame.resources-invalidation-descriptors-cljs-test` (12 deftests): bare-set resolves the mutation scope; descriptor reaches global + session scopes **exactly** (a different user's session feed is untouched — the precise-vs-blast proof); refetch (active owner) vs mark-stale (ownerless) variants; composes with the slice-4 `:reply-to` continuation; stale/superseded settle does not invalidate; `{:from-db}` resolved at settle time + nil fail-closed; scopeless descriptor defaults to `:rf.scope/same`; pure normalization of all forms + malformed fail-closed; trace-evidence facet records both resolved descriptor scopes.

## Quality gates

- `clojure -M:test` (resources artefact, JVM): **282 tests, 1073 assertions, 0 failures, 0 errors** (was 270 → +12).
- `npm run test:cljs` (consolidated node-test): **6586 tests, 24086 assertions, 0 failures, 0 errors**.
- `mkdocs build --strict`: **not run** — no spec/doc cross-ref touched (the slice-1 spec already documents the descriptor model at Spec 016 §Scoped invalidation descriptors).
- `tools/xray` unchanged — no Xray spec update required.

Closes rf2-hwc2ev.
