### PR TITLE
feat(core): EP-0013 D2 — internal app-value projection over the default realm (rf2-yozjzo)

### DIFF
--- a/implementation/core/src/re_frame/app_value.cljc
+++ b/implementation/core/src/re_frame/app_value.cljc
@@ -1,0 +1,232 @@
+(ns re-frame.app-value
+  "The app value — the program-as-a-value (EP-0013 D2 stage 5, accepted
+  2026-06-11; sequenced behind the merged D1 `re-frame.realm`).
+
+  > The program is a value; the runtime is a container you install it into.
+
+  Per [EP-0013](docs/EP/EP-0013-app-values-and-runtime-realms.md) §D2 (the
+  app value) + §Public API Staging stage 5, the app value is the immutable
+  description of a program: its registration descriptors grouped by registry
+  kind, its capability requirements, and the source coordinates that declared
+  each contract surface. Where D1 made registrar *ownership* explicit (a realm
+  owns the `(kind, id) → metadata` table), D2 makes the *program* explicit:
+  the registrations a realm carries are no longer load-order mutation seen
+  only through the live registrar — they are an enumerable, recomputable
+  VALUE projected over that registrar.
+
+  ## Stage 5 is INTERNAL — no public surface, no facade, no manifest
+
+  This is EP-0013 staging step 5: an internal app-value descriptor format +
+  the projection seam, for the registrations that ALREADY exist in the
+  default realm's registrar. **No public `rf/app` / `rf/module` constructor
+  (stage 6), no public `rf/install!` / `rf/reinstall!` (stage 7), no
+  `re-frame.core` facade export, and no api-manifest change ship here** —
+  those names are reserved vocabulary and exposure graduates internal-first
+  (EP-0013 issue 1). Everything here is reached only by `re-frame.realm` and
+  the conformance tests. The headline is **zero ergonomic regression**: the
+  ordinary namespace-load `reg-*` sugar path is byte-identical; nothing on
+  the registration hot path changes.
+
+  ## The app value is a RECOMPUTABLE PROJECTION, not a mirror
+
+  The single most important property (EP-0013 §D2 + the bead ruling): the app
+  value is a **pure projection** computed on demand from the realm's
+  registrar atom — it is NOT a separately-maintained copy that registration
+  has to keep in sync. The registrar is the single source of truth; the app
+  value is a `(kind, id) → descriptor` re-grouping of what the registrar
+  already holds, normalized into the app-value descriptor shape (Spec-Schemas
+  draft §App Values). Consequences:
+
+    * the SUGAR PATH is free: an ordinary `reg-*` call updates the registrar,
+      and the next `(app-value realm)` reflects it with no extra work — there
+      is nothing to invalidate, nothing to re-register, no possibility of
+      desync (the projection IS the registrar, re-shaped);
+    * it is RECOMPUTABLE: two projections taken at the same registrar state
+      are equal values; a projection taken after a `reg-*` reflects the new
+      descriptor;
+    * it is correct under hot-reload for free: re-registration replaces the
+      registrar slot, so the next projection carries the new handler/coords.
+
+  The EP's later stages (6/7) add explicit `rf/app` / `rf/module`
+  *construction* (compose modules into an app value as INERT data, before
+  any realm) and `install!` / `reinstall!` (seat an explicit app value into a
+  realm). This stage ships neither — it ships only the read direction: the
+  default realm already HAS an installed program (the process-load `reg-*`
+  registrations), and this projects it into the descriptor value the later
+  stages and tooling will read and diff.
+
+  ## Production elision
+
+  Pure readers over the realm/registrar maps; no trace emit sites, no
+  DEBUG-gated branches, no feature sentinels, and no per-feature `:require`
+  (only `re-frame.realm` + `re-frame.late-bind`, both already in the core
+  spine; the registrar atom is reached through `realm/registrar`, never
+  required directly). The projection is operational metadata, not a dev
+  surface — it survives `:advanced` + `goog.DEBUG=false` intact and is
+  bundle-isolation neutral. (It is never *called* on the hot path; in stage 5
+  it is reached only by tests, so in a production app it is dead code Closure
+  DCE removes.)"
+  (:require [re-frame.realm     :as realm]
+            [re-frame.late-bind :as late-bind]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- the app-value top-level shape ----------------------------------------
+;;
+;; Per EP-0013 §App Values + the draft normalized shape (Spec-Schemas), an
+;; app value contains (directly or through its modules, which stage 6 adds):
+;;
+;;   :rf.app/id     the app's id. In stage 5 the only app is the one the
+;;                  default realm carries (the process-load registrations),
+;;                  so the id is the realm's id (`:rf.realm/default`). Stage 6
+;;                  gives an explicitly-constructed app value its own id.
+;;   :registrations the normalized registration descriptors, grouped by
+;;                  registry kind: `kind → id → descriptor`. This is the
+;;                  re-grouping of the realm's registrar into the descriptor
+;;                  shape (below).
+;;   :requires      the set of `:rf.capability/*` requirements the program
+;;                  declares. In stage 5 this is empty — capability
+;;                  requirements are declared on MODULE values (stage 6/D3);
+;;                  the default realm's load-order registrations carry none.
+;;                  The slot is present (always `#{}` here) so the shape is
+;;                  stable across the stage-6 graduation.
+;;
+;; D2/D3-RESERVED, never produced in stage 5: :modules (the module map — D3),
+;; :diagnostics (composition diagnostics — stage 6's compose step). Left
+;; absent here; an empty :registrations app is still a valid app value.
+
+;; ---- the registration descriptor ------------------------------------------
+;;
+;; Per EP-0013 §Registration Descriptors, every registrar-backed registration
+;; lowers to a descriptor. The registrar stores `kind → id → metadata`, where
+;; the metadata map carries the handler under `:handler-fn`, the source coords
+;; flat (`:ns` / `:file` / `:line` / `:column`, per Spec 001 §Source-coordinate
+;; capture), and the rest of the Spec 001 registration metadata. The descriptor
+;; NORMALIZES that into the app-value shape the EP draft shows:
+;;
+;;   :kind     the registry kind (Spec 001 taxonomy)
+;;   :id       the registration id
+;;   :handler  the registered handler / value / factory (the registrar's
+;;             `:handler-fn`), or nil for kinds that carry none
+;;   :source   the `{:ns :file :line :column}` source coordinate ENVELOPE,
+;;             lifted out of the flat metadata (nil when the host captured
+;;             none — programmatic / non-macro registrations)
+;;   :metadata the remaining Spec 001 registration metadata — `:doc`,
+;;             `:schema`, `:tags`, and the kind-specific extras (`:event/kind`,
+;;             `:input-kind`, `:input-signals`, …) — with the handler and the
+;;             lifted source-coord slots removed so the descriptor does not
+;;             double-carry them.
+;;
+;; A descriptor is a pure function of one registrar metadata entry, so it is
+;; deterministic and recomputable: same metadata → same descriptor value.
+
+(def ^:private source-coord-keys
+  "The flat source-coordinate slots the registrar metadata carries (Spec 001
+  §Source-coordinate capture, CLJS reference). Lifted into the descriptor's
+  `:source` envelope and removed from `:metadata` so a descriptor carries each
+  coordinate exactly once."
+  [:ns :file :line :column])
+
+(defn- descriptor-source
+  "Lift the source-coordinate envelope (`{:ns :file :line :column}`) out of a
+  registrar metadata map, or nil when the host captured none (programmatic /
+  non-macro registration). Mirrors the envelope EP-0013 §Source Coordinates
+  pins; absence never changes behaviour (EP-0013 issue 8 disposition)."
+  [metadata]
+  (let [coords (select-keys metadata source-coord-keys)]
+    (when (seq coords) coords)))
+
+(defn descriptor
+  "Normalize one registrar metadata entry into an app-value registration
+  descriptor (EP-0013 §Registration Descriptors). Pure: a function of `kind`,
+  `id`, and the registrar `metadata` map only — same inputs, same value.
+
+  Lifts the handler out of `:handler-fn`, the source coords out of the flat
+  `:ns`/`:file`/`:line`/`:column` slots into `:source`, and keeps the rest of
+  the Spec 001 registration metadata under `:metadata` (with the handler and
+  source-coord slots removed so each fact is carried once). INTERNAL."
+  [kind id metadata]
+  (let [source (descriptor-source metadata)
+        ;; The remaining metadata: the Spec 001 registration map minus the
+        ;; handler slot and the lifted source-coord slots. Kind-specific
+        ;; extras (`:event/kind`, `:input-kind`, `:input-signals`,
+        ;; `:interceptors`, …) stay here — they are part of the registration's
+        ;; description, not framework-internal book-keeping.
+        rest-meta (apply dissoc metadata :handler-fn source-coord-keys)]
+    (cond-> {:kind kind
+             :id   id}
+      (contains? metadata :handler-fn) (assoc :handler (:handler-fn metadata))
+      source                           (assoc :source source)
+      (seq rest-meta)                  (assoc :metadata rest-meta))))
+
+;; ---- the projection seam --------------------------------------------------
+;;
+;; `app-value` is the projection: realm → app value. It reads the realm's
+;; registrar atom ONCE (a single deref — the registrar is the single source of
+;; truth) and re-groups every `(kind, id) → metadata` entry into the
+;; `(kind, id) → descriptor` app-value shape. Pure with respect to that deref:
+;; two calls at the same registrar state return equal values.
+
+(defn registrations->descriptors
+  "Project a registrar snapshot (`kind → id → metadata`) into the app-value
+  `:registrations` shape (`kind → id → descriptor`). Pure — a function of the
+  snapshot map only. INTERNAL."
+  [snapshot]
+  (reduce-kv
+    (fn [acc kind id->meta]
+      (assoc acc kind
+             (reduce-kv (fn [m id metadata]
+                          (assoc m id (descriptor kind id metadata)))
+                        {}
+                        id->meta)))
+    {}
+    snapshot))
+
+(defn app-value
+  "Project the app value installed in `realm-or-id` (defaults to the default
+  realm) over its registrar — the immutable, recomputable description of the
+  program the realm is running (EP-0013 §D2 stage 5, INTERNAL).
+
+  The app value is a PURE PROJECTION over the realm's registrar atom, not a
+  stored mirror: it derefs the registrar once and re-groups every registration
+  into the app-value descriptor shape. Because the registrar is the single
+  source of truth, the ordinary `reg-*` sugar path keeps the app value current
+  for free — the next call reflects any registration with no invalidation step
+  and no possibility of desync.
+
+  Returns:
+    {:rf.app/id     <realm-id>            ;; the app the realm carries
+     :registrations {kind {id descriptor}} ;; normalized descriptors by kind
+     :requires      #{}}                  ;; capability requirements (empty in
+                                          ;; stage 5 — declared on modules, D3)
+
+  INTERNAL — there is NO public `rf/app` constructor and no public
+  installed-app read surface in stage 5 (EP-0013 issue 1; stages 6/7). nil
+  resolves to the default realm (absence = default realm, the D1 rule)."
+  ([] (app-value realm/default-realm-id))
+  ([realm-or-id]
+   (let [rid       (realm/realm-id realm-or-id)
+         registrar (realm/registrar (realm/realm rid))
+         snapshot  (if registrar @registrar {})]
+     {:rf.app/id     rid
+      :registrations (registrations->descriptors snapshot)
+      :requires      #{}})))
+
+;; ---- the realm-side installed-app seam (the late-bind bridge) --------------
+;;
+;; The realm's `:app` slot (Spec-Schemas §`:rf/realm`, D2-reserved) is the
+;; installed app VALUE. `re-frame.realm/installed-app` is the realm-side read
+;; seam over that slot: it returns the stored `:app` if a future `install!`
+;; (stage 7) seated one, else the recomputable projection. `re-frame.realm`
+;; requires NOTHING from this ns (this ns requires it, projecting over its
+;; registrar), so `installed-app` reaches the projection through the
+;; `:app-value/project` late-bind hook published below — a static back-require
+;; would cycle. The hook takes a realm-id and returns the projected app value;
+;; published once at ns-load and never withdrawn (drift-tested via
+;; `re-frame.late-bind.directory`).
+;;
+;; The projection IS the realm's app value in stage 5: with no construction
+;; (stage 6) and no install (stage 7), the realm stores no `:app`, so the
+;; recomputable projection of its registrar is exactly the program it runs.
+
+(late-bind/set-fn! :app-value/project app-value)

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -74,6 +74,16 @@
             ;; here; the require exists so the hooks are bound at boot before
             ;; any runtime `reg-frame` call.
             [re-frame.frame-classification]
+            ;; EP-0013 D2 stage 5 (rf2-yozjzo): required for its ns-load
+            ;; side-effect only — it publishes the `:app-value/project`
+            ;; late-bind hook `re-frame.realm/installed-app` consults to
+            ;; project the realm's installed app VALUE over its registrar.
+            ;; No symbols are referenced here; the require exists so the
+            ;; hook is bound at boot. INTERNAL — no public app constructor /
+            ;; installed-app surface ships in stage 5 (stages 6/7). The ns
+            ;; pulls only `re-frame.realm` + `re-frame.late-bind` (core
+            ;; spine), so it is bundle-isolation neutral.
+            [re-frame.app-value]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.core-flows    :as rf-flows]
             [re-frame.core-routing  :as rf-routing]

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -963,6 +963,10 @@
     :producer-ns 're-frame.frame
     :design-bead "rf2-gkddyq"
     :description "EP-0013 D1 realm-owned frame-registry view. Returns `realm-id → #{frame-id …}` over the live (non-destroyed) frames, grouped by each frame record's `:realm` slot. `re-frame.realm/realm-frames` consults it to answer the realm-owned membership query — `re-frame.frame` requires `re-frame.realm` for the frame record's default realm-id, so the back-read is late-bound to avoid a require cycle. Membership is DERIVED from `re-frame.frame/frames` (single source of truth; no separately-stored set), so the `(reset! frame/frames {})` test fixtures reset it for free."}
+   {:key         :app-value/project
+    :producer-ns 're-frame.app-value
+    :design-bead "rf2-yozjzo"
+    :description "EP-0013 D2 stage-5 app-value projection. Returns the immutable, recomputable app VALUE projected over a realm's registrar — `realm-id → {:rf.app/id … :registrations {kind {id descriptor}} :requires #{}}`. `re-frame.realm/installed-app` consults it to answer the realm-side installed-app read seam — `re-frame.app-value` requires `re-frame.realm` (it projects over the realm's registrar), so the back-read is late-bound to avoid a require cycle. The projection is RECOMPUTABLE over the registrar (the single source of truth), so the ordinary `reg-*` sugar path keeps it current with no invalidation step. INTERNAL — no public app constructor / installed-app read surface ships in stage 5 (EP-0013 issue 1)."}
 
    ;; ---- re-frame.trace.cascade (rf2-931pm — focused-event-only cascade-DAG aggregator) ----
    ;;

--- a/implementation/core/src/re_frame/realm.cljc
+++ b/implementation/core/src/re_frame/realm.cljc
@@ -246,6 +246,50 @@
      (get (by-realm) rid #{})
      #{})))
 
+;; ---- the installed app VALUE — the projection seam (EP-0013 D2 stage 5) ----
+;;
+;; The realm's `:app` slot (Spec-Schemas §`:rf/realm`, D2-reserved) is the
+;; installed app VALUE — the program-as-a-value the realm is running. D2
+;; makes the registrations a realm carries an enumerable, recomputable VALUE
+;; projected over its registrar, rather than load-order mutation seen only
+;; through the live registrar.
+;;
+;; Stage 5 is INTERNAL + read-only: there is NO construction (stage 6) and no
+;; `install!` (stage 7) yet, so the realm STORES no constructed app value and
+;; the `:app` slot stays absent. The installed app is therefore the
+;; RECOMPUTABLE PROJECTION over the realm's own registrar — `re-frame.app-value`
+;; owns the descriptor format and the projection fn. Because the registrar is
+;; the single source of truth, the ordinary `reg-*` sugar path keeps this app
+;; value current for free: a registration updates the registrar, and the next
+;; `installed-app` reflects it with no invalidation step and no desync.
+;;
+;; `re-frame.app-value` requires THIS ns (it projects over the realm's
+;; registrar), so a static back-require would cycle; the projection is reached
+;; through the `:app-value/project` late-bind hook, which `app-value` publishes
+;; at ns-load. Returns `nil` when the hook is unbound (app-value ns not yet
+;; loaded) — the realm has no enumerated installed-app projection until then.
+
+(defn installed-app
+  "Return the app VALUE installed in `realm-or-id` (defaults to the default
+  realm) — the realm's program as a recomputable value (EP-0013 D2 stage 5,
+  INTERNAL). When the realm STORES an `:app` (a future `install!`, stage 7),
+  that value is returned; otherwise the installed app is the recomputable
+  projection over the realm's registrar (`re-frame.app-value/app-value`,
+  reached via the `:app-value/project` late-bind hook). Returns `nil` when the
+  app-value ns is not yet loaded.
+
+  This is the realm-side read seam over the D2-reserved `:app` slot: the
+  reader's contract — \"give me the realm's installed app value\" — is stable
+  across the stage-6/7 graduation; only its internals change (read the stored
+  slot, else project). INTERNAL — no public installed-app read surface ships
+  in stage 5 (EP-0013 issue 1)."
+  ([] (installed-app default-realm-id))
+  ([realm-or-id]
+   (let [rid (realm-id realm-or-id)]
+     (or (:app (realm rid))
+         (when-let [project (late-bind/get-fn :app-value/project)]
+           (project rid))))))
+
 ;; ---- realm-owned adapter SELECTION (EP-0013 D1 stage 4, rf2-0lq5cd) --------
 ;;
 ;; The adapter SELECTION — the installed adapter spec map and the

--- a/implementation/core/test/re_frame/app_value_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_cljs_test.cljc
@@ -1,0 +1,259 @@
+(ns re-frame.app-value-cljs-test
+  "EP-0013 D2 stage-5 — the internal app-value projection over the default
+  realm (rf2-yozjzo, sequenced behind the merged D1 `re-frame.realm`).
+
+  D2 stage 5 is INTERNAL + read-only: no public `rf/app` / `rf/module`
+  constructor (stage 6), no public `rf/install!` / `rf/reinstall!` (stage 7),
+  no `re-frame.core` facade export, no api-manifest change. The registrations
+  a realm carries become an enumerable, recomputable VALUE projected over its
+  registrar — but the ordinary `reg-*` sugar path is byte-identical (zero
+  ergonomic regression). These tests pin:
+
+    (1) the app value projects correctly over the default-realm registrar —
+        the descriptor shape (kind / id / handler / source / metadata), the
+        top-level shape (`:rf.app/id` / `:registrations` / `:requires`), and
+        the source-coord lifting + non-double-carry;
+    (2) the SUGAR PATH updates it — an ordinary `reg-*` is reflected by the
+        next projection, with no invalidation step (the registrar is the
+        single source of truth, the app value is a projection over it);
+    (3) it is RECOMPUTABLE — two projections at the same registrar state are
+        equal values; a projection after a `reg-*` carries the new descriptor;
+        hot-reload (re-registration) is reflected for free;
+    (4) the realm-side `installed-app` seam returns the projection (via the
+        `:app-value/project` late-bind hook), and reads a stored `:app` slot
+        first (forward-stable across the stage-6/7 graduation);
+    (5) default-realm ergonomics are UNCHANGED — reg-* / dispatch / subscribe
+        behave exactly as before (the headline).
+
+  Dual-runtime: named `*_cljs_test.cljc` so the shadow-cljs `:node-test`
+  build (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both pick
+  it up. Pure CLJC — no DOM dependency; uses the plain-atom adapter."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.app-value :as av]
+            [re-frame.realm :as realm]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; (1) the app value projects correctly over the default-realm registrar
+;; ---------------------------------------------------------------------------
+
+(deftest app-value-top-level-shape
+  (testing "the projection carries the app-value top-level shape — the app id
+            (the realm's id), the :registrations grouping, and the :requires
+            set (empty in stage 5 — declared on modules, D3)"
+    (let [v (av/app-value)]
+      (is (= :rf.realm/default (:rf.app/id v))
+          "the app id is the default realm's id — the app it carries")
+      (is (map? (:registrations v))
+          "registrations is a kind → id → descriptor map")
+      (is (= #{} (:requires v))
+          "requires is empty in stage 5 (capability requirements are module/D3)")
+      (is (not (contains? v :modules))
+          ":modules is D3-reserved, never produced in stage 5")
+      (is (not (contains? v :diagnostics))
+          ":diagnostics is stage-6 (compose), never produced in stage 5"))))
+
+(deftest event-descriptor-shape-and-coord-lifting
+  (testing "an event registration projects to a normalized descriptor: kind /
+            id / handler lifted out of :handler-fn, source coords lifted into
+            :source, the rest of the Spec 001 metadata under :metadata, each
+            fact carried exactly once"
+    (rf/reg-event-db :av/add
+      {:doc "Add an item."}
+      (fn add-handler [db _] (update db :items (fnil conj []) :x)))
+    (let [d (get-in (av/app-value) [:registrations :event :av/add])]
+      (is (= :event (:kind d)) "the descriptor carries the kind")
+      (is (= :av/add (:id d)) "the descriptor carries the id")
+      (is (fn? (:handler d)) "the handler is lifted out of :handler-fn")
+      (is (identical? (:handler d)
+                      (:handler-fn (registrar/lookup :event :av/add)))
+          "the lifted handler IS the registrar's :handler-fn")
+      ;; The Spec 001 metadata is preserved under :metadata, including the
+      ;; kind-specific :event/kind extra — those are part of the registration's
+      ;; DESCRIPTION, not framework book-keeping.
+      (is (= "Add an item." (get-in d [:metadata :doc]))
+          ":doc is preserved under :metadata")
+      (is (= :db (get-in d [:metadata :event/kind]))
+          "the kind-specific :event/kind extra is preserved under :metadata")
+      ;; The handler and source-coord slots are NOT double-carried in :metadata.
+      (is (not (contains? (:metadata d) :handler-fn))
+          ":handler-fn is removed from :metadata (carried under :handler)")
+      (is (not (contains? (:metadata d) :ns))
+          "source coords are removed from :metadata (carried under :source)"))))
+
+(deftest sub-descriptor-shape
+  (testing "a sub registration projects to a descriptor preserving its
+            kind-specific extras (:input-kind / :input-signals) under :metadata"
+    (rf/reg-sub :av/items
+      {:doc "The items."}
+      (fn [db _] (:items db)))
+    (let [d (get-in (av/app-value) [:registrations :sub :av/items])]
+      (is (= :sub (:kind d)))
+      (is (= :av/items (:id d)))
+      (is (fn? (:handler d)) "the sub handler is lifted out of :handler-fn")
+      (is (= :db (get-in d [:metadata :input-kind]))
+          "the sub's :input-kind extra is preserved under :metadata")
+      (is (= [] (get-in d [:metadata :input-signals]))
+          "the sub's :input-signals extra is preserved under :metadata"))))
+
+(deftest frame-descriptor-carries-no-handler
+  (testing "a :frame registration carries no :handler-fn, so the descriptor
+            omits :handler rather than carrying a nil one"
+    (rf/reg-frame :av/main {:doc "the main frame"})
+    (let [d (get-in (av/app-value) [:registrations :frame :av/main])]
+      (is (= :frame (:kind d)))
+      (is (= :av/main (:id d)))
+      (is (not (contains? d :handler))
+          "no :handler key — :frame registrations carry no :handler-fn")
+      (is (= "the main frame" (get-in d [:metadata :doc]))
+          "the frame's :doc is preserved under :metadata"))))
+
+(deftest fx-cofx-descriptors-project
+  (testing "fx and cofx registrations project to descriptors with their
+            handlers lifted"
+    (rf/reg-fx :av/send {:doc "send"} (fn [_] nil))
+    (rf/reg-cofx :av/now {:doc "now"} (fn [cofx] (assoc cofx :now 42)))
+    (let [v (av/app-value)]
+      (is (fn? (get-in v [:registrations :fx :av/send :handler]))
+          "the fx handler is lifted")
+      (is (fn? (get-in v [:registrations :cofx :av/now :handler]))
+          "the cofx handler is lifted"))))
+
+(deftest programmatic-registration-has-no-source-coords
+  (testing "a programmatic registration (no macro source capture) omits
+            :source rather than carrying an empty envelope — absence never
+            changes behaviour (EP-0013 issue 8 disposition)"
+    (registrar/register! :event :av/programmatic
+      {:doc "no coords" :handler-fn (fn [db _] db)})
+    (let [d (get-in (av/app-value) [:registrations :event :av/programmatic])]
+      (is (not (contains? d :source))
+          "no :source key when the host captured no coordinates")
+      (is (fn? (:handler d)) "the handler is still lifted")
+      (is (= "no coords" (get-in d [:metadata :doc]))
+          "the metadata is still projected"))))
+
+;; ---------------------------------------------------------------------------
+;; (2) the sugar path updates it — reg-* is reflected, no invalidation step
+;; ---------------------------------------------------------------------------
+
+(deftest sugar-path-updates-the-projection
+  (testing "an ordinary reg-* (the sugar path) is reflected by the NEXT
+            projection — the registrar is the single source of truth and the
+            app value is a projection over it, so there is nothing to invalidate"
+    (is (nil? (get-in (av/app-value) [:registrations :event :av/sugar]))
+        "absent before registration")
+    (rf/reg-event-db :av/sugar {:doc "sugar"} (fn [db _] db))
+    (is (some? (get-in (av/app-value) [:registrations :event :av/sugar]))
+        "present in the next projection after the sugar-path reg-* — no
+         invalidation step, no desync")))
+
+(deftest sugar-path-and-unregister-round-trip
+  (testing "unregister removes the descriptor from the next projection too —
+            the projection tracks the registrar exactly"
+    (rf/reg-event-db :av/ephemeral {:doc "ephemeral"} (fn [db _] db))
+    (is (some? (get-in (av/app-value) [:registrations :event :av/ephemeral]))
+        "present after registration")
+    (registrar/unregister! :event :av/ephemeral)
+    (is (nil? (get-in (av/app-value) [:registrations :event :av/ephemeral]))
+        "absent in the next projection after unregister")))
+
+;; ---------------------------------------------------------------------------
+;; (3) the projection is RECOMPUTABLE
+;; ---------------------------------------------------------------------------
+
+(deftest projection-is-recomputable-equal-values
+  (testing "two projections taken at the same registrar state are EQUAL values
+            — the projection is pure with respect to the registrar deref"
+    (rf/reg-event-db :av/r1 {:doc "r1"} (fn [db _] db))
+    (rf/reg-sub :av/r2 {:doc "r2"} (fn [db _] (:r2 db)))
+    (is (= (av/app-value) (av/app-value))
+        "recomputing at the same registrar state yields an equal app value")))
+
+(deftest projection-reflects-hot-reload-re-registration
+  (testing "re-registering an id (hot-reload) is reflected by the next
+            projection for free — the descriptor carries the NEW handler"
+    (let [h1 (fn handler-1 [db _] (assoc db :v 1))
+          h2 (fn handler-2 [db _] (assoc db :v 2))]
+      (rf/reg-event-db :av/reload {:doc "v1"} h1)
+      (is (identical? h1 (get-in (av/app-value)
+                                 [:registrations :event :av/reload :handler]))
+          "the projection carries the first handler")
+      ;; Hot-reload: re-register the same id with a different handler.
+      (rf/reg-event-db :av/reload {:doc "v2"} h2)
+      (is (identical? h2 (get-in (av/app-value)
+                                 [:registrations :event :av/reload :handler]))
+          "the next projection carries the new handler — no invalidation step")
+      (is (= "v2" (get-in (av/app-value)
+                          [:registrations :event :av/reload :metadata :doc]))
+          "the re-registered :doc is reflected too"))))
+
+(deftest empty-realm-projects-an-empty-app
+  (testing "a realm whose registrar is empty projects an app value with an
+            empty :registrations — still a valid app value, never an error"
+    (registrar/clear-all!)
+    (let [v (av/app-value)]
+      (is (= :rf.realm/default (:rf.app/id v)))
+      (is (= {} (:registrations v))
+          "an empty registrar projects an empty registrations map")
+      (is (= #{} (:requires v))))))
+
+;; ---------------------------------------------------------------------------
+;; (4) the realm-side installed-app seam (the late-bind bridge)
+;; ---------------------------------------------------------------------------
+
+(deftest installed-app-seam-returns-the-projection
+  (testing "realm/installed-app returns the recomputable projection over the
+            realm's registrar, reached through the :app-value/project hook"
+    (rf/reg-event-db :av/seam {:doc "seam"} (fn [db _] db))
+    (is (= (av/app-value) (realm/installed-app))
+        "the realm-side seam equals the direct projection (default realm)")
+    (is (= (av/app-value :rf.realm/default)
+           (realm/installed-app :rf.realm/default))
+        "explicit default-realm id resolves the same way")
+    (is (= (av/app-value) (realm/installed-app nil))
+        "nil resolves to the default realm (absence = default realm)")))
+
+(deftest installed-app-reads-stored-app-slot-first
+  (testing "installed-app reads a STORED :app slot first (forward-stable across
+            the stage-6/7 graduation — a future install! seats a value), and
+            falls back to the projection when no :app is stored"
+    ;; Seat a sentinel :app on a fresh test realm to prove precedence — this is
+    ;; the shape a stage-7 install! would write; stage 5 never writes it.
+    (let [sentinel {:rf.app/id :av/sentinel :registrations {} :requires #{}}
+          test-rid :av/test-realm]
+      (swap! realm/realms assoc test-rid
+             (assoc (realm/make-realm test-rid) :app sentinel))
+      (is (= sentinel (realm/installed-app test-rid))
+          "a stored :app slot is returned verbatim (precedence over projection)")
+      ;; Cleanup the test realm so the registry returns to its fixture state.
+      (swap! realm/realms dissoc test-rid))))
+
+;; ---------------------------------------------------------------------------
+;; (5) default-realm ergonomics are UNCHANGED — the headline
+;; ---------------------------------------------------------------------------
+
+(deftest default-realm-ergonomics-unchanged
+  (testing "reg-* / dispatch / subscribe behave EXACTLY as before — the
+            app-value projection is read-only and adds no registration-path
+            behaviour (zero ergonomic regression)"
+    (rf/reg-frame :av/app {:doc "ergonomics app"})
+    (rf/reg-event-db :av/set {:doc "set n"} (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-sub :av/read-n {:doc "read n"} (fn [db _] (:n db)))
+    ;; Dispatch + subscribe against the default-realm frame — unchanged.
+    (rf/dispatch-sync [:av/set 9] {:frame :av/app})
+    (is (= {:n 9} (rf/app-db-value :av/app))
+        "app-db carries the dispatched value — single-app dispatch unchanged")
+    (let [reaction (rf/subscribe :av/app [:av/read-n])]
+      (is (= 9 @reaction)
+          "subscribe reads the value — single-app subscribe unchanged"))
+    ;; And the registrar read API the existing tooling uses is byte-stable.
+    (is (some? (registrar/lookup :event :av/set))
+        "registrar/lookup resolves a default-realm registration unchanged")))


### PR DESCRIPTION
EP-0013 **D2 stage 5** — the internal app-value projection — sequenced behind the merged D1 `re-frame.realm`. The registrations a realm carries become an enumerable, recomputable **app VALUE** projected over its registrar (the program-as-a-value), while the ordinary namespace-load `reg-*` sugar path stays byte-identical. **Zero ergonomic regression.**

Implements `bd show rf2-yozjzo` (authoritative) per EP-0013 §D2 + §Public API Staging stage 5 + the RULED D1/D2/D3 matrix.

## What landed (INTERNAL only — no public surface)

- **`re-frame.app-value`** (new ns): the immutable registration-**descriptor** format and the projection seam.
  - `descriptor` normalizes one registrar metadata entry into `{:kind :id :handler :source :metadata}` — the handler lifted out of `:handler-fn`, the source coords lifted out of the flat `:ns`/`:file`/`:line`/`:column` slots into a `:source` envelope, the rest of the Spec 001 metadata (incl. kind-specific extras like `:event/kind`, `:input-kind`) under `:metadata`. Each fact carried exactly once; absent source coords omit `:source` (never faked — EP-0013 issue 8).
  - `app-value` projects `realm → app value` as a **pure function of the realm's registrar deref**: `{:rf.app/id <realm-id> :registrations {kind {id descriptor}} :requires #{}}`. The registrar is the single source of truth, so the **sugar path keeps the projection current for free** — no invalidation step, no desync, recomputable, hot-reload (re-registration) reflected automatically. `:requires` is `#{}` in stage 5 (capability requirements are declared on module values — D3).
- **`re-frame.realm/installed-app`**: the realm-side read seam over the D2-reserved `:app` slot. Reads a stored `:app` first (forward-stable across the stage-6/7 `install!` graduation), else the recomputable projection, reached via the new `:app-value/project` late-bind hook (a static back-require would cycle — same pattern as `:realm/frames-by-realm`).
- **`re-frame.core`** requires `re-frame.app-value` side-effect-only (publishes the hook at boot); **`late-bind/directory`** gains the drift-tested entry.

**Deferred (not this slice):** stage 6 (`rf/app` / `rf/module` constructors + composition), stage 7 (`rf/install!` / `rf/reinstall!`), the public installed-app read surface, realm-targeted queries (stage 8). No `re-frame.core` facade export and **no api-manifest / `spec/API.md` / `spec/Spec-Schemas` change** — reserved vocabulary, exposure graduates internal-first (EP-0013 issue 1). The `:rf/realm` schema already reserves the `:app` slot, so no spec edit was required.

## App-value shape

```clojure
{:rf.app/id     :rf.realm/default          ;; the app the realm carries
 :registrations {:event {:cart/add {:kind :event :id :cart/add
                                     :handler #fn
                                     :source  {:ns shop.cart :file "..." :line 22 :column 1}
                                     :metadata {:doc "..." :event/kind :db ...}}}
                 :sub   {:cart/items {:kind :sub :id :cart/items :handler #fn
                                      :metadata {:input-kind :db :input-signals []}}}}
 :requires      #{}}                        ;; capability requirements — module/D3
```

## Quality gates

- `clojure -M:test` (core JVM suite) — **1246 tests, 5499 assertions, 0 failures, 0 errors** (incl. the new ns + the late-bind drift test, post-rebase on origin/main)
- `npm run test:cljs` (node-runtime, dual-runtime tests) — **6693 tests, 24745 assertions, 0 failures, 0 errors**
- `npm run test:bundle-isolation` — **PASS** (22 artefact entries, 40 internal sentinels absent; the new ns pulls only `re-frame.realm` + `re-frame.late-bind`, core spine, so it is bundle-isolation neutral)
- `npm run test:elision` — **PASS** (production 41/41 sentinels absent; the projection is pure operational metadata, survives `:advanced` + `goog.DEBUG=false`)

New tests (`re-frame.app-value-cljs-test`, 14 deftests, dual-runtime): projection top-level + descriptor shape, source-coord lifting + non-double-carry, frame-carries-no-handler, fx/cofx, programmatic (no coords), **sugar-path updates the projection**, unregister round-trip, **recomputable (equal values)**, hot-reload re-registration reflected, empty-realm → empty app, **installed-app seam** (projection + stored-`:app`-slot precedence), **default-realm ergonomics unchanged**.

Closes rf2-yozjzo.