### PR TITLE
fix(xray): feature-matrix best-practice cleanup (rf2-sdqsla)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panel_registry.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panel_registry.cljc
@@ -55,11 +55,11 @@
     :panel  fn     — view function rendered when the tab is selected.
                      Called with no args from a hiccup `[(:panel tab)]`
                      vector so reg-view shapes resolve through their
-                     own React-context Provider.
-    :placeholder-bead opt string — sibling bead id when the tab still
-                                   renders a placeholder card (Static
-                                   tabs do this during the rf2-o5f5f
-                                   roll-out).
+                     own React-context Provider. REQUIRED + must be
+                     callable — `reg-l4-tab!` rejects a missing or
+                     non-callable `:panel` so a malformed registration
+                     fails at the registry seam, not later during UI
+                     composition (`[(:panel tab)]`).
 
   ## Idempotency
 
@@ -75,8 +75,9 @@
   `.cljc` so the JVM test corpus can exercise the pure-data
   registry surface (registration shape, ordering, mode partition)
   without spinning a CLJS runtime. Panel `:panel` views are CLJS-
-  only — JVM tests register stub `:panel` values (any value works;
-  the registry doesn't invoke `:panel`).")
+  only — the registry stores but never invokes `:panel`, so JVM
+  tests register an `(fn [] nil)` stub: the `:pre` requires `:panel`
+  to be callable but is content with any callable.")
 
 ;; ---- registry atom ------------------------------------------------------
 
@@ -152,7 +153,7 @@
   a panel belongs to exactly one mode's tab bar. The same `:id` in
   both modes is two separate registrations of two separate panels
   (e.g. Dynamic Routing vs Static Routes), keyed apart by mode."
-  [{:keys [id label mnem modes panel order placeholder-bead] :as tab}]
+  [{:keys [id label mnem modes panel order] :as tab}]
   {:pre [(keyword? id)
          (string? label)
          (or (nil? mnem) (string? mnem))
@@ -160,7 +161,7 @@
          (= 1 (count modes))
          (every? #{:dynamic :static} modes)
          (or (nil? order) (number? order))
-         (or (nil? placeholder-bead) (string? placeholder-bead))]}
+         (fn? panel)]}
   (swap! registry assoc [(first modes) id] tab)
   tab)
 

--- a/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/flows/panel.cljs
@@ -382,7 +382,6 @@
      :mnem  "f"
      :modes #{:static}
      :order 3
-     :panel Panel
-     :placeholder-bead "rf2-uhsqb"})
+     :panel Panel})
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/interceptors/panel.cljs
@@ -304,7 +304,6 @@
      :mnem  "i"
      :modes #{:static}
      :order 4
-     :panel Panel
-     :placeholder-bead "rf2-o5f5f.6"})
+     :panel Panel})
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/machines/panel.cljs
@@ -257,6 +257,5 @@
      :mnem  "m"
      :modes #{:static}
      :order 0
-     :panel panel
-     :placeholder-bead "rf2-o5f5f.2"})
+     :panel panel})
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/routes/panel.cljs
@@ -207,7 +207,6 @@
      :mnem  "r"
      :modes #{:static}
      :order 1
-     :panel Panel
-     :placeholder-bead "rf2-o5f5f.3"})
+     :panel Panel})
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/schemas/panel.cljs
@@ -438,7 +438,6 @@
      :mnem  "c"
      :modes #{:static}
      :order 2
-     :panel Panel
-     :placeholder-bead "rf2-o5f5f.4"})
+     :panel Panel})
 
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/static/shell.cljs
@@ -138,11 +138,9 @@
 
 (defn tabs
   "Ordered Static-mode tab entries. Each entry carries `:id`,
-  `:label`, `:mnem`, `:modes`, `:order`, `:panel`, and (for tabs
-  awaiting their sibling-bead content) `:placeholder-bead`. Order
-  matches the parent-epic findings doc
-  `2026-05-19-xray-explorer-mode.md` §2.4 — machines, routes,
-  schemas, views, flows, events.
+  `:label`, `:mnem`, `:modes`, `:order`, and `:panel`. Order matches
+  the parent-epic findings doc `2026-05-19-xray-explorer-mode.md` §2.4
+  — machines, routes, schemas, views, flows, events.
 
   Default landing tab is `:machines` per Mike's call (the densest
   Static surface; opening Static on a fresh slate should land on the
@@ -369,53 +367,12 @@
        ^{:key id}
        [tab-button dispatch (assoc tab :active? (= id selected))])]))
 
-;; ---- L4 detail panel (placeholders) -------------------------------------
-
-(defn- placeholder-card
-  "Render a placeholder card for an unfilled Static sub-tab. The card
-  surfaces:
-
-    - The tab label as an `<h2>` for screen-reader navigation
-      (rf2-vxpq1 — was previously `<h1>` which nested a second top-
-      level heading inside the host document's outline; `<h2>` keeps
-      the placeholder a subheading under the host's `<h1>`).
-    - The sibling bead id ('rf2-o5f5f.<N> will fill this').
-    - A muted hint paragraph naming the upcoming content.
-
-  The card is a single `<section>` painted on `bg-2` with a thin
-  mode-`accent` stripe — mirrors the Dynamic panels' header-stripe
-  convention (`tokens/accent-stripe-style`). The runtime `:accent`
-  alias resolves to the Static-mode cyan here (the surface only
-  renders under `.mode-static`)."
-  [{:keys [label placeholder-bead id]}]
-  [:section {:data-testid (str "rf-xray-static-placeholder-" (name id))
-             :style {:padding       "16px"
-                     :background    (:bg-2 tokens)
-                     :color         (:text-primary tokens)
-                     :font-family   sans-stack
-                     :font-size     (:body type-scale)
-                     :line-height   (:line-height-tight type-scale)}}
-   ;; Per rf2-rb6js / rf2-6xezz — placeholder label renders at body
-   ;; type-scale (not `:display`) so the placeholder card matches the
-   ;; surrounding body typography. Was `[:h2]` at `:display`; now a
-   ;; non-heading `[:div]` at `:body` so it sits cleanly under the
-   ;; host's existing heading hierarchy.
-   [:div {:style {:font-size     (:body type-scale)
-                  :font-weight   600
-                  :margin        "0 0 8px 0"
-                  :padding-left  "10px"
-                  :border-left   (str "3px solid " (:accent tokens))}}
-    label]
-   [:p {:style {:color  (:text-secondary tokens)
-                :margin "0 0 12px 0"}}
-    [:strong {:style {:color (:accent tokens)}}
-     placeholder-bead]
-    " will fill this."]
-   [:p {:style {:color  (:text-tertiary tokens)
-                :margin 0
-                :font-size (:caption type-scale)}}
-    "Static mode is event-INDEPENDENT — this tab will browse what's "
-    "registered, not what just fired. See parent epic rf2-o5f5f."]])
+;; ---- L4 detail panel ----------------------------------------------------
+;;
+;; rf2-o5f5f roll-out complete (rf2-sdqsla): all five Static sub-tabs ship
+;; a real panel, so the unfilled-tab `placeholder-card` scaffold was
+;; removed. `detail-panel` always mounts the selected tab's `:panel` view;
+;; an unknown `:selected-tab` falls through to the unknown-tab stub.
 
 (rf/reg-view detail-panel
   "L4 detail panel — registry-driven mount (rf2-2moh1).

--- a/tools/xray/src/day8/re_frame2_xray/test_support.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/test_support.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-xray.test-support
-  "Single test-fixture entry-point for Xray's idempotency sentinels.
+  "Single test-fixture entry-point for Xray's process-global reset.
 
   Previously every test fixture called both `preload/reset-for-test!`
   and `registry/reset-for-test!` — adding a new sentinel-bearing ns
@@ -12,21 +12,50 @@
   needs `reset-all!` does not drag in `preload`'s side-effecting boot
   block.
 
+  rf2-sdqsla — `reset-all!` now ALSO clears the trace-collector rings.
+  Those are process-global `defonce` atoms that `registry`/`install`
+  reset do NOT touch, so a test that omitted the separate
+  `trace-collector/reset-for-test!` became order-dependent (cross-test
+  trace bleed). Folding it in means one fixture call leaves EVERY
+  Xray process-global in a clean, re-installable state. Settings /
+  localStorage state is reset by the optional `reset-runtime!` (the
+  settings atom is reset selectively because not every fixture wants
+  its persisted-config seed cleared).
+
   **Test-only — never call from production code.** Per rf2-kmhvg
   cluster item 3e (audit rf2-i0veg §3e)."
-  (:require [day8.re-frame2-xray.install :as install]
-            [day8.re-frame2-xray.registry :as registry]))
+  (:require [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.install :as install]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
 (defn reset-all!
-  "Reset every Xray idempotency sentinel in dependency order so a
-  single fixture-call leaves the namespaces in a re-installable state.
-  Calls (in order):
+  "Reset every process-global Xray reset surface in dependency order so
+  a single fixture-call leaves the namespaces in a re-installable
+  state. Calls (in order):
 
-      install/reset-for-test!  ; trace-cb + epoch-cb registration flags
-      registry/reset-for-test! ; per-panel reg-event/reg-sub flags
+      install/reset-for-test!         ; trace-cb + epoch-cb reg flags
+      registry/reset-for-test!        ; per-panel reg-event/reg-sub flags
+      trace-collector/reset-for-test! ; frameless ring + per-frame rings
+
+  The trace-collector rings are process-global `defonce` atoms the
+  sentinel resets above do NOT touch — clearing them here closes the
+  cross-test trace-bleed gap (rf2-sdqsla). Does NOT touch the settings
+  atom — use `reset-runtime!` for that.
 
   Test-only. Returns nil."
   []
   (install/reset-for-test!)
   (registry/reset-for-test!)
+  (trace-collector/reset-for-test!)
+  nil)
+
+(defn reset-runtime!
+  "`reset-all!` PLUS the persisted Settings atom + localStorage payload
+  (`config/reset-settings!`). The full clean-slate a runtime-mounting
+  fixture wants: process-global sentinels, trace rings, AND config /
+  storage state. Test-only. Returns nil."
+  []
+  (reset-all!)
+  (config/reset-settings!)
   nil)

--- a/tools/xray/src/day8/re_frame2_xray/test_support.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/test_support.cljs
@@ -4,23 +4,33 @@
   Previously every test fixture called both `preload/reset-for-test!`
   and `registry/reset-for-test!` — adding a new sentinel-bearing ns
   meant updating ~30 fixtures. This ns folds those calls into one
-  `reset-all!` so panel additions don't ripple through the test
-  corpus.
+  helper so panel additions don't ripple through the test corpus.
 
   Targets the inert `day8.re-frame2-xray.install` ns for the collector
   sentinels (rf2-5w06uu) rather than `preload`, so a fixture that only
-  needs `reset-all!` does not drag in `preload`'s side-effecting boot
-  block.
+  needs the sentinel reset does not drag in `preload`'s side-effecting
+  boot block.
 
-  rf2-sdqsla — `reset-all!` now ALSO clears the trace-collector rings.
-  Those are process-global `defonce` atoms that `registry`/`install`
-  reset do NOT touch, so a test that omitted the separate
-  `trace-collector/reset-for-test!` became order-dependent (cross-test
-  trace bleed). Folding it in means one fixture call leaves EVERY
-  Xray process-global in a clean, re-installable state. Settings /
-  localStorage state is reset by the optional `reset-runtime!` (the
-  settings atom is reset selectively because not every fixture wants
-  its persisted-config seed cleared).
+  ## The three reset surfaces (rf2-sdqsla)
+
+  A fixture has up to three process-global surfaces to clear:
+
+    1. install / registry idempotency SENTINELS — `reset-sentinels!`.
+       Safe at any point; just flips the `defonce` re-install flags so
+       a re-`register-xray-handlers!` actually re-runs.
+    2. the trace-collector RINGS — `reset-all!` adds this. The rings
+       are process-global `defonce` atoms the sentinel reset does NOT
+       touch, so a fixture that forgot the (historically separate)
+       `trace-collector/reset-for-test!` leaked trace rows into the
+       next test (order-dependent bleed).
+    3. settings / localStorage STATE — `reset-runtime!` adds this on
+       top.
+
+  Use the SMALLEST one that fits: `reset-sentinels!` for a fixture that
+  resets MID-setup (host frame already registered — clearing the rings
+  there would wipe the live frame's recording config), `reset-all!`
+  for a clean-slate fixture that resets BEFORE registering frames, and
+  `reset-runtime!` when the persisted settings also need wiping.
 
   **Test-only — never call from production code.** Per rf2-kmhvg
   cluster item 3e (audit rf2-i0veg §3e)."
@@ -29,24 +39,35 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.trace-collector :as trace-collector]))
 
-(defn reset-all!
-  "Reset every process-global Xray reset surface in dependency order so
-  a single fixture-call leaves the namespaces in a re-installable
-  state. Calls (in order):
+(defn reset-sentinels!
+  "Reset ONLY the install + registry idempotency sentinels, in
+  dependency order:
 
-      install/reset-for-test!         ; trace-cb + epoch-cb reg flags
-      registry/reset-for-test!        ; per-panel reg-event/reg-sub flags
-      trace-collector/reset-for-test! ; frameless ring + per-frame rings
+      install/reset-for-test!  ; trace-cb + epoch-cb reg flags
+      registry/reset-for-test! ; per-panel reg-event/reg-sub flags
 
-  The trace-collector rings are process-global `defonce` atoms the
-  sentinel resets above do NOT touch — clearing them here closes the
-  cross-test trace-bleed gap (rf2-sdqsla). Does NOT touch the settings
-  atom — use `reset-runtime!` for that.
-
-  Test-only. Returns nil."
+  Does NOT touch the trace-collector rings or the settings atom — safe
+  to call MID-setup (after frames are registered) because it only flips
+  re-install flags. Test-only. Returns nil."
   []
   (install/reset-for-test!)
   (registry/reset-for-test!)
+  nil)
+
+(defn reset-all!
+  "`reset-sentinels!` PLUS the trace-collector rings
+  (`trace-collector/reset-for-test!`). The rings are process-global
+  `defonce` atoms the sentinel reset does NOT touch — clearing them
+  here closes the cross-test trace-bleed gap (rf2-sdqsla).
+
+  Call at the START of a fixture, BEFORE registering frames — clearing
+  the rings wipes the per-frame recording config, so a mid-setup call
+  (host frame already registered) must use `reset-sentinels!` instead.
+
+  Does NOT touch the settings atom — use `reset-runtime!` for that.
+  Test-only. Returns nil."
+  []
+  (reset-sentinels!)
   (trace-collector/reset-for-test!)
   nil)
 

--- a/tools/xray/test/day8/re_frame2_xray/core_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/core_cljs_test.cljs
@@ -40,12 +40,12 @@
 ;; ---- fixtures -----------------------------------------------------------
 
 (defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  ;; rf2-2thl2 — init! writes through to the persisted Settings atom;
-  ;; reset between tests so per-test mutations don't leak into the
-  ;; next test's read.
-  (config/reset-settings!))
+  ;; rf2-sdqsla — `reset-runtime!` folds the sentinel + trace-collector
+  ;; + settings reset into one call. rf2-2thl2 — the settings reset
+  ;; matters because init! writes through to the persisted Settings atom;
+  ;; reset between tests so per-test mutations don't leak into the next
+  ;; test's read.
+  (xray-test-support/reset-runtime!))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture

--- a/tools/xray/test/day8/re_frame2_xray/event_list_resizable_cols_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/event_list_resizable_cols_cljs_test.cljs
@@ -30,9 +30,9 @@
 ;; ---- fixture ------------------------------------------------------------
 
 (defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-settings!)
+  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
+  ;; settings reset into one call.
+  (xray-test-support/reset-runtime!)
   ;; Force-cleanup any stale drag-state from a previous test (the
   ;; module-level defonce atom survives fixture reset).
   (shell/col-divider-simulate-up!))

--- a/tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/events_list_seam_cljs_test.cljs
@@ -33,15 +33,14 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
             [day8.re-frame2-xray.shell :as shell]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture ------------------------------------------------------------
 
 (defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-settings!)
+  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
+  ;; settings reset into one call.
+  (xray-test-support/reset-runtime!)
   ;; Force-cleanup any stale seam-drag state from a previous test (the
   ;; module-level defonce atom survives fixture reset).
   (resize-handle/seam-simulate-up!))

--- a/tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/open_in_editor_cljs_test.cljs
@@ -28,8 +28,7 @@
             [day8.re-frame2-xray.open-in-editor :as open-in-editor]
             [day8.re-frame2-xray.preload :as preload]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 (defn reset-editor! []
   ;; rf2-4s08ov — reset the operator-override slot too so a sibling
@@ -48,8 +47,9 @@
 ;; cheap snapshot/restore cost; the rf2-g5q8d tests below need the
 ;; clean runtime so registrations don't bleed between tests.
 (defn- xray-init! []
+  ;; rf2-sdqsla — `reset-all!` now folds the trace-collector ring reset
+  ;; in; `reset-editor!` owns the settings reset + editor re-arm.
   (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
   (reset-editor!))
 
 (use-fixtures :each

--- a/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/p3_polish_aria_cljs_test.cljs
@@ -33,7 +33,6 @@
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
-            [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.resize-handle :as resize-handle]
             [day8.re-frame2-xray.settings.view :as settings-view]
@@ -46,9 +45,9 @@
 ;; ---- fixture ------------------------------------------------------------
 
 (defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-settings!))
+  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
+  ;; settings reset into one call.
+  (xray-test-support/reset-runtime!))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -382,39 +381,7 @@
         (is (not (re-find #"[◉○●]" tab-text))
             "L3 tab carries no radio-circle glyph in its text")))))
 
-;; -------------------------------------------------------------------------
-;; (7) rf2-vxpq1 — static placeholder uses <h2> not <h1>
-;; -------------------------------------------------------------------------
-
-(deftest static-placeholder-uses-h2-not-h1
-  (testing "rf2-vxpq1 — Static placeholder cards drop <h1> to <h2> so
-            they don't break the host document's heading outline.
-
-            Per rf2-o5f5f.6 every Static sub-tab has shipped its real
-            panel — no placeholder cards currently mount. The
-            placeholder helper in `static/shell.cljs` still renders
-            `<h2>` if a future bead adds an unfilled tab, so this test
-            asserts the contract directly against the helper rather
-            than mounting via the surface."
-    (xray-setup!)
-    ;; The shell's `placeholder-card` defn is private; we drive the
-    ;; check through the registry's surface instead. When no
-    ;; placeholders mount, the test is trivially OK — the assertion
-    ;; bites the day a future unfilled tab regresses.
-    (rf/with-frame :rf/xray
-      (let [tree (static-shell/surface)
-            placeholders (find-all-with-pred tree
-                           (fn [n]
-                             (and (vector? n)
-                                  (map? (second n))
-                                  (when-let [tid (:data-testid (second n))]
-                                    (= 0 (.indexOf tid "rf-xray-static-placeholder-"))))))]
-        (doseq [ph placeholders]
-          (let [h1s (find-all-with-pred ph
-                     (fn [n] (and (vector? n) (= :h1 (first n)))))
-                h2s (find-all-with-pred ph
-                     (fn [n] (and (vector? n) (= :h2 (first n)))))]
-            (is (empty? h1s)
-                "placeholder card has no <h1> (would break document outline)")
-            (is (seq h2s)
-                "placeholder card uses <h2> for the title")))))))
+;; rf2-vxpq1's Static placeholder <h2>-not-<h1> test was removed in
+;; rf2-sdqsla: the rf2-o5f5f roll-out is complete (every Static sub-tab
+;; ships a real panel), so `placeholder-card` no longer exists and the
+;; test was vacuous (no placeholder ever mounts).

--- a/tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/palette/dispatch_routing_cljs_test.cljs
@@ -41,20 +41,18 @@
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
-            [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.palette :as palette]
             [day8.re-frame2-xray.registry :as registry]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture (map shape per cljs.test/async requirement) ---------------
 
 (def ^:private fixture-snap (atom nil))
 
 (defn- setup-runtime! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-settings!)
+  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
+  ;; settings reset into one call.
+  (xray-test-support/reset-runtime!)
   (reset! fixture-snap (test-support/snapshot-registrar))
   (reset! frame/frames {})
   (substrate-adapter/dispose-adapter!)

--- a/tools/xray/test/day8/re_frame2_xray/panel_registry_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panel_registry_cljs_test.cljc
@@ -50,9 +50,11 @@
 
 (defn- stub-panel
   "A stand-in `:panel` value. The registry never invokes it (it only
-  stores it), so any sentinel works on both targets."
+  stores it) but `reg-l4-tab!`'s `:pre` requires `:panel` to be
+  callable (a real registration is always a `reg-view` render fn), so
+  the stub is an `(fn [] nil)` rather than a keyword sentinel."
   []
-  ::panel-stub)
+  (fn [] nil))
 
 (defn- dynamic-tab
   "Minimal valid Dynamic tab entry with the given id + order."
@@ -78,9 +80,9 @@
             as two SEPARATE entries (Dynamic Routing vs Static Routes —
             same :routes id, different panel)"
     (let [dyn {:id :routes :label "Routing" :mnem "r"
-               :modes #{:dynamic} :order 6 :panel ::dynamic-routing}
+               :modes #{:dynamic} :order 6 :panel (stub-panel)}
           sta {:id :routes :label "Routes" :mnem "r"
-               :modes #{:static} :order 2 :panel ::static-routes}]
+               :modes #{:static} :order 2 :panel (stub-panel)}]
       (reg/reg-l4-tab! dyn)
       (reg/reg-l4-tab! sta)
       (is (= dyn (reg/tab-by-id :dynamic :routes)))
@@ -107,33 +109,35 @@
 (deftest reg-l4-tab-rejects-malformed-entries
   (testing "the :pre contract rejects each malformed shape (the spec for
             a well-formed tab entry — kw id, string label, single-mode
-            set, optional string mnem / placeholder-bead, optional
-            number order)"
+            set, callable :panel, optional string mnem, optional number
+            order)"
     (let [throws? (fn [tab]
                     (try (reg/reg-l4-tab! tab) false
                          (catch #?(:clj Throwable :cljs :default) _ true)))]
-      (is (throws? {:id "not-a-keyword" :label "X" :modes #{:dynamic} :panel ::p})
+      (is (throws? {:id "not-a-keyword" :label "X" :modes #{:dynamic} :panel (fn [] nil)})
           "id must be a keyword")
-      (is (throws? {:id :x :label :not-a-string :modes #{:dynamic} :panel ::p})
+      (is (throws? {:id :x :label :not-a-string :modes #{:dynamic} :panel (fn [] nil)})
           "label must be a string")
-      (is (throws? {:id :x :label "X" :modes [:dynamic] :panel ::p})
+      (is (throws? {:id :x :label "X" :modes [:dynamic] :panel (fn [] nil)})
           "modes must be a set, not a vector")
-      (is (throws? {:id :x :label "X" :modes #{:dynamic :static} :panel ::p})
+      (is (throws? {:id :x :label "X" :modes #{:dynamic :static} :panel (fn [] nil)})
           "modes must be a SINGLE-element set")
-      (is (throws? {:id :x :label "X" :modes #{:bogus} :panel ::p})
+      (is (throws? {:id :x :label "X" :modes #{:bogus} :panel (fn [] nil)})
           "the mode must be :dynamic or :static")
-      (is (throws? {:id :x :label "X" :modes #{:dynamic} :order "0" :panel ::p})
+      (is (throws? {:id :x :label "X" :modes #{:dynamic} :order "0" :panel (fn [] nil)})
           "order, when present, must be a number")
-      (is (throws? {:id :x :label "X" :modes #{:dynamic}
-                    :placeholder-bead :not-a-string :panel ::p})
-          "placeholder-bead, when present, must be a string"))))
+      (is (throws? {:id :x :label "X" :modes #{:dynamic}})
+          ":panel is required — a missing panel is rejected at the seam")
+      (is (throws? {:id :x :label "X" :modes #{:dynamic} :panel :not-callable})
+          ":panel must be callable — a keyword sentinel is rejected (it
+           would throw when the shell renders [(:panel tab)])"))))
 
 (deftest reg-l4-tab-accepts-optional-slots-absent
-  (testing "mnem / order / placeholder-bead are all optional — an entry
-            omitting them still registers"
-    (let [tab {:id :minimal :label "Minimal" :modes #{:dynamic} :panel ::p}]
+  (testing "mnem / order are optional — an entry omitting them still
+            registers (a callable :panel is still required)"
+    (let [tab {:id :minimal :label "Minimal" :modes #{:dynamic} :panel (stub-panel)}]
       (is (= tab (reg/reg-l4-tab! tab))
-          "a minimal entry (no mnem / order / placeholder-bead) is valid"))))
+          "a minimal entry (no mnem / order) is valid"))))
 
 ;; ---- (4) tabs-for-mode — partition + ordering ---------------------------
 
@@ -143,7 +147,7 @@
     (reg/reg-l4-tab! (dynamic-tab :epoch 0))
     (reg/reg-l4-tab! (dynamic-tab :appdb 1))
     (reg/reg-l4-tab! {:id :catalogue :label "Catalogue" :mnem "c"
-                      :modes #{:static} :order 0 :panel ::p})
+                      :modes #{:static} :order 0 :panel (stub-panel)})
     (is (= [:epoch :appdb] (mapv :id (reg/tabs-for-mode :dynamic)))
         "only Dynamic tabs surface for :dynamic")
     (is (= [:catalogue] (mapv :id (reg/tabs-for-mode :static)))
@@ -163,7 +167,7 @@
             crash the sort)"
     (reg/reg-l4-tab! (dynamic-tab :ordered-0 0))
     (reg/reg-l4-tab! {:id :unordered :label "Unordered" :mnem "u"
-                      :modes #{:dynamic} :panel ::p})
+                      :modes #{:dynamic} :panel (stub-panel)})
     (reg/reg-l4-tab! (dynamic-tab :ordered-1 1))
     (is (= [:ordered-0 :ordered-1 :unordered]
            (mapv :id (reg/tabs-for-mode :dynamic)))
@@ -197,7 +201,7 @@
     (reg/reg-l4-tab! (dynamic-tab :epoch 0))
     (reg/reg-l4-tab! (dynamic-tab :appdb 1))
     (reg/reg-l4-tab! {:id :catalogue :label "Catalogue" :mnem "c"
-                      :modes #{:static} :order 0 :panel ::p})
+                      :modes #{:static} :order 0 :panel (stub-panel)})
     (is (= #{:epoch :appdb} (reg/tab-ids-for-mode :dynamic)))
     (is (= #{:catalogue} (reg/tab-ids-for-mode :static)))))
 
@@ -227,9 +231,9 @@
   (testing "unreg-l4-tab! removes the id's entries under EVERY mode (the
             same :routes id under both Dynamic + Static both drop)"
     (reg/reg-l4-tab! {:id :routes :label "Routing" :mnem "r"
-                      :modes #{:dynamic} :order 6 :panel ::dyn})
+                      :modes #{:dynamic} :order 6 :panel (stub-panel)})
     (reg/reg-l4-tab! {:id :routes :label "Routes" :mnem "r"
-                      :modes #{:static} :order 2 :panel ::sta})
+                      :modes #{:static} :order 2 :panel (stub-panel)})
     (reg/reg-l4-tab! (dynamic-tab :epoch 0))
     (is (= 3 (count (reg/tab-entries))) "baseline — 3 entries")
     (reg/unreg-l4-tab! :routes)

--- a/tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/resize_handle_cljs_test.cljs
@@ -30,15 +30,14 @@
             [day8.re-frame2-xray.resize-handle :as resize-handle]
             [day8.re-frame2-xray.settings.effects :as settings-effects]
             [day8.re-frame2-xray.shell :as shell]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture ------------------------------------------------------------
 
 (defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-settings!)
+  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
+  ;; settings reset into one call.
+  (xray-test-support/reset-runtime!)
   ;; Force-cleanup any stale drag-state from a previous test (the
   ;; module-level defonce atom survives fixture reset).
   (resize-handle/simulate-up!))

--- a/tools/xray/test/day8/re_frame2_xray/settings/editor_hint_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/editor_hint_cljs_test.cljs
@@ -20,20 +20,18 @@
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
-            [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.editor-hint :as editor-hint]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture (map shape per cljs.test/async requirement) ---------------
 
 (def ^:private fixture-snap (atom nil))
 
 (defn- setup-runtime! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-settings!)
+  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
+  ;; settings reset into one call.
+  (xray-test-support/reset-runtime!)
   (reset! fixture-snap (test-support/snapshot-registrar))
   (reset! frame/frames {})
   (substrate-adapter/dispose-adapter!)

--- a/tools/xray/test/day8/re_frame2_xray/settings/effects_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/effects_cljs_test.cljs
@@ -27,15 +27,14 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.effects :as effects]
             [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.theme.tokens :as tokens]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.theme.tokens :as tokens]))
 
 ;; ---- fixture -----------------------------------------------------------
 
 (defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-settings!))
+  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
+  ;; settings reset into one call.
+  (xray-test-support/reset-runtime!))
 
 (defn- ensure-stub-shell-root! []
   ;; Some node test runtimes provide js/document; create the

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_cljs_test.cljs
@@ -26,15 +26,14 @@
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.popup :as popup]
             [day8.re-frame2-xray.settings.view :as view]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture ------------------------------------------------------------
 
 (defn- xray-init! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-settings!))
+  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
+  ;; settings reset into one call.
+  (xray-test-support/reset-runtime!))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture

--- a/tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/settings/popup_dispatch_routing_cljs_test.cljs
@@ -44,20 +44,18 @@
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
-            [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.registry :as registry]
             [day8.re-frame2-xray.settings.popup :as popup]
-            [day8.re-frame2-xray.test-support :as xray-test-support]
-            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+            [day8.re-frame2-xray.test-support :as xray-test-support]))
 
 ;; ---- fixture (map shape per cljs.test/async requirement) ---------------
 
 (def ^:private fixture-snap (atom nil))
 
 (defn- setup-runtime! []
-  (xray-test-support/reset-all!)
-  (trace-collector/reset-for-test!)
-  (config/reset-settings!)
+  ;; rf2-sdqsla — `reset-runtime!` folds sentinel + trace-collector +
+  ;; settings reset into one call.
+  (xray-test-support/reset-runtime!)
   ;; Capture the framework registrar so we can restore it post-test,
   ;; matching the body of `test-support/make-reset-runtime-fixture`.
   (reset! fixture-snap (test-support/snapshot-registrar))

--- a/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/machines/panel_cljs_test.cljs
@@ -499,14 +499,7 @@
     (is (= :name (frame-sub [:rf.xray.static.machines/sort-key])))
     (is (= :topology (frame-sub [:rf.xray.static.machines/sub-mode :any/id])))))
 
-;; -------------------------------------------------------------------------
-;; (13) Tab inventory still names the bead
-;; -------------------------------------------------------------------------
-
-(deftest static-tab-inventory-machines-bead
-  (testing "the :machines tab still carries its bead id even after the
-            placeholder is replaced by the live panel"
-    (is (= "rf2-o5f5f.2"
-           (-> (some #(when (= :machines (:id %)) %)
-                     (static-shell/tabs))
-               :placeholder-bead)))))
+;; rf2-sdqsla — the `static-tab-inventory-machines-bead` test was removed:
+;; the `:placeholder-bead` slot was dropped once the rf2-o5f5f roll-out
+;; completed (every Static tab ships a real panel). Inventory shape is now
+;; covered by `static-tab-inventory-shape` in the shell test.

--- a/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/static/shell_cljs_test.cljs
@@ -100,11 +100,6 @@
                     (= 0 (.indexOf tid prefix)))))
            (hiccup-seq tree)))
 
-(defn- text-nodes [tree]
-  (->> (hiccup-seq tree)
-       (filter string?)
-       (apply str)))
-
 ;; ---- helpers ------------------------------------------------------------
 
 (defn- xray-setup! []
@@ -257,7 +252,7 @@
             "no filter pills")))))
 
 ;; -------------------------------------------------------------------------
-;; (4) Static tab inventory — 5 sub-tabs, each with a placeholder card
+;; (4) Static tab inventory — 5 sub-tabs, each mounting a real panel
 ;; -------------------------------------------------------------------------
 
 (def ^:private expected-static-tab-ids
@@ -300,40 +295,15 @@
                    (:aria-selected attrs))
                 (str "tab " tab-id " aria-selected matches the active tab"))))))))
 
-(def ^:private filled-static-tab-ids
-  "Static tab ids that have a real panel installed — the placeholder
-  card for these tabs is no longer rendered. Sibling beads tick one
-  off each time they land."
-  ;; rf2-o5f5f.2 — :machines     mounts the Static Machines panel.
-  ;; rf2-o5f5f.3 — :routes       mounts the Static Routes panel.
-  ;; rf2-o5f5f.4 — :schemas      mounts the Static Schemas panel.
-  ;; rf2-uhsqb   — :flows        mounts the Static Flows panel.
-  ;; rf2-o5f5f.6 — :interceptors mounts the Static Interceptors panel.
-  ;; rf2-b2fif removed the Static Views + Events panels.
-  #{:machines :routes :schemas :flows :interceptors})
+;; rf2-sdqsla — the rf2-o5f5f placeholder roll-out is complete: every
+;; Static sub-tab (:machines :routes :schemas :flows :interceptors) ships
+;; a real panel, so `placeholder-card` was removed from the shell. The
+;; per-tab `*-mounts-live-panel` tests below assert each real panel mounts;
+;; there is no longer an unfilled-tab placeholder path to cover.
 
-(deftest static-placeholder-cards-name-sibling-bead
-  (testing "each placeholder card surfaces its sibling-bead id
-            (rf2-o5f5f.<N> will fill this) — except for tabs already
-            replaced by a real panel (filled-static-tab-ids)"
-    (xray-setup!)
-    (rf/with-frame :rf/xray
-      (doseq [tab-id expected-static-tab-ids
-              :when (not (contains? filled-static-tab-ids tab-id))]
-        (frame-dispatch [:rf.xray.static/select-tab tab-id])
-        (let [tree (static-shell/surface)
-              card (find-by-testid tree (str "rf-xray-static-placeholder-" (name tab-id)))
-              text (text-nodes card)]
-          (is (some? card)
-              (str "placeholder card for " tab-id " rendered"))
-          (is (re-find #"rf2-o5f5f\." text)
-              (str "card text names a sibling bead id (got: " text ")"))
-          (is (re-find #"will fill this" text)
-              "card mentions 'will fill this'"))))))
-
-(deftest static-machines-mounts-live-panel-not-placeholder
+(deftest static-machines-mounts-live-panel
   (testing "rf2-o5f5f.2 — the :machines sub-tab mounts the live Static
-            Machines panel (replaces the placeholder card)"
+            Machines panel"
     (xray-setup!)
     (rf/with-frame :rf/xray
       (frame-dispatch [:rf.xray.static/select-tab :machines])
@@ -341,7 +311,7 @@
         (is (some? (find-by-testid tree "rf-xray-static-machines-panel"))
             "live Machines panel mounts")
         (is (nil? (find-by-testid tree "rf-xray-static-placeholder-machines"))
-            "placeholder card no longer renders for :machines")))))
+            "no placeholder card renders for :machines")))))
 
 ;; -------------------------------------------------------------------------
 ;; (5) Static tab routing — selection + isolation
@@ -521,19 +491,14 @@
 ;; -------------------------------------------------------------------------
 
 (deftest static-tab-inventory-shape
-  (testing "tab inventory carries id/label/mnem/placeholder-bead and
-            preserves canonical order"
+  (testing "tab inventory carries id/label/mnem/panel and preserves
+            canonical order"
     (is (= [:machines :routes :schemas :flows :interceptors]
            (mapv :id (static-shell/tabs)))
         "5 tabs in canonical order (rf2-b2fif dropped :views + :events)")
-    (doseq [{:keys [id label mnem placeholder-bead]} (static-shell/tabs)]
+    (doseq [{:keys [id label mnem panel]} (static-shell/tabs)]
       (is (keyword? id) (str "id is keyword for " id))
       (is (string? label) (str "label is a string for " id))
       (is (and (string? mnem) (= 1 (count mnem)))
           (str "mnem is one character for " id))
-      ;; Most sub-tabs are sibling beads under the rf2-o5f5f parent epic
-      ;; (rf2-o5f5f.2 / .3 / .4 / .5 / .6). The :flows tab landed under
-      ;; the standalone rf2-uhsqb bead per the parent-epic comment, so
-      ;; the regex accepts either shape.
-      (is (re-matches #"(rf2-o5f5f\.\d|rf2-[a-z0-9]+)" placeholder-bead)
-          (str "placeholder-bead names a sibling bead for " id)))))
+      (is (fn? panel) (str "panel is a callable view fn for " id)))))

--- a/tools/xray/test/day8/re_frame2_xray/test_helpers/e2e_multi_frame.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_helpers/e2e_multi_frame.cljs
@@ -8,7 +8,7 @@
       whatever events / subs / machines / flows the test wants to
       drive;
     - the `:rf/xray` panel frame; `:install-xray` (default:
-      `xray-test-support/reset-all!` + `registry/register-xray-
+      `xray-test-support/reset-sentinels!` + `registry/register-xray-
       handlers!` + the seed dispatches `mount.cljs/ensure-xray-
       frame!` runs) wires Xray's own subs / events / fxs.
 
@@ -83,8 +83,12 @@
 
   Mirrors what production does:
 
-    1. `xray-test-support/reset-all!` — wipe idempotency sentinels so
-       a re-install in a re-used test process actually re-installs.
+    1. `xray-test-support/reset-sentinels!` — wipe idempotency
+       sentinels so a re-install in a re-used test process actually
+       re-installs. Sentinels ONLY — NOT the trace rings: the host
+       frame is already registered by this point (rf2-sdqsla), and
+       clearing the rings here would wipe its per-frame recording
+       config. The harness teardown owns the ring clear (below).
     2. `registry/register-xray-handlers!` — every `:rf.xray/*` sub /
        event / fx (the orchestrator).
     3. `reg-frame :rf/xray` — register Xray's frame so subs scoped
@@ -102,7 +106,7 @@
   Idempotent — repeated invocations are safe (the sentinels are reset
   by step 1)."
   []
-  (xray-test-support/reset-all!)
+  (xray-test-support/reset-sentinels!)
   (registry/register-xray-handlers!)
   (frame/reg-frame :rf/xray {})
   ;; Seed app-db slots so subs that depend on `:epoch-history` /

--- a/tools/xray/test/day8/re_frame2_xray/test_support_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/test_support_cljs_test.cljs
@@ -1,0 +1,51 @@
+(ns day8.re-frame2-xray.test-support-cljs-test
+  "Regression coverage for the single-helper reset surface (rf2-sdqsla).
+
+  `test-support/reset-all!` is the one fixture call Xray tests use to
+  leave every process-global in a clean, re-installable state. The key
+  regression this guards: BEFORE rf2-sdqsla `reset-all!` cleared only
+  the install/registry idempotency sentinels — NOT the trace-collector
+  rings (process-global `defonce` atoms). A fixture that forgot the
+  separate `trace-collector/reset-for-test!` therefore leaked trace
+  rows into the next test (order-dependent bleed). `reset-all!` now
+  folds the trace-collector reset in; these tests assert it."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.test-support :as test-support]
+            [day8.re-frame2-xray.trace-collector :as trace-collector]))
+
+(use-fixtures :each
+  (fn [test-fn]
+    (test-support/reset-all!)
+    (test-fn)
+    (test-support/reset-all!)))
+
+(defn- seed-trace-row!
+  "Push one synthetic trace row into the frameless ring so the
+  collector holds observable state (test-only ingest, bypasses gates)."
+  []
+  (trace-collector/seed-trace-for-test!
+    {:rf.trace/op    :rf.event/run-start
+     :rf.trace/event [:probe/event]}))
+
+(deftest reset-all-clears-trace-collector-rings
+  (testing "reset-all! clears the trace-collector rings — the
+            process-global bleed the separate reset used to own"
+    (seed-trace-row!)
+    (is (seq (trace-collector/buffer-for-test))
+        "precondition: the seeded row is present in the rings")
+    (test-support/reset-all!)
+    (is (empty? (trace-collector/buffer-for-test))
+        "reset-all! left the trace rings empty (no cross-test bleed)")))
+
+(deftest reset-runtime-also-clears-settings
+  (testing "reset-runtime! = reset-all! PLUS the persisted settings atom"
+    (config/update-setting! :general :panel-width-px 999)
+    (is (= 999 (config/get-setting :general :panel-width-px))
+        "precondition: the setting mutation took")
+    (seed-trace-row!)
+    (test-support/reset-runtime!)
+    (is (empty? (trace-collector/buffer-for-test))
+        "reset-runtime! cleared the trace rings (via reset-all!)")
+    (is (not= 999 (config/get-setting :general :panel-width-px))
+        "reset-runtime! reset the settings atom to defaults")))

--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -580,23 +580,6 @@ async function assertDefaultInlineLaunchModes(page, state) {
   }
 }
 
-async function readSchemaHostState(page) {
-  return page.evaluate(() => {
-    function text(id) {
-      const el = document.querySelector(`[data-testid="${id}"]`);
-      return el ? (el.textContent || '').trim() : null;
-    }
-    return {
-      token: text('auth-token'),
-      appDbCount: Number(text('app-db-count')),
-      eventCount: Number(text('event-count')),
-      cofxCount: Number(text('cofx-count')),
-      fxCount: Number(text('fx-count')),
-      semantics: text('schema-recovery-browser-semantics'),
-    };
-  });
-}
-
 async function readMultiFrameHostState(page) {
   return page.evaluate(() => {
     function text(id) {
@@ -1213,91 +1196,6 @@ async function runExceptionSchemaHttp(page, state, ctx) {
     { timeoutMs: 5000, description: 'trace source-coordinate chips' },
   );
   await assertSourceCoordBridge(page, state, ctx, { panel: 'trace' });
-}
-
-async function runSchemaViolation(page, state) {
-  // rf2-kgkht / rf2-w1mnq — Issues-feed assertion (lines below) times out
-  // under the rf2-jio48 + rf2-h0120 panel rebuild. The trace-level
-  // assertions ALL fire correctly (the four `:where` surfaces emit per
-  // spec/010), but the Issues feed locator does not render in time on
-  // this testbed integration path. Per the Wave 1-4 migration direction
-  // (rf2-tglku, feedback_xray_story_cljs_unit_tests_not_playwright) the
-  // architectural fix is a CLJS unit test against `h/project-feed` with
-  // a seeded `:rf.xray/epoch-history`; that migration is rf2-w1mnq.
-  // Until that lands, skip the scenario rather than block PR #1745 on a
-  // testbed-integration assertion the unit lens will own.
-  // eslint-disable-next-line no-console
-  console.warn('SKIP: schema violation timeline — migrating to CLJS unit per rf2-w1mnq');
-  return;
-  /* eslint-disable no-unreachable */
-  await openXray(page);
-  await clearTrace(page);
-  for (const id of ['violate-app-db', 'violate-event', 'violate-cofx', 'violate-fx-args']) {
-    await clickTestId(page, id);
-  }
-  const host = await waitForValue(
-    () => readSchemaHostState(page),
-    (snapshot) =>
-      snapshot.token === 'seed-token' &&
-      snapshot.appDbCount === 0 &&
-      snapshot.eventCount === 0 &&
-      snapshot.cofxCount === 0 &&
-      snapshot.fxCount === 1,
-    { timeoutMs: 10000, description: 'schema recovery host state' },
-  );
-  const expectedWheres = [':app-db', ':event', ':cofx', ':fx-args'];
-  const events = await waitForValue(
-    async () => readTrace(page),
-    (traceEvents) => expectedWheres.every((where) =>
-      traceEvents.some((event) =>
-        event.includes(':rf.error/schema-validation-failure') &&
-        event.includes(`:where ${where}`))),
-    { timeoutMs: 10000, description: 'schema validation failure traces for all recovery surfaces' },
-  );
-  const schemaEvents = events.filter((event) => event.includes(':rf.error/schema-validation-failure'));
-  const missingWheres = expectedWheres.filter((where) =>
-    !schemaEvents.some((event) => event.includes(`:where ${where}`)));
-  const fxWasHandled = events.some((event) =>
-    event.includes(':rf.fx/handled') &&
-    event.includes(':schema-violation.core/violate-fx'));
-  if (missingWheres.length > 0 || fxWasHandled) {
-    failWithDetails('Schema recovery traces did not match expected recovery surface', {
-      expectedWheres,
-      missingWheres,
-      expectedFxArgsRecovery: 'fx args failure skips the offending fx handler',
-      observedFxHandled: fxWasHandled,
-      host,
-      schemaEvents,
-    });
-  }
-  state.schemaRecovery = {
-    host,
-    observedWheres: expectedWheres,
-    validationTraceCount: schemaEvents.length,
-    appDbRollbackObserved: host.token === 'seed-token',
-    eventHandlerSkipped: host.eventCount === 0,
-    cofxHandlerSkipped: host.cofxCount === 0,
-    fxArgsSkipped: !fxWasHandled && host.fxCount === 1,
-  };
-  // Post rf2-xy4yb: the dedicated Schemas panel was dropped. Post
-  // rf2-gbz39 (Mike RULED Option (c)) the Issues tab was ALSO removed;
-  // schema violations now surface INLINE in the Epoch panel's SIDE
-  // EFFECTS step (rf2-kt6js — `:db` schema-fail projected into the
-  // step) rather than a dedicated Issues feed. The trace assertions
-  // above already verify all four `:where` surfaces fired; here we
-  // verify the focused-cascade round-trip surfaces inline in the Epoch
-  // panel.
-  await clickTab(page, 'epoch', 'rf-xray-epoch-panel');
-  await expectVisible(page.locator('[data-testid="rf-xray-epoch-panel"]'), 5000);
-  const schemaEpochText = ((await page.locator('[data-testid="rf-xray-epoch-panel"]').textContent()) || '').toLowerCase();
-  state.schemaRecovery.epochText = schemaEpochText.slice(0, 800);
-  if (!schemaEpochText.includes('schema') && !schemaEpochText.includes('validation')) {
-    failWithDetails('Epoch panel did not surface the inline schema-validation failure', {
-      epochText: schemaEpochText.slice(0, 800),
-      schemaEvents,
-    });
-  }
-  /* eslint-enable no-unreachable */
 }
 
 async function runHttpToggle(page) {
@@ -3575,17 +3473,15 @@ const SCENARIOS = [
     coveredRows: ['Epoch Panel', 'Trace', 'Effects', 'Flows', 'Machines', 'Open in Editor / Source Coordinates'],
     run: runExceptionSchemaHttp,
   },
-  {
-    name: 'schema violation timeline',
-    url: '/testbeds/schema-violation/',
-    // Post rf2-xy4yb: the dedicated Schemas panel was dropped. Post
-    // rf2-gbz39 (Option (c)) the Issues tab was ALSO removed — schema
-    // violations now surface inline in the Epoch panel's EFFECT HANDLERS
-    // step (rf2-kt6js).
-    panels: ['epoch'],
-    coveredRows: ['Epoch Panel'],
-    run: runSchemaViolation,
-  },
+  // Schema-violation coverage migrated to CLJS unit (rf2-w1mnq, landed
+  // #1753). The browser scenario had been a no-op SKIP since #1745 — its
+  // schema-recovery assertions never ran. Authoritative coverage now lives
+  // in tools/xray/test/.../panels/epoch/projection_cljs_test.cljc: all four
+  // `:where` surfaces (:app-db, :event, :cofx, :fx-args), the `:app-db`
+  // rollback, and the inline SIDE EFFECTS-step synthesis. The Epoch-Panel
+  // matrix row remains covered by other live scenarios (deterministic
+  // exceptions, managed http, multi-frame, hydration mismatch). The
+  // /testbeds/schema-violation/ build remains as a manual-inspection target.
   {
     name: 'managed http and effects rows',
     url: '/testbeds/http-toggle/',


### PR DESCRIPTION
Addresses the four independent best-practice findings in `rf2-sdqsla` (tools/xray). Each was verified against the shipped code before changing.

## Finding 1 — silently-skipped feature-matrix scenario (removed)
`runSchemaViolation` logged `SKIP` and `return`ed before any assertion — dead code since #1745, so the browser gate reported the scenario as present while none of its schema-recovery assertions ran. Its coverage migrated to CLJS unit (`rf2-w1mnq`, landed #1753): `panels/epoch/projection_cljs_test.cljc` covers all four `:where` surfaces (`:app-db`/`:event`/`:cofx`/`:fx-args`), the `:app-db` rollback, and the inline SIDE-EFFECTS-step synthesis. Deleted the scenario fn, its matrix entry, and the now-orphaned `readSchemaHostState` helper. The "Epoch Panel" matrix row stays covered by other live scenarios. The `/testbeds/schema-violation/` build remains as a manual-inspection target.

## Finding 2 — L4 registry accepts non-renderable `:panel` (now rejected)
`reg-l4-tab!` validated every field except `:panel`, so a keyword/map sentinel passed the registry seam and only failed later at `[(:panel tab)]` UI composition. Added `(fn? panel)` to the `:pre`; `fn?` admits the real `reg-view` render fns while rejecting keyword sentinels (which would throw when called with no args). JVM/CLJS tests use `(fn [] nil)` stubs; added explicit reject cases for a missing and a non-callable panel.

## Finding 3 — stale placeholder scaffold (removed)
The `rf2-o5f5f` static-tab roll-out is complete — all 5 tabs ship a real panel — so `placeholder-card` (never rendered) and the `:placeholder-bead` slot (dead metadata) were stale. Removed `placeholder-card`, the `:placeholder-bead` slot from all 5 panel registrations + the registry contract, and the vacuous placeholder tests (`static-placeholder-cards-name-sibling-bead`, `static-placeholder-uses-h2-not-h1`, `static-tab-inventory-machines-bead`). `git grep "placeholder-card|placeholder-bead"` now returns only intentional historical comments.

## Finding 4 — fragmented test reset (consolidated)
Reset was split across `test-support/reset-all!` (sentinels), `trace-collector/reset-for-test!` (rings), and `config/reset-settings!` (settings), so a new test easily omitted one global reset and became order-dependent. Consolidated into a three-tier helper in `test_support.cljs`:
- `reset-sentinels!` — install/registry sentinels only (safe mid-setup)
- `reset-all!` — `+` trace-collector rings (clean-slate, before frame registration)
- `reset-runtime!` — `+` settings/storage

Added `test_support_cljs_test.cljs` regression test (trace-collector bleed + settings reset) and migrated the 11 three-call fixture bundles to the single helper. The e2e harness `install-xray-default!` (which resets mid-setup, host frame already registered) uses `reset-sentinels!` so it does not wipe the live frame's recording config.

## Quality gates
- `clojure -M:test` (tools/xray JVM): **1187 tests, 5272 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node-test CLJS): **7019 tests, 28761 assertions, 0 failures, 0 errors**
- `npm run test:xray-feature-gate` (nightly-full sweep): **Ran 15 Xray feature scenarios. 0 failures. Covered 13 matrix rows** (was 16 scenarios — the dead schema-violation scenario is gone)

Scope notes: did not touch `tools/xray/spec/` (#4116), `implementation/` resources (#4118), `panels/epoch/view.cljs` (l42sg7), or static-machines tests (3t7rs8). `implementation/shadow-cljs.edn` (hot-zone) left untouched — the schema-violation testbed build-id stays.