### PR TITLE
fix: EP-0011 reply-target/reply-map validation + durable boundary (rf2-o7pqbm + 6kdcs9)

### DIFF
--- a/implementation/core/src/re_frame/reply.cljc
+++ b/implementation/core/src/re_frame/reply.cljc
@@ -120,6 +120,18 @@
   [target]
   (map? target))
 
+(defn- event-vector?
+  "True when `event` is a valid event-vector prefix: a NON-EMPTY vector whose
+  head (the event id) is a keyword. Managed-Effects §The reply target requires
+  `:event` to be an event-vector prefix `[:event-id arg ...]`; a bare keyword,
+  an empty vector, a non-vector, or a vector whose head is not a keyword is NOT
+  a dispatchable event prefix and must fail closed rather than travel on to
+  `complete` and become a bogus dispatch shape."
+  [event]
+  (and (vector? event)
+       (seq event)
+       (keyword? (first event))))
+
 (defn normalize-target
   "Normalize a reply target to the canonical descriptor map.
 
@@ -131,16 +143,35 @@
   Returns `{:event <vector> :delivery <kw> ...}` with `:delivery` defaulted
   to `:append`. Idempotent: normalizing an already-normalized target is the
   identity (it preserves any accumulated `::post` transform and the gate
-  fields). A nil/blank target yields nil (no continuation)."
+  fields). A nil/blank target yields nil (no continuation).
+
+  FAILS CLOSED on a malformed target (Managed-Effects §The reply target —
+  `:event` is REQUIRED and is an event-vector prefix). A descriptor missing
+  `:event`, carrying a non-vector / empty-vector / non-keyword-headed `:event`,
+  or a non-vector/non-map target throws `ex-info`
+  `:rf.reply/invalid-target` rather than letting a bogus `{}` / `{:event nil}` /
+  `{:event :x}` travel on to `complete` (which would `(vec event)` it into a
+  garbage dispatch shape). Validating here means EVERY downstream consumer
+  (`complete`, `map-target`, `durable-target`, `target->short-form`) inherits
+  the guarantee — the target is either nil or a well-formed descriptor."
   [target]
   (cond
     (nil? target) nil
 
     (vector? target)
-    {:event target :delivery :append}
+    (if (event-vector? target)
+      {:event target :delivery :append}
+      (throw (ex-info "Invalid :rf/reply-to target — an event-vector prefix must be a non-empty vector whose head is a keyword event id."
+                      {:rf.error/kind :rf.reply/invalid-target
+                       :target        target})))
 
     (descriptor? target)
     (let [{:keys [event delivery]} target]
+      (when-not (event-vector? event)
+        (throw (ex-info "Invalid :rf/reply-to target — the descriptor's :event must be an event-vector prefix [:event-id arg ...] (a non-empty vector with a keyword head)."
+                        {:rf.error/kind :rf.reply/invalid-target
+                         :target        target
+                         :event         event})))
       (cond-> target
         (nil? delivery) (assoc :delivery :append)
         true            (assoc :event event)))
@@ -232,12 +263,19 @@
   id, status classification, cancellation, stale checks, or tracing (none
   of those live on the target). This is the role `Cmd.map` plays in Elm's
   command algebra: relocating or wrapping a continuation is a pure data
-  transform."
+  transform.
+
+  A nil target stays nil (no continuation to relocate) — mapping the absence
+  of a continuation is still the absence of a continuation, NOT a bogus
+  descriptor carrying only the private `::post` accumulator and no `:event`.
+  This preserves the no-continuation semantics through a relocation: a family
+  that maps a missing target gets nil back, and `complete` on it yields nil
+  (no delivery)."
   [f target]
-  (let [d        (normalize-target target)
-        existing (get d post-key)
-        composed (if existing (comp f existing) f)]
-    (assoc d post-key composed)))
+  (when-let [d (normalize-target target)]
+    (let [existing (get d post-key)
+          composed (if existing (comp f existing) f)]
+      (assoc d post-key composed))))
 
 ;; ---------------------------------------------------------------------------
 ;; Stale-delivery authority — the framework/tool capability (Managed-Effects
@@ -283,20 +321,38 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- host-handle?
-  "Best-effort detector for a host resource that MUST NOT appear in a
-  data-only reply map: a fn (callback), or a known host object (Promise,
-  AbortController, AbortSignal, a DOM node, a JS Date / RegExp). Plain EDN
-  data — maps, vectors, sets, keywords, strings, numbers, booleans, nil,
-  symbols, instants represented as longs — passes."
+  "Detector for a host resource that MUST NOT appear in a data-only reply map
+  or a durable reply target (Managed-Effects §The reply map / §The reply
+  target: the data-only invariant). The CLOSED host-handle set is:
+
+    - a fn (a callback — every family error rides data, never a thunk);
+    - on CLJS: a `Promise`, `AbortController`, `AbortSignal`, a DOM node
+      (anything exposing a numeric `nodeType`), a `js/Date`, a `js/RegExp`;
+    - on the JVM: a `java.util.concurrent.Future`, a `java.lang.Thread`, a
+      `java.util.Date`, a `java.util.regex.Pattern`.
+
+  The `Date` / `RegExp` (and their JVM counterparts) belong to the closed set
+  because they are NON-EDN host objects: they neither round-trip through the
+  EDN reader nor compare by value, so they cannot ride durable reply data (SSR
+  / hydration / epoch snapshots / replay) safely — a durable timestamp is an
+  epoch-millisecond long under EP-0010, never a host `Date`. Plain EDN data —
+  maps, vectors, sets, keywords, strings, numbers, booleans, nil, symbols,
+  instants represented as longs — passes. (This detector and its documented
+  contract are now ALIGNED — the predicate enforces exactly the set the
+  docstring names, on both runtimes.)"
   [v]
   (or (fn? v)
-      #?(:cljs (or (instance? js/Promise v)
+      #?(:cljs (or (and (exists? js/Promise) (instance? js/Promise v))
                    (and (exists? js/AbortController) (instance? js/AbortController v))
                    (and (exists? js/AbortSignal) (instance? js/AbortSignal v))
+                   (instance? js/Date v)
+                   (instance? js/RegExp v)
                    ;; A DOM node exposes a numeric nodeType.
                    (and (object? v) (number? (.-nodeType v))))
          :clj  (or (instance? java.util.concurrent.Future v)
-                   (instance? java.lang.Thread v)))))
+                   (instance? java.lang.Thread v)
+                   (instance? java.util.Date v)
+                   (instance? java.util.regex.Pattern v)))))
 
 (defn- walk-find-host-handle
   "Walk `v` (maps / vectors / sets) and return the path to the first host
@@ -409,10 +465,16 @@
              (and (contains? reply :status) (not (contains? statuses status)))
              (conj (problem :rf.reply/invalid-status [:status] status))
 
-             ;; :ok — value present, error absent.
+             ;; :ok — value present, error ABSENT. The contract says `:error`
+             ;; is *absent* for `:ok` (Managed-Effects §Status taxonomy + the
+             ;; "omit optional fields when absent" rule), so a PRESENT `:error`
+             ;; key — including a nil placeholder — is rejected. Checking
+             ;; `contains?` (not `some?`) closes the `{:status :ok :error nil}`
+             ;; gap: a nil sentinel is still a present-but-absent-meaning slot
+             ;; the family should have omitted.
              (and (= status :ok) (not (contains? reply :value)))
              (conj (problem :rf.reply/ok-missing-value [:value] nil))
-             (and (= status :ok) (some? error))
+             (and (= status :ok) (contains? reply :error))
              (conj (problem :rf.reply/ok-has-error [:error] error))
 
              ;; :partial — both value and error present; :error is a family

--- a/implementation/core/test/re_frame/reply_test.cljc
+++ b/implementation/core/test/re_frame/reply_test.cljc
@@ -42,7 +42,17 @@
     (is (some #(= :rf.reply/ok-missing-value (:rf.reply/problem %))
               (reply/validate-reply {:status :ok})))
     (is (some #(= :rf.reply/ok-has-error (:rf.reply/problem %))
-              (reply/validate-reply {:status :ok :value 1 :error {:kind :x}})))))
+              (reply/validate-reply {:status :ok :value 1 :error {:kind :x}}))))
+  (testing "a PRESENT :error key on :ok — including a nil placeholder — is rejected (rf2-o7pqbm finding 3)"
+    ;; The contract says :error is ABSENT for :ok (omit optional fields when
+    ;; absent rather than fill a nil sentinel). A {:status :ok :error nil}
+    ;; reply previously slipped through because validation rejected only
+    ;; `(some? error)`; it now rejects a present-but-nil :error too.
+    (is (some #(= :rf.reply/ok-has-error (:rf.reply/problem %))
+              (reply/validate-reply {:status :ok :value 1 :error nil}))
+        "{:status :ok :error nil} fails — :error should be OMITTED on :ok, not nil-filled")
+    (is (reply/valid-reply? {:status :ok :value 1})
+        "the well-formed shape OMITS :error entirely")))
 
 (deftest error-conventions
   (testing ":error requires :error as a family error MAP carrying a :kind"
@@ -133,6 +143,42 @@
            :completed-at 1781078400456
            :correlation  {:request-id [:article/by-id 42]}}))))
 
+(deftest data-only-invariant-rejects-non-edn-host-objects
+  ;; rf2-o7pqbm finding 4 — the host-handle docstring named JS Date / RegExp
+  ;; (and the JVM counterparts) among the rejected host objects, but the
+  ;; predicate never checked them. The detector and its documented contract
+  ;; are now ALIGNED: a Date / RegExp (a non-EDN host object that neither
+  ;; round-trips through the EDN reader nor compares by value) is a host handle
+  ;; and fails the data-only invariant on BOTH runtimes — a durable timestamp
+  ;; is an epoch-millisecond long (EP-0010), never a host Date.
+  (testing "a host Date in the reply is a host handle (CLJS js/Date, JVM java.util.Date)"
+    (let [d #?(:cljs (js/Date.) :clj (java.util.Date.))]
+      (is (some #(= :rf.reply/host-handle (:rf.reply/problem %))
+                (reply/validate-reply {:status :ok :value {:settled-at d}}))
+          "a host Date must not ride a data-only reply — use an epoch-ms long")
+      (let [probs (reply/validate-reply {:status :ok :value {:settled-at d}})
+            path  (some #(when (= :rf.reply/host-handle (:rf.reply/problem %)) (:path %)) probs)]
+        (is (= [:value :settled-at] path) "the problem reports the exact path to the Date"))))
+  (testing "a host RegExp in the reply is a host handle (CLJS js/RegExp, JVM java.util.regex.Pattern)"
+    (let [re #?(:cljs (js/RegExp. "x") :clj (java.util.regex.Pattern/compile "x"))]
+      (is (some #(= :rf.reply/host-handle (:rf.reply/problem %))
+                (reply/validate-reply {:status :error :error {:kind :x :re re}}))
+          "a host RegExp must not ride a data-only reply")
+      (let [probs (reply/validate-reply {:status :error :error {:kind :x :re re}})
+            path  (some #(when (= :rf.reply/host-handle (:rf.reply/problem %)) (:path %)) probs)]
+        (is (= [:error :re] path) "the problem reports the exact path to the RegExp"))))
+  (testing "the durable-target guard rejects a non-EDN host object in a public field too"
+    (let [d #?(:cljs (js/Date.) :clj (java.util.Date.))]
+      (try
+        (reply/durable-target {:event [:x] :suppress {:at d}})
+        (is false "expected durable-target to reject a host Date in :suppress")
+        (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+          (is (= :rf.reply/non-data-target (:rf.error/kind (ex-data e))))
+          (is (= [:suppress :at] (:path (ex-data e))))))))
+  (testing "plain EDN — including an epoch-ms long instant — still passes"
+    (is (reply/valid-reply?
+          {:status :ok :value {:title "x"} :completed-at 1781078400456}))))
+
 ;; ---------------------------------------------------------------------------
 ;; Group 1b — target normalization.
 ;; ---------------------------------------------------------------------------
@@ -156,6 +202,67 @@
     (is (map? (reply/target->short-form {:event [:x] :suppress {:g 1}}))))
   (testing "nil target ⇒ nil (no continuation)"
     (is (nil? (reply/normalize-target nil)))))
+
+;; ---------------------------------------------------------------------------
+;; Group 1b'' — MALFORMED target rejection (rf2-o7pqbm finding 1+2). The
+;; descriptor's `:event` is REQUIRED and is an event-vector prefix
+;; (Managed-Effects §The reply target). A descriptor missing `:event`, or
+;; carrying a non-vector / empty / non-keyword-headed `:event`, must FAIL
+;; CLOSED at normalization rather than travel on to `complete` and become a
+;; bogus dispatch shape. `map-target` must preserve the nil/no-continuation
+;; semantics rather than fabricate an eventless `{::post f}` descriptor.
+;; ---------------------------------------------------------------------------
+
+(defn- invalid-target? [thunk]
+  (try (thunk) false
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+         (= :rf.reply/invalid-target (:rf.error/kind (ex-data e))))))
+
+(deftest malformed-target-fails-closed
+  (testing "a descriptor with NO :event is rejected (not silently passed to complete)"
+    (is (invalid-target? #(reply/normalize-target {}))
+        "{} carries no event — it cannot become a dispatch shape")
+    (is (invalid-target? #(reply/normalize-target {:delivery :append :suppress {:g 1}}))
+        "a descriptor with gates but no :event is still malformed"))
+  (testing "a descriptor whose :event is nil / a bare keyword / not a vector is rejected"
+    (is (invalid-target? #(reply/normalize-target {:event nil}))
+        "{:event nil} would (vec nil) into a garbage event")
+    (is (invalid-target? #(reply/normalize-target {:event :x}))
+        "{:event :x} is a bare keyword, not an event-vector prefix")
+    (is (invalid-target? #(reply/normalize-target {:event "boom"})))
+    (is (invalid-target? #(reply/normalize-target {:event {:id 1}}))))
+  (testing "an EMPTY or non-keyword-headed event vector is rejected"
+    (is (invalid-target? #(reply/normalize-target []))
+        "an empty vector has no event id to dispatch")
+    (is (invalid-target? #(reply/normalize-target {:event []})))
+    (is (invalid-target? #(reply/normalize-target [42 :arg]))
+        "the head must be a keyword event id, not a number")
+    (is (invalid-target? #(reply/normalize-target ["not-a-keyword"]))))
+  (testing "a non-vector / non-map target is rejected"
+    (is (invalid-target? #(reply/normalize-target :x)))
+    (is (invalid-target? #(reply/normalize-target 42)))
+    (is (invalid-target? #(reply/normalize-target "boom"))))
+  (testing "a WELL-FORMED target still normalizes (the guard rejects only malformed shapes)"
+    (is (= {:event [:x 1] :delivery :append} (reply/normalize-target [:x 1])))
+    (is (= {:event [:x] :delivery :append} (reply/normalize-target {:event [:x]}))))
+  (testing "the malformed-target rejection propagates through complete / target->short-form"
+    (is (invalid-target? #(reply/complete {:event :x} {:status :ok :value 1}))
+        "complete fails closed on a malformed descriptor (never (vec :x))")
+    (is (invalid-target? #(reply/target->short-form {})))))
+
+(deftest map-target-preserves-nil-no-continuation
+  (testing "mapping a nil target stays nil — NOT a bogus {::post f} eventless descriptor"
+    (is (nil? (reply/map-target identity nil)))
+    (is (nil? (reply/map-target (fn [e] [:wrap e]) nil))
+        "mapping the absence of a continuation is still the absence of a continuation")
+    (is (nil? (reply/complete (reply/map-target (fn [e] [:wrap e]) nil)
+                              {:status :ok :value 1}))
+        "and completing that mapped-nil target yields nil (no delivery)"))
+  (testing "mapping a well-formed target still relocates it (the nil guard does not weaken mapping)"
+    (let [mapped (reply/map-target (fn [e] [:parent e]) [:x {:id 1}])]
+      (is (some? mapped))
+      (is (= [:parent [:x {:id 1} {:status :ok :value 7}]]
+             (reply/complete mapped {:status :ok :value 7}))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Group 1b' — the reply-target-as-data contract (rf2-r16hfc item 1). A

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -493,6 +493,18 @@
         ;; instance falls through to the generated id (serializable by
         ;; construction).
         _          (mstate/validate-instance-id! instance where)
+        ;; rf2-6kdcs9 — the call-site `:reply-to` continuation (EP-0016 D1) is
+        ;; a TRANSPORT-PAYLOAD-only app target (NOT a durable ledger row fact),
+        ;; but it MUST still be data-only: it rides the internal reply payload
+        ;; across the transport boundary and is later dispatched. Run it through
+        ;; the shared `re-frame.reply/durable-target` HERE, at issuance — BEFORE
+        ;; any runtime-db / work-ledger write, transport lower, or trace — so a
+        ;; malformed target (missing / non-vector `:event`) or a host handle
+        ;; smuggled into a public slot FAILS LOUD now rather than silently
+        ;; mis-delivering (or stranding a non-serializable value on the wire)
+        ;; at completion. A nil target stays nil (no continuation). The
+        ;; data-only-validated target rides the `:reply-payload` below.
+        reply-to'  (when (some? reply-to) (reply/durable-target reply-to))
         generation (state/next-generation gen-snapshot)
         instance-id (mint-instance-id mutation instance generation)
         ;; the work-id reuses the resource work-id shape, but keyed by the
@@ -574,7 +586,9 @@
                                               :work/id     work-id
                                               :scope       cscope
                                               :generation  generation}
-                                       (some? reply-to) (assoc :reply-to reply-to))
+                                       ;; the data-only-validated (rf2-6kdcs9)
+                                       ;; call-site target rides the payload.
+                                       (some? reply-to') (assoc :reply-to reply-to'))
                       :work-id      work-id
                       :resource-key [:rf.mutation instance-id]
                       :scope        cscope

--- a/implementation/resources/src/re_frame/resources/work_ledger.cljc
+++ b/implementation/resources/src/re_frame/resources/work_ledger.cljc
@@ -54,8 +54,36 @@
   route loaders / spawned actors / machine async work), but who mints
   authority for each additional writer is an OPEN question deferred to the
   first non-resource writer (Spec 016 §Open questions). This slice keeps
-  it single-writer / resource-owned."
-  (:require [re-frame.resources.state :as state]))
+  it single-writer / resource-owned.
+
+  ## The durable reply-target boundary (rf2-6kdcs9, EP-0011 §Work Ledger
+  ## Integration / Managed-Effects §Work-ledger integration)
+
+  Managed-Effects §Work-ledger integration says a ledger row *is* the
+  reified continuation, and its `:reply-to` field is the reply target made
+  DURABLE — \"where the ledger row and the reply envelope visibly become one
+  fact.\" The resource-read row's continuation is the FRAMEWORK-INTERNAL
+  reply target (`:rf.resource.internal/succeeded` carrying the verification
+  payload), which is DETERMINISTICALLY RECONSTRUCTABLE from the row's own
+  durable facts (`:work/id` / `:resource/key` / `:generation` / `:work/frame`)
+  — so the durable continuation is a DERIVED row fact, not a separately stored
+  copy that could drift from the verification identity. `durable-reply-to`
+  reconstructs it and runs it through `re-frame.reply/durable-target` so the
+  reified continuation is asserted DATA-ONLY (no host handle, no ephemeral
+  `::post` / `::stale-authority` slot) before it could ride a durable row —
+  the same crispness the spec illustrates.
+
+  An app-supplied CALL-SITE continuation (the mutation `:reply-to`, EP-0016
+  D1) is a DIFFERENT continuation: a transport-payload-only app target fired
+  once on an accepted reply, NOT a durable ledger row fact. It is hardened at
+  its OWN boundary (the mutation execute handler runs it through
+  `re-frame.reply/durable-target` before it rides the transport payload, so a
+  malformed / host-handle target fails LOUD at issuance, before transport /
+  trace). The two continuations are kept distinct: the ledger owns the
+  framework-internal reified continuation; the call-site target is the app's
+  transport-payload continuation."
+  (:require [re-frame.reply :as reply]
+            [re-frame.resources.state :as state]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -181,6 +209,53 @@
    :cancellable? (if (some? cancellable?) cancellable? true)
    :started-at   started-at
    :deadline-at  deadline-at})
+
+;; ---- durable reply-target (rf2-6kdcs9) ------------------------------------
+;;
+;; The framework-internal resource-read reply target made DURABLE
+;; (Managed-Effects §Work-ledger integration — "the row's `:reply-to` field is
+;; the reply target made durable"). The target is DERIVED from the durable row
+;; facts (it is the verification payload the internal reply handlers gate on),
+;; then asserted DATA-ONLY via `re-frame.reply/durable-target`.
+
+(def resource-internal-succeeded
+  "The framework-internal resource success reply event id — the head of the
+  resource-read row's reified continuation (Spec 016 §Events; matches
+  `re-frame.resources.transport.http/succeeded-reply`, spelled here so the
+  ledger reconstructs its durable continuation without inverting the
+  transport dependency). The success leg is canonical: the failure leg
+  (`:rf.resource.internal/failed`) shares the SAME verification payload, so
+  one durable target represents the reified continuation."
+  :rf.resource.internal/succeeded)
+
+(defn durable-reply-to
+  "Reconstruct the DURABLE, data-only reply target for a resource-read work
+  `record` — the reified continuation Managed-Effects §Work-ledger
+  integration says the row carries as `:reply-to`. The target is DERIVED from
+  the record's own durable facts (the verification payload the internal reply
+  handler gates on: `:work/id` + `:resource/key` + `:generation` +
+  `:work/frame`), so the durable continuation can never drift from the
+  stale-suppression identity. Runs the reconstructed descriptor through
+  `re-frame.reply/durable-target`, which strips any ephemeral slot and FAILS
+  LOUD (`:rf.reply/non-data-target`) if a host handle hid in a public field —
+  asserting the reified continuation is data-only before it could ride a
+  durable row / SSR / hydration / epoch snapshot. Returns the data-only
+  normalized descriptor. Per Spec 016 §Frame work ledger / Managed-Effects
+  §Work-ledger integration.
+
+  The verification payload carries exactly the stale-suppression identity the
+  internal reply handler gates on — `:work/id` (the single suppression key,
+  EP-0007), the linked `:resource/key`, the `:generation`, and the carried
+  `:rf.frame/id` (the `:work/frame` stamp). Scope is NOT a suppression key (it
+  is correlation metadata derivable from the resource key), so it is omitted
+  from the durable continuation — one name per fact."
+  [record]
+  (reply/durable-target
+    {:event [resource-internal-succeeded
+             {:work/id      (:work/id record)
+              :resource-key (:resource/key record)
+              :generation   (:generation record)
+              :rf.frame/id  (:work/frame record)}]}))
 
 (defn join-owner+cause
   "Dedupe-join a SUPPLEMENTARY ensure onto an existing non-terminal work

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -31,6 +31,7 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
+   [re-frame.reply :as reply]
    ;; load-bearing side-effecting requires: register the :rf.resource/* +
    ;; :rf.mutation/* events + subs + the generation cofx/fx.
    [re-frame.resources]
@@ -1161,6 +1162,51 @@
       (is (= [:test/save-replied {:kind :article} 7] (subvec ev 0 3)))
       (is (map? (last ev)))
       (is (= :ok (:status (last ev)))))))
+
+(deftest reply-to-durable-target-rejects-malformed-and-host-handle-at-fn-boundary
+  ;; rf2-6kdcs9 — the call-site `:reply-to` is transport-payload-only, but it
+  ;; MUST be data-only. The execute handler runs it through
+  ;; `re-frame.reply/durable-target` AT ISSUANCE, before any runtime-db /
+  ;; work-ledger write, transport lower, or trace. The throw itself is asserted
+  ;; HERE at the fn boundary (the event loop catches a handler throw and
+  ;; surfaces it as :rf.error/handler-exception rather than rethrowing to
+  ;; dispatch-sync's caller — same convention as the instance-id validation).
+  (testing "a malformed call-site target (non-vector / bare-keyword :event) is rejected"
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #"event-vector|Invalid"
+          (reply/durable-target {:event :not-a-vector})))
+    (is (thrown-with-msg?
+          #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          #"event-vector|Invalid"
+          (reply/durable-target {}))))
+  (testing "a host handle smuggled into a public slot (a fn in :suppress) is rejected"
+    (try
+      (reply/durable-target {:event [:test/save-replied] :suppress {:cb (fn [] 1)}})
+      (is false "expected durable-target to reject a host-handle target")
+      (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+        (is (= :rf.reply/non-data-target (:rf.error/kind (ex-data e)))))))
+  (testing "a WELL-FORMED data-only call-site target survives durable projection"
+    (is (= {:event [:test/save-replied] :delivery :append}
+           (reply/durable-target [:test/save-replied])))))
+
+(deftest execute-rejects-malformed-reply-to-fails-closed
+  ;; rf2-6kdcs9 — the dispatch-path fail-closed EFFECT: a malformed call-site
+  ;; `:reply-to` rejects BEFORE any transport lower / instance write (the throw
+  ;; itself is asserted directly above). The event loop catches the throw, so
+  ;; we observe the absence of side effects (mirrors
+  ;; `execute-rejects-non-serializable-instance-id-fails-closed`).
+  (reg-capture-continuation!)
+  (rf/reg-mutation :m/save (save-article-spec))
+  (reset! last-managed-args nil)
+  (rf/dispatch-sync [:rf.mutation/execute
+                     {:mutation :m/save :params {:slug "w"} :instance :bad-rt
+                      :reply-to {:event :not-a-vector}}])
+  (testing "nothing was lowered to transport (fail-closed BEFORE the write)"
+    (is (nil? @last-managed-args)))
+  (testing "no instance row was written and no continuation fired"
+    (is (nil? (instance :bad-rt)))
+    (is (empty? @replied))))
 
 (deftest reply-to-observes-settled-instance-and-cache-consequences
   ;; Validation rule 3: the continuation fires AFTER cache consequences and

--- a/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
@@ -28,6 +28,7 @@
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
    [re-frame.frame :as frame]
+   [re-frame.reply :as reply]
    ;; load-bearing side-effecting require: the façade registers the
    ;; :rf.resource/* events + the work-ledger side-table fx these tests
    ;; dispatch through.
@@ -430,6 +431,62 @@
                                         :started-at 1})]
         (is (= wid (:work/id r)))
         (is (not (contains? r :stale-key)))))))
+
+;; ===========================================================================
+;; 10b. DURABLE REPLY-TARGET BOUNDARY (rf2-6kdcs9) — Managed-Effects §Work-
+;;      ledger integration: a ledger row IS the reified continuation, and its
+;;      `:reply-to` is the reply target made durable. `durable-reply-to`
+;;      reconstructs the resource-read row's framework-internal continuation
+;;      from the row's own durable facts and asserts it DATA-ONLY.
+;; ===========================================================================
+
+(deftest durable-reply-to-derives-data-only-continuation-from-the-row
+  (testing "the row's reified continuation is DERIVED from its durable facts
+            (work-id / resource-key / generation / work-frame) — not a stored
+            copy that could drift from the stale-suppression identity"
+    (let [scoped-key [:rf.scope/global :r/x {:id 1}]
+          wid        (work-ledger/resource-work-id scoped-key 4)
+          r          (work-ledger/work-record {:work-id wid :frame-id :app/main
+                                               :resource-key scoped-key
+                                               :generation 4 :transport :rf.http/managed
+                                               :started-at 1})
+          target     (work-ledger/durable-reply-to r)]
+      (testing "the continuation addresses the framework-internal reply handler
+                carrying the verification payload the handler gates on"
+        (is (= [:rf.resource.internal/succeeded
+                {:work/id      wid
+                 :resource-key scoped-key
+                 :generation   4
+                 :rf.frame/id  :app/main}]
+               (:event target)))
+        (is (= :append (:delivery target))))
+      (testing "the reconstructed durable continuation is DATA-ONLY (no
+                ephemeral ::post / ::stale-authority, no host handle) and EDN-
+                serializable — it can ride the durable row / SSR / epoch wire"
+        (is (true? (reply/data-only-target? target)))
+        (is (work-ledger/serializable-record? target)))
+      (testing "the durable continuation carries ONLY the suppression identity
+                — no scope (correlation metadata, not a suppression key) and no
+                :stale-key synonym (one name per fact)"
+        (let [vp (second (:event target))]
+          (is (not (contains? vp :scope)))
+          (is (not (contains? vp :stale-key)))
+          (is (= wid (:work/id vp)) "the single suppression identity")))))
+  (testing "durable-reply-to FAILS LOUD if a host handle ever hid in a row fact
+            (an impossible-by-construction smuggle, but the boundary asserts it)"
+    ;; A record whose :resource/key carried a host handle (a fn) must never
+    ;; produce a durable continuation — durable-target rejects it before the
+    ;; bogus target could ride a row / transport / trace.
+    (let [bad (work-ledger/work-record {:work-id [:rf.work/resource [(fn [] 1)] 4]
+                                        :frame-id :app/main
+                                        :resource-key [(fn [] 1)]
+                                        :generation 4 :transport :rf.http/managed
+                                        :started-at 1})]
+      (try
+        (work-ledger/durable-reply-to bad)
+        (is false "expected durable-reply-to to reject a host-handle row fact")
+        (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
+          (is (= :rf.reply/non-data-target (:rf.error/kind (ex-data e)))))))))
 
 ;; ===========================================================================
 ;; 11. ADVERSARIAL (rf2-sxyrzk / eu2ifi) — two frames issuing the SAME


### PR DESCRIPTION
Hardens the shared EP-0011 `re-frame.reply` substrate and settles the durable reply-target boundary for ledger-backed continuations. EP-0011 is final/graduated; this is correctness + good-practice tightening on the shipped substrate.

## rf2-o7pqbm (P2 correctness) — harden reply-target + reply-map validation

Independent EP-0011 review found four shared-substrate validation gaps. All four are fixed in `implementation/core/src/re_frame/reply.cljc`, with adversarial tests for every rejection path in `reply_test.cljc`:

1. **`normalize-target` now fails closed on a malformed target.** A descriptor missing `:event`, or carrying a non-vector / empty-vector / non-keyword-headed `:event`, or a non-vector/non-map target, throws `:rf.reply/invalid-target` rather than letting `{}`, `{:event nil}`, `{:event :x}` travel on to `complete` and become a bogus `(vec event)` dispatch shape. The guard lives at normalization, so every downstream consumer (`complete`, `map-target`, `durable-target`, `target->short-form`) inherits the guarantee.
2. **`map-target` preserves nil/no-continuation semantics.** Mapping a nil target stays nil rather than fabricating an eventless `{::post f}` descriptor.
3. **`validate-reply` rejects a present `:error` key on `:ok` — including a nil placeholder.** The contract says `:error` is *absent* for `:ok` (omit optional fields when absent); checking `contains?` (not `some?`) closes the `{:status :ok :error nil}` gap.
4. **`host-handle?` aligned with its documented contract.** The closed host-handle set now includes JS `Date` / `RegExp` (and the JVM `java.util.Date` / `java.util.regex.Pattern` counterparts) on both runtimes, matching the docstring; a non-EDN host object now correctly fails the data-only invariant on the reply map AND the durable target. (Also guarded the CLJS `js/Promise` check with `exists?` for runtime safety.)

## rf2-6kdcs9 (P3 best-practice) — settle the durable reply-target boundary

This was a settleable boundary, not an un-rulable tension — the existing spec text is the ruling. Two distinct continuations, settled at their respective boundaries:

- **Resource-read row = the reified continuation (framework-internal).** Its `:reply-to` (the spec's illustrative `[:rf.resource.internal/succeeded …]`) is *deterministically reconstructable* from the row's own durable facts (`:work/id` / `:resource/key` / `:generation` / `:work/frame`). New `work-ledger/durable-reply-to` reconstructs it and runs it through `reply/durable-target` — making the spec's ledger `:reply-to` field a crisp, **data-only derived** fact (asserted host-handle-free, EDN-serializable) rather than a stored copy that could drift from the stale-suppression identity.
- **Mutation call-site `:reply-to` = transport-payload-only (intentionally).** EP-0016 D1's app continuation is NOT a durable ledger row fact; it rides the internal reply payload and fires once on an accepted reply. It is hardened at its OWN boundary: the execute handler runs it through `reply/durable-target` **at issuance** — before any runtime-db / work-ledger write, transport lower, or trace — so a malformed / host-handle target fails loud now rather than silently mis-delivering (or stranding a non-serializable value on the wire) at completion.

**No spec change required.** `spec/Managed-Effects.md` §Work-ledger integration already states the ledger row *is* the reified continuation and its `:reply-to` is the reply target made durable; it does not claim every continuation is stored as a row fact. This PR makes the implementation crisp and conformant with that existing text. (`durable-reply-to` derives the durable target where it owns one; the call-site target stays transport-payload-only.)

## Quality gates

- `npm run test:cljs` — 6775 tests / 27354 assertions, 0 failures, 0 errors.
- reply-conformance JVM (`implementation/reply-conformance` `clojure -M:test`) — 15 tests / 237 assertions, 0 failures.
- core JVM (`implementation/core` `clojure -M:test`) — 1318 tests / 5820 assertions, 0 failures.
- resources JVM (`implementation/resources` `clojure -M:test`) — 333 tests / 1285 assertions, 0 failures.
- mkdocs `--strict` — not run (no `spec/` files touched).