### PR TITLE
fix(xray): cancellation-cascade live tab id + resources nav-token isolation (rf2-cduftx)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade_events.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/cancellation_cascade_events.cljs
@@ -79,11 +79,18 @@
                (conj [:dispatch [[:rf.xray/select-dispatch-id
                                   dispatch-id frame]
                                  {:frame here}]])
-               ;; Flip the visible tab to Event so the row jump lands
-               ;; in event-detail. The legacy `:rf.xray/select-panel`
+               ;; Flip the visible tab to Epoch so the row jump lands on
+               ;; the focused cascade's pipeline detail. The retired
+               ;; `:event` tab id (and its event-detail panel) folded
+               ;; into Epoch — Epoch is the cascade-pipeline master view
+               ;; the `:rf.xray/select-dispatch-id` spine pin drives
+               ;; (epoch_panel.cljs :order -1). Selecting `:event` here
+               ;; landed the shell's unknown-tab stub (rf2-cduftx F1);
+               ;; `:epoch` is a LIVE Dynamic L4 tab (focus.cljc
+               ;; `valid-panels`). The legacy `:rf.xray/select-panel`
                ;; slot is no longer read by the 4-layer shell (rf2-qy0nu).
                dispatch-id
-               (conj [:dispatch [[:rf.xray/select-tab :event]
+               (conj [:dispatch [[:rf.xray/select-tab :epoch]
                                  {:frame here}]])
                ;; Also close the popover when a row jump fires — the
                ;; user has navigated away.

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources.cljs
@@ -907,12 +907,21 @@
          :live-work     (reply/live-work ledger trace-buffer)
          :stale-races   (reply/races-by-work-id trace-buffer)
          :stale-tally   (reply/stale-tally-by-kind trace-buffer)
-         :route-graph   (h/project-route-graph
-                          routes-map
-                          {:instance-rows instance-rows
-                           :work-rows     work-rows
-                           :current       (h/routing-current routing-slice)
-                           :blocking-keys (h/routing-blocking-keys routing-slice)})
+         :route-graph   (let [current (h/routing-current routing-slice)]
+                          (h/project-route-graph
+                            routes-map
+                            {:instance-rows instance-rows
+                             :work-rows     work-rows
+                             :current       current
+                             ;; rf2-cduftx F2 — scope the live wait points to
+                             ;; the CURRENT route's nav-token bucket only.
+                             ;; Flattening all coexisting nav-token buckets
+                             ;; let an OLD token's unsettled key bleed onto
+                             ;; the active route's `:blocking-live`, falsely
+                             ;; reporting it as blocked (Spec 024 §Route/
+                             ;; resource graph: per-nav-token unsettled set).
+                             :blocking-keys (h/routing-blocking-keys
+                                              routing-slice (:nav-token current))}))
          :timeline      (h/lifecycle-timeline trace-buffer)
          :invalidations (h/invalidation-graph trace-buffer)
          ;; EP-0016 D3 (slice 8): the named-scope-resolver RESOLUTION timeline

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -702,13 +702,37 @@
 (defn routing-blocking-keys
   "Extract the live UNSETTLED-blocking scoped keys from the routing-runtime
   subtree. `[:resource-blocking <nav-token>]` is a map of per-nav-token sets
-  of scoped keys whose blocking ensure has not yet settled; this flattens
-  them to a single vector of scoped keys (the live SSR/route wait points the
-  graph flags on the current route — rf2-m5u3gt). Pure; nil/missing ⇒ `[]`."
-  [routing-slice]
-  (let [by-token (when (map? routing-slice)
-                   (get routing-slice routing-blocking-key))]
-    (into [] (mapcat seq) (vals (or by-token {})))))
+  of scoped keys whose blocking ensure has not yet settled.
+
+  TWO arities (rf2-cduftx F2):
+
+  - `[routing-slice nav-token]` — the SCOPED read: returns ONLY the scoped
+    keys still unsettled for `nav-token`. This is the form the route graph
+    must use for the CURRENT route's `:blocking-live`, per Spec 024
+    §Route/resource graph (\"the declared blocking resources whose scoped
+    keys are still in the PER-nav-token unsettled-blocking set\"). A nil
+    `nav-token` (no active route) ⇒ `[]` — a route with no live navigation
+    has no live wait point.
+
+  - `[routing-slice]` — the ALL-TOKEN flatten: every unsettled key across
+    every coexisting nav-token bucket. Retained for an all-routes / global
+    wait-point diagnostic; it must NOT be used to flag a single route's
+    `:blocking-live`, because an OLD token's bucket can still hold a key
+    that shares a resource-id with the current route, which would falsely
+    report the active route as blocked by a wait point belonging to a
+    superseded navigation (the rf2-cduftx F2 cross-token bleed).
+
+  Pure; nil/missing ⇒ `[]`."
+  ([routing-slice]
+   (let [by-token (when (map? routing-slice)
+                    (get routing-slice routing-blocking-key))]
+     (into [] (mapcat seq) (vals (or by-token {})))))
+  ([routing-slice nav-token]
+   (let [by-token (when (map? routing-slice)
+                    (get routing-slice routing-blocking-key))]
+     (if (some? nav-token)
+       (into [] (get by-token nav-token #{}))
+       []))))
 
 (defn- resource-liveness
   "Aggregate the LIVE state of one declared resource-id across the projected
@@ -807,6 +831,14 @@
        :work-rows      <projected work-ledger rows>
        :current        {:id <route-id> :nav-token <token>}   ; routing slice
        :blocking-keys  [<scoped-key> …]}  ; the live unsettled-blocking set
+                                          ;   SCOPED to the current route's
+                                          ;   nav-token (rf2-cduftx F2) — the
+                                          ;   caller passes
+                                          ;   `(routing-blocking-keys slice
+                                          ;     (:nav-token current))`, not the
+                                          ;   all-token flatten, so an older
+                                          ;   token's wait point cannot bleed
+                                          ;   onto the active route.
 
   Each resource node gains a `:live` freshness rollup; the active route's
   node is flagged `:current? true` with its `:nav-token`, and its

--- a/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/cancellation_cascade_cljs_test.cljs
@@ -31,6 +31,7 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.preload]
             [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.test-support :as xray-test-support]
             [day8.re-frame2-xray.trace-collector :as trace-collector]
             [day8.re-frame2-xray.panels.cancellation-cascade :as cc]))
@@ -222,6 +223,46 @@
       (rf/dispatch-sync [:rf.xray/focus-trace-entry
                          {:dispatch-id 7 :frame :rf/default :trace-id 1}])
       (is (true? true)))))
+
+(deftest focus-trace-entry-lands-on-a-live-tab
+  ;; rf2-cduftx F1 — the row-jump used to `[:rf.xray/select-tab :event]`,
+  ;; but `:event` is a RETIRED tab id (the event-detail panel folded into
+  ;; Epoch). Selecting it landed the shell's `rf-xray-tab-unknown` stub
+  ;; instead of the cascade detail. This locks the row-jump's tab onto a
+  ;; LIVE Dynamic L4 tab — and never onto an unregistered id.
+  (testing "a row jump (with a dispatch-id) selects a LIVE Dynamic L4 tab"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-trace! cancel-cascade-buffer)
+      (rf/dispatch-sync [:rf.xray/focus-trace-entry
+                         {:dispatch-id 7 :frame :rf/default :trace-id 1}])
+      (let [selected   @(rf/subscribe [:rf.xray/selected-tab])
+            live-tabs  (panel-registry/tab-ids-for-mode :dynamic)]
+        (is (contains? live-tabs selected)
+            (str "row-jump selected " (pr-str selected)
+                 " which is NOT a live Dynamic L4 tab "
+                 (pr-str live-tabs) " — it would render the unknown-tab stub"))
+        (is (not= :event selected)
+            "the retired `:event` tab id must never be selected again")
+        ;; Lock the specific live replacement: Epoch is the cascade-
+        ;; pipeline master surface the `:rf.xray/select-dispatch-id` pin
+        ;; drives. If the row-jump target moves, this assertion is the
+        ;; deliberate update point.
+        (is (= :epoch selected)
+            "the row jump lands on the Epoch tab (the focused-cascade detail)")))))
+
+(deftest focus-trace-entry-without-dispatch-id-does-not-switch-tab
+  ;; The tab flip is gated on `dispatch-id` — a row with no addressable
+  ;; dispatch (e.g. an actor-destroy abort outside a drain) must NOT
+  ;; switch the tab at all (so it certainly can't land an unknown tab).
+  (testing "a no-dispatch-id row jump leaves the selected tab unchanged"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-trace! cancel-cascade-buffer)
+      (let [before @(rf/subscribe [:rf.xray/selected-tab])]
+        (rf/dispatch-sync [:rf.xray/focus-trace-entry {:trace-id 1}])
+        (is (= before @(rf/subscribe [:rf.xray/selected-tab]))
+            "no dispatch-id ⇒ the tab selection is untouched")))))
 
 ;; ---- (5) collapse / expand ---------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/resources_helpers_cljs_test.cljc
@@ -466,10 +466,88 @@
            (h/routing-current m5-routing-slice)))
     (is (nil? (h/routing-current nil)))
     (is (nil? (h/routing-current {}))))
-  (testing "routing-blocking-keys flattens the per-nav-token unsettled sets; nil-safe"
+  (testing "routing-blocking-keys (1-arity) flattens the per-nav-token unsettled sets; nil-safe"
     (is (= [m5-article-key] (h/routing-blocking-keys m5-routing-slice)))
     (is (= [] (h/routing-blocking-keys nil)))
-    (is (= [] (h/routing-blocking-keys {})))))
+    (is (= [] (h/routing-blocking-keys {}))))
+  (testing "routing-blocking-keys (2-arity) reads ONLY the named nav-token bucket; nil-safe"
+    (is (= [m5-article-key] (h/routing-blocking-keys m5-routing-slice m5-nav-token)))
+    ;; an unknown / superseded token resolves to its own (empty) bucket
+    (is (= [] (h/routing-blocking-keys m5-routing-slice "nav-stale")))
+    ;; nil nav-token (no active route) ⇒ no live wait point, NOT the flatten
+    (is (= [] (h/routing-blocking-keys m5-routing-slice nil)))
+    (is (= [] (h/routing-blocking-keys nil m5-nav-token)))
+    (is (= [] (h/routing-blocking-keys {} m5-nav-token)))))
+
+;; ---- (6c) cross-nav-token blocking isolation (rf2-cduftx F2) ------------
+;;
+;; The route graph's `:blocking-live` must come from the CURRENT route's
+;; nav-token bucket ONLY (Spec 024 §Route/resource graph). The bug: the
+;; helper flattened ALL coexisting nav-token buckets, so an OLD token whose
+;; bucket held a key sharing the current route's resource-id falsely
+;; reported the active route as still blocked.
+
+(def ^:private cduftx-current-token "nav-current")
+(def ^:private cduftx-stale-token "nav-stale")
+;; SAME resource-id (:article/by-slug) as the current route declares, but
+;; pinned under the SUPERSEDED token's bucket — the cross-token bleed bait.
+(def ^:private cduftx-stale-key
+  [session-scope :article/by-slug {:slug "previous-article"}])
+
+(def ^:private cduftx-multi-token-slice
+  "A multi-token routing slice: the OLD token still has an unsettled blocking
+  key for :article/by-slug; the CURRENT token's bucket is empty (the current
+  route has settled). The current route must NOT be flagged blocked."
+  {:current {:id :route/article :nav-token cduftx-current-token
+             :params {:slug "now-article"} :path "/articles/now-article"}
+   :resource-blocking {cduftx-stale-token   #{cduftx-stale-key}
+                       cduftx-current-token #{}}})
+
+(deftest project-route-graph-isolates-blocking-by-nav-token
+  (testing "an OLD token's unsettled key for the current route's resource-id
+            does NOT bleed onto the active route's :blocking-live"
+    (let [nodes (h/project-route-graph
+                  routes-map
+                  {:instance-rows []
+                   :work-rows     []
+                   :current       (h/routing-current cduftx-multi-token-slice)
+                   ;; the CORRECTED call: scoped to the current nav-token
+                   :blocking-keys (h/routing-blocking-keys
+                                    cduftx-multi-token-slice
+                                    (:nav-token (h/routing-current cduftx-multi-token-slice)))})
+          article-node (first (filter #(= :route/article (:route-id %)) nodes))]
+      (is (:current? article-node)
+          "the active route is still flagged :current?")
+      (is (= cduftx-current-token (:nav-token article-node)))
+      (is (= [] (:blocking-live article-node))
+          "the stale token's wait point must NOT surface on the current route")))
+  (testing "the bug repro: the all-token FLATTEN would have falsely flagged it"
+    ;; Demonstrate the difference is real — feeding the flattened keys
+    ;; (the pre-fix data path) DOES light up :blocking-live, which is the
+    ;; cross-token bleed this fix removes.
+    (let [nodes (h/project-route-graph
+                  routes-map
+                  {:instance-rows []
+                   :work-rows     []
+                   :current       (h/routing-current cduftx-multi-token-slice)
+                   :blocking-keys (h/routing-blocking-keys cduftx-multi-token-slice)})
+          article-node (first (filter #(= :route/article (:route-id %)) nodes))]
+      (is (= [:article/by-slug] (:blocking-live article-node))
+          "the flatten path (pre-fix) leaks the stale token's wait point —
+           proving the scoped read is load-bearing")))
+  (testing "single-token behaviour is unchanged: a CURRENT-token wait point
+            still surfaces (rf2-m5u3gt regression intact)"
+    (let [nodes (h/project-route-graph
+                  routes-map
+                  {:instance-rows []
+                   :work-rows     []
+                   :current       (h/routing-current m5-routing-slice)
+                   :blocking-keys (h/routing-blocking-keys
+                                    m5-routing-slice
+                                    (:nav-token (h/routing-current m5-routing-slice)))})
+          article-node (first (filter #(= :route/article (:route-id %)) nodes))]
+      (is (= [:article/by-slug] (:blocking-live article-node))
+          "the current nav-token's own unsettled blocking resource still surfaces"))))
 
 ;; ---- (7) timeline / invalidation / cache-growth ------------------------
 


### PR DESCRIPTION
Fixes **rf2-cduftx** (P2 correctness) — two independent correctness-review findings in `tools/xray`.

## Finding 1 — cancellation-cascade row-jump selected a RETIRED tab id

`:rf.xray/focus-trace-entry` (cancellation_cascade_events.cljs) dispatched `[:rf.xray/select-tab :event]`, but `:event` is a retired tab id — the event-detail panel folded into Epoch. The live Dynamic L4 tabs are `:epoch :app-db :views :trace :machines :routing :resources :derivation-graph :module-view` (`focus.cljc` `valid-panels`). Selecting `:event` landed the shell's `rf-xray-tab-unknown` stub (shell.cljs `detail-panel`) instead of the cascade detail.

**Fix:** switch the row-jump tab to `:epoch` — the cascade-pipeline master surface that the `:rf.xray/select-dispatch-id` spine pin drives (epoch_panel.cljs `:order -1`).

**Regression:** `focus-trace-entry-lands-on-a-live-tab` asserts the selected tab is a member of the LIVE `panel-registry/tab-ids-for-mode :dynamic` set, never `:event`, and locks the current target to `:epoch`. `focus-trace-entry-without-dispatch-id-does-not-switch-tab` covers the no-dispatch-id no-op path.

## Finding 2 — resources route graph mixed blocking resources across nav tokens

`routing-blocking-keys` flattened ALL `[:resource-blocking <nav-token>]` buckets into one set, and `project-route-graph` derived the current route's `:blocking-live` from that flattened set. If an OLD nav-token's bucket still held an unsettled key sharing a resource-id with the current route, the active route was falsely reported as a blocked wait point. Spec 024 §Route/resource graph requires `:blocking-live` to come from the **per-nav-token** unsettled-blocking set.

**Fix:** added a 2-arity `routing-blocking-keys [routing-slice nav-token]` that reads only the named token's bucket; the resources panel call site now passes the current route's `:nav-token`. The 1-arity all-token flatten is retained (documented as a global/all-routes diagnostic only).

**Regression:** `project-route-graph-isolates-blocking-by-nav-token` — a multi-token slice where the old token has a matching blocking key and the current token does not; asserts `:blocking-live` stays empty for the current route, shows the flatten path (pre-fix) would have leaked it, and confirms single-token behaviour (rf2-m5u3gt) is intact.

Owns only `tools/xray/src/` + tests; no spec/README touched (the spec already specifies the per-nav-token set; spec workers own those files).

## Quality gates

- `clojure -M:test` (tools/xray): **1188 tests, 5281 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **7023 tests, 28770 assertions, 0 failures, 0 errors**
- `npm run test:xray-feature-gate`: **16 scenarios (nightly-full sweep), 0 failures, 13 matrix rows**
