### PR TITLE
fix(xray): Resources panel runtime completeness (rf2-dh0y8o)

### DIFF
--- a/tools/xray/spec/API.md
+++ b/tools/xray/spec/API.md
@@ -844,6 +844,37 @@ gate is reachable only through the runtime accessors.
 | `get-handlers` | `get-handlers` | `{:ok? true :handlers <vec> :count <n>}` | `rf/registrations` per-kind. Optional `:kind` narrows to one of `:event :sub :fx :cofx :machine :flow :reg-machine :frame :view`. |
 | `get-source-coord` | `get-source-coord` | `{:ok? true :kind <kw> :id <any> :source-coord <map>}` | `rf/handler-meta` projected to `:source-coord`, routed through `egress-value` (rf2-j8b0u — Spec 009's user-supplied `:rf.handler/source` override can stamp arbitrary values into the slot, so the accessor egresses unconditionally rather than judging per-read; `:include-sensitive?` / `:include-large?` opt back in). |
 
+### Resources read band (5 accessors — read-only)
+
+The Resources panel's AI / MCP read API (rf2-dh0y8o). Five read-only
+accessors on `runtime.cljs` that project the resource registry + the
+live per-frame resource-instance cache + the `:rf.resource/*` trace
+family. They apply the two-layer privacy elision documented in
+[`024-Resources-Panel.md`](./024-Resources-Panel.md) §Tool accessors and
+Spec 016 §Xray and AI tooling: the projection always summarizes
+scope/params/data (type + bounded size + redaction-aware preview, never
+the raw value); on top, the payload slots (`:data` / `:error` /
+`:refresh-error` + the key's scope/params) route through the off-box
+`resource-egress-fn` walker so a `:sensitive?` declaration egresses as
+`:rf/redacted` and a `:large?` slot as `:rf.size/large-elided`. The
+non-PII metadata (status / generation / attempt / request-id / owners /
+tags / timestamps) is NEVER redacted, so the status / tag / owner /
+request-id filters work without an opt-in; `:include-runtime-db? true`
+(trusted-local) lifts even a non-declared payload to its raw value.
+`:scope` / `:resource-id` / `:params` filter against the raw cache key
+**before** projection; the remaining axes filter the already-projected
+rows. Per EP-0002 the frame target is carried explicitly — a frameless
+call with no resolvable context fails closed (`{:ok? false :reason
+:no-frame-resolved}`).
+
+| Accessor (fn) | Tool name | Returns | Reads |
+|---|---|---|---|
+| `list-resources` | `list-resources` | `{:ok? true :resources <vec> :count <n>}` | The STATIC resource registry (`rf/registrations :resource` projected via `project-registry`, joined with `:route` registrations): id, source coords, summarized param/data schemas, request summary, stale/GC policy, tag producer, scope policy, sensitivity/large class, declaring routes. Rows carry only static registry facts (no live values), so they egress freely. Filter axis: `:resource-id` (nil lists all). |
+| `list-resource-instances` | `list-resource-instances` | `{:ok? true :frame <id> :instances <vec> :count <n>}` | The LIVE per-frame resource-instance table from the frame's runtime-db at `[:rf.runtime/resources :entries]` (EP-0001 — framework-owned runtime-db state): resource key, scope, status, timestamps, generation, request id, attempt, active owners, tags, data summary, GC eligibility. Filter axes: `:frame` `:scope` `:resource-id` `:params` `:status` `:stale?` `:tag` `:owner` `:request-id`. Payload slots egress per the band's per-slot redaction (rf2-tgm1xu); `:include-sensitive?` / `:include-large?` / `:include-runtime-db?` opt the raw values back in. |
+| `get-resource-state` | `get-resource-state` | `{:ok? true :frame <id> :state <instance-row>}` | The LIVE durable state of ONE resource instance addressed by its scoped key at `[:rf.runtime/resources :entries [scope resource-id params]]` (Spec 016 §Introspection / §Status semantics). Required: `:resource-id` AND `:scope` AND `:params` (the full scoped-key triple); any missing part fails closed with `:reason :missing-key`. `:stale?` / `:has-data?` are derived, not stored. Payload slots egress per the band's per-slot redaction; `:include-runtime-db? true` opts in to the raw payload. |
+| `get-resource-history` | `get-resource-history` | `{:ok? true :frame <id> :history <vec> :count <n>}` | The BOUNDED lifecycle timeline — projects the `:rf.resource/*` trace family out of the frame's trace ring into ordered lifecycle rows (Spec 016 §Xray and AI tooling; history MUST be bounded). Filter axes: `:resource-id` `:nav-token` `:limit` (default 50 — the bound). Whole `:sensitive? true` trace events are default-suppressed at the off-box seam unless `:include-sensitive? true`. |
+| `list-resource-invalidations` | `list-resource-invalidations` | `{:ok? true :frame <id> :invalidations <vec> :count <n>}` | The invalidation / mutation graph — projects the `:rf.resource/invalidated` trace rows: summarized scope, invalidated tags, summarized cause, matched scoped keys, refetch count (distinguishes a broad-tag storm by high `:match-count` from a zero-match invalidation, `:match-count 0`). Filter axis: `:tag` (only invalidations touching the tag). Whole `:sensitive? true` events default-suppressed unless `:include-sensitive? true`. |
+
 ### Mutation band (3 accessors — write)
 
 | Accessor (fn) | Tool name | Returns | Behaviour |

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -3,12 +3,14 @@
 
   Pins the load-bearing contracts the F-4 port lands:
 
-    1. **Eighteen tool-shaped accessors.** Each MCP tool in
-       `tools/xray/spec/010-MCP-Server.md` §Tool catalogue maps to
+    1. **Twenty-three tool-shaped accessors.** Each accessor in
+       `tools/xray/spec/API.md` §Runtime accessor surface maps to
        exactly one runtime fn; the lint here enumerates and asserts
        every one is `fn?`. Drift between the catalogue and the
        runtime surface fails this test first, before any tool dispatch
-       round-trip would notice.
+       round-trip would notice. The five-accessor Resources read band
+       is enumerated in `tools/xray/spec/024-Resources-Panel.md`
+       §Tool accessors (rf2-dh0y8o).
     2. **Session sentinel.** `session-id` is a non-empty string and a
        mirror lands at `js/globalThis.__day8_re_frame2_xray_runtime`
        (under node-test the global is the Node global; we exercise it
@@ -66,12 +68,12 @@
      :init-fn runtime-init!}))
 
 ;; ---------------------------------------------------------------------------
-;; (1) Eighteen tool-shaped accessors are resolvable.
+;; (1) Twenty-three tool-shaped accessors are resolvable.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private tool-accessor-vars
-  "The canonical eighteen tool-shaped accessors per
-  `tools/xray/spec/010-MCP-Server.md` §Tool catalogue. Order matches
+  "The canonical twenty-three tool-shaped accessors per
+  `tools/xray/spec/API.md` §Runtime accessor surface. Order matches
   the catalogue band split for readability — change here only when
   the catalogue changes (and update the count assertion below).
 
@@ -90,6 +92,12 @@
    ['get-issues          runtime/get-issues]
    ['get-handlers        runtime/get-handlers]
    ['get-source-coord    runtime/get-source-coord]
+   ;; Resources read (5) — rf2-dh0y8o
+   ['list-resources              runtime/list-resources]
+   ['list-resource-instances     runtime/list-resource-instances]
+   ['get-resource-state          runtime/get-resource-state]
+   ['get-resource-history        runtime/get-resource-history]
+   ['list-resource-invalidations runtime/list-resource-invalidations]
    ;; Mutation (3)
    ['dispatch!           runtime/dispatch!]
    ['restore-epoch!      runtime/restore-epoch!]
@@ -104,11 +112,13 @@
    ['health              runtime/health]
    ['tail-build-probe    runtime/tail-build-probe]])
 
-(deftest eighteen-tool-accessors-exist
+(deftest twenty-three-tool-accessors-exist
   (testing "every catalogue tool has a runtime-side accessor — drift
-            between the eighteen MCP tools and this ns fails here first"
-    (is (= 18 (count tool-accessor-vars))
-        "the canonical list is the eighteen-tool catalogue")
+            between the MCP tools and this ns fails here first"
+    (is (= 23 (count tool-accessor-vars))
+        "the canonical list is the twenty-three-tool catalogue
+         (9 inspection + 5 resources + 3 mutation + 3 streaming +
+         1 escape + 2 meta)")
     (doseq [[sym f] tool-accessor-vars]
       (is (fn? f)
           (str "accessor not callable: day8.re-frame2-xray.runtime/" sym)))))


### PR DESCRIPTION
Closes rf2-dh0y8o.

## What

The stable Xray runtime/MCP accessor catalogue (`tools/xray/spec/API.md`
§Runtime accessor surface) and its guard test
(`runtime_cljs_test.cljs`) omitted the shipped Resources read API — the
five read-only accessors already implemented on `runtime.cljs`:
`list-resources`, `list-resource-instances`, `get-resource-state`,
`get-resource-history`, `list-resource-invalidations`. Tool implementers
could miss the Resources surface, and future deletion/rename drift would
not fail the catalogue guard.

## Changes

- **`tools/xray/spec/API.md`** — add a "Resources read band (5
  accessors — read-only)" subsection to §Runtime accessor surface
  (slotted after the Inspection band, before Mutation). Each row gives
  the accessor fn, tool name, returns shape, reads source, and filter
  axes; the band intro documents the two-layer privacy elision
  (always-summarize + per-slot `resource-egress-fn` redaction with the
  `:include-sensitive?` / `:include-large?` / `:include-runtime-db?`
  opt-ins) and the fail-closed frame contract, cross-referencing
  `024-Resources-Panel.md` §Tool accessors and Spec 016.
- **`runtime_cljs_test.cljs`** — add the five resource accessors to
  `tool-accessor-vars` (new "Resources read (5)" block); bump the
  accessor-count assertion **18 → 23** (9 inspection + 5 resources + 3
  mutation + 3 streaming + 1 escape + 2 meta); rename the deftest +
  docstrings; retarget the stale `010-MCP-Server.md` references (that
  file was removed) to `API.md` §Runtime accessor surface and
  `024-Resources-Panel.md`.

## Acceptance criteria (per bead)

- [x] API.md lists `list-resources`, `list-resource-instances`,
  `get-resource-state`, `get-resource-history`,
  `list-resource-invalidations`.
- [x] `tool-accessor-vars` includes those five resource accessors.
- [x] The accessor-count assertion reflects the new total (23).
- [x] Runtime tests pass.

Each of the five accessors was verified against the shipped
`runtime.cljs` implementation (all public `defn`, `Tool:`-tagged) before
documenting; the returns shapes / filter axes / privacy posture are
transcribed from the implementations and reconciled with
`024-Resources-Panel.md`.

## Quality gates

- `clojure -M:test` (tools/xray): **1188 tests, 5281 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node-runtime): **7050 tests, 28851 assertions, 0 failures, 0 errors**
- `npm run test:xray-feature-gate`: **16 scenarios, 0 failures, 13 matrix rows covered**
