### PR TITLE
docs(comments): EP-0010 causal-world-input comment pass (rf2-kpg1fh)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -12,7 +12,10 @@
 
     :epoch-id       opaque, unique within a frame's history
     :frame          frame keyword
-    :committed-at   timestamp
+    :committed-at   the committing event's CAUSAL time — its envelope's
+                    `:rf.world/inputs` `:time-ms`, stamped at the router's
+                    causal boundary (rf2-bh56rc / EP-0010 §Time), NOT an
+                    ambient assembly-time clock read; replayable
     :event-id       the event keyword that triggered the cascade
     :trigger-event  the full event vector
     :db-before      app-db snapshot before the cascade


### PR DESCRIPTION
Wave-end CODE-COMMENTS review of the merged EP-0010 (causal world inputs) work (rf2-kpg1fh). Reviews the prose IN the code — comments + docstrings — for COMPLETENESS and ACCURACY across every EP-0010 surface. Comment-only.

## Surfaces reviewed

- `router.cljc` — `build-envelope` world-input stamping (the causal boundary; `epoch-now-ms` read; caller-supplied-wins; child = distinct token; not-in-`inheritable-envelope-keys`); the debug-gated `:rf.world/inputs` trace stamp on `:rf.event/dispatched`; `:committed-at` causal-time threading (settle / halt-depth / mid-drain destroy).
- `cofx.cljc` — the `:app/now-ms` compatibility time cofx (recordable migration target; reads only the seeded `:rf.world/inputs`; nil off-dispatch).
- `interop.clj` / `interop.cljs` — the `now-ms` (perf clock, origin-relative on CLJS, elapsed measurement) vs `epoch-now-ms` (durable wall-clock epoch) split.
- `fx.cljc` — `inheritable-envelope-keys` (correctly EXCLUDES `:rf.world/inputs`) and `framework-coeffect-keys` (correctly INCLUDES it for the user-cofx trace filter) — two distinct sets, both accurate; no contradiction.
- `resources/events.cljc` — the three freshness DECISION sites routed off the causal `(:time-ms world)` (fresh-skip gate, active-stale selection, stale-fired re-check); private ambient `now-ms` helper removed; passive subs/ssr reads keep theirs.
- `resources/ssr.cljc` — restore-reconcile `:settled-at`-from-causal-token (`:restore-time-ms`) clause + the "restore must not re-read the live clock" rationale (rf2-wshzsp); `now-ms` de-privatised for the adversarial suite.
- `epoch/tool_pair.cljc` — `:restore-time-ms` = restored epoch's `:committed-at` threading.
- `epoch.cljc`, `frame.cljc` (`*cascade-time-ms*`), `resources/mutation_events.cljc` (causal reply timestamps), `http_*` (reply-token completion time folded into `:rf.world/inputs :time-ms`).

## Verdict

Comments + docstrings are **accurate and complete**. The causal-vs-ambient distinction (durable frame-state reads causal world inputs; diagnostics/scheduling/host-transient may read ambient), the `now-ms`=perf-clock vs `epoch-now-ms`=durable-wall-clock split, fresh-token-at-fire, and the restore-must-not-re-read-the-live-clock + option-1 `:settled-at`-from-causal-token rationale are all documented and match the code. The tool-injected-epoch carve-out (`epoch.cljc` legitimately reads `epoch-now-ms` when no causal token is in flight) is correctly explained. No stale pre-EP-0010 ambient-clock comments found; the residual `now-ms` mentions in `events.cljc` are all inside comments describing the *removed* ambient read.

One trivial completeness fix applied inline:

- `epoch.cljc` top-of-namespace `:rf/epoch-record` field summary described `:committed-at` as a bare "timestamp". The EP-0010 change (rf2-bh56rc) made it the committing token's causal `:rf.world/inputs` `:time-ms` (replay-stable) — documented fully in the `settle!`/`build-record` docstrings below, but the first-look field list understated it. Aligned the summary to the causal nature.

No follow-up beads filed — no larger clusters of missing/inaccurate prose surfaced.

## Quality gates

- core `clojure -M:test` — 1318 tests / 5807 assertions, 0 failures, 0 errors.
- epoch `clojure -M:test` (artefact owning the edited file) — 323 tests / 1264 assertions, 0 failures, 0 errors.
- `npm run test:cljs` — NOT run in this worktree (no `node_modules`; full `npm install` not provisioned here). The change is a single namespace-docstring string literal with no structural/code-path change; the epoch namespace loads and is exercised by the passing epoch JVM suite, so CLJS-compile risk is nil.