### PR TITLE
fix(examples): EP-0010 move durable storage reads to causal world inputs (rf2-lk86xl)

### DIFF
--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -54,12 +54,39 @@
         (.setItem    ls "jwtToken" token)
         (.removeItem ls "jwtToken")))))
 
+;; EP-0010 (causal world inputs, rf2-lk86xl): the saved JWT is a STORAGE world
+;; fact that `:auth/initialise` folds into durable app-db (and that drives
+;; session restore). A durable write must be a function of prior frame-state
+;; plus the causal token — not of an ambient `localStorage` read at the write
+;; site, which replay/restore could not reproduce. The host-boundary boot read
+;; happens once, in `realworld.core/run`, and rides the boot dispatch token as
+;; `:rf.world/inputs {:storage {:jwt-token …}}`.
+(defn read-jwt-from-storage
+  "Host-boundary read of the saved JWT from localStorage (or nil). Called from
+   `realworld.core/run` so the token rides the boot dispatch token as a causal
+   world input rather than being read ambiently in the durable initialise
+   handler. nil when absent / unavailable (e.g. node, logged-out first run)."
+  []
+  (some-> (.-localStorage js/globalThis)
+          (.getItem "jwtToken")))
+
 (rf/reg-cofx :auth.session/token
-  {:doc "Inject the saved token (or nil) from localStorage into coeffects."}
+  {:doc "Inject the saved JWT (or nil) into coeffects.
+
+         EP-0010 recordable storage coeffect (the `:app/now-ms` pattern,
+         EP-0010 §Backwards Compatibility): returns the captured
+         `(get-in cofx [:rf.world/inputs :storage :jwt-token])` value when the
+         boot token supplied one (replay / restore / test fixtures get the exact
+         recorded value, no host re-read), falling back to a live
+         `read-jwt-from-storage` host read only when none was supplied — i.e.
+         when building a fresh live token at the boundary where reading the host
+         IS correct."}
   (fn cofx-auth-session-token [ctx _]
-    (rf/assoc-coeffect ctx :auth.session/token
-                       (some-> (.-localStorage js/globalThis)
-                               (.getItem "jwtToken")))))
+    (let [world (get-in ctx [:coeffects :rf.world/inputs])]
+      (rf/assoc-coeffect ctx :auth.session/token
+                         (if (contains? (:storage world) :jwt-token)
+                           (get-in world [:storage :jwt-token])
+                           (read-jwt-from-storage))))))
 
 ;; ============================================================================
 ;; SUPPORT EVENTS

--- a/examples/reagent/realworld_resources/auth.cljs
+++ b/examples/reagent/realworld_resources/auth.cljs
@@ -71,12 +71,39 @@
         (.setItem ls "jwtToken" token)
         (.removeItem ls "jwtToken")))))
 
+;; EP-0010 (causal world inputs, rf2-lk86xl): the saved JWT is a STORAGE world
+;; fact that `:auth/initialise` folds into durable app-db (and that drives
+;; session restore). A durable write must be a function of prior frame-state
+;; plus the causal token — not of an ambient `localStorage` read at the write
+;; site, which replay/restore could not reproduce. The host-boundary boot read
+;; happens once, in `realworld-resources.core/run`, and rides the boot dispatch
+;; token as `:rf.world/inputs {:storage {:jwt-token …}}`.
+(defn read-jwt-from-storage
+  "Host-boundary read of the saved JWT from localStorage (or nil). Called from
+   `realworld-resources.core/run` so the token rides the boot dispatch token as
+   a causal world input rather than being read ambiently in the durable
+   initialise handler. nil when absent / unavailable."
+  []
+  (some-> (.-localStorage js/globalThis)
+          (.getItem "jwtToken")))
+
 (rf/reg-cofx :realworld-resources.session/token
-  {:doc "Inject the saved token (or nil) from localStorage into coeffects."}
+  {:doc "Inject the saved JWT (or nil) into coeffects.
+
+         EP-0010 recordable storage coeffect (the `:app/now-ms` pattern,
+         EP-0010 §Backwards Compatibility): returns the captured
+         `(get-in cofx [:rf.world/inputs :storage :jwt-token])` value when the
+         boot token supplied one (replay / restore / test fixtures get the exact
+         recorded value, no host re-read), falling back to a live
+         `read-jwt-from-storage` host read only when none was supplied — i.e.
+         when building a fresh live token at the boundary where reading the host
+         IS correct."}
   (fn [ctx _]
-    (rf/assoc-coeffect ctx :realworld-resources.session/token
-                       (some-> (.-localStorage js/globalThis)
-                               (.getItem "jwtToken")))))
+    (let [world (get-in ctx [:coeffects :rf.world/inputs])]
+      (rf/assoc-coeffect ctx :realworld-resources.session/token
+                         (if (contains? (:storage world) :jwt-token)
+                           (get-in world [:storage :jwt-token])
+                           (read-jwt-from-storage))))))
 
 ;; ============================================================================
 ;; SESSION SUPPORT EVENTS

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -4,7 +4,7 @@
             [re-frame.core :as rf]
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
-            [todomvc.db]
+            [todomvc.db :as db]
             [todomvc.events]
             [todomvc.subs]
             [todomvc.views :as views]))
@@ -65,7 +65,14 @@
   (rf/init! reagent-adapter/adapter)
   (rf/reg-frame app-frame {:doc "TodoMVC demo frame." :url-bound? true})
   (rf/with-frame app-frame
-    (rf/dispatch-sync [:todo/initialise])
+    ;; EP-0010 (rf2-lk86xl): read the saved todos from localStorage HERE, at the
+    ;; host/boot boundary, and ride them on the boot token as a causal world
+    ;; input — never as an ambient `localStorage` read in the `:todo/initialise`
+    ;; durable handler. The router preserves this supplied `:rf.world/inputs` and
+    ;; only fills the framework-required `:time-ms`; the recordable
+    ;; `:todo.storage/todos` cofx (db.cljs) returns this captured value exactly.
+    (rf/dispatch-sync [:todo/initialise]
+                      {:rf.world/inputs {:storage {:todos (db/read-todos-from-storage)}}})
     (rf/dispatch-sync [:rf.route/handle-url-change (current-path)]))
   (.removeEventListener js/window "hashchange" on-hashchange)
   (.addEventListener js/window "hashchange" on-hashchange)

--- a/examples/reagent/todomvc/db.cljs
+++ b/examples/reagent/todomvc/db.cljs
@@ -28,16 +28,50 @@
         (sorted-map)))))
 
 ;; localStorage is deliberate — see README. The Spec-014 :rf.http/managed demo lives with realworld.
+;;
+;; EP-0010 (causal world inputs, rf2-lk86xl): the saved todos are a STORAGE
+;; world fact, and `:todo/initialise` folds them into durable app-db. A durable
+;; write must be a function of prior frame-state plus the causal token — not of
+;; an ambient `localStorage` read at the write site (which replay/restore could
+;; not reproduce). So the host-boundary boot read happens once, in
+;; `todomvc.core/run`, and rides the boot dispatch token as
+;; `:rf.world/inputs {:storage {:todos …}}`.
+;;
+;; This cofx is the RECORDABLE migration target the EP blesses (the `:app/now-ms`
+;; pattern, EP-0010 §Backwards Compatibility): it reads the captured storage
+;; value off `:rf.world/inputs` and returns it exactly under replay / restore /
+;; test fixtures. It falls back to a live host read ONLY when no storage was
+;; supplied on the token — i.e. when building a fresh live token at the boundary
+;; where reading the host IS correct. Either way the value is always coerced to a
+;; `(sorted-map)`: a nil (empty / absent localStorage, first run) would otherwise
+;; clobber default-db's `(sorted-map)` and break allocate-next-id's
+;; `(last (keys todos))` = max-id invariant once the map promotes to an unordered
+;; PersistentHashMap (>8 entries).
+(defn read-todos-from-storage
+  "Host-boundary read of the saved TodoMVC items from localStorage, normalised
+   to a sorted-map. Called from `todomvc.core/run` so the value rides the boot
+   dispatch token as a causal world input rather than being read ambiently in a
+   durable handler. nil/empty localStorage (first run, or node with no
+   localStorage) yields an empty sorted-map."
+  []
+  (or (some-> (.-localStorage js/globalThis)
+              (.getItem ls-key)
+              (storage->todos))
+      (sorted-map)))
+
 (rf/reg-cofx :todo.storage/todos
-  {:doc "Inject the saved TodoMVC items from localStorage into coeffects."}
+  {:doc "Inject the saved TodoMVC items into coeffects as a sorted-map.
+
+         EP-0010 recordable storage coeffect: returns the captured
+         `(get-in cofx [:rf.world/inputs :storage :todos])` value when the boot
+         token supplied one (replay / restore / test fixtures get the exact
+         recorded value, no host re-read); falls back to a live
+         `read-todos-from-storage` host read only when none was supplied. Always
+         a sorted-map (never nil) so the allocate-next-id invariant holds."}
   (fn cofx-todo-storage-todos [ctx]
-    ;; Always yield a sorted-map. `some->` short-circuits to nil when
-    ;; localStorage is empty (first run) or unavailable; without the `or`
-    ;; the nil clobbers default-db's (sorted-map) downstream, breaking
-    ;; allocate-next-id's `(last (keys todos))` = max-id invariant once the
-    ;; map promotes to an unordered PersistentHashMap (>8 entries).
-    (assoc-in ctx [:coeffects :todo.storage/todos]
-              (or (some-> (.-localStorage js/globalThis)
-                          (.getItem ls-key)
-                          (storage->todos))
-                  (sorted-map)))))
+    (let [recorded (get-in ctx [:coeffects :rf.world/inputs :storage :todos])
+          todos    (cond
+                     (map? recorded) (into (sorted-map) recorded)
+                     (some? recorded) (sorted-map)
+                     :else (read-todos-from-storage))]
+      (assoc-in ctx [:coeffects :todo.storage/todos] todos))))


### PR DESCRIPTION
## Summary

Follow-up tail of the EP-0010 (causal world inputs) core review (rf2-47lgee #2), split out from the core PR (#4051) to keep the `examples/` trees off that diff. EP-0010 is **final**.

The example apps restored durable app-db state from **ambient localStorage cofxes** — reading the browser at the durable write site rather than at the boot/host boundary:

- `examples/reagent/todomvc/` — `:todo.storage/todos` read `localStorage` and `:todo/initialise` wrote `:todos`.
- `examples/reagent/realworld/` — `:auth.session/token` read `jwtToken` and `:auth/initialise` wrote `[:auth :token]` / drove restore.
- `examples/reagent/realworld_resources/` — `:realworld-resources.session/token` repeated the same pattern.

EP-0010 §Browser And Storage Facts: *"localStorage reads that initialize app state arrive on boot or restore tokens."* §Backwards Compatibility blesses the recordable-coeffect migration target (the `:app/now-ms` pattern).

## What changed

- **todomvc** — the host-boundary localStorage read moves into `todomvc.core/run` (new `db/read-todos-from-storage` helper) and rides the boot token as `:rf.world/inputs {:storage {:todos …}}`. `:todo/initialise` IS the top-level boot dispatch, so its recordable `:todo.storage/todos` cofx returns the captured value exactly (no host re-read under replay/restore/fixtures); host fallback fires only when no storage was supplied. Always coerced to a `sorted-map` (allocate-next-id invariant preserved).
- **realworld + realworld_resources** — the session-token cofx becomes the same recordable storage coeffect: reads `:rf.world/inputs :storage :jwt-token` first, falling back to a live host read (new `read-jwt-from-storage` helper) only at the genuine live-boot boundary. Replay/restore/test fixtures that supply the storage world input get the recorded value, not a browser re-read.

The cofxes stay registered and keep their `[:coeffects <id>]` assoc-shape, so the framework example tests (todomvc cold-boot id-allocation, the `:auth.session/token` shape guard) stay green. No `core.cljs` change is needed for the realworld variants — `:auth/initialise` is a child dispatch (fresh world inputs by design), so the recordable cofx's host fallback is the correct live-boot read there; only TodoMVC's top-level initialise can carry the recorded storage on its own token.

Examples remain **test-free** (rf2-8cevm) — no `spec.cjs` added.

## Quality gates

- `python scripts/check_ambient_durable_reads.py` → exit 0 (clean; lint scans the 18 `implementation/` durable-write namespaces — examples are out of its scan surface, and stay clean).
- `npm run test:cljs` → **6892 tests, 28025 assertions, 0 failures, 0 errors** (compiles the edited examples; exercises todomvc cold-boot + the realworld init / session-token-cofx-shape paths that reference the migrated cofxes).
- `npm run test:examples` → **3 adapter specs (Reagent / UIx / Helix), 0 failures, 0 skipped**.