### PR TITLE
fix(conformance): omit supplier for provided cofx in runner — unblock main tests gate (rf2-xuhdni)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -458,10 +458,17 @@
     ;; `known-skipped-capabilities`).
     (let [all-cofx-ids (into #{} (concat (keys cofx-bodies) (keys cofx-registry)))]
       (doseq [cofx-id all-cofx-ids]
-        (let [body     (get cofx-bodies cofx-id [[:noop]])
-              meta     (get cofx-registry cofx-id {})
-              supplier (realise-cofx-supplier body)]
-          (rf/reg-cofx cofx-id meta supplier))))
+        (let [body (get cofx-bodies cofx-id [[:noop]])
+              meta (get cofx-registry cofx-id {})]
+          ;; A `:provided?` cofx is a boundary-supplied fact with NO supplier —
+          ;; its VALUE rides the dispatch token via `:rf.cofx`, not a generator.
+          ;; Post-#4104, `reg-cofx` rejects `provided? true` + a supplier as
+          ;; `:rf.error/cofx-registration-invalid`, so register without one. The
+          ;; `cofx/missing-vs-unregistered` fixture relies on this: the value is
+          ;; absent from the token ⇒ `missing-required-cofx` at delivery.
+          (if (:provided? meta)
+            (rf/reg-cofx cofx-id meta)
+            (rf/reg-cofx cofx-id meta (realise-cofx-supplier body))))))
     ;; event registrations
     ;;
     ;; EP-0017 model (rf2-mrp8jg): a body that reads `[:cofx-key K]` declares

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -488,10 +488,17 @@
     ;; `known-skipped-capabilities`).
     (let [all-cofx-ids (into #{} (concat (keys cofx-bodies) (keys cofx-registry)))]
       (doseq [cofx-id all-cofx-ids]
-        (let [body     (get cofx-bodies cofx-id [[:noop]])
-              meta     (get cofx-registry cofx-id {})
-              supplier (realise-cofx-supplier body)]
-          (rf/reg-cofx cofx-id meta supplier))))
+        (let [body (get cofx-bodies cofx-id [[:noop]])
+              meta (get cofx-registry cofx-id {})]
+          ;; A `:provided?` cofx is a boundary-supplied fact with NO supplier —
+          ;; its VALUE rides the dispatch token via `:rf.cofx`, not a generator.
+          ;; Post-#4104, `reg-cofx` rejects `provided? true` + a supplier as
+          ;; `:rf.error/cofx-registration-invalid`, so register without one. The
+          ;; `cofx/missing-vs-unregistered` fixture relies on this: the value is
+          ;; absent from the token ⇒ `missing-required-cofx` at delivery.
+          (if (:provided? meta)
+            (rf/reg-cofx cofx-id meta)
+            (rf/reg-cofx cofx-id meta (realise-cofx-supplier body))))))
     ;; EP-0017 model (rf2-mrp8jg): a body that reads `[:cofx-key K]` declares
     ;; the consumed coeffect ids via the `:rf.cofx/requires` registration-
     ;; metadata key (the ctx→ctx `inject-cofx` interceptor wiring is retired).


### PR DESCRIPTION
## Summary

Main's `tests` gate went red after #4104 and #4105 merged. The conformance fixture `:cofx/missing-vs-unregistered` failed with `:rf.error/cofx-registration-invalid` instead of the expected `:rf.error/missing-required-cofx`.

**Root cause (merge interaction):**
- #4104 (rf2-d8mvke.1) added `reg-cofx` validation that rejects a `:provided? true` fact carrying a supplier as `:rf.error/cofx-registration-invalid`.
- #4105's conformance runners *always* built and passed a value-returning supplier — even for `{:provided? true}` fixtures.
- So the fixture's provided fact was rejected at **registration** rather than producing `:rf.error/missing-required-cofx` at **delivery**.

**Fix (both runners only):** register a `:provided?` cofx with the 2-arg no-supplier form `(rf/reg-cofx cofx-id meta)`; pass the realised supplier only for non-provided cofx. A provided fact's value rides the dispatch token via `:rf.cofx`, not a supplier — which is exactly what the fixture's `missing` case relies on (value absent from token ⇒ `missing-required-cofx` at delivery).

Touches only the two conformance runners. The #4104 validation (`cofx.cljc`) and the fixture are unchanged.

- `implementation/core/test/re_frame/conformance_test.clj` (JVM runner)
- `implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs` (CLJS corpus runner)

## Quality gates

| Gate | Result |
| --- | --- |
| `clojure -M:test -n re-frame.conformance-test` (core) | ✅ 0 failures, 0 errors |
| `clojure -M:test` (full core JVM suite, 1423 tests / 6322 assertions) | ✅ 0 failures, 0 errors |
| `npm run test:cljs` (CLJS corpus runner, 7002 tests / 28680 assertions) | ✅ 0 failures, 0 errors |

The `:cofx/missing-vs-unregistered` fixture now passes: probe/missing → `missing-required-cofx`; probe/typo → `unregistered-cofx`.

Stance: pre-alpha masterpiece (CORRECTNESS). Closes rf2-xuhdni.