### PR TITLE
docs(comments): EP-0014 algebra-view + graph comment pass (rf2-exdipj)

### DIFF
--- a/implementation/core/src/re_frame/derivation/graph.cljc
+++ b/implementation/core/src/re_frame/derivation/graph.cljc
@@ -87,6 +87,17 @@
 ;; `:live-shape :node` — the live-fn returns ONE node or nil (the route
 ;;                       slice).
 ;;
+;; The `:static-fn` / `:live-fn` are usually two DISTINCT sibling fns (the
+;; subs / resources / routes / machines pattern: a registration-derived
+;; static view + a runtime-cache / runtime-db live view). FLOWS are the
+;; exception: a flow has no separate ephemeral cache to snapshot — it
+;; materializes into app-db and is frame-scoped — so its ONE
+;; `flow-algebra-view` serves both slots. The static-fn is its zero-arity
+;; (every frame's flows, `{frame-id {flow-id node}}`); the live-fn is the
+;; SAME symbol invoked one-arity (`(flow-algebra-view frame-id)` →
+;; `{flow-id node}`, the `:map` shape). The "live" flow projection is thus
+;; the per-frame static projection — there is nothing further to realize.
+;;
 ;; The subs contributor is built from the in-core sibling; the four optional
 ;; contributors are resolved (JVM) or supplied (CLJS).
 ;; ---------------------------------------------------------------------------
@@ -150,6 +161,10 @@
                       [family (cond-> c
                                 selector-sym
                                 (assoc :selector? (some-> (requiring-resolve selector-sym) deref)))])))
+            ;; flows reuse the ONE `flow-algebra-view` for both slots
+            ;; (static = zero-arity all-frames, live = one-arity per-frame —
+            ;; a flow has no separate ephemeral cache to snapshot; see the
+            ;; contributor-seam comment above).
             [[:flows     're-frame.flows.tooling/flow-algebra-view
                          're-frame.flows.tooling/flow-algebra-view :map]
              [:resources 're-frame.resources.tooling/resource-algebra-view
@@ -178,10 +193,11 @@
   is the family-local fact identity; this lifts it into the family-tagged
   node id the graph + its edges reference:
 
-    :subs      → the node's `:id` verbatim — already a `[:sub …]`-shaped
-                 fact (a `[:fact <id>]` output's id, or a live query
-                 vector). We wrap a bare sub-id keyword in `[:sub <id>]`
-                 so every subscription node id is uniformly tagged.
+    :subs      → `[:sub <id>]`, where `<id>` is the node's `:id`: a bare
+                 sub-id keyword for a STATIC node (`[:sub :cart/total]`), or
+                 the concrete query vector for a LIVE cache-entry node
+                 (`[:sub [:cart/total …args]]`). Wrapping unconditionally
+                 keeps every subscription node id uniformly tagged.
     :flows     → `[:flow <flow-id>]`.
     :resources → `[:resource <resource-id-or-scoped-key>]`.
     :machines  → `[:machine <machine-or-actor-id>]`.

--- a/implementation/machines/src/re_frame/machines/tooling.cljc
+++ b/implementation/machines/src/re_frame/machines/tooling.cljc
@@ -365,6 +365,10 @@
   redacts at egress per Derivations §Redaction metadata); only the `:state`
   summary is surfaced.
 
+  The zero-arity form reads the ambient `re-frame.frame/current-frame`; the
+  one-arity form takes an explicit `frame-id` (the form the graph composer's
+  `:live-fn` calls).
+
   CLJS-and-JVM runnable, but dev-gated on `interop/debug-enabled?` (the
   `goog.DEBUG` mirror) so production builds DCE the runtime-db walk. Returns
   `nil` for a missing/destroyed frame and in production builds, `{}` for a


### PR DESCRIPTION
Wave-end CODE-COMMENTS review (rf2-exdipj) of the merged EP-0014 derivation/process algebra-view work: the 5 `*.tooling` algebra-view siblings (subs / flows / resources / routing / machines), `re-frame.derivation.graph`, the `derivation-conformance/` suite, and the parent-artefact facade wirings.

## Verdict

The EP-0014 comment + docstring surface is exceptionally thorough and accurate. Every non-obvious decision the bead enumerated is already documented somewhere on the surface: the read-the-registry-not-the-write-path rule (every sibling's ns docstring), the bundle-isolation `requiring-resolve` / late-bind seam + why no static cross-artefact require (graph.cljc ns docstring + `default-contributors`), the node-kind/superkind lowering (per-sibling classification blocks + conformance `refined->superkind`), the storage/eval/lifecycle classification per family (per-sibling fixed-classification comment tables), the `:remote`-not-storage issue-2 split (resources `resource-storage` + conformance), the parametric-input-no-static-edge / don't-execute rule (subs + graph `input-edges` + conformance), the whole-value law (conformance suite), and the no-public-authoring-primitive issue-1 constraint (every sibling + graph ns docstring). DerivationGraph shape described correctly throughout.

Found and fixed THREE small inline issues; no follow-up beads warranted.

### Fixed inline (comment-only)

1. **graph.cljc `node-id` `:subs` docstring** (accuracy): the clause was internally contradictory — it claimed the node's `:id` is taken verbatim ("already a `[:sub ...]`-shaped fact") AND that a bare keyword is wrapped. The code wraps unconditionally (`[:sub id]`), and a static sub `:id` is a bare keyword (e.g. `:cart/total`), not already tagged. Rewrote to match the code + the accurate inline `case` comment.

2. **graph.cljc contributor seam** (completeness): documented the non-obvious flows special case — flows reuse the ONE `flow-algebra-view` for both the `:static-fn` (zero-arity, all frames) and `:live-fn` (one-arity, per-frame) slots, because a flow has no separate ephemeral cache to snapshot (it materializes into app-db). Added rationale to the seam comment block + an inline note on the `default-contributors` flows row (which silently passed the same symbol twice).

3. **machines/tooling.cljc `machine-instance-algebra-view`** (completeness): documented the previously-undocumented zero-arity (ambient `current-frame`) vs one-arity (explicit `frame-id`) forms.

Out of scope (left as-is): `re-frame.subs.tooling/sub-topology` + `sub-cache-snapshot` predate EP-0014 (rf2-qwm0a / rf2-bmzq0 / rf2-e3acps); their input-kind docstring omits `:runtime-db` / `:frame-state` but that drift is not from this EP.

## Quality gates

- core `clojure -M:test -n re-frame.derivation-graph-test`: 8 tests, 37 assertions, 0 failures, 0 errors
- machines `clojure -M:test -n re-frame.machine-algebra-view-test`: 17 tests, 45 assertions, 0 failures, 0 errors
- `npm run test:cljs`: 6689 tests, 26933 assertions, 0 failures, 0 errors (compile-checks both touched `.cljc` files + runs the EP-0014 conformance suite)

Comment-only edits; no behaviour change.
