### PR TITLE
fix(xray): remove retired :stale-key work-identity synonym (rf2-r1zjd0)

### DIFF
--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -159,10 +159,11 @@ stacked sections:
    current work id, active owners, owner count, tags, GC eligibility.
    `:stale?` / `:has-data?` are **derived** here (Spec 016 §Status
    semantics — never stored facts).
-3. **Work ledger** (per frame) — per work record: work id, kind, linked
+3. **Work ledger** (per frame) — per work record: work id (the single
+   attempt identity — one durable `:work/id` per record, no separate
+   stale-suppression synonym; Spec 016 §Ledger row retention), kind, linked
    resource key, generation, status (+ terminal flag), owners, causes
-   (summarized), stale-key (= work id — one identity per record, Spec 016
-   §Ledger row retention), cancellable?, deadline, attempt, transport,
+   (summarized), cancellable?, deadline, attempt, transport,
    outcome. **Raw host handles** (AbortControllers, timeout handles,
    promises) are structurally inaccessible — they live in side tables
    outside durable frame-state. Non-terminal (live) rows lead; the

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -644,7 +644,6 @@
        :terminal?    false
        :owners       [<owner> …]
        :causes       [<cause> …]            ; causes are summarized (may carry data)
-       :stale-key    <work-id>             ; one identity per record (= :work/id)
        :cancellable? true
        :deadline-at  1780752005100
        :attempt      2
@@ -657,8 +656,8 @@
         ;; on the opaque CEDN-1 byte `work-id-id` STRING; the kind-preserving
         ;; work-id VECTOR is carried on the record as `:work/id`. Read it from
         ;; there (fall back to the map key for a legacy record that lacks the
-        ;; stamp) so the displayed `:work-id` / `:stale-key` is the
-        ;; kind-preserving identity, NOT the byte string.
+        ;; stamp) so the displayed `:work-id` is the kind-preserving identity,
+        ;; NOT the byte string.
         work-id (or (:work/id record) map-key)]
     {:work-id      work-id
      :kind         (or (:work/kind record) (:kind record))
@@ -669,7 +668,6 @@
      :terminal?    (contains? terminal-work-statuses (:status record))
      :owners       (vec (:owners record))
      :causes       (mapv summarize (:causes record))
-     :stale-key    work-id
      :cancellable? (boolean (:cancellable? record))
      :deadline-at  (or (:deadline-at record) (:deadline record))
      :attempt      (or (:attempt record) (:retry-attempt record))

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
@@ -369,8 +369,14 @@
         (is (= 5100 (:deadline-at r)))
         ;; resource-key scope/params summarized
         (is (= "vector" (get-in r [:resource-key :scope :type])))
-        ;; one identity per record — stale-key = work-id (Spec 016)
-        (is (= (:work-id r) (:stale-key r)))))
+        ;; rf2-r1zjd0 / EP-0016 — SINGLE attempt identity: the row exposes
+        ;; exactly :work-id (= the record's :work/id); the retired :stale-key
+        ;; synonym MUST NOT be present (Spec 016 §Ledger row retention,
+        ;; spec/Managed-Effects.md — one work id, no stale-key synonym).
+        (is (= [:rf.work/resource [session-scope :article/by-slug {:slug "welcome"}] 4]
+               (:work-id r)))
+        (is (not (contains? r :stale-key))
+            "no second work-identity synonym in the projection")))
     (testing "causes summarized (may carry data)"
       (is (vector? (:causes (first rows)))))))
 


### PR DESCRIPTION
## Summary

EP-0016 correctness review (rf2-r1zjd0). The Xray Resources work-ledger projection re-introduced a **retired** second work-identity synonym `:stale-key` (emitted as `(= :work-id)`). The canon establishes **one** durable attempt identity:

- `spec/Managed-Effects.md:184` — ledger-backed async work uses `:work/id` as the single attempt identity, no `:stale-key`-style synonym.
- `spec/016-Resources.md:536` — the separate `:stale-key` is dropped.

Exposing a second synonym to tooling / AI consumers makes a non-normative field easy to depend on. Stance: pre-alpha masterpiece (CORRECTNESS), no back-compat shims.

## Changes

- `tools/xray/src/.../panels/resources_helpers.cljc` — drop the `:stale-key` emit from the `work-row` projection; remove its docstring entry and the `:stale-key` mention in the byte-keying comment. The row now exposes exactly `:work-id` (the record's kind-preserving `:work/id`).
- `tools/xray/test/.../panels/resources_helpers_cljs_test.cljc` — replace the `:work-id == :stale-key` equality assertion with: (a) the single canonical `:work/id` identity, and (b) an adversarial `(not (contains? r :stale-key))` check.
- `tools/xray/spec/024-Resources-Panel.md` — drop `stale-key` from the public §3 Work-ledger panel contract; reword to state the single attempt identity explicitly.

Builds on the just-merged rf2-hgy5kf byte-keying (`work-row` reads the record's kind-preserving `:work/id`). No replacement synonym introduced. The unrelated `rf2-ndb13` edn-inspector regression test (a different "stale-key" predicate bug) is intentionally out of scope.

## Quality gates

- `clojure -M:test` (tools/xray): 1181 tests, 5246 assertions — 0 failures, 0 errors
- `npm run test:xray-feature-gate`: 16 scenarios (nightly-full sweep), 0 failures, 13 matrix rows
- `npm run test:cljs`: 6972 tests, 28560 assertions — 0 failures, 0 errors
