### PR TITLE
fix(core): EP-0013 install! wires :frame + refuses-loudly for deferred kinds (rf2-chc8vs)

### DIFF
--- a/implementation/core/src/re_frame/app_value.cljc
+++ b/implementation/core/src/re_frame/app_value.cljc
@@ -619,14 +619,19 @@
   "Seat one descriptor into the realm's registrar so it is dispatch/resolve-
   ready. A CONSTRUCTED descriptor (high-level `module` form) must be lowered
   through its kind's real registration logic (the event interceptor wrap, the
-  sub input-signal parse, …) — that logic lives in `re-frame.events` / `.subs`
-  / `.fx` / `.cofx`, which this leaf ns must not require, so it is reached
-  through the `:app-value/install-descriptor!` late-bind hook core publishes.
-  When the hook handles the kind it returns truthy; otherwise (a projected
-  descriptor — whose `:metadata` already carries the wrapped slots — or a kind
-  the hook does not special-case, or the hook being unbound) fall back to the
-  flat registrar lowering, which round-trips a projected descriptor unchanged.
-  INTERNAL."
+  sub input-signal parse, the frame container create + `:on-create`, …) — that
+  logic lives in `re-frame.events` / `.subs` / `.fx` / `.cofx` / `.frame`,
+  which this leaf ns must not require, so it is reached through the
+  `:app-value/install-descriptor!` late-bind hook core publishes. The hook
+  wires the EP-0013 step-7 first-format kinds (`:event`/`:sub`/`:fx`/`:cofx`/
+  `:frame`) and returns truthy; for the step-8-DEFERRED kinds (`:route`/`:flow`/
+  `:resource`/`:mutation`/`:view`/`:head`/`:error-projector`/`:resource-scope`)
+  it THROWS `:rf.error/unsupported-descriptor-kind` (refuse-loudly, fail-closed
+  per EP-0013 issue-12) rather than seat a malformed flat slot. The flat
+  registrar lowering is the FALLBACK reached only when the hook returns falsy —
+  a projected descriptor whose `:metadata` already carries the wrapped slots,
+  with the hook unbound (a bundle that never loaded core's reg surfaces); it
+  round-trips a projected descriptor unchanged. INTERNAL."
   [kind id desc]
   (let [lower (late-bind/get-fn :app-value/install-descriptor!)]
     (when-not (and lower (lower kind id desc))

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1706,24 +1706,69 @@
 ;; `register-event!` wraps the handler into the kind-appropriate interceptor;
 ;; `reg-sub` parses input signals; `reg-fx`/`reg-cofx` stamp their slots. That
 ;; logic lives in `re-frame.events` / `re-frame.subs` / `re-frame.fx` /
-;; `re-frame.cofx`, which `re-frame.app-value` must NOT require (it is a leaf on
-;; the realm/registrar spine, bundle-isolation neutral). So core — which already
-;; pulls all four reg surfaces — publishes a `:app-value/install-descriptor!`
-;; late-bind hook that `app-value/install!` consults per descriptor; the flat
-;; registrar lowering is the FALLBACK for kinds this hook does not special-case
-;; (and for a projected descriptor, whose `:metadata` already carries the
-;; wrapped slots — it round-trips through the flat path unchanged).
+;; `re-frame.cofx` / `re-frame.frame`, which `re-frame.app-value` must NOT
+;; require (it is a leaf on the realm/registrar spine, bundle-isolation
+;; neutral). So core — which already pulls all those reg surfaces — publishes a
+;; `:app-value/install-descriptor!` late-bind hook that `app-value/install!`
+;; consults per descriptor.
+;;
+;; EP-0013 §Implementation step 7 defines the FIRST descriptor-format kinds —
+;; `:event`/`:sub`/`:fx`/`:cofx` AND `:frame`. All five are wired here through
+;; their real registration logic (`:frame` → `reg-frame`, which creates the
+;; frame container + runs `:on-create` + installs classification — the malformed
+;; flat slot that `reg-frame` never produces is the rf2-chc8vs gap this closes).
+;;
+;; Step 8 DEFERS the rest (`:route`/`:flow`/`:resource`/`:mutation`/`:view`/
+;; `:head`/`:error-projector`/`:resource-scope`): each has real registration
+;; logic (route compile, flow input-signal parse, scope wiring, …) the flat
+;; registrar lowering BYPASSES, so flat-lowering one seats a slot the subsystem
+;; cannot consume. Rather than silently seat that malformed slot, the hook
+;; REFUSES LOUDLY — a diagnosable `:rf.error/unsupported-descriptor-kind` naming
+;; the unsupported kind + the wired set + that it is a later slice — per EP-0013
+;; issue-12 (refuse-loudly is fail-closed) + the corpus no-silent-swallow rule
+;; (rf2-3nbl5.1). The flat fallback in `register-descriptor!` now only ever runs
+;; for a projected descriptor of a wired kind whose `:metadata` already carries
+;; the registrar slot (when the hook is unbound — e.g. a production bundle that
+;; never loaded core's reg surfaces).
+
+(def ^:private install-deferred-kinds
+  "EP-0013 step-8 registration kinds whose install lowering is NOT yet wired.
+  Each carries real registration logic (route compile, flow input-signal parse,
+  resource/mutation/scope wiring, view handler wrap, SSR head + error-projector
+  registration) the flat registrar lowering bypasses, so `install!` REFUSES
+  LOUDLY rather than seat a malformed flat slot the subsystem cannot consume —
+  fail-closed per EP-0013 issue-12. Wiring these is a later slice."
+  #{:route :flow :resource :mutation :resource-scope :view :head :error-projector})
+
+(def ^:private install-wired-kinds
+  "EP-0013 step-7 FIRST descriptor-format kinds — those `install-descriptor!`
+  lowers through their real registration logic. The complement of
+  `install-deferred-kinds` within the Spec 001 registrar taxonomy."
+  #{:event :sub :fx :cofx :frame})
 
 (defn- install-descriptor!
   "Lower one app-value registration descriptor into the realm's registrar
   through its kind's real registration path, so a constructed (high-level)
   descriptor becomes dispatch/resolve-ready exactly as a `reg-*` call would.
-  Returns `true` when the kind was handled here, `false` to signal `install!`
-  should fall back to the flat registrar lowering (projected descriptors +
-  kinds not special-cased — e.g. `:frame`/`:view`/`:route`, whose seating is a
-  later slice). The `:event/kind` is read from the descriptor metadata
+
+  Handles the EP-0013 step-7 first-format kinds — `:event`/`:sub`/`:fx`/`:cofx`
+  AND `:frame` — through their real `reg-*` logic, returning `true`. `:frame`
+  lowers through `reg-frame` (atomic create-and-register: a frame container,
+  `:on-create`, classification install), so a seated frame is a REAL frame that
+  appears in `frame-ids` — not the malformed flat slot the registrar-only path
+  produced (rf2-chc8vs). The `:event/kind` is read from the descriptor metadata
   (defaulting to `:db`), so a module event entry tagged `{:event/kind :fx}`
-  lowers through `reg-event-fx`."
+  lowers through `reg-event-fx`.
+
+  For the step-8-DEFERRED kinds (`install-deferred-kinds`) THROWS
+  `:rf.error/unsupported-descriptor-kind` (the ex-data IS the diagnostic —
+  naming the kind + the wired set + that its install lowering is a later slice)
+  rather than silently flat-lowering a slot the subsystem cannot consume —
+  fail-closed per EP-0013 issue-12 + the no-silent-swallow rule.
+
+  Returns `false` for any other kind to signal `install!` should fall back to
+  the flat registrar lowering — reached only by a projected descriptor when the
+  hook is unbound (the flat path round-trips a projected descriptor unchanged)."
   [kind id {:keys [handler metadata source owner]}]
   ;; Fold the descriptor's lifted `:source` envelope back into the metadata the
   ;; reg fn sees, so an explicitly-supplied source coordinate (issue 8: a
@@ -1733,16 +1778,33 @@
   ;; so the realm's registrar records which module installed each registration.
   (let [meta (cond-> (merge source (or metadata {}))
                (some? owner) (assoc :owner owner))]
-    (case kind
-      :event (do (case (:event/kind meta)
-                   :fx  (events/reg-event-fx  id meta handler)
-                   :ctx (events/reg-event-ctx id meta handler)
-                   (events/reg-event-db id meta handler))
-                 true)
-      :sub   (do (subs/reg-sub id meta handler) true)
-      :fx    (do (fx/reg-fx id meta handler) true)
-      :cofx  (do (cofx/reg-cofx id meta handler) true)
-      false)))
+    (cond
+      (contains? install-deferred-kinds kind)
+      (throw (ex-info (str "rf/install!: descriptor kind " kind
+                           " is not yet installable — its real registration"
+                           " logic is a later EP-0013 slice (step 8). install!"
+                           " wires " (pr-str install-wired-kinds) " so far;"
+                           " seating " kind " through the flat registrar would"
+                           " produce a slot the subsystem cannot consume.")
+                      {:error/id    :rf.error/unsupported-descriptor-kind
+                       :kind        kind
+                       :id          id
+                       :wired       install-wired-kinds
+                       :deferred    install-deferred-kinds
+                       :recovery    :register-through-reg-*-sugar}))
+
+      :else
+      (case kind
+        :event (do (case (:event/kind meta)
+                     :fx  (events/reg-event-fx  id meta handler)
+                     :ctx (events/reg-event-ctx id meta handler)
+                     (events/reg-event-db id meta handler))
+                   true)
+        :sub   (do (subs/reg-sub id meta handler) true)
+        :fx    (do (fx/reg-fx id meta handler) true)
+        :cofx  (do (cofx/reg-cofx id meta handler) true)
+        :frame (do (frame/reg-frame id meta) true)
+        false))))
 
 (late-bind/set-fn! :app-value/install-descriptor! install-descriptor!)
 

--- a/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
@@ -536,31 +536,72 @@
       (is (= h (get-in @registrar/kind->id->metadata [:event :xms/ghost-ev :handler-fn]))
           "it is the process-global atom, confirming the absence-is-default fallback"))))
 
-(deftest install-of-a-non-wired-kind-seats-a-malformed-slot-known-limitation
-  (testing "CHARACTERIZATION of the flat-fallback gap (rf2-xmslkr / follow-up
-            rf2-chc8vs): a CONSTRUCTED :frame descriptor is NOT among the
-            install-descriptor! wired kinds (:event/:sub/:fx/:cofx), so install!
-            falls back to the FLAT registrar lowering — it writes a :frame
-            registrar slot but NEVER runs reg-frame's real registration logic
-            (no frame container is created, no :on-create runs). The slot is
-            thus MALFORMED for the frame subsystem: it appears in the registrar
-            yet `frame/frame` finds no container, so the 'installed' frame is not
-            dispatchable.
-
-            EP-0013 §Implementation step 7 lists :frame among the FIRST
-            descriptor-format kinds, but its install lowering is unwired in this
-            slice (step 8 extends the format to routes/flows/resources/…). This
-            test PINS the current behaviour as a known limitation and is the
-            regression guard for the wiring (or the refuse-loudly posture per
-            issue 12) the follow-up bead lands."
+(deftest install-wires-the-frame-kind-through-reg-frame
+  (testing "rf2-chc8vs: :frame is an EP-0013 step-7 FIRST-format kind, so a
+            CONSTRUCTED :frame descriptor is now lowered through reg-frame's REAL
+            registration logic — install! creates a real frame CONTAINER (not the
+            malformed flat registrar slot the prior slice left). The frame
+            appears in `frame-ids`, `frame/frame` resolves a live container, and
+            it is dispatchable. This FLIPS the rf2-xmslkr characterization test
+            that pinned `frame/frame -> nil` as a known limitation."
     (rf/install! (rf/app {:id :xms/frame-app :modules
                           [(rf/module {:id :m :frames {:xms/frame {:doc "constructed frame"}}})]}))
-    ;; The registrar slot WAS written (flat fallback).
+    ;; The registrar slot is written (reg-frame's first step) — the frame kind is
+    ;; a registrar kind, so the (kind,id) table carries the config.
     (is (some? (registrar/lookup :frame :xms/frame))
-        "the flat fallback wrote a :frame registrar slot")
-    ;; But NO frame container exists — reg-frame's real logic never ran.
-    (is (nil? (frame/frame :xms/frame))
-        "KNOWN LIMITATION: no frame container — the flat slot is malformed for
-         the frame subsystem (the install lowering for :frame is unwired)")
-    (is (not (contains? (frame/frame-ids) :xms/frame))
-        "the 'installed' frame is absent from the live frame registry")))
+        "reg-frame wrote the :frame registrar slot")
+    ;; And — the rf2-chc8vs fix — a REAL frame container now exists: reg-frame's
+    ;; full registration logic ran (container create + :on-create + classify).
+    (is (some? (frame/frame :xms/frame))
+        "a real frame container exists — reg-frame's registration logic ran")
+    (is (contains? (frame/frame-ids) :xms/frame)
+        "the installed frame appears in the live frame registry")
+    ;; The seated config round-trips (the :doc the module carried).
+    (is (= "constructed frame" (:doc (frame/frame-meta :xms/frame)))
+        "the constructed frame's config was seated through reg-frame")
+    ;; End-to-end: the installed frame is dispatchable / subscribable, proving it
+    ;; is a real frame and not a malformed slot.
+    (rf/install! (rf/app {:id :xms/frame-prog :modules
+                          [(rf/module {:id :m2
+                                       :events {:xms/frame-set {:handler (fn [db [_ v]] (assoc db :n v))}}
+                                       :subs   {:xms/frame-read {:handler (fn [db _] (:n db))}}})]}))
+    (rf/dispatch-sync [:xms/frame-set 7] {:frame :xms/frame})
+    (is (= {:n 7} (rf/app-db-value :xms/frame))
+        "the install!-seated frame dispatches an installed event handler")
+    (is (= 7 @(rf/subscribe :xms/frame [:xms/frame-read]))
+        "the install!-seated frame resolves an installed subscription")))
+
+(deftest install-of-a-step8-deferred-kind-refuses-loudly
+  (testing "rf2-chc8vs: a CONSTRUCTED descriptor of an EP-0013 step-8 DEFERRED
+            kind (:route/:flow/:resource/:mutation/:view/:head/:error-projector/
+            :resource-scope) — each carries real registration logic the flat
+            lowering bypasses — REFUSES LOUDLY at install!: a diagnosable
+            :rf.error/unsupported-descriptor-kind naming the kind + the wired set
+            + that it is a later slice, rather than silently seating a malformed
+            flat slot (fail-closed per EP-0013 issue-12 + no-silent-swallow)."
+    (doseq [[section kind] [[:routes :route]
+                            [:flows :flow]
+                            [:resources :resource]
+                            [:mutations :mutation]
+                            [:resource-scopes :resource-scope]
+                            [:views :view]
+                            [:heads :head]
+                            [:error-projectors :error-projector]]]
+      (let [a  (rf/app {:id :xms/deferred-app :modules
+                        [(rf/module (assoc {:id :m}
+                                           section {:xms/deferred {:handler (fn [& _] nil)}}))]})
+            ed (try (rf/install! a)
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
+                      (ex-data e)))]
+        (is (= :rf.error/unsupported-descriptor-kind (:error/id ed))
+            (str "install! of a " kind " descriptor refuses loudly"))
+        (is (= kind (:kind ed))
+            (str "the refusal names the unsupported kind " kind))
+        (is (contains? (:deferred ed) kind)
+            "the refusal enumerates the deferred set")
+        (is (contains? (:wired ed) :frame)
+            "the refusal enumerates the wired set (now including :frame)")
+        ;; Atomic: the refusal threw before recording an :app, and rolled back any
+        ;; seating — no descriptor of the refused kind leaked into the registrar.
+        (is (nil? (registrar/lookup kind :xms/deferred))
+            (str "no malformed " kind " slot was seated — the refusal was loud, not silent"))))))


### PR DESCRIPTION
## What

EP-0013 `install!`/`install-descriptor!` special-cased only `:event`/`:sub`/`:fx`/`:cofx` through their real `reg-*` registration logic. ALL other kinds fell back to the FLAT registrar lowering (`descriptor->registration-metadata` -> `registrar/register!`), which wrote a `(kind, id)` slot WITHOUT running the subsystem's real registration. Confirmed by the `rf2-xmslkr` characterization test: a constructed `:frame` descriptor seated a `:frame` registrar slot but created NO frame container (`frame/frame` -> nil; absent from `frame-ids`), because `reg-frame` (container create + `:on-create` + classification) never ran — a malformed seating.

This closes the gap per EP-0013 step 7 (wire `:frame` now) + issue-12 (refuse-loudly / fail-closed) + the corpus no-silent-swallow rule.

## Changes

- **WIRE `:frame`** (an EP-0013 step-7 first-format kind) through `reg-frame` in `install-descriptor!`. A seated `:frame` is now a REAL frame container: it appears in `frame-ids`, `frame/frame` resolves it, and it is dispatchable/subscribable.
- **REFUSE LOUDLY** for the step-8-deferred kinds — `:route` / `:flow` / `:resource` / `:mutation` / `:resource-scope` / `:view` / `:head` / `:error-projector`. Each has real registration logic the flat path bypasses, so `install!` throws a diagnosable `:rf.error/unsupported-descriptor-kind` (ex-data names the kind + the wired set + the deferred set + that it is a later slice) rather than seat a malformed flat slot. `seat-into-realm!`'s existing snapshot/rollback makes the refusal atomic — no partial seating leaks.
- **Flip the `rf2-xmslkr` characterization test** from pinning `frame/frame -> nil` as a known limitation to asserting (a) `:frame` seats a real frame (container present, in `frame-ids`, dispatch + subscribe end-to-end) and (b) each deferred kind refuses loudly + leaks no registrar slot.
- **Docstrings** for `install-descriptor!` (core) + `register-descriptor!` (app-value) updated — the "fall back to the flat registrar lowering for `:frame`/`:view`/`:route`, whose seating is a later slice" note was the bug.

No spec/docs touched — implementation + test only.

## Quality gates

- `clojure -M:test` (core JVM): **1328 tests / 5905 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node CLJS): **6802 tests / 27570 assertions, 0 failures, 0 errors**
- `npm run test:bundle-isolation`: **PASS** (22 artefact entries, 40 sentinels absent, 3 budgets ok; uix/helix/reagent-free PASS)
- `mkdocs --strict`: N/A — no spec/docs files changed

Closes rf2-chc8vs.
