### PR TITLE
EP-0011 wave-end tail — code-comments + final review (rf2-t4syko + btzh6b)

### DIFF
--- a/docs/EP/EP-0011-uniform-async-reply-envelope.md
+++ b/docs/EP/EP-0011-uniform-async-reply-envelope.md
@@ -33,9 +33,11 @@ Type: standards-track
 > omission.
 >
 > **`final` settles the decisions; it does not on its own assert the build is
-> gap-free (EP-0005 pattern).** Two non-blocking follow-ups remain open and are
-> tracked in the [Implementation errata](#implementation-errata) ledger below —
-> neither reopens a ruling.
+> gap-free (EP-0005 pattern).** One non-blocking follow-up remains open (a P4
+> cosmetic one-name-per-fact tidy); the one P3 observability follow-up has since
+> been resolved. Both are tracked in the
+> [Implementation errata](#implementation-errata) ledger below — neither reopens
+> a ruling.
 >
 > Plain-language summary: when framework-managed async work completes, it
 > reports back as one standard reply map delivered to one standard reply target.
@@ -53,24 +55,30 @@ conformance-proven by the test-only managed-timer probe. The final correctness
 review (`rf2-zqefg3.9`) and this completeness review (`rf2-zqefg3.10`) both
 passed clean with no state-safety or correctness defect.
 
-The items below are **open errata** — small build/tidy follow-ups that carry
-out the settled design; neither reopens a ruling or changes a contract. They
-are recorded here per the EP-0005 final-with-errata pattern: finalizing the
-*decisions* does not, on its own, assert the *implementation* is gap-free.
+The items below carry out the settled design; neither reopens a ruling or
+changes a contract. They are recorded here per the EP-0005 final-with-errata
+pattern: finalizing the *decisions* does not, on its own, assert the
+*implementation* is gap-free.
 
-- **`rf2-lohbfg`** *(open — P3, observability, behaviourally safe)* — wire the
-  machine `stale-spawn-reply` into the one reachable machine-supersession path:
-  a spawned child reaching a `:final?` leaf *after* its parent was already
-  destroyed. That path is handled today in `finalize-machine` by silently
-  reducing `:on-done` to identity when the parent snapshot is `nil` — which is
+- **`rf2-lohbfg`** *(RESOLVED — P3, observability, behaviourally safe)* — wire
+  the machine `stale-spawn-reply` into the one reachable machine-supersession
+  path: a spawned child reaching a `:final?` leaf *after* its parent was
+  already destroyed. This path was previously handled in `finalize-machine` by
+  silently reducing `:on-done` to identity when the parent snapshot is `nil` —
   **behaviourally safe** (no parent to mutate, no app-state corruption) and so
-  meets the §Stale suppression clauses (1) app target not run and (5) no app
-  mutation. The gap is observability only: it does not yet emit the
-  `:status :stale` reply (clause 2) nor the stale-suppression trace joined to
-  `:work/id` (clause 4) that the machine `:after`-timer stale path already
-  emits. The machine completion model is synchronous, so a genuinely-late
-  completion arriving after the child itself was destroyed is not reachable;
-  parent-destroyed-before-child-finishes is the only live case.
+  already meeting the §Stale suppression clauses (1) app target not run and (5)
+  no app mutation, but it did not yet emit the `:status :stale` reply (clause 2)
+  nor the stale-suppression trace joined to `:work/id` (clause 4) that the
+  machine `:after`-timer stale path emits. **Now resolved:** `finalize-machine`
+  gates on parent liveness (`parent-live?`) and, for a stale late completion,
+  builds `stale-spawn-reply` and emits the `:rf.machine/done` trace carrying the
+  reply-envelope `:rf.reply/status :stale` / `:rf.reply/work-status :suppressed`
+  facts plus the carried/current generation correlation joined to `:work/id` —
+  the spawn analogue of the `:after` path's `:rf.machine.timer/stale-after`
+  trace, so all five §Stale suppression clauses now hold for the spawn path.
+  The machine completion model is synchronous, so a genuinely-late completion
+  arriving after the child itself was destroyed is not reachable;
+  parent-destroyed-before-child-finishes was the only live case.
 - **`rf2-mdjzs0`** *(open — P4, cosmetic, one-name-per-fact tidy)* — converge
   the unqualified `:work-id` spelling that survives in several resource /
   mutation **trace-tag** and internal in-flight-bookkeeping maps onto the

--- a/implementation/http/src/re_frame/http_reply.cljc
+++ b/implementation/http/src/re_frame/http_reply.cljc
@@ -16,7 +16,8 @@
   Three concerns:
 
    1. **Work-id correlation** (`work-id`). One HTTP attempt has one
-      `:work/id` head `[:rf.work/http logical-id args... generation]`
+      `:work/id` head `[:rf.work/http logical-id attempt]` (the `attempt`
+      number is HTTP's generation slot — see `work-id`)
       (Managed-Effects §Work-id correlation). The HTTP `:request-id` is
       NOT a second stale-suppression key — it rides as `:correlation`
       metadata on the reply map. The frame-qualified transport
@@ -58,7 +59,8 @@
 ;; ---------------------------------------------------------------------------
 ;; Work-id correlation (Managed-Effects §Work-id correlation).
 ;;
-;; HTTP head: `[:rf.work/http logical-id args... generation]`. The logical
+;; HTTP head: `[:rf.work/http logical-id attempt]` (the trailing `attempt`
+;; is HTTP's generation slot — see below). The logical
 ;; identity is the caller's `:request-id` when supplied (a stable, =-
 ;; comparable handle the caller already chose for supersede/abort), else
 ;; the originating event-id (the default reply target's identity). HTTP has


### PR DESCRIPTION
Wave-end review tail for the EP-0011 uniform reply envelope (impl fully merged; the correctness + testing-coverage reviews already ran). Two trivial corrective edits; no behaviour change.

## rf2-t4syko — code-comments review

Read-through of every EP-0011 docstring + inline comment across the reply substrate (`re-frame.reply`) and the five per-family slices (`http-reply`, `resources.reply`, `machines.reply`, `routing.reply`, the wiring in `events` / `mutation-events` / `finalize` / `nav-token`) plus the two `reply-conformance/` suites and the xray reader.

**Verdict: thorough and accurate.** The 12-field reply contract, `:completed-at` causal-time handling, the functor-law / reply-vocab rationale, acceptance-keyed (stale-suppressed) delivery, and the spec cross-references (`spec/Managed-Effects.md` §The uniform reply envelope / §Status taxonomy / §Work-id correlation / §Stale suppression / §Tracing / §Reply mapping and the functor law) all resolve and match the code.

**One drift fixed inline:** `http_reply.cljc` described the HTTP work-id head as `[:rf.work/http logical-id args... generation]` in the ns docstring and the section comment, but the code builds the 3-tuple `[:rf.work/http logical-id attempt]` (the `work-id` function docstring, `http_transport.cljc`, and every test already use the shipped spelling). Corrected both mentions.

## rf2-btzh6b — final completeness + correctness review (with remediation)

Reviewed the merged wave against the EP + its dispositions. The lowering chain shipped: all four managed-async families complete through the one `re-frame.reply` substrate, each carrying property 9 + its work-id tuple; the timer probe conformance-proves the inheritance claim; the cross-family vocab + functor-law conformance suites are green.

**One errata-ledger staleness fixed:** the EP's Implementation-errata ledger listed `rf2-lohbfg` as an **open** P3 observability gap (machine `stale-spawn-reply` unwired, no `:status :stale` emitted on the parent-destroyed-before-child path). lohbfg has since been **remediated and closed** — `finalize-machine` now gates on parent liveness and, for a stale late spawn completion, builds `stale-spawn-reply` + emits the `:rf.machine/done` trace carrying `:rf.reply/status :stale` / `:rf.reply/work-status :suppressed` + the carried/current generation correlation joined to `:work/id` (the spawn analogue of the `:after` path). All five §Stale suppression clauses now hold for the spawn path. Updated the errata entry to RESOLVED and corrected the header summary ("two follow-ups" → one).

`rf2-mdjzs0` (P4 cosmetic, unqualified `:work-id` trace-tag spelling) correctly remains open — it is a deferred tidy, not a corrective-PR candidate (no durable second identity; xray tolerates both spellings).

**Wave verdict: clean** apart from the two doc/comment corrections in this PR. No larger follow-up needed.

## Quality gates
- `implementation/http` `clojure -M:test`: 417 tests, 1897 assertions, 0 failures (covers the `http_reply.cljc` docstring edits)
- `implementation/reply-conformance` `clojure -M:test`: 15 tests, 237 assertions, 0 failures (cross-family vocab + functor-law substrate)
- `shadow-cljs compile node-test`: clean. (The full `node-test` *runtime* gate is blocked by a missing `markdown-it` dependency in the local install — an environment gap in the mayor `node_modules`, unrelated to this change; these edits are docstring/comment + EP markdown only.)
- `mkdocs build --strict`: passed (EP-0011 doc anchors resolve)