### PR TITLE
feat(core): EP-0014 slice-3 — flows expose algebra views (rf2-s8w3nw)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -29,7 +29,18 @@
             [re-frame.flows.topo :as topo]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as trace]
+            ;; EP-0014 slice-3 (rf2-s8w3nw): the JVM-only require of the
+            ;; flows tooling sibling that backs the `flow-algebra-view`
+            ;; alias at the foot of this ns. CLJS deliberately OMITS this
+            ;; require so a CLJS app that loads the flows artefact but never
+            ;; attaches a tool DCEs the tooling body wholesale — the facade
+            ;; never reaches it. JVM has no bundle to protect; the alias
+            ;; gives JVM tools / conformance fixtures the ergonomic
+            ;; `re-frame.flows/flow-algebra-view` shape. Mirrors the
+            ;; `re-frame.subs` → `re-frame.subs.tooling` JVM-only require
+            ;; (rf2-bmzq0 / rf2-gge6mf slice-2).
+            #?@(:clj [[re-frame.flows.tooling :as flows-tooling]])))
 
 ;; ---- public-surface re-exports -------------------------------------------
 ;;
@@ -47,6 +58,20 @@
 (def clear-flow         registry/clear-flow)
 (def reset-flows!       registry/reset-flows!)
 (def reset-last-inputs! registry/reset-last-inputs!)
+
+;; EP-0014 slice-3 (rf2-s8w3nw): the derivation/process algebra view of
+;; registered flows. JVM-runnable (the flow registry is partition-agnostic
+;; registration metadata), so a JVM convenience alias lets tools /
+;; conformance fixtures reach it as `re-frame.flows/flow-algebra-view`
+;; without naming the sibling. The body lives in `re-frame.flows.tooling`
+;; so a CLJS app that loads the flows artefact but attaches no tool DCEs it
+;; (the CLJS facade never `:require`s the tooling sibling — the require
+;; above is `#?@(:clj ...)`-gated). CLJS consumers (Xray + conformance)
+;; call `re-frame.flows.tooling/flow-algebra-view` directly. No
+;; `re-frame.core` facade export (EP-0014 issue-1 disposition). Mirrors the
+;; `re-frame.subs/sub-algebra-view` JVM alias (slice-2).
+#?(:clj
+   (def flow-algebra-view flows-tooling/flow-algebra-view))
 
 ;; ---- evaluation ---------------------------------------------------------
 ;;

--- a/implementation/flows/src/re_frame/flows/tooling.cljc
+++ b/implementation/flows/src/re_frame/flows/tooling.cljc
@@ -1,0 +1,260 @@
+(ns re-frame.flows.tooling
+  "Flows tooling sibling of `re-frame.flows` — carries the EP-0014 slice-3
+  derivation/process algebra view of registered flows (`flow-algebra-view`)
+  that pair tools (Xray, re-frame2-pair-mcp) and the conformance fixtures
+  query, but no production application code reads.
+
+  Mirrors the rf2-bmzq0 `re-frame.subs.tooling` split (and the rf2-qwm0a
+  `re-frame.trace.tooling` split before it):
+    - CLJS consumers needing the surface call
+      `re-frame.flows.tooling/<name>` directly. Apps that load the flows
+      artefact but never attach a tool DCE the body wholesale (the sibling
+      ns is loaded only when a test fixture, tool, or dev preload requires
+      it; the `re-frame.flows` facade never `:require`s it).
+    - JVM consumers keep an ergonomic `re-frame.flows/<name>` alias (gated
+      under `#?(:clj ...)`). The JVM has no bundle to protect; the alias
+      costs nothing. The whole flows artefact is already bundle-isolated
+      from production builds (counter never `:require`s `re-frame.flows`),
+      so this sibling can never reach a no-flows app's bundle; the
+      explicit sentinel at the foot of this ns additionally proves no
+      stray `:require` ever pulled the body in.
+
+  READ-ONLY over the registry. Per the EP-0013 D1-impl in-flight work
+  (rf2-pnf7t5 / gkddyq) this ns touches NEITHER the core registrar
+  write-path NOR the flow registration signatures — exactly as slice-2's
+  subs.tooling read the sub registry without touching the registrar. It
+  reads the per-frame flow registry through the existing public accessor
+  `re-frame.flows.registry/flows-snapshot` (the rf2-4gvb4 read seam).
+
+  Per [Derivations.md](../../../../../../spec/Derivations.md) (graduated
+  from EP-0014) and the projected Malli shapes in [Spec-Schemas
+  §`:rf/derivation-node`](../../../../../../spec/Spec-Schemas.md)."
+  (:require [re-frame.flows.registry :as registry]
+            [re-frame.registrar :as registrar]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- algebra views (EP-0014 slice-3) -------------------------------------
+;;
+;; Per [Derivations.md] §Worked equivalence — the flow is the canonical
+;; `:app-db` / `:after-event` / `:frame` MATERIALIZED member of the
+;; derivation/process algebra (the subscription's policy twin: same
+;; whole-value function, different output / storage / evaluation /
+;; lifecycle). Every `reg-flow` registration is an instance of the algebra:
+;; a `:derivation` (subscriptions AND flows are derivations, never processes
+;; — Derivations §Derivation), whose output is MATERIALIZED into app-db,
+;; evaluated `:after-event` (inside the event drain, per Spec 013 §Drain
+;; integration), owned by the `:frame` it registered against.
+;;
+;; This is the *registrar-derived* slice (Derivations §The EP-0013
+;; relocation seam): the algebra view is assembled from the flow-map
+;; metadata at the surface that registered it, NOT (yet) from an EP-0013
+;; app value. It feeds the later internal graph-inspection helper (EP-0014
+;; bead-plan item 7); slice-3 ships NO public accessor — these functions
+;; live in the bundle-isolated tooling sibling, consumed by Xray + the
+;; conformance fixtures (the two named first consumers). No
+;; `re-frame.core` facade export (EP-0014 issue-1 disposition).
+;;
+;; The five fixed classifications for EVERY flow node (Derivations §Worked
+;; equivalence — the flow column):
+;;   :kind          :derivation
+;;   :storage       :app-db               (materialized into the app-db partition)
+;;   :evaluation    :after-event          (evaluated inside the event drain)
+;;   :lifecycle     :frame                (the frame owns it; destroy-frame! releases it)
+;;   :materialized? true                  (the output has a durable app-db address)
+;; The per-flow axes that vary are the declared INPUTS and the OUTPUT path.
+;;
+;; A flow consumes the slice-1 vocabulary verbatim — it does NOT redefine
+;; the `:rf/storage-class` / `:rf/evaluation-policy` / `:rf/lifecycle` enums
+;; or the `:rf/derivation-node` shape (those are owned by Spec-Schemas /
+;; Derivations).
+
+(def ^:private runtime-partition-key
+  "The reserved partition key that, as a leading `:inputs`-path element,
+  marks a flow input as a runtime-db read (`:rf.db/runtime`). The binary
+  syntax (EP-0001 §535-551, rf2-4eisfr): a bare path reads app-db; a
+  `[:rf.db/runtime …rest]` path reads runtime-db at `…rest`. Held as the
+  same const `re-frame.flows` uses for input resolution so the projection
+  and the resolver stay in lockstep."
+  :rf.db/runtime)
+
+(defn- declared-input
+  "Lower ONE flow `:inputs` path to its algebra declared-input form
+  (Derivations §Declared input). A bare path is an app-db read `[:db path]`;
+  a partition-qualified `[:rf.db/runtime …rest]` path is a runtime-db read
+  `[:runtime …rest]` (the partition key stripped). Flow inputs are always
+  concrete app-db / runtime-db paths — never `:sub` edges or the
+  `:parametric` marker — because a flow declares its dependency graph
+  statically as paths (Spec 013 §Flow shape)."
+  [path]
+  (if (= runtime-partition-key (first path))
+    [:runtime (subvec (vec path) 1)]
+    [:db (vec path)]))
+
+(defn- declared-inputs
+  "Project a flow's `:inputs` vector into the algebra view's declared
+  inputs — each path lowered per `declared-input`, in declaration order
+  (so a downstream tool can reconstruct the dependency graph the `:output`
+  fn's positional args expect)."
+  [flow]
+  (mapv declared-input (:inputs flow)))
+
+(defn- frame-matched-source-coords
+  "Return the `:ns` / `:line` / `:file` source-coordinate map for `flow-id`
+  on `frame-id`, or `nil` when none apply. The per-frame `flows` registry
+  stores the raw flow-map WITHOUT source coords — `reg-flow` runs the flow
+  through `source-coords/merge-coords` only when stamping the `:flow`
+  registrar slot. So coords are read (READ-only — slice-2's subs.tooling
+  read sub metadata from the registrar the same way) from that slot.
+
+  The `:flow` registrar slot is keyed by flow-id ALONE and holds the
+  MOST-RECENTLY-REGISTERED frame's metadata (Spec 013 §Frame-scoping), so it
+  is frame-blind. To stay frame-SAFE we attach the coords only when the
+  slot's stamped `:frame` matches THIS node's frame — a different frame's
+  same-id flow never inherits the wrong source location. A frame whose
+  same-id flow is not the slot's current owner simply carries no `:source`
+  (the conservative, never-wrong choice over a cross-frame mis-attribution)."
+  [frame-id flow-id]
+  (let [slot (registrar/lookup :flow flow-id)]
+    (when (= frame-id (:frame slot))
+      (let [source (cond-> {}
+                     (contains? slot :ns)   (assoc :ns   (:ns   slot))
+                     (contains? slot :file) (assoc :file (:file slot))
+                     (contains? slot :line) (assoc :line (:line slot)))]
+        (when (seq source) source)))))
+
+(defn- with-metadata
+  "Attach source coordinates, the `:schema` fact, the `:doc`, and the opaque
+  `:derive` body token to a node when present. `:schema` / `:doc` are
+  user-supplied flow-map keys, read straight off the frame-scoped flow-map
+  (frame-safe). The `:source` coords are read frame-matched from the
+  registrar slot (the only place `reg-flow` records them). The `:output` fn
+  is the flow's whole-value derivation — surfaced under `:derive` as an
+  opaque token so a tool can show the function identity / source without it
+  being serialized."
+  [node frame-id flow]
+  (let [flow-id (:id flow)
+        source  (frame-matched-source-coords frame-id flow-id)]
+    (cond-> node
+      (some? source)           (assoc :source source)
+      (contains? flow :schema) (assoc :schema (:schema flow))
+      (contains? flow :doc)    (assoc :doc (:doc flow))
+      (contains? flow :output) (assoc :derive (:output flow)))))
+
+(defn- node-for
+  "Build the derivation/process algebra view of one flow-map (Derivations
+  §The node shape; Spec-Schemas §`:rf/derivation-node`). `frame-id` is the
+  frame the flow registered against — flows are frame-scoped (Spec 013
+  §Frame-scoping), so the owning frame is part of the node's lifecycle
+  contract and is surfaced under `:owner`.
+
+  The fixed-classification spine — a `:derivation` whose materialized output
+  lands in app-db, evaluated `:after-event`, owned by its `:frame` — plus
+  the per-flow `:inputs` (lowered app-db / runtime-db paths), `:output`
+  (`[:db <:path>]`), `:source-form`, opaque `:derive` token, and source
+  coords / schema / doc."
+  [frame-id flow]
+  (let [flow-id (:id flow)]
+    (-> {:id            flow-id
+         :kind          :derivation
+         :source-form   {:kind :reg-flow :id flow-id}
+         :inputs        (declared-inputs flow)
+         :output        [:db (vec (:path flow))]
+         :storage       :app-db
+         :evaluation    :after-event
+         :lifecycle     :frame
+         :owner         [:frame frame-id]
+         :materialized? true}
+        (with-metadata frame-id flow))))
+
+(defn flow-algebra-view
+  "Return the STATIC derivation/process algebra view of every registered
+  flow (EP-0014 slice-3; [Derivations.md], [Spec-Schemas
+  §`:rf/derivation-node`]).
+
+  Pure data over the per-frame flow registry — read through the public
+  `re-frame.flows.registry/flows-snapshot` seam (rf2-4gvb4), never touching
+  the registrar write-path or the flow registration signatures. The algebra
+  view companion to `flows-snapshot`: where `flows-snapshot` returns the raw
+  `{frame-id {flow-id flow-map}}` registry, this lowers every flow into the
+  normalized `:rf/derivation-node` shape the derivation/process algebra
+  names, so a tool can show subscriptions, flows, resources, route facts,
+  and machine selectors as ONE family.
+
+  Flows are FRAME-SCOPED (Spec 013 §Frame-scoping): the same flow-id can
+  register against two frames with different `:inputs` / `:output` / `:path`,
+  so the view preserves the frame dimension — keyed the same way as
+  `flows-snapshot`.
+
+  Each node carries:
+
+  - `:id`          — the flow id (its canonical fact identity).
+  - `:kind`        — `:derivation` (flows are derivations, never processes —
+                     Derivations §Derivation).
+  - `:source-form` — `{:kind :reg-flow :id <flow-id>}`.
+  - `:inputs`      — the declared inputs (Derivations §Declared input): each
+                     `:inputs` path lowered to `[:db path]` (a bare app-db
+                     read) or `[:runtime …rest]` (a `[:rf.db/runtime …]`
+                     partition-qualified runtime-db read — EP-0001 §535-551),
+                     in declaration order.
+  - `:output`      — `[:db <:path>]` — the flow MATERIALIZES its whole value
+                     into the app-db partition at its `:path` (flow writes
+                     are app-db only — Spec 013 §Input partition).
+  - `:storage`     — `:app-db`.
+  - `:evaluation`  — `:after-event` (evaluated inside the event drain — Spec
+                     013 §Drain integration).
+  - `:lifecycle`   — `:frame`.
+  - `:owner`       — `[:frame <frame-id>]` (the frame the flow registered
+                     against; `destroy-frame!` releases it).
+  - `:materialized?` — `true`.
+  - `:derive`      — the opaque `:output` body-fn token (never serialized).
+  - `:source` / `:schema` / `:doc` — present when the registration carried
+                     them (source coords auto-captured by `reg-flow` via
+                     `source-coords/merge-coords`).
+
+  Zero-arity returns `{frame-id {flow-id <node>}}` for every registered flow
+  (`{}` when none). The one-arity form returns `{flow-id <node>}` for a
+  single frame (`{}` when the frame has no flows). JVM-runnable — the flow
+  registry is partition-agnostic registration metadata.
+
+  Slice-3 ships NO public accessor (EP-0014 issue-1 disposition): this lives
+  in the bundle-isolated tooling sibling and is consumed by Xray + the
+  conformance fixtures; the public name is deferred until a third consumer
+  needs it. There is no `re-frame.core/flow-algebra-view` facade export."
+  ([]
+   (let [snapshot (registry/flows-snapshot)]
+     (reduce-kv
+       (fn [acc frame-id flow-map]
+         (assoc acc frame-id
+                (reduce-kv
+                  (fn [m flow-id flow]
+                    (assoc m flow-id (node-for frame-id flow)))
+                  {}
+                  flow-map)))
+       {}
+       snapshot)))
+  ([frame-id]
+   (let [flow-map (get (registry/flows-snapshot) frame-id)]
+     (reduce-kv
+       (fn [m flow-id flow]
+         (assoc m flow-id (node-for frame-id flow)))
+       {}
+       (or flow-map {})))))
+
+;; ---- bundle-isolation sentinel ------------------------------------------
+;;
+;; Per rf2-bmzq0 / rf2-qwm0a (the subs.tooling + trace.tooling split
+;; pattern): `implementation/scripts/check-bundle-isolation.cjs` greps the
+;; counter bundle for this exact string. The string lives ONLY in this
+;; file's source body — no other namespace, no docstring, no test fixture
+;; references it — so its presence in the production counter bundle proves
+;; the tooling sibling's body got pulled in (most likely via a stray
+;; `:require` from a production-reachable ns). The whole flows artefact is
+;; already bundle-isolated from counter (counter never `:require`s
+;; `re-frame.flows`), so this sentinel is the belt-and-braces guard the
+;; sibling pattern standardises. The string survives `:advanced` because
+;; string literals are not renamed; it sits outside any gate so DCE cannot
+;; drop the literal independently of the surrounding ns body.
+
+(defonce ^:private bundle-isolation-sentinel
+  "rf.flows.tooling/sentinel:rf2-s8w3nw-2026-06-12:do-not-rename")

--- a/implementation/flows/test/re_frame/flow_algebra_view_test.clj
+++ b/implementation/flows/test/re_frame/flow_algebra_view_test.clj
@@ -1,0 +1,237 @@
+(ns re-frame.flow-algebra-view-test
+  "Tests for the STATIC derivation/process algebra view of flows
+  (EP-0014 slice-3, rf2-s8w3nw). Per [spec/Derivations.md] (graduated from
+  EP-0014) and the `:rf/derivation-node` shape in [spec/Spec-Schemas.md].
+
+  `re-frame.flows.tooling/flow-algebra-view` lowers every registered flow
+  into the normalized algebra node every declared fact/process shares: a
+  `:derivation` whose MATERIALIZED output lands in app-db, evaluated
+  `:after-event`, owned by the `:frame` it registered against — the
+  subscription's policy twin (same whole-value function, different output /
+  storage / evaluation / lifecycle).
+
+  These tests pin the registrar-derived projection: the fixed
+  classifications (`:kind` / `:storage` / `:evaluation` / `:lifecycle` /
+  `:materialized?`), the per-path declared-input lowering (bare app-db vs
+  `[:rf.db/runtime …]`), the output app-db address, the frame-scoped keying,
+  the `:owner`, the source-form metadata, the opaque `:derive` body token,
+  and the source coordinates.
+
+  Slice-3 ships NO public accessor (EP-0014 issue-1 disposition): the view
+  lives in the bundle-isolated `re-frame.flows.tooling` sibling, reached on
+  JVM through the `re-frame.flows/flow-algebra-view` convenience alias, and
+  consumed by Xray + the conformance fixtures. There is no
+  `re-frame.core/flow-algebra-view` public facade export."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.flows.tooling :as flows-tooling]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace]))
+
+;; Mirrors the flows_test.clj fixture so each deftest starts from a clean
+;; registrar / frames / flows state, with a :rf/default frame established
+;; and `*current-frame*` pinned so the ambient `reg-flow` calls in the
+;; bodies below carry a scope stamp (EP-0002 — reg-flow is context-required
+;; frame-local).
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (flows/reset-flows!)
+  (flows/reset-last-inputs!)
+  (schemas/clear-schemas-by-frame!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (frame/ensure-default-frame!)
+  (binding [frame/*current-frame* :rf/default]
+    (test-fn)))
+
+(use-fixtures :each reset-runtime)
+
+;; The five fixed classifications EVERY flow algebra node carries
+;; (Derivations §Worked equivalence — the flow column: the canonical
+;; app-db / after-event / frame MATERIALIZED member of the algebra).
+(def fixed-classifications
+  {:kind          :derivation
+   :storage       :app-db
+   :evaluation    :after-event
+   :lifecycle     :frame
+   :materialized? true})
+
+(defn- has-fixed-classifications? [node]
+  (= fixed-classifications (select-keys node (keys fixed-classifications))))
+
+;; ---- empty / shape contract ----------------------------------------------
+
+(deftest empty-registry-returns-empty-map
+  (testing "(flow-algebra-view) returns {} (not nil) when no flows are registered"
+    (flows/reset-flows!)
+    (is (= {} (flows-tooling/flow-algebra-view)))
+    (is (map? (flows-tooling/flow-algebra-view))))
+  (testing "(flow-algebra-view frame-id) returns {} for a frame with no flows"
+    (is (= {} (flows-tooling/flow-algebra-view :rf/default)))))
+
+(deftest jvm-alias-mirrors-the-tooling-fn
+  (testing "the JVM `re-frame.flows/flow-algebra-view` alias is the tooling fn"
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]})
+    (is (= (flows-tooling/flow-algebra-view)
+           (flows/flow-algebra-view))
+        "the JVM convenience alias projects identically to the tooling sibling")))
+
+;; ---- a registered flow exposes its algebra view --------------------------
+
+(deftest flow-exposes-its-full-algebra-view
+  (testing "a reg-flow exposes the full materialized / after-event / frame node"
+    (rf/reg-flow {:id     :cart/materialized-total
+                  :inputs [[:cart :items] [:pricing :discounts]]
+                  :output (fn [items discounts] [items discounts])
+                  :path   [:cart :total]})
+    (let [node (get-in (flows-tooling/flow-algebra-view)
+                       [:rf/default :cart/materialized-total])]
+      (is (some? node) "the flow is present under its owning frame's slot")
+      (is (has-fixed-classifications? node)
+          "flow carries the fixed derivation / app-db / after-event / frame / materialized classifications")
+      (is (= :cart/materialized-total (:id node)))
+      (is (= {:kind :reg-flow :id :cart/materialized-total} (:source-form node)))
+      (is (= [:db [:cart :total]] (:output node))
+          "the output materializes the whole value into app-db at the flow's :path")
+      (is (= [[:db [:cart :items]] [:db [:pricing :discounts]]] (:inputs node))
+          "each bare :inputs path lowers to a [:db path] declared input, in declaration order")
+      (is (= [:frame :rf/default] (:owner node))
+          "the owner is the frame the flow registered against")
+      (is (fn? (:derive node))
+          "the :output body fn is surfaced as an opaque :derive token"))))
+
+(deftest single-frame-arity-returns-that-frames-flows
+  (testing "(flow-algebra-view frame-id) returns {flow-id node} for one frame"
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]})
+    (let [per-frame (flows-tooling/flow-algebra-view :rf/default)]
+      (is (= #{:area} (set (keys per-frame))))
+      (is (= (get-in (flows-tooling/flow-algebra-view) [:rf/default :area])
+             (get per-frame :area))
+          "the one-frame form equals that frame's entry in the all-flows map"))))
+
+;; ---- runtime-db partition-qualified input --------------------------------
+
+(deftest runtime-qualified-input-lowers-to-a-runtime-read
+  (testing "a [:rf.db/runtime …] input lowers to a [:runtime …rest] declared input"
+    ;; EP-0001 §535-551 (rf2-4eisfr): any flow may READ runtime-db via an
+    ;; explicit partition-qualified input; only the write side is reserved.
+    (rf/reg-flow {:id     :route/derived
+                  :inputs [[:rf.db/runtime :rf.runtime/routing :current :id]
+                           [:local :seed]]
+                  :output (fn [route-id seed] [route-id seed])
+                  :path   [:derived :slug]})
+    (let [node (get-in (flows-tooling/flow-algebra-view)
+                       [:rf/default :route/derived])]
+      (is (has-fixed-classifications? node))
+      (is (= [[:runtime [:rf.runtime/routing :current :id]]
+              [:db [:local :seed]]]
+             (:inputs node))
+          "the partition key is stripped for the runtime read; the bare path stays a [:db …] read"))))
+
+;; ---- multiple flows ------------------------------------------------------
+
+(deftest multiple-flows-all-project
+  (testing "every registered flow on a frame projects to its own node"
+    (rf/reg-flow {:id     :a
+                  :inputs [[:w]]
+                  :output (fn [w] w)
+                  :path   [:out :a]})
+    (rf/reg-flow {:id     :b
+                  :inputs [[:h]]
+                  :output (fn [h] h)
+                  :path   [:out :b]})
+    (let [per-frame (flows-tooling/flow-algebra-view :rf/default)]
+      (is (= #{:a :b} (set (keys per-frame))))
+      (is (every? has-fixed-classifications? (vals per-frame)))
+      (is (= [:db [:out :a]] (:output (:a per-frame))))
+      (is (= [:db [:out :b]] (:output (:b per-frame)))))))
+
+(deftest same-flow-id-on-two-frames-projects-per-frame
+  (testing "the same flow-id on two frames yields two distinct nodes (frame-scoped)"
+    ;; Flows are frame-scoped — the same id may carry different :inputs /
+    ;; :path on different frames. The view preserves the frame dimension.
+    (rf/reg-frame :other {:doc "second frame for the frame-scoped view test"})
+    (rf/reg-flow {:id     :shared
+                  :inputs [[:a]]
+                  :output (fn [a] a)
+                  :path   [:out :default]}
+                 {:frame :rf/default})
+    (rf/reg-flow {:id     :shared
+                  :inputs [[:b]]
+                  :output (fn [b] b)
+                  :path   [:out :other]}
+                 {:frame :other})
+    (let [view (flows-tooling/flow-algebra-view)]
+      (is (= [:db [:out :default]] (get-in view [:rf/default :shared :output])))
+      (is (= [:db [:out :other]]   (get-in view [:other :shared :output])))
+      (is (= [:frame :rf/default]  (get-in view [:rf/default :shared :owner])))
+      (is (= [:frame :other]       (get-in view [:other :shared :owner]))
+          "each node names its own owning frame"))))
+
+;; ---- source-coords / schema / doc passthrough ----------------------------
+
+(deftest source-coords-surface-in-the-node
+  (testing ":ns / :line / :file captured by reg-flow surface under :source"
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]})
+    (let [node   (get-in (flows-tooling/flow-algebra-view) [:rf/default :area])
+          source (:source node)]
+      (is (some? source) ":source map is present when the registration carried coords")
+      (is (some? (:ns source))     ":ns captured at the call site")
+      (is (number? (:line source)) ":line captured at the call site")
+      (is (some? (:file source))   ":file captured at the call site"))))
+
+(deftest schema-and-doc-pass-through
+  (testing ":schema and :doc supplied on the flow map surface in the node"
+    (rf/reg-flow {:id     :priced
+                  :doc    "a priced total"
+                  :schema :app.money/amount
+                  :inputs [[:price]]
+                  :output (fn [p] p)
+                  :path   [:cart :total]})
+    (let [node (get-in (flows-tooling/flow-algebra-view) [:rf/default :priced])]
+      (is (= :app.money/amount (:schema node))
+          "the declared output :schema surfaces as a node fact")
+      (is (= "a priced total" (:doc node))))))
+
+(deftest no-schema-or-doc-when-absent
+  (testing ":schema / :doc are absent when the registration didn't supply them"
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* (or w 0) (or h 0)))
+                  :path   [:rect :area]})
+    (let [node (get-in (flows-tooling/flow-algebra-view) [:rf/default :area])]
+      (is (not (contains? node :schema)))
+      (is (not (contains? node :doc))))))
+
+;; ---- registry semantics --------------------------------------------------
+
+(deftest cleared-flow-is-removed
+  (testing "(clear-flow id) removes the flow from the algebra view"
+    (rf/reg-flow {:id     :a
+                  :inputs [[:w]]
+                  :output (fn [w] w)
+                  :path   [:out :a]})
+    (rf/reg-flow {:id     :b
+                  :inputs [[:h]]
+                  :output (fn [h] h)
+                  :path   [:out :b]})
+    (is (contains? (flows-tooling/flow-algebra-view :rf/default) :a))
+    (rf/clear-flow :a)
+    (let [per-frame (flows-tooling/flow-algebra-view :rf/default)]
+      (is (not (contains? per-frame :a)))
+      (is (contains? per-frame :b)))))

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -313,6 +313,31 @@ const ARTEFACTS = [
     expectedAllowListHits: 0,
   },
 
+  // re-frame.flows.tooling (rf2-s8w3nw — EP-0014 slice-3
+  // `flow-algebra-view` split off from the flows artefact for production
+  // DCE). The whole flows artefact is ALREADY bundle-isolated from
+  // counter (counter never `:require`s `re-frame.flows` — the `flows`
+  // entry above pins that), so this sibling can never reach a no-flows
+  // app's bundle; this entry is the belt-and-braces guard the
+  // tooling-sibling pattern standardises (it also fires if a flows-using
+  // CLJS app's facade ever `:require`s the tooling sibling — the
+  // `re-frame.flows` → `re-frame.flows.tooling` require is `#?@(:clj ...)`-
+  // gated so the body stays out of CLJS). Sentinel mirrors the
+  // subs-tooling / trace-tooling shape: a unique string planted at the
+  // bottom of the namespace body, surviving `:advanced` (string literals
+  // are not renamed) and outside any DCE gate.
+  {
+    name: 'flows-tooling',
+    internalSentinels: [
+      // flows/tooling.cljc — explicit sentinel planted at the bottom
+      // of the namespace body (`bundle-isolation-sentinel`).
+      { source: 're-frame.flows.tooling (bundle-isolation-sentinel)',
+        sentinel: 'rf.flows.tooling/sentinel:rf2-s8w3nw-2026-06-12:do-not-rename' },
+    ],
+    consumerAllowList: null,
+    expectedAllowListHits: 0,
+  },
+
   // re-frame.trace.cascade (rf2-931pm — focused-event-only cascade-DAG
   // aggregator). Same posture as `trace.tooling`: the namespace is
   // autoloaded from `re-frame.core` only via the JVM-only conditional

--- a/spec/Derivations.md
+++ b/spec/Derivations.md
@@ -475,6 +475,33 @@ The node additionally carries the opaque `:derive` body token (never serialized 
 
 This exposure is *internal registration metadata*, consistent with the slice scope: it ships **no public accessor**. The static and live subscription views live in the bundle-isolated subscription tooling sibling (`re-frame.subs.tooling/sub-algebra-view` and `…/sub-cache-algebra-view` in the reference implementation; production CLJS bundles DCE the bodies), consumed by [Xray](../tools/xray/spec/README.md) and the conformance fixtures — the two named first consumers. They feed the later internal graph-inspection helper ([EP-0014 §Reference Implementation / Bead Plan](../docs/EP/EP-0014-derivation-and-process-algebra.md#reference-implementation--bead-plan) item 7); the public name is deferred until a third consumer needs it (the [graduation gate](#one-accessor-two-projections-ep-0014-issue-1-disposition)).
 
+## Flows expose algebra views
+
+Flows are the second concrete algebra member to expose its view, and the subscription's exact policy twin: the *same* whole-value function, materialized instead of ephemeral (the [§Worked equivalence](#worked-equivalence--one-function-two-policies) above). Every `reg-flow` registration projects to the [node shape](#the-node-shape). The projection is **registrar-derived** (see [§The EP-0013 relocation seam](#the-ep-0013-relocation-seam)): [013](013-Flows.md) keeps the per-frame registry, the topological-sort engine, the dirty-check, and the drain-integration semantics; the algebra view is assembled from the flow-map metadata that already exists, never from re-running the `:output` function.
+
+A flow is always a **`:derivation`** (never a process — [§Derivation](#derivation)), and every flow node carries the same five fixed classifications, because a flow is the canonical *materialized* member of the algebra:
+
+| Axis | Value | Why |
+|---|---|---|
+| `:kind` | `:derivation` | a pure whole-value computation; the materialized output is its only durable state |
+| `:storage` | `:app-db` | the output is materialized into the application-owned app-db partition (flow writes are app-db only — [013 §Input partition](013-Flows.md#input-partition--bare--app-db-rfdbruntime---runtime-db)) |
+| `:evaluation` | `:after-event` | evaluated inside the event drain, as the outermost `:after` transform, participating in the event's atomicity ([013 §Drain integration](013-Flows.md#drain-integration); [§Evaluation policy](#evaluation-policy) rule 2) |
+| `:lifecycle` | `:frame` | flows are frame-scoped; the frame owns the flow and `destroy-frame!` releases it ([013 §Frame-scoping](013-Flows.md)) |
+| `:materialized?` | `true` | the output has a durable app-db address, not just a fact identity |
+
+The two axes that **vary** per flow are the declared **inputs** and the **output** path:
+
+- **`:output`** is `[:db <:path>]` — the flow's `:path`, the app-db address its whole value materializes into.
+- **`:inputs`** lowers each declared `:inputs` path ([§Declared input](#declared-input)), in declaration order:
+  - a bare path is an app-db read — `[:db path]`;
+  - a partition-qualified `[:rf.db/runtime …rest]` path is a runtime-db read — `[:runtime …rest]` (the binary input syntax — any flow may *read* runtime-db, only the *write* side is reserved to app-db; [EP-0001 §535-551](013-Flows.md#input-partition--bare--app-db-rfdbruntime---runtime-db)).
+
+  Flow inputs are always concrete paths — never `:sub` edges and never the `:parametric` marker — because a flow declares its dependency graph statically as paths, not as an input-producer over a query vector.
+
+Because flows are frame-scoped — the same flow-id may register against two frames with different `:inputs` / `:output` / `:path` — the flow view preserves the frame dimension: it is keyed `{frame-id {flow-id <node>}}`, the same shape as the flow registry it reads. Each node additionally records its owning frame under `:owner` `[:frame <frame-id>]` (the lifecycle owner, distinct from the cause of any one evaluation — [§Lifecycle and owner](#lifecycle-and-owner)), the opaque `:derive` body token (the `:output` fn, never serialized), the `:source-form` `{:kind :reg-flow :id <id>}`, and the `:source` coordinates / `:schema` / doc when the registration carried them.
+
+This exposure is *internal registration metadata*, consistent with the slice scope: it ships **no public accessor**. The flow view lives in the bundle-isolated flows tooling sibling (`re-frame.flows.tooling/flow-algebra-view` in the reference implementation; a CLJS app that loads the flows artefact but attaches no tool DCEs the body, and the whole flows artefact is already absent from a no-flows app's bundle), consumed by [Xray](../tools/xray/spec/README.md) and the conformance fixtures — the two named first consumers. It reads the per-frame flow registry through the existing public `flows-snapshot` seam and touches neither the registrar write-path nor the flow registration signatures. It feeds the later internal graph-inspection helper ([EP-0014 §Reference Implementation / Bead Plan](../docs/EP/EP-0014-derivation-and-process-algebra.md#reference-implementation--bead-plan) item 7); the public name is deferred until a third consumer needs it (the [graduation gate](#one-accessor-two-projections-ep-0014-issue-1-disposition)).
+
 ## The EP-0013 relocation seam
 
 In slice-1 the algebra view is **registrar-derived** — assembled from registration metadata at the surface that registers each source form. The normalized node this doc defines is deliberately the per-fact/per-process row an app value would carry, so a future move to [EP-0013](../docs/EP/EP-0013-app-values-and-runtime-realms.md) app values/runtime realms is a *relocation, not a redesign*.

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -675,6 +675,16 @@
   ["re-frame.flows" "clear-flow"]            {:tier :internal-public :owner "013" :status "v1"}
   ["re-frame.flows" "flows-snapshot"]        {:tier :tooling :owner "013" :status "v1"}
   ["re-frame.flows" "last-inputs-snapshot"]  {:tier :tooling :owner "013" :status "v1"}
+  ;; EP-0014 slice-3 (rf2-s8w3nw): the derivation/process algebra view of
+  ;; registered flows. JVM-only convenience alias of
+  ;; `re-frame.flows.tooling/flow-algebra-view` (the body lives in the
+  ;; bundle-isolated tooling sibling; the CLJS facade never `:require`s it,
+  ;; so prod CLJS bundles DCE it). `:tooling`, no `re-frame.core` facade
+  ;; export (EP-0014 issue-1 disposition). Mirror of `sub-algebra-view`
+  ;; (slice-2) — which carries no manifest row only because its host
+  ;; `re-frame.subs` is not a generator-introspected namespace, whereas
+  ;; `re-frame.flows` is.
+  ["re-frame.flows" "flow-algebra-view"]     {:tier :tooling :owner "013" :status "v1"}
   ["re-frame.flows" "run-flows-on-db"]       {:tier :internal-public :owner "013" :status "v1"}
   ["re-frame.flows" "reset-flows!"]          {:tier :internal-public :owner "013" :status "v1"}
   ["re-frame.flows" "reset-last-inputs!"]    {:tier :internal-public :owner "013" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 508,
+ :var-count 509,
  :tier-vocab
  [:front-porch
   :advanced
@@ -246,6 +246,7 @@
   {:namespace "re-frame.epoch", :var "settle!", :tier :internal-public, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.epoch", :var "unregister-epoch-listener!", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "clear-flow", :tier :internal-public, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.flows", :var "flow-algebra-view", :tier :tooling, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "flows-snapshot", :tier :tooling, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "last-inputs-snapshot", :tier :tooling, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.flows", :var "reg-flow", :tier :internal-public, :kind :fn, :owner "013", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
EP-0014 action-wave **slice-3** (epic rf2-k0meap; Reference Implementation Plan item 3). Slices 1-2 merged (algebra vocabulary in `spec/Derivations.md` + the `:rf/derivation-node` schema; subscriptions expose algebra views via the bundle-isolated `re-frame.subs.tooling` sibling). This slice does the same for **flows**, mirroring the slice-2 pattern.

## What

Every `reg-flow` registration now projects to the EP-0014 derivation/process algebra node shape — the subscription's exact policy twin (the *same* whole-value function, materialized instead of ephemeral).

A registrar-derived projection in a new bundle-isolated **`re-frame.flows.tooling`** sibling (DCE'd in production CLJS bundles; JVM-aliased — mirrors `re-frame.subs.tooling`):

- **`flow-algebra-view`** (static, JVM-runnable): every registered flow lowered to a `:derivation` node.

### The flow algebra-view shape

```clojure
{:id            :cart/materialized-total
 :kind          :derivation                 ;; flows are derivations, never processes
 :source-form   {:kind :reg-flow :id :cart/materialized-total}
 :inputs        [[:db [:cart :items]]        ;; bare path → app-db read
                 [:db [:pricing :discounts]]]
 :output        [:db [:cart :total]]         ;; MATERIALIZED into app-db at :path
 :storage       :app-db
 :evaluation    :after-event                 ;; evaluated inside the event drain
 :lifecycle     :frame
 :owner         [:frame :rf/default]         ;; flows are frame-scoped
 :materialized? true
 :derive        <opaque :output fn token>
 :source        {:ns … :line … :file …}      ;; frame-matched; present when captured
 :schema        :app.money/amount            ;; when declared
 :doc           "…"}                          ;; when declared
```

The five fixed classifications (`:derivation` / `:app-db` / `:after-event` / `:frame` / `materialized? true`) are constant per the Derivations §Worked-equivalence flow column. The varying axes are the declared **inputs** and the **output** path. A `[:rf.db/runtime …rest]` partition-qualified input lowers to `[:runtime …rest]` (EP-0001 §535-551 — any flow may *read* runtime-db; writes stay app-db).

Flows are frame-scoped, so the view preserves the frame dimension: keyed `{frame-id {flow-id node}}`, the same shape as the flow registry it reads. Zero-arity returns all frames; one-arity `[frame-id]` returns one frame's `{flow-id node}`.

## Constraints honored

- **READ-ONLY over the registry.** Reads the per-frame flow registry via the existing public `re-frame.flows.registry/flows-snapshot` seam, and the `:flow` registrar slot (frame-matched, for source coords only). Touches **neither** the core registrar write-path **nor** the flow registration signatures — EP-0013 D1-impl is in flight (rf2-pnf7t5). Mirrors exactly how slice-2's `subs.tooling` read the sub registry.
- **Consumes slice-1 vocabulary** — does not redefine the storage-class / evaluation-policy / lifecycle enums or the `:rf/derivation-node` shape; Spec-Schemas untouched.
- **No public accessor** (EP-0014 issue-1 disposition): reached via `flows.tooling` directly (CLJS: Xray + conformance) / the `re-frame.flows/flow-algebra-view` JVM alias (`#?(:clj ...)`-gated; the CLJS facade never `:require`s the sibling). No `re-frame.core` facade export. Feeds the later internal graph-inspection helper (plan item 7).

## Files

- `implementation/flows/src/re_frame/flows/tooling.cljc` — new bundle-isolated sibling (+ sentinel).
- `implementation/flows/src/re_frame/flows.cljc` — `#?@(:clj ...)` require of the sibling + JVM `flow-algebra-view` alias.
- `implementation/flows/test/re_frame/flow_algebra_view_test.clj` — 11 new tests.
- `implementation/scripts/check-bundle-isolation.cjs` — new `flows-tooling` sentinel entry.
- `spec/Derivations.md` — new §Flows expose algebra views.

## Quality gates

- `npm run test:cljs` (core): 6586 tests, 0 failures
- core `clojure -M:test`: 1205 tests, 0 failures
- flows `clojure -M:test`: 197 tests, 0 failures (incl. 11 new in `flow-algebra-view-test`)
- `npm run test:bundle-isolation`: PASS (18 artefact entries; new `flows-tooling` sentinel absent from the counter bundle)
- `mkdocs build --strict`: clean

### CI fix (rebased onto origin/main)

The new JVM alias `re-frame.flows/flow-algebra-view` is a public var in a generator-introspected namespace (`re-frame.flows` is in the api-manifest generator's `jvm-namespaces`), so the **Public-API manifest drift-check** went red ("Public vars with no sidecar classification: re-frame.flows/flow-algebra-view"), which cascaded the **Lint required** aggregator (api-manifest is in its `needs`). Fixed by classifying the var in `spec/api-manifest-metadata.edn` and regenerating `spec/api-manifest.edn`:

- `["re-frame.flows" "flow-algebra-view"] {:tier :tooling :owner "013" :status "v1"}` — mirrors the sibling `flows-snapshot`/`last-inputs-snapshot` tooling vars and the slice-2 `sub-algebra-view` disposition (tooling, no `re-frame.core` facade export). `re-frame.subs/sub-algebra-view` needs no row only because `re-frame.subs` is not a generator-introspected namespace; `re-frame.flows` is.
- `spec/api-manifest.edn` regenerated: 508 -> 509 vars (one-row `:facade? false` `:tier :tooling` addition).

Local re-run (all green):
- `gen --check`: OK, in sync (509 vars)
- `api-md-check` / `story-spec-check` / `xray-spec-check` / `skills-check` / `doc-guide-check`: all OK
- api-manifest reconciler regression tests (`clojure -M:test`): 27 tests, 57 assertions, 0 failures/0 errors
- `clj-kondo --fail-level error` on changed flows files: errors: 0 (lint failure was a pure cascade, not a kondo finding)
- `npm run test:cljs`: 6597 tests, 24144 assertions, 0 failures/0 errors
