### PR TITLE
fix(core): EP-0013 dispose-realm teardown + install atomicity + spec-drift (rf2-kq0yfb + 9swh84 + 4tamp7)

### DIFF
--- a/implementation/core/src/re_frame/app_value.cljc
+++ b/implementation/core/src/re_frame/app_value.cljc
@@ -641,10 +641,34 @@
   default-realm seating path is byte-identical. A realm with no registry entry
   (unknown id) falls back to the global atom rather than throwing — installing
   into an unconstructed id seats into the default table (the absence-is-default
-  rule). INTERNAL."
+  rule).
+
+  ATOMIC (EP-0013 §Installation step 4 — \"attach the app and registrar
+  atomically\"): the seating loop is all-or-nothing. The thunk seats a
+  MULTI-descriptor app one descriptor at a time, and a malformed descriptor can
+  throw PART-WAY (after kinds 1..N-1 already landed). To keep the realm's
+  registrar and its `:app` slot from ever disagreeing, the registrar atom's
+  value is captured BEFORE the loop and RESTORED on any throw, then the throw
+  re-propagates — so a failed `install!` leaves the realm exactly as it was
+  (no half-populated registrar; `install!` records no partial `:app`, since
+  `set-installed-app!` runs only after the thunk returns cleanly). The
+  default-realm path snapshots the process-global atom the same way; a
+  successful seating restores nothing (the loop's writes stand). INTERNAL."
   [rid thunk]
-  (binding [registrar/*registrar* (realm/registrar (realm/realm rid))]
-    (thunk)))
+  (let [reg (realm/registrar (realm/realm rid))]
+    (binding [registrar/*registrar* reg]
+      (if reg
+        (let [snapshot @reg]
+          (try
+            (thunk)
+            (catch #?(:clj Throwable :cljs :default) e
+              ;; Roll back every registration the partial loop landed, so a
+              ;; mid-stream failure leaves the realm's registrar untouched.
+              (reset! reg snapshot)
+              (throw e))))
+        ;; No registrar atom resolved (an unknown id with no default fallback) —
+        ;; nothing to snapshot; run the thunk as-is.
+        (thunk)))))
 
 (defn install!
   "Seat an immutable app VALUE into a realm — make `app`'s registrations the

--- a/implementation/core/src/re_frame/realm.cljc
+++ b/implementation/core/src/re_frame/realm.cljc
@@ -328,24 +328,10 @@
                       (contains? opts :app)          (assoc :app          (:app opts)))]
       (register-realm! realm-map))))
 
-(defn dispose-realm!
-  "Drop a constructed realm from the process `realms` registry, releasing its
-  own registrar (and adapter/host-transient inventory) for GC. nil / the
-  default realm id is a NO-OP — the default realm is never disposed (it backs
-  the byte-identical single-realm path). Returns nil. The teardown counterpart
-  of `construct-realm` for hermetic-test cleanup and multi-tenant realm
-  lifecycle. PUBLIC (`rf/dispose-realm!`).
-
-  Per EP-0013 §Realm Conformance the deeper teardown (disposing adapter/root
-  resources + walking the host-transient subsystem inventory) rides the
-  realm-owned `dispose-realm-adapter!` / `clear-host-transient!` seams; this
-  releases the realm's registry entry so its program + own registrar are no
-  longer reachable."
-  [realm-or-id]
-  (let [rid (realm-id realm-or-id)]
-    (when-not (= rid default-realm-id)
-      (swap! realms dissoc rid)))
-  nil)
+;; `dispose-realm!` (the teardown counterpart of `construct-realm`) lives at the
+;; END of this ns: it walks the realm-owned adapter + host-transient teardown
+;; seams (`dispose-realm-adapter!` / `host-transient` / `clear-host-transient!`),
+;; which are defined further down, so it is placed after them (rf2-kq0yfb).
 
 ;; ---- realm-targeted registrar queries (EP-0013 D1 stage 8, rf2-blibek) ----
 ;;
@@ -661,3 +647,72 @@
   ([realm-or-id]
    (update-realm! (realm-id realm-or-id) dissoc :host-transient)
    nil))
+
+;; ---- realm disposal — the teardown counterpart of construct-realm ----------
+;;
+;; Placed at the END of the ns because it walks the realm-owned adapter +
+;; host-transient teardown seams defined above (`realm-adapter` /
+;; `dispose-realm-adapter!` / `host-transient` / `clear-host-transient!`).
+;; Disposing a realm MUST release the operational resources the realm owns —
+;; a bare `(swap! realms dissoc rid)` would ORPHAN the seated adapter + every
+;; host-transient subsystem the realm inventoried (rf2-kq0yfb).
+
+(defn- dispose-realm-host-transient!
+  "Walk realm `rid`'s host-transient subsystem inventory and run each
+  descriptor's `:teardown` token, then drop the inventory. The `:teardown` is
+  the realm-dispose cleanup hook the descriptor declares (Spec-Schemas
+  §`:rf/host-transient-descriptor`); it is invoked with `rid` so a
+  realm-scoped subsystem tears down THIS realm's entries. A descriptor that
+  declares no `:teardown` (the inventory is a queryable record only — its
+  side-table bytes are reset through the late-bind reset hooks) is skipped,
+  and a non-callable `:teardown` token is ignored. INTERNAL — the
+  host-transient arm of `dispose-realm!`."
+  [rid]
+  (doseq [[_ descriptor] (host-transient rid)]
+    (when-let [td (:teardown descriptor)]
+      (when (fn? td)
+        (td rid))))
+  (clear-host-transient! rid))
+
+(defn dispose-realm!
+  "Dispose a constructed realm: tear down its adapter + host-transient
+  subsystem state, then drop it from the process `realms` registry (releasing
+  its own registrar for GC). nil / the default realm id is a NO-OP — the
+  default realm is never disposed (it backs the byte-identical single-realm
+  path). Returns nil. The teardown counterpart of `construct-realm` for
+  hermetic-test cleanup and multi-tenant realm lifecycle. PUBLIC
+  (`rf/dispose-realm!`).
+
+  Per EP-0013 §Realm Conformance disposing a realm MUST release the operational
+  resources the realm owns, not merely drop the registry entry (a bare `dissoc`
+  would ORPHAN the seated adapter + the host-transient subsystems). The teardown
+  walks the realm-owned seams, in order:
+
+    1. ADAPTER — run the seated adapter's own `:dispose-adapter!` fn (read
+       directly off the realm's `:adapter` slot, so this leaf ns needs no
+       `substrate.adapter` require), then clear the slot + set the disposed
+       breadcrumb via `dispose-realm-adapter!`. Mirrors
+       `substrate.adapter/dispose-adapter!` for the default realm.
+    2. HOST-TRANSIENT — walk the realm's host-transient inventory, running each
+       descriptor's `:teardown` token (the realm-dispose cleanup hook), then
+       drop the inventory via `clear-host-transient!`.
+    3. REGISTRY — `dissoc` the realm so its program + own registrar are no
+       longer reachable.
+
+  The teardown runs only for a CONSTRUCTED realm; for the default realm (and
+  nil) the whole call is a no-op — the default realm's adapter/host-transient
+  lifecycle is owned by `substrate.adapter` + the per-subsystem reset hooks, and
+  the realm itself is never disposed."
+  [realm-or-id]
+  (let [rid (realm-id realm-or-id)]
+    (when-not (= rid default-realm-id)
+      ;; (1) adapter: run the seated adapter's own teardown, then clear the slot.
+      (when-let [adapter (realm-adapter rid)]
+        (when-let [f (:dispose-adapter! adapter)]
+          (f))
+        (dispose-realm-adapter! rid))
+      ;; (2) host-transient: walk the inventory's teardown tokens, then drop it.
+      (dispose-realm-host-transient! rid)
+      ;; (3) registry: drop the realm so its registrar + program are unreachable.
+      (swap! realms dissoc rid)))
+  nil)

--- a/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
@@ -139,6 +139,65 @@
       (is (nil? (registrar/lookup :event :cart/add))
           "no descriptor was seated — the failure was atomic (pre-mutation)"))))
 
+(deftest install-seating-loop-is-atomic-mid-stream-throw-rolls-back
+  (testing "install!'s seating loop is ALL-OR-NOTHING — when a descriptor throws
+            PART-WAY through (after kinds 1..N-1 already seated), the realm's
+            registrar is rolled back to its pre-install state AND no partial
+            :app is recorded; the realm's registrar + :app slot never disagree
+            (rf2-9swh84, EP-0013 §Installation step 4 'attach atomically')"
+    ;; A hermetic constructed realm so its OWN registrar is cleanly inspectable
+    ;; (empty before install; rollback must return it to empty).
+    (let [r (rf/realm {:id :atomic/r})]
+      (try
+        (is (= {} @(realm/registrar r))
+            "the hermetic realm's registrar starts empty")
+        (is (nil? (:app (realm/realm :atomic/r)))
+            "no :app stored before install")
+        ;; A 3-descriptor app — the seating loop seats them one at a time. We
+        ;; force a throw on the SECOND register! so the first descriptor has
+        ;; ALREADY landed in the realm's registrar when the loop blows up — the
+        ;; exact partial-install edge: registrar half-populated, :app not yet set.
+        (let [a (rf/app {:id :atomic/app :modules
+                         [(rf/module {:id :m
+                                      :events {:atomic/e1 {:handler cart-add}
+                                               :atomic/e2 {:handler cart-add}
+                                               :atomic/e3 {:handler cart-add}}})]})
+              calls (atom 0)
+              real-register! registrar/register!
+              ;; Redef the ACTUAL lowering target so we hit the real
+              ;; install! → seat-into-realm! → register-descriptor! → register!
+              ;; path (not a routed-around stub): seat the first descriptor for
+              ;; real, then throw mid-loop.
+              ed (with-redefs [registrar/register!
+                               (fn [kind id metadata]
+                                 (if (= 2 (swap! calls inc))
+                                   (throw (ex-info "boom: malformed descriptor mid-loop"
+                                                   {:error/id :atomic.test/boom :kind kind :id id}))
+                                   (real-register! kind id metadata)))]
+                   (try (rf/install! r a)
+                        (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
+                          (ex-data e))))]
+          (is (= :atomic.test/boom (:error/id ed))
+              "the mid-loop throw propagated out of install! (not swallowed)")
+          (is (>= @calls 2)
+              "the loop got at least two descriptors deep before the throw")
+          ;; ROLLBACK: the realm's registrar is back to its pre-install state —
+          ;; the first descriptor that DID land was rolled back, none leaked.
+          (is (= {} @(realm/registrar r))
+              "the realm's registrar is rolled back to empty — no half-populated table")
+          (is (nil? (get-in @(realm/registrar r) [:event :atomic/e1]))
+              "the descriptor that landed before the throw did not leak")
+          ;; ATOMIC :app: set-installed-app! runs only after a clean seating, so
+          ;; the failed install recorded no :app — the registrar + :app agree.
+          (is (nil? (:app (realm/realm :atomic/r)))
+              "no partial :app was recorded — set-installed-app! never ran")
+          ;; installed-app falls back to the recomputable projection when no
+          ;; :app is stored; after the rollback that projection is the EMPTY
+          ;; program (the rolled-back registrar), confirming no leak.
+          (is (= {} (:registrations (realm/installed-app r)))
+              "the realm's installed-app projects an empty program after rollback"))
+        (finally (rf/dispose-realm! :atomic/r))))))
+
 (deftest install-succeeds-when-the-realm-satisfies-requires
   (testing "install! succeeds once the realm provides the required capability"
     (with-default-realm-capabilities! {:rf.capability/http {:request! identity}})

--- a/implementation/core/test/re_frame/realm_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/realm_conformance_cljs_test.cljc
@@ -143,6 +143,74 @@
       (is (contains? (:capabilities r) :rf.capability/http)
           "the capability map rides the realm"))))
 
+(deftest dispose-realm-walks-adapter-and-host-transient-teardown
+  (testing "dispose-realm! TEARS DOWN the realm's operational resources — it
+            runs the seated adapter's own :dispose-adapter! fn + clears the
+            adapter slot, walks the host-transient inventory running each
+            descriptor's :teardown token + drops the inventory, THEN drops the
+            registry entry. A bare dissoc would orphan both (rf2-kq0yfb)."
+    (let [adapter-disposed?   (atom false)
+          torn-down-subsystems (atom #{})
+          ;; An adapter SELECTION carrying its own teardown fn, exactly the
+          ;; shape substrate.adapter/dispose-adapter! runs for the default realm.
+          adapter {:kind            :rf.adapter/conformance-teardown
+                   :dispose-adapter! (fn [] (reset! adapter-disposed? true))}
+          r       (rf/realm {:id :conf/teardown :adapter adapter})]
+      ;; Seat a host-transient inventory of two subsystems, each with a
+      ;; :teardown token the realm-dispose walk must run (one :frame-scoped,
+      ;; one :realm-scoped) — Spec-Schemas §:rf/host-transient-descriptor.
+      (realm/register-host-transient! :conf/teardown
+        {:id            :rf.test/in-flight
+         :storage-class :host-transient :scope :frame :durability :none
+         :teardown      (fn [_rid] (swap! torn-down-subsystems conj :rf.test/in-flight))})
+      (realm/register-host-transient! :conf/teardown
+        {:id            :rf.test/timers
+         :storage-class :host-transient :scope :realm :durability :none
+         :teardown      (fn [_rid] (swap! torn-down-subsystems conj :rf.test/timers))})
+      ;; Pre-conditions: the realm owns a seated adapter + a 2-entry inventory.
+      (is (= adapter (realm/realm-adapter :conf/teardown))
+          "the adapter selection is seated on the realm before dispose")
+      (is (= #{:rf.test/in-flight :rf.test/timers}
+             (set (keys (realm/host-transient :conf/teardown))))
+          "the host-transient inventory carries both subsystems before dispose")
+      ;; Dispose: the teardown seams fire.
+      (rf/dispose-realm! :conf/teardown)
+      (is (true? @adapter-disposed?)
+          "dispose-realm! ran the seated adapter's own :dispose-adapter! fn")
+      (is (= #{:rf.test/in-flight :rf.test/timers} @torn-down-subsystems)
+          "dispose-realm! ran every host-transient descriptor's :teardown token")
+      ;; Post-conditions: nothing orphaned — the realm is gone from the registry,
+      ;; so its adapter slot + host-transient inventory are unreachable.
+      (is (nil? (realm/realm :conf/teardown))
+          "the realm is dropped from the registry after teardown")
+      (is (nil? (realm/realm-adapter :conf/teardown))
+          "the adapter slot is not reachable on a disposed realm (no orphan)")
+      (is (nil? (realm/host-transient :conf/teardown))
+          "the host-transient inventory is not reachable on a disposed realm"))))
+
+(deftest dispose-realm-default-realm-teardown-is-a-no-op
+  (testing "disposing the default realm never tears down its adapter or
+            host-transient state — the default realm backs the byte-identical
+            single-realm path and is never disposed (rf2-kq0yfb)"
+    ;; The fixture seated plain-atom into the default realm; register a
+    ;; host-transient descriptor with a :teardown that would fire if the
+    ;; default-realm dispose were NOT a no-op.
+    (let [default-torn-down? (atom false)]
+      (realm/register-host-transient! realm/default-realm-id
+        {:id            :rf.test/default-guard
+         :storage-class :host-transient :scope :realm :durability :none
+         :teardown      (fn [_rid] (reset! default-torn-down? true))})
+      (rf/dispose-realm! realm/default-realm-id)
+      (rf/dispose-realm! nil)
+      (is (false? @default-torn-down?)
+          "the default realm's host-transient teardown never ran (dispose is a no-op)")
+      (is (some? (realm/realm-adapter realm/default-realm-id))
+          "the default realm's seated adapter is untouched by a dispose call")
+      (is (some? (realm/default-realm))
+          "the default realm survives the dispose call")
+      ;; Clean up the guard descriptor so it does not leak into a sibling test.
+      (realm/clear-host-transient! realm/default-realm-id))))
+
 ;; ---------------------------------------------------------------------------
 ;; (2) ISOLATION — install! seats ONLY into the target realm's registrar
 ;; ---------------------------------------------------------------------------

--- a/spec/Runtime-Subsystems.md
+++ b/spec/Runtime-Subsystems.md
@@ -202,7 +202,7 @@ A subtree that answers fewer than five is ad-hoc runtime state, not a runtime su
 
 ## Runtime realms — the container
 
-> **EP-0013 D1, accepted 2026-06-11 (Mike, ruling [rf2-1vj3b6](https://github.com/day8/re-frame2/issues/rf2-1vj3b6); D1 = adopt, stands alone).** This section graduates the **realm-container model** from [EP-0013 §D1](../docs/EP/EP-0013-app-values-and-runtime-realms.md). It is **internal**: D1 ships **no public API surface** and no public source break — the four constructor names (`rf/app`, `rf/module`, `rf/realm`, `rf/install!`) are *reserved vocabulary*, not exposed (public exposure is D2/D3, staged later per the EP's `≥2-consumer` graduation criterion). What graduates here is the **shape and the ownership boundary**, so the rest of the corpus can name the container without inventing one per feature.
+> **EP-0013, accepted 2026-06-11 (Mike, ruling [rf2-1vj3b6](https://github.com/day8/re-frame2/issues/rf2-1vj3b6); D1 = adopt, stands alone).** This section graduates the **realm-container model** from [EP-0013 §D1](../docs/EP/EP-0013-app-values-and-runtime-realms.md). D1 shipped the **shape and the ownership boundary** as an internal record (no public source break), so the rest of the corpus could name the container without inventing one per feature. The reserved-vocabulary constructor names then graduated to **public API** through the staged D2/D3 rollout: `rf/module` / `rf/app` (stage 6), `rf/install!` / `rf/reinstall!` (stage 7), and `rf/realm` / `rf/dispose-realm!` (stage 9) all ship from `re-frame.core`. A single-realm app still never spells a realm — the default realm carries the program implicitly (the byte-identical single-realm path).
 
 The five-clause contract above organises the **durable** runtime-db partition: the `:rf.runtime/*` children of `:rf.db/runtime`, which ride frame-state serialization, restore, and SSR hydration. But a running app also holds a second framework-owned layer that is **not** durable frame-state — the registrar it dispatches against, the reactive adapter it renders through, the capability map its features depend on, and the **host-transient** side tables (HTTP abort handles, timers, nav counters, scroll caches, flow last-input caches, machine timer handles). Today these are mostly process-global. The **runtime realm** is the value that owns them.
 
@@ -238,7 +238,7 @@ A runtime realm MUST own:
 
 These resources share one lifecycle question — who owns them, and when are they disposed? — and the realm is the smallest useful answer. Putting them on each frame would duplicate behaviour across the common many-frames-one-app case; keeping them process-global blocks multi-tenant and multi-root operation. The realm sits between: many frames share one installed program; one process can host more than one program. The realm-record shape is [`:rf/realm`](Spec-Schemas.md#rfrealm-runtime-realm-ep-0013) in [Spec-Schemas](Spec-Schemas.md).
 
-The `:rf.realm/id` slot was reserved early ([rf2-n92kjm](https://github.com/day8/re-frame2/issues/rf2-n92kjm)) on the [dispatch-envelope](002-Frames.md#routing-the-dispatch-envelope) and the reply-map / continuation record shapes, so the later stamp is non-breaking. Adding the `:rf.realm/*` (and `:rf.capability/*`, §Capability maps) rows to the [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned) table is a sequential hot-zone follow-up (Conventions is owned by a separate bead in this wave; [rf2-n92kjm](https://github.com/day8/re-frame2/issues/rf2-n92kjm) reserved the record-shape *slots*, not the namespace-table rows).
+The `:rf.realm/id` slot was reserved early ([rf2-n92kjm](https://github.com/day8/re-frame2/issues/rf2-n92kjm)) on the [dispatch-envelope](002-Frames.md#routing-the-dispatch-envelope) and the reply-map / continuation record shapes, so the later stamp is non-breaking. The `:rf.realm/*` (and `:rf.capability/*`, §Capability maps) rows are reserved in the [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned) table ([rf2-n92kjm](https://github.com/day8/re-frame2/issues/rf2-n92kjm) reserved the record-shape *slots*; the namespace-table rows landed separately).
 
 ### Adapter ownership
 
@@ -277,7 +277,7 @@ A realm's **capability map** is the explicit dependency surface for runtime serv
 
 A feature (a D3 module, when manifests graduate) declares the capabilities it `:requires`; installation fails before the program becomes visible if a required capability is absent (`:rf.error/missing-capability`, with `:realm` / `:capability` / `:recovery`). Capabilities make test doubles, SSR services, tenant-specific HTTP clients, schema validators, and routing hosts explicit and injectable, rather than process-global state discovered by namespace load order.
 
-The `:rf.capability/*` capability-key namespace reservation rides the same Conventions follow-up as `:rf.realm/*` (see §What a realm owns above).
+The `:rf.capability/*` capability-key namespace is reserved in the [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned) table alongside `:rf.realm/*` (see §What a realm owns above).
 
 ### Late-bind compatibility
 
@@ -349,5 +349,5 @@ Stage 8 (D1) ships the **realm-targeted public registrar query surface**: the re
 - [EP-0006](../docs/EP/EP-0006-runtime-subsystem-contract.md) — owns the durable five-clause contract; §The host-transient grading column is the EP-0013 realm-ownership amendment, not a second contract.
 - [002 §Frames reference realms](002-Frames.md#frames-reference-realms) — a frame belongs to exactly one realm; frame ids are unique within a realm.
 - [Spec-Schemas §`:rf/realm`](Spec-Schemas.md#rfrealm-runtime-realm-ep-0013) / [§`:rf/host-transient-descriptor`](Spec-Schemas.md#rfhost-transient-descriptor-ep-0013) — the realm-record and host-transient-descriptor shapes.
-- [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned) — the framework-owned `:rf.*` reserved-namespace table (the `:rf.realm/*` + `:rf.capability/*` rows are a sequential hot-zone follow-up; the `:rf.realm/id` record-shape slot is already reserved per [rf2-n92kjm](https://github.com/day8/re-frame2/issues/rf2-n92kjm)).
+- [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned) — the framework-owned `:rf.*` reserved-namespace table (the `:rf.realm/*` + `:rf.capability/*` rows are reserved here; the `:rf.realm/id` record-shape slot was reserved earlier per [rf2-n92kjm](https://github.com/day8/re-frame2/issues/rf2-n92kjm)).
 - [Ownership](Ownership.md) — the contract-surface → owning-Spec map; consult before naming a new runtime subsystem.

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -3406,28 +3406,28 @@ Returned by `(frame-meta frame-id)`. The `:preset` field, when present, records 
 
 > **Layer:** Runtime
 > **Owner:** [Runtime-Subsystems §Runtime realms](Runtime-Subsystems.md#runtime-realms--the-container)
-> **Status:** post-v1 (EP-0013 D1 — internal record; no public constructor ships)
+> **Status:** post-v1 (EP-0013 — shipped through stage 9; the public `rf/realm` constructor + `rf/install!` / `rf/reinstall!` / `rf/dispose-realm!` + the map-shaped realm queries all ship)
 
-The runtime-realm record ([EP-0013](../docs/EP/EP-0013-app-values-and-runtime-realms.md) D1, accepted 2026-06-11). A realm owns the **non-durable operational layer** an app runs in — the registrar it dispatches against, the installed adapter selection, the capability map, the frame registry, and the host-transient subsystem state — distinct from the *durable* `:rf.runtime/*` subsystems which live inside the frames the realm owns ([`:rf/runtime-db`](#rfframe-state-the-two-partition-projection-and-rfruntime-db-the-runtime-partition)). **The realm record shape is internal — no public `rf/realm` constructor ships yet** (the name is reserved vocabulary; the constructor graduates with the stage-9 multi-adapter conformance slice, EP-0013 issue 1). What DOES ship (D1 stage 8) is the **realm-targeted public registrar query** — the map-shaped `(rf/registrations {:realm r :kind k})` / `(rf/handler-meta {:realm r :kind k :id id})` forms that read only the specified realm's registrar (issue 11), the realm being addressed by id keyword or by the realm map. The process creates one **default realm** (`:rf.realm/id` = `:rf.realm/default`) that backs existing `reg-*` / adapter-install / registrar-query call shapes; absence of an explicit realm means the default realm, an explicit documented rule.
+The runtime-realm record ([EP-0013](../docs/EP/EP-0013-app-values-and-runtime-realms.md), accepted 2026-06-11). A realm owns the **non-durable operational layer** an app runs in — the registrar it dispatches against, the installed adapter selection, the capability map, the frame registry, and the host-transient subsystem state — distinct from the *durable* `:rf.runtime/*` subsystems which live inside the frames the realm owns ([`:rf/runtime-db`](#rfframe-state-the-two-partition-projection-and-rfruntime-db-the-runtime-partition)). As of EP-0013 **stage 9** the realm has a **public constructor** — `rf/realm` (`construct-realm`, re-exported from `re-frame.core`; the name is reserved vocabulary, ruled `rf/realm` and never `rf/runtime`, EP-0013 issue 1) — that stands up a hermetic, registered realm to `rf/install!` an app value into and target the realm-scoped queries against; `rf/dispose-realm!` is its teardown counterpart (it tears down the realm's adapter + host-transient state, then drops it from the registry — the default realm is never disposed). The **realm-targeted public registrar query** (D1 stage 8) — the map-shaped `(rf/registrations {:realm r :kind k})` / `(rf/handler-meta {:realm r :kind k :id id})` forms that read only the specified realm's registrar (issue 11), the realm being addressed by id keyword or by the realm map — ships alongside. The process creates one **default realm** (`:rf.realm/id` = `:rf.realm/default`) that backs existing `reg-*` / adapter-install / registrar-query call shapes; absence of an explicit realm means the default realm, an explicit documented rule (a single-realm app never spells a realm — the byte-identical single-realm path).
 
 ```clojure
 (def Realm
   ;; Open map; an implementation MAY represent it as a record for host
-  ;; efficiency, but MUST expose this data projection for tooling. None of
-  ;; these fields is a public read surface in D1 — the projection is for
-  ;; conformance and the eventual (D2/D3) tooling.
+  ;; efficiency, but MUST expose this data projection for tooling /
+  ;; conformance (the realm-scoped registrar queries + the installed-app
+  ;; read surface project over it).
   [:map
    [:rf.realm/id   :keyword]                                ;; stable, process-unique; the default realm is :rf.realm/default
    [:adapter       {:optional true} :any]                   ;; the realm's adapter SELECTION (capability) — render roots own concrete instances. CLJS reference: a keyword id (:reagent / :uix / :helix / :plain-atom) or the adapter value
-   [:capabilities  {:optional true} [:map-of :keyword :any]] ;; :rf.capability/* → service map/record (http, clock, random, schemas, routes, ssr, test doubles)
+   [:capabilities  {:optional true} [:map-of :keyword :any]] ;; :rf.capability/* → service map/record (http, clock, random, schemas, routes, ssr, test doubles). Checked by install! against the app's :requires
    [:frames        {:optional true} [:set :keyword]]        ;; frame ids registered in this realm — unique WITHIN the realm (not globally)
    [:host-transient {:optional true} [:map-of :keyword #'HostTransientDescriptor]] ;; subsystem-id → descriptor for the realm-owned non-durable side tables
-   ;; --- D2/D3, RESERVED here, never required in D1 (the container only) ---
-   [:app           {:optional true} :any]                   ;; the installed app VALUE (D2) — immutable descriptor projection
-   [:lifecycle     {:optional true} [:map [:disposed? {:optional true} :boolean]]]])
+   ;; --- the installed app value (shipped, stage 7); :lifecycle still D3-reserved ---
+   [:app           {:optional true} :any]                   ;; the installed app VALUE — the immutable descriptor program install!/reinstall! seat at the realm boundary
+   [:lifecycle     {:optional true} [:map [:disposed? {:optional true} :boolean]]]]) ;; D3-RESERVED, never required (dispose-realm! drops the registry entry rather than stamping a slot)
 ```
 
-The `:app` slot is reserved for the D2 app-value (registrations as immutable descriptors); D1 may hold today's mutable registrar behind the realm unchanged and leaves `:app` absent. The `:rf.realm/id` record-shape slot is already reserved ([rf2-n92kjm](https://github.com/day8/re-frame2/issues/rf2-n92kjm)); adding the `:rf.realm/*` + `:rf.capability/*` rows to the [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned) table is a sequential hot-zone follow-up.
+The `:app` slot holds the **installed app value** (registrations as immutable descriptors): `rf/install!` lowers an app value into the realm's registrar and records the seated value here, so `rf/reinstall!` can diff against it and `installed-app` returns it in preference to the recomputable projection. A realm booted purely through the `reg-*` sugar path leaves `:app` absent and projects its program over the registrar instead — the slot is populated only by an explicit `install!`. The `:rf.realm/id` record-shape slot was reserved early ([rf2-n92kjm](https://github.com/day8/re-frame2/issues/rf2-n92kjm)); the `:rf.realm/*` + `:rf.capability/*` namespace rows are now reserved in the [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned) table.
 
 ### `:rf/host-transient-descriptor` (EP-0013)
 


### PR DESCRIPTION
Fixes three EP-0013 (app values + runtime realms) findings surfaced by the tail-1 + testing-coverage reviews. Pre-alpha masterpiece stance: CORRECTNESS.

## rf2-kq0yfb (P2 BUG) — `dispose-realm!` orphaned adapter + host-transient state

`dispose-realm!` only did `(swap! realms dissoc rid)`, so disposing a constructed realm with a seated adapter + a host-transient inventory ORPHANED both (its own docstring admitted the deeper teardown "rides the seams" without wiring them).

Now `dispose-realm!` walks the realm-owned teardown seams, in order, for a constructed realm:
1. **Adapter** — run the seated adapter's own `:dispose-adapter!` fn (read straight off the realm's `:adapter` slot, so this leaf ns needs no `substrate.adapter` require), then `dispose-realm-adapter!` clears the slot + sets the breadcrumb (mirrors `substrate.adapter/dispose-adapter!` for the default realm).
2. **Host-transient** — walk the inventory, run each descriptor's `:teardown` token (invoked with the realm-id), then `clear-host-transient!`.
3. **Registry** — `dissoc` so the program + own registrar are unreachable.

The default realm (and nil) stays a full no-op. `dispose-realm!` + its helper moved to the end of `realm.cljc` (they reference seams defined further down). New tests: `dispose-realm-walks-adapter-and-host-transient-teardown` (asserts the adapter fn fired, every host-transient `:teardown` fired, and nothing is reachable post-dispose) and `dispose-realm-default-realm-teardown-is-a-no-op`. Tests hit the ACTUAL teardown path (per the worker-false-close lesson), not a route-around.

## rf2-9swh84 (P3) — `install!` seating loop had no rollback

`seat-into-realm!`'s `doseq` had no try/rollback: a descriptor that threw part-way (after kinds 1..N-1 seated) left the realm's registrar half-populated AND `:app` never recorded (`set-installed-app!` runs after the loop) — registrar and `:app` slot disagree.

Now the seating is all-or-nothing: `seat-into-realm!` snapshots the realm's registrar atom before the loop and `reset!`s it on any throw, then re-propagates. A failed `install!` leaves the realm exactly as it was, and `set-installed-app!` runs only after a clean seating. New adversarial test `install-seating-loop-is-atomic-mid-stream-throw-rolls-back`: installs a 3-descriptor app into a hermetic realm, forces a throw on the 2nd `register!` (the real lowering target — `install!` → `seat-into-realm!` → `register-descriptor!` → `register!`), and asserts neither the descriptor that already landed leaked nor any partial `:app` was recorded.

## rf2-4tamp7 (P2 spec-drift) — `:rf/realm` prose stale after stage-9

Prose-only reconciliation (the malli `Realm` schema structure was already correct). `spec/Spec-Schemas.md §:rf/realm` Status line + body + the schema's reserved-slot comment now reflect the shipped surface: the public `rf/realm` constructor, `rf/install!`/`rf/reinstall!`/`rf/dispose-realm!`, the populated `:app` slot, and the landed `:rf.realm/*` + `:rf.capability/*` Conventions rows. Cross-checked + de-staled the matching Runtime-Subsystems.md notes (the §What a realm owns header + lines calling the Conventions rows "pending"/"follow-up"). Verified against origin/main: `rf/realm`/`install!`/`reinstall!`/`dispose-realm!` are all in `spec/api-manifest.edn` (status "v1", facade) and re-exported from `re-frame.core`; the Conventions rows are present.

## Quality gates

- `clojure -M:test` (core): 1313 tests, 5782 assertions, 0 failures / 0 errors
- `npm run test:cljs` (node): 6775 tests, 27357 assertions, 0 failures / 0 errors
- `npm run test:bundle-isolation`: PASS (22 artefact entries, 40 sentinels absent; uix/helix/reagent-free PASS)
- `mkdocs build --strict`: built clean (exit 0)

Beads: rf2-kq0yfb, rf2-9swh84, rf2-4tamp7. Epic rf2-c6armm. `spec/Spec-Schemas.md` is hot-zone — sole toucher this round; the edit is prose-only.