### PR TITLE
refactor(core): retire dead :rf.warning/plain-fn-under-non-default-frame-once emit (rf2-7yqn39)

### DIFF
--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -953,11 +953,11 @@ Per Spec 009 §Performance instrumentation: every render of a registered view br
 
 The trace late-bind hook (`:trace/emit!`) is unchanged. The render-key binding (`*render-key*`) is unchanged.
 
-### §9.6 The plain-fn-under-non-default-frame warning
+### §9.6 The plain-fn-under-non-default-frame warning — RETIRED (EP-0002)
 
-The detection at `re-frame.views/maybe-warn-plain-fn-under-non-default-frame!` (views.cljs:454-531) reads `(r/current-component)` and inspects `(.-context cmp)`. Under the rewrite this becomes `(reagent2.core/current-component)` — same shape, same field access. **The narrowness contract is preserved**: reg-view-wrapped components carry `:contextType frame-context` (read into `(.-context cmp)`) so they get the surrounding frame; plain Reagent fns lack the wiring and route to `:rf/default`, triggering the warning.
+The `:rf.warning/plain-fn-under-non-default-frame-once` warning and its detection helper were RETIRED (EP-0002; rf2-7yqn39 deleted the dead emit). Under EP-0002 there is no `:rf/default` floor: a plain (non-`reg-view`) Reagent fn that cannot read the surrounding Provider's frame resolves to nil and its ambient `subscribe`/`dispatch` raises the always-on `:rf.error/no-frame-context` — the loud error superseded the soft warning. There is no longer a plain-fn detection path for the rewrite to preserve.
 
-This is the one place the rewrite is forced to keep Reagent's class-component context-read shape (`(.-context cmp)`) — UIx / Helix function components route through `_currentValue` per `re-frame.adapter.context/function-component-current-frame`. The rewrite's class-component-shape preserves the existing detection path.
+Reg-view-wrapped components still carry `:contextType frame-context` (read into `(.-context cmp)`) so they pick up the surrounding frame; this is the one place the rewrite keeps Reagent's class-component context-read shape (`(.-context cmp)`) — UIx / Helix function components route through `_currentValue` per `re-frame.adapter.context/function-component-current-frame`.
 
 ---
 

--- a/implementation/core/src/re_frame/adapter/context.cljs
+++ b/implementation/core/src/re_frame/adapter/context.cljs
@@ -173,10 +173,12 @@
 ;; canonical impl that the UIx and Helix adapters publish through the
 ;; `:adapter/current-frame` late-bind hook. Reagent has its own impl
 ;; in `re-frame.views/current-frame` that uses the class-component
-;; `(.-context cmp)` path so the plain-fn-under-non-default-frame-once
-;; warning's narrowness contract is preserved (plain Reagent fns
-;; lacking `:contextType` continue to route to `:rf/default`, which is
-;; what the warning targets).
+;; `(.-context cmp)` path: a plain Reagent fn lacking `:contextType`
+;; cannot read the surrounding Provider's frame, so under EP-0002 (no
+;; `:rf/default` floor) its ambient `subscribe`/`dispatch` resolves nil
+;; and raises the always-on `:rf.error/no-frame-context` rather than
+;; silently routing to a default. (This superseded the retired
+;; `:rf.warning/plain-fn-under-non-default-frame-once` warning.)
 
 (defn function-component-current-frame
   "Resolution chain (READER) for function-component substrates (UIx,

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -809,12 +809,9 @@
     :description "Install the substrate-specific hiccup emitter for SSR. Chained — every loaded React-shaped adapter contributes its own install step so a single SSR ns-load auto-wires every adapter's render-to-string slot."}
 
    ;; ---- re-frame.views (CLJS, rf2-4edk warn-once chain) ---------------------
-   {:key         :views/maybe-warn-plain-fn-under-non-default-frame!
-    :producer-ns 're-frame.views.warn-once
-    :description "Emit the once-per-pair warning when a plain fn renders under a non-default frame."}
    {:key         :views/clear-plain-fn-warned-pairs!
     :producer-ns 're-frame.views.warn-once
-    :description "Clear the warned-pairs cache (test isolation)."}
+    :description "Clear the warned-plain-fn-frame-pairs cache (warn-once-clear chain / test isolation; rf2-z79p8). The warning this cache once gated is retired per EP-0002 (rf2-7yqn39) — the cache is retained only as a governed member of the :adapter/clear-warn-once-caches! chain."}
    {:key         :views/reading-render-key
     :producer-ns 're-frame.views
     :design-bead "rf2-vh1k3"

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -921,22 +921,11 @@
    ;; than silently reading the wrong frame's app-db. The `extra` threads
    ;; the sub-id into the error payload's `:event-id` slot so a frameless
    ;; subscribe's error is attributed to the query it carried.
-   #?(:cljs
-      (let [frame-id (frame/require-current-frame!
-                       :subscribe
-                       {:where    're-frame.subs/subscribe
-                        :event-id (first query-v)})]
-        (when interop/debug-enabled?
-          (when-let [warn! (late-bind/get-fn
-                            :views/maybe-warn-plain-fn-under-non-default-frame!)]
-            (warn! frame-id query-v)))
-        (subscribe frame-id query-v))
-      :clj
-      (subscribe (frame/require-current-frame!
-                   :subscribe
-                   {:where    're-frame.subs/subscribe
-                    :event-id (first query-v)})
-                 query-v)))
+   (subscribe (frame/require-current-frame!
+                :subscribe
+                {:where    're-frame.subs/subscribe
+                 :event-id (first query-v)})
+              query-v))
   ([frame-id query-v]
    ;; rf2-9hoos (CLJS, dev-only): record the view→sub edge — push this
    ;; query-v into the in-flight render's deref sink so `:rf.view/rendered`

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -185,8 +185,6 @@
 
 (def clear-warned-non-dom-roots! warn-once/clear-warned-non-dom-roots!)
 (def clear-plain-fn-warned-pairs! warn-once/clear-plain-fn-warned-pairs!)
-(def maybe-warn-plain-fn-under-non-default-frame!
-  warn-once/maybe-warn-plain-fn-under-non-default-frame!)
 
 ;; The React-context object is consumed by `reg-view*` below (the
 ;; `:contextType` static-field) and by the warn-once helpers in

--- a/implementation/core/src/re_frame/views/warn_once.cljs
+++ b/implementation/core/src/re_frame/views/warn_once.cljs
@@ -1,11 +1,9 @@
 (ns re-frame.views.warn-once
   "Warn-once caches and detection helpers for the Reagent-side views ns.
   Re-frame.views re-exports the publicly-referenced surface
-  (`clear-warned-non-dom-roots!`,
-  `maybe-warn-plain-fn-under-non-default-frame!`,
-  `clear-plain-fn-warned-pairs!`).
+  (`clear-warned-non-dom-roots!`, `clear-plain-fn-warned-pairs!`).
 
-  Two warn-once concerns live here:
+  Two warn-once caches live here:
 
   1. Non-DOM-root warning (Spec 006 §Source-coord annotation,
      documented exemption). When a reg-view'd component returns a
@@ -15,16 +13,14 @@
      the per-process set; `make-reset-runtime-fixture` clears it via the
      chained `:adapter/clear-warn-once-caches!` hook.
 
-  2. Plain-fn-under-non-default-frame warning (Spec 004 §Plain
-     Reagent fns / Spec 006 §706). Detected at subscribe-time;
-     suppression keyed by `[component-id non-default-frame-id]` pairs.
-     Production builds elide via the `interop/debug-enabled?` gate."
-  (:require [re-frame.adapter.context :as adapter-context]
-            [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.trace :as trace]
-            [re-frame.views.provider :as provider]))
+  2. Plain-fn-under-non-default-frame suppression cache (`warned-plain-fn-
+     frame-pairs`). The warning this cache once gated is RETIRED — see the
+     section below — but the cache itself is retained as a governed member
+     of the warn-once-clear chain (rf2-z79p8): it is one of the empirical
+     example caches the warn-once-clear governance gate arms/fires/asserts
+     against, proving the canonical `:adapter/clear-warn-once-caches!`
+     chain wipes every enrolled cache between tests."
+  (:require [re-frame.late-bind :as late-bind]))
 
 ;; ---- non-DOM-root warning ------------------------------------------------
 
@@ -57,196 +53,57 @@
              "§Source-coord annotation: pair tools fall back to :rf/id "
              "for non-DOM roots).")))))
 
-;; ---- plain-fn-under-non-default-frame warning (rf2-d3k3) -----------------
+;; ---- plain-fn-under-non-default-frame warning — RETIRED (EP-0002) --------
 ;;
-;; SUPERSEDED BY EP-0002 (rf2-69r7ui). The old contract: a plain Reagent fn
-;; (not registered via `reg-view`, so without the `^{:contextType
-;; frame-context}` metadata `reg-view` attaches) cannot read the
-;; surrounding React-context frame, so its `(rf/subscribe ...)` /
-;; `(rf/dispatch ...)` fell through to `:rf/default` — and this helper
+;; The `:rf.warning/plain-fn-under-non-default-frame-once` warning is RETIRED
+;; (Spec 009 §Error event catalogue, the strikethrough row), superseded by the
+;; always-on `:rf.error/no-frame-context` error per EP-0002 (rf2-69r7ui). The
+;; old contract: a plain Reagent fn (not registered via `reg-view`, so without
+;; the `^{:contextType frame-context}` metadata `reg-view` attaches) cannot
+;; read the surrounding React-context frame, so its `(rf/subscribe ...)` /
+;; `(rf/dispatch ...)` fell through to `:rf/default` — and a now-deleted helper
 ;; emitted a once-per-pair warning about the silent fall-through.
 ;;
-;; Under EP-0002 there is NO `:rf/default` floor. A plain fn that cannot
-;; read the context resolves to nil (the no-provider sentinel coerces to
-;; nil), and `frame/require-current-frame!` — which `subs/subscribe` and
-;; the dispatch envelope call BEFORE this helper — raises the always-on
-;; `:rf.error/no-frame-context` and HALTS the operation. That loud error
-;; IS the sharper diagnostic this warning used to soften: a bare reagent fn
-;; under no usable scope now fails fast rather than silently targeting a
-;; default. So the warning's original firing case (plain fn under a
-;; non-default provider, no `with-frame`) is now UNREACHABLE — the throw
-;; happens first. The only remaining reachable code path is a plain fn
-;; under an explicit `with-frame` scope (Condition 4 below requires
-;; `*current-frame*` SET for the resolution to have succeeded), where the
-;; fn correctly picks up the dynamic-var frame and NO warning is wanted —
-;; so this helper is now a structural no-op. It is retained (rather than
-;; deleted) so the late-bind hook table + the warn-once governance chain
-;; keep a stable shape across the EP-0002 chain; a follow-on cleanup bead
-;; may retire it once the `:rf.warning/plain-fn-under-non-default-frame-once`
-;; consumers (10x / pair) migrate to the no-frame-context error.
+;; Under EP-0002 there is NO `:rf/default` floor. A plain fn that cannot read
+;; the context resolves to nil (the no-provider sentinel coerces to nil), and
+;; `frame/require-current-frame!` — which `subs/subscribe` and the dispatch
+;; envelope call BEFORE anything else — raises the always-on
+;; `:rf.error/no-frame-context` and HALTS the operation. That loud error IS
+;; the sharper diagnostic the warning used to soften. So the warning's firing
+;; case (plain fn under a non-default provider, no `with-frame`) became
+;; UNREACHABLE — the throw happened first — leaving the helper a structural
+;; no-op contradicting the catalogue's RETIRED ruling. rf2-7yqn39 deleted the
+;; dead emit site, the helper, its `:views/maybe-warn-plain-fn-under-non-
+;; default-frame!` late-bind hook, the `subs/subscribe` call site, and the
+;; `re-frame.views` re-export.
 ;;
-;; Detection sits at subscribe-time per Spec 006 §706: subscribe
-;; consults this helper through the late-bind hook table; the JVM build
-;; never sees this ns and the lookup returns nil there.
-;;
-;; Suppression: a process-wide `defonce` atom set keyed by [component-id
-;; frame-id] pairs. The suppression cache survives hot-reload (`defonce`)
-;; so repeated re-renders of the same plain fn produce exactly one
-;; warning per pair across the JS process. Per Spec 004 §The suppression
-;; cache: destroying and re-creating a frame resets the warning history
-;; for that frame — implemented by `clear-plain-fn-warned-pairs-for-frame!`
-;; which the frame-destroy path can call (today the cache is process-wide
-;; and the helper is exported for tests / future destroy-frame! integration).
-;;
-;; Production-elision: every code path is gated on `interop/debug-enabled?`.
-;; Under :advanced + `goog.DEBUG=false` the closure compiler constant-folds
-;; the gate and the entire detection branch, the trace emission, and the
-;; `console.warn` fallback are dead-code-eliminated. Per Spec 009
-;; §Production builds.
+;; The `warned-plain-fn-frame-pairs` suppression cache and its
+;; `clear-plain-fn-warned-pairs!` clear-fn are RETAINED — not for the retired
+;; warning, but as a governed member of the warn-once-clear chain (rf2-z79p8).
+;; They enrol through `register-warn-once-clear-fn!` below so the warn-once-
+;; clear governance gate (`re-frame.warn-once-clear-governance-{cljs-,}test`)
+;; can arm/fire/assert that the canonical `:adapter/clear-warn-once-caches!`
+;; chain wipes every enrolled cache between tests.
 
 (defonce ^:private warned-plain-fn-frame-pairs
-  ;; Set of `[component-id frame-id]` pairs already warned about. Per
-  ;; Spec 004 §The suppression cache.
+  ;; Set of `[component-id frame-id]` pairs. Retained as a governed member of
+  ;; the warn-once-clear chain (rf2-z79p8); the warning it once gated is
+  ;; retired (see the section above).
   (atom #{}))
 
 (defn clear-plain-fn-warned-pairs!
-  "Reset the warn-once suppression cache. Tests use this between cases
-  so each case starts from a clean slate. Per Spec 004 §The suppression
-  cache."
+  "Reset the warn-once suppression cache. Retained as the clear-fn the
+  warn-once-clear governance chain (rf2-z79p8) drives — see the RETIRED
+  section above and `register-warn-once-clear-fn!` below."
   []
   (reset! warned-plain-fn-frame-pairs #{})
   nil)
 
-(defn- plain-fn-component-id
-  "Identify the rendering component for warn-once keying. Reagent
-  components carry the user's render-fn as `.-cljsLegacyRender` (form-1)
-  or as the bound fn proper. We prefer `displayName` (which Reagent /
-  React tend to set for named fns), then fall back to the constructor's
-  `name`, then a string repr. The id is opaque text used only as the
-  cache key and the warning's `:fn-name` payload — stable across renders
-  of the same component, distinct across different component fns."
-  [cmp]
-  (or (when-let [n (.-displayName ^js cmp)]
-        (when (and (string? n) (not= "" n)) n))
-      (let [c (.-constructor ^js cmp)
-            n (when c (.-name ^js c))]
-        (when (and (string? n) (not= "" n) (not= "Object" n)) n))
-      (pr-str cmp)))
-
-(defn- read-react-context-frame
-  "Read the value the closest enclosing frame-provider has pushed onto
-  the shared React context. A thin wrapper around
-  `adapter-context/current-frame` minus the dynamic-var tier — the
-  warn-once detection below has already filtered to the case where
-  `*current-frame*` is unset (Condition 4), so we want the React-
-  context value alone.
-
-  The canonical user-facing surface (`rf/frame-provider`) mounts the
-  Provider via Reagent's `:r>` interop head so the props map flows to
-  React as a raw JS object — `convert-prop-value` is bypassed and the
-  keyword reaches React unchanged. A raw-hiccup mount via
-  `[:> (.-Provider frame-context) {:value :foo}]` directly still
-  passes through stock Reagent's `convert-prop-value`, which
-  stringifies the keyword. The keyword/string coercion below tolerates
-  both shapes so the detection logic sees a keyword regardless of how
-  the closest Provider was authored. EP-0002 (rf2-69r7ui): the
-  createContext default is the no-provider sentinel
-  (`adapter-context/no-provider-sentinel`, a keyword), so this raw read
-  returns that sentinel when no Provider sits above — distinguishable
-  from a genuine frame keyword by the caller (the detection below already
-  filters to the non-default-provider case)."
-  []
-  (let [v (.-_currentValue ^js adapter-context/frame-context)]
-    (cond
-      (keyword? v)                  v
-      (and (string? v) (not= "" v)) (keyword v))))
-
-(defn maybe-warn-plain-fn-under-non-default-frame!
-  "Detection per Spec 006 §706 (plain-fn-under-non-default-frame
-  warning). Called from `re-frame.subs/subscribe` after frame
-  resolution; `resolved-frame-id` is the frame the subscribe call
-  routed to.
-
-  Conditions for the warning to fire (all must hold):
-    1. We are mid-render — `(current-component)` returns a component.
-    2. The component is NOT a reg-view-wrapped one — its `contextType`
-       is not the shared `frame-context`. (reg-view-wrapped components
-       carry the `:contextType` so they read the surrounding Provider's
-       value into `(.-context cmp)`; plain fns do not.)
-    3. The closest enclosing Provider names a non-default frame.
-    4. The dynamic `*current-frame*` tier is unset — i.e. no `with-frame`
-       binding shadows the React-context read. When `with-frame` IS set,
-       the plain fn picks up the frame correctly via the dynamic var,
-       and no warning is needed.
-
-  Suppression: warn-once per `[component-id non-default-frame-id]` pair.
-  Subsequent renders of the same plain fn under the same Provider stay
-  silent. Per Spec 004 §at most once per (component, non-default-frame)
-  pair.
-
-  Returns nil. Production builds elide the entire body via the
-  `interop/debug-enabled?` gate the trace surface itself rides — the
-  call site in subs already pays a `(when interop/debug-enabled? ...)`
-  test, so this fn is reached only in dev / JVM (where it is unbound
-  via late-bind and not called)."
-  [resolved-frame-id _query-v]
-  (when interop/debug-enabled?
-    (let [cmp (provider/current-component)]
-      ;; Condition 1: must be mid-render.
-      (when (some? cmp)
-        ;; Condition 2: component must NOT be reg-view-wrapped. The
-        ;; sentinel is the `contextType` static — reg-view's wrapper
-        ;; sets it to `frame-context`; plain fns leave it unset (or
-        ;; React's empty default).
-        (let [ctx-type (some-> ^js cmp .-constructor .-contextType)]
-          (when-not (identical? ctx-type adapter-context/frame-context)
-            ;; Condition 3: closest enclosing Provider names a
-            ;; non-default frame.
-            (let [provider-frame (read-react-context-frame)]
-              (when (and (keyword? provider-frame)
-                         (not= :rf/default provider-frame))
-                ;; Condition 4: no with-frame binding shadowing the
-                ;; React-context read.
-                (when (nil? frame/*current-frame*)
-                  (let [fn-id (plain-fn-component-id cmp)
-                        pair  [fn-id provider-frame]]
-                    (when-not (contains? @warned-plain-fn-frame-pairs pair)
-                      (swap! warned-plain-fn-frame-pairs conj pair)
-                      (let [reason (str "Plain Reagent fns do not pick "
-                                        "up the surrounding frame; their "
-                                        "dispatch/subscribe targets "
-                                        ":rf/default. To capture the "
-                                        "surrounding frame, register the "
-                                        "view via reg-view.")]
-                        (trace/emit! :warning
-                                     :rf.warning/plain-fn-under-non-default-frame-once
-                                     {:fn-name        fn-id
-                                      :rendered-under provider-frame
-                                      :routed-to      resolved-frame-id
-                                      :reason         reason
-                                      :recovery       :warned-and-replaced})
-                        ;; Per Spec 004 §The footgun is loud: in dev,
-                        ;; the runtime also `console.warn`s the first
-                        ;; occurrence. The trace event is the
-                        ;; programmatic surface (10x, re-frame-pair);
-                        ;; the console message is the human-eyeballs
-                        ;; surface.
-                        (when (exists? js/console)
-                          (.warn js/console
-                            (str "[re-frame] :rf.warning/plain-fn-under-"
-                                 "non-default-frame-once — " fn-id
-                                 " rendered under " provider-frame
-                                 "; subscribe/dispatch routed to "
-                                 resolved-frame-id ". " reason)))))))))))))
-    nil))
-
-;; Publish through the late-bind hook table so re-frame.subs (a leaf
-;; namespace, .cljc, JVM-runnable) can call the helper without
-;; statically requiring this CLJS-only ns. JVM builds never load this
-;; file; the lookup returns nil there and subs no-ops the warning
-;; check. Per re-frame.late-bind §Hook keys.
-(late-bind/set-fn! :views/maybe-warn-plain-fn-under-non-default-frame!
-                   maybe-warn-plain-fn-under-non-default-frame!)
+;; Publish the clear-fn through the late-bind hook table so re-frame.subs
+;; (a leaf namespace, .cljc, JVM-runnable) and the governance chain can
+;; reach it without statically requiring this CLJS-only ns. JVM builds
+;; never load this file; the lookup returns nil there. Per re-frame.late-bind
+;; §Hook keys.
 (late-bind/set-fn! :views/clear-plain-fn-warned-pairs!
                    clear-plain-fn-warned-pairs!)
 
@@ -260,14 +117,9 @@
 ;; registry so the governance assertion proves the chain wipes it.
 ;;
 ;;   1. `warned-non-dom-roots` — the rf2-4edk source-coord / non-DOM-root
-;;      cache (kept chained here as it was at line 240 pre-rf2-z79p8).
-;;   2. `warned-plain-fn-frame-pairs` — the Spec 004 plain-fn-under-non-
-;;      default-frame suppression set (rf2-z79p8: the 4th straggler, NOT
-;;      chained before this fix, so the standard fixture never re-armed
-;;      it — only three test files reset it by hand). The standalone
-;;      `:views/clear-plain-fn-warned-pairs!` hook (set above) is RETAINED
-;;      for the per-frame destroy path / elision-probe direct call; this
-;;      adds the fixture-chain wiring it was missing.
+;;      cache.
+;;   2. `warned-plain-fn-frame-pairs` — the rf2-z79p8 4th straggler (its
+;;      warning is now retired, but it stays a governed chain member).
 (late-bind/register-warn-once-clear-fn!
   {:label    :views/warned-non-dom-roots
    :clear-fn clear-warned-non-dom-roots!

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -332,25 +332,14 @@
   (let [_m (views/first-render?! [:probe/unmounted 1])]
     nil)
   (views/clear-seen-render-keys!)
-  ;; Per Spec 004 §Plain Reagent fns and Spec 006 §Plain-fn-under-non-
-  ;; default-frame warning (rf2-d3k3): the warn-once helper sits inside
-  ;; `(when interop/debug-enabled? ...)`. Touch the helper's public
-  ;; entry points so the reachability graph keeps the ns body — the
-  ;; trace-emit branch itself is gated on `(some? (r/current-component))`
-  ;; which is nil at probe time (no Reagent render in flight), so the
-  ;; emit-site keyword is DCE'd from BOTH bundles by closure dataflow.
-  ;; The browser-runner test
-  ;; (re-frame.cross-spec-dom-cljs-test/plain-fn-under-non-default-frame) is
-  ;; the load-bearing assertion that the gate fires under DEBUG=true;
-  ;; production elision rests on the surrounding
-  ;; `(when interop/debug-enabled? ...)` constant-folding to false the
-  ;; same way every other warn site does.
-  (rf/reg-sub :probe/sub (fn [_db _q] nil))
-  (let [_r (rf/subscribe [:probe/sub])]
-    (views/clear-plain-fn-warned-pairs!)
-    (views/maybe-warn-plain-fn-under-non-default-frame!
-      :rf/default [:probe/sub])
-    nil))
+  ;; The plain-fn-under-non-default-frame WARNING is retired (EP-0002;
+  ;; superseded by the always-on :rf.error/no-frame-context — rf2-7yqn39
+  ;; deleted the dead emit). The `warned-plain-fn-frame-pairs` suppression
+  ;; cache and its `clear-plain-fn-warned-pairs!` clear-fn are retained only
+  ;; as a governed member of the warn-once-clear chain (rf2-z79p8). Touch the
+  ;; clear-fn so the warn-once ns body stays in the reachability graph for
+  ;; the elision check.
+  (views/clear-plain-fn-warned-pairs!))
 
 ;; ---- Spec 005 §Source-coord stamping — reg-machine macro (rf2-8bp3) -------
 

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -289,29 +289,29 @@
   typo advisory — each a DIAGNOSTIC catalogue row (they fail the EP-0008
   promotion criterion and correctly stay diagnostic).
 
-  TWO categories are ruled INTENTIONALLY-OUT-OF-CATALOGUE with a one-line
-  note in Spec 009 §Error event catalogue (rf2-r8oiw7), NOT a row:
+  TWO categories were ruled INTENTIONALLY-OUT-OF-CATALOGUE with a one-line
+  note in Spec 009 §Error event catalogue (rf2-r8oiw7), NEITHER needing an
+  allow-list entry now:
     - `:rf.route/navigation-blocked` — a `:rf.event` op-type user-event
       lifecycle trace, not an error/warning category; it never matched this
       scan's chokepoints anyway, so it needs no allow-list entry.
-    - `:rf.warning/plain-fn-under-non-default-frame-once` — a catalogue/source
-      DRIFT: RETIRED in the catalogue (the strikethrough row, superseded by
-      `:rf.error/no-frame-context` per EP-0002) but `re-frame.views.warn_once`
-      still carries the dev-gated emit site as a structural no-op (the firing
-      case is unreachable — the no-frame-context throw happens first). Adding a
-      live row would contradict the EP-0002 retirement; the fix is the
-      source-side retirement of the dead emit, tracked as rf2-7yqn39
-      (an rf2-r8oiw7 follow-up). Until that lands it stays on this
-      allow-list — the ONLY remaining entry.
+    - `:rf.warning/plain-fn-under-non-default-frame-once` — was a
+      catalogue/source DRIFT: RETIRED in the catalogue (the strikethrough row,
+      superseded by `:rf.error/no-frame-context` per EP-0002) but
+      `re-frame.views.warn_once` still carried the dev-gated emit site as a
+      structural no-op (the firing case was unreachable — the no-frame-context
+      throw happens first). rf2-7yqn39 deleted that dead emit site, so the
+      category is NO LONGER emitted from source; its allow-list entry — the
+      last remaining one — was dropped in the same PR. Source now matches the
+      catalogue's RETIRED ruling.
 
-  `allow-list-stays-honest` fails if this last entry becomes catalogued or
-  stops being emitted, forcing the co-edit so the list cannot rot into a
-  silent blanket suppression."
-  #{;; views plain-fn advisory — catalogue marks RETIRED but source still
-    ;; emits it (a catalogue/source drift; source-side retirement is the fix,
-    ;; tracked as an rf2-r8oiw7 follow-up — see the Spec 009
-    ;; INTENTIONALLY-OUT-OF-CATALOGUE note)
-    :rf.warning/plain-fn-under-non-default-frame-once})
+  The allow-list is now EMPTY: the wider-scan backlog is fully catalogued and
+  the one drift entry is retired at the source. It is kept as a live ratchet
+  seam — a future deliberate non-catalogue emit category lands here with a
+  rationale — and `allow-list-stays-honest` fails if any future entry becomes
+  catalogued or stops being emitted, forcing the co-edit so the list cannot rot
+  into a silent blanket suppression."
+  #{})
 
 ;; ---------------------------------------------------------------------------
 ;; Tests

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -452,18 +452,12 @@ const DEV_ONLY_SENTINELS = [
   // enough that a global grep is unambiguous.
   { source: 're-frame.core/reg-* macros (:doc pure-documentation metadata literal)',
     sentinel: 'rf2-9wwkcm-doc-elision-sentinel' }
-  // Note (rf2-d3k3): re-frame.views/maybe-warn-plain-fn-under-non-
-  // default-frame! emits :rf.warning/plain-fn-under-non-default-frame-
-  // once gated on interop/debug-enabled?. We do NOT add a sentinel
-  // entry here because the elision-probe runs outside Reagent's render
-  // cycle — `(r/current-component)` is nil — and closure compiler's
-  // dataflow analysis under :advanced determines the inner emit branch
-  // is unreachable, so the keyword's literal string is dropped from
-  // the control build too. The methodology check would be vacuous.
-  // The browser-test (re-frame.cross-spec-dom-cljs-test/plain-fn-under-
-  // non-default-frame) is the load-bearing assertion that the gate is
-  // wired up under DEBUG=true; under :advanced + goog.DEBUG=false the
-  // gate is constant-folded false and the body DCE's regardless.
+  // Note (rf2-7yqn39): the :rf.warning/plain-fn-under-non-default-frame-
+  // once warning + its emit helper were RETIRED (EP-0002; superseded by
+  // the always-on :rf.error/no-frame-context). There is no longer any
+  // gated emit site to elide-probe; the browser-test
+  // (re-frame.cross-spec-dom-cljs-test/plain-fn-under-non-default-frame)
+  // pins the replacement no-frame-context contract.
 ];
 
 // ----- helpers ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

EP-0008 catalogue/source drift cleanup (rf2-7yqn39, an rf2-r8oiw7 follow-up).

Spec 009 §Error event catalogue marks `:rf.warning/plain-fn-under-non-default-frame-once` as **RETIRED** (the strikethrough row — superseded by the always-on `:rf.error/no-frame-context` per EP-0002), but `re-frame.views.warn_once` still carried the dev-gated `trace/emit! :warning` emit site as a *structural no-op*: its firing case is unreachable because `frame/require-current-frame!` (called first by `subs/subscribe` / the dispatch envelope) raises `:rf.error/no-frame-context` and halts. The conformance source-scan therefore kept the category as the single remaining `out-of-catalogue-allow-list` entry. This PR retires the dead emit at source so the code matches the catalogue's RETIRED ruling, then drops the now-stale allow-list entry.

## What was removed

- The dead `trace/emit!` + `console.warn` emit site, and the whole `maybe-warn-plain-fn-under-non-default-frame!` detection helper (plus its private `read-react-context-frame` / `plain-fn-component-id` helpers — used only by it).
- Its `:views/maybe-warn-plain-fn-under-non-default-frame!` late-bind `set-fn!` publication and its `late_bind/directory` entry (the late-bind-drift test stays in sync — both sides removed).
- The `re-frame.subs/subscribe` call site (the `:cljs` arm now matches the `:clj` arm, so the reader conditional collapses) and the `re-frame.views` re-export.
- The elision-probe touch of the deleted helper.
- The sole remaining `out-of-catalogue-allow-list` entry in `error_catalogue_channel_conformance_test.clj` — the allow-list is now empty. `allow-list-stays-honest` stays green because the category is no longer emitted from source; the seam is retained as a live ratchet for any future deliberate non-catalogue category.

## What was retained (deliberately)

The `warned-plain-fn-frame-pairs` suppression cache, its `clear-plain-fn-warned-pairs!` clear-fn, the `:views/clear-plain-fn-warned-pairs!` late-bind hook, and its `register-warn-once-clear-fn!` chain enrolment. The warning they once gated is gone, but they are an **independent governed member of the rf2-z79p8 warn-once-clear chain** with dedicated coverage (`warn-once-clear-governance-{cljs-,}test`); gutting them would revert that hardening gate and is out of this bead's scope.

## Stale-comment refresh (CLARITY)

Refreshed three comments that still described the retired warning / a pre-EP-0002 `:rf/default` fall-through:
- `adapter/context.cljs` — Reagent's plain-fn path now raises `:rf.error/no-frame-context` (no `:rf/default` floor).
- `scripts/check-elision.cjs` — the gated emit no longer exists to elide-probe.
- `reagent-slim/IMPL-SPEC.md` §9.6 — marked RETIRED (EP-0002).

## Follow-up (not actioned)

`cross_spec_dom_cljs_test/reg-view-under-non-default-frame-no-warning` is now a trivially-passing negative test (it asserts a retired warning never fires for reg-view'd components). It still passes correctly; a cleanup could remove it, but it is in the reagent adapter test surface and out of this bead's owned files.

## Quality gates

- core `clojure -M:test`: **1356 tests, 6016 assertions, 0 failures** (incl. `error-catalogue-channel-conformance-test`, `late-bind-drift-test`, `warn-once-clear-governance-test`; re-verified green post-rebase)
- `npm run test:cljs`: **6863 tests, 27875 assertions, 0 failures** (incl. `warn-once-clear-governance-cljs-test`)
- `npm run test:elision`: **PASS** (42/42 sentinels absent in production / present in control)
