### PR TITLE
feat(xray/docs): EP-0016 slice-8 — tooling + guide for resource mutation completion (rf2-g9ui01)

### DIFF
--- a/docs/guide/27-resources.md
+++ b/docs/guide/27-resources.md
@@ -137,6 +137,43 @@ The practical rule: **if a route or event ensures under a session scope, the vie
   ...)
 ```
 
+### Named scope resolvers — derive viewer scope once
+
+Session, tenant, organization, locale, account, and impersonation all have the same shape: a *viewer identity* lives in app state, and it should determine cache scope. Threading that derivation by hand through every route resource, event-side ensure, subscription, and invalidation descriptor is exactly the kind of repetition the framework should own. **`reg-resource-scope`** registers a named, pure, *declared* scope resolver, derived once and reused everywhere a derived scope is allowed:
+
+```clojure
+(rf/reg-resource-scope :realworld/session
+  {:inputs {:username [:db [:auth :user :username]]}
+   :resolve
+   (fn [{:keys [username]} _ctx]
+     (when username
+       [:rf.scope/session {:username username}]))})
+```
+
+A resolver is **pure** — it derives a scope and does nothing else (no fetch, no dispatch, no ambient host reads). The `:inputs` map is the load-bearing part: names on the left, `[:db <path>]` source descriptors on the right. Declaring inputs lets tools *explain which app facts decide a resource identity*, and lets the runtime re-resolve scope only when a relevant input changes. (A whole-db function sugar — `(fn [db _ctx] …)` — is supported, but it lowers to an explicit whole-db dependency, and tooling marks that cost.)
+
+You reference a named resolver with `{:from-db :realworld/session}` anywhere a derived scope is allowed — resource registration `:scope`, route resource entries, event-side ensure/refetch payloads, subscriptions, invalidation descriptors, map-form populate/patch/remove targets, and clear-scope helpers:
+
+```clojure
+(rf/reg-resource :realworld/feed
+  {:scope   {:from-db :realworld/session}
+   :params  (fn [{:keys [page]}] {:page page})
+   :request (fn [{:keys [page]} _ctx]
+              {:request {:method :get :url "/articles/feed"
+                         :params {:limit 20 :offset (* 20 (dec page))}}
+               :decode :json})
+   :tags    (fn [_params _value] #{[:feed] [:article-list]})})
+
+(rf/reg-route :realworld/home
+  {:path "/"
+   :resources [{:resource :realworld/feed :params {:page 1}
+                :scope {:from-db :realworld/session} :blocking? true}]})
+```
+
+The session feed can now be a declarative route resource — loaded on entry, released on leave, read by subs, and invalidated by descriptors — all keyed by the *same* resolver. Nil from a resolver at a scope-requiring site is **fail-closed**: route planning never substitutes global, and a subscription surfaces a "scope unresolved" diagnostic rather than quietly reading a different entry.
+
+Xray surfaces both halves: a **Named scope resolvers** section lists each resolver's id + declared inputs + the whole-db cost flag (the static declaration, no PII), and a **scope resolution timeline** shows each `:rf.resource/scope-resolved` event — which resolver ran, the resolved scope (summarized), and the fail-closed nil evidence.
+
 ### `clear-scope` is causal
 
 Logout, account switch, tenant switch, permission change, locale switch that affects wire data, and impersonation enter/exit must each clear or replace the affected scope. That's a causal operation, the `:rf.resource/clear-scope` event:
@@ -148,6 +185,18 @@ Logout, account switch, tenant switch, permission change, locale switch that aff
 ```
 
 It removes or marks unusable every entry in that scope, releases owners in it, aborts in-flight requests that have no remaining owner outside it, suppresses late replies by scope + generation, and emits trace rows explaining what it removed, aborted, or left alone. (An auth-*token* refresh doesn't necessarily require clearing scope — if the user, tenant, permissions, and impersonation state are unchanged, the cache is still valid.)
+
+Logout has a subtle ordering problem: you want to clear the scope the user *was in*, but the obvious place to do it — after `(dissoc db :auth)` — has already removed the identity the scope is derived from. The canonical idiom resolves the **concrete** old scope from the handler's **coeffect db** (pre-transition by definition — the causal input) with the pure `resolve-resource-scope` helper, and passes it to `clear-scope` concretely:
+
+```clojure
+(rf/reg-event-fx :auth/logout
+  (fn [{:keys [db]} _]
+    (let [old-scope (rf/resolve-resource-scope db :realworld/session)]
+      {:db (dissoc db :auth)
+       :fx [[:dispatch [:rf.resource/clear-scope {:scope old-scope :cause :logout}]]]})))
+```
+
+`resolve-resource-scope` is a plain pure function over the resolver registry — not an effect, no resolution-timing ambiguity. (A whole-db snapshot riding an event payload was considered and rejected: it would be an egress-bearing record on traces and epoch history. A `{:from-db …}` reference *may* still appear on a `clear-scope` payload under the single use-time resolution rule; one that resolves nil at a clear-scope site emits a loud diagnostic, never a silent no-op.)
 
 ### Xray is defense-in-depth, not the boundary
 
@@ -370,6 +419,46 @@ The full instance view-model and sub family:
 
 The instance-keyed model is load-bearing: **two concurrent submissions of the same mutation never clobber each other.** Fire `:comment/add` twice (instances `:c-1` and `:c-2`) and each keeps its own `:pending` / `:success` / `:error` row. A caller-supplied instance id makes the relationship between a form and its submission explicit; an omitted instance id is generated (and closes over the monotone generation, so concurrent generated submissions still differ). `:rf.mutation/clear` is the **causal** reset of a runtime instance (best-effort aborting in-flight work) — distinct from `clear-mutation`, which is the registration-lifecycle removal of the mutation definition itself, not a form reset.
 
+### Continue the workflow with `:reply-to`
+
+Watching the instance from a view is right for *rendering* — the button reads `:pending?` and disables itself. But a write usually also has to **drive workflow**: save the user, navigate to the new article's slug, clear the editor, show a toast. Those are *causes*, not renders, and they should not live in a component lifecycle reaction watching mutation state. They belong on the event tape.
+
+`:rf.mutation/execute` takes an optional call-site **`:reply-to`** event target. When the runtime accepts the mutation reply as current, it dispatches that target with one **reply map** appended as the final argument:
+
+```clojure
+(rf/reg-event-fx :settings/save
+  (fn [_ [_ form]]
+    {:fx [[:dispatch [:rf.mutation/execute
+                      {:mutation :realworld/update-user
+                       :params   form
+                       :instance [:settings/save]
+                       :reply-to [:settings/save-replied]}]]]}))
+
+(rf/reg-event-fx :settings/save-replied
+  (fn [{:keys [db]} [_ {:keys [status value error]}]]
+    (case status
+      :ok    {:db (assoc db :auth/user (:user value))
+              :fx [[:dispatch [:toast/show "Settings saved"]]]}
+      :error {:db (assoc db :settings/error error)})))
+```
+
+No view watcher. The accepted reply becomes the next causal event — folded through the interceptor chain, the trace tape, and replay like any other event. (It is **not** a callback: a callback that returned effects would mint effects outside the event tape, outside replay, outside frame causality. The continuation is a *causal event target*.)
+
+The reply map carries the mutation-specific facts the handler reads directly: `:status` (`:ok` / `:error` / accepted `:cancelled`), `:mutation`, `:params`, `:instance`, `:scope`, `:value` / `:error`, `:affected-keys` (the resource keys the reply populated / patched / invalidated), `:work/id`, `:rf.frame/id`, `:completed-at`, and `:cause`. Static call-site args are preserved — `:reply-to [:toast/after-save {:kind :article}]` dispatches `[:toast/after-save {:kind :article} reply]`.
+
+**The delivery rule:** `:reply-to` fires for any **accepted terminal reply** — `:ok`, `:error`, or an accepted terminal `:cancelled`. It **never** fires for a stale or superseded reply (a re-execute under the same instance, an `:rf.mutation/clear`). The handler branches on `:status`; the runtime guarantees it only ever sees an accepted one.
+
+**Phase order is deterministic.** The continuation runs *after* the cache consequences and instance settlement, so a handler reached by `:reply-to` observes a settled world:
+
+1. resolve canonical params + mutation scope;
+2. issue the managed request under runtime-owned reply addressing;
+3. accept or stale-suppress the host reply;
+4. apply success-time cache consequences (`:patches`, `:populates`, `:invalidates`, removes);
+5. settle mutation instance + work-ledger state;
+6. dispatch the `:reply-to` continuation, if present.
+
+> **The doctrine, in one line: `:reply-to` is for *workflow*; `:populates` / `:patches` / `:invalidates` are for *cache*.** A continuation updates app-db, navigates, toasts. A cache consequence updates resource entries. Don't reach for `:reply-to` to invalidate a tag (the registration already declared that, scoped and owner-aware), and don't try to express navigation as a cache consequence. Registration-level `:reply-to` is deliberately *not* added — an invariant workflow continuation is spelled by every call site passing the same target, and a workflow target hidden inside the remote-write definition would hide app behaviour.
+
 ### The write→invalidate→refetch loop, end to end
 
 Putting the two halves together — this is the write→invalidate→refetch loop, end to end:
@@ -419,13 +508,86 @@ You *can* write with an ordinary `:rf.http/managed` event whose success handler 
 
 - **Instance-keyed lifecycle** — `:pending?` / `:success?` / `:error?` / `:settled?` per submission, concurrency-safe, with no `app-db` slice to maintain. (A write has no last-known-good, so there's no `:refresh-error` analogue — failure simply settles `:error`.)
 - **Stale-suppression on writes** — a superseded reply (a re-execute under the same instance, or an `:rf.mutation/clear`) can never overwrite a newer instance, by the same work-id + generation check resources use.
-- **Patch / populate before invalidate** — `:patches` and `:populates` (controlled transforms / seeds keyed by scoped key) update resource entries *before* the success-time invalidation, so a saved article can appear in the cache immediately without waiting for the refetch round-trip.
+- **Causal workflow continuation** — call-site `:reply-to` (above) dispatches an app event with the accepted reply map after cache consequences settle, so post-write navigation / session updates / toasts ride the event tape instead of a view-side watcher.
+- **Patch / populate before invalidate** — `:patches` and `:populates` ([map-form exact targets](#map-form-exact-targets), keyed by scoped key) update resource entries *before* the success-time invalidation, so a saved article can appear in the cache immediately without waiting for the refetch round-trip. A populated key is an [authoritative load](#populate-is-an-authoritative-load) — it is treated as freshly loaded and is not refetched by the same mutation's invalidation pass.
+- **Per-target scoped invalidation** — `:invalidates` can target [different scopes precisely](#per-target-scoped-invalidation) (one write that affects a global fact *and* a session-scoped fact), instead of one resolved scope for every tag.
 - **Invalidation timing** — `:invalidate-timing` is explicit: `:after-success` (default), `:before-request`, `:after-failure`, or `:after-settle`.
-- **Trace-visible instance ids** — the `:rf.mutation/*` trace family (`started` / `succeeded` / `failed` / `cleared` / `stale-suppressed`) carries the instance id, so Xray groups submissions under their mutation and shows the write→invalidate→refetch causality.
+- **Trace-visible instance ids** — the `:rf.mutation/*` trace family (`started` / `succeeded` / `failed` / `replied` / `cleared` / `stale-suppressed`) carries the instance id, so Xray groups submissions under their mutation and shows the write→invalidate→refetch→continue causality. `succeeded` / `failed` carry the per-descriptor invalidation evidence; `replied` is the `:reply-to` continuation dispatch.
 
 (Optimistic rollback — the snapshot/rollback/reconciliation shape — is reserved in the success trace but **deferred**; until it lands, patch/populate are forward-only.)
 
 > **When managed HTTP is still the right tool: user-visible optimistic *rollback*.** `:patches` / `:populates` are **forward-only** seeds — they make a change appear immediately and let the success-time invalidation reconcile, but there is **no automatic revert on failure** (the snapshot/rollback shape is deferred — see [What's deferred](#whats-deferred)). So when you need a write that flips the UI optimistically *and* rolls the change back if the server rejects it — the favourite toggle that un-flips on a 500, a like-count that decrements again, a positional list re-insert that undoes itself — reach for a plain `:rf.http/managed` write where your own `:on-failure` handler restores the prior `app-db` value. A mutation cannot express that today. The favourite / follow / comment-delete shapes in [`examples/reagent/realworld/`](../../examples/reagent/realworld/) (the managed-HTTP sibling of the resources RealWorld variant) are worked examples of exactly this optimistic-then-rollback pattern; the resources variant ([`examples/reagent/realworld_resources/`](../../examples/reagent/realworld_resources/)) uses forward-only `:populates` for the same toggles and accepts the brief refetch round-trip instead.
+
+### Per-target scoped invalidation
+
+The bare tag-set shorthand invalidates those tags **in the mutation's resolved scope**:
+
+```clojure
+:invalidates (fn [{:keys [slug]} _result] #{[:article slug] [:article-list]})
+```
+
+That's the common case, and it's all most writes need. But one write can affect facts in **more than one scope** — and tags name *facts* while scopes name *viewers*. The minimal failing case is favourite/unfavourite: it changes the global article-detail and article-list facts *and* the current user's session-scoped feed. "Invalidate `[:feed]` in the mutation's global scope" never reaches a feed entry that lives under a session scope; "invalidate `[:feed]` across every scope" is a blunt cross-user fan-out.
+
+The fix is the **descriptor form** — each target carries its own scope:
+
+```clojure
+:invalidates
+(fn [{:keys [slug]} _result]
+  [{:scope :rf.scope/global
+    :tags  #{[:article slug] [:article-list]}}
+   {:scope {:from-db :realworld/session}      ;; a named scope resolver, below
+    :tags  #{[:feed]}}])
+```
+
+A descriptor `:scope` may be `:rf.scope/same` (the default — the mutation's resolved scope), `:rf.scope/global`, a concrete canonical scope value (`[:rf.scope/session {:username "jake"}]`), or a **named scope resolver reference** (`{:from-db :realworld/session}`, resolved against the handler's coeffect db at settle time). Bare shorthand and descriptor form lower to the *same* scoped invalidation engine — the descriptor is just the public data telling the engine which `(tags, scope)` pairs to mark stale.
+
+A `{:from-db …}` reference that resolves **nil** is **fail-closed**: that descriptor produces no invalidation — never an implicit global blast. Xray's mutation-invalidation surface shows the per-descriptor resolved scope and lists any fail-closed `:unresolved` references.
+
+Deliberate broad invalidation (admin tooling, cache-poisoning response, a migration — "invalidate this tag in *every* scope currently holding it") stays available as an explicit audited escape (`:cross-scope? true`), is privacy-relevant in traces, and must never be the default reading of a bare tag.
+
+### Map-form exact targets
+
+`:populates`, `:patches`, and removes address an **exact** cache entry. The canonical source shape is the **target map**:
+
+```clojure
+{:resource :realworld/article
+ :params   {:slug slug}
+ :scope    :rf.scope/global}
+```
+
+`:scope` may be concrete, `:rf.scope/same`, `:rf.scope/global`, or a named resolver reference. Populate creates-or-replaces exactly one key; patch updates an existing exact key only (patch does not target tags). The internal storage representation is a scoped-key tuple, but the **map form is the only public input form** — spec, guide, traces, and examples use it.
+
+### Populate is an authoritative load
+
+Some replies carry authoritative resource data — an article save returns the full updated article. `:populates` seeds that into the cache. The rule that makes populate + invalidate coherent: **populate is an authoritative load.** A key populated by an accepted mutation reply becomes loaded, its value becomes current, freshness timers arm as if it had loaded normally — and it is **exempt from immediate refetch by that same mutation's invalidation pass**. So a mutation can populate the article detail *and* invalidate a broad `[:article …]` tag without immediately re-fetching the key it just learned from the write.
+
+The populated value MUST be the resource's **stored shape** — the same value a successful load produces (the full decoded envelope), not a sub-projection of the reply — so a populated entry reads identically to a fetched one. If the reply is *partial* relative to the full GET, opt into a same-mutation refetch per descriptor:
+
+```clojure
+:invalidates
+[{:scope :rf.scope/global
+  :tags  #{[:article slug]}
+  :refetch-populated? true}]
+```
+
+The key may still be invalidated/refetched later by other events, focus/reconnect policy, or explicit refetch — `:refetch-populated?` only governs *this* mutation's own invalidation pass.
+
+### Request decoration lives in managed HTTP, not in every resource
+
+Resources and mutations lower through Spec 014 managed HTTP. A resource's `:request` fn describes the **domain** request — method, URL, params, body, decode. Cross-cutting transport concerns — auth headers, tracing headers, common base URLs, tenant headers, default read-retry policy — are **frame/application managed-HTTP policy**, not something to copy into every resource. The seam is the managed-HTTP interceptor/defaults layer ([chapter 10](10-http.md)):
+
+```clojure
+(rf/reg-http-interceptor :realworld/auth
+  {:before (fn [ctx]
+             (let [token (some-> (rf/app-db-value (:frame ctx)) :auth :token)]
+               (cond-> ctx
+                 token (assoc-in [:request :headers "Authorization"] (str "Token " token)))))})
+
+(rf/reg-resource :realworld/current-user
+  {:request (fn [_params _ctx] {:request {:method :get :url "/user"} :decode :json})})
+```
+
+Registered once per frame, the interceptor decorates *every* managed request the frame issues — resource reads, mutations, and plain managed calls alike — so `:realworld/current-user` needs no per-resource opt-in. It reads the token from `(:frame ctx)` (carried-frame-correct, not an ambient db) and returns `ctx` unchanged when there's no token. Two riders: default retry policy should be **read-focused** (retrying writes can duplicate side effects, so mutation retry defaults stay conservative), and traces should report *that* an auth interceptor applied, never the bearer token value.
 
 ## Route-driven loading
 
@@ -501,7 +663,7 @@ The payoff: time-travel over an app full of server-state is coherent, with no re
 
 ## Xray
 
-Resources are a trace/accessor contract, not just panel UI. Xray exposes a static resource registry (ids, schemas, request summary, stale/GC policy, tag producer, scope resolver, sensitivity, declaring routes); a live resource-instance table per frame (key, scope, status, timestamps, generation, owners, tags, errors, data summary, GC eligibility); a live work-ledger table per frame; a route/resource graph; a lifecycle timeline; an invalidation graph; a cache-growth view; and the **scope audit surface** — the standing enumeration of every `:rf.scope/global` resource. Two lints ride it: a **scope-mismatch lint** (an entry under scope A while a live sub reads the same key under scope B and gets a permanent `:idle`) and the **orphaned-owner lint**. Tool accessors prefer summaries over raw values — an agent usually needs "this route owns `:article/by-slug`, it's stale, the last refresh failed 503," not the full article body — and params/scopes get the same privacy/size elision as data. (The Xray docs cover the panels in depth.)
+Resources are a trace/accessor contract, not just panel UI. Xray exposes a static resource registry (ids, schemas, request summary, stale/GC policy, tag producer, scope resolver, sensitivity, declaring routes); a **named scope resolver registry** (each `reg-resource-scope` resolver's id + declared inputs + whole-db cost flag); a live resource-instance table per frame (key, scope, status, timestamps, generation, owners, tags, errors, data summary, GC eligibility); a live work-ledger table per frame; a route/resource graph; a lifecycle timeline; an invalidation graph; a **scope resolution timeline** (each `:rf.resource/scope-resolved` event — which resolver ran, the resolved scope, and the fail-closed nil evidence); a **mutation continuations + scoped invalidation** view (the per-descriptor resolved scopes + fail-closed unresolved references off the mutation settlement traces, and the `:reply-to` continuation dispatches); a cache-growth view; and the **scope audit surface** — the standing enumeration of every `:rf.scope/global` resource. Two lints ride it: a **scope-mismatch lint** (an entry under scope A while a live sub reads the same key under scope B and gets a permanent `:idle`) and the **orphaned-owner lint**. Tool accessors prefer summaries over raw values — an agent usually needs "this route owns `:article/by-slug`, it's stale, the last refresh failed 503," not the full article body — and params/scopes get the same privacy/size elision as data. (The Xray docs cover the panels in depth.)
 
 ## What's deferred
 

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -120,7 +120,7 @@ The Resources tab is a Dynamic L3 tab (`:rf.xray/selected-tab`
 `:resources`, mnemonic `s`, order 7 — after Routing). The view
 (`panels/resources.cljs`) is pure hiccup over the single composite sub
 `:rf.xray/resources-tab-data`; the projection algebra is pure data in
-`panels/resources_helpers.cljc` (JVM-portable, unit-tested). Eight
+`panels/resources_helpers.cljc` (JVM-portable, unit-tested). Eleven
 stacked sections:
 
 1. **Static resource registry** — per registered resource: id, source
@@ -129,6 +129,16 @@ stacked sections:
    GC policy, tag-producer presence, scope policy, sensitivity/large
    class, and the **declaring routes** (cross-joined from the route
    registry's `:resources` metadata).
+1b. **Named scope resolvers** (EP-0016 D3) — per `reg-resource-scope`
+   resolver: its id, its **declared inputs** (the `[:db path]` source per
+   input name, paths summarized — the structural fact that explains which
+   app facts decide a resource identity), and the **whole-db cost flag**
+   (the explicit-cost fn-sugar marker — EP-0015 disposition 8: whole-db
+   sugar degrades both narrow re-resolution and sensitivity-inheritance
+   precision). Per-resolution input VALUES + the resolved scope are NOT
+   here (a static declaration carries no PII) — they surface in the scope
+   resolution timeline (§6b) off the egress-projected
+   `:rf.resource/scope-resolved` trace.
 2. **Live instances** (per frame) — per cache entry: resource key
    (scope + params summarized), status, derived `:stale?`, `:has-data?`,
    data summary, error / refresh-error summaries, `:loaded-at` /
@@ -167,6 +177,35 @@ stacked sections:
    rows: summarized scope, the invalidated tags, summarized cause, the
    matched scoped keys, the match count (distinguishes a broad-tag storm
    and a zero-match "no match in this scope"), and the refetch count.
+6b. **Scope resolution timeline** (EP-0016 D3) — the
+   `:rf.resource/scope-resolved` rows: which named resolver ran, its
+   declared input names, the resolved scope (summarized — a scope carries
+   PII), and the **fail-closed nil evidence** (`:resolved-nil?` — the
+   scope-requiring site got nil and produced NO global fallback). The
+   visible proof that derived scope is explicit and inspectable, and that
+   nil fails closed (Spec 016 §Named resource-scope resolvers — scope is a
+   leak boundary).
+6c. **Mutation continuations + scoped invalidation** (EP-0016 D1/D2) — two
+   stacked surfaces making the EP-0016 doctrine visible ("reply-to is for
+   workflow; populate/patch/invalidate are for cache"):
+   - the **descriptor-level invalidation evidence** off the
+     `:rf.mutation/succeeded` / `:rf.mutation/failed` settlement traces
+     (the `:invalidation` plan-trace): the descriptor count, the
+     per-descriptor **resolved scope** (summarized) + tags +
+     `:cross-scope?` (the audited scope-agnostic escape) +
+     `:refetch-populated?` (the Rider-1 partial-reply opt-in), the
+     **fail-closed `:unresolved`** `{:from-db …}` ids (descriptors that
+     resolved nil and produced NO invalidation — never an implicit global
+     blast), and the Rider-1 **`:populate-exempt`** keys (the keys this
+     mutation populated that are exempt from its own refetch). Surfaces
+     the favorite/unfavorite global+session shape precisely;
+   - the **`:reply-to` continuation dispatch** off the
+     `:rf.mutation/replied` trace (mutation phase 6, after cache
+     consequences + instance settlement): the mutation id, instance, work
+     id, the accepted reply `:status`, and the call-site `:reply-to` event
+     **target**. A row here is positive evidence the accepted reply
+     continued into app workflow; a stale/superseded reply never fires one
+     (it appears as `:rf.mutation/stale-suppressed` instead).
 7. **Cache growth** — per-resource aggregate of entry count, owned
    count, and GC-eligible count, plus the totals + live-work count.
    Surfaces unbounded list-param growth (many entries, few owners).
@@ -206,6 +245,7 @@ against [Spec 009 §Where trace emission lives](../../../spec/009-Instrumentatio
 | Operation | Class | Emit site |
 |---|---|---|
 | `:rf.resource/registered` | lifecycle | `registry.cljc` (first-time `reg-resource`) |
+| `:rf.resource/scope-resolved` | lifecycle | `scope_registry.cljc` (a named `reg-resource-scope` resolver resolved a `{:from-db …}` reference — EP-0016 D3; carries the resolver id, declared input names + values, whole-db flag, the resolved scope, and `:resolved-nil?`) |
 | `:rf.resource/owner-attached` | lifecycle | `events.cljc` (ensure — a new lease lands) |
 | `:rf.resource/cache-hit` | dedupe | `events.cljc` (ensure — fresh-skip cache serve) |
 | `:rf.resource/deduped` | dedupe | `events.cljc` (ensure — join in-flight work) |
@@ -314,7 +354,7 @@ No event registered here dispatches a `:rf.resource/*` event (read-only).
 | `:rf.xray/resource-work-ledger` | `:rf.xray/target-frame-runtime-db`, override | the live work-ledger map at `[:rf.runtime/work-ledger]`. |
 | `:rf.xray/resource-sub-reads` | override | observed live subscription reads backing the scope-mismatch lint (empty by default). |
 | `:rf.xray/resource-routing-slice` | `:rf.xray/target-frame-runtime-db`, override | the live routing-runtime subtree at `[:rf.runtime/routing]` (current route + nav-token + per-nav-token unsettled-blocking set) backing the live route/resource graph. |
-| `:rf.xray/resources-tab-data` | the six above + `:rf.xray/trace-buffer` + the route registry | the view-facing composite: `{:silent? :registry :scope-resolvers :instances :work :live-work :stale-races :stale-tally :route-graph :timeline :invalidations :cache-growth :audit}`. Its `:scope-resolvers` is the projected named-scope-resolver registry (id + declared inputs + whole-db cost flag, paths summarized, NO resolved value); `:route-graph` joins the static route plan against the live instance/work rows + routing slice. The `:live-work` / `:stale-races` / `:stale-tally` slots are the UNIFORM reply-envelope reads (see below). |
+| `:rf.xray/resources-tab-data` | the six above + `:rf.xray/trace-buffer` + the route registry | the view-facing composite: `{:silent? :registry :scope-resolvers :instances :work :live-work :stale-races :stale-tally :route-graph :timeline :invalidations :scope-resolutions :mutation-invalidations :continuations :cache-growth :audit}`. Its `:scope-resolvers` is the projected named-scope-resolver registry (id + declared inputs + whole-db cost flag, paths summarized, NO resolved value); `:scope-resolutions` is the `:rf.resource/scope-resolved` resolution timeline (resolver id + resolved scope summarized + fail-closed nil evidence — EP-0016 D3); `:mutation-invalidations` is the descriptor-level invalidation evidence off the mutation settlement traces (per-descriptor resolved scope + fail-closed `:unresolved` + Rider-1 `:populate-exempt` — EP-0016 D2); `:continuations` is the `:rf.mutation/replied` call-site `:reply-to` dispatch evidence (EP-0016 D1). `:route-graph` joins the static route plan against the live instance/work rows + routing slice. The `:live-work` / `:stale-races` / `:stale-tally` slots are the UNIFORM reply-envelope reads (see below). |
 
 ### Events (test-only override hooks)
 
@@ -340,7 +380,12 @@ The resource family is the only ledger writer today, so the rows are all
 `:work/kind :resource` (and `:mutation`) for now; as HTTP / route /
 machine / timer families write their own ledger rows and emit their
 reply-envelope trace ops, these surfaces pick them up with no panel
-change. The contract is owned by
+change. The mutation phase ops are explicitly classified onto the
+reply-envelope phases (EP-0016 D1): `:rf.mutation/started` → `:issued`,
+`:rf.mutation/succeeded` / `:rf.mutation/failed` → `:completed`,
+`:rf.mutation/stale-suppressed` → `:stale-suppressed`, and
+`:rf.mutation/replied` (the `:reply-to` continuation dispatch) →
+`:delivered`. The contract is owned by
 [`013-Trace-Consumer.md` §One work/reply vocabulary](013-Trace-Consumer.md#one-workreply-vocabulary--reading-the-uniform-reply-envelope);
 this panel is one consumer.
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reply_envelope.cljc
@@ -337,6 +337,11 @@
    ;; Resources lower their issuance onto the work-ledger row (`.3`, landed):
    :rf.resource/work-started               :issued
    :rf.resource/fetch-started              :issued
+   ;; Mutations reuse the resource work-ledger substrate (`:work/kind
+   ;; :mutation`); `:rf.mutation/started` is the issuance row (EP-0016 D1 —
+   ;; the mutation phase order, phase 2: the managed request is issued under
+   ;; runtime-owned reply addressing).
+   :rf.mutation/started                    :issued
    ;; HTTP issues the request through the `:rf.http/managed` fx (`.2`, landed);
    ;; the canonical completion is `:rf.http/replied` (see :completed below).
    ;; Machines (`.4`) + routing (`.5`) issuance ops are forward-looking; the
@@ -367,6 +372,12 @@
    :rf.resource/succeeded                  :completed
    :rf.resource/failed                     :completed
    :rf.resource/refresh-failed             :completed
+   ;; Mutation settlement (EP-0016 D1 — phase 5, instance + work-ledger
+   ;; settled; the row carries the accepted reply `:status` via the canonical
+   ;; reply map). A `:rf.mutation/succeeded` is `:ok`; `:rf.mutation/failed` is
+   ;; `:error` or an accepted terminal `:cancelled`.
+   :rf.mutation/succeeded                  :completed
+   :rf.mutation/failed                     :completed
    :rf.machine.timer/fired                 :completed
    :rf.machine/done                        :completed
    ;; ---- stale suppression (the correctness boundary) ----
@@ -376,8 +387,18 @@
    ;; forward-looking; the suffix heuristic catches `*stale-suppress*` /
    ;; `*suppressed*` until those PRs land.
    :rf.resource/stale-suppressed           :stale-suppressed
+   ;; Mutations emit `:rf.mutation/stale-suppressed` for a superseded / cleared
+   ;; / cross-frame reply (EP-0016 D1 — a stale reply NEVER fires the
+   ;; `:reply-to` continuation; it suppresses here instead), carrying the
+   ;; identical `:rf.reply/*` correlation shape (carried-vs-current generation).
+   :rf.mutation/stale-suppressed           :stale-suppressed
    :rf.reply/suppressed                    :stale-suppressed
    ;; ---- delivery ----
+   ;; `:rf.mutation/replied` is the call-site `:reply-to` continuation dispatch
+   ;; (EP-0016 D1 — phase 6, after cache consequences + instance settlement). A
+   ;; row here is the accepted reply CONTINUING into app workflow; it is emitted
+   ;; only for an accepted terminal reply, never a stale one.
+   :rf.mutation/replied                    :delivered
    :rf.reply/delivered                     :delivered})
 
 (def ^:private suffix->phase

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -182,6 +182,54 @@
       (empty-caption "No resources registered in the host app."
                      "rf-xray-resources-registry-empty"))))
 
+;; ---- §1b NAMED SCOPE RESOLVERS (EP-0016 D3) -----------------------------
+;;
+;; The static `(rf/registrations :resource-scope)` registry: each named
+;; resolver's id + its DECLARED inputs (the `[:db path]` sources that decide a
+;; resource identity, paths summarized) + the whole-db-sugar cost flag. Per
+;; Spec 016 §Named resource-scope resolvers. The LIVE per-resolution input
+;; values + resolved scope surface in the resolution timeline (§5b) off the
+;; egress-projected `:rf.resource/scope-resolved` trace — NEVER here (a static
+;; declaration carries no PII).
+
+(defn- scope-resolver-row-view [row]
+  (let [sid (:scope-id row)
+        testid (str "rf-xray-resources-scope-resolver-row-"
+                    (when sid (-> sid str (subs 1))))]
+    [:div {:data-testid testid
+           :data-scope-id (str sid)
+           :style {:display "flex" :align-items "baseline" :gap "10px"
+                   :flex-wrap "wrap" :padding "3px 0"
+                   :font-family mono-stack :font-size "12px"}}
+     [:span {:data-testid (str testid "-id")
+             :style {:color mode-accent :font-weight 600 :min-width "10rem"}}
+      (str sid)]
+     (if (seq (:inputs row))
+       (into [:span {:data-testid (str testid "-inputs")
+                     :style {:color (:text-tertiary tokens)}}
+              "inputs: "]
+             (interpose " "
+               (for [in (:inputs row)]
+                 [:span {:style {:color (:text-primary tokens)}}
+                  (str (:name in) "←" (:source in) " " (get-in in [:path :preview]))])))
+       [:span {:style {:color (:text-tertiary tokens)}} "no declared inputs"])
+     (when (:whole-db? row)
+       [:span {:data-testid (str testid "-whole-db")
+               :style {:color (:warning tokens)}}
+        "whole-db cost"])]))
+
+(defn- scope-resolvers-section [rows]
+  (section
+    {:first? false :testid "rf-xray-resources-scope-resolvers"}
+    (section-caption "Named scope resolvers" "rf-xray-resources-scope-resolvers-caption")
+    (if (seq rows)
+      (into [:div {:data-testid "rf-xray-resources-scope-resolvers-body"
+                   :style {:display "flex" :flex-direction "column" :gap "2px"}}]
+            (for [row rows]
+              ^{:key (str (:scope-id row))} (scope-resolver-row-view row)))
+      (empty-caption "No named resource-scope resolvers registered."
+                     "rf-xray-resources-scope-resolvers-empty"))))
+
 ;; ---- §2 LIVE INSTANCES --------------------------------------------------
 
 (defn- instance-row-view [row]
@@ -419,6 +467,136 @@
       (empty-caption "No invalidations in this epoch."
                      "rf-xray-resources-invalidation-empty"))))
 
+;; ---- §6b SCOPE RESOLUTION TIMELINE (EP-0016 D3) -------------------------
+;;
+;; The `:rf.resource/scope-resolved` rows: which named resolver ran, the
+;; declared input names, the resolved scope (PRIVACY-summarized), and the
+;; fail-closed nil evidence (`resolved-nil?` — the scope-requiring site got nil,
+;; never an implicit global). Per Spec 016 §Named resource-scope resolvers.
+
+(defn- scope-resolution-row-view [row]
+  [:div {:data-testid (str "rf-xray-resources-scope-resolution-row-" (:id row))
+         :data-resolved-nil (str (:resolved-nil? row))
+         :style {:display "flex" :gap "8px" :align-items "baseline"
+                 :padding "2px 0" :font-family mono-stack :font-size "11px"}}
+   [:span {:style {:color (if (:resolved-nil? row)
+                            (:warning tokens)
+                            (:text-primary tokens))
+                   :font-weight 600 :min-width "9rem"}}
+    (if (:resolved-nil? row) "resolved nil" "scope resolved")]
+   [:span {:style {:color mode-accent}} (str (:scope-id row))]
+   (when (seq (:inputs row))
+     [:span {:style {:color (:text-tertiary tokens)}}
+      "inputs " (str/join "," (map name (:inputs row)))])
+   (when (:whole-db? row)
+     [:span {:style {:color (:warning tokens)}} "whole-db"])
+   (if (:resolved-nil? row)
+     [:span {:data-testid (str "rf-xray-resources-scope-resolution-failclosed-" (:id row))
+             :style {:color (:warning tokens)}}
+      "fail-closed (no global fallback)"]
+     [:span {:style {:color (:text-tertiary tokens)}}
+      "→ " (get-in row [:scope :preview])])])
+
+(defn- scope-resolution-section [rows]
+  (section
+    {:first? false :testid "rf-xray-resources-scope-resolution"}
+    (section-caption "Scope resolution timeline" "rf-xray-resources-scope-resolution-caption")
+    (if (seq rows)
+      (into [:div {:data-testid "rf-xray-resources-scope-resolution-body"
+                   :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+            (for [row rows]
+              ^{:key (str (:id row))} (scope-resolution-row-view row)))
+      (empty-caption "No named-scope resolutions in this epoch."
+                     "rf-xray-resources-scope-resolution-empty"))))
+
+;; ---- §6c MUTATION CONTINUATIONS + DESCRIPTOR EVIDENCE (EP-0016 D1/D2) ----
+;;
+;; The descriptor-level invalidation evidence (per-descriptor resolved scope +
+;; fail-closed `:unresolved` + Rider-1 `:populate-exempt`) off the mutation
+;; settlement traces, and the call-site `:reply-to` continuation dispatch
+;; (`:rf.mutation/replied`). The doctrine made visible: "reply-to is for
+;; workflow; populate/patch/invalidate are for cache" (Spec 016 §Mutation
+;; completion continuations / §Trace evidence for invalidation).
+
+(defn- descriptor-chip [d]
+  [:span {:style {:color (:text-tertiary tokens)}}
+   "["
+   (if (:cross-scope? d)
+     [:span {:style {:color (:warning tokens)}} "cross-scope"]
+     [:span {:style {:color (:text-primary tokens)}} (get-in d [:scope :preview])])
+   " " (str/join " " (map pr-str (:tags d)))
+   (when (:refetch-populated? d)
+     [:span {:style {:color (:info tokens)}} " refetch-populated"])
+   "]"])
+
+(defn- mutation-invalidation-row-view [row]
+  [:div {:data-testid (str "rf-xray-resources-mutation-invalidation-row-" (:id row))
+         :data-mutation (str (:mutation row))
+         :style {:display "flex" :gap "8px" :align-items "baseline" :flex-wrap "wrap"
+                 :padding "2px 0" :font-family mono-stack :font-size "11px"}}
+   [:span {:style {:color (:orange tokens) :font-weight 600 :min-width "9rem"}}
+    "mutation invalidate"]
+   [:span {:style {:color mode-accent}} (str (:mutation row))]
+   [:span {:style {:color (:text-tertiary tokens)}}
+    (str (:descriptor-count row) " descriptors")]
+   (into [:span {:style {:display "flex" :gap "6px" :flex-wrap "wrap"}}]
+         (for [d (:dispatched row)]
+           ^{:key (str (get-in d [:scope :preview]) (:tags d))} (descriptor-chip d)))
+   (when (seq (:unresolved row))
+     [:span {:data-testid (str "rf-xray-resources-mutation-invalidation-unresolved-" (:id row))
+             :style {:color (:warning tokens)}}
+      "unresolved (fail-closed): " (str/join " " (map str (:unresolved row)))])
+   (when (seq (:populate-exempt row))
+     [:span {:style {:color (:info tokens)}}
+      (count (:populate-exempt row)) " populate-exempt"])])
+
+(defn- continuation-status-colour
+  "Reply-status → token for a `:reply-to` continuation row (the accepted reply
+  status, NOT a resource status): `:ok` green, `:error` red, `:cancelled`
+  muted-warning, else accent."
+  [status]
+  (case status
+    :ok        (:green tokens)
+    :error     (:error tokens)
+    :cancelled (:warning tokens)
+    mode-accent))
+
+(defn- continuation-row-view [row]
+  [:div {:data-testid (str "rf-xray-resources-continuation-row-" (:id row))
+         :data-mutation (str (:mutation row))
+         :data-status (str (some-> (:status row) name))
+         :style {:display "flex" :gap "8px" :align-items "baseline" :flex-wrap "wrap"
+                 :padding "2px 0" :font-family mono-stack :font-size "11px"}}
+   [:span {:style {:color (continuation-status-colour (:status row)) :font-weight 600 :min-width "9rem"}}
+    "reply-to → " (some-> (:status row) name)]
+   [:span {:style {:color mode-accent}} (str (:mutation row))]
+   [:span {:style {:color (:text-primary tokens)}} (pr-str (:target row))]
+   (when (:work-id row)
+     [:span {:style {:color (:text-tertiary tokens)}} "work " (pr-str (:work-id row))])])
+
+(defn- continuations-section [{:keys [continuations mutation-invalidations]}]
+  (section
+    {:first? false :testid "rf-xray-resources-continuations"}
+    (section-caption "Mutation continuations + scoped invalidation"
+                     "rf-xray-resources-continuations-caption")
+    [:div {:style {:display "flex" :flex-direction "column" :gap "8px"}}
+     ;; the descriptor-level invalidation evidence (cache consequence)
+     (if (seq mutation-invalidations)
+       (into [:div {:data-testid "rf-xray-resources-mutation-invalidation-body"
+                    :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+             (for [row mutation-invalidations]
+               ^{:key (str (:id row))} (mutation-invalidation-row-view row)))
+       (empty-caption "No scoped mutation invalidations in this epoch."
+                      "rf-xray-resources-mutation-invalidation-empty"))
+     ;; the call-site :reply-to continuation dispatch (workflow)
+     (if (seq continuations)
+       (into [:div {:data-testid "rf-xray-resources-continuations-body"
+                    :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+             (for [row continuations]
+               ^{:key (str (:id row))} (continuation-row-view row)))
+       (empty-caption "No :reply-to continuations dispatched in this epoch."
+                      "rf-xray-resources-continuations-empty"))]))
+
 ;; ---- §7 CACHE GROWTH ----------------------------------------------------
 
 (defn- cache-growth-section [growth]
@@ -512,14 +690,17 @@
 
 (rf/reg-view Panel
   "The Resources tab's root view (Spec 016 §Xray and AI tooling).
-  Subscribes to `:rf.xray/resources-tab-data` and renders the eight
-  sections top → bottom: static registry, live instances, work ledger,
-  route/resource graph, lifecycle timeline, invalidation graph, cache
-  growth, scope audit + lints. When the host has no resources registered
-  AND no live instances, renders the silent-by-default caption."
+  Subscribes to `:rf.xray/resources-tab-data` and renders the sections
+  top → bottom: static registry, named scope resolvers (EP-0016 D3), live
+  instances, work ledger, route/resource graph, lifecycle timeline,
+  invalidation graph, scope resolution timeline (EP-0016 D3), mutation
+  continuations + scoped invalidation (EP-0016 D1/D2), cache growth, scope
+  audit + lints. When the host has no resources registered AND no live
+  instances, renders the silent-by-default caption."
   []
-  (let [{:keys [silent? registry instances work route-graph timeline
-                invalidations cache-growth audit]}
+  (let [{:keys [silent? registry scope-resolvers instances work route-graph
+                timeline invalidations scope-resolutions mutation-invalidations
+                continuations cache-growth audit]}
         @(rf/subscribe [:rf.xray/resources-tab-data])]
     [:section {:data-testid "rf-xray-resources"
                :style {:height         "100%"
@@ -534,11 +715,15 @@
        (silent-state)
        [:<>
         (registry-section registry)
+        (scope-resolvers-section scope-resolvers)
         (instances-section instances)
         (work-ledger-section work)
         (route-graph-section route-graph)
         (timeline-section timeline)
         (invalidation-section invalidations)
+        (scope-resolution-section scope-resolutions)
+        (continuations-section {:continuations continuations
+                                :mutation-invalidations mutation-invalidations})
         (cache-growth-section cache-growth)
         (audit-section audit)])]))
 
@@ -724,6 +909,18 @@
                            :blocking-keys (h/routing-blocking-keys routing-slice)})
          :timeline      (h/lifecycle-timeline trace-buffer)
          :invalidations (h/invalidation-graph trace-buffer)
+         ;; EP-0016 D3 (slice 8): the named-scope-resolver RESOLUTION timeline
+         ;; — `:rf.resource/scope-resolved` rows (which resolver ran, resolved
+         ;; scope summarized, fail-closed nil evidence).
+         :scope-resolutions (h/scope-resolutions trace-buffer)
+         ;; EP-0016 D2 (slice 8): the descriptor-level invalidation evidence off
+         ;; the mutation settlement traces (resolved scope per descriptor +
+         ;; fail-closed `:unresolved` + Rider-1 `:populate-exempt`).
+         :mutation-invalidations (h/mutation-invalidation-evidence trace-buffer)
+         ;; EP-0016 D1 (slice 8): the call-site `:reply-to` continuation
+         ;; dispatch evidence (`:rf.mutation/replied` — phase 6, after cache
+         ;; consequences + instance settlement).
+         :continuations (h/mutation-continuations trace-buffer)
          :cache-growth  (h/cache-growth instance-rows work-rows)
          :audit         {:global-audit (h/global-scope-audit registry-rows)
                          :suspicious   (h/suspicious-global-warnings registry-rows)

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -105,7 +105,10 @@
 ;;
 ;; The runtime EMITS these rows across the resource artefact —
 ;; `:rf.resource/registered` (`registry.cljc`, frame-agnostic),
-;; `:owner-attached` / `:cache-hit` / `:deduped` / `:fetch-started` /
+;; `:rf.resource/scope-resolved` (`scope_registry.cljc` — a named
+;; resource-scope resolver resolved an `{:from-db …}` reference to a
+;; concrete scope (or nil); EP-0016 D3 / Spec 016 §Named resource-scope
+;; resolvers), `:owner-attached` / `:cache-hit` / `:deduped` / `:fetch-started` /
 ;; `:work-started` (`events.cljc` ensure path), `:invalidated`,
 ;; `:refetch-decision`, `:revalidate-scan` (focus/reconnect scan summary),
 ;; `:owner-released`, `:removed`, `:succeeded` / `:failed` /
@@ -154,6 +157,7 @@
   and `:hydration`. Per Spec 016 §Xray and AI tooling (the trace-family
   enumeration)."
   {:rf.resource/registered           {:class :lifecycle    :label "registered"}
+   :rf.resource/scope-resolved       {:class :lifecycle    :label "scope resolved"}
    :rf.resource/owner-attached       {:class :lifecycle    :label "owner attached"}
    :rf.resource/cache-hit            {:class :dedupe       :label "cache hit"}
    :rf.resource/deduped              {:class :dedupe       :label "deduped"}
@@ -919,6 +923,163 @@
                   :matched     (mapv scoped-key-summary matched)
                   :match-count (count matched)
                   :refetched   (or (:refetched tags) 0)})))))
+
+;; ---------------------------------------------------------------------------
+;; EP-0016 D3 — named scope-resolver resolution timeline (Spec 016 §Named
+;; resource-scope resolvers / §Trace evidence). The runtime emits
+;; `:rf.resource/scope-resolved` whenever a named resolver resolves a
+;; `{:from-db …}` reference (route entry, event ensure, subscription read,
+;; invalidation descriptor, the pure `resolve-resource-scope` helper). Each row
+;; explains WHICH resolver ran, the declared input NAMES that decided the
+;; identity, the resolved scope (PRIVACY-summarized — a scope carries PII), and
+;; whether the resolution FAILED CLOSED (`:resolved-nil?` — the scope-requiring
+;; site got nil, never an implicit global).
+;; ---------------------------------------------------------------------------
+
+(defn scope-resolutions
+  "Project the `:rf.resource/scope-resolved` trace rows into the named-scope
+  resolution timeline (EP-0016 D3 / Spec 016 §Named resource-scope resolvers).
+  One row per resolution event:
+
+      {:id           <trace-id>
+       :scope-id     :realworld/session   ; the named resolver that ran
+       :inputs       [:username]          ; declared input NAMES (not values)
+       :input-values <summary>            ; PRIVACY — resolved input values summarized
+       :whole-db?    false                ; the explicit-cost fn-sugar flag
+       :scope        <summary>            ; PRIVACY — the resolved scope summarized
+       :resolved-nil? false}              ; true ⇒ FAIL-CLOSED (no implicit global)
+
+  PRIVACY: the resolved input VALUES and the resolved SCOPE both carry PII
+  (user/tenant/locale/impersonation ids), so both go through `summarize`; the
+  declared input NAMES and the `:scope-id` are structural keywords (never PII).
+  A `:resolved-nil? true` row is the fail-closed evidence — the resolver
+  returned nil and the scope-requiring site produced NO global fallback. Pure
+  over the trace vector; preserves buffer order (oldest-first). Per Spec 016."
+  [trace-buffer]
+  (->> (or trace-buffer [])
+       (filter #(= :rf.resource/scope-resolved (trace-op %)))
+       (mapv (fn [ev]
+               (let [tags (trace-tags ev)]
+                 {:id            (:id ev)
+                  :scope-id      (or (:resource-id tags) (:scope-id tags))
+                  :inputs        (vec (:inputs tags))
+                  :input-values  (when (contains? tags :input-values)
+                                   (summarize (:input-values tags)))
+                  :whole-db?     (boolean (:whole-db? tags))
+                  :scope         (summarize (:scope tags))
+                  :resolved-nil? (boolean (:resolved-nil? tags))})))))
+
+;; ---------------------------------------------------------------------------
+;; EP-0016 D1/D2 — mutation continuation + descriptor-level invalidation
+;; evidence (Spec 016 §Mutation completion continuations / §Trace evidence for
+;; invalidation / §Phase order). The descriptor evidence rides ADDITIVELY on
+;; the existing `:rf.mutation/succeeded` / `:rf.mutation/failed` settlement op
+;; under `:invalidation` (resolved scope PER descriptor + the fail-closed
+;; `:unresolved` `{:from-db …}` ids + the Rider-1 `:populate-exempt` keys); the
+;; call-site `:reply-to` continuation dispatch is the `:rf.mutation/replied`
+;; op. These two surfaces answer the operator's EP-0016 questions: "did one
+;; write invalidate global AND session scopes precisely?" and "did the accepted
+;; reply continue into app workflow, after the cache consequences settled?"
+;; ---------------------------------------------------------------------------
+
+(def ^:private mutation-settlement-ops
+  "The `:rf.mutation/*` settlement ops that carry the descriptor-level
+  `:invalidation` plan-trace (success + failure phases). A mutation `:succeeded`
+  / `:failed` row carries `:invalidation` only when the mutation declared
+  `:invalidates`."
+  #{:rf.mutation/succeeded :rf.mutation/failed})
+
+(defn- descriptor-summary
+  "Summarize ONE resolved invalidation descriptor `{:scope … :cross-scope? …
+  :tags … :refetch-populated? …}` (the per-descriptor plan-trace facet, Spec
+  016 §Trace evidence for invalidation) for a render-safe row. PRIVACY: the
+  resolved `:scope` carries PII → summarized; the tags are identity, not PII.
+  `:cross-scope?` marks the audited scope-agnostic escape (privacy-relevant per
+  EP-0015); `:refetch-populated?` marks the partial-reply opt-in to a
+  same-mutation refetch of a populated key."
+  [{:keys [scope cross-scope? tags refetch-populated?]}]
+  {:scope              (summarize scope)
+   :cross-scope?       (boolean cross-scope?)
+   :tags               (vec tags)
+   :refetch-populated? (boolean refetch-populated?)})
+
+(defn mutation-invalidation-evidence
+  "Project the descriptor-level invalidation evidence off the
+  `:rf.mutation/succeeded` / `:rf.mutation/failed` settlement traces (EP-0016
+  D2 / Spec 016 §Trace evidence for invalidation). One row per settled mutation
+  that declared `:invalidates`:
+
+      {:id              <trace-id>
+       :operation       :rf.mutation/succeeded
+       :mutation        :realworld/favorite-article
+       :instance        [:favorite \"welcome\"]
+       :descriptor-count 2
+       :dispatched      [{:scope <summary> :cross-scope? false
+                          :tags [[:article-list] [:article \"welcome\"]]
+                          :refetch-populated? false}
+                         {:scope <summary> :cross-scope? false
+                          :tags [[:feed]] :refetch-populated? false}]
+       :unresolved      [:realworld/session]   ; {:from-db …} refs that resolved nil
+       :populate-exempt [<scoped-key> …]}      ; Rider-1 keys exempt from refetch
+
+  Distinguishes the precise-multi-scope case (≥2 dispatched descriptors with
+  different scopes — the favorite/unfavorite global+session shape) from a
+  fail-closed `:unresolved` descriptor (a `{:from-db …}` reference that
+  resolved nil and produced NO invalidation, never an implicit global blast).
+  PRIVACY: each descriptor's resolved scope is summarized; tags are identity.
+  Pure over the trace vector. Per Spec 016."
+  [trace-buffer]
+  (->> (or trace-buffer [])
+       (keep (fn [ev]
+               (let [op   (trace-op ev)
+                     tags (trace-tags ev)
+                     inv  (:invalidation tags)]
+                 (when (and (contains? mutation-settlement-ops op) (map? inv))
+                   {:id               (:id ev)
+                    :operation        op
+                    :mutation         (:mutation tags)
+                    :instance         (:instance tags)
+                    :descriptor-count (:descriptor-count inv)
+                    :dispatched       (mapv descriptor-summary (:dispatched inv))
+                    :unresolved       (vec (:unresolved inv))
+                    :populate-exempt  (mapv scoped-key-summary (:populate-exempt inv))}))))
+       vec))
+
+(defn mutation-continuations
+  "Project the call-site `:reply-to` continuation dispatch evidence off the
+  `:rf.mutation/replied` trace rows (EP-0016 D1 / Spec 016 §Mutation completion
+  continuations / §Phase order). The runtime emits `:rf.mutation/replied` ONLY
+  when it dispatches a continuation to a call-site `:reply-to` target for an
+  ACCEPTED terminal reply — a stale / superseded reply never fires one (that is
+  a `:rf.mutation/stale-suppressed` row instead), so a row here is positive
+  evidence the accepted reply continued into app workflow AFTER the cache
+  consequences and instance settlement (phase 6 of the deterministic order).
+  One row per continuation:
+
+      {:id        <trace-id>
+       :mutation  :realworld/save-article
+       :instance  [:editor/save \"first-post\"]
+       :work-id   [:rf.work/resource [:rf.mutation [:editor/save \"first-post\"]] 8]
+       :status    :ok                     ; the accepted reply status
+       :target    [:editor/save-replied]  ; the call-site :reply-to event target
+       :cause     <summary>}              ; [:mutation <id> <instance>] — summarized
+
+  PRIVACY: the `:cause` may carry data → summarized; the `:target` is a public
+  event-vector prefix (data-only — the reply substrate rejects host handles),
+  the mutation/instance/work/status are framework bookkeeping. Pure over the
+  trace vector; preserves buffer order. Per Spec 016."
+  [trace-buffer]
+  (->> (or trace-buffer [])
+       (filter #(= :rf.mutation/replied (trace-op %)))
+       (mapv (fn [ev]
+               (let [tags (trace-tags ev)]
+                 {:id       (:id ev)
+                  :mutation (:mutation tags)
+                  :instance (:instance tags)
+                  :work-id  (or (:work-id tags) (:work/id tags))
+                  :status   (:status tags)
+                  :target   (:target tags)
+                  :cause    (when (contains? tags :cause) (summarize (:cause tags)))})))))
 
 (defn cache-growth
   "Project the live instance rows + the work ledger into the cache-growth

--- a/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
@@ -185,6 +185,8 @@
   (testing "issuance / start across families (the landed literals)"
     (is (= :issued (re/phase-of :rf.resource/work-started)))
     (is (= :issued (re/phase-of :rf.resource/fetch-started)))
+    ;; EP-0016 D1 (slice 8) — mutation issuance reuses the resource ledger.
+    (is (= :issued (re/phase-of :rf.mutation/started)))
     (is (= :issued (re/phase-of :rf.machine.timer/scheduled))))
   (testing "retry / intermediate"
     (is (= :retry (re/phase-of :rf.http/retry-attempt)))
@@ -202,12 +204,19 @@
     (is (= :completed (re/phase-of :rf.http/failed)))
     (is (= :completed (re/phase-of :rf.resource/work-completed)))
     (is (= :completed (re/phase-of :rf.resource/succeeded)))
+    ;; EP-0016 D1 (slice 8) — mutation settlement (phase 5).
+    (is (= :completed (re/phase-of :rf.mutation/succeeded)))
+    (is (= :completed (re/phase-of :rf.mutation/failed)))
     (is (= :completed (re/phase-of :rf.machine/done))))
   (testing "stale suppression lowers to ONE phase — the landed resource op +
-            the shared substrate :rf.reply/suppressed"
+            the shared substrate :rf.reply/suppressed + the mutation analogue"
     (is (= :stale-suppressed (re/phase-of :rf.resource/stale-suppressed)))
+    ;; EP-0016 D1 — a stale mutation reply suppresses, never fires :reply-to.
+    (is (= :stale-suppressed (re/phase-of :rf.mutation/stale-suppressed)))
     (is (= :stale-suppressed (re/phase-of :rf.reply/suppressed))))
-  (testing "delivery"
+  (testing "delivery — the call-site :reply-to continuation is the mutation
+            delivery row (EP-0016 D1, phase 6)"
+    (is (= :delivered (re/phase-of :rf.mutation/replied)))
     (is (= :delivered (re/phase-of :rf.reply/delivered))))
   (testing "the suffix heuristic classifies a NOT-YET-enumerated family op
             (a new :rf.stream/* surface) before the table learns it"

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
@@ -184,6 +184,10 @@
         (is (some? (find-by-testid tree "rf-xray-resources-route-graph")) "route-graph section")
         (is (some? (find-by-testid tree "rf-xray-resources-timeline")) "timeline section")
         (is (some? (find-by-testid tree "rf-xray-resources-invalidation")) "invalidation section")
+        ;; EP-0016 slice-8 sections (always present when not silent)
+        (is (some? (find-by-testid tree "rf-xray-resources-scope-resolvers")) "scope-resolvers section")
+        (is (some? (find-by-testid tree "rf-xray-resources-scope-resolution")) "scope-resolution timeline section")
+        (is (some? (find-by-testid tree "rf-xray-resources-continuations")) "continuations section")
         (is (some? (find-by-testid tree "rf-xray-resources-cache-growth")) "cache-growth section")
         (is (some? (find-by-testid tree "rf-xray-resources-audit")) "audit section")
         ;; a registry row for the article resource
@@ -197,6 +201,86 @@
           (is (some? audit))
           (is (re-find #":article/by-slug" (node-text audit))
               "global-scope audit lists the explicit-global resource"))))))
+
+;; ---- (3b) EP-0016 slice-8 surfaces --------------------------------------
+
+(def scope-resolver-regs
+  {:realworld/session
+   {:doc "Session scope from the auth username."
+    :rf/resource-scope {:doc "Session scope from the auth username."
+                        :inputs {:username [:db [:auth :user :username]]}
+                        :whole-db? false
+                        :resolve (fn [_ _] nil)}}})
+
+(def ep0016-buffer
+  [;; a named resolver resolved {:from-db :realworld/session} → a session scope
+   {:id 50 :op-type :rf.event :operation :rf.resource/scope-resolved
+    :tags {:resource-id :realworld/session :kind :resource-scope
+           :inputs [:username] :input-values {:username "jake"}
+           :whole-db? false :scope [:rf.scope/session {:username "jake"}]
+           :resolved-nil? false}}
+   ;; a favorite mutation invalidated global article/list + the session feed,
+   ;; with a fail-closed unresolved {:from-db …} + a populate-exempt key
+   {:id 51 :op-type :rf.event :operation :rf.mutation/succeeded
+    :tags {:mutation :realworld/favorite-article :instance [:favorite "welcome"]
+           :invalidation
+           {:descriptor-count 3
+            :dispatched [{:scope :rf.scope/global :cross-scope? false
+                          :tags #{[:article-list]} :refetch-populated? false}
+                         {:scope [:rf.scope/session {:username "jake"}] :cross-scope? false
+                          :tags #{[:feed]} :refetch-populated? false}]
+            :unresolved [:realworld/tenant]
+            :populate-exempt [[:rf.scope/global :realworld/article {:slug "welcome"}]]}}}
+   ;; the call-site :reply-to continuation dispatch
+   {:id 52 :op-type :rf.event :operation :rf.mutation/replied
+    :tags {:rf.frame/id :app/main :mutation :realworld/save-article
+           :instance [:editor/save "first-post"] :status :ok
+           :work-id [:rf.work/resource [:rf.mutation [:editor/save "first-post"]] 8]
+           :target [:editor/save-replied]
+           :cause [:mutation :realworld/save-article [:editor/save "first-post"]]}}])
+
+(deftest ep0016-surfaces-render
+  (testing "scope resolvers, scope-resolution timeline, descriptor-level
+            invalidation evidence, and :reply-to continuations render from the
+            registry + trace buffer (EP-0016 slice 8)"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-overrides!)
+      (rf/dispatch-sync [:rf.xray/set-registered-scope-resolvers-override-for-test
+                         scope-resolver-regs]
+                        {:frame :rf/xray})
+      (rf/dispatch-sync [:rf.xray/sync-trace-buffer ep0016-buffer] {:frame :rf/xray})
+      (let [tree (resources/Panel)]
+        ;; D3 — the named-scope-resolver registry row (id + declared inputs)
+        (is (some? (find-by-testid tree "rf-xray-resources-scope-resolver-row-realworld/session"))
+            "named scope-resolver row rendered")
+        (is (re-find #"username"
+                     (node-text (find-by-testid
+                                 tree "rf-xray-resources-scope-resolver-row-realworld/session-inputs")))
+            "declared input name surfaced")
+        ;; D3 — the resolution timeline row (resolved scope, not nil)
+        (is (some? (find-by-testid tree "rf-xray-resources-scope-resolution-row-50"))
+            "scope-resolution timeline row rendered")
+        ;; D2 — the descriptor-level invalidation evidence row
+        (let [row (find-by-testid tree "rf-xray-resources-mutation-invalidation-row-51")]
+          (is (some? row) "mutation invalidation evidence row rendered")
+          (is (re-find #"3 descriptors" (node-text row))
+              "descriptor count surfaced")
+          ;; the two dispatched descriptors (global + session) render as chips
+          (is (re-find #":rf.scope/global" (node-text row))
+              "global descriptor scope surfaced")
+          (is (re-find #":feed" (node-text row))
+              "session-scoped feed descriptor surfaced"))
+        ;; D2 — the fail-closed unresolved {:from-db …} evidence
+        (is (some? (find-by-testid tree "rf-xray-resources-mutation-invalidation-unresolved-51"))
+            "fail-closed unresolved descriptor surfaced")
+        ;; D1 — the :reply-to continuation dispatch row (phase 6)
+        (let [row (find-by-testid tree "rf-xray-resources-continuation-row-52")]
+          (is (some? row) ":reply-to continuation row rendered")
+          (is (re-find #":editor/save-replied" (node-text row))
+              "the call-site :reply-to target surfaced")
+          (is (re-find #":realworld/save-article" (node-text row))
+              "the mutation id surfaced"))))))
 
 (deftest instance-row-shows-status-and-owners
   (testing "the instance row surfaces status + owner-count, derived not stored"

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
@@ -86,6 +86,10 @@
     (is (= :gc (h/op-class :rf.resource/gc-fired)))
     (is (= :dedupe (h/op-class :rf.resource/deduped)))
     (is (= :hydration (h/op-class :rf.resource/hydrated)))
+    ;; EP-0016 D3 (slice 8) — the named-scope-resolver resolution op.
+    (is (h/resource-trace-op? :rf.resource/scope-resolved))
+    (is (= :lifecycle (h/op-class :rf.resource/scope-resolved)))
+    (is (= "scope resolved" (h/op-label :rf.resource/scope-resolved)))
     (is (= "fetch started" (h/op-label :rf.resource/fetch-started))))
   (testing "the SSR / route / revalidate ops the runtime also emits are
             enumerated (rf2-uqwbhr — align the enum with the emitted set)"
@@ -104,6 +108,7 @@
           ;; set, cross-checked against implementation/resources/ emit sites
           ;; + Spec 009 §Where trace emission lives.
           emitted    #{:rf.resource/registered
+                       :rf.resource/scope-resolved
                        :rf.resource/owner-attached
                        :rf.resource/cache-hit
                        :rf.resource/deduped
@@ -477,6 +482,112 @@
         (is (= 2 (:entry-count article)))
         (is (= 1 (:owned-count article)))
         (is (= 1 (:gc-eligible article)))))))
+
+;; ---- (7b) EP-0016 slice-8 projections ----------------------------------
+;; scope-resolution timeline (D3), descriptor-level invalidation evidence
+;; (D2), and the call-site :reply-to continuation dispatch (D1).
+
+(def ^:private ep0016-trace-buffer
+  [;; a named resolver resolved a {:from-db …} reference to a concrete scope
+   {:id 10 :operation :rf.resource/scope-resolved
+    :tags {:resource-id :realworld/session
+           :kind :resource-scope
+           :inputs [:username]
+           :input-values {:username "jake"}
+           :whole-db? false
+           :scope [:rf.scope/session {:username "jake"}]
+           :resolved-nil? false}}
+   ;; a resolver that FAILED CLOSED — returned nil (no implicit global)
+   {:id 11 :operation :rf.resource/scope-resolved
+    :tags {:resource-id :realworld/session
+           :inputs [:username]
+           :input-values {:username nil}
+           :whole-db? false
+           :scope nil
+           :resolved-nil? true}}
+   ;; a mutation settled with per-target scoped invalidation descriptors
+   ;; (global + session) + a fail-closed unresolved {:from-db …} + a Rider-1
+   ;; populate-exempt key
+   {:id 12 :operation :rf.mutation/succeeded
+    :tags {:mutation :realworld/favorite-article
+           :instance [:favorite "welcome"]
+           :invalidation
+           {:descriptor-count 3
+            :dispatched [{:scope :rf.scope/global :cross-scope? false
+                          :tags #{[:article-list] [:article "welcome"]}
+                          :refetch-populated? false}
+                         {:scope [:rf.scope/session {:username "jake"}] :cross-scope? false
+                          :tags #{[:feed]} :refetch-populated? false}]
+            :unresolved [:realworld/tenant]
+            :populate-exempt [[:rf.scope/global :realworld/article {:slug "welcome"}]]}}}
+   ;; a mutation settlement with NO :invalidation facet (no :invalidates) — skipped
+   {:id 13 :operation :rf.mutation/succeeded
+    :tags {:mutation :realworld/noop :instance [:noop 1]}}
+   ;; the call-site :reply-to continuation dispatch (phase 6)
+   {:id 14 :operation :rf.mutation/replied
+    :tags {:rf.frame/id :app/main
+           :mutation :realworld/save-article
+           :instance [:editor/save "first-post"]
+           :work-id [:rf.work/resource [:rf.mutation [:editor/save "first-post"]] 8]
+           :status :ok
+           :target [:editor/save-replied]
+           :cause [:mutation :realworld/save-article [:editor/save "first-post"]]}}])
+
+(deftest scope-resolutions-test
+  (let [rows (h/scope-resolutions ep0016-trace-buffer)]
+    (testing "one row per :rf.resource/scope-resolved, in buffer order"
+      (is (= 2 (count rows)))
+      (is (= [10 11] (mapv :id rows))))
+    (testing "resolver id + declared input NAMES surfaced; scope summarized"
+      (let [r (first rows)]
+        (is (= :realworld/session (:scope-id r)))
+        (is (= [:username] (:inputs r)))
+        (is (false? (:whole-db? r)))
+        (is (false? (:resolved-nil? r)))
+        ;; the resolved scope is PRIVACY-summarized, never raw
+        (is (= "vector" (get-in r [:scope :type])))
+        ;; the resolved input values are summarized too
+        (is (map? (:input-values r)))))
+    (testing "a nil resolution surfaces as fail-closed (:resolved-nil? true)"
+      (let [r (second rows)]
+        (is (true? (:resolved-nil? r)))))))
+
+(deftest mutation-invalidation-evidence-test
+  (let [rows (h/mutation-invalidation-evidence ep0016-trace-buffer)]
+    (testing "only mutation settlements that carry an :invalidation facet"
+      (is (= 1 (count rows)))
+      (is (= 12 (:id (first rows)))))
+    (testing "per-descriptor resolved scope (summarized) + descriptor count"
+      (let [r (first rows)]
+        (is (= :realworld/favorite-article (:mutation r)))
+        (is (= 3 (:descriptor-count r)))
+        (is (= 2 (count (:dispatched r))))
+        ;; first descriptor is global, second is the session scope — both
+        ;; resolved scopes are summarized (PRIVACY), tags are identity
+        (is (= "keyword" (get-in r [:dispatched 0 :scope :type])))
+        (is (= "vector"  (get-in r [:dispatched 1 :scope :type])))
+        (is (false? (get-in r [:dispatched 0 :cross-scope?])))
+        (is (= #{[:feed]} (set (get-in r [:dispatched 1 :tags]))))))
+    (testing "fail-closed :unresolved {:from-db …} ids surface"
+      (is (= [:realworld/tenant] (:unresolved (first rows)))))
+    (testing "Rider-1 populate-exempt keys surface (summarized scoped keys)"
+      (let [r (first rows)]
+        (is (= 1 (count (:populate-exempt r))))
+        (is (= :realworld/article (get-in r [:populate-exempt 0 :resource-id])))))))
+
+(deftest mutation-continuations-test
+  (let [rows (h/mutation-continuations ep0016-trace-buffer)]
+    (testing "one row per :rf.mutation/replied continuation dispatch"
+      (is (= 1 (count rows)))
+      (let [r (first rows)]
+        (is (= :realworld/save-article (:mutation r)))
+        (is (= [:editor/save "first-post"] (:instance r)))
+        (is (= :ok (:status r)))
+        (is (= [:editor/save-replied] (:target r)))
+        (is (= [:rf.work/resource [:rf.mutation [:editor/save "first-post"]] 8]
+               (:work-id r)))
+        ;; the cause is summarized (may carry data)
+        (is (map? (:cause r)))))))
 
 ;; ---- (8) lints ----------------------------------------------------------
 


### PR DESCRIPTION
Surfaces the EP-0016 resource-mutation-completion capabilities in **Xray** and the **user guide** — EP-0016 Reference Implementation Plan **slice 8** (`docs/EP/EP-0016-resource-mutation-completion.md`). Slices 1-7 landed the runtime (resolver registry, scope integration, mutation completion, scoped invalidation, populate, request decoration); this slice makes them visible in the tools and teaches the model. Belongs to epic rf2-fi6tda.

Fence respected: only `tools/xray/` (src + spec + tests) + `docs/guide/27-resources.md`. No `implementation/` (resources/core/machines untouched), no `.beads/issues.jsonl`. The RealWorld dogfood rewrite (rf2-mgljgu) is separate and not done here.

## What landed in tools (tools/xray)

- **`resources_helpers.cljc`** — add `:rf.resource/scope-resolved` to the `trace-ops` family (class `:lifecycle`); three new pure projections:
  - `scope-resolutions` (D3) — the named-scope resolution timeline off `:rf.resource/scope-resolved` (resolver id + declared input names + resolved scope summarized + **fail-closed `:resolved-nil?`** evidence);
  - `mutation-invalidation-evidence` (D2) — the descriptor-level evidence off `:rf.mutation/succeeded`/`:failed` `:invalidation` plan-trace (per-descriptor resolved scope + `:cross-scope?` + fail-closed `:unresolved` `{:from-db …}` ids + Rider-1 `:populate-exempt`);
  - `mutation-continuations` (D1) — the call-site `:reply-to` dispatch off `:rf.mutation/replied`.
- **`reply_envelope.cljc`** — classify the mutation phase ops explicitly onto the reply-envelope phases: `started`→`:issued`, `succeeded`/`failed`→`:completed`, `stale-suppressed`→`:stale-suppressed`, `replied`→`:delivered`.
- **`resources.cljs`** — three new panel sections (Named scope resolvers, Scope resolution timeline, Mutation continuations + scoped invalidation) + the composite-sub slots.
- **`024-Resources-Panel.md`** (standing rule: xray spec updated in the same PR) — the new sections, the `scope-resolved` trace-family row, the mutation phase classification, and the composite slots.

## What landed in docs (docs/guide/27-resources.md)

- **Continue the workflow with `:reply-to`** — the doctrine ("`:reply-to` is for workflow; populate/patch/invalidate are for cache"), the deterministic 6-phase order, the accepted-reply delivery rule.
- **Per-target scoped invalidation** descriptors (the global + session favourite/unfavourite shape, fail-closed nil, the audited `:cross-scope?` escape).
- **Map-form exact targets**; **populate-as-authoritative-load** + `:refetch-populated?`.
- **Named scope resolvers** (`reg-resource-scope`, `{:from-db …}`, declared inputs, fail-closed nil).
- **Logout `clear-scope`** via `resolve-resource-scope` over the coeffect db.
- **Request decoration** lives in managed HTTP, not every resource.

## Quality gates

- `cd tools/xray && clojure -M:test` — **1130 tests / 4965 assertions, 0 failures, 0 errors**.
- `npm run test:cljs` (node-runtime CLJS, includes the Xray panel + helpers + reply-envelope tests) — **6638 tests / 24511 assertions, 0 failures, 0 errors**.
- `npm run test:xray-feature-gate` (browser smoke, nightly-full sweep; xray touched) — **16 scenarios, 0 failures, 13 matrix rows; all testbeds compiled 0 warnings**.
- `mkdocs build --strict` (docs/guide + spec touched) — **exit 0, clean**.

Belongs to epic rf2-fi6tda. Do not merge (mayor-gated).