### PR TITLE
feat(resources): EP-0016 slice-6 — populate as authoritative load + exact-target (rf2-h6n40v)

### DIFF
--- a/examples/reagent/realworld_resources/mutations.cljs
+++ b/examples/reagent/realworld_resources/mutations.cljs
@@ -58,7 +58,7 @@
    ;; the whole `{:article …}` envelope its `:decode schema/ArticleResponse`
    ;; produces — so the populated entry reads identically to a fetched one.
    :populates     (fn [{:keys [slug]} result]
-                    {[:rf.scope/global :realworld/article {:slug slug}] result})
+                    {{:resource :realworld/article :params {:slug slug} :scope :rf.scope/global} result})
    ;; Then invalidate so any list showing this article refetches its count.
    :invalidates   (fn [{:keys [slug]} _result] #{[:article slug] [:article-list] [:feed]})})
 
@@ -70,7 +70,7 @@
                     {:request {:method :delete :url (rh/full-url (str "/articles/" slug "/favorite"))}
                      :decode  schema/ArticleResponse})
    :populates     (fn [{:keys [slug]} result]
-                    {[:rf.scope/global :realworld/article {:slug slug}] result})
+                    {{:resource :realworld/article :params {:slug slug} :scope :rf.scope/global} result})
    :invalidates   (fn [{:keys [slug]} _result] #{[:article slug] [:article-list] [:feed]})})
 
 ;; ============================================================================
@@ -91,7 +91,7 @@
    ;; Seed the banner from the reply (the whole `{:profile …}` envelope, the
    ;; `:realworld/profile` resource's stored shape) so it flips immediately.
    :populates     (fn [{:keys [username]} result]
-                    {[:rf.scope/global :realworld/profile {:username username}] result})
+                    {{:resource :realworld/profile :params {:username username} :scope :rf.scope/global} result})
    :invalidates   (fn [{:keys [username]} _result] #{[:profile username]})})
 
 (rf/reg-mutation :realworld/unfollow
@@ -102,7 +102,7 @@
                     {:request {:method :delete :url (rh/full-url (str "/profiles/" username "/follow"))}
                      :decode  schema/ProfileResponse})
    :populates     (fn [{:keys [username]} result]
-                    {[:rf.scope/global :realworld/profile {:username username}] result})
+                    {{:resource :realworld/profile :params {:username username} :scope :rf.scope/global} result})
    :invalidates   (fn [{:keys [username]} _result] #{[:profile username]})})
 
 ;; ============================================================================

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -594,9 +594,20 @@
   **No-match distinction** (Spec 016 §Invalidation): the summary carries
   `:matched` (the matched keys), `:any-tag-match-other-scope?` (whether the
   tags match an entry in ANOTHER scope — \"no match HERE\" vs \"no resource
-  provides this tag in any scope\"), so Xray can tell the two apart."
+  provides this tag in any scope\"), so Xray can tell the two apart.
+
+  **Populate exemption** (EP-0016 Rider 1, Spec 016 §Populate is an
+  authoritative load): `:exempt-keys` is an optional set of EXACT scoped keys
+  EXEMPT from this pass — a key a same-mutation `:populates` just seeded
+  AUTHORITATIVELY is fresh for the mutation result, so this same mutation's
+  invalidation pass must NOT re-stale or refetch it (unless the descriptor
+  opted into `:refetch-populated? true`, in which case the mutation passes no
+  exempt set). An exempt key is removed from the matched set BEFORE the
+  stale-mark / refetch decision, so it keeps its fresh populated value and arms
+  no refetch. The summary carries `:exempt` (the exempt keys that actually
+  matched the tags, so Xray can show what the populate spared)."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
-   [_event-id {:keys [scope tags cause cross-scope?]}]]
+   [_event-id {:keys [scope tags cause cross-scope? exempt-keys]}]]
   (let [runtime-db (or rt {})
         ;; FAIL CLOSED (rf2-pvdae1): a scoped (default) invalidation MUST
         ;; carry an explicit :scope — a missing scope would otherwise match
@@ -634,11 +645,26 @@
         ;; rewrites the SAME `:invalidated-at`.
         invalidated-at (:time-ms world)
         entries    (get-in runtime-db (state/entries-path))
+        ;; EP-0016 Rider 1 — keys this same mutation just POPULATED
+        ;; authoritatively are EXEMPT from this pass (kept fresh, never
+        ;; re-staled / refetched). The set is canonicalized at the producer
+        ;; (the populate path re-keys by the canonical scoped key), so a plain
+        ;; set membership test is identity-correct.
+        exempt     (set exempt-keys)
         tags-hit?  (fn [entry] (seq (set/intersection (set (:tags entry)) tag-set)))
         in-scope?  (fn [k] (or cross-scope? (= cscope (first k))))
-        ;; matched: tags intersect AND (cross-scope OR scope matches)
+        ;; matched: tags intersect AND (cross-scope OR scope matches) AND NOT
+        ;; exempt (a populated key the same mutation kept authoritative)
         matched    (into {}
-                         (filter (fn [[k entry]] (and (in-scope? k) (tags-hit? entry))))
+                         (filter (fn [[k entry]] (and (not (contains? exempt k))
+                                                      (in-scope? k) (tags-hit? entry))))
+                         entries)
+        ;; the exempt keys that WOULD have matched (for the trace — what the
+        ;; populate spared from this same-mutation refetch)
+        exempt-hit (into []
+                         (comp (filter (fn [[k entry]] (and (contains? exempt k)
+                                                            (in-scope? k) (tags-hit? entry))))
+                               (map key))
                          entries)
         ;; tag matches that fell OUTSIDE the requested scope (the
         ;; "no match HERE, but the tag exists in another scope" signal — only
@@ -681,6 +707,9 @@
                   :matched (mapv :resource-key decisions)
                   :refetched (count refetches)
                   :left-stale (count (remove :active? decisions))
+                  ;; EP-0016 Rider 1: keys a same-mutation populate kept
+                  ;; authoritative and spared from this pass (would have matched)
+                  :exempt exempt-hit
                   ;; no-match distinction: no match in this scope vs no resource
                   ;; provides this tag in any scope (Spec 016 §Invalidation)
                   :any-tag-match-other-scope? other-scope-hit?})

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -137,77 +137,120 @@
   (or supplied-instance
       [:rf.mutation/instance mutation-id generation]))
 
+;; ---- exact-target scope resolution (EP-0016 Rider 2 / slice 6) -------------
+;;
+;; A map-form `:populates` / `:patches` target declares its OWN `:scope` —
+;; concrete, `:rf.scope/same` (the mutation's resolved scope, the default), or
+;; a `{:from-db …}` named-resolver reference resolved against the settle-time
+;; app-db (the single use-time rule). This mirrors the invalidation-descriptor
+;; scope resolution (`resolve-descriptor-scope` below); both share the same
+;; `:rf.scope/same` marker, the same `state/canonicalize-scope` path, and the
+;; same fail-closed nil-resolution discipline.
+
+(defn- resolve-exact-target-scope
+  "Resolve a map-form exact target's DECLARED `:scope` (via `mstate/target-scope`,
+  defaulting `:rf.scope/same`) to a concrete cache scope at settle time, against
+  the mutation's resolved scope `mut-scope` and the handler's app-db `db`.
+  Returns `[:resolved <concrete-scope>]` or `[:nil-resolved <from-db-id>]` (a
+  `{:from-db …}` reference that resolved nil — FAIL-CLOSED: the target is
+  dropped, never written under an implicit global). Cross-scope is NOT a target
+  concept (an exact target writes ONE key, so there is no scope-agnostic form).
+  Per Spec 016 §Map-form exact resource targets / §Resolver references."
+  [target mut-scope db where]
+  (let [scope (mstate/target-scope target)]
+    (cond
+      (= scope mstate/same-scope-marker)
+      [:resolved mut-scope]
+
+      (scope-registry/from-db-reference? scope)
+      (if-let [s (scope-registry/resolve-from-db-reference scope db where)]
+        [:resolved (state/canonicalize-scope s where nil)]
+        [:nil-resolved (:from-db scope)])
+
+      :else
+      [:resolved (state/canonicalize-scope scope where nil)])))
+
 ;; ---- the success-time patch / populate / invalidate composition -----------
 
 (defn- apply-patches
   "Apply the mutation spec's `:patches` to the resource cache. `:patches` is
-  `(fn [params result] -> {scoped-key patch-fn})` — each `patch-fn` is
-  `(fn [old-data result] -> new-data)` applied to the keyed resource entry's
-  last-known-good `:data` (controlled patch, structural-shared, freshness
-  refreshed). Returns `[runtime-db' affected-keys]`. A patch on a key with
-  no entry / no data is a no-op (a patch transforms existing data; populate
-  seeds). Per EP-0003 §Mutations (controlled resource patch APIs)."
-  [runtime-db patches-fn params result clock-ms]
-  (if-let [patches (when patches-fn
-                     ;; rf2-3yyaur — validate + canonicalize EVERY patch target
-                     ;; scoped key BEFORE any cache mutation (fail-closed: one
-                     ;; bad target rejects the whole patch arm, never a partial
-                     ;; write). Re-keys by the canonical scoped key so the
-                     ;; write lands under the canonical identity.
-                     (mstate/validate-target-map!
-                       (patches-fn params result) registry/resource-meta
-                       :patches 'rf.mutation.internal/succeeded))]
-    (reduce-kv
-      (fn [[db ks policies] scoped-key patch-fn]
-        (let [entry (get-in db (state/entry-path scoped-key))]
-          (if (and entry (state/has-data? entry))
-            (let [rspec    (registry/resource-meta (:resource/id entry))
-                  stale-at (stale-at-for rspec clock-ms)
-                  entry'   (mstate/patch-entry entry patch-fn result
-                                               {:clock-ms clock-ms :stale-at stale-at})
-                  delays   (timer-delays rspec)]
-              [(assoc-in db (state/entry-path scoped-key) entry')
-               (conj ks scoped-key)
-               (cond-> policies delays (assoc scoped-key delays))])
-            [db ks policies])))
-      [runtime-db #{} {}]
-      patches)
-    [runtime-db #{} {}]))
+  `(fn [params result] -> {target patch-fn})` — each KEY is a map-form exact
+  target `{:resource :params :scope}` (EP-0016 Rider 2 — the only public input
+  form) and each `patch-fn` is `(fn [old-data result] -> new-data)` applied to
+  the resolved key's last-known-good `:data` (controlled patch,
+  structural-shared, freshness refreshed). Returns `[runtime-db' affected-keys
+  policies nil-resolved-ids]`. A patch on a key with no entry / no data is a
+  no-op (a patch transforms existing data; populate seeds); a target whose
+  `{:from-db …}` scope resolves nil is FAIL-CLOSED (dropped). Per EP-0003
+  §Mutations / Spec 016 §Map-form exact resource targets."
+  [runtime-db patches-fn params result clock-ms mut-scope db where]
+  (let [[patches nil-ids]
+        (when patches-fn
+          ;; rf2-3yyaur / EP-0016 Rider 2 — resolve each map-form target's
+          ;; scope against the settle-time db, then validate + canonicalize
+          ;; EVERY resolved key BEFORE any cache mutation (fail-closed: one bad
+          ;; target rejects the whole patch arm; a nil-resolving {:from-db …}
+          ;; target is dropped, never a partial / wrong-scope write).
+          (mstate/validate-target-map!
+            (patches-fn params result)
+            #(resolve-exact-target-scope % mut-scope db where)
+            registry/resource-meta :patches where))]
+    (if (seq patches)
+      (reduce-kv
+        (fn [[db' ks policies nils] scoped-key patch-fn]
+          (let [entry (get-in db' (state/entry-path scoped-key))]
+            (if (and entry (state/has-data? entry))
+              (let [rspec    (registry/resource-meta (:resource/id entry))
+                    stale-at (stale-at-for rspec clock-ms)
+                    entry'   (mstate/patch-entry entry patch-fn result
+                                                 {:clock-ms clock-ms :stale-at stale-at})
+                    delays   (timer-delays rspec)]
+                [(assoc-in db' (state/entry-path scoped-key) entry')
+                 (conj ks scoped-key)
+                 (cond-> policies delays (assoc scoped-key delays))
+                 nils])
+              [db' ks policies nils])))
+        [runtime-db #{} {} (vec nil-ids)]
+        patches)
+      [runtime-db #{} {} (vec nil-ids)])))
 
 (defn- apply-populates
-  "Apply the mutation spec's `:populates` to the resource cache.
-  `:populates` is `(fn [params result] -> {scoped-key value})` — each
-  keyed entry is SEEDED `:loaded` from `value` (controlled populate). The
-  populated entry takes the resource's tags from the resource spec's
-  `:tags` fn (a populated entry MUST carry its own tags so a later
-  invalidation can reach it). Returns `[runtime-db' affected-keys]`. Per
-  EP-0003 §Mutations (controlled resource populate APIs)."
-  [runtime-db populates-fn params result clock-ms]
-  (if-let [populates (when populates-fn
-                       ;; rf2-3yyaur — validate + canonicalize EVERY populate
-                       ;; target scoped key BEFORE any cache mutation
-                       ;; (fail-closed: one bad target rejects the whole
-                       ;; populate arm, never a partial write).
-                       (mstate/validate-target-map!
-                         (populates-fn params result) registry/resource-meta
-                         :populates 'rf.mutation.internal/succeeded))]
-    (reduce-kv
-      (fn [[db ks policies] scoped-key value]
-        (let [[_scope resource-id rparams] scoped-key
-              rspec    (registry/resource-meta resource-id)
-              stale-at (stale-at-for rspec clock-ms)
-              tags-fn  (:tags rspec)
-              tags     (when tags-fn (set (tags-fn rparams value)))
-              entry    (get-in db (state/entry-path scoped-key))
-              entry'   (mstate/populate-entry entry resource-id value
-                                              {:clock-ms clock-ms :stale-at stale-at :tags tags})
-              delays   (timer-delays rspec)]
-          [(assoc-in db (state/entry-path scoped-key) entry')
-           (conj ks scoped-key)
-           (cond-> policies delays (assoc scoped-key delays))]))
-      [runtime-db #{} {}]
-      populates)
-    [runtime-db #{} {}]))
+  "Apply the mutation spec's `:populates` to the resource cache. `:populates`
+  is `(fn [params result] -> {target value})` — each KEY is a map-form exact
+  target `{:resource :params :scope}` (EP-0016 Rider 2) and each resolved key
+  is SEEDED `:loaded` from `value` (controlled populate — an AUTHORITATIVE
+  load, Rider 1). The populated entry takes the resource's tags from the
+  resource spec's `:tags` fn (a populated entry MUST carry its own tags so a
+  later invalidation can reach it). Returns `[runtime-db' affected-keys
+  policies nil-resolved-ids]`. A target whose `{:from-db …}` scope resolves nil
+  is FAIL-CLOSED (dropped). Per EP-0003 §Mutations / Spec 016 §Map-form exact
+  resource targets / §Populate is an authoritative load."
+  [runtime-db populates-fn params result clock-ms mut-scope db where]
+  (let [[populates nil-ids]
+        (when populates-fn
+          (mstate/validate-target-map!
+            (populates-fn params result)
+            #(resolve-exact-target-scope % mut-scope db where)
+            registry/resource-meta :populates where))]
+    (if (seq populates)
+      (reduce-kv
+        (fn [[db' ks policies nils] scoped-key value]
+          (let [[_scope resource-id rparams] scoped-key
+                rspec    (registry/resource-meta resource-id)
+                stale-at (stale-at-for rspec clock-ms)
+                tags-fn  (:tags rspec)
+                tags     (when tags-fn (set (tags-fn rparams value)))
+                entry    (get-in db' (state/entry-path scoped-key))
+                entry'   (mstate/populate-entry entry resource-id value
+                                                {:clock-ms clock-ms :stale-at stale-at :tags tags})
+                delays   (timer-delays rspec)]
+            [(assoc-in db' (state/entry-path scoped-key) entry')
+             (conj ks scoped-key)
+             (cond-> policies delays (assoc scoped-key delays))
+             nils]))
+        [runtime-db #{} {} (vec nil-ids)]
+        populates)
+      [runtime-db #{} {} (vec nil-ids)])))
 
 ;; ---- scoped invalidation descriptors (EP-0016 D2 / slice 5) ---------------
 ;;
@@ -297,14 +340,26 @@
   "Turn an `invalidation-plan` `:dispatches` vector into the per-descriptor
   `[:dispatch [:rf.resource/invalidate-tags …]]` fx — one dispatch into the
   SINGLE scoped invalidation engine per resolved descriptor. Returns nil when
-  the plan dispatches nothing (so the caller's `cond->` skips it)."
-  [plan cause]
+  the plan dispatches nothing (so the caller's `cond->` skips it).
+
+  EP-0016 Rider 1 (populate is an authoritative load): `populated-ks` is the
+  set of EXACT scoped keys this same mutation just POPULATED. A populated key
+  is FRESH for the mutation result, so it is EXEMPT from immediate refetch by
+  this same mutation's invalidation pass — UNLESS the descriptor opts in with
+  `:refetch-populated? true` (the partial-reply case). Each descriptor's
+  dispatch therefore carries `:exempt-keys` = the populated keys (default) or
+  `#{}` (when `:refetch-populated?`), and the invalidation engine excludes the
+  exempt keys from its matched set. Per Spec 016 §Populate is an authoritative
+  load."
+  [plan cause populated-ks]
   (not-empty
-    (mapv (fn [{:keys [scope cross-scope? tags]}]
-            [:dispatch [:rf.resource/invalidate-tags
-                        (cond-> {:tags tags :cause cause}
-                          (some? scope) (assoc :scope scope)
-                          cross-scope?  (assoc :cross-scope? true))]])
+    (mapv (fn [{:keys [scope cross-scope? tags refetch-populated?]}]
+            (let [exempt (if refetch-populated? #{} (set populated-ks))]
+              [:dispatch [:rf.resource/invalidate-tags
+                          (cond-> {:tags tags :cause cause}
+                            (some? scope)  (assoc :scope scope)
+                            cross-scope?   (assoc :cross-scope? true)
+                            (seq exempt)   (assoc :exempt-keys exempt))]]))
           (:dispatches plan))))
 
 (defn- plan-tags
@@ -316,16 +371,24 @@
 (defn- plan-trace
   "The descriptor-level invalidation evidence facet for the mutation settlement
   trace (Spec 016 §Trace evidence for invalidation): the descriptor count, the
-  per-descriptor resolved `(scope, cross-scope?, tags)`, and the fail-closed
-  `:unresolved` `{:from-db …}` ids (descriptors that resolved nil and produced
-  no invalidation). nil-safe (an absent plan yields nil)."
-  [plan]
+  per-descriptor resolved `(scope, cross-scope?, tags, refetch-populated?)`, the
+  fail-closed `:unresolved` `{:from-db …}` ids (descriptors that resolved nil
+  and produced no invalidation), and `:populate-exempt` — the EXACT keys this
+  same mutation populated that are exempted from same-mutation refetch by
+  Rider 1 (empty when no `:populates`, or when every descriptor opted into
+  `:refetch-populated? true`). nil-safe (an absent plan yields nil)."
+  [plan populated-ks]
   (when plan
-    {:descriptor-count (:descriptor-count plan)
-     :dispatched (mapv (fn [{:keys [scope cross-scope? tags]}]
-                         {:scope scope :cross-scope? cross-scope? :tags (vec tags)})
-                       (:dispatches plan))
-     :unresolved (vec (:unresolved plan))}))
+    (let [any-refetch? (some :refetch-populated? (:dispatches plan))]
+      {:descriptor-count (:descriptor-count plan)
+       :dispatched (mapv (fn [{:keys [scope cross-scope? tags refetch-populated?]}]
+                           {:scope scope :cross-scope? cross-scope? :tags (vec tags)
+                            :refetch-populated? (boolean refetch-populated?)})
+                         (:dispatches plan))
+       :unresolved (vec (:unresolved plan))
+       ;; Rider 1: the populated keys exempted from this mutation's refetch
+       ;; (empty when a descriptor opted into a same-mutation refetch).
+       :populate-exempt (if any-refetch? [] (vec populated-ks))})))
 
 ;; ---- mutation completion continuation — call-site :reply-to (D1) -----------
 ;;
@@ -465,8 +528,11 @@
         ;; of the single scoped invalidation engine.
         before-plan (when before?
                       (invalidation-plan (:invalidates spec) cparams nil cscope app-db where))
+        ;; a `:before-request` invalidation runs BEFORE the write is even sent,
+        ;; so no `:populates` has run — there are no populated keys to exempt
+        ;; (Rider 1 is a success-path concept).
         before-fxs  (when before-plan
-                      (plan->fx before-plan [:mutation mutation instance-id]))
+                      (plan->fx before-plan [:mutation mutation instance-id] #{}))
         instance'  (mstate/empty-instance
                      mutation instance-id
                      {:scope cscope :params cparams :cause cause
@@ -525,7 +591,7 @@
                    ;; EP-0016 D2: a `:before-request` invalidation attaches its
                    ;; descriptor-level evidence (resolved scopes + fail-closed
                    ;; nil-resolved `{:from-db …}` ids) to the started trace.
-                   before-plan (assoc :invalidation (plan-trace before-plan))))
+                   before-plan (assoc :invalidation (plan-trace before-plan #{}))))
     {:rf.db/runtime rdb'
      ;; rf2-agrjvk — `:before-request` invalidation must precede the request
      ;; being lowered to transport. fx run in order, so the invalidation
@@ -801,17 +867,23 @@
             ;; `:loaded-at` produced by the mutation uses that SAME causal
             ;; completion time (off the reply token, never an ambient read).
             clock-ms    completed-at
-            ;; 1. controlled patch / populate (BEFORE invalidation). Each
-            ;; arm also returns the per-key advisory stale / GC timer policy
-            ;; (the third value) so this handler arms timers exactly as the
-            ;; resource read path does (a populate seeds a fresh, ownerless
-            ;; entry that otherwise has a durable :stale-at / :gc-after-ms
-            ;; policy but NO armed reaper). populate wins on a key written by
-            ;; both (it ran last, so its entry — and policy — is current).
-            [rdb1 patched-ks patch-policies]     (apply-patches runtime-db (:patches spec) params result clock-ms)
-            [rdb2 populated-ks populate-policies] (apply-populates rdb1 (:populates spec) params result clock-ms)
+            ;; 1. controlled patch / populate (BEFORE invalidation). Each arm
+            ;; takes a map-form exact target (EP-0016 Rider 2 — the only public
+            ;; input form), resolves each target's declared `:scope`
+            ;; (`:rf.scope/same` / concrete / `{:from-db …}`) against this
+            ;; reply's app-db at settle time, validates + canonicalizes the
+            ;; resolved key fail-closed, and returns the per-key advisory stale
+            ;; / GC timer policy (so this handler arms timers exactly as the
+            ;; read path does — a populate seeds a fresh, ownerless entry that
+            ;; otherwise has a durable :stale-at / :gc-after-ms policy but NO
+            ;; armed reaper) PLUS the fail-closed nil-resolved {:from-db …} ids
+            ;; (targets dropped because their scope resolver returned nil).
+            ;; populate wins on a key written by both (it ran last).
+            [rdb1 patched-ks patch-policies patch-nil-ids]        (apply-patches runtime-db (:patches spec) params result clock-ms scope app-db where)
+            [rdb2 populated-ks populate-policies populate-nil-ids] (apply-populates rdb1 (:populates spec) params result clock-ms scope app-db where)
             patch-affected      (set/union patched-ks populated-ks)
             timer-policies      (merge patch-policies populate-policies)
+            target-nil-ids      (into (vec patch-nil-ids) populate-nil-ids)
             ;; the success-time invalidation (EP-0016 D2: per-descriptor
             ;; scoped). The patch already freshened the keys it touched; the
             ;; invalidation reaches the OTHER tagged entries (lists, siblings)
@@ -819,10 +891,14 @@
             ;; (incl. `{:from-db …}` against this reply's app-db at settle time)
             ;; and lowers into one dispatch of the single scoped invalidation
             ;; engine; a nil-resolving `{:from-db …}` is fail-closed (recorded
-            ;; in the plan `:unresolved`, no dispatch).
+            ;; in the plan `:unresolved`, no dispatch). EP-0016 Rider 1: the
+            ;; keys this same mutation just POPULATED are EXEMPT from this
+            ;; invalidation pass's refetch (a populate is an authoritative load
+            ;; — the key is already fresh for the result) unless a descriptor
+            ;; opts in with `:refetch-populated? true`.
             inv-plan    (when (#{:after-success :after-settle} timing)
                           (invalidation-plan (:invalidates spec) params result scope app-db where))
-            inv-fxs     (when inv-plan (plan->fx inv-plan [:mutation mutation-id instance-id]))
+            inv-fxs     (when inv-plan (plan->fx inv-plan [:mutation mutation-id instance-id] populated-ks))
             ;; the union of every dispatched descriptor's tags (the affected-key
             ;; / patch-summary trace reservation records the invalidated tags).
             inv-tags    (when inv-plan (plan-tags inv-plan))
@@ -832,6 +908,11 @@
             patch-summary {:patched   (vec patched-ks)
                            :populated (vec populated-ks)
                            :invalidated-tags (vec (or inv-tags #{}))
+                           ;; EP-0016 Rider 2 fail-closed evidence: map-form
+                           ;; populate/patch targets whose {:from-db …} scope
+                           ;; resolved nil were DROPPED (never written under an
+                           ;; implicit global).
+                           :target-unresolved (vec target-nil-ids)
                            ;; reserved for the later optimistic slice:
                            :snapshot-id nil :rollback nil :reconciliation-refetches nil}
             inst'       (mstate/instance-succeeded
@@ -889,8 +970,11 @@
                        ;; EP-0016 D2: the descriptor-level invalidation evidence
                        ;; (resolved scope per descriptor + fail-closed
                        ;; nil-resolved `{:from-db …}` ids) rides the settlement
-                       ;; trace (Spec 016 §Trace evidence for invalidation).
-                       inv-plan (assoc :invalidation (plan-trace inv-plan))))
+                       ;; trace (Spec 016 §Trace evidence for invalidation). The
+                       ;; Rider 1 populate-exempt evidence (the populated keys
+                       ;; exempted from this mutation's refetch) rides the same
+                       ;; facet (Spec 016 §Populate is an authoritative load).
+                       inv-plan (assoc :invalidation (plan-trace inv-plan populated-ks))))
         {:rf.db/runtime rdb'
          :fx (cond-> (vec timer-fx)
                inv-fxs (into inv-fxs)
@@ -962,7 +1046,11 @@
             ;; descriptor fns close over only `params`).
             inv-plan (when (#{:after-failure :after-settle} timing)
                        (invalidation-plan (:invalidates spec) params nil scope app-db where))
-            inv-fxs  (when inv-plan (plan->fx inv-plan [:mutation mutation-id instance-id]))
+            ;; a FAILED write applies no `:populates` (the result is nil), so
+            ;; there are no populated keys to exempt (Rider 1 is a success-path
+            ;; concept) — the empty exempt set keeps the failure-time
+            ;; invalidation a plain pass.
+            inv-fxs  (when inv-plan (plan->fx inv-plan [:mutation mutation-id instance-id] #{}))
             inv-tags (when inv-plan (plan-tags inv-plan))
             inst'    (mstate/instance-failed
                        inst {:error error :settled-at clock-ms
@@ -996,8 +1084,10 @@
                               :work-id work-id :generation generation :error error
                               :invalidated-tags (vec (or inv-tags #{}))}
                        ;; EP-0016 D2: descriptor-level failure-invalidation
-                       ;; evidence rides the failed-settlement trace.
-                       inv-plan (assoc :invalidation (plan-trace inv-plan))))
+                       ;; evidence rides the failed-settlement trace (no
+                       ;; populated keys on a failure, so the Rider 1 exempt
+                       ;; set is empty).
+                       inv-plan (assoc :invalidation (plan-trace inv-plan #{}))))
         {:rf.db/runtime rdb'
          :fx (cond-> []
                inv-fxs (into inv-fxs)

--- a/implementation/resources/src/re_frame/resources/mutation_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_registry.cljc
@@ -124,10 +124,13 @@
 
   - **`:invalidates`** — `(fn [params result] -> #{tag …})` — the resource
     tags this mutation's success (and optionally failure) invalidates;
-  - **`:patches`** — `(fn [params result] -> {scoped-key-or-spec patch-fn})`
-    — controlled resource-entry patches applied on success;
-  - **`:populates`** — `(fn [params result] -> {resource-spec value})` —
-    controlled resource-entry seeds applied on success;
+  - **`:patches`** — `(fn [params result] -> {target patch-fn})` — controlled
+    resource-entry patches applied on success; each KEY is a map-form exact
+    target `{:resource :params :scope}` (EP-0016 Rider 2 — the only public
+    input form);
+  - **`:populates`** — `(fn [params result] -> {target value})` — controlled
+    resource-entry seeds applied on success (an AUTHORITATIVE load, Rider 1);
+    each KEY is the same map-form exact target;
   - **`:scope`** — the cache scope the invalidation / patch defaults to
     (same scope rules as resources; OPTIONAL — defaults from the execute
     payload, else `:rf.scope/global`);

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -330,6 +330,15 @@
        (= reserved-scope-ns (namespace scope))
        (not (contains? reserved-scope-policies scope))))
 
+(def same-scope-marker
+  "The `:scope` marker meaning \"the mutation's resolved (execution) scope\" —
+  the DEFAULT when an invalidation descriptor OR a map-form exact target omits
+  `:scope`, and the meaning of the bare tag-set invalidation shorthand (Spec
+  016 §Scoped invalidation descriptors / §Map-form exact resource targets).
+  Resolved to the concrete mutation scope by the events layer at settle time;
+  it is NOT itself a literal cache scope (it never reaches the cache key)."
+  :rf.scope/same)
+
 (defn target-key-error
   "Build the canonical thrown-error shape (Spec 009 §The thrown-error shape)
   for an invalid mutation patch / populate TARGET scoped key. `arm`
@@ -344,15 +353,49 @@
                    :target      (pr-str target)}
                   extra)))
 
-(defn validate-target-key!
-  "Fail-closed validation of a SINGLE mutation patch / populate TARGET scoped
-  key, BEFORE any cache mutation (EP-0003 §Mutations / Spec 016 §Resource
-  identity). A target key is the canonical scoped resource key
-  `[scope resource-id params]` — the SAME shape `state/scoped-resource-key`
-  produces and the read path writes under. Rejects, loudly:
+;; ---- map-form exact target (EP-0016 Rider 2 / slice 6) --------------------
+;;
+;; The ONLY public input form for an exact `:populates` / `:patches` (and a
+;; future remove) target is the TARGET MAP `{:resource … :params … :scope …}`
+;; (Spec 016 §Map-form exact resource targets / EP-0016 issue 4 — no migration
+;; window; pre-alpha, no external consumers). The hand-built scoped-key tuple
+;; `[scope resource-id params]` remains the documented INTERNAL / STORAGE
+;; representation (the `:rf/scoped-resource-key` shape the read path writes
+;; under) — an input-form-vs-storage-form distinction per EP-0007 rule 3, NOT
+;; two public spellings of one fact.
+;;
+;; The map `:scope` is one of: `:rf.scope/same` (the mutation's resolved
+;; scope — the DEFAULT when omitted), `:rf.scope/global`, a concrete canonical
+;; scope value, or a `{:from-db <id>}` named-resolver reference. The DERIVED
+;; scope forms (`:rf.scope/same` / `{:from-db …}`) resolve against the
+;; settle-time app-db, so this PURE runtime validator does NOT resolve scope
+;; itself — the events layer resolves each target's scope first (it owns the
+;; registry + db), then this validator validates + canonicalizes the resulting
+;; CONCRETE key fail-closed before any cache write.
 
-  - a malformed key (not a 3-element `[scope resource-id params]` vector);
-  - a non-keyword `resource-id`;
+(defn target-map?
+  "True iff `target` is the public map-form exact target
+  `{:resource <id> :params <params>}` (a map carrying `:resource`). The
+  `:scope` key is optional (it defaults to `:rf.scope/same`). A 3-element
+  storage tuple is NOT a target map. Per Spec 016 §Map-form exact resource
+  targets / EP-0016 Rider 2."
+  [target]
+  (and (map? target) (contains? target :resource)))
+
+(defn validate-target-key!
+  "Fail-closed validation of a SINGLE mutation patch / populate TARGET, BEFORE
+  any cache mutation (EP-0003 §Mutations / Spec 016 §Resource identity /
+  §Map-form exact resource targets). The public INPUT form is the TARGET MAP
+  `{:resource <id> :params <params> :scope <scope>}` (EP-0016 Rider 2 — the
+  only public input form, no tuple migration window). The map's `:scope` has
+  already been RESOLVED to a CONCRETE scope value by the events layer
+  (`resolved-scope` — the `:rf.scope/same` default and any `{:from-db …}`
+  reference resolve against the settle-time app-db upstream); this PURE
+  validator never resolves scope itself. Rejects, loudly:
+
+  - a non-map target (the tuple is the internal storage form, not a public
+    input — a tuple reaching here is rejected loudly);
+  - a missing / non-keyword `:resource` id;
   - an UNREGISTERED resource id (`registered-resource?` returns falsey) — a
     patch / populate must target a resource the read path also knows, or the
     seeded / patched entry is unreachable by any subscription;
@@ -366,26 +409,30 @@
   registry-lookup predicate (so this PURE validator carries no registry
   require). `where` names the call-site public surface; `arm`
   (`:patches` | `:populates`) names the offending mutation-spec arm. Returns
-  the CANONICALIZED scoped key `[canonical-scope resource-id canonical-params]`
+  the CANONICAL STORAGE key `[canonical-scope resource-id canonical-params]`
   on success (so the caller writes under the canonical identity, never a
   caller's alternate spelling). Throws `:rf.error/mutation-invalid-target`
   otherwise."
-  [target registered-resource? where arm]
-  (when-not (and (vector? target) (= 3 (count target)))
+  [target resolved-scope registered-resource? where arm]
+  (when-not (target-map? target)
     (throw (target-key-error
              where arm
-             (str "a mutation " (name arm) " target must be a canonical "
-                  "scoped resource key [scope resource-id params] (a "
-                  "3-element vector); got " (pr-str target) ". Per EP-0003 "
-                  "§Mutations / Spec 016 §Resource identity.")
+             (str "a mutation " (name arm) " target must be the map-form exact "
+                  "target {:resource <id> :params <params> :scope <scope>} (the "
+                  "only public input form — the scoped-key tuple is the internal "
+                  "storage representation, not a public input); got "
+                  (pr-str target) ". Per Spec 016 §Map-form exact resource "
+                  "targets / EP-0016 Rider 2.")
              target {})))
-  (let [[scope resource-id params] target]
-    (when-not (keyword? resource-id)
+  (let [{:keys [resource params]} target
+        scope resolved-scope]
+    (when-not (keyword? resource)
       (throw (target-key-error
                where arm
-               (str "a mutation " (name arm) " target's resource id must be "
-                    "a keyword; got " (pr-str resource-id) ".")
-               target {:resource-id resource-id})))
+               (str "a mutation " (name arm) " target map's :resource must be "
+                    "a keyword; got " (pr-str resource) " in " (pr-str target)
+                    ". Per Spec 016 §Map-form exact resource targets.")
+               target {:resource-id resource})))
     (when (reserved-scope-typo? scope)
       (throw (target-key-error
                where arm
@@ -410,32 +457,58 @@
                     "serializable EDN — host / opaque values are rejected at "
                     "the cache-key boundary. Per Spec 016 §Resource identity.")
                target {:params (pr-str params)})))
-    (when-not (registered-resource? resource-id)
+    (when-not (registered-resource? resource)
       (throw (target-key-error
                where arm
                (str "a mutation " (name arm) " targets the UNREGISTERED "
-                    "resource " (pr-str resource-id) " — a controlled patch / "
+                    "resource " (pr-str resource) " — a controlled patch / "
                     "populate must target a resource the read path also "
                     "knows, or the seeded / patched entry is unreachable by "
                     "any subscription. Call rf/reg-resource first. Per "
                     "EP-0003 §Mutations.")
-               target {:resource-id resource-id})))
-    (state/scoped-resource-key scope resource-id params)))
+               target {:resource-id resource})))
+    (state/scoped-resource-key scope resource params)))
+
+(defn target-scope
+  "The DECLARED `:scope` of a map-form exact target, defaulting to
+  `:rf.scope/same` (the mutation's resolved scope) when the target omits
+  `:scope` — the same default the invalidation-descriptor `:scope` carries.
+  Pure; the events layer resolves the returned scope (concrete /
+  `:rf.scope/same` / `{:from-db …}`) against the settle-time app-db. Per Spec
+  016 §Map-form exact resource targets."
+  [target]
+  (if (contains? target :scope) (:scope target) same-scope-marker))
 
 (defn validate-target-map!
   "Fail-closed validation + canonicalization of a WHOLE mutation `:patches` /
-  `:populates` target map `{scoped-key value}` BEFORE any cache mutation
-  (EP-0003 §Mutations). Validates EVERY target key via `validate-target-key!`
-  (so one bad target rejects the whole success-time patch / populate — no
-  partial cache mutation) and returns a NEW map re-keyed by the CANONICAL
-  scoped key, values preserved. `kind` (`:patches` | `:populates`) names the
-  offending arm in the error. A nil / empty map returns itself."
-  [target-map registered-resource? kind where]
-  (when (seq target-map)
+  `:populates` target map `{target value}` BEFORE any cache mutation (EP-0003
+  §Mutations / Spec 016 §Map-form exact resource targets). Each KEY is a public
+  map-form target `{:resource :params :scope}`; `resolve-target-scope` is
+  `(fn [target] -> [:resolved <concrete-scope>] | [:nil-resolved <from-db-id>])`
+  — injected by the events layer (it owns the registry + settle-time db) and
+  resolves each target's declared `:scope` (`:rf.scope/same` / concrete /
+  `{:from-db …}`). A target whose scope resolves NIL (`:nil-resolved`) is
+  FAIL-CLOSED: it is DROPPED (no cache write under an implicit global, never a
+  silent wrong-scope poke). Validates every resolved key via
+  `validate-target-key!` (one bad target rejects the whole arm — no partial
+  cache mutation) and returns `[canonical-map nil-resolved-ids]`: a map re-keyed
+  by the CANONICAL STORAGE key (values preserved) plus the vector of
+  `{:from-db …}` ids that resolved nil (fail-closed evidence for the trace).
+  `kind` (`:patches` | `:populates`) names the offending arm in the error. A
+  nil / empty input map returns `[nil []]`."
+  [target-map resolve-target-scope registered-resource? kind where]
+  (if-not (seq target-map)
+    [nil []]
     (reduce-kv
-      (fn [m target value]
-        (assoc m (validate-target-key! target registered-resource? where kind) value))
-      {}
+      (fn [[m nils] target value]
+        (let [[outcome scope-or-id] (resolve-target-scope target)]
+          (case outcome
+            :nil-resolved [m (conj nils scope-or-id)]
+            :resolved     [(assoc m (validate-target-key!
+                                      target scope-or-id registered-resource? where kind)
+                                  value)
+                           nils])))
+      [{} []]
       target-map)))
 
 ;; ---- mutation INSTANCE id validation (Spec 016 §Resource identity) --------
@@ -504,15 +577,6 @@
 ;; This namespace owns the PURE normalization (raw form -> canonical descriptor
 ;; vector); the impure per-descriptor scope resolution + the engine dispatch fx
 ;; live in `mutation-events` (it needs the registry + app-db + trace).
-
-(def same-scope-marker
-  "The descriptor `:scope` marker meaning \"the mutation's resolved
-  (execution) scope\" — the DEFAULT when a descriptor omits `:scope`, and the
-  meaning of the bare tag-set shorthand (Spec 016 §Scoped invalidation
-  descriptors). Resolved to the concrete mutation scope by the events layer at
-  settle time; it is NOT itself a literal cache scope (it never reaches the
-  cache key)."
-  :rf.scope/same)
 
 (defn invalidation-descriptor-error
   "Build the canonical thrown-error shape (Spec 009 §The thrown-error shape)

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -107,6 +107,15 @@
   ([args failure] (rf/dispatch-sync (conj (:on-failure args) {:kind :failure :failure failure})))
   ([args failure opts] (rf/dispatch-sync (conj (:on-failure args) {:kind :failure :failure failure}) opts)))
 
+(defn- art-target
+  "The map-form exact target (EP-0016 Rider 2 — the only public input form for
+  `:populates` / `:patches`) for the `:r/article {:slug \"w\"}` global key the
+  patch/populate tests use. Its canonical STORAGE key is
+  `(state/scoped-resource-key :rf.scope/global :r/article {:slug \"w\"})`, the
+  `rkey` the entry-lookup assertions read."
+  ([] (art-target "w"))
+  ([slug] {:resource :r/article :params {:slug slug} :scope :rf.scope/global}))
+
 (defn- record-mutation-traces!
   "Run `body-fn` with a trace listener installed; return the vector of every
   `:rf.mutation/*`-operation trace event emitted during it (capture order)."
@@ -321,7 +330,7 @@
                      {:params-schema [:map [:slug :string]]
                       :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
                       :patches (fn [_params result]
-                                 {rkey (fn [old _result] (merge old result))})})
+                                 {(art-target) (fn [old _result] (merge old result))})})
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :r/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:view :a]}])
@@ -356,7 +365,7 @@
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
                       :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
-                      :populates (fn [_params result] {rkey result})})
+                      :populates (fn [_params result] {(art-target) result})})
     (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :ms1}])
     (reply-success! @last-managed-args {:title "seed"} {:rf.world/inputs {:time-ms completed-at}})
     (testing "the instance :settled-at is EXACTLY the reply completion time"
@@ -393,7 +402,7 @@
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
                       :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
-                      :populates (fn [_params result] {rkey result})})
+                      :populates (fn [_params result] {(art-target) result})})
     ;; no prior ensure — the populate SEEDS the entry from the mutation result
     (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :pop1}])
     (reply-success! @last-managed-args {:slug "w" :title "Fresh"})
@@ -421,7 +430,7 @@
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
                       :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
-                      :populates (fn [_params result] {rkey result})})
+                      :populates (fn [_params result] {(art-target) result})})
     (reset! scheduled-timers [])
     ;; no prior ensure — the populate SEEDS an ownerless entry
     (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :pgc1}])
@@ -459,7 +468,7 @@
                      {:params-schema [:map [:slug :string]]
                       :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
                       :patches (fn [_params result]
-                                 {rkey (fn [old _result] (merge old result))})})
+                                 {(art-target) (fn [old _result] (merge old result))})})
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :r/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:view :a]}])
@@ -486,7 +495,7 @@
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
                       :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
-                      :populates (fn [_params result] {rkey result})})
+                      :populates (fn [_params result] {(art-target) result})})
     (reset! scheduled-timers [])
     (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :pnp1}])
     (reply-success! @last-managed-args {:slug "w" :title "Fresh"})
@@ -747,6 +756,11 @@
 ;; `mutation-registry-rejects-non-edn-params` does, and proves the
 ;; dispatch-path fail-closed behavior by OBSERVING no partial cache mutation).
 
+;; The map-form exact target is the only public input form (EP-0016 Rider 2 /
+;; slice 6). The events layer RESOLVES each target map's :scope to a concrete
+;; value first, then `validate-target-key!` validates the [resolved-scope
+;; resource params] identity. These unit tests pass the resolved scope directly.
+
 (deftest validate-target-key-rejects-unregistered-resource
   ;; rf2-3yyaur — a controlled patch / populate targeting an UNREGISTERED
   ;; resource fails CLOSED (the patched / seeded entry would be unreachable by
@@ -755,36 +769,48 @@
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
           (mstate/validate-target-key!
-            [:rf.scope/global :r/never-registered {:slug "w"}]
-            (fn [_] false) 'test :patches)))))
+            {:resource :r/never-registered :params {:slug "w"}}
+            :rf.scope/global (fn [_] false) 'test :patches)))))
 
-(deftest validate-target-key-rejects-malformed-key
-  ;; rf2-3yyaur — a target that is not a 3-element scoped key is rejected.
-  (testing "a 1-element key is malformed"
+(deftest validate-target-key-rejects-malformed-target
+  ;; EP-0016 Rider 2 — the public input is the map form {:resource :params
+  ;; :scope}; a non-map (a bare tuple, a keyword) is rejected loudly.
+  (testing "a tuple (the internal storage form) is NOT a public input"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/validate-target-key! [:r/article] (constantly true) 'test :populates))))
-  (testing "a non-vector target is malformed"
+          (mstate/validate-target-key!
+            [:rf.scope/global :r/article {:slug "w"}] :rf.scope/global
+            (constantly true) 'test :populates))))
+  (testing "a non-map target is rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/validate-target-key! :r/article (constantly true) 'test :patches))))
-  (testing "a non-keyword resource id is rejected"
+          (mstate/validate-target-key! :r/article :rf.scope/global (constantly true) 'test :patches))))
+  (testing "a map missing :resource is rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/validate-target-key! [:rf.scope/global "article" {}] (constantly true) 'test :patches)))))
+          (mstate/validate-target-key! {:params {}} :rf.scope/global (constantly true) 'test :patches))))
+  (testing "a non-keyword :resource is rejected"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
+          (mstate/validate-target-key! {:resource "article" :params {}} :rf.scope/global
+                                       (constantly true) 'test :patches)))))
 
 (deftest validate-target-key-rejects-reserved-scope-typo
   ;; rf2-3yyaur — a bare framework-reserved :rf.scope/* keyword outside the
   ;; closed enum (a typo) would silently write under a wrong scope — rejected.
+  ;; The events layer resolves the map :scope first; a typo'd literal resolves
+  ;; to itself and is caught here.
   (testing ":rf.scope/glabal (a typo) is rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
           (mstate/validate-target-key!
-            [:rf.scope/glabal :r/article {:slug "w"}] (constantly true) 'test :patches))))
+            {:resource :r/article :params {:slug "w"}} :rf.scope/glabal
+            (constantly true) 'test :patches))))
   (testing "the closed reserved policy :rf.scope/global is a legitimate literal scope"
     (is (= [:rf.scope/global :r/article {:slug "w"}]
            (mstate/validate-target-key!
-             [:rf.scope/global :r/article {:slug "w"}] (constantly true) 'test :patches)))))
+             {:resource :r/article :params {:slug "w"}} :rf.scope/global
+             (constantly true) 'test :patches)))))
 
 (deftest validate-target-key-rejects-non-edn-params
   ;; rf2-3yyaur — a host value in the target's params / scope reaches the
@@ -794,31 +820,48 @@
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
           (mstate/validate-target-key!
-            [:rf.scope/global :r/article {:slug "w" :cb (fn [])}] (constantly true) 'test :patches))))
+            {:resource :r/article :params {:slug "w" :cb (fn [])}} :rf.scope/global
+            (constantly true) 'test :patches))))
   (testing "non-EDN scope rejected"
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
           (mstate/validate-target-key!
-            [(fn []) :r/article {:slug "w"}] (constantly true) 'test :patches)))))
+            {:resource :r/article :params {:slug "w"}} (fn [])
+            (constantly true) 'test :patches)))))
 
 (deftest validate-target-map-canonicalizes-and-rejects-whole-map
-  ;; rf2-3yyaur — one bad target rejects the WHOLE arm (no partial write), and
-  ;; valid targets are re-keyed by the canonical scoped key.
-  (testing "a single bad target rejects the whole map"
-    (is (thrown-with-msg?
-          #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
-          (mstate/validate-target-map!
-            {[:rf.scope/global :r/article {:slug "w"}] :ok
-             [:rf.scope/glabal :r/article {:slug "x"}] :bad}
-            (constantly true) :patches 'test))))
-  (testing "an all-valid map is re-keyed by the canonical scoped key"
-    (is (= {[:rf.scope/global :r/article {:slug "w"}] :v}
-           (mstate/validate-target-map!
-             {[:rf.scope/global :r/article {:slug "w"}] :v}
-             (constantly true) :populates 'test))))
-  (testing "an empty / nil map returns nil (no-op arm)"
-    (is (nil? (mstate/validate-target-map! {} (constantly true) :patches 'test)))
-    (is (nil? (mstate/validate-target-map! nil (constantly true) :patches 'test)))))
+  ;; rf2-3yyaur / EP-0016 Rider 2 — one bad target rejects the WHOLE arm (no
+  ;; partial write), valid targets are re-keyed by the canonical STORAGE key,
+  ;; and a {:from-db …} target whose scope resolves nil is FAIL-CLOSED (dropped,
+  ;; recorded in the returned nil-resolved ids — never an implicit global).
+  ;; The injected `resolve-target-scope` resolves :rf.scope/same (here the
+  ;; supplied mut-scope) and a fake {:from-db :nope} reference to nil.
+  (let [resolve-scope (fn [{:keys [scope]}]
+                        (cond
+                          (nil? scope)                 [:resolved :rf.scope/global]
+                          (= scope {:from-db :nope})   [:nil-resolved :nope]
+                          :else                        [:resolved scope]))]
+    (testing "a single bad target (typo scope) rejects the whole map"
+      (is (thrown-with-msg?
+            #?(:clj Throwable :cljs js/Error) #"mutation-invalid-target"
+            (mstate/validate-target-map!
+              {{:resource :r/article :params {:slug "w"} :scope :rf.scope/global} :ok
+               {:resource :r/article :params {:slug "x"} :scope :rf.scope/glabal} :bad}
+              resolve-scope (constantly true) :patches 'test))))
+    (testing "an all-valid map is re-keyed by the canonical STORAGE key (and no nils)"
+      (is (= [{[:rf.scope/global :r/article {:slug "w"}] :v} []]
+             (mstate/validate-target-map!
+               {{:resource :r/article :params {:slug "w"} :scope :rf.scope/global} :v}
+               resolve-scope (constantly true) :populates 'test))))
+    (testing "a {:from-db …} target that resolves nil is FAIL-CLOSED — dropped,
+              its resolver id recorded as nil-resolved (never an implicit global)"
+      (is (= [{} [:nope]]
+             (mstate/validate-target-map!
+               {{:resource :r/article :params {:slug "w"} :scope {:from-db :nope}} :v}
+               resolve-scope (constantly true) :populates 'test))))
+    (testing "an empty / nil map returns [nil []] (no-op arm)"
+      (is (= [nil []] (mstate/validate-target-map! {} resolve-scope (constantly true) :patches 'test)))
+      (is (= [nil []] (mstate/validate-target-map! nil resolve-scope (constantly true) :patches 'test))))))
 
 (deftest bad-patch-target-fails-closed-no-partial-cache-mutation
   ;; rf2-3yyaur — end-to-end: a mutation whose :patches targets an unregistered
@@ -832,8 +875,10 @@
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
                       :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
-                      :patches (fn [_p _r] {good-key (fn [old r] (merge old r))
-                                            bad-key  (fn [old _] old)})})
+                      :patches (fn [_p _r] {{:resource :r/article :params {:slug "w"} :scope :rf.scope/global}
+                                            (fn [old r] (merge old r))
+                                            {:resource :r/never-registered :params {:slug "w"} :scope :rf.scope/global}
+                                            (fn [old _] old)})})
     ;; seed the good entry so a (wrongly) partial patch would be observable
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :r/article :scope :rf.scope/global
@@ -858,7 +903,7 @@
                       :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
                       ;; target params spelled in a different key order — must
                       ;; canonicalize to the same identity the read path stored.
-                      :patches (fn [_p _r] {[:rf.scope/global :r/article {:slug "w"}]
+                      :patches (fn [_p _r] {{:resource :r/article :params {:slug "w"} :scope :rf.scope/global}
                                             (fn [old result] (merge old result))})})
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :r/article :scope :rf.scope/global
@@ -1048,7 +1093,7 @@
     (rf/reg-mutation :m/save
                      {:params-schema [:map [:slug :string]]
                       :request   (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
-                      :populates (fn [_params result] {rkey result})})
+                      :populates (fn [_params result] {(art-target) result})})
     (rf/dispatch-sync [:rf.mutation/execute
                        {:mutation :m/save :params {:slug "w"} :instance :rc1
                         :reply-to [:test/save-replied]}])
@@ -1132,7 +1177,7 @@
       (rf/reg-mutation :m/save
                        {:params-schema [:map [:slug :string]]
                         :request   (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
-                        :populates (fn [_params result] {rkey result})})
+                        :populates (fn [_params result] {(art-target) result})})
       ;; the continuation handler reads the runtime-db AT continuation time:
       ;; both the instance settle AND the populated entry must already be in.
       (rf/reg-event-fx :test/save-replied

--- a/implementation/resources/test/re_frame/resources_populate_exact_target_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_populate_exact_target_cljs_test.cljc
@@ -1,0 +1,394 @@
+(ns re-frame.resources-populate-exact-target-cljs-test
+  "Populate-as-authoritative-load + map-form exact targets (rf2-h6n40v,
+  EP-0016 Riders 1 + 2 / slice 6 — Spec 016 §Populate is an authoritative load
+  + §Map-form exact resource targets).
+
+  Slice 6 completes two riders the earlier slices set up but did not consume:
+
+    R2 — the MAP-FORM exact target `{:resource :params :scope}` is the ONLY
+         public input form for `:populates` / `:patches` (no tuple migration
+         window; the tuple is the internal STORAGE key). The map's `:scope` may
+         be concrete, `:rf.scope/same` (the default), or a `{:from-db …}` named
+         resolver reference resolved against the settle-time app-db; a
+         nil-resolving reference is FAIL-CLOSED (the target is dropped, never
+         written under an implicit global).
+
+    R1 — a `:populates` is an AUTHORITATIVE load: the populated key becomes
+         `:loaded`/fresh with the resource's stored shape, and is EXEMPT from
+         the SAME mutation's invalidation refetch (even when an `:invalidates`
+         tag matches it) UNLESS a descriptor opts in with
+         `:refetch-populated? true`.
+
+  These JVM+CLJS unit tests pin the slice's semantics:
+
+    1. a map-form populate writes the EXACT canonical scoped key
+       authoritatively (loaded/fresh, the resource's stored shape, its tags);
+    2. a map-form `:scope {:from-db …}` populate resolves the scoped key
+       against the settle-time app-db (the session feed case);
+    3. a populated key is EXEMPT from the same mutation's invalidation refetch
+       by default — even when the invalidation tag matches it;
+    4. `:refetch-populated? true` re-enables the same-mutation refetch of the
+       populated key (the partial-reply case);
+    5. the populate-exempt composes with the slice-5 invalidation descriptors
+       AND the slice-4 `:reply-to` continuation (the continuation still fires);
+    6. a STALE / superseded settle does NOT populate (the mandatory
+       stale-suppression boundary);
+    7. a map-form `:patches` updates the exact key only;
+    8. a `{:from-db …}` populate target that resolves NIL is FAIL-CLOSED
+       (dropped, recorded in the settlement trace — never an implicit global).
+
+  The transport is exercised end-to-end by overriding `:rf.http/managed` with a
+  capturing stub that synthesises the transport's reply-event-append shape."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   ;; load-bearing side-effecting requires: register the :rf.resource/* +
+   ;; :rf.mutation/* events + subs + the generation cofx/fx.
+   [re-frame.resources]
+   [re-frame.resources.state :as state]
+   [re-frame.registrar :as registrar]
+   [re-frame.resources.test-support]
+   [re-frame.http-managed]
+   [re-frame.schemas]
+   [re-frame.test-support :as core-test-support]
+   [re-frame.trace.tooling :as trace-tooling]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+;; ---- capturing transport ---------------------------------------------------
+
+(def ^:private last-managed-args (atom nil))
+
+(defn- init! []
+  (registrar/clear-kind! :resource-scope)
+  ;; the named db-derived viewer-session resolver (EP-0016 D3 canonical form)
+  (rf/reg-resource-scope :t/session
+    {:inputs  {:username [:db [:auth :user :username]]}
+     :resolve (fn [{:keys [username]} _ctx]
+                (when username [:rf.scope/session {:username username}]))})
+  (rf/reg-event-db :t/login (fn [db [_ username]] (assoc-in db [:auth :user :username] username))))
+
+(defn- capturing-transport-fixture [f]
+  (reset! last-managed-args nil)
+  (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (rf/reg-fx :rf.resource/schedule-timers (fn [_ _] nil))
+  (f))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter :init-fn init!}
+       :cljs {:adapter reagent-adapter/adapter :init-fn init!}))
+  capturing-transport-fixture)
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- runtime-db [] (rf/runtime-db-value :rf/default))
+(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+(defn- instance [instance-id]
+  (get-in (runtime-db) [:rf.runtime/mutations instance-id]))
+
+(defn- reply-success! [args result]
+  (rf/dispatch-sync (conj (:on-success args) {:kind :success :value result})))
+
+(def ^:private global-article-key
+  (state/scoped-resource-key :rf.scope/global :r/article {:slug "w"}))
+
+(defn- session-feed-key [u]
+  (state/scoped-resource-key [:rf.scope/session {:username u}] :r/feed {}))
+
+(defn- reg-article-resource! []
+  (rf/reg-resource :r/article
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}})
+     :tags (fn [{:keys [slug]} _] #{[:article slug] [:article-list]})}))
+
+(defn- reg-feed-resource! []
+  (rf/reg-resource :r/feed
+    {:scope {:from-db :t/session}
+     :params-schema [:map]
+     :request (fn [_p _] {:request {:method :get :url "/feed"}})
+     :tags (fn [_p _] #{[:feed] [:article-list]})}))
+
+(defn- own-loaded!
+  "Ensure + load an entry so it has an ACTIVE owner (so a subsequent
+  invalidation would REFETCH it). Resets `last-managed-args` after."
+  [payload]
+  (rf/dispatch-sync [:rf.resource/ensure payload])
+  (reply-success! @last-managed-args {:seed true})
+  (reset! last-managed-args nil))
+
+(defn- succeeded-trace
+  "Run `body-fn`; return the LAST `:rf.mutation/succeeded` trace event's
+  top-level data map (its facets ride under `:tags`)."
+  [body-fn]
+  (let [seen (atom [])
+        k    ::succeeded-recorder]
+    (trace-tooling/register-listener!
+      k (fn [ev] (when (= :rf.mutation/succeeded (:operation ev)) (swap! seen conj ev))))
+    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    (:tags (last @seen))))
+
+;; ===========================================================================
+;; 1. A map-form populate writes the EXACT canonical scoped key authoritatively
+;; ===========================================================================
+
+(deftest map-form-populate-writes-exact-key-authoritatively
+  ;; Validation 11/12: the public input is the map form {:resource :params
+  ;; :scope}; it writes the EXACT canonical storage key, loaded/fresh, with the
+  ;; resource's stored shape + tags — identical to a fetched entry.
+  (reg-article-resource!)
+  (rf/reg-mutation :m/save
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+     ;; map-form target with a concrete :scope (EP-0016 Rider 2 — the only
+     ;; public input form). No prior ensure — the populate SEEDS the entry.
+     :populates (fn [{:keys [slug]} result]
+                  {{:resource :r/article :params {:slug slug} :scope :rf.scope/global} result})})
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :p1}])
+  (reply-success! @last-managed-args {:slug "w" :title "Fresh"})
+  (testing "the map-form populate seeded the EXACT canonical scoped key,
+            :loaded with the result as :data + the resource's own tags"
+    (let [e (entry global-article-key)]
+      (is (= :loaded (:status e)))
+      (is (= {:slug "w" :title "Fresh"} (:data e)))
+      (is (nil? (:invalidated-at e)) "fresh — not stale")
+      (is (= #{[:article "w"] [:article-list]} (:tags e)))))
+  (testing "the populated key is recorded on the instance patch-summary (the
+            canonical STORAGE tuple, not the input map)"
+    (is (= [global-article-key]
+           (:populated (:patch-summary (instance :p1)))))))
+
+;; ===========================================================================
+;; 2. A {:from-db …} populate :scope resolves the scoped key at settle time
+;; ===========================================================================
+
+(deftest map-form-populate-from-db-scope-resolves-at-settle
+  ;; Validation 7/9: a map-form target whose :scope is a {:from-db …} resolver
+  ;; reference resolves the EXACT scoped key against the settle-time app-db (the
+  ;; session feed case) — the populated key lands under the resolved session.
+  (reg-feed-resource!)
+  (rf/reg-mutation :m/save-feed
+    {:scope :rf.scope/global
+     :params-schema [:map]
+     :request (fn [_p _] {:request {:method :put :url "/feed"}})
+     :populates (fn [_p result]
+                  {{:resource :r/feed :params {} :scope {:from-db :t/session}} result})})
+  (rf/dispatch-sync [:t/login "jake"])
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save-feed :params {} :instance :pf1}])
+  (reply-success! @last-managed-args {:articles [:x]})
+  (testing "the {:from-db} populate seeded jake's SESSION-scoped feed key"
+    (let [e (entry (session-feed-key "jake"))]
+      (is (= :loaded (:status e)))
+      (is (= {:articles [:x]} (:data e)))))
+  (testing "no OTHER session was touched (the exact resolved key only)"
+    (is (nil? (entry (session-feed-key "abel"))))))
+
+;; ===========================================================================
+;; 3. A populated key is EXEMPT from the same mutation's invalidation refetch
+;; ===========================================================================
+
+(deftest populated-key-exempt-from-same-mutation-refetch
+  ;; Validation 11 (the core slice-6 rule): a mutation that POPULATES an
+  ;; article-detail key and then INVALIDATES a tag that matches that same key
+  ;; must NOT immediately refetch the key it just learned from the reply (a
+  ;; populate is an authoritative load). The detail entry stays fresh; only the
+  ;; OTHER tagged entry (a list) refetches.
+  (reg-article-resource!)
+  ;; the detail key has an ACTIVE owner — WITHOUT the exemption it would refetch
+  (own-loaded! {:resource :r/article :scope :rf.scope/global :params {:slug "w"} :owner [:v :detail]})
+  ;; a SEPARATE list entry (also :article-list tagged, but a different key) is
+  ;; owned too — it MUST refetch (the populate did not seed it).
+  (rf/reg-resource :r/article-list
+    {:scope :rf.scope/global
+     :params-schema [:map]
+     :request (fn [_p _] {:request {:method :get :url "/articles"}})
+     :tags (fn [_p _] #{[:article-list]})})
+  (own-loaded! {:resource :r/article-list :scope :rf.scope/global :params {} :owner [:v :list]})
+  (rf/reg-mutation :m/favorite
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :post :url (str "/a/" slug "/fav")}})
+     ;; populate the detail key authoritatively from the reply…
+     :populates (fn [{:keys [slug]} result]
+                  {{:resource :r/article :params {:slug slug} :scope :rf.scope/global} result})
+     ;; …then invalidate the broad article-list tag (which ALSO matches the
+     ;; just-populated detail key, since the article resource carries it).
+     :invalidates (fn [_p _r] #{[:article-list]})})
+  (let [list-key (state/scoped-resource-key :rf.scope/global :r/article-list {})
+        trace    (succeeded-trace
+                   #(do (rf/dispatch-sync [:rf.mutation/execute
+                                           {:mutation :m/favorite :params {:slug "w"} :instance :f1}])
+                        (reply-success! @last-managed-args {:slug "w" :title "fav'd" :favorited true})))]
+    (testing "the POPULATED detail key stayed FRESH (loaded, the populated
+              value, NOT re-staled or refetched) — populate is authoritative"
+      (let [e (entry global-article-key)]
+        (is (= :loaded (:status e)))
+        (is (= {:slug "w" :title "fav'd" :favorited true} (:data e)))
+        (is (nil? (:invalidated-at e)) "the populated key was exempt — not re-staled")
+        (is (not (contains? #{:loading :fetching} (:status e))) "no refetch armed")))
+    (testing "the OTHER :article-list-tagged key (NOT populated) DID refetch"
+      (let [e (entry list-key)]
+        (is (contains? #{:loading :fetching} (:status e)))))
+    (testing "the settlement trace records the populate-exempt key"
+      (is (= [global-article-key] (:populate-exempt (:invalidation trace)))
+          "the populated key is named as exempt from same-mutation refetch"))))
+
+;; ===========================================================================
+;; 4. :refetch-populated? true re-enables the same-mutation refetch
+;; ===========================================================================
+
+(deftest refetch-populated-opts-back-into-same-mutation-refetch
+  ;; Validation 11 (the opt-in half): when the reply is PARTIAL relative to the
+  ;; full GET, a descriptor sets :refetch-populated? true so the just-populated
+  ;; key IS refetched by this same mutation's invalidation pass.
+  (reg-article-resource!)
+  (own-loaded! {:resource :r/article :scope :rf.scope/global :params {:slug "w"} :owner [:v :detail]})
+  (rf/reg-mutation :m/save
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+     :populates (fn [{:keys [slug]} result]
+                  {{:resource :r/article :params {:slug slug} :scope :rf.scope/global} result})
+     ;; the descriptor opts the populated key BACK into the same-mutation refetch
+     :invalidates (fn [{:keys [slug]} _r]
+                    [{:scope :rf.scope/global :tags #{[:article slug]} :refetch-populated? true}])})
+  (let [trace (succeeded-trace
+                #(do (rf/dispatch-sync [:rf.mutation/execute
+                                        {:mutation :m/save :params {:slug "w"} :instance :rp1}])
+                     (reply-success! @last-managed-args {:slug "w" :title "partial"})))]
+    (testing ":refetch-populated? true — the populated key WAS refetched by this
+              same mutation's invalidation pass (a fresh GET lowered)"
+      (let [e (entry global-article-key)]
+        (is (contains? #{:loading :fetching} (:status e)))
+        (is (= {:method :get :url "/a/w"} (:request @last-managed-args)))))
+    (testing "the trace records an EMPTY populate-exempt set (the opt-in cleared it)"
+      (is (= [] (:populate-exempt (:invalidation trace)))))))
+
+;; ===========================================================================
+;; 5. Composes with slice-5 descriptors AND the slice-4 :reply-to continuation
+;; ===========================================================================
+
+(deftest populate-exempt-composes-with-descriptors-and-reply-to
+  ;; The populate-exempt pass composes with a per-descriptor scoped invalidation
+  ;; (the favorite/feed case) AND the :reply-to completion continuation: the
+  ;; populated detail stays fresh, the session feed is invalidated by a
+  ;; {:from-db} descriptor, and the continuation still fires after.
+  (let [replied (atom [])]
+    (reg-article-resource!)
+    (reg-feed-resource!)
+    (rf/reg-event-fx :test/saved (fn [_ ev] (swap! replied conj ev) {}))
+    (rf/dispatch-sync [:t/login "jake"])
+    ;; jake's feed is ownerless (so a {:from-db} descriptor leaves it stale)
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :r/feed :scope {:from-db :t/session}
+                                            :params {} :owner [:v :feed]}])
+    (reply-success! @last-managed-args {:seed true})
+    (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/feed :scope {:from-db :t/session}
+                                                   :params {} :owner [:v :feed]}])
+    ;; the detail key has an active owner (so WITHOUT the exemption it'd refetch)
+    (own-loaded! {:resource :r/article :scope :rf.scope/global :params {:slug "w"} :owner [:v :detail]})
+    (rf/reg-mutation :m/favorite
+      {:scope :rf.scope/global
+       :params-schema [:map [:slug :string]]
+       :request (fn [{:keys [slug]} _] {:request {:method :post :url (str "/a/" slug "/fav")}})
+       :populates (fn [{:keys [slug]} result]
+                    {{:resource :r/article :params {:slug slug} :scope :rf.scope/global} result})
+       :invalidates (fn [{:keys [slug]} _r]
+                      [{:scope :rf.scope/global :tags #{[:article slug] [:article-list]}}
+                       {:scope {:from-db :t/session} :tags #{[:feed]}}])})
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/favorite :params {:slug "w"} :instance :c1
+                                             :reply-to [:test/saved]}])
+    (reply-success! @last-managed-args {:slug "w" :favorited true})
+    (testing "the populated detail key stayed fresh (exempt from the global
+              [:article …] descriptor that matches it)"
+      (let [e (entry global-article-key)]
+        (is (= :loaded (:status e)))
+        (is (nil? (:invalidated-at e)))))
+    (testing "the {:from-db} descriptor still invalidated jake's session feed"
+      (is (some? (:invalidated-at (entry (session-feed-key "jake"))))))
+    (testing "the :reply-to continuation fired exactly once, after the consequences"
+      (is (= 1 (count @replied)))
+      (is (= :ok (:status (second (first @replied))))))))
+
+;; ===========================================================================
+;; 6. A stale / superseded settle does NOT populate
+;; ===========================================================================
+
+(deftest stale-settle-does-not-populate
+  ;; The populate path is gated behind the live-instance acceptance — a
+  ;; superseded reply applies NO cache consequence, so it never seeds a key.
+  (reg-article-resource!)
+  (rf/reg-mutation :m/save
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+     :populates (fn [{:keys [slug]} result]
+                  {{:resource :r/article :params {:slug slug} :scope :rf.scope/global} result})})
+  ;; execute, capture its reply args, then SUPERSEDE by re-executing under the
+  ;; same instance id (new generation / work-id) — the first reply is now stale.
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :s1}])
+  (let [stale-args @last-managed-args]
+    (reset! last-managed-args nil)
+    (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :s1}])
+    ;; deliver the STALE first reply — it must be suppressed, no populate
+    (reply-success! stale-args {:slug "w" :title "stale"})
+    (testing "the superseded reply did NOT populate the key"
+      (is (nil? (entry global-article-key))))))
+
+;; ===========================================================================
+;; 7. A map-form :patches updates the exact key only (no tag targeting)
+;; ===========================================================================
+
+(deftest map-form-patch-updates-exact-key-only
+  ;; Validation 12: a map-form :patches target updates exactly the resolved key
+  ;; (transforms its existing :data); a key with no entry is a no-op (a patch
+  ;; transforms; populate seeds).
+  (reg-article-resource!)
+  (rf/reg-mutation :m/patch
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+     :patches (fn [{:keys [slug]} result]
+                {{:resource :r/article :params {:slug slug} :scope :rf.scope/global}
+                 (fn [old _r] (merge old result))})})
+  ;; seed real data on the owned entry (a single ensure + reply)
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :r/article :scope :rf.scope/global
+                                          :params {:slug "w"} :owner [:v :a]}])
+  (reply-success! @last-managed-args {:title "old" :views 5})
+  (reset! last-managed-args nil)
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/patch :params {:slug "w"} :instance :pt1}])
+  (reply-success! @last-managed-args {:title "new"})
+  (testing "the map-form patch transformed the EXACT key's :data in place"
+    (let [e (entry global-article-key)]
+      (is (= {:title "new" :views 5} (:data e)))
+      (is (= :loaded (:status e))))))
+
+;; ===========================================================================
+;; 8. A {:from-db …} populate target that resolves NIL is FAIL-CLOSED
+;; ===========================================================================
+
+(deftest from-db-populate-target-nil-fails-closed
+  ;; A map-form populate whose {:from-db …} :scope resolves NIL (no logged-in
+  ;; user) is DROPPED — no key is seeded under an implicit global, and the
+  ;; settlement trace names the unresolved resolver id.
+  (reg-feed-resource!)
+  (rf/reg-mutation :m/save-feed
+    {:scope :rf.scope/global
+     :params-schema [:map]
+     :request (fn [_p _] {:request {:method :put :url "/feed"}})
+     :populates (fn [_p result]
+                  {{:resource :r/feed :params {} :scope {:from-db :t/session}} result})})
+  ;; NOT logged in — the resolver's :inputs are absent, so {:from-db :t/session}
+  ;; resolves nil.
+  (let [trace (succeeded-trace
+                #(do (rf/dispatch-sync [:rf.mutation/execute
+                                        {:mutation :m/save-feed :params {} :instance :n1}])
+                     (reply-success! @last-managed-args {:articles [:x]})))]
+    (testing "FAIL-CLOSED — NO session feed key was seeded under any scope"
+      (is (nil? (entry (session-feed-key "jake"))))
+      (is (nil? (entry (state/scoped-resource-key :rf.scope/global :r/feed {})))
+          "and never under an implicit global"))
+    (testing "the dropped target's resolver id is recorded as :target-unresolved"
+      (is (= [:t/session] (:target-unresolved (:patch-summary trace)))))))


### PR DESCRIPTION
EP-0016 action-wave **slice 6** (populate + exact-target), per `docs/EP/EP-0016-resource-mutation-completion.md` §Reference Implementation Plan slice 6 + Riders 1 & 2. Slices 1–5 merged; slice-5 parsed `:refetch-populated?` on the invalidation descriptor but did not consume it — **this slice does**.

## Populate contract

**Rider 2 — map-form exact targets (the only public input form).** `:populates` / `:patches` return `{target value}` where each KEY is the map `{:resource :params :scope}`. The scoped-key tuple `[scope resource-id params]` is now the **internal storage representation only** (no migration window; pre-alpha, no external consumers — EP-0016 issue 4). The map's `:scope` may be concrete, `:rf.scope/same` (the default), `:rf.scope/global`, or a `{:from-db …}` named-resolver reference. The events layer resolves each target's declared scope against the **settle-time app-db** (the single use-time rule), then `validate-target-key!` validates + canonicalizes the resolved `[scope resource-id params]` identity fail-closed before any cache write. A `{:from-db …}` target that resolves **nil is fail-closed**: dropped (never written under an implicit global) and recorded on the settlement trace as `:target-unresolved`.

**Rider 1 — populate is an authoritative load.** A key a same-mutation `:populates` seeds is fresh for the mutation result, so it is **exempt from that same mutation's invalidation refetch** even when an `:invalidates` tag matches it. The populated keys ride into each descriptor's `:rf.resource/invalidate-tags` dispatch as `:exempt-keys`, and the engine excludes them from the matched set **before** the stale-mark / refetch decision (kept fresh, no refetch armed). A descriptor opts the populated key back in with `:refetch-populated? true` (the partial-reply case) — then no exempt set is passed for that descriptor. Exempt evidence rides the settlement trace's `:invalidation` facet as `:populate-exempt`; the invalidation engine summary carries `:exempt`.

Composes with the slice-4 `:reply-to` continuation and the slice-5 scoped invalidation descriptors; verifies frame + `:work/id` + generation (a stale / superseded settle applies no populate). In-repo tuple writers (`examples/reagent/realworld_resources/mutations.cljs`) swept to the map form.

## Test deltas

- **New** `implementation/resources/test/re_frame/resources_populate_exact_target_cljs_test.cljc` — 8 deftests: (1) map-form populate writes the exact canonical key authoritatively (loaded/fresh, stored shape, tags); (2) `{:from-db …}` populate scope resolves the scoped key at settle time; (3) populated key exempt from the same mutation's refetch even when the tag matches; (4) `:refetch-populated? true` re-enables the same-mutation refetch; (5) composes with descriptors + `:reply-to`; (6) stale/superseded settle does not populate; (7) map-form `:patches` updates the exact key only; (8) nil-resolving `{:from-db …}` populate target is fail-closed.
- **Migrated** `resources_mutation_cljs_test.cljc` populate/patch registrations + `validate-target-key!` / `validate-target-map!` unit tests to the map-form input contract (new signatures; `validate-target-map!` now returns `[canonical-map nil-resolved-ids]`).

## Quality gates

- `cd implementation/resources && clojure -M:test` — **290 tests, 1103 assertions, 0 failures, 0 errors** (8 new slice-6 + the migrated mutation tests + the slice-5 descriptor suite).
- `cd implementation && npm run test:cljs` — **6605 tests, 24174 assertions, 0 failures, 0 errors**.
- `mkdocs build --strict` — **not required**: no `spec/` file touched. The slice-1 Spec 016 amendment (§Populate is an authoritative load + §Map-form exact resource targets) already documents both riders; this slice implements them.

Fence respected: `implementation/resources` (the populate path + `:refetch-populated?` consumption) + tests + the in-repo example sweep. No `implementation/core` or machines touched. Belongs to epic rf2-fi6tda.