### PR TITLE
fix(routing): EP-0017 — owner-qualify :nav-token cofx id (rf2-mzhko8 +nklpwn)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -238,15 +238,17 @@
                      nav-counters-meta
                      url-change/handle-url-change-handler)
 
-;; :nav-token cofx — Spec 012 §Navigation tokens — stale-result
+;; :rf.route/nav-token cofx — Spec 012 §Navigation tokens — stale-result
 ;; suppression step 2. A value-returning AMBIENT supplier (EP-0017) for
 ;; the current navigation epoch token; delivered under `:coeffects
-;; :nav-token` to any `:on-match`-reached handler that declares
-;; `:rf.cofx/requires [:nav-token]`, so the documented
-;; `(fn [{:keys [db nav-token]} _] ...)` shape resolves the live token
-;; (not nil). Registered in the façade so a `:reload` re-wires it on a
-;; fresh registrar.
-(cofx/reg-cofx :nav-token
+;; :rf.route/nav-token` to any `:on-match`-reached handler that declares
+;; `:rf.cofx/requires [:rf.route/nav-token]`, so the documented
+;; `(fn [{:rf.route/keys [nav-token]} _] ...)` shape resolves the live
+;; token (not nil). Owner-qualified to the routing subsystem root per
+;; EP-0017 §2 / Conventions §Recordable-coeffect fact naming, like its
+;; sibling `:rf.route/nav-counters`. Registered in the façade so a
+;; `:reload` re-wires it on a fresh registrar.
+(cofx/reg-cofx :rf.route/nav-token
                nav-token/nav-token-cofx-meta
                nav-token/nav-token-cofx)
 

--- a/implementation/routing/src/re_frame/routing/nav_token.cljc
+++ b/implementation/routing/src/re_frame/routing/nav_token.cljc
@@ -2,10 +2,11 @@
   "Navigation-token stale-result suppression for re-frame2 routing.
 
   Per Spec 012 §Navigation tokens — stale-result suppression. Owns:
-    - `:nav-token` cofx — injects the current navigation epoch token
-      (`[:rf.runtime/routing :current :nav-token]`) into an `:on-match`
-      handler's `:coeffects` under key `:nav-token`, so the handler can
-      capture it and thread it into an async continuation;
+    - `:rf.route/nav-token` cofx — injects the current navigation epoch
+      token (`[:rf.runtime/routing :current :nav-token]`) into an
+      `:on-match` handler's `:coeffects` under key `:rf.route/nav-token`,
+      so the handler can capture it and thread it into an async
+      continuation;
     - `:rf.route/with-nav-token` fx — wraps an async-completion fx
       entry (`:do`) with a stale-result check: match → run; mismatch →
       suppress and emit `:rf.route.nav-token/stale-suppressed`.
@@ -41,7 +42,7 @@
             [re-frame.trace :as trace]))
 
 (def nav-token-cofx-meta
-  "Metadata for the `:nav-token` cofx registration. Per Spec 012
+  "Metadata for the `:rf.route/nav-token` cofx registration. Per Spec 012
   §Navigation tokens — stale-result suppression step 2: the cofx
   injects the current navigation epoch token so an `:on-match`-reached
   handler can capture the token live at scheduling time and thread it
@@ -52,13 +53,14 @@
   so the cofx resolves under SSR and browser alike."
   {:doc "The current navigation epoch token, read from
 `[:rf.runtime/routing :current :nav-token]` and delivered under
-`:coeffects :nav-token`. Declare with `:rf.cofx/requires [:nav-token]` on an
-`:on-match`-reached handler; capture the value and thread it into an
-async continuation so a superseding navigation suppresses the stale
-result. Per Spec 012 §Navigation tokens — stale-result suppression."})
+`:coeffects :rf.route/nav-token`. Declare with
+`:rf.cofx/requires [:rf.route/nav-token]` on an `:on-match`-reached
+handler; capture the value and thread it into an async continuation so a
+superseding navigation suppresses the stale result. Per Spec 012
+§Navigation tokens — stale-result suppression."})
 
 (defn nav-token-cofx
-  "Value-returning AMBIENT supplier for the `:nav-token` cofx (EP-0017 §2).
+  "Value-returning AMBIENT supplier for the `:rf.route/nav-token` cofx (EP-0017 §2).
   Reads the current navigation epoch token from the active frame's runtime-db
   route slice (`[:rf.runtime/routing :current :nav-token]`, read via
   `frame/frame-runtime-db-value` of `frame/*current-frame*` — bound by the
@@ -66,7 +68,7 @@ result. Per Spec 012 §Navigation tokens — stale-result suppression."})
   routing runtime-db state. Never recorded; replay re-runs it (the token is
   re-presented because the route slice itself is recorded durable state).
 
-  A handler declares `:rf.cofx/requires [:nav-token]` and reads the value flat.
+  A handler declares `:rf.cofx/requires [:rf.route/nav-token]` and reads the value flat.
   Meaningful only inside a handler reached via an `:on-match` drain (or a
   follow-up of one), where the route slice holds the epoch the navigation
   cascade allocated. Read from any other handler it reflects whatever

--- a/implementation/routing/src/re_frame/routing/reply.cljc
+++ b/implementation/routing/src/re_frame/routing/reply.cljc
@@ -12,7 +12,7 @@
   and gated by the data-only suppression map `{:route/nav-token
   nav-token}`, validated against the live `[:rf.runtime/routing :current
   :nav-token]` before the app reply target runs. The PUBLIC routing API
-  (the `:nav-token` cofx, `:rf.route/with-nav-token`, `:on-match` /
+  (the `:rf.route/nav-token` cofx, `:rf.route/with-nav-token`, `:on-match` /
   loaders) is PRESERVED — this is internal lowering only.
 
   Two concerns, both consuming the shared `re-frame.reply` substrate:

--- a/implementation/routing/test/re_frame/routing_nav_token_test.clj
+++ b/implementation/routing/test/re_frame/routing_nav_token_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.routing-nav-token-test
   "Navigation-token stale-result-suppression + `:on-match` loader tests
-  for re-frame.routing (nav-token allocation, the `:nav-token` cofx, the
+  for re-frame.routing (nav-token allocation, the `:rf.route/nav-token` cofx, the
   `:rf.route/with-nav-token` fx, and multi-loader `:on-match` ordering /
   error precedence). Split from routing_test.clj per rf2-u8qe7y finding 3."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
@@ -279,20 +279,21 @@
                               @traces)))
           "exactly one stale-suppressed trace fired — the fresh :do did NOT trip the validation"))))
 
-;; ---- Spec 012 §Navigation tokens step 2 — the `:nav-token` cofx ----------
+;; ---- Spec 012 §Navigation tokens step 2 — the `:rf.route/nav-token` cofx ----------
 ;;
-;; rf2-8fnwq: the spec promised an `:on-match`-reachable `:nav-token` cofx
-;; (step 2 / step 4 "validating cofx") but no `reg-cofx :nav-token` was
-;; registered. A handler that followed the spec — declared
-;; `(inject-cofx :nav-token)` and read `{:keys [db nav-token]}` — threaded
-;; `nil`, which mismatched the current token in `:rf.route/with-nav-token`
-;; EVERY time, so the documented stale-suppression pattern silently ate
-;; the result. These tests are the failing-before / passing-after guard.
+;; rf2-8fnwq: the spec promised an `:on-match`-reachable `:rf.route/nav-token`
+;; cofx (step 2 / step 4 "validating cofx") but no `reg-cofx
+;; :rf.route/nav-token` was registered. A handler that followed the spec —
+;; declared `:rf.cofx/requires [:rf.route/nav-token]` and read
+;; `{:rf.route/keys [nav-token]}` — threaded `nil`, which mismatched the
+;; current token in `:rf.route/with-nav-token` EVERY time, so the documented
+;; stale-suppression pattern silently ate the result. These tests are the
+;; failing-before / passing-after guard.
 
 (deftest nav-token-cofx-injects-the-live-token
-  (testing ":rf.cofx/requires [:nav-token] delivers the current slice token — not nil"
+  (testing ":rf.cofx/requires [:rf.route/nav-token] delivers the current slice token — not nil"
     ;; The minimal contract: a handler declaring the cofx sees the live
-    ;; navigation epoch. Pre-fix this was nil (no reg-cofx :nav-token).
+    ;; navigation epoch. Pre-fix this was nil (no reg-cofx :rf.route/nav-token).
     (rf/reg-route :route/article {:path   "/articles/:id"
                                   :params [:map [:id :string]]})
     (rf/reg-fx :rf.nav/push-url
@@ -301,8 +302,8 @@
     (let [seen (atom :unset)]
       ;; An :on-match-reached handler that captures the injected token.
       (rf/reg-event-fx :article/capture-token
-                       {:rf.cofx/requires [:nav-token]}
-                       (fn [{:keys [nav-token]} _]
+                       {:rf.cofx/requires [:rf.route/nav-token]}
+                       (fn [{:rf.route/keys [nav-token]} _]
                          (reset! seen nav-token)
                          {}))
       ;; Land on the route, then fire the on-match-style continuation.
@@ -352,8 +353,8 @@
       ;; The capture closes over `captured` so the test replays the
       ;; completion later, out of order.
       (rf/reg-event-fx :article/load
-                       {:rf.cofx/requires [:nav-token]}
-                       (fn [{:keys [nav-token]} [_ id]]
+                       {:rf.cofx/requires [:rf.route/nav-token]}
+                       (fn [{:rf.route/keys [nav-token]} [_ id]]
                          (swap! captured assoc id nav-token)
                          {}))
 


### PR DESCRIPTION
## What

The routing nav-token coeffect was registered under the **bare** id `:nav-token`, violating EP-0017 §2 + Conventions §Recordable-coeffect fact naming — framework subsystem facts must carry their subsystem root (the sibling `:rf.route/nav-counters` cofx is correctly owner-qualified). A bare id pollutes the single global cofx id-namespace (one registry, one id-namespace) and risks app-collision.

This renames the cofx **id** to the owner-qualified `:rf.route/nav-token`. Pre-alpha: direct rename, **no back-compat alias**.

## Changes

- **`routing.cljc`** — `reg-cofx :nav-token` → `reg-cofx :rf.route/nav-token` (+ registration comment).
- **`nav_token.cljc`** — cofx-id references in the ns docstring, `nav-token-cofx-meta` (incl. its `:doc` describing the delivered `:coeffects` key + the `:rf.cofx/requires` declaration shape), and `nav-token-cofx` docstring.
- **`reply.cljc`** — cofx-id reference in the public-API list docstring.
- **`routing_nav_token_test.clj`** — both consumer handlers' `:rf.cofx/requires [:nav-token]` → `[:rf.route/nav-token]`, and their delivered-coeffect destructure `{:keys [nav-token]}` → `{:rf.route/keys [nav-token]}` (the delivered coeffect key equals the cofx id verbatim, per `cofx/deliver-declared-cofx` `assoc-in [:coeffects id]`), plus the doc/comment cofx-id references.

## Out of scope (deliberately unchanged)

These are field-in-a-map keys, **not registered ids** (the bead explicitly carves them out as a separate concern):
- the route-slice field key `[:rf.runtime/routing :current :nav-token]` and the published slice shape `{:id … :nav-token}`
- the `:nav-token-counter` allocator key
- the work-id tuple component `[:rf.work/route route-id nav-token loader-id]`
- the `:route/nav-token` data-only suppression-gate value and the `:rf.fx/with-nav-token-args` schema `[:nav-token :any]`
- the `:rf.route/with-nav-token` fx `:nav-token` arg key (event/fx payload, not a cofx id)

The top-level `spec/012-*` doc is outside this worktree's boundary (other workers / hot-zone); any Spec 012 prose touch-up is a follow-up.

This PR does **not** add a `reg-cofx` owner-qualification validation to core — that is a separate concern, tracked elsewhere.

## Quality gates

- `clojure -M:test` (routing artefact): **244 tests, 1224 assertions, 0 failures, 0 errors** ✅
- `npm run test:cljs` (node-runtime CLJS, full suite): **6971 tests, 28565 assertions, 0 failures, 0 errors** ✅

Closes rf2-mzhko8, rf2-nklpwn (both children of EP-0017 epic rf2-d8mvke).
