### PR TITLE
fix: remove stale resource key shapes + preserve explicit nil params (rf2-hgy5kf)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -48,7 +48,9 @@
   ## Work-ledger substrate (rf2-afpdkn)
 
   Each load-causing attempt now also writes a SERIALIZABLE work record at
-  `[:rf.runtime/work-ledger <work-id>]` (the entry points at it via
+  `[:rf.runtime/work-ledger <work-id-id>]` — keyed on the CEDN-1 byte
+  `work-ledger/work-id-id` (NOT the work-id vector; rf2-9e0tyq), via
+  `work-ledger/record-path` (the entry points at it via
   `:current-work`; the record carries status / owners / causes / deadline /
   outcome — NO host handles). Host abort handles live in a side table keyed
   by `[frame-id work-id]` (`work-ledger/handle-table`), recorded via the
@@ -141,7 +143,7 @@
   Returns the event-fx map `{:rf.db/runtime :fx}`."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, gen-snapshot :rf.resource/generation
     world :rf.world/inputs, app-db :db}
-   {:keys [resource params owner cause keep-previous?] :as payload} {:keys [force-new? where]}]
+   {:keys [resource owner cause keep-previous?] :as payload} {:keys [force-new? where]}]
   (let [runtime-db (or rt {})
         spec       (registry/require-resource-spec! resource where)
         ;; EP-0016 D3 slice 3: a `{:from-db …}` payload-scope OR spec-policy
@@ -150,7 +152,11 @@
         ;; scopes resolve as before.
         scope      (registry/resolve-scope-for-event
                      resource spec {:payload-scope (:scope payload) :db app-db} where)
-        cparams    (registry/validate+canonicalize-params resource spec params where)
+        ;; rf2-hgy5kf — thread `:params` PRESENCE (absent vs explicit nil) to
+        ;; the validation boundary; an absent slot becomes `{}` there, an
+        ;; explicit `{:params nil}` reaches the schema unchanged.
+        cparams    (registry/validate+canonicalize-params
+                     resource spec (state/params-present? payload) where)
         scoped-key (state/scoped-resource-key scope resource cparams)
         entry      (or (get-in runtime-db (state/entry-path scoped-key))
                        (state/empty-entry resource scoped-key))
@@ -1043,14 +1049,17 @@
   "`:rf.resource/remove` — remove a single resource instance from the cache
   by its scoped key, and drop its owner/tag-index rows. Per Spec 016
   §Events. Payload: `{:resource :scope :params}`."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, app-db :db} [_event-id {:keys [resource params] :as payload}]]
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, app-db :db} [_event-id {:keys [resource] :as payload}]]
   (let [runtime-db (or rt {})
         spec       (registry/require-resource-spec! resource 'rf.resource/remove)
         ;; EP-0016 D3 slice 3: resolve a `{:from-db …}` scope against app-db.
         scope      (registry/resolve-scope-for-event
                      resource spec {:payload-scope (:scope payload) :db app-db} 'rf.resource/remove)
+        ;; rf2-hgy5kf — thread `:params` presence (absent vs explicit nil) to
+        ;; the validation boundary so removal keys on the SAME identity an
+        ;; explicit-nil-params ensure produced.
         cparams    (registry/validate+canonicalize-params
-                     resource spec params 'rf.resource/remove)
+                     resource spec (state/params-present? payload) 'rf.resource/remove)
         scoped-key (state/scoped-resource-key scope resource cparams)
         entry      (get-in runtime-db (state/entry-path scoped-key))
         wid        (:current-work entry)

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -614,11 +614,15 @@
   Returns the event-fx map (`:rf.db/runtime` + `:fx`)."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, gen-snapshot :rf.resource/generation
     world :rf.world/inputs, app-db :db}
-   [_event-id {:keys [mutation params instance scope cause reply-to] :as _payload}]]
+   [_event-id {:keys [mutation instance scope cause reply-to] :as payload}]]
   (let [where      'rf.mutation/execute
         runtime-db (or rt {})
         spec       (mreg/require-mutation-spec! mutation where)
-        cparams    (mreg/validate+canonicalize-params mutation spec params where)
+        ;; rf2-hgy5kf — thread `:params` presence (absent vs explicit nil) to
+        ;; the validation boundary: an absent slot defaults to `{}` there, an
+        ;; explicit `{:params nil}` reaches `:params-schema` unchanged.
+        cparams    (mreg/validate+canonicalize-params
+                     mutation spec (state/params-present? payload) where)
         cscope     (mreg/resolve-scope mutation spec scope)
         ;; rf2-e8wj5t — reject a non-serializable caller-supplied instance id
         ;; BEFORE any runtime-db / work-ledger write or HTTP lowering (the

--- a/implementation/resources/src/re_frame/resources/mutation_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_registry.cljc
@@ -230,9 +230,18 @@
   cache key must be (a mutation is not cached by params) — but the
   `:invalidates` / `:patches` fns close over the canonical params and the
   instance row stores them (serializable, for Xray / SSR), so the same
-  EDN discipline applies."
+  EDN discipline applies.
+
+  `nil` vs missing is schema-defined (rf2-hgy5kf): a caller threads
+  `state/missing-params` for an ABSENT `:params` slot (lowered to the
+  documented `{}` default via `state/default-omitted-params`), while a PRESENT
+  explicit `nil` passes THROUGH to `:params-schema` validation +
+  canonicalization — the schema, not a blanket `(or params {})`, decides
+  whether nil conforms. The two registrars apply the SAME presence-aware
+  policy so a validation boundary never performs an accidental API default
+  (EP-0012 §canonical-forms)."
   [mutation-id spec params where]
-  (let [params (or params {})
+  (let [params (state/default-omitted-params params)
         schema (:params-schema spec)]
     (state/reject-non-edn! params where :params mutation-id)
     (when schema

--- a/implementation/resources/src/re_frame/resources/registry.cljc
+++ b/implementation/resources/src/re_frame/resources/registry.cljc
@@ -354,12 +354,17 @@
   `:rf.error/resource-invalid-params` on a schema-conformance failure.
   Per Spec 016 §Resource identity / §Canonicalization rule.
 
-  `nil` vs missing is schema-defined: the `:params-schema` decides whether a
-  key may be absent or nil — this fn does not impose a separate policy, it
-  defers to the schema (Spec 016: \"nil vs missing MUST be schema-defined,
-  not accidental\")."
+  `nil` vs missing is schema-defined (rf2-hgy5kf): a caller threads
+  `state/missing-params` for an ABSENT `:params` slot (the documented
+  omitted-default lowers it to `{}` via `state/default-omitted-params`), while
+  a PRESENT explicit `nil` is passed THROUGH to `:params-schema` validation +
+  canonicalization unchanged — the schema (not a blanket `(or params {})`)
+  decides whether nil conforms. This keeps the validation boundary from
+  silently performing an accidental API default, so `{:params nil}` and an
+  omitted `:params` stay distinct identities (Spec 016: \"nil vs missing MUST
+  be schema-defined, not accidental\"; EP-0012 §canonical-forms)."
   [resource-id spec params where]
-  (let [params (or params {})
+  (let [params (state/default-omitted-params params)
         schema (:params-schema spec)]
     ;; host / opaque values are rejected at the cache-key boundary
     (state/reject-non-edn! params where :params resource-id)

--- a/implementation/resources/src/re_frame/resources/state.cljc
+++ b/implementation/resources/src/re_frame/resources/state.cljc
@@ -142,12 +142,6 @@
   [k-id]
   [resources-key :entries k-id])
 
-(defn work-record-path
-  "Runtime-db-relative path to a single work record by its `:work/id`.
-  Per Spec 016 §Frame work ledger."
-  [work-id]
-  [work-ledger-key work-id])
-
 ;; ---- framework-write authority -------------------------------------------
 ;;
 ;; `:rf.runtime/resources` and `:rf.runtime/work-ledger` are framework-
@@ -264,6 +258,54 @@
 ;; `identity/canonical` also fails closed on DUPLICATE canonical map keys
 ;; (two distinct host keys whose CEDN-1 bytes collide), so a colliding cache
 ;; key can never silently collapse two identity-distinct param maps.
+
+;; ---- explicit-nil vs omitted params (Spec 016 §Resource identity —
+;; ---- "nil vs missing MUST be schema-defined, not accidental";
+;; ---- EP-0012 §canonical-forms) -------------------------------------------
+;;
+;; A payload `:params` slot is one of THREE distinct things, and the cache-key
+;; boundary must not silently fold them: a present non-nil value, a PRESENT
+;; explicit `nil` (`{:params nil}`), or an ABSENT key (`{}`). Spec 016 + EP-0012
+;; say present-nil and absent are DISTINCT unless explicitly elided — the
+;; `:params-schema` (not the framework) decides whether nil / absence conforms.
+;;
+;; The defaulting policy (omitted `:params` → `{}`) is therefore a PAYLOAD-
+;; BOUNDARY default, applied ONLY when the key is genuinely absent — never a
+;; blanket `(or params {})` that also collapses an explicit nil before Malli /
+;; canonicalization can decide. A handler that has destructured `:params` out
+;; of its payload has lost the absent-vs-nil distinction, so it threads the
+;; presence explicitly: a present slot (incl. explicit nil) passes its value,
+;; an absent slot passes `missing-params`.
+
+(def missing-params
+  "The sentinel a payload boundary threads for an ABSENT `:params` slot
+  (distinct from a PRESENT explicit `nil`). `default-omitted-params` lowers
+  it to the documented omitted-params default (`{}`); a present value —
+  INCLUDING explicit `nil` — is passed through to schema validation /
+  canonicalization unchanged. Per Spec 016 §Resource identity (nil vs missing
+  is schema-defined) / EP-0012 §canonical-forms."
+  ::missing-params)
+
+(defn params-present?
+  "Resolve a payload's `:params` presence WITHOUT collapsing explicit nil:
+  returns `missing-params` when `payload` lacks a `:params` key, else the
+  present value (which may be `nil`). The single helper a handler uses to
+  thread params presence to `validate+canonicalize-params` so an absent slot
+  and a `{:params nil}` slot stay distinct at the validation boundary."
+  [payload]
+  (if (contains? payload :params)
+    (:params payload)
+    missing-params))
+
+(defn default-omitted-params
+  "Apply the documented omitted-`:params` API default: an ABSENT slot
+  (`missing-params`) becomes `{}`; every present value — INCLUDING explicit
+  `nil` — passes through unchanged so the `:params-schema` (not a blanket
+  `(or params {})`) decides whether nil conforms. The single home for the
+  defaulting policy both registrars share. Per Spec 016 §Resource identity /
+  EP-0012 §canonical-forms."
+  [params]
+  (if (= params missing-params) {} params))
 
 (defn serializable-edn?
   "True iff `x` is a portable CEDN-1 EDN identity value the cache key may

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -102,12 +102,16 @@
   kept for the direct-dispatch test path (no `{:from-db …}` scope), where
   references resolve against an empty db (fail-closed)."
   ([payload] (resolve-scoped-key payload nil))
-  ([{:keys [resource params] :as payload} db]
+  ([{:keys [resource] :as payload} db]
    (let [spec    (registry/require-resource-spec! resource 'rf.resource/subscribe)
          scope   (registry/resolve-scope-for-sub
                    resource spec (:scope payload) 'rf.resource/subscribe db)
+         ;; rf2-hgy5kf — thread `:params` presence (absent vs explicit nil) so
+         ;; the sub re-keys to the SAME identity the ensure produced (an absent
+         ;; slot defaults to `{}` at the boundary; explicit nil reaches the
+         ;; schema unchanged).
          cparams (registry/validate+canonicalize-params
-                   resource spec params 'rf.resource/subscribe)]
+                   resource spec (state/params-present? payload) 'rf.resource/subscribe)]
      (state/scoped-resource-key scope resource cparams))))
 
 ;; ---- dev-mode scope-mismatch warning (Spec 016 §Subscription-side scope

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -232,6 +232,86 @@
                  (state/scoped-resource-key :rf.scope/global :r/x absent)))
           "the scoped resource keys differ — present-nil is its own cache fact"))))
 
+;; rf2-hgy5kf (EP-0012) — the WHOLE-slot case the prior `(or params {})` at the
+;; validation boundary silently collapsed: a PAYLOAD with `:params` PRESENT and
+;; explicitly `nil` (`{:params nil}`) vs `:params` ABSENT (`{}`). Spec 016:70 +
+;; EP-0012:1316 say present-nil and absent are DISTINCT unless explicitly
+;; elided; the schema (not a blanket boundary default) decides whether the
+;; whole-slot nil conforms. `state/params-present?` threads the presence, and
+;; `state/default-omitted-params` applies the omitted-→`{}` policy ONLY to an
+;; absent slot — an explicit whole-slot nil reaches the schema unchanged.
+
+(deftest resource-explicit-nil-params-slot-distinct-from-omitted
+  (testing "the presence helper distinguishes an explicit nil :params slot from
+            an absent one (the distinction the old (or params {}) destroyed)"
+    (is (= nil (state/params-present? {:params nil}))
+        "a PRESENT explicit nil slot threads nil")
+    (is (= state/missing-params (state/params-present? {}))
+        "an ABSENT slot threads the missing sentinel")
+    (is (= {} (state/default-omitted-params (state/params-present? {})))
+        "an absent slot defaults to {} at the boundary")
+    (is (= nil (state/default-omitted-params (state/params-present? {:params nil})))
+        "an explicit nil slot passes THROUGH the default unchanged (not {})"))
+  (testing "under a schema that ACCEPTS a nil params value ([:maybe :map]), an
+            explicit whole-slot nil is preserved to the cache key and is a
+            DISTINCT canonical identity from the omitted-→{} case"
+    (let [spec {:scope         :rf.scope/global
+                :params-schema [:maybe :map]   ;; the whole params value may be nil
+                :request       (fn [_ _ctx] {:request {:method :get :url "/x"}})}
+          explicit-nil (registry/validate+canonicalize-params
+                         :r/x spec (state/params-present? {:params nil}) 'test)
+          omitted      (registry/validate+canonicalize-params
+                         :r/x spec (state/params-present? {}) 'test)]
+      (is (nil? explicit-nil)
+          "explicit whole-slot nil survives validation — NOT coerced to {}")
+      (is (= {} omitted) "the omitted slot defaults to {}")
+      (is (not (identity/identical-identity? explicit-nil omitted))
+          "explicit-nil and omitted are DISTINCT canonical identities")
+      (is (not (identity/identical-identity?
+                 (state/scoped-resource-key :rf.scope/global :r/x explicit-nil)
+                 (state/scoped-resource-key :rf.scope/global :r/x omitted)))
+          "the scoped resource keys differ — explicit-nil params is its own fact"))))
+
+(deftest resource-explicit-nil-params-slot-rejected-when-schema-rejects-nil
+  (testing "rf2-hgy5kf — under a schema that REJECTS a nil params value
+            ([:map], a non-nilable map), an explicit whole-slot {:params nil}
+            fails closed with :rf.error/resource-invalid-params and the
+            structured error reports the offending nil (NOT a coerced {})"
+    (let [spec {:scope         :rf.scope/global
+                :params-schema [:map [:slug :string]]   ;; requires a map, rejects nil
+                :request       (fn [_ _] {:request {:method :get :url "/x"}})}
+          ex   (try (registry/validate+canonicalize-params
+                      :r/x spec (state/params-present? {:params nil}) 'test)
+                    nil
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e e))]
+      (is (some? ex)
+          "an explicit whole-slot nil against a non-nilable schema throws — NOT
+           silently coerced to {} (which would have PASSED a [:map] schema)")
+      (is (= :rf.error/resource-invalid-params (:rf.error/id (ex-data ex))))
+      (is (nil? (:params (ex-data ex)))
+          "the reported params preserve the offending nil (not coerced away)"))))
+
+(deftest mutation-explicit-nil-params-slot-rejected-when-schema-rejects-nil
+  (testing "rf2-hgy5kf — the mutation registry applies the SAME presence-aware
+            policy: an explicit whole-slot {:params nil} reaches a non-nilable
+            :params-schema and fails closed (not coerced to {})"
+    (let [spec {:scope         :rf.scope/global
+                :params-schema [:map [:slug :string]]
+                :request       (fn [_ _] {:request {:method :post :url "/x"}})}
+          ex   (try (mreg/validate+canonicalize-params
+                      :m/x spec (state/params-present? {:params nil}) 'test)
+                    nil
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo) e e))]
+      (is (some? ex) "an explicit nil mutation params slot against [:map] throws")
+      (is (= :rf.error/mutation-invalid-params (:rf.error/id (ex-data ex))))
+      (is (nil? (:params (ex-data ex)))
+          "the reported params preserve the offending nil"))
+    (testing "an OMITTED mutation params slot still defaults to {} (API policy)"
+      (let [spec {:scope :rf.scope/global :params-schema [:map]
+                  :request (fn [_ _] {:request {:method :post :url "/x"}})}]
+        (is (= {} (mreg/validate+canonicalize-params
+                    :m/x spec (state/params-present? {}) 'test)))))))
+
 (deftest resource-present-nil-rejected-when-schema-rejects-nil
   (testing "under a schema that REJECTS nil ([:map [:x :string]]), an explicit
             {:x nil} fails closed with :rf.error/resource-invalid-params and
@@ -876,10 +956,16 @@
         (is (empty? (get-in (runtime-db) (state/owner-index-path)))))
       (testing "rf2-m9h5iq — the in-flight work record is settled terminal
                 (:suppressed) so the ledger row is not left in-flight"
-        (let [rec (get-in (runtime-db) (state/work-record-path inflight-wid))]
-          ;; record may be pruned or marked terminal; if present it must be
-          ;; the terminal :suppressed status, never still in-flight.
+        ;; Read through the byte-keyed work-ledger API (rf2-hgy5kf): the row is
+        ;; addressed by `work-ledger/work-id-id`, NOT the stale vector key. The
+        ;; assertion is NON-vacuous — a present post-clear row MUST be terminal
+        ;; (`:suppressed`), and a present-but-NON-terminal row FAILS the test
+        ;; (the exact drift EP-0012 closes; the old `(when rec …)` made it pass
+        ;; silently when the byte-keyed row was read through a dead address).
+        (let [rec (work-ledger/get-record (runtime-db) inflight-wid)]
           (when rec
+            (is (work-ledger/terminal? (:status rec))
+                "a present post-clear work record must be terminal, never in-flight")
             (is (= :suppressed (:status rec))))))
       (testing "rf2-m9h5iq — a LATE reply for a cleared in-flight entry cannot
                 recreate it (its existence check finds the entry gone)"

--- a/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
@@ -152,6 +152,33 @@
         (is (not (contains? r :promise)))
         (is (not (contains? r :abort-fn)))))))
 
+(deftest work-record-byte-keyed-address-is-canonical
+  ;; rf2-hgy5kf (EP-0012) — the work record lives at ONE address: the
+  ;; byte-keyed `work-ledger/record-path` (`[:rf.runtime/work-ledger
+  ;; (work-id-id work-id)]`). The stale `[work-ledger-key work-id]` VECTOR
+  ;; address (the removed `state/work-record-path` shape) holds NOTHING — a
+  ;; test reading through it would silently miss the live row, making any
+  ;; `(when rec …)` assertion vacuous. This pins the one home so the drift
+  ;; cannot reappear.
+  (rf/reg-resource :wlbk/article (article-spec))
+  (let [scoped-key (state/scoped-resource-key :rf.scope/global :wlbk/article {:slug "w"})]
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :wlbk/article :scope :rf.scope/global
+                        :params {:slug "w"} :owner [:route :r 1]}])
+    (let [wid (:current-work (entry scoped-key))
+          rdb (runtime-db)]
+      (testing "the byte-keyed work-ledger API reads the live row"
+        (is (some? (work-ledger/get-record rdb wid)))
+        (is (= :running (:status (work-ledger/get-record rdb wid)))))
+      (testing "the row is stored under the CEDN-1 byte work-id-id, NOT the
+                work-id vector"
+        (is (contains? (:rf.runtime/work-ledger rdb) (work-ledger/work-id-id wid)))
+        (is (not (contains? (:rf.runtime/work-ledger rdb) wid)))
+        (is (string? (work-ledger/work-id-id wid))))
+      (testing "the removed stale [work-ledger-key work-id] vector address
+                holds nothing (the dead shape EP-0012 eliminates)"
+        (is (nil? (get-in rdb [state/work-ledger-key wid])))))))
+
 (deftest work-record-started-at-deadline-at-from-token-time-ms
   ;; rf2-uuzj88 / EP-0010 §Resources, Mutations, And Work-Ledger Timestamps:
   ;; the durable work-ledger `:started-at` is the TRIGGERING TOKEN'S

--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -375,6 +375,17 @@ the frame target is carried explicitly — a frameless call with no
 resolvable context fails closed (`{:ok? false :reason
 :no-frame-resolved}`).
 
+The live `:rf.runtime/resources :entries` map is keyed on the **opaque
+CEDN-1 byte `key-id` string** (rf2-9e0tyq), with the kind-preserving
+`[scope resource-id params]` scoped-key vector carried on each entry as
+`:resource/key`. The upstream `:scope` / `:resource-id` / `:params` key
+filter therefore matches against the entry's **`:resource/key` stamp**
+(falling back to the map key only for a legacy entry that lacks it) — never
+the byte map-key, which would match nothing for live runtime data. The
+selected map preserves its byte map-keys as the row identity. Symmetrically,
+the work-ledger projection reads each row's kind-preserving `:work/id`
+vector from the record, not its byte `work-id-id` map-key.
+
 ## `:rf.xray/*` registry surface
 
 Installed by `panels/resources.cljs`'s `install!` under the `:rf.xray/*`

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -650,9 +650,16 @@
        :attempt      2
        :transport    :rf.http/managed
        :outcome      <summary>}"
-  [[work-id record]]
+  [[map-key record]]
   (let [rkey (or (:resource/key record) (:resource-key record))
-        {:keys [scope resource-id params]} (scoped-key-summary rkey)]
+        {:keys [scope resource-id params]} (scoped-key-summary rkey)
+        ;; rf2-9e0tyq / rf2-hgy5kf: the `:rf.runtime/work-ledger` map is keyed
+        ;; on the opaque CEDN-1 byte `work-id-id` STRING; the kind-preserving
+        ;; work-id VECTOR is carried on the record as `:work/id`. Read it from
+        ;; there (fall back to the map key for a legacy record that lacks the
+        ;; stamp) so the displayed `:work-id` / `:stale-key` is the
+        ;; kind-preserving identity, NOT the byte string.
+        work-id (or (:work/id record) map-key)]
     {:work-id      work-id
      :kind         (or (:work/kind record) (:kind record))
      :resource-key {:scope scope :resource-id resource-id :params params}
@@ -1283,10 +1290,16 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- scoped-key-matches?
-  "Does a scoped key `[scope rid params]` match the supplied filter
+  "Does the scoped key `[scope rid params]` match the supplied filter
   axes? `scope` / `resource-id` / `params` are compared against the RAW
-  key parts (the accessor receives the raw runtime-db key); a nil filter
-  axis is a wildcard."
+  key parts; a nil filter axis is a wildcard.
+
+  rf2-9e0tyq / rf2-hgy5kf: the `:entries` map is keyed on the opaque CEDN-1
+  byte `key-id` STRING, so the kind-preserving `[scope rid params]` scoped-key
+  VECTOR is read from the entry's `:resource/key` stamp (with a fallback to
+  the map key for a legacy entry that lacks the stamp) — exactly as
+  `instance-row` projects. Matching the map key directly would silently match
+  NOTHING for live byte-keyed runtime data."
   [scoped-key {:keys [scope resource-id params]}]
   (let [[ks krid kparams] (if (and (vector? scoped-key) (= 3 (count scoped-key)))
                             scoped-key
@@ -1312,14 +1325,22 @@
        vec))
 
 (defn select-raw-entries
-  "Select the RAW runtime-db entries (`{<scoped-key> <entry>}`) matching
-  the scope / resource-id / params key axes — the upstream filter the
-  accessors apply BEFORE projection/elision (so an accessor can scope its
-  read by the cache key before summarizing). Pure; the accessor still
-  routes selected values through the off-box elision walker afterwards."
+  "Select the RAW runtime-db entries (`{<key-id> <entry>}`) matching the
+  scope / resource-id / params key axes — the upstream filter the accessors
+  apply BEFORE projection/elision (so an accessor can scope its read by the
+  cache key before summarizing). Pure; the accessor still routes selected
+  values through the off-box elision walker afterwards.
+
+  rf2-9e0tyq / rf2-hgy5kf: the `:entries` map is keyed on the opaque CEDN-1
+  byte `key-id` STRING, so each entry is matched against its `:resource/key`
+  stamp (the kind-preserving `[scope rid params]` vector), with a fallback to
+  the map key for a legacy entry that lacks the stamp. Matching the byte
+  map-key directly would silently return NO matches for live byte-keyed
+  runtime data."
   [entries key-filter]
   (into {}
-        (filter (fn [[k _]] (scoped-key-matches? k key-filter)))
+        (filter (fn [[k entry]]
+                  (scoped-key-matches? (or (:resource/key entry) k) key-filter)))
         (or entries {})))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
@@ -33,7 +33,14 @@
     9. **filters** — instance / work / history filter axes; bounded
        history."
   (:require [clojure.test :refer [deftest is testing]]
-            [day8.re-frame2-xray.panels.resources-helpers :as h]))
+            [day8.re-frame2-xray.panels.resources-helpers :as h]
+            ;; rf2-hgy5kf — the live `:entries` / `:rf.runtime/work-ledger` maps
+            ;; are keyed on the CEDN-1 byte `key-id` STRING (rf2-9e0tyq), with the
+            ;; kind-preserving scoped-key VECTOR carried on the entry's
+            ;; `:resource/key`. The fixtures below model that runtime shape via
+            ;; `state/key-id` rather than the dead vector-keyed shape.
+            [re-frame.resources.state :as state]
+            [re-frame.resources.work-ledger :as work-ledger]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
@@ -266,19 +273,32 @@
 
 (def ^:private now 1000000)
 
+(defn- byte-keyed
+  "rf2-9e0tyq / rf2-hgy5kf — build the LIVE-shape `:entries` map: keyed on the
+  CEDN-1 byte `state/key-id` of each scoped-key VECTOR, with the
+  kind-preserving vector stamped on the entry's `:resource/key` (exactly as
+  `state/empty-entry` / the runtime write it). Input is the author-friendly
+  `{<scoped-key-vector> <entry>}` map."
+  [vector-keyed]
+  (into {}
+        (map (fn [[scoped-key entry]]
+               [(state/key-id scoped-key) (assoc entry :resource/key scoped-key)]))
+        vector-keyed))
+
 (def ^:private entries
-  {[session-scope :article/by-slug {:slug "welcome"}]
-   {:resource/id :article/by-slug :status :loaded
-    :data {:title "Welcome"} :generation 4 :attempt 2
-    :loaded-at (- now 1000) :stale-at (+ now 50000)
-    :active-owners #{[:route :route/article "nav-1"]}
-    :tags #{[:article "welcome"]} :request-id [:w 4]}
-   [session-scope :article/by-slug {:slug "old"}]
-   {:resource/id :article/by-slug :status :loaded
-    :data {:title "Old"} :generation 2
-    :loaded-at (- now 99999) :stale-at (- now 1)   ; past stale-at → stale
-    :active-owners #{}                              ; no owner → gc-eligible
-    :tags #{[:article "old"]}}})
+  (byte-keyed
+    {[session-scope :article/by-slug {:slug "welcome"}]
+     {:resource/id :article/by-slug :status :loaded
+      :data {:title "Welcome"} :generation 4 :attempt 2
+      :loaded-at (- now 1000) :stale-at (+ now 50000)
+      :active-owners #{[:route :route/article "nav-1"]}
+      :tags #{[:article "welcome"]} :request-id [:w 4]}
+     [session-scope :article/by-slug {:slug "old"}]
+     {:resource/id :article/by-slug :status :loaded
+      :data {:title "Old"} :generation 2
+      :loaded-at (- now 99999) :stale-at (- now 1)   ; past stale-at → stale
+      :active-owners #{}                              ; no owner → gc-eligible
+      :tags #{[:article "old"]}}}))
 
 (deftest project-instances-test
   (let [rows (h/project-instances entries now)]
@@ -305,18 +325,27 @@
 
 ;; ---- (5) project-work-ledger -------------------------------------------
 
+(defn- byte-keyed-ledger
+  "rf2-9e0tyq / rf2-hgy5kf — build the LIVE-shape `:rf.runtime/work-ledger`
+  map: keyed on the CEDN-1 byte `work-ledger/work-id-id` of each record's
+  `:work/id` VECTOR (exactly as `work-ledger/put-record` writes it). Input is
+  the author-friendly seq of records (each carrying its own `:work/id`)."
+  [records]
+  (into {}
+        (map (fn [record] [(work-ledger/work-id-id (:work/id record)) record]))
+        records))
+
 (def ^:private ledger
-  {[:rf.work/resource [session-scope :article/by-slug {:slug "welcome"}] 4]
-   {:work/id [:rf.work/resource [session-scope :article/by-slug {:slug "welcome"}] 4]
-    :work/kind :resource :resource/key [session-scope :article/by-slug {:slug "welcome"}]
-    :generation 4 :transport :rf.http/managed :status :running
-    :owners #{[:route :route/article "nav-1"]}
-    :causes [[:route-entry :route/article "nav-1"]]
-    :cancellable? true :started-at 100 :deadline-at 5100}
-   [:rf.work/resource [session-scope :article/by-slug {:slug "old"}] 1]
-   {:work/id [:rf.work/resource [session-scope :article/by-slug {:slug "old"}] 1]
-    :work/kind :resource :resource/key [session-scope :article/by-slug {:slug "old"}]
-    :generation 1 :status :completed :outcome {:ok true}}})
+  (byte-keyed-ledger
+    [{:work/id [:rf.work/resource [session-scope :article/by-slug {:slug "welcome"}] 4]
+      :work/kind :resource :resource/key [session-scope :article/by-slug {:slug "welcome"}]
+      :generation 4 :transport :rf.http/managed :status :running
+      :owners #{[:route :route/article "nav-1"]}
+      :causes [[:route-entry :route/article "nav-1"]]
+      :cancellable? true :started-at 100 :deadline-at 5100}
+     {:work/id [:rf.work/resource [session-scope :article/by-slug {:slug "old"}] 1]
+      :work/kind :resource :resource/key [session-scope :article/by-slug {:slug "old"}]
+      :generation 1 :status :completed :outcome {:ok true}}]))
 
 (deftest project-work-ledger-test
   (let [rows (h/project-work-ledger ledger)]
@@ -324,6 +353,15 @@
       (is (= 2 (count rows)))
       (is (= [:running :completed] (mapv :status rows)))
       (is (= [false true] (mapv :terminal? rows))))
+    (testing "the displayed :work-id is the KIND-PRESERVING :work/id VECTOR
+              (rf2-hgy5kf), NOT the opaque byte map-key — read from the record"
+      ;; the live ledger map IS byte-keyed (string keys); the row must still
+      ;; surface the kind-preserving work-id from the record's `:work/id`.
+      (is (every? string? (keys ledger)))
+      (let [r (first rows)]
+        (is (vector? (:work-id r)))
+        (is (= [:rf.work/resource [session-scope :article/by-slug {:slug "welcome"}] 4]
+               (:work-id r)))))
     (testing "host handles are structurally absent — only serializable facts"
       (let [r (first rows)]
         (is (= :resource (:kind r)))
@@ -672,9 +710,10 @@
     (let [prefix     (apply str (repeat 200 "x"))
           params-a   {:q (str prefix "-AAA")}
           params-b   {:q (str prefix "-BBB")}
-          entries*   {[session-scope :search/run params-a]
-                      {:resource/id :search/run :status :loaded :data {}
-                       :active-owners #{} :generation 1}}
+          entries*   (byte-keyed
+                       {[session-scope :search/run params-a]
+                        {:resource/id :search/run :status :loaded :data {}
+                         :active-owners #{} :generation 1}})
           rows       (h/project-instances entries* now)]
       ;; sanity: the two params DO summarize to the same truncated preview
       (is (= (:preview (h/summarize params-a)) (:preview (h/summarize params-b)))
@@ -703,9 +742,10 @@
     (let [scope-1   :rf/redacted                  ; an upstream-redacted scope
           scope-2   [:rf.scope/session {:tenant "t-1"}]
           scope-3   [:rf.scope/session {:tenant "t-9"}]
-          entries*  {[scope-2 :doc/get {:id 1}]
-                     {:resource/id :doc/get :status :loaded :data {}
-                      :active-owners #{} :generation 1}}
+          entries*  (byte-keyed
+                      {[scope-2 :doc/get {:id 1}]
+                       {:resource/id :doc/get :status :loaded :data {}
+                        :active-owners #{} :generation 1}})
           rows      (h/project-instances entries* now)]
       ;; A sub reading the SAME canonical scope as the entry → NO mismatch,
       ;; even though scope-2 summarizes to a redaction-aware preview.
@@ -740,10 +780,26 @@
       (is (= 1 (count (h/filter-instance-rows instance-rows {:tag [:article "welcome"]}))))
       (is (= 1 (count (h/filter-instance-rows instance-rows
                         {:owner [:route :route/article "nav-1"]})))))
-    (testing "select-raw-entries key-axis filter (scope/resource-id/params)"
+    (testing "select-raw-entries key-axis filter (scope/resource-id/params)
+              over BYTE-KEYED entries (rf2-hgy5kf) — matches each entry's
+              `:resource/key` stamp, NOT the opaque byte map-key. The old
+              map-key-matching impl returned ZERO matches for live byte-keyed
+              data (the byte map-key is a string, never `[scope rid params]`)."
+      ;; the live `:entries` map IS byte-keyed (string keys), the exact shape
+      ;; the old `scoped-key-matches?` could never match.
+      (is (every? string? (keys entries)))
       (is (= 2 (count (h/select-raw-entries entries {:resource-id :article/by-slug}))))
       (is (= 1 (count (h/select-raw-entries entries {:params {:slug "welcome"}}))))
-      (is (= 2 (count (h/select-raw-entries entries {:scope session-scope})))))
+      (is (= 2 (count (h/select-raw-entries entries {:scope session-scope}))))
+      ;; the selected map preserves the byte map-keys (the row identity) and
+      ;; the selected entry carries the matching `:resource/key`.
+      (let [sel (h/select-raw-entries entries {:params {:slug "welcome"}})]
+        (is (every? string? (keys sel)))
+        (is (= [session-scope :article/by-slug {:slug "welcome"}]
+               (:resource/key (first (vals sel))))))
+      ;; a params axis that matches NO entry is empty (no false-match on the
+      ;; opaque byte key).
+      (is (empty? (h/select-raw-entries entries {:params {:slug "nope"}}))))
     (testing "work filter axes incl. nav-token (matches an owner carrying it)"
       (is (= 1 (count (h/filter-work-rows work-rows {:status :running}))))
       (is (= 1 (count (h/filter-work-rows work-rows {:nav-token "nav-1"})))))


### PR DESCRIPTION
EP-0012 (Path Optics & Canonical Forms) best-practice review (rf2-hgy5kf). Three maintainability fixes where old storage/keying shapes leaked through after the CEDN-1 resource re-keying work. Pre-alpha masterpiece posture — no back-compat shims; ≥1 adversarial test per finding.

## F1 — Xray resource filters assumed scoped-key MAP keys

Runtime `:entries` are byte-keyed (rf2-9e0tyq): the map key is the opaque CEDN-1 byte `key-id` string; the kind-preserving `[scope rid params]` vector lives on the entry's `:resource/key`. `scoped-key-matches?`/`select-raw-entries` filtered by the map key, so a scope/resource-id/params filter returned **zero** matches for live byte-keyed data while tests passed against the dead vector-keyed shape.

- `select-raw-entries` now matches `(or (:resource/key entry) k)` (fallback for a legacy unstamped entry), docstring corrected to `{<key-id> <entry>}`.
- Same drift also fixed in `work-row` (now reads the record's kind-preserving `:work/id`, not the byte `work-id-id` map-key, for the displayed `:work-id` / `:stale-key`).
- Test fixtures (`entries`, two `entries*`, `ledger`) converted to the live byte-keyed shape via `state/key-id` / `work-ledger/work-id-id`, carrying `:resource/key` / `:work/id`. Adversarial assertions pin `(every? string? (keys entries))` + the right filter counts (the old impl would return 0) and confirm `:work-id` is the kind-preserving vector.

## F2 — stale vector-key work-ledger helper

`state/work-record-path` addressed `[work-ledger-key work-id]` while the canonical ledger key is byte identity (`work-ledger/record-path` → `[:rf.runtime/work-ledger (work-id-id work-id)]`). The lone test reader sat inside `(when rec …)`, making the assertion vacuous when the byte-keyed row lived elsewhere.

- Removed `state/work-record-path` (pre-alpha, no shim). `rg work-record-path` finds no live helper/caller.
- Updated the clear-resource test to read via `work-ledger/get-record` with a non-vacuous assertion (a present post-clear row MUST be terminal `:suppressed`).
- Added an adversarial test (`work-record-byte-keyed-address-is-canonical`) pinning the byte-keyed address as the one home and asserting the removed vector address holds nothing.
- Cleaned the stale `[:rf.runtime/work-ledger <work-id>]` comment in `events.cljc`.

## F3 — explicit nil params collapsed before schema validation

Both registrars' `validate+canonicalize-params` did `(or params {})`, folding an explicit whole-slot `{:params nil}` into `{}` before Malli/canonicalization — making a validation boundary also perform an accidental API default. Spec 016:70 + EP-0012:1316 say present-nil and absent are distinct unless explicitly elided; the `:params-schema` decides whether nil conforms.

- Added `state/missing-params` sentinel + `params-present?` / `default-omitted-params` (one shared vocabulary for both registrars). Omitted `:params` → `{}` (documented API default); explicit nil passes through to schema validation/canonicalization unchanged.
- Call sites thread presence from the raw payload: ensure/refetch core, `:rf.resource/remove`, the sub key resolver, and `:rf.mutation/execute`. Route planning (`route.cljc`) already produces a non-nil params map, unchanged.
- Adversarial tests: explicit-nil slot vs omitted are distinct canonical identities + distinct cache keys under `[:maybe :map]`; explicit-nil fails closed under a non-nilable `[:map …]` with nil reported in ex-data (resource + mutation); omitted still defaults to `{}`. (These complement the existing `{:x nil}` inner-value tests, which were never affected by `(or params {})`.)

## Quality gates

- `cd implementation/resources && clojure -M:test` — 399 tests, 1555 assertions, 0 failures (run post-rebase).
- `cd tools/xray && clojure -M:test` — 1172 tests, 5219 assertions, 0 failures.
- `npm run test:cljs` — 6960 tests, 28519 assertions, 0 failures.
- `npm run test:xray-feature-gate` — 16 scenarios, 0 failures, 13 matrix rows (all testbeds compiled 0 warnings).
- `mkdocs build --strict` — **not applicable**: the touched doc (`tools/xray/spec/024-Resources-Panel.md`) is the xray-internal normative spec; the mkdocs site builds from `docs/` (`docs_dir: docs`) and the Xray nav references `docs/xray/*.md`, not `tools/xray/spec/`. No mkdocs nav entry covers this file.

Closes rf2-hgy5kf.