### PR TITLE
docs(comments): EP-0015 egress-policy comment pass (rf2-d85cm9)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1707,11 +1707,12 @@
   Returns nil. Per Spec 009 §Error observability."}
   unregister-error-listener! error-emit/unregister-error-listener!)
 
-(def ^{:doc "Walk `v` and substitute schema-declared sensitive or large
-  paths for wire egress. Sensitive wins over large when both
-  declarations match. Sensitive paths become `:rf/redacted`; large paths
-  become `:rf.size/large-elided`. Per Spec 009 §Wire elision and
-  Security.md §Off-box egress."}
+(def ^{:doc "Walk `v` and substitute the frame's declared sensitive or
+  large paths for wire egress (the durable declarations are frame-owned —
+  installed by `reg-frame` `:sensitive` / `:large {:app-db …}`, EP-0015 §8).
+  Sensitive wins over large when both declarations match. Sensitive paths
+  become `:rf/redacted`; large paths become `:rf.size/large-elided`. Per
+  Spec 009 §Wire elision and Security.md §Off-box egress."}
   elide-wire-value                 elision/elide-wire-value)
 
 (def ^{:doc "Project a record or value for egress across a trust boundary

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -40,8 +40,9 @@
 ;;
 ;;   explicit `:rf.size/threshold-bytes` opt  >  `(rf/configure! :elision …)`  >  default
 ;;
-;; A threshold of 0 disables runtime auto-detect entirely (only declared /
-;; schema-marked entries elide); the unschema'd-large warning never fires.
+;; A threshold of 0 disables runtime auto-detect entirely (only
+;; frame-declared `:large` entries elide); the unschema'd-large warning
+;; never fires.
 ;; The default mirrors the documented `{:rf.size/threshold-bytes 16384}`.
 
 (def ^:private default-threshold-bytes 16384)
@@ -55,7 +56,7 @@
   "Update the elision configuration. Supports
   `{:rf.size/threshold-bytes N}` — a non-negative integer runtime
   auto-detect size threshold for the `:rf.warning/large-value-unschema'd`
-  advisory (0 disables runtime auto-detect; only declared / schema-marked
+  advisory (0 disables runtime auto-detect; only frame-declared `:large`
   entries elide). Per API.md §Configure keys (`:elision`) and Spec 009
   §Size elision in traces. Routed from `re-frame.core/configure!`."
   [opts]
@@ -542,8 +543,11 @@
     (walk v seed-path #{seed-path} ctx)))
 
 (defn elide-wire-value
-  "Walk `v` and substitute schema-declared sensitive or large paths for
-  wire egress. Sensitive wins over large when both declarations match.
+  "Walk `v` and substitute the frame's declared sensitive or large paths for
+  wire egress (the durable declarations live in `[:rf.runtime/elision …]`,
+  installed frame-owned by `re-frame.frame-classification` under
+  `:source :frame` — EP-0015 §8; the schema→app-db-egress route is gone).
+  Sensitive wins over large when both declarations match.
 
   EP-0002 (rf2-gjq3ow) — the wire-egress frame resolves from the CARRIED
   stamp: the explicit `:frame` opt (*override*) wins, else the in-effect

--- a/implementation/core/src/re_frame/frame_classification.cljc
+++ b/implementation/core/src/re_frame/frame_classification.cljc
@@ -34,13 +34,15 @@
     values (EP-0012). They are INSTALLED into the frame's durable elision
     registry (`[:rf.runtime/elision :sensitive-declarations]` /
     `[:rf.runtime/elision :declarations]`, Conventions §Reserved runtime-db
-    keys) under `:source :frame`, ALONGSIDE the schema-sourced
-    (`:source :schema`) and the imperative-mark-sourced (`:source :marks`)
-    declarations. The three sources union at lookup time exactly as Spec
-    015 §Relationship with schema-attached marks describes — a path
-    declared by ANY source is classified. Re-registering a frame REPLACES
-    the `:source :frame` entries (the declaration IS the frame's policy);
-    schema- and marks-sourced entries survive untouched.
+    keys) under `:source :frame` — the canonical durable app-db egress
+    route post-EP-0015 §8 (the `reg-app-schema` schema→app-db-egress route
+    is GONE; schemas describe shape, not durable app-db egress policy). The
+    only other source that can live in this registry is the demoted
+    imperative-mark route (`:source :marks` — internal / test /
+    generated-code only, no longer public). A path declared by ANY source
+    is classified: the sources union at lookup time. Re-registering a frame
+    REPLACES the `:source :frame` entries (the declaration IS the frame's
+    policy); any `:source :marks` entries survive untouched.
 
   - **`:sensitive :http :headers` / `:query-params`** are frame-local
     EXTENSIONS to the immutable built-in HTTP carrier denylist (Spec 014
@@ -369,17 +371,19 @@
 
 ;; ---- install into the durable elision registry --------------------------
 ;;
-;; Frame-owned app-db classification installs ALONGSIDE schema- and
-;; marks-sourced declarations in `[:rf.runtime/elision …]`, tagged
-;; `:source :frame`. The three sources union at lookup time (Spec 015
-;; §Relationship with schema-attached marks). Re-registration REPLACES the
-;; `:source :frame` entries; the other sources survive (matching how
-;; `re-frame.elision/install-schema-declarations!` replaces only
-;; `:source :schema` entries).
+;; Frame-owned app-db classification installs into `[:rf.runtime/elision …]`
+;; tagged `:source :frame`. Re-registration REPLACES only the `:source :frame`
+;; entries; any `:source :marks` entries (the demoted imperative-mark route —
+;; `re-frame.marks`, internal / test only) survive untouched, and the sources
+;; union at lookup time. The schema→app-db-egress route is GONE (EP-0015 §8 —
+;; no `:source :schema` installer feeds this registry; schemas describe shape,
+;; not durable app-db egress policy). This mirrors how `re-frame.marks/set-marks`
+;; replaces only its own `:source :marks` entries.
 
 (defn- without-frame-sourced
   "Drop `:source :frame` entries from a `{path decl}` declaration map,
-  preserving schema- and marks-sourced entries. Returns `{}` for nil."
+  preserving any other-sourced entries (the demoted `:source :marks` route).
+  Returns `{}` for nil."
   [decls]
   (reduce-kv (fn [acc p decl]
                (if (= :frame (:source decl))

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -25,14 +25,18 @@
   tables at boot (constant memory), but emit-time projection is gated
   and constant-folds out of CLJS production bundles via `goog.DEBUG`.
 
-  Per Spec 015 §Relationship with schema-attached marks: this
-  namespace writes into the SAME registry slot the schema-first
-  elision walker reads from
+  This namespace writes into the SAME durable elision registry slot the
+  frame-owned classification installs into
   (`[:rf.runtime/elision :sensitive-declarations]` and
   `[:rf.runtime/elision :declarations]` in the frame's runtime-db
-  partition — EP-0001 rf2-vzld77), keyed by absolute path. The
-  two declaration sources union at lookup time — a path declared
-  sensitive by EITHER source is sensitive."
+  partition — EP-0001 rf2-vzld77), keyed by absolute path, tagged
+  `:source :marks`. The frame-owned (`:source :frame`, EP-0015 §3) and
+  marks-sourced declarations union at lookup time — a path declared
+  sensitive by EITHER source is sensitive. (`add-marks` / `set-marks`
+  are DEMOTED off the public façade — EP-0015 §3, rf2-mngp4o — and remain
+  as internal / test / generated-code helpers; durable app-db
+  classification is authored on the frame. The former
+  schema→app-db-egress route is gone post-EP-0015 §8.)"
   (:require [re-frame.elision :as elision]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -61,10 +65,11 @@
 ;;
 ;; Schema-derived machine marks live in a SEPARATE per-machine-id table from
 ;; the author-sourced `kind->id->marks` `:event` entry, and `marks-for :event
-;; <id>` UNIONS the two at READ time. This is the SAME architecture app-db
-;; marks already use: a schema-sourced declaration (`:source :schema`) lives
-;; ALONGSIDE the `:marks`-sourced ones in the elision registry, unioned at
-;; lookup. Bringing it to machine marks makes the schema-vs-author union
+;; <id>` UNIONS the two at READ time. This is the SAME multi-source-union
+;; architecture the app-db elision registry uses: differently-sourced
+;; declarations (`:source :frame` from `reg-frame`, `:source :marks` from the
+;; demoted imperative route) live ALONGSIDE each other in the registry,
+;; unioned at lookup. Bringing it to machine marks makes the schema-vs-author union
 ;; truly ORDER-INDEPENDENT (rf2-qpibk0): a `register-marks!` (or a bare-meta
 ;; re-registration) on the `:event` entry REPLACES that entry in full
 ;; (matching the registrar slot semantics every other reg-* site relies on),
@@ -409,16 +414,18 @@
 ;;   survive). Author-facing repeat-call semantics: declarative.
 ;;
 ;; Both honour last-write-wins semantics when called against the same
-;; frame and overlap with each other. Schema-sourced entries (carrying
-;; `:source :schema`) are always preserved — they are not owned by
-;; this namespace and live alongside per Spec 015 §Relationship with
-;; schema-attached marks.
+;; frame and overlap with each other. Differently-sourced entries are
+;; always preserved — frame-owned classification (`:source :frame` from
+;; `reg-frame`, EP-0015 §3) is not owned by this namespace and lives
+;; alongside the `:source :marks` entries, unioned at lookup. (The former
+;; schema→app-db-egress route — `:source :schema` — is gone post-EP-0015 §8;
+;; schemas describe shape, not durable app-db egress policy.)
 
 (defn- without-marks-sourced
   "Drop entries whose `:source` is `:marks` from a declaration map.
   Used by `set-marks` to clear the prior `add-marks` / `set-marks`
-  contributions before overlaying the new ones — schema-sourced
-  entries survive."
+  contributions before overlaying the new ones — frame-sourced
+  (`:source :frame`) entries survive."
   [decls]
   (when decls
     (reduce-kv (fn [acc path decl]
@@ -473,12 +480,12 @@
   `:sensitive` / `:large` classification is the public authoring surface;
   this is an internal / test / generated-code helper.
 
-  Schema-attached marks (via `reg-app-schema` with `:sensitive?` /
-  `:large?` slot metadata) are preserved — the two declaration sources
-  union at lookup time per Spec 015 §Relationship with schema-attached
-  marks. Use `set-marks` for replace-semantics, or call `add-marks`
-  with a path mapped to a different mark to last-write-wins overwrite
-  that path's mark."
+  Frame-owned declarations (`reg-frame` `:sensitive` / `:large {:app-db …}`,
+  `:source :frame`) are preserved — the two declaration sources union at
+  lookup time. (The former schema→app-db-egress route is gone post-EP-0015
+  §8; schemas describe shape, not durable app-db egress policy.) Use
+  `set-marks` for replace-semantics, or call `add-marks` with a path mapped
+  to a different mark to last-write-wins overwrite that path's mark."
   [frame-id path->mark]
   (let [[sens-paths large-paths] (split-by-mark path->mark)]
     (elision/swap-elision-slot! frame-id
@@ -515,17 +522,17 @@
   `:sensitive` / `:large` classification is the public authoring surface;
   this is an internal / test / generated-code helper.
 
-  Schema-attached marks (via `reg-app-schema` with `:sensitive?` /
-  `:large?` slot metadata) are preserved — only the `:source :marks`
-  entries are dropped. The two declaration sources union at lookup
-  time per Spec 015 §Relationship with schema-attached marks.
+  Frame-owned declarations (`reg-frame` `:sensitive` / `:large {:app-db …}`,
+  `:source :frame`) are preserved — only the `:source :marks` entries are
+  dropped. The two declaration sources union at lookup time. (The former
+  schema→app-db-egress route is gone post-EP-0015 §8.)
 
   Use `add-marks` for additive-merge semantics."
   [frame-id path->mark]
   (let [[sens-paths large-paths] (split-by-mark path->mark)]
     (elision/swap-elision-slot! frame-id
       (fn [reg]
-        ;; Drop prior :marks-sourced entries first (schema-sourced survive),
+        ;; Drop prior :marks-sourced entries first (frame-sourced survive),
         ;; then assoc the new paths.
         (let [carry-s (without-marks-sourced (get reg :sensitive-declarations))
               carry-l (without-marks-sourced (get reg :declarations))
@@ -540,8 +547,8 @@
 
 (defn clear-app-db-marks!
   "Drop every `add-marks` / `set-marks`-sourced declaration for
-  `frame-id`. Schema-sourced declarations are preserved. Returns nil.
-  Test-isolation only; production code rarely needs this."
+  `frame-id`. Frame-sourced (`:source :frame`) declarations are preserved.
+  Returns nil. Test-isolation only; production code rarely needs this."
   [frame-id]
   (elision/swap-elision-slot! frame-id
     (fn [reg]

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -107,11 +107,13 @@
                         record: post-EP-0010 epoch records are causal replay
                         material, and mutating them at rest would corrupt the
                         replay contract. The fn is the rare advanced escape
-                        for an app that records material the schema-driven
-                        projection cannot prove (a non-schema-declared
-                        sensitive slot); ordinary redaction needs only the
-                        frame's `:sensitive?` / `:large?` classification,
-                        which `projected-record` already applies. A throwing
+                        for an app that records material the declaration-driven
+                        projection cannot prove (a sensitive slot no frame /
+                        schema declaration covers); ordinary redaction needs
+                        only the frame's `:sensitive` / `:large` classification
+                        (EP-0015 §3) plus the per-slot schema props machine /
+                        resource data carry, which `projected-record` already
+                        applies. A throwing
                         fn emits `:rf.warning/epoch-redact-fn-exception` and
                         falls back to the projected (frame/profile-redacted)
                         record. Passing `nil` clears any previously-installed

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -132,10 +132,11 @@
   record so on-box devtools (Xray diff, REPL, `restore-epoch`) reason
   about exact state.
 
-  The fn is the rare advanced escape for material the schema-driven
-  projection cannot prove (a non-schema-declared sensitive slot); the
-  ordinary case needs only the frame's `:sensitive?` / `:large?`
-  classification, which `project-egress` already applies. Because it runs
+  The fn is the rare advanced escape for material the declaration-driven
+  projection cannot prove (a sensitive slot no frame / schema declaration
+  covers); the ordinary case needs only the frame's `:sensitive` / `:large`
+  classification (EP-0015 §3) plus the per-slot schema props machine /
+  resource data carry, which `project-egress` already applies. Because it runs
   on the projected egress COPY (the off-box record), it cannot affect
   `restore-epoch` fidelity — that hazard the §15 'may affect restore
   fidelity' warning flagged is gone by construction.

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -870,7 +870,8 @@
 ;; RULED). After the frame/profile projection lands, `projected-record`
 ;; applies the installed `:redact-fn` (`assembly/apply-redact-fn`) to the
 ;; PROJECTED record — the rare advanced escape for material the
-;; schema-driven projection cannot prove. It runs ONLY here, on the off-box
+;; declaration-driven projection cannot prove (a slot no frame / schema
+;; declaration covers). It runs ONLY here, on the off-box
 ;; egress copy; the ring stays raw, so it can never affect `restore-epoch`
 ;; fidelity (the §15 hazard is gone by construction).
 ;;
@@ -892,8 +893,9 @@
   off-box safe path) and, when a trusted-local caller opts them back in,
   compose on top as explicit `:rf.size/*` overrides (the override wins —
   see `re-frame.projection/resolve-elision-opts`). The record frame is
-  stamped so schema-declared sensitive / large paths (keyed by absolute
-  app-db path) match the projected value."
+  stamped so the frame's declared sensitive / large paths (keyed by absolute
+  app-db path, installed frame-owned per EP-0015 §3) match the projected
+  value."
   [frame-id {:keys [include-sensitive? include-large?]}]
   {:rf.egress/profile          egress-profile
    :frame                      frame-id

--- a/implementation/http/src/re_frame/http_privacy_body.cljc
+++ b/implementation/http/src/re_frame/http_privacy_body.cljc
@@ -25,7 +25,7 @@
 
   2. **Whole-body root prop.** A root-level (`[]`) `:sensitive?` prop on the
      `:decode` schema (e.g. an opaque-token response whose WHOLE body is the
-     secret) redacts the whole body. `:large?` at the root omits it.
+     secret) redacts the whole body.
 
   3. **Unschematized is whole-sensitive (fail-closed).** A managed request
      with NO Malli-schema `:decode` (`:auto` / `:json` / `:text` / a custom
@@ -50,9 +50,21 @@
   The existing per-call / per-request `:sensitive?` flag (Spec 014 §Privacy)
   is the COARSE escape hatch: it redacts the whole body wholesale regardless
   of schema marks. This namespace is the FINE-grained, schema-driven layer
-  that fires INDEPENDENTLY of that flag. Sensitive wins over large, matching
-  the shared `re-frame.elision/walk` ordering and the frame-classification
-  install-time rule.
+  that fires INDEPENDENTLY of that flag.
+
+  ## Scope — sensitive marks only (`:large?` not yet applied)
+
+  `classify-decoded` applies only the `:decode` schema's `:sensitive?`
+  per-slot marks (via `re-frame.privacy/redact-paths`). The `:large?` axis
+  is EXTRACTED here (`decode-schema-marks` returns both `:sensitive` and
+  `:large` path maps) for the shared-walker symmetry with the resource /
+  app-schema surfaces, but no per-slot `:large?` body elision is wired yet —
+  the response body never rides the `elide-wire-value` walker that would
+  apply it, so there is no large-body marker emit and no sensitive-wins-over-
+  large precedence exercised on this path. Large-body classification is a
+  follow-up (rf2-jhyccs). When it lands it will
+  route through the shared walker, where sensitive already wins over large
+  (the `re-frame.elision/walk` ordering).
 
   ## Production elision
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -313,7 +313,8 @@
     (raw trace events) — are tree-shaped values rooted at the frame's
     app-db, so the size-elision walker
     `re-frame.core/elide-wire-value` is the correct primitive: it
-    redacts schema-declared-sensitive slots and elides large slots.
+    redacts the frame's declared-sensitive slots and elides large slots
+    (the declarations are frame-owned, EP-0015 §3/§8).
 
   - **The `:epoch` topic's `:events`** carry whole `:rf/epoch-record`s
     (`:db-before` / `:db-after` / `:trigger-event` / `:trace-events`


### PR DESCRIPTION
Wave-end **code-comments** review of the merged EP-0015 (frame-owned egress policy) work, per rf2-d85cm9. Reviews the prose **in** the code (comments + docstrings) for completeness + accuracy — complements the testing-coverage + correctness review tails. **Comment/docstring-only edits; no code logic changed** (the only `(def` lines in the diff are docstring text on `elide-wire-value`).

## Findings + fixes

The dominant inaccuracy was a **stale schema-marker-era spelling**: EP-0015 §8 removed the schema→app-db-egress route (`reg-app-schema` `:sensitive?`/`:large?` props no longer populate the `[:rf.runtime/elision …]` registry), so durable app-db classification is now **frame-owned** (`:source :frame`). Many comments still called those registry paths "schema-declared" / "schema-sourced" and claimed schema entries "are preserved" / "union at lookup". Fixed in the EP-0015-diff-scope files I own:

- `elide-wire-value` docstrings (`elision.cljc` + `core.cljc` facade) — "schema-declared" → the frame's declared paths.
- `elision.cljc` threshold comments — "declared / schema-marked" → frame-declared `:large` entries (x2).
- `marks.cljc` — the "schema-sourced entries preserved" / "§Relationship with schema-attached marks" cluster across the ns docstring, `add-marks`/`set-marks`/`clear-app-db-marks!` docstrings, `without-marks-sourced`, and the App-db marks block → frame-sourced (`:source :frame`).
- `frame_classification.cljc` — ns docstring item + install comment; **removed a dangling reference to the nonexistent `re-frame.elision/install-schema-declarations!`**.
- epoch redact-fn-escape phrasing (`epoch.cljc`, `epoch/assembly.cljc`, `epoch/tool_pair.cljc`) — "non-schema-declared" + the **wrong frame `:sensitive?`/`:large?` spelling** (frame classification is `:sensitive`/`:large`, no `?`) → frame `:sensitive`/`:large` + declaration-driven.
- `subscribe.cljs` — "schema-declared-sensitive" → the frame's declared-sensitive.

`http_privacy_body.cljc` had a **substantive comment/code mismatch**: the ns docstring claimed "sensitive wins over large" and rule 2 claimed "`:large?` at the root omits it", but `classify-decoded` applies **only** the `:sensitive?` marks (via `redact-paths`); the `:large?` axis is extracted by `decode-schema-marks` but **never consumed** — no large-body elision is wired. Dropped the false claims and added a Scope section recording the actual sensitive-only behaviour + pointing to the follow-up.

The reviewed files were otherwise well-documented and accurate (`projection.cljc`, `resources/classification.cljc`, `privacy.cljc`, the API-demote notes, the schema-removal note in `schemas/storage.cljc`).

## Follow-ups filed

- **rf2-jhyccs** (bug, P3) — HTTP response-body `:large?` per-slot classification is extracted but never applied; decide wire-or-drop.
- **rf2-r5r98f** (task, P4) — sweep the **pre-existing, out-of-EP-diff** stale "schema-declared" spelling for the frame elision registry in `epoch/assembly.cljc` (~15 sites), `http_reply.cljc`, `flows.cljc`, `router.cljc`, and test prose.

## Quality gates

- `clojure -M:test` (core): **1246 tests, 5504 assertions, 0 failures, 0 errors**
- `clojure -M:test` (epoch): **310 tests, 1241 assertions, 0 failures, 0 errors**
- `clojure -M:test` (http): **409 tests, 1880 assertions, 0 failures, 0 errors**
- Touched namespaces (core/epoch/http) compile-load clean; `subscribe.cljs` reader-validated past the edit.
- `npm run test:cljs` not run locally (no `node_modules` in this worktree; comment-only change, JVM compile + per-artefact tests cover the touched namespaces). CI will run it.
