### PR TITLE
docs(EP): close out EP-0016 + EP-0014 implementation-errata ledgers

### DIFF
--- a/docs/EP/EP-0014-derivation-and-process-algebra.md
+++ b/docs/EP/EP-0014-derivation-and-process-algebra.md
@@ -11,9 +11,23 @@ Type: standards-track
 > final-corrective pass — the one P1 node-kind enum defect found and fixed),
 > and the normative contract lives in its home —
 > [`spec/Derivations.md`](../../spec/Derivations.md). This EP is now the
-> **rationale record**; where it and the spec differ, the spec governs. The
-> action epic (`rf2-k0meap`) stays open for the post-graduation consumer
-> propagation (skills / examples / docs-guide / the Xray graph panel).
+> **rationale record**; where it and the spec differ, the spec governs.
+>
+> **BUILD status (updated 2026-06-12):** complete. The post-graduation consumer
+> propagation has shipped — `/skills` (`rf2-1w4x3l`) and `/examples`
+> (`rf2-d9ol4m`, a considered no-op: the algebra is a view, not an authoring
+> surface) via PR #3971, `/docs/guide` (`rf2-mpa1t5`) via PR #3983, and the
+> Xray derivation-graph panel (`rf2-9ett2d`, plus the `rf2-yjarv6`
+> redact-keep-structure coverage test) via the `feat(xray): EP-0014
+> derivation-graph panel + off-box redaction` merge — all closed and on
+> `main`. The action epic (`rf2-k0meap`) is therefore complete for its ruled
+> slice scope and ready to close. The items that legitimately remain
+> outstanding are deferred-by-criterion, not pending work: the public
+> graph-accessor name + facade classification (graduation-gated on a third
+> consumer beyond Xray + conformance, [issue 1](#open-issues)), the executable
+> delta protocol (semantic-only by [issue 5](#open-issues)), and machine
+> selectors as a source form ([issue 4](#open-issues) keeps them ordinary
+> subscriptions).
 
 > This EP defines the common model behind subscriptions, runtime
 > subscriptions, flows, resources, route facts, and selected machine state:

--- a/docs/EP/EP-0016-resource-mutation-completion.md
+++ b/docs/EP/EP-0016-resource-mutation-completion.md
@@ -11,9 +11,19 @@ Type: standards-track
 > final-corrective pass), and it was dogfooded through the realworld example.
 > The normative amendment lives in its home —
 > [`spec/016-Resources.md`](../../spec/016-Resources.md). This EP is now the
-> **rationale record**; where it and the spec differ, the spec governs. The
-> action epic (`rf2-fi6tda`) stays open for the deferred derived-sensitivity
-> propagation arm (`rf2-fi6tda.1`).
+> **rationale record**; where it and the spec differ, the spec governs.
+>
+> **BUILD status (updated 2026-06-12):** complete. The deferred
+> derived-sensitivity propagation arm (`rf2-fi6tda.1`) shipped — the
+> named-scope-resolver sensitivity inheritance landed via PR #3993 (merged
+> 2026-06-12) — so the gate the original ruling held open is now resolved. The
+> action epic (`rf2-fi6tda`) is ready to close: all implementation slices, both
+> wave-end review passes (`rf2-tho0f9` correctness / `rf2-8xq7kp` clean repeat),
+> and all four propagation beads (`/skills` `rf2-hdwp7h`, `/examples`
+> `rf2-3gl52p`, `/tools` `rf2-f8s9g6`, `/docs/guide` `rf2-40o3nm`) are closed and
+> merged. The items this EP lists as deferred — optimistic rollback,
+> tag-addressed patching, and the GraphQL transport — remain intentional
+> future-EP non-goals, not outstanding action-epic work (see [§Non-Goals](#non-goals)).
 
 > This EP defines a narrow post-EP-0003 amendment to Spec 016:
 > mutation completion continuations, per-target scoped invalidation, named


### PR DESCRIPTION
@
Doc-only verify-then-flip of the implementation-errata ledgers for two graduated, `Status: final` EPs. Each header carried a "stays open" gate note; I verified the wave actually shipped via `bd show` + `gh pr view` + git log, then flipped the note to a BUILD-status record. The decision record above each note is preserved unchanged.

## Verification

| EP | Wave shipped? | Final-review bead + evidence | Ledger action |
|---|---|---|---|
| **EP-0016** (`rf2-fi6tda`) | **Yes — fully.** | tail-1 `rf2-tho0f9` (PASS-with-defects, 3 findings filed) + tail-2 `rf2-8xq7kp` (**CLEAN PASS**, all 3 fixes verified); the deferred arm `rf2-fi6tda.1` merged via **PR #3993** (2026-06-12); 4 propagation beads `rf2-hdwp7h`/`rf2-3gl52p`/`rf2-f8s9g6`/`rf2-40o3nm` all CLOSED. Only open EP-0016 bead is the epic itself. | **Flipped.** "stays open for the deferred derived-sensitivity propagation arm" → resolved; epic ready to close. Deferred items (optimistic rollback / tag-addressed patching / GraphQL) kept as future-EP non-goals. |
| **EP-0014** (`rf2-k0meap`) | **Yes — fully.** | tail-1 `rf2-7mse5i` (PASS w/ one P1 `rf2-7wwp1z`, fixed via #3948) + tail-2 `rf2-6y7wnb` (**CLEAN PASS**); consumer sweep `rf2-1w4x3l`+`rf2-d9ol4m` (**PR #3971**), `rf2-mpa1t5` (**PR #3983**), Xray panel `rf2-9ett2d`+`rf2-yjarv6` (commit `cbb492286`/`feat(xray): EP-0014 derivation-graph panel`) — all CLOSED + on `main`. Only open EP-0014 bead is the epic itself. | **Flipped.** "stays open for the post-graduation consumer propagation" → shipped; epic ready to close. Deferred-by-criterion items (public accessor name, delta protocol, machine selectors) noted as non-blocking. |

**No fake-flips.** Both action epics are genuinely complete for their ruled scope — every implementation slice, both review passes, and every propagation bead are closed-and-merged. The only open beads per EP are the action epics themselves, both marked "eligible for close" in their own notes.

## Quality gates

- `python scripts/check_ep_status_sync.py` → **EXIT=0** (clean).
- `cp -r spec docs/spec && python -m mkdocs build --strict` → **EXIT=0** (built in 13.15s; remaining lines are pre-existing INFO notices, not errors).
- `git status` → only the two EP files modified; generated `docs/spec` is gitignored.
@