### PR TITLE
fix(core): EP-0015 fail closed on unknown/unresolvable frame in egress projection (rf2-t55hxg.18)

### DIFF
--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -557,32 +557,54 @@
   (Spec 002 §Frame target resolution; EP-0002 §Trace, Projection, And
   Elision / §Privacy And Egress).
 
-  Frameless egress FAILS CLOSED. When no frame is carried, the per-frame
-  elision registry is unreachable, so a permissive identity walk would ship
-  every value verbatim under NO policy — the silent leak this contract
-  exists to abolish. Rather than borrow another frame's marks, the whole
-  value is conservatively redacted to the `:rf/redacted` sentinel.
-  `:rf.size/include-sensitive? true` is the deliberate opt-out: a caller
-  that has explicitly waived sensitive redaction gets the value walked with
-  an empty policy (the identity transform), so an inspector that genuinely
-  wants the raw, policy-free value asks for it on purpose."
+  A resolved frame-id is not enough — it must RESOLVE to a live frame.
+  An explicit `:frame` opt (or a stale carried scope) may name a frame that
+  was never registered or has since been destroyed. EP-0015 issue 1
+  (rf2-t55hxg.18): an unresolvable frame's per-frame elision registry is
+  unreachable (`registry-of` returns nil), so feeding it through the policy
+  walk produced an EMPTY-policy identity transform — shipping every value
+  verbatim under NO policy, the exact silent leak this contract abolishes.
+  An unknown / destroyed frame therefore FAILS CLOSED here too, identically
+  to the frameless case: it is validated against the live registry
+  (`frame/frame`) before being treated as policy-bearing. Spec 015
+  §Direct reads and fail-closed frame resolution: an unresolved frame must
+  fail closed — it must not fall through to a permissive walk, and never
+  synthesizes `:rf/default`.
+
+  Frameless / unresolvable-frame egress FAILS CLOSED. When no LIVE frame is
+  carried, the per-frame elision registry is unreachable, so a permissive
+  identity walk would ship every value verbatim under NO policy. Rather than
+  borrow another frame's marks, the whole value is conservatively redacted
+  to the `:rf/redacted` sentinel. `:rf.size/include-sensitive? true` is the
+  deliberate opt-out: a caller that has explicitly waived sensitive
+  redaction gets the value walked with an empty policy (the identity
+  transform), so an inspector that genuinely wants the raw, policy-free
+  value asks for it on purpose."
   ([v] (elide-wire-value v nil))
   ([v opts]
-   (let [frame-id (or (:frame opts) (frame/resolve-current-frame))]
+   (let [frame-id   (or (:frame opts) (frame/resolve-current-frame))
+         ;; A frame-id alone is not policy-bearing — it must resolve to a
+         ;; LIVE frame. `frame/frame` returns nil for an unknown /
+         ;; never-registered / destroyed id, so an explicit `:frame` opt or
+         ;; a stale carried scope that names a dead frame is treated exactly
+         ;; like the frameless case below (fail closed). rf2-t55hxg.18.
+         live-frame? (and (some? frame-id) (some? (frame/frame frame-id)))]
      (cond
-       ;; Known carried frame ⇒ apply that frame's elision policy.
-       (some? frame-id)
+       ;; Known + LIVE carried frame ⇒ apply that frame's elision policy.
+       live-frame?
        (elide-against-frame v opts frame-id)
 
-       ;; Frameless + the caller waived sensitive redaction ⇒ identity
-       ;; walk against an empty (no-frame) policy. The walker is the
-       ;; identity transform when no declarations are reachable.
+       ;; Frameless / unresolvable-frame + the caller waived sensitive
+       ;; redaction ⇒ identity walk against an empty (no-frame) policy. The
+       ;; walker is the identity transform when no declarations are
+       ;; reachable.
        (true? (:rf.size/include-sensitive? opts))
        (elide-against-frame v opts ::no-frame)
 
-       ;; Frameless egress, no opt-out ⇒ fail closed: no policy is
-       ;; available, so conservatively redact the whole value rather than
-       ;; borrow another frame's marks.
+       ;; Frameless / unresolvable-frame egress, no opt-out ⇒ fail closed:
+       ;; no policy is available, so conservatively redact the whole value
+       ;; rather than borrow another frame's marks or pass it through under
+       ;; an empty policy.
        :else
        privacy/redacted-sentinel))))
 

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -464,6 +464,88 @@
         "include-sensitive? true ⇒ frameless value rides verbatim (opt-out)")))
 
 ;; ---------------------------------------------------------------------------
+;; EP-0015 issue 1 (rf2-t55hxg.18) — an explicit / carried frame-id that
+;; cannot RESOLVE to a live frame fails CLOSED, identical to the frameless
+;; case. Before the fix `elide-wire-value` only checked `(some? frame-id)`:
+;; a non-nil id that named a never-registered or destroyed frame slipped
+;; into the policy walk, where `registry-of` returned nil → empty `:large` /
+;; `:sensitive` tables → an IDENTITY walk that shipped every value verbatim
+;; under NO policy. Spec 015 §Direct reads and fail-closed frame resolution:
+;; an unresolved frame must fail closed, never fall through to a permissive
+;; walk and never synthesize `:rf/default`.
+;; ---------------------------------------------------------------------------
+
+(deftest never-registered-explicit-frame-fails-closed
+  ;; An explicit `:frame` opt naming a frame that was never registered is
+  ;; non-nil but unresolvable ⇒ redact the whole value (do NOT pass through
+  ;; under an empty policy).
+  (binding [frame/*current-frame* nil]
+    (is (= :rf/redacted
+           (rf/elide-wire-value {:a 1 :b [2 3]}
+                                {:frame :elision-test/never-registered}))
+        "explicit unknown frame ⇒ whole value redacted (no empty-policy leak)")
+    (is (= :rf/redacted
+           (rf/elide-wire-value 42 {:frame :elision-test/never-registered}))
+        "fail-closed applies to scalars under an unknown explicit frame too")))
+
+(deftest destroyed-explicit-frame-fails-closed
+  ;; A frame that WAS registered (and could have carried a real `:large` /
+  ;; `:sensitive` policy) but has since been destroyed is no longer
+  ;; resolvable ⇒ fail closed. `frame/frame` returns nil for a destroyed id.
+  (frame/reg-frame :elision-test/doomed {})
+  (frame/destroy-frame! :elision-test/doomed)
+  (binding [frame/*current-frame* nil]
+    (is (= :rf/redacted
+           (rf/elide-wire-value {:secret "shh"}
+                                {:frame :elision-test/doomed}))
+        "destroyed explicit frame ⇒ whole value redacted")))
+
+(deftest unresolvable-frame-redacts-value-that-would-be-public-under-known-frame
+  ;; ADVERSARIAL — the value here carries NO sensitive declaration, so under
+  ;; a KNOWN frame it rides through verbatim (the value is "public"). The
+  ;; safety property is that the SAME value, projected under a frame that
+  ;; cannot be resolved, must NOT leak: fail-closed redacts the whole value
+  ;; regardless of what its policy WOULD have been under a live frame.
+  (binding [frame/*current-frame* nil]
+    ;; Baseline: under the live :rf/default frame (no declarations) the value
+    ;; passes through verbatim — it is "public".
+    (is (= {:profile {:name "Ada"}}
+           (rf/elide-wire-value {:profile {:name "Ada"}}
+                                {:frame :rf/default}))
+        "baseline: under a KNOWN frame with no policy the value is public")
+    ;; Same value, unresolvable frame ⇒ redacted whole. A would-be-public
+    ;; value still fails closed when the frame can't be resolved.
+    (is (= :rf/redacted
+           (rf/elide-wire-value {:profile {:name "Ada"}}
+                                {:frame :elision-test/never-registered}))
+        "the would-be-public value redacts whole under an unresolvable frame")))
+
+(deftest unresolvable-frame-include-sensitive-opt-out-still-identity
+  ;; The deliberate opt-out is unchanged: `:rf.size/include-sensitive? true`
+  ;; against an unresolvable frame walks the value under an empty (no-frame)
+  ;; policy — the caller explicitly waived redaction, so the value rides
+  ;; through. This keeps the escape hatch symmetric with the frameless case.
+  (binding [frame/*current-frame* nil]
+    (is (= {:a 1 :b [2 3]}
+           (rf/elide-wire-value {:a 1 :b [2 3]}
+                                {:frame :elision-test/never-registered
+                                 :rf.size/include-sensitive? true}))
+        "include-sensitive? true ⇒ unresolvable-frame value rides verbatim (opt-out)")))
+
+(deftest stale-carried-scope-frame-fails-closed
+  ;; The carried scope (`*current-frame*`) can outlive the frame it names —
+  ;; e.g. a `frame-bound-fn` closure fires after the frame was destroyed.
+  ;; A stale scope id that no longer resolves to a live frame must fail
+  ;; closed exactly like an explicit unknown `:frame` opt (the same
+  ;; `frame/frame` liveness check governs both resolution tiers).
+  (frame/reg-frame :elision-test/stale {})
+  (frame/destroy-frame! :elision-test/stale)
+  (binding [frame/*current-frame* :elision-test/stale]
+    (is (= :rf/redacted
+           (rf/elide-wire-value {:a 1}))
+        "stale carried scope naming a destroyed frame ⇒ fail closed")))
+
+;; ---------------------------------------------------------------------------
 ;; Collection-nested frame-declared elision at direct-read egress
 ;; (rf2-wm9kp).
 ;;

--- a/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
@@ -195,7 +195,16 @@
       (let [r (first @seen)]
         (is (= :rf.error/frame-destroyed (:error r)))
         (is (= :gone/frame (:frame r)))
-        (is (= [:whatever] (:event r)))
+        ;; EP-0015 issue 1 (rf2-t55hxg.18) — the `:event` slot is projected
+        ;; against the record's frame, which is UNRESOLVABLE here. With no
+        ;; classification policy to consult the slot FAILS CLOSED to
+        ;; `:rf/redacted` (it must not leak the attempted event vector under
+        ;; an empty policy) — and the fail-closed posture holds in production
+        ;; (`goog.DEBUG=false`), not just dev. Mirrors the dev-mode
+        ;; counterpart `listener-fires-on-frame-destroyed-dispatch`. The
+        ;; structural `:event-id` keyword still survives for observability.
+        (is (= :rf/redacted (:event r))
+            ":event fails closed under an unresolvable frame (prod survival)")
         (is (= :whatever (:event-id r)))))))
 
 (deftest frame-destroyed-dispatch-sync-listener-survives-prod

--- a/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
@@ -223,7 +223,14 @@
       (let [r (first @seen)]
         (is (= :rf.error/frame-destroyed (:error r)))
         (is (= :gone/frame (:frame r)))
-        (is (= [:any-sub] (:event r)))))))
+        ;; EP-0015 issue 1 (rf2-t55hxg.18) — the `:event` slot is projected
+        ;; against the record's frame, which is UNRESOLVABLE here. With no
+        ;; classification policy to consult the slot FAILS CLOSED to
+        ;; `:rf/redacted` (it must not leak the attempted query-v under an
+        ;; empty policy) — and the fail-closed posture holds in production
+        ;; (`goog.DEBUG=false`), not just dev.
+        (is (= :rf/redacted (:event r))
+            ":event fails closed under an unresolvable frame (prod survival)")))))
 
 (deftest no-such-handler-listener-survives-prod
   (testing "Per rf2-2hvga (= B / widen): a dispatch to a never-registered

--- a/implementation/core/test/re_frame/on_error_test.cljc
+++ b/implementation/core/test/re_frame/on_error_test.cljc
@@ -203,7 +203,15 @@
       (let [r (first @seen)]
         (is (= :rf.error/frame-destroyed (:error r)))
         (is (= :gone/frame (:frame r)) ":frame names the target frame")
-        (is (= [:whatever] (:event r)) ":event carries the attempted vector")
+        ;; EP-0015 issue 1 (rf2-t55hxg.18) — the `:event` slot is projected
+        ;; through `elide-wire-value` against the record's frame. Here the
+        ;; frame is UNRESOLVABLE (never registered), so there is no
+        ;; classification policy to consult and the slot FAILS CLOSED: the
+        ;; attempted vector is redacted whole rather than shipped verbatim
+        ;; under no policy. The structural `:event-id` keyword still survives
+        ;; for observability — it is not a user-value tree slot.
+        (is (= :rf/redacted (:event r))
+            ":event fails closed under an unresolvable frame (no empty-policy leak)")
         (is (= :whatever (:event-id r)))))))
 
 (deftest listener-fires-on-frame-destroyed-dispatch-sync
@@ -234,7 +242,12 @@
       (let [r (first @seen)]
         (is (= :rf.error/frame-destroyed (:error r)))
         (is (= :gone/frame (:frame r)))
-        (is (= [:any-sub] (:event r)) ":event carries the attempted query-v")))))
+        ;; EP-0015 issue 1 (rf2-t55hxg.18) — `:event` (here the attempted
+        ;; query-v) is projected against the record's frame. The frame is
+        ;; UNRESOLVABLE, so the slot fails closed to `:rf/redacted` rather
+        ;; than leaking the attempted query-v under no policy.
+        (is (= :rf/redacted (:event r))
+            ":event fails closed under an unresolvable frame (no empty-policy leak)")))))
 
 (deftest listener-fires-on-frame-destroyed-after-destroy-frame
   (testing "Per rf2-2hvga + Spec 002 §Destroy: after `destroy-frame!`,

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
@@ -394,6 +394,14 @@
   (testing "a record whose :db-after is itself the :rf/redacted scalar —
             the projection MUST preserve the scalar (no walk, no warning,
             no marker)"
+    ;; EP-0015 issue 1 (rf2-t55hxg.18) — `projected-record` is an EGRESS
+    ;; projection: each payload slot is walked against the record's frame
+    ;; (`:test/main`). The frame must RESOLVE to a live frame for its
+    ;; (empty) classification policy to be consulted; an unresolvable frame
+    ;; FAILS CLOSED and redacts the whole slot. The frame is registered with
+    ;; an empty (no-declaration) policy here exactly as every sibling test
+    ;; in this file does, so the public `{:n 0}` slot walks through verbatim.
+    (rf/reg-frame :test/main {})
     (let [synthetic
           {:epoch-id      1
            :frame         :test/main

--- a/tools/story/test/re_frame/story_error_test.clj
+++ b/tools/story/test/re_frame/story_error_test.clj
@@ -8,9 +8,28 @@
   `:stack` / `:data`). These tests pin the canonical shape and confirm the
   drift is gone — every routed site now yields the SAME
   `{:message :stack :data}` shape."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story.error :as story-error]))
+
+;; ---- fixture ---------------------------------------------------------------
+;;
+;; Most assertions here are pure (`throwable->error-map` is data→data), but
+;; the `exception-record` projection is FRAME-SCOPED egress (EP-0015 issue 1,
+;; rf2-t55hxg.18): the `:data` slot is walked against the record's frame and
+;; FAILS CLOSED when that frame is unresolvable. Tests that need a live
+;; variant frame (`reg-frame`) require an installed adapter, so init the
+;; plain-atom adapter and clean frame state around each test.
+(use-fixtures :each
+  (fn [test-fn]
+    (reset! frame/frames {})
+    (try (rf/init! plain-atom/adapter)
+         (catch clojure.lang.ExceptionInfo _ nil))
+    (frame/ensure-default-frame!)
+    (test-fn)))
 
 ;; ---- throwable->error-map -------------------------------------------------
 
@@ -71,19 +90,34 @@
 (deftest exception-record-wraps-the-projection
   (testing "exception-record builds the full :rf.error/exception assertion
             record with the canonical error projection embedded"
-    (let [e (ex-info "kaboom" {:k :v})
-          r (story-error/exception-record :story.x/v :phase-2-events
-                                          [:some/event 1] e)]
-      (is (= :rf.error/exception (:assertion r)))
-      (is (= :story.x/v          (:variant-id r)))
-      (is (= :phase-2-events     (:phase r)))
-      (is (= [:some/event 1]     (:event r)))
-      (is (false?                (:passed? r)))
-      (is (= (story-error/throwable->error-map e) (:error r))
-          "the :error slot is exactly the shared projection")
-      (is (= "kaboom" (-> r :error :message)))
-      (is (= {:k :v}  (-> r :error :data)))
-      (is (string?    (-> r :error :stack))))))
+    ;; EP-0015 issue 1 (rf2-t55hxg.18) — `exception-record` threads
+    ;; `variant-id` as the `:frame` for the `:data` wire-elision. The
+    ;; `:data` projection is FRAME-SCOPED egress: the frame must RESOLVE to
+    ;; a live frame for its (empty) policy to be consulted; an unresolvable
+    ;; frame FAILS CLOSED and redacts the whole `ex-data` map. In the real
+    ;; Story runtime the variant frame is always live when an error is
+    ;; recorded (`re-frame.story.frames` `reg-frame`s `variant-id` before
+    ;; the phases run), so register it here too — the public `{:k :v}` then
+    ;; walks through verbatim under the empty policy. `throwable->error-map`
+    ;; in the assertion below must be projected against the SAME live frame
+    ;; (a frameless call would itself fail closed) to match `exception-record`.
+    (rf/reg-frame :story.x/v {})
+    (try
+      (let [e (ex-info "kaboom" {:k :v})
+            r (story-error/exception-record :story.x/v :phase-2-events
+                                            [:some/event 1] e)]
+        (is (= :rf.error/exception (:assertion r)))
+        (is (= :story.x/v          (:variant-id r)))
+        (is (= :phase-2-events     (:phase r)))
+        (is (= [:some/event 1]     (:event r)))
+        (is (false?                (:passed? r)))
+        (is (= (story-error/throwable->error-map e {:frame :story.x/v}) (:error r))
+            "the :error slot is exactly the shared projection (same live frame)")
+        (is (= "kaboom" (-> r :error :message)))
+        (is (= {:k :v}  (-> r :error :data)))
+        (is (string?    (-> r :error :stack))))
+      (finally
+        (rf/destroy-frame! :story.x/v)))))
 
 (deftest exception-record-threads-message-override
   (testing "the opts arity threads :message through to the embedded


### PR DESCRIPTION
## Summary

EP-0015 post-graduation review, issue 1 (rf2-t55hxg.18) — a **privacy/security correctness fix**. The egress/classification path did NOT fail closed on an unknown/unresolvable frame: it fell through to passing data unredacted under an empty policy.

### The gap

`re-frame.elision/elide-wire-value` decided a frame was policy-bearing on `(some? frame-id)` alone:

- An explicit `:frame` opt (or a stale carried scope) can name a frame that was **never registered or has since been destroyed**. That id is non-nil.
- `(some? frame-id)` was true, so it fell through to `elide-against-frame`, where `registry-of` returns `nil` (no live container) -> `:large`/`:sensitive` tables both `{}` -> the walker becomes the **identity transform** -> every value shipped **verbatim under NO policy**.

That is the exact fail-OPEN leak the contract exists to abolish: a would-be-public value (or a sensitive one) crosses the boundary raw whenever the frame can't be resolved. spec/015 §Direct reads and fail-closed frame resolution (L358/L381) requires unresolved frames to fail closed — redact whole, never synthesize `:rf/default`.

### The fix

Validate the resolved `frame-id` against the **live** registry (`frame/frame`, which returns nil for unknown/never-registered/destroyed ids) before treating it as policy-bearing. An unresolvable frame now FAILS CLOSED identically to the frameless case: the whole value is redacted to `:rf/redacted`. The `:rf.size/include-sensitive? true` opt-out is unchanged (a deliberate waiver -> identity walk against an empty policy).

`re-frame.projection/project-egress` delegates every tree-shaped slot to `elide-wire-value` (via `walk-slot`), so the record-level boundary primitive inherits the fix at the single central point — no second code path. No `:rf/default` is ever synthesized.

### Tests

- `elision_test.clj`: never-registered explicit frame redacts whole (map + scalar); destroyed explicit frame redacts whole; **adversarial** — a would-be-public value (no sensitive decl, public under a known frame) still redacts whole under an unresolvable frame; stale carried scope naming a destroyed frame fails closed; the `include-sensitive? true` opt-out still rides verbatim.
- The always-on error-emit path (`error_emit/dispatch-on-error!`) projects a frame-destroyed record's `:event` against that (destroyed) frame, so it now correctly fails closed. Updated the frame-destroyed observability assertions in BOTH the dispatch and subscribe paths, dev and production, to assert `:event` redacts to `:rf/redacted` — the structural `:event-id` keyword still survives for observability — (`on_error_test.cljc` dispatch + subscribe; `on_error_elision_prod_test.cljs` dispatch + subscribe, the dispatch one was the CI miss below).

### CI fail-closed reconciliation (test-only)

Three CI gates broke because they asserted the OLD permissive contract (unresolvable frame -> empty-policy identity walk -> value shipped verbatim). All three were **case (a) stale-test-updated** to the fail-closed reality — the fail-closed invariant in `elision.cljc` is untouched. None was an over-reach.

- **JVM epoch** — `epoch_redact_fn_projection_test` `E-projected-record-on-record-with-sentinel-db-after` built a synthetic record naming `:test/main` but never registered it (unlike every sibling test). `projected-record` is an egress projection walking each slot against the record frame; an unregistered frame fails closed and redacts `:db-before`. **Fix:** register `:test/main` (empty policy) so the public `{:n 0}` slot walks through — matching the sibling tests and the real runtime.
- **JVM tools/story** — `story_error_test` `exception-record-wraps-the-projection` built a record with `variant-id :story.x/v` without mounting that frame. `exception-record` threads `variant-id` as the `:frame` for the `:data` wire-elision; an unresolvable frame fails closed and redacts `ex-data`. In the real Story runtime the variant frame is always live (`re-frame.story.frames` `reg-frame`s `variant-id` before phases run). **Fix:** register `:story.x/v` (init the plain-atom adapter in a `:each` fixture) and project the baseline assertion against the same live frame.
- **browser-prod-elision** — `on_error_elision_prod_test` `frame-destroyed-dispatch-listener-survives-prod` still asserted `:event = [:whatever]` (the prior pass updated the prod *subscribe* path but missed the prod *dispatch* path). `:event` is projected against the unresolvable `:gone/frame`, so it fails closed to `:rf/redacted` — identical to the already-updated dev-mode dispatch test and the prod subscribe test. **Fix:** expect `:rf/redacted`; `:event-id` survives.

### Scope

This PR delivers EP-0015 review **issue 1** (core fail-closed). Issue 2 (Story-MCP owns a standalone derived-tree value-redaction engine; centralize into a shared framework/MCP-base primitive) is a distinct `tools/story-mcp/` refactor, split to **rf2-i783h0**.

Spec unchanged — spec/015 §Direct reads and fail-closed frame resolution (L358/L381) already mandated this behavior; the implementation now matches the spec.

## Quality gates

| Gate | Result |
|---|---|
| `clojure -M:test` (epoch JVM) | PASS — 324 tests, 1268 assertions, 0 failures, 0 errors |
| `clojure -M:test` (tools/story JVM) | PASS — 1672 tests, 6195 assertions, 0 failures, 0 errors |
| `npm run test:browser-prod-elision` (`:advanced` + `goog.DEBUG=false`) | PASS — 74 tests, 231 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (node CLJS) | PASS — 6863 tests, 27875 assertions, 0 failures, 0 errors |
| `npm run test:elision` (production elision probe) | PASS — production 42/42 absent; control 42/42 present |

Classification/elision path touched -> elision gates run and green.
