### PR TITLE
fix(adapters): UIx/Helix use-subscribe honors frame-resolution chain (rf2-4mi2zj)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -33,6 +33,7 @@
             [helix.dom  :as d]
             [helix.hooks :as helix-hooks]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.adapter.helix :as helix-adapter]
             [re-frame.adapter.react-shared-suite :as suite]
             [re-frame.test-support :as test-support]))
@@ -153,6 +154,13 @@
    :probe-frame-provider-observed probe-frame-provider-observed
    :frame-provider-frame          :rf.helix-use-subscribe-test/frame-provider-frame
    :frame-provider-query          :rf.helix-use-subscribe-test/k
+   ;; rf2-4mi2zj — 1-arg full frame-resolution chain (reuses ProbeFrameProvider
+   ;; + :frame-provider-query :k; isolated frame ids per case).
+   :provider-tier-frame               :rf.helix-4mi2zj/provider-tier-frame
+   :dynamic-precedence-provider-frame :rf.helix-4mi2zj/precedence-provider-frame
+   :dynamic-precedence-dynamic-frame  :rf.helix-4mi2zj/precedence-dynamic-frame
+   :no-scope-frame                    :rf.helix-4mi2zj/no-scope-frame
+   :substrate-kw                      :helix
    ;; 2-arg explicit pin
    :probe-2arg-element    (fn [] ($ :div ($ Probe2ArgA) ($ Probe2ArgB)))
    :probe-2arg-a-observed probe-2arg-a-observed
@@ -191,6 +199,17 @@
 
 (deftest use-subscribe-2-arg-pins-explicit-frame
   (suite/assert-use-subscribe-2-arg-pins-explicit-frame cfg))
+
+;; rf2-4mi2zj — 1-arg full frame-resolution chain (the bug: spine fed the
+;; raw use-context read into the explicit 2-arg path, bypassing the chain).
+(deftest use-subscribe-provider-tier-resolution-ambient-cleared
+  (suite/assert-use-subscribe-provider-tier-resolution-ambient-cleared cfg))
+
+(deftest use-subscribe-dynamic-var-precedence-over-provider
+  (suite/assert-use-subscribe-dynamic-var-precedence-over-provider cfg))
+
+(deftest use-subscribe-no-provider-no-dynamic-raises-no-frame-context
+  (suite/assert-use-subscribe-no-provider-no-dynamic-raises-no-frame-context cfg))
 
 (deftest use-subscribe-cleanup-decrements-sub-cache-refcount
   (suite/assert-use-subscribe-cleanup-decrements-refcount cfg))
@@ -293,28 +312,34 @@
           (is true "act() not reachable from this runner; skipping")
           (let [frame-kw :rf.helix-use-subscribe-test/frame-provider-frame
                 query-v  [:rf.helix-use-subscribe-test/k]]
-            (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
-            (reset! probe-frame-provider-observed [])
-            (rf/reg-frame frame-kw {:doc "rf2-7kii2 trailing-children frame-provider probe"})
-            (rf/reg-event-db ::dollar-shape-seed (fn [_ _] {:k :wrapped}))
-            (rf/dispatch-sync [::dollar-shape-seed] {:frame frame-kw})
-            (rf/reg-sub (first query-v) (fn [db _] (:k db)))
-            (let [mount-node (.createElement js/document "div")
-                  root       (react-dom-client/createRoot mount-node)]
-              (try
-                (act-fn
-                  (fn []
-                    ;; The idiomatic public call shape — TWO native trailing
-                    ;; children (no `:children` key), flowing through Helix's
-                    ;; `$` → `extract-cljs-props` → the native `defnc` shell.
-                    (.render root
-                      ($ helix-adapter/frame-provider
-                         {:frame frame-kw}
-                         ($ ProbeFrameProvider)
-                         ($ ProbeFrameProvider)))))
-                (is (some #{:wrapped} @probe-frame-provider-observed)
-                    "trailing children's use-subscribe read the wrapped frame's value, not :rf/default")
-                (is (= 2 (count (filterv #{:wrapped} @probe-frame-provider-observed)))
-                    "both trailing children rendered (not dropped)")
-                (finally
-                  (try (.unmount root) (catch :default _ nil)))))))))))
+            ;; rf2-4mi2zj: clear the fixture's ambient `:rf/default` dynamic
+            ;; scope so the 1-arg `use-subscribe` in ProbeFrameProvider
+            ;; resolves via the React-context (provider) tier rather than
+            ;; reading the shadowing :rf/default frame. See the suite's
+            ;; assert-use-subscribe-frame-provider-resolution masking note.
+            (binding [frame/*current-frame* nil]
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+              (reset! probe-frame-provider-observed [])
+              (rf/reg-frame frame-kw {:doc "rf2-7kii2 trailing-children frame-provider probe"})
+              (rf/reg-event-db ::dollar-shape-seed (fn [_ _] {:k :wrapped}))
+              (rf/dispatch-sync [::dollar-shape-seed] {:frame frame-kw})
+              (rf/reg-sub (first query-v) (fn [db _] (:k db)))
+              (let [mount-node (.createElement js/document "div")
+                    root       (react-dom-client/createRoot mount-node)]
+                (try
+                  (act-fn
+                    (fn []
+                      ;; The idiomatic public call shape — TWO native trailing
+                      ;; children (no `:children` key), flowing through Helix's
+                      ;; `$` → `extract-cljs-props` → the native `defnc` shell.
+                      (.render root
+                        ($ helix-adapter/frame-provider
+                           {:frame frame-kw}
+                           ($ ProbeFrameProvider)
+                           ($ ProbeFrameProvider)))))
+                  (is (some #{:wrapped} @probe-frame-provider-observed)
+                      "trailing children's use-subscribe read the wrapped frame's value, not :rf/default")
+                  (is (= 2 (count (filterv #{:wrapped} @probe-frame-provider-observed)))
+                      "both trailing children rendered (not dropped)")
+                  (finally
+                    (try (.unmount root) (catch :default _ nil))))))))))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -30,6 +30,7 @@
             ["react-dom/client" :as react-dom-client]
             [uix.core :as uix :refer-macros [defui $]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.adapter.react-shared-suite :as suite]
             [re-frame.test-support :as test-support]))
@@ -149,6 +150,13 @@
    :probe-frame-provider-observed probe-frame-provider-observed
    :frame-provider-frame          :rf.uix-use-subscribe-test/frame-provider-frame
    :frame-provider-query          :rf.uix-use-subscribe-test/k
+   ;; rf2-4mi2zj — 1-arg full frame-resolution chain (reuses ProbeFrameProvider
+   ;; + :frame-provider-query :k; isolated frame ids per case).
+   :provider-tier-frame               :rf.uix-4mi2zj/provider-tier-frame
+   :dynamic-precedence-provider-frame :rf.uix-4mi2zj/precedence-provider-frame
+   :dynamic-precedence-dynamic-frame  :rf.uix-4mi2zj/precedence-dynamic-frame
+   :no-scope-frame                    :rf.uix-4mi2zj/no-scope-frame
+   :substrate-kw                      :uix
    ;; 2-arg explicit pin
    :probe-2arg-element    (fn [] (uix/$ :div (uix/$ Probe2ArgA) (uix/$ Probe2ArgB)))
    :probe-2arg-a-observed probe-2arg-a-observed
@@ -187,6 +195,17 @@
 
 (deftest use-subscribe-2-arg-pins-explicit-frame
   (suite/assert-use-subscribe-2-arg-pins-explicit-frame cfg))
+
+;; rf2-4mi2zj — 1-arg full frame-resolution chain (the bug: spine fed the
+;; raw use-context read into the explicit 2-arg path, bypassing the chain).
+(deftest use-subscribe-provider-tier-resolution-ambient-cleared
+  (suite/assert-use-subscribe-provider-tier-resolution-ambient-cleared cfg))
+
+(deftest use-subscribe-dynamic-var-precedence-over-provider
+  (suite/assert-use-subscribe-dynamic-var-precedence-over-provider cfg))
+
+(deftest use-subscribe-no-provider-no-dynamic-raises-no-frame-context
+  (suite/assert-use-subscribe-no-provider-no-dynamic-raises-no-frame-context cfg))
 
 (deftest use-subscribe-cleanup-decrements-sub-cache-refcount
   (suite/assert-use-subscribe-cleanup-decrements-refcount cfg))
@@ -291,28 +310,34 @@
           (is true "act() not reachable from this runner; skipping")
           (let [frame-kw :rf.uix-use-subscribe-test/frame-provider-frame
                 query-v  [:rf.uix-use-subscribe-test/k]]
-            (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
-            (reset! probe-frame-provider-observed [])
-            (rf/reg-frame frame-kw {:doc "rf2-7kii2 trailing-children frame-provider probe"})
-            (rf/reg-event-db ::dollar-shape-seed (fn [_ _] {:k :wrapped}))
-            (rf/dispatch-sync [::dollar-shape-seed] {:frame frame-kw})
-            (rf/reg-sub (first query-v) (fn [db _] (:k db)))
-            (let [mount-node (.createElement js/document "div")
-                  root       (react-dom-client/createRoot mount-node)]
-              (try
-                (act-fn
-                  (fn []
-                    ;; The idiomatic public call shape — TWO native trailing
-                    ;; children (no `:children` key), flowing through UIx's
-                    ;; `$` → `glue-args` → the native `defui` shell.
-                    (.render root
-                      ($ uix-adapter/frame-provider
-                         {:frame frame-kw}
-                         ($ ProbeFrameProvider)
-                         ($ ProbeFrameProvider)))))
-                (is (some #{:wrapped} @probe-frame-provider-observed)
-                    "trailing children's use-subscribe read the wrapped frame's value, not :rf/default")
-                (is (= 2 (count (filterv #{:wrapped} @probe-frame-provider-observed)))
-                    "both trailing children rendered (not dropped)")
-                (finally
-                  (try (.unmount root) (catch :default _ nil)))))))))))
+            ;; rf2-4mi2zj: clear the fixture's ambient `:rf/default` dynamic
+            ;; scope so the 1-arg `use-subscribe` in ProbeFrameProvider
+            ;; resolves via the React-context (provider) tier rather than
+            ;; reading the shadowing :rf/default frame. See the suite's
+            ;; assert-use-subscribe-frame-provider-resolution masking note.
+            (binding [frame/*current-frame* nil]
+              (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+              (reset! probe-frame-provider-observed [])
+              (rf/reg-frame frame-kw {:doc "rf2-7kii2 trailing-children frame-provider probe"})
+              (rf/reg-event-db ::dollar-shape-seed (fn [_ _] {:k :wrapped}))
+              (rf/dispatch-sync [::dollar-shape-seed] {:frame frame-kw})
+              (rf/reg-sub (first query-v) (fn [db _] (:k db)))
+              (let [mount-node (.createElement js/document "div")
+                    root       (react-dom-client/createRoot mount-node)]
+                (try
+                  (act-fn
+                    (fn []
+                      ;; The idiomatic public call shape — TWO native trailing
+                      ;; children (no `:children` key), flowing through UIx's
+                      ;; `$` → `glue-args` → the native `defui` shell.
+                      (.render root
+                        ($ uix-adapter/frame-provider
+                           {:frame frame-kw}
+                           ($ ProbeFrameProvider)
+                           ($ ProbeFrameProvider)))))
+                  (is (some #{:wrapped} @probe-frame-provider-observed)
+                      "trailing children's use-subscribe read the wrapped frame's value, not :rf/default")
+                  (is (= 2 (count (filterv #{:wrapped} @probe-frame-provider-observed)))
+                      "both trailing children rendered (not dropped)")
+                  (finally
+                    (try (.unmount root) (catch :default _ nil))))))))))))

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1710,7 +1710,56 @@
             (React/useSyncExternalStore subscribe-fn get-snap get-snap)))
         use-subscribe
         (fn use-subscribe
-          ([query-v] (use-subscribe-2 (use-current-frame) query-v))
+          ;; ---- 1-arg ambient form — full frame-resolution chain (rf2-4mi2zj) ----
+          ;;
+          ;; The ambient `(use-subscribe [:q …])` form MUST resolve the
+          ;; frame through the SAME carried-invariant chain `subs/subscribe`'s
+          ;; own 1-arity uses (Spec 006 §Frame resolution (1-arg form), :734,
+          ;; :1058; EP-0002): dynamic-var tier (`frame/*current-frame*`, set by
+          ;; `with-frame` / `frame-bound-fn`) FIRST, the React-context tier
+          ;; (the surrounding `frame-provider`) SECOND, and **nil → a loud
+          ;; `:rf.error/no-frame-context`** with NO `:rf/default` floor.
+          ;;
+          ;; The earlier shortcut `(use-subscribe-2 (use-current-frame) …)`
+          ;; bypassed that chain in two correctness-breaking ways:
+          ;;
+          ;;   1. `use-current-frame` is the NARROW raw `use-context` read
+          ;;      (React-context tier ONLY — it never consults the dynamic
+          ;;      var). Passing its result straight into the 2-arg EXPLICIT
+          ;;      path let a surrounding provider beat a `with-frame` /
+          ;;      `frame-bound-fn` dynamic scope — inverting the spec's tier
+          ;;      precedence (dynamic-var MUST win).
+          ;;   2. With no enclosing provider, `use-context` returns the
+          ;;      no-provider sentinel (`:rf.frame/no-provider`), NOT nil. The
+          ;;      explicit 2-arg path then subscribed against that sentinel as
+          ;;      a literal frame id — surfacing a bad-/destroyed-frame path
+          ;;      instead of the specified `:rf.error/no-frame-context`.
+          ;;
+          ;; Fix: still CALL `use-current-frame` (the `use-context` hook) so
+          ;; the component stays subscribed to provider-value changes and
+          ;; re-renders when the surrounding `frame-provider` swaps frames —
+          ;; a hook-safe, unconditional top-of-body call — but DISCARD its raw
+          ;; value for resolution. Resolve the real frame via
+          ;; `frame/require-current-frame!`, which delegates to
+          ;; `resolve-current-frame` → the live `:adapter/current-frame`
+          ;; late-bind hook (`function-component-current-frame`: dynamic-var →
+          ;; `_currentValue` with sentinel→nil and corrupted-value detection)
+          ;; and emits + throws `:rf.error/no-frame-context` on nil. This
+          ;; single-sources resolution with `subs/subscribe`'s 1-arity — the
+          ;; hook and the imperative read can never diverge — and then hands
+          ;; the now-EXPLICIT resolved frame to the 2-arg path. The 2-arg
+          ;; EXPLICIT form is unchanged (it bypasses the chain by design).
+          ([query-v]
+           ;; Hook subscription to provider-value changes (re-render). The
+           ;; returned sentinel/keyword is intentionally NOT used as the
+           ;; frame — resolution runs through the chain below.
+           (use-current-frame)
+           (use-subscribe-2
+             (frame/require-current-frame!
+               :subscribe
+               {:where    're-frame.substrate.spine/use-subscribe
+                :event-id (first query-v)})
+             query-v))
           ([frame-kw query-v] (use-subscribe-2 frame-kw query-v)))]
     {:emitter-cell                emitter-cell
      :warn-cache                  warn-cache

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -3055,25 +3055,36 @@
   (testing (str name " — use-subscribe 1-arg resolves via frame-provider (rf2-518sp / rf2-z7hfp)")
     (with-browser-act
      (fn [act-fn]
-      (reset! probe-frame-provider-observed [])
-      (rf/reg-frame frame-provider-frame {:doc "use-subscribe frame-provider probe frame"})
-      (rf/reg-event-db ::frame-provider-seed (fn [_ _] {:k :wrapped}))
-      (rf/dispatch-sync [::frame-provider-seed] {:frame frame-provider-frame})
-      (rf/reg-sub frame-provider-query (fn [db _] (:k db)))
-      (let [mount-node (make-mount-node!)
-            root       (react-dom-client/createRoot mount-node)]
-        (try
-          (act-fn
-            (fn []
-              ;; The NATIVE frame-provider component mounted via the
-              ;; substrate's documented `$` shape (rf2-z7hfp).
-              (.render root
-                (frame-provider-mount-element
-                  frame-provider-frame (probe-frame-provider-element)))))
-          (is (some #{:wrapped} @probe-frame-provider-observed)
-              "use-subscribe 1-arg form read from the wrapped frame, not :rf/default")
-          (finally
-            (try (.unmount root) (catch :default _ nil)))))))))
+      ;; rf2-4mi2zj: CLEAR the fixture's ambient `:rf/default` dynamic scope.
+      ;; The 1-arg `use-subscribe` resolves dynamic-var FIRST (tier 1), then
+      ;; the React-context tier (tier 2). With the fixture's ambient
+      ;; `*current-frame*` :rf/default left bound, tier 1 ALWAYS wins and the
+      ;; provider tier is never the decider — the sub would read :rf/default's
+      ;; app-db (no :k → nil), MASKING the very provider-resolution this test
+      ;; means to prove. (The prior raw-`use-context` spine resolved provider-
+      ;; first, so this passed by accident; under the carried-invariant chain
+      ;; the dynamic var legitimately shadows the provider.) Clearing it makes
+      ;; the React-context tier the genuine decider. Per the bead's masking note.
+      (binding [frame/*current-frame* nil]
+        (reset! probe-frame-provider-observed [])
+        (rf/reg-frame frame-provider-frame {:doc "use-subscribe frame-provider probe frame"})
+        (rf/reg-event-db ::frame-provider-seed (fn [_ _] {:k :wrapped}))
+        (rf/dispatch-sync [::frame-provider-seed] {:frame frame-provider-frame})
+        (rf/reg-sub frame-provider-query (fn [db _] (:k db)))
+        (let [mount-node (make-mount-node!)
+              root       (react-dom-client/createRoot mount-node)]
+          (try
+            (act-fn
+              (fn []
+                ;; The NATIVE frame-provider component mounted via the
+                ;; substrate's documented `$` shape (rf2-z7hfp).
+                (.render root
+                  (frame-provider-mount-element
+                    frame-provider-frame (probe-frame-provider-element)))))
+            (is (some #{:wrapped} @probe-frame-provider-observed)
+                "use-subscribe 1-arg form read from the wrapped frame, not :rf/default")
+            (finally
+              (try (.unmount root) (catch :default _ nil))))))))))
 
 (defn assert-use-subscribe-2-arg-pins-explicit-frame
   "rf2-rcgsc / rf2-y0db2: use-subscribe's 2-arg form
@@ -3114,6 +3125,198 @@
               "tenant-b probe did NOT leak tenant-a's value")
           (finally
             (try (.unmount root) (catch :default _ nil)))))))))
+
+;; ===========================================================================
+;; rf2-4mi2zj — use-subscribe 1-arg FULL frame-resolution chain.
+;;
+;; The shared spine's 1-arg `use-subscribe` used to short-circuit through
+;; `(use-subscribe-2 (use-current-frame) query-v)`: it took the NARROW raw
+;; `use-context` read (React-context tier ONLY) and fed it straight into
+;; the EXPLICIT 2-arg path. Two correctness breaks followed (Spec 006 §734
+;; / §1058; EP-0002):
+;;
+;;   1. A surrounding `frame-provider` beat a `with-frame` /
+;;      `frame-bound-fn` dynamic scope — INVERTING the tier order
+;;      (dynamic-var MUST win over React-context).
+;;   2. With no provider, `use-context` returns the no-provider sentinel
+;;      (`:rf.frame/no-provider`), NOT nil. The explicit path subscribed
+;;      against that sentinel as a literal frame — surfacing a bad/
+;;      destroyed-frame outcome instead of the specified
+;;      `:rf.error/no-frame-context`.
+;;
+;; The existing `assert-use-subscribe-frame-provider-resolution` proves
+;; provider resolution under the fixture's ambient `:rf/default` dynamic
+;; scope — which MASKS the tier order (the dynamic var is always bound, so
+;; the React-context tier is never the decider). These three assertions
+;; clear the ambient scope (`binding [frame/*current-frame* nil]`) so the
+;; chain's real tier order is exercised, and add the two cases the prior
+;; coverage never had: dynamic-var precedence, and no-scope failure.
+;; ===========================================================================
+
+(defn assert-use-subscribe-provider-tier-resolution-ambient-cleared
+  "rf2-4mi2zj — provider-tier resolution with the AMBIENT dynamic scope
+  CLEARED. The 1-arg `use-subscribe` under a `frame-provider`, with
+  `frame/*current-frame*` bound to nil, must still resolve to the
+  provider's frame via the React-context tier (tier 2). The fixture's
+  default `:rf/default` ambient scope would mask this — with it cleared,
+  the React-context tier is genuinely the decider, so this proves the
+  spine consults it (and is not, e.g., resolving everything to the dynamic
+  var or to the no-provider sentinel).
+
+  Reuses the 1-arg ProbeFrameProvider (`:frame-provider-query`)
+  observation surface; isolates onto its own frame id so it can't collide
+  with `assert-use-subscribe-frame-provider-resolution`.
+
+  cfg keys:
+    :frame-provider-mount-element   thunk (fn [frame-kw child-el])
+    :probe-frame-provider-element   thunk → 1-arg ProbeFrameProvider
+    :probe-frame-provider-observed  atom the probe pushes observed values into
+    :provider-tier-frame            frame-id for the wrapped frame
+    :frame-provider-query           query-v keyword the probe subscribes to"
+  [{:keys [name frame-provider-mount-element probe-frame-provider-element
+           probe-frame-provider-observed provider-tier-frame frame-provider-query]}]
+  (testing (str name " — use-subscribe 1-arg provider-tier resolution, ambient scope cleared (rf2-4mi2zj)")
+    (with-browser-act
+     (fn [act-fn]
+      ;; Clear the fixture's ambient :rf/default dynamic scope so the
+      ;; React-context tier is the genuine decider, not a shadowing
+      ;; dynamic var (the masking the bead flags).
+      (binding [frame/*current-frame* nil]
+        (reset! probe-frame-provider-observed [])
+        (rf/reg-frame provider-tier-frame {:doc "rf2-4mi2zj provider-tier (ambient cleared) frame"})
+        (rf/reg-event-db ::provider-tier-seed (fn [_ _] {:k :from-provider}))
+        (rf/dispatch-sync [::provider-tier-seed] {:frame provider-tier-frame})
+        (rf/reg-sub frame-provider-query (fn [db _] (:k db)))
+        (let [mount-node (make-mount-node!)
+              root       (react-dom-client/createRoot mount-node)]
+          (try
+            (act-fn
+              (fn []
+                (.render root
+                  (frame-provider-mount-element
+                    provider-tier-frame (probe-frame-provider-element)))))
+            (is (some #{:from-provider} @probe-frame-provider-observed)
+                "use-subscribe 1-arg resolved via the React-context tier (provider frame)
+                 even with the dynamic var cleared — tier 2 is live")
+            (is (not (some #{:rf.frame/no-provider} @probe-frame-provider-observed))
+                "the no-provider sentinel never leaked into the subscription")
+            (finally
+              (try (.unmount root) (catch :default _ nil))))))))))
+
+(defn assert-use-subscribe-dynamic-var-precedence-over-provider
+  "rf2-4mi2zj — the ADVERSARIAL precedence case. With BOTH a dynamic-var
+  scope (`frame/*current-frame*` bound to the dynamic frame) AND a
+  surrounding `frame-provider` naming a DIFFERENT frame, the 1-arg
+  `use-subscribe` MUST resolve to the DYNAMIC frame (tier 1 wins over tier
+  2). The buggy spine — raw `use-context` fed into the explicit path —
+  read the PROVIDER's frame, inverting the spec tier order; this is the
+  case the fix is for.
+
+  Both frames register the same query so the only signal that
+  distinguishes them is which frame's app-db the subscription read. The
+  dynamic frame is seeded `:from-dynamic`; the provider frame
+  `:from-provider`. The mount render runs synchronously inside the dynamic
+  binding (React 18 `act()` flushes the component body on the calling
+  stack), so the bound dynamic var is in scope for the render's
+  `require-current-frame!` resolution.
+
+  cfg keys:
+    :frame-provider-mount-element   thunk (fn [frame-kw child-el])
+    :probe-frame-provider-element   thunk → 1-arg ProbeFrameProvider
+    :probe-frame-provider-observed  atom the probe pushes observed values into
+    :dynamic-precedence-provider-frame  provider (loser) frame-id
+    :dynamic-precedence-dynamic-frame   dynamic-var (winner) frame-id
+    :frame-provider-query           query-v keyword the probe subscribes to"
+  [{:keys [name frame-provider-mount-element probe-frame-provider-element
+           probe-frame-provider-observed dynamic-precedence-provider-frame
+           dynamic-precedence-dynamic-frame frame-provider-query]}]
+  (testing (str name " — use-subscribe 1-arg: dynamic-var beats provider (rf2-4mi2zj)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! probe-frame-provider-observed [])
+      (rf/reg-frame dynamic-precedence-provider-frame {:doc "rf2-4mi2zj provider (precedence loser)"})
+      (rf/reg-frame dynamic-precedence-dynamic-frame  {:doc "rf2-4mi2zj dynamic-var (precedence winner)"})
+      (rf/reg-event-db ::precedence-seed (fn [_ [_ v]] {:k v}))
+      (rf/dispatch-sync [::precedence-seed :from-provider] {:frame dynamic-precedence-provider-frame})
+      (rf/dispatch-sync [::precedence-seed :from-dynamic]  {:frame dynamic-precedence-dynamic-frame})
+      (rf/reg-sub frame-provider-query (fn [db _] (:k db)))
+      (let [mount-node (make-mount-node!)
+            root       (react-dom-client/createRoot mount-node)]
+        (try
+          ;; Bind the DYNAMIC frame around the synchronous mount render. The
+          ;; probe sits under a provider naming the OTHER frame; the chain
+          ;; must pick the dynamic var (tier 1).
+          (binding [frame/*current-frame* dynamic-precedence-dynamic-frame]
+            (act-fn
+              (fn []
+                (.render root
+                  (frame-provider-mount-element
+                    dynamic-precedence-provider-frame (probe-frame-provider-element))))))
+          (is (some #{:from-dynamic} @probe-frame-provider-observed)
+              "1-arg use-subscribe resolved to the DYNAMIC frame (tier 1 wins over the provider)")
+          (is (not (some #{:from-provider} @probe-frame-provider-observed))
+              "the surrounding provider's frame did NOT win — tier order is dynamic-var → React-context")
+          (finally
+            (try (.unmount root) (catch :default _ nil)))))))))
+
+(defn assert-use-subscribe-no-provider-no-dynamic-raises-no-frame-context
+  "rf2-4mi2zj — the second ADVERSARIAL case. A 1-arg `use-subscribe` with
+  NO surrounding `frame-provider` and NO dynamic scope must resolve to nil
+  and emit `:rf.error/no-frame-context` (EP-0002 — no `:rf/default`
+  floor), NOT subscribe against the no-provider sentinel
+  `:rf.frame/no-provider` (which the buggy spine did, surfacing a
+  bad/destroyed-frame outcome instead).
+
+  Proof shape: clear the ambient dynamic scope, register the sub but mount
+  the 1-arg probe with NO provider, and assert a `:rf.error/no-frame-context`
+  trace fired during the render. The render itself will throw (the error is
+  emitted then re-thrown by `require-current-frame!`); React surfaces that
+  through the act() commit, so we tolerate the throw and assert on the
+  captured trace — the load-bearing signal that the chain failed CLOSED on
+  the specified error rather than silently subscribing to the sentinel.
+
+  cfg keys:
+    :substrate-kw                   keyword fragment for the listener key
+    :probe-frame-provider-element   thunk → 1-arg ProbeFrameProvider
+    :probe-frame-provider-observed  atom the probe pushes observed values into
+    :no-scope-frame                 frame-id the sub is registered under
+                                    (never resolved — proves the sentinel
+                                    is NOT used as the frame)
+    :frame-provider-query           query-v keyword the probe subscribes to"
+  [{:keys [name substrate-kw probe-frame-provider-element probe-frame-provider-observed
+           no-scope-frame frame-provider-query]}]
+  (testing (str name " — use-subscribe 1-arg with no scope raises no-frame-context (rf2-4mi2zj)")
+    (with-browser-act
+     (fn [act-fn]
+      (binding [frame/*current-frame* nil]
+        (let [lk     (keyword "re-frame.adapter.react-shared-suite"
+                              (str "no-scope-" (clojure.core/name substrate-kw)))
+              traces (atom [])]
+          (trace-tooling/register-listener! lk (fn [ev] (swap! traces conj ev)))
+          (reset! probe-frame-provider-observed [])
+          ;; Register the sub + a frame so the ONLY reason resolution can
+          ;; fail is the absent scope — not a missing sub/frame.
+          (rf/reg-frame no-scope-frame {:doc "rf2-4mi2zj no-scope frame (must never be resolved-to)"})
+          (rf/reg-sub frame-provider-query (fn [db _] (:k db)))
+          (let [mount-node (make-mount-node!)
+                root       (react-dom-client/createRoot mount-node)]
+            (try
+              ;; The render throws :rf.error/no-frame-context out of
+              ;; require-current-frame!; React funnels it through act().
+              ;; Tolerate the throw — the captured trace is the contract.
+              (try
+                (act-fn (fn [] (.render root (probe-frame-provider-element))))
+                (catch :default _ nil))
+              (let [no-frame-errs (filterv #(= :rf.error/no-frame-context (:operation %)) @traces)]
+                (is (pos? (count no-frame-errs))
+                    "a :rf.error/no-frame-context trace fired — the 1-arg read failed
+                     CLOSED on the specified error (no :rf/default floor)"))
+              (is (not (some #{:rf.frame/no-provider} @probe-frame-provider-observed))
+                  "the no-provider sentinel was NEVER used as a frame id (the buggy
+                   spine subscribed against :rf.frame/no-provider instead of erroring)")
+              (finally
+                (trace-tooling/unregister-listener! lk)
+                (try (.unmount root) (catch :default _ nil)))))))))))
 
 (defn assert-use-subscribe-cleanup-decrements-refcount
   "rf2-7g959: use-subscribe pairs subscribe with subs/unsubscribe on


### PR DESCRIPTION
## Summary

Fixes **rf2-4mi2zj** (P1 bug): the shared UIx/Helix `use-subscribe` 1-arg form bypassed the carried frame-resolution chain.

### Root cause

In `implementation/core/src/re_frame/substrate/spine.cljs`, the 1-arg `use-subscribe` was `(use-subscribe-2 (use-current-frame) query-v)`. `use-current-frame` is the **narrow raw `use-context` read** (React-context tier ONLY) and its result was fed straight into the **explicit** 2-arg subscription path. This broke the chain (Spec 006 §734/§1058; EP-0002) two ways:

1. **Tier order inverted.** A surrounding `frame-provider` (React-context) beat a `with-frame` / `frame-bound-fn` dynamic scope. The spec requires the dynamic-var tier to win first.
2. **No-provider sentinel leaked as a frame.** With no provider, `use-context` returns the no-provider sentinel `:rf.frame/no-provider` (not nil); the explicit path subscribed against it as a literal frame id, surfacing a bad/destroyed-frame outcome instead of the specified `:rf.error/no-frame-context`.

### Fix

The 1-arg form still **calls** `use-current-frame` (the `use-context` hook) so the component stays subscribed to provider-value changes and re-renders when the provider swaps frames — a hook-safe, unconditional top-of-body call — but **discards its raw value for resolution**. The frame is resolved via `frame/require-current-frame!` → `resolve-current-frame` → the live `:adapter/current-frame` hook (`function-component-current-frame`: dynamic-var → React-context `_currentValue` with sentinel→nil and corrupted-value detection), which emits + throws `:rf.error/no-frame-context` on nil. This single-sources resolution with `subs/subscribe`'s own 1-arity — the hook and the imperative read can no longer diverge. The 2-arg explicit form is unchanged (bypasses the chain by design).

No core frame-resolution change was needed — the canonical resolver and `:adapter/current-frame` hook already existed and are correct; the spine was diverging from the spec. The spec already documents the correct contract, so no spec change (aligned code to spec per the bead).

### Tests (adversarial; single-sourced in `react-shared-suite`, forwarded UIx + Helix)

- `assert-use-subscribe-provider-tier-resolution-ambient-cleared` — provider-tier resolution with the ambient dynamic scope cleared (so tier 2 is the genuine decider, not masked).
- `assert-use-subscribe-dynamic-var-precedence-over-provider` — dynamic-var beats a surrounding provider naming a different frame (the precedence-inversion the bug caused).
- `assert-use-subscribe-no-provider-no-dynamic-raises-no-frame-context` — no provider + no dynamic scope emits `:rf.error/no-frame-context`, never subscribes against `:rf.frame/no-provider`.

The pre-existing `use-subscribe-frame-provider-resolution` and `frame-provider-trailing-children-propagate-frame` tests passed only because the buggy spine resolved provider-first; under the correct chain the fixture's ambient `:rf/default` dynamic scope masks the provider tier. Cleared it via `binding [frame/*current-frame* nil]` per the bead's masking note so those tests genuinely exercise the React-context tier.

## Quality gates

- `npm run test:cljs` (node CLJS) — **7055 tests / 28863 assertions, 0 failures, 0 errors**
- `npm run test:browser` (Playwright DOM — where the new + adjusted assertions execute) — **211 tests / 654 assertions, 0 failures, 0 errors** (was 6 failing assertions from the masking regression, now fixed)
- `npm run test:elision` — **PASS** (production 42/42 absent; control 42/42 present)
- `npm run test:bundle-isolation` — **PASS** (incl. uix-helix-reagent-free)
- UIx + Helix adapter `clojure -M:test` — PASS (classpath-probe-only by design)

Closes rf2-4mi2zj.