### PR TITLE
fix(machines-viz): close share decode schema gap (rf2-dplwxh)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -295,6 +295,53 @@ parser's transition count) so a visual-regression test can pin
 parity at every stage of the parser → projector → DOM chain — the
 silent-drop bug cannot recur at any layer without failing the gate.
 
+### Rendered-topology geometry gate (rf2-dplwxh)
+
+The browser chart suite (`chart-dom-cljs-test`) asserts FIRST-COMMIT
+DOM — node count, edge count, class/testid contract — BEFORE the async
+elkjs pass resolves, so it cannot catch layout-quality regressions
+(wrong fit, overlapped bands/nodes, bad route geometry, missing
+projected edges, adaptive-layout drift). The Xray feature gate only
+requires `nodeCount > 0`; the PNG exporter test proves nonblank output,
+not topology correctness. Those failure classes were therefore
+invisible to CI.
+
+`topology-layout-gate-cljs-test` closes the gap. It drives the REAL
+`chart/compute-layout!` (elkjs — the SAME engine xyflow uses as its
+layout backend — runs Node-side, no DOM/React/`@xyflow/react`),
+**awaits the layout settle** (the callback the synchronous DOM suite
+cannot await), and asserts **post-layout geometry invariants** for the
+representative machines on the topology-parity surface
+(`001-Topology-Parity.md`): a linear/cyclic spine, a guarded fork, a
+parallel machine, a compound machine, and a non-trivial Context-band
+case. Per-machine the gate pins:
+
+- **Fit** — every leaf state node lands at a DISTINCT, finite,
+  positive-area box (not a degenerate origin-stack), and the overall
+  bounding box is finite + positive.
+- **No overlap** — no two leaf siblings (same coordinate frame) overlap;
+  every compound / region container ENCLOSES each of its children (a
+  band painted over its contents fails here).
+- **No missing edges** — every projected transition has BOTH routed
+  halves present (events-as-nodes splits each edge into an `__in` +
+  `__out` segment), each a polyline of ≥ 2 points.
+- **Route placement** — each half's polyline stays within a finite
+  tolerance of the union box of its endpoint nodes (the route attaches
+  to the right nodes rather than flying off into empty canvas).
+
+Geometry invariants are used in lieu of committed pixel/screenshot
+baselines: pixel baselines are cross-platform-flaky (this project's
+maintainer develops on Windows, the ecosystem maintainers on
+Mac/Linux), whereas elkjs's positions are deterministic Node-side and
+the invariants encode the actual quality contract rather than a
+snapshot of one renderer's px output.
+
+**When changing `chart.cljs` `default-elk-options`, `chart.projection`,
+the density / visual constants, or `chart.layout`, run
+`cd implementation && npm run test:cljs`** — the gate runs under the
+always-on `:node-test` build (its ns ends in `-cljs-test`) and fails on
+any fit / overlap / routing / missing-edge regression.
+
 ### Events as nodes — Stately graph view paradigm (rf2-qo5xy)
 
 **This is a paradigm-shift section.** Pre-rf2-qo5xy the chart painted
@@ -1616,9 +1663,15 @@ encoder validates the allowlisted chart state — including the snapshot
 shape — *before* serialising), so the two stay symmetric: the encoder
 never emits a payload the decoder would reject, and a malformed `:state`
 (none of the three configuration arms) is rejected at encode rather than
-producing an undecodable URL. The decoder rejects any `:snapshot`
-carrying additional keys, or a `:state` outside the three arms, with
-`:invalid-chart-state`. The viewer page mounts `MachineChart` with
+producing an undecodable URL. **The top-level ChartState map is CLOSED
+over `#{:machine-id :frame-id :definition :snapshot}` on BOTH sides**
+(rf2-dplwxh): a hand-crafted share URL that bypasses the encoder cannot
+smuggle an extra top-level key (`:source-coords`, `:data`, or any future
+unreviewed field) past `decode-share-url` / `decode-share-url-safe` — the
+decoder rejects it with `:invalid-chart-state`, so the viewer never loads
+anything outside the validated payload schema. The decoder likewise
+rejects any `:snapshot` carrying additional keys, or a `:state` outside
+the three arms, with `:invalid-chart-state`. The viewer page mounts `MachineChart` with
 `:current-state` set to the snapshot's `:state` configuration (there is
 no runtime `:data` to render); the chart highlights every active leaf
 without any data-driven affordance.
@@ -1643,10 +1696,13 @@ definition before serialisation (registered definitions carry
 source-coord meta per Spec 001; that meta does not propagate). The
 viewer page never resolves guards or actions; it only renders.
 
-Anything not in the schema is silently dropped by the encoder. New
-top-level keys (and any future expansion of `:snapshot`) require
-an explicit `:rf.machines-viz.share/allow?` opt-in plus an
-operator-controlled redaction hook (per
+Anything not in the schema is silently dropped by the encoder AND
+rejected by the decoder (rf2-dplwxh — the top-level map is closed on
+both sides; a forged URL adding an extra top-level key fails decode
+with `:invalid-chart-state`). New top-level keys (and any future
+expansion of `:snapshot`) require an explicit
+`:rf.machines-viz.share/allow?` opt-in plus an operator-controlled
+redaction hook (per
 [Principles §No session data in shares](./Principles.md)); CI
 enforces.
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -340,18 +340,31 @@
        (keyword? (:frame-id cs))
        (valid-definition? (:definition cs))))
 
+(def ^:private chart-state-keys
+  "The ONLY top-level keys a ChartState may carry (per API.md
+  §Share-URL payload schema). `valid-chart-state?` is closed over this
+  set on BOTH sides so a hand-edited URL cannot smuggle extra top-level
+  keys (`:source-coords`, `:data`, future unreviewed fields) past
+  decode. Widening this set requires the documented
+  `:rf.machines-viz.share/allow?` opt-in + operator redaction hook."
+  #{:machine-id :frame-id :definition :snapshot})
+
 (defn- valid-chart-state?
-  "Validate a fully-allowlisted ChartState shape. `:snapshot` is
-  optional; when present it must be `{:state <state-configuration>}`
-  EXACTLY (closed; `:state` only). Used on BOTH sides so encode/decode
-  stay symmetric — the encoder validates the allowlisted chart state
-  with this same predicate before serialising, so it never emits a
-  payload the decoder would reject (a hand-edited URL smuggling `:data`
-  onto `:snapshot`, or a malformed `:state` that is none of the three
-  arms, is rejected at decode; an in-process caller passing the same is
+  "Validate a fully-allowlisted ChartState shape. The top-level map is
+  CLOSED over `chart-state-keys` — any extra top-level key (e.g. a
+  hand-edited `:source-coords` / `:data` smuggled past the encoder)
+  fails validation. `:snapshot` is optional; when present it must be
+  `{:state <state-configuration>}` EXACTLY (closed; `:state` only).
+  Used on BOTH sides so encode/decode stay symmetric — the encoder
+  validates the allowlisted chart state with this same predicate before
+  serialising, so it never emits a payload the decoder would reject (a
+  hand-edited URL adding an extra top-level key, smuggling `:data` onto
+  `:snapshot`, or a malformed `:state` that is none of the three arms,
+  is rejected at decode; an in-process caller passing the same is
   rejected at encode)."
   [cs]
   (and (valid-core-chart-state? cs)
+       (every? chart-state-keys (keys cs))
        (or (not (contains? cs :snapshot))
            (valid-snapshot? (:snapshot cs)))))
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/topology_layout_gate_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/topology_layout_gate_cljs_test.cljs
@@ -1,0 +1,316 @@
+(ns day8.re-frame2-machines-viz.chart.topology-layout-gate-cljs-test
+  "rf2-dplwxh — rendered-topology layout/geometry gate.
+
+  ## Why this exists
+
+  The slice had strong pure-data + DOM-structure coverage, but no
+  representative gate over the SETTLED layout geometry. The browser
+  `chart-dom-cljs-test` deliberately asserts first-commit DOM BEFORE
+  the async elkjs pass resolves (positions are still {0 0}); the Xray
+  feature gate only requires `nodeCount > 0`; the PNG exporter test
+  proves nonblank output, not topology correctness. Real rendered
+  failures — wrong fit, overlapped bands/nodes, bad route geometry,
+  missing projected edges, adaptive-layout drift — were therefore
+  invisible to CI.
+
+  ## What this gate does (and why it's a node `-cljs-test`)
+
+  It drives the REAL `chart/compute-layout!` (elkjs runs as xyflow's
+  layout backend; elkjs is the SAME engine the live chart uses and is
+  Node-runnable — no DOM, no React, no `@xyflow/react`) for the
+  representative machines named on the topology-parity surface
+  (`spec/001-Topology-Parity.md`): a linear/cyclic spine, a guarded
+  fork, a parallel machine, a compound (hierarchical) machine, and a
+  non-trivial Context-band case. It AWAITS the layout settle (the
+  callback / Promise the synchronous DOM suite cannot await) and then
+  asserts POST-LAYOUT GEOMETRY INVARIANTS the spec explicitly accepts
+  in lieu of committed pixel baselines (which are cross-platform-flaky;
+  Mike develops on Windows, maintainers on Mac/Linux). The invariants
+  catch the failure classes the bead enumerates:
+
+    - WRONG FIT / degenerate origin-stack — every state node lands at a
+      DISTINCT, finite, positive-area box (not all stacked at {0 0}),
+      and the overall bounding box is finite + positive.
+    - OVERLAPPED bands/nodes — no two sibling leaf state nodes (same
+      coordinate frame) overlap; every container ENCLOSES its children
+      (catches a band/region painted over its contents).
+    - MISSING projected edges — every projected transition has BOTH
+      routed halves (events-as-nodes splits each edge into an `__in` +
+      `__out` segment) present in `:edge-points`, each a polyline of
+      >= 2 points.
+    - BAD route placement — each routed half's polyline stays within a
+      tolerance of the union box of its endpoint nodes (the route
+      connects the RIGHT nodes; it does not fly off into empty space).
+
+  ## Command to run when changing layout/projection/visual constants
+
+      cd implementation && npm run test:cljs
+
+  (This gate runs under the always-on `:node-test` build — its ns ends
+  in `-cljs-test`. A change to `chart.cljs` `default-elk-options`,
+  `chart.projection`, the density/visual constants, or `chart.layout`
+  that regresses fit / overlap / routing fails THIS gate.)"
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [day8.re-frame2-machines-viz.chart :as chart]
+            [day8.re-frame2-machines-viz.chart.layout :as layout]))
+
+;; ---------------------------------------------------------------------------
+;; Representative machines (the topology-parity surface, rf2 001-Topology-Parity)
+
+(def ^:private linear-cyclic
+  "A linear spine WITH a back-edge (cyclic): the common case + a cycle
+  ELK must acyclic-ise. 4 reachable states, a fan + a loop."
+  {:initial :idle
+   :states  {:idle    {:on {:start :loading}}
+             :loading {:on {:ok :done :err :failed}}
+             :done    {:on {:again :idle} :final? false}
+             :failed  {:final? true}}})
+
+(def ^:private guarded-fork
+  "One state, one event, TWO guarded targets — a fork ELK must lay out
+  side-by-side without overlapping the two branch targets."
+  {:initial :idle
+   :states  {:idle {:on {:submit [{:target :ok :guard :valid?}
+                                   {:target :err}]}}
+             :ok   {:final? true}
+             :err  {:final? true}}})
+
+(def ^:private parallel
+  "Two orthogonal regions, each a 2-state cycle — the region BANDS must
+  sit side-by-side (no band overlap) and each must enclose its states."
+  {:type :parallel
+   :regions {:audio   {:initial :playing
+                       :states {:playing {:on {:pause :paused}}
+                                :paused  {:on {:play :playing}}}}
+             :display {:initial :on
+                       :states {:on  {:on {:dim :off}}
+                                :off {:on {:lit :on}}}}}})
+
+(def ^:private compound
+  "A 3-deep hierarchical machine — the compound containers must enclose
+  their nested children at every depth."
+  {:initial :authenticated
+   :states  {:authenticated
+             {:initial :cart
+              :states  {:cart    {:initial :browsing
+                                  :states  {:browsing {:on {:checkout :checkout}}
+                                            :checkout {:on {:back :browsing}}}}
+                        :account {}}}
+             :anonymous {:on {:login :authenticated}}}})
+
+(def ^:private context-band
+  "A flat machine with a machine-level `:on` fallback + machine `:data`
+  — drives a non-trivial root Context band (machine-root chip + reset
+  edge). The band must reserve its own vertical space and the spine
+  must sit below it without overlap."
+  {:initial :a
+   :on      {:reset :a}
+   :data    {:hits 0 :seen [] :token nil}
+   :states  {:a {:on {:go :b}}
+             :b {:on {:go :a}}}})
+
+;; ---------------------------------------------------------------------------
+;; Geometry helpers
+
+(def ^:private route-tolerance
+  "Slack (px) allowed between a routed edge half's endpoint and the union
+  box of its endpoint nodes. ELK pads routes off the node boundary by
+  `elk.spacing.edgeNode` (24) and routes around the events-as-nodes
+  hop; a generous-but-finite tolerance pins 'the route connects the
+  right nodes' without over-fitting ELK's exact bend geometry."
+  140)
+
+(defn- abs-pos
+  "Resolve `node-id`'s ABSOLUTE box by summing the parent-chain offsets.
+  elkjs reports each child's x/y RELATIVE to its parent container, so a
+  nested state's absolute position is its own offset plus every
+  ancestor container's offset. `parent-of` maps node-id → parent-id (nil
+  at the root). Returns `{:x :y :width :height}` in the root frame, or
+  nil if the node has no recorded position."
+  [positions parent-of node-id]
+  (when-let [{:keys [width height]} (get positions node-id)]
+    (loop [id node-id, x 0.0, y 0.0]
+      (if-let [{px :x py :y} (get positions id)]
+        (recur (get parent-of id) (+ x px) (+ y py))
+        {:x x :y y :width width :height height}))))
+
+(defn- overlap?
+  "True when two absolute boxes overlap with positive area (touching
+  edges do NOT count as overlap)."
+  [a b]
+  (and (< (:x a) (+ (:x b) (:width b)))
+       (< (:x b) (+ (:x a) (:width a)))
+       (< (:y a) (+ (:y b) (:height b)))
+       (< (:y b) (+ (:y a) (:height a)))))
+
+(defn- encloses?
+  "True when absolute box `outer` contains box `inner` (inclusive, with
+  a 1px slack for float noise)."
+  [outer inner]
+  (and (<= (- (:x outer) 1) (:x inner))
+       (<= (- (:y outer) 1) (:y inner))
+       (>= (+ (:x outer) (:width outer) 1) (+ (:x inner) (:width inner)))
+       (>= (+ (:y outer) (:height outer) 1) (+ (:y inner) (:height inner)))))
+
+(defn- union-box
+  "Axis-aligned bounding box enclosing every box in `boxes`."
+  [boxes]
+  (let [xs  (mapv :x boxes)
+        ys  (mapv :y boxes)
+        x2s (mapv #(+ (:x %) (:width %)) boxes)
+        y2s (mapv #(+ (:y %) (:height %)) boxes)
+        x0  (apply min xs)
+        y0  (apply min ys)]
+    {:x x0 :y y0
+     :width  (- (apply max x2s) x0)
+     :height (- (apply max y2s) y0)}))
+
+(defn- point-near-box?
+  "True when point `{:x :y}` is within `tol` px of `box` (inside, or no
+  more than `tol` outside any edge)."
+  [{px :x py :y} box tol]
+  (and (>= px (- (:x box) tol))
+       (<= px (+ (:x box) (:width box) tol))
+       (>= py (- (:y box) tol))
+       (<= py (+ (:y box) (:height box) tol))))
+
+(defn- parent-map
+  "node-id → parent-id from the parsed projection (root container has
+  no parent → absent from the map)."
+  [parsed]
+  (into {} (keep (fn [{:keys [id parent-id]}]
+                   (when parent-id [id parent-id])))
+        (:nodes parsed)))
+
+;; ---------------------------------------------------------------------------
+;; The gate — one assertion battery, run per representative machine
+
+(defn- assert-topology!
+  "Run the post-settle geometry invariants against `parsed` + the elk
+  `result` (`{:positions :edge-points :layout-error}`). `label` names
+  the machine for failure messages."
+  [label parsed result]
+  (let [positions   (:positions result)
+        edge-points (:edge-points result)
+        parent-of   (parent-map parsed)
+        ;; State (non-event, non-root-container) parsed nodes.
+        state-nodes (remove #(= "__rf2_root_container__" (:id %)) (:nodes parsed))
+        leaf-nodes  (remove :compound? state-nodes)
+        abs-of      (fn [id] (abs-pos positions parent-of id))]
+
+    ;; ---- layout actually settled (no error, non-empty) ----
+    (is (nil? (:layout-error result))
+        (str label ": layout settled without error"))
+    (is (seq positions)
+        (str label ": elk produced non-empty positions (not the degenerate empty settle)"))
+
+    ;; ---- every projected node is positioned with a positive-area box ----
+    (doseq [{:keys [id]} state-nodes]
+      (let [box (abs-of id)]
+        (is (some? box) (str label ": node " id " has a position"))
+        (when box
+          (is (and (pos? (:width box)) (pos? (:height box)))
+              (str label ": node " id " has a positive-area box (not collapsed)")))))
+
+    ;; ---- WRONG FIT: leaf boxes are DISTINCT (not all stacked at origin) ----
+    (let [leaf-origins (->> leaf-nodes
+                            (map :id)
+                            (keep abs-of)
+                            (map (juxt :x :y)))]
+      (is (= (count leaf-origins) (count (set leaf-origins)))
+          (str label ": every leaf state node lands at a DISTINCT origin "
+               "(a degenerate origin-stack = wrong fit)")))
+
+    ;; ---- WRONG FIT: overall bounding box is finite + positive ----
+    (let [bbox (union-box (keep abs-of (map :id state-nodes)))]
+      (is (and (js/isFinite (:width bbox)) (js/isFinite (:height bbox))
+               (pos? (:width bbox)) (pos? (:height bbox)))
+          (str label ": overall topology bbox is finite + positive " (pr-str bbox))))
+
+    ;; ---- OVERLAP: no two leaf siblings (same parent / frame) overlap ----
+    (doseq [[pid sibs] (group-by :parent-id leaf-nodes)
+            :let  [boxes (keep #(some-> (abs-of (:id %)) (assoc :id (:id %))) sibs)]
+            [a b] (for [a boxes b boxes :when (neg? (compare (:id a) (:id b)))] [a b])]
+      (is (not (overlap? a b))
+          (str label ": leaf siblings under " pid " do not overlap — "
+               (:id a) " " (dissoc a :id) " vs " (:id b) " " (dissoc b :id))))
+
+    ;; ---- ENCLOSURE: every container encloses each of its children ----
+    (doseq [{:keys [id compound?]} state-nodes
+            :when compound?
+            :let  [outer (abs-of id)
+                   kids  (filter #(= id (:parent-id %)) state-nodes)]]
+      (doseq [{kid :id} kids]
+        (when-let [inner (abs-of kid)]
+          (is (encloses? outer inner)
+              (str label ": container " id " " (when outer (dissoc outer :id))
+                   " encloses child " kid " " inner)))))
+
+    ;; ---- MISSING EDGES + BAD ROUTE PLACEMENT ----
+    (doseq [{:keys [id source target]} (:edges parsed)
+            :let [in-pts  (get edge-points (str id "__in"))
+                  out-pts (get edge-points (str id "__out"))
+                  src-box (abs-of source)
+                  tgt-box (abs-of target)]]
+      ;; Each projected transition emits a routed `__in` AND `__out` half
+      ;; (events-as-nodes). Both must be present + a real polyline.
+      (is (and (>= (count in-pts) 2) (>= (count out-pts) 2))
+          (str label ": projected edge " id " has BOTH routed halves "
+               "(__in + __out, >= 2 points each) — none missing"))
+      ;; Route placement: the `__in` half connects FROM the source box;
+      ;; the `__out` half connects INTO the target box. Endpoints near the
+      ;; relevant node's box (within tolerance) = the route attaches to the
+      ;; right nodes rather than flying off into empty canvas.
+      (when (and (seq in-pts) src-box)
+        (is (point-near-box? (first in-pts) src-box route-tolerance)
+            (str label ": edge " id " __in route starts near its SOURCE "
+                 source " " src-box " (route placement) — " (first in-pts))))
+      (when (and (seq out-pts) tgt-box)
+        (is (point-near-box? (last out-pts) tgt-box route-tolerance)
+            (str label ": edge " id " __out route ends near its TARGET "
+                 target " " tgt-box " (route placement) — " (last out-pts)))))))
+
+(defn- run-gate!
+  "Drive the real elk layout for `parsed` then run the invariant battery
+  on the settle. `context-rows` reserves the root Context band height
+  (0 for the non-context machines)."
+  [label parsed context-rows done]
+  (chart/compute-layout!
+    parsed :tb nil (keyword "gate" label) nil nil context-rows
+    (fn [result]
+      (try
+        (assert-topology! label parsed result)
+        (finally (done))))))
+
+;; ---------------------------------------------------------------------------
+;; One deftest per representative class (each awaits its own settle)
+
+(deftest linear-cyclic-topology-settles-cleanly
+  (testing "rf2-dplwxh — a linear/cyclic spine lays out with distinct,
+            non-overlapping, fully-routed geometry"
+    (async done
+      (run-gate! "linear" (layout/project-definition linear-cyclic) 0 done))))
+
+(deftest guarded-fork-topology-settles-cleanly
+  (testing "rf2-dplwxh — a guarded fork's two branch targets sit
+            side-by-side without overlap, both routes present"
+    (async done
+      (run-gate! "fork" (layout/project-definition guarded-fork) 0 done))))
+
+(deftest parallel-topology-settles-cleanly
+  (testing "rf2-dplwxh — parallel region BANDS sit side-by-side without
+            overlap, each enclosing its own states"
+    (async done
+      (run-gate! "parallel" (layout/project-definition parallel) 0 done))))
+
+(deftest compound-topology-settles-cleanly
+  (testing "rf2-dplwxh — a 3-deep compound machine's containers enclose
+            their nested children at every depth"
+    (async done
+      (run-gate! "compound" (layout/project-definition compound) 0 done))))
+
+(deftest context-band-topology-settles-cleanly
+  (testing "rf2-dplwxh — a Context-band machine reserves the band space
+            and the spine sits below it without overlap"
+    (async done
+      (run-gate! "context" (layout/project-definition context-band) 3 done))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -407,6 +407,91 @@
                  (catch :default e (ex-data e)))]
       (is (= :invalid-chart-state (:reason d))))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-dplwxh — top-level ChartState is CLOSED on decode. The encoder
+;; allowlists to #{:machine-id :frame-id :definition :snapshot} before
+;; serialising, but a hand-crafted URL bypasses the encoder entirely. The
+;; decoder must therefore reject any extra top-level chart key
+;; (:source-coords, :data, or any future unreviewed field) rather than
+;; returning it in the public envelope — the viewer contract loads nothing
+;; outside the validated payload schema (API.md §Share-URL payload schema:
+;; "Anything not in the schema is silently dropped by the encoder. New
+;; top-level keys … require an explicit :rf.machines-viz.share/allow? opt-in").
+
+(deftest decoded-extra-top-level-source-coords-rejected
+  (testing "a forged URL adding a top-level :source-coords cannot survive decode"
+    (let [smuggled (envelope->url
+                     {:rf.machines-viz.share/v       "1"
+                      :rf.machines-viz.share/chart   (assoc chart-state
+                                                            :source-coords {:file "/Users/mike/secret/x.cljs"
+                                                                            :line 42})
+                      :rf.machines-viz.share/created 0})
+          d (try (share/decode-share-url smuggled)
+                 (catch :default e (ex-data e)))]
+      (is (= :invalid-chart-state (:reason d))
+          "an extra top-level :source-coords fails the closed ChartState check at decode"))))
+
+(deftest decoded-extra-top-level-data-rejected
+  (testing "a forged URL adding a top-level :data cannot survive decode"
+    (let [smuggled (envelope->url
+                     {:rf.machines-viz.share/v       "1"
+                      :rf.machines-viz.share/chart   (assoc chart-state
+                                                            :data {:token "leak-abc"
+                                                                   :form  {:password "hunter2"}})
+                      :rf.machines-viz.share/created 0})
+          d (try (share/decode-share-url smuggled)
+                 (catch :default e (ex-data e)))]
+      (is (= :invalid-chart-state (:reason d))
+          "an extra top-level :data fails the closed ChartState check at decode"))))
+
+(deftest decoded-future-unreviewed-top-level-key-rejected
+  (testing "any unknown future top-level key is rejected — the set is closed, not just the two known leaks"
+    (let [smuggled (envelope->url
+                     {:rf.machines-viz.share/v       "1"
+                      :rf.machines-viz.share/chart   (assoc chart-state
+                                                            :rf.machines-viz.share/some-future-field
+                                                            {:anything :goes})
+                      :rf.machines-viz.share/created 0})
+          d (try (share/decode-share-url smuggled)
+                 (catch :default e (ex-data e)))]
+      (is (= :invalid-chart-state (:reason d))
+          "an unreviewed top-level key requires the documented allow? opt-in, so decode fails closed"))))
+
+(deftest decoded-extra-top-level-key-rejected-safe
+  (testing "decode-share-url-safe returns {:error {:reason :invalid-chart-state}} for a forged extra key"
+    (let [smuggled (envelope->url
+                     {:rf.machines-viz.share/v       "1"
+                      :rf.machines-viz.share/chart   (assoc chart-state
+                                                            :source-coords {:file "/Users/mike/secret/x.cljs"}
+                                                            :data {:token "leak-abc"})
+                      :rf.machines-viz.share/created 0})
+          {:keys [ok error]} (share/decode-share-url-safe smuggled)]
+      (is (nil? ok) "the forged payload is NOT returned as :ok")
+      (is (= :invalid-chart-state (:reason error))
+          "the safe wrapper surfaces a banner-friendly reason rather than leaking the forged chart"))))
+
+(deftest decoded-extra-key-alongside-valid-snapshot-rejected
+  (testing "a forged top-level key is rejected even when the rest of the ChartState (incl. :snapshot) is valid"
+    (let [smuggled (envelope->url
+                     {:rf.machines-viz.share/v       "1"
+                      :rf.machines-viz.share/chart   (assoc chart-state
+                                                            :snapshot {:state :loading}  ;; legitimately valid
+                                                            :data {:token "leak"})       ;; forged extra
+                      :rf.machines-viz.share/created 0})
+          d (try (share/decode-share-url smuggled)
+                 (catch :default e (ex-data e)))]
+      (is (= :invalid-chart-state (:reason d))
+          "a valid :snapshot does not excuse an extra top-level key"))))
+
+(deftest valid-chart-state-with-exact-keys-still-decodes
+  (testing "guard against over-tightening — a legitimate ChartState (no extra keys) still round-trips"
+    (let [url  (share/encode-share-url chart-state)
+          back (:rf.machines-viz.share/chart (share/decode-share-url url))]
+      (is (= :auth/login-flow (:machine-id back)))
+      (is (= {:state :loading} (:snapshot back)))
+      (is (= #{:machine-id :frame-id :definition :snapshot} (set (keys back)))
+          "the decoded chart carries exactly the four ChartState keys"))))
+
 (deftest malformed-fragment-rejected
   (testing "a URL with no #machine= fragment throws :malformed-fragment"
     (is (thrown-with-msg? :default #"malformed-fragment"


### PR DESCRIPTION
Closes rf2-dplwxh (P2 bug, review slice `tools/machines-viz`).

## Finding 1 — share decode now fails closed over the ChartState schema

`valid-chart-state?` runs on BOTH encode + decode, but it only checked the
required top-level keys (`valid-core-chart-state?`) plus the closed
`:snapshot` shape — it never rejected EXTRA top-level keys. A hand-crafted
share URL that bypasses `encode-share-url` could therefore carry
`:source-coords`, `:data`, or any future unreviewed top-level field and
`decode-share-url` would return it in the public envelope, contrary to the
viewer contract (`viewer.cljs:24-32`) that it never loads data outside the
validated payload schema.

**Fix:** `valid-chart-state?` is now CLOSED over
`chart-state-keys` = `#{:machine-id :frame-id :definition :snapshot}`
(`(every? chart-state-keys (keys cs))`). Any extra top-level key fails with
`:invalid-chart-state`. Encode/decode stay symmetric: `allowlist-chart-state`
only ever emits those four keys, so the encoder never produces a payload the
tightened predicate rejects (round-trip + privacy tests confirm).

**Adversarial tests** (bypass the encoder via `envelope->url`): extra
top-level `:source-coords`, extra `:data` (with a fake secret payload), an
unknown future namespaced key, the `decode-share-url-safe` `{:error …}` arm,
an extra key alongside a *valid* `:snapshot`, plus an over-tightening guard
(a legitimate exact-keys ChartState still round-trips). Existing flat /
compound / parallel `:snapshot :state` arms + privacy sanitisation stay green.

## Finding 2 — rendered-topology geometry gate

Added `topology-layout-gate-cljs-test`. The browser chart suite asserts
first-commit DOM BEFORE the async elkjs pass settles; the Xray feature gate
only requires `nodeCount > 0`; the PNG test proves nonblank, not topology
correctness — so wrong fit / overlap / bad routes / missing edges were
invisible to CI.

The gate drives the REAL `chart/compute-layout!` (elkjs — xyflow's own
layout backend — runs Node-side, no DOM/React), **awaits the layout settle**,
and asserts **post-layout geometry invariants** for the representative parity
machines (linear/cyclic, guarded fork, parallel, compound, Context-band):

- **Fit** — every leaf node lands at a distinct, finite, positive-area box;
  overall bbox finite + positive (catches the degenerate origin-stack).
- **No overlap** — no two leaf siblings overlap; every compound/region
  container encloses each child (catches a band painted over its contents).
- **No missing edges** — every projected transition has BOTH routed halves
  (`__in` + `__out`, events-as-nodes), each a ≥2-point polyline.
- **Route placement** — each half's endpoints stay within tolerance of the
  union box of its endpoint nodes.

Geometry invariants in lieu of cross-platform-flaky pixel baselines
(Windows dev / Mac+Linux maintainers); elkjs positions are deterministic
Node-side. Liveness verified by a temporary forced-fail (tripped exactly 5×,
one per machine class) then reverted.

`API.md` documents both the closed-decoder contract (Finding 1) and the new
geometry gate (Finding 2), including the run command for layout/projection/
visual-constant changes.

## Quality gates

- `cd implementation && npm run test:cljs` — **PASS** (7060 tests, 29001
  assertions, 0 failures, 0 errors). The 1 build warning is a pre-existing
  unrelated `resources_revalidation` undeclared-var, not from this change.
- `cd tools/machines-viz && clojure -M:test` (JVM `.cljc` corpus) — **PASS**
  (486 tests, 1710 assertions, 0 failures, 0 errors).
- Gate liveness confirmed (forced-fail probe → 5 failures, reverted).
