### PR TITLE
docs+test(resources): scoped-cache leak-boundary guide + scenarios (rf2-wwhedk)

### DIFF
--- a/docs/guide/27-resources.md
+++ b/docs/guide/27-resources.md
@@ -202,6 +202,46 @@ Logout has a subtle ordering problem: you want to clear the scope the user *was 
 
 Because every resource carries an explicit policy, the old `/me`-URL heuristic is downgraded to a hint. Xray's standing security-review surface is *structural*: it enumerates every `:rf.scope/global` resource (the audit list) and warns about *suspicious* explicit-global resources whose requests look session-dependent. A missing scope is now a loud error, not something a tool compensates for.
 
+## Scope — the leak boundary other libraries do not have
+
+The previous section described *how* re-frame2's scope works. This one is about *what it is*, because it's the one place this chapter makes a claim no competitor can: **re-frame2 is the only server-state library in its class where cache scope is a structural, fail-closed isolation axis — not a convention you have to remember.** That's worth being precise about, because "we have multi-tenancy support" is a thing every library says and almost none enforces.
+
+### The mental model you already have: a viewer id inside the query key
+
+If you've used TanStack Query, RTK Query, SWR, or `shipclojure/re-frame-query`, you already know the shape of the answer. You put viewer identity *inside the query key* so two users' caches don't collide:
+
+```js
+// TanStack Query — the viewer id is one segment of the key, by convention.
+useQuery({ queryKey: ['dashboard', userId, tenantId], queryFn: ... })
+
+// RTK Query — the tag/arg carries the viewer; tenancy lives in the arg.
+useGetDashboardQuery({ tenantId, userId })
+
+// SWR — the viewer is interpolated into the key string.
+useSWR(`/api/dashboard?tenant=${tenantId}&user=${userId}`, fetcher)
+```
+
+This works, and it's the right instinct. The cache key *should* carry the viewer. The problem is **nothing enforces it.** The viewer id is one segment of a key you assemble by hand, in every call site, every time. Forget `tenantId` in one of forty `queryKey`s and that read silently shares one tenant's cache with the next — no error, no warning, just a dashboard showing the previous user's data. The leak is a *missing line*, and a missing line throws no exception. And there's a second seam these libraries don't even have a place to address: **logout.** Clearing "the previous user's cache" is `queryClient.clear()` (a sledgehammer that drops everyone's, including a still-valid global cache) or a hand-maintained list of keys to invalidate (another thing to forget). None of the four benchmarked libraries ships a *scoped* clear, and — verified across their canonical example apps (RealWorld, TodoMVC, Linearlite) — none even *exercises* multi-tenancy. The leak boundary is left as an exercise for the reader.
+
+### The re-frame2 equivalent: the resolved scope *is* a key segment, and it's required
+
+re-frame2 keeps the same mental model — the viewer belongs in the key — and removes the two ways it goes wrong: the *forgotten segment* and the *missing logout clear*. Scope is a **declared policy at registration** (you cannot register a read without saying whose cache it is), it **resolves into the key structurally** (the runtime puts it there, not your call site), it **fails closed** (an unresolvable scope is a loud error, never a silent shared read), and it has a **causal clear** (logout is a first-class scoped operation, not a manual key list). The convention you were *trusting* becomes a guarantee the framework *enforces*. Concretely, the boundary rests on six structural facts, each one already introduced above:
+
+| Guarantee | Mechanism | What it prevents |
+|---|---|---|
+| **Scope is required, declared once** | `:scope` is mandatory at `reg-resource`; no policy is a `:rf.error/resource-missing-scope-policy` registration error. | "I forgot this read is user-scoped." The viewer dimension is unrepresentable as an afterthought — it's stated at the definition site, not assembled per call. |
+| **Scope is *in* the identity** | The [scoped resource key](#resource-identity--the-scoped-key) is `[scope resource-id params]`; the resolved scope is a canonicalized key segment the runtime computes, not a string you concatenate. | The forgotten-segment leak. Two principals' reads of the same params land on two structurally distinct entries — neither is reachable through the other's key. |
+| **Sub-side resolution fails closed** | A subscription resolves its own scope or raises `:rf.error/resource-sub-unresolved-scope` — [never a silent global, never a silent `:idle`](#subscription-side-resolution-the-silent-leak-seam). | The read seam: a view that under-specifies scope can't quietly read a *different* (or shared) principal's entry. The error names the fix. |
+| **Logout is a causal scoped clear** | [`:rf.resource/clear-scope`](#clear-scope-is-causal) removes a *named* scope's entries, releases its owners, suppresses its late replies, and emits a trace of exactly what it touched — leaving every other scope (and global) intact. | The cross-session leak. The next principal's session structurally cannot read the prior one's cache, and clearing one principal never collaterally drops another's (or a still-valid global). |
+| **Invalidation is scoped by default** | [Tag invalidation](#invalidation-by-tag) and [per-target descriptors](#per-target-scoped-invalidation) reach *exactly* the resolved scope; crossing principals is an explicit, audited `:cross-scope? true` escape, visible in Xray. | The cross-tenant blast. A write can't accidentally stale or refetch another tenant's data through a shared tag. |
+| **The boundary is auditable, not heuristic** | Xray enumerates every `:rf.scope/global` resource (the [scope audit surface](#xray-is-defense-in-depth-not-the-boundary)), lists each [named resolver's declared inputs](#named-scope-resolvers--derive-viewer-scope-once), shows the scope-resolution timeline, and runs the [scope-mismatch lint](#subscription-side-resolution-the-silent-leak-seam). | The *un-reviewable* cache. "Which reads cross users?" is a query over declared data, not a code review hoping someone remembered every key segment. |
+
+The shift is from *trust* to *structure*. In a query-key library, "no cross-user leak" is a property of your discipline — true only as long as every developer remembers every segment in every key forever. In re-frame2 it's a property of the *type of the cache key*: the viewer is in the identity, resolution fails closed, and the only way to cross the boundary is the loud, audited escape hatch. A forgotten scope is a registration error; a wrong scope is a fail-closed read with a diagnostic; a logout is one causal event. (These guarantees are pinned as executable conformance tests — the cross-user logout-leak, the wrong-scope fail-closed read, and the scoped-invalidation isolation — in `implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc`, alongside the multi-scope lease-lifecycle non-interference suite.)
+
+### Where this matters, and where it doesn't
+
+This isn't free abstraction tax for a single-tenant app. A genuinely global read — public articles, a shared product catalog, anything where the same params produce the same bytes for every viewer — is `:scope :rf.scope/global`, an explicit one-word claim, and you're done; the boundary machinery costs you nothing. The structural payoff lands the moment your app has *any* viewer-relative server state — a per-user dashboard, a tenant-scoped feed, an impersonation/admin mode, a permission-gated list — which is almost every real app eventually. At that point the question stops being "did I remember the viewer in this key?" (a question you re-answer, fallibly, at every call site) and becomes "is this resource's declared scope correct?" (a question you answer once, at registration, and a tool can audit). That's the differentiator: the leak boundary is part of the cache's structure, so it holds without anyone having to keep holding it up.
+
 ## Status — facts, not derived booleans
 
 Resource state uses [Pattern-RemoteData](../../spec/Pattern-RemoteData.md) semantics, but it *refines* the broad `:error` state into something views never have to disambiguate. The durable entry stores facts; the `:rf.resource/state` sub projects derived booleans. The five statuses:

--- a/implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc
@@ -1,0 +1,327 @@
+(ns re-frame.resources-scope-leak-boundary-cljs-test
+  "The scoped-cache LEAK BOUNDARY as an executable security guarantee
+  (rf2-wwhedk, spun from rf2-s6rviz; guide §\"Scope — the leak boundary other
+  libraries do not have\").
+
+  re-frame2's differentiating proposition: cache SCOPE is a first-class,
+  fail-closed isolation axis. The benchmarked class (TanStack Query, RTK
+  Query, SWR, shipclojure/re-frame-query) puts viewer identity inside a query
+  key / tag BY CONVENTION — nothing structurally stops a forgotten key segment
+  from silently sharing one principal's cache with the next. re-frame2's
+  boundary is STRUCTURAL: the resolved scope is IN the cache key, a sub
+  resolves that scope (or fails closed), logout `clear-scope` removes a
+  principal's entries causally, and a scoped invalidation reaches exactly the
+  resolved scope.
+
+  The lease-lifecycle non-interference property (a held lease on scope A
+  neither pins nor collects scope B's entry) is pinned by
+  `resources_scoped_lease_lifecycle_cljs_test.cljc`; the named-resolver
+  resolution mechanics (event / route / sub / clear-scope / mismatch warning)
+  by `resources_from_db_scope_cljs_test.cljc`; the per-target scoped
+  invalidation engine by `resources_invalidation_descriptors_cljs_test.cljc`.
+
+  What THIS suite pins — the same boundary expressed as the READ-PATH security
+  guarantee those suites do not assert: that NO principal's live subscription
+  can ever observe ANOTHER principal's cached data, across logout, a wrong
+  scope, and a multi-scope invalidation. It asserts at the live `rf/subscribe`
+  read (the seam a real leak would be visible at), not only at the durable
+  entry. The bead's Part-2 leak-boundary scenarios 1/2/3:
+
+    1. LOGOUT clear-scope — after principal A logs out and the session scope is
+       cleared, principal B's next session structurally cannot read A's
+       entries: B's live sub reads B's (un-ensured) idle empty-state, never
+       A's stale-cached data (the cross-user leak test).
+    2. WRONG-but-valid scope — a sub that resolves a DIFFERENT valid scope than
+       the owning ensure reads ITS OWN (empty) entry, never a silent shared
+       read of the other principal's data; under `:rf.scope/from-caller` the
+       mismatch is additionally DIAGNOSABLE (a dev `:rf.warning/resource-sub-
+       scope-mismatch`), and a nil-resolving reference FAILS CLOSED loudly.
+    3. MIXED-scope invalidation — a clear-scope / scoped invalidation reaches
+       EXACTLY the resolved scope's entries and no other principal's, so an
+       invalidation can never cross the principal boundary without the
+       explicit, audited cross-scope escape.
+
+  Dual-target (`.cljc` + `_cljs_test`): the JVM runner picks it up via the
+  `.*-test$` ns regex; Shadow's `:node-test` build via the `cljs-test$` regex.
+  Cross-host so the boundary holds identically server- and client-side."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [re-frame.core :as rf]
+   ;; load-bearing side-effecting requires: register the :rf.resource/* events
+   ;; + subs and the named-resolver scope plumbing.
+   [re-frame.resources]
+   [re-frame.resources.registry]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.subs :as r-subs]
+   [re-frame.resources.test-support]
+   [re-frame.schemas]
+   [re-frame.http-managed]
+   [re-frame.registrar :as registrar]
+   [re-frame.trace.tooling :as trace-tooling]
+   [re-frame.test-support :as core-test-support]
+   #?(:clj  [re-frame.substrate.plain-atom :as substrate]
+      :cljs [re-frame.adapter.reagent :as substrate])))
+
+;; ---- fixture --------------------------------------------------------------
+
+(defn- init!
+  "A default app frame; stub managed-HTTP so ensure never fetches; register a
+  named tenant-scope resolver (db-derived viewer identity, the EP-0016 D3
+  form) plus a tenant-scoped feed resource whose spec :scope is the
+  `{:from-db :t/tenant}` reference. `:t/login` writes the resolver's app-db
+  input (the viewer's tenant id); `:t/logout` removes it."
+  []
+  (rf/reg-frame :rf/default {:url-bound? true
+                             :doc "scope-leak-boundary suite default app frame."})
+  (registrar/clear-kind! :resource-scope)
+  (rf/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf/reg-resource-scope :t/tenant
+    {:inputs  {:tenant [:db [:viewer :tenant-id]]}
+     :resolve (fn [{:keys [tenant]} _ctx]
+                (when tenant [:rf.scope/tenant {:tenant-id tenant}]))})
+  (rf/reg-resource :t/feed
+    {:scope         {:from-db :t/tenant}
+     :params-schema [:map [:page :int]]
+     :request       (fn [{:keys [page]} _ctx]
+                      {:request {:method :get :url "/feed" :params {:page page}}})
+     :tags          (fn [_p _v] #{[:feed]})})
+  (rf/reg-event-db :t/login  (fn [db [_ tenant]] (assoc-in db [:viewer :tenant-id] tenant)))
+  (rf/reg-event-db :t/logout (fn [db _] (update db :viewer dissoc :tenant-id))))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    {:adapter substrate/adapter
+     :init-fn init!}))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- runtime-db [] (rf/runtime-db-value :rf/default))
+(defn- entries [] (get-in (runtime-db) (state/entries-path)))
+(defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
+
+(defn- tenant-key
+  "The scoped feed key for tenant `t`, page `page`."
+  [t page]
+  (state/scoped-resource-key [:rf.scope/tenant {:tenant-id t}] :t/feed {:page page}))
+
+(defn- ensure-feed!
+  "Ensure + load the tenant-scoped feed for tenant `t`, page `page`, under
+  owner `owner`, with `data`. First writes the resolver's app-db input to
+  `t` (a tenant switch / impersonation) so the named resolver yields tenant
+  `t`'s scope at use time, then drives the entry to :loaded."
+  [t page owner data]
+  (rf/dispatch-sync [:t/login t])
+  (rf/dispatch-sync [:rf.resource/ensure {:resource :t/feed :params {:page page}
+                                          :owner owner}])
+  (let [e (entry (tenant-key t page))]
+    (rf/dispatch-sync [:rf.resource.internal/succeeded
+                       {:resource-key (tenant-key t page)
+                        :work/id      (:current-work e)
+                        :generation   (:generation e)
+                        :data         data}])))
+
+;; ===========================================================================
+;; 1. LOGOUT clear-scope — the cross-user leak test.
+;;    After tenant A logs out and its session scope is cleared, tenant B's
+;;    next session structurally cannot read A's entries.
+;; ===========================================================================
+
+(deftest logout-clear-scope-removes-the-prior-principals-entries
+  ;; tenant "acme" logs in, ensures + loads a feed under its tenant scope
+  (ensure-feed! "acme" 1 [:lease :acme 1] {:secret "acme-only"})
+  (is (some? (entry (tenant-key "acme" 1))) "acme's entry loaded under its tenant scope")
+  (testing "logout resolves acme's concrete scope from the pre-transition
+            coeffect db and clear-scope removes every acme entry + owner —
+            the causal logout boundary (Spec 016 §clear-scope is causal)"
+    ;; resolve the concrete scope from the still-current db, THEN clear it,
+    ;; THEN drop the identity — the canonical logout ordering.
+    (let [old-scope (rf/resolve-resource-scope (rf/app-db-value :rf/default) :t/tenant)]
+      (is (= [:rf.scope/tenant {:tenant-id "acme"}] old-scope)
+          "the pre-logout db resolves acme's concrete tenant scope")
+      (rf/dispatch-sync [:rf.resource/clear-scope {:scope old-scope :cause :logout}])
+      (rf/dispatch-sync [:t/logout]))
+    (is (nil? (entry (tenant-key "acme" 1))) "acme's entry was removed by clear-scope")
+    (is (empty? (entries)) "no entry survives acme's scope clear")))
+
+(deftest next-principal-sub-cannot-read-the-logged-out-principals-data
+  ;; THE CROSS-USER LEAK TEST, at the live read. tenant "acme" loads a feed,
+  ;; logs out (scope cleared), then tenant "globex" logs in on the SAME frame
+  ;; and a live sub (scope derived from app-db via the {:from-db} spec policy)
+  ;; reads what globex sees.
+  (ensure-feed! "acme" 1 [:lease :acme 1] {:secret "acme-only"})
+  (let [old-scope (rf/resolve-resource-scope (rf/app-db-value :rf/default) :t/tenant)]
+    (rf/dispatch-sync [:rf.resource/clear-scope {:scope old-scope :cause :logout}])
+    (rf/dispatch-sync [:t/logout]))
+  ;; globex's session now begins on the same frame
+  (rf/dispatch-sync [:t/login "globex"])
+  (let [q   {:resource :t/feed :params {:page 1}}   ;; no :scope — derived from app-db
+        st  (rf/subscribe [:rf.resource/state q])
+        dat (rf/subscribe [:rf.resource/data q])]
+    (testing "globex's live sub resolves GLOBEX's tenant scope and reads its
+              own (un-ensured) idle empty-state — NEVER acme's cleared data.
+              This is the structural property TanStack/RTK/SWR enforce only by
+              convention: the resolved scope is IN the key, so globex's read
+              cannot address acme's entry at all"
+      (is (= :idle (:status @st)) "globex sees idle (no entry under globex's scope)")
+      (is (false? (:has-data? @st)) "no data for globex's un-ensured key")
+      (is (nil? @dat) "globex's :data is nil — never acme's {:secret \"acme-only\"}")
+      (is (nil? (entry (tenant-key "acme" 1))) "acme's entry is gone from the cache")
+      (is (nil? (entry (tenant-key "globex" 1)))
+          "globex has no entry yet — the leak boundary is not a stale-read"))))
+
+(deftest clear-scope-isolates-the-cleared-principal-other-scopes-survive
+  ;; two tenants simultaneously cached; clearing ONE leaves the other intact —
+  ;; logout of acme must not collateral-clear globex.
+  (ensure-feed! "acme"   1 [:lease :acme 1]   {:for "acme"})
+  (ensure-feed! "globex" 1 [:lease :globex 1] {:for "globex"})
+  (is (= #{(tenant-key "acme" 1) (tenant-key "globex" 1)} (set (keys (entries))))
+      "both tenants cached at once")
+  (testing "clearing acme's scope removes ONLY acme's entries — globex's
+            separately-scoped entry + data survive the clear (the leak
+            boundary holds under clear-scope)"
+    (rf/dispatch-sync [:rf.resource/clear-scope
+                       {:scope [:rf.scope/tenant {:tenant-id "acme"}] :cause :logout}])
+    (is (nil? (entry (tenant-key "acme" 1))) "acme cleared")
+    (is (some? (entry (tenant-key "globex" 1))) "globex's entry survives acme's clear")
+    (is (= {:for "globex"} (:data (entry (tenant-key "globex" 1))))
+        "globex's data intact")
+    (is (= #{(tenant-key "globex" 1)} (set (keys (entries))))
+        "exactly globex remains — acme's clear touched nothing of globex's")))
+
+;; ===========================================================================
+;; 2. WRONG-but-valid scope — a sub at the wrong scope reads its OWN entry,
+;;    never a silent shared read; a nil-resolving reference fails closed.
+;; ===========================================================================
+
+(deftest wrong-scope-sub-reads-its-own-empty-entry-never-the-other-principals
+  ;; acme has a loaded feed; a view subscribes with an EXPLICIT — but WRONG —
+  ;; tenant scope (globex's). The wrong-scope read resolves globex's key, which
+  ;; has no entry: it reads idle, NEVER acme's data.
+  (ensure-feed! "acme" 1 [:lease :acme 1] {:secret "acme-only"})
+  (let [wrong-q {:resource :t/feed :params {:page 1}
+                 :scope [:rf.scope/tenant {:tenant-id "globex"}]}
+        st      (rf/subscribe [:rf.resource/state wrong-q])
+        dat     (rf/subscribe [:rf.resource/data wrong-q])]
+    (testing "a wrong-but-valid scope addresses ITS OWN (empty) key — the
+              resolved scope is part of the key, so the wrong-scope sub
+              cannot reach acme's entry. It reads idle, never acme's data"
+      (is (= :idle (:status @st)) "the wrong scope's key has no entry — idle")
+      (is (nil? @dat) "never a silent shared read of acme's {:secret \"acme-only\"}")
+      (is (some? (entry (tenant-key "acme" 1)))
+          "acme's entry is untouched — the wrong-scope read did not address it"))))
+
+(deftest from-caller-wrong-scope-is-diagnosable-not-silent
+  ;; The from-caller footgun: a route/event ensures under scope A; a view
+  ;; subscribes under a DIFFERENT scope. The sub reads :idle forever — correct
+  ;; (fail-closed: never a wrong-principal read) but, under :rf.scope/from-
+  ;; caller, additionally diagnosable via the dev scope-mismatch warning.
+  (rf/reg-resource :t/notes
+    {:scope         :rf.scope/from-caller
+     :params-schema [:map]
+     :request       (fn [_p _ctx] {:request {:method :get :url "/notes"}})})
+  ;; ensure + load acme's notes under acme's explicit scope (an ACTIVE owner)
+  (rf/dispatch-sync [:rf.resource/ensure
+                     {:resource :t/notes :params {}
+                      :scope [:rf.scope/tenant {:tenant-id "acme"}]
+                      :owner [:lease :n 1]}])
+  (let [ka (state/scoped-resource-key [:rf.scope/tenant {:tenant-id "acme"}] :t/notes {})
+        e  (entry ka)]
+    (rf/dispatch-sync [:rf.resource.internal/succeeded
+                       {:resource-key ka :work/id (:current-work e)
+                        :generation (:generation e) :data {:secret "acme-notes"}}]))
+  (testing "a from-caller sub at a DIFFERENT (wrong) scope than the active
+            ensure reads :idle (fail-closed) AND emits the dev-only
+            :rf.warning/resource-sub-scope-mismatch diagnostic — the silent
+            permanent-skeleton footgun is surfaced, never a wrong-principal read"
+    (let [seen (atom [])
+          k    ::mismatch-recorder
+          wrong-q {:resource :t/notes :params {}
+                   :scope [:rf.scope/tenant {:tenant-id "globex"}]}]
+      (r-subs/reset-scope-mismatch-warnings!)
+      (trace-tooling/register-listener!
+        k (fn [ev] (when (= :rf.warning/resource-sub-scope-mismatch (:operation ev))
+                     (swap! seen conj ev))))
+      (try
+        (let [st (rf/subscribe [:rf.resource/state wrong-q])]
+          (is (= :idle (:status @st)) "wrong-scope read is idle (fail-closed)")
+          (is (nil? (:data @st)) "never acme's notes"))
+        (finally (trace-tooling/unregister-listener! k)))
+      ;; the dev build fires the mismatch warning; production elides it. We
+      ;; assert it fired when present, and that the read was fail-closed
+      ;; regardless (the security property does not depend on the warning).
+      (when (seq @seen)
+        (let [w (first @seen)]
+          (is (= :rf.warning/resource-sub-scope-mismatch (:operation w)))
+          (is (= [:rf.scope/tenant {:tenant-id "globex"}] (:sub-scope (:tags w)))
+              "names the wrong subscribed scope")
+          (is (= [:rf.scope/tenant {:tenant-id "acme"}] (:active-scope (:tags w)))
+              "names the active scope the ensure used"))))))
+
+(deftest nil-resolving-sub-scope-fails-closed-loudly
+  ;; A {:from-db} sub whose resolver yields nil (no logged-in viewer) raises
+  ;; the sub-side fail-closed diagnostic — never a silent :idle / global /
+  ;; wrong-entry read. Asserted at the resolution boundary `resolve-scoped-key`
+  ;; (a sub-body throw is otherwise routed to the runtime error path).
+  (testing "a {:from-db} spec-policy sub resolving nil raises
+            :rf.error/resource-sub-unresolved-scope — fail-closed, never a
+            silent shared read"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"resource-sub-unresolved-scope"
+          (r-subs/resolve-scoped-key {:resource :t/feed :params {:page 1}} {})))))
+
+;; ===========================================================================
+;; 3. MIXED-scope invalidation — a scoped invalidation reaches EXACTLY the
+;;    resolved scope, never another principal's, without the audited
+;;    cross-scope escape.
+;; ===========================================================================
+
+(deftest scoped-invalidate-tags-reaches-only-the-named-principal
+  ;; two tenants hold the SAME-tagged feed entry under their own scopes. A
+  ;; scoped invalidation of [:feed] in acme's scope marks ONLY acme stale —
+  ;; globex's same-tagged entry is untouched. Scope is part of the
+  ;; invalidation target, so a tag-invalidation cannot cross the principal
+  ;; boundary (Spec 016 §Scoped invalidation is the default).
+  ;;
+  ;; Both entries are made OWNERLESS after load (release the lease) so the
+  ;; durable :invalidated-at stale marker is observable rather than being
+  ;; cleared by the active-owner refetch the invalidation would otherwise start
+  ;; (Spec 016 §Invalidation 3/4 — owned entries refetch, ownerless go stale).
+  (ensure-feed! "acme"   1 [:lease :acme 1]   {:for "acme"})
+  (ensure-feed! "globex" 1 [:lease :globex 1] {:for "globex"})
+  (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :acme 1]}])
+  (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :globex 1]}])
+  (testing "a scoped :rf.resource/invalidate-tags reaches exactly the resolved
+            scope's entries (acme), never another principal's (globex)"
+    (rf/dispatch-sync [:rf.resource/invalidate-tags
+                       {:scope [:rf.scope/tenant {:tenant-id "acme"}]
+                        :tags  #{[:feed]}
+                        :cause [:test :scoped-invalidate]}])
+    (is (some? (:invalidated-at (entry (tenant-key "acme" 1))))
+        "acme's feed was invalidated (its scope was the target)")
+    (is (nil? (:invalidated-at (entry (tenant-key "globex" 1))))
+        "globex's same-tagged feed was NOT touched — invalidation is scoped, not a cross-user blast")))
+
+(deftest clear-scope-and-invalidation-compose-without-crossing-principals
+  ;; the leak boundary holds across BOTH causal scope operations in one flow:
+  ;; clear acme on logout, then invalidate globex's feed — each reaches only
+  ;; its own principal.
+  (ensure-feed! "acme"   1 [:lease :acme 1]   {:for "acme"})
+  (ensure-feed! "globex" 1 [:lease :globex 1] {:for "globex"})
+  ;; globex ownerless so its :invalidated-at stale marker is observable (an
+  ;; active-owner entry would refetch and clear the marker — §Invalidation 3/4).
+  (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :globex 1]}])
+  (testing "clearing acme then invalidating globex each stays within its own
+            principal — neither operation crosses the boundary"
+    (rf/dispatch-sync [:rf.resource/clear-scope
+                       {:scope [:rf.scope/tenant {:tenant-id "acme"}] :cause :logout}])
+    (rf/dispatch-sync [:rf.resource/invalidate-tags
+                       {:scope [:rf.scope/tenant {:tenant-id "globex"}]
+                        :tags  #{[:feed]}
+                        :cause [:test :scoped-invalidate]}])
+    (is (nil? (entry (tenant-key "acme" 1))) "acme was cleared (logout)")
+    (is (some? (entry (tenant-key "globex" 1))) "globex survives acme's clear")
+    (is (some? (:invalidated-at (entry (tenant-key "globex" 1))))
+        "globex's feed was invalidated in its own scope")
+    (is (= #{(tenant-key "globex" 1)} (set (keys (entries))))
+        "exactly globex remains, marked stale — the two ops never crossed principals")))


### PR DESCRIPTION
Spun from rf2-s6rviz (PR #4012 landed the lease-lifecycle slice + multi-scope non-interference test). This delivers the **non-hot-zone remainder**: the guide positioning section and the remaining Part-2 leak-boundary test scenarios.

## What changed

**`docs/guide/27-resources.md`** — new `## Scope — the leak boundary other libraries do not have` positioning section. Per the skill-anchoring convention it frames the differentiator via the known mental model first: TanStack Query / RTK Query / SWR / `re-frame-query` all put the viewer id *inside the query key* **by convention** — nothing enforces it, a forgotten segment silently shares one principal's cache with the next, none ships a *scoped* logout clear, and (verified) none exercises multi-tenancy in its canonical example apps. It then maps onto re-frame2's structural equivalent: a six-row guarantee table (scope required + declared once; scope *in* the identity; sub-side fail-closed resolution; causal scoped `clear-scope`; scoped-by-default invalidation; auditable not heuristic), each row cross-linked to the mechanics subsection that introduces it. Closes with a "where this matters / where it doesn't" note (a global read is a one-word claim that costs nothing; the payoff lands the moment any viewer-relative server state appears). The existing `## Scope — the leak boundary that fails closed` mechanics section is unchanged — this new section is the *positioning* counterpart.

**`implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc`** (8 deftests) — the leak boundary as the **read-path security guarantee** the existing suites do not assert: that NO principal's live `rf/subscribe` can ever observe another principal's cached data. Pins the bead's Part-2 scenarios 1/2/3:

- **1. Logout `clear-scope` (cross-user leak test):** clearing tenant A's scope removes its entries + owners; tenant B's next session on the same frame reads B's own idle empty-state through a live sub, **never** A's cleared data; clearing A leaves a simultaneously-cached B intact.
- **2. Wrong-but-valid scope:** a sub at a different valid scope reads its own (empty) entry — never a silent shared read of the other principal's data; a `:rf.scope/from-caller` mismatch additionally emits the dev `:rf.warning/resource-sub-scope-mismatch` diagnostic; a nil-resolving `{:from-db}` sub fails closed loudly (`:rf.error/resource-sub-unresolved-scope`).
- **3. Mixed-scope invalidation:** a scoped `:rf.resource/invalidate-tags` reaches exactly the resolved scope's entries and never another principal's same-tagged entry; `clear-scope` + invalidation compose without crossing principals.

Cross-host `.cljc` (JVM + CLJS node-test). Complements the lease-lifecycle non-interference suite (`resources_scoped_lease_lifecycle_cljs_test.cljc`) and the resolution-mechanics suites (`resources_from_db_scope_cljs_test.cljc`, `resources_invalidation_descriptors_cljs_test.cljc`) — those assert resolution + entry presence; this asserts the security property at the live read.

## Explicitly deferred (per dispatch)

- The **hot-zone tenant-switcher TESTBED** (touches `implementation/shadow-cljs.edn` build-id) — filed as a follow-up bead.
- **rf2-pubg18** skills coordination (the skills resources leaf teaching the same positioning).

## Quality gates

- `resources clojure -M:test` — **363 tests, 1403 assertions, 0 failures** (8 new deftests).
- `npm run test:cljs` — **6850 tests, 27810 assertions, 0 failures**.
- `mkdocs build --strict` — **exit 0** (`cp -r spec docs/spec` + `scripts/check_doc_slugs.py` clean; all new cross-link anchors resolve).
