### PR TITLE
test: EP-0008 pin frameful malformed-hydration always-on error (rf2-hguive)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr_error_emit_promotion_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_emit_promotion_test.clj
@@ -46,7 +46,8 @@
             [re-frame.ssr.boot :as boot]
             [re-frame.ssr.error-listener :as error-listener]
             [re-frame.ssr.error-projector :as error-projector]
-            [re-frame.ssr.test-fixture :as tf]))
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.subs :as subs]))
 
 (use-fixtures :each
   (fn [t]
@@ -78,6 +79,34 @@
       ::acceptance-recorder
       (fn [record] (swap! seen conj (:error record))))
     seen))
+
+(defn- capture-records!
+  "Like `capture-always-on!` but records the WHOLE record (not just the
+  `:error` slot) so a consumer can assert the union shape's `:frame` /
+  `:where` / `:failing-id` / `:recovery` slots. Returns the seen-records
+  atom."
+  []
+  (let [seen (atom [])]
+    (rf/register-error-listener!
+      ::record-recorder
+      (fn [record] (swap! seen conj record)))
+    seen))
+
+(defn- register-hydration-handlers!
+  "Register the minimal subs that let a frameful `:rf/hydrate` rejection
+  be observed fail-closed through the REAL router (mirrors the baseline
+  handlers in `ssr_hydration_test`): `:count` / `:title` read app-db,
+  `:hydrated?` reads the durable runtime-db hydration metadata slot. The
+  `tf/reset-runtime` fixture clears registrations before each test, so
+  this runs inside the test body."
+  []
+  (rf/reg-event-db ::inc       (fn [db _ev]   (update db :count (fnil inc 0))))
+  (rf/reg-event-db ::set-title (fn [db [_ t]] (assoc db :title t)))
+  (rf/reg-sub :count (fn [db _] (or (:count db) 0)))
+  (rf/reg-sub :title (fn [db _] (or (:title db) "untitled")))
+  ;; EP-0001 (rf2-vzld77): hydration metadata is durable runtime-db state.
+  (subs/reg-runtime-sub :hydrated?
+    (fn [rt _] (boolean (get-in rt [:rf.runtime/ssr :hydration])))))
 
 ;; ===========================================================================
 ;; (A) EXERCISE — each promoted category fans out through
@@ -180,6 +209,84 @@
           (is (empty? @error-listener/pending-error-traces)
               "a frameless record is not buffered for any frame's
                projection — no status moved"))))))
+
+(deftest malformed-hydration-payload-frameful-reaches-listener-under-debug-off
+  (testing "rf2-hguive: the FRAMEFUL `:rf/hydrate` shape-guard emit
+            (the frame EXISTS) rides the always-on
+            `register-error-listener!` axis under `debug-enabled? = false`
+            — the production posture where the dev trace surface is elided.
+            Driven END-TO-END through the REAL router against a client
+            frame: a malformed payload is REJECTED (app-db + runtime-db
+            unchanged), AND exactly one `:rf.error/malformed-hydration-payload`
+            record reaches the off-box listener carrying the frame context
+            (`:frame <client-frame>`, `:where 'rf.ssr/hydrate`,
+            `:failing-id :rf/hydrate`, `:recovery :no-recovery`). This pins
+            the frameful site the bead names — before this only the
+            PRE-FRAME frameless sibling (above) was pinned on the always-on
+            axis under debug-off, so the frameful site could silently
+            regress to dev-trace-only while the fail-closed-state tests in
+            `ssr_hydration_test` still passed.
+
+            ADVERSARIAL: the assertion is NOT merely 'the rejection
+            happened' (covered elsewhere) — it is that the always-on record
+            SURVIVES production elision (`debug-enabled? false`) AND carries
+            the frame so an off-box shipper can attribute the corrupt
+            payload to the right frame. Two malformed shapes are
+            parametrised — a non-map app-db slice and a non-map runtime-db
+            slice — so both fail-closed branches of the guard are pinned on
+            the always-on axis, not just one."
+    (doseq [bad-payload [{:rf/app-db "slice-is-a-string"}
+                         {:rf/app-db   {:count 99 :title "would-replace"}
+                          :rf/runtime-db [:runtime :is :a :vector]}]]
+      (let [seen-records (capture-records!)]
+        (register-hydration-handlers!)
+        (let [client-frame (rf/make-frame {:doc "ep0008-hguive client frame"
+                                           :platform :client})]
+          ;; Seed a recognisable pre-hydration client slice so we can prove
+          ;; the rejection left both partitions untouched (fail-closed).
+          (rf/dispatch-sync [::set-title "pre-hydration"] {:frame client-frame})
+          (rf/dispatch-sync [::inc]                       {:frame client-frame}) ;; 0 → 1
+          (with-redefs [interop/debug-enabled? false]
+            (rf/dispatch-sync [:rf/hydrate bad-payload] {:frame client-frame}))
+
+          ;; (A) the FRAMEFUL always-on record reached the off-box listener
+          ;;     under debug-off, carrying the frame context.
+          (let [recs (filter #(= :rf.error/malformed-hydration-payload (:error %))
+                             @seen-records)
+                rec  (first recs)]
+            (is (= 1 (count recs))
+                (str (pr-str bad-payload)
+                     ": exactly ONE frameful malformed-hydration record fanned
+                      out on the always-on axis (no duplicate)"))
+            (is (some? rec)
+                (str (pr-str bad-payload)
+                     ": the frameful malformed-payload record reached the
+                      listener under debug-off (dev trace elided)"))
+            (is (= client-frame (:frame rec))
+                (str (pr-str bad-payload)
+                     ": the always-on record carries the REJECTING client
+                      frame (not nil — this is the frameful site, the
+                      frameless pre-frame parse is the sibling)"))
+            (is (= 'rf.ssr/hydrate (:where rec))
+                (str (pr-str bad-payload) ": :where is the hydrate handler"))
+            (is (= :rf/hydrate (:failing-id rec))
+                (str (pr-str bad-payload) ": :failing-id is the :rf/hydrate event"))
+            (is (= :no-recovery (:recovery rec))
+                (str (pr-str bad-payload)
+                     ": :recovery is :no-recovery (fail-closed boundary)"))
+            (is (string? (:reason rec))
+                (str (pr-str bad-payload) ": a human-readable :reason rides along")))
+
+          ;; (B) FAIL-CLOSED — the existing client state survives the
+          ;;     malformed payload (the rejection the always-on record reports
+          ;;     is real, not a phantom emit on an applied hydration).
+          (is (= "pre-hydration" (rf/subscribe-once client-frame [:title]))
+              (str (pr-str bad-payload) ": :title unchanged (fail closed)"))
+          (is (= 1 (rf/subscribe-once client-frame [:count]))
+              (str (pr-str bad-payload) ": :count unchanged (fail closed)"))
+          (is (false? (rf/subscribe-once client-frame [:hydrated?]))
+              (str (pr-str bad-payload)
+                   ": no hydration metadata stashed (rejected, not applied)")))))))
 
 ;; ===========================================================================
 ;; (B) WIRE-UNCHANGED for the NON-PROJECTING categories driven through the


### PR DESCRIPTION
Pins the **frameful** `:rf/hydrate` malformed-payload always-on error emission (rf2-hguive, EP-0008 production-observability post-graduation review sweep).

## Context

`:rf.error/malformed-hydration-payload` is one of the six promoted SSR always-on error categories (Spec 009 catalogue, reconciled by #4053). It has two real emit sites in `re-frame.ssr.hydrate`:

- the **pre-frame frameless** parse failure (`boot/read-server-payload`) — already pinned on the always-on axis under `debug-enabled? false` by `malformed-hydration-payload-frameless-reaches-listener-under-debug-off`;
- the **frameful** `:rf/hydrate` shape-guard (the frame EXISTS) at `hydrate.cljc:138-147` — emits via `:error-emit/dispatch-error-record` **alongside** the dev trace, but **was not pinned** on the always-on axis. The existing `ssr_hydration_test` malformed-payload tests assert only fail-closed state + the dev-trace `:operation`, so the frameful always-on emit could regress to dev-trace-only (elided in production) while those tests still passed.

## Change (coverage-only)

Adds `malformed-hydration-payload-frameful-reaches-listener-under-debug-off` to `ssr_error_emit_promotion_test`. It drives `[:rf/hydrate <bad-payload>]` **end-to-end through the real router** against a `:client` frame under `with-redefs [interop/debug-enabled? false]` (the production posture — dev trace surface elided), registers a `register-error-listener!` off-box-shipper stand-in, and asserts:

- **exactly one** `:rf.error/malformed-hydration-payload` record reaches the listener (no duplicate fan-out);
- it carries the **frame context** — `:frame <client-frame>` (NOT nil — adversarial: distinguishes the frameful site from its frameless sibling), `:where 'rf.ssr/hydrate`, `:failing-id :rf/hydrate`, `:recovery :no-recovery`, plus a human-readable `:reason`;
- the existing **fail-closed state** survives (`:title` / `:count` unchanged, no hydration metadata stashed) — so the always-on record reports a *real* rejection, not a phantom emit on an applied hydration.

Parametrised over a non-map `:rf/app-db` slice and a non-map `:rf/runtime-db` slice so **both** fail-closed guard branches are pinned on the always-on axis. The always-on emit path was already correct; no production code changed.

## Quality gates

- `cd implementation/ssr && clojure -M:test` — **337 tests, 1350 assertions, 0 failures, 0 errors** (new deftest: 20 assertions)
- `cd implementation/core && clojure -M:test` — **1378 tests, 6094 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:cljs` — **6893 tests, 28029 assertions, 0 failures, 0 errors**
- `cd implementation && npm run test:elision` — **PASS** (production 42/42 absent, control 42/42 present) — the always-on record survives production elision
