### PR TITLE
test+docs: EP-0015 schema-prop :large?/:params-schema coverage + schema-declared spelling sweep (rf2-t55hxg.5 + rf2-r5r98f)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/view_rendered_op_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_rendered_op_cljs_test.cljs
@@ -179,7 +179,7 @@
    arbitrary user data, so :rf.view/render-args routes through the SAME
    emit-time elision chokepoint as :rf.event/db — the marks projection runs
    `elide-wire-value` against the frame's app-db elision registry. A
-   schema-declared `{:sensitive? true}` path inside a render arg reaches the
+   frame-declared `:sensitive` app-db path inside a render arg reaches the
    trace surface as :rf/redacted, never raw."
     (with-trace-recorder! [traces {:pred view-rendered-pred}]
       ;; EP-0015 §8 (rf2-d2r3um): durable app-db classification is frame-owned.

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1467,12 +1467,15 @@
      :emit-event   (if (seq all-paths)
                      (privacy/redact-event (:event envelope) all-paths)
                      (:event envelope))
-     ;; `:schema-sensitive?` strictly tracks the schema-declared
-     ;; sensitive path overlap — it drives the scope-meta `:sensitive?`
-     ;; stamp on every emitted trace event. User `redact-interceptor` does
-     ;; NOT stamp `:sensitive?`; sensitivity is path-marked via the
-     ;; schema-slot meta (the handler-meta annotation has been
-     ;; removed).
+     ;; `:schema-sensitive?` (a RETAINED key name, like the
+     ;; `schema-redaction-paths` fn it derives from — see
+     ;; `re-frame.privacy`) strictly tracks the FRAME-DECLARED sensitive
+     ;; path overlap (EP-0015 §3/§8 — the `:sensitive {:app-db …}` frame
+     ;; classification registry, no longer schema-attached slot props). It
+     ;; drives the scope-meta `:sensitive?` stamp on every emitted trace
+     ;; event. User `redact-interceptor` does NOT stamp `:sensitive?`;
+     ;; sensitivity is path-marked via the frame's app-db classification
+     ;; (the handler-meta annotation has been removed).
      :schema-sensitive? (boolean (seq redaction-paths))}))
 
 (defn- run-chain

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -1502,7 +1502,7 @@
   data, so :rf.view/render-args routes through the SAME emit-time elision
   chokepoint as every other user-data trace payload — the marks projection
   runs `elide-wire-value` against the frame's app-db elision registry. A
-  schema-declared `{:sensitive? true}` path inside a render arg must reach
+  frame-declared `:sensitive` app-db path inside a render arg must reach
   the trace surface as the `:rf/redacted` sentinel, never raw. Marks
   artefact must be loaded for this to apply; substrate-agnostic."
   [{:keys [substrate-kw name]}]

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -393,7 +393,7 @@
   ;; A declared `:large?` path inside a sub-cache `:value` emits the
   ;; `:rf.size/large-elided` marker. The marker's `:path` is the actual
   ;; walked-from-root path so the agent's follow-up `get-path` can drill
-  ;; in directly. Mirrors the schema-declared :large? coverage above,
+  ;; in directly. Mirrors the frame-declared :large? coverage above,
   ;; but with sub-cache-shaped input.
   (let [path     [[:user/uploaded] :value :pdf]
         frame-id :rf/default

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -11,7 +11,7 @@
                           Delegates the cascade-buffer walks to
                           `re-frame.epoch.capture`.
     2. `sensitive-rollup` — computes `:rf.epoch/sensitive?` from raw
-                          signals (trace-event stamps + schema-declared
+                          signals (trace-event stamps + frame-declared
                           sensitive paths).
     3. `apply-redact-fn` — runs the installed `:redact-fn` advanced
                           override at the OFF-BOX EGRESS boundary only
@@ -194,7 +194,7 @@
 ;;   1. The captured trace stream already stamps `:sensitive?` per
 ;;      handler-meta scope — if any event in `:trace-events` carries the
 ;;      stamp, the record's cascade involved sensitive material.
-;;   2. The frame's schema-declared `[:rf.runtime/elision :sensitive-declarations]`
+;;   2. The frame's frame-declared `[:rf.runtime/elision :sensitive-declarations]`
 ;;      registry names paths that hold sensitive data; if any such path
 ;;      resolves to a non-nil leaf in `:db-before` or `:db-after`, the
 ;;      record's app-db state carries sensitive material.
@@ -212,9 +212,10 @@
   (boolean (some privacy/sensitive? events)))
 
 (defn- sensitive-paths-for
-  "Return the schema-declared sensitive paths for `frame-id`. Empty when
-  no schema layer is registered or when no slot carries
-  `{:sensitive? true}`."
+  "Return the frame-declared sensitive paths for `frame-id`. Empty when
+  the frame declares no `:sensitive {:app-db …}` classification (EP-0015
+  §3/§8 — the `[:rf.runtime/elision :sensitive-declarations]` registry is
+  frame-owned, not schema-populated)."
   [frame-id]
   (try (keys (elision/sensitive-declarations frame-id))
        (catch #?(:clj Throwable :cljs :default) _ nil)))
@@ -236,14 +237,14 @@
   "Compute the record-level `:rf.epoch/sensitive?` rollup for the
   assembled record. Returns `true` when the record's content overlaps
   a sensitive area — either via a stamped trace event or via a
-  schema-declared sensitive path that holds a non-nil leaf in the
+  frame-declared sensitive path that holds a non-nil leaf in the
   recorded db. Returns `false` otherwise (always a strict boolean —
   consumers branch on `(true? ...)` / `(false? ...)`).
 
   HOT PATH: fires once per dequeued event (rf2-nj6p7). `sensitive-paths-for` derefs
   the elision registry once; the leaf check short-circuits at the
   first non-nil hit; the trace-event check short-circuits at the first
-  stamped event. For the common case (no schema-declared sensitive
+  stamped event. For the common case (no frame-declared sensitive
   paths, no sensitive handlers in scope) the cost is one keys-of-empty
   call plus two sequence-with-no-work walks."
   [frame-id db-before db-after events]
@@ -258,7 +259,7 @@
 ;;
 ;; Per Security.md §Epoch privacy posture and rf2-dl3gx (follow-on to
 ;; rf2-bz1cl's Xray-side heuristic chip): the record carries a
-;; top-level integer count of schema-declared sensitive paths
+;; top-level integer count of frame-declared sensitive paths
 ;; (`[:rf.runtime/elision :sensitive-declarations]`) whose value differs between
 ;; `:db-before` and `:db-after`. Computed inside `build-record` from RAW
 ;; values BEFORE the installed `:redact-fn` runs — parallel to the
@@ -275,7 +276,7 @@
 ;; sees an empty diff body and no signal that anything happened.
 ;;
 ;; The count closes that gap by recording, on the raw record, exactly
-;; how many schema-declared sensitive paths mutated this cascade.
+;; how many frame-declared sensitive paths mutated this cascade.
 ;; Downstream consumers (Xray's `redacted-paths-modified` chip per
 ;; `tools/xray/spec/004-App-DB-Diff.md`, MCP wire pipeline, story
 ;; recorders) read the integer directly rather than re-deriving from
@@ -286,7 +287,9 @@
 ;;
 ;; A path P counts when:
 ;;   1. P appears in `sensitive-paths-for frame-id`
-;;      (schema-declared via `{:sensitive? true}` props per Spec 015).
+;;      (frame-declared via `:sensitive {:app-db …}` on `reg-frame` —
+;;      EP-0015 §3/§8; the app-db elision registry is frame-owned, no
+;;      longer populated from schema `{:sensitive? true}` props).
 ;;   2. `(not= (get-in db-before P) (get-in db-after P))`.
 ;;
 ;; The check uses **value-equality** on the raw (pre-redact-fn) dbs.
@@ -296,15 +299,15 @@
 ;;
 ;; ## What this does NOT cover
 ;;
-;; - `:redact-fn` substitutions at NON-schema-declared paths. The
+;; - `:redact-fn` substitutions at NON-frame-declared paths. The
 ;;   redact-fn is opaque (record-in, record-out); the framework cannot
 ;;   inspect "would the fn redact this leaf?" without running it. The
-;;   schema-declared sensitive-paths set is the framework's authoritative
+;;   frame-declared sensitive-paths set is the framework's authoritative
 ;;   "what would be redacted" oracle — apps that install a redact-fn
-;;   pointing at non-schema paths get the schema-declared count, not a
-;;   superset. (In practice apps either declare sensitive props on
-;;   schemas or run a redact-fn covering the same paths; the two
-;;   surfaces compose at the schema-declaration site.)
+;;   pointing at non-declared paths get the frame-declared count, not a
+;;   superset. (In practice apps either declare sensitive paths on the
+;;   frame or run a redact-fn covering the same paths; the two surfaces
+;;   compose at the frame-declaration site.)
 ;; - Paths nominated as sensitive but with no live leaf (`nil` on both
 ;;   sides) — `(= nil nil)` is true, so the path doesn't count. A
 ;;   transition from non-nil to nil (or vice versa) counts as a value
@@ -316,19 +319,19 @@
 (defn redacted-modified-paths-count
   "Compute the record-level `:rf.epoch/redacted-modified-paths-count`
   rollup for the assembled record. Returns the integer count of
-  schema-declared sensitive paths whose value differs between
+  frame-declared sensitive paths whose value differs between
   `db-before` and `db-after` (per rf2-dl3gx).
 
   HOT PATH: fires once per dequeued event (rf2-nj6p7). `sensitive-paths-for` derefs
   the elision registry once and the walk is O(P) where P is the
   declared-sensitive-path count for the frame — typically a small
   constant (apps declare a handful of `[:auth :password]`-shaped
-  paths). For the common case (no schema-declared sensitive paths)
+  paths). For the common case (no frame-declared sensitive paths)
   the cost is one keys-of-empty call and an empty-reduce.
 
   Returns `0` when:
-    - No paths are declared sensitive (no schema layer / no
-      `{:sensitive? true}` props), OR
+    - No paths are declared sensitive (the frame declares no
+      `:sensitive {:app-db …}` classification), OR
     - No declared-sensitive path's value differs across the cascade.
 
   Halted records: `db-before` and/or `db-after` may be `nil` on the
@@ -382,8 +385,8 @@
    ;; PROJECTION (`(:rf.db/app frame-state-…)`) so pair tools can render
    ;; app-db diffs cheaply without re-projecting (Spec-Schemas
    ;; §`:rf/epoch-record`). The two `db-*` projections are also what the
-   ;; sensitive-path rollup + redacted-modified count read — schema-declared
-   ;; sensitive declarations target app-db paths (Spec 015), so the rollup
+   ;; sensitive-path rollup + redacted-modified count read — frame-declared
+   ;; sensitive declarations target app-db paths (EP-0015 §3/§8), so the rollup
    ;; reasons over the app-db projection, not the whole frame-state.
    ;;
    ;; Per rf2-v0jwt §Outcomes — :outcome is required and pins the
@@ -428,7 +431,7 @@
          ;; the app-db projection (`db-before` / `db-after`).
          sensitive? (sensitive-rollup frame-id db-before db-after events)
          ;; Per rf2-dl3gx and Security.md §Epoch privacy posture: the
-         ;; record-level integer counter of schema-declared sensitive
+         ;; record-level integer counter of frame-declared sensitive
          ;; paths whose value differs between :db-before / :db-after.
          ;; Closes Xray's "redact-fn ⇒ empty diff but something changed"
          ;; gap by surfacing the suppressed signal directly on the

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -987,7 +987,7 @@
   FULL pending `:db` value under `:tags :rf.event/db`. The bulk
   `project-payload-slot` above walks `:trace-events` as a single root —
   its path tracker treats the nested `:db` value as `[<i> :tags
-  :rf.event/db :a :b …]`, so schema-declared sensitive paths like
+  :rf.event/db :a :b …]`, so frame-declared sensitive paths like
   `[:auth :password]` do NOT match (the walker expects them rooted at
   the frame's app-db).
 
@@ -1291,7 +1291,7 @@
     2. **`:redact-fn` advanced override.** If the app installed a
        `(rf/configure! :epoch-history {:redact-fn …})`, it is applied to
        the already-projected record (`assembly/apply-redact-fn`) as the
-       rare advanced escape for material the schema-driven projection
+       rare advanced escape for material the frame/profile projection
        cannot prove. It runs ONLY here, on the off-box egress copy — the
        ring stays raw (post-EP-0010 causal replay material), so the fn can
        never affect `restore-epoch` fidelity.
@@ -1360,7 +1360,7 @@
   After the frame/profile projection lands, the installed `:redact-fn`
   advanced override (`assembly/apply-redact-fn`) runs over the PROJECTED
   record (EP-0015 §15 + open-issue 6, RULED) — the rare escape for
-  material the schema-driven projection cannot prove. A throwing override
+  material the frame/profile projection cannot prove. A throwing override
   emits `:rf.warning/epoch-redact-fn-exception` and falls back to the
   projected record. When no `:redact-fn` is installed it is an identity
   pass-through (the common case).

--- a/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_trace_events_test.clj
@@ -7,7 +7,7 @@
   `:rf.event/db-pending-post-flow` (t2) trace events each carry the FULL
   pending app-db value under `:tags :rf.event/db`. The bulk
   `elide-wire-value` walk over `:trace-events` treats that nested db as
-  rooted at `[<i> :tags :rf.event/db ...]`, so a schema-declared sensitive
+  rooted at `[<i> :tags :rf.event/db ...]`, so a frame-declared sensitive
   path like `[:auth :password]` does NOT match (the walker expects it
   rooted at the frame's app-db). `reroot-trace-event-db-slots` re-roots the
   walk at the frame's app-db (`{:path []}`) so the sensitive / large
@@ -26,7 +26,7 @@
   DEFENCE-IN-DEPTH note (verified against `re-frame.marks/project-db-tags`,
   rf2-6773q): when the frame HAS elision declarations, the t1/t2
   `:rf.event/db` tag is ALSO redacted at EMIT time, so the on-ring trace
-  already carries `:rf/redacted` for schema-declared paths. The egress
+  already carries `:rf/redacted` for frame-declared paths. The egress
   re-root is therefore the redaction site for records whose tag was NOT
   emit-redacted — a raw record fed to `projected-record` directly, or a
   frame whose declarations were registered after the record was captured —
@@ -170,7 +170,7 @@
                   t-evts)
           "every projected t1/t2 trace's nested :rf.event/db sensitive leaf
            is :rf/redacted (or absent) — the re-root matched the
-           schema-declared path")
+           frame-declared path")
       (is (not (contains-secret? projected))
           "the raw secret appears NOWHERE in the projected record — not in
            :db-after, not nested inside any :trace-events :rf.event/db tag"))))
@@ -241,7 +241,7 @@
   (testing "the re-root is SCOPED to the t1/t2 ops: a non-t1/t2 trace event
             whose tags carry a value at a NON-app-db-rooted path is NOT
             re-rooted (the bulk walk handles it at its real root, where the
-            schema-declared [:auth :password] does not match)"
+            frame-declared [:auth :password] does not match)"
     (rf/reg-frame :test/eg2 {})
     (install-sensitive-schema! :test/eg2)
     (let [;; A non-t1/t2 op carrying a nested map at a slot that is NOT the

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -111,7 +111,7 @@
     - :seed — non-sensitive bookkeeping
     - :login — writes the sensitive path (secret value closed-over in the
               handler so it never appears in the trigger-event vector;
-              the schema-declared sensitive path is the only sensitive
+              the frame-declared sensitive path is the only sensitive
               leaf the projection's wire-elision walker can match
               against, not arbitrary positional event args)
     - :upload — writes the large path (large payload closed-over in the
@@ -332,7 +332,7 @@
           thrice (mapv epoch/projected-record twice)
           ;; The :upload cascade is the third one driven (index 2):
           ;; that record is the one whose :db-after carries the large
-          ;; payload at the schema-declared `[:blob :payload]` slot.
+          ;; payload at the frame-declared `[:blob :payload]` slot.
           large-slot (fn [r] (get-in r [:db-after :blob :payload]))]
       (is (elision/marker? (large-slot (nth once 2)))
           "first projection pass substitutes a marker at the large slot")

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -4,7 +4,7 @@
 
     1. The record-level :rf.epoch/sensitive? rollup — true when any
        captured trace event carries the :sensitive? stamp OR any
-       schema-declared sensitive path holds a non-nil leaf in
+       frame-declared sensitive path holds a non-nil leaf in
        :db-before / :db-after; false otherwise.
 
     2. re-frame.epoch/projected-record + projected-history — the
@@ -102,7 +102,7 @@
 ;; ---- 1. sensitive rollup ---------------------------------------------------
 
 (deftest rollup-false-on-non-sensitive-cascade
-  (testing "no sensitive handler, no schema-declared sensitive path —
+  (testing "no sensitive handler, no frame-declared sensitive path —
             rollup reads strict false"
     (rf/reg-frame :test/main {})
     (rf/reg-event-db :seed (fn [_ _] {:n 0}))
@@ -128,8 +128,8 @@
       (is (false? (:rf.epoch/sensitive? r))
           "rollup reads false — handler-meta annotation no longer drives the stamp"))))
 
-(deftest rollup-true-from-schema-declared-non-nil-leaf
-  (testing "a schema-declared sensitive path that resolves to a non-nil
+(deftest rollup-true-from-frame-declared-non-nil-leaf
+  (testing "a frame-declared sensitive path that resolves to a non-nil
             leaf in :db-after triggers the rollup even when no handler
             in scope is sensitive"
     (rf/reg-frame :test/main {})
@@ -141,7 +141,7 @@
       (is (true? (:rf.epoch/sensitive? r))))))
 
 (deftest rollup-false-when-schema-path-resolves-to-nil
-  (testing "a frame with a schema-declared sensitive path BUT the
+  (testing "a frame with a frame-declared sensitive path BUT the
             recorded :db-before / :db-after carry no value at the path
             — rollup reads false (the declaration is structural; the
             cascade carried no actual sensitive material)"
@@ -255,7 +255,7 @@
 ;; Keep idempotency assertions there; do not duplicate them here (rf2-zymix).
 
 (deftest projected-record-redacts-sensitive-in-db-after
-  (testing "schema-declared sensitive path in :db-after lands as
+  (testing "frame-declared sensitive path in :db-after lands as
             :rf/redacted in the projected record"
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
@@ -293,7 +293,7 @@
           "projected :db-before substitutes :rf/redacted"))))
 
 (deftest projected-record-elides-large-in-db-after
-  (testing "schema-declared :large? path in :db-after lands as a
+  (testing "frame-declared :large? path in :db-after lands as a
             :rf.size/large-elided marker in the projected record"
     (rf/reg-frame :test/main {})
     (install-large-schema! :test/main)
@@ -569,7 +569,7 @@
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
     ;; The login event payload itself is the sensitive value, but the
-    ;; schema-declared sensitive path is :auth/password, not the
+    ;; frame-declared sensitive path is :auth/password, not the
     ;; trigger-event slot. The projection still walks :trigger-event;
     ;; whether the leaf there gets redacted depends on whether the
     ;; walker can find a sensitive declaration matching that path.

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
@@ -9,10 +9,10 @@
 
     1. frame/profile projection — each tree slot through
        `re-frame.projection/project-egress` under
-       `:rf.egress/off-box-observability` (schema-declared sensitive paths
+       `:rf.egress/off-box-observability` (frame-declared sensitive paths
        → `:rf/redacted`, large paths → markers);
     2. `:redact-fn` advanced override — the installed fn applied to the
-       already-projected record (the escape for non-schema-declared
+       already-projected record (the escape for non-frame-declared
        material).
 
   This file pins the cross-surface contract: the two stages compose
@@ -85,7 +85,7 @@
 
 (deftest A-override-runs-after-frame-profile-projection
   (testing "the :redact-fn override observes the ALREADY-PROJECTED record:
-            a schema-declared sensitive path is :rf/redacted by the
+            a frame-declared sensitive path is :rf/redacted by the
             frame/profile stage before the override runs over it. The
             override is the escape for a NON-declared slot the projection
             could not prove."
@@ -115,7 +115,7 @@
             "the override saw :password ALREADY :rf/redacted — it ran after
              the frame/profile projection")
         (is (= :rf/redacted (get-in projected [:db-after :auth :password]))
-            "schema-declared path redacted by the projection")
+            "frame-declared path redacted by the projection")
         (is (= :rf/redacted (get-in projected [:db-after :session :token]))
             "non-declared path scrubbed by the override")
         (is (= "topsecret" (get-in r [:db-after :auth :password]))
@@ -156,7 +156,7 @@
 ;; ============================================================================
 
 (deftest C-projection-redacts-declared-override-redacts-the-rest
-  (testing "the frame/profile projection redacts the schema-declared
+  (testing "the frame/profile projection redacts the frame-declared
             sensitive path; the override redacts a SECOND, non-declared
             path against the same projected map. No double-walk corruption:
             the declared leaf stays :rf/redacted, the override's leaf
@@ -181,7 +181,7 @@
     (let [r         (last-record :test/main)
           projected (epoch/projected-record r)]
       (is (= :rf/redacted (get-in projected [:db-after :auth :password]))
-          "frame/profile projection redacted the schema-declared :password")
+          "frame/profile projection redacted the frame-declared :password")
       (is (= :rf/redacted (get-in projected [:db-after :session :token]))
           "the override redacted the non-declared :token")
       (is (= "alice" (get-in projected [:db-after :public :name]))
@@ -230,7 +230,7 @@
 ;;
 ;; Per Spec-Schemas §`:rf/epoch-record` and Security.md §Epoch privacy
 ;; posture: each assembled record carries an integer count of
-;; schema-declared sensitive paths whose value differs between :db-before
+;; frame-declared sensitive paths whose value differs between :db-before
 ;; and :db-after. Computed inside `build-record` from the RAW dbs (now
 ;; always raw — storage-side redaction was removed). Closes the
 ;; "redact-fn ⇒ empty diff but something changed" gap for projected egress.
@@ -244,7 +244,7 @@
 ;;   G7. Halted record (nil :db-after) — counter handles the nil edge.
 
 (deftest G1-no-sensitive-paths-yields-zero-count
-  (testing "with no schema-declared sensitive paths registered, the
+  (testing "with no frame-declared sensitive paths registered, the
             counter is 0 (the empty-paths short-circuit)."
     (rf/reg-frame :test/main {})
     (rf/reg-event-db :seed (fn [_ _] {:n 0}))
@@ -455,7 +455,7 @@
           "ordering preserved across the projection pass")
 
       (testing "every projected record's password slot is nil or
-                :rf/redacted — the schema-declared path is redacted by the
+                :rf/redacted — the frame-declared path is redacted by the
                 frame/profile projection on every record, regardless of when
                 the override was installed"
         (doseq [r ph]
@@ -487,7 +487,7 @@
 
 (deftest fixpoint-project-twice-equals-project-once
   (testing "the core composition claim: (project (project r)) = (project r).
-            The first projection lands schema-declared sensitive paths on
+            The first projection lands frame-declared sensitive paths on
             :rf/redacted (frame/profile) and the override's leaf on
             :rf/redacted; the second projection finds the same sentinels and
             produces no further change."

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
@@ -23,12 +23,12 @@
 
     2. **`projected-record` applies the override.** The installed
        `:redact-fn` runs on the PROJECTED record (after the frame/profile
-       projection). It sees the projected shape (schema-declared sensitive
+       projection). It sees the projected shape (frame-declared sensitive
        paths already `:rf/redacted`) and is the escape for material the
        projection cannot prove.
 
     3. **`:rf.epoch/sensitive?` rollup is raw-signal-derived.** Computed
-       inside `build-record` from the raw record's schema-declared
+       inside `build-record` from the raw record's frame-declared
        sensitive leaves; it is a trustworthy off-box-branch signal on the
        RAW ring record regardless of any projection-side redaction.
 
@@ -250,15 +250,15 @@
 
 (deftest invariant-2-override-sees-projected-shape
   (testing "the :redact-fn runs AFTER the frame/profile projection, so it
-            observes the projected record — a schema-declared sensitive
+            observes the projected record — a frame-declared sensitive
             path is already :rf/redacted when the override runs. The
             override is the escape for material the projection cannot
-            prove (a non-schema-declared slot)."
+            prove (a non-frame-declared slot)."
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
     (let [observed (atom nil)]
       ;; The override records what it SEES at [:db-after :auth :password]
-      ;; and scrubs a NON-schema-declared slot the projection left raw.
+      ;; and scrubs a NON-frame-declared slot the projection left raw.
       (rf/configure! :epoch-history
                     {:redact-fn (fn [r]
                                   (reset! observed
@@ -277,13 +277,13 @@
       (let [r         (last-record :test/main)
             projected (epoch/projected-record r)]
         (is (= :rf/redacted @observed)
-            "the override observed the schema-declared :password ALREADY
+            "the override observed the frame-declared :password ALREADY
              :rf/redacted by the frame/profile projection (it ran AFTER)")
         (is (= :rf/redacted (get-in projected [:db-after :session :token]))
-            "the override scrubbed the NON-schema-declared slot the
+            "the override scrubbed the NON-frame-declared slot the
              projection could not prove — its purpose as the advanced escape")
         (is (= :rf/redacted (get-in projected [:db-after :auth :password]))
-            "the schema-declared path stays redacted (projection did it)")
+            "the frame-declared path stays redacted (projection did it)")
         (is (= "tok-xyz" (get-in r [:db-after :session :token]))
             "the RAW ring record keeps the non-declared token verbatim")))))
 
@@ -310,7 +310,7 @@
 
 (deftest invariant-3-rollup-on-raw-ring-record
   (testing "the :rf.epoch/sensitive? rollup on the RAW ring record reflects
-            the schema-declared sensitive leaves the cascade touched — a
+            the frame-declared sensitive leaves the cascade touched — a
             trustworthy off-box-branch signal independent of any
             projection-side redaction."
     (rf/reg-frame :test/main {})
@@ -355,7 +355,7 @@
         ;; The projection ran the (throwing) override → warning + fallback.
         (is (= :rf/redacted (get-in projected [:db-after :auth :password]))
             "fallback is the PROJECTED record — the frame/profile projection
-             still redacted the schema-declared path; the throwing override
+             still redacted the frame-declared path; the throwing override
              only forfeited its own additional scrub")
         (is (= "topsecret" (get-in r [:db-after :auth :password]))
             "the RAW ring record is untouched by the throwing override")
@@ -399,7 +399,7 @@
 
 (deftest invariant-5-no-redact-fn-projection-is-plain-frame-profile
   (testing "without a :redact-fn installed, projected-record is exactly the
-            frame/profile projection — no override stage. A schema-declared
+            frame/profile projection — no override stage. A frame-declared
             sensitive path is redacted by the projection; everything else
             passes through."
     (rf/reg-frame :test/main {})
@@ -414,7 +414,7 @@
     (let [r         (last-record :test/main)
           projected (epoch/projected-record r)]
       (is (= :rf/redacted (get-in projected [:db-after :auth :password]))
-          "schema-declared sensitive path redacted by the frame/profile walk")
+          "frame-declared sensitive path redacted by the frame/profile walk")
       (is (= "alice" (get-in projected [:db-after :public :name]))
           "non-sensitive sibling passes through the projection unchanged")
       (is (= "topsecret" (get-in r [:db-after :auth :password]))
@@ -534,7 +534,7 @@
 ;; the :redact-fn override) happens at projection time. These tests pin:
 ;; (a) a back-filled value is RAW in the ring + listener record; (b) the
 ;; projection of that record redacts via the frame/profile projection (a
-;; schema-declared sensitive value) and via the override (a non-declared
+;; frame-declared sensitive value) and via the override (a non-declared
 ;; value); (c) a benign value passes through.
 ;;
 ;; POST-SETTLE-EMIT TECHNIQUE (mirrors epoch_attribution_test): emit the
@@ -593,11 +593,11 @@
 (deftest back-fill-value-redacted-on-projection
   (testing "EP-0015 §15 — the back-filled RAW value is REDACTED when the
             record is projected for off-box egress: the frame/profile
-            projection redacts a schema-declared sub-value, and the
+            projection redacts a frame-declared sub-value, and the
             :redact-fn override can scrub a non-declared one."
     (rf/reg-frame :test/main {})
     (install-sensitive-schema! :test/main)
-    ;; The override scrubs the :secret sub-run's :value (a non-schema-
+    ;; The override scrubs the :secret sub-run's :value (a non-frame-
     ;; declared, non-app-db-rooted slot the projection cannot prove).
     (rf/configure! :epoch-history
                   {:redact-fn (fn [r]

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -349,7 +349,7 @@
           ;; `:input-values` entry is the value at the matching input
           ;; path. The walker reads `[:rf.runtime/elision
           ;; :declarations <path>]` and emits the marker for
-          ;; schema-declared large slots.
+          ;; frame-declared large slots.
           ;;
           ;; Outer `interop/debug-enabled?` gate keeps the elision
           ;; walker out of CLJS prod builds (rf2-drr4z) — Closure

--- a/implementation/http/src/re_frame/http_reply.cljc
+++ b/implementation/http/src/re_frame/http_reply.cljc
@@ -247,11 +247,11 @@
    - `:sensitive?` — Spec 014 §Privacy per-call sensitivity. When true,
                      EVERY wire slot is redacted to the framework sentinel
                      BEFORE the shared walker runs (the coarse escape hatch
-                     for an ad-hoc sensitive request whose payload is not
-                     schema-declared), matching the existing `:rf.http/*`
+                     for an ad-hoc sensitive request whose payload carries no
+                     schema marks), matching the existing `:rf.http/*`
                      trace redaction posture. When false/absent the shared
-                     walker applies the frame's schema-declared
-                     `:sensitive?` / `:large?` policy as usual."
+                     walker applies the frame's frame-declared
+                     `:sensitive?` / `:large?` app-db policy as usual."
   ([reply] (trace-reply reply nil))
   ([reply {:keys [sensitive?] :as opts}]
    (let [;; Per-call sensitivity is the coarse escape hatch — redact every
@@ -266,6 +266,6 @@
                          wire-slots)
                  reply)]
      ;; The shared walker still runs (the EP mandate): on a non-sensitive
-     ;; reply it applies the frame's schema-declared elision; on a
+     ;; reply it applies the frame's frame-declared elision; on a
      ;; pre-redacted one the sentinel passes through untouched.
      (reply/trace-summary reply (dissoc opts :sensitive?)))))

--- a/implementation/http/test/re_frame/http_privacy_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_test.clj
@@ -71,6 +71,37 @@
       ;; defaults are immutable — they apply regardless of extras
       (is (headers/sensitive-header? "Authorization")))))
 
+(deftest frame-cannot-remove-a-built-in-header-default
+  (testing "EP-0015 §3 — the built-in header denylist is IMMUTABLE: a frame's
+            carrier policy is a union-EXTEND of the defaults, never a remove.
+            There is no removal API; the only frame surface is the additive
+            `:sensitive {:http {:headers [..]}}` extras set. Adversarially: a
+            frame that tries to 'declare' a built-in default itself (a no-op
+            redeclaration) cannot DROP it, and extras for unrelated headers
+            leave every default intact — a built-in carrier stays denylisted
+            regardless of what the frame supplies (rf2-t55hxg.5)"
+    ;; a frame whose extras set is non-empty (even if it names a default,
+    ;; which is a harmless redeclaration) cannot turn a default OFF.
+    (let [extras-redeclaring-default #{"authorization"}
+          extras-unrelated          #{"x-honeycomb-team"}
+          extras-empty              #{}]
+      (doseq [extras [extras-redeclaring-default extras-unrelated extras-empty nil]]
+        (is (headers/sensitive-header? "Authorization" extras)
+            "the built-in Authorization default survives every frame extras shape")
+        (is (headers/sensitive-header? "Cookie" extras)
+            "the built-in Cookie default survives every frame extras shape")
+        (is (headers/sensitive-header? "Set-Cookie" extras)
+            "the built-in Set-Cookie default survives every frame extras shape"))
+      ;; redact-headers (the egress chokepoint) honours the same immutability:
+      ;; a built-in default value is scrubbed even when the frame supplies
+      ;; unrelated extras.
+      (let [r (headers/redact-headers
+                {"Authorization" "Bearer abc" "X-Honeycomb-Team" "team-1" "Accept" "json"}
+                extras-unrelated)]
+        (is (= :rf/redacted (get r "Authorization")) "built-in default still redacted")
+        (is (= :rf/redacted (get r "X-Honeycomb-Team")) "frame extra also redacted (extend)")
+        (is (= "json" (get r "Accept")) "an unlisted header rides verbatim")))))
+
 (deftest sensitive-header-tolerates-non-string
   (testing "nil / non-string is not sensitive"
     (is (not (headers/sensitive-header? nil)))

--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -62,6 +62,7 @@
     + Spec-Schemas — EP-0015 bead-plan item 9)."
   (:require [re-frame.elision :as elision]
             [re-frame.late-bind :as late-bind]
+            [re-frame.marks :as marks]
             [re-frame.path :as path]
             [re-frame.privacy :as privacy]
             [re-frame.projection :as projection]
@@ -260,6 +261,18 @@
     (or (extract schema base-path) {})
     {}))
 
+(defn- schema-marks
+  "The per-slot `:sensitive?` / `:large?` classification a `schema` declares,
+  as `{:sensitive {path decl} :large {path decl}}` rooted at `[]`, via the
+  shared schema walker. The common engine behind `data-schema-marks`
+  (resource DATA value) and `params-schema-marks` (resource PARAMS value) —
+  one extraction, two owner surfaces (EP-0015 issue 11: `:data-schema` /
+  `:params-schema` are CO-EQUAL fine-grained surfaces). Empty maps when
+  `schema` is nil or carries no marks. Pure (modulo the memoised walker)."
+  [schema]
+  {:sensitive (extract-paths :schemas/extract-sensitive-paths-from-schema schema [])
+   :large     (extract-paths :schemas/extract-large-paths-from-schema     schema [])})
+
 (defn data-schema-marks
   "The per-slot `:sensitive?` / `:large?` classification a resource /
   mutation `spec`'s `:data-schema` declares for its DATA value, as
@@ -267,9 +280,21 @@
   (`[]`). The fine-grained owner surface (EP-0015 issue 11). Empty maps when
   no `:data-schema` or no marks. Pure (modulo the memoised shared walker)."
   [spec]
-  (let [schema (:data-schema spec)]
-    {:sensitive (extract-paths :schemas/extract-sensitive-paths-from-schema schema [])
-     :large     (extract-paths :schemas/extract-large-paths-from-schema     schema [])}))
+  (schema-marks (:data-schema spec)))
+
+(defn params-schema-marks
+  "The per-slot `:sensitive?` / `:large?` classification a resource /
+  mutation `spec`'s `:params-schema` declares for its PARAMS value, as
+  `{:sensitive {path decl} :large {path decl}}` rooted at the params root
+  (`[]`). The CO-EQUAL fine-grained owner surface to `data-schema-marks`
+  (EP-0015 issue 11, ruled: `:params-schema` is a canonical fine-grained
+  surface alongside `:data-schema`) — extracted through the SAME shared
+  walker, so a `[:account-id {:sensitive? true} :string]` params slot is
+  classified identically to a data slot. Spec 016 §Runtime-subsystem
+  graduation clause 4: \"params, scopes, and data carry the same
+  classification.\" Empty maps when no `:params-schema` or no marks. Pure."
+  [spec]
+  (schema-marks (:params-schema spec)))
 
 (defn data-schema-classifies?
   "True iff `spec`'s `:data-schema` marks ANY slot `:sensitive?` or
@@ -279,6 +304,15 @@
   `project-data`."
   [spec]
   (let [{:keys [sensitive large]} (data-schema-marks spec)]
+    (boolean (or (seq sensitive) (seq large)))))
+
+(defn params-schema-classifies?
+  "True iff `spec`'s `:params-schema` marks ANY slot `:sensitive?` or
+  `:large?`. When true, a `:serialize` entry's scoped-key PARAMS carry a
+  fine-grained classification that must be honoured on the wire — see
+  `project-params`."
+  [spec]
+  (let [{:keys [sensitive large]} (params-schema-marks spec)]
     (boolean (or (seq sensitive) (seq large)))))
 
 ;; ---------------------------------------------------------------------------
@@ -349,3 +383,55 @@
                                  {:frame             frame-id
                                   :rf.egress/profile boundary-profile})
       owner-redacted)))
+
+;; ---------------------------------------------------------------------------
+;; Params projection — the CO-EQUAL fine-grained owner surface for the scoped
+;; key (EP-0015 issue 11; Spec 016 clause 4 "params, scopes, and data carry
+;; the same classification").
+;;
+;; The scoped resource key is `[scope resource-id canonical-params]`. On a
+;; `:serialize` entry (no coarse whole-entry claim) the key rides VERBATIM on
+;; the hydration wire — so without this, a params slot the owner marked
+;; `:sensitive?` via `:params-schema` (e.g. `[:account-id {:sensitive? true}
+;; :string]`) would ride RAW in the wire key even though it is the same
+;; privacy class as the data. `project-params` applies the OWNER's per-slot
+;; `:params-schema` marks to the params component of the key so a marked slot
+;; redacts (`:sensitive?`) / elides (`:large?`) — the SAME walker, sentinel,
+;; and ordering (`sensitive` wins) as `project-data` layer (a). It is
+;; frame-INDEPENDENT (the owner declaration, not frame app-db classification —
+;; resource params do not live at a frame app-db path), so it fires even
+;; frameless. The COARSE whole-entry `:redact` / `:omit` dispositions still
+;; replace the entire params component with an opaque content-addressed digest
+;; (`re-frame.resources.ssr/project-scoped-key`) — this per-slot surface is
+;; the fine-grained complement that fires on a `:serialize` key the coarse
+;; claim leaves verbatim.
+;; ---------------------------------------------------------------------------
+
+(defn project-params
+  "Project a resource entry's scoped-key PARAMS value for egress against the
+  resource `spec`'s OWNER per-slot `:params-schema` marks (EP-0015 issue 11;
+  Spec 016 clause 4). The CO-EQUAL counterpart to `project-data` for the
+  params component of the scoped key:
+
+    - each slot the `:params-schema` marks `:sensitive?` is redacted to the
+      `:rf/redacted` sentinel via `re-frame.privacy/redact-paths`;
+    - each slot it marks `:large?` is elided through the shared
+      `re-frame.elision/elide-wire-value` walker to the
+      `:rf.size/large-elided` marker.
+
+  Both axes go through the SHARED frame-independent
+  `re-frame.marks/redact-with-paths` walker (sensitive → `:rf/redacted`,
+  large → `:rf.size/large-elided`, sensitive wins over large at the same
+  slot) — the SAME walker the HTTP response-body surface
+  (`re-frame.http-privacy-body/classify-decoded`) uses, never a
+  resource-private walker. Frame-INDEPENDENT — the OWNER's declaration fires
+  irrespective of any frame app-db classification (resource params do not
+  live at a frame app-db path). `spec` nil / no `:params-schema` / no marks →
+  `params` rides UNCHANGED (the coarse whole-entry disposition is the
+  separate authority that redacts/omits the whole key — see
+  `re-frame.resources.ssr/project-scoped-key`). Pure."
+  [params spec]
+  (let [{:keys [sensitive large]} (params-schema-marks spec)]
+    (if (or (seq sensitive) (seq large))
+      (marks/redact-with-paths params (keys sensitive) (keys large))
+      params)))

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -235,19 +235,31 @@
   "Project a scoped resource KEY (`[scope resource-id params]`) to its wire
   shape per the resource's `disposition` (Spec 016 clause 4 / rf2-otms75):
 
-    - `:serialize` — the key rides VERBATIM (a non-sensitive, non-large
-      resource: its scope / params are wire-safe, same as its data);
+    - `:serialize` — the key rides with its scope verbatim, but its PARAMS
+      are projected through the resource OWNER's per-slot `:params-schema`
+      classification (`classification/project-params`) so a params slot the
+      owner marked `:sensitive?` / `:large?` does NOT ride raw even though the
+      coarse whole-entry claim leaves the key serialized (EP-0015 issue 11 —
+      the CO-EQUAL fine-grained counterpart to the data surface; Spec 016
+      clause 4 \"params, scopes, and data carry the same classification\").
+      A resource with no `:params-schema` marks rides its params verbatim
+      (the wire-safe default — same as its data);
     - `:redact` / `:omit` — the scope and params are replaced by opaque
       content-addressed `{:rf/redacted <digest>}` tokens so the sensitive /
       large raw identity does NOT ride, while the resource-id (position 1) and
       key DISTINCTNESS are preserved (the digest differs per distinct value).
+      The COARSE whole-entry claim already redacts the WHOLE params component
+      here, so the per-slot `:params-schema` surface is subsumed.
 
   The wire key keeps the `[scope resource-id params]` SHAPE so the client's
   index recompute + refetch plan parse it unchanged (resource-id at position
-  1). PURE."
-  [scoped-key disposition]
+  1). `spec` is the resource owner spec (`registry/resource-meta`), carrying
+  the `:params-schema` marks; nil / no marks → the params ride verbatim on
+  `:serialize`. PURE."
+  [scoped-key disposition spec]
   (if (= :serialize disposition)
-    scoped-key
+    (let [[scope resource-id params] scoped-key]
+      [scope resource-id (classification/project-params params spec)])
     (let [[scope resource-id params] scoped-key]
       [(redact-key-component scope) resource-id (redact-key-component params)])))
 
@@ -388,8 +400,10 @@
             clock-ms (now-ms)
             wired    (into {}
                            (map (fn [[k entry]]
-                                  (let [disposition (entry-classification frame-id k entry)
-                                        wire-key    (project-scoped-key k disposition)]
+                                  (let [resource-id (nth k 1)
+                                        spec        (registry/resource-meta resource-id)
+                                        disposition (entry-classification frame-id k entry)
+                                        wire-key    (project-scoped-key k disposition spec)]
                                     [wire-key (first (project-entry frame-id clock-ms k entry))])))
                            entries)]
         {state/resources-key {:entries wired}})

--- a/implementation/resources/test/re_frame/resources_classification_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_classification_cljs_test.cljc
@@ -123,6 +123,76 @@
       (is (false? (classification/data-schema-classifies? spec))))))
 
 ;; ===========================================================================
+;; 2b. params-schema-marks — the CO-EQUAL fine-grained owner surface (issue 11)
+;; ===========================================================================
+;;
+;; EP-0015 issue 11 names :params-schema co-equal with :data-schema as a
+;; canonical fine-grained owner surface (Spec 015 / Spec 016 clause 4 "params,
+;; scopes, and data carry the same classification"). The audit (rf2-edbj53)
+;; flagged only :data-schema was exercised; this section pins the :params-schema
+;; arm symmetrically (rf2-t55hxg.5).
+
+(deftest params-schema-marks-extract-per-slot-props
+  (testing "per-slot :sensitive? / :large? props on :params-schema are extracted
+            via the SAME shared walker as :data-schema — the co-equal fine-grained
+            owner surface, rooted at the params root"
+    (let [spec {:params-schema [:map
+                                 [:account-id {:sensitive? true} :string]
+                                 [:cursor     {:large? true} :string]
+                                 [:page :int]]}
+          {:keys [sensitive large]} (classification/params-schema-marks spec)]
+      (is (contains? sensitive [:account-id]) "the :sensitive? params slot path is extracted")
+      (is (contains? large [:cursor]) "the :large? params slot path is extracted")
+      (is (not (contains? sensitive [:page])) "a plain params slot is not classified")
+      (is (true? (classification/params-schema-classifies? spec))
+          "params-schema-classifies? is true when any params slot is marked"))))
+
+(deftest params-schema-marks-empty-without-schema-or-marks
+  (testing "no :params-schema, or a schema with no marks → empty maps, classifies? false"
+    (is (= {:sensitive {} :large {}} (classification/params-schema-marks {})))
+    (let [plain {:params-schema [:map [:slug :string]]}]
+      (is (= {} (:sensitive (classification/params-schema-marks plain))))
+      (is (= {} (:large (classification/params-schema-marks plain))))
+      (is (false? (classification/params-schema-classifies? plain))))))
+
+(deftest project-params-redacts-sensitive-and-elides-large
+  (testing "EP-0015 issue 11: project-params applies the owner's per-slot
+            :params-schema marks — :sensitive? slots redact to the :rf/redacted
+            sentinel, :large? slots elide to the :rf.size/large-elided marker,
+            plain slots ride verbatim — via the SHARED redact-with-paths walker,
+            frame-independently"
+    (let [spec {:params-schema [:map
+                                [:account-id {:sensitive? true} :string]
+                                [:cursor     {:large? true} :string]
+                                [:page :int]]}
+          out  (classification/project-params
+                 {:account-id "acct-secret-42" :cursor (apply str (repeat 200 "x")) :page 3}
+                 spec)]
+      (is (= privacy/redacted-sentinel (:account-id out))
+          "the :sensitive? params slot is redacted")
+      (is (contains? (:cursor out) :rf.size/large-elided)
+          "the :large? params slot is elided to the size marker")
+      (is (= 3 (:page out)) "the plain params slot rides verbatim")
+      (is (not (str/includes? (pr-str out) "acct-secret-42"))
+          "the raw sensitive params value does not ride"))))
+
+(deftest project-params-sensitive-wins-over-large
+  (testing "a params slot marked BOTH :sensitive? and :large? redacts (sensitive
+            wins over large — the shared walker ordering, same as data + HTTP body)"
+    (let [spec {:params-schema [:map [:token {:sensitive? true :large? true} :string]]}
+          out  (classification/project-params {:token (apply str (repeat 100 "z"))} spec)]
+      (is (= privacy/redacted-sentinel (:token out))
+          "sensitive wins — the slot is the redaction sentinel, not a large marker"))))
+
+(deftest project-params-no-marks-rides-verbatim
+  (testing "a spec with no :params-schema marks (or nil spec) rides params
+            UNCHANGED — the coarse whole-entry disposition is the separate
+            authority that redacts/omits the whole key"
+    (is (= {:slug "x"} (classification/project-params {:slug "x"}
+                                                      {:params-schema [:map [:slug :string]]})))
+    (is (= {:slug "x"} (classification/project-params {:slug "x"} nil)))))
+
+;; ===========================================================================
 ;; 3. project-data — defer to the merged frame-owned project-egress
 ;; ===========================================================================
 
@@ -257,6 +327,31 @@
       (is (= "Alice" (get-in we [:data :name])) "the unmarked sibling rides verbatim")
       (is (not (str/includes? (pr-str we) "4111-1111-1111-1111"))
           "no raw owner-marked value rides on the wire"))))
+
+(deftest ssr-serialize-entry-redacts-owner-params-schema-sensitive-slot-in-key
+  (reg! :report/by-account {:params-schema [:map
+                                            [:account-id {:sensitive? true} :string]
+                                            [:slug :string]]})
+  (testing "EP-0015 issue 11 END-TO-END: a :serialize resource whose
+            :params-schema marks a params slot :sensitive? must NOT ride that
+            slot RAW in the projected wire KEY — the params surface is co-equal
+            with the data surface (Spec 016 clause 4). The coarse claim leaves
+            the key serialized, so the per-slot params classification is the
+            only thing standing between the secret and every SSR visitor's wire"
+    (let [k   (state/scoped-resource-key :rf.scope/global :report/by-account
+                                         {:account-id "acct-secret-42" :slug "q3"})
+          e   (entry {:resource-id :report/by-account :data {:total 99}})
+          [wk we] (only-wire-entry (ssr/project-resources-runtime-db (runtime-db-with {k e})))]
+      (is (= :serialize (classification/whole-entry-disposition
+                          (rf/resource-meta :report/by-account)))
+          "no coarse claim → :serialize (the per-slot params mark is the surface)")
+      (is (= :report/by-account (nth wk 1)) "resource-id preserved (position 1)")
+      (is (= privacy/redacted-sentinel (get-in wk [2 :account-id]))
+          "the owner-marked :account-id params slot is redacted in the wire key")
+      (is (= "q3" (get-in wk [2 :slug])) "the unmarked params sibling rides verbatim")
+      (is (= {:total 99} (:data we)) "the (unmarked) data rides verbatim — serialize")
+      (is (not (str/includes? (pr-str wk) "acct-secret-42"))
+          "no raw sensitive params value rides in the wire key"))))
 
 ;; ===========================================================================
 ;; 5. load-bearing Spec 016 rules preserved (the projection contract)

--- a/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
@@ -291,14 +291,15 @@
             scope+params, preserve resource-id + distinctness"
     (let [k1 (state/scoped-resource-key :rf.scope/global :r {:a 1})
           k2 (state/scoped-resource-key :rf.scope/global :r {:a 2})]
-      (is (= k1 (ssr/project-scoped-key k1 :serialize)))
-      (let [r1 (ssr/project-scoped-key k1 :redact)
-            r2 (ssr/project-scoped-key k2 :redact)]
+      ;; nil spec → no :params-schema marks → :serialize rides params verbatim.
+      (is (= k1 (ssr/project-scoped-key k1 :serialize nil)))
+      (let [r1 (ssr/project-scoped-key k1 :redact nil)
+            r2 (ssr/project-scoped-key k2 :redact nil)]
         (is (= :r (nth r1 1)) "resource-id preserved")
         (is (contains? (nth r1 2) :rf/redacted))
         (is (not= r1 r2) "distinct params → distinct redacted keys")
-        (is (= r1 (ssr/project-scoped-key k1 :redact)) "deterministic (same input → same digest)")
-        (is (= (ssr/project-scoped-key k1 :redact) (ssr/project-scoped-key k1 :omit))
+        (is (= r1 (ssr/project-scoped-key k1 :redact nil)) "deterministic (same input → same digest)")
+        (is (= (ssr/project-scoped-key k1 :redact nil) (ssr/project-scoped-key k1 :omit nil))
             ":redact and :omit redact the key identically (both metadata-only)")))))
 
 ;; ===========================================================================


### PR DESCRIPTION
EP-0015 graduation-tail beads. Pre-alpha masterpiece posture: CORRECTNESS for the tests, CLARITY for the comments.

## rf2-t55hxg.5 — schema-prop :large? + :params-schema classification coverage

The EP-0015 testing-coverage audit (rf2-edbj53) graded resource-class projection and HTTP response-body classification A-, flagging two missing schema-prop arms.

**Resources `:params-schema` (the real gap).** The audit named `:params-schema` a CO-EQUAL fine-grained owner surface to `:data-schema` (Spec 015 §Resource and mutation durable classification; Spec 016 clause 4 — "params, scopes, and data carry the same classification"). It was declared normative in the spec and the classification ns docstring, but **unwired**: `classification.cljc` only extracted `:data-schema` marks, and a `:serialize` resource's scoped-key params rode **verbatim** on the SSR wire — so a params slot the owner marked `:sensitive?` via `:params-schema` leaked raw in the wire key (a fail-open the coarse whole-entry digest-redaction does not cover on a serialize key). Closed it with the minimal symmetric surface:
- `params-schema-marks` / `params-schema-classifies?` — sharing one `schema-marks` engine with `data-schema-marks` (one extraction, two co-equal owner surfaces).
- `project-params` — over the shared frame-independent `re-frame.marks/redact-with-paths` walker (same walker, sentinel, and sensitive-wins-over-large ordering the HTTP response-body surface uses; never a resource-private walker).
- `ssr/project-scoped-key` now projects the params component of a `:serialize` key through `project-params`.
- Tests: `params-schema-marks` extraction, `params-schema-classifies?`, `project-params` redact / elide / sensitive-wins / no-marks-verbatim, and an end-to-end SSR test proving a sensitive params slot does NOT ride raw in the projected wire key.

**HTTP-body `:large?` (already closed).** The `:large?`-slot tests landed in rf2-t55hxg.6, which postdates the audit's snapshot: `classify-decoded-elides-large-slot`, `classify-decoded-whole-body-large-elides`, `classify-decoded-sensitive-wins-over-large`, `off-box-classify-body-classifies-schema-bodies` all assert the `:rf.size/large-elided` marker on `:decode`-schema bodies. No new test needed.

**LOW-priority adversarial (added).** `frame-cannot-remove-a-built-in-header-default` — the built-in HTTP carrier denylist is an immutable union-EXTEND; a built-in default survives every frame extras shape (redeclare a default / unrelated extras / empty / nil), at both `sensitive-header?` and the `redact-headers` chokepoint.

## rf2-r5r98f — `schema-declared` spelling sweep

Comment/docstring-only rename of the stale `schema-declared` / `schema-driven` spelling for the frame-owned app-db elision registry (`[:rf.runtime/elision :sensitive-declarations]`, now `:source :frame` per EP-0015 §8) to the canonical **frame-declared** spelling, across the EP-0015-adjacent files: `epoch/assembly.cljc`, `epoch/tool_pair.cljc`, `http_reply.cljc`, `flows.cljc`, `core/router.cljc`, plus the lower-priority test prose (`epoch_*_test.clj`, `react_shared_suite.cljs`, `view_rendered_op` test, `elision_test`). The `:schema-sensitive?` key NAME is retained as a compat surface (like the `schema-redaction-paths` fn it derives from); only its stale prose was corrected. Genuine LIVE schema routes left untouched (machine / resource `:data-schema`, HTTP `:decode` body marks, schema-validation-failure-trace redaction). No behaviour change.

## Quality gates
- `npm run test:cljs` — 6824 tests, 27693 assertions, 0 failures, 0 errors
- `resources clojure -M:test` — 354 tests, 1363 assertions, 0/0
- `http clojure -M:test` — 421 tests, 1919 assertions, 0/0
- `epoch clojure -M:test` — 324 tests, 1268 assertions, 0/0
- `flows clojure -M:test` — 197 tests, 4801 assertions, 0/0
- `scripts/check_retired_spellings.py` — clean (exit 0)