### PR TITLE
fix: EP-0012 resource-identity + route-query canonical alignment (rf2-wgutc2)

### DIFF
--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -15,7 +15,8 @@
   `:rf.runtime/work-ledger`. Both are reserved runtime-db keys (per
   [Conventions §Reserved runtime-db keys]) — allocated lazily, per-frame
   isolated, never an app-db location."
-  (:require [re-frame.frame :as frame]))
+  (:require [re-frame.frame :as frame]
+            [re-frame.identity :as identity]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -146,107 +147,78 @@
 
 ;; ---- canonicalization (Spec 016 §Canonicalization rule) -------------------
 ;;
-;; Canonicalization is a pure function over EDN: a map is normalized so
-;; member order is irrelevant to identity and equality; nested maps recurse;
-;; sets and vectors keep their value semantics. The SAME rule applies to
-;; params maps and scope maps, so a scope and a param map spelled two ways
-;; collapse to one cache identity. Host values (functions, promises, dates,
-;; DOM nodes, AbortControllers, JS objects) are rejected loudly here — the
-;; cache key MUST be serializable EDN.
+;; Resource params + scopes are EP-0012 canonical-EDN identities: the SAME
+;; CEDN-1 rule the work ledger, route params, and epoch/replay records use,
+;; via the shared `re-frame.identity` algebra (Conventions §Canonical EDN
+;; identity). There is no resource-local identity dialect — a thin wrapper
+;; preserves the public resource error categories but delegates the actual
+;; canonicalization / domain validation to `identity/canonical` (rf2-wgutc2,
+;; EP-0012 correctness review item 1).
+;;
+;; This closes three divergences the prior resource-local canonicalizer
+;; carried against CEDN-1:
+;;   - it accepted broad `number?` values (floats, ratios, decimals,
+;;     out-of-safe-range integers) — CEDN-1 admits only portable integers in
+;;     the ECMAScript safe range, and rejects the rest fail-closed;
+;;   - it collapsed lists to vectors (`(sequential? x) (mapv …)`), erasing
+;;     the list-vs-vector EDN distinction CEDN-1 preserves (Conventions
+;;     §Sequences and sets: "Vectors and lists … are distinct EDN facts");
+;;   - it sorted map keys under a bespoke `total-edn-compare`, a second
+;;     ordering definition the shared CEDN-1 byte order subsumes.
+;;
+;; `identity/canonical` also fails closed on DUPLICATE canonical map keys
+;; (two distinct host keys whose CEDN-1 bytes collide), so a colliding cache
+;; key can never silently collapse two identity-distinct param maps.
 
 (defn serializable-edn?
-  "True iff `x` is serializable EDN data the cache key may carry — a
-  keyword / symbol / string / number / boolean / nil, or a collection
+  "True iff `x` is a portable CEDN-1 EDN identity value the cache key may
+  carry — encodable by the shared `re-frame.identity` algebra without
+  failing closed. A keyword / symbol / string / boolean / nil, a portable
+  integer in the ECMAScript safe range, a UUID, an instant, or a collection
   (map / vector / list / set) recursively built from such. Host / opaque
-  values (functions, dates, promises, DOM nodes, AbortControllers, raw JS
-  objects, atoms) are rejected. Per Spec 016 §Resource identity (\"Host
-  values … are rejected\")."
+  values (functions, dates beyond instants, promises, DOM nodes,
+  AbortControllers, raw JS objects, atoms) AND non-portable numbers (floats,
+  ratios, decimals, NaN / infinities, integers outside the safe range) are
+  rejected — exactly the CEDN-1 domain (Conventions §Canonical EDN
+  identity). Per Spec 016 §Resource identity (\"Host values … are rejected\")."
   [x]
-  (cond
-    (nil? x)     true
-    (keyword? x) true
-    (symbol? x)  true
-    (string? x)  true
-    (boolean? x) true
-    (number? x)  true
-    (map? x)     (every? (fn [[k v]] (and (serializable-edn? k)
-                                          (serializable-edn? v))) x)
-    (set? x)     (every? serializable-edn? x)
-    ;; vectors, lists, seqs
-    (sequential? x) (every? serializable-edn? x)
-    :else        false))
-
-(defn- type-rank
-  "Total type ordering used by `total-edn-compare` so a map with MIXED key
-  types (e.g. a keyword key and a string key) sorts deterministically rather
-  than throwing a raw `ClassCastException` (rf2-ptz7z8). The rank groups
-  values by their EDN kind; WITHIN a kind the natural / string ordering
-  breaks ties. Covers exactly the serializable-EDN kinds the cache key may
-  carry (`serializable-edn?`)."
-  [x]
-  (cond
-    (nil? x)        0
-    (boolean? x)    1
-    (number? x)     2
-    (string? x)     3
-    (keyword? x)    4
-    (symbol? x)     5
-    :else           6))
-
-(defn- total-edn-compare
-  "A TOTAL comparator over the serializable-EDN key shapes a canonical map
-  may carry (rf2-ptz7z8). Orders first by `type-rank` (so mixed
-  keyword/string/number/nil keys are orderable instead of throwing), then
-  WITHIN a kind by the kind's natural order — numbers numerically, strings /
-  keywords / symbols by their printed form. A deterministic total order is
-  all canonicalization needs: it only has to be stable + order-independent,
-  not semantically meaningful across kinds. Returns a negative / zero /
-  positive int."
-  [a b]
-  (let [ra (type-rank a) rb (type-rank b)]
-    (if (not= ra rb)
-      (compare ra rb)
-      ;; same kind — compare within it. numbers compare numerically; every
-      ;; other comparable kind compares by its printed form (keywords /
-      ;; symbols carry namespace + name; strings are themselves), which is a
-      ;; total order within the kind.
-      (if (number? a)
-        (compare a b)
-        (compare (str a) (str b))))))
+  (try
+    (identity/canonical-bytes x)
+    true
+    (catch #?(:clj Throwable :cljs :default) _
+      false)))
 
 (defn canonicalize
-  "Pure canonicalization of an EDN value for use in a cache key (Spec 016
-  §Canonicalization rule). A map is normalized into a sorted-by-key map under
-  a TOTAL comparator so two spellings (key order) collapse to one identity
-  and `=`; nested maps recurse; sets and vectors keep value semantics (their
-  elements recurse). Reject non-EDN / host values loudly via `reject-non-edn!`
-  upstream — this fn assumes its input is already serializable EDN.
+  "Pure canonicalization of an EDN value for use in a cache key — delegates
+  to the shared CEDN-1 `re-frame.identity/canonical` (Spec 016
+  §Canonicalization rule / Conventions §Canonical EDN identity). Map entries
+  and set elements are reordered into CEDN-1 canonical order so two spellings
+  (key/element order) collapse to one identity and `=`; nested values recurse;
+  vectors and LISTS preserve their kind and order (distinct EDN facts, not
+  collapsed). Two map spellings differing only in insertion order return an
+  `=` canonical value (and therefore the identical scoped resource key).
 
-  The sorted-map normalization makes member ORDER irrelevant to BOTH
-  equality and hashing, so `{:a 1 :b 2}` and `{:b 2 :a 1}` produce the
-  identical canonical value (and therefore the identical scoped resource
-  key). The comparator is TOTAL over the accepted EDN key shapes
-  (rf2-ptz7z8): a map mixing keyword and string keys canonicalizes
-  deterministically (ordered by `total-edn-compare`) instead of throwing a
-  raw `ClassCastException` from the default sorted-map comparator. Returns
-  the canonical value."
+  Fails closed with `:rf.error/non-edn-identity` for any out-of-domain value
+  (a host handle, a float / ratio / out-of-safe-range integer) and for a map
+  carrying DUPLICATE canonical keys. Callers route the value through
+  `reject-non-edn!` first to surface the public resource error category."
   [x]
-  (cond
-    (map? x)        (into (sorted-map-by total-edn-compare)
-                          (map (fn [[k v]] [k (canonicalize v)]))
-                          x)
-    (set? x)        (into #{} (map canonicalize) x)
-    (vector? x)     (mapv canonicalize x)
-    (sequential? x) (mapv canonicalize x)
-    :else           x))
+  (identity/canonical x))
 
 (defn reject-non-edn!
   "Throw `:rf.error/resource-non-edn-params` when `value` (a params or
-  scope map) is not serializable EDN — a host / opaque value (fn, promise,
-  date, DOM node, AbortController, JS object) reached the cache-key
-  boundary. Per Spec 016 §Resource identity (host values are rejected) /
-  §Canonicalization rule. `where` / `kind` (`:params` | `:scope`) name the
-  offending boundary. Returns `value` unchanged when it conforms."
+  scope map) is not a portable CEDN-1 identity — a host / opaque value (fn,
+  promise, date, DOM node, AbortController, JS object) OR a non-portable
+  number (float, ratio, decimal, NaN / infinity, out-of-safe-range integer)
+  reached the cache-key boundary. Per Spec 016 §Resource identity (host
+  values are rejected) / §Canonicalization rule / Conventions §Canonical EDN
+  identity. `where` / `kind` (`:params` | `:scope`) name the offending
+  boundary. Returns `value` unchanged when it conforms.
+
+  Preserves the public resource error category (`:rf.error/resource-non-edn-
+  params`) while delegating the domain decision to the shared CEDN-1 rule
+  (`serializable-edn?` → `identity/canonical-bytes`); the underlying
+  `:rf.error/non-edn-identity` cause rides `:rf.error/cause` for diagnosis."
   [value where kind resource-id]
   (when-not (serializable-edn? value)
     (throw (ex-info ":rf.error/resource-non-edn-params"
@@ -254,13 +226,16 @@
                      :where       where
                      :recovery    :fix-params
                      :reason      (str "resource " resource-id " " (name kind)
-                                       " is not serializable EDN — host / opaque "
-                                       "values (functions, promises, dates, DOM "
-                                       "nodes, AbortControllers, JS objects) are "
-                                       "rejected at the cache-key boundary. Put "
-                                       "every value that affects remote identity "
-                                       "in params as plain EDN. Per Spec 016 "
-                                       "§Resource identity.")
+                                       " is not a portable CEDN-1 EDN identity — "
+                                       "host / opaque values (functions, promises, "
+                                       "dates, DOM nodes, AbortControllers, JS "
+                                       "objects) and non-portable numbers (floats, "
+                                       "ratios, decimals, NaN/infinities, integers "
+                                       "outside the safe range) are rejected at the "
+                                       "cache-key boundary. Put every value that "
+                                       "affects remote identity in params as plain "
+                                       "portable EDN. Per Spec 016 §Resource "
+                                       "identity / Conventions §Canonical EDN identity.")
                      :resource-id resource-id
                      :kind        kind
                      :value       (pr-str value)})))

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -33,6 +33,7 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
    [re-frame.frame :as frame]
+   [re-frame.identity :as identity]
    [re-frame.late-bind :as late-bind]
    [re-frame.registrar :as registrar]
    ;; load-bearing side-effecting require: the façade registers the
@@ -129,6 +130,69 @@
     (is (thrown-with-msg?
           #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
           (state/reject-non-edn! {:f (fn [])} 'test :params :r/x)))))
+
+;; rf2-wgutc2 (EP-0012 correctness review item 1): resource params + scopes
+;; use the SHARED CEDN-1 identity rule (`re-frame.identity/canonical`), not a
+;; resource-local dialect. This closes three divergences the prior
+;; resource-local canonicalizer carried:
+;;   - it accepted broad `number?` (floats / ratios / decimals / out-of-safe-
+;;     range integers) — CEDN-1 admits only portable safe-range integers;
+;;   - it collapsed lists → vectors, erasing the list-vs-vector EDN distinction;
+;;   - it sorted keys under a bespoke comparator the CEDN-1 byte order subsumes.
+(deftest resource-identity-uses-shared-cedn1-rule
+  (testing "non-portable NUMBERS are rejected at the cache-key boundary
+            (CEDN-1 admits only portable safe-range integers)"
+    ;; floats / doubles
+    (is (false? (state/serializable-edn? {:ratio 1.5}))
+        "a float param is not a portable CEDN-1 identity")
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-non-edn-params"
+          (state/reject-non-edn! {:ratio 1.5} 'test :params :r/x))
+        "a float param is rejected loudly")
+    ;; out-of-safe-range integer (> 2^53 - 1) — diverges across hosts, so
+    ;; CEDN-1 fails it closed.
+    (is (false? (state/serializable-edn? {:n 9007199254740993}))
+        "an integer beyond the ECMAScript safe range is rejected")
+    #?(:clj
+       ;; ratios + bigdecimals only exist on the JVM
+       (do
+         (is (false? (state/serializable-edn? {:r 1/3}))
+             "a ratio param is rejected")
+         (is (false? (state/serializable-edn? {:d 1.5M}))
+             "a bigdecimal param is rejected"))))
+  (testing "a plain safe-range integer param is STILL accepted (the common case)"
+    (is (true? (state/serializable-edn? {:rev 1 :page 42})))
+    (is (= {:rev 1 :page 42} (state/canonicalize {:page 42 :rev 1}))))
+  (testing "list vs vector are DISTINCT EDN facts — never collapsed
+            (Conventions §Sequences and sets)"
+    ;; The prior resource-local canonicalize ACTIVELY COERCED lists to vectors
+    ;; (`(sequential? x) (mapv …)`), erasing the kind entirely — a vector and a
+    ;; list params value became byte-identical, silently sharing one cache
+    ;; entry. CEDN-1 PRESERVES the kind, so the two stay distinct EDN identities.
+    ;;
+    ;; Note: Clojure value `=` does NOT discriminate a vector from a list
+    ;; (`(= [1 2 3] '(1 2 3))` is true), so the distinction is at the
+    ;; AUTHORITATIVE CEDN-1 identity level (EP-0012 disposition 5: the canonical
+    ;; EDN value IS the identity, and equality-as-identity is CEDN-1 byte
+    ;; equality, `identity/identical-identity?`) — the vector encodes `v[…]`
+    ;; and the list encodes `l(…)`, distinct token streams.
+    (is (not (identity/identical-identity?
+               (state/canonicalize {:xs [1 2 3]})
+               (state/canonicalize {:xs '(1 2 3)})))
+        "a vector value and a list value canonicalize to DISTINCT CEDN-1 identities")
+    (is (not (identity/identical-identity?
+               (state/scoped-resource-key :rf.scope/global :r/x {:xs [1 2 3]})
+               (state/scoped-resource-key :rf.scope/global :r/x {:xs '(1 2 3)})))
+        "the scoped keys are distinct identities — list and vector params are
+         not the same cache fact")
+    (is (vector? (:xs (state/canonicalize {:xs [1 2 3]})))
+        "a vector value stays a vector")
+    (is (seq? (:xs (state/canonicalize {:xs '(1 2 3)})))
+        "a list value stays a list (not coerced to a vector — the prior
+         resource-local canonicalizer's silent collapse is gone)"))
+  (testing "key-order independence is preserved through the shared rule"
+    (is (= (state/canonicalize {:a 1 :b 2})
+           (state/canonicalize {:b 2 :a 1})))))
 
 ;; ===========================================================================
 ;; 2. Fail-closed scope policy (no global fallthrough)

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -17,6 +17,7 @@
   facade's re-exports. Per the rf2-2yabr cohesion split: REGISTRY +
   MATCH/EMIT seam."
   (:require [clojure.string :as str]
+            [re-frame.identity :as identity]
             [re-frame.registrar :as registrar]
             [re-frame.late-bind :as late-bind]
             [re-frame.routing.match :as match]
@@ -1020,9 +1021,26 @@
          ;; (`false`, `0`, `""`) is a legitimate value and is preserved —
          ;; only `nil` is elided — so non-nil invalid values STILL fail
          ;; validation against the elided map.
+         ;;
+         ;; rf2-wgutc2 (EP-0012 correctness review item 2): after nil
+         ;; elision the surviving entries are sorted into DETERMINISTIC
+         ;; CANONICAL KEY ORDER by their keys' shared CEDN-1 bytes
+         ;; (`re-frame.identity/canonical-bytes`), NOT the caller's
+         ;; insertion order. Per Conventions §The `:rf/path` algebra
+         ;; (route-url/match-url prism): "query keys are emitted in
+         ;; deterministic canonical order". Two callers that pass the same
+         ;; query map spelled in different key orders now build the
+         ;; BYTE-IDENTICAL URL — a stable href for caching / dedupe /
+         ;; identical-route-target? no-op detection / SSR-hydration parity,
+         ;; rather than a URL that varies with map literal order. The sort
+         ;; is by the key's canonical EDN identity (the same order the
+         ;; CEDN-1 map encoding uses), so it is total over the mixed-kind
+         ;; query keys a route may carry. An array-map preserves this sorted
+         ;; order downstream through validation and emission.
          emitted-query (into (array-map)
-                             (remove (fn [[_ v]] (nil? v)))
-                             query-params)
+                             (sort-by (comp identity/canonical-bytes key)
+                                      (remove (fn [[_ v]] (nil? v))
+                                              query-params)))
          route-meta   (registrar/lookup :route route-id)
          pattern      (:path route-meta)]
      (when (nil? pattern)

--- a/implementation/routing/test/re_frame/routing_registry_test.clj
+++ b/implementation/routing/test/re_frame/routing_registry_test.clj
@@ -382,20 +382,38 @@
 ;; ---- route-url query-string emission -------------------------------------
 ;;
 ;; Per Spec 012 §Bidirectional URL ↔ params. The qs builder
-;; (routing.cljc:725-731) joins `(name k)=url-encode(v)` pairs with `&`.
+;; (registry.cljc) joins `(name k)=url-encode(v)` pairs with `&`.
 ;; Coverage elsewhere only hits the single-pair `{:lang "en"}` case
 ;; (route-url-4-arity-appends-fragment:918), which can't observe pair
 ;; ORDERING or query-VALUE percent-encoding. These are the two behaviours
 ;; the multi-pair `&`-join + per-value `url-encode` exist for.
+;;
+;; rf2-wgutc2 (EP-0012 correctness review item 2): query keys are emitted
+;; in DETERMINISTIC CANONICAL ORDER (by CEDN-1 key bytes), NOT the caller's
+;; insertion order — so the same query map spelled in different key orders
+;; builds the BYTE-IDENTICAL URL (Conventions §The `:rf/path` algebra: "query
+;; keys are emitted in deterministic canonical order").
 (deftest route-url-query-string-emission
-  (testing "multi-pair query: pairs joined with `&` in insertion order"
+  (testing "multi-pair query: pairs joined with `&` in CANONICAL key order
+            (construction-order independent)"
     (rf/reg-route :route/list {:path "/list"})
+    ;; both spellings of {:a … :b …} build the same URL — canonical order,
+    ;; not insertion order.
     (is (= "/list?a=1&b=2"
            (routing/route-url :route/list {} (array-map :a "1" :b "2")))
-        "two query pairs join with `&`, preserving insertion order")
+        "two query pairs join with `&` in canonical key order")
+    (is (= "/list?a=1&b=2"
+           (routing/route-url :route/list {} (array-map :b "2" :a "1")))
+        "the SAME URL regardless of caller insertion order (a before b)")
     (is (= "/list?x=1&y=2&z=3"
            (routing/route-url :route/list {} (array-map :x "1" :y "2" :z "3")))
-        "three query pairs join with `&` in insertion order"))
+        "three query pairs join with `&` in canonical key order")
+    (is (= "/list?x=1&y=2&z=3"
+           (routing/route-url :route/list {} (array-map :z "3" :x "1" :y "2")))
+        "three pairs: canonical order is construction-order independent")
+    (is (= (routing/route-url :route/list {} (array-map :z "3" :y "2" :x "1"))
+           (routing/route-url :route/list {} (array-map :x "1" :y "2" :z "3")))
+        "any two permutations of one query map build the byte-identical URL"))
 
   (testing "query VALUES are percent-encoded (encodeURIComponent semantics)"
     (rf/reg-route :route/search {:path "/search"})

--- a/spec/conformance/fixtures/routing-match-url.edn
+++ b/spec/conformance/fixtures/routing-match-url.edn
@@ -62,9 +62,13 @@
   {:call :route-url :route-id :route/article-detail :params {:id "intro"}
    :expect "/articles/intro"}
 
-  ;; 3-arity form: with query-params
+  ;; 3-arity form: with query-params. Query keys are emitted in DETERMINISTIC
+  ;; CANONICAL KEY ORDER (by CEDN-1 key bytes), NOT the caller's source order —
+  ;; so `:page` precedes `:q` regardless of how the query map was spelled
+  ;; (EP-0012, rf2-wgutc2; Conventions §The :rf/path algebra: "query keys are
+  ;; emitted in deterministic canonical order").
   {:call :route-url :route-id :route/search :params {} :query {:q "clojure" :page 2}
-   :expect "/search?q=clojure&page=2"}
+   :expect "/search?page=2&q=clojure"}
 
   ;; Splat round-trip
   {:call :route-url :route-id :route/files :params {:rest "a/b/c.txt"}
@@ -90,11 +94,17 @@
   {:call :route-url :route-id :route/article-detail :params {:id "intro"} :query {} :fragment nil
    :expect "/articles/intro"}
 
-  ;; Round-trip property: for every registered route, route-url ∘ match-url is identity.
+  ;; Round-trip property: route-url ∘ match-url recovers the URL. This is a
+  ;; PRISM (a lawful partial round-trip, Conventions §The :rf/path algebra),
+  ;; not an isomorphism: the query string round-trips byte-identical only when
+  ;; its keys are already in canonical order, because route-url emits query
+  ;; keys in deterministic canonical order (`:page` before `:q`; EP-0012,
+  ;; rf2-wgutc2). The query URLs below are spelled in canonical key order so
+  ;; the byte-identical round-trip holds.
   {:call :round-trip :url "/articles/intro"}
   {:call :round-trip :url "/files/a/b/c.txt"}
-  {:call :round-trip :url "/search?q=test&page=3"}
+  {:call :round-trip :url "/search?page=3&q=test"}
 
   ;; Fragment round-trip: URL with '#fragment' parses, rebuilds back byte-identical.
   {:call :round-trip :url "/articles/intro#section-1"}
-  {:call :round-trip :url "/search?q=test&page=3#results"}]}
+  {:call :round-trip :url "/search?page=3&q=test#results"}]}

--- a/spec/conformance/fixtures/routing-query-string-coercion.edn
+++ b/spec/conformance/fixtures/routing-query-string-coercion.edn
@@ -108,7 +108,12 @@
             :fragment nil
             :validation-failed? true}}
 
-  ;; route-url's 3-arity emits the query string in input order.
+  ;; route-url's 3-arity emits the query string in DETERMINISTIC CANONICAL
+  ;; KEY ORDER (by CEDN-1 key bytes), NOT the caller's input/source order —
+  ;; `:page` precedes `:q` regardless of how the query map is spelled
+  ;; (EP-0012, rf2-wgutc2; Conventions §The :rf/path algebra: "query keys are
+  ;; emitted in deterministic canonical order"). Two callers passing the same
+  ;; query map in different key orders build the byte-identical URL.
   {:call :route-url :route-id :route/articles :params {}
                     :query {:q "clojure" :page 2}
-   :expect "/articles?q=clojure&page=2"}]}
+   :expect "/articles?page=2&q=clojure"}]}


### PR DESCRIPTION
Implements **rf2-wgutc2** — the EP-0012 correctness-review findings that the merged w9x5fv foundation (#3944) did not cover. Builds on #3944 (does not re-edit `path.cljc` / `identity.cljc`).

## What this does

### Finding 1 — resource params/scopes use the shared CEDN-1 rule
`implementation/resources/src/re_frame/resources/state.cljc`: `serializable-edn?` / `canonicalize` / `reject-non-edn!` are now **thin wrappers over `re-frame.identity`** (`canonical-bytes` / `canonical`), preserving the public resource error category (`:rf.error/resource-non-edn-params`). The bespoke resource-local `total-edn-compare` / `type-rank` comparator is dropped (CEDN-1 byte order subsumes it).

Closes three CEDN-1 divergences the resource-local canonicalizer carried:
- it accepted broad `number?` (floats / ratios / decimals / out-of-safe-range integers) — now **rejected fail-closed**;
- it collapsed lists → vectors — now the **list-vs-vector EDN distinction is preserved** (Conventions §Sequences and sets);
- it sorted keys under a bespoke comparator — now subsumed by the shared CEDN-1 order.

`canonicalize-scope` / `scoped-resource-key` are unchanged callers that pick up the corrected canonicalization through the wrappers.

### Finding 2 — route-url query emission is deterministic by canonical key order
`implementation/routing/src/re_frame/routing/registry.cljc`: after nil-elision the surviving query entries are sorted by their keys'' shared CEDN-1 bytes (`identity/canonical-bytes`) before rendering — **not** the caller'`s insertion order. Two callers passing one query map spelled in different key orders now build the byte-identical URL. Matches the already-normative Conventions §The `:rf/path` algebra ("query keys are emitted in deterministic canonical order") — **no spec prose change needed**.

### Finding 3 — concrete-path consumer boundaries
**Already covered by #3944** (frame-classification `:app-db` paths + resource-scope `:db` inputs route through `normalize-concrete`; resource-scope requires explicit `[]` for root, whole-db sugar lowers to `[:db []]`). No-op here; verified and noted for completeness.

## Tests
- `resources_runtime_cljs_test`: float/ratio/decimal/out-of-safe-range rejection + list-vs-vector identity distinctness (asserted at the authoritative CEDN-1 `identical-identity?` level — Clojure `=` does not discriminate list/vector).
- `routing_registry_test`: route-url query emission now asserts **construction-order independence** (canonical order), replacing the prior insertion-order lock.
- Conformance fixtures `routing-match-url` + `routing-query-string-coercion`: route-url expectations + round-trip URLs updated to canonical key order.

## Follow-up filed
**rf2-o84qq2** (P3): the resource cache keys entries by the canonical EDN *value* under Clojure `=`, which folds list-vs-vector params together even though their CEDN-1 byte identities differ. The thin-wrapper now preserves the kind structurally (the prior canonicalizer actively collapsed it), so the authoritative CEDN-1 identity is distinct — but fully honouring it at the cache map-keying layer (key on `canonical-bytes`) is a larger change than this bead'`s scope.

## Quality gates
- `resources clojure -M:test`: 327 tests, 1249 assertions, 0 failures, 0 errors
- `routing clojure -M:test`: 224 tests, 1010 assertions, 0 failures, 0 errors
- `core conformance-test` (JVM): 0 failures, 0 errors
- `npm run test:cljs`: 6690 tests, 26945 assertions, 0 failures, 0 errors
- `python -m mkdocs build --strict`: exit 0