### PR TITLE
refactor(core,story-mcp): centralize derived-tree value-match redaction (rf2-i783h0)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -2122,6 +2122,50 @@
   {:app-db …}`). Per Spec 015 §Frame-owned durable classification."}
   elision-sensitive-declarations   elision/sensitive-declarations)
 
+(def ^{:doc "Value-redact a DERIVED tree (rendered hiccup, a resolved
+  `:effective-args` map, a snapshot body, a plan-resolved value slot) against
+  the live values at the frame's declared-`:sensitive?` app-db paths, before
+  wire egress (EP-0015 issue 2). The value-based DUAL of `elide-wire-value`:
+  where the path-based walker redacts by app-db PATH, this collects the
+  sensitive VALUES from the source db and substitutes any matching leaf in the
+  derived tree (a sensitive value re-surfaces at a non-app-db position the
+  path-based walker can't reach) with `:rf/redacted`. Includes the
+  non-unique-secret guard (a candidate already disclosed on the wire is
+  dropped, classified against the elided db). `(redact-derived-values tree
+  source-db frame-id wire-opts)` — `wire-opts` is the `elide-wire-value` opts
+  the path-based `:app-db` slot ships under (the egress floor; `:frame` is
+  supplied automatically). Per Spec 015 §Projection and Security.md §Off-box
+  egress."}
+  redact-derived-values            elision/redact-derived-values)
+
+(def ^{:doc "The set of live values at the frame's declared-`:sensitive?`
+  app-db paths, read from a raw db, MINUS any value already disclosed on the
+  wire (the non-unique-secret guard, classified against the elided db). The
+  candidate secret set `redact-derived-values` substitutes; exposed for tools
+  that drive the value-match over MULTIPLE derived slots from one collection
+  pass. `(elision-sensitive-value-set app-db frame-id wire-opts)`. Per
+  Spec 015 §Projection."}
+  elision-sensitive-value-set      elision/sensitive-value-set)
+
+(def ^{:doc "The set of values at the frame's declared-`:sensitive?` app-db
+  paths, read from a raw source db, with NO wire-disclosure guard — the
+  fail-SAFE base candidate set. Use for a source that is NOT the live wire
+  `:app-db` (e.g. a plan's authored `:db-seed` slot), where every governed
+  value must stay redacted; for the live source use
+  `elision-sensitive-value-set`. `(elision-collect-sensitive-values source-db
+  frame-id)`. Per Spec 015 §Projection."}
+  elision-collect-sensitive-values elision/collect-sensitive-values)
+
+(def ^{:doc "Walk a derived tree, substituting any leaf `=` to a member of a
+  pre-collected `secrets` set with the `:rf/redacted` sentinel (the redaction
+  arm of the value-match primitive). Recurses maps/vectors/sets/seqs; map keys
+  walked too; returns the tree unchanged when `secrets` is empty. Use with a
+  set from `elision-sensitive-value-set` /
+  `elision-collect-sensitive-values` to redact MULTIPLE derived slots from one
+  collection pass. `(redact-matching-values tree secrets)`. Per Spec 015
+  §Projection."}
+  redact-matching-values           elision/redact-matching-values)
+
 (def ^{:doc "Project a sequence of raw trace events into one cascade
   record per `:dispatch-id`. Pure data — JVM and CLJS. Used by
   `re-frame-10x`, Xray, and other tools that present cascade-level

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -616,6 +616,269 @@
   [v]
   (and (vector? v) (= :rf.elision/at (first v))))
 
+;; ---------------------------------------------------------------------------
+;; Derived-tree VALUE-based redaction (EP-0015 issue 2, rf2-i783h0).
+;;
+;; `elide-wire-value` redacts a value by its frame-declared `:sensitive`
+;; app-db PATH. But a DERIVED tree — rendered hiccup, a resolved
+;; `:effective-args` map, a snapshot body, a plan-resolved value slot —
+;; re-surfaces the SAME sensitive value at a NON-app-db position the
+;; path-based walker can never reach (a token sitting at hiccup coordinate
+;; `[1 :value]`, not at `[:auth :token]`). The path-based walker is
+;; structurally blind to the re-keyed copy.
+;;
+;; The sound posture for a DERIVED tree is VALUE-based redaction: collect the
+;; live values sitting at the frame's declared-`:sensitive?` app-db paths,
+;; then substitute any leaf in the derived tree that EQUALS one of them with
+;; the same `:rf/redacted` sentinel `elide-wire-value` emits. This is the
+;; value-based DUAL of the path-based walker above — it belongs in the same
+;; ns so the two arms of "redact app-db-sensitive values at egress" share one
+;; home (the elision registry, the sentinel, the indexing convention). It
+;; centralizes the engine Story-MCP / re-frame2-pair-mcp previously each
+;; carried privately (the SECOND place EP-0015 egress semantics could drift).
+;;
+;; ## Non-unique-secret guard
+;;
+;; Value-matching is a heuristic: it substitutes EVERY derived-tree leaf `=`
+;; a sensitive value. When a sensitive path holds a short/common scalar (`0`,
+;; an HTTP `200`, `:ok`, `""`), naive matching scrubs every benign leaf that
+;; merely equals it — degrading the consumer's view AND leaking the secret's
+;; value-CLASS. The guard subtracts any candidate value that ALSO appears,
+;; VERBATIM, on the wire — i.e. in the POST-elision db (the actual wire
+;; bytes). Such a value is provably NOT a protected secret: the path-based
+;; `:app-db` egress already discloses it, so removing it from the secret set
+;; leaks nothing new — the fail-SAFE invariant (never leak a genuine secret)
+;; holds by construction.
+;;
+;; Classifying against the ELIDED db (not the raw db) is load-bearing: a
+;; secret aliased into a `:large?`-declared subtree is replaced by the
+;; `:rf.size/large-elided` marker on the wire, so it is NOT disclosed and MUST
+;; stay redacted; and a seq-indexed `:sensitive?` element redacted by
+;; `elide-wire-value` simply does not appear in the elided db. Reasoning
+;; against the actual wire bytes is robust to any elision class (digests, new
+;; markers, the string auto-detect threshold) without per-class reasoning.
+
+(defn- under-prefix?
+  "True when `path` is `prefix` or descends from it (element-wise prefix
+  match). Both are indexed vectors. Decides whether an app-db position is
+  governed by a declared-`:sensitive?` path — a slot marked sensitive covers
+  itself AND everything beneath it."
+  [prefix path]
+  (let [pn (count prefix)]
+    (and (<= pn (count path))
+         (loop [i 0]
+           (cond
+             (== i pn)                       true
+             (= (nth prefix i) (nth path i)) (recur (inc i))
+             :else                           false)))))
+
+(defn- collect-governed-values!
+  "Walk the RAW `node` at `path`, conj!ing onto transient set `acc!` every
+  scalar value sitting at (or beneath) a `:sensitive?` prefix — the candidate
+  secrets. Returns `acc!`.
+
+  Indexing MIRRORS the path-based walker above so a declared path lands on
+  the SAME node `elide-wire-value` redacts: maps descend by key, vectors AND
+  seqs descend by integer index (so a seq-indexed `[:tokens 0]` declaration
+  is reached — `get-in` cannot read a seq index), and sets are walked at
+  their own path (set elements have no stable index, so a whole
+  sensitive-declared set contributes all its members).
+
+  Only governed positions contribute, and `nil` / boolean leaves are skipped
+  (a `nil`/`false` is not a secret and value-matching it would scrub swathes
+  of benign tree). Collections that ARE governed still recurse so nested
+  scalars under a sensitive subtree are all collected."
+  [acc! node path sensitive-prefixes]
+  (let [governed? (some #(under-prefix? % path) sensitive-prefixes)]
+    (when (and governed?
+               (not (coll? node))
+               (not (nil? node))
+               (not (boolean? node)))
+      (conj! acc! node))
+    (cond
+      (map? node)
+      (reduce-kv (fn [a k v]
+                   (collect-governed-values! a v (conj path k) sensitive-prefixes))
+                 acc! node)
+
+      (vector? node)
+      (reduce (fn [a i] (collect-governed-values! a (nth node i) (conj path i)
+                                                  sensitive-prefixes))
+              acc! (range (count node)))
+
+      (seq? node)
+      (let [idx (volatile! -1)]
+        (reduce (fn [a x]
+                  (collect-governed-values! a x (conj path (vswap! idx inc))
+                                            sensitive-prefixes))
+                acc! node))
+
+      (set? node)
+      ;; Sets have no stable element index; walk members at the set's own
+      ;; path so a sensitive-declared set contributes every member.
+      (reduce (fn [a x] (collect-governed-values! a x path sensitive-prefixes))
+              acc! node)
+
+      :else
+      acc!)))
+
+(defn- collect-wire-values!
+  "Walk the POST-elision `node`, conj!ing onto transient set `acc!` every
+  value (intermediate collections AND leaves) that is `=` to a candidate
+  secret. `node` is the elided db — the actual wire bytes — so any candidate
+  found here is one the path-based egress ships VERBATIM. Returns `acc!`.
+
+  Because the input is already elided, every `:sensitive?` slot is the
+  `:rf/redacted` sentinel and every `:large?` (or auto-detected) slot is the
+  `:rf.size/large-elided` marker — the secret value simply is not present at
+  any governed position, so there is no path-shape reasoning to get right.
+  Membership is the only question; map keys, vector elements, and set/seq
+  elements are all walked, since a candidate aliased to ANY surviving wire
+  position is disclosed."
+  [acc! node candidates]
+  (when (contains? candidates node)
+    (conj! acc! node))
+  (cond
+    (map? node)
+    (reduce-kv (fn [a k v]
+                 (collect-wire-values! a k candidates)
+                 (collect-wire-values! a v candidates))
+               acc! node)
+
+    (coll? node)
+    (reduce (fn [a x] (collect-wire-values! a x candidates))
+            acc! node)
+
+    :else
+    acc!))
+
+(defn collect-sensitive-values
+  "The set of values sitting at `frame-id`'s declared-`:sensitive?` app-db
+  paths, read out of the RAW `source-db` — the candidate secrets, with NO
+  wire-disclosure guard applied. The fail-SAFE base set for value-matching a
+  derived tree (EP-0015 issue 2, rf2-i783h0).
+
+  Reads the SAME frame-owned `:sensitive` `:app-db` declarations
+  (`sensitive-declarations`) the path-based walker reads — installed by
+  `re-frame.frame-classification` at `reg-frame` time (EP-0015 §8). Candidates
+  are collected by WALKING `source-db` at governed positions (mirroring the
+  elider's indexing) rather than by `get-in` on each declared path — `get-in`
+  cannot index into a seq, so a seq-indexed declaration (`[:tokens 0]`) would
+  otherwise yield no candidate and the secret would leak. `nil` / boolean
+  leaves are excluded (not secrets, and value-matching them would scrub
+  swathes of benign tree).
+
+  No guard means every governed value stays in the set — over-scrub at worst,
+  never under-scrub. Use this for a source that is NOT the live wire `:app-db`
+  (e.g. a plan's authored `:db-seed` slot); for the live source use
+  `sensitive-value-set`, which layers the non-unique-secret guard on top.
+  Returns `#{}` when `source-db` is nil or the frame declares nothing
+  sensitive."
+  [source-db frame-id]
+  (if (nil? source-db)
+    #{}
+    (let [sensitive-prefixes (mapv vec (keys (sensitive-declarations frame-id)))]
+      (if (empty? sensitive-prefixes)
+        #{}
+        (persistent!
+          (collect-governed-values! (transient #{}) source-db []
+                                    sensitive-prefixes))))))
+
+(defn sensitive-value-set
+  "The set of live values sitting at `frame-id`'s declared-`:sensitive?`
+  app-db paths, read out of the RAW `app-db`, MINUS any value that is already
+  disclosed on the wire (the non-unique-secret guard). Use this to
+  value-redact a DERIVED tree where the same sensitive value reappears at a
+  non-app-db position the path-based `elide-wire-value` walker can't reach
+  (EP-0015 issue 2, rf2-i783h0).
+
+  Candidates come from `collect-sensitive-values` (the unguarded base set).
+  The non-unique-secret guard then subtracts any candidate that ALSO appears,
+  VERBATIM, in the POST-elision db — the actual wire bytes produced by
+  walking `app-db` through `elide-wire-value` under `wire-opts` (which MUST
+  carry the egress floor the path-based `:app-db` slot ships under, so the
+  wire-classification reasons about the IDENTICAL bytes; `:frame frame-id` is
+  supplied automatically).
+
+  A candidate present there is already disclosed by the path-based egress, so
+  dropping it leaks nothing new; one that is absent (redacted / large-elided)
+  stays in the set and is redacted everywhere. Classifying against the ELIDED
+  db (not the raw db) is load-bearing — a secret aliased into a
+  `:large?`-declared subtree is the marker on the wire, NOT the verbatim
+  value, so it must stay redacted; a seq-indexed `:sensitive?` element
+  redacted by `elide-wire-value` does not appear in the elided db either. The
+  irreducible same-value aliasing case (a uniquely-secret short scalar)
+  over-scrubs — fail-SAFE, never under-safe.
+
+  Returns `#{}` when `app-db` is nil, when the frame declares nothing
+  sensitive, or when every candidate is already on the wire."
+  [app-db frame-id wire-opts]
+  (let [candidates (collect-sensitive-values app-db frame-id)]
+    (if (empty? candidates)
+      #{}
+      (let [wire   (elide-wire-value app-db (assoc wire-opts :frame frame-id))
+            public (persistent!
+                     (collect-wire-values! (transient #{}) wire candidates))]
+        (into #{} (remove public) candidates)))))
+
+(defn redact-matching-values
+  "Walk `tree`, substituting any leaf `=` to a member of `secrets` with the
+  `:rf/redacted` sentinel. Recurses through maps, vectors, sets, seqs; treats
+  every other value as a leaf. Map KEYS are walked too — a secret used as a
+  key (rare, but a `{:value <token>}`-style attribute map could in principle
+  key on one) is redacted on both sides. Returns `tree` unchanged when
+  `secrets` is empty."
+  [tree secrets]
+  (if (empty? secrets)
+    tree
+    (letfn [(walk* [t]
+              (cond
+                (contains? secrets t) privacy/redacted-sentinel
+                (map? t)    (persistent!
+                              (reduce-kv (fn [acc k v]
+                                           (assoc! acc (walk* k) (walk* v)))
+                                         (transient {})
+                                         t))
+                (vector? t) (mapv walk* t)
+                (set? t)    (into #{} (map walk*) t)
+                (seq? t)    (map walk* t)
+                :else       t))]
+      (walk* tree))))
+
+(defn redact-derived-values
+  "Value-redact a DERIVED `tree` (rendered hiccup, a resolved `:effective-args`
+  map, a snapshot body, a plan-resolved value slot) against the live values
+  at `frame-id`'s declared-`:sensitive?` app-db paths, before wire egress
+  (EP-0015 issue 2, rf2-i783h0). The single framework home for the
+  value-match-redaction primitive Story-MCP / re-frame2-pair-mcp previously
+  each carried privately.
+
+  Collects the secret set from `source-db` (the raw db the derived tree was
+  produced from) via `sensitive-value-set` — including the non-unique-secret
+  guard, classified against the wire bytes `source-db` ships under
+  `wire-opts` — then substitutes any matching leaf in `tree` with
+  `:rf/redacted`.
+
+  `wire-opts` is the `elide-wire-value` opts the path-based `:app-db` slot
+  ships under (the egress floor — e.g. an off-box-tool / off-box-observability
+  profile's `:rf.size/*` opt-set); `:frame frame-id` is supplied
+  automatically. Keeping the egress floor a caller argument keeps this helper
+  egress-profile-agnostic — the `:rf.egress/*` profile vocabulary stays in the
+  MCP-base / tool layer.
+
+  Short-circuits: a nil `tree` or nil `source-db` returns `tree` (nothing to
+  scrub / no source of secrets); no declared-sensitive (or all-disclosed)
+  values returns `tree` unwalked. The opt-out (trusted-local raw) belongs to
+  the caller — pass the value through directly when the operator has waived
+  redaction."
+  [tree source-db frame-id wire-opts]
+  (cond
+    (nil? tree)      tree
+    (nil? source-db) tree
+    :else            (redact-matching-values
+                       tree
+                       (sensitive-value-set source-db frame-id wire-opts))))
+
 ;; EP-0015 §8 (rf2-d2r3um): no `:elision/populate-from-schemas!` hook —
 ;; schemas no longer feed the app-db egress registry (frame policy owns it).
 (late-bind/set-fn! :elision/sensitive-declarations sensitive-declarations)

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -567,6 +567,16 @@
   ["re-frame.core" "elision-declarations"]              {:tier :tooling  :owner "009" :status "v1"}
   ["re-frame.core" "elision-sensitive-declarations"]    {:tier :tooling  :owner "009" :status "v1"}
   ["re-frame.core" "sensitive?"]                        {:tier :tooling  :owner "009" :status "v1"}
+  ;; Derived-tree value-match redaction (EP-0015 — rf2-i783h0). The
+  ;; value-based DUAL of the path-based `elide-wire-value` / record-level
+  ;; `project-egress` egress surface — same Spec 015 §Projection ownership.
+  ;; A framework-owned primitive Story-MCP consumes through the façade
+  ;; (the engine centralized in `re-frame.elision`); :tooling, like its
+  ;; egress siblings, not a front-porch app primitive.
+  ["re-frame.core" "redact-derived-values"]             {:tier :tooling  :owner "015" :status "v1"}
+  ["re-frame.core" "elision-sensitive-value-set"]       {:tier :tooling  :owner "015" :status "v1"}
+  ["re-frame.core" "elision-collect-sensitive-values"]  {:tier :tooling  :owner "015" :status "v1"}
+  ["re-frame.core" "redact-matching-values"]            {:tier :tooling  :owner "015" :status "v1"}
 
   ;; --- Individually-named extra-vars (generator `extra-vars`) ---
   ;; The two dev-gate Vars rowed in spec/API.md §Tracing whose home

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 516,
+ :var-count 520,
  :tier-vocab
  [:front-porch
   :advanced
@@ -112,8 +112,10 @@
   {:namespace "re-frame.core", :var "dispose-realm!", :tier :advanced, :kind :fn, :owner "Runtime-Subsystems", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "domino-bucket", :tier :tooling, :kind :fn, :owner "009", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "elide-wire-value", :tier :tooling, :kind :fn, :owner "009", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "elision-collect-sensitive-values", :tier :tooling, :kind :fn, :owner "015", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "elision-declarations", :tier :tooling, :kind :fn, :owner "009", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "elision-sensitive-declarations", :tier :tooling, :kind :fn, :owner "009", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "elision-sensitive-value-set", :tier :tooling, :kind :fn, :owner "015", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "emit-trace-event!", :tier :tooling, :kind :fn, :owner "009", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "epoch-history", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "feature-loaded?", :tier :advanced, :kind :fn, :owner "Conventions", :status "v1", :facade? true, :runtime-verified? true}
@@ -160,6 +162,8 @@
   {:namespace "re-frame.core", :var "projected-history", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "projected-record", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "v1 (dev-only)", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "realm", :tier :advanced, :kind :fn, :owner "Runtime-Subsystems", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "redact-derived-values", :tier :tooling, :kind :fn, :owner "015", :status "v1", :facade? true, :runtime-verified? true}
+  {:namespace "re-frame.core", :var "redact-matching-values", :tier :tooling, :kind :fn, :owner "015", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reg-app-schema", :tier :advanced, :kind :macro, :owner "010", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reg-app-schemas", :tier :advanced, :kind :macro, :owner "010", :status "v1", :facade? true, :runtime-verified? true}
   {:namespace "re-frame.core", :var "reg-cofx", :tier :front-porch, :kind :macro, :owner "002", :status "v1 (preserved)", :facade? true, :runtime-verified? true}

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/egress.cljc
@@ -67,16 +67,29 @@
 
   Value-matching is a heuristic; its one collateral hazard is a
   sensitive path holding a SHORT/COMMON scalar (`0`, `200`, `:ok`),
-  which would scrub every benign leaf that equals it. `sensitive-values`
-  guards that (rf2-g7cd1, hardened rf2-f3kf7) by dropping any candidate
+  which would scrub every benign leaf that equals it. The framework
+  `re-frame.core/elision-sensitive-value-set` guards that (rf2-g7cd1,
+  hardened rf2-f3kf7; centralized rf2-i783h0) by dropping any candidate
   that ALSO appears, VERBATIM, in the POST-elision `:app-db` (the actual
   wire bytes) — such a value is already disclosed by the path-based
   `:app-db` egress, so excluding it leaks nothing new while restoring the
   benign leaves. Classifying against the elided db (not the raw db) is
   load-bearing: a secret aliased into a `:large?`-declared subtree is
   replaced by the `:rf.size/large-elided` marker on the wire, so it is NOT
-  disclosed and MUST stay redacted. See `sensitive-values` for the
-  fail-SAFE argument."
+  disclosed and MUST stay redacted. See the framework helper for the
+  fail-SAFE argument.
+
+  ## Centralized value-match engine (rf2-i783h0)
+
+  The value-match-redaction ENGINE — candidate collection, the
+  non-unique-secret guard, and the matching-leaf substitution — lives ONCE
+  in `re-frame.elision` (the value-based DUAL of `elide-wire-value`), exposed
+  through the `re-frame.core` facade as `redact-derived-values` /
+  `elision-sensitive-value-set` / `elision-collect-sensitive-values` /
+  `redact-matching-values`. The scrubbers below are ORCHESTRATION only —
+  resolve the egress floor from the posture, read the source app-db, apply
+  the `:include-sensitive` opt-out. This removes the SECOND place EP-0015
+  egress semantics could drift (EP-0015 best-practice review issue 2)."
   (:require [re-frame.core :as rf]
             [re-frame.mcp-base.egress :as base-egress]
             [re-frame.mcp-base.elision :as base-elision]
@@ -194,241 +207,52 @@
     :else          (sensitive/strip-sensitive records false)))
 
 ;; ---------------------------------------------------------------------------
-;; Derived-tree value-based redaction (rf2-ee38b.17)
+;; Derived-tree value-based redaction (rf2-ee38b.17; centralized rf2-i783h0)
 ;; ---------------------------------------------------------------------------
-
-(defn- under-prefix?
-  "True when `path` is `prefix` or descends from it (element-wise prefix
-  match). Both are indexed vectors. Used to decide whether an app-db
-  position is governed by a declared-`:sensitive?` path — a slot marked
-  sensitive covers itself AND everything beneath it."
-  [prefix path]
-  (let [pn (count prefix)]
-    (and (<= pn (count path))
-         (loop [i 0]
-           (cond
-             (== i pn)                       true
-             (= (nth prefix i) (nth path i)) (recur (inc i))
-             :else                           false)))))
-
-(defn- collect-governed-values!
-  "Walk the RAW `node` at `path`, conj!ing onto transient set `acc!` every
-  scalar value sitting at (or beneath) a `:sensitive?` prefix — the
-  candidate secrets. Returns `acc!`.
-
-  Indexing MIRRORS `elide-wire-value`'s walk so a declared path lands on
-  the SAME node the elider redacts: maps descend by key, vectors AND seqs
-  descend by integer index (the fix for the seq-indexed `[:tokens 0]`
-  facet — `get-in` cannot read a seq index, so the old candidate-by-`get-in`
-  extraction silently dropped seq-indexed secrets => under-scrub), and
-  sets are walked at their own path (set elements have no stable index, so
-  a whole sensitive-declared set contributes all its members).
-
-  Only governed positions contribute, and `nil` / boolean leaves are
-  skipped (a `nil`/`false` is not a secret and value-matching it would
-  scrub swathes of benign tree). Collections that ARE governed still
-  recurse so nested scalars under a sensitive subtree are all collected."
-  [acc! node path sensitive-prefixes]
-  (let [governed? (some #(under-prefix? % path) sensitive-prefixes)]
-    (when (and governed?
-               (not (coll? node))
-               (not (nil? node))
-               (not (boolean? node)))
-      (conj! acc! node))
-    (cond
-      (map? node)
-      (reduce-kv (fn [a k v]
-                   (collect-governed-values! a v (conj path k) sensitive-prefixes))
-                 acc! node)
-
-      (vector? node)
-      (reduce (fn [a i] (collect-governed-values! a (nth node i) (conj path i)
-                                                  sensitive-prefixes))
-              acc! (range (count node)))
-
-      (seq? node)
-      (let [idx (volatile! -1)]
-        (reduce (fn [a x]
-                  (collect-governed-values! a x (conj path (vswap! idx inc))
-                                            sensitive-prefixes))
-                acc! node))
-
-      (set? node)
-      ;; Sets have no stable element index; walk members at the set's own
-      ;; path so a sensitive-declared set contributes every member.
-      (reduce (fn [a x] (collect-governed-values! a x path sensitive-prefixes))
-              acc! node)
-
-      :else
-      acc!)))
-
-(defn- collect-wire-values!
-  "Walk the POST-elision `node`, conj!ing onto transient set `acc!` every
-  value (intermediate collections AND leaves) that is `=` to a candidate
-  secret. `node` is the elided `:app-db` — the actual wire bytes — so any
-  candidate found here is one the path-based `:app-db` egress ships
-  VERBATIM. Returns `acc!`.
-
-  Because the input is already elided, every `:sensitive?` slot is the
-  `:rf/redacted` sentinel and every `:large?` (or auto-detected) slot is
-  the `:rf.size/large-elided` marker — the secret value simply is not
-  present at any governed position, so there is no path-shape reasoning to
-  get right (no prefix walk, no seq-index correction). Membership is the
-  only question; map keys, vector elements, and set/seq elements are all
-  walked, since a candidate aliased to ANY surviving wire position is
-  disclosed."
-  [acc! node candidates]
-  (when (contains? candidates node)
-    (conj! acc! node))
-  (cond
-    (map? node)
-    (reduce-kv (fn [a k v]
-                 (collect-wire-values! a k candidates)
-                 (collect-wire-values! a v candidates))
-               acc! node)
-
-    (coll? node)
-    (reduce (fn [a x] (collect-wire-values! a x candidates))
-            acc! node)
-
-    :else
-    acc!))
-
-(defn- sensitive-values
-  "The set of live values sitting at `variant-id`'s declared-`:sensitive?`
-  app-db paths, read out of the RAW `app-db`. Used to value-redact derived
-  trees (rendered hiccup, effective-args, snapshot) where the same value
-  reappears at a non-app-db path the path-based walker can't reach.
-
-  Reads the SAME frame-owned `:sensitive` `:app-db` declarations
-  (`re-frame.core/elision-sensitive-declarations`) `elide-app-db` reads —
-  installed by `re-frame.frame-classification` at `reg-frame` time
-  (EP-0015 §8). Nil / boolean values are excluded — a `nil` or `false`
-  leaf is not a secret and value-matching them would scrub swathes of
-  benign tree.
-
-  ## Non-unique-secret guard (rf2-g7cd1, hardened rf2-f3kf7)
-
-  Value-based redaction is a heuristic: it substitutes EVERY derived-tree
-  leaf `=` a sensitive value. When a sensitive path holds a short/common
-  scalar (`0`, an HTTP `200`, `:ok`, `\"\"`), naive value-matching scrubs
-  every benign leaf that merely happens to equal it — degrading the
-  agent's view AND leaking the secret's value-CLASS.
-
-  The guard subtracts any candidate value that ALSO appears, VERBATIM, on
-  the wire — i.e. in the POST-elision `:app-db` (`elide-app-db` of the raw
-  db). Such a value is provably NOT a protected secret: the path-based
-  `:app-db` egress already discloses it, so removing it from the
-  derived-tree secret set leaks nothing new — the fail-SAFE invariant
-  (never leak a genuine secret) holds by construction.
-
-  Classifying against the elided db (rather than the raw db) is the
-  correction for rf2-f3kf7: the original guard walked the RAW db, so a
-  secret that ALSO lived under a `:large?`-declared non-sensitive path was
-  seen at that position and dropped from the secret set — yet
-  `elide-app-db` replaces a `:large?` slot with the `:rf.size/large-elided`
-  marker, so the secret was NOT on the wire and then leaked VERBATIM into
-  the derived trees. Reasoning against the actual wire bytes closes that
-  hole AND is robust to any future elision class (digests, new markers,
-  the string auto-detect threshold), not just `:large?` — and it subsumes
-  the seq-indexed `:sensitive?` edge (an indexed element redacted by
-  `elide-wire-value` simply does not appear in the elided db).
-
-  A value that survives ONLY under sensitive / large positions (so is
-  absent from the elided db) stays in the set and is redacted everywhere
-  (no under-scrub); the irreducible same-value aliasing case (a
-  uniquely-secret short scalar) still over-scrubs — that residual is
-  fail-SAFE, never under-safe."
-  [app-db variant-id]
-  (let [decls              (rf/elision-sensitive-declarations variant-id)
-        sensitive-prefixes (mapv vec (keys decls))
-        ;; Collect candidate secrets by WALKING the raw db at governed
-        ;; positions (mirroring the elider's indexing) rather than reading
-        ;; each declared path with `get-in` — `get-in` cannot index into a
-        ;; seq, so seq-indexed declarations (`[:tokens 0]`) would otherwise
-        ;; silently yield no candidate and the secret would leak.
-        candidates         (persistent!
-                             (collect-governed-values! (transient #{}) app-db []
-                                                        sensitive-prefixes))]
-    (if (empty? candidates)
-      #{}
-      ;; Classify "public" against the actual wire bytes: the elided
-      ;; app-db. A candidate present here is shipped verbatim by the
-      ;; :app-db egress (already disclosed) so it is dropped; one that is
-      ;; absent (redacted / elided away) stays redacted in derived trees.
-      ;; Walk under the SAME `:rf.egress/off-box-tool` floor `elide-app-db`
-      ;; uses (rf2-qus09h) so the wire-classification reasons about the
-      ;; identical bytes the `:app-db` egress actually ships.
-      (let [wire   (rf/elide-wire-value
-                     app-db
-                     (assoc (posture->elision-opts false) :frame variant-id))
-            public (persistent!
-                     (collect-wire-values! (transient #{}) wire candidates))]
-        (into #{} (remove public) candidates)))))
-
-(defn- redact-matching
-  "Walk `tree`, substituting any leaf `=` to a member of `secrets` with the
-  `:rf/redacted` sentinel. Recurses through maps, vectors, sets, seqs;
-  treats every other value as a leaf. Map KEYS are walked too — a secret
-  used as a key (rare, but a `{:value <token>}`-style attribute map could
-  in principle key on one) is redacted on both sides."
-  [tree secrets]
-  (cond
-    (contains? secrets tree) :rf/redacted
-    (map? tree)    (persistent!
-                     (reduce-kv (fn [acc k v]
-                                  (assoc! acc
-                                          (redact-matching k secrets)
-                                          (redact-matching v secrets)))
-                                (transient {})
-                                tree))
-    (vector? tree) (mapv #(redact-matching % secrets) tree)
-    (set? tree)    (into #{} (map #(redact-matching % secrets)) tree)
-    (seq? tree)    (map #(redact-matching % secrets) tree)
-    :else          tree))
+;;
+;; `elide-app-db` closes the leak for the `:app-db` slot by PATH — but the
+;; same sensitive value reappears, VERBATIM, in `:rendered-hiccup`,
+;; `:effective-args`, a `:snapshot` body, and the explain plan-resolved value
+;; slots, at a non-app-db position the path-based walker can never reach. The
+;; sound posture for a derived tree is VALUE-based redaction: collect the live
+;; values at the frame's declared-`:sensitive?` paths and substitute any
+;; matching leaf with `:rf/redacted`.
+;;
+;; The VALUE-MATCH ENGINE — candidate collection (mirroring the elider's
+;; indexing so a seq-indexed `[:tokens 0]` is reached), the non-unique-secret
+;; guard (drop any candidate already on the wire, classified against the
+;; ELIDED db — rf2-g7cd1 / rf2-f3kf7), and the matching-leaf substitution —
+;; now lives ONCE in the framework `re-frame.elision` ns (EP-0015 issue 2,
+;; rf2-i783h0). It is the value-based DUAL of `elide-wire-value`, so it
+;; belongs beside it (one home for the egress fact; a SECOND place the
+;; semantics could drift is removed). story-mcp keeps only the ORCHESTRATION:
+;; resolve the egress floor from the posture, read the source app-db, apply
+;; the `:include-sensitive` opt-out. The behaviour is byte-identical — the
+;; engine moved, the contract did not.
 
 (defn scrub-rendered
   "Value-redact a DERIVED tree (rendered hiccup, `:effective-args`, a
-  snapshot body) before wire egress. The path-based `elide-wire-value`
-  walker scrubs `:app-db` by path, but the same sensitive value reappears
-  in these derived surfaces at a non-app-db position — so we collect the
-  live values at `variant-id`'s declared-`:sensitive?` paths and substitute
-  any matching leaf in `tree` with `:rf/redacted` (rf2-ee38b.17).
+  snapshot body) before wire egress, keyed to `variant-id`'s frame. Delegates
+  the value-match engine to the framework `re-frame.core/redact-derived-values`
+  (rf2-i783h0): collect the live values at `variant-id`'s declared-`:sensitive?`
+  paths from `app-db` — with the non-unique-secret guard, classified against
+  the elided db under the `:rf.egress/off-box-tool` floor — and substitute any
+  matching leaf in `tree` with `:rf/redacted` (rf2-ee38b.17).
 
   Short-circuits, mirroring `elide-app-db`:
 
     - `include? true` returns `tree` unchanged (the opt-out escape hatch).
-    - A nil `tree` or nil `app-db` returns `tree` (nothing to scrub /
-      no source of secrets).
-    - No declared-sensitive values ⇒ `tree` is returned unwalked (the
-      common case is one cheap set build, then the no-secrets early out)."
+    - A nil `tree` or nil `app-db` returns `tree` (handled by the framework
+      helper — nothing to scrub / no source of secrets).
+    - No declared-sensitive (or all-disclosed) values ⇒ `tree` is returned
+      unwalked."
   [tree app-db variant-id include?]
-  (cond
-    include?        tree
-    (nil? tree)     tree
-    (nil? app-db)   tree
-    :else           (let [secrets (sensitive-values app-db variant-id)]
-                      (if (empty? secrets)
-                        tree
-                        (redact-matching tree secrets)))))
-
-(defn- frame-sensitive-prefixes
-  "The `:sensitive` `:app-db` declaration PATHS for `variant-id`, read from
-  the frame's durable elision registry
-  (`re-frame.core/elision-sensitive-declarations`) — the SAME source
-  `sensitive-values` and `elide-app-db` read.
-
-  Frame-owned classification (EP-0015 §8): `re-frame.frame-classification`
-  installs these `:source :frame` declarations at `reg-frame` time, so they
-  are live for the WHOLE life of the frame — no run required to populate
-  them. (The former schema→registry population route was removed in §8;
-  schema `{:sensitive? true}` slot props no longer feed this registry.)
-  Returns a vec of path-prefix vectors (the `collect-governed-values!`
-  input shape); `[]` when the variant declares nothing sensitive (or its
-  frame is unallocated — `elision-sensitive-declarations` reads an empty
-  registry for an absent frame)."
-  [variant-id]
-  (mapv vec (keys (rf/elision-sensitive-declarations variant-id))))
+  (if include?
+    tree
+    ;; Classify against the SAME `:rf.egress/off-box-tool` floor `elide-app-db`
+    ;; ships under (rf2-qus09h) so the wire-classification reasons about the
+    ;; identical bytes the `:app-db` egress actually emits.
+    (rf/redact-derived-values tree app-db variant-id (posture->elision-opts false))))
 
 (defn- plan-sensitive-values
   "The candidate-secret set derived from a PLAN-side seed source `seed-db`
@@ -437,32 +261,17 @@
   `:sensitive` `:app-db` paths. The pre-RUN source for `explain-variant`
   (rf2-tag30h): `explain-variant` is a documented no-run path, so the live
   app-db may be unseeded — but a secret authored into `:db-seed` (and
-  re-surfaced in `:effective-args` / `:network` / a step payload) must
-  still be value-matched. We walk the plan's OWN seed map at the frame's
-  declared-sensitive paths to collect the values destined for sensitive
-  positions; those are the secrets to redact out of the sibling
-  value-bearing slots.
+  re-surfaced in `:effective-args` / `:network` / a step payload) must still
+  be value-matched.
 
-  The declared-sensitive PATHS come from the frame's durable elision
-  registry (`frame-sensitive-prefixes`) — frame-owned classification is
-  live from `reg-frame` time (EP-0015 §8), so the paths are available
-  pre-run without any schema→registry population.
-
-  No public-against-the-wire subtraction here: this seed source is the
-  authored plan, not the live wire `:app-db` egress, so every governed
-  seed value stays in the set (fail-SAFE — over-scrub at worst, never
-  under-scrub). `nil` / boolean leaves are skipped by
-  `collect-governed-values!` for the same reason `sensitive-values` skips
-  them."
+  Delegates the unguarded governed-value collection to the framework
+  `re-frame.core/elision-collect-sensitive-values` (rf2-i783h0) — the SAME
+  candidate-collection engine `scrub-rendered`'s guarded path uses. No
+  public-against-the-wire subtraction here: this seed source is the authored
+  plan, not the live wire `:app-db` egress, so every governed seed value stays
+  in the set (fail-SAFE — over-scrub at worst, never under-scrub)."
   [seed-db variant-id]
-  (if (nil? seed-db)
-    #{}
-    (let [sensitive-prefixes (frame-sensitive-prefixes variant-id)]
-      (if (empty? sensitive-prefixes)
-        #{}
-        (persistent!
-          (collect-governed-values! (transient #{}) seed-db []
-                                    sensitive-prefixes))))))
+  (rf/elision-collect-sensitive-values seed-db variant-id))
 
 (defn scrub-explain-values
   "Value-redact the runtime/seeded VALUE slots `value-slot-keys` of an
@@ -472,9 +281,11 @@
 
   Candidate secrets come from BOTH sources, unioned:
 
-    - the LIVE variant-frame app-db (via `sensitive-values`) — the source
-      once `run-variant` / `preview-variant` has allocated and seeded the
-      frame; AND
+    - the LIVE variant-frame app-db (via the framework
+      `re-frame.core/elision-sensitive-value-set` — the guarded live reader,
+      classified against the elided db under the `:rf.egress/off-box-tool`
+      floor) — the source once `run-variant` / `preview-variant` has
+      allocated and seeded the frame; AND
     - the PLAN's OWN `:db-seed` slot (via `plan-sensitive-values`) — the
       FAIL-CLOSED pre-frame source. `explain-variant` is a documented
       no-run path: a caller can read it BEFORE any run allocates the frame.
@@ -484,12 +295,18 @@
       plan's seed at the frame's declared-sensitive paths recovers those
       candidates with no live frame.
 
+  The matching-leaf substitution over the value slots uses the framework
+  `re-frame.core/redact-matching-values` (rf2-i783h0) — the SAME redaction arm
+  `scrub-rendered` drives, run once per slot against the unioned secret set.
+
   `include?` opts out (the `--allow-sensitive-reads` + per-call escape
   hatch) — when true the raw values cross (the operator signed off)."
   [explain variant-id value-slot-keys include?]
   (if (or include? (nil? explain))
     explain
-    (let [live-secrets (sensitive-values (rf/app-db-value variant-id) variant-id)
+    (let [live-secrets (rf/elision-sensitive-value-set
+                         (rf/app-db-value variant-id) variant-id
+                         (posture->elision-opts false))
           seed-secrets (plan-sensitive-values (:db-seed explain) variant-id)
           secrets      (into live-secrets seed-secrets)]
       (if (empty? secrets)
@@ -497,7 +314,7 @@
         (reduce (fn [m k]
                   (cond-> m
                     (contains? m k)
-                    (update k redact-matching secrets)))
+                    (update k rf/redact-matching-values secrets)))
                 explain
                 value-slot-keys)))))
 
@@ -524,7 +341,8 @@
 ;; frame's declared-sensitive values — that `scrub-rendered` already
 ;; applies to the live derived trees. The slot is value-bearing and
 ;; frame-keyed (the recorder records against `vk`; the plan is compiled
-;; for `vk`), so the same `sensitive-values vk` candidate set governs it.
+;; for `vk`), so the same framework `elision-sensitive-value-set` candidate
+;; set (for `vk`) governs it.
 ;;
 ;; INTENTIONALLY-PUBLIC (NOT scrubbed): the docs-discovery surfaces that
 ;; return author-published STATIC registration prose — `get-story` /

--- a/tools/story/spec/006-MCP-Surface.md
+++ b/tools/story/spec/006-MCP-Surface.md
@@ -88,8 +88,10 @@ data, so the egress classifies each payload as runtime/captured VALUE
   that carries observed runtime state or a captured/plan-resolved value
   is run through the egress scrubbers (path-based
   `re-frame.core/elide-wire-value` for `:app-db`; value-based redaction
-  against the variant frame's declared-`:sensitive?` values for derived
-  / non-live trees). This covers the live-state tools' `:app-db` /
+  via the framework `re-frame.core/redact-derived-values` against the
+  variant frame's declared-`:sensitive?` values for derived / non-live
+  trees — the value-match engine is centralized in `re-frame.elision`,
+  EP-0015 issue 2). This covers the live-state tools' `:app-db` /
   `:rendered-hiccup` / `:snapshot` / evidence slots and assertion
   records (`preview-variant` / `run-variant` / `read-failures`),
   `run-a11y`'s `:violations` (axe-core nodes — the violating element's


### PR DESCRIPTION
Split from `rf2-t55hxg.18` (the core fail-closed half shipped in #4026, merged). EP-0015 best-practice review **issue 2**: Story-MCP owned a PRIVATE derived-tree value-redaction engine (`under-prefix?`, `collect-governed-values!`, `collect-wire-values!`, `sensitive-values`, `redact-matching` in `tools/story-mcp/.../egress.cljc`) that DUPLICATED privacy-traversal concepts already centralized in `re-frame.elision` — a SECOND place EP-0015 egress semantics could drift.

## What moved

The **value-match-redaction primitive** is extracted into the framework `re-frame.elision` ns — the value-based DUAL of `elide-wire-value`, so it lives beside the path-based walker, the `sensitive-declarations` registry, and the `:rf/redacted` sentinel (one home for the egress fact):

- `collect-sensitive-values` — unguarded governed-value collection from a raw source db. Mirrors the elider's indexing (maps by key, vectors/seqs by integer index, sets at own path) so a seq-indexed `[:tokens 0]` declaration is reached and a secret cannot leak via `get-in`'s seq-blindness.
- `sensitive-value-set` — layers the **non-unique-secret guard** (drop any candidate that ALSO appears verbatim in the POST-elision db, classified against the ELIDED bytes — rf2-g7cd1 / rf2-f3kf7).
- `redact-matching-values` — the matching-leaf substitution (maps/vectors/sets/seqs, keys walked too).
- `redact-derived-values` — collect + guard + redact a derived tree in one call.

The egress floor is a **caller argument** (`wire-opts`), so the framework helper stays egress-profile-agnostic — the `:rf.egress/*` profile vocabulary remains in the MCP-base / tool layer.

## What Story-MCP now consumes

`scrub-rendered` / `plan-sensitive-values` / `scrub-explain-values` / `scrub-frame-value` are now **orchestration only** — resolve the egress floor from the posture (`posture->elision-opts false` → off-box-tool floor), read the source app-db, apply the `:include-sensitive` opt-out — delegating the engine to the `re-frame.core` facade:

- `scrub-rendered` → `rf/redact-derived-values`
- `plan-sensitive-values` (no-guard seed source) → `rf/elision-collect-sensitive-values`
- `scrub-explain-values` (live source, guarded) → `rf/elision-sensitive-value-set` + `rf/redact-matching-values`
- `scrub-frame-value` → unchanged thin wrapper over `scrub-rendered`

Behaviour is byte-identical — the engine moved, the contract did not. ~340 lines of duplicate engine deleted from Story-MCP; ~90 lines of orchestration remain.

## Facade-export classification (diff-time rule)

Four new `re-frame.core` exports, all framework-owned value-match primitives (the value-based dual of the existing `elide-wire-value` / `project-egress` egress surface; same Spec 015 §Projection ownership):

| Export | Why public |
|---|---|
| `redact-derived-values` | the one-call derived-tree value-match entrypoint tools consume |
| `elision-sensitive-value-set` | the guarded live secret set, for tools driving the match over multiple slots from one collection pass |
| `elision-collect-sensitive-values` | the unguarded base set for a non-wire source (a plan's authored `:db-seed`) |
| `redact-matching-values` | the redaction arm, for redacting multiple slots against one pre-collected secret set |

## Other surfaces

Xray / re-frame2-pair-mcp / machines-viz carry **no** equivalent value-match engine (checked via `git grep` over the corpus) — Story-MCP was the only duplicate. No further refactor needed.

## Quality gates

- story-mcp `clojure -M:test` — **259 tests / 1283 assertions, 0 failures, 0 errors**
- core `clojure -M:test` — **1365 tests / 6048 assertions, 0 failures, 0 errors**
- `npm run test:cljs` — **6867 tests / 27910 assertions, 0 failures, 0 errors**
- `npm run test:bundle-isolation` — **PASS** (40 internal sentinels absent; slim bundles clean — Story-MCP consumes only the `re-frame.core` facade, not internal namespaces)

### CI-fix follow-up (rf2-i783h0)

The four new façade exports were not classified in the public-API manifest sidecar, so the **Public-API manifest drift-check** went red ("Public vars with no sidecar classification") and the **Lint required** aggregator failed with it (its `needs` are `detect / clj-kondo / splint / api-manifest`; only `api-manifest` was failure — clj-kondo and splint were already green). Fix: added the four `:classification` entries to `spec/api-manifest-metadata.edn` (the value-based dual of `elide-wire-value` / `project-egress` — `:tier :tooling :owner "015" :status "v1"`) and **regenerated** `spec/api-manifest.edn` (not hand-edited; `:var-count` 516 → 520). Re-verified:

- `clojure -M -m re-frame.api-manifest.gen --check` — **OK: in sync (520 public vars)**, exit 0
- `clj-kondo` on changed source — **errors: 0** (warnings informational)
- `npm run test:cljs` — **6867 tests / 27910 assertions, 0 failures, 0 errors**

Closes rf2-i783h0.

