### PR TITLE
fix(resources): mutation-state fails closed without explicit frame (rf2-a76921)

### DIFF
--- a/implementation/resources/src/re_frame/resources.cljc
+++ b/implementation/resources/src/re_frame/resources.cljc
@@ -127,9 +127,12 @@
 ;; registrar kind; `clear-resource-scope` is the registration-lifecycle
 ;; removal; `resolve-resource-scope` is a resolver helper that resolves a
 ;; named scope against a supplied db value (the logout coeffect-db idiom) —
-;; not an effect (no app-state / dispatch side effects), but it emits
-;; `:rf.resource/scope-resolved` dev-time trace, so it is not a pure data
-;; helper (rf2-fi6tda.7).
+;; a PURE function over the resolver registry: not an effect (no app-state /
+;; dispatch side effects) and (rf2-ru73k6) NO observability side effect
+;; either, so it does NOT emit `:rf.resource/scope-resolved` trace. The
+;; `:rf.resource/scope-resolved` evidence is emitted only at the CAUSAL
+;; resolution boundaries (`{:from-db ...}` scope, route entry, mutation
+;; settle), per Spec 016 §Named resource-scope resolvers.
 (def reg-resource-scope     scope-registry/reg-resource-scope)
 (def clear-resource-scope   scope-registry/clear-resource-scope)
 (def resolve-resource-scope scope-registry/resolve-resource-scope)
@@ -222,9 +225,32 @@
   "Return a mutation INSTANCE's durable runtime row for an explicit
   `:frame` introspection target `{:instance :frame}` (EP-0003 §Mutations),
   or nil when no instance exists under that instance id in that frame. Per
-  EP-0002 the frame target is carried explicitly; a frameless call with no
-  resolvable context fails closed."
-  [{:keys [instance frame]}]
+  EP-0002 the frame target is carried explicitly; a frameless call FAILS
+  CLOSED (rf2-a76921): an absent / nil `:frame` raises the structured
+  `:rf.error/no-frame-context` rather than passing nil through to a
+  runtime-db lookup that returns nil — a nil that is INDISTINGUISHABLE from
+  a genuinely absent instance. This mirrors `resource-state`'s explicit-frame
+  contract; the two introspection halves now fail closed symmetrically.
+
+  Frame existence is NOT a precondition: an explicit but unknown / destroyed
+  `:frame` reads as `nil` runtime-db and returns `nil` (no instance) — the
+  same result as a live frame with no instance under that id. The fail-closed
+  boundary is the MISSING explicit target, not a vanished one; a valid
+  explicit frame lookup returns `nil` only for a genuinely absent instance."
+  [{:keys [instance frame] :as opts}]
+  (when (nil? frame)
+    (throw (ex-info ":rf.error/no-frame-context"
+                    {:rf.error/id :rf.error/no-frame-context
+                     :where       'rf/mutation-state
+                     :recovery    :pass-frame
+                     :reason      (str "mutation-state requires an explicit :frame "
+                                       "introspection target. A frameless call would "
+                                       "pass nil through to the runtime-db lookup and "
+                                       "return nil — indistinguishable from a genuinely "
+                                       "absent instance. Pass {:instance … "
+                                       ":frame <frame-id>}. Per EP-0003 §Mutations / "
+                                       "EP-0002.")
+                     :opts        (dissoc opts :frame)})))
   (let [runtime-db (frame/frame-runtime-db-value frame)]
     (get-in runtime-db (mstate/instance-path instance))))
 

--- a/implementation/resources/src/re_frame/resources/mutation_registry.cljc
+++ b/implementation/resources/src/re_frame/resources/mutation_registry.cljc
@@ -7,10 +7,12 @@
   causal-write counterpart of the `:resource` kind). `reg-mutation`
   validates the spec — the REQUIRED `:request` (the Spec 014 managed-HTTP
   args map the write lowers into) and `:params-schema` — and writes the
-  entry; `clear-mutation` is a registration-lifecycle removal that ALSO
-  disposes the mutation's runtime instances (EP-0003 §Public API:
-  \"clear the mutation registration and its runtime instances, not
-  masquerade as a form-level error reset\").
+  entry; `clear-mutation` is a registration-lifecycle removal of the
+  registrar entry ONLY. Runtime-instance disposal (drop the mutation's
+  instances in each affected frame + best-effort abort their in-flight
+  work) is the CAUSAL `:rf.mutation/clear` event's job (it carries a frame
+  target), distinct from this process-level registration removal — see the
+  `clear-mutation` docstring.
 
   Mirrors `re-frame.resources.registry` (the resource registrar) so the two
   registrars read as one family; the params-validation + (optional) scope

--- a/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_mutation_cljs_test.cljc
@@ -1606,3 +1606,41 @@
       (is (= 0 (count replied-rows))))
     (testing "the stale reply WAS recorded as stale-suppressed"
       (is (= 1 (count stale-rows))))))
+
+;; ===========================================================================
+;; 14. mutation-state fails closed without an explicit frame (rf2-a76921)
+;; ===========================================================================
+
+(deftest mutation-state-fails-closed-without-frame
+  ;; rf2-a76921 — the mutation introspection half MUST be symmetric with
+  ;; `resource-state` (rf2-c8lgy3): a frameless `mutation-state` call cannot
+  ;; silently pass nil through to `frame-runtime-db-value` (which returns nil
+  ;; for a missing frame) and return a nil that is INDISTINGUISHABLE from a
+  ;; genuinely absent instance. Per EP-0002 the frame target is carried
+  ;; explicitly; the MISSING explicit target fails closed.
+  (rf/reg-mutation :m/save (save-article-spec))
+  (testing "a frameless mutation-state call raises :rf.error/no-frame-context
+            (never a silent nil that is indistinguishable from an absent
+            instance)"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"no-frame-context"
+          (rf/mutation-state {:instance :ms-no-frame}))))
+  (testing "an explicit nil :frame ALSO fails closed (nil is not a frame)"
+    (is (thrown-with-msg?
+          #?(:clj Throwable :cljs js/Error) #"no-frame-context"
+          (rf/mutation-state {:instance :ms-no-frame :frame nil}))))
+  (testing "a valid explicit frame returns nil ONLY for a genuinely absent
+            instance (the fail-closed boundary is the missing target, not a
+            vanished one)"
+    (is (nil? (rf/mutation-state {:instance :ms-absent :frame :rf/default}))))
+  (testing "an explicit but UNKNOWN / destroyed frame reads as nil runtime-db
+            and returns nil (no instance) — same result as a live frame with
+            no instance for the id, NOT a fail-closed throw"
+    (is (nil? (rf/mutation-state {:instance :ms-absent :frame :no/such-frame}))))
+  (testing "a valid explicit frame returns the instance row when present"
+    (rf/dispatch-sync [:rf.mutation/execute
+                       {:mutation :m/save :params {:slug "w"} :instance :ms-present}])
+    (reply-success! @last-managed-args {:ok true})
+    (let [row (rf/mutation-state {:instance :ms-present :frame :rf/default})]
+      (is (some? row))
+      (is (= :success (:status row))))))


### PR DESCRIPTION
## Summary

`rf/mutation-state` did not enforce the explicit-frame / no-ambient-default contract that the resources introspection surface promises (Spec 016 Introspection, EP-0002). It destructured `{:instance :frame}` and called `frame/frame-runtime-db-value` with the supplied frame with **no nil-frame guard**. Since `frame-runtime-db-value` returns `nil` for an unknown/destroyed frame, a missing or nil `:frame` **silently returned nil** — indistinguishable from a real explicit frame that simply has no such mutation instance. This violated the EP-0002 carried-frame posture and was asymmetric with `resource-state`, which already throws `:rf.error/no-frame-context` for a nil frame.

## Root cause

`mutation-state` (`implementation/resources/src/re_frame/resources.cljc`) lacked the nil-frame fail-closed guard that `resource-state` has. The mutation introspection half fell through to a runtime-db lookup that returns nil for a missing frame, conflating "no frame given" with "no instance for this id".

## Fix

- Added the same fail-closed guard `resource-state` carries: a missing or nil `:frame` now raises structured `:rf.error/no-frame-context` (`:where 'rf/mutation-state`, `:recovery :pass-frame`). An **explicit but unknown/destroyed** frame still reads nil runtime-db and returns nil — the fail-closed boundary is the *missing* explicit target, not a vanished one. The two introspection halves are now symmetric.
- Adversarial regression test (`resources_mutation_cljs_test.cljc`): frameless call -> raises; explicit `nil` frame -> raises; valid explicit frame, absent instance -> nil; unknown frame -> nil (not a throw); valid frame, present instance -> row.
- Aligned two stale source comments flagged on the same surface:
  - `resolve-resource-scope` facade comment claimed it emits `:rf.resource/scope-resolved` trace and "is not a pure data helper" — Spec 016 lines 557-559 and the implementation (`scope_registry.cljc`) make it trace-free/passive.
  - `mutation_registry.cljc` ns prose said `clear-mutation` "ALSO disposes the mutation's runtime instances" — its body, docstring, and the API doc say it removes only the registration (runtime reset is the causal `:rf.mutation/clear` event's job).
- No Spec/API change: the already-documented contract (`docs/api/16-resources.md` Introspection intro + EP-0002 reference) was correct; this brings the implementation into line. `mutations` / `resources` no-arg static introspection unchanged.

## Quality gates

- `clojure -M:test` (implementation/resources, JVM): **403 tests, 1587 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node-runtime CLJS): **7070 tests, 29039 assertions, 0 failures, 0 errors** (includes the new `mutation-state-fails-closed-without-frame` regression)
