### PR TITLE
docs(guide): EP-0014 source-form ↔ algebra-view examples (rf2-sk33rb)

### DIFF
--- a/docs/guide/derivations-and-algebra-views.md
+++ b/docs/guide/derivations-and-algebra-views.md
@@ -1,0 +1,307 @@
+# One Graph: Derivations and Their Algebra Views
+
+If you've read [Where should this value live?](where-state-lives.md), you already met the punchline in a `<details>` box: a subscription, a flow, a resource, and a machine are *the same thing seen four ways* — a node in one dependency graph rooted at your state, distinguished only by where the value is kept and when it's recomputed. This page is that box, opened up and made concrete. You don't need it to write a re-frame2 app — the four questions get you to the right home without it. You want it when you're inspecting an app you didn't write, when a tool shows you a graph and you want to read it, or when you simply like the unifying idea behind the five separate APIs you've been learning.
+
+The closest thing in the JavaScript ecosystem is the moment you realise that TanStack Query's `useQuery`, a derived `useMemo`, a Redux selector, and an XState machine are all *the same dependency-graph node* with different caching and re-evaluation policies — except nobody ever wrote that down as one model. re-frame2 does. It's called the **derivation/process algebra**, and the normative version lives in [`spec/Derivations.md`](https://github.com/day8/re-frame2/blob/main/spec/Derivations.md). This page is the friendly tour.
+
+## The shape every node has
+
+A **derivation** is a declared way to compute a fact from inputs. A **process** is a derivation that also has state, a lifecycle, and commands over time. Every declared fact in re-frame2 — every subscription, runtime subscription, flow, resource read, route fact, and machine selector — is one or the other, and every one of them answers the same five questions:
+
+| Question | Field | Possible answers |
+|---|---|---|
+| What does it read? | **`:inputs`** | other subs, app-db paths, runtime-db paths, route/resource/machine refs, events… (or `:parametric`) |
+| What fact does it produce? | **`:output`** | an ephemeral `[:fact …]`, or a durable `[:db …]` / `[:runtime …]` address |
+| Where does the value live? | **`:storage`** | `:ephemeral` · `:app-db` · `:runtime-db` · `:host-transient` |
+| When does it run? | **`:evaluation`** | `:on-demand` · `:after-event` · `:on-reply` · `:on-route` · `:on-transition` · `:scheduled` · `:manual` |
+| Who keeps it alive? | **`:lifecycle`** | a cache entry · the frame · a route · a resource key · a machine instance · a host root |
+
+That's the whole vocabulary. The five plural source forms you write (`reg-sub`, `reg-flow`, `reg-resource`, `reg-route`, `reg-machine`) each **lower** to this one shape — the **algebra view**. You keep writing the ergonomic source form; tools, tests, and docs read the normalized view. The rest of this page is the lowering, one member at a time, source form on the left, algebra view on the right.
+
+> **You never write the algebra view.** It is not a new API — there is no `reg-fact` or `reg-derivation`. The view is *derived* from the registration you already wrote, exactly so a tool can answer "where does this value come from, when does it run, where does it live, and who owns it?" without reading your function bodies. The source form stays the thing humans write.
+
+## The keystone: one function, two policies
+
+Start with the example that makes the whole idea click. Here is a cart total expressed *twice* — once as a subscription, once as a flow — using the identical formula:
+
+```clojure
+;; Source form A — a subscription.
+(rf/reg-sub :cart/total
+  :<- [:cart/items]
+  :<- [:pricing/discounts]
+  (fn [[items discounts] _] (sum-cart items discounts)))
+
+;; Source form B — a flow, the same function.
+(rf/reg-flow
+  {:id     :cart/materialized-total
+   :inputs [[:cart :items] [:pricing :discounts]]
+   :output (fn [items discounts] (sum-cart items discounts))
+   :path   [:cart :total]})
+```
+
+`sum-cart` is one whole-value function. Their algebra views differ **only in the four policy axes** — not in the math:
+
+| | Subscription view | Flow view |
+|---|---|---|
+| `:kind` | `:derivation` | `:derivation` |
+| `:output` | `[:fact :cart/total]` | `[:db [:cart :total]]` |
+| `:storage` | `:ephemeral` | `:app-db` |
+| `:evaluation` | `:on-demand` | `:after-event` |
+| `:lifecycle` | `:subscription-cache-entry` | `:frame` |
+| `:materialized?` | `false` | `true` |
+| `:derive` | `#'app.cart/sum-cart` | `#'app.cart/sum-cart` |
+
+The difference between a subscription and a flow is **not the function; it is policy over the same dependency graph.** That sentence is the entire reason the algebra exists. Once you see it, the other four homes are just other points in the same policy space.
+
+## Subscription → derivation
+
+A subscription is the canonical *ephemeral* derivation: recompute on demand, never written anywhere durable, kept alive only while a view is reading it.
+
+```clojure
+;; SOURCE FORM                              ;; ALGEBRA VIEW
+(rf/reg-sub :cart/total                     {:id          :cart/total
+  :<- [:cart/items]                          :kind        :derivation
+  :<- [:pricing/discounts]                   :source-form {:kind :reg-sub :id :cart/total}
+  (fn [[items discounts] _]                  :inputs      [[:sub [:cart/items]]
+    (sum-cart items discounts)))                           [:sub [:pricing/discounts]]]
+                                             :output      [:fact :cart/total]
+                                             :storage     :ephemeral
+                                             :evaluation  :on-demand
+                                             :lifecycle   :subscription-cache-entry
+                                             :materialized? false
+                                             :derive      #'app.cart/sum-cart}
+```
+
+The two `:<-` lines become two `[:sub …]` input edges, in order. A **layer-1** sub that reads `app-db` directly is conservatively declared `[[:db []]]` (it was handed the whole `app-db` value, so the safe declared input is the whole partition):
+
+```clojure
+;; SOURCE FORM                              ;; ALGEBRA VIEW
+(rf/reg-sub :cart/items                      {:id      :cart/items
+  (fn [db _]                                  :kind    :derivation
+    (get-in db [:cart :items])))              :inputs  [[:db []]]
+                                              :output  [:fact :cart/items]
+                                              :storage :ephemeral
+                                              :evaluation :on-demand
+                                              :lifecycle  :subscription-cache-entry}
+```
+
+### Parametric subscription — static vs live
+
+When a subscription's inputs are computed by an input function, the **static** graph can't know the edges before a concrete query vector exists — it must *not* invent them. It reports `:parametric` and names the producer; the **live** graph reports the realized edges per concrete entry:
+
+```clojure
+;; SOURCE FORM
+(rf/reg-sub :article/page
+  (fn [[_ slug]]                             ;; input function — edges depend on `slug`
+    [[:article/by-slug slug]
+     [:comments/for-article slug]])
+  (fn [[article comments] [_ slug]]
+    {:slug slug :article article :comments comments}))
+```
+
+```clojure
+;; STATIC VIEW                               ;; LIVE VIEW for [:article/page "welcome"]
+{:id :article/page                           {:id [:sub [:article/page "welcome"]]
+ :kind :derivation                            :kind :derivation
+ :inputs :parametric                          :inputs [[:sub [:article/by-slug "welcome"]]
+ :input-producer                                       [:sub [:comments/for-article "welcome"]]]
+   #'app.article/article-page-inputs          :output [:fact [:article/page "welcome"]]
+ :output [:fact :article/page]                :storage :ephemeral
+ :storage :ephemeral                          :evaluation :on-demand
+ :evaluation :on-demand                       :lifecycle :subscription-cache-entry}
+ :lifecycle :subscription-cache-entry}
+```
+
+This **don't-execute rule** — static inspection never runs your input/scope/param functions — is what makes the static graph safe to compute anywhere (tests, docs, an editor plugin) with no side effects and no runtime assumptions.
+
+## Flow → materialized derivation
+
+A flow is the subscription's policy twin: same kind of whole-value function, but `:after-event` evaluation writing into `:app-db`, owned by the frame.
+
+```clojure
+;; SOURCE FORM                              ;; ALGEBRA VIEW
+(rf/reg-flow                                 {:id          :cart/materialized-total
+  {:id     :cart/materialized-total           :kind        :derivation
+   :inputs [[:cart :items]                    :source-form {:kind :reg-flow
+            [:pricing :discounts]]                          :id   :cart/materialized-total}
+   :output (fn [items discounts]              :inputs      [[:db [:cart :items]]
+             (sum-cart items discounts))                    [:db [:pricing :discounts]]]
+   :path   [:cart :total]})                   :output      [:db [:cart :total]]
+                                              :storage     :app-db
+                                              :evaluation  :after-event
+                                              :lifecycle   :frame
+                                              :materialized? true
+                                              :derive      #'app.cart/sum-cart}
+```
+
+Each `:inputs` path becomes a `[:db …]` edge; the `:path` becomes the `[:db …]` output address. `:after-event` means same-commit materialization — for a registered flow there's no general one-event staleness; the inputs and the materialized output move together in one atomic install.
+
+## Resource → process
+
+A resource is the first **process** — a derivation *with state, lifecycle, and commands*. One declaration lowers to **more than one** node: a process node for the cache entry, plus the `:rf.resource/*` read facts (its selectors) over that entry.
+
+```clojure
+;; SOURCE FORM
+(rf/reg-resource :article/by-slug
+  {:params-schema  [:map [:slug :string]]
+   :data-schema    :app/article
+   :scope          :rf.scope/from-caller
+   :request        (fn [{:keys [slug]} _ctx]
+                     {:request {:method :get :url (str "/api/articles/" slug)}
+                      :decode  :app/article})
+   :stale-after-ms 60000
+   :gc-after-ms    300000})
+```
+
+```clojure
+;; STATIC ALGEBRA VIEW
+{:id          :article/by-slug
+ :kind        :process                       ;; refinement :resource-process
+ :source-form {:kind :reg-resource :id :article/by-slug}
+ :inputs      [[:param :slug]
+               [:scope :rf.scope/from-caller]]
+ :output      [:runtime [:rf.runtime/resources :entries]]
+ :storage     :runtime-db                     ;; the LOCAL cache lives here
+ :authority   {:kind :remote :system :server  ;; the source of truth is external
+               :transport :rf.http/managed}
+ :evaluation  #{:on-route :on-reply :scheduled :manual}   ;; a multi-trigger process
+ :lifecycle   :resource-key
+ :materialized? true
+ :selectors   [:rf.resource/state :rf.resource/data :rf.resource/status
+               :rf.resource/loading? :rf.resource/error :rf.resource/has-data?]}
+```
+
+Notice the two-axis split that the algebra makes explicit: **`:storage` always names the local home** (`:runtime-db` — the cache entry), while **`:authority` names where the truth really lives** (an external server). "Remote" is never a storage class; it's a separate fact. Reading a selector is an ordinary on-demand derivation over the runtime-db entry — it does *not* start resource work.
+
+The **live** view reports one node per concrete scoped key, with realized inputs and the in-flight handle:
+
+```clojure
+;; LIVE ALGEBRA VIEW for one scoped key
+{:id     [:resource [[:rf.scope/session {:tenant-id "acme"}] :article/by-slug {:slug "welcome"}]]
+ :kind   :process
+ :inputs [[:scope [:rf.scope/session {:tenant-id "acme"}]] [:param {:slug "welcome"}]]
+ :output [:runtime [:rf.runtime/resources :entries
+                    [[:rf.scope/session {:tenant-id "acme"}] :article/by-slug {:slug "welcome"}]]]
+ :storage :runtime-db
+ :authority {:kind :remote :system :server}
+ :status  :loaded
+ :lifecycle {:kind :resource-key :owners #{[:route :route/article 17]}}
+ :host-transient [[:rf.http/in-flight :work/id-123]]}
+```
+
+The local representation is runtime-owned durable state (`:runtime-db`) **plus** a host-transient in-flight handle that lives outside durable frame state and must be torn down at its boundary.
+
+## Route → route fact (process-like)
+
+A route transition materializes the route slice and can own resource activation. Every route lowers to the *same* fact id — `:rf/route`, the one consumer-facing name for the route slice — with the per-route id recorded under `:source-form`:
+
+```clojure
+;; SOURCE FORM
+(rf/reg-route :route/article
+  {:path "/articles/:slug"
+   :params [:map [:slug :string]]
+   :resources [{:resource :article/by-slug
+                :params   (fn [route] {:slug (get-in route [:params :slug])})
+                :blocking? true}]})
+```
+
+```clojure
+;; ALGEBRA VIEW
+{:id          :rf/route                       ;; the one name for the slice (every route shares it)
+ :kind        :process                        ;; refinement :route-fact
+ :source-form {:kind :reg-route :id :route/article}
+ :inputs      [[:event :rf.route/navigate]    ;; the on-route causal triggers
+               [:event :rf.route/transitioned]
+               [:event :rf.route/handle-url-change]]
+ :output      [:runtime [:rf.runtime/routing :current]]
+ :storage     :runtime-db
+ :evaluation  :on-route
+ :lifecycle   :frame
+ :materialized? true
+ :resource-edges                              ;; route OWNS this resource's activation
+ [{:from [:runtime [:rf.runtime/routing :current :params]]
+   :to   [:resource :article/by-slug]
+   :role :param
+   :target :parametric                        ;; concrete key needs a live match + scope
+   :blocking? true}]}
+```
+
+The route's `:resources` declaration becomes a route-owned **resource activation edge**: the matched params flow into the resource. Its `:target` is `:parametric` — by the don't-execute rule, static inspection never runs the entry's `:params`/`:scope` functions, so the concrete scoped key only appears in the live graph.
+
+## Machine → process, and its selectors → derivations
+
+A machine is the algebra's canonical process — the surface that motivates the `:process` superkind at all. Its snapshot is durable runtime-db state; its selectors are ordinary ephemeral derivations over that snapshot.
+
+```clojure
+;; SOURCE FORM
+(rf/reg-machine :upload/main
+  {:initial :idle
+   :data    {:progress 0}
+   :states  {:idle      {:on {:upload/start {:target :uploading}}}
+             :uploading {:entry :start-upload
+                         :on {:upload/progress  {:action :record-progress}
+                              :upload/succeeded {:target :done}
+                              :upload/failed    {:target :failed}}}
+             :failed {} :done {}}})
+```
+
+```clojure
+;; MACHINE PROCESS VIEW
+{:id          :upload/main
+ :kind        :machine-process               ;; refinement of :process
+ :source-form {:kind :reg-machine :id :upload/main}
+ :inputs      [[:event :upload/start] [:event :upload/progress]   ;; every :on key, deduped
+               [:event :upload/succeeded] [:event :upload/failed]]
+ :output      [:runtime [:rf.runtime/machines :snapshots :upload/main]]
+ :storage     :runtime-db
+ :evaluation  #{:on-transition}              ;; + :scheduled if any :after, + :on-reply if it spawns
+ :lifecycle   :machine-instance
+ :materialized? true}
+```
+
+```clojure
+;; SELECTOR SOURCE FORM                      ;; SELECTOR ALGEBRA VIEW
+(rf/reg-sub :upload/progress                  {:id      :upload/progress
+  :<- [:rf/machine :upload/main]               :kind    :machine-selector   ;; a :derivation refinement
+  (fn [snapshot _]                             :inputs  [[:machine :upload/main [:data :progress]]]
+    (get-in snapshot [:data :progress] 0)))    :output  [:fact :upload/progress]
+                                               :storage :ephemeral
+                                               :evaluation :on-demand
+                                               :lifecycle  :subscription-cache-entry
+                                               :derive     #'app.upload/progress}
+```
+
+The machine is the stateful **process**; the selector is an ephemeral **derivation** over the materialized snapshot. Machines do not become a second subscription system — a selector is just a `reg-sub` over `[:rf/machine …]`, recognized and edged to its machine with a `:selector` role.
+
+## Reading the assembled graph
+
+A tool stitches all of those per-family views into one graph: a map of `:nodes` keyed by canonical id and a list of `:edges`. An Xray panel renders it as a single picture even though the runtime mechanisms underneath are a subscription cache, a flow, a resource cache, a route slice, and a machine snapshot:
+
+```clojure
+{:mode  :live
+ :frame :main
+ :nodes
+ {[:sub [:article/page "welcome"]]    {:kind :derivation :storage :ephemeral  :evaluation :on-demand}
+  [:runtime [:rf.runtime/routing :current]] {:kind :process :storage :runtime-db}
+  [:resource [[:rf.scope/session {:tenant-id "acme"}] :article/by-slug {:slug "welcome"}]]
+                                       {:kind :process :storage :runtime-db
+                                        :status :loaded :owners #{[:route :route/article 17]}}}
+ :edges
+ [{:from [:runtime [:rf.runtime/routing :current :params :slug]]
+   :to   [:sub [:article/page "welcome"]] :role :input}
+  {:from [:runtime [:rf.runtime/routing :current :params :slug]]
+   :to   [:resource [[:rf.scope/session {:tenant-id "acme"}] :article/by-slug {:slug "welcome"}]]
+   :role :param}
+  {:from [:resource [[:rf.scope/session {:tenant-id "acme"}] :article/by-slug {:slug "welcome"}]]
+   :to   [:sub [:article/page "welcome"]] :role :input}]}
+```
+
+Two things make this graph safe to ship to a tool. **Redaction**: the graph carries source coordinates and value *summaries*, never raw sensitive values — a redacted param is still an edge, so structure survives even when content is hidden. And **the whole-value law**: every derivation must be correct as a function that recomputes its entire output from its inputs. Memoization, equality pruning, and (someday) deltas are optimizations that must not change the observed value — which is exactly why a tool can recompute any node from the graph and trust the answer.
+
+## The one rule worth remembering
+
+You don't carry the table around in your head. You carry the one sentence the keystone example proved:
+
+> A subscription, a flow, a resource, a route fact, and a machine selector are the same dependency-graph node under different **storage** and **evaluation** policies. The source forms differ for good ergonomic reasons; the algebra view is what they have in common.
+
+When you want the full normative contract — the node schema, every classification rule, the static/live modes, the don't-execute rule, the whole-value and optional-delta laws — read [`spec/Derivations.md`](https://github.com/day8/re-frame2/blob/main/spec/Derivations.md). When you just want to pick a home for a value, go back to the four questions in [Where should this value live?](where-state-lives.md). This page is the bridge between them: the *why* the four homes are four faces of one idea.

--- a/docs/guide/where-state-lives.md
+++ b/docs/guide/where-state-lives.md
@@ -123,6 +123,8 @@ What it buys: the checkout can now only be in a state it can legally reach, the 
 <summary>For the categorically curious</summary>
 
 All four homes are the same thing seen four ways: a node in **one dependency graph rooted at your state**, distinguished only by its *storage policy* (where the value is kept) and its *evaluation policy* (when it's recomputed). A **subscription** is *no storage, recompute on demand*. A **flow** is *stored in app-db, recompute after each event*. A **resource** is *stored in a runtime cache, recompute on cause and staleness*. A **machine** is *stored as a snapshot, recompute on transition*. Same graph, four policies — which is why "where should this value live?" is really "which storage-and-evaluation policy does this value need?"
+
+If that idea grabs you, [One graph: derivations and algebra views](derivations-and-algebra-views.md) opens it all the way up — it shows each source form (`reg-sub` / `reg-flow` / `reg-resource` / `reg-route` / `reg-machine`) next to the normalized *algebra view* it lowers to, side by side, so you can see the four-policy claim made concrete.
 </details>
 
 ## Signs you picked the wrong home

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -186,6 +186,7 @@ nav:
     - "26 - Operating well": guide/26-operating-well.md
     - "27 - Server-state and resources": guide/27-resources.md
     - "Where should this value live?": guide/where-state-lives.md
+    - "One graph: derivations and algebra views": guide/derivations-and-algebra-views.md
 
   - CLJS:
     - "ClojureScript for non-Clojurians": cljs/index.md

--- a/spec/Derivations.md
+++ b/spec/Derivations.md
@@ -456,7 +456,218 @@ Their algebra views differ only in output, storage, evaluation, and lifecycle:
 | `:materialized?` | `false` | `true` |
 | `:derive` | `#'app.cart/sum-cart` | `#'app.cart/sum-cart` |
 
-`sum-cart` is one whole-value function. The difference between the subscription and the flow is **not the mathematical function; it is policy over the same dependency graph.** That is the whole point of naming the algebra. Full worked source-form/algebra-view pairs for every member — parametric subscriptions, runtime subscriptions, resources (static + live), route facts, machine processes and selectors — live in [EP-0014 §Examples](../docs/EP/EP-0014-derivation-and-process-algebra.md#examples).
+`sum-cart` is one whole-value function. The difference between the subscription and the flow is **not the mathematical function; it is policy over the same dependency graph.** That is the whole point of naming the algebra. The full worked source-form/algebra-view pairs for every member — parametric subscriptions, runtime subscriptions, resources (static + live), route facts, machine processes and selectors — are catalogued [below](#side-by-side-catalogue--every-source-form-and-its-algebra-view) and in [EP-0014 §Examples](../docs/EP/EP-0014-derivation-and-process-algebra.md#examples).
+
+## Side-by-side catalogue — every source form and its algebra view
+
+This section is **illustrative, not normative** — the binding rules are the per-member sections below and the [§Conformance](#conformance) list. It collects, in one scannable place, the source form an author writes next to the algebra view it lowers to, for every member of the algebra. Read it as the worked companion to the [node shape](#the-node-shape): each pair shows which axes are *fixed* for that member (the member's identity in the algebra) and which *vary* per registration (its declared `:inputs` and `:output`). A reader-first walkthrough of the same mapping, anchored to the four-homes mental model, lives in the guide chapter [One graph: derivations and algebra views](../docs/guide/derivations-and-algebra-views.md).
+
+### Subscription (static `:<-`) → ephemeral derivation
+
+```clojure
+;; SOURCE FORM                              ;; ALGEBRA VIEW
+(rf/reg-sub :cart/total                     {:id          :cart/total
+  :<- [:cart/items]                          :kind        :derivation
+  :<- [:pricing/discounts]                   :source-form {:kind :reg-sub :id :cart/total}
+  (fn [[items discounts] _]                  :inputs      [[:sub [:cart/items]]
+    (sum-cart items discounts)))                           [:sub [:pricing/discounts]]]
+                                             :output      [:fact :cart/total]
+                                             :storage     :ephemeral
+                                             :evaluation  :on-demand
+                                             :lifecycle   :subscription-cache-entry
+                                             :materialized? false
+                                             :derive      #'app.cart/sum-cart}
+```
+
+Each literal `:<-` input lowers to a `[:sub query-vector]` edge in declaration order. A **layer-1** `:db` reader, which is handed the whole `app-db` value, lowers conservatively to the app-db projection root `[[:db []]]` ([§Subscriptions expose algebra views](#subscriptions-expose-algebra-views)).
+
+### Parametric subscription → static `:parametric` / live realized edges
+
+```clojure
+;; SOURCE FORM
+(rf/reg-sub :article/page
+  (fn [[_ slug]]                              ;; input function — edges depend on `slug`
+    [[:article/by-slug slug]
+     [:comments/for-article slug]])
+  (fn [[article comments] [_ slug]]
+    {:slug slug :article article :comments comments}))
+```
+
+```clojure
+;; STATIC VIEW                               ;; LIVE VIEW for [:article/page "welcome"]
+{:id :article/page                           {:id [:sub [:article/page "welcome"]]
+ :kind :derivation                            :kind :derivation
+ :inputs :parametric                          :inputs [[:sub [:article/by-slug "welcome"]]
+ :input-producer                                       [:sub [:comments/for-article "welcome"]]]
+   #'app.article/article-page-inputs          :output [:fact [:article/page "welcome"]]
+ :output [:fact :article/page]                :storage :ephemeral
+ :storage :ephemeral                          :evaluation :on-demand
+ :evaluation :on-demand                       :lifecycle :subscription-cache-entry}
+ :lifecycle :subscription-cache-entry}
+```
+
+The static graph reports the `:parametric` marker plus the opaque `:input-producer` token — it never runs the input function ([§The don't-execute rule](#the-dont-execute-rule-ep-0014-issue-3-disposition)). The live sub-cache view reports the realized `[:sub q]` edges the static graph cannot enumerate.
+
+### Runtime subscription → ephemeral derivation over `runtime-db`
+
+```clojure
+;; SOURCE FORM (framework-internal — subsystem facade, not app code)
+(subs/reg-runtime-sub :rf.route/params
+  (fn [runtime-db _]
+    (get-in runtime-db [:rf.runtime/routing :current :params])))
+```
+
+```clojure
+;; ALGEBRA VIEW
+{:id         :rf.route/params
+ :kind       :derivation
+ :inputs     [[:runtime [:rf.runtime/routing :current :params]]]
+ :output     [:fact :rf.route/params]
+ :storage    :ephemeral
+ :evaluation :on-demand
+ :lifecycle  :subscription-cache-entry}
+```
+
+The same ephemeral-derivation classifications as an ordinary subscription; the only difference is the partition the conservative input names — `[:runtime …]` for `reg-runtime-sub`, `[:frame-state …]` for the cross-partition framework-internal `reg-frame-state-sub`.
+
+### Flow → materialized derivation
+
+```clojure
+;; SOURCE FORM                              ;; ALGEBRA VIEW
+(rf/reg-flow                                 {:id          :cart/materialized-total
+  {:id     :cart/materialized-total           :kind        :derivation
+   :inputs [[:cart :items]                    :source-form {:kind :reg-flow
+            [:pricing :discounts]]                          :id   :cart/materialized-total}
+   :output (fn [items discounts]              :inputs      [[:db [:cart :items]]
+             (sum-cart items discounts))                    [:db [:pricing :discounts]]]
+   :path   [:cart :total]})                   :output      [:db [:cart :total]]
+                                              :storage     :app-db
+                                              :evaluation  :after-event
+                                              :lifecycle   :frame
+                                              :materialized? true
+                                              :derive      #'app.cart/sum-cart}
+```
+
+The subscription's exact policy twin — same whole-value function, materialized instead of ephemeral ([§Worked equivalence](#worked-equivalence--one-function-two-policies)). Each `:inputs` path lowers to a `[:db path]` edge (a partition-qualified `[:rf.db/runtime …]` input lowers to `[:runtime …]`); the `:path` lowers to the `[:db …]` output address.
+
+### Resource → process (static, then live)
+
+```clojure
+;; SOURCE FORM
+(rf/reg-resource :article/by-slug
+  {:params-schema  [:map [:slug :string]]
+   :data-schema    :app/article
+   :scope          :rf.scope/from-caller
+   :request        (fn [{:keys [slug]} _ctx]
+                     {:request {:method :get :url (str "/api/articles/" slug)}
+                      :decode  :app/article})
+   :stale-after-ms 60000
+   :gc-after-ms    300000})
+```
+
+```clojure
+;; STATIC ALGEBRA VIEW
+{:id          :article/by-slug
+ :kind        :process                       ;; refinement :resource-process
+ :source-form {:kind :reg-resource :id :article/by-slug}
+ :inputs      [[:param :slug]
+               [:scope :rf.scope/from-caller]]
+ :output      [:runtime [:rf.runtime/resources :entries]]
+ :storage     :runtime-db                     ;; the LOCAL cache home
+ :authority   {:kind :remote :system :server  ;; the source of truth is external
+               :transport :rf.http/managed}
+ :evaluation  #{:on-route :on-reply :scheduled :manual}
+ :lifecycle   :resource-key
+ :materialized? true
+ :selectors   [:rf.resource/state :rf.resource/data :rf.resource/status
+               :rf.resource/loading? :rf.resource/error :rf.resource/has-data?]}
+```
+
+```clojure
+;; LIVE ALGEBRA VIEW for one scoped key
+{:id     [:resource [[:rf.scope/session {:tenant-id "acme"}] :article/by-slug {:slug "welcome"}]]
+ :kind   :process
+ :inputs [[:scope [:rf.scope/session {:tenant-id "acme"}]] [:param {:slug "welcome"}]]
+ :output [:runtime [:rf.runtime/resources :entries
+                    [[:rf.scope/session {:tenant-id "acme"}] :article/by-slug {:slug "welcome"}]]]
+ :storage :runtime-db
+ :authority {:kind :remote :system :server}
+ :status  :loaded
+ :lifecycle {:kind :resource-key :owners #{[:route :route/article 17]}}
+ :host-transient [[:rf.http/in-flight :work/id-123]]}
+```
+
+The split the [§Authority](#authority--the-remote-axis) section names is visible here: `:storage` always names the *local* representation home (`:runtime-db` for the cache entry, `:host-transient` for the live in-flight handle), and `:authority` is the separate external-truth axis. One declaration lowers to **more than one** node — the process node plus its `:selectors` read facts — and reading a selector starts no work ([§Evaluation policy](#evaluation-policy) rule 1).
+
+### Route → route fact (process-like) with an owned resource edge
+
+```clojure
+;; SOURCE FORM
+(rf/reg-route :route/article
+  {:path "/articles/:slug"
+   :params [:map [:slug :string]]
+   :resources [{:resource :article/by-slug
+                :params   (fn [route] {:slug (get-in route [:params :slug])})
+                :blocking? true}]})
+```
+
+```clojure
+;; ALGEBRA VIEW
+{:id          :rf/route                       ;; the one slice name; every route shares it
+ :kind        :process                        ;; refinement :route-fact
+ :source-form {:kind :reg-route :id :route/article}
+ :inputs      [[:event :rf.route/navigate]
+               [:event :rf.route/transitioned]
+               [:event :rf.route/handle-url-change]]
+ :output      [:runtime [:rf.runtime/routing :current]]
+ :storage     :runtime-db
+ :evaluation  :on-route
+ :lifecycle   :frame
+ :materialized? true
+ :resource-edges
+ [{:from   [:runtime [:rf.runtime/routing :current :params]]
+   :to     [:resource :article/by-slug]
+   :role   :param
+   :target :parametric                        ;; concrete key needs a live match + scope
+   :blocking? true}]}
+```
+
+Every route materializes the *same* slice fact `:rf/route`; the per-route id is recorded under `:source-form`. The `:resources` declaration lowers to a route-owned [resource activation edge](#route-owned-resource-activation-edges) whose `:target` stays `:parametric` (the don't-execute rule forbids running the entry's `:params`/`:scope` functions statically).
+
+### Machine → process; its selector → derivation
+
+```clojure
+;; SOURCE FORM
+(rf/reg-machine :upload/main
+  {:initial :idle
+   :data    {:progress 0}
+   :states  {:idle      {:on {:upload/start {:target :uploading}}}
+             :uploading {:entry :start-upload
+                         :on {:upload/progress  {:action :record-progress}
+                              :upload/succeeded {:target :done}
+                              :upload/failed    {:target :failed}}}
+             :failed {} :done {}}})
+```
+
+```clojure
+;; MACHINE PROCESS VIEW                      ;; SELECTOR (a reg-sub over [:rf/machine …])
+{:id          :upload/main                   (rf/reg-sub :upload/progress
+ :kind        :machine-process                 :<- [:rf/machine :upload/main]
+ :source-form {:kind :reg-machine              (fn [snapshot _]
+               :id   :upload/main}               (get-in snapshot [:data :progress] 0)))
+ :inputs      [[:event :upload/start]
+               [:event :upload/progress]     ;; SELECTOR ALGEBRA VIEW
+               [:event :upload/succeeded]    {:id      :upload/progress
+               [:event :upload/failed]]       :kind    :machine-selector   ;; a :derivation refinement
+ :output  [:runtime [:rf.runtime/machines     :inputs  [[:machine :upload/main [:data :progress]]]
+           :snapshots :upload/main]]          :output  [:fact :upload/progress]
+ :storage :runtime-db                         :storage :ephemeral
+ :evaluation #{:on-transition}                :evaluation :on-demand
+ :lifecycle  :machine-instance                :lifecycle  :subscription-cache-entry
+ :materialized? true}                         :derive     #'app.upload/progress}
+```
+
+The machine is the stateful **process**; the selector is an ephemeral **derivation** over its materialized snapshot. `:inputs` are every `:on` event key across the state tree, de-duplicated; `:evaluation` gains `:scheduled` if the spec declares any `:after` transition and `:on-reply` if it spawns children. A selector is an ordinary subscription node ([§Subscriptions expose algebra views](#subscriptions-expose-algebra-views)) the [machines tooling](#machines-expose-algebra-views) merely labels with the `:machine-selector` refinement and edges back to its machine with a `:selector` role — machines do **not** become a second subscription system (EP-0014 issue-4).
 
 ## Subscriptions expose algebra views
 


### PR DESCRIPTION
EP-0014 (Derivation/Process Algebra) Reference Implementation Plan **item 8**: documentation examples that show each **source form** next to the **algebra view** it lowers to, side by side, so a reader can see how `reg-sub` / static `:<-` / `reg-flow` / resource decl / route decl / machine def project into the derivation/process algebra the tooling siblings (items 2–7, all merged) expose.

Belongs to epic `rf2-k0meap`. Fence honored: `docs/guide/` + `spec/Derivations.md` (illustrative examples) only — no `implementation/`, no `Spec-Schemas`, no `core`.

## What this adds

**New guide chapter — `docs/guide/derivations-and-algebra-views.md`.**
A reader-first walkthrough of the algebra, anchored to the dominant mental model already in the guide (the four homes from `where-state-lives.md`) and to the JS-ecosystem intuition (TanStack Query / `useMemo` / Redux selector / XState as one dependency-graph node under different policies). It leads with the keystone "one function, two policies" sub-vs-flow pair, then walks each member — subscription (static + parametric, static vs live), runtime subscription, flow, resource (static + live), route fact + owned-resource edge, machine process + selector — with the source form on the left and the algebra view on the right. Closes on the assembled `{:mode :nodes :edges}` graph view, redaction, and the whole-value law.
  - Wired into the Guide nav (after `where-state-lives.md`).
  - Forward-linked from the "categorically curious" `<details>` box in `where-state-lives.md`, which already names the storage-policy/evaluation-policy idea — this chapter is its full opening.

**`spec/Derivations.md` — new illustrative "Side-by-side catalogue" section.**
Collects every member's source-form/algebra-view pair in one scannable place. Previously the full pairs lived only in EP-0014 §Examples; the merged spec carried only the single sub-vs-flow worked pair in §Worked equivalence. The section is explicitly marked **illustrative, not normative** (the per-member sections and §Conformance remain binding) and cross-links into the existing normative anchors (authority split, don't-execute rule, evaluation rules, machines issue-4). The §Worked equivalence pointer now references the in-doc catalogue alongside the EP.

No new public surface, no schema/impl changes — pure documentation, consistent with the EP's slice-1 "vocabulary + examples, no new primitive" scope.

## Quality gates

- `python scripts/check_doc_slugs.py --self-test --verbose` — **green** (all 13 self-tests pass).
- `python scripts/check_doc_slugs.py --verbose` — **green** (431 files scanned, no broken links; new headings, internal anchors, and the cross-tree `spec → docs/guide` link all resolve).
- `mkdocs build --strict` reproducing CI staging (`cp -r spec docs/spec && cp -r migration docs/migration`, social plugin off locally per the `!ENV [CI,false]` gate) — **green**, exit 0, zero warnings/errors.
- Rebased on `origin/main` (clean; the 2 intervening commits were `.beads/issues.jsonl` heartbeats only).