### PR TITLE
fix(adapter): dispose clears frame sub-cache without live frame-context (rf2-x0e5kf)

### DIFF
--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_test.cljc
@@ -246,9 +246,14 @@
     (rf/reg-sub ::n (fn [db _] (:n db)))
     (try
       ;; Seed app-db = {:n 1} and materialise a sub-cache entry by subscribing.
-      ;; Use the explicit-frame `subs/subscribe` (the macro resolves a render-
-      ;; time frame context headless tests do not establish).
-      (rf/dispatch-sync [::seed 1])
+      ;; Both the dispatch and the subscribe pin `:rf/default` explicitly: per
+      ;; EP-0002 there is no ambient `:rf/default` floor, so the macro forms
+      ;; (`rf/dispatch-sync` / the `subscribe` macro) would resolve a render-
+      ;; time frame context this headless test does not establish and raise
+      ;; `:rf.error/no-frame-context`. Use the explicit-frame fn form
+      ;; `rf/dispatch-sync*` (and `subs/subscribe` below) which carry the
+      ;; target frame directly.
+      (rf/dispatch-sync* [::seed 1] {:frame :rf/default})
       (let [r (subs/subscribe :rf/default [::n])]
         (is (= 1 @r) "sub reads the seeded value")
         (is (contains? (default-sub-cache-keys) [::n])
@@ -271,7 +276,7 @@
       ;; pre-fix slot had survived, the re-subscribe would have aliased the old
       ;; reaction and the isolation guarantee would be broken.
       (substrate-adapter/install-adapter! test-react/adapter)
-      (rf/dispatch-sync [::seed 99])
+      (rf/dispatch-sync* [::seed 99] {:frame :rf/default})
       (let [r2 (subs/subscribe :rf/default [::n])]
         (is (= 99 @r2)
             "re-subscribe after reinstall recomputed from the CURRENT app-db")


### PR DESCRIPTION
## Summary

Fixes **rf2-x0e5kf** (P2 BUG) — the test-react adapter JVM sweep test
`dispose-adapter-clears-frame-sub-cache-no-stale-cross-lifecycle-reads`
failed with `:rf.error/no-frame-context` on clean `origin/main`.

## Root cause

The failure was **not** in the dispose path — it fired at the test's own
seed `(rf/dispatch-sync [::seed 1])` **before** dispose ran (stack:
`router/build-envelope` → `frame/require-current-frame!` →
`frame.cljc:359` throw).

The test's `install-test-react!` fixture does not bind
`frame/*current-frame*` (unlike the CLJS sibling's
`make-reset-runtime-fixture`, which does — that is why the CLJS-only
companion test passes). Per **EP-0002** there is no ambient `:rf/default`
floor, so the bare `rf/dispatch-sync` macro found no established scope and
`build-envelope` emitted + threw `:rf.error/no-frame-context`. The same-ns
`subs/subscribe :rf/default [...]` calls already pin the frame explicitly
(the test's own comment notes headless tests don't establish render-time
context); the two `dispatch-sync` calls were the lone ambient-resolution
holdouts. The bug landed with `bd492e37c` (rf2-ghfkkk) and surfaced once
the EP-0013/EP-0002 frame-context work removed the `:rf/default` floor.

## The fix seam

The dispose path itself is already teardown-safe and needed **no** change:
`re-frame.substrate.adapter/dispose-adapter!` → test-react
`dispose-adapter!` → `re-frame.subs.cache/clear-all-frame-sub-caches!` →
the 1-arity `clear-sub-cache!` over `frame/frame-ids`. That walk targets
explicit, non-destroyed frame-ids and emits `:rf.sub/dispose` with explicit
frame-ids — it never resolves ambient frame-context, so it does not depend
on context the teardown invalidated (mirrors the EP-0013 `destroy-frame!`
discipline of capturing identity before teardown).

Fix is test-side: switch both seed dispatches to the explicit-frame fn form
`rf/dispatch-sync* [::seed v] {:frame :rf/default}`, matching the
explicit-frame subscribe discipline already in the test and the sibling
CLJS test's multi-frame case. The failing test is retained as the
regression.

## Quality gates

**test-react adapter JVM sweep** (`clojure -M:test` in
`implementation/adapters/test-react/`) — the named failing test:

- BEFORE: `Ran 24 tests containing 78 assertions. 0 failures, 1 errors.`
  — `ERROR in (dispose-adapter-clears-frame-sub-cache-no-stale-cross-lifecycle-reads) (frame.cljc:359)` / `:rf.error/no-frame-context`
- AFTER: `Ran 24 tests containing 84 assertions. 0 failures, 0 errors.`
  (the test now completes all 6 of its assertions)

**core `clojure -M:test`** (`implementation/core/`):
- AFTER: `Ran 1400 tests containing 6197 assertions. 0 failures, 0 errors.`

**`npm run test:cljs`** (`implementation/`):
- AFTER: `Ran 6952 tests containing 28351 assertions. 0 failures, 0 errors.`

Closes rf2-x0e5kf.
