### PR TITLE
fix(examples): SSR examples against current hydration payload contract (rf2-2pjgiq)

### DIFF
--- a/examples/reagent/resources_ssr/core.cljc
+++ b/examples/reagent/resources_ssr/core.cljc
@@ -61,6 +61,12 @@
             ;; omitted per the resource's classification; indexes recompute on
             ;; install). Server-side only — `handle-request` (`:clj`) uses it.
             #?(:clj [re-frame.ssr.payload-policy :as payload-policy])
+            ;; The EDN-aware `<script>`-body escaper the production Ring host
+            ;; uses (`re-frame.ssr.ring.shell/payload-script-tag` →
+            ;; `escape-edn-script-body`). Server-side only — a server-provided
+            ;; string carrying `</script>` would otherwise close the payload
+            ;; `<script>` envelope (security audit 2026-05-14 §P1, rf2-7ksyr).
+            #?(:clj [re-frame.ssr.html-helpers :as html])
             #?(:cljs [reagent.dom.client :as rdc])
             #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
 
@@ -185,25 +191,54 @@
                  html          (rf/render-to-string hiccup {:doctype? true :emit-hash? true})
                  render-hash   (rf/render-tree-hash hiccup)
                  ;; (2) build the canonical payload the way the Ring host does:
-                 ;; the app-db slice through the fail-closed allowlist (empty
-                 ;; here — no app-db state to ship), and the runtime-db through
-                 ;; the SSR projection (only the allowed resource `:entries`).
-                 policy-opts   {:payload []}
+                 ;; the app-db slice through the fail-closed allowlist, and
+                 ;; the runtime-db through the SSR projection (only the allowed
+                 ;; resource `:entries`).
+                 ;;
+                 ;; The page state is the RESOURCE (it rides `:rf/runtime-db`),
+                 ;; so app-db carries nothing of its own — but `:payload` is
+                 ;; FAIL-CLOSED and an empty `[]` allowlist is treated as
+                 ;; MISSING policy (it throws `:rf.error/ssr-missing-payload-
+                 ;; policy`), not as a valid empty allowlist (Spec 011 §`:rf/app-db`
+                 ;; projection). The explicit, valid policy for "ship the whole
+                 ;; (here empty) app-db" is the `:rf.ssr.payload/whole-app-db`
+                 ;; opt-in keyword — it projects the empty app-db to `{}`
+                 ;; cleanly.
+                 policy-opts   {:payload :rf.ssr.payload/whole-app-db}
                  payload       (payload-policy/build-payload
                                  f
                                  (payload-policy/apply-policy final-db policy-opts)
                                  render-hash
                                  (assoc policy-opts
                                         :runtime-db (payload-policy/project-runtime-db
-                                                      final-runtime)))]
+                                                      final-runtime)))
+                 ;; EP-0002 (rf2-acjknb): `build-payload` stamps the per-request
+                 ;; server frame (`f`) as `:rf/frame-id`, but the client
+                 ;; hydrates a FIXED app-frame (`app-frame` → `:rf/default`,
+                 ;; below). `ssr/hydrate!` VALIDATES a present payload
+                 ;; `:rf/frame-id` against the client's explicit `:frame` and
+                 ;; raises `:rf.error/hydration-frame-id-mismatch` on
+                 ;; disagreement (Spec 011 §The hydration payload). The server's
+                 ;; per-request gensym would always conflict with the client's
+                 ;; fixed frame, so we DROP it — an absent `:rf/frame-id` is
+                 ;; explicitly NO conflict (the explicit client target stands),
+                 ;; matching the static `index.html` next to this file. A
+                 ;; deployment that wants a frame-id on the wire stamps a STABLE
+                 ;; id both sides agree on, not a per-request gensym.
+                 payload       (dissoc payload :rf/frame-id)]
              {:status  200
               :headers {"Content-Type" "text/html"}
               :body
               (str "<!DOCTYPE html><html><head><meta charset='utf-8'/>"
                    "<title>Resources SSR demo</title></head><body>"
                    "<div id='app'>" html "</div>"
+                   ;; Emit the payload `<script>` through the EDN-aware
+                   ;; `</script>`-escaper the production Ring host uses
+                   ;; (security audit 2026-05-14 §P1, rf2-7ksyr) so a server-
+                   ;; provided string carrying `</script>` can't close the
+                   ;; envelope.
                    "<script id='__rf_payload' type='application/edn'>"
-                   (pr-str payload)
+                   (html/escape-edn-script-body (pr-str payload))
                    "</script><script src='/main.js'></script>"
                    "</body></html>")}))
          (finally
@@ -222,6 +257,16 @@
 
 #?(:cljs (defonce react-root (atom nil)))
 
+;; EP-0002 (rf2-acjknb): the SSR hydration target is CARRIED — established
+;; explicitly here and threaded through both `ssr/hydrate!` and the root
+;; `frame-provider`. This example uses `:rf/default` as its FIXED client
+;; app-frame. `handle-request` above renders under a per-request gensym frame
+;; but DROPS `:rf/frame-id` from the wire payload (an absent frame-id is no
+;; conflict with this explicit target); a present-but-different stamp would
+;; raise `:rf.error/hydration-frame-id-mismatch` in `ssr/hydrate!` (Spec 011
+;; §The hydration payload). The frame MUST be `:client`-platform so the
+;; `:rf.ssr/check-*` compatibility-check fxs the `:rf/hydrate` handler
+;; dispatches actually fire.
 (def app-frame :rf/default)
 
 #?(:cljs

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -63,6 +63,17 @@
             ;; `:ssr/project-error`). Without the require the four core
             ;; re-exports raise `:rf.error/ssr-artefact-missing`.
             [re-frame.ssr :as ssr]
+            ;; The EDN-aware `<script>`-body escaper the production Ring
+            ;; host uses (`re-frame.ssr.ring.shell/payload-script-tag` →
+            ;; `escape-edn-script-body`). Server-side only — the `:clj`
+            ;; `handle-request` drops the `pr-str`'d payload inside a
+            ;; `<script type="application/edn">` body and a server-provided
+            ;; string containing `</script>` would otherwise close the
+            ;; envelope (security audit 2026-05-14 §P1, rf2-7ksyr). It lives
+            ;; in the SSR artefact (`re-frame.ssr.html-helpers`), so it ships
+            ;; with the same `day8/re-frame2-ssr` dep the example already
+            ;; requires above.
+            #?(:clj [re-frame.ssr.html-helpers :as html])
             #?(:cljs [reagent.dom.client :as rdc])
             #?(:cljs [re-frame.adapter.reagent :as reagent-adapter])))
 
@@ -252,8 +263,25 @@
                  ;; environments (server logs, CDN cache keys) can read it
                  ;; without HTML parsing.
                  render-hash (rf/render-tree-hash hiccup)
+                 ;; EP-0002 (rf2-acjknb): the payload DELIBERATELY OMITS
+                 ;; `:rf/frame-id`. The server renders under a per-request
+                 ;; gensym frame (`f`), but the client hydrates a FIXED app-
+                 ;; frame (`app-frame` → `:rf/default`, below). `ssr/hydrate!`
+                 ;; VALIDATES a present payload `:rf/frame-id` against the
+                 ;; client's explicit `:frame` and raises
+                 ;; `:rf.error/hydration-frame-id-mismatch` on disagreement
+                 ;; (Spec 011 §The hydration payload — the frame-id is
+                 ;; validation evidence, NOT a target resolver). Stamping the
+                 ;; server's per-request gensym here would always conflict
+                 ;; with the client's fixed frame; an ABSENT `:rf/frame-id` is
+                 ;; explicitly NO conflict (the explicit client target
+                 ;; stands), so the dynamic server output matches the static
+                 ;; `index.html` next to this file exactly. A deployment that
+                 ;; WANTS the round-trip to carry a frame-id stamps a STABLE
+                 ;; id both sides agree on (or has the client read the
+                 ;; payload's frame-id as its hydration target) — not a
+                 ;; per-request gensym.
                  payload  {:rf/version     1
-                           :rf/frame-id    f
                            :rf/app-db      final-db        ;; app-db partition
                            :rf/runtime-db  final-runtime   ;; serializable runtime-db projection
                            :rf/render-hash render-hash}]
@@ -265,8 +293,17 @@
                    "<title>SSR demo</title>"
                    "</head><body>"
                    "<div id='app'>" html "</div>"
+                   ;; Emit the payload `<script>` through the EDN-aware
+                   ;; `</script>`-escaper the production Ring host uses
+                   ;; (security audit 2026-05-14 §P1, rf2-7ksyr): a server-
+                   ;; provided string carrying `</script>` (round-tripped
+                   ;; through app-db) can't close the envelope. The encoder
+                   ;; rewrites a less-than char to its unicode reader escape
+                   ;; ONLY inside EDN string literals, so the payload still
+                   ;; round-trips through the client's `cljs.reader/read-string`
+                   ;; unchanged.
                    "<script id='__rf_payload' type='application/edn'>"
-                   (pr-str payload)
+                   (html/escape-edn-script-body (pr-str payload))
                    "</script>"
                    "<script src='/main.js'></script>"
                    "</body></html>")}))
@@ -327,11 +364,16 @@
 ;; runtime will not infer it). It MUST be a `:client`-platform frame so the
 ;; `:rf.ssr/check-*` compatibility-check fxs the `:rf/hydrate` handler
 ;; dispatches actually fire (Spec 011 §The :rf/hydrate event — a `:server`-
-;; platform frame skips them). The static `index.html` payload carries no
-;; `:rf/frame-id` (a real server stamps it via `handle-request` above), which
-;; is NOT a hydration-frame-id conflict — the explicit `:frame` stands; a
-;; present-but-different payload `:rf/frame-id` would surface a structured
-;; `:rf.error/hydration-frame-id-mismatch` (Spec 011 §The hydration payload).
+;; platform frame skips them). BOTH the static `index.html` payload AND the
+;; dynamic `handle-request` payload above carry NO `:rf/frame-id`: the server
+;; renders under a per-request gensym frame the client can't know ahead of
+;; time, and the client hydrates this FIXED app-frame, so an absent frame-id
+;; is the correct shape (it is NOT a hydration-frame-id conflict — the
+;; explicit `:frame` stands). A present-but-different payload `:rf/frame-id`
+;; — e.g. the server's per-request gensym against this `:rf/default` client
+;; target — WOULD surface a structured `:rf.error/hydration-frame-id-mismatch`
+;; (Spec 011 §The hydration payload), which is exactly why `handle-request`
+;; omits it.
 (def app-frame :rf/default)
 
 #?(:cljs

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -156,6 +156,19 @@
                              fid render-hash
                              {:version 1
                               :payload :rf.ssr.payload/whole-app-db}))
+           ;; EP-0002 (rf2-acjknb): `streaming-build-final-payload` stamps the
+           ;; per-request server frame (`fid`) as `:rf/frame-id`, but the
+           ;; client hydrates a FIXED app-frame (`app-frame` → `:rf/default`,
+           ;; below). `ssr/hydrate!` VALIDATES a present payload `:rf/frame-id`
+           ;; against the client's explicit `:frame` and raises
+           ;; `:rf.error/hydration-frame-id-mismatch` on disagreement (Spec 011
+           ;; §The hydration payload). The server's per-request gensym would
+           ;; always conflict with the client's fixed frame, so we DROP it —
+           ;; an absent `:rf/frame-id` is explicitly NO conflict (the explicit
+           ;; client target stands), matching the static `index.html` next to
+           ;; this file. A deployment that wants a frame-id on the wire stamps
+           ;; a STABLE id both sides agree on, not a per-request gensym.
+           final-payload (dissoc final-payload :rf/frame-id)
            _ (rf/destroy-frame! fid)]
        {:shell shell-html
         :resolved-chunks resolved-chunks
@@ -213,10 +226,15 @@
 ;; never synthesises a frame from absence. This example uses `:rf/default`
 ;; as its client app-frame id; it MUST be a `:client`-platform frame so the
 ;; `:rf.ssr/check-*` compatibility-check fxs the `:rf/hydrate` handler
-;; dispatches actually fire (Spec 011 §The :rf/hydrate event). The static
-;; `index.html` payload carries no `:rf/frame-id` (a real streaming server
-;; stamps it via `handle-request`/`streaming-build-final-payload` above),
-;; which is NOT a hydration-frame-id conflict — the explicit `:frame` stands.
+;; dispatches actually fire (Spec 011 §The :rf/hydrate event). BOTH the static
+;; `index.html` payload AND the dynamic `handle-request` final-payload above
+;; carry NO `:rf/frame-id`: the server renders under a per-request gensym
+;; frame the client can't know ahead of time, and the client hydrates this
+;; FIXED app-frame, so an absent frame-id is the correct shape (it is NOT a
+;; hydration-frame-id conflict — the explicit `:frame` stands). A present-but-
+;; different stamp (the server's per-request gensym against this `:rf/default`
+;; client target) WOULD surface `:rf.error/hydration-frame-id-mismatch` (Spec
+;; 011 §The hydration payload), which is why `handle-request` drops it.
 #?(:cljs (def app-frame :rf/default))
 
 #?(:cljs

--- a/implementation/core/test/re_frame/examples_test.clj
+++ b/implementation/core/test/re_frame/examples_test.clj
@@ -19,6 +19,7 @@
   reset registrar) and exercises it directly."
   (:require [clojure.set]
             [clojure.string]
+            [clojure.edn :as edn]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -26,6 +27,12 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
+            ;; The resources artefact (Spec 016) — TEST-ONLY dep on the core
+            ;; test classpath (deps.edn `:test` alias). Loading it registers
+            ;; the resource registrar kind, the `:rf.resource/*` events/subs,
+            ;; and the late-bound SSR runtime-db projection + hydration
+            ;; reconcile hooks the `resources-ssr` example drives.
+            [re-frame.resources]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.error-listener :as ssr-error-listener]
             [re-frame.ssr.request :as ssr-request]
@@ -76,6 +83,15 @@
   ;; idempotent (won't re-fire the toplevel forms once loaded), so reload here
   ;; — mirroring the http / machines reloads above (rf2-kb7zis).
   (require 're-frame.ssr :reload)
+  ;; clear-all! also drops the resources artefact's registrar kind +
+  ;; `:rf.resource/*` events/subs AND its late-bind hooks
+  ;; (`:ssr/extend-runtime-db-projection`, `:resources/hydrate-runtime-db`)
+  ;; — the `resources-ssr` example's `handle-request` ensures + drains a
+  ;; resource and its client hydrate reconciles the resource projection, so
+  ;; both surfaces need resurrecting. Transitive require from the example ns
+  ;; is idempotent once loaded, so reload here (mirrors the http/machines/ssr
+  ;; reloads above, rf2-2pjgiq).
+  (require 're-frame.resources :reload)
   ;; Reset the SSR per-frame side-channel atoms (request slots, response
   ;; accumulators, pending error traces) between tests. These are `defonce`
   ;; tables keyed by frame-id, OUTSIDE app-db, so neither `clear-all!` nor
@@ -91,6 +107,7 @@
   ;; re-evaluates their namespace-level handlers against a fresh registrar.
   (remove-ns 'ssr.core)
   (remove-ns 'ssr-streaming.core)
+  (remove-ns 'resources-ssr.core)
   (remove-ns 'state-machine-walkthrough.core)
   ;; EP-0002 (rf2-9o48ih): `init!` no longer synthesises `:rf/default`;
   ;; framework operation surfaces require a carried frame stamp. Register
@@ -400,6 +417,190 @@
       (is (some? (:rf/render-hash (:final-payload result))))
       (is (= 3 (count (:cards (:rf/app-db (:final-payload result)))))
           "three cards' state in the final payload (revenue, signups, latency); the flaky card has no app-db slice because it threw before its data fetched"))))
+
+;; ============================================================================
+;; SSR examples — dynamic payload path round-trip (rf2-2pjgiq).
+;;
+;; The acceptance gate the review (rf2-2pjgiq) named: feed the ACTUAL dynamic
+;; example payload — the plain `handle-request` HTML payload, the resources
+;; `handle-request` HTML payload, and the streaming `final-payload` — into the
+;; framework `ssr/hydrate!` against the example's OWN client frame
+;; (`:rf/default`) and assert NO `:rf.error/hydration-frame-id-mismatch` plus
+;; the expected hydrated state. The earlier example tests covered server and
+;; client separately with hand-built payloads that omitted `:rf/frame-id`;
+;; these drive the real server→client wire so a drift back to stamping the
+;; per-request server gensym (which would conflict with the fixed
+;; `:rf/default` client frame) fails loud here.
+;;
+;; The fix (rf2-2pjgiq): the dynamic example payloads deliberately OMIT
+;; `:rf/frame-id` (an absent frame-id is no conflict; the explicit client
+;; target stands — Spec 011 §The hydration payload), and the manual payload
+;; `<script>` emission routes through the EDN-aware `escape-edn-script-body`
+;; so a server-provided `</script>` can't close the envelope.
+;; ============================================================================
+
+(defn- extract-payload-edn
+  "Pull the `__rf_payload` EDN string out of an SSR example's HTML body and
+  read it. `clojure.edn/read-string` decodes the `\\u003c` reader escapes
+  `escape-edn-script-body` emits inside string literals, so the parsed value
+  is the exact payload the server built."
+  [html-body]
+  (let [m (re-find #"(?s)id='__rf_payload' type='application/edn'>(.*?)</script>"
+                   html-body)]
+    (some-> (second m) edn/read-string)))
+
+(deftest ssr-example-dynamic-payload-hydrates-without-frame-id-mismatch
+  (testing "examples/reagent/ssr — the payload the dynamic `handle-request`
+            emits feeds into `ssr/hydrate!` against the example's `:rf/default`
+            client frame with NO `:rf.error/hydration-frame-id-mismatch` (the
+            payload omits the per-request server frame-id) and seeds the
+            client app-db with the server's articles (rf2-2pjgiq)"
+    (require 'ssr.core :reload)
+    (rf/init! ssr/adapter)
+    (install-canned-articles-stub!)
+    (let [handle-request (resolve 'ssr.core/handle-request)
+          resp           (rf/with-fx-overrides
+                           {:rf.http/managed :ssr.http/canned-articles}
+                           (handle-request {:uri "/articles"}))
+          payload        (extract-payload-edn (:body resp))]
+      (is (= 200 (:status resp)))
+      (is (some? payload) "the __rf_payload EDN parsed out of the HTML body")
+      (is (not (contains? payload :rf/frame-id))
+          (str "the dynamic payload OMITS :rf/frame-id (server gensym frame "
+               "would conflict with the fixed :rf/default client frame)"))
+      ;; Hydrate the example's OWN client frame (:rf/default, a :client frame).
+      (let [client-frame @(resolve 'ssr.core/app-frame)
+            _            (rf/reg-frame client-frame
+                           {:doc "ssr-example client frame" :platform :client})
+            returned     (ssr/hydrate! {:frame client-frame :payload payload})]
+        (is (= payload returned)
+            "hydrate! applied the payload (no frame-id conflict thrown)")
+        (is (= [{:id "a" :title "Article A" :body "Body A"}
+                {:id "b" :title "Article B" :body "Body B"}]
+               (:articles (rf/app-db-value client-frame)))
+            "the client app-db carries the server's articles after hydration")))))
+
+(deftest ssr-example-payload-script-escapes-script-breakout
+  (testing "examples/reagent/ssr — a server-provided string containing
+            `</script>` (round-tripped through app-db) is escaped by the
+            EDN-aware `<script>`-body encoder, so it CANNOT close the
+            `__rf_payload` envelope, and the payload still round-trips through
+            the client EDN reader unchanged (security audit 2026-05-14 §P1,
+            rf2-7ksyr / rf2-2pjgiq)"
+    (require 'ssr.core :reload)
+    (rf/init! ssr/adapter)
+    ;; A canned stub whose article title carries a `</script>` breakout
+    ;; precursor — the exact XSS shape the EDN-aware escaper exists to defang.
+    (rf/reg-fx :ssr.http/canned-evil
+      {:platforms #{:server :client}}
+      (fn [frame-ctx args-map]
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx
+                (assoc args-map
+                       :value [{:id "x"
+                                :title "</script><script>alert('xss')</script>"
+                                :body "b"}])))))
+    (let [handle-request (resolve 'ssr.core/handle-request)
+          resp           (rf/with-fx-overrides
+                           {:rf.http/managed :ssr.http/canned-evil}
+                           (handle-request {:uri "/x"}))
+          body           (:body resp)]
+      (is (= 200 (:status resp)))
+      ;; The raw breakout must NOT appear verbatim — the `<` inside the EDN
+      ;; string literal is escaped to the `<` reader escape.
+      (is (not (clojure.string/includes?
+                 body "</script><script>alert('xss')</script>"))
+          "the raw </script> breakout must not survive into the HTML")
+      (is (clojure.string/includes? body "\\u003c")
+          "the breakout `<` is escaped to the \\u003c EDN reader escape")
+      ;; And the escaped payload still parses back to the exact server value —
+      ;; the EDN reader decodes < inside the string literal.
+      (let [payload (extract-payload-edn body)]
+        (is (= "</script><script>alert('xss')</script>"
+               (-> payload :rf/app-db :articles first :title))
+            "the payload round-trips through the EDN reader unchanged")))))
+
+(deftest ssr-streaming-example-final-payload-hydrates-without-frame-id-mismatch
+  (testing "examples/reagent/ssr_streaming — the dynamic `handle-request`
+            `:final-payload` feeds into `ssr/hydrate!` against the example's
+            `:rf/default` client frame with NO frame-id mismatch (it omits the
+            per-request server frame-id) and seeds the client app-db with the
+            three streamed cards (rf2-2pjgiq)"
+    (require 'ssr-streaming.core :reload)
+    (rf/init! ssr/adapter)
+    (let [handle-request (resolve 'ssr-streaming.core/handle-request)
+          result         (handle-request {:uri "/dashboard"})
+          payload        (:final-payload result)]
+      (is (not (contains? payload :rf/frame-id))
+          "the streaming final-payload OMITS :rf/frame-id")
+      ;; The example's `app-frame` is `:cljs`-only (the streaming client boot
+      ;; is browser-side), so reference its value (`:rf/default`) directly
+      ;; here — the JVM cannot resolve a reader-conditional `:cljs` def.
+      (let [client-frame :rf/default
+            _            (rf/reg-frame client-frame
+                           {:doc "ssr-streaming-example client frame"
+                            :platform :client})
+            returned     (ssr/hydrate! {:frame client-frame :payload payload})]
+        (is (= payload returned)
+            "hydrate! applied the final-payload (no frame-id conflict thrown)")
+        (is (= 3 (count (:cards (rf/app-db-value client-frame))))
+            "the client app-db carries the three streamed cards after hydration")))))
+
+(deftest resources-ssr-example-dynamic-payload-hydrates-without-frame-id-mismatch
+  (testing "examples/reagent/resources_ssr — the payload the dynamic
+            `handle-request` emits (under the valid
+            `:rf.ssr.payload/whole-app-db` policy, NOT the invalid empty
+            `[]`) feeds into `ssr/hydrate!` against the example's `:rf/default`
+            client frame with NO frame-id mismatch and installs the SSR-
+            preloaded resource entry into the client `:rf.runtime/resources`
+            slice (Spec 016 §SSR client hydration, rf2-2pjgiq)"
+    (require 'resources-ssr.core :reload)
+    (rf/init! ssr/adapter)
+    ;; Stub the resource's managed-HTTP fetch with a canned-success reply so
+    ;; the example's blocking drain settles the page resource synchronously
+    ;; (no real network; mirrors the plain-SSR canned-articles stub).
+    (rf/reg-fx :resources-ssr.http/canned
+      {:platforms #{:server :client}}
+      (fn [frame-ctx args-map]
+        (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+          (stub frame-ctx
+                (assoc args-map
+                       :value [{:slug "welcome"   :title "Welcome to re-frame2"}
+                               {:slug "resources" :title "Server-state as resources"}])))))
+    (let [handle-request (resolve 'resources-ssr.core/handle-request)
+          resp           (rf/with-fx-overrides
+                           {:rf.http/managed :resources-ssr.http/canned}
+                           (handle-request {:uri "/articles"}))
+          payload        (extract-payload-edn (:body resp))]
+      (is (= 200 (:status resp))
+          (str "the dynamic handle-request returned 200 (valid payload policy "
+               "— an empty `[]` policy would have thrown "
+               ":rf.error/ssr-missing-payload-policy)"))
+      (is (some? payload))
+      (is (not (contains? payload :rf/frame-id))
+          "the resources payload OMITS :rf/frame-id")
+      ;; The runtime-db projection carries the loaded resource entry (the
+      ;; allowed `:entries`, not the indexes).
+      (let [entries (get-in payload [:rf/runtime-db :rf.runtime/resources :entries])]
+        (is (= 1 (count entries)) "one resource entry rides :rf/runtime-db")
+        (is (= :loaded (-> entries vals first :status))
+            "the SSR-preloaded resource settled :loaded before render"))
+      ;; Hydrate the example's OWN :rf/default client frame.
+      (let [client-frame @(resolve 'resources-ssr.core/app-frame)
+            _            (rf/reg-frame client-frame
+                           {:doc "resources-ssr-example client frame"
+                            :platform :client})
+            returned     (ssr/hydrate! {:frame client-frame :payload payload})]
+        (is (= payload returned)
+            "hydrate! applied the payload (no frame-id conflict thrown)")
+        ;; The client runtime-db carries the reconciled resource entry — the
+        ;; reverse indexes are recomputed from `:entries` on install (Spec 016).
+        (let [client-entries (get-in (rf/runtime-db-value client-frame)
+                                     [:rf.runtime/resources :entries])]
+          (is (= 1 (count client-entries))
+              "the hydrated resource entry installed into the client frame")
+          (is (= :loaded (-> client-entries vals first :status))
+              "the hydrated entry is :loaded (renders immediately, no refetch)"))))))
 
 ;; ============================================================================
 ;; state-machine-walkthrough — chapter §Headless testing. Two flavours:


### PR DESCRIPTION
Fixes **rf2-2pjgiq** (P2 bug). The worked SSR examples' dynamic server branches had drifted from the current hydration payload contract. Static demo pages and the prior tests avoided the failing shapes, so the drift shipped green.

## What changed

Three example sources (`examples/reagent/{ssr,resources_ssr,ssr_streaming}/core.cljc`):

1. **Frame-id mismatch (finding 1).** Each dynamic `handle-request` stamped the per-request server gensym frame as `:rf/frame-id`, but the client hydrates a FIXED `:rf/default` app-frame. `ssr/hydrate!` validates a present payload `:rf/frame-id` against the explicit client `:frame` and throws `:rf.error/hydration-frame-id-mismatch` on disagreement (`implementation/ssr/src/re_frame/ssr/boot.cljc`, Spec 011 §The hydration payload). All three dynamic examples now **omit** `:rf/frame-id` (an absent frame-id is explicitly no conflict — the explicit client target stands), matching the static `index.html` shape exactly. Documented inline per the acceptance criterion.

2. **Unsafe script emission (finding 2).** The plain/resources examples concatenated raw `(pr-str payload)` into the `<script type="application/edn">` body — a server-provided `</script>` could close the envelope. They now route through the EDN-aware `escape-edn-script-body` the production Ring host uses (`re-frame.ssr.html-helpers`, security audit 2026-05-14 §P1, rf2-7ksyr). Streaming's `handle-request` returns the payload as data (no manual script), so it needed only the frame-id fix.

3. **Invalid resources payload policy (finding 3).** `resources_ssr` used `:payload []`, which the current fail-closed contract treats as MISSING policy (throws `:rf.error/ssr-missing-payload-policy`). It now uses the valid `:rf.ssr.payload/whole-app-db` opt-in (the page state is the resource; app-db is empty and ships as `{}`).

## Tests

Examples are test-free (rf2-8cevm), so the contract-regression tests live in the framework test tree (`implementation/core/test/re_frame/examples_test.clj`). They drive the **real** dynamic example payload path (acceptance criterion 4): feed each `handle-request` HTML payload / streaming `final-payload` into `ssr/hydrate!` against the example's own `:rf/default` client frame and assert **no frame-id mismatch** plus the expected hydrated app-db / resource state. Plus a `</script>`-breakout escaping regression (criterion 2) asserting the raw breakout does not survive into the HTML and the payload still round-trips through the EDN reader unchanged.

## Quality gates

- `npm run test:examples-compile` — PASS (42 example builds, 0 warnings; incl. `:examples/ssr`, `:examples/resources-ssr`, `:examples/ssr-streaming`)
- `npm run test:cljs` — PASS (7069 tests, 29033 assertions, 0 failures/0 errors)
- `npm run test:examples` — PASS (3 adapter smokes, 0 failures/0 skipped)
- `clojure -M:test -n re-frame.examples-test` (JVM) — PASS (13 tests, 59 assertions; +4 new tests)
- `clojure -M:test` in `implementation/ssr` (JVM) — PASS (337 tests, 1349 assertions; unchanged baseline)