### PR TITLE
test(resources): EP-0016 final review — remediate coverage + citation errata (rf2-36nxdg)

### DIFF
--- a/implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_descriptors_cljs_test.cljc
@@ -46,6 +46,7 @@
    [re-frame.http-managed]
    [re-frame.schemas]
    [re-frame.test-support :as core-test-support]
+   [re-frame.error-emit :as error-emit]
    [re-frame.trace.tooling :as trace-tooling]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
        :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
@@ -401,6 +402,131 @@
                (set (map :scope (:dispatched inv))))
             "the global descriptor + the {:from-db}-resolved session scope")
         (is (empty? (:unresolved inv)))))))
+
+;; ---- rf2-700p0r: a typo'd CONCRETE literal scope in an :invalidates --------
+;; DESCRIPTOR fails closed at settle through the SAME canonicalize-scope path.
+;; The reserved-scope-typo rejection is covered elsewhere via OTHER surfaces
+;; (the scope-resolver path: scope_registry/resolved-scope-routes-through-
+;; canonicalization; the :patches/:populates target-map path:
+;; mutation/validate-target-key-rejects-reserved-scope-typo). This pins it
+;; through the :invalidates DESCRIPTOR wiring specifically — a regression that
+;; bypassed canonicalize-scope HERE would turn a typo into a silent wrong /
+;; no-op cache-scope invalidation, the exact fail-closed promise the EP makes.
+
+(defn- record-surfaced-errors!
+  "Run `body-fn`; return the vector of always-on error-emit records surfaced
+  during it (the production-survivable error stream the dispatched settle-time
+  throw fans out through, carrying the underlying ex-info as `:exception`)."
+  [body-fn]
+  (let [seen (atom [])
+        k    ::err-recorder]
+    (error-emit/register-error-listener! k (fn [rec] (swap! seen conj rec)))
+    (try (body-fn) (finally (error-emit/unregister-error-listener! k)))
+    @seen))
+
+(defn- error-id-of
+  "The `:rf.error/id` an error-emit record carries — either directly on the
+  record's `:error` (a typed category record) or on the underlying
+  `:exception`'s ex-data (a dispatched handler throw wrapping the boundary
+  ex-info)."
+  [rec]
+  (or (some-> rec :exception ex-data :rf.error/id)
+      (:error rec)))
+
+(deftest descriptor-typo-concrete-scope-fails-closed-at-settle
+  ;; A mutation :invalidates DESCRIPTOR carrying a typo'd CONCRETE reserved
+  ;; scope (:rf.scope/glabal) is resolved at settle time through
+  ;; resolve-descriptor-scope -> state/canonicalize-scope — the SAME
+  ;; typo-rejecting path. It fails closed LOUD (no silent wrong-scope blast).
+  (reg-article-resource!)
+  (rf/reg-mutation :m/save
+    {:scope :rf.scope/global
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+     ;; the descriptor's CONCRETE :scope is a reserved-namespace typo
+     :invalidates (fn [{:keys [slug]} _result]
+                    [{:scope :rf.scope/glabal :tags #{[:article slug]}}])})
+  ;; an ownerless GLOBAL article entry exists; a regression that dropped
+  ;; canonicalization (resolving the typo to itself, or blasting global) would
+  ;; be observable as this entry wrongly marked stale.
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :r/article :scope :rf.scope/global
+                                          :params {:slug "w"} :owner [:v :a]}])
+  (reply-success! @last-managed-args {:title "old"})
+  (rf/dispatch-sync [:rf.resource/release-owner {:resource :r/article :scope :rf.scope/global
+                                                 :params {:slug "w"} :owner [:v :a]}])
+  (reset! last-managed-args nil)
+  (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :ty1}])
+  (let [errs (record-surfaced-errors! #(reply-success! @last-managed-args {:title "new"}))]
+    (testing "the typo'd descriptor scope failed closed at settle through the
+              shared canonicalize-scope path — surfaced as
+              :rf.error/resource-invalid-scope (never a silent wrong cache
+              scope)"
+      (is (some (fn [rec] (= :rf.error/resource-invalid-scope (error-id-of rec))) errs)
+          ":rf.error/resource-invalid-scope was surfaced at the resolution boundary"))
+    (testing "FAIL-CLOSED — no entry was blasted: the global article was NOT
+              marked stale by the typo'd descriptor (the invalidation never
+              dispatched)"
+      (is (nil? (:invalidated-at (entry global-key)))))))
+
+;; ---- rf2-kjpq3f: :cross-scope? true on an :invalidates DESCRIPTOR settles --
+;; end-to-end (the scope-agnostic fan-out reaches entries in MULTIPLE scopes,
+;; and the mutation-supplied [:mutation …] cause satisfies the cause-required
+;; gate). The cross-scope cause-required REJECTION is covered on the raw
+;; :rf.resource/invalidate-tags event (invalidation_gc/invalidate-tags-cross-
+;; scope-*); the descriptor path was covered ONLY by the pure normalize
+;; round-trip (normalize-lowers-the-public-forms), which proves the flag is
+;; carried but does NOT settle a mutation, prove the fan-out, or pin the
+;; [:mutation …] cause wiring. This is the end-to-end pin.
+
+(deftest descriptor-cross-scope-fans-out-and-supplies-mutation-cause-at-settle
+  ;; a FROM-CALLER article so the two entries can live under two concrete
+  ;; (distinct) scopes; a :rf.scope/global-policy resource could not.
+  (rf/reg-resource :rx/article
+    {:scope :rf.scope/from-caller
+     :params-schema [:map [:slug :string]]
+     :request (fn [{:keys [slug]} _] {:request {:method :get :url (str "/a/" slug)}})
+     :tags (fn [{:keys [slug]} _] #{[:article slug]})})
+  ;; two same-tag article entries in DIFFERENT scopes, both ownerless +
+  ;; stale-observable. A scoped (non-cross-scope) invalidation would reach at
+  ;; most one; only the scope-agnostic fan-out reaches BOTH.
+  (let [sa {:user "amy"}
+        sb {:user "bo"}
+        ka (state/scoped-resource-key sa :rx/article {:slug "w"})
+        kb (state/scoped-resource-key sb :rx/article {:slug "w"})]
+    (ownerless-stale-load! {:resource :rx/article :scope sa :params {:slug "w"} :owner [:v :a]})
+    (ownerless-stale-load! {:resource :rx/article :scope sb :params {:slug "w"} :owner [:v :b]})
+    (rf/reg-mutation :m/purge
+      {:scope :rf.scope/global
+       :params-schema [:map [:slug :string]]
+       :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
+       ;; a :cross-scope? true descriptor with NO explicit :cause — the
+       ;; mutation runtime supplies the [:mutation <id> <instance>] cause by
+       ;; construction, satisfying the rf2-7r8kgd cause-required gate.
+       :invalidates (fn [{:keys [slug]} _result]
+                      [{:tags #{[:article slug]} :cross-scope? true}])})
+    (let [seen (atom [])
+          k    ::succeeded-recorder]
+      (trace-tooling/register-listener!
+        k (fn [ev] (when (= :rf.mutation/succeeded (:operation ev)) (swap! seen conj ev))))
+      (try
+        (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/purge :params {:slug "w"} :instance :x1}])
+        (reply-success! @last-managed-args {:purged true})
+        (finally (trace-tooling/unregister-listener! k)))
+      (testing "the scope-agnostic fan-out reached the same tag in BOTH scopes
+                (a scoped descriptor would have reached at most one)"
+        (is (some? (:invalidated-at (entry ka))) "amy's session entry marked stale")
+        (is (some? (:invalidated-at (entry kb))) "bo's session entry marked stale"))
+      (testing "the settlement :invalidation trace facet records the
+                cross-scope dispatch as the audited escape (the :cross-scope?
+                flag rides the dispatched descriptor evidence)"
+        (let [inv (:invalidation (:tags (first @seen)))]
+          (is (= 1 (:descriptor-count inv)))
+          (is (= 1 (count (:dispatched inv))))
+          (let [d (first (:dispatched inv))]
+            (is (true? (:cross-scope? d)) "the descriptor is recorded cross-scope")
+            (is (nil? (:scope d)) "a cross-scope dispatch is scope-agnostic (no concrete scope)")
+            (is (= #{[:article "w"]} (set (:tags d)))))
+          (is (empty? (:unresolved inv)) "no unresolved descriptor"))))))
 
 ;; ===========================================================================
 ;; 7. :rf.scope/same is the default when a descriptor omits :scope

--- a/implementation/resources/test/re_frame/resources_request_decoration_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_request_decoration_cljs_test.cljc
@@ -66,6 +66,7 @@
    [re-frame.http-machine-wrapper :as http-wrapper]
    [re-frame.schemas]
    [re-frame.test-support :as core-test-support]
+   [re-frame.trace.tooling :as trace-tooling]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
        :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
 
@@ -277,3 +278,81 @@
     (is (= "https://api.example.com/api/articles/w"
            (get-in @last-decorated [:request :url]))
         "the resource read's url carries the base-URL prefix")))
+
+;; ===========================================================================
+;; 6. The decorated bearer-token VALUE does NOT leak into any trace row
+;;    (Spec 016 §Security, Privacy, And Observability — the adversarial
+;;    complement of validation rule 13; rf2-9htz7c)
+;; ===========================================================================
+;;
+;; §Security: "Request decoration must not leak sensitive header values into
+;; trace rows. Traces should report that an auth interceptor applied, not the
+;; bearer token itself." The contract is structural: the resource / mutation
+;; runtime lowers the DOMAIN request (pre-decoration) into the trace stream;
+;; the header is stamped LATER, inside the managed-HTTP `:before` chain (the
+;; transport seam) — runtime-owned addressing, not a trace facet. The positive
+;; tests above prove the header IS stamped onto the lowered `:rf.http/managed`
+;; request; THIS test is the adversarial complement: it records the full
+;; `:rf.resource/*` + `:rf.mutation/*` lifecycle trace stream across a decorated
+;; read AND a decorated mutation and asserts the bearer-token VALUE never
+;; appears in ANY emitted trace row's serialized form. A regression that started
+;; echoing the post-`:before` decorated request (Authorization header and all)
+;; into a trace facet would pass every existing decoration test silently — this
+;; pins the §Security non-leak against exactly that.
+
+(defn- record-resource+mutation-traces!
+  "Run `body-fn`; return the vector of every `:rf.resource/*` / `:rf.mutation/*`
+  trace row emitted during it (the lifecycle + lower-fx + settlement ops the
+  privacy-leak clause governs)."
+  [body-fn]
+  (let [seen (atom [])
+        k    ::leak-recorder
+        resource-or-mutation-op?
+        (fn [op]
+          (when (keyword? op)
+            (let [ns* (namespace op)]
+              (contains? #{"rf.resource" "rf.resource.internal"
+                           "rf.mutation" "rf.mutation.internal"}
+                         ns*))))]
+    (trace-tooling/register-listener!
+      k (fn [ev] (when (resource-or-mutation-op? (:operation ev)) (swap! seen conj ev))))
+    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    @seen))
+
+(deftest decorated-bearer-token-does-not-leak-into-trace-rows
+  (let [token "abc123"]
+    (seed-token! token)
+    (reg-auth-interceptor!)
+    (rf/reg-resource :rl/article (article-spec))
+    (rf/reg-mutation :ml/save (save-spec))
+    (let [rows (record-resource+mutation-traces!
+                 (fn []
+                   ;; a decorated READ — lower + settle
+                   (rf/dispatch-sync [:rf.resource/ensure
+                                      {:resource :rl/article :scope :rf.scope/global
+                                       :params {:slug "w"} :owner [:lease :rl 1]}])
+                   (reply-success! :on-success {:title "Welcome"})
+                   ;; a decorated MUTATION — lower + settle
+                   (rf/dispatch-sync [:rf.mutation/execute
+                                      {:mutation :ml/save :params {:slug "w"}
+                                       :instance :ml/save-1}])
+                   (reply-success! :on-success {:slug "w"})))]
+      (testing "the test actually exercised the decorated lifecycle (the
+                interceptor DID stamp the header on the lowered request — so
+                the token genuinely entered the seam this trace stream watches)"
+        (is (= (str "Token " token) (auth-header))
+            "the decoration applied (precondition for a meaningful leak check)")
+        (is (seq rows) "resource + mutation lifecycle trace rows were captured"))
+      (testing "Spec 016 §Security — the bearer-token VALUE appears in NO
+                emitted resource/mutation trace row (the decorated request,
+                Authorization header and all, is never echoed into a trace
+                facet; traces carry the DOMAIN request pre-decoration only)"
+        (let [offenders (filterv (fn [ev] (re-find (re-pattern token) (pr-str ev))) rows)]
+          (is (empty? offenders)
+              (str "the bearer token '" token "' leaked into " (count offenders)
+                   " trace row(s); §Security prohibits sensitive header values "
+                   "in trace rows"))))
+      (testing "and the literal Authorization-header SPELLING (the stamped
+                facet) is likewise absent from every trace row"
+        (is (empty? (filterv (fn [ev] (re-find #"Authorization" (pr-str ev))) rows))
+            "no trace row carries the stamped Authorization header")))))


### PR DESCRIPTION
EP-0016 wave-end **final completeness + correctness review** with a corrective PR (rf2-36nxdg). EP-0016 impl is fully merged and passed tail-1 + tail-2 (clean), a strong testing-rigour audit, and an exemplary code-comments review. This is the final remediation gate.

## Verdict

**EP-0016 is complete and correct.** The four prior reviews (correctness x2, testing-coverage, code-comments) are confirmed — not re-litigated. The three open coverage-gap errata are remediated test-only; the citation errata is rejected on a corrected premise (below). No new source bug found.

## What this PR does (test-only)

Three regression pins on **existing** behaviour (no source change):

- **rf2-9htz7c** (Security non-leak): records the full `:rf.resource/*` + `:rf.mutation/*` trace stream across a decorated read AND a decorated mutation, and asserts the bearer-token VALUE (and the literal `Authorization` spelling) appear in NO trace row. The decoration genuinely applied (verified precondition), so the token entered the seam the stream watches — pinning that traces carry the DOMAIN request pre-decoration only, per Spec 016 §Security, Privacy, And Observability.
- **rf2-700p0r** (descriptor-typo-at-settle): a mutation `:invalidates` DESCRIPTOR carrying a typo'd CONCRETE reserved scope (`:rf.scope/glabal`) fails closed at settle through the shared `state/canonicalize-scope` path — surfaced as `:rf.error/resource-invalid-scope` via the always-on error-emit listener, with no entry blasted. Pins the `:invalidates` descriptor surface specifically (previously covered only via the scope-resolver and `:patches`/`:populates` surfaces).
- **rf2-kjpq3f** (cross-scope end-to-end settle): two same-tag entries in two distinct scopes; a `:cross-scope? true` descriptor with no explicit `:cause`; on settle BOTH scopes' entries are marked stale (the scope-agnostic fan-out) and the settlement `:invalidation` trace facet records the cross-scope dispatch. The mutation-supplied `[:mutation <id> <instance>]` cause satisfies the rf2-7r8kgd cause-required gate (previously only the pure normalize round-trip covered the descriptor path).

## Citation errata — rejected on corrected premise (rf2-4nae75)

The bead asked to strip `§Restore and replay part 2` to `§Restore and replay` (in `mutation_runtime.cljc` x3 + `ssr.cljc` x4), on the premise that the spec has "no part 2 subsection / anchor." **That premise is incorrect.** `spec/016-Resources.md` §Restore and replay states "**The contract has five parts**" with five numbered `### N.` subsections, and the spec's own prose cites them as "part 1" / "part 3" / "part 5" (lines 1087/1092/1099). The citation `§Restore and replay part 2` resolves to part 2 ("In-flight work does not survive restore as live work") and is accurate as written; stripping the suffix would DEGRADE precision. No change made (the sweep also found existing accurate "part 4"/"part 5" citations in `ssr.cljc`, confirming the convention). Recommending rf2-4nae75 be closed won't-fix.

## Quality gates

- `npm run test:cljs` (node-runtime, all artefacts incl. resources): **6673 tests / 24647 assertions, 0 failures, 0 errors** ✅
- resources `clojure -M:test` (JVM): **326 tests / 1237 assertions, 0 failures, 0 errors** ✅
- `mkdocs build --strict`: **built clean** (no warnings/errors; spec unchanged) ✅

## Notes for the mayor

- `rf2-qiv160` (slice-3 impl) remains open — out of scope here; its work is complete in green PR #3900 awaiting merge (a mayor merge action, no worker re-dispatch per the bead note).
