### PR TITLE
fix(xray): fail-soft on malformed after-timer trace shape in Epoch projection (rf2-q25i4o)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -92,13 +92,17 @@
   Returns nil when the event vector doesn't match the timer shape —
   defensive: a future stamp-site that emits `:source :after-timer` on
   some non-canonical event shape still gets the kind label without
-  fields that don't apply."
+  fields that don't apply. The slot-3 invoke-id/source-path must be
+  sequential before it can be coerced into a state-path vector; a
+  scalar or nil there (partial/imported/future trace) falls through to
+  a plain DISPATCH row rather than throwing on `(vec <scalar>)`."
   [event]
   (when (and (vector? event) (= 2 (count event)))
     (let [[machine-id inner] event]
       (when (and (vector? inner)
                  (= :rf.machine.timer/after-elapsed (first inner))
-                 (>= (count inner) 4))
+                 (>= (count inner) 4)
+                 (sequential? (nth inner 3)))
         {:machine-id        machine-id
          :delay-ms          (nth inner 1)
          :source-state-path (vec (nth inner 3))}))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -176,6 +176,28 @@
       (is (nil? (:source-enrichment r))
           "non-canonical timer-event shape → no enrichment"))))
 
+(deftest dispatch-row-after-timer-scalar-slot3-fail-soft-test
+  (testing "rf2-q25i4o — a partial `:rf.machine.timer/after-elapsed`
+            event whose slot-3 invoke-id is a SCALAR (or nil) passes the
+            keyword + count shape checks but must NOT crash on
+            `(vec <scalar>)`. The row fails soft: it preserves
+            `:source :after-timer` and omits `:source-enrichment`,
+            rendering as a plain DISPATCH row (the documented
+            fall-through for malformed/imported/future trace data)"
+    (doseq [slot3 [42 nil "x" :a]]
+      (let [event [:m [:rf.machine.timer/after-elapsed 250 1 slot3]]
+            ev    {:op-type   :rf.event
+                   :operation :rf.event/dispatched
+                   :tags      {:rf.event/v event
+                               :source     :after-timer}}
+            r     (proj/dispatch-row [ev] nil)]
+        (is (some? r)
+            (str "dispatch-row does not throw for slot-3 " (pr-str slot3)))
+        (is (= :after-timer (:source r))
+            (str "source :after-timer preserved for slot-3 " (pr-str slot3)))
+        (is (nil? (:source-enrichment r))
+            (str "scalar/nil slot-3 → no enrichment for " (pr-str slot3)))))))
+
 (deftest dispatch-row-machine-spawn-enrichment-test
   (testing "rf2-5qp4g — `:source :machine-spawn` enrichment extracts
             the spawned actor-id (event vector's head) so the renderer


### PR DESCRIPTION
## Problem

`tools/xray/.../panels/epoch/projection.cljc` `after-timer-enrichment` accepted any inner vector shaped `[:rf.machine.timer/after-elapsed _ _ _]` with `(count inner) >= 4`, then unconditionally called `(vec (nth inner 3))`. A trace such as `[:m [:rf.machine.timer/after-elapsed 250 1 42]]` passes those shape checks but its slot-3 invoke-id is a scalar — `(vec 42)` is not seqable and **throws**. Because this runs inside `dispatch-row`, the exception could take down the entire Epoch panel for malformed, imported, or future trace data, instead of falling through to a plain DISPATCH row (the behaviour the docstring at line 92 documents).

## Fix

Validate slot 3 with `sequential?` before coercing. When slot 3 isn't sequential, the enrichment returns `nil` and the normal dispatch row renders with `:source :after-timer` preserved and no `:source-enrichment` — fail-soft, per the pre-alpha CORRECTNESS stance.

Diff is two files only (source + its CLJS test), keeping the other in-flight xray review beads rebasing cleanly.

## Test

Added `dispatch-row-after-timer-scalar-slot3-fail-soft-test`: a partially-matching `:rf.machine.timer/after-elapsed` event with scalar/nil slot 3 (`42`, `nil`, `"x"`, `:a`) — asserts `dispatch-row` does not throw, the row preserves `:source :after-timer`, and omits `:source-enrichment`. The existing happy-path enrichment test and the existing non-canonical-shape defensive test are unchanged.

## Quality gates

- `clojure -M:test` (tools/xray): 1182 tests, 5261 assertions — 0 failures, 0 errors
- `npm run test:cljs`: 6998 tests, 28662 assertions — 0 failures, 0 errors
- `npm run test:xray-feature-gate`: 16 scenarios, 13 matrix rows — 0 failures

Closes rf2-q25i4o.