### PR TITLE
docs+fix: EP-0013 precise disposition-12 to the kind-boundary reading + :frame-removal edge (rf2-7zn9kg)

### DIFF
--- a/docs/EP/EP-0013-app-values-and-runtime-realms.md
+++ b/docs/EP/EP-0013-app-values-and-runtime-realms.md
@@ -964,6 +964,46 @@ Reinstall MUST preserve the existing hot-reload safety rules:
 The implementation MAY still mutate registrar slots internally. The specified
 behavior is app-value replacement and diff-driven invalidation.
 
+#### Live-instance refusal binds at the kind boundary, then per-kind
+
+The first reinstall slice is descriptor-only (issue 12). Refuse-loudly binds at
+the **kind boundary** in this slice: the step-8-deferred kinds (`:route` /
+`:flow` / `:resource` / `:mutation` / `:resource-scope` / `:view` / `:head` /
+`:error-projector`) throw `:rf.error/unsupported-descriptor-kind` at
+install/reinstall, so the live-instance classes the refusal rule worried about
+(machine actors, in-flight resources/mutations, route transitions) are
+**structurally unreachable** through the descriptor diff. The per-kind
+live-instance **blocker / continue / migrate** rule binds **when each deferred
+kind becomes installable** — it is not a single global query over a universal
+work ledger.
+
+The ONE wired kind that *is* a live instance is `:frame`. A `:removed` `:frame`
+whose live container still exists MUST be **refused loudly** — never silently
+orphaned. `registrar/unregister! :frame id` alone drops only the registrar slot,
+leaving the container live in the core frame registry (still
+dispatchable/subscribable) with the `destroy-frame!` teardown (its `:on-destroy`,
+the machine teardown cascade, sub-cache disposal) skipped. `reinstall!` therefore
+raises `:rf.error/live-frame-removal-unsupported`, enumerating the blocking
+frame-ids, **before any mutation**; the recovery is explicit `destroy-frame!`
+then reinstall. The check reads only the core frame registry (the realm's
+live-frame view), not cross-subsystem machinery. (Removed `:event` / `:fx` /
+`:cofx` have no live instance — they fail loudly on future use per the rule
+above; a removed `:sub`'s disposal/loud-read is pre-existing per-kind hot-reload
+behaviour.)
+
+> **Step-8 installability obligation (binding, bead `rf2-7zn9kg`).** EVERY
+> step-8 kind, when it is made installable through the app-value path, MUST ship
+> its own live-instance **blocker / continue / migrate** rule **and** a per-class
+> refusal test BEFORE its `:rf.error/unsupported-descriptor-kind` throw is
+> lifted. Lifting the kind throw without first defining that rule reopens the
+> silent-orphaning window this disposition closed. This is an **acceptance
+> criterion of the step-8 bead(s)**, not a follow-up nicety. The blocker source
+> is **per-kind**: the durable work ledger (`:rf.runtime/work-ledger`) for the
+> ledger-backed classes (resource + mutation writers — the only writers it
+> carries today), and the **per-subsystem live registries** (machine snapshots,
+> routing `:current`, the core frame registry) for the rest. There is no
+> universal enumeration source.
+
 ### Source Coordinates
 
 Source coordinates are part of the app-value contract. They are required for
@@ -1701,6 +1741,40 @@ inline.
     block the reinstall — and the work ledger is the enumeration source (after
     the EP-0011/0016 waves, every live instance class carries a ledger row),
     so the refusal check is a ledger query, not new machinery.
+
+    > **Errata — 2026-06-12 (Mike, bead `rf2-7zn9kg`).** This disposition is
+    > PRECISED, not deleted, against what shipped. Two corrections:
+    >
+    > 1. **Where refuse-loudly binds in slice 1.** The shipped slice 1
+    >    (`reinstall!`) is descriptor-only and binds refuse-loudly **at the kind
+    >    boundary**: the step-8-deferred kinds (`:route` / `:flow` /
+    >    `:resource` / `:mutation` / `:resource-scope` / `:view` / `:head` /
+    >    `:error-projector`) throw `:rf.error/unsupported-descriptor-kind` at
+    >    install/reinstall, so the live-instance classes this disposition worried
+    >    about (machine actors, in-flight resources/mutations, route transitions)
+    >    are **structurally unreachable** through the descriptor diff — a generic
+    >    blocker query would protect nothing reachable while inventing
+    >    cross-subsystem machinery ahead of those kinds having install semantics.
+    >    The live-instance **blocker / continue / migrate rule binds PER-KIND**,
+    >    when each deferred kind becomes installable; defining that rule is a
+    >    **precondition of lifting the unsupported-kind throw** for that kind (see
+    >    the §Implementation step-8 obligation). The ONE wired kind that *is* a
+    >    live instance — `:frame` — is handled: a `:removed` `:frame` whose live
+    >    container still exists is refused loudly
+    >    (`:rf.error/live-frame-removal-unsupported`, enumerating the blocking
+    >    frame-ids) rather than silently orphaned.
+    >
+    > 2. **The enumeration-source overclaim.** "The work ledger is THE
+    >    enumeration source … every live instance class carries a ledger row" is
+    >    corrected: per the shipped ledger (`spec/016` §What Spec 016 does NOT
+    >    cover / §Work-ledger multi-writer authority, ~L1249/L1259) the durable
+    >    ledger carries **only resource + mutation writers** —
+    >    timers, route loaders, spawned actors, and machine async are explicitly
+    >    *future*. The work ledger is therefore **one** blocker source for the
+    >    ledger-backed classes, never the universal enumeration source. The other
+    >    blocker sources are the **per-subsystem live registries** (machine
+    >    snapshots, routing `:current`, the core frame registry). Each per-kind
+    >    rule names its own source when that kind becomes installable.
 13. Does the host-transient subsystem descriptor live here or as an extension row
     in EP-0006's grading table? **Recommendation:** EP-0006 owns the contract;
     this EP contributes realm ownership and lifecycle as the host-transient

--- a/implementation/core/src/re_frame/app_value.cljc
+++ b/implementation/core/src/re_frame/app_value.cljc
@@ -740,12 +740,18 @@
 ;; its cache — §Hot Reload: "changed subscriptions invalidate the relevant
 ;; caches", "future lookups use the new registrar").
 ;;
-;; This is the descriptor-only first slice (EP-0013 issue 12: the first reinstall
-;; slice is descriptor-only). Live-instance migration (active machines /
-;; resources / route transitions whose runtime state would need migrating) is a
-;; later slice; the per-kind hot-reload rules each subsystem already honours
+;; This is the descriptor-only first slice (EP-0013 issue 12, PRECISED: the first
+;; reinstall slice is descriptor-only). Refuse-loudly binds at the KIND BOUNDARY:
+;; the step-8-deferred kinds throw `:rf.error/unsupported-descriptor-kind` at
+;; install/reinstall, so the live-instance classes the disposition worried about
+;; (machine actors / in-flight resources/mutations / route transitions) are
+;; STRUCTURALLY UNREACHABLE through the diff — the per-kind live-instance
+;; blocker/continue/migrate rule binds when each deferred kind becomes
+;; installable. The per-kind hot-reload rules each subsystem already honours
 ;; (active machine instances continue with their captured spec, etc.) are
-;; unchanged.
+;; unchanged. The ONE reachable live edge — `:frame` removal of a live container
+;; — is refused loudly (`refuse-live-frame-removal!`) rather than silently
+;; orphaned.
 
 (defn- diff-registrations
   "Diff two `:registrations` maps (`kind → id → descriptor`) into added /
@@ -765,6 +771,57 @@
     {:added   (vec added)
      :changed (vec changed)
      :removed (vec removed)}))
+
+(defn- refuse-live-frame-removal!
+  "The ONE reachable live-instance edge in the descriptor-only slice
+  (EP-0013 issue 12, PRECISED — see `reinstall!`'s docstring). Of the
+  step-7 wired kinds, `:frame` is the only one that IS a live instance: a
+  removed `:event`/`:fx`/`:cofx` has no live runtime instance (it
+  fail-loud's on future use per EP body rule 960), a removed `:sub`'s
+  disposal/loud-read is pre-existing per-kind hot-reload behaviour, and
+  the step-8-deferred kinds are STRUCTURALLY UNREACHABLE through the diff
+  (they throw `:rf.error/unsupported-descriptor-kind` at install/reinstall,
+  so no live instance of those classes can be seated through the descriptor
+  path). `:frame` is the exception: a removed `:frame` whose live container
+  still exists would be ORPHANED — `registrar/unregister! :frame id` drops
+  only the registrar SLOT, leaving the container live in the core frame
+  registry (`@frame/frames`), still dispatchable/subscribable, with its
+  `:on-destroy`, the machine teardown cascade, and sub-cache disposal that
+  `destroy-frame!` runs all SKIPPED. That silent orphan is exactly what
+  disposition 12 closed; refuse-loudly is the per-kind rule here.
+
+  This is a TARGETED check against the core frame registry only (the
+  `:realm/frames-by-realm` late-bind hook `re-frame.frame` publishes —
+  realm-id → live, non-destroyed frame-ids), NOT the cross-subsystem
+  blocker query the original disposition imagined. It throws BEFORE any
+  mutation so a refused reinstall leaves the realm untouched. The
+  diagnostic enumerates exactly the live frame-ids that block. The
+  recovery is explicit `destroy-frame!` then reinstall — orphaning a live
+  frame is never the framework's silent default. INTERNAL."
+  [rid diff]
+  (let [removed-frame-ids (->> (:removed diff)
+                               (filter (fn [[kind _]] (= :frame kind)))
+                               (map second)
+                               set)]
+    (when (seq removed-frame-ids)
+      (let [frames-by-realm (when-let [f (late-bind/get-fn :realm/frames-by-realm)]
+                              (f))
+            live-in-realm   (get frames-by-realm rid #{})
+            blocking        (set/intersection removed-frame-ids live-in-realm)]
+        (when (seq blocking)
+          (throw (ex-info (str "rf/reinstall!: cannot remove the live frame(s) "
+                               (pr-str (sort blocking)) " from realm " rid
+                               " — a :frame descriptor still backs a live frame"
+                               " container. Removing it through the descriptor"
+                               " diff would orphan the container (its :on-destroy,"
+                               " machine teardown, and sub-cache disposal would be"
+                               " skipped). Destroy the frame explicitly"
+                               " (re-frame.frame/destroy-frame!) before reinstalling"
+                               " without it.")
+                          {:error/id       :rf.error/live-frame-removal-unsupported
+                           :realm          rid
+                           :live-frames    (vec (sort blocking))
+                           :recovery       :destroy-frame-then-reinstall})))))))
 
 (defn reinstall!
   "Hot-reload a realm by replacing its installed app VALUE with `new-app` —
@@ -795,10 +852,28 @@
   that adds an unmet capability requirement THROWS `:rf.error/missing-capability`
   before any mutation, exactly as `install!` would.
 
-  Descriptor-only slice (EP-0013 issue 12): the diff is over registration
-  descriptors; live-instance migration (active machines/resources that would
-  need state migration) is a later slice and the per-kind hot-reload rules each
-  subsystem already honours are unchanged.
+  Descriptor-only slice (EP-0013 issue 12, PRECISED): the diff is over
+  registration descriptors. Refuse-loudly binds at the KIND BOUNDARY in this
+  slice — the step-8-deferred kinds (`:route`/`:flow`/`:resource`/`:mutation`/
+  `:resource-scope`/…) THROW `:rf.error/unsupported-descriptor-kind` at
+  install/reinstall, so the live-instance classes the disposition worried about
+  (machine actors, in-flight resources/mutations, route transitions) are
+  STRUCTURALLY UNREACHABLE through the descriptor diff; the live-instance
+  blocker/continue/migrate rule binds PER-KIND when each deferred kind becomes
+  installable (defining that rule is a precondition of lifting the kind throw).
+  The per-kind hot-reload rules each subsystem already honours (active machine
+  instances continue with their captured spec; changed subs invalidate caches;
+  removed registrations fail loudly on future use) are unchanged.
+
+  The ONE reachable live-instance edge is `:frame` REMOVAL — `:frame` is the
+  only wired kind that IS a live instance. A `:removed` `:frame` whose live
+  container still exists is REFUSED loudly (`refuse-live-frame-removal!` →
+  `:rf.error/live-frame-removal-unsupported`, enumerating the blocking
+  frame-ids) BEFORE any mutation, rather than silently orphaning the container
+  (which `registrar/unregister! :frame id` alone would, skipping the
+  `destroy-frame!` teardown). The check reads only the core frame registry (the
+  `:realm/frames-by-realm` hook), not cross-subsystem machinery. The recovery is
+  explicit `destroy-frame!` then reinstall.
 
   Arities (the realm is the LEADING positional when present, matching
   `install!` + the EP's `(reinstall! shop-realm new-app {:reason …})` examples):
@@ -821,6 +896,11 @@
      ;; The capability invariant holds across reloads too — fail loud before
      ;; any mutation if the new app raises a requirement the realm can't meet.
      (check-capabilities! rid new-app)
+     ;; The ONE reachable live-instance edge (EP-0013 issue 12, PRECISED): a
+     ;; `:removed` `:frame` that still backs a live container is refused loudly
+     ;; here — before any mutation — rather than silently orphaned. Targeted
+     ;; check against the core frame registry only; no cross-subsystem machinery.
+     (refuse-live-frame-removal! rid diff)
      ;; Apply the delta against the realm's OWN registrar (EP-0013 stage 9):
      ;; added + changed re-derive the registrar slot from the new descriptor
      ;; (lowered through its kind's real registration logic, so a reloaded

--- a/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
@@ -347,6 +347,73 @@
             "app-db carries only the pre-removal write — the dropped handler did not run")
         (finally (rf/unregister-error-listener! :q4x5zz/recorder))))))
 
+;; ---------------------------------------------------------------------------
+;; (4b) reinstall! — the ONE reachable live-instance edge: :frame removal
+;; (EP-0013 issue 12 PRECISED — rf2-7zn9kg)
+;; ---------------------------------------------------------------------------
+
+(deftest reinstall-removing-a-live-frame-refuses-loudly
+  (testing "EP-0013 issue 12 (PRECISED, rf2-7zn9kg): :frame is the one wired kind
+            that IS a live instance. A reinstall! whose diff would :removed a
+            :frame that still backs a LIVE container REFUSES LOUDLY with
+            :rf.error/live-frame-removal-unsupported — enumerating the blocking
+            frame-id — BEFORE any mutation, rather than silently ORPHANING the
+            container (registrar/unregister! :frame alone drops only the slot,
+            leaving the container live + dispatchable with destroy-frame!'s
+            :on-destroy / machine teardown / sub-cache disposal SKIPPED)."
+    ;; v1: install an app whose only registration is a :frame — a real live
+    ;; container exists in the core frame registry after install.
+    (rf/install! :rf.realm/default
+                 (rf/app {:id :fr0/app :modules
+                          [(rf/module {:id :m :frames {:fr0/live {:doc "live frame"}}})]}))
+    (is (some? (frame/frame :fr0/live)) "the installed :frame is a live container")
+    (is (contains? (frame/frame-ids) :fr0/live) "and appears in the live registry")
+    ;; v2: reinstall WITHOUT :fr0/live — the diff would :removed it, but the
+    ;; container is live → refuse loudly before any mutation.
+    (let [ed (try (rf/reinstall! :rf.realm/default
+                                 (rf/app {:id :fr0/app :modules
+                                          [(rf/module {:id :m2
+                                                       :events {:fr0/ev {:handler (fn [db _] db)}}})]}))
+                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
+                    (ex-data e)))]
+      (is (= :rf.error/live-frame-removal-unsupported (:error/id ed))
+          "removing a live :frame refuses loudly with the targeted error id")
+      (is (= [:fr0/live] (:live-frames ed))
+          "the diagnostic enumerates exactly the blocking live frame-id")
+      (is (= :destroy-frame-then-reinstall (:recovery ed))
+          "the error names the recovery: destroy-frame! then reinstall"))
+    ;; The refusal was BEFORE any mutation — the live frame + its registrar slot
+    ;; are untouched, and the new :added event was NOT seated.
+    (is (some? (frame/frame :fr0/live)) "the live frame survives the refused reinstall")
+    (is (some? (registrar/lookup :frame :fr0/live)) "its registrar slot is untouched")
+    (is (nil? (registrar/lookup :event :fr0/ev))
+        "the refused reinstall seated nothing — it failed before any mutation")))
+
+(deftest reinstall-removing-a-frame-after-explicit-destroy-succeeds
+  (testing "EP-0013 issue 12 (PRECISED, rf2-7zn9kg): the recovery path — once the
+            frame is explicitly destroyed (destroy-frame!, the proper teardown),
+            its container is no longer live, so a reinstall! that removes the
+            :frame descriptor succeeds and the slot is dropped cleanly."
+    (rf/install! :rf.realm/default
+                 (rf/app {:id :fr1/app :modules
+                          [(rf/module {:id :m :frames {:fr1/live {:doc "to be destroyed"}}})]}))
+    (is (some? (frame/frame :fr1/live)) "the frame is live after install")
+    ;; The documented recovery: destroy the frame first (full teardown), THEN
+    ;; reinstall without it.
+    (frame/destroy-frame! :fr1/live)
+    (is (nil? (frame/frame :fr1/live)) "destroy-frame! tore the container down")
+    (let [diff (rf/reinstall! :rf.realm/default
+                              (rf/app {:id :fr1/app :modules
+                                       [(rf/module {:id :m2
+                                                    :events {:fr1/ev {:handler (fn [db _] db)}}})]}))]
+      ;; The :frame is :removed (its registrar slot dropped) — no live container
+      ;; blocks it, so the reinstall applies the delta cleanly.
+      (is (some #{[:frame :fr1/live]} (:removed diff))
+          "the now-dead :frame is removed cleanly")
+      (is (some #{[:event :fr1/ev]} (:added diff)) "the new event was added")
+      (is (nil? (registrar/lookup :frame :fr1/live)) "the :frame registrar slot is dropped")
+      (is (some? (registrar/lookup :event :fr1/ev)) "the new event handler is seated"))))
+
 (deftest reinstall-changed-sub-invalidates-the-live-cache
   (testing "the EP-0013 §Hot Reload behavioural claim the registrar-slot
             assertion only approximates: a :changed sub reinstall INVALIDATES the
@@ -432,9 +499,14 @@
     (rf/reg-event-db :boot/a {:doc "a"} cart-add)
     ;; Reinstall a new app value. The diff is against the projection of the
     ;; sugar-booted registrar, so :boot/a (present in the projection, absent in
-    ;; the new app) shows as :removed, and :boot/b shows as :added.
+    ;; the new app) shows as :removed, and :boot/b shows as :added. The new app
+    ;; RE-DECLARES the fixture's live `:rf/default` frame (in the projection too)
+    ;; so it stays unchanged, not :removed — otherwise the reinstall would
+    ;; (correctly) refuse to orphan that live frame (rf2-7zn9kg).
     (let [diff (rf/reinstall! (rf/app {:id :app :modules
-                                       [(rf/module {:id :m :events {:boot/b {:handler cart-add}}})]}))]
+                                       [(rf/module {:id :m
+                                                    :events {:boot/b {:handler cart-add}}
+                                                    :frames {:rf/default {}}})]}))]
       (is (some #{[:event :boot/b]} (:added diff))
           ":boot/b is added relative to the projected installed app")
       (is (some #{[:event :boot/a]} (:removed diff))


### PR DESCRIPTION
Re-scope of **rf2-7zn9kg** per Mike's ruling (2026-06-12, the bead NOTES block governs over the original description). The shipped descriptor-only `reinstall!` is CORRECT for slice 1 — no live-instance blocker query is added. Disposition 12 refuse-loudly is already honored at the **kind boundary** (the step-8-deferred kinds throw `:rf.error/unsupported-descriptor-kind`, so live-instance classes are structurally unreachable through the descriptor diff). This is the **reconcile** work.

## What changed (the 5 ruled items)

1. **DOC — disposition 12 precised** (errata note, original wording preserved per the EP-0001 `cg7llv` precedent). Refuse-loudly binds at the kind boundary in slice 1; the live-instance blocker/continue/migrate rule binds **per-kind** when each deferred kind becomes installable (a precondition of lifting its kind throw). Corrects the enumeration-source overclaim: per shipped `spec/016` the durable work ledger carries **only resource + mutation writers** (timers/route-loaders/spawned-actors/machine-async are future) — the ledger is ONE blocker source for ledger-backed classes, never the universal enumeration source; per-subsystem live registries (machine snapshots, routing `:current`, the core frame registry) are the others.

2. **DOC — action-epic staging text corrected.** The rf2-c6armm epic's slice-1 line ("REFUSES live-instance migration … enumerated FROM THE WORK LEDGER") is superseded by a `STAGING CORRECTION (rf2-7zn9kg ruling)` note on the epic — already recorded in the bead store (not a tracked-file edit).

3. **OBLIGATION recorded on the EP-0013 epic** (in §Hot Reload And Reinstall, binding): EVERY step-8 kind, when made installable, MUST ship its blocker/continue/migrate rule + per-class refusal test BEFORE its unsupported-kind throw is lifted — acceptance criterion of the step-8 bead(s). Names the per-kind blocker source (work ledger for ledger-backed classes; per-subsystem live registries for the rest).

4. **FIX — the one reachable edge: `:frame` removal.** Finding: `reinstall!`'s `:removed` path calls only `(registrar/unregister! :frame id)`, which drops the registrar slot but leaves the live frame container in `@frame/frames` — fully dispatchable/subscribable, with `destroy-frame!`'s `:on-destroy` / machine teardown / sub-cache disposal all SKIPPED. That is a silent **orphan** (the worst of destroy/orphan/untouched). Chosen behavior: a **targeted refusal** (`:rf.error/live-frame-removal-unsupported`, enumerating the blocking frame-ids) raised BEFORE any mutation, reading only the core frame registry via the `:realm/frames-by-realm` late-bind hook — no cross-subsystem machinery. Recovery: explicit `destroy-frame!` then reinstall.

5. **`reinstall!` docstring** (+ surrounding comments) cite the precised kind-boundary rule and the `:frame`-removal edge.

### Tests
- `reinstall-removing-a-live-frame-refuses-loudly` — the refusal fires, enumerates the frame-id, and the realm is untouched (no `:added` seated; live frame + slot survive).
- `reinstall-removing-a-frame-after-explicit-destroy-succeeds` — the recovery path: after `destroy-frame!`, the `:frame` is removed cleanly and the new delta applies.
- Fixed `reinstall-after-pure-sugar-boot-diffs-against-the-projection`: it was silently orphaning the fixture's live `:rf/default` frame; the new app now re-declares it. (The guard caught a real pre-existing orphan.)

## Quality gates

- core `clojure -M:test` — **1358 tests, 6033 assertions, 0 failures / 0 errors** (incl. the new `:frame`-edge tests + install/reinstall suites)
- `npm run test:cljs` — **6865 tests, 27889 assertions, 0 failures / 0 errors**
- `mkdocs build --strict` (after `cp -r spec docs/spec`) — built clean, no WARNING/ERROR; `docs/spec` is gitignored (generated copy, not committed)
- `python scripts/check_ep_status_sync.py` — clean

## Scope
Three tracked files: `docs/EP/EP-0013-app-values-and-runtime-realms.md`, `implementation/core/src/re_frame/app_value.cljc`, `implementation/core/test/re_frame/app_value_install_cljs_test.cljc`. No hot-zone files. EP edit is post-acceptance disposition-precision via the errata pattern. Tail-2 (rf2-dn4pen) re-reviews against the precised disposition.
