### PR TITLE
fix(resources): EP-0012 re-key :entries on CEDN-1 byte identity (full, all 4 carriers) (rf2-9e0tyq)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -153,7 +153,7 @@
         cparams    (registry/validate+canonicalize-params resource spec params where)
         scoped-key (state/scoped-resource-key scope resource cparams)
         entry      (or (get-in runtime-db (state/entry-path scoped-key))
-                       (state/empty-entry resource))
+                       (state/empty-entry resource scoped-key))
         prior-work (:current-work entry)
         in-flight? (some? prior-work)
         ;; JOINABLE work (rf2-v4ygg5): an `ensure` may DEDUPE onto the prior
@@ -243,7 +243,7 @@
                      (assoc-in (state/entry-path scoped-key) hit)
                      (cond->
                        owner (update-in (state/owner-index-path)
-                                        update owner (fnil conj #{}) scoped-key))
+                                        update owner (fnil conj #{}) (state/key-id scoped-key)))
                      ;; route blocking: a route-owned blocking resource that
                      ;; is already fresh MUST settle the nav-token blocking
                      ;; slot NOW (no fetch will ever land a reply to drain
@@ -281,7 +281,7 @@
                          prior-work work-ledger/join-owner+cause owner cause)
                        (cond->
                          owner (update-in (state/owner-index-path)
-                                          update owner (fnil conj #{}) scoped-key)))]
+                                          update owner (fnil conj #{}) (state/key-id scoped-key))))]
         (trace/emit! :rf.event :rf.resource/deduped
                      {:rf.frame/id frame-id :resource-key scoped-key
                       :generation (:generation entry) :owner owner :cause cause
@@ -348,7 +348,7 @@
                            (work-ledger/put-record work-id record)
                            (cond->
                              owner (update-in (state/owner-index-path)
-                                              update owner (fnil conj #{}) scoped-key)))
+                                              update owner (fnil conj #{}) (state/key-id scoped-key))))
             ;; lower into the resource's transport (the existing seam). The
             ;; runtime owns reply addressing: the internal reply payloads
             ;; stamp the qualified :rf.frame/id + :work/id + :resource-key +
@@ -513,11 +513,14 @@
   [runtime-db clock-ms]
   (let [entries (get-in runtime-db (state/entries-path))]
     (into []
-          (keep (fn [[scoped-key entry]]
+          (keep (fn [[_k-id entry]]
                   (when (and (seq (:active-owners entry))
                              (state/entry-stale? entry clock-ms)
                              (not (entry-revalidation-in-flight? runtime-db entry)))
-                    (let [[scope resource-id params] scoped-key]
+                    ;; rf2-9e0tyq — read the scoped-key VECTOR from the entry's
+                    ;; `:resource/key` (the map key is now the opaque byte id).
+                    (let [scoped-key (:resource/key entry)
+                          [scope resource-id params] scoped-key]
                       {:resource-key scoped-key
                        :scope        scope
                        :resource     resource-id
@@ -717,21 +720,32 @@
         ;; re-staled / refetched). The set is canonicalized at the producer
         ;; (the populate path re-keys by the canonical scoped key), so a plain
         ;; set membership test is identity-correct.
-        exempt     (set exempt-keys)
+        ;; rf2-9e0tyq — `entries` is keyed on the byte `key-id`; every
+        ;; scope/identity decision below reads the entry's `:resource/key`
+        ;; VECTOR (`sk`). `exempt` is matched by byte identity (the populate
+        ;; path supplies scoped-key vectors; reduce both to `key-id`) so a
+        ;; list- vs vector-params exempt key matches exactly. The matched MAP
+        ;; is keyed on the byte `key-id` (so `assoc-in (entry-path …)` and the
+        ;; trace's `:resource-key` use the right form: byte for the db write,
+        ;; vector for the trace/refetch).
+        exempt     (into #{} (map state/key-id) exempt-keys)
         tags-hit?  (fn [entry] (seq (set/intersection (set (:tags entry)) tag-set)))
-        in-scope?  (fn [k] (or cross-scope? (= cscope (first k))))
+        sk-of      (fn [entry] (:resource/key entry))
+        in-scope?  (fn [entry] (or cross-scope? (= cscope (first (sk-of entry)))))
         ;; matched: tags intersect AND (cross-scope OR scope matches) AND NOT
-        ;; exempt (a populated key the same mutation kept authoritative)
+        ;; exempt (a populated key the same mutation kept authoritative).
+        ;; Keyed on the byte key-id.
         matched    (into {}
-                         (filter (fn [[k entry]] (and (not (contains? exempt k))
-                                                      (in-scope? k) (tags-hit? entry))))
+                         (filter (fn [[k-id entry]] (and (not (contains? exempt k-id))
+                                                         (in-scope? entry) (tags-hit? entry))))
                          entries)
         ;; the exempt keys that WOULD have matched (for the trace — what the
-        ;; populate spared from this same-mutation refetch)
+        ;; populate spared from this same-mutation refetch). The trace names
+        ;; them by the scoped-key VECTOR.
         exempt-hit (into []
-                         (comp (filter (fn [[k entry]] (and (contains? exempt k)
-                                                            (in-scope? k) (tags-hit? entry))))
-                               (map key))
+                         (comp (filter (fn [[k-id entry]] (and (contains? exempt k-id)
+                                                               (in-scope? entry) (tags-hit? entry))))
+                               (map (fn [[_k-id entry]] (sk-of entry))))
                          entries)
         ;; tag matches that fell OUTSIDE the requested scope (the
         ;; "no match HERE, but the tag exists in another scope" signal — only
@@ -739,20 +753,21 @@
         other-scope-hit?
         (and (not cross-scope?)
              (boolean
-               (some (fn [[k entry]] (and (not= cscope (first k)) (tags-hit? entry)))
+               (some (fn [[_k-id entry]] (and (not= cscope (first (sk-of entry))) (tags-hit? entry)))
                      entries)))
-        ;; mark each matched entry stale (durable :invalidated-at fact)
+        ;; mark each matched entry stale (durable :invalidated-at fact). Keyed
+        ;; on the byte key-id — write straight to the entries-path slot.
         rdb'       (reduce-kv
-                     (fn [db k entry]
-                       (assoc-in db (state/entry-path k)
+                     (fn [db k-id entry]
+                       (assoc-in db (state/entry-path-by-id k-id)
                                  (assoc entry :invalidated-at invalidated-at)))
                      runtime-db matched)
         ;; per-entry decision: active-owner entries refetch (Spec 016
         ;; §Invalidation 3); ownerless entries are left stale / GC-eligible
         ;; (§Invalidation 4). Collected once for both the dispatches and the
-        ;; per-entry trace detail.
-        decisions  (mapv (fn [[k entry]]
-                           {:resource-key k
+        ;; per-entry trace detail. `:resource-key` is the scoped-key VECTOR.
+        decisions  (mapv (fn [[_k-id entry]]
+                           {:resource-key (sk-of entry)
                             :active? (boolean (seq (:active-owners entry)))
                             :decision (if (seq (:active-owners entry))
                                         :refetch :left-stale)
@@ -819,10 +834,13 @@
         rdb0       (if (and (vector? owner) (= :route (first owner)))
                      (route/clear-blocking-slot runtime-db (nth owner 2))
                      runtime-db)
+        ;; rf2-9e0tyq — `owned` is a set of byte `key-id`s (the owner-index
+        ;; members), so resolve each to its entry via `entry-path-by-id` (NOT
+        ;; `entry-path`, which would re-transform a scoped-key vector).
         ;; drop the owner from each owned entry + the index
         rdb1       (-> (reduce
-                         (fn [db k]
-                           (update-in db (state/entry-path k)
+                         (fn [db k-id]
+                           (update-in db (state/entry-path-by-id k-id)
                                       (fn [e] (when e (update e :active-owners disj owner)))))
                          rdb0 (or owned #{}))
                        (update-in (state/owner-index-path) dissoc owner))
@@ -831,9 +849,9 @@
         ;; (orphaned in-flight attempts → opportunistic abort).
         {rdb2 :rdb aborts :aborts}
         (reduce
-          (fn [acc k]
+          (fn [acc k-id]
             (let [db   (:rdb acc)
-                  e    (get-in db (state/entry-path k))
+                  e    (get-in db (state/entry-path-by-id k-id))
                   wid  (:current-work e)
                   rec  (when wid (work-ledger/get-record db wid))]
               (if (and wid rec)
@@ -867,23 +885,31 @@
   [runtime-db frame-id scope cause]
   (let [cscope     (state/canonicalize-scope scope 'rf.resource/clear-scope nil)
         entries    (get-in runtime-db (state/entries-path))
-        in-scope   (into #{} (comp (filter (fn [[k _]] (= cscope (first k))))
-                                   (map key))
-                         entries)
+        ;; rf2-9e0tyq — `entries` is keyed on the byte `key-id`; the scope to
+        ;; match against lives in each entry's `:resource/key` vector
+        ;; (`(first (:resource/key entry))`), not the map key. `in-scope` is
+        ;; the set of byte key-ids to remove + the scoped-key VECTORS for the
+        ;; downstream trace / timer fx (which name resources by their vector).
+        in-scope-ids (into #{} (comp (filter (fn [[_k-id e]] (= cscope (first (:resource/key e)))))
+                                     (map key))
+                           entries)
+        in-scope     (into #{} (comp (filter (fn [[_k-id e]] (= cscope (first (:resource/key e)))))
+                                     (map (fn [[_k-id e]] (:resource/key e))))
+                           entries)
         ;; collect the in-flight work ids for the cleared entries (best-effort
         ;; abort + terminal :cancelled work rows)
         in-flight  (into []
-                         (keep (fn [k]
-                                 (let [e (get entries k)
+                         (keep (fn [k-id]
+                                 (let [e (get entries k-id)
                                        wid (:current-work e)]
                                    (when wid
                                      [wid (:transport (work-ledger/get-record runtime-db wid))]))))
-                         in-scope)
+                         in-scope-ids)
         ;; remove the entries, settle their in-flight work rows :cancelled,
         ;; then recompute the indexes from what remains
         rdb'       (-> runtime-db
                        (update-in (state/entries-path)
-                                  (fn [es] (reduce dissoc es in-scope)))
+                                  (fn [es] (reduce dissoc es in-scope-ids)))
                        (as-> db (reduce (fn [d [wid _]]
                                           (work-ledger/update-record
                                             d wid work-ledger/mark-terminal
@@ -996,7 +1022,9 @@
         wid        (:current-work entry)
         transport  (when wid (:transport (work-ledger/get-record runtime-db wid)))
         rdb'       (-> runtime-db
-                       (update-in (state/entries-path) dissoc scoped-key)
+                       ;; rf2-9e0tyq — dissoc by the byte key-id (a dissoc by
+                       ;; the scoped-key vector would no-op and leak the entry).
+                       (update-in (state/entries-path) dissoc (state/key-id scoped-key))
                        (cond-> wid (work-ledger/update-record
                                      wid work-ledger/mark-terminal
                                      :cancelled {:reason :remove}))
@@ -1577,8 +1605,11 @@
   (let [runtime-db (or rt {})
         entry      (get-in runtime-db (state/entry-path resource-key))]
     (if (and entry (empty? (:active-owners entry)) (nil? (:current-work entry)))
+      ;; rf2-9e0tyq — `:entries` is keyed on the byte `key-id`; dissoc by it
+      ;; (a dissoc by the scoped-key VECTOR would be a no-op and the GC removal
+      ;; would silently leak the entry).
       (let [rdb' (-> runtime-db
-                     (update-in (state/entries-path) dissoc resource-key)
+                     (update-in (state/entries-path) dissoc (state/key-id resource-key))
                      (update state/resources-key state/recompute-indexes))]
         (trace/emit! :rf.event :rf.resource/gc-fired
                      {:rf.frame/id frame-id :resource-key resource-key})

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -242,7 +242,8 @@
                 tags     (when tags-fn (set (tags-fn rparams value)))
                 entry    (get-in db' (state/entry-path scoped-key))
                 entry'   (mstate/populate-entry entry resource-id value
-                                                {:clock-ms clock-ms :stale-at stale-at :tags tags})
+                                                {:clock-ms clock-ms :stale-at stale-at :tags tags
+                                                 :scoped-key scoped-key})
                 delays   (timer-delays rspec)]
             [(assoc-in db' (state/entry-path scoped-key) entry')
              (conj ks scoped-key)

--- a/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_runtime.cljc
@@ -270,13 +270,17 @@
 
   `resource-id` stamps the seeded entry's `:resource/id` when fresh; `tags`
   is the produced tag set (a populated entry MUST carry its own tags so a
-  later invalidation can reach it)."
-  [entry resource-id populate-value {:keys [clock-ms stale-at tags]}]
-  (let [base   (or entry (state/empty-entry resource-id))
+  later invalidation can reach it). `scoped-key` (opt) stamps the seeded
+  entry's `:resource/key` when fresh (rf2-9e0tyq — a populate may CREATE an
+  entry, and every entry must carry its own scoped-key vector now that
+  `:entries` is keyed on the byte `key-id`); an existing entry keeps its own."
+  [entry resource-id populate-value {:keys [clock-ms stale-at tags scoped-key]}]
+  (let [base   (or entry (state/empty-entry resource-id scoped-key))
         old    (:data base)
         shared (if (and (some? old) (= old populate-value)) old populate-value)]
     (assoc base
            :resource/id    (:resource/id base resource-id)
+           :resource/key   (or (:resource/key base) scoped-key)
            :data           shared
            :status         :loaded
            :error          nil

--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -211,11 +211,18 @@
   resource-id)
 
 (defn- entry-keys-for-resource
-  "The scoped keys in `runtime-db`'s `:entries` whose resource id (the
-  SECOND element of `[scope resource-id params]`) is `resource-id`."
+  "The scoped-key VECTORS in `runtime-db`'s `:entries` whose resource id (the
+  SECOND element of `[scope resource-id params]`) is `resource-id`. rf2-9e0tyq:
+  `:entries` is keyed on the opaque byte `key-id`, so the resource-id filter
+  reads each entry's stored `:resource/key` vector (NOT the map key), and the
+  returned keys are the kind-preserving VECTORS the timer-cancel / abort / trace
+  consumers name resources by. The disposal `dissoc` maps these through
+  `state/key-id` to address the byte-keyed `:entries` slots."
   [runtime-db resource-id]
   (into []
-        (comp (map key) (filter (fn [[_scope rid _params]] (= rid resource-id))))
+        (comp (map val)
+              (filter (fn [entry] (= resource-id (second (:resource/key entry)))))
+              (map :resource/key))
         (get-in runtime-db (state/entries-path))))
 
 (defn- dispose-resource-runtime!
@@ -248,7 +255,10 @@
           frame-id
           (fn [rdb]
             (-> (or rdb {})
-                (update-in (state/entries-path) (fn [es] (reduce dissoc es keys')))
+                ;; rf2-9e0tyq — `keys'` are scoped-key VECTORS; the byte-keyed
+                ;; `:entries` map is dissoc'd by their `key-id`s.
+                (update-in (state/entries-path)
+                           (fn [es] (reduce dissoc es (map state/key-id keys'))))
                 (as-> db (reduce (fn [d [wid _]]
                                    (work-ledger/update-record
                                      d wid work-ledger/mark-terminal

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -144,32 +144,12 @@
 ;; (the owner-classification seam); this slice consults it — never a
 ;; family-private elider.
 
-(defn- entry-classification
-  "Classify how `entry` (under `scoped-key`) may ride the wire against the SSR
-  `frame-id`, deferring to the resource OWNER's coarse root-prop `:sensitive?` /
-  `:large?` claim AND the named-scope-resolver derived-sensitivity inheritance
-  arm (`classification/whole-entry-disposition-for`, EP-0015 §6 / issue 11 +
-  EP-0016 wave rf2-fi6tda.1). Returns one of:
-
-    :serialize  — ship the data (still PROJECTED through frame
-                  classification — see `project-entry`);
-    :redact     — ship the entry as METADATA ONLY (status / timestamps /
-                  generation) with the data replaced by the redaction
-                  sentinel — a `:sensitive?` resource, OR a resource whose
-                  `{:from-db <id>}` scope resolver derived a sensitive scope
-                  from a frame-sensitive `:db` input (automatic inheritance);
-    :omit       — drop the entry's data wholesale (ship metadata only, no
-                  data key at all) — a `:large?` resource whose payload is
-                  too big to ride the hydration wire.
-
-  Sensitive (owner-declared OR derived) wins over large when both apply (the
-  redaction sentinel is the more conservative shape — it still announces an
-  entry exists). Per Spec 016 §Runtime-subsystem graduation clause 4 / EP-0015
-  §6 / Spec 015 §Derived sensitivity."
-  [frame-id scoped-key _entry]
-  (let [resource-id (nth scoped-key 1)
-        spec        (registry/resource-meta resource-id)]
-    (classification/whole-entry-disposition-for spec frame-id)))
+;; The per-entry disposition (`:serialize` / `:redact` / `:omit`) is computed
+;; inside `project-entry` (`classification/whole-entry-disposition-for` over the
+;; resource OWNER's coarse root-prop `:sensitive?` / `:large?` claim PLUS the
+;; named-scope-resolver derived-sensitivity inheritance arm — EP-0015 §6 / issue
+;; 11 + EP-0016 wave rf2-fi6tda.1; Spec 015 §Derived sensitivity). Sensitive wins
+;; over large (the redaction sentinel is the more conservative shape).
 
 ;; ---- scoped-key privacy (Spec 016 clause 4, rf2-otms75) -------------------
 ;;
@@ -288,9 +268,17 @@
   `:refresh-error` rides ONLY when the entry's data is serialized (it is
   the same privacy/size class as data — Spec 016 §SSR and hydration: a
   `:refresh-error` serializes only when the error envelope is allowed by
-  the data projection). A redacted/omitted entry drops `:refresh-error`."
-  [frame-id clock-ms scoped-key entry]
-  (let [resource-id (nth scoped-key 1)
+  the data projection). A redacted/omitted entry drops `:refresh-error`.
+
+  rf2-9e0tyq: the entry carries its own scoped-key VECTOR as `:resource/key`
+  (the `:entries` map is keyed on the byte `key-id`), so the scoped key is
+  read from the entry, not a separate map-key argument. The wire entry's
+  `:resource/key` is PROJECTED through `project-scoped-key` (scope+params
+  redacted for a `:redact` / `:omit` resource) so the raw identity never rides
+  in the in-entry copy any more than in the wire MAP key."
+  [frame-id clock-ms entry]
+  (let [scoped-key  (:resource/key entry)
+        resource-id (second scoped-key)
         ;; resolve the owner spec once: it carries BOTH the coarse root-prop
         ;; disposition (`whole-entry-disposition`) and the per-slot
         ;; `:data-schema` marks (`project-data` layer (a)) — EP-0015 §6.
@@ -348,6 +336,14 @@
         ;; survive the round-trip (Spec 016 §Restore and replay part 2 — a
         ;; non-terminal attempt is dangling on install).
         wire-entry  (dissoc wire-entry :current-work)
+        ;; rf2-9e0tyq — the in-entry `:resource/key` copy is PROJECTED the same
+        ;; way as the wire MAP key (`project-scoped-key`): a `:redact` / `:omit`
+        ;; resource redacts its scope + params to opaque content-addressed
+        ;; tokens here too, so the raw identity never rides in EITHER carrier.
+        ;; The client's `recompute-indexes` keys index members on the byte
+        ;; `key-id` of this projected `:resource/key`, matching the wire map key.
+        wire-entry  (assoc wire-entry :resource/key
+                           (project-scoped-key scoped-key disposition spec))
         meta'       (assoc base
                            :disposition (case disposition
                                           :serialize :serialized
@@ -364,7 +360,7 @@
   decisions). Returns a vector of per-entry metadata maps. PURE; the host
   adapter records it in route/SSR diagnostics."
   [frame-id clock-ms entries]
-  (mapv (fn [[k entry]] (second (project-entry frame-id clock-ms k entry)))
+  (mapv (fn [[_k-id entry]] (second (project-entry frame-id clock-ms entry)))
         entries))
 
 (defn project-resources-runtime-db
@@ -398,13 +394,16 @@
     (if (seq entries)
       (let [frame-id (frame/resolve-current-frame)
             clock-ms (now-ms)
+            ;; rf2-9e0tyq — the projected wire entries are RE-KEYED on the byte
+            ;; `key-id` of each entry's PROJECTED `:resource/key` (the wire
+            ;; entry's own `:resource/key`, set by `project-entry`), so the
+            ;; client installs them under the same byte identity it will then
+            ;; `recompute-indexes` over. `entries` here is keyed on the byte
+            ;; `key-id`; the scoped-key vector is read from each entry.
             wired    (into {}
-                           (map (fn [[k entry]]
-                                  (let [resource-id (nth k 1)
-                                        spec        (registry/resource-meta resource-id)
-                                        disposition (entry-classification frame-id k entry)
-                                        wire-key    (project-scoped-key k disposition spec)]
-                                    [wire-key (first (project-entry frame-id clock-ms k entry))])))
+                           (map (fn [[_k-id entry]]
+                                  (let [wire-entry (first (project-entry frame-id clock-ms entry))]
+                                    [(state/key-id (:resource/key wire-entry)) wire-entry])))
                            entries)]
         {state/resources-key {:entries wired}})
       {})))
@@ -437,20 +436,24 @@
   with no blocking resources never blocks the render). PURE — the host
   reads the live frame's entries each tick and re-evaluates.
 
-  `blocking-keys` are scoped resource keys; nav-token isolation is the
-  CALLER's responsibility — the route slice computes the blocking-keys for
-  the current nav-token only, so a superseded navigation's keys never enter
-  this predicate."
+  `blocking-keys` are scoped resource keys (the VECTOR form the route slice
+  stores); nav-token isolation is the CALLER's responsibility — the route
+  slice computes the blocking-keys for the current nav-token only, so a
+  superseded navigation's keys never enter this predicate.
+
+  rf2-9e0tyq: `entries` is keyed on the CEDN-1 byte `key-id`, so each
+  scoped-key vector is translated through `state/key-id` before lookup."
   [entries blocking-keys]
-  (every? (fn [k] (entry-settled? (get entries k))) blocking-keys))
+  (every? (fn [k] (entry-settled? (get entries (state/key-id k)))) blocking-keys))
 
 (defn unsettled-blocking-keys
   "Return the subset of `blocking-keys` whose entries have NOT settled
   (still `:idle` / `:loading` / `:fetching`, or absent). The set
   `settle-blocking-timeout` fails closed against when the SSR deadline
-  fires. Per Spec 016 §SSR and hydration (blocking timeout policy)."
+  fires. Per Spec 016 §SSR and hydration (blocking timeout policy).
+  rf2-9e0tyq: looks each scoped-key vector up by its byte `key-id`."
   [entries blocking-keys]
-  (into #{} (remove (fn [k] (entry-settled? (get entries k)))) blocking-keys))
+  (into #{} (remove (fn [k] (entry-settled? (get entries (state/key-id k))))) blocking-keys))
 
 (defn ssr-timeout-error
   "The structured first-load failure envelope a blocking SSR timeout
@@ -496,11 +499,17 @@
     (if (empty? unsettled)
       {:entries entries :route-blocking-failure nil}
       (let [error    (ssr-timeout-error deadline-ms)
+            ;; rf2-9e0tyq — `unsettled` are scoped-key VECTORS; the `:entries`
+            ;; map is keyed on the byte `key-id`, so key each settle by
+            ;; `key-id` and stamp the entry's own `:resource/key` vector (so a
+            ;; freshly-minted timeout entry carries its identity for the
+            ;; downstream iterators / projection).
             entries' (reduce
                        (fn [es k]
-                         (let [entry (or (get es k)
-                                         (state/empty-entry (nth k 1)))]
-                           (assoc es k (state/entry-failed entry {:error error}))))
+                         (let [k-id  (state/key-id k)
+                               entry (or (get es k-id)
+                                         (state/empty-entry (second k) k))]
+                           (assoc es k-id (state/entry-failed entry {:error error}))))
                        entries unsettled)]
         (trace/emit-error! :rf.error/resource-ssr-blocking-timeout
                            {:rf.error/id :rf.error/resource-ssr-blocking-timeout
@@ -1006,12 +1015,16 @@
                            ledger)]
     (if (empty? non-terminal)
       [runtime-db []]
-      [(reduce (fn [rdb work-id]
-                 (work-ledger/update-record rdb work-id
-                                            work-ledger/mark-terminal
-                                            :suppressed
-                                            {:reason :dangling
-                                             :recovery :restore-reconcile}))
+      ;; rf2-9e0tyq — `non-terminal` are ledger map keys (already byte
+      ;; `work-id-id`s from the `(map key)` scan), so update them via
+      ;; `update-record-by-id` (NOT `update-record`, which re-transforms a
+      ;; work-id VECTOR to its byte id and would double-hash).
+      [(reduce (fn [rdb work-id-id]
+                 (work-ledger/update-record-by-id rdb work-id-id
+                                                   work-ledger/mark-terminal
+                                                   :suppressed
+                                                   {:reason :dangling
+                                                    :recovery :restore-reconcile}))
                runtime-db non-terminal)
        non-terminal])))
 
@@ -1433,12 +1446,16 @@
   ([runtime-db clock-ms] (hydrate-refetch-plan runtime-db clock-ms nil))
   ([runtime-db clock-ms frame-id]
    (let [entries (get-in runtime-db [state/resources-key :entries])
+         ;; rf2-9e0tyq — `entries` is keyed on the opaque byte `key-id`; the
+         ;; plan names each entry by its stored `:resource/key` VECTOR (the
+         ;; route slice re-resolves params from the live route under that key)
+         ;; and reads the resource-id from position 1 of THAT vector.
          plan    (into []
                        (comp
                          (filter (fn [[_ entry]] (entry-needs-refetch? entry clock-ms)))
-                         (map (fn [[k entry]]
-                                {:resource-key k
-                                 :resource-id  (nth k 1)
+                         (map (fn [[_k-id entry]]
+                                {:resource-key (:resource/key entry)
+                                 :resource-id  (second (:resource/key entry))
                                  :reason       (cond
                                                  ;; a REDACTED entry rides the
                                                  ;; sentinel as `:data` — metadata

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -39,9 +39,36 @@
   spawned actors / machine async work. Per Spec 016 §Frame work ledger."
   :rf.runtime/work-ledger)
 
+(defn key-id
+  "The CEDN-1 BYTE-IDENTITY map-key for a scoped resource key
+  `[canonical-scope resource-id canonical-params]` — its `canonical-bytes`
+  string (rf2-9e0tyq). This is the value the `:entries` map, the reverse
+  indexes, and the work-ledger map are keyed on, replacing the scoped-key
+  VECTOR as the map key.
+
+  WHY (the EP-0012 `=`-collapse fix): the scoped-key vector was used directly
+  as a Clojure map key, and Clojure map keys compare by `=` + hash. The SOLE
+  place `=` is COARSER than the authoritative CEDN-1 byte identity is
+  SEQUENTIAL vector-vs-list — `(= [1 2 3] '(1 2 3))` is TRUE while their
+  `canonical-bytes` differ (`v[…]` vs `l(…)`). Keying on the canonical-bytes
+  STRING makes the map-key comparison EXACTLY the CEDN-1 byte identity
+  (strings compare by `=` over their content, which IS the byte identity), so
+  a list-params key and a vector-params key get DISTINCT entries — without
+  re-erasing the kind (the canonical scoped-key vector, kind-preserving, is
+  stored alongside as `:resource/key`). The bytes string is plain serializable
+  EDN, so it rides the SSR / epoch / trace wire with no custom transit handler
+  (the failure mode a `deftype` key would have silently introduced).
+
+  Total on an already-canonical scoped key (`scoped-resource-key` canonicalizes
+  scope + params, and `canonical-bytes` is total on canonical EDN). Per Spec
+  016 §Resource identity / Conventions §Canonical EDN identity."
+  [scoped-key]
+  (identity/canonical-bytes scoped-key))
+
 (defn entries-path
-  "Runtime-db-relative path to the cache entries map
-  `{<scoped-resource-key> <entry>}`. Per Spec 016 §Cache home."
+  "Runtime-db-relative path to the cache entries map `{<key-id> <entry>}` —
+  keyed on the CEDN-1 byte-identity `key-id` (NOT the scoped-key vector;
+  rf2-9e0tyq). Per Spec 016 §Cache home."
   []
   [resources-key :entries])
 
@@ -61,11 +88,20 @@
   [resources-key :owner-index])
 
 (defn entry-path
-  "Runtime-db-relative path to a single cache entry by its scoped
-  resource key `[cache-scope resource-id canonical-params]`. Per Spec 016
-  §Resource identity."
+  "Runtime-db-relative path to a single cache entry. Accepts the scoped
+  resource key VECTOR `[cache-scope resource-id canonical-params]` and keys
+  the entry on its CEDN-1 byte-identity `key-id` (rf2-9e0tyq) so a list- and
+  a vector-params key never collapse. Per Spec 016 §Resource identity."
   [scoped-resource-key]
-  [resources-key :entries scoped-resource-key])
+  [resources-key :entries (key-id scoped-resource-key)])
+
+(defn entry-path-by-id
+  "Runtime-db-relative path to a single cache entry by its already-computed
+  `key-id` (the CEDN-1 byte string). Used by callers that hold a reverse-index
+  member (already a `key-id`) and must not re-transform it through `entry-path`
+  (rf2-9e0tyq). Per Spec 016 §Resource identity."
+  [k-id]
+  [resources-key :entries k-id])
 
 (defn work-record-path
   "Runtime-db-relative path to a single work record by its `:work/id`.
@@ -111,17 +147,13 @@
   §Ledger row retention and identity."
   #{:completed :failed :timed-out :suppressed :cancelled})
 
-(defn empty-entry
-  "Construct an empty `:idle` durable cache entry for `resource-id`. The
-  durable entry stores FACTS, not derived booleans (`:stale?` /
-  `:loading?` / `:has-data?` are public derived sub values, computed in
-  the subs layer, never stored). Per Spec 016 §Status semantics.
-
-  The runtime populates / transitions this shape; this constructor pins
-  the canonical key set so an entry written by one sibling reads correctly
-  in another."
+(defn- empty-entry*
+  "The base empty `:idle` durable cache entry shape for `resource-id`,
+  `:resource/key` nil. `empty-entry` stamps the key. Private — callers use
+  `empty-entry`."
   [resource-id]
   {:resource/id    resource-id
+   :resource/key   nil
    :status         :idle
    :data           nil
    :error          nil
@@ -144,6 +176,30 @@
    ;; key becomes `:loaded` (it then has its own data). nil when this entry
    ;; does not keep previous data.
    :previous-key   nil})
+
+(defn empty-entry
+  "Construct an empty `:idle` durable cache entry for `resource-id`. The
+  durable entry stores FACTS, not derived booleans (`:stale?` /
+  `:loading?` / `:has-data?` are public derived sub values, computed in
+  the subs layer, never stored). Per Spec 016 §Status semantics.
+
+  The runtime populates / transitions this shape; this constructor pins
+  the canonical key set so an entry written by one sibling reads correctly
+  in another.
+
+  The 2-arity stamps the entry's own `:resource/key` — the scoped-key VECTOR
+  `[canonical-scope resource-id canonical-params]` (rf2-9e0tyq). Since the
+  `:entries` map is now keyed on the CEDN-1 byte `key-id` (a string), the
+  kind-preserving scoped-key vector is carried INSIDE the entry so every
+  consumer that needs the `[scope rid params]` shape (the prior-sibling scan,
+  the scope-mismatch heuristic, the clear-scope filter, the Xray live-node
+  view, the SSR projection) reads it from the entry rather than the map key.
+  The 1-arity (no key in scope — e.g. the SSR timeout settle) leaves
+  `:resource/key` nil; callers that have the key use the 2-arity or stamp it."
+  ([resource-id] (empty-entry* resource-id))
+  ([resource-id scoped-key]
+   (cond-> (empty-entry* resource-id)
+     scoped-key (assoc :resource/key scoped-key))))
 
 ;; ---- canonicalization (Spec 016 §Canonicalization rule) -------------------
 ;;
@@ -374,18 +430,17 @@
   supersede each other). Per Spec 016 §Resource identity. Assumes scope +
   params are already validated serializable EDN (`reject-non-edn!`).
 
-  KNOWN DEFERRED EDGE (rf2-o84qq2; full fix planned in rf2-9e0tyq): the
-  returned vector is used DIRECTLY as a Clojure map key (in `:entries` and,
-  embedded, in the work-ledger work-id), so it compares by `=` + hash. The
-  SOLE place `=` is COARSER than the authoritative CEDN-1 byte identity is
-  SEQUENTIAL vector-vs-list — `(= [1 2 3] '(1 2 3))` is TRUE while their
-  `canonical-bytes` differ (`v[…]` vs `l(…)`). So a LIST as a params/scope
-  VALUE collapses with the vector spelling at the map-keying layer even
-  though `canonicalize` preserves the kind. The edge is extremely narrow
-  (params are Malli `:map`s of scalars/vectors, never lists); pinned in
-  `resources_runtime_cljs_test` so it cannot silently shift. The fix is a
-  cross-cutting re-keying onto `canonical-bytes` (rf2-9e0tyq), NOT a
-  list→vector normalize (that would re-erase the kind rf2-wgutc2 added)."
+  The returned vector is the kind-PRESERVING canonical identity (a list value
+  stays a list, distinct from a vector — rf2-wgutc2). It is NO LONGER used
+  directly as a Clojure map key: the `:entries` map, the reverse indexes, and
+  the work-ledger map are keyed on its CEDN-1 byte `key-id` (`state/key-id`,
+  rf2-9e0tyq) so the map-key comparison is EXACTLY the CEDN-1 byte identity
+  and a list- and a vector-params key get DISTINCT entries (Clojure `=` would
+  otherwise collapse `[1 2 3]` and `'(1 2 3)`). The vector itself remains the
+  kind-preserving value carried as the entry's `:resource/key`, embedded in
+  the work-id, on the SSR wire, and in trace payloads — so the kind distinction
+  rf2-wgutc2 introduced is preserved end-to-end, and the `=`-collapse is closed
+  at the map-keying layer where it actually occurred."
   [scope resource-id params]
   [(canonicalize scope) resource-id (canonicalize params)])
 
@@ -394,18 +449,23 @@
   (Spec 016 §Paginated and previous data): among the cache `entries`, the
   key with the SAME `[scope resource-id]` as `new-key` but DIFFERENT
   params, that currently has usable `:data`, picking the most recently
-  loaded (`:loaded-at`). Returns the sibling scoped key, or nil when there
-  is no sibling to project (the new key first-loads with no placeholder).
-  A pure selection — the projection pointer it returns never inserts data
-  into the new entry."
+  loaded (`:loaded-at`). Returns the sibling SCOPED KEY (the vector — the
+  `:previous-key` projection pointer is the kind-preserving vector, not the
+  byte `key-id`), or nil when there is no sibling to project (the new key
+  first-loads with no placeholder). A pure selection — the projection pointer
+  it returns never inserts data into the new entry.
+
+  rf2-9e0tyq: `entries` is now keyed on the CEDN-1 byte `key-id`, so the
+  scope/params comparison reads each candidate entry's stored `:resource/key`
+  vector — NOT the map key (which is the opaque bytes string)."
   [entries new-key]
   (let [[scope rid params] new-key]
     (->> entries
-         (keep (fn [[k entry]]
-                 (let [[s r p] k]
+         (keep (fn [[_k-id entry]]
+                 (let [[s r p] (:resource/key entry)]
                    (when (and (= s scope) (= r rid) (not= p params)
                               (some? (:data entry)))
-                     [k (:loaded-at entry)]))))
+                     [(:resource/key entry) (:loaded-at entry)]))))
          (sort-by (fn [[_ loaded-at]] (or loaded-at 0)) >)
          ffirst)))
 
@@ -571,20 +631,27 @@
 ;; rebuild both restore and an in-cascade index repair use.
 
 (defn recompute-indexes
-  "Rebuild `:tag-index` (`{<tag> #{<scoped-key> …}}`) and `:owner-index`
-  (`{<owner> #{<scoped-key> …}}`) from the resource subtree's `:entries`.
+  "Rebuild `:tag-index` (`{<tag> #{<key-id> …}}`) and `:owner-index`
+  (`{<owner> #{<key-id> …}}`) from the resource subtree's `:entries`.
   Returns the resource subtree with both indexes replaced. Per Spec 016
-  §Restore and replay part 5 / §Cache home."
+  §Restore and replay part 5 / §Cache home.
+
+  rf2-9e0tyq: the index MEMBERS are the CEDN-1 byte `key-id` — the SAME key
+  the `:entries` map uses — so a list- and a vector-params key produce
+  DISTINCT index members (the `=`-collapse would otherwise fold two sets'
+  members into one). The member is the map key of `:entries` directly (it
+  already IS the byte `key-id`), so consumers resolve an index member to its
+  entry via `entry-path-by-id`."
   [resources-subtree]
   (let [entries (:entries resources-subtree)]
     (reduce-kv
-      (fn [acc k entry]
+      (fn [acc k-id entry]
         (-> acc
             (update :tag-index
-                    (fn [ti] (reduce (fn [ti tag] (update ti tag (fnil conj #{}) k))
+                    (fn [ti] (reduce (fn [ti tag] (update ti tag (fnil conj #{}) k-id))
                                      ti (:tags entry))))
             (update :owner-index
-                    (fn [oi] (reduce (fn [oi owner] (update oi owner (fnil conj #{}) k))
+                    (fn [oi] (reduce (fn [oi owner] (update oi owner (fnil conj #{}) k-id))
                                      oi (:active-owners entry))))))
       (assoc resources-subtree :tag-index {} :owner-index {})
       entries)))

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -181,8 +181,10 @@
   other scope for this resource is active. Pure."
   [entries sub-key]
   (let [[sub-scope rid _params] sub-key]
-    (some (fn [[k entry]]
-            (let [[scope r _p] k]
+    (some (fn [[_k-id entry]]
+            ;; rf2-9e0tyq — read the scope/rid from the entry's stored
+            ;; `:resource/key` VECTOR (the map key is now the opaque byte id).
+            (let [[scope r _p] (:resource/key entry)]
               (when (and (= r rid)
                          (not= scope sub-scope)
                          (entry-active? entry))

--- a/implementation/resources/src/re_frame/resources/timers.cljc
+++ b/implementation/resources/src/re_frame/resources/timers.cljc
@@ -60,7 +60,8 @@
   `:server` and a JVM client-mode unit test must still arm timers. A re-load
   reschedules (cancel-then-arm) so a single live timer per `[key kind]`
   survives."
-  (:require [re-frame.interop :as interop]
+  (:require [re-frame.identity :as identity]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.trace :as trace]))
 
@@ -117,9 +118,14 @@
   (atom {}))
 
 (defn- timer-key
-  "The side-table key for `[frame-id resource-key kind]`."
+  "The side-table key for `[frame-id resource-key kind]`. rf2-9e0tyq: the
+  `resource-key` is reduced to its CEDN-1 byte identity (`canonical-bytes`)
+  so a list- and a vector-params resource never share a timer slot (the
+  Clojure-`=` map-key collapse the cache-key re-keying closes). The dispatched
+  recheck event still carries the kind-preserving scoped-key VECTOR; only the
+  host side-table key is byte-reduced."
   [frame-id resource-key kind]
-  [frame-id resource-key kind])
+  [frame-id (identity/canonical-bytes resource-key) kind])
 
 (defn cancel!
   "Cancel + drop the host timer for `[frame-id resource-key kind]` (a no-op

--- a/implementation/resources/src/re_frame/resources/tooling.cljc
+++ b/implementation/resources/src/re_frame/resources/tooling.cljc
@@ -460,8 +460,12 @@
   (let [runtime-db (frame/frame-runtime-db-value frame-id)
         entries    (get-in runtime-db (state/entries-path))]
     (reduce-kv
-      (fn [acc scoped-key entry]
-        (let [resource-id (second scoped-key)
+      ;; rf2-9e0tyq — `:entries` is keyed on the opaque byte `key-id`; the live
+      ;; node's `:id` / inputs use the entry's own `:resource/key` VECTOR (the
+      ;; canonical fact identity), read from the entry, not the map key.
+      (fn [acc _k-id entry]
+        (let [scoped-key  (:resource/key entry)
+              resource-id (second scoped-key)
               static-node (resource-algebra-view resource-id)]
           (assoc acc scoped-key
                  (live-node-for runtime-db scoped-key entry static-node))))

--- a/implementation/resources/src/re_frame/resources/work_ledger.cljc
+++ b/implementation/resources/src/re_frame/resources/work_ledger.cljc
@@ -82,7 +82,8 @@
   trace). The two continuations are kept distinct: the ledger owns the
   framework-internal reified continuation; the call-site target is the app's
   transport-payload continuation."
-  (:require [re-frame.reply :as reply]
+  (:require [re-frame.identity :as identity]
+            [re-frame.reply :as reply]
             [re-frame.resources.state :as state]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -122,6 +123,22 @@
   identity)."
   [scoped-key generation]
   [:rf.work/resource scoped-key generation])
+
+(defn work-id-id
+  "The CEDN-1 BYTE-IDENTITY map-key for a `work-id`
+  (`[:rf.work/resource <scoped-key> <generation>]`) — its `canonical-bytes`
+  string (rf2-9e0tyq). The work-ledger runtime-db map is keyed on THIS string,
+  NOT the work-id vector, for the SAME reason `:entries` is keyed on
+  `state/key-id`: the work-id embeds the scoped-key, so two work-ids that
+  differ only by a list-vs-vector params spelling are `=`-equal (Clojure
+  `(= [1 2 3] '(1 2 3))`) and would collide in the ledger map even though
+  their CEDN-1 byte identities differ. Keying on the bytes string makes the
+  map-key comparison exactly the CEDN-1 identity. The work-id VECTOR remains
+  the kind-preserving `:work/id` carried in the record, the entry's
+  `:current-work`, and on the wire. Total on a work-id over a canonical
+  scoped-key. Per Spec 016 §Frame work ledger."
+  [work-id]
+  (identity/canonical-bytes work-id))
 
 (defn managed-request-id
   "Build the frame-QUALIFIED managed-HTTP transport correlation token
@@ -315,14 +332,16 @@
 ;; and the linked entry move together.
 
 (defn record-path
-  "Runtime-db-relative path to a single work record by its `:work/id`. Per
-  Spec 016 §Cache home (`[:rf.runtime/work-ledger <work-id>]`)."
+  "Runtime-db-relative path to a single work record, keyed on the CEDN-1 byte
+  `work-id-id` (NOT the work-id vector; rf2-9e0tyq) so a list- and a
+  vector-params work-id never collide in the ledger map. Per Spec 016
+  §Cache home (`[:rf.runtime/work-ledger <work-id-id>]`)."
   [work-id]
-  [:rf.runtime/work-ledger work-id])
+  [:rf.runtime/work-ledger (work-id-id work-id)])
 
 (defn put-record
-  "Write `record` at `[:rf.runtime/work-ledger <work-id>]` in `runtime-db`.
-  Returns the updated runtime-db."
+  "Write `record` at the work-ledger byte-keyed slot for `work-id` in
+  `runtime-db`. Returns the updated runtime-db."
   [runtime-db work-id record]
   (assoc-in runtime-db (record-path work-id) record))
 
@@ -346,7 +365,19 @@
   (Spec 016 §Ledger row retention and identity). Returns the updated
   runtime-db."
   [runtime-db work-id]
-  (update runtime-db :rf.runtime/work-ledger dissoc work-id))
+  (update runtime-db :rf.runtime/work-ledger dissoc (work-id-id work-id)))
+
+(defn update-record-by-id
+  "Apply `f` (and `args`) to the work record under an ALREADY-COMPUTED byte
+  `work-id-id` (a ledger map key from a `(map key)` ledger scan) in
+  `runtime-db`, writing the result back (rf2-9e0tyq). No-op when no record
+  exists. Distinct from `update-record` (which transforms a work-id VECTOR to
+  its byte id first) — a caller iterating the ledger already holds the byte
+  id and must NOT re-transform it. Returns the updated runtime-db."
+  [runtime-db work-id-id f & args]
+  (if (get-in runtime-db [:rf.runtime/work-ledger work-id-id])
+    (apply update-in runtime-db [:rf.runtime/work-ledger work-id-id] f args)
+    runtime-db))
 
 (def default-terminal-tail
   "How many terminal work rows to retain per resource-key for Xray's
@@ -368,10 +399,14 @@
   ([runtime-db resource-key] (prune-terminal-for-key runtime-db resource-key default-terminal-tail))
   ([runtime-db resource-key keep-tail]
    (let [ledger (:rf.runtime/work-ledger runtime-db)
+         ;; rf2-9e0tyq — match by CEDN-1 byte identity, not `=` over the
+         ;; `:resource/key` vector (which would `=`-collapse a list- and a
+         ;; vector-params key and prune both resources' rows).
+         rk-id  (state/key-id resource-key)
          ;; terminal rows for this key, newest-first by :started-at
          terminal-for-key
          (->> ledger
-              (filter (fn [[_ r]] (and (= resource-key (:resource/key r))
+              (filter (fn [[_ r]] (and (= rk-id (state/key-id (:resource/key r)))
                                        (terminal? (:status r)))))
               (sort-by (fn [[_ r]] (or (:started-at r) 0)) >))
          drop-ids (->> terminal-for-key (drop keep-tail) (map key))]
@@ -410,14 +445,16 @@
   nil. Per Spec 016 §Frame work ledger (host handles live OUTSIDE durable
   frame-state, keyed by frame id + work id)."
   [frame-id work-id handle]
-  (swap! handle-table assoc [frame-id work-id] handle)
+  (swap! handle-table assoc [frame-id (work-id-id work-id)] handle)
   nil)
 
 (defn get-handle
   "Read the host handle for `[frame-id work-id]` from the side table, or
-  nil (when absent — already cleared, or a transport that records none)."
+  nil (when absent — already cleared, or a transport that records none).
+  Keyed on `[frame-id (work-id-id work-id)]` (rf2-9e0tyq) so a list- and a
+  vector-params work-id never collapse in the side table."
   [frame-id work-id]
-  (get @handle-table [frame-id work-id]))
+  (get @handle-table [frame-id (work-id-id work-id)]))
 
 (defn clear-handle!
   "Drop the host handle for `[frame-id work-id]` from the side table
@@ -425,7 +462,7 @@
   when a work record terminates so a settled attempt's handle does not leak.
   Idempotent. Returns nil."
   [frame-id work-id]
-  (swap! handle-table dissoc [frame-id work-id])
+  (swap! handle-table dissoc [frame-id (work-id-id work-id)])
   nil)
 
 (defn opportunistic-abort!
@@ -444,6 +481,20 @@
                                  (catch #?(:clj Throwable :cljs :default) _ false))))]
     (clear-handle! frame-id work-id)
     aborted?))
+
+(defn- abort-slot!
+  "Best-effort abort + drop a side-table slot addressed by its ALREADY-COMPUTED
+  table key `[frame-id work-id-id]` (rf2-9e0tyq). The frame-teardown / reset
+  paths iterate `(keys @handle-table)` (which are already byte-keyed pairs) and
+  must NOT re-transform the work-id-id through `work-id-id` (the public
+  `opportunistic-abort!` takes a work-id VECTOR and transforms it; this private
+  variant takes the table key directly). Never throws."
+  [slot-key]
+  (let [handle (get @handle-table slot-key)]
+    (when-let [abort-fn (:abort-fn handle)]
+      (try (abort-fn :resource-superseded) (catch #?(:clj Throwable :cljs :default) _ nil)))
+    (swap! handle-table dissoc slot-key)
+    nil))
 
 ;; ---- opportunistic abort via the transport fx (transport-neutral) ---------
 ;;
@@ -576,8 +627,8 @@ attempt is superseded / settled so a stale handle does not leak. Per Spec 016
   [frame-id]
   (let [slots (->> (keys @handle-table)
                    (filter (fn [[fid _]] (= fid frame-id))))]
-    (doseq [[fid wid] slots]
-      (opportunistic-abort! fid wid)))
+    (doseq [slot-key slots]
+      (abort-slot! slot-key)))
   nil)
 
 (defn reset-cache!
@@ -587,8 +638,8 @@ attempt is superseded / settled so a stale handle does not leak. Per Spec 016
   cleared by the runtime / frames reset). Best-effort aborts each handle on
   the way out. Returns nil."
   []
-  (doseq [[fid wid] (keys @handle-table)]
-    (opportunistic-abort! fid wid))
+  (doseq [slot-key (keys @handle-table)]
+    (abort-slot! slot-key))
   (reset! handle-table {})
   nil)
 

--- a/implementation/resources/test/re_frame/resource_algebra_view_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resource_algebra_view_cljs_test.cljc
@@ -197,7 +197,10 @@
   [frame-id resource-id scope params {:keys [status owner in-flight?]}]
   (let [scoped-key (state/scoped-resource-key scope resource-id params)
         work-id    (when in-flight? (work-ledger/resource-work-id scoped-key 1))
-        entry      (cond-> (assoc (state/empty-entry resource-id)
+        ;; rf2-9e0tyq — the runtime stamps each entry's `:resource/key`; the
+        ;; live algebra view reads it for the node `:id` / `:inputs` (the
+        ;; `:entries` map is keyed on the opaque byte `key-id`).
+        entry      (cond-> (assoc (state/empty-entry resource-id scoped-key)
                                   :status        (or status :loaded)
                                   :data          {:slug (:slug params)}
                                   :active-owners (if owner #{owner} #{}))

--- a/implementation/resources/test/re_frame/resources_cache_key_identity_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_cache_key_identity_cljs_test.cljc
@@ -1,0 +1,189 @@
+(ns re-frame.resources-cache-key-identity-cljs-test
+  "EP-0012 cache-key byte-identity round-trip (rf2-9e0tyq).
+
+  The full fix for the resource cache-key `=`-collapse: the `:entries` map,
+  the reverse indexes, and the work-ledger map are keyed on the CEDN-1 byte
+  `key-id` (`state/key-id` / `work-ledger/work-id-id`) rather than the scoped
+  resource key VECTOR under Clojure `=`. The vector is the kind-preserving
+  identity (`rf2-wgutc2`) carried as each entry's `:resource/key`, embedded in
+  the work-id, on the SSR wire, and in trace payloads.
+
+  Clojure `=` collapses `(= [1 2 3] '(1 2 3))` to TRUE, but the byte key-id
+  (a `canonical-bytes` STRING) never collapses, so a list-params key and a
+  vector-params key get DISTINCT entries / work-ids / index members.
+
+  This suite proves the fix holds through ALL FOUR carriers the scoped key
+  flows into (the blast radius that deferred the fix):
+
+    1. `:entries` map key (the collapse site);
+    2. the work-ledger work-id (`[:rf.work/resource <scoped-key> <gen>]`,
+       a runtime-db map key + the stale-suppression basis);
+    3. the SSR hydration wire (`project-resources-runtime-db` → install →
+       `hydrate-runtime-db` recompute) and the epoch restore reconcile
+       (`reconcile-on-restore`);
+    4. trace payloads (the scoped-key vector rides verbatim).
+
+  CRITICAL: the byte key-id is a plain UTF-8 STRING, so it rides the SSR /
+  epoch / trace wire with NO custom transit handler — the failure mode a
+  `deftype` key would have silently introduced (it would pass an in-process
+  unit gate yet break serialization). The round-trip tests below install the
+  PROJECTED wire shape and assert the two distinct entries survive."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   #?(:cljs [cljs.reader])
+   [re-frame.identity :as identity]
+   [re-frame.resources.ssr :as ssr]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.work-ledger :as work-ledger]
+   ;; the façade publishes the SSR projection / reconcile hooks + registrar.
+   [re-frame.resources]
+   [re-frame.test-support :as core-test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    #?(:clj  {:adapter plain-atom/adapter}
+       :cljs {:adapter reagent-adapter/adapter})))
+
+;; ---- the two adversarial keys: same scope+rid, list-vs-vector params -------
+
+(def ^:private kv (state/scoped-resource-key :rf.scope/global :r/x {:xs [1 2 3]}))
+(def ^:private kl (state/scoped-resource-key :rf.scope/global :r/x {:xs '(1 2 3)}))
+
+(defn- loaded-entry
+  "A loaded durable entry stamped with its scoped-key `sk` (the runtime
+  stamps `:resource/key` on every entry now)."
+  [sk data tags]
+  (-> (state/empty-entry :r/x sk)
+      (merge {:status :loaded :data data :loaded-at 1000 :stale-at 9.0e15
+              :generation 1 :tags tags})))
+
+(defn- byte-keyed-entries
+  "Build a runtime-db `:entries` map the runtime way — keyed on the byte
+  `key-id`, each entry carrying its own `:resource/key`. Takes a SEQUENCE of
+  `[scoped-key entry]` pairs (NOT a map literal — a `{kv … kl …}` literal
+  would itself throw `Duplicate key` because `kv` and `kl` are Clojure-`=`,
+  which is the very collapse this fix routes around)."
+  [pairs]
+  (into {} (map (fn [[sk e]] [(state/key-id sk) e])) pairs))
+
+;; ===========================================================================
+;; Carrier 1 — the :entries map key
+;; ===========================================================================
+
+(deftest carrier-1-entries-map-keys-distinctly
+  (testing "list- and vector-params keys are `=` as VECTORS but their byte
+            key-ids differ, so the :entries map holds TWO entries"
+    (is (= kv kl) "the vectors are Clojure-= (the collapse the fix routes around)")
+    (is (not= (state/key-id kv) (state/key-id kl))
+        "the byte key-ids differ (v[…] vs l(…))")
+    (let [es (byte-keyed-entries [[kv (loaded-entry kv {:v 1} #{:t})]
+                                   [kl (loaded-entry kl {:l 1} #{:t})]])]
+      (is (= 2 (count es)) "two distinct entries — no =-collapse")
+      (is (= {:v 1} (:data (get es (state/key-id kv)))) "vector entry intact")
+      (is (= {:l 1} (:data (get es (state/key-id kl)))) "list entry intact")
+      (is (= kv (:resource/key (get es (state/key-id kv)))) "vector entry keeps its vector key")
+      (is (seq? (-> (get es (state/key-id kl)) :resource/key (nth 2) :xs))
+          "the list entry's :resource/key PRESERVES the list kind (not coerced to a vector)"))))
+
+;; ===========================================================================
+;; Carrier 2 — the work-ledger work-id (runtime-db map key + suppression basis)
+;; ===========================================================================
+
+(deftest carrier-2-work-ledger-keys-distinctly
+  (testing "the embedded work-id keys the work-ledger map on its own byte id"
+    (let [wv (work-ledger/resource-work-id kv 1)
+          wl (work-ledger/resource-work-id kl 1)]
+      (is (= wv wl) "the work-id VECTORS are = (they embed the key vector)")
+      (is (not= (work-ledger/work-id-id wv) (work-ledger/work-id-id wl))
+          "their byte work-id-ids differ")
+      (let [recv (work-ledger/work-record {:work-id wv :frame-id :f :resource-key kv
+                                           :generation 1 :transport :rf.http/managed})
+            recl (work-ledger/work-record {:work-id wl :frame-id :f :resource-key kl
+                                           :generation 1 :transport :rf.http/managed})
+            rdb  (-> {} (work-ledger/put-record wv recv) (work-ledger/put-record wl recl))]
+        (is (= 2 (count (:rf.runtime/work-ledger rdb))) "two distinct ledger rows")
+        (is (= wv (:work/id (work-ledger/get-record rdb wv))) "vector work record reads back")
+        (is (= wl (:work/id (work-ledger/get-record rdb wl))) "list work record reads back")
+        (is (= kv (:resource/key (work-ledger/get-record rdb wv))))
+        (is (= kl (:resource/key (work-ledger/get-record rdb wl))))))))
+
+;; ===========================================================================
+;; Carrier 3 — the SSR hydration wire (project → install → hydrate recompute)
+;; ===========================================================================
+
+(deftest carrier-3-ssr-projection-round-trip-keeps-two-entries
+  (testing "ADVERSARIAL: a frame holding BOTH a list- and a vector-params entry
+            PROJECTS to two distinct wire entries, and HYDRATION reinstalls them
+            as two distinct entries (the byte key-id rides the wire as a plain
+            string — no transit handler needed; a deftype key would break here)"
+    (let [es   (byte-keyed-entries [[kv (loaded-entry kv {:v 1} #{:t})]
+                                     [kl (loaded-entry kl {:l 1} #{:t})]])
+          rdb  {state/resources-key {:entries es :tag-index {} :owner-index {}}}
+          ;; SERVER projection (the :ssr/extend-runtime-db-projection body)
+          proj (ssr/project-resources-runtime-db rdb)
+          wired (get-in proj [state/resources-key :entries])]
+      (is (= 2 (count wired)) "two distinct wire entries projected")
+      ;; the wire keys are plain strings (transit/JSON-safe — the load-bearing
+      ;; property a deftype key would have violated).
+      (is (every? string? (keys wired)) "wire map keys are plain canonical-bytes STRINGS")
+      ;; round-trip through a pr-str/read-string (a stand-in for the transit
+      ;; wire) — the keys + kind-preserving :resource/key survive verbatim.
+      (let [round-tripped #?(:clj  (read-string (pr-str wired))
+                             :cljs (cljs.reader/read-string (pr-str wired)))]
+        (is (= wired round-tripped) "the projected wire entries survive an EDN round-trip"))
+      ;; CLIENT hydration reinstalls + recomputes indexes over the two entries.
+      (let [installed {state/resources-key {:entries wired}}
+            out (ssr/hydrate-runtime-db installed :app/main)
+            out-es (get-in out [state/resources-key :entries])
+            tag-members (get-in out [state/resources-key :tag-index :t])]
+        (is (= 2 (count out-es)) "hydration installs TWO distinct entries (no collapse)")
+        (is (= #{(state/key-id kv) (state/key-id kl)} (set (keys out-es)))
+            "both byte key-ids present after hydration")
+        (is (= 2 (count tag-members))
+            "the recomputed tag-index has TWO distinct members for the shared tag")
+        (is (= #{(state/key-id kv) (state/key-id kl)} tag-members)
+            "the tag-index members are the byte key-ids of both entries")))))
+
+;; ===========================================================================
+;; Carrier 3b — the epoch restore reconcile (unprojected snapshot)
+;; ===========================================================================
+
+(deftest carrier-3b-restore-reconcile-keeps-two-entries
+  (testing "ADVERSARIAL: an UNPROJECTED restored snapshot holding both a list-
+            and a vector-params entry reconciles to TWO distinct entries with a
+            recomputed two-member shared tag index (restore never collapses)"
+    (let [es  (byte-keyed-entries [[kv (loaded-entry kv {:v 1} #{:t})]
+                                    [kl (loaded-entry kl {:l 1} #{:t})]])
+          rdb {state/resources-key {:entries es :tag-index {} :owner-index {}}
+               state/work-ledger-key {}}
+          out (ssr/reconcile-on-restore rdb)
+          out-es (get-in out [state/resources-key :entries])]
+      (is (= 2 (count out-es)) "two distinct entries survive restore reconcile")
+      (is (= #{(state/key-id kv) (state/key-id kl)}
+             (get-in out [state/resources-key :tag-index :t]))
+          "the recomputed tag-index keeps both byte key-ids for the shared tag"))))
+
+;; ===========================================================================
+;; Carrier 4 — trace payloads carry the kind-preserving scoped-key vector
+;; ===========================================================================
+
+(deftest carrier-4-trace-scoped-key-preserves-kind
+  (testing "the scoped-key VECTOR carried in trace payloads / Xray is the
+            kind-preserving canonical form (a list value stays a list) — the
+            trace carrier never sees the byte id"
+    ;; the list-params key's params VALUE is a genuine list (seq?), not a vector
+    (is (seq? (:xs (nth kl 2))) "the list-params scoped key keeps its list kind")
+    (is (vector? (:xs (nth kv 2))) "the vector-params scoped key keeps its vector kind")
+    ;; and the two are byte-distinct identities — a trace consumer can tell them
+    ;; apart (the authoritative CEDN-1 identity, not Clojure =).
+    (is (not (identity/identical-identity? kv kl))
+        "the two trace-carried keys are byte-distinct CEDN-1 identities")))
+
+;; The real-ensure path (the runtime stamping `:resource/key` on a freshly
+;; minted entry, keyed under the byte `key-id`) is exercised by the broader
+;; `resources-runtime-cljs-test` suite (its `entry` helper reads via
+;; `state/entry-path`, which byte-keys) — this focused file pins the cache-key
+;; byte-identity round-trip through the four serialization carriers.

--- a/implementation/resources/test/re_frame/resources_classification_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_classification_cljs_test.cljc
@@ -66,11 +66,22 @@
   (merge (state/empty-entry resource-id)
          {:status status :data data :loaded-at loaded-at :stale-at stale-at}))
 
+;; rf2-9e0tyq — the runtime keys `:entries` on the byte `key-id` and stamps
+;; each entry's `:resource/key`; this helper re-keys the natural
+;; `{scoped-key-vector entry}` form callers write into the runtime's shape.
 (defn- runtime-db-with [entries]
-  {state/resources-key {:entries entries :tag-index {} :owner-index {}}})
+  {state/resources-key {:entries (into {}
+                                       (map (fn [[sk e]]
+                                              [(state/key-id sk) (assoc e :resource/key sk)]))
+                                       entries)
+                        :tag-index {} :owner-index {}}})
 
+;; The projection map is byte-keyed; the projected SCOPED KEY (verbatim or
+;; redacted) rides as the wire entry's `:resource/key`. Return it as the
+;; first element so the privacy/distinctness assertions inspect it.
 (defn- only-wire-entry [proj]
-  (first (get-in proj [state/resources-key :entries])))
+  (let [we (val (first (get-in proj [state/resources-key :entries])))]
+    [(:resource/key we) we]))
 
 ;; ===========================================================================
 ;; 1. whole-entry-disposition — the coarse root-prop owner classification
@@ -382,7 +393,9 @@
           e    (entry {:resource-id :secret/thing :data {:ssn "x"}})
           proj (ssr/project-resources-runtime-db (runtime-db-with {k e}))
           [wk we] (only-wire-entry proj)
-          installed {state/resources-key {:entries {wk we}}}
+          ;; rf2-9e0tyq — install the real byte-keyed projection; the plan
+          ;; names entries by their `:resource/key` (the projected wk).
+          installed proj
           plan (->> (ssr/hydrate-refetch-plan installed 5000)
                     (into {} (map (juxt :resource-key identity))))]
       (is (= privacy/redacted-sentinel (:data we)) "redacted (metadata only) on the wire")

--- a/implementation/resources/test/re_frame/resources_derived_scope_sensitivity_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_derived_scope_sensitivity_cljs_test.cljc
@@ -75,11 +75,20 @@
   (merge (state/empty-entry resource-id)
          {:status :loaded :data data :loaded-at 1000 :stale-at 9.0e15}))
 
+;; rf2-9e0tyq — re-key into the runtime's byte-`key-id` :entries shape, stamping
+;; each entry's `:resource/key`.
 (defn- runtime-db-with [entries]
-  {state/resources-key {:entries entries :tag-index {} :owner-index {}}})
+  {state/resources-key {:entries (into {}
+                                       (map (fn [[sk e]]
+                                              [(state/key-id sk) (assoc e :resource/key sk)]))
+                                       entries)
+                        :tag-index {} :owner-index {}}})
 
+;; the projected SCOPED KEY rides as the wire entry's `:resource/key` (the map
+;; key is the opaque byte id); return it as the first element.
 (defn- only-wire [proj]
-  (first (get-in proj [state/resources-key :entries])))
+  (let [we (val (first (get-in proj [state/resources-key :entries])))]
+    [(:resource/key we) we]))
 
 (defn- session-key [u page]
   (state/scoped-resource-key [:rf.scope/session {:username u}] :t/feed {:page page}))

--- a/implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc
@@ -87,7 +87,12 @@
 ;; ---- helpers --------------------------------------------------------------
 
 (defn- runtime-db [] (rf/runtime-db-value :rf/default))
-(defn- entries [] (get-in (runtime-db) (state/entries-path)))
+;; rf2-9e0tyq — `:entries` is keyed on the byte `key-id`; return a vector-keyed
+;; VIEW (re-keyed from each entry's `:resource/key`) so the assertions speak
+;; scoped-key vectors. Semantics unchanged.
+(defn- entries []
+  (into {} (map (fn [[_k-id e]] [(:resource/key e) e]))
+        (get-in (runtime-db) (state/entries-path))))
 (defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
 (defn- slice [] (get-in (runtime-db) [:rf.runtime/routing :current]))
 

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -370,7 +370,8 @@
     (succeed! k {:rev 1})
     (testing "first load produces version-1 tags"
       (is (= #{[:article "w"] [:rev 1]} (:tags (entry k))))
-      (is (= #{k} (get-in (runtime-db) (conj (state/tag-index-path) [:rev 1])))))
+      ;; rf2-9e0tyq — tag-index members are the byte key-id.
+      (is (= #{(state/key-id k)} (get-in (runtime-db) (conj (state/tag-index-path) [:rev 1])))))
     ;; refetch → data now rev 2 → tags REPLACED
     (rf/dispatch-sync [:rf.resource/refetch {:resource :tagrep/article :scope scope
                                              :params {:slug "w"}}])
@@ -380,7 +381,7 @@
               removed (stale list/detail relationships stop receiving
               invalidations)"
       (is (= #{[:article "w"] [:rev 2]} (:tags (entry k))) "entry tags replaced")
-      (is (= #{k} (get-in (runtime-db) (conj (state/tag-index-path) [:rev 2])))
+      (is (= #{(state/key-id k)} (get-in (runtime-db) (conj (state/tag-index-path) [:rev 2])))
           "new tag indexed")
       (is (nil? (get-in (runtime-db) (conj (state/tag-index-path) [:rev 1])))
           "OLD tag removed from the index (not accumulated)"))))
@@ -540,29 +541,34 @@
   (testing "Spec 016 §Stale and GC scheduling — timers live in a host SIDE
             TABLE keyed by [frame-id resource-key kind], NOT in frame-state"
     (timers/reset-cache!)
-    (let [k [:rf.scope/global :t/x {:id 1}]]
+    ;; rf2-9e0tyq — the side-table key's resource-key element is the CEDN-1
+    ;; byte `key-id` (so a list- and a vector-params resource never share a
+    ;; timer slot). The dispatched recheck event still carries the vector.
+    (let [k    [:rf.scope/global :t/x {:id 1}]
+          k-id (state/key-id k)]
       ;; arm a real (long) timer so it does not fire during the test
       (timers/schedule! :rf/default k timers/gc-kind 1000000)
-      (is (contains? @timers/timer-table [:rf/default k timers/gc-kind])
+      (is (contains? @timers/timer-table [:rf/default k-id timers/gc-kind])
           "the timer handle lives in the module-level side table")
       ;; the durable runtime-db carries NO timer handle
       (is (not (contains? (runtime-db) :rf.runtime/resources-timers))
           "no timer state leaked into runtime-db")
       (timers/cancel! :rf/default k timers/gc-kind)
-      (is (not (contains? @timers/timer-table [:rf/default k timers/gc-kind]))
+      (is (not (contains? @timers/timer-table [:rf/default k-id timers/gc-kind]))
           "cancel! drops the handle"))))
 
 (deftest timer-reschedule-cancels-prior
   (testing "Spec 016 — a re-load reschedules (cancel-then-arm), not accumulate"
     (timers/reset-cache!)
-    (let [k [:rf.scope/global :t/y {:id 1}]]
+    (let [k    [:rf.scope/global :t/y {:id 1}]
+          k-id (state/key-id k)]
       (timers/schedule! :rf/default k timers/stale-kind 1000000)
-      (let [h1 (get @timers/timer-table [:rf/default k timers/stale-kind])]
+      (let [h1 (get @timers/timer-table [:rf/default k-id timers/stale-kind])]
         (timers/schedule! :rf/default k timers/stale-kind 1000000)
-        (let [h2 (get @timers/timer-table [:rf/default k timers/stale-kind])]
+        (let [h2 (get @timers/timer-table [:rf/default k-id timers/stale-kind])]
           (is (not= h1 h2) "a fresh handle replaced the prior one")
           (is (= 1 (count (filter (fn [[[_ rk kind] _]]
-                                    (and (= rk k) (= kind timers/stale-kind)))
+                                    (and (= rk k-id) (= kind timers/stale-kind)))
                                   @timers/timer-table)))
               "exactly one live stale timer per [key kind]")))
       (timers/cancel-for-key! :rf/default k))))
@@ -718,13 +724,14 @@
         k     (state/scoped-resource-key scope :rmt/article {:slug "w"})]
     (ensure! :rmt/article scope "w" [:lease :rmt 1])
     (succeed! k {:title "W"})
-    ;; arm a real long timer so remove has something to cancel
+    ;; arm a real long timer so remove has something to cancel. rf2-9e0tyq —
+    ;; the timer side-table key's resource-key element is the byte key-id.
     (timers/schedule! :rf/default k timers/gc-kind 1000000)
-    (is (contains? @timers/timer-table [:rf/default k timers/gc-kind]))
+    (is (contains? @timers/timer-table [:rf/default (state/key-id k) timers/gc-kind]))
     (testing "Spec 016 §Events / §Stale and GC scheduling — :rf.resource/remove
               evicts the instance AND cancels its advisory timers"
       (rf/dispatch-sync [:rf.resource/remove {:resource :rmt/article :scope scope
                                               :params {:slug "w"}}])
       (is (nil? (entry k)) "instance removed")
-      (is (not (contains? @timers/timer-table [:rf/default k timers/gc-kind]))
+      (is (not (contains? @timers/timer-table [:rf/default (state/key-id k) timers/gc-kind]))
           "its GC timer cancelled"))))

--- a/implementation/resources/test/re_frame/resources_lifecycle_trace_ops_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_lifecycle_trace_ops_cljs_test.cljc
@@ -207,11 +207,13 @@
   (let [k-fresh [:rf.scope/global :h/fresh {:slug "f"}]
         k-stale [:rf.scope/global :h/stale {:slug "s"}]
         k-meta  [:rf.scope/global :h/meta  {:slug "m"}]]
+    ;; rf2-9e0tyq — `:entries` is keyed on the byte `key-id`; each entry carries
+    ;; its own `:resource/key` (the refetch plan reads it for :resource-id).
     {state/resources-key
      {:entries
-      {k-fresh {:status :loaded :data {:x 1} :loaded-at (- clock 10) :stale-at (+ clock 10000)}
-       k-stale {:status :loaded :data {:y 2} :loaded-at (- clock 20000) :stale-at (- clock 1)}
-       k-meta  {:status :loaded :data nil    :loaded-at (- clock 10) :stale-at (+ clock 10000)}}}}))
+      {(state/key-id k-fresh) {:resource/key k-fresh :status :loaded :data {:x 1} :loaded-at (- clock 10) :stale-at (+ clock 10000)}
+       (state/key-id k-stale) {:resource/key k-stale :status :loaded :data {:y 2} :loaded-at (- clock 20000) :stale-at (- clock 1)}
+       (state/key-id k-meta)  {:resource/key k-meta  :status :loaded :data nil    :loaded-at (- clock 10) :stale-at (+ clock 10000)}}}}))
 
 (deftest hydrate-refetch-emits-per-plan-entry
   (testing "hydrate-refetch-plan emits one :rf.resource/hydrate-refetch per

--- a/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_restore_cljs_test.cljc
@@ -83,11 +83,20 @@
 
 (defn- runtime-db-with
   "A runtime-db carrying a `:rf.runtime/resources :entries` map (and optional
-  `:rf.runtime/work-ledger`)."
+  `:rf.runtime/work-ledger`). rf2-9e0tyq: re-keys the natural
+  `{scoped-key-vector entry}` form into the runtime's byte-`key-id` shape
+  (stamping each entry's `:resource/key`), and re-keys the ledger from
+  `{work-id-vector record}` to the byte `work-id-id` shape."
   ([entries] (runtime-db-with entries nil))
   ([entries ledger]
-   (cond-> {state/resources-key {:entries entries :tag-index {} :owner-index {}}}
-     ledger (assoc state/work-ledger-key ledger))))
+   (cond-> {state/resources-key
+            {:entries (into {}
+                            (map (fn [[sk e]]
+                                   [(state/key-id sk) (assoc e :resource/key sk)]))
+                            entries)
+             :tag-index {} :owner-index {}}}
+     ledger (assoc state/work-ledger-key
+                   (into {} (map (fn [[wid r]] [(work-ledger/work-id-id wid) r])) ledger)))))
 
 (defn- with-live-nav-token
   "Install a restored routing slice naming `nav-token` as live
@@ -109,7 +118,7 @@
     (let [e   (entry {:resource-id :article/by-slug :status :loading :data nil
                       :current-work [:rf.work/resource gkey 3]})
           out (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries gkey])]
+          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
       (is (= :idle (:status se)) "loading-with-no-data → :idle, never stranded :loading")
       (is (nil? (:current-work se)) "the vanished current-work pointer is cleared"))))
 
@@ -120,7 +129,7 @@
                       :data {:title "kept"} :loaded-at 1000 :stale-at 9.0e15
                       :current-work [:rf.work/resource gkey 4]})
           out (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries gkey])]
+          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
       (is (= :loaded (:status se)) "fetching-with-data → :loaded (keep last-known-good)")
       (is (= {:title "kept"} (:data se)) "the last-known-good data is preserved")
       (is (nil? (:current-work se)) "the vanished current-work pointer is cleared"))))
@@ -132,7 +141,7 @@
           e   (entry {:resource-id :article/by-slug :status :loading :data nil
                       :error err :current-work [:rf.work/resource gkey 5]})
           out (ssr/reconcile-on-restore (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries gkey])]
+          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
       (is (= :error (:status se)) "loading-with-error-and-no-data → :error")
       (is (= err (:error se)) "the first-load error envelope is retained")
       (is (nil? (:current-work se))))))
@@ -149,9 +158,10 @@
           kc (state/scoped-resource-key :rf.scope/global :c {})
           out (ssr/reconcile-on-restore (runtime-db-with {ka loaded kb errd kc idle}) :app/main)
           es  (get-in out [state/resources-key :entries])]
-      (is (= :loaded (:status (es ka))))
-      (is (= :error  (:status (es kb))))
-      (is (= :idle   (:status (es kc)))))))
+      ;; rf2-9e0tyq — entries are keyed on the byte key-id.
+      (is (= :loaded (:status (es (state/key-id ka)))))
+      (is (= :error  (:status (es (state/key-id kb)))))
+      (is (= :idle   (:status (es (state/key-id kc))))))))
 
 (deftest settle-entry-to-last-stable-is-pure
   (testing "settle-entry-to-last-stable: the three in-flight resolutions + pass-through"
@@ -193,12 +203,15 @@
           kb (state/scoped-resource-key :rf.scope/global :b {})]
       (with-redefs [ssr/now-ms (constantly sentinel)]
         (let [out (ssr/reconcile-on-restore (runtime-db-with {ka loaded kb invalidated}) :app/main)
-              es  (get-in out [state/resources-key :entries])]
-          (is (= 1000 (:loaded-at (es ka))) ":loaded-at is the snapshot's, NOT the install clock")
-          (is (= 2000 (:stale-at  (es ka))) ":stale-at is the snapshot's, NOT the install clock")
-          (is (= 1000 (:loaded-at (es kb))) ":loaded-at (invalidated entry) is the snapshot's")
-          (is (= 8000 (:stale-at  (es kb))) ":stale-at (invalidated entry) is the snapshot's")
-          (is (= 1500 (:invalidated-at (es kb))) ":invalidated-at is the snapshot's, NOT the install clock")
+              es  (get-in out [state/resources-key :entries])
+              ;; rf2-9e0tyq — entries are keyed on the byte key-id.
+              ea (es (state/key-id ka))
+              eb (es (state/key-id kb))]
+          (is (= 1000 (:loaded-at ea)) ":loaded-at is the snapshot's, NOT the install clock")
+          (is (= 2000 (:stale-at  ea)) ":stale-at is the snapshot's, NOT the install clock")
+          (is (= 1000 (:loaded-at eb)) ":loaded-at (invalidated entry) is the snapshot's")
+          (is (= 8000 (:stale-at  eb)) ":stale-at (invalidated entry) is the snapshot's")
+          (is (= 1500 (:invalidated-at eb)) ":invalidated-at is the snapshot's, NOT the install clock")
           (is (not-any? #{sentinel}
                         (mapcat (juxt :loaded-at :stale-at :invalidated-at) (vals es)))
               "NO durable entry timestamp equals the stubbed install clock — restore re-read it nowhere durable"))))))
@@ -230,7 +243,8 @@
           out (ssr/reconcile-on-restore rdb :app/main)
           out-ledger (get out state/work-ledger-key)]
       (doseq [wid [w-running w-queued w-abort]]
-        (let [row (get out-ledger wid)]
+        ;; rf2-9e0tyq — the ledger is keyed on the byte work-id-id.
+        (let [row (get out-ledger (work-ledger/work-id-id wid))]
           (is (= :suppressed (:status row))
               (str wid " settled to terminal :suppressed"))
           (is (work-ledger/terminal? (:status row))
@@ -248,7 +262,7 @@
                                              :loaded-at 1 :stale-at 9.0e15})}
                                {w-done row})
           out (ssr/reconcile-on-restore rdb :app/main)]
-      (is (= row (get-in out [state/work-ledger-key w-done]))
+      (is (= row (get-in out [state/work-ledger-key (work-ledger/work-id-id w-done)]))
           "a completed row is unchanged"))))
 
 (deftest dangle-non-terminal-work-returns-dangled-ids
@@ -406,7 +420,7 @@
          {:kind :success :value {:title "STALE pre-restore write"}}]
         {:frame fid})
       (let [post (frame/frame-runtime-db-value fid)
-            e    (get-in post [state/resources-key :entries gkey])]
+            e    (get-in post [state/resources-key :entries (state/key-id gkey)])]
         (is (= {:title "post-restore"} (:data e))
             "the resource entry is UNCHANGED — the stale reply did not patch/populate it")
         (is (= :error (get-in post [mstate/mutations-key instance-id :status]))
@@ -430,7 +444,7 @@
           ;; names the same nav-token, so it revives (Spec 016 §Restore part 4).
           rdb (with-live-nav-token (runtime-db-with {gkey e}) "nav-1")
           out (ssr/reconcile-on-restore rdb :app/main)
-          owners (get-in out [state/resources-key :entries gkey :active-owners])]
+          owners (get-in out [state/resources-key :entries (state/key-id gkey) :active-owners])]
       (is (not (contains? owners [:ssr "req-9" "nav-1"])) "SSR owner orphaned")
       (is (contains? owners [:route :route/article "nav-1"])
           "live-nav route owner survives (its nav-token is the one routing names live)")
@@ -455,7 +469,7 @@
           ;; navigation the timeline has already left.
           rdb (with-live-nav-token (runtime-db-with {gkey e}) "nav-NEW")
           out (ssr/reconcile-on-restore rdb :app/main)
-          owners (get-in out [state/resources-key :entries gkey :active-owners])]
+          owners (get-in out [state/resources-key :entries (state/key-id gkey) :active-owners])]
       (is (not (contains? owners stale))
           "the stale-nav route owner (nav-OLD ≠ live nav-NEW) is orphaned")
       (is (contains? owners live)
@@ -493,7 +507,7 @@
                                     [:machine :checkout/flow "inst-1"]
                                     [:lease :dashboard 7]}})
               out (ssr/reconcile-on-restore (rdb-fn (runtime-db-with {gkey e})) :app/main)
-              owners (get-in out [state/resources-key :entries gkey :active-owners])]
+              owners (get-in out [state/resources-key :entries (state/key-id gkey) :active-owners])]
           (is (not (contains? owners route-owner))
               "the route owner is ORPHANED (no live nav-token names it live)")
           (is (not (contains? owners [:ssr "req-9" "nav-1"])) "SSR owner orphaned")
@@ -563,7 +577,7 @@
       (is (seq (-> out meta (get :re-frame.resources.ssr/deferred-trace-intents)))
           "the trace intents ride back as metadata on the reconciled runtime-db")
       ;; the reconcile work still happened (the stale owner was orphaned)
-      (is (not (contains? (get-in out [state/resources-key :entries gkey :active-owners]) stale))
+      (is (not (contains? (get-in out [state/resources-key :entries (state/key-id gkey) :active-owners]) stale))
           "the stale-nav owner is still reconciled (only the TRACE is deferred)"))))
 
 (deftest commit-restore-reconcile-traces-emits-deferred-rows
@@ -621,7 +635,7 @@
                       :loaded-at 1 :stale-at 9.0e15
                       :owners #{[:ssr "req-9" "nav-1"] route-owner}})
           out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
-          owners (get-in out [state/resources-key :entries gkey :active-owners])]
+          owners (get-in out [state/resources-key :entries (state/key-id gkey) :active-owners])]
       (is (not (contains? owners [:ssr "req-9" "nav-1"]))
           "SSR owner still orphans on hydration")
       (is (contains? owners route-owner)
@@ -641,15 +655,19 @@
           ;; name nav-1 live so the route owner SURVIVES (rf2-64bdnk) — this
           ;; test pins the index RECOMPUTE, not owner orphaning; without a live
           ;; token the route owner would now correctly orphan.
-          rdb (-> {state/resources-key {:entries     {gkey e}
-                                        :tag-index   {[:bogus] #{:nope}}
-                                        :owner-index {[:bogus] #{:nope}}}}
+          ;; rf2-9e0tyq — build via runtime-db-with (byte-keyed + :resource/key
+          ;; stamped), then overwrite the indexes with deliberately-wrong
+          ;; snapshot values to prove they are discarded + recomputed.
+          rdb (-> (runtime-db-with {gkey e})
+                  (assoc-in [state/resources-key :tag-index]   {[:bogus] #{:nope}})
+                  (assoc-in [state/resources-key :owner-index] {[:bogus] #{:nope}})
                   (with-live-nav-token "nav-1"))
           out (ssr/reconcile-on-restore rdb :app/main)
           sub (get out state/resources-key)]
-      (is (= {[:article "x"] #{gkey}} (:tag-index sub))
+      ;; rf2-9e0tyq — index MEMBERS are the byte key-id, not the scoped-key vector.
+      (is (= {[:article "x"] #{(state/key-id gkey)}} (:tag-index sub))
           "tag-index recomputed from the entry's :tags; bogus snapshot index discarded")
-      (is (= {[:route :route/article "nav-1"] #{gkey}} (:owner-index sub))
+      (is (= {[:route :route/article "nav-1"] #{(state/key-id gkey)}} (:owner-index sub))
           "owner-index recomputed from the entry's owners; bogus snapshot index discarded"))))
 
 ;; ===========================================================================
@@ -765,7 +783,7 @@
       ;; the reconcile returns a runtime-db, never an fx vector / dispatch plan
       (is (map? out))
       (is (contains? out state/resources-key))
-      (is (= {:x 1} (get-in out [state/resources-key :entries gkey :data]))
+      (is (= {:x 1} (get-in out [state/resources-key :entries (state/key-id gkey) :data]))
           "the stale entry keeps its data; restore double-fetches nothing"))))
 
 (deftest restore-noop-without-resources
@@ -785,10 +803,12 @@
                      :loaded-at 1 :stale-at 9.0e15 :tags #{[:article "x"]}})
           out (ssr/reconcile-on-restore (runtime-db-with {ka ea kb eb}) :app/main)
           es  (get-in out [state/resources-key :entries])]
-      (is (= {:owner "a"} (:data (es ka))) "scope-a data stays under scope-a's key")
-      (is (= :loaded (:status (es ka))) "scope-a fetching → loaded (kept data)")
-      (is (= {:owner "b"} (:data (es kb))) "scope-b data stays under scope-b's key")
-      (is (= #{ka kb} (get-in out [state/resources-key :tag-index [:article "x"]]))
+      ;; rf2-9e0tyq — entries + tag-index members are keyed on the byte key-id.
+      (is (= {:owner "a"} (:data (es (state/key-id ka)))) "scope-a data stays under scope-a's key")
+      (is (= :loaded (:status (es (state/key-id ka)))) "scope-a fetching → loaded (kept data)")
+      (is (= {:owner "b"} (:data (es (state/key-id kb)))) "scope-b data stays under scope-b's key")
+      (is (= #{(state/key-id ka) (state/key-id kb)}
+             (get-in out [state/resources-key :tag-index [:article "x"]]))
           "the shared tag maps to both scoped keys, never collapsed"))))
 
 (deftest reconcile-on-restore-hook-published

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -194,92 +194,64 @@
     (is (= (state/canonicalize {:a 1 :b 2})
            (state/canonicalize {:b 2 :a 1})))))
 
-;; rf2-o84qq2 (EP-0012 final-review, DEFERRED — full fix planned in
-;; rf2-9e0tyq): the scoped resource key is the CEDN-1 canonical VECTOR
-;; `[scope rid params]` used DIRECTLY as a Clojure map key in the `:entries`
-;; cache. Clojure map keys compare by `=` + hash, and `(= [1 2 3] '(1 2 3))`
-;; is TRUE — so a vector-params key and a list-params key, though they carry
-;; DISTINCT authoritative CEDN-1 identities (the test above), still COLLAPSE
-;; to one entry at the map-keying layer. The map-key `=` is COARSER than the
-;; CEDN-1 byte identity for the list-vs-vector edge.
-;;
-;; This pins the KNOWN, deliberately-deferred limitation so it cannot
-;; silently shift, and pins its EXACT NARROWNESS so a future canonical-bytes
-;; re-keying (rf2-9e0tyq) has concrete invariants to flip:
-;;
-;;   1. the collapse is confined to SEQUENTIAL vector-vs-list — the SOLE
-;;      `=`-vs-CEDN-1 divergence in the EDN domain. Every OTHER kind that can
-;;      appear in params (strings / keywords / numbers / maps / sets / uuids)
-;;      is `=`-distinct iff CEDN-1-distinct, so the cache keys them CORRECTLY
-;;      today (asserted below). A future fix must keep those correct.
-;;   2. the SAME single-collapse propagates IDENTICALLY into the embedded
-;;      work-id `[:rf.work/resource <scoped-key> <generation>]` (asserted
-;;      below) — the work-id is the second carrier of the scoped key (also a
-;;      runtime-db map key and the stale-suppression `=` basis), so the two
-;;      carriers move together and the full fix must re-key BOTH.
-;;
-;; The correct fix (keying `:entries` + the work-id on `canonical-bytes`
-;; rather than the canonical EDN value under `=`) is a cross-cutting re-keying
-;; refactor — the scoped vector is destructured as `[scope rid params]` and
-;; used as a `get-in`/`assoc-in` path component across events, the reverse
-;; tag/owner indexes, mutation descriptors, the work-ledger work-id, the SSR
-;; hydration wire, tooling, and the subs layer — far beyond a surgical change,
-;; and a deftype key would silently break the (untested-here) SSR/epoch/trace
-;; serialization wire (see rf2-9e0tyq for the full blast-radius analysis). The
-;; edge is extremely narrow (a LIST as a resource params value; params are
-;; typically Malli `:map`s of scalars/vectors, never lists). The competing
-;; "normalize list→vector" fix is REJECTED: it would re-erase the CEDN-1
-;; list-vs-vector kind distinction rf2-wgutc2 deliberately introduced (the
-;; test above). Deferred per the rf2-o84qq2 triage → rf2-9e0tyq plan; this
-;; pin is the target that re-keying would flip from collapse to distinctness.
-(deftest scoped-key-map-collapse-is-a-known-deferred-edge-rf2-o84qq2
+;; rf2-9e0tyq (full fix; was the rf2-o84qq2 deferred-edge pin): the scoped
+;; resource key carries a kind-PRESERVING canonical VECTOR `[scope rid params]`
+;; (a list value stays a list, distinct from a vector — rf2-wgutc2), but it is
+;; NO LONGER used directly as a Clojure map key. The `:entries` map, the
+;; reverse indexes, and the work-ledger map are keyed on the CEDN-1 byte
+;; `key-id` (`state/key-id` / `work-ledger/work-id-id`), so the map-key
+;; comparison is EXACTLY the CEDN-1 byte identity. Clojure `=` collapses
+;; `(= [1 2 3] '(1 2 3))` to TRUE, but two distinct `canonical-bytes` strings
+;; never collapse — so a list-params key and a vector-params key get DISTINCT
+;; entries AND distinct work-ids. This flips the former rf2-o84qq2 pin from
+;; documenting-the-collapse to asserting-distinctness (the bead's acceptance
+;; criterion). The fix is NOT a list→vector normalize (that would re-erase the
+;; CEDN-1 kind distinction rf2-wgutc2 introduced — the test above).
+(deftest list-vs-vector-params-get-distinct-entries-rf2-9e0tyq
   (testing "list-vs-vector params keys carry DISTINCT CEDN-1 identities..."
     (let [kv (state/scoped-resource-key :rf.scope/global :r/x {:xs [1 2 3]})
           kl (state/scoped-resource-key :rf.scope/global :r/x {:xs '(1 2 3)})]
       (is (not (identity/identical-identity? kv kl))
           "the authoritative identities differ (v[...] vs l(...))")
-      ;; ...yet Clojure `=` (the map-key comparator) does NOT discriminate
-      ;; them, so they collapse to ONE entry in an `:entries`-shaped map.
-      (testing "...but COLLAPSE under Clojure = at the :entries map-keying layer
-                (the known deferred limitation)"
-        (is (= kv kl)
-            "Clojure value = treats the vector- and list-params keys as equal")
-        (is (= 1 (count (-> {} (assoc kv :v) (assoc kl :l))))
-            "both keys map to ONE entry — the coarser-than-CEDN-1 collapse")
-        (is (= :l (get (-> {} (assoc kv :v) (assoc kl :l)) kv))
-            "the second write wins under =, confirming the single-slot collapse"))
-      ;; The SAME single-collapse rides into the embedded work-id (carrier 2),
-      ;; so the full re-keying must move both carriers together (rf2-9e0tyq).
-      (testing "...and propagates identically into the embedded work-id
-                `[:rf.work/resource <scoped-key> <generation>]`"
+      ;; Clojure `=` still treats the VECTORS as equal — but the cache no longer
+      ;; keys on the vector; it keys on the byte `key-id`, which is DISTINCT.
+      (is (= kv kl)
+          "Clojure value = treats the vector- and list-params VECTORS as equal …")
+      (testing "...and now resolve to DISTINCT :entries entries (the byte key-id
+                comparison is exactly the CEDN-1 identity — the fix)"
+        (is (not= (state/key-id kv) (state/key-id kl))
+            "their byte key-ids differ (v[…] vs l(…)) — the map-key identity")
+        (is (= 2 (count (-> {}
+                            (assoc (state/key-id kv) :v)
+                            (assoc (state/key-id kl) :l))))
+            "both keys map to TWO distinct entries — the =-collapse is closed")
+        (is (= :v (get (-> {}
+                           (assoc (state/key-id kv) :v)
+                           (assoc (state/key-id kl) :l))
+                       (state/key-id kv)))
+            "the vector-params entry is NOT overwritten by the list-params write"))
+      ;; carrier 2 — the embedded work-id is keyed on its OWN byte id too, so
+      ;; the two work-ledger slots stay distinct (stale suppression keys on the
+      ;; entry's :current-work + the entry lookup, both byte-disambiguated).
+      (testing "...and the embedded work-id keys on its own byte id (carrier 2)"
         (let [wv (work-ledger/resource-work-id kv 1)
               wl (work-ledger/resource-work-id kl 1)]
-          (is (= wv wl)
-              "the vector- and list-params work-ids collapse under = too")
-          (is (= 1 (count (-> {} (assoc wv :v) (assoc wl :l))))
-              "both work-ids map to ONE work-ledger slot — same coarse collapse")))))
-  ;; Pin the EXACT NARROWNESS: the collapse is ONLY sequential vector-vs-list.
-  ;; Every other CEDN-distinct params kind is ALSO `=`-distinct, so the cache
-  ;; keys them correctly TODAY — the deferred edge does not leak beyond seqs.
-  (testing "the edge is CONFINED to vector-vs-list — every other CEDN-distinct
-            params kind is also =-distinct, so the cache keys it correctly"
-    (let [k (fn [params] (state/scoped-resource-key :rf.scope/global :r/x params))]
-      ;; string "1" vs integer 1 vs keyword :1 — distinct CEDN-1 AND distinct =
-      (is (= 3 (count (-> {}
-                          (assoc (k {:v "1"}) :s)
-                          (assoc (k {:v 1})   :i)
-                          (assoc (k {:v :a})  :k))))
+          (is (= wv wl) "the work-id VECTORS are still `=` (they embed the key vector) …")
+          (is (not= (work-ledger/work-id-id wv) (work-ledger/work-id-id wl))
+              "…but their byte work-id-ids differ — distinct ledger slots")
+          (is (= 2 (count (-> {}
+                              (assoc (work-ledger/work-id-id wv) :v)
+                              (assoc (work-ledger/work-id-id wl) :l))))
+              "both work-ids map to TWO distinct work-ledger slots")))))
+  ;; The other CEDN-distinct params kinds were already `=`-distinct and stay
+  ;; keyed correctly (the fix never regresses them).
+  (testing "every other CEDN-distinct params kind also keys distinctly"
+    (let [k (fn [params] (state/key-id (state/scoped-resource-key :rf.scope/global :r/x params)))]
+      (is (= 3 (count (-> {} (assoc (k {:v "1"}) :s) (assoc (k {:v 1}) :i) (assoc (k {:v :a}) :k))))
           "string / integer / keyword params keep distinct cache entries")
-      ;; a set vs a vector with the same elements — distinct CEDN-1 AND `=`
-      (is (= 2 (count (-> {}
-                          (assoc (k {:v #{1 2}}) :set)
-                          (assoc (k {:v [1 2]}) :vec))))
+      (is (= 2 (count (-> {} (assoc (k {:v #{1 2}}) :set) (assoc (k {:v [1 2]}) :vec))))
           "set-params and vector-params keep distinct cache entries")
-      ;; map insertion-order independence still collapses to ONE (correct: the
-      ;; canonical rule reorders, so these are the SAME identity, not the edge)
-      (is (= 1 (count (-> {}
-                          (assoc (k {:a 1 :b 2}) :ab)
-                          (assoc (k {:b 2 :a 1}) :ba))))
+      (is (= 1 (count (-> {} (assoc (k {:a 1 :b 2}) :ab) (assoc (k {:b 2 :a 1}) :ba))))
           "key-order-only-different maps are ONE entry (canonical, not the edge)"))))
 
 ;; ===========================================================================
@@ -963,7 +935,8 @@
     (is (contains? (registrar/registrations mreg/mutation-kind) :rst/save))
     (is (= 7 (state/generation-snapshot :rf/default)))
     (is (some? (work-ledger/get-handle :rf/default work-id)))
-    (is (contains? @timers/timer-table [:rf/default k timers/gc-kind]))
+    ;; rf2-9e0tyq — the timer side-table key's resource-key element is the byte key-id.
+    (is (contains? @timers/timer-table [:rf/default (state/key-id k) timers/gc-kind]))
     (is (contains? @revalidate-listeners/listener-table :rf/default))
     (testing "rf2-784223 — `reset-resources!` clears the resource + mutation
               registrars AND the generation / work-ledger-handle / timer /

--- a/implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_scope_leak_boundary_cljs_test.cljc
@@ -97,7 +97,12 @@
 ;; ---- helpers --------------------------------------------------------------
 
 (defn- runtime-db [] (rf/runtime-db-value :rf/default))
-(defn- entries [] (get-in (runtime-db) (state/entries-path)))
+;; rf2-9e0tyq — `:entries` is keyed on the byte `key-id`; return a vector-keyed
+;; VIEW (re-keyed from each entry's `:resource/key`) so the scope-isolation
+;; assertions speak scoped-key vectors. Semantics unchanged.
+(defn- entries []
+  (into {} (map (fn [[_k-id e]] [(:resource/key e) e]))
+        (get-in (runtime-db) (state/entries-path))))
 (defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
 
 (defn- tenant-key

--- a/implementation/resources/test/re_frame/resources_scoped_lease_lifecycle_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_scoped_lease_lifecycle_cljs_test.cljc
@@ -81,9 +81,22 @@
 ;; ---- helpers --------------------------------------------------------------
 
 (defn- runtime-db [] (rf/runtime-db-value :rf/default))
-(defn- entries [] (get-in (runtime-db) (state/entries-path)))
+;; rf2-9e0tyq — `:entries` is keyed on the opaque byte `key-id`; this test
+;; reasons about scoped-key VECTORS, so `entries` returns a vector-keyed VIEW
+;; (re-keyed from each entry's `:resource/key`) and `owner-index` returns the
+;; index with its member byte-ids mapped back to the scoped-key vectors. The
+;; semantics (which keys/owners map where) are unchanged.
+(defn- entries []
+  (into {} (map (fn [[_k-id e]] [(:resource/key e) e]))
+        (get-in (runtime-db) (state/entries-path))))
 (defn- entry [scoped-key] (get-in (runtime-db) (state/entry-path scoped-key)))
-(defn- owner-index [] (get-in (runtime-db) (state/owner-index-path)))
+(defn- owner-index []
+  (let [rdb (runtime-db)
+        es  (get-in rdb (state/entries-path))
+        id->sk (into {} (map (fn [[k-id e]] [k-id (:resource/key e)])) es)]
+    (into {} (map (fn [[owner members]]
+                    [owner (into #{} (map #(get id->sk % %)) members)]))
+          (get-in rdb (state/owner-index-path)))))
 
 (defn- tenant-key
   "The scoped feed key for tenant `t`, page `page`."

--- a/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_ssr_cljs_test.cljc
@@ -119,9 +119,31 @@
           :refresh-error  refresh-error}))
 
 (defn- runtime-db-with
-  "A runtime-db carrying a `:rf.runtime/resources :entries` map."
+  "A runtime-db carrying a `:rf.runtime/resources :entries` map. rf2-9e0tyq:
+  the runtime keys `:entries` on the CEDN-1 byte `key-id` and stamps each
+  entry's own `:resource/key` vector, so this helper RE-KEYS the
+  `{scoped-key-vector entry}` map callers supply into the runtime's
+  `{key-id (assoc entry :resource/key scoped-key)}` shape — the call sites
+  stay written in the natural scoped-key-vector form."
   [entries]
-  {state/resources-key {:entries entries :tag-index {} :owner-index {}}})
+  {state/resources-key {:entries (into {}
+                                       (map (fn [[sk e]]
+                                              [(state/key-id sk) (assoc e :resource/key sk)]))
+                                       entries)
+                        :tag-index {} :owner-index {}}})
+
+;; rf2-9e0tyq — the runtime keys `:entries` on the CEDN-1 byte `key-id` and
+;; stamps each entry's `:resource/key`. These helpers build / read the
+;; byte-keyed `:entries` map directly so the unit tests speak the runtime's
+;; shape (the `key-id` translation is what `blocking-settled?` /
+;; `settle-blocking-timeout` / the drain loop / projection apply to the
+;; scoped-key vectors).
+(defn- entries*
+  "Build a byte-keyed `:entries` map from `{scoped-key-vector entry}`,
+  stamping each entry's `:resource/key` (mirrors `runtime-db-with`)."
+  [m]
+  (into {} (map (fn [[sk e]] [(state/key-id sk) (assoc e :resource/key sk)])) m))
+(defn- entry-by [entries sk] (get entries (state/key-id sk)))
 
 (def ^:private gkey
   ;; canonical global-scope key for :article/by-slug {:slug "x"}
@@ -145,7 +167,7 @@
           "only the :rf.runtime/resources subsystem key is projected")
       (is (= #{:entries} (set (keys (get proj state/resources-key))))
           "only :entries rides — indexes are recomputable-from-entries")
-      (is (contains? (get-in proj [state/resources-key :entries]) gkey)))))
+      (is (contains? (get-in proj [state/resources-key :entries]) (state/key-id gkey))))))
 
 (deftest projection-empty-when-no-entries
   (testing "no resource entries → empty projection (the hook contributes nothing)"
@@ -153,11 +175,16 @@
     (is (= {} (ssr/project-resources-runtime-db (runtime-db-with {}))))))
 
 (defn- only-wire-entry
-  "The single projected wire entry `[wire-key wire-entry]` from a one-entry
-  projection (the projected key may be redacted, so callers can't look it up
-  by the raw key — rf2-otms75)."
+  "The single projected wire entry as `[projected-scoped-key wire-entry]` from
+  a one-entry projection. rf2-9e0tyq: the projection MAP is keyed on the
+  opaque byte `key-id`; the projected SCOPED KEY (scope+params verbatim for a
+  `:serialize` resource, redacted for `:sensitive?` / `:large?`) rides as the
+  wire entry's own `:resource/key`. The privacy/distinctness assertions are
+  about that projected scoped key, so this returns it as the first element
+  (the byte map-key is exercised separately by the byte-keying tests)."
   [proj]
-  (first (get-in proj [state/resources-key :entries])))
+  (let [we (val (first (get-in proj [state/resources-key :entries])))]
+    [(:resource/key we) we]))
 
 (deftest sensitive-resource-is-redacted
   (reg! :secret/thing {:sensitive? true})
@@ -214,9 +241,14 @@
           k-stale (state/scoped-resource-key :rf.scope/global :article/by-slug {:slug "y"})
           k-sens  (state/scoped-resource-key :rf.scope/global :secret/thing {:slug "s"})
           k-big   (state/scoped-resource-key :rf.scope/global :big/thing {:slug "b"})
+          ;; rf2-9e0tyq — `projection-metadata` reads each entry's own
+          ;; `:resource/key` (the `:entries` map is byte-keyed), so stamp it
+          ;; (mirrors the runtime's byte-keyed `:entries` shape). The returned
+          ;; metadata `:resource-key` is the scoped-key VECTOR, so the
+          ;; `(metas k-…)` vector lookups below stay unchanged.
           metas   (->> (ssr/projection-metadata
                          nil 5000
-                         {k-fresh fresh k-stale stale k-sens sens k-big big})
+                         (entries* {k-fresh fresh k-stale stale k-sens sens k-big big}))
                        (into {} (map (juxt :resource-key identity))))]
       (is (= :serialized (:disposition (metas k-fresh))))
       (is (= :fresh      (:freshness   (metas k-fresh))))
@@ -277,14 +309,20 @@
           e1 (entry {:resource-id :secret/thing :data {:s 1} :loaded-at 1000 :stale-at 9.0e15})
           e2 (entry {:resource-id :secret/thing :data {:s 2} :loaded-at 1000 :stale-at 9.0e15})
           proj (ssr/project-resources-runtime-db (runtime-db-with {k1 e1 k2 e2}))
-          wks  (set (keys (get-in proj [state/resources-key :entries])))]
-      (is (= 2 (count wks)) "two distinct entries → two distinct wire keys (no collision)")
+          ;; rf2-9e0tyq — the wire MAP is byte-keyed (distinct byte ids prove no
+          ;; collision); the projected (redacted) scoped keys live as each wire
+          ;; entry's `:resource/key`.
+          wire-entries (vals (get-in proj [state/resources-key :entries]))
+          wks  (set (map :resource/key wire-entries))]
+      (is (= 2 (count (set (keys (get-in proj [state/resources-key :entries])))))
+          "two distinct entries → two distinct byte wire keys (no collision)")
+      (is (= 2 (count wks)) "two distinct projected (redacted) scoped keys (no collision)")
       (is (every? (fn [wk] (= :secret/thing (nth wk 1))) wks)
-          "both wire keys preserve the resource-id")
+          "both projected keys preserve the resource-id")
       (is (every? (fn [wk] (and (contains? (nth wk 2) :rf/redacted)
                                 (not= {:slug "alpha"} (nth wk 2))
                                 (not= {:slug "beta"} (nth wk 2)))) wks)
-          "neither wire key carries the raw params"))))
+          "neither projected key carries the raw params"))))
 
 (deftest project-scoped-key-is-pure
   (testing "project-scoped-key: :serialize rides verbatim; :redact/:omit redact
@@ -315,7 +353,7 @@
     (let [loaded  (entry {:resource-id :a :status :loaded :data {:x 1}})
           errored (entry {:resource-id :b :status :error})
           loading (entry {:resource-id :c :status :loading})
-          es      {ka loaded kb errored kc loading}]
+          es      (entries* {ka loaded kb errored kc loading})]
       (is (true?  (ssr/blocking-settled? es #{ka kb}))
           ":loaded and :error are settled")
       (is (false? (ssr/blocking-settled? es #{ka kc}))
@@ -330,17 +368,17 @@
             structured first-load failure + a route-blocking-failure record (never hangs)"
     (let [loading (entry {:resource-id :a :status :loading})
           loaded  (entry {:resource-id :b :status :loaded :data {:x 1}})
-          es      {ka loading kb loaded}
+          es      (entries* {ka loading kb loaded})
           {:keys [entries route-blocking-failure]}
           (ssr/settle-blocking-timeout es #{ka kb} 250 :app/main)]
       (testing "the unsettled blocking entry settles to a first-load :error"
-        (let [se (get entries ka)]
+        (let [se (entry-by entries ka)]
           (is (= :error (:status se)))
           (is (= :rf.http/timeout (:kind (:error se))))
           (is (= :ssr-blocking-timeout (:reason (:error se))))
           (is (nil? (:data se)) "first-load failure has no usable data")))
       (testing "the already-settled entry is untouched"
-        (is (= :loaded (:status (get entries kb)))))
+        (is (= :loaded (:status (entry-by entries kb)))))
       (testing "the route-blocking-failure record names the timed-out keys + deadline"
         (is (= :rf.error/resource-ssr-blocking-timeout (:rf.error/id route-blocking-failure)))
         (is (= #{ka} (set (:timed-out route-blocking-failure))))
@@ -348,7 +386,7 @@
 
 (deftest blocking-timeout-noop-when-all-settled
   (testing "no unsettled blocking entries → no failure record, entries unchanged"
-    (let [es {ka (entry {:resource-id :a :status :loaded :data {:x 1}})}
+    (let [es (entries* {ka (entry {:resource-id :a :status :loaded :data {:x 1}})})
           {:keys [entries route-blocking-failure]}
           (ssr/settle-blocking-timeout es #{ka} 250 :app/main)]
       (is (= es entries))
@@ -359,7 +397,8 @@
     (let [kmiss (state/scoped-resource-key :rf.scope/global :missing {})
           {:keys [entries route-blocking-failure]}
           (ssr/settle-blocking-timeout {} #{kmiss} 100 :app/main)]
-      (is (= :error (:status (get entries kmiss))))
+      ;; rf2-9e0tyq — the settled entry is keyed on the byte key-id.
+      (is (= :error (:status (entry-by entries kmiss))))
       (is (= #{kmiss} (set (:timed-out route-blocking-failure)))))))
 
 ;; ===========================================================================
@@ -426,7 +465,7 @@
       (is (true? (:settled? res)))
       (is (nil? (:route-blocking-failure res)))
       (is (= :loaded (get-in (frame/frame-runtime-db-value fid)
-                             [state/resources-key :entries ka :status]))
+                             [state/resources-key :entries (state/key-id ka) :status]))
           "the settled entry is untouched")
       (frame/destroy-frame! fid))))
 
@@ -442,13 +481,14 @@
           pump! (fn [_]
                   (when (= 2 (swap! ticks inc))
                     (frame/swap-runtime-db!
-                      fid assoc-in [state/resources-key :entries ka]
-                      (entry {:resource-id :a :status :loaded :data {:x 1}}))))
+                      fid assoc-in [state/resources-key :entries (state/key-id ka)]
+                      (assoc (entry {:resource-id :a :status :loaded :data {:x 1}})
+                             :resource/key ka))))
           res   (ssr/drain-blocking-resources! fid {:pump! pump! :deadline-ms 60000})]
       (is (true? (:settled? res)) "the loop settled once the reply landed")
       (is (nil? (:route-blocking-failure res)) "no timeout — it settled in time")
       (is (= {:x 1} (get-in (frame/frame-runtime-db-value fid)
-                            [state/resources-key :entries ka :data])))
+                            [state/resources-key :entries (state/key-id ka) :data])))
       (frame/destroy-frame! fid))))
 
 (deftest drain-times-out-a-never-settling-blocking-resource
@@ -469,7 +509,7 @@
         (is (false? (:settled? res)) "the loop reported a timeout, not a settle")
         (is (= #{ka} (:timed-out res)))
         (let [se (get-in (frame/frame-runtime-db-value fid)
-                         [state/resources-key :entries ka])]
+                         [state/resources-key :entries (state/key-id ka)])]
           (is (= :error (:status se))
               "the never-settling blocking entry is SETTLED to :error, not left :loading")
           (is (= :rf.http/timeout (:kind (:error se))))
@@ -491,7 +531,7 @@
                 fid {:pump! nil :deadline-ms 50 :clock-fn clock-fn})]
       (is (false? (:settled? res)))
       (is (= :error (get-in (frame/frame-runtime-db-value fid)
-                            [state/resources-key :entries ka :status])))
+                            [state/resources-key :entries (state/key-id ka) :status])))
       (frame/destroy-frame! fid))))
 
 (deftest drain-hook-published
@@ -684,7 +724,7 @@
                       :owners #{[:ssr "req-7" "nav-1"]
                                 [:route :route/article "nav-1"]}})
           out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
-          owners (get-in out [state/resources-key :entries gkey :active-owners])]
+          owners (get-in out [state/resources-key :entries (state/key-id gkey) :active-owners])]
       (is (not (contains? owners [:ssr "req-7" "nav-1"]))
           "the SSR owner is dropped as an orphan")
       (is (contains? owners [:route :route/article "nav-1"])
@@ -699,15 +739,15 @@
                       :loaded-at 1000 :stale-at 9.0e15
                       :current-work [:rf.work/resource gkey 1]})
           out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)]
-      (is (nil? (get-in out [state/resources-key :entries gkey :current-work]))))))
+      (is (nil? (get-in out [state/resources-key :entries (state/key-id gkey) :current-work]))))))
 
 (deftest hydrate-preserves-entry-data
   (testing "hydrated entries are PRESERVED (data + status survive the reconcile)"
     (let [e   (entry {:resource-id :article/by-slug :data {:t "kept"}
                       :loaded-at 1000 :stale-at 9.0e15})
           out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)]
-      (is (= {:t "kept"} (get-in out [state/resources-key :entries gkey :data])))
-      (is (= :loaded (get-in out [state/resources-key :entries gkey :status]))))))
+      (is (= {:t "kept"} (get-in out [state/resources-key :entries (state/key-id gkey) :data])))
+      (is (= :loaded (get-in out [state/resources-key :entries (state/key-id gkey) :status]))))))
 
 (deftest hydrate-noop-without-resources
   (testing "a runtime-db with no resource entries is returned unchanged (SSR app without resources)"
@@ -733,7 +773,7 @@
             (never stranded :loading), and the refetch plan then refetches it"
     (let [e   (entry {:resource-id :article/by-slug :status :loading :data nil})
           out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries gkey])]
+          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
       (is (= :idle (:status se)) "loading-with-no-data → :idle, never a dangling :loading")
       (let [plan (->> (ssr/hydrate-refetch-plan out 5000)
                       (into {} (map (juxt :resource-key identity))))]
@@ -747,7 +787,7 @@
     (let [e   (entry {:resource-id :article/by-slug :status :fetching
                       :data {:t "fresh"} :loaded-at 1000 :stale-at 9.0e15})
           out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries gkey])]
+          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
       (is (= :loaded (:status se)) "fetching-with-fresh-data → :loaded (keep last-known-good)")
       (is (= {:t "fresh"} (:data se)) "the data is preserved")
       (let [plan (->> (ssr/hydrate-refetch-plan out 5000)
@@ -761,7 +801,7 @@
     (let [e   (entry {:resource-id :article/by-slug :status :fetching
                       :data {:t "stale"} :loaded-at 1000 :stale-at 1500})  ;; stale vs 5000
           out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries gkey])]
+          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
       (is (= :loaded (:status se)) "fetching-with-stale-data → :loaded")
       (is (= {:t "stale"} (:data se)) "the stale last-known-good data is preserved")
       (let [plan (->> (ssr/hydrate-refetch-plan out 5000)
@@ -775,7 +815,7 @@
     (let [e   (entry {:resource-id :article/by-slug :status :loaded
                       :data {:t "kept"} :loaded-at 1000 :stale-at 9.0e15})
           out (ssr/hydrate-runtime-db (runtime-db-with {gkey e}) :app/main)
-          se  (get-in out [state/resources-key :entries gkey])]
+          se  (get-in out [state/resources-key :entries (state/key-id gkey)])]
       (is (= :loaded (:status se)) "a :loaded entry stays :loaded")
       (is (= {:t "kept"} (:data se)))
       (let [plan (->> (ssr/hydrate-refetch-plan out 5000)
@@ -795,9 +835,11 @@
           [wk we] (only-wire-entry proj)]
       (is (= :fetching (:status we)) "the projection keeps the entry's :fetching status on the wire")
       (is (not (contains? we :current-work)) "the projection strips :current-work on the wire")
-      (let [installed {state/resources-key {:entries {wk we}}}
+      ;; rf2-9e0tyq — install the REAL projected (byte-keyed) map; look the
+      ;; settled entry up by the byte `key-id` of the projected scoped key.
+      (let [installed proj
             out (ssr/hydrate-runtime-db installed :app/main)
-            se  (get-in out [state/resources-key :entries wk])]
+            se  (get-in out [state/resources-key :entries (state/key-id wk)])]
         (is (= :loaded (:status se))
             "hydration settles the dangling :fetching entry to :loaded — not installed verbatim")
         (is (nil? (:current-work se)) "current-work stays cleared")))))
@@ -932,13 +974,15 @@
                      :owners #{[:route :r "nav-b"]}})
           out (ssr/hydrate-runtime-db (runtime-db-with {ka ea kb eb}) :app/main)
           es  (get-in out [state/resources-key :entries])]
-      (is (= {:owner "a"} (:data (es ka))) "scope-a data stays under scope-a's key")
-      (is (= {:owner "b"} (:data (es kb))) "scope-b data stays under scope-b's key")
+      (is (= {:owner "a"} (:data (es (state/key-id ka)))) "scope-a data stays under scope-a's key")
+      (is (= {:owner "b"} (:data (es (state/key-id kb)))) "scope-b data stays under scope-b's key")
       (testing "the shared tag [:article \"x\"] maps to BOTH scoped keys, never collapsed"
-        (is (= #{ka kb} (get-in out [state/resources-key :tag-index [:article "x"]]))))
+        ;; rf2-9e0tyq — index members are the byte key-id.
+        (is (= #{(state/key-id ka) (state/key-id kb)}
+               (get-in out [state/resources-key :tag-index [:article "x"]]))))
       (testing "each scope's owner indexes only its own key"
-        (is (= #{ka} (get-in out [state/resources-key :owner-index [:route :r "nav-a"]])))
-        (is (= #{kb} (get-in out [state/resources-key :owner-index [:route :r "nav-b"]])))))))
+        (is (= #{(state/key-id ka)} (get-in out [state/resources-key :owner-index [:route :r "nav-a"]])))
+        (is (= #{(state/key-id kb)} (get-in out [state/resources-key :owner-index [:route :r "nav-b"]])))))))
 
 ;; ===========================================================================
 ;; 6. End-to-end through the :rf/hydrate reconcile hook
@@ -962,7 +1006,7 @@
           ;; the SSR payload-policy is the consumer of :ssr/extend-runtime-db-projection
           proj (payload-policy/project-runtime-db rdb)]
       (is (contains? proj state/resources-key))
-      (is (contains? (get-in proj [state/resources-key :entries]) gkey)))))
+      (is (contains? (get-in proj [state/resources-key :entries]) (state/key-id gkey))))))
 
 (deftest hydrate-event-reconciles-resource-slice
   (reg! :article/by-slug)
@@ -978,13 +1022,13 @@
                    :rf/runtime-db (runtime-db-with {gkey e})}]
       (rf/dispatch-sync [:rf/hydrate payload])
       (let [rdb (rf/runtime-db-value :rf/default)
-            installed (get-in rdb [state/resources-key :entries gkey])]
+            installed (get-in rdb [state/resources-key :entries (state/key-id gkey)])]
         (is (= {:t "x"} (:data installed)) "entry data preserved through hydrate")
         (is (nil? (:current-work installed)) "transient current-work cleared")
         (is (not (contains? (:active-owners installed) [:ssr "req-1" "nav-1"]))
             "SSR owner orphaned during the :rf/hydrate reconcile")
         (is (contains? (:active-owners installed) [:route :route/article "nav-1"])
             "route owner survives")
-        (is (= {[:article "x"] #{gkey}}
+        (is (= {[:article "x"] #{(state/key-id gkey)}}
                (get-in rdb [state/resources-key :tag-index]))
-            "tag-index recomputed from entries during the :rf/hydrate reconcile")))))
+            "tag-index recomputed from entries during the :rf/hydrate reconcile (byte key-id member)")))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -560,9 +560,14 @@
   whose scope/params redact to the same sentinel. A `nil` slot is left as
   nil (nothing to redact) so the derived `:has-data?` fact survives."
   ([entry+key now-ms] (instance-row entry+key now-ms nil))
-  ([[scoped-key entry] now-ms egress-fn]
+  ([[map-key entry] now-ms egress-fn]
    (let [egress       (or egress-fn (fn [v _slot] v))
          eg           (fn [v slot] (when (some? v) (egress v slot)))
+         ;; rf2-9e0tyq — the `:entries` map key is now the opaque CEDN-1 byte
+         ;; `key-id` STRING; the kind-preserving scoped-key VECTOR lives on the
+         ;; entry as `:resource/key`. Read the scope/rid/params from there (fall
+         ;; back to the map key for a legacy entry that lacks the stamp).
+         scoped-key   (or (:resource/key entry) map-key)
          [raw-scope raw-rid raw-params]
                       (if (and (vector? scoped-key) (= 3 (count scoped-key)))
                         scoped-key


### PR DESCRIPTION
## What

Full fix for the EP-0012 resource cache-key `=`-collapse (deferred from rf2-o84qq2, which shipped a minimal hardening). The scoped resource key `[canonical-scope rid canonical-params]` was used **directly** as a Clojure map key in `:entries`, the reverse tag/owner indexes, **and** the work-ledger map. Clojure map keys compare by `=` + hash, and `(= [1 2 3] '(1 2 3))` is `true`, so a list-params key and a vector-params key collapsed to **one** entry/work-id despite distinct CEDN-1 byte identities (wgutc2 made `canonical` preserve list-vs-vector kind).

## How

Re-key `:entries`, the reverse indexes, and the work-ledger map on the **CEDN-1 `canonical-bytes` STRING** (`state/key-id` / `work-ledger/work-id-id`). Strings compare by content `=`, which *is* the byte identity, so distinct list/vector keys get distinct slots. The kind-preserving scoped-key **vector** is stored alongside as each entry's `:resource/key` and remains embedded in the work-id, on the SSR wire, and in trace payloads — the kind distinction is preserved end-to-end. **No** list→vector normalize (would re-erase the kind wgutc2 added).

The byte key-id is a plain UTF-8 string, so it rides the SSR / epoch / trace wire with **no custom transit handler** — the silent-serialization-break failure mode a `deftype` key would have introduced (the reason this was deferred).

Three production `=`-collapse latent bugs the byte-keying surfaced were also fixed: `hydrate-refetch-plan` read `(nth k 1)` on the byte string; `gc-fired` and `remove` `dissoc`'d `:entries` by the scoped-key vector (a no-op leak); `clear-resource`'s `entry-keys-for-resource` destructured the byte string. The rf2-o84qq2 deferred-edge pin is flipped from documenting-the-collapse to **asserting-distinctness**.

## All four carriers (the verified blast radius) — per-carrier round-trip evidence

New suite `resources_cache_key_identity_cljs_test` (5 tests, 26 assertions, all green) proves each carrier keeps the list- and vector-params keys distinct:

1. **`:entries` map key** — `carrier-1-entries-map-keys-distinctly`: the two vectors are `=` but their byte key-ids differ → 2 distinct entries; the list entry's `:resource/key` keeps `seq?` kind.
2. **work-ledger work-id** (runtime-db map key + stale-suppression basis) — `carrier-2-work-ledger-keys-distinctly`: distinct `work-id-id`s → 2 distinct ledger rows that read back correctly.
3. **SSR hydration wire** — `carrier-3-ssr-projection-round-trip-keeps-two-entries`: `project-resources-runtime-db` → 2 distinct **plain-string** wire keys → `pr-str`/`read-string` EDN round-trip survives verbatim → `hydrate-runtime-db` reinstalls 2 entries with a 2-member recomputed tag-index. **epoch restore** — `carrier-3b-restore-reconcile-keeps-two-entries`: `reconcile-on-restore` over the unprojected snapshot keeps 2 entries + a 2-member shared-tag index.
4. **trace payloads** — `carrier-4-trace-scoped-key-preserves-kind`: the trace-carried scoped key keeps `seq?`/`vector?` kinds and is byte-distinct.

## Quality gates

- `cd implementation/resources && clojure -M:test` — **374 tests, 1452 assertions, 0 failures**
- `cd implementation && npm run test:cljs` — **6872 tests, 27938 assertions, 0 failures** (cross-artefact: resources + SSR + epoch + derivation consumers)
- `cd tools/xray && clojure -M:test` — **1156 tests, 5111 assertions, 0 failures** (resources panel reads `:resource/key`)
- `cd implementation && npm run test:bundle-isolation` — **PASS** (0 warnings under `:advanced`)

## Notes

- No spec files touched. The Xray resources-panel `instance-row` now reads scope/rid/params from the entry's `:resource/key` — the byte map-key is an internal `:entries` representation detail; the panel's rendered contract is unchanged, so `tools/xray/spec/*` is **unchanged**.
- Touched only the resources cache-key surface (`state.cljc` `:entries` keying + `work_ledger.cljc` work-id + `ssr.cljc` projection/reconcile + the identity helpers + `events`/`registry`/`subs`/`timers`/`tooling`/`mutation_*`) and one xray panel helper. No hot-zone files.
