### PR TITLE
fix: EP-0014 machine/resource algebra nodes use closed :kind + refinement (rf2-7wwp1z)

### DIFF
--- a/docs/EP/EP-0014-derivation-and-process-algebra.md
+++ b/docs/EP/EP-0014-derivation-and-process-algebra.md
@@ -410,11 +410,16 @@ this shape:
 The exact public accessor name is deferred. The required information is not.
 Tools must be able to recover the same facts from a conforming implementation.
 
-Every `:kind` value classifies as either a derivation or a process. Refined
-kinds used in this EP's examples — `:resource-process`, `:route-fact`,
-`:machine-process`, `:machine-selector` — are informative refinements of those
-two superkinds; specs may add refinements, but a tool that understands only
-`:derivation` and `:process` must still be able to classify every node.
+Every `:kind` value is one of exactly two closed superkinds — `:derivation` or
+`:process` (the graduated, closed `DerivationKind` enum). Refined kinds used in
+this EP's examples — `:resource-process`, `:route-fact`, `:machine-process`,
+`:machine-selector` — are informative refinements of those two superkinds,
+carried on the separate `:refinement` axis, never in `:kind`: specs may add
+refinements, but a tool that understands only `:derivation` and `:process` must
+still be able to classify every node by reading `:kind` alone. (Graduation note:
+earlier drafts placed the refined kind directly in `:kind`; the graduated
+Spec-Schemas `DerivationKind` closed the enum to the two superkinds, so the
+examples below carry the refinement under `:refinement` — rf2-7wwp1z.)
 
 Function values in graph output MAY be represented by symbols, source
 coordinates, registry metadata, or opaque implementation tokens. The graph
@@ -937,7 +942,8 @@ Static algebra view:
 
 ```clojure
 {:id :article/by-slug
- :kind :resource-process
+ :kind :process
+ :refinement :resource-process
  :source-form {:kind :reg-resource :id :article/by-slug}
  :inputs [[:param :slug]
           [:scope :rf.scope/from-caller]]
@@ -1012,7 +1018,8 @@ Spec 012 already gives the route slice (one name per fact, per EP-0007):
 
 ```clojure
 {:id :rf/route
- :kind :route-fact
+ :kind :process
+ :refinement :route-fact
  :source-form {:kind :reg-route :id :route/article}
  :inputs [[:event :rf.route/navigate]
           [:event :rf.route/transitioned]
@@ -1081,7 +1088,8 @@ Machine process algebra:
 
 ```clojure
 {:id :upload/main
- :kind :machine-process
+ :kind :process
+ :refinement :machine-process
  :source-form {:kind :reg-machine :id :upload/main}
  :inputs [[:event :upload/start]
           [:event :upload/progress]
@@ -1109,7 +1117,8 @@ Selector algebra:
 
 ```clojure
 {:id :upload/progress
- :kind :machine-selector
+ :kind :derivation
+ :refinement :machine-selector
  :inputs [[:machine :upload/main [:data :progress]]]
  :output [:fact :upload/progress]
  :storage :ephemeral
@@ -1132,7 +1141,8 @@ A live graph for an article page might expose:
          :nav-token 17}
  :facts
  {[:runtime [:rf.runtime/routing :current]]
-  {:kind :route-fact
+  {:kind :process
+   :refinement :route-fact
    :storage :runtime-db}
 
   [:sub [:article/page "welcome"]]

--- a/docs/guide/derivations-and-algebra-views.md
+++ b/docs/guide/derivations-and-algebra-views.md
@@ -156,7 +156,8 @@ A resource is the first **process** — a derivation *with state, lifecycle, and
 ```clojure
 ;; STATIC ALGEBRA VIEW
 {:id          :article/by-slug
- :kind        :process                       ;; refinement :resource-process
+ :kind        :process                       ;; the closed superkind
+ :refinement  :resource-process              ;; the informative refinement
  :source-form {:kind :reg-resource :id :article/by-slug}
  :inputs      [[:param :slug]
                [:scope :rf.scope/from-caller]]
@@ -208,7 +209,8 @@ A route transition materializes the route slice and can own resource activation.
 ```clojure
 ;; ALGEBRA VIEW
 {:id          :rf/route                       ;; the one name for the slice (every route shares it)
- :kind        :process                        ;; refinement :route-fact
+ :kind        :process                        ;; the closed superkind
+ :refinement  :route-fact                     ;; the informative refinement
  :source-form {:kind :reg-route :id :route/article}
  :inputs      [[:event :rf.route/navigate]    ;; the on-route causal triggers
                [:event :rf.route/transitioned]
@@ -248,7 +250,8 @@ A machine is the algebra's canonical process — the surface that motivates the 
 ```clojure
 ;; MACHINE PROCESS VIEW
 {:id          :upload/main
- :kind        :machine-process               ;; refinement of :process
+ :kind        :process                       ;; the closed superkind
+ :refinement  :machine-process               ;; the informative refinement
  :source-form {:kind :reg-machine :id :upload/main}
  :inputs      [[:event :upload/start] [:event :upload/progress]   ;; every :on key, deduped
                [:event :upload/succeeded] [:event :upload/failed]]
@@ -261,11 +264,12 @@ A machine is the algebra's canonical process — the surface that motivates the 
 
 ```clojure
 ;; SELECTOR SOURCE FORM                      ;; SELECTOR ALGEBRA VIEW
-(rf/reg-sub :upload/progress                  {:id      :upload/progress
-  :<- [:rf/machine :upload/main]               :kind    :machine-selector   ;; a :derivation refinement
-  (fn [snapshot _]                             :inputs  [[:machine :upload/main [:data :progress]]]
-    (get-in snapshot [:data :progress] 0)))    :output  [:fact :upload/progress]
-                                               :storage :ephemeral
+(rf/reg-sub :upload/progress                  {:id         :upload/progress
+  :<- [:rf/machine :upload/main]               :kind       :derivation
+  (fn [snapshot _]                             :refinement :machine-selector  ;; a :derivation refinement
+    (get-in snapshot [:data :progress] 0)))    :inputs     [[:machine :upload/main [:data :progress]]]
+                                               :output     [:fact :upload/progress]
+                                               :storage    :ephemeral
                                                :evaluation :on-demand
                                                :lifecycle  :subscription-cache-entry
                                                :derive     #'app.upload/progress}

--- a/implementation/core/test/re_frame/derivation_graph_test.clj
+++ b/implementation/core/test/re_frame/derivation_graph_test.clj
@@ -163,7 +163,12 @@
       (is (= :derivation (get-in nodes [[:flow :cart/materialized-total] :kind])))
       (is (= :process    (get-in nodes [[:resource :article/by-slug] :kind])))
       (is (= :process    (get-in nodes [[:rf/route :route/article] :kind])))
-      (is (= :machine-process (get-in nodes [[:machine :upload/main] :kind]))))))
+      (is (= :process    (get-in nodes [[:machine :upload/main] :kind])))
+      ;; The informative refinement rides on :refinement, never :kind — the
+      ;; three :process families share one closed superkind (rf2-7wwp1z).
+      (is (= :resource-process (get-in nodes [[:resource :article/by-slug] :refinement])))
+      (is (= :route-fact       (get-in nodes [[:rf/route :route/article] :refinement])))
+      (is (= :machine-process  (get-in nodes [[:machine :upload/main] :refinement]))))))
 
 (deftest static-graph-edges-span-input-param-and-selector-roles
   (testing "the assembled edges carry :input, :param, and :selector roles"

--- a/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
+++ b/implementation/derivation-conformance/test/re_frame/derivation_algebra_conformance_cljs_test.cljc
@@ -30,12 +30,14 @@
   restated as the slice-1 contract):
 
     (a) LOWERING        — each source form lowers to the correct node KIND /
-                          SUPERKIND. Every node's `:kind` classifies as the
-                          closed two-superkind enum (`:derivation` |
+                          SUPERKIND. Every node's `:kind` is DIRECTLY a member
+                          of the closed two-superkind enum (`:derivation` |
                           `:process`); a tool that understands ONLY the two
-                          superkinds can classify EVERY node (refined kinds
-                          — `:machine-process`, `:route-fact` — reduce to a
-                          superkind).
+                          superkinds can classify EVERY node by reading `:kind`
+                          alone. Informative refined kinds
+                          (`:resource-process`, `:route-fact`,
+                          `:machine-process`) ride the separate `:refinement`
+                          axis, NEVER `:kind` (rf2-7wwp1z).
     (b) CLASSIFICATION  — storage-class / evaluation-policy / lifecycle
                           correctness PER FAMILY, against the
                           spec/Derivations.md fixed-classification tables
@@ -108,21 +110,25 @@
   understands only these MUST be able to classify every node."
   #{:derivation :process})
 
-(def refined->superkind
-  "Informative refined kinds (Derivations §Two superkinds, refinable) and
-  the superkind they reduce to. `:machine-process` refines `:process`; a
-  route's `:kind` is already the bare `:process` superkind (the `:route-fact`
-  detail rides `:refinement`)."
-  {:derivation       :derivation
-   :process          :process
+(def refinements
+  "The informative refined kinds (Derivations §The node shape — refinements
+  are informative, the superkind is canonical) and the superkind each refines.
+  Per the graduated Spec-Schemas `DerivationKind` enum these are CLOSED out of
+  `:kind` (a node's `:kind` is always a bare superkind); a refinement rides the
+  separate `:refinement` axis. This map exists only to validate that a node's
+  declared `:refinement` (when present) refines the superkind its `:kind`
+  asserts (rf2-7wwp1z)."
+  {:resource-process :process
+   :route-fact       :process
    :machine-process  :process
-   :resource-process :process
-   :route-fact       :process})
+   :machine-selector :derivation})
 
-(defn superkind-of
-  "Reduce any node `:kind` to its closed superkind, or nil if unknown."
-  [kind]
-  (get refined->superkind kind))
+;; NOTE (rf2-7wwp1z): there is deliberately NO `superkind-of` reduction helper.
+;; The closed `DerivationKind` enum makes a node's `:kind` ALWAYS a bare
+;; superkind, so conformance asserts `(contains? superkinds (:kind node))`
+;; DIRECTLY. The historic refined->superkind lookup masked a `:kind
+;; :machine-process` violation by accepting a refined kind in `:kind` and
+;; reducing it — the closed-enum contract is pinned by direct membership now.
 
 (def storage-classes
   "The closed storage-class set (Derivations §Storage class — the issue-2
@@ -294,23 +300,43 @@
       (is (= #{:subs :flows :resources :routes :machines}
              (->> nodes vals (map :rf/family) set))
           "every source form lowered to at least one node"))
-    (testing "EVERY node classifies to the closed two-superkind enum — a tool
-              that understands only :derivation / :process classifies all"
+    (testing "EVERY node's :kind is DIRECTLY a member of the closed two-superkind
+              enum — a tool that understands only :derivation / :process classifies
+              all by reading :kind alone (no refined-kind reduction; rf2-7wwp1z)"
       (doseq [[node-id node] nodes]
-        (is (contains? superkinds (superkind-of (:kind node)))
+        (is (contains? superkinds (:kind node))
             (str node-id " :kind " (:kind node)
-                 " does not reduce to a closed superkind"))))
+                 " is not DIRECTLY in the closed DerivationKind enum "
+                 (pr-str superkinds)
+                 " — refined kinds must ride :refinement, never :kind"))))
+    (testing "every refinement (when present) is informative and refines the
+              superkind its :kind asserts — refinements never replace the
+              superkind (rf2-7wwp1z)"
+      (doseq [[node-id node] nodes
+              :let [refinement (:refinement node)]
+              :when (some? refinement)]
+        (is (contains? refinements refinement)
+            (str node-id " :refinement " refinement " is not a known refinement"))
+        (is (= (:kind node) (get refinements refinement))
+            (str node-id " :refinement " refinement " refines "
+                 (get refinements refinement) " but :kind asserts " (:kind node)))))
     (testing "subscriptions + flows are DERIVATIONS (Derivations §Derivation)"
       (is (= :derivation (:kind (node-by-family nodes :subs :cart/total))))
       (is (= :derivation (:kind (node-by-family nodes :subs :cart/items))))
       (is (= :derivation (:kind (node-by-family nodes :flows :cart/materialized-total)))))
-    (testing "resources + routes + machines are PROCESSES (Derivations §Process)"
-      ;; resource carries the bare superkind :process; route carries :process
-      ;; with the :route-fact refinement; machine carries the :machine-process
-      ;; refinement — all three reduce to :process.
-      (is (= :process (superkind-of (:kind (node-by-family nodes :resources :article/by-slug)))))
-      (is (= :process (superkind-of (:kind (node-by-family nodes :routes :route/article)))))
-      (is (= :process (superkind-of (:kind (node-by-family nodes :machines :upload/main))))))
+    (testing "resources + routes + machines are PROCESSES (Derivations §Process)
+              — :kind is the bare :process superkind across ALL THREE families;
+              the informative refinement (:resource-process / :route-fact /
+              :machine-process) rides :refinement, one convention (rf2-7wwp1z)"
+      (let [res   (node-by-family nodes :resources :article/by-slug)
+            route (node-by-family nodes :routes    :route/article)
+            mach  (node-by-family nodes :machines  :upload/main)]
+        (is (= :process (:kind res)))
+        (is (= :process (:kind route)))
+        (is (= :process (:kind mach)))
+        (is (= :resource-process (:refinement res)))
+        (is (= :route-fact       (:refinement route)))
+        (is (= :machine-process  (:refinement mach)))))
     (testing "the route fact's id is the ONE consumer-facing slice name :rf/route
               (one-name-per-fact), with the per-route id under :source-form"
       (let [route (node-by-family nodes :routes :route/article)]

--- a/implementation/machines/src/re_frame/machines/tooling.cljc
+++ b/implementation/machines/src/re_frame/machines/tooling.cljc
@@ -83,7 +83,8 @@
 ;;
 ;; The fixed classifications for EVERY machine-process node (Derivations
 ;; §Machines expose algebra views — the machine column):
-;;   :kind          :machine-process     (a process — refines :process)
+;;   :kind          :process             (the superkind — Derivations §Two superkinds)
+;;   :refinement    :machine-process     (the informative refinement of :process)
 ;;   :storage       :runtime-db          (the snapshot is durable runtime-db state)
 ;;   :lifecycle     :machine-instance    (machine destroy releases it)
 ;;   :materialized? true                 (the snapshot has a durable runtime-db address)
@@ -228,14 +229,16 @@
   coordinates (the registered TYPE id — a spawned actor inherits its type's
   coords).
 
-  The fixed-classification spine — a `:machine-process` whose materialized
-  snapshot lands in runtime-db, evaluated `:on-transition` (+ derived policies),
-  owned by its `:machine-instance` — plus the per-machine `:inputs` (the
+  The fixed-classification spine — a `:process` (refinement `:machine-process`)
+  whose materialized snapshot lands in runtime-db, evaluated `:on-transition`
+  (+ derived policies), owned by its `:machine-instance` — plus the per-machine
+  `:inputs` (the
   declared `[:event …]` triggers), `:output` (the runtime-db snapshot path),
   `:source-form`, `:spawns?` flag, and source coords / schema / doc."
   [id source-id machine meta]
   (-> {:id            id
-       :kind          :machine-process
+       :kind          :process
+       :refinement    :machine-process
        :source-form   {:kind :reg-machine :id source-id}
        :inputs        (declared-event-inputs machine)
        :output        [:runtime (paths/snapshot-path id)]
@@ -265,8 +268,10 @@
   lifecycle, and commands over time — Derivations §Process). Each node carries:
 
   - `:id`          — the machine id (its canonical fact identity).
-  - `:kind`        — `:machine-process` (a process — refines `:process`;
-                     Derivations §Two superkinds).
+  - `:kind`        — `:process` (the superkind; Derivations §Two superkinds).
+  - `:refinement`  — `:machine-process` (the informative refinement — a process
+                     WITH state, lifecycle, and commands over time;
+                     Derivations §The node shape).
   - `:source-form` — `{:kind :reg-machine :id <machine-id>}`.
   - `:inputs`      — the declared inputs (Derivations §Declared input): each
                      author-declared `:on` event trigger across the whole

--- a/implementation/machines/test/re_frame/machine_algebra_view_test.clj
+++ b/implementation/machines/test/re_frame/machine_algebra_view_test.clj
@@ -6,7 +6,8 @@
 
   `re-frame.machines.tooling/machine-algebra-view` lowers every registered
   machine into the normalized algebra node every declared fact/process
-  shares: the canonical `:process` member — a `:machine-process` whose
+  shares: the canonical `:process` member — a `:process` (refinement
+  `:machine-process`) whose
   snapshot MATERIALIZES into runtime-db, evaluated `:on-transition` (plus
   `:scheduled` / `:on-reply` when the spec declares timers / spawns), owned by
   its `:machine-instance` lifecycle. `…/machine-instance-algebra-view` is the
@@ -38,11 +39,15 @@
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-;; The four fixed classifications EVERY machine-process node carries
-;; (Derivations §Machines expose algebra views — the machine column: the
-;; canonical runtime-db / machine-instance MATERIALIZED process member).
+;; The fixed classifications EVERY machine-process node carries (Derivations
+;; §Machines expose algebra views — the machine column: the canonical
+;; runtime-db / machine-instance MATERIALIZED process member). `:kind` is the
+;; CLOSED superkind `:process` (Spec-Schemas DerivationKind); the informative
+;; `:machine-process` refinement rides on `:refinement` (matching the routes
+;; `:route-fact` convention), never in `:kind`.
 (def fixed-classifications
-  {:kind          :machine-process
+  {:kind          :process
+   :refinement    :machine-process
    :storage       :runtime-db
    :lifecycle     :machine-instance
    :materialized? true})

--- a/implementation/resources/src/re_frame/resources/tooling.cljc
+++ b/implementation/resources/src/re_frame/resources/tooling.cljc
@@ -260,6 +260,7 @@
         resolver     (scope-resolver-enrichment spec)]
     (-> {:id            resource-id
          :kind          resource-superkind
+         :refinement    resource-refined-kind
          :source-form   {:kind :reg-resource :id resource-id}
          :inputs        (declared-inputs spec)
          :output        [:runtime [state/resources-key :entries]]
@@ -292,7 +293,9 @@
   derivation — Derivations §Process). Each node carries:
 
   - `:id`          — the resource id (its canonical fact identity when static).
-  - `:kind`        — `:process` (the superkind; refined `:resource-process`).
+  - `:kind`        — `:process` (the superkind; Derivations §Two superkinds).
+  - `:refinement`  — `:resource-process` (the informative refinement;
+                     Derivations §The node shape).
   - `:source-form` — `{:kind :reg-resource :id <resource-id>}`.
   - `:inputs`      — the declared inputs (Derivations §Declared input): the
                      params (`[:param :rf.params]`) and the scope policy
@@ -377,6 +380,7 @@
         record   (when work-id (work-ledger/get-record runtime-db work-id))]
     (cond-> {:id            scoped-key
              :kind          resource-superkind
+             :refinement    resource-refined-kind
              :source-form   {:kind :reg-resource :id resource-id}
              :inputs        [[:scope scope] [:param params]]
              :output        [:runtime (state/entry-path scoped-key)]

--- a/implementation/resources/test/re_frame/resource_algebra_view_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resource_algebra_view_cljs_test.cljc
@@ -64,9 +64,13 @@
 
 ;; The fixed classifications EVERY resource algebra node carries
 ;; (Derivations §Resources expose process nodes: the canonical runtime-db /
-;; remote-authority PROCESS member of the algebra).
+;; remote-authority PROCESS member of the algebra). `:kind` is the CLOSED
+;; superkind `:process` (Spec-Schemas DerivationKind); the informative
+;; `:resource-process` refinement rides on `:refinement` (matching the routes
+;; `:route-fact` convention), never in `:kind`.
 (def fixed-classifications
   {:kind          :process
+   :refinement    :resource-process
    :storage       :runtime-db
    :evaluation    #{:on-route :on-reply :scheduled :manual}
    :lifecycle     :resource-key

--- a/spec/Derivations.md
+++ b/spec/Derivations.md
@@ -244,7 +244,7 @@ Every derivation/process SHOULD be describable by an algebra view equivalent to:
  :source      {:ns "app.cart" :file "src/app/cart.cljs" :line 42}}
 ```
 
-**Two superkinds, refinable.** Every `:kind` classifies as either `:derivation` or `:process`. The refined kinds in the examples below — `:resource-process`, `:route-fact`, `:machine-process`, `:machine-selector` — are *informative refinements*; specs MAY add refinements, but a tool that understands only the two superkinds MUST still be able to classify every node.
+**Two superkinds, refinable.** Every `:kind` is one of exactly two closed superkinds: `:derivation` or `:process` (the closed `DerivationKind` enum — [Spec-Schemas §`:rf/derivation-node`](Spec-Schemas.md#rfderivation-node-rffact-rfderivation-edge-rfstorage-class-rfevaluation-policy-rflifecycle-the-derivationprocess-algebra-ep-0014)). The refined kinds — `:resource-process`, `:route-fact`, `:machine-process`, `:machine-selector` — are *informative refinements*, carried on the separate **`:refinement`** axis, **never in `:kind`**: specs MAY add refinements, but a tool that understands only the two superkinds MUST still be able to classify every node by reading `:kind` alone. A refinement always refines its node's superkind (`:resource-process` / `:route-fact` / `:machine-process` refine `:process`; `:machine-selector` refines `:derivation`).
 
 **Functions are opaque.** Function values (`:derive`, an input-producer) MAY be represented by symbols, source coordinates, registry metadata, or opaque implementation tokens. The graph contract is about dependencies, storage, evaluation, and ownership — it does **not** require serializing executable functions.
 
@@ -298,7 +298,8 @@ A **named resolver** turns part of a parametric declaration into a *static fact*
 
 ```clojure
 {:id :article/by-slug
- :kind :resource-process
+ :kind :process                                          ;; the closed superkind
+ :refinement :resource-process                           ;; the informative refinement
  :inputs [[:param :slug]
           [:scope {:from-db :session/current-tenant}]]   ;; named resolver — static!
  :scope-resolver {:id :session/current-tenant
@@ -568,7 +569,8 @@ The subscription's exact policy twin — same whole-value function, materialized
 ```clojure
 ;; STATIC ALGEBRA VIEW
 {:id          :article/by-slug
- :kind        :process                       ;; refinement :resource-process
+ :kind        :process                       ;; the closed superkind
+ :refinement  :resource-process              ;; the informative refinement
  :source-form {:kind :reg-resource :id :article/by-slug}
  :inputs      [[:param :slug]
                [:scope :rf.scope/from-caller]]
@@ -614,7 +616,8 @@ The split the [§Authority](#authority--the-remote-axis) section names is visibl
 ```clojure
 ;; ALGEBRA VIEW
 {:id          :rf/route                       ;; the one slice name; every route shares it
- :kind        :process                        ;; refinement :route-fact
+ :kind        :process                        ;; the closed superkind
+ :refinement  :route-fact                     ;; the informative refinement
  :source-form {:kind :reg-route :id :route/article}
  :inputs      [[:event :rf.route/navigate]
                [:event :rf.route/transitioned]
@@ -652,16 +655,17 @@ Every route materializes the *same* slice fact `:rf/route`; the per-route id is 
 ```clojure
 ;; MACHINE PROCESS VIEW                      ;; SELECTOR (a reg-sub over [:rf/machine …])
 {:id          :upload/main                   (rf/reg-sub :upload/progress
- :kind        :machine-process                 :<- [:rf/machine :upload/main]
- :source-form {:kind :reg-machine              (fn [snapshot _]
-               :id   :upload/main}               (get-in snapshot [:data :progress] 0)))
- :inputs      [[:event :upload/start]
-               [:event :upload/progress]     ;; SELECTOR ALGEBRA VIEW
-               [:event :upload/succeeded]    {:id      :upload/progress
-               [:event :upload/failed]]       :kind    :machine-selector   ;; a :derivation refinement
- :output  [:runtime [:rf.runtime/machines     :inputs  [[:machine :upload/main [:data :progress]]]
-           :snapshots :upload/main]]          :output  [:fact :upload/progress]
- :storage :runtime-db                         :storage :ephemeral
+ :kind        :process                         :<- [:rf/machine :upload/main]
+ :refinement  :machine-process                 (fn [snapshot _]
+ :source-form {:kind :reg-machine                (get-in snapshot [:data :progress] 0)))
+               :id   :upload/main}
+ :inputs      [[:event :upload/start]        ;; SELECTOR ALGEBRA VIEW
+               [:event :upload/progress]     {:id         :upload/progress
+               [:event :upload/succeeded]     :kind       :derivation
+               [:event :upload/failed]]       :refinement :machine-selector  ;; a :derivation refinement
+ :output  [:runtime [:rf.runtime/machines     :inputs     [[:machine :upload/main [:data :progress]]]
+           :snapshots :upload/main]]          :output     [:fact :upload/progress]
+ :storage :runtime-db                         :storage    :ephemeral
  :evaluation #{:on-transition}                :evaluation :on-demand
  :lifecycle  :machine-instance                :lifecycle  :subscription-cache-entry
  :materialized? true}                         :derive     #'app.upload/progress}
@@ -730,11 +734,12 @@ Resources are the third concrete algebra member to expose its view, and the **fi
 
 A single resource declaration lowers to **more than one** algebra node ([§Source form and algebra view](#source-form-and-algebra-view)): a `:process` node for the cache entry, **plus** the derived read facts (state, data, loading flag, error projection) over that entry. The read facts are the `:rf.resource/*` passive subscriptions ([016 §Subscriptions](016-Resources.md)); they are ordinary on-demand derivations (already covered by the [subscription view](#subscriptions-expose-algebra-views)), so the resource process node lists them under `:selectors` rather than re-minting them — and reading a selector does **not** start resource work ([§Evaluation policy](#evaluation-policy) rule 1).
 
-A resource is always a **`:process`** (refined `:resource-process`), and every resource node carries the same fixed classifications, because a resource is the canonical *runtime-db / remote-authority* member of the algebra:
+A resource's superkind is always **`:process`**; its informative refinement is **`:resource-process`**, carried under `:refinement` ([§Two superkinds, refinable](#the-node-shape): the `:kind` is the closed superkind enum, so a tool that understands only the two superkinds classifies the node by `:kind` alone). Every resource node carries the same fixed classifications, because a resource is the canonical *runtime-db / remote-authority* member of the algebra:
 
 | Axis | Value | Why |
 |---|---|---|
-| `:kind` | `:process` | a derivation with state, lifecycle, and commands over time ([§Process](#process)) |
+| `:kind` | `:process` | a derivation with state, lifecycle, and commands over time ([§Process](#process)); refinement `:resource-process` under `:refinement` |
+| `:refinement` | `:resource-process` | the informative refinement of `:process` ([§The node shape](#the-node-shape)) — never a third superkind in `:kind` |
 | `:storage` | `:runtime-db` | the **local** cache entry lives in the framework-owned runtime-db partition ([016 §Cache home](016-Resources.md)) — storage always names the local home |
 | `:authority` | `{:kind :remote :system :server :transport <id>}` | the source of truth is **external** ([§Authority](#authority--the-remote-axis)); `:transport` mirrors the registered transport (a recomputable projection, never a second home) |
 | `:evaluation` | `#{:on-route :on-reply :scheduled :manual}` | a multi-trigger process — route activation, async reply, scheduled stale/GC timers, and manual refresh/ensure ([§Evaluation policy](#evaluation-policy)) |
@@ -796,13 +801,14 @@ This exposure is *internal registration metadata*, consistent with the slice sco
 
 ## Machines expose algebra views
 
-Machines are the algebra's canonical **`:process`** member — the surface that motivates the [§Process](#process) superkind at all. Where subscriptions and flows are **derivations** (a pure whole-value function with no durable private state beyond its output), a machine is a *derivation WITH state, lifecycle, and commands over time*: it materializes a snapshot, reacts to events and replies and timers, spawns and destroys child actors, and is kept alive by an instance owner until machine destroy releases it. Every `reg-machine` registration projects to the [node shape](#the-node-shape) with the refined kind **`:machine-process`** (an *informative refinement* of `:process` — [§Two superkinds](#fact-identity); a tool that knows only `:derivation` / `:process` still classifies it correctly). The projection is **registrar-derived** (see [§The EP-0013 relocation seam](#the-ep-0013-relocation-seam)): [005](005-StateMachines.md) keeps the transition engine, the snapshot shape, the spawn/destroy lifecycle, and the timer table; the algebra view is assembled from the machine spec metadata that already exists, never from running a transition.
+Machines are the algebra's canonical **`:process`** member — the surface that motivates the [§Process](#process) superkind at all. Where subscriptions and flows are **derivations** (a pure whole-value function with no durable private state beyond its output), a machine is a *derivation WITH state, lifecycle, and commands over time*: it materializes a snapshot, reacts to events and replies and timers, spawns and destroys child actors, and is kept alive by an instance owner until machine destroy releases it. A machine's superkind is **`:process`**; its informative refinement is **`:machine-process`**, carried under `:refinement` ([§Two superkinds, refinable](#the-node-shape): the `:kind` is the closed superkind enum, so a tool that understands only the two superkinds classifies the node by `:kind` alone). Every `reg-machine` registration projects to the [node shape](#the-node-shape). The projection is **registrar-derived** (see [§The EP-0013 relocation seam](#the-ep-0013-relocation-seam)): [005](005-StateMachines.md) keeps the transition engine, the snapshot shape, the spawn/destroy lifecycle, and the timer table; the algebra view is assembled from the machine spec metadata that already exists, never from running a transition.
 
-Every machine-process node carries the same four fixed classifications, because a machine is the canonical *runtime-db process* of the algebra:
+Every machine-process node carries the same fixed classifications, because a machine is the canonical *runtime-db process* of the algebra:
 
 | Axis | Value | Why |
 |---|---|---|
-| `:kind` | `:machine-process` | a process — a derivation with state, lifecycle, and commands over time ([§Process](#process)) |
+| `:kind` | `:process` | a process — a derivation with state, lifecycle, and commands over time ([§Process](#process)); refinement `:machine-process` under `:refinement` |
+| `:refinement` | `:machine-process` | the informative refinement of `:process` ([§The node shape](#the-node-shape)) — never a third superkind in `:kind` |
 | `:storage` | `:runtime-db` | the snapshot is materialized into the framework-owned runtime-db partition (machine snapshots are durable runtime-db state — [EP-0001](../docs/EP/EP-0001-frame-partitions.md); [005 §Reserved snapshot-internal keys](005-StateMachines.md)) |
 | `:lifecycle` | `:machine-instance` | a singleton or spawned-actor snapshot owns it; machine destroy (and frame teardown) releases it |
 | `:materialized?` | `true` | the snapshot has a durable runtime-db address, not just a fact identity |

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2575,9 +2575,19 @@ The normalized **algebra view** every declared fact / process lowers to — the 
   ;; The two superkinds every node classifies as. The refined kinds
   ;; (:resource-process / :route-fact / :machine-process / :machine-selector)
   ;; are informative refinements — a tool that knows only the two superkinds
-  ;; MUST still classify every node. Refinements appear in :source-form / the
-  ;; per-owner specs, not as a third superkind.
+  ;; MUST still classify every node by reading :kind alone. A refinement rides
+  ;; the separate :refinement key (the per-owner specs name it), NEVER :kind —
+  ;; :kind is always one of these two superkinds, never a refined kind.
   [:enum :derivation :process])
+
+(def RefinedKind
+  ;; The informative refinement a node MAY carry under :refinement (open —
+  ;; specs MAY add more). Each refines exactly one superkind:
+  ;; :resource-process / :route-fact / :machine-process refine :process;
+  ;; :machine-selector refines :derivation. A refinement NEVER replaces the
+  ;; :kind superkind — a tool that knows only :derivation / :process still
+  ;; classifies the node by reading :kind alone.
+  [:enum :resource-process :route-fact :machine-process :machine-selector])
 
 (def StorageClass
   ;; Where the LOCAL representation lives. Always one of these four — the
@@ -2649,6 +2659,7 @@ The normalized **algebra view** every declared fact / process lowers to — the 
   [:map
    [:id           :any]
    [:kind         DerivationKind]
+   [:refinement   {:optional true} RefinedKind]  ;; informative refinement of :kind — NEVER replaces the superkind
    [:source-form  {:optional true} [:map [:kind :keyword] [:id {:optional true} :any]]]
    [:inputs       [:or [:vector DeclaredInput] [:= :parametric]]]
    [:input-producer {:optional true} :any]   ;; opaque fn token — present when :inputs is :parametric


### PR DESCRIPTION
## What

EP-0014 tail-1 correctness fix (rf2-7wwp1z). Machine algebra-view nodes emitted `:kind :machine-process`, which is **not** a member of the closed `DerivationKind` enum `[:enum :derivation :process]` graduated into `spec/Spec-Schemas.md`. This violated the `spec/Derivations.md` node-shape rule ("a tool understanding only the two superkinds MUST classify every node by reading `:kind` alone"). Three inconsistent conventions had shipped across the three `:process` families:

- **Routes** (correct, the target convention): `:kind :process` + `:refinement :route-fact`.
- **Machines** (violation): `:kind :machine-process` — a refined kind in `:kind`.
- **Resources** (lossy): `:kind :process` but the defined `:resource-process` refinement was never attached.

## Three-family alignment

All three `:process` families now follow ONE convention — `:kind` is always the closed superkind, the informative refined kind rides the separate `:refinement` axis (mirroring routes):

- **Machines** — `re-frame.machines.tooling/node-for`: now emits `:kind :process` + `:refinement :machine-process`. The same builder backs the live instance view, so `machine-instance-algebra-view` is aligned too.
- **Resources** — `re-frame.resources.tooling/static-node-for` AND `live-node-for`: now attach `:refinement :resource-process` (the `resource-refined-kind` def existed but was never wired in). Both the static and live cache-entry nodes carry it.
- **Routes** — unchanged (already correct); used as the reference shape.

Spec swept to the two-superkind + `:refinement` model:
- `spec/Derivations.md` — §Machines and §Resources prose + tables (added a `:refinement` row), the §Two-superkinds node-shape rule, and every illustrative example (node-shape, named-resolver-enrichment, machine/selector side-by-side).
- `spec/Spec-Schemas.md` — added a `RefinedKind` enum + an explicit optional `:refinement` key on `DerivationNode`; tightened the `DerivationKind` comment to state refinements ride `:refinement`, never `:kind`.
- `docs/EP/EP-0014-...md` — all example node shapes (`:resource-process` / `:route-fact` / `:machine-process` / `:machine-selector`) reconciled to refined-kind-on-`:refinement`, with a graduation note that earlier drafts placed it in `:kind`.
- `docs/guide/derivations-and-algebra-views.md` — the resource/route/machine/selector view examples.

## Conformance tightening

`derivation_algebra_conformance_cljs_test.cljc` previously masked the violation: it used a `refined->superkind` lookup (`{:machine-process :process, ...}`) and asserted `(superkind-of (:kind node))` was in the closed set — accommodating a refined kind in `:kind` instead of rejecting it. Now:
- The `(a)` lowering law asserts `(contains? superkinds (:kind node))` **directly** for every node — `:kind` must be a bare superkind, no reduction.
- A new per-node check asserts every `:refinement` (when present) is a known refinement that refines the superkind its `:kind` asserts.
- The process-families block asserts each of resources/routes/machines carries `:kind :process` directly **and** its correct `:refinement`.
- The dead `superkind-of`/`refined->superkind` reduction helper is removed (replaced by a `refinements` validation map + an explanatory note).

Per-family tests (`machine_algebra_view_test`, `resource_algebra_view_cljs_test`, `derivation_graph_test`) updated to pin `:kind :process` + the `:refinement` on each process family.

`git grep` confirms no `:machine-process` (or any refined kind) appears as a `:kind` value anywhere in tracked source/spec/docs.

## Quality gates

- `npm run test:cljs` — 6703 tests, 27047 assertions, 0 failures, 0 errors
- machines `clojure -M:test` — 646 tests, 2080 assertions, 0 failures, 0 errors (re-run post-rebase)
- resources `clojure -M:test` — 326 tests, 1237 assertions, 0 failures, 0 errors
- derivation-conformance `clojure -M:test` — 10 tests, 287 assertions, 0 failures, 0 errors
- `npm run test:bundle-isolation` — PASS (22 artefact entries, 40 sentinels absent, 3 budgets ok; uix/helix/reagent-free PASS)
- `mkdocs build --strict` — exit 0 (Derivations.md / Spec-Schemas.md / EP / guide touched)

Rebased onto `origin/main` after #3946 (rf2-exdipj EP-0014 comment pass) merged; the comment-vs-code overlap in `machines/tooling.cljc` auto-merged cleanly (different regions) — both #3946's comments and this `:kind` code change are present.
