### PR TITLE
docs(core): sync reg-event-* docstrings to the superset :interceptors model (rf2-0c6ak7)

### DIFF
--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -899,14 +899,24 @@
   handlers reach for `reg-event-fx`; for full-context manipulation reach
   for `reg-event-ctx`.
 
-  Shapes (the middle slot is optional and may be metadata OR
-  interceptor-vector, NOT both — per Conventions §`:interceptors` is
-  positional, not metadata):
+  Shapes (the optional middle slot is the **superset** metadata map —
+  it carries reflection metadata (`:doc`, `:schema`, …) **and** a
+  reserved `:interceptors` chain in one map; the positional interceptor
+  vector is sugar for `{:interceptors [...]}` — per Conventions
+  §`:interceptors` in the metadata-map — the superset middle slot):
 
       (reg-event-db :id                            (fn [db ev] new-db))
       (reg-event-db :id {:doc \"...\" :schema ...} (fn [db ev] new-db))
       (reg-event-db :id [(path :counter)]          (fn [slice ev] new-slice))
+      (reg-event-db :id {:doc \"...\" :interceptors [(path :counter)]}
+                                                    (fn [slice ev] new-slice))
       (reg-event-db :id {:doc \"...\"} [icpt]        (fn [db ev] new-db))
+
+  The positional vector and the metadata-map `:interceptors` key are
+  exactly equivalent (`[i1 i2]` ≡ `{:interceptors [i1 i2]}`). Supplying
+  a chain in **both** slots at once raises the loud registration error
+  `:rf.error/interceptors-supplied-twice` — the two sources are never
+  silently merged.
 
   Returns `id`.
 
@@ -944,13 +954,21 @@
   keys (`:dispatch`, `:dispatch-later`, `:http`, ...) wrap as `:fx`
   entries — `{:fx [[:dispatch event] ...]}`.
 
-  Shapes (the middle slot is optional and may be metadata OR
-  interceptor-vector, NOT both):
+  Shapes (the optional middle slot is the **superset** metadata map —
+  it carries reflection metadata **and** a reserved `:interceptors`
+  chain in one map; the positional interceptor vector is sugar for
+  `{:interceptors [...]}`):
 
       (reg-event-fx :id                       (fn [cofx ev] {...}))
       (reg-event-fx :id {:doc \"...\"}          (fn [cofx ev] {...}))
       (reg-event-fx :id [(inject-cofx :now)]  (fn [cofx ev] {...}))
+      (reg-event-fx :id {:doc \"...\" :interceptors [(inject-cofx :now)]}
+                                              (fn [cofx ev] {...}))
       (reg-event-fx :id {:doc \"...\"} [icpt]   (fn [cofx ev] {...}))
+
+  `[i1 i2]` ≡ `{:interceptors [i1 i2]}`; supplying a chain in **both**
+  slots raises `:rf.error/interceptors-supplied-twice` (per Conventions
+  §`:interceptors` in the metadata-map — the superset middle slot).
 
   Returns `id`. Returning `nil` from the handler is a documented no-op.
 
@@ -986,12 +1004,20 @@
   Returns `id`. Returning `nil` from the handler leaves the inbound
   context unchanged (documented no-op).
 
-  Shapes (the middle slot is optional and may be metadata OR
-  interceptor-vector, NOT both):
+  Shapes (the optional middle slot is the **superset** metadata map —
+  it carries reflection metadata **and** a reserved `:interceptors`
+  chain in one map; the positional interceptor vector is sugar for
+  `{:interceptors [...]}`):
 
       (reg-event-ctx :id                  (fn [ctx] new-ctx))
       (reg-event-ctx :id {:doc \"...\"}     (fn [ctx] new-ctx))
       (reg-event-ctx :id [icpt1 icpt2]    (fn [ctx] new-ctx))
+      (reg-event-ctx :id {:doc \"...\" :interceptors [icpt1 icpt2]}
+                                          (fn [ctx] new-ctx))
+
+  `[i1 i2]` ≡ `{:interceptors [i1 i2]}`; supplying a chain in **both**
+  slots raises `:rf.error/interceptors-supplied-twice` (per Conventions
+  §`:interceptors` in the metadata-map — the superset middle slot).
 
   See also: `reg-event-db`, `reg-event-fx`, `->interceptor`,
   `assoc-coeffect`, `assoc-effect`."


### PR DESCRIPTION
Syncs the three public `reg-event-*` docstrings in `implementation/core/src/re_frame/events.cljc` to the shipped superset middle-slot model (rf2-bpmszk resolution, PR #3777, commit 53fbd9d00). Surfaced by the rf2-iczn3 audit.

## What changed

The `reg-event-db` / `reg-event-fx` / `reg-event-ctx` docstrings carried pre-resolution wording — "the middle slot is optional and may be metadata OR interceptor-vector, **NOT both**" — plus a dangling cite to a Conventions section ("`:interceptors` is positional, not metadata") that no longer exists.

Shipped reality: the metadata map is the **superset** middle slot — it gained a reserved `:interceptors` key, and the positional vector is sugar (`[i1 i2]` ≡ `{:interceptors [i1 i2]}`). Supplying a chain in both slots raises the loud `:rf.error/interceptors-supplied-twice`.

- Rewrote all three `Shapes` blocks to describe the superset metadata map (reflection metadata AND a reserved `:interceptors` chain in one map) and the positional vector as sugar.
- Added the superset shape line (`{:doc … :interceptors […]}`) to each Shapes list.
- Re-pointed the dangling cite to the current `Conventions §:interceptors in the metadata-map — the superset middle slot`.

Confirmed against `spec/001-Registration.md` §57-94 and `spec/Conventions.md:706`. Doc-only; behaviourally inert.

## Quality gates

- `npm run test:cljs` — 6848 tests, 27802 assertions, 0 failures, 0 errors
- core `clojure -M:test` — 1343 tests, 5974 assertions, 0 failures, 0 errors