### PR TITLE
fix(core): EP-0008 observability cataloguing bug + conformance + fx-override test (rf2-87f7fb + 9fvp25 + uh5ic5)

### DIFF
--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -314,3 +314,18 @@
 ;; (`error-emit` → `elision` → `frame`). Per EP-0008 / rf2-ini4wr.
 (late-bind/set-fn! :error-emit/dispatch-frame-teardown-report
                    dispatch-frame-teardown-report!)
+
+;; The corpus-wide listener registry's register / unregister surfaces are
+;; published through late-bind so `frame.cljc` can install a TRANSIENT
+;; always-on error listener around the `:on-destroy` dispatch without a
+;; static require (the same `error-emit` → `elision` → `frame` load cycle).
+;; This is the production-survivable replacement for the dev-only
+;; `:trace.tooling/register-listener!` capture the common `:on-destroy`-throw
+;; path used before EP-0008 / rf2-87f7fb: the router fans the handler throw
+;; out as `:rf.error/handler-exception` on THIS always-on axis, so a
+;; transient listener here observes it under `goog.DEBUG=false` where the
+;; dev trace is DCE'd. Survives `:advanced` + `goog.DEBUG=false` — these are
+;; the same surfaces `rf/register-error-listener!` exports, just addressable
+;; from a non-requiring artefact.
+(late-bind/set-fn! :error-emit/register-error-listener!   register-error-listener!)
+(late-bind/set-fn! :error-emit/unregister-error-listener! unregister-error-listener!)

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1228,18 +1228,35 @@
   torn down.
 
   Mechanism: the router catches handler throws and converts them to
-  `:rf.error/handler-exception` traces — `dispatch-sync!` does not re-
-  throw. To surface the throw as the dedicated `:rf.error/on-destroy-
-  handler-exception` category (Mike's decision), we observe the trace
-  stream for the duration of the dispatch: any `:rf.error/handler-
-  exception` whose `:frame` matches us is captured and re-emitted under
-  the new category. We also wrap the dispatch itself in try/catch as a
-  defence-in-depth: if `dispatch-sync!` ever re-throws (e.g. a fault
-  inside the dispatch infrastructure itself, not the user handler),
-  we catch it here — and per EP-0008 (rf2-7b9r4l) the dedicated category
-  now rides the always-on axis so this defence-in-depth branch (which never
-  produced a router `:rf.error/handler-exception`) is observable in
-  production.
+  `:rf.error/handler-exception` — `dispatch-sync!` does not re-throw. To
+  surface the throw as the dedicated `:rf.error/on-destroy-handler-
+  exception` category (Mike's decision), we install a TRANSIENT listener
+  on the ALWAYS-ON error-emit axis for the duration of the dispatch: any
+  `:rf.error/handler-exception` record whose `:frame` matches us is
+  captured and re-emitted under the new category. The always-on axis is
+  the one surface the router's handler-exception fan-out ALSO rides
+  (`re-frame.router/emit-pipeline-exception!` → `error-emit/dispatch-on-
+  error!`), so this capture survives `:advanced` + `goog.DEBUG=false`
+  where the dev trace is DCE'd (rf2-87f7fb — the pre-EP-0008 capture
+  observed the dev-only `trace.tooling` listener registry, which no-ops
+  in production, so the dedicated discriminator did NOT survive prod for
+  the common path despite the Spec 009 catalogue promising it does). We
+  reach the registry through the `:error-emit/register-error-listener!` /
+  `:error-emit/unregister-error-listener!` late-bind hooks because a
+  static `re-frame.frame` → `re-frame.error-emit` require closes the
+  `error-emit` → `elision` → `frame` load cycle (the same reason the
+  emission below rides `:error-emit/dispatch-on-error`).
+
+  We ALSO wrap the dispatch itself in try/catch as a defence-in-depth: if
+  `dispatch-sync!` ever re-throws (e.g. a fault inside the dispatch
+  infrastructure itself, not the user handler), we catch it here — and
+  per EP-0008 (rf2-7b9r4l) the dedicated category now rides the always-on
+  axis so this defence-in-depth branch (which never produced a router
+  `:rf.error/handler-exception`) is observable in production. The two
+  paths are mutually exclusive (a router-converted handler throw never
+  re-throws out of `dispatch-sync!`; an infra fault re-throws and never
+  produces a router handler-exception record), and a `re-entered?` guard
+  makes the single-record contract explicit either way.
 
   This mirrors the swallow-then-continue shape of `safe-call-hook!` below
   but ALSO emits a structured error event (where `safe-call-hook!` is
@@ -1248,21 +1265,23 @@
   [id f]
   (when-let [on-destroy (-> f :config :on-destroy)]
     (when-let [dispatch-sync (late-bind/get-fn :router/dispatch-sync!)]
-      (let [captured (atom nil)
-            ;; The trace-buffer / listener registry lives in the optional
-            ;; trace.tooling sibling per rf2-qwm0a. Reach it through
-            ;; late-bind so this fn carries no static dep on the tooling
-            ;; ns; in production CLJS builds where trace.tooling is not
-            ;; loaded, the listener install is a silent no-op (no trace
-            ;; surface to observe, no trace to re-emit).
-            register   (late-bind/get-fn :trace.tooling/register-listener!)
-            remove-cb  (late-bind/get-fn :trace.tooling/unregister-listener!)
-            listener-k ::on-destroy-throw-watch
-            listener   (fn [ev]
-                         (when (and (= :rf.error/handler-exception (:operation ev))
-                                    (= id (-> ev :tags :frame))
-                                    (nil? @captured))
-                           (reset! captured ev)))]
+      (let [captured     (atom nil)
+            infra-fault? (atom false)
+            ;; The always-on error-emit listener registry — the
+            ;; production-survivable axis the router's handler-exception
+            ;; fan-out rides. Reached via late-bind so this fn carries no
+            ;; static dep on `error-emit` (the `error-emit` → `elision` →
+            ;; `frame` load cycle). The producer always loads at boot, so
+            ;; the lookup never misses in production; the `when register`
+            ;; guard keeps the install defensive regardless.
+            register     (late-bind/get-fn :error-emit/register-error-listener!)
+            remove-cb    (late-bind/get-fn :error-emit/unregister-error-listener!)
+            listener-k   ::on-destroy-throw-watch
+            listener     (fn [record]
+                           (when (and (= :rf.error/handler-exception (:error record))
+                                      (= id (:frame record))
+                                      (nil? @captured))
+                             (reset! captured record)))]
         (when (and register remove-cb)
           (register listener-k listener))
         (try
@@ -1275,20 +1294,26 @@
               ;; branch never produced a router :rf.error/handler-exception,
               ;; so the always-on emission here is its ONLY production
               ;; observability (EP-0008, rf2-7b9r4l).
+              (reset! infra-fault? true)
               (emit-on-destroy-handler-exception! id on-destroy ex nil)))
           (finally
             (when (and register remove-cb)
               (remove-cb listener-k))))
-        ;; If the router converted a handler throw to a trace, re-emit
-        ;; under the dedicated :on-destroy category so consumers can
-        ;; discriminate teardown failures from regular handler throws.
-        ;; Rides the always-on axis (EP-0008, rf2-7b9r4l) so the
-        ;; discriminable teardown signal survives `goog.DEBUG=false`.
-        (when-let [ev @captured]
-          (let [tags (:tags ev)]
+        ;; If the router converted a handler throw to an always-on
+        ;; `:rf.error/handler-exception` record, re-emit under the
+        ;; dedicated :on-destroy category so consumers can discriminate
+        ;; teardown failures from regular handler throws. Rides the
+        ;; always-on axis (EP-0008, rf2-7b9r4l) so the discriminable
+        ;; teardown signal survives `goog.DEBUG=false` (rf2-87f7fb). The
+        ;; `infra-fault?` guard keeps the single-record contract explicit
+        ;; — the defence-in-depth arm above already emitted in that case.
+        (when (and (not @infra-fault?) @captured)
+          (let [record @captured]
             (emit-on-destroy-handler-exception!
-              id on-destroy (:exception tags)
-              {:exception-message (:exception-message tags)})))))))
+              id on-destroy (:exception record)
+              {:exception-message (when-let [ex (:exception record)]
+                                    #?(:clj  (.getMessage ^Throwable ex)
+                                       :cljs (.-message ex)))})))))))
 
 (defn- notify-machine-destruction!
   "Frame-destroy machine-cascade entry-point.

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -757,6 +757,14 @@
     :producer-ns 're-frame.error-emit
     :design-bead "rf2-ini4wr"
     :description "Always-on ONE-bounded-record-per-destroy frame-teardown report (EP-0008 promotion criterion / Spec 009 §Channel-promotion catalogue rows). `frame/destroy-frame!` accumulates per-hook failures during the best-effort teardown walk and, through a FINALLY-shaped flush boundary, fires this hook once with the `:frame` + the collected `:hook-failures` vector — so a mid-teardown abort still ships the entries gathered so far. Builds the catalogue-shaped `:rf.error/frame-teardown-failed` record (`:recovery :ignored`) and fans it out to the corpus-wide error listeners. NOT one record per failed hook (the per-hook detail stays on the dev-only `:rf.warning/teardown-hook-exception` trace, DCE'd in prod). `frame` reaches it via late-bind because a static require closes a `error-emit` → `elision` → `frame` load cycle. Survives `:advanced` + `goog.DEBUG=false`. No-op when no hook failed."}
+   {:key         :error-emit/register-error-listener!
+    :producer-ns 're-frame.error-emit
+    :design-bead "rf2-87f7fb"
+    :description "Register a TRANSIENT always-on error listener under a key on the corpus-wide error-emit registry (the same surface `rf/register-error-listener!` exports). Published so `frame/fire-on-destroy-event!` can observe the router's always-on `:rf.error/handler-exception` fan-out for the duration of a throwing `:on-destroy` dispatch and re-emit the discriminable `:rf.error/on-destroy-handler-exception` category — WITHOUT a static `re-frame.frame` → `re-frame.error-emit` require (that closes the `error-emit` → `elision` → `frame` load cycle). Replaces the dev-only `:trace.tooling/register-listener!` capture the common path used pre-EP-0008 (which DCE'd under `goog.DEBUG=false`, so the dedicated teardown discriminator did not survive prod, rf2-87f7fb). Survives `:advanced` + `goog.DEBUG=false`."}
+   {:key         :error-emit/unregister-error-listener!
+    :producer-ns 're-frame.error-emit
+    :design-bead "rf2-87f7fb"
+    :description "Drop a listener registered through `:error-emit/register-error-listener!`. Paired with it in `frame/fire-on-destroy-event!`'s finally-shaped teardown of the transient `:on-destroy`-throw capture listener (rf2-87f7fb), so the listener never leaks past the dispatch. Survives `:advanced` + `goog.DEBUG=false`."}
 
    ;; ---- re-frame.observability (rf2-t55hxg.7 — EP-0015 §9 frame sink routing) -
    {:key         :observability/route-handled-event

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -32,8 +32,11 @@
 
     1. Every catalogue row carries a `Channel` value, and that value is
        one of the two graduated channels (`always-on` / `diagnostic`).
-       A new row added WITHOUT a channel (an empty cell, or a typo'd
-       channel name) fails here — the co-edit invariant made testable.
+       A new row added WITHOUT a channel (a blank cell, or a typo'd
+       channel name) fails DIRECTLY — the parser now captures the whole
+       third column (rf2-9fvp25), so a blank cell parses as a row with an
+       out-of-set channel and is flagged, rather than silently dropped
+       and caught only by the row-count floor.
     2. No category appears twice (the vocabulary is a set, not a bag).
     3. The three EP-0008-promoted categories are present and `always-on`
        (`:rf.error/frame-teardown-failed` — the teardown report;
@@ -48,9 +51,31 @@
        automatically drives it through the listener. Promotion stays
        real, not documentary, with no fragile fixed list.
 
-  JVM-only (`.clj`, NOT `*-cljs-test`): it `slurp`s a repo markdown file,
-  which only the JVM `clojure -M:test` runner can do. The exercise leg is
-  the dual-runtime half."
+  ## The co-edit ratchet against the EMIT SITES (rf2-9fvp25)
+
+  Invariants 1-4 pin the catalogue's INTERNAL consistency (and its
+  coupling to the exercise literal) — but they only ever compare the
+  catalogue against ITSELF + that literal. A production runtime that
+  EMITS a `:rf.error/*` / `:rf.warning/*` / advisory category with NO
+  catalogue row would pass all of them: the emitted-but-uncatalogued
+  category is invisible to a catalogue-only scan. rf2-sgz1zq was meant
+  to pin exactly that co-edit invariant; the durable ratchet lives here:
+
+    5. SOURCE-SCAN — derive the set of diagnostic/error/advisory
+       categories actually EMITTED from non-test runtime source (the
+       keyword arg to `emit-error!` / `emit-warning!` / `dispatch-on-
+       error!`, and the second keyword of an `emit!` whose op-type is
+       `:warning` / `:advisory`), across EVERY artefact's `src/` tree.
+       Every emitted category must be catalogued OR on the explicit
+       `out-of-catalogue-allow-list` (the EP-0008 audit-ruled intentional
+       exclusions, rf2-r8oiw7). A new uncatalogued emitted category fails
+       with a missing-row diagnostic. The allow-list itself is kept honest
+       (`allow-list-stays-honest`): an entry that stops being emitted, or
+       that gets catalogued, must be dropped.
+
+  JVM-only (`.clj`, NOT `*-cljs-test`): it `slurp`s repo markdown + source
+  files, which only the JVM `clojure -M:test` runner can do. The exercise
+  leg is the dual-runtime half."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
             [clojure.set :as set]
@@ -76,28 +101,36 @@
 
 (def ^:private catalogue-row-re
   "Matches one catalogue table row, capturing the `:operation` category
-  keyword (group 1) and the `Channel` column value (group 2). The table
-  shape (Spec 009 §Error event catalogue):
+  keyword (group 1) and the RAW `Channel` column cell (group 2,
+  possibly blank). The table shape (Spec 009 §Error event catalogue):
 
     | `:operation` | `:op-type` | Channel | Trigger / meaning | … |
 
   Group 1 is the back-ticked `:rf.<area>/<category>` in column 1; the
-  `:op-type` in column 2 is skipped; group 2 is the bare lowercase
-  channel token in column 3. Anchored at `^|` so it only matches genuine
-  table rows, not prose mentions of a category."
-  #"^\|\s*`(:rf\.[^`]+)`\s*\|\s*`?:[^|`]+`?\s*\|\s*([a-z-]+)\s*\|")
+  `:op-type` in column 2 is skipped; group 2 is the WHOLE third column
+  cell up to the next `|` — captured verbatim (NOT pre-filtered to a
+  lowercase token) so a blank or typo'd channel cell still parses as a
+  row and is validated downstream rather than silently dropped (rf2-9fvp25).
+  Anchored at `^|` so it only matches genuine table rows, not prose
+  mentions of a category. The retired-row sentinel (a strikethrough
+  `~~:rf...~~` in column 1) does not match — group 1 requires the
+  back-ticked category as the first cell content."
+  #"^\|\s*`(:rf\.[^`]+)`\s*\|\s*`?:[^|`]+`?\s*\|([^|]*)\|")
 
 (defn- parse-catalogue
   "Parse the Spec 009 error-event catalogue into a vector of
-  `{:category <kw> :channel <string>}` maps, in table order. Reads the
-  markdown fresh each call (cheap; one file)."
+  `{:category <kw> :channel <string>}` maps, in table order. The
+  `:channel` is the TRIMMED third-column cell — possibly the empty
+  string when the cell is blank — so the blank/invalid-channel
+  invariant is testable directly (rf2-9fvp25) rather than relying on a
+  row-count floor. Reads the markdown fresh each call (cheap; one file)."
   []
   (->> (slurp spec-009-file)
        (str/split-lines)
        (keep (fn [line]
                (when-let [[_ cat-str chan] (re-find catalogue-row-re line)]
                  {:category (keyword (subs cat-str 1)) ;; drop leading ':'
-                  :channel  chan})))
+                  :channel  (str/trim chan)})))
        vec))
 
 (def ^:private allowed-channels
@@ -105,6 +138,195 @@
   catalogue: \"Its value is one of two\"). The causal channel is data, not
   a catalogue row, so it is not a `Channel` cell value."
   #{"always-on" "diagnostic"})
+
+;; ---------------------------------------------------------------------------
+;; Source-scan: derive the EMITTED diagnostic/error/advisory category set
+;; from non-test runtime source, vs the parsed catalogue (rf2-9fvp25)
+;; ---------------------------------------------------------------------------
+;;
+;; The catalogue-side invariants above pin the catalogue's internal shape
+;; (every row has a valid channel; the always-on set matches the exercise
+;; literal). They do NOT close the co-edit invariant the bead names: a
+;; production runtime that EMITS a `:rf.error/*` / `:rf.warning/*` category
+;; with NO catalogue row would pass every test above — the catalogue is
+;; only compared against itself + the exercise literal, never against the
+;; actual emit sites. rf2-sgz1zq was meant to pin exactly that; this scan
+;; is the durable ratchet.
+;;
+;; Scope: the error/warning/advisory emit CHOKEPOINTS — the keyword passed
+;; as the category arg to `emit-error!` / `emit-warning!` / `dispatch-on-
+;; error!`, and the SECOND keyword of `emit!` when its op-type (first
+;; keyword) is `:warning` / `:advisory`. This deliberately EXCLUDES
+;; success-path / lifecycle traces (`(emit! :rf.fx :rf.fx/handled …)`,
+;; `(emit! :rf.event …)`): those ride op-type families the catalogue lists
+;; but are not the diagnostic/error/advisory vocabulary this co-edit
+;; invariant governs (the bead's acceptance criterion is scoped to
+;; "diagnostic/error/advisory category"). The scan is over every artefact's
+;; `src/` tree — not just core — so a feature artefact that emits an
+;; uncatalogued error is caught too.
+;;
+;; Limitation (CONSERVATIVE by design): a category emitted ONLY through an
+;; intermediate helper that takes the category as a literal arg but calls
+;; the chokepoint fns with a VARIABLE (e.g. `fx.cljc`'s `emit-fx-error!`,
+;; or the router's computed `classify-pipeline-exception` operation) is NOT
+;; captured here. That direction never false-POSITIVES (it under-reports,
+;; so a genuinely uncatalogued category emitted only via a helper would
+;; slip through) — acceptable for a ratchet whose job is to catch NEW
+;; direct emit sites. The dominant emit idiom across the corpus is the
+;; direct literal `(emit-error! :rf.x/y …)` / `(emit! :warning :rf.x/y …)`
+;; form, so coverage is high; widening to follow helper indirection is a
+;; future tightening, not a correctness gap in the ratchet's promise.
+
+(def ^:private impl-src-roots
+  "Every artefact's non-test source root, resolved from the JVM test CWD
+  (`implementation/core/` per rf2-0hxm → repo root is `../../`). Falls
+  back to the pre-split `../implementation/...` layout for a transitional
+  REPL run from `implementation/`. Only existing dirs are kept."
+  (let [bases ["../../implementation" "../implementation" "../.."]]
+    (->> bases
+         (mapcat (fn [base]
+                   (let [d (io/file base)]
+                     (when (.isDirectory d)
+                       (->> (.listFiles d)
+                            (filter #(.isDirectory %))
+                            (map #(io/file % "src")))))))
+         (filter #(.isDirectory %))
+         distinct
+         vec)))
+
+(def ^:private source-file-exts
+  #{".clj" ".cljc" ".cljs"})
+
+(defn- non-test-source-files
+  "Every `.clj` / `.cljc` / `.cljs` file under the artefact src roots.
+  src roots carry only production source (tests live in sibling `test/`
+  dirs), so no path-based test exclusion is needed; we guard with a
+  `/test/` path check anyway in case a root ever nests one."
+  []
+  (->> impl-src-roots
+       (mapcat (fn [root] (file-seq root)))
+       (filter #(.isFile %))
+       (filter (fn [f]
+                 (let [n (.getName f)]
+                   (some #(str/ends-with? n %) source-file-exts))))
+       (remove (fn [f]
+                 (let [p (str/replace (.getPath f) "\\" "/")]
+                   (or (str/includes? p "/test/")
+                       (str/ends-with? (.getName f) "_test.clj")
+                       (str/ends-with? (.getName f) "_test.cljc")
+                       (str/ends-with? (.getName f) "_test.cljs")))))))
+
+;; The keyword char class includes the apostrophe so categories like
+;; `:rf.warning/large-value-unschema'd` parse whole (NOT truncated at the
+;; `'`). Names are `:rf.<area>/<cat>`; the area segment may be dotted
+;; (`:rf.http.interceptor/…`, `:rf.epoch.cb/…`).
+(def ^:private category-kw-class "[a-z0-9][a-z0-9'-]*")
+
+(def ^:private emit-error-re
+  "`(… emit-error! :rf.<area>/<cat> …)` / `(… dispatch-on-error!
+  :rf.<area>/<cat> …)` / `(… emit-warning! :rf.<area>/<cat> …)` — the
+  category keyword is the token immediately after the fn symbol. The fn
+  may be ns-qualified (`trace/emit-error!`, `error-emit/dispatch-on-
+  error!`) or bare."
+  (re-pattern (str "(?:emit-error!|dispatch-on-error!|emit-warning!)\\s+"
+                   "(:rf\\.[a-z][a-z0-9.]*/" category-kw-class ")")))
+
+(def ^:private emit-bang-warning-re
+  "`(… emit! :warning :rf.<area>/<cat> …)` / `(… emit! :advisory
+  :rf.<area>/<cat> …)` — `emit!` takes the op-type FIRST and the category
+  SECOND, so only treat the category as diagnostic when the op-type is a
+  warning/advisory level. An `emit!` with op-type `:rf.event` / `:rf.fx`
+  / `:rf.sub` etc. is a success-path or lifecycle trace, NOT a
+  diagnostic/error/advisory category, and is intentionally skipped."
+  (re-pattern (str "emit!\\s+:(?:warning|advisory)\\s+"
+                   "(:rf\\.[a-z][a-z0-9.]*/" category-kw-class ")")))
+
+(defn- emitted-categories
+  "Scan every non-test source file for the diagnostic/error/advisory emit
+  chokepoints and return the SET of emitted category keywords. Pure text
+  scan — no classpath load — so it sees every artefact regardless of which
+  are on the test classpath."
+  []
+  (->> (non-test-source-files)
+       (mapcat (fn [f]
+                 (let [src (slurp f)]
+                   (concat (map second (re-seq emit-error-re src))
+                           (map second (re-seq emit-bang-warning-re src))))))
+       (map (fn [s] (keyword (subs s 1)))) ;; ":rf.x/y" string → keyword
+       set))
+
+(def ^:private out-of-catalogue-allow-list
+  "Categories EMITTED from non-test runtime source that currently have NO
+  Spec 009 §Error event catalogue row — the KNOWN backlog at the time this
+  ratchet landed (rf2-9fvp25). The source-scan revealed the co-edit gap is
+  WIDER than the original audit captured (rf2-r8oiw7 enumerated 7; the full
+  scan finds the set below). Reconciling each — add a catalogue row with a
+  Channel/recovery/tags ruling, or deliberately keep it out-of-catalogue
+  with a one-line 009 note — is tracked under rf2-r8oiw7 (the catalogue
+  co-edit-invariant bead); it is NOT this core-observability bead's job to
+  rule + author ~30 catalogue rows across the feature artefacts (the
+  hot-zone spec file). This list is the explicit ratchet baseline the bead
+  authorises (\"an explicit allow/ignore list for intentional non-catalogue
+  event IDs if needed\"): a NEW uncatalogued emitted category — beyond this
+  frozen baseline — fails the coverage test loudly. As rf2-r8oiw7 catalogues
+  each (or rules it intentionally out), DROP it from here in the SAME PR;
+  `allow-list-stays-honest` fails if a listed entry becomes catalogued or
+  stops being emitted, forcing the co-edit so the list cannot rot into a
+  silent blanket suppression.
+
+  Grouped by the EP-0008 audit's disposition (rf2-r8oiw7) where known;
+  the remainder are feature-artefact diagnostics surfaced by the wider
+  scan and awaiting the same triage."
+  #{;; --- the original rf2-r8oiw7 audit set (ruled: stay diagnostic) ---
+    ;; epoch callback isolation — :rf.epoch.cb op-type, time-axis tooling
+    :rf.epoch.cb/listener-exception
+    ;; epoch redaction fallback — DCE'd dev advisory
+    :rf.warning/epoch-redact-fn-exception
+    ;; resources dev advisories owned by the time-axis / resource family
+    :rf.warning/resource-sub-scope-mismatch
+    :rf.resource/hydrate-clock-skew
+    ;; machines DCE'd dev teaching advisory
+    :rf.warning/on-spawn-return-ignored
+    ;; (`:rf.resource/restore-clock-skew` + `:rf.route/navigation-blocked`
+    ;;  from the audit are NOT in this scan's set: the former is built as a
+    ;;  deferred-trace record literal, the latter is emitted with op-type
+    ;;  `:rf.event` — neither matches the diagnostic/error/advisory emit
+    ;;  chokepoints this scan targets, so they need no allow-list entry.)
+
+    ;; --- wider scan: feature-artefact diagnostics awaiting triage (rf2-r8oiw7) ---
+    ;; routing :can-leave guard validation + artefact-missing advisories
+    :rf.error/can-leave-non-boolean
+    :rf.warning/can-leave-subs-artefact-missing
+    :rf.error/navigate-arity-misuse
+    ;; machines `:after` timer / spawn-join validation diagnostics
+    :rf.error/machine-after-fn-threw
+    :rf.error/machine-after-sub-threw
+    :rf.error/machine-after-watch-failed
+    :rf.error/machine-spawn-all-bad-child-id
+    ;; SSR hydration / streaming / ring host diagnostics
+    :rf.error/hydration-frame-id-mismatch
+    :rf.error/suspense-boundary-duplicate-id
+    :rf.ssr/suspense-boundary-failed
+    :rf.error/ssr-ring-error-view-failed
+    :rf.error/ssr-ring-on-error-failed
+    :rf.ssr/csp-allowlist-violation
+    :rf.ssr/destroy-frame-failed
+    :rf.ssr/ssr-non-integer-status
+    :rf.ssr/ssr-non-string-header-value
+    :rf.ssr/ssr-redirect-no-target
+    :rf.ssr.head/cleanup-failed
+    ;; HTTP transport / decode diagnostics
+    :rf.http/aborted
+    :rf.warning/http-header-invalid
+    :rf.warning/http-malli-absent
+    :rf.warning/failure-swallowed
+    ;; resources clear-scope advisory
+    :rf.warning/resource-clear-scope-unresolved
+    ;; router dispatch-opt typo advisory
+    :rf.warning/unknown-dispatch-opt
+    ;; views plain-fn advisory — catalogue marks RETIRED but source still
+    ;; emits it (a catalogue/source drift rf2-r8oiw7 must reconcile)
+    :rf.warning/plain-fn-under-non-default-frame-once})
 
 ;; ---------------------------------------------------------------------------
 ;; Tests
@@ -205,3 +427,104 @@
                (pr-str (sort (set/difference
                                exercise/always-on-categories
                                catalogue-always-on))))))))
+
+(deftest every-table-row-has-a-nonblank-valid-channel
+  (testing "Per rf2-9fvp25: the catalogue parser now captures the WHOLE
+            third column (not a pre-filtered lowercase token), so a row
+            whose Channel cell is BLANK or holds a typo'd value parses as
+            a row with an out-of-set `:channel` and fails HERE directly —
+            rather than silently vanishing from the parse (the old regex
+            dropped it) and being caught only by the >= 100 row-count
+            floor. This makes the blank/invalid-channel invariant explicit
+            and independent of the floor."
+    (let [rows         (parse-catalogue)
+          blank        (filter #(str/blank? (:channel %)) rows)
+          invalid-set  (->> rows
+                            (remove #(str/blank? (:channel %)))
+                            (remove (comp allowed-channels :channel)))]
+      (is (empty? blank)
+          (str "catalogue rows with a BLANK Channel cell (rf2-9fvp25): "
+               (pr-str (map :category blank))))
+      (is (empty? invalid-set)
+          (str "catalogue rows with an invalid (non-"
+               allowed-channels ") Channel cell: "
+               (pr-str (map (juxt :category :channel) invalid-set)))))))
+
+;; ---------------------------------------------------------------------------
+;; Source-scan ratchet (rf2-9fvp25) — the co-edit invariant made testable
+;; against the ACTUAL emit sites, not just the catalogue's self-consistency.
+;; ---------------------------------------------------------------------------
+
+(deftest source-scan-finds-the-emit-sites
+  (testing "Sanity: the source scan reaches the artefact src trees and
+            finds the known emit chokepoints. A zero / tiny result means
+            the src roots did not resolve from the test CWD (a path-layout
+            change) — fail loudly rather than vacuously passing the
+            coverage invariant below with an empty emitted set."
+    (let [roots impl-src-roots
+          cats  (emitted-categories)]
+      (is (seq roots)
+          "at least one artefact src root resolved from the JVM test CWD")
+      (is (>= (count cats) 50)
+          (str "source scan found the diagnostic/error/advisory emit "
+               "vocabulary (>= 50 categories), not a broken / empty scan; "
+               "found " (count cats)))
+      ;; Anchor on the EP-0008 common-path producer (rf2-87f7fb) — emitted
+      ;; via `emit-error!` with a LITERAL category arg, so the emit-error!
+      ;; arm of the scan is exercised. (`:rf.error/handler-exception` is
+      ;; NOT a literal at its emit site — the router computes the category
+      ;; from the captured component identity and passes a VARIABLE to
+      ;; `dispatch-on-error!` — so it is intentionally not anchored here.)
+      (is (contains? cats :rf.error/on-destroy-handler-exception)
+          ":rf.error/on-destroy-handler-exception is among the scanned emit sites")
+      ;; Anchor on a second literal `emit-error!` category from a different
+      ;; ns (router/diagnostics) to prove the cross-file scan is live.
+      (is (contains? cats :rf.error/no-such-handler)
+          ":rf.error/no-such-handler is among the scanned emit sites"))))
+
+(deftest every-emitted-category-is-catalogued
+  (testing "Per rf2-9fvp25 (the durable co-edit ratchet, superseding the
+            self-referential rf2-sgz1zq pin): EVERY diagnostic/error/
+            advisory `:rf.*` category EMITTED from non-test runtime source
+            must appear in the Spec 009 §Error event catalogue — UNLESS it
+            is on the explicit `out-of-catalogue-allow-list` (the EP-0008
+            audit-ruled intentional exclusions, rf2-r8oiw7). A production
+            source that adds a NEW uncatalogued error/warning/advisory
+            category — without a catalogue row and without an allow-list
+            entry — fails HERE with a missing-row diagnostic, closing the
+            gap the prior tests left open (they compared the catalogue only
+            against itself + the exercise literal, never against the actual
+            emit sites)."
+    (let [catalogued (->> (parse-catalogue) (map :category) set)
+          emitted    (emitted-categories)
+          missing    (set/difference emitted catalogued out-of-catalogue-allow-list)]
+      (is (empty? missing)
+          (str "categories EMITTED from non-test runtime source with NO "
+               "Spec 009 catalogue row and no allow-list entry "
+               "(rf2-9fvp25 co-edit invariant): "
+               (pr-str (sort missing))
+               " — either add the catalogue row (with a Channel) or, if it "
+               "is an intentional non-catalogue category, add it to "
+               "out-of-catalogue-allow-list with a rationale.")))))
+
+(deftest allow-list-stays-honest
+  (testing "Per rf2-9fvp25: every category on the out-of-catalogue
+            allow-list must STILL be emitted from non-test source AND must
+            STILL be absent from the catalogue. This keeps the allow-list
+            from rotting into a stale suppression: if a listed category is
+            retired (no longer emitted) it must be dropped from the list,
+            and if it is finally catalogued (r8oiw7 adds a row) it must
+            ALSO be dropped (otherwise the list silently masks a real
+            catalogued category from the coverage check). Both drifts fail
+            here, forcing the co-edit."
+    (let [catalogued (->> (parse-catalogue) (map :category) set)
+          emitted    (emitted-categories)
+          stale-unemitted  (set/difference out-of-catalogue-allow-list emitted)
+          now-catalogued   (set/intersection out-of-catalogue-allow-list catalogued)]
+      (is (empty? stale-unemitted)
+          (str "allow-list entries no longer emitted from source (drop "
+               "them, rf2-9fvp25): " (pr-str (sort stale-unemitted))))
+      (is (empty? now-catalogued)
+          (str "allow-list entries that are NOW catalogued (drop them so "
+               "the coverage check governs them, rf2-9fvp25): "
+               (pr-str (sort now-catalogued)))))))

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -31,6 +31,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
+            [re-frame.error-emit :as error-emit]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]))
 
@@ -39,6 +40,10 @@
   (reset! frame/frames {})
   (flows/reset-flows!)
   (schemas/clear-schemas-by-frame!)
+  ;; The always-on error-emit listener registry is a `defonce` atom that
+  ;; `clear-all!` does NOT touch; clear it so an error listener registered
+  ;; by one test cannot leak into the next (rf2-uh5ic5).
+  (error-emit/clear-error-listeners!)
   (rf/init! plain-atom/adapter)
   ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`, and
   ;; the framework operation surfaces now require a carried frame stamp.
@@ -64,6 +69,20 @@
   [id]
   (let [acc (atom [])]
     (rf/register-listener! id (fn [ev] (swap! acc conj ev)))
+    acc))
+
+(defn- collect-errors!
+  "Register an ALWAYS-ON error listener under `id` via
+  `rf/register-error-listener!`, returning the atom that accumulates the
+  tight error-records (the production-survivable observability surface —
+  Spec 009 §What IS available in production §Error-emit listener). Tests
+  must (rf/unregister-error-listener! id) to detach (the fixture also
+  clears the registry). Distinct from `collect-traces!`: that listens on
+  the dev-only trace surface (DCE'd in prod); this listens on the
+  always-on axis."
+  [id]
+  (let [acc (atom [])]
+    (rf/register-error-listener! id (fn [record] (swap! acc conj record)))
     acc))
 
 ;; ---- 1. Source-order ordering across mixed effect types -------------------
@@ -1211,6 +1230,68 @@
           "the reserved :rf.fx/reg-flow body ran despite the redirect")
       (is (= 1 (count (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces)))
           "one :rf.error/reserved-fx-override trace fired for the redirect form too"))))
+
+(deftest reject-tier-override-fans-out-on-always-on-axis
+  ;; rf2-uh5ic5: the existing reserved-fx tests above assert the dev-only
+  ;; TRACE surface (`:operation` via `collect-traces!`). But Spec 009 §Error
+  ;; event catalogue marks `:rf.error/reserved-fx-override` as ALWAYS-ON — a
+  ;; production-reachable misconfiguration MUST reach the corpus-wide
+  ;; `register-error-listener!` substrate (surface #4, the off-box shipper
+  ;; axis). This pins the always-on listener contract for the REAL producer
+  ;; path (`fx.cljc`'s reject emit through `emit-fx-error!` →
+  ;; `error-emit/dispatch-on-error!`), driven through the genuine
+  ;; `dispatch-sync` → fx-walk path — NOT by calling the error substrate
+  ;; directly. The companion prod-elision leg lives in
+  ;; `re-frame.on-error-elision-prod-test` (proves it survives goog.DEBUG=false).
+  (testing "the real fn-value reject producer fans :rf.error/reserved-fx-override
+            out through register-error-listener! with event/id/frame context"
+    (let [errors (collect-errors! ::reject-always-on)]
+      (rf/reg-event-fx :fx-test.uh5ic5/install-flow
+        (fn [_ _] {:fx [[:rf.fx/reg-flow {:id     :fx-test.uh5ic5/a-flow
+                                          :inputs [[:fx-test.uh5ic5 :seed]]
+                                          :output (fn [_] 7)
+                                          :path   [:fx-test.uh5ic5 :out]}]]}))
+      (rf/dispatch-sync
+        [:fx-test.uh5ic5/install-flow]
+        {:fx-overrides {:rf.fx/reg-flow (fn [_ _] :should-not-fire)}})
+      (rf/unregister-error-listener! ::reject-always-on)
+      (let [records (filter #(= :rf.error/reserved-fx-override (:error %)) @errors)]
+        (is (= 1 (count records))
+            "exactly ONE always-on record reached register-error-listener!")
+        (let [r (first records)]
+          (is (= :rf.error/reserved-fx-override (:error r))
+              "the always-on record carries the reserved-fx-override category")
+          (is (= [:fx-test.uh5ic5/install-flow] (:event r))
+              ":event carries the dispatched event vector")
+          (is (= :fx-test.uh5ic5/install-flow (:event-id r))
+              ":event-id is the dispatched event-vector head")
+          (is (= :rf/default (:frame r))
+              ":frame names the frame the override was rejected in")
+          (is (number? (:time r)) ":time is a wall-clock millis number")))
+      (is (contains? (get (flows/flows-snapshot) :rf/default) :fx-test.uh5ic5/a-flow)
+          "the reserved :rf.fx/reg-flow body still ran (recovery :reserved-body-ran)")))
+
+  (testing "the keyword-redirect reject producer ALSO fans out on the always-on axis"
+    (let [errors (collect-errors! ::reject-always-on-redir)]
+      (rf/reg-fx :fx-test.uh5ic5/redir-target
+                 {:platforms #{:client :server}}
+                 (fn [_ _] :should-not-fire))
+      (rf/reg-event-fx :fx-test.uh5ic5/install-flow-2
+        (fn [_ _] {:fx [[:rf.fx/reg-flow {:id     :fx-test.uh5ic5/b-flow
+                                          :inputs [[:fx-test.uh5ic5 :seed]]
+                                          :output (fn [_] 1)
+                                          :path   [:fx-test.uh5ic5 :b]}]]}))
+      (rf/dispatch-sync
+        [:fx-test.uh5ic5/install-flow-2]
+        {:fx-overrides {:rf.fx/reg-flow :fx-test.uh5ic5/redir-target}})
+      (rf/unregister-error-listener! ::reject-always-on-redir)
+      (let [records (filter #(= :rf.error/reserved-fx-override (:error %)) @errors)]
+        (is (= 1 (count records))
+            "one always-on record for the keyword-redirect reject form too")
+        (is (= :fx-test.uh5ic5/install-flow-2 (:event-id (first records)))
+            ":event-id is the dispatched event-vector head"))
+      (is (contains? (get (flows/flows-snapshot) :rf/default) :fx-test.uh5ic5/b-flow)
+          "the reserved body still ran for the redirect form"))))
 
 (deftest overridable-tier-unaffected-by-reject
   (testing "OVERRIDABLE reserved fxs (:dispatch) still honour fn-value overrides"

--- a/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
@@ -327,6 +327,41 @@
         (is (some? r) "listener received :rf.error/override-fallthrough under prod")
         (is (= :rf/default (:frame r)))))))
 
+(deftest reserved-fx-override-listener-survives-prod
+  (testing "Per rf2-uh5ic5 / Spec 009 §Error event catalogue: under
+            `:advanced` + `goog.DEBUG=false`, a rejected `:fx-overrides`
+            entry targeting a REJECT-tier reserved fx-id fans
+            `:rf.error/reserved-fx-override` through the always-on
+            `register-error-listener!` substrate. This is the REAL producer
+            path: under prod the dev per-call reject in `handle-one-fx`
+            DCEs with the trace surface, so the router routes the effective
+            override map through `re-frame.fx/strip-rejected-overrides`
+            (the `:production-strip` site), which fans the error out on the
+            always-on axis. Driven through the genuine `dispatch-sync` →
+            fx-walk path — proving the production prod-strip producer (not
+            just the dev per-call one) survives elision."
+    (let [seen (atom [])]
+      (rf/register-error-listener! :prod/recorder
+                                   (fn [record] (swap! seen conj record)))
+      ;; :rf.fx/reg-flow is a REJECT-tier reserved fx (installs durable
+      ;; per-frame flow-registry state). A prod build cannot stub it out.
+      (rf/reg-event-fx :uh5ic5/install-flow
+                       (fn [_ _] {:fx [[:rf.fx/reg-flow
+                                        {:id     :uh5ic5/prod-flow
+                                         :inputs [[:uh5ic5 :seed]]
+                                         :output (fn [_] 1)
+                                         :path   [:uh5ic5 :out]}]]}))
+      (rf/dispatch-sync [:uh5ic5/install-flow]
+                        {:fx-overrides {:rf.fx/reg-flow (fn [_ _] :should-not-fire)}})
+      (let [r (some (fn [x] (when (= :rf.error/reserved-fx-override (:error x)) x)) @seen)]
+        (is (some? r)
+            "listener received :rf.error/reserved-fx-override under prod
+             (the strip-rejected-overrides production producer survives elision)")
+        (is (= :uh5ic5/install-flow (:event-id r))
+            ":event-id is the dispatched event-vector head")
+        (is (= :rf/default (:frame r))
+            ":frame names the frame the override was rejected in")))))
+
 (deftest no-such-cofx-listener-survives-prod
   (testing "Per rf2-goum9x: an `inject-cofx` to an unregistered cofx-id
             fans `:rf.error/no-such-cofx` through the always-on listener

--- a/implementation/core/test/re_frame/teardown_always_on_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/teardown_always_on_elision_prod_test.cljs
@@ -23,24 +23,32 @@
   rows (handler-exception / frame-destroyed / no-such-* / fx). This file
   closes the gap for the NEW EP-0008-promoted rows under the prod build.
 
-  NUANCE for `:rf.error/on-destroy-handler-exception` (rf2-7b9r4l): the
-  dedicated category has TWO producers with DIFFERENT prod-survival:
+  CONTRACT for `:rf.error/on-destroy-handler-exception` (rf2-7b9r4l +
+  rf2-87f7fb): the dedicated category has TWO producers, and BOTH now
+  survive prod (rf2-87f7fb closed the common-path gap):
 
-    - COMMON path (the user `:on-destroy` handler throws): the dedicated
-      record is re-emitted by `fire-on-destroy-event!` OBSERVING the
-      router's `:rf.error/handler-exception` trace via
-      `:trace.tooling/register-listener!` — a dev-only surface that DCEs.
-      So the dedicated record does NOT survive prod for this path. The
-      PRODUCTION SOURCE OF RECORD is the router's
-      `:rf.error/handler-exception` (which DOES ride the always-on axis).
-      This is the documented PARTIAL-COVERAGE NUANCE — dev-discrimination
-      only by design, NOT a regression.
+    - COMMON path (the user `:on-destroy` handler throws): the router
+      converts the throw to an always-on `:rf.error/handler-exception`
+      record (`emit-pipeline-exception!` → `error-emit/dispatch-on-
+      error!`, which is NOT `goog.DEBUG`-gated). `fire-on-destroy-event!`
+      installs a TRANSIENT listener on that SAME always-on axis (via the
+      `:error-emit/register-error-listener!` late-bind hook) for the
+      duration of the dispatch, captures the record, and re-emits the
+      dedicated `:rf.error/on-destroy-handler-exception` category. Because
+      the capture rides the always-on axis (NOT the dev-only
+      `trace.tooling` listener registry it used pre-rf2-87f7fb), the
+      dedicated discriminable record SURVIVES `:advanced` +
+      `goog.DEBUG=false` — exactly what the Spec 009 catalogue promises.
+      The router's generic `:rf.error/handler-exception` ALSO fires (the
+      production source of record for the handler throw itself); the
+      dedicated category is the discriminator (it happened during
+      destroy).
 
     - DEFENCE-IN-DEPTH branch (`dispatch-sync!` itself faults, rf2-bxud9v):
       `fire-on-destroy-event!` calls `emit-on-destroy-handler-exception!`
-      DIRECTLY (no trace capture), so the dedicated record DOES survive
-      prod — and this branch never produced a router handler-exception, so
-      the always-on emission is its ONLY production observability.
+      DIRECTLY (no capture), so the dedicated record DOES survive prod —
+      and this branch never produced a router handler-exception, so the
+      always-on emission is its ONLY production observability.
 
   This file pins BOTH legs explicitly so the contract is unambiguous.
 
@@ -209,27 +217,26 @@
 ;; throw signal survives prod (rf2-7b9r4l promotion).
 ;; ===========================================================================
 
-(deftest on-destroy-common-path-prod-coverage-is-handler-exception
-  (testing "Per rf2-7b9r4l PARTIAL-COVERAGE NUANCE: for the COMMON path (the
-            user `:on-destroy` handler itself throws), the DEDICATED
-            `:rf.error/on-destroy-handler-exception` category is
-            dev-discrimination-ONLY by design — it is re-emitted by
-            `fire-on-destroy-event!` observing the router's
-            `:rf.error/handler-exception` TRACE, and that trace-capture
-            mechanism (`:trace.tooling/register-listener!`) is a silent
-            no-op under `:advanced` + `goog.DEBUG=false` (the trace surface
-            is DCE'd). So under prod the dedicated record does NOT fire for
-            the common path. The PRODUCTION SOURCE OF RECORD for the throw
-            is the router's `:rf.error/handler-exception`, which DOES ride
-            the always-on axis and survives elision (per rf2-7b9r4l: 'the
-            underlying handler throw is ALSO caught by the router and emitted
-            as :rf.error/handler-exception, which DOES ride the always-on
-            axis -- so the failure is NOT fully silent in production'). This
-            test pins exactly that contract under the prod build: NO
-            dedicated record, but the handler-exception record survives. The
-            discriminable dedicated signal for a path with NO router
-            coverage — the dispatch-infra defence-in-depth branch — is pinned
-            by `dispatch-sync-infra-fault-survives-prod` below."
+(deftest on-destroy-common-path-dedicated-record-survives-prod
+  (testing "Per rf2-87f7fb / Spec 009 §Error event catalogue: for the COMMON
+            path (the user `:on-destroy` handler itself throws), the
+            DEDICATED `:rf.error/on-destroy-handler-exception` category
+            SURVIVES `:advanced` + `goog.DEBUG=false`. `fire-on-destroy-
+            event!` captures the router's ALWAYS-ON
+            `:rf.error/handler-exception` record (the router fans it out
+            via `error-emit/dispatch-on-error!`, NOT `goog.DEBUG`-gated)
+            through a TRANSIENT listener installed on the SAME always-on
+            axis (the `:error-emit/register-error-listener!` late-bind
+            hook), then re-emits the dedicated category — so the
+            discriminable teardown signal rides a production-survivable
+            surface. Before rf2-87f7fb the capture observed the dev-only
+            `trace.tooling` listener registry, which DCE'd under prod, so
+            the dedicated record did NOT fire for the common path despite
+            the catalogue promising it does — this test is the regression
+            that would have caught that gap. BOTH the dedicated discriminator
+            AND the router's generic `:rf.error/handler-exception` (the
+            production source of record for the handler throw itself) must
+            survive."
     (let [seen (atom [])]
       (rf/register-error-listener! :prod/recorder
                                    (fn [record] (swap! seen conj record)))
@@ -241,15 +248,25 @@
                      :on-destroy [:prod.ondestroy/blow-up]})
       (is (nil? (rf/destroy-frame! :prod.ondestroy/worker))
           "destroy-frame! returns nil even though :on-destroy threw under prod")
-      (is (empty? (filter #(= :rf.error/on-destroy-handler-exception (:error %)) @seen))
-          "the DEDICATED category does NOT survive prod for the common path
-           (it rides the DCE'd trace-capture mechanism — dev-discrimination
-           only, per rf2-7b9r4l)")
+      (let [reports (filter #(= :rf.error/on-destroy-handler-exception (:error %)) @seen)]
+        (is (= 1 (count reports))
+            "the DEDICATED discriminable teardown category SURVIVES prod for
+             the common path (rf2-87f7fb) — EXACTLY ONE record")
+        (let [r (first reports)]
+          (is (= :rf.error/on-destroy-handler-exception (:error r)))
+          (is (= :prod.ondestroy/worker (:frame r))
+              ":frame names the frame being torn down")
+          (is (= [:prod.ondestroy/blow-up] (:event r))
+              ":event carries the :on-destroy event vector")
+          (is (= :prod.ondestroy/blow-up (:event-id r))
+              ":event-id is the event-vector head")
+          (is (some? (:exception r))
+              ":exception carries the thrown object")
+          (is (number? (:time r)) ":time is a wall-clock millis number")))
       (let [hx (filter #(= :rf.error/handler-exception (:error %)) @seen)]
         (is (= 1 (count hx))
-            "the router's :rf.error/handler-exception IS the production
-             source of record — it rides the always-on axis and survives
-             elision")
+            "the router's :rf.error/handler-exception ALSO survives — the
+             production source of record for the handler throw itself")
         (let [r (first hx)]
           (is (= [:prod.ondestroy/blow-up] (:event r))
               ":event carries the :on-destroy event vector")


### PR DESCRIPTION
Clears the EP-0008 production-observability core tail (three beads). All changes are in `implementation/core/src` + `implementation/core/test` — no hot-zone files touched, Spec 009 untouched.

## rf2-87f7fb (P2 BUG) — on-destroy common path now survives prod elision

Spec 009 marks `:rf.error/on-destroy-handler-exception` as **always-on** and promises the discriminable teardown signal survives `goog.DEBUG=false`. But the common path (user `:on-destroy` handler throws) produced the dedicated category only by observing the router's `:rf.error/handler-exception` via the **dev-only** `:trace.tooling/register-listener!` surface, which DCEs in production — so the dedicated discriminator did **not** actually survive prod for the common path. The implementation was the lagging side of an already-correct catalogue promise.

Fix: `fire-on-destroy-event!` now captures via a **transient listener on the always-on error-emit axis** (the same axis the router's handler-exception fan-out rides), reached through two new late-bind hooks `:error-emit/register-error-listener!` / `:error-emit/unregister-error-listener!` (frame cannot static-require error-emit — `error-emit → elision → frame` load cycle). The dedicated discriminable record now survives `:advanced` + `goog.DEBUG=false`. The defence-in-depth (`dispatch-sync!` infra-fault) branch is unchanged; an `infra-fault?` guard makes the single-record contract explicit. The prod-elision test is rewritten to pin the corrected contract (it previously asserted the dedicated record does NOT fire for the common path).

## rf2-9fvp25 (P3 conformance) — compare emitted categories to the catalogue, not only parsed rows

The channel-conformance test only ever compared the catalogue against itself + the dual-runtime exercise literal, so a category emitted from runtime source with no catalogue row passed silently. Added:
- A **source-scan ratchet** (`every-emitted-category-is-catalogued`) that derives the diagnostic/error/advisory category set actually emitted from non-test source (`emit-error!` / `emit-warning!` / `dispatch-on-error!`, and `emit!` with a `:warning`/`:advisory` op-type) across **every artefact's** `src/` tree, and fails when an emitted category has no Spec 009 row and no allow-list entry.
- **Tightened parsing**: the parser now captures every table row (blank/invalid channel fails **directly** via `every-table-row-has-a-nonblank-valid-channel`, not via the row-count floor).
- `allow-list-stays-honest` keeps the explicit out-of-catalogue allow-list from rotting (an entry that becomes catalogued or stops being emitted fails).

The scan surfaced a **wider** uncatalogued backlog than the original audit (7 → 30). Rather than rule + author ~30 catalogue rows across the hot-zone spec file in this core bead, the full set is frozen as the explicit ratchet baseline (the allow-list the bead authorises) and noted on **rf2-r8oiw7** for catalogue triage — each row to be catalogued-or-ruled-out and dropped from the allow-list in the same PR.

## rf2-uh5ic5 (P3 test) — reserved-fx-override real producer on the always-on listener under prod

The conformance test exercised `:rf.error/reserved-fx-override` by calling the error substrate directly; existing real-producer tests assert **trace** behaviour only. Added:
- `reject-tier-override-fans-out-on-always-on-axis` (`fx_test.clj`): the real fn-value + keyword-redirect reject producers, driven through the genuine `dispatch-sync` → fx-walk path, fan `:rf.error/reserved-fx-override` out through `register-error-listener!` with event/id/frame context.
- `reserved-fx-override-listener-survives-prod` (`on_error_elision_prod_test.cljs`): the production `strip-rejected-overrides` producer survives `goog.DEBUG=false`. Existing trace assertions kept.

## Quality gates

- `npm run test:cljs` — 6753 tests, 27256 assertions, **0 failures**
- core `clojure -M:test` — 1297 tests, 5720 assertions, **0 failures**
- `npm run test:elision` — **PASS** (production 41/41 absent; control 41/41 present)
- `npm run test:browser-prod-elision` — 74 tests, 230 assertions, **0 failures** (the load-bearing prod-elision validation for 87f7fb + uh5ic5)
- `mkdocs --strict` — not required (Spec 009 untouched; the catalogue was already correct, the implementation was the lagging side)
