### PR TITLE
EP-0013 tails: deferred-kind removal matrix + MCP realm-pin reset + Story realm-stamp util (rf2-c6armm.9 + c6armm.12)

### DIFF
--- a/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
+++ b/implementation/core/test/re_frame/app_value_install_cljs_test.cljc
@@ -421,51 +421,66 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest reinstall-removing-a-sugar-registered-step8-kind-refuses-loudly
-  (testing "rf2-cquy9u: a step-8 DEFERRED kind (:mutation/:resource/:route/
-            :flow/…) registered through its OWN sugar reaches the realm's
-            registrar and is projected into reinstall!'s old-app, so a reinstall!
-            that OMITS it lands it in :removed. PRE-FIX the :removed path called
-            registrar/unregister! UNCONDITIONALLY — silently dropping the slot
-            and skipping the subsystem teardown (in-flight abort, routing
-            :current, flow owner-rebind), the silent-orphan window the :frame fix
-            closed, reopened on the removal path. The fix REFUSES LOUDLY with
+  (testing "rf2-cquy9u / rf2-c6armm.9 #1: a step-8 DEFERRED kind registered
+            through its OWN sugar reaches the realm's registrar and is projected
+            into reinstall!'s old-app, so a reinstall! that OMITS it lands it in
+            :removed. PRE-FIX the :removed path called registrar/unregister!
+            UNCONDITIONALLY — silently dropping the slot and skipping the
+            subsystem teardown (in-flight abort, routing :current, flow
+            owner-rebind), the silent-orphan window the :frame fix closed,
+            reopened on the removal path. The fix REFUSES LOUDLY with
             :rf.error/unsupported-descriptor-kind — symmetric with the add/changed
             path's throw — BEFORE any mutation, enumerating the blocking [kind id]
-            and naming the deferred set + the clear-* recovery."
-    ;; Simulate the sugar registration (reg-mutation lives in the resources
-    ;; artefact, off core's test classpath): seat a :mutation slot directly into
-    ;; the default realm's registrar (which IS the global atom), exactly as the
-    ;; sugar's registrar/register! :mutation would. The projection picks it up.
-    (registrar/register! :mutation :cquy9u/save {:handler-fn (fn [& _] nil)})
-    (is (some? (registrar/lookup :mutation :cquy9u/save))
-        "the sugar-registered :mutation slot is in the registrar")
-    ;; reinstall! a new app that OMITS :cquy9u/save → it lands in :removed.
-    ;; Re-declare nothing else mutation/frame-shaped so this refusal (not the
-    ;; :frame refusal) is the one that fires.
-    (let [ed (try (rf/reinstall! :rf.realm/default
-                                 (rf/app {:id :cquy9u/app :modules
-                                          [(rf/module {:id :m
-                                                       :events {:cquy9u/ev {:handler (fn [db _] db)}}})]}))
-                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
-                    (ex-data e)))]
-      (is (= :rf.error/unsupported-descriptor-kind (:error/id ed))
-          "removing a sugar-registered step-8 kind refuses loudly, not silently")
-      (is (some #{[:mutation :cquy9u/save]} (:removed ed))
-          "the diagnostic enumerates exactly the blocking removed [kind id]")
-      (is (contains? (:deferred ed) :mutation)
-          "the refusal names the deferred set")
-      (is (= :clear-through-reg-*-sugar (:recovery ed))
-          "the error names the recovery: clear through the kind's own clear-* sugar"))
-    ;; The refusal was BEFORE any mutation — the :mutation slot is UNTOUCHED (the
-    ;; orphan the bug produced: pre-fix it would be nil here) and the new :added
-    ;; event was NOT seated.
-    (is (some? (registrar/lookup :mutation :cquy9u/save))
-        "the sugar-registered slot survives the refused reinstall — NOT silently unregistered")
-    (is (nil? (registrar/lookup :event :cquy9u/ev))
-        "the refused reinstall seated nothing — it failed before any mutation")
-    ;; Cleanup: drop the directly-seeded slot (the runtime-reset fixture
-    ;; snapshots the registrar, but be explicit since this test seeds it raw).
-    (registrar/unregister! :mutation :cquy9u/save)))
+            and naming the deferred set + the clear-* recovery.
+
+            PARAMETERIZED over the FULL step-8 deferred-kind set (core.cljc:1753)
+            — :route :flow :resource :mutation :resource-scope :view :head
+            :error-projector — not just :mutation: drift in the deferred set or
+            the removal filter could silently unregister routes/resources/flows/
+            views/etc. while a :mutation-only test still passed (rf2-c6armm.9 #1)."
+    ;; Simulate the sugar registration (the reg-route / reg-flow / reg-resource /
+    ;; reg-mutation / … sugar lives in feature artefacts off core's test
+    ;; classpath): seat ONE slot of the deferred kind directly into the default
+    ;; realm's registrar (which IS the global atom), exactly as that kind's sugar
+    ;; registrar/register! <kind> would. The projection picks it up.
+    (doseq [kind [:route :flow :resource :mutation
+                  :resource-scope :view :head :error-projector]]
+      (let [slot-id (keyword "cquy9u" (str (name kind) "-save"))
+            ev-id   (keyword "cquy9u" (str (name kind) "-ev"))]
+        (registrar/register! kind slot-id {:handler-fn (fn [& _] nil)})
+        (is (some? (registrar/lookup kind slot-id))
+            (str "the sugar-registered " kind " slot is in the registrar"))
+        ;; reinstall! a new app that OMITS the slot → it lands in :removed.
+        ;; Re-declare nothing else of a deferred/frame kind so THIS refusal (not a
+        ;; sibling slot's, nor the :frame refusal) is the one whose :removed we
+        ;; assert below — every previously-seeded slot survived its own refusal so
+        ;; it would ALSO be :removed, so we assert membership, not equality.
+        (let [ed (try (rf/reinstall! :rf.realm/default
+                                     (rf/app {:id :cquy9u/app :modules
+                                              [(rf/module {:id :m
+                                                           :events {ev-id {:handler (fn [db _] db)}}})]}))
+                      (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
+                        (ex-data e)))]
+          (is (= :rf.error/unsupported-descriptor-kind (:error/id ed))
+              (str "removing a sugar-registered " kind " refuses loudly, not silently"))
+          (is (some #{[kind slot-id]} (:removed ed))
+              (str "the diagnostic enumerates the blocking removed [" kind " " slot-id "]"))
+          (is (contains? (:deferred ed) kind)
+              (str "the refusal names " kind " in the deferred set"))
+          (is (= :clear-through-reg-*-sugar (:recovery ed))
+              "the error names the recovery: clear through the kind's own clear-* sugar"))
+        ;; The refusal was BEFORE any mutation — the slot is UNTOUCHED (the orphan
+        ;; the bug produced: pre-fix it would be nil here) and the new :added
+        ;; event was NOT seated.
+        (is (some? (registrar/lookup kind slot-id))
+            (str "the sugar-registered " kind " slot survives the refused reinstall — NOT silently unregistered"))
+        (is (nil? (registrar/lookup :event ev-id))
+            (str "the refused " kind " reinstall seated nothing — it failed before any mutation"))))
+    ;; Cleanup: drop the directly-seeded slots (the runtime-reset fixture
+    ;; snapshots the registrar, but be explicit since this test seeds them raw).
+    (doseq [kind [:route :flow :resource :mutation
+                  :resource-scope :view :head :error-projector]]
+      (registrar/unregister! kind (keyword "cquy9u" (str (name kind) "-save"))))))
 
 (deftest reinstall-not-omitting-the-step8-kind-leaves-it-untouched
   (testing "rf2-cquy9u: the refusal is targeted at REMOVAL only — a reinstall!

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -1321,25 +1321,38 @@
      :edn-submap {:ok? false :reason :no-such-realm :realm :nope}}}
 
    {:fixture/id    :reset-operating-frame/clears-pin
-    :fixture/doc   "reset-operating-frame clears the session pin (select-frame! nil) and returns the post-reset triple with :selected nil."
+    :fixture/doc   "reset-operating-frame clears BOTH session pins — the frame pin (select-frame! nil) AND the realm pin (select-realm! nil, EP-0013 rf2-09ijml) — and returns the post-reset map with :selected nil, :selected-realm nil, and :operating-realm back at the default realm (rf2-c6armm.9 #2)."
     :fixture/tool  "reset-operating-frame"
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"  true]
-     ;; The clear-then-reread form: select-frame! nil, then frames-list
-     ;; reports :selected nil. In a multi-frame app :operating is now nil
-     ;; (back to tier-4 ambiguous).
+     ;; The clear-then-reread form: select-frame! nil, select-realm! nil, then
+     ;; frames-list reports BOTH pins cleared — :selected nil (multi-frame app →
+     ;; :operating nil, back to tier-4 ambiguous) AND :selected-realm nil
+     ;; (:operating-realm falls back to the default realm). The substring match
+     ;; on "select-frame!" matches the single clear-then-reread form.
      ["select-frame!"             {:ok? true
                                    :frames [:rf/default :stories]
                                    :selected nil
-                                   :operating nil}]
+                                   :operating nil
+                                   :realms [:rf.realm/default :shop/realm]
+                                   :selected-realm nil
+                                   :operating-realm :rf.realm/default
+                                   :frame-realms {:rf/default :rf.realm/default
+                                                  :stories :shop/realm}}]
      [:default                    nil]]
+    ;; The emitted reset form MUST clear BOTH pins, not just the frame pin: a
+    ;; regression that dropped `select-realm! nil` would leave a stale operating
+    ;; realm after reset (subsequent tool calls scoped to the wrong realm) yet
+    ;; still pass a frame-only assertion (rf2-c6armm.9 #2).
     :fixture/eval-form-must-contain
-    ["select-frame! nil" "frames-list"]
+    ["select-frame! nil" "select-realm! nil" "frames-list"]
     :fixture/expect
     {:isError? false
-     :edn-submap {:ok? true :selected nil :operating nil}
-     :edn-contains-keys #{:frames :selected :operating}}}
+     :edn-submap {:ok? true :selected nil :operating nil
+                  :selected-realm nil :operating-realm :rf.realm/default}
+     :edn-contains-keys #{:frames :selected :operating
+                          :realms :selected-realm :operating-realm :frame-realms}}}
 
    {:fixture/id    :get-operating-frame/reports-triple
     :fixture/doc   "get-operating-frame returns the normative {:frames :selected :operating} triple; :selected reflects a prior set."

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -49,6 +49,10 @@
             [re-frame.story.play.runner :as runner]
             [re-frame.story.play.settled-boundary :as boundary]
             [re-frame.story.predicates  :as pred]
+            ;; rf2-c6armm.12 — the shared absent-key realm util (the
+            ;; "carry only a non-default realm" rule, here under the `:realm`
+            ;; address-map key rather than the recording `:rf.realm/id` stamp).
+            [re-frame.story.realm       :as story-realm]
             [re-frame.story.registrar   :as registrar]))
 
 ;; ---- per-variant run-state -----------------------------------------------
@@ -280,9 +284,10 @@
   [variant-id]
   (let [realm (try (rf/frame-realm variant-id)
                    (catch #?(:clj Throwable :cljs :default) _ nil))]
-    (cond-> {:frame variant-id}
-      (and (some? realm) (not= realm :rf.realm/default))
-      (assoc :realm realm))))
+    ;; rf2-c6armm.12 — the absent-key rule through the shared Story realm util,
+    ;; under the `:realm` address-map key: a nil / default realm carries `:realm`
+    ;; nothing (target is `{:frame v}`), a constructed realm carries it.
+    (story-realm/stamp-realm {:frame variant-id} :realm realm)))
 
 ;; ---- folded-plan consumption (rf2-5x1wt.19) ------------------------------
 ;;

--- a/tools/story/src/re_frame/story/realm.cljc
+++ b/tools/story/src/re_frame/story/realm.cljc
@@ -1,0 +1,82 @@
+(ns re-frame.story.realm
+  "The ONE place Story makes the EP-0013 \"stamp only a non-default realm\"
+  decision — the absent-key rule (Spec-Schemas §`:rf/realm`, EP-0013 issue 2):
+  absence of a realm key means THE DEFAULT realm.
+
+  ## Why this ns exists (rf2-c6armm.12)
+
+  Three Story paths independently needed to answer \"does this frame's runtime
+  realm get carried, and if so under what key?\":
+
+    - the RECORDER (`re-frame.story.recorder`) stamps a captured recording's
+      target frame under `:rf.realm/id` (`realm-stamp-key`);
+    - PLAY EXPORT (`re-frame.story.recorder.play-export`) carries the same
+      `:rf.realm/id` stamp onto the emitted play-script map;
+    - the REPLAY TARGET (`re-frame.story.play.runner-events`) carries the realm
+      onto the `{:realm r :frame v}` address it replays against (under `:realm`,
+      the address-map key — a DIFFERENT key, same predicate).
+
+  Each had repeated the literal `(and (some? realm) (not= realm
+  :rf.realm/default))` predicate inline. EP-0013 realm addressing is still
+  evolving, so a predicate repeated across recorder / export / replay is a
+  drift hazard — a future refinement of \"which realms get stamped\" would have
+  to find and update three sites. Centralising the decision here keeps it ONE
+  edit.
+
+  Pure data → data; no `re-frame.core` dependency (the live `frame-realm` read
+  stays at each call site — this ns only decides what to do with the value)."
+  (:require [re-frame.realm :as realm]))
+
+(def ^:const realm-stamp-key
+  "The reserved app-value key a recording stamps its target frame's runtime
+  realm under (EP-0013). Matches the framework's reserved `:rf.realm/id`
+  spelling (Spec-Schemas §`:rf/realm`) so a stamped recording reads the way
+  the realm-targeted query forms (`rf/registrations {:realm …}`) spell it."
+  :rf.realm/id)
+
+(defn non-default-realm
+  "Return `realm-id` verbatim when it is a realm a Story path should CARRY, or
+  nil when nothing should be carried. The single expression of the EP-0013
+  absent-key rule for Story.
+
+  Returns nil for:
+
+    - `nil` — an unknown / destroyed frame (`rf/frame-realm` returns nil), or
+              no realm resolvable;
+    - `re-frame.realm/default-realm-id` (`:rf.realm/default`) — a single-realm
+              / default-realm frame. Absence IS the default, so nothing is
+              carried and the recording / target round-trips unchanged (zero
+              ceremony).
+
+  Returns the realm id verbatim for any other (constructed) realm so replay can
+  verify it targets the same realm the recording was captured in."
+  [realm-id]
+  (when (and (some? realm-id)
+             (not= realm-id realm/default-realm-id))
+    realm-id))
+
+(defn assoc-realm
+  "Pure LOW-LEVEL stamper: assoc `realm-id` onto `m` under `k`, or leave `m`
+  UNTOUCHED when `realm-id` is nil. Guards ONLY nil — a caller that wants the
+  absent-key default-realm reduction reduces through `non-default-realm` FIRST
+  (the two-layer split the recorder documents: `start` is the low-level
+  stamper; `start-recording!` reduces through the predicate before calling it).
+
+  `k` defaults to `realm-stamp-key` (`:rf.realm/id`, the recording-stamp key);
+  the replay-target path passes `:realm` (the address-map key). The SAME
+  nil-guarded assoc, two target keys."
+  ([m realm-id] (assoc-realm m realm-stamp-key realm-id))
+  ([m k realm-id]
+   (cond-> m
+     (some? realm-id) (assoc k realm-id))))
+
+(defn stamp-realm
+  "Pure: the COMBINED absent-key stamp — reduce a live `realm-id` (what
+  `rf/frame-realm` returned) through `non-default-realm`, then `assoc-realm`
+  the result under `k`. So a nil / default realm leaves `m` untouched and any
+  constructed realm assocs its id. The one-call form play export + replay-target
+  reach for (they hold a raw live value, not a pre-reduced stamp); the recorder
+  keeps the split form because its `start` layer is deliberately low-level."
+  ([m realm-id] (stamp-realm m realm-stamp-key realm-id))
+  ([m k realm-id]
+   (assoc-realm m k (non-default-realm realm-id))))

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -132,6 +132,11 @@
             ;; this is the same framework-facade dependency, JVM + CLJS.
             [re-frame.core :as rf]
             [re-frame.story.config :as config]
+            ;; rf2-c6armm.12 — the absent-key realm-stamp decision + reserved
+            ;; `:rf.realm/id` key live here, shared by recorder / play-export /
+            ;; replay-target so the "stamp only a non-default realm" rule is ONE
+            ;; place, not three repeated inline predicates.
+            [re-frame.story.realm :as story-realm]
             [re-frame.story.predicates :as pred]
             [re-frame.story.review-dialog :as review-dialog]
             ;; rf2-qwm0a — listener surface lives in
@@ -205,33 +210,24 @@
 ;; frame.
 ;; ---------------------------------------------------------------------------
 
+;; The absent-key decision + the reserved stamp key live in the shared Story
+;; realm util (`re-frame.story.realm`, rf2-c6armm.12) so recorder / play-export /
+;; replay-target make the SAME decision in ONE place. The recorder re-exports
+;; the names its public surface + tests already reference.
+
 (def ^:const realm-stamp-key
   "The reserved app-value key a recording stamps its target frame's runtime
-  realm under (EP-0013). Matches the framework's reserved `:rf.realm/id`
-  spelling (Spec-Schemas §`:rf/realm`) so a stamped recording reads the way
-  the realm-targeted query forms (`rf/registrations {:realm …}`) spell it."
-  :rf.realm/id)
+  realm under (EP-0013) — `:rf.realm/id`. Re-export of
+  `re-frame.story.realm/realm-stamp-key`."
+  story-realm/realm-stamp-key)
 
-(defn realm-stamp
+(def realm-stamp
   "Return the realm id to STAMP on a recording whose target frame reports
   `frame-realm-id` (the value `rf/frame-realm` returned), or nil when nothing
-  should be stamped. Pure data → data.
-
-  The absent-key rule (EP-0013 disposition): a recording stamps `:rf.realm/id`
-  ONLY where the frame is in a NON-default realm. Returns nil for:
-
-    - `nil` — an unknown / destroyed frame (`rf/frame-realm` returns nil), or
-              no realm resolvable.
-    - `re-frame.realm/default-realm-id` (`:rf.realm/default`) — a single-realm
-              / default-realm frame. Absence IS the default, so we stamp
-              nothing and the recording replays unchanged (zero ceremony).
-
-  Returns the realm id verbatim for any other (constructed) realm so replay
-  can verify it targets the same realm the recording was captured in."
-  [frame-realm-id]
-  (when (and (some? frame-realm-id)
-             (not= frame-realm-id :rf.realm/default))
-    frame-realm-id))
+  should be stamped — the EP-0013 absent-key rule (nil / default-realm → nil;
+  any constructed realm → its id verbatim). Re-export of
+  `re-frame.story.realm/non-default-realm`."
+  story-realm/non-default-realm)
 
 (defn- frame-realm-stamp
   "Impure: read the live runtime realm `variant-id`'s frame lives in (via
@@ -245,14 +241,14 @@
          (catch #?(:clj Throwable :cljs :default) _ nil))))
 
 (defn assoc-realm
-  "Pure: stamp `realm-id` onto recorder `state` under `realm-stamp-key`, or
-  leave `state` UNTOUCHED when `realm-id` is nil (the default-realm absent-key
-  rule — EP-0013). The single helper both `start` and the impure
-  `start-recording!` thread through so the absent-key invariant lives in one
-  place: a default-realm recording's state map carries no `:rf.realm/id` key."
+  "Pure LOW-LEVEL stamper: assoc `realm-id` onto recorder `state` under
+  `realm-stamp-key`, or leave `state` UNTOUCHED when `realm-id` is nil. This is
+  the low-level layer (`start` calls it); `start-recording!` reduces the live
+  realm through `realm-stamp` (the absent-key predicate) BEFORE calling it, so
+  the default-realm reduction lives there, not here. Delegates to
+  `re-frame.story.realm/assoc-realm`."
   [state realm-id]
-  (cond-> state
-    (some? realm-id) (assoc realm-stamp-key realm-id)))
+  (story-realm/assoc-realm state realm-id))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: dispatch-only code-gen — `(reg-variant ... :script {...})` snippet

--- a/tools/story/src/re_frame/story/recorder/play_export.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export.cljc
@@ -74,6 +74,9 @@
   build the snippet text. JVM-testable end-to-end."
   (:require [clojure.string :as str]
             [re-frame.story.play.runner :as runner]
+            ;; rf2-c6armm.12 — the shared absent-key realm-stamp util (the
+            ;; "stamp only a non-default realm under :rf.realm/id" rule).
+            [re-frame.story.realm       :as story-realm]
             [re-frame.story.predicates  :as pred]))
 
 ;; ---------------------------------------------------------------------------
@@ -390,15 +393,14 @@
                           [])
          script         (vec (concat dispatch-steps assert-steps))
          base           {:script    script
-                         :auto-run? (boolean auto-run?)}
-         ;; rf2-0io9uq (EP-0013): carry the realm stamp WHERE present, by the
-         ;; absent-key rule. A nil / default realm assocs nothing (zero
-         ;; ceremony), so a single-realm body round-trips unchanged.
-         realm-stamp    (when (and (some? realm) (not= realm :rf.realm/default))
-                          realm)]
-     (cond-> base
-       (and (string? name) (seq name)) (assoc :name name)
-       (some? realm-stamp)             (assoc :rf.realm/id realm-stamp)))))
+                         :auto-run? (boolean auto-run?)}]
+     ;; rf2-0io9uq (EP-0013): carry the realm stamp WHERE present, by the
+     ;; absent-key rule (rf2-c6armm.12: through the shared Story realm util — a
+     ;; nil / default realm assocs nothing, so a single-realm body round-trips
+     ;; unchanged; any constructed realm stamps `:rf.realm/id`).
+     (-> (cond-> base
+           (and (string? name) (seq name)) (assoc :name name))
+         (story-realm/stamp-realm realm)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: render the play-script map as EDN

--- a/tools/story/test/re_frame/story/realm_test.cljc
+++ b/tools/story/test/re_frame/story/realm_test.cljc
@@ -1,0 +1,67 @@
+(ns re-frame.story.realm-test
+  "Pure unit tests for the shared Story realm-stamp util (rf2-c6armm.12).
+
+  `re-frame.story.realm` is the ONE place the EP-0013 absent-key rule (\"carry a
+  realm key ONLY for a non-default realm\") lives, so recorder / play-export /
+  replay-target make the SAME decision in one place. These pin the predicate +
+  the keyed assoc around the two cases the rule turns on: DEFAULT-realm omission
+  and NON-default-realm emission. Pure data → data; CLJC (JVM + node-test)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [re-frame.realm :as realm]
+            [re-frame.story.realm :as story-realm]))
+
+;; ---- the predicate: non-default-realm ------------------------------------
+
+(deftest non-default-realm-drops-nil-and-default
+  (testing "non-default-realm carries NOTHING for nil (unknown / destroyed
+            frame) or the default realm — absence IS the default (the
+            absent-key rule)"
+    (is (nil? (story-realm/non-default-realm nil))
+        "a nil realm carries nothing")
+    (is (nil? (story-realm/non-default-realm realm/default-realm-id))
+        "the default realm carries nothing")
+    (is (nil? (story-realm/non-default-realm :rf.realm/default))
+        "the literal default id carries nothing"))
+  (testing "a constructed (non-default) realm is carried verbatim"
+    (is (= :tenant/acme (story-realm/non-default-realm :tenant/acme))
+        "a constructed realm id rides through unchanged")))
+
+;; ---- the keyed assoc: assoc-realm (low-level, nil-guard only) -------------
+
+(deftest assoc-realm-is-the-low-level-nil-guard-stamper
+  (testing "assoc-realm guards ONLY nil — it assocs any non-nil value verbatim
+            (the default reduction is the caller's job, via non-default-realm)"
+    (is (= {:frame :v} (story-realm/assoc-realm {:frame :v} nil))
+        "a nil value leaves the map untouched")
+    (is (= {:frame :v :rf.realm/id :tenant/acme}
+           (story-realm/assoc-realm {:frame :v} :tenant/acme))
+        "a non-nil value stamps under the default :rf.realm/id key")
+    (is (= {:frame :v :realm :tenant/acme}
+           (story-realm/assoc-realm {:frame :v} :realm :tenant/acme))
+        "a caller-supplied key (the replay-target :realm address key) is honoured")
+    ;; The deliberate low-level semantics the recorder's `start` layer relies on:
+    ;; a RAW default is assoc'd verbatim here (start-recording! reduces first).
+    (is (= {:rf.realm/id :rf.realm/default}
+           (story-realm/assoc-realm {} realm/default-realm-id))
+        "a raw default is stamped verbatim at the low level (no reduction here)")))
+
+;; ---- the combined form: stamp-realm (reduce + assoc) ----------------------
+
+(deftest stamp-realm-applies-the-absent-key-rule-end-to-end
+  (testing "default-realm OMISSION: a nil / default realm carries no key —
+            the map round-trips unchanged (zero ceremony)"
+    (is (= {:frame :v} (story-realm/stamp-realm {:frame :v} nil))
+        "nil realm → no :rf.realm/id key")
+    (is (= {:frame :v} (story-realm/stamp-realm {:frame :v} realm/default-realm-id))
+        "default realm → no :rf.realm/id key")
+    (is (not (contains? (story-realm/stamp-realm {:frame :v} :rf.realm/default)
+                        :rf.realm/id))
+        "the absent-key invariant: default-realm maps never grow a realm key"))
+  (testing "non-default-realm EMISSION: a constructed realm stamps its id"
+    (is (= {:frame :v :rf.realm/id :tenant/acme}
+           (story-realm/stamp-realm {:frame :v} :tenant/acme))
+        "a constructed realm stamps :rf.realm/id (the recording-stamp key)")
+    (is (= {:frame :v :realm :tenant/acme}
+           (story-realm/stamp-realm {:frame :v} :realm :tenant/acme))
+        "the replay-target form stamps under :realm (the address-map key)")))


### PR DESCRIPTION
Two EP-0013 round-2 review tails on disjoint code/test surfaces (one worker, two commits). EP-0013 is `final`; the realm-core impl (c6armm.7/.8) just merged.

## rf2-c6armm.9 (P3 test-coverage) — two findings

1. **Deferred-kind removal matrix.** `reinstall!`'s removal-refusal guard was only exercised for `:mutation`. Parameterized `reinstall-removing-a-sugar-registered-step8-kind-refuses-loudly` over the FULL step-8 deferred-kind set (`:route :flow :resource :mutation :resource-scope :view :head :error-projector`, per `core.cljc:1753`). For each kind: seed a sugar-like registrar slot, `reinstall!` an app omitting it, assert `:rf.error/unsupported-descriptor-kind`, the blocking `[kind id]` in `:removed`, original-slot survival, and no new descriptor seated. Closes the drift window where the removal filter could silently unregister routes/resources/flows/views while a `:mutation`-only test still passed.

2. **MCP realm-pin reset coverage.** The `:reset-operating-frame/clears-pin` conformance fixture only required `select-frame! nil` and asserted the frame triple. It now also requires `select-realm! nil` in the emitted form, returns a post-reset map carrying the realm fields, and asserts `:selected-realm nil`, `:operating-realm :rf.realm/default`, and the `:realms`/`:frame-realms` keys — catching a regression that left a stale operating realm after reset.

## rf2-c6armm.12 (P4 best-practice) — Story realm-stamp util

The EP-0013 "carry a realm key ONLY for a non-default realm" rule was a helper in `re-frame.story.recorder`, but the literal `(and (some? realm) (not= realm :rf.realm/default))` predicate was repeated inline at `play_export.cljc:397` and `runner_events.cljc:281`. Moved the decision into a small shared util `re-frame.story.realm` (`realm-stamp-key`, `non-default-realm`, low-level `assoc-realm`, combined `stamp-realm`). The recorder re-exports its public/tested names (surface unchanged); play-export and replay-target call `stamp-realm` — under `:rf.realm/id` (recording stamp) and `:realm` (address-map key) respectively. Added a focused regression (`realm_test.cljc`) pinning default-realm omission + non-default-realm emission across both keys.

## Quality gates

- core `clojure -M:test` — 1399 tests, 6233 assertions, 0 failures.
- pair-mcp `npm test` (shadow-cljs server-test) — 1048 tests, 3198 assertions, 0 failures.
- story `clojure -M:test` — 1686 tests, 6241 assertions, 0 failures.
- `npm run test:cljs` (consolidated node-test, covers core CLJS + story compile) — 6932 tests, 28284 assertions, 0 failures.

Surfaces touched: `implementation/core/test/`, the pair-mcp RESET conformance fixture, `tools/story/`. No docs/spec/skills. Disjoint from the in-flight pair-mcp `handler_meta_test`/`orient_test` PR.