### PR TITLE
feat(xray): EP-0013 realm-awareness — frames-by-realm + trace realm stamp + module-view (rf2-3caq85 + 7vqpwa + wtg9z4)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -397,45 +397,56 @@ dispatch `:rf.xray/select-frame`. Reaching the spine's `:rf.xray/
 set-frame` primitive directly bypasses the persistence + future
 instrumentation layers attached to the canonical event.
 
-### EP-0013 realm-awareness posture (considered, deferred — rf2-1koiq1)
+### EP-0013 realm-awareness (shipped — rf2-3caq85 · rf2-7vqpwa · rf2-wtg9z4)
 
 EP-0013 (app values and runtime realms) makes the *realm* the owner of
 the registrar/adapter/frame-registry; a frame belongs to exactly one
-realm, and the `(realm, frame)` pair is the full address. The
-`rf2-1koiq1` propagation considered how Xray adopts this and concluded:
-**no Xray code changes today, by the EP's own zero-ceremony rule.** The
-considered scope, recorded so a later slice does not re-derive it:
+realm, and the `(realm, frame)` pair is the full address. The public
+realm address API (`rf/realm-ids` — the installed realms; `rf/frame-realm`
+— a frame's realm; PR #4038) landed, so the `rf2-1koiq1`-deferred posture
+is now implemented. **Zero-ceremony extends to the tooling: a single-realm
+process renders byte-identically to the pre-EP picker / trace rows; the
+realm dimension is spelled only when more than one realm is present.**
 
-- **Frames panel — group by realm in multi-realm processes only.**
-  EP-0013 disposition 3: the frame switcher (`frame_switcher.cljs`,
-  `:rf.xray/available-frames`, `distinct-frames`) would render an
-  `<optgroup>` per realm when more than one realm is present; the
-  single-realm render stays byte-identical (zero-ceremony extends to
-  tooling). Tracked: **rf2-3caq85**.
-- **Trace/causality rows — show `:rf.realm/id` where present.** EP-0013
-  disposition 2: the trace rows (`panels/trace.cljs`, which already read
-  a `:frame` stamp) render the realm stamp *where the trace event carries
-  it*, and omit it otherwise. Tracked: **rf2-7vqpwa**.
-- **Module-view — the disposition-6 demand trigger.** EP-0013 keeps
-  descriptor provenance metadata internal *until* an Xray module-view
-  demands it; that view (inspecting app-value modules: ownership,
-  capability requirements, EP-0015 classification, and provenance) is its
-  own design slice, not in-scope here. Tracked: **rf2-wtg9z4**.
-
-All three are **blocked on observability**, not on UI work: Xray consumes
-the Spec 009 trace stream and enumerates frames from trace cascades. The
-public frame→realm read (`re-frame.core/frame-realm`) and realm
-enumeration (`re-frame.core/realm-ids`) have since shipped (EP-0013), so
-Xray *could* resolve a frame's realm out-of-band — but the **trace
-stream still carries no `:rf.realm/id`** stamp, and Xray's realm grouping
-/ per-row stamping are trace-driven. Until the framework stamps
-`:rf.realm/id` on the observability surfaces (the EP-0010/0011/0016 record
-shapes reserve the slot now per disposition 2; the emit is a later core
-slice), every trace-enumerated frame reads as the default realm — so
-realm grouping/stamping would be speculative UI for constant data. The
-single-realm UX is therefore correct as-is, and the deferred beads carry
-the standing rule (update `tools/xray/spec/*` same-PR) for when the
-observability lands.
+- **Frames panel — groups by realm in multi-realm processes only**
+  (disposition 3, rf2-3caq85). `frame_switcher.cljs` adds
+  `:rf.xray/available-frame-realm-groups` (the pickable frames grouped by
+  `rf/frame-realm`) and the pure `group-frames-by-realm` /
+  `multi-realm?` helpers. When the result spans >1 realm the picker
+  renders an `<optgroup>` per realm (`data-testid
+  rf-xray-ribbon-frame-realm-group-<realm>`); when it collapses to one
+  realm the picker renders the FLAT option list, byte-identical to the
+  pre-bead render. A frame whose realm is unknown buckets to
+  `:rf.realm/default` (absence = default realm, the EP-0013 D1 rule).
+- **Trace rows — surface `:rf.realm/id` where present** (disposition 2,
+  rf2-7vqpwa). `trace_helpers.cljc` projects the row's `:realm` from
+  `[:tags :rf.realm/id]` (`realm-of`), and the feed carries
+  `:multi-realm?` (`multi-realm-feed?`). `panels/trace.cljs` renders a
+  compact realm chip (`data-testid rf-xray-trace-row-<id>-realm`) at the
+  end of the target column ONLY when the arc spans >1 realm AND the row
+  carries a stamp — a single-realm (or unstamped) arc renders unchanged.
+  The framework's trace emit does not stamp `:rf.realm/id` yet (the slot
+  is reserved per disposition 2; the emit is a later core slice), so in a
+  single-realm process every row's `:realm` is nil and the surface is
+  inert — exactly the zero-ceremony posture.
+- **Module-view — the disposition-6 demand-trigger tab** (rf2-wtg9z4).
+  A new Dynamic L4 tab (`panels/module_view.cljs`, label **Modules**,
+  order 9, registered via `reg-l4-tab!` — an L4-only tab, no `mount-*!`
+  facade, so it is NOT in `panel-enum`). It renders the **(realm, frame)
+  address space** of the running process — `rf/realm-ids` × `rf/frame-realm`
+  — as a REALMS section (every installed realm + its frames). The MODULES
+  section (per-module ownership / capability requirements / EP-0015
+  classification / descriptor provenance) is **scaffolded behind an
+  awaiting-seam caption**: those facts live on a *constructed* app value's
+  `:modules` map (`rf/app` / `rf/module`), and a running realm exposes no
+  public read of its installed app value (`re-frame.realm/installed-app`
+  is internal; the internal registrar projection carries no module
+  structure). Per the rf2-wtg9z4 brief this slice does **not** expand core
+  scope to invent the seam — the demand trigger files a follow-up bead
+  (rf2-imquoq) for the public realm→installed-app provenance read surface,
+  and the row
+  shapes already carry the `:owns` / `:requires` / `:classification` slots
+  so the fill-in is a no-reshape change when the seam graduates.
 
 ## The default landing view
 

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -237,6 +237,20 @@ When the Settings "Show tool frames in picker" power-user toggle is on, tool fra
 
 Single-frame apps still get the full `Frame ▾` dropdown — it is interactive and opens a 1-entry list naming that lone frame (rf2-ad7zx.14). The earlier "collapse to a flat label" behaviour is gone (rf2-ad7zx.12 always renders the dropdown). Only a zero-frame state disables the overlaid `<select>` (no inert popup).
 
+**Realm grouping in multi-realm processes (EP-0013 disposition 3 · rf2-3caq85).** When the host runs **more than one runtime realm**, the option list groups frames into an `<optgroup>` per realm (`data-testid rf-xray-ribbon-frame-realm-group-<realm>`), so the `(realm, frame)` address reads at a glance:
+
+```
+┌────────────────────────┐
+│ :rf.realm/default      │   ← <optgroup> label
+│ ✓ :app/main            │
+│   :app/cart            │
+│ :app/realm-b           │   ← <optgroup> label
+│   :other/x             │
+└────────────────────────┘
+```
+
+In a **single-realm process** the grouping collapses to one realm and the picker renders the **flat option list** above — byte-identical to the pre-EP render (zero-ceremony extends to the tooling; the realm dimension is spelled only when more than one realm exists). The grouping reads `:rf.xray/available-frame-realm-groups` (the pickable frames grouped by the public `rf/frame-realm`); the pure helpers `frame_switcher/group-frames-by-realm` + `multi-realm?` decide the branch. A frame whose realm is unknown buckets to `:rf.realm/default` (absence = default realm, the EP-0013 D1 rule).
+
 ### Filter pills
 
 The filter system lives in this cluster — see §7 for full IN/OUT pill semantics and the edit-popup contract.

--- a/tools/xray/spec/023-Trace-Panel.md
+++ b/tools/xray/spec/023-Trace-Panel.md
@@ -104,6 +104,12 @@ Registration ops (`:rf.flow/registered`, `:rf.route/registered`, `:rf.fx/reg-flo
 
 Cross-cutting, **not a stage**. An `:rf.error/*` / `:rf.warning/*` op renders **inline at its chronological point** in the flat list, visually emphasised so failures stand out while scanning (and error vs warning distinguishable) — the row's left edge rides the severity colour over the stage colour; exact treatment delegated to Figma (§8). It carries the failing op's context (the `:rf.error/*` operation id + ex-data). The same diagnostics also populate the Issues panel ([`021`](./021-Dynamic-Panel-Designs.md) §8).
 
+## §7a Realm stamp — where present (EP-0013 disposition 2 · rf2-7vqpwa)
+
+Cross-cutting, **not a stage**. When the focused arc spans **more than one runtime realm**, each row that carries an `:rf.realm/id` stamp surfaces a compact **realm chip** at the end of the target/detail column (`data-testid rf-xray-trace-row-<id>-realm`). The chip is rendered **only when the arc is multi-realm** — a single-realm (or unstamped) arc renders the rows **byte-identically** to the pre-EP panel (zero-ceremony extends to the tooling; the realm dimension is spelled only when it varies).
+
+The row's `:realm` is projected from `[:tags :rf.realm/id]` (`trace_helpers/realm-of`), and the feed carries `:multi-realm?` (`trace_helpers/multi-realm-feed?` — true when the rows span >1 distinct realm). **The framework's trace emit does not stamp `:rf.realm/id` yet** (the slot is reserved per EP-0013 disposition 2; the emit is a later core slice), so in a single-realm process every row's `:realm` is nil and the chip never renders — the surface is inert until the framework stamps it. The (realm, frame) address halves a tool reads are the public `rf/realm-ids` (installed realms) + `rf/frame-realm` (a frame's realm).
+
 ## §8 Visual encoding (delegated to Figma)
 
 Colour and visual styling are intentionally **not specified here** — to be designed in Figma. The design must, however, make these dimensions visually distinguishable:

--- a/tools/xray/spec/026-Module-View-Panel.md
+++ b/tools/xray/spec/026-Module-View-Panel.md
@@ -1,0 +1,133 @@
+# 026 — Module-view Panel
+
+> The Xray-side consumer contract for EP-0013 app values + runtime realms:
+> the **(realm, frame) address space** of the running process and the
+> **disposition-6 demand-trigger** for per-module descriptor provenance.
+
+Status: **shipped (scaffold)** — rf2-wtg9z4. The realm/frame address space
+renders from public seams today; the per-module provenance section is
+scaffolded behind an awaiting-seam caption until a public
+realm→installed-app read surface graduates (follow-up bead rf2-imquoq).
+
+## §1 Purpose & scope
+
+EP-0013 (app values and runtime realms — framework
+[`spec/Runtime-Subsystems.md`](../../../spec/Runtime-Subsystems.md) §Runtime
+realms, [`docs/EP/EP-0013-app-values-and-runtime-realms.md`](../../../docs/EP/EP-0013-app-values-and-runtime-realms.md))
+makes the **realm** the owner of the registrar / adapter / frame-registry.
+A frame belongs to exactly one realm; the `(realm, frame)` pair is the
+**full address** of a runtime context (disposition 3). An *app value* is the
+immutable, composable description of a program (built from feature
+*modules*); a *realm* is the container an app value is installed into.
+
+The Module-view tab is the **cohesive home** for app-value / realm / module
+inspection — per Mike's *cohesive-sub-domains-get-their-own-tab* ruling,
+realm/module structure earns its own L4 tab rather than piling into App-db.
+It is a **browse surface** (registry-wide, like the Static surfaces), not an
+event-coupled lens.
+
+It is also the **named demand trigger** of EP-0013 disposition 6: the EP
+keeps per-module descriptor **provenance** / metadata internal *until an
+Xray module-view demands it*. This is that view (see §4).
+
+## §2 Layout
+
+Two stacked sections (the shared `theme/section` rhythm):
+
+```
+│ ▼ REALMS  (N)                                                   │
+│   :rf.realm/default  · 2 frames                                 │
+│     frames: :app/main  :app/cart                                │
+│ ─────────────────────────────────────────────────────────────  │
+│ ▼ MODULES                                                       │
+│   Per-module ownership, capability requirements, classification │
+│   and descriptor provenance await a public realm→installed-app  │
+│   read seam (EP-0013 disposition 6 graduation).                 │
+```
+
+## §3 REALMS section — the (realm, frame) address space
+
+Every installed runtime realm, each followed by the frames it holds. Reads
+the **public** seams:
+
+- `rf/realm-ids` — the set of installed realm ids (EP-0013 disposition 3 ·
+  PR #4038). A single-realm process returns exactly `#{:rf.realm/default}`.
+- `rf/frame-ids` — the live frame ids.
+- `rf/frame-realm` — a frame's realm (the frame-side address half).
+
+The pure projection (`module_view_helpers/project-module-view`) groups
+frames by realm (`realm-frames`), produces one realm-row per installed
+realm (`project-realm-row`), and classifies single vs multi-realm
+(`:multi-realm?`). Notes:
+
+- **Zero-ceremony.** A single-realm process surfaces one realm with the
+  realm dimension implicit — no realm-grouping ceremony, exactly as a
+  single-frame app never spells a frame.
+- **A frameless realm still appears** — a realm can exist with zero frames.
+- **A stale frame never strands the view** — a frame resolving to a realm
+  absent from `realm-ids` still gets a row (defensive); a nil realm buckets
+  to `:rf.realm/default` (absence = default realm, the EP-0013 D1 rule).
+
+## §4 MODULES section — the disposition-6 demand trigger (scaffolded)
+
+The per-module facts EP-0013 disposition 6 rules public — **ownership**
+(`:owns`), **capability requirements** (`:requires`), **EP-0015
+classification** metadata — plus **descriptor provenance** (which module
+owns a handler / sub / path; source coords).
+
+**These cannot be read from a running process today**, and this slice does
+**not** expand core scope to invent the seam:
+
+- the per-module facts live on a **constructed** app value's `:modules` map
+  (`rf/app` / `rf/module`) — they do not exist on a registrar projection;
+- a **running realm exposes no public read of its installed app value**:
+  `re-frame.realm/installed-app` is internal, and the internal `app-value`
+  projection over a realm's registrar carries no module structure;
+- the public inspectors `rf/app-registrations` / `rf/app-owns` /
+  `rf/app-requires` operate on an app value you **already hold** — there is
+  no public seam to obtain a running realm's app value to feed them.
+
+So the demand trigger **files a follow-up bead** (rf2-imquoq) for the
+public realm→installed-app provenance read surface (the graduation EP-0013
+disposition 6 reserves), and the MODULES section renders the calm
+**awaiting-seam caption** (`module_view_helpers/awaiting-provenance-caption`)
+until it lands. The realm-row shape already carries the `:modules` /
+`:owns` / `:requires` / `:classification` slots (defaulted nil/empty) and
+`:provenance-available?` (false), so the fill-in is a **no-reshape change**
+when the seam graduates.
+
+## §5 Tab registration
+
+A **Dynamic L4 tab** registered via `panel-registry/reg-l4-tab!` in
+`panels/module_view.cljs`'s `install!`: id `:module-view`, label
+**"Modules"**, mnemonic `u`, order **9** (after the Derivation-Graph at 8,
+keeping the cross-feature runtime-structure tabs adjacent).
+
+Like the Derivation-Graph tab this is an **L4-only** surface — it exposes
+no standalone `mount-*!` facade, so it is **not** in
+[`panel_enum.cljc`](../src/day8/re_frame2_xray/panel_enum.cljc) (that enum
+carries the *mountable* surface; an L4-only tab is shell-internal). The
+Cmd-K palette picks it up automatically (the palette reads
+`panel-registry/tabs-for-mode :dynamic`).
+
+## §6 Data sources & privacy
+
+- `:rf.xray/module-view` — the view composite; reads `rf/realm-ids` ·
+  `rf/frame-ids` · `rf/frame-realm` at recompute time and projects via the
+  pure helper. **Read-only** — enumerating realms/frames pins nothing and
+  dispatches nothing.
+- The surface carries realm/frame **ids only** (keywords), no app-db values
+  — there is no data egress concern in this slice. When the provenance seam
+  graduates, the off-box egress posture (the
+  [`025`](025-Derivation-Graph-Panel.md) §egress redaction pattern) applies
+  to any value-bearing module metadata.
+
+## §7 Implementation
+
+- `panels/module_view.cljs` — the panel view + `install!` (sub + tab).
+- `panels/module_view_helpers.cljc` — the pure `data → data` projection
+  (`realm-frames` · `project-realm-row` · `project-module-view` ·
+  `awaiting-provenance-caption` · `realm-summary-line`); JVM-testable.
+- Tests: `panels/module_view_helpers_cljs_test.cljc` (the projection
+  shape + the zero-ceremony / multi-realm classification + the empty /
+  stale-frame edge cases + the awaiting-seam caption).

--- a/tools/xray/spec/README.md
+++ b/tools/xray/spec/README.md
@@ -128,6 +128,19 @@ main read**.
   per-frame, fail-closed, via `rf/elide-wire-value`; redact value, keep
   edge): on-box rendering is raw (Security.md permits on-box), off-box
   egress projects through the frame's elision policy. Read-only.
+- **[026-Module-View-Panel.md](026-Module-View-Panel.md)** — The
+  Module-view tab: the Xray-side consumer contract for EP-0013 app values +
+  runtime realms (framework
+  [`spec/Runtime-Subsystems.md`](../../../spec/Runtime-Subsystems.md) §Runtime
+  realms). Renders the **(realm, frame) address space** of the running
+  process — `rf/realm-ids` × `rf/frame-realm` (disposition 3) — as a REALMS
+  section (every installed realm + its frames), zero-ceremony (single-realm
+  implicit). The **disposition-6 demand trigger** for per-module ownership /
+  capability / EP-0015 classification / descriptor provenance: that section
+  is **scaffolded** behind an awaiting-seam caption (a running realm exposes
+  no public read of its installed app value — the demand files a follow-up
+  for the realm→installed-app provenance seam rather than expanding core).
+  An L4-only Dynamic tab (not in `panel-enum`). Read-only.
 
 ### Reference
 

--- a/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/frame_switcher.cljs
@@ -85,6 +85,24 @@
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens type-scale sans-stack]]))
 
+;; ---- public contract: realm grouping (EP-0013 disposition 3 · rf2-3caq85) --
+;;
+;; In a MULTI-REALM process the picker groups its frame options by the
+;; runtime realm each frame belongs to (a `<optgroup>` per realm). In a
+;; SINGLE-REALM process the picker render is BYTE-IDENTICAL to the
+;; pre-bead flat option list — zero-ceremony extends to the tooling
+;; (EP-0013 disposition 3: a single-realm app never spells a realm, and
+;; neither does its devtool). The grouping appears ONLY when more than
+;; one distinct realm is present across the pickable frames.
+;;
+;; The frame→realm map is the public `re-frame.frame/frame-realm`
+;; (re-exported `rf/frame-realm`) — the frame-side half of the (realm,
+;; frame) address. Pairing it with `rf/realm-ids` (the installed realms)
+;; is the full address-space walk EP-0013 disposition 3 documents. The
+;; grouping helper takes the resolver as an argument so the pure
+;; data-shape logic runs under the unit-test target without a live
+;; frame registry.
+
 ;; ---- public contract: which frames Xray filters out by default ---------
 
 (def internal-frames
@@ -144,6 +162,48 @@
                        (not (contains? internal-frames f)))
               f)))
         (reverse cascades)))
+
+;; ---- realm grouping (EP-0013 disposition 3 · rf2-3caq85) ----------------
+
+(defn group-frames-by-realm
+  "Pure helper — group `frames` (a first-seen-order vec from
+  `distinct-frames`) by the runtime realm each frame belongs to, using
+  `realm-of` (a `frame-id → realm-id` resolver, normally
+  `rf/frame-realm`). Returns a vector of `{:realm <realm-id> :frames
+  [<frame-id> …]}` groups in first-realm-seen order, each group's
+  `:frames` preserving the input frame order.
+
+  Frames whose `realm-of` resolves to nil (an unknown / destroyed frame
+  the picker still lists) fall into a single trailing group keyed by
+  `:rf.realm/default` — absence is the default realm, the documented
+  EP-0013 D1 rule, so an unstamped frame never strands the picker.
+
+  The view calls `multi-realm?` on the result first: in a single-realm
+  process this collapses to one group and the picker renders the FLAT
+  option list (byte-identical to the pre-bead render); only a
+  multi-realm result drives the `<optgroup>` grouping. Pure data → data;
+  JVM-testable."
+  [frames realm-of]
+  (let [order (volatile! [])
+        seen  (volatile! #{})]
+    (->> frames
+         (reduce
+           (fn [acc f]
+             (let [rid (or (realm-of f) :rf.realm/default)]
+               (when-not (contains? @seen rid)
+                 (vswap! seen conj rid)
+                 (vswap! order conj rid))
+               (update acc rid (fnil conj []) f)))
+           {})
+         (#(mapv (fn [rid] {:realm rid :frames (get % rid)}) @order)))))
+
+(defn multi-realm?
+  "Pure predicate — true when `groups` (the `group-frames-by-realm`
+  result) spans more than one realm. Drives the picker's zero-ceremony
+  branch: a single-realm process renders the flat option list, a
+  multi-realm process renders `<optgroup>`s. Pure; JVM-testable."
+  [groups]
+  (> (count groups) 1))
 
 ;; ---- persistence ---------------------------------------------------------
 
@@ -326,6 +386,12 @@
   [_props]
   (let [selected-frame  @(rf/subscribe [:rf.xray/current-frame])
         frames          @(rf/subscribe [:rf.xray/available-frames])
+        ;; rf2-3caq85 — the realm grouping of the same pickable frames.
+        ;; A single-realm process collapses to one group and renders the
+        ;; flat option list below (byte-identical to the pre-bead render);
+        ;; only a multi-realm process renders `<optgroup>`s.
+        realm-groups    @(rf/subscribe [:rf.xray/available-frame-realm-groups])
+        multi-realm     (multi-realm? realm-groups)
         active          (or selected-frame (first frames))
         ;; rf2-ad7zx.14 — interactive whenever there is >=1 frame. A native
         ;; <select> with one option opens + shows it (not inert), which is
@@ -392,10 +458,23 @@
                              :border     "none"
                              :margin     0
                              :padding    0}}
-      (for [f frames]
-        ^{:key (str f)}
-        [:option {:value (str f)}
-         (str (if (= f active) "✓ " "  ") f)])]]))
+      ;; rf2-3caq85 — in a MULTI-REALM process the options group by realm
+      ;; (a `<optgroup>` per realm). In a SINGLE-REALM process this branch
+      ;; is skipped and the flat option list below renders byte-identically
+      ;; to the pre-bead picker — zero-ceremony extends to the tooling.
+      (if multi-realm
+        (for [{:keys [realm frames]} realm-groups]
+          ^{:key (str realm)}
+          [:optgroup {:label       (str realm)
+                      :data-testid (str "rf-xray-ribbon-frame-realm-group-" (name realm))}
+           (for [f frames]
+             ^{:key (str f)}
+             [:option {:value (str f)}
+              (str (if (= f active) "✓ " "  ") f)])])
+        (for [f frames]
+          ^{:key (str f)}
+          [:option {:value (str f)}
+           (str (if (= f active) "✓ " "  ") f)]))]]))
 
 ;; ---- install -------------------------------------------------------------
 
@@ -510,6 +589,23 @@
     (fn [cascades _query]
       ;; show-tool-frames? hardcoded false — see ns docstring.
       (distinct-frames cascades false)))
+
+  ;; `:rf.xray/available-frame-realm-groups` (rf2-3caq85) — the same
+  ;; pickable frames, grouped by the runtime realm each belongs to
+  ;; (EP-0013 disposition 3). Composes off `:rf.xray/available-frames`
+  ;; and resolves each frame's realm through the PUBLIC `rf/frame-realm`
+  ;; (the frame-side half of the (realm, frame) address). In a
+  ;; single-realm process every frame resolves to the default realm, so
+  ;; the result is ONE group and the picker renders the flat option list
+  ;; (byte-identical to the pre-bead render — `multi-realm?` is false);
+  ;; only a multi-realm process drives the `<optgroup>` grouping in the
+  ;; view. The resolver is `frame/frame-realm` (live frame registry); the
+  ;; pure grouping is `group-frames-by-realm` so the data shape is
+  ;; JVM-testable independently of a runtime.
+  (rf/reg-sub :rf.xray/available-frame-realm-groups
+    :<- [:rf.xray/available-frames]
+    (fn [frames _query]
+      (group-frames-by-realm frames frame/frame-realm)))
 
   ;; ---- events --------------------------------------------------------
   ;;

--- a/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
@@ -1,0 +1,210 @@
+(ns day8.re-frame2-xray.panels.module-view
+  "Module-view tab — the EP-0013 disposition-6 demand-trigger surface
+  (rf2-wtg9z4).
+
+  ## What this tab shows
+
+  The (realm, frame) ADDRESS SPACE of the running process (EP-0013
+  disposition 3): every installed runtime realm, and the frames each
+  realm holds. It is a BROWSE surface (Static-style — registry-wide, not
+  event-coupled), the cohesive home for app-value / realm / module
+  inspection (per Mike's 'cohesive sub-domains get their own tab' ruling —
+  realm/module structure earns its own L4 tab rather than piling into
+  App-db).
+
+      │ REALMS                                                          │
+      │   :rf.realm/default  · 2 frames                                 │
+      │     frames: :app/main  :app/cart                                │
+      │ ─────────────────────────────────────────────────────────────  │
+      │ MODULES                                                         │
+      │   Per-module ownership, capability requirements, classification │
+      │   and descriptor provenance await a public realm→installed-app  │
+      │   read seam (EP-0013 disposition 6 graduation).                 │
+
+  ## The provenance graduation (why MODULES is scaffolded)
+
+  EP-0013 disposition 6 keeps per-module descriptor PROVENANCE / metadata
+  (`:owns` · `:requires` · EP-0015 classification · source coords)
+  INTERNAL until a Module-view demands it — and this is that view. But
+  reading those facts from a RUNNING process needs a CORE seam that has
+  not shipped: there is no public read of a realm's installed app value,
+  and the internal projection over a realm's registrar carries no module
+  structure at all (the per-module facts exist only on a CONSTRUCTED app
+  value — `rf/app` / `rf/module`). Per the rf2-wtg9z4 brief, this slice
+  does NOT silently expand core scope to invent the seam — a follow-up
+  bead is filed for the public realm→installed-app provenance read
+  surface, and the MODULES section renders the calm awaiting-seam caption
+  until it graduates. The row shapes already carry the
+  `:owns` / `:requires` / `:classification` slots so the fill-in is a
+  no-reshape change.
+
+  ## Public seams used (all genuinely public today)
+
+    - `rf/realm-ids`  — the installed realm ids (EP-0013, PR #4038);
+    - `rf/frame-ids`  — the live frame ids;
+    - `rf/frame-realm`— a frame's realm (the frame-side address half).
+
+  ## Zero-ceremony (single-realm unchanged)
+
+  A single-realm process resolves `rf/realm-ids` to exactly
+  `#{:rf.realm/default}`; the tab renders one realm with the realm
+  dimension implicit (no realm grouping ceremony) — the (realm) axis is
+  spelled only when more than one realm exists, exactly as a single-frame
+  app never spells a frame.
+
+  ## Pure hiccup + helpers
+
+  Same contract as every Xray panel — pure hiccup, no Reagent / UIx /
+  Helix. The pure data → data projection (address-space assembly, the
+  realm-row shape, single/multi-realm classification) lives in
+  `module_view_helpers.cljc` so the algebra runs under the JVM unit-test
+  target."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.panels.module-view-helpers :as h]
+            [day8.re-frame2-xray.theme.section :as section]
+            [day8.re-frame2-xray.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- styles --------------------------------------------------------------
+
+(def ^:private panel-root-style
+  {:height         "100%"
+   :display        "flex"
+   :flex-direction "column"
+   :background     (:bg-2 tokens)
+   :color          (:text-primary tokens)
+   :font-family    sans-stack
+   :font-size      "14px"})
+
+(def ^:private panel-scroll-container-style
+  {:flex 1 :overflow "auto"})
+
+(def ^:private realm-row-style
+  {:display       "flex"
+   :align-items   "baseline"
+   :gap           "8px"
+   :padding       "2px 0"
+   :font-family   mono-stack
+   :font-size     "12px"})
+
+(def ^:private realm-id-style
+  {:color       (:accent tokens)
+   :font-weight 600})
+
+(def ^:private realm-meta-style
+  {:color (:text-tertiary tokens)})
+
+(def ^:private realm-frames-style
+  {:color       (:text-secondary tokens)
+   :padding     "1px 0 4px 18px"
+   :font-family mono-stack
+   :font-size   "11px"})
+
+(def ^:private awaiting-caption-style
+  {:color       (:text-tertiary tokens)
+   :font-family sans-stack
+   :font-size   "12px"
+   :line-height 1.5})
+
+;; ---- realm row -----------------------------------------------------------
+
+(defn- realm-row
+  "Render one realm: its id + frame count, with the realm's frames listed
+  beneath. Pure hiccup."
+  [{:keys [realm frames frame-count] :as _realm-row}]
+  (let [rid-name (name realm)]
+    [:div {:data-testid (str "rf-xray-module-view-realm-" rid-name)}
+     [:div {:style realm-row-style}
+      [:span {:data-testid (str "rf-xray-module-view-realm-" rid-name "-id")
+              :style       realm-id-style}
+       (str realm)]
+      [:span {:style realm-meta-style}
+       (str "· " frame-count " frame" (when (not= 1 frame-count) "s"))]]
+     (when (seq frames)
+       [:div {:data-testid (str "rf-xray-module-view-realm-" rid-name "-frames")
+              :style       realm-frames-style}
+        (str "frames: " (str/join "  " (map str frames)))])]))
+
+;; ---- public view ---------------------------------------------------------
+
+(rf/reg-view Panel
+  "The Module-view tab's root — the (realm, frame) address space of the
+  running process (EP-0013 disposition 3 · rf2-wtg9z4). Subscribes to
+  `:rf.xray/module-view` (the projected address space) and renders a
+  REALMS section (every installed realm + its frames) followed by a
+  MODULES section that, until the per-module provenance seam graduates
+  (rf2-wtg9z4 follow-up rf2-imquoq), reads the calm awaiting-seam caption."
+  []
+  (let [{:keys [realms provenance-available?] :as _data}
+        @(rf/subscribe [:rf.xray/module-view])]
+    [:section {:data-testid "rf-xray-module-view"
+               :style       panel-root-style}
+     [:div {:style panel-scroll-container-style}
+      ;; REALMS — the installed realms and each realm's frames.
+      (section/section-row
+        {:label  "Realms"
+         :testid "rf-xray-module-view-realms"
+         :count* (count realms)}
+        (into [:div {:data-testid "rf-xray-module-view-realms-list"}]
+              (for [r realms]
+                (with-meta (realm-row r) {:key (str (:realm r))}))))
+      ;; MODULES — the per-module ownership / capability / classification /
+      ;; provenance facts. Scaffolded: until the core realm→installed-app
+      ;; read seam graduates (rf2-wtg9z4 follow-up rf2-imquoq) this reads the calm
+      ;; awaiting-seam caption rather than fabricating data.
+      (section/section-row
+        {:label  "Modules"
+         :testid "rf-xray-module-view-modules"}
+        (if provenance-available?
+          ;; rf2-wtg9z4 follow-up rf2-imquoq fills this in from the graduated seam.
+          [:div {:data-testid "rf-xray-module-view-modules-list"}]
+          [:div {:data-testid "rf-xray-module-view-modules-awaiting"
+                 :style       awaiting-caption-style}
+           h/awaiting-provenance-caption]))]]))
+
+;; ---- registration entry --------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Module-view tab's Xray-side registrations
+  (rf2-wtg9z4). Registers the address-space composite + the Dynamic L4
+  tab."
+  []
+  ;; `:rf.xray/module-view` — the projected (realm, frame) address space.
+  ;; Reads the PUBLIC realm/frame seams (`rf/realm-ids` · `rf/frame-ids` ·
+  ;; `rf/frame-realm`) and projects via the pure
+  ;; `module-view-helpers/project-module-view`. Read-only — enumerating
+  ;; realms/frames pins nothing and dispatches nothing.
+  ;;
+  ;; It does NOT compose off an `:rf.xray/*` app-db slot because the
+  ;; address space is a process-global fact (realms + frames live in the
+  ;; framework's registries, not Xray's app-db). The sub reads them
+  ;; directly at recompute time; a tab activation (`:rf.xray/select-tab`)
+  ;; re-renders the panel which re-derefs. (A future live-refresh signal
+  ;; can compose this off a frame/realm-lifecycle tick if the operator
+  ;; wants push updates; today the browse-on-open shape matches the other
+  ;; Static-style surfaces.)
+  (rf/reg-sub :rf.xray/module-view
+    (fn [_db _query]
+      (h/project-module-view (rf/realm-ids)
+                             (rf/frame-ids)
+                             frame/frame-realm)))
+
+  ;; Register the Dynamic Module-view tab with the internal L4 tab
+  ;; registry. Order 9 — after the Derivation-Graph (order 8), keeping the
+  ;; cross-feature runtime-structure tabs adjacent. Label is the domain
+  ;; noun "Modules" (the app-value module is the tab's subject). Like the
+  ;; Derivation-Graph tab this is a reg-l4-tab! surface only — it exposes
+  ;; no standalone `mount-*!` facade, so it is NOT in `panel-enum` (that
+  ;; enum carries the mountable surface; an L4-only tab is shell-internal).
+  (panel-registry/reg-l4-tab!
+    {:id    :module-view
+     :label "Modules"
+     :mnem  "u"
+     :modes #{:dynamic}
+     :order 9
+     :panel Panel})
+
+  nil)

--- a/tools/xray/src/day8/re_frame2_xray/panels/module_view_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/module_view_helpers.cljc
@@ -1,0 +1,178 @@
+(ns day8.re-frame2-xray.panels.module-view-helpers
+  "Pure-data helpers for Xray's Module-view tab — the EP-0013 disposition-6
+  demand-trigger surface (rf2-wtg9z4).
+
+  ## What this view shows
+
+  EP-0013 introduces *app values* (immutable descriptions of a program,
+  composed from feature *modules*) and *runtime realms* (the containers a
+  program is installed into). The Module-view is the disposition-6 NAMED
+  DEMAND TRIGGER: the view that would inspect, per module, the three
+  public descriptor facts EP-0013 disposition 6 rules —
+
+    - **ownership** (`:owns`) — the app-db paths / routes / resources a
+      module declares it owns;
+    - **capability requirements** (`:requires`) — the `:rf.capability/*`
+      a module's install demands;
+    - **EP-0015 classification metadata** — the durable data
+      classification a module's surfaces carry;
+
+  plus, as the trigger itself, **descriptor provenance** (which module
+  owns a handler / sub / path; source coordinates).
+
+  ## The provenance graduation (why this slice is a SCAFFOLD)
+
+  EP-0013 keeps descriptor PROVENANCE / module metadata INTERNAL until a
+  Module-view demands it — and this is that view. But the graduation is a
+  CORE slice, not a tooling slice: the per-module facts above live on a
+  CONSTRUCTED app value's `:modules` map (`rf/app` / `rf/module`), and a
+  RUNNING realm exposes no public read of its installed app value.
+
+    - `re-frame.realm/installed-app` is INTERNAL (no `rf/*` re-export);
+    - even the internal `app-value` PROJECTION over a realm's registrar
+      carries NO `:modules`, NO `:owns`, NO `:requires` (load-order
+      registrations have no module — those facts exist only on a
+      constructed app value);
+    - the public inspectors `rf/app-registrations` / `rf/app-owns` /
+      `rf/app-requires` operate on an app value you ALREADY HOLD — there
+      is no public seam to obtain a running realm's app value to feed
+      them.
+
+  So the per-module provenance / ownership / capability / classification
+  inspection the bead names CANNOT be read from a running process today.
+  Per the rf2-wtg9z4 brief, the view does NOT silently expand core scope
+  to invent the seam — a follow-up bead is filed for the public
+  realm→installed-app provenance read surface, and THIS slice ships the
+  parts the genuinely-public seams support:
+
+    - the **realm / frame address space** — `rf/realm-ids` (the installed
+      realms) × `rf/frame-realm` (each frame's realm), the (realm, frame)
+      address EP-0013 disposition 3 documents;
+    - per realm, its **frames** and a per-realm capability surface WHEN a
+      constructed app value is available to the tooling (it is not, in a
+      pure load-order app — so the module section reads a calm
+      awaiting-core-seam caption rather than fabricating data).
+
+  When the core provenance seam graduates (the follow-up bead), the
+  module section fills in from it with no reshape here — the row shapes
+  below already carry the `:owns` / `:requires` / `:classification` /
+  `:provenance` slots, defaulted to nil/empty until the seam supplies
+  them.
+
+  ## Zero-ceremony (single-realm unchanged)
+
+  In a single-realm process `rf/realm-ids` returns exactly
+  `#{:rf.realm/default}`. The view still renders (a Module-view is a
+  browse surface, not an event-coupled lens), but it surfaces ONE realm
+  with no realm-grouping ceremony — the (realm) dimension is implicit,
+  exactly as the single-frame app never spells a frame. `multi-realm?`
+  drives whether the realm dimension is foregrounded.
+
+  ## Why a separate `.cljc` ns
+
+  Mirrors every other Xray panel: the panel view paints + dispatches; the
+  pure data → data projection (realm address-space assembly, the
+  module-row shape, the single/multi-realm classification) lives here so
+  it runs under the JVM unit-test target (`clojure -M:test`)."
+  (:require [clojure.string :as str]))
+
+;; ---- realm / frame address space (EP-0013 disposition 3) ----------------
+
+(defn realm-frames
+  "Group `frame-ids` by the realm each belongs to, using `realm-of` (a
+  `frame-id → realm-id` resolver, normally `rf/frame-realm`). Returns
+  `{realm-id #{frame-id …}}`. A frame whose `realm-of` resolves to nil
+  falls into the `:rf.realm/default` bucket (absence = default realm, the
+  EP-0013 D1 rule). Pure data → data; JVM-testable."
+  [frame-ids realm-of]
+  (reduce
+    (fn [acc fid]
+      (let [rid (or (realm-of fid) :rf.realm/default)]
+        (update acc rid (fnil conj #{}) fid)))
+    {}
+    frame-ids))
+
+(defn project-realm-row
+  "Project one realm into the Module-view's realm-row shape:
+
+      {:realm          <realm-id>
+       :frames         [<frame-id> …]   ;; sorted for stable render
+       :frame-count    <int>
+       ;; provenance slots — AWAITING the core realm→installed-app seam
+       ;; (rf2-wtg9z4 follow-up rf2-imquoq). nil/empty until it graduates; the row
+       ;; shape already carries them so the fill-in is a no-reshape change.
+       :modules        nil
+       :requires       #{}
+       :owns           nil
+       :classification nil}
+
+  `realm-id` is the realm; `frames` is the set of frame-ids in that realm
+  (from `realm-frames`). Pure data → data; JVM-testable."
+  [realm-id frames]
+  {:realm          realm-id
+   :frames         (vec (sort-by str frames))
+   :frame-count    (count frames)
+   :modules        nil
+   :requires       #{}
+   :owns           nil
+   :classification nil})
+
+(defn project-module-view
+  "Top-level projection — produce every slot the Module-view needs from
+  the (realm, frame) address space (EP-0013 disposition 3). Pure data →
+  data; JVM-testable.
+
+  `realm-ids` is the set of installed realm ids (`rf/realm-ids`);
+  `frame-ids` is the set/seq of live frame ids (`rf/frame-ids`);
+  `realm-of` resolves a frame's realm (`rf/frame-realm`).
+
+  Returns:
+
+      {:realms        [{:realm … :frames … :frame-count … …} …]  ;; per realm,
+                                     ;; sorted by realm-id for stable render
+       :realm-count   <int>
+       :multi-realm?  <bool>        ;; >1 realm → the realm dimension is
+                                    ;; foregrounded; single-realm renders
+                                    ;; with the (realm) dimension implicit
+       :provenance-available? false ;; rf2-wtg9z4 — the per-module
+                                    ;; provenance seam has not graduated
+                                    ;; (no public realm→installed-app read);
+                                    ;; the view shows the awaiting-seam
+                                    ;; caption while this is false}
+
+  Every installed realm appears even when it holds no frames (a realm can
+  exist with zero frames). Pure data → data."
+  [realm-ids frame-ids realm-of]
+  (let [by-realm (realm-frames frame-ids realm-of)
+        ;; Every installed realm, plus any realm a frame resolves into
+        ;; that somehow isn't in realm-ids (defensive — the two should
+        ;; agree, but a stale frame must never strand the view).
+        all-rids (into (set realm-ids) (keys by-realm))
+        realms   (->> all-rids
+                      (sort-by str)
+                      (mapv (fn [rid]
+                              (project-realm-row rid (get by-realm rid #{})))))]
+    {:realms                realms
+     :realm-count           (count realms)
+     :multi-realm?          (> (count realms) 1)
+     ;; rf2-wtg9z4 — flipped to true by the follow-up bead that ships the
+     ;; public realm→installed-app provenance read seam.
+     :provenance-available? false}))
+
+;; ---- awaiting-seam caption (rf2-wtg9z4) ---------------------------------
+
+(def awaiting-provenance-caption
+  "The calm caption the module section renders while the per-module
+  provenance seam has not graduated (rf2-wtg9z4 follow-up rf2-imquoq). Names the
+  facts the view WILL surface so the operator understands the surface is
+  scaffolded, not broken. Pure data → string."
+  (str "Per-module ownership, capability requirements, classification, "
+       "and descriptor provenance are not yet readable from a running "
+       "process — they await a public realm→installed-app read seam "
+       "(EP-0013 disposition 6 graduation)."))
+
+(defn realm-summary-line
+  "A one-line plain-language summary for a realm row — `<realm-id> · N
+  frame(s)`. Pure data → string; JVM-testable."
+  [{:keys [realm frame-count] :as _realm-row}]
+  (str realm " · " frame-count " frame" (when (not= 1 frame-count) "s")))

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -310,6 +310,22 @@
    :white-space "nowrap"
    :text-align  "right"})
 
+;; rf2-7vqpwa — the realm stamp chip. Rendered inline in the target
+;; column ONLY when the focused arc spans more than one realm (EP-0013
+;; disposition 2 — surface the `:rf.realm/id` WHERE PRESENT, omit
+;; otherwise). A single-realm (or unstamped) arc never renders this, so
+;; the row is byte-identical to the pre-bead panel (zero-ceremony).
+(def ^:private op-row-realm-chip-style
+  {:flex-shrink    0
+   :color          (:text-tertiary tokens)
+   :background     (:bg-1 tokens)
+   :border         (str "1px solid " (:border-subtle tokens))
+   :border-radius  "3px"
+   :padding        "0 4px"
+   :font-size      "10px"
+   :letter-spacing "0.3px"
+   :white-space    "nowrap"})
+
 ;; Severity row tints — `color-mix` over the semantic CSS-var keeps
 ;; light/dark theme correct (the var resolves at paint time).
 (def ^:private op-row-bg-error
@@ -583,10 +599,18 @@
   duration). Each carries `data-rf-xray-resizable-col` so the
   pointer-down handler can locate the adjacent cell off the live DOM,
   AND keeps the original `data-testid` so the trace_view tests resolve
-  unchanged."
+  unchanged.
+
+  `multi-realm?` (rf2-7vqpwa) drives the conditional realm stamp: when
+  the focused arc spans >1 realm AND this row carries a `:rf.realm/id`
+  stamp, a compact realm chip rides at the end of the target column. A
+  single-realm (or unstamped) arc never renders it — the row is
+  byte-identical to the pre-bead panel (zero-ceremony)."
   [{:keys [id operation rel-time time area area-badge stage-label
-           stage-colour verb target duration-ms source-coord dispatch-id]
-    :as row}]
+           stage-colour verb target duration-ms source-coord dispatch-id
+           realm]
+    :as row}
+   multi-realm?]
   ;; rf2-nesy9 — render-time frame capture for the deferred cell handlers.
   (let [frame       (rf/current-frame-id)
         row-test-id (str "rf-xray-trace-row-" id)
@@ -666,7 +690,17 @@
                                     {:kind :dispatch-id :id dispatch-id}]
                                    {:frame frame}))
                   :style       op-row-cancellation-button-style}
-         "⟲"])]
+         "⟲"])
+      ;; rf2-7vqpwa — the realm stamp, surfaced WHERE PRESENT (EP-0013
+      ;; disposition 2). Renders ONLY when the arc spans >1 realm AND
+      ;; this row carries a `:rf.realm/id`; a single-realm / unstamped
+      ;; arc renders nothing here (zero-ceremony — the row is unchanged).
+      (when (and multi-realm? realm)
+        [:span {:data-testid (str row-test-id "-realm")
+                :data-rf-xray-realm (name realm)
+                :title       (str "Runtime realm: " realm)
+                :style       op-row-realm-chip-style}
+         (str realm)])]
      ;; ⑥ duration — `N.N ms` when timed, em-dash otherwise (spec/023 §6).
      [:span {:data-rf-xray-resizable-col "duration"
              :data-testid (str row-test-id "-duration")
@@ -706,8 +740,11 @@
   rows (rf2-aqusw). Rows mount through `rt/resizable-table` with
   `:header? false` (the header lives once at the top of the panel) so
   the list shares the `:rf.xray.trace/ops` column-widths slot — a drag
-  on the panel header re-aligns every row live."
-  [rows expanded-row-ids]
+  on the panel header re-aligns every row live.
+
+  `multi-realm?` (rf2-7vqpwa) is threaded to every row's cells so the
+  realm stamp surfaces only when the arc spans >1 realm (zero-ceremony)."
+  [rows expanded-row-ids multi-realm?]
   [rt/resizable-table
    {:table-id        trace-ops-table-id
     :header?         false
@@ -720,7 +757,7 @@
                        (op-row-attrs row
                                      (contains? (or expanded-row-ids #{})
                                                 (:id row))))
-    :row-cells       (fn [row _i] (op-row-cells row))
+    :row-cells       (fn [row _i] (op-row-cells row multi-realm?))
     :row-extras      (fn [row _i]
                        (op-row-extras row
                                       (contains? (or expanded-row-ids #{})
@@ -783,7 +820,7 @@
   on its raw trace MAP inline. No bands, no envelope, no hierarchy. No
   mock data — fed by real trace data throughout."
   []
-  (let [{:keys [rows empty-kind] :as _data}
+  (let [{:keys [rows empty-kind multi-realm?] :as _data}
         @(rf/subscribe [:rf.xray/trace-feed])
         ;; rf2-wcfsy — focused-cascade is a layer-3 composite over
         ;; `:rf.xray/cascades` + `:rf.xray/focus`, NOT an inline scan in
@@ -825,8 +862,10 @@
            :header-cell-style trace-header-cell-style}]
          ;; rf2-aqusw — the flat list of every op the focused epoch
          ;; emitted, in fire order (oldest-first). No bands, no envelope.
+         ;; rf2-7vqpwa — `multi-realm?` threads the realm-surface gate so
+         ;; the per-row realm stamp shows only in a multi-realm arc.
          ^{:key "rows"}
-         (flat-row-list rows expanded-ids)])]]))
+         (flat-row-list rows expanded-ids multi-realm?)])]]))
 
 ;; ---- registration entry --------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
@@ -692,6 +692,21 @@
   (or (get-in ev [:tags :frame])
       (:frame ev)))
 
+(defn realm-of
+  "Project the event's runtime realm id — the `:rf.realm/id` stamp
+  (EP-0013 disposition 2), WHERE PRESENT. Reads `[:tags :rf.realm/id]`
+  then a top-level `:rf.realm/id` fallback (defensive against the
+  emit-shape settling). Returns nil when the event carries no realm
+  stamp — today the framework's trace emit does not stamp it (the slot
+  is reserved per disposition 2; the actual emit is a later core slice),
+  so this is nil for every event in a single-realm process and the view
+  renders the trace rows unchanged (zero-ceremony). When a realm stamp
+  IS present, the view surfaces it WHERE PRESENT and omits it otherwise.
+  Pure data → keyword-or-nil; JVM-testable."
+  [ev]
+  (or (get-in ev [:tags :rf.realm/id])
+      (:rf.realm/id ev)))
+
 (defn origin-of
   "Project the dispatch-origin slot (`:tags :rf.event/origin`).
   Defensive against absence — returns nil."
@@ -783,6 +798,9 @@
        :source          <kw-or-nil>
        :origin          <kw-or-nil>
        :frame           <kw-or-nil>
+       :realm           <kw-or-nil>        ;; the :rf.realm/id stamp (EP-0013
+                                           ;; disposition 2) WHERE PRESENT;
+                                           ;; nil otherwise (single-realm)
        :event-id        <kw-or-nil>
        :handler-id      <kw-or-nil>
        :dispatch-id     <int-or-nil>
@@ -825,6 +843,7 @@
    :source          (or source (get-in ev [:tags :source]))
    :origin          (origin-of ev)
    :frame           (frame-of ev)
+   :realm           (realm-of ev)
    :event-id        (get-in ev [:tags :rf.trace/event-id])
    :handler-id      (get-in ev [:tags :handler-id])
    :dispatch-id     (get-in ev [:tags :rf.trace/dispatch-id])
@@ -854,6 +873,35 @@
   (into [] (comp (filter (comp some? :id))
                  (map project-row))
         events))
+
+;; ---- realm surface (EP-0013 disposition 2 · rf2-7vqpwa) -----------------
+;;
+;; The realm stamp `:rf.realm/id` is surfaced in the Trace rows WHERE
+;; PRESENT and omitted otherwise (zero-ceremony: single-realm rows are
+;; unchanged). The view reads `multi-realm-feed?` over the projected rows
+;; to decide whether to render the realm surface at all — in a
+;; single-realm process every row's `:realm` is nil (the framework does
+;; not stamp it yet — the slot is reserved per disposition 2, the emit is
+;; a later core slice), so the predicate is false and the rows render
+;; byte-identically to the pre-bead panel. Only when the rows actually
+;; span more than one realm does the view surface the stamp.
+
+(defn feed-realms
+  "The set of distinct non-nil `:rf.realm/id` stamps across `rows` — the
+  realms the focused epoch's trace arc touched (EP-0013 disposition 2).
+  Empty in a single-realm process (no row carries a realm stamp). Pure
+  data → set; JVM-testable."
+  [rows]
+  (into #{} (keep :realm) rows))
+
+(defn multi-realm-feed?
+  "Pure predicate — true when the projected `rows` carry MORE THAN ONE
+  distinct realm stamp. Drives the Trace view's zero-ceremony branch: the
+  realm surface (a conditional inline stamp on each row) renders ONLY
+  when the arc spans multiple realms; a single-realm (or unstamped) arc
+  renders unchanged. Pure; JVM-testable."
+  [rows]
+  (> (count (feed-realms rows)) 1))
 
 ;; ---- band projection (spec/023 §2 · §4) ---------------------------------
 ;;
@@ -992,6 +1040,8 @@
        :total       <int>         ;; the epoch's trace-event count
        :rendered    <int>         ;; same as :total (no filtering)
        :epoch-id    <int-or-nil>  ;; the focused epoch's id
+       :multi-realm? <bool>       ;; rf2-7vqpwa — arc spans >1 realm (the
+                                  ;; view surfaces the realm stamp only then)
        :empty-kind  <:no-events / :no-focus / :epoch-evicted / nil>}
 
   Rows render OLDEST-first (chronological) so the arc reads top-down —
@@ -1019,14 +1069,18 @@
                           (= focus-status :epoch-evicted) :epoch-evicted
                           (zero? n)                       :no-events
                           :else                           nil)]
-    {:rows       rows
-     :envelope   envelope
-     :outcome    outcome
-     :bands      bands
-     :total      n
-     :rendered   n
-     :epoch-id   (:epoch-id epoch-record)
-     :empty-kind empty-kind}))
+    {:rows         rows
+     :envelope     envelope
+     :outcome      outcome
+     :bands        bands
+     :total        n
+     :rendered     n
+     :epoch-id     (:epoch-id epoch-record)
+     ;; rf2-7vqpwa — true only when the arc spans >1 realm; the view
+     ;; renders the realm surface (a conditional inline stamp per row)
+     ;; ONLY then, so a single-realm arc is byte-identical (zero-ceremony).
+     :multi-realm? (multi-realm-feed? rows)
+     :empty-kind   empty-kind}))
 
 ;; ---- React keys ---------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -85,6 +85,7 @@
             [day8.re-frame2-xray.panels.routing :as routing]
             [day8.re-frame2-xray.panels.resources :as resources]
             [day8.re-frame2-xray.panels.derivation-graph :as derivation-graph]
+            [day8.re-frame2-xray.panels.module-view :as module-view]
             [day8.re-frame2-xray.panels.reactive-panel :as reactive-panel]
             [day8.re-frame2-xray.panels.trace :as trace]))
 
@@ -970,6 +971,16 @@
     ;; redaction is `derivation-graph-helpers/redact-graph-for-egress`.
     ;; Read-only: assembling the graph pins nothing, dispatches nothing.
     (derivation-graph/install!)
+    ;; Module-view tab (EP-0013 disposition 6, rf2-wtg9z4) — Dynamic L4
+    ;; tab: the (realm, frame) address space of the running process
+    ;; (`rf/realm-ids` × `rf/frame-realm`, the EP-0013 disposition-3
+    ;; public address halves). The disposition-6 demand-trigger surface
+    ;; for per-module ownership/capability/classification/provenance —
+    ;; the MODULES section is scaffolded behind the awaiting-seam caption
+    ;; until the public realm→installed-app provenance read seam
+    ;; graduates (follow-up bead). Read-only: enumerating realms/frames
+    ;; pins nothing, dispatches nothing.
+    (module-view/install!)
     ;; Static Routes panel (rf2-o5f5f.3) — Static-surface browse +
     ;; Simulate-URL + per-row inline expand + hermetic Simulate-
     ;; navigation preview. Installs the UI-state slots under

--- a/tools/xray/test/day8/re_frame2_xray/frame_switcher_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/frame_switcher_cljs_test.cljs
@@ -375,3 +375,62 @@
     (is (= frame-switcher/default-storage-key
            (frame-switcher/get-storage-key))
         "nil resets to the canonical default")))
+
+;; -------------------------------------------------------------------------
+;; (7) Realm grouping (EP-0013 disposition 3 · rf2-3caq85)
+;; -------------------------------------------------------------------------
+
+(deftest group-frames-by-realm-single-realm-zero-ceremony
+  (testing "every frame in the default realm collapses to ONE group; the
+            view renders the FLAT option list (byte-identical) — multi-realm?
+            is false (zero-ceremony extends to tooling)"
+    (let [frames [:app/main :app/cart]
+          groups (frame-switcher/group-frames-by-realm
+                   frames (constantly :rf.realm/default))]
+      (is (= [{:realm :rf.realm/default :frames [:app/main :app/cart]}]
+             groups)
+          "one group, frame order preserved")
+      (is (false? (frame-switcher/multi-realm? groups))
+          "single realm → flat render"))))
+
+(deftest group-frames-by-realm-multi-realm
+  (testing "frames group by realm in first-realm-seen order, each group's
+            frames preserving input order; multi-realm? true → <optgroup>s"
+    (let [realm-of {:app/main :rf.realm/default
+                    :app/cart :rf.realm/default
+                    :other/x  :app/realm-b}
+          groups   (frame-switcher/group-frames-by-realm
+                     [:app/main :other/x :app/cart] realm-of)]
+      (is (= [{:realm :rf.realm/default :frames [:app/main :app/cart]}
+              {:realm :app/realm-b     :frames [:other/x]}]
+             groups)
+          "first-realm-seen order; per-group input order preserved")
+      (is (true? (frame-switcher/multi-realm? groups))))))
+
+(deftest group-frames-by-realm-nil-resolution-falls-to-default
+  (testing "a frame whose realm resolves to nil buckets to the default
+            realm — an unknown/destroyed frame never strands the picker"
+    (let [groups (frame-switcher/group-frames-by-realm
+                   [:app/main :ghost] (constantly nil))]
+      (is (= [{:realm :rf.realm/default :frames [:app/main :ghost]}]
+             groups)))))
+
+(deftest available-frame-realm-groups-sub
+  (testing "the sub composes off :rf.xray/available-frames + frame-realm;
+            in a single-realm test runtime it returns ONE default-realm
+            group carrying the pickable frames (zero-ceremony — the
+            picker renders the flat option list, multi-realm? false)"
+    ;; Seed cascades BEFORE setup! (mirrors the available-frames tests).
+    (dispatch-trace 1 :rf/default)
+    (dispatch-trace 2 :app/main)
+    (setup!)
+    (rf/with-frame :rf/xray
+      (let [groups @(rf/subscribe [:rf.xray/available-frame-realm-groups])]
+        (is (vector? groups))
+        (is (= 1 (count groups)) "single realm in the test runtime")
+        (is (= :rf.realm/default (:realm (first groups)))
+            "frames resolve to the default realm via frame-realm")
+        (is (= [:rf/default :app/main] (:frames (first groups)))
+            "the pickable frames, first-seen order, in the default group")
+        (is (false? (frame-switcher/multi-realm? groups))
+            "single realm → flat render (zero-ceremony)")))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/module_view_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/module_view_helpers_cljs_test.cljc
@@ -1,0 +1,115 @@
+(ns day8.re-frame2-xray.panels.module-view-helpers-cljs-test
+  "JVM + CLJS coverage for the Module-view pure-data helpers (rf2-wtg9z4
+  — the EP-0013 disposition-6 demand-trigger surface).
+
+  Verifies the (realm, frame) address-space projection (EP-0013
+  disposition 3): realm→frames grouping, the realm-row shape, the
+  single/multi-realm classification, and the zero-ceremony posture (a
+  single-realm process projects ONE realm). The per-module provenance
+  slots are asserted EMPTY (the seam has not graduated — rf2-wtg9z4
+  follow-up)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [day8.re-frame2-xray.panels.module-view-helpers :as h]))
+
+;; ---- realm-frames -------------------------------------------------------
+
+(deftest realm-frames-groups-by-resolver
+  (testing "frames group by their realm-of resolution"
+    (let [realm-of {:app/main  :rf.realm/default
+                    :app/cart  :rf.realm/default
+                    :other/x   :app/realm-b}
+          grouped  (h/realm-frames [:app/main :app/cart :other/x] realm-of)]
+      (is (= #{:app/main :app/cart} (get grouped :rf.realm/default)))
+      (is (= #{:other/x} (get grouped :app/realm-b))))))
+
+(deftest realm-frames-nil-resolution-falls-to-default
+  (testing "a frame whose realm-of returns nil buckets to the default realm
+            (absence = default realm — EP-0013 D1 rule)"
+    (let [grouped (h/realm-frames [:app/main :ghost] (constantly nil))]
+      (is (= #{:app/main :ghost} (get grouped :rf.realm/default))
+          "nil realm → default realm bucket"))))
+
+;; ---- project-realm-row --------------------------------------------------
+
+(deftest project-realm-row-shape
+  (testing "the realm-row carries id, sorted frames, count, and EMPTY
+            provenance slots (seam not graduated)"
+    (let [row (h/project-realm-row :rf.realm/default #{:app/cart :app/main})]
+      (is (= :rf.realm/default (:realm row)))
+      (is (= [:app/cart :app/main] (:frames row)) "frames sorted by str")
+      (is (= 2 (:frame-count row)))
+      ;; provenance slots — awaiting the core seam (rf2-wtg9z4 follow-up).
+      (is (nil? (:modules row)))
+      (is (= #{} (:requires row)))
+      (is (nil? (:owns row)))
+      (is (nil? (:classification row))))))
+
+;; ---- project-module-view ------------------------------------------------
+
+(deftest project-module-view-single-realm-zero-ceremony
+  (testing "a single-realm process projects ONE realm, multi-realm? false
+            (zero-ceremony — the realm dimension stays implicit)"
+    (let [data (h/project-module-view #{:rf.realm/default}
+                                      [:app/main :app/cart]
+                                      (constantly :rf.realm/default))]
+      (is (= 1 (:realm-count data)))
+      (is (false? (:multi-realm? data)))
+      (is (= :rf.realm/default (:realm (first (:realms data)))))
+      (is (= [:app/cart :app/main] (:frames (first (:realms data)))))
+      (is (false? (:provenance-available? data))
+          "the provenance seam has NOT graduated (rf2-wtg9z4 follow-up)"))))
+
+(deftest project-module-view-multi-realm
+  (testing "more than one realm → multi-realm? true, every realm present,
+            sorted by realm-id"
+    (let [realm-of {:app/main :rf.realm/default
+                    :other/x  :app/realm-b}
+          data     (h/project-module-view #{:rf.realm/default :app/realm-b}
+                                          [:app/main :other/x]
+                                          realm-of)]
+      (is (= 2 (:realm-count data)))
+      (is (true? (:multi-realm? data)))
+      (is (= [:app/realm-b :rf.realm/default]
+             (mapv :realm (:realms data)))
+          "realms sorted by realm-id str"))))
+
+(deftest project-module-view-empty-realm-still-present
+  (testing "an installed realm with no frames still appears (a realm can
+            exist with zero frames)"
+    (let [data (h/project-module-view #{:rf.realm/default :app/empty}
+                                      [:app/main]
+                                      (constantly :rf.realm/default))]
+      (is (= 2 (:realm-count data)))
+      (let [empty-row (first (filter #(= :app/empty (:realm %)) (:realms data)))]
+        (is (some? empty-row) "the frameless realm is present")
+        (is (= 0 (:frame-count empty-row)))
+        (is (= [] (:frames empty-row)))))))
+
+(deftest project-module-view-stale-frame-realm-never-strands
+  (testing "a frame resolving to a realm absent from realm-ids still gets a
+            row (defensive — a stale frame never strands the view)"
+    (let [data (h/project-module-view #{:rf.realm/default}
+                                      [:app/main :ghost]
+                                      {:app/main :rf.realm/default
+                                       :ghost    :app/gone})]
+      (is (contains? (set (map :realm (:realms data))) :app/gone)
+          "the orphan realm is surfaced rather than dropped"))))
+
+;; ---- captions / summaries -----------------------------------------------
+
+(deftest awaiting-caption-names-the-deferred-facts
+  (testing "the awaiting-seam caption names ownership, capability,
+            classification, and provenance so the operator knows the
+            surface is scaffolded, not broken"
+    (let [c h/awaiting-provenance-caption]
+      (is (re-find #"(?i)ownership" c))
+      (is (re-find #"(?i)capability" c))
+      (is (re-find #"(?i)classification" c))
+      (is (re-find #"(?i)provenance" c)))))
+
+(deftest realm-summary-line-pluralizes
+  (is (= ":rf.realm/default · 1 frame"
+         (h/realm-summary-line {:realm :rf.realm/default :frame-count 1})))
+  (is (= ":rf.realm/default · 2 frames"
+         (h/realm-summary-line {:realm :rf.realm/default :frame-count 2}))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_cljs_test.cljs
@@ -166,8 +166,8 @@
     (let [panels (palette-subs/palette-panels)
           ids    (set (map :id panels))]
       (is (contains? ids :resources) ":resources in palette-panels")
-      (is (= 8 (count panels))
-          "8 Dynamic tabs — Epoch / App DB / Views / Trace / Machines / Routing / Resources / Graph (rf2-9ett2d added the EP-0014 derivation-graph tab)"))))
+      (is (= 9 (count panels))
+          "9 Dynamic tabs — Epoch / App DB / Views / Trace / Machines / Routing / Resources / Graph / Modules (rf2-9ett2d added the EP-0014 derivation-graph tab; rf2-wtg9z4 added the EP-0013 Modules tab)"))))
 
 ;; ---- (3) sections render ------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/routing_cljs_test.cljs
@@ -175,8 +175,9 @@
     (let [panels (palette-subs/palette-panels)
           ids    (set (map :id panels))]
       (is (contains? ids :routing) ":routing in palette-panels")
-      (is (= 8 (count panels))
-          "exactly 8 entries — Epoch / App DB / Views / Trace / Machines / Routing / Resources / Graph (the Resources tab — Spec 016 §Xray and AI tooling — earns its own L4 tab per Mike's cohesive-sub-domain ruling; rf2-9ett2d added the EP-0014 derivation-graph 'Graph' tab — the unified derivation/process graph across all algebra-view families; rf2-gbz39 removed the Issues tab per Mike's Option (c) ruling — issues surface inline + event-row pink-wash + the always-on issues ribbon signal. rf2-5gl5r retired the Event/Handler tab; the Epoch panel supersedes it. rf2-sc3r1 originally added Epoch at order 5; rf2-4v67l removed the Chrome A11y dogfood in favour of Story's shipped panel; rf2-ga16q removed the Machines Canvas tab — its browse-all canvas relocated to the Static Machines sub-tab.)"))))
+      (is (contains? ids :module-view) ":module-view in palette-panels")
+      (is (= 9 (count panels))
+          "exactly 9 entries — Epoch / App DB / Views / Trace / Machines / Routing / Resources / Graph / Modules (the Resources tab — Spec 016 §Xray and AI tooling — earns its own L4 tab per Mike's cohesive-sub-domain ruling; rf2-9ett2d added the EP-0014 derivation-graph 'Graph' tab — the unified derivation/process graph across all algebra-view families; rf2-wtg9z4 added the EP-0013 'Modules' tab — the (realm, frame) address space + the disposition-6 demand-trigger surface; rf2-gbz39 removed the Issues tab per Mike's Option (c) ruling — issues surface inline + event-row pink-wash + the always-on issues ribbon signal. rf2-5gl5r retired the Event/Handler tab; the Epoch panel supersedes it. rf2-sc3r1 originally added Epoch at order 5; rf2-4v67l removed the Chrome A11y dogfood in favour of Story's shipped panel; rf2-ga16q removed the Machines Canvas tab — its browse-all canvas relocated to the Static Machines sub-tab.)"))))
 
 ;; ---- (2) three sections render (always-visible base layer) --------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
@@ -853,3 +853,62 @@
             by-path (into {} (map (juxt :path identity)) (:db-diff db-row))]
         (is (contains? by-path [:counter]))
         (is (contains? by-path [:totals :sum]))))))
+
+;; ---- (N) realm stamp surface (EP-0013 disposition 2 · rf2-7vqpwa) -------
+
+(deftest realm-of-reads-stamp-where-present
+  (testing "realm-of projects the :rf.realm/id stamp from :tags, where present"
+    (is (= :app/realm-b
+           (h/realm-of {:tags {:rf.realm/id :app/realm-b}}))))
+  (testing "top-level :rf.realm/id fallback (defensive against emit shape)"
+    (is (= :app/realm-b
+           (h/realm-of {:rf.realm/id :app/realm-b}))))
+  (testing "nil when no realm stamp is present (the single-realm case —
+            the framework does not stamp it yet, disposition 2 reserves
+            the slot; the emit is a later core slice)"
+    (is (nil? (h/realm-of {:tags {:frame :app/main}})))
+    (is (nil? (h/realm-of {})))))
+
+(deftest project-row-threads-realm
+  (testing "project-row carries the realm stamp onto the row WHERE PRESENT"
+    (let [row (h/project-row {:id 1 :op-type :rf.event
+                              :operation :rf.event/dispatched
+                              :time 1 :tags {:rf.realm/id :app/realm-b}})]
+      (is (= :app/realm-b (:realm row)))))
+  (testing "nil realm slot when unstamped (single-realm — row unchanged)"
+    (let [row (h/project-row {:id 1 :op-type :rf.event
+                              :operation :rf.event/dispatched
+                              :time 1 :tags {}})]
+      (is (nil? (:realm row))))))
+
+(deftest feed-realms-and-multi-realm-feed?
+  (testing "feed-realms collects distinct non-nil realm stamps"
+    (let [rows [{:realm :a} {:realm :b} {:realm :a} {:realm nil}]]
+      (is (= #{:a :b} (h/feed-realms rows)))))
+  (testing "multi-realm-feed? is true only when >1 distinct realm present"
+    (is (false? (h/multi-realm-feed? [{:realm nil} {:realm nil}]))
+        "single-realm / unstamped arc — false (zero-ceremony)")
+    (is (false? (h/multi-realm-feed? [{:realm :a} {:realm :a}]))
+        "one realm — false")
+    (is (true? (h/multi-realm-feed? [{:realm :a} {:realm :b}]))
+        "two realms — true")))
+
+(deftest feed-projection-surfaces-multi-realm-flag
+  (testing "project-feed-from-epoch surfaces :multi-realm? — false in the
+            ordinary single-realm (unstamped) arc (zero-ceremony)"
+    (let [record {:epoch-id 1
+                  :trace-events [{:id 1 :op-type :rf.event
+                                  :operation :rf.event/dispatched :time 1
+                                  :tags {}}]}
+          feed   (h/project-feed-from-epoch record :focused)]
+      (is (false? (:multi-realm? feed)))))
+  (testing ":multi-realm? true when the arc's events span >1 realm"
+    (let [record {:epoch-id 1
+                  :trace-events [{:id 1 :op-type :rf.event
+                                  :operation :rf.event/dispatched :time 1
+                                  :tags {:rf.realm/id :app/a}}
+                                 {:id 2 :op-type :rf.sub
+                                  :operation :rf.sub/run :time 2
+                                  :tags {:rf.realm/id :app/b}}]}
+          feed   (h/project-feed-from-epoch record :focused)]
+      (is (true? (:multi-realm? feed))))))

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -201,6 +201,10 @@
    ;; surfaces. See `frame_switcher.cljs` for the full contract.
    :rf.xray/current-frame
    :rf.xray/available-frames
+   ;; rf2-3caq85 — the realm grouping of the pickable frames (EP-0013
+   ;; disposition 3): a `<optgroup>` per realm in a multi-realm process;
+   ;; collapses to one default-realm group (flat render) single-realm.
+   :rf.xray/available-frame-realm-groups
    ;; rf2-4vp5j — the dedicated VIEW-SCOPE frame slot (frame is a view
    ;; scope, not a filter): the resolved scope + its raw stored slot +
    ;; the raw target-frame slot it falls back to on a host seed.
@@ -291,6 +295,11 @@
    :rf.xray/derivation-graph-mode
    :rf.xray/derivation-graph-override
    :rf.xray/derivation-graph-tab-data
+   ;; rf2-wtg9z4 — Module-view tab (EP-0013 disposition 6): the projected
+   ;; (realm, frame) address space (`rf/realm-ids` × `rf/frame-realm`).
+   ;; The disposition-6 demand-trigger surface; the per-module provenance
+   ;; section is scaffolded behind the awaiting-seam caption.
+   :rf.xray/module-view
    ;; rf2-o5f5f.3 — Routes browse + Simulate-URL state lives under
    ;; the Static Routes panel (promoted from `:rf.xray.routing/*` per
    ;; the two-verbs-two-homes split). The Dynamic Routing lens narrows


### PR DESCRIPTION
EP-0013 (app values + runtime realms) realm-awareness adoption in tools/xray, using the public realm address API (`rf/realm-ids` + `rf/frame-realm`, PR #4038). Per the EP's own zero-ceremony rule: **single-realm processes render byte-identically to the pre-EP UI; the realm dimension is spelled only when more than one realm is present.**

## What shipped (per bead)

### rf2-3caq85 â€” Frames panel groups by realm in multi-realm processes
`frame_switcher.cljs` adds `:rf.xray/available-frame-realm-groups` (the pickable frames grouped by `rf/frame-realm`) and the pure helpers `group-frames-by-realm` / `multi-realm?`. When the result spans >1 realm the picker renders an `<optgroup>` per realm (`data-testid rf-xray-ribbon-frame-realm-group-<realm>`); when it collapses to one realm the picker renders the **flat option list, byte-identical** to the pre-bead render. A frame whose realm is unknown buckets to `:rf.realm/default` (absence = default realm, EP-0013 D1 rule).

### rf2-7vqpwa â€” Trace rows surface `:rf.realm/id` where present
`trace_helpers.cljc` projects the row's `:realm` from `[:tags :rf.realm/id]` (`realm-of`) and the feed carries `:multi-realm?` (`multi-realm-feed?`). `panels/trace.cljs` renders a compact realm chip (`data-testid rf-xray-trace-row-<id>-realm`) at the end of the target column **only when the arc spans >1 realm AND the row carries a stamp** â€” a single-realm/unstamped arc renders unchanged. The framework's trace emit does not stamp `:rf.realm/id` yet (slot reserved per disposition 2; emit is a later core slice), so single-realm the surface is inert.

### rf2-wtg9z4 â€” Module-view (the disposition-6 demand trigger)
A new **Dynamic L4 tab** (`panels/module_view.cljs`, label "Modules", order 9, `reg-l4-tab!` only â€” an L4-only tab, no `mount-*!` facade, so **not** in `panel-enum`). It renders the **(realm, frame) address space** â€” `rf/realm-ids` Ã— `rf/frame-realm` â€” as a REALMS section. The MODULES section (per-module ownership / capability / EP-0015 classification / descriptor provenance) is **scaffolded behind an awaiting-seam caption**: those facts live on a *constructed* app value's `:modules` map, and a running realm exposes **no public read** of its installed app value (`re-frame.realm/installed-app` is internal; the internal registrar projection carries no module structure). Per the brief, this slice does **not** expand core scope to invent the seam.

**Follow-up filed: rf2-imquoq** â€” public `realmâ†’installed-app` read seam carrying module provenance (the disposition-6 graduation). The Module-view row shapes already carry the `:owns`/`:requires`/`:classification` slots + `:provenance-available?` so the fill-in is a no-reshape change when the seam lands.

## Specs (standing rule â€” updated same-PR)
- `007-UX-IA.md` â€” EP-0013 realm-awareness section flipped *deferred â†’ shipped*.
- `018-Event-Spine.md` â€” frame-dropdown realm grouping (`<optgroup>` per realm, flat single-realm).
- `023-Trace-Panel.md` â€” new Â§7a realm stamp (where present, multi-realm only).
- `026-Module-View-Panel.md` â€” new spec doc + `README.md` index entry.

## Quality gates
Re-run after rebasing `worker/ep0013-xray-realm` onto current `origin/main` (resolved the `tools/xray/spec/007-UX-IA.md` conflict, keeping the shipped EP-0013 bullets; EP-0014 derivation-graph tab + its `025` spec + `deps.edn` deps preserved from main):
- `clojure -M:test` (xray JVM): **1169 tests, 5152 assertions, 0 failures**
- `npm run test:cljs`: **6909 tests, 28093 assertions, 0 failures**
- `npm run test:bundle-isolation`: **PASS** (22 artefact entries, 40 internal sentinels absent; tools do not leak into production bundles)
- `npm run test:xray-feature-gate`: **16 scenarios, 0 failures, 13 matrix rows** on a clean run. Note: the `static mode chrome and chord` scenario intermittently hit the 5s shell-mount `openXray` timeout under load (2 of 3 local runs); it passes on re-run. Not a regression: `module-view/install!` adds only a lazy `:rf.xray/module-view` sub + a dynamic-mode `reg-l4-tab!`, so a real break would fail every `openXray` scenario deterministically; all other shell-opening scenarios pass on every run.

Registration-snapshot + palette-count guards carry the new `:module-view` tab + `:rf.xray/available-frame-realm-groups` / `:rf.xray/module-view` subs (alongside main's `:rf.xray/derivation-graph-*` slots).
