### PR TITLE
docs(skills): EP-0014 align Xray skill to shipped derivation graph (rf2-96go1i + 4xm7pk)

### DIFF
--- a/docs/skills/re-frame2-xray.md
+++ b/docs/skills/re-frame2-xray.md
@@ -15,7 +15,7 @@ The skill answers two questions:
 
 Xray runs in one of two modes, flipped by the L1 mode pill or `Cmd/Ctrl+Shift+M`:
 
-- **Dynamic** — the event-coupled spine (4-layer chrome). Every tab is a lens on the *one focused event*. 6 tabs: **Epoch · app-db · Views · Trace · Machine · Routes** (mnemonics `e a v t m r`). There is **no Issues tab** — issues surface inline (in the Epoch cascade, the L2 event-row pink-wash, and the always-on issues-ribbon signal).
+- **Dynamic** — the event-coupled spine (4-layer chrome). Every tab is a lens on the *one focused event*. 8 tabs: **Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph** (mnemonics `e a v t m r s g`) — the core six plus the cross-feature **Resources** (declarative server-state) and **Graph** (Xray's UI over the EP-0014 derivation/process graph) lenses. There is **no Issues tab** — issues surface inline (in the Epoch cascade, the L2 event-row pink-wash, and the always-on issues-ribbon signal).
 - **Static** — event-INDEPENDENT registry browse (3-layer chrome, no spine). Every tab is a catalogue of what's *registered* in the picked frame. 5 tabs: **Machines · Routes · Schemas · Flows · Interceptors**.
 
 When the user wants to inspect a single dispatch, that's Dynamic; when they want to browse the whole registry, that's Static.

--- a/skills/README.md
+++ b/skills/README.md
@@ -91,8 +91,9 @@ re-frame2 ships **eight** skills, grouped by the situation they cover:
   **Xray**, the re-frame2 in-app devtools panel. Answers how to *launch*
   Xray (true-inline panel, pop-out, programmatic `init!`, wired hotkeys,
   the Dynamic ↔ Static mode toggle) and *which tab shows X* — across the
-  6 Dynamic event-spine tabs (Epoch (hero) / app-db / Views / Trace /
-  Machine / Routes) and the 5 Static registry-browse
+  8 Dynamic event-spine tabs (Epoch (hero) / app-db / Views / Trace /
+  Machine / Routes / Resources / Graph — the last being Xray's UI over the
+  EP-0014 derivation/process graph) and the 5 Static registry-browse
   tabs (Machines / Routes / Schemas / Flows / Interceptors). There is no
   Issues tab — issues surface inline. Xray owns
   the *seeing*; `re-frame2-pair` owns the *driving*.

--- a/skills/re-frame2-xray/.claude-plugin/plugin.json
+++ b/skills/re-frame2-xray/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "re-frame2-xray",
   "version": "0.1.0-alpha.1",
-  "description": "Read-only tour skill for Xray — the re-frame2 in-app devtools panel. Teaches launch modes, the Dynamic ↔ Static mode toggle, and the tab inventory (6 Dynamic event-spine tabs + 5 Static registry-browse tabs); defers driving / implementing Xray to sibling skills.",
+  "description": "Read-only tour skill for Xray — the re-frame2 in-app devtools panel. Teaches launch modes, the Dynamic ↔ Static mode toggle, and the tab inventory (8 Dynamic event-spine tabs incl. Resources + the EP-0014 derivation/process Graph + 5 Static registry-browse tabs); defers driving / implementing Xray to sibling skills.",
   "skills": [
     "./SKILL.md"
   ],

--- a/skills/re-frame2-xray/README.md
+++ b/skills/re-frame2-xray/README.md
@@ -5,7 +5,7 @@
 `re-frame2-xray` is a Claude Code **tour skill** for [Xray](https://github.com/day8/re-frame2/tree/main/tools/xray) — the re-frame2 in-app devtools panel. It answers three questions, and only three:
 
 1. **How do I launch Xray?** — the inline panel, the overlay fallback (`open-overlay!`, for hosts that can't give Xray a layout column), the pop-out, the programmatic `init!`, the wired hotkeys, and the Dynamic ↔ Static mode toggle.
-2. **Which tab shows X?** — a one-line purpose for each tab across both modes: the 6 Dynamic event-spine tabs (Epoch · app-db · Views · Trace · Machine · Routes) and the 5 Static registry-browse tabs.
+2. **Which tab shows X?** — a one-line purpose for each tab across both modes: the 8 Dynamic event-spine tabs (Epoch · app-db · Views · Trace · Machine · Routes · Resources · Graph) and the 5 Static registry-browse tabs. The **Graph** tab is Xray's UI over the EP-0014 derivation/process graph; the underlying graph accessor stays internal (no `re-frame.core` facade export).
 3. **What's the chrome around the tabs for?** — the first-screen navigation primitives: time-travel inspect / `Reset`-rewind, the filter-pill cluster, the command palette, and the Settings popup.
 
 Workflow procedures (find-wrong-sub, scrub-bad-epoch, click-to-source, redaction-marker semantics) are out of scope for this iteration — see `SKILL.md` §Out of scope for what to do when one of those comes up.
@@ -20,7 +20,7 @@ Xray is the **human-facing** panel; for an AI agent surface against the running 
 
 - `SKILL.md` — the compact tour/router (launch quick-reference, mode/tab chooser, chrome one-liners, and the leaf-loading guide)
 - `references/launch-modes.md` — full launch-mode decision tree (preload vs `init!`, suppress-auto-open, `:rf.xray/layout-host-selector`, host-CSS-variable resize, the `open-overlay!` no-layout-host fallback, pop-out lifecycle, wired hotkeys)
-- `references/panels.md` — the full tab tour in depth (6 Dynamic event-spine tabs + 5 Static registry-browse tabs, deeper "open it when…" guidance, the retired-panel content-home mapping)
+- `references/panels.md` — the full tab tour in depth (8 Dynamic event-spine tabs + 5 Static registry-browse tabs, deeper "open it when…" guidance, the retired-panel content-home mapping)
 - `references/chrome.md` — the first-screen chrome inventory in depth (LIVE/RETRO, time-travel rewind, filter pills, command-palette sources, the Settings-popup tabs, the Snapshot app-db redaction contract)
 - `references/shared-components.md` — the components every L4 panel reuses (`edn-inspector/render-node`, `film_strip/header`, `focus_resolver`) + the tab-icon / L2-badge / cross-panel-arrow glyph reference
 - `evals/evals.json` — eval fixtures (trigger accuracy + answer-quality assertions for the high-drift launch / chrome / tab-routing prompts)

--- a/skills/re-frame2-xray/SKILL.md
+++ b/skills/re-frame2-xray/SKILL.md
@@ -14,7 +14,9 @@ description: >
  "Xray mode toggle", "Xray popout", "Xray overlay",
  "Xray open-overlay!", "open Xray with no layout host / no
  [data-rf-xray-host] / full-screen canvas", "Xray machine inspector",
- "Xray epoch cascade", "where do Xray issues show up", and similar.
+ "Xray epoch cascade", "where do Xray issues show up", "Xray Graph
+ tab", "Xray derivation/process graph", "where does this value come
+ from in Xray", "Xray Resources tab", and similar.
  **Do not use** for: driving Xray
  programmatically from a live REPL (that's `re-frame2-pair`), authoring
  the host app (`re-frame2`), bootstrapping a new project
@@ -66,8 +68,9 @@ This skill answers three questions, and only three:
  programmatic entry points, the wired hotkeys, the Dynamic ↔ Static
  mode toggle.
 2. **Which tab shows X?** — a one-line purpose for each tab Xray ships,
- across both modes: the 6 Dynamic event-spine tabs (per spec/018 §5 +
- spec/021 §9.1) and the 5 Static registry-browse tabs (per
+ across both modes: the 8 Dynamic event-spine tabs (the 6 in
+ spec/018 §5 + spec/021 §9.1, plus the cross-feature **Resources**
+ and **Graph** tabs) and the 5 Static registry-browse tabs (per
  spec/007-UX-IA.md §Static mode).
 3. **What's the chrome around the tabs for?** — the first-screen
  navigation primitives the user meets immediately: the time-travel
@@ -118,7 +121,8 @@ the `Cmd/Ctrl+Shift+M` chord:
 - **Dynamic** — the event-coupled spine. A 4-layer chrome (L1 ribbon ·
  L2 event list · L3 tab bar · L4 detail). Every tab is a *lens on the
  one focused event* — pick an event in the L2 list and every tab
- rebinds. This is "what happened in **this** epoch?". 6 tabs.
+ rebinds. This is "what happened in **this** epoch?". 8 tabs (the
+ core 6 plus the cross-feature Resources + Graph lenses).
 - **Static** — event-INDEPENDENT browse of what's *registered*. A
  3-layer chrome (no L2 spine — Static has no event focus). Every tab is
  a registry catalogue: every machine, every route, every schema, every
@@ -230,16 +234,19 @@ Static (about the whole registry) — then route to the tab. For per-tab
 layout, iconography, stripe tokens, and "open it when…" depth see
 [`references/panels.md`](references/panels.md).
 
-### Dynamic mode — 6 lenses on the focused event
+### Dynamic mode — 8 lenses on the focused event
 
-The L3 tab bar holds **6 lenses on the focused event**, in the order set
-by spec/018 §5 + spec/021 §9.1 (mnemonics `e a v t m r`): **Epoch ·
-app-db · Views · Trace · Machine · Routes**. Cross-epoch
-signal lives on the L2 timeline above (badges + stripes); every tab
-answers "what happened in **this** epoch?" through its own lens. To
-browse a machine's full topology cold (spine-INDEPENDENT — picker +
-zoom / pan / fit, regardless of the focused event), flip to **Static
-mode** and open its Machines tab.
+The L3 tab bar holds **8 lenses on the focused event**, left-to-right
+(mnemonics `e a v t m r s g`): **Epoch · app-db · Views · Trace ·
+Machine · Routes · Resources · Graph**. The first six are the core spine
+lenses (spec/018 §5 + spec/021 §9.1); **Resources** and **Graph** are the
+two cross-feature lenses that landed last (the registry-driven L4 tab
+seam lets a panel register its own tab — see `panels/resources.cljs` and
+`panels/derivation_graph.cljs`). Cross-epoch signal lives on the L2
+timeline above (badges + stripes); every tab answers "what happened in
+**this** epoch?" through its own lens. To browse a machine's full
+topology cold (spine-INDEPENDENT — picker + zoom / pan / fit, regardless
+of the focused event), flip to **Static mode** and open its Machines tab.
 
 There is **no Issues tab** — Mike ruled it out (Option
 (c), 2026-05-31; `panels/issues_ribbon.cljs` deleted). Issues now surface
@@ -253,6 +260,32 @@ inline (see *Where issues surface now* below).
 | **Trace** | `t` · `⬢` · orange | Raw Spec 009 trace events for the focused epoch — a single **flat oldest-first row list** (no bands/envelope), each row carrying a **stage column** (DISPATCH·COEFFECT·HANDLER·FLOW·SIDE EFFECTS·SUBSCRIPTIONS·VIEWS) + a **colour-coded left edge** reusing the Epoch badge taxonomy; the focused epoch IS the scope (no filter chips), click any row to expand its payload inline. | "Show me every raw op in this epoch." / "Is `:rf.fx/*` firing as expected?" |
 | **Machine** | `m` · `◆` · green | **Event-driven.** Per-machine topology + transition highlight + guards / actions / cancellation cascade for the focused event. BLANK when the focused event had no machine activity; per-machine prev/next walks the spine. (Display label is singular **Machine** — the focused-epoch lens is on one machine; internal tab id `:machines`.) To browse a machine's full topology cold (picker + zoom / pan / fit, spine-INDEPENDENT), use **Static mode**'s Machines tab. | "What did this event do to my machines?" / "What transition fired?" / "What guards passed/failed?" |
 | **Routes** | `r` · `🌐` · yellow | Flat focused-event lens: current matched route + params/query/fragment + a **Simulate-URL** input that ranks every registered route, with per-event glyphs `◉ TO` / `◇ FROM` / `● HERE`. Silent when no routes registered. (Display label **Routes**, plural-noun convention; internal tab id `:routing`.) | "What route am I on?" / "Did the route change this epoch?" / "What params resolved?" |
+| **Resources** | `s` · cross-feature | The declarative server-state lens (Spec 016 §Xray and AI tooling): the static resource registry, per-frame **live instances** (state · generation · owners · freshness), the **work ledger** of live fetch attempts, the route/resource graph, lifecycle/invalidation/cache-growth, and a scope audit + lints. **Read-only** — observing pins nothing; values are summarized (params/scopes/data redaction-aware), never raw. Reads the runtime-db resource slices decoupled — Xray does **not** `:require` the optional resources artefact, so the panel renders cleanly even when the host has no resources. | "Where's my server state, what owns it, and is it stale?" / "What fetches are in flight?" |
+| **Graph** | `g` · cross-feature (violet — the algebra lens) | Xray's UI over the **EP-0014 derivation/process graph** — the one node-and-edge view where every declared fact and process (subscriptions, flows, resources, route facts, machine processes + selectors) is a node over the frame fold. Every node is classified by its two closed superkinds (`:derivation` / `:process`) read off `:kind` alone; the refined kinds tint the family accent. A per-panel **static ↔ live** toggle (its own toggle, distinct from the L1 mode pill) flips between the registration-derived graph (parametric subs marked, no edge — the don't-execute rule) and the frame-realized graph (concrete query vectors, active resource keys, live machine instances). **On-box raw, off-box redacted.** | "Where does this value come from / when is it evaluated / where does it live / who owns it?" — across families, in one place |
+
+#### What the Graph tab contributes today (and what it doesn't)
+
+The Graph tab composes the families Xray's artefact already carries —
+**subscriptions, flows, and routes**. Machines and resources are
+optional, post-v1 artefacts that Xray does **not** statically depend on,
+so today they contribute **no nodes** to the graph (the no-machines /
+no-resources story). The contributor seam is ready: those families join
+the one graph the moment their artefacts are on Xray's classpath, with no
+panel change. So if a user asks "why aren't my machines in the Graph
+tab?", that's the dependency boundary, not a bug — point them at the
+per-family lenses (the **Machine** Dynamic tab, the **Resources** Dynamic
+tab, and **Static → Machines**) for those families in the meantime.
+
+> **The underlying graph accessor is internal, not a public API.** The
+> Graph tab is a *consumer* of EP-0014's internal `re-frame.derivation.graph`
+> composer — a **structured** internal accessor, NOT a `re-frame.core`
+> facade export and NOT a public app authoring/accessor primitive. EP-0014
+> defers the public name until a third consumer (beyond Xray and the
+> conformance fixtures) needs it. So tell users to **open the Graph tab**
+> (it exists, it ships), but do **not** tell them to call a public graph
+> API from their app code — there isn't one. Source of truth:
+> [`spec/Derivations.md` §Graph inspection — internal but structured](../../spec/Derivations.md#graph-inspection--internal-but-structured)
+> + [`docs/EP/EP-0014-derivation-and-process-algebra.md`](../../docs/EP/EP-0014-derivation-and-process-algebra.md).
 
 #### Where issues surface now (no Issues tab)
 
@@ -349,19 +382,20 @@ short of improvising.
  [`tools/xray/spec/011-Launch-Modes.md` §Mount lifecycle](../../tools/xray/spec/011-Launch-Modes.md)
  and the per-panel implementation specs. A `xray-implementor` sibling
  skill is **deferred to post-alpha** until the Xray surface stabilises.
-- **The "derivation/process graph" view** (subs / flows / resources /
- routes / machines as one node-and-edge graph — the EP-0014 algebra).
- There is **no shipped Xray tab** that renders that unified graph today.
- The algebra view is an **internal, structured accessor** the framework
- produces for Xray + the conformance fixtures to consume — it ships **no
- public accessor name** and **no `re-frame.core` facade export** (the
- public name is deferred until a third consumer needs it). So: do **not**
- tell a user to "open the derivation-graph tab" or call a public graph
- API — neither exists. What Xray ships *today* is the per-family browse:
- **Static → Machines / Routes / Flows** (registry catalogues) and the
- Dynamic per-epoch lenses. If a user asks for the cross-family graph,
- say it's an internal substrate (not a current panel) and cite
- [`spec/Derivations.md` §Graph inspection — internal but structured](../../spec/Derivations.md#graph-inspection--internal-but-structured).
+- **Deep derivation-graph workflow recipes** (reading large cross-family
+ graphs, the static↔live diffing workflow, the off-box egress/redaction
+ grammar). The **Graph** Dynamic tab itself is **in scope** — it ships,
+ and §The tabs above is the router for it. What's deferred here is the
+ deep how-to-debug-with-it recipe layer; cite
+ [`spec/Derivations.md`](../../spec/Derivations.md) +
+ [`docs/EP/EP-0014-derivation-and-process-algebra.md`](../../docs/EP/EP-0014-derivation-and-process-algebra.md)
+ for the algebra contract. **Note on the public boundary:** the graph the
+ tab renders comes from EP-0014's **internal, structured**
+ `re-frame.derivation.graph` composer — there is **no public accessor
+ name** and **no `re-frame.core` facade export** (deferred until a third
+ consumer beyond Xray + the conformance fixtures needs it). So route users
+ to *open the Graph tab*, but do **not** tell them to call a public graph
+ API from app code — there isn't one.
 ---
 
 ## Style guidance

--- a/skills/re-frame2-xray/package.json
+++ b/skills/re-frame2-xray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@day8/re-frame2-xray",
   "version": "0.1.0-alpha.1",
-  "description": "Read-only tour skill for Xray — the re-frame2 in-app devtools panel. Teaches how to launch Xray (true-inline, the open-overlay! fallback for no-layout-host / full-screen-canvas hosts, pop-out, programmatic, hotkeys, Dynamic ↔ Static mode toggle) and which tab — across the 6 Dynamic event-spine tabs and 5 Static registry-browse tabs — surfaces the data you're looking for.",
+  "description": "Read-only tour skill for Xray — the re-frame2 in-app devtools panel. Teaches how to launch Xray (true-inline, the open-overlay! fallback for no-layout-host / full-screen-canvas hosts, pop-out, programmatic, hotkeys, Dynamic ↔ Static mode toggle) and which tab — across the 8 Dynamic event-spine tabs (incl. Resources and the EP-0014 derivation/process Graph) and 5 Static registry-browse tabs — surfaces the data you're looking for.",
   "keywords": [
     "claude-code",
     "claude-code-skill",

--- a/skills/re-frame2-xray/references/panels.md
+++ b/skills/re-frame2-xray/references/panels.md
@@ -14,14 +14,17 @@ Sources of truth: the live tab inventory is the set of
 palette tokens, density. Tab order is set declaratively via `reg-l4-tab!`
 `:order` and rendered by `shell.cljs` (Dynamic) / `static/shell.cljs`
 (Static). The live Dynamic `:order` values are Epoch `-1` · app-db `1` ·
-Views `2` · Trace `3` · Machine `4` · Routes `6`.
+Views `2` · Trace `3` · Machine `4` · Routes `6` · Resources `7` ·
+Graph `8` — eight Dynamic tabs in all (the core six plus the two
+cross-feature lenses, **Resources** and **Graph**, each registered by its
+own panel through the `reg-l4-tab!` seam).
 
 ## Two modes
 
 The two-mode model (Dynamic event-spine 4-layer chrome · Static registry
 3-layer chrome, flipped by the L1 mode pill or `Cmd/Ctrl+Shift+M`) is
 covered in [`SKILL.md` §Two modes](../SKILL.md#two-modes). This leaf is
-the per-panel tour: the 6 Dynamic tabs in §Panel-by-panel below, the 5
+the per-panel tour: the 8 Dynamic tabs in §Panel-by-panel below, the 5
 Static tabs in §Static mode — registry browse. One binding constraint to
 restate: **no cross-epoch L4 panels** — every Dynamic L4 tab is a lens on
 the one focused epoch; aggregate signal lives on L2 badges only (§021
@@ -72,14 +75,19 @@ tab-bar ribbon, which rewinds the observed frame's live
 
 ## Panel-by-panel (Dynamic mode)
 
-Six Dynamic tabs, in their fixed L3-tab order (§018 §5 + §021 §9.1;
-mnemonics `e a v t m r`): **Epoch · app-db · Views · Trace · Machine ·
-Routes.** (Internal tab ids stay `:epoch :app-db :views :trace :machines
-:routing` — the display labels rebased over a rename history but the ids
-are stable.) The pre-rebuild **Event** panel was retired
-(2026-05-27 — `panels/event_detail.cljs` is deleted) and the **Issues**
-tab was retired (2026-05-31 — `panels/issues_ribbon.cljs` is
-deleted); see §What's deliberately NOT here.
+Eight Dynamic tabs, left-to-right by `:order` (mnemonics
+`e a v t m r s g`): **Epoch · app-db · Views · Trace · Machine · Routes ·
+Resources · Graph.** The first six are the core spine lenses (§018 §5 +
+§021 §9.1); **Resources** (`:order 7`) and **Graph** (`:order 8`) are the
+two cross-feature lenses that landed last, each self-registered through
+the `reg-l4-tab!` seam (`panels/resources.cljs`,
+`panels/derivation_graph.cljs`). (Internal tab ids stay `:epoch :app-db
+:views :trace :machines :routing :resources :derivation-graph` — the
+display labels rebased over a rename history but the ids are stable.) The
+pre-rebuild **Event** panel was retired (2026-05-27 —
+`panels/event_detail.cljs` is deleted) and the **Issues** tab was retired
+(2026-05-31 — `panels/issues_ribbon.cljs` is deleted); see §What's
+deliberately NOT here.
 
 Most Dynamic tabs share the same chrome: panel icon (left of stripe) ·
 panel title · focused-event id · `[◀ Prev] [Next ▶]` film-strip walking
@@ -436,6 +444,104 @@ Spec: [`021-Dynamic-Panel-Designs.md` §7](../../../tools/xray/spec/021-Dynamic-
 + [`spec/012-Routing.md`](../../../spec/012-Routing.md);
 implementation at
 [`panels/routing.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/routing.cljs).
+
+### Resources — cross-feature · mnem `s` · `:order 7`
+
+Question: **Where is my server state — what owns it, and is it stale?**
+(Display label **Resources**, plural-noun convention; internal tab id
+`:resources`.) The Xray surface for re-frame2's declarative server-state
+(Spec 016 §Xray and AI tooling). Sections, top → bottom:
+
+- **STATIC RESOURCE REGISTRY** — every registered resource + scope,
+ stale-after, GC-after, and the routes that activate it.
+- **LIVE INSTANCES** (per frame) — each scoped cache entry with state,
+ generation, owner count, and freshness; scope/params summarized.
+- **WORK LEDGER** — live fetch attempts (running · cancellable ·
+ deadline); host handles are inaccessible by design.
+- **ROUTE / RESOURCE GRAPH** — blocking activations are the SSR wait
+ points; plus lifecycle timeline, invalidation graph, cache growth.
+- **SCOPE AUDIT** — every `:rf.scope/global` use + lints.
+
+**Read-only** — opening this panel pins nothing: it dispatches no
+`:rf.resource/ensure`, attaches no owner, refetches nothing, extends no
+GC (Spec 016 §Active owners and causes). **Privacy**: params, scopes, AND
+data all get the same summarize-and-redact treatment — every value is a
+bounded, redaction-aware preview, never the raw value. **Decoupled**:
+Xray does **not** `:require` the optional `re-frame.resources.*` artefact;
+the panel reads the static registry via `(rf/registrations :resource)`
+and the live cache/ledger from the runtime-db slice the spine already
+publishes — so it renders cleanly even when the host wired no resources
+(identical posture to the Routes tab's route slice + the Machine tab's
+snapshots).
+
+**Open when:** "where's my server state?", "what's in flight?", "is this
+resource stale?", "what owns this cache entry?"
+
+Spec: [`spec/016-Resources.md` §Xray and AI tooling](../../../spec/016-Resources.md);
+implementation at
+[`panels/resources.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/resources.cljs)
++ [`panels/resources_helpers.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc).
+
+### Graph — cross-feature · mnem `g` · `:order 8`
+
+Question: **Where does this value come from — when is it evaluated, where
+does it live, who owns it?** — across families, in one place. (Display
+label **Graph**; internal tab id `:derivation-graph`.) Xray's UI over the
+**EP-0014 derivation/process algebra graph** and the **named first
+consumer** of EP-0014's structured graph accessor. Every declared fact
+and process in the host app — subscriptions, flows, resources, route
+facts, machine processes + selectors — is a node in **one**
+node-and-edge graph over the frame fold.
+
+- **Classification by the two closed superkinds.** Each node is grouped +
+ classified by its `:kind` — exactly `:derivation` or `:process` — read
+ off `:kind` alone (a tool MUST classify knowing only the two
+ superkinds). The refined kinds (`:resource-process`, `:route-fact`,
+ `:machine-process`, `:machine-selector`) are the **colour** axis (family
+ accent), never the contract; an unknown future refinement still renders
+ and classifies off its superkind.
+- **Per-panel static ↔ live toggle** (its OWN toggle, in the panel
+ header — distinct from the L1 Dynamic/Static mode pill). **Static**: the
+ registration-derived graph (process-global); a parametric sub shows the
+ `:parametric` marker and contributes **no** edge — the **don't-execute
+ rule** (static inspection never invokes param/scope functions).
+ **Live**: the graph realized in the observed frame — concrete
+ subscription query vectors with realized edges, active resource keys,
+ live machine instances, the materialized route slice with its nav-token
+ owner.
+- **Contributor coverage today.** The panel composes the families Xray's
+ artefact carries — **subscriptions, flows, routes**. Machines and
+ resources are optional artefacts Xray does **not** `:require`, so they
+ contribute **no nodes** today (the no-machines / no-resources story); the
+ composer's present-family-only seam accepts them with no panel change
+ the moment those artefacts join Xray's classpath.
+- **On-box raw, off-box redacted.** On-box rendering shows raw value
+ summaries (the developer is entitled to their own app's values; previews
+ are bounded for ergonomics, not privacy). The off-box egress boundary —
+ shipping the graph to a remote agent or a serialized capture — projects
+ each node's value-bearing fields through the frame's wire-elision policy
+ (per-frame, fail-closed), preserving node + edge structure.
+
+**Read-only** — observing the graph pins nothing, dispatches nothing,
+mutates no host state.
+
+> **The graph accessor is internal, not a public API.** The Graph tab
+> *consumes* EP-0014's internal `re-frame.derivation.graph` composer — a
+> **structured** internal accessor, **not** a `re-frame.core` facade
+> export and **not** a public app authoring/accessor primitive. EP-0014
+> defers the public name until a third consumer (beyond Xray + the
+> conformance fixtures) needs it. Route users to **open the Graph tab**;
+> do **not** tell them to call a public graph API from app code.
+
+**Open when:** "where does this value come from?", "show me the whole
+derivation graph", "what's the dependency graph for this page?", "is this
+ephemeral or materialized, and who owns it?"
+
+Spec: [`spec/Derivations.md` §Graph inspection — internal but structured](../../../spec/Derivations.md)
++ [`docs/EP/EP-0014-derivation-and-process-algebra.md`](../../../docs/EP/EP-0014-derivation-and-process-algebra.md);
+implementation at
+[`panels/derivation_graph.cljs`](../../../tools/xray/src/day8/re_frame2_xray/panels/derivation_graph.cljs)
++ [`panels/derivation_graph_helpers.cljc`](../../../tools/xray/src/day8/re_frame2_xray/panels/derivation_graph_helpers.cljc).
 
 ### Issues — no longer a Dynamic tab
 

--- a/skills/re-frame2-xray/references/shared-components.md
+++ b/skills/re-frame2-xray/references/shared-components.md
@@ -84,11 +84,15 @@ signal, colour is never alone):
 | Trace | `t` | `⬢` | `:orange` |
 | Machine | `m` | `◆` | `:green` |
 | Routes | `r` | `🌐` | `:yellow` |
+| Resources | `s` | — | (family-tinted rows; no single stripe) |
+| Graph | `g` | — | `:magenta` (violet — the algebra lens) |
 
-Six Dynamic tabs (Epoch is `:order -1`, the leftmost / default-landing
-slot). There is **no Issues tab** and **no Event tab**
-(replaced by Epoch) — issues surface inline in the Epoch
-cascade, the L2 pink-wash, and the issues-ribbon signal.
+Eight Dynamic tabs (Epoch is `:order -1`, the leftmost / default-landing
+slot; **Resources** `:order 7` and **Graph** `:order 8` are the two
+cross-feature lenses, each self-registered through `reg-l4-tab!`). There
+is **no Issues tab** and **no Event tab** (replaced by Epoch) — issues
+surface inline in the Epoch cascade, the L2 pink-wash, and the
+issues-ribbon signal.
 
 L2 row badges (live impl `l2_timeline.cljc`): `⚠` issue · `◆` machine
 transition · `🌐` HTTP activity · `⚡` fx-emit child dispatch · `⏲` timer


### PR DESCRIPTION
## What

Aligns the Xray skill to the **shipped EP-0014 derivation/process graph**. EP-0014 is `final` and the Derivation-Graph panel shipped, but the skill still said the algebra view was an internal substrate with **no shipped Xray tab** and told agents **not** to route users to a derivation-graph tab. It also still claimed **6** Dynamic tabs; the live inventory is **8** (the cross-feature **Resources** tab, `:order 7`, was also missing).

Resolves two EP-0014 post-graduation review beads, both on the Xray SKILL surface:

- **rf2-96go1i** (completeness) — the skill/docs contradicted the shipped derivation-graph panel.
- **rf2-4xm7pk** (skills) — update the Xray skill + index metadata for the shipped Dynamic Graph tab; refresh the 6 -> 8 tab counts.

## Shipped contract (authoritative, from the live source)

The Dynamic L4 tab inventory is now **8** tabs (left-to-right by `:order`, mnemonics `e a v t m r s g`):

| order | id | label | mnem |
|---|---|---|---|
| -1 | `:epoch` | Epoch | `e` |
| 1 | `:app-db` | app-db | `a` |
| 2 | `:views` | Views | `v` |
| 3 | `:trace` | Trace | `t` |
| 4 | `:machines` | Machine | `m` |
| 6 | `:routing` | Routes | `r` |
| 7 | `:resources` | Resources | `s` |
| 8 | `:derivation-graph` | Graph | `g` |

The **Graph** tab is Xray's UI over the EP-0014 graph and the named first consumer of EP-0014's structured graph accessor. Contributor coverage today is **subs / flows / routes**; machines + resources are optional artefacts Xray does not `:require`, so they contribute no nodes until on Xray's classpath (the seam is ready). The underlying `re-frame.derivation.graph` composer stays **internal/structured** — not a `re-frame.core` facade export, not a public app accessor (public name deferred until a third consumer needs it). The skill now routes users to *open the Graph tab* while preserving that no-public-API boundary.

## Changes (skills/ + one docs mirror only)

- `skills/re-frame2-xray/SKILL.md` — replaced the contradicting §Out of scope item; added Graph + Resources rows to the Dynamic tab table + trigger phrases; 6 -> 8 throughout.
- `skills/re-frame2-xray/references/panels.md` — added full Resources + Graph panel sections; 6 -> 8 count; refreshed `:order` list.
- `skills/re-frame2-xray/references/shared-components.md` — iconography table + count.
- `skills/re-frame2-xray/README.md`, `package.json`, `.claude-plugin/plugin.json` — tab list + descriptions.
- `skills/README.md` + `docs/skills/re-frame2-xray.md` — same tab-count refresh.

**Scope:** no `tools/xray/` source or `tools/xray/spec/*` touched (sibling worker `ep0014-xray-deriv` owns those).

## Quality gates

- `skills-check` (api-manifest skills projection): **OK** — 575 public-var references in sync; no retired `(rf/…)` calls introduced (the graph accessor is referenced as the internal `re-frame.derivation.graph` namespace / `:rf.xray/*` subs, never a `(rf/…)` facade call).
- `check_skill_package_refs.py --verbose --ci`: **clean**.
- `check_skill_eval_packaging.py --verbose --ci`: **no drift** (8 packaged skills).
- `check_skill_eval_docs.py --verbose --ci`: **no drift**.
- `mkdocs build --strict`: **exit 0**, no errors/warnings (the touched `docs/skills/re-frame2-xray.md` added prose only, no new links).
