### PR TITLE
fix(testbeds): migrate schema_violation off inject-cofx + rerun xray-feature-gate (rf2-adi70o)

### DIFF
--- a/testbeds/schema_violation/README.md
+++ b/testbeds/schema_violation/README.md
@@ -10,7 +10,7 @@ of the five check-points fired; each `:where` carries a different
 |---|---|---|---|---|
 | A · :where :app-db | `violate-app-db` | `:app-db` | `:rollback? true`, `:recovery :no-recovery`. The `:db` effect is rolled back to its pre-handler value; flows do NOT evaluate and `:fx` does NOT walk for this dispatch. Downstream queued events still drain. | `[:auth :token]` stays at `"seed-token"`. The handler tried to commit `42` (an int) at a slot whose registered schema demands `:string`. |
 | B · :where :event | `violate-event` | `:event` | `:no-recovery` — handler not invoked; downstream queue continues. | `[:click-count :event]` stays at `0`. The handler's `:schema` is `[:cat [:= ::violate-event] pos-int?]`; the button dispatches it with the string `"not-a-number"`. |
-| C · :where :cofx | `violate-cofx` | `:cofx` | `:no-recovery` — handler not invoked; downstream queue continues. | `[:click-count :cofx]` stays at `0`. The cofx's `:schema` is `pos-int?`; the cofx body deliberately injects `-1`. |
+| C · :where :cofx | `violate-cofx` | `:cofx` | `:no-recovery` — handler not invoked; downstream queue continues. | `[:click-count :cofx]` stays at `0`. The cofx's `:schema` is `pos-int?`; the value-returning supplier (declared via `:rf.cofx/requires`, EP-0017) deliberately returns `-1`. |
 | D · :where :fx-args | `violate-fx-args` | `:fx-args` | `:recovery :skipped` — the offending fx is skipped; sibling fx continue. The handler's `:db` already committed. | `[:click-count :fx]` increments per click (the handler's `:db` ran). The fx body never ran — its `:schema` (`[:map [:url :string]]`) rejected the vector args. |
 
 ## Trace shape per click (per [spec/009 §Error contract](../../spec/009-Instrumentation.md))

--- a/testbeds/schema_violation/core.cljs
+++ b/testbeds/schema_violation/core.cljs
@@ -85,23 +85,30 @@
     (update-in db [:click-count :event] inc)))
 
 ;; ----------------------------------------------------------------------------
-;; Button C — :where :cofx (cofx :spec rejects the injected value)
+;; Button C — :where :cofx (cofx :schema rejects the supplied value)
 ;; ----------------------------------------------------------------------------
 ;;
-;; The cofx :spec demands the injected value is a positive int; the
-;; cofx body deliberately injects -1. The handler is NOT invoked; the
-;; failure trace fires with :where :cofx and :failing-id naming the
-;; cofx. The downstream queue continues to drain.
+;; EP-0017: `reg-cofx` is a value-returning supplier — the v1 ctx->ctx
+;; idiom and `inject-cofx` are removed. The cofx :schema demands a
+;; positive int; the supplier deliberately returns -1. The consumer
+;; declares the cofx via `:rf.cofx/requires` (the one declaration
+;; surface). Per [spec/010 §Validation order] step 2 the supplied value
+;; is validated after delivery, before the handler sees the merged
+;; context: the handler is NOT invoked; the failure trace fires with
+;; :where :cofx and :failing-id naming the cofx. The downstream queue
+;; continues to drain.
 
 (rf/reg-cofx ::bad-counter
-  {:schema pos-int?}
-  (fn [ctx _]
-    ;; HOT PATH — the injection site for :where :cofx.
+  {:doc    "Deliberately returns a value its own :schema rejects, to
+            light up the :where :cofx schema-validation surface."
+   :schema pos-int?}
+  (fn []
+    ;; HOT PATH — the supply site for :where :cofx.
     ;; Returns a value that the registered :schema will reject.
-    (rf/assoc-coeffect ctx ::bad-counter -1)))
+    -1))
 
 (rf/reg-event-fx ::violate-cofx
-  [(rf/inject-cofx ::bad-counter)]
+  {:rf.cofx/requires [::bad-counter]}
   (fn [{:keys [db]} _ev]
     {:db (update-in db [:click-count :cofx] inc)}))
 


### PR DESCRIPTION
## What

EP-0017 retired `inject-cofx` and the ctx→ctx `reg-cofx` shape (calling `inject-cofx` is now a hard error `:rf.error/inject-cofx-removed`, in production too). The shared top-level `testbeds/schema_violation/core.cljs` was the last straggler still using both — its Button C (`:where :cofx` surface) registered a ctx→ctx cofx and injected it via the removed positional `inject-cofx` interceptor. This failed to compile under the merged EP-0017 runtime and broke `npm run test:xray-feature-gate` (the browser gate compiles this shared testbed).

EP-0017 slices A.1/A.2/A.3/A.5 are all merged to main; A.5 migrated the `standard_epochs` testbed. This bead handles the remaining `schema_violation` one.

## Change

Migrated Button C to the EP-0017 cofx model, preserving the testbed's demonstrated behaviour (a cofx whose supplied value violates its own `:schema`, exercising the `:where :cofx` schema-validation-failure surface — spec/010 step 2):

- `::bad-counter` becomes a value-returning supplier `(fn [] -1)`, keeping its `{:schema pos-int?}` so the supplied value still fails validation. (Ambient grade; `validate-cofx!` runs grade-agnostically after delivery.)
- `::violate-cofx` declares the cofx via `:rf.cofx/requires [::bad-counter]` — the one EP-0017 declaration surface — instead of the removed positional `inject-cofx` interceptor.
- Added a `:doc` to the cofx registration (EP-0017 dev-warns missing `:doc`).
- README matrix row C reworded from "injects" to the value-returning model.

Intent unchanged: the handler is still skipped, the `:where :cofx` failure trace still fires, the four-button per-`:where` matrix is intact.

## Scope

Top-level `testbeds/` only. A grep of the whole `testbeds/` tree found `schema_violation` as the sole straggler (the only top-level testbed using the removed cofx mechanism). No `:rf.world/inputs`, nested `{:time-ms}`, or other ctx→ctx `reg-cofx` remained. `tools/` testbeds and `implementation/` runtime are already migrated + merged and were not touched.

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:xray-feature-gate` (acceptance) | **PASS** (exit 0) — `:testbeds/schema-violation` build completed, 0 warnings; ran 16 Xray feature scenarios, 0 failures, 13 matrix rows covered |
| `npm run test:cljs` (regression) | **PASS** (exit 0) — 6971 tests / 28565 assertions, 0 failures, 0 errors |

Bundle-isolation: not implicated — the change is dev-only cofx wiring inside a testbed; nothing crosses into `implementation/` production builds.

Closes rf2-adi70o.
