### PR TITLE
docs(comments): EP-0012 path/identity foundation comment pass (rf2-fe3a9q)

### DIFF
--- a/implementation/core/src/re_frame/identity.cljc
+++ b/implementation/core/src/re_frame/identity.cljc
@@ -28,8 +28,9 @@
   value. A *digest* is an OPTIONAL, versioned, always-recomputable
   projection for size-constrained surfaces; it is never an independent
   identity fact, never required for correctness, never the authoritative
-  stored key. This namespace ships `canonical` + `canonical-bytes`
-  (the CEDN-1 byte string the comparison/digest is defined over) and no
+  stored key. This namespace ships `canonical`, `canonical-bytes` (the
+  CEDN-1 byte string the comparison/digest is defined over), and
+  `identical-identity?` (CEDN-1 byte equality) — and no
   authoritative-digest store.
 
   ## The CEDN-1 byte encoding


### PR DESCRIPTION
Wave-end **code-comments** review of the merged EP-0012 path/identity foundation (`re-frame.path` `:rf/path` algebra + `re-frame.identity` CEDN-1 canonical identity), per rf2-fe3a9q. Reviews the prose *in* the code for completeness + accuracy (complements the testing-coverage + correctness review tails).

## Verdict

The foundation comments + docstrings are **clean** — complete and accurate. One trivial inline fix; no larger clusters; no follow-up beads filed.

### Reviewed (all accurate, no staleness)
- `implementation/core/src/re_frame/path.cljc` — ns docstring (algebra summary, all 7 laws + 5 root-path laws, intermediate-container policy, INTERNAL-status graduation gate), `container-for`/`put`/`over`/`prefix?`/`overlap?` rationale, the `[:rf.path/param …]` data-form vs `'?name` sugar template prose, fail-closed `instantiate`. All match the code + the `path_laws` test + Conventions §The `:rf/path` algebra. Cross-references resolve.
- `implementation/core/src/re_frame/identity.cljc` — ns docstring (why-canonical-not-stringification, identity-vs-digest disposition 5, CEDN-1 byte encoding + type-tag rationale, fail-closed domain), per-fn comments (`reject!`, safe-integer range, `bad-number?` cross-host CLJ/CLJS, instant UTC-millis normalization, map/set ordering). All match the encoder + the `identity_cedn1` test + Conventions §Canonical EDN identity / §Canonical byte encoding.
- Consumer comments referencing the foundation (`frame_classification.cljc` path-validation block, `resources/scope_registry.cljc`) — accurate; correctly cite `rf.path/normalize` + its `:rf.error/bad-path` throw; no private path/overlap logic duplicated.

### Fixed inline
- `identity.cljc` "Identity vs digest" section listed the shipped surface as `canonical` + `canonical-bytes` but omitted the third public-internal fn `identical-identity?`. Surface-list now complete (comment-only).

### Noted, NOT actioned (out of comment-scope; covered by existing beads)
- `identity.cljc` `encode`/`canonical` carry both a `(seq? x)` and a `(list? x)` branch producing the same `"l("` form; `seq?` already subsumes `list?`, so the `list?` branch is dead. This is a **code** simplification, not a comment inaccuracy — fits the existing best-practice bead **rf2-w9x5fv** (harden path/identity foundation boundaries); not filing a duplicate.

## Quality gates
- Comment-only edit inside a docstring string literal (cannot affect compilation).
- `clojure -M:test` (core JVM, includes the `.cljc` `path_laws` + `identity_cedn1` law tests): **1227 tests, 5416 assertions, 0 failures, 0 errors**. Both foundation namespaces `:reload` cleanly.
- `npm run test:cljs` not run — worktree has no `node_modules`; the change is a docstring string literal with no compile impact, and the JVM `.cljc` path exercises the same source.

Closes rf2-fe3a9q.