### PR TITLE
feat: EP-0015 derived :output-sensitivity declassification + Xray :public audit (rf2-t55hxg.8)

### DIFF
--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -178,27 +178,132 @@
      :else
      paths)))
 
+;; ---- derived-output sensitivity claim (EP-0015 issue 9) ------------------
+;;
+;; A subscription / flow can copy, summarise, hash, or reshape a sensitive
+;; input into a NEW value. The author declares the resulting output's
+;; sensitivity with the closed `:rf.egress/output-sensitivity` enum (Spec 015
+;; §Derived sensitivity) — NOT by overloading the boolean `:sensitive?`
+;; declassify spelling (that overload is REJECTED, Spec 015:425, because
+;; `:sensitive` already names a path COLLECTION at the registration layer).
+;;
+;;   :rf.egress/inherit    — default; the output inherits sensitivity from
+;;                           its inputs (propagation, fail-closed).
+;;   :rf.egress/sensitive  — force-mark the output sensitive even from
+;;                           public inputs.
+;;   :rf.egress/public     — DECLASSIFY: the output is safe to surface
+;;                           despite sensitive inputs. The declassification
+;;                           analogue of `:rf.scope/global` — Xray enumerates
+;;                           every `:public` claim as a standing audit
+;;                           surface (see `public-declassification-claims`).
+;;
+;; Fail-closed: an unknown value THROWS (the enum is closed — a typo never
+;; silently falls through to a permissive inherit), and `:inherit` is the
+;; safe default when the key is absent. The claim is stored verbatim in the
+;; per-(kind, id) marks table under `:output-sensitivity`; `resolve-sub-output-marks`
+;; (subs) and the flows registry resolver consult it instead of the removed
+;; `:sensitive?` boolean override.
+
+(def ^:const output-sensitivity-values
+  "The closed value set of the `:rf.egress/output-sensitivity` derived-output
+  declassification claim (EP-0015 issue 9; Spec 015 §Derived sensitivity)."
+  #{:rf.egress/inherit
+    :rf.egress/sensitive
+    :rf.egress/public})
+
+(defn- coerce-output-sensitivity
+  "Validate a `:rf.egress/output-sensitivity` claim against the closed enum
+  and return it verbatim. Fail-closed: an unknown value THROWS
+  `:rf.error/bad-marks` (the enum is closed — a typo is a loud error, never a
+  silent permissive fall-through). `nil` (key absent) returns `:rf.egress/inherit`,
+  the safe default."
+  [v]
+  (cond
+    (nil? v)                          :rf.egress/inherit
+    (contains? output-sensitivity-values v) v
+    :else
+    (throw (marks-error :rf.egress/output-sensitivity
+                        (str ":rf.egress/output-sensitivity must be one of "
+                             (pr-str output-sensitivity-values)
+                             " — :rf.egress/inherit (default) inherits from inputs, "
+                             ":rf.egress/sensitive force-marks, :rf.egress/public declassifies")
+                        {:bad-value v
+                         :valid     output-sensitivity-values}))))
+
+(defn- reject-sensitive-boolean-overload!
+  "REJECT the boolean `:sensitive?` declassify/force spelling on a derived
+  output (`:sub` kind — Spec 015:425): `:sensitive` already names a path
+  collection at the registration layer, so overloading `:sensitive?` to a
+  whole-output boolean is forbidden. Derived-output sensitivity is declared
+  with the `:rf.egress/output-sensitivity` enum instead. Throws with a recovery
+  hint naming the correct spelling.
+
+  SCOPED to derived outputs (`:sub`): for non-derived kinds (`:event` / `:fx`
+  / `:cofx` / machine `:event` entries), a top-level `:sensitive?` was always a
+  stored-but-never-consulted no-op vestige (it is meaningful ONLY as a Malli
+  schema-slot prop, never as registration meta), so this rejection does not
+  fire there — those kinds keep their prior permissive behaviour and the key is
+  simply dropped by `normalise-marks`. (`:large?` is NOT rejected on any kind —
+  it remains the whole-output size override; size has no declassification
+  analogue and is out of EP-0015 issue 9's scope.)
+
+  No-op when `kind` is not `:sub` or the meta carries no `:sensitive?` key."
+  [kind meta]
+  (when (and (= :sub kind) (contains? meta :sensitive?))
+    (throw (marks-error :sensitive?
+                        (str "the boolean :sensitive? declassify/force spelling is "
+                             "rejected on a derived (sub) output (Spec 015) — declare "
+                             "derived-output sensitivity with "
+                             ":rf.egress/output-sensitivity, whose closed value set is "
+                             (pr-str output-sensitivity-values)
+                             " (:rf.egress/public to declassify, :rf.egress/sensitive "
+                             "to force-mark, :rf.egress/inherit — the default — to "
+                             "inherit from inputs)")
+                        {:bad-value (:sensitive? meta)
+                         :use       :rf.egress/output-sensitivity}))))
+
 (defn- normalise-marks
   "Extract the mark-relevant subset of a registration meta-map and
   normalise into the canonical shape this namespace consults:
 
-    {:sensitive  [vector-of-paths]
-     :large      [vector-of-paths]
-     :sensitive? <bool-or-nil>   ;; whole-output override (subs/flows)
-     :large?     <bool-or-nil>}  ;; whole-output override (subs/flows)
+    {:sensitive           [vector-of-paths]
+     :large               [vector-of-paths]
+     :output-sensitivity  <closed enum>  ;; derived-output claim (subs/flows)
+     :large?              <bool-or-nil>}  ;; whole-output size override (subs/flows)
 
-  Returns `nil` when the meta-map carries no mark-relevant keys —
-  callers branch on the nil to avoid stashing empty tables."
-  [meta]
-  (when (or (contains? meta :sensitive)
-            (contains? meta :large)
-            (contains? meta :sensitive?)
-            (contains? meta :large?))
-    (cond-> {}
-      (contains? meta :sensitive)  (assoc :sensitive  (coerce-paths (:sensitive meta) :sensitive))
-      (contains? meta :large)      (assoc :large      (coerce-paths (:large meta) :large))
-      (contains? meta :sensitive?) (assoc :sensitive? (boolean (:sensitive? meta)))
-      (contains? meta :large?)     (assoc :large?     (boolean (:large? meta))))))
+  Derived-output sensitivity is declared with the closed
+  `:rf.egress/output-sensitivity` enum (EP-0015 issue 9; Spec 015 §Derived
+  sensitivity). On the derived (`:sub`) path the legacy boolean `:sensitive?`
+  declassify/force spelling is REJECTED (Spec 015:425) — a `:sensitive?` key
+  throws with a recovery hint naming the enum; on non-derived kinds it is the
+  prior stored-but-ignored no-op and is silently dropped. An explicit
+  `:rf.egress/output-sensitivity` is validated against the closed enum
+  (fail-closed: an unknown value throws); the absent default
+  `:rf.egress/inherit` is NOT stored (the resolver treats a missing claim as
+  inherit, so an empty marks entry stays empty).
+
+  `kind` scopes the `:sensitive?` rejection to derived outputs (see
+  `reject-sensitive-boolean-overload!`). Returns `nil` when the meta-map
+  carries no mark-relevant keys — callers branch on the nil to avoid stashing
+  empty tables."
+  [kind meta]
+  (reject-sensitive-boolean-overload! kind meta)
+  (let [;; The explicit (non-default) output-sensitivity claim, or nil when
+        ;; the key is absent OR is the no-op `:rf.egress/inherit` default —
+        ;; either way the marks entry omits the slot and the resolver
+        ;; inherits. An unknown value throws (fail-closed).
+        os (when (contains? meta :rf.egress/output-sensitivity)
+             (let [v (coerce-output-sensitivity (:rf.egress/output-sensitivity meta))]
+               (when (not= :rf.egress/inherit v) v)))]
+    (when (or (contains? meta :sensitive)
+              (contains? meta :large)
+              (some? os)
+              (contains? meta :large?))
+      (cond-> {}
+        (contains? meta :sensitive) (assoc :sensitive (coerce-paths (:sensitive meta) :sensitive))
+        (contains? meta :large)     (assoc :large     (coerce-paths (:large meta) :large))
+        (some? os)                  (assoc :output-sensitivity os)
+        (contains? meta :large?)    (assoc :large?    (boolean (:large? meta)))))))
 
 (defn register-marks!
   "Record a registration's mark declaration for later emit-time consultation.
@@ -208,7 +313,7 @@
   marks table mirrors the registry. Re-registration replaces the prior
   marks entry in full (no merge — matches the registrar's slot semantics)."
   [kind id meta]
-  (let [marks (normalise-marks meta)]
+  (let [marks (normalise-marks kind meta)]
     (if (nil? marks)
       ;; Clear any prior marks for this (kind, id) on re-registration
       ;; without marks — the new registration's declaration set should
@@ -253,6 +358,21 @@
     (or (false? existing-flag) (false? added-flag)) false
     :else nil))
 
+(defn- union-output-sensitivity
+  "Union a derived-output `:rf.egress/output-sensitivity` claim across the
+  existing and added declarations. Returns the resolved enum value, or nil
+  when NEITHER side declared a non-inherit claim. Monotone toward sensitivity
+  (fail-closed): `:rf.egress/sensitive` (force) on either side wins over
+  `:rf.egress/public` (declassify) — a union can never let one source's
+  declassify retract another source's force-mark, mirroring the
+  `:sensitive?`-flag monotone-OR. An explicit `:public` is preserved when the
+  other side is absent."
+  [existing added]
+  (cond
+    (or (= :rf.egress/sensitive existing) (= :rf.egress/sensitive added)) :rf.egress/sensitive
+    (or (= :rf.egress/public existing)    (= :rf.egress/public added))    :rf.egress/public
+    :else nil))
+
 (defn union-marks!
   "Union a mark declaration into the existing `(kind, id)` marks entry —
   the per-(kind, id) marks-table analogue of `add-marks` merging into a
@@ -284,19 +404,20 @@
   egress (`project-machine-tags`) exactly like an app-db slot — and a
   machine that ALSO carries a manual `register-marks!` keeps both sets."
   [kind id meta]
-  (let [added (normalise-marks meta)]
+  (let [added (normalise-marks kind meta)]
     (when added
       (swap! kind->id->marks update-in [kind id]
              (fn [existing]
                (let [union-s (union-path-vecs (:sensitive existing) (:sensitive added))
                      union-l (union-path-vecs (:large existing)     (:large added))
-                     sens?   (union-whole-output-flag (:sensitive? existing) (:sensitive? added))
+                     os      (union-output-sensitivity (:output-sensitivity existing)
+                                                       (:output-sensitivity added))
                      large?  (union-whole-output-flag (:large? existing)     (:large? added))]
                  (cond-> {}
-                   union-s          (assoc :sensitive  union-s)
-                   union-l          (assoc :large      union-l)
-                   (some? sens?)    (assoc :sensitive? sens?)
-                   (some? large?)   (assoc :large?     large?)))))))
+                   union-s          (assoc :sensitive          union-s)
+                   union-l          (assoc :large              union-l)
+                   (some? os)       (assoc :output-sensitivity os)
+                   (some? large?)   (assoc :large?             large?)))))))
   nil)
 
 (defn- merge-schema-marks
@@ -314,21 +435,24 @@
   (when (or manual schema)
     (let [union-s (union-path-vecs (:sensitive manual) (:sensitive schema))
           union-l (union-path-vecs (:large manual)     (:large schema))
-          sens?   (union-whole-output-flag (:sensitive? manual) (:sensitive? schema))
+          os      (union-output-sensitivity (:output-sensitivity manual)
+                                            (:output-sensitivity schema))
           large?  (union-whole-output-flag (:large? manual)     (:large? schema))
           merged  (cond-> {}
-                    union-s        (assoc :sensitive  union-s)
-                    union-l        (assoc :large      union-l)
-                    (some? sens?)  (assoc :sensitive? sens?)
-                    (some? large?) (assoc :large?     large?))]
+                    union-s        (assoc :sensitive          union-s)
+                    union-l        (assoc :large              union-l)
+                    (some? os)     (assoc :output-sensitivity os)
+                    (some? large?) (assoc :large?             large?))]
       (when (seq merged) merged))))
 
 (defn marks-for
   "Return the registered mark declaration for `(kind, id)`, or nil.
 
   The returned shape is `{:sensitive [paths] :large [paths]
-  :sensitive? bool :large? bool}` — slots are present only when the
-  registration declared them.
+  :output-sensitivity <enum> :large? bool}` — slots are present only when the
+  registration declared them. `:output-sensitivity` is the derived-output
+  declassification claim (`:rf.egress/sensitive` / `:rf.egress/public`; the
+  `:rf.egress/inherit` default is omitted).
 
   For `:event`-kind ids that name a machine carrying a `:data-schema`, the
   author-sourced `kind->id->marks` entry is UNIONED at read time with the
@@ -343,6 +467,29 @@
     (if (= :event kind)
       (merge-schema-marks manual (get @machine-id->schema-marks id))
       manual)))
+
+(defn public-declassification-claims
+  "Enumerate every registered derived output that carries an explicit
+  `:rf.egress/output-sensitivity :rf.egress/public` declassification claim —
+  the standing AUDIT surface (EP-0015 issue 9; Spec 015 §Derived sensitivity).
+  A `:public` claim is the declassification analogue of `:rf.scope/global`:
+  this list lets a reviewer see every place an author asserted \"this
+  derived-from-sensitive value is safe.\"
+
+  Returns a vector of `{:kind <kind> :id <id>}` maps (e.g.
+  `{:kind :sub :id :auth/token-prefix}`), sorted by `(kind, id)` string for a
+  stable audit ordering. Pure read over the process-scoped marks table — the
+  Xray `:public`-claim panel consumes it, mirroring how `global-scope-audit`
+  consumes the resources registry. Empty when no output is declassified."
+  []
+  (->> @kind->id->marks
+       (mapcat (fn [[kind id->marks]]
+                 (keep (fn [[id marks]]
+                         (when (= :rf.egress/public (:output-sensitivity marks))
+                           {:kind kind :id id}))
+                       id->marks)))
+       (sort-by (juxt (comp str :kind) (comp str :id)))
+       vec))
 
 (defn declare-machine-schema-marks!
   "Record a machine's `:data-schema`-derived marks under `machine-id` in the
@@ -782,18 +929,21 @@
   state + a layer-1 sub's path overlap with the frame's app-db
   sensitive declarations.
 
-  Resolution per Spec 015 §3. Subscriptions:
-    1. `:sensitive? true`  forces sensitive
-    2. `:sensitive? false` opts out (overrides propagation)
-    3. Otherwise: propagate — if ANY input-signal's resolved sub-output
-       is sensitive, OR if the sub is layer-1 and any sensitive app-db
-       path was declared, mark sensitive
-  Mirror for `:large?` / `:large`.
+  Sensitivity resolution per Spec 015 §Derived sensitivity — driven by the
+  closed `:rf.egress/output-sensitivity` declassification claim (EP-0015
+  issue 9), NOT the rejected boolean `:sensitive?` overload (removed):
+    1. `:rf.egress/sensitive` forces sensitive (even from public inputs)
+    2. `:rf.egress/public`    DECLASSIFIES (overrides propagation)
+    3. `:rf.egress/inherit` (default, claim absent): propagate — if ANY
+       input-signal's resolved sub-output is sensitive, OR if the sub is
+       layer-1 and any sensitive app-db path was declared, mark sensitive
+  Size still uses the `:large?` whole-output override (size has no
+  declassification analogue — EP-0015 issue 9 is sensitivity-only).
 
   Returns `[sensitive? large?]`."
   [frame-id sub-id input-signals layer-1?]
   (let [marks       (sub-marks sub-id)
-        forced-s    (:sensitive? marks)
+        output-sens (:output-sensitivity marks)
         forced-l    (:large? marks)
         ;; Propagation from inputs
         input-s?    (and (seq input-signals)
@@ -823,9 +973,9 @@
                             decls     (get-in rt [:rf.runtime/elision :declarations])]
                         (boolean (seq decls))))
         sensitive?  (cond
-                      (true? forced-s)  true
-                      (false? forced-s) false
-                      :else             (or input-s? (boolean any-sens?)))
+                      (= :rf.egress/sensitive output-sens) true
+                      (= :rf.egress/public output-sens)    false
+                      :else                                (or input-s? (boolean any-sens?)))
         large?      (cond
                       (true? forced-l)  true
                       (false? forced-l) false

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -1078,8 +1078,12 @@
       (and (nil? marks) (not prop-s?) (not prop-l?))
       tags
 
-      ;; Whole-output propagation wins: stamp at root.
-      (and prop-s? (not (false? (:sensitive? marks))))
+      ;; Whole-output propagation wins: stamp at root. `prop-s?` is the
+      ;; RESOLVED sensitivity (`resolve-sub-output-marks` already applied the
+      ;; `:rf.egress/output-sensitivity` claim — a `:public` declassify
+      ;; resolves to false here, a `:sensitive` force / inherited-sensitive to
+      ;; true), so no per-marks declassify guard is needed.
+      prop-s?
       (cond-> (assoc tags :rf.sub/value privacy/redacted-sentinel :sensitive? true)
         has-prev? (assoc :rf.sub/prev-value privacy/redacted-sentinel))
 

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -240,9 +240,12 @@
                      :input-kind    input-kind
                      :input-signals (or input-signals []))
         input-fn (assoc :input-fn input-fn)))
-    ;; Per Spec 015 §3. Subscriptions — stash declarations:
+    ;; Per Spec 015 §Derived sensitivity — stash declarations:
     ;;   :sensitive / :large — per-output-path marks
-    ;;   :sensitive? / :large? — whole-output override
+    ;;   :rf.egress/output-sensitivity — the derived-output declassification
+    ;;     enum (:rf.egress/inherit | :rf.egress/sensitive | :rf.egress/public,
+    ;;     EP-0015 issue 9; the rejected :sensitive? overload is gone)
+    ;;   :large? — whole-output size override
     ;; The propagation table (`re-frame.marks/mark-sub-output!`) is
     ;; updated on each sub-cache compute pass — see `compute-and-cache!`.
     (when-let [register! (late-bind/get-fn :marks/register-marks!)]
@@ -696,8 +699,9 @@
     ;; Per Spec 015 §App-db → subs / §Subs → fx propagation: when this
     ;; sub is being built, resolve whether its output should be marked
     ;; sensitive/large for downstream emit-time consultation. Honours
-    ;; the `:sensitive? true/false` and `:large? true/false` overrides
-    ;; on the sub's registration meta. Late-bound — when the marks
+    ;; the `:rf.egress/output-sensitivity` declassification enum (sensitive
+    ;; axis) and the `:large?` whole-output override on the sub's
+    ;; registration meta. Late-bound — when the marks
     ;; artefact is absent, this is a silent no-op. Gated by debug so
     ;; production builds DCE the lookup.
     (when interop/debug-enabled?

--- a/implementation/core/test/re_frame/marks_test.clj
+++ b/implementation/core/test/re_frame/marks_test.clj
@@ -177,11 +177,32 @@
 
 (deftest reg-sub-stashes-marks-and-overrides
   (rf/reg-sub :s1
-    {:sensitive [[:hashed]] :sensitive? false}
+    {:sensitive [[:hashed]] :rf.egress/output-sensitivity :rf.egress/public}
     (fn [_ _] {:hashed "abc"}))
   (let [m (marks/marks-for :sub :s1)]
     (is (= [[:hashed]] (:sensitive m)))
-    (is (false? (:sensitive? m)))))
+    (is (= :rf.egress/public (:output-sensitivity m))
+        "the derived-output declassify claim is stashed as :output-sensitivity")))
+
+(deftest reg-sub-rejects-sensitive-boolean-overload
+  ;; The rejected `:sensitive?` declassify/force spelling on a derived (sub)
+  ;; output throws at registration — EP-0015 issue 9, Spec 015:425.
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #":rf.error/bad-marks"
+        (rf/reg-sub :s/rejected
+          {:sensitive? false}
+          (fn [_ _] {}))))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #":rf.error/bad-marks"
+        (rf/reg-sub :s/rejected2
+          {:sensitive? true}
+          (fn [_ _] {})))))
+
+(deftest reg-sub-rejects-unknown-output-sensitivity
+  ;; Fail-closed: an unknown enum value throws (the enum is closed; a typo is
+  ;; never a silent permissive inherit).
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #":rf.error/bad-marks"
+        (rf/reg-sub :s/typo
+          {:rf.egress/output-sensitivity :rf.egress/publik}
+          (fn [_ _] {})))))
 
 (deftest reg-fx-stashes-marks
   (rf/reg-fx :myfx
@@ -354,48 +375,48 @@
   (is (= [[:data :a]] (:sensitive (marks/marks-for :event :u4)))
       "a mark-key-free meta is a no-op (does NOT clear, unlike register-marks!)"))
 
-(deftest union-marks-ors-whole-output-flags
-  (marks/register-marks! :sub :u5 {:sensitive? false})
-  (marks/union-marks!    :sub :u5 {:sensitive? true})
-  (is (true? (:sensitive? (marks/marks-for :sub :u5)))
-      "whole-output :sensitive? flags OR (true wins)"))
+;; ---- union-marks! :rf.egress/output-sensitivity monotone (EP-0015 #9) -----
+;; The derived-output declassification enum (`:rf.egress/output-sensitivity`)
+;; replaces the rejected boolean `:sensitive?` declassify spelling. The union
+;; is monotone toward sensitivity (fail-closed): `:rf.egress/sensitive` (force)
+;; on EITHER side wins over `:rf.egress/public` (declassify); an explicit
+;; `:public` is preserved when the other side is absent / path-only.
 
-;; ---- union-marks! preserves explicit false whole-output overrides --------
-;; (rf2-1zqh1z) The OR semantics the contract documents must hold BOTH ways:
-;; a `true` on either side wins, and an explicit `false` opt-out is PRESERVED
-;; when the added declaration touches only paths (or carries no flag). The
-;; prior `(or existing added)` collapsed `(or false nil)` to nil and DROPPED
-;; the opt-out.
+(deftest union-marks-ors-output-sensitivity-flags
+  (marks/register-marks! :sub :u5 {:rf.egress/output-sensitivity :rf.egress/public})
+  (marks/union-marks!    :sub :u5 {:rf.egress/output-sensitivity :rf.egress/sensitive})
+  (is (= :rf.egress/sensitive (:output-sensitivity (marks/marks-for :sub :u5)))
+      "output-sensitivity unions monotone toward sensitive (force wins over public)"))
 
-(deftest union-marks-preserves-false-when-added-has-only-paths
-  (marks/register-marks! :sub :f1 {:sensitive? false})
+(deftest union-marks-preserves-public-when-added-has-only-paths
+  (marks/register-marks! :sub :f1 {:rf.egress/output-sensitivity :rf.egress/public})
   (marks/union-marks!    :sub :f1 {:sensitive [[:data :token]]})
   (let [m (marks/marks-for :sub :f1)]
-    (is (false? (:sensitive? m))
-        "explicit false survives a union that adds only path marks")
+    (is (= :rf.egress/public (:output-sensitivity m))
+        "explicit :public survives a union that adds only path marks")
     (is (= [[:data :token]] (:sensitive m))
-        "the added path mark lands alongside the preserved false override")))
+        "the added path mark lands alongside the preserved :public claim")))
 
-(deftest union-marks-preserves-false-when-added-is-nil-shaped
+(deftest union-marks-preserves-public-when-added-is-nil-shaped
   ;; The added declaration carries a DIFFERENT flag (`:large?`) but no
-  ;; `:sensitive?` — the existing `:sensitive? false` must not vanish.
-  (marks/register-marks! :sub :f2 {:sensitive? false})
+  ;; output-sensitivity claim — the existing `:public` must not vanish.
+  (marks/register-marks! :sub :f2 {:rf.egress/output-sensitivity :rf.egress/public})
   (marks/union-marks!    :sub :f2 {:large? true})
   (let [m (marks/marks-for :sub :f2)]
-    (is (false? (:sensitive? m)) "existing false :sensitive? preserved")
-    (is (true?  (:large? m))     "added true :large? lands")))
+    (is (= :rf.egress/public (:output-sensitivity m)) "existing :public preserved")
+    (is (true? (:large? m))                           "added true :large? lands")))
 
-(deftest union-marks-true-overrides-existing-false
-  (marks/register-marks! :sub :f3 {:sensitive? false})
-  (marks/union-marks!    :sub :f3 {:sensitive? true})
-  (is (true? (:sensitive? (marks/marks-for :sub :f3)))
-      "a later true wins over an existing false (monotone OR)"))
+(deftest union-marks-sensitive-overrides-existing-public
+  (marks/register-marks! :sub :f3 {:rf.egress/output-sensitivity :rf.egress/public})
+  (marks/union-marks!    :sub :f3 {:rf.egress/output-sensitivity :rf.egress/sensitive})
+  (is (= :rf.egress/sensitive (:output-sensitivity (marks/marks-for :sub :f3)))
+      "a later :sensitive wins over an existing :public (monotone toward sensitive)"))
 
-(deftest union-marks-false-added-over-existing-true-stays-true
-  (marks/register-marks! :sub :f4 {:sensitive? true})
-  (marks/union-marks!    :sub :f4 {:sensitive? false})
-  (is (true? (:sensitive? (marks/marks-for :sub :f4)))
-      "an added false cannot retract an existing true (true wins)"))
+(deftest union-marks-public-added-over-existing-sensitive-stays-sensitive
+  (marks/register-marks! :sub :f4 {:rf.egress/output-sensitivity :rf.egress/sensitive})
+  (marks/union-marks!    :sub :f4 {:rf.egress/output-sensitivity :rf.egress/public})
+  (is (= :rf.egress/sensitive (:output-sensitivity (marks/marks-for :sub :f4)))
+      "an added :public cannot retract an existing :sensitive (force wins)"))
 
 ;; ---- machine schema marks: order-independent union (rf2-qpibk0) ----------
 ;; Schema-sourced machine marks live in a SEPARATE table that `marks-for
@@ -677,24 +698,64 @@
   ;; Layer-1 sub with sensitive declarations present → propagation flag set
   (is (true? (marks/sub-output-sensitive? :rf/default :all-users))))
 
-(deftest sub-explicit-opt-out-clears-propagation
-  ;; Spec 015 conformance fixture #4
+(deftest sub-explicit-public-clears-propagation
+  ;; Spec 015 §Derived sensitivity — the conformance
+  ;; `derived-output-declassified-public.edn` fixture: a sub reading a
+  ;; sensitive input with `:rf.egress/output-sensitivity :rf.egress/public`
+  ;; DECLASSIFIES — its output is NOT marked sensitive despite the sensitive
+  ;; input (replaces the rejected `:sensitive? false` spelling).
   (rf/reg-event-db :seed (fn [_ _] {:user {:ssn "X" :name "A"}}))
   (rf/dispatch-sync [:seed])
   (marks/set-marks :rf/default {[:user :ssn] :sensitive})
   (rf/reg-sub :safe
-    {:sensitive? false}
+    {:rf.egress/output-sensitivity :rf.egress/public}
     (fn [db _] (get-in db [:user :name])))
   @(rf/subscribe [:safe])
   (is (false? (marks/sub-output-sensitive? :rf/default :safe))))
 
 (deftest sub-force-marked
-  ;; :sensitive? true forces even with no upstream
+  ;; :rf.egress/output-sensitivity :rf.egress/sensitive forces sensitive even
+  ;; with no sensitive upstream input.
   (rf/reg-sub :synthetic
-    {:sensitive? true}
+    {:rf.egress/output-sensitivity :rf.egress/sensitive}
     (fn [_ _] "public-input-derived-secret"))
   @(rf/subscribe [:synthetic])
   (is (true? (marks/sub-output-sensitive? :rf/default :synthetic))))
+
+(deftest public-declassification-claims-audit
+  ;; EP-0015 issue 9: every `:rf.egress/output-sensitivity :rf.egress/public`
+  ;; claim is enumerable as a STANDING audit surface (the declassification
+  ;; analogue of `:rf.scope/global`). A `:sensitive` / `:inherit` sub does NOT
+  ;; appear; a `:public` one does.
+  (rf/reg-sub :pub/a
+    {:rf.egress/output-sensitivity :rf.egress/public}
+    (fn [_ _] "ok"))
+  (rf/reg-sub :pub/forced
+    {:rf.egress/output-sensitivity :rf.egress/sensitive}
+    (fn [_ _] "secret"))
+  (rf/reg-sub :pub/inheriting
+    (fn [_ _] "plain"))
+  (let [claims (marks/public-declassification-claims)]
+    (is (some #(= {:kind :sub :id :pub/a} %) claims)
+        "the :public-declassified sub is enumerated in the audit")
+    (is (not (some #(= :pub/forced (:id %)) claims))
+        "a force-:sensitive sub is NOT a declassification claim")
+    (is (not (some #(= :pub/inheriting (:id %)) claims))
+        "an :inherit (default) sub is NOT a declassification claim")))
+
+(deftest sub-inherit-default-propagates
+  ;; Spec 015 §Derived sensitivity — the conformance
+  ;; `derived-output-inherits-sensitivity.edn` fixture: a sub reading a
+  ;; sensitive input with NO `:rf.egress/output-sensitivity` (the `:inherit`
+  ;; default) propagates — its output IS marked sensitive.
+  (rf/reg-event-db :seed (fn [_ _] {:user {:ssn "X" :name "A"}}))
+  (rf/dispatch-sync [:seed])
+  (marks/set-marks :rf/default {[:user :ssn] :sensitive})
+  (rf/reg-sub :inheriting
+    (fn [db _] (get-in db [:user :name])))
+  @(rf/subscribe [:inheriting])
+  (is (true? (marks/sub-output-sensitive? :rf/default :inheriting))
+      "a layer-1 sub over a frame with sensitive declarations inherits sensitivity by default"))
 
 ;; ---- composed: subs propagation through layer-2 ------------------------
 

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -38,6 +38,7 @@
             [re-frame.flows.topo :as topo]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
+            [re-frame.marks :as marks]
             [re-frame.path :as path]
             [re-frame.registrar :as registrar]
             [re-frame.source-coords :as source-coords]
@@ -244,10 +245,12 @@
 ;; callers don't have to chase the failure into the topo / evaluator stack.
 ;;
 ;; The OPTIONAL output data-classification keys (`:sensitive` / `:large` /
-;; `:sensitive?` / `:large?`, Spec 015 §7) are validated in the same table
-;; (rf2-cgk0wb): previously they were FAIL-OPEN — a malformed declaration
-;; (`:sensitive [:token]`, `:large "blob"`, `:sensitive? :yes`) registered
-;; cleanly but installed no redaction, the worst failure for a safety feature.
+;; `:rf.egress/output-sensitivity` / `:large?`, Spec 015 §Derived sensitivity)
+;; are validated in the same table (rf2-cgk0wb): previously they were
+;; FAIL-OPEN — a malformed declaration (`:sensitive [:token]`, `:large "blob"`,
+;; a typo'd enum value) registered cleanly but installed no redaction, the
+;; worst failure for a safety feature. The boolean `:sensitive?` declassify
+;; spelling is now REJECTED (EP-0015 issue 9; Spec 015:425).
 
 (defn- valid-path-element?
   "True iff `x` is admissible as a flow path segment — the SHARED EP-0012
@@ -441,16 +444,36 @@
     :extras   (fn [flow] {:bad-key     :large
                           :bad-entries (vec (remove valid-output-subpath? (:large flow)))})}
 
-   ;; Whole-output boolean rules: `:sensitive?` / `:large?`, when PRESENT,
-   ;; must be an actual boolean. `explicit-flow-output-mark-paths` and the
-   ;; propagation resolver branch on literal `true` / `false`; any other
-   ;; present value (`:yes`, `1`, `"true"`) would silently behave as ABSENT
-   ;; (neither force-mark nor opt-out), which is exactly the fail-open trap.
-   {:pred     (fn [flow] (or (not (contains? flow :sensitive?))
-                             (boolean? (:sensitive? flow))))
+   ;; Derived-output sensitivity (EP-0015 issue 9): a flow declares its
+   ;; output's sensitivity with the closed `:rf.egress/output-sensitivity`
+   ;; enum (`:rf.egress/inherit` default | `:rf.egress/sensitive` force |
+   ;; `:rf.egress/public` declassify) — NOT the rejected boolean `:sensitive?`
+   ;; overload (Spec 015:425). REJECT a `:sensitive?` key with a recovery
+   ;; hint naming the enum; an unknown enum value is fail-closed (a typo is a
+   ;; loud error, never a silent permissive inherit).
+   {:pred     (fn [flow] (not (contains? flow :sensitive?)))
     :error-kw :rf.error/flow-bad-marks
-    :reason   ":sensitive?, when present, must be a boolean (true forces the whole output sensitive; false opts out of propagation)"
-    :extras   (fn [flow] {:bad-key :sensitive? :bad-value (:sensitive? flow)})}
+    :reason   (str "the boolean :sensitive? declassify/force spelling is rejected on a "
+                   "flow output (Spec 015) — declare derived-output sensitivity with "
+                   ":rf.egress/output-sensitivity, whose closed value set is "
+                   (pr-str marks/output-sensitivity-values)
+                   " (:rf.egress/public to declassify, :rf.egress/sensitive to force-mark, "
+                   ":rf.egress/inherit — the default — to inherit from inputs)")
+    :extras   (fn [flow] {:bad-key :sensitive?
+                          :bad-value (:sensitive? flow)
+                          :use :rf.egress/output-sensitivity})}
+
+   {:pred     (fn [flow] (or (not (contains? flow :rf.egress/output-sensitivity))
+                             (contains? marks/output-sensitivity-values
+                                        (:rf.egress/output-sensitivity flow))))
+    :error-kw :rf.error/flow-bad-marks
+    :reason   (str ":rf.egress/output-sensitivity, when present, must be one of "
+                   (pr-str marks/output-sensitivity-values)
+                   " — :rf.egress/inherit (default) inherits from inputs, "
+                   ":rf.egress/sensitive force-marks, :rf.egress/public declassifies")
+    :extras   (fn [flow] {:bad-key   :rf.egress/output-sensitivity
+                          :bad-value (:rf.egress/output-sensitivity flow)
+                          :valid     marks/output-sensitivity-values})}
 
    {:pred     (fn [flow] (or (not (contains? flow :large?))
                              (boolean? (:large? flow))))
@@ -469,7 +492,9 @@
 ;; A `reg-flow` registration may carry data-classification keys describing
 ;; the SENSITIVITY / SIZE of the flow's OWN OUTPUT value:
 ;;
-;;   :sensitive? true   — the whole output is sensitive
+;;   :rf.egress/output-sensitivity — the closed derived-output declassification
+;;        enum (EP-0015 issue 9): :rf.egress/inherit (default) | :rf.egress/sensitive
+;;        (force the whole output sensitive) | :rf.egress/public (declassify)
 ;;   :large?     true   — the whole output is large
 ;;   :sensitive  [paths]— per-output-path sensitive sub-slots ([[]] = whole)
 ;;   :large      [paths]— per-output-path large sub-slots ([[]] = whole)
@@ -478,15 +503,17 @@
 ;; 2026-06-09) — a flow OUTPUT inherits the data-classification of its
 ;; INPUT paths. A flow reading a sensitive app-db (or runtime-db-qualified,
 ;; rf2-4eisfr) input emits a sensitive output unless the author explicitly
-;; opts out with `:sensitive? false`. This is the same propagation/override
-;; grammar subscriptions already implement (`marks/resolve-sub-output-marks`)
-;; — flows just need their OWN trigger because a flow does not recompute on a
-;; mark-only change (subs re-resolve on every compute pass). Propagation is
-;; FAIL-CLOSED: an over-redacted derived value is visibly wrong in dev; an
-;; under-redacted one is an invisible privacy leak. Format-preserving
-;; derivations (copy / reformat / concat — e.g. 015's :computed/full-name)
-;; must propagate; de-sensitising derivations (hash / mask / aggregate)
-;; declassify with `:sensitive? false` (015's :computed/hashed-token).
+;; declassifies with `:rf.egress/output-sensitivity :rf.egress/public` (the
+;; rejected `:sensitive? false` spelling is gone — Spec 015:425). This is the
+;; same propagation/override grammar subscriptions already implement
+;; (`marks/resolve-sub-output-marks`) — flows just need their OWN trigger
+;; because a flow does not recompute on a mark-only change (subs re-resolve on
+;; every compute pass). Propagation is FAIL-CLOSED: an over-redacted derived
+;; value is visibly wrong in dev; an under-redacted one is an invisible privacy
+;; leak. Format-preserving derivations (copy / reformat / concat — e.g. 015's
+;; :computed/full-name) propagate by default; de-sensitising derivations (hash /
+;; mask / aggregate) declassify with `:rf.egress/output-sensitivity
+;; :rf.egress/public` (015's :computed/hashed-token).
 ;;
 ;; :large is ASYMMETRIC and is NOT auto-propagated (Mike's lean, rf2-ihfz9o
 ;; OPEN PRECISION, settled here in impl): :sensitive is TRANSITIVE (derived-
@@ -547,10 +574,11 @@
 ;; so lifecycle cleanup (clear-flow / path-change re-register / frame
 ;; destroy) can drop exactly this flow's contributions while leaving
 ;; schema-sourced (`:source :schema`) and add-marks-sourced
-;; (`:source :marks`) entries untouched. A flow's `:sensitive? false`
-;; declassify suppresses only the FLOW's own propagated/whole mark — it can
-;; never unmark a schema- or add-marks-sourced declaration on the same path
-;; (union semantics, Spec 015:295).
+;; (`:source :marks`) entries untouched. A flow's
+;; `:rf.egress/output-sensitivity :rf.egress/public` declassify suppresses only
+;; the FLOW's own propagated/whole mark — it can never unmark a schema- or
+;; add-marks-sourced declaration on the same path (union semantics,
+;; Spec 015:295).
 
 (defn- explicit-flow-output-mark-paths
   "Translate a flow's EXPLICIT output-rooted classification keys into
@@ -559,19 +587,21 @@
   This is the author's hand-declared set; the PROPAGATED whole-output
   sensitive mark (input-inherited) is layered on by the resolver below.
 
-  - whole-output `:sensitive?` / `:large?` (true) ⇒ the flow's `:path`
-    itself;
+  - `:rf.egress/output-sensitivity :rf.egress/sensitive` ⇒ the flow's
+    `:path` itself (force-mark the whole output sensitive); `:large? true`
+    ⇒ the `:path` itself (force-mark large);
   - per-path `:sensitive` / `:large` entries ⇒ `(:path flow)` ++ sub-path
     (`[[]]` whole-value mark ⇒ the `:path` itself);
-  - `:sensitive? false` / `:large? false` ⇒ NO whole-output mark here (the
-    explicit-false override suppresses propagation too — see the resolver);
-    per-path entries, if any, still apply."
+  - `:rf.egress/output-sensitivity :rf.egress/public` / `:large? false` ⇒ NO
+    whole-output mark here (the `:public` declassify suppresses propagation
+    too — see the resolver); per-path entries, if any, still apply."
   [flow]
   (let [base       (:path flow)
         abs        (fn [sub] (into (vec base) sub))
         per-sens   (->> (:sensitive flow) (filter vector?) (map abs))
         per-large  (->> (:large flow)     (filter vector?) (map abs))
-        whole-sens (when (true? (:sensitive? flow)) [(vec base)])
+        whole-sens (when (= :rf.egress/sensitive (:rf.egress/output-sensitivity flow))
+                     [(vec base)])
         whole-lg   (when (true? (:large? flow))     [(vec base)])]
     [(vec (concat whole-sens per-sens))
      (vec (concat whole-lg   per-large))]))
@@ -620,7 +650,7 @@
   [flow]
   (or (contains? flow :sensitive)
       (contains? flow :large)
-      (contains? flow :sensitive?)
+      (contains? flow :rf.egress/output-sensitivity)
       (contains? flow :large?)))
 
 (defn- drop-flow-sourced
@@ -656,21 +686,24 @@
   CURRENT registry `reg` (after THIS flow's own `:source :flow` entries have
   been dropped, so propagation never feeds back on itself). The set is:
 
-    explicit `:sensitive?` true / `:sensitive [paths]` declarations
+    explicit `:rf.egress/output-sensitivity :rf.egress/sensitive` (force) /
+           `:sensitive [paths]` declarations
     UNION  the PROPAGATED whole-output mark — installed iff (a) the flow did
-           not opt out with `:sensitive? false`, and (b) some input path
-           overlaps an existing sensitive declaration on the frame.
+           not declassify with `:rf.egress/output-sensitivity :rf.egress/public`,
+           and (b) some input path overlaps an existing sensitive declaration
+           on the frame.
 
-  `:sensitive? false` is a REAL declassify: it suppresses BOTH the whole-
-  output force-mark and the propagated mark (per-path `:sensitive` entries,
-  being explicit author intent on sub-slots, still apply). It cannot unmark
-  a schema-/add-marks-sourced declaration on the same path — those entries
-  are never `:source :flow`, so they survive the `drop-flow-sourced` carry
-  and re-union at read time (Spec 015:295)."
+  `:rf.egress/output-sensitivity :rf.egress/public` is the DECLASSIFY claim
+  (EP-0015 issue 9; replaces the rejected `:sensitive? false` spelling): it
+  suppresses BOTH the whole-output force-mark and the propagated mark (per-path
+  `:sensitive` entries, being explicit author intent on sub-slots, still
+  apply). It cannot unmark a schema-/add-marks-sourced declaration on the same
+  path — those entries are never `:source :flow`, so they survive the
+  `drop-flow-sourced` carry and re-union at read time (Spec 015:295)."
   [flow reg]
   (let [base        (vec (:path flow))
         [explicit-s _] (explicit-flow-output-mark-paths flow)
-        opted-out?  (false? (:sensitive? flow))
+        opted-out?  (= :rf.egress/public (:rf.egress/output-sensitivity flow))
         ;; Propagate against the carried (non-flow) declarations PLUS any
         ;; OTHER flow's already-resolved sensitive declarations — so a flow
         ;; reading an upstream flow's sensitive `:path` inherits it (the

--- a/implementation/flows/test/re_frame/flows_output_marks_test.clj
+++ b/implementation/flows/test/re_frame/flows_output_marks_test.clj
@@ -3,11 +3,12 @@
   (rf2-ouemt — senior-review finding; rf2-ihfz9o — input→output PROPAGATION).
 
   A `reg-flow` registration may carry output data-classification keys
-  (`:sensitive?` / `:large?` whole-output, `:sensitive` / `:large`
-  per-output-path). Pre-fix these were stashed in the frame-blind global
+  (`:rf.egress/output-sensitivity` derived-output sensitivity enum + `:large?`
+  whole-output size, `:sensitive` / `:large` per-output-path). Pre-fix these
+  were stashed in the frame-blind global
   `re-frame.marks` `{flow-id marks}` table whose only reader (`flow-marks`)
   was never wired into the central trace projection switch — so the contract
-  was silently inert: a `{:sensitive [[:secret]]}` or `{:sensitive? true}`
+  was silently inert: a `{:sensitive [[:secret]]}` or `{:rf.egress/output-sensitivity :rf.egress/sensitive}`
   flow emitted its raw `:result` on `:rf.flow/computed` AND wrote the raw
   value to its app-db destination slot (visible to App-DB-Diff / pending-db
   egress / view render-arg egress).
@@ -24,21 +25,21 @@
   of its INPUT paths (Spec 015:313 + the 015:568 conformance fixture). A flow
   reading a SENSITIVE app-db (or runtime-db-qualified, rf2-4eisfr) input
   emits a sensitive output BY DEFAULT (fail-closed — taint by default,
-  declassify explicitly) unless the author opts out with `:sensitive? false`.
+  declassify explicitly) unless the author opts out with `:rf.egress/output-sensitivity :rf.egress/public`.
   `:large` is asymmetric and is NOT auto-propagated (a flow usually shrinks a
-  large input). `:sensitive? false` is now a REAL declassify — it suppresses
+  large input). `:rf.egress/output-sensitivity :rf.egress/public` is now a REAL declassify — it suppresses
   the propagated mark (previously a no-op).
 
   These tests pin the acceptance cases the bead enumerates:
     1. per-path flow output redaction (`:sensitive` / `:large` sub-paths);
-    2. whole-output `:sensitive? true`;
+    2. whole-output `:rf.egress/output-sensitivity :rf.egress/sensitive`;
     3. `:large` whole-output markers;
-    4. `:sensitive? false` opt-out (the explicit-false override);
+    4. `:rf.egress/output-sensitivity :rf.egress/public` declassify (the explicit opt-out);
     5. same-flow-id multi-frame registrations with DIFFERENT marks (frame
        isolation — the frame-blind table would conflate them);
     6. lifecycle (clear-flow / path-change drop & move declarations);
     7. PROPAGATION (rf2-ihfz9o) — default sensitive inheritance, explicit
-       `:sensitive? true` over a sensitive input, explicit `:sensitive? false`
+       `:rf.egress/output-sensitivity :rf.egress/sensitive` over a sensitive input, explicit `:rf.egress/output-sensitivity :rf.egress/public`
        declassify of a sensitive input, per-output-path coexisting with
        propagation, BOTH `:sensitive` AND `:large` axes, runtime-db-qualified
        input propagation, flow→flow DAG propagation, and the t2
@@ -133,18 +134,18 @@
           ":public rides raw on the db egress too"))))
 
 ;; ---------------------------------------------------------------------------
-;; 2. Whole-output `:sensitive? true`
+;; 2. Whole-output `:rf.egress/output-sensitivity :rf.egress/sensitive`
 ;; ---------------------------------------------------------------------------
 
 (deftest reg-flow-whole-output-sensitive-redacts-entire-result
-  (testing "a flow declaring `:sensitive? true` redacts its WHOLE output on
+  (testing "a flow declaring `:rf.egress/output-sensitivity :rf.egress/sensitive` redacts its WHOLE output on
             :result and at the app-db destination slot"
     (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
     (rf/reg-flow {:id         :token
                   :inputs     [[:n]]
                   :output     (fn [_] {:jwt "header.payload.sig"})
                   :path       [:auth :token]
-                  :sensitive? true})
+                  :rf.egress/output-sensitivity :rf.egress/sensitive})
     (is (contains? (sensitive-decls :rf/default) [:auth :token])
         "the whole-output sensitive declaration is installed at :path itself")
     (reset! *captured* [])
@@ -213,18 +214,18 @@
           ":small rides raw — only the declared sub-path is marked"))))
 
 ;; ---------------------------------------------------------------------------
-;; 4. `:sensitive? false` opt-out — no whole-output mark installed
+;; 4. `:rf.egress/output-sensitivity :rf.egress/public` opt-out — no whole-output mark installed
 ;; ---------------------------------------------------------------------------
 
 (deftest reg-flow-sensitive-false-installs-no-whole-output-mark
-  (testing "a flow declaring `:sensitive? false` over an UNMARKED input
+  (testing "a flow declaring `:rf.egress/output-sensitivity :rf.egress/public` over an UNMARKED input
             installs NO whole-output declaration — its result rides raw. With
             an unmarked input there is nothing to propagate, so the result is
             the same under both the old no-propagation model and the new
             propagate-by-default model; the explicit-false override is still
             the absence of a whole-output mark. Per-path `:sensitive`
             declarations on the same flow still apply. (The sensitive-INPUT
-            declassify — where `:sensitive? false` actively SUPPRESSES a
+            declassify — where `:rf.egress/output-sensitivity :rf.egress/public` actively SUPPRESSES a
             propagated mark — is pinned in `propagation-explicit-false-...`
             below; rf2-ihfz9o.)"
     (rf/reg-event-db :init (fn [db _] (merge db {:n 1})))
@@ -232,11 +233,11 @@
                   :inputs     [[:n]]
                   :output     (fn [_] {:hashed :H :raw :R})
                   :path       [:safe]
-                  :sensitive? false
+                  :rf.egress/output-sensitivity :rf.egress/public
                   :sensitive  [[:hashed]]})
     ;; No whole-output declaration at :path itself.
     (is (not (contains? (sensitive-decls :rf/default) [:safe]))
-        ":sensitive? false installs no whole-output declaration at :path")
+        ":rf.egress/output-sensitivity :rf.egress/public installs no whole-output declaration at :path")
     ;; The per-path declaration still applies.
     (is (contains? (sensitive-decls :rf/default) [:safe :hashed])
         "the per-path :sensitive [[:hashed]] declaration is still installed")
@@ -283,7 +284,7 @@
                   :inputs     [[:n]]
                   :output     (fn [_] {:v :LEFT})
                   :path       [:out]
-                  :sensitive? true}
+                  :rf.egress/output-sensitivity :rf.egress/sensitive}
                  {:frame :left})
     ;; :right — same id, NO marks (rides raw).
     (rf/reg-flow {:id     :shared
@@ -306,7 +307,7 @@
                                                  (= :right (-> % :tags :frame)))
                                            @*captured*)))]
       (is (= privacy/redacted-sentinel (:result left-tags))
-          ":left's result is redacted (its frame declared :sensitive? true)")
+          ":left's result is redacted (its frame declared :rf.egress/output-sensitivity :rf.egress/sensitive)")
       (is (= {:v :RIGHT} (:result right-tags))
           ":right's result rides raw — its frame declared no marks"))))
 
@@ -321,7 +322,7 @@
                   :inputs     [[:n]]
                   :output     (fn [_] {:jwt "x"})
                   :path       [:auth :token]
-                  :sensitive? true})
+                  :rf.egress/output-sensitivity :rf.egress/sensitive})
     (is (contains? (sensitive-decls :rf/default) [:auth :token])
         "declaration present after reg-flow")
     (rf/clear-flow :token)
@@ -338,7 +339,7 @@
                   :inputs     [[:n]]
                   :output     (fn [_] {:jwt "x"})
                   :path       [:auth :token]
-                  :sensitive? true})
+                  :rf.egress/output-sensitivity :rf.egress/sensitive})
     (rf/clear-flow :token)
     (is (not (contains? (sensitive-decls :rf/default) [:auth :token]))
         "the flow-sourced declaration is gone")
@@ -357,7 +358,7 @@
                   :inputs     [[:n]]
                   :output     (fn [_] {:jwt "x"})
                   :path       [:old :token]
-                  :sensitive? true})
+                  :rf.egress/output-sensitivity :rf.egress/sensitive})
     (is (contains? (sensitive-decls :rf/default) [:old :token])
         "declaration at the original path")
     ;; Re-register the SAME id on the SAME frame with a NEW path.
@@ -365,7 +366,7 @@
                   :inputs     [[:n]]
                   :output     (fn [_] {:jwt "x"})
                   :path       [:new :token]
-                  :sensitive? true})
+                  :rf.egress/output-sensitivity :rf.egress/sensitive})
     (is (not (contains? (sensitive-decls :rf/default) [:old :token]))
         "the OLD path's flow declaration is dropped on path-change")
     (is (contains? (sensitive-decls :rf/default) [:new :token])
@@ -400,8 +401,8 @@
 ;; (Spec 015:313 + the 015:568 conformance fixture). The cases below pin the
 ;; bead's enumerated propagation coverage:
 ;;   - default inheritance (no explicit key on the flow);
-;;   - explicit `:sensitive? true` over a sensitive input (force-mark holds);
-;;   - explicit `:sensitive? false` declassify of a sensitive input (the
+;;   - explicit `:rf.egress/output-sensitivity :rf.egress/sensitive` over a sensitive input (force-mark holds);
+;;   - explicit `:rf.egress/output-sensitivity :rf.egress/public` declassify of a sensitive input (the
 ;;     opt-out actively SUPPRESSES the propagated mark — previously a no-op);
 ;;   - per-output-path marks coexisting with whole-output propagation;
 ;;   - both `:sensitive` AND `:large` axes (the asymmetry: :sensitive
@@ -473,7 +474,7 @@
         "the output is redacted on the first drain after the input was marked")))
 
 (deftest propagation-explicit-true-over-sensitive-input-holds
-  (testing "explicit `:sensitive? true` over a sensitive input keeps the
+  (testing "explicit `:rf.egress/output-sensitivity :rf.egress/sensitive` over a sensitive input keeps the
             whole-output redaction (force-mark and propagation agree)"
     (rf/reg-event-db :init (fn [db _] (merge db {:tok "T"})))
     (marks/add-marks :rf/default {[:tok] :sensitive})
@@ -481,7 +482,7 @@
                   :inputs     [[:tok]]
                   :output     (fn [t] {:wrapped t})
                   :path       [:wrapped-tok]
-                  :sensitive? true})
+                  :rf.egress/output-sensitivity :rf.egress/sensitive})
     (is (contains? (sensitive-decls :rf/default) [:wrapped-tok]))
     (reset! *captured* [])
     (rf/dispatch-sync [:init])
@@ -489,7 +490,7 @@
         "whole output redacted")))
 
 (deftest propagation-explicit-false-declassifies-sensitive-input
-  (testing "explicit `:sensitive? false` over a SENSITIVE input is a REAL
+  (testing "explicit `:rf.egress/output-sensitivity :rf.egress/public` over a SENSITIVE input is a REAL
             declassify — it SUPPRESSES the propagated whole-output mark (the
             hash/mask/aggregate opt-out, Spec 015's :computed/hashed-token).
             Previously a no-op; rf2-ihfz9o makes it load-bearing."
@@ -499,16 +500,16 @@
                   :inputs     [[:tok]]
                   :output     (fn [t] (hash t))      ; safe — author de-sensitised
                   :path       [:computed :token-hash]
-                  :sensitive? false})
+                  :rf.egress/output-sensitivity :rf.egress/public})
     (is (not (contains? (sensitive-decls :rf/default) [:computed :token-hash]))
-        ":sensitive? false suppresses the propagated whole-output mark")
+        ":rf.egress/output-sensitivity :rf.egress/public suppresses the propagated whole-output mark")
     (reset! *captured* [])
     (rf/dispatch-sync [:init])
     (is (integer? (computed-result :computed/hashed-token))
         "the declassified hash output rides RAW (not redacted)")))
 
 (deftest propagation-false-cannot-unmark-schema-or-add-marks-source
-  (testing "a flow's `:sensitive? false` declassify suppresses only the FLOW's
+  (testing "a flow's `:rf.egress/output-sensitivity :rf.egress/public` declassify suppresses only the FLOW's
             own propagated/whole mark — it CANNOT unmark an add-marks-sourced
             declaration on the SAME output path (union semantics, Spec 015:295)"
     (rf/reg-event-db :init (fn [db _] (merge db {:in "x"})))
@@ -519,7 +520,7 @@
                   :inputs     [[:in]]
                   :output     (fn [v] (str v "!"))
                   :path       [:out]
-                  :sensitive? false})
+                  :rf.egress/output-sensitivity :rf.egress/public})
     ;; The add-marks-sourced declaration on [:out] survives — the flow's
     ;; opt-out only governs its OWN :source :flow contribution.
     (is (contains? (sensitive-decls :rf/default) [:out])

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -221,10 +221,14 @@ The metadata map accepted by `reg-sub`. The `:<-` chain is **not** a metadata-ma
    [:map
     [:rf/inputs    {:optional true} [:vector [:vector :any]]]                ;; runtime-stamped: the resolved :<- chain as a vector of query-vectors
     [:rf/layer     {:optional true} [:enum :layer-1 :layer-2+]]              ;; runtime-stamped: derived from :rf/inputs at registration time
+    [:rf.egress/output-sensitivity {:optional true}                         ;; derived-output declassification claim (EP-0015 issue 9); absent ⇒ :rf.egress/inherit
+     [:enum :rf.egress/inherit :rf.egress/sensitive :rf.egress/public]]
     ]])
 ```
 
-`:rf/inputs` and `:rf/layer` are stamped by the runtime at registration time from the `:<-` positional args — user code MUST NOT set them. Static topology queries (`sub-topology`, per [006](006-ReactiveSubstrate.md)) read `:rf/inputs` back to project the `:<-` graph.
+`:rf/inputs` and `:rf/layer` are stamped by the runtime at registration time from the `:<-` positional args — user code MUST NOT set them.
+
+`:rf.egress/output-sensitivity` is the optional derived-output declassification claim (EP-0015 issue 9; [015 §Derived sensitivity](015-Data-Classification.md#derived-sensitivity)) — a closed enum `:rf.egress/inherit` (default, absent ⇒ inherit sensitivity from inputs) / `:rf.egress/sensitive` (force-mark the output sensitive) / `:rf.egress/public` (declassify — surface unredacted despite sensitive inputs). It is the SOLE derived-output sensitivity surface: the boolean `:sensitive?` declassify/force spelling is rejected at registration (`:sensitive` already names a path collection at this layer). An unknown value throws `:rf.error/bad-marks` (fail-closed). The same key + enum is accepted on the `reg-flow` registration map. Static topology queries (`sub-topology`, per [006](006-ReactiveSubstrate.md)) read `:rf/inputs` back to project the `:<-` graph.
 
 #### `:rf/fx-meta`
 
@@ -320,10 +324,15 @@ The registration-shape accepted by `reg-flow`. Unlike the other kinds, `reg-flow
     [:inputs       [:vector [:vector :any]]]                                 ;; required: vector of app-db paths; positional args to :output
     [:output       fn?]                                                      ;; required: pure fn (in-1, ..., in-n) → output
     [:path         [:vector :any]]                                           ;; required: app-db path to write output to
+    [:rf.egress/output-sensitivity {:optional true}                         ;; derived-output declassification claim (EP-0015 issue 9); absent ⇒ :rf.egress/inherit
+     [:enum :rf.egress/inherit :rf.egress/sensitive :rf.egress/public]]
+    [:sensitive    {:optional true} [:vector [:vector :any]]]                ;; per-output-path sensitive sub-slots ([[]] = whole)
+    [:large        {:optional true} [:vector [:vector :any]]]                ;; per-output-path large sub-slots ([[]] = whole)
+    [:large?       {:optional true} :boolean]                                ;; whole-output size override (size has no declassification analogue)
     ]])
 ```
 
-`:id`, `:inputs`, `:output`, `:path` are **required** at registration time; the base `:rf/registration-metadata` keys (`:doc`, `:schema`, `:ns`/`:line`/`:file`, `:tags`) compose additively. The `[:id :keyword]` constraint is enforced at the API boundary — `reg-flow` rejects a present-but-non-keyword `:id` rather than normalising it later, so the `:flow-id` trace/error slot never carries an arbitrary id shape (rf2-ihfz9o). `reg-flow` rejects malformed maps with one of five distinct error keys — `:rf.error/flow-missing-id` (`:id` absent), `:rf.error/flow-bad-id` (`:id` present but not a keyword), `:rf.error/flow-bad-inputs`, `:rf.error/flow-bad-output`, `:rf.error/flow-bad-path` — surfaced via [009 §Error contract](009-Instrumentation.md#error-contract); see also [013 §The registration shape](013-Flows.md).
+`:id`, `:inputs`, `:output`, `:path` are **required** at registration time; the base `:rf/registration-metadata` keys (`:doc`, `:schema`, `:ns`/`:line`/`:file`, `:tags`) compose additively. `:rf.egress/output-sensitivity` is the derived-output declassification claim (EP-0015 issue 9; same closed enum as [`SubMeta`](#rfsub-meta)) — the SOLE derived-output sensitivity surface; the boolean `:sensitive?` declassify/force spelling is rejected at registration with `:rf.error/flow-bad-marks`, and an unknown enum value throws the same key (fail-closed). The `[:id :keyword]` constraint is enforced at the API boundary — `reg-flow` rejects a present-but-non-keyword `:id` rather than normalising it later, so the `:flow-id` trace/error slot never carries an arbitrary id shape (rf2-ihfz9o). `reg-flow` rejects malformed maps with one of five distinct error keys — `:rf.error/flow-missing-id` (`:id` absent), `:rf.error/flow-bad-id` (`:id` present but not a keyword), `:rf.error/flow-bad-inputs`, `:rf.error/flow-bad-output`, `:rf.error/flow-bad-path` — surfaced via [009 §Error contract](009-Instrumentation.md#error-contract); see also [013 §The registration shape](013-Flows.md).
 
 #### `:rf/app-schema-meta`
 

--- a/spec/conformance/fixtures/data-classification-derived-output-declassified-public.edn
+++ b/spec/conformance/fixtures/data-classification-derived-output-declassified-public.edn
@@ -1,0 +1,56 @@
+;; Conformance fixture: data-classification/derived-output-declassified-public
+;; Per Spec 015 §Derived sensitivity + §Tests (the
+;; `derived-output-declassified-public.edn` row) — a `reg-sub` reading a
+;; sensitive input WITH `:rf.egress/output-sensitivity :rf.egress/public`
+;; projects its output UNREDACTED (the DECLASSIFICATION case), and the claim
+;; is enumerable as a standing audit surface.
+;;
+;; `:rf.egress/public` is the declassify claim (EP-0015 issue 9) — it replaces
+;; the rejected boolean `:sensitive? false` spelling. The author asserts the
+;; derived value is safe despite the sensitive input, so the propagation that
+;; would otherwise mark the output sensitive is suppressed: the `:rf.sub/run`
+;; trace's `:rf.sub/value` carries the RAW value.
+;;
+;; A `:public` claim is the declassification analogue of `:rf.scope/global`:
+;; the runtime keeps it enumerable so Xray can render a standing
+;; `:public`-claim audit list (mirroring the global-scope audit).
+
+{:fixture/id           :data-classification/derived-output-declassified-public
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub :core/trace
+                         :data-classification/marks}
+ :fixture/doc          "A reg-sub reading a sensitive input with :rf.egress/output-sensitivity :rf.egress/public projects its :rf.sub/run output value UNREDACTED — the declassification case. The :public claim suppresses the input-inherited sensitivity that the default :rf.egress/inherit would propagate."
+
+ :fixture/registry
+ {:event {:dc/init {:doc "Seed a sensitive :count slot."}}
+  :sub   {:dc/declassified {:doc                          "Layer-1 sub reading app-db; declassified with :rf.egress/output-sensitivity :rf.egress/public so its output is NOT marked sensitive despite the sensitive :count input."
+                            :rf.egress/output-sensitivity :rf.egress/public}}}
+
+ :fixture/handlers
+ {:event {:dc/init [[:set [:count] 42]]}
+  :sub   {:dc/declassified [[:get [:count]]]}}
+
+ ;; Mark the input path sensitive BEFORE the sub computes. The :public claim
+ ;; declassifies, so the propagation does NOT mark the sub output sensitive.
+ :fixture/app-marks
+ [{:add-marks {[:count] :sensitive}}]
+
+ :fixture/frame-config
+ {:on-create [:dc/init]}
+
+ :fixture/dispatches
+ [[:dc/init]]
+
+ :fixture/expect
+ {:final-app-db {:count 42}
+
+  :sub-values {[:dc/declassified] 42}
+
+  ;; The :rf.sub/run trace's :rf.sub/value is the RAW value (42) — the
+  ;; :rf.egress/public declassify suppressed the input-inherited sensitivity,
+  ;; so the output is surfaced unredacted.
+  :trace-emissions
+  [{:operation :rf.sub/run
+    :op-type   :rf.sub
+    :tags      {:rf.sub/id    :dc/declassified
+                :rf.sub/value 42}}]}}

--- a/spec/conformance/fixtures/data-classification-derived-output-inherits-sensitivity.edn
+++ b/spec/conformance/fixtures/data-classification-derived-output-inherits-sensitivity.edn
@@ -1,0 +1,61 @@
+;; Conformance fixture: data-classification/derived-output-inherits-sensitivity
+;; Per Spec 015 §Derived sensitivity + §Tests (the
+;; `derived-output-inherits-sensitivity.edn` row) — a `reg-sub` reading a
+;; frame-sensitive input with NO `:rf.egress/output-sensitivity` claim (the
+;; `:rf.egress/inherit` default) projects its output as SENSITIVE.
+;;
+;; A derived output inherits the data-classification of its inputs by default
+;; (EP-0015 issue 8/9, fail-closed — taint by default, declassify explicitly).
+;; The `:count` slot is marked sensitive on the frame; a layer-1 sub reads
+;; app-db, so the conservative footgun-prevention rule treats its output as
+;; sensitive (the sub MAY have read the sensitive slot). The `:rf.sub/run`
+;; trace's `:rf.sub/value` therefore redacts to `:rf/redacted`.
+;;
+;; Harness note: `:fixture/app-marks` installs the sensitive app-db
+;; declaration before the sub runs; the runner's `:sub-values` check triggers
+;; a fresh `:rf.sub/run` emit whose `:rf.sub/value` slot the trace projection
+;; redacts from the per-frame propagation table.
+
+{:fixture/id           :data-classification/derived-output-inherits-sensitivity
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub :core/trace
+                         :data-classification/marks}
+ :fixture/doc          "A reg-sub reading a frame-sensitive input with no :rf.egress/output-sensitivity claim (the :rf.egress/inherit default) projects its :rf.sub/run output value as :rf/redacted — derived sensitivity inherits from inputs by default (fail-closed)."
+
+ :fixture/registry
+ {:event {:dc/init {:doc "Seed a sensitive :count slot."}}
+  :sub   {:dc/derived {:doc "Layer-1 sub reading app-db; inherits sensitivity from the frame-sensitive :count slot by default (no :rf.egress/output-sensitivity claim)."}}}
+
+ :fixture/handlers
+ {:event {:dc/init [[:set [:count] 42]]}
+  :sub   {:dc/derived [[:get [:count]]]}}
+
+ ;; Mark the input path sensitive BEFORE the sub computes, so the layer-1
+ ;; propagation marks the sub's output sensitive.
+ :fixture/app-marks
+ [{:add-marks {[:count] :sensitive}}]
+
+ :fixture/frame-config
+ {:on-create [:dc/init]}
+
+ :fixture/dispatches
+ [[:dc/init]]
+
+ :fixture/expect
+ ;; The committed app-db is the RAW value — redaction is a trace-egress
+ ;; concern only.
+ {:final-app-db {:count 42}
+
+  ;; The runner's :sub-values check triggers a fresh :rf.sub/run emit. The
+  ;; value the runner reads is the RAW computed value (a direct sub read,
+  ;; not egress); the LOAD-BEARING assertion is the trace slot below.
+  :sub-values {[:dc/derived] 42}
+
+  ;; The :rf.sub/run trace's :rf.sub/value redacts to :rf/redacted because the
+  ;; sub's output inherited sensitivity from the frame-sensitive input, and the
+  ;; event carries the top-level :sensitive? true stamp.
+  :trace-emissions
+  [{:operation :rf.sub/run
+    :op-type   :rf.sub
+    :tags      {:rf.sub/id    :dc/derived
+                :rf.sub/value :rf/redacted}}]}}

--- a/tools/xray/spec/012-Views.md
+++ b/tools/xray/spec/012-Views.md
@@ -427,6 +427,32 @@ The panel observes; the framework records.
 | `:rf/epoch-record :db-before` / `:db-after` | Same | Changed-paths derivation used to attribute layer-1 invalidations to specific `app-db` slices. |
 | Render-tracker `:owning-frame` tag | Spec 009 / [`018-Event-Spine.md`](018-Event-Spine.md) §8 I3 | The isolation filter: `(filter #(= (:owning-frame %) (sub :rf.xray/focus.frame)) renders)`. |
 
+## Declassification audit (`:rf.egress/public` claims)
+
+The Views panel renders a STANDING **Declassified Outputs** audit list — the
+declassification analogue of the Resources panel's `:rf.scope/global`
+scope-audit ([`024-Resources-Panel.md`](024-Resources-Panel.md)). It
+enumerates every registered subscription / flow that carries
+`:rf.egress/output-sensitivity :rf.egress/public` — the EP-0015 issue 9
+derived-output declassification claim ([spec/015 §Derived
+sensitivity](../../../spec/015-Data-Classification.md#derived-sensitivity)).
+
+A `:public` claim asserts "this derived-from-sensitive value is safe to
+surface despite sensitive inputs." Because it is the framework-blessed way to
+turn redaction OFF on a derived output, every such claim is a security-review
+surface: the audit list lets a reviewer see, at a glance, every place an
+author opted out of the fail-closed default. No reason-note is required in v1.
+
+| Surface | Spec | Use |
+|---|---|---|
+| `re-frame.marks/public-declassification-claims` | [spec/015 §Derived sensitivity](../../../spec/015-Data-Classification.md#derived-sensitivity) | Registry-level read returning `[{:kind :sub|:flow :id …} …]` for every `:rf.egress/public`-declared derived output. Pure over the process marks table. |
+
+The list is REGISTRY-level (not epoch-scoped), so it renders even when no
+cascade is focused (the panel's only always-on section). Empty state:
+`(no derived outputs declassified)`. Rendered under
+`rf-xray-reactive-declassify-section` / `-list` / `-row-<id>` /
+`-empty` / `-caption` testids.
+
 ## Isolation invariant (I3)
 
 The Views panel's render projection is filtered to the selected frame

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_subs.cljs
@@ -75,7 +75,15 @@
          :view-rows       [{:view-id _ :action _ :reason {...} :coord _} ...]
          :counts          {:subs-ran N :subs-skipped N
                            :views-rendered N
-                           :flows-recomputed N}}
+                           :flows-recomputed N}
+         :public-declassifications [{:kind <kind> :id <id>} ...]}
+
+  `:public-declassifications` (EP-0015 issue 9) is the STANDING
+  derived-output declassification audit — every registered sub / flow
+  carrying `:rf.egress/output-sensitivity :rf.egress/public`, the
+  declassification analogue of the resources `:rf.scope/global` audit.
+  Registry-level (NOT epoch-scoped), so it renders even with no cascade
+  focused.
 
   `:sub-readers` (rf2-y23uw) is the shared-subscription edge map — for
   each sub-id, the views that deref'd it this cascade ('which views read
@@ -97,6 +105,7 @@
   `install!` registers `:rf.xray/reactive-data` + the panel-local
   disclosure-toggle state slot. Idempotent."
   (:require [re-frame.core :as rf]
+            [re-frame.marks :as marks]
             [re-frame.subs.tooling :as subs-tooling]
             [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]))
 
@@ -509,6 +518,24 @@
                         :flows-recomputed flows-comp
                         :flows-skipped    flows-skipped}})))
 
+(defn public-declassification-rows
+  "The STANDING derived-output declassification audit (EP-0015 issue 9; Spec
+  015 §Derived sensitivity): enumerate every registered sub / flow that
+  carries `:rf.egress/output-sensitivity :rf.egress/public`. A `:public`
+  claim is the declassification analogue of a resource's `:rf.scope/global`
+  scope, so this list is the sibling of the resources panel's
+  `global-scope-audit` — it lets a reviewer see every place an author
+  asserted 'this derived-from-sensitive value is safe to surface.'
+
+  Registry-level (NOT epoch-scoped) — reads the process marks table via
+  `re-frame.marks/public-declassification-claims`. Returns
+  `[{:kind <kind> :id <id>} …]` sorted stably; empty when nothing is
+  declassified. Defensive `try` so a marks-table read never crashes the
+  panel."
+  []
+  (try (vec (marks/public-declassification-claims))
+       (catch :default _ [])))
+
 (defn- triggered-by
   "The triggering event vector for the epoch. Reads the `:event` slot
   the spine seeds on every epoch record (per spec/018) — the single
@@ -553,6 +580,11 @@
                 :dispatch-id  (:dispatch-id focus)
                 :triggered-by (when record (triggered-by record))
                 :seed-paths   (when record (seed-paths record))
+                ;; The STANDING :public-claim declassification audit — a
+                ;; registry-level surface (sibling of the resources
+                ;; :rf.scope/global audit), independent of the focused
+                ;; cascade, so it renders even with no epoch focused.
+                :public-declassifications (public-declassification-rows)
                 :has-cascade? (some? record)}))))
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_view.cljs
@@ -452,6 +452,39 @@
           :style destroyed-caption-style}
       "Subscriptions cleaned up when their last reader unmounted"]]))
 
+(defn- declassification-audit-section
+  "The STANDING `:public`-claim declassification audit (EP-0015 issue 9;
+  Spec 015 §Derived sensitivity). Enumerates every registered sub / flow
+  carrying `:rf.egress/output-sensitivity :rf.egress/public` — the
+  declassification analogue of the resources panel's `:rf.scope/global`
+  scope-audit list, so a reviewer can see every place an author asserted a
+  derived-from-sensitive value is safe to surface.
+
+  Registry-level (NOT epoch-scoped) — `:public-declassifications` rides the
+  composite independent of the focused cascade, so this list renders even
+  with no event focused (it is the panel's only always-on section)."
+  [data]
+  (let [rows (:public-declassifications data)]
+    [:section {:data-testid "rf-xray-reactive-declassify-section"
+               :style section-margin-top-style}
+     (section-label "declassify" "Declassified Outputs")
+     (if (seq rows)
+       (into [:div {:data-testid "rf-xray-reactive-declassify-list"
+                    :style list-card-style}]
+             (for [{:keys [kind id]} rows]
+               ^{:key (str kind "/" id)}
+               [list-row {:testid (str "rf-xray-reactive-declassify-row-"
+                                       (id-slug id))
+                          :swatch-token :warning
+                          :primary (format-id id)
+                          :tag (str kind " · :rf.egress/public")}]))
+       [:div {:data-testid "rf-xray-reactive-declassify-empty"
+              :style empty-placeholder-style}
+        "(no derived outputs declassified)"])
+     [:p {:data-testid "rf-xray-reactive-declassify-caption"
+          :style destroyed-caption-style}
+      "Outputs an author asserted safe via :rf.egress/output-sensitivity :rf.egress/public — review each"]]))
+
 ;; ---- legend ------------------------------------------------------------
 
 (def ^:private legend-swatch-wrapper-style
@@ -525,11 +558,14 @@
                        :font-family sans-stack
                        :font-size "14px"}}
      [:div {:style {:flex 1 :overflow "auto"}}
-      (cond
-        (not (:has-cascade? data))
-        (empty-state data)
-
-        :else
+      ;; The :public-claim declassification audit is REGISTRY-level (not
+      ;; epoch-scoped), so it renders in BOTH branches — even the no-cascade
+      ;; empty state — at the bottom of the panel.
+      (if (not (:has-cascade? data))
+        [:div {:data-testid "rf-xray-reactive-pipeline-empty"
+               :style {:padding "16px"}}
+         (empty-state data)
+         (declassification-audit-section data)]
         [:div {:data-testid "rf-xray-reactive-pipeline"
                :style {:padding "16px"}}
          [:section {:data-testid "rf-xray-reactive-flow-section"}
@@ -537,4 +573,5 @@
           (flow-graph data)]
          (unmounted-views-section data)
          (destroyed-subs-section data)
+         (declassification-audit-section data)
          (legend)])]]))


### PR DESCRIPTION
Implements EP-0015 disposition 9 (ruled, authoritative): the closed `:rf.egress/output-sensitivity` declassification enum on derived sub/flow outputs, replacing the rejected `:sensitive? false` overload, plus the standing Xray `:public`-claim audit. Spec-present / impl-absent → reconciled. Closes rf2-t55hxg.8 (and its test complement rf2-t55hxg.1).

## What changed

**The enum (`:rf.egress/inherit | :rf.egress/sensitive | :rf.egress/public`)**
- `re-frame.marks`: `normalise-marks` recognises + closed-enum-validates `:rf.egress/output-sensitivity` (fail-closed — an unknown value throws `:rf.error/bad-marks`; `:inherit` is the safe default). `resolve-sub-output-marks` consults the claim: `:sensitive` forces, `:public` declassifies, absent/`:inherit` propagates from inputs. The union helpers (`union-marks!` / `merge-schema-marks`) carry the claim monotone-toward-sensitive (force wins over declassify).
- `re-frame.flows.registry`: validation rejects `:sensitive?` and closed-enum-validates `:rf.egress/output-sensitivity`; the flow output resolver honours `:sensitive` (force) / `:public` (declassify).

**Rejected-overload removal**
- The boolean `:sensitive? false` (declassify) / `:sensitive? true` (force) spelling on a **derived** output is now rejected at registration (`:sub` kind + `reg-flow`), with a recovery hint naming the enum (Spec 015:425). Scoped to derived outputs only — `:sensitive?` as a Malli schema-slot prop (machines/resources/schemas) and the legacy stored-but-ignored `:event`-meta vestige are untouched. `:large?` is unchanged (size has no declassification analogue).

**Xray `:public`-claim audit**
- `re-frame.marks/public-declassification-claims` enumerates every sub/flow carrying `:rf.egress/output-sensitivity :rf.egress/public` — the declassification analogue of the resources `:rf.scope/global` scope-audit.
- Views (reactive) panel renders a standing **Declassified Outputs** audit list (registry-level, always-on even with no cascade focused). `tools/xray/spec/012-Views.md` documents it.

**Spec reconciliation**
- Two sub-based conformance fixtures backing the spec/015 §Tests rows (`derived-output-inherits-sensitivity`, `derived-output-declassified-public`).
- `spec/Spec-Schemas.md`: `:rf.egress/output-sensitivity` added to `SubMeta` + `FlowMeta`. (spec/015 §Derived + Conventions prose already matched the code — no drift to fix.)
- Tests migrated to the enum; new coverage for the rejection, fail-closed unknown-value throw, the inherit/force/declassify resolution, and the audit reader.

## Quality gates
- `npm run test:cljs` — 6734 tests, 27185 assertions, 0 failures (incl. the conformance corpus + the two new fixtures)
- `clojure -M:test` core (1266 tests), flows (197 tests), schemas-sensitive (66 tests) — all 0 failures
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures, all testbeds compiled 0 warnings
- `npm run test:bundle-isolation` — PASS (production bundles 0 warnings; no internal-sentinel leak)
- `mkdocs build --strict` — built clean

Do NOT merge — handing back for review.
