### PR TITLE
docs(guide): EP-0014 tighten derivation guide handoffs (rf2-ycinhg)

### DIFF
--- a/docs/guide/13-testing.md
+++ b/docs/guide/13-testing.md
@@ -380,6 +380,7 @@ Runs on the JVM:
 - `machine-transition` (a pure function)
 - `compute-sub` (sub computation against an `app-db` value)
 - public registrar queries — `registrations`, `frame-meta`, `sub-topology`, and friends
+- the **derivation graph** assembled from those registrations — composed and checked purely, with no app-db and no browser (it's how the conformance tier verifies the algebra; the model lives in [One graph: derivations and algebra views](derivations-and-algebra-views.md))
 - **hiccup → HTML** via the SSR renderer — also a pure function, so snapshot tests and SSR conformance run headlessly too
 
 Needs CLJS:

--- a/docs/guide/17-tooling.md
+++ b/docs/guide/17-tooling.md
@@ -24,7 +24,9 @@ The useful question is not "what component is selected?" It is "what did that ev
 
 Xray owns the diagnostic panels. Story can embed or focus those panels, but it should not grow a second app-db diff engine, a second schema timeline, or a second subscription inspector. Duplication here would be worse than waste; it would create two tools that can tell different stories about the same event. That is how developer trust dies, usually in a meeting where everyone keeps saying "interesting" and nobody is having fun.
 
-For installation, panels, time travel, click-to-source, schema timelines, hydration, machines, and app-db diffing, use the [Xray docs](../xray/index.md).
+Xray also answers a quieter question: *where does this value come from?* The same registration facts assemble into one **derivation graph** — every subscription, flow, resource, route fact, and machine selector as a node in a single dependency graph rooted at your state. When you want to read that graph, start with [One graph: derivations and algebra views](derivations-and-algebra-views.md) for the model, then reach for Xray's graph view to see it for your running app.
+
+For installation, panels, time travel, click-to-source, schema timelines, hydration, machines, app-db diffing, and the derivation graph, use the [Xray docs](../xray/index.md).
 
 ## Story answers: what states should this thing have?
 

--- a/docs/guide/derivations-and-algebra-views.md
+++ b/docs/guide/derivations-and-algebra-views.md
@@ -279,14 +279,15 @@ The machine is the stateful **process**; the selector is an ephemeral **derivati
 
 ## Reading the assembled graph
 
-A tool stitches all of those per-family views into one graph: a map of `:nodes` keyed by canonical id and a list of `:edges`. An Xray panel renders it as a single picture even though the runtime mechanisms underneath are a subscription cache, a flow, a resource cache, a route slice, and a machine snapshot:
+A tool stitches all of those per-family views into one graph: a map of `:nodes` keyed by canonical node id and a list of `:edges`. The node *key* is the canonical id of the node itself — `[:sub <query>]`, `[:resource <scoped-key>]`, `:rf/route` for the live route slice (or `[:rf/route <route-id>]` in a static graph). It is **not** the node's `:output` address; the runtime address the route slice writes to (`[:runtime [:rf.runtime/routing :current]]`) is that node's `:output`, recorded *inside* the node, not the key you look it up by. An Xray panel renders the assembled graph as a single picture even though the runtime mechanisms underneath are a subscription cache, a flow, a resource cache, a route slice, and a machine snapshot:
 
 ```clojure
 {:mode  :live
  :frame :main
  :nodes
  {[:sub [:article/page "welcome"]]    {:kind :derivation :storage :ephemeral  :evaluation :on-demand}
-  [:runtime [:rf.runtime/routing :current]] {:kind :process :storage :runtime-db}
+  :rf/route                           {:kind :process :storage :runtime-db
+                                       :output [:runtime [:rf.runtime/routing :current]]}
   [:resource [[:rf.scope/session {:tenant-id "acme"}] :article/by-slug {:slug "welcome"}]]
                                        {:kind :process :storage :runtime-db
                                         :status :loaded :owners #{[:route :route/article 17]}}}
@@ -300,7 +301,9 @@ A tool stitches all of those per-family views into one graph: a map of `:nodes` 
    :to   [:sub [:article/page "welcome"]] :role :input}]}
 ```
 
-Two things make this graph safe to ship to a tool. **Redaction**: the graph carries source coordinates and value *summaries*, never raw sensitive values — a redacted param is still an edge, so structure survives even when content is hidden. And **the whole-value law**: every derivation must be correct as a function that recomputes its entire output from its inputs. Memoization, equality pruning, and (someday) deltas are optimizations that must not change the observed value — which is exactly why a tool can recompute any node from the graph and trust the answer.
+Two things make this graph safe to ship to a tool. **Redaction**: the graph carries source coordinates and value *summaries*, never raw sensitive values — a redacted param is still an edge, so structure survives even when content is hidden. And **the whole-value law**: every derivation must be correct as a function that recomputes its entire output from its inputs. Memoization, equality pruning, and (someday) deltas are optimizations that must not change the observed value.
+
+That law is what lets *conformance tests* verify a derivation by recomputing its whole-value output — and what lets a tool **trust the graph's declared edges and classifications without executing your app code or reading raw values.** It is not a public recompute API. The first slice is internal inspection plus conformance, not an "ask a tool to recompute any node" promise: off-box tools may hold only summaries or redacted values, and process nodes like resources and machines are not arbitrary pure recomputations. The graph you can trust is the *structure* — who reads what, where it lives, when it runs — not a live re-execution of every node.
 
 ## The one rule worth remembering
 


### PR DESCRIPTION
EP-0014 (derivation & process algebra) post-graduation review sweep — the `docs/guide/` slice (rf2-ycinhg). Tightens the guide's derivation handoffs and removes the stale graph-shape wording Agent D flagged. Stance: CLARITY; generic to any consumer app. Verified against the EP-0014 contract (`spec/Derivations.md`) and the graph composer (`implementation/core/src/re_frame/derivation/graph.cljc`).

## What changed

**`docs/guide/derivations-and-algebra-views.md`**
- **Stale graph-shape example fixed.** The assembled-graph example keyed the live route node by its runtime address `[:runtime [:rf.runtime/routing :current]]`. That address is the node's `:output`, not its node-id key. Per the graph contract, the canonical node key is `:rf/route` for the live route slice (and `[:rf/route <route-id>]` in a static graph). The example now keys the node `:rf/route` and records the runtime address under `:output`; added one prose sentence distinguishing the node *key* from the `:output` address.
- **Over-broad tool promise reworded.** The whole-value-law paragraph claimed "a tool can recompute any node from the graph and trust the answer." Reworded to: conformance tests verify whole-value derivations, and tools trust the declared edges/classifications without executing app code or reading raw values. Notes that the first slice is internal inspection + conformance (not a public recompute API), that off-box tools may hold only summaries/redacted values, and that process nodes (resources/machines) are not arbitrary pure recomputations.

**`docs/guide/17-tooling.md`**
- Added one concise Xray handoff for the "where does this value come from?" / derivation-graph angle, linking to `derivations-and-algebra-views.md` then the Xray docs; added "the derivation graph" to the Xray-docs pointer list.

**`docs/guide/13-testing.md`**
- Added one concise conformance handoff in the JVM-runnable list noting the derivation graph is assembled from registrations and checked purely (no app-db, no browser) by the conformance tier, linking to the guide topic — without turning the testing chapter into the spec.

## Contract verification
- Static route node key `[:rf/route <route-id>]`, live route slice key `:rf/route`: `implementation/core/src/re_frame/derivation/graph.cljc` (lines ~425-431, ~476-480); `implementation/core/test/re_frame/derivation_graph_test.clj` (lines ~159, ~280-281).
- Internal-inspection + conformance posture (no public accessor / recompute API), tool redaction, whole-value law: `spec/Derivations.md` (§26, §314, §838-849).

## Quality gates
- `cp -r spec docs/spec` + `python scripts/check_doc_slugs.py` — clean (no output).
- `mkdocs build --strict` — **EXIT=0**, no warnings; all four changed links resolve. (Generated `docs/spec` + `site` removed before commit; only the three guide files are committed.)