### PR TITLE
fix: EP-0010 :app/now-ms cofx + causal resource-freshness reads (rf2-2941zx + 95b0lc)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -372,3 +372,37 @@
     ;; event vector before invoking the chain — so this cofx is a no-op.
     ;; Registered for symmetry with `:db`.
     ctx))
+
+;; ---- EP-0010 compatibility time cofx --------------------------------------
+;;
+;; The initial recordable time coeffect (EP-0010 §Backwards Compatibility and
+;; Migration, reference-implementation step 7). It is the migration target for
+;; the v1-style `(inject-cofx :now)` source shape: handlers that need a
+;; wall-clock instant for a DURABLE write read it from the dispatch envelope's
+;; causal `:rf.world/inputs` `:time-ms` (the one host-clock read the router
+;; stamped at the causal boundary — Spec 002 §The World-Input Rule) rather than
+;; calling `interop/now-ms` / `(.now js/Date)` ambiently at the write site.
+;;
+;; Because the value is sourced from `:rf.world/inputs` — already captured in
+;; the replay record and projected/elided like other replayable event data —
+;; this cofx is RECORDABLE: a scripted / replayed / SSR-hydration dispatch that
+;; supplies an exact `:rf.world/inputs {:time-ms …}` sees that exact value
+;; returned, with NO ambient clock read. That satisfies the durable-coeffect
+;; requirement (Spec 002 §Event Context And Coeffects: "a coeffect that can
+;; affect durable state MUST be recordable").
+;;
+;; `:rf.world/inputs` is a framework coeffect the runtime seeds into every
+;; event context (`re-frame.router/build-envelope`), so this cofx is a pure
+;; read of an already-present coeffect — no host call of its own. When
+;; `:rf.world/inputs` is absent (a handler invoked outside the dispatch path)
+;; the injected value is `nil`; a durable handler MUST get its time from a
+;; stamped envelope.
+;;
+;; UUID / random helpers are deferred per EP-0010 rider a — only the core time
+;; path ships in this initial slice.
+
+(reg-cofx :app/now-ms
+  {:doc "EP-0010 compatibility time coeffect. Injects the dispatch envelope's causal `(:time-ms (:rf.world/inputs cofx))` under `:coeffects :app/now-ms` — the recordable migration target for v1-style host-clock reads (`interop/now-ms` / `(.now js/Date)`) in durable handlers. Reads only the already-seeded `:rf.world/inputs` coeffect; performs no ambient clock read, so a scripted/replayed `:time-ms` is returned exactly. nil when `:rf.world/inputs` is absent (a handler invoked outside the dispatch path)."}
+  (fn [ctx]
+    (let [world (get-in ctx [:coeffects :rf.world/inputs])]
+      (assoc-in ctx [:coeffects :app/now-ms] (:time-ms world)))))

--- a/implementation/core/test/re_frame/cofx_test.clj
+++ b/implementation/core/test/re_frame/cofx_test.clj
@@ -42,6 +42,10 @@
   (require 're-frame.routing :reload)
   (require 're-frame.ssr     :reload)
   (require 're-frame.machines :reload)
+  ;; rf2-2941zx — re-register the standard cofx (`:db` / `:event`) plus the
+  ;; EP-0010 `:app/now-ms` compatibility time cofx, wiped by `clear-all!`.
+  ;; The `:app/now-ms` injection test below resolves it from the registry.
+  (require 're-frame.cofx     :reload)
   ;; EP-0002: establish an explicit frame scope for the body. `init!` no
   ;; longer creates `:rf/default`; register it as an ordinary frame and
   ;; pin `*current-frame*` so the ambient `dispatch-sync` calls below
@@ -403,3 +407,68 @@
       (is (= 1 (count (filter #(= :rf.cofx/skipped-on-platform (:operation %))
                               @traces)))
           "the skip trace fired instead"))))
+
+;; ---- EP-0010 :app/now-ms compatibility time cofx (rf2-2941zx) --------------
+;;
+;; The initial recordable time coeffect (EP-0010 §Backwards Compatibility and
+;; Migration, reference-implementation step 7): `:app/now-ms` injects the
+;; dispatch envelope's causal `(:time-ms (:rf.world/inputs cofx))` so a v1-style
+;; host-clock read in a durable handler becomes a recordable coeffect. It reads
+;; ONLY the already-seeded `:rf.world/inputs` framework coeffect — no ambient
+;; `(.now js/Date)` / `interop/now-ms` of its own — so a scripted / replayed
+;; `:time-ms` is returned exactly (Spec 002 §Event Context And Coeffects: a
+;; coeffect that can affect durable state MUST be recordable).
+
+(deftest app-now-ms-reads-causal-time-ms-exactly
+  (testing ":app/now-ms returns the supplied :rf.world/inputs :time-ms VERBATIM
+            — a scripted past timestamp comes back exactly, proving no ambient
+            clock read at the injection site (replay determinism)"
+    (let [scripted 1781078400123      ;; a fixed past epoch-ms; an ambient
+          seen     (atom ::unset)]    ;; (.now js/Date) read would never equal it
+      (rf/reg-event-fx :cofx-test/read-now
+        [(rf/inject-cofx :app/now-ms)]
+        (fn [{:keys [app/now-ms]} _]
+          (reset! seen now-ms)
+          {}))
+      (rf/dispatch-sync [:cofx-test/read-now]
+                        {:rf.world/inputs {:time-ms scripted}})
+      (is (= scripted @seen)
+          "the handler saw the EXACT scripted :time-ms — sourced from the causal
+           token, not a live host-clock read (a replayed dispatch is stable)"))))
+
+(deftest app-now-ms-tracks-router-stamped-time-ms
+  (testing "with no caller-supplied world inputs, :app/now-ms returns the SAME
+            value the router stamped on the envelope (:rf.world/inputs :time-ms)
+            — one causal read, surfaced through the cofx (not a second read)"
+    (let [seen-now   (atom ::unset)
+          seen-world (atom ::unset)]
+      (rf/reg-event-fx :cofx-test/read-now-stamped
+        [(rf/inject-cofx :app/now-ms)]
+        (fn [{:keys [app/now-ms rf.world/inputs]} _]
+          (reset! seen-now now-ms)
+          (reset! seen-world (:time-ms inputs))
+          {}))
+      (rf/dispatch-sync [:cofx-test/read-now-stamped])
+      (is (number? @seen-now)
+          ":app/now-ms is a stamped epoch-ms number on the live path")
+      (is (= @seen-world @seen-now)
+          ":app/now-ms equals the envelope's own :rf.world/inputs :time-ms —
+           it surfaces the single causal read, never re-reads the host"))))
+
+(deftest app-now-ms-nil-without-world-inputs
+  (testing ":app/now-ms injects nil when no :rf.world/inputs coeffect is present
+            (a handler invoked outside the dispatch path) — it never falls back
+            to an ambient host read (durable time must come from a stamped
+            envelope)"
+    (let [seen   (atom ::unset)
+          ;; Drive the cofx directly with a context carrying NO :rf.world/inputs
+          ;; coeffect — isolates the cofx body from the router's stamping so the
+          ;; nil-source branch is exercised deterministically.
+          cofx    (registrar/lookup :cofx :app/now-ms)
+          handler (:handler-fn cofx)
+          ctx     {:coeffects {:event [:cofx-test/no-world]}}
+          result  (handler ctx)]
+      (reset! seen (get-in result [:coeffects :app/now-ms]))
+      (is (nil? @seen)
+          "no :rf.world/inputs → :app/now-ms is nil (no ambient (.now js/Date)
+           fallback — durable time is causal-only)"))))

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -71,15 +71,19 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-;; ---- shared clock + work-id -----------------------------------------------
-
-(defn- now-ms
-  "Current epoch-ms. Used for `:loaded-at` / `:stale-at` durable
-  timestamps (Spec 016 §Stale and GC scheduling: freshness is computed
-  from durable timestamps). Host-platform clock."
-  []
-  #?(:clj  (System/currentTimeMillis)
-     :cljs (.now js/Date)))
+;; ---- shared timestamp helpers ---------------------------------------------
+;;
+;; EP-0010 §The World-Input Rule (rf2-95b0lc): event handlers in this
+;; namespace take their "now" from the triggering token's causal
+;; `(:time-ms (:rf.world/inputs cofx))` — the one host-clock read the router
+;; stamped at the causal boundary — NOT an ambient `(.now js/Date)` /
+;; `System/currentTimeMillis` read at the decision site. There is therefore no
+;; private host-clock helper here: a handler reading the live host clock for a
+;; freshness DECISION would be non-replayable (a replay under a later clock
+;; could take a different branch). Passive view / SSR re-derivation reads
+;; (`subs.cljc`, `ssr.cljc`) keep their own ambient `now-ms` — those are reads,
+;; not handler decisions (EP §Restore endorses lazy on-read freshness for the
+;; VIEW layer).
 
 (defn- stale-at-for
   "Compute `:stale-at` from `loaded-at` + the resource's `:stale-after-ms`
@@ -121,7 +125,8 @@
 
   `force-new?` false (ensure) ALSO short-circuits a FRESH-SKIP: an
   `ensure` of an already-`:loaded` entry that is still fresh-by-policy
-  (`state/entry-stale?` false against `now-ms`) neither dedupes (no
+  (`state/entry-stale?` false against the token's causal `(:time-ms world)`)
+  neither dedupes (no
   in-flight work to join) nor starts a fetch — it serves the cached value,
   attaches the supplied owner lease, emits `:rf.resource/cache-hit`, and
   (for a route-owned blocking resource) drains the blocking slot
@@ -180,10 +185,25 @@
         ;; entry can't exist — `:fetching`/`:loading` is the in-flight
         ;; status — but the explicit `(not in-flight?)` guard keeps the two
         ;; branches disjoint and order-independent).
+        ;;
+        ;; EP-0010 §The World-Input Rule (clauses 2 + 5, rf2-95b0lc): this is
+        ;; a FRESHNESS DECISION that gates a DURABLE runtime-db write — the
+        ;; fresh branch serves cache (no new work-ledger row), the stale
+        ;; branch mints a new generation + work record. The basis MUST be the
+        ;; triggering token's causal `(:time-ms world)` (already in scope and
+        ;; used below for the durable `:started-at`), NOT an ambient
+        ;; `(now-ms)` host read — otherwise a replay under a LATER live clock
+        ;; could take the OPPOSITE branch (refetch vs serve-cache) and produce
+        ;; a divergent work-ledger, breaking the EP's same-tokens→equal-durable
+        ;; -projections property at the decision boundary. The durable
+        ;; `:stale-at`/`:loaded-at` facts the entry carries are still the
+        ;; freshness data; `(:time-ms world)` is the causal "now" they are
+        ;; compared against (EP §Restore: "freshness decisions made lazily
+        ;; from that token plus durable timestamps").
         fresh-skip? (and (not force-new?)
                          (not in-flight?)
                          (= :loaded (:status entry))
-                         (not (state/entry-stale? entry (now-ms))))
+                         (not (state/entry-stale? entry (:time-ms world))))
         ;; a NEW owner lease lands on the entry when an owner is supplied and
         ;; was not already in the active-owner set. `:rf.resource/owner-attached`
         ;; marks that liveness change distinctly from work — symmetric with the
@@ -415,7 +435,10 @@
 ;;     entry is GC fodder, not a revalidation target);
 ;;   - DURABLE stale/fresh timestamps decide WHETHER — `state/entry-stale?`
 ;;     (the single shared freshness derivation the subs / SSR / stale-timer
-;;     re-check all use) against the live clock; a fresh entry is LEFT ALONE;
+;;     re-check all use) against the focus/reconnect token's causal
+;;     `(:time-ms world)` (rf2-95b0lc — not an ambient host-clock read at the
+;;     scan site, so the SELECTION is replay-stable); a fresh entry is LEFT
+;;     ALONE;
 ;;   - GENERATION CHECKS suppress stale replies — the refetch lowers through
 ;;     the ordinary `ensure-load` path (force-new generation), so a
 ;;     focus-triggered refetch is just another CAUSE; it attaches NO owner, so
@@ -517,10 +540,19 @@
 
   `signal` is the revalidation op (`:rf.resource/window-focused` /
   `:rf.resource/network-reconnected`) for the trace; `cause` is the cause
-  keyword recorded on each refetch."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id} signal cause]
+  keyword recorded on each refetch.
+
+  EP-0010 §The World-Input Rule (rf2-95b0lc): the active-stale SELECTION is a
+  freshness decision — it picks which entries get a `:refetch` dispatched —
+  so its basis is the triggering focus/reconnect token's causal
+  `(:time-ms world)`, not an ambient `(now-ms)` host read. The scan writes
+  nothing durable itself (the child refetches do, each stamped with its own
+  fresh world inputs), so this is the softer of the three sites; but a
+  replayed focus/reconnect must still SELECT the same set the recorded
+  `:time-ms` dictated, or the replay diverges from the original run."
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs} signal cause]
   (let [runtime-db (or rt {})
-        eligible   (active-stale-scan runtime-db (now-ms))
+        eligible   (active-stale-scan runtime-db (:time-ms world))
         refetches  (mapv (fn [{:keys [resource scope params]}]
                            [:dispatch [:rf.resource/refetch
                                        {:resource resource :scope scope
@@ -1486,7 +1518,7 @@
       stale entry refreshes on its next live cause: route re-entry, an
       explicit event, or the focus/reconnect active-stale scan
       `revalidate-handler`, rf2-vtblcq)."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
    [_event-id {:keys [resource-key]}]]
   (let [runtime-db (or rt {})
         entry      (get-in runtime-db (state/entry-path resource-key))
@@ -1495,7 +1527,16 @@
         ;; re-loaded since the timer armed has a future :stale-at and is not
         ;; yet stale, so the re-check naturally no-ops. Shared derivation
         ;; (`state/entry-stale?`) so it never drifts from the subs / SSR view.
-        stale?     (state/entry-stale? entry (now-ms))]
+        ;;
+        ;; EP-0010 §Resources / §The World-Input Rule (rf2-95b0lc): a TIMER-
+        ;; FIRE event's freshness re-check uses the timer-fire envelope's own
+        ;; causal `(:time-ms world)`, not an ambient `(now-ms)` host read.
+        ;; This handler writes nothing durable (the decision is trace-only —
+        ;; the durable `:stale-at` already drives the `:stale?` sub), but the
+        ;; recorded `:decision` must be replay-stable: a replayed
+        ;; `:stale-fired` under a later live clock must classify the entry the
+        ;; same way the recorded `:time-ms` did.
+        stale?     (state/entry-stale? entry (:time-ms world))]
     (trace/emit! :rf.event :rf.resource/stale-fired
                  {:rf.frame/id frame-id :resource-key resource-key
                   :decision (cond (nil? entry) :no-entry

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -538,6 +538,67 @@
     (testing ":stale-at = :loaded-at + the :stale-after-ms policy"
       (is (= (+ completed-at 60000) (:stale-at (entry scoped-key)))))))
 
+;; rf2-95b0lc / EP-0010 §The World-Input Rule: the ensure FRESH-SKIP gate is a
+;; freshness DECISION that gates a durable runtime-db write (serve-cache vs
+;; start-new-work). Its basis MUST be the ensure token's causal
+;; `(:time-ms (:rf.world/inputs cofx))`, NOT an ambient host-clock read — so a
+;; replayed ensure under a LATER live clock takes the SAME branch the recorded
+;; `:time-ms` dictated. Pre-fix the gate read `(now-ms)` (= the live host
+;; clock, ~1.78e12 epoch-ms / `System/currentTimeMillis`), which dwarfs any
+;; scripted `:stale-at`, so a replay always re-read the live clock and could
+;; flip serve-cache → refetch, minting a DIVERGENT work-ledger row.
+(deftest fresh-skip-decision-reads-causal-time-ms-not-ambient-clock
+  (rf/reg-resource :fsd/article (article-spec {:stale-after-ms 60000}))
+  (let [scoped-key  (state/scoped-resource-key :rf.scope/global :fsd/article {:slug "w"})
+        t0          1000000          ;; a SMALL scripted epoch-ms (a "recorded
+        ;; run" basis far below the live host clock). The entry loads at t0 and
+        ;; is fresh until t0 + 60000.
+        completed-at t0]
+    ;; --- first ensure + scripted reply: entry loads, fresh until t0+60s ------
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :fsd/article :scope :rf.scope/global
+                                            :params {:slug "w"} :owner [:lease :fsd 1]}])
+    (let [e (entry scoped-key)]
+      (rf/dispatch-sync [:rf.resource.internal/succeeded
+                         {:resource-key scoped-key :work/id (:current-work e)
+                          :generation (:generation e) :data {:title "W"}}]
+                        {:rf.world/inputs {:time-ms completed-at}}))
+    (is (= :loaded (:status (entry scoped-key))) "entry loaded")
+    (is (= (+ t0 60000) (:stale-at (entry scoped-key))) "durable :stale-at = t0 + policy")
+    (let [gen0 (:generation (entry scoped-key))]
+      ;; --- replay the ensure under a LATER causal clock, still WITHIN the
+      ;; freshness window — MUST fresh-skip (serve cache), even though the LIVE
+      ;; host clock is decades past t0+60s. -------------------------------------
+      (reset! last-managed-args nil)
+      (rf/dispatch-sync [:rf.resource/ensure {:resource :fsd/article :scope :rf.scope/global
+                                              :params {:slug "w"} :owner [:lease :fsd 1]}]
+                        ;; scripted causal "now": t0 + 30s — fresh by policy.
+                        {:rf.world/inputs {:time-ms (+ t0 30000)}})
+      (testing "a within-window causal :time-ms takes the FRESH-SKIP branch
+                — no new work, no transport call, generation unchanged"
+        (is (nil? @last-managed-args)
+            "no managed-HTTP fetch fired — the ensure served cache (fresh-skip),
+             NOT a new load (a pre-fix ambient (now-ms) read would have seen the
+             live clock far past :stale-at and started a divergent fetch)")
+        (is (= gen0 (:generation (entry scoped-key)))
+            "generation unchanged — no new work-ledger generation was minted")
+        (is (= :loaded (:status (entry scoped-key)))
+            "entry stayed :loaded (served cache); did NOT transition to :fetching"))
+      ;; --- the SAME entry, replayed under a causal :time-ms PAST the window,
+      ;; takes the opposite (refetch) branch — proving the gate genuinely reads
+      ;; the causal token, not a constant. ------------------------------------
+      (reset! last-managed-args nil)
+      (rf/dispatch-sync [:rf.resource/ensure {:resource :fsd/article :scope :rf.scope/global
+                                              :params {:slug "w"} :owner [:lease :fsd 1]}]
+                        ;; scripted causal "now": t0 + 90s — STALE by policy.
+                        {:rf.world/inputs {:time-ms (+ t0 90000)}})
+      (testing "a past-window causal :time-ms takes the REFETCH branch — a new
+                load fires (the decision tracks the causal token both ways)"
+        (is (some? @last-managed-args)
+            "a managed-HTTP fetch fired — the stale-by-causal-time ensure started
+             a fresh load")
+        (is (= (inc gen0) (:generation (entry scoped-key)))
+            "a new generation was minted — the stale ensure forced new work")))))
+
 ;; ===========================================================================
 ;; 10. owner release / clear-scope / remove / tag invalidation
 ;; ===========================================================================


### PR DESCRIPTION
Closes two EP-0010 (causal world inputs) consistency gaps so durable time DECISIONS read the dispatch token's causal `:rf.world/inputs` `:time-ms` rather than an ambient host-clock read. EP-0010's property — same tokens → equal durable projections — was holding for durable timestamp VALUES but breaking at the freshness-DECISION boundary.

## rf2-2941zx — add the `:app/now-ms` compatibility time cofx (EP-0010 step 7)

`implementation/core/src/re_frame/cofx.cljc`: new `:app/now-ms` cofx injects `(:time-ms (:rf.world/inputs cofx))` under `:coeffects :app/now-ms`.

- **Time-source fix**: the migration target for v1-style `(inject-cofx :now)` host-clock reads in durable handlers. It reads ONLY the already-seeded `:rf.world/inputs` framework coeffect (the one causal `now-ms` the router stamped at the dispatch boundary) — it performs NO ambient `(.now js/Date)` / `interop/now-ms` of its own. A scripted / replayed `:time-ms` is therefore returned exactly (recordable per Spec 002 §Event Context And Coeffects).
- Registered in `re-frame.cofx` alongside the standard `:db` / `:event`. `nil` when `:rf.world/inputs` is absent (a handler invoked outside the dispatch path) — no host fallback. UUID/random helpers deferred per EP-0010 rider a.
- Exact spec-blessed shape from `docs/EP/EP-0010-causal-world-inputs.md` §Backwards Compatibility and Migration.

## rf2-95b0lc — route resource-freshness DECISIONS off the causal token (3 sites)

`implementation/resources/src/re_frame/resources/events.cljc` — all three handler-side freshness decisions converted from ambient `(now-ms)` to the triggering token's causal `(:time-ms world)`:

1. **`ensure-load` fresh-skip? gate** (line ~186): gates a DURABLE runtime-db write (serve-cache vs start-new-work / new work-ledger row). `world` was already destructured and used for the durable `:started-at` — mechanical fix to `(:time-ms world)`. This was the clearest case (could mint a divergent work-ledger on replay).
2. **`revalidate-handler` active-stale SELECTION** (focus/reconnect): bound `:rf.world/inputs` into the handler and scan against `(:time-ms world)`. Writes nothing durable itself, but the SELECTION must be replay-stable.
3. **`stale-fired-handler` timer-fire re-check**: bound `:rf.world/inputs` and re-check against the timer-fire envelope's own `(:time-ms world)` (EP §Resources: timer wake-ups use the timer-fire event's `:time-ms`). Trace-only decision, now replay-stable.

Removed the now-unused private `now-ms` host-clock helper from `events.cljc` (all three call sites converted). Passive view / SSR re-derivation reads in `subs.cljc` / `ssr.cljc` keep their own ambient `now-ms` — EP §Restore endorses lazy on-read freshness for the VIEW layer; those are reads, not handler decisions, and the bead explicitly scopes them out.

All three target handlers dispatch through the router's `build-envelope`, which stamps `:rf.world/inputs {:time-ms …}` unconditionally (production too), so `(:time-ms world)` is always present.

## Tests

- `cofx_test.clj` (+3): `:app/now-ms` returns the supplied `:time-ms` VERBATIM (scripted past timestamp ⇒ exact, proving no ambient read); equals the router-stamped envelope `:time-ms` on the live path; `nil` with no world inputs (no host fallback). Fixture reloads `re-frame.cofx` so the registration survives `clear-all!`.
- `resources_runtime_cljs_test.cljc` (+1) replay-determinism: load an entry at a small scripted `t0` (stale-after 60s), then replay `ensure` under a causal `:time-ms` of `t0+30s` (within window) ⇒ fresh-skip (no transport call, generation unchanged); and `t0+90s` (past window) ⇒ refetch (new generation). Both run under a live host clock decades past `t0` — pre-fix the ambient `(now-ms)` read would always refetch.

## Quality gates

- `npm run test:cljs` — 6754 tests, 27263 assertions, 0 failures / 0 errors
- core `clojure -M:test` — 1295 tests, 5699 assertions, 0 failures / 0 errors
- resources `clojure -M:test` — 329 tests, 1260 assertions, 0 failures / 0 errors
- `mkdocs build --strict` — N/A (no `spec/` or `docs/` files touched; implementation src + test only)