### PR TITLE
refactor(core): EP-0017 slice-A.2 — rename :rf.world/inputs→:rf.cofx + flat reshape (rf2-alc1lf)

### DIFF
--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -60,7 +60,7 @@
 ;; plus the causal token — not of an ambient `localStorage` read at the write
 ;; site, which replay/restore could not reproduce. The host-boundary boot read
 ;; happens once, in `realworld.core/run`, and rides the boot dispatch token as
-;; `:rf.world/inputs {:storage {:jwt-token …}}`.
+;; the flat recordable coeffect `:rf.cofx {:auth.session/stored-token …}`.
 (defn read-jwt-from-storage
   "Host-boundary read of the saved JWT from localStorage (or nil). Called from
    `realworld.core/run` so the token rides the boot dispatch token as a causal
@@ -73,19 +73,19 @@
 (rf/reg-cofx :auth.session/token
   {:doc "Inject the saved JWT (or nil) into coeffects.
 
-         EP-0010 recordable storage coeffect (the `:app/now-ms` pattern,
-         EP-0010 §Backwards Compatibility): returns the captured
-         `(get-in cofx [:rf.world/inputs :storage :jwt-token])` value when the
-         boot token supplied one (replay / restore / test fixtures get the exact
+         EP-0010 / EP-0017 recordable storage coeffect (the `:app/now-ms`
+         pattern, EP-0010 §Backwards Compatibility): returns the captured
+         `(:auth.session/stored-token (:rf.cofx cofx))` value when the boot
+         token supplied one (replay / restore / test fixtures get the exact
          recorded value, no host re-read), falling back to a live
          `read-jwt-from-storage` host read only when none was supplied — i.e.
          when building a fresh live token at the boundary where reading the host
          IS correct."}
   (fn cofx-auth-session-token [ctx _]
-    (let [world (get-in ctx [:coeffects :rf.world/inputs])]
+    (let [cofx (get-in ctx [:coeffects :rf.cofx])]
       (rf/assoc-coeffect ctx :auth.session/token
-                         (if (contains? (:storage world) :jwt-token)
-                           (get-in world [:storage :jwt-token])
+                         (if (contains? cofx :auth.session/stored-token)
+                           (:auth.session/stored-token cofx)
                            (read-jwt-from-storage))))))
 
 ;; ============================================================================

--- a/examples/reagent/realworld/http.cljs
+++ b/examples/reagent/realworld/http.cljs
@@ -185,30 +185,30 @@
 ;; `(.getTime (js/Date.))` at handler-run time cannot guarantee.
 ;;
 ;; The framework stamps that fact once, at the causal boundary, onto every
-;; dispatch envelope as `:rf.world/inputs {:time-ms ...}`, and exposes it as
-;; a built-in event-context coeffect. Tests, SSR hydration, and replay
-;; fixtures supply an exact `:time-ms` via the dispatch opts; live code lets
-;; the router stamp it.
+;; dispatch envelope as `:rf.cofx {:rf/time-ms ...}` (EP-0017 flat recordable
+;; coeffects), and exposes it as a built-in event-context coeffect. Tests, SSR
+;; hydration, and replay fixtures supply an exact `:rf/time-ms` via the dispatch
+;; opts; live code lets the router stamp it.
 ;;
 ;; The handlers below were written against an `:realworld/now` cofx, so this
 ;; example keeps that recognizable source form (the EP-0010-sanctioned
 ;; migration, §Backwards Compatibility) but moves its SOURCE from the host
-;; clock to the envelope: the cofx now reads `:time-ms` off `:rf.world/inputs`
+;; clock to the envelope: the cofx now reads `:rf/time-ms` off `:rf.cofx`
 ;; instead of calling `(.getTime (js/Date.))`. A greenfield handler would skip
-;; the cofx entirely and destructure `:rf.world/keys [inputs]` directly —
+;; the cofx entirely and destructure the `:rf.cofx` coeffect directly —
 ;; `realworld_resources/` shows that path, where managed resources stamp
 ;; `:loaded-at` from the same envelope time internally.
 
 (rf/reg-cofx :realworld/now
   {:doc "Inject the causal wall-clock time (ms since epoch) into coeffects
          under `:realworld/now`, read from the dispatch envelope's
-         `:rf.world/inputs` `:time-ms` (EP-0010) rather than the host clock,
-         so `:loaded-at` durable writes are replay-deterministic. Use
+         `:rf.cofx` `:rf/time-ms` (EP-0010 / EP-0017) rather than the host
+         clock, so `:loaded-at` durable writes are replay-deterministic. Use
          `(rf/inject-cofx :realworld/now)` on any handler that stamps
          `:loaded-at`."}
   (fn cofx-realworld-now [ctx]
     (rf/assoc-coeffect ctx :realworld/now
-                       (:time-ms (rf/get-coeffect ctx :rf.world/inputs)))))
+                       (:rf/time-ms (rf/get-coeffect ctx :rf.cofx)))))
 
 ;; ============================================================================
 ;; FAILURE PROJECTION

--- a/examples/reagent/realworld_resources/auth.cljs
+++ b/examples/reagent/realworld_resources/auth.cljs
@@ -77,7 +77,8 @@
 ;; plus the causal token — not of an ambient `localStorage` read at the write
 ;; site, which replay/restore could not reproduce. The host-boundary boot read
 ;; happens once, in `realworld-resources.core/run`, and rides the boot dispatch
-;; token as `:rf.world/inputs {:storage {:jwt-token …}}`.
+;; token as the flat recordable coeffect
+;; `:rf.cofx {:realworld-resources.session/stored-token …}`.
 (defn read-jwt-from-storage
   "Host-boundary read of the saved JWT from localStorage (or nil). Called from
    `realworld-resources.core/run` so the token rides the boot dispatch token as
@@ -90,19 +91,19 @@
 (rf/reg-cofx :realworld-resources.session/token
   {:doc "Inject the saved JWT (or nil) into coeffects.
 
-         EP-0010 recordable storage coeffect (the `:app/now-ms` pattern,
-         EP-0010 §Backwards Compatibility): returns the captured
-         `(get-in cofx [:rf.world/inputs :storage :jwt-token])` value when the
-         boot token supplied one (replay / restore / test fixtures get the exact
-         recorded value, no host re-read), falling back to a live
+         EP-0010 / EP-0017 recordable storage coeffect (the `:app/now-ms`
+         pattern, EP-0010 §Backwards Compatibility): returns the captured
+         `(:realworld-resources.session/stored-token (:rf.cofx cofx))` value when
+         the boot token supplied one (replay / restore / test fixtures get the
+         exact recorded value, no host re-read), falling back to a live
          `read-jwt-from-storage` host read only when none was supplied — i.e.
          when building a fresh live token at the boundary where reading the host
          IS correct."}
   (fn [ctx _]
-    (let [world (get-in ctx [:coeffects :rf.world/inputs])]
+    (let [cofx (get-in ctx [:coeffects :rf.cofx])]
       (rf/assoc-coeffect ctx :realworld-resources.session/token
-                         (if (contains? (:storage world) :jwt-token)
-                           (get-in world [:storage :jwt-token])
+                         (if (contains? cofx :realworld-resources.session/stored-token)
+                           (:realworld-resources.session/stored-token cofx)
                            (read-jwt-from-storage))))))
 
 ;; ============================================================================

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -65,14 +65,15 @@
   (rf/init! reagent-adapter/adapter)
   (rf/reg-frame app-frame {:doc "TodoMVC demo frame." :url-bound? true})
   (rf/with-frame app-frame
-    ;; EP-0010 (rf2-lk86xl): read the saved todos from localStorage HERE, at the
-    ;; host/boot boundary, and ride them on the boot token as a causal world
-    ;; input — never as an ambient `localStorage` read in the `:todo/initialise`
-    ;; durable handler. The router preserves this supplied `:rf.world/inputs` and
-    ;; only fills the framework-required `:time-ms`; the recordable
-    ;; `:todo.storage/todos` cofx (db.cljs) returns this captured value exactly.
+    ;; EP-0010 / EP-0017 (rf2-lk86xl): read the saved todos from localStorage
+    ;; HERE, at the host/boot boundary, and ride them on the boot token as a flat
+    ;; recordable coeffect — never as an ambient `localStorage` read in the
+    ;; `:todo/initialise` durable handler. The router preserves this supplied
+    ;; `:rf.cofx` and only fills the framework-required `:rf/time-ms`; the
+    ;; recordable `:todo.storage/todos` cofx (db.cljs) returns this captured value
+    ;; exactly.
     (rf/dispatch-sync [:todo/initialise]
-                      {:rf.world/inputs {:storage {:todos (db/read-todos-from-storage)}}})
+                      {:rf.cofx {:todo.storage/todos (db/read-todos-from-storage)}})
     (rf/dispatch-sync [:rf.route/handle-url-change (current-path)]))
   (.removeEventListener js/window "hashchange" on-hashchange)
   (.addEventListener js/window "hashchange" on-hashchange)

--- a/examples/reagent/todomvc/db.cljs
+++ b/examples/reagent/todomvc/db.cljs
@@ -34,12 +34,12 @@
 ;; write must be a function of prior frame-state plus the causal token — not of
 ;; an ambient `localStorage` read at the write site (which replay/restore could
 ;; not reproduce). So the host-boundary boot read happens once, in
-;; `todomvc.core/run`, and rides the boot dispatch token as
-;; `:rf.world/inputs {:storage {:todos …}}`.
+;; `todomvc.core/run`, and rides the boot dispatch token as the flat recordable
+;; coeffect `:rf.cofx {:todo.storage/todos …}`.
 ;;
 ;; This cofx is the RECORDABLE migration target the EP blesses (the `:app/now-ms`
 ;; pattern, EP-0010 §Backwards Compatibility): it reads the captured storage
-;; value off `:rf.world/inputs` and returns it exactly under replay / restore /
+;; value off `:rf.cofx` and returns it exactly under replay / restore /
 ;; test fixtures. It falls back to a live host read ONLY when no storage was
 ;; supplied on the token — i.e. when building a fresh live token at the boundary
 ;; where reading the host IS correct. Either way the value is always coerced to a
@@ -62,14 +62,14 @@
 (rf/reg-cofx :todo.storage/todos
   {:doc "Inject the saved TodoMVC items into coeffects as a sorted-map.
 
-         EP-0010 recordable storage coeffect: returns the captured
-         `(get-in cofx [:rf.world/inputs :storage :todos])` value when the boot
-         token supplied one (replay / restore / test fixtures get the exact
-         recorded value, no host re-read); falls back to a live
-         `read-todos-from-storage` host read only when none was supplied. Always
-         a sorted-map (never nil) so the allocate-next-id invariant holds."}
+         EP-0010 / EP-0017 recordable storage coeffect: returns the captured
+         `(:todo.storage/todos (:rf.cofx cofx))` value when the boot token
+         supplied one (replay / restore / test fixtures get the exact recorded
+         value, no host re-read); falls back to a live `read-todos-from-storage`
+         host read only when none was supplied. Always a sorted-map (never nil)
+         so the allocate-next-id invariant holds."}
   (fn cofx-todo-storage-todos [ctx]
-    (let [recorded (get-in ctx [:coeffects :rf.world/inputs :storage :todos])
+    (let [recorded (get-in ctx [:coeffects :rf.cofx :todo.storage/todos])
           todos    (cond
                      (map? recorded) (into (sorted-map) recorded)
                      (some? recorded) (sorted-map)

--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -122,15 +122,15 @@
 
   Consumed by event handlers via `inject-cofx` placed in the
   interceptor-vector slot of `reg-event-{db,fx,ctx}`. A DURABLE timestamp
-  reads the causal world input (EP-0010 §The World-Input Rule) — the
-  framework stamps `:time-ms` (wall-clock epoch ms) into `:rf.world/inputs`
-  once at the dispatch boundary, so a durable write that folds it stays
-  replay-/restore-/SSR-stable. It is read from the framework coeffect, not
-  a fresh host-clock cofx:
+  reads the causal recordable coeffect (EP-0010 §The World-Input Rule) — the
+  framework stamps `:rf/time-ms` (wall-clock epoch ms) into the flat
+  `:rf.cofx` map once at the dispatch boundary, so a durable write that folds
+  it stays replay-/restore-/SSR-stable. It is read from the framework
+  coeffect, not a fresh host-clock cofx:
 
       (rf/reg-event-fx :user/save
-        (fn [{:keys [db] :rf.world/keys [inputs]} [_ user]] ;; <-- read here
-          {:db (assoc db :saved-at (:time-ms inputs)        ;; durable epoch ms
+        (fn [{:keys [db] cofx :rf.cofx} [_ user]]           ;; <-- read here
+          {:db (assoc db :saved-at (:rf/time-ms cofx)       ;; durable epoch ms
                          :user user)}))
 
   A raw host-clock cofx (`(js/Date.)`) is for DIAGNOSTIC / host-transient
@@ -187,7 +187,7 @@
   cofx whose value is genuinely user-injected and recordable (a stub, a
   fixture seam, a DIAGNOSTIC reading) is the right tool here; a value that
   feeds a DURABLE app-db write must be a recordable causal input — the
-  framework `:rf.world/inputs` coeffect for time / generated ids (EP-0010),
+  framework `:rf.cofx` coeffect for time / generated ids (EP-0010 / EP-0017),
   not a fresh ambient host read at the write site:
 
       (rf/reg-cofx :stub-config
@@ -395,22 +395,23 @@
 ;; Migration, reference-implementation step 7). It is the migration target for
 ;; the v1-style `(inject-cofx :now)` source shape: handlers that need a
 ;; wall-clock instant for a DURABLE write read it from the dispatch envelope's
-;; causal `:rf.world/inputs` `:time-ms` (the one host-clock read the router
-;; stamped at the causal boundary — Spec 002 §The World-Input Rule) rather than
-;; calling `interop/now-ms` / `(.now js/Date)` ambiently at the write site.
+;; causal `(:rf/time-ms (:rf.cofx coeffects))` (the one host-clock read the
+;; router stamped at the causal boundary — Spec 002 §The World-Input Rule)
+;; rather than calling `interop/now-ms` / `(.now js/Date)` ambiently at the
+;; write site.
 ;;
-;; Because the value is sourced from `:rf.world/inputs` — already captured in
+;; Because the value is sourced from `:rf.cofx` — already captured in
 ;; the replay record and projected/elided like other replayable event data —
 ;; this cofx is RECORDABLE: a scripted / replayed / SSR-hydration dispatch that
-;; supplies an exact `:rf.world/inputs {:time-ms …}` sees that exact value
+;; supplies an exact `:rf.cofx {:rf/time-ms …}` sees that exact value
 ;; returned, with NO ambient clock read. That satisfies the durable-coeffect
 ;; requirement (Spec 002 §Event Context And Coeffects: "a coeffect that can
 ;; affect durable state MUST be recordable").
 ;;
-;; `:rf.world/inputs` is a framework coeffect the runtime seeds into every
+;; `:rf.cofx` is a framework coeffect the runtime seeds into every
 ;; event context (`re-frame.router/build-envelope`), so this cofx is a pure
 ;; read of an already-present coeffect — no host call of its own. When
-;; `:rf.world/inputs` is absent (a handler invoked outside the dispatch path)
+;; `:rf.cofx` is absent (a handler invoked outside the dispatch path)
 ;; the injected value is `nil`; a durable handler MUST get its time from a
 ;; stamped envelope.
 ;;
@@ -418,7 +419,7 @@
 ;; path ships in this initial slice.
 
 (reg-cofx :app/now-ms
-  {:doc "EP-0010 compatibility time coeffect. Injects the dispatch envelope's causal `(:time-ms (:rf.world/inputs cofx))` under `:coeffects :app/now-ms` — the recordable migration target for v1-style host-clock reads (`interop/now-ms` / `(.now js/Date)`) in durable handlers. Reads only the already-seeded `:rf.world/inputs` coeffect; performs no ambient clock read, so a scripted/replayed `:time-ms` is returned exactly. nil when `:rf.world/inputs` is absent (a handler invoked outside the dispatch path)."}
+  {:doc "EP-0010 compatibility time coeffect. Injects the dispatch envelope's causal `(:rf/time-ms (:rf.cofx coeffects))` under `:coeffects :app/now-ms` — the recordable migration target for v1-style host-clock reads (`interop/now-ms` / `(.now js/Date)`) in durable handlers. Reads only the already-seeded `:rf.cofx` coeffect; performs no ambient clock read, so a scripted/replayed `:rf/time-ms` is returned exactly. nil when `:rf.cofx` is absent (a handler invoked outside the dispatch path)."}
   (fn [ctx]
-    (let [world (get-in ctx [:coeffects :rf.world/inputs])]
-      (assoc-in ctx [:coeffects :app/now-ms] (:time-ms world)))))
+    (let [cofx (get-in ctx [:coeffects :rf.cofx])]
+      (assoc-in ctx [:coeffects :app/now-ms] (:rf/time-ms cofx)))))

--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1133,8 +1133,8 @@
 ;; is moot there).
 (def ^:dynamic *cascade-frame-state-before* nil)
 
-;; rf2-bh56rc: the in-flight dequeued event's causal `:time-ms` (the
-;; `:rf.world/inputs` `:time-ms` stamped on its envelope at the causal
+;; rf2-bh56rc: the in-flight dequeued event's causal `:rf/time-ms` (the
+;; `:rf.cofx` `:rf/time-ms` stamped on its envelope at the causal
 ;; boundary), bound by the router around `process-event!` alongside
 ;; `*cascade-frame-state-before*`. A handler that calls `destroy-frame!`
 ;; on its own frame mid-drain runs INSIDE this binding, so the
@@ -1531,7 +1531,7 @@
   step 6) does not have to read a container that is already gone — the
   root cause of the prior nil-`:db-before` / nil-`:db-after` records.
 
-  `committed-at` (rf2-bh56rc) is the destroying event's causal `:time-ms`
+  `committed-at` (rf2-bh56rc) is the destroying event's causal `:rf/time-ms`
   (the router-bound `*cascade-time-ms*`), threaded so the `:halted-destroy`
   record's `:committed-at` is replayable per EP-0010 §Time rather than an
   ambient host-clock read. nil outside a drain (the moot out-of-cascade

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -228,9 +228,9 @@
 ;; §Cascade propagation (line 1162) and §Drain-loop pseudocode
 ;; `inheritable-envelope-keys` (lines 947-952). `:event` is NOT
 ;; inherited — the child gets its own.
-;; Per EP-0010 (rf2-s9ss0t) `:rf.world/inputs` is ALSO not inherited —
-;; a child dispatch is a DISTINCT causal token, so `build-envelope`
-;; stamps it a fresh `:time-ms` rather than copying the parent's (Spec
+;; Per EP-0010 (rf2-s9ss0t) / EP-0017 (rf2-alc1lf) `:rf.cofx` is ALSO not
+;; inherited — a child dispatch is a DISTINCT causal token, so `build-envelope`
+;; stamps it a fresh `:rf/time-ms` rather than copying the parent's (Spec
 ;; 002 §Dispatch Envelope Stamping). Its absence from this list is the
 ;; mechanism. (`:dispatched-at` was retired in the same change — EP-0010
 ;; rider b — so there is nothing left to exclude on that axis.)
@@ -940,12 +940,12 @@
   coeffect is gone, rf2-1m6rf1) are the EP-0001 partition coeffects,
   likewise injected by `assemble-initial-ctx` — framework defaults, not
   user cofx (rf2-bvwoi4).
-  `:rf.world/inputs` (the EP-0010 causal world-input map, rf2-s9ss0t) is
-  a framework coeffect stamped at envelope construction, so it is
-  filtered out here exactly like the other framework defaults — the
+  `:rf.cofx` (the EP-0017 flat recordable-coeffect map, rf2-s9ss0t /
+  rf2-alc1lf) is a framework coeffect stamped at envelope construction, so it
+  is filtered out here exactly like the other framework defaults — the
   COEFFECTS section shows only genuinely user-injected coeffects (Spec
   002 §Event Context And Coeffects)."
-  #{:db :event :source :trace-id :rf.db/runtime :rf.frame/id :rf.world/inputs})
+  #{:db :event :source :trace-id :rf.db/runtime :rf.frame/id :rf.cofx})
 
 (defn user-injected-coeffects
   "Project the user-injected subset of a coeffects map. Pure data → data.

--- a/implementation/core/src/re_frame/interop.clj
+++ b/implementation/core/src/re_frame/interop.clj
@@ -181,7 +181,7 @@
 
 (defn epoch-now-ms
   "Wall-clock epoch milliseconds — the canonical source for EP-0010 durable
-  causal time (`:rf.world/inputs` `:time-ms`). On the JVM this coincides with
+  causal time (`:rf.cofx` `:rf/time-ms`). On the JVM this coincides with
   `now-ms`; the CLJS counterpart diverges (`performance.now()` vs
   `js/Date.now()`), which is why durable timestamps read this dedicated
   surface."

--- a/implementation/core/src/re_frame/interop.cljs
+++ b/implementation/core/src/re_frame/interop.cljs
@@ -121,7 +121,7 @@
 
 (defn epoch-now-ms
   "Wall-clock epoch milliseconds. The canonical source for EP-0010 durable
-  causal time (`:rf.world/inputs` `:time-ms`, EP-0010 §Time — \"wall-clock
+  causal time (`:rf.cofx` `:rf/time-ms`, EP-0010 §Time — \"wall-clock
   epoch milliseconds\"). DISTINCT from `now-ms`: that is `performance.now()`
   (origin-relative, for elapsed measurement) on CLJS, which is NOT comparable
   with `js/Date`-based freshness checks. A durable timestamp folded from this

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -71,48 +71,53 @@
 ;; key (the per-frame tier).
 (def ^:dynamic *fx-overrides* nil)
 
-;; ---- EP-0010 causal world-input stamping (rf2-s9ss0t) ---------------------
+;; ---- EP-0017 recordable-coeffect stamping (rf2-s9ss0t / rf2-alc1lf) --------
 ;;
 ;; The CAUSAL BOUNDARY: `build-envelope` ensures every dispatch carries an
-;; `:rf.world/inputs` map bearing `:time-ms` — the one host-clock read whose
-;; value durable writes may fold (Spec 002 §The World-Input Rule). This is the
-;; ONLY place the clock is read for the causal token; it is NOT re-read inside
-;; the handler, flow transform, resource reducer, work-ledger writer, or commit.
+;; `:rf.cofx` map bearing `:rf/time-ms` — the one host-clock read whose value
+;; durable writes may fold (Spec 002 §The World-Input Rule, EP-0010). EP-0017
+;; (slice-A.2) renames the envelope field from `:rf.world/inputs` to the flat
+;; `:rf.cofx` map (one fact per owner-qualified key, no grouping sub-maps) and
+;; the framework time fact from the nested `:time-ms` to the flat `:rf/time-ms`.
+;; This is the ONLY place the clock is read for the causal token; it is NOT
+;; re-read inside the handler, flow transform, resource reducer, work-ledger
+;; writer, or commit.
 ;;
-;; `ensure-world-inputs` owns the shape contract so `build-envelope`'s let does
-;; not inline it:
+;; `ensure-cofx` owns the shape contract so `build-envelope`'s let does not
+;; inline it:
 ;;
 ;;   - caller-supplied wins — a test / replay / SSR-hydration / tool dispatch
-;;     that supplies `:rf.world/inputs` has its map PRESERVED verbatim (extra
-;;     `:uuid` / `:random` / browser/storage slots ride through). The router
-;;     fills ONLY the framework-required `:time-ms` when absent, never
-;;     overwriting a supplied one (EP-0010 §Restore, Replay, And Hydration).
-;;   - `:time-ms` is WALL-CLOCK EPOCH ms (rf2-n1rh0f / EP-0010 §Time), read from
-;;     `interop/epoch-now-ms` (`js/Date.now()` / `System/currentTimeMillis`) —
-;;     NOT `interop/now-ms` (CLJS `performance.now()` is origin-relative, so a
+;;     that supplies `:rf.cofx` has its map PRESERVED verbatim (extra
+;;     owner-qualified fact slots ride through). The router fills ONLY the
+;;     framework-required `:rf/time-ms` when absent, never overwriting a
+;;     supplied one (EP-0010 §Restore, Replay, And Hydration).
+;;   - `:rf/time-ms` is WALL-CLOCK EPOCH ms (rf2-n1rh0f / EP-0010 §Time), read
+;;     from `interop/epoch-now-ms` (`js/Date.now()` / `System/currentTimeMillis`)
+;;     — NOT `interop/now-ms` (CLJS `performance.now()` is origin-relative, so a
 ;;     durable timestamp folded from it would be incomparable with `js/Date`-
 ;;     based freshness checks: resource `:stale-at`, invalidation, etc.).
 ;;
 ;; Unlike `:dispatch-id` / the retired `:dispatched-at`, this is NOT dev-gated:
-;; world inputs are DURABLE causal data, not a diagnostic, so `:time-ms` must be
-;; present in production too. The cost is one `epoch-now-ms` read + a small map
-;; on the dispatch path — the price of a deterministic fold.
+;; recordable coeffects are DURABLE causal data, not a diagnostic, so
+;; `:rf/time-ms` must be present in production too. The cost is one
+;; `epoch-now-ms` read + a small map on the dispatch path — the price of a
+;; deterministic fold.
 ;;
 ;; Child dispatches (`:dispatch` / `:dispatch-later` fx) get their OWN map —
-;; `:rf.world/inputs` is deliberately NOT in
+;; `:rf.cofx` is deliberately NOT in
 ;; `re-frame.fx/inheritable-envelope-keys`, so each child re-enters here and is
-;; stamped fresh as a distinct causal token (no `:time-ms` inheritance — Spec
+;; stamped fresh as a distinct causal token (no `:rf/time-ms` inheritance — Spec
 ;; 002 §Dispatch Envelope Stamping).
 
-(defn- ensure-world-inputs
-  "Return the caller-supplied `:rf.world/inputs` map with the framework-required
-  `:time-ms` filled from `interop/epoch-now-ms` iff absent. A supplied `:time-ms`
-  (and every other supplied slot) is preserved verbatim. See the section comment
-  above for the full causal-boundary contract."
+(defn- ensure-cofx
+  "Return the caller-supplied `:rf.cofx` map with the framework-required
+  `:rf/time-ms` filled from `interop/epoch-now-ms` iff absent. A supplied
+  `:rf/time-ms` (and every other supplied fact) is preserved verbatim. See the
+  section comment above for the full causal-boundary contract."
   [supplied]
-  (if (contains? supplied :time-ms)
+  (if (contains? supplied :rf/time-ms)
     supplied
-    (assoc supplied :time-ms (interop/epoch-now-ms))))
+    (assoc supplied :rf/time-ms (interop/epoch-now-ms))))
 
 (defn- build-envelope
   "Build the dispatch envelope per Spec 002 §Routing: the dispatch envelope.
@@ -172,19 +177,19 @@
                         Open-vocabulary; distinct from :source which is
                         the closed-enum trigger-kind / functional-origin
                         axis.
-    :rf.world/inputs    EP-0010 causal world-input map (Spec 002 §The
-                        World-Input Rule). The router ensures it exists
-                        and carries `:time-ms` (epoch-ms wall clock)
-                        stamped from `interop/epoch-now-ms` HERE — the
-                        causal boundary — UNLESS the caller supplied a map,
-                        in
-                        which case it is preserved and only the missing
-                        framework-required `:time-ms` is filled. This is
-                        the durable causal-time contract: the read happens
-                        ONCE, at envelope construction, never re-read in a
-                        handler / flow / resource reducer / commit. Child
-                        dispatches get their OWN map — `:time-ms` is NOT
-                        inherited (a child is a distinct causal token).
+    :rf.cofx            EP-0017 recordable-coeffect map (flat, one fact per
+                        owner-qualified key; Spec 002 §The World-Input Rule).
+                        The router ensures it exists and carries `:rf/time-ms`
+                        (epoch-ms wall clock) stamped from
+                        `interop/epoch-now-ms` HERE — the causal boundary —
+                        UNLESS the caller supplied a map, in which case it is
+                        preserved and only the missing framework-required
+                        `:rf/time-ms` is filled. This is the durable
+                        causal-time contract: the read happens ONCE, at
+                        envelope construction, never re-read in a handler /
+                        flow / resource reducer / commit. Child dispatches get
+                        their OWN map — `:rf/time-ms` is NOT inherited (a child
+                        is a distinct causal token).
     :dispatch-id        process-monotonic id allocated here per
                         Spec 009 §Dispatch correlation
     :parent-dispatch-id the in-flight dispatch's id when this dispatch is
@@ -210,35 +215,35 @@
         ;; EP-0010 disposition 5 (rf2-lj39cn): the RETIRED `:dispatched-at`
         ;; dispatch opt gets the STANDARD RETIREMENT TREATMENT — a HARD
         ;; ERROR naming the replacement, NOT the generic warn-on-unknown-opt
-        ;; below. Checked FIRST — BEFORE the world-input clock stamp below —
+        ;; below. Checked FIRST — BEFORE the cofx clock stamp below —
         ;; so a caller still passing `:dispatched-at` fails fast with the
         ;; specific, actionable retirement error (naming
-        ;; `(:time-ms (:rf.world/inputs envelope))`) WITHOUT first triggering
+        ;; `(:rf/time-ms (:rf.cofx envelope))`) WITHOUT first triggering
         ;; the `epoch-now-ms` clock read / map allocation for a dispatch that
         ;; cannot proceed. Always-on (not dev-gated): a retirement hard error
         ;; is a correctness contract that must fire in production too — see
         ;; `reject-retired-dispatch-opts!`.
         _                  (diag/reject-retired-dispatch-opts! opts event)
         ;; EP-0010 (rf2-47lgee / rf2-nftz2s): VALIDATE a caller-supplied
-        ;; `:rf.world/inputs` at the PUBLIC dispatch boundary BEFORE the clock
+        ;; `:rf.cofx` at the PUBLIC dispatch boundary BEFORE the clock
         ;; stamp below — a supplied value must be nil-or-map and a supplied
-        ;; `:time-ms` must be an integer (Spec 002 §The World-Input Rule +
-        ;; Spec-Schemas.md §:rf.world/inputs). A malformed causal token is not
+        ;; `:rf/time-ms` must be an integer (Spec 002 §The World-Input Rule +
+        ;; Spec-Schemas.md §:rf.cofx). A malformed causal token is not
         ;; a harmless typo: it folds straight into durable writes (the epoch
         ;; record's `:committed-at`, resource `:settled-at`) and breaks the
         ;; deterministic fold / replay. Always-on (a corrupt durable token is a
         ;; production correctness contract); fails fast WITHOUT reading the
         ;; clock for a dispatch that cannot proceed — same fail-before-clock-
         ;; read ordering as the retirement check above. See
-        ;; `diag/validate-world-inputs!`.
-        _                  (diag/validate-world-inputs! opts event)
-        ;; EP-0010 §Dispatch Envelope Stamping (rf2-s9ss0t): the CAUSAL
-        ;; BOUNDARY — ensure `:rf.world/inputs` carries `:time-ms`, the one
-        ;; host-clock read durable writes fold. `ensure-world-inputs` owns the
-        ;; preserve-supplied / fill-missing-`:time-ms` shape contract (see the
+        ;; `diag/validate-cofx!`.
+        _                  (diag/validate-cofx! opts event)
+        ;; EP-0017 §Dispatch Envelope Stamping (rf2-s9ss0t / rf2-alc1lf): the
+        ;; CAUSAL BOUNDARY — ensure `:rf.cofx` carries `:rf/time-ms`, the one
+        ;; host-clock read durable writes fold. `ensure-cofx` owns the
+        ;; preserve-supplied / fill-missing-`:rf/time-ms` shape contract (see the
         ;; section comment on the helper above). Stamped AFTER the retirement +
         ;; validation checks so an invalid dispatch never reads the clock.
-        world-inputs       (ensure-world-inputs (:rf.world/inputs opts))
+        cofx               (ensure-cofx (:rf.cofx opts))
         ;; Per rf2-jbzhj: surface unrecognised opts keys (typically a typo'd
         ;; opt like `:fram` for `:frame`) rather than silently swallowing
         ;; them. Emitted HERE — BEFORE the frame resolution below — so a
@@ -328,12 +333,12 @@
              ;; `emit-dispatched-trace`).
              :source-detail          (:source-detail opts)
              :origin                 (:origin opts :app)
-             ;; EP-0010 (rf2-s9ss0t): the causal world-input map, stamped
-             ;; unconditionally (durable causal data, not a diagnostic —
-             ;; see the `world-inputs` binding above). Always carries
-             ;; `:time-ms`; caller-supplied additional keys (`:uuid`,
-             ;; `:random`, browser/storage facts) ride through preserved.
-             :rf.world/inputs        world-inputs}
+             ;; EP-0017 (rf2-s9ss0t / rf2-alc1lf): the flat recordable-coeffect
+             ;; map, stamped unconditionally (durable causal data, not a
+             ;; diagnostic — see the `cofx` binding above). Always carries
+             ;; `:rf/time-ms`; caller-supplied additional owner-qualified facts
+             ;; ride through preserved.
+             :rf.cofx                cofx}
       ;; Per rf2-ts1a: the macro form of `dispatch` / `dispatch-sync`
       ;; stamps an `:rf.trace/call-site` on the opts map. The read in
       ;; `call-site` above is gated on interop/debug-enabled? so this
@@ -553,17 +558,17 @@
                          :event           event
                          :rf.db/runtime   runtime-db
                          :rf.frame/id     frame
-                         ;; EP-0010 (rf2-s9ss0t): the causal world-input
-                         ;; map is a framework coeffect alongside `:db` /
-                         ;; `:event` / `:rf.db/runtime` / `:rf.frame/id`
-                         ;; (Spec 002 §Event Context And Coeffects).
-                         ;; `build-envelope` guarantees `:time-ms` on the
-                         ;; envelope, so a durable handler reads
-                         ;; `(:time-ms (:rf.world/inputs cofx))` instead of
+                         ;; EP-0017 (rf2-s9ss0t / rf2-alc1lf): the flat
+                         ;; recordable-coeffect map is a framework coeffect
+                         ;; alongside `:db` / `:event` / `:rf.db/runtime` /
+                         ;; `:rf.frame/id` (Spec 002 §Event Context And
+                         ;; Coeffects). `build-envelope` guarantees
+                         ;; `:rf/time-ms` on the envelope, so a durable handler
+                         ;; reads `(:rf/time-ms (:rf.cofx coeffects))` instead of
                          ;; an ambient `interop/now-ms`. Filtered out of the
                          ;; user-cofx trace projection by
                          ;; `fx/framework-coeffect-keys`.
-                         :rf.world/inputs (:rf.world/inputs envelope)}
+                         :rf.cofx         (:rf.cofx envelope)}
                   (:source envelope)   (assoc :source (:source envelope))
                   (:trace-id envelope) (assoc :trace-id (:trace-id envelope)))
      :effects {}
@@ -1977,14 +1982,14 @@
         ;; pending child under the runaway-cascade pattern that trips it).
         halting-envelope (peek queue)
         halting-event   (or (:event halting-envelope) last-event)
-        ;; rf2-bh56rc: the halting event's causal `:time-ms` (stamped on its
+        ;; rf2-bh56rc: the halting event's causal `:rf/time-ms` (stamped on its
         ;; envelope at the causal boundary). Threaded into the synthesised
         ;; `:halted-depth` record's `:committed-at` so even this never-ran
         ;; marker carries a replayable causal time per EP-0010 §Time / Spec
         ;; 002 §The World-Input Rule, not an ambient assembly-time read. nil
         ;; only on the defensive empty-queue fallback (no envelope to read);
         ;; the epoch surface tolerates a nil `:committed-at` there.
-        halting-time-ms (-> halting-envelope :rf.world/inputs :time-ms)
+        halting-time-ms (-> halting-envelope :rf.cofx :rf/time-ms)
         ;; Current durable frame-state value — the state the last-settled
         ;; event left behind. The halting event makes no write, so
         ;; :frame-state-before equals :frame-state-after on its record.
@@ -2011,7 +2016,7 @@
       ;; `settle!` would skip; `commit-halt-record!` commits regardless,
       ;; pinning the halting event's trigger. :frame-state-before equals
       ;; :frame-state-after — the halting event made no write. rf2-bh56rc:
-      ;; `:committed-at` is the halting event's causal `:time-ms`, not an
+      ;; `:committed-at` is the halting event's causal `:rf/time-ms`, not an
       ;; ambient read.
       (commit-halt! frame-id fs-now fs-now halting-time-ms :halted-depth halt-reason
                     halting-event))))
@@ -2037,8 +2042,8 @@
   are whole frame-state values (both partitions); `build-record` derives the
   `:db-before` / `:db-after` app-db projections from them.
 
-  rf2-bh56rc: `committed-at` is the settling event's causal `:time-ms` (its
-  envelope's `:rf.world/inputs` `:time-ms`, stamped at the causal boundary).
+  rf2-bh56rc: `committed-at` is the settling event's causal `:rf/time-ms` (its
+  envelope's `:rf.cofx` `:rf/time-ms`, stamped at the causal boundary).
   Threaded into the epoch record's `:committed-at` so the durable
   causal-time fact is replayable per EP-0010 §Time / Spec 002 §The
   World-Input Rule, not an ambient assembly-time host-clock read."
@@ -2200,13 +2205,13 @@
         ;; an epoch carries (and `restore-epoch` rewinds to) machine snapshots
         ;; / the route slice / SSR metadata, not just app-db.
         (let [fs-before (frame/frame-state-value frame-id)
-              ;; rf2-bh56rc: this event's causal `:time-ms` — the
-              ;; `:rf.world/inputs` `:time-ms` stamped on the envelope at the
+              ;; rf2-bh56rc: this event's causal `:rf/time-ms` — the
+              ;; `:rf.cofx` `:rf/time-ms` stamped on the envelope at the
               ;; causal boundary (`build-envelope`). Threaded into the epoch
               ;; record's `:committed-at` (per EP-0010 §Time / Spec 002 §The
               ;; World-Input Rule) so the durable causal-time fact is
               ;; replayable rather than an ambient assembly-time clock read.
-              time-ms   (-> envelope :rf.world/inputs :time-ms)]
+              time-ms   (-> envelope :rf.cofx :rf/time-ms)]
           ;; Per rf2-9neiq: expose this event's pre-cascade frame-state to a
           ;; handler that calls `destroy-frame!` on its OWN frame mid-drain.
           ;; `destroy-frame!`'s epoch hook reads `frame/*cascade-frame-state-before*`
@@ -2402,27 +2407,28 @@
     (when-not no-emit?
       (trace/with-call-site (:call-site envelope)
         (trace/emit! :rf.event :rf.event/dispatched
-                     ;; Per rf2-jt854w (EP-0010 observability completion):
-                     ;; stamp the envelope's causal world-input map onto the
-                     ;; enqueue trace so Xray's Event lens (018 §5.1) can render
-                     ;; the WORLD INPUTS surface — the framework-stamped
-                     ;; `:time-ms` plus any caller-supplied `:uuid` / `:random`
-                     ;; / browser/storage facts. Without it the only trace-side
-                     ;; view of the causal token is the filtered framework-
-                     ;; default cofx (the user-cofx projection drops it via
-                     ;; `fx/framework-coeffect-keys`), so the lens had no data.
+                     ;; Per rf2-jt854w (EP-0010 observability completion) /
+                     ;; EP-0017 (rf2-alc1lf): stamp the envelope's flat
+                     ;; recordable-coeffect map onto the enqueue trace so Xray's
+                     ;; Event lens (018 §5.1) can render the COEFFECTS surface —
+                     ;; the framework-stamped `:rf/time-ms` plus any
+                     ;; caller-supplied owner-qualified facts. Without it the
+                     ;; only trace-side view of the causal token is the filtered
+                     ;; framework-default cofx (the user-cofx projection drops it
+                     ;; via `fx/framework-coeffect-keys`), so the lens had no
+                     ;; data.
                      ;;
                      ;; DEBUG-GATED via the canonical OUTERMOST
                      ;; `(if interop/debug-enabled? <stamped> <plain>)` shape —
-                     ;; the dev arm carries the `:rf.world/inputs` slot, the
+                     ;; the dev arm carries the `:rf.cofx` slot, the
                      ;; prod arm omits it. This is the rf2-7ynhyn-correct idiom:
                      ;; NOT a `cond->` test-position gate, because Closure does
                      ;; not constant-fold a keyword literal away from a `cond->`
-                     ;; step test, so a `(envelope :rf.world/inputs) (assoc …)`
+                     ;; step test, so a `(envelope :rf.cofx) (assoc …)`
                      ;; step would leave the slot reachable under `:advanced` +
                      ;; `goog.DEBUG=false`. This is a dev-trace / diagnostic
                      ;; surface, NOT always-on — unlike the envelope's
-                     ;; `:rf.world/inputs` itself (durable causal data, stamped
+                     ;; `:rf.cofx` itself (durable causal data, stamped
                      ;; unconditionally in `build-envelope`, present in
                      ;; production). The whole `:rf.event/dispatched` emit
                      ;; already elides in production (the `event/dispatched` op
@@ -2436,7 +2442,7 @@
                                 :rf.event/origin    (:origin envelope)
                                 :source             (:source envelope)
                                 :rf.event/sync?     sync?
-                                :rf.world/inputs    (:rf.world/inputs envelope)}
+                                :rf.cofx            (:rf.cofx envelope)}
                                {:rf.event/v         event
                                 :frame              (:frame envelope)
                                 :rf.event/origin    (:origin envelope)

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -113,13 +113,14 @@
     :source                 closed-enum trigger-kind / functional-origin
     :source-detail          per-source-kind detail payload
     :origin                 actor identity tag
-    :rf.world/inputs        EP-0010 causal world-input map (caller-supplied
-                            `:time-ms` / `:uuid` / `:random` / etc.; the
-                            router fills `:time-ms` when absent — rf2-s9ss0t)
+    :rf.cofx                EP-0017 flat recordable-coeffect map
+                            (caller-supplied `:rf/time-ms` + owner-qualified
+                            facts; the router fills `:rf/time-ms` when absent —
+                            rf2-s9ss0t / rf2-alc1lf)
     :rf.trace/call-site     macro-stamped invocation coord (dev-only)
     :rf.machine/internal?   machine-internal continuation flag (front-queue)"
   #{:frame :fx-overrides :interceptor-overrides :trace-id :source
-    :source-detail :origin :rf.world/inputs :rf.trace/call-site
+    :source-detail :origin :rf.cofx :rf.trace/call-site
     :rf.machine/internal?})
 
 (defn reject-retired-dispatch-opts!
@@ -135,11 +136,11 @@
   merely lists the known set (which would let the soft path become the
   de-facto spelling — the cg7llv deterrent precedent).
 
-  The durable causal-time fact is `(:time-ms (:rf.world/inputs envelope))`
+  The durable causal-time fact is `(:rf/time-ms (:rf.cofx envelope))`
   — stamped by the framework at the dispatch causal boundary, NOT supplied
   by the caller. (The diagnostic dispatch-time need is the trace event's own
-  ambient `:time` stamp, Spec 009.) The error names `:rf.world/inputs`'s
-  `:time-ms` as the replacement so the programmer rewrites rather than
+  ambient `:time` stamp, Spec 009.) The error names `:rf.cofx`'s
+  `:rf/time-ms` as the replacement so the programmer rewrites rather than
   retries.
 
   ALWAYS-ON — NOT gated on `interop/debug-enabled?`: a retirement hard error
@@ -158,15 +159,15 @@
                      :event-id    (first event)
                      :event       event
                      :retired-key :dispatched-at
-                     :replacement '(:time-ms (:rf.world/inputs envelope))
+                     :replacement '(:rf/time-ms (:rf.cofx envelope))
                      :reason      (str "Dispatch opt `:dispatched-at` is RETIRED "
                                        "(EP-0010 disposition 5 / EP-0007 "
                                        "one-name-per-fact). There is no "
                                        "caller-supplied dispatch-time field. "
                                        "The durable causal-time fact is "
-                                       "`(:time-ms (:rf.world/inputs envelope))` "
-                                       "— the framework stamps `:time-ms` into "
-                                       "`:rf.world/inputs` at the dispatch causal "
+                                       "`(:rf/time-ms (:rf.cofx envelope))` "
+                                       "— the framework stamps `:rf/time-ms` into "
+                                       "`:rf.cofx` at the dispatch causal "
                                        "boundary; durable code reads it from there. "
                                        "For a diagnostic dispatch-time, use the "
                                        "trace event's own ambient `:time` stamp "
@@ -174,81 +175,80 @@
                                        "is no back-compat alias.")
                      :recovery    :no-recovery}))))
 
-(defn validate-world-inputs!
-  "Throw `:rf.error/invalid-world-inputs` when a caller-supplied
-  `:rf.world/inputs` is structurally malformed at the PUBLIC dispatch
-  boundary (rf2-47lgee / rf2-nftz2s).
+(defn validate-cofx!
+  "Throw `:rf.error/invalid-cofx` when a caller-supplied `:rf.cofx` is
+  structurally malformed at the PUBLIC dispatch boundary (rf2-47lgee /
+  rf2-nftz2s / rf2-alc1lf).
 
-  EP-0010 makes `:rf.world/inputs` the durable causal token: its `:time-ms`
-  is the one host-clock fact durable writes fold (Spec 002 §The World-Input
-  Rule), and replay / restore / SSR-hydration feed it verbatim. So a
-  malformed token is not a harmless typo — a non-map supplied value, or a
-  non-integer `:time-ms`, propagates straight into durable-write code (the
-  epoch record's `:committed-at`, resource `:settled-at`, …) and makes the
-  fold dishonest. The pair-tool (`re-frame2-pair-mcp.tools.args/parse-world-
-  inputs`) already validates its own wire shape, but that does NOT protect
-  ordinary public `dispatch` / `dispatch-sync`; a single central validator
-  at the dispatch boundary is simpler to reason about than relying on every
-  caller / tool to validate (rf2-nftz2s §1).
+  EP-0017 makes `:rf.cofx` the durable causal token (the flat
+  recordable-coeffect map): its `:rf/time-ms` is the one host-clock fact
+  durable writes fold (Spec 002 §The World-Input Rule), and replay / restore
+  / SSR-hydration feed it verbatim. So a malformed token is not a harmless
+  typo — a non-map supplied value, or a non-integer `:rf/time-ms`, propagates
+  straight into durable-write code (the epoch record's `:committed-at`,
+  resource `:settled-at`, …) and makes the fold dishonest. The pair-tool
+  already validates its own wire shape, but that does NOT protect ordinary
+  public `dispatch` / `dispatch-sync`; a single central validator at the
+  dispatch boundary is simpler to reason about than relying on every caller /
+  tool to validate (rf2-nftz2s §1).
 
-  The contract MIRRORS `WorldInputs` (Spec-Schemas.md §:rf.world/inputs):
+  The contract MIRRORS the `:rf.cofx` schema (Spec-Schemas.md §:rf.cofx):
 
-    - a supplied `:rf.world/inputs` MUST be nil or a MAP (`nil` ⇒ the router
+    - a supplied `:rf.cofx` MUST be nil or a MAP (`nil` ⇒ the router
       stamps a fresh map — the ordinary live-dispatch path);
-    - a supplied `:time-ms` MUST be an integer (wall-clock epoch ms — the
-      schema's lone required-on-the-envelope key).
+    - a supplied `:rf/time-ms` MUST be an integer (wall-clock epoch ms — the
+      framework's lone provided-on-the-envelope fact).
 
-  Other slots (`:uuid` / `:random` / `:storage` / browser facts) ride
-  through unvalidated here — they are open, subsystem-qualified, and a
-  narrower spec / schema gate is the deeper check; this is the cheap
-  structural shape gate that stops the two shapes that corrupt the durable
-  fold.
+  Other facts (app-owned, subsystem-qualified) ride through unvalidated here
+  — they are open, owner-qualified, and a narrower spec / schema gate is the
+  deeper check; this is the cheap structural shape gate that stops the two
+  shapes that corrupt the durable fold.
 
   ALWAYS-ON — NOT gated on `interop/debug-enabled?`: like
   `reject-retired-dispatch-opts!`, a corrupt causal token is a correctness
   contract that must fail fast in `:advanced` + `goog.DEBUG=false`
-  production too (a non-integer `:time-ms` folded into a durable timestamp
+  production too (a non-integer `:rf/time-ms` folded into a durable timestamp
   is a production data-integrity bug, not a dev nicety). The cost is a
   `contains?` + a `map?` / `int?` check on the dispatch path — no allocation
-  unless the caller supplied a `:rf.world/inputs`.
+  unless the caller supplied a `:rf.cofx`.
 
   Checked at the causal boundary in `re-frame.router/build-envelope` BEFORE
-  `ensure-world-inputs` stamps `:time-ms`, so an invalid token fails fast
-  WITHOUT first reading the clock for a dispatch that cannot proceed (the
-  same fail-before-clock-read ordering as the retirement check). Per Spec
-  002 §The World-Input Rule + EP-0010 §Time."
+  `ensure-cofx` stamps `:rf/time-ms`, so an invalid token fails fast WITHOUT
+  first reading the clock for a dispatch that cannot proceed (the same
+  fail-before-clock-read ordering as the retirement check). Per Spec 002 §The
+  World-Input Rule + EP-0010 §Time + EP-0017 §The envelope field."
   [opts event]
-  (when (contains? opts :rf.world/inputs)
-    (let [supplied (:rf.world/inputs opts)]
+  (when (contains? opts :rf.cofx)
+    (let [supplied (:rf.cofx opts)]
       (when-not (or (nil? supplied) (map? supplied))
-        (throw (ex-info ":rf.error/invalid-world-inputs"
-                        {:rf.error/id :rf.error/invalid-world-inputs
+        (throw (ex-info ":rf.error/invalid-cofx"
+                        {:rf.error/id :rf.error/invalid-cofx
                          :where       're-frame.router/build-envelope
                          :event-id    (first event)
                          :event       event
                          :supplied    supplied
-                         :reason      (str ":rf.world/inputs must be nil or a MAP "
-                                           "of causal world facts (Spec 002 §The "
+                         :reason      (str ":rf.cofx must be nil or a MAP "
+                                           "of recordable coeffect facts (Spec 002 §The "
                                            "World-Input Rule), got "
                                            (pr-str supplied)
-                                           ". The map's `:time-ms` (wall-clock "
+                                           ". The map's `:rf/time-ms` (wall-clock "
                                            "epoch ms) is the durable causal token "
                                            "durable writes fold; a non-map value "
                                            "cannot carry it.")
                          :recovery    :no-recovery})))
       (when (and (map? supplied)
-                 (contains? supplied :time-ms)
-                 (not (int? (:time-ms supplied))))
-        (throw (ex-info ":rf.error/invalid-world-inputs"
-                        {:rf.error/id :rf.error/invalid-world-inputs
+                 (contains? supplied :rf/time-ms)
+                 (not (int? (:rf/time-ms supplied))))
+        (throw (ex-info ":rf.error/invalid-cofx"
+                        {:rf.error/id :rf.error/invalid-cofx
                          :where       're-frame.router/build-envelope
                          :event-id    (first event)
                          :event       event
-                         :time-ms     (:time-ms supplied)
-                         :reason      (str ":rf.world/inputs :time-ms must be an "
+                         :rf/time-ms  (:rf/time-ms supplied)
+                         :reason      (str ":rf.cofx :rf/time-ms must be an "
                                            "INTEGER (wall-clock epoch milliseconds "
-                                           "— Spec-Schemas.md §:rf.world/inputs), "
-                                           "got " (pr-str (:time-ms supplied))
+                                           "— Spec-Schemas.md §:rf.cofx), "
+                                           "got " (pr-str (:rf/time-ms supplied))
                                            ". This value becomes the durable "
                                            "causal time the frame fold reads "
                                            "(epoch `:committed-at`, resource "

--- a/implementation/core/test/re_frame/always_on_axis_conformance_cljs_test.cljc
+++ b/implementation/core/test/re_frame/always_on_axis_conformance_cljs_test.cljc
@@ -101,7 +101,23 @@
     :rf.error/malformed-hydration-payload
     :rf.error/ssr-head-resolution-failed
     :rf.error/sanitised-on-projection
-    :rf.error/ssr-ring-error-view-failed})
+    :rf.error/ssr-ring-error-view-failed
+    ;; EP-0017 (rf2-alc1lf): the cofx error family graduated `always-on` in
+    ;; the Spec 009 catalogue by the `:rf.cofx` contract spec commit
+    ;; (2536b2d98). Each is a causal-token / coeffect-contract validation that
+    ;; fires in production too (the `:dispatched-at` precedent — an
+    ;; out-of-contract durable value is corrupt state), so it rides the
+    ;; always-on axis. The emit SITES land across slices A.2/A.3/B; this leg
+    ;; drives every always-on category through `dispatch-on-error!` to prove
+    ;; the listener fan-out, so the literal pins the catalogue's always-on set
+    ;; regardless of which slice wires up the emit site. The JVM companion
+    ;; (`parsed-always-on-set-equals-the-exercise-literal`) keeps this set ==
+    ;; the parsed catalogue.
+    :rf.error/unregistered-cofx
+    :rf.error/missing-required-cofx
+    :rf.error/cofx-value-invalid
+    :rf.error/inject-cofx-removed
+    :rf.error/world-inputs-renamed})
 
 ;; The frame-teardown report is the ONE always-on category that rides the
 ;; bounded `dispatch-frame-teardown-report!` sibling (Spec 009: one record

--- a/implementation/core/test/re_frame/cofx_test.clj
+++ b/implementation/core/test/re_frame/cofx_test.clj
@@ -412,15 +412,15 @@
 ;;
 ;; The initial recordable time coeffect (EP-0010 §Backwards Compatibility and
 ;; Migration, reference-implementation step 7): `:app/now-ms` injects the
-;; dispatch envelope's causal `(:time-ms (:rf.world/inputs cofx))` so a v1-style
+;; dispatch envelope's causal `(:rf/time-ms (:rf.cofx coeffects))` so a v1-style
 ;; host-clock read in a durable handler becomes a recordable coeffect. It reads
-;; ONLY the already-seeded `:rf.world/inputs` framework coeffect — no ambient
+;; ONLY the already-seeded `:rf.cofx` framework coeffect — no ambient
 ;; `(.now js/Date)` / `interop/now-ms` of its own — so a scripted / replayed
-;; `:time-ms` is returned exactly (Spec 002 §Event Context And Coeffects: a
+;; `:rf/time-ms` is returned exactly (Spec 002 §Event Context And Coeffects: a
 ;; coeffect that can affect durable state MUST be recordable).
 
 (deftest app-now-ms-reads-causal-time-ms-exactly
-  (testing ":app/now-ms returns the supplied :rf.world/inputs :time-ms VERBATIM
+  (testing ":app/now-ms returns the supplied :rf.cofx :rf/time-ms VERBATIM
             — a scripted past timestamp comes back exactly, proving no ambient
             clock read at the injection site (replay determinism)"
     (let [scripted 1781078400123      ;; a fixed past epoch-ms; an ambient
@@ -431,37 +431,37 @@
           (reset! seen now-ms)
           {}))
       (rf/dispatch-sync [:cofx-test/read-now]
-                        {:rf.world/inputs {:time-ms scripted}})
+                        {:rf.cofx {:rf/time-ms scripted}})
       (is (= scripted @seen)
-          "the handler saw the EXACT scripted :time-ms — sourced from the causal
+          "the handler saw the EXACT scripted :rf/time-ms — sourced from the causal
            token, not a live host-clock read (a replayed dispatch is stable)"))))
 
 (deftest app-now-ms-tracks-router-stamped-time-ms
   (testing "with no caller-supplied world inputs, :app/now-ms returns the SAME
-            value the router stamped on the envelope (:rf.world/inputs :time-ms)
+            value the router stamped on the envelope (:rf.cofx :rf/time-ms)
             — one causal read, surfaced through the cofx (not a second read)"
     (let [seen-now   (atom ::unset)
           seen-world (atom ::unset)]
       (rf/reg-event-fx :cofx-test/read-now-stamped
         [(rf/inject-cofx :app/now-ms)]
-        (fn [{:keys [app/now-ms rf.world/inputs]} _]
+        (fn [{:keys [app/now-ms] cofx :rf.cofx} _]
           (reset! seen-now now-ms)
-          (reset! seen-world (:time-ms inputs))
+          (reset! seen-world (:rf/time-ms cofx))
           {}))
       (rf/dispatch-sync [:cofx-test/read-now-stamped])
       (is (number? @seen-now)
           ":app/now-ms is a stamped epoch-ms number on the live path")
       (is (= @seen-world @seen-now)
-          ":app/now-ms equals the envelope's own :rf.world/inputs :time-ms —
+          ":app/now-ms equals the envelope's own :rf.cofx :rf/time-ms —
            it surfaces the single causal read, never re-reads the host"))))
 
 (deftest app-now-ms-nil-without-world-inputs
-  (testing ":app/now-ms injects nil when no :rf.world/inputs coeffect is present
+  (testing ":app/now-ms injects nil when no :rf.cofx coeffect is present
             (a handler invoked outside the dispatch path) — it never falls back
             to an ambient host read (durable time must come from a stamped
             envelope)"
     (let [seen   (atom ::unset)
-          ;; Drive the cofx directly with a context carrying NO :rf.world/inputs
+          ;; Drive the cofx directly with a context carrying NO :rf.cofx
           ;; coeffect — isolates the cofx body from the router's stamping so the
           ;; nil-source branch is exercised deterministically.
           cofx    (registrar/lookup :cofx :app/now-ms)
@@ -470,5 +470,5 @@
           result  (handler ctx)]
       (reset! seen (get-in result [:coeffects :app/now-ms]))
       (is (nil? @seen)
-          "no :rf.world/inputs → :app/now-ms is nil (no ambient (.now js/Date)
+          "no :rf.cofx → :app/now-ms is nil (no ambient (.now js/Date)
            fallback — durable time is causal-only)"))))

--- a/implementation/core/test/re_frame/dispatched_trace_world_inputs_test.clj
+++ b/implementation/core/test/re_frame/dispatched_trace_world_inputs_test.clj
@@ -1,13 +1,13 @@
 (ns re-frame.dispatched-trace-world-inputs-test
   "Per rf2-jt854w (EP-0010 observability completion) — the
   `:rf.event/dispatched` enqueue trace carries the envelope's causal
-  `:rf.world/inputs` map so Xray's Event lens (rf2-9fyn40, the WORLD INPUTS
+  `:rf.cofx` map so Xray's Event lens (rf2-9fyn40, the WORLD INPUTS
   surface) has data to render.
 
   Before this, `emit-dispatched-trace!` stamped
   `:rf.event/v` / `:frame` / `:rf.event/origin` / `:source` / `:rf.event/sync?`
   / `:source-detail` / the dispatch-id correlation slots, but NOT
-  `:rf.world/inputs` — so the only trace-side view of the causal token was
+  `:rf.cofx` — so the only trace-side view of the causal token was
   the filtered framework-default cofx (the user-cofx projection drops it via
   `fx/framework-coeffect-keys`), leaving the lens with no input map.
 
@@ -61,74 +61,74 @@
 (defn- dispatched-of [evs]
   (filterv #(= :rf.event/dispatched (:operation %)) evs))
 
-;; ---- the dispatched trace carries :rf.world/inputs ------------------------
+;; ---- the dispatched trace carries :rf.cofx ------------------------
 
 (deftest dispatched-trace-carries-world-inputs-with-time-ms
-  (testing ":rf.event/dispatched carries the envelope's :rf.world/inputs map,
+  (testing ":rf.event/dispatched carries the envelope's :rf.cofx map,
    and that map carries the framework-stamped causal :time-ms"
     (rf/reg-event-db :rf2-jt854w/noop (fn [db _] db))
     (let [evs        (record-traces
                        (fn [] (rf/dispatch-sync [:rf2-jt854w/noop])))
           [enqueue]  (dispatched-of evs)
           ;; The op-type-specific payload slots (`:rf.event/v`,
-          ;; `:rf.event/origin`, `:rf.world/inputs`, ...) ride under
+          ;; `:rf.event/origin`, `:rf.cofx`, ...) ride under
           ;; `:tags`; `build-event` hoists only `:source` to top-level.
-          wi         (get-in enqueue [:tags :rf.world/inputs])]
+          wi         (get-in enqueue [:tags :rf.cofx])]
       (is (some? enqueue) ":rf.event/dispatched fired")
-      (is (contains? (:tags enqueue) :rf.world/inputs)
-          ":rf.world/inputs is stamped on the dispatched trace (rf2-jt854w)")
-      (is (map? wi) ":rf.world/inputs is a map")
-      (is (contains? wi :time-ms)
-          "the causal world-input map carries the framework-stamped :time-ms")
-      (is (integer? (:time-ms wi))
-          ":time-ms is an epoch-ms integer"))))
+      (is (contains? (:tags enqueue) :rf.cofx)
+          ":rf.cofx is stamped on the dispatched trace (rf2-jt854w)")
+      (is (map? wi) ":rf.cofx is a map")
+      (is (contains? wi :rf/time-ms)
+          "the recordable-coeffect map carries the framework-stamped :rf/time-ms")
+      (is (integer? (:rf/time-ms wi))
+          ":rf/time-ms is an epoch-ms integer"))))
 
 (deftest dispatched-trace-preserves-caller-supplied-world-inputs
-  (testing "a caller-supplied :rf.world/inputs (test/replay/SSR fixture) rides
-   onto the dispatched trace verbatim — the additional :uuid / :random keys
-   are preserved alongside the framework-required :time-ms"
+  (testing "a caller-supplied :rf.cofx (test/replay/SSR fixture) rides
+   onto the dispatched trace verbatim — additional owner-qualified facts
+   are preserved alongside the framework-required :rf/time-ms"
     (rf/reg-event-db :rf2-jt854w/scripted (fn [db _] db))
-    (let [scripted   {:time-ms 1234567890123
-                      :uuid    #uuid "00000000-0000-0000-0000-000000000001"
-                      :random  0.42}
+    (let [scripted   {:rf/time-ms 1234567890123
+                      :todo/id    #uuid "00000000-0000-0000-0000-000000000001"
+                      :todo/score 0.42}
           evs        (record-traces
                        (fn []
                          (rf/dispatch-sync [:rf2-jt854w/scripted]
-                                           {:rf.world/inputs scripted})))
+                                           {:rf.cofx scripted})))
           [enqueue]  (dispatched-of evs)]
       (is (some? enqueue) ":rf.event/dispatched fired")
-      (is (= scripted (get-in enqueue [:tags :rf.world/inputs]))
+      (is (= scripted (get-in enqueue [:tags :rf.cofx]))
           "the caller-supplied causal world-input map is stamped verbatim"))))
 
 (deftest dispatched-trace-fills-missing-time-ms-from-supplied-map
-  (testing "a caller-supplied map WITHOUT :time-ms has it filled by the router;
+  (testing "a caller-supplied map WITHOUT :rf/time-ms has it filled by the router;
    the dispatched trace reflects the filled-and-preserved map"
     (rf/reg-event-db :rf2-jt854w/fill (fn [db _] db))
     (let [evs        (record-traces
                        (fn []
                          (rf/dispatch-sync [:rf2-jt854w/fill]
-                                           {:rf.world/inputs {:random 0.99}})))
+                                           {:rf.cofx {:todo/score 0.99}})))
           [enqueue]  (dispatched-of evs)
-          wi         (get-in enqueue [:tags :rf.world/inputs])]
+          wi         (get-in enqueue [:tags :rf.cofx])]
       (is (some? enqueue) ":rf.event/dispatched fired")
-      (is (= 0.99 (:random wi)) "caller-supplied :random preserved")
-      (is (integer? (:time-ms wi))
-          ":time-ms filled by the router at the causal boundary"))))
+      (is (= 0.99 (:todo/score wi)) "caller-supplied fact preserved")
+      (is (integer? (:rf/time-ms wi))
+          ":rf/time-ms filled by the router at the causal boundary"))))
 
 (deftest world-inputs-rides-under-tags-alongside-event-payload-slots
-  (testing ":rf.world/inputs rides under :tags alongside the other op-type-
+  (testing ":rf.cofx rides under :tags alongside the other op-type-
    specific payload slots (:rf.event/v, :rf.event/origin, :rf.event/sync?) —
    build-event hoists only :source to top-level, so the Event lens reads the
-   world-input map off (get-in event [:tags :rf.world/inputs])"
+   world-input map off (get-in event [:tags :rf.cofx])"
     (rf/reg-event-db :rf2-jt854w/placement (fn [db _] db))
     (let [evs       (record-traces
                       (fn [] (rf/dispatch-sync [:rf2-jt854w/placement])))
           [enqueue] (dispatched-of evs)]
       (is (some? enqueue))
-      (is (contains? (:tags enqueue) :rf.world/inputs)
-          ":rf.world/inputs lives under :tags")
-      (is (not (contains? enqueue :rf.world/inputs))
-          ":rf.world/inputs is NOT a top-level slot (only :source is hoisted)")
+      (is (contains? (:tags enqueue) :rf.cofx)
+          ":rf.cofx lives under :tags")
+      (is (not (contains? enqueue :rf.cofx))
+          ":rf.cofx is NOT a top-level slot (only :source is hoisted)")
       ;; Co-located with the other dispatched payload slots under :tags.
       (is (contains? (:tags enqueue) :rf.event/v)
           ":rf.event/v also rides under :tags — same placement"))))

--- a/implementation/core/test/re_frame/event_context_coeffect_keys_test.clj
+++ b/implementation/core/test/re_frame/event_context_coeffect_keys_test.clj
@@ -63,21 +63,21 @@
   (testing "a vanilla event with no user cofx sees EXACTLY the framework keys"
     (rf/reg-frame :ck/exact {:doc "ctx"})
     (let [cofx (capture-coeffects :ck/exact)]
-      (is (= #{:db :event :rf.db/runtime :rf.frame/id :rf.world/inputs :source}
+      (is (= #{:db :event :rf.db/runtime :rf.frame/id :rf.cofx :source}
              (set (keys cofx)))
           "the coeffect key set is exactly the framework defaults — no bare :frame")
       (is (not (contains? cofx :frame))
           "the retired bare :frame coeffect is absent (one carrier, one name)")
       (is (= :ck/exact (:rf.frame/id cofx))
           ":rf.frame/id carries the running frame's id")
-      (is (number? (get-in cofx [:rf.world/inputs :time-ms]))
-          ":rf.world/inputs carries a stamped :time-ms (EP-0010 rf2-s9ss0t)"))))
+      (is (number? (get-in cofx [:rf.cofx :rf/time-ms]))
+          ":rf.cofx carries a stamped :rf/time-ms (EP-0010 rf2-s9ss0t)"))))
 
 (deftest no-frame-coeffect-even-with-trace-id
   (testing "threading a :trace-id adds :trace-id but never re-introduces :frame"
     (rf/reg-frame :ck/traced {:doc "ctx"})
     (let [cofx (capture-coeffects :ck/traced {:trace-id "tid-1"})]
-      (is (= #{:db :event :rf.db/runtime :rf.frame/id :rf.world/inputs :source :trace-id}
+      (is (= #{:db :event :rf.db/runtime :rf.frame/id :rf.cofx :source :trace-id}
              (set (keys cofx)))
           ":trace-id appears when threaded; :frame still does not")
       (is (not (contains? cofx :frame))
@@ -111,9 +111,9 @@
         ":frame is not a framework coeffect key (it was the retired duplicate)")
     (is (contains? fx/framework-coeffect-keys :rf.frame/id)
         ":rf.frame/id is the retained frame-stamp coeffect key")
-    (is (contains? fx/framework-coeffect-keys :rf.world/inputs)
-        ":rf.world/inputs is a framework coeffect key (EP-0010 rf2-s9ss0t)")
-    (is (= #{:db :event :source :trace-id :rf.db/runtime :rf.frame/id :rf.world/inputs}
+    (is (contains? fx/framework-coeffect-keys :rf.cofx)
+        ":rf.cofx is a framework coeffect key (EP-0010 rf2-s9ss0t)")
+    (is (= #{:db :event :source :trace-id :rf.db/runtime :rf.frame/id :rf.cofx}
            fx/framework-coeffect-keys)
         "the framework-coeffect-keys set is exactly the framework defaults")))
 
@@ -121,7 +121,7 @@
   (testing "user-injected-coeffects strips every framework default incl. :rf.frame/id"
     (let [cofx {:db {} :event [:e] :source :unknown :trace-id "t"
                 :rf.db/runtime {} :rf.frame/id :f
-                :rf.world/inputs {:time-ms 1781078400123}
+                :rf.cofx {:rf/time-ms 1781078400123}
                 :my/cofx 1}]
       (is (= {:my/cofx 1} (fx/user-injected-coeffects cofx))
-          "only the genuinely user-injected coeffect survives the projection (EP-0010: :rf.world/inputs filtered too)"))))
+          "only the genuinely user-injected coeffect survives the projection (EP-0010: :rf.cofx filtered too)"))))

--- a/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
+++ b/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
@@ -85,9 +85,9 @@
             coexistence window. Its diagnostic dispatch-time need is the
             trace event `:time` stamp (Spec 009), not a second envelope
             field. The replacement causal-time fact is
-            `(:time-ms (:rf.world/inputs envelope))`, which — unlike the
+            `(:rf/time-ms (:rf.cofx envelope))`, which — unlike the
             dev-gated `:dispatch-id` — is stamped UNCONDITIONALLY because
-            world inputs are DURABLE causal data that durable writes
+            recordable coeffects are DURABLE causal data that durable writes
             fold, not a diagnostic."
     (rf/reg-frame :rf/default {})
     (testing ":dispatched-at is gone under BOTH gate states"
@@ -97,15 +97,15 @@
       (with-redefs [interop/debug-enabled? false]
         (is (not (contains? (build-envelope [:noop] {}) :dispatched-at))
             "no :dispatched-at with the dev gate OFF")))
-    (testing ":rf.world/inputs with :time-ms is stamped REGARDLESS of the gate"
+    (testing ":rf.cofx with :rf/time-ms is stamped REGARDLESS of the gate"
       (with-redefs [interop/debug-enabled? true]
-        (let [world (:rf.world/inputs (build-envelope [:noop] {}))]
-          (is (number? (:time-ms world))
-              ":time-ms present + numeric under the dev gate ON")))
+        (let [cofx (:rf.cofx (build-envelope [:noop] {}))]
+          (is (number? (:rf/time-ms cofx))
+              ":rf/time-ms present + numeric under the dev gate ON")))
       (with-redefs [interop/debug-enabled? false]
-        (let [world (:rf.world/inputs (build-envelope [:noop] {}))]
-          (is (number? (:time-ms world))
-              ":time-ms present + numeric under the prod gate OFF — durable, not dev-gated"))))))
+        (let [cofx (:rf.cofx (build-envelope [:noop] {}))]
+          (is (number? (:rf/time-ms cofx))
+              ":rf/time-ms present + numeric under the prod gate OFF — durable, not dev-gated"))))))
 
 (deftest always-on-error-emit-still-fires-when-debug-disabled
   (testing "Per Spec 009 §Error-emit + rf2-bacs4: the always-on

--- a/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
+++ b/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
@@ -143,6 +143,6 @@
     ;; set must move with it. This is the canonical enumeration callers
     ;; (and the warning message) rely on.
     (is (= #{:frame :fx-overrides :interceptor-overrides :trace-id :source
-             :source-detail :origin :rf.world/inputs :rf.trace/call-site
+             :source-detail :origin :rf.cofx :rf.trace/call-site
              :rf.machine/internal?}
            diag/known-dispatch-opts))))

--- a/implementation/core/test/re_frame/world_inputs_router_stamp_clock_cljs_test.cljs
+++ b/implementation/core/test/re_frame/world_inputs_router_stamp_clock_cljs_test.cljs
@@ -1,6 +1,6 @@
 (ns re-frame.world-inputs-router-stamp-clock-cljs-test
   "rf2-qz0uog (EP-0010 §Dispatch Envelope Stamping) — CLJS LIVE-path
-  regression for the router's `:rf.world/inputs` `:time-ms` stamp.
+  regression for the router's `:rf.cofx` `:rf/time-ms` stamp.
 
   WHY A NEW CLJS SUITE. The existing core world-input tests
   (`re-frame.world-inputs-test`) are JVM-ONLY and assert only that an
@@ -16,7 +16,7 @@
                                process), NOT comparable with `js/Date`.
     - `interop/epoch-now-ms` = `js/Date.now()`     — wall-clock epoch ms
                                (~1.78e12 as of 2026), the durable causal
-                               time `:rf.world/inputs` `:time-ms` MUST be.
+                               time `:rf.cofx` `:rf/time-ms` MUST be.
 
   A durable timestamp folded from `performance.now()` would be ~12 orders
   of magnitude too small and incomparable with the `js/Date`-based
@@ -28,9 +28,9 @@
   itself — the single causal-boundary read every durable write folds.
 
   It drives the REAL router: it dispatches an UNSCRIPTED event (NO
-  `:rf.world/inputs` supplied), lets the genuine `build-envelope` stamp the
+  `:rf.cofx` supplied), lets the genuine `build-envelope` stamp the
   causal `:time-ms` from the host clock, and reads the stamped map back two
-  ways — (a) off the handler's `:rf.world/inputs` COEFFECT (the public
+  ways — (a) off the handler's `:rf.cofx` COEFFECT (the public
   handler-visible path, Spec 002 §Event Context And Coeffects), and (b) off
   the `:rf.event/dispatched` TRACE (the Xray-visible path, rf2-jt854w). Both
   must carry a WALL-CLOCK epoch ms (> 1e12, within seconds of
@@ -57,9 +57,9 @@
 (def ^:private wall-clock-floor 1e12)
 
 (deftest router-stamps-omitted-time-ms-as-wall-clock-epoch-on-the-coeffect
-  (testing "rf2-qz0uog — an UNSCRIPTED dispatch (no :rf.world/inputs) flows
+  (testing "rf2-qz0uog — an UNSCRIPTED dispatch (no :rf.cofx) flows
             through the live router, which stamps the causal :time-ms from the
-            host clock; the handler reads :rf.world/inputs off its coeffect and
+            host clock; the handler reads :rf.cofx off its coeffect and
             the stamped :time-ms MUST be a WALL-CLOCK epoch ms (close to
             js/Date.now), NOT a perf-clock (performance.now) origin-relative
             value. A regression swapping epoch-now-ms -> now-ms at the causal
@@ -67,22 +67,22 @@
     (rf/reg-frame :wi.clk/cofx {:doc "ctx"})
     (let [captured (atom nil)]
       ;; reg-event-ctx so we read the FULL coeffect map the handler saw —
-      ;; :rf.world/inputs is a framework coeffect alongside :db / :event.
+      ;; :rf.cofx is a framework coeffect alongside :db / :event.
       (rf/reg-event-ctx :wi.clk/capture
         (fn [ctx] (reset! captured (:coeffects ctx)) ctx))
       (let [before (js/Date.now)]
-        ;; intentionally UNSCRIPTED — no :rf.world/inputs opt — so the router's
+        ;; intentionally UNSCRIPTED — no :rf.cofx opt — so the router's
         ;; build-envelope performs the live host-clock read under test.
         (rf/dispatch-sync [:wi.clk/capture] {:frame :wi.clk/cofx})
         (let [after   (js/Date.now)
               cofx    @captured
-              world   (:rf.world/inputs cofx)
-              time-ms (:time-ms world)]
+              world   (:rf.cofx cofx)
+              time-ms (:rf/time-ms world)]
           (is (some? cofx) "the handler ran and captured its coeffects")
-          (is (contains? cofx :rf.world/inputs)
-              ":rf.world/inputs is a framework coeffect on the handler ctx")
-          (is (map? world) ":rf.world/inputs is a map")
-          (is (number? time-ms) ":time-ms is a stamped number")
+          (is (contains? cofx :rf.cofx)
+              ":rf.cofx is a framework coeffect on the handler ctx")
+          (is (map? world) ":rf.cofx is a map")
+          (is (number? time-ms) ":rf/time-ms is a stamped number")
           ;; The CLASS assertion: wall-clock epoch ms, not a perf origin time.
           ;; Pre-swap ~1.78e12; a now-ms swap lands ~1e4 (performance.now) on
           ;; the CLJS runtime — far below the floor.
@@ -103,7 +103,7 @@
 (deftest router-stamps-omitted-time-ms-as-wall-clock-epoch-on-the-dispatched-trace
   (testing "rf2-qz0uog — the SAME omitted-time-ms stamp rides the
             :rf.event/dispatched trace (the Xray Event-lens WORLD INPUTS
-            surface, rf2-jt854w): the trace-side :rf.world/inputs :time-ms is
+            surface, rf2-jt854w): the trace-side :rf.cofx :time-ms is
             ALSO a wall-clock epoch ms (> 1e12), not a perf-clock value. Covers
             the router envelope-stamp path as seen by the trace stream, not
             just the handler coeffect."
@@ -120,14 +120,14 @@
                              first)
               ;; the op-type-specific payload slots ride under :tags;
               ;; build-event hoists only :source to top-level (rf2-jt854w).
-              world     (get-in enqueue [:tags :rf.world/inputs])
-              time-ms   (:time-ms world)]
+              world     (get-in enqueue [:tags :rf.cofx])
+              time-ms   (:rf/time-ms world)]
           (is (some? enqueue) ":rf.event/dispatched fired")
           (is (map? world)
-              ":rf.world/inputs rides the dispatched trace under :tags")
-          (is (number? time-ms) "the trace-side :time-ms is a stamped number")
+              ":rf.cofx rides the dispatched trace under :tags")
+          (is (number? time-ms) "the trace-side :rf/time-ms is a stamped number")
           (is (> time-ms wall-clock-floor)
-              "the trace-side :time-ms is a WALL-CLOCK epoch ms (> 1e12) —
+              "the trace-side :rf/time-ms is a WALL-CLOCK epoch ms (> 1e12) —
                js/Date.now, NOT performance.now")
           (is (and (>= time-ms (- before 10000))
                    (<= time-ms (+ after 10000)))

--- a/implementation/core/test/re_frame/world_inputs_test.clj
+++ b/implementation/core/test/re_frame/world_inputs_test.clj
@@ -1,18 +1,18 @@
 (ns re-frame.world-inputs-test
   "EP-0010 §Causal World Inputs core slice (rf2-s9ss0t).
 
-  Pins the `:rf.world/inputs` envelope + coeffect contract that makes the
+  Pins the `:rf.cofx` envelope + coeffect contract that makes the
   frame fold deterministic with respect to prior frame-state plus the
   causal token (Spec 002 §The World-Input Rule):
 
-    - the router STAMPS `:rf.world/inputs {:time-ms ...}` when the caller
+    - the router STAMPS `:rf.cofx {:rf/time-ms ...}` when the caller
       omits it (Spec 002 §Dispatch Envelope Stamping);
     - a caller-supplied map is PRESERVED verbatim — including extra slots
       (`:uuid`, `:random`, browser/storage facts) — and the router never
-      overwrites a supplied `:time-ms`;
-    - a CHILD dispatch (`:fx [[:dispatch ...]]`) gets its OWN map: `:time-ms`
+      overwrites a supplied `:rf/time-ms`;
+    - a CHILD dispatch (`:fx [[:dispatch ...]]`) gets its OWN map: `:rf/time-ms`
       is NOT inherited from the parent (each is a distinct causal token);
-    - the value is visible to handler bodies as the `:rf.world/inputs`
+    - the value is visible to handler bodies as the `:rf.cofx`
       coeffect alongside `:db` / `:event` / `:rf.db/runtime` / `:rf.frame/id`
       (Spec 002 §Event Context And Coeffects);
     - it is FILTERED out of the user-cofx trace projection exactly like the
@@ -86,127 +86,127 @@
 ;; ===========================================================================
 
 (deftest stamps-time-ms-when-absent
-  (testing "the router stamps :rf.world/inputs {:time-ms ...} when the caller omits it"
+  (testing "the router stamps :rf.cofx {:rf/time-ms ...} when the caller omits it"
     (rf/reg-frame :wi/stamp {:doc "ctx"})
     (let [env   (build-envelope [:noop] {:frame :wi/stamp})
-          world (:rf.world/inputs env)]
-      (is (map? world) ":rf.world/inputs is present on the envelope")
-      (is (number? (:time-ms world)) ":time-ms is a stamped epoch-ms number")
-      (is (= #{:time-ms} (set (keys world)))
-          "only the framework-required :time-ms is stamped — no other keys invented"))))
+          world (:rf.cofx env)]
+      (is (map? world) ":rf.cofx is present on the envelope")
+      (is (number? (:rf/time-ms world)) ":rf/time-ms is a stamped epoch-ms number")
+      (is (= #{:rf/time-ms} (set (keys world)))
+          "only the framework-required :rf/time-ms is stamped — no other keys invented"))))
 
 (deftest preserves-caller-supplied-time-ms
-  (testing "a caller-supplied :time-ms is preserved verbatim — the router does NOT overwrite it"
+  (testing "a caller-supplied :rf/time-ms is preserved verbatim — the router does NOT overwrite it"
     (rf/reg-frame :wi/supplied {:doc "ctx"})
     (let [env (build-envelope [:noop]
                               {:frame :wi/supplied
-                               :rf.world/inputs {:time-ms 1781078400123}})]
-      (is (= 1781078400123 (get-in env [:rf.world/inputs :time-ms]))
-          "the exact supplied :time-ms rides through (replay / SSR / fixtures)"))))
+                               :rf.cofx {:rf/time-ms 1781078400123}})]
+      (is (= 1781078400123 (get-in env [:rf.cofx :rf/time-ms]))
+          "the exact supplied :rf/time-ms rides through (replay / SSR / fixtures)"))))
 
 (deftest preserves-caller-supplied-extra-keys-and-fills-time-ms
-  (testing "extra world-input slots ride through; a missing :time-ms is filled, supplied keys untouched"
+  (testing "extra recordable-coeffect facts ride through (flat); a missing :rf/time-ms is filled, supplied facts untouched"
     (rf/reg-frame :wi/extra {:doc "ctx"})
     (let [uuid  #uuid "018ff2b4-9bbd-7a0a-a4df-cf2a91cbe86d"
           env   (build-envelope [:noop]
                                 {:frame :wi/extra
-                                 :rf.world/inputs
-                                 {:uuid   {:todo/id uuid}
-                                  :random {:todo/color :green}}})
-          world (:rf.world/inputs env)]
-      (is (= {:todo/id uuid} (:uuid world)) "supplied :uuid slot preserved")
-      (is (= {:todo/color :green} (:random world)) "supplied :random slot preserved")
-      (is (number? (:time-ms world))
-          "the framework-required :time-ms is filled in alongside the supplied keys"))))
+                                 :rf.cofx
+                                 {:todo/id    uuid
+                                  :todo/color :green}})
+          world (:rf.cofx env)]
+      (is (= uuid (:todo/id world)) "supplied :todo/id fact preserved")
+      (is (= :green (:todo/color world)) "supplied :todo/color fact preserved")
+      (is (number? (:rf/time-ms world))
+          "the framework-required :rf/time-ms is filled in alongside the supplied facts"))))
 
 ;; ===========================================================================
 ;; rf2-47lgee / rf2-nftz2s: PUBLIC-boundary validation of a caller-supplied
-;; :rf.world/inputs. A malformed causal token folds into durable writes (the
+;; :rf.cofx. A malformed causal token folds into durable writes (the
 ;; epoch record's :committed-at, resource :settled-at) and breaks the
 ;; deterministic fold, so build-envelope rejects it with a structured
-;; :rf.error/invalid-world-inputs BEFORE stamping — always-on, prod-survivable,
+;; :rf.error/invalid-cofx BEFORE stamping — always-on, prod-survivable,
 ;; and BEFORE the clock read (a dispatch that cannot proceed never reads the
 ;; clock). The pair-tool validated this on its own wire; this pins the central
 ;; core boundary that protects ordinary public dispatch.
 ;; ===========================================================================
 
 (deftest non-map-world-inputs-is-a-hard-error
-  (testing "a supplied non-map :rf.world/inputs is a hard error (not silently stamped)"
+  (testing "a supplied non-map :rf.cofx is a hard error (not silently stamped)"
     (rf/reg-frame :wi/bad-shape {:doc "ctx"})
     (testing "build-envelope throws even with the dev gate OFF (prod-survivable)"
       (with-redefs [interop/debug-enabled? false]
         (is (thrown? clojure.lang.ExceptionInfo
                      (build-envelope [:noop] {:frame :wi/bad-shape
-                                              :rf.world/inputs "now"}))
-            "a string :rf.world/inputs is rejected, not coerced/stamped")))
-    (testing "the error carries the structured :rf.error/invalid-world-inputs id"
+                                              :rf.cofx "now"}))
+            "a string :rf.cofx is rejected, not coerced/stamped")))
+    (testing "the error carries the structured :rf.error/invalid-cofx id"
       (let [ex   (try
                    (build-envelope [:noop] {:frame :wi/bad-shape
-                                            :rf.world/inputs [:not :a :map]})
+                                            :rf.cofx [:not :a :map]})
                    nil
                    (catch clojure.lang.ExceptionInfo e e))
             data (ex-data ex)]
         (is (some? ex) "an exception was thrown")
-        (is (= :rf.error/invalid-world-inputs (:rf.error/id data))
-            "the error category is :rf.error/invalid-world-inputs")
+        (is (= :rf.error/invalid-cofx (:rf.error/id data))
+            "the error category is :rf.error/invalid-cofx")
         (is (= [:not :a :map] (:supplied data)) "names the bad supplied value")
-        (is (re-find #":time-ms" (:reason data))
-            "the message explains :time-ms is the durable causal token")
+        (is (re-find #":rf/time-ms" (:reason data))
+            "the message explains :rf/time-ms is the durable causal token")
         (is (= :no-recovery (:recovery data)) "no recovery / no coercion")))))
 
 (deftest non-integer-time-ms-is-a-hard-error
-  (testing "a supplied :time-ms that is not an integer is a hard error"
+  (testing "a supplied :rf/time-ms that is not an integer is a hard error"
     (rf/reg-frame :wi/bad-time {:doc "ctx"})
-    (testing "build-envelope throws on a string :time-ms (even dev-gate OFF)"
+    (testing "build-envelope throws on a string :rf/time-ms (even dev-gate OFF)"
       (with-redefs [interop/debug-enabled? false]
         (is (thrown? clojure.lang.ExceptionInfo
                      (build-envelope [:noop] {:frame :wi/bad-time
-                                              :rf.world/inputs {:time-ms "now"}}))
-            "a string :time-ms is rejected (the schema requires :int)")))
-    (testing "nil :time-ms is also rejected (a present-but-nil causal time is malformed)"
+                                              :rf.cofx {:rf/time-ms "now"}}))
+            "a string :rf/time-ms is rejected (the schema requires :int)")))
+    (testing "nil :rf/time-ms is also rejected (a present-but-nil causal time is malformed)"
       (is (thrown? clojure.lang.ExceptionInfo
                    (build-envelope [:noop] {:frame :wi/bad-time
-                                            :rf.world/inputs {:time-ms nil}}))
-          "a nil :time-ms is not an integer — rejected"))
-    (testing "a fractional :time-ms is rejected (epoch ms is an integer)"
+                                            :rf.cofx {:rf/time-ms nil}}))
+          "a nil :rf/time-ms is not an integer — rejected"))
+    (testing "a fractional :rf/time-ms is rejected (epoch ms is an integer)"
       (is (thrown? clojure.lang.ExceptionInfo
                    (build-envelope [:noop] {:frame :wi/bad-time
-                                            :rf.world/inputs {:time-ms 1781078400.5}}))
-          "a double :time-ms is not an integer — rejected"))
-    (testing "the error names the bad :time-ms and the integer/epoch-ms contract"
+                                            :rf.cofx {:rf/time-ms 1781078400.5}}))
+          "a double :rf/time-ms is not an integer — rejected"))
+    (testing "the error names the bad :rf/time-ms and the integer/epoch-ms contract"
       (let [ex   (try
                    (build-envelope [:noop] {:frame :wi/bad-time
-                                            :rf.world/inputs {:time-ms "now"}})
+                                            :rf.cofx {:rf/time-ms "now"}})
                    nil
                    (catch clojure.lang.ExceptionInfo e e))
             data (ex-data ex)]
-        (is (= :rf.error/invalid-world-inputs (:rf.error/id data))
-            "the error category is :rf.error/invalid-world-inputs")
-        (is (= "now" (:time-ms data)) "names the bad :time-ms value")
+        (is (= :rf.error/invalid-cofx (:rf.error/id data))
+            "the error category is :rf.error/invalid-cofx")
+        (is (= "now" (:rf/time-ms data)) "names the bad :rf/time-ms value")
         (is (re-find #"INTEGER" (:reason data))
             "the message states the integer/epoch-ms contract")))))
 
 (deftest valid-world-inputs-shapes-pass
   (testing "the valid shapes the validator must NOT reject"
     (rf/reg-frame :wi/valid {:doc "ctx"})
-    (testing "nil :rf.world/inputs passes (the router stamps a fresh map)"
+    (testing "nil :rf.cofx passes (the router stamps a fresh map)"
       (is (number? (get-in (build-envelope [:noop] {:frame :wi/valid
-                                                    :rf.world/inputs nil})
-                           [:rf.world/inputs :time-ms]))
-          "a nil supplied value is filled with a stamped :time-ms"))
-    (testing "an integer :time-ms passes verbatim"
+                                                    :rf.cofx nil})
+                           [:rf.cofx :rf/time-ms]))
+          "a nil supplied value is filled with a stamped :rf/time-ms"))
+    (testing "an integer :rf/time-ms passes verbatim"
       (is (= 1781078400123
              (get-in (build-envelope [:noop] {:frame :wi/valid
-                                              :rf.world/inputs {:time-ms 1781078400123}})
-                     [:rf.world/inputs :time-ms]))
-          "a valid integer :time-ms rides through preserved"))
-    (testing "a map with NO :time-ms passes (the router fills it)"
-      (let [world (get (build-envelope [:noop]
-                                       {:frame :wi/valid
-                                        :rf.world/inputs {:uuid {:todo/id 1}}})
-                       :rf.world/inputs)]
-        (is (= {:todo/id 1} (:uuid world)) "the supplied :uuid rides through")
-        (is (number? (:time-ms world)) "the missing :time-ms is filled")))))
+                                              :rf.cofx {:rf/time-ms 1781078400123}})
+                     [:rf.cofx :rf/time-ms]))
+          "a valid integer :rf/time-ms rides through preserved"))
+    (testing "a map with NO :rf/time-ms passes (the router fills it)"
+      (let [cofx (get (build-envelope [:noop]
+                                      {:frame :wi/valid
+                                       :rf.cofx {:todo/id 1}})
+                      :rf.cofx)]
+        (is (= 1 (:todo/id cofx)) "the supplied fact rides through")
+        (is (number? (:rf/time-ms cofx)) "the missing :rf/time-ms is filled")))))
 
 (deftest invalid-world-inputs-rejected-before-clock-read
   ;; Mirrors retired-dispatched-at-rejected-before-world-input-clock-read: the
@@ -214,7 +214,7 @@
   ;; fails fast WITHOUT triggering the always-on epoch-now-ms read for a
   ;; dispatch that cannot proceed. Redefine epoch-now-ms to throw a distinct
   ;; marker; if the clock is read before validation, that marker surfaces.
-  (testing "a malformed :rf.world/inputs throws the validation error WITHOUT
+  (testing "a malformed :rf.cofx throws the validation error WITHOUT
             reading the world-input clock first"
     (rf/reg-frame :wi/order2 {:doc "ctx"})
     (with-redefs [interop/epoch-now-ms
@@ -222,14 +222,14 @@
                                          {::clock-read true})))]
       (let [ex   (try
                    (build-envelope [:noop] {:frame :wi/order2
-                                            :rf.world/inputs {:time-ms "now"}})
+                                            :rf.cofx {:rf/time-ms "now"}})
                    nil
                    (catch clojure.lang.ExceptionInfo e e))
             data (ex-data ex)]
         (is (some? ex) "an exception was thrown")
         (is (not (::clock-read data))
             "the world-input clock was NOT read before validation — failed fast")
-        (is (= :rf.error/invalid-world-inputs (:rf.error/id data))
+        (is (= :rf.error/invalid-cofx (:rf.error/id data))
             "the surfaced error is the validation error, proving it ran first")))))
 
 (deftest invalid-world-inputs-raised-through-full-dispatch
@@ -239,15 +239,15 @@
     (is (thrown? clojure.lang.ExceptionInfo
                  (rf/dispatch-sync [:wi/bad-noop]
                                    {:frame :wi/dispatch-bad
-                                    :rf.world/inputs {:time-ms "now"}}))
+                                    :rf.cofx {:rf/time-ms "now"}}))
         "dispatch-sync surfaces the malformed-token error synchronously")))
 
 ;; ===========================================================================
-;; Child dispatch gets its OWN world-input map (no :time-ms inheritance)
+;; Child dispatch gets its OWN world-input map (no :rf/time-ms inheritance)
 ;; ===========================================================================
 
 (deftest child-dispatch-gets-fresh-time-ms
-  (testing "a :fx [[:dispatch ...]] child gets its OWN :rf.world/inputs — :time-ms NOT inherited"
+  (testing "a :fx [[:dispatch ...]] child gets its OWN :rf.cofx — :rf/time-ms NOT inherited"
     (rf/reg-frame :wi/cascade {:doc "ctx"})
     (let [envelopes (atom [])]
       ;; A user fx-handler receives the parent dispatch envelope under
@@ -263,25 +263,25 @@
         (fn [_ _]
           {:fx [[:wi/capture-env]]}))
 
-      ;; Parent supplies an explicit :time-ms; the child must NOT inherit it.
+      ;; Parent supplies an explicit :rf/time-ms; the child must NOT inherit it.
       (rf/dispatch-sync [:wi/parent]
                         {:frame :wi/cascade
-                         :rf.world/inputs {:time-ms 1781078400000}})
+                         :rf.cofx {:rf/time-ms 1781078400000}})
 
       (let [[parent-env child-env] @envelopes
-            parent-t (get-in parent-env [:rf.world/inputs :time-ms])
-            child-t  (get-in child-env  [:rf.world/inputs :time-ms])]
+            parent-t (get-in parent-env [:rf.cofx :rf/time-ms])
+            child-t  (get-in child-env  [:rf.cofx :rf/time-ms])]
         (is (= [:wi/parent] (:event parent-env)) "first capture is the parent")
         (is (= [:wi/child]  (:event child-env))  "second capture is the child")
-        (is (= 1781078400000 parent-t) "parent carries the supplied :time-ms")
-        (is (number? child-t) "child has its own stamped :time-ms")
+        (is (= 1781078400000 parent-t) "parent carries the supplied :rf/time-ms")
+        (is (number? child-t) "child has its own stamped :rf/time-ms")
         (is (not= 1781078400000 child-t)
-            "child did NOT inherit the parent's :time-ms — distinct causal token (EP-0010)")))))
+            "child did NOT inherit the parent's :rf/time-ms — distinct causal token (EP-0010)")))))
 
 ;; ===========================================================================
 ;; rf2-irbjjq: a :dispatch-later child gets FRESH world-inputs stamped at
 ;; FIRE time (the causal boundary is when the deferred dispatch RUNS, not when
-;; it was enqueued) — :time-ms is NOT the parent's, NOT the enqueue-time clock,
+;; it was enqueued) — :rf/time-ms is NOT the parent's, NOT the enqueue-time clock,
 ;; while the inherited envelope fields (:frame / :trace-id / :origin) still
 ;; propagate from the parent.
 ;;
@@ -290,11 +290,11 @@
 ;; time-ms (above) covers the IMMEDIATE :dispatch child; the deferred path is
 ;; distinct because `:dispatch-later` wraps the router `dispatch!` in
 ;; `interop/set-timeout!` (re-frame.fx §reserved-fx-handlers), so the child's
-;; `build-envelope` — and thus its `:rf.world/inputs` stamp — happens inside
+;; `build-envelope` — and thus its `:rf.cofx` stamp — happens inside
 ;; the timer callback, an arbitrary wall-clock interval after the parent
-;; settled. `:rf.world/inputs` is deliberately ABSENT from
+;; settled. `:rf.cofx` is deliberately ABSENT from
 ;; `re-frame.fx/inheritable-envelope-keys`, so the deferred child is stamped
-;; a fresh `:time-ms` at fire from `interop/epoch-now-ms` rather than copying
+;; a fresh `:rf/time-ms` at fire from `interop/epoch-now-ms` rather than copying
 ;; the parent's — the mechanism the existing world-input tests pin only for
 ;; the synchronous case.
 ;;
@@ -302,13 +302,13 @@
 ;; redef) and capture the timer thunk via a `set-timeout!` redef so we fire it
 ;; AFTER advancing — adversarially separating the three candidate stamp times
 ;; (parent token / enqueue clock / fire clock). A regression that inherited
-;; the parent's :time-ms, or that stamped at enqueue time, or that added
-;; :rf.world/inputs to the inheritable set, fails loudly here.
+;; the parent's :rf/time-ms, or that stamped at enqueue time, or that added
+;; :rf.cofx to the inheritable set, fails loudly here.
 ;; ===========================================================================
 
 (deftest dispatch-later-child-gets-fresh-world-inputs-stamped-at-fire-time
   (testing "a :fx [[:dispatch-later …]] child is stamped FRESH world-inputs at
-            FIRE time — :time-ms is the fire-time clock, NOT the parent token,
+            FIRE time — :rf/time-ms is the fire-time clock, NOT the parent token,
             NOT the enqueue-time clock; inherited fields still propagate"
     (rf/reg-frame :wi/later {:doc "ctx"})
     (let [;; mutable wall clock — the value `epoch-now-ms` reads moves between
@@ -342,13 +342,13 @@
                     ;; test is at the deferred dispatch's `build-envelope`,
                     ;; which the inline drain reaches deterministically.
                     interop/next-tick   (fn [f] (f) nil)]
-        ;; Parent supplies an explicit token :time-ms and rides a distinctive
+        ;; Parent supplies an explicit token :rf/time-ms and rides a distinctive
         ;; :trace-id / :origin so we can assert inheritance onto the child.
         (rf/dispatch-sync [:wi.later/parent]
                           {:frame           :wi/later
                            :trace-id        :wi.later/T
                            :origin          :ui
-                           :rf.world/inputs {:time-ms 1781078400000}})
+                           :rf.cofx {:rf/time-ms 1781078400000}})
         ;; ENQUEUE happened at clock=1000; the child's envelope is NOT built yet
         ;; (it is deferred). Advance the wall clock, THEN fire the deferred
         ;; thunk so the child's build-envelope reads the ADVANCED clock.
@@ -359,18 +359,18 @@
         (@deferred))                   ; fire the deferred dispatch at clock=5000
 
       (let [child-env @captured-child
-            child-t   (get-in child-env [:rf.world/inputs :time-ms])]
+            child-t   (get-in child-env [:rf.cofx :rf/time-ms])]
         (is (some? child-env) "the deferred child ran when the thunk fired")
         (is (= [:wi.later/child] (:event child-env)) "captured the child event")
         ;; FRESH at FIRE — the three adversarial candidates are separated:
         (is (= 5000 child-t)
-            "child :time-ms is the FIRE-time clock (5000) — stamped when the
+            "child :rf/time-ms is the FIRE-time clock (5000) — stamped when the
              deferred dispatch RAN, not at enqueue")
         (is (not= 1781078400000 child-t)
-            "child did NOT inherit the parent token's :time-ms — distinct
+            "child did NOT inherit the parent token's :rf/time-ms — distinct
              causal token (EP-0010 §Dispatch Envelope Stamping)")
         (is (not= 1000 child-t)
-            "child :time-ms is NOT the enqueue-time clock — the stamp is read
+            "child :rf/time-ms is NOT the enqueue-time clock — the stamp is read
              at fire, inside the timer callback, not captured at schedule time")
         ;; INHERITED envelope fields still propagate from the parent.
         (is (= :wi/later (:frame child-env))
@@ -384,7 +384,7 @@
         ;; The deferred child's :source reflects its OWN immediate trigger
         ;; (the :dispatch-later fx), NOT inherited (rf2-ejtpd) — a foil that
         ;; confirms the inheritance set is exactly the trace-context keys, not
-        ;; "everything", so :rf.world/inputs being excluded is the same shape.
+        ;; "everything", so :rf.cofx being excluded is the same shape.
         (is (= :fx-dispatch-later (:source child-env))
             "the deferred child's :source is its immediate trigger
              (:fx-dispatch-later), stamped by the fx handler — not inherited")))))
@@ -394,24 +394,24 @@
 ;; ===========================================================================
 
 (deftest world-inputs-visible-as-coeffect
-  (testing "handlers read :rf.world/inputs from the coeffect map"
+  (testing "handlers read :rf.cofx from the coeffect map"
     (rf/reg-frame :wi/cofx {:doc "ctx"})
     (let [cofx (capture-coeffects :wi/cofx
-                                  {:rf.world/inputs {:time-ms 1781078400456}})]
-      (is (contains? cofx :rf.world/inputs)
-          ":rf.world/inputs is a framework coeffect in the initial context")
-      (is (= 1781078400456 (get-in cofx [:rf.world/inputs :time-ms]))
-          "the supplied :time-ms is what the handler reads"))))
+                                  {:rf.cofx {:rf/time-ms 1781078400456}})]
+      (is (contains? cofx :rf.cofx)
+          ":rf.cofx is a framework coeffect in the initial context")
+      (is (= 1781078400456 (get-in cofx [:rf.cofx :rf/time-ms]))
+          "the supplied :rf/time-ms is what the handler reads"))))
 
 (deftest world-inputs-filtered-from-user-cofx-projection
-  (testing "fx/user-injected-coeffects strips :rf.world/inputs like the other framework defaults"
-    (is (contains? fx/framework-coeffect-keys :rf.world/inputs)
-        ":rf.world/inputs is in the framework-coeffect-keys filter set")
+  (testing "fx/user-injected-coeffects strips :rf.cofx like the other framework defaults"
+    (is (contains? fx/framework-coeffect-keys :rf.cofx)
+        ":rf.cofx is in the framework-coeffect-keys filter set")
     (let [cofx {:db {} :event [:e] :rf.db/runtime {} :rf.frame/id :f
-                :rf.world/inputs {:time-ms 1781078400789}
+                :rf.cofx {:rf/time-ms 1781078400789}
                 :my/cofx 1}]
       (is (= {:my/cofx 1} (fx/user-injected-coeffects cofx))
-          ":rf.world/inputs does NOT appear in the user-cofx trace projection"))))
+          ":rf.cofx does NOT appear in the user-cofx trace projection"))))
 
 ;; ===========================================================================
 ;; :dispatched-at is retired
@@ -425,17 +425,17 @@
         (is (not (contains? (build-envelope [:noop] {:frame :wi/no-dispatched-at})
                             :dispatched-at))
             "no :dispatched-at key on the envelope")))
-    (testing "the durable causal-time fact is (:time-ms (:rf.world/inputs env)) instead"
+    (testing "the durable causal-time fact is (:rf/time-ms (:rf.cofx env)) instead"
       (let [env (build-envelope [:noop] {:frame :wi/no-dispatched-at})]
-        (is (number? (get-in env [:rf.world/inputs :time-ms]))
-            ":time-ms is the replacement for the retired :dispatched-at")))))
+        (is (number? (get-in env [:rf.cofx :rf/time-ms]))
+            ":rf/time-ms is the replacement for the retired :dispatched-at")))))
 
 (deftest dispatched-at-supplied-is-a-hard-error
   ;; EP-0010 disposition 5 (rf2-lj39cn): SUPPLYING the retired :dispatched-at
   ;; dispatch opt is the STANDARD RETIREMENT TREATMENT — a HARD ERROR naming
   ;; the replacement, not the soft generic unknown-opt warn. The error carries
   ;; the canonical-replacement category id and a message naming
-  ;; (:time-ms (:rf.world/inputs envelope)).
+  ;; (:rf/time-ms (:rf.cofx envelope)).
   (testing "EP-0010 disposition 5 / EP-0007 rule 2: supplying :dispatched-at throws"
     (rf/reg-frame :wi/retired-supply {:doc "ctx"})
     (testing "build-envelope throws on the retired key (always-on, even with the dev gate OFF)"
@@ -444,7 +444,7 @@
                      (build-envelope [:noop] {:frame :wi/retired-supply
                                               :dispatched-at 123}))
             "supplying :dispatched-at is a hard error, not a warn (prod-survivable)")))
-    (testing "the error names the canonical replacement (:time-ms / :rf.world/inputs)"
+    (testing "the error names the canonical replacement (:rf/time-ms / :rf.cofx)"
       (let [ex   (try
                    (build-envelope [:noop] {:frame :wi/retired-supply
                                             :dispatched-at 123})
@@ -455,10 +455,10 @@
         (is (= :rf.error/dispatched-at-retired (:rf.error/id data))
             "the error category is the retired-spelling :rf.error/* id")
         (is (= :dispatched-at (:retired-key data)) "names the retired key")
-        (is (re-find #":time-ms" (:reason data))
-            "the message references :time-ms as the replacement")
-        (is (re-find #":rf\.world/inputs" (:reason data))
-            "the message references :rf.world/inputs as the replacement carrier")
+        (is (re-find #":rf/time-ms" (:reason data))
+            "the message references :rf/time-ms as the replacement")
+        (is (re-find #":rf\.cofx" (:reason data))
+            "the message references :rf.cofx as the replacement carrier")
         (is (= :no-recovery (:recovery data)) "no back-compat alias / recovery")))
     (testing "the full dispatch path (not just build-envelope) raises it"
       (rf/reg-event-db :wi/retired-noop (fn [db _] db))
@@ -472,7 +472,7 @@
   ;; rf2-s2mizv finding #3: the retired-opt validation runs BEFORE the
   ;; world-input clock stamp, so an invalid dispatch fails fast WITHOUT first
   ;; triggering the always-on `epoch-now-ms` read + world-input map allocation.
-  ;; Pre-fix, `build-envelope` stamped `:rf.world/inputs {:time-ms …}` and only
+  ;; Pre-fix, `build-envelope` stamped `:rf.cofx {:rf/time-ms …}` and only
   ;; THEN rejected `:dispatched-at` — wasting a clock read on a dispatch that
   ;; cannot proceed. We assert ordering by redefining `epoch-now-ms` to throw a
   ;; DISTINCT marker: if the clock is read before the retirement check, that
@@ -497,43 +497,43 @@
              retirement check ran first")))))
 
 ;; ===========================================================================
-;; rf2-sppf0m: a handler READS :uuid / :random from the :rf.world/inputs
-;; coeffect and WRITES the supplied values into a durable app-db entity.
+;; rf2-sppf0m / rf2-alc1lf: a handler READS owner-qualified facts from the
+;; flat :rf.cofx coeffect and WRITES the supplied values into a durable app-db
+;; entity.
 ;;
 ;; This is the EP-0010 §Validation/Conformance bullet — "random/UUID values
 ;; supplied by fixtures become durable ids exactly as supplied" — executed
 ;; against an actual durable WRITE, not merely the envelope pass-through that
-;; `preserves-caller-supplied-extra-keys-and-fills-time-ms` (above) pins. The
-;; EP §Examples "Correct Generated Values From The Token" shows the shape: a
-;; `:todo/create` handler reads `(get-in inputs [:uuid :todo/id])` +
-;; `(get-in inputs [:random :todo/color])` and folds them into app-db so the
-;; replay log explains every durable value. The deferred `:rf.world/uuid` /
-;; `:rf.world/random` framework cofx (EP disposition 2 / rider a) are NOT
-;; involved here — the test scripts the slots directly, exactly as a fixture /
+;; `preserves-caller-supplied-extra-keys-and-fills-time-ms` (above) pins. Under
+;; EP-0017 the recordable coeffects are flat (one fact per owner-qualified key,
+;; no grouping sub-maps): a `:todo/create` handler reads `(:todo/id cofx)` +
+;; `(:todo/color cofx)` and folds them into app-db so the replay log explains
+;; every durable value. No framework generator vocabulary is involved (EP-0017
+;; §Non-Goals) — the test scripts the facts directly, exactly as a fixture /
 ;; replay / SSR-hydration dispatch would, and the handler reads them straight
-;; from the coeffect map.
+;; from the flat coeffect map.
 ;; ===========================================================================
 
 (deftest supplied-uuid-random-become-durable-ids-exactly
-  (testing "a handler reads :uuid / :random from the :rf.world/inputs coeffect
+  (testing "a handler reads owner-qualified facts from the flat :rf.cofx coeffect
             and the supplied values land in app-db EXACTLY as supplied"
     (rf/reg-frame :wi/todos {:doc "ctx"})
     ;; The durable handler: reads the causal token's scripted id + colour from
     ;; the world-input coeffect (NOT an ambient `random-uuid` / `rand-nth`) and
     ;; folds them into a durable app-db entity. `reg-event-fx` so we can read
-    ;; the `:rf.world/inputs` framework coeffect off the cofx map.
+    ;; the `:rf.cofx` framework coeffect off the cofx map.
     (rf/reg-event-fx :todo/create
-      (fn [{:keys [db rf.world/inputs]} [_ text]]
-        (let [id    (get-in inputs [:uuid :todo/id])
-              color (get-in inputs [:random :todo/color])]
+      (fn [{:keys [db] cofx :rf.cofx} [_ text]]
+        (let [id    (:todo/id cofx)
+              color (:todo/color cofx)]
           {:db (assoc-in db [:todos id]
                          {:todo/id id :todo/color color :todo/text text})})))
     (let [id    #uuid "018ff2b4-9bbd-7a0a-a4df-cf2a91cbe86d"
           color :green]
       (rf/dispatch-sync [:todo/create "buy milk"]
                         {:frame :wi/todos
-                         :rf.world/inputs {:uuid   {:todo/id id}
-                                           :random {:todo/color color}}})
+                         :rf.cofx {:todo/id    id
+                                   :todo/color color}})
       (let [entity (get-in (rf/app-db-value :wi/todos) [:todos id])]
         (is (some? entity)
             "the entity is keyed in app-db under the EXACT supplied uuid")
@@ -551,24 +551,24 @@
             diverged run-to-run (EP-0010 §Restore, Replay, And Hydration)"
     (rf/reg-frame :wi/replay {:doc "ctx"})
     (rf/reg-event-fx :todo/create-from-token
-      (fn [{:keys [db rf.world/inputs]} _]
-        (let [id    (get-in inputs [:uuid :todo/id])
-              color (get-in inputs [:random :todo/color])]
+      (fn [{:keys [db] cofx :rf.cofx} _]
+        (let [id    (:todo/id cofx)
+              color (:todo/color cofx)]
           {:db (assoc db :entity {:todo/id id :todo/color color})})))
     ;; The scripted causal token — the SAME map supplied on both runs, exactly
     ;; as a replay / restore would re-feed it.
-    (let [token {:uuid   {:todo/id #uuid "018ff2b4-9bbd-7a0a-a4df-cf2a91cbe86d"}
-                 :random {:todo/color :blue}}
+    (let [token {:todo/id    #uuid "018ff2b4-9bbd-7a0a-a4df-cf2a91cbe86d"
+                 :todo/color :blue}
           run!  (fn []
                   (rf/dispatch-sync [:todo/create-from-token]
-                                    {:frame :wi/replay :rf.world/inputs token})
+                                    {:frame :wi/replay :rf.cofx token})
                   (:entity (rf/app-db-value :wi/replay)))
           first-entity  (run!)
           second-entity (run!)]
       (is (= first-entity second-entity)
           "two runs of the same token produce IDENTICAL durable entities —
            replay-stable")
-      (is (= (get-in token [:uuid :todo/id]) (:todo/id second-entity))
+      (is (= (:todo/id token) (:todo/id second-entity))
           "the reproduced durable id is the token's id, not a fresh draw")
       ;; Contrast: an ambient generator (random-uuid / rand-nth) folded into a
       ;; durable write would have produced two DIFFERENT ids across the two
@@ -589,13 +589,13 @@
 ;; This is the positive half of the EP-0008 / EP-0010 causal-vs-diagnostic
 ;; split (§Validation/Conformance bullet: "ambient diagnostic timestamps may
 ;; differ without changing durable state"). The runtime records BOTH a durable
-;; CAUSAL time (the token's `:rf.world/inputs` `:time-ms` → the epoch record's
+;; CAUSAL time (the token's `:rf.cofx` `:rf/time-ms` → the epoch record's
 ;; `:committed-at`, read ONCE at the causal boundary from `epoch-now-ms`) AND
 ;; ambient DIAGNOSTIC times (the trace event `:time`, stamped from the elapsed
 ;; `interop/now-ms` at every emit). The bullet asserts the ambient ones are
 ;; free to vary run-to-run while the durable projection stays EQUAL.
 ;;
-;; We run the SAME scripted token (same supplied `:time-ms`) twice under two
+;; We run the SAME scripted token (same supplied `:rf/time-ms`) twice under two
 ;; DIFFERENT ambient clocks and assert:
 ;;   (a) the durable :committed-at is EQUAL across both runs (it folds the
 ;;       supplied token time, never the ambient clock), AND
@@ -612,7 +612,7 @@
             :committed-at EQUAL while the diagnostic trace :time DIFFERS"
     (rf/reg-frame :wi/split {:doc "ctx"})
     (rf/reg-event-db :wi/note (fn [db _] (update db :n (fnil inc 0))))
-    (let [token-time   1781078400123     ; the supplied causal token :time-ms
+    (let [token-time   1781078400123     ; the supplied causal token :rf/time-ms
           ;; capture the diagnostic trace :time of THIS frame's :wi/note event
           ;; per run — the trace `:time` is stamped from the ambient
           ;; `interop/now-ms` (re-frame.trace/build-event), the diagnostic
@@ -635,14 +635,14 @@
                            ;; Pin BOTH host clocks to the SAME per-run ambient
                            ;; value so the trace :time is deterministic within
                            ;; the run yet DIFFERENT between the two runs, while
-                           ;; the SUPPLIED token :time-ms rides through
-                           ;; unchanged (the router only fills :time-ms when
+                           ;; the SUPPLIED token :rf/time-ms rides through
+                           ;; unchanged (the router only fills :rf/time-ms when
                            ;; absent — see preserves-caller-supplied-time-ms).
                            (with-redefs [interop/now-ms       (constantly ambient-clock)
                                          interop/epoch-now-ms (constantly ambient-clock)]
                              (rf/dispatch-sync [:wi/note]
                                                {:frame :wi/split
-                                                :rf.world/inputs {:time-ms token-time}}))
+                                                :rf.cofx {:rf/time-ms token-time}}))
                            (rf/unregister-listener! ::split-probe)
                            (swap! trace-times conj @seen)
                            ;; the durable :committed-at of the just-settled epoch
@@ -651,9 +651,9 @@
           committed-2  (run! 9999999)]
       ;; (a) DURABLE side — equal across the two ambient clocks.
       (is (= token-time committed-1)
-          "run 1: durable :committed-at folds the supplied token :time-ms")
+          "run 1: durable :committed-at folds the supplied token :rf/time-ms")
       (is (= token-time committed-2)
-          "run 2: durable :committed-at folds the SAME supplied token :time-ms")
+          "run 2: durable :committed-at folds the SAME supplied token :rf/time-ms")
       (is (= committed-1 committed-2)
           "durable :committed-at is EQUAL across runs — wall-clock drift
            between the two commits did not change durable state")

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -13,7 +13,7 @@
     :epoch-id       opaque, unique within a frame's history
     :frame          frame keyword
     :committed-at   the committing event's CAUSAL time — its envelope's
-                    `:rf.world/inputs` `:time-ms`, stamped at the router's
+                    `:rf.cofx` `:rf/time-ms`, stamped at the router's
                     causal boundary (rf2-bh56rc / EP-0010 §Time), NOT an
                     ambient assembly-time clock read; replayable
     :event-id       the event keyword that triggered the cascade
@@ -233,7 +233,7 @@
   canonical pin. `db-before` / `db-after` are the pre-cascade and
   destroy-time snapshots `destroy-frame!` captured before the frame was
   removed (both nil for an out-of-cascade destroy). `committed-at`
-  (rf2-bh56rc) is the destroying event's causal `:time-ms`, used for the
+  (rf2-bh56rc) is the destroying event's causal `:rf/time-ms`, used for the
   `:halted-destroy` record's replayable `:committed-at`."
   [frame-id db-before db-after committed-at]
   (listeners/on-frame-destroyed! frame-id db-before db-after committed-at))
@@ -281,7 +281,7 @@
 
   `committed-at` is the record's durable causal time — per EP-0010 §Time
   and Spec 002 §The World-Input Rule (rf2-bh56rc) the committing causal
-  token's `:rf.world/inputs` `:time-ms`, threaded down from the router's
+  token's `:rf.cofx` `:rf/time-ms`, threaded down from the router's
   per-event settle / depth-halt seam, NOT an ambient host-clock read at
   assembly time. This makes `:committed-at` replayable."
   [frame-id frame-state-before frame-state-after events committed-at outcome halt-reason trigger-event]
@@ -352,12 +352,12 @@
 
   `committed-at` is the record's durable causal time — per EP-0010 §Time
   (epoch record causal time) and Spec 002 §The World-Input Rule
-  (rf2-bh56rc) the committing causal token's `:rf.world/inputs` `:time-ms`,
+  (rf2-bh56rc) the committing causal token's `:rf.cofx` `:rf/time-ms`,
   read ONCE at the causal boundary (envelope construction) and threaded
   down here by the router's per-event settle seam (`settle-event-epoch!`),
   NOT an ambient host-clock read at assembly time. This makes the record's
   `:committed-at` replayable: the same event log replayed with the same
-  supplied `:time-ms` values yields records with equal `:committed-at`.
+  supplied `:rf/time-ms` values yields records with equal `:committed-at`.
 
   Arities:
     (settle! frame-id frame-state-before frame-state-after committed-at)
@@ -449,7 +449,7 @@
 
   `committed-at` is the record's durable causal time — per EP-0010 §Time
   and Spec 002 §The World-Input Rule (rf2-bh56rc) the halting causal
-  token's `:rf.world/inputs` `:time-ms`, threaded down from the router's
+  token's `:rf.cofx` `:rf/time-ms`, threaded down from the router's
   `handle-depth-exceeded!` seam, NOT an ambient host-clock read. The
   halting event never ran, but its envelope carries a `:time-ms` stamped
   at its dispatch (the causal boundary); using it keeps even this

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -357,10 +357,10 @@
   "Assemble a `:rf/epoch-record`. `committed-at` is the record's durable
   causal time — per EP-0010 §Time (epoch record causal time) and Spec 002
   §The World-Input Rule it MUST be the committing causal token's
-  `:rf.world/inputs` `:time-ms`, threaded down from the router's settle /
+  `:rf.cofx` `:rf/time-ms`, threaded down from the router's settle /
   halt seam, NOT an ambient host-clock read at assembly time. Threading
-  the token's `:time-ms` makes `:committed-at` replayable: replaying the
-  same event log with the same supplied `:time-ms` values produces records
+  the token's `:rf/time-ms` makes `:committed-at` replayable: replaying the
+  same event log with the same supplied `:rf/time-ms` values produces records
   with equal `:committed-at`, and a restored frame-state's recorded
   timestamps are not silently reinterpreted against a new ambient clock.
 
@@ -443,7 +443,7 @@
               :frame              frame-id
               ;; EP-0010 §Time (epoch record causal time) + Spec 002 §The
               ;; World-Input Rule (rf2-bh56rc): the durable causal-time fact
-              ;; is the committing token's `:rf.world/inputs` `:time-ms`,
+              ;; is the committing token's `:rf.cofx` `:rf/time-ms`,
               ;; threaded in via `committed-at` — NOT an ambient
               ;; `interop/now-ms` read at assembly time. The one `now-ms`
               ;; read happens ONCE at the causal boundary (envelope

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -301,7 +301,7 @@
   (rf2-3aizt1, decision #2): the canonical snapshot unit is the whole
   frame-state; `build-record` derives the `:db-*` app-db projections.
 
-  `committed-at` (rf2-bh56rc) is the destroying event's causal `:time-ms`
+  `committed-at` (rf2-bh56rc) is the destroying event's causal `:rf/time-ms`
   (the router-bound `frame/*cascade-time-ms*`, threaded through
   `destroy-frame!`), used for the `:halted-destroy` record's
   `:committed-at` so it is replayable per EP-0010 §Time rather than an

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -577,7 +577,7 @@
   failed restore leaks no resource success traces.
 
   Per rf2-wshzsp the restore's CAUSAL time — `restore-time-ms`, the restored
-  epoch's `:committed-at` (the committing token's `:rf.world/inputs` `:time-ms`,
+  epoch's `:committed-at` (the committing token's `:rf.cofx` `:rf/time-ms`,
   replay-stable per EP-0010 §Time) — is threaded through `:restore-time-ms` so
   the reconcile stamps a dangled-on-restore mutation instance's DURABLE
   `:settled-at` from that causal input rather than the live install clock
@@ -684,8 +684,8 @@
             ;; and a pre-restore reply cannot write stale data into a restored
             ;; entry.
             ;; rf2-wshzsp: thread the restored epoch's CAUSAL time
-            ;; (`:committed-at` = the committing token's `:rf.world/inputs`
-            ;; `:time-ms`) so the reconcile stamps a dangled-on-restore
+            ;; (`:committed-at` = the committing token's `:rf.cofx`
+            ;; `:rf/time-ms`) so the reconcile stamps a dangled-on-restore
             ;; mutation instance's durable `:settled-at` from a replay-stable
             ;; causal input, not the live install clock (EP-0010 §Restore/Replay).
             frame-state-target (reconcile-runtime-db-on-restore

--- a/implementation/epoch/test/re_frame/epoch_committed_at_clock_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_committed_at_clock_cljs_test.cljs
@@ -9,7 +9,7 @@
   `committed-at-replay-stable-across-wall-clock-drift`,
   `committed-at-each-child-event-reads-its-own-token`, …) lives in
   `re-frame.epoch-test` — a `.clj` (JVM-ONLY) file — and SCRIPTS the
-  committing token's `:rf.world/inputs` `:time-ms` to an explicit sentinel
+  committing token's `:rf.cofx` `:rf/time-ms` to an explicit sentinel
   (pinning BOTH `now-ms` AND `epoch-now-ms` with `with-redefs`). That proves
   the causal-time THREADING (token `:time-ms` -> `:committed-at`, replayable,
   no ambient assembly-time read), but it deliberately bypasses the live
@@ -27,7 +27,7 @@
   (`resources_http_completed_at_clock_cljs_test.cljs`) was added.
 
   This suite drives the REAL router: it dispatches an UNSCRIPTED event (no
-  `:rf.world/inputs` supplied), lets the genuine `build-envelope` stamp the
+  `:rf.cofx` supplied), lets the genuine `build-envelope` stamp the
   causal `:time-ms` from the host clock, and asserts the resulting durable
   epoch record `:committed-at` is a wall-clock epoch value (within ~10s of
   `js/Date.now()`), NOT a small perf-clock origin-relative number. A clock
@@ -58,7 +58,7 @@
 (def ^:private wall-clock-floor 1e12)
 
 (deftest committed-at-unscripted-dispatch-is-wall-clock-epoch-cljs
-  (testing "rf2-1t30y7 — an UNSCRIPTED dispatch (no :rf.world/inputs) flows
+  (testing "rf2-1t30y7 — an UNSCRIPTED dispatch (no :rf.cofx) flows
             through the live router, which stamps the causal :time-ms from
             the host clock; the resulting epoch record :committed-at MUST be
             a wall-clock epoch ms (close to js/Date.now), NOT a perf-clock
@@ -72,7 +72,7 @@
 
     ;; Capture js/Date.now() bracketing the dispatch so the comparison band
     ;; is tight and robust to scheduling. The dispatch is intentionally
-    ;; UNSCRIPTED — no :rf.world/inputs — so build-envelope performs the live
+    ;; UNSCRIPTED — no :rf.cofx — so build-envelope performs the live
     ;; clock read that is the unit under test.
     (let [before (js/Date.now)]
       (rf/dispatch-sync [:clk/init])

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -185,7 +185,7 @@
 ;;
 ;; Per EP-0010 §Time (epoch record causal time) + Spec 002 §The World-Input
 ;; Rule: the durable :committed-at fact MUST come from the committing causal
-;; token's `:rf.world/inputs` :time-ms (read ONCE at the causal boundary,
+;; token's `:rf.cofx` :time-ms (read ONCE at the causal boundary,
 ;; envelope construction, from `interop/epoch-now-ms` per rf2-n1rh0f), NOT an
 ;; ambient clock read at epoch assembly time. These tests pin that conversion:
 ;; they stub BOTH host clocks (`interop/now-ms` + `interop/epoch-now-ms`) to a
@@ -195,7 +195,7 @@
 
 (deftest committed-at-comes-from-supplied-token-time-ms
   (testing "the durable :committed-at on a clean settle is the committing
-            token's `:rf.world/inputs` :time-ms — NOT an ambient now-ms
+            token's `:rf.cofx` :time-ms — NOT an ambient now-ms
             read at assembly time (rf2-bh56rc / EP-0010 §Time)"
     (rf/reg-frame :test/main {})
     (rf/reg-event-db :seed (fn [_ _] {:n 0}))
@@ -211,7 +211,7 @@
       (with-redefs [interop/now-ms       (constantly clock-time)
                     interop/epoch-now-ms (constantly clock-time)]
         (rf/dispatch-sync [:seed] {:frame            :test/main
-                                   :rf.world/inputs {:time-ms token-time}}))
+                                   :rf.cofx {:rf/time-ms token-time}}))
       (let [r (last (rf/epoch-history :test/main))]
         (is (= token-time (:committed-at r))
             ":committed-at is the supplied token :time-ms — replayable")
@@ -235,11 +235,11 @@
       (with-redefs [interop/now-ms       (constantly 100)
                     interop/epoch-now-ms (constantly 100)]
         (rf/dispatch-sync [:seed] {:frame            :test/main
-                                   :rf.world/inputs {:time-ms token-time}}))
+                                   :rf.cofx {:rf/time-ms token-time}}))
       (with-redefs [interop/now-ms       (constantly 8888888888888)
                     interop/epoch-now-ms (constantly 8888888888888)]
         (rf/dispatch-sync [:inc]  {:frame            :test/main
-                                   :rf.world/inputs {:time-ms token-time}}))
+                                   :rf.cofx {:rf/time-ms token-time}}))
       (let [history (rf/epoch-history :test/main)]
         (is (= 2 (count history)))
         (is (= [token-time token-time]
@@ -272,7 +272,7 @@
       (rf/dispatch-sync [:seed] {:frame :test/main})
       (with-redefs [interop/epoch-now-ms (constantly child-clock)]
         (rf/dispatch-sync [:parent] {:frame            :test/main
-                                     :rf.world/inputs {:time-ms parent-time}}))
+                                     :rf.cofx {:rf/time-ms parent-time}}))
       (let [history    (rf/epoch-history :test/main)
             by-event   (into {} (map (juxt :event-id :committed-at)) history)]
         (is (= parent-time (get by-event :parent))
@@ -919,7 +919,7 @@
 
 (deftest perform-restore!-threads-restored-epoch-causal-time-as-restore-time-ms
   (testing "rf2-wshzsp — perform-restore! threads the RESTORED epoch's causal
-            :committed-at (the committing token's :rf.world/inputs :time-ms,
+            :committed-at (the committing token's :rf.cofx :time-ms,
             replay-stable per EP-0010 §Time) into the reconcile hook as
             :restore-time-ms — NOT the live install wall clock. The hook stamps a
             dangled-on-restore mutation instance's durable :settled-at from it, so
@@ -947,7 +947,7 @@
         ;; Commit the mid-flight epoch under a SCRIPTED causal token time so the
         ;; restored epoch's :committed-at is a known sentinel-distinct value.
         (rf/dispatch-sync [:put-resource] {:frame           :test/main
-                                           :rf.world/inputs {:time-ms token-time}})
+                                           :rf.cofx {:rf/time-ms token-time}})
         (let [mid-record (last (rf/epoch-history :test/main))
               mid-epoch  (:epoch-id mid-record)]
           (is (= token-time (:committed-at mid-record))
@@ -1736,7 +1736,7 @@
       (with-redefs [interop/now-ms (constantly clock-time)]
         (rf/dispatch-sync [:self-destruct]
                           {:frame            :test/short-lived
-                           :rf.world/inputs {:time-ms token-time}}))
+                           :rf.cofx {:rf/time-ms token-time}}))
       (is (= 1 (count @halted))
           "exactly one :halted-destroy record reached the listener")
       (let [r (first @halted)]

--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -259,23 +259,23 @@
   `:rf/dispatch-origin :http` was collapsed — `:source :http` is now
   the single axis.
 
-  EP-0010 (rf2-n1rh0f / rf2-40dqi6 / rf2-r65m41): the reply is a CAUSAL
-  TOKEN, and the host completion time (`:completed-at`, read ONCE at
-  finalisation in `reply-ctx`) is carried as the reply dispatch's
-  `:rf.world/inputs` `:time-ms`. The router PRESERVES a supplied
-  `:rf.world/inputs` that already carries `:time-ms` (it only fills a
-  missing one), so a reply reducer deriving a durable timestamp reads it
-  off the reply event's world inputs — the causal completion fact, never
-  a fresh ambient clock read in the handler. When `completed-at` is absent
-  (a synthetic / canned reply with no host clock read), the router stamps
-  the dispatch time as usual."
+  EP-0010 / EP-0017 (rf2-n1rh0f / rf2-40dqi6 / rf2-r65m41 / rf2-alc1lf): the
+  reply is a CAUSAL TOKEN, and the host completion time (`:completed-at`, read
+  ONCE at finalisation in `reply-ctx`) is carried as the reply dispatch's
+  `:rf.cofx` `:rf/time-ms`. The router PRESERVES a supplied `:rf.cofx` that
+  already carries `:rf/time-ms` (it only fills a missing one), so a reply
+  reducer deriving a durable timestamp reads it off the reply event's
+  recordable coeffects — the causal completion fact, never a fresh ambient
+  clock read in the handler. When `completed-at` is absent (a synthetic /
+  canned reply with no host clock read), the router stamps the dispatch time
+  as usual."
   [args frame]
   (when-let [ev (build-reply-event args)]
     (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
       (dispatch! ev (cond-> {:source :http}
                       frame                  (assoc :frame frame)
-                      (:completed-at args)   (assoc :rf.world/inputs
-                                                    {:time-ms (:completed-at args)}))))))
+                      (:completed-at args)   (assoc :rf.cofx
+                                                    {:rf/time-ms (:completed-at args)}))))))
 
 (defn build-reply-event
   "Per Spec 014 §Reply addressing. Returns the event vector to dispatch,

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -442,8 +442,8 @@
   `opts` carries `:frame`, `:middleware-ctx`, the three keys
   `dispatch-reply-via-late-bind!` consumes (`:origin-event`,
   `:explicit-on`, `:kind`), and the EP-0010 `:completed-at` causal
-  completion time threaded onto the reply dispatch's `:rf.world/inputs`
-  (rf2-n1rh0f). No-op when the router is absent / the reply is silenced
+  completion time threaded onto the reply dispatch's `:rf.cofx`
+  (rf2-n1rh0f / rf2-alc1lf). No-op when the router is absent / the reply is silenced
   (delegated to `dispatch-reply-via-late-bind!`)."
   [{:keys [frame middleware-ctx origin-event explicit-on reply-payload kind completed-at]}]
   (let [final-payload (if middleware-ctx

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -80,9 +80,9 @@
        :explicit-on    explicit
        :reply-payload  reply-payload
        :kind           kind
-       ;; EP-0010 (rf2-n1rh0f): the host completion time rides the reply
-       ;; dispatch's `:rf.world/inputs` `:time-ms` so a reply reducer reads
-       ;; it as causal data, never a fresh clock.
+       ;; EP-0010 / EP-0017 (rf2-n1rh0f / rf2-alc1lf): the host completion time
+       ;; rides the reply dispatch's `:rf.cofx` `:rf/time-ms` so a reply reducer
+       ;; reads it as causal data, never a fresh clock.
        :completed-at   completed-at})))
 
 ;; rf2-zqefg3.2 — the canonical-reply lowering seam (EP-0011 §Managed HTTP
@@ -108,7 +108,7 @@
   Managed-Effects §Causal completion metadata).
 
   EP-0010 §Time (rf2-2elcw3): `:completed-at` is DURABLE causal time — it
-  flows through `:rf.world/inputs` `:time-ms` into resource `:loaded-at` /
+  flows through `:rf.cofx` `:rf/time-ms` into resource `:loaded-at` /
   `:stale-at` and mutation `:settled-at`, which freshness readers compare
   against `js/Date.now`. It MUST therefore be wall-clock epoch ms
   (`epoch-now-ms`), NOT `now-ms` — on CLJS `now-ms` is `performance.now()`

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -231,14 +231,14 @@
         ;; `(.now)`. Per spec/Managed-Effects.md §155/§231 a machine
         ;; completion that affects durable state (a spawned child's
         ;; `:on-done` mutating the parent's `:data`) MUST carry causal
-        ;; completion metadata. The router's `:rf.world/inputs` `:time-ms`
-        ;; (EP-0010 — the single causal-boundary clock read) is threaded
-        ;; onto the machine def under `:rf/world-inputs`
+        ;; completion metadata. The router's `:rf.cofx` `:rf/time-ms`
+        ;; (EP-0010 / EP-0017 — the single causal-boundary clock read) is
+        ;; threaded onto the machine def under `:rf/cofx`
         ;; (lifecycle-fx.registration); read it here so the done reply +
         ;; trace carry the causal time instead of silently losing it. nil
-        ;; when the trigger was unscripted (no world-input) — omitted, not
+        ;; when the trigger was unscripted (no recordable cofx) — omitted, not
         ;; nil-filled (Managed-Effects §The reply map).
-        completed-at (get-in machine [:rf/world-inputs :time-ms])
+        completed-at (get-in machine [:rf/cofx :rf/time-ms])
         reply-ctx   (cond-> {:actor-id          machine-id
                              :parent-id         parent-id
                              :work-bearing-path invoke-id
@@ -357,7 +357,7 @@
                                 :rf.reply/work-id     (:work/id done-summary)
                                 :rf.reply/work-status (:work/status done-summary)}
                          ;; (rf2-6mfkp3) the causal completion timestamp — the
-                         ;; router's `:rf.world/inputs` `:time-ms` threaded
+                         ;; router's `:rf.cofx` `:rf/time-ms` threaded
                          ;; into the reply (Managed-Effects §155/§231: a
                          ;; completion affecting durable state carries causal
                          ;; completion metadata). Additive + present-only so

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -348,19 +348,19 @@
   `:rf.error/machine-state-not-in-definition` or
   `:rf.error/machine-snapshot-version-mismatch` event.
 
-  Per EP-0010 (rf2-g0m4p5): the event handler's causal world-input token
-  (`world-inputs` — the router's `:rf.world/inputs` coeffect, Spec 002
-  §Event Context And Coeffects) is stamped onto the machine def under
-  `:rf/world-inputs` alongside `:rf/frame` / `:rf/platform` / `:rf/parent-id`,
+  Per EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): the event handler's causal
+  recordable-coeffect token (`cofx` — the router's `:rf.cofx` coeffect, Spec
+  002 §Event Context And Coeffects) is stamped onto the machine def under
+  `:rf/cofx` alongside `:rf/frame` / `:rf/platform` / `:rf/parent-id`,
   so the transition engine's `callback-ctx` can surface it to guards /
-  actions / entry / exit under `:rf.world/inputs`. A durable machine
+  actions / entry / exit under `:rf.cofx`. A durable machine
   decision (time / random / UUID host fact) reads the causal token rather
   than an ambient clock, so the decision and any snapshot write replay
   deterministically. `nil` (the router always supplies the coeffect, but a
   REPL `reg-machine*` dispatch through a non-router path may not) leaves the
   slot absent — `callback-ctx` then surfaces no key and the pure-fn callers
   (conformance corpus) are unaffected."
-  [db runtime-db frame world-inputs event machine base-initial]
+  [db runtime-db frame cofx event machine base-initial]
   (let [machine-id    (first event)
         ;; EP-0002 — `frame` is the cascade-threaded envelope frame the
         ;; calling machine handler already asserted via
@@ -371,11 +371,12 @@
                                      :rf/frame     frame-id
                                      :rf/platform  platform
                                      :rf/parent-id machine-id)
-                        ;; EP-0010 (rf2-g0m4p5): thread the causal world-input
-                        ;; token onto the machine def so `callback-ctx` exposes
-                        ;; it as `:rf.world/inputs`. Stamp only when present so
-                        ;; the absent-token path stays clean for pure-fn callers.
-                        (some? world-inputs) (assoc :rf/world-inputs world-inputs))
+                        ;; EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): thread
+                        ;; the causal recordable-coeffect token onto the machine
+                        ;; def so `callback-ctx` exposes it as `:rf.cofx`. Stamp
+                        ;; only when present so the absent-token path stays clean
+                        ;; for pure-fn callers.
+                        (some? cofx) (assoc :rf/cofx cofx))
         path          (paths/snapshot-path machine-id)
         existing-snap (get-in runtime-db path)
         snapshot      (cond
@@ -672,7 +673,7 @@
   (let [base-initial (delay (parallel/build-initial-snapshot
                               machine {:bootstrap-pending? false}))]
     (fn [{:keys [db] frame :rf.frame/id rt :rf.db/runtime
-          world-inputs :rf.world/inputs :as _cofx} event]
+          cofx :rf.cofx :as _cofx} event]
       ;; EP-0002 carried invariant: a machine handler is invoked inside an
       ;; event cascade, so the cofx ALWAYS carries the frame stamp under
       ;; `:rf.frame/id` (the HELD stamp). A nil stamp is an invariant
@@ -696,7 +697,7 @@
       ;; is still threaded for the spawn-`:on-error` parent lookup +
       ;; action-failure diagnostics.
       (let [runtime-db  (or rt {})
-            ctx         (prepare-machine-ctx db runtime-db frame world-inputs event machine base-initial)
+            ctx         (prepare-machine-ctx db runtime-db frame cofx event machine base-initial)
             intercepted (join/intercept-spawn-all-event
                           (:machine ctx) runtime-db (:path ctx) (:snapshot ctx)
                           (:machine-id ctx) (:inner-event ctx))]

--- a/implementation/machines/src/re_frame/machines/parallel.cljc
+++ b/implementation/machines/src/re_frame/machines/parallel.cljc
@@ -131,11 +131,12 @@
         (assoc :rf/parent-id      (:rf/parent-id parent-machine))
         (assoc :rf/platform       (:rf/platform parent-machine))
         (assoc :rf/frame          (:rf/frame parent-machine))
-        ;; EP-0010 (rf2-g0m4p5): inherit the causal world-input token so a
-        ;; region's guard / action reads `:rf.world/inputs` causally too. The
-        ;; cached spec's value is overlaid live in `region-spec-overlaid`
-        ;; (the token is dynamic, stamped per dispatch by `prepare-machine-ctx`).
-        (assoc :rf/world-inputs   (:rf/world-inputs parent-machine))
+        ;; EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): inherit the causal
+        ;; recordable-coeffect token so a region's guard / action reads
+        ;; `:rf.cofx` causally too. The cached spec's value is overlaid live in
+        ;; `region-spec-overlaid` (the token is dynamic, stamped per dispatch by
+        ;; `prepare-machine-ctx`).
+        (assoc :rf/cofx           (:rf/cofx parent-machine))
         (assoc :rf/region         region-name))))
 
 (defn region-machine
@@ -353,13 +354,14 @@
       ;; runtime) and must replace any stale cached value.
       true (assoc :rf/platform (:rf/platform parent-machine)
                   :rf/frame    (:rf/frame parent-machine))
-      ;; EP-0010 (rf2-g0m4p5): overlay the live causal world-input token so a
-      ;; region guard / action reads the CURRENT dispatch's `:rf.world/inputs`
-      ;; (the cache was populated at registration time, before the token was
-      ;; stamped). Only when present so the absent path leaves the cached spec
-      ;; free of a stale slot — `callback-ctx` keys off presence.
-      (contains? parent-machine :rf/world-inputs)
-      (assoc :rf/world-inputs (:rf/world-inputs parent-machine)))))
+      ;; EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): overlay the live causal
+      ;; recordable-coeffect token so a region guard / action reads the CURRENT
+      ;; dispatch's `:rf.cofx` (the cache was populated at registration time,
+      ;; before the token was stamped). Only when present so the absent path
+      ;; leaves the cached spec free of a stale slot — `callback-ctx` keys off
+      ;; presence.
+      (contains? parent-machine :rf/cofx)
+      (assoc :rf/cofx (:rf/cofx parent-machine)))))
 
 (defn- reduce-regions
   "Apply `step-fn` to each region of `parent-machine` in declaration

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -235,14 +235,14 @@
   the parallel-region marker: present iff this is a region snapshot, so
   flat / compound machines surface neither key and their ctx is unchanged.
 
-  Per EP-0010 (rf2-g0m4p5): when the event handler's causal world-input
-  token (the router's `:rf.world/inputs` coeffect — Spec 002 §Event Context
-  And Coeffects) has been threaded onto the machine def under `:rf/world-inputs`
-  (stamped by `prepare-machine-ctx` alongside `:rf/frame` / `:rf/platform` /
-  `:rf/parent-id`, and propagated to region specs), surface it on the ctx
-  under the SAME `:rf.world/inputs` key. A durable guard / action that
+  Per EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf): when the event handler's
+  causal recordable-coeffect token (the router's `:rf.cofx` coeffect — Spec
+  002 §Event Context And Coeffects) has been threaded onto the machine def
+  under `:rf/cofx` (stamped by `prepare-machine-ctx` alongside `:rf/frame` /
+  `:rf/platform` / `:rf/parent-id`, and propagated to region specs), surface
+  it on the ctx under the SAME `:rf.cofx` key. A durable guard / action that
   decides on time / random / UUID host facts then reads
-  `(:time-ms (:rf.world/inputs ctx))` — the causal token — instead of an
+  `(:rf/time-ms (:rf.cofx ctx))` — the causal token — instead of an
   ambient `interop/now-ms`, so machine decisions and snapshot writes replay
   deterministically. Absent for pure-fn callers (conformance corpus / JVM
   fixtures) that drive the engine without a router coeffect — the key is
@@ -254,16 +254,16 @@
            :meta  (:meta snapshot)}
     (contains? snapshot :all-state) (assoc :all-state (:all-state snapshot)
                                            :tags      (:tags snapshot))
-    (contains? machine :rf/world-inputs) (assoc :rf.world/inputs
-                                                (:rf/world-inputs machine))))
+    (contains? machine :rf/cofx) (assoc :rf.cofx
+                                        (:rf/cofx machine))))
 
 (defn- call-guard
   "Invoke a resolved guard fn against a snapshot + event with the unified
   context-map contract — `(fn [{:keys [data event state meta]}] boolean)`.
   Per Spec 005 §Guards (rf2-grw4i / rf2-v0rrr); a parallel region's guard
   additionally receives `:tags` + `:all-state` (rf2-46ly6 / rf2-69d1n), and —
-  per EP-0010 (rf2-g0m4p5) — the causal `:rf.world/inputs` token when the
-  handler threaded it onto the machine def."
+  per EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf) — the causal `:rf.cofx`
+  token when the handler threaded it onto the machine def."
   [machine g snapshot event]
   (g (callback-ctx machine snapshot event)))
 
@@ -272,8 +272,8 @@
   context-map contract — `(fn [{:keys [data event state meta]}] effects)`.
   Per Spec 005 §Actions (rf2-grw4i / rf2-v0rrr); a parallel region's action
   additionally receives `:tags` + `:all-state` (rf2-46ly6 / rf2-69d1n), and —
-  per EP-0010 (rf2-g0m4p5) — the causal `:rf.world/inputs` token when the
-  handler threaded it onto the machine def."
+  per EP-0010 / EP-0017 (rf2-g0m4p5 / rf2-alc1lf) — the causal `:rf.cofx`
+  token when the handler threaded it onto the machine def."
   [machine f snapshot event]
   (f (callback-ctx machine snapshot event)))
 

--- a/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
+++ b/implementation/machines/test/re_frame/cross_region_guard_ctx_test.clj
@@ -225,7 +225,7 @@
   (testing "a FLAT machine's guard ctx carries the four base keys — no :tags,
             no :all-state (the parallel-region keys never leak to a flat
             machine). A router-driven dispatch ALSO carries the EP-0010 causal
-            :rf.world/inputs token (rf2-g0m4p5); the cross-region keys stay
+            :rf.cofx token (rf2-g0m4p5); the cross-region keys stay
             absent."
     (let [captured (atom nil)
           m {:initial :idle
@@ -240,7 +240,7 @@
       (rf/dispatch-sync [:flat/ctx [:go]])
       (is (= :done (:state (snapshot :flat/ctx))))
       (is (= #{:data :event :state :meta}
-             (set (keys (dissoc @captured :rf.world/inputs))))
+             (set (keys (dissoc @captured :rf.cofx))))
           "flat guard ctx carries the four base keys (+ the EP-0010 causal
            token a router dispatch always stamps — rf2-g0m4p5)")
       (is (not (contains? @captured :tags))
@@ -253,7 +253,7 @@
 (deftest compound-guard-ctx-has-no-cross-region-keys
   (testing "a COMPOUND machine's guard ctx also carries the four base keys and
             none of the parallel-region keys (a router dispatch additionally
-            carries the EP-0010 :rf.world/inputs token — rf2-g0m4p5)"
+            carries the EP-0010 :rf.cofx token — rf2-g0m4p5)"
     (let [captured (atom nil)
           m {:initial :parent
              :data    {}
@@ -265,7 +265,7 @@
       (rf/reg-machine :compound/ctx m)
       (rf/dispatch-sync [:compound/ctx [:go]])
       (is (= #{:data :event :state :meta}
-             (set (keys (dissoc @captured :rf.world/inputs))))
+             (set (keys (dissoc @captured :rf.cofx))))
           "compound guard ctx carries the four base keys (+ the EP-0010 causal
            token a router dispatch always stamps — rf2-g0m4p5)")
       (is (not (contains? @captured :tags))

--- a/implementation/machines/test/re_frame/machine_after_timer_fresh_causal_token_test.clj
+++ b/implementation/machines/test/re_frame/machine_after_timer_fresh_causal_token_test.clj
@@ -7,7 +7,7 @@
   `[<parent-id> [:rf.machine.timer/after-elapsed ...]]` dispatch back into
   the parent machine. That dispatch is a DISPATCH ENVELOPE in its own right
   — and per EP-0010 every dispatch envelope stamps or supplies its OWN
-  `:rf.world/inputs` at its OWN causal boundary. Timer/child tokens MUST
+  `:rf.cofx` at its OWN causal boundary. Timer/child tokens MUST
   NOT inherit a parent's `:time-ms`: the timer-fire envelope is a DISTINCT
   causal token, stamped fresh at FIRE time.
 
@@ -15,8 +15,8 @@
   `schedule-after-timer!` installs the host-clock callback via
   `interop/schedule-after!`; that callback calls the late-bound
   `:router/dispatch!` with `{:frame ... :source :after-timer}` and
-  DELIBERATELY supplies NO `:rf.world/inputs`. So the router (build-envelope)
-  stamps a fresh `{:time-ms (interop/epoch-now-ms)}` at fire time — the
+  DELIBERATELY supplies NO `:rf.cofx`. So the router (build-envelope)
+  stamps a fresh `{:rf/time-ms (interop/epoch-now-ms)}` at fire time — the
   timer-driven guard/action reads the FIRE-time token, not the scheduling-
   time parent token.
 
@@ -25,9 +25,9 @@
   `dispatch-sync`. NONE drive the REAL `:after` timer-fire boundary, where
   the token is router-STAMPED (not supplied). `after_test.clj` drives the
   `:after` semantics by dispatching the synthetic `after-elapsed` event by
-  HAND (no `:rf.world/inputs`), so it never exercises the stamping either. A
+  HAND (no `:rf.cofx`), so it never exercises the stamping either. A
   regression that made the timer callback INHERIT the parent/scheduling
-  token (e.g. by threading the entry dispatch's `:rf.world/inputs` through to
+  token (e.g. by threading the entry dispatch's `:rf.cofx` through to
   the `after-elapsed` dispatch opts) would pass every existing test. This
   test fails on exactly that regression.
 
@@ -73,7 +73,7 @@
 
 (deftest after-timer-fire-stamps-fresh-causal-token
   (testing "the :after timer's dispatched event carries a FRESH router-
-            stamped :rf.world/inputs :time-ms at FIRE time (not the parent
+            stamped :rf.cofx :time-ms at FIRE time (not the parent
             scheduling-time token) — driven through the REAL
             interop/schedule-after! fire boundary (rf2-hg39nf)"
     (let [;; The mutable host clock the router's epoch-now-ms reads. Starts
@@ -82,7 +82,7 @@
           ;; The timer-callback thunk captured by the stubbed schedule-after!.
           captured-thunk  (atom nil)
           ;; What the :after-transition guard + action actually observed off
-          ;; (:rf.world/inputs ctx) at fire time.
+          ;; (:rf.cofx ctx) at fire time.
           guard-saw       (atom ::unset)
           action-saw      (atom ::unset)
           ;; The machine: :loading bears an :after whose transition both
@@ -91,13 +91,13 @@
           m {:initial :idle
              :data    {}
              :guards  {:capture-fire-time
-                       (fn [{inputs :rf.world/inputs}]
-                         (reset! guard-saw (:time-ms inputs))
+                       (fn [{cofx :rf.cofx}]
+                         (reset! guard-saw (:rf/time-ms cofx))
                          true)}
              :actions {:stamp-fire-time
-                       (fn [{inputs :rf.world/inputs}]
-                         (reset! action-saw (:time-ms inputs))
-                         {:data {:fired-at (:time-ms inputs)}})}
+                       (fn [{cofx :rf.cofx}]
+                         (reset! action-saw (:rf/time-ms cofx))
+                         {:data {:fired-at (:rf/time-ms cofx)}})}
              :states  {:idle    {:on {:fetch :loading}}
                        :loading {:after {5000 {:target :timeout
                                                :guard  :capture-fire-time
@@ -119,7 +119,7 @@
         ;; would equal PARENT here — but we ADVANCE the clock before firing,
         ;; so a fresh stamp MUST diverge.
         (rf/dispatch-sync [:after-fresh/m [:fetch]]
-                          {:rf.world/inputs {:time-ms PARENT-TIME-MS}})
+                          {:rf.cofx {:rf/time-ms PARENT-TIME-MS}})
         (is (= :loading (:state (snapshot :after-fresh/m)))
             "entered the :after-bearing state")
         (is (some? @captured-thunk)
@@ -133,8 +133,8 @@
         ;; entry dispatch-sync has returned), so routing :router/dispatch!
         ;; through dispatch-sync! is legal and keeps the cascade inline +
         ;; deterministic on the JVM. The thunk calls dispatch! with
-        ;; {:frame ... :source :after-timer} and NO :rf.world/inputs, so the
-        ;; router stamps {:time-ms @clock} = CHILD afresh.
+        ;; {:frame ... :source :after-timer} and NO :rf.cofx, so the
+        ;; router stamps {:rf/time-ms @clock} = CHILD afresh.
         (try
           (late-bind/set-fn! :router/dispatch! router/dispatch-sync!)
           (@captured-thunk)
@@ -148,7 +148,7 @@
       ;; (5) THE CONTRACT: both callbacks saw the FRESH FIRE-TIME token —
       ;; CHILD — not the PARENT scheduling-time token. This is the
       ;; assertion that fails if the timer callback ever inherits the
-      ;; parent envelope's :rf.world/inputs.
+      ;; parent envelope's :rf.cofx.
       (is (= CHILD-TIME-MS @guard-saw)
           "the :after guard read the FRESH fire-time :time-ms (router-
            stamped at fire), NOT the parent scheduling-time token")

--- a/implementation/machines/test/re_frame/machine_reply_lowering_test.clj
+++ b/implementation/machines/test/re_frame/machine_reply_lowering_test.clj
@@ -348,7 +348,7 @@
 ;;     completion can mutate durable parent-machine data (:on-done writes
 ;;     the parent's :data). Per spec/Managed-Effects.md §155/§231 a
 ;;     completion that affects durable state MUST carry causal completion
-;;     metadata — the ROUTER's `:rf.world/inputs` `:time-ms` (EP-0010, the
+;;     metadata — the ROUTER's `:rf.cofx` `:rf/time-ms` (EP-0010, the
 ;;     single causal-boundary clock read), NOT an ambient host-clock read.
 ;;     The production finalize path threads that world-input time into the
 ;;     reply-ctx so the done reply + `:rf.machine/done` trace carry the
@@ -356,7 +356,7 @@
 ;; ===========================================================================
 
 (deftest spawned-completion-threads-causal-completed-at
-  (testing "the done reply trace carries the CAUSAL :completed-at — the finishing event's :rf.world/inputs :time-ms — when a spawned child completion mutates durable parent data"
+  (testing "the done reply trace carries the CAUSAL :completed-at — the finishing event's :rf.cofx :time-ms — when a spawned child completion mutates durable parent data"
     (let [traces      (capture-traces ::completed-at)
           completed-at 1781078400888]                ;; the causal token time
       (try
@@ -380,10 +380,10 @@
                                             (assoc data :token-from-child result))}}}})
         (rf/dispatch-sync [:rl/cparent [:go]])
         ;; The child finishes under a SCRIPTED causal time — the finishing
-        ;; dispatch supplies :rf.world/inputs {:time-ms completed-at}, the
+        ;; dispatch supplies :rf.cofx {:rf/time-ms completed-at}, the
         ;; one host-clock read the router captures at the causal boundary.
         (rf/dispatch-sync [:rl/cchild#1 [:finish :secret-token]]
-                          {:rf.world/inputs {:time-ms completed-at}})
+                          {:rf.cofx {:rf/time-ms completed-at}})
         ;; Behavioural parity: :on-done still ran with the canonical value.
         (is (= :secret-token (get-in (snapshot :rl/cparent) [:data :token-from-child]))
             ":on-done mutated the parent's durable :data (the §155/§231 case)")
@@ -393,11 +393,11 @@
           (is (some? done) ":rf.machine/done trace fired")
           (let [tags (:tags done)]
             ;; THE coverage gap: the causal completion timestamp rides the
-            ;; done trace — the supplied :rf.world/inputs :time-ms VERBATIM,
+            ;; done trace — the supplied :rf.cofx :time-ms VERBATIM,
             ;; not an ambient clock read. Both the additive reply-envelope
             ;; spelling and the bare :completed-at carry it.
             (is (= completed-at (:rf.reply/completed-at tags))
-                "the causal :rf.world/inputs :time-ms rides the done reply trace")
+                "the causal :rf.cofx :time-ms rides the done reply trace")
             (is (= completed-at (:completed-at tags))
                 "the bare :completed-at fact carries the same causal time")
             ;; sanity: the rest of the canonical envelope is intact.
@@ -406,7 +406,7 @@
         (finally (trace/unregister-listener! ::completed-at))))))
 
 (deftest unscripted-completion-omits-completed-at
-  (testing "adversarial: an UNSCRIPTED completion (no :rf.world/inputs) carries NO :completed-at — the fact is OMITTED, never nil-filled or stamped from an ambient clock (Managed-Effects §The reply map)"
+  (testing "adversarial: an UNSCRIPTED completion (no :rf.cofx) carries NO :completed-at — the fact is OMITTED, never nil-filled or stamped from an ambient clock (Managed-Effects §The reply map)"
     (let [traces (capture-traces ::no-completed-at)]
       (try
         (rf/reg-machine :rl/uchild
@@ -425,7 +425,7 @@
                               :on-done    (fn [{data :data result :result}]
                                             (assoc data :token-from-child result))}}}})
         (rf/dispatch-sync [:rl/uparent [:go]])
-        ;; The finishing dispatch supplies NO :rf.world/inputs — the
+        ;; The finishing dispatch supplies NO :rf.cofx — the
         ;; unscripted path. The router seeds its own world-inputs only when
         ;; running the full dispatch path with a clock; in this direct
         ;; dispatch-sync with no override the machine def carries whatever

--- a/implementation/machines/test/re_frame/machine_world_inputs_ctx_test.clj
+++ b/implementation/machines/test/re_frame/machine_world_inputs_ctx_test.clj
@@ -4,7 +4,7 @@
 
   EP-0010 requires that durable machine decisions and snapshot writes
   depending on time / random / UUID-style host facts fold the CAUSAL
-  world-input token (the router's `:rf.world/inputs` coeffect, stamped at
+  world-input token (the router's `:rf.cofx` coeffect, stamped at
   the dispatch envelope's causal boundary — Spec 002 §The World-Input
   Rule) rather than reading an ambient clock (`interop/now-ms`). Folding
   the token is what makes the decision deterministic under restore /
@@ -17,14 +17,14 @@
   so a durable machine guard / action had no causal way to read host facts
   and fell back to ambient reads.
 
-  The fix threads the handler's `:rf.world/inputs` coeffect onto the
+  The fix threads the handler's `:rf.cofx` coeffect onto the
   machine def (`prepare-machine-ctx`, alongside `:rf/frame` /
   `:rf/platform` / `:rf/parent-id`, propagated to region specs) and
-  surfaces it on the callback ctx under the SAME `:rf.world/inputs` key.
+  surfaces it on the callback ctx under the SAME `:rf.cofx` key.
 
   Coverage:
     (a) a flat-machine GUARD reads exactly the scripted `:time-ms` from
-        `(:rf.world/inputs ctx)` — no ambient clock — and decides on it.
+        `(:rf.cofx ctx)` — no ambient clock — and decides on it.
     (b) a flat-machine ACTION reads exactly the scripted `:time-ms` and
         folds it into a `:data` write (a durable snapshot write).
     (c) an :entry action (on the initial-entry boot cascade) reads the
@@ -34,7 +34,7 @@
     (e) a non-time fact (random / UUID-style) supplied in the SAME token
         map is readable verbatim — the token carries arbitrary host facts.
     (f) the absent-token path: a pure `machine-transition` call (no router
-        coeffect) surfaces NO `:rf.world/inputs` ctx key — the key keys
+        coeffect) surfaces NO `:rf.cofx` ctx key — the key keys
         off presence, so pure-fn callers (conformance corpus) are
         unaffected."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -56,7 +56,7 @@
 ;; ---- (a) a flat-machine GUARD reads the scripted :time-ms -----------------
 
 (deftest guard-reads-causal-time-ms
-  (testing "a guard reads exactly the dispatch's :rf.world/inputs :time-ms —
+  (testing "a guard reads exactly the dispatch's :rf.cofx :time-ms —
             the causal token, not an ambient clock"
     (let [seen (atom nil)
           ;; The guard fires the transition iff the causal :time-ms equals
@@ -64,16 +64,16 @@
           m {:initial :idle
              :data    {}
              :guards  {:at-scripted-time?
-                       (fn [{inputs :rf.world/inputs}]
-                         (reset! seen (:time-ms inputs))
-                         (= SCRIPTED-TIME-MS (:time-ms inputs)))}
+                       (fn [{cofx :rf.cofx}]
+                         (reset! seen (:rf/time-ms cofx))
+                         (= SCRIPTED-TIME-MS (:rf/time-ms cofx)))}
              :states  {:idle {:on {:go {:target :done :guard :at-scripted-time?}}}
                        :done {}}}]
       (rf/reg-machine :world/guard m)
       (rf/dispatch-sync [:world/guard [:go]]
-                        {:rf.world/inputs {:time-ms SCRIPTED-TIME-MS}})
+                        {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
       (is (= SCRIPTED-TIME-MS @seen)
-          "the guard read the scripted :time-ms off (:rf.world/inputs ctx)")
+          "the guard read the scripted :time-ms off (:rf.cofx ctx)")
       (is (= :done (:state (snapshot :world/guard)))
           "the guard fired the transition on the causal :time-ms"))))
 
@@ -83,13 +83,13 @@
     (let [m {:initial :idle
              :data    {}
              :guards  {:at-scripted-time?
-                       (fn [{inputs :rf.world/inputs}]
-                         (= SCRIPTED-TIME-MS (:time-ms inputs)))}
+                       (fn [{cofx :rf.cofx}]
+                         (= SCRIPTED-TIME-MS (:rf/time-ms cofx)))}
              :states  {:idle {:on {:go {:target :done :guard :at-scripted-time?}}}
                        :done {}}}]
       (rf/reg-machine :world/guard-block m)
       (rf/dispatch-sync [:world/guard-block [:go]]
-                        {:rf.world/inputs {:time-ms (inc SCRIPTED-TIME-MS)}})
+                        {:rf.cofx {:rf/time-ms (inc SCRIPTED-TIME-MS)}})
       (is (= :idle (:state (snapshot :world/guard-block)))
           ":go blocked — the causal :time-ms did not match the guard's predicate"))))
 
@@ -101,13 +101,13 @@
     (let [m {:initial :idle
              :data    {}
              :actions {:stamp-time
-                       (fn [{inputs :rf.world/inputs}]
-                         {:data {:stamped-at (:time-ms inputs)}})}
+                       (fn [{cofx :rf.cofx}]
+                         {:data {:stamped-at (:rf/time-ms cofx)}})}
              :states  {:idle {:on {:go {:target :done :action :stamp-time}}}
                        :done {}}}]
       (rf/reg-machine :world/action m)
       (rf/dispatch-sync [:world/action [:go]]
-                        {:rf.world/inputs {:time-ms SCRIPTED-TIME-MS}})
+                        {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
       (is (= SCRIPTED-TIME-MS (:stamped-at (:data (snapshot :world/action))))
           "the action wrote the causal :time-ms into :data — folded from the
            token, not from an ambient clock"))))
@@ -120,14 +120,14 @@
     (let [m {:initial :ready
              :data    {}
              :actions {:stamp-birth
-                       (fn [{inputs :rf.world/inputs}]
-                         {:data {:born-at (:time-ms inputs)}})}
+                       (fn [{cofx :rf.cofx}]
+                         {:data {:born-at (:rf/time-ms cofx)}})}
              :states  {:ready {:entry :stamp-birth}}}]
       (rf/reg-machine :world/entry m)
       ;; First real dispatch boots the machine; the :entry cascade runs under
       ;; the same handler call and so reads this dispatch's causal token.
       (rf/dispatch-sync [:world/entry [:noop]]
-                        {:rf.world/inputs {:time-ms SCRIPTED-TIME-MS}})
+                        {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
       (is (= SCRIPTED-TIME-MS (:born-at (:data (snapshot :world/entry))))
           "the :entry action read the causal :time-ms on the boot cascade"))))
 
@@ -139,8 +139,8 @@
     (let [m {:type    :parallel
              :data    {}
              :guards  {:at-scripted-time?
-                       (fn [{inputs :rf.world/inputs}]
-                         (= SCRIPTED-TIME-MS (:time-ms inputs)))}
+                       (fn [{cofx :rf.cofx}]
+                         (= SCRIPTED-TIME-MS (:rf/time-ms cofx)))}
              :regions
              {:a {:initial :idle
                   :states  {:idle {:on {:go {:target :done
@@ -149,7 +149,7 @@
               :b {:initial :x :states {:x {}}}}}]
       (rf/reg-machine :world/region m)
       (rf/dispatch-sync [:world/region [:go]]
-                        {:rf.world/inputs {:time-ms SCRIPTED-TIME-MS}})
+                        {:rf.cofx {:rf/time-ms SCRIPTED-TIME-MS}})
       (is (= :done (get-in (snapshot :world/region) [:state :a]))
           "the region guard fired on the causal :time-ms — the token reached
            the region callback ctx")))
@@ -157,8 +157,8 @@
     (let [m {:type    :parallel
              :data    {}
              :guards  {:at-scripted-time?
-                       (fn [{inputs :rf.world/inputs}]
-                         (= SCRIPTED-TIME-MS (:time-ms inputs)))}
+                       (fn [{cofx :rf.cofx}]
+                         (= SCRIPTED-TIME-MS (:rf/time-ms cofx)))}
              :regions
              {:a {:initial :idle
                   :states  {:idle {:on {:go {:target :done
@@ -167,7 +167,7 @@
               :b {:initial :x :states {:x {}}}}}]
       (rf/reg-machine :world/region-block m)
       (rf/dispatch-sync [:world/region-block [:go]]
-                        {:rf.world/inputs {:time-ms (inc SCRIPTED-TIME-MS)}})
+                        {:rf.cofx {:rf/time-ms (inc SCRIPTED-TIME-MS)}})
       (is (= :idle (get-in (snapshot :world/region-block) [:state :a]))
           "the region guard blocked — wrong causal :time-ms"))))
 
@@ -181,14 +181,14 @@
           m {:initial :idle
              :data    {}
              :actions {:stamp-facts
-                       (fn [{inputs :rf.world/inputs}]
-                         {:data {:seed (:rng-seed inputs)
-                                 :id   (:new-uuid inputs)}})}
+                       (fn [{cofx :rf.cofx}]
+                         {:data {:seed (:rng-seed cofx)
+                                 :id   (:new-uuid cofx)}})}
              :states  {:idle {:on {:go {:target :done :action :stamp-facts}}}
                        :done {}}}]
       (rf/reg-machine :world/facts m)
       (rf/dispatch-sync [:world/facts [:go]]
-                        {:rf.world/inputs {:time-ms  SCRIPTED-TIME-MS
+                        {:rf.cofx {:rf/time-ms  SCRIPTED-TIME-MS
                                            :rng-seed seed
                                            :new-uuid gen-uuid}})
       (let [d (:data (snapshot :world/facts))]
@@ -197,11 +197,11 @@
         (is (= gen-uuid (:id d))
             "the action read the causal uuid-style fact off the token")))))
 
-;; ---- (f) absent token — pure-fn caller surfaces no :rf.world/inputs key ----
+;; ---- (f) absent token — pure-fn caller surfaces no :rf.cofx key ----
 
 (deftest pure-fn-callback-ctx-has-no-world-inputs-key
   (testing "a pure machine-transition (no router coeffect, the conformance /
-            JVM-fixture path) surfaces NO :rf.world/inputs ctx key — the key
+            JVM-fixture path) surfaces NO :rf.cofx ctx key — the key
             is presence-gated, so pure-fn callers are unaffected"
     (let [captured (atom nil)
           m {:initial :idle
@@ -210,10 +210,10 @@
              :states  {:idle {:on {:go {:target :done :guard :capture}}}
                        :done {}}}]
       ;; Drive the PURE engine directly — no dispatch, no handler, so the
-      ;; machine def carries no :rf/world-inputs stamp.
+      ;; machine def carries no :rf/cofx stamp.
       (machines/machine-transition m {:state :idle :data {}} [:go])
       (is (some? @captured) "the guard ran")
-      (is (not (contains? @captured :rf.world/inputs))
-          "no :rf.world/inputs key when the engine is driven without a token")
+      (is (not (contains? @captured :rf.cofx))
+          "no :rf.cofx key when the engine is driven without a token")
       (is (= #{:data :event :state :meta} (set (keys @captured)))
           "the pure-fn guard ctx is exactly the four base keys"))))

--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -77,7 +77,7 @@
 ;;
 ;; EP-0010 §The World-Input Rule (rf2-95b0lc): event handlers in this
 ;; namespace take their "now" from the triggering token's causal
-;; `(:time-ms (:rf.world/inputs cofx))` — the one host-clock read the router
+;; `(:rf/time-ms (:rf.cofx coeffects))` — the one host-clock read the router
 ;; stamped at the causal boundary — NOT an ambient `(.now js/Date)` /
 ;; `System/currentTimeMillis` read at the decision site. There is therefore no
 ;; private host-clock helper here: a handler reading the live host clock for a
@@ -127,7 +127,7 @@
 
   `force-new?` false (ensure) ALSO short-circuits a FRESH-SKIP: an
   `ensure` of an already-`:loaded` entry that is still fresh-by-policy
-  (`state/entry-stale?` false against the token's causal `(:time-ms world)`)
+  (`state/entry-stale?` false against the token's causal `(:rf/time-ms cofx)`)
   neither dedupes (no
   in-flight work to join) nor starts a fetch — it serves the cached value,
   attaches the supplied owner lease, emits `:rf.resource/cache-hit`, and
@@ -142,7 +142,7 @@
 
   Returns the event-fx map `{:rf.db/runtime :fx}`."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, gen-snapshot :rf.resource/generation
-    world :rf.world/inputs, app-db :db}
+    cofx :rf.cofx, app-db :db}
    {:keys [resource owner cause keep-previous?] :as payload} {:keys [force-new? where]}]
   (let [runtime-db (or rt {})
         spec       (registry/require-resource-spec! resource where)
@@ -196,20 +196,20 @@
         ;; a FRESHNESS DECISION that gates a DURABLE runtime-db write — the
         ;; fresh branch serves cache (no new work-ledger row), the stale
         ;; branch mints a new generation + work record. The basis MUST be the
-        ;; triggering token's causal `(:time-ms world)` (already in scope and
+        ;; triggering token's causal `(:rf/time-ms cofx)` (already in scope and
         ;; used below for the durable `:started-at`), NOT an ambient
         ;; `(now-ms)` host read — otherwise a replay under a LATER live clock
         ;; could take the OPPOSITE branch (refetch vs serve-cache) and produce
         ;; a divergent work-ledger, breaking the EP's same-tokens→equal-durable
         ;; -projections property at the decision boundary. The durable
         ;; `:stale-at`/`:loaded-at` facts the entry carries are still the
-        ;; freshness data; `(:time-ms world)` is the causal "now" they are
+        ;; freshness data; `(:rf/time-ms cofx)` is the causal "now" they are
         ;; compared against (EP §Restore: "freshness decisions made lazily
         ;; from that token plus durable timestamps").
         fresh-skip? (and (not force-new?)
                          (not in-flight?)
                          (= :loaded (:status entry))
-                         (not (state/entry-stale? entry (:time-ms world))))
+                         (not (state/entry-stale? entry (:rf/time-ms cofx))))
         ;; a NEW owner lease lands on the entry when an owner is supplied and
         ;; was not already in the active-owner set. `:rf.resource/owner-attached`
         ;; marks that liveness change distinctly from work — symmetric with the
@@ -320,7 +320,7 @@
             ;; plus the configured timeout policy — NOT an ambient clock read
             ;; in the reducer. Replay-stable: the same ensure/refetch token
             ;; mints the same `:started-at` / `:deadline-at`.
-            started-at (:time-ms world)
+            started-at (:rf/time-ms cofx)
             deadline   (when-let [ms (:timeout-ms spec)] (+ started-at ms))
             entry'     (cond-> (state/entry-start-load
                                  entry {:generation generation :work-id work-id
@@ -442,7 +442,7 @@
 ;;   - DURABLE stale/fresh timestamps decide WHETHER — `state/entry-stale?`
 ;;     (the single shared freshness derivation the subs / SSR / stale-timer
 ;;     re-check all use) against the focus/reconnect token's causal
-;;     `(:time-ms world)` (rf2-95b0lc — not an ambient host-clock read at the
+;;     `(:rf/time-ms cofx)` (rf2-95b0lc — not an ambient host-clock read at the
 ;;     scan site, so the SELECTION is replay-stable); a fresh entry is LEFT
 ;;     ALONE;
 ;;   - GENERATION CHECKS suppress stale replies — the refetch lowers through
@@ -554,14 +554,14 @@
   EP-0010 §The World-Input Rule (rf2-95b0lc): the active-stale SELECTION is a
   freshness decision — it picks which entries get a `:refetch` dispatched —
   so its basis is the triggering focus/reconnect token's causal
-  `(:time-ms world)`, not an ambient `(now-ms)` host read. The scan writes
+  `(:rf/time-ms cofx)`, not an ambient `(now-ms)` host read. The scan writes
   nothing durable itself (the child refetches do, each stamped with its own
   fresh world inputs), so this is the softer of the three sites; but a
   replayed focus/reconnect must still SELECT the same set the recorded
   `:time-ms` dictated, or the replay diverges from the original run."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs} signal cause]
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, cofx :rf.cofx} signal cause]
   (let [runtime-db (or rt {})
-        eligible   (active-stale-scan runtime-db (:time-ms world))
+        eligible   (active-stale-scan runtime-db (:rf/time-ms cofx))
         refetches  (mapv (fn [{:keys [resource scope params]}]
                            [:dispatch [:rf.resource/refetch
                                        {:resource resource :scope scope
@@ -705,7 +705,7 @@
   stale-mark / refetch decision, so it keeps its fresh populated value and arms
   no refetch. The summary carries `:exempt` (the exempt keys that actually
   matched the tags, so Xray can show what the populate spared)."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, cofx :rf.cofx}
    [_event-id {:keys [scope tags cause cross-scope? exempt-keys]}]]
   (let [runtime-db (or rt {})
         ;; FAIL CLOSED (rf2-pvdae1): a scoped (default) invalidation MUST
@@ -771,7 +771,7 @@
         ;; at the dispatch boundary), NOT an ambient clock read in the
         ;; reducer. Replay-stable: re-running the same invalidation token
         ;; rewrites the SAME `:invalidated-at`.
-        invalidated-at (:time-ms world)
+        invalidated-at (:rf/time-ms cofx)
         entries    (get-in runtime-db (state/entries-path))
         ;; EP-0016 Rider 1 — keys this same mutation just POPULATED
         ;; authoritatively are EXEMPT from this pass (kept fresh, never
@@ -1303,19 +1303,19 @@
   transport appends `{:kind :success :value <decoded-data>}` as the last arg
   (Spec 014 §Reply addressing); the decoded data is read from there
   (`reply-success-data`) and re-lifted into the canonical `:value`."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, cofx :rf.cofx}
    [_event-id {work-id :work/id :keys [resource-key generation] :as payload} http-result]]
   (let [runtime-db (or rt {})
         value      (reply-success-data payload http-result)
         ;; EP-0010 §Managed Effects And Reply Tokens / §Resources, Mutations,
         ;; And Work-Ledger Timestamps: the reply is a CAUSAL TOKEN. The host
         ;; completion time (`:completed-at`, read ONCE at the transport
-        ;; finalisation boundary) rides the reply event's `:rf.world/inputs`
-        ;; `:time-ms` — the reply handler MUST NOT re-read the clock. It is
+        ;; finalisation boundary) rides the reply event's `:rf.cofx`
+        ;; `:rf/time-ms` — the reply handler MUST NOT re-read the clock. It is
         ;; carried onto the canonical reply map as `:completed-at` (the
         ;; uniform-reply spelling) and is the source of the durable
         ;; `:loaded-at`.
-        completed-at (:time-ms world)
+        completed-at (:rf/time-ms cofx)
         ;; the ONE canonical reply map every managed-async family produces
         ;; (Managed-Effects §The uniform reply envelope). The internal
         ;; resource reply target receives it DIRECTLY (no public `{:kind …}`
@@ -1599,7 +1599,7 @@
       stale entry refreshes on its next live cause: route re-entry, an
       explicit event, or the focus/reconnect active-stale scan
       `revalidate-handler`, rf2-vtblcq)."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, cofx :rf.cofx}
    [_event-id {:keys [resource-key]}]]
   (let [runtime-db (or rt {})
         entry      (get-in runtime-db (state/entry-path resource-key))
@@ -1611,13 +1611,13 @@
         ;;
         ;; EP-0010 §Resources / §The World-Input Rule (rf2-95b0lc): a TIMER-
         ;; FIRE event's freshness re-check uses the timer-fire envelope's own
-        ;; causal `(:time-ms world)`, not an ambient `(now-ms)` host read.
+        ;; causal `(:rf/time-ms cofx)`, not an ambient `(now-ms)` host read.
         ;; This handler writes nothing durable (the decision is trace-only —
         ;; the durable `:stale-at` already drives the `:stale?` sub), but the
         ;; recorded `:decision` must be replay-stable: a replayed
         ;; `:stale-fired` under a later live clock must classify the entry the
         ;; same way the recorded `:time-ms` did.
-        stale?     (state/entry-stale? entry (:time-ms world))]
+        stale?     (state/entry-stale? entry (:rf/time-ms cofx))]
     (trace/emit! :rf.event :rf.resource/stale-fired
                  {:rf.frame/id frame-id :resource-key resource-key
                   :decision (cond (nil? entry) :no-entry

--- a/implementation/resources/src/re_frame/resources/mutation_events.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_events.cljc
@@ -77,11 +77,11 @@
 
 ;; ---- durable timestamps ---------------------------------------------------
 ;;
-;; EP-0010: every durable mutation timestamp is a causal world input — the
-;; instance / work-ledger `:started-at` is the `:rf.mutation/execute` token's
-;; `:time-ms` (rf2-dsyqmz); the terminal `:settled-at` + any patch / populate
-;; `:loaded-at` is the reply token's completion time (`:completed-at`, carried
-;; on the reply event's `:rf.world/inputs`, rf2-40dqi6 / rf2-r65m41). No
+;; EP-0010 / EP-0017: every durable mutation timestamp is a recordable coeffect
+;; — the instance / work-ledger `:started-at` is the `:rf.mutation/execute`
+;; token's `:rf/time-ms` (rf2-dsyqmz); the terminal `:settled-at` + any patch /
+;; populate `:loaded-at` is the reply token's completion time (`:completed-at`,
+;; carried on the reply event's `:rf.cofx`, rf2-40dqi6 / rf2-r65m41). No
 ;; ambient clock is read at a durable write site, so this ns no longer defines
 ;; a `now-ms` helper (the remaining timer DELAYS are advisory host transients
 ;; computed from the durable absolute timestamps).
@@ -613,7 +613,7 @@
 
   Returns the event-fx map (`:rf.db/runtime` + `:fx`)."
   [{rt :rf.db/runtime, frame-id :rf.frame/id, gen-snapshot :rf.resource/generation
-    world :rf.world/inputs, app-db :db}
+    cofx :rf.cofx, app-db :db}
    [_event-id {:keys [mutation instance scope cause reply-to] :as payload}]]
   (let [where      'rf.mutation/execute
         runtime-db (or rt {})
@@ -664,7 +664,7 @@
         ;; world input the router stamped once at the dispatch boundary), NOT
         ;; an ambient clock read in the reducer. Replay-stable: the same
         ;; execute token mints the same `:started-at`.
-        started-at (:time-ms world)
+        started-at (:rf/time-ms cofx)
         transport-id (or (:transport spec) transport/default-transport)
         ;; the mutation's :request returns the Spec 014 managed-HTTP args
         ;; (the causal write); the runtime owns reply addressing.
@@ -982,18 +982,18 @@
   (the instance-layer spelling — kh9jz6 / EP-0007).
 
   Event shape: `[_ <verification-payload> <http-result>]`."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs, app-db :db}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, cofx :rf.cofx, app-db :db}
    [_event-id {work-id :work/id :keys [instance-id mutation-id generation scope reply-to] :as payload} http-result]]
   (let [where      'rf.mutation.internal/succeeded
         runtime-db (or rt {})
         ;; EP-0010 §Managed Effects And Reply Tokens / §Resources, Mutations,
         ;; And Work-Ledger Timestamps: the reply is a CAUSAL TOKEN; the host
         ;; completion time (`:completed-at`, read ONCE at the transport
-        ;; finalisation boundary) rides the reply event's `:rf.world/inputs`
-        ;; `:time-ms`. The handler MUST NOT re-read the clock. It carries onto
+        ;; finalisation boundary) rides the reply event's `:rf.cofx`
+        ;; `:rf/time-ms`. The handler MUST NOT re-read the clock. It carries onto
         ;; the canonical reply as `:completed-at` and is the source of the
         ;; terminal `:settled-at` + any patch/populate `:loaded-at`.
-        completed-at (:time-ms world)
+        completed-at (:rf/time-ms cofx)
         ;; the ONE canonical reply map (Managed-Effects §The uniform reply
         ;; envelope), `:work/kind :mutation`. The internal mutation reply
         ;; target receives it directly; the decoded result is `:value`.
@@ -1198,7 +1198,7 @@
   `:error` stores) is read back from the canonical reply.
 
   Event shape: `[_ <verification-payload> <http-result>]`."
-  [{rt :rf.db/runtime, frame-id :rf.frame/id, world :rf.world/inputs, app-db :db}
+  [{rt :rf.db/runtime, frame-id :rf.frame/id, cofx :rf.cofx, app-db :db}
    [_event-id {work-id :work/id :keys [instance-id mutation-id generation scope reply-to] :as payload} http-result]]
   (let [where      'rf.mutation.internal/failed
         runtime-db (or rt {})
@@ -1206,10 +1206,10 @@
         ;; And Work-Ledger Timestamps: a terminal mutation reply writes
         ;; `:settled-at` from the reply completion time. The host
         ;; `:completed-at` (read ONCE at the transport finalisation boundary)
-        ;; rides the reply event's `:rf.world/inputs` `:time-ms`; the handler
+        ;; rides the reply event's `:rf.cofx` `:rf/time-ms`; the handler
         ;; MUST NOT re-read the clock. Carried onto the canonical reply as
         ;; `:completed-at`.
-        completed-at (:time-ms world)
+        completed-at (:rf/time-ms cofx)
         ;; the ONE canonical reply map (Managed-Effects §The uniform reply
         ;; envelope), `:work/kind :mutation`. `:error` carries the closed
         ;; `:rf.http/*` envelope the instance `:error` also stores.

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -1221,8 +1221,8 @@
     (idempotent; the only failure path is an already-destroyed frame whose
     transients were already released).
   - `:restore-time-ms` (rf2-wshzsp) — the restore's CAUSAL time: the restored
-    epoch's `:committed-at` (the committing token's `:rf.world/inputs`
-    `:time-ms`, replay-stable per EP-0010 §Time). It is the source of the
+    epoch's `:committed-at` (the committing token's `:rf.cofx`
+    `:rf/time-ms`, replay-stable per EP-0010 §Time). It is the source of the
     DURABLE `:settled-at` stamped on a PENDING mutation instance dangled on
     restore — NOT the live install clock (`now-ms`). Per EP-0010 §Restore/Replay
     a durable frame-state field MUST come from a causal input, never an ambient
@@ -1284,7 +1284,7 @@
              ;; frame-state field, so per EP-0010 §Time + §Restore/Replay it MUST
              ;; come from the restore's CAUSAL time (`restore-time-ms` — the
              ;; restored epoch's `:committed-at`, itself the committing token's
-             ;; `:rf.world/inputs` `:time-ms`), NOT the ambient `clock-ms`
+             ;; `:rf.cofx` `:rf/time-ms`), NOT the ambient `clock-ms`
              ;; (`now-ms`) read above. Sourcing it from the live install clock
              ;; would make the durable stamp non-replayable (the exact shape the
              ;; EP's restore clause warns against: a durable write fed by an

--- a/implementation/resources/test/re_frame/replay_determinism_e2e_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/replay_determinism_e2e_cljs_test.cljc
@@ -6,7 +6,7 @@
   ## What the EP promises (and what was missing)
 
   EP-0010's headline guarantee: a recorded epoch — a token log with
-  `:rf.world/inputs` (`:time-ms` / `:uuid` / `:random`) on each token —
+  `:rf.cofx` (`:time-ms` / `:uuid` / `:random`) on each token —
   replays DETERMINISTICALLY from its captured world-inputs, EQUAL durable
   state across two runs under DIFFERING host clock + RNG. Every durable
   causal-time / id fact folds the TOKEN's world inputs, never an ambient
@@ -32,7 +32,7 @@
   A token log spanning BOTH durable partitions:
 
     1. APP-DB entity create — a `:repl/create` handler reads `:uuid` /
-       `:random` / `:time-ms` from the token's `:rf.world/inputs` and folds
+       `:random` / `:time-ms` from the token's `:rf.cofx` and folds
        them into a durable app-db entity (the EP §Examples \"Correct
        Generated Values From The Token\" shape). Ambient `random-uuid` /
        `rand` would diverge run-to-run; reading the token does not.
@@ -103,7 +103,7 @@
 ;; The live managed-HTTP transport APPENDS its result to the runtime-supplied
 ;; `:on-success` event vector as the LAST arg (Spec 014 §Reply addressing).
 ;; To exercise the runtime's reply handlers against that EXACT shape WITHOUT
-;; a live Fetch — and so we can SCRIPT the reply token's `:rf.world/inputs`
+;; a live Fetch — and so we can SCRIPT the reply token's `:rf.cofx`
 ;; `:time-ms` exactly as a replay would re-feed it — the stub captures the
 ;; lowered args; the test replays the success reply explicitly.
 
@@ -125,7 +125,7 @@
 
 ;; ---- the durable handlers + resource the token log drives -----------------
 ;;
-;; Each handler reads its durable facts from the token's `:rf.world/inputs`
+;; Each handler reads its durable facts from the token's `:rf.cofx`
 ;; coeffect — NEVER an ambient `random-uuid` / `rand` / clock read. That is
 ;; the property under test: replay-determinism follows iff every durable
 ;; write folds the token, so the two runs (differing ambient clock/RNG)
@@ -134,17 +134,17 @@
 (defn- register-log! []
   ;; (1) APP-DB entity create from the token's generated values.
   (rf/reg-event-fx :repl/create
-    (fn [{:keys [db rf.world/inputs]} [_ text]]
-      (let [id    (get-in inputs [:uuid :todo/id])
-            color (get-in inputs [:random :todo/color])
-            at    (:time-ms inputs)]
+    (fn [{:keys [db] cofx :rf.cofx} [_ text]]
+      (let [id    (:todo/id cofx)
+            color (:todo/color cofx)
+            at    (:rf/time-ms cofx)]
         {:db (assoc-in db [:todos id]
                        {:todo/id id :todo/color color
                         :todo/text text :todo/created-at at})})))
   ;; (3) APP-DB mutation — a second durable write folding the token time.
   (rf/reg-event-fx :repl/touch
-    (fn [{:keys [db rf.world/inputs]} [_ id]]
-      {:db (assoc-in db [:todos id :todo/touched-at] (:time-ms inputs))}))
+    (fn [{:keys [db] cofx :rf.cofx} [_ id]]
+      {:db (assoc-in db [:todos id :todo/touched-at] (:rf/time-ms cofx))}))
   ;; (2) RESOURCE — loaded-at / stale-at fold the success-reply token time;
   ;;     work-ledger started-at / deadline-at fold the ensure token time.
   (rf/reg-resource :repl/article
@@ -158,12 +158,12 @@
 (defn- reply-success!
   "Dispatch the captured `:on-success` reply with the transport's success
   result appended as the LAST arg (the live transport shape), carrying a
-  SCRIPTED `:rf.world/inputs` `:time-ms` — exactly as a replay re-feeds the
+  SCRIPTED `:rf.cofx` `:rf/time-ms` — exactly as a replay re-feeds the
   reply token's causal completion time."
   [data time-ms]
   (rf/dispatch-sync (conj (:on-success @last-managed-args)
                           {:kind :success :value data})
-                    {:frame frame-id :rf.world/inputs {:time-ms time-ms}}))
+                    {:frame frame-id :rf.cofx {:rf/time-ms time-ms}}))
 
 ;; ---- the canonical scripted token log -------------------------------------
 ;;
@@ -183,7 +183,7 @@
 (defn- run-log!
   "Replay the whole token log through the LIVE router once, against the
   fresh runtime the caller has just reset. Every dispatch supplies its
-  `:rf.world/inputs` so the durable fold is token-sourced; the ambient
+  `:rf.cofx` so the durable fold is token-sourced; the ambient
   clock/RNG the caller pinned must NOT leak into any durable write.
   Returns the two-partition durable projection `{:rf.db/app :rf.db/runtime}`."
   []
@@ -191,31 +191,31 @@
   ;; (1) APP-DB create from token uuid/random/time-ms.
   (rf/dispatch-sync [:repl/create "buy milk"]
                     {:frame frame-id
-                     :rf.world/inputs {:uuid   {:todo/id todo-id}
-                                       :random {:todo/color :green}
-                                       :time-ms (:create-time log)}})
+                     :rf.cofx {:todo/id    todo-id
+                               :todo/color :green
+                               :rf/time-ms (:create-time log)}})
   ;; (2) RESOURCE ensure → success. The ensure token's :time-ms folds into the
   ;; work-ledger :started-at; the success reply token's :time-ms folds into the
   ;; durable :loaded-at / :stale-at.
   (rf/dispatch-sync [:rf.resource/ensure
                      {:resource :repl/article :scope :rf.scope/global
                       :params {:slug "w"} :owner [:lease :repl 1]}]
-                    {:frame frame-id :rf.world/inputs {:time-ms (:ensure-time log)}})
+                    {:frame frame-id :rf.cofx {:rf/time-ms (:ensure-time log)}})
   (reply-success! {:title "Welcome"} (:reply-time log))
   ;; (3) APP-DB mutation folding the touch token time.
   (rf/dispatch-sync [:repl/touch todo-id]
-                    {:frame frame-id :rf.world/inputs {:time-ms (:touch-time log)}})
+                    {:frame frame-id :rf.cofx {:rf/time-ms (:touch-time log)}})
   ;; (4) OWNER release — drop the lease so the invalidation below LEAVES the
   ;; entry stale rather than spawning a live (ambient-stamped) refetch. Keeps
   ;; the fixture a pure recorded-log replay.
   (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :repl 1]}]
-                    {:frame frame-id :rf.world/inputs {:time-ms (:release-time log)}})
+                    {:frame frame-id :rf.cofx {:rf/time-ms (:release-time log)}})
   ;; (5) TAG invalidation — durable :invalidated-at from the invalidation
   ;; token's :time-ms (the freshness-DECISION branch, rf2-95b0lc). Ownerless
   ;; ⇒ left stale, no refetch (Spec 016 §Invalidation 4).
   (rf/dispatch-sync [:rf.resource/invalidate-tags
                      {:scope :rf.scope/global :tags #{[:article "w"]}}]
-                    {:frame frame-id :rf.world/inputs {:time-ms (:invalidate-time log)}})
+                    {:frame frame-id :rf.cofx {:rf/time-ms (:invalidate-time log)}})
   {:rf.db/app     (rf/app-db-value frame-id)
    :rf.db/runtime (rf/runtime-db-value frame-id)})
 
@@ -252,7 +252,7 @@
   (testing "rf2-b7w7i0 — the SAME multi-event token log, replayed twice under
             WILDLY different ambient clocks AND RNG, yields EQUAL durable
             {:rf.db/app :rf.db/runtime} projections. Every durable causal-time
-            / id fact folds the token's :rf.world/inputs, so ambient drift
+            / id fact folds the token's :rf.cofx, so ambient drift
             (the very thing replay must be immune to) does not change durable
             state. Spans app-db (entity create + mutation) AND runtime-db
             (resource loaded-at/stale-at, work-ledger started-at, tag

--- a/implementation/resources/test/re_frame/resources_http_completed_at_clock_cljs_test.cljs
+++ b/implementation/resources/test/re_frame/resources_http_completed_at_clock_cljs_test.cljs
@@ -6,7 +6,7 @@
 
   WHY A NEW SUITE: every existing `:completed-at` test (e.g.
   `resources-managed-http-cljs-test`, `http-reply-lowering`) SCRIPTS the
-  reply token's `:completed-at` / `:rf.world/inputs` `:time-ms` with an
+  reply token's `:completed-at` / `:rf.cofx` `:rf/time-ms` with an
   explicit epoch value, bypassing the live `reply-ctx` clock read in
   `re-frame.http-transport`. So the wall-clock-vs-perf-clock bug (the
   transport boundary the router's fresh-token fix 427f260d3 / rf2-n1rh0f

--- a/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_invalidation_gc_cljs_test.cljc
@@ -171,7 +171,7 @@
   ;; rf2-258p1z / EP-0010 §Resources, Mutations, And Work-Ledger Timestamps:
   ;; the durable :invalidated-at is the INVALIDATION EVENT'S :time-ms (the
   ;; causal world input), NOT an ambient clock read in the reducer. Scripting
-  ;; the dispatch's :rf.world/inputs pins the value; replaying the SAME token
+  ;; the dispatch's :rf.cofx pins the value; replaying the SAME token
   ;; rewrites the SAME :invalidated-at (replay-stable, not the live clock).
   (rf/reg-resource :ivt/article (article-spec))
   (let [sa {:user "a"}
@@ -183,7 +183,7 @@
     (rf/dispatch-sync [:rf.resource/release-owner {:owner [:lease :a 1]}])
     (rf/dispatch-sync [:rf.resource/invalidate-tags
                        {:scope sa :tags #{[:article "w"]}}]
-                      {:rf.world/inputs {:time-ms t1}})
+                      {:rf.cofx {:rf/time-ms t1}})
     (testing ":invalidated-at is EXACTLY the supplied token :time-ms (not now)"
       (is (= t1 (:invalidated-at (entry ka)))))
     ;; re-invalidate with a DIFFERENT scripted time — the durable fact tracks
@@ -191,7 +191,7 @@
     ;; is read off the token, not a fresh clock read).
     (rf/dispatch-sync [:rf.resource/invalidate-tags
                        {:scope sa :tags #{[:article "w"]}}]
-                      {:rf.world/inputs {:time-ms t2}})
+                      {:rf.cofx {:rf/time-ms t2}})
     (testing "replaying with a new scripted token rewrites :invalidated-at to
               that token's :time-ms (read off the token, not the clock)"
       (is (= t2 (:invalidated-at (entry ka)))))))

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -99,7 +99,7 @@
 
 (defn- reply-success!
   ([args result] (rf/dispatch-sync (conj (:on-success args) {:kind :success :value result})))
-  ;; EP-0010: a fixture may script the reply token's :rf.world/inputs to pin
+  ;; EP-0010: a fixture may script the reply token's :rf.cofx to pin
   ;; the host :completed-at (the managed transport stamps it on the reply
   ;; dispatch in live code).
   ([args result opts] (rf/dispatch-sync (conj (:on-success args) {:kind :success :value result}) opts)))
@@ -233,14 +233,14 @@
   ;; rf2-dsyqmz / EP-0010 §Resources, Mutations, And Work-Ledger Timestamps:
   ;; :rf.mutation/execute writes the durable instance :started-at from the
   ;; TRIGGERING TOKEN'S :time-ms (the causal world input), NOT an ambient
-  ;; clock read in the reducer. Scripting the dispatch's :rf.world/inputs
+  ;; clock read in the reducer. Scripting the dispatch's :rf.cofx
   ;; pins it; the same execute token mints the same :started-at
   ;; (replay-stable).
   (rf/reg-mutation :m/save (save-article-spec))
   (let [t1 1781078400123]
     (rf/dispatch-sync [:rf.mutation/execute
                        {:mutation :m/save :params {:slug "w"} :instance :st/save-1}]
-                      {:rf.world/inputs {:time-ms t1}})
+                      {:rf.cofx {:rf/time-ms t1}})
     (testing "the instance :started-at is EXACTLY the token :time-ms (not now)"
       (is (= t1 (:started-at (instance :st/save-1)))))))
 
@@ -354,7 +354,7 @@
   ;; and ANY resource patch/populate :loaded-at the mutation produces uses
   ;; that SAME causal completion time (off the reply token, never an ambient
   ;; read in the handler). The host :completed-at rides the reply event's
-  ;; :rf.world/inputs :time-ms; scripting it pins both.
+  ;; :rf.cofx :time-ms; scripting it pins both.
   (rf/reg-resource :r/article
                    {:scope :rf.scope/global
                     :params-schema [:map [:slug :string]]
@@ -368,7 +368,7 @@
                       :request (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}})
                       :populates (fn [_params result] {(art-target) result})})
     (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :ms1}])
-    (reply-success! @last-managed-args {:title "seed"} {:rf.world/inputs {:time-ms completed-at}})
+    (reply-success! @last-managed-args {:title "seed"} {:rf.cofx {:rf/time-ms completed-at}})
     (testing "the instance :settled-at is EXACTLY the reply completion time"
       (is (= completed-at (:settled-at (instance :ms1)))))
     (testing "the populated entry's :loaded-at is the SAME causal completion
@@ -381,13 +381,13 @@
   ;; rf2-r65m41 / EP-0010 §Resources, Mutations + §Managed Effects: a terminal
   ;; mutation FAILURE reply writes :settled-at from the reply completion time
   ;; carried on the failure reply token — the handler MUST NOT re-read the
-  ;; clock. The host :completed-at rides the reply event's :rf.world/inputs
+  ;; clock. The host :completed-at rides the reply event's :rf.cofx
   ;; :time-ms; scripting it pins :settled-at (replay-stable).
   (rf/reg-mutation :m/save (save-article-spec))
   (let [completed-at 1781078999999]
     (rf/dispatch-sync [:rf.mutation/execute {:mutation :m/save :params {:slug "w"} :instance :mf1}])
     (reply-failure! @last-managed-args {:kind :rf.http/http-5xx :status 500}
-                    {:rf.world/inputs {:time-ms completed-at}})
+                    {:rf.cofx {:rf/time-ms completed-at}})
     (testing "the instance settles :error with :settled-at = the reply
               completion time (not now)"
       (is (= :error (:status (instance :mf1))))
@@ -1099,7 +1099,7 @@
                        {:mutation :m/save :params {:slug "w"} :instance :rc1
                         :reply-to [:test/save-replied]}])
     (reply-success! @last-managed-args {:slug "w" :title "Fresh"}
-                    {:rf.world/inputs {:time-ms completed-at}})
+                    {:rf.cofx {:rf/time-ms completed-at}})
     (testing "the continuation fired exactly once"
       (is (= 1 (count @replied))))
     (testing "EP-0016 — the appended reply map carries the full continuation contract"

--- a/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_runtime_cljs_test.cljc
@@ -676,9 +676,9 @@
   ;; rf2-n1rh0f / EP-0010 §Resources, Mutations, And Work-Ledger Timestamps:
   ;; the resource :loaded-at IS the successful reply's completion time
   ;; (carried on the reply token as the host :completed-at, which the managed
-  ;; transport threads onto the reply event's :rf.world/inputs :time-ms), and
+  ;; transport threads onto the reply event's :rf.cofx :time-ms), and
   ;; :stale-at = :loaded-at + :stale-after-ms — NOT an ambient clock read in
-  ;; the reply handler. Scripting the reply dispatch's :rf.world/inputs pins
+  ;; the reply handler. Scripting the reply dispatch's :rf.cofx pins
   ;; both; the same reply token rewrites the same durable timestamps.
   (rf/reg-resource :lra/article (article-spec {:stale-after-ms 60000}))
   (let [scoped-key (state/scoped-resource-key :rf.scope/global :lra/article {:slug "w"})
@@ -692,7 +692,7 @@
                         ;; the managed transport stamps the host :completed-at
                         ;; here; a fixture scripts it directly on the reply
                         ;; token's world inputs.
-                        {:rf.world/inputs {:time-ms completed-at}}))
+                        {:rf.cofx {:rf/time-ms completed-at}}))
     (testing ":loaded-at is EXACTLY the reply completion time (not now)"
       (is (= completed-at (:loaded-at (entry scoped-key)))))
     (testing ":stale-at = :loaded-at + the :stale-after-ms policy"
@@ -701,7 +701,7 @@
 ;; rf2-95b0lc / EP-0010 §The World-Input Rule: the ensure FRESH-SKIP gate is a
 ;; freshness DECISION that gates a durable runtime-db write (serve-cache vs
 ;; start-new-work). Its basis MUST be the ensure token's causal
-;; `(:time-ms (:rf.world/inputs cofx))`, NOT an ambient host-clock read — so a
+;; `(:time-ms (:rf.cofx cofx))`, NOT an ambient host-clock read — so a
 ;; replayed ensure under a LATER live clock takes the SAME branch the recorded
 ;; `:time-ms` dictated. Pre-fix the gate read `(now-ms)` (= the live host
 ;; clock, ~1.78e12 epoch-ms / `System/currentTimeMillis`), which dwarfs any
@@ -721,7 +721,7 @@
       (rf/dispatch-sync [:rf.resource.internal/succeeded
                          {:resource-key scoped-key :work/id (:current-work e)
                           :generation (:generation e) :data {:title "W"}}]
-                        {:rf.world/inputs {:time-ms completed-at}}))
+                        {:rf.cofx {:rf/time-ms completed-at}}))
     (is (= :loaded (:status (entry scoped-key))) "entry loaded")
     (is (= (+ t0 60000) (:stale-at (entry scoped-key))) "durable :stale-at = t0 + policy")
     (let [gen0 (:generation (entry scoped-key))]
@@ -732,7 +732,7 @@
       (rf/dispatch-sync [:rf.resource/ensure {:resource :fsd/article :scope :rf.scope/global
                                               :params {:slug "w"} :owner [:lease :fsd 1]}]
                         ;; scripted causal "now": t0 + 30s — fresh by policy.
-                        {:rf.world/inputs {:time-ms (+ t0 30000)}})
+                        {:rf.cofx {:rf/time-ms (+ t0 30000)}})
       (testing "a within-window causal :time-ms takes the FRESH-SKIP branch
                 — no new work, no transport call, generation unchanged"
         (is (nil? @last-managed-args)
@@ -750,7 +750,7 @@
       (rf/dispatch-sync [:rf.resource/ensure {:resource :fsd/article :scope :rf.scope/global
                                               :params {:slug "w"} :owner [:lease :fsd 1]}]
                         ;; scripted causal "now": t0 + 90s — STALE by policy.
-                        {:rf.world/inputs {:time-ms (+ t0 90000)}})
+                        {:rf.cofx {:rf/time-ms (+ t0 90000)}})
       (testing "a past-window causal :time-ms takes the REFETCH branch — a new
                 load fires (the decision tracks the causal token both ways)"
         (is (some? @last-managed-args)

--- a/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_work_ledger_cljs_test.cljc
@@ -184,7 +184,7 @@
   ;; the durable work-ledger `:started-at` is the TRIGGERING TOKEN'S
   ;; `:time-ms` (the causal world input), and `:deadline-at` is
   ;; `:started-at` + the configured `:timeout-ms` policy — NOT an ambient
-  ;; clock read in the reducer. Scripting the dispatch's `:rf.world/inputs`
+  ;; clock read in the reducer. Scripting the dispatch's `:rf.cofx`
   ;; pins both; the same token mints the same row (replay-stable).
   (rf/reg-resource :wlt/article (article-spec {:timeout-ms 5000}))
   (let [scoped-key (state/scoped-resource-key :rf.scope/global :wlt/article {:slug "w"})
@@ -192,7 +192,7 @@
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :wlt/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:route :r 1]}]
-                      {:rf.world/inputs {:time-ms t1}})
+                      {:rf.cofx {:rf/time-ms t1}})
     (let [r (record (:current-work (entry scoped-key)))]
       (testing ":started-at is EXACTLY the triggering token :time-ms (not now)"
         (is (= t1 (:started-at r))))
@@ -206,7 +206,7 @@
     (rf/dispatch-sync [:rf.resource/ensure
                        {:resource :wlnt/article :scope :rf.scope/global
                         :params {:slug "w"} :owner [:route :r 1]}]
-                      {:rf.world/inputs {:time-ms t2}})
+                      {:rf.cofx {:rf/time-ms t2}})
     (let [r (record (:current-work (entry scoped-key)))]
       (testing ":started-at tracks the token even with no timeout policy"
         (is (= t2 (:started-at r))))

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -3010,15 +3010,18 @@ so the gate is not blinded by them:
 
 - **wall-clock timestamps** — `:committed-at` (epoch record), `:time`
   (trace event), `:elapsed-ms` (run / assertion record), and the
-  framework-stamped `:time-ms` nested inside the `:rf.world/inputs` causal
-  map that rides a `:rf.event/dispatched` trace event's `:tags` (rf2-jt854w —
-  EP-0010 dev-stamps the envelope's world-input map onto the enqueue trace).
-  The `:rf.world/inputs` map itself is **semantic** (caller-supplied `:uuid` /
-  `:random` / browser-or-storage facts are the deterministic causal token a
-  scripted / replayed run pins, and a real difference in them MUST perturb the
-  hash), but its framework-filled `:time-ms` is epoch-ms wall-clock filled
-  fresh per dispatch, so two semantically-equal fresh-frame replays stamp
-  different values — it is stripped one level deeper, like `:committed-at`;
+  framework-stamped `:rf/time-ms` nested inside the flat `:rf.cofx`
+  recordable-coeffect map that rides a `:rf.event/dispatched` trace event's
+  `:tags` (rf2-jt854w — EP-0010 dev-stamps the envelope's recordable-coeffect
+  map onto the enqueue trace; EP-0017 / rf2-alc1lf renamed the field from the
+  nested `:rf.world/inputs` to the flat `:rf.cofx` map and the framework time
+  fact from `:time-ms` to `:rf/time-ms`). The `:rf.cofx` map itself is
+  **semantic** (caller-supplied owner-qualified facts — `:uuid` / `:random` /
+  browser-or-storage facts — are the deterministic causal token a scripted /
+  replayed run pins, and a real difference in them MUST perturb the hash), but
+  its framework-filled `:rf/time-ms` is epoch-ms wall-clock filled fresh per
+  dispatch, so two semantically-equal fresh-frame replays stamp different
+  values — it is stripped one level deeper, like `:committed-at`;
 
 - **elapsed durations** — `:elapsed-ms`, and the dev-only handler
   wall-clock trace tags `:rf.event/elapsed-ms` (event run),
@@ -3043,7 +3046,7 @@ The strip is split by SAFETY: reserved / framework-specific keys
 volatile set) are stripped **recursively** by the projection; the
 genuinely-common keys a trace event / epoch record also carries (`:id`,
 `:time`, `:frame`, the volatile `:tags` keys, and the nested
-`[:tags :rf.world/inputs] :time-ms`) are stripped
+`[:tags :rf.cofx] :rf/time-ms`) are stripped
 **structurally** — only on their trace-event (`:operation` + `:op-type`) or
 epoch-record (`:epoch-id` + a record slot) carrier — so an app-db value
 that legitimately keys on `:id` / `:time` / `:frame` survives and a real

--- a/tools/story/src/re_frame/story/fingerprint.cljc
+++ b/tools/story/src/re_frame/story/fingerprint.cljc
@@ -270,27 +270,31 @@
   #{:frame :rf.trace/dispatch-id :rf.trace/trace-id
     :rf.event/elapsed-ms :rf.fx/elapsed-ms :rf.cofx/elapsed-ms})
 
-(def ^:private volatile-world-input-keys
-  "The per-run volatile keys nested INSIDE the `:rf.world/inputs` causal map
-  that rides a `:rf.event/dispatched` trace event's `:tags` (rf2-jt854w —
-  EP-0010 observability completion: the router dev-stamps the envelope's
-  `:rf.world/inputs` onto the enqueue trace so Xray's Event lens can render
-  the WORLD INPUTS surface).
+(def ^:private volatile-cofx-keys
+  "The per-run volatile facts nested INSIDE the flat `:rf.cofx` recordable-
+  coeffect map that rides a `:rf.event/dispatched` trace event's `:tags`
+  (rf2-jt854w — EP-0010 observability completion: the router dev-stamps the
+  envelope's `:rf.cofx` onto the enqueue trace so Xray's Event lens can render
+  the COEFFECTS surface; EP-0017 / rf2-alc1lf renamed the envelope field from
+  the nested `:rf.world/inputs` to the flat `:rf.cofx` map — one fact per
+  owner-qualified key, no grouping sub-maps — and the framework time fact from
+  the nested `:time-ms` to the flat `:rf/time-ms`).
 
-  The `:rf.world/inputs` MAP is semantic — caller-supplied `:uuid` / `:random`
-  / browser-or-storage facts are the deterministic causal token a scripted /
-  replayed run pins, and a real difference in them MUST still perturb the
-  canonical value. But the framework-stamped `:time-ms` (epoch-ms WALL-CLOCK,
-  filled fresh per dispatch via `interop/epoch-now-ms` when the caller did not
-  supply one — see `re-frame.router/build-envelope`) is per-RUN volatile: two
-  semantically-equal programs replayed into FRESH frames stamp DIFFERENT
-  `:time-ms`, so the determinism gate / semantic-diff / `:run-hash` false-drift
-  unless it is stripped. It is the world-input analogue of the `:committed-at`
-  wall-clock + the `:rf.event/elapsed-ms` handler timing already stripped —
-  same volatile class, one level deeper. Stripping it is also safe when a
-  caller scripted `:time-ms` (two equal runs both strip it; a difference in the
-  surviving `:uuid` / `:random` facts still perturbs the hash)."
-  #{:time-ms})
+  The `:rf.cofx` MAP is semantic — caller-supplied owner-qualified facts (a
+  `:uuid` / `:random` / browser-or-storage fact) are the deterministic causal
+  token a scripted / replayed run pins, and a real difference in them MUST
+  still perturb the canonical value. But the framework-stamped `:rf/time-ms`
+  (epoch-ms WALL-CLOCK, filled fresh per dispatch via `interop/epoch-now-ms`
+  when the caller did not supply one — see `re-frame.router/build-envelope`)
+  is per-RUN volatile: two semantically-equal programs replayed into FRESH
+  frames stamp DIFFERENT `:rf/time-ms`, so the determinism gate / semantic-diff
+  / `:run-hash` false-drift unless it is stripped. It is the recordable-coeffect
+  analogue of the `:committed-at` wall-clock + the `:rf.event/elapsed-ms`
+  handler timing already stripped — same volatile class, one level deeper.
+  Stripping it is also safe when a caller scripted `:rf/time-ms` (two equal
+  runs both strip it; a difference in the surviving owner-qualified facts still
+  perturbs the hash)."
+  #{:rf/time-ms})
 
 (defn- trace-event?
   "True iff `m` is a trace event (Spec 009 §Trace event shape): a map
@@ -298,27 +302,28 @@
   [m]
   (and (map? m) (contains? m :operation) (contains? m :op-type)))
 
-(defn- strip-world-input-stamps
-  "Drop the per-run volatile keys (`volatile-world-input-keys` — the
-  framework-stamped wall-clock `:time-ms`) from a trace event's
-  `[:tags :rf.world/inputs]` causal map, leaving the semantic caller-supplied
-  facts (`:uuid` / `:random` / browser-or-storage) intact (rf2-jt854w). No-op
-  when the tag is absent or not a map. Pure data → data."
+(defn- strip-cofx-stamps
+  "Drop the per-run volatile facts (`volatile-cofx-keys` — the framework-stamped
+  wall-clock `:rf/time-ms`) from a trace event's `[:tags :rf.cofx]` recordable-
+  coeffect map, leaving the semantic caller-supplied owner-qualified facts
+  intact (rf2-jt854w / EP-0017 rf2-alc1lf). No-op when the tag is absent or not
+  a map. Pure data → data."
   [tags]
-  (if (map? (:rf.world/inputs tags))
-    (update tags :rf.world/inputs #(apply dissoc % volatile-world-input-keys))
+  (if (map? (:rf.cofx tags))
+    (update tags :rf.cofx #(apply dissoc % volatile-cofx-keys))
     tags))
 
 (defn- strip-trace-tags
   "Drop the per-run stamp keys (`volatile-trace-tag-keys`) from a trace
   event's `:tags` sub-map, leaving the semantic tags, and strip the per-run
-  volatile `:time-ms` nested inside the `:rf.world/inputs` causal tag
-  (rf2-jt854w). No-op when `:tags` is absent. Pure data → data."
+  volatile `:rf/time-ms` nested inside the flat `:rf.cofx` recordable-coeffect
+  tag (rf2-jt854w / EP-0017 rf2-alc1lf). No-op when `:tags` is absent. Pure
+  data → data."
   [trace-event]
   (if (map? (:tags trace-event))
     (update trace-event :tags
             #(-> (apply dissoc % volatile-trace-tag-keys)
-                 strip-world-input-stamps))
+                 strip-cofx-stamps))
     trace-event))
 
 (defn- epoch-record?

--- a/tools/story/test/re_frame/story_fingerprint_test.clj
+++ b/tools/story/test/re_frame/story_fingerprint_test.clj
@@ -182,53 +182,56 @@
       (is (= (fp/content-hash once) (fp/content-hash once))))))
 
 ;; ===========================================================================
-;; WORLD-INPUT :time-ms STRUCTURAL STRIP (rf2-jt854w — EP-0010)
+;; RECORDABLE-COEFFECT :rf/time-ms STRUCTURAL STRIP (rf2-jt854w — EP-0010 /
+;; EP-0017 rf2-alc1lf)
 ;; ===========================================================================
 ;;
-;; The router dev-stamps the envelope's `:rf.world/inputs` causal map onto the
-;; `:rf.event/dispatched` enqueue trace under `[:tags :rf.world/inputs]` so
-;; Xray's Event lens can render the WORLD INPUTS surface. That map's
-;; framework-filled `:time-ms` is epoch-ms WALL-CLOCK (filled fresh per
+;; The router dev-stamps the envelope's flat `:rf.cofx` recordable-coeffect map
+;; onto the `:rf.event/dispatched` enqueue trace under `[:tags :rf.cofx]` so
+;; Xray's Event lens can render the COEFFECTS surface. That map's
+;; framework-filled `:rf/time-ms` is epoch-ms WALL-CLOCK (filled fresh per
 ;; dispatch), so two semantically-equal fresh-frame replays stamp DIFFERENT
 ;; values — `canonicalize` must strip it (one level deeper than the other
 ;; trace-tag stamps) or the determinism gate / semantic-diff / `:run-hash`
-;; false-drift. The semantic caller-supplied facts (`:uuid` / `:random`) MUST
-;; survive so a real causal-token difference still perturbs the hash.
+;; false-drift. The semantic caller-supplied owner-qualified facts (`:uuid` /
+;; `:random`) MUST survive so a real causal-token difference still perturbs the
+;; hash. EP-0017 renamed the tag from the nested `:rf.world/inputs` to the flat
+;; `:rf.cofx` map and the framework time fact from `:time-ms` to `:rf/time-ms`.
 
 (defn- dispatched-trace-event
-  "A minimal `:rf.event/dispatched` trace event carrying a `:rf.world/inputs`
+  "A minimal `:rf.event/dispatched` trace event carrying a `:rf.cofx`
   tag — the carrier `strip-trace-tags` recognises via `:operation` +
   `:op-type`."
-  [world-inputs]
+  [cofx]
   {:operation :rf.event/dispatched
    :op-type   :rf.event
-   :tags      {:rf.event/v       [:some/event]
-               :rf.world/inputs  world-inputs}})
+   :tags      {:rf.event/v  [:some/event]
+               :rf.cofx     cofx}})
 
-(deftest world-input-time-ms-is-stripped-from-the-dispatched-trace
+(deftest cofx-time-ms-is-stripped-from-the-dispatched-trace
   (testing "two dispatched trace events differing ONLY in the framework
-            wall-clock :rf.world/inputs :time-ms canonicalize = and hash equal"
-    (let [a (dispatched-trace-event {:time-ms 1000 :uuid :u :random 0.5})
-          b (dispatched-trace-event {:time-ms 9999 :uuid :u :random 0.5})]
+            wall-clock :rf.cofx :rf/time-ms canonicalize = and hash equal"
+    (let [a (dispatched-trace-event {:rf/time-ms 1000 :uuid :u :random 0.5})
+          b (dispatched-trace-event {:rf/time-ms 9999 :uuid :u :random 0.5})]
       (is (= (fp/canonicalize a) (fp/canonicalize b))
-          "differing only in :time-ms must canonicalize =")
+          "differing only in :rf/time-ms must canonicalize =")
       (is (= (fp/canonical-hash a) (fp/canonical-hash b))
-          "differing only in :time-ms must hash equal")))
+          "differing only in :rf/time-ms must hash equal")))
   (testing "the semantic caller-supplied facts survive the strip — a :uuid /
             :random difference still perturbs the canonical value + hash"
-    (let [base   (dispatched-trace-event {:time-ms 1000 :uuid :u :random 0.5})
-          uuid'  (dispatched-trace-event {:time-ms 1000 :uuid :v :random 0.5})
-          rand'  (dispatched-trace-event {:time-ms 1000 :uuid :u :random 0.9})]
+    (let [base   (dispatched-trace-event {:rf/time-ms 1000 :uuid :u :random 0.5})
+          uuid'  (dispatched-trace-event {:rf/time-ms 1000 :uuid :v :random 0.5})
+          rand'  (dispatched-trace-event {:rf/time-ms 1000 :uuid :u :random 0.9})]
       (is (not= (fp/canonicalize base) (fp/canonicalize uuid'))
           "a :uuid difference must perturb the canonical value")
       (is (not= (fp/canonical-hash base) (fp/canonical-hash rand'))
           "a :random difference must perturb the hash")))
-  (testing "the strip only fires on the world-input carrier — a plain app-db
-            map keying on :time-ms is NOT stripped (structural, not recursive)"
-    (let [a {:app-db {:time-ms 1}}
-          b {:app-db {:time-ms 2}}]
+  (testing "the strip only fires on the :rf.cofx carrier — a plain app-db
+            map keying on :rf/time-ms is NOT stripped (structural, not recursive)"
+    (let [a {:app-db {:rf/time-ms 1}}
+          b {:app-db {:rf/time-ms 2}}]
       (is (not= (fp/canonicalize a) (fp/canonicalize b))
-          ":time-ms outside a :rf.world/inputs trace tag is semantic app data"))))
+          ":rf/time-ms outside a :rf.cofx trace tag is semantic app data"))))
 
 ;; ===========================================================================
 ;; STRUCTURAL TYPE TAGS — map / set / vector / seq are distinguishable (rf2-lvrqa)


### PR DESCRIPTION
EP-0017 (Recordable Coeffects) **slice-A bead 2** — runtime rename + flat reshape, per EP-0017 §Specification + §Backwards Compatibility. Parent rf2-d8mvke; sequential after slice-A.1 (spec, PR #4082).

## What changed

Renamed the recordable-coeffect envelope/coeffect field from the nested `:rf.world/inputs` to the **flat `:rf.cofx`** map (one fact per owner-qualified key, no grouping sub-maps), and the framework time fact from the nested `:time-ms` to the flat **`:rf/time-ms`**, across `implementation/`.

**Pure rename + flat reshape — no delivery-semantics change.** `inject-cofx` and ambient delivery are unchanged (the `:rf.cofx/requires` declared-only delivery + `inject-cofx` removal is slice-A.3 / rf2-oa2dun). No alias for the old key (`:rf.world/inputs` is gone, not aliased).

### Rename surface covered
- **Envelope construction + stamping** — `router/ensure-cofx` (was `ensure-world-inputs`), `build-envelope`, `assemble-initial-ctx` (seeds `:rf.cofx`).
- **Dispatch-opts key + boundary validation** — `diagnostics/validate-cofx!` (was `validate-world-inputs!`), `known-dispatch-opts`; error id `:rf.error/invalid-world-inputs` → `:rf.error/invalid-cofx`; `:dispatched-at` retirement-error replacement text now names `(:rf/time-ms (:rf.cofx envelope))`.
- **Reply construction (EP-0011)** — `http_encoding` reply envelope carries `:rf.cofx {:rf/time-ms <completed-at>}`; `http_transport` / `http_middleware` prose.
- **Resource / mutation / work-ledger reads** — `resources/events` + `mutation_events` destructure `cofx :rf.cofx` and read `(:rf/time-ms cofx)`.
- **Machine threading** — threading key `:rf/world-inputs` → `:rf/cofx`; callback ctx surfaces `:rf.cofx` (`transition`, `registration`, `parallel`, `finalize`).
- **Epoch / SSR** — committed-at provenance docstrings.
- **fx** — `framework-coeffect-keys` + `inheritable-envelope-keys` (`:rf.cofx` not inherited; child stamped fresh).
- **Trace** — `:rf.event/dispatched` enqueue tag now carries `:rf.cofx`.
- **Examples in the CLJS test path** — realworld `:realworld/now` time-cofx + auth storage-cofx, realworld_resources auth, todomvc storage-cofx reshaped to flat owner-qualified facts (`:auth.session/stored-token`, `:todo.storage/todos`) so the rename is behaviour-preserving end-to-end.
- **Tests** — updated to the new key + shape; the grouped `:uuid`/`:random` seats (no shipped producers) flattened to owner-qualified app facts (`:todo/id`, `:todo/color`); a rename-round-trip on the envelope-preservation + child-fresh-stamp + replay-determinism tests confirms every fact survives the flat reshape.

### Site that needed care (flag for A.3)
The example consumer cofx (`realworld/auth`, `todomvc/db`, etc.) are still ctx→ctx `reg-cofx` handlers reading the renamed runtime coeffect — left functional here (pure rename). Their conversion to value-returning `reg-cofx` + `:rf.cofx/requires`, and the `inject-cofx` removal, are slice-A.3 (rf2-oa2dun) / the migration audit (slice-A.4).

## Quality gates
- `implementation/core` `clojure -M:test` — **1412 tests / 6294 assertions, 0 failures, 0 errors**
- `implementation/resources` `clojure -M:test` — **399 / 1555, 0/0**
- `implementation/machines` `clojure -M:test` — **653 / 2127, 0/0**
- `implementation/http` `clojure -M:test` — **423 / 1942, 0/0**
- `implementation/epoch` `clojure -M:test` — **324 / 1268, 0/0**
- `implementation/routing` `clojure -M:test` — **244 / 1224, 0/0**
- `implementation/ssr` `clojure -M:test` — **337 / 1350, 0/0**
- `npm run test:cljs` — **6972 tests / 28560 assertions, 0 failures, 0 errors**
- `npm run test:bundle-isolation` — **PASS** (22 artefact entries; 40 internal sentinels absent; uix/helix reagent-free)

A pure rename, all gates green.
