### PR TITLE
feat(story): EP-0013 realm stamp on recordings + replay targeting (rf2-0io9uq)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -92,12 +92,20 @@
   the write-back produces a new variant body and the origin tag
   identifies the MCP write surface as its producer.
 
+  rf2-0io9uq (EP-0013): the captured recording's runtime-realm stamp (read off
+  the source frame at recording time, `realm`) is threaded into
+  `recording->play-script` so the written-back body carries `:rf.realm/id`
+  WHERE the source frame is in a non-default realm — replay targets the same
+  realm. The default-realm absent-key rule applies: a single-realm recording
+  passes a nil / default realm, so the body carries no realm key and replays
+  unchanged (zero ceremony).
+
   Returns the structured success result on the happy path, or an
   `error-result` whose `:structuredContent` merges the base recorder
   payload, the failure flag, and the registrar's `ex-data`."
-  [base body events target-vid]
+  [base body events realm target-vid]
   (try
-    (let [play-body (story/recording->play-script events)
+    (let [play-body (story/recording->play-script events {:realm realm})
           id        (story/reg-variant*
                       target-vid
                       (assoc body :script play-body :origin config/origin))
@@ -289,6 +297,12 @@
                       _           (sleep-ms duration-ms)
                       final-state (story/stop-recording!)
                       events      (vec (:events final-state))
+                      ;; rf2-0io9uq (EP-0013): the recorder stamped the source
+                      ;; frame's runtime realm onto the recording WHERE it is a
+                      ;; non-default realm (absent-key rule). Read it back so the
+                      ;; write-back body can target the same realm on replay; nil
+                      ;; for a single-realm recording (no realm key emitted).
+                      realm       (get final-state :rf.realm/id)
                       ;; rf2-12f2q — the captured event vectors cross the
                       ;; AI/off-box boundary in BOTH the `:captured` slot
                       ;; and the `:play-snippet` text. A recorded event can
@@ -320,7 +334,7 @@
                                    :written-back?        false}]
                   (if-not write-back?
                     (result/edn-result base)
-                    (write-back! base body events target-vid))))))))))))
+                    (write-back! base body events realm target-vid))))))))))))
 
 (def descriptors
   "Registry descriptors for the recorder's MCP surface — the single

--- a/tools/story/spec/API.md
+++ b/tools/story/spec/API.md
@@ -261,12 +261,32 @@ write-back path (`record-as-variant`) registers (rf2-x9zsr / rf2-d5u89).
 | Fn | Signature | Purpose |
 |---|---|---|
 | `start-recording!` | `(start-recording! variant-id)` | Begin recording dispatched events against `variant-id`'s frame. |
-| `stop-recording!` | `(stop-recording!)` | Stop the in-flight recording; return the captured events. |
+| `stop-recording!` | `(stop-recording!)` | Stop the in-flight recording; return the captured events. The returned state carries `:rf.realm/id` WHERE the target frame is in a non-default runtime realm (rf2-0io9uq, EP-0013); a single-realm recording carries no realm key (the absent-key rule). |
 | `clear-recording!` | `(clear-recording!)` | Drop the buffer + return the recorder to idle. |
 | `recording?` | `(recording?)` | Predicate — is a recording in flight? |
-| `recorder-state` | `(recorder-state)` | Read-only view of the current recorder state map. |
+| `recorder-state` | `(recorder-state)` | Read-only view of the current recorder state map (includes `:rf.realm/id` where the recording is stamped — rf2-0io9uq). |
 | `gen-play-snippet` | `(gen-play-snippet events opts)` | Pure codegen → string: render a captured `events` vector as a `(reg-variant <id> {... :script {:script [...]}})` EDN snippet. Emits the PUBLIC `:script` slot (rf2-7mj4z); each captured event vector is wrapped as `[:dispatch-sync <event-vec>]` (rf2-0wrud). See [005-SOTA-Features.md](005-SOTA-Features.md) §Recorder for the round-trip contract. |
-| `recording->play-script` | `(recording->play-script events)` / `(recording->play-script events opts)` | Pure data → data: translate a recording (bare `events` vector OR the rich `:entries` vector) into the live, replayable `{:script [...] :auto-run? bool :name str?}` body a runner executes. The runtime counterpart to `gen-play-snippet`'s text output; the MCP write-back path calls this to re-register the variant with a live `:script` slot. Re-exported from `re-frame.story.recorder.play-export`. |
+| `recording->play-script` | `(recording->play-script events)` / `(recording->play-script events opts)` | Pure data → data: translate a recording (bare `events` vector OR the rich `:entries` vector) into the live, replayable `{:script [...] :auto-run? bool :name str?}` body a runner executes. The runtime counterpart to `gen-play-snippet`'s text output; the MCP write-back path calls this to re-register the variant with a live `:script` slot. `opts :realm` (rf2-0io9uq, EP-0013) carries the recording's runtime realm onto the body under `:rf.realm/id` WHERE non-default so replay targets the same realm (omitted for the default realm — absent-key rule). Re-exported from `re-frame.story.recorder.play-export`. |
+
+### Runtime-realm stamp on recordings (rf2-0io9uq, EP-0013)
+
+A recording targets a **frame** (`:variant-id`); a frame references the
+runtime **realm** it lives in (Spec 002 §Frames reference realms; EP-0013).
+The recorder reads that realm off the live runtime via
+`re-frame.core/frame-realm` at `start-recording!` and stamps it on the
+recording under `:rf.realm/id` — but ONLY **where** the frame is in a
+**non-default** realm. The default-realm **absent-key rule**
+(Spec-Schemas §`:rf/realm`, EP-0013 issue 2) holds end-to-end: a
+single-realm / default-realm recording carries **no** realm key, its play
+body is byte-identical to the pre-realm shape, and it replays unchanged
+(zero ceremony). Replay dispatches frame-scoped (`{:frame variant-id}`), so
+it lands in the frame's own realm by construction; the explicit
+`{:realm r :frame v}` address is resolved by
+`re-frame.story.play.runner-events/replay-target` (which applies the same
+absent-key rule), making "replay targets the right realm" verifiable. When
+a frame is in a constructed realm, the stamp + the resolved target carry
+that realm id so a caller can assert replay re-enters the SAME realm the
+recording was captured in.
 
 ### Rich-DSL `:script` translator — sub-namespace home
 

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -1840,7 +1840,13 @@
 (defn stop-recording!
   "Stop the in-flight recording. Returns the recorder state map with
   `:recording?` false, `:events` carrying the captured event vectors in
-  declared order, and `:variant-id` naming the source variant."
+  declared order, and `:variant-id` naming the source variant.
+
+  rf2-0io9uq (EP-0013): the returned state carries `:rf.realm/id` WHERE the
+  recording's target frame was in a non-default runtime realm; a single-realm
+  recording carries no realm key (the absent-key rule — absence means the
+  default realm). Pass the stamp through `recording->play-script`'s `:realm`
+  opt so replay targets the same realm."
   []
   (recorder/stop-recording!))
 
@@ -1895,10 +1901,13 @@
 
   `events` may be the legacy bare-events vector OR the rich `:entries`
   vector (rf2-d5u89). `opts` accepts `:auto-run?`, `:name`,
-  `:auto-assert?` + `:final-db`/`:seed-db`/`:max-auto-assertions`, and
-  `:wait-threshold-ms` — see `re-frame.story.recorder.play-export/
+  `:auto-assert?` + `:final-db`/`:seed-db`/`:max-auto-assertions`,
+  `:wait-threshold-ms`, and `:realm` (rf2-0io9uq, EP-0013 — the runtime realm
+  the recording was captured in; carried onto the body under `:rf.realm/id`
+  WHERE non-default so replay targets the same realm, omitted for the default
+  realm by the absent-key rule) — see `re-frame.story.recorder.play-export/
   recording->play-script` for the full contract.
 
-  Returns `{:script [...steps] :auto-run? bool :name str?}`."
+  Returns `{:script [...steps] :auto-run? bool :name str? :rf.realm/id kw?}`."
   ([events]      (play-export/recording->play-script events))
   ([events opts] (play-export/recording->play-script events opts)))

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -250,6 +250,40 @@
     (registrar/handler-meta :variant variant-id)
     (catch #?(:clj Throwable :cljs :default) _ nil)))
 
+;; ---- replay realm targeting (rf2-0io9uq, EP-0013) ------------------------
+;;
+;; A recording targets a FRAME (`variant-id`); the frame references the
+;; runtime REALM it lives in (Spec 002 §Frames reference realms). Replay
+;; dispatches through `{:frame variant-id}` — the framework derives the realm
+;; from the frame, so frame-scoped dispatch ALREADY lands in the frame's own
+;; realm. `replay-target` makes that address EXPLICIT + verifiable: it returns
+;; the `{:realm r :frame v}` map the recording replays against, reading the
+;; live realm via `rf/frame-realm` and applying the DEFAULT-realm absent-key
+;; rule — a default-realm / unknown frame omits `:realm`, so a single-realm
+;; recording's target is `{:frame v}` (byte-identical to the pre-realm shape,
+;; zero ceremony). A frame in a constructed realm reports `{:realm r :frame
+;; v}` so a caller can assert replay targets the SAME realm the recording was
+;; captured in.
+
+(defn replay-target
+  "Resolve the `{:realm r :frame v}` address replay dispatches `variant-id`'s
+  script against (rf2-0io9uq, EP-0013). Pure-ish — reads the live frame's realm
+  via `rf/frame-realm`, no dispatch.
+
+  Always carries `:frame variant-id`. Carries `:realm` ONLY when the frame is
+  in a NON-default realm (the absent-key rule — absence of `:realm` means the
+  default realm). So a single-realm recording resolves to `{:frame v}` and a
+  multi-realm recording to `{:realm r :frame v}`. Tolerant: a frame-realm read
+  that throws (no frame, framework absent) yields `{:frame v}` (the default-
+  realm target). The frame-scoped dispatch the runner already performs lands in
+  exactly this realm — this is the readable, assertable counterpart to it."
+  [variant-id]
+  (let [realm (try (rf/frame-realm variant-id)
+                   (catch #?(:clj Throwable :cljs :default) _ nil))]
+    (cond-> {:frame variant-id}
+      (and (some? realm) (not= realm :rf.realm/default))
+      (assoc :realm realm))))
+
 ;; ---- folded-plan consumption (rf2-5x1wt.19) ------------------------------
 ;;
 ;; The runtime CONSUMES the `.18`-folded plan: every play's script is folded

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -124,6 +124,13 @@
   - `append-assertion`        — pure: state → state with assertion appended.
   - `insert-assertion!`       — impure entrypoint for the picker UI."
   (:require [clojure.string :as str]
+            ;; rf2-0io9uq (EP-0013): `re-frame.core/frame-realm` reads the
+            ;; runtime realm a recording-target frame lives in, so a recording
+            ;; can carry the `:rf.realm/id` stamp WHERE the frame is in a
+            ;; non-default realm (the absent-key default-realm rule — see
+            ;; `realm-stamp`). The runner already requires `re-frame.core`;
+            ;; this is the same framework-facade dependency, JVM + CLJS.
+            [re-frame.core :as rf]
             [re-frame.story.config :as config]
             [re-frame.story.predicates :as pred]
             [re-frame.story.review-dialog :as review-dialog]
@@ -175,6 +182,77 @@
   from `re-frame.privacy`) has no registered handler — the resulting
   dispatch error is clean rather than a malformed-event-vector error."
   [:rf/redacted])
+
+;; ---------------------------------------------------------------------------
+;; rf2-0io9uq (EP-0013): the recording's runtime-realm stamp
+;;
+;; A re-frame2 frame references the runtime REALM it lives in (Spec 002
+;; §Frames reference realms; EP-0013). A single-realm app runs every frame in
+;; the process DEFAULT realm; a multi-tenant / hermetic-test app can construct
+;; explicit realms (`rf/realm`) and seat frames in them. A recording targets a
+;; FRAME (`:variant-id`), so the realm the recording belongs to is the realm
+;; THAT frame lives in — read off the live runtime via `rf/frame-realm`.
+;;
+;; The disposition is the documented ABSENT-KEY rule (Spec-Schemas §`:rf/realm`,
+;; EP-0013 issue 2): "absence of `:rf.realm/id` means THE DEFAULT realm". So a
+;; recording carries the `:rf.realm/id` stamp ONLY where the target frame is in
+;; a NON-default realm; a single-realm / default-realm recording carries NO
+;; realm key and replays unchanged (zero ceremony). `realm-stamp` is the ONE
+;; place this decision is made: it returns the realm id to stamp, or nil when
+;; the realm is the default (or unknown — an unknown frame's `rf/frame-realm`
+;; is nil, which also stamps nothing). The pure `start` threads the resolved
+;; stamp through `assoc-realm`, so the predicate is JVM-testable without a live
+;; frame.
+;; ---------------------------------------------------------------------------
+
+(def ^:const realm-stamp-key
+  "The reserved app-value key a recording stamps its target frame's runtime
+  realm under (EP-0013). Matches the framework's reserved `:rf.realm/id`
+  spelling (Spec-Schemas §`:rf/realm`) so a stamped recording reads the way
+  the realm-targeted query forms (`rf/registrations {:realm …}`) spell it."
+  :rf.realm/id)
+
+(defn realm-stamp
+  "Return the realm id to STAMP on a recording whose target frame reports
+  `frame-realm-id` (the value `rf/frame-realm` returned), or nil when nothing
+  should be stamped. Pure data → data.
+
+  The absent-key rule (EP-0013 disposition): a recording stamps `:rf.realm/id`
+  ONLY where the frame is in a NON-default realm. Returns nil for:
+
+    - `nil` — an unknown / destroyed frame (`rf/frame-realm` returns nil), or
+              no realm resolvable.
+    - `re-frame.realm/default-realm-id` (`:rf.realm/default`) — a single-realm
+              / default-realm frame. Absence IS the default, so we stamp
+              nothing and the recording replays unchanged (zero ceremony).
+
+  Returns the realm id verbatim for any other (constructed) realm so replay
+  can verify it targets the same realm the recording was captured in."
+  [frame-realm-id]
+  (when (and (some? frame-realm-id)
+             (not= frame-realm-id :rf.realm/default))
+    frame-realm-id))
+
+(defn- frame-realm-stamp
+  "Impure: read the live runtime realm `variant-id`'s frame lives in (via
+  `rf/frame-realm`) and reduce it through `realm-stamp` to the value the
+  recording should carry (the constructed realm id, or nil for the default /
+  unknown). Tolerant — a frame-realm read that throws (no frame, framework
+  absent) yields nil, so recording is never broken by realm-read failure."
+  [variant-id]
+  (realm-stamp
+    (try (rf/frame-realm variant-id)
+         (catch #?(:clj Throwable :cljs :default) _ nil))))
+
+(defn assoc-realm
+  "Pure: stamp `realm-id` onto recorder `state` under `realm-stamp-key`, or
+  leave `state` UNTOUCHED when `realm-id` is nil (the default-realm absent-key
+  rule — EP-0013). The single helper both `start` and the impure
+  `start-recording!` thread through so the absent-key invariant lives in one
+  place: a default-realm recording's state map carries no `:rf.realm/id` key."
+  [state realm-id]
+  (cond-> state
+    (some? realm-id) (assoc realm-stamp-key realm-id)))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: dispatch-only code-gen — `(reg-variant ... :script {...})` snippet
@@ -459,7 +537,13 @@
   `:dom/submit`) with per-event timestamps — consumed by the
   `:play-script` translator; `:variant-id` records which frame the
   capture targets; `:started-ms` is the wall-clock start time for
-  elapsed-time display."
+  elapsed-time display.
+
+  rf2-0io9uq (EP-0013): the idle state carries NO `:rf.realm/id` key — by the
+  absent-key rule absence means the default realm. `start` adds the
+  `:rf.realm/id` stamp only when the target frame is in a NON-default realm
+  (`realm-stamp` / `assoc-realm`), so a single-realm recording's state map is
+  byte-identical to the pre-realm shape."
   {:recording? false
    :variant-id nil
    :events     []
@@ -487,6 +571,17 @@
   []
   (:variant-id @state))
 
+(defn recording-realm
+  "Return the runtime realm id the current recording is stamped with
+  (`:rf.realm/id`), or nil when the recording carries no realm stamp
+  (rf2-0io9uq, EP-0013). nil is the DEFAULT-realm signal under the absent-key
+  rule: a single-realm recording stamps no realm, so this returns nil and
+  replay targets the frame's (default) realm unchanged. A non-nil return is a
+  constructed (non-default) realm the recording was captured in — replay must
+  land in THAT realm."
+  []
+  (get @state realm-stamp-key))
+
 (defn recorded-events
   "Return the vector of captured event vectors (oldest first). Feeds the
   simple `gen-play-snippet` codegen, which wraps each as a
@@ -507,13 +602,24 @@
 
 (defn start
   "Pure: return the recorder state for a new recording targeting
-  `variant-id`. `now-ms` is the wall-clock start time."
-  [_state variant-id now-ms]
-  {:recording? true
-   :variant-id variant-id
-   :events     []
-   :entries    []
-   :started-ms now-ms})
+  `variant-id`. `now-ms` is the wall-clock start time.
+
+  rf2-0io9uq (EP-0013): the four-arity stamps the recording's runtime-realm
+  id (`realm-id`) onto the state under `realm-stamp-key` via `assoc-realm` —
+  but ONLY when `realm-id` is non-nil (a constructed, non-default realm; the
+  caller passes the value `realm-stamp` already reduced, so a default-realm /
+  unknown frame is nil here). The three-arity is the default-realm path: it
+  stamps nothing, so a single-realm recording carries no `:rf.realm/id` key
+  and replays unchanged (the absent-key rule)."
+  ([state variant-id now-ms]
+   (start state variant-id now-ms nil))
+  ([_state variant-id now-ms realm-id]
+   (-> {:recording? true
+        :variant-id variant-id
+        :events     []
+        :entries    []
+        :started-ms now-ms}
+       (assoc-realm realm-id))))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-d5u89 — per-event timestamps + DOM-event entries
@@ -735,13 +841,26 @@
   "Begin recording events dispatched against `variant-id`'s frame.
   Returns the new state. Stops any in-flight recording first. Under
   elision (`config/enabled?` false) returns the idle `initial-state`
-  without touching the atom."
+  without touching the atom.
+
+  rf2-0io9uq (EP-0013): reads the runtime realm `variant-id`'s frame lives in
+  (via `rf/frame-realm`) and STAMPS it on the recording WHERE the frame is in
+  a non-default realm (`frame-realm-stamp` → `realm-stamp`). A single-realm /
+  default-realm recording stamps nothing (absent-key rule); the stamp read is
+  tolerant, so realm-read failure never breaks recording.
+
+  The two-arity `(start-recording! variant-id now-ms)` resolves the realm
+  off the live frame; the three-arity `(start-recording! variant-id now-ms
+  realm-id)` lets a test pin the realm without a live frame (the value is
+  reduced through `realm-stamp` again so the absent-key rule still applies)."
   ([variant-id]
    (start-recording! variant-id #?(:clj (System/currentTimeMillis)
                                    :cljs (.now js/Date))))
   ([variant-id now-ms]
+   (start-recording! variant-id now-ms (frame-realm-stamp variant-id)))
+  ([variant-id now-ms realm-id]
    (if config/enabled?
-     (swap! state start variant-id now-ms)
+     (swap! state start variant-id now-ms (realm-stamp realm-id))
      initial-state)))
 
 (defn stop-recording!

--- a/tools/story/src/re_frame/story/recorder/play_export.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export.cljc
@@ -355,8 +355,17 @@
       :wait-threshold-ms  ms threshold above which the translator
                          inserts a `[:wait Δt]` step between entries.
                          Default `default-wait-threshold-ms` (50ms).
+      :realm             optional — the runtime realm id the recording was
+                         captured in (rf2-0io9uq, EP-0013). When supplied AND
+                         non-default, it is carried onto the body under
+                         `:rf.realm/id` so replay targets the same realm the
+                         recording was captured in. The DEFAULT-realm absent-
+                         key rule applies: a nil / `:rf.realm/default` realm
+                         stamps NOTHING, so a single-realm recording's body is
+                         byte-identical to the pre-realm shape and replays
+                         unchanged (zero ceremony).
 
-  Returns a map: `{:script [...steps] :auto-run? bool :name str?}`.
+  Returns a map: `{:script [...steps] :auto-run? bool :name str? :rf.realm/id kw?}`.
   The script is pre-coerced via `runner/coerce-script` so it round-
   trips through `runner/parse-spec` without further normalisation —
   what you get back is what the runner will execute.
@@ -366,7 +375,7 @@
   ([events]
    (recording->play-script events {}))
   ([events {:keys [name auto-assert? final-db seed-db max-auto-assertions
-                   auto-run? wait-threshold-ms]
+                   auto-run? wait-threshold-ms realm]
             :or   {auto-assert?         false
                    auto-run?            true
                    max-auto-assertions  default-max-auto-assertions
@@ -381,9 +390,15 @@
                           [])
          script         (vec (concat dispatch-steps assert-steps))
          base           {:script    script
-                         :auto-run? (boolean auto-run?)}]
+                         :auto-run? (boolean auto-run?)}
+         ;; rf2-0io9uq (EP-0013): carry the realm stamp WHERE present, by the
+         ;; absent-key rule. A nil / default realm assocs nothing (zero
+         ;; ceremony), so a single-realm body round-trips unchanged.
+         realm-stamp    (when (and (some? realm) (not= realm :rf.realm/default))
+                          realm)]
      (cond-> base
-       (and (string? name) (seq name)) (assoc :name name)))))
+       (and (string? name) (seq name)) (assoc :name name)
+       (some? realm-stamp)             (assoc :rf.realm/id realm-stamp)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: render the play-script map as EDN

--- a/tools/story/test/re_frame/story_recorder_test.clj
+++ b/tools/story/test/re_frame/story_recorder_test.clj
@@ -29,7 +29,11 @@
             ;; published from `re-frame.core`; it survives as an internal
             ;; helper in its home ns, exercised here directly.
             [re-frame.privacy :as privacy]
+            ;; rf2-0io9uq (EP-0013): the realm-stamp tests reach for the
+            ;; default-realm id constant + the replay-target resolver.
+            [re-frame.realm :as realm]
             [re-frame.registrar :as registrar]
+            [re-frame.story.play.runner-events :as runner-events]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story :as story]
             [re-frame.story.async :as async]
@@ -749,3 +753,222 @@
       ;; thin delegation, not a divergent reimplementation.
       (is (= one-arg (play-export/recording->play-script events))
           "facade re-export == sub-namespace fn (pure delegation)"))))
+
+;; ---- rf2-0io9uq (EP-0013): recording realm stamp + replay targeting ------
+;;
+;; A recording targets a FRAME; the frame references its runtime REALM
+;; (Spec 002 §Frames reference realms). The recorder stamps `:rf.realm/id`
+;; on a recording WHERE the frame is in a NON-default realm; a single-realm /
+;; default-realm recording carries NO realm key (the absent-key rule — absence
+;; means the default realm) and replays unchanged (zero ceremony). Replay
+;; dispatches frame-scoped, so it lands in the frame's own realm by
+;; construction; `runner-events/replay-target` resolves the explicit
+;; `{:realm :frame}` address applying the same absent-key rule.
+
+;; ---- pure: realm-stamp (the absent-key decision) -------------------------
+
+(deftest realm-stamp-drops-the-default-realm
+  (testing "realm-stamp returns nil for the default realm — absence is the
+            default (the absent-key rule); only a non-default realm stamps"
+    (is (nil? (recorder/realm-stamp realm/default-realm-id))
+        "the default realm stamps nothing")
+    (is (nil? (recorder/realm-stamp nil))
+        "a nil (unknown / destroyed frame) realm stamps nothing")
+    (is (= :tenant/acme (recorder/realm-stamp :tenant/acme))
+        "a constructed (non-default) realm stamps its id verbatim")))
+
+(deftest assoc-realm-respects-the-absent-key-rule
+  (testing "assoc-realm stamps :rf.realm/id only for a non-nil realm; a nil
+            leaves the state byte-identical (no realm key)"
+    (is (= {:recording? true}
+           (recorder/assoc-realm {:recording? true} nil))
+        "nil realm → state untouched (no :rf.realm/id key)")
+    (is (not (contains? (recorder/assoc-realm {:recording? true} nil)
+                        :rf.realm/id))
+        "the absent-key invariant: default-realm state never grows a realm key")
+    (is (= {:recording? true :rf.realm/id :tenant/acme}
+           (recorder/assoc-realm {:recording? true} :tenant/acme))
+        "non-nil realm → stamped under :rf.realm/id")))
+
+;; ---- pure: start arities -------------------------------------------------
+
+(deftest start-default-realm-carries-no-realm-key
+  (testing "the 3-arity start (default-realm path) writes no :rf.realm/id —
+            a single-realm recording's state map is byte-identical to the
+            pre-realm shape"
+    (let [s (recorder/start recorder/initial-state :story.x/y 1000)]
+      (is (not (contains? s :rf.realm/id))
+          "no realm key on a default-realm recording")
+      (is (= {:recording? true :variant-id :story.x/y
+              :events [] :entries [] :started-ms 1000}
+             s)
+          "state shape unchanged from the pre-realm recorder"))))
+
+(deftest start-stamps-a-non-default-realm
+  (testing "the 4-arity start stamps :rf.realm/id for a non-default realm"
+    (let [s (recorder/start recorder/initial-state :story.x/y 1000 :tenant/acme)]
+      (is (= :tenant/acme (:rf.realm/id s))
+          "the constructed realm id rides onto the recording state")))
+  (testing "the 4-arity start is the LOW-LEVEL stamper — it assocs whatever
+            non-nil value it is handed (the absent-key reduction is
+            start-recording!'s job, via realm-stamp); only a nil value here
+            stamps nothing"
+    ;; A nil passed to the 4-arity stamps nothing (assoc-realm's guard).
+    (is (not (contains?
+               (recorder/start recorder/initial-state :story.x/y 1000 nil)
+               :rf.realm/id))
+        "a nil realm in the 4-arity stamps nothing (assoc-realm guard)")
+    ;; A raw default keyword DOES stamp at this layer — proving the reduction
+    ;; lives in start-recording! / realm-stamp, not in start.
+    (is (= realm/default-realm-id
+           (:rf.realm/id (recorder/start recorder/initial-state :story.x/y 1000
+                                         realm/default-realm-id)))
+        "the 4-arity assocs a raw default verbatim; start-recording! reduces
+         through realm-stamp BEFORE calling start, so callers never hit this")))
+
+;; ---- impure: start-recording! 3-arity (pinned realm) ---------------------
+
+(deftest start-recording!-3-arity-reduces-through-realm-stamp
+  (testing "the pinned-realm 3-arity reduces the realm through realm-stamp —
+            a default realm stamps nothing, a constructed realm stamps"
+    (recorder/clear!)
+    (recorder/start-recording! :story.x/y 0 realm/default-realm-id)
+    (is (nil? (recorder/recording-realm))
+        "a pinned default realm → no stamp (absent-key rule)")
+    (is (not (contains? (recorder/current-state) :rf.realm/id))
+        "the recorder state carries no realm key for a default-realm recording")
+    (recorder/clear!)
+    (recorder/start-recording! :story.x/y 0 :tenant/acme)
+    (is (= :tenant/acme (recorder/recording-realm))
+        "a pinned constructed realm → stamped + readable via recording-realm")
+    (recorder/clear!)))
+
+;; ---- recording->play-script realm passthrough ----------------------------
+
+(deftest recording->play-script-omits-default-realm
+  (testing "the play-export translator carries no :rf.realm/id for a nil /
+            default realm — the body is byte-identical to the no-realm shape"
+    (let [events  [[:counter/inc] [:counter/by 7]]
+          no-opt  (play-export/recording->play-script events)
+          nil-rlm (play-export/recording->play-script events {:realm nil})
+          dflt    (play-export/recording->play-script events
+                                                      {:realm realm/default-realm-id})]
+      (is (not (contains? no-opt :rf.realm/id)))
+      (is (not (contains? nil-rlm :rf.realm/id)))
+      (is (not (contains? dflt :rf.realm/id))
+          "an explicit default realm omits the key (absent-key rule)")
+      (is (= no-opt nil-rlm dflt)
+          "all three default-realm bodies are identical — zero ceremony"))))
+
+(deftest recording->play-script-stamps-non-default-realm
+  (testing "a non-default realm rides onto the body under :rf.realm/id while
+            the :script is otherwise unchanged"
+    (let [events (vec [[:counter/inc]])
+          base   (play-export/recording->play-script events)
+          realm- (play-export/recording->play-script events {:realm :tenant/acme})]
+      (is (= :tenant/acme (:rf.realm/id realm-)))
+      (is (= (:script base) (:script realm-))
+          "the script is unaffected by the realm stamp")
+      (is (= base (dissoc realm- :rf.realm/id))
+          "dropping the realm key recovers the default-realm body exactly"))))
+
+;; ---- replay-target (the explicit {:realm :frame} address) ----------------
+
+(deftest replay-target-omits-default-realm
+  (testing "replay-target resolves {:frame v} for a default-realm frame —
+            absent-key rule (no :realm)"
+    (reset-rf-state!)
+    (story/reg-variant :story.replay/default {})
+    (async/deref-blocking (story/run-variant :story.replay/default) 5000)
+    ;; Every frame today lives in the default realm (core seats no other),
+    ;; so the resolved target carries no :realm.
+    (is (= {:frame :story.replay/default}
+           (runner-events/replay-target :story.replay/default))
+        "a default-realm recording replays into {:frame v} (no :realm key)")
+    (story/destroy-variant! :story.replay/default))
+  (testing "an unknown frame resolves to {:frame v} tolerantly (no :realm)"
+    (is (= {:frame :story.replay/never-registered}
+           (runner-events/replay-target :story.replay/never-registered)))))
+
+(deftest replay-target-carries-a-non-default-realm
+  (testing "replay-target carries :realm WHERE the frame is in a non-default
+            realm — the (realm, frame) address replay re-enters"
+    (reset-rf-state!)
+    (story/reg-variant :story.replay/tenant {})
+    (async/deref-blocking (story/run-variant :story.replay/tenant) 5000)
+    ;; Core ships no public realm-targeted reg-frame yet (every frame is
+    ;; seated in the default realm), so simulate a frame living in a
+    ;; constructed realm by setting its :realm slot directly. rf/frame-realm
+    ;; reads that slot, so this exercises the real read path.
+    (swap! frame/frames assoc-in [:story.replay/tenant :realm] :tenant/acme)
+    (is (= :tenant/acme (rf/frame-realm :story.replay/tenant))
+        "the frame now reports the constructed realm")
+    (is (= {:realm :tenant/acme :frame :story.replay/tenant}
+           (runner-events/replay-target :story.replay/tenant))
+        "replay-target carries the constructed realm + frame as the address")
+    (story/destroy-variant! :story.replay/tenant)))
+
+;; ---- end-to-end: realm-stamped recording round-trip ----------------------
+
+(deftest end-to-end-default-realm-recording-carries-no-realm-key
+  (testing "a recording against a default-realm frame (the single-realm case)
+            captures NO :rf.realm/id and its play body replays unchanged —
+            the absent-key round-trip (zero ceremony)"
+    (reset-rf-state!)
+    (rf/reg-event-db :counter/inc (fn [db _] (update db :n (fnil inc 0))))
+    (story/reg-variant :story.realm/default {})
+    (async/deref-blocking (story/run-variant :story.realm/default) 5000)
+    (recorder/install-trace-listener!)
+    (recorder/start-recording! :story.realm/default)
+    (rf/dispatch-sync [:counter/inc] {:frame :story.realm/default})
+    (rf/dispatch-sync [:counter/inc] {:frame :story.realm/default})
+    (let [final-state (recorder/stop-recording!)]
+      (is (not (contains? final-state :rf.realm/id))
+          "the recording carries no realm key for a default-realm frame")
+      (is (nil? (recorder/recording-realm))
+          "recording-realm is nil — the default-realm signal")
+      ;; The play body the recording translates to is byte-identical to the
+      ;; pre-realm body — passing the (nil) recorded realm changes nothing.
+      (let [events (:events final-state)
+            body   (story/recording->play-script
+                     events {:realm (get final-state :rf.realm/id)})]
+        (is (not (contains? body :rf.realm/id))
+            "the default-realm play body carries no realm key — replays unchanged")
+        (is (= (story/recording->play-script events) body)
+            "the recorded-realm body == the no-realm body (round-trips unchanged)")))
+    (story/destroy-variant! :story.realm/default)
+    (recorder/remove-trace-listener!)))
+
+(deftest end-to-end-non-default-realm-recording-carries-the-stamp
+  (testing "a recording against a frame in a NON-default realm captures the
+            :rf.realm/id stamp, and the stamp rides through to the replayable
+            play body so replay targets the same realm"
+    (reset-rf-state!)
+    (rf/reg-event-db :counter/inc (fn [db _] (update db :n (fnil inc 0))))
+    (story/reg-variant :story.realm/tenant {})
+    (async/deref-blocking (story/run-variant :story.realm/tenant) 5000)
+    ;; Simulate the frame living in a constructed realm (core seats no other
+    ;; realm yet); rf/frame-realm reads the :realm slot, so start-recording!
+    ;; will stamp the constructed realm.
+    (swap! frame/frames assoc-in [:story.realm/tenant :realm] :tenant/acme)
+    (recorder/install-trace-listener!)
+    (recorder/start-recording! :story.realm/tenant)
+    (rf/dispatch-sync [:counter/inc] {:frame :story.realm/tenant})
+    (let [final-state (recorder/stop-recording!)]
+      (is (= :tenant/acme (get final-state :rf.realm/id))
+          "the recording captured the frame's constructed realm")
+      (is (= :tenant/acme (recorder/recording-realm))
+          "recording-realm reads the stamp back")
+      ;; The recorded realm rides into the replayable body so replay targets
+      ;; the same realm the recording was captured in.
+      (let [events (:events final-state)
+            body   (story/recording->play-script
+                     events {:realm (get final-state :rf.realm/id)})]
+        (is (= :tenant/acme (:rf.realm/id body))
+            "the play body carries the realm stamp for replay targeting")
+        ;; replay-target resolves the same realm off the live frame.
+        (is (= {:realm :tenant/acme :frame :story.realm/tenant}
+               (runner-events/replay-target :story.realm/tenant))
+            "replay-target re-enters the SAME realm the recording was captured in")))
+    (story/destroy-variant! :story.realm/tenant)
+    (recorder/remove-trace-listener!)))


### PR DESCRIPTION
EP-0013 (app values + runtime realms) tools consumer for **Story**. A recording targets a frame; a frame references the runtime realm it lives in (Spec 002 §Frames reference realms). Story recordings now carry the `:rf.realm/id` stamp **where stamped** (a non-default realm), and replay targets the right realm — both governed by the **default-realm absent-key rule** (absence of `:rf.realm/id` means the default realm), so a single-realm / default-realm recording carries no realm key and replays unchanged (zero ceremony).

Uses the just-merged public realm API (`rf/frame-realm` + `rf/realm-ids`, PR #4038 / rf2-f1xa3k).

## What changed

- **`recorder.cljc`** — `start-recording!` reads the target frame's realm via `rf/frame-realm` and stamps `:rf.realm/id` on the recording **only where the frame is in a non-default realm**. New `realm-stamp` (the absent-key decision), `assoc-realm` (the single stamp site), `recording-realm` accessor. `start` grows a 4-arity; `start-recording!` a 3-arity (pin a realm in tests). `initial-state` carries no realm key.
- **`recorder/play_export.cljc`** — `recording->play-script` gains a `:realm` opt that carries `:rf.realm/id` onto the play body **where non-default** (absent-key rule); a default-realm body is byte-identical to the pre-realm shape.
- **`play/runner_events.cljc`** — new `replay-target` resolves the explicit `{:realm r :frame v}` address off the live frame, omitting `:realm` for the default realm. This is the assertable counterpart to the frame-scoped dispatch the runner already performs (which lands in the frame's own realm by construction).
- **`story.cljc` facade** — `stop-recording!` / `recording->play-script` docstrings note the realm stamp + `:realm` opt. (`recorder-state` already surfaces the full state map incl. the stamp — no new facade export needed.)
- **`story-mcp` `record-as-variant`** — threads the recorded realm through the write-back into `recording->play-script` so a written-back variant targets the same realm.
- **`spec/API.md`** — recorder-facade rows updated + a "(realm, frame) stamp" section.

Note: core today seats every frame in the default realm (no public realm-targeted `reg-frame` arity yet), so the default-realm absent-key round-trip is satisfied trivially and the non-default path is exercised by setting a frame's `:realm` slot in tests (the same slot `rf/frame-realm` reads). The stamp infrastructure is forward-compatible: when core later seats frames in constructed realms, the stamp appears automatically.

## Tests (CLJS unit, JVM + node — no Playwright)

Added to `story_recorder_test.clj`: pure `realm-stamp` / `assoc-realm` absent-key decision; `start` arities; `start-recording!` 3-arity reduction; `recording->play-script` realm passthrough + absent-key; `replay-target` default + non-default; **end-to-end default-realm absent-key round-trip** (recording carries no realm key, body round-trips unchanged) and **non-default-realm stamp round-trip** (stamp captured, rides into the play body, `replay-target` re-enters the same realm).

## Quality gates
- story `clojure -M:test`: 1683 tests, 6228 assertions, 0 failures
- story-mcp `clojure -M:test`: 259 tests, 1283 assertions, 0 failures
- `npm run test:cljs`: 6872 tests, 27927 assertions, 0 failures
- `npm run test:bundle-isolation`: PASS (the recorder's new `re-frame.core` require does not leak into production bundles)