### PR TITLE
test(xray): Static Machines persistence + coverage gaps (rf2-3t7rs8)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/panels/shared/coord_affordances_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/shared/coord_affordances_cljs_test.cljs
@@ -1,0 +1,192 @@
+(ns day8.re-frame2-xray.panels.shared.coord-affordances-cljs-test
+  "Behavioural hiccup tests for the two shared click-to-source
+  affordances — `coord-link` (label-as-link) and `coord-chip`
+  (icon-only) — per rf2-3t7rs8 finding 3.
+
+  ## What was unpinned
+
+  `click_to_source_consolidation_test.clj` is a SOURCE-TEXT guard (it
+  greps for bespoke dispatches). `open_in_editor_cljs_test.cljs` covers
+  the reg-event-fx RECEIVER and the static `open-chip` anchor — NOT the
+  rendering / click branches of these two shared helpers. So the
+  load-bearing render contract was never exercised:
+
+    - valid coord renders a clickable `<button>`
+    - missing / `:file`-less coord degrades (link → plain `<span>`,
+      chip → nil)
+    - aria / title / testid shape on both branches
+    - glyph / no-glyph ordering (`coord-link`'s `:glyph?` /
+      `:glyph-leading?` knobs)
+    - the `:on-click` stops event propagation
+    - the `:on-click` dispatches `[:rf.xray/open-in-editor
+      {:source-coord coord}]` through the captured `:dispatch-fn`
+
+  ## Test seam
+
+  Pure hiccup — these helpers return data, so we inspect the returned
+  vector directly (no DOM mount). The click branch is driven by pulling
+  `:on-click` off the rendered attrs and invoking it with a stub event
+  (a JS object whose `stopPropagation` flips an atom) and a captured
+  `:dispatch-fn` (an atom-collector) supplied via opts — both helpers
+  expose `:dispatch-fn` as the rf2-r0o63 frame-aware override seam, so
+  no real frame / dispatch bus is touched."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-xray.panels.shared.coord-chip :as coord-chip]
+            [day8.re-frame2-xray.panels.shared.coord-link :as coord-link]))
+
+;; ---- stubs --------------------------------------------------------------
+
+(defn- stub-event
+  "A minimal DOM-event stand-in. `stopPropagation` flips the supplied
+  atom so the test can assert the click guard fired."
+  [stopped?]
+  #js {:stopPropagation (fn [] (reset! stopped? true))})
+
+(defn- capturing-dispatch
+  "Returns `[dispatch-fn calls-atom]`. The fn captures every event
+  vector it's handed (the rf2-r0o63 `:dispatch-fn` override seam)."
+  []
+  (let [calls (atom [])]
+    [(fn [ev] (swap! calls conj ev)) calls]))
+
+(def ^:private coord {:file "src/app/events.cljs" :line 17})
+
+;; =========================================================================
+;; coord-link — label-as-link
+;; =========================================================================
+
+(deftest coord-link-renders-clickable-button-for-valid-coord
+  (testing "rf2-3t7rs8 — a valid coord renders a `<button>` carrying the
+            testid, aria-label, and title (the `open <file>:<line> in
+            editor` shape)"
+    (let [[tree] [(coord-link/coord-link coord "open" "tid-link")]
+          [tag attrs & _] tree]
+      (is (= :button tag) "valid coord → button (clickable)")
+      (is (= "tid-link" (:data-testid attrs)))
+      (is (= "open src/app/events.cljs:17 in editor" (:aria-label attrs))
+          "aria-label carries the file:line")
+      (is (= "open src/app/events.cljs:17 in editor" (:title attrs))
+          "title mirrors aria-label")
+      (is (fn? (:on-click attrs)) "click handler present"))))
+
+(deftest coord-link-degrades-to-span-when-coord-missing
+  (testing "rf2-3t7rs8 — nil coord (or one without :file) degrades to a
+            plain `<span>` carrying the SAME testid, with no click
+            affordance — a missing coord is non-clickable label text,
+            not a dead button"
+    (doseq [bad [nil {} {:line 5} {:file ""}]]
+      (let [[tag attrs & _] (coord-link/coord-link bad "open" "tid-link")]
+        (is (= :span tag) (str "no usable :file → span for " (pr-str bad)))
+        (is (= "tid-link" (:data-testid attrs))
+            "fallback span keeps the testid so a test pins either branch")
+        (is (nil? (:on-click attrs))
+            "fallback span has no click handler")))))
+
+(deftest coord-link-glyph-ordering
+  (testing "rf2-3t7rs8 — the glyph knobs: default appends the glyph
+            AFTER the label (`label ↗`); :glyph-leading? leads with it
+            (`↗ label`); :glyph? false renders the label ALONE"
+    ;; default: [label glyph]
+    (let [tree (coord-link/coord-link coord "L" "tid")
+          body (vec (drop 2 tree))]
+      (is (= "L" (first body)) "default: label first")
+      (is (vector? (second body)) "default: glyph (an svg hiccup) after label")
+      (is (= 2 (count body)) "default body is exactly [label glyph]"))
+    ;; glyph-leading?: [glyph label]
+    (let [tree (coord-link/coord-link coord "L" "tid" {:glyph-leading? true})
+          body (vec (drop 2 tree))]
+      (is (vector? (first body)) "glyph-leading?: glyph first")
+      (is (= "L" (second body)) "glyph-leading?: label after glyph"))
+    ;; glyph? false: [label] only
+    (let [tree (coord-link/coord-link coord "L" "tid" {:glyph? false})
+          body (vec (drop 2 tree))]
+      (is (= ["L"] body) "glyph? false: label alone, no glyph"))))
+
+(deftest coord-link-click-stops-propagation-and-dispatches
+  (testing "rf2-3t7rs8 — clicking the link stops event propagation (so an
+            enclosing row handler doesn't also fire) and dispatches
+            `[:rf.xray/open-in-editor {:source-coord coord}]` through the
+            captured `:dispatch-fn`"
+    (let [stopped?     (atom false)
+          [disp calls] (capturing-dispatch)
+          tree         (coord-link/coord-link coord "open" "tid"
+                                              {:dispatch-fn disp})
+          on-click     (:on-click (second tree))]
+      (on-click (stub-event stopped?))
+      (is (true? @stopped?) "stopPropagation fired on the click")
+      (is (= [[:rf.xray/open-in-editor {:source-coord coord}]] @calls)
+          "exactly one open-in-editor dispatch with the coord payload"))))
+
+;; =========================================================================
+;; coord-chip — icon-only
+;; =========================================================================
+
+(deftest coord-chip-renders-button-for-valid-coord
+  (testing "rf2-3t7rs8 — a valid coord renders a focusable `<button>`
+            with the canonical aria-label / title (`open in editor`) and
+            the supplied testid"
+    (let [tree (coord-chip/coord-chip coord "tid-chip")
+          [tag attrs & _] tree]
+      (is (= :button tag) "valid coord → button")
+      (is (= "tid-chip" (:data-testid attrs)))
+      (is (= "open in editor" (:aria-label attrs)))
+      (is (= "open in editor" (:title attrs)))
+      (is (fn? (:on-click attrs)) "click handler present"))))
+
+(deftest coord-chip-returns-nil-when-coord-missing
+  (testing "rf2-3t7rs8 — nil coord (or one without a usable :file)
+            returns nil so call-sites can drop the chip cleanly (the
+            chip has no plain-text fallback — that's the link's job)"
+    (doseq [bad [nil {} {:line 5} {:file ""}]]
+      (is (nil? (coord-chip/coord-chip bad "tid-chip"))
+          (str "no usable :file → nil for " (pr-str bad))))))
+
+(deftest coord-chip-applies-pixel-knob-overrides
+  (testing "rf2-3t7rs8 — :color and :margin-left opts overlay the hoisted
+            base style; defaults are inherit / 4px"
+    (let [default-style (-> (coord-chip/coord-chip coord "tid") second :style)
+          override-style (-> (coord-chip/coord-chip coord "tid"
+                                                    {:color "red"
+                                                     :margin-left "6px"})
+                             second :style)]
+      (is (= "inherit" (:color default-style)) "default colour inherits")
+      (is (= "4px" (:margin-left default-style)) "default margin 4px")
+      (is (= "red" (:color override-style)) "override colour applied")
+      (is (= "6px" (:margin-left override-style)) "override margin applied"))))
+
+(deftest coord-chip-click-stops-propagation-and-dispatches
+  (testing "rf2-3t7rs8 — clicking the chip stops propagation and
+            dispatches the open-in-editor event through the captured
+            `:dispatch-fn`"
+    (let [stopped?     (atom false)
+          [disp calls] (capturing-dispatch)
+          tree         (coord-chip/coord-chip coord "tid"
+                                             {:dispatch-fn disp})
+          on-click     (:on-click (second tree))]
+      (on-click (stub-event stopped?))
+      (is (true? @stopped?) "stopPropagation fired on the click")
+      (is (= [[:rf.xray/open-in-editor {:source-coord coord}]] @calls)
+          "exactly one open-in-editor dispatch with the coord payload"))))
+
+;; =========================================================================
+;; shared open-in-editor! action (coord-link's exported dispatch)
+;; =========================================================================
+
+(deftest open-in-editor!-stops-propagation-and-routes-through-dispatch-fn
+  (testing "rf2-3t7rs8 — the shared `open-in-editor!` action (the ONE
+            dispatch every affordance funnels through) stops propagation
+            and routes the event through the supplied dispatch-fn"
+    (let [stopped?     (atom false)
+          [disp calls] (capturing-dispatch)]
+      (coord-link/open-in-editor! coord (stub-event stopped?) disp)
+      (is (true? @stopped?))
+      (is (= [[:rf.xray/open-in-editor {:source-coord coord}]] @calls)))))
+
+(deftest open-in-editor!-tolerates-nil-event
+  (testing "rf2-3t7rs8 — `open-in-editor!` guards the `.stopPropagation`
+            on event presence, so a nil event (a programmatic invoke
+            with no DOM event) does not throw; the dispatch still fires"
+    (let [[disp calls] (capturing-dispatch)]
+      (coord-link/open-in-editor! coord nil disp)
+      (is (= [[:rf.xray/open-in-editor {:source-coord coord}]] @calls)
+          "dispatch still routes with a nil event"))))

--- a/tools/xray/test/day8/re_frame2_xray/preload_decoupling_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/preload_decoupling_cljs_test.cljs
@@ -301,6 +301,74 @@
           (is (fn? (aget xray "toggle_BANG_"))
               "the toggle! launch API is exported on the global"))))))
 
+;; ---- (2b) install-browser-api-exports! `core` branch (rf2-3t7rs8) --------
+;;
+;; rf2-3t7rs8 finding 2: install-browser-api-exports! (install.cljs:156-173)
+;; exports onto `window.day8.re_frame2_xray` and CONDITIONALLY augments an
+;; EXISTING `window.day8.re_frame2_xray.core`, explicitly NEVER pre-creating
+;; `core` (pre-creating it races `goog.provide` in browser-test with a
+;; "Namespace already declared" failure). The pre-existing coverage above
+;; only asserted the top-level `toggle_BANG_` export — neither conditional
+;; `core` branch was pinned. These two cases close that gap without relying
+;; on real browser globals (they drive the stub window directly).
+
+(deftest install-browser-api-exports-does-not-create-core-when-absent
+  (testing "rf2-3t7rs8 — install-browser-api-exports! must NOT pre-create
+            `core`. With no pre-existing core object on the stub window,
+            `re_frame2_xray.core` stays absent after install (the
+            `when-let [core …]` guard skips the augment branch). This is
+            load-bearing: pre-creating core would race goog.provide and
+            fail browser-test with 'Namespace already declared'."
+    (with-stub-dom*
+      (fn [{:keys [window]}]
+        ;; Baseline: clear-world! ran; the stub window is bare.
+        (is (nil? (aget window "day8")) "no day8 namespace before install")
+        (install/install-browser-api-exports!)
+        (let [day8 (aget window "day8")
+              xray (when day8 (aget day8 "re_frame2_xray"))]
+          (is (some? xray) "top-level export object created")
+          (is (fn? (aget xray "toggle_BANG_"))
+              "top-level launch API still installed")
+          (is (nil? (aget xray "core"))
+              "core was NOT pre-created — the absent-core branch is a
+               no-op, never a `goog.provide`-racing object creation"))))))
+
+(deftest install-browser-api-exports-augments-preexisting-core
+  (testing "rf2-3t7rs8 — when Closure has ALREADY created the real
+            `window.day8.re_frame2_xray.core` namespace object, install!
+            augments it in place with the launch API (the `when-let
+            [core …]` branch fires). The existing object identity is
+            preserved (no replacement) and the exact exports the facade
+            relies on land on it."
+    (with-stub-dom*
+      (fn [{:keys [window]}]
+        ;; Model Closure having already declared the core namespace:
+        ;; pre-seed window.day8.re_frame2_xray.core with a marker so we
+        ;; can prove the SAME object is augmented (not replaced).
+        (let [day8        (js-obj)
+              xray        (js-obj)
+              core        (js-obj "rf2-3t7rs8-marker" true)]
+          (aset xray "core" core)
+          (aset day8 "re_frame2_xray" xray)
+          (aset window "day8" day8)
+          (install/install-browser-api-exports!)
+          (let [core' (-> (aget window "day8")
+                          (aget "re_frame2_xray")
+                          (aget "core"))]
+            (is (identical? core core')
+                "the pre-existing core object is augmented in place, not
+                 replaced — its identity (and the marker) survives")
+            (is (true? (aget core' "rf2-3t7rs8-marker"))
+                "the pre-existing marker is preserved (augment, not clobber)")
+            (is (fn? (aget core' "toggle_BANG_"))
+                "toggle_BANG_ landed on the pre-existing core object")
+            (is (fn? (aget core' "status"))
+                "status landed on the pre-existing core object")
+            ;; And the top-level export is unconditionally present too.
+            (is (fn? (aget xray "toggle_BANG_"))
+                "the top-level export still installs alongside the
+                 core augment")))))))
+
 (deftest install-ns-load-is-side-effect-free
   (testing "rf2-5w06uu — the install ns is load-inert: its re-exports are
             identity-equal to the preload re-exports (one shared backing

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/persistence_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/persistence_cljs_test.cljs
@@ -1,0 +1,272 @@
+(ns day8.re-frame2-xray.static.machines.persistence-cljs-test
+  "Direct slot tests for the Static Machines persistence round-trip
+  (rf2-3t7rs8, finding 1).
+
+  ## What's under test
+
+  `panel_cljs_test.cljs` only smoke-tests the persisted slots through
+  the registered subs (the default sub-mode resolves to `:topology`) —
+  it never hits `load-sub-mode-by-id`, `save-sub-mode-by-id!`,
+  `load-selected-id`, or `save-selected-id!` directly. The edge cases
+  those four functions guard were unpinned:
+
+    - empty / unavailable sub-mode slot
+    - malformed (unparseable) EDN
+    - non-map EDN
+    - invalid sub-mode VALUES (normalise back to `:topology`)
+    - non-keyword KEYS dropped
+    - selected-id nil clear
+    - selected-id namespaced-keyword round-trip
+
+  ## Test seam
+
+  Per the bead these are CLJS unit tests that `with-redefs` the shared
+  `local-storage` seam (`get-item` / `set-item!` / `remove-item!`) over
+  an in-process atom. No `js/window` / jsdom is touched — the slot
+  parse + normalise logic is exercised hermetically.
+
+  ## Adversarial posture (rf2-3t7rs8)
+
+  The bead's finding 1 evidence flags a doc-vs-implementation tension on
+  the EMPTY-slot read: the `load-sub-mode-by-id` docstring says it
+  'returns `{}` when the slot is empty / unparseable', but the body
+  wraps the whole read in `when-let`, so an empty slot actually returns
+  `nil`. `load-empty-slot-returns-nil-not-empty-map` PINS the AS-BUILT
+  behaviour (nil) and documents the asymmetry: `nil` and `{}` are
+  observationally identical to every consumer (`get`/`merge`/`into`
+  treat them the same, and the hydrate event seeds the slot either
+  way), so the implementation is correct as written — only the
+  docstring overstates. Pinning the real value keeps a future refactor
+  honest about which branch fires."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-xray.local-storage :as ls]
+            [day8.re-frame2-xray.static.machines.persistence :as persistence]))
+
+;; ---- in-process localStorage stub ---------------------------------------
+;;
+;; A bare atom standing in for `window.localStorage`. The shared
+;; `local-storage` seam is the one place the persistence ns touches the
+;; browser; redefing its three primitives over this atom lets the slot
+;; round-trip run under node-test with no jsdom.
+
+(def ^:private store (atom {}))
+
+(defn- stub-get-item [k] (get @store k))
+(defn- stub-set-item! [k v] (swap! store assoc k v) nil)
+(defn- stub-remove-item! [k] (swap! store dissoc k) nil)
+
+(use-fixtures :each
+  {:before (fn [] (reset! store {}))})
+
+(defn- with-stub-storage* [f]
+  (with-redefs [ls/get-item    stub-get-item
+                ls/set-item!   stub-set-item!
+                ls/remove-item! stub-remove-item!]
+    (f)))
+
+;; -------------------------------------------------------------------------
+;; (1) sub-mode slot — empty / unavailable
+;; -------------------------------------------------------------------------
+
+(deftest load-empty-slot-returns-nil-not-empty-map
+  (testing "rf2-3t7rs8 — AS-BUILT: an empty / unavailable sub-mode slot
+            reads back nil (the outer `when-let` short-circuits before
+            the `{}` fallback). nil and {} are observationally identical
+            to every consumer, so this pins the real branch rather than
+            the docstring's overstated `{}`."
+    (with-stub-storage*
+      (fn []
+        ;; store is empty → get-item returns nil → when-let is falsey.
+        (is (nil? (persistence/load-sub-mode-by-id))
+            "empty slot reads nil, not {}")))))
+
+(deftest load-empty-string-slot-returns-nil
+  (testing "rf2-3t7rs8 — a present-but-empty-string slot DOES reach the
+            parse branch (the `when-let` raw is the non-nil empty
+            string). `cljs.reader/read-string \"\"` returns nil (it does
+            NOT throw), so the `(when (map? parsed) …)` guard fails and
+            the read yields nil — not the catch-branch `{}`. Pins the
+            real path: the catch `{}` only fires for genuinely
+            unparseable EDN, which the next test exercises."
+    (with-stub-storage*
+      (fn []
+        (stub-set-item! persistence/sub-mode-key "")
+        (is (nil? (persistence/load-sub-mode-by-id))
+            "empty string reads as nil → fails map? → nil")))))
+
+;; -------------------------------------------------------------------------
+;; (2) sub-mode slot — malformed / non-map EDN
+;; -------------------------------------------------------------------------
+
+(deftest load-malformed-edn-returns-empty-map
+  (testing "rf2-3t7rs8 — unparseable EDN falls into the catch and
+            returns {} rather than crashing the render"
+    (with-stub-storage*
+      (fn []
+        (stub-set-item! persistence/sub-mode-key "{:a/b :topology")  ;; unbalanced
+        (is (= {} (persistence/load-sub-mode-by-id))
+            "unbalanced map literal → catch → {}")))))
+
+(deftest load-non-map-edn-returns-nil
+  (testing "rf2-3t7rs8 — parseable BUT non-map EDN (a vector / scalar)
+            fails the `(when (map? parsed) …)` guard, so the read yields
+            nil — the value is neither a usable map nor a crash."
+    (with-stub-storage*
+      (fn []
+        (stub-set-item! persistence/sub-mode-key "[:m/a :topology]")
+        (is (nil? (persistence/load-sub-mode-by-id))
+            "vector EDN parses but fails map? → nil")
+        (stub-set-item! persistence/sub-mode-key ":just-a-keyword")
+        (is (nil? (persistence/load-sub-mode-by-id))
+            "scalar EDN parses but fails map? → nil")))))
+
+;; -------------------------------------------------------------------------
+;; (3) sub-mode slot — value normalisation + key filtering
+;; -------------------------------------------------------------------------
+
+(deftest load-normalises-invalid-sub-mode-values
+  (testing "rf2-3t7rs8 — every value normalises through
+            helpers/normalise-sub-mode; an out-of-enum value falls back
+            to :topology rather than riding through corrupted"
+    (with-stub-storage*
+      (fn []
+        (persistence/save-sub-mode-by-id!
+          {:m/a :bogus          ;; not in the 4-mode enum → :topology
+           :m/b :sim            ;; valid → preserved
+           :m/c "instances"})   ;; string form of a valid mode → :instances
+        (is (= {:m/a :topology
+                :m/b :sim
+                :m/c :instances}
+               (persistence/load-sub-mode-by-id))
+            "invalid → :topology; valid kw preserved; valid string coerced")))))
+
+(deftest load-drops-non-keyword-keys
+  (testing "rf2-3t7rs8 — the `(when (keyword? k) …)` keep-guard drops
+            entries whose key is not a keyword (a corrupted slot could
+            carry string / numeric keys)"
+    (with-stub-storage*
+      (fn []
+        ;; Hand-write a map with mixed key types (can't go through
+        ;; save! which only round-trips what the panel produces).
+        (stub-set-item! persistence/sub-mode-key
+                        (pr-str {:m/a :sim, "m/b" :topology, 42 :instances}))
+        (is (= {:m/a :sim} (persistence/load-sub-mode-by-id))
+            "string + numeric keys dropped; only the keyword key survives")))))
+
+(deftest load-namespaced-keyword-keys-round-trip
+  (testing "rf2-3t7rs8 — namespaced machine-id keys survive the
+            pr-str → read-string round-trip intact"
+    (with-stub-storage*
+      (fn []
+        (persistence/save-sub-mode-by-id! {:foo.bar/login :instances})
+        (is (= {:foo.bar/login :instances}
+               (persistence/load-sub-mode-by-id))
+            "fully-qualified ns keyword key preserved")))))
+
+;; -------------------------------------------------------------------------
+;; (4) sub-mode slot — save! clears on empty / nil
+;; -------------------------------------------------------------------------
+
+(deftest save-empty-or-nil-clears-the-slot
+  (testing "rf2-3t7rs8 — save-sub-mode-by-id! with nil OR an empty map
+            removes the slot (so a cleared selection doesn't leave a
+            `{}` husk in storage)"
+    (with-stub-storage*
+      (fn []
+        (persistence/save-sub-mode-by-id! {:m/a :sim})
+        (is (contains? @store persistence/sub-mode-key)
+            "non-empty map writes the slot")
+        (persistence/save-sub-mode-by-id! {})
+        (is (not (contains? @store persistence/sub-mode-key))
+            "empty map removes the slot")
+        (persistence/save-sub-mode-by-id! {:m/a :sim})
+        (persistence/save-sub-mode-by-id! nil)
+        (is (not (contains? @store persistence/sub-mode-key))
+            "nil also removes the slot")))))
+
+(deftest sub-mode-round-trip-survives-storage
+  (testing "rf2-3t7rs8 — a valid {machine-id sub-mode} map written via
+            save! reads back identical via load"
+    (with-stub-storage*
+      (fn []
+        (let [by-id {:m/a :topology :m/b :sim :m/c :instances :m/d :cascade}]
+          (persistence/save-sub-mode-by-id! by-id)
+          (is (= by-id (persistence/load-sub-mode-by-id))
+              "all four valid modes round-trip"))))))
+
+;; -------------------------------------------------------------------------
+;; (5) selected-id slot — save / load / clear
+;; -------------------------------------------------------------------------
+
+(deftest selected-id-round-trips-bare-keyword
+  (testing "rf2-3t7rs8 — a bare (un-namespaced) machine-id keyword
+            round-trips: save! stores the `name`-only string, load
+            re-keywords it"
+    (with-stub-storage*
+      (fn []
+        (persistence/save-selected-id! :login)
+        (is (= "login" (get @store persistence/selection-key))
+            "stored as bare name string (no leading colon)")
+        (is (= :login (persistence/load-selected-id))
+            "load re-keywords the stored name")))))
+
+(deftest selected-id-round-trips-namespaced-keyword
+  (testing "rf2-3t7rs8 — a namespaced machine-id keyword round-trips via
+            the `ns/name` string form (the slot drops the leading colon
+            but keeps the namespace)"
+    (with-stub-storage*
+      (fn []
+        (persistence/save-selected-id! :foo.bar/login)
+        (is (= "foo.bar/login" (get @store persistence/selection-key))
+            "stored as ns/name (leading colon stripped)")
+        (is (= :foo.bar/login (persistence/load-selected-id))
+            "load reconstructs the namespaced keyword")))))
+
+(deftest selected-id-nil-clears-the-slot
+  (testing "rf2-3t7rs8 — save-selected-id! nil removes the slot; a
+            subsequent load reads nil"
+    (with-stub-storage*
+      (fn []
+        (persistence/save-selected-id! :login)
+        (is (contains? @store persistence/selection-key))
+        (persistence/save-selected-id! nil)
+        (is (not (contains? @store persistence/selection-key))
+            "nil clears the selection slot")
+        (is (nil? (persistence/load-selected-id))
+            "load reads nil from the cleared slot")))))
+
+(deftest selected-id-non-keyword-is-a-no-op
+  (testing "rf2-3t7rs8 — save-selected-id! with a non-nil, non-keyword
+            value neither writes nor crashes (the inner `when keyword?`
+            guard). Pins that a corrupted caller can't poison the slot."
+    (with-stub-storage*
+      (fn []
+        (persistence/save-selected-id! "not-a-keyword")
+        (is (not (contains? @store persistence/selection-key))
+            "string value is not persisted")
+        (persistence/save-selected-id! 42)
+        (is (not (contains? @store persistence/selection-key))
+            "numeric value is not persisted")))))
+
+(deftest load-selected-id-empty-slot-reads-nil
+  (testing "rf2-3t7rs8 — an absent selection slot reads back nil (the
+            `when-let` short-circuits)"
+    (with-stub-storage*
+      (fn []
+        (is (nil? (persistence/load-selected-id))
+            "empty selection slot → nil")))))
+
+;; -------------------------------------------------------------------------
+;; (6) clear! drops BOTH slots
+;; -------------------------------------------------------------------------
+
+(deftest clear-drops-both-slots
+  (testing "rf2-3t7rs8 — clear! removes the selection AND sub-mode slots
+            in one call (the per-test reset hook used by the panel tests)"
+    (with-stub-storage*
+      (fn []
+        (persistence/save-selected-id! :login)
+        (persistence/save-sub-mode-by-id! {:login :sim})
+        (is (= 2 (count @store)) "both slots present")
+        (persistence/clear!)
+        (is (empty? @store) "clear! drops both slots")))))


### PR DESCRIPTION
Adds the three missing test-coverage gaps from the independent review (rf2-3t7rs8). All CLJS unit tests; no production code changed.

## Finding 1 — Static Machines persistence direct slot tests

`panel_cljs_test.cljs` only smoke-tested the persisted slots through registered subs; the four persistence functions had no direct coverage. New `static/machines/persistence_cljs_test.cljs` `with-redefs` the shared `local-storage` seam (`get-item` / `set-item!` / `remove-item!`) over an in-process atom and pins:

- empty / unavailable sub-mode slot → nil (the outer `when-let` short-circuits)
- empty-string slot → nil (`read-string ""` is nil, fails `map?`)
- malformed EDN → `{}` (the catch branch)
- non-map EDN (vector / scalar) → nil (fails `map?`)
- invalid sub-mode VALUES normalise to `:topology`; valid string coerces; valid kw preserved
- non-keyword keys dropped; namespaced keyword keys round-trip
- `save-sub-mode-by-id!` clears on nil / empty map
- selected-id: bare + namespaced keyword round-trip, nil clear, non-keyword no-op, empty-slot nil
- `clear!` drops both slots

Adversarial note (per the bead): the bead flagged a doc-vs-impl tension on the empty-slot read — the docstring says `{}`, the body's `when-let` returns nil. The tests PIN the as-built nil and document that nil and `{}` are observationally identical to every consumer, so the implementation is correct as written; only the docstring overstates. No production change made — pinned, not reconciled.

## Finding 2 — install-browser-api-exports! `core` branch

Extended the stub-window suite in `preload_decoupling_cljs_test.cljs` with the two conditional `core` branches that were unpinned:

- absent `core` stays absent after install (no `goog.provide`-racing pre-creation)
- pre-existing `core` is augmented IN PLACE (object identity + a seeded marker preserved; `toggle_BANG_` / `status` land on it)

Both drive the stub window directly — no real browser globals.

## Finding 3 — shared click-to-source helper behavioural tests

New `panels/shared/coord_affordances_cljs_test.cljs` pins the render + click branches of `coord-link` and `coord-chip` (the existing consolidation test is a source-text guard; `open_in_editor_cljs_test` covers the receiver, not these helpers):

- valid coord → clickable `<button>`; missing/`:file`-less coord degrades (link → plain `<span>` keeping testid; chip → nil)
- aria-label / title / testid shape on both branches
- `coord-link` glyph ordering (`label ↗` / `↗ label` / label-alone via `:glyph?` `:glyph-leading?`)
- `coord-chip` pixel-knob overrides (`:color` / `:margin-left`)
- `:on-click` stops event propagation and dispatches `[:rf.xray/open-in-editor {:source-coord coord}]` through the captured `:dispatch-fn` seam
- the shared `open-in-editor!` action: stops propagation, routes through dispatch-fn, tolerates a nil event

## Quality gates

- `npm run test:cljs` — green: Ran 7047 tests, 28832 assertions, 0 failures, 0 errors (includes all three new `_cljs_test.cljs`)
- xray `clojure -M:test` — green: Ran 1187 tests, 5271 assertions, 0 failures, 0 errors

Spec unchanged because this is test-only coverage of existing behaviour — no `tools/xray/spec/*` contract surface changed.