### PR TITLE
refactor(machines): remove compatibility shims (rf2-wtw3rw)

### DIFF
--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -12,10 +12,13 @@
   that triggers cancel-and-reschedule on sub-value change. On expiry the
   timer dispatches the synthetic
 
-      [<parent-id> [:rf.machine.timer/after-elapsed <delay-key> <epoch>]]
+      [<parent-id> [:rf.machine.timer/after-elapsed <delay-key> <epoch> <decl-path>]]
 
   back into the parent machine via the late-bound `:router/dispatch!`
-  hook. Pick-after-transition (in transition) resolves the delay-key
+  hook. Per Spec 005 §Hierarchy interaction the scheduling node's
+  declaring path (`<decl-path>`) travels with EVERY timer alongside its
+  per-path epoch — the event is always this 4-element shape.
+  Pick-after-transition (in transition) resolves the delay-key
   against the active state path's `:after` table; epoch-mismatch surfaces
   as `:rf.machine.timer/stale-after`, epoch-match drives the transition
   through the standard cascade.
@@ -405,10 +408,12 @@
 
   The synthetic event dispatched on expiry is
 
-      [<parent-id> [:rf.machine.timer/after-elapsed <delay-key> <epoch>]]
+      [<parent-id> [:rf.machine.timer/after-elapsed <delay-key> <epoch> <decl-path>]]
 
-  which routes through pick-after-transition's epoch check and (on match)
-  through the standard transition cascade.
+  (the scheduling node's declaring path travels with the timer per Spec
+  005 §Hierarchy interaction) which routes through pick-after-transition's
+  per-node epoch check and (on match) through the standard transition
+  cascade.
 
   No-op under `:platform :server` (per Spec 005 §SSR mode)."
   [{frame-id :frame} args]

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -754,10 +754,14 @@
   arrives. `carried-decl-path` (the scheduling node's absolute path) is
   carried by the runtime so the staleness check is per scheduling node —
   the per-level tracking the normative external contract (005 §Hierarchy
-  interaction) requires. Legacy 3-element events (no decl-path) fall back
-  to a leaf→root walk for the delay-key, resolving against the matched
-  node's per-path epoch — sufficient when delay-keys do not collide
-  across hierarchy levels.
+  interaction) requires. Per Spec 005 §Hierarchy interaction (invariant
+  2202) the node's epoch AND its declaring path travel with EVERY timer:
+  the synthetic event is the 4-element `[delay-key epoch decl-path]`
+  shape the runtime always emits, so a `nil` `carried-decl-path` is a
+  malformed event (a hand-rolled / pre-decl-path dispatch). It resolves
+  to nil — no transition, the benign unhandled-no-op signal. There is no
+  legacy 3-element leaf→root fallback (rf2-wtw3rw): the decl-path is
+  contractual, not optional.
 
   A timer is **live** iff its scheduling node is still on the active path
   (its `carried-decl-path` is a prefix of the current path) AND the
@@ -869,37 +873,13 @@
            :scheduled-epoch carried-epoch
            :current-epoch   cur-epoch}))
 
-      ;; Legacy 3-element event — resolve via the leaf→root walk.
-      :else
-      (let [hit
-            (path-walk/walk-path-leaf-to-root
-              machine path
-              (fn [prefix n]
-                (when-let [t (get-in n [:after delay-key])]
-                  (let [cur-epoch (node-epoch machine snapshot prefix)]
-                    (if (= carried-epoch cur-epoch)
-                      (resolve-hit prefix t)
-                      {:stale?          true
-                       :state           (last prefix)
-                       :decl-path       (vec prefix)
-                       :delay           delay-key
-                       :scheduled-epoch carried-epoch
-                       :current-epoch   cur-epoch})))))]
-        (cond
-          hit    hit
-          ;; No `:after` table matched along any level of the path — the
-          ;; timer carried in from a state the machine has since exited.
-          ;; Surface it as stale so the lifecycle emits
-          ;; `:rf.machine.timer/stale-after`. No `:after` table matched
-          ;; along any level, so there is no live declaring node — the
-          ;; carried path is the timer's only address (`:current-epoch`
-          ;; nil signals the absent live counterpart).
-          :else  {:stale?          true
-                  :state           (last path)
-                  :decl-path       carried-decl-path
-                  :delay           delay-key
-                  :scheduled-epoch carried-epoch
-                  :current-epoch   nil})))))
+      ;; A malformed event with no carried decl-path (rf2-wtw3rw): the
+      ;; runtime always emits the 4-element `[delay-key epoch decl-path]`
+      ;; shape (Spec 005 §Hierarchy interaction), so a nil decl-path can
+      ;; only be a hand-rolled / pre-decl-path dispatch. There is no
+      ;; legacy leaf→root fallback — resolve to nil (no transition, the
+      ;; benign unhandled-no-op).
+      :else nil)))
 
 (defn ns-wildcard-key
   "Per Spec 005 §Wildcard transitions §Namespaced (partial) event

--- a/implementation/machines/test/re_frame/after_test.clj
+++ b/implementation/machines/test/re_frame/after_test.clj
@@ -15,10 +15,12 @@
       registration throws :rf.error/spawn-timeout-ms-removed.
 
   These JVM tests dispatch the synthetic
-  [:rf.machine.timer/after-elapsed delay-key epoch] event manually so
-  the verification is deterministic without depending on setTimeout
-  firing. The CLJS runtime path for actual wall-clock scheduling is
-  exercised by machines_cljs_test.cljs."
+  [:rf.machine.timer/after-elapsed delay-key epoch decl-path] event
+  manually so the verification is deterministic without depending on
+  setTimeout firing. The decl-path is contractual — the runtime always
+  emits the 4-element shape (Spec 005 §Hierarchy interaction). The CLJS
+  runtime path for actual wall-clock scheduling is exercised by
+  machines_cljs_test.cljs."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]

--- a/implementation/machines/test/re_frame/lifecycle_composed_corners_test.clj
+++ b/implementation/machines/test/re_frame/lifecycle_composed_corners_test.clj
@@ -18,9 +18,10 @@
       + `[:rf.runtime/machines :spawned]` slot + spawn-order channel after `destroy-frame!`.
 
   JVM-only by design — synthetic
-  `[:rf.machine.timer/after-elapsed <delay-key> <epoch>]` dispatches are
-  deterministic without wall-clock host scheduling, matching the
-  precedent in `after_test.clj`."
+  `[:rf.machine.timer/after-elapsed <delay-key> <epoch> <decl-path>]`
+  dispatches are deterministic without wall-clock host scheduling,
+  matching the precedent in `after_test.clj` (the decl-path is
+  contractual — the runtime always emits the 4-element shape)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -89,7 +90,7 @@
       (let [[recorded unreg] (record! ::stale-1)]
         (try
           (is (nil? (rf/dispatch-sync
-                      [:corner.timer/m [:rf.machine.timer/after-elapsed 5000 1]]
+                      [:corner.timer/m [:rf.machine.timer/after-elapsed 5000 1 [:loading]]]
                       {:frame :corner.timer/scoped}))
               "stale firing does not throw")
           (is (some #(= :rf.error/frame-destroyed (:operation %)) @recorded)
@@ -157,7 +158,7 @@
       (let [[recorded unreg] (record! ::stale-2)]
         (try
           (rf/dispatch-sync [:corner.sid/child#1
-                             [:rf.machine.timer/after-elapsed 5000 1]])
+                             [:rf.machine.timer/after-elapsed 5000 1 [:running]]])
           ;; A is gone; the dispatch traces :rf.error/no-such-handler.
           (is (some #(= :rf.error/no-such-handler (:operation %)) @recorded)
               "stale dispatch to A's gone handler trace :rf.error/no-such-handler")
@@ -291,7 +292,7 @@
         (let [[recorded unreg] (record! ::corner-dyn)]
           (try
             (rf/dispatch-sync [:corner.dyn/m
-                               [:rf.machine.timer/after-elapsed 5000 epoch-loading]])
+                               [:rf.machine.timer/after-elapsed 5000 epoch-loading [:loading]]])
             (is (= :ready (:state (get-in (rf/runtime-db-value :rf/default)
                                           [:rf.runtime/machines :snapshots :corner.dyn/m])))
                 "stale firing did NOT transition the machine off :ready")

--- a/implementation/machines/test/re_frame/machine_trace_frame_tag_sweep_test.clj
+++ b/implementation/machines/test/re_frame/machine_trace_frame_tag_sweep_test.clj
@@ -184,7 +184,7 @@
               (rf/dispatch-sync [:ko8jb/stale [:cancel]])
               (rf/dispatch-sync
                 [:ko8jb/stale
-                 [:rf.machine.timer/after-elapsed 5000 0]])))
+                 [:rf.machine.timer/after-elapsed 5000 0 [:loading]]])))
           ev (first-of-op traces :rf.machine.timer/stale-after)]
       (is (some? ev) ":rf.machine.timer/stale-after fired")
       (is (= :rf/default (frame-tag ev))

--- a/implementation/machines/test/re_frame/trace_enhancements_rf2_82a0u_test.clj
+++ b/implementation/machines/test/re_frame/trace_enhancements_rf2_82a0u_test.clj
@@ -12,8 +12,7 @@
     3. `:rf.machine.timer/cancelled` (single canonical event id) is
        emitted on every cancellation path with `:reason` from the
        closed set `:on-exit / :on-destroy / :on-resolution /
-       :on-supersede / :on-frame-destroy`. The pre-rf2-82a0u event
-       `:rf.machine.timer/cancelled-on-resolution` is gone."
+       :on-supersede / :on-frame-destroy`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -317,24 +316,3 @@
                     :on-supersede :on-frame-destroy}]
       (is (every? allowed reasons)
           (str "every :reason ∈ closed set; got " reasons)))))
-
-;; =====================================================================
-;; Negative gate: the old event id is gone from the runtime stream
-;; =====================================================================
-
-(deftest old-cancelled-on-resolution-event-id-not-emitted
-  (testing "no path emits the pre-rf2-82a0u
-            `:rf.machine.timer/cancelled-on-resolution` — every
-            cancellation rides the unified
-            `:rf.machine.timer/cancelled`"
-    (rf/reg-machine :rf2-82a0u/no-old-id
-      {:initial :a
-       :states  {:a {:after {1000 :b} :on {:exit :c}}
-                 :b {}
-                 :c {}}})
-    (let [evs (record-traces!
-                (fn []
-                  (rf/dispatch-sync [:rf2-82a0u/no-old-id [:rf.machine/start]])
-                  (rf/dispatch-sync [:rf2-82a0u/no-old-id [:exit]])))]
-      (is (empty? (ops evs :rf.machine.timer/cancelled-on-resolution))
-          "no emit of the legacy event id (rf2-82a0u removed it)"))))


### PR DESCRIPTION
Implements **rf2-wtw3rw** — `[vestigial][implementation/machines]` remove compatibility shims and legacy trace/timer coverage.

Two of the bead's four findings are genuinely dead and spec-aligned to remove. The other two are **spec-mandated current behaviour** — their premises are wrong, and actioning them would diverge from the authoritative spec. Rejection rationale below.

## What was removed

### Finding 2 — legacy 3-element `:after-elapsed` fallback (ACTIONED)
- **Dead-code verification:** the runtime scheduler (`timer.cljc`) *always* dispatches the 4-element synthetic event `[:rf.machine.timer/after-elapsed delay-key epoch decl-path]`. Spec 005 §Hierarchy interaction makes the scheduling node's declaring path contractual — it travels with **every** timer alongside its per-path epoch (Spec 005 lines 78, 2202 ["what's contractual is that the node's epoch AND its declaring path travel with the timer"], 2203, 2273; `:rf/after-epoch` is a per-decl-path map). The `:else` leaf→root fallback in `pick-after-transition` (for a nil carried-decl-path) was pre-decl-path residue with **no runtime producer** — only hand-rolled test dispatches could reach it.
- **Removed:** the legacy `:else` branch in `pick-after-transition` (`transition.cljc`). A nil carried-decl-path now resolves to `nil` (the benign unhandled-no-op). Updated `pick-after-transition` + `timer.cljc` docstrings to require the contractual 4-element shape.
- **Tests migrated** to the 4-element form: `lifecycle_composed_corners_test.clj` (×3 — destroyed-frame stale, system-id-rebind stale, dynamic-delay-cleared stale), `machine_trace_frame_tag_sweep_test.clj` (×1 — stale-after tag); `after_test.clj` docstring updated. All other timer tests already used the 4-element form.

### Finding 4 — dead `cancelled-on-resolution` negative test (ACTIONED)
- **Dead-code verification:** `:rf.machine.timer/cancelled-on-resolution` was removed in rf2-82a0u and has **zero** `src/` references (`grep` confirmed). The `old-cancelled-on-resolution-event-id-not-emitted` test only asserted an already-deleted event-id is absent — pure negative legacy coverage.
- **Removed:** the negative test + its docstring "is gone" framing. **Unified cancellation coverage still exists** (acceptance satisfied): `cancelled-on-exit-emits-reason-on-exit`, `cancelled-on-destroy-emits-reason-on-destroy`, and `cancelled-reason-closed-set` (asserts every emitted `:reason` ∈ the closed set `:on-exit / :on-destroy / :on-resolution / :on-supersede / :on-frame-destroy`).

## What was NOT actioned (premise rejected — requires a spec ruling)

These two findings frame **spec-mandated, currently-documented behaviour** as vestigial. Removing them would break spec conformance, and the spec edits required are hot-zone (sequential, ruling-level) and out of scope for this implementation-only bead.

### Finding 1 — snapshot reconciler / version-check (REJECTED)
The bead asks to remove `reconcile-snapshot` / `rebuild-incompatible-snapshot` / `version-compatible?` and delete `snapshot_compat_test`. But these implement **Spec 005 §Snapshot shape stability invariants 3 & 4** verbatim:
- Invariant 3 (005:60): snapshots whose `:state` is no longer in the definition "transition to the new `:initial` and emit `:rf.error/machine-state-not-in-definition`."
- Invariant 4 (005:61): a `:rf/snapshot-version` mismatch "emits `:rf.error/machine-snapshot-version-mismatch`."
- Both error events are documented as **canonical** in 009-Instrumentation.md (1839, 1840), Spec-Schemas.md (2195), and Conventions.md (397). `snapshot_compat_test` is the conformance coverage for those invariants.

This is current behaviour, not a back-compat shim. Recommend filing a spec-ruling bead if Mike wants to drop these invariants (would touch hot-zone `spec/005`, `spec/009`, `spec/Spec-Schemas`, `spec/Conventions`).

### Finding 3 — `:rf.reply/work-id` (REJECTED)
The bead asks to drop `:rf.reply/work-id` from machine traces. But Spec 005 §Async completions explicitly **retains** it:
- 005:3556: "the canonical `:work/id` is the join key the uniform work/reply view groups on, **with `:rf.reply/work-id` retained as the back-compatible spelling**" — stamped *additively* alongside `:work/id`.
- 005:3560 documents the same additive retention for the `:after` timer fired/stale traces.

EP-0007 (one-name-per-fact) ruling #3 retired the *resources* `:work-id` synonym but the machines spec text deliberately keeps `:rf.reply/work-id` additive. Removing it diverges from current spec 005. Recommend a spec-ruling bead if the intent is to retire it from machines too (hot-zone `spec/005`).

## Quality gates

| Gate | Result |
|------|--------|
| machines `clojure -M:test` | 658 tests, 2153 assertions, **0 failures, 0 errors** |
| `npm run test:cljs` | 7076 tests, 29100 assertions, **0 failures, 0 errors** |

No production code path relied on the removed fallback (runtime always emits 4-element); no `src/` referenced the removed event-id. Spec unchanged (the two ACTIONED findings align *to* existing spec; the two REJECTED findings would *require* spec changes, deliberately deferred).