### PR TITLE
feat(core): EP-0013 D2 stage-6 — public app/module constructors + composition (rf2-zlhgr6)

### DIFF
--- a/implementation/core/src/re_frame/app_value.cljc
+++ b/implementation/core/src/re_frame/app_value.cljc
@@ -1,11 +1,12 @@
 (ns re-frame.app-value
-  "The app value — the program-as-a-value (EP-0013 D2 stage 5, accepted
-  2026-06-11; sequenced behind the merged D1 `re-frame.realm`).
+  "The app value — the program-as-a-value (EP-0013 D2; stage 5 projection
+  accepted 2026-06-11, stage 6 public constructors + composition added on top
+  of it; sequenced behind the merged D1 `re-frame.realm`).
 
   > The program is a value; the runtime is a container you install it into.
 
   Per [EP-0013](docs/EP/EP-0013-app-values-and-runtime-realms.md) §D2 (the
-  app value) + §Public API Staging stage 5, the app value is the immutable
+  app value) + §Public API Staging stages 5-6, the app value is the immutable
   description of a program: its registration descriptors grouped by registry
   kind, its capability requirements, and the source coordinates that declared
   each contract surface. Where D1 made registrar *ownership* explicit (a realm
@@ -14,18 +15,38 @@
   only through the live registrar — they are an enumerable, recomputable
   VALUE projected over that registrar.
 
-  ## Stage 5 is INTERNAL — no public surface, no facade, no manifest
+  ## Two ways to obtain an app value: PROJECT a live realm, or CONSTRUCT one
 
-  This is EP-0013 staging step 5: an internal app-value descriptor format +
-  the projection seam, for the registrations that ALREADY exist in the
-  default realm's registrar. **No public `rf/app` / `rf/module` constructor
-  (stage 6), no public `rf/install!` / `rf/reinstall!` (stage 7), no
-  `re-frame.core` facade export, and no api-manifest change ship here** —
-  those names are reserved vocabulary and exposure graduates internal-first
-  (EP-0013 issue 1). Everything here is reached only by `re-frame.realm` and
-  the conformance tests. The headline is **zero ergonomic regression**: the
-  ordinary namespace-load `reg-*` sugar path is byte-identical; nothing on
-  the registration hot path changes.
+  There are two complementary origins for an app value, both producing the
+  same descriptor-grouped shape:
+
+    * the **projection** (stage 5, `app-value`): read the program a realm is
+      already running by re-grouping its registrar — the read direction over
+      the load-order `reg-*` sugar path (see §The projection seam below);
+    * the **construction** (stage 6, `module` + `app`): build an app value as
+      INERT data from explicit module descriptors, BEFORE any realm — the
+      surface large-SPA code uses to compose + inspect a program before it is
+      installed (see §Public construction + composition below).
+
+  ## Stage 5 (projection) is INTERNAL; stage 6 (construction) is PUBLIC
+
+  Stage 5 shipped an internal app-value descriptor format + the projection
+  seam, for the registrations that ALREADY exist in the default realm's
+  registrar — INTERNAL, reached only by `re-frame.realm` and the conformance
+  tests, with **zero ergonomic regression** (the ordinary namespace-load
+  `reg-*` sugar path is byte-identical; nothing on the registration hot path
+  changes).
+
+  Stage 6 graduates the PUBLIC construction half: `module` + `app` (and the
+  inspectors `app-registrations` / `app-owns` / `app-requires`), re-exported
+  from `re-frame.core` as `rf/module` / `rf/app` / `rf/app-registrations` /
+  `rf/app-owns` / `rf/app-requires`. These are the reserved-vocabulary names
+  ruled in EP-0013 issue 1; `rf/realm` + `rf/install!` / `rf/reinstall!`
+  (stage 7 — seating an app value into a realm) are NOT shipped here.
+  Construction is PURE: a `module` / `app` call has no registration side
+  effect (no realm, no registrar touch — the value is inert data per EP-0013
+  issue 10's \"inert is load-bearing\" rule); the projection seam (stage 5)
+  is untouched.
 
   ## The app value is a RECOMPUTABLE PROJECTION, not a mirror
 
@@ -74,26 +95,48 @@
 ;; ---- the app-value top-level shape ----------------------------------------
 ;;
 ;; Per EP-0013 §App Values + the draft normalized shape (Spec-Schemas), an
-;; app value contains (directly or through its modules, which stage 6 adds):
+;; app value contains (directly or through its modules):
 ;;
-;;   :rf.app/id     the app's id. In stage 5 the only app is the one the
-;;                  default realm carries (the process-load registrations),
-;;                  so the id is the realm's id (`:rf.realm/default`). Stage 6
-;;                  gives an explicitly-constructed app value its own id.
+;;   :rf.app/id     the app's id. A PROJECTED app (stage 5) carries the
+;;                  realm's id (`:rf.realm/default` for the default realm —
+;;                  the program the realm carries). A CONSTRUCTED app (stage
+;;                  6) carries the `:id` its `app` call declared.
 ;;   :registrations the normalized registration descriptors, grouped by
-;;                  registry kind: `kind → id → descriptor`. This is the
-;;                  re-grouping of the realm's registrar into the descriptor
-;;                  shape (below).
+;;                  registry kind: `kind → id → descriptor`. For a projected
+;;                  app this is the re-grouping of the realm's registrar; for
+;;                  a constructed app it is the composition of its modules'
+;;                  descriptors (collision-checked, owner-stamped).
 ;;   :requires      the set of `:rf.capability/*` requirements the program
-;;                  declares. In stage 5 this is empty — capability
-;;                  requirements are declared on MODULE values (stage 6/D3);
-;;                  the default realm's load-order registrations carry none.
-;;                  The slot is present (always `#{}` here) so the shape is
-;;                  stable across the stage-6 graduation.
+;;                  declares. EMPTY for a projected app (capability
+;;                  requirements are declared on MODULE values — the
+;;                  default realm's load-order registrations carry none). For
+;;                  a constructed app it is the union of its modules'
+;;                  `:requires`. The slot is always present.
+;;   :modules       (CONSTRUCTED apps only) the module map keyed by module id:
+;;                  `module-id → module value`. A projected app carries no
+;;                  modules (the load-order registrar has no module grouping),
+;;                  so the slot is absent there. An app constructed from zero
+;;                  modules carries an empty `:modules` map.
 ;;
-;; D2/D3-RESERVED, never produced in stage 5: :modules (the module map — D3),
-;; :diagnostics (composition diagnostics — stage 6's compose step). Left
-;; absent here; an empty :registrations app is still a valid app value.
+;; A module value (stage 6, `module`) is a composable app-value FRAGMENT — the
+;; same descriptor-grouped shape, plus a module id, the `:owns` ownership
+;; declarations, and the `:requires` capability set:
+;;
+;;   :rf.module/id  the module's id (stamped onto each descriptor's :owner).
+;;   :registrations the module's own descriptors grouped by kind.
+;;   :owns          the ownership declarations (`{:app-db [...] :routes [...]
+;;                  :resources [...] ...}`) — not merely documentation;
+;;                  composition surfaces them for tooling (overlap validation
+;;                  beyond same-(kind,id) collision is a later slice).
+;;   :requires      the module's `:rf.capability/*` requirements (empty set
+;;                  when none declared).
+;;   :source        the module's own source-coordinate envelope, when the
+;;                  caller supplies one (absent otherwise — issue 8: absence
+;;                  never changes behaviour).
+;;
+;; D3-RESERVED, never produced here: :diagnostics as a SUCCESS-path slot —
+;; composition reports collisions by THROWING (issue 7: data is the primitive,
+;; the ex-data IS the diagnostic), so a returned app value is always valid.
 
 ;; ---- the registration descriptor ------------------------------------------
 ;;
@@ -211,6 +254,282 @@
      {:rf.app/id     rid
       :registrations (registrations->descriptors snapshot)
       :requires      #{}})))
+
+;; ---- public construction + composition (EP-0013 D2 stage 6) ---------------
+;;
+;; The CONSTRUCTION half: build an app value as INERT data from explicit
+;; module descriptors, before any realm. `module` lowers a module-descriptor
+;; map into a module value (the same descriptor-grouped shape the projection
+;; produces, owner-stamped); `app` composes a vector of module values into an
+;; app value. Both are PURE — no realm, no registrar, no side effect (a
+;; `module` / `app` call is data, not registration — EP-0013 issue 10's
+;; "inert is load-bearing").
+;;
+;; The construction descriptor shape MATCHES the projection's (`descriptor`
+;; above), so a constructed app's `:registrations` and a projected app's are
+;; the SAME shape — one app-value vocabulary, two origins. The only addition
+;; is `:owner` (the module id), which the projection never carries (load-order
+;; registrations have no module). The module-section input shape is the EP's
+;; (`{:doc … :schema … :handler …}` per entry — a handler-and-metadata map),
+;; not the registrar's flat `:handler-fn` metadata, so construction has its
+;; own normalizer (`module-descriptor`) rather than reusing `descriptor`.
+
+(def ^:private module-section->kind
+  "The module-descriptor section keys (plural, per the EP module form) mapped
+  to their Spec 001 registry kind (singular). A `module` map carries its
+  registrations under these section keys (`:events {…}`, `:subs {…}`, …); each
+  section lowers to descriptors under the corresponding registry kind. The set
+  is the Spec 001 `registrar/kinds` taxonomy — adding a registry kind that a
+  module can carry is a one-row addition here (kept in lockstep with the
+  closed `registrar/kinds` set)."
+  {:events          :event
+   :subs            :sub
+   :fx              :fx
+   :cofx            :cofx
+   :views           :view
+   :frames          :frame
+   :routes          :route
+   :heads           :head
+   :error-projectors :error-projector
+   :flows           :flow
+   :resources       :resource
+   :mutations       :mutation
+   :resource-scopes :resource-scope})
+
+(def ^:private module-source-coord-keys
+  "Reserved top-level module keys that are NOT registration sections — lifted
+  out before the section scan so a module's own `:id` / `:owns` / `:requires`
+  / `:source` are never mistaken for a registration kind."
+  #{:id :owns :requires :source})
+
+(defn- module-descriptor
+  "Normalize one module registration entry into an app-value registration
+  descriptor (EP-0013 §Registration Descriptors), stamped with its owning
+  module id. Pure: a function of `kind`, `id`, the module id, and the entry
+  map only.
+
+  The entry map is the EP's module-form shape (`{:doc … :schema … :handler …
+  :source …}` — a handler-and-metadata map), NOT the registrar's flat
+  `:handler-fn` metadata. The handler is lifted out of `:handler`, the source
+  coords out of `:source` (an explicit envelope a non-macro/code-gen host may
+  supply — issue 8), and the rest of the entry kept under `:metadata` (with
+  the lifted slots removed so each fact is carried once). INTERNAL."
+  [kind id owner entry]
+  (let [source    (:source entry)
+        rest-meta (dissoc entry :handler :source)]
+    (cond-> {:kind  kind
+             :id    id
+             :owner owner}
+      (contains? entry :handler) (assoc :handler (:handler entry))
+      (seq source)               (assoc :source source)
+      (seq rest-meta)            (assoc :metadata rest-meta))))
+
+(defn module
+  "Construct a MODULE value — a composable app-value fragment (EP-0013 §Module
+  Values And Feature Ownership), as INERT data. PUBLIC (`rf/module`).
+
+  `descriptor-map` carries:
+
+    :id        the module id (required) — stamped onto every descriptor's
+               `:owner` so composition can name the colliding source.
+    :owns      ownership declarations (`{:app-db [[:cart]] :routes […]
+               :resources […] …}`) — the feature surfaces the module owns.
+               Carried through to the app value for tooling (overlap
+               validation beyond same-(kind,id) collision is a later slice).
+    :requires  the set of `:rf.capability/*` requirements (defaults to `#{}`).
+    :source    the module's own source-coordinate envelope, when the host
+               supplies one (optional — issue 8: absence never changes
+               behaviour).
+    <sections> registration sections keyed by the plural section name
+               (`:events {id entry} :subs {…} :routes {…} …`, per the EP
+               module form); each `entry` is a `{:doc … :schema … :handler …
+               :source …}` handler-and-metadata map. The section→kind map is
+               the Spec 001 registry taxonomy.
+
+  Returns a module value:
+
+    {:rf.module/id  <id>
+     :registrations {kind {id descriptor}}  ;; descriptors, :owner-stamped
+     :owns          <owns or {}>
+     :requires      <requires set>
+     :source        <source>}               ;; present only when supplied
+
+  PURE — no realm, no registrar, no side effect. Throws `:rf.error/invalid-module`
+  (an ex-info whose ex-data IS the diagnostic) when `:id` is missing — the one
+  construction-time precondition (issue 7: data is the primitive)."
+  [descriptor-map]
+  (let [id (:id descriptor-map)]
+    (when (nil? id)
+      (throw (ex-info "rf/module requires an :id"
+                      {:error/id :rf.error/invalid-module
+                       :descriptor descriptor-map
+                       :recovery :supply-a-module-id})))
+    (let [registrations
+          (reduce-kv
+            (fn [acc section entries]
+              (if-let [kind (module-section->kind section)]
+                (assoc acc kind
+                       (reduce-kv (fn [m eid entry]
+                                    (assoc m eid (module-descriptor kind eid id entry)))
+                                  {}
+                                  entries))
+                ;; A non-section, non-reserved top-level key is a malformed
+                ;; module — fail loudly rather than silently dropping it.
+                (if (contains? module-source-coord-keys section)
+                  acc
+                  (throw (ex-info (str "rf/module: unknown section key " section)
+                                  {:error/id :rf.error/invalid-module
+                                   :module id
+                                   :unknown-section section
+                                   :recovery :remove-or-correct-the-section-key})))))
+            {}
+            descriptor-map)]
+      (cond-> {:rf.module/id  id
+               :registrations registrations
+               :owns          (get descriptor-map :owns {})
+               :requires      (set (get descriptor-map :requires #{}))}
+        (seq (:source descriptor-map)) (assoc :source (:source descriptor-map))))))
+
+;; ---- composition: modules → an app value ----------------------------------
+;;
+;; Composition is DETERMINISTIC and ORDER-STABLE (EP-0013 §Composition): given
+;; the same module values it produces the same app value or the same ordered
+;; diagnostic, regardless of namespace load timing or how the modules were
+;; grouped. It MUST NOT silently use last-writer-wins for same-(kind,id)
+;; conflicts — a collision THROWS `:rf.error/app-composition-collision`,
+;; enumerating EVERY colliding source available (issue 7: the ex-data IS the
+;; validation result; the family is a boot-time-reachable install failure, so
+;; it routes through the EP-0008 promotion criterion at stage 7).
+;;
+;; The composition laws (EP-0013 §Composition + §Validation/Conformance) the
+;; tests pin: composing with an empty module is identity; grouping modules
+;; differently does not change the resulting app value; successful composition
+;; preserves every input descriptor exactly once; failed composition reports
+;; every colliding source.
+
+(defn- merge-module-registrations
+  "Fold one module's `:registrations` (`kind → id → descriptor`) into the
+  accumulating app registrations, detecting same-(kind,id) collisions. On a
+  collision throws `:rf.error/app-composition-collision` carrying BOTH the
+  already-present descriptor's owner+source and the incoming one's, so the
+  host can name every colliding source (EP-0013 §Composition). INTERNAL."
+  [acc module-regs]
+  (reduce-kv
+    (fn [acc kind id->desc]
+      (reduce-kv
+        (fn [acc id desc]
+          (if-let [existing (get-in acc [kind id])]
+            (throw (ex-info (str "app composition collision: two modules register "
+                                 kind " " id)
+                            {:error/id :rf.error/app-composition-collision
+                             :kind     kind
+                             :id       id
+                             :sources  [(cond-> {:module (:owner existing)}
+                                          (:source existing) (assoc :source (:source existing)))
+                                        (cond-> {:module (:owner desc)}
+                                          (:source desc) (assoc :source (:source desc)))]
+                             :recovery :rename-or-explicitly-replace}))
+            (assoc-in acc [kind id] desc)))
+        acc
+        id->desc))
+    acc
+    module-regs))
+
+(defn app
+  "Construct an APP value by composing module values (EP-0013 §App Values +
+  §Composition), as INERT data. PUBLIC (`rf/app`).
+
+  `app-map` carries:
+
+    :id      the app id (required) — the constructed app's `:rf.app/id`.
+    :modules a vector (or seq) of module values (from `module`). Defaults to
+             empty — an app of zero modules is a valid, empty app value.
+
+  Returns an app value:
+
+    {:rf.app/id     <id>
+     :modules       {module-id module}        ;; the composed modules by id
+     :registrations {kind {id descriptor}}    ;; every module's descriptors,
+                                               ;; collision-checked + owner-stamped
+     :requires      #{:rf.capability/* …}}     ;; union of module :requires
+
+  DETERMINISTIC + ORDER-STABLE: the same modules compose to the same app value
+  regardless of order, and a same-(kind,id) collision across modules THROWS
+  `:rf.error/app-composition-collision` (the ex-data names every colliding
+  source) rather than silently picking a winner — there is no last-writer-wins
+  (EP-0013 §Composition; issue 7). PURE — no realm, no registrar, no side
+  effect; an app value is inert until a stage-7 `install!` seats it.
+
+  Throws `:rf.error/invalid-app` when `:id` is missing, or when a `:modules`
+  entry is not a module value (a `module`-constructed map carrying
+  `:rf.module/id`)."
+  [app-map]
+  (let [id      (:id app-map)
+        modules (vec (get app-map :modules []))]
+    (when (nil? id)
+      (throw (ex-info "rf/app requires an :id"
+                      {:error/id :rf.error/invalid-app
+                       :app app-map
+                       :recovery :supply-an-app-id})))
+    (doseq [m modules]
+      (when-not (and (map? m) (contains? m :rf.module/id))
+        (throw (ex-info "rf/app :modules entries must be module values (from rf/module)"
+                        {:error/id :rf.error/invalid-app
+                         :app id
+                         :bad-module m
+                         :recovery :wrap-the-descriptor-in-rf-module}))))
+    {:rf.app/id     id
+     :modules       (into {} (map (juxt :rf.module/id identity)) modules)
+     :registrations (reduce (fn [acc m]
+                              (merge-module-registrations acc (:registrations m)))
+                            {}
+                            modules)
+     :requires      (reduce (fn [acc m] (into acc (:requires m)))
+                            #{}
+                            modules)}))
+
+;; ---- public inspection over an app value (EP-0013 §Examples) --------------
+;;
+;; The three inspectors the EP's "A Whole App As Data" example shows — read an
+;; app value WITHOUT installing it: enumerate its registrations by kind, find
+;; the module that owns an app-db path, read its capability requirements. Pure
+;; readers over the app-value data; no realm, no registrar. PUBLIC.
+
+(defn app-registrations
+  "Return the registration descriptors an app value carries for `kind`
+  (`kind → {id descriptor}` for that one kind), or `nil` when the app declares
+  none of that kind. The enumerable registration view that makes static
+  dispatch-coverage checks possible WITHOUT installing the app (EP-0013
+  §Validation/Conformance). PUBLIC (`rf/app-registrations`).
+
+  Works over both constructed apps (`app`) and projected apps (`app-value`) —
+  the `:registrations` shape is the same for both. Pure."
+  [app-value kind]
+  (get-in app-value [:registrations kind]))
+
+(defn app-requires
+  "Return the set of `:rf.capability/*` requirements an app value declares —
+  the union of its modules' `:requires` (EP-0013 §Capability Maps). The
+  explicit dependency surface a realm must satisfy before a stage-7 `install!`
+  succeeds. PUBLIC (`rf/app-requires`). Pure — returns `#{}` for a projected
+  app (load-order registrations declare no requirements)."
+  [app-value]
+  (get app-value :requires #{}))
+
+(defn app-owns
+  "Return the module id that owns app-db `path` in an app value, or `nil` when
+  no module declares it (EP-0013 §Module Values And Feature Ownership /
+  §Examples `(rf/app-owns app [:cart])`). PUBLIC (`rf/app-owns`).
+
+  Resolves against the modules' `:owns {:app-db [...]}` declarations: returns
+  the id of the module whose `:owns :app-db` vector contains exactly `path`.
+  Pure; returns `nil` for a projected app (no modules, hence no ownership
+  declarations)."
+  [app-value path]
+  (some (fn [[mid m]]
+          (when (some #(= % path) (get-in m [:owns :app-db]))
+            mid))
+        (:modules app-value)))
 
 ;; ---- the realm-side installed-app seam (the late-bind bridge) --------------
 ;;

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -74,16 +74,19 @@
             ;; here; the require exists so the hooks are bound at boot before
             ;; any runtime `reg-frame` call.
             [re-frame.frame-classification]
-            ;; EP-0013 D2 stage 5 (rf2-yozjzo): required for its ns-load
-            ;; side-effect only — it publishes the `:app-value/project`
+            ;; EP-0013 D2 stage 5 (rf2-yozjzo) + stage 6 (rf2-zlhgr6): the
+            ;; app-value ns. Stage 5 published the `:app-value/project`
             ;; late-bind hook `re-frame.realm/installed-app` consults to
-            ;; project the realm's installed app VALUE over its registrar.
-            ;; No symbols are referenced here; the require exists so the
-            ;; hook is bound at boot. INTERNAL — no public app constructor /
-            ;; installed-app surface ships in stage 5 (stages 6/7). The ns
-            ;; pulls only `re-frame.realm` + `re-frame.late-bind` (core
-            ;; spine), so it is bundle-isolation neutral.
-            [re-frame.app-value]
+            ;; project the realm's installed app VALUE over its registrar
+            ;; (an ns-load side-effect — bound at boot). Stage 6 adds the
+            ;; PUBLIC construction half (`module` / `app` + the inspectors
+            ;; `app-registrations` / `app-owns` / `app-requires`), re-exported
+            ;; below under `rf/module` / `rf/app` / `rf/app-*`. The ns pulls
+            ;; only `re-frame.realm` + `re-frame.late-bind` (core spine), so it
+            ;; is bundle-isolation neutral; construction is PURE inert data
+            ;; (no realm, no registrar). `rf/realm` + `rf/install!` (stage 7 —
+            ;; seating an app into a realm) are NOT shipped here.
+            [re-frame.app-value :as app-value]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.core-flows    :as rf-flows]
             [re-frame.core-routing  :as rf-routing]
@@ -1521,6 +1524,54 @@
        the tooling ns directly so production bundles DCE the body.
        Per Spec 002 §The public registrar query API."}
        sub-topology subs/sub-topology)))
+
+;; ---- app-value construction + composition (EP-0013 D2 stage 6) -----------
+;;
+;; The PUBLIC construction half of EP-0013 D2: build a program as an INERT app
+;; value from explicit feature modules, then inspect it BEFORE installing it
+;; into a realm. `module` / `app` are the reserved-vocabulary constructors
+;; (EP-0013 issue 1); `app-registrations` / `app-owns` / `app-requires` are
+;; the inspectors the EP's "A Whole App As Data" example shows. PURE — a
+;; `module` / `app` call has no registration side effect (it returns data, not
+;; a realm mutation); the ordinary `reg-*` sugar path is untouched. Seating an
+;; app value into a realm (`rf/install!`) is stage 7 (deferred).
+
+(def ^{:doc "Construct a MODULE value — a composable app-value fragment
+  (EP-0013 §Module Values). `(module {:id … :owns {…} :requires #{…} :events
+  {id entry} :subs {…} …})` lowers each registration section into descriptors
+  stamped with the module id, as INERT data (no realm, no registrar, no side
+  effect). The reserved-vocabulary `rf/module` constructor. Per spec/API.md
+  §App values and composition (EP-0013)."}
+  module app-value/module)
+
+(def ^{:doc "Construct an APP value by composing module values — `(app {:id …
+  :modules [m1 m2 …]})`. Composition is DETERMINISTIC + order-stable; a
+  same-(kind,id) collision across modules THROWS
+  `:rf.error/app-composition-collision` (the ex-data names every colliding
+  source) rather than last-writer-wins. INERT data — an app value is pure
+  until a stage-7 `install!` seats it. The reserved-vocabulary `rf/app`
+  constructor. Per spec/API.md §App values and composition (EP-0013)."}
+  app app-value/app)
+
+(def ^{:doc "Return an app value's registration descriptors for `kind`
+  (`{id descriptor}`), or `nil` — `(app-registrations app :event)`. The
+  enumerable registration view that makes static dispatch-coverage checks
+  possible WITHOUT installing the app. Works over both constructed and
+  projected app values. Per spec/API.md §App values and composition
+  (EP-0013)."}
+  app-registrations app-value/app-registrations)
+
+(def ^{:doc "Return the set of `:rf.capability/*` requirements an app value
+  declares — `(app-requires app)`, the union of its modules' `:requires`. The
+  explicit dependency surface a realm must satisfy before install. Per
+  spec/API.md §App values and composition (EP-0013)."}
+  app-requires app-value/app-requires)
+
+(def ^{:doc "Return the module id that owns app-db `path` in an app value, or
+  `nil` — `(app-owns app [:cart])`. Resolves against the modules' `:owns
+  {:app-db [...]}` ownership declarations. Per spec/API.md §App values and
+  composition (EP-0013)."}
+  app-owns app-value/app-owns)
 
 ;; ---- interceptors --------------------------------------------------------
 

--- a/implementation/core/test/re_frame/app_value_compose_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_compose_cljs_test.cljc
@@ -1,0 +1,296 @@
+(ns re-frame.app-value-compose-cljs-test
+  "EP-0013 D2 stage-6 — the PUBLIC app/module constructors + composition
+  algebra (rf2-zlhgr6, built on the merged stage-5 projection).
+
+  Stage 6 graduates the CONSTRUCTION half of the app value: build a program
+  as INERT data from explicit feature modules, then inspect it before any
+  realm. The public surface (re-exported from `re-frame.core` as `rf/module`
+  / `rf/app` / `rf/app-registrations` / `rf/app-owns` / `rf/app-requires`):
+
+    (1) `module` lowers a module-descriptor map into a module value — the
+        descriptor-grouped shape, owner-stamped, with `:owns` / `:requires`
+        / `:source` carried; PURE (no realm, no registrar);
+    (2) `app` composes module values into an app value — DETERMINISTIC +
+        order-stable, `:requires` unioned, `:modules` keyed by id;
+    (3) composition is STRICT — a same-(kind,id) collision across modules
+        THROWS `:rf.error/app-composition-collision` enumerating every
+        colliding source (never last-writer-wins);
+    (4) the composition LAWS (EP-0013 §Composition / §Validation): empty
+        module is identity; grouping order does not change the value; every
+        input descriptor is preserved exactly once;
+    (5) the inspectors (`app-registrations` / `app-requires` / `app-owns`)
+        read an app value WITHOUT installing it;
+    (6) construction is PURE — building a module/app touches no registrar
+        (the sugar path is unaffected), and the descriptor shape MATCHES the
+        stage-5 projection's (one app-value vocabulary, two origins).
+
+  Dual-runtime `*_cljs_test.cljc` — the shadow-cljs `:node-test` build
+  (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both pick it up.
+  Pure CLJC, no DOM."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.app-value :as av]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter}))
+
+;; Two handler stand-ins — value identity is what the descriptor must carry.
+(defn- cart-add  [db _] (update db :items (fnil conj []) :x))
+(defn- cart-items [db _] (:items db))
+(defn- auth-login [db _] (assoc db :user :alice))
+
+;; ---------------------------------------------------------------------------
+;; (1) module — lowers a descriptor map into a module value
+;; ---------------------------------------------------------------------------
+
+(deftest module-shape-and-owner-stamping
+  (testing "module lowers each registration section into descriptors stamped
+            with the module id as :owner, carries :owns / :requires, and is
+            keyed by the singular registry kind"
+    (let [m (rf/module
+              {:id :shop/cart
+               :owns {:app-db [[:cart]] :resources [:shop.cart/items]}
+               :requires #{:rf.capability/http}
+               :events {:cart/add {:doc "Add an item." :handler cart-add}}
+               :subs   {:cart/items {:doc "Cart items." :handler cart-items}}})]
+      (is (= :shop/cart (:rf.module/id m)) "the module carries its id")
+      (is (= {:app-db [[:cart]] :resources [:shop.cart/items]} (:owns m))
+          ":owns is carried through verbatim")
+      (is (= #{:rf.capability/http} (:requires m))
+          ":requires is carried as a set")
+      ;; sections lower to the SINGULAR registry kind (:events -> :event).
+      (let [d (get-in m [:registrations :event :cart/add])]
+        (is (= :event (:kind d)) "the section lowers to the singular kind")
+        (is (= :cart/add (:id d)))
+        (is (= :shop/cart (:owner d)) "the descriptor is owner-stamped")
+        (is (identical? cart-add (:handler d)) "the handler is lifted out of :handler")
+        (is (= "Add an item." (get-in d [:metadata :doc]))
+            "the rest of the entry is kept under :metadata")
+        (is (not (contains? (:metadata d) :handler))
+            ":handler is not double-carried in :metadata"))
+      (is (= :shop/cart (get-in m [:registrations :sub :cart/items :owner]))
+          "the :subs section lowers to :sub, owner-stamped"))))
+
+(deftest module-requires-defaults-empty
+  (testing "a module with no :requires gets #{}"
+    (let [m (rf/module {:id :m :events {:e {:handler cart-add}}})]
+      (is (= #{} (:requires m)))
+      (is (= {} (:owns m)) ":owns defaults to {}"))))
+
+(deftest module-lifts-explicit-source-coords
+  (testing "an entry's explicit :source envelope is lifted into the descriptor
+            and removed from :metadata (issue 8 — a non-macro/code-gen host may
+            supply coords); the module's own :source is carried top-level"
+    (let [src {:ns 'shop.cart.events :file "src/shop/cart/events.cljs" :line 22 :column 1}
+          msrc {:ns 'shop.cart :file "src/shop/cart.cljs" :line 12 :column 1}
+          m (rf/module
+              {:id :shop/cart
+               :source msrc
+               :events {:cart/add {:doc "Add." :handler cart-add :source src}}})
+          d (get-in m [:registrations :event :cart/add])]
+      (is (= src (:source d)) "the entry's :source is lifted into the descriptor")
+      (is (not (contains? (:metadata d) :source))
+          ":source is not double-carried in :metadata")
+      (is (= msrc (:source m)) "the module's own :source is carried top-level"))))
+
+(deftest module-rejects-missing-id-and-unknown-section
+  (testing "module throws :rf.error/invalid-module on a missing :id (the one
+            construction precondition) and on an unknown section key"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                 (rf/module {:events {:e {:handler cart-add}}}))
+        "missing :id throws")
+    (let [ed (try (rf/module {:id :m :bogus {:x {:handler cart-add}}})
+                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
+                    (ex-data e)))]
+      (is (= :rf.error/invalid-module (:error/id ed)))
+      (is (= :bogus (:unknown-section ed))
+          "the unknown section key is named in the diagnostic"))))
+
+;; ---------------------------------------------------------------------------
+;; (2) app — composes module values into an app value
+;; ---------------------------------------------------------------------------
+
+(deftest app-composes-modules
+  (testing "app composes module values: :registrations is the union of every
+            module's descriptors, :requires is the union of :requires, and
+            :modules is keyed by module id"
+    (let [auth (rf/module {:id :shop/auth
+                           :requires #{:rf.capability/http}
+                           :events {:auth/login {:handler auth-login}}})
+          cart (rf/module {:id :shop/cart
+                           :owns {:app-db [[:cart]]}
+                           :requires #{:rf.capability/schemas}
+                           :events {:cart/add {:handler cart-add}}
+                           :subs   {:cart/items {:handler cart-items}}})
+          a (rf/app {:id :shop/app :modules [auth cart]})]
+      (is (= :shop/app (:rf.app/id a)) "the app carries the declared id")
+      (is (= #{:shop/auth :shop/cart} (set (keys (:modules a))))
+          ":modules is keyed by module id")
+      (is (identical? auth-login (get-in a [:registrations :event :auth/login :handler]))
+          "auth's descriptor is composed in")
+      (is (identical? cart-add (get-in a [:registrations :event :cart/add :handler]))
+          "cart's descriptor is composed in")
+      (is (= #{:rf.capability/http :rf.capability/schemas} (:requires a))
+          ":requires is the union of the modules' requirements"))))
+
+(deftest app-of-zero-modules-is-valid-empty-app
+  (testing "an app of zero modules is a valid, empty app value"
+    (let [a (rf/app {:id :empty/app})]
+      (is (= :empty/app (:rf.app/id a)))
+      (is (= {} (:modules a)))
+      (is (= {} (:registrations a)))
+      (is (= #{} (:requires a))))))
+
+(deftest app-rejects-missing-id-and-non-module
+  (testing "app throws :rf.error/invalid-app on a missing :id or a :modules
+            entry that is not a module value"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                 (rf/app {:modules []}))
+        "missing :id throws")
+    (let [ed (try (rf/app {:id :a :modules [{:not :a-module}]})
+                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
+                    (ex-data e)))]
+      (is (= :rf.error/invalid-app (:error/id ed))
+          "a non-module :modules entry throws :rf.error/invalid-app"))))
+
+;; ---------------------------------------------------------------------------
+;; (3) composition is STRICT — collisions throw, naming every source
+;; ---------------------------------------------------------------------------
+
+(deftest app-composition-collision-throws-with-every-source
+  (testing "a same-(kind,id) collision across modules THROWS
+            :rf.error/app-composition-collision enumerating BOTH colliding
+            sources (never last-writer-wins) — EP-0013 §Composition"
+    (let [a-src {:ns 'a :file "a.cljs" :line 1 :column 1}
+          b-src {:ns 'b :file "b.cljs" :line 9 :column 1}
+          ma (rf/module {:id :a :events {:shared/save {:handler cart-add :source a-src}}})
+          mb (rf/module {:id :b :events {:shared/save {:handler auth-login :source b-src}}})
+          ed (try (rf/app {:id :bad/app :modules [ma mb]})
+                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
+                    (ex-data e)))]
+      (is (= :rf.error/app-composition-collision (:error/id ed)))
+      (is (= :event (:kind ed)))
+      (is (= :shared/save (:id ed)))
+      (is (= #{:a :b} (set (map :module (:sources ed))))
+          "both colliding module ids are reported")
+      (is (= #{a-src b-src} (set (map :source (:sources ed))))
+          "every available colliding source coordinate is reported")
+      (is (= :rename-or-explicitly-replace (:recovery ed))))))
+
+(deftest app-collision-is-cross-kind-safe
+  (testing "the SAME id under DIFFERENT kinds is NOT a collision — collision
+            is per-(kind,id)"
+    (let [ma (rf/module {:id :a :events {:shared/x {:handler cart-add}}})
+          mb (rf/module {:id :b :subs   {:shared/x {:handler cart-items}}})
+          a (rf/app {:id :ok/app :modules [ma mb]})]
+      (is (identical? cart-add   (get-in a [:registrations :event :shared/x :handler])))
+      (is (identical? cart-items (get-in a [:registrations :sub   :shared/x :handler]))
+          "same id, different kind — both compose without collision"))))
+
+;; ---------------------------------------------------------------------------
+;; (4) the composition LAWS (EP-0013 §Composition / §Validation/Conformance)
+;; ---------------------------------------------------------------------------
+
+(deftest law-empty-module-is-identity
+  (testing "composing with an empty module is identity — the app value equals
+            the app value composed without it"
+    (let [cart  (rf/module {:id :cart :events {:cart/add {:handler cart-add}}})
+          empty (rf/module {:id :empty})
+          with    (rf/app {:id :app :modules [cart empty]})
+          without (rf/app {:id :app :modules [cart]})]
+      (is (= (:registrations without) (:registrations with))
+          "an empty module contributes no registrations")
+      (is (= (:requires without) (:requires with))
+          "an empty module contributes no requirements"))))
+
+(deftest law-grouping-order-does-not-change-the-value
+  (testing "grouping modules in a different ORDER does not change the resulting
+            app value — composition is order-stable (EP-0013 §Composition)"
+    (let [auth (rf/module {:id :auth :requires #{:rf.capability/http}
+                           :events {:auth/login {:handler auth-login}}})
+          cart (rf/module {:id :cart :requires #{:rf.capability/schemas}
+                           :events {:cart/add {:handler cart-add}}})
+          a1 (rf/app {:id :app :modules [auth cart]})
+          a2 (rf/app {:id :app :modules [cart auth]})]
+      (is (= (:registrations a1) (:registrations a2))
+          "registrations are independent of module order")
+      (is (= (:requires a1) (:requires a2))
+          "requires are independent of module order")
+      (is (= a1 a2) "the whole app value is order-independent"))))
+
+(deftest law-every-input-descriptor-preserved-once
+  (testing "successful composition preserves every input descriptor exactly
+            once — the composed event set is the union of the modules' ids"
+    (let [auth (rf/module {:id :auth :events {:auth/login {:handler auth-login}}})
+          cart (rf/module {:id :cart :events {:cart/add {:handler cart-add}
+                                              :cart/clear {:handler cart-add}}})
+          a (rf/app {:id :app :modules [auth cart]})]
+      (is (= #{:auth/login :cart/add :cart/clear}
+             (set (keys (get-in a [:registrations :event]))))
+          "every input event descriptor is present, exactly once"))))
+
+;; ---------------------------------------------------------------------------
+;; (5) the inspectors — read an app value WITHOUT installing it
+;; ---------------------------------------------------------------------------
+
+(deftest inspectors-read-a-constructed-app
+  (testing "app-registrations / app-requires / app-owns read a constructed app
+            value without installing it (EP-0013 §Examples 'A Whole App As
+            Data')"
+    (let [cart (rf/module {:id :shop/cart
+                           :owns {:app-db [[:cart]]}
+                           :requires #{:rf.capability/http}
+                           :events {:cart/add {:handler cart-add}}})
+          a (rf/app {:id :shop/app :modules [cart]})]
+      (is (= #{:cart/add} (set (keys (rf/app-registrations a :event))))
+          "app-registrations enumerates the app's events by kind")
+      (is (nil? (rf/app-registrations a :route))
+          "app-registrations is nil for a kind the app declares none of")
+      (is (= #{:rf.capability/http} (rf/app-requires a))
+          "app-requires reads the capability dependency surface")
+      (is (= :shop/cart (rf/app-owns a [:cart]))
+          "app-owns resolves the module owning an app-db path")
+      (is (nil? (rf/app-owns a [:unowned]))
+          "app-owns is nil for an unowned path"))))
+
+;; ---------------------------------------------------------------------------
+;; (6) construction is PURE + the descriptor shape matches the projection
+;; ---------------------------------------------------------------------------
+
+(deftest construction-touches-no-registrar
+  (testing "building a module/app has NO registration side effect — the
+            registrar is untouched (the sugar path is unaffected; an app value
+            is inert data per EP-0013 issue 10)"
+    (is (nil? (registrar/lookup :event :cart/add))
+        "no :cart/add in the registrar before construction")
+    (let [m (rf/module {:id :cart :events {:cart/add {:handler cart-add}}})]
+      (rf/app {:id :app :modules [m]})
+      (is (nil? (registrar/lookup :event :cart/add))
+          "STILL no :cart/add in the registrar after module + app — construction
+           registered nothing"))))
+
+(deftest constructed-descriptor-shape-matches-projection
+  (testing "a constructed app's descriptor shape MATCHES the stage-5
+            projection's (one app-value vocabulary, two origins) — kind / id /
+            handler / metadata are the same keys, with the only addition being
+            :owner (which the projection never carries)"
+    (rf/reg-event-db :av/proj {:doc "projected"} cart-add)
+    (let [proj-d (get-in (av/app-value) [:registrations :event :av/proj])
+          cons-d (get-in (rf/app {:id :a :modules
+                                  [(rf/module {:id :m :events
+                                               {:av/cons {:doc "constructed"
+                                                          :handler cart-add}}})]})
+                         [:registrations :event :av/cons])]
+      ;; Same descriptor keys, modulo the construction-only :owner.
+      (is (= #{:kind :id :handler :metadata}
+             (disj (set (keys cons-d)) :owner))
+          "the constructed descriptor carries the projection's keys (+ :owner)")
+      (is (= :event (:kind proj-d) (:kind cons-d)) "both carry :kind")
+      (is (= :m (:owner cons-d)) "only the constructed descriptor carries :owner")
+      (is (not (contains? proj-d :owner))
+          "the projected descriptor carries no :owner (load-order has no module)"))))

--- a/spec/API.md
+++ b/spec/API.md
@@ -505,6 +505,20 @@ Schema-introspection accessors — `app-schemas`, `app-schema-at`, `app-schemas-
 
 ---
 
+## App values and composition (EP-0013)
+
+> **The program is a value.** `module` lowers a feature's registrations + ownership + capability requirements into an immutable, composable **module value**; `app` composes module values into an immutable **app value** — the description of a program that can be inspected (and, at a later stage, installed into a realm) *before* anything is registered. Both are **pure**: a `module` / `app` call has no registration side effect — it returns inert data, leaving the ordinary `reg-*` sugar path untouched. These are the reserved-vocabulary constructors ruled in [EP-0013](../docs/EP/EP-0013-app-values-and-runtime-realms.md) issue 1; **install / reinstall (seating an app value into a runtime realm) is a later stage and not yet shipped.**
+
+| API | M/Fn | Signature | Status | Tier | JVM-runnable? | Spec |
+|---|---|---|---|---|---|---|
+| `module` | Fn | `(module {:id … :owns {:app-db [[:cart]] …} :requires #{:rf.capability/http} :events {id entry} :subs {…} …})` → a **module value** `{:rf.module/id … :registrations {kind {id descriptor}} :owns … :requires …}`. Each registration section (`:events` / `:subs` / `:routes` / …, plural per the EP form) lowers to descriptors stamped with the module id as `:owner`. INERT data — no realm, no registrar. Throws `:rf.error/invalid-module` on a missing `:id` or an unknown section key. | v1 | advanced | ✓ | Runtime-Subsystems |
+| `app` | Fn | `(app {:id … :modules [m1 m2 …]})` → an **app value** `{:rf.app/id … :modules {…} :registrations {kind {id descriptor}} :requires #{…}}`. Composition is **deterministic + order-stable**; a same-`(kind,id)` collision across modules **throws** `:rf.error/app-composition-collision` (the ex-data names every colliding source) — never last-writer-wins. Throws `:rf.error/invalid-app` on a missing `:id` or a non-module `:modules` entry. INERT data — an app value is pure until a later-stage install seats it. | v1 | advanced | ✓ | Runtime-Subsystems |
+| `app-registrations` | Fn | `(app-registrations app kind)` → the app value's `{id descriptor}` for that `kind`, or `nil`. The enumerable registration view for static dispatch-coverage checks WITHOUT installing the app. Works over both constructed (`app`) and projected app values. | v1 | advanced | ✓ | Runtime-Subsystems |
+| `app-requires` | Fn | `(app-requires app)` → the set of `:rf.capability/*` requirements (the union of the modules' `:requires`) — the dependency surface a realm must satisfy before install. | v1 | advanced | ✓ | Runtime-Subsystems |
+| `app-owns` | Fn | `(app-owns app [:cart])` → the module id owning that app-db path, or `nil`. Resolves against the modules' `:owns {:app-db [...]}` declarations. | v1 | advanced | ✓ | Runtime-Subsystems |
+
+---
+
 ## Schemas
 
 > **Namespace:** the introspection surfaces below live in `re-frame.schemas` (artefact `day8/re-frame2-schemas`); consumers `(:require [re-frame.schemas :as schemas])`. They are not re-exported from `re-frame.core` — apps targeting schemas add the artefact and require the namespace directly. The registration macros (`reg-app-schema` / `reg-app-schemas`) live in `re-frame.core` and route through the schemas artefact at registration time. Per the §Conventions per-artefact namespace table.

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -428,6 +428,17 @@
   ["re-frame.core" "current-adapter"]      {:tier :advanced :owner "006" :status "v1"}
   ["re-frame.core" "current-adapter-spec"] {:tier :advanced :owner "006" :status "v1"}
   ["re-frame.core" "configure!"]           {:tier :front-porch :owner "Conventions" :status "v1"}
+  ;; EP-0013 D2 stage 6 (rf2-zlhgr6): the PUBLIC app/module constructors +
+  ;; composition algebra (the reserved-vocabulary `rf/app` / `rf/module` per
+  ;; EP-0013 issue 1) + the three inspectors. `advanced` tier — the surface
+  ;; large-SPA code uses to compose a program as a value before install; not
+  ;; a day-one front-porch surface. Owner: Runtime-Subsystems (the EP-0013
+  ;; realm/app-value contract home). install!/reinstall! (stage 7) deferred.
+  ["re-frame.core" "module"]               {:tier :advanced :owner "Runtime-Subsystems" :status "v1"}
+  ["re-frame.core" "app"]                  {:tier :advanced :owner "Runtime-Subsystems" :status "v1"}
+  ["re-frame.core" "app-registrations"]    {:tier :advanced :owner "Runtime-Subsystems" :status "v1"}
+  ["re-frame.core" "app-requires"]         {:tier :advanced :owner "Runtime-Subsystems" :status "v1"}
+  ["re-frame.core" "app-owns"]             {:tier :advanced :owner "Runtime-Subsystems" :status "v1"}
   ;; Feature registry (optional-artefact presence checks).
   ["re-frame.core" "feature-loaded?"]      {:tier :advanced :owner "Conventions" :status "v1"}
   ["re-frame.core" "features"]             {:tier :advanced :owner "Conventions" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 505,
+ :var-count 510,
  :tier-vocab
  [:front-porch
   :advanced
@@ -73,7 +73,11 @@
   {:namespace "re-frame.core", :var "->interceptor*", :tier :advanced, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "active-head", :tier :advanced, :kind :fn, :owner "011", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "adapter-disposed?", :tier :advanced, :kind :fn, :owner "006", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "app", :tier :advanced, :kind :fn, :owner "Runtime-Subsystems", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "app-db-value", :tier :advanced, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "app-owns", :tier :advanced, :kind :fn, :owner "Runtime-Subsystems", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "app-registrations", :tier :advanced, :kind :fn, :owner "Runtime-Subsystems", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "app-requires", :tier :advanced, :kind :fn, :owner "Runtime-Subsystems", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "app-schema-at", :tier :tooling, :kind :fn, :owner "010", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "app-schema-meta-at", :tier :tooling, :kind :fn, :owner "010", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "app-schemas", :tier :tooling, :kind :fn, :owner "010", :status "v1", :facade? true, :runtime-verified? true}
@@ -144,6 +148,7 @@
   {:namespace "re-frame.core", :var "make-frame-handle", :tier :advanced, :kind :fn, :owner "002", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "make-machine-handler", :tier :advanced, :kind :fn, :owner "005", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "match-url", :tier :advanced, :kind :fn, :owner "012", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "module", :tier :advanced, :kind :fn, :owner "Runtime-Subsystems", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "mutation-meta", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "mutation-state", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "mutations", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? true, :runtime-verified? true}


### PR DESCRIPTION
## What

EP-0013 action-wave D2 **stage 6** (per epic rf2-c6armm + `docs/EP/EP-0013` §D2 + §Public API Staging stage 6, bead rf2-zlhgr6): the **PUBLIC** app/module constructors + the composition algebra. Builds on the merged stage-5 internal app-value projection (`re-frame.app-value`).

> The program is a value; the runtime is a container you install it into.

This is the **construction** half of D2: build a program as an **inert** app value from explicit feature modules, then inspect it *before* installing it into a realm. `install!` / `reinstall!` (seating an app value into a realm — stage 7) is **deferred**.

## The constructor / composition surface

In `re-frame.app-value` (the canonical app-value home), re-exported from `re-frame.core`:

- **`module`** (`rf/module`) — lowers a module-descriptor map (the EP's `{:id … :owns {…} :requires #{…} :events {id entry} :subs {…} …}` form) into a **module value**: registrations grouped by the singular registry kind, each descriptor stamped with the module id as `:owner`, with `:owns` / `:requires` / `:source` carried. **PURE** — no realm, no registrar, no side effect (EP-0013 issue 10's "inert is load-bearing").
- **`app`** (`rf/app`) — composes module values into an **app value**. **Deterministic + order-stable**; `:requires` unioned; `:modules` keyed by id. A same-`(kind,id)` collision across modules **throws** `:rf.error/app-composition-collision` enumerating *every* colliding source — never last-writer-wins (issue 7: the ex-data IS the diagnostic).
- **`app-registrations`** / **`app-requires`** / **`app-owns`** (`rf/app-*`) — the EP's "A Whole App As Data" inspectors; read an app value without installing it.

The construction descriptor shape **matches** the stage-5 projection's, so a constructed app's `:registrations` and a projected app's are one vocabulary with two origins (the only addition is `:owner`). The projection seam is untouched.

## New facade exports (classified at diff-time)

Per the standing facade-export rule, each new `re-frame.core` export is classified + justified:

| Export | Tier | Owner | Note |
|---|---|---|---|
| `rf/module` | advanced | Runtime-Subsystems | reserved-vocab constructor (EP-0013 issue 1) |
| `rf/app` | advanced | Runtime-Subsystems | reserved-vocab constructor (EP-0013 issue 1) |
| `rf/app-registrations` | advanced | Runtime-Subsystems | inspector |
| `rf/app-requires` | advanced | Runtime-Subsystems | inspector |
| `rf/app-owns` | advanced | Runtime-Subsystems | inspector |

`api-manifest` regenerated: **505 → 510** vars. `spec/API.md` gains a new §App values and composition (EP-0013) table. `rf/realm` + `rf/install!` (stage 7) are **not** shipped.

## Deferred (stage 7)

`install!` / `reinstall!` — seating a constructed app value into a runtime realm, deriving its registrar, checking capability requirements, modeling hot-reload as a diff. The realm `:app` slot + the stage-5 `installed-app` seam already reserve the read contract; stage 6 ships only construction.

## Quality gates

- `npm run test:cljs` — **green** (6718 tests / 27034 assertions, 0 failures)
- core `clojure -M:test` — **green** (1261 tests / 5558 assertions, 0 failures)
- `npm run test:bundle-isolation` — **green** (app-value is bundle-isolation neutral; pure inert-data construction, no new sentinels)
- api-manifest `gen --check` — **green** (510 vars in sync)
- `api-md-check` — **green** (205 var-rows checked)
- story-spec / xray-spec / skills / doc-guide projection checks — **green**
- `mkdocs build --strict` — **green** (exit 0, no warnings)

bead: rf2-zlhgr6 · epic: rf2-c6armm
