### PR TITLE
feat(core): EP-0013 D1 stage-4 — realm-owned adapter + host-transient singletons (rf2-0lq5cd)

### DIFF
--- a/implementation/core/src/re_frame/realm.cljc
+++ b/implementation/core/src/re_frame/realm.cljc
@@ -12,8 +12,12 @@
 
   ## D1 is INTERNAL — no public source break, no public constructor
 
-  This is EP-0013 staging 1-3: an internal realm record + a default realm +
-  realm-owned registrar + a frame realm-reference. **No public `rf/realm`
+  This is EP-0013 staging 1-4: an internal realm record + a default realm +
+  realm-owned registrar + a frame realm-reference (stages 1-3), plus the
+  realm-owned adapter SELECTION + host-transient subsystem descriptor table
+  (stage 4 — `re-frame.substrate.adapter` is now the access seam over the
+  realm's `:adapter` slot, and the framework's host-transient side-tables are
+  inventoried in the realm's `:host-transient` slot). **No public `rf/realm`
   constructor and no realm-targeted public query ship here** (EP-0013 issue
   1 — those names are reserved vocabulary, exposure graduates internal-first;
   D2/later stages). Everything in a single-realm app routes through ONE
@@ -75,8 +79,23 @@
 ;;                    default realm holds a REFERENCE to the existing
 ;;                    process-global `registrar/kind->id->metadata` atom, so
 ;;                    the registry shape + read/write API are unchanged.
-;;   :adapter         the realm's adapter SELECTION (capability); render
-;;                    roots own concrete instances. Absent until installed.
+;;   :adapter         the realm's adapter SELECTION (the installed adapter
+;;                    spec map / capability); render roots own concrete
+;;                    instances. Absent until `install-adapter!` seats one;
+;;                    the install/dispose lifecycle is realm-owned as of
+;;                    stage 4 (EP-0013 issue 5 — `re-frame.substrate.adapter`
+;;                    is now the access seam over this slot).
+;;   :adapter-disposed? the realm-owned adapter-lifecycle breadcrumb. `true`
+;;                    iff the most recent adapter lifecycle event on this
+;;                    realm was a successful `dispose-adapter!` with no
+;;                    subsequent install — distinguishes `never installed`
+;;                    (fresh realm) from `installed then torn down` so the
+;;                    delegation surfaces raise the right diagnosis
+;;                    (`:rf.error/no-adapter-installed` vs
+;;                    `:rf.error/adapter-disposed`). Absent on a fresh realm
+;;                    (treated as `false`). NOT the D2/D3-reserved
+;;                    `:lifecycle` slot, which is REALM disposal — this is the
+;;                    adapter sub-lifecycle that stage 4 moved behind the realm.
 ;;   :capabilities    :rf.capability/* → service map/record. Absent in the
 ;;                    bare default realm; late-bind hooks bridge in (D1
 ;;                    §Late-bind compatibility).
@@ -84,9 +103,17 @@
 ;;                    WITHIN the realm). Frame records still live in the
 ;;                    process `frame/frames` atom in D1; this set is the
 ;;                    realm-owned membership view.
-;;   :host-transient  subsystem-id → HostTransientDescriptor. Absent until a
-;;                    subsystem moves behind the realm (EP-0013 issue 5 — a
-;;                    later D1 slice / stage 4).
+;;   :host-transient  subsystem-id → HostTransientDescriptor — the realm-owned
+;;                    registry of the framework's non-durable process-mutable
+;;                    side-tables (HTTP in-flight handles, routing nav
+;;                    counters, machine timers, flow last-input caches, …).
+;;                    Stage 4 (EP-0013 issue 5) makes the realm the OWNER of
+;;                    this descriptor table; the side-table atoms still live in
+;;                    their producing artefacts (reached through the late-bind
+;;                    reset hooks), and a descriptor registered here records
+;;                    the subsystem's scope / teardown / test-reset so the
+;;                    realm is the single inventory of what must be torn down on
+;;                    realm/frame destroy. Absent until a subsystem registers.
 ;;
 ;; D2/D3-RESERVED, never required in D1: :app (the installed app VALUE),
 ;; :lifecycle ({:disposed? …}). Left absent here.
@@ -125,16 +152,33 @@
 ;; realm — it carries the default realm implicitly (the EP-0002 refinement
 ;; pattern). The realm is held in an atom so the (future, D2) install! /
 ;; reinstall! path can replace the realm's installed app at the realm
-;; boundary; in D1 the only mutation is the frame-membership set.
+;; boundary; the live mutations in D1 are the realm-owned adapter SELECTION
+;; (the install/dispose lifecycle, stage 4) and the host-transient descriptor
+;; table; the frame-membership set is DERIVED (never stored), so it is not a
+;; mutation of this atom.
 
 (defonce
   ^{:doc "The process realm registry: realm-id → realm map. D1 holds exactly
   one entry — the default realm. Held as an atom so a later stage can add
-  realms and so the default realm's frame-membership set can be updated in
-  place. The registry is process-wide; realm ids are unique within a
-  process (Spec-Schemas §`:rf/realm`)."}
+  realms and so the default realm's realm-owned mutable slots — the adapter
+  SELECTION (install/dispose lifecycle, stage 4) and the host-transient
+  descriptor table — can be updated in place. The registry is process-wide;
+  realm ids are unique within a process (Spec-Schemas §`:rf/realm`)."}
   realms
   (atom {default-realm-id (make-realm default-realm-id)}))
+
+(defn- update-realm!
+  "Apply `f` (+ `args`) to the realm map registered under `rid`, in place in
+  the `realms` registry. INTERNAL — the single mutation seam for the
+  realm-owned mutable slots (adapter SELECTION + host-transient). Returns the
+  updated realm map. A no-op (returns nil) for an unknown realm — D1 only ever
+  has the default realm at runtime, so this is defensive."
+  [rid f & args]
+  (rid (swap! realms
+              (fn [m]
+                (if (contains? m rid)
+                  (apply update m rid f args)
+                  m)))))
 
 (defn default-realm
   "Return the process default realm map — the realm that backs every
@@ -201,3 +245,156 @@
    (if-let [by-realm (late-bind/get-fn :realm/frames-by-realm)]
      (get (by-realm) rid #{})
      #{})))
+
+;; ---- realm-owned adapter SELECTION (EP-0013 D1 stage 4, rf2-0lq5cd) --------
+;;
+;; The adapter SELECTION — the installed adapter spec map and the
+;; adapter-disposed breadcrumb — is OWNED BY the realm (Runtime-Subsystems
+;; §Adapter Ownership: "adapter ownership belongs to a realm or render root,
+;; not to the process as such"). Stage 4 moves the two process-global
+;; `defonce` cells that used to live in `re-frame.substrate.adapter` into the
+;; realm record's `:adapter` + `:adapter-disposed?` slots. `substrate.adapter`
+;; becomes the ACCESS SEAM over these slots: its public surface
+;; (`install-adapter!` / `current-adapter` / `current-adapter-spec` /
+;; `dispose-adapter!` / `adapter-disposed?` / the delegation fns) is
+;; byte-identical, and in a single-realm app every call routes through the one
+;; default realm — so the install/dispose lifecycle and every "single adapter
+;; per process" diagnostic behave exactly as before. A future multi-realm
+;; runtime gets a per-realm adapter for free: the seam already keys on a realm.
+;;
+;; Why the realm OWNS it rather than substrate.adapter holding it: the realm
+;; is the value that owns the non-durable operational layer (the registrar,
+;; the adapter, the capability map, the host-transient state). Concentrating
+;; the adapter selection there — instead of in a leaf substrate ns — is what
+;; lets D2/later replace the whole operational environment at the realm
+;; boundary in one place. There is no cycle: this ns requires only
+;; `registrar` + `late-bind`, neither of which pulls `substrate.adapter`, so
+;; `substrate.adapter` statically requires THIS ns (no late-bind indirection).
+;;
+;; Two slots, mirroring the prior two-cell shape:
+;;   :adapter           the installed adapter spec map, or absent/nil.
+;;   :adapter-disposed? the dispose breadcrumb (absent ⇒ false ⇒ never
+;;                      installed; true ⇒ installed then torn down).
+
+(defn realm-adapter
+  "Return the adapter SELECTION (the installed adapter spec map) for a realm,
+  or nil when none is seated. Accepts a realm map or realm-id keyword; nil
+  resolves to the default realm (absence = default realm). The realm-owned
+  read seam `re-frame.substrate.adapter/current-adapter-spec` is built on.
+  INTERNAL."
+  ([] (realm-adapter default-realm-id))
+  ([realm-or-id]
+   (:adapter (realm (realm-id realm-or-id)))))
+
+(defn realm-adapter-disposed?
+  "Return the realm's adapter-lifecycle breadcrumb — `true` iff the most
+  recent adapter lifecycle event on the realm was a successful
+  `dispose-realm-adapter!` with no subsequent install (absence ⇒ `false` ⇒
+  the adapter was never installed). nil resolves to the default realm.
+  INTERNAL."
+  ([] (realm-adapter-disposed? default-realm-id))
+  ([realm-or-id]
+   (boolean (:adapter-disposed? (realm (realm-id realm-or-id))))))
+
+(defn install-realm-adapter!
+  "Seat `adapter` (the spec map) as the realm's SELECTION and clear the
+  dispose breadcrumb. The single mutation point for adapter install — the
+  realm-owned counterpart of the prior process-global cell. Returns
+  `adapter`. nil resolves to the default realm. Does NOT enforce the
+  single-adapter-per-realm guard — `re-frame.substrate.adapter/install-adapter!`
+  owns that check (it reads `realm-adapter` first and throws
+  `:rf.error/adapter-already-installed`), so this seam stays a plain setter the
+  guard composes over. INTERNAL."
+  ([adapter] (install-realm-adapter! default-realm-id adapter))
+  ([realm-or-id adapter]
+   (update-realm! (realm-id realm-or-id)
+                  #(assoc % :adapter adapter :adapter-disposed? false))
+   adapter))
+
+(defn dispose-realm-adapter!
+  "Clear the realm's adapter SELECTION and set the dispose breadcrumb. The
+  realm-owned counterpart of the prior process-global dispose. Idempotent:
+  clearing an already-absent adapter just (re)sets the breadcrumb. Returns
+  nil. nil resolves to the default realm. Does NOT call the adapter's own
+  `:dispose-adapter!` fn — `re-frame.substrate.adapter/dispose-adapter!` owns
+  that (it reads the seated adapter, runs its teardown, THEN clears the slot
+  here), so this seam stays a pure state transition the lifecycle composes
+  over. INTERNAL."
+  ([] (dispose-realm-adapter! default-realm-id))
+  ([realm-or-id]
+   (update-realm! (realm-id realm-or-id)
+                  #(-> % (dissoc :adapter) (assoc :adapter-disposed? true)))
+   nil))
+
+(defn reset-realm-adapter-lifecycle!
+  "Reset the realm's adapter SELECTION + breadcrumb to a never-installed cold
+  state (adapter absent, breadcrumb false). The realm-owned counterpart of the
+  prior `reset-lifecycle-state-for-tests!` cold-start seam. nil resolves to
+  the default realm. INTERNAL — NOT part of the runtime contract; cold-start
+  test fixtures use it to wipe lifecycle state so the no-adapter-installed
+  throw can be asserted independently of the adapter-disposed throw."
+  ([] (reset-realm-adapter-lifecycle! default-realm-id))
+  ([realm-or-id]
+   (update-realm! (realm-id realm-or-id)
+                  #(-> % (dissoc :adapter) (dissoc :adapter-disposed?)))
+   nil))
+
+;; ---- realm-owned host-transient subsystem registry (stage 4) --------------
+;;
+;; The framework's host-transient subsystem state — the non-durable
+;; process-mutable side-tables (HTTP in-flight handles + abort controllers,
+;; routing nav counters + scroll caches, machine timers + spawn-order helpers,
+;; flow last-input caches, resource work-ledgers, SSR side channels, adapter
+;; render roots/disposers) — is OWNED BY the realm (Runtime-Subsystems
+;; §Host-Transient Subsystem State: "the owner of the table is the realm, not
+;; an arbitrary namespace-level singleton").
+;;
+;; Stage 4 makes the realm the OWNER of the host-transient DESCRIPTOR
+;; inventory: `subsystem-id → :rf/host-transient-descriptor`. The side-table
+;; atoms continue to live in their producing artefacts and are reset/torn down
+;; through the existing late-bind reset + frame-destroy hooks (the
+;; `re-frame.test-support` reset-hook-table and the per-artefact
+;; `*/on-frame-destroyed!` hooks) — moving the bytes is not what this stage
+;; does. What it does is give the realm the single, queryable record of WHICH
+;; host-transient subsystems exist and HOW each is scoped / torn down /
+;; test-reset, so realm/frame teardown has one inventory to walk rather than a
+;; scattering of namespace-level singletons. Each descriptor's `:durability`
+;; is `:none` — host-transient state MUST NOT ride the wire (no snapshot, no
+;; SSR, no restore), per the descriptor contract (Spec-Schemas
+;; §`:rf/host-transient-descriptor`).
+
+(defn register-host-transient!
+  "Register a host-transient subsystem `descriptor` (a
+  `:rf/host-transient-descriptor` map carrying at least `:id`) under its
+  `:id` in the realm's `:host-transient` inventory. The realm becomes the
+  owner of the record of this non-durable side-table. nil resolves to the
+  default realm. Returns the descriptor. INTERNAL."
+  ([descriptor] (register-host-transient! default-realm-id descriptor))
+  ([realm-or-id descriptor]
+   (update-realm! (realm-id realm-or-id)
+                  update :host-transient
+                  (fnil assoc {}) (:id descriptor) descriptor)
+   descriptor))
+
+(defn host-transient
+  "Return the realm's host-transient subsystem inventory
+  (`subsystem-id → descriptor`), or the descriptor for a single `subsystem-id`
+  when supplied. nil realm resolves to the default realm. Returns nil when the
+  realm holds no host-transient registry (none registered yet). INTERNAL — the
+  realm-owned read seam for the framework's non-durable side-table inventory."
+  ([] (host-transient default-realm-id))
+  ([realm-or-id]
+   (:host-transient (realm (realm-id realm-or-id))))
+  ([realm-or-id subsystem-id]
+   (get (:host-transient (realm (realm-id realm-or-id))) subsystem-id)))
+
+(defn clear-host-transient!
+  "Drop the realm's host-transient subsystem inventory (the descriptor
+  records, not the side-table contents — those are reset through each
+  subsystem's own reset hook). nil resolves to the default realm. Returns nil.
+  INTERNAL — the inventory counterpart of the per-subsystem reset hooks; used
+  by cold-start test fixtures so a realm starts with an empty inventory."
+  ([] (clear-host-transient! default-realm-id))
+  ([realm-or-id]
+   (update-realm! (realm-id realm-or-id) dissoc :host-transient)
+   nil))

--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -34,17 +34,29 @@
   ships only that adapter's code."
   (:require [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.realm :as realm]
             [re-frame.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- adapter installation -------------------------------------------------
+;; ---- adapter installation — realm-owned (EP-0013 D1 stage 4, rf2-0lq5cd) --
 ;;
-;; Two cells, not one. `installed-adapter` holds the live spec
-;; map when an adapter is installed and `nil` otherwise. `disposed?` is a
-;; boolean breadcrumb left behind by the most recent
-;; `(dispose-adapter!)` so subsequent runtime calls can distinguish
+;; The adapter SELECTION is OWNED BY the realm (Runtime-Subsystems §Adapter
+;; Ownership). Stage 4 moved the two process-global `defonce` cells that used
+;; to live HERE into the default realm's record — `:adapter` (the live spec
+;; map, or absent) and `:adapter-disposed?` (the dispose breadcrumb). This ns
+;; is now the ACCESS SEAM over those realm slots; the public surface below is
+;; byte-identical and every call in a single-realm app routes through the one
+;; default realm, so the install/dispose lifecycle and the "single adapter per
+;; process" diagnostics behave exactly as before. The two-cell shape is
+;; preserved across the move:
 ;;
+;;   `realm/realm-adapter`            ← the old `@installed-adapter` read
+;;   `realm/install-realm-adapter!`   ← the old `(reset! installed-adapter …)`
+;;   `realm/dispose-realm-adapter!`   ← clears the slot + sets the breadcrumb
+;;   `realm/realm-adapter-disposed?`  ← the old `@disposed?` read
+;;
+;; The breadcrumb still distinguishes:
 ;;   (a) `no adapter installed yet` — fresh process, init! never ran;
 ;;       the right diagnosis is `:rf.error/no-adapter-installed`;
 ;;   (b) `adapter was installed and then torn down` — usually a test
@@ -53,28 +65,29 @@
 ;;
 ;; Both states leave the install slot empty so a fresh adapter can
 ;; install via `install-adapter!`; the breadcrumb clears on the next
-;; successful install.
-
-(defonce ^:private installed-adapter (atom nil))
-(defonce ^:private disposed?         (atom false))
+;; successful install. No cycle: `re-frame.realm` requires only `registrar` +
+;; `late-bind` (neither pulls this ns), so the static require above is sound.
 
 (defn install-adapter!
   "Install the adapter for this process. Once. A second call without an
   intervening dispose-adapter! raises :rf.error/adapter-already-installed
   (per Spec 006 §Single adapter per process). Clears the disposed
   breadcrumb so subsequent delegation calls see a fresh adapter rather
-  than `:rf.error/adapter-disposed`."
+  than `:rf.error/adapter-disposed`.
+
+  The adapter SELECTION is owned by the default realm (EP-0013 D1 stage 4);
+  this fn guards the single-adapter invariant and then seats the adapter via
+  `realm/install-realm-adapter!`."
   [adapter]
-  (when @installed-adapter
+  (when-let [installed (realm/realm-adapter)]
     (throw (ex-info ":rf.error/adapter-already-installed"
                     {:rf.error/id :rf.error/adapter-already-installed
                      :where       'rf/init!
                      :recovery    :no-recovery
                      :reason      "A second install-adapter! was called without an intervening (rf/destroy-adapter!); the existing adapter remains installed (per Spec 006 §Single adapter per process)."
-                     :installed   @installed-adapter
+                     :installed   installed
                      :attempted   adapter})))
-  (reset! installed-adapter adapter)
-  (reset! disposed? false)
+  (realm/install-realm-adapter! adapter)
   adapter)
 
 (defn current-adapter
@@ -88,7 +101,7 @@
   For \"give me the adapter spec map\" (fn handles, hot-swap, identity
   checks across install/dispose), use `current-adapter-spec`."
   []
-  (when-let [a @installed-adapter]
+  (when-let [a (realm/realm-adapter)]
     (:kind a :custom)))
 
 (defn current-adapter-spec
@@ -102,7 +115,7 @@
   human-readable discriminator (predicate / branch code), use
   `current-adapter`."
   []
-  @installed-adapter)
+  (realm/realm-adapter))
 
 (defn dispose-adapter!
   "Tear down the installed adapter. Calls the adapter's :dispose-adapter!
@@ -111,33 +124,36 @@
   `:rf.error/adapter-disposed` instead of `:rf.error/no-adapter-installed`
   (rf2-6wxys). Calling dispose with no adapter installed leaves the
   breadcrumb untouched — it doesn't pretend a never-installed adapter
-  was disposed."
+  was disposed.
+
+  The adapter SELECTION is owned by the default realm (EP-0013 D1 stage 4);
+  this fn runs the seated adapter's own teardown and then clears the realm's
+  adapter slot via `realm/dispose-realm-adapter!`."
   []
-  (when-let [adapter @installed-adapter]
+  (when-let [adapter (realm/realm-adapter)]
     (when-let [f (:dispose-adapter! adapter)]
       (f))
-    (reset! installed-adapter nil)
-    (reset! disposed? true))
+    (realm/dispose-realm-adapter!))
   nil)
 
 (defn adapter-disposed?
   "Return true iff the most recent lifecycle event was a successful
   `dispose-adapter!` and no `install-adapter!` has fired since. False
   for `never installed` (fresh process) and after a fresh install.
-  Read-only — the breadcrumb is owned by the install / dispose pair."
+  Read-only — the breadcrumb is owned by the install / dispose pair (the
+  default realm's `:adapter-disposed?` slot, EP-0013 D1 stage 4)."
   []
-  @disposed?)
+  (realm/realm-adapter-disposed?))
 
 (defn ^:no-doc reset-lifecycle-state-for-tests!
-  "Test-only seam — resets the installed-adapter slot and the disposed
+  "Test-only seam — resets the default realm's adapter slot and the disposed
   breadcrumb to a never-installed cold state. NOT part of the runtime
   contract; cold-start test fixtures (e.g. `boot_test/cold-start`) use
   this to wipe the lifecycle state between cases so the no-adapter-
   installed throw can be asserted independently of the adapter-
   disposed throw."
   []
-  (reset! installed-adapter nil)
-  (reset! disposed? false)
+  (realm/reset-realm-adapter-lifecycle!)
   nil)
 
 ;; ---- delegation helpers ---------------------------------------------------
@@ -185,10 +201,12 @@
   pivots to the same category. `where-sym` is stamped on the throw so
   grep-for-symbol finds the delegation site in user code. Private —
   callers in this ns thread the symbol of the public surface they
-  implement (e.g. `'rf/make-state-container`)."
+  implement (e.g. `'rf/make-state-container`).
+
+  Reads the adapter SELECTION from the default realm (EP-0013 D1 stage 4)."
   [where-sym]
-  (or @installed-adapter
-      (if @disposed?
+  (or (realm/realm-adapter)
+      (if (realm/realm-adapter-disposed?)
         (throw (ex-info ":rf.error/adapter-disposed"
                         {:rf.error/id :rf.error/adapter-disposed
                          :where    where-sym

--- a/implementation/core/test/re_frame/realm_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_cljs_test.cljc
@@ -1,7 +1,8 @@
 (ns re-frame.realm-cljs-test
-  "EP-0013 D1 internal staging 1-3 (rf2-gkddyq) — the runtime realm record,
-  the default realm, the realm-owned registrar, and the frame's realm
-  reference.
+  "EP-0013 D1 internal staging 1-4 — the runtime realm record, the default
+  realm, the realm-owned registrar, the frame's realm reference (stages 1-3,
+  rf2-gkddyq), and the realm-owned adapter SELECTION + host-transient
+  subsystem inventory (stage 4, rf2-0lq5cd).
 
   D1 is INTERNAL: no public `rf/realm` constructor and no realm-targeted
   public query ship. The headline acceptance is **zero ergonomic regression**
@@ -17,7 +18,15 @@
         exactly as before);
     (3) a frame carries its realm REFERENCE internally (`:realm` slot →
         `:rf.realm/default`); the realm-owned frame-membership VIEW is
-        derived live from the frame registry, with no separately-stored set.
+        derived live from the frame registry, with no separately-stored set;
+    (4) the realm OWNS the adapter SELECTION — `re-frame.substrate.adapter` is
+        the access seam over the default realm's `:adapter` +
+        `:adapter-disposed?` slots; install / current / dispose route through
+        the realm with byte-identical behaviour (stage 4);
+    (5) the realm OWNS the host-transient subsystem DESCRIPTOR inventory —
+        `subsystem-id → :rf/host-transient-descriptor` lives in the default
+        realm's `:host-transient` slot; register / read / clear are
+        realm-owned (stage 4).
 
   Dual-runtime: named `*_cljs_test.cljc` so the shadow-cljs `:node-test`
   build (`npm run test:cljs`, `:ns-regexp \"cljs-test$\"`) AND the JVM
@@ -29,6 +38,7 @@
             [re-frame.frame :as frame]
             [re-frame.realm :as realm]
             [re-frame.registrar :as registrar]
+            [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as ts]))
 
@@ -190,3 +200,123 @@
           "a destroyed frame drops out of the grouping")
       (is (contains? (get by-realm :rf.realm/default) :realm-test/b)
           "the surviving frame stays in the grouping"))))
+
+;; ---------------------------------------------------------------------------
+;; (4) the realm OWNS the adapter SELECTION — stage 4 (rf2-0lq5cd)
+;;
+;; The adapter selection moved off the two process-global `defonce` cells that
+;; used to live in `re-frame.substrate.adapter` and onto the default realm's
+;; record (`:adapter` + `:adapter-disposed?`). `substrate.adapter` is now the
+;; ACCESS SEAM. The headline is STILL zero ergonomic regression: install /
+;; current / dispose behave byte-identically, routed through the one default
+;; realm. (The reset fixture installs plain-atom into the default realm, so
+;; these tests assert the seam reads/writes the realm slot rather than that an
+;; adapter is absent at entry.)
+;; ---------------------------------------------------------------------------
+
+(deftest default-realm-owns-the-adapter-selection
+  (testing "the installed adapter is OWNED BY the default realm — the seam's
+            read resolves the realm's :adapter slot"
+    ;; The fixture installed plain-atom into the default realm.
+    (is (identical? plain-atom/adapter (realm/realm-adapter))
+        "realm/realm-adapter returns the fixture-installed adapter")
+    (is (identical? (realm/realm-adapter)
+                    (:adapter (realm/default-realm)))
+        "the read seam IS the default realm's :adapter slot")
+    (is (identical? (realm/realm-adapter)
+                    (adapter/current-adapter-spec))
+        "substrate.adapter/current-adapter-spec routes through the realm")
+    (is (= :rf.adapter/plain-atom (adapter/current-adapter))
+        "current-adapter reports the realm-owned adapter's kind")))
+
+(deftest adapter-install-dispose-lifecycle-is-realm-owned
+  (testing "install seats the adapter on the realm + clears the breadcrumb;
+            dispose clears the slot + sets the breadcrumb — the two-cell shape
+            is preserved across the move onto the realm record"
+    ;; Start from the fixture-installed state, tear down to a clean cold slate.
+    (adapter/dispose-adapter!)
+    (is (nil? (realm/realm-adapter))
+        "dispose clears the realm's :adapter slot")
+    (is (true? (realm/realm-adapter-disposed?))
+        "dispose sets the realm's :adapter-disposed? breadcrumb")
+    (is (true? (adapter/adapter-disposed?))
+        "the seam's adapter-disposed? reads the realm breadcrumb")
+    ;; Re-install: the breadcrumb clears, the slot is seated.
+    (adapter/install-adapter! plain-atom/adapter)
+    (is (identical? plain-atom/adapter (realm/realm-adapter))
+        "install re-seats the adapter on the realm")
+    (is (false? (realm/realm-adapter-disposed?))
+        "install clears the breadcrumb")
+    ;; The single-adapter-per-realm guard still fires on a double install.
+    (is (thrown? #?(:clj Exception :cljs js/Error)
+                 (adapter/install-adapter! plain-atom/adapter))
+        "a second install without an intervening dispose still throws")))
+
+(deftest adapter-lifecycle-cold-reset-seam
+  (testing "reset-lifecycle-state-for-tests! wipes the realm's adapter slot +
+            breadcrumb to a never-installed cold state"
+    ;; The fixture already seated plain-atom; tear it down so the breadcrumb is
+    ;; set, then prove the cold reset clears BOTH the slot and the breadcrumb.
+    (adapter/dispose-adapter!)
+    (is (true? (realm/realm-adapter-disposed?))
+        "dispose leaves the disposed breadcrumb set")
+    (adapter/reset-lifecycle-state-for-tests!)
+    (is (nil? (realm/realm-adapter))
+        "cold reset clears the realm's :adapter slot")
+    (is (false? (realm/realm-adapter-disposed?))
+        "cold reset clears the breadcrumb — distinct from a disposed state")))
+
+;; ---------------------------------------------------------------------------
+;; (5) the realm OWNS the host-transient subsystem inventory — stage 4
+;;
+;; The framework's host-transient side-tables (HTTP in-flight, routing nav
+;; counters, machine timers, …) are realm-owned. Stage 4 makes the realm the
+;; OWNER of the DESCRIPTOR inventory (subsystem-id → descriptor), recording
+;; each subsystem's scope / teardown / test-reset. The side-table bytes stay
+;; in their producing artefacts (reset through the existing late-bind hooks);
+;; this is the queryable record of what exists + how each is torn down.
+;; ---------------------------------------------------------------------------
+
+(deftest host-transient-inventory-is-realm-owned
+  (testing "a host-transient descriptor registers under the default realm and
+            reads back; the inventory lives in the realm's :host-transient slot"
+    ;; A fresh realm carries no host-transient inventory.
+    (realm/clear-host-transient!)
+    (is (nil? (realm/host-transient))
+        "a realm with no registered subsystem has no host-transient inventory")
+    (let [descriptor {:id            :rf.test/in-flight
+                      :storage-class :host-transient
+                      :scope         :frame
+                      :durability    :none}]
+      (realm/register-host-transient! descriptor)
+      (is (= descriptor (realm/host-transient :rf.realm/default :rf.test/in-flight))
+          "the descriptor reads back by subsystem-id")
+      (is (= {:rf.test/in-flight descriptor}
+             (realm/host-transient))
+          "the inventory is the realm's :host-transient slot")
+      (is (= {:rf.test/in-flight descriptor}
+             (:host-transient (realm/default-realm)))
+          "the slot lives on the default realm record")
+      ;; Registering a second subsystem adds to (does not clobber) the table.
+      (let [d2 {:id :rf.test/timers :storage-class :host-transient
+                :scope :realm :durability :none}]
+        (realm/register-host-transient! d2)
+        (is (= #{:rf.test/in-flight :rf.test/timers}
+               (set (keys (realm/host-transient))))
+            "a second register adds to the inventory")))
+    ;; Clearing drops the inventory (the test-reset / cold-start counterpart).
+    (realm/clear-host-transient!)
+    (is (nil? (realm/host-transient))
+        "clear-host-transient! drops the realm's inventory")))
+
+(deftest host-transient-durability-is-none
+  (testing "every host-transient descriptor declares :durability :none — the
+            non-durable contract (MUST NOT ride the wire)"
+    (realm/clear-host-transient!)
+    (realm/register-host-transient!
+      {:id :rf.test/nav-counters :storage-class :host-transient
+       :scope :frame :durability :none})
+    (is (= :none (:durability (realm/host-transient :rf.realm/default
+                                                    :rf.test/nav-counters)))
+        "the registered descriptor is non-durable")
+    (realm/clear-host-transient!)))


### PR DESCRIPTION
## What

EP-0013 action-wave D1 **stage 4** (continues the merged stages 1-3, PR #3920). Moves the **adapter SELECTION** and the **host-transient subsystem inventory** to be OWNED BY the default realm, per `docs/EP/EP-0013` §Public API Staging stage 4 and the merged D1 spec (`Runtime-Subsystems.md` §Adapter Ownership / §Host-Transient Subsystem State).

**INTERNAL only — no public source break.** Everything still routes through the one process default realm, so single-app ergonomics are byte-identical. No public realm-targeted API ships (that is D2 stages 5-7).

## What moved under the realm

- **Adapter selection.** The two process-global `defonce` cells in `re-frame.substrate.adapter` (`installed-adapter` + `disposed?`) are gone. The default realm record now owns them as its `:adapter` + `:adapter-disposed?` slots. `re-frame.substrate.adapter` becomes the **access seam** over those slots — `install-adapter!` / `current-adapter` / `current-adapter-spec` / `dispose-adapter!` / `adapter-disposed?` / `reset-lifecycle-state-for-tests!` all route through new realm seams (`install-realm-adapter!` / `dispose-realm-adapter!` / `realm-adapter` / `realm-adapter-disposed?` / `reset-realm-adapter-lifecycle!`). Public surface is byte-identical; the single-adapter-per-process guard still fires.
- **Host-transient subsystem inventory.** The realm record's `:host-transient` slot is now the realm-owned registry of `subsystem-id → :rf/host-transient-descriptor` (HTTP in-flight, routing nav counters, machine timers, …). New seams `register-host-transient!` / `host-transient` / `clear-host-transient!`. Each descriptor declares `:durability :none` (MUST NOT ride the wire). The side-table *bytes* stay in their producing artefacts (reset through the existing late-bind hooks); the realm now owns the single queryable record of what exists + how each is torn down.
- The `realms` registry atom is mutated in place through a single private `update-realm!` seam.

## Transparency proof (zero ergonomic regression)

- No cycle: `re-frame.realm`'s require closure is `{registrar, late-bind, interop, source-coords}` — none pulls `substrate.adapter`, so `substrate.adapter` **statically requires** `re-frame.realm` (no late-bind indirection needed).
- The full existing suite passes unchanged (1219 JVM / 6634 CLJS), and the new realm tests assert install/current/dispose/cold-reset behave identically while reading/writing the realm slot. Bundle-isolation confirms the realm ns survives `:advanced` builds (no production elision regression).

## Remaining deferred stages (D2/later, not this PR)

5. Internal app-value projection for existing registrations.
6. Public app/module constructors.
7. Public explicit realm install/reinstall + realm-targeted query APIs.
8-9. Multi-realm / multi-adapter conformance.

## Quality gates

- `npm run test:cljs` (core node-runtime, the key zero-ergonomic-regression gate) — **6634 tests / 24464 assertions, 0 failures, 0 errors**
- core `clojure -M:test` (JVM) — **1219 tests / 5378 assertions, 0 failures, 0 errors**
- `npm run test:bundle-isolation` — **PASS** (17 artefact entries, 35 internal sentinels absent; uix/helix/reagent-free PASS)
- `scripts/test-fast-pr.sh` (full canonical PR spine: lockstep, drift guards, CLJS suite, link/anchor gates) — **PASS** (mkdocs soft-skipped on Windows; CI runs it)

All gates run post-rebase onto the latest `origin/main` (includes the just-merged #3919 / #3921 / #3922).