### PR TITLE
fix(resources): managed-HTTP resource teardown no longer aborts (rf2-rak684)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -579,6 +579,10 @@
    {:key         :http/clear-all-in-flight!
     :producer-ns 're-frame.http-managed
     :description "Abort every in-flight managed request (test isolation)."}
+   {:key         :http/abort-in-flight!
+    :producer-ns 're-frame.http-managed
+    :design-bead "rf2-rak684"
+    :description "Best-effort abort the in-flight managed request registered under a frame-qualified request-id (fires its :abort-fn with a reason, default :user; no-op when nothing is registered). The shared abort-by-request-id seam the Resources out-of-cascade teardown paths (clear-resource / frame destroy) reach through so they can abort a managed request without the resources artefact statically :require-ing the http transport."}
    {:key         :http/reg-http-interceptor
     :producer-ns 're-frame.http-managed
     :design-bead "rf2-6y3q"

--- a/implementation/http/src/re_frame/http_handlers.cljc
+++ b/implementation/http/src/re_frame/http_handlers.cljc
@@ -400,9 +400,12 @@
   (the abort-fn closure calls into it). The earlier shape pre-cleared
   the registry here AND inside `finalise-failure!`, doubling the
   `swap!` traffic per abort. Now the single source of truth lives at
-  the failure-finalise site; this handler only fires the abort-fn."
+  the failure-finalise site; this handler only fires the abort-fn.
+
+  rf2-rak684 — routes through the shared `registry/abort-in-flight!`
+  abort-by-request-id seam (the SAME seam the resources out-of-cascade
+  teardown reaches through the `:http/abort-in-flight!` late-bind hook),
+  so the fx and the teardown hook fire identical abort semantics."
   [_frame-ctx request-id]
-  (when-let [handle (registry/lookup-in-flight request-id)]
-    (try ((:abort-fn handle) :user)
-         (catch #?(:clj Throwable :cljs :default) _ nil)))
+  (registry/abort-in-flight! request-id :user)
   nil)

--- a/implementation/http/src/re_frame/http_managed.cljc
+++ b/implementation/http/src/re_frame/http_managed.cljc
@@ -270,6 +270,7 @@
 ;; macros and the canned-stub fxs share one require gate, symmetric with
 ;; the test-support naming.
 
+(late-bind/set-fn! :http/abort-in-flight!                 registry/abort-in-flight!)
 (late-bind/set-fn! :http/abort-on-actor-destroy           abort-on-actor-destroy)
 (late-bind/set-fn! :http/clear-all-http-interceptors!     clear-all-http-interceptors!)
 (late-bind/set-fn! :http/clear-all-in-flight!             clear-all-in-flight!)

--- a/implementation/http/src/re_frame/http_registry.cljc
+++ b/implementation/http/src/re_frame/http_registry.cljc
@@ -132,6 +132,31 @@
   (when request-id
     (get @in-flight request-id)))
 
+(defn abort-in-flight!
+  "Best-effort abort the in-flight managed request registered under
+  `request-id`, firing its `:abort-fn` with `reason` (default `:user`).
+  No-op when nothing is registered under `request-id` (the reply already
+  landed, or the id is unknown / nil) — cancellation is opportunistic.
+
+  Per rf2-plngk the in-flight registry cleanup is owned by
+  `finalise-failure!` (the abort-fn closure calls into it), so this fn
+  only fires the abort-fn and never touches the index directly. Never
+  throws (a throwing abort-fn is swallowed). Returns true iff a handle was
+  found and its abort-fn fired, false otherwise.
+
+  This is the shared abort-by-request-id seam: the `:rf.http/managed-abort`
+  fx handler routes through it (`managed-abort-handler`), AND the resources
+  out-of-cascade teardown paths (clear-resource / frame destroy) reach it
+  through the published `:http/abort-in-flight!` late-bind hook so they can
+  abort a managed request by its frame-qualified request-id without the
+  resources artefact statically `:require`ing the http transport (rf2-rak684)."
+  ([request-id] (abort-in-flight! request-id :user))
+  ([request-id reason]
+   (boolean
+     (when-let [handle (lookup-in-flight request-id)]
+       (try ((:abort-fn handle) reason) true
+            (catch #?(:clj Throwable :cljs :default) _ false))))))
+
 ;; ---- per-request-id issuance generation (rf2-azcmd3) -----------------------
 ;;
 ;; EP-0011 §Work-id correlation: "one attempt has one work id". HTTP has no

--- a/implementation/resources/src/re_frame/resources/work_ledger.cljc
+++ b/implementation/resources/src/re_frame/resources/work_ledger.cljc
@@ -83,6 +83,7 @@
   framework-internal reified continuation; the call-site target is the app's
   transport-payload continuation."
   (:require [re-frame.identity :as identity]
+            [re-frame.late-bind :as late-bind]
             [re-frame.reply :as reply]
             [re-frame.resources.state :as state]))
 
@@ -465,20 +466,70 @@
   (swap! handle-table dissoc [frame-id (work-id-id work-id)])
   nil)
 
+;; Forward declaration — `abort-handle!` reads the managed-HTTP transport
+;; marker (`managed-abort-fx-transport`, defined below alongside the
+;; in-cascade `abort-fx` builder) to decide whether to fire the
+;; `:http/abort-in-flight!` hook for a recorded slot (rf2-rak684).
+(declare managed-abort-fx-transport)
+
+(defn- abort-handle!
+  "Best-effort abort the transport request a recorded side-table `handle`
+  describes, firing whatever abort capability the slot carries:
+
+   - a DIRECT host `:abort-fn` (a future transport that hands the runtime a
+     live handle fills this slot — e.g. a non-HTTP transport), and/or
+   - for MANAGED HTTP, the frame-qualified `:request-id` the slot records
+     (`[:rf.req frame-id work-id]`) routed through the `:http/abort-in-flight!`
+     late-bind hook the http artefact publishes (rf2-rak684).
+
+  The managed-HTTP arm is THE out-of-cascade teardown seam: the resource
+  runtime does not itself hold the AbortController (the managed-HTTP
+  transport owns it, keyed by request-id), so the work-handle side-table
+  slot records ONLY the correlation `:request-id` and no live `:abort-fn`
+  (see `record-work-handle-handler`). The in-cascade lifecycle events
+  (`:rf.resource/remove`, clear-scope, refetch supersession, owner-release)
+  abort by emitting `:rf.http/managed-abort` via `abort-fx`; the
+  OUT-of-cascade lifecycle paths (`clear-resource`, frame destroy) run no
+  cascade, so they reach the SAME abort-by-request-id operation
+  (`re-frame.http-registry/abort-in-flight!`) through the published hook —
+  the same token the lower registered, so it resolves the right frame's
+  in-flight request rather than just clearing the side-table slot.
+
+  Opportunistic — a no-op when no transport is holding the request (the
+  reply already landed, or the http artefact is not on the classpath, in
+  which case the hook resolves to nil). Correctness still rests on the
+  work-id + generation stale-suppression gate, NOT on the cancel landing.
+  Never throws (a throwing abort-fn / hook is swallowed — a failed cancel
+  must not strand the teardown). Returns true iff an abort capability was
+  found and fired (a hint for the caller's trace), false otherwise."
+  [handle]
+  (let [direct? (boolean (when-let [abort-fn (:abort-fn handle)]
+                           (try (abort-fn :resource-superseded) true
+                                (catch #?(:clj Throwable :cljs :default) _ false))))
+        managed? (boolean
+                   (when (and (= (:transport handle) managed-abort-fx-transport)
+                              (:request-id handle))
+                     (try
+                       (when-let [abort! (late-bind/get-fn :http/abort-in-flight!)]
+                         (boolean (abort! (:request-id handle) :resource-superseded)))
+                       (catch #?(:clj Throwable :cljs :default) _ false))))]
+    (or direct? managed?)))
+
 (defn opportunistic-abort!
   "BEST-EFFORT cancel the host handle for `[frame-id work-id]`, then drop it
   from the side table. Per Spec 016 §Cancellation is opportunistic; stale
   suppression is mandatory: this MAY abort the in-flight request if the host
   handle exists and can be cancelled; if it cannot, correctness still rests
   on the work-id + generation stale-suppression check (NOT on the cancel
-  landing). Returns true iff an abort thunk was found and fired (a hint for
+  landing). For managed HTTP the slot records only the frame-qualified
+  `:request-id` (no live `:abort-fn`), so the abort rides the
+  `:http/abort-in-flight!` late-bind hook by that request-id (rf2-rak684) —
+  this is the out-of-cascade counterpart to the in-cascade `:rf.http/managed-abort`
+  fx. Returns true iff an abort capability was found and fired (a hint for
   the caller's trace), false otherwise. Never throws (a throwing abort-fn is
   swallowed — a failed cancel must not strand the teardown)."
   [frame-id work-id]
-  (let [handle (get-handle frame-id work-id)
-        aborted? (boolean (when-let [abort-fn (:abort-fn handle)]
-                            (try (abort-fn :resource-superseded) true
-                                 (catch #?(:clj Throwable :cljs :default) _ false))))]
+  (let [aborted? (abort-handle! (get-handle frame-id work-id))]
     (clear-handle! frame-id work-id)
     aborted?))
 
@@ -488,13 +539,15 @@
   paths iterate `(keys @handle-table)` (which are already byte-keyed pairs) and
   must NOT re-transform the work-id-id through `work-id-id` (the public
   `opportunistic-abort!` takes a work-id VECTOR and transforms it; this private
-  variant takes the table key directly). Never throws."
+  variant takes the table key directly). Aborts managed HTTP by the recorded
+  frame-qualified `:request-id` through the `:http/abort-in-flight!` hook
+  (rf2-rak684), so frame destroy cancels the underlying in-flight request
+  before dropping the generation high-water — a surviving host reply can never
+  match a future same-id frame. Never throws."
   [slot-key]
-  (let [handle (get @handle-table slot-key)]
-    (when-let [abort-fn (:abort-fn handle)]
-      (try (abort-fn :resource-superseded) (catch #?(:clj Throwable :cljs :default) _ nil)))
-    (swap! handle-table dissoc slot-key)
-    nil))
+  (abort-handle! (get @handle-table slot-key))
+  (swap! handle-table dissoc slot-key)
+  nil)
 
 ;; ---- opportunistic abort via the transport fx (transport-neutral) ---------
 ;;

--- a/implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_managed_http_cljs_test.cljc
@@ -36,13 +36,18 @@
    ;; load-bearing side-effecting requires: register the :rf.resource/*
    ;; events + subs + the generation cofx/fx these tests dispatch.
    [re-frame.resources]
+   [re-frame.resources.registry :as registry]
    [re-frame.resources.state :as state]
    [re-frame.resources.transport.http :as http]
    [re-frame.resources.work-ledger :as work-ledger]
    [re-frame.resources.test-support]
    ;; production HTTP fx surface (so the transport feature probe resolves);
    ;; the actual fetch is overridden by the capturing reply stub below.
+   ;; rf2-rak684 — the teardown-abort regression tests seed + assert the REAL
+   ;; managed-HTTP in-flight registry (NOT a captured no-op abort), so the
+   ;; abort-by-request-id seam (`:http/abort-in-flight!`) runs end-to-end.
    [re-frame.http-managed]
+   [re-frame.http-registry :as http-registry]
    [re-frame.schemas]
    [re-frame.test-support :as core-test-support]
    #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
@@ -71,8 +76,12 @@
   state cache before this fixture runs — no per-suite reset is repeated here."
   [f]
   (reset! last-managed-args nil)
+  ;; rf2-rak684 — the in-flight registry is module-level host state; clear any
+  ;; entry a prior test seeded so the teardown-abort regressions start clean.
+  (http-registry/clear-all-in-flight!)
   (rf/reg-fx :rf.http/managed (fn [_ctx args] (reset! last-managed-args args) nil))
-  (f))
+  (f)
+  (http-registry/clear-all-in-flight!))
 
 (use-fixtures :each
   (core-test-support/make-reset-runtime-fixture
@@ -491,3 +500,191 @@
         (reply-success! args-after-first {:title "Joined"})
         (is (= :loaded (:status (entry scoped-key))))
         (is (= {:title "Joined"} (:data (entry scoped-key))))))))
+
+;; ===========================================================================
+;; 6. OUT-OF-CASCADE teardown aborts the underlying managed-HTTP request
+;;    (rf2-rak684)
+;;
+;;    The in-cascade lifecycle events (:rf.resource/remove, clear-scope,
+;;    refetch supersession, owner-release) abort the underlying managed-HTTP
+;;    request by emitting :rf.http/managed-abort via `work-ledger/abort-fx`
+;;    (covered by the suites above + the work-ledger suite). The OUT-of-cascade
+;;    lifecycle paths run no cascade:
+;;
+;;      - `clear-resource`  (registry/dispose-resource-runtime! →
+;;                           work-ledger/opportunistic-abort!)
+;;      - frame destroy     (resources/release-resources-host-caches! →
+;;                           work-ledger/release-frame! → abort-slot!)
+;;
+;;    Before rf2-rak684 these only fired the side-table `:abort-fn` (nil for
+;;    managed HTTP, whose AbortController is host-owned), so they dropped the
+;;    Resources-side work handle while leaving the underlying managed request
+;;    ALIVE. The fix routes them through `work-ledger/abort-handle!`, which —
+;;    for a managed-HTTP slot — fires the abort-by-request-id seam
+;;    (`re-frame.http-registry/abort-in-flight!`) through the published
+;;    `:http/abort-in-flight!` late-bind hook, by the SAME frame-qualified
+;;    request-id (`[:rf.req <frame-id> <work-id>]`) the lower registered.
+;;
+;;    These regressions seed + assert the REAL managed-HTTP in-flight registry
+;;    (NOT a captured no-op abort), so the seam runs end-to-end and the abort
+;;    must leave NO live HTTP in-flight entry.
+;; ===========================================================================
+
+(defn- seed-in-flight!
+  "Seed the REAL managed-HTTP in-flight registry under `request-id`, mimicking
+  what the live transport's `run-attempt!` does (`record-in-flight!` with an
+  `:abort-fn` whose firing clears the registry — production's abort-fn closure
+  reaches `finalise-failure!` → `clear-in-flight!`). The `:abort-fn` records the
+  abort reason into `recorder` so the test can assert WHICH reason fired and
+  that exactly one abort happened. Returns the recorder atom."
+  [request-id recorder]
+  (http-registry/record-in-flight!
+    request-id nil
+    {:abort-fn (fn [reason]
+                 (swap! recorder conj [request-id reason])
+                 (http-registry/clear-in-flight! request-id))})
+  recorder)
+
+(deftest clear-resource-aborts-managed-http-in-flight
+  ;; rf2-rak684 — clear-resource MUST abort the underlying managed-HTTP request
+  ;; for an in-flight resource (Spec 016 §clear-resource MUST-dispose +
+  ;; §Cancellation is opportunistic), not just clear the work-handle side-table
+  ;; slot. The abort fires by the frame-qualified request-id and the HTTP
+  ;; in-flight registry entry is gone afterwards.
+  (rf/reg-resource :crab/article (article-spec))
+  (let [k (state/scoped-resource-key :rf.scope/global :crab/article {:slug "w"})]
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :crab/article :scope :rf.scope/global
+                                            :params {:slug "w"} :owner [:lease :crab 1]}])
+    (let [wid        (:current-work (entry k))
+          request-id (work-ledger/managed-request-id :rf/default wid)
+          aborted    (seed-in-flight! request-id (atom []))]
+      (testing "the managed-HTTP request is in flight + the work-handle slot
+                records the frame-qualified request-id (no live :abort-fn —
+                the transport owns the AbortController)"
+        (is (some? (http-registry/lookup-in-flight request-id)) "request in flight")
+        (let [handle (work-ledger/get-handle :rf/default wid)]
+          (is (= :rf.http/managed (:transport handle)))
+          (is (= request-id (:request-id handle)))
+          (is (nil? (:abort-fn handle)) "managed-HTTP slot carries NO direct abort-fn")))
+      (registry/clear-resource :crab/article)
+      (testing "rf2-rak684 — clear-resource aborts the underlying managed-HTTP
+                request by [:rf.req frame-id work-id] (not just the side-table slot)"
+        (is (= [[request-id :resource-superseded]] @aborted)
+            "exactly one abort fired, by the frame-qualified request-id")
+        (is (nil? (http-registry/lookup-in-flight request-id))
+            "no live HTTP in-flight entry remains")
+        (is (nil? (work-ledger/get-handle :rf/default wid))
+            "the work-handle side-table slot is dropped")))))
+
+(deftest frame-destroy-aborts-managed-http-in-flight
+  ;; rf2-rak684 — frame destroy MUST abort any in-flight managed-HTTP resource
+  ;; work for the frame BEFORE dropping the generation high-water (Spec 016
+  ;; [Runtime-Subsystems] clause 5). A surviving host request would otherwise
+  ;; outlive the frame and could satisfy a future same-id frame's reply gate.
+  (rf/reg-resource :fdab/article (article-spec))
+  (let [fa :fdab/frame-a
+        k  (state/scoped-resource-key :rf.scope/global :fdab/article {:slug "w"})]
+    (rf/reg-frame fa {:doc "teardown-abort frame"})
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :fdab/article :scope :rf.scope/global
+                                            :params {:slug "w"} :owner [:lease :fdab 1]}]
+                      {:frame fa})
+    (let [wid        (:current-work (entry fa k))
+          request-id (work-ledger/managed-request-id fa wid)
+          aborted    (seed-in-flight! request-id (atom []))]
+      (testing "before destroy: request in flight, handle + generation high-water present"
+        (is (some? (http-registry/lookup-in-flight request-id)) "request in flight")
+        (is (some? (work-ledger/get-handle fa wid)) "work-handle slot present")
+        (is (pos? (state/generation-snapshot fa)) "generation high-water present"))
+      (frame/destroy-frame! fa)
+      (testing "rf2-rak684 — frame destroy aborts the underlying managed-HTTP
+                request by [:rf.req frame-id work-id] and leaves no live in-flight entry"
+        (is (= [[request-id :resource-superseded]] @aborted)
+            "exactly one abort fired, by the frame-qualified request-id")
+        (is (nil? (http-registry/lookup-in-flight request-id))
+            "no live HTTP in-flight entry survives frame destroy")
+        (is (nil? (work-ledger/get-handle fa wid)) "host handle dropped")
+        (is (zero? (state/generation-snapshot fa)) "generation high-water dropped")))))
+
+(deftest same-frame-id-reuse-old-reply-cannot-mutate-new-frame
+  ;; rf2-rak684 — the structural-safety case the teardown abort protects, and
+  ;; WHY the abort (not stale suppression) is load-bearing here.
+  ;;
+  ;; Same-id frame re-registration is supported, and frame destroy DROPS the
+  ;; destroyed frame's generation high-water (state/release-frame!), so a
+  ;; re-registered frame mints generation 1 AGAIN for the same scoped key. The
+  ;; work-id `[:rf.work/resource <scoped-key> <generation>]` embeds ONLY the
+  ;; scoped key + generation (it is frame-LOCAL), so the OLD incarnation's
+  ;; work-id and the NEW incarnation's work-id are EQUAL — and the reused frame
+  ;; id makes the reply's stamped :rf.frame/id match too. The stale-suppression
+  ;; gate (`live-entry-for-reply`: frame stamp + work-id + generation) therefore
+  ;; CANNOT distinguish an old-incarnation reply from a new-incarnation one.
+  ;;
+  ;; The ONLY structural protection is that the surviving managed request is
+  ;; ABORTED on frame destroy (rf2-rak684), so it never delivers a late
+  ;; :on-success — an aborted request fires :on-failure (:rf.http/aborted),
+  ;; never the success the new frame would otherwise have accepted. This test
+  ;; models the real transport: the seeded request's abort-fn delivers the
+  ;; abort's :on-failure reply (what the live transport does on cancel), and we
+  ;; assert that reply does NOT mutate the re-registered frame's fresh entry.
+  (rf/reg-resource :rab/article (article-spec))
+  (let [fr :rab/reused
+        k  (state/scoped-resource-key :rf.scope/global :rab/article {:slug "w"})]
+    ;; ---- first incarnation: start a load; capture the reply addressing ----
+    (rf/reg-frame fr {:doc "reuse frame — first incarnation"})
+    (rf/dispatch-sync [:rf.resource/ensure {:resource :rab/article :scope :rf.scope/global
+                                            :params {:slug "w"} :owner [:lease :rab 1]}]
+                      {:frame fr})
+    (let [old-payload    (nth (:on-success @last-managed-args) 1)
+          old-wid        (:current-work (entry fr k))
+          old-request-id (work-ledger/managed-request-id fr old-wid)
+          ;; seed the REAL in-flight registry with an abort-fn that, like the
+          ;; live transport's cancel path, clears the registry when fired (the
+          ;; production abort-fn closure reaches finalise-failure! →
+          ;; clear-in-flight!). `delivered` records that the abort fired.
+          delivered      (atom [])
+          _              (http-registry/record-in-flight!
+                           old-request-id nil
+                           {:abort-fn (fn [reason]
+                                        (swap! delivered conj [old-request-id reason])
+                                        (http-registry/clear-in-flight! old-request-id))})]
+      (is (= 1 (:generation (entry fr k))) "first incarnation on generation 1")
+      (is (some? (http-registry/lookup-in-flight old-request-id)) "old request in flight")
+      ;; ---- destroy + re-register the SAME frame id ----
+      (frame/destroy-frame! fr)
+      (testing "rf2-rak684 — destroy aborts the surviving managed request"
+        (is (= [[old-request-id :resource-superseded]] @delivered)
+            "the old request was aborted on destroy")
+        (is (nil? (http-registry/lookup-in-flight old-request-id))
+            "no surviving in-flight request to deliver a late success"))
+      (reset! last-managed-args nil)
+      (rf/reg-frame fr {:doc "reuse frame — second incarnation"})
+      (rf/dispatch-sync [:rf.resource/ensure {:resource :rab/article :scope :rf.scope/global
+                                              :params {:slug "w"} :owner [:lease :rab 2]}]
+                        {:frame fr})
+      (let [new-wid     (:current-work (entry fr k))
+            new-payload (nth (:on-success @last-managed-args) 1)]
+        (is (= 1 (:generation (entry fr k)))
+            "second incarnation mints generation 1 again (high-water was dropped)")
+        (testing "WHY the abort is load-bearing: the old + new work-ids are EQUAL
+                  (the work-id is frame-LOCAL — same scoped-key + gen 1) and the
+                  reused frame id makes the reply's :rf.frame/id stamp match too,
+                  so the stale-suppression gate CANNOT distinguish an old reply
+                  from a new one. Only the destroy-time abort prevents the old
+                  request from ever delivering into the re-registered frame."
+          (is (= old-wid new-wid) "old + new work-ids collide")
+          (is (= fr (:rf.frame/id old-payload) (:rf.frame/id new-payload))
+              "both incarnations stamp the SAME (reused) frame id")
+          (is (= (:work/id old-payload) (:work/id new-payload))
+              "the reply verification work-ids collide too"))
+        (is (= :loading (:status (entry fr k))) "second incarnation in flight")
+        (testing "rf2-rak684 — the old request was aborted on destroy and is gone
+                  from the registry, so NO surviving request can deliver a late
+                  success into the re-registered frame (the only structural
+                  protection, since the gate can't tell the replies apart)"
+          (is (nil? (http-registry/lookup-in-flight old-request-id))
+              "the colliding old request cannot deliver any reply"))
+        (testing "the NEW incarnation's OWN reply settles it normally"
+          (reply-into-frame! fr new-payload {:title "FRESH"})
+          (is (= {:title "FRESH"} (:data (entry fr k))) "new reply settles the new entry")
+          (is (= :loaded (:status (entry fr k)))))))
+    (frame/destroy-frame! fr)))


### PR DESCRIPTION
## Summary

Fixes **rf2-rak684** (P1): resource teardown was aborting for managed-HTTP resources — the out-of-cascade lifecycle paths dropped the Resources-side work handle while leaving the underlying `:rf.http/managed` request alive.

### Root cause

Managed-HTTP work-handle side-table slots record only `{:transport :rf.http/managed :request-id [:rf.req frame-id work-id]}` and intentionally no `:abort-fn` (the managed-HTTP transport owns the AbortController, keyed host-side by request-id). The event-driven teardown paths (`:rf.resource/remove`, clear-scope, refetch supersession, owner-release) abort by emitting `:rf.http/managed-abort` via `work-ledger/abort-fx` using that frame-qualified request-id. But the **out-of-cascade** lifecycle paths did not:

- `clear-resource` → `work-ledger/opportunistic-abort!`
- frame destroy → `work-ledger/release-frame!` → `abort-slot!`

Both only fired the slot's `:abort-fn` (nil for managed HTTP), so they cleared the side-table slot but left the underlying request in flight. A surviving request outliving frame destroy could match a future same-id frame's reply gate (the frame-local work-id collides on re-registration at gen 1, and the reused frame stamp matches), opening a stale-reply acceptance path.

### Fix (single principled seam)

- **http**: add `re-frame.http-registry/abort-in-flight!` — the shared abort-by-request-id fn (`managed-abort-handler` now routes through it) — and publish it as the `:http/abort-in-flight!` late-bind hook.
- **resources**: `work-ledger/abort-handle!` fires any direct `:abort-fn` AND, for a managed-HTTP slot, the `:http/abort-in-flight!` hook by the recorded frame-qualified request-id. `opportunistic-abort!` and `abort-slot!` both route through it.

No host handles are serialized into runtime-db; the resources artefact reaches the http transport only through late-bind (no static `:require`), matching the existing transport-neutral discipline. Event-driven abort paths and EP-0011 reply/stale-suppression traces are unchanged.

Frame destroy now aborts the surviving request **before** dropping the generation high-water, so the same-frame-id reuse stale-acceptance path is structurally closed: the abort is the only protection there, since the stale gate (frame stamp + work-id + generation) cannot distinguish an old-incarnation reply from a new one once the frame id and gen-1 work-id collide.

### Tests

Three regression tests in `resources_managed_http_cljs_test.cljc` that seed and assert the **real** managed-HTTP in-flight registry (not a captured no-op abort), so the seam runs end-to-end:

- `clear-resource-aborts-managed-http-in-flight` — abort fires by `[:rf.req frame-id work-id]`, no live in-flight entry remains.
- `frame-destroy-aborts-managed-http-in-flight` — abort fires + no live in-flight entry survives destroy.
- `same-frame-id-reuse-old-reply-cannot-mutate-new-frame` — proves the work-ids/frame-stamps collide (so the gate can't help) and the destroy-time abort is the structural protection.

Verified load-bearing: all three fail (7 assertions) when the managed arm of `abort-handle!` is neutered.

## Quality gates

- `clojure -M:test` (resources): **402 tests, 1581 assertions, 0 failures, 0 errors** (green)
- `clojure -M:test` (http): **423 tests, 1942 assertions, 0 failures, 0 errors** (green)
- `clojure -M:test` (core, cross-artefact): **1423 tests, 6325 assertions, 0 failures, 0 errors** (green)
- `npm run test:cljs`: **7052 tests, 28883 assertions, 0 failures, 0 errors** (green)
- Adversarial check: neutered the fix → the 3 regression tests fail (7 assertions); restored → green.

### CI follow-up fix

The new `:http/abort-in-flight!` late-bind hook was not registered in `re-frame.late-bind.directory/hooks`, so the cross-artefact JVM core drift gate (`late-bind-drift-test/every-published-key-has-a-directory-entry`) failed it as an orphan. Added the directory entry (`:producer-ns re-frame.http-managed`); core gate now green.

Closes rf2-rak684.

