### PR TITLE
feat(xray): EP-0014 derivation-graph panel + off-box redaction (rf2-9ett2d + yjarv6)

### DIFF
--- a/tools/xray/spec/025-Derivation-Graph-Panel.md
+++ b/tools/xray/spec/025-Derivation-Graph-Panel.md
@@ -1,0 +1,211 @@
+# 025-Derivation-Graph-Panel
+
+The Xray surface for the **derivation/process algebra graph** — the
+consumer-side panel that renders the single unified `{:mode :nodes :edges}`
+`DerivationGraph` view across all five algebra-view families
+([`spec/Derivations.md`](../../../spec/Derivations.md);
+[EP-0014](../../../docs/EP/EP-0014-derivation-and-process-algebra.md)). The
+"where does this fact come from, when is it evaluated, where does it live,
+and who owns it?" lens — answered for subscriptions, flows, resources, route
+facts, and machine processes + selectors **in one place**.
+
+> **Owning framework spec.**
+> [`spec/Derivations.md`](../../../spec/Derivations.md) is the normative
+> source for the derivation/process algebra: the node shape, the two closed
+> superkinds, the storage / evaluation / lifecycle classifications, the
+> static-vs-live rule, the don't-execute rule, the graph-assembly composer
+> (`re-frame.derivation.graph`), and the redaction-metadata contract. This
+> doc is the Xray-side consumer contract: the panel sections, the
+> `:rf.xray/*` registry surface, the contributor map Xray supplies, the
+> on-box-raw / off-box-redacted posture, and the egress redaction call
+> site. Where this doc and Derivations.md differ, Derivations.md governs the
+> algebra; this doc governs Xray's presentation.
+
+> **Xray is the EP's NAMED FIRST CONSUMER.** EP-0014 §Reference
+> Implementation / Bead Plan item 7: "Add an internal graph-inspection
+> helper for static and live graphs. Xray may consume it first." This panel
+> is that consumption — the disposition-1 proof that the structured graph
+> shape survives real use (rf2-9ett2d).
+
+## Bug class
+
+> **Bug class:** "This page reads a dozen subscriptions, a couple of
+> resources, a route param, and a machine selector, and I cannot see how
+> they relate. Which fact feeds which? Is this value durable app-db state, a
+> server-owned cache entry, or an ephemeral reaction? When does it
+> re-evaluate? Which owner keeps it alive? Is this node a pure derivation or
+> a stateful process?"
+> **Insight Xray provides:** the whole derivation/process graph as ONE
+> view — every fact + process node classified by its closed superkind,
+> tinted by family, carrying its storage / evaluation / lifecycle
+> classifications and its declared input / param / selector edges; static
+> (registration-derived) or live (realized in the observed frame); all
+> read-only, all summarized for display.
+
+## The one graph (the composer)
+
+Every declared fact and process is a node over the frame fold. The five
+algebra-view tooling siblings each project one family
+([`spec/Derivations.md`](../../../spec/Derivations.md) — subscriptions /
+flows / resources / routes / machines); the composer
+`re-frame.derivation.graph` (EP-0014 slice-7) stitches those per-family
+projections into the single `{:mode :nodes :edges}` view this panel renders.
+The composer is a **projection over the five sibling projections** — it adds
+no new fact identity and re-runs no source form (the registrar-derived
+discipline). It ships **no public accessor** and **no `re-frame.core` facade
+export** (the issue-1 disposition; the public name is deferred until a
+consumer beyond the two named first consumers — Xray + the conformance
+fixtures — needs it, the graduation gate).
+
+## The two superkinds are the contract
+
+The panel groups + classifies **every** node by its closed superkind —
+`:derivation` | `:process` — read off `:kind` **alone** (EP-0014 §Algebra
+Declaration Shape: a tool MUST classify every node knowing only the two
+superkinds). The refined kinds (`:resource-process`, `:route-fact`,
+`:machine-process`, `:machine-selector`) ride the separate `:refinement`
+axis and are **colour, not contract** — they tint the row's family accent
+but never gate classification. A node carrying an unknown FUTURE refinement
+still renders + classifies off its superkind. A malformed node missing
+`:kind` degrades to an inert `:unknown` row (never throws).
+
+## Static vs live
+
+Two modes, toggled in the panel header
+([`spec/Derivations.md`](../../../spec/Derivations.md) §Static and live
+graphs):
+
+- **STATIC** — `re-frame.derivation.graph/derivation-graph`: the
+  registration-derived graph. Every registered fact/process + its
+  registration-known `:input` / `:param` / `:selector` edges. A parametric
+  subscription shows the `:parametric` marker and contributes **no** static
+  edge (the don't-execute rule — its realized edges appear only in the live
+  graph). Process-global, frame-agnostic.
+- **LIVE** — `re-frame.derivation.graph/live-derivation-graph`: the graph
+  realized in the **observed** frame (`:rf.xray/target-frame`) at a point in
+  time. Concrete subscription query vectors with realized `[:sub q]` input
+  edges, active resource cache entries keyed by scoped key, live machine
+  instances + spawned actors, and the materialized route slice with its
+  nav-token owner. Empty for a missing/destroyed frame or a production build
+  (the live projections are dev-gated; their bodies DCE).
+
+## Panel sections (top → bottom)
+
+```
+│ HEADER  — mode toggle · N nodes · M edges · derivation/process tally · roles │
+│ ─────────────────────────────────────────────────────────────────────────── │
+│ per-family node sections (editorial order):                                   │
+│   Subscriptions · Flows · Resources · Routes · Machines                       │
+│     each node row: ○ derivation / ◆ process · id · refinement · storage ·     │
+│     eval · owner · authority · parametric marker · value summaries            │
+│ ─────────────────────────────────────────────────────────────────────────── │
+│ EDGES  — :input / :param / :selector records (from → to)                      │
+```
+
+## The contributor seam — present families only
+
+The composer reaches each optional family through a `{family contributor}`
+map. On CLJS the **consuming tool supplies it** from the tooling siblings it
+statically `:require`s
+([`spec/Derivations.md`](../../../spec/Derivations.md) §The graph-assembly
+composer — "the optional siblings it has"). Xray's artefact deps are core
+(→ `re-frame.subs.tooling`, always present), routing
+(→ `re-frame.routing.tooling`), and flows (→ `re-frame.flows.tooling`); it
+does **not** `:require` the optional `re-frame.machines.*` /
+`re-frame.resources.*` runtime artefacts — the same decoupling the Resources
+panel ([024](024-Resources-Panel.md)) and the Machine Inspector
+([003](003-Machine-Inspector.md)) honour (they read those families'
+runtime-db slices decoupled, never `:require`ing the artefact). So
+`day8.re-frame2-xray.panels.derivation-graph/xray-contributors` carries the
+**three families Xray HAS**; the composer's present-family-only contract
+renders machines + resources as soon as those siblings join the map — a
+family Xray lacks simply contributes no nodes (the no-machines /
+no-resources story). The panel's silent state names this when nothing is
+registered.
+
+## Privacy — ON-BOX raw, OFF-BOX redacted
+
+This is the heart of the panel's egress contract, and it splits cleanly
+along the box boundary (the EP-0014 tail-2 redaction ruling, rf2-6y7wnb):
+
+### On-box rendering is RAW (Security.md permits on-box)
+
+The panel renders in the developer's own browser, in the `:rf/xray` frame,
+against the developer's own app. On-box inspection sees **raw** value
+summaries — that is the in-process truth (raw-on-box is correct-as-designed
+for read-only projections; the composer composes nodes verbatim by design
+and does **no** redaction). `derivation-graph-helpers/summarize` produces
+bounded, render-safe previews **for display ergonomics only** (a multi-MB
+value would wreck the panel) — it is a size/shape projection, **not** an
+egress boundary, and consults no elision policy.
+
+### Off-box egress is REDACTED, per-frame, FAIL-CLOSED
+
+The egress redaction **call site is born here** — the wire boundary where a
+tool ships the graph **off** the developer's box (an MCP surface streaming
+the graph to a remote agent, a serialized capture written to disk / posted
+to a service). `derivation-graph-helpers/redact-graph-for-egress` is that
+call site:
+
+- each node's value-bearing summary field (`:value` / `:params` / `:query`
+  / `:state`) is projected through the single shared `rf/elide-wire-value`
+  walker ([`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md)
+  §Privacy, [`spec/015-Data-Classification.md`](../../../spec/015-Data-Classification.md),
+  [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) §5);
+- **per-frame** — under the OBSERVED frame's own declared `:sensitive` /
+  `:large` `:app-db` elision policy (`re-frame.elision`, sourced from
+  `reg-frame`), passed as the explicit `:frame` opt so the named frame's
+  policy applies, never a borrowed or ambient one;
+- **fail-closed** — when the named frame is **not** a live frame (nil id, a
+  destroyed / never-registered frame), the projection walks frameless so
+  `rf/elide-wire-value` takes its own fail-closed branch and redacts the
+  whole value to the `:rf/redacted` sentinel rather than ship it raw under
+  no policy. A sensitive-declared value → `:rf/redacted`; a large-declared
+  value → the `:rf.size/large-elided` marker.
+
+**Redaction MUST NOT lose graph structure** (the headline guarantee — a
+redacted param is still an edge): the node **keys** (canonical family-tagged
+ids) and the `:edges` vector ride through **untouched**; the node is still
+present and still classified by its superkind; the storage / evaluation /
+lifecycle classifications, `:source-form`, `:refinement`, `:inputs`
+topology, and `:output` address are **structure, not values**, and are never
+walked. Only the value-bearing leaf fields inside node bodies are redacted.
+
+## `:rf.xray/*` registry surface
+
+All under the `:rf.xray/*` isolation prefix (the collision contract); all
+read-only (assembling the graph dispatches nothing and pins nothing):
+
+| Surface | Kind | Role |
+|---|---|---|
+| `:rf.xray/derivation-graph-mode` | sub | `:static` \| `:live` toggle (default `:static`) |
+| `:rf.xray/set-derivation-graph-mode` | event | set the mode toggle |
+| `:rf.xray/derivation-graph-override` | sub | test-only graph override |
+| `:rf.xray/set-derivation-graph-override-for-test` | event | set the override |
+| `:rf.xray/derivation-graph` | sub | the assembled `DerivationGraph` (static / live, over `xray-contributors`) |
+| `:rf.xray/derivation-graph-tab-data` | sub | the view-facing composite (on-box summaries + family grouping + summary header) |
+
+## Read-only
+
+Same contract as every Xray panel — observing the graph pins nothing,
+dispatches nothing, mutates no host state. Pure hiccup; the projection
+algebra + the egress redaction call site live in
+`derivation_graph_helpers.cljc` (JVM-portable). Frame isolation comes from
+the enclosing `[rf/frame-provider {:frame :rf/xray}]` in `shell.cljs`.
+
+## Test coverage
+
+- **`derivation_graph_helpers_cljs_test.cljc`** (JVM + node) — superkind
+  classification by `:kind` alone; family grouping; edge role grouping +
+  node degree; on-box `summarize` raw-permitting posture; `summarize-node`
+  structure preservation; `graph-summary` tallies.
+- **`derivation_graph_redaction_cljs_test.cljc`** (JVM + node, runtime
+  fixture) — the **positive** off-box egress test (rf2-yjarv6): a sensitive
+  node value run through `rf/elide-wire-value` is elided **while** the node
+  + edge structure survives (the "redact value, keep edge" arm the EP-0014
+  testing-coverage audit flagged as missing); large elision → marker keeping
+  structure; per-frame policy (a non-classifying frame ships the same value
+  raw); frameless fail-closed.
+- The composer assembly mechanics + the cross-family classification
+  conformance are pinned by `re-frame.derivation-graph-test` (JVM) and the
+  derivation-algebra conformance fixture (the other named first consumer).

--- a/tools/xray/spec/README.md
+++ b/tools/xray/spec/README.md
@@ -115,6 +115,19 @@ main read**.
   privacy posture (params/scopes get the SAME summary + size elision as
   data; read-only — observing pins no resource). Decoupled from the
   optional Resources artefact.
+- **[025-Derivation-Graph-Panel.md](025-Derivation-Graph-Panel.md)** — The
+  Derivation-Graph tab: the Xray-side consumer contract for the EP-0014
+  derivation/process algebra graph (framework
+  [`spec/Derivations.md`](../../../spec/Derivations.md)). Xray is the EP's
+  **named first consumer** of the structured graph accessor: the unified
+  `{:mode :nodes :edges}` view composed by `re-frame.derivation.graph`
+  across all five algebra-view families, classified by the two closed
+  superkinds (`:derivation` / `:process`), static vs live, with the
+  contributor seam supplying the families Xray `:require`s. Carries the
+  **off-box egress redaction call site** (`redact-graph-for-egress` —
+  per-frame, fail-closed, via `rf/elide-wire-value`; redact value, keep
+  edge): on-box rendering is raw (Security.md permits on-box), off-box
+  egress projects through the frame's elision policy. Read-only.
 
 ### Reference
 

--- a/tools/xray/src/day8/re_frame2_xray/focus.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/focus.cljc
@@ -124,8 +124,9 @@
   `:views` / `:routes` per `tools/xray/spec/007-UX-IA.md`. The Issues
   tab was removed per rf2-gbz39 (Option (c) — issues surface inline in
   the Epoch + the L2 event-row pink-wash + the always-on issues ribbon
-  signal), so `:issues` is no longer a focusable panel."
-  #{:epoch :app-db :views :trace :machines :routes})
+  signal), so `:issues` is no longer a focusable panel. `:derivation-graph`
+  (EP-0014 prop-3, rf2-9ett2d) is the unified derivation/process graph tab."
+  #{:epoch :app-db :views :trace :machines :routes :derivation-graph})
 
 ;; ---------------------------------------------------------------------------
 ;; Pure command → dispatches translation (JVM-runnable)

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
@@ -165,14 +165,19 @@
 
 ;; ---- mode toggle ---------------------------------------------------------
 
-(defn- mode-toggle [mode]
+;; `dispatch` (rf2-1w07r) is the reg-view-injected frame-bound dispatcher
+;; threaded down from the `Panel` body, so the deferred `:on-click` lands on
+;; the surrounding `:rf/xray` instance frame (not a bare global `rf/dispatch`
+;; that leaks to `:rf/default` once render unwinds and the ambient frame is
+;; gone). Read-only panel: the only dispatch is the maintainer's mode toggle.
+(defn- mode-toggle [dispatch mode]
   [:div {:data-testid "rf-xray-derivation-graph-mode-toggle"
          :style {:display "flex" :gap "8px" :align-items "center"}}
    (for [m [:static :live]]
      ^{:key (name m)}
      [:button {:data-testid (str "rf-xray-derivation-graph-mode-" (name m))
                :data-active (str (= mode m))
-               :on-click #(rf/dispatch [:rf.xray/set-derivation-graph-mode m])
+               :on-click #(dispatch [:rf.xray/set-derivation-graph-mode m])
                :style {:font-family mono-stack :font-size "11px"
                        :padding "2px 10px" :cursor "pointer"
                        :border (str "1px solid "
@@ -184,7 +189,7 @@
 
 ;; ---- header summary ------------------------------------------------------
 
-(defn- summary-header [{:keys [mode node-count edge-count by-superkind by-role]} mode-now]
+(defn- summary-header [dispatch {:keys [mode node-count edge-count by-superkind by-role]} mode-now]
   [:section {:data-testid "rf-xray-derivation-graph-header"
              :style {:padding "12px 16px"
                      :border-bottom (str "1px solid " (:border-subtle tokens))
@@ -193,7 +198,7 @@
     [:span {:style {:color mode-accent :font-weight 600 :font-family sans-stack
                     :font-size "12px" :text-transform "uppercase" :letter-spacing "0.5px"}}
      "Derivation / process graph"]
-    (mode-toggle mode-now)]
+    (mode-toggle dispatch mode-now)]
    [:div {:data-testid "rf-xray-derivation-graph-counts"
           :style {:display "flex" :gap "12px" :flex-wrap "wrap"
                   :font-family mono-stack :font-size "11px"
@@ -329,7 +334,7 @@
                :style {:height "100%" :display "flex" :flex-direction "column"
                        :background (:bg-2 tokens) :color (:text-primary tokens)
                        :font-family sans-stack :font-size "14px" :overflow "auto"}}
-     (summary-header summary mode)
+     (summary-header dispatch summary mode)
      (if silent?
        (silent-state)
        (into [:<>]

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs
@@ -1,0 +1,421 @@
+(ns day8.re-frame2-xray.panels.derivation-graph
+  "Derivation-Graph tab — Xray's unified view of the EP-0014
+  derivation/process algebra graph (prop-3, rf2-9ett2d; the NAMED FIRST
+  CONSUMER of the structured graph accessor).
+
+  ## The one graph
+
+  Every declared fact and process in the host app — subscriptions, flows,
+  resources, route facts, machine processes + selectors — is a node in ONE
+  derivation/process graph over the frame fold ([Derivations.md] §Graph
+  inspection; [EP-0014]). The five algebra-view tooling siblings each
+  project one family; `re-frame.derivation.graph` (the composer, slice-7)
+  stitches them into a single `{:mode :nodes :edges}` view. This panel
+  renders that one graph, so a maintainer (or agent) answers \"where does
+  this value come from, when is it evaluated, where does it live, who owns
+  it?\" across families in one place — even though the underlying runtime
+  mechanisms are subscription cache, flow registry, route slice, resource
+  cache, and machine snapshots.
+
+  ## Static vs live
+
+  Two modes, toggled in the panel header (mirroring [Derivations.md]
+  §Static and live graphs):
+
+    - STATIC — `derivation-graph`: the registration-derived graph. Every
+      registered fact/process + its registration-known `:input` /
+      `:param` / `:selector` edges; a parametric sub shows the
+      `:parametric` marker and contributes NO edge (the don't-execute
+      rule). Process-global, frame-agnostic.
+    - LIVE — `live-derivation-graph`: the graph realized in the OBSERVED
+      frame at a point in time. Concrete subscription query vectors with
+      realized `[:sub q]` input edges, active resource cache entries,
+      live machine instances + spawned actors, the materialized route
+      slice with its nav-token owner.
+
+  ## The two superkinds are the contract
+
+  The panel groups + classifies every node by its CLOSED superkind
+  (`:derivation` | `:process`) read off `:kind` alone (EP-0014: a tool MUST
+  classify every node knowing only the two superkinds). The refined kinds
+  (`:resource-process`, `:route-fact`, `:machine-process`,
+  `:machine-selector`) are the COLOUR axis — they tint the row's family
+  accent but never gate classification. A node carrying an unknown FUTURE
+  refinement still renders + classifies off its superkind.
+
+  ## ON-BOX raw, OFF-BOX redacted
+
+  On-box rendering shows raw value summaries (Security.md permits on-box;
+  the developer is entitled to their own app's values — the TAIL-2 ruling:
+  raw-on-box is the in-process truth). `derivation-graph-helpers/summarize`
+  bounds value previews for display ergonomics only, NOT for privacy. The
+  OFF-BOX egress boundary — where a tool ships the graph to a remote agent
+  or a serialized capture — is `derivation-graph-helpers/redact-graph-for-
+  egress`, which projects each node's value-bearing fields through the
+  frame's `rf/elide-wire-value` policy (per-frame, fail-closed), preserving
+  edge + node structure (rf2-yjarv6). This panel renders on-box, so it
+  reads the RAW graph.
+
+  ## The contributor seam — present families only
+
+  The composer reaches each optional family through a `{family
+  contributor}` map. On CLJS the consuming tool supplies it from the
+  tooling siblings it statically `:require`s ([Derivations.md] §The
+  graph-assembly composer — \"the optional siblings it has\"). Xray's
+  artefact deps are core (→ `re-frame.subs.tooling`), routing (→
+  `re-frame.routing.tooling`), and flows (→ `re-frame.flows.tooling`); it
+  does NOT `:require` the optional `re-frame.machines.*` / `re-frame.
+  resources.*` runtime artefacts (the same decoupling the Resources panel +
+  Machine Inspector honour — they read those families' runtime-db slices
+  decoupled, never `:require`ing the artefact). So the contributor map here
+  carries the three families Xray HAS; the composer's present-family-only
+  contract renders machines/resources as soon as those siblings join the
+  map (the seam is ready). A family Xray lacks simply contributes no nodes
+  — the no-machines / no-resources story.
+
+  ## Read-only
+
+  Same contract as every Xray panel — observing the graph pins nothing,
+  dispatches nothing, mutates no host state. Pure hiccup; projection
+  algebra lives in `derivation_graph_helpers.cljc` (JVM-portable). Frame
+  isolation comes from the enclosing `[rf/frame-provider {:frame :rf/xray}]`
+  in `shell.cljs`."
+  (:require [re-frame.core :as rf]
+            [re-frame.derivation.graph :as dgraph]
+            [re-frame.flows.tooling :as flows-tooling]
+            [re-frame.routing.tooling :as routing-tooling]
+            [re-frame.subs.tooling :as subs-tooling]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.panels.derivation-graph-helpers :as h]
+            [day8.re-frame2-xray.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- the Xray contributor map -------------------------------------------
+;;
+;; The three families Xray statically `:require`s (see ns docstring). The
+;; composer composes these; machines/resources are absent from Xray's deps
+;; and contribute no nodes (the no-machines/no-resources story). When those
+;; artefacts join Xray's deps the seam accepts them with no panel change.
+
+(def xray-contributors
+  "The `{family contributor}` map for `re-frame.derivation.graph`, built
+  from the tooling siblings Xray statically `:require`s. `:subs` lives in
+  core (always present); `:flows` + `:routes` are Xray hard deps."
+  {:subs   {:static-fn  subs-tooling/sub-algebra-view
+            :live-fn    subs-tooling/sub-cache-algebra-view
+            :live-shape :map}
+   :flows  {:static-fn  flows-tooling/flow-algebra-view
+            :live-fn    flows-tooling/flow-algebra-view
+            :live-shape :map}
+   :routes {:static-fn  routing-tooling/route-algebra-view
+            :live-fn    routing-tooling/route-slice-algebra-view
+            :live-shape :node}})
+
+(def ^:private mode-accent (:magenta tokens))     ; violet — the algebra lens
+
+;; ---- family accents ------------------------------------------------------
+;;
+;; Colour, not contract — the family tint reads families apart at a glance.
+
+(defn- family-accent [family]
+  (case family
+    :subs      (:accent tokens)         ; GitHub-blue
+    :flows     (:green tokens)
+    :resources (:info tokens)
+    :routes    (:syntax-number tokens)  ; orange
+    :machines  (:magenta-pink tokens)
+    (:text-tertiary tokens)))
+
+(defn- role-colour [role]
+  (case role
+    :input    (:accent tokens)
+    :param    (:info tokens)
+    :selector (:magenta-pink tokens)
+    (:text-tertiary tokens)))
+
+;; ---- shared primitives ---------------------------------------------------
+
+(defn- section-caption [label testid]
+  [:div {:data-testid testid
+         :style {:color (:text-tertiary tokens)
+                 :font-family sans-stack
+                 :font-size "10px" :font-weight 600
+                 :text-transform "uppercase" :letter-spacing "0.5px"
+                 :margin-bottom "8px"}}
+   label])
+
+(defn- section [{:keys [first? testid]} caption body]
+  [:section {:data-testid testid
+             :style (cond-> {:padding "12px 16px"}
+                      (not first?)
+                      (assoc :border-top (str "1px solid " (:border-subtle tokens))))}
+   caption body])
+
+(defn- summary-chip
+  "Render a `helpers/summarize` shape as a compact, render-safe chip. NEVER
+  the raw value object — always the bounded preview; a `:rf/redacted`
+  sentinel (a value that arrived already redacted) renders muted."
+  [{:keys [type size preview redacted?]} testid]
+  [:span {:data-testid testid
+          :style {:font-family mono-stack :font-size "11px"
+                  :color (if redacted? (:text-tertiary tokens) (:text-primary tokens))}}
+   (str preview
+        (when (and size (#{:map :set :vector :seq} type))
+          (str " (" size ")")))])
+
+;; ---- mode toggle ---------------------------------------------------------
+
+(defn- mode-toggle [mode]
+  [:div {:data-testid "rf-xray-derivation-graph-mode-toggle"
+         :style {:display "flex" :gap "8px" :align-items "center"}}
+   (for [m [:static :live]]
+     ^{:key (name m)}
+     [:button {:data-testid (str "rf-xray-derivation-graph-mode-" (name m))
+               :data-active (str (= mode m))
+               :on-click #(rf/dispatch [:rf.xray/set-derivation-graph-mode m])
+               :style {:font-family mono-stack :font-size "11px"
+                       :padding "2px 10px" :cursor "pointer"
+                       :border (str "1px solid "
+                                    (if (= mode m) mode-accent (:border-default tokens)))
+                       :border-radius "3px"
+                       :background (if (= mode m) (:bg-3 tokens) "transparent")
+                       :color (if (= mode m) (:text-primary tokens) (:text-tertiary tokens))}}
+      (name m)])])
+
+;; ---- header summary ------------------------------------------------------
+
+(defn- summary-header [{:keys [mode node-count edge-count by-superkind by-role]} mode-now]
+  [:section {:data-testid "rf-xray-derivation-graph-header"
+             :style {:padding "12px 16px"
+                     :border-bottom (str "1px solid " (:border-subtle tokens))
+                     :display "flex" :flex-direction "column" :gap "8px"}}
+   [:div {:style {:display "flex" :justify-content "space-between" :align-items "center"}}
+    [:span {:style {:color mode-accent :font-weight 600 :font-family sans-stack
+                    :font-size "12px" :text-transform "uppercase" :letter-spacing "0.5px"}}
+     "Derivation / process graph"]
+    (mode-toggle mode-now)]
+   [:div {:data-testid "rf-xray-derivation-graph-counts"
+          :style {:display "flex" :gap "12px" :flex-wrap "wrap"
+                  :font-family mono-stack :font-size "11px"
+                  :color (:text-tertiary tokens)}}
+    [:span {:data-testid "rf-xray-derivation-graph-mode-badge"} (str "mode " (name (or mode mode-now)))]
+    [:span (str node-count " nodes")]
+    [:span (str edge-count " edges")]
+    [:span {:data-testid "rf-xray-derivation-graph-superkind-derivation"
+            :style {:color (:accent tokens)}}
+     (str (get by-superkind :derivation 0) " derivation")]
+    [:span {:data-testid "rf-xray-derivation-graph-superkind-process"
+            :style {:color (:magenta-pink tokens)}}
+     (str (get by-superkind :process 0) " process")]
+    (for [role h/edge-roles]
+      ^{:key (name role)}
+      (when-let [n (get by-role role)]
+        [:span {:style {:color (role-colour role)}} (str n " " (name role))]))]])
+
+;; ---- node row ------------------------------------------------------------
+
+(defn- node-row [[node-id node] family]
+  (let [skind  (h/superkind node)
+        testid (str "rf-xray-derivation-graph-node-" (hash node-id))]
+    [:div {:data-testid testid
+           :data-superkind (name skind)
+           :data-refinement (some-> (:refinement node) name)
+           :data-family (name family)
+           :style {:display "flex" :flex-wrap "wrap" :align-items "baseline"
+                   :gap "8px" :padding "3px 0"
+                   :font-family mono-stack :font-size "12px"}}
+     ;; superkind dot — the CONTRACT classification (derivation vs process)
+     [:span {:data-testid (str testid "-superkind")
+             :style {:color (if (= :process skind) (:magenta-pink tokens) (:accent tokens))
+                     :font-weight 700}}
+      (if (= :process skind) "◆" "○")]
+     [:span {:data-testid (str testid "-id")
+             :style {:color (family-accent family) :font-weight 600 :min-width "12rem"}}
+      (h/node-label node-id)]
+     ;; refinement — COLOUR, not contract
+     (when-let [r (:refinement node)]
+       [:span {:data-testid (str testid "-refinement")
+               :style {:color (:text-tertiary tokens)}}
+        (name r)])
+     ;; storage / evaluation / lifecycle classifications
+     (when-let [s (:storage node)]
+       [:span {:style {:color (:text-tertiary tokens)}} "store " (pr-str s)])
+     (when-let [e (:evaluation node)]
+       [:span {:style {:color (:text-tertiary tokens)}} "eval " (pr-str e)])
+     (when-let [l (:lifecycle node)]
+       [:span {:style {:color (:text-tertiary tokens)}}
+        "owner " (pr-str (if (map? l) (:kind l) l))])
+     ;; external authority split (resources) — :storage local, :authority remote
+     (when-let [a (:authority node)]
+       [:span {:data-testid (str testid "-authority")
+               :style {:color (:warning tokens)}}
+        "authority " (pr-str (:kind a))])
+     ;; parametric marker — the don't-execute rule made visible
+     (when (= :parametric (:inputs node))
+       [:span {:data-testid (str testid "-parametric")
+               :style {:color (:advisory tokens)}}
+        "parametric"])
+     ;; ON-BOX value summaries (raw-permitting; bounded previews)
+     (for [[k summary] (:summaries node)]
+       ^{:key (name k)}
+       [:span {:style {:display "inline-flex" :gap "4px" :align-items "baseline"}}
+        [:span {:style {:color (:text-tertiary tokens)}} (name k)]
+        (summary-chip summary (str testid "-" (name k)))])]))
+
+(defn- family-section [family entries first?]
+  (section
+   {:first? first? :testid (str "rf-xray-derivation-graph-family-" (name family))}
+   (section-caption (str (h/family-label family) " (" (count entries) ")")
+                    (str "rf-xray-derivation-graph-family-" (name family) "-caption"))
+   (into [:div {:data-testid (str "rf-xray-derivation-graph-family-" (name family) "-body")
+                :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+         (for [entry entries]
+           ^{:key (pr-str (first entry))} (node-row entry family)))))
+
+;; ---- edges section -------------------------------------------------------
+
+(defn- edge-row [{:keys [from to role]}]
+  [:div {:data-testid (str "rf-xray-derivation-graph-edge-" (hash [from to role]))
+         :data-role (name role)
+         :style {:display "flex" :gap "6px" :align-items "baseline"
+                 :padding "1px 0" :font-family mono-stack :font-size "11px"}}
+   [:span {:style {:color (role-colour role) :font-weight 600 :min-width "5rem"}}
+    (name role)]
+   [:span {:style {:color (:text-primary tokens)}} (h/node-label from)]
+   [:span {:style {:color (:text-tertiary tokens)}} "→"]
+   [:span {:style {:color (:text-primary tokens)}} (h/node-label to)]])
+
+(defn- edges-section [edges]
+  (section
+   {:first? false :testid "rf-xray-derivation-graph-edges"}
+   (section-caption (str "Edges (" (count edges) ")")
+                    "rf-xray-derivation-graph-edges-caption")
+   (if (seq edges)
+     (into [:div {:data-testid "rf-xray-derivation-graph-edges-body"
+                  :style {:display "flex" :flex-direction "column" :gap "1px"}}]
+           (for [e edges]
+             ^{:key (pr-str [(:from e) (:to e) (:role e)])} (edge-row e)))
+     [:div {:data-testid "rf-xray-derivation-graph-edges-empty"
+            :style {:color (:text-tertiary tokens) :font-style "italic"
+                    :font-size "11px" :font-family sans-stack}}
+      "No node→node edges (a graph of layer-1 readers + parametric subs has no static edges)."])))
+
+;; ---- silent state --------------------------------------------------------
+
+(defn- silent-state []
+  [:div {:data-testid "rf-xray-derivation-graph-silent"
+         :style {:padding "16px" :display "flex" :flex-direction "column" :gap "8px"
+                 :color (:text-tertiary tokens) :font-family sans-stack :font-size "11px"}}
+   [:span {:style {:font-style "italic"}}
+    "No derivation/process nodes in the host app."]
+   [:span
+    "Register subscriptions, flows, or routes — the unified graph renders once "
+    "the host installs any algebra-view family. (Machines + resources join the "
+    "graph when their artefacts are on Xray's classpath.)"]])
+
+;; ---- public view ---------------------------------------------------------
+
+(rf/reg-view Panel
+  "The Derivation-Graph tab's root view (EP-0014 prop-3). Subscribes to
+  `:rf.xray/derivation-graph-tab-data` and renders the header (mode toggle +
+  counts), the per-family node sections (grouped + classified by superkind),
+  and the edges section. Reads the ON-BOX raw graph (Security.md permits
+  on-box); off-box egress redaction is `helpers/redact-graph-for-egress`,
+  exercised by tooling that ships the graph off the developer's box."
+  []
+  (let [{:keys [mode summary by-family edges silent?]}
+        @(rf/subscribe [:rf.xray/derivation-graph-tab-data])]
+    [:section {:data-testid "rf-xray-derivation-graph"
+               :style {:height "100%" :display "flex" :flex-direction "column"
+                       :background (:bg-2 tokens) :color (:text-primary tokens)
+                       :font-family sans-stack :font-size "14px" :overflow "auto"}}
+     (summary-header summary mode)
+     (if silent?
+       (silent-state)
+       (into [:<>]
+             (concat
+              (map-indexed
+               (fn [idx family]
+                 (when-let [entries (seq (get by-family family))]
+                   ^{:key (name family)}
+                   (family-section family entries (zero? idx))))
+               h/families)
+              [^{:key "edges"} (edges-section edges)])))]))
+
+;; ---- registration entry --------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Derivation-Graph panel's Xray-side
+  registrations (all under the `:rf.xray/*` isolation prefix).
+
+  Registers:
+
+    - `:rf.xray/derivation-graph-mode` — `:static` | `:live` toggle slot
+      (default `:static`). Settable via `:rf.xray/set-derivation-graph-mode`.
+    - `:rf.xray/derivation-graph-override` — test override for the assembled
+      graph (so JVM/CLJS tests drive a fixture graph without a full runtime).
+    - `:rf.xray/derivation-graph` — the assembled `DerivationGraph`. In
+      `:static` mode, `derivation-graph` over `xray-contributors`
+      (process-global). In `:live` mode, `live-derivation-graph` for the
+      OBSERVED target frame (`:rf.xray/target-frame`). Re-runs when the trace
+      buffer ticks (the registration / cache surface may have changed) or the
+      observed frame switches.
+    - `:rf.xray/derivation-graph-tab-data` — the view-facing composite:
+      summarizes node value fields for ON-BOX display, groups by family,
+      classifies by superkind, and carries the summary header data. The
+      single read the Panel subscribes.
+
+  Read-only: assembling the graph reads the registrar + the observed frame's
+  runtime-db decoupled; it dispatches nothing and pins nothing."
+  []
+  ;; ---- mode toggle ------------------------------------------------------
+  (rf/reg-event-db :rf.xray/set-derivation-graph-mode
+    (fn [db [_ mode]]
+      (assoc db :derivation-graph-mode (if (#{:static :live} mode) mode :static))))
+
+  (rf/reg-sub :rf.xray/derivation-graph-mode
+    (fn [db _] (get db :derivation-graph-mode :static)))
+
+  ;; ---- test override ----------------------------------------------------
+  (rf/reg-event-db :rf.xray/set-derivation-graph-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov) (dissoc db :derivation-graph-override)
+          (assoc db :derivation-graph-override ov))))
+  (rf/reg-sub :rf.xray/derivation-graph-override
+    (fn [db _] (get db :derivation-graph-override)))
+
+  ;; ---- assembled graph --------------------------------------------------
+  (rf/reg-sub :rf.xray/derivation-graph
+    :<- [:rf.xray/trace-buffer]
+    :<- [:rf.xray/derivation-graph-mode]
+    :<- [:rf.xray/target-frame]
+    :<- [:rf.xray/derivation-graph-override]
+    (fn [[_buffer mode target-frame override] _]
+      (cond
+        (some? override) override
+        (= :live mode)   (dgraph/live-derivation-graph target-frame xray-contributors)
+        :else            (dgraph/derivation-graph xray-contributors))))
+
+  ;; ---- view-facing composite -------------------------------------------
+  (rf/reg-sub :rf.xray/derivation-graph-tab-data
+    :<- [:rf.xray/derivation-graph]
+    (fn [graph _]
+      (let [summarized (h/summarize-graph graph)]
+        {:mode      (:mode graph)
+         :silent?   (h/empty-graph? graph)
+         :summary   (h/graph-summary graph)
+         :by-family (h/group-by-family summarized)
+         :edges     (:edges graph)})))
+
+  ;; Register the Dynamic Derivation-Graph tab with the internal L4 tab
+  ;; registry. Order 8 — after Resources (order 7), keeping the cross-feature
+  ;; runtime-graph tabs adjacent. Label is the domain noun "Graph".
+  (panel-registry/reg-l4-tab!
+    {:id    :derivation-graph
+     :label "Graph"
+     :mnem  "g"
+     :modes #{:dynamic}
+     :order 8
+     :panel Panel})
+
+  nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc
@@ -1,0 +1,374 @@
+(ns day8.re-frame2-xray.panels.derivation-graph-helpers
+  "Pure-data projection algebra for the Derivation-Graph panel (EP-0014
+  prop-3, rf2-9ett2d) + the OFF-BOX EGRESS REDACTION call site (rf2-yjarv6).
+
+  ## What this panel renders
+
+  The composer `re-frame.derivation.graph` (EP-0014 slice-7) assembles the
+  five algebra-view siblings (subs / flows / resources / routes / machines)
+  into ONE `{:mode :nodes :edges}` `DerivationGraph` view — the unified
+  derivation/process graph the EP names. Xray is the NAMED FIRST CONSUMER
+  ([Derivations.md] §Graph inspection; [EP-0014 §Reference Implementation /
+  Bead Plan] item 7). This panel is that consumption made real: a single
+  graph view that answers \"where does this fact come from, when is it
+  evaluated, where does it live, and who owns it?\" across all families at
+  once — even though the underlying runtime mechanisms are subscription
+  cache, flow registry, route slice, resource cache, and machine snapshots.
+
+  These helpers are the pure-data projection layer (the view-side hiccup
+  lives in `derivation_graph.cljs`): they classify each node by the TWO
+  closed superkinds, group nodes by family, summarize value-bearing fields
+  for on-box display, and — the rider task — project the graph through the
+  frame's egress policy when a tool ships it OFF-BOX.
+
+  ## The two superkinds are the contract (EP-0014 §Algebra Declaration Shape)
+
+  `:kind` is one of exactly two closed superkinds — `:derivation` or
+  `:process` (the graduated, closed `DerivationKind` enum). A tool MUST be
+  able to classify EVERY node by reading `:kind` alone. The refined kinds
+  (`:resource-process`, `:route-fact`, `:machine-process`,
+  `:machine-selector`) ride the separate `:refinement` axis and are COLOUR,
+  NOT CONTRACT — this panel colours by `:refinement` for legibility but
+  groups + classifies by `:kind`. A node carrying an unknown future
+  refinement still classifies correctly off its superkind.
+
+  ## ON-BOX rendering is RAW (Security.md permits on-box)
+
+  The panel renders in the developer's own browser, in the `:rf/xray`
+  frame, against the developer's own app. On-box inspection sees raw values
+  — that is the in-process truth (the TAIL-2 correctness ruling on
+  rf2-6y7wnb: raw-on-box is correct-as-designed for read-only projections;
+  the composer composes nodes verbatim by design and does NO redaction).
+  So `summarize-graph` produces bounded, render-safe PREVIEWS purely for
+  display ergonomics (a 4MB value would wreck the panel), NOT for privacy —
+  it is a size/shape projection, not an egress boundary.
+
+  ## OFF-BOX egress is REDACTED, per-frame, FAIL-CLOSED (rf2-yjarv6)
+
+  `redact-graph-for-egress` is the EGRESS REDACTION CALL SITE the EP-0014
+  tail-2 redaction ruling says is BORN HERE — the wire boundary where a
+  tool ships the graph OFF the developer's box (an MCP surface streaming the
+  graph to a remote agent, a serialized capture written to disk / posted to
+  a service). Per [Derivations.md] §Redaction metadata and the EP-0014
+  issue-1 disposition, the graph SHOULD be useful WITHOUT exposing sensitive
+  raw values: each node's value-bearing summary fields are projected through
+  the single shared `rf/elide-wire-value` walker
+  ([009 §Privacy], [015-Data-Classification], [Managed-Effects §5]) under
+  the FRAME's own elision policy (`re-frame.elision`, per-frame, fail-closed
+  when frameless). Redaction MUST NOT lose graph STRUCTURE — a redacted
+  param is still an edge; the node is still present + classified. The
+  composer itself stays RAW-ON-BOX by design; this projection is the
+  consuming tool's egress obligation, not the composer's.
+
+  JVM-portable (`.cljc`) so the projection + redaction contracts are pinned
+  by the JVM test corpus without a CLJS runtime."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; Superkind classification (the contract axis).
+;; ---------------------------------------------------------------------------
+
+(defn superkind
+  "The node's CLOSED superkind — `:derivation` | `:process` — read off
+  `:kind` alone (EP-0014 §Algebra Declaration Shape: a tool MUST classify
+  every node knowing only the two superkinds). Returns `:unknown` for a
+  malformed node missing `:kind` so the panel degrades to an inert row
+  rather than throwing."
+  [node]
+  (case (:kind node)
+    :derivation :derivation
+    :process    :process
+    :unknown))
+
+(defn process?    [node] (= :process    (superkind node)))
+(defn derivation? [node] (= :derivation (superkind node)))
+
+;; ---------------------------------------------------------------------------
+;; Family grouping (the EDITORIAL axis — colour, not contract).
+;;
+;; The node id is family-tagged by the composer (`node-id`): `[:sub …]`,
+;; `[:flow …]`, `[:resource …]`, `[:machine …]`, or the route fact id
+;; `:rf/route` / `[:rf/route <route-id>]`. We read the tag to bucket nodes
+;; into the five families for the grouped render — falling back to the
+;; verbatim `:rf/family` tag the composer stamps on every node when the id
+;; tag is ambiguous.
+;; ---------------------------------------------------------------------------
+
+(def families
+  "Editorial render order — the canonical reading order of
+  [Derivations.md] (subscriptions → flows → resources → routes →
+  machines), mirroring `re-frame.derivation.graph/families`."
+  [:subs :flows :resources :routes :machines])
+
+(defn node-family
+  "Bucket one node into a render family. Prefers the composer-stamped
+  `:rf/family` tag (authoritative — set on every node in
+  `family-static-nodes` / `family-live-nodes`); falls back to inferring
+  from the node id tag for a hand-built fixture node that omits it."
+  [node-id node]
+  (or (:rf/family node)
+      (cond
+        (and (vector? node-id) (= :sub      (first node-id))) :subs
+        (and (vector? node-id) (= :flow     (first node-id))) :flows
+        (and (vector? node-id) (= :resource (first node-id))) :resources
+        (and (vector? node-id) (= :machine  (first node-id))) :machines
+        (= :rf/route node-id)                                 :routes
+        (and (vector? node-id) (= :rf/route  (first node-id))) :routes
+        :else :subs)))
+
+(defn group-by-family
+  "Partition the graph's `:nodes` map into `{family [[node-id node] …]}`,
+  each family's entries sorted by a stable string key so the render order
+  is deterministic across re-renders. Families with no nodes are absent
+  from the result."
+  [{:keys [nodes]}]
+  (->> nodes
+       (group-by (fn [[node-id node]] (node-family node-id node)))
+       (reduce-kv
+        (fn [acc family entries]
+          (assoc acc family
+                 (vec (sort-by (fn [[node-id _]] (pr-str node-id)) entries))))
+        {})))
+
+;; ---------------------------------------------------------------------------
+;; Edge classification.
+;; ---------------------------------------------------------------------------
+
+(def edge-roles
+  "The edge roles the composer emits (Derivations §Graph inspection):
+  `:input` (a `[:sub q]` declared input), `:param` (a route-owned resource
+  activation), `:selector` (a machine → its selector subscription). Drives
+  the per-role legend + edge colour."
+  [:input :param :selector])
+
+(defn edges-by-role
+  "Group the graph's `:edges` vector by `:role` → `[edge …]`. Roles absent
+  from the graph are absent from the result."
+  [{:keys [edges]}]
+  (group-by :role edges))
+
+(defn node-degree
+  "Count `{:in n :out n}` undirected degree per node id across the edge
+  set, for the summary header (\"42 nodes · 17 edges\" + the most-connected
+  node). A node id absent from any edge has zero degree."
+  [{:keys [nodes edges]}]
+  (reduce
+   (fn [acc {:keys [from to]}]
+     (-> acc
+         (update-in [from :out] (fnil inc 0))
+         (update-in [to :in] (fnil inc 0))))
+   (zipmap (keys nodes) (repeat {:in 0 :out 0}))
+   edges))
+
+;; ---------------------------------------------------------------------------
+;; ON-BOX value summarization (size/shape projection — NOT an egress boundary).
+;;
+;; A render-safe preview of any value: type tag, bounded size, short printed
+;; preview. This protects the PANEL from a 4MB value, not the user's privacy
+;; — the on-box panel is entitled to the raw value (Security.md permits
+;; on-box; the redacted `:rf/redacted` sentinel a frame-policy walk produced
+;; off-box is itself just a keyword and previews cleanly through here).
+;; ---------------------------------------------------------------------------
+
+(def ^:private preview-limit 80)
+
+(defn- value-type [v]
+  (cond
+    (map? v)        :map
+    (vector? v)     :vector
+    (set? v)        :set
+    (sequential? v) :seq
+    (string? v)     :string
+    (keyword? v)    :keyword
+    (nil? v)        :nil
+    :else           :scalar))
+
+(defn summarize
+  "A bounded, render-safe summary of `v` for ON-BOX display: `{:type :size
+  :preview :redacted?}`. `:size` is the element count for collections, nil
+  otherwise. `:preview` is the printed value truncated to `preview-limit`.
+  `:redacted?` flags the `:rf/redacted` sentinel (so a value that arrived
+  already redacted — e.g. a value the egress walk redacted, then fed back —
+  renders muted). Pure size/shape projection: it does NOT consult any
+  elision policy (that is `redact-graph-for-egress`'s job)."
+  [v]
+  (let [redacted? (= :rf/redacted v)
+        printed   (pr-str v)
+        truncated (if (> (count printed) preview-limit)
+                    (str (subs printed 0 preview-limit) "…")
+                    printed)]
+    (cond-> {:type      (value-type v)
+             :preview   truncated
+             :redacted? redacted?}
+      (coll? v) (assoc :size (count v)))))
+
+;; The value-bearing summary fields a LIVE node may carry — the value
+;; summaries [Derivations.md] §Redaction metadata names as egress-bearing
+;; once shipped off-box: a sub-cache entry's `:value`, a route slice's
+;; `:params` / `:query`, a machine instance's `:state` summary, a resource
+;; entry's `:work-ledger` summary. (Each is the in-process value summary the
+;; sibling lives surface; the composer carries them verbatim.) Node IDs,
+;; edges, and the storage/evaluation/lifecycle classifications are STRUCTURE
+;; and are never touched.
+(def value-bearing-node-keys
+  [:value :params :query :state])
+
+(defn summarize-node
+  "Attach an ON-BOX `:summaries {<k> <summary>}` map to a node for any
+  value-bearing key it carries — the bounded previews the panel renders.
+  Leaves the node otherwise untouched (its `:kind` / `:refinement` /
+  `:inputs` / `:output` / classifications ride through verbatim)."
+  [node]
+  (let [present (filter #(contains? node %) value-bearing-node-keys)]
+    (if (seq present)
+      (assoc node :summaries
+             (into {} (map (fn [k] [k (summarize (get node k))])) present))
+      node)))
+
+(defn summarize-graph
+  "Map `summarize-node` over the graph's `:nodes`, returning the graph with
+  each node carrying its ON-BOX `:summaries`. The on-box display projection
+  — raw-permitting, size-bounding. NOT the egress boundary."
+  [graph]
+  (update graph :nodes update-vals summarize-node))
+
+;; ===========================================================================
+;; OFF-BOX EGRESS REDACTION (rf2-yjarv6) — the call site the EP-0014 tail-2
+;; redaction ruling says is BORN HERE.
+;; ===========================================================================
+
+(defn redact-graph-for-egress
+  "Project a `DerivationGraph` through the FRAME's egress policy for the
+  wire boundary where a tool ships the graph OFF-BOX (rf2-yjarv6;
+  [Derivations.md] §Redaction metadata; EP-0014 issue-1 disposition).
+
+  This is the egress redaction CALL SITE the tail-2 ruling locates in the
+  consuming tool — NOT in the registrar-derived composer (which composes
+  nodes verbatim, raw-on-box by design). Each node's value-bearing summary
+  field (`:value` / `:params` / `:query` / `:state` —
+  `value-bearing-node-keys`) is walked through the single shared
+  `rf/elide-wire-value` walker under the named `frame-id`'s own elision
+  policy:
+
+  - **per-frame** — the policy is the FRAME's declared `:sensitive` /
+    `:large` `:app-db` classifications (`re-frame.elision`, sourced from
+    `reg-frame`), passed explicitly as the `:frame` opt so the walk applies
+    THAT frame's policy regardless of any ambient scope;
+  - **fail-closed** — `rf/elide-wire-value` redacts the whole value to the
+    `:rf/redacted` sentinel when no frame is reachable (frameless egress
+    under no `:rf.size/include-sensitive?` opt-out); a sensitive-declared
+    value is replaced by the sentinel; a large-declared value by the
+    `:rf.size/large-elided` marker.
+
+  STRUCTURE IS PRESERVED (the headline guarantee): the node KEYS (the
+  canonical family-tagged node ids) and the `:edges` vector ride through
+  UNTOUCHED — a redacted param is still an `:input` / `:param` edge, the
+  node is still present and still classified by its `:kind` superkind. Only
+  the value-bearing leaf fields inside node bodies are redacted. The
+  storage / evaluation / lifecycle classifications, `:source-form`,
+  `:refinement`, `:inputs` topology, and `:output` address are structure,
+  not values, and are never walked.
+
+  `frame-id` is the frame whose elision policy governs egress (the observed
+  app's frame — typically the graph's `:frame` for a live graph). `opts`
+  (optional) ride through to `rf/elide-wire-value` (e.g.
+  `:rf.size/threshold-bytes`); the `:frame` opt is set from `frame-id` and
+  overrides any caller-supplied one (egress redacts under the OBSERVED
+  frame's policy, never a borrowed one).
+
+  FAIL-CLOSED on an UNREACHABLE frame: `rf/elide-wire-value` treats a
+  carried `:frame` opt as a KNOWN frame even when that id names no live
+  frame — applying an empty (identity) policy, which would ship the value
+  RAW under no policy. Egress must not do that. So this projection first
+  checks the named frame is LIVE (`rf/frame-ids`); when it is not (nil id,
+  a destroyed / never-registered frame), it walks WITHOUT a `:frame` opt so
+  `rf/elide-wire-value` takes its own frameless fail-closed branch and
+  redacts the whole value to `:rf/redacted` rather than borrow another
+  frame's marks. This is the silent-leak this contract abolishes — a graph
+  egressing under no reachable policy redacts, never ships raw.
+
+  Returns the graph with redacted node value fields; `:mode` / `:frame` /
+  `:nodes` keys / `:edges` unchanged. Idempotent over `:rf/redacted`
+  (re-walking an already-redacted value is a no-op — the sentinel is a
+  non-matchable scalar)."
+  ([graph frame-id] (redact-graph-for-egress graph frame-id nil))
+  ([graph frame-id opts]
+   ;; A reachable (live) frame governs egress under its own policy; an
+   ;; unreachable / nil frame walks frameless so the walker fails closed.
+   (let [reachable? (and (some? frame-id) (contains? (rf/frame-ids) frame-id))
+         walk-opts  (if reachable? (assoc opts :frame frame-id) opts)
+         redact-node
+         (fn [node]
+           (reduce
+            (fn [n k]
+              (if (contains? n k)
+                (assoc n k (rf/elide-wire-value (get n k) walk-opts))
+                n))
+            node
+            value-bearing-node-keys))]
+     (update graph :nodes update-vals redact-node))))
+
+;; ---------------------------------------------------------------------------
+;; Header summary (counts + family/role tallies for the panel header).
+;; ---------------------------------------------------------------------------
+
+(defn graph-summary
+  "A compact header summary of the graph: total node / edge counts, the
+  per-superkind tally (`{:derivation n :process n}`), the per-family node
+  tally, and the per-role edge tally. Pure data; the view renders it as the
+  panel's count strip."
+  [{:keys [mode nodes edges] :as graph}]
+  {:mode          mode
+   :node-count    (count nodes)
+   :edge-count    (count edges)
+   :by-superkind  (frequencies (map (fn [[_ node]] (superkind node)) nodes))
+   :by-family     (update-vals (group-by-family graph) count)
+   :by-role       (update-vals (edges-by-role graph) count)})
+
+(defn empty-graph?
+  "True when the graph has no nodes — the panel renders its silent state
+  (host registered nothing in any family, or a production build DCE'd the
+  live projections)."
+  [{:keys [nodes]}]
+  (empty? nodes))
+
+(defn redacted?
+  "True when `v` is the `:rf/redacted` sensitive-egress sentinel
+  (`re-frame.privacy/redacted-sentinel`) — the shape a sensitive-declared
+  value (or a frameless fail-closed walk) produced at egress."
+  [v]
+  (= :rf/redacted v))
+
+(defn large-elided?
+  "True when `v` is the `:rf.size/large-elided` size-elision marker
+  (`re-frame.elision/marker?`) — the shape a large-declared value produced
+  at egress: structure-preserving (path / bytes / type / handle), value
+  withheld."
+  [v]
+  (and (map? v) (contains? v :rf.size/large-elided)))
+
+;; ---------------------------------------------------------------------------
+;; Display labels.
+;; ---------------------------------------------------------------------------
+
+(defn node-label
+  "A short human label for a node id — the family tag stripped to its
+  fact identity for the row heading. `[:sub :cart/total]` → `:cart/total`;
+  `[:resource <scoped-key>]` → the printed scoped key; `:rf/route` → the
+  route fact id."
+  [node-id]
+  (cond
+    (and (vector? node-id) (= 2 (count node-id))) (pr-str (second node-id))
+    :else                                         (pr-str node-id)))
+
+(defn family-label
+  "Human label for a render family."
+  [family]
+  (case family
+    :subs      "Subscriptions"
+    :flows     "Flows"
+    :resources "Resources"
+    :routes    "Routes"
+    :machines  "Machines"
+    (str/capitalize (name family))))

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -84,6 +84,7 @@
             [day8.re-frame2-xray.panels.managed-fx-subs :as managed-fx-subs]
             [day8.re-frame2-xray.panels.routing :as routing]
             [day8.re-frame2-xray.panels.resources :as resources]
+            [day8.re-frame2-xray.panels.derivation-graph :as derivation-graph]
             [day8.re-frame2-xray.panels.reactive-panel :as reactive-panel]
             [day8.re-frame2-xray.panels.trace :as trace]))
 
@@ -957,6 +958,18 @@
     ;; resources artefact (Xray does not :require it; bundle isolation).
     ;; Read-only: no `:rf.resource/*` dispatch (observing pins nothing).
     (resources/install!)
+    ;; Derivation-Graph tab (EP-0014 prop-3, rf2-9ett2d) — Dynamic L3 tab:
+    ;; the UNIFIED derivation/process graph composed by
+    ;; `re-frame.derivation.graph` across the five algebra-view families.
+    ;; Xray is the EP's NAMED FIRST CONSUMER of the structured graph
+    ;; accessor. Installs the static/live mode toggle, the assembled-graph
+    ;; sub (composing the subs/flows/routes tooling siblings Xray :requires),
+    ;; and the `:rf.xray/derivation-graph-tab-data` composite. Reads the
+    ;; registrar (static) + the observed target frame's runtime-db (live)
+    ;; decoupled. ON-BOX raw (Security.md permits on-box); off-box egress
+    ;; redaction is `derivation-graph-helpers/redact-graph-for-egress`.
+    ;; Read-only: assembling the graph pins nothing, dispatches nothing.
+    (derivation-graph/install!)
     ;; Static Routes panel (rf2-o5f5f.3) — Static-surface browse +
     ;; Simulate-URL + per-row inline expand + hermetic Simulate-
     ;; navigation preview. Installs the UI-state slots under

--- a/tools/xray/test/day8/re_frame2_xray/focus_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/focus_cljs_test.cljs
@@ -134,10 +134,12 @@
   (is (= [[:rf.xray/focus-slice-path [:user :profile :name]]]
          (focus/focus-command->dispatches {:path [:user :profile :name]}))))
 
-(deftest valid-panels-is-the-six-tab-inventory
+(deftest valid-panels-is-the-tab-inventory
   ;; rf2-gbz39 — the Issues tab was removed (Mike RULED Option (c));
   ;; `:issues` is no longer a focusable panel.
-  (is (= #{:epoch :app-db :views :trace :machines :routes}
+  ;; rf2-9ett2d (EP-0014 prop-3) — `:derivation-graph` is the unified
+  ;; derivation/process graph tab.
+  (is (= #{:epoch :app-db :views :trace :machines :routes :derivation-graph}
          focus/valid-panels)))
 
 ;; =========================================================================

--- a/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_helpers_cljs_test.cljc
@@ -1,0 +1,218 @@
+(ns day8.re-frame2-xray.panels.derivation-graph-helpers-cljs-test
+  "Pure-data tests for the Derivation-Graph panel helpers (EP-0014 prop-3,
+  rf2-9ett2d).
+
+  Dual-target naming (`.cljc` + `_cljs_test`):
+    - Cognitect's test-runner (CLJ) picks it up via the default `.*-test$`
+      regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$` regex.
+
+  ## What's under test (no runtime — pure data over fixture graphs)
+
+    1. **superkind classification** — every node classified by `:kind`
+       ALONE into the two closed superkinds; a refined kind in `:kind`
+       would be a violation (the contract axis); a node carrying only a
+       refinement is still classified off its superkind; a malformed node
+       degrades to `:unknown`.
+    2. **family grouping** — nodes bucketed by the composer-stamped
+       `:rf/family` tag (authoritative) with id-tag fallback; deterministic
+       sort.
+    3. **edges** — role grouping, node degree, the empty-edge case.
+    4. **ON-BOX summarize** — bounded preview, size, the raw-permitting
+       posture (a non-sensitive value is summarized verbatim, NOT redacted);
+       the `:rf/redacted` sentinel flags `:redacted?`.
+    5. **summarize-graph / summarize-node** — value-bearing fields summarized
+       for display; node STRUCTURE (kind / inputs / output / classifications)
+       rides through untouched.
+    6. **graph-summary** — counts + superkind / family / role tallies.
+
+  The OFF-BOX egress redaction (rf2-yjarv6) needs a live frame elision
+  policy, so it lives in the runtime test
+  `derivation_graph_redaction_cljs_test.cljc`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-xray.panels.derivation-graph-helpers :as h]))
+
+;; ---------------------------------------------------------------------------
+;; A representative cross-family graph fixture — one node of each family,
+;; each carrying its composer `:rf/family` tag + the closed-superkind `:kind`
+;; + the refined `:refinement` (colour axis) the siblings emit.
+;; ---------------------------------------------------------------------------
+
+(def ^:private sub-node
+  {:id :cart/total :kind :derivation :rf/family :subs
+   :inputs [[:sub [:cart/items]]] :output [:fact :cart/total]
+   :storage :ephemeral :evaluation :on-demand :lifecycle :subscription-cache-entry})
+
+(def ^:private flow-node
+  {:id :cart/materialized-total :kind :derivation :rf/family :flows
+   :inputs [[:db [:cart :items]]] :output [:db [:cart :total]]
+   :storage :app-db :evaluation :after-event :lifecycle :frame})
+
+(def ^:private resource-node
+  {:id :article/by-slug :kind :process :refinement :resource-process :rf/family :resources
+   :inputs :parametric :output [:runtime [:rf.runtime/resources :entries]]
+   :storage :runtime-db :authority {:kind :remote :system :server}
+   :evaluation #{:on-route :on-reply} :lifecycle :resource-key})
+
+(def ^:private route-node
+  {:id :rf/route :kind :process :refinement :route-fact :rf/family :routes
+   :output [:runtime [:rf.runtime/routing :current]]
+   :storage :runtime-db :evaluation :on-route :lifecycle :frame})
+
+(def ^:private machine-node
+  {:id :upload/main :kind :process :refinement :machine-process :rf/family :machines
+   :output [:runtime [:rf.runtime/machines :snapshots :upload/main]]
+   :storage :runtime-db :evaluation #{:on-transition} :lifecycle :machine-instance})
+
+(def ^:private selector-node
+  {:id :upload/progress :kind :derivation :refinement :machine-selector :rf/family :subs
+   :inputs [[:machine :upload/main [:data :progress]]] :output [:fact :upload/progress]
+   :storage :ephemeral :evaluation :on-demand :lifecycle :subscription-cache-entry})
+
+(def ^:private fixture-graph
+  {:mode :static
+   :nodes {[:sub :cart/total]               sub-node
+           [:flow :cart/materialized-total] flow-node
+           [:resource :article/by-slug]     resource-node
+           [:rf/route :route/article]       route-node
+           [:machine :upload/main]          machine-node
+           [:sub :upload/progress]          selector-node}
+   :edges [{:from [:sub :cart/items] :to [:sub :cart/total] :role :input}
+           {:from [:rf/route :route/article] :to [:resource :article/by-slug] :role :param}
+           {:from [:machine :upload/main] :to [:sub :upload/progress] :role :selector}]})
+
+;; ---------------------------------------------------------------------------
+;; 1. superkind classification — the CONTRACT axis (classify by :kind alone).
+;; ---------------------------------------------------------------------------
+
+(deftest superkind-classifies-by-kind-alone
+  (testing "every node reduces to one of the two closed superkinds via :kind"
+    (is (= :derivation (h/superkind sub-node)))
+    (is (= :derivation (h/superkind flow-node)))
+    (is (= :process    (h/superkind resource-node)))
+    (is (= :process    (h/superkind route-node)))
+    (is (= :process    (h/superkind machine-node)))
+    (is (= :derivation (h/superkind selector-node))))
+  (testing "classification reads :kind, NOT :refinement — a node carrying only
+            a refinement still classifies off its superkind"
+    (is (h/process? {:kind :process :refinement :some-future-refinement}))
+    (is (h/derivation? {:kind :derivation :refinement :another-future-kind})))
+  (testing "a malformed node missing :kind degrades to :unknown (no throw)"
+    (is (= :unknown (h/superkind {:id :broken})))
+    (is (not (h/process? {:id :broken})))
+    (is (not (h/derivation? {:id :broken})))))
+
+;; ---------------------------------------------------------------------------
+;; 2. family grouping.
+;; ---------------------------------------------------------------------------
+
+(deftest group-by-family-uses-stamped-tag
+  (let [grouped (h/group-by-family fixture-graph)]
+    (testing "nodes bucket by their composer :rf/family tag"
+      (is (= 2 (count (:subs grouped))))      ; cart/total + the selector
+      (is (= 1 (count (:flows grouped))))
+      (is (= 1 (count (:resources grouped))))
+      (is (= 1 (count (:routes grouped))))
+      (is (= 1 (count (:machines grouped)))))
+    (testing "entries are sorted deterministically by node id"
+      (is (= (h/group-by-family fixture-graph)
+             (h/group-by-family fixture-graph))))))
+
+(deftest node-family-falls-back-to-id-tag
+  (testing "a node without an :rf/family tag infers from the id tag"
+    (is (= :subs      (h/node-family [:sub :x] {:kind :derivation})))
+    (is (= :flows     (h/node-family [:flow :x] {:kind :derivation})))
+    (is (= :resources (h/node-family [:resource :x] {:kind :process})))
+    (is (= :machines  (h/node-family [:machine :x] {:kind :process})))
+    (is (= :routes    (h/node-family :rf/route {:kind :process})))
+    (is (= :routes    (h/node-family [:rf/route :route/x] {:kind :process})))))
+
+;; ---------------------------------------------------------------------------
+;; 3. edges.
+;; ---------------------------------------------------------------------------
+
+(deftest edges-by-role-groups-the-three-roles
+  (let [by-role (h/edges-by-role fixture-graph)]
+    (is (= 1 (count (:input by-role))))
+    (is (= 1 (count (:param by-role))))
+    (is (= 1 (count (:selector by-role))))))
+
+(deftest node-degree-counts-in-and-out
+  (let [deg (h/node-degree fixture-graph)]
+    (is (= {:in 0 :out 1} (get deg [:rf/route :route/article])))
+    (is (= {:in 1 :out 0} (get deg [:resource :article/by-slug])))
+    (is (= {:in 1 :out 0} (get deg [:sub :upload/progress])))
+    (testing "a node absent from any edge has zero degree"
+      (is (= {:in 0 :out 0} (get deg [:flow :cart/materialized-total]))))))
+
+(deftest empty-edges-is-handled
+  (let [g {:mode :static :nodes {[:sub :a] {:kind :derivation}} :edges []}]
+    (is (= {} (h/edges-by-role g)))
+    (is (= {:in 0 :out 0} (get (h/node-degree g) [:sub :a])))))
+
+;; ---------------------------------------------------------------------------
+;; 4. ON-BOX summarize — raw-permitting (NOT an egress boundary).
+;; ---------------------------------------------------------------------------
+
+(deftest summarize-is-raw-permitting
+  (testing "a non-sensitive value is summarized VERBATIM, not redacted —
+            on-box display is entitled to the raw value (Security.md)"
+    (let [s (h/summarize {:slug "welcome" :secret "shhh"})]
+      (is (= :map (:type s)))
+      (is (= 2 (:size s)))
+      (is (false? (:redacted? s)))
+      (is (re-find #"welcome" (:preview s)))))
+  (testing "a long value's preview is bounded for display ergonomics"
+    (let [s (h/summarize (apply str (repeat 500 "x")))]
+      (is (= :string (:type s)))
+      (is (<= (count (:preview s)) 81))
+      (is (re-find #"…$" (:preview s)))))
+  (testing "the :rf/redacted sentinel (a value that arrived already redacted)
+            flags :redacted? so the row renders muted"
+    (let [s (h/summarize :rf/redacted)]
+      (is (true? (:redacted? s))))))
+
+(deftest summarize-node-attaches-summaries-leaves-structure
+  (let [node {:id [:sub [:article/page "welcome"]] :kind :derivation
+              :inputs [[:sub [:article/by-slug "welcome"]]]
+              :output [:fact [:article/page "welcome"]]
+              :storage :ephemeral :evaluation :on-demand
+              :value {:slug "welcome"}}
+        summarized (h/summarize-node node)]
+    (testing "the value-bearing :value field gains an on-box summary"
+      (is (= :map (get-in summarized [:summaries :value :type]))))
+    (testing "structure rides through verbatim — kind / inputs / output /
+              classifications untouched"
+      (is (= :derivation (:kind summarized)))
+      (is (= [[:sub [:article/by-slug "welcome"]]] (:inputs summarized)))
+      (is (= [:fact [:article/page "welcome"]] (:output summarized)))
+      (is (= :ephemeral (:storage summarized)))))
+  (testing "a node with no value-bearing field is returned unchanged"
+    (is (= sub-node (h/summarize-node sub-node)))))
+
+;; ---------------------------------------------------------------------------
+;; 5. graph-summary.
+;; ---------------------------------------------------------------------------
+
+(deftest graph-summary-tallies
+  (let [s (h/graph-summary fixture-graph)]
+    (is (= :static (:mode s)))
+    (is (= 6 (:node-count s)))
+    (is (= 3 (:edge-count s)))
+    (is (= {:derivation 3 :process 3} (:by-superkind s)))
+    (is (= 2 (get-in s [:by-family :subs])))
+    (is (= {:input 1 :param 1 :selector 1} (:by-role s)))))
+
+(deftest empty-graph-detection
+  (is (h/empty-graph? {:mode :static :nodes {} :edges []}))
+  (is (not (h/empty-graph? fixture-graph))))
+
+;; ---------------------------------------------------------------------------
+;; labels.
+;; ---------------------------------------------------------------------------
+
+(deftest node-label-strips-family-tag
+  (is (= ":cart/total" (h/node-label [:sub :cart/total])))
+  (is (= ":rf/route"   (h/node-label :rf/route)))
+  (is (= "Subscriptions" (h/family-label :subs)))
+  (is (= "Machines"      (h/family-label :machines))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_redaction_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/derivation_graph_redaction_cljs_test.cljc
@@ -1,0 +1,247 @@
+(ns day8.re-frame2-xray.panels.derivation-graph-redaction-cljs-test
+  "The POSITIVE off-box egress redaction test for the Derivation-Graph panel
+  (rf2-yjarv6 — the EP-0014 testing-coverage gap the audit rf2-4j6w6v flagged
+  as the missing arm).
+
+  ## The gap this closes
+
+  spec/Derivations.md §Conformance 'Tool redaction' + §Redaction metadata
+  require: graph inspection can summarize or redact sensitive params,
+  scopes, and values WITHOUT losing graph STRUCTURE — a redacted param is
+  still an edge — composing through the single shared `rf/elide-wire-value`
+  walker. Before this test the only related assertion was a weak NEGATIVE
+  ('the snapshot :value is NOT inlined'). There was NO positive test that
+  (a) a sensitive value is run through `rf/elide-wire-value` AND (b) the
+  corresponding edge / node STRUCTURE survives.
+
+  ## Where the redaction lives (the tail-2 ruling)
+
+  Per the EP-0014 tail-2 correctness ruling (rf2-6y7wnb): raw params/values
+  on the live algebra views are NOT a defect — they are correct-as-designed
+  raw-on-box projections. Redaction is an EGRESS concern owned by the FRAME
+  elision policy via the shared `rf/elide-wire-value` walker (per-frame,
+  fail-closed), applied at the wire boundary where a consuming tool ships
+  the graph OFF-BOX — NOT at the registrar-derived composer. The named first
+  consumer Xray is where that egress call site is BORN
+  (`derivation-graph-helpers/redact-graph-for-egress`), so the
+  redact-without-losing-structure test belongs HERE alongside the consumer
+  wiring (rf2-9ett2d).
+
+  ## What's asserted
+
+    1. **POSITIVE redact-value-keep-edge** — a node carries a sensitive
+       value at a frame-declared sensitive path; egress projection runs it
+       through the frame's `rf/elide-wire-value`; the value is replaced by
+       `:rf/redacted` WHILE the node remains present + classified AND the
+       edge that names it survives intact (structure preserved).
+    2. **per-frame** — egress redacts under the OBSERVED frame's policy,
+       not an ambient or borrowed one; a non-sensitive value rides through.
+    3. **fail-closed** — egress for an unknown / frameless target redacts
+       the whole value rather than ship it raw under no policy.
+    4. **large elision** — a frame-declared `:large` value is replaced by
+       the `:rf.size/large-elided` marker, again keeping structure."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame-classification :as frame-class]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.panels.derivation-graph-helpers :as h]))
+
+;; ---------------------------------------------------------------------------
+;; Runtime fixture — reset the registry / frame state, install the plain-atom
+;; substrate (a non-React JVM-and-node substrate), then register two frames
+;; with declared elision policy:
+;;
+;;   :app/secure   — declares the path [:current :params :token] sensitive
+;;                   (a route :params slug carrying a session token) and
+;;                   [:cart :items] large.
+;;   :app/plain    — no classification (every value egresses verbatim, modulo
+;;                   the runtime size threshold which we leave at default).
+;; ---------------------------------------------------------------------------
+
+(def secure-frame :app/secure)
+(def plain-frame  :app/plain)
+
+(defn- install-policy! []
+  ;; Frame-owned classification, the EP-0015 §8 successor to the removed
+  ;; schema→elision route — install :sensitive / :large :app-db declarations
+  ;; directly through the frame-classification path (same seam reg-frame uses).
+  (frame-class/install!
+    secure-frame
+    (frame-class/validate+extract
+      secure-frame
+      {:sensitive {:app-db [[:current :params :token]]}
+       :large     {:app-db [[:cart :items]]}})))
+
+(defn- init-fn []
+  (rf/reg-frame plain-frame {})
+  (rf/reg-frame secure-frame {})
+  (install-policy!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     ;; OPT OUT of the default `:rf/default` ambient scope: the fail-closed
+     ;; arm asserts that egress against an unreachable frame redacts because
+     ;; NO frame is resolvable. A bound ambient `:rf/default` would let the
+     ;; frameless walk resolve to it (empty-policy identity) and ship raw —
+     ;; masking the fail-closed contract. Our frames carry no `:on-create`
+     ;; work, so a clear ambient scope is safe.
+     :ambient-frame nil
+     :init-fn init-fn}))
+
+;; ---------------------------------------------------------------------------
+;; A live-shaped derivation graph fixture: a route-fact node whose live
+;; `:params` carry a SENSITIVE token at the frame-declared sensitive path,
+;; plus the edge that names it. This mirrors the live route-slice node shape
+;; (`re-frame.routing.tooling/route-slice-algebra-view` surfaces raw
+;; `:params` / `:query` value summaries — the exact case the gap names).
+;; ---------------------------------------------------------------------------
+
+(def ^:private route-fact-node
+  {:id :rf/route :kind :process :refinement :route-fact :rf/family :routes
+   :route-id :route/article
+   :params {:current {:params {:token "secret-session-jwt-abc123"
+                               :slug "welcome"}}}
+   :query {:ref "home"}
+   :output [:runtime [:rf.runtime/routing :current]]
+   :storage :runtime-db :evaluation :on-route :lifecycle :frame
+   :nav-token 17})
+
+(def ^:private resource-node
+  ;; the resource the route activates — the :param edge target; its node body
+  ;; carries no value-bearing summary field, only structure.
+  {:id :article/by-slug :kind :process :refinement :resource-process :rf/family :resources
+   :inputs :parametric :output [:runtime [:rf.runtime/resources :entries]]
+   :storage :runtime-db :authority {:kind :remote :system :server}
+   :evaluation #{:on-route} :lifecycle :resource-key})
+
+(def ^:private cart-sub-node
+  ;; a sub-cache node whose live :value is at the frame-declared LARGE path.
+  {:id [:cart/items] :kind :derivation :rf/family :subs
+   :inputs [[:sub [:cart/raw]]] :output [:fact [:cart/items]]
+   :storage :ephemeral :evaluation :on-demand :lifecycle :subscription-cache-entry
+   :value {:cart {:items (vec (range 200))}}})
+
+(def ^:private live-graph
+  {:mode :live
+   :frame secure-frame
+   :nodes {[:rf/route :route/article]    route-fact-node
+           [:resource :article/by-slug]  resource-node
+           [:sub [:cart/items]]          cart-sub-node}
+   :edges [{:from [:rf/route :route/article] :to [:resource :article/by-slug] :role :param}
+           {:from [:sub [:cart/raw]] :to [:sub [:cart/items]] :role :input}]})
+
+;; ---------------------------------------------------------------------------
+;; 1. THE POSITIVE TEST — redact value, keep edge (the missing arm).
+;; ---------------------------------------------------------------------------
+
+(deftest redact-sensitive-value-keeps-edge-and-node-structure
+  (let [redacted (h/redact-graph-for-egress live-graph secure-frame)
+        route    (get-in redacted [:nodes [:rf/route :route/article]])]
+
+    (testing "(a) the sensitive value was RUN THROUGH rf/elide-wire-value and
+              ELIDED — the token at the frame-declared sensitive path is
+              replaced by the :rf/redacted sentinel"
+      (is (= :rf/redacted
+             (get-in route [:params :current :params :token]))
+          "the sensitive token must be redacted at egress"))
+
+    (testing "(b) the node STRUCTURE survives — the node is still present and
+              still classified by its superkind + refinement; the sibling
+              non-sensitive value in the same map rides through raw"
+      (is (some? route) "the route node is still present")
+      (is (= :process (h/superkind route)) "still classified by :kind alone")
+      (is (= :route-fact (:refinement route)))
+      (is (= "welcome" (get-in route [:params :current :params :slug]))
+          "the NON-sensitive sibling slug is NOT redacted")
+      (is (= {:ref "home"} (:query route))
+          "the non-sensitive :query summary rides through"))
+
+    (testing "(c) the EDGE that names the redacted node survives intact — a
+              redacted param is STILL a :param edge (structure preserved)"
+      (is (= (:edges live-graph) (:edges redacted))
+          "the entire edge vector is untouched by egress redaction")
+      (is (some #(and (= :param (:role %))
+                      (= [:rf/route :route/article] (:from %))
+                      (= [:resource :article/by-slug] (:to %)))
+                (:edges redacted))
+          "the route→resource :param edge is still present"))
+
+    (testing "(d) the node KEYS (canonical family-tagged ids) are unchanged —
+              the graph topology a tool draws edges between is preserved"
+      (is (= (set (keys (:nodes live-graph)))
+             (set (keys (:nodes redacted)))))
+      (is (some? (get-in redacted [:nodes [:resource :article/by-slug]]))
+          "the edge's target node is still present + classified")
+      (is (= :process (h/superkind (get-in redacted [:nodes [:resource :article/by-slug]])))))
+
+    (testing "(e) the storage / evaluation / lifecycle classifications + the
+              :output address + :inputs topology are STRUCTURE, never walked"
+      (is (= :runtime-db (:storage route)))
+      (is (= :on-route (:evaluation route)))
+      (is (= :frame (:lifecycle route)))
+      (is (= [:runtime [:rf.runtime/routing :current]] (:output route)))
+      (is (= 17 (:nav-token route))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. large elision — a frame-declared :large value → marker, keeping structure.
+;; ---------------------------------------------------------------------------
+
+(deftest large-value-elided-to-marker-keeps-structure
+  (let [redacted (h/redact-graph-for-egress live-graph secure-frame)
+        sub      (get-in redacted [:nodes [:sub [:cart/items]]])
+        ;; the large path [:cart :items] sits NESTED inside the node's
+        ;; :value summary {:cart {:items <large>}}; the walker descends to it
+        ;; and replaces THAT leaf with the marker, leaving the surrounding
+        ;; map shape intact (structure preserved).
+        marker   (get-in sub [:value :cart :items])]
+    (testing "the large-declared value is replaced by the :rf.size/large-elided
+              marker, not shipped in full"
+      (is (h/large-elided? marker)
+          "the large value egresses as a size-elision marker")
+      (is (= [:cart :items] (get-in marker [:rf.size/large-elided :path]))
+          "the marker preserves the path (structure), withholds the value"))
+    (testing "the node + its :input edge survive"
+      (is (= :derivation (h/superkind sub)))
+      (is (= [[:sub [:cart/raw]]] (:inputs sub)) "inputs topology untouched")
+      (is (some #(and (= :input (:role %)) (= [:sub [:cart/items]] (:to %)))
+                (:edges redacted))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. per-frame — a frame with NO classification ships the same value raw.
+;; ---------------------------------------------------------------------------
+
+(deftest egress-applies-the-named-frames-policy-not-a-borrowed-one
+  (testing "redacting under the SECURE frame's policy elides the token"
+    (let [r (h/redact-graph-for-egress live-graph secure-frame)]
+      (is (= :rf/redacted
+             (get-in r [:nodes [:rf/route :route/article] :params :current :params :token])))))
+  (testing "redacting under the PLAIN frame's policy (no sensitive decl)
+            ships the same token VERBATIM — the policy is per-frame, applied
+            from the named frame, not a borrowed or ambient one"
+    (let [r (h/redact-graph-for-egress live-graph plain-frame)]
+      (is (= "secret-session-jwt-abc123"
+             (get-in r [:nodes [:rf/route :route/article] :params :current :params :token]))
+          "no sensitive decl on :app/plain ⇒ the value rides through raw"))))
+
+;; ---------------------------------------------------------------------------
+;; 4. fail-closed — an unknown/frameless target redacts the WHOLE value
+;;    rather than ship it under no policy (the silent-leak this contract
+;;    abolishes).
+;; ---------------------------------------------------------------------------
+
+(deftest frameless-egress-fails-closed
+  (testing "egress against an UNKNOWN frame (no reachable elision policy)
+            fails closed — the whole value-bearing field is redacted to the
+            :rf/redacted sentinel rather than shipped raw"
+    (let [r     (h/redact-graph-for-egress live-graph :app/does-not-exist)
+          route (get-in r [:nodes [:rf/route :route/article]])]
+      (is (= :rf/redacted (:params route))
+          "no reachable policy ⇒ the whole :params summary is redacted")
+      (is (= :rf/redacted (:query route)))
+      (testing "structure STILL survives even in the fail-closed case"
+        (is (some? route))
+        (is (= :process (h/superkind route)))
+        (is (= (:edges live-graph) (:edges r)))
+        (is (= (set (keys (:nodes live-graph))) (set (keys (:nodes r)))))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
@@ -166,8 +166,8 @@
     (let [panels (palette-subs/palette-panels)
           ids    (set (map :id panels))]
       (is (contains? ids :resources) ":resources in palette-panels")
-      (is (= 7 (count panels))
-          "7 Dynamic tabs — Epoch / App DB / Views / Trace / Machines / Routing / Resources"))))
+      (is (= 8 (count panels))
+          "8 Dynamic tabs — Epoch / App DB / Views / Trace / Machines / Routing / Resources / Graph (rf2-9ett2d added the EP-0014 derivation-graph tab)"))))
 
 ;; ---- (3) sections render ------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
@@ -175,8 +175,8 @@
     (let [panels (palette-subs/palette-panels)
           ids    (set (map :id panels))]
       (is (contains? ids :routing) ":routing in palette-panels")
-      (is (= 7 (count panels))
-          "exactly 7 entries — Epoch / App DB / Views / Trace / Machines / Routing / Resources (the Resources tab — Spec 016 §Xray and AI tooling — earns its own L4 tab per Mike's cohesive-sub-domain ruling; rf2-gbz39 removed the Issues tab per Mike's Option (c) ruling — issues surface inline + event-row pink-wash + the always-on issues ribbon signal. rf2-5gl5r retired the Event/Handler tab; the Epoch panel supersedes it. rf2-sc3r1 originally added Epoch at order 5; rf2-4v67l removed the Chrome A11y dogfood in favour of Story's shipped panel; rf2-ga16q removed the Machines Canvas tab — its browse-all canvas relocated to the Static Machines sub-tab.)"))))
+      (is (= 8 (count panels))
+          "exactly 8 entries — Epoch / App DB / Views / Trace / Machines / Routing / Resources / Graph (the Resources tab — Spec 016 §Xray and AI tooling — earns its own L4 tab per Mike's cohesive-sub-domain ruling; rf2-9ett2d added the EP-0014 derivation-graph 'Graph' tab — the unified derivation/process graph across all algebra-view families; rf2-gbz39 removed the Issues tab per Mike's Option (c) ruling — issues surface inline + event-row pink-wash + the always-on issues ribbon signal. rf2-5gl5r retired the Event/Handler tab; the Epoch panel supersedes it. rf2-sc3r1 originally added Epoch at order 5; rf2-4v67l removed the Chrome A11y dogfood in favour of Story's shipped panel; rf2-ga16q removed the Machines Canvas tab — its browse-all canvas relocated to the Static Machines sub-tab.)"))))
 
 ;; ---- (2) three sections render (always-visible base layer) --------------
 

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -284,6 +284,13 @@
    :rf.xray/resource-routing-slice
    :rf.xray/resource-routing-slice-override
    :rf.xray/resources-tab-data
+   ;; rf2-9ett2d (EP-0014 prop-3) — Derivation-Graph tab subs: the
+   ;; assembled `re-frame.derivation.graph` view (static/live), the mode
+   ;; toggle slot, the test override, and the view-facing composite.
+   :rf.xray/derivation-graph
+   :rf.xray/derivation-graph-mode
+   :rf.xray/derivation-graph-override
+   :rf.xray/derivation-graph-tab-data
    ;; rf2-o5f5f.3 — Routes browse + Simulate-URL state lives under
    ;; the Static Routes panel (promoted from `:rf.xray.routing/*` per
    ;; the two-verbs-two-homes split). The Dynamic Routing lens narrows
@@ -665,6 +672,10 @@
    :rf.xray/set-resource-sub-reads-override-for-test
    ;; rf2-m5u3gt — live route/resource graph routing-slice override.
    :rf.xray/set-resource-routing-slice-override-for-test
+   ;; rf2-9ett2d (EP-0014 prop-3) — Derivation-Graph tab events: the
+   ;; static/live mode toggle + the test-only graph override.
+   :rf.xray/set-derivation-graph-mode
+   :rf.xray/set-derivation-graph-override-for-test
    ;; rf2-o5f5f.3 — Static Routes UI-state events (search input,
    ;; Simulate-URL input, expand-row toggle, hermetic Simulate-nav
    ;; toggle, cross-link to Dynamic Routing). Promoted from the


### PR DESCRIPTION
## What

Wires Xray to consume `re-frame.derivation.graph` — the unified `{:mode :nodes :edges}` `DerivationGraph` the composer assembles across the five algebra-view families (subs / flows / resources / routes / machines). Xray is the **EP-0014 named first consumer** of the structured graph accessor (prop-3, rf2-9ett2d); this is the disposition-1 proof that the shape survives real use. Rider rf2-yjarv6 lands the off-box egress redaction call site + the positive "redact value, keep edge" test the EP-0014 testing-coverage audit flagged as the missing arm.

## The panel — `tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs`

A new Dynamic L4 tab ("Graph", mnem `g`, order 8) that renders the one derivation/process graph:

- **Static vs live** — header toggle. Static = `derivation-graph` (registration-derived, process-global; parametric subs show the `:parametric` marker and contribute no edge — the don't-execute rule). Live = `live-derivation-graph` for the observed `:rf.xray/target-frame` (concrete query vectors, realized edges, active resource entries, live machine instances, the materialized route slice).
- **Two superkinds are the contract** — every node grouped + classified by its closed superkind (`:derivation` ○ / `:process` ◆) read off `:kind` **alone**; the refined kinds (`:resource-process`, `:route-fact`, `:machine-process`, `:machine-selector`) are the colour axis, never the contract. An unknown future refinement still classifies off its superkind; a malformed node degrades to an inert `:unknown` row.
- **Per-family node sections** + the `:input` / `:param` / `:selector` edge records, with a count/tally header.
- **Contributor seam** — `xray-contributors` supplies the three tooling siblings Xray statically `:require`s (subs via core, flows, routes). Machines + resources runtime artefacts are **not** Xray deps (the same decoupling the Resources panel + Machine Inspector honour); the composer's present-family-only contract renders them as soon as those siblings join the map.

## The redaction call site (rf2-yjarv6) — `derivation_graph_helpers.cljc`

`redact-graph-for-egress` is the off-box egress boundary the EP-0014 tail-2 ruling says is **born here**. Each node's value-bearing summary field (`:value` / `:params` / `:query` / `:state`) is projected through the single shared `rf/elide-wire-value` walker under the **named frame's** elision policy — **per-frame**, **fail-closed** (an unreachable frame walks frameless so the walker redacts the whole value rather than ship it raw under no policy). Node ids + the `:edges` vector + the storage/evaluation/lifecycle classifications + `:inputs` topology + `:output` address are **structure** and ride through untouched — **a redacted param is still an edge**. On-box rendering stays raw (Security.md permits on-box; `summarize` bounds previews for display ergonomics, not privacy). The composer itself stays raw-on-box by design — redaction is the consuming tool's egress obligation.

## The test (rf2-yjarv6) — `derivation_graph_redaction_cljs_test.cljc`

The **positive** "redact value, keep edge" arm: a sensitive node value at a frame-declared sensitive path is run through `rf/elide-wire-value` and elided to `:rf/redacted` **while** (a) the node remains present + classified by superkind and (b) the edge naming it survives intact. Plus large-elision → marker keeping structure, per-frame policy (a non-classifying frame ships the same value raw), and frameless fail-closed. Pure-data helper contracts (superkind classification, family grouping, on-box raw-permitting summarize, structure preservation) live in `derivation_graph_helpers_cljs_test.cljc`.

## Spec

Per the standing rule, `tools/xray/spec/025-Derivation-Graph-Panel.md` is added (the Xray-side consumer contract: sections, registry surface, contributor seam, on-box-raw / off-box-redacted posture) + indexed in `tools/xray/spec/README.md` — in this PR.

## Quality gates

- `clojure -M:test` (xray JVM) — **PASS** (1145 tests, 5052 assertions, 0 failures)
- `npm run test:cljs` — **PASS** (6787 tests, 27460 assertions, 0 failures)
- `npm run test:xray-feature-gate` — **PASS** (16 scenarios, 0 failures, 13 matrix rows)
- `npm run test:bundle-isolation` — **PASS** (22 artefact entries, 40 internal sentinels absent; counter/uix/helix bundles clean — Xray dev-only, the composer + tooling siblings never reach production)
- `mkdocs build --strict` — **PASS** (exit 0)
- New tests also green on JVM (`clojure -M:test`): 11 helper + 4 redaction.

### CI fix (post-review)

The xray JVM gate (`JVM tools/xray (clojure -M:test)`) flagged the new panel's mode toggle: it wired a bare global `rf/dispatch` to an `:on-click`, which the frame-singleton-guard (rf2-1w07r, `no-global-dispatch-in-on-handler-in-migrated-files`) rejects — after render unwinds the ambient frame is gone, so a bare global dispatch leaks to `:rf/default`. Fixed by threading the **reg-view-injected frame-bound `dispatch`** from the `Panel` body through `summary-header` into `mode-toggle`, so the deferred toggle lands on the surrounding `:rf/xray` instance frame. The `.cljc` redaction helpers are unaffected and stay JVM-loadable. All four gates re-run green (counts above).

Closes rf2-9ett2d, rf2-yjarv6.
