### PR TITLE
feat(core): EP-0013 D1 — internal realm record + default realm + realm-owned registrar (rf2-gkddyq)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -19,6 +19,7 @@
     :rf.frame/<gensym>       — anonymous instances from make-frame"
   (:require [clojure.string]
             [re-frame.registrar :as registrar]
+            [re-frame.realm :as realm]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -31,6 +32,15 @@
 ;;
 ;; Per Spec 002 §What lives in a frame, a frame is a map with:
 ;;   :id          the keyword identity
+;;   :realm       the id of the runtime realm the frame belongs to for its
+;;                lifetime (EP-0013 D1, Spec 002 §Frames reference realms).
+;;                A frame REFERENCES its realm internally; the registrar,
+;;                adapter, and capabilities are the realm's, not the frame's.
+;;                In a single-realm app this is `realm/default-realm-id` —
+;;                a single-frame/single-realm app never spells a realm
+;;                (the EP-0002 refinement pattern). The reference is the
+;;                realm-id keyword (not the realm map) so the frame record
+;;                stays a plain value the (realm, frame) address is built on.
 ;;   :frame-state the ONE physical durable container (opaque; through adapter)
 ;;                — holds BOTH partitions as a frame-state value
 ;;                `{:rf.db/app <app-db> :rf.db/runtime <runtime-db>}`.
@@ -75,6 +85,35 @@
   ^{:doc "Map of frame-id → frame-record. Per-process (one global frame registry)."}
   frames
   (atom {}))
+
+;; ---- realm-owned frame-registry view (EP-0013 D1, rf2-gkddyq) -------------
+;;
+;; The frame registry is realm-owned (Spec 002 §Frames reference realms). In
+;; D1 the frame RECORDS live here in `frames`; the realm owns the MEMBERSHIP
+;; VIEW, derived live from this atom by grouping on each frame's `:realm`
+;; slot. Deriving (rather than maintaining a separate per-realm set) keeps
+;; ONE source of truth and means the many `(reset! frame/frames {})` test
+;; fixtures reset membership for free. `re-frame.realm` reads this through
+;; the `:realm/frames-by-realm` late-bind hook (a static back-require would
+;; cycle — frame requires realm for the record's default realm-id).
+
+(defn frames-by-realm
+  "Return `realm-id → #{frame-id …}` over the live, non-destroyed frames —
+  the realm-owned membership view (EP-0013 D1). A frame contributes to its
+  `:realm` slot's set (default realm when the slot is absent). INTERNAL —
+  the realm-membership reader; published as `:realm/frames-by-realm`."
+  []
+  (persistent!
+    (reduce-kv
+      (fn [acc fid f]
+        (if (-> f :lifecycle :destroyed?)
+          acc
+          (let [rid (or (:realm f) realm/default-realm-id)]
+            (assoc! acc rid (conj (get acc rid #{}) fid)))))
+      (transient {})
+      @frames)))
+
+(late-bind/set-fn! :realm/frames-by-realm frames-by-realm)
 
 ;; ---- destroy-in-flight guard (rf2-r1ciy) ---------------------------------
 ;;
@@ -368,6 +407,17 @@
     ;; while a pass is already in flight, so the latter case cannot
     ;; arise from that seam.
     true))
+
+(defn frame-realm
+  "Return the id of the runtime realm `id` belongs to (EP-0013 D1,
+  Spec 002 §Frames reference realms), or nil for an unknown / destroyed
+  frame. A frame references its realm internally; the registrar, adapter,
+  and capabilities are the realm's. In a single-realm app this is
+  `realm/default-realm-id` for every frame. INTERNAL — D1 ships no public
+  realm-targeted API."
+  [id]
+  (when-let [f (frame id)]
+    (or (:realm f) realm/default-realm-id)))
 
 (defn frame-meta
   "Per Spec 002 §The public registrar query API and Spec-Schemas
@@ -809,6 +859,13 @@
   (let [frame-state (adapter/make-state-container {app-partition-key     {}
                                                    runtime-partition-key {}})]
    {:id          id
+    ;; EP-0013 D1 (rf2-gkddyq): the frame REFERENCES the runtime realm it
+    ;; belongs to for its lifetime (Spec 002 §Frames reference realms). D1
+    ;; ships no public realm-targeted `reg-frame` arity, so every frame
+    ;; belongs to the default realm — a single-realm app never spells a
+    ;; realm. The stored value is the realm-id keyword (the carried (realm,
+    ;; frame) address dimension), not the realm map.
+    :realm       realm/default-realm-id
     :frame-state frame-state
     ;; app-db / runtime-db are READ-ONLY projection reactions over the one
     ;; physical container — `make-derived-value` memoises on `=`, so a
@@ -1321,6 +1378,10 @@
 
 (defn- dissoc-frame!
   [id]
+  ;; EP-0013 D1 (rf2-gkddyq): realm membership is a VIEW derived from this
+  ;; atom (filtered on each frame's `:realm` slot — see `frames-by-realm`),
+  ;; so removing the frame record here drops it from its realm's membership
+  ;; with no separate retraction step and no desync.
   (swap! frames dissoc id))
 
 (defn- unregister-frame!

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -960,6 +960,10 @@
     :producer-ns 're-frame.frame
     :design-bead "rf2-g1b2m"
     :description "Read the currently-bound frame id from `re-frame.frame/*current-frame*`. Consulted by `re-frame.trace.tooling/push-to-ring!` as the routing fallback when the trace event itself does not carry a `:frame` tag (e.g. sub recompute / view render emits inside an in-flight cascade)."}
+   {:key         :realm/frames-by-realm
+    :producer-ns 're-frame.frame
+    :design-bead "rf2-gkddyq"
+    :description "EP-0013 D1 realm-owned frame-registry view. Returns `realm-id → #{frame-id …}` over the live (non-destroyed) frames, grouped by each frame record's `:realm` slot. `re-frame.realm/realm-frames` consults it to answer the realm-owned membership query — `re-frame.frame` requires `re-frame.realm` for the frame record's default realm-id, so the back-read is late-bound to avoid a require cycle. Membership is DERIVED from `re-frame.frame/frames` (single source of truth; no separately-stored set), so the `(reset! frame/frames {})` test fixtures reset it for free."}
 
    ;; ---- re-frame.trace.cascade (rf2-931pm — focused-event-only cascade-DAG aggregator) ----
    ;;

--- a/implementation/core/src/re_frame/realm.cljc
+++ b/implementation/core/src/re_frame/realm.cljc
@@ -1,0 +1,203 @@
+(ns re-frame.realm
+  "The runtime realm — the container that owns the non-durable operational
+  layer an app runs in (EP-0013 D1, accepted 2026-06-11).
+
+  Per [Runtime-Subsystems §Runtime realms](spec/Runtime-Subsystems.md) and
+  Spec-Schemas §`:rf/realm`, a runtime realm owns the registrar it
+  dispatches/subscribes/resolves against, the installed adapter SELECTION,
+  the capability map, the frame registry (frame ids are unique *within* a
+  realm), and the host-transient subsystem state — distinct from the
+  *durable* `:rf.runtime/*` subsystems, which live inside the frames the
+  realm owns.
+
+  ## D1 is INTERNAL — no public source break, no public constructor
+
+  This is EP-0013 staging 1-3: an internal realm record + a default realm +
+  realm-owned registrar + a frame realm-reference. **No public `rf/realm`
+  constructor and no realm-targeted public query ship here** (EP-0013 issue
+  1 — those names are reserved vocabulary, exposure graduates internal-first;
+  D2/later stages). Everything in a single-realm app routes through ONE
+  process-created **default realm** (`:rf.realm/id` = `:rf.realm/default`),
+  so today's single-app ergonomics are byte-identical: a single-realm app
+  never spells a realm, exactly as a single-frame app never spells a frame
+  outside its root (the EP-0002 refinement pattern). Absence of an explicit
+  realm means the default realm — an explicit documented rule, never
+  synthesis.
+
+  ## The registrar is owned, not copied
+
+  D1 changes registrar *ownership*, not the registrar *shape*. The default
+  realm OWNS the existing process-global `re-frame.registrar` atom
+  (`kind->id->metadata`) by holding a reference to it in its `:registrar`
+  slot. The registry shape, the `register!` / `lookup` / `registrations`
+  read+write API, and every public `reg-*` / frame signature are unchanged.
+  Existing specs call the default realm's registrar \"global\"; under D1 it
+  is the default realm's, and the surface is identical. D2 (the app value —
+  registrations as immutable descriptors) is sequenced behind D1; this ns
+  holds today's mutable registrar behind the realm unchanged and leaves the
+  `:app` slot absent.
+
+  ## Production elision
+
+  This ns allocates a small realm map for the default realm at process load
+  and exposes pure readers. It has no trace emit sites and no DEBUG-gated
+  branches — the realm record is operational metadata, not a dev surface, so
+  it survives `:advanced` + `goog.DEBUG=false` builds intact (it carries no
+  feature sentinels and no per-feature `:require`, so the bundle-isolation
+  gate is unaffected)."
+  (:require [re-frame.registrar :as registrar]
+            [re-frame.late-bind :as late-bind]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- the default realm id -------------------------------------------------
+
+(def ^:const default-realm-id
+  "The process default realm's id. Stable, process-unique. Existing
+  one-argument / ambient-looking surfaces (`reg-*`, adapter install, the
+  registrar query API) resolve through this realm when no explicit realm is
+  supplied; absence of `:rf.realm/id` means THIS realm, an explicit
+  documented rule (Spec-Schemas §`:rf/realm`, EP-0013 issue 2 disposition)."
+  :rf.realm/default)
+
+;; ---- the realm record -----------------------------------------------------
+;;
+;; Per Spec-Schemas §`:rf/realm` the realm is an open map (an implementation
+;; MAY use a host record for efficiency, but MUST expose this data
+;; projection for tooling/conformance). D1 keeps it a plain map — none of
+;; these fields is a public read surface in D1, and a map IS the data
+;; projection. The shipped D1 slots:
+;;
+;;   :rf.realm/id     stable, process-unique keyword (the default is
+;;                    :rf.realm/default)
+;;   :registrar       the realm's registrar — the `(kind, id) → descriptor`
+;;                    table it dispatches/subscribes/resolves against. The
+;;                    default realm holds a REFERENCE to the existing
+;;                    process-global `registrar/kind->id->metadata` atom, so
+;;                    the registry shape + read/write API are unchanged.
+;;   :adapter         the realm's adapter SELECTION (capability); render
+;;                    roots own concrete instances. Absent until installed.
+;;   :capabilities    :rf.capability/* → service map/record. Absent in the
+;;                    bare default realm; late-bind hooks bridge in (D1
+;;                    §Late-bind compatibility).
+;;   :frames          the set of frame ids registered in this realm (unique
+;;                    WITHIN the realm). Frame records still live in the
+;;                    process `frame/frames` atom in D1; this set is the
+;;                    realm-owned membership view.
+;;   :host-transient  subsystem-id → HostTransientDescriptor. Absent until a
+;;                    subsystem moves behind the realm (EP-0013 issue 5 — a
+;;                    later D1 slice / stage 4).
+;;
+;; D2/D3-RESERVED, never required in D1: :app (the installed app VALUE),
+;; :lifecycle ({:disposed? …}). Left absent here.
+
+(defn make-realm
+  "Build a realm map. INTERNAL — there is NO public `rf/realm` constructor
+  in D1 (EP-0013 issue 1); this is the internal record factory the default
+  realm and tests use.
+
+  `opts` may carry `:registrar` (the realm's `(kind, id) → descriptor`
+  table — defaults to the process-global `registrar/kind->id->metadata` so a
+  realm with no explicit registrar shares the surface existing specs call
+  \"global\"), `:adapter` (selection), and `:capabilities`. The frame set
+  starts empty.
+
+  Per Spec-Schemas §`:rf/realm` the realm is an open map; only `:rf.realm/id`
+  is required, and the data projection IS the map."
+  ([id] (make-realm id nil))
+  ([id opts]
+   (cond-> {:rf.realm/id id
+            ;; The default registrar is the existing process-global atom —
+            ;; ownership moves to the realm, the shape does not. A realm
+            ;; created with an explicit `:registrar` (hermetic test realm)
+            ;; gets its own table; the registry API operates on whichever
+            ;; atom the realm hands it (D2 work). In D1 only the default
+            ;; realm exists at runtime, so this defaults to the global atom.
+            :registrar (get opts :registrar registrar/kind->id->metadata)}
+     (contains? opts :adapter)      (assoc :adapter      (:adapter opts))
+     (contains? opts :capabilities) (assoc :capabilities (:capabilities opts)))))
+
+;; ---- the default realm ----------------------------------------------------
+;;
+;; The process creates ONE default realm at boot, holding the existing
+;; process-global registrar atom. It is the compatibility surface for every
+;; one-argument / ambient-looking call. A single-realm app never mentions a
+;; realm — it carries the default realm implicitly (the EP-0002 refinement
+;; pattern). The realm is held in an atom so the (future, D2) install! /
+;; reinstall! path can replace the realm's installed app at the realm
+;; boundary; in D1 the only mutation is the frame-membership set.
+
+(defonce
+  ^{:doc "The process realm registry: realm-id → realm map. D1 holds exactly
+  one entry — the default realm. Held as an atom so a later stage can add
+  realms and so the default realm's frame-membership set can be updated in
+  place. The registry is process-wide; realm ids are unique within a
+  process (Spec-Schemas §`:rf/realm`)."}
+  realms
+  (atom {default-realm-id (make-realm default-realm-id)}))
+
+(defn default-realm
+  "Return the process default realm map — the realm that backs every
+  existing one-argument / ambient-looking `reg-*` / adapter-install /
+  registrar-query call shape. Absence of an explicit realm means THIS realm
+  (Spec-Schemas §`:rf/realm`; EP-0013 issue 2 disposition). INTERNAL in D1 —
+  not a public read surface."
+  []
+  (get @realms default-realm-id))
+
+(defn realm
+  "Return the realm map for `id`, or nil. INTERNAL. D1 only ever has the
+  default realm at runtime; this reader exists for the (realm, frame)
+  addressing model the later stages build on."
+  [id]
+  (get @realms id))
+
+(defn realm-id
+  "Return a realm's id. Accepts the realm map or, for ergonomic call sites,
+  a realm-id keyword (returned unchanged). Returns `default-realm-id` for nil
+  — absence is the default realm, the documented rule."
+  [realm-or-id]
+  (cond
+    (nil? realm-or-id)     default-realm-id
+    (keyword? realm-or-id) realm-or-id
+    :else                  (:rf.realm/id realm-or-id)))
+
+(defn registrar
+  "Return the registrar atom a realm dispatches/resolves against — the
+  `(kind, id) → descriptor` table. For the default realm this IS the
+  existing process-global `registrar/kind->id->metadata`, so the registry
+  read/write API is unchanged. Accepts a realm map; nil resolves to the
+  default realm's registrar (absence = default realm). INTERNAL."
+  ([] (registrar (default-realm)))
+  ([realm-map]
+   (:registrar (or realm-map (default-realm)))))
+
+;; ---- realm-owned frame registry (membership view) -------------------------
+;;
+;; The frame registry is realm-owned (Spec 002 §Frames reference realms,
+;; Runtime-Subsystems §What a realm owns). In D1 the frame RECORDS still live
+;; in the process `re-frame.frame/frames` atom — moving them into per-realm
+;; tables is a later stage. The realm owns the MEMBERSHIP VIEW, derived from
+;; that atom by filtering on each frame's `:realm` slot, so there is ONE
+;; source of truth and no desync with the many `(reset! frame/frames {})`
+;; test fixtures. Frame ids are unique within a realm, not globally (EP-0013
+;; issue 3) — the same id in two realms is a tested legal case, so membership
+;; is computed per-realm.
+;;
+;; `re-frame.frame` requires THIS ns (for `default-realm-id` on the frame
+;; record), so a static back-require would cycle; the membership reader is
+;; reached through the `:realm/frames-by-realm` late-bind hook, which frame
+;; publishes at ns-load. Returns `nil` when the hook is unbound (frame ns not
+;; yet loaded), which the public reader treats as the empty set.
+
+(defn realm-frames
+  "Return the set of frame ids whose `:realm` reference is `rid` (defaults
+  to the default realm). The realm-owned membership view, derived live from
+  `re-frame.frame/frames` via the `:realm/frames-by-realm` hook — single
+  source of truth, no separately-stored set. Returns `#{}` when the frame ns
+  is not yet loaded. INTERNAL."
+  ([] (realm-frames default-realm-id))
+  ([rid]
+   (if-let [by-realm (late-bind/get-fn :realm/frames-by-realm)]
+     (get (by-realm) rid #{})
+     #{})))

--- a/implementation/core/test/re_frame/realm_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_cljs_test.cljc
@@ -1,0 +1,192 @@
+(ns re-frame.realm-cljs-test
+  "EP-0013 D1 internal staging 1-3 (rf2-gkddyq) — the runtime realm record,
+  the default realm, the realm-owned registrar, and the frame's realm
+  reference.
+
+  D1 is INTERNAL: no public `rf/realm` constructor and no realm-targeted
+  public query ship. The headline acceptance is **zero ergonomic regression**
+  — everything routes through one default realm so a single-realm app's
+  surface is byte-identical. These tests pin:
+
+    (1) the default realm exists with id `:rf.realm/default` and the shipped
+        D1 record shape (Spec-Schemas §`:rf/realm`);
+    (2) the realm OWNS the registrar — the default realm's `:registrar` slot
+        IS the existing process-global `registrar/kind->id->metadata` atom,
+        so the registry shape + read/write API are unchanged
+        (default-realm transparency: `reg-*` / dispatch / subscribe behave
+        exactly as before);
+    (3) a frame carries its realm REFERENCE internally (`:realm` slot →
+        `:rf.realm/default`); the realm-owned frame-membership VIEW is
+        derived live from the frame registry, with no separately-stored set.
+
+  Dual-runtime: named `*_cljs_test.cljc` so the shadow-cljs `:node-test`
+  build (`npm run test:cljs`, `:ns-regexp \"cljs-test$\"`) AND the JVM
+  `clojure -M:test` runner both pick it up. Pure CLJC — no DOM dependency;
+  uses the plain-atom adapter."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.realm :as realm]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; (1) the internal realm record + the default realm
+;; ---------------------------------------------------------------------------
+
+(deftest default-realm-exists-with-reserved-id
+  (testing "the process creates one default realm with id :rf.realm/default"
+    (is (= :rf.realm/default realm/default-realm-id))
+    (let [dr (realm/default-realm)]
+      (is (some? dr) "default realm exists at process load")
+      (is (= :rf.realm/default (:rf.realm/id dr))
+          "the default realm carries the reserved :rf.realm/id")
+      ;; The default realm is reachable by id through the realm registry.
+      (is (identical? dr (realm/realm :rf.realm/default))
+          "default-realm and (realm :rf.realm/default) are the same record"))))
+
+(deftest realm-record-shipped-d1-shape
+  (testing "the D1 realm record carries the shipped slots and leaves the
+            D2/D3-reserved slots absent (Spec-Schemas §:rf/realm)"
+    (let [dr (realm/default-realm)]
+      ;; Shipped D1 slots.
+      (is (contains? dr :rf.realm/id) "carries :rf.realm/id")
+      (is (contains? dr :registrar)   "carries the realm-owned :registrar")
+      ;; D2/D3-reserved — never required in D1, the container only.
+      (is (not (contains? dr :app)) ":app (D2 app value) is absent in D1"))))
+
+(deftest realm-id-reader-absence-is-default
+  (testing "realm-id resolves nil → default realm (absence is the documented
+            rule), passes a keyword through, and reads the map's id"
+    (is (= :rf.realm/default (realm/realm-id nil))
+        "absence resolves to the default realm")
+    (is (= :tenant/a (realm/realm-id :tenant/a))
+        "a realm-id keyword passes through unchanged")
+    (is (= :rf.realm/default (realm/realm-id (realm/default-realm)))
+        "a realm map resolves to its :rf.realm/id")))
+
+;; ---------------------------------------------------------------------------
+;; (2) the realm owns the registrar — default-realm transparency
+;; ---------------------------------------------------------------------------
+
+(deftest default-realm-owns-the-process-registrar
+  (testing "the default realm's :registrar IS the existing process-global
+            registrar atom — ownership moved to the realm, the shape did not"
+    (is (identical? registrar/kind->id->metadata
+                    (:registrar (realm/default-realm)))
+        "the default realm holds the existing process-global registrar atom")
+    (is (identical? registrar/kind->id->metadata
+                    (realm/registrar (realm/default-realm)))
+        "realm/registrar returns that same atom")
+    (is (identical? registrar/kind->id->metadata
+                    (realm/registrar nil))
+        "realm/registrar nil resolves to the default realm's registrar")))
+
+(deftest registry-read-api-unchanged-for-tooling
+  (testing "the registry shape + read API are byte-stable — a registration
+            made through the public reg-* surface is visible through the
+            existing registrar read API the EP-0014 tooling sibling uses"
+    (rf/reg-event-db :realm-test/inc
+      {:doc "increment counter"}
+      (fn [db _] (update db :n (fnil inc 0))))
+    (rf/reg-sub :realm-test/n
+      {:doc "the counter"}
+      (fn [db _] (:n db)))
+    ;; Read API on the process-global registrar — unchanged shape.
+    (is (some? (registrar/lookup :event :realm-test/inc))
+        "registrar/lookup resolves a default-realm registration")
+    (is (contains? (registrar/registrations :event) :realm-test/inc)
+        "registrar/registrations exposes the registration")
+    (is (fn? (registrar/handler :event :realm-test/inc))
+        "registrar/handler returns the handler fn")
+    ;; And reading through the realm's owned registrar atom is identical —
+    ;; the realm owns the SAME table.
+    (is (contains? (get @(realm/registrar (realm/default-realm)) :event)
+                   :realm-test/inc)
+        "the realm-owned registrar atom carries the same registration")))
+
+(deftest default-realm-transparency-dispatch-subscribe
+  (testing "reg-* / dispatch / subscribe work UNCHANGED through the default
+            realm — the zero-ergonomic-regression headline"
+    (rf/reg-frame :realm-test/app {:doc "transparency app"})
+    (rf/reg-event-db :realm-test/set
+      {:doc "set n"}
+      (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-sub :realm-test/read-n
+      {:doc "read n"}
+      (fn [db _] (:n db)))
+    ;; Dispatch + subscribe against the default-realm frame.
+    (rf/dispatch-sync [:realm-test/set 7] {:frame :realm-test/app})
+    (is (= {:n 7} (rf/app-db-value :realm-test/app))
+        "app-db carries the dispatched value — single-app dispatch unchanged")
+    (let [reaction (rf/subscribe :realm-test/app [:realm-test/read-n])]
+      (is (= 7 @reaction)
+          "subscribe reads the value — single-app subscribe unchanged"))))
+
+;; ---------------------------------------------------------------------------
+;; (3) a frame carries its realm reference internally
+;; ---------------------------------------------------------------------------
+
+(deftest frame-carries-default-realm-reference
+  (testing "a frame stores a realm REFERENCE (the :rf.realm/default id) and
+            frame-realm reads it back"
+    (rf/reg-frame :realm-test/f {:doc "a frame"})
+    (let [record (frame/frame :realm-test/f)]
+      (is (= :rf.realm/default (:realm record))
+          "the frame record carries the default realm id in its :realm slot")
+      (is (= :rf.realm/default (frame/frame-realm :realm-test/f))
+          "frame-realm reads the frame's realm reference"))
+    (is (nil? (frame/frame-realm :realm-test/never-registered))
+        "frame-realm is nil for an unknown frame")))
+
+(deftest realm-owned-frame-membership-view-is-derived
+  (testing "the realm-owned frame-membership view is derived live from the
+            frame registry — a reg-frame joins it, a destroy-frame! leaves it.
+            (The reset fixture installs the ordinary :rf/default frame into the
+            default realm, so membership is asserted by joins/leaves of the
+            test frames, not by exact-set equality with the fixture frame.)"
+    (let [base (realm/realm-frames :rf.realm/default)]
+      (is (not (contains? base :realm-test/m1))
+          "the test frames are not members before registration")
+      (rf/reg-frame :realm-test/m1 {:doc "member 1"})
+      (rf/reg-frame :realm-test/m2 {:doc "member 2"})
+      (let [members (realm/realm-frames :rf.realm/default)]
+        (is (contains? members :realm-test/m1)
+            "a reg-frame joins the default realm's membership view")
+        (is (contains? members :realm-test/m2)
+            "the second frame joins too")
+        (is (= members (realm/realm-frames))
+            "the zero-arg arity defaults to the default realm"))
+      ;; Destroying a frame retracts it from the view (membership is derived,
+      ;; so the dissoc from the frame registry is the only step needed).
+      (rf/destroy-frame! :realm-test/m1)
+      (let [members (realm/realm-frames :rf.realm/default)]
+        (is (not (contains? members :realm-test/m1))
+            "a destroy-frame! leaves the membership view")
+        (is (contains? members :realm-test/m2)
+            "the surviving frame is still a member")))
+    ;; A realm with no frames is empty, never an error.
+    (is (= #{} (realm/realm-frames :tenant/nonexistent))
+        "an unknown realm has an empty membership view")))
+
+(deftest frames-by-realm-groups-live-frames-only
+  (testing "frames-by-realm groups non-destroyed frames by their :realm slot"
+    (rf/reg-frame :realm-test/a {:doc "a"})
+    (rf/reg-frame :realm-test/b {:doc "b"})
+    (let [by-realm (frame/frames-by-realm)]
+      (is (contains? (get by-realm :rf.realm/default) :realm-test/a)
+          "default-realm frame a is grouped under :rf.realm/default")
+      (is (contains? (get by-realm :rf.realm/default) :realm-test/b)
+          "default-realm frame b is grouped under :rf.realm/default"))
+    (rf/destroy-frame! :realm-test/a)
+    (let [by-realm (frame/frames-by-realm)]
+      (is (not (contains? (get by-realm :rf.realm/default) :realm-test/a))
+          "a destroyed frame drops out of the grouping")
+      (is (contains? (get by-realm :rf.realm/default) :realm-test/b)
+          "the surviving frame stays in the grouping"))))


### PR DESCRIPTION
EP-0013 action-wave **D1 IMPL** slice — internal staging stages 1-3 (per `docs/EP/EP-0013-app-values-and-runtime-realms.md` §Public API Staging + the merged D1 spec, PR #3912: the runtime-realm container in `Runtime-Subsystems.md` / `002-Frames.md` + the `Realm` schema in `Spec-Schemas.md`). The realm-id reservation (`rf2-n92kjm`) is merged.

**INTERNAL only — no public source break.** No public `rf/realm` constructor and no realm-targeted public query ship here (those names are reserved vocabulary; D2/later stages). Everything routes through one process-created **default realm**, so today's single-app ergonomics are byte-identical (the EP-0002 refinement pattern — a single-realm app never spells a realm).

## What landed

**Stage 1 — internal realm record + default realm.** New `re-frame.realm` ns defines the realm map per Spec-Schemas §`:rf/realm`:

```clojure
{:rf.realm/id   :rf.realm/default   ;; stable, process-unique
 :registrar     <atom>             ;; the (kind, id) → descriptor table the realm dispatches against
 ;; optional: :adapter (selection), :capabilities (:rf.capability/* → service)
 ;; D2/D3-RESERVED, absent in D1: :app (the installed app value), :lifecycle
 }
```

The process creates one default realm at boot (`:rf.realm/id` = `:rf.realm/default`); absence of an explicit realm means the default realm (an explicit documented rule).

**Stage 2 — the realm owns the registrar.** The default realm's `:registrar` slot **IS** the existing process-global `re-frame.registrar/kind->id->metadata` atom — ownership moved to the realm, the registry *shape* did not. `registrar.cljc` is **untouched**: the `register!` / `lookup` / `registrations` read+write API and every `reg-*` / frame public signature are byte-stable, so the in-flight EP-0014 slice-3 registry-reading sibling (`s8w3nw`) keeps working.

**Stage 3 — frames store a realm reference.** The frame record gains a `:realm` slot (the realm-id keyword, default `:rf.realm/default`); `frame/frame-realm` reads it back. The realm-owned frame-membership view is **derived live** from `frame/frames` (grouped on each record's `:realm` slot) via the `:realm/frames-by-realm` late-bind hook — single source of truth, no separately-stored set, so the many `(reset! frame/frames {})` test fixtures reset membership for free.

## Default-realm transparency proof

`reg-*` / `dispatch` / `subscribe` are unchanged because they target the default realm, which owns the same process-global registrar. Pinned by `realm_cljs_test.cljc`:
- `(identical? registrar/kind->id->metadata (:registrar (realm/default-realm)))` — the default realm holds the existing atom;
- a `reg-event-db` / `reg-sub` registration is visible through `registrar/lookup` / `registrar/registrations` / `registrar/handler` exactly as before (the EP-0014 read path);
- `dispatch-sync` → `app-db-value` and `subscribe` against a default-realm frame behave identically to pre-change.

## Files

- **new** `implementation/core/src/re_frame/realm.cljc` — realm record + default realm + realm-owned registrar + derived membership reader
- **new** `implementation/core/test/re_frame/realm_cljs_test.cljc` — dual-runtime (JVM + CLJS) acceptance tests
- `implementation/core/src/re_frame/frame.cljc` — frame `:realm` reference, `frames-by-realm` derivation + hook publish, `frame-realm` reader
- `implementation/core/src/re_frame/late_bind/directory.cljc` — directory entry for the new `:realm/frames-by-realm` hook (drift-test required)

## Deferred stages (not in this PR, per EP-0013 staging)

- Stage 4: adapter + host-transient singleton state move behind the default realm (issue 5 — adapter-first proving slice).
- Stages 5-7 (D2): internal app-value descriptor projection; public app/module/realm constructors; public `install!` / `reinstall!`.
- Stages 8-9: realm-targeted public registrar/frame queries (map-shaped, issue 11); multi-realm + multi-adapter conformance.

## Quality gates

- `clojure -M:test` (core, JVM): **1214 tests / 5358 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node-runtime CLJS, the key zero-regression gate): **6595 tests / 24140 assertions, 0 failures, 0 errors** (`realm_cljs_test.cljc` runs on both runtimes)
- `npm run test:bundle-isolation`: **PASS** — realm internals absent from / do not bloat the counter / counter-uix / counter-helix production bundles
- Full existing suite green → zero ergonomic regression confirmed (the headline D1 gate)