### PR TITLE
test(xray): cover localStorage access-error fail-soft paths (rf2-dwn5yn)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/local_storage.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/local_storage.cljs
@@ -45,10 +45,20 @@
 (defn available?
   "True when `js/window.localStorage` is reachable. Node / JVM test
   runtimes without jsdom return false so the read/write/remove
-  primitives no-op silently."
+  primitives no-op silently.
+
+  The `js/window.localStorage` PROPERTY read is itself wrapped in a
+  try: a sandboxed iframe (`sandbox` without `allow-same-origin`) or a
+  cross-origin / cookie-blocked context throws a `SecurityError` on
+  the property ACCESS — before any method is called. Per the :33
+  posture that access throw must never propagate into the dispatch
+  chain that drove the read/write; it degrades to `false` (unavailable)
+  exactly like the absent-window branch."
   []
   (and (exists? js/window)
-       (some? (.-localStorage js/window))))
+       (try
+         (some? (.-localStorage js/window))
+         (catch :default _ false))))
 
 (defn get-item
   "Read the raw string stored under `k`. Returns nil when the slot is

--- a/tools/xray/test/day8/re_frame2_xray/coverage_matrix_metadata_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/coverage_matrix_metadata_test.clj
@@ -1,0 +1,271 @@
+(ns day8.re-frame2-xray.coverage-matrix-metadata-test
+  "Guard against silent drift in the Xray feature-matrix coverage
+  METADATA (rf2-dwn5yn, finding 2).
+
+  ## The problem
+
+  Two artefacts must agree on what the browser feature gate covers:
+
+    1. `tools/xray/spec/017-Test-Coverage-Matrix.md` §Coverage matrix —
+       the NORMATIVE row set (the human-readable contract). Each row's
+       first column names a user-visible surface.
+    2. `tools/xray/testbeds/feature_matrix/scenarios.cjs` — every
+       `SCENARIOS[*].coveredRows` entry NAMES a matrix row the scenario
+       claims to exercise. `serve-and-run-xray-feature-gate.cjs` dedupes
+       these into a `Covered N matrix rows` summary line.
+
+  Until this guard landed, `coveredRows` was free-form text: nothing
+  checked the names against the spec, so a scenario could claim
+  `'Epoch Panel'` while the matrix row is `'Event Detail'`, or claim a
+  row that no longer exists, and the gate would happily print a
+  MISLEADING `Covered N matrix rows` count (the audit finding: the
+  scenarios already drifted to `Epoch Panel` / `Effects` / `Flows` /
+  `Pop-out, Docking, …` against spec rows `Event Detail` /
+  `Pop-out and Default True-Inline Embedding`).
+
+  ## What this guard enforces
+
+  - Every `coveredRows` name resolves to a canonical matrix row —
+    EITHER an exact spec-row name OR a curated alias (the keystone idiom,
+    mirrors `panel_enum_spec_refs.clj` / `frame_singleton_guard_test.clj`).
+    An UNKNOWN name fails.
+  - Every curated alias targets a row that STILL EXISTS in the spec —
+    so renaming / removing a matrix row fails the build until the
+    coverage metadata (this map) is updated.
+  - The bug-class catalogue (`019-Cross-Cutting-Insight.md` §2 — every
+    `M.*` / `R.*` / `S.*` / `F.*` id) is audited against an explicit
+    coverage/deferred mapping: every catalogued id has an entry and
+    every entry names a real catalogued id, so ADDING or REMOVING a
+    bug-class fails until the mapping is updated (017 §Vision).
+
+  Runs in the fast `clojure -M:test` JVM gate (it slurps committed
+  markdown + the scenarios CJS at test time — same posture as the
+  source-text guards in this dir)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.string :as str]))
+
+;; ---- file resolution ----------------------------------------------------
+
+(def ^:private matrix-spec-rel
+  ["tools" "xray" "spec" "017-Test-Coverage-Matrix.md"])
+
+(def ^:private insight-spec-rel
+  ["tools" "xray" "spec" "019-Cross-Cutting-Insight.md"])
+
+(def ^:private scenarios-rel
+  ["tools" "xray" "testbeds" "feature_matrix" "scenarios.cjs"])
+
+(defn- find-repo-root
+  "Walk up from `user.dir` until the matrix spec resolves — robust
+  whether the `:test` alias runs from `tools/xray` or the repo root.
+  Mirrors `panel_enum_spec_refs.clj`."
+  []
+  (loop [dir (io/file (System/getProperty "user.dir"))]
+    (when (nil? dir)
+      (throw (ex-info (str "coverage-matrix-metadata: could not locate "
+                           (str/join "/" matrix-spec-rel)
+                           " walking up from " (System/getProperty "user.dir"))
+                      {})))
+    (if (.exists (apply io/file dir matrix-spec-rel))
+      dir
+      (recur (.getParentFile dir)))))
+
+(defn- slurp-rel [rel]
+  (slurp (apply io/file (find-repo-root) rel)))
+
+;; ---- spec matrix-row parse ----------------------------------------------
+
+(defn- table-row?
+  "A markdown table BODY row: starts with `|` and is not the
+  `|---|---|` separator."
+  [line]
+  (let [t (str/triml line)]
+    (and (str/starts-with? t "|")
+         (not (re-matches #"\|[\s:|-]+\|?" t)))))
+
+(defn- first-cell
+  "The trimmed text of the first `|`-delimited column, with markdown
+  backticks stripped (matrix row names like `App-DB Diff` carry no
+  backticks; rows like `Spine binding (\\`:rf.xray/focus\\`)` do — strip
+  them so the canonical name is the rendered text)."
+  [line]
+  (-> line str/triml
+      (str/replace-first #"^\|" "")
+      (str/split #"\|")
+      first
+      (str/replace "`" "")
+      str/trim))
+
+(defn- matrix-row-names
+  "Parse the §Coverage matrix block: the rows between the
+  `| Surface | …` header and the next `## ` heading. Returns the SET of
+  canonical surface names (the first column of each body row)."
+  []
+  (let [lines (str/split-lines (slurp-rel matrix-spec-rel))
+        ;; drop everything up to and including the matrix header line
+        after-header (->> lines
+                          (drop-while #(not (str/starts-with? (str/triml %) "| Surface |")))
+                          rest)
+        ;; take body rows until the next markdown section heading
+        block (take-while #(not (str/starts-with? (str/triml %) "## ")) after-header)]
+    (->> block
+         (filter table-row?)
+         (map first-cell)
+         (remove str/blank?)
+         (into #{}))))
+
+;; ---- scenarios coveredRows parse ----------------------------------------
+
+(defn- covered-row-names
+  "Every distinct string that appears inside a `coveredRows: [ … ]`
+  literal in `scenarios.cjs`. The gate dedupes these into its
+  `Covered N matrix rows` summary, so this IS the gate's row universe.
+
+  Parsed by lexing every single-quoted string literal that follows a
+  `coveredRows:` key — tolerant of the inline vs multi-line array
+  layouts both present in the file."
+  []
+  (let [text (slurp-rel scenarios-rel)
+        ;; isolate each `coveredRows: [ ... ]` body (may span lines)
+        bodies (re-seq #"(?s)coveredRows:\s*\[(.*?)\]" text)]
+    (->> bodies
+         (mapcat (fn [[_ body]]
+                   (->> (re-seq #"'([^']*)'" body)
+                        (map second))))
+         (remove str/blank?)
+         (into #{}))))
+
+;; ---- curated alias map (the keystone idiom) -----------------------------
+
+(def ^:private covered-row-aliases
+  "`coveredRows` names that DELIBERATELY differ from the spec matrix
+  row they exercise — each mapped to its canonical spec-row name. The
+  guard requires every alias TARGET to still exist in the spec, so a
+  matrix-row rename/removal breaks the build here until the alias (or
+  the scenario) is reconciled. Keep this set MINIMAL — a new
+  `coveredRows` name should prefer the exact spec-row name.
+
+    - `Epoch Panel` → `Event Detail`: the Epoch panel superseded the
+      retired Event/Handler panel (rf2-5gl5r); the matrix row kept its
+      user-facing `Event Detail` name (it names the user-visible
+      contract, not the impl panel id).
+    - `Effects` → `Event Detail`: the dedicated Effects panel was
+      dropped (rf2-xy4yb); fx/effects rows fold into the Epoch panel's
+      numbered cascade, whose matrix row is `Event Detail`.
+    - `Flows` → `Views (incl. nested subs)`: the dedicated Flows panel
+      was dropped (rf2-xy4yb / spec 018 §5); flows fold into the Views
+      tab as derived state.
+    - `Pop-out, Docking, and Inline Embedding` →
+      `Pop-out and Default True-Inline Embedding`: the `dock!`/`undock!`
+      body-padding surface was removed (rf2-sbfb7); the matrix row was
+      renamed to drop 'Docking', but the scenario label still carries
+      the old phrasing."
+  {"Epoch Panel"                              "Event Detail"
+   "Effects"                                  "Event Detail"
+   "Flows"                                    "Views (incl. nested subs)"
+   "Pop-out, Docking, and Inline Embedding"   "Pop-out and Default True-Inline Embedding"})
+
+;; ---- bug-class catalogue parse + coverage mapping -----------------------
+
+(defn- catalogue-bug-class-ids
+  "Every distinct bug-class id (`M.<n>` / `R.<n>` / `S.<n>` / `F.<n>`)
+  named in `019-Cross-Cutting-Insight.md`. 017 §Vision promises every
+  one appears in (eventually) a matrix bug-class column."
+  []
+  (->> (re-seq #"\b([MRSF]\.\d+)\b" (slurp-rel insight-spec-rel))
+       (map second)
+       (into #{})))
+
+(def ^:private bug-class-coverage
+  "Audit mapping for every catalogued bug-class id — the coverage
+  metadata 017 §Vision asks for. Status is one of:
+
+    `:covered`  — a feature-matrix row exercises the user-visible
+                  insight this id promises (none yet — the bug-class
+                  COLUMN is a §Vision enhancement, not yet built).
+    `:deferred` — bookkept against the §Vision bug-class-column work;
+                  the audit tracks the id so it can't silently vanish.
+
+  Every catalogued id MUST have an entry and every entry MUST name a
+  catalogued id (the guard enforces both directions), so adding or
+  removing a bug-class in 019 fails the build until this map is
+  updated. The whole catalogue is currently `:deferred` to the §Vision
+  bug-class-column work (017 lines 141-163)."
+  (into {}
+        (for [id ["M.1" "M.2" "M.3" "M.4" "M.5" "M.6" "M.7" "M.8" "M.9" "M.10" "M.11"
+                  "R.1" "R.2" "R.3" "R.4" "R.5" "R.6" "R.7" "R.8" "R.9" "R.10" "R.11"
+                  "S.1" "S.2" "S.3" "S.4" "S.5" "S.6" "S.7" "S.8" "S.9" "S.10" "S.11" "S.12" "S.13"
+                  "F.1" "F.2" "F.3" "F.4" "F.5" "F.6" "F.7" "F.8" "F.9" "F.10" "F.11"]]
+          [id :deferred])))
+
+;; ---- tests --------------------------------------------------------------
+
+(deftest spec-and-scenarios-resolve
+  (testing "the parse located both spec files and the scenarios CJS"
+    (is (seq (matrix-row-names))   "spec §Coverage matrix yielded rows")
+    (is (seq (covered-row-names))  "scenarios.cjs yielded coveredRows names")
+    (is (seq (catalogue-bug-class-ids)) "spec 019 yielded bug-class ids")))
+
+(deftest aliases-target-real-matrix-rows
+  (testing "every curated alias resolves to a row that STILL EXISTS in the
+            spec — a matrix-row rename/removal fails here until the alias
+            (or scenario) is reconciled"
+    (let [rows    (matrix-row-names)
+          orphans (remove rows (vals covered-row-aliases))]
+      (is (empty? orphans)
+          (str "alias targets no longer in the spec matrix: "
+               (str/join ", " (sort (distinct orphans)))
+               " — reconcile covered-row-aliases with §Coverage matrix")))))
+
+(deftest every-covered-row-is-a-known-matrix-row
+  (testing "every `coveredRows` name is an exact spec matrix row OR a
+            curated alias — an UNKNOWN name fails the gate (so it cannot
+            print a misleading `Covered N matrix rows` summary)"
+    (let [rows      (matrix-row-names)
+          known     (set/union rows (set (keys covered-row-aliases)))
+          unknown   (remove known (covered-row-names))]
+      (is (empty? unknown)
+          (str "coveredRows names with no matching matrix row: "
+               (str/join ", " (sort (distinct unknown)))
+               " — add the name to §Coverage matrix, or map it in "
+               "covered-row-aliases if it deliberately differs")))))
+
+(deftest covered-rows-summary-count-is-canonical
+  (testing "the deduped, alias-canonicalised coveredRows count the gate's
+            `Covered N matrix rows` summary should report — pinned so a
+            scenario claiming a stale/duplicate name cannot inflate it"
+    (let [canonical (->> (covered-row-names)
+                         (map #(get covered-row-aliases % %))
+                         (into #{}))]
+      ;; Every canonicalised name is a real matrix row (follows from the
+      ;; two guards above); the count is the honest covered-row tally.
+      (is (every? (matrix-row-names) canonical)
+          "every canonicalised coveredRow is a real matrix row")
+      ;; Regression pin: the current canonical covered-row set. Update
+      ;; this number deliberately when a scenario starts/stops covering a
+      ;; row — that is the signal the gate's summary changed.
+      (is (= 12 (count canonical))
+          (str "canonical covered-row count drifted to " (count canonical)
+               " (" (str/join ", " (sort canonical)) ") — update this pin "
+               "when a scenario's coverage changes, deliberately")))))
+
+(deftest bug-class-coverage-audits-the-whole-catalogue
+  (testing "every catalogued bug-class id has a coverage/deferred entry and
+            every entry names a catalogued id — adding/removing a bug-class
+            in 019 fails until this map is updated (017 §Vision)"
+    (let [catalogue (catalogue-bug-class-ids)
+          mapped    (set (keys bug-class-coverage))
+          missing   (set/difference catalogue mapped)
+          stale     (set/difference mapped catalogue)]
+      (is (empty? missing)
+          (str "catalogued bug-classes with no coverage entry: "
+               (str/join ", " (sort missing))
+               " — add them to bug-class-coverage (:covered <row> | :deferred)"))
+      (is (empty? stale)
+          (str "bug-class-coverage entries no longer in the 019 catalogue: "
+               (str/join ", " (sort stale))
+               " — remove them from bug-class-coverage")))
+    (testing "every status is a recognised verdict"
+      (is (every? #{:covered :deferred} (vals bug-class-coverage))))))

--- a/tools/xray/test/day8/re_frame2_xray/local_storage_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/local_storage_cljs_test.cljs
@@ -1,0 +1,139 @@
+(ns day8.re-frame2-xray.local-storage-cljs-test
+  "Fail-soft contract for the shared `local-storage` seam (rf2-dwn5yn).
+
+  `local_storage.cljs`'s :33 posture promises a quota error or a
+  cross-origin `SecurityError` NEVER poisons the dispatch chain that
+  drove a write, and that reads degrade to `nil`. Seven Xray
+  namespaces persist a slot through this one seam, so a single
+  unguarded throw here propagates into every persistence call-site —
+  and (since several fire from init / dispatch hooks) into dispatch.
+
+  The existing `init_filter_reset_cljs_test` covers the HAPPY round-trip
+  (an in-memory stub whose methods never throw) and the absent-window
+  branch. It does NOT cover the two error edges this file pins:
+
+    (a) the `window.localStorage` PROPERTY access itself throwing — the
+        sandboxed-iframe / cross-origin / cookie-blocked `SecurityError`
+        case. The browser raises it on the bare `js/window.localStorage`
+        read, BEFORE any get/set/remove method is called. `available?`
+        reads that property, so an unguarded read there propagates the
+        throw out of `available?` — past every primitive's own
+        method-level try — and into dispatch.
+
+    (b) the METHOD-level throw — `available?` returns true but
+        `getItem` / `setItem` / `removeItem` themselves throw (quota
+        exceeded on write; a hostile getItem). Each primitive's own
+        `(catch :default _ …)` must swallow these.
+
+  Both edges assert the SAME invariant: `available?`, `get-item`,
+  `set-item!`, and `remove-item!` never throw; reads return nil; writes
+  / removes no-op and return nil."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-xray.local-storage :as ls]))
+
+;; -------------------------------------------------------------------------
+;; window stub install / restore
+;; -------------------------------------------------------------------------
+;;
+;; Node-test has no jsdom, so each scenario installs its own
+;; `js/globalThis.window` for the test's duration and tears the whole
+;; stub down afterwards (the same teardown shape as
+;; `init_filter_reset_cljs_test`), so a leaked window can't bleed the
+;; throwing-localStorage into sibling namespaces.
+
+(def ^:private had-window?
+  "Whether a `js/globalThis.window` existed BEFORE this ns ran. Node-test
+  normally has none; we restore to the original absence on teardown."
+  (exists? js/globalThis.window))
+
+(defn- uninstall-window! []
+  (when-not had-window?
+    (js-delete js/globalThis "window")))
+
+(use-fixtures :each
+  {:after uninstall-window!})
+
+(defn- install-window-with-throwing-localStorage-getter!
+  "Install a `js/globalThis.window` whose `localStorage` PROPERTY read
+  throws a `SecurityError`-shaped error — the sandboxed-iframe /
+  cross-origin case. The throw fires on the bare property access, not
+  on any method, so it reproduces the seam (b)-vs-(a) distinction
+  precisely."
+  []
+  (let [win #js {}]
+    (js/Object.defineProperty
+      win "localStorage"
+      (js-obj "get" (fn []
+                      (throw (js/Error. "SecurityError: localStorage access denied")))
+              "configurable" true))
+    (set! (.-window js/globalThis) win)))
+
+(defn- install-window-with-throwing-methods!
+  "Install a `js/globalThis.window` whose `localStorage` PROPERTY reads
+  fine (so `available?` sees a non-nil object) but whose getItem /
+  setItem / removeItem METHODS each throw — the quota-exceeded /
+  hostile-method case the per-primitive try must swallow."
+  []
+  (let [throwing #js {:getItem    (fn [_k] (throw (js/Error. "getItem boom")))
+                      :setItem    (fn [_k _v] (throw (js/Error. "QuotaExceededError")))
+                      :removeItem (fn [_k] (throw (js/Error. "removeItem boom")))}]
+    (set! (.-window js/globalThis) #js {:localStorage throwing})))
+
+;; -------------------------------------------------------------------------
+;; (a) localStorage PROPERTY access throws (SecurityError / cross-origin)
+;; -------------------------------------------------------------------------
+
+(deftest available?-fails-soft-when-property-access-throws
+  (testing "a throwing `window.localStorage` getter degrades `available?`
+            to false rather than propagating the SecurityError"
+    (install-window-with-throwing-localStorage-getter!)
+    (is (false? (ls/available?))
+        "available? swallows the property-access throw and returns false")))
+
+(deftest get-item-fails-soft-when-property-access-throws
+  (testing "get-item never propagates a property-access SecurityError"
+    (install-window-with-throwing-localStorage-getter!)
+    (is (nil? (ls/get-item "k"))
+        "get-item returns nil instead of throwing into the caller")))
+
+(deftest set-item!-fails-soft-when-property-access-throws
+  (testing "set-item! never propagates a property-access SecurityError
+            into the dispatch chain that drove the write"
+    (install-window-with-throwing-localStorage-getter!)
+    (is (nil? (ls/set-item! "k" "v"))
+        "set-item! no-ops and returns nil")))
+
+(deftest remove-item!-fails-soft-when-property-access-throws
+  (testing "remove-item! never propagates a property-access SecurityError"
+    (install-window-with-throwing-localStorage-getter!)
+    (is (nil? (ls/remove-item! "k"))
+        "remove-item! no-ops and returns nil")))
+
+;; -------------------------------------------------------------------------
+;; (b) localStorage methods throw (quota / hostile method)
+;; -------------------------------------------------------------------------
+
+(deftest available?-is-true-when-only-methods-throw
+  (testing "available? sees a non-nil localStorage object even though its
+            methods will throw — the (a)/(b) distinction"
+    (install-window-with-throwing-methods!)
+    (is (true? (ls/available?))
+        "the property read succeeds; method throws are a separate concern")))
+
+(deftest get-item-fails-soft-when-getItem-throws
+  (testing "a throwing getItem degrades the read to nil"
+    (install-window-with-throwing-methods!)
+    (is (nil? (ls/get-item "k"))
+        "get-item swallows the method throw and returns nil")))
+
+(deftest set-item!-fails-soft-when-setItem-throws
+  (testing "a quota-exceeded setItem must not poison the dispatch chain"
+    (install-window-with-throwing-methods!)
+    (is (nil? (ls/set-item! "k" "v"))
+        "set-item! swallows the QuotaExceededError and returns nil")))
+
+(deftest remove-item!-fails-soft-when-removeItem-throws
+  (testing "a throwing removeItem no-ops cleanly"
+    (install-window-with-throwing-methods!)
+    (is (nil? (ls/remove-item! "k"))
+        "remove-item! swallows the method throw and returns nil")))


### PR DESCRIPTION
Closes the two findings of the independent test-coverage review **rf2-dwn5yn**.

## Finding 1 — shared localStorage access-error path was untested (and the seam leaked)

`tools/xray/src/day8/re_frame2_xray/local_storage.cljs`'s :33 posture promises a quota / cross-origin `SecurityError` **never poisons the dispatch chain**. But `available?` read `js/window.localStorage` **outside a try**. A sandboxed iframe (`sandbox` without `allow-same-origin`), a cross-origin context, or a cookie-blocked context throws a `SecurityError` on that **property access** — before any get/set/remove method is reached. Because `available?` had no try, the throw propagated out, **past** each primitive's own method-level `(catch :default …)`, into the dispatch chain that drove the read/write. Seven Xray namespaces persist through this one seam, several from init/dispatch hooks.

**Fix:** wrap the property read in `available?` so an access throw degrades to `false` (unavailable) — fail-soft, exactly like the absent-window branch.

**Test (`local_storage_cljs_test.cljs`, new):** covers both edges the existing `init_filter_reset` suite missed —
- (a) a `window.localStorage` **throwing getter** (the property-access `SecurityError` case), and
- (b) a stub whose **getItem / setItem / removeItem methods throw** (quota / hostile method).

All four primitives (`available?`, `get-item`, `set-item!`, `remove-item!`) assert never-throw + nil/no-op. Verified the (a) tests **fail before the fix** (the access throw propagates) and pass after.

## Finding 2 — feature-matrix coverage metadata could drift silently

`feature_matrix/scenarios.cjs` treated `coveredRows` as free-form text; nothing checked it against `spec/017` §Coverage matrix, and the gate prints `Covered N matrix rows`. The names **had** drifted (`Epoch Panel` / `Effects` / `Flows` / `Pop-out, Docking, and Inline Embedding` vs spec rows `Event Detail` / `Views (incl. nested subs)` / `Pop-out and Default True-Inline Embedding`).

**Test (`coverage_matrix_metadata_test.clj`, new, JVM gate):**
- Every `coveredRows` name resolves to an exact spec matrix row OR a **curated alias** (keystone idiom, mirrors `panel_enum_spec_refs.clj`); an unknown name fails.
- Every alias target must **still exist** in the spec — a matrix-row rename/removal fails the build until reconciled.
- The canonical covered-row count is pinned, so a scenario can't inflate the gate's summary.
- Audits every `019-Cross-Cutting-Insight` bug-class id (`M.* / R.* / S.* / F.*`) against an explicit coverage/deferred mapping — adding/removing a bug-class fails until the metadata is updated (017 §Vision). The catalogue is currently all `:deferred` (the bug-class column is a §Vision enhancement not yet built).

Encoding the known drift as a curated alias map (rather than editing scenarios.cjs / the spec) keeps this PR within its ownership boundary (`local_storage.cljs` + two test files only — no spec / scenarios / feature-gate-script edits, avoiding conflict with in-flight #4112 and the other sequenced xray beads). Verified the guard goes RED when an alias is removed.

## Quality gates

- `tools/xray` `clojure -M:test` — **1187 tests, 5271 assertions, 0 failures** (includes the new `coverage_matrix_metadata_test`).
- `npm run test:cljs` (node-test) — 7010 tests, 28688 assertions; the two new `local_storage_cljs_test` edges pass. **1 pre-existing unrelated failure** on `:cofx/missing-vs-unregistered` (`re_frame/conformance_corpus_cljs_test`, core cofx fixture) — present on `origin/main`; this PR's entire diff is xray-only (12-line `local_storage.cljs` + 2 test files), so it cannot have caused a core-conformance failure.
- `npm run test:xray-feature-gate:smoke` — **4 scenarios, 0 failures** (Covered 9 matrix rows).