### PR TITLE
feat(xray): EP-0015 adopt :rf.egress/local-redacted as Xray local-render default (rf2-t55hxg.12)

### DIFF
--- a/spec/015-Data-Classification.md
+++ b/spec/015-Data-Classification.md
@@ -303,12 +303,12 @@ The six-profile enum is a **closed set** but the **exact names do not lock** unt
 |---|---|---|
 | `:rf.egress/off-box-observability` | a hosted-monitoring sink (Datadog / Sentry shape) | ✅ frame `:observability` sink routing — `re-frame.observability` routes handled-event / error records through `project-egress` under this profile to declared sinks (`re-frame.frame-classification` default; rf2-t55hxg.7) |
 | `:rf.egress/off-box-tool` | pair-MCP / Story-MCP wire | ✅ re-frame2-pair-mcp + story-mcp default boundary — both servers resolve their direct-read / live-state egress to this profile via `re-frame.mcp-base.egress` (rf2-qus09h) |
-| `:rf.egress/local-redacted` | an on-box dev tool (Xray panel) | ⏳ **gap** — defined + unit-tested in `re-frame.projection`; Xray local-render adoption is deferred behind the in-flight EP-0014 derivation-graph panel (rf2-9ett2d) to avoid a same-file rewrite (follow-up: rf2-t55hxg.12) |
+| `:rf.egress/local-redacted` | an on-box dev tool (Xray panel) | ✅ Xray's App-DB panel local render — the `:rf.xray/app-db-state` section-model sub projects every value-bearing partition through `project-egress` under this profile, keyed on the observed frame (`day8.re-frame2-xray.panels.local-render`; suppress sensitive display, keep large on-box, fail-closed; rf2-t55hxg.12) |
 | `:rf.egress/local-raw` | a dev tool under explicit trusted-local opt-in | ✅ the pair-MCP / story-mcp `--allow-sensitive-reads` + per-call `:include-sensitive` two-key opt-in resolves to this profile (rf2-qus09h) |
 | `:rf.egress/ssr-hydration` | a real SSR / hydration payload | ✅ `re-frame.resources.ssr` projects the allowlisted resource hydration slice under this profile (`re-frame.resources.classification`) |
 | `:rf.egress/public-error` | a public error-response projection | ✅ `re-frame.error-emit` / `re-frame.observability` route the `:rf.observe/error` record under this profile (drops the host `:exception`, never internal raw values) |
 
-Until every row is exercised, the names are provisional and may be re-thrashed. The EP stays `accepted` (not `final`) for the duration. **Five of six profiles now have a real consumer; `:rf.egress/local-redacted` is the one remaining gap** (the on-box Xray-render adoption, deferred to sequence behind rf2-9ett2d's in-flight panel work). Additions to the set after lock require a recorded ruling.
+**All six profiles now have a real consumer** (rf2-t55hxg.12 closed the final gap — the on-box Xray App-DB local-render adoption of `:rf.egress/local-redacted`). With every row exercised, the names are eligible to lock and the EP can move `accepted` → `final` (the EP-0015 graduation assessment owns that flip). Additions to the set after lock require a recorded ruling.
 
 ## Frame-owned observability sink policy
 

--- a/tools/xray/spec/004-App-DB-Diff.md
+++ b/tools/xray/spec/004-App-DB-Diff.md
@@ -613,6 +613,55 @@ log. Xray's writes are funnelled through dispatch — inspection is the
 default, rewind is opt-in (per
 [Tool-Pair §Time-travel: epoch snapshots and undo](../../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo)).
 
+## On-box local-render egress policy (EP-0015, rf2-t55hxg.12)
+
+Even though the panel renders on-box, the value the section model hands
+to the shared edn-inspector is **projected** through the frame-owned
+egress policy first. The App-DB panel is the **graduating on-box-dev-tool
+consumer** of the `:rf.egress/local-redacted` profile (the on-box dev-UI
+default — [Spec 015 §Projection profiles](../../../spec/015-Data-Classification.md#projection-profiles--the-rfegress-enum-provisional)
++ [§The graduation gate](../../../spec/015-Data-Classification.md#the-graduation-gate)).
+
+The section-model sub `:rf.xray/app-db-state` projects every value-bearing
+partition (the app-db `value` / `before` + the runtime-db `runtime-value`
+/ `runtime-before`) through `re-frame.core/project-egress` under
+`:rf.egress/local-redacted`, keyed on the **observed frame** (the frame
+the picker / focus selects). The contract — the shared seam
+`day8.re-frame2-xray.panels.local-render/local-render-value`:
+
+- **Suppress sensitive display by default.** A slot the observed frame
+  declared `:sensitive` (`re-frame.frame-classification`) is replaced by
+  the `:rf/redacted` sentinel — which the edn-inspector already renders as
+  a first-class muted chip (the R8 redaction type). A shoulder-surfer,
+  screen-share, or recorded debugging session never sees the secret.
+- **The local operator MAY see large values.** `:rf.egress/local-redacted`'s
+  floor (`:rf.size/include-large? false`) is overlaid with an explicit
+  `:rf.size/include-large? true` (the override wins —
+  [`re-frame.projection` composition](../../../spec/015-Data-Classification.md#projection-profiles--the-rfegress-enum-provisional)).
+  On-box size bounding is a *display ergonomics* concern owned by the
+  edn-inspector, **not** an egress-redaction concern — the operator is
+  entitled to big values, only secrets are withheld.
+- **Per-frame.** The policy is applied from the OBSERVED frame's own
+  classification, passed as the explicit `:frame` opt, never a borrowed or
+  ambient one. Both the value and its diff pre-image are projected under
+  the same policy, so a sensitive slot reads `:rf/redacted` on both sides
+  and the inline `← was X` annotation never reconstructs the redacted
+  content.
+- **Fail-closed.** An unreachable observed frame (nil / destroyed /
+  never-registered) projects WITHOUT a `:frame` opt so the underlying
+  `elide-wire-value` walker takes its frameless redact-whole branch —
+  redacting the entire value rather than shipping it raw under no policy.
+
+Revealing sensitive values is **not** a process-global toggle. Per
+[Spec 015 §Cross-tool visibility grain](../../../spec/015-Data-Classification.md#cross-tool-visibility-grain)
+on-box visibility is **per (tool, frame)**: an explicit trusted-local
+operator act flips the grain to `:rf.egress/local-raw` (include sensitive
+AND large), carried by `local-render-value`'s `raw?` arg. This is the
+on-box analogue of the off-box redaction call site
+`derivation-graph-helpers/redact-graph-for-egress` (rf2-yjarv6) — the same
+frame-owned, fail-closed `project-egress` boundary, here the on-box render
+default rather than the off-box wire.
+
 ## "Show me when this changed"
 
 The high-leverage right-click affordance. When invoked on any path:

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_subs.cljs
@@ -58,7 +58,8 @@
   machinery is needed (adding any would be machinery for a surface that
   no longer exists)."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-xray.panels.app-db-diff-helpers :as h]))
+            [day8.re-frame2-xray.panels.app-db-diff-helpers :as h]
+            [day8.re-frame2-xray.panels.local-render :as local-render]))
 
 (defn- find-epoch-in-history
   "Return the `:rf/epoch-record` in `history` whose `:epoch-id` matches
@@ -277,16 +278,41 @@
   ;; nil-safe — absent / empty partitions yield an empty TOP + zero
   ;; reserved-area entries (rf2-jcdvo — empty areas are filtered at
   ;; projection time so the renderer never draws placeholder cards).
+  ;; EP-0015 (rf2-t55hxg.12) — the ON-BOX LOCAL-RENDER egress seam. Every
+  ;; value-bearing partition of the section model (the app-db `value` /
+  ;; `before` + the runtime-db `runtime-value` / `runtime-before`) is
+  ;; projected through `re-frame.core/project-egress` under the on-box
+  ;; dev-UI default profile `:rf.egress/local-redacted` (Spec 015
+  ;; §Projection profiles + §The graduation gate). Xray is the EP-0015
+  ;; issue-3 GRADUATING CONSUMER for that profile: the local operator sees
+  ;; large values (the `include-large?` overlay) but NOT slots the OBSERVED
+  ;; frame declared `:sensitive` — those redact to `:rf/redacted`, which
+  ;; the shared edn-inspector already paints as a first-class chip. Per
+  ;; EP-0015 §Cross-tool visibility grain there is NO process-global
+  ;; show-sensitive toggle: revealing sensitive values is a per-(tool,frame)
+  ;; `:rf.egress/local-raw` operator opt-in, not the default.
+  ;;
+  ;; Projecting BOTH the value AND the matching pre-image under the SAME
+  ;; frame policy keeps the diff honest — a sensitive slot reads
+  ;; `:rf/redacted` on both sides, so the inline `← was X` annotation never
+  ;; reconstructs (or even hints at) the redacted content. Fail-closed: an
+  ;; unreachable observed frame redacts the whole value rather than ship it
+  ;; raw under no policy (`local-render/local-render-value`).
   (rf/reg-sub :rf.xray/app-db-state
     :<- [:rf.xray/app-db-current+diff]
-    (fn [{:keys [value before runtime-value runtime-before]} _query]
-      ;; Diff-mode is entered iff a real app-db pre-image is present,
-      ;; mirroring the pre-rf2-yng0y `(if-let [before (:db-before record)]
-      ;; …)` contract: an absent / nil `:db-before` (cold boot, or a record
-      ;; with no pre-image slot) renders plain current-state. When diffing,
-      ;; the runtime areas diff against the SAME focused epoch's runtime-db
-      ;; pre-image.
-      (if (some? before)
-        (h/current-state-sections value runtime-value
-                                  {:app before :runtime runtime-before})
-        (h/current-state-sections value runtime-value)))))
+    :<- [:rf.xray/observed-frame]
+    (fn [[{:keys [value before runtime-value runtime-before]} observed-frame] _query]
+      (let [redact (fn [v] (local-render/local-render-value v observed-frame))
+            value          (redact value)
+            runtime-value  (redact runtime-value)]
+        ;; Diff-mode is entered iff a real app-db pre-image is present,
+        ;; mirroring the pre-rf2-yng0y `(if-let [before (:db-before record)]
+        ;; …)` contract: an absent / nil `:db-before` (cold boot, or a record
+        ;; with no pre-image slot) renders plain current-state. When diffing,
+        ;; the runtime areas diff against the SAME focused epoch's runtime-db
+        ;; pre-image.
+        (if (some? before)
+          (h/current-state-sections value runtime-value
+                                    {:app     (redact before)
+                                     :runtime (redact runtime-before)})
+          (h/current-state-sections value runtime-value))))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/local_render.cljc
@@ -1,0 +1,162 @@
+(ns day8.re-frame2-xray.panels.local-render
+  "Xray's ON-BOX local-render egress seam — the EP-0015 `:rf.egress/local-redacted`
+  graduating consumer (rf2-t55hxg.12).
+
+  ## What this is
+
+  ONE projection seam every Xray panel routes a FRAME-SOURCED value through
+  before it reaches the shared `views/edn-inspector`: App-DB Diff,
+  Subscriptions / Reactive, Machine Inspector, Flow, reply-envelope, Event
+  Detail. It resolves the value through the public record-level boundary
+  primitive `re-frame.core/project-egress` under the named egress PROFILE
+  for on-box dev-tool rendering.
+
+  ## The default is `:rf.egress/local-redacted` (EP-0015 §10, issue 3)
+
+  [spec/015-Data-Classification.md §Projection profiles] names six closed
+  `:rf.egress/*` profiles. The on-box dev-UI default is
+  **`:rf.egress/local-redacted`**: *suppress sensitive display by default;
+  the local operator may still see large values* (Xray runs in the
+  developer's own browser, against the developer's own app — Security.md
+  permits on-box value inspection; the only thing the local-redacted
+  default withholds is data the FRAME declared `:sensitive`, which a
+  shoulder-surfer / screen-share / recorded-session must not leak).
+
+  This is the EP-0015 issue-3 **graduation consumer** for the
+  `:rf.egress/local-redacted` profile (the one remaining gap in
+  [spec/015 §The graduation gate]): the profile was defined + unit-tested
+  in `re-frame.projection` but no on-box dev tool named it as its render
+  default. Xray is that tool — the named on-box-dev-tool consumer the
+  graduation row requires. Routing the local panel render through it
+  exercises the profile end-to-end.
+
+  ## `:rf.egress/local-raw` is the per-(tool,frame) opt-in (EP-0015 issue 7)
+
+  [spec/015 §Cross-tool visibility grain]: on-box visibility is per
+  (tool, frame) — there is **no single process-global `show-sensitive?`
+  user toggle**. The default is `:rf.egress/local-redacted`; revealing
+  sensitive values is an explicit trusted-local OPERATOR ACT that flips
+  the per-(tool,frame) grain to `:rf.egress/local-raw` (include sensitive
+  AND large). `local-render-value`'s `raw?` arg carries that grain — the
+  caller resolves it per (tool, frame); this seam does not own the toggle
+  state.
+
+  ## Why a frame-keyed projection (not a global redact)
+
+  Egress policy is FRAME-SCOPED (EP-0002 / Spec 015 §Direct reads). A value
+  is projected under the OBSERVED frame's own `:sensitive` / `:large`
+  classification — the frame Xray is currently inspecting — never a
+  borrowed or ambient one. The named frame is passed as the explicit
+  `:frame` opt so the walk applies THAT frame's policy regardless of any
+  ambient scope, exactly as `redact-graph-for-egress` (the off-box sibling,
+  rf2-yjarv6) does.
+
+  ## Fail-closed (the silent-leak this seam abolishes)
+
+  `rf/project-egress` delegates to `rf/elide-wire-value`, which treats a
+  carried `:frame` opt as a KNOWN frame even when that id names no LIVE
+  frame — applying an empty (identity) policy that would ship the value
+  RAW under no policy. The local-render default must not do that. So this
+  seam first checks the named frame is LIVE (`rf/frame-ids`); when it is
+  not (nil id, a destroyed / never-registered frame), it projects WITHOUT a
+  `:frame` opt so the underlying walker takes its own frameless fail-closed
+  branch and redacts the whole value to `:rf/redacted` rather than borrow
+  another frame's marks. (Under `:rf.egress/local-raw`'s explicit
+  `:rf.size/include-sensitive? true` opt-out the walker ships the value
+  raw even frameless — the operator has explicitly asked for it.)
+
+  ## The edn-inspector renders the sentinels natively
+
+  A sensitive slot becomes the `:rf/redacted` keyword sentinel; a large
+  slot (only under the redacted default if the caller does NOT pass
+  `include-large?`) becomes the `{:rf.size/large-elided …}` marker. The
+  shared `views/edn-inspector` already paints BOTH as first-class types
+  (the muted `redacted` chip / the yellow `● large` chip) — so the panel
+  needs no special-casing: it hands the PROJECTED value to the inspector
+  and the sentinels render themselves.
+
+  JVM-portable (`.cljc`) so the local-render contract is pinned by the JVM
+  test corpus without a CLJS runtime."
+  (:require [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; The on-box render profiles.
+;; ---------------------------------------------------------------------------
+
+(def local-redacted-profile
+  "The EP-0015 on-box dev-UI DEFAULT egress profile (Spec 015 §Projection
+  profiles): suppress sensitive display; the local operator may still see
+  large values (see `local-render-opts`). The single source of truth for
+  the keyword so panels + tests never fork the spelling."
+  :rf.egress/local-redacted)
+
+(def local-raw-profile
+  "The trusted-local OPT-IN egress profile (EP-0015 §Cross-tool visibility
+  grain): include sensitive AND large. Flipped per (tool, frame) by an
+  explicit operator act, never a process-global toggle."
+  :rf.egress/local-raw)
+
+(defn local-render-profile
+  "Resolve the egress profile a local panel render should project under,
+  given the per-(tool,frame) `raw?` grain. `true` ⇒ the trusted-local
+  `:rf.egress/local-raw` opt-in; anything else ⇒ the
+  `:rf.egress/local-redacted` default."
+  [raw?]
+  (if (true? raw?) local-raw-profile local-redacted-profile))
+
+(defn local-render-opts
+  "Build the `rf/project-egress` opts map for an on-box local render of a
+  value sourced from `frame-id`.
+
+  - **profile** — `local-render-profile` resolves the named boundary from
+    the per-(tool,frame) `raw?` grain (default `:rf.egress/local-redacted`).
+  - **`:frame frame-id`** — only when the frame is LIVE (`rf/frame-ids`).
+    A nil / unreachable frame is OMITTED so the underlying walker fails
+    closed (redacts the whole value) rather than borrow another frame's
+    policy.
+  - **`:rf.size/include-large? true`** — the on-box 'keep large' override
+    (EP-0015 §10: `local-redacted` *suppresses sensitive display*; the
+    local operator IS entitled to large values — Xray's own size-bounding
+    is a display ergonomics concern, not a privacy one). Composition: the
+    profile floor (`include-large? false`) is overlaid by this explicit
+    `:rf.size/*` boolean (the override WINS — `re-frame.projection`
+    §resolve-elision-opts). Under `:rf.egress/local-raw` the floor already
+    includes large; the explicit overlay is a harmless no-op there.
+
+  Pure / JVM-portable except for the live-frame probe, which is a pure read
+  over the runtime frame registry."
+  ([frame-id] (local-render-opts frame-id false))
+  ([frame-id raw?]
+   (cond-> {:rf.egress/profile      (local-render-profile raw?)
+            :rf.size/include-large? true}
+     (and (some? frame-id) (contains? (rf/frame-ids) frame-id))
+     (assoc :frame frame-id))))
+
+;; ---------------------------------------------------------------------------
+;; The projection seam.
+;; ---------------------------------------------------------------------------
+
+(defn local-render-value
+  "Project `v` for ON-BOX local rendering through `rf/project-egress` under
+  the EP-0015 on-box dev-UI default `:rf.egress/local-redacted` (or
+  `:rf.egress/local-raw` when the per-(tool,frame) `raw?` grain opts in).
+
+  `frame-id` is the OBSERVED frame whose `:sensitive` / `:large`
+  classification governs the projection (the frame Xray is currently
+  inspecting). A sensitive-declared slot is replaced by the `:rf/redacted`
+  sentinel; non-sensitive siblings + large values ride through (the
+  `include-large?` overlay). Structure is preserved — only declared leaf
+  slots are touched.
+
+  Fail-closed: an unreachable `frame-id` (nil / destroyed / never
+  registered) under the redacted default redacts the WHOLE value rather
+  than ship it raw under no policy. Idempotent over the sentinels (a
+  re-projection of an already-`:rf/redacted` value is a no-op — the
+  sentinel is a non-matchable scalar).
+
+  Returns the projected value, ready to hand to the shared
+  `views/edn-inspector` (which renders the `:rf/redacted` / large markers
+  as first-class chips)."
+  ([v frame-id] (local-render-value v frame-id false))
+  ([v frame-id raw?]
+   (rf/project-egress v (local-render-opts frame-id raw?))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/local_render_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/local_render_cljs_test.cljc
@@ -1,0 +1,197 @@
+(ns day8.re-frame2-xray.panels.local-render-cljs-test
+  "The local-render egress test for Xray's ON-BOX panel value rendering — the
+  EP-0015 `:rf.egress/local-redacted` GRADUATING-CONSUMER proof (rf2-t55hxg.12).
+
+  ## The gap this closes
+
+  [spec/015-Data-Classification.md §The graduation gate] requires each of the
+  six `:rf.egress/*` profiles be EXERCISED by a real consumer before the names
+  lock. `:rf.egress/local-redacted` was the one remaining gap: defined +
+  unit-tested in `re-frame.projection` but no on-box dev tool named it as its
+  render default. Xray is that consumer — its local panel value rendering now
+  routes through `re-frame.core/project-egress` under
+  `:rf.egress/local-redacted` (`day8.re-frame2-xray.panels.local-render`). This
+  test is the end-to-end exercise the graduation row names: the on-box LOCAL
+  render of a value REDACTS a frame-declared sensitive slot by default while
+  KEEPING large values (the local-render contract: suppress sensitive display;
+  the local operator may see big values).
+
+  ## What's asserted
+
+    1. **DEFAULT redacts sensitive** — a value carrying a sensitive slot at a
+       frame-declared sensitive path is projected under the local-render
+       default; the sensitive slot becomes `:rf/redacted` WHILE non-sensitive
+       siblings + structure ride through.
+    2. **DEFAULT keeps large** — a frame-declared `:large` value is NOT elided
+       on-box (the operator sees big values; only secrets are withheld).
+    3. **per-frame** — projection uses the OBSERVED frame's policy, not a
+       borrowed / ambient one; a plain frame ships the same value verbatim.
+    4. **`:rf.egress/local-raw` opt-in** — the per-(tool,frame) trusted-local
+       grain reveals the sensitive slot (an explicit operator act).
+    5. **fail-closed** — an unreachable observed frame redacts the WHOLE value
+       under the redacted default rather than ship it raw.
+    6. **end-to-end** — the App-DB Diff section model sub
+       (`:rf.xray/app-db-state`) redacts a sensitive app-db slot, so what the
+       panel hands the edn-inspector is already projected."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame-classification :as frame-class]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.panels.app-db-diff-helpers :as h]
+            [day8.re-frame2-xray.panels.local-render :as local-render]))
+
+;; ---------------------------------------------------------------------------
+;; Runtime fixture — mirror the off-box derivation-graph redaction test
+;; (rf2-yjarv6): two frames, one with declared :sensitive / :large policy.
+;;
+;;   :app/secure — declares [:auth :token] sensitive and [:catalog :rows] large.
+;;   :app/plain  — no classification (every value renders verbatim).
+;; ---------------------------------------------------------------------------
+
+(def secure-frame :app/secure)
+(def plain-frame  :app/plain)
+
+(defn- install-policy! []
+  (frame-class/install!
+    secure-frame
+    (frame-class/validate+extract
+      secure-frame
+      {:sensitive {:app-db [[:auth :token]]}
+       :large     {:app-db [[:catalog :rows]]}})))
+
+(defn- init-fn []
+  (rf/reg-frame plain-frame {})
+  (rf/reg-frame secure-frame {})
+  (install-policy!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     ;; OPT OUT of the default `:rf/default` ambient scope so the fail-closed
+     ;; arm asserts a frameless walk redacts (a bound ambient frame would let
+     ;; the frameless projection resolve to its empty-policy identity and ship
+     ;; raw — masking the fail-closed contract). Mirrors the off-box sibling
+     ;; test's fixture.
+     :ambient-frame nil
+     :init-fn init-fn}))
+
+;; A value with both a frame-declared sensitive slot and a frame-declared
+;; large slot, plus plain siblings — the shape an app-db panel renders.
+(def ^:private app-db-value
+  {:auth    {:token "secret-session-jwt-abc123"
+             :user-id 42}
+   :catalog {:rows (vec (range 300))}
+   :ui      {:open? true :tab :home}})
+
+;; ---------------------------------------------------------------------------
+;; 1 + 2. DEFAULT — redact sensitive, KEEP large.
+;; ---------------------------------------------------------------------------
+
+(deftest local-render-default-redacts-sensitive-keeps-large
+  (let [rendered (local-render/local-render-value app-db-value secure-frame)]
+    (testing "(1) the frame-declared sensitive slot is REDACTED under the
+              on-box default (:rf.egress/local-redacted)"
+      (is (= :rf/redacted (get-in rendered [:auth :token]))
+          "the sensitive token must redact in the local render default"))
+
+    (testing "non-sensitive siblings + structure ride through"
+      (is (= 42 (get-in rendered [:auth :user-id])) "non-sensitive sibling kept")
+      (is (= {:open? true :tab :home} (:ui rendered)) "unrelated subtree kept"))
+
+    (testing "(2) the frame-declared LARGE slot is NOT elided on-box — the
+              local operator sees big values; only secrets are withheld
+              (the include-large? overlay)"
+      (is (= (vec (range 300)) (get-in rendered [:catalog :rows]))
+          "a large value renders raw on-box (display-only size bounding is
+           the edn-inspector's job, not an egress redaction)"))))
+
+;; ---------------------------------------------------------------------------
+;; 3. per-frame — projection uses the OBSERVED frame's policy, not a borrowed one.
+;; ---------------------------------------------------------------------------
+
+(deftest local-render-applies-the-observed-frames-policy
+  (testing "under the SECURE frame the sensitive token redacts"
+    (is (= :rf/redacted
+           (get-in (local-render/local-render-value app-db-value secure-frame)
+                   [:auth :token]))))
+  (testing "under the PLAIN frame (no sensitive decl) the SAME value renders
+            verbatim — the policy is per-frame, applied from the observed
+            frame, never borrowed or ambient"
+    (is (= "secret-session-jwt-abc123"
+           (get-in (local-render/local-render-value app-db-value plain-frame)
+                   [:auth :token]))
+        "no sensitive decl on :app/plain ⇒ the value renders raw")))
+
+;; ---------------------------------------------------------------------------
+;; 4. `:rf.egress/local-raw` opt-in — the trusted-local per-(tool,frame) grain.
+;; ---------------------------------------------------------------------------
+
+(deftest local-raw-opt-in-reveals-sensitive
+  (testing "the redacted default suppresses the sensitive slot"
+    (is (= :rf/redacted
+           (get-in (local-render/local-render-value app-db-value secure-frame false)
+                   [:auth :token]))))
+  (testing "the explicit trusted-local :rf.egress/local-raw grain (raw? true)
+            reveals it — an operator act, not the process-global default"
+    (is (= "secret-session-jwt-abc123"
+           (get-in (local-render/local-render-value app-db-value secure-frame true)
+                   [:auth :token]))
+        "raw? true resolves to :rf.egress/local-raw which includes sensitive"))
+  (testing "the profile resolver maps the grain to the named boundary"
+    (is (= :rf.egress/local-redacted (local-render/local-render-profile false)))
+    (is (= :rf.egress/local-redacted (local-render/local-render-profile nil)))
+    (is (= :rf.egress/local-raw (local-render/local-render-profile true)))))
+
+;; ---------------------------------------------------------------------------
+;; 5. fail-closed — an UNREACHABLE observed frame redacts the WHOLE value.
+;; ---------------------------------------------------------------------------
+
+(deftest local-render-fails-closed-on-unreachable-frame
+  (testing "projecting under an unknown / destroyed observed frame redacts the
+            whole value to :rf/redacted rather than ship it raw under no policy"
+    (is (= :rf/redacted
+           (local-render/local-render-value app-db-value :app/does-not-exist))
+        "frameless local-redacted render fails closed (no :frame opt ⇒ the
+         walker's frameless redact-whole branch)"))
+  (testing "a nil observed frame likewise fails closed"
+    (is (= :rf/redacted (local-render/local-render-value app-db-value nil))))
+  (testing "the live frame is carried as the :frame opt; an unreachable one is
+            omitted so the walker fails closed"
+    (is (= secure-frame (:frame (local-render/local-render-opts secure-frame))))
+    (is (not (contains? (local-render/local-render-opts :app/does-not-exist) :frame)))
+    (is (= :rf.egress/local-redacted
+           (:rf.egress/profile (local-render/local-render-opts secure-frame))))
+    (is (true? (:rf.size/include-large? (local-render/local-render-opts secure-frame)))
+        "the keep-large overlay is always present")))
+
+;; ---------------------------------------------------------------------------
+;; 6. end-to-end — the App-DB Diff section-model derivation redacts a sensitive
+;;    slot, so what the panel hands the edn-inspector is already projected.
+;;
+;; Replicates the `:rf.xray/app-db-state` sub's body exactly (project the
+;; observed-frame value through `local-render-value`, then decompose into the
+;; section model via `current-state-sections`) — exercising the integrated
+;; project-then-section path the panel renders without standing up the full
+;; reactive Xray sub graph.
+;; ---------------------------------------------------------------------------
+
+(deftest app-db-state-section-model-redacts-sensitive-under-observed-frame
+  (let [observed-frame secure-frame
+        ;; The exact projection the `:rf.xray/app-db-state` sub applies.
+        projected (local-render/local-render-value app-db-value observed-frame)
+        {:keys [top]} (h/current-state-sections projected nil)]
+    (testing "the TOP (user-domain) section's sensitive slot is redacted in the
+              model the panel hands to the edn-inspector"
+      (is (= :rf/redacted (get-in top [:auth :token]))
+          "the section model is projected through :rf.egress/local-redacted"))
+    (testing "non-sensitive + large slots survive the section-model projection"
+      (is (= 42 (get-in top [:auth :user-id])))
+      (is (= (vec (range 300)) (get-in top [:catalog :rows]))
+          "large stays on-box; only the secret is withheld")))
+
+  (testing "under a plain frame the section model renders the value verbatim"
+    (let [projected (local-render/local-render-value app-db-value plain-frame)
+          {:keys [top]} (h/current-state-sections projected nil)]
+      (is (= "secret-session-jwt-abc123" (get-in top [:auth :token]))
+          "no sensitive decl ⇒ section model is unredacted"))))


### PR DESCRIPTION
Closes the EP-0015 issue-3 graduation gap: `:rf.egress/local-redacted` was the one of six `:rf.egress/*` profiles defined + unit-tested in `re-frame.projection` with **no on-box-dev-tool consumer** naming it as its render default. Xray is the graduation consumer the [spec/015 §The graduation gate](../blob/main/spec/015-Data-Classification.md#the-graduation-gate) row requires.

## What changed

- **New shared seam** `day8.re-frame2-xray.panels.local-render/local-render-value` — projects a frame-sourced value through `re-frame.core/project-egress` under the on-box dev-UI default `:rf.egress/local-redacted` (or `:rf.egress/local-raw` via the per-(tool,frame) `raw?` opt-in grain).
- **App-DB panel wired** — `:rf.xray/app-db-state` projects every value-bearing partition (app-db `value`/`before` + runtime-db `runtime-value`/`runtime-before`) keyed on the observed frame, before decomposing into the section model.

The contract:
- **suppress sensitive display by default** — a frame-declared `:sensitive` slot becomes the `:rf/redacted` sentinel the edn-inspector already paints as a first-class chip;
- **keep large on-box** — the local operator may see big values (explicit `:rf.size/include-large? true` overlay over the profile floor); on-box size bounding is the inspector's display concern, not egress;
- **per-frame** — applied from the observed frame's own classification; value AND diff pre-image projected under the same policy, so the inline `← was X` annotation never reconstructs the redacted content;
- **fail-closed** — an unreachable observed frame redacts the whole value rather than ship it raw under no policy.

Revealing sensitive values is the per-(tool,frame) `:rf.egress/local-raw` operator opt-in (EP-0015 §Cross-tool visibility grain), **not** a process-global toggle. This is the on-box analogue of the off-box redaction call site `derivation-graph-helpers/redact-graph-for-egress` (rf2-yjarv6).

- **Spec:** flipped the spec/015 graduation-gate row to ✅ exercised (all six profiles now have a real consumer → the EP can move `accepted` → `final`); documented the on-box local-render egress policy in `tools/xray/spec/004-App-DB-Diff.md`.
- **Test:** the graduation proof — the local-render default redacts a frame-declared sensitive slot while keeping large + structure; per-frame, local-raw opt-in, fail-closed, and end-to-end section-model arms.

## Quality gates

| Gate | Result |
|---|---|
| `clojure -M:test` (xray artefact) | ✅ 1150 tests, 5073 assertions, 0 failures |
| new `local-render-cljs-test` (JVM) | ✅ 5 tests, 21 assertions, 0 failures |
| `npm run test:cljs` | ✅ 6823 tests, 27693 assertions, 0 failures |
| `npm run test:xray-feature-gate` | ✅ 16 scenarios, 0 failures (13 matrix rows) |
| `npm run test:bundle-isolation` | ✅ xray not leaked into prod (22 entries, 40 sentinels absent) |

rf2-t55hxg.12
