### PR TITLE
fix(examples): helix :data-schema + causal durable-ids + sensitive password (rf2-j6oy5j + xd1ro4 + 0m6fbd)

### DIFF
--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -53,10 +53,18 @@
 ;; SCHEMAS
 ;; ============================================================================
 
+;; EP-0015 (Frame-Owned Egress Policy): the `:password` slot is classified
+;; `:sensitive?` (the declarative secret-data marking) and the managed-HTTP
+;; request below carries `:sensitive? true` to scrub the password off the wire.
+;; See examples/reagent/login for the full HONEST-SCOPE rationale: the slot
+;; mark on a machine EVENT-arg schema classifies the shape but does not itself
+;; redact the dispatched event vector; the per-request HTTP `:sensitive?` flag
+;; is the working, observable EP-0015 redaction (the password's real off-box
+;; egress path is the request body). Parity across reagent/login + uix.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
-   [:password [:string {:min 8}]]])
+   [:password {:sensitive? true} [:string {:min 8}]]])
 
 ;; Outer event-vector schema for the :auth.login/flow machine handler —
 ;; see examples/reagent/login for the full rationale. The :submit
@@ -179,10 +187,15 @@
     :issue-request
     (fn [{[_ creds] :event}]
       {:fx [[:rf.http/managed
+             ;; EP-0015 / Spec 014 §Privacy: `:sensitive? true` redacts the
+             ;; request body (carrying the `:password`) from every `:rf.http/*`
+             ;; trace event — the observable EP-0015 redaction (see
+             ;; examples/reagent/login for the full rationale).
              {:request    {:method :post
                            :url    "/api/login"
                            :body   creds
-                           :request-content-type :json}
+                           :request-content-type :json
+                           :sensitive? true}
               :decode     :json
               :on-success [:auth.login/flow [:auth.login/success]]
               :on-failure [:auth.login/flow [:auth.login/failure]]}]]})

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -79,18 +79,24 @@
     [:vector :any]]
    [:? :any]])
 
-(def AuthLoginSnapshot
+;; The machine's `:data-schema` validates the machine's `:data` slot ONLY —
+;; the user-domain extended state `{:attempts ... :error ...}` — NOT the whole
+;; `{:state ... :data ...}` snapshot. Per Spec 005 §Schema validation and Spec
+;; 010 §Machine data schema, `:data-schema` sits as a top-level key on the
+;; machine spec beside `:data`, and the framework validates it at every
+;; macrostep-commit boundary + at bootstrap (`:where :machine-data`). Identical
+;; to examples/reagent/login + examples/uix/login_uix — the artefact layer is
+;; byte-for-byte parity across the three substrates (see the divider above).
+(def AuthLoginData
   [:map
-   [:state [:enum :idle :submitting :error-shown :authed :locked-out]]
-   [:data  [:map
-            [:attempts {:default 0} :int]
-            [:error    [:maybe :string]]]]])
+   [:attempts {:default 0} :int]
+   [:error    [:maybe :string]]])
 
 ;; EP-0001 (rf2-vzld77): machine snapshots are runtime-db state, not app-db —
 ;; an `reg-app-schema` on a machine-snapshot path validates nothing (app
 ;; schemas validate the app-db partition only, Mike ruling #11). The
-;; machine's own `:data-schema` is the snapshot-validation surface, so the
-;; vestigial app-schema reg is removed.
+;; machine's own `:data-schema` (attached below) is the snapshot-validation
+;; surface, so no app-schema reg applies to the login snapshot.
 
 ;; ============================================================================
 ;; FX
@@ -155,6 +161,11 @@
   {:doc    "Login flow: idle → submitting → authed / error-shown / locked-out."
    :schema AuthLoginEvent}
   {:initial :idle
+   ;; Spec 010 §Machine data schema — `:data-schema` validates the snapshot's
+   ;; `:data` slot (not the whole snapshot) at the `:where :machine-data`
+   ;; boundary; `reg-machine` (above) bridges its `:sensitive?` / `:large?`
+   ;; redaction marks into snapshot egress. Parity with reagent/login + uix.
+   :data-schema AuthLoginData
    :data    {:attempts 0 :error nil}
 
    :guards

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -104,10 +104,30 @@
 ;; The submit-event payload — the credentials map the view collects from
 ;; the form. Open by default; the regex/min-length checks describe the
 ;; shape the inner handler relies on.
+;; EP-0015 (Frame-Owned Egress Policy): the `:password` slot is classified
+;; `:sensitive?` — the declarative "this is secret data" marking on the
+;; credentials shape (Spec 015 §Worked example, Option B). This is the
+;; canonical place a reader expects the marking idiom on a login form.
+;;
+;; HONEST SCOPE — where this mark does and does NOT redact. `Credentials` is
+;; the machine's EVENT-arg schema (it rides `AuthLoginEvent` via the machine's
+;; event `:schema`), not an app-db `reg-app-schema` and not the machine's
+;; `:data-schema`. The password is never written to durable app-db or to the
+;; machine `:data` slot, so neither the app-db schema-marks bridge
+;; (`populate-sensitive-from-schemas!`) nor the machine `:data-schema` egress
+;; bridge (`register-data-schema-marks!`) applies, and a machine handler does
+;; not stash event-arg `:sensitive` paths (reg-event-fx skips that for
+;; `:rf/machine?`). So this slot mark does NOT by itself redact the password
+;; from the dispatched event vector. The password's real off-box egress path
+;; is the HTTP request body — redacted by the per-request `:sensitive? true`
+;; flag on the managed-HTTP call in `:issue-request` below (Spec 014 §Privacy /
+;; EP-0015 issue 5), which is the WORKING, observable redaction. The two
+;; together are the complete EP-0015 picture: declarative slot classification +
+;; the carrier-level flag that actually scrubs the wire.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
-   [:password [:string {:min 8}]]])
+   [:password {:sensitive? true} [:string {:min 8}]]])
 
 ;; Outer event-vector schema for the :auth.login/flow machine handler.
 ;; The login form is the canonical user-facing boundary, so we validate
@@ -270,10 +290,17 @@
       ;; :failure ...}`) appended as their last arg by the runtime.
       (fn [{[_ creds] :event}]
         {:fx [[:rf.http/managed
+               ;; EP-0015 / Spec 014 §Privacy: `:sensitive? true` on the request
+               ;; redacts the request body (carrying the `:password`) and all
+               ;; params from every `:rf.http/*` trace event — the password's
+               ;; real off-box egress path. This is the observable EP-0015
+               ;; redaction for the login flow (the credentials event-arg
+               ;; `:sensitive?` slot classifies the shape; this scrubs the wire).
                {:request    {:method :post
                              :url    "/api/login"
                              :body   creds
-                             :request-content-type :json}
+                             :request-content-type :json
+                             :sensitive? true}
                 :decode     :json
                 :on-success [:auth.login/flow [:auth.login/success]]
                 :on-failure [:auth.login/flow [:auth.login/failure]]}]]})

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -75,9 +75,30 @@
                         (if (= (:id d) id) (assoc d :body text) d))
                       docs))))))
 
+;; EP-0010 (Causal World Inputs): the new document's id is written into durable
+;; app-db (`:notebook/documents`), so it must be a function of prior frame-state
+;; — never an ambient `(rand-int)` read at the durable-write site (a fresh
+;; event-stream replay would mint a different id, breaking replay determinism).
+;; So we allocate it deterministically from the existing documents, the todomvc
+;; `allocate-next-id` idiom: scan the `doc-N` keyword ids already in app-db and
+;; take max+1. Seeded ids (`:welcome`, `:six-dominoes`, …) carry no `doc-`
+;; prefix, so they don't participate — the first minted id is `:doc-1`.
+(defn- allocate-next-doc-id
+  "Deterministic next `:doc-N` id from the existing documents — max prior
+   N + 1 (1 when none yet). A pure function of prior app-db state, so it
+   replays identically (EP-0010)."
+  [documents]
+  (let [used-ns (->> documents
+                     (keep (fn [{id :id}]
+                             (some->> (re-matches #"doc-(\d+)" (name id))
+                                      second
+                                      (js/parseInt))))
+                     (apply max 0))]
+    (keyword (str "doc-" (inc used-ns)))))
+
 (rf/reg-event-db :notebook/new
   (fn [db _event]
-    (let [id (keyword (str "doc-" (rand-int 1000000)))
+    (let [id  (allocate-next-doc-id (:notebook/documents db))
           doc {:id id :title "Untitled" :body "# Untitled\n\nStart writing…"}]
       (-> db
           (update :notebook/documents (fnil conj []) doc)

--- a/examples/reagent/seven_guis/circle_drawer/core.cljs
+++ b/examples/reagent/seven_guis/circle_drawer/core.cljs
@@ -35,9 +35,17 @@
 ;; SCHEMA
 ;; ============================================================================
 
+;; EP-0010 (Causal World Inputs): a circle's `:id` is written into durable
+;; app-db (`[:drawer :circles]`), so it must be a function of prior frame-state
+;; — never an ambient `(random-uuid)` at the durable-write site (a fresh
+;; event-stream replay would mint different ids). The id is an internal handle
+;; (React `:key` + context-menu target), so we mint it deterministically as a
+;; monotonic `:int` from a db-held counter — the todomvc `allocate-next-id`
+;; idiom — rather than a uuid. Undo/redo snapshot whole `:circles` vectors, so
+;; the ids ride the snapshot and round-trip unchanged.
 (def Circle
   [:map
-   [:id      :uuid]
+   [:id      :int]
    [:x       :double]
    [:y       :double]
    [:radius  pos-int?]])
@@ -45,8 +53,9 @@
 (def DrawerState
   [:map
    [:circles   [:vector Circle]]
+   [:next-id    :int]                           ;; deterministic id allocator (EP-0010)
    [:dialog    [:maybe [:map
-                        [:circle-id      :uuid]
+                        [:circle-id      :int]
                         [:initial-radius pos-int?]
                         [:draft-radius   pos-int?]]]]
    [:undo      [:vector :any]]                  ;; stack of prior :circles values
@@ -85,16 +94,24 @@
 ;; ============================================================================
 
 (rf/reg-event-db :drawer/initialise
-  {:doc "Seed an empty canvas."}
+  {:doc "Seed an empty canvas. `:next-id` is the deterministic id allocator
+         (EP-0010) — circles take monotonic int ids starting at 1."}
   (fn handler-drawer-initialise [db _]
-    (assoc db :drawer {:circles [] :dialog nil :undo [] :redo []})))
+    (assoc db :drawer {:circles [] :next-id 1 :dialog nil :undo [] :redo []})))
 
 (rf/reg-event-db :drawer/add-circle
-  {:doc "Click on canvas. Adds a circle of default radius."}
+  {:doc "Click on canvas. Adds a circle of default radius. The id is minted
+         deterministically from the db-held `:next-id` counter (EP-0010 causal
+         world inputs — a durable id must be a function of prior frame-state,
+         not an ambient `(random-uuid)` read), then the counter is bumped. The
+         counter is NOT in the undoable `:circles` snapshot, so it advances
+         monotonically across undo/redo and never re-mints a live id."}
   [undoable]
   (fn handler-drawer-add-circle [db [_ x y]]
-    (update-in db [:drawer :circles] conj
-               {:id (random-uuid) :x x :y y :radius 30})))
+    (let [id (get-in db [:drawer :next-id])]
+      (-> db
+          (update-in [:drawer :circles] conj {:id id :x x :y y :radius 30})
+          (assoc-in  [:drawer :next-id] (inc id))))))
 
 (rf/reg-event-db :drawer/open-dialog
   {:doc "Right-clicked a circle. Opens the adjust-diameter dialog. Not undoable."}

--- a/examples/uix/login_uix/core.cljs
+++ b/examples/uix/login_uix/core.cljs
@@ -32,10 +32,18 @@
 ;; SCHEMAS
 ;; ============================================================================
 
+;; EP-0015 (Frame-Owned Egress Policy): the `:password` slot is classified
+;; `:sensitive?` (the declarative secret-data marking) and the managed-HTTP
+;; request below carries `:sensitive? true` to scrub the password off the wire.
+;; See examples/reagent/login for the full HONEST-SCOPE rationale: the slot
+;; mark on a machine EVENT-arg schema classifies the shape but does not itself
+;; redact the dispatched event vector; the per-request HTTP `:sensitive?` flag
+;; is the working, observable EP-0015 redaction (the password's real off-box
+;; egress path is the request body). Parity across reagent/login + helix.
 (def Credentials
   [:map
    [:email    [:re #".+@.+"]]
-   [:password [:string {:min 8}]]])
+   [:password {:sensitive? true} [:string {:min 8}]]])
 
 ;; Outer event-vector schema for the :auth.login/flow machine handler —
 ;; see examples/reagent/login for the full rationale. The :submit
@@ -152,10 +160,15 @@
     :issue-request
     (fn [{[_ creds] :event}]
       {:fx [[:rf.http/managed
+             ;; EP-0015 / Spec 014 §Privacy: `:sensitive? true` redacts the
+             ;; request body (carrying the `:password`) from every `:rf.http/*`
+             ;; trace event — the observable EP-0015 redaction (see
+             ;; examples/reagent/login for the full rationale).
              {:request    {:method :post
                            :url    "/api/login"
                            :body   creds
-                           :request-content-type :json}
+                           :request-content-type :json
+                           :sensitive? true}
               :decode     :json
               :on-success [:auth.login/flow [:auth.login/success]]
               :on-failure [:auth.login/flow [:auth.login/failure]]}]]})


### PR DESCRIPTION
Three examples-surface fixes, one commit per bead. Examples stay idiomatic re-frame2 (app-db + events + cofx; no ambient durable reads) and test-free (no `*.spec.cjs`).

## rf2-j6oy5j — login_helix live `:data-schema` (EP-0005)
`examples/helix/login_helix` carried no live `:data-schema` on its `:auth.login/flow` machine (unlike its reagent/uix siblings), leaving the `:data` slot unvalidated and the cross-substrate parity claim dishonest, plus a vestigial unused `AuthLoginSnapshot` def. Defined `AuthLoginData [:map [:attempts :int] [:error [:maybe :string]]]`, attached it as the machine's `:data-schema` (validated at `:where :machine-data`), and deleted the dead `AuthLoginSnapshot`. The artefact layer is now byte-for-byte parity across the three substrates.

## rf2-xd1ro4 — causal/deterministic durable ids (EP-0010)
`notebook` (`:notebook/new`, `(rand-int 1000000)`) and `circle_drawer` (`:drawer/add-circle`, `(random-uuid)`) minted durable app-db ids from ambient randomness, breaking fresh event-stream replay determinism and drifting from the canonical todomvc `allocate-next-id` idiom. Aligned both to deterministic allocators (a function of prior frame-state, never an ambient read at the durable-write site):
- notebook: `allocate-next-doc-id` scans existing `doc-N` ids → max+1.
- circle_drawer: db-held `:next-id` counter (Circle `:id` `:uuid` → `:int`); the counter sits outside the undoable `:circles` snapshot so it advances monotonically across undo/redo and never re-mints a live id.

No ambient `(rand-int)`/`(random-uuid)` writes a durable id in either example now.

## rf2-0m6fbd — login password `:sensitive?` + wire redaction (EP-0015)
The login examples classified the JWT token `:sensitive?` but not the password. Classified the `:password` slot `{:sensitive? true}` in the `Credentials` schema across reagent/login + uix/login_uix + helix/login_helix (the declarative secret-data marking), AND added the per-request `:sensitive? true` flag to the managed-HTTP login call in `:issue-request`.

**Honest-scope finding:** the slot mark alone does NOT redact the dispatched event vector here — `Credentials` is the machine's EVENT-arg schema (not an app-db schema or the machine `:data-schema`), the password is never written to durable state, and a machine handler does not stash event-arg `:sensitive` paths (reg-event-fx skips that for `:rf/machine?`; only `:data-schema` marks bridge to egress). The password's real off-box egress path is the HTTP request body, which the per-request `:sensitive? true` flag scrubs from every `:rf.http/*` trace event (Spec 014 §Privacy / EP-0015 issue 5) — the working, observable redaction. The two together are the complete EP-0015 picture; inline comments document the honest scope of each. (The bead's literal "mark flows to event-vector redaction" premise was incorrect for a machine handler; the HTTP-flag path is the genuine demonstration.)

## Quality gates
- `npm run test:examples-compile` — all 42 example builds compiled, **0 warnings** (warnings-as-errors), exit 0. Covers `:examples/notebook`, `:examples/circle-drawer`, `:examples/login`, `:examples/login-uix`, `:examples/login-helix`.
- `npm run test:cljs` — **6927 tests / 28202 assertions, 0 failures, 0 errors**.
- `npm run test:examples` — 3 adapter smokes (Reagent / UIx / Helix), **0 failures, 0 skipped**.
- `python scripts/check_ambient_durable_reads.py` — exit 0, no ambient durable-world reads in any durable-write namespace. (Scope note: this gate scans `implementation/` durable-write namespaces, not `examples/`; the examples alignment is the idiom fix the bead requested. Gate confirms no framework regression.)