### PR TITLE
test(reply): EP-0011 cross-family vocab-consistency + functor-law coverage (rf2-wbh1ln rf2-5ha70w)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -163,6 +163,15 @@ implementation/
   security/                  Cross-cutting security regression tests (MCP egress, schema
                              redaction, SSR escaping) — test-only, no shipped namespace.
     test/re_frame/security/        JVM + CLJS security regression suites.
+
+  reply-conformance/         Cross-family reply-vocabulary conformance tier (EP-0011) —
+                             test-only, no shipped namespace. Holds the umbrella guards
+                             that sit above several artefacts: the shared :status /
+                             :work/status / :work/id / canonical-stale vocabulary across
+                             every managed-async family (HTTP, resources, mutations,
+                             machines, routing) plus the family-level functor/naturality
+                             law at the target-relocating families.
+    test/re_frame/                 JVM + CLJS cross-family reply conformance suites.
 ```
 
 ## Status by spec area

--- a/implementation/reply-conformance/deps.edn
+++ b/implementation/reply-conformance/deps.edn
@@ -1,0 +1,65 @@
+;; re-frame2 EP-0011 cross-family reply-VOCABULARY-consistency tier
+;; (rf2-wbh1ln + rf2-5ha70w; EP-0011 testing-rigour audit rf2-h8xw2v).
+;;
+;; This is NOT a published Maven artefact — it has no `src/`. It is a
+;; cross-artefact TEST surface (the precedent is `security/`) that holds
+;; the umbrella conformance the per-family reply suites cannot: the
+;; cross-family VOCABULARY-consistency guard (every managed-async family —
+;; HTTP, resources, mutations, machines, routing — produces the ONE shared
+;; `:status` / `:work/status` / `:work/id` / canonical-stale shape, the
+;; axis rf2-mn4j89 violated) and the family-level functor/naturality law at
+;; the TARGET-RELOCATING families (route-loader relay, machine-spawn
+;; `:on-done`). The test namespaces sit ABOVE several artefacts (core,
+;; http, resources, machines, routing), so they live in their own
+;; top-level `reply-conformance/` surface rather than any single family's
+;; test tree.
+;;
+;; ## Why this deps.edn exists
+;;
+;; The conformance namespaces are `.cljc` and run in BOTH runtimes. They
+;; ride the always-on CLJS `:node-test` gate (`npm run test:cljs`, ns
+;; matches `cljs-test$`) via the cross-artefact source paths the top-level
+;; `implementation/shadow-cljs.edn` lists. This alias is the JVM
+;; counterpart: it runs the SAME `.cljc` namespaces under the JVM so the
+;; `:clj` reader-conditional arms (the EDN round-trip `read-string`, any
+;; `:clj` host-handle detection) are exercised — mirroring why
+;; `security/deps.edn` exists. Wired into
+;; `scripts/test-jvm-implementation.sh`.
+;;
+;; ## Why test-only deps, not :local/root in :deps
+;;
+;; This artefact ships nothing, so the top-level `:deps` is empty. The
+;; cross-artefact source the test namespaces `:require` (`re-frame.reply`
+;; from core; `re-frame.http-reply`; `re-frame.resources.reply`;
+;; `re-frame.machines.reply`; `re-frame.routing.reply`) is pulled in under
+;; the `:test` alias only. `:extra-paths` is JUST `["test"]` so the
+;; cognitect test-runner scans ONLY this tier's test dir — the artefact
+;; `:local/root` deps contribute their `src` (never their `:test`), so no
+;; other artefact's tests run here.
+;;
+;; ## Bundle isolation (tools/README.md)
+;;
+;; No tool deps; this is a pure cross-FAMILY conformance surface. The
+;; dependency arrow flows reply-conformance(test) → implementation
+;; artefacts, never the reverse. Nothing under `implementation/` production
+;; `src/` `:require`s anything here, so no production bundle is widened.
+{:paths []
+ :deps  {}
+
+ :aliases
+ {:test
+  {:extra-paths ["test"]
+   ;; The five managed-async families whose reply builders the conformance
+   ;; tests `:require`. core carries `re-frame.reply` (the shared
+   ;; substrate); http / resources / machines / routing carry their
+   ;; per-family reply slices.
+   :extra-deps  {day8/re-frame2           {:local/root "../core"}
+                 day8/re-frame2-http      {:local/root "../http"}
+                 day8/re-frame2-resources {:local/root "../resources"}
+                 day8/re-frame2-machines  {:local/root "../machines"}
+                 day8/re-frame2-routing   {:local/root "../routing"}
+                 ;; rf2-try1x — silent-on-success reporter.
+                 day8/re-frame2-test-quiet {:local/root "../test-quiet"}
+                 io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/implementation/reply-conformance/test/re_frame/reply_functor_law_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_functor_law_cljs_test.cljc
@@ -1,0 +1,248 @@
+(ns re-frame.reply-functor-law-cljs-test
+  "Family-level reply-target functor/naturality law conformance for the
+  TARGET-RELOCATING families (rf2-5ha70w, EP-0011 testing-rigour audit
+  rf2-h8xw2v).
+
+  The reply-target functor laws —
+
+    identity      (map-target identity t)            ≡ t
+    composition   (map-target f (map-target g t))     ≡ (map-target (comp f g) t)
+    naturality    (complete (map-target f t) r)       ≡ (f (complete t r))
+
+  — are pinned RIGOROUSLY at the substrate (`re-frame.reply-test`:
+  identity + naturality + composition both orders + mapping-changes-only-
+  the-event) and RE-PROVEN by the first fresh consumer
+  (`re-frame.timer-probe-conformance-cljs-test/reply-target-functor-law`).
+  They are NOT re-pinned at any LOWERED family.
+
+  ## Why this suite exists
+
+  For the families that pass HTTP's target through UNCHANGED (HTTP itself,
+  resources, mutations — `map-target` stores nothing on the target, so the
+  law holds structurally) a per-family re-proof is low-value; the substrate
+  + probe already cover that case. The risk — if any — is in the families
+  that RELOCATE / WRAP their target before completion:
+
+    - a ROUTE LOADER relaying a loader continuation onto a PARENT route
+      event (the child's reply re-targeted onto `[:route/parent … reply]`);
+    - a MACHINE SPAWN routing the child's reply onto the parent's
+      `:on-done` / `:on-error` continuation (the child's reply re-targeted
+      onto `[:parent/on-done … reply]`).
+
+  Those relocations are exactly where a naturality break — a mapping that
+  changes MORE than the completed event, or a composition whose order
+  matters — would hide. The second review judged routing/machines PASS by
+  READING (the nav-token wrap reads current + suppresses before the app
+  target; spawn drives `:on-done` with `(:value reply)`), so this is a
+  belt-and-braces REGRESSION GUARD, not a known defect: it proves the laws
+  hold where the target is RELOCATED, executable rather than read.
+
+  ## What the relocation transforms model
+
+  A relocating family builds an event-transform `f` (the role Elm's
+  `Cmd.map` plays) that wraps / relays the completed continuation. The
+  family-level law is: relocating the target via `map-target` then
+  completing equals completing then relocating — for the relay shapes the
+  two families actually use:
+
+    - route-relay:   `(fn [event] [:route/parent-relay route-id event])`
+                     — wrap the loader continuation under a parent route
+                       relay event (the loader reply rides as the relay's
+                       payload).
+    - spawn-on-done: `(fn [event] [:parent/on-done parent-id event])`
+                     — route the child completion onto the parent's
+                       `:on-done` continuation event.
+
+  Pure-fn conformance over `re-frame.reply` (`map-target` / `complete`) for
+  the relocation SHAPES the relocating families use. Lives in the
+  cross-artefact `reply-conformance/` surface alongside the vocab
+  conformance suite. Runs on `npm run test:cljs` (ns matches `cljs-test$`)
+  AND the JVM gate (`reply-conformance/deps.edn` `:test`).
+
+  Canonical contract: `spec/Managed-Effects.md` §Reply mapping and the
+  functor law."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.reply :as reply]
+            [re-frame.routing.reply :as route-reply]
+            [re-frame.machines.reply :as m-reply]))
+
+;; ---------------------------------------------------------------------------
+;; Canonical replies for the two relocating families. Both are
+;; family-shaped (so the law is exercised over a REAL family reply, not a
+;; synthetic stub) and validate against the shared contract.
+;; ---------------------------------------------------------------------------
+
+(def ^:private route-reply
+  "A canonical route-loader :ok reply (the loader's decoded payload). The
+  route work-id rides; the value is the loaded resource."
+  {:status      :ok
+   :value       {:article {:id 42 :title "Welcome"}}
+   :work/id     (route-reply/work-id {:route-id :route/article :nav-token "nav-1" :loader-id :article/loaded})
+   :work/kind   :route
+   :rf.frame/id :app/main})
+
+(def ^:private spawn-reply
+  "A canonical machine spawned-actor :ok reply (the child's :output-key
+  result under :value). The machine work-id rides."
+  (m-reply/success-reply {:actor-id :auth/flow#1 :parent-id :auth/main
+                          :work-bearing-path [:authenticating] :frame :app/main}
+                         {:user-id "u-42"}))
+
+;; ---------------------------------------------------------------------------
+;; The RELOCATION transforms each family uses. An event-transform receives
+;; the FULLY-COMPLETED event (the target event with the reply map already
+;; appended) and returns the relocated/rewrapped event — exactly what a
+;; relay loader / spawn :on-done routing does.
+;; ---------------------------------------------------------------------------
+
+(defn- route-relay
+  "Relocate a loader continuation onto a PARENT route relay event — the
+  route-loader relay shape. The completed continuation rides as the relay
+  event's payload (`[:route/parent-relay route-id <completed-event>]`)."
+  [route-id]
+  (fn [event] [:route/parent-relay route-id event]))
+
+(defn- spawn-on-done
+  "Route a child completion onto the parent's :on-done continuation event —
+  the machine-spawn relay shape (`[:parent/on-done parent-id
+  <completed-event>]`)."
+  [parent-id]
+  (fn [event] [:parent/on-done parent-id event]))
+
+;; A SECOND relay per family so the COMPOSITION law is exercised with two
+;; genuinely-different relocations. Both are WRAP transforms
+;; (`event → [tag … event]`), the realistic relocating shape — a relay onto
+;; a relay (a loader continuation relayed through a parent AND a
+;; grandparent; a spawn child relayed through the parent AND a supervisor).
+;; Wraps compose in EITHER order (each takes any event and wraps it), so the
+;; composition law is exercised both ways without a shape-mismatch.
+(defn- grandparent-relay
+  "Relocate a continuation onto a GRANDPARENT relay event — a second,
+  distinct wrap that composes with `route-relay` / `spawn-on-done` in either
+  order (the relay-onto-a-relay relocation)."
+  [grandparent-id]
+  (fn [event] [:relay/grandparent grandparent-id event]))
+
+;; ---------------------------------------------------------------------------
+;; Naturality — the one that would catch a relocation that changes MORE than
+;; the completed event. `(complete (map-target f t) r) == (f (complete t r))`.
+;; ---------------------------------------------------------------------------
+
+(deftest naturality-holds-for-the-route-relay-relocation
+  (testing "route-loader relay: complete(map-target(relay, t), r) == relay(complete(t, r))"
+    (let [target [:article/loaded {:slug "welcome"}]
+          relay  (route-relay :route/article)]
+      (is (= (reply/complete (reply/map-target relay target) route-reply)
+             (relay (reply/complete target route-reply)))
+          "relocating the loader target onto a parent relay then completing equals
+           completing then relocating — the relay changes ONLY the event")
+      (testing "the relocated event is the parent relay carrying the completed loader event"
+        (is (= [:route/parent-relay :route/article
+                [:article/loaded {:slug "welcome"} route-reply]]
+               (reply/complete (reply/map-target relay target) route-reply)))))))
+
+(deftest naturality-holds-for-the-spawn-on-done-relocation
+  (testing "machine-spawn :on-done: complete(map-target(on-done, t), r) == on-done(complete(t, r))"
+    (let [target  [:auth/done {:flow :login}]
+          on-done (spawn-on-done :auth/main)]
+      (is (= (reply/complete (reply/map-target on-done target) spawn-reply)
+             (on-done (reply/complete target spawn-reply)))
+          "routing the child completion onto the parent's :on-done then completing
+           equals completing then routing — the routing changes ONLY the event")
+      (testing "the routed event is the parent :on-done carrying the completed child event"
+        (is (= [:parent/on-done :auth/main
+                [:auth/done {:flow :login} spawn-reply]]
+               (reply/complete (reply/map-target on-done target) spawn-reply)))))))
+
+;; ---------------------------------------------------------------------------
+;; Identity — relocating through identity is a no-op on completion.
+;; ---------------------------------------------------------------------------
+
+(deftest identity-holds-for-both-relocating-families
+  (testing "route relay target: map-target identity is the identity on completion"
+    (let [target [:article/loaded {:slug "welcome"}]]
+      (is (= (reply/complete target route-reply)
+             (reply/complete (reply/map-target identity target) route-reply)))))
+  (testing "spawn :on-done target: map-target identity is the identity on completion"
+    (let [target [:auth/done {:flow :login}]]
+      (is (= (reply/complete target spawn-reply)
+             (reply/complete (reply/map-target identity target) spawn-reply))))))
+
+;; ---------------------------------------------------------------------------
+;; Composition — `map f ∘ map g == map (f ∘ g)`, BOTH orders, with two
+;; genuinely-different relocations so a composition whose order mattered
+;; would surface.
+;; ---------------------------------------------------------------------------
+
+(deftest composition-holds-for-the-route-relay-relocation
+  (testing "route parent-relay ∘ grandparent-relay composes in either order — map-target composes the transforms"
+    (let [target  [:article/loaded {:slug "welcome"}]
+          relay   (route-relay :route/article)
+          grandpa (grandparent-relay :route/root)]
+      (is (= (reply/complete (reply/map-target relay (reply/map-target grandpa target)) route-reply)
+             (reply/complete (reply/map-target (comp relay grandpa) target) route-reply))
+          "map relay ∘ map grandpa == map (relay ∘ grandpa)")
+      (is (= (reply/complete (reply/map-target grandpa (reply/map-target relay target)) route-reply)
+             (reply/complete (reply/map-target (comp grandpa relay) target) route-reply))
+          "and the other order: map grandpa ∘ map relay == map (grandpa ∘ relay)")
+      (testing "the composed (relay ∘ grandpa) result wraps grandpa's relay inside the parent relay"
+        (is (= [:route/parent-relay :route/article
+                [:relay/grandparent :route/root
+                 [:article/loaded {:slug "welcome"} route-reply]]]
+               (reply/complete (reply/map-target (comp relay grandpa) target) route-reply)))))))
+
+(deftest composition-holds-for-the-spawn-on-done-relocation
+  (testing "spawn :on-done ∘ grandparent-relay (supervisor relay) composes in either order"
+    (let [target  [:auth/done {:flow :login}]
+          on-done (spawn-on-done :auth/main)
+          grandpa (grandparent-relay :auth/supervisor)]
+      (is (= (reply/complete (reply/map-target on-done (reply/map-target grandpa target)) spawn-reply)
+             (reply/complete (reply/map-target (comp on-done grandpa) target) spawn-reply))
+          "map on-done ∘ map grandpa == map (on-done ∘ grandpa)")
+      (is (= (reply/complete (reply/map-target grandpa (reply/map-target on-done target)) spawn-reply)
+             (reply/complete (reply/map-target (comp grandpa on-done) target) spawn-reply))
+          "and the other order"))))
+
+;; ---------------------------------------------------------------------------
+;; The structural guarantee — relocating the target changes ONLY the
+;; completed event, NEVER the reply's identity facts (work-id / status /
+;; correlation). This is the property a naturality break would violate: a
+;; relocation that smuggled a status / work-id change would show here.
+;; ---------------------------------------------------------------------------
+
+(deftest relocation-changes-only-the-event-not-the-reply-identity
+  (testing "route relay: the appended reply's work-id / status / correlation are untouched by relocation"
+    (let [target    [:article/loaded {:slug "welcome"}]
+          relay     (route-relay :route/article)
+          completed (reply/complete (reply/map-target relay target) route-reply)
+          ;; the completed event is [:route/parent-relay route-id [loader-event reply]]
+          inner     (nth completed 2)
+          delivered (peek inner)]
+      (is (= (:work/id route-reply) (:work/id delivered)) "work-id rides unchanged through the relay")
+      (is (= :ok (:status delivered)) "status rides unchanged")
+      (is (= :route (:work/kind delivered)))))
+  (testing "spawn :on-done: the appended reply's work-id / status are untouched by routing"
+    (let [target    [:auth/done {:flow :login}]
+          on-done   (spawn-on-done :auth/main)
+          completed (reply/complete (reply/map-target on-done target) spawn-reply)
+          inner     (nth completed 2)
+          delivered (peek inner)]
+      (is (= (:work/id spawn-reply) (:work/id delivered)) "machine work-id rides unchanged")
+      (is (= :ok (:status delivered)))
+      (is (= :machine (:work/kind delivered))))))
+
+;; ---------------------------------------------------------------------------
+;; The relocation transforms are PURE DATA→DATA event transforms (no host
+;; handle) — a relayed target stays data-only-projectable. (A relocation
+;; that captured a host handle would make the durable target non-data-only;
+;; durable-target would reject it. Prove the relayed target's DURABLE
+;; projection — ephemeral ::post stripped — is data-only.)
+;; ---------------------------------------------------------------------------
+
+(deftest a-relocated-target-projects-to-a-data-only-durable-target
+  (testing "the mapped (relocated) target carries the ephemeral ::post fn — NOT data-only — but its durable projection strips it and is data-only"
+    (let [relayed (reply/map-target (route-relay :route/article) [:article/loaded {:slug "welcome"}])]
+      (is (false? (reply/data-only-target? relayed))
+          "a relocated target carries the functor accumulator fn (not safe to persist verbatim)")
+      (is (true? (reply/data-only-target? (reply/durable-target relayed)))
+          "durable projection strips the ::post accumulator — the persisted target is data-only"))))

--- a/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
+++ b/implementation/reply-conformance/test/re_frame/reply_vocab_conformance_cljs_test.cljc
@@ -1,0 +1,430 @@
+(ns re-frame.reply-vocab-conformance-cljs-test
+  "Cross-family reply-VOCABULARY-consistency conformance (rf2-wbh1ln,
+  EP-0011 testing-rigour audit rf2-h8xw2v).
+
+  EP-0011's whole point is ONE work/reply vocabulary across EVERY managed
+  *async* family — the closed `:status` enum, the closed `:work/status`
+  enum, the `:work/id` correlation tuple, the canonical `:status :stale`
+  suppression shape — so tools read ONE stream and apps classify
+  completion ONE way. Each family already validates its OWN reply slice
+  against the shared `re-frame.reply/validate-reply` (the per-family
+  `*-reply-lowering-*` suites), and the substrate test
+  (`re-frame.reply-test`) pins the closed sets ONCE. But until this suite
+  NO test compared ACROSS families to prove they produce the SAME shapes
+  for the SAME situations.
+
+  That gap is exactly what rf2-mn4j89 exploited: machines (`:after`),
+  routing, and the timer-probe produced the canonical `:status :stale` on
+  their stale trace while resources / mutations emitted a bespoke
+  `:rf.resource/stale-suppressed` WITHOUT `:rf.reply/status :stale` — a
+  cross-family INconsistency no per-family test could catch (each family
+  only ever looked at itself). The stale-reply remediation has since
+  landed across families (machines #3908 + resources #3911); this is the
+  umbrella regression GUARD that turns the one-vocabulary EP claim into a
+  table-driven gate so the divergence cannot silently return.
+
+  ## What this suite is
+
+  A table of the FIVE managed-async families (HTTP, resources, mutations,
+  machines, routing), each as a descriptor naming the situation→reply
+  builders it supports (`:success`, `:error`, `:cancel`, `:stale`). One
+  set of cross-family assertions then proves EVERY family, for EVERY
+  situation it supports, produces the canonical shared shape:
+
+    (a) success    → `:status :ok`        + `:work/status :completed`
+    (b) error      → `:status :error`     + `:work/status :failed`
+                     (or `:timed-out`, the timeout work-status) + a family
+                     `:error` MAP carrying a `:kind`
+    (c) cancel     → `:status :cancelled` + `:work/status :cancelled`
+                     + `:cancelled? true`
+    (d) stale      → `:status :stale`     + `:work/status :suppressed`
+                     + `:stale? true` + a carried/current correlation gate,
+                     and NO `:value` (no app mutation)
+
+  PLUS the invariants every reply shares regardless of situation: every
+  reply VALIDATES against the single `re-frame.reply/validate-reply`; the
+  `:status` is in the closed `re-frame.reply/statuses`; the `:work/status`
+  (when present) is in the closed `re-frame.reply/work-statuses`; the
+  `:work/id` is a `[:rf.work/* …]` tuple, `=`-comparable and EDN-round-
+  trippable; and the reply is DATA-ONLY (no host handle anywhere).
+
+  Pure-fn conformance over the per-family reply builders — no runtime
+  fixture. The families sit ABOVE several artefacts (core, http,
+  resources, machines, routing), so this lives in its own cross-artefact
+  `reply-conformance/` surface (the precedent is `security/`), not any
+  single family's test tree. Runs on the `npm run test:cljs` node gate
+  (ns matches `cljs-test$`) AND the JVM gate
+  (`implementation/reply-conformance/deps.edn` `:test`).
+
+  Canonical contract: `spec/Managed-Effects.md` §The uniform reply
+  envelope."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.reply :as reply]
+            [re-frame.http-reply :as http-reply]
+            [re-frame.resources.reply :as rreply]
+            [re-frame.machines.reply :as m-reply]
+            [re-frame.routing.reply :as route-reply]))
+
+;; ---------------------------------------------------------------------------
+;; EDN round-trip — the work-id must be `=`-comparable and serializable. On
+;; the JVM `read-string` parses EDN; on CLJS we round-trip through the EDN
+;; reader. (`pr-str` of a `:rf.work/*` tuple is plain EDN — keywords, vectors,
+;; maps, strings, numbers — so both arms reconstruct an `=`-equal value.)
+;; ---------------------------------------------------------------------------
+
+(defn- edn-roundtrip [x]
+  #?(:clj  (read-string (pr-str x))
+     :cljs (cljs.reader/read-string (pr-str x))))
+
+;; ---------------------------------------------------------------------------
+;; Shared fixtures threaded into the per-family builders. Each family's
+;; verification-payload / context shape differs (that is the family's job);
+;; this table normalizes the OUTPUT (the reply map) for cross-family
+;; comparison.
+;; ---------------------------------------------------------------------------
+
+(def ^:private http-ctx
+  {:request-id   :article/by-id
+   :origin-event [:article/load {:id 42}]
+   :attempt      1
+   :frame        :app/main
+   :completed-at 1781078400456})
+
+(def ^:private resource-vp
+  {:work/id      [:rf.work/resource [:rf.scope/global :article/by-slug {:slug "w"}] 4]
+   :resource-key [:rf.scope/global :article/by-slug {:slug "w"}]
+   :scope        :rf.scope/global
+   :generation   4
+   :rf.frame/id  :app/main})
+
+(def ^:private mutation-vp
+  {:work/id     [:rf.work/resource [:rf.mutation :form/save-1] 2]
+   :instance-id :form/save-1
+   :mutation-id :article/save
+   :scope       :rf.scope/global
+   :generation  2
+   :rf.frame/id :app/main})
+
+(def ^:private machine-ctx
+  {:actor-id          :auth/flow#1
+   :parent-id         :auth/main
+   :work-bearing-path [:authenticating]
+   :frame             :app/main
+   :completed-at      1781078400888})
+
+;; A family error MAP carrying a :kind — the closed reply-map contract
+;; demands every family error rides this shape (a loose scalar is rejected).
+(def ^:private a-failure {:kind :rf.http/http-5xx :status 503 :body "down"})
+
+;; An :rf.http/aborted failure envelope — the cancellation shape shared by
+;; HTTP / resources / mutations (an intentional abort, NOT an :error).
+(def ^:private an-abort {:kind :rf.http/aborted :reason :user})
+
+;; ---------------------------------------------------------------------------
+;; THE TABLE. Each family is a descriptor:
+;;   :family        — the family keyword (diagnostics)
+;;   :work-head     — the expected `[:rf.work/* …]` head keyword
+;;   :success       — () → success reply map, or nil if N/A
+;;   :error         — () → error reply map, or nil if N/A
+;;   :error-work-status — the expected error :work/status (:failed default;
+;;                    HTTP timeout family also proves :timed-out separately)
+;;   :cancel        — () → cancelled reply map, or nil if N/A
+;;   :stale         — () → stale reply map, or nil if N/A
+;;
+;; A nil situation means the family does not lower that situation onto a
+;; reply (e.g. a machine spawn has no cancellation reply; the route loader's
+;; success/error flow THROUGH HTTP, so the family-level builder here covers
+;; only the situations the family itself shapes). The assertions skip nil
+;; situations — a family is only held to the shapes it produces.
+;; ---------------------------------------------------------------------------
+
+(defn- machine-stale-reply []
+  (m-reply/stale-spawn-reply (assoc machine-ctx :current-generation nil)))
+
+(defn- after-stale-reply []
+  (m-reply/after-stale-reply
+    {:machine-id      :a/multi
+     :state           :loading
+     :delay           30000
+     :decl-path       [:loading]
+     :scheduled-epoch 1
+     :current-epoch   2
+     :frame           :app/main}))
+
+(defn- route-stale-reply []
+  (:reply (route-reply/suppress {:route-id  :route/article
+                                 :nav-token "nav-1"
+                                 :loader-id :article/loaded
+                                 :frame     :app/main}
+                                "nav-2")))
+
+(defn- resource-stale-reply []
+  (let [carried {:work/id [:rf.work/resource [:rf.scope/global :r {}] 4] :generation 4}
+        current {:work/id [:rf.work/resource [:rf.scope/global :r {}] 5] :generation 5}]
+    (:reply (rreply/stale-reply
+              {:carried carried :current current
+               :extra   {:work/id      (:work/id carried)
+                         :work/kind    :resource
+                         :rf.frame/id  :app/main
+                         :stale/reason :resource/generation-mismatch}}))))
+
+(def ^:private families
+  [{:family    :http
+    :work-head :rf.work/http
+    :success   #(http-reply/success-reply http-ctx {:title "Welcome"})
+    :error     #(http-reply/failure-reply http-ctx a-failure)
+    :cancel    #(http-reply/aborted-reply http-ctx an-abort)
+    ;; HTTP supersession is the stale path (a same-:request-id supersede)
+    ;; lowered through the shared substrate `suppress`; pin the canonical
+    ;; stale shape via the substrate directly with the HTTP work-id.
+    :stale     #(:reply (reply/suppress nil
+                                        {:work/id (http-reply/work-id http-ctx)}
+                                        {:work/id [:rf.work/http :article/by-id 2]}
+                                        {:work/id      (http-reply/work-id http-ctx)
+                                         :work/kind    :http
+                                         :rf.frame/id  :app/main
+                                         :stale/reason :rf.http/superseded}))}
+
+   {:family    :resource
+    :work-head :rf.work/resource
+    :success   #(rreply/success-reply resource-vp {:title "Welcome"}
+                                      {:work-kind rreply/work-kind-resource
+                                       :completed-at 1781078400456})
+    :error     #(rreply/failure-reply resource-vp a-failure
+                                      {:work-kind rreply/work-kind-resource})
+    :cancel    #(rreply/failure-reply resource-vp an-abort
+                                      {:work-kind rreply/work-kind-resource})
+    :stale     resource-stale-reply}
+
+   {:family    :mutation
+    :work-head :rf.work/resource ;; mutation reuses the resource head with a [:rf.mutation …] key
+    :success   #(rreply/success-reply mutation-vp {:slug "w" :title "Welcome"}
+                                      {:work-kind rreply/work-kind-mutation
+                                       :completed-at 1781078400456})
+    :error     #(rreply/failure-reply mutation-vp a-failure
+                                      {:work-kind rreply/work-kind-mutation})
+    :cancel    #(rreply/failure-reply mutation-vp an-abort
+                                      {:work-kind rreply/work-kind-mutation})
+    :stale     #(let [carried {:work/id [:rf.work/resource [:rf.mutation :form/save-1] 2] :generation 2}
+                      current {:work/id [:rf.work/resource [:rf.mutation :form/save-1] 3] :generation 3}]
+                  (:reply (rreply/stale-reply
+                            {:carried carried :current current
+                             :extra   {:work/id      (:work/id carried)
+                                       :work/kind    :mutation
+                                       :rf.frame/id  :app/main
+                                       :stale/reason :mutation/superseded}})))}
+
+   {:family    :machine
+    :work-head :rf.work/machine
+    :success   #(m-reply/success-reply machine-ctx {:user-id "u-42"})
+    :error     #(m-reply/error-reply machine-ctx {:reason :bad-creds})
+    ;; A machine spawn has no cancellation reply (the parent/child either
+    ;; finishes or is superseded → stale); cancellation is N/A.
+    :cancel    nil
+    :stale     machine-stale-reply}
+
+   ;; The machine :after timer is a specialized timer instance — its ONLY
+   ;; reply-envelope completion is the stale (epoch-mismatch) suppression.
+   {:family    :timer
+    :work-head nil ;; :after stale reply carries no :work/id (the gate is the path+epoch)
+    :success   nil
+    :error     nil
+    :cancel    nil
+    :stale     after-stale-reply}
+
+   ;; The route loader's success / error flow THROUGH the HTTP transport
+   ;; (covered by the :http row); the family itself shapes ONLY the
+   ;; nav-token stale suppression.
+   {:family    :route
+    :work-head :rf.work/route
+    :success   nil
+    :error     nil
+    :cancel    nil
+    :stale     route-stale-reply}])
+
+;; ---------------------------------------------------------------------------
+;; (0) Universal invariants — EVERY reply EVERY family produces, in EVERY
+;; supported situation, conforms to the single shared contract.
+;; ---------------------------------------------------------------------------
+
+(deftest every-reply-validates-against-the-one-shared-contract
+  (doseq [{:keys [family] :as f} families
+          [situation builder] (select-keys f [:success :error :cancel :stale])
+          :when builder
+          :let [reply (builder)]]
+    (testing (str family " / " situation)
+      (is (reply/valid-reply? reply)
+          (str family " " situation " reply MUST validate against the shared "
+               "re-frame.reply/validate-reply: " (reply/validate-reply reply)))
+      (testing ":status is in the ONE closed status vocabulary"
+        (is (contains? reply/statuses (:status reply))
+            (str family " " situation " :status " (:status reply)
+                 " is not in the closed " reply/statuses)))
+      (testing ":work/status (when present) is in the ONE closed work-status vocabulary"
+        (when (contains? reply :work/status)
+          (is (contains? reply/work-statuses (:work/status reply))
+              (str family " " situation " :work/status " (:work/status reply)
+                   " is not in the closed " reply/work-statuses))))
+      (testing "the reply is DATA-ONLY (no host handle anywhere)"
+        (is (not-any? #(= :rf.reply/host-handle (:rf.reply/problem %))
+                      (reply/validate-reply reply))
+            (str family " " situation " reply carries a host handle"))))))
+
+(deftest every-work-id-is-a-comparable-edn-tuple
+  (doseq [{:keys [family work-head] :as f} families
+          [situation builder] (select-keys f [:success :error :cancel :stale])
+          :when (and builder work-head)
+          :let [reply (builder)
+                wid   (:work/id reply)]
+          ;; The :after stale reply legitimately carries no :work/id (its
+          ;; gate IS the path+epoch correlation); skip rows that produce none.
+          :when (some? wid)]
+    (testing (str family " / " situation " :work/id correlation")
+      (is (vector? wid) (str family " " situation " :work/id is not a vector"))
+      (is (= work-head (first wid))
+          (str family " " situation " :work/id head is " (first wid)
+               ", expected " work-head))
+      (is (= wid (edn-roundtrip wid))
+          (str family " " situation " :work/id is not EDN-round-trippable / =-comparable")))))
+
+;; ---------------------------------------------------------------------------
+;; (a) SUCCESS — every family that produces a success reply produces the
+;; SAME success shape: :status :ok + :work/status :completed + a :value.
+;; ---------------------------------------------------------------------------
+
+(deftest success-shape-is-consistent-across-families
+  (doseq [{:keys [family success]} families
+          :when success
+          :let [reply (success)]]
+    (testing (str family " success → canonical :ok / :completed")
+      (is (= :ok (:status reply))
+          (str family " success :status must be :ok, got " (:status reply)))
+      (is (= :completed (:work/status reply))
+          (str family " success :work/status must be :completed, got " (:work/status reply)))
+      (is (contains? reply :value)
+          (str family " success reply MUST carry a :value (the decoded result)"))
+      (is (nil? (:error reply))
+          (str family " success reply MUST NOT carry an :error")))))
+
+;; ---------------------------------------------------------------------------
+;; (b) ERROR — every family that produces an error reply produces the SAME
+;; error shape: :status :error + a :work/status in #{:failed :timed-out} +
+;; a family :error MAP carrying a :kind (never a loose scalar).
+;; ---------------------------------------------------------------------------
+
+(deftest error-shape-is-consistent-across-families
+  (doseq [{:keys [family error]} families
+          :when error
+          :let [reply (error)]]
+    (testing (str family " error → canonical :error + family-error map")
+      (is (= :error (:status reply))
+          (str family " error :status must be :error, got " (:status reply)))
+      (is (contains? #{:failed :timed-out} (:work/status reply))
+          (str family " error :work/status must be :failed (or :timed-out), got "
+               (:work/status reply)))
+      (is (map? (:error reply))
+          (str family " error :error must be a family-error MAP (never a loose scalar)"))
+      (is (some? (:kind (:error reply)))
+          (str family " error :error map MUST carry a :kind")))))
+
+(deftest http-timeout-is-error-plus-timed-out-work-status
+  (testing "timeout is :status :error + :work/status :timed-out (NOT a top-level status) — the one family with a :timed-out work-status proves it lands in the closed enum"
+    (let [reply (http-reply/failure-reply http-ctx {:kind :rf.http/timeout :limit-ms 30000 :elapsed-ms 30012})]
+      (is (reply/valid-reply? reply) (str (reply/validate-reply reply)))
+      (is (= :error (:status reply)) "timeout is NOT a top-level :status")
+      (is (= :timed-out (:work/status reply)))
+      (is (contains? reply/work-statuses (:work/status reply))
+          ":timed-out is in the ONE closed work-status vocabulary"))))
+
+;; ---------------------------------------------------------------------------
+;; (c) CANCEL — every family that produces a cancellation reply produces the
+;; SAME shape: :status :cancelled + :work/status :cancelled + :cancelled? true
+;; + a :cancel/reason. (An :rf.http/aborted lowers to cancellation, never an
+;; :error, uniformly across HTTP / resources / mutations.)
+;; ---------------------------------------------------------------------------
+
+(deftest cancel-shape-is-consistent-across-families
+  (doseq [{:keys [family cancel]} families
+          :when cancel
+          :let [reply (cancel)]]
+    (testing (str family " cancel → canonical :cancelled")
+      (is (= :cancelled (:status reply))
+          (str family " cancel :status must be :cancelled, got " (:status reply)))
+      (is (= :cancelled (:work/status reply))
+          (str family " cancel :work/status must be :cancelled, got " (:work/status reply)))
+      (is (true? (:cancelled? reply))
+          (str family " cancel reply MUST carry the :cancelled? true marker"))
+      (is (some? (:cancel/reason reply))
+          (str family " cancel reply MUST carry a :cancel/reason")))))
+
+;; ---------------------------------------------------------------------------
+;; (d) STALE — THE axis rf2-mn4j89 violated. EVERY family that suppresses a
+;; superseded completion produces the SAME canonical stale shape:
+;;   :status :stale + :work/status :suppressed + :stale? true + :stale/reason
+;;   + NO :value (a stale reply MUST NOT mutate app state).
+;; This is the umbrella guard: had resources/mutations still emitted their
+;; bespoke :rf.resource/stale-suppressed shape (no :status :stale, no
+;; :work/status :suppressed), THIS test would go RED.
+;; ---------------------------------------------------------------------------
+
+(deftest stale-shape-is-consistent-across-EVERY-family
+  ;; Every managed-async family suppresses (it is the safety boundary), so —
+  ;; unlike success/error/cancel — there is NO family without a :stale path.
+  ;; Assert that, then assert the canonical shape for each.
+  (doseq [{:keys [family stale]} families]
+    (is (some? stale)
+        (str family " MUST lower a stale completion onto the shared envelope "
+             "(stale suppression is the universal correctness boundary)")))
+  (doseq [{:keys [family stale]} families
+          :when stale
+          :let [reply (stale)]]
+    (testing (str family " stale → canonical :stale / :suppressed (the rf2-mn4j89 axis)")
+      (is (reply/valid-reply? reply)
+          (str family " stale reply must validate: " (reply/validate-reply reply)))
+      (is (= :stale (:status reply))
+          (str family " stale :status must be :stale (NOT a bespoke shape), got "
+               (:status reply)))
+      (is (= :suppressed (:work/status reply))
+          (str family " stale :work/status must be :suppressed, got " (:work/status reply)))
+      (is (true? (:stale? reply))
+          (str family " stale reply MUST carry the :stale? true marker"))
+      (is (some? (:stale/reason reply))
+          (str family " stale reply MUST carry a :stale/reason"))
+      (is (not (contains? reply :value))
+          (str family " stale reply MUST NOT carry a :value — a stale reply "
+               "mutates NO app state")))))
+
+(deftest stale-replies-carry-a-carried-and-current-correlation-gate
+  ;; The canonical stale shape carries the carried-vs-current correlation —
+  ;; either on the suppress OUTCOME's :trace (HTTP / resources / mutations /
+  ;; routing, which delegate to re-frame.reply/suppress) or in the reply's
+  ;; :correlation map (machines spawn + :after, which build the gate inline).
+  ;; Pin the correlation presence per family at the altitude each exposes it.
+  (testing "machine spawn-stale carries the carried/current generation gate in :correlation"
+    (let [reply (machine-stale-reply)
+          corr  (:correlation reply)]
+      (is (= 1 (-> corr :generation :carried)) "carried generation parsed off the actor id")
+      (is (nil? (-> corr :generation :current)) "current generation gone (no live counterpart)")))
+  (testing "machine :after-stale carries the carried/current path+epoch gate in :correlation"
+    (let [reply (after-stale-reply)
+          corr  (:correlation reply)]
+      (is (= {:path [:loading] :rf/after-epoch 1} (:carried corr)) "carried path + scheduled epoch")
+      (is (= {:path [:loading] :rf/after-epoch 2} (:current corr)) "current path + advanced epoch")))
+  (testing "the suppress-delegating families (HTTP / resources / mutations / routing) carry carried+current on the :trace"
+    (let [route-out  (route-reply/suppress {:route-id :route/article :nav-token "nav-1"
+                                            :loader-id :article/loaded :frame :app/main}
+                                           "nav-2")
+          res-out    (rreply/stale-reply
+                       {:carried {:work/id [:rf.work/resource [:rf.scope/global :r {}] 4] :generation 4}
+                        :current {:work/id [:rf.work/resource [:rf.scope/global :r {}] 5] :generation 5}
+                        :extra   {:work/id [:rf.work/resource [:rf.scope/global :r {}] 4]
+                                  :work/kind :resource :stale/reason :resource/generation-mismatch}})]
+      (doseq [[family out] [[:route route-out] [:resource res-out]]]
+        (is (false? (:deliver? out))
+            (str family " stale suppression MUST NOT deliver the app target"))
+        (is (= :suppressed (:work/status out))
+            (str family " stale suppression outcome is :work/status :suppressed"))
+        (is (some? (get-in out [:trace :rf.reply/carried]))
+            (str family " stale trace carries the :rf.reply/carried correlation"))
+        (is (some? (get-in out [:trace :rf.reply/current]))
+            (str family " stale trace carries the :rf.reply/current correlation"))))))

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -127,6 +127,24 @@
                 ;; dedicated `:node-test-security` build below
                 ;; (`-security-cljs-test$`, wired as `npm run test:security`).
                 "security/test"
+                ;; rf2-wbh1ln + rf2-5ha70w — EP-0011 cross-family
+                ;; reply-VOCABULARY-consistency tier. The umbrella
+                ;; conformance the per-family reply suites cannot hold: the
+                ;; cross-family vocab-consistency guard (every managed-async
+                ;; family — HTTP, resources, mutations, machines, routing —
+                ;; produces the ONE shared :status/:work/status/:work/id/
+                ;; canonical-stale shape, the axis rf2-mn4j89 violated) and
+                ;; the family-level functor/naturality law at the
+                ;; TARGET-RELOCATING families (route-loader relay,
+                ;; machine-spawn :on-done). The tests sit ABOVE several
+                ;; artefacts (core, http, resources, machines, routing), so
+                ;; — like security/ — they live in their own top-level
+                ;; reply-conformance/ surface; the cross-artefact node-test
+                ;; classpath already spans every required ns. Namespaces end
+                ;; in `-cljs-test`, so they run under the always-on
+                ;; :node-test gate (`cljs-test$` matches); the JVM
+                ;; counterpart is reply-conformance/deps.edn `:test`.
+                "reply-conformance/test"
                 ;; tools/mcp-base — the security tier's MCP-egress surface
                 ;; (`re-frame.mcp-base.sensitive`, the spec/009 §Privacy
                 ;; default-suppress filter) is CLJC and lives here. Source

--- a/scripts/test-jvm-implementation.sh
+++ b/scripts/test-jvm-implementation.sh
@@ -27,6 +27,14 @@ artefacts=(
   # goes RED here — previously only the CLJS side (`npm run test:security`
   # + the always-on `:node-test` gate) ever exercised the tier.
   implementation/security
+  # rf2-wbh1ln + rf2-5ha70w — the EP-0011 cross-family reply-VOCABULARY-
+  # consistency tier is `.cljc` and runs in BOTH runtimes (it round-trips
+  # work-id tuples through the reader-conditional EDN reader: `:clj`
+  # `read-string` vs `:cljs` `cljs.reader/read-string`). Its own `:test`
+  # alias (implementation/reply-conformance/deps.edn) runs the SAME `.cljc`
+  # namespaces under the JVM so the `:clj` arm is exercised — previously
+  # only the CLJS side (the always-on `:node-test` gate) ever ran the tier.
+  implementation/reply-conformance
 )
 
 for artefact in "${artefacts[@]}"; do


### PR DESCRIPTION
Closes the two EP-0011 reply-vocab coverage tails the testing-rigour audit (rf2-h8xw2v) filed, left after the stale-reply remediation landed across families (machines #3908 + resources #3911). **TEST-ONLY — no source changes.** Pre-alpha masterpiece posture: CORRECTNESS.

New cross-artefact test surface `implementation/reply-conformance/` (the precedent is `implementation/security/`): the suites sit ABOVE several artefacts (core, http, resources, machines, routing), so they live in their own surface, not any single family's test tree. The `.cljc` suites ride the always-on CLJS `:node-test` gate (ns ends in `-cljs-test`) and the JVM gate via `reply-conformance/deps.edn` `:test` (wired into `scripts/test-jvm-implementation.sh`).

## rf2-wbh1ln — cross-family reply-VOCABULARY-consistency conformance

`reply_vocab_conformance_cljs_test.cljc`. A table of the FIVE managed-async families (HTTP, resources, mutations, machines/spawn + `:after` timer, routing), each a descriptor naming its situation→reply builders, with ONE set of cross-family assertions proving every family produces the ONE canonical shape for the SAME situation:

- **success** → `:status :ok` + `:work/status :completed` + a `:value`, no `:error`
- **error** → `:status :error` + `:work/status` in `#{:failed :timed-out}` + a family `:error` MAP carrying a `:kind` (never a loose scalar); HTTP timeout proves `:timed-out` lands in the closed enum
- **cancel** → `:status :cancelled` + `:work/status :cancelled` + `:cancelled? true` + `:cancel/reason` (an `:rf.http/aborted` lowers to cancellation uniformly across HTTP/resources/mutations)
- **stale** → `:status :stale` + `:work/status :suppressed` + `:stale? true` + `:stale/reason` + a carried/current correlation gate + **NO `:value`** (no app mutation)

Plus the universal invariants every reply shares: validates against the single `re-frame.reply/validate-reply`; `:status` in closed `reply/statuses`; `:work/status` (when present) in closed `reply/work-statuses`; `:work/id` a `[:rf.work/* …]` tuple that is `=`-comparable + EDN-round-trippable; data-only (no host handle anywhere).

**This is the umbrella guard the rf2-mn4j89 axis violated** — had resources/mutations still emitted their bespoke `:rf.resource/stale-suppressed` shape (no `:status :stale`, no `:work/status :suppressed`), `stale-shape-is-consistent-across-EVERY-family` would go RED. The suite also asserts EVERY family lowers a stale completion onto the shared envelope (stale suppression is the universal correctness boundary), and pins the carried/current correlation per family at the altitude each exposes it (suppress-outcome `:trace` for the delegating families; reply `:correlation` for the machines spawn + `:after` inline gates).

## rf2-5ha70w — family-level functor/naturality law at TARGET-RELOCATING families

`reply_functor_law_cljs_test.cljc`. Re-pins the reply-target functor laws where the target RELOCATES — a route-loader relay onto a parent route event, a machine-spawn `:on-done` routing onto the parent continuation — rather than only at the substrate + timer-probe (the families that pass the target through unchanged hold the law structurally). Belt-and-braces regression guard, executable rather than read:

- **naturality** `complete(map-target(f, t), r) == f(complete(t, r))` for the route-relay and spawn-`:on-done` relay shapes the two families actually use (over REAL family-shaped replies)
- **identity** `(map-target identity t)` is the identity on completion, both families
- **composition** `map f ∘ map g == map (f ∘ g)` BOTH orders, with two genuinely-different wrap relocations (parent-relay ∘ grandparent/supervisor-relay)
- **relocation changes ONLY the event** — the appended reply's `:work/id` / `:status` / `:work/kind` ride unchanged through the relay
- a relocated target carries the ephemeral `::post` accumulator (not data-only), and its `durable-target` projection strips it and is data-only

## Quality gates

- `npm run test:cljs` (node, all artefacts): **6612 tests / 24381 assertions, 0 failures, 0 errors** — both new namespaces discovered + registered in the runner
- `clojure -M:test` in `implementation/reply-conformance/` (JVM): **15 tests / 237 assertions, 0 failures, 0 errors**
- Splint: clean (0 style warnings on the new tier)

EP-0011 is graduated `final`; this converts the one-vocabulary claim into a table-driven cross-family regression gate. Do NOT merge — handing to the merge loop.
- **CI fix (README link-slugs job, rf2-br5u7):** the README-inventory drift gate flagged `implementation/README.md` layout map omitting the new on-disk `reply-conformance/` dir. Added the layout-map entry mirroring the `security/` precedent (test-only, no shipped namespace). All four job steps now pass (`check_readme_links.py --self-test`/`--ci`, `check_readme_inventories.py --self-test`/validate, exit 0); `npm run test:cljs` re-confirmed green (6612 tests / 24381 assertions, 0/0).
