### PR TITLE
feat(tools): EP-0015 direct-read audit — tools project classified data via project-egress (rf2-mahffz)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -243,7 +243,8 @@
       (catch :default _ nil))))
 
 ;; ---------------------------------------------------------------------------
-;; Drain eval-form — server-side elision wrap (rf2-vr2hn + rf2-mscih).
+;; Drain eval-form — server-side off-box projection (rf2-vr2hn + rf2-mscih
+;; + rf2-mahffz/EP-0015 §13).
 ;; ---------------------------------------------------------------------------
 ;;
 ;; `drain-subscription!` returns one of two envelopes per the sub's topic
@@ -258,77 +259,174 @@
 ;;   - Flat topics (`:epoch`/`:frameless`) →
 ;;     `{:ok? :sub-id :events [...] :dropped-events ... :gone? ...}`.
 ;;
-;; The `:epoch` topic ships full epoch records (`:db-after` / `:db-before`
-;; ride verbatim). When the `--allow-sensitive-reads` boot gate is OFF (the
-;; published-build default), each delivered value must flow through
-;; `re-frame.core/elide-wire-value` BEFORE it crosses the nREPL wire —
-;; mirroring the snapshot / get-path gate (rf2-c2dtu) so an operator who
-;; didn't pass `--allow-sensitive-reads` can't be talked into shipping raw
-;; state through a hostile per-call arg.
+;; The delivered slots take DIFFERENT off-box-egress primitives, selected
+;; by topic (rf2-mahffz):
 ;;
-;; The walker reads the live `[:rf.runtime/elision]` runtime-db registry, so it has to run
-;; app-side. We compose `drain-subscription!` server-side with mapv over
-;; whichever slot the drain produced — `:cascades` for cascade-bundle
-;; topics, `:events` for flat topics. When elision is OFF (operator opted
-;; in via `--allow-sensitive-reads` AND passed `:elision false`), the bare
-;; drain form ships raw — the pre-rf2-vr2hn posture.
+;;   - TRACE-event slots — `:cascades` (cascade-bundle topics) + the
+;;     `:frameless` topic's `:events` — are tree-shaped values rooted at
+;;     the frame's app-db, so each flows through
+;;     `re-frame.core/elide-wire-value` (the size-elision walker reading
+;;     the live `[:rf.runtime/elision]` runtime-db registry — it runs
+;;     app-side). Gated by the `:elision` toggle (rf2-vr2hn / rf2-c2dtu):
+;;     gate-OFF forces it on; gate-ON + `:elision false` ships raw.
+;;
+;;   - The `:epoch` topic's `:events` carry whole `:rf/epoch-record`s,
+;;     including the structured `:effects` rows whose `:args` slot is
+;;     payload-bearing fx input NOT rooted at app-db (so the schema-path
+;;     walker cannot prove it safe — `elide-wire-value` over a whole
+;;     record would ship `:effects[].args` RAW). Per Security.md §Epoch
+;;     privacy posture, off-box epoch egress MUST route through
+;;     `re-frame.core/projected-record` — the single normative emission
+;;     site, which FAILS CLOSED on `:effects[].args`, default-redacts the
+;;     frame-state runtime-db partition, and projects every payload slot
+;;     under `:rf.egress/off-box-observability`. Per-tool reimplementation
+;;     (the prior whole-record `elide-wire-value` walk) is prohibited. The
+;;     `:epoch` projection is gated on the SENSITIVE opt-in axis (`incl?`,
+;;     via `--allow-sensitive-reads`), like the pull-mode `watch-epochs` /
+;;     `trace-window` tools — independent of the large-slot `:elision`
+;;     toggle — so a gate-ON `:elision false` caller still gets projected
+;;     (fail-closed) records unless they ALSO pass `:include-sensitive
+;;     true`.
+;;
+;; The projection runs server-side, before any value crosses the nREPL
+;; wire, so an operator who didn't pass `--allow-sensitive-reads` can't be
+;; talked into shipping raw state through a hostile per-call arg.
 
 (defn drain-form
   "Build the nREPL drain eval form. When `elision?` is true, wraps the
   drain envelope so the delivered slot (`:cascades` or `:events`,
-  whichever the runtime produced) flows through
-  `re-frame.core/elide-wire-value` server-side. `incl?` threads into the
-  walker's `:rf.size/include-sensitive?` opt — gate-OFF callers see
-  redacted sensitive slots regardless of any per-call opt-in.
+  whichever the runtime produced) is projected for off-box egress
+  server-side. `incl?` threads into the projection's sensitive opt-in —
+  gate-OFF callers see redacted sensitive slots regardless of any
+  per-call opt-in.
 
   Per rf2-mscih the wrapper handles both delivery shapes (cascade-bundle
-  topics → `:cascades`; flat topics → `:events`) without baking the
-  topic into the form — `cond->` over slot presence keeps the form
-  topic-agnostic and the elision contract single-sourced.
+  topics → `:cascades`; flat topics → `:events`).
 
-  EP-0002 (rf2-bd4div) — the walker opts thread the resolved operating
-  frame in as the explicit `:frame` override. The drain form runs on the
-  nREPL eval thread, which carries NO ambient `with-frame` scope, so a
-  frameless `re-frame.core/elide-wire-value` would FAIL CLOSED and redact
-  every cascade slot to `:rf/redacted` (the carried-frame invariant). We
-  resolve the operating frame app-side via
+  ## Per-slot egress primitive — `topic` selects (rf2-mahffz, EP-0015 §13)
+
+  The two delivered slots are NOT the same shape, so they take DIFFERENT
+  egress primitives — selected by `topic`, not by slot presence:
+
+  - **Trace-event slots** — `:cascades` (cascade-bundle topics
+    `:trace`/`:fx`/`:error`) and the `:frameless` topic's `:events`
+    (raw trace events) — are tree-shaped values rooted at the frame's
+    app-db, so the size-elision walker
+    `re-frame.core/elide-wire-value` is the correct primitive: it
+    redacts schema-declared-sensitive slots and elides large slots.
+
+  - **The `:epoch` topic's `:events`** carry whole `:rf/epoch-record`s
+    (`:db-before` / `:db-after` / `:trigger-event` / `:trace-events`
+    PLUS the structured `:effects` rows whose `:args` slot is
+    payload-bearing fx-handler input — an HTTP body, a dispatched event
+    vector, a payment map — NOT rooted at app-db, so the schema-path
+    walker cannot prove it safe). A bare `elide-wire-value` walk over a
+    whole record therefore ships those `:effects[].args` (and the
+    `:sub-runs` rows + the frame-state runtime-db partition) RAW off-box.
+    Per Security.md §Epoch privacy posture, off-box epoch egress MUST
+    route through `re-frame.core/projected-record` — the single
+    normative emission site — which FAILS CLOSED on `:effects[].args`
+    (`:rf/redacted` unless `:include-fx-args? true`), default-redacts the
+    runtime-db partition, and projects every payload slot under
+    `:rf.egress/off-box-observability`. Per-tool reimplementation of the
+    projection (the prior whole-record `elide-wire-value` walk) is
+    prohibited. This mirrors `watch-epochs` / `trace-window`
+    (`epoch-egress/project-page-src`) and the snapshot `:epochs` slice
+    (rf2-8fin7.1): one off-box epoch-egress site, one projector.
+
+  The `:epoch` projection is gated on `(not incl?)` (the
+  `--allow-sensitive-reads` opt-in axis, like the pull-mode epoch tools)
+  rather than on `elision?`: gate-OFF forces `incl?` false ⇒ every record
+  is projected; gate-ON + `:include-sensitive true` ⇒ records ship raw
+  (the operator's deliberate opt-in). When `elision?` is false (gate-ON +
+  `:elision false`) the trace-event slots ship raw — but a gate-ON caller
+  who left `:include-sensitive` at its default (`incl?` false) still gets
+  PROJECTED epoch records, because epoch projection tracks the sensitive
+  axis, not the large-slot toggle.
+
+  EP-0002 (rf2-bd4div) — the elide-wire-value opts thread the resolved
+  operating frame in as the explicit `:frame` override. The drain form
+  runs on the nREPL eval thread, which carries NO ambient `with-frame`
+  scope, so a frameless `re-frame.core/elide-wire-value` would FAIL
+  CLOSED and redact every cascade slot to `:rf/redacted` (the
+  carried-frame invariant). We resolve the operating frame app-side via
   `(re-frame2-pair.runtime/current-frame)` and merge it into the opts —
   the same idiom `elision/elide-sub-value-src` uses for the sub-cache
   walker and `runtime/pair-dispatch!` uses for the dispatch override — so
   the walker resolves against the frame's `[:rf.runtime/elision]`
-  runtime-db registry instead of failing closed.
+  runtime-db registry instead of failing closed. `projected-record`
+  resolves the frame off each record's own `:frame` slot, so the
+  `:epoch` arm needs no `current-frame` thread.
 
   Public (not `defn-`) so unit tests can pin the form shape directly —
   the form-string is the contract surface between MCP server and the
   app-side runtime."
-  [sub-id elision? incl?]
-  (if elision?
-    (ef/emit
-      (ef/rt-let
-        ['drain (ef/rt-call 'drain-subscription! sub-id)
-         ;; rf2-suoj2 — `elision-opts-edn` first arg is walker-aligned
-         ;; `include-large?` (subscribe always elides, so emit markers ⇒
-         ;; pass `false`). Pre-rf2-suoj2 this was `true` under the old
-         ;; "enabled?" polarity that the helper inverted internally.
-         ;; EP-0002 (rf2-bd4div): merge the resolved operating frame in as
-         ;; the explicit `:frame` override (the nREPL eval thread carries
-         ;; no ambient frame scope, so a frameless elide-wire-value would
-         ;; fail closed → redact every cascade to `:rf/redacted`).
-         'opts  (ef/rt-raw
-                  (str "(merge {:frame (re-frame2-pair.runtime/current-frame)} "
-                       (elision/elision-opts-edn false incl?) ")"))]
-        ;; Apply the walker to whichever slot the drain produced.
-        ;; Per rf2-mscih cascade-bundle topics return `:cascades`; flat
-        ;; topics return `:events`. `cond->` handles both without baking
-        ;; the topic into the form.
-        (ef/rt-raw
-          (str "(let [walk (fn [xs] (mapv (fn [x] (re-frame.core/elide-wire-value x opts)) xs))]"
-               " (cond-> drain"
-               " (contains? drain :cascades)"
-               " (update :cascades walk)"
-               " (contains? drain :events)"
-               " (update :events walk)))"))))
-    (ef/emit (ef/rt-call 'drain-subscription! sub-id))))
+  [sub-id topic elision? incl?]
+  (let [epoch?         (= :epoch topic)
+        ;; Epoch records project on the sensitive opt-in axis (mirrors
+        ;; watch-epochs / trace-window) — independent of the large-slot
+        ;; `elision?` toggle, so a gate-ON `:elision false` caller who
+        ;; left `:include-sensitive` at its default still gets projected
+        ;; (fail-closed) epoch records rather than raw fx-arg payloads.
+        project-epoch? (and epoch? (not incl?))
+        ;; The trace-event walker (`:cascades` / `:frameless` `:events`)
+        ;; rides the `elision?` toggle as before. The `:epoch` topic's
+        ;; `:events` are NOT trace events — they take `projected-record`,
+        ;; never the walker — so the walker arm is suppressed for it.
+        walk-trace?    (and elision? (not epoch?))
+        drain-call     (ef/rt-call 'drain-subscription! sub-id)]
+    (cond
+      ;; Nothing to project: gate-ON + `:elision false` on a non-epoch
+      ;; topic, OR a gate-ON epoch caller who opted into raw via
+      ;; `:include-sensitive true`. Bare drain ships raw (the
+      ;; pre-rf2-vr2hn / operator-opt-in posture).
+      (not (or walk-trace? project-epoch?))
+      (ef/emit drain-call)
+
+      ;; Epoch-only projection (no trace-event walk). Each record routes
+      ;; through `re-frame.core/projected-record` — the single normative
+      ;; off-box epoch-egress site (Security.md §Epoch privacy posture):
+      ;; fails closed on `:effects[].args`, default-redacts the
+      ;; frame-state runtime-db partition, projects every payload slot
+      ;; under `:rf.egress/off-box-observability`. `projected-record`
+      ;; resolves the frame off each record's own `:frame` slot, so no
+      ;; `current-frame` thread is needed. Per-tool reimplementation (the
+      ;; prior whole-record `elide-wire-value` walk, which left
+      ;; `:effects[].args` / `:sub-runs` / runtime-db raw) is prohibited.
+      project-epoch?
+      (ef/emit
+        (ef/rt-let
+          ['drain drain-call]
+          (ef/rt-raw
+            (str "(cond-> drain"
+                 " (contains? drain :events)"
+                 " (update :events (fn [es] (mapv re-frame.core/projected-record es))))"))))
+
+      ;; Trace-event walk (cascade-bundle topics `:trace`/`:fx`/`:error`
+      ;; ship `:cascades`; the `:frameless` topic ships `:events`). These
+      ;; are tree-shaped trace events rooted at the frame's app-db, so the
+      ;; size-elision walker is the correct primitive.
+      ;;
+      ;; rf2-suoj2 — `elision-opts-edn` first arg is walker-aligned
+      ;; `include-large?` (subscribe always elides, so emit markers ⇒ pass
+      ;; `false`). EP-0002 (rf2-bd4div): merge the resolved operating frame
+      ;; in as the explicit `:frame` override (the nREPL eval thread carries
+      ;; no ambient frame scope, so a frameless elide-wire-value would fail
+      ;; closed → redact every cascade to `:rf/redacted`).
+      :else
+      (ef/emit
+        (ef/rt-let
+          ['drain drain-call
+           'opts  (ef/rt-raw
+                    (str "(merge {:frame (re-frame2-pair.runtime/current-frame)} "
+                         (elision/elision-opts-edn false incl?) ")"))]
+          (ef/rt-raw
+            (str "(let [walk (fn [xs] (mapv (fn [x] (re-frame.core/elide-wire-value x opts)) xs))]"
+                 " (cond-> drain"
+                 " (contains? drain :cascades)"
+                 " (update :cascades walk)"
+                 " (contains? drain :events)"
+                 " (update :events walk)))")))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Streaming controller — termination + poll loop.
@@ -366,7 +464,7 @@
   [{:keys [conn build-id sub-id topic resolve state
            signal send-note progress-tk poll-ms max-events
            incl? elision? dedup? cap]}]
-  (let [drain-src    (drain-form sub-id elision? incl?)
+  (let [drain-src    (drain-form sub-id topic elision? incl?)
         terminated?  (atom false)
         terminate
         (fn terminate [reason]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/subscribe_test.cljs
@@ -578,12 +578,13 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest drain-form-gated-elision-wraps-events
-  ;; Gate OFF (the default published-build posture). The drain form must:
+  ;; Gate OFF (the default published-build posture), a TRACE-event topic.
+  ;; The drain form must:
   ;;   - call `drain-subscription!` for the sub-id.
   ;;   - mapv each event through `re-frame.core/elide-wire-value`.
   ;;   - assoc the elided events back onto the drain envelope.
   ;;   - thread `:rf.size/include-sensitive? false` into the walker opts.
-  (let [form (sub/drain-form "sub-abc" true false)]
+  (let [form (sub/drain-form "sub-abc" :trace true false)]
     (is (str/includes? form "drain-subscription!")
         "drain-subscription! is the runtime entry point")
     (is (str/includes? form "\"sub-abc\"")
@@ -604,8 +605,9 @@
   ;; (`(re-frame2-pair.runtime/current-frame)`), the same idiom the
   ;; sub-cache walker + pair-dispatch override use. Without this the live
   ;; subscribe streaming gate goes RED (the cascade event vector — and its
-  ;; causal nonce — never crosses the wire; it redacts away).
-  (let [form (sub/drain-form "sub-frame" true false)]
+  ;; causal nonce — never crosses the wire; it redacts away). Trace-event
+  ;; topic — the walker arm carries the frame thread.
+  (let [form (sub/drain-form "sub-frame" :trace true false)]
     (is (str/includes? form "(re-frame2-pair.runtime/current-frame)")
         "the walker opts resolve the operating frame app-side")
     (is (str/includes? form ":frame")
@@ -617,17 +619,17 @@
   ;; Gate ON path — when the operator passed `--allow-sensitive-reads` AND the
   ;; caller passed `:include-sensitive true`, the walker still fires
   ;; (elision is independent of sensitive), but sensitive slots pass
-  ;; through.
-  (let [form (sub/drain-form "sub-xyz" true true)]
+  ;; through. Trace-event topic.
+  (let [form (sub/drain-form "sub-xyz" :trace true true)]
     (is (str/includes? form "re-frame.core/elide-wire-value"))
     (is (str/includes? form ":rf.size/include-sensitive? true")
         "include-sensitive? true threads into the walker opts")))
 
 (deftest drain-form-elision-off-bare-drain
-  ;; Gate ON + caller passes `:elision false` — the form must NOT wrap
-  ;; with the walker. Bare `drain-subscription!` call ships raw events
-  ;; (the pre-rf2-vr2hn posture).
-  (let [form (sub/drain-form "sub-raw" false false)]
+  ;; Gate ON + caller passes `:elision false` on a trace-event topic —
+  ;; the form must NOT wrap with the walker. Bare `drain-subscription!`
+  ;; call ships raw events (the pre-rf2-vr2hn posture).
+  (let [form (sub/drain-form "sub-raw" :trace false false)]
     (is (str/includes? form "drain-subscription!"))
     (is (not (str/includes? form "re-frame.core/elide-wire-value"))
         "elision OFF ⇒ no walker; raw events ride the wire")
@@ -639,12 +641,78 @@
   ;; The sub-id is an EDN string literal — `pr-str` escapes quotes /
   ;; backslashes correctly so a runtime read-string round-trips it
   ;; verbatim. Pin against a sub-id containing characters that would
-  ;; break naive concatenation.
-  (let [form (sub/drain-form "id-with-\"quote\"" true false)]
+  ;; break naive concatenation. Trace-event topic.
+  (let [form (sub/drain-form "id-with-\"quote\"" :trace true false)]
     ;; pr-str emits the embedded quotes as `\"` — the round-trip is
     ;; correct, no raw-`str` concatenation hazard.
     (is (str/includes? form "\\\"quote\\\"")
         "embedded quotes survive as escaped EDN literals")))
+
+;; ---------------------------------------------------------------------------
+;; rf2-mahffz (EP-0015 §13) — the `:epoch` topic's `:events` slot egresses
+;; whole `:rf/epoch-record`s. Those carry the structured `:effects` rows
+;; whose `:args` slot is payload-bearing fx input (an HTTP body, a payment
+;; map) — NOT rooted at app-db, so the schema-path-keyed
+;; `elide-wire-value` walker cannot prove it safe and ships it RAW. Per
+;; Security.md §Epoch privacy posture, off-box epoch egress MUST route
+;; through `re-frame.core/projected-record` — the single normative
+;; emission site, which FAILS CLOSED on `:effects[].args` — NOT the
+;; per-slot wire-value walker. Pre-rf2-mahffz the streaming `:epoch`
+;; drain reused the cascade walker (`elide-wire-value`) on whole records,
+;; leaking `:effects[].args`. The fix routes the `:epoch` topic's
+;; `:events` through `projected-record`, mirroring `watch-epochs` /
+;; `trace-window`.
+;; ---------------------------------------------------------------------------
+
+(deftest drain-form-epoch-topic-projects-via-projected-record
+  ;; Gate OFF (the default). The `:epoch` drain form MUST:
+  ;;   - call `drain-subscription!`,
+  ;;   - mapv the `:events` slot through `re-frame.core/projected-record`
+  ;;     (the single normative off-box epoch-egress site, fail-closed on
+  ;;     `:effects[].args`),
+  ;;   - NOT walk records through `elide-wire-value` (the prohibited
+  ;;     per-tool reimplementation that left `:effects[].args` raw).
+  (let [form (sub/drain-form "sub-epoch" :epoch true false)]
+    (is (str/includes? form "drain-subscription!")
+        "drain-subscription! is the runtime entry point")
+    (is (str/includes? form "re-frame.core/projected-record")
+        "epoch records route through the normative projector")
+    (is (str/includes? form ":events")
+        "the projection targets the flat :events slot")
+    (is (not (str/includes? form "re-frame.core/elide-wire-value"))
+        "epoch records MUST NOT use the per-slot wire-value walker — it leaves :effects[].args raw")))
+
+(deftest drain-form-epoch-projection-tracks-sensitive-axis-not-elision
+  ;; Epoch projection rides the `--allow-sensitive-reads` opt-in axis
+  ;; (`incl?`), like watch-epochs / trace-window — NOT the large-slot
+  ;; `elision?` toggle. A gate-ON caller who passed `:elision false` but
+  ;; left `:include-sensitive` at its default (incl? false) STILL gets
+  ;; PROJECTED (fail-closed) epoch records, not raw fx-arg payloads.
+  (let [form (sub/drain-form "sub-epoch" :epoch false false)]
+    (is (str/includes? form "re-frame.core/projected-record")
+        "elision? false does not disable epoch projection — sensitive axis governs")))
+
+(deftest drain-form-epoch-include-sensitive-opt-in-ships-raw
+  ;; Gate ON + `:include-sensitive true` (incl? true) — the operator's
+  ;; deliberate raw opt-in. Mirrors subscribe's bare-drain / watch-epochs
+  ;; raw path: the epoch records ship verbatim (no projection).
+  (let [form (sub/drain-form "sub-epoch" :epoch false true)]
+    (is (= "(re-frame2-pair.runtime/drain-subscription! \"sub-epoch\")"
+           form)
+        "raw epoch opt-in is the bare drain form")
+    (is (not (str/includes? form "re-frame.core/projected-record"))
+        "the operator opted into raw — no projection")))
+
+(deftest drain-form-frameless-topic-uses-wire-value-walker
+  ;; The `:frameless` topic's `:events` are raw TRACE events (registration
+  ;; emits, REPL evals, lifecycle) — tree-shaped, rooted at app-db — so
+  ;; they take the size-elision walker, NOT projected-record (which is for
+  ;; whole epoch records). Confirm the topic discriminates correctly.
+  (let [form (sub/drain-form "sub-fl" :frameless true false)]
+    (is (str/includes? form "re-frame.core/elide-wire-value")
+        "frameless trace events take the wire-value walker")
+    (is (not (str/includes? form "re-frame.core/projected-record"))
+        "frameless events are not epoch records — no projected-record")))
 
 ;; ---------------------------------------------------------------------------
 ;; Cascade-bundle wire format (rf2-mscih) — drain envelope shape, slot
@@ -653,19 +721,23 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest drain-form-handles-both-cascade-and-events-slots
-  ;; rf2-mscih — `drain-form` with elision ON must wrap WHICHEVER slot
-  ;; the runtime produced. The form uses `cond->` over slot presence so
-  ;; it's topic-agnostic at the form level; the runtime determines
-  ;; which slot the drain envelope carries.
-  (let [form (sub/drain-form "sub-1" true false)]
+  ;; rf2-mscih — for a TRACE-event topic (cascade-bundle `:trace`/`:fx`/
+  ;; `:error` ship `:cascades`; `:frameless` ships `:events`), `drain-form`
+  ;; with elision ON wraps WHICHEVER trace-event slot the runtime produced.
+  ;; The walker arm uses `cond->` over slot presence so it's slot-agnostic
+  ;; WITHIN the trace-event family; the runtime determines which slot the
+  ;; drain envelope carries. (rf2-mahffz: the `:epoch` topic's `:events`
+  ;; take a DIFFERENT primitive — `projected-record` — so they are NOT in
+  ;; this walker arm; covered by `drain-form-epoch-*` above.)
+  (let [form (sub/drain-form "sub-1" :trace true false)]
     (is (str/includes? form ":cascades")
         "drain form mentions the :cascades slot for cascade-bundle topics")
     (is (str/includes? form ":events")
-        "drain form mentions the :events slot for flat topics")
+        "drain form mentions the :events slot for the frameless flat topic")
     (is (str/includes? form "contains?")
         "the form uses contains? to discriminate the slot")
     (is (str/includes? form "re-frame.core/elide-wire-value")
-        "the walker is applied to whichever slot is present")))
+        "the walker is applied to whichever trace-event slot is present")))
 
 (deftest progress-payload-uses-cascades-slot-on-cascade-bundle-topics
   ;; rf2-mscih — the progress payload's load slot is named per the


### PR DESCRIPTION
## What

EP-0015 §13 direct-read/tool audit slice (bead-plan item 11, epic rf2-t55hxg). Audits every `tools/` boundary that reads frame / runtime-db / resource / machine state for DIRECT reads of classified data, confirms each projects through the framework's normative egress primitives (never raw) under the appropriate `:rf.egress/*` posture with fail-closed frame resolution, and closes the one remaining gap.

## The gap fixed — streaming `:epoch` egress

The streaming `subscribe` `:epoch` topic egressed whole `:rf/epoch-record`s over the MCP wire via `re-frame.core/elide-wire-value` (the per-slot size-elision walker). That walker is schema-path-keyed against the frame's app-db, so it **cannot prove the structured `:effects` rows' payload-bearing `:args` slot safe** — fx-handler args (an HTTP body, a dispatched event vector, a payment map) are NOT rooted at app-db. So `:effects[].args` (plus the `:sub-runs` rows and the frame-state runtime-db partition) shipped **RAW off-box** even with `--allow-sensitive-reads` OFF (the published-build default).

Per `spec/Security.md` §Epoch privacy posture, off-box epoch egress MUST route through `re-frame.core/projected-record` — the single normative emission site, which **fails closed** on `:effects[].args` (`:rf/redacted` unless `:include-fx-args? true`), default-redacts the runtime-db partition, and projects every payload slot under `:rf.egress/off-box-observability`. Per-tool reimplementation of the projection is prohibited.

The fix makes `drain-form` topic-aware:
- **`:epoch` topic `:events`** → `projected-record` (mirrors the pull-mode `watch-epochs` / `trace-window` tools and the `snapshot` `:epochs` slice), gated on the **sensitive opt-in axis** (`incl?`, via `--allow-sensitive-reads`) rather than the large-slot `:elision` toggle — so a gate-ON `:elision false` caller who left `:include-sensitive` at its default still gets fail-closed projected records, not raw fx-arg payloads.
- **Trace-event slots** (`:cascades` for `:trace`/`:fx`/`:error`; `:events` for `:frameless`) keep `elide-wire-value` — they are tree-shaped values rooted at app-db, where the walker is the correct primitive, with the existing fail-closed `(current-frame)` thread.

The on-box runtime `drain-subscription!` still returns the raw record (Security.md: listener fan-out delivers raw; the off-box forwarder projects at egress). The projection point is the MCP wire boundary, which matches the spec posture.

## Audit verdict per surface

| Surface | Reads | Egress primitive | Verdict |
|---|---|---|---|
| `subscribe` `:epoch` (streaming) | epoch records | **`projected-record`** | **FIXED (was `elide-wire-value` → leaked `:effects[].args`)** |
| `subscribe` `:trace`/`:fx`/`:error`/`:frameless` | trace events | `elide-wire-value` (+ fail-closed frame) | verified correct |
| `snapshot` (`:app-db`/`:sub-cache`) | app-db / sub-cache | `elide-wire-value`; `:epochs`→`projected-record`; `:machines` runtime-db redacted | verified correct |
| `get-path` / `read-sub` / `read-ui` / `read-dom` / `list-subscriptions` | app-db / sub / DOM | `elide-wire-value` | verified correct |
| `trace-window` / `watch-epochs` | epoch records | `projected-record` (`epoch-egress/project-page-src`) | verified correct (rf2-6wvh5) |
| `record` / `watch-until` | `:app-db`/`:sub` samples | `elide-wire-value` (runtime `:elide-opts`) | verified correct (rf2-8fin7.2) |
| `dispatch-dry-run` | would-be app-db + `:would-fire-effects[].args` | `elide-wire-value` | verified; fx-args NOT fail-closed (see follow-up) |
| story-mcp `preview/run-variant` / `read-failures` | variant app-db / assertions / derived trees | `elide-app-db` + `scrub-rendered` + `strip-sensitive` | verified correct |
| story-mcp `explain-variant` / `record-as-variant` | plan-resolved / captured values | `scrub-frame-value` / `scrub-explain-values` | verified correct (rf2-12f2q) |
| xray epoch panel | in-process raw ring | on-box display (consumes pre-elided values) | correct — on-box dev-gated, not off-box egress |

All off-box surfaces gate on `--allow-sensitive-reads` and fail closed on frame resolution. `eval-cljs` is the deliberate trusted-operator escape hatch (operator types the form) — out of scope for forced projection by design.

## Follow-up filed

`dispatch-dry-run`'s `:would-fire-effects[*].args` is walked through `elide-wire-value` (rf2-z7roa gate-parity), not fail-closed like epoch `:effects[].args`. It is a dry-run-recorder envelope, not an `:rf/epoch-record`, so it sits outside Security.md's epoch-egress MUST — but the fx-args leak class is the same. Filed as a separate bead for Mike's ruling rather than changing the rf2-z7roa contract in this slice.

## Quality gates

- `tools/re-frame2-pair-mcp` `npm test` (shadow `server-test` build + node runner): **1028 tests, 3136 assertions, 0 failures, 0 errors, 0 warnings**. Includes new coverage: `drain-form-epoch-topic-projects-via-projected-record`, `drain-form-epoch-projection-tracks-sensitive-axis-not-elision`, `drain-form-epoch-include-sensitive-opt-in-ships-raw`, `drain-form-frameless-topic-uses-wire-value-walker`.
- No spec doc touched (the per-topic egress primitive is documented in the src docstrings; `tools/re-frame2-pair-mcp/spec/API.md`'s generic "sensitive/large slots redact/elide before crossing the wire" statement remains accurate). No `tools/xray` change, so the xray-spec-same-PR rule does not apply.
- `mkdocs build --strict` not run — no `mkdocs.yml`-tracked doc changed.