### PR TITLE
test(core): EP-0012 path/identity foundation coverage (CEDN-1, concrete paths) (rf2-orcbow)

### DIFF
--- a/implementation/core/test/re_frame/frame_classification_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_classification_cljs_test.cljc
@@ -257,3 +257,70 @@
       (is (= :my-app.sinks/datadog
              (get-in meta [:observability :handled-events 0 :sink]))
           ":observability sink policy rides the frame config"))))
+
+;; ---------------------------------------------------------------------------
+;; concrete path host-segment rejection (rf2-orcbow point 2)
+;;
+;; `:sensitive :app-db` / `:large :app-db` entries are concrete `:rf/path`
+;; vectors (EP-0012). A concrete path's SEGMENTS must be portable EDN identity
+;; values — Conventions §Path shape: "Concrete runtime paths MUST NOT contain
+;; host values; such values are rejected at the boundary that accepts the
+;; path." The existing fail-loud tests above cover path-SHAPE rejection
+;; (a bare keyword, a non-vector :app-db) and list->vector normalization, but
+;; NOT opaque host-OBJECT segments inside an otherwise well-shaped path.
+;;
+;; KNOWN GAP — `normalize-app-db-paths` validates only that each path is
+;; sequential and routes it through `path/normalize`, which coerces container
+;; shape but does NOT validate the segment domain. So `[:auth (Object.)]`
+;; currently passes. The fail-closed source fix (a validated concrete-path
+;; normalization helper at the declaration boundary) is owned by the
+;; correctness / best-practice review beads rf2-wgutc2 (item 3, "Concrete
+;; path boundaries do not reject non-EP path segments ... frame classification
+;; ... can accept host/opaque values as segments") and rf2-w9x5fv (item 2,
+;; "Split shape coercion from validated concrete normalization ... use the
+;; validated helper at concrete boundaries such as frame classification"),
+;; NOT by this coverage bead (tests-only).
+;;
+;; These tests therefore (a) DOCUMENT + PIN the current (does-not-reject)
+;; behaviour on both runtimes so the gap is visible, and (b) carry the
+;; spec-correct fail-closed assertion inline so the flip is a one-line edit
+;; when the source fix lands. Flip the `host-segment-*` blocks then.
+;; ---------------------------------------------------------------------------
+
+(deftest host-object-path-segment-is-not-yet-rejected
+  (testing "KNOWN GAP (rf2-wgutc2 / rf2-w9x5fv): an opaque host-object path
+            segment is NOT rejected at reg-frame — current behaviour pinned"
+    (let [host #?(:clj (java.lang.Object.) :cljs #js {:opaque true})]
+      ;; CURRENT behaviour: validate+extract accepts the host segment, returning
+      ;; it verbatim in the normalized declaration (no fail-loud).
+      (let [{:keys [sensitive-app-db]}
+            (fc/validate+extract :app/host-seg
+              {:sensitive {:app-db [[:auth host]]}})]
+        (is (= 1 (count sensitive-app-db))
+            "current: host-object segment passes through (does not throw)")
+        (is (= :auth (first (first sensitive-app-db)))
+            "the literal prefix segment survives")
+        (is (identical? host (second (first sensitive-app-db)))
+            "the opaque host object rides in the stored path verbatim"))
+      ;; SPEC-CORRECT behaviour, asserted once the source fix lands — flip to:
+      ;;   (let [data (bad-classification-ex
+      ;;                #(rf/reg-frame :app/host-seg
+      ;;                   {:sensitive {:app-db [[:auth host]]}}))]
+      ;;     (is (= :rf.error/bad-frame-classification (:rf.error/id data)))
+      ;;     (is (= [:sensitive :app-db] (:bad-key data)))
+      ;;     (is (= [:auth host] (:bad-path data))))
+      ;; (Conventions §Path shape: concrete paths MUST NOT contain host values;
+      ;;  rejected at the boundary that accepts the path.)
+      )))
+
+(deftest existing-segment-shape-rejections-still-hold
+  (testing "well-formed concrete paths (incl. the root []) still validate + normalize"
+    ;; A vector of concrete EDN segments — and the explicit root [] — are
+    ;; accepted; this anchors the negative (host-segment) case above against
+    ;; the positive baseline so a future over-broad rejection is caught.
+    (let [{:keys [sensitive-app-db]}
+          (fc/validate+extract :app/ok-paths
+            {:sensitive {:app-db [[:auth :token]
+                                  [:cart :items 42 :qty]  ;; integer segment OK
+                                  []]}})]                  ;; root path OK
+      (is (= [[:auth :token] [:cart :items 42 :qty] []] sensitive-app-db)))))

--- a/implementation/core/test/re_frame/identity_cedn1_cljs_test.cljc
+++ b/implementation/core/test/re_frame/identity_cedn1_cljs_test.cljc
@@ -190,7 +190,33 @@
              #inst "2026-06-10T10:00:00.000+10:00"
              #inst "2026-06-10T00:00:00.000-00:00"))
        (is (= "t:2026-06-10T00:00:00.000Z"
-              (id/canonical-bytes #inst "2026-06-10T00:00:00.000-00:00"))))))
+              (id/canonical-bytes #inst "2026-06-10T00:00:00.000-00:00")))))
+  ;; --- CLJS js/Date instant encoding (rf2-orcbow point 4) ---
+  ;; The JVM instant tests above exercise the java.time path; CLJS js/Date
+  ;; encoding rides a SEPARATE branch (`.toISOString`) that can regress
+  ;; independently, so it gets its own dedicated assertions. The exact
+  ;; `t:...Z` millisecond-precision token, and the equivalent-instant
+  ;; timezone-collapse property, are both pinned for the JS host.
+  #?(:cljs
+     (testing "CLJS js/Date encodes to the exact RFC 3339 millis-UTC t:...Z token"
+       ;; 2026-06-10T00:00:00.000Z == epoch millis 1781049600000.
+       (is (= "t:2026-06-10T00:00:00.000Z"
+              (id/canonical-bytes (js/Date. 1781049600000))))
+       (testing "a whole-second instant still renders the millisecond .000 suffix"
+         (is (= "t:2026-06-10T00:00:00.000Z"
+                (id/canonical-bytes (js/Date. "2026-06-10T00:00:00Z")))))
+       (testing "sub-second precision is preserved in the token"
+         (is (= "t:2026-06-10T00:00:00.123Z"
+                (id/canonical-bytes (js/Date. 1781049600123)))))
+       (testing "two js/Date objects built for the same instant in different
+                 timezone literals collapse to one identity"
+         (is (id/identical-identity?
+               (js/Date. "2026-06-10T10:00:00+10:00")
+               (js/Date. "2026-06-10T00:00:00Z"))))
+       (testing "a js/Date is identity-equal to its EDN #inst counterpart for the
+                 same instant (host-date and EDN-instant are one fact)"
+         (is (= (id/canonical-bytes (js/Date. 1781049600000))
+                (id/canonical-bytes #inst "2026-06-10T00:00:00.000-00:00")))))))
 
 ;; ---- fail-closed rejection -----------------------------------------------
 
@@ -229,3 +255,124 @@
   #?(:clj
      (testing "an arbitrary host object fails closed"
        (is (non-edn-id-error? #(id/canonical-bytes (java.lang.Object.)))))))
+
+;; ---- canonical projection: ordering is owned by canonical-bytes ----------
+;;
+;; rf2-orcbow point 3. The bead asks whether `canonical` returns a
+;; deterministically-ordered readable projection, or merely an =-equal
+;; value. These tests PIN the actual contract: `canonical` returns an
+;; =-equal, recursively-normalized value but does NOT reorder map/set entries
+;; — ordering is owned EXCLUSIVELY by `canonical-bytes` (the byte-level
+;; identity the equality contract is defined over, Conventions §Canonical
+;; byte encoding). Two map spellings that differ only in insertion order have
+;; identical `canonical-bytes`; their `canonical` projections are `=` but
+;; their entry-iteration order is not a contract. A consumer that needs a
+;; deterministic readable projection sorts by `canonical-bytes` itself (or a
+;; future surface narrows this). Pinning the narrow contract here keeps a
+;; later "make canonical ordered" change from silently widening it.
+
+(deftest canonical-projection-ordering-contract
+  (testing "canonical-bytes is the deterministically-ordered surface"
+    ;; Map key order in the source spelling does not change the bytes.
+    (is (= (id/canonical-bytes {:z 1 :a 2 :m 3})
+           (id/canonical-bytes {:a 2 :m 3 :z 1})
+           (id/canonical-bytes {:m 3 :z 1 :a 2})))
+    ;; Repeated calls are byte-identical (determinism).
+    (is (= (id/canonical-bytes {:z 1 :a 2})
+           (id/canonical-bytes {:z 1 :a 2})))
+    ;; Sets order by element bytes regardless of construction order.
+    (is (= (id/canonical-bytes #{:gamma :alpha :beta})
+           (id/canonical-bytes #{:beta :gamma :alpha}))))
+  (testing "canonical returns an =-equal value but ordering is NOT its contract"
+    ;; Equal as a value, key-order normalized away.
+    (is (= (id/canonical {:z 1 :a 2 :m 3})
+           (id/canonical {:a 2 :m 3 :z 1})))
+    (is (= {:a 2 :m 3 :z 1} (id/canonical {:z 1 :a 2 :m 3})))
+    ;; The projection recurses but preserves vector order (vectors are
+    ;; order-significant EDN facts).
+    (is (= {:xs [3 1 2]} (id/canonical {:xs [3 1 2]})))
+    ;; A set projection is =-equal to the source set.
+    (is (= #{:alpha :beta :gamma} (id/canonical #{:gamma :alpha :beta}))))
+  (testing "two values are equal-as-identity iff their canonical-bytes are ="
+    ;; The normative equality contract (Conventions §Canonical EDN identity):
+    ;; canonical-bytes equality is the identity, not canonical-value =.
+    (is (= (id/identical-identity? {:z 1 :a 2} {:a 2 :z 1})
+           (= (id/canonical-bytes {:z 1 :a 2}) (id/canonical-bytes {:a 2 :z 1}))
+           true))))
+
+;; ---- duplicate canonical map keys (the host-value collision) -------------
+;;
+;; rf2-orcbow point 1. Two DISTINCT host values can encode to the same
+;; CEDN-1 key bytes. The canonical adversarial case (the one the bead names)
+;; is JVM-only: a `java.util.Date` and a `java.time.Instant` for the SAME
+;; instant are distinct host types AND distinct Clojure map keys (`=` does
+;; not equate them), yet both render the identical `t:<utc>.SSSZ` token. A
+;; map keyed by both keeps BOTH entries, so its CEDN-1 bytes carry two
+;; colliding key tokens inside one `m{…}` group. Conventions §Canonical byte
+;; encoding: "Duplicate canonical keys are invalid and MUST be rejected
+;; before the value becomes a cache key, route identity, or work id."
+;;
+;; CLJS has a single host date type (`js/Date`), and CLJS `=` equates two
+;; `js/Date`s (and an EDN `#inst`, which READS as a `js/Date`) for the same
+;; instant — so a map keyed by "two same-instant dates" COLLAPSES to one
+;; entry on CLJS. The distinct-host-keys-same-bytes map collision is
+;; therefore inherently a JVM phenomenon; the CLJS leg pins the cross-host
+;; "same instant → one identity" facts instead (which hold on both hosts).
+;;
+;; KNOWN GAP — the current encoder does NOT yet detect the JVM collision: it
+;; sorts entries by key bytes and emits both, producing colliding key tokens.
+;; The fail-closed source fix is owned by the correctness/best-practice
+;; review beads rf2-wgutc2 (item 1, canonical alignment) and rf2-w9x5fv
+;; (item 3, "rejecting duplicate canonical map keys"), NOT by this coverage
+;; bead (tests-only). These tests therefore (a) DOCUMENT + PIN the current
+;; observable behaviour so the gap is visible and a regression can't slip in
+;; unnoticed, and (b) carry the spec-correct assertion commented inline so
+;; the flip to fail-closed is a one-line edit when the source fix lands.
+
+(deftest duplicate-canonical-keys
+  (testing "two distinct host instants for the same moment encode to identical key bytes"
+    ;; Holds on both hosts: a host date and its EDN-instant counterpart are
+    ;; one identity fact (the cross-host instant-collapse property).
+    (let [d #?(:clj (java.util.Date. 1781049600000) :cljs (js/Date. 1781049600000))
+          i #inst "2026-06-10T00:00:00.000-00:00"]
+      (is (= (id/canonical-bytes d) (id/canonical-bytes i))
+          "distinct host representations, identical CEDN-1 bytes")
+      (is (id/identical-identity? d i))))
+  #?(:clj
+     ;; The map-collision premise only holds where the two same-instant keys
+     ;; are DISTINCT map keys — i.e. on the JVM, where Date and Instant are
+     ;; distinct types that `=` does not equate.
+     (let [dup-map {(java.util.Date. 1781049600000)               :via-date
+                    (java.time.Instant/ofEpochMilli 1781049600000) :via-instant}]
+       (testing "a JVM map keyed by Date + Instant for one instant keeps BOTH entries"
+         (is (not= (java.util.Date. 1781049600000)
+                   (java.time.Instant/ofEpochMilli 1781049600000))
+             "Date and Instant are distinct keys (= does not equate them)")
+         (is (= 2 (count dup-map))
+             "the map carries two entries whose canonical key bytes collide"))
+       (testing "KNOWN GAP (rf2-wgutc2 / rf2-w9x5fv): the duplicate canonical
+                 key is NOT yet rejected — current behaviour pinned"
+         ;; CURRENT behaviour: canonical-bytes emits both colliding key tokens.
+         (is (string? (id/canonical-bytes dup-map))
+             "current: encodes (does not throw) — collision is silently serialized")
+         ;; SPEC-CORRECT behaviour, asserted once the source fix lands — flip to:
+         ;;   (is (non-edn-id-error? #(id/canonical-bytes dup-map)))
+         ;;   (is (non-edn-id-error? #(id/canonical       dup-map)))
+         ;; (Conventions: duplicate canonical keys are invalid and MUST be
+         ;; rejected before the value becomes a cache key / route id / work id.)
+         (let [bytes (id/canonical-bytes dup-map)]
+           ;; The colliding key token appears for BOTH entries inside the
+           ;; group — the observable symptom the rejection will eliminate.
+           (is (= 2 (count (re-seq #"t:2026-06-10T00:00:00\.000Z" bytes)))
+               "the same key token appears twice — the duplicate-key defect")))))
+  #?(:cljs
+     (testing "CLJS collapses same-instant js/Date keys (no distinct-key
+               collision to reject on this host)"
+       ;; Documents WHY there is no CLJS map-collision leg: value-equal dates
+       ;; are one key, so the map has a single entry and a single key token.
+       (let [m {(js/Date. 1781049600000)              :a
+                #inst "2026-06-10T00:00:00.000-00:00" :b}]
+         (is (= 1 (count m))
+             "value-equal js/Date keys collapse to one entry on CLJS")
+         (is (= 1 (count (re-seq #"t:2026-06-10T00:00:00\.000Z"
+                                 (id/canonical-bytes m)))))))))

--- a/implementation/core/test/re_frame/path_laws_cljs_test.cljc
+++ b/implementation/core/test/re_frame/path_laws_cljs_test.cljc
@@ -261,3 +261,92 @@
   (testing "an unbound param fails closed"
     (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
                  (path/instantiate [:a '?x] {})))))
+
+;; ---- vector-index container policy (rf2-orcbow point 5) ------------------
+;;
+;; The intermediate-container policy (Conventions §Path laws) defines the
+;; vector-index case EXPLICITLY rather than letting a host `assoc` throw.
+;; The generative laws above prove put-lookup / put-put hold for every
+;; generated path, but the SPECIFIC vector-vs-map behaviour was only inferred
+;; from them. These direct examples PIN the intended policy so a change to
+;; `container-for` is caught:
+;;
+;;   - a vector holds an entry ONLY at an in-range non-negative integer index;
+;;   - an out-of-range index, a negative index, or a non-integer segment
+;;     REPLACES the vector with a fresh map (never throws, never grows the
+;;     vector) — keeping `put` total so put-lookup holds for every path;
+;;   - an existing compatible vector is preserved (not silently rebuilt).
+
+(deftest vector-index-container-policy
+  (testing "in-range non-negative integer index: vector is preserved + updated in place"
+    (is (= [10 99 30] (path/put [10 20 30] [1] 99)))
+    (is (= {:present? true :value 20} (path/lookup [10 20 30] [1])))
+    (is (= 20 (path/get [10 20 30] [1])))
+    ;; index 0 and the last in-range index are both legal vector steps
+    (is (= [99 20 30] (path/put [10 20 30] [0] 99)))
+    (is (= [10 20 99] (path/put [10 20 30] [2] 99)))
+    ;; a nested vector under a map key composes through
+    (is (= 30 (path/get {:xs [10 20 30]} [:xs 2])))
+    (is (= {:xs [10 99 30]} (path/put {:xs [10 20 30]} [:xs 1] 99))))
+  (testing "out-of-range index: vector is REPLACED by a fresh map (no growth, no throw)"
+    (is (= {5 99} (path/put [10 20] [5] 99)))
+    ;; the index equal to count is out of range (a vector has no slot there)
+    (is (= {2 99} (path/put [10 20] [2] 99)))
+    ;; lookup of an out-of-range index on a vector is simply missing
+    (is (= {:present? false} (path/lookup [10 20] [5])))
+    (is (= {:present? false} (path/lookup [10 20] [2]))))
+  (testing "negative index: vector is REPLACED by a fresh map (not a tail index)"
+    (is (= {-1 99} (path/put [10 20] [-1] 99)))
+    (is (= {:present? false} (path/lookup [10 20] [-1]))))
+  (testing "non-integer segment over a vector: REPLACED by a fresh map"
+    (is (= {:k 99} (path/put [10 20] [:k] 99)))
+    (is (= {"s" 99} (path/put [10 20] ["s"] 99)))
+    (is (= {:present? false} (path/lookup [10 20] [:k])))
+    ;; lookup on a vector with a non-integer segment is missing, not a throw
+    (is (= ::nf (path/get [10 20] [:k] ::nf))))
+  (testing "deeper write that must create a fresh map UNDER a replaced vector"
+    ;; [10 20] faced with non-integer :a is replaced by {}, then :b nests
+    (is (= {:a {:b 99}} (path/put [10 20] [:a :b] 99)))
+    ;; and the put-lookup law still holds across the replacement
+    (is (= {:present? true :value 99}
+           (path/lookup (path/put [10 20] [:a :b] 99) [:a :b]))))
+  (testing "an in-range vector write does NOT clobber sibling indexes"
+    (is (= [:a :B :c :d] (path/put [:a :b :c :d] [1] :B))))
+  (testing "vector-index put at x=nil stores present-nil at the index (not dissoc)"
+    (is (= [10 nil 30] (path/put [10 20 30] [1] nil)))
+    (is (= {:present? true :value nil}
+           (path/lookup (path/put [10 20 30] [1] nil) [1])))))
+
+;; ---- concrete paths + explicit root (rf2-orcbow concrete-path coverage) ---
+;;
+;; A concrete `:rf/path` is a vector of EDN segments; the empty vector `[]`
+;; is the explicit root path (Conventions §Path shape). normalize coerces any
+;; sequential container to the canonical vector form. These pin the
+;; container-shape coercion + the root spelling directly (the laws cover root
+;; semantics; this covers the SHAPE the declaration boundary stores).
+
+(deftest concrete-path-shape-and-root
+  (testing "normalize coerces sequential containers to the canonical vector"
+    (is (= [:a :b 3] (path/normalize (list :a :b 3))))
+    (is (= [:a :b]   (path/normalize (seq [:a :b]))))
+    (is (vector? (path/normalize (list :a :b))))
+    ;; an already-vector path passes through
+    (is (= [:cart :items 42 :qty] (path/normalize [:cart :items 42 :qty]))))
+  (testing "the empty vector is the canonical root path"
+    (is (= [] (path/normalize [])))
+    (is (= [] (path/normalize (list))))
+    ;; KNOWN GAP (rf2-w9x5fv item 1 / rf2-wgutc2 item 3): nil currently
+    ;; normalizes to root [] — flagged for an explicit-root source change.
+    ;; Pinned here so the behaviour is documented, not relied upon silently.
+    ;; SPEC-CORRECT once the fix lands: nil -> :rf.error/bad-path. Flip to:
+    ;;   (is (thrown? ... (path/normalize nil)))
+    (is (= [] (path/normalize nil))))
+  (testing "a non-sequential path fails closed with :rf.error/bad-path"
+    (is (= :rf.error/bad-path
+           (try (path/normalize :not-a-path) nil
+                (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+                  (:rf.error/id (ex-data e))))))
+    (is (= :rf.error/bad-path
+           (try (path/normalize 42) nil
+                (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+                  (:rf.error/id (ex-data e))))))))


### PR DESCRIPTION
Strengthens the EP-0012 path/identity foundation **test tree** per the coverage review (rf2-orcbow). **Test additions only — no source touched.**

## What changed

Three test files in `implementation/core/test/re_frame/`, +304 lines.

### `identity_cedn1_cljs_test.cljc` (CEDN-1)
- **CLJS js/Date instant encoding** (point 4) — exact `t:...Z` millisecond token, whole-second `.000` suffix, sub-second precision, cross-timezone collapse, and `js/Date` == EDN `#inst` identity. The JVM `java.time` path already had coverage; the `.toISOString` branch can regress independently.
- **`canonical-projection-ordering-contract`** (point 3) — pins the narrow contract: `canonical-bytes` owns ordering **exclusively**; `canonical` returns an `=`-equal, recursively-normalized value whose entry-iteration order is **not** a contract; equality-as-identity `==` `canonical-bytes` `=`. Prevents a later "make canonical ordered" change from silently widening the contract.
- **`duplicate-canonical-keys`** (point 1) — a JVM `java.util.Date` and `java.time.Instant` for the same instant are distinct map keys with identical CEDN-1 key bytes (the map keeps both entries → two colliding key tokens). Documents + pins the current (not-yet-rejected) behaviour, with the spec-correct fail-closed assertion inline for a one-line flip. CLJS leg documents why there is no CLJS map-collision (value-equal `js/Date` keys collapse).

### `path_laws_cljs_test.cljc`
- **`vector-index-container-policy`** (point 5) — direct put/lookup examples over in-range, out-of-range, negative, and non-integer vector segments; in-place vector update vs fresh-map replacement; present-nil written at an index. Pins the intermediate-container policy that the generative laws only implied.
- **`concrete-path-shape-and-root`** — `normalize` sequential→vector coercion, explicit root `[]`, and `:rf.error/bad-path` fail-closed; pins `nil`→`[]` as a flagged gap.

### `frame_classification_cljs_test.cljc` (point 2)
- **`host-object-path-segment-is-not-yet-rejected`** — JVM + CLJS document + pin that an opaque host-object path segment is **not yet** rejected at `reg-frame` (the boundary validates path shape, not segment domain), with the spec-correct `:rf.error/bad-frame-classification` assertion inline for the flip. Plus a positive baseline (`existing-segment-shape-rejections-still-hold`) for valid concrete paths incl. root.

## Surfaced gaps (out of scope — owned by source-fix beads)

Two spec-mandated fail-closed behaviours are **not yet implemented** in the source. They are owned by the correctness/best-practice review beads, not this tests-only coverage bead:
- **Duplicate canonical map keys** (distinct host values → same CEDN-1 key bytes) → `rf2-w9x5fv` item 3 / `rf2-wgutc2` item 1.
- **Host-segment / concrete-path validation** at declaration boundaries → `rf2-wgutc2` item 3 / `rf2-w9x5fv` items 1-2.

These tests document + pin the current behaviour so the gaps stay visible, and carry the spec-correct assertions inline so flipping each to assert rejection is a one-line edit when the source fix lands.

## Quality gates

- `npm run test:cljs` (from `implementation/`) — **green**: `Ran 6676 tests containing 24685 assertions. 0 failures, 0 errors.`
- `clojure -M:test` (full JVM core suite, from `implementation/core/`) — **green**: `Ran 1233 tests containing 5465 assertions. 0 failures, 0 errors.` (baseline was 1227/5416 — the additions add 6 tests / 49 assertions on the JVM).

Closes rf2-orcbow.