### PR TITLE
docs(comments): EP-0016 code-comment completeness+accuracy pass (rf2-l8j6ym)

### DIFF
--- a/implementation/resources/src/re_frame/resources/route.cljc
+++ b/implementation/resources/src/re_frame/resources/route.cljc
@@ -479,8 +479,9 @@
   (`{:id :params :query :fragment …}`), `ctx` the entry context (the seam
   routing threads through `:routing/on-route-entry`; a `:scope` / `:when`
   resolver reads it, e.g. `(fn [_route ctx] (:current-session-scope ctx))`).
-  `entry-ctx` carries `:nav-token`, `:prev-id`, `:prev-nav-token`. Returns
-  `{:fx [...] :blocking #{<scoped-key> …} :plan-error err?}`.
+  `entry-ctx` carries `:nav-token`, `:prev-id`, `:prev-nav-token`, and
+  `:app-db` (the route-entry app-db value — see the `:app-db` paragraph
+  below). Returns `{:fx [...] :blocking #{<scoped-key> …} :plan-error err?}`.
 
   FAIL-CLOSED structural inputs (rf2-ac71vm): a `nil` `ctx` or a missing
   `nav-token` is a planning bug, not a silently-defaulted read — the owner


### PR DESCRIPTION
Wave-end CODE-COMMENTS review of the merged EP-0016 wave (resource mutation completion, scoped invalidation, named resolvers, populate, request decoration). Reviewed every comment + docstring across the EP-0016 implementation surface in `implementation/resources` (slices 2-7 + tail fixes `mfnc5i` / `7r8kgd`) for **completeness** and **accuracy**.

## Verdict

The EP-0016 code comments are **exemplary** — the non-obvious decisions, invariants, and edge-cases the bead enumerated are all documented:

- the stale-discipline gates (work-id + generation, frame stamp) and their mandatory-vs-opportunistic split;
- the fail-closed-nil rationale at every scope-requiring site (event / route / sub / clear-scope / exact-target / invalidation descriptor);
- the canonical-reply-via-substrate choice (`re-frame.reply/complete`, not a family-private callback);
- the populate-exempt / `:refetch-populated?` logic and its trace evidence;
- the cross-scope `:cause` requirement (the audited escape);
- the scope-resolution **use-time** rule and the `{:from-db …}` reactive sub re-keying answer (rf2-616xa6);
- the descriptor / continuation-reply shapes are described correctly and match the code.

Spec cross-references resolve (including the level-5 `§Phase order`, `§The cross-scope lattice — three precise rungs`, and `§Trace evidence for invalidation` anchors). No stale spellings from Rider 2 (the scoped-key tuple is correctly framed as internal-storage-only, never a public input) and the `now-ms`-removal note matches the code (no `defn now-ms` remains).

## Change

One trivial accuracy fix applied inline:

- **`route.cljc`** `route-resource-plan` docstring — the `entry-ctx` enumeration sentence listed `:nav-token` / `:prev-id` / `:prev-nav-token` but omitted `:app-db` (added by slice-3, bound in the destructure, and described in a later paragraph). Completed the enumeration so the summary matches the binding.

## Follow-up filed

- A whole-resources-tree citation-style sweep: `§Restore and replay part 2` is cited in `mutation_runtime.cljc` (×3) **and** the un-touched `ssr.cljc` (×4), but the spec header is just `§Restore and replay` (no "part 2" anchor). Fixing only the EP-0016 occurrences would diverge from the ssr.cljc ones, so it is deferred to a consistent tree-wide sweep rather than a partial inline edit.

## Quality gates

- `clojure -M:test` (resources artefact): **323 tests, 1223 assertions, 0 failures** — compile-checks the comment-only edit (route.cljc) across the resources classpath.
- `npm run test:cljs`: not run — this worktree has no `node_modules` and the edit is a pure docstring-string change inside an existing `defn`; the `.cljc` reader-string compiles identically under the JVM reader (already green) and the CLJS reader. Bootstrapping a full node toolchain for a one-line docstring edit is disproportionate.