### PR TITLE
fix: EP-0012 finish schema/marks path-identity alignment + remove fail-open mark logic (rf2-94o54l.2 + .6)

### DIFF
--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -41,6 +41,7 @@
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.path :as path]
             [re-frame.privacy :as privacy]
             [re-frame.substrate.adapter :as adapter]))
 
@@ -114,19 +115,30 @@
 ;; shape) and names the offending key + value/entry so the author can fix it
 ;; without a stack-trace dig.
 
-(defn- valid-mark-element?
-  "A mark path element is a scalar map key: keyword / string / integer /
-  symbol / boolean. A collection element is never a valid `get-in` step and
-  signals a caller bug (e.g. a nested-vector path `[[:a [:b]]]`)."
-  [x]
-  (or (keyword? x) (string? x) (integer? x) (symbol? x) (boolean? x)))
+;; A mark-path SEGMENT is admitted by the shared EP-0012 segment domain
+;; (`re-frame.path/segment?` — Conventions §The `:rf/path` algebra §Segment
+;; domain), NOT a private re-enumeration. Redaction-mark paths are
+;; `:rf/path` consumers (Spec 015 §6 points classification path maps at the
+;; shared `:rf/path` identity), so a mark path inherits the one segment
+;; algebra every other path-shaped fact uses — keyword / string / symbol /
+;; boolean / integer / UUID / instant / nil. The prior private
+;; `valid-mark-element?` omitted UUID, instant, and nil, narrowing the
+;; domain with no recorded policy (rf2-94o54l.2 finding 2, rf2-94o54l.6):
+;; a `:sensitive [[:user #uuid "…"]]` mark — a perfectly valid `get-in`
+;; path against a uuid-keyed map — was silently REJECTED. Per Conventions
+;; §The `:rf/path` algebra a subsystem MUST NOT keep private ad hoc path
+;; logic once the shared helper exists; marks compose ON the shared domain.
 
 (defn- valid-mark-subpath?
-  "A `:sensitive` / `:large` entry is a vector of scalar path elements. Unlike
-  a flow `:inputs` path the EMPTY vector `[]` is legal — it marks the whole
-  value (the `[[]]` convention)."
+  "A `:sensitive` / `:large` entry is a vector of EP-0012 path segments
+  (`re-frame.path/segment?` — the shared segment domain). Unlike a flow
+  `:inputs` path the EMPTY vector `[]` is legal — it marks the whole value
+  (the `[[]]` convention). A composite element (a nested vector / map) is
+  not a concrete segment and signals a caller bug (e.g. the nested-vector
+  path `[[:a [:b]]]`); `path/segment?` rejects it without re-enumerating
+  the host-type discrimination here."
   [x]
-  (and (vector? x) (every? valid-mark-element? x)))
+  (and (vector? x) (every? path/segment? x)))
 
 (defn- marks-error
   "Build the malformed-marks ex-info with the canonical thrown-error shape
@@ -171,8 +183,9 @@
      (not (every? valid-mark-subpath? paths))
      (throw (marks-error mark-key
                          (str mark-key " entries must each be a vector of "
-                              "scalar keys (keyword / string / integer / "
-                              "symbol / boolean); [] marks the whole value")
+                              "EP-0012 path segments (keyword / string / "
+                              "symbol / boolean / integer / UUID / instant / "
+                              "nil); [] marks the whole value")
                          {:bad-entries (vec (remove valid-mark-subpath? paths))}))
 
      :else
@@ -326,13 +339,21 @@
 (defn- union-path-vecs
   "Union `existing` and `added` path-vector collections, preserving order
   (existing first, then any added paths not already present) and dropping
-  non-vector / duplicate entries. Returns a vector, or nil when the union
-  is empty — so the caller can omit an empty slot rather than stash `[]`."
+  DUPLICATE entries. Returns a vector, or nil when the union is empty — so
+  the caller can omit an empty slot rather than stash `[]`.
+
+  Both inputs are routed through `coerce-paths`, which now REJECTS a
+  malformed (non-vector) entry LOUDLY with `:rf.error/bad-marks`
+  (rf2-y7l5t5) — so every entry reaching the reduce is a validated path
+  vector. The reduce's sole remaining job is order-preserving dedup; there
+  is no silent non-vector drop (the stale `(not (vector? p))` guard that
+  doc once described was a no-op after the fail-loud validation landed and
+  has been removed — rf2-94o54l.6)."
   [existing added]
   (let [seen   (volatile! #{})
         result (reduce (fn [acc p]
                          (let [p (vec p)]
-                           (if (or (not (vector? p)) (contains? @seen p))
+                           (if (contains? @seen p)
                              acc
                              (do (vswap! seen conj p)
                                  (conj acc p)))))
@@ -582,16 +603,48 @@
                {}
                decls)))
 
+(def ^:private app-db-mark-values
+  "The closed value set of an `add-marks` / `set-marks` `{path mark}` map's
+  mark slot. A mark is `:sensitive` (redact the value) or `:large` (emit a
+  size marker) — nothing else."
+  #{:sensitive :large})
+
 (defn- split-by-mark
-  "Partition `{path mark}` map into `[sensitive-paths large-paths]`.
-  Any unknown mark value is silently dropped (best-effort — the
-  declaration is non-validating)."
+  "Partition `{path mark}` map into `[sensitive-paths large-paths]`, with
+  each path routed through `re-frame.path/normalize-concrete` — the same
+  VALIDATED concrete boundary frame classification and resource scope use
+  (EP-0012, rf2-w9x5fv). An `add-marks` / `set-marks` path is a CONCRETE
+  app-db path, so it normalizes to its canonical vector form AND fails
+  closed (`:rf.error/bad-path`) on any host-object / composite segment that
+  could never match a real `get-in` step.
+
+  FAIL-CLOSED on the mark VALUE too (rf2-94o54l.6): a mark outside the
+  closed set `#{:sensitive :large}` is REJECTED LOUDLY with
+  `:rf.error/bad-marks` naming the offending path + mark — NOT silently
+  dropped. The prior silent drop was a privacy footgun (Conventions §No
+  silent swallow, §738 — recognized-but-unhonored input MUST signal): a
+  typoed mark (`{[:user :ssn] :sensitivee}`) made the author believe a
+  path was redacted while `split-by-mark` quietly discarded it, the same
+  armed-trap shape the `:sensitive` / `:large` declaration validator
+  (`coerce-paths`) already rejects. The mark enum is closed, so a typo is
+  a loud error, never a permissive no-op."
   [path->mark]
   (reduce-kv (fn [[s l] path mark]
-               (case mark
-                 :sensitive [(conj s (vec path)) l]
-                 :large     [s (conj l (vec path))]
-                 [s l]))
+               (let [p (path/normalize-concrete path)]
+                 (case mark
+                   :sensitive [(conj s p) l]
+                   :large     [s (conj l p)]
+                   (throw (ex-info (str :rf.error/bad-marks)
+                                   {:rf.error/id :rf.error/bad-marks
+                                    :where       'rf/add-marks
+                                    :recovery    :fix-mark-value
+                                    :reason      (str "an app-db mark value must be one of "
+                                                      (pr-str app-db-mark-values)
+                                                      " — :sensitive redacts the value, :large "
+                                                      "emits a size marker")
+                                    :bad-path    path
+                                    :bad-mark    mark
+                                    :valid       app-db-mark-values})))))
              [[] []]
              path->mark))
 
@@ -610,7 +663,10 @@
   `path->mark` is a map from `get-in`-shaped path vectors to mark
   keywords (`:sensitive` or `:large`). Paths supplied here MERGE into
   the frame's existing marks — paths NOT mentioned keep their prior
-  state. Repeat calls accumulate.
+  state. Repeat calls accumulate. Each path is normalized to its
+  canonical EP-0012 vector form, and a mark value outside the closed set
+  `#{:sensitive :large}` FAILS CLOSED with `:rf.error/bad-marks` (a typoed
+  mark is never silently dropped — rf2-94o54l.6).
 
       (marks/add-marks :rf/default
         {[:user :ssn]   :sensitive
@@ -653,6 +709,9 @@
   `path->mark` is a map from `get-in`-shaped path vectors to mark
   keywords (`:sensitive` or `:large`). Paths supplied here REPLACE the
   frame's prior marks set wholesale — paths NOT mentioned are CLEARED.
+  Each path is normalized to its canonical EP-0012 vector form, and a
+  mark value outside the closed set `#{:sensitive :large}` FAILS CLOSED
+  with `:rf.error/bad-marks` (rf2-94o54l.6).
 
       (marks/set-marks :rf/default
         {[:user :ssn]   :sensitive

--- a/implementation/core/test/re_frame/marks_test.clj
+++ b/implementation/core/test/re_frame/marks_test.clj
@@ -332,6 +332,88 @@
     (is (nil? (:sensitive (marks/marks-for :event :empty)))
         "an empty :sensitive vector is accepted (no throw, no paths)")))
 
+;; ---- EP-0012 shared segment domain (rf2-94o54l.2 / .6) -------------------
+;;
+;; Mark-path segment validity is the SHARED `re-frame.path/segment?` domain,
+;; not a private re-enumeration. The prior private `valid-mark-element?`
+;; omitted UUID / instant / nil segments — perfectly valid `get-in` path
+;; segments under the EP-0012 segment domain — so a `:sensitive [[:user
+;; #uuid "…"]]` mark against a uuid-keyed map was silently rejected. These
+;; tests pin that the shared segment types are now ACCEPTED.
+
+(deftest register-marks-accepts-uuid-segment
+  (testing "rf2-94o54l.2 — a UUID path segment (valid EP-0012 segment, was
+            omitted by the private validator) is accepted"
+    (let [uid (java.util.UUID/randomUUID)]
+      (marks/register-marks! :event :uuid-seg {:sensitive [[:invoices uid :total]]})
+      (is (= [[:invoices uid :total]] (:sensitive (marks/marks-for :event :uuid-seg)))
+          "a UUID segment registers — shared segment domain, not the narrow private one"))))
+
+(deftest register-marks-accepts-instant-segment
+  (testing "rf2-94o54l.2 — an instant path segment (valid EP-0012 segment)
+            is accepted"
+    (let [inst (java.time.Instant/parse "2026-06-12T00:00:00Z")]
+      (marks/register-marks! :event :inst-seg {:large [[:audit inst :payload]]})
+      (is (= [[:audit inst :payload]] (:large (marks/marks-for :event :inst-seg)))
+          "an instant segment registers"))))
+
+(deftest register-marks-accepts-nil-segment
+  (testing "rf2-94o54l.2 — a nil path segment (valid EP-0012 segment, a real
+            map key) is accepted — distinct from the [[]] whole-value mark"
+    (marks/register-marks! :event :nil-seg {:sensitive [[:by-key nil :secret]]})
+    (is (= [[:by-key nil :secret]] (:sensitive (marks/marks-for :event :nil-seg)))
+        "a nil segment registers — segment? admits nil")))
+
+(deftest register-marks-still-rejects-composite-segment
+  (testing "rf2-94o54l.6 — widening to the shared domain did NOT loosen the
+            composite-segment rejection: a nested-vector element is still a
+            loud :rf.error/bad-marks (segment? rejects composites)"
+    (let [data (bad-marks-data {:sensitive [[:a [:b]]]})]
+      (is (= :rf.error/bad-marks (:rf.error/id data)))
+      (is (= [[:a [:b]]] (:bad-entries data))
+          ":bad-entries names the composite-segment entry"))))
+
+;; ---- add-marks / set-marks fail-closed on unknown mark (rf2-94o54l.6) ----
+;;
+;; `split-by-mark` used to SILENTLY DROP a mark value outside
+;; `#{:sensitive :large}`, so a typoed mark (`:sensitivee`) made the author
+;; believe a path was redacted while the declaration was quietly discarded —
+;; a privacy footgun (Conventions §No silent swallow). It now FAILS CLOSED.
+
+(deftest add-marks-rejects-unknown-mark-value
+  (testing "rf2-94o54l.6 — a typoed mark value fails closed with
+            :rf.error/bad-marks naming the offending path + mark"
+    (let [ex (try (marks/add-marks :rf/default {[:user :ssn] :sensitivee})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex) "add-marks threw on the unknown mark")
+      (let [data (ex-data ex)]
+        (is (= :rf.error/bad-marks (:rf.error/id data)) ":rf.error/id discriminator")
+        (is (= [:user :ssn] (:bad-path data)) ":bad-path names the offending path")
+        (is (= :sensitivee (:bad-mark data)) ":bad-mark names the typoed value")
+        (is (= #{:sensitive :large} (:valid data)) ":valid lists the closed mark set")))
+    (is (empty? (elision/sensitive-declarations :rf/default))
+        "no marks landed — the rejected declaration did not partially apply")))
+
+(deftest set-marks-rejects-unknown-mark-value
+  (testing "rf2-94o54l.6 — set-marks shares the split-by-mark chokepoint, so a
+            typoed mark fails closed too"
+    (let [ex (try (marks/set-marks :rf/default {[:docs :csv] :largeish})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :rf.error/bad-marks (:rf.error/id (ex-data ex))))
+      (is (= :largeish (:bad-mark (ex-data ex)))))))
+
+(deftest add-marks-normalizes-seq-path-to-vector
+  (testing "rf2-94o54l.2 — a non-vector seq path key normalizes to its
+            canonical vector form in the elision registry"
+    (marks/add-marks :rf/default {(list :user :ssn) :sensitive})
+    (let [decls (elision/sensitive-declarations :rf/default)]
+      (is (contains? decls [:user :ssn])
+          "the seq path is stored under the canonical vector key")
+      (is (every? vector? (keys decls))
+          "every declaration key is a canonical vector"))))
+
 (deftest union-marks-rejects-malformed
   (testing "union-marks! shares the coerce-paths chokepoint, so a malformed
             added declaration is rejected too"

--- a/implementation/schemas/src/re_frame/schemas/digest.cljc
+++ b/implementation/schemas/src/re_frame/schemas/digest.cljc
@@ -27,6 +27,7 @@
       have shifted under them."
   (:require #?@(:cljs [[goog.crypt :as gcrypt]
                        [goog.crypt.Sha256]])
+            [re-frame.path :as path]
             [re-frame.schemas.storage :as storage]
             [re-frame.schemas.validator :as validator])
   #?(:clj (:import [java.security MessageDigest]
@@ -71,9 +72,20 @@
   `(path, schema-value)` of the form `<path-string> <hex-of-sha256>\\n`.
   The per-schema serialisation routes through the registered
   `schema-print` companion (rf2-wla45) so non-Malli ports compute
-  digests against their own canonical bytes."
+  digests against their own canonical bytes.
+
+  EP-0012 §Path shape (rf2-94o54l.2): the path key is NORMALIZED to its
+  canonical vector form (`re-frame.path/normalize`) before `pr-str`, so a
+  list path and the equivalent vector path emit byte-identical digest
+  lines — the digest path keys participate in the one canonical-vector
+  identity every other path consumer inherits, not the raw container shape.
+  `app-schemas` already returns canonically-keyed entries (storage
+  normalizes at registration), so this normalize is the defensive
+  belt-and-braces guaranteeing byte identity for ANY directly-fed
+  `path->schema` map (e.g. the parity fixtures). A canonical vector
+  normalizes to itself, so every pinned digest literal is unchanged."
   [path schema-value]
-  (str (pr-str path)
+  (str (pr-str (path/normalize path))
        " "
        (sha256-hex (validator/run-printer schema-value))
        "\n"))

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -25,6 +25,7 @@
   (:require [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.path :as path]
             [re-frame.privacy :as privacy]
             [re-frame.schemas.validator :as validator]
             [re-frame.schemas.walker :as walker]
@@ -121,10 +122,15 @@
   keyword, string, number, nil, map, set — are rejected: they break the
   `(get-in db path)` the validation hot path runs.
 
-  `sequential?` (not `vector?`) is deliberate — `get-in`/`assoc-in`
-  accept any sequential `ks`, and the bead's suggested direction permits
-  non-vector seqs; the only hard requirement is sequential-ness so the
-  validation walk's `get-in` cannot throw."
+  `sequential?` (not `vector?`) is deliberate — APIs MAY accept any
+  sequential collection for migration ergonomics (Conventions §The
+  `:rf/path` algebra §Path shape). The only hard requirement at the
+  acceptance boundary is sequential-ness so the validation walk's
+  `get-in` cannot throw; the accepted seq is then NORMALIZED to its
+  canonical vector form (`re-frame.path/normalize`) before it becomes a
+  stored declaration / digest path key, so a list path and the equivalent
+  vector path are ONE identity (EP-0012 §Path shape — \"all stored
+  declarations MUST normalize to a vector\")."
   [path]
   (sequential? path))
 
@@ -587,6 +593,17 @@
    (assert-app-schema-path! path (best-effort-frame opts-or-frame-id))
    (let [opts         (coerce-opts opts-or-frame-id)
          frame-id     (resolve-frame opts)
+         ;; EP-0012 §Path shape (rf2-94o54l.2): a `reg-app-schema` path is
+         ;; accepted as any sequential collection but NORMALIZED to its
+         ;; canonical vector form before it becomes the stored key / digest
+         ;; path key, so a list path `(list :a :b)` and the equivalent
+         ;; vector `[:a :b]` are ONE identity — the side-table key, the
+         ;; `schema-meta` `:path`, the prior-schema lookup, and the digest
+         ;; line all derive from the same canonical vector. `normalize`
+         ;; (not `normalize-concrete`) — a `reg-app-schema` path validates
+         ;; SHAPE only (Spec 010 permits any get-in segment), so we coerce
+         ;; the container without narrowing the segment domain.
+         path         (path/normalize path)
          ;; The per-frame schema-metadata map (the {path → schema-meta}
          ;; entry value) — `:schema` + `:path` + `:frame` + source-coords.
          ;; Named `schema-meta` to match the slice vocabulary
@@ -721,7 +738,12 @@
   Per Spec 010 §Schemas as a tooling and agent surface."
   ([path] (app-schema-at path {}))
   ([path opts-or-frame-id]
-   (let [frame-id (coerce->frame-id opts-or-frame-id)]
+   ;; EP-0012 §Path shape (rf2-94o54l.2): normalize the lookup path to its
+   ;; canonical vector so a `(list :a :b)` read finds the entry stored under
+   ;; the equivalent `[:a :b]` key (registration normalizes the same way) —
+   ;; storage and lookup AGREE on one canonical-vector identity.
+   (let [frame-id (coerce->frame-id opts-or-frame-id)
+         path     (path/normalize path)]
      (when-let [m (get-in @schemas-by-frame [frame-id path])]
        (:schema m)))))
 
@@ -744,7 +766,11 @@
                                       ;; (keyword sugar also accepted)"
   ([path] (app-schema-meta-at path {}))
   ([path opts-or-frame-id]
-   (let [frame-id (coerce->frame-id opts-or-frame-id)]
+   ;; EP-0012 §Path shape (rf2-94o54l.2): normalize the lookup path so a
+   ;; non-vector seq read resolves to the canonically-stored vector entry
+   ;; (registration normalizes the key the same way).
+   (let [frame-id (coerce->frame-id opts-or-frame-id)
+         path     (path/normalize path)]
      (get-in @schemas-by-frame [frame-id path]))))
 
 (defn app-schemas

--- a/implementation/schemas/test/re_frame/schemas_storage_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_storage_test.clj
@@ -261,6 +261,48 @@
     (is (= :string (rf/app-schema-at (list :a :b)))
         "non-vector seq path registers (get-in accepts any sequential ks)")))
 
+(deftest reg-app-schema-normalizes-seq-path-to-canonical-vector
+  (testing "rf2-94o54l.2 / EP-0012 §Path shape — a list path and the
+            equivalent vector path are ONE canonical-vector identity:
+            the entry is STORED under the canonical vector key, looked up
+            by EITHER spelling, and re-registering via the other spelling
+            overwrites the SAME slot (not a parallel list-keyed entry)"
+    ;; Register via a non-vector seq; the stored key is the canonical vector.
+    (rf/reg-app-schema (list :a :b) :string)
+    (let [frame-keys (keys (get (schemas/snapshot-schemas-by-frame) :rf/default))]
+      (is (every? vector? frame-keys)
+          "every stored schemas-by-frame key is a canonical vector")
+      (is (contains? (set frame-keys) [:a :b])
+          "the stored key is the canonical VECTOR, not the supplied list"))
+    ;; The vector-spelling lookup finds the list-registered entry.
+    (is (= :string (rf/app-schema-at [:a :b]))
+        "vector lookup resolves the list-registered entry — one identity")
+    ;; The stored meta :path is itself the canonical vector.
+    (is (= [:a :b] (:path (rf/app-schema-meta-at (list :a :b))))
+        "schema-meta :path is the canonical vector, regardless of read spelling")
+    ;; reg-app-schema returns the normalized canonical-vector path.
+    (is (= [:c :d] (rf/reg-app-schema (list :c :d) :int))
+        "reg-app-schema returns the canonical vector form of a seq path")
+    ;; Re-registering via the vector spelling overwrites the SAME slot
+    ;; (no parallel list-keyed entry survives).
+    (rf/reg-app-schema [:a :b] :int)
+    (is (= :int (rf/app-schema-at (list :a :b)))
+        "re-register via the vector spelling hits the same canonical slot")
+    (is (= 1 (count (filter #(= [:a :b] %)
+                            (keys (get (schemas/snapshot-schemas-by-frame) :rf/default)))))
+        "exactly ONE entry for the path — no list-vs-vector key split")))
+
+(deftest app-schemas-digest-list-path-equals-vector-path
+  (testing "rf2-94o54l.2 / EP-0012 §Digest path keys — a frame populated
+            via a list path digests identically to one populated via the
+            equivalent vector path (digest keys derive from the canonical
+            vector, not the raw container shape)"
+    (rf/reg-app-schema (list :a :b) :string {:frame :seq-frame})
+    (rf/reg-app-schema [:a :b] :string {:frame :vec-frame})
+    (is (= (rf/app-schemas-digest :vec-frame)
+           (rf/app-schemas-digest :seq-frame))
+        "list-keyed and vector-keyed frames produce byte-identical digests")))
+
 (deftest reg-app-schemas-rejects-batch-with-bad-path-atomically
   (testing "rf2-sk0ql — a bulk batch containing a non-sequential path key
             is rejected ATOMICALLY: the whole call throws and NO entry


### PR DESCRIPTION
Two same-surface EP-0012 (path optics + canonical forms) tier-2 consumer-sweep beads, sequenced as two commits. EP-0012 is `final`; stance is pre-alpha masterpiece (CORRECTNESS + CLARITY, fail-CLOSED). Builds on PR #4010 (the shared marks/redact-with-paths walker + params-schema wiring) — does not redo that wiring.

## rf2-94o54l.2 — completeness: schema + marks consumer alignment to shared `:rf/path` identity

EP-0012 §Path shape requires every stored path declaration to normalize to a vector and schema digest path keys to participate in the one canonical-vector identity. A `reg-app-schema` list path `(list :a :b)` was stored, looked up, and digested as a *list* — a parallel identity to the equivalent vector `[:a :b]`.

- **storage.cljc**: `reg-app-schema` now `re-frame.path/normalize`s the path before it becomes the `schemas-by-frame` key, the `schema-meta` `:path`, and the prior-schema lookup. `app-schema-at` / `app-schema-meta-at` normalize the lookup path so either spelling resolves the one canonical-vector entry. `normalize` (not `normalize-concrete`) — a `reg-app-schema` path validates SHAPE only (Spec 010 permits any get-in segment).
- **digest.cljc**: `digest-line` normalizes the path key before `pr-str`, so a list path and the equivalent vector path emit byte-identical digest lines. Canonical vectors normalize to themselves, so every pinned digest-parity fixture is unchanged.
- **marks** (shared with .6): mark segment domain now uses the shared `re-frame.path/segment?`, and `add-marks` / `set-marks` paths normalize to canonical vectors — so UUID / instant / nil segments (valid EP-0012 segments the private validator omitted) are accepted.
- **test**: the list-path test now asserts canonical-vector storage / lookup (one slot, no list-vs-vector key split) + digest byte-equality between a list-keyed and a vector-keyed frame.

## rf2-94o54l.6 — best-practice: remove private / fail-open mark path logic + stale comments

`re-frame.marks` kept a private path grammar and a fail-OPEN classification helper.

- **segment domain**: dropped private `valid-mark-element?` (omitted UUID / instant / nil) and validate mark subpaths with the shared `re-frame.path/segment?`. Conventions §The `:rf/path` algebra forbids private ad hoc path logic once the shared helper exists. Composite segments stay rejected (`segment?` rejects them) with the same `:rf.error/bad-marks`.
- **fail-closed `split-by-mark`**: a mark value outside `#{:sensitive :large}` now throws `:rf.error/bad-marks` naming the offending path + mark, instead of silently dropping it (the prior fail-OPEN drop let a typoed mark look successful — a privacy footgun, Conventions §No silent swallow / §738). `add-marks` / `set-marks` paths route through `path/normalize-concrete` (the validated concrete boundary frame classification + resource scope use), so a host / composite segment also fails closed.
- **stale comment**: `union-path-vecs` no longer claims to drop non-vector entries — `coerce-paths` rejects them loudly upstream, so the dead `(not (vector? p))` guard is removed and the doc matches reality.
- **tests**: accepted UUID / instant / nil segments, retained composite rejection, unknown-mark fail-closed on `add-marks` / `set-marks`, seq-path canonical-vector normalization.

No spec change: Conventions §Path shape / §Digest path keys and Spec 015 §6 already mandate this identity; these commits bring the implementation into compliance.

## Quality gates

- `npm run test:cljs` — 6848 tests, 27802 assertions, 0 failures / 0 errors
- core `clojure -M:test` — 1350 tests, 5989 assertions, 0 failures / 0 errors
- schemas `clojure -M:test` — 300 tests, 18757 assertions, 0 failures / 0 errors
- `npm run test:elision` — PASS (production 41/41 absent, control 41/41 present)