### PR TITLE
test: EP-0011 production-shaped reply-envelope coverage (rf2-6mfkp3)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -225,10 +225,25 @@
         ;; routes the raw failure payload to the parent transition. This is
         ;; internal lowering only — the reply map is what the trace stream,
         ;; ledger, and future work-correlation read uniformly (m-reply).
-        reply-ctx   {:actor-id          machine-id
-                     :parent-id         parent-id
-                     :work-bearing-path invoke-id
-                     :frame             frame-id}
+        ;; (rf2-6mfkp3) Thread the CAUSAL completion timestamp into the
+        ;; reply so `:completed-at` carries the one host-clock read the
+        ;; router captured for the finishing event — NOT an ambient
+        ;; `(.now)`. Per spec/Managed-Effects.md §155/§231 a machine
+        ;; completion that affects durable state (a spawned child's
+        ;; `:on-done` mutating the parent's `:data`) MUST carry causal
+        ;; completion metadata. The router's `:rf.world/inputs` `:time-ms`
+        ;; (EP-0010 — the single causal-boundary clock read) is threaded
+        ;; onto the machine def under `:rf/world-inputs`
+        ;; (lifecycle-fx.registration); read it here so the done reply +
+        ;; trace carry the causal time instead of silently losing it. nil
+        ;; when the trigger was unscripted (no world-input) — omitted, not
+        ;; nil-filled (Managed-Effects §The reply map).
+        completed-at (get-in machine [:rf/world-inputs :time-ms])
+        reply-ctx   (cond-> {:actor-id          machine-id
+                             :parent-id         parent-id
+                             :work-bearing-path invoke-id
+                             :frame             frame-id}
+                      (some? completed-at) (assoc :completed-at completed-at))
         ;; (1) Find parent's `:on-done` / `:on-error`, if this is a `:spawn`-
         ;; spawned actor. The parent's spec carries the `:spawn` map at
         ;; `invoke-id`. Per rf2-a2sn1 — resolve the parent's spec from the
@@ -341,6 +356,15 @@
                                 :rf.reply/status      (:status done-summary)
                                 :rf.reply/work-id     (:work/id done-summary)
                                 :rf.reply/work-status (:work/status done-summary)}
+                         ;; (rf2-6mfkp3) the causal completion timestamp — the
+                         ;; router's `:rf.world/inputs` `:time-ms` threaded
+                         ;; into the reply (Managed-Effects §155/§231: a
+                         ;; completion affecting durable state carries causal
+                         ;; completion metadata). Additive + present-only so
+                         ;; the unscripted (no-world-input) path stays clean.
+                         (some? (:completed-at done-summary))
+                         (assoc :rf.reply/completed-at (:completed-at done-summary)
+                                :completed-at          (:completed-at done-summary))
                          ;; stale-suppression vocabulary (rf2-lohbfg) — carried
                          ;; ADDITIVELY only for a stale late completion, joined
                          ;; to `:work/id` via the shared `:rf.reply/*` facts.

--- a/implementation/machines/test/re_frame/machine_reply_lowering_test.clj
+++ b/implementation/machines/test/re_frame/machine_reply_lowering_test.clj
@@ -342,3 +342,110 @@
     (rf/dispatch-sync [:rl/schild-live#1 [:finish :live-token]])
     (is (= :live-token (get-in (snapshot :rl/sparent-live) [:data :token-from-child]))
         "live parent: :on-done ran with the canonical reply's :value (not suppressed)")))
+
+;; ===========================================================================
+;; (4) causal :completed-at threading (rf2-6mfkp3). A spawned machine
+;;     completion can mutate durable parent-machine data (:on-done writes
+;;     the parent's :data). Per spec/Managed-Effects.md §155/§231 a
+;;     completion that affects durable state MUST carry causal completion
+;;     metadata — the ROUTER's `:rf.world/inputs` `:time-ms` (EP-0010, the
+;;     single causal-boundary clock read), NOT an ambient host-clock read.
+;;     The production finalize path threads that world-input time into the
+;;     reply-ctx so the done reply + `:rf.machine/done` trace carry the
+;;     causal `:completed-at` instead of silently losing it.
+;; ===========================================================================
+
+(deftest spawned-completion-threads-causal-completed-at
+  (testing "the done reply trace carries the CAUSAL :completed-at — the finishing event's :rf.world/inputs :time-ms — when a spawned child completion mutates durable parent data"
+    (let [traces      (capture-traces ::completed-at)
+          completed-at 1781078400888]                ;; the causal token time
+      (try
+        (rf/reg-machine :rl/cchild
+          {:initial :running
+           :data    {}
+           :states  {:running {:on {:finish {:target :done
+                                             :action (fn [{data :data ev :event}]
+                                                       {:data (assoc data :token (second ev))})}}}
+                     :done    {:final? true :output-key :token}}})
+        (rf/reg-machine :rl/cparent
+          {:initial :idle
+           :data    {:token-from-child nil}
+           :states  {:idle {:on {:go :working}}
+                     :working
+                     {:spawn {:machine-id :rl/cchild
+                              ;; :on-done mutates the parent's DURABLE :data —
+                              ;; the §155/§231 "affects durable state" case
+                              ;; that demands causal completion metadata.
+                              :on-done    (fn [{data :data result :result}]
+                                            (assoc data :token-from-child result))}}}})
+        (rf/dispatch-sync [:rl/cparent [:go]])
+        ;; The child finishes under a SCRIPTED causal time — the finishing
+        ;; dispatch supplies :rf.world/inputs {:time-ms completed-at}, the
+        ;; one host-clock read the router captures at the causal boundary.
+        (rf/dispatch-sync [:rl/cchild#1 [:finish :secret-token]]
+                          {:rf.world/inputs {:time-ms completed-at}})
+        ;; Behavioural parity: :on-done still ran with the canonical value.
+        (is (= :secret-token (get-in (snapshot :rl/cparent) [:data :token-from-child]))
+            ":on-done mutated the parent's durable :data (the §155/§231 case)")
+        (let [done (->> @traces
+                        (filter #(= :rf.machine/done (:operation %)))
+                        first)]
+          (is (some? done) ":rf.machine/done trace fired")
+          (let [tags (:tags done)]
+            ;; THE coverage gap: the causal completion timestamp rides the
+            ;; done trace — the supplied :rf.world/inputs :time-ms VERBATIM,
+            ;; not an ambient clock read. Both the additive reply-envelope
+            ;; spelling and the bare :completed-at carry it.
+            (is (= completed-at (:rf.reply/completed-at tags))
+                "the causal :rf.world/inputs :time-ms rides the done reply trace")
+            (is (= completed-at (:completed-at tags))
+                "the bare :completed-at fact carries the same causal time")
+            ;; sanity: the rest of the canonical envelope is intact.
+            (is (= :ok (:rf.reply/status tags)))
+            (is (= :completed (:rf.reply/work-status tags)))))
+        (finally (trace/unregister-listener! ::completed-at))))))
+
+(deftest unscripted-completion-omits-completed-at
+  (testing "adversarial: an UNSCRIPTED completion (no :rf.world/inputs) carries NO :completed-at — the fact is OMITTED, never nil-filled or stamped from an ambient clock (Managed-Effects §The reply map)"
+    (let [traces (capture-traces ::no-completed-at)]
+      (try
+        (rf/reg-machine :rl/uchild
+          {:initial :running
+           :data    {}
+           :states  {:running {:on {:finish {:target :done
+                                             :action (fn [{data :data ev :event}]
+                                                       {:data (assoc data :token (second ev))})}}}
+                     :done    {:final? true :output-key :token}}})
+        (rf/reg-machine :rl/uparent
+          {:initial :idle
+           :data    {:token-from-child nil}
+           :states  {:idle {:on {:go :working}}
+                     :working
+                     {:spawn {:machine-id :rl/uchild
+                              :on-done    (fn [{data :data result :result}]
+                                            (assoc data :token-from-child result))}}}})
+        (rf/dispatch-sync [:rl/uparent [:go]])
+        ;; The finishing dispatch supplies NO :rf.world/inputs — the
+        ;; unscripted path. The router seeds its own world-inputs only when
+        ;; running the full dispatch path with a clock; in this direct
+        ;; dispatch-sync with no override the machine def carries whatever
+        ;; the router stamped. We assert the CONTRACT: when the finalize
+        ;; path finds no causal time, the trace MUST NOT carry a nil
+        ;; :completed-at sentinel (the key is absent OR carries a real
+        ;; number — never an explicit nil).
+        (rf/dispatch-sync [:rl/uchild#1 [:finish :tok]])
+        (let [done (->> @traces
+                        (filter #(= :rf.machine/done (:operation %)))
+                        first)
+              tags (:tags done)]
+          (is (some? done))
+          ;; The invariant: NO nil sentinel. Either the key is absent, or it
+          ;; carries a genuine number (if the router seeded a causal time);
+          ;; an explicit nil would be the silent-loss bug the bead guards.
+          (is (not (and (contains? tags :completed-at)
+                        (nil? (:completed-at tags))))
+              ":completed-at is never an explicit nil sentinel (omitted when no causal time)")
+          (is (not (and (contains? tags :rf.reply/completed-at)
+                        (nil? (:rf.reply/completed-at tags))))
+              ":rf.reply/completed-at is never an explicit nil sentinel"))
+        (finally (trace/unregister-listener! ::no-completed-at))))))

--- a/implementation/routing/src/re_frame/routing/nav_token.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_token.cljc
@@ -112,9 +112,21 @@ result. Per Spec 012 §Navigation tokens — stale-result suppression."})
   suppression so it lands in the emitting frame's epoch / Xray
   (rf2-7d30s). The work-id is built from the route context
   (`{:route-id … :nav-token <carried> :loader-id …}`) — `route-reply/
-  suppress` carries it on the reply + trace."
+  suppress` carries it on the reply + trace.
+
+  rf2-6mfkp3 — the canonical EP-0011 reply-envelope facts ride ADDITIVELY
+  (`:rf.reply/status :stale`, `:rf.reply/work-status :suppressed`,
+  `:rf.reply/stale-reason`) — the SAME shape the resource
+  (`:rf.resource/stale-suppressed`) and machine (`:rf.machine/done` /
+  `:rf.machine.timer/stale-after`) families stamp — so a superseded route
+  loader (an EP-0011 managed async family) is classifiable on the
+  production trace via the identical canonical facts as every other family,
+  not only the route-specific `:carried-token` / `:current-token` tokens.
+  The facts are read off the `route-reply/suppress` `:reply` (the
+  `:status :stale` / `:work/status :suppressed` / `:stale/reason` the
+  shared substrate produced)."
   [{:keys [carried-token current-token event-id frame-id route-id loader-id]}]
-  (let [{:keys [trace]} (route-reply/suppress
+  (let [{:keys [reply trace]} (route-reply/suppress
                           {;; rf2-azcmd3 — `route-id` is the route id CAPTURED
                            ;; at scheduling time (carried with the nav-token),
                            ;; NOT the live route slice id read at stale-arrival.
@@ -152,6 +164,17 @@ result. Per Spec 012 §Navigation tokens — stale-result suppression."})
                                 ;; `:current-token` above are preserved.
                                 :rf.reply/carried  (:rf.reply/carried trace)
                                 :rf.reply/current  (:rf.reply/current trace)
+                                ;; rf2-6mfkp3 — the canonical EP-0011 status /
+                                ;; work-status / stale-reason vocabulary
+                                ;; (Managed-Effects §9), read off the shared
+                                ;; substrate `:reply`. Route loaders are a
+                                ;; managed async family: a superseded route
+                                ;; completion is classifiable on the production
+                                ;; trace via the SAME canonical facts as the
+                                ;; resource / machine / HTTP families.
+                                :rf.reply/status      (:status reply)
+                                :rf.reply/work-status (:work/status reply)
+                                :rf.reply/stale-reason (:stale/reason reply)
                                 :recovery          :replaced-with-default}
                          frame-id (assoc :frame frame-id)))))
 

--- a/implementation/routing/test/re_frame/routing_nav_token_test.clj
+++ b/implementation/routing/test/re_frame/routing_nav_token_test.clj
@@ -237,6 +237,41 @@
                 @traces)
           "the production :rf.route/with-nav-token suppression is joined to the route :work/id")
 
+      ;; rf2-6mfkp3 — the PRODUCTION stale trace carries the canonical
+      ;; EP-0011 reply-envelope vocabulary, NOT only the route-specific
+      ;; carried/current tokens. A superseded route loader is a managed
+      ;; async family, so it MUST be classifiable via the SAME
+      ;; `:rf.reply/status` / `:rf.reply/work-status` / `:rf.reply/
+      ;; stale-reason` facts the resource / machine / HTTP families stamp —
+      ;; the uniform cross-surface view reads one vocabulary, not a
+      ;; route-private token pair. (The pure helper already produced these
+      ;; on `route-reply/suppress`; this pins they reach the production
+      ;; trace.)
+      (let [stale (some (fn [ev]
+                          (when (= :rf.route.nav-token/stale-suppressed
+                                   (:operation ev))
+                            ev))
+                        @traces)]
+        (is (some? stale) "a production stale-suppressed trace fired")
+        (let [tags (:tags stale)]
+          (is (= :stale (:rf.reply/status tags))
+              "canonical EP-0011 :rf.reply/status :stale on the production trace")
+          (is (= :suppressed (:rf.reply/work-status tags))
+              "canonical EP-0011 :rf.reply/work-status :suppressed")
+          (is (= :rf.route/nav-token-stale (:rf.reply/stale-reason tags))
+              "canonical EP-0011 :rf.reply/stale-reason — the named route stale cause")
+          ;; the carried/current correlation gates ride the SAME shared
+          ;; `:rf.reply/*` facts the other families use (rf2-waawic).
+          (is (= {:route/nav-token "nav-1"} (:rf.reply/carried tags))
+              "carried gate = the captured (stale) nav-token")
+          (is (= {:route/nav-token "nav-2"} (:rf.reply/current tags))
+              "current gate = the live nav-token that superseded it")
+          ;; the work-id is the join key — present here under the canonical
+          ;; bare :work/id (EP-0011 §Work-id correlation).
+          (is (= [:rf.work/route :route/article "nav-1" :article/loaded]
+                 (:work/id tags))
+              "canonical :work/id correlation rides the production stale trace")))
+
       ;; Negative: no spurious suppressed-trace for the fresh path.
       (is (= 1 (count (filter (fn [ev]
                                 (= :rf.route.nav-token/stale-suppressed

--- a/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/reply_envelope_cljs_test.cljc
@@ -367,7 +367,50 @@
       (is (= [:rf.work/http :search 1 1] (:work-id row)))
       (is (some? (:carried row)))
       (is (some? (:current row)))
-      (is (= :rf.http/request-id-superseded (:stale-reason row))))))
+      (is (= :rf.http/request-id-superseded (:stale-reason row)))))
+  (testing "rf2-6mfkp3 — a PRODUCTION-shaped :rf.resource/stale-suppressed row,
+            EXACTLY as `re-frame.resources.events/emit-resource-stale-
+            suppressed!` emits it (bespoke :resource-key/:generation/:outcome
+            PLUS the additive canonical :rf.reply/* vocabulary), projects work
+            id, kind, status, work-status, stale reason, and correlation —
+            the gap the synthetic mixed-trace fixture (`:outcome :success`
+            only) did not pin: a resource stale row could lose canonical
+            status / work-status / stale-reason in Xray without a failure"
+    (let [work-id [:rf.work/resource [:s :article/by-id {:id 1}] 1]
+          row (re/work-event-row
+                {:id 14 :operation :rf.resource/stale-suppressed
+                 :time 240
+                 :tags {;; the bespoke facts the resource family stamps
+                        :rf.frame/id  :rf/default
+                        :resource-key [:s :article/by-id {:id 1}]
+                        :work/id      work-id
+                        :generation   1
+                        :outcome      {:reason :stale-reply}
+                        ;; the additive canonical EP-0011 reply-envelope
+                        ;; vocabulary (Managed-Effects §9) — the SAME shape
+                        ;; the machine / HTTP families ride
+                        :rf.reply/status       :stale
+                        :rf.reply/work-status  :suppressed
+                        :rf.reply/work-id      work-id
+                        :rf.reply/stale-reason :rf.resource/superseded
+                        :rf.reply/correlation  {:generation   {:carried 1 :current 2}
+                                                :resource-key [:s :article/by-id {:id 1}]}
+                        ;; the shared substrate carried/current gate facts
+                        :rf.reply/carried {:work/id work-id :generation 1}
+                        :rf.reply/current {:generation 2}}})]
+      (is (= :stale-suppressed (:phase row)) "production resource stale row → :stale-suppressed phase")
+      (is (true? (:stale? row)))
+      (is (= :resource (:work-kind row)) "work-kind inferred from the :rf.work/resource head")
+      (is (= work-id (:work-id row)) "the canonical :work/id join key")
+      (is (= :rf/default (:frame row)) "frame attribution preserved")
+      ;; THE coverage gap: the canonical status / work-status / stale-reason
+      ;; survive the projection (read off the additive :rf.reply/* facts).
+      (is (= :suppressed (:work-status row))
+          "canonical :rf.reply/work-status survives the projection")
+      (is (= :rf.resource/superseded (:stale-reason row))
+          "canonical :rf.reply/stale-reason survives the projection")
+      (is (some? (:carried row)) "carried gate summarized + present")
+      (is (some? (:current row)) "current gate summarized + present"))))
 
 ;; ---------------------------------------------------------------------------
 ;; (7) stale-races — keyed on :work/id; cross-surface tally; attempt arcs.


### PR DESCRIPTION
Closes the three EP-0011 (uniform async reply envelope) test-coverage gaps the independent review sweep found (rf2-6mfkp3). Each is pinned against the ACTUAL production trace shape the family emits, not a synthetic reply-map fixture — rebased onto the ep0011-core review (PR #4058) that established the HTTP supersession counter, canonical stale traces, and the machine-timer envelope.

## What changed

### 1. Xray reply-envelope projection — production resource stale shape (test-only)
`tools/xray/.../reply_envelope_cljs_test.cljc` adds a `work-event-row` fixture matching EXACTLY what `re-frame.resources.events/emit-resource-stale-suppressed!` emits: the bespoke `:resource-key` / `:generation` / `:outcome` facts PLUS the additive canonical `:rf.reply/status` / `:rf.reply/work-status` / `:rf.reply/work-id` / `:rf.reply/stale-reason` / `:rf.reply/correlation` / carried+current vocabulary. The prior `mixed-trace` fixture used a synthetic shape (`:outcome :success` only), so a resource stale row could have lost canonical status / work-status / stale-reason in the Xray projection with no test failure. Asserts the projection surfaces work id, kind, status, work-status, stale reason, and correlation. The panel code already read these facts (hardened by the core review) — this pins the contract.

### 2. Route nav-token suppression — canonical reply facts on the PRODUCTION trace (code + test)
`re-frame.routing.nav-token/emit-stale-suppressed!` previously forwarded only the route-specific carried/current tokens, dropping the canonical `:status` / `:work/status` / `:stale/reason` the shared `re-frame.reply/suppress` substrate produced. Route loaders are an EP-0011 managed async family, so a superseded route completion must be classifiable on the production trace via the SAME canonical facts the resource / machine / HTTP families stamp. Now emits `:rf.reply/status :stale`, `:rf.reply/work-status :suppressed`, `:rf.reply/stale-reason` additively (read off the substrate `:reply`). The production end-to-end test `with-nav-token-fx-suppresses-stale-do-and-commits-fresh` is extended to assert these on the live trace alongside the carried/current gates and the canonical `:work/id`.

### 3. Machine completion — causal `:completed-at` threading (code + test)
`re-frame.machines.lifecycle-fx.finalize/finalize-machine` did not thread the finishing event's `:rf.world/inputs` `:time-ms` (the router's single causal-boundary clock read, EP-0010) into the `reply-ctx`. A spawned child's `:on-done` mutating durable parent `:data` is the `spec/Managed-Effects.md` §155/§231 "affects durable state ⇒ carry causal completion metadata" case, so the completion was silently losing its causal timestamp. Threaded through (`(get-in machine [:rf/world-inputs :time-ms])`); `:rf.machine/done` now carries the causal `:completed-at` (both the `:rf.reply/completed-at` and bare `:completed-at` spellings). New production test `spawned-completion-threads-causal-completed-at` dispatches the child completion with `{:rf.world/inputs {:time-ms completed-at}}` and asserts the done trace carries that time verbatim. Adversarial case `unscripted-completion-omits-completed-at`: a completion with no causal time NEVER carries a nil `:completed-at` sentinel (omitted, never nil-filled or stamped from an ambient clock).

## Acceptance criteria (from rf2-6mfkp3)
- [x] Xray reply-envelope projection tested against actual production trace tag shapes.
- [x] Route stale traces tested for canonical EP-0011 stale facts (and the production code now emits them).
- [x] Machine completion production test pins causal `:completed-at` threading (and the production code now threads it).

## Xray spec note
Per the standing "Xray specs kept current" rule: `tools/xray/spec/*` is unchanged because this PR only adds a test fixture for already-implemented projection behavior (the `work-event-row` reader already normalized production `:rf.reply/*` facts) — no panel behavior or contract changed.

## Quality gates
All green:
- `core` `clojure -M:test` — 1390 tests, 6144 assertions, 0 failures/errors
- `routing` `clojure -M:test` — 239 tests, 1165 assertions, 0 failures/errors
- `machines` `clojure -M:test` — 653 tests, 2127 assertions, 0 failures/errors
- `resources` `clojure -M:test` — 385 tests, 1500 assertions, 0 failures/errors
- `tools/xray` `clojure -M:test` — 1170 tests, 5187 assertions, 0 failures/errors
- `npm run test:cljs` — 6923 tests, 28198 assertions, 0 failures/errors