### PR TITLE
fix(core): EP-0012 path/identity foundation fail-closed hardening (rf2-w9x5fv)

### DIFF
--- a/implementation/core/src/re_frame/frame_classification.cljc
+++ b/implementation/core/src/re_frame/frame_classification.cljc
@@ -104,7 +104,9 @@
   "Build the `:rf.error/bad-frame-classification` ex-info with the canonical
   thrown-error shape (Spec 009 §The thrown-error shape). `reason` is the
   human-facing message; `extras` names the offending slot (`:bad-key`,
-  `:bad-path`, `:bad-carrier`, `:bad-entry`, `:bad-value`)."
+  `:bad-path`, `:bad-segment`, `:bad-carrier`, `:bad-entry`, `:bad-value`)
+  and MAY carry `:rf.error/cause` (the inner `:rf.error/id` of a wrapped
+  path error — kept distinct so it never clobbers this error's own id)."
   [frame-id reason extras]
   (ex-info (str :rf.error/bad-frame-classification)
            (merge {:rf.error/id :rf.error/bad-frame-classification
@@ -116,13 +118,18 @@
 
 ;; ---- path validation (EP-0012 :rf/path) ----------------------------------
 ;;
-;; `:sensitive :app-db` / `:large :app-db` entries are `:rf/path` values.
-;; A well-formed declaration is a VECTOR of paths; each path is a
-;; sequential collection of scalar segments (the empty path `[]` is legal
-;; — it marks the whole app-db). `rf.path/normalize` is the EP-0012 helper:
-;; it canonicalises a sequential path to a vector and THROWS
-;; `:rf.error/bad-path` on a non-sequential path. We catch that and re-raise
-;; as the frame-classification error so the author sees the frame + key.
+;; `:sensitive :app-db` / `:large :app-db` entries are concrete `:rf/path`
+;; values. A well-formed declaration is a VECTOR of paths; each path is a
+;; sequential collection of CONCRETE EDN segments (the empty path `[]` is
+;; legal — it marks the whole app-db). `rf.path/normalize-concrete` is the
+;; EP-0012 VALIDATED concrete boundary (rf2-w9x5fv item 2): it canonicalises
+;; a sequential path to a vector AND fails closed with `:rf.error/bad-path`
+;; on a non-sequential path OR any segment outside the concrete EDN domain
+;; (an opaque host object, a function, a template-parameter segment). We
+;; catch that and re-raise as the frame-classification error so the author
+;; sees the frame + key. This is a concrete declaration boundary, so it MUST
+;; use `normalize-concrete`, never bare `normalize` — a host/opaque segment
+;; in a stored elision path is rejected here, not silently stored.
 
 (defn- normalize-app-db-paths
   "Validate + normalise the `:app-db` paths of a `:sensitive` / `:large`
@@ -153,15 +160,21 @@
                             ":rf/path (a sequential collection of segments)")
                        {:bad-key [class-key :app-db] :bad-path p})))
             (try
-              (path/normalize p)
+              (path/normalize-concrete p)
               (catch #?(:clj Exception :cljs :default) e
                 (throw (classification-error
                          frame-id
                          (str class-key " :app-db carries a malformed "
                               ":rf/path: " #?(:clj (.getMessage e)
                                               :cljs (ex-message e)))
+                         ;; Surface the offending segment + the inner path
+                         ;; error cause WITHOUT clobbering this error's own
+                         ;; `:rf.error/id :rf.error/bad-frame-classification`
+                         ;; (the inner cause is `:rf.error/bad-path`).
                          (merge {:bad-key [class-key :app-db] :bad-path p}
-                                (select-keys (ex-data e) [:rf.error/id])))))))
+                                (when-some [cause (:rf.error/id (ex-data e))]
+                                  {:rf.error/cause cause})
+                                (select-keys (ex-data e) [:bad-segment])))))))
           paths)))
 
 ;; ---- HTTP carrier validation --------------------------------------------

--- a/implementation/core/src/re_frame/identity.cljc
+++ b/implementation/core/src/re_frame/identity.cljc
@@ -177,12 +177,22 @@
 (defn- encode-map [m]
   ;; Order entries by their keys' CEDN-1 bytes; each key token is separated
   ;; from its value token, and entries from each other, by a single space.
-  ;; Duplicate canonical keys are impossible inside a Clojure map (the
-  ;; reader collapses them); a reader/adapter that could produce duplicates
-  ;; rejects them upstream before this boundary.
+  ;;
+  ;; Duplicate canonical keys FAIL CLOSED (Conventions §Map key
+  ;; canonicalization: "Duplicate canonical keys are invalid and MUST be
+  ;; rejected before the value becomes a cache key, route identity, or work
+  ;; id."). Two DISTINCT host map keys can encode to the SAME CEDN-1 key
+  ;; bytes — e.g. a `java.util.Date` and a `java.time.Instant` for one
+  ;; instant are distinct JVM map keys (`=` does not equate them) yet render
+  ;; the identical `t:<utc>` token. Emitting both would produce a structurally
+  ;; ambiguous identity; instead we reject the whole identity closed
+  ;; (rf2-w9x5fv item 3) rather than silently serialize colliding key tokens.
   (let [entries (->> m
                      (map (fn [[k v]] [(encode k) (encode v)]))
-                     (sort-by first))]
+                     (sort-by first))
+        ks      (map first entries)]
+    (when-not (= (count ks) (count (distinct ks)))
+      (reject! m :duplicate-canonical-map-key))
     (str "m{"
          (str/join " " (mapcat (fn [[ke ve]] [ke ve]) entries))
          "}")))
@@ -214,8 +224,10 @@
     (vector? x)         (str "v[" (encode-elements x) "]")
     (set? x)            (encode-set x)
     (map? x)            (encode-map x)
+    ;; `seq?` subsumes `list?` (every list is a seq; lazy seqs are seq? but
+    ;; not list?) and both encode identically, so one `seq?` branch covers
+    ;; the whole list-kind (fe3a9q: the prior `list?` branch was dead).
     (seq? x)            (str "l(" (encode-elements x) ")")
-    (list? x)           (str "l(" (encode-elements x) ")")
     :else               (reject! x :unsupported-host-value)))
 
 ;; ---- public-internal surface ---------------------------------------------
@@ -230,6 +242,28 @@
   [value]
   (encode value))
 
+(declare canonical)
+
+(defn- canonical-map
+  "Canonicalize a map's keys and values, failing closed on DUPLICATE
+  canonical keys. Two DISTINCT source keys can canonicalize to the SAME key
+  (e.g. a java.util.Date and a java.time.Instant for one instant both
+  normalize to the same UTC text), which would silently collapse two
+  identity-distinct entries into one. Per Conventions §Map key
+  canonicalization (\"Duplicate canonical keys are invalid and MUST be
+  rejected before the value becomes a cache key, route identity, or work
+  id\") this rejects the whole identity closed — the same fail-closed rule
+  `canonical-bytes` enforces, so the two surfaces never diverge (rf2-w9x5fv
+  item 3)."
+  [m]
+  (let [out (reduce-kv (fn [acc k v]
+                         (let [ck (canonical k)]
+                           (when (contains? acc ck)
+                             (reject! m :duplicate-canonical-map-key))
+                           (assoc acc ck (canonical v))))
+                       {} m)]
+    out))
+
 (defn canonical
   "Return the canonical normalized EDN identity of `value` — the storage,
   work-ledger, trace, and replay identity (EP-0012 disposition 5: canonical
@@ -238,9 +272,14 @@
   The normalization recursively reorders map entries and set elements into
   CEDN-1 canonical order while preserving vector / list order and EDN kind,
   so two map spellings that differ only in insertion order return an `=`
-  canonical value. Fails closed with `:rf.error/non-edn-identity` for any
-  out-of-domain value — the validation walk runs eagerly so a host handle
-  buried anywhere in the structure is rejected, never host-stringified.
+  canonical value. Instants normalize to a single representation
+  (millisecond-precision UTC), so `canonical` and `canonical-bytes` share ONE
+  canonical form — a value stored via `canonical` and a value compared via
+  `canonical-bytes` can never disagree (rf2-w9x5fv item 3). Fails closed with
+  `:rf.error/non-edn-identity` for any out-of-domain value — the validation
+  walk runs eagerly so a host handle buried anywhere in the structure is
+  rejected, never host-stringified — and for a map carrying DUPLICATE
+  canonical keys (two distinct host keys whose CEDN-1 bytes collide).
 
   Present `nil` stays distinct from a missing key: `(canonical {:page nil})`
   is not `(canonical {})`. `nil` elision, if a surface wants it, is a
@@ -251,8 +290,15 @@
     (boolean? value)   value
     (string? value)    value
     (keyword? value)   value
-    (uuid-value? value)    value
-    (instant-value? value) value
+    ;; A UUID is `=` across both surfaces already (UUID equality is over the
+    ;; canonical 4122 form), so it has no two-surface divergence — preserve it.
+    (uuid-value? value) value
+    ;; Instants DO diverge: a java.util.Date and a java.time.Instant for one
+    ;; moment are NOT `=`, so preserving the host object would give two
+    ;; unequal canonical values for one identity fact. Normalize both to the
+    ;; single CEDN-1 UTC text so `canonical` and `canonical-bytes` agree on a
+    ;; single canonical form (rf2-w9x5fv item 3).
+    (instant-value? value) (instant->utc-millis-string value)
     (symbol? value)    value
     (integer? value)   (if (and (not (bad-number? value)) (safe-integer? value))
                          value
@@ -260,10 +306,9 @@
     (number? value)    (reject! value :non-integer-number)
     (vector? value)    (mapv canonical value)
     (set? value)       (into #{} (map canonical) value)
-    (map? value)       (reduce-kv (fn [acc k v] (assoc acc (canonical k) (canonical v)))
-                                  {} value)
+    (map? value)       (canonical-map value)
+    ;; `seq?` subsumes `list?` (fe3a9q) — one branch covers list-kind.
     (seq? value)       (apply list (map canonical value))
-    (list? value)      (apply list (map canonical value))
     :else              (reject! value :unsupported-host-value)))
 
 (defn identical-identity?

--- a/implementation/core/src/re_frame/path.cljc
+++ b/implementation/core/src/re_frame/path.cljc
@@ -57,28 +57,105 @@
   Pure namespace — no runtime state, no trace, no host coupling. `.cljc`
   so the JVM test sweep exercises the algebra without the CLJS runtime."
   (:refer-clojure :exclude [get])
-  (:require [clojure.core :as core]))
+  (:require [clojure.core :as core])
+  #?(:clj (:import [java.util UUID Date]
+                   [java.time Instant])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
 ;; ---- path shape / normalization ------------------------------------------
 
+(defn- bad-path!
+  "Throw the canonical `:rf.error/bad-path` error. `where` names the source
+  helper; `reason` is the human-facing message; `extras` names the offending
+  slot (`:bad-path`, `:bad-segment`)."
+  [where reason extras]
+  (throw (ex-info (str "rf.path: " reason)
+                  (merge {:rf.error/id :rf.error/bad-path
+                          :where       where
+                          :recovery    :fix-path}
+                         extras))))
+
 (defn normalize
-  "Normalize a path input to the canonical vector form. The primary path
-  container is a vector; APIs MAY accept any sequential collection for
-  migration ergonomics, but every stored declaration MUST normalize to a
-  vector (Conventions §Path shape). A nil path normalizes to the root
-  path `[]`."
+  "Coerce a path input's CONTAINER SHAPE to the canonical vector form. The
+  primary path container is a vector; APIs MAY accept any sequential
+  collection for migration ergonomics, but every stored declaration MUST
+  normalize to a vector (Conventions §Path shape).
+
+  The root path is the EXPLICIT empty vector `[]`; a nil path FAILS CLOSED
+  with `:rf.error/bad-path` (EP-0012 fail-closed boundary, rf2-w9x5fv). An
+  omitted path is NOT silently the whole value: a caller that legitimately
+  has no path handles that absence BEFORE normalization (e.g. an `or`-default
+  to `[]` at its own boundary, where targeting the root is the deliberate
+  intent), so an accidental nil here can never silently put/over the whole
+  value. `normalize` validates SHAPE only — it does not validate that each
+  segment is a concrete EDN identity value; the validated concrete boundary
+  is `normalize-concrete`."
   [p]
   (cond
-    (nil? p)        []
+    (nil? p)        (bad-path! 'rf.path/normalize
+                               (str "a path must be a sequential collection of segments; "
+                                    "the root path is the explicit empty vector [], not nil")
+                               {:bad-path p})
     (vector? p)     p
     (sequential? p) (vec p)
-    :else           (throw (ex-info "rf.path: a path must be a sequential collection of segments"
-                                    {:rf.error/id :rf.error/bad-path
-                                     :where       'rf.path/normalize
-                                     :recovery    :fix-path
-                                     :bad-path    p}))))
+    :else           (bad-path! 'rf.path/normalize
+                               "a path must be a sequential collection of segments"
+                               {:bad-path p})))
+
+;; ---- concrete-segment domain (Conventions §Segment domain) ---------------
+;;
+;; The shared upper bound for a CONCRETE path segment: a portable EDN
+;; identity value usable as an associative key or vector index — a keyword,
+;; string, symbol, integer, boolean, UUID, instant, or nil. Functions,
+;; atoms, promises, DOM nodes, AbortControllers, opaque host objects, and
+;; other host handles are NOT valid segments. A spec MAY narrow this domain
+;; for its surface, but never widen it (Conventions §Segment domain).
+
+(defn- valid-segment?
+  "True iff `seg` is a concrete EDN identity value admissible as a path
+  segment (Conventions §Segment domain). Composite values (vectors, maps,
+  sets, seqs) and host handles are NOT valid concrete segments — a
+  composite vector is only the template-parameter data form, which is not a
+  concrete segment."
+  [seg]
+  (or (nil? seg)
+      (keyword? seg)
+      (string? seg)
+      (symbol? seg)
+      (boolean? seg)
+      (integer? seg)
+      #?(:clj  (or (instance? UUID seg)
+                   (instance? Instant seg)
+                   (instance? Date seg))
+         :cljs (or (uuid? seg)
+                   (instance? js/Date seg)))))
+
+(defn normalize-concrete
+  "Normalize a path to the canonical vector form AND validate that every
+  segment is a concrete EDN identity value (Conventions §Segment domain).
+
+  This is the VALIDATED concrete boundary (EP-0012 rf2-w9x5fv item 2):
+  `normalize` coerces container shape only; `normalize-concrete` additionally
+  fails closed with `:rf.error/bad-path` on any segment outside the concrete
+  domain — an opaque host object, a function, a template-parameter segment
+  (`[:rf.path/param …]`), or any other composite. Concrete boundaries such as
+  frame classification and resource-scope inputs MUST route through this
+  helper, never bare `normalize`, so a host/opaque segment is rejected at the
+  declaration boundary rather than silently riding in a stored path."
+  [p]
+  (let [v (normalize p)]
+    (reduce (fn [_ seg]
+              (when-not (valid-segment? seg)
+                (bad-path! 'rf.path/normalize-concrete
+                           (str "a concrete path segment must be a portable EDN "
+                                "identity value (keyword, string, symbol, integer, "
+                                "boolean, UUID, instant, or nil) — host objects and "
+                                "composite/template segments are not valid concrete "
+                                "segments")
+                           {:bad-path v :bad-segment seg})))
+            nil v)
+    v))
 
 ;; ---- the unique missing sentinel -----------------------------------------
 ;;

--- a/implementation/core/test/re_frame/frame_classification_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_classification_cljs_test.cljc
@@ -269,49 +269,37 @@
 ;; (a bare keyword, a non-vector :app-db) and list->vector normalization, but
 ;; NOT opaque host-OBJECT segments inside an otherwise well-shaped path.
 ;;
-;; KNOWN GAP — `normalize-app-db-paths` validates only that each path is
-;; sequential and routes it through `path/normalize`, which coerces container
-;; shape but does NOT validate the segment domain. So `[:auth (Object.)]`
-;; currently passes. The fail-closed source fix (a validated concrete-path
-;; normalization helper at the declaration boundary) is owned by the
-;; correctness / best-practice review beads rf2-wgutc2 (item 3, "Concrete
-;; path boundaries do not reject non-EP path segments ... frame classification
-;; ... can accept host/opaque values as segments") and rf2-w9x5fv (item 2,
+;; HARDENED (rf2-w9x5fv) — `normalize-app-db-paths` now routes each path
+;; through `path/normalize-concrete`, the VALIDATED concrete boundary (item 2:
 ;; "Split shape coercion from validated concrete normalization ... use the
-;; validated helper at concrete boundaries such as frame classification"),
-;; NOT by this coverage bead (tests-only).
-;;
-;; These tests therefore (a) DOCUMENT + PIN the current (does-not-reject)
-;; behaviour on both runtimes so the gap is visible, and (b) carry the
-;; spec-correct fail-closed assertion inline so the flip is a one-line edit
-;; when the source fix lands. Flip the `host-segment-*` blocks then.
+;; validated helper at concrete boundaries such as frame classification").
+;; `normalize` still coerces container shape only; `normalize-concrete`
+;; additionally validates the segment domain, so an opaque host-object segment
+;; like `[:auth (Object.)]` FAILS CLOSED at reg-frame (item 3 / Conventions
+;; §Segment domain) rather than silently riding in a stored elision path.
 ;; ---------------------------------------------------------------------------
 
-(deftest host-object-path-segment-is-not-yet-rejected
-  (testing "KNOWN GAP (rf2-wgutc2 / rf2-w9x5fv): an opaque host-object path
-            segment is NOT rejected at reg-frame — current behaviour pinned"
+(deftest host-object-path-segment-is-rejected
+  (testing "rf2-w9x5fv (items 2 + 3): an opaque host-object path segment FAILS
+            LOUDLY at reg-frame — the concrete declaration boundary routes
+            through path/normalize-concrete, which rejects non-EDN segments
+            (Conventions §Path shape / §Segment domain: concrete paths MUST NOT
+            contain host values; rejected at the boundary that accepts them)"
     (let [host #?(:clj (java.lang.Object.) :cljs #js {:opaque true})]
-      ;; CURRENT behaviour: validate+extract accepts the host segment, returning
-      ;; it verbatim in the normalized declaration (no fail-loud).
-      (let [{:keys [sensitive-app-db]}
-            (fc/validate+extract :app/host-seg
-              {:sensitive {:app-db [[:auth host]]}})]
-        (is (= 1 (count sensitive-app-db))
-            "current: host-object segment passes through (does not throw)")
-        (is (= :auth (first (first sensitive-app-db)))
-            "the literal prefix segment survives")
-        (is (identical? host (second (first sensitive-app-db)))
-            "the opaque host object rides in the stored path verbatim"))
-      ;; SPEC-CORRECT behaviour, asserted once the source fix lands — flip to:
-      ;;   (let [data (bad-classification-ex
-      ;;                #(rf/reg-frame :app/host-seg
-      ;;                   {:sensitive {:app-db [[:auth host]]}}))]
-      ;;     (is (= :rf.error/bad-frame-classification (:rf.error/id data)))
-      ;;     (is (= [:sensitive :app-db] (:bad-key data)))
-      ;;     (is (= [:auth host] (:bad-path data))))
-      ;; (Conventions §Path shape: concrete paths MUST NOT contain host values;
-      ;;  rejected at the boundary that accepts the path.)
-      )))
+      (let [data (bad-classification-ex
+                   #(rf/reg-frame :app/host-seg
+                      {:sensitive {:app-db [[:auth host]]}}))]
+        (is (= :rf.error/bad-frame-classification (:rf.error/id data))
+            "a host-object segment is rejected with the frame-classification error")
+        (is (= [:sensitive :app-db] (:bad-key data))
+            "the offending classification key is named")
+        (is (= [:auth host] (:bad-path data))
+            "the offending path is named")
+        (is (identical? host (:bad-segment data))
+            "the offending host segment is surfaced from the path boundary"))
+      ;; The frame must NOT have been registered (fail-loud is transactional).
+      (is (nil? (frame/frame :app/host-seg))
+          "the malformed classification threw before any frame state mutated"))))
 
 (deftest existing-segment-shape-rejections-still-hold
   (testing "well-formed concrete paths (incl. the root []) still validate + normalize"

--- a/implementation/core/test/re_frame/identity_cedn1_cljs_test.cljc
+++ b/implementation/core/test/re_frame/identity_cedn1_cljs_test.cljc
@@ -319,15 +319,13 @@
 ;; therefore inherently a JVM phenomenon; the CLJS leg pins the cross-host
 ;; "same instant → one identity" facts instead (which hold on both hosts).
 ;;
-;; KNOWN GAP — the current encoder does NOT yet detect the JVM collision: it
-;; sorts entries by key bytes and emits both, producing colliding key tokens.
-;; The fail-closed source fix is owned by the correctness/best-practice
-;; review beads rf2-wgutc2 (item 1, canonical alignment) and rf2-w9x5fv
-;; (item 3, "rejecting duplicate canonical map keys"), NOT by this coverage
-;; bead (tests-only). These tests therefore (a) DOCUMENT + PIN the current
-;; observable behaviour so the gap is visible and a regression can't slip in
-;; unnoticed, and (b) carry the spec-correct assertion commented inline so
-;; the flip to fail-closed is a one-line edit when the source fix lands.
+;; HARDENED (rf2-w9x5fv item 3) — the encoder now DETECTS the JVM collision:
+;; `encode-map` (and the value-form `canonical`) compare the entries' canonical
+;; key tokens and FAIL CLOSED with `:rf.error/non-edn-identity` on a duplicate,
+;; rather than sorting by key bytes and emitting both colliding tokens. Both
+;; surfaces share the one fail-closed rule, so `canonical` and `canonical-bytes`
+;; never disagree. The tests below assert the fail-closed behaviour on the JVM
+;; (the only host where Date and Instant are distinct keys for one instant).
 
 (deftest duplicate-canonical-keys
   (testing "two distinct host instants for the same moment encode to identical key bytes"
@@ -350,21 +348,17 @@
              "Date and Instant are distinct keys (= does not equate them)")
          (is (= 2 (count dup-map))
              "the map carries two entries whose canonical key bytes collide"))
-       (testing "KNOWN GAP (rf2-wgutc2 / rf2-w9x5fv): the duplicate canonical
-                 key is NOT yet rejected — current behaviour pinned"
-         ;; CURRENT behaviour: canonical-bytes emits both colliding key tokens.
-         (is (string? (id/canonical-bytes dup-map))
-             "current: encodes (does not throw) — collision is silently serialized")
-         ;; SPEC-CORRECT behaviour, asserted once the source fix lands — flip to:
-         ;;   (is (non-edn-id-error? #(id/canonical-bytes dup-map)))
-         ;;   (is (non-edn-id-error? #(id/canonical       dup-map)))
-         ;; (Conventions: duplicate canonical keys are invalid and MUST be
-         ;; rejected before the value becomes a cache key / route id / work id.)
-         (let [bytes (id/canonical-bytes dup-map)]
-           ;; The colliding key token appears for BOTH entries inside the
-           ;; group — the observable symptom the rejection will eliminate.
-           (is (= 2 (count (re-seq #"t:2026-06-10T00:00:00\.000Z" bytes)))
-               "the same key token appears twice — the duplicate-key defect")))))
+       (testing "rf2-w9x5fv item 3: a duplicate canonical key FAILS CLOSED
+                 (Conventions §Map key canonicalization — duplicate canonical
+                 keys are invalid and MUST be rejected before the value becomes
+                 a cache key / route id / work id)"
+         ;; BOTH surfaces reject the whole identity closed — no silent
+         ;; serialization of colliding key tokens, and canonical + canonical-bytes
+         ;; agree (one canonical form).
+         (is (non-edn-id-error? #(id/canonical-bytes dup-map))
+             "canonical-bytes rejects the duplicate-canonical-key map")
+         (is (non-edn-id-error? #(id/canonical dup-map))
+             "canonical rejects it too — the two surfaces share one fail-closed rule"))))
   #?(:cljs
      (testing "CLJS collapses same-instant js/Date keys (no distinct-key
                collision to reject on this host)"

--- a/implementation/core/test/re_frame/path_laws_cljs_test.cljc
+++ b/implementation/core/test/re_frame/path_laws_cljs_test.cljc
@@ -335,12 +335,14 @@
   (testing "the empty vector is the canonical root path"
     (is (= [] (path/normalize [])))
     (is (= [] (path/normalize (list))))
-    ;; KNOWN GAP (rf2-w9x5fv item 1 / rf2-wgutc2 item 3): nil currently
-    ;; normalizes to root [] — flagged for an explicit-root source change.
-    ;; Pinned here so the behaviour is documented, not relied upon silently.
-    ;; SPEC-CORRECT once the fix lands: nil -> :rf.error/bad-path. Flip to:
-    ;;   (is (thrown? ... (path/normalize nil)))
-    (is (= [] (path/normalize nil))))
+    ;; rf2-w9x5fv item 1: the root path is the EXPLICIT empty vector [], and a
+    ;; nil path fails closed with :rf.error/bad-path — an omitted path is NOT
+    ;; silently the whole value. (Hardened from the prior nil->[] coercion.)
+    (is (= :rf.error/bad-path
+           (try (path/normalize nil) nil
+                (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+                  (:rf.error/id (ex-data e)))))
+        "nil is not the root path — it fails closed (explicit [] is the root)"))
   (testing "a non-sequential path fails closed with :rf.error/bad-path"
     (is (= :rf.error/bad-path
            (try (path/normalize :not-a-path) nil

--- a/implementation/resources/src/re_frame/resources/scope_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/scope_registry.cljc
@@ -149,18 +149,37 @@
                     "016 §The :inputs grammar.")
                {:scope-id scope-id :input input-name :source head}))
 
-      (not (or (nil? raw-path) (sequential? raw-path)))
+      ;; A `:db` target must be a CONCRETE sequential `:rf/path`. nil is NOT
+      ;; the root path — the root is the explicit `[]` (the whole-db sugar
+      ;; lowers to `[:db []]`). A nil here is an accidental absent path and
+      ;; fails closed rather than silently targeting the whole db (EP-0012
+      ;; rf2-w9x5fv item 1: explicit root, no silent nil→root).
+      (not (sequential? raw-path))
       (throw (registration-error
                :rf.error/invalid-resource-scope-spec
                'rf/reg-resource-scope
                (str "resource-scope " scope-id " input " input-name
                     " has a non-path `:db` target " (pr-str raw-path)
                     ". `[:db <rf-path>]` takes an EP-0012 concrete :rf/path "
-                    "(a sequential collection of segments). Per Spec 016 "
-                    "§The :inputs grammar / Conventions §The :rf/path algebra.")
+                    "(a sequential collection of segments; the root is the "
+                    "explicit [], not nil). Per Spec 016 §The :inputs grammar "
+                    "/ Conventions §The :rf/path algebra.")
                {:scope-id scope-id :input input-name :descriptor descriptor}))
 
-      :else [:db (path/normalize raw-path)])))
+      ;; Route through the VALIDATED concrete boundary (rf2-w9x5fv item 2):
+      ;; a host/opaque or template segment in a `:db` path fails closed here.
+      :else
+      (try
+        [:db (path/normalize-concrete raw-path)]
+        (catch #?(:clj Exception :cljs :default) e
+          (throw (registration-error
+                   :rf.error/invalid-resource-scope-spec
+                   'rf/reg-resource-scope
+                   (str "resource-scope " scope-id " input " input-name
+                        " `:db` path carries a malformed segment: "
+                        #?(:clj (.getMessage e) :cljs (ex-message e))
+                        " Per Conventions §Segment domain.")
+                   {:scope-id scope-id :input input-name :descriptor descriptor})))))))
 
 (defn- canonical-spec
   "Normalize a resolver registration argument into the canonical STORED

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -65,13 +65,14 @@ This catalogue is a **projection** of shapes that originate in the owning per-Sp
 
 ## Schema layers
 
-Each schema in this catalogue belongs to exactly one of three layers. The layer tells consumers what role the schema plays in the contract:
+Each schema in this catalogue belongs to exactly one layer. The layer tells consumers what role the schema plays in the contract:
 
 - **Runtime** — shapes the framework produces or consumes during normal operation (the dispatch envelope the runtime constructs, the effect-map a handler returns, the snapshot a machine writes, the trace event a tool reads). Implementations *must* match these on the wire; they are observable to every layer above.
-- **Public** — shapes the user passes into `reg-*` metadata or `(rf/configure! ...)` opts. These describe *what tooling reads when introspecting registrations*: the metadata map shape, the frame-meta returned by `(frame-meta id)`, the route-metadata accepted by `reg-route`. Tools target this surface; implementations validate user input against it.
+- **Public** — shapes the user passes into `reg-*` metadata or `(rf/configure! ...)` opts. These describe *what tooling reads when introspecting registrations*: the metadata map shape, the frame-meta returned by `(frame-meta id)`, the route-metadata accepted by `reg-route`. Tools target this surface; implementations validate user input against it. A `> Layer:` header MAY add a parenthetical refinement (e.g. `Public (input forms)` / `Authoring (input forms)`) to mark a public **authoring** shape validated at registration / dispatch as distinct from the runtime storage shape it lowers into; the refinement narrows Public, it does not introduce a separate layer.
 - **Conformance** — shapes that exist for the conformance corpus and capability-tagging machinery. The handler-body DSL, the fixture-file format, the capability-tagging convention — none of these flow through the runtime; they exist so a host-agnostic test harness can drive any implementation.
+- **Value** — cross-cutting **EDN value / identity** shapes that are not a single subsystem's runtime, public, or conformance surface but the shared *vocabulary* many surfaces normalize to. The canonical example is the [`:rf/path`](#rfpath-rfpath-template-the-path-algebra-ep-0012) algebra (EP-0012): a path is neither a runtime envelope the framework emits nor a `reg-*` metadata key, but the shared shape app-db focus, schema paths, redaction marks, flow inputs/outputs, route params, and named declarations all share. A Value schema is owned by a Conventions / EP section (the shared definition) rather than by one subsystem spec.
 
-Layer membership is **disjoint**: a schema is exactly one of Runtime, Public, or Conformance. Each schema entry below carries a `> Layer:` header naming its layer.
+Layer membership is **disjoint**: a schema names exactly one layer (Runtime, Public, Conformance, or Value — Public MAY carry a narrowing parenthetical). Each schema entry below carries a `> Layer:` header naming its layer.
 
 ### v1 vs post-v1 contracts
 


### PR DESCRIPTION
Hardens the EP-0012 path/identity foundation boundaries that the spec mandates fail-closed but the source coerced silently. Best-practice review from the EP-0012 sweep (rf2-w9x5fv, authoritative) — sources the gaps `orcbow` (#3942) pinned with inline KNOWN-GAP markers.

## Boundaries hardened

**1. `path/normalize` nil → fail-closed (item 1)**
`(normalize nil)` now throws `:rf.error/bad-path`. The root path is the EXPLICIT `[]`; an omitted/accidental nil can no longer silently target the whole value via `put`/`over`. `normalize` is now documented as SHAPE-only coercion.

**2. `path/normalize-concrete` — the validated concrete boundary (item 2)**
New helper: coerces container shape then validates each segment is in the Conventions §Segment domain (keyword/string/symbol/integer/boolean/UUID/instant/nil). Rejects host objects, functions, template-param segments (`[:rf.path/param …]`), and composites. The concrete declaration boundaries — frame-classification `:app-db` paths and resource-scope `:db` inputs — now route through it, so a host/opaque segment fails loud at registration instead of riding in a stored path.

**3. Duplicate canonical map keys + one canonical form (item 3)**
`encode-map` and `canonical` reject DUPLICATE canonical map keys fail-closed — two distinct host keys whose CEDN-1 bytes collide (a `java.util.Date` + `java.time.Instant` for one instant) no longer serialize ambiguously. `canonical` and `canonical-bytes` now share ONE canonical form: instants normalize to the single millisecond-UTC representation in `canonical` too, so the two surfaces can never disagree.

**4. Dead `list?` branch removed (fe3a9q)**
`seq?` subsumes `list?` (every list is a seq; both encode identically) — the dead branch is removed from `encode` and `canonical`.

**5. Spec-Schemas layer taxonomy internally consistent (item 4)**
Added `Value` to the schema-layer taxonomy (the `:rf/path` algebra's layer) and reworded the disjoint-membership text so the catalogue metadata is consistent.

### orcbow KNOWN-GAP assertions flipped (pin-current → assert-spec-correct)
- `path_laws_cljs_test`: `(normalize nil)` → asserts `:rf.error/bad-path` (was: pinned `[]`)
- `identity_cedn1_cljs_test`: duplicate canonical map key → asserts both `canonical-bytes` and `canonical` reject (was: pinned silent serialization with double key token)
- `frame_classification_cljs_test`: host-object path segment → asserts `:rf.error/bad-frame-classification` at reg-frame + transactional (frame not registered) (was: pinned pass-through)

All prior passing coverage preserved.

Also fixed a latent clobber in `frame-classification`: a wrapped path error's `:rf.error/id` was overwriting the classification error id via `select-keys`; the inner cause now rides `:rf.error/cause`.

## Quality gates
- `npm run test:cljs`: 6679 tests, 24702 assertions, 0 failures, 0 errors
- core `clojure -M:test`: 1232 tests, 5453 assertions, 0 failures, 0 errors
- resources `clojure -M:test`: 326 tests, 1237 assertions, 0 failures, 0 errors
- `mkdocs build --strict`: exit 0
