### PR TITLE
test(conformance): EP-0017 r2 — pin Slice-A cofx contracts (rf2-d8mvke.3 f1)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -1242,7 +1242,10 @@
           _            (rf/with-frame scope-frame
                          (realise-flows! fixture))
           dispatches   (or (:fixture/dispatches fixture) [])
-          sub-registry (get-in fixture [:fixture/registry :sub] {})]
+          sub-registry (get-in fixture [:fixture/registry :sub] {})
+          ;; EP-0017 (rf2-d8mvke.3): per-dispatch `:expect-error` assertions —
+          ;; mirror of the JVM runner. See the JVM runner's binding comment.
+          dispatch-error-failures (atom [])]
       (rf/with-frame scope-frame
       (doseq [ev dispatches]
         (cond
@@ -1275,6 +1278,31 @@
                                 (concat (when (seq sub-meta) [sub-meta])
                                         (interleave (repeat :<-) inputs)
                                         [body]))))
+
+            ;; EP-0017 (rf2-d8mvke.3): a dispatch asserting a boundary /
+            ;; context-assembly THROW. `:expect-error` is the `:rf.error/id`
+            ;; the dispatch must raise (cofx delivery errors, or the
+            ;; `:rf.world/inputs` retirement). The throw escapes
+            ;; `dispatch-sync`, so the runner catches it here and compares
+            ;; the ex-data `:rf.error/id`. Mirror of the JVM runner.
+            (contains? ev :expect-error)
+            (let [{event :event want :expect-error} ev
+                  opts   (dissoc ev :event :expect-error)
+                  got    (try (rf/dispatch-sync event opts) ::no-throw
+                              (catch :default e
+                                (or (:rf.error/id (ex-data e)) e)))]
+              (cond
+                (= got ::no-throw)
+                (swap! dispatch-error-failures conj
+                       (str "dispatch " (pr-str event) " expected to throw "
+                            want " but did not throw"))
+                (not= got want)
+                (swap! dispatch-error-failures conj
+                       (str "dispatch " (pr-str event) " expected error " want
+                            " but got " (if (keyword? got)
+                                          got
+                                          (str "a non-rf.error/id throw: "
+                                               (some-> got ex-message)))))))
 
             :else
             (let [{event :event :as opts} ev]
@@ -1321,6 +1349,9 @@
       (let [expect       (or (:fixture/expect fixture) {})
             expected-db  (:final-app-db expect)
             expected-dbs (:final-app-dbs expect)
+            ;; EP-0017 (rf2-d8mvke.3): NEGATIVE app-db path assertions —
+            ;; mirror of the JVM runner. Each path's tip key must be ABSENT.
+            expected-absent (:final-app-db-absent expect)
             final-db     (rf/app-db-value :rf/default)
             final-dbs    (when expected-dbs
                            (into {}
@@ -1343,6 +1374,19 @@
                   {:query    query-v
                    :expected expected-val
                    :actual   (rf/subscribe-once frame-id qv)})))
+            ;; EP-0017 (rf2-d8mvke.3): NEGATIVE app-db path assertions —
+            ;; mirror of the JVM runner. A sentinel `get-in` distinguishes
+            ;; absent from present-with-nil.
+            absent-failures
+            (when expected-absent
+              (vec
+                (keep (fn [path]
+                        (let [sentinel ::absent
+                              v        (get-in final-db path sentinel)]
+                          (when-not (identical? v sentinel)
+                            (str "expected app-db path " (pr-str path)
+                                 " to be ABSENT but found " (pr-str v)))))
+                      expected-absent)))
             trace-failures (check-trace-emissions @traces (:trace-emissions expect))
             ;; rf2-wxe9t — substrate-side error-emit records mirror of
             ;; the JVM runner. A fixture without `:error-emit-records`
@@ -1392,12 +1436,18 @@
                             (or (nil? expected-rts)
                                 (every? (fn [[fid rt]] (submap? rt (get final-rts fid)))
                                         expected-rts))
+                            ;; EP-0017 (rf2-d8mvke.3) — negative app-db paths +
+                            ;; per-dispatch expect-error assertions.
+                            (empty? absent-failures)
+                            (empty? @dispatch-error-failures)
                             (every? #(= (:expected %) (:actual %)) sub-checks)
                             (empty? trace-failures)
                             (empty? effects-failures)
                             (empty? error-emit-failures)
                             (or (nil? public-error-check)
                                 (:passed? public-error-check)))
+         :absent-failures         absent-failures
+         :dispatch-error-failures @dispatch-error-failures
          :final-db     final-db
          :final-dbs    final-dbs
          :expected-db  expected-db
@@ -1504,6 +1554,12 @@
             (when (not= tds (:final-dbs f))
               (println "    expected app-dbs:" tds)
               (println "    actual   app-dbs:" (:final-dbs f))))
+          (when (seq (:absent-failures f))
+            (doseq [af (:absent-failures f)]
+              (println "    absent:" af)))
+          (when (seq (:dispatch-error-failures f))
+            (doseq [def (:dispatch-error-failures f)]
+              (println "    expect-error:" def)))
           (doseq [sc (:sub-checks f)]
             (when (not= (:expected sc) (:actual sc))
               (println "    sub" (:query sc) "expected:" (:expected sc) "actual:" (:actual sc))))

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -1433,7 +1433,18 @@
           _            (rf/with-frame scope-frame
                          (realise-flows! fixture))
           dispatches   (or (:fixture/dispatches fixture) [])
-          sub-registry (get-in fixture [:fixture/registry :sub] {})]
+          sub-registry (get-in fixture [:fixture/registry :sub] {})
+          ;; EP-0017 (rf2-d8mvke.3): a dispatch map may carry
+          ;; `:expect-error <:rf.error/id>` to assert the dispatch THROWS an
+          ;; `ex-info` whose `:rf.error/id` ex-data slot equals the expected
+          ;; id (the cofx delivery errors + the `:rf.world/inputs` retirement
+          ;; throw from context assembly / the dispatch boundary, escaping
+          ;; `dispatch-sync`). Mirrors the Mode-B `:reg-machine` /
+          ;; `:path-instantiate` `:expect-error` convention. Failures
+          ;; (no-throw, wrong id, or generic throw) accumulate here and fail
+          ;; the fixture; an UNEXPECTED throw (no `:expect-error`) still
+          ;; propagates to the outer fixture-level catch.
+          dispatch-error-failures (atom [])]
       ;; EP-0002 (rf2-9o48ih) — bare `dispatch-sync` resolves its target
       ;; from the `scope-frame` established here; see the registration-
       ;; time note above for the carried-invariant rationale.
@@ -1483,6 +1494,36 @@
                                 (concat (when (seq sub-meta) [sub-meta])
                                         (interleave (repeat :<-) inputs)
                                         [body]))))
+
+            ;; EP-0017 (rf2-d8mvke.3): a dispatch asserting a boundary /
+            ;; context-assembly THROW. `:expect-error` is the
+            ;; `:rf.error/id` the dispatch must raise (e.g. the cofx
+            ;; delivery errors, or the `:rf.world/inputs` retirement). The
+            ;; throw escapes `dispatch-sync` (the cofx errors throw during
+            ;; context assembly, the retirement at the dispatch boundary —
+            ;; neither is captured into the chain), so the runner catches it
+            ;; here and compares the ex-data `:rf.error/id`. The remaining
+            ;; opts (e.g. `:rf.cofx` / `:rf.world/inputs`) pass through to
+            ;; `dispatch-sync`.
+            (contains? ev :expect-error)
+            (let [{event :event want :expect-error} ev
+                  opts   (dissoc ev :event :expect-error)
+                  got    (try (rf/dispatch-sync event opts) ::no-throw
+                              (catch clojure.lang.ExceptionInfo e
+                                (:rf.error/id (ex-data e)))
+                              (catch Throwable e e))]
+              (cond
+                (= got ::no-throw)
+                (swap! dispatch-error-failures conj
+                       (str "dispatch " (pr-str event) " expected to throw "
+                            want " but did not throw"))
+                (not= got want)
+                (swap! dispatch-error-failures conj
+                       (str "dispatch " (pr-str event) " expected error " want
+                            " but got " (if (instance? Throwable got)
+                                          (str "a non-ExceptionInfo throw: "
+                                               (some-> ^Throwable got .getMessage))
+                                          got)))))
 
             :else
             (let [{event :event :as opts} ev]
@@ -1552,6 +1593,14 @@
             ;; {frame-id db}.
             expected-db  (:final-app-db expect)
             expected-dbs (:final-app-dbs expect)
+            ;; EP-0017 (rf2-d8mvke.3): NEGATIVE app-db assertion. A vector of
+            ;; `get-in`-shaped paths that must be ABSENT from the final
+            ;; (`:rf/default`) app-db — the key at the path's tip must not be
+            ;; present (distinguished from present-with-nil). `:final-app-db`'s
+            ;; submap matching tolerates extra keys, so it cannot pin
+            ;; declared-only delivery (an over-delivering port still passes);
+            ;; this absent-path check is what FAILS such a port.
+            expected-absent (:final-app-db-absent expect)
             final-db     (rf/app-db-value :rf/default)
             final-dbs    (when expected-dbs
                            (into {}
@@ -1581,6 +1630,21 @@
                   {:query    query-v
                    :expected expected-val
                    :actual   (rf/subscribe-once frame-id qv)})))
+            ;; EP-0017 (rf2-d8mvke.3): NEGATIVE app-db path assertions. Each
+            ;; path's tip key must be ABSENT from the final app-db. Uses a
+            ;; sentinel `get-in` so a present-with-nil leaf is NOT mistaken
+            ;; for absent (the over-delivery case might legitimately deliver
+            ;; a nil-valued coeffect, which is still a delivery).
+            absent-failures
+            (when expected-absent
+              (vec
+                (keep (fn [path]
+                        (let [sentinel ::absent
+                              v        (get-in final-db path sentinel)]
+                          (when-not (identical? v sentinel)
+                            (str "expected app-db path " (pr-str path)
+                                 " to be ABSENT but found " (pr-str v)))))
+                      expected-absent)))
             trace-failures (check-trace-emissions @traces (:trace-emissions expect))
             ;; rf2-wxe9t — substrate-side error-emit records (the
             ;; corpus-wide listener fan-out). The matcher mirrors
@@ -1644,6 +1708,10 @@
                             (or (nil? expected-rts)
                                 (every? (fn [[fid rt]] (submap? rt (get final-rts fid)))
                                         expected-rts))
+                            ;; EP-0017 (rf2-d8mvke.3) — negative app-db paths +
+                            ;; per-dispatch expect-error assertions.
+                            (empty? absent-failures)
+                            (empty? @dispatch-error-failures)
                             (every? #(= (:expected %) (:actual %)) sub-checks)
                             (empty? trace-failures)
                             (empty? effects-failures)
@@ -1651,6 +1719,8 @@
                             (empty? error-emit-failures)
                             (or (nil? public-error-check)
                                 (:passed? public-error-check)))
+         :absent-failures         absent-failures
+         :dispatch-error-failures @dispatch-error-failures
          :final-db     final-db
          :final-dbs    final-dbs
          :expected-db  expected-db
@@ -1768,6 +1838,12 @@
             (when (not= tds (:final-dbs f))
               (println "    expected app-dbs:" tds)
               (println "    actual   app-dbs:" (:final-dbs f))))
+          (when (seq (:absent-failures f))
+            (doseq [af (:absent-failures f)]
+              (println "    absent:" af)))
+          (when (seq (:dispatch-error-failures f))
+            (doseq [def (:dispatch-error-failures f)]
+              (println "    expect-error:" def)))
           (doseq [sc (:sub-checks f)]
             (when (not= (:expected sc) (:actual sc))
               (println "    sub" (:query sc) "expected:" (:expected sc) "actual:" (:actual sc))))

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -60,7 +60,7 @@ The classic shape: a starting state (frame configuration plus initial `app-db`),
   :effects-routed      []}}
 ```
 
-The expectation keys inside `:fixture/expect` are partial-match by convention: `:trace-emissions` matches each trace event by its specified keys (absent keys ignored), `:final-app-db` is a literal compare, `:effects-routed` matches the routed-fx pairs in declaration order. See [§Fixture lifecycle](#fixture-lifecycle) for the full comparison contract.
+The expectation keys inside `:fixture/expect` are partial-match by convention: `:trace-emissions` matches each trace event by its specified keys (absent keys ignored), `:final-app-db` is a **submap** compare (every declared key must match; extra actual keys are tolerated), `:effects-routed` matches the routed-fx pairs in declaration order. Because `:final-app-db`'s submap match tolerates extras, a **negative** companion key `:final-app-db-absent` — a vector of `get-in`-shaped paths that must be ABSENT from the final app-db (the tip key not present; a present-with-`nil` leaf counts as present) — pins contracts the positive submap cannot, e.g. EP-0017 declared-only delivery (a port that over-delivers undeclared coeffects still passes the positive check but fails the absent-path check). See [§Fixture lifecycle](#fixture-lifecycle) for the full comparison contract.
 
 ### Mode B — pure / direct-call
 
@@ -248,6 +248,7 @@ In addition, `:fixture/dispatches` accepts two harness-level map forms (alongsid
 |---|---|
 | `{:destroy-frame <frame-id>}` | Call `destroy-frame!` on the named frame. The machine-cascade teardown hook fires (`:rf.machine.lifecycle/destroyed` per active machine), the sub-cache disposes, the substrate releases frame-scoped resources, and `:rf.frame/destroyed` trace fires. Used by Cross-Spec Interaction §1's fixture. |
 | `{:reg-sub <sub-id> :body <sub-body-dsl>}` | Re-register the sub with a new body realised via the conformance sub-DSL interpreter. The registrar's replacement hook fires (`:rf.registry/handler-replaced` with `:kind :sub`), invalidating the cache slot for that query-id. Used by Cross-Spec Interaction §18's fixture. |
+| `{:event <event-vec> :expect-error <:rf.error/id> & opts}` | Dispatch `:event` (forwarding any remaining opts, e.g. `:rf.cofx` / `:rf.world/inputs`) and assert it **throws** an error whose `:rf.error/id` ex-data slot equals `:expect-error`. For boundary / context-assembly errors that escape `dispatch-sync` before any handler runs — the EP-0017 cofx delivery errors (`:rf.error/missing-required-cofx`, `:rf.error/unregistered-cofx`) and the `:rf.world/inputs` retirement (`:rf.error/world-inputs-renamed`). The same `:expect-error` convention the Mode-B `:reg-machine` / `:path-instantiate` ops use, lifted to Mode-A dispatches. A dispatch that does not throw, throws a different `:rf.error/id`, or throws a generic (non-`ex-info`) error is a fixture failure. (A dispatch WITHOUT `:expect-error` that throws still propagates as a fixture-level error.) |
 
 **Control / failure ops:**
 
@@ -296,7 +297,7 @@ Each fixture defines an **invariant the implementation upholds**. The harness:
 4. **Runs `:fixture/dispatches`** — one event vector per call, each via `dispatch-sync`. Each settles to fixed point before the next.
 5. **Runs `:fixture/calls`** (if present) — direct invocations of pure primitives (`machine-transition`, `reg-machine`, `match-url`, `route-url`, `render-to-string`, `round-trip`, `assert-rank-greater`). Each call carries its own expectation; mismatches surface as fixture-level failures.
 6. **Captures observables** (Mode A) — final `app-db`, sub values (per `:fixture/expect :sub-values`), trace events emitted, effects routed.
-7. **Compares** (Mode A) — partial-match per assertion. `:trace-emissions` partial-matches each trace event by its specified keys; absent keys are ignored. `:final-app-db` is a literal compare. `:effects-routed` matches the routed-fx pairs in declaration order.
+7. **Compares** (Mode A) — partial-match per assertion. `:trace-emissions` partial-matches each trace event by its specified keys; absent keys are ignored. `:final-app-db` is a **submap** compare (declared keys must match; extra actual keys tolerated); `:final-app-db-absent` (a vector of `get-in`-shaped paths) asserts each path's tip key is ABSENT. `:effects-routed` matches the routed-fx pairs in declaration order. A dispatch carrying `:expect-error` asserts that dispatch threw the named `:rf.error/id`.
 
 For Mode B fixtures, comparison happens inline at each call; there is no top-level `:fixture/expect` to evaluate after drain.
 
@@ -345,6 +346,10 @@ See `fixtures/` for the actual files. Each fixture is one EDN file; each exercis
 | `frame-multi-instance.edn` | `:frame/multi-instance` | Multi-frame isolation with shared registrar |
 | `frame-lifecycle.edn` | `:frame/lifecycle` | `:on-create` and `:on-destroy` events; lifecycle trace emissions |
 | `dispatch-envelope.edn` | `:dispatch/envelope` | Envelope shape (`:event`, `:frame`, `:source`, `:trace-id`) surfacing in cofx |
+| `cofx-envelope-preserved.edn` | `:cofx/envelope-preserved` | EP-0017 Slice-A: the dispatch envelope's `:rf.cofx` recordable-coeffect map is delivered into the event context under `:rf.cofx`, preserved verbatim (a caller-supplied `:rf/time-ms` rides through unchanged). Expected app-db INCLUDES `:rf.cofx` — the `dispatch-envelope.edn` fixture's expected output omits it, so a port could drop the key and still pass the weaker fixture |
+| `cofx-declared-only-delivery.edn` | `:cofx/declared-only-delivery` | EP-0017 Slice-A: a handler receives EXACTLY its `:rf.cofx/requires` declarations, flat; a REGISTERED-but-undeclared coeffect is withheld. The `:final-app-db-absent` check FAILS a port that over-delivers (submap matching alone tolerates the extra) |
+| `cofx-missing-vs-unregistered.edn` | `:cofx/missing-vs-unregistered` | EP-0017 Slice-A: a declared-but-absent REGISTERED provided coeffect is `:rf.error/missing-required-cofx`; a declared coeffect with NO registration is `:rf.error/unregistered-cofx`. Two distinct error ids (per-dispatch `:expect-error`) — a port that conflates them, throws generically, or fails to throw FAILS |
+| `cofx-world-inputs-retired.edn` | `:cofx/world-inputs-retired` | EP-0017 Slice-A: the retired `:rf.world/inputs` dispatch opt is the hard error `:rf.error/world-inputs-renamed` (per-dispatch `:expect-error`); the canonical `:rf.cofx` replacement is accepted (control dispatch runs). A port that aliases the retired key or fails to reject it FAILS |
 | `drain-depth-limit.edn` | `:drain/depth-limit` | Drain-depth-exceeded error + `:rf.error/drain-depth-exceeded` trace |
 | `sub-chain.edn` | `:sub/chain` | `:<-` chained subs; static dependency topology |
 | `fx-db-first.edn` | `:fx/db-first` | `:db` commits atomically before any `:fx` entry runs; the first `:fx` entry's handler observes the post-`:db` state |

--- a/spec/conformance/fixtures/cofx-declared-only-delivery.edn
+++ b/spec/conformance/fixtures/cofx-declared-only-delivery.edn
@@ -1,0 +1,61 @@
+;; Conformance fixture: cofx/declared-only-delivery
+;;
+;; EP-0017 Slice-A contract — DECLARED-ONLY delivery (Spec 002 §Satisfaction
+;; algorithm + EP-0017 §5). The runtime delivers EXACTLY the facts a handler
+;; declares via `:rf.cofx/requires`, flat, into the coeffect map. A REGISTERED
+;; coeffect that the handler does NOT declare is NOT delivered — nothing
+;; implicit crosses into the handler's coeffects.
+;;
+;; Two ambient coeffects are registered: `:cofxdecl/yes` and `:cofxdecl/no`.
+;; The handler declares ONLY `:cofxdecl/yes` (by reading `[:cofx-key
+;; :cofxdecl/yes]`, which the corpus auto-wires onto the handler's
+;; `:rf.cofx/requires`). Reading a fully-qualified cofx id auto-wires exactly
+;; that id — NOT every sibling in its namespace (the namespace-grouped
+;; auto-wire convention triggers only when the read key is the bare namespace
+;; keyword). So `:cofxdecl/no` is registered-but-undeclared.
+;;
+;; The handler captures the WHOLE delivered coeffect map (minus the framework
+;; context keys) under `[:delivered]` so the corpus can inspect exactly which
+;; facts crossed. Two assertions pin the contract:
+;;
+;;   - `:final-app-db` (submap) — `[:delivered :cofxdecl/yes]` IS present with
+;;     its supplied value (declared delivery works);
+;;   - `:final-app-db-absent` — `[:delivered :cofxdecl/no]` is ABSENT (the
+;;     undeclared registered fact was withheld). `submap?` tolerates extra
+;;     keys, so the POSITIVE app-db check alone could not catch a port that
+;;     over-delivers; the absent-path check is what FAILS such a port.
+
+{:fixture/id           :cofx/declared-only-delivery
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler}
+ :fixture/doc          "EP-0017 declared-only delivery: a handler receives EXACTLY its `:rf.cofx/requires` declarations, flat. A REGISTERED coeffect (`:cofxdecl/no`) the handler does NOT declare is withheld; the declared one (`:cofxdecl/yes`) is delivered. The absent-path check FAILS a port that over-delivers (submap matching alone tolerates the extra)."
+
+ :fixture/registry
+ {:event {:probe/declared-only {:doc "Capture the delivered coeffect map for declared-only inspection."}}
+  :cofx  {:cofxdecl/yes {:doc "Ambient coeffect the handler DECLARES."}
+          :cofxdecl/no  {:doc "Ambient coeffect the handler does NOT declare — must be withheld."}}}
+
+ :fixture/handlers
+ {:cofx  {:cofxdecl/yes [[:set [] "YES"]]
+          :cofxdecl/no  [[:set [] "NO"]]}
+  :event {:probe/declared-only
+          ;; Reading `[:cofx-key :cofxdecl/yes]` declares ONLY :cofxdecl/yes
+          ;; (auto-wired onto `:rf.cofx/requires`). The `:cofx-without` capture
+          ;; strips the framework context keys so `[:delivered]` holds exactly
+          ;; the user-facing coeffects that crossed.
+          [[:set [:got-yes]   [:cofx-key :cofxdecl/yes]]
+           [:set [:delivered] [:cofx-without :db :event :rf.cofx :rf.frame/id :rf.db/runtime :source :trace-id]]]}}
+
+ :fixture/frame-config {}
+
+ :fixture/dispatches
+ [[:probe/declared-only]]
+
+ :fixture/expect
+ {:final-app-db
+  {:got-yes "YES"
+   :delivered {:cofxdecl/yes "YES"}}
+
+  ;; The undeclared registered coeffect was NOT delivered flat.
+  :final-app-db-absent
+  [[:delivered :cofxdecl/no]]}}

--- a/spec/conformance/fixtures/cofx-envelope-preserved.edn
+++ b/spec/conformance/fixtures/cofx-envelope-preserved.edn
@@ -1,0 +1,53 @@
+;; Conformance fixture: cofx/envelope-preserved
+;;
+;; EP-0017 Slice-A contract — the `:rf.cofx` envelope is delivered into the
+;; event context. Per Spec 002 §4 (Event context) + EP-0017 §5, the flat
+;; recordable-coeffect map the dispatch envelope carries under `:rf.cofx`
+;; (one fact per owner-qualified key; always carrying `:rf/time-ms`, the one
+;; framework-provided recordable fact) is reachable through the coeffect
+;; context map under `:rf.cofx` — generic code that wants the whole causal
+;; record reads it there. A port that omits `:rf.cofx` from the context map
+;; would pass the WEAK dispatch-envelope fixture (whose expected output omits
+;; `:rf.cofx`), so this fixture pins the POSITIVE contract: the expected
+;; app-db INCLUDES the preserved `:rf.cofx` map.
+;;
+;; The fixture supplies `:rf.cofx {:rf/time-ms <fixed>}` on the dispatch opts
+;; so the value is deterministic — `ensure-cofx` (re-frame.router) preserves a
+;; caller-supplied `:rf/time-ms` verbatim rather than stamping a fresh host
+;; clock read, so the captured value is the literal the fixture supplied.
+;;
+;; Reading `[:cofx-key :rf.cofx]` forces the realised handler into the event-fx
+;; shape (its body reads a coeffect beyond `:db` / `:event`) so the full
+;; coeffect context — including the framework `:rf.cofx` key — is available.
+;; `:rf.cofx` is an unqualified keyword (no namespace), so the corpus
+;; `:cofx-key` auto-wiring (which only declares REGISTERED cofx ids onto the
+;; consuming handler's `:rf.cofx/requires`) does not treat it as a declarable
+;; coeffect — it is a framework context key, not a registered supplier.
+
+{:fixture/id           :cofx/envelope-preserved
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/sub}
+ :fixture/doc          "EP-0017: the dispatch envelope's `:rf.cofx` recordable-coeffect map is delivered into the event context under `:rf.cofx`, preserved verbatim. A caller-supplied `:rf/time-ms` rides through unchanged; the expected app-db INCLUDES the `:rf.cofx` map (the dispatch-envelope fixture's expected output omits it, so a port could drop the key and still pass that weaker fixture)."
+
+ :fixture/registry
+ {:event {:probe/capture-cofx {:doc "Capture the envelope's `:rf.cofx` map into app-db for inspection."}}
+  :sub   {:envelope-cofx {:doc "Read the captured `:rf.cofx` map."}}}
+
+ :fixture/handlers
+ {:event {:probe/capture-cofx
+          ;; Capture the framework `:rf.cofx` context key verbatim. Reading a
+          ;; coeffect beyond :db/:event routes this through the event-fx shape.
+          [[:set [:envelope-cofx] [:cofx-key :rf.cofx]]]}
+  :sub   {:envelope-cofx [[:get [:envelope-cofx]]]}}
+
+ :fixture/frame-config {}
+
+ :fixture/dispatches
+ [{:event [:probe/capture-cofx] :rf.cofx {:rf/time-ms 1781078400123}}]
+
+ :fixture/expect
+ {:final-app-db
+  {:envelope-cofx {:rf/time-ms 1781078400123}}
+
+  :sub-values
+  {[:envelope-cofx] {:rf/time-ms 1781078400123}}}}

--- a/spec/conformance/fixtures/cofx-missing-vs-unregistered.edn
+++ b/spec/conformance/fixtures/cofx-missing-vs-unregistered.edn
@@ -1,0 +1,71 @@
+;; Conformance fixture: cofx/missing-vs-unregistered
+;;
+;; EP-0017 Slice-A contract — the TWO DISTINCT cofx delivery errors are NOT
+;; conflated (Spec 002 §Satisfaction algorithm + Spec 009 §Error catalogue).
+;; A port must surface a different `:rf.error/id` for each:
+;;
+;;   - `:rf.error/missing-required-cofx` — a declared coeffect that IS
+;;     registered (here a `:recordable? :provided?` boundary fact) but whose
+;;     value is absent from the dispatch token. The fact has a registration;
+;;     the VALUE was not stamped.
+;;   - `:rf.error/unregistered-cofx` — a declared coeffect id with NO
+;;     `reg-cofx` registration at all (the typo case).
+;;
+;; Both are always-on correctness contracts that halt the cascade by throwing
+;; during context assembly (before the handler runs). The conformance dispatch
+;; carries `:expect-error <id>`; the runner asserts the dispatch threw an
+;; `ex-info` whose `:rf.error/id` ex-data slot equals the expected id (mirrors
+;; the Mode-B `:reg-machine` / `:path-instantiate` `:expect-error` convention).
+;; A port that conflated the two ids — or threw a generic error, or did not
+;; throw — FAILS; current core PASSES.
+;;
+;; Each handler reads its declared coeffect via `[:cofx-key …]` so the realised
+;; handler is the event-fx shape (the only kind that may declare
+;; `:rf.cofx/requires`). For the registered-provided fact, the read auto-wires
+;; the (registered) id; for the unregistered id, the read forces event-fx but
+;; auto-wiring withholds the unregistered id, so the explicit
+;; `:rf.cofx/requires` in the event's registry meta is what declares it.
+
+{:fixture/id           :cofx/missing-vs-unregistered
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/error}
+ :fixture/doc          "EP-0017: a declared-but-absent REGISTERED provided coeffect is `:rf.error/missing-required-cofx`; a declared coeffect with NO registration (typo) is `:rf.error/unregistered-cofx`. The two are distinct error ids — a port that conflates them, throws generically, or fails to throw FAILS this fixture."
+
+ :fixture/registry
+ {:event {:probe/missing
+          {:doc "Declares a registered provided coeffect whose value is absent from the token."}
+          :probe/typo
+          {:doc                "Declares an UNREGISTERED coeffect id (the typo case)."
+           ;; Explicit declaration — the unregistered id cannot be auto-wired
+           ;; (the auto-wire convention only declares REGISTERED ids), so the
+           ;; fixture authors `:rf.cofx/requires` directly on the event meta.
+           :rf.cofx/requires [:cofxerr/unregistered]}}
+  :cofx  {:cofxerr/required-boundary
+          ;; A PROVIDED recordable fact — no supplier; its owner stamps the
+          ;; value onto the token. Absent from the token ⇒ missing-required.
+          {:recordable? true :provided? true
+           :doc "Provided recordable boundary fact; absent from the token here."}}}
+
+ :fixture/handlers
+ {:event {:probe/missing
+          ;; Reading the registered provided fact auto-wires it onto
+          ;; `:rf.cofx/requires` and forces the event-fx shape. The handler
+          ;; body never runs — delivery throws first.
+          [[:set [:never] [:cofx-key :cofxerr/required-boundary]]]
+          :probe/typo
+          ;; Reading the unregistered id forces event-fx (so the explicit
+          ;; `:rf.cofx/requires` lands on a reg-event-fx); the read does NOT
+          ;; auto-wire it (unregistered). The handler body never runs.
+          [[:set [:never] [:cofx-key :cofxerr/unregistered]]]}}
+
+ :fixture/frame-config {}
+
+ :fixture/dispatches
+ [{:event [:probe/missing] :expect-error :rf.error/missing-required-cofx}
+  {:event [:probe/typo]    :expect-error :rf.error/unregistered-cofx}]
+
+ :fixture/expect
+ {;; The handler bodies never ran — context assembly threw first, so no
+  ;; `:never` slot was written.
+  :final-app-db-absent
+  [[:never]]}}

--- a/spec/conformance/fixtures/cofx-world-inputs-retired.edn
+++ b/spec/conformance/fixtures/cofx-world-inputs-retired.edn
@@ -1,0 +1,47 @@
+;; Conformance fixture: cofx/world-inputs-retired
+;;
+;; EP-0017 Slice-A contract — the `:rf.world/inputs` dispatch opt is RETIRED
+;; (renamed to `:rf.cofx`, no alias, no coexistence window — EP-0007
+;; one-name-per-fact rule 2). Supplying the retired opt is the hard error
+;; `:rf.error/world-inputs-renamed`, naming `:rf.cofx` as the replacement.
+;; Per Spec 002 §The World-Input Rule + the diagnostics rejection site
+;; (`reject-retired-dispatch-opts!`), the rejection is ALWAYS-ON — it fires in
+;; production too, checked at the public dispatch boundary BEFORE the clock
+;; stamp / frame resolution.
+;;
+;; The conformance dispatch supplies the retired `:rf.world/inputs` opt and
+;; carries `:expect-error :rf.error/world-inputs-renamed`; the runner asserts
+;; the dispatch threw an `ex-info` whose `:rf.error/id` equals it. A CONTROL
+;; dispatch supplies the canonical `:rf.cofx` replacement and runs cleanly,
+;; writing a marker — so the fixture also pins that the replacement opt is
+;; accepted (not merely that the old one is rejected).
+;;
+;; A port that silently accepts `:rf.world/inputs` (an alias), throws a
+;; generic error, or does not reject it FAILS; current core PASSES.
+
+{:fixture/id           :cofx/world-inputs-retired
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/error}
+ :fixture/doc          "EP-0017: supplying the retired `:rf.world/inputs` dispatch opt is the hard error `:rf.error/world-inputs-renamed`; the canonical `:rf.cofx` replacement is accepted. A port that aliases the retired key, throws generically, or fails to reject it FAILS this fixture."
+
+ :fixture/registry
+ {:event {:probe/world-inputs {:doc "A plain handler; the load-bearing assertion is at the dispatch boundary, not in the body."}}}
+
+ :fixture/handlers
+ {:event {:probe/world-inputs [[:set [:ran] true]]}}
+
+ :fixture/frame-config {}
+
+ :fixture/dispatches
+ [;; Retired opt — rejected at the dispatch boundary with the renamed-error.
+  {:event [:probe/world-inputs] :rf.world/inputs {:rf/time-ms 1}
+   :expect-error :rf.error/world-inputs-renamed}
+  ;; Control — the canonical replacement opt is accepted; the handler runs.
+  {:event [:probe/world-inputs] :rf.cofx {:rf/time-ms 1781078400123}}]
+
+ :fixture/expect
+ {;; The control dispatch's handler ran (the replacement opt is accepted); the
+  ;; retired-opt dispatch threw before its handler — so the only write is the
+  ;; control's `:ran true`.
+  :final-app-db
+  {:ran true}}}


### PR DESCRIPTION
Closes **finding-1 only** of rf2-d8mvke.3 (EP-0017 round-2 test-coverage review). Finding-2 (the doc-residue gate) is **deferred** to a later tick until the `inject-cofx` / `:rf.world/inputs` residue is cleared from docs/specs — the bead is left **OPEN** for finding-2.

## What

The independent review found EP-0017 cofx rules pinned in unit tests but too weak in conformance fixtures: `dispatch-envelope.edn` captures all cofx except `:db` and its expected output OMITS `:rf.cofx`, and the runner's submap matching lets a port omit `:rf.cofx`, deliver undeclared leaves, accept the retired `:rf.world/inputs`, or conflate missing-vs-unregistered cofx errors.

This PR adds four focused EDN conformance fixtures + the minimal runner support they need (both JVM `conformance_test.clj` and the CLJS corpus runner), plus README docs:

- **`cofx-envelope-preserved.edn`** — the dispatch envelope's `:rf.cofx` recordable-coeffect map is delivered into the event context under `:rf.cofx`, preserved verbatim (a caller-supplied `:rf/time-ms` rides through unchanged). Expected app-db **INCLUDES** `:rf.cofx` — the weak `dispatch-envelope.edn` omits it, so a port could drop the key and still pass that fixture.
- **`cofx-declared-only-delivery.edn`** — a handler receives EXACTLY its `:rf.cofx/requires` declarations, flat; a REGISTERED-but-undeclared coeffect is withheld.
- **`cofx-missing-vs-unregistered.edn`** — a declared-but-absent REGISTERED provided coeffect is `:rf.error/missing-required-cofx`; a declared coeffect with NO registration is `:rf.error/unregistered-cofx` — two distinct error ids.
- **`cofx-world-inputs-retired.edn`** — the retired `:rf.world/inputs` dispatch opt is the hard error `:rf.error/world-inputs-renamed`; the canonical `:rf.cofx` replacement is accepted (control dispatch runs).

### Runner support (host-agnostic, mirrored JVM + CLJS)

- **`:final-app-db-absent`** — a vector of `get-in`-shaped paths that must be ABSENT from the final app-db. `:final-app-db`'s submap match tolerates extra keys, so it cannot catch an over-delivering port; this negative check is what fails one. (Sentinel `get-in` so present-with-`nil` is not mistaken for absent.)
- **per-dispatch `:expect-error`** — a dispatch map may carry `:expect-error <:rf.error/id>`, asserting the dispatch throws that error. The cofx delivery errors throw during context assembly and the `:rf.world/inputs` retirement throws at the dispatch boundary — both escape `dispatch-sync` before any handler runs, so the runner catches and compares the ex-data `:rf.error/id`. Mirrors the existing Mode-B `:reg-machine` / `:path-instantiate` `:expect-error` convention.

Scope was kept to the owned surface: `spec/conformance/` (fixtures + README), `implementation/core/test/re_frame/conformance_test.clj`, and the CLJS corpus runner. No changes to `cofx.cljc`, `cofx_cljs_test`, other specs, or docs.

## Acceptance

Conformance **FAILS** an implementation missing any of these Slice-A contracts and **PASSES** on current core. Proven empirically: a temporary negative-probe fixture asserting a present key absent + a no-throw dispatch with `:expect-error` FAILED both new checks (`absent: ... but found 1`; `expect-error: ... did not throw`); the four real fixtures all passed on current core. Probe removed before commit.

## Quality gates

- JVM conformance — `clojure -M:test -n re-frame.conformance-test` (from `implementation/core/`): `Ran 1 tests ... 0 failures, 0 errors` (181 fixtures passed, 4 pre-existing out-of-claim skips, none introduced by this PR).
- CLJS conformance corpus — `npm run test:cljs` (from `implementation/`): `Ran 6997 tests containing 28649 assertions. 0 failures, 0 errors` (includes the CLJS corpus runner exercising the new fixtures, compile-time inlined via the directory-globbing fixture macro).