### PR TITLE
refactor(core): narrow contributor catch + localize graph family mechanics (rf2-k0meap.8)

### DIFF
--- a/implementation/core/src/re_frame/derivation/graph.cljc
+++ b/implementation/core/src/re_frame/derivation/graph.cljc
@@ -43,7 +43,7 @@
     - `re-frame.subs.tooling` lives in core and IS required directly (it
       is always present).
     - The four optional siblings contribute through the `contributors`
-      argument — a `{family {:static-fn f :live-fn f :live-arity …}}`
+      argument — a `{family {:static-fn f :live-fn f :live-shape …}}`
       map. On the JVM `default-contributors` auto-resolves each sibling's
       tooling fns via `requiring-resolve` (returning only the families
       whose artefact is on the classpath); on CLJS the consuming tool
@@ -51,6 +51,18 @@
       contributor map explicitly. A family whose artefact is absent
       simply contributes no nodes — exactly the no-flows / no-resources
       story the five siblings already each honour.
+
+  FAMILY-AGNOSTIC ASSEMBLY (rf2-k0meap.8). The central assembler stitches
+  nodes + edges WITHOUT knowing any family's mechanics. Every
+  family-specific decision — how a family's projection keys lift into the
+  canonical node id, and how a node's declared projection yields edges —
+  lives in the family's CONTRIBUTOR CONTRACT (`:node-id-fn` / `:edge-fn`),
+  beside the family that owns it (see `family-contract` below). A
+  contributor that omits these inherits the per-family contract by family
+  key; a contributor that supplies its own participates without any edit
+  to the central `node-id` / `collect-*` / `graph-edges` functions — a NEW
+  family needs only a contributor (its own contract pieces or a new
+  `family-contract` entry), never a new conditional in the assembler.
 
   This is the *registrar-derived* slice (Derivations §The EP-0013
   relocation seam): the graph is assembled from the per-family algebra
@@ -72,8 +84,364 @@
 (def families
   "The five algebra-view families this helper composes (Derivations §Why
   this doc exists — the six surfaces, with runtime-subs folded into
-  `:subs`). Each maps to one tooling sibling's static + live projection."
+  `:subs`). Each maps to one tooling sibling's static + live projection.
+  This is the canonical READING ORDER; the assembler composes whatever
+  families a `contributors` map actually carries (a synthetic family beyond
+  these five participates too — rf2-k0meap.8), these first."
   [:subs :flows :resources :routes :machines])
+
+(defn- contributor-families
+  "The families to compose for a `contributors` map: the canonical
+  `families` (in reading order) that the map carries, followed by any EXTRA
+  families the map carries beyond the canonical five (a synthetic family —
+  rf2-k0meap.8). Family-agnostic: the assembler iterates THIS, never a
+  hard-coded family list, so a contributor-supplied family participates with
+  no central edit."
+  [contributors]
+  (let [present (filter #(contains? contributors %) families)
+        extra   (remove (set families) (keys contributors))]
+    (concat present extra)))
+
+;; ---------------------------------------------------------------------------
+;; Family-local node identity.
+;;
+;; Each family's projection returns nodes keyed by the family's natural key
+;; (sub-id, flow-id, route-id, resource-id, machine-id, or a concrete live
+;; key). The graph keys every node by its CANONICAL NODE ID (Derivations
+;; §Graph inspection — canonical node ids under EP-0012 identity rules): the
+;; `[:sub …] / [:flow …] / [:resource …] / [:machine …]` / `:rf/route`
+;; tagged form a tool draws edges between.
+;;
+;; Each family OWNS its node-id construction (rf2-k0meap.8) — a one-arg
+;; `(fn [node] -> node-id)` published on the contributor's `:node-id-fn`.
+;; The central collector calls it; it never branches on family. A NEW
+;; family supplies its own `:node-id-fn` (or a `family-contract` entry) and
+;; participates with no edit to the collector.
+;; ---------------------------------------------------------------------------
+
+(defn- sub-node-id
+  "The `:subs` family node id. A STATIC sub node's `:id` is the bare sub-id
+  keyword → `[:sub :cart/total]`; a LIVE cache-entry node's `:id` is the
+  concrete query vector → `[:sub [:cart/total …args]]`. Wrapping
+  unconditionally keeps every subscription node id uniformly `[:sub …]`."
+  [node]
+  [:sub (:id node)])
+
+(defn- flow-node-id
+  "The `:flows` family node id — FRAME-SCOPED (rf2-k0meap.2). The same
+  `flow-id` may register against two frames with different `:inputs` /
+  `:output` / `:path`, so the node id carries the owning frame to keep the
+  per-frame flow facts distinct (Derivations §Flows expose algebra views —
+  the view preserves `{frame-id {flow-id node}}`). The frame is read off
+  the node's `:owner` `[:frame <frame-id>]` (the lifecycle owner the flow
+  view stamps); absent an `:owner` the id degrades to `[:flow <flow-id>]`
+  (a hand-built fixture)."
+  [node]
+  (let [owner (:owner node)
+        id    (:id node)]
+    (if (and (vector? owner) (= :frame (first owner)))
+      [:flow (second owner) id]
+      [:flow id])))
+
+(defn- resource-node-id
+  "The `:resources` family node id — `[:resource <resource-id-or-scoped-key>]`."
+  [node]
+  [:resource (:id node)])
+
+(defn- machine-node-id
+  "The `:machines` family node id — `[:machine <machine-or-actor-id>]`."
+  [node]
+  [:machine (:id node)])
+
+(defn- route-node-id
+  "The `:routes` family node id. Every route materializes the ONE slice
+  fact `:rf/route` (Derivations §Routes expose algebra views), so a node's
+  own `:id` IS the node id — the per-route source-form id distinguishes
+  static route nodes by their map key, not by `:id` (see the route family's
+  `:static-key-fn` in `family-contract`)."
+  [node]
+  (:id node))
+
+;; ---------------------------------------------------------------------------
+;; Family-local edge extraction.
+;;
+;; Edges are explicit `{:from <node-id> :to <node-id> :role <role>}` records
+;; (Derivations §Graph inspection — explicit edge records). They are derived
+;; from each node's DECLARED projection — never by executing anything:
+;;
+;;   - `:input`    — a node's `[:sub q]` declared input → an edge from the
+;;                   upstream sub node to this node (every family carries the
+;;                   common input-edge derivation).
+;;   - `:param`    — a route node's `:resource-edges` (route-owned resource
+;;                   activation — Derivations §Route-owned resource
+;;                   activation edges) ride through verbatim; PLUS the live
+;;                   route-owned realized resource owner edges (live only).
+;;   - `:selector` — a machine `:process` node → each of the machine
+;;                   SELECTOR subscription nodes that read THAT machine
+;;                   (Derivations §Machines: selectors are ordinary
+;;                   derivations the machine draws a :selector edge to).
+;;
+;; A `:parametric` `:inputs` marker contributes NO static edges (the
+;; don't-execute rule — Derivations §Static and live graphs); its realized
+;; edges appear only in the live graph (where the live sub-cache node's
+;; `:inputs` are concrete `[:sub q]` forms).
+;;
+;; Each family OWNS the edges its nodes contribute BEYOND the common
+;; `:input` edges (rf2-k0meap.8) via the contributor's `:edge-fn`
+;; `(fn [ctx] -> [edges…])`, where `ctx` is the graph-wide assembly context
+;; `{:mode :nodes :node-ids …}`. The central assembler runs the common
+;; `:input` derivation over every node, then folds in each present family's
+;; `:edge-fn`. A family with no extra edges supplies no `:edge-fn`.
+;; ---------------------------------------------------------------------------
+
+(defn- sub-input-node-id
+  "Normalize a `[:sub query-vector]` DECLARED INPUT to the node id of the
+  subscription it names, in `mode`. In a `:static` graph, subscription
+  nodes are keyed by bare sub-id (`[:sub :cart/items]`), so a declared
+  input `[:sub [:cart/items …args]]` resolves to `[:sub :cart/items]` (the
+  query vector's head — the sub-id). In a `:live` graph, nodes are keyed
+  by the concrete query vector, so the input resolves to `[:sub
+  query-vector]` verbatim. This is what lets an edge's upstream end MATCH a
+  node key in the same graph."
+  [mode query-vector]
+  (if (= :static mode)
+    [:sub (if (vector? query-vector) (first query-vector) query-vector)]
+    [:sub query-vector]))
+
+(defn- input-edges
+  "Edges from one node's DECLARED `:inputs` (Derivations §Declared input).
+  Only `[:sub <query-vector>]` inputs become graph edges here — they name
+  another subscription node by its `[:sub …]` id, which is exactly the
+  canonical node id. `[:db …]` / `[:runtime …]` / `[:event …]` /
+  `[:param …]` / `[:scope …]` inputs name source facts / triggers that are
+  not (yet) nodes in the graph, so they do not become node→node edges. The
+  `:parametric` marker contributes nothing (the don't-execute rule).
+
+  This is the ONE edge derivation common to EVERY family (a node of any
+  family may declare `[:sub …]` inputs), so the central assembler runs it
+  over every node — it is NOT a per-family `:edge-fn`."
+  [mode to-id node]
+  (let [inputs (:inputs node)]
+    (if (or (not (sequential? inputs)) (= :parametric inputs))
+      []
+      (->> inputs
+           (keep (fn [in]
+                   (when (and (vector? in) (= :sub (first in)))
+                     {:from (sub-input-node-id mode (second in))
+                      :to   to-id
+                      :role :input})))
+           vec))))
+
+(defn- realized-route-owner
+  "The live route node's realized owner `[:route route-id nav-token]`, or
+  nil. The live route slice carries `:owner` when both the matched route id
+  and the nav-token are known (`route-slice-algebra-view`); a static route
+  node carries no `:owner`."
+  [node]
+  (let [owner (:owner node)]
+    (when (and (vector? owner) (= :route (first owner)))
+      owner)))
+
+(defn- route-edges
+  "The `:routes` family `:edge-fn`. Composes a route's STATIC route-owned
+  resource activation edges (`:resource-edges` — Derivations §Route-owned
+  resource activation edges) with the LIVE realized route-owned resource
+  owner edges (rf2-k0meap.1; live only).
+
+  STATIC: the sibling already produced `{:from … :to [:resource <id>]
+  :role :param :target :parametric}` records; we re-target `:from` to the
+  route node's id (the `:rf/route` slice the route materializes) and carry
+  the static `:resource` id + `:target` / `:blocking?` through verbatim.
+
+  LIVE ([Derivations.md] §Route-owned resource activation edges — \"The
+  realized resource owner edge (`[:route route-id nav-token]` → the
+  concrete scoped key) is LIVE state, surfaced by the live view\"): where
+  the STATIC graph marks a route's resource target `:parametric` (the
+  concrete scoped key requires a live match + scope resolution, so the
+  don't-execute rule withholds it), the LIVE graph RESOLVES that into a
+  concrete edge once navigation has committed and a scoped resource entry
+  is owned by the route. We read each live resource node's lifecycle owner
+  set (`:lifecycle :owners`): an owner shaped `[:route route-id nav-token]`
+  is a route-owned activation; we connect the matching LIVE route node (the
+  `:rf/route` slice whose realized `:owner` equals that owner) to the
+  concrete `[:resource <scoped-key>]` node, `:role :param`, carrying the
+  realized owner under `:owner`. Live-only: no realized owner edge in
+  `:static` mode (a static graph has no realized owners) and none when no
+  live route node carries a matching realized owner (an orphaned scope
+  owner — e.g. a `:rf.scope/global` activation — is not a route edge)."
+  [{:keys [mode nodes]}]
+  (let [static (->> nodes
+                    (mapcat (fn [[node-id node]]
+                              (when (= :rf/route (:id node))
+                                (->> (:resource-edges node)
+                                     (map (fn [edge]
+                                            (-> edge
+                                                (assoc :from node-id)
+                                                (update :to (fn [to]
+                                                              (if (vector? to)
+                                                                to
+                                                                [:resource to]))))))))))
+                    vec)
+        live   (if (not= :live mode)
+                 []
+                 (let [route-owners (into {}
+                                          (keep (fn [[node-id node]]
+                                                  (when-let [owner (realized-route-owner node)]
+                                                    [owner node-id])))
+                                          nodes)]
+                   (if (empty? route-owners)
+                     []
+                     (vec
+                      (for [[node-id node] nodes
+                            :when     (and (vector? node-id) (= :resource (first node-id)))
+                            owner     (get-in node [:lifecycle :owners])
+                            :when     (and (vector? owner) (= :route (first owner)))
+                            :let      [route-node-id (get route-owners owner)]
+                            :when     route-node-id]
+                        {:from  route-node-id
+                         :to    node-id
+                         :role  :param
+                         :owner owner})))))]
+    (into (vec static) live)))
+
+(defn- machine-edges
+  "The `:machines` family `:edge-fn`. The `:selector`-role edges from each
+  machine `:process` node to the machine-selector subscription nodes that
+  read THAT machine (Derivations §Machines: selectors are ordinary
+  derivations; the machine draws the `:selector` edge to them). The
+  `:selector-targets` extractor (the optional `machine-selector-targets`
+  fn on the `:machines` contributor) returns the SET of machine ids one
+  selector subscription reads.
+
+  Precise targeting (rf2-4qmiij): for each subscription node we ask which
+  machine ids it selects, then emit a `:selector` edge ONLY from each
+  `[:machine target-id]` node that actually EXISTS in the graph — never the
+  cross product of every machine against every selector. A selector that
+  names a machine which is not a node (unregistered / a different family)
+  contributes no edge for that target. Indexing is by the machine-node-id
+  SET so the scan is `O(subs × targets-per-sub)`, not `O(machines × subs)`.
+
+  Returns `[]` when the extractor or machine nodes are absent — the
+  don't-execute rule applies (the extractor reads registrar metadata, never
+  runs a sub body)."
+  [{:keys [node-ids selector-targets]}]
+  (let [machine-node-ids (->> node-ids (filter #(and (vector? %) (= :machine (first %)))))
+        subs-node-ids    (->> node-ids (filter #(and (vector? %) (= :sub (first %)))))]
+    (if (or (nil? selector-targets) (empty? machine-node-ids))
+      []
+      (let [machine-node-set (set machine-node-ids)]
+        (vec
+         (for [sub-id    subs-node-ids
+               :let      [raw (second sub-id)]            ;; [:sub <id-or-q>] → id|q
+               :let      [sid (if (vector? raw) (first raw) raw)]
+               :when     (keyword? sid)
+               target-id (selector-targets sid)
+               :let      [m-id [:machine target-id]]
+               :when     (contains? machine-node-set m-id)]
+           {:from m-id :to sub-id :role :selector}))))))
+
+;; ---------------------------------------------------------------------------
+;; The per-family CONTRACT (rf2-k0meap.8).
+;;
+;; Every family-specific decision the central assembler used to branch on
+;; lives HERE, beside the family, as DATA the central code reads uniformly:
+;;
+;;   :node-id-fn   (fn [node] -> node-id)   — lift the projection's node into
+;;                                            its canonical family-tagged id.
+;;   :static-key-fn (fn [proj-key] -> key)  — OPTIONAL: when a family keys its
+;;                                            STATIC projection by something
+;;                                            OTHER than the node-id (routes
+;;                                            key by the per-route source-form
+;;                                            id so per-route resource edges
+;;                                            are not collapsed onto the one
+;;                                            `:rf/route` slice). Defaults to
+;;                                            the node-id.
+;;   :flatten-fn   (fn [projection] -> {key node}) — OPTIONAL: when a family's
+;;                                            STATIC projection is not a flat
+;;                                            `{key node}` map (flows project
+;;                                            doubly-keyed `{frame-id {flow-id
+;;                                            node}}`). Defaults to identity.
+;;   :edge-fn      (fn [ctx] -> [edges…])    — OPTIONAL: the edges this family's
+;;                                            nodes contribute BEYOND the common
+;;                                            `:input` edges (routes own the
+;;                                            `:param` resource-activation edges;
+;;                                            machines own the `:selector`
+;;                                            edges). `ctx` is the graph-wide
+;;                                            `{:mode :nodes :node-ids
+;;                                            :selector-targets}`.
+;;
+;; A contributor MAY carry any of these directly (a synthetic / test family);
+;; otherwise the central assembler inherits them from this table by family
+;; key. Adding a NEW family = one entry here (or a self-describing
+;; contributor) — NO edit to `node-id`, the collectors, or `graph-edges`.
+;; ---------------------------------------------------------------------------
+
+(def family-contract
+  "The per-family graph contract — `:node-id-fn` (always) plus the optional
+  `:static-key-fn` / `:flatten-fn` / `:edge-fn` hooks (see the comment
+  above). The central assembler reads a contributor's own hook first and
+  falls back to this table by family key, so every family-specific
+  mechanic stays beside the family it describes and the assembler is
+  family-agnostic (rf2-k0meap.8)."
+  {:subs      {:node-id-fn sub-node-id}
+   :flows     {:node-id-fn flow-node-id
+               ;; flows project doubly-keyed {frame-id {flow-id node}} —
+               ;; flatten the frame dimension to a flat {[frame-id flow-id]
+               ;; node} map. The COMPOSITE key keeps two frames' same flow-id
+               ;; distinct through the flatten (a bare flow-id key would
+               ;; collapse them); the collector re-keys by the node's
+               ;; frame-scoped `:node-id-fn`, so the composite key is only a
+               ;; uniqueness device, not the final node id.
+               :flatten-fn (fn [projection]
+                             (into {}
+                                   (mapcat (fn [[frame-id flow-map]]
+                                             (map (fn [[flow-id node]]
+                                                    [[frame-id flow-id] node])
+                                                  flow-map)))
+                                   projection))}
+   :resources {:node-id-fn resource-node-id}
+   :routes    {:node-id-fn  route-node-id
+               ;; many source forms, one fact id (:rf/route) — key each
+               ;; STATIC route node by [:rf/route <source-form-id>] so
+               ;; per-route resource edges are not collapsed onto the one
+               ;; slice. The map's key is the per-route id; the node's :id
+               ;; is the shared :rf/route slice name.
+               :static-key-fn (fn [route-id] [:rf/route route-id])
+               :edge-fn     route-edges}
+   :machines  {:node-id-fn machine-node-id
+               :edge-fn    machine-edges}})
+
+(defn- contract-for
+  "The effective contract for `family` from its `contributor`: the
+  contributor's own hooks (a self-describing / synthetic family) layered
+  over the per-family `family-contract` defaults. A contributor that omits
+  every hook inherits the standard contract by family key; one that
+  supplies its own participates with NO central edit (rf2-k0meap.8)."
+  [family contributor]
+  (merge (get family-contract family)
+         (select-keys contributor [:node-id-fn :static-key-fn :flatten-fn :edge-fn])))
+
+(defn node-id
+  "The canonical graph node id for one algebra node in `family`
+  (Derivations §Graph inspection / §Fact identity). Delegates to the
+  family's `:node-id-fn` contract (rf2-k0meap.8) — the central code does
+  NOT branch on family. The family-tagged forms:
+
+    :subs      → `[:sub <id>]`  (bare sub-id keyword for a STATIC node;
+                 concrete query vector for a LIVE cache-entry node).
+    :flows     → `[:flow <frame-id> <flow-id>]` — FRAME-SCOPED; degrades to
+                 `[:flow <flow-id>]` for an `:owner`-less fixture.
+    :resources → `[:resource <resource-id-or-scoped-key>]`.
+    :machines  → `[:machine <machine-or-actor-id>]`.
+    :routes    → the route fact id `:rf/route` (every route materializes
+                 the ONE slice).
+
+  Provided for tools that need the canonical id of a single projection
+  node; the assembler uses the family contract directly."
+  [family node]
+  (if-let [f (:node-id-fn (get family-contract family))]
+    (f node)
+    [family (:id node)]))
 
 ;; ---------------------------------------------------------------------------
 ;; The contributor seam.
@@ -86,6 +454,10 @@
 ;;                       per-frame / resources / machines instances).
 ;; `:live-shape :node` — the live-fn returns ONE node or nil (the route
 ;;                       slice).
+;;
+;; A contributor MAY additionally carry its own contract hooks (`:node-id-fn`
+;; / `:static-key-fn` / `:flatten-fn` / `:edge-fn`) — see `family-contract`;
+;; omitting them inherits the standard per-family contract by family key.
 ;;
 ;; The `:static-fn` / `:live-fn` are usually two DISTINCT sibling fns (the
 ;; subs / resources / routes / machines pattern: a registration-derived
@@ -116,36 +488,115 @@
    :live-shape :map})
 
 #?(:clj
+   (defn- absent-ns-fnf?
+     "Is this `FileNotFoundException` the EXPECTED-absence signal for an
+     un-loaded optional family namespace `ns-sym` (vs a real transitive
+     load failure of a PRESENT namespace)? `requiring-resolve` of an absent
+     namespace throws an FNF whose message names that namespace's munged
+     resource path (`re_frame/flows/tooling__init.class, …`). A FNF naming
+     a DIFFERENT resource — a dep the present sibling failed to load — is a
+     real error, not expected absence. We match on the munged path so only
+     the requested namespace's own absence is tolerated (rf2-k0meap.8)."
+     [^java.io.FileNotFoundException e ns-sym]
+     ;; Clojure munges the namespace to a classpath resource path: dots →
+     ;; slashes AND dashes → underscores (re-frame.flows.tooling →
+     ;; re_frame/flows/tooling). The FNF message names that munged path, so
+     ;; the absence test must munge identically (both substitutions).
+     (let [munged (-> (name ns-sym)
+                      (.replace \- \_)
+                      (.replace \. \/))
+           msg    (str (.getMessage e))]
+       (boolean
+        (or (.contains msg (str munged "__init.class"))
+            (.contains msg (str munged ".clj"))
+            (.contains msg (str munged ".cljc")))))))
+
+#?(:clj
+   (defn- resolve-var
+     "JVM-only: resolve ONE fully-qualified `sym` via `requiring-resolve`,
+     distinguishing the three genuinely-different outcomes the broad
+     `catch Throwable` used to flatten into nil (rf2-k0meap.8):
+
+       - the symbol's NAMESPACE is absent from the classpath — the optional
+         artefact is not loaded. `requiring-resolve` throws a
+         `FileNotFoundException` naming that namespace; we return `::absent`,
+         the EXPECTED-absence signal a core-only / no-flows app produces.
+       - the namespace IS present but the VAR is missing — API drift (the
+         sibling renamed / dropped a tooling fn). `requiring-resolve`
+         returns nil with no throw; that is NOT expected absence, so we
+         throw an explicit `ex-info` rather than silently dropping the
+         family.
+       - the namespace throws DURING LOAD (an init/compile failure, or a
+         FileNotFoundException for a TRANSITIVE dep of a present ns) — a real
+         error. We do NOT catch it; it propagates.
+
+     Returns the resolved var on success, `::absent` for expected absence."
+     [sym]
+     (let [ns-sym   (symbol (namespace sym))
+           resolved (try
+                      (requiring-resolve sym)
+                      (catch java.io.FileNotFoundException e
+                        (if (absent-ns-fnf? e ns-sym)
+                          ::absent                       ;; expected absence
+                          (throw e))))]                  ;; real load failure
+       (cond
+         (= ::absent resolved) ::absent
+         (nil? resolved)
+         (throw (ex-info (str "re-frame.derivation.graph: optional contributor var "
+                              sym " is unresolvable though its namespace loaded — "
+                              "API drift, not expected absence (rf2-k0meap.8). "
+                              "A genuinely-absent optional family must throw "
+                              "FileNotFoundException for its namespace.")
+                         {:sym sym :ns ns-sym}))
+         :else resolved))))
+
+#?(:clj
    (defn- resolve-sibling
      "JVM-only: resolve one optional sibling's `[static-sym live-sym]`
-     tooling fns via `requiring-resolve`, returning a contributor map, or
-     nil when the artefact is absent from the classpath (the
-     `requiring-resolve` throws `FileNotFoundException` / returns nil).
-     Used by `default-contributors` so a core-only JVM process composes
-     only the families whose artefact is loaded — the no-flows /
-     no-resources story."
+     tooling fns into a contributor map, or nil when the artefact is absent
+     from the classpath (the no-flows / no-resources story). Used by
+     `default-contributors` so a core-only JVM process composes only the
+     families whose artefact is loaded.
+
+     Narrowed loading (rf2-k0meap.8): a genuinely-ABSENT family (its
+     namespace is not on the classpath) returns nil — that is the only
+     tolerated absence. A real load/init error or API drift (a present
+     namespace missing the expected var) is NOT masked as 'family absent':
+     it surfaces (`resolve-var` rethrows / throws ex-info). The broad
+     `catch Throwable _ nil` that used to swallow ALL of these is gone."
      [static-sym live-sym live-shape]
-     (try
-       (let [s (requiring-resolve static-sym)
-             l (requiring-resolve live-sym)]
-         (when (and s l)
-           {:static-fn @s :live-fn @l :live-shape live-shape}))
-       (catch java.io.FileNotFoundException _ nil)
-       (catch Throwable _ nil))))
+     (let [s (resolve-var static-sym)]
+       (if (= ::absent s)
+         nil                                            ;; expected absence
+         (let [l (resolve-var live-sym)]
+           (when-not (= ::absent l)                     ;; both present → contribute
+             {:static-fn @s :live-fn @l :live-shape live-shape}))))))
 
 (defn default-contributors
   "The default `{family contributor}` map.
 
   On the JVM, auto-resolves the four optional siblings' tooling fns via
   `requiring-resolve` (returning only the families whose artefact is on
-  the classpath) and always includes the in-core `:subs` contributor.
+  the classpath) and always includes the in-core `:subs` contributor. The
+  `:machines` contributor additionally carries the `machine-selector-targets`
+  extractor on `:selector-targets`, so the assembled graph draws PRECISE
+  machine→selector edges and refines the selector subscription nodes
+  (rf2-4qmiij / rf2-k0meap.2 / rf2-k0meap.8) — the machine selector-target
+  surface EP-0014's machine-selector refinement reads.
 
   On CLJS, returns ONLY the in-core `:subs` contributor — the consuming
   tool (which statically `:require`s the optional siblings it has) supplies
-  the rest via the `contributors` argument to `derivation-graph` /
-  `live-derivation-graph`. This keeps the four optional sibling bodies out
-  of a no-feature CLJS bundle (a static `:require` from this core ns would
-  defeat the bundle-isolation the siblings each guard with their sentinel)."
+  the rest (including the `:machines` `:selector-targets`) via the
+  `contributors` argument to `derivation-graph` / `live-derivation-graph`.
+  This keeps the four optional sibling bodies out of a no-feature CLJS
+  bundle (a static `:require` from this core ns would defeat the
+  bundle-isolation the siblings each guard with their sentinel).
+
+  Optional-loading diagnostics (rf2-k0meap.8): a genuinely-absent optional
+  family contributes nothing (the no-flows / no-resources story); but a
+  real load/init failure or API drift in a PRESENT sibling now SURFACES
+  rather than being silently masked as 'family absent' (see
+  `resolve-sibling` / `resolve-var`)."
   []
   (merge
    {:subs subs-contributor}
@@ -163,7 +614,8 @@
                       [family (cond-> c
                                 selector-targets-sym
                                 (assoc :selector-targets
-                                       (some-> (requiring-resolve selector-targets-sym) deref)))])))
+                                       (let [v (resolve-var selector-targets-sym)]
+                                         (when-not (= ::absent v) @v))))])))
             ;; flows reuse the ONE `flow-algebra-view` for both slots
             ;; (static = zero-arity all-frames, live = one-arity per-frame —
             ;; a flow has no separate ephemeral cache to snapshot; see the
@@ -180,117 +632,53 @@
       :cljs nil)))
 
 ;; ---------------------------------------------------------------------------
-;; Node identity + collection.
+;; Node collection.
 ;;
-;; Each family's projection returns nodes keyed by the family's natural key
-;; (sub-id, flow-id, route-id, resource-id, machine-id, or a concrete live
-;; key). The graph keys every node by its CANONICAL NODE ID (Derivations
-;; §Graph inspection — canonical node ids under EP-0012 identity rules): the
-;; `[:sub …] / [:flow …] / [:resource …] / [:machine …]` / `:rf/route`
-;; tagged form a tool draws edges between.
+;; The collectors are FAMILY-AGNOSTIC (rf2-k0meap.8): they read the family's
+;; contract (`:node-id-fn` / `:flatten-fn` / `:static-key-fn`) and never
+;; branch on family. Each collected node carries `:rf/family` so a tool can
+;; group or filter.
 ;; ---------------------------------------------------------------------------
 
-(defn node-id
-  "The canonical graph node id for one algebra node in `family`
-  (Derivations §Graph inspection / §Fact identity). The node's own `:id`
-  is the family-local fact identity; this lifts it into the family-tagged
-  node id the graph + its edges reference:
-
-    :subs      → `[:sub <id>]`, where `<id>` is the node's `:id`: a bare
-                 sub-id keyword for a STATIC node (`[:sub :cart/total]`), or
-                 the concrete query vector for a LIVE cache-entry node
-                 (`[:sub [:cart/total …args]]`). Wrapping unconditionally
-                 keeps every subscription node id uniformly tagged.
-    :flows     → `[:flow <frame-id> <flow-id>]` — flows are FRAME-SCOPED
-                 (the SAME `flow-id` may register against two frames with
-                 different `:inputs` / `:output` / `:path`), so the node id
-                 carries the owning frame to keep the per-frame flow facts
-                 distinct (Derivations §Flows expose algebra views — the
-                 view preserves `{frame-id {flow-id node}}`; rf2-k0meap.2).
-                 The frame is read off the node's `:owner` `[:frame
-                 <frame-id>]` (the lifecycle owner the flow view stamps);
-                 absent an `:owner` the id degrades to `[:flow <flow-id>]`.
-    :resources → `[:resource <resource-id-or-scoped-key>]`.
-    :machines  → `[:machine <machine-or-actor-id>]`.
-    :routes    → the route fact id `:rf/route` (every route materializes
-                 the ONE slice — Derivations §Routes expose algebra views;
-                 the per-route source-form id distinguishes static nodes)."
-  [family node]
-  (let [id (:id node)]
-    (case family
-      ;; a STATIC sub node's :id is the bare sub-id keyword → [:sub <id>];
-      ;; a LIVE cache-entry node's :id is the concrete query vector →
-      ;; [:sub [<id> …args]]. Both forms are valid sub node ids in their
-      ;; respective graphs.
-      :subs      [:sub id]
-      ;; FRAME-SCOPED flow id (rf2-k0meap.2): the flow view preserves the
-      ;; frame dimension (`{frame-id {flow-id node}}`), so a reused flow-id
-      ;; across two frames must NOT collapse onto one node slot. Read the
-      ;; owning frame off the node's `:owner` `[:frame <frame-id>]`; key the
-      ;; node `[:flow <frame-id> <flow-id>]`. A node without an `:owner`
-      ;; (a hand-built fixture) degrades to the legacy `[:flow <flow-id>]`.
-      :flows     (let [owner (:owner node)]
-                   (if (and (vector? owner) (= :frame (first owner)))
-                     [:flow (second owner) id]
-                     [:flow id]))
-      :resources [:resource id]
-      :machines  [:machine id]
-      :routes    id
-      [family id])))
-
-(defn- sub-input-node-id
-  "Normalize a `[:sub query-vector]` DECLARED INPUT to the node id of the
-  subscription it names, in `mode`. In a `:static` graph, subscription
-  nodes are keyed by bare sub-id (`[:sub :cart/items]`), so a declared
-  input `[:sub [:cart/items …args]]` resolves to `[:sub :cart/items]` (the
-  query vector's head — the sub-id). In a `:live` graph, nodes are keyed
-  by the concrete query vector, so the input resolves to `[:sub
-  query-vector]` verbatim. This is what lets an edge's upstream end MATCH a
-  node key in the same graph."
-  [mode query-vector]
-  (if (= :static mode)
-    [:sub (if (vector? query-vector) (first query-vector) query-vector)]
-    [:sub query-vector]))
+(defn- collect-nodes
+  "Lift one family's `{key node}` projection into `{node-id node}`, stamping
+  `:rf/family`. Family-agnostic: the `node-id-fn` from the family's contract
+  computes each canonical id."
+  [family node-id-fn projection]
+  (reduce-kv
+   (fn [acc _k node]
+     (assoc acc (node-id-fn node) (assoc node :rf/family family)))
+   {}
+   projection))
 
 (defn- family-static-nodes
   "Collect one family's STATIC nodes from its contributor, returning a
-  `{node-id node}` map (the node carries `:rf/family` so a tool can group
-  or filter by family). A family with no contributor (artefact absent)
-  contributes `{}`. Subs / flows / machines / resources project a
-  `{key node}` map; flows are doubly-keyed `{frame-id {flow-id node}}` so
-  we flatten the frame dimension; routes project `{route-id node}` (all
-  carrying the same `:rf/route` fact id, distinguished by source-form)."
+  `{node-id node}` map. A family with no contributor (artefact absent)
+  contributes `{}`. The family's contract drives the shape:
+
+    - `:flatten-fn` flattens a non-flat projection to `{key node}` (flows
+      project doubly-keyed `{frame-id {flow-id node}}`); defaults to
+      identity.
+    - `:static-key-fn` is applied to the (flattened) projection key when a
+      family keys its STATIC nodes by something OTHER than the node-id
+      (routes key by `[:rf/route <source-form-id>]` so per-route resource
+      edges are not collapsed onto the one `:rf/route` slice); defaults to
+      the `:node-id-fn`."
   [family contributor]
   (if-not contributor
     {}
-    (let [projection ((:static-fn contributor))]
-      (case family
-        ;; flows are keyed {frame-id {flow-id node}} — flatten to nodes.
-        :flows
-        (reduce-kv
-         (fn [acc _frame-id flow-map]
-           (reduce-kv
-            (fn [m _flow-id node]
-              (assoc m (node-id family node) (assoc node :rf/family family)))
-            acc
-            flow-map))
-         {}
-         projection)
-        ;; routes: many source forms, one fact id — key each STATIC route
-        ;; node by [:rf/route <source-form-id>] so per-route resource
-        ;; edges are not collapsed onto one slot.
-        :routes
-        (reduce-kv
-         (fn [acc route-id node]
-           (assoc acc [:rf/route route-id] (assoc node :rf/family family)))
-         {}
-         projection)
-        ;; subs / resources / machines: {natural-key node}.
-        (reduce-kv
-         (fn [acc _k node]
-           (assoc acc (node-id family node) (assoc node :rf/family family)))
-         {}
-         projection)))))
+    (let [{:keys [node-id-fn flatten-fn static-key-fn]} (contract-for family contributor)
+          projection ((:static-fn contributor))
+          flat       (if flatten-fn (flatten-fn projection) projection)]
+      (reduce-kv
+       (fn [acc k node]
+         ;; `:static-key-fn` (when a family keys its STATIC nodes by the
+         ;; projection KEY — routes by the per-route source-form id) wins;
+         ;; otherwise the canonical `:node-id-fn` of the NODE.
+         (assoc acc (if static-key-fn (static-key-fn k) (node-id-fn node))
+                (assoc node :rf/family family)))
+       {}
+       flat))))
 
 (defn- family-live-nodes
   "Collect one family's LIVE nodes for `frame-id`, returning `{node-id
@@ -298,121 +686,62 @@
   return `{key node}`; `:node` projections (the route slice) return ONE
   node or nil. A live-fn that returns nil (a missing/destroyed frame or an
   unmaterialized fact — or a production CLJS build where the body DCEs)
-  contributes `{}`."
+  contributes `{}`. Family-agnostic: the family's `:node-id-fn` keys every
+  live node (a LIVE route node IS keyed by its node-id — the `:rf/route`
+  slice — unlike the static per-route source-form key)."
   [family contributor frame-id]
   (if-not contributor
     {}
-    (let [live-fn (:live-fn contributor)
+    (let [{:keys [node-id-fn]} (contract-for family contributor)
+          live-fn (:live-fn contributor)
           result  (live-fn frame-id)]
       (case (:live-shape contributor)
         :node (if (nil? result)
                 {}
-                {(node-id family result) (assoc result :rf/family family)})
+                {(node-id-fn result) (assoc result :rf/family family)})
         ;; :map — {key node}; nil (prod DCE / missing frame) → {}.
-        (reduce-kv
-         (fn [acc _k node]
-           (assoc acc (node-id family node) (assoc node :rf/family family)))
-         {}
-         (or result {}))))))
+        (collect-nodes family node-id-fn (or result {}))))))
 
 ;; ---------------------------------------------------------------------------
-;; Edge extraction.
+;; Edge assembly.
 ;;
-;; Edges are explicit `{:from <node-id> :to <node-id> :role <role>}` records
-;; (Derivations §Graph inspection — explicit edge records). They are derived
-;; from each node's DECLARED projection — never by executing anything:
-;;
-;;   - `:input`    — a node's `[:sub q]` declared input → an edge from the
-;;                   upstream sub node to this node.
-;;   - `:param`    — a route node's `:resource-edges` (route-owned resource
-;;                   activation — Derivations §Route-owned resource
-;;                   activation edges) ride through verbatim.
-;;   - `:selector` — a machine `:process` node → each of the machine
-;;                   SELECTOR subscription nodes that read THAT machine
-;;                   (Derivations §Machines: selectors are ordinary
-;;                   derivations; the machine draws the `:selector` edge to
-;;                   them). The selector's TARGET machine ids are mined from
-;;                   its static `[:rf/machine …]` inputs (not the boolean
-;;                   recognizer), so the edge runs from the specific machine
-;;                   each selector reads — never the cross product
-;;                   (rf2-4qmiij). Computed by `machine-selector-edges`.
-;;
-;; A `:parametric` `:inputs` marker contributes NO static edges (the
-;; don't-execute rule — Derivations §Static and live graphs); its realized
-;; edges appear only in the live graph (where the live sub-cache node's
-;; `:inputs` are concrete `[:sub q]` forms).
+;; The central edge assembler is FAMILY-AGNOSTIC (rf2-k0meap.8): it runs the
+;; common `:input` derivation over EVERY node, then folds in each PRESENT
+;; family's `:edge-fn` (the edges that family's nodes own beyond `:input`).
 ;; ---------------------------------------------------------------------------
 
-(defn- input-edges
-  "Edges from one node's DECLARED `:inputs` (Derivations §Declared input).
-  Only `[:sub <query-vector>]` inputs become graph edges here — they name
-  another subscription node by its `[:sub …]` id, which is exactly the
-  canonical node id (`node-id :subs`). `[:db …]` / `[:runtime …]` /
-  `[:event …]` / `[:param …]` / `[:scope …]` inputs name source facts /
-  triggers that are not (yet) nodes in the graph, so they do not become
-  node→node edges. The `:parametric` marker contributes nothing (the
-  don't-execute rule)."
-  [mode to-id node]
-  (let [inputs (:inputs node)]
-    (if (or (not (sequential? inputs)) (= :parametric inputs))
-      []
-      (->> inputs
-           (keep (fn [in]
-                   (when (and (vector? in) (= :sub (first in)))
-                     {:from (sub-input-node-id mode (second in))
-                      :to   to-id
-                      :role :input})))
-           vec))))
+(defn- graph-edges
+  "Every edge across the assembled `nodes` map, in `mode` (`:static` /
+  `:live`). Composes the common per-node `:input` edges (every family) with
+  each present family's `:edge-fn` extra edges (routes → `:param`
+  resource-activation + live realized owner edges; machines → `:selector`
+  edges), de-duplicated. The assembler does NOT branch on family — it folds
+  the per-family `:edge-fn`s from `contributors` through one
+  graph-wide context (rf2-k0meap.8). `selector-targets` is threaded into
+  the context for the machine `:edge-fn`."
+  [mode nodes contributors selector-targets]
+  (let [node-ids (keys nodes)
+        ctx      {:mode mode :nodes nodes :node-ids node-ids
+                  :selector-targets selector-targets}
+        ;; the ONE edge derivation common to every family.
+        input    (reduce-kv
+                  (fn [acc node-id node]
+                    (into acc (input-edges mode node-id node)))
+                  []
+                  nodes)
+        ;; each PRESENT family's extra edges, from its contract :edge-fn.
+        extra    (mapcat
+                  (fn [family]
+                    (when-let [edge-fn (:edge-fn (contract-for family (get contributors family)))]
+                      (edge-fn ctx)))
+                  (contributor-families contributors))]
+    (->> (concat input extra)
+         distinct
+         vec)))
 
-(defn- resource-activation-edges
-  "A route node's `:resource-edges` (route-owned resource activation —
-  Derivations §Route-owned resource activation edges) lifted to graph
-  edges. The sibling already produced `{:from … :to [:resource <id>]
-  :role :param :target :parametric}` records; we re-target `:from` to this
-  route node's id (the `:rf/route` slice the route materializes) and carry
-  the static `:resource` id + `:target` / `:blocking?` through verbatim."
-  [from-id node]
-  (->> (:resource-edges node)
-       (map (fn [edge]
-              (-> edge
-                  (assoc :from from-id)
-                  (update :to (fn [to] (if (vector? to) to [:resource to]))))))
-       vec))
-
-(defn- machine-selector-edges
-  "The `:selector`-role edges from each machine `:process` node to the
-  machine-selector subscription nodes that read THAT machine (Derivations
-  §Machines: selectors are ordinary derivations; the machine draws the
-  `:selector` edge to them). `selector-targets` is the optional
-  `machine-selector-targets` extractor from the machines sibling (passed
-  through the `:machines` contributor's `:selector-targets` slot, or nil
-  when machines is absent): it returns the SET of machine ids one selector
-  subscription reads.
-
-  Precise targeting (rf2-4qmiij): for each subscription node we ask which
-  machine ids it selects, then emit a `:selector` edge ONLY from each
-  `[:machine target-id]` node that actually EXISTS in the graph — never the
-  cross product of every machine against every selector. A selector that
-  names a machine which is not a node (unregistered / a different family)
-  contributes no edge for that target. Indexing is by the machine-node-id
-  SET so the scan is `O(subs × targets-per-sub)`, not `O(machines × subs)`.
-
-  Returns `[]` when the extractor or machine nodes are absent — the
-  don't-execute rule applies (the extractor reads registrar metadata, never
-  runs a sub body)."
-  [machine-node-ids subs-node-ids selector-targets]
-  (if (or (nil? selector-targets) (empty? machine-node-ids))
-    []
-    (let [machine-node-set (set machine-node-ids)]
-      (vec
-       (for [sub-id    subs-node-ids
-             :let      [raw (second sub-id)]            ;; [:sub <id-or-q>] → id|q
-             :let      [sid (if (vector? raw) (first raw) raw)]
-             :when     (keyword? sid)
-             target-id (selector-targets sid)
-             :let      [m-id [:machine target-id]]
-             :when     (contains? machine-node-set m-id)]
-         {:from m-id :to sub-id :role :selector})))))
+;; ---------------------------------------------------------------------------
+;; The DerivationGraph assembly.
+;; ---------------------------------------------------------------------------
 
 (defn- selector-target-ids
   "The SET of `[:sub …]` node ids that are machine selectors (the `:to`
@@ -420,93 +749,6 @@
   refinement enrichment (rf2-k0meap.2)."
   [selector-edges]
   (into #{} (map :to) selector-edges))
-
-(defn- realized-route-owner
-  "The live route node's realized owner `[:route route-id nav-token]`, or
-  nil. The live route slice carries `:owner` when both the matched route id
-  and the nav-token are known (`route-slice-algebra-view`); a static route
-  node carries no `:owner`."
-  [node]
-  (let [owner (:owner node)]
-    (when (and (vector? owner) (= :route (first owner)))
-      owner)))
-
-(defn- live-route-resource-edges
-  "REALIZED route-owned resource owner edges (rf2-k0meap.1; [Derivations.md]
-  §Route-owned resource activation edges — \"The realized resource owner
-  edge (`[:route route-id nav-token]` → the concrete scoped key) is LIVE
-  state, surfaced by the live view\"; EP-0014 §Validation / Conformance —
-  the live graph reports route owners + realized parametric edges).
-
-  Where the STATIC graph marks a route's resource target `:parametric` (the
-  concrete scoped key requires a live match + scope resolution, so the
-  don't-execute rule withholds it), the LIVE graph RESOLVES that into a
-  concrete edge once navigation has committed and a scoped resource entry
-  is owned by the route. We read each live resource node's lifecycle owner
-  set (`:lifecycle :owners`, a set the resource cache view surfaces from the
-  entry's `:active-owners`): an owner shaped `[:route route-id nav-token]`
-  is a route-owned activation. We connect the matching LIVE route node (the
-  `:rf/route` slice whose realized `:owner` equals that owner) to the
-  concrete `[:resource <scoped-key>]` node, `:role :param`, carrying the
-  realized owner under `:owner` so a tool can show WHICH route lease keeps
-  the entry alive — preserving the static edge's `:param` role while
-  reporting the concrete scoped key the static edge could only mark
-  parametric.
-
-  Live-only: returns `[]` in `:static` mode (a static graph has no realized
-  owners) and `[]` when no live route node carries a matching realized
-  owner (an orphaned scope owner — e.g. a `:rf.scope/global` activation —
-  is not a route edge)."
-  [mode nodes]
-  (if (not= :live mode)
-    []
-    (let [route-owners (into {}
-                             (keep (fn [[node-id node]]
-                                     (when-let [owner (realized-route-owner node)]
-                                       [owner node-id])))
-                             nodes)]
-      (if (empty? route-owners)
-        []
-        (vec
-         (for [[node-id node] nodes
-               :when     (and (vector? node-id) (= :resource (first node-id)))
-               owner     (get-in node [:lifecycle :owners])
-               :when     (and (vector? owner) (= :route (first owner)))
-               :let      [route-node-id (get route-owners owner)]
-               :when     route-node-id]
-           {:from  route-node-id
-            :to    node-id
-            :role  :param
-            :owner owner}))))))
-
-(defn- graph-edges
-  "Every edge across the assembled `nodes` map, in `mode` (`:static` /
-  `:live`). Composes the per-node `:input` edges, the route `:param`
-  resource-activation edges, the REALIZED live route-owned resource edges
-  (`:live` only — rf2-k0meap.1), and the machine→selector `:selector`
-  edges, de-duplicated. `selector-targets` is the optional machine-selector
-  target extractor (nil when machines is absent)."
-  [mode nodes selector-targets]
-  (let [machine-ids (->> nodes keys (filter #(and (vector? %) (= :machine (first %)))) vec)
-        subs-ids    (->> nodes keys (filter #(and (vector? %) (= :sub (first %)))) vec)
-        per-node    (reduce-kv
-                     (fn [acc node-id node]
-                       (-> acc
-                           (into (input-edges mode node-id node))
-                           (cond->
-                             (= :rf/route (:id node))
-                             (into (resource-activation-edges node-id node)))))
-                     []
-                     nodes)
-        live-route  (live-route-resource-edges mode nodes)
-        selector    (machine-selector-edges machine-ids subs-ids selector-targets)]
-    (->> (concat per-node live-route selector)
-         distinct
-         vec)))
-
-;; ---------------------------------------------------------------------------
-;; The DerivationGraph assembly.
-;; ---------------------------------------------------------------------------
 
 (defn- mark-machine-selectors
   "Stamp `:refinement :machine-selector` on every subscription node that is
@@ -535,11 +777,12 @@
 
 (defn- assemble
   "Assemble a `DerivationGraph` from a `{node-id node}` map + a `:mode`.
-  Computes the edge set (the optional machine-selector target extractor
-  threads through `selector-targets`), then enriches selector subscription
-  nodes with the `:machine-selector` refinement (rf2-k0meap.2)."
-  [mode nodes selector-targets extra]
-  (let [edges          (graph-edges mode nodes selector-targets)
+  Computes the edge set (folding each present family's `:edge-fn`; the
+  optional machine-selector target extractor threads through
+  `selector-targets`), then enriches selector subscription nodes with the
+  `:machine-selector` refinement (rf2-k0meap.2)."
+  [mode nodes contributors selector-targets extra]
+  (let [edges          (graph-edges mode nodes contributors selector-targets)
         selector-edges (filter #(= :selector (:role %)) edges)
         nodes          (mark-machine-selectors nodes selector-edges)]
     (merge
@@ -592,9 +835,9 @@
                 (fn [acc family]
                   (merge acc (family-static-nodes family (get contributors family))))
                 {}
-                families)
+                (contributor-families contributors))
          selector-targets (get-in contributors [:machines :selector-targets])]
-     (assemble :static nodes selector-targets nil))))
+     (assemble :static nodes contributors selector-targets nil))))
 
 (defn live-derivation-graph
   "Return the LIVE `DerivationGraph` for `frame-id` — the full graph
@@ -636,9 +879,9 @@
                 (fn [acc family]
                   (merge acc (family-live-nodes family (get contributors family) frame-id)))
                 {}
-                families)
+                (contributor-families contributors))
          selector-targets (get-in contributors [:machines :selector-targets])]
-     (assemble :live nodes selector-targets {:frame frame-id}))))
+     (assemble :live nodes contributors selector-targets {:frame frame-id}))))
 
 ;; ---- bundle-isolation sentinel ------------------------------------------
 ;;

--- a/implementation/core/test/re_frame/derivation_graph_test.clj
+++ b/implementation/core/test/re_frame/derivation_graph_test.clj
@@ -501,3 +501,146 @@
       ;; is also gated on :live mode regardless.
       (is (not-any? #(= :param (:role %)) (:edges g))
           "the static graph emits no realized route-resource edge"))))
+
+;; ---- F1: narrowed optional-contributor loading (rf2-k0meap.8) -------------
+;;
+;; The optional-sibling resolver used to `(catch Throwable _ nil)` — masking a
+;; real load/init failure or API drift (a present namespace missing the
+;; expected tooling var) as if the FAMILY were absent. The narrowed resolver
+;; tolerates ONLY genuine namespace absence; everything else surfaces.
+
+(deftest resolve-var-tolerates-a-genuinely-absent-namespace
+  (testing "a symbol whose NAMESPACE is not on the classpath is EXPECTED
+            absence — resolve-var returns ::absent (the no-flows story)"
+    (is (= :re-frame.derivation.graph/absent
+           (#'graph/resolve-var 'totally.absent.optional.sibling/some-view))
+        "an un-loaded optional family namespace is tolerated as absent"))
+  (testing "a DASHED absent namespace is tolerated too — Clojure munges
+            dashes to underscores in the FNF resource path, so the absence
+            test must munge identically (the real sibling ns'es are dashed,
+            e.g. re-frame.flows.tooling)"
+    (is (= :re-frame.derivation.graph/absent
+           (#'graph/resolve-var 're-frame.totally-absent.optional-sibling/some-view))
+        "a dashed un-loaded optional family namespace is tolerated as absent")))
+
+(deftest resolve-var-surfaces-api-drift-a-present-ns-missing-the-var
+  (testing "a symbol whose NAMESPACE loads but whose VAR is missing is API
+            drift, NOT absence — resolve-var throws rather than masking it"
+    ;; clojure.string is always present; this var does not exist → the old
+    ;; broad catch would have swallowed this as 'family absent'.
+    (let [ex (try (#'graph/resolve-var 'clojure.string/this-tooling-var-does-not-exist)
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex)
+          "a present-namespace-missing-var surfaces an explicit error, not nil")
+      (is (re-find #"API drift" (ex-message ex))
+          "the error names API drift (a real load/resolution failure)")
+      (is (= 'clojure.string/this-tooling-var-does-not-exist (:sym (ex-data ex)))
+          "the error carries the offending symbol"))))
+
+(deftest resolve-var-resolves-a-present-var
+  (testing "a present namespace + present var resolves to the var (the happy path)"
+    (is (var? (#'graph/resolve-var 'clojure.string/upper-case))
+        "an existing tooling var resolves")))
+
+(deftest resolve-sibling-distinguishes-absence-from-failure
+  (testing "an absent optional sibling resolves to nil (the family contributes
+            nothing) — the no-flows / no-resources story"
+    (is (nil? (#'graph/resolve-sibling 'totally.absent.sibling/static-view
+                                       'totally.absent.sibling/live-view
+                                       :map))
+        "a genuinely-absent family yields nil (tolerated)"))
+  (testing "a present sibling-namespace missing its expected var SURFACES (it
+            is API drift, not absence) — the broad catch no longer masks it"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo #"API drift"
+          (#'graph/resolve-sibling 'clojure.string/static-view-does-not-exist
+                                   'clojure.string/live-view-does-not-exist
+                                   :map))
+        "a real load/resolution failure of a PRESENT namespace surfaces")))
+
+(deftest default-contributors-wires-the-machine-selector-targets-surface
+  (testing "the JVM default contributors wire the machine selector-target
+            extractor (EP-0014 machine-selector refinement reads it) — present
+            and callable, not dropped by the narrowed resolver (rf2-k0meap.8)"
+    (let [c (graph/default-contributors)]
+      (is (fn? (get-in c [:machines :selector-targets]))
+          "the :machines contributor carries a callable :selector-targets extractor")
+      ;; and the assembled default-contributors graph still draws the precise
+      ;; selector edge — the wiring is live end-to-end.
+      (rf/reg-machine :upload/main
+                      {:initial :idle :data {} :states {:idle {}}})
+      (rf/reg-sub :upload/progress
+                  :<- [:rf/machine :upload/main]
+                  (fn [snapshot _] snapshot))
+      (let [g   (graph/derivation-graph)            ;; zero-arg → default-contributors
+            sel (filter #(= :selector (:role %)) (:edges g))]
+        (is (some #(= % {:from [:machine :upload/main]
+                         :to   [:sub :upload/progress]
+                         :role :selector})
+                  sel)
+            "the default-contributor graph draws the precise machine→selector edge")))))
+
+;; ---- F2: family-agnostic assembly — a synthetic family participates -------
+;;
+;; The bead's structural test (rf2-k0meap.8): a NEW contributor family that
+;; supplies its OWN contract hooks (`:node-id-fn` / `:edge-fn`) composes into
+;; the graph — its nodes appear canonically keyed and its edges appear —
+;; WITHOUT any edit to the central `node-id` / collector / `graph-edges`
+;; family-specific conditionals (there are none left to edit). This proves the
+;; mechanics moved out of the assembler and onto the contributor contract.
+
+(deftest a-synthetic-family-participates-via-its-own-contract-hooks
+  (testing "a contributor with its own :node-id-fn + :edge-fn composes
+            into the graph with NO central family-specific edit"
+    (let [;; a synthetic family `:widgets` the core assembler has never heard
+          ;; of: it keys its nodes [:widget <id>] and draws a :wires edge from
+          ;; every widget to a fixed sink — mechanics that live ENTIRELY on the
+          ;; contributor, not in graph.cljc.
+          widget-contrib
+          {:static-fn  (constantly {:w/a {:id :w/a :kind :process}
+                                    :w/b {:id :w/b :kind :process}})
+           :live-shape :map
+           :live-fn    (constantly {})
+           :node-id-fn (fn [node] [:widget (:id node)])
+           :edge-fn    (fn [{:keys [node-ids]}]
+                         (for [nid node-ids
+                               :when (and (vector? nid) (= :widget (first nid)))]
+                           {:from nid :to [:widget :sink] :role :wires}))}
+          ;; pair it with the real subs family so the graph is non-degenerate.
+          contributors {:subs    (:subs all-contributors)
+                        :widgets widget-contrib}]
+      (rf/reg-sub :cart/items (fn [db _] (get-in db [:cart :items])))
+      (let [g     (graph/derivation-graph contributors)
+            nodes (:nodes g)
+            edges (:edges g)]
+        (testing "the synthetic family's nodes are canonically keyed by its
+                  OWN :node-id-fn (no central node-id branch needed)"
+          (is (contains? nodes [:widget :w/a]))
+          (is (contains? nodes [:widget :w/b]))
+          (is (= :widgets (get-in nodes [[:widget :w/a] :rf/family]))
+              "every node carries its :rf/family tag, set by the central collector"))
+        (testing "the real subs family still composes alongside it"
+          (is (contains? nodes [:sub :cart/items])))
+        (testing "the synthetic family's OWN :edge-fn edges appear (no central
+                  family-specific edge conditional needed)"
+          (is (some #(= % {:from [:widget :w/a] :to [:widget :sink] :role :wires}) edges))
+          (is (some #(= % {:from [:widget :w/b] :to [:widget :sink] :role :wires}) edges)))))))
+
+(deftest a-synthetic-family-needs-no-family-contract-entry
+  (testing "the synthetic family is NOT in core's `family-contract` table, yet
+            participates — proving the assembler reads the contract off the
+            CONTRIBUTOR, not a central registry (rf2-k0meap.8)"
+    (is (not (contains? @#'graph/family-contract :widgets))
+        "core has no built-in knowledge of the :widgets family")
+    ;; but it must be in `families` to be iterated — pin that the central
+    ;; `families` vector is the only thing a built-in family rides; a purely
+    ;; synthetic family must be added to a custom families list. Here we prove
+    ;; the contract-resolution path itself is contributor-first by calling the
+    ;; private collector directly with a contributor-carried node-id-fn.
+    (let [contrib {:static-fn  (constantly {:x {:id :x :kind :process}})
+                   :node-id-fn (fn [n] [:custom (:id n)])}
+          nodes   (#'graph/family-static-nodes :anything contrib)]
+      (is (= {[:custom :x] {:id :x :kind :process :rf/family :anything}} nodes)
+          "the collector keys by the contributor's OWN node-id-fn for a family
+           core has no contract entry for"))))


### PR DESCRIPTION
EP-0014 best-practice review of the derivation-graph contributor seam (rf2-k0meap.8). Two findings in `implementation/core/src/re_frame/derivation/graph.cljc`.

## F1 — narrow optional-contributor loading; keep machine selector-target wired

`resolve-sibling` used `(catch Throwable _ nil)`, masking real load/init failures and API drift (a present sibling namespace missing its expected tooling var) as if the *family were absent*.

Split into `resolve-var` + `absent-ns-fnf?`:
- **genuine absence** — a `FileNotFoundException` naming THAT namespace's munged resource path (dots→slashes **and** dashes→underscores, matching Clojure's munging) → tolerated (`::absent`); the no-flows / no-resources story.
- **API drift** — namespace loads but the var is missing (`requiring-resolve` returns nil, no throw) → explicit `ex-info` (no longer silently dropped).
- **real load error** — any other throwable / transitive-dep FNF → propagates.

The machine selector-target surface (`machine-selector-targets`) stays wired into the JVM `default-contributors` (now resolved through the same narrowed path), so EP-0014's machine-selector refinement reads it robustly — a machines-load error no longer silently drops the whole `:machines` contributor (incl. `:selector-targets`).

## F2 — localize family-specific graph mechanics; central assembler is family-agnostic

Family-specific node-id construction (`node-id` `case family`), static collection special cases for flows/routes (`family-static-nodes`), and route/machine edge extraction (`graph-edges`) lived in the central assembler — new families / shape changes required central edits.

Moved every family-specific mechanic onto a **per-family contract** (`:node-id-fn` / `:static-key-fn` / `:flatten-fn` / `:edge-fn`) in `family-contract`, read uniformly via `contract-for`. The central collectors + edge assembler are now family-agnostic: they run the one common `:input` edge derivation over every node and fold each present family's `:edge-fn`. A contributor may carry its own contract hooks; `derivation-graph` / `live-derivation-graph` compose whatever families a contributor map carries — a synthetic family beyond the canonical five participates **with no central edit**. Behavior preserved exactly (the merged graph tests + conformance + xray-feature-gate stay green).

## Spec

The contributor contract shape for the five real families is **unchanged** (`:static-fn` / `:live-fn` / `:live-shape` / `:selector-targets`) — the new hooks are optional and inherited from `family-contract`. So `spec/Derivations.md` §Graph inspection (which documents that consumer-facing shape) needs no edit. **Spec unchanged because the externally-observable contributor contract shape did not change.**

## Tests

`implementation/core/test/re_frame/derivation_graph_test.clj`:
- F1: absent namespace tolerated (incl. **dashed** ns'es — caught a munging bug); API drift surfaces with `ex-info`; present var resolves; `resolve-sibling` distinguishes absence from failure; `default-contributors` wires a callable `:machines` `:selector-targets` end-to-end.
- F2: a **synthetic `:widgets` family** participates via its own `:node-id-fn` + `:edge-fn` with no central edit; and the collector keys by a contributor's own `:node-id-fn` for a family core has no `family-contract` entry for.

## Quality gates

- core `clojure -M:test` (`re-frame.derivation-graph-test`): 20 tests / 80 assertions, **0 failures**.
- core `clojure -M:test` (full suite): **0 failures, 0 errors** (1409 tests).
- `npm run test:cljs`: **0 failures, 0 errors** (6956 tests) — exercises the Xray graph consumer + both conformance CLJS suites.
- derivation-conformance `clojure -M:test`: **0 failures, 0 errors** (15 tests / 318 assertions).
- `npm run test:xray-feature-gate` (the graph consumer): **0 failures, 16/16 scenarios**, 13 matrix rows. (A first run flaked 6 scenarios via an http-server process crash — `http-server exited unexpectedly`; a clean re-run was green, confirming the graph-consuming scenarios — routes-epochs ladder, machine-epochs stepper, deep machine inspector — pass.)
- `npm run test:bundle-isolation`: **PASS** (graph sentinel absent from production bundles; 40 internal sentinels absent).
- No facade export added/changed → no api-manifest regen needed. `*warn-on-reflection*` clean.

Closes rf2-k0meap.8.