### PR TITLE
refactor(epoch): prune legacy restore fallback (rf2-cawt1f)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -479,10 +479,10 @@
   — the WHOLE frame-state, reinstalling app-db AND runtime-db as two
   separate partitions in ONE atomic write (EP-0001 rf2-3aizt1: reviving
   machine snapshots, the route slice, elision declarations, and SSR
-  metadata, not just the app-db partition). The retained `:db-after` is
-  an OPTIONAL app-db projection used only as a legacy fallback for
-  records that carry no `:frame-state-after`. Emits `:rf.epoch/restored`
-  on success.
+  metadata, not just the app-db partition). `:frame-state-after` is the
+  only restore source — every record `build-record` emits carries it; the
+  retained `:db-after` is an OPTIONAL app-db projection for tool diffs,
+  never a restore source. Emits `:rf.epoch/restored` on success.
 
   Failure modes (each is a no-op on the frame-state and emits a
   structured error trace):

--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -390,7 +390,7 @@
 
     {:outcome :ok :epoch <epoch>}
                  — all checks passed; `:epoch` is the resolved history
-                   record whose `:db-after` is the restore target.
+                   record whose `:frame-state-after` is the restore target.
     {:outcome :fail :op <kw> :tags <map>}
                  — first failing check; `:op` is the trace operation
                    the caller must emit, `:tags` are its tags. No
@@ -444,16 +444,16 @@
           :else
           (let [;; EP-0001 (rf2-3aizt1, decision #2): the canonical restore
                 ;; target is the whole frame-state. The app-db partition
-                ;; (`:db-after` is its retained projection — equal to
-                ;; `(:rf.db/app frame-state-after)`) feeds the schema check;
-                ;; the runtime-db partition feeds the machine / route
-                ;; reference + version checks (rf2-k4xe7u — snapshots + route
-                ;; slice are runtime-db state). Read both off the canonical
-                ;; `:frame-state-after`, falling back to the `:db-after`
-                ;; projection for the app-db slice (always present alongside).
+                ;; feeds the schema check; the runtime-db partition feeds
+                ;; the machine / route reference + version checks (rf2-k4xe7u
+                ;; — snapshots + route slice are runtime-db state). Both are
+                ;; read off the canonical `:frame-state-after` — the only
+                ;; restore target `build-record` ever emits (the `:db-after`
+                ;; slot is a retained app-db PROJECTION for tool diffs, never
+                ;; a restore source). A record with no `:frame-state-after`
+                ;; is malformed/unreachable on the current build path.
                 frame-state-target (:frame-state-after epoch)
-                db-target          (or (get frame-state-target frame/app-partition-key)
-                                       (:db-after epoch))
+                db-target          (get frame-state-target frame/app-partition-key)
                 runtime-target     (get frame-state-target frame/runtime-partition-key)]
             ;; Each helper is called once and its result bound, so the
             ;; failure path walks the recorded db / schema set / machine
@@ -561,8 +561,8 @@
   `:resources/reconcile-on-restore` hook (Spec 016 §Restore and replay). Returns
   the frame-state with its `:rf.db/runtime` partition reconciled — or
   `frame-state` unchanged when no resources artefact is loaded (the hook is nil),
-  or when the frame-state carries no runtime-db partition (a legacy / app-db-only
-  record). The runtime-db value is passed with the carried `frame-id` so the
+  or when the frame-state carries no runtime-db partition (a `:frame-state-after`
+  whose runtime-db is empty). The runtime-db value is passed with the carried `frame-id` so the
   reconcile can stamp its trace. Other runtime subsystems (machines, routing)
   reconcile their own snapshots through their own contracts; this seam is the
   resources-first extension point, mirroring SSR hydration's single
@@ -583,9 +583,8 @@
   `:settled-at` from that causal input rather than the live install clock
   (`now-ms`). A durable frame-state field MUST come from a causal input, never
   an ambient world read at install (EP-0010 §Restore/Replay). The 2-arity
-  passes a nil causal time (a legacy / app-db-only record carries no mutation
-  instances to stamp; the reconcile then falls back to its own clock for the
-  no-token case)."
+  passes a nil causal time (a frame-state with no mutation instances to stamp;
+  the reconcile then falls back to its own clock for the no-token case)."
   ([frame-id frame-state] (reconcile-runtime-db-on-restore frame-id frame-state nil))
   ([frame-id frame-state restore-time-ms]
    (if-let [reconcile (late-bind/get-fn :resources/reconcile-on-restore)]
@@ -625,10 +624,11 @@
   snapshots, the route slice, elision declarations, and SSR metadata
   (runtime-db state) — not just the app-db partition. Without this, a
   rewind past a machine spawn / destroy left the actor's snapshot un-reverted
-  (the Goal-2 revertibility leak the actor-revertibility tests pin). Falls
-  back to the retained `:db-after` projection (app-db only) for legacy
-  records that carry no `:frame-state-after` — those install runtime-db nil,
-  matching the pre-EP behaviour.
+  (the Goal-2 revertibility leak the actor-revertibility tests pin).
+  `:frame-state-after` is the only restore source — every record
+  `build-record` emits carries it. The `:db-after` slot is a retained
+  app-db PROJECTION for tool diffs, never a restore source; a record with
+  no `:frame-state-after` is malformed/unreachable on the current build path.
 
   Per rf2-7i872 (validate-then-destroy race): re-resolves the container at
   the write boundary via `live-container-or-fail`. If the frame was
@@ -671,11 +671,12 @@
     (if (= :fail outcome)
       (do (emit-precondition-failure! op tags)
           false)
-      (let [frame-state-target
-            (or (:frame-state-after epoch)
-                ;; Legacy / synthetic record with only the app-db projection:
-                ;; install it as the app-db partition; runtime-db installs nil.
-                {frame/app-partition-key (:db-after epoch)})
+      (let [;; EP-0001 (rf2-3aizt1): the canonical, only restore source is
+            ;; the whole `:frame-state-after`. The `:db-after` slot is a
+            ;; retained app-db projection for tool diffs, never installed —
+            ;; a record with no `:frame-state-after` is malformed/unreachable
+            ;; on the current build path.
+            frame-state-target (:frame-state-after epoch)
             ;; rf2-7r5mc2: reconcile the runtime-db partition's runtime
             ;; subsystems (Resources, first writer) BEFORE the atomic install,
             ;; the same way SSR hydration reconciles its installed slice — so a

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -860,9 +860,9 @@
           (late-bind/set-fn! hook-key original))))))
 
 (deftest reconcile-runtime-db-on-restore-noop-on-app-db-only-record
-  (testing "rf2-7r5mc2 — a legacy / synthetic frame-state with only the app-db
-            partition (no :rf.db/runtime key) passes through unchanged even when
-            the hook is present (nothing to reconcile)."
+  (testing "rf2-7r5mc2 — a frame-state with only the app-db partition (no
+            :rf.db/runtime key) passes through unchanged even when the hook
+            is present (nothing to reconcile)."
     (let [hook-key :resources/reconcile-on-restore
           original (late-bind/get-fn hook-key)
           called?  (atom false)]


### PR DESCRIPTION
Implements **rf2-cawt1f** finding 1 (vestigial prune, `implementation/epoch` slice).

## What was pruned

`restore-epoch` retained a legacy fallback: it read its restore target off `:frame-state-after`, then fell back to the optional `:db-after` app-db projection for records that carried no `:frame-state-after`. Current `build-record` always emits the whole-frame `:frame-state-after`, so the fallback was dead.

- **`check-restore-preconditions!`** — `db-target` now reads only off `:frame-state-after`; the `(or (get frame-state-target app-partition-key) (:db-after epoch))` fallback is removed.
- **`perform-restore!`** — `frame-state-target` is `(:frame-state-after epoch)` directly; the synthetic `{app-partition-key (:db-after epoch)}` install for legacy records is removed (runtime-db no longer silently installs nil for a missing `:frame-state-after`).
- **Docstrings / comments** (`epoch.cljc`, `tool_pair.cljc`) now state `:frame-state-after` is the sole restore source and `:db-after` is a projection-only slot, never a restore source. A record with no `:frame-state-after` is malformed/unreachable on the current build path.
- **De-"legacy" wording** of the still-valid no-runtime-partition guard in `reconcile-runtime-db-on-restore` + its test (a `:frame-state-after` may legitimately carry only the app-db partition; that guard stays).

## Dead-code verification

- `:db-after` → restore-source was reachable only via the two `or`/`(:frame-state-after ...)` fallbacks edited here. Every record produced by `build-record` (`assembly.cljc`) carries `:frame-state-after`; `replace-app-db!` / `reset-app-db!` / `replace-runtime-db!` / `replace-frame-state!` synthetic records all go through `build-record`. No live caller constructs a `:db-after`-only restore record.
- No epoch test synthesizes or injects an app-db-only restore record (all `perform-restore!` test sites resolve a real `epoch` from genuine history). Verified by grep over the test file.
- The `:db-after` slot itself is **retained** — it remains an optional app-db projection consumed by tool diffs, the sensitive-rollup, `projected-record` egress, and destroy-time listeners (unchanged).

## Scope note — finding 2 split out

Finding 2 (rename the `:rf.epoch/replace-app-db-*` failure ops so the runtime-db / frame-state mutators don't emit app-db-named ops) is a **published trace-op contract** that spans hot-zone spec files (`009-Instrumentation.md`, `API.md`, `Tool-Pair.md`, `Spec-Schemas.md`), `implementation/core`, the elision + bundle-isolation sentinel scripts (which grep the op string literally — renaming only in epoch would break the gate), `tools/xray`, `tools/re-frame2-pair-mcp`, and `skills/`. That exceeds this worker's `implementation/epoch`-only boundary and the hot-zone sequential rule, and overlaps concurrent xray/pair-mcp workers. Filed as **rf2-54b515** for a single coordinated sequential worker.

## Quality gates

- epoch JVM (`clojure -M:test` in `implementation/epoch`): **329 tests, 1300 assertions, 0 failures, 0 errors**
- CLJS (`npm run test:cljs` from `implementation`): **7076 tests, 29100 assertions, 0 failures, 0 errors**
