### PR TITLE
fix: unify test-quiet stdout/stderr warning contract (rf2-nrk066)

### DIFF
--- a/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
+++ b/implementation/security/test/re_frame/security/mcp_egress_security_cljs_test.cljc
@@ -45,50 +45,38 @@
   Reverting the `scrub-snapshot` `:traces`/`:epochs` scrub makes the
   snapshot property go RED. Confirmed by temporary local revert + restore
   (see PR Quality gates)."
-  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
-               :cljs [cljs.test :refer-macros [deftest is testing]
-                      :refer [use-fixtures]])
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
             [clojure.walk :as walk]
             [re-frame.mcp-base.sensitive :as sens]
             [re-frame.security.gen :as gen]))
 
 ;; ---------------------------------------------------------------------------
-;; Expected-warning capture (rf2-80jyfk)
+;; Expected-warning quieting (rf2-80jyfk → rf2-nrk066)
 ;; ---------------------------------------------------------------------------
 ;;
 ;; These property tests INTENTIONALLY drive thousands of malformed
 ;; `:sensitive?` stamps through `sens/strip-sensitive` / `scrub-snapshot` /
 ;; `sensitive-event?` (the rf2-ih7g4 fail-closed corpus). Each malformed
-;; stamp fires `re-frame.mcp-base.sensitive`'s contract-drift warning. On the
-;; CLJS path the silent-on-success node runner stubs `js/console.warn` (see
-;; `re-frame.test-quiet.shadow-node`), so that warning never reaches test
-;; output. The JVM path emits the warning via `(binding [*out* *err*]
-;; (println …))`, which the quiet runner does NOT capture (it filters only
-;; cognitect's stdout banner) — so a green JVM run floods stderr with
-;; thousands of expected WARN lines, defeating the silent-on-success posture
-;; (rf2-80jyfk issue 1).
+;; stamp fires `re-frame.mcp-base.sensitive`'s contract-drift warning to
+;; stderr (JVM `*err*`) / `console.warn` (CLJS).
 ;;
-;; This `:once` fixture mirrors the CLJS console.warn stub on the JVM: it
-;; binds `*err*` to a throwaway sink for the duration of the namespace's test
-;; run, so the EXPECTED malformed-stamp warnings are captured rather than
-;; leaked. The warning's having FIRED is still asserted, just not via stderr
-;; bytes — the `malformed-count` counter is the framework's observability
-;; hook and is pinned by `gate-off-malformed-stamp-counts-as-dropped`, so the
-;; fail-closed log path stays exercised + verified.
+;; Quieting these EXPECTED warnings on a green run is now the SHARED
+;; responsibility of the quiet runners on BOTH runtimes, so this namespace
+;; needs NO local `*err*` sink (rf2-nrk066): the CLJS node runner buffers
+;; `console.warn` and the JVM runner (`re-frame.test-quiet.runner`) buffers
+;; `*err*`/`System/err` into a bounded ring, dropping it on green and
+;; replaying it only on red. Pre-rf2-nrk066 the JVM runner had no central
+;; stderr handling, so this suite wrapped its whole run in a private `*err*`
+;; sink (the rf2-80jyfk workaround) — that ad-hoc sink is removed now that
+;; the runner owns the policy symmetrically.
 ;;
-;; Scope discipline (acceptance criteria): only `*err*` is rebound, and ONLY
-;; on the JVM. clojure.test routes assertion / FAIL / ERROR / summary output
-;; through `clojure.test/*test-out*` (bound to the real `*out*`), so failure
-;; diagnostics are untouched — a red run still reports normally. CLJS is a
-;; no-op fixture: the node runner's console.warn stub already covers it.
-#?(:clj
-   (use-fixtures :once
-     (fn [t]
-       (binding [*err* (java.io.PrintWriter. (java.io.StringWriter.))]
-         (t))))
-   :cljs
-   (use-fixtures :once
-     (fn [t] (t))))
+;; The warning's having FIRED is still asserted structurally — the
+;; `malformed-count` counter is the framework's observability hook, pinned by
+;; `gate-off-malformed-stamp-counts-as-dropped` — so the fail-closed log path
+;; stays exercised + verified. A RED run keeps these diagnostics (the runner
+;; replays the buffer), and clojure.test routes FAIL/ERROR/summary output
+;; through `*test-out*` (the real `*out*`), so failure reporting is untouched.
 
 (def ^:private sentinel "S3CR3T-rf2-3cfvt-EGRESS-DO-NOT-SHIP")
 

--- a/implementation/test-quiet/deps.edn
+++ b/implementation/test-quiet/deps.edn
@@ -3,13 +3,32 @@
 ;;
 ;; A tiny, test-only library that overrides `clojure.test/report` (JVM)
 ;; and `cljs.test/report` (CLJS) so a green run of any test alias in the
-;; repository emits only the 3-line summary:
+;; repository REPORTS only the 3-line summary:
 ;;
 ;;     Ran N tests containing M assertions.
 ;;     0 failures, 0 errors.
 ;;
+;; The cross-runtime quiet contract (rf2-nrk066) is pass-through stdout +
+;; central stderr buffering, SYMMETRIC across JVM / CLJS node / browser:
+;;
+;;   - STDOUT is PASS-THROUGH, not summary-only. The reporter makes the
+;;     reporter's OWN green output the canonical summary, but the runner
+;;     forwards every other stdout byte a test/fixture/CLI emits — `-H`
+;;     usage, parse-error diagnostics, and bare `(println …)` — so runner
+;;     misuse and failure-time diagnostics stay visible (rf2-lbo79.2).
+;;     Only cognitect's own `Running tests in #{…}` discovery banner is
+;;     dropped. A green run is therefore "summary + whatever a test chose
+;;     to print", which under the repo's no-stray-println discipline is
+;;     just the summary.
+;;   - STDERR/WARNINGS are BUFFERED, replayed on red, dropped on green —
+;;     the JVM runner (`re-frame.test-quiet.runner`) and the CLJS node
+;;     runner (`re-frame.test-quiet.shadow-node`) both ring-buffer stderr
+;;     noise and replay it only when the run is RED, so warning-heavy
+;;     suites stay quiet on green WITHOUT ad-hoc local `*err*` sinks.
+;;
 ;; Failures are unchanged — a failing namespace's banner + the failure
-;; lines + the failure stack reach stdout exactly as before.
+;; lines + the failure stack reach stdout exactly as before, and a red
+;; run additionally replays the buffered stderr context.
 ;;
 ;; Wired into every per-artefact `:test` alias by replacing
 ;; `:main-opts ["-m" "cognitect.test-runner"]` with

--- a/implementation/test-quiet/src/re_frame/test_quiet.cljc
+++ b/implementation/test-quiet/src/re_frame/test_quiet.cljc
@@ -2,8 +2,9 @@
   "Silent-on-success test reporter.
 
   Loading this namespace installs `defmethod` overrides on
-  `clojure.test/report` (JVM) and `cljs.test/report` (CLJS) so a green
-  test run emits exactly the canonical 3-line summary:
+  `clojure.test/report` (JVM) and `cljs.test/report` (CLJS) so the
+  REPORTER's own green-run output is exactly the canonical 3-line
+  summary:
 
       Ran N tests containing M assertions.
       0 failures, 0 errors.
@@ -11,6 +12,17 @@
   Per-namespace `Testing <ns>` banners are SUPPRESSED on the success
   path; per-`deftest` `Testing <var>` banners were already silent in
   both reporters by default and stay that way.
+
+  This reporter governs only the REPORTER's output.  The cross-runtime
+  quiet contract (rf2-nrk066) is completed by the runtime entry points
+  (`re-frame.test-quiet.runner` on the JVM,
+  `re-frame.test-quiet.shadow-node` on CLJS node): stdout is
+  PASS-THROUGH (a test's bare `(println …)` reaches stdout — only
+  cognitect's discovery banner is dropped), and stderr/warning noise is
+  BUFFERED and replayed only on RED.  So a green run shows the summary
+  plus whatever a test deliberately printed, and never the expected
+  warnings warning-heavy suites emit.  See those namespaces' docstrings
+  for the runtime side of the contract.
 
   On failure or error the suppressed banner for that namespace is
   flushed lazily (once per namespace), so a red run looks like:

--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -12,6 +12,38 @@
   load time.  By the time cognitect-test-runner discovers tests and
   starts dispatching reports, the overrides are in place.
 
+  ## The cross-runtime quiet contract (rf2-nrk066)
+
+  re-frame2 runs the same silent-on-success policy on three runtimes —
+  JVM (this runner), CLJS node (`re-frame.test-quiet.shadow-node`), and
+  browser-test.  The contract is *documented pass-through stdout +
+  central stderr buffering*, and it is SYMMETRIC across runtimes:
+
+   - STDOUT is pass-through, NOT summary-only.  The reporter
+     (`re-frame.test-quiet`) makes a green run's stdout the canonical
+     summary, but the runner forwards every OTHER byte a test, fixture,
+     or the runner's own CLI emits — `-H`/`--test-help` usage,
+     CLI parse-error diagnostics, and any bare `(println ...)` a test
+     makes.  This is deliberate (rf2-lbo79.2): a blanket stdout sink
+     made runner misuse opaque and lost failure-time diagnostics.  Only
+     cognitect's own discovery banner is dropped (see below).  The CLJS
+     node runner forwards stdout the same way.
+   - STDERR/WARNINGS are BUFFERED, replayed on red, dropped on green.
+     A green run must not flood stdout/stderr with the expected
+     warnings that warning-heavy suites emit (e.g.
+     `re-frame.mcp-base.sensitive`'s fail-closed contract-drift WARN on
+     thousands of malformed `:sensitive?` stamps).  This runner binds
+     `*err*`/`System/err` to a bounded ring buffer for the duration of
+     the delegated run; the captured stderr is REPLAYED to the real
+     stderr only when the run is RED (so a failing run keeps the
+     diagnostic context that may explain it), and DROPPED on green.
+     This mirrors the CLJS node runner's `console.warn` buffer + red
+     replay exactly — so suites no longer need ad-hoc `(binding [*err*
+     <sink>] …)` workarounds to stay quiet on green (rf2-80jyfk /
+     rf2-nrk066).  Tests that ASSERT on captured warning text still
+     capture `*err*` locally; only the noise-suppression-only sinks are
+     removed.
+
   ## The discovery-banner contract
 
   cognitect-test-runner emits exactly one stdout artefact of its own that
@@ -335,6 +367,108 @@
         (forward-partial!)
         (.flush target)))))
 
+;; ----------------------------------------------------------------------
+;; Central stderr buffer + red replay (rf2-nrk066).
+;;
+;; The symmetric counterpart to the CLJS node runner's `console.warn`
+;; ring buffer (`re-frame.test-quiet.shadow-node`).  Warning-heavy JVM
+;; suites emit expected stderr noise on the green path (e.g.
+;; `re-frame.mcp-base.sensitive` logging a contract-drift WARN for every
+;; malformed `:sensitive?` stamp it fail-closes).  Pre-rf2-nrk066 the JVM
+;; runner had NO central stderr handling — it filtered only cognitect's
+;; stdout banner — so those warnings flooded a green run unless each
+;; namespace bound `*err*` to a private sink.  We now buffer stderr in a
+;; bounded ring for the delegated run and:
+;;   - GREEN: drop the buffer silently (quiet on success);
+;;   - RED:   replay it to the real stderr from the `:summary` reporter
+;;            hook below, BEFORE cognitect computes its exit code, so a
+;;            failing run keeps the diagnostic context.
+;;
+;; clojure.test routes its assertion / FAIL / ERROR / summary output
+;; through `clojure.test/*test-out*` (bound to the real `*out*`), NOT
+;; through `*err*`, so buffering stderr never hides failure diagnostics —
+;; the red FAIL/ERROR blocks reach stdout via the `*out*` filter exactly
+;; as before.
+
+(def ^:private stderr-buffer-cap
+  "Bounded stderr ring capacity (characters).  Caps memory + replay
+  volume on a red run while keeping enough recent context to explain a
+  failure — the newest `stderr-buffer-cap` characters are retained,
+  older ones dropped.  ~256 KB is generous for diagnostic warnings
+  without risking heap pressure on a pathologically chatty suite."
+  (* 256 1024))
+
+(defn- buffering-stderr-writer
+  "A `java.io.Writer` over the shared `sb` ring that captures everything
+  written to it (trimming `sb` to the newest `stderr-buffer-cap`
+  characters) and forwards NOTHING to the real stderr.  The runner reads
+  `sb` back at `:summary` time and replays it only on red
+  (`install-summary-replay-hook!`); on green the buffer is dropped."
+  ^java.io.Writer [^StringBuilder sb]
+  (let [append! (fn [^String s]
+                  (.append sb s)
+                  ;; Trim from the FRONT once past the cap so the ring
+                  ;; keeps the most-recent context (the bytes nearest a
+                  ;; failure), matching the CLJS ring's newest-N policy.
+                  (let [n (.length sb)]
+                    (when (> n stderr-buffer-cap)
+                      (.delete sb 0 (- n stderr-buffer-cap)))))]
+    (proxy [java.io.Writer] []
+      (write
+        ([x]
+         (cond
+           (string? x)  (append! x)
+           (integer? x) (append! (String. (char-array [(char x)])))
+           (instance? (Class/forName "[C") x)
+           (append! (String. ^chars x))
+           :else (throw (IllegalArgumentException.
+                          (str "unexpected write arg: " (class x))))))
+        ([cbuf off len]
+         (append! (if (string? cbuf)
+                    (subs cbuf off (+ off len))
+                    (String. ^chars cbuf (int off) (int len))))))
+      (flush [])
+      (close []))))
+
+(defn- install-summary-replay-hook!
+  "Install a `clojure.test/report :summary` override that REPLAYS the
+  buffered stderr (`sb`) to `real-err` when the run is RED, then delegates
+  to whatever `:summary` method was installed before us so the canonical
+  summary line still prints.
+
+  `:summary` is the JVM-side counterpart to the CLJS `:end-run-tests`
+  reporter: it fires once at the end of `run-tests` from the same
+  fail/error counts cognitect reads to compute the exit code, and it runs
+  on the test-driver thread INSIDE the `binding` that rebinds `*err*` —
+  so it runs before cognitect's `System/exit` and can flush the captured
+  context.  A run is RED iff `(pos? (+ fail error))`, matching cognitect's
+  `(zero? (+ fail error))` green test.
+
+  The replay goes to the REAL stderr (the `*err*` ring is still bound at
+  this point, so we must NOT use `*err*`/`println` here or the replay
+  would feed straight back into the buffer).  Each captured chunk is
+  written verbatim; a header marks it as a red-run replay so it is
+  distinguishable from the reporter's own stdout, mirroring the CLJS
+  replay's `[test-quiet]` prefix.  On green the buffer is simply dropped
+  (never written)."
+  [^StringBuilder sb ^java.io.Writer real-err]
+  (let [prior-summary (get-method clojure.test/report :summary)]
+    (defmethod clojure.test/report :summary [m]
+      (let [{:keys [fail error]} m]
+        (when (and (pos? (+ (or fail 0) (or error 0)))
+                   (pos? (.length sb)))
+          (let [captured (.toString sb)]
+            (.write real-err
+                    (str "\n[test-quiet] buffered stderr replayed because"
+                         " the run was RED:\n"))
+            (.write real-err captured)
+            (when-not (.endsWith captured "\n")
+              (.write real-err "\n"))
+            (.flush real-err))))
+      ;; Delegate to the prior :summary so the canonical
+      ;; "Ran N tests…/K failures, J errors." line still prints.
+      (when prior-summary (prior-summary m)))))
+
 (defn -main [& args]
   ;; Bind `*out*` to a line-filtering writer over the real stdout that
   ;; drops ONLY cognitect's "\nRunning tests in #{...}" discovery banner.
@@ -355,12 +489,46 @@
   ;; wrapper and the OS — could be lost exactly when a failing run needs
   ;; it most.  The hook makes flush-on-exit deterministic rather than
   ;; relying on the runtime or cognitect to flush before exiting.
-  (let [real-out  *out*
-        filtering (java.io.PrintWriter. (banner-filtering-writer real-out))]
+  ;;
+  ;; We ALSO bind `*err*` (and `System/err`) to a bounded ring buffer for
+  ;; the delegated run (rf2-nrk066): expected stderr warnings are captured
+  ;; rather than flooding a green run, and the `:summary` reporter hook
+  ;; replays them to the real stderr only on RED — symmetric with the CLJS
+  ;; node runner's `console.warn` buffer + red replay.  `*err*` is bound on
+  ;; the test-driver thread (cognitect runs single-threaded), so library
+  ;; code that logs via `*err*` is captured; `System/err` is also swapped
+  ;; so a raw `System.err` write is buffered too.  The summary hook reads
+  ;; the buffer and writes any red replay to the REAL stderr captured here.
+  (let [real-out   *out*
+        real-err   *err*
+        sys-err    System/err
+        filtering  (java.io.PrintWriter. (banner-filtering-writer real-out))
+        stderr-sb  (StringBuilder.)
+        buffered-w (buffering-stderr-writer stderr-sb)
+        buffered-e (java.io.PrintWriter. buffered-w)]
     (.addShutdownHook (Runtime/getRuntime)
                       (Thread. ^Runnable #(.flush filtering)))
-    (binding [*out* filtering]
+    (install-summary-replay-hook! stderr-sb real-err)
+    ;; Route raw `System/err` bytes into the SAME ring as `*err*` so a
+    ;; library that writes `System.err` directly is buffered too. The
+    ;; bridge decodes each chunk as UTF-8 and appends to the ring; the
+    ;; single-arg `write` proxy arity receives an int byte.
+    (let [sys-bridge (proxy [java.io.OutputStream] []
+                       (write
+                         ([b]
+                          ;; proxy dispatches by arity; the 1-arg form is
+                          ;; write(int) — the low 8 bits are the byte (0-255),
+                          ;; so use `unchecked-byte` (a plain `byte` cast
+                          ;; throws for 128-255).
+                          (.write buffered-w (String. (byte-array [(unchecked-byte b)]))))
+                         ([b off len]
+                          (.write buffered-w (String. ^bytes b (int off) (int len))))))]
+      (System/setErr (java.io.PrintStream. sys-bridge true "UTF-8")))
+    (binding [*out* filtering
+              *err* buffered-e]
       (try
         (apply cognitect.test-runner/-main args)
         (finally
-          (.flush filtering))))))
+          (.flush filtering)
+          ;; Restore the real System/err for any post-run / shutdown code.
+          (System/setErr sys-err))))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -31,7 +31,12 @@
      replayed on red — the documented capture-and-replay was
      unreachable and the docs now match this).
    - ERROR: exit 1; the `ERROR in` block + the thrown message reach
-     stdout."
+     stdout.
+   - STDERR BUFFER (rf2-nrk066): a GREEN run that emits expected
+     stderr warnings stays quiet (the warnings are buffered + dropped);
+     a RED run REPLAYS the buffered stderr context so a failing run
+     keeps it.  This is the JVM counterpart to the CLJS node runner's
+     `console.warn` buffer + red replay."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [clojure.java.io :as io]))
@@ -639,6 +644,78 @@
                    " got:\n" out))
           (is (str/includes? out "0 failures, 0 errors.")
               (str "the green summary must still print; got:\n" out)))))))
+
+;; ----------------------------------------------------------------------
+;; Central stderr buffer + red replay — rf2-nrk066.
+;;
+;; The JVM runner buffers everything written to `*err*` (and `System/err`)
+;; during the delegated run into a bounded ring, then:
+;;   - GREEN: drops it silently — a passing run that emits expected
+;;            warnings (e.g. a fail-closed contract-drift WARN) stays
+;;            quiet, with NO ad-hoc per-namespace `*err*` sink needed;
+;;   - RED:   replays it to the real stderr from the `:summary` reporter
+;;            hook, before cognitect's `System/exit`, so the failing run
+;;            keeps the diagnostic context.
+;; This is the symmetric JVM counterpart to the CLJS node runner's
+;; `console.warn` ring + `:end-run-tests` red replay
+;; (`re-frame.test-quiet-shadow-node-cljs-test`).  These pins can only be
+;; observed across a process boundary (the replay fires from `:summary`
+;; just before the runner exits).
+
+(deftest green-run-buffers-and-drops-expected-stderr
+  (testing "a GREEN run that writes expected stderr stays quiet — the warning is buffered, not leaked (rf2-nrk066)"
+    (with-fixture-dir
+      (fn [dir]
+        ;; A passing test that emits an expected warning to *err* — exactly
+        ;; the class warning-heavy suites used to wrap in a private *err*
+        ;; sink. With the central buffer it must be DROPPED on green.
+        (write-fixture! dir "green_warn_fixture_test" "green-warn-fixture-test"
+                        (str "(deftest a-warning-but-passing-test"
+                             " (binding [*out* *err*]"
+                             "   (println \"EXPECTED-WARN-MARKER-GREEN\"))"
+                             " (is (= 1 1)))"))
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (zero? exit)
+              (str "the warning-but-passing suite is green; must exit 0; got "
+                   exit "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          ;; The CORE green pin: the expected warning is buffered + dropped,
+          ;; so it appears on NEITHER stdout NOR stderr.
+          (is (not (str/includes? (str out err) "EXPECTED-WARN-MARKER-GREEN"))
+              (str "an expected stderr warning on a GREEN run must be buffered"
+                   " and dropped — not leaked to stdout or stderr (rf2-nrk066);"
+                   " got\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? out "0 failures, 0 errors.")
+              (str "the green summary must still print; got:\n" out)))))))
+
+(deftest red-run-replays-buffered-stderr
+  (testing "a RED run replays the buffered stderr context to real stderr (rf2-nrk066)"
+    (with-fixture-dir
+      (fn [dir]
+        ;; A test that emits a diagnostic to *err* and then FAILS. The
+        ;; warning is buffered as the run proceeds, then replayed on the
+        ;; red exit so the failing run keeps the context.
+        (write-fixture! dir "red_warn_fixture_test" "red-warn-fixture-test"
+                        (str "(deftest a-warning-and-failing-test"
+                             " (binding [*out* *err*]"
+                             "   (println \"EXPECTED-WARN-MARKER-RED diagnostic context\"))"
+                             " (is (= :exp :act)))"))
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (= 1 exit)
+              (str "the warning-and-failing suite is red; must exit 1; got "
+                   exit "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          ;; The failure diagnostics still reach stdout (routed via
+          ;; *test-out*, never *err*, so the buffer never hides them).
+          (is (str/includes? out "FAIL in (a-warning-and-failing-test)")
+              (str "the FAIL block must still reach stdout; got:\n" out))
+          ;; The CORE red pin: the buffered stderr is replayed (to the real
+          ;; stderr) so the failing run keeps the diagnostic context.
+          (is (str/includes? err "EXPECTED-WARN-MARKER-RED")
+              (str "the buffered stderr must be REPLAYED on a RED run"
+                   " (rf2-nrk066); got\n--- stdout ---\n" out
+                   "\n--- stderr ---\n" err))
+          (is (str/includes? err "buffered stderr replayed because the run was RED")
+              (str "the replay must be labelled so it is distinguishable from"
+                   " the reporter's own output; got stderr:\n" err)))))))
 
 ;; ----------------------------------------------------------------------
 ;; Subprocess-harness pipe-deadlock regression — rf2-spzkgo.

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -29,11 +29,13 @@
   ;; serialisation bug has coerced the boolean into the wrong shape.
   ;; The previous fail-OPEN posture silently leaked sensitive events
   ;; on such drift. The fix is fail-CLOSED: drop AND log.
-  (binding [*err* (java.io.StringWriter.)] ; absorb the contract-drift warning
-    (is (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? "true"}))
-    (is (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? :yes}))
-    (is (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? 1}))
-    (is (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? ["any" "truthy"]}))))
+  ;; The expected contract-drift WARN is quieted by the central quiet
+  ;; runner's stderr buffer (rf2-nrk066) — no local `*err*` sink needed;
+  ;; it stays buffered on green and replays on red.
+  (is (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? "true"}))
+  (is (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? :yes}))
+  (is (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? 1}))
+  (is (sensitive/sensitive-event? {:operation :rf.event/dispatched :sensitive? ["any" "truthy"]})))
 
 (deftest sensitive-event?-non-map-input-passes
   (is (not (sensitive/sensitive-event? nil)))
@@ -53,14 +55,15 @@
   ;; NOT silently leak the event. The fail-closed posture drops the
   ;; malformed-truthy event (with a stderr warning) so the contract
   ;; drift is visible to operators.
-  (binding [*err* (java.io.StringWriter.)] ; absorb the warning
-    (let [evts [{:id 1 :sensitive? false}
-                {:id 2 :sensitive? "true"} ; malformed-truthy → drop
-                {:id 3}
-                {:id 4 :sensitive? :yes}]  ; malformed-truthy → drop
-          [kept dropped] (sensitive/strip-sensitive evts false)]
-      (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
-      (is (= 2 dropped)))))
+  ;; Expected WARN quieted by the central quiet-runner stderr buffer
+  ;; (rf2-nrk066) — no local `*err*` sink needed.
+  (let [evts [{:id 1 :sensitive? false}
+              {:id 2 :sensitive? "true"} ; malformed-truthy → drop
+              {:id 3}
+              {:id 4 :sensitive? :yes}]  ; malformed-truthy → drop
+        [kept dropped] (sensitive/strip-sensitive evts false)]
+    (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
+    (is (= 2 dropped))))
 
 ;; ---------------------------------------------------------------------------
 ;; strip-sensitive — the default-suppress filter applied per batch.
@@ -424,10 +427,11 @@
   (sensitive/reset-malformed-count!)
   (is (zero? (sensitive/malformed-count))
       "precondition: counter starts at zero after reset")
-  (binding [*err* (java.io.StringWriter.)] ; absorb the warning
-    (sensitive/sensitive-event? {:sensitive? "true"})
-    (sensitive/sensitive-event? {:sensitive? :yes})
-    (sensitive/sensitive-event? {:sensitive? 1}))
+  ;; Expected WARNs quieted by the central quiet-runner stderr buffer
+  ;; (rf2-nrk066) — no local `*err*` sink needed.
+  (sensitive/sensitive-event? {:sensitive? "true"})
+  (sensitive/sensitive-event? {:sensitive? :yes})
+  (sensitive/sensitive-event? {:sensitive? 1})
   (is (= 3 (sensitive/malformed-count))
       "every fail-closed drop bumps the counter once")
   ;; Well-formed stamps don't bump the counter.
@@ -440,8 +444,9 @@
   (sensitive/reset-malformed-count!))
 
 (deftest reset-malformed-count!-zeroes-the-counter
-  (binding [*err* (java.io.StringWriter.)]
-    (sensitive/sensitive-event? {:sensitive? "true"}))
+  ;; Expected WARN quieted by the central quiet-runner stderr buffer
+  ;; (rf2-nrk066) — no local `*err*` sink needed.
+  (sensitive/sensitive-event? {:sensitive? "true"})
   (is (pos? (sensitive/malformed-count))
       "precondition: a fail-closed drop has bumped the counter")
   (is (zero? (sensitive/reset-malformed-count!))
@@ -492,18 +497,19 @@
   ;; so a single malformed event bumped the counter ~2×. The single-pass
   ;; classifier fixes this: each event is classified exactly once, so the
   ;; counter is a faithful per-event metric.
+  ;; Expected WARNs quieted by the central quiet-runner stderr buffer
+  ;; (rf2-nrk066) — no local `*err*` sink needed.
   (sensitive/reset-malformed-count!)
-  (binding [*err* (java.io.StringWriter.)] ; absorb the warnings
-    (let [evts          [{:id 1 :sensitive? false}
-                         {:id 2 :sensitive? "true"} ; malformed → drop, bump 1
-                         {:id 3}
-                         {:id 4 :sensitive? :yes}    ; malformed → drop, bump 1
-                         {:id 5 :sensitive? true}]   ; well-formed → drop, NO bump
-          [kept dropped] (sensitive/strip-sensitive evts false)]
-      (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
-      (is (= 3 dropped) "all three sensitive events drop")
-      (is (= 2 (sensitive/malformed-count))
-          "exactly one bump per MALFORMED event — not ~2× per scan")))
+  (let [evts          [{:id 1 :sensitive? false}
+                       {:id 2 :sensitive? "true"} ; malformed → drop, bump 1
+                       {:id 3}
+                       {:id 4 :sensitive? :yes}    ; malformed → drop, bump 1
+                       {:id 5 :sensitive? true}]   ; well-formed → drop, NO bump
+        [kept dropped] (sensitive/strip-sensitive evts false)]
+    (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
+    (is (= 3 dropped) "all three sensitive events drop")
+    (is (= 2 (sensitive/malformed-count))
+        "exactly one bump per MALFORMED event — not ~2× per scan"))
   (sensitive/reset-malformed-count!))
 
 (deftest strip-sensitive-malformed-warning-emitted-once-per-event
@@ -527,15 +533,16 @@
   ;; `strip-sensitive`, so the per-event count guarantee must hold
   ;; through the snapshot scrubber too — one malformed trace event in a
   ;; `:traces` slice bumps the counter exactly once.
+  ;; Expected WARNs quieted by the central quiet-runner stderr buffer
+  ;; (rf2-nrk066) — no local `*err*` sink needed.
   (sensitive/reset-malformed-count!)
-  (binding [*err* (java.io.StringWriter.)]
-    (let [snap {:rf/default {:traces [{:id 1 :sensitive? "true"}  ; malformed → 1 bump
-                                      {:id 2}]
-                             :epochs [{:event-id :auth :sensitive? :yes}]}} ; malformed → 1 bump
-          [_ dropped] (sensitive/scrub-snapshot snap false)]
-      (is (= 2 dropped))
-      (is (= 2 (sensitive/malformed-count))
-          "scrub-snapshot bumps the counter exactly once per malformed event")))
+  (let [snap {:rf/default {:traces [{:id 1 :sensitive? "true"}  ; malformed → 1 bump
+                                    {:id 2}]
+                           :epochs [{:event-id :auth :sensitive? :yes}]}} ; malformed → 1 bump
+        [_ dropped] (sensitive/scrub-snapshot snap false)]
+    (is (= 2 dropped))
+    (is (= 2 (sensitive/malformed-count))
+        "scrub-snapshot bumps the counter exactly once per malformed event"))
   (sensitive/reset-malformed-count!))
 
 (deftest strip-sensitive-no-drop-preserves-identity


### PR DESCRIPTION
## Summary

Unifies the split, self-contradictory test-quiet contract (rf2-nrk066). The docs promised summary-only green output, but the JVM runner deliberately forwards arbitrary test stdout on green (rf2-lbo79.2) and had **no** central stderr/warning buffer, while the CLJS node path already buffered `console.warn` and replayed it on red. Warning-heavy JVM suites papered over the gap with ad-hoc per-namespace `*err*` sinks.

**One cross-runtime contract** now holds, symmetric across JVM / CLJS node / browser-test: *documented pass-through stdout + central stderr buffering*.

- **stdout is pass-through, not summary-only** — the reporter's own green output is the canonical summary, but a test's bare `(println …)`, `-H` usage, and parse-error diagnostics all reach stdout (only cognitect's discovery banner is dropped). Documented correctly now.
- **stderr/warnings are buffered, replayed on red, dropped on green** — the JVM runner (`re-frame.test-quiet.runner`) binds `*err*`/`System/err` to a bounded ring for the delegated run and replays it to the real stderr from a `:summary` reporter hook only on red (before cognitect's `System/exit`). This is the symmetric counterpart to the CLJS node runner's `console.warn` ring + `:end-run-tests` red replay. Failure diagnostics are unaffected (clojure.test routes FAIL/ERROR/summary through `*test-out*` = `*out*`).

### Acceptance criteria
- [x] One cross-runtime quiet contract defined (pass-through stdout + central stderr buffer/replay), documented in `deps.edn` + `test_quiet.cljc` + runner docstrings.
- [x] Shared JVM stderr handling added — suites no longer need ad-hoc `*err*` sinks; red-run diagnostic path preserved (buffer replayed on red).
- [x] Local `*err*` sinks centralized: removed the namespace-wide `:once` fixture in the security egress test and 5 suppression-only `(binding [*err* …])` wrappers in mcp-base `sensitive_test`. Kept the 2 assertion-bearing captures (redaction / no-double-log) that test warning *content*.
- [x] Process-boundary coverage added: green run with expected stderr stays quiet (buffered + dropped); red run replays the buffered context; existing help/parse-error/failure output remains visible (existing pins still green).
- [x] Docs + contract tests now state the policy the runner actually enforces.

## Quality gates

- `clojure -M:test` (test-quiet self-tests): **21 tests, 77 assertions, 0 failures** — includes the 2 new rf2-nrk066 process-boundary pins (green-buffers-and-drops, red-replays).
- `clojure -M:test` (tools/mcp-base full JVM): **234 tests, 761 assertions, 0 failures** — clean output, no WARN flood after removing the local sinks.
- `clojure -M:test` (implementation/security full JVM): **63 tests, 486 assertions, 0 failures** — clean output after removing the `:once` `*err*` fixture.
- `npm run test:cljs` (full CLJS suite): **7076 tests, 29100 assertions, 0 failures**.