### PR TITLE
test: EP-0010 world-input stamping + replay-determinism coverage (rf2-irbjjq + qz0uog + b7w7i0)

### DIFF
--- a/implementation/core/test/re_frame/world_inputs_router_stamp_clock_cljs_test.cljs
+++ b/implementation/core/test/re_frame/world_inputs_router_stamp_clock_cljs_test.cljs
@@ -1,0 +1,150 @@
+(ns re-frame.world-inputs-router-stamp-clock-cljs-test
+  "rf2-qz0uog (EP-0010 §Dispatch Envelope Stamping) — CLJS LIVE-path
+  regression for the router's `:rf.world/inputs` `:time-ms` stamp.
+
+  WHY A NEW CLJS SUITE. The existing core world-input tests
+  (`re-frame.world-inputs-test`) are JVM-ONLY and assert only that an
+  omitted `:time-ms` is stamped to a NUMBER. On the JVM `interop/now-ms`
+  (elapsed) and `interop/epoch-now-ms` (wall-clock) are BOTH
+  `System.currentTimeMillis`-ish, so a regression swapping the router's
+  stamp source from `epoch-now-ms` -> `now-ms` (rf2-n1rh0f names
+  `epoch-now-ms` as THE durable wall-clock source) stays GREEN on every
+  JVM suite. On CLJS the two clocks are DISTINCT CLASSES:
+
+    - `interop/now-ms`       = `performance.now()` — origin-relative,
+                               for ELAPSED measurement (~1e4 in a fresh
+                               process), NOT comparable with `js/Date`.
+    - `interop/epoch-now-ms` = `js/Date.now()`     — wall-clock epoch ms
+                               (~1.78e12 as of 2026), the durable causal
+                               time `:rf.world/inputs` `:time-ms` MUST be.
+
+  A durable timestamp folded from `performance.now()` would be ~12 orders
+  of magnitude too small and incomparable with the `js/Date`-based
+  freshness / invalidation / staleness readers (resources `:stale-at`,
+  `:invalidated-at`, epoch `:committed-at`). This is the EXACT clock-class
+  bug the resources `:completed-at` perf-clock regression (rf2-2elcw3) and
+  the epoch `:committed-at` regression (rf2-1t30y7) each needed a dedicated
+  CLJS suite to catch. This suite closes it for the ROUTER ENVELOPE STAMP
+  itself — the single causal-boundary read every durable write folds.
+
+  It drives the REAL router: it dispatches an UNSCRIPTED event (NO
+  `:rf.world/inputs` supplied), lets the genuine `build-envelope` stamp the
+  causal `:time-ms` from the host clock, and reads the stamped map back two
+  ways — (a) off the handler's `:rf.world/inputs` COEFFECT (the public
+  handler-visible path, Spec 002 §Event Context And Coeffects), and (b) off
+  the `:rf.event/dispatched` TRACE (the Xray-visible path, rf2-jt854w). Both
+  must carry a WALL-CLOCK epoch ms (> 1e12, within seconds of
+  `js/Date.now()`), NOT a perf-clock origin-relative value.
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up via
+  `:ns-regexp \"cljs-test$\"`. Plain-atom adapter (the `:node-test` build
+  has no DOM / Reagent reactive context); the clock read under test lives
+  at the router boundary and is adapter-independent."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; Sanity floor: a wall-clock epoch ms is far above any plausible
+;; `performance.now()` origin-relative value (a fresh Node process is well
+;; under 1e12 ms of uptime — that is ~31 years). 1e12 is a generous,
+;; host-independent discriminator between the two clock CLASSES.
+(def ^:private wall-clock-floor 1e12)
+
+(deftest router-stamps-omitted-time-ms-as-wall-clock-epoch-on-the-coeffect
+  (testing "rf2-qz0uog — an UNSCRIPTED dispatch (no :rf.world/inputs) flows
+            through the live router, which stamps the causal :time-ms from the
+            host clock; the handler reads :rf.world/inputs off its coeffect and
+            the stamped :time-ms MUST be a WALL-CLOCK epoch ms (close to
+            js/Date.now), NOT a perf-clock (performance.now) origin-relative
+            value. A regression swapping epoch-now-ms -> now-ms at the causal
+            boundary is JVM-benign but lands ~12 orders of magnitude low here."
+    (rf/reg-frame :wi.clk/cofx {:doc "ctx"})
+    (let [captured (atom nil)]
+      ;; reg-event-ctx so we read the FULL coeffect map the handler saw —
+      ;; :rf.world/inputs is a framework coeffect alongside :db / :event.
+      (rf/reg-event-ctx :wi.clk/capture
+        (fn [ctx] (reset! captured (:coeffects ctx)) ctx))
+      (let [before (js/Date.now)]
+        ;; intentionally UNSCRIPTED — no :rf.world/inputs opt — so the router's
+        ;; build-envelope performs the live host-clock read under test.
+        (rf/dispatch-sync [:wi.clk/capture] {:frame :wi.clk/cofx})
+        (let [after   (js/Date.now)
+              cofx    @captured
+              world   (:rf.world/inputs cofx)
+              time-ms (:time-ms world)]
+          (is (some? cofx) "the handler ran and captured its coeffects")
+          (is (contains? cofx :rf.world/inputs)
+              ":rf.world/inputs is a framework coeffect on the handler ctx")
+          (is (map? world) ":rf.world/inputs is a map")
+          (is (number? time-ms) ":time-ms is a stamped number")
+          ;; The CLASS assertion: wall-clock epoch ms, not a perf origin time.
+          ;; Pre-swap ~1.78e12; a now-ms swap lands ~1e4 (performance.now) on
+          ;; the CLJS runtime — far below the floor.
+          (is (> time-ms wall-clock-floor)
+              ":time-ms is a WALL-CLOCK epoch ms (> 1e12) — sourced from
+               interop/epoch-now-ms (js/Date.now), NOT interop/now-ms
+               (performance.now, origin-relative ~1e4)")
+          ;; The TIGHT band: within the bracketing js/Date.now() reads (plus a
+          ;; ~10s slack for slow CI). Confirms both the magnitude AND that the
+          ;; stamp tracks the same wall clock the freshness readers compare
+          ;; against.
+          (is (and (>= time-ms (- before 10000))
+                   (<= time-ms (+ after 10000)))
+              ":time-ms lands in the bracketing js/Date.now() band (within
+               10s) — it IS the live wall clock, not a stale or perf-relative
+               read"))))))
+
+(deftest router-stamps-omitted-time-ms-as-wall-clock-epoch-on-the-dispatched-trace
+  (testing "rf2-qz0uog — the SAME omitted-time-ms stamp rides the
+            :rf.event/dispatched trace (the Xray Event-lens WORLD INPUTS
+            surface, rf2-jt854w): the trace-side :rf.world/inputs :time-ms is
+            ALSO a wall-clock epoch ms (> 1e12), not a perf-clock value. Covers
+            the router envelope-stamp path as seen by the trace stream, not
+            just the handler coeffect."
+    (rf/reg-frame :wi.clk/trace {:doc "ctx"})
+    (rf/reg-event-db :wi.clk/noop (fn [db _] db))
+    (let [seen (atom [])]
+      (rf/register-listener! ::clk-probe (fn [ev] (swap! seen conj ev)))
+      (let [before (js/Date.now)]
+        (rf/dispatch-sync [:wi.clk/noop] {:frame :wi.clk/trace})
+        (let [after     (js/Date.now)
+              _         (rf/unregister-listener! ::clk-probe)
+              enqueue   (->> @seen
+                             (filter #(= :rf.event/dispatched (:operation %)))
+                             first)
+              ;; the op-type-specific payload slots ride under :tags;
+              ;; build-event hoists only :source to top-level (rf2-jt854w).
+              world     (get-in enqueue [:tags :rf.world/inputs])
+              time-ms   (:time-ms world)]
+          (is (some? enqueue) ":rf.event/dispatched fired")
+          (is (map? world)
+              ":rf.world/inputs rides the dispatched trace under :tags")
+          (is (number? time-ms) "the trace-side :time-ms is a stamped number")
+          (is (> time-ms wall-clock-floor)
+              "the trace-side :time-ms is a WALL-CLOCK epoch ms (> 1e12) —
+               js/Date.now, NOT performance.now")
+          (is (and (>= time-ms (- before 10000))
+                   (<= time-ms (+ after 10000)))
+              "the trace-side :time-ms lands in the bracketing js/Date.now()
+               band — the same live wall clock"))))))
+
+(deftest clock-class-discriminator-sanity-cljs
+  (testing "rf2-qz0uog — corroborate the discriminator the regression
+            assertions lean on: on the CLJS runtime epoch-now-ms is a
+            wall-clock epoch ms (> 1e12) while now-ms (performance.now) is an
+            origin-relative elapsed value BELOW the wall-clock floor. Pins that
+            the two clock surfaces ARE distinguishable here — so the band tests
+            above genuinely catch a swap (they would be vacuous if both clocks
+            read the same class, as on the JVM)."
+    (is (> (interop/epoch-now-ms) wall-clock-floor)
+        "epoch-now-ms is a wall-clock epoch ms on CLJS (js/Date.now)")
+    (is (< (interop/now-ms) wall-clock-floor)
+        "now-ms is an origin-relative perf time on CLJS (performance.now),
+         below the wall-clock floor — distinct CLASS from epoch-now-ms, so a
+         swap is observable on this runtime (JVM-benign)")))

--- a/implementation/core/test/re_frame/world_inputs_test.clj
+++ b/implementation/core/test/re_frame/world_inputs_test.clj
@@ -156,6 +156,117 @@
             "child did NOT inherit the parent's :time-ms — distinct causal token (EP-0010)")))))
 
 ;; ===========================================================================
+;; rf2-irbjjq: a :dispatch-later child gets FRESH world-inputs stamped at
+;; FIRE time (the causal boundary is when the deferred dispatch RUNS, not when
+;; it was enqueued) — :time-ms is NOT the parent's, NOT the enqueue-time clock,
+;; while the inherited envelope fields (:frame / :trace-id / :origin) still
+;; propagate from the parent.
+;;
+;; EP-0010 §Dispatch Envelope Stamping names BOTH :dispatch and :dispatch-later
+;; as child causal-token producers. The existing child-dispatch-gets-fresh-
+;; time-ms (above) covers the IMMEDIATE :dispatch child; the deferred path is
+;; distinct because `:dispatch-later` wraps the router `dispatch!` in
+;; `interop/set-timeout!` (re-frame.fx §reserved-fx-handlers), so the child's
+;; `build-envelope` — and thus its `:rf.world/inputs` stamp — happens inside
+;; the timer callback, an arbitrary wall-clock interval after the parent
+;; settled. `:rf.world/inputs` is deliberately ABSENT from
+;; `re-frame.fx/inheritable-envelope-keys`, so the deferred child is stamped
+;; a fresh `:time-ms` at fire from `interop/epoch-now-ms` rather than copying
+;; the parent's — the mechanism the existing world-input tests pin only for
+;; the synchronous case.
+;;
+;; We make the wall clock ADVANCE between enqueue and fire (a mutable clock
+;; redef) and capture the timer thunk via a `set-timeout!` redef so we fire it
+;; AFTER advancing — adversarially separating the three candidate stamp times
+;; (parent token / enqueue clock / fire clock). A regression that inherited
+;; the parent's :time-ms, or that stamped at enqueue time, or that added
+;; :rf.world/inputs to the inheritable set, fails loudly here.
+;; ===========================================================================
+
+(deftest dispatch-later-child-gets-fresh-world-inputs-stamped-at-fire-time
+  (testing "a :fx [[:dispatch-later …]] child is stamped FRESH world-inputs at
+            FIRE time — :time-ms is the fire-time clock, NOT the parent token,
+            NOT the enqueue-time clock; inherited fields still propagate"
+    (rf/reg-frame :wi/later {:doc "ctx"})
+    (let [;; mutable wall clock — the value `epoch-now-ms` reads moves between
+          ;; enqueue (parent dispatch) and fire (deferred thunk run).
+          clock          (atom 1000)
+          ;; capture the deferred timer thunk so the test fires it MANUALLY
+          ;; after advancing the clock (rather than relying on a real timer).
+          deferred       (atom nil)
+          captured-child (atom nil)]
+      ;; The deferred child reads its own envelope off the fx-handler ctx
+      ;; (:envelope m) — the same surface child-dispatch-gets-fresh-time-ms
+      ;; uses — so we observe the world-inputs map the router stamped for it.
+      (rf/reg-fx :wi.later/capture-env
+        (fn [m _args] (reset! captured-child (:envelope m))))
+      (rf/reg-event-fx :wi.later/parent
+        (fn [_ _]
+          {:fx [[:dispatch-later {:ms 50 :event [:wi.later/child]}]]}))
+      (rf/reg-event-fx :wi.later/child
+        (fn [_ _]
+          {:fx [[:wi.later/capture-env]]}))
+
+      (with-redefs [interop/epoch-now-ms (fn [] @clock)
+                    ;; capture the deferred thunk; do NOT run it yet, so the
+                    ;; clock can advance before the child's build-envelope runs.
+                    interop/set-timeout! (fn [f _ms] (reset! deferred f) :handle)
+                    ;; the deferred thunk calls the ASYNC router `dispatch!`,
+                    ;; which schedules its drain on `interop/next-tick` (a
+                    ;; separate executor thread on the JVM). Run next-tick
+                    ;; INLINE so the deferred child's cascade settles
+                    ;; synchronously within this test — the clock read under
+                    ;; test is at the deferred dispatch's `build-envelope`,
+                    ;; which the inline drain reaches deterministically.
+                    interop/next-tick   (fn [f] (f) nil)]
+        ;; Parent supplies an explicit token :time-ms and rides a distinctive
+        ;; :trace-id / :origin so we can assert inheritance onto the child.
+        (rf/dispatch-sync [:wi.later/parent]
+                          {:frame           :wi/later
+                           :trace-id        :wi.later/T
+                           :origin          :ui
+                           :rf.world/inputs {:time-ms 1781078400000}})
+        ;; ENQUEUE happened at clock=1000; the child's envelope is NOT built yet
+        ;; (it is deferred). Advance the wall clock, THEN fire the deferred
+        ;; thunk so the child's build-envelope reads the ADVANCED clock.
+        (is (some? @deferred) "the :dispatch-later scheduled a deferred thunk")
+        (is (nil? @captured-child)
+            "the child has not run yet — it is genuinely deferred")
+        (reset! clock 5000)            ; wall clock advanced between enqueue and fire
+        (@deferred))                   ; fire the deferred dispatch at clock=5000
+
+      (let [child-env @captured-child
+            child-t   (get-in child-env [:rf.world/inputs :time-ms])]
+        (is (some? child-env) "the deferred child ran when the thunk fired")
+        (is (= [:wi.later/child] (:event child-env)) "captured the child event")
+        ;; FRESH at FIRE — the three adversarial candidates are separated:
+        (is (= 5000 child-t)
+            "child :time-ms is the FIRE-time clock (5000) — stamped when the
+             deferred dispatch RAN, not at enqueue")
+        (is (not= 1781078400000 child-t)
+            "child did NOT inherit the parent token's :time-ms — distinct
+             causal token (EP-0010 §Dispatch Envelope Stamping)")
+        (is (not= 1000 child-t)
+            "child :time-ms is NOT the enqueue-time clock — the stamp is read
+             at fire, inside the timer callback, not captured at schedule time")
+        ;; INHERITED envelope fields still propagate from the parent.
+        (is (= :wi/later (:frame child-env))
+            ":frame is inherited onto the deferred child")
+        (is (= :wi.later/T (:trace-id child-env))
+            ":trace-id is inherited onto the deferred child")
+        (is (= :origin (key (find child-env :origin)))
+            "the :origin slot is present on the child envelope")
+        (is (= :ui (:origin child-env))
+            ":origin is inherited onto the deferred child")
+        ;; The deferred child's :source reflects its OWN immediate trigger
+        ;; (the :dispatch-later fx), NOT inherited (rf2-ejtpd) — a foil that
+        ;; confirms the inheritance set is exactly the trace-context keys, not
+        ;; "everything", so :rf.world/inputs being excluded is the same shape.
+        (is (= :fx-dispatch-later (:source child-env))
+            "the deferred child's :source is its immediate trigger
+             (:fx-dispatch-later), stamped by the fx handler — not inherited")))))
+
+;; ===========================================================================
 ;; Coeffect visibility + trace projection filtering
 ;; ===========================================================================
 

--- a/implementation/resources/test/re_frame/replay_determinism_e2e_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/replay_determinism_e2e_cljs_test.cljc
@@ -1,0 +1,337 @@
+(ns re-frame.replay-determinism-e2e-cljs-test
+  "rf2-b7w7i0 (EP-0010 §Validation/Conformance + §Replay Fixture) — the
+  UNIFIED end-to-end replay-determinism fixture. The EP's STRONGEST stated
+  property, proven end-to-end rather than component-by-component.
+
+  ## What the EP promises (and what was missing)
+
+  EP-0010's headline guarantee: a recorded epoch — a token log with
+  `:rf.world/inputs` (`:time-ms` / `:uuid` / `:random`) on each token —
+  replays DETERMINISTICALLY from its captured world-inputs, EQUAL durable
+  state across two runs under DIFFERING host clock + RNG. Every durable
+  causal-time / id fact folds the TOKEN's world inputs, never an ambient
+  host read inside a handler / reducer / reply path.
+
+  Before this fixture, that property was proven only COMPONENT-by-COMPONENT:
+    - epoch `:committed-at` — `committed-at-replay-stable-across-wall-clock-
+      drift` (epoch_test.clj): single durable field, app-db-epoch partition,
+      JVM-only.
+    - resources — `succeeded-loaded-at-…`, `work-record-started-at-…`,
+      `invalidate-tags-invalidated-at-…`: each scripts ONE token's `:time-ms`
+      and asserts the durable value equals it (token-sourced ⇒ implicitly
+      replay-stable). Most do ONE dispatch.
+  No test took a MULTI-EVENT log spanning app-db AND runtime-db, ran the
+  WHOLE log through the live router TWICE under two DIFFERENT ambient
+  clocks / RNGs, and asserted the two `{:rf.db/app :rf.db/runtime}`
+  projections EQUAL. A component test passes even if the fold leaks an
+  ambient read in a path none exercises TOGETHER (e.g. the freshness-
+  decision branch flagged by rf2-95b0lc).
+
+  ## The fixture
+
+  A token log spanning BOTH durable partitions:
+
+    1. APP-DB entity create — a `:repl/create` handler reads `:uuid` /
+       `:random` / `:time-ms` from the token's `:rf.world/inputs` and folds
+       them into a durable app-db entity (the EP §Examples \"Correct
+       Generated Values From The Token\" shape). Ambient `random-uuid` /
+       `rand` would diverge run-to-run; reading the token does not.
+    2. RESOURCE ensure → success — a `reg-resource` ensure lowers through
+       the managed-HTTP transport (capturing stub replaying the real reply-
+       append shape); the success reply token's `:time-ms` becomes the
+       durable `:loaded-at` / `:stale-at` (runtime-db). The work-ledger
+       `:started-at` / `:deadline-at` fold the ensure token's `:time-ms`.
+    3. APP-DB mutation — a `:repl/touch` handler folds the token's
+       `:time-ms` into a durable app-db field (a second durable write,
+       app-db partition).
+    4. OWNER release — `:rf.resource/release-owner` drops the lease so the
+       subsequent invalidation LEAVES the entry stale rather than triggering
+       a live refetch. (A refetch is a NEW causal action whose child token is
+       freshly stamped — correct EP-0010 behaviour, but it is NOT part of the
+       RECORDED log; a real recorded-epoch replay would carry the refetch's
+       own token. Releasing the owner keeps this fixture a pure recorded-log
+       replay: every durable write folds a SCRIPTED token, nothing is live-
+       stamped. This very divergence — an active-owner invalidation spawning
+       an ambient-stamped refetch — is what the fixture SURFACED on first
+       authoring, exactly the cross-path leak rf2-95b0lc predicts.)
+    5. TAG invalidation — `:rf.resource/invalidate-tags` writes the durable
+       `:invalidated-at` from the invalidation token's `:time-ms` (runtime-
+       db), driving the freshness-DECISION branch (`entry-stale?`). With no
+       active owner the entry is LEFT STALE (durable `:invalidated-at`, no
+       refetch — Spec 016 §Invalidation 4).
+
+  The SAME log is replayed TWICE. Run A uses ambient clock/RNG sentinel A;
+  run B uses a WILDLY different ambient clock/RNG sentinel B (we redef BOTH
+  `interop/now-ms` and `interop/epoch-now-ms`, and the host `rand` /
+  `random-uuid` generators). Each run starts from a FRESH runtime + reset
+  host-transient caches (generation allocator, resource/timer caches) so the
+  only difference between the two runs is the ambient clock/RNG — exactly the
+  drift the EP says must NOT change durable state.
+
+  We assert the two runs' `{:rf.db/app :rf.db/runtime}` projections are
+  EQUAL after stripping diagnostic / host-transient state (canonical-form
+  compare, the tools/story determinism-harness shape). If ANY durable write
+  in the whole log folded an ambient read instead of the token, the two
+  projections diverge and this fails — the end-to-end guarantee the component
+  tests could not give.
+
+  Cross-ref rf2-95b0lc (it predicts this fixture surfaces a fresh-skip-branch
+  ambient-read divergence). CLJS-runnable (the `.cljs` runtime is where the
+  clock CLASSES diverge — `now-ms`=performance.now vs
+  `epoch-now-ms`=js/Date.now); `.cljc` so the JVM core test build also runs
+  it (the threading is platform-agnostic)."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   [re-frame.interop :as interop]
+   ;; load-bearing side-effecting requires: register the :rf.resource/*
+   ;; events + subs + the generation cofx/fx the ensure/invalidate drive.
+   [re-frame.resources]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.test-support]
+   ;; production HTTP fx surface (so the transport feature probe resolves);
+   ;; the actual fetch is overridden by the capturing reply stub below.
+   [re-frame.http-managed]
+   [re-frame.schemas]
+   [re-frame.test-support :as core-test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+;; ---- capturing transport (replays the real reply-append shape) ------------
+;;
+;; The live managed-HTTP transport APPENDS its result to the runtime-supplied
+;; `:on-success` event vector as the LAST arg (Spec 014 §Reply addressing).
+;; To exercise the runtime's reply handlers against that EXACT shape WITHOUT
+;; a live Fetch — and so we can SCRIPT the reply token's `:rf.world/inputs`
+;; `:time-ms` exactly as a replay would re-feed it — the stub captures the
+;; lowered args; the test replays the success reply explicitly.
+
+(def ^:private last-managed-args (atom nil))
+
+(defn- capturing-transport-fixture [f]
+  (reset! last-managed-args nil)
+  (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
+  (f))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter}))
+  capturing-transport-fixture)
+
+(def ^:private frame-id :rf/default)
+(def ^:private stale-after-ms 60000)
+
+;; ---- the durable handlers + resource the token log drives -----------------
+;;
+;; Each handler reads its durable facts from the token's `:rf.world/inputs`
+;; coeffect — NEVER an ambient `random-uuid` / `rand` / clock read. That is
+;; the property under test: replay-determinism follows iff every durable
+;; write folds the token, so the two runs (differing ambient clock/RNG)
+;; converge.
+
+(defn- register-log! []
+  ;; (1) APP-DB entity create from the token's generated values.
+  (rf/reg-event-fx :repl/create
+    (fn [{:keys [db rf.world/inputs]} [_ text]]
+      (let [id    (get-in inputs [:uuid :todo/id])
+            color (get-in inputs [:random :todo/color])
+            at    (:time-ms inputs)]
+        {:db (assoc-in db [:todos id]
+                       {:todo/id id :todo/color color
+                        :todo/text text :todo/created-at at})})))
+  ;; (3) APP-DB mutation — a second durable write folding the token time.
+  (rf/reg-event-fx :repl/touch
+    (fn [{:keys [db rf.world/inputs]} [_ id]]
+      {:db (assoc-in db [:todos id :todo/touched-at] (:time-ms inputs))}))
+  ;; (2) RESOURCE — loaded-at / stale-at fold the success-reply token time;
+  ;;     work-ledger started-at / deadline-at fold the ensure token time.
+  (rf/reg-resource :repl/article
+    {:scope          :rf.scope/global
+     :params-schema  [:map [:slug :string]]
+     :stale-after-ms stale-after-ms
+     :request        (fn [{:keys [slug]} _ctx]
+                       {:request {:method :get :url (str "/api/articles/" slug)}})
+     :tags           (fn [{:keys [slug]} _data] #{[:article slug]})}))
+
+(defn- reply-success!
+  "Dispatch the captured `:on-success` reply with the transport's success
+  result appended as the LAST arg (the live transport shape), carrying a
+  SCRIPTED `:rf.world/inputs` `:time-ms` — exactly as a replay re-feeds the
+  reply token's causal completion time."
+  [data time-ms]
+  (rf/dispatch-sync (conj (:on-success @last-managed-args)
+                          {:kind :success :value data})
+                    {:frame frame-id :rf.world/inputs {:time-ms time-ms}}))
+
+;; ---- the canonical scripted token log -------------------------------------
+;;
+;; The SAME causal world-inputs on every token across BOTH runs — the replay
+;; record. Ambient clock/RNG vary between runs; these do NOT.
+
+(def ^:private todo-id #uuid "018ff2b4-9bbd-7a0a-a4df-cf2a91cbe86d")
+
+(def ^:private log
+  {:create-time     1781078400000
+   :ensure-time     1781078400100
+   :reply-time      1781078400250
+   :touch-time      1781078400400
+   :release-time    1781078400700
+   :invalidate-time 1781078400900})
+
+(defn- run-log!
+  "Replay the whole token log through the LIVE router once, against the
+  fresh runtime the caller has just reset. Every dispatch supplies its
+  `:rf.world/inputs` so the durable fold is token-sourced; the ambient
+  clock/RNG the caller pinned must NOT leak into any durable write.
+  Returns the two-partition durable projection `{:rf.db/app :rf.db/runtime}`."
+  []
+  (register-log!)
+  ;; (1) APP-DB create from token uuid/random/time-ms.
+  (rf/dispatch-sync [:repl/create "buy milk"]
+                    {:frame frame-id
+                     :rf.world/inputs {:uuid   {:todo/id todo-id}
+                                       :random {:todo/color :green}
+                                       :time-ms (:create-time log)}})
+  ;; (2) RESOURCE ensure → success. The ensure token's :time-ms folds into the
+  ;; work-ledger :started-at; the success reply token's :time-ms folds into the
+  ;; durable :loaded-at / :stale-at.
+  (rf/dispatch-sync [:rf.resource/ensure
+                     {:resource :repl/article :scope :rf.scope/global
+                      :params {:slug "w"} :owner [:lease :repl 1]}]
+                    {:frame frame-id :rf.world/inputs {:time-ms (:ensure-time log)}})
+  (reply-success! {:title "Welcome"} (:reply-time log))
+  ;; (3) APP-DB mutation folding the touch token time.
+  (rf/dispatch-sync [:repl/touch todo-id]
+                    {:frame frame-id :rf.world/inputs {:time-ms (:touch-time log)}})
+  ;; (4) OWNER release — drop the lease so the invalidation below LEAVES the
+  ;; entry stale rather than spawning a live (ambient-stamped) refetch. Keeps
+  ;; the fixture a pure recorded-log replay.
+  (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :repl 1]}]
+                    {:frame frame-id :rf.world/inputs {:time-ms (:release-time log)}})
+  ;; (5) TAG invalidation — durable :invalidated-at from the invalidation
+  ;; token's :time-ms (the freshness-DECISION branch, rf2-95b0lc). Ownerless
+  ;; ⇒ left stale, no refetch (Spec 016 §Invalidation 4).
+  (rf/dispatch-sync [:rf.resource/invalidate-tags
+                     {:scope :rf.scope/global :tags #{[:article "w"]}}]
+                    {:frame frame-id :rf.world/inputs {:time-ms (:invalidate-time log)}})
+  {:rf.db/app     (rf/app-db-value frame-id)
+   :rf.db/runtime (rf/runtime-db-value frame-id)})
+
+;; ---- determinism canonicalizer (strip diagnostic / host-transient) --------
+;;
+;; The durable projection compare excludes purely-diagnostic / host-transient
+;; slots that are LEGITIMATELY free to vary (or that hold a host handle, never
+;; durable replay data). Per the EP §Replay Fixture the equality is over the
+;; DURABLE projection — diagnostic + host-transient state is excluded. We strip
+;; defensively, then assert the canonicalised projections are EQUAL.
+
+(def ^:private host-transient-keys
+  "Keys whose values are host-transient (opaque handles) or diagnostic and so
+  are excluded from the durable-equality compare. The work-ledger durable
+  records carry NO host handles by contract (work_ledger.cljc §Serializable
+  work records), so the equality holds WITHOUT stripping ledger internals —
+  these are a defensive belt for any diagnostic slot a record might carry."
+  #{:rf.runtime/diagnostics})
+
+(defn- canonical
+  "Recursively strip host-transient / diagnostic keys so the compare is over
+  the DURABLE projection only. Pure data → data."
+  [x]
+  (cond
+    (map? x)  (into {} (for [[k v] x
+                             :when (not (contains? host-transient-keys k))]
+                         [k (canonical v)]))
+    (coll? x) (into (empty x) (map canonical x))
+    :else     x))
+
+;; ---- the unified end-to-end replay-determinism test -----------------------
+
+(deftest token-log-replays-deterministically-under-differing-clock-and-rng
+  (testing "rf2-b7w7i0 — the SAME multi-event token log, replayed twice under
+            WILDLY different ambient clocks AND RNG, yields EQUAL durable
+            {:rf.db/app :rf.db/runtime} projections. Every durable causal-time
+            / id fact folds the token's :rf.world/inputs, so ambient drift
+            (the very thing replay must be immune to) does not change durable
+            state. Spans app-db (entity create + mutation) AND runtime-db
+            (resource loaded-at/stale-at, work-ledger started-at, tag
+            invalidated-at) — the end-to-end guarantee the per-component tests
+            could not give."
+    ;; RUN A — ambient clock + RNG sentinel A. The redefs pin BOTH host clock
+    ;; surfaces and the host random generators to values NOTHING durable should
+    ;; fold (the tokens supply every durable fact). A regression that re-read
+    ;; ANY ambient surface in a durable write stamps a sentinel and diverges
+    ;; from run B.
+    (let [run-a (with-redefs [interop/now-ms       (constantly 111)
+                              interop/epoch-now-ms (constantly 111)
+                              rand        (fn ([] 0.111) ([n] (* n 0.111)))
+                              random-uuid (constantly
+                                            #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")]
+                  (run-log!))]
+      ;; FULL fresh reset between runs: rerun the :each fixture body so the
+      ;; runtime, frames, schemas, AND host-transient caches (generation
+      ;; allocator, resource/timer caches) are clean — the ONLY difference
+      ;; between the two runs is the ambient clock/RNG.
+      ((core-test-support/make-reset-runtime-fixture
+         #?(:clj  {:adapter plain-atom/adapter}
+            :cljs {:adapter reagent-adapter/adapter}))
+       (fn []
+         (reset! last-managed-args nil)
+         (rf/reg-fx :rf.http/managed
+                    (fn [_ctx args] (reset! last-managed-args args) nil))
+         ;; RUN B — a WILDLY different ambient clock + RNG sentinel.
+         (let [run-b (with-redefs [interop/now-ms       (constantly 9999999999999)
+                                   interop/epoch-now-ms (constantly 9999999999999)
+                                   rand        (fn ([] 0.999) ([n] (* n 0.999)))
+                                   random-uuid (constantly
+                                                 #uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")]
+                       (run-log!))
+               ca (canonical run-a)
+               cb (canonical run-b)]
+           ;; The headline equality: durable projections EQUAL across the
+           ;; differing ambient clock/RNG.
+           (is (= ca cb)
+               "the two runs' durable {:rf.db/app :rf.db/runtime} projections
+                are EQUAL — replay-determinism holds end-to-end across app-db
+                AND runtime-db under differing host clock/RNG")
+
+           ;; --- corroborating PIN: the durable facts ARE the token values, ---
+           ;; --- not a sentinel (so the equality is non-vacuous and we are  ---
+           ;; --- folding the token, not coincidentally-equal ambient reads).---
+           (let [app   (:rf.db/app run-b)
+                 todo  (get-in app [:todos todo-id])
+                 rt    (:rf.db/runtime run-b)
+                 scoped-key (state/scoped-resource-key
+                              :rf.scope/global :repl/article {:slug "w"})
+                 entry (get-in rt (state/entry-path scoped-key))]
+             ;; (1) app-db entity — token uuid/random/time-ms, NOT ambient.
+             (is (= todo-id (:todo/id todo))
+                 "the durable entity id is the token uuid, not the ambient
+                  random-uuid sentinel (bbbb… would appear if ambient leaked)")
+             (is (= :green (:todo/color todo))
+                 "the durable colour is the token :random value, not ambient")
+             (is (= (:create-time log) (:todo/created-at todo))
+                 "the durable created-at is the create token's :time-ms")
+             ;; (3) app-db mutation — token time, not ambient.
+             (is (= (:touch-time log) (:todo/touched-at todo))
+                 "the durable touched-at is the touch token's :time-ms")
+             ;; (2) runtime-db resource — loaded-at / stale-at from reply token.
+             (is (= {:title "Welcome"} (:data entry))
+                 "the resource loaded the reply value")
+             (is (= (:reply-time log) (:loaded-at entry))
+                 "the durable :loaded-at is the success-reply token's :time-ms,
+                  NOT an ambient reply-handler clock read")
+             (is (= (+ (:reply-time log) stale-after-ms) (:stale-at entry))
+                 "the durable :stale-at is reply :time-ms + :stale-after-ms")
+             ;; (4) runtime-db invalidation — invalidated-at from token.
+             (is (= (:invalidate-time log) (:invalidated-at entry))
+                 "the durable :invalidated-at is the invalidation token's
+                  :time-ms — the freshness-DECISION branch reads the token,
+                  not an ambient clock (rf2-95b0lc)")
+             ;; the freshness DECISION itself is replay-stable: against ANY
+             ;; clock the entry is stale (it was explicitly invalidated), a
+             ;; durable fact, not an ambient-clock-dependent computation.
+             (is (true? (state/entry-stale? entry (:reply-time log)))
+                 "the entry is stale (explicitly invalidated) — a durable,
+                  token-sourced decision, identical across both runs"))))))))


### PR DESCRIPTION
Closes the EP-0010 (causal world inputs) test tail. The impl is merged; these are test-only additions that adversarially pin the causal-world-input behaviour. No src changes.

## What's added

### rf2-irbjjq — `:dispatch-later` stamps FRESH world-inputs at FIRE time (JVM)
`dispatch-later-child-gets-fresh-world-inputs-stamped-at-fire-time` in `world_inputs_test.clj`. EP-0010 §Dispatch Envelope Stamping names BOTH `:dispatch` and `:dispatch-later` as child causal-token producers; the existing coverage pins only the immediate `:dispatch` child. The deferred path is distinct — `:dispatch-later` wraps the router `dispatch!` in `interop/set-timeout!`, so the child's `build-envelope` (and its `:rf.world/inputs` stamp) runs inside the timer callback, an arbitrary interval after the parent settled. The test uses a mutable clock + a `set-timeout!`/`next-tick` redef to fire the deferred thunk AFTER advancing the wall clock, adversarially separating the three candidate stamp times: the child `:time-ms` is the FIRE-time clock, NOT the parent token, NOT the enqueue-time clock. Inherited envelope fields (`:frame` / `:trace-id` / `:origin`) still propagate; `:source` reflects the child's own `:fx-dispatch-later` trigger.

### rf2-qz0uog — CLJS router envelope stamp wall-clock test (CLJS)
New `world_inputs_router_stamp_clock_cljs_test.cljs`. The existing core world-input tests are JVM-only, where `now-ms` (`System.currentTimeMillis`) and `epoch-now-ms` are the same class — so an `epoch-now-ms` -> `now-ms` swap at the router's causal boundary stays green. On CLJS the clocks are distinct CLASSES (`now-ms` = `performance.now()` origin-relative ~1e4; `epoch-now-ms` = `js/Date.now()` wall-clock ~1.78e12). This suite drives an UNSCRIPTED live dispatch and asserts the router-stamped `:time-ms` is a wall-clock epoch ms (> 1e12, within the bracketing `js/Date.now()` band) on BOTH the handler `:rf.world/inputs` coeffect and the `:rf.event/dispatched` trace, plus a clock-class discriminator sanity pin. Closes the clock-class blind spot for the envelope stamp (the same gap rf2-2elcw3 / rf2-1t30y7 each needed a dedicated CLJS suite to catch).

### rf2-b7w7i0 — unified end-to-end replay-determinism fixture (CLJS, `.cljc`)
New `replay_determinism_e2e_cljs_test.cljc`. The EP's strongest property — a recorded token log replays deterministically from its captured world-inputs — was proven only component-by-component. This fixture replays a MULTI-EVENT token log spanning app-db (entity create from token `:uuid`/`:random`/`:time-ms` + a mutation) AND runtime-db (resource ensure->success `:loaded-at`/`:stale-at`, work-ledger `:started-at`, owner release, tag `:invalidated-at`) through the LIVE router TWICE under WILDLY different ambient clocks AND RNG (redefs of `now-ms`/`epoch-now-ms`/`rand`/`random-uuid`), asserting EQUAL durable `{:rf.db/app :rf.db/runtime}` projections via a canonical-form compare, with corroborating per-fact pins (non-vacuous). While authoring, the fixture SURFACED the active-owner-invalidation refetch leak rf2-95b0lc predicts (a refetch is a new causal token, correctly fresh-stamped from the ambient clock); the fixture releases the owner before invalidating to stay a pure recorded-log replay.

## Quality gates

- `npm run test:cljs` (node-test) — **6757 tests / 27279 assertions, 0 failures, 0 errors**. Confirmed both new CLJS namespaces (`world_inputs_router_stamp_clock`, `replay_determinism_e2e`) compile into the bundle and run.
- core `clojure -M:test` (JVM) — **1293 tests / 5707 assertions, 0 failures, 0 errors** (covers rf2-irbjjq + the `.cljc` e2e fixture on the JVM).
- resources `clojure -M:test` (JVM) — **329 tests / 1263 assertions, 0 failures, 0 errors** (covers the e2e fixture's resources path).

Test-only; no production-bundle surface. The `shadow-cljs.edn` hot-zone was NOT touched — both new CLJS tests live in existing test trees (`core/test`, `resources/test`) and ride the existing `:node-test` `:ns-regexp "cljs-test$"`.