### PR TITLE
fix(core): EP-0017 r2 — reject contradictory provided+supplier cofx + cofx-registration-invalid error (rf2-d8mvke.1)

### DIFF
--- a/docs/EP/EP-0017-recordable-coeffects.md
+++ b/docs/EP/EP-0017-recordable-coeffects.md
@@ -616,8 +616,9 @@ delivery).
 | `:rf.error/missing-required-cofx` | a required fact is absent and cannot be ensured — strict mode (no generator runs), or any mode for a provided fact whose value wasn't stamped |
 | `:rf.error/unregistered-cofx` | a required id has no registration (the typo case) — registration-time where statically checkable, else first processing |
 | `:rf.error/cofx-request-invalid` | malformed `:rf.cofx/requires` at registration |
+| `:rf.error/cofx-registration-invalid` | malformed `reg-cofx` metadata grade at registration — `:provided?` without `:recordable?`, a missing supplier on a non-provided fact, or a provided fact carrying a (silently ignored) supplier |
 | `:rf.error/cofx-value-invalid` | a supplied/replayed value fails the structural EDN check or the registration's `:schema` — **fires in production** |
-| `:rf.error/cofx-name-collision` | registration-time name collision (above) |
+| `:rf.error/cofx-name-collision` | registration-time name collision (above) — genuine duplicate ownership only |
 | `:rf.error/world-inputs-renamed` | `:rf.world/inputs` supplied in dispatch opts — hard error naming `:rf.cofx` |
 | `:rf.error/inject-cofx-removed` | `inject-cofx` called — hard error naming `:rf.cofx/requires` |
 

--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -110,6 +110,27 @@
                    :reason      reason
                    :recovery    :no-recovery})))
 
+(defn- emit-cofx-registration-invalid!
+  "Emit `:rf.error/cofx-registration-invalid` (registration-time, diagnostic)
+  and throw. The malformed-METADATA case — a `reg-cofx` whose grade is
+  internally contradictory (`:provided?` without `:recordable?`; a missing
+  supplier on a non-provided fact; a provided fact carrying a supplier that
+  delivery will silently ignore). DISTINCT from
+  `:rf.error/cofx-name-collision`, which is reserved for genuine duplicate
+  ownership (`:db` / `:event` / another registered id). Per Spec 001
+  §`reg-cofx` + Spec 009 §Error catalogue."
+  [id reason]
+  (trace/emit-error! :rf.error/cofx-registration-invalid
+                     {:rf.cofx/id id
+                      :reason     reason
+                      :recovery   :no-recovery})
+  (throw (ex-info ":rf.error/cofx-registration-invalid"
+                  {:rf.error/id :rf.error/cofx-registration-invalid
+                   :rf.cofx/id  id
+                   :where       'rf/reg-cofx
+                   :reason      reason
+                   :recovery    :no-recovery})))
+
 (defn reg-cofx
   "Register a coeffect id with a **value-returning supplier** and standard
   Spec 001 metadata. Per Spec 001 §`reg-cofx` + EP-0017.
@@ -153,9 +174,16 @@
 
   Registration-time errors:
 
-      :rf.error/cofx-name-collision  the id collides with the fold's
-                                     argument keys (`:db` / `:event`) or
-                                     another registered coeffect id.
+      :rf.error/cofx-name-collision       the id collides with the fold's
+                                          argument keys (`:db` / `:event`)
+                                          or another registered coeffect id
+                                          (genuine duplicate ownership).
+      :rf.error/cofx-registration-invalid the metadata grade is malformed —
+                                          `:provided?` without
+                                          `:recordable?`, a missing supplier
+                                          on a non-provided fact, or a
+                                          provided fact carrying a (silently
+                                          ignored) supplier.
 
   Examples:
 
@@ -205,9 +233,10 @@
       ;; grade that would otherwise register as an ambient fact with a nil
       ;; supplier, surfacing only as an opaque host NPE at delivery
       ;; (`run-ambient-supplier` invoking nil). Reject it loudly at the call
-      ;; site instead (Spec-Schemas §`:rf/cofx-meta`, rf2-cu8wet).
+      ;; site instead (Spec-Schemas §`:rf/cofx-meta`, rf2-cu8wet). This is a
+      ;; malformed-grade error, NOT a name collision (rf2-d8mvke.6).
       (when (and provided? (not recordable?))
-        (emit-cofx-name-collision!
+        (emit-cofx-registration-invalid!
           id
           (str "`reg-cofx` id `" id "` declared `:provided? true` without "
                "`:recordable? true`. A provided coeffect is recordable by "
@@ -216,12 +245,35 @@
                "`:recordable? true` (a provided recordable fact) or drop "
                "`:provided?` and supply a value-returning fn (an ambient "
                "fact).")))
+      ;; A PROVIDED recordable fact has NO generator: its value is stamped
+      ;; onto the token by its owner and delivery reads it from the token's
+      ;; `:rf.cofx` verbatim (`deliver-declared-cofx`'s recordable branch
+      ;; never invokes a supplier). A supplier passed alongside `:provided?
+      ;; true` is therefore SILENTLY IGNORED at delivery — the registration
+      ;; looks like it provides a generator, but the first handler requiring
+      ;; the fact (when it is absent from the token) fails as
+      ;; `:rf.error/missing-required-cofx`. Reject the contradiction at the
+      ;; call site (rf2-d8mvke.1). The valid provided shape is
+      ;; `{:recordable? true :provided? true}` with NO supplier.
+      (when (and provided? (some? supplier))
+        (emit-cofx-registration-invalid!
+          id
+          (str "`reg-cofx` id `" id "` declared `:provided? true` WITH a "
+               "supplier. A provided recordable fact has NO generator — its "
+               "value is stamped onto the causal token by its owner and "
+               "delivered verbatim, so this supplier would be silently "
+               "ignored at delivery (the first consumer fails as "
+               "`:rf.error/missing-required-cofx`). Either drop the supplier "
+               "(a provided recordable fact: `{:recordable? true :provided? "
+               "true}`) or drop `:provided?` (a recordable fact whose "
+               "supplier generates the value).")))
       ;; A non-recordable (ambient) fact with no supplier cannot produce a
       ;; value; only a PROVIDED recordable fact legitimately omits its
       ;; generator (its owner stamps the token). An ambient fact MUST carry a
-      ;; supplier.
+      ;; supplier. This is a malformed-grade error, NOT a name collision
+      ;; (rf2-d8mvke.6).
       (when (and (nil? supplier) (not provided?))
-        (emit-cofx-name-collision!
+        (emit-cofx-registration-invalid!
           id
           (str "`reg-cofx` id `" id "` declared no supplier. Only a PROVIDED "
                "recordable fact (`{:recordable? true :provided? true}`) may "

--- a/implementation/core/test/re_frame/cofx_cljs_test.cljc
+++ b/implementation/core/test/re_frame/cofx_cljs_test.cljc
@@ -466,18 +466,86 @@
             a registration-time hard error — a provided fact is recordable by
             definition; the malformed grade would otherwise register as an
             ambient fact with a nil supplier and surface only as an opaque
-            host throw at delivery (rf2-cu8wet · Spec-Schemas §`:rf/cofx-meta`)"
+            host throw at delivery (rf2-cu8wet · Spec-Schemas §`:rf/cofx-meta`).
+            The taxonomy is `:rf.error/cofx-registration-invalid` (malformed
+            metadata), NOT `:rf.error/cofx-name-collision` (rf2-d8mvke.6
+            finding-1 — collision is reserved for duplicate ownership)."
     (let [ex (try (rf/reg-cofx :cofx-test/bad-grade {:provided? true})
                   nil (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))]
       (is (some? ex) "the malformed registration threw")
-      (is (= :rf.error/cofx-name-collision (:rf.error/id (ex-data ex)))
-          "rejected at the call site, not as a late delivery NPE")
+      (is (= :rf.error/cofx-registration-invalid (:rf.error/id (ex-data ex)))
+          "rejected as malformed metadata, not a name collision and not a late delivery NPE")
       (is (= :cofx-test/bad-grade (:rf.cofx/id (ex-data ex)))
           "the offending id rides the error payload")
       (is (re-find #":recordable\? true" (:reason (ex-data ex)))
           "the reason points the author at the fix")
       (is (nil? (registrar/lookup :cofx :cofx-test/bad-grade))
           "the malformed fact did NOT register"))))
+
+(deftest no-supplier-non-provided-is-registration-invalid
+  (testing "`reg-cofx` with NO supplier and no `:provided?` is
+            `:rf.error/cofx-registration-invalid` — an ambient fact must carry
+            a value-returning supplier; only a provided recordable fact may
+            omit it (rf2-d8mvke.6 finding-1 — malformed metadata, NOT a name
+            collision)"
+    (let [ex (try (rf/reg-cofx :cofx-test/no-supplier {:doc "missing supplier"})
+                  nil (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))]
+      (is (some? ex) "the no-supplier registration threw")
+      (is (= :rf.error/cofx-registration-invalid (:rf.error/id (ex-data ex)))
+          "a missing supplier is malformed metadata, not a name collision")
+      (is (= :cofx-test/no-supplier (:rf.cofx/id (ex-data ex)))
+          "the offending id rides the error payload")
+      (is (re-find #"no supplier" (:reason (ex-data ex)))
+          "the reason names the missing supplier")
+      (is (nil? (registrar/lookup :cofx :cofx-test/no-supplier))
+          "the malformed fact did NOT register"))))
+
+(deftest provided-with-supplier-is-rejected-at-registration
+  (testing "ADVERSARIAL (rf2-d8mvke.1): `reg-cofx` with `{:recordable? true
+            :provided? true}` AND a supplier is a contradictory registration —
+            a provided recordable fact has NO generator (its owner stamps the
+            token; delivery reads it verbatim), so the supplier would be
+            SILENTLY IGNORED and the first consumer would fail as
+            missing-required. It is rejected at the call site as
+            `:rf.error/cofx-registration-invalid`."
+    (let [ex (try (rf/reg-cofx :cofx-test/provided-with-fn
+                    {:recordable? true :provided? true}
+                    (fn [] "this would be silently ignored"))
+                  nil (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))]
+      (is (some? ex) "the contradictory registration threw")
+      (is (= :rf.error/cofx-registration-invalid (:rf.error/id (ex-data ex)))
+          "a provided fact carrying a supplier is malformed metadata")
+      (is (= :cofx-test/provided-with-fn (:rf.cofx/id (ex-data ex)))
+          "the offending id rides the error payload")
+      (is (re-find #"silently ignored" (:reason (ex-data ex)))
+          "the reason explains the supplier is silently ignored at delivery")
+      (is (nil? (registrar/lookup :cofx :cofx-test/provided-with-fn))
+          "the contradictory fact did NOT register"))))
+
+(deftest provided-without-supplier-registers-cleanly
+  (testing "the VALID provided shape — `{:recordable? true :provided? true}`
+            with NO supplier — still registers (rf2-d8mvke.1 keeps it valid:
+            only the supplier-bearing contradiction is rejected)"
+    (is (= :cofx-test/clean-provided
+           (rf/reg-cofx :cofx-test/clean-provided
+             {:recordable? true :provided? true})))
+    (let [meta (registrar/lookup :cofx :cofx-test/clean-provided)]
+      (is (true? (:recordable? meta)) "recordable")
+      (is (true? (:provided? meta)) "provided")
+      (is (nil? (:handler-fn meta)) "no supplier — its owner stamps the token"))))
+
+(deftest recordable-with-supplier-no-provided-registers-cleanly
+  (testing "a RECORDABLE fact WITH a supplier but no `:provided?` still
+            registers (rf2-d8mvke.1 — recordable-with-supplier is valid; the
+            generator backs the recordable fact)"
+    (is (= :cofx-test/recordable-gen
+           (rf/reg-cofx :cofx-test/recordable-gen
+             {:recordable? true}
+             (fn [] "generated"))))
+    (let [meta (registrar/lookup :cofx :cofx-test/recordable-gen)]
+      (is (true? (:recordable? meta)) "recordable")
+      (is (false? (:provided? meta)) "not provided")
+      (is (fn? (:handler-fn meta)) "carries its generator supplier"))))
 
 (deftest provided-recordable-registers-cleanly
   (testing "the well-formed provided-recordable grade

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -310,17 +310,23 @@
   fails if any entry becomes catalogued or stops being emitted, forcing the
   co-edit so the list cannot rot into a silent blanket suppression.
 
-  CURRENT ENTRY (transitional co-edit, rf2-d8mvke.1 / rf2-d8mvke.6 finding-1):
+  CO-EDIT RESOLVED (rf2-d8mvke.1 / rf2-d8mvke.6 finding-1):
     - `:rf.error/cofx-registration-invalid` — the malformed-`reg-cofx`-metadata
       error introduced by the EP-0017 round-2 review (`reject :provided?+supplier
       contradiction; reserve `:rf.error/cofx-name-collision` for genuine
-      duplicate ownership). The Spec 009 §Error event catalogue row for it is
-      authored by the concurrent EP-0017 completeness-sync worker (rf2-d8mvke.2,
-      which owns the hot-zone 009 file); this code-side PR only EMITS the
-      error-id. Allow-listed so the emit lands green before the catalogue row
-      does. `allow-list-stays-honest` forces the co-edit: once rf2-d8mvke.2
-      catalogues the row, this entry MUST be dropped in that same PR."
-  #{:rf.error/cofx-registration-invalid})
+      duplicate ownership) — was held here transitionally while this code-side
+      PR emitted the error-id ahead of its catalogue row. The Spec 009 §Error
+      event catalogue row was authored + MERGED by the EP-0017 completeness-sync
+      worker (rf2-d8mvke.2, which owns the hot-zone 009 file). The category is
+      now CATALOGUED, so per the ratchet it has been DROPPED from this list:
+      `allow-list-stays-honest` forced exactly this co-edit (a listed entry that
+      becomes catalogued must leave the allow-list).
+
+  The list is currently EMPTY — every emitted category is catalogued or ruled
+  intentionally out-of-catalogue with a 009 note. A new uncatalogued emitted
+  category lands here with a rationale, and the coverage test fails loudly until
+  it does."
+  #{})
 
 ;; ---------------------------------------------------------------------------
 ;; Tests

--- a/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
+++ b/implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj
@@ -305,13 +305,22 @@
       last remaining one — was dropped in the same PR. Source now matches the
       catalogue's RETIRED ruling.
 
-  The allow-list is now EMPTY: the wider-scan backlog is fully catalogued and
-  the one drift entry is retired at the source. It is kept as a live ratchet
-  seam — a future deliberate non-catalogue emit category lands here with a
-  rationale — and `allow-list-stays-honest` fails if any future entry becomes
-  catalogued or stops being emitted, forcing the co-edit so the list cannot rot
-  into a silent blanket suppression."
-  #{})
+  The allow-list is kept as a live ratchet seam — a deliberate non-catalogue
+  emit category lands here with a rationale — and `allow-list-stays-honest`
+  fails if any entry becomes catalogued or stops being emitted, forcing the
+  co-edit so the list cannot rot into a silent blanket suppression.
+
+  CURRENT ENTRY (transitional co-edit, rf2-d8mvke.1 / rf2-d8mvke.6 finding-1):
+    - `:rf.error/cofx-registration-invalid` — the malformed-`reg-cofx`-metadata
+      error introduced by the EP-0017 round-2 review (`reject :provided?+supplier
+      contradiction; reserve `:rf.error/cofx-name-collision` for genuine
+      duplicate ownership). The Spec 009 §Error event catalogue row for it is
+      authored by the concurrent EP-0017 completeness-sync worker (rf2-d8mvke.2,
+      which owns the hot-zone 009 file); this code-side PR only EMITS the
+      error-id. Allow-listed so the emit lands green before the catalogue row
+      does. `allow-list-stays-honest` forces the co-edit: once rf2-d8mvke.2
+      catalogues the row, this entry MUST be dropped in that same PR."
+  #{:rf.error/cofx-registration-invalid})
 
 ;; ---------------------------------------------------------------------------
 ;; Tests


### PR DESCRIPTION
## What

EP-0017 round-2 review fixes for `reg-cofx` registration validation.

### rf2-d8mvke.1 — reject contradictory provided+supplier registrations
`reg-cofx` accepted a contradictory `{:recordable? true :provided? true}` registration carrying a supplier. A provided recordable fact has **no generator** — its value is stamped onto the causal token by its owner and `deliver-declared-cofx`'s recordable branch reads it verbatim, never invoking a supplier. So the supplier was **silently ignored** at delivery, and the first handler requiring the fact (when absent from the token) failed as `:rf.error/missing-required-cofx` even though registration looked like it provided a generator.

Fix: reject `(and provided? (some? supplier))` at registration.

Valid shapes kept valid:
- provided-without-supplier (`{:recordable? true :provided? true}`, no fn) → registers
- recordable-with-supplier (`{:recordable? true}` + fn, no `:provided?`) → registers
- an absent provided fact still fails `:rf.error/missing-required-cofx` at dispatch

### rf2-d8mvke.6 finding-1 — tighten cofx error taxonomy
Malformed `reg-cofx` metadata (invalid grade / missing supplier) was emitted as `:rf.error/cofx-name-collision` — wrong; collision is for duplicate ownership. Introduced `:rf.error/cofx-registration-invalid` and routed the three malformed-metadata cases through it:
- `:provided?` without `:recordable?`
- missing supplier on a non-provided fact
- the new provided+supplier contradiction

`:rf.error/cofx-name-collision` is now reserved for genuine duplicates: fold-arg-key (`:db`/`:event`), `rf.`-prefixed app id, and duplicate id in `:rf.cofx/requires`.

## Files
- `implementation/core/src/re_frame/cofx.cljc` — new `emit-cofx-registration-invalid!`; the provided+supplier rejection; re-route the two malformed-metadata checks; docstring.
- `implementation/core/test/re_frame/cofx_cljs_test.cljc` — re-pinned the existing `provided-without-recordable` test to the new error-id (was pinning the old name at :464); added tests for no-supplier→registration-invalid, provided+supplier→registration-invalid, and the two valid shapes.
- `docs/EP/EP-0017-recordable-coeffects.md` — added the `:rf.error/cofx-registration-invalid` error-grammar table row; clarified `cofx-name-collision` is duplicate-ownership only.
- `implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj` — co-edit RESOLVED: now that the spec-residue PR (#4103) merged the `:rf.error/cofx-registration-invalid` Spec 009 catalogue row to main, the transitional allow-list entry has been **dropped** (the set is now empty `#{}`) and the surrounding docstring updated to record the resolution. `allow-list-stays-honest` forced exactly this co-edit.

## Coordination
The **Spec 009 catalogue row** for `:rf.error/cofx-registration-invalid` was authored by the EP-0017 completeness worker (**rf2-d8mvke.2**) and merged to main via **#4103**. This PR emits the error-id from code; per the task brief it does not touch `spec/009-Instrumentation.md`. With the catalogue row now on main, this branch was rebased onto it and the transitional allow-list entry removed — the ratchet co-edit is complete.

This PR closes **finding-1 of rf2-d8mvke.6 only**; findings 2 (inject-cofx docs residue) and 3 (routing nav-id ambient cofx) are other workers, so rf2-d8mvke.6 stays open.

## Quality gates
Rebased onto `origin/main` (which carries #4103's catalogue row) before running.
- `clojure -M:test` (core, JVM): **pass** — 1423 tests / 6322 assertions, 0 failures, 0 errors. The previously-noted 3 pre-existing failures are gone now that #4103 fixed the spec/009 residue; `allow-list-stays-honest` and the catalogue-coverage test both pass with `cofx-registration-invalid` catalogued (not allow-listed).
- `npm run test:cljs` (node CLJS, canonical gate): **pass** — 7001 tests / 28668 assertions, 0 failures, 0 errors.
