### PR TITLE
feat(xray): fill Module-view provenance from rf/installed-app (rf2-at0oen)

### DIFF
--- a/tools/xray/spec/026-Module-View-Panel.md
+++ b/tools/xray/spec/026-Module-View-Panel.md
@@ -4,10 +4,13 @@
 > the **(realm, frame) address space** of the running process and the
 > **disposition-6 demand-trigger** for per-module descriptor provenance.
 
-Status: **shipped (scaffold)** — rf2-wtg9z4. The realm/frame address space
-renders from public seams today; the per-module provenance section is
-scaffolded behind an awaiting-seam caption until a public
-realm→installed-app read surface graduates (follow-up bead rf2-imquoq).
+Status: **shipped** — rf2-wtg9z4 (address space) + rf2-at0oen (per-module
+provenance). The realm/frame address space renders from public seams, and the
+MODULES section reads real per-module provenance off each realm's installed app
+value via the public `rf/installed-app` read seam (EP-0013 disposition 6,
+PR #4061). A process running entirely on the `reg-*` sugar / load-order path
+carries no constructed app value, so its MODULES section shows the honest
+no-module caption.
 
 ## §1 Purpose & scope
 
@@ -40,10 +43,16 @@ Two stacked sections (the shared `theme/section` rhythm):
 │     frames: :app/main  :app/cart                                │
 │ ─────────────────────────────────────────────────────────────  │
 │ ▼ MODULES                                                       │
-│   Per-module ownership, capability requirements, classification │
-│   and descriptor provenance await a public realm→installed-app  │
-│   read seam (EP-0013 disposition 6 graduation).                 │
+│   :shop/cart                                                    │
+│     owns      :app-db [:cart]   :routes :shop/checkout          │
+│     requires  :rf.capability/http                               │
+│     registers 2 descriptors (event · sub)                       │
+│     source    shop.cart:12                                      │
 ```
+
+(In a single-realm process the modules list with the realm dimension
+implicit; with more than one realm each realm's modules sit under an uppercase
+realm header — zero-ceremony.)
 
 ## §3 REALMS section — the (realm, frame) address space
 
@@ -68,33 +77,46 @@ realm (`project-realm-row`), and classifies single vs multi-realm
   absent from `realm-ids` still gets a row (defensive); a nil realm buckets
   to `:rf.realm/default` (absence = default realm, the EP-0013 D1 rule).
 
-## §4 MODULES section — the disposition-6 demand trigger (scaffolded)
+## §4 MODULES section — the disposition-6 demand trigger (shipped)
 
 The per-module facts EP-0013 disposition 6 rules public — **ownership**
-(`:owns`), **capability requirements** (`:requires`), **EP-0015
-classification** metadata — plus **descriptor provenance** (which module
-owns a handler / sub / path; source coords).
+(`:owns`), **capability requirements** (`:requires`), and **descriptor
+provenance** (which module owns which descriptors, owner-stamped; source
+coords) — read off each realm's installed app value via the public
+`rf/installed-app` read seam (graduated by rf2-imquoq → rf2-at0oen, PR #4061).
 
-**These cannot be read from a running process today**, and this slice does
-**not** expand core scope to invent the seam:
+The seam yields a running realm's installed app value **without installing
+anything**:
 
-- the per-module facts live on a **constructed** app value's `:modules` map
-  (`rf/app` / `rf/module`) — they do not exist on a registrar projection;
-- a **running realm exposes no public read of its installed app value**:
-  `re-frame.realm/installed-app` is internal, and the internal `app-value`
-  projection over a realm's registrar carries no module structure;
-- the public inspectors `rf/app-registrations` / `rf/app-owns` /
-  `rf/app-requires` operate on an app value you **already hold** — there is
-  no public seam to obtain a running realm's app value to feed them.
+- a realm seated via `rf/install!` returns the **rich constructed value**
+  whose `:modules` map (`{module-id module}`) carries each module's `:owns` /
+  `:requires` and its `:owner`-stamped `:registrations`;
+- a realm seated only through the `reg-*` sugar / load-order path returns the
+  registrar **projection** — registrations by kind, but **no `:modules`**
+  (load-order registrations declare no module). That is the honest
+  no-provenance case: the MODULES section renders the calm **no-module
+  caption** (`module_view_helpers/no-modules-caption`), naming the
+  `rf/app` / `rf/module` / `rf/install!` remedy, rather than fabricating rows.
 
-So the demand trigger **files a follow-up bead** (rf2-imquoq) for the
-public realm→installed-app provenance read surface (the graduation EP-0013
-disposition 6 reserves), and the MODULES section renders the calm
-**awaiting-seam caption** (`module_view_helpers/awaiting-provenance-caption`)
-until it lands. The realm-row shape already carries the `:modules` /
-`:owns` / `:requires` / `:classification` slots (defaulted nil/empty) and
-`:provenance-available?` (false), so the fill-in is a **no-reshape change**
-when the seam graduates.
+The pure projection (`module_view_helpers`):
+
+- `project-module-row` — one module value → `{:module-id :owns :requires
+  :registration-kinds :registration-count :source}`;
+- `project-app-modules` — an app value → its sorted module rows + union
+  `:requires` (nil `:modules` when the app carries none);
+- `project-realm-row` (3-arity) — fills a realm's `:modules` / `:requires`
+  from `(rf/installed-app realm)`;
+- `project-module-view` (4-arity) — takes an `installed-app-of` resolver
+  (`rf/installed-app`) and sets `:provenance-available?` **true**.
+
+**EP-0015 classification is NOT a per-module fact.** Durable data
+classification is **frame-owned** — declared on `reg-frame` / `make-frame` and
+installed by `re-frame.frame-classification` (Spec 015 §Frame-owned durable
+classification) — not carried on a module value (`rf/module` has no
+`:classification` slot). So the MODULES section surfaces ownership, capability
+requirements, and descriptor provenance; the classification dimension lives on
+the frame side, not here. The realm-row keeps a reserved `:classification` slot
+(defaulted nil) for shape stability, but it is not populated from `:modules`.
 
 ## §5 Tab registration
 
@@ -113,21 +135,29 @@ Cmd-K palette picks it up automatically (the palette reads
 ## §6 Data sources & privacy
 
 - `:rf.xray/module-view` — the view composite; reads `rf/realm-ids` ·
-  `rf/frame-ids` · `rf/frame-realm` at recompute time and projects via the
-  pure helper. **Read-only** — enumerating realms/frames pins nothing and
-  dispatches nothing.
-- The surface carries realm/frame **ids only** (keywords), no app-db values
-  — there is no data egress concern in this slice. When the provenance seam
-  graduates, the off-box egress posture (the
-  [`025`](025-Derivation-Graph-Panel.md) §egress redaction pattern) applies
-  to any value-bearing module metadata.
+  `rf/frame-ids` · `rf/frame-realm` · `rf/installed-app` at recompute time and
+  projects via the pure helper. **Read-only** — enumerating realms/frames and
+  reading installed app values pins nothing and dispatches nothing
+  (`rf/installed-app` is a *static* read of the install-time value, not a
+  routing path).
+- The surface carries realm/frame/module **ids and declarations** — realm ids,
+  frame ids, module ids, `:owns` paths/routes, `:requires` capability keywords,
+  registry kinds, and source coordinates (ns/line). These are **structural
+  descriptors**, not app-db values. No handler values or app-db data egress
+  through this surface. (Should a future slice surface value-bearing module
+  metadata, the off-box egress posture — the
+  [`025`](025-Derivation-Graph-Panel.md) §egress redaction pattern — would
+  apply to it.)
 
 ## §7 Implementation
 
-- `panels/module_view.cljs` — the panel view + `install!` (sub + tab).
+- `panels/module_view.cljs` — the panel view + `install!` (sub + tab); the sub
+  reads `rf/installed-app` per realm.
 - `panels/module_view_helpers.cljc` — the pure `data → data` projection
-  (`realm-frames` · `project-realm-row` · `project-module-view` ·
-  `awaiting-provenance-caption` · `realm-summary-line`); JVM-testable.
-- Tests: `panels/module_view_helpers_cljs_test.cljc` (the projection
-  shape + the zero-ceremony / multi-realm classification + the empty /
-  stale-frame edge cases + the awaiting-seam caption).
+  (`realm-frames` · `project-module-row` · `project-app-modules` ·
+  `project-realm-row` · `project-module-view` · `any-modules?` ·
+  `no-modules-caption` · `realm-summary-line`); JVM-testable.
+- Tests: `panels/module_view_helpers_cljs_test.cljc` (the address-space
+  projection + the zero-ceremony / multi-realm classification + the empty /
+  stale-frame edge cases + the module-row shape + the seam-fed
+  `project-module-view` + the no-modules / `any-modules?` empty state).

--- a/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
@@ -17,32 +17,34 @@
       │     frames: :app/main  :app/cart                                │
       │ ─────────────────────────────────────────────────────────────  │
       │ MODULES                                                         │
-      │   Per-module ownership, capability requirements, classification │
-      │   and descriptor provenance await a public realm→installed-app  │
-      │   read seam (EP-0013 disposition 6 graduation).                 │
+      │   :shop/cart                                                    │
+      │     owns      :app-db [:cart]                                   │
+      │     requires  :rf.capability/http                               │
+      │     registers 1 event · 1 sub                                   │
 
-  ## The provenance graduation (why MODULES is scaffolded)
+  ## The provenance graduation (rf2-at0oen — the seam SHIPPED)
 
-  EP-0013 disposition 6 keeps per-module descriptor PROVENANCE / metadata
-  (`:owns` · `:requires` · EP-0015 classification · source coords)
-  INTERNAL until a Module-view demands it — and this is that view. But
-  reading those facts from a RUNNING process needs a CORE seam that has
-  not shipped: there is no public read of a realm's installed app value,
-  and the internal projection over a realm's registrar carries no module
-  structure at all (the per-module facts exist only on a CONSTRUCTED app
-  value — `rf/app` / `rf/module`). Per the rf2-wtg9z4 brief, this slice
-  does NOT silently expand core scope to invent the seam — a follow-up
-  bead is filed for the public realm→installed-app provenance read
-  surface, and the MODULES section renders the calm awaiting-seam caption
-  until it graduates. The row shapes already carry the
-  `:owns` / `:requires` / `:classification` slots so the fill-in is a
-  no-reshape change.
+  EP-0013 disposition 6 kept per-module descriptor PROVENANCE / metadata
+  (`:owns` · `:requires` · the owner-stamped descriptors) INTERNAL until a
+  Module-view demanded it — and this is that view. The follow-up beads
+  (rf2-imquoq → rf2-at0oen) shipped the public realm→installed-app READ
+  seam `rf/installed-app` (PR #4061): `(rf/installed-app realm)` returns a
+  running realm's installed app value WITHOUT installing anything. A realm
+  seated via `rf/install!` returns the RICH constructed value whose
+  `:modules` map carries each module's `:owns` / `:requires` and its
+  owner-stamped descriptors; a realm on the `reg-*` sugar / load-order path
+  has no `:modules` (the registrar projection declares no module), so the
+  MODULES section renders the honest no-module caption rather than
+  fabricated rows. (EP-0015 classification is FRAME-owned, declared on
+  `reg-frame` — not a per-module fact, so it is not surfaced here.)
 
   ## Public seams used (all genuinely public today)
 
-    - `rf/realm-ids`  — the installed realm ids (EP-0013, PR #4038);
-    - `rf/frame-ids`  — the live frame ids;
-    - `rf/frame-realm`— a frame's realm (the frame-side address half).
+    - `rf/realm-ids`     — the installed realm ids (EP-0013, PR #4038);
+    - `rf/frame-ids`     — the live frame ids;
+    - `rf/frame-realm`   — a frame's realm (the frame-side address half);
+    - `rf/installed-app` — a realm's installed app value, for the per-module
+                           provenance (EP-0013 disposition 6, PR #4061).
 
   ## Zero-ceremony (single-realm unchanged)
 
@@ -109,6 +111,81 @@
    :font-size   "12px"
    :line-height 1.5})
 
+(def ^:private module-id-style
+  {:color       (:accent tokens)
+   :font-weight 600
+   :font-family mono-stack
+   :font-size   "12px"
+   :padding     "4px 0 1px 0"})
+
+(def ^:private module-fact-style
+  {:color       (:text-secondary tokens)
+   :font-family mono-stack
+   :font-size   "11px"
+   :padding     "0 0 0 18px"})
+
+(def ^:private module-fact-label-style
+  {:color (:text-tertiary tokens)})
+
+(def ^:private module-realm-header-style
+  {:color          (:text-tertiary tokens)
+   :font-family    sans-stack
+   :font-size      "11px"
+   :letter-spacing "0.4px"
+   :text-transform "uppercase"
+   :padding        "6px 0 2px 0"})
+
+;; ---- module row ----------------------------------------------------------
+
+(defn- owns-summary
+  "A compact one-line rendering of a module's `:owns` declarations —
+  `:app-db [:cart]  :routes :shop/checkout`. Empty when the module owns
+  nothing. Pure string."
+  [owns]
+  (->> owns
+       (sort-by (comp str key))
+       (keep (fn [[kind paths]]
+               (when (seq paths)
+                 (str kind " " (str/join " " (map pr-str paths))))))
+       (str/join "   ")))
+
+(defn- registers-summary
+  "A compact rendering of the registry kinds a module owns —
+  `1 event · 1 sub`. Pure string."
+  [module-row]
+  (let [{:keys [registration-kinds registration-count]} module-row]
+    (if (seq registration-kinds)
+      (str registration-count " descriptor"
+           (when (not= 1 registration-count) "s")
+           " (" (str/join " · " (map name registration-kinds)) ")")
+      "no registrations")))
+
+(defn- module-row
+  "Render one module's provenance: its id + owned surfaces + capability
+  requirements + the descriptor kinds it registers. Pure hiccup."
+  [{:keys [module-id owns requires source] :as m-row}]
+  (let [mid-name (str module-id)]
+    [:div {:data-testid (str "rf-xray-module-view-module-" mid-name)}
+     [:div {:data-testid (str "rf-xray-module-view-module-" mid-name "-id")
+            :style       module-id-style}
+      mid-name]
+     (when (seq owns)
+       [:div {:style module-fact-style}
+        [:span {:style module-fact-label-style} "owns      "]
+        (owns-summary owns)])
+     (when (seq requires)
+       [:div {:style module-fact-style}
+        [:span {:style module-fact-label-style} "requires  "]
+        (str/join "  " (sort-by str requires))])
+     [:div {:style module-fact-style}
+      [:span {:style module-fact-label-style} "registers "]
+      (registers-summary m-row)]
+     (when source
+       [:div {:style module-fact-style}
+        [:span {:style module-fact-label-style} "source    "]
+        (str (:ns source)
+             (when (:line source) (str ":" (:line source))))])]))
+
 ;; ---- realm row -----------------------------------------------------------
 
 (defn- realm-row
@@ -130,15 +207,45 @@
 
 ;; ---- public view ---------------------------------------------------------
 
+(defn- modules-section-body
+  "The MODULES section body — every realm's modules, grouped by realm only
+  when the process is multi-realm (zero-ceremony: a single-realm process
+  lists its modules with the realm dimension implicit). When NO realm carries
+  module provenance (a load-order / sugar-only process), renders the calm
+  no-module caption rather than an empty list. Pure hiccup."
+  [realms multi-realm?]
+  (if (h/any-modules? realms)
+    (into [:div {:data-testid "rf-xray-module-view-modules-list"}]
+          (for [{:keys [realm modules] :as _r} realms
+                :when (seq modules)]
+            (with-meta
+              [:div {:data-testid (str "rf-xray-module-view-modules-realm-"
+                                       (name realm))}
+               ;; Spell the realm header only when more than one realm exists
+               ;; (zero-ceremony — single-realm keeps the realm implicit).
+               (when multi-realm?
+                 [:div {:style module-realm-header-style} (str realm)])
+               (into [:div]
+                     (for [m modules]
+                       (with-meta (module-row m)
+                         {:key (str (:module-id m))})))]
+              {:key (str realm)})))
+    [:div {:data-testid "rf-xray-module-view-modules-empty"
+           :style       awaiting-caption-style}
+     h/no-modules-caption]))
+
 (rf/reg-view Panel
   "The Module-view tab's root — the (realm, frame) address space of the
-  running process (EP-0013 disposition 3 · rf2-wtg9z4). Subscribes to
-  `:rf.xray/module-view` (the projected address space) and renders a
-  REALMS section (every installed realm + its frames) followed by a
-  MODULES section that, until the per-module provenance seam graduates
-  (rf2-wtg9z4 follow-up rf2-imquoq), reads the calm awaiting-seam caption."
+  running process (EP-0013 disposition 3) PLUS the per-module provenance read
+  off each realm's installed app value (EP-0013 disposition 6 · rf2-at0oen).
+  Subscribes to `:rf.xray/module-view` and renders a REALMS section (every
+  installed realm + its frames) followed by a MODULES section listing each
+  realm's modules with their ownership / capability / descriptor provenance.
+  A process running entirely on the `reg-*` sugar / load-order path has no
+  constructed app value, so the MODULES section shows the honest no-module
+  caption."
   []
-  (let [{:keys [realms provenance-available?] :as _data}
+  (let [{:keys [realms multi-realm?] :as _data}
         @(rf/subscribe [:rf.xray/module-view])]
     [:section {:data-testid "rf-xray-module-view"
                :style       panel-root-style}
@@ -151,19 +258,13 @@
         (into [:div {:data-testid "rf-xray-module-view-realms-list"}]
               (for [r realms]
                 (with-meta (realm-row r) {:key (str (:realm r))}))))
-      ;; MODULES — the per-module ownership / capability / classification /
-      ;; provenance facts. Scaffolded: until the core realm→installed-app
-      ;; read seam graduates (rf2-wtg9z4 follow-up rf2-imquoq) this reads the calm
-      ;; awaiting-seam caption rather than fabricating data.
+      ;; MODULES — the per-module ownership / capability / descriptor
+      ;; provenance, read from each realm's installed app value via
+      ;; `rf/installed-app` (EP-0013 disposition 6, rf2-at0oen).
       (section/section-row
         {:label  "Modules"
          :testid "rf-xray-module-view-modules"}
-        (if provenance-available?
-          ;; rf2-wtg9z4 follow-up rf2-imquoq fills this in from the graduated seam.
-          [:div {:data-testid "rf-xray-module-view-modules-list"}]
-          [:div {:data-testid "rf-xray-module-view-modules-awaiting"
-                 :style       awaiting-caption-style}
-           h/awaiting-provenance-caption]))]]))
+        (modules-section-body realms multi-realm?))]]))
 
 ;; ---- registration entry --------------------------------------------------
 
@@ -172,11 +273,15 @@
   (rf2-wtg9z4). Registers the address-space composite + the Dynamic L4
   tab."
   []
-  ;; `:rf.xray/module-view` — the projected (realm, frame) address space.
+  ;; `:rf.xray/module-view` — the projected (realm, frame) address space PLUS
+  ;; the per-module provenance read off each realm's installed app value.
   ;; Reads the PUBLIC realm/frame seams (`rf/realm-ids` · `rf/frame-ids` ·
-  ;; `rf/frame-realm`) and projects via the pure
-  ;; `module-view-helpers/project-module-view`. Read-only — enumerating
-  ;; realms/frames pins nothing and dispatches nothing.
+  ;; `rf/frame-realm`) and the realm→installed-app read seam
+  ;; (`rf/installed-app`, EP-0013 disposition 6, PR #4061), and projects via
+  ;; the pure `module-view-helpers/project-module-view`. Read-only —
+  ;; enumerating realms/frames and reading installed app values pins nothing
+  ;; and dispatches nothing (`rf/installed-app` is a STATIC read of the
+  ;; install-time value, not a routing path).
   ;;
   ;; It does NOT compose off an `:rf.xray/*` app-db slot because the
   ;; address space is a process-global fact (realms + frames live in the
@@ -190,7 +295,8 @@
     (fn [_db _query]
       (h/project-module-view (rf/realm-ids)
                              (rf/frame-ids)
-                             frame/frame-realm)))
+                             frame/frame-realm
+                             rf/installed-app)))
 
   ;; Register the Dynamic Module-view tab with the internal L4 tab
   ;; registry. Order 9 — after the Derivation-Graph (order 8), keeping the

--- a/tools/xray/src/day8/re_frame2_xray/panels/module_view_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/module_view_helpers.cljc
@@ -7,57 +7,45 @@
   EP-0013 introduces *app values* (immutable descriptions of a program,
   composed from feature *modules*) and *runtime realms* (the containers a
   program is installed into). The Module-view is the disposition-6 NAMED
-  DEMAND TRIGGER: the view that would inspect, per module, the three
-  public descriptor facts EP-0013 disposition 6 rules —
+  DEMAND TRIGGER: the view that inspects, per module, the public
+  descriptor facts EP-0013 disposition 6 rules —
 
     - **ownership** (`:owns`) — the app-db paths / routes / resources a
       module declares it owns;
     - **capability requirements** (`:requires`) — the `:rf.capability/*`
       a module's install demands;
-    - **EP-0015 classification metadata** — the durable data
-      classification a module's surfaces carry;
 
-  plus, as the trigger itself, **descriptor provenance** (which module
-  owns a handler / sub / path; source coordinates).
+  plus, as the trigger itself, **descriptor provenance** (the registry
+  kinds and descriptor count each module owns, owner-stamped; source
+  coordinates). EP-0015 classification is FRAME-owned (declared on
+  `reg-frame`, not on a module), so it is NOT a per-module fact — the
+  classification dimension lives on the frame side, not in `:modules`.
 
-  ## The provenance graduation (why this slice is a SCAFFOLD)
+  ## The provenance graduation (rf2-at0oen — the seam SHIPPED)
 
-  EP-0013 keeps descriptor PROVENANCE / module metadata INTERNAL until a
-  Module-view demands it — and this is that view. But the graduation is a
-  CORE slice, not a tooling slice: the per-module facts above live on a
-  CONSTRUCTED app value's `:modules` map (`rf/app` / `rf/module`), and a
-  RUNNING realm exposes no public read of its installed app value.
+  EP-0013 kept descriptor PROVENANCE / module metadata INTERNAL until a
+  Module-view demanded it — and this is that view. The graduation was a
+  CORE slice: the per-module facts above live on a CONSTRUCTED app value's
+  `:modules` map (`rf/app` / `rf/module`), and a RUNNING realm exposed no
+  public read of its installed app value. The follow-up beads
+  (rf2-imquoq → rf2-at0oen) shipped the public read seam
+  `rf/installed-app` (PR #4061): the realm→installed-app READ that yields
+  a running realm's installed app value WITHOUT installing anything.
 
-    - `re-frame.realm/installed-app` is INTERNAL (no `rf/*` re-export);
-    - even the internal `app-value` PROJECTION over a realm's registrar
-      carries NO `:modules`, NO `:owns`, NO `:requires` (load-order
-      registrations have no module — those facts exist only on a
-      constructed app value);
-    - the public inspectors `rf/app-registrations` / `rf/app-owns` /
-      `rf/app-requires` operate on an app value you ALREADY HOLD — there
-      is no public seam to obtain a running realm's app value to feed
-      them.
+    - `(rf/installed-app realm)` returns the app value the realm runs;
+    - a realm seated via `rf/install!` returns the RICH constructed value —
+      its `:modules` map carries each module's `:owns` / `:requires` and
+      its `:owner`-stamped descriptors;
+    - a realm seated only through the `reg-*` sugar (load-order, no
+      `install!`) returns the registrar PROJECTION — registrations by kind,
+      but NO `:modules` (load-order registrations declare no module). The
+      MODULES section renders the honest no-module caption there, not
+      fabricated rows.
 
-  So the per-module provenance / ownership / capability / classification
-  inspection the bead names CANNOT be read from a running process today.
-  Per the rf2-wtg9z4 brief, the view does NOT silently expand core scope
-  to invent the seam — a follow-up bead is filed for the public
-  realm→installed-app provenance read surface, and THIS slice ships the
-  parts the genuinely-public seams support:
-
-    - the **realm / frame address space** — `rf/realm-ids` (the installed
-      realms) × `rf/frame-realm` (each frame's realm), the (realm, frame)
-      address EP-0013 disposition 3 documents;
-    - per realm, its **frames** and a per-realm capability surface WHEN a
-      constructed app value is available to the tooling (it is not, in a
-      pure load-order app — so the module section reads a calm
-      awaiting-core-seam caption rather than fabricating data).
-
-  When the core provenance seam graduates (the follow-up bead), the
-  module section fills in from it with no reshape here — the row shapes
-  below already carry the `:owns` / `:requires` / `:classification` /
-  `:provenance` slots, defaulted to nil/empty until the seam supplies
-  them.
+  This slice reads `(rf/installed-app realm)` per realm and projects its
+  `:modules` into the module rows below — no reshape from the scaffold: the
+  realm-row already carried the `:modules` / `:owns` / `:requires` slots,
+  now FILLED from the seam.
 
   ## Zero-ceremony (single-realm unchanged)
 
@@ -92,84 +80,175 @@
     {}
     frame-ids))
 
+(defn project-module-row
+  "Project one MODULE value (from `(rf/installed-app realm) :modules`) into the
+  Module-view's module-row shape:
+
+      {:module-id          <:rf.module/id>
+       :owns               {:app-db [[:cart] …] :routes […] …}  ;; the module's
+                                       ;; declared feature ownership (`:owns`)
+       :requires           #{:rf.capability/* …}  ;; its capability requirements
+       :registration-kinds [<kind> …]  ;; the registry kinds it registers under,
+                                        ;; sorted for stable render (provenance)
+       :registration-count <int>       ;; total descriptors the module carries
+       :source             {:ns … :file … :line … :column …}}  ;; or nil
+
+  The module value is the descriptor EP-0013 §Module Values pins
+  (`:rf.module/id` · `:owns` · `:requires` · `:registrations` (kind→id→
+  descriptor, each `:owner`-stamped) · optional `:source`). This row surfaces
+  the per-module PROVENANCE the disposition-6 demand trigger names: ownership,
+  capability requirements, and the kinds/count of the descriptors the module
+  owns. (EP-0015 classification is FRAME-owned — declared on `reg-frame`, not
+  on a module — so it is NOT a module-row fact; see §6 of the panel spec.)
+
+  Pure data → data; JVM-testable."
+  [module]
+  (let [registrations (:registrations module)
+        kinds         (vec (sort-by str (keys registrations)))]
+    {:module-id          (:rf.module/id module)
+     :owns               (get module :owns {})
+     :requires           (set (get module :requires #{}))
+     :registration-kinds kinds
+     :registration-count (reduce + 0 (map (comp count val) registrations))
+     :source             (:source module)}))
+
+(defn project-app-modules
+  "Project a realm's installed APP VALUE (from `rf/installed-app`) into the
+  Module-view's per-realm module rows. Returns
+
+      {:modules   [<module-row> …]      ;; sorted by module-id str, or nil when
+                                        ;; the app carries no `:modules`
+       :requires  #{:rf.capability/* …} ;; the app's union capability set}
+
+  An app value carries `:modules` (a `{module-id module}` map) ONLY when it was
+  CONSTRUCTED (`rf/app` / `rf/install!`); a realm seated through the `reg-*`
+  sugar (load-order, no `install!`) carries NO `:modules` — its installed app is
+  the registrar projection (EP-0013 disposition 6, the honest no-provenance
+  case). `nil` app (no seam value) is likewise module-less. `:modules` is nil
+  (not `[]`) in the no-provenance case so the panel can distinguish \"a
+  module-less load-order app\" from \"an app with zero modules\". Pure data →
+  data; JVM-testable."
+  [app]
+  (let [modules (:modules app)]
+    {:modules  (when (seq modules)
+                 (->> (vals modules)
+                      (sort-by (comp str :rf.module/id))
+                      (mapv project-module-row)))
+     :requires (set (get app :requires #{}))}))
+
 (defn project-realm-row
   "Project one realm into the Module-view's realm-row shape:
 
       {:realm          <realm-id>
        :frames         [<frame-id> …]   ;; sorted for stable render
        :frame-count    <int>
-       ;; provenance slots — AWAITING the core realm→installed-app seam
-       ;; (rf2-wtg9z4 follow-up rf2-imquoq). nil/empty until it graduates; the row
-       ;; shape already carries them so the fill-in is a no-reshape change.
-       :modules        nil
-       :requires       #{}
-       :owns           nil
-       :classification nil}
+       ;; per-module provenance — filled from `(rf/installed-app realm)`
+       ;; (EP-0013 disposition 6, rf2-at0oen). `:modules` is nil for a
+       ;; load-order (sugar-only / module-less) app — the honest
+       ;; no-provenance case; the realm renders its address row but no module
+       ;; rows.
+       :modules        [<module-row> …] | nil
+       :requires       #{:rf.capability/* …}  ;; the app's union requires
+       :owns           nil                    ;; reserved — ownership lives per
+                                              ;; module (`:modules … :owns`)
+       :classification nil}                   ;; reserved — EP-0015
+                                              ;; classification is frame-owned,
+                                              ;; not a module fact (see §6)
 
   `realm-id` is the realm; `frames` is the set of frame-ids in that realm
-  (from `realm-frames`). Pure data → data; JVM-testable."
-  [realm-id frames]
-  {:realm          realm-id
-   :frames         (vec (sort-by str frames))
-   :frame-count    (count frames)
-   :modules        nil
-   :requires       #{}
-   :owns           nil
-   :classification nil})
+  (from `realm-frames`); `app` is the realm's installed app value
+  (`rf/installed-app realm`), or nil. Pure data → data; JVM-testable."
+  ([realm-id frames] (project-realm-row realm-id frames nil))
+  ([realm-id frames app]
+   (let [{:keys [modules requires]} (project-app-modules app)]
+     {:realm          realm-id
+      :frames         (vec (sort-by str frames))
+      :frame-count    (count frames)
+      :modules        modules
+      :requires       requires
+      :owns           nil
+      :classification nil})))
 
 (defn project-module-view
   "Top-level projection — produce every slot the Module-view needs from
-  the (realm, frame) address space (EP-0013 disposition 3). Pure data →
-  data; JVM-testable.
+  the (realm, frame) address space (EP-0013 disposition 3) PLUS the
+  per-module provenance read off each realm's installed app value (EP-0013
+  disposition 6, rf2-at0oen). Pure data → data; JVM-testable.
 
   `realm-ids` is the set of installed realm ids (`rf/realm-ids`);
   `frame-ids` is the set/seq of live frame ids (`rf/frame-ids`);
-  `realm-of` resolves a frame's realm (`rf/frame-realm`).
+  `realm-of` resolves a frame's realm (`rf/frame-realm`);
+  `installed-app-of` resolves a realm's installed app value
+  (`rf/installed-app`) — a `realm-id → app-value` fn. Optional: the 3-arity
+  (no resolver) renders the address space with no module provenance, which
+  keeps the legacy address-only call site working.
 
   Returns:
 
-      {:realms        [{:realm … :frames … :frame-count … …} …]  ;; per realm,
-                                     ;; sorted by realm-id for stable render
+      {:realms        [{:realm … :frames … :modules … :requires … …} …]
+                                     ;; per realm, sorted by realm-id, each
+                                     ;; carrying its installed app's modules
        :realm-count   <int>
        :multi-realm?  <bool>        ;; >1 realm → the realm dimension is
                                     ;; foregrounded; single-realm renders
                                     ;; with the (realm) dimension implicit
-       :provenance-available? false ;; rf2-wtg9z4 — the per-module
-                                    ;; provenance seam has not graduated
-                                    ;; (no public realm→installed-app read);
-                                    ;; the view shows the awaiting-seam
-                                    ;; caption while this is false}
+       :provenance-available? true} ;; rf2-at0oen — the public
+                                    ;; realm→installed-app read seam
+                                    ;; (`rf/installed-app`) has graduated, so
+                                    ;; the MODULES section reads real module
+                                    ;; provenance. A realm whose installed app
+                                    ;; carries no `:modules` (a load-order /
+                                    ;; sugar-only app) renders no module rows —
+                                    ;; the honest no-provenance case, NOT the
+                                    ;; absent-seam caption.
 
   Every installed realm appears even when it holds no frames (a realm can
   exist with zero frames). Pure data → data."
-  [realm-ids frame-ids realm-of]
-  (let [by-realm (realm-frames frame-ids realm-of)
-        ;; Every installed realm, plus any realm a frame resolves into
-        ;; that somehow isn't in realm-ids (defensive — the two should
-        ;; agree, but a stale frame must never strand the view).
-        all-rids (into (set realm-ids) (keys by-realm))
-        realms   (->> all-rids
-                      (sort-by str)
-                      (mapv (fn [rid]
-                              (project-realm-row rid (get by-realm rid #{})))))]
-    {:realms                realms
-     :realm-count           (count realms)
-     :multi-realm?          (> (count realms) 1)
-     ;; rf2-wtg9z4 — flipped to true by the follow-up bead that ships the
-     ;; public realm→installed-app provenance read seam.
-     :provenance-available? false}))
+  ([realm-ids frame-ids realm-of]
+   (project-module-view realm-ids frame-ids realm-of (constantly nil)))
+  ([realm-ids frame-ids realm-of installed-app-of]
+   (let [by-realm (realm-frames frame-ids realm-of)
+         ;; Every installed realm, plus any realm a frame resolves into
+         ;; that somehow isn't in realm-ids (defensive — the two should
+         ;; agree, but a stale frame must never strand the view).
+         all-rids (into (set realm-ids) (keys by-realm))
+         realms   (->> all-rids
+                       (sort-by str)
+                       (mapv (fn [rid]
+                               (project-realm-row rid
+                                                  (get by-realm rid #{})
+                                                  (installed-app-of rid)))))]
+     {:realms                realms
+      :realm-count           (count realms)
+      :multi-realm?          (> (count realms) 1)
+      ;; rf2-at0oen — the `rf/installed-app` read seam shipped (PR #4061);
+      ;; the MODULES section reads real per-module provenance.
+      :provenance-available? true})))
 
-;; ---- awaiting-seam caption (rf2-wtg9z4) ---------------------------------
+;; ---- no-provenance empty-state caption (rf2-at0oen) ---------------------
 
-(def awaiting-provenance-caption
-  "The calm caption the module section renders while the per-module
-  provenance seam has not graduated (rf2-wtg9z4 follow-up rf2-imquoq). Names the
-  facts the view WILL surface so the operator understands the surface is
-  scaffolded, not broken. Pure data → string."
-  (str "Per-module ownership, capability requirements, classification, "
-       "and descriptor provenance are not yet readable from a running "
-       "process — they await a public realm→installed-app read seam "
-       "(EP-0013 disposition 6 graduation)."))
+(def no-modules-caption
+  "The calm empty-state caption the MODULES section renders when NO realm's
+  installed app carries module provenance (rf2-at0oen). The
+  `rf/installed-app` seam HAS graduated (so `:provenance-available?` is true),
+  but a process running entirely on the `reg-*` sugar / load-order path has no
+  CONSTRUCTED app value — its installed app is the registrar projection, which
+  carries no `:modules`. Names why the section is empty so the operator
+  understands it is the honest no-module state, not a broken surface. Pure data
+  → string."
+  (str "No module provenance — this process's realms are running on the "
+       "load-order (reg-* sugar) path, whose installed app value carries no "
+       "modules. Compose an app from modules (rf/app / rf/module) and install "
+       "it (rf/install!) to surface per-module ownership, capability "
+       "requirements, and descriptor provenance here."))
+
+(defn any-modules?
+  "True when at least one realm-row carries module provenance — i.e. some
+  realm's installed app was constructed and seated (`:modules` non-empty). Used
+  by the panel to choose between the module list and the no-modules caption.
+  Pure data → bool; JVM-testable."
+  [realm-rows]
+  (boolean (some (comp seq :modules) realm-rows)))
 
 (defn realm-summary-line
   "A one-line plain-language summary for a realm row — `<realm-id> · N

--- a/tools/xray/test/day8/re_frame2_xray/panels/module_view_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/module_view_helpers_cljs_test.cljc
@@ -1,16 +1,46 @@
 (ns day8.re-frame2-xray.panels.module-view-helpers-cljs-test
   "JVM + CLJS coverage for the Module-view pure-data helpers (rf2-wtg9z4
-  — the EP-0013 disposition-6 demand-trigger surface).
+  address space + rf2-at0oen per-module provenance — the EP-0013
+  disposition-6 demand-trigger surface).
 
   Verifies the (realm, frame) address-space projection (EP-0013
   disposition 3): realm→frames grouping, the realm-row shape, the
   single/multi-realm classification, and the zero-ceremony posture (a
-  single-realm process projects ONE realm). The per-module provenance
-  slots are asserted EMPTY (the seam has not graduated — rf2-wtg9z4
-  follow-up)."
+  single-realm process projects ONE realm); AND the per-module provenance
+  projection (rf2-at0oen): the module-row shape (`:owns` / `:requires` /
+  registration kinds+count / source) read off a realm's installed app
+  value, the no-modules (load-order / sugar-only) case, and the seam-fed
+  `project-module-view` with `:provenance-available?` true."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
             [day8.re-frame2-xray.panels.module-view-helpers :as h]))
+
+;; A representative module value (the shape `(rf/module {...})` produces — see
+;; re-frame.app-value/module): `:rf.module/id` · `:owns` · `:requires` ·
+;; `:registrations` (kind→id→owner-stamped descriptor) · optional `:source`.
+(def ^:private cart-module
+  {:rf.module/id  :shop/cart
+   :owns          {:app-db [[:cart]] :routes [:shop/checkout]}
+   :requires      #{:rf.capability/http}
+   :registrations {:event {:cart/add   {:kind :event :id :cart/add   :owner :shop/cart}}
+                   :sub   {:cart/items {:kind :sub   :id :cart/items :owner :shop/cart}}}
+   :source        {:ns "shop.cart" :file "cart.cljs" :line 12 :column 1}})
+
+;; A constructed app value seating that module (the shape `rf/app` / a seated
+;; `rf/installed-app` returns): `:modules` keyed by module id.
+(def ^:private cart-app
+  {:rf.app/id     :shop/app
+   :modules       {:shop/cart cart-module}
+   :registrations (:registrations cart-module)
+   :requires      #{:rf.capability/http}})
+
+;; A projected (load-order / sugar-only) app value: registrations present, but
+;; NO :modules and empty :requires (re-frame.realm/installed-app returns this
+;; for a realm seated through reg-* sugar with no install!).
+(def ^:private projected-app
+  {:rf.app/id     :rf.realm/default
+   :registrations {:event {:sugar/inc {:kind :event :id :sugar/inc}}}
+   :requires      #{}})
 
 ;; ---- realm-frames -------------------------------------------------------
 
@@ -30,20 +60,76 @@
       (is (= #{:app/main :ghost} (get grouped :rf.realm/default))
           "nil realm → default realm bucket"))))
 
+;; ---- project-module-row -------------------------------------------------
+
+(deftest project-module-row-shape
+  (testing "a module value projects to the module-row: id, owns, requires,
+            sorted registration kinds + total descriptor count, source"
+    (let [row (h/project-module-row cart-module)]
+      (is (= :shop/cart (:module-id row)))
+      (is (= {:app-db [[:cart]] :routes [:shop/checkout]} (:owns row)))
+      (is (= #{:rf.capability/http} (:requires row)))
+      (is (= [:event :sub] (:registration-kinds row)) "kinds sorted by str")
+      (is (= 2 (:registration-count row)) "one event + one sub")
+      (is (= {:ns "shop.cart" :file "cart.cljs" :line 12 :column 1} (:source row))))))
+
+(deftest project-module-row-defaults
+  (testing "a bare module (no owns/requires/source) projects empty/nil slots"
+    (let [row (h/project-module-row {:rf.module/id :m/empty :registrations {}})]
+      (is (= :m/empty (:module-id row)))
+      (is (= {} (:owns row)))
+      (is (= #{} (:requires row)))
+      (is (= [] (:registration-kinds row)))
+      (is (= 0 (:registration-count row)))
+      (is (nil? (:source row))))))
+
+;; ---- project-app-modules ------------------------------------------------
+
+(deftest project-app-modules-constructed
+  (testing "a constructed app value projects its :modules to sorted module rows
+            + the app's union requires"
+    (let [{:keys [modules requires]} (h/project-app-modules cart-app)]
+      (is (= [:shop/cart] (mapv :module-id modules)))
+      (is (= #{:rf.capability/http} requires)))))
+
+(deftest project-app-modules-sorted-by-id
+  (testing "module rows sort by module-id str (stable render)"
+    (let [m-b {:rf.module/id :b/mod :registrations {}}
+          m-a {:rf.module/id :a/mod :registrations {}}
+          app {:rf.app/id :x :modules {:b/mod m-b :a/mod m-a} :requires #{}}
+          {:keys [modules]} (h/project-app-modules app)]
+      (is (= [:a/mod :b/mod] (mapv :module-id modules))))))
+
+(deftest project-app-modules-projected-is-module-less
+  (testing "a projected (load-order / sugar-only) app carries no :modules — the
+            honest no-provenance case; :modules is nil (not [])"
+    (let [{:keys [modules requires]} (h/project-app-modules projected-app)]
+      (is (nil? modules) "module-less app → nil modules (distinct from [])")
+      (is (= #{} requires))))
+  (testing "nil app (no seam value) is likewise module-less"
+    (is (nil? (:modules (h/project-app-modules nil))))))
+
 ;; ---- project-realm-row --------------------------------------------------
 
-(deftest project-realm-row-shape
-  (testing "the realm-row carries id, sorted frames, count, and EMPTY
-            provenance slots (seam not graduated)"
+(deftest project-realm-row-shape-no-app
+  (testing "the realm-row (no installed app) carries id, sorted frames, count,
+            and module-less provenance slots"
     (let [row (h/project-realm-row :rf.realm/default #{:app/cart :app/main})]
       (is (= :rf.realm/default (:realm row)))
       (is (= [:app/cart :app/main] (:frames row)) "frames sorted by str")
       (is (= 2 (:frame-count row)))
-      ;; provenance slots — awaiting the core seam (rf2-wtg9z4 follow-up).
-      (is (nil? (:modules row)))
+      (is (nil? (:modules row)) "no installed app → no modules")
       (is (= #{} (:requires row)))
+      ;; reserved slots — ownership is per-module (`:modules … :owns`);
+      ;; classification is frame-owned (not a module fact).
       (is (nil? (:owns row)))
       (is (nil? (:classification row))))))
+
+(deftest project-realm-row-shape-with-app
+  (testing "the realm-row fills :modules + :requires from the installed app value"
+    (let [row (h/project-realm-row :rf.realm/default #{:app/main} cart-app)]
+      (is (= [:shop/cart] (mapv :module-id (:modules row))))
+      (is (= #{:rf.capability/http} (:requires row))))))
 
 ;; ---- project-module-view ------------------------------------------------
 
@@ -57,8 +143,30 @@
       (is (false? (:multi-realm? data)))
       (is (= :rf.realm/default (:realm (first (:realms data)))))
       (is (= [:app/cart :app/main] (:frames (first (:realms data)))))
-      (is (false? (:provenance-available? data))
-          "the provenance seam has NOT graduated (rf2-wtg9z4 follow-up)"))))
+      (is (true? (:provenance-available? data))
+          "the rf/installed-app read seam has graduated (rf2-at0oen)"))))
+
+(deftest project-module-view-fills-modules-from-seam
+  (testing "project-module-view reads the per-realm installed app value via the
+            installed-app-of resolver and fills each realm's :modules"
+    (let [installed-app-of {:rf.realm/default cart-app}
+          data (h/project-module-view #{:rf.realm/default}
+                                      [:app/main]
+                                      (constantly :rf.realm/default)
+                                      installed-app-of)
+          row  (first (:realms data))]
+      (is (true? (:provenance-available? data)))
+      (is (= [:shop/cart] (mapv :module-id (:modules row))))
+      (is (= #{:rf.capability/http} (:requires row))))))
+
+(deftest project-module-view-no-resolver-is-module-less
+  (testing "the 3-arity (no installed-app-of) projects the address space with no
+            module provenance — the legacy address-only call still works"
+    (let [data (h/project-module-view #{:rf.realm/default}
+                                      [:app/main]
+                                      (constantly :rf.realm/default))]
+      (is (true? (:provenance-available? data)))
+      (is (nil? (:modules (first (:realms data))))))))
 
 (deftest project-module-view-multi-realm
   (testing "more than one realm → multi-realm? true, every realm present,
@@ -96,17 +204,26 @@
       (is (contains? (set (map :realm (:realms data))) :app/gone)
           "the orphan realm is surfaced rather than dropped"))))
 
-;; ---- captions / summaries -----------------------------------------------
+;; ---- no-modules empty-state / any-modules? ------------------------------
 
-(deftest awaiting-caption-names-the-deferred-facts
-  (testing "the awaiting-seam caption names ownership, capability,
-            classification, and provenance so the operator knows the
-            surface is scaffolded, not broken"
-    (let [c h/awaiting-provenance-caption]
-      (is (re-find #"(?i)ownership" c))
-      (is (re-find #"(?i)capability" c))
-      (is (re-find #"(?i)classification" c))
-      (is (re-find #"(?i)provenance" c)))))
+(deftest any-modules?-detects-provenance
+  (testing "any-modules? is true when some realm-row carries modules"
+    (is (true? (h/any-modules? [{:realm :r1 :modules nil}
+                                {:realm :r2 :modules [{:module-id :m/a}]}])))
+    (is (false? (h/any-modules? [{:realm :r1 :modules nil}
+                                 {:realm :r2 :modules []}]))
+        "no modules anywhere → false")))
+
+(deftest no-modules-caption-explains-the-empty-state
+  (testing "the no-modules caption names the load-order / sugar reason and the
+            rf/app / rf/module / rf/install! remedy so the operator knows the
+            section is the honest empty state, not broken"
+    (let [c h/no-modules-caption]
+      (is (re-find #"(?i)load-order" c))
+      (is (re-find #"(?i)rf/module" c))
+      (is (re-find #"(?i)rf/install!" c)))))
+
+;; ---- summaries ----------------------------------------------------------
 
 (deftest realm-summary-line-pluralizes
   (is (= ":rf.realm/default · 1 frame"


### PR DESCRIPTION
## What & why

EP-0013 disposition 6 graduation. The Xray Module-view MODULES section was scaffolded behind an *awaiting-seam* caption (rf2-wtg9z4, PR #4050) because no public read of a running realm's installed app value existed. The public realm→installed-app read seam **`rf/installed-app`** shipped (rf2-imquoq, PR #4061), so this PR flips `:provenance-available?` to `true` and fills the MODULES section from `(rf/installed-app realm)` per realm — no row reshape, the scaffold already carried the slots.

Spun from **rf2-at0oen** (P3, EP-0013).

## Changes

- **`module_view_helpers.cljc`**
  - `project-module-row` — one module value → `{:module-id :owns :requires :registration-kinds :registration-count :source}`.
  - `project-app-modules` — an app value → sorted module rows + union `:requires`; **nil `:modules`** for a load-order / sugar-only app (distinct from `[]`).
  - `project-realm-row` 3-arity — fills `:modules` / `:requires` from the realm's installed app value.
  - `project-module-view` 4-arity — takes an `installed-app-of` resolver (`rf/installed-app`); `:provenance-available?` → `true`. 3-arity preserved (address-only).
  - Replaced the awaiting-seam caption with `no-modules-caption` (the honest empty state — load-order process has no constructed app value) + `any-modules?` predicate.
- **`module_view.cljs`** — MODULES section renders per realm (realm header only when multi-realm — zero-ceremony), each module showing owns / requires / registers / source; honest no-module caption when no realm carries a constructed app. Sub passes `rf/installed-app` into the projection (static read — pins nothing, dispatches nothing).
- **`spec/026-Module-View-Panel.md`** — §1/§2/§4/§6/§7 updated to *shipped*; documents the seam, the no-provenance case, and that **EP-0015 classification is frame-owned (NOT a per-module fact)** so it is not surfaced here (the `:classification` row slot stays reserved/nil).
- **tests** — module-row shape, `project-app-modules` (constructed / projected / nil), seam-fed `project-module-view`, `any-modules?` / `no-modules-caption` empty state.

### Correctness note — classification is frame-owned
The bead brief named `:classification` as a per-module fact, but module values (`rf/module`) carry no `:classification` slot — EP-0015 durable classification is **frame-owned** (declared on `reg-frame`, installed by `re-frame.frame-classification`). The seam genuinely surfaces `:owns` / `:requires` / owner-stamped descriptors / source coords; the MODULES section surfaces those and documents that classification lives on the frame side. The reserved `:classification` row slot is kept for shape stability but not populated from `:modules`.

## Quality gates

- `clojure -M:test` (tools/xray): **1181 tests, 5238 assertions, 0 failures, 0 errors** ✅
- `npm run test:cljs`: **6965 tests, 28515 assertions, 0 failures, 0 errors** ✅
- `npm run test:xray-feature-gate`: **16 scenarios, 0 failures, 13 matrix rows** (all surfaces incl. panel-gallery compiled, 0 warnings) ✅
- Staged `rm -rf docs/spec && cp -r spec docs/spec && mkdocs build --strict`: **built, exit 0** ✅ (note: `tools/xray/spec/` is not part of the mkdocs site; build confirms no top-level spec regression)

File boundary respected: only the Module-view panel + helpers + its test + `spec/026` touched. No edits to `resources_helpers`, the graph panel, or core `graph.cljc`.