### PR TITLE
test(testbed): EP-0013 scoped-cache tenant-switcher isolation testbed (rf2-5e22yc)

### DIFF
--- a/implementation/package.json
+++ b/implementation/package.json
@@ -36,6 +36,7 @@
     "test:examples-compile": "node scripts/check-examples-compile.cjs",
     "test:reagent-slim:bundle-isolation": "shadow-cljs release examples/counter examples/counter-slim-and-fast && node scripts/check-reagent-slim-bundle-isolation.cjs",
     "test:examples": "node ../examples/scripts/serve-and-run-examples-tests.cjs",
+    "test:testbed-tenant-switcher": "node scripts/serve-and-run-tenant-switcher-testbed.cjs",
     "dev:example": "node ../examples/scripts/serve-example.cjs",
     "story:build": "node scripts/story-build.cjs",
     "test:story-feature-load": "node ../examples/scripts/serve-and-run-story-feature-load-tests.cjs",

--- a/implementation/scripts/dev-testbed.cjs
+++ b/implementation/scripts/dev-testbed.cjs
@@ -98,6 +98,8 @@ const { REPO_ROOT, IMPL_ROOT } = require('./_path-policy.cjs');
 //   805x        examples orchestrator     DEFAULT_PORT in
 //                                           examples/scripts/examples-port.cjs
 //                                           (8050; pre-flight + forward scan).
+//   806x        Top-level testbeds        :dev-http (shadow-cljs.edn):
+//                                           8060 tenant-switcher (rf2-5e22yc)
 //   8765        Xray panel-gallery        :dev-http (shadow-cljs.edn).
 //
 // The :dev-http bands (8030-8035 / 8040-8043 / 8765) are mirrored in the
@@ -124,6 +126,8 @@ const DEV_HTTP = {
   ':examples/login-with-stories': { port: 8041, story: true },
   ':examples/counter-with-stories': { port: 8042, story: true },
   ':examples/login-form': { port: 8043, story: true },
+  // rf2-5e22yc — top-level tenant-switcher testbed (806x band).
+  ':testbeds/tenant-switcher': { port: 8060 },
 };
 
 /**

--- a/implementation/scripts/serve-and-run-tenant-switcher-testbed.cjs
+++ b/implementation/scripts/serve-and-run-tenant-switcher-testbed.cjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/*
+ * Browser smoke runner for the top-level tenant-switcher testbed
+ * (testbeds/tenant_switcher/, rf2-5e22yc). The shared framework testbeds
+ * under testbeds/** are normally Xray observation targets driven by CLJS
+ * unit tests; the tenant-switcher additionally carries its OWN colocated
+ * spec.cjs (testbeds are exempt from the examples-test-free rule — per
+ * CLAUDE.md "Framework testbeds carry their own non-adapter spec.cjs for
+ * cross-cutting surfaces"). This runner is its gate.
+ *
+ * It mirrors serve-and-run-browser-tests.cjs end-to-end:
+ *   1. Compile the :testbeds/tenant-switcher shadow-cljs build, shell-free
+ *      under THIS node binary (process.execPath + the resolved shadow-cljs
+ *      JS entry-point) — never npx/npx.cmd under a shell (rf2-wn4o1).
+ *   2. Stage the hand-written index.html into the build's :output-dir next
+ *      to main.js.
+ *   3. Serve the output dir over http-server (also shell-free), bound to
+ *      127.0.0.1, with the per-run ownership-token handshake (rf2-gkf9).
+ *   4. Drive the colocated spec.cjs in headless Chromium: navigate, run its
+ *      assertions, and fail on any uncaught pageerror (rf2-mwx08 discipline:
+ *      pageerrors are tracked in a dedicated array and flip the verdict).
+ *   5. Always tear the server down.
+ *
+ * Cross-platform: same hardened spawn posture as the implementation/scripts
+ * browser launchers; passes _script-spawn-policy.test.cjs.
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { enforcePolicy, DEFAULT_OUT_ROOT } = require('./_path-policy.cjs');
+const {
+  TOKEN_FILE_BASENAME,
+  createHarnessCleanup,
+  resolveServePort,
+  spawnHarnessProcess,
+  waitForOwnedHttpReady,
+} = require('./lib/local-browser-harness.cjs');
+
+const IMPL_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(IMPL_ROOT, '..');
+const BUILD_ID = ':testbeds/tenant-switcher';
+// The build's :output-dir (shadow-cljs.edn) — kept under implementation/out.
+const ROOT = enforcePolicy(
+  'TENANT_SWITCHER_TESTBED_ROOT',
+  path.join(IMPL_ROOT, 'out', 'testbeds', 'tenant-switcher'),
+  { allowedRoots: [DEFAULT_OUT_ROOT] },
+);
+// The hand-written index.html staged into the output dir next to main.js.
+const HTML_SRC = path.join(
+  REPO_ROOT,
+  'testbeds',
+  'tenant_switcher',
+  'index.html',
+);
+const SPEC = require(path.join(
+  REPO_ROOT,
+  'testbeds',
+  'tenant_switcher',
+  'spec.cjs',
+));
+
+const DEFAULT_PORT = 8060; // top-level testbeds band (806x); see shadow-cljs.edn :dev-http.
+const READY_TIMEOUT_MS = 30000;
+const SPEC_TIMEOUT_MS = parseInt(process.env.TESTBED_SPEC_TIMEOUT_MS || '30000', 10);
+const POLL_MS = 200;
+
+// Resolve the shadow-cljs + http-server JS entry-points so they can be
+// spawned shell-free under process.execPath (rf2-wn4o1). Rooted at IMPL_ROOT
+// regardless of this script's cwd.
+let SHADOW_CLJS_RUNNER;
+let HTTP_SERVER_BIN;
+try {
+  SHADOW_CLJS_RUNNER = require.resolve('shadow-cljs/cli/runner.js', {
+    paths: [IMPL_ROOT],
+  });
+  HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
+    paths: [IMPL_ROOT],
+  });
+} catch {
+  console.error(
+    'serve-and-run-tenant-switcher-testbed: could not resolve shadow-cljs / ' +
+      `http-server. Run \`npm install\` in ${IMPL_ROOT} first.`,
+  );
+  process.exit(1);
+}
+
+const { spawnSync } = require('child_process');
+const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] }));
+
+const cleanup = createHarnessCleanup();
+const TOKEN_PATH = path.join(ROOT, TOKEN_FILE_BASENAME);
+cleanup.addCleanup(removeOwnershipToken);
+cleanup.installSignalHandlers();
+
+function compile() {
+  // Spawn the resolved shadow-cljs runner under THIS node binary, shell-free.
+  const result = spawnSync(
+    process.execPath,
+    [SHADOW_CLJS_RUNNER, 'compile', BUILD_ID],
+    { cwd: IMPL_ROOT, stdio: 'inherit' },
+  );
+  if (result.status !== 0) {
+    console.error(`shadow-cljs compile ${BUILD_ID} failed (exit ${result.status})`);
+    return false;
+  }
+  return true;
+}
+
+function stageHtml() {
+  if (!fs.existsSync(ROOT)) {
+    console.error(`Build output dir missing: ${ROOT}. Did the compile run?`);
+    return false;
+  }
+  if (!fs.existsSync(HTML_SRC)) {
+    console.error(`HTML source missing: ${HTML_SRC}`);
+    return false;
+  }
+  fs.copyFileSync(HTML_SRC, path.join(ROOT, 'index.html'));
+  return true;
+}
+
+function writeOwnershipToken() {
+  if (!fs.existsSync(ROOT)) return null;
+  const token = crypto.randomBytes(16).toString('hex');
+  fs.writeFileSync(TOKEN_PATH, token, 'utf8');
+  return token;
+}
+
+function removeOwnershipToken() {
+  try {
+    if (fs.existsSync(TOKEN_PATH)) fs.unlinkSync(TOKEN_PATH);
+  } catch (_) {
+    // best-effort cleanup.
+  }
+}
+
+function withTimeout(promise, ms, label) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Spec '${label}' timed out after ${ms}ms`)),
+      ms,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+async function runSpec(baseUrl) {
+  const browser = await chromium.launch({ headless: true });
+  // rf2-mwx08 discipline: pageerrors are tracked in a DEDICATED array (not
+  // merely the diagnostic buffer) and flip the verdict to fail, even if the
+  // assertions otherwise pass.
+  const pageErrors = [];
+  const lines = [];
+  const log = (s) => lines.push(s);
+  let passed = false;
+  try {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    page.on('console', (msg) => log(`[browser:${msg.type()}] ${msg.text()}`));
+    page.on('pageerror', (err) => {
+      pageErrors.push(err);
+      log(`[browser:pageerror] ${err.message}`);
+      if (err.stack) log(err.stack);
+    });
+
+    const fullUrl = SPEC.url.startsWith('http') ? SPEC.url : baseUrl + SPEC.url;
+    log(`\n=== ${SPEC.name} ===`);
+    log(`Navigating to ${fullUrl}`);
+    await page.goto(fullUrl, { waitUntil: 'load', timeout: SPEC_TIMEOUT_MS });
+    await withTimeout(SPEC.run(page), SPEC_TIMEOUT_MS, SPEC.name);
+    if (pageErrors.length > 0) {
+      throw new Error(`Page emitted ${pageErrors.length} uncaught error(s); first: ${pageErrors[0].message}`);
+    }
+    passed = true;
+  } catch (err) {
+    log(`FAIL ${SPEC.name}: ${err && err.message ? err.message : err}`);
+    if (err && err.stack) log(err.stack);
+  } finally {
+    await browser.close();
+  }
+  if (!passed) for (const ln of lines) console.log(ln);
+  console.log(passed ? `PASS  ${SPEC.name}` : `FAIL  ${SPEC.name}`);
+  return passed ? 0 : 1;
+}
+
+(async () => {
+  if (!compile()) return 1;
+  if (!stageHtml()) return 1;
+
+  const token = writeOwnershipToken();
+  if (!token) {
+    console.error(`Asset root missing: ${ROOT}. Did shadow-cljs compile run?`);
+    return 1;
+  }
+
+  const port = await resolveServePort(DEFAULT_PORT, {
+    onFallback: (pref, fallback) =>
+      console.warn(`Port ${pref} busy; falling back to free port ${fallback}.`),
+  });
+  console.log(`Serving ${ROOT} on http://127.0.0.1:${port}`);
+
+  const args = [HTTP_SERVER_BIN, ROOT, '-a', '127.0.0.1', '-p', String(port), '-s', '-c-1'];
+  const server = cleanup.trackProcess(
+    spawnHarnessProcess(process.execPath, args, {
+      cwd: IMPL_ROOT,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    }),
+  );
+  const state = { exited: false, exitCode: null, exitSignal: null };
+  server.on('exit', (code, signal) => {
+    state.exited = true;
+    state.exitCode = code;
+    state.exitSignal = signal;
+  });
+
+  const ready = await waitForOwnedHttpReady(port, token, Date.now() + READY_TIMEOUT_MS, {
+    pollMs: POLL_MS,
+    isAborted: () => state.exited,
+  });
+  if (!ready.ok) {
+    if (ready.reason === 'child-exited' || state.exited) {
+      console.error(
+        `http-server exited before becoming reachable on :${port} ` +
+          `(code=${state.exitCode}, signal=${state.exitSignal}).`,
+      );
+    } else if (ready.reason === 'token-mismatch') {
+      console.error(
+        `A foreign server is reachable on :${port} (token mismatch). Refusing to run.`,
+      );
+    } else {
+      console.error(`http-server did not become reachable on :${port} within ${READY_TIMEOUT_MS}ms.`);
+    }
+    return 1;
+  }
+
+  return await runSpec(`http://127.0.0.1:${port}`);
+})()
+  .then(async (code) => {
+    await cleanup.cleanup();
+    process.exit(code == null ? 1 : code);
+  })
+  .catch(async (err) => {
+    console.error(err);
+    await cleanup.cleanup();
+    process.exit(1);
+  });

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -430,7 +430,17 @@
             8042 ["../tools/story/testbeds/counter_with_stories"
                   "out/examples/counter-with-stories"]
             8043 ["../tools/story/testbeds/login_form"
-                  "out/examples/login-form"]}
+                  "out/examples/login-form"]
+            ;; --- Top-level testbeds (rf2-5e22yc) ---------------------
+            ;; The 806x band for top-level testbeds/<surface>/ dev-http
+            ;; servers (Xray testbeds own 803x + 8765, Story 804x, the
+            ;; examples orchestrator 805x). The tenant-switcher testbed is
+            ;; the first such server: source dir first so the hand-written
+            ;; index.html resolves at `/`, the compiled main.js falls
+            ;; through to out/testbeds/tenant-switcher per the same cascade
+            ;; as the testbeds above.
+            8060 ["../testbeds/tenant_switcher"
+                  "out/testbeds/tenant-switcher"]}
 
  :builds
  {:node-test
@@ -1618,6 +1628,28 @@
    :output-dir "out/testbeds/large-dispatcher"
    :asset-path "."
    :modules    {:main {:init-fn large-dispatcher.core/run}}
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-xray.preload]}}
+
+  ;; rf2-5e22yc (EP-0013/resources) — tenant-switcher testbed. The
+  ;; scoped-cache leak-boundary Part-2 scenario 5 as a LIVE demonstrator:
+  ;; one app, one frame, two tenant SCOPES coexisting in one cache (an
+  ;; admin impersonating tenant acme then globex), with the active scope
+  ;; deciding which entry a read can address. The multi-SCOPE consumer the
+  ;; rest of the testbed tree lacks (multi_frame is multi-FRAME, not
+  ;; multi-scope). Carries its OWN colocated spec.cjs (testbeds are exempt
+  ;; from the examples-test-free rule); run via the
+  ;; `npm run test:testbed-tenant-switcher` gate. Served on :dev-http 8060
+  ;; (the top-level testbeds band) — source dir first so the hand-written
+  ;; index.html resolves at `/`, compiled main.js falls through to
+  ;; out/testbeds/tenant-switcher. rf2-54jz4 — re-frame2-pair.runtime
+  ;; preload added so pair-MCP can probe this dev testbed's live runtime
+  ;; alongside Xray.
+  :testbeds/tenant-switcher
+  {:target     :browser
+   :output-dir "out/testbeds/tenant-switcher"
+   :asset-path "."
+   :modules    {:main {:init-fn tenant-switcher.core/run}}
    :devtools   {:preloads [re-frame2-pair.runtime
                            day8.re-frame2-xray.preload]}}
 

--- a/testbeds/README.md
+++ b/testbeds/README.md
@@ -25,6 +25,7 @@ testbeds/
   ssr_basic/               <-- SSR hydration baseline: payload → :rf/hydrate → render → verify-hydration!
   ssr_hydration_mismatch/  <-- deliberate-mismatch: known-wrong :rf/render-hash emits :rf.ssr/hydration-mismatch
   ssr_multi_frame/         <-- three frames, each hydrated from its own slice of the baked payload
+  tenant_switcher/         <-- one app, one frame, two tenant scopes coexisting in one cache; the multi-scope leak boundary
 ```
 
 Per-surface conventions (every testbed in this directory follows them):
@@ -52,6 +53,7 @@ shadow-cljs watch testbeds/large-dispatcher
 shadow-cljs watch testbeds/ssr-basic
 shadow-cljs watch testbeds/ssr-hydration-mismatch
 shadow-cljs watch testbeds/ssr-multi-frame
+shadow-cljs watch testbeds/tenant-switcher
 ```
 
 Then open `http://localhost:9630/build/<build-id>/dashboard` (or the per-testbed index.html served from `implementation/out/testbeds/<name>/`). The Xray preload is wired on every testbed build (mirroring the examples convention) so the trace panel and dev-tools are live on each surface.

--- a/testbeds/tenant_switcher/README.md
+++ b/testbeds/tenant_switcher/README.md
@@ -1,0 +1,114 @@
+# `testbeds/tenant-switcher`
+
+A single Reagent app on a single frame (`:rf/default`) that switches the
+**active principal** — an admin impersonating tenant `acme`, then `globex`,
+then back — while the scoped-cache keeps each tenant's loaded dashboard
+structurally isolated and *simultaneously live*.
+
+This is the multi-**scope** consumer the rest of the testbed tree lacks. Every
+other multi-tenant-shaped surface (e.g. `multi_frame/`) is multi-**frame**:
+one app per frame, each frame isolated. This one is multi-**scope**: one app,
+one frame, two tenant scopes coexisting in one cache, with the active scope
+deciding which entry a read can address.
+
+It is the live demonstrator of the guide's claim
+([`docs/guide/27-resources.md` §"Scope — the leak boundary other libraries do
+not have"](../../docs/guide/27-resources.md)): the resolved scope is *in* the
+cache key, so two tenants' reads of the same params land on two structurally
+distinct entries — neither reachable through the other's key. EP-0013/resources
+Part-2 leak-boundary **scenario 5** (rf2-5e22yc, spun from rf2-wwhedk).
+
+## The model
+
+- **Named scope resolver** (EP-0016 D3): `reg-resource-scope :tenant/scope`
+  derives `[:rf.scope/tenant {:tenant-id …}]` from `[:viewer :active-tenant]`.
+  Pure, with declared `:inputs` so a tool can explain which app fact decides a
+  resource's identity.
+- **Scoped resource**: `:tenant/dashboard` declares
+  `:scope {:from-db :tenant/scope}`, so its cache key carries the active
+  tenant structurally.
+- **Switching** is one ordinary event (`::switch-tenant`) rewriting
+  `[:viewer :active-tenant]`; ensure and the active-scope sub re-resolve
+  through the named resolver.
+- **Transport** is a deterministic in-memory stub: the testbed overrides the
+  `:rf.http/managed` fx to reply through the runtime's own `:on-success`
+  target, so the entry loads exactly as a live read would — no network, fully
+  deterministic. The success `:value` is derived from the resolved scope baked
+  into the resource-key, so each tenant loads its OWN distinct payload (a real
+  cross-tenant leak would surface as the wrong motto in the DOM).
+
+## Controls
+
+| Control | `data-testid` | What it does |
+|---|---|---|
+| Acme Corp | `switch-acme` | Impersonate tenant `acme` (active scope → acme). |
+| Globex Inc | `switch-globex` | Impersonate tenant `globex` (active scope → globex). |
+| Load active dashboard | `load` | Ensure `:tenant/dashboard {:page 1}` for the CURRENTLY-active tenant (scope derived from app-db). |
+
+## Observables
+
+- **Active dashboard panel** (`dashboard-panel`) — reads `:rf.resource/state` /
+  `:rf.resource/data` with NO explicit scope; resolves the active tenant's
+  scope from app-db. `active-tenant` / `status` / `motto` testids. This is the
+  read seam where a leak would be visible — it structurally cannot read another
+  tenant's entry.
+- **Cache witnesses** (`witness-acme` / `witness-globex`) — one EXPLICIT-scope
+  `:rf.resource/state` read per tenant, side by side, regardless of who is
+  active. Once both dashboards are loaded, both witnesses read `:loaded` with
+  their OWN distinct motto at the same time (`witness-status-<id>`,
+  `witness-motto-<id>`): the load-bearing evidence that both entries are
+  simultaneously live in one cache and each explicit scope addresses exactly
+  its own data.
+
+## Scenario 5 — simultaneously-live multi-scope isolation
+
+The canonical sequence the colocated `spec.cjs` drives:
+
+1. Active tenant boots as `acme`. Click **Load** → acme's dashboard loads
+   (`motto = acme-only secret`).
+2. Switch to **Globex Inc**. The active panel immediately reads globex's
+   *idle* empty-state — **never** acme's cached motto. Click **Load** →
+   globex's dashboard loads (`motto = globex-only secret`).
+3. Both cache witnesses now read `:loaded` with their own distinct motto at
+   once — both entries are live in the cache simultaneously.
+4. Switch back to **Acme Corp**. The active panel reads acme's `motto`
+   straight from cache (no refetch) — the entry was never evicted, just not
+   addressable while globex was active.
+
+A leak in any other server-state library (TanStack Query / RTK Query / SWR)
+would show the previous tenant's data after a switch when a key segment is
+forgotten; here scope is part of the key's *type*, so the active view can only
+ever address the active tenant's entry.
+
+## What's deliberately *missing*
+
+- **No logout / `clear-scope`, wrong-scope, or invalidation paths.** Those
+  leak-boundary guarantees are the EXECUTABLE regression vehicle and live as
+  CLJS unit tests
+  ([`resources_scope_leak_boundary_cljs_test.cljc`](../../implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc)
+  scenarios 1/2/3 +
+  [`resources_scoped_lease_lifecycle_cljs_test.cljc`](../../implementation/resources/test/re_frame/resources_scoped_lease_lifecycle_cljs_test.cljc)).
+  This surface is the live demonstrator of the simultaneous-multi-scope shape
+  (scenario 5), not a duplicate regression vehicle.
+- **No deliberate bugs / anti-pattern demos.** Idiomatic re-frame2 throughout
+  (app-db + events + subs; named scope resolver; explicit-owner lease) — a
+  clean test surface (feedback_testbeds_are_test_surfaces).
+
+## Running
+
+From `implementation/`:
+
+```bash
+npm run dev -- :testbeds/tenant-switcher
+# then open http://localhost:8060/
+```
+
+The shadow-cljs build id is `testbeds/tenant-switcher`; output lands in
+`implementation/out/testbeds/tenant-switcher/`. The browser smoke is the
+colocated `spec.cjs`, run via `npm run test:testbed-tenant-switcher`.
+
+## Cross-references
+
+- [`docs/guide/27-resources.md` §"Scope — the leak boundary other libraries do not have"](../../docs/guide/27-resources.md) — the positioning this surface demonstrates live.
+- [`spec/016` resources §Named resource-scope resolvers / §Resource identity — the scoped key](../../spec/Spec-Schemas.md) — the `reg-resource-scope` + scoped-key contract.
+- [`implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc`](../../implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc) — the executable leak-boundary guarantees (scenarios 1/2/3).

--- a/testbeds/tenant_switcher/core.cljs
+++ b/testbeds/tenant_switcher/core.cljs
@@ -1,0 +1,303 @@
+(ns tenant-switcher.core
+  "Shared framework-behavior testbed — the scoped-cache TENANT SWITCHER.
+
+  EP-0013/resources Part-2 leak-boundary scenario 5 (rf2-5e22yc, spun from
+  rf2-wwhedk): the multi-SCOPE consumer the rest of the testbed tree lacks.
+  Every other multi-tenant-shaped surface in the repo is multi-FRAME (one app
+  per frame, each isolated). THIS one is multi-SCOPE: a SINGLE app, on a
+  SINGLE frame, switching the active principal — an admin impersonating
+  tenant `acme`, then `globex`, then back — while the scoped-cache keeps each
+  tenant's loaded dashboard structurally isolated and SIMULTANEOUSLY live.
+
+  The live demonstration of the guide's claim (docs/guide/27-resources.md
+  §\"Scope — the leak boundary other libraries do not have\"): the resolved
+  scope is IN the cache key, so two tenants' reads of the SAME params land on
+  two structurally distinct entries. After switching from `acme` to `globex`,
+  the active-scope view reads GLOBEX's dashboard — never `acme`'s cached data
+  — and switching back reads `acme`'s entry straight from cache (no refetch).
+  Both entries coexist in `:entries` the whole time; the active scope decides
+  which one a sub can even address. That is the structural property TanStack
+  Query / RTK Query / SWR enforce only by convention (the viewer id is one
+  hand-assembled segment of a query key); here it is the *type* of the key.
+
+  Scope resolution is the EP-0016 D3 named-resolver form: a `reg-resource-scope`
+  derives the active tenant's `[:rf.scope/tenant {:tenant-id …}]` from app-db
+  (`[:viewer :active-tenant]`), and the dashboard resource references it with
+  `{:from-db :tenant/scope}`. Switching tenants is one ordinary event that
+  rewrites `[:viewer :active-tenant]`; everything downstream (ensure, the
+  active-scope sub) re-resolves through the named resolver.
+
+  This is NOT a tutorial — the bodies are minimal and there are no deliberate
+  bugs or anti-pattern demos (feedback_testbeds_are_test_surfaces). The
+  EXECUTABLE leak-boundary guarantees (cross-user logout leak, wrong-scope
+  fail-closed read, scoped-invalidation isolation, lease-lifecycle
+  non-interference) are pinned by the CLJS unit suites
+  `resources_scope_leak_boundary_cljs_test.cljc` +
+  `resources_scoped_lease_lifecycle_cljs_test.cljc`; THIS surface is the live
+  demonstrator a tool (Xray / Story / re-frame2-pair-mcp) observes, not the
+  regression vehicle."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            ;; Resources artefact (day8/re-frame2-resources): requiring at
+            ;; app boot triggers its load-time registrations (the
+            ;; :rf.resource/* events + subs and the named-resolver scope
+            ;; plumbing). Without it, dispatching :rf.resource/ensure or
+            ;; subscribing :rf.resource/state would fail late-bound.
+            [re-frame.resources]
+            [re-frame.resources.registry]
+            ;; Managed-HTTP is the resource runtime's single built-in read
+            ;; transport. Requiring it publishes the late-bind feature probe
+            ;; the resource lowering consults (`:http/abort-on-actor-destroy`)
+            ;; so an HTTP-backed ensure does not fail artefact-missing. The
+            ;; testbed then OVERRIDES the `:rf.http/managed` fx with a
+            ;; deterministic in-memory stub (below) so no request crosses the
+            ;; wire — a testbed IS a test affordance, so this is correct.
+            [re-frame.http-managed]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ----------------------------------------------------------------------------
+;; The two tenants
+;; ----------------------------------------------------------------------------
+
+(def tenants
+  "The two principals the admin switches between. Each carries a distinct
+  display name and the secret payload its dashboard resource loads — the
+  payloads are intentionally different so a leak (reading the other tenant's
+  data after a switch) would be visible in the DOM. Ordered so the view's
+  button row and witness row render deterministically."
+  [["acme"   {:label "Acme Corp"  :motto "acme-only secret"}]
+   ["globex" {:label "Globex Inc" :motto "globex-only secret"}]])
+
+(def tenant-index
+  "Map view of `tenants` for id-keyed lookups."
+  (into {} tenants))
+
+(def no-data
+  "DOM sentinel rendered when a scope's dashboard has no loaded data — a
+  stable string the smoke can assert against (an empty motto would be a
+  fragile empty-string assertion, and would also read identically whether
+  the entry is genuinely absent or merely empty)."
+  "(no data)")
+
+;; ----------------------------------------------------------------------------
+;; Named scope resolver (EP-0016 D3) — derive the active tenant's scope once
+;; ----------------------------------------------------------------------------
+;;
+;; The viewer's ACTIVE tenant lives at [:viewer :active-tenant]; the resolver
+;; derives the concrete `[:rf.scope/tenant {:tenant-id …}]` from it. Pure —
+;; it derives a scope and does nothing else. Declaring `:inputs` lets a tool
+;; explain which app fact decides a resource identity (and lets the runtime
+;; re-resolve only when that input changes). Nil when no tenant is active —
+;; fail-closed by contract (never a silent shared/global read).
+
+(rf/reg-resource-scope :tenant/scope
+  {:inputs  {:tenant [:db [:viewer :active-tenant]]}
+   :resolve (fn [{:keys [tenant]} _ctx]
+              (when tenant [:rf.scope/tenant {:tenant-id tenant}]))})
+
+;; ----------------------------------------------------------------------------
+;; The tenant-scoped dashboard resource
+;; ----------------------------------------------------------------------------
+;;
+;; `:scope {:from-db :tenant/scope}` references the named resolver above, so
+;; the dashboard's cache key carries the active tenant structurally. Two
+;; tenants reading `{:page 1}` therefore land on two distinct entries — the
+;; leak boundary, by construction.
+
+(rf/reg-resource :tenant/dashboard
+  {:scope         {:from-db :tenant/scope}
+   :params-schema [:map [:page :int]]
+   :request       (fn [{:keys [page]} _ctx]
+                    {:request {:method :get :url "/dashboard" :params {:page page}}})
+   :tags          (fn [_p _v] #{[:dashboard]})})
+
+;; ----------------------------------------------------------------------------
+;; Deterministic in-memory transport stub
+;; ----------------------------------------------------------------------------
+;;
+;; The resource runtime lowers an ensure into `:rf.http/managed`, stamping the
+;; reply addressing it OWNS (`:on-success` / `:on-failure` carrying the
+;; verification payload — work-id + resource-key + scope + generation). This
+;; testbed overrides that fx with a stub that reads the runtime's own
+;; `:on-success` target and replies with a synthetic success through the
+;; ordinary internal reply path — so the entry loads exactly as a live read
+;; would, but deterministically and with no network. The success `:value` is
+;; derived from the resolved scope baked into the resource-key, so each
+;; tenant's entry loads ITS OWN distinct payload (a real cross-tenant leak
+;; would surface as the wrong motto in the DOM).
+
+(defn- tenant-id-of
+  "Extract the tenant-id from a scoped resource key's scope segment
+  `[:rf.scope/tenant {:tenant-id …}]`. The scope is the first element of the
+  `[scope resource-id params]` key the runtime computed."
+  [resource-key]
+  (let [[scope] resource-key]
+    (when (and (vector? scope) (= :rf.scope/tenant (first scope)))
+      (:tenant-id (second scope)))))
+
+(rf/reg-fx :rf.http/managed
+  (fn [_frame-ctx {:keys [on-success]}]
+    ;; HOT PATH — synthesise the success reply the live transport would have
+    ;; dispatched. `on-success` is `[reply-id verification-payload]`; the
+    ;; runtime verifies frame + work-id + generation on the payload before it
+    ;; writes, so stale/superseded replies are still suppressed correctly.
+    (let [[reply-id payload] on-success
+          tenant (tenant-id-of (:resource-key payload))
+          motto  (get-in tenant-index [tenant :motto])]
+      (rf/dispatch [reply-id payload {:kind :success
+                                      :value {:tenant tenant
+                                              :motto  motto}}]))))
+
+;; ----------------------------------------------------------------------------
+;; Events
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-db ::initialise
+  (fn [_db _ev]
+    ;; Boot with `acme` as the active tenant (the admin starts impersonating
+    ;; acme). No dashboard is ensured yet — the active-scope view reads idle
+    ;; until the operator clicks Load.
+    {:viewer {:active-tenant "acme"}}))
+
+(rf/reg-event-db ::switch-tenant
+  (fn [db [_ tenant]]
+    ;; The impersonation switch — one ordinary app-db write. The named scope
+    ;; resolver re-derives `[:rf.scope/tenant {:tenant-id tenant}]` from this
+    ;; on the next resolution, so every downstream ensure + active-scope sub
+    ;; re-points at the new tenant's entry.
+    (assoc-in db [:viewer :active-tenant] tenant)))
+
+(rf/reg-event-fx ::load-active-dashboard
+  (fn [_ctx _ev]
+    ;; Ensure the dashboard for the CURRENTLY-ACTIVE tenant. No explicit
+    ;; :scope — it is derived from app-db via the resource's {:from-db
+    ;; :tenant/scope} policy at use time, so this loads exactly the active
+    ;; tenant's entry. An :owner lease keeps the entry pinned for the session.
+    {:fx [[:dispatch [:rf.resource/ensure
+                      {:resource :tenant/dashboard
+                       :params   {:page 1}
+                       :owner    [:lease :tenant-switcher 1]}]]]}))
+
+;; ----------------------------------------------------------------------------
+;; Subs
+;; ----------------------------------------------------------------------------
+
+(rf/reg-sub :active-tenant (fn [db _] (get-in db [:viewer :active-tenant])))
+
+;; ----------------------------------------------------------------------------
+;; Views
+;; ----------------------------------------------------------------------------
+;;
+;; The active-scope panel subscribes `:rf.resource/state` / `:rf.resource/data`
+;; with NO explicit :scope — the sub resolves the active tenant's scope from
+;; app-db (the {:from-db} spec policy), so it ALWAYS reads the active tenant's
+;; entry and can never address another tenant's. That is the read seam where a
+;; leak would be visible; it structurally cannot happen.
+
+;; The ACTIVE-scope dashboard panel. Subscribes with NO explicit :scope — the
+;; sub resolves the active tenant's scope from app-db (the {:from-db} spec
+;; policy), so it always reads the active tenant's entry and can never address
+;; another tenant's. This is the read seam where a leak would be visible.
+(reg-view dashboard-panel []
+  (let [active (subscribe [:active-tenant])
+        q      {:resource :tenant/dashboard :params {:page 1}}
+        state  (subscribe [:rf.resource/state q])
+        data   (subscribe [:rf.resource/data q])]
+    (fn []
+      (let [tenant @active
+            label  (get-in tenant-index [tenant :label])
+            st     @state
+            d      @data]
+        [:div {:data-testid "dashboard-panel"
+               :style {:border "1px solid #aaa" :padding "0.75em"
+                       :margin "0.5em 0" :min-width "22em"}}
+         [:h3 "Active dashboard"]
+         [:p "tenant=" [:span {:data-testid "active-tenant"} tenant]
+          " (" label ")"]
+         [:p "status=" [:span {:data-testid "status"} (name (:status st))]]
+         [:p "motto=" [:span {:data-testid "motto"} (or (:motto d) no-data)]]]))))
+
+;; The CACHE WITNESS row — one explicit-scope read per tenant, side by side.
+;; Each subscribes `:rf.resource/state` at an EXPLICIT `[:rf.scope/tenant …]`
+;; scope, so it reads THAT tenant's entry regardless of who is active. This is
+;; the load-bearing evidence for scenario 5: once each tenant's dashboard is
+;; loaded, BOTH witnesses read `:loaded` with their OWN distinct motto at the
+;; same time — the two entries are simultaneously live in one cache, and each
+;; explicit scope addresses exactly its own (never the other's) data.
+(reg-view cache-witness [tenant]
+  (let [scope [:rf.scope/tenant {:tenant-id tenant}]
+        q     {:resource :tenant/dashboard :params {:page 1} :scope scope}
+        state (subscribe [:rf.resource/state q])
+        data  (subscribe [:rf.resource/data q])]
+    (fn [tenant]
+      (let [st @state
+            d  @data]
+        [:div {:data-testid (str "witness-" tenant)
+               :style {:border "1px dashed #bbb" :padding "0.5em"
+                       :margin "0.25em" :min-width "12em"}}
+         [:strong (get-in tenant-index [tenant :label])]
+         [:p {:style {:margin "0.25em 0"}}
+          "status="
+          [:span {:data-testid (str "witness-status-" tenant)} (name (:status st))]]
+         [:p {:style {:margin "0.25em 0"}}
+          "motto="
+          [:span {:data-testid (str "witness-motto-" tenant)} (or (:motto d) no-data)]]]))))
+
+(reg-view root []
+  (let [active (subscribe [:active-tenant])]
+    (fn []
+      [:div {:data-testid "tenant-switcher" :style {:font-family "sans-serif" :padding "1em"}}
+       [:h1 "tenant-switcher testbed"]
+       [:p "One app, one frame. Switch the active tenant (impersonation), load
+            each tenant's dashboard, and watch the scoped-cache keep both
+            tenants' entries simultaneously live yet structurally isolated —
+            the active-scope view only ever reads the active tenant's data."]
+
+       [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap :align-items :center}}
+        [:span "Impersonate:"]
+        ;; `doall` realises the deref-bearing lazy seq inside the reactive
+        ;; render (a bare `for` would defer the `@active` deref out of the
+        ;; reactive context — the "deref not supported in lazy seq" warning).
+        (doall
+          (for [[id {:keys [label]}] tenants]
+            ^{:key id}
+            [:button {:data-testid (str "switch-" id)
+                      :disabled    (= id @active)
+                      :on-click    #(dispatch [::switch-tenant id])}
+             label]))
+        [:button {:data-testid "load"
+                  :on-click    #(dispatch [::load-active-dashboard])}
+         "Load active dashboard"]]
+
+       [dashboard-panel]
+
+       [:h3 "Cache witnesses (explicit per-tenant scope)"]
+       [:p {:style {:color "#666"}}
+        "Each reads ITS OWN tenant scope explicitly, regardless of who is
+         active — evidence both entries coexist in one cache once loaded;
+         scope (not params) decides which one a read can address."]
+       [:div {:style {:display :flex :flex-wrap :wrap :align-items :flex-start}}
+        (doall
+          (for [[id _] tenants]
+            ^{:key id}
+            [cache-witness id]))]])))
+
+;; ----------------------------------------------------------------------------
+;; Mount
+;; ----------------------------------------------------------------------------
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  ;; EP-0002 (rf2-9o48ih): the runtime never synthesises a frame from absence.
+  ;; `:rf/default` is this testbed's app frame, registered explicitly; the
+  ;; boot dispatch runs under it and the render is wrapped in a
+  ;; `frame-provider` so in-tree dispatch/subscribe resolve to it.
+  (rf/reg-frame :rf/default {})
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [::initialise]))
+  (rdc/render react-root [rf/frame-provider {:frame :rf/default} [root]]))

--- a/testbeds/tenant_switcher/index.html
+++ b/testbeds/tenant_switcher/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: tenant-switcher</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    .rf2-testbed-shell { display: flex; min-height: 100vh; }
+    [data-rf-xray-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
+    #app { flex: 1; min-width: 0; padding: 2em; }
+  </style>
+</head>
+<body>
+  <div class="rf2-testbed-shell">
+    <main id="app"></main>
+    <aside data-rf-xray-host></aside>
+  </div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/testbeds/tenant_switcher/spec.cjs
+++ b/testbeds/tenant_switcher/spec.cjs
@@ -1,0 +1,92 @@
+/*
+ * tenant-switcher testbed — browser smoke (rf2-5e22yc, EP-0013/resources
+ * Part-2 leak-boundary scenario 5).
+ *
+ * The LIVE demonstration of the scoped-cache leak boundary as a multi-SCOPE
+ * consumer: one app, one frame, two tenant scopes simultaneously live in one
+ * cache, with the active scope deciding which entry a read can address. The
+ * executable leak-boundary GUARANTEES (cross-user logout leak, wrong-scope
+ * fail-closed read, scoped-invalidation isolation, lease-lifecycle
+ * non-interference) are pinned by the CLJS unit suites
+ * (resources_scope_leak_boundary_cljs_test.cljc +
+ * resources_scoped_lease_lifecycle_cljs_test.cljc); this smoke asserts the
+ * surface itself behaves — mount + switch + assert simultaneous isolation.
+ *
+ * Run via `npm run test:testbed-tenant-switcher` (the colocated runner
+ * compiles :testbeds/tenant-switcher, serves it, and drives this spec).
+ */
+const {
+  expectTextEquals,
+  expectVisible,
+} = require('../../examples/scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'tenant-switcher scoped-cache isolation smoke',
+  url: '/',
+  run: async (page) => {
+    const root = page.locator('[data-testid="tenant-switcher"]');
+    await expectVisible(root, 10000);
+
+    // The active panel + per-tenant cache witnesses.
+    const activeTenant = page.locator('[data-testid="active-tenant"]');
+    const activeMotto = page.locator('[data-testid="motto"]');
+    const activeStatus = page.locator('[data-testid="status"]');
+    const acmeWitnessMotto = page.locator('[data-testid="witness-motto-acme"]');
+    const acmeWitnessStatus = page.locator('[data-testid="witness-status-acme"]');
+    const globexWitnessMotto = page.locator('[data-testid="witness-motto-globex"]');
+    const globexWitnessStatus = page.locator('[data-testid="witness-status-globex"]');
+
+    const load = page.locator('[data-testid="load"]');
+    const switchAcme = page.locator('[data-testid="switch-acme"]');
+    const switchGlobex = page.locator('[data-testid="switch-globex"]');
+
+    // --- Step 1: boot as acme, nothing loaded yet. ---
+    await expectTextEquals(activeTenant, 'acme');
+    await expectTextEquals(activeStatus, 'idle');
+    await expectTextEquals(activeMotto, '(no data)'); // sentinel when no entry
+
+    // Load acme's dashboard — the active scope is derived as acme.
+    await load.click();
+    await expectTextEquals(activeStatus, 'loaded');
+    await expectTextEquals(activeMotto, 'acme-only secret');
+    // The acme cache witness (explicit scope) agrees; globex has no entry.
+    await expectTextEquals(acmeWitnessStatus, 'loaded');
+    await expectTextEquals(acmeWitnessMotto, 'acme-only secret');
+    await expectTextEquals(globexWitnessStatus, 'idle');
+    await expectTextEquals(globexWitnessMotto, '(no data)'); // sentinel — no entry
+
+    // --- Step 2: switch to globex. ---
+    // CRITICAL leak assertion: the active panel immediately reads globex's
+    // idle empty-state — NEVER acme's cached motto. The resolved scope is in
+    // the key, so the active read structurally cannot address acme's entry.
+    await switchGlobex.click();
+    await expectTextEquals(activeTenant, 'globex');
+    await expectTextEquals(activeStatus, 'idle');
+    // Sentinel empty-state (never "acme-only secret"): the active read
+    // resolves globex's scope and finds no entry, so it reads the sentinel
+    // — it structurally cannot address acme's cached entry.
+    await expectTextEquals(activeMotto, '(no data)');
+
+    // Load globex's dashboard.
+    await load.click();
+    await expectTextEquals(activeStatus, 'loaded');
+    await expectTextEquals(activeMotto, 'globex-only secret');
+
+    // --- Step 3: BOTH tenants simultaneously live + isolated (scenario 5). ---
+    // Both cache witnesses read :loaded with their OWN distinct motto at the
+    // same time — two entries coexist in one cache, each addressable only by
+    // its own scope.
+    await expectTextEquals(acmeWitnessStatus, 'loaded');
+    await expectTextEquals(acmeWitnessMotto, 'acme-only secret');
+    await expectTextEquals(globexWitnessStatus, 'loaded');
+    await expectTextEquals(globexWitnessMotto, 'globex-only secret');
+
+    // --- Step 4: switch back to acme — its data is still cached. ---
+    // The entry was never evicted; switching back reads it straight from
+    // cache (no refetch), and it is acme's data, never globex's.
+    await switchAcme.click();
+    await expectTextEquals(activeTenant, 'acme');
+    await expectTextEquals(activeStatus, 'loaded');
+    await expectTextEquals(activeMotto, 'acme-only secret');
+  },
+};


### PR DESCRIPTION
## What

Adds the **multi-SCOPE tenant-switcher testbed** — the live demonstrator of the scoped-cache **leak boundary** (EP-0013/resources Part-2 **scenario 5**, spun from rf2-wwhedk). One Reagent app on one frame (`:rf/default`) switches the active principal — an admin impersonating tenant `acme`, then `globex`, then back — while the scoped-cache keeps each tenant's loaded dashboard structurally isolated and *simultaneously live*. This is the multi-**scope** consumer the rest of the testbed tree lacks (every other multi-tenant-shaped surface, e.g. `multi_frame`, is multi-**frame**).

## How (idiomatic re-frame2 throughout)

- **Named scope resolver** (`reg-resource-scope :tenant/scope`, EP-0016 D3) derives `[:rf.scope/tenant {:tenant-id …}]` from `[:viewer :active-tenant]`, declared-inputs form. Nil → fail-closed.
- **Scoped resource** `:tenant/dashboard` references it via `:scope {:from-db :tenant/scope}`, so the active tenant rides the cache key *structurally* — two tenants reading `{:page 1}` land on two distinct entries.
- **Switching** is one ordinary `reg-event-db`; ensure + the active-scope sub re-resolve through the named resolver.
- **Deterministic in-memory transport stub**: overrides the `:rf.http/managed` fx to reply through the runtime's own `:on-success` target (the documented 3-arg internal reply `[reply-id verification-payload {:kind :success :value …}]`), deriving each tenant's payload from the resolved scope baked into the resource-key — so a real cross-tenant leak would surface as the wrong motto in the DOM. No network.
- **Active-scope panel** reads `:rf.resource/state` / `:rf.resource/data` with NO explicit scope (the read seam where a leak would be visible); **cache witnesses** read each tenant's entry at an explicit scope side by side (evidence both entries coexist).

The executable leak-boundary *guarantees* stay pinned by the CLJS unit suites (`resources_scope_leak_boundary_cljs_test` + `resources_scoped_lease_lifecycle_cljs_test`); this surface is the **live demonstrator**, not the regression vehicle.

## Hot-zone (`implementation/shadow-cljs.edn`)

Surgical add only: the `:testbeds/tenant-switcher` build-id + the `:dev-http 8060` port (the new 806x top-level-testbeds band, documented in `dev-testbed.cjs`). No other build touched. **Merge this PR before any parallel `shadow-cljs.edn` edit** (per the "Testbed build-ids in hot-zone shadow" reference).

## Recovery note

Recovered from a prior worker killed mid-task (5 uncommitted files). The partial work was sound and near-complete; salvaged it and fixed one inconsistency in `spec.cjs` — two assertions expected `'nil'` for the empty-state motto, but the view renders the `"(no data)"` sentinel (the robust choice the prior worker had introduced in `core.cljs`). Corrected both assertions to the sentinel. Scope limited to item (1) of the bead; the rf2-pubg18 skills coordination (item 2) is deliberately **not** done here.

## Quality gates

- `npm run test:testbed-tenant-switcher` (the new colocated browser smoke: compile + serve + mount + switch + assert simultaneous isolation) — **PASS** (0 warnings; re-run green post-rebase).
- **README link/inventory gate (`Verify README link slugs`, rf2-br5u7) — FIXED + PASS.** The new `testbeds/tenant_switcher/` dir was missing from the `testbeds/README.md` Layout map, so `check_readme_inventories.py` failed the job (layout-map<->disk drift). Added the `tenant_switcher/` row to the Layout map (and the matching `shadow-cljs watch` dev-run line). Now green: `check_readme_links.py --self-test`, `check_readme_links.py --ci`, `check_readme_inventories.py --self-test`, `check_readme_inventories.py --verbose` all exit 0.
- `npm run test:cljs` — **6856 tests / 27831 assertions, 0 failures, 0 errors**.
- `shadow-cljs.edn` parses cleanly (Clojure EDN reader + a live shadow-cljs compile of the build).

