### PR TITLE
docs(core): EP-0013 code-comment + docstring review (rf2-wtm09b)

### DIFF
--- a/implementation/core/src/re_frame/app_value.cljc
+++ b/implementation/core/src/re_frame/app_value.cljc
@@ -68,25 +68,31 @@
     * it is correct under hot-reload for free: re-registration replaces the
       registrar slot, so the next projection carries the new handler/coords.
 
-  The EP's later stages (6/7) add explicit `rf/app` / `rf/module`
-  *construction* (compose modules into an app value as INERT data, before
-  any realm) and `install!` / `reinstall!` (seat an explicit app value into a
-  realm). This stage ships neither — it ships only the read direction: the
-  default realm already HAS an installed program (the process-load `reg-*`
-  registrations), and this projects it into the descriptor value the later
-  stages and tooling will read and diff.
+  Projection (stage 5) is the READ direction over the default realm's
+  load-order program (the process-load `reg-*` registrations re-grouped into
+  the descriptor value tooling reads and diffs). On top of it this ns now also
+  ships the WRITE directions that complete D2: explicit `rf/app` / `rf/module`
+  *construction* (stage 6 — compose modules into an app value as INERT data,
+  before any realm) and `install!` / `reinstall!` (stage 7 — seat an explicit
+  app value into a realm; see §Installation + §reinstall below). All three
+  produce or consume the SAME descriptor-grouped shape, so a projected app and
+  a constructed app are interchangeable to the inspectors and the installer.
 
   ## Production elision
 
-  Pure readers over the realm/registrar maps; no trace emit sites, no
+  Pure data over the realm/registrar maps; no trace emit sites, no
   DEBUG-gated branches, no feature sentinels, and no per-feature `:require`
-  (only `re-frame.realm` + `re-frame.late-bind`, both already in the core
-  spine; the registrar atom is reached through `realm/registrar`, never
-  required directly). The projection is operational metadata, not a dev
-  surface — it survives `:advanced` + `goog.DEBUG=false` intact and is
-  bundle-isolation neutral. (It is never *called* on the hot path; in stage 5
-  it is reached only by tests, so in a production app it is dead code Closure
-  DCE removes.)"
+  (only `re-frame.realm` + `re-frame.registrar` + `re-frame.late-bind`, all
+  already in the core spine; the lowering into a kind's real registration
+  logic is reached through the `:app-value/install-descriptor!` late-bind hook,
+  never a direct `:require` of the reg surfaces, so this ns stays a leaf on the
+  realm/registrar spine and is bundle-isolation neutral). The projection +
+  construction are operational metadata, not a dev surface — they survive
+  `:advanced` + `goog.DEBUG=false` intact. None of these fns runs on the
+  registration hot path (the `reg-*` sugar path is byte-identical), so in an
+  app that never calls the construction/install surface they are dead code
+  Closure DCE removes; an app that DOES call `rf/app` / `rf/install!` keeps
+  exactly what it references."
   (:require [clojure.set        :as set]
             [re-frame.realm     :as realm]
             [re-frame.registrar :as registrar]
@@ -242,12 +248,18 @@
   Returns:
     {:rf.app/id     <realm-id>            ;; the app the realm carries
      :registrations {kind {id descriptor}} ;; normalized descriptors by kind
-     :requires      #{}}                  ;; capability requirements (empty in
-                                          ;; stage 5 — declared on modules, D3)
+     :requires      #{}}                  ;; capability requirements — always
+                                          ;; empty for a projected app
+                                          ;; (requirements are declared on
+                                          ;; MODULE values; load-order
+                                          ;; registrations carry none)
 
-  INTERNAL — there is NO public `rf/app` constructor and no public
-  installed-app read surface in stage 5 (EP-0013 issue 1; stages 6/7). nil
-  resolves to the default realm (absence = default realm, the D1 rule)."
+  This PROJECTION fn is INTERNAL — there is no public read surface for a
+  realm's projected installed app (the public app-value vocabulary is the
+  stage-6 `rf/app` / `rf/module` CONSTRUCTORS + the `rf/install!` seating
+  path, not this read seam). `re-frame.realm/installed-app` reaches it through
+  the `:app-value/project` late-bind hook. nil resolves to the default realm
+  (absence = default realm, the D1 rule)."
   ([] (app-value realm/default-realm-id))
   ([realm-or-id]
    (let [rid       (realm/realm-id realm-or-id)
@@ -733,8 +745,9 @@
 ;;   :removed — (kind, id) in OLD but not NEW → unregister (removed
 ;;              registrations fail loudly on future lookup — §Hot Reload rule)
 ;; then records the new app value in the realm's `:app` slot. Returns the diff
-;; (the same `{:realm :added :changed :removed}` shape the EP's example shows),
-;; so a dev tool can show what a save changed. The diff is the value; trace +
+;; (the `{:realm :reason :added :changed :removed}` shape the EP's example shows
+;; — `:reason` echoes `opts`, defaulting to `:hot-reload`), so a dev tool can
+;; show what a save changed. The diff is the value; trace +
 ;; cache invalidation ride the registrar's existing hot-reload surface (a
 ;; re-register fires the replacement hooks subs.cljc already uses to invalidate
 ;; its cache — §Hot Reload: "changed subscriptions invalidate the relevant
@@ -777,7 +790,8 @@
   (EP-0013 issue 12, PRECISED — see `reinstall!`'s docstring). Of the
   step-7 wired kinds, `:frame` is the only one that IS a live instance: a
   removed `:event`/`:fx`/`:cofx` has no live runtime instance (it
-  fail-loud's on future use per EP body rule 960), a removed `:sub`'s
+  fail-loud's on future use per EP-0013 §Hot Reload And Reinstall —
+  \"removed registrations fail loudly on future use\"), a removed `:sub`'s
   disposal/loud-read is pre-existing per-kind hot-reload behaviour, and
   the step-8-deferred kinds are STRUCTURALLY UNREACHABLE through the diff
   (they throw `:rf.error/unsupported-descriptor-kind` at install/reinstall,


### PR DESCRIPTION
Wave-end CODE-COMMENTS review (rf2-wtm09b) of the EP-0013 realm / app-value / install machinery. Reviews the prose IN the code (comments + docstrings) for currency, clarity, and correctness against the merged behaviour — including the precised disposition-12 kind-boundary rule and the `:frame`-removal refusal. Comment/docstring-only; **no behaviour change**.

## What changed

All four edits are in `implementation/core/src/re_frame/app_value.cljc`:

1. **Dropped a stale ns-docstring paragraph.** The "the EP's later stages (6/7) add construction + install … **this stage ships neither**" text was stage-5-era prose that directly contradicted the file's own header (which already says stage 6 + composition were added on top) and its content (`module`/`app`/`install!`/`reinstall!` all live in this file now). Rewritten to state that projection (stage 5) + construction (stage 6) + install/reinstall (stage 7) all ship here over one descriptor shape.

2. **Corrected the production-elision claim.** The "in stage 5 it is reached only by tests, so it is dead code DCE removes" framing is stale now that `rf/app` / `rf/module` / `rf/install!` / `rf/reinstall!` are public exports — they are live code in an app that calls them. Also fixed the `:require` list (it omitted `re-frame.registrar`, which the ns does require) and named the `:app-value/install-descriptor!` late-bind hook as the seam that keeps this ns a `:require`-free leaf on the realm/registrar spine.

3. **Fixed the `reinstall!` return-shape comment.** The module-level comment said the return was `{:realm :added :changed :removed}`, omitting `:reason` — which the `reinstall!` docstring and the EP example both carry, and which the code actually returns. Now `{:realm :reason :added :changed :removed}`.

4. **De-drifted a bare line-number reference.** `refuse-live-frame-removal!`'s docstring cited "EP body rule 960" (a raw line number into a hot-zone doc — a drift hazard). Replaced with the named §Hot Reload And Reinstall section + the quoted rule text.

## What was verified accurate (no change needed)

- The precised **disposition-12** kind-boundary comments (`reinstall!` + module headers in `app_value.cljc`, `install-descriptor!` + `install-deferred-kinds`/`install-wired-kinds` in `core.cljc`) match EP-0013 §Hot Reload And Reinstall + the 2026-06-12 errata exactly: step-8-deferred kinds throw `:rf.error/unsupported-descriptor-kind`; the live-instance blocker/continue/migrate rule binds per-kind when each becomes installable; `:frame` removal is the one reachable live edge and is refused loudly.
- `module-section->kind`, `install-wired-kinds`, and `install-deferred-kinds` are exact partitions of the closed `registrar/kinds` taxonomy (13 kinds; wired 5 + deferred 8).
- The realm.cljc docstrings (realm record slots, `construct-realm`, `dispose-realm!`, the `*registrar*` seating seam, the late-bind bridges) match the shipped behaviour; the "stage 9 is the LAST EP-0013 impl slice" / "stage 7 is the LAST D2 slice" claims are both correct and non-contradictory per the EP staging table.

## Quality gates

- `clojure -M:test` (core JVM): **1365 tests, 6048 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node CLJS): **6867 tests, 27900 assertions, 0 failures, 0 errors**