### PR TITLE
fix(xray): Module-view preserves zero-module apps (rf2-e0mq7a)

### DIFF
--- a/tools/xray/spec/024-Resources-Panel.md
+++ b/tools/xray/spec/024-Resources-Panel.md
@@ -139,6 +139,31 @@ Two elision layers compose:
    fails closed with `:reason :missing-key` (a partial key cannot address
    an entry).
 
+3. **Off-box egress for the TRACE-borne accessors** (`get-resource-history` /
+   `list-resource-invalidations`, rf2-e0mq7a). These two project off the
+   **trace ring**, not the live cache, so their value-bearing fields are
+   trace-event values — the scoped key's scope/params, the `:cause` (a mutation
+   may carry data), and the invalidation's `:scope` + `:matched` keys. They get
+   the **same per-slot egress posture** as the live-cache accessors, via the
+   trace-buffer peer of `resource-egress-fn`: the runtime threads
+   `egress-value` (off-box `:sensitive?` / `:large?` defaults baked in) into
+   `lifecycle-timeline` / `invalidation-graph`, which apply it to those
+   value-bearing fields **before** `summarize`. A declared-`:sensitive?` /
+   `:large?` value therefore redacts / elides **by default** and reveals only
+   under the trusted-local `:include-sensitive?` / `:include-large?` opt-ins.
+   Because these are trace values (not runtime-db `:entries` payloads) the
+   walker is the plain `egress-value`, NOT `egress-runtime-db-value` — there is
+   no runtime-db partition default to gate; the per-slot declaration posture is
+   the boundary. This composes **on top of** the upstream whole-envelope
+   default-suppress (`drop-sensitive-events` drops `:sensitive? true`
+   ENVELOPES; this scrubs the VALUES inside the survivors). The **non-PII
+   metadata** — the lifecycle shape (`:operation` / `:class` / `:resource-id` /
+   `:generation` / `:owner` / `:status`) and the invalidation identity
+   (`:tags`, `:match-count`, `:refetched`) — is **never egressed**, so the
+   `:tag` filter axis and the storm / zero-match distinction stay useful on the
+   default-redacted path (the same "redacted summary still exposes metadata"
+   contract as the live-cache accessors).
+
 The same `instance-row` per-slot egress seam carries the EP-0015 **on-box
 local-render** default (`:rf.egress/local-redacted`, Spec 015 §Projection
 profiles + §The graduation gate; `panels/local-render`). When a panel routes

--- a/tools/xray/spec/026-Module-View-Panel.md
+++ b/tools/xray/spec/026-Module-View-Panel.md
@@ -98,16 +98,46 @@ anything**:
   caption** (`module_view_helpers/no-modules-caption`), naming the
   `rf/app` / `rf/module` / `rf/install!` remedy, rather than fabricating rows.
 
+### The three-way empty-state decision (rf2-e0mq7a)
+
+The core app-value contract distinguishes a **projected / load-order** app
+(no `:modules` slot) from an app **CONSTRUCTED from zero modules** (an explicit
+empty `:modules {}` map). The MODULES section preserves that distinction so a
+genuinely-installed zero-module app is never mislabelled as the load-order case:
+
+- some realm carries **module rows** (`any-modules?` true) → render the module
+  list;
+- some realm carries **provenance** (`any-provenance?` true — a CONSTRUCTED,
+  installed app whose `:modules` projects to a **vector**, `[]` for zero
+  modules) but no realm has any modules → render the **zero-module-app caption**
+  (`module_view_helpers/zero-module-app-caption`): the honest
+  installed-but-empty state, naming the `rf/module` remedy;
+- no realm carries provenance at all (every `:modules` nil — load-order /
+  sugar-only) → render the **no-module caption** (`no-modules-caption`).
+
+`project-app-modules` keys provenance off the **presence** of the `:modules`
+key, not its non-emptiness: an explicit `:modules {}` projects to an empty
+**vector** `[]` (constructed, zero modules), while an absent/nil `:modules`
+projects to **nil** (no provenance). Collapsing `{}` to nil — the prior
+`(when (seq modules) …)` bug — falsely rendered the load-order caption over an
+installed zero-module app.
+
 The pure projection (`module_view_helpers`):
 
 - `project-module-row` — one module value → `{:module-id :owns :requires
   :registration-kinds :registration-count :source}`;
 - `project-app-modules` — an app value → its sorted module rows + union
-  `:requires` (nil `:modules` when the app carries none);
+  `:requires`. `:modules` is **nil** when the app carries no `:modules` slot
+  (no provenance), an empty **vector** `[]` when `:modules {}` (constructed,
+  zero modules), or a non-empty row vector;
 - `project-realm-row` (3-arity) — fills a realm's `:modules` / `:requires`
   from `(rf/installed-app realm)`;
 - `project-module-view` (4-arity) — takes an `installed-app-of` resolver
-  (`rf/installed-app`) and sets `:provenance-available?` **true**.
+  (`rf/installed-app`) and sets `:provenance-available?` **true**;
+- `any-provenance?` — true when some realm's `:modules` is a vector (a
+  constructed app, including a zero-module one); separates the zero-module-app
+  caption from the no-provenance caption;
+- `any-modules?` — true when some realm carries at least one module row.
 
 **EP-0015 classification is NOT a per-module fact.** Durable data
 classification is **frame-owned** — declared on `reg-frame` / `make-frame` and
@@ -155,9 +185,13 @@ Cmd-K palette picks it up automatically (the palette reads
   reads `rf/installed-app` per realm.
 - `panels/module_view_helpers.cljc` — the pure `data → data` projection
   (`realm-frames` · `project-module-row` · `project-app-modules` ·
-  `project-realm-row` · `project-module-view` · `any-modules?` ·
-  `no-modules-caption` · `realm-summary-line`); JVM-testable.
+  `project-realm-row` · `project-module-view` · `any-provenance?` ·
+  `any-modules?` · `no-modules-caption` · `zero-module-app-caption` ·
+  `realm-summary-line`); JVM-testable.
 - Tests: `panels/module_view_helpers_cljs_test.cljc` (the address-space
   projection + the zero-ceremony / multi-realm classification + the empty /
   stale-frame edge cases + the module-row shape + the seam-fed
-  `project-module-view` + the no-modules / `any-modules?` empty state).
+  `project-module-view` + the three-way empty-state decision: module list /
+  zero-module-app caption / no-provenance caption via
+  `any-provenance?` / `any-modules?`, incl. the explicit `:modules {}`
+  constructed app — rf2-e0mq7a).

--- a/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/module_view.cljs
@@ -210,11 +210,22 @@
 (defn- modules-section-body
   "The MODULES section body — every realm's modules, grouped by realm only
   when the process is multi-realm (zero-ceremony: a single-realm process
-  lists its modules with the realm dimension implicit). When NO realm carries
-  module provenance (a load-order / sugar-only process), renders the calm
-  no-module caption rather than an empty list. Pure hiccup."
+  lists its modules with the realm dimension implicit). The empty-state is a
+  THREE-WAY decision (rf2-e0mq7a):
+
+    1. some realm has module rows → render the module list.
+    2. some realm carries PROVENANCE (a constructed, installed app) but NO
+       realm has any modules (every constructed app has `:modules []`) →
+       render the zero-module-app caption — the installed-but-empty state.
+    3. no realm carries provenance at all (load-order / sugar-only) → render
+       the no-provenance caption.
+
+  Cases 2 and 3 are distinct: a zero-module constructed app must NOT render the
+  load-order caption (which falsely claims the process never installed an app).
+  Pure hiccup."
   [realms multi-realm?]
-  (if (h/any-modules? realms)
+  (cond
+    (h/any-modules? realms)
     (into [:div {:data-testid "rf-xray-module-view-modules-list"}]
           (for [{:keys [realm modules] :as _r} realms
                 :when (seq modules)]
@@ -230,6 +241,16 @@
                        (with-meta (module-row m)
                          {:key (str (:module-id m))})))]
               {:key (str realm)})))
+
+    ;; Provenance present (constructed + installed) but no modules anywhere —
+    ;; the honest installed-but-empty state, NOT the load-order caption.
+    (h/any-provenance? realms)
+    [:div {:data-testid "rf-xray-module-view-modules-zero-module-app"
+           :style       awaiting-caption-style}
+     h/zero-module-app-caption]
+
+    ;; No provenance on any realm — the load-order / sugar-only process.
+    :else
     [:div {:data-testid "rf-xray-module-view-modules-empty"
            :style       awaiting-caption-style}
      h/no-modules-caption]))

--- a/tools/xray/src/day8/re_frame2_xray/panels/module_view_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/module_view_helpers.cljc
@@ -124,13 +124,26 @@
   CONSTRUCTED (`rf/app` / `rf/install!`); a realm seated through the `reg-*`
   sugar (load-order, no `install!`) carries NO `:modules` — its installed app is
   the registrar projection (EP-0013 disposition 6, the honest no-provenance
-  case). `nil` app (no seam value) is likewise module-less. `:modules` is nil
-  (not `[]`) in the no-provenance case so the panel can distinguish \"a
-  module-less load-order app\" from \"an app with zero modules\". Pure data →
-  data; JVM-testable."
+  case). `nil` app (no seam value) is likewise module-less.
+
+  The PRESENCE of the `:modules` KEY — not its non-emptiness — decides
+  provenance (rf2-e0mq7a). The core app-value contract (app_value.cljc) is
+  explicit: a projected/load-order app carries NO `:modules` slot, while an app
+  CONSTRUCTED from zero modules carries an EMPTY `:modules {}` map. So:
+
+    - `:modules` key ABSENT/nil → `:modules` projects to nil — the honest
+      no-provenance (load-order / sugar-only) case.
+    - `:modules` key PRESENT (even `{}`) → `:modules` projects to a VECTOR
+      (`[]` for a zero-module constructed app) — an installed constructed app.
+      This must NOT collapse to nil, or the panel falsely renders the
+      load-order/no-provenance caption over a genuinely-installed zero-module
+      app.
+
+  `:modules` is therefore one of: nil (no provenance), `[]` (constructed, zero
+  modules), or a non-empty row vector. Pure data → data; JVM-testable."
   [app]
   (let [modules (:modules app)]
-    {:modules  (when (seq modules)
+    {:modules  (when (some? modules)
                  (->> (vals modules)
                       (sort-by (comp str :rf.module/id))
                       (mapv project-module-row)))
@@ -146,8 +159,10 @@
        ;; (EP-0013 disposition 6, rf2-at0oen). `:modules` is nil for a
        ;; load-order (sugar-only / module-less) app — the honest
        ;; no-provenance case; the realm renders its address row but no module
-       ;; rows.
-       :modules        [<module-row> …] | nil
+       ;; rows. `:modules` is an empty VECTOR `[]` for a CONSTRUCTED app with
+       ;; zero modules (rf2-e0mq7a) — present-but-empty provenance, NOT the
+       ;; no-provenance case; the realm carries an installed constructed app.
+       :modules        [<module-row> …] | [] | nil
        :requires       #{:rf.capability/* …}  ;; the app's union requires
        :owns           nil                    ;; reserved — ownership lives per
                                               ;; module (`:modules … :owns`)
@@ -234,18 +249,50 @@
   but a process running entirely on the `reg-*` sugar / load-order path has no
   CONSTRUCTED app value — its installed app is the registrar projection, which
   carries no `:modules`. Names why the section is empty so the operator
-  understands it is the honest no-module state, not a broken surface. Pure data
-  → string."
+  understands it is the honest no-module state, not a broken surface.
+
+  This caption is for the NO-PROVENANCE case ONLY (`:modules` absent/nil on
+  every realm). An installed CONSTRUCTED app that simply has zero modules
+  (`:modules {}` → `[]`) carries provenance — it must render
+  `zero-module-app-caption`, not this one (rf2-e0mq7a). Pure data → string."
   (str "No module provenance — this process's realms are running on the "
        "load-order (reg-* sugar) path, whose installed app value carries no "
        "modules. Compose an app from modules (rf/app / rf/module) and install "
        "it (rf/install!) to surface per-module ownership, capability "
        "requirements, and descriptor provenance here."))
 
+(def zero-module-app-caption
+  "The empty-state caption the MODULES section renders when at least one realm
+  carries module PROVENANCE (a CONSTRUCTED, installed app — `:modules` present)
+  but no realm declares any modules — every constructed app was composed from
+  ZERO modules (`:modules {}` → `[]`) (rf2-e0mq7a). Distinct from
+  `no-modules-caption`: this app IS constructed and installed (it did NOT run on
+  the load-order path), it simply owns no modules yet. The honest
+  installed-but-empty state, NOT the no-provenance one. Pure data → string."
+  (str "Installed app has zero modules — this process's app value was "
+       "constructed and installed (rf/app / rf/install!) but composed from no "
+       "modules, so there is no per-module ownership, capability, or descriptor "
+       "provenance to show. Add modules (rf/module) to the app to populate this "
+       "section."))
+
+(defn any-provenance?
+  "True when at least one realm-row carries module PROVENANCE — i.e. some
+  realm's installed app was CONSTRUCTED and seated, so its `:modules` slot is a
+  VECTOR (`[]` for a zero-module app, or a non-empty row vector). A
+  no-provenance (load-order / sugar-only) realm carries `:modules` nil and does
+  NOT count. Used by the panel to decide whether ANY realm has a constructed app
+  at all — separating the no-provenance caption (no constructed app anywhere)
+  from the zero-module-app caption (a constructed app with no modules)
+  (rf2-e0mq7a). Pure data → bool; JVM-testable."
+  [realm-rows]
+  (boolean (some (comp vector? :modules) realm-rows)))
+
 (defn any-modules?
-  "True when at least one realm-row carries module provenance — i.e. some
-  realm's installed app was constructed and seated (`:modules` non-empty). Used
-  by the panel to choose between the module list and the no-modules caption.
+  "True when at least one realm-row carries at least one MODULE ROW — i.e. some
+  realm's installed app was constructed and seated with a NON-EMPTY `:modules`
+  vector. A constructed-but-zero-module app (`:modules []`) carries provenance
+  (`any-provenance?` is true) but NO module rows, so `any-modules?` is false for
+  it. Used by the panel to decide whether to render the module list at all.
   Pure data → bool; JVM-testable."
   [realm-rows]
   (boolean (some (comp seq :modules) realm-rows)))

--- a/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/resources_helpers.cljc
@@ -305,16 +305,27 @@
   scope carries PII, params identify the remote read), while the
   resource-id is a plain keyword (a registry name, never PII). Returns
   `{:scope <summary> :resource-id <kw> :params <summary>}`. A malformed
-  key (not a 3-vector) summarizes the whole key as a single value."
-  [scoped-key]
-  (if (and (vector? scoped-key) (= 3 (count scoped-key)))
-    (let [[scope rid params] scoped-key]
-      {:scope       (summarize scope)
-       :resource-id rid
-       :params      (summarize params)})
-    {:scope       (summarize scoped-key)
-     :resource-id nil
-     :params      (summarize nil)}))
+  key (not a 3-vector) summarizes the whole key as a single value.
+
+  Optional `egress-fn` (rf2-e0mq7a): `(fn [value] -> egressed)` applied to
+  the PII-bearing scope + params BEFORE `summarize`, so the off-box
+  (AI/MCP / log) accessors route those values through the framework
+  `egress-value` walker — a `:sensitive?` slot summarizes as `[redacted]`
+  and a `:large?` slot as `[large — elided]`. The resource-id is a registry
+  name (never PII), so it is never egressed. The in-panel caller omits the
+  fn — the in-panel `summarize` is sufficient for human rendering and the
+  values never leave the box."
+  ([scoped-key] (scoped-key-summary scoped-key nil))
+  ([scoped-key egress-fn]
+   (let [eg (or egress-fn identity)]
+     (if (and (vector? scoped-key) (= 3 (count scoped-key)))
+       (let [[scope rid params] scoped-key]
+         {:scope       (summarize (eg scope))
+          :resource-id rid
+          :params      (summarize (eg params))})
+       {:scope       (summarize (eg scoped-key))
+        :resource-id nil
+        :params      (summarize nil)}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Static resource registry projection (Spec 016 §Xray and AI tooling).
@@ -914,27 +925,44 @@
 
   Pure over the trace vector; preserves buffer order (oldest-first). The
   panel renders this as the per-resource lifecycle strip; filtering by
-  resource-id happens in the composite. Per Spec 016."
-  [trace-buffer]
-  (->> (or trace-buffer [])
-       (filter #(resource-trace-op? (trace-op %)))
-       (mapv (fn [ev]
-               (let [op   (trace-op ev)
-                     tags (trace-tags ev)
-                     rkey (or (:resource-key tags) (:resource/key tags))]
-                 {:id           (:id ev)
-                  :operation    op
-                  :label        (op-label op)
-                  :class        (op-class op)
-                  :resource-id  (or (:resource-id tags)
-                                    (when (vector? rkey) (second rkey)))
-                  :resource-key (when rkey (scoped-key-summary rkey))
-                  :generation   (:generation tags)
-                  :work-id      (:work/id tags)
-                  :owner        (:owner tags)
-                  :cause        (when (contains? tags :cause) (summarize (:cause tags)))
-                  :status       {:before (:status-before tags)
-                                 :after  (or (:status-after tags) (:status tags))}})))))
+  resource-id happens in the composite. Per Spec 016.
+
+  Optional `egress-fn` (rf2-e0mq7a): `(fn [value] -> egressed)` applied to
+  the VALUE-BEARING fields — the `:resource-key`'s scope/params (PII) and
+  the `:cause` (may carry mutation data) — BEFORE `summarize`. The off-box
+  (AI/MCP / log) accessor (`get-resource-history`) threads
+  `runtime/egress-value` here so per-slot `:sensitive?` / `:large?`
+  declarations are honoured on the trace-borne values, parallel to the way
+  `list-resource-instances` / `get-resource-state` route the live-cache
+  payloads through `resource-egress-fn`. The METADATA (operation, label,
+  class, resource-id, generation, work-id, owner, status) is NOT a payload
+  value and is never egressed — a redacted timeline STILL exposes the
+  lifecycle shape. The in-panel caller omits the fn (the in-panel
+  `summarize` is sufficient; values never leave the box). Pure when
+  `egress-fn` is pure."
+  ([trace-buffer] (lifecycle-timeline trace-buffer nil))
+  ([trace-buffer egress-fn]
+   (let [eg (or egress-fn identity)]
+     (->> (or trace-buffer [])
+          (filter #(resource-trace-op? (trace-op %)))
+          (mapv (fn [ev]
+                  (let [op   (trace-op ev)
+                        tags (trace-tags ev)
+                        rkey (or (:resource-key tags) (:resource/key tags))]
+                    {:id           (:id ev)
+                     :operation    op
+                     :label        (op-label op)
+                     :class        (op-class op)
+                     :resource-id  (or (:resource-id tags)
+                                       (when (vector? rkey) (second rkey)))
+                     :resource-key (when rkey (scoped-key-summary rkey eg))
+                     :generation   (:generation tags)
+                     :work-id      (:work/id tags)
+                     :owner        (:owner tags)
+                     :cause        (when (contains? tags :cause)
+                                     (summarize (eg (:cause tags))))
+                     :status       {:before (:status-before tags)
+                                    :after  (or (:status-after tags) (:status tags))}})))))))
 
 (defn invalidation-graph
   "Project the `:rf.resource/invalidated` trace rows into the
@@ -951,20 +979,35 @@
 
   Distinguishes a broad-tag storm (high `:match-count`) without flooding;
   a zero-match invalidation surfaces `:match-count 0` so 'no match in
-  this scope' is visible. Pure over the trace vector. Per Spec 016."
-  [trace-buffer]
-  (->> (or trace-buffer [])
-       (filter #(= :rf.resource/invalidated (trace-op %)))
-       (mapv (fn [ev]
-               (let [tags    (trace-tags ev)
-                     matched (or (:matched tags) [])]
-                 {:id          (:id ev)
-                  :scope       (summarize (:scope tags))
-                  :tags        (vec (:tags tags))
-                  :cause       (when (contains? tags :cause) (summarize (:cause tags)))
-                  :matched     (mapv scoped-key-summary matched)
-                  :match-count (count matched)
-                  :refetched   (or (:refetched tags) 0)})))))
+  this scope' is visible. Pure over the trace vector. Per Spec 016.
+
+  Optional `egress-fn` (rf2-e0mq7a): `(fn [value] -> egressed)` applied to
+  the VALUE-BEARING fields — `:scope` (PII), `:cause` (may carry mutation
+  data), and each `:matched` scoped key's scope/params — BEFORE `summarize`.
+  The off-box (AI/MCP / log) accessor (`list-resource-invalidations`)
+  threads `runtime/egress-value` here so per-slot `:sensitive?` / `:large?`
+  declarations are honoured on the trace-borne values, parallel to the
+  live-cache accessors. The non-PII metadata (`:tags` — invalidation
+  identity, `:match-count`, `:refetched`) is NEVER egressed, so the
+  tag-filter axis and the storm / zero-match distinction stay useful even
+  on the default-redacted path. The in-panel caller omits the fn. Pure when
+  `egress-fn` is pure."
+  ([trace-buffer] (invalidation-graph trace-buffer nil))
+  ([trace-buffer egress-fn]
+   (let [eg (or egress-fn identity)]
+     (->> (or trace-buffer [])
+          (filter #(= :rf.resource/invalidated (trace-op %)))
+          (mapv (fn [ev]
+                  (let [tags    (trace-tags ev)
+                        matched (or (:matched tags) [])]
+                    {:id          (:id ev)
+                     :scope       (summarize (eg (:scope tags)))
+                     :tags        (vec (:tags tags))
+                     :cause       (when (contains? tags :cause)
+                                    (summarize (eg (:cause tags))))
+                     :matched     (mapv #(scoped-key-summary % eg) matched)
+                     :match-count (count matched)
+                     :refetched   (or (:refetched tags) 0)})))))))
 
 ;; ---------------------------------------------------------------------------
 ;; EP-0016 D3 — named scope-resolver resolution timeline (Spec 016 §Named

--- a/tools/xray/src/day8/re_frame2_xray/runtime.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/runtime.cljs
@@ -1018,6 +1018,32 @@
                       [scoped-key entry] (.now js/Date)
                       (resource-egress-fn egress-opts))}))))))
 
+;; rf2-e0mq7a — the trace-value egress closure for the resource
+;; history/invalidation accessors. The lifecycle-timeline / invalidation-graph
+;; helpers project VALUE-BEARING fields off trace tags (the scoped key's
+;; scope/params, the cause, the matched keys). Those are trace-borne VALUES
+;; (NOT runtime-db `:entries` payloads — they live in the trace ring), so they
+;; egress through the plain `egress-value` walker with the off-box
+;; sensitive/large defaults baked in, NOT `resource-egress-fn` (which layers
+;; the runtime-db partition default + the `:entries` slot path). This is the
+;; trace-buffer peer of the per-slot egress the live-cache accessors thread:
+;; `list-resource-instances` / `get-resource-state` route runtime-db payloads
+;; through `resource-egress-fn`; these two route trace payloads through
+;; `egress-value`. Both honour per-slot `:sensitive?` / `:large?` declarations
+;; (matched by schema path) and both default-redact, opting back in per call.
+;; `drop-sensitive-events` already removes whole `:sensitive? true` ENVELOPES
+;; upstream; this scrubs the VALUES carried inside the surviving events.
+(defn- resource-trace-egress-fn
+  "Return the `(fn [value] -> egressed)` value-egress closure the resource
+  trace projections (`lifecycle-timeline` / `invalidation-graph`) apply to
+  their value-bearing fields (scope / params / cause / matched). Routes
+  through `egress-value` with the off-box defaults; `include-sensitive?` /
+  `include-large?` opt the matching declared slots back in (rf2-e0mq7a)."
+  [{:keys [include-sensitive? include-large?]}]
+  (fn [value]
+    (egress-value value {:include-sensitive? include-sensitive?
+                         :include-large?     include-large?})))
+
 (defn get-resource-history
   "Tool: `get-resource-history`. The BOUNDED lifecycle history for a
   resource (Spec 016 §Xray and AI tooling — the lifecycle timeline;
@@ -1026,21 +1052,36 @@
   `:resource-id`, `:nav-token`, `:limit` (default 50 — the bound).
 
   Returns `{:ok? true :frame <id> :history [<timeline-row> …] :count N}`
-  or `{:ok? false :reason :no-frame-resolved}`. The rows carry the
-  PRIVACY-summarized scope/params/cause projection (a cause may carry
-  data); whole `:sensitive? true` trace events are default-suppressed at
-  the off-box seam."
+  or `{:ok? false :reason :no-frame-resolved}`.
+
+  PRIVACY (rf2-e0mq7a — the off-box egress boundary for the value-bearing
+  trace fields): TWO layers, mirroring the live-cache accessors.
+    1. Whole `:sensitive? true` trace ENVELOPES are default-suppressed
+       (`drop-sensitive-events`); `:include-sensitive? true` opts them back
+       in.
+    2. The VALUE-BEARING fields carried INSIDE the surviving events — the
+       scoped key's scope/params (PII) and the cause (may carry mutation
+       data) — route through `egress-value` (`resource-trace-egress-fn`)
+       BEFORE the in-panel `summarize`, so per-slot `:sensitive?` / `:large?`
+       declarations redact / elide them by default. `:include-sensitive?` /
+       `:include-large?` are the trusted-local opt-ins. The METADATA
+       (operation / class / resource-id / generation / owner / status) is
+       NEVER egressed — a redacted timeline STILL exposes the lifecycle shape
+       and the resource-id filter stays useful."
   ([] (get-resource-history nil))
-  ([{:keys [frame resource-id nav-token limit include-sensitive?]
+  ([{:keys [frame resource-id nav-token limit include-sensitive? include-large?]
      :or   {limit 50} :as _opts}]
    (let [fid (resolve-frame frame)]
      (if-let [fail (frame-failure frame fid)]
        fail
-       (let [events  (-> (trace-tooling/trace-buffer fid {:flat true})
-                         (drop-sensitive-events include-sensitive?))
-             rows    (-> (resources-helpers/lifecycle-timeline events)
-                         (resources-helpers/filter-history-rows
-                           {:resource-id resource-id :nav-token nav-token :limit limit}))]
+       (let [events    (-> (trace-tooling/trace-buffer fid {:flat true})
+                           (drop-sensitive-events include-sensitive?))
+             egress-fn (resource-trace-egress-fn
+                         {:include-sensitive? include-sensitive?
+                          :include-large?     include-large?})
+             rows      (-> (resources-helpers/lifecycle-timeline events egress-fn)
+                           (resources-helpers/filter-history-rows
+                             {:resource-id resource-id :nav-token nav-token :limit limit}))]
          {:ok?     true
           :frame   fid
           :history (vec rows)
@@ -1056,16 +1097,29 @@
   Filter axis: `:tag` (only invalidations touching the tag).
 
   Returns `{:ok? true :frame <id> :invalidations [<row> …] :count N}` or
-  `{:ok? false :reason :no-frame-resolved}`."
+  `{:ok? false :reason :no-frame-resolved}`.
+
+  PRIVACY (rf2-e0mq7a — symmetric with `get-resource-history`): whole
+  `:sensitive? true` envelopes are default-suppressed, AND the value-bearing
+  fields (`:scope` / `:cause` / each `:matched` key's scope/params) route
+  through `egress-value` BEFORE `summarize` so per-slot `:sensitive?` /
+  `:large?` declarations redact / elide them by default; `:include-sensitive?`
+  / `:include-large?` are the trusted-local opt-ins. The non-PII metadata
+  (`:tags` — the invalidation identity used by the `:tag` filter axis,
+  `:match-count`, `:refetched`) is NEVER egressed, so tag filtering and the
+  storm / zero-match distinction stay useful on the default-redacted path."
   ([] (list-resource-invalidations nil))
-  ([{:keys [frame tag include-sensitive?] :as _opts}]
+  ([{:keys [frame tag include-sensitive? include-large?] :as _opts}]
    (let [fid (resolve-frame frame)]
      (if-let [fail (frame-failure frame fid)]
        fail
-       (let [events (-> (trace-tooling/trace-buffer fid {:flat true})
-                        (drop-sensitive-events include-sensitive?))
-             rows   (cond->> (resources-helpers/invalidation-graph events)
-                      (some? tag) (filter #(some #{tag} (:tags %))))]
+       (let [events    (-> (trace-tooling/trace-buffer fid {:flat true})
+                           (drop-sensitive-events include-sensitive?))
+             egress-fn (resource-trace-egress-fn
+                         {:include-sensitive? include-sensitive?
+                          :include-large?     include-large?})
+             rows      (cond->> (resources-helpers/invalidation-graph events egress-fn)
+                         (some? tag) (filter #(some #{tag} (:tags %))))]
          {:ok?           true
           :frame         fid
           :invalidations (vec rows)

--- a/tools/xray/test/day8/re_frame2_xray/panels/module_view_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/module_view_helpers_cljs_test.cljc
@@ -42,6 +42,18 @@
    :registrations {:event {:sugar/inc {:kind :event :id :sugar/inc}}}
    :requires      #{}})
 
+;; A CONSTRUCTED app composed from ZERO modules (rf2-e0mq7a). The core
+;; app-value contract (app_value.cljc:123-127) is explicit: an app constructed
+;; from zero modules carries an EMPTY `:modules {}` map — distinct from a
+;; projected/load-order app, which carries no `:modules` slot at all. Core
+;; tests pin `(rf/app {:id :empty/app})` → `:modules {}` + `:requires #{}`
+;; (app_value_compose_cljs_test.cljc:141-147), so this fixture mirrors that
+;; shape.
+(def ^:private zero-module-app
+  {:rf.app/id :empty/app
+   :modules   {}
+   :requires  #{}})
+
 ;; ---- realm-frames -------------------------------------------------------
 
 (deftest realm-frames-groups-by-resolver
@@ -108,6 +120,24 @@
       (is (= #{} requires))))
   (testing "nil app (no seam value) is likewise module-less"
     (is (nil? (:modules (h/project-app-modules nil))))))
+
+(deftest project-app-modules-zero-module-constructed-app
+  ;; rf2-e0mq7a — the adversarial case: an app CONSTRUCTED from zero modules
+  ;; carries an explicit empty `:modules {}` map (the core contract). The
+  ;; projection MUST preserve the present-but-empty distinction — an empty
+  ;; VECTOR `[]`, NOT nil — so the panel never falsely renders the
+  ;; load-order/no-provenance caption over a genuinely-installed app.
+  (testing "a constructed app with `:modules {}` projects to `[]` (NOT nil) —
+            present-but-empty provenance, distinct from no-provenance"
+    (let [{:keys [modules requires]} (h/project-app-modules zero-module-app)]
+      (is (= [] modules)
+          "explicit empty `:modules {}` → empty VECTOR, not nil")
+      (is (vector? modules)
+          "the empty result is a vector (constructed) — `(vector? modules)`
+           is the provenance signal `any-provenance?` reads")
+      (is (not (nil? modules))
+          "MUST NOT collapse to nil — that would erase the constructed app")
+      (is (= #{} requires)))))
 
 ;; ---- project-realm-row --------------------------------------------------
 
@@ -204,15 +234,54 @@
       (is (contains? (set (map :realm (:realms data))) :app/gone)
           "the orphan realm is surfaced rather than dropped"))))
 
-;; ---- no-modules empty-state / any-modules? ------------------------------
+;; ---- empty-state decision: any-modules? / any-provenance? ---------------
 
-(deftest any-modules?-detects-provenance
-  (testing "any-modules? is true when some realm-row carries modules"
+(deftest any-modules?-detects-module-rows
+  (testing "any-modules? is true when some realm-row carries at least one
+            MODULE ROW"
     (is (true? (h/any-modules? [{:realm :r1 :modules nil}
                                 {:realm :r2 :modules [{:module-id :m/a}]}])))
     (is (false? (h/any-modules? [{:realm :r1 :modules nil}
                                  {:realm :r2 :modules []}]))
-        "no modules anywhere → false")))
+        "a zero-module constructed app ([]) carries NO module rows → false")))
+
+(deftest any-provenance?-detects-constructed-app
+  ;; rf2-e0mq7a — the predicate that separates the zero-module-app caption
+  ;; (a constructed app with no modules) from the no-provenance caption (no
+  ;; constructed app anywhere). `:modules` is a VECTOR exactly when the realm's
+  ;; installed app was CONSTRUCTED (`[]` for a zero-module app); it is nil for
+  ;; the load-order / no-provenance case.
+  (testing "true when some realm carries a constructed app — including a
+            zero-module one (`:modules []`)"
+    (is (true? (h/any-provenance? [{:realm :r1 :modules nil}
+                                   {:realm :r2 :modules []}]))
+        "an empty VECTOR is present provenance (a constructed zero-module app)")
+    (is (true? (h/any-provenance? [{:realm :r1 :modules [{:module-id :m/a}]}]))
+        "a non-empty module vector is provenance too"))
+  (testing "false when NO realm carries a constructed app (every :modules nil)"
+    (is (false? (h/any-provenance? [{:realm :r1 :modules nil}
+                                    {:realm :r2 :modules nil}]))
+        "all load-order / no-provenance → no provenance anywhere")))
+
+(deftest empty-state-decision-three-way
+  ;; rf2-e0mq7a — the decision the UI `modules-section-body` consumes. Pins the
+  ;; three mutually-exclusive outcomes off the predicate pair so the panel's
+  ;; caption choice is correct without a browser render.
+  (testing "module rows present → render the module list (any-modules? true)"
+    (let [rows [{:realm :r :modules [{:module-id :m/a}]}]]
+      (is (true? (h/any-modules? rows)))))
+  (testing "constructed zero-module app → zero-module-app caption, NOT the
+            load-order caption (any-modules? false, any-provenance? true)"
+    (let [rows [{:realm :r :modules []}]]
+      (is (false? (h/any-modules? rows))
+          "no module rows → not the module list")
+      (is (true? (h/any-provenance? rows))
+          "provenance present → the zero-module-app branch, not no-provenance")))
+  (testing "no provenance anywhere → the load-order/no-provenance caption
+            (any-modules? false AND any-provenance? false)"
+    (let [rows [{:realm :r :modules nil}]]
+      (is (false? (h/any-modules? rows)))
+      (is (false? (h/any-provenance? rows))))))
 
 (deftest no-modules-caption-explains-the-empty-state
   (testing "the no-modules caption names the load-order / sugar reason and the
@@ -222,6 +291,22 @@
       (is (re-find #"(?i)load-order" c))
       (is (re-find #"(?i)rf/module" c))
       (is (re-find #"(?i)rf/install!" c)))))
+
+(deftest zero-module-app-caption-distinct-from-no-provenance
+  ;; rf2-e0mq7a — the caption an installed zero-module app renders. It MUST be
+  ;; distinct from `no-modules-caption` (a different string) and MUST NOT claim
+  ;; the process is on the load-order path (which is false for an installed
+  ;; constructed app).
+  (testing "the zero-module-app caption names the installed-but-empty state +
+            the rf/module remedy"
+    (let [c h/zero-module-app-caption]
+      (is (re-find #"(?i)zero modules" c))
+      (is (re-find #"(?i)constructed" c))
+      (is (re-find #"(?i)rf/module" c))
+      (is (not (re-find #"(?i)load-order" c))
+          "MUST NOT claim the load-order path — the app WAS constructed")))
+  (testing "the two empty-state captions are different strings"
+    (is (not= h/no-modules-caption h/zero-module-app-caption))))
 
 ;; ---- summaries ----------------------------------------------------------
 

--- a/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/runtime_cljs_test.cljs
@@ -1337,3 +1337,217 @@
                :params      {:slug "does-not-exist"}})]
       (is (false? (:ok? r)))
       (is (= :no-such-instance (:reason r))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-e0mq7a — get-resource-history / list-resource-invalidations egress the
+;; VALUE-BEARING trace fields (scope/params in the scoped key, the cause, the
+;; matched keys) through `egress-value` BEFORE summarizing, so per-slot
+;; :sensitive? / :large? declarations redact / elide them by DEFAULT and reveal
+;; them only under the trusted-local :include-sensitive? / :include-large?
+;; opt-ins, while the non-PII metadata (tags, counts, lifecycle shape) stays
+;; useful. This is the trace-buffer peer of the per-slot egress
+;; list-resource-instances / get-resource-state thread through
+;; `resource-egress-fn` for the live-cache payloads.
+;;
+;; The framework wire walker matches a :sensitive? / :large? declaration by
+;; APP-DB path WITHIN the value it walks (see egress-value-redacts-sensitive-
+;; on-the-safe-default-path). We declare a sub-path (`[:secret]`) that sits
+;; INSIDE the scope / cause map values, emit resource trace events carrying
+;; those values, and assert on the in-panel SUMMARY PREVIEW: when the walker
+;; redacts a nested leaf the surrounding map is still a map (so `:redacted?` on
+;; the wrapper stays false — the SENTINEL is nested, not the whole value), but
+;; the preview text carries the `:rf/redacted` sentinel in place of the raw
+;; secret. The load-bearing observable is therefore: the raw secret is ABSENT
+;; from the preview by default and PRESENT under the opt-in. A tiny helper makes
+;; that the assertion.
+
+(defn- seed-resource-trace-elision-schema! []
+  ;; A sensitive leaf (`[:secret]`) that sits INSIDE the scope / cause map
+  ;; values, plus a large leaf (`[:blob]`). The walker substitutes
+  ;; :rf/redacted / :rf.size/large-elided for those paths on off-box egress.
+  (frame-class/install! :rf/default
+    (frame-class/validate+extract :rf/default
+      {:sensitive {:app-db [[:secret]]}
+       :large     {:app-db [[:blob]]}})))
+
+;; A scope value carrying a declared-sensitive leaf alongside a plain identity
+;; leaf (which must survive — the scope's non-PII shape stays inspectable).
+(def ^:private e0mq7a-secret "tenant-shh-9001")
+(def ^:private e0mq7a-scope
+  {:secret e0mq7a-secret :region "ap-southeast"})
+(def ^:private e0mq7a-rkey
+  [e0mq7a-scope :article/by-slug {:slug "welcome"}])
+;; A cause value carrying a declared-sensitive leaf (a mutation may carry data).
+(def ^:private e0mq7a-cause
+  {:mutation :article/save :secret e0mq7a-secret})
+
+(defn- emit-resource-trace-into-ring! [operation tags]
+  (rf/emit-trace-event! :rf.resource operation
+                        (merge {:frame                :rf/default
+                                :rf.trace/dispatch-id (random-uuid)}
+                               tags)))
+
+(defn- preview-has? [summary substr]
+  ;; True when the summary's preview text contains substr (plain substring,
+  ;; no regex — the sentinels carry `.` / `/`). The redaction observable: the
+  ;; raw secret is absent (and `:rf/redacted` present) by default; the raw
+  ;; secret is present under the opt-in.
+  (boolean (and (string? (:preview summary))
+                (<= 0 (.indexOf ^js/String (:preview summary) substr)))))
+
+(deftest get-resource-history-redacts-value-bearing-fields-by-default
+  (testing "rf2-e0mq7a — the scoped-key scope (PII) and the cause (may carry
+            data) are routed through egress-value BEFORE summarizing, so a
+            declared-sensitive leaf is REDACTED OUT of the summary preview by
+            DEFAULT while the lifecycle metadata still projects"
+    (trace-tooling/clear-trace-buffer! :rf/default)
+    (seed-resource-trace-elision-schema!)
+    (emit-resource-trace-into-ring! :rf.resource/fetch-started
+                                    {:resource-key e0mq7a-rkey
+                                     :generation   4
+                                     :cause        e0mq7a-cause})
+    (let [result (runtime/get-resource-history {:resource-id :article/by-slug})]
+      (is (true? (:ok? result)))
+      (is (= 1 (:count result)))
+      (let [row        (first (:history result))
+            scope-sum  (get-in row [:resource-key :scope])
+            cause-sum  (:cause row)]
+        ;; METADATA rides — a redacted timeline still exposes the shape.
+        (is (= :rf.resource/fetch-started (:operation row)) "operation metadata projects")
+        (is (= :article/by-slug (:resource-id row)) "resource-id metadata projects")
+        (is (= 4 (:generation row)) "generation metadata projects")
+        ;; The scope's declared-sensitive leaf is gone from the preview; the
+        ;; non-PII sibling (:region) survives — the shape stays inspectable.
+        (is (not (preview-has? scope-sum e0mq7a-secret))
+            "the raw secret is REDACTED OUT of the scope preview by default")
+        (is (preview-has? scope-sum ":rf/redacted")
+            "the scope preview carries the :rf/redacted sentinel where the secret was")
+        (is (preview-has? scope-sum "ap-southeast")
+            "the non-PII scope sibling survives (metadata stays useful)")
+        ;; The cause carried a declared-sensitive leaf too → redacted out.
+        (is (not (preview-has? cause-sum e0mq7a-secret))
+            "the raw secret is REDACTED OUT of the cause preview by default")
+        (is (preview-has? cause-sum ":rf/redacted")
+            "the cause preview carries the sentinel")))))
+
+(deftest get-resource-history-reveals-value-bearing-fields-on-opt-in
+  (testing "rf2-e0mq7a — :include-sensitive? true is the trusted-local opt-in:
+            the raw sensitive leaf returns to the scope / cause preview"
+    (trace-tooling/clear-trace-buffer! :rf/default)
+    (seed-resource-trace-elision-schema!)
+    (emit-resource-trace-into-ring! :rf.resource/fetch-started
+                                    {:resource-key e0mq7a-rkey
+                                     :generation   4
+                                     :cause        e0mq7a-cause})
+    (let [result (runtime/get-resource-history
+                   {:resource-id :article/by-slug :include-sensitive? true})
+          row    (first (:history result))]
+      (is (true? (:ok? result)))
+      (is (preview-has? (get-in row [:resource-key :scope]) e0mq7a-secret)
+          ":include-sensitive? true ⇒ the raw secret returns to the scope preview")
+      (is (preview-has? (:cause row) e0mq7a-secret)
+          ":include-sensitive? true ⇒ the raw secret returns to the cause preview"))))
+
+(deftest get-resource-history-large-leaf-elided-by-default
+  (testing "rf2-e0mq7a — a declared-:large? leaf is size-elided out of the
+            scope preview by default and returns under :include-large? true"
+    (trace-tooling/clear-trace-buffer! :rf/default)
+    (seed-resource-trace-elision-schema!)
+    ;; A scope whose ONLY value-bearing slot is a declared-large leaf, so the
+    ;; large elision is observable independent of the sensitive redaction.
+    (let [big-scope {:blob {:rows (vec (range 50))} :region "ap-southeast"}
+          big-rkey  [big-scope :article/by-slug {:slug "big"}]]
+      (emit-resource-trace-into-ring! :rf.resource/fetch-started
+                                      {:resource-key big-rkey :generation 4})
+      (testing "default path elides the large leaf out of the preview"
+        (let [row   (first (:history (runtime/get-resource-history
+                                       {:resource-id :article/by-slug})))
+              scope (get-in row [:resource-key :scope])]
+          (is (preview-has? scope ":rf.size/large-elided")
+              "the large leaf is replaced by the size-elided sentinel by default")
+          (is (not (preview-has? scope ":rows"))
+              "the large leaf's raw contents (the :rows blob) do NOT cross by default")))
+      (testing ":include-large? true returns the raw large leaf to the preview"
+        (let [row   (first (:history (runtime/get-resource-history
+                                       {:resource-id :article/by-slug
+                                        :include-large? true})))
+              scope (get-in row [:resource-key :scope])]
+          (is (not (preview-has? scope ":rf.size/large-elided"))
+              ":include-large? true ⇒ the large leaf is no longer elided"))))))
+
+(deftest list-resource-invalidations-redacts-value-bearing-fields-by-default
+  (testing "rf2-e0mq7a — :scope (PII), :cause (may carry data), and each
+            :matched key's scope are routed through egress-value BEFORE
+            summarizing, so a declared-sensitive leaf is redacted out by
+            default; the non-PII :tags / :match-count / :refetched metadata
+            still project"
+    (trace-tooling/clear-trace-buffer! :rf/default)
+    (seed-resource-trace-elision-schema!)
+    (emit-resource-trace-into-ring! :rf.resource/invalidated
+                                    {:scope   e0mq7a-scope
+                                     :tags    #{[:article "welcome"]}
+                                     :cause   e0mq7a-cause
+                                     :matched [e0mq7a-rkey]
+                                     :refetched 1})
+    (let [result (runtime/list-resource-invalidations)]
+      (is (true? (:ok? result)))
+      (is (= 1 (:count result)))
+      (let [row (first (:invalidations result))]
+        ;; Non-PII metadata rides → the :tag filter axis + storm/zero-match
+        ;; distinction stay useful on the default-redacted path.
+        (is (= [[:article "welcome"]] (:tags row)) "invalidated tags project (identity)")
+        (is (= 1 (:match-count row)) "match-count projects")
+        (is (= 1 (:refetched row)) "refetched projects")
+        ;; Value-bearing fields redact the secret out by default.
+        (is (not (preview-has? (:scope row) e0mq7a-secret))
+            "the invalidation scope redacts the secret out by default")
+        (is (preview-has? (:scope row) ":rf/redacted")
+            "the scope preview carries the sentinel")
+        (is (not (preview-has? (:cause row) e0mq7a-secret))
+            "the cause redacts the secret out by default")
+        (is (not (preview-has? (get-in row [:matched 0 :scope]) e0mq7a-secret))
+            "each matched key's scope redacts the secret out by default")
+        (is (preview-has? (get-in row [:matched 0 :scope]) ":rf/redacted")
+            "the matched-key scope preview carries the sentinel")))))
+
+(deftest list-resource-invalidations-reveals-value-bearing-fields-on-opt-in
+  (testing "rf2-e0mq7a — :include-sensitive? true reveals the raw secret in the
+            invalidation scope / cause / matched-key scope previews, while the
+            metadata is unchanged"
+    (trace-tooling/clear-trace-buffer! :rf/default)
+    (seed-resource-trace-elision-schema!)
+    (emit-resource-trace-into-ring! :rf.resource/invalidated
+                                    {:scope   e0mq7a-scope
+                                     :tags    #{[:article "welcome"]}
+                                     :cause   e0mq7a-cause
+                                     :matched [e0mq7a-rkey]
+                                     :refetched 1})
+    (let [result (runtime/list-resource-invalidations {:include-sensitive? true})
+          row    (first (:invalidations result))]
+      (is (true? (:ok? result)))
+      (is (preview-has? (:scope row) e0mq7a-secret) ":include-sensitive? reveals the scope secret")
+      (is (preview-has? (:cause row) e0mq7a-secret) ":include-sensitive? reveals the cause secret")
+      (is (preview-has? (get-in row [:matched 0 :scope]) e0mq7a-secret)
+          ":include-sensitive? reveals the matched-key scope secret")
+      (is (= [[:article "welcome"]] (:tags row))
+          "metadata is unchanged by the opt-in"))))
+
+(deftest list-resource-invalidations-tag-filter-works-on-default-path
+  (testing "rf2-e0mq7a — the :tag filter axis (which matches the non-PII
+            invalidated :tags) still works on the default-redacted path,
+            because :tags are NEVER routed through egress"
+    (trace-tooling/clear-trace-buffer! :rf/default)
+    (seed-resource-trace-elision-schema!)
+    (emit-resource-trace-into-ring! :rf.resource/invalidated
+                                    {:scope e0mq7a-scope
+                                     :tags  #{[:article "welcome"]}
+                                     :matched [e0mq7a-rkey]})
+    (emit-resource-trace-into-ring! :rf.resource/invalidated
+                                    {:scope e0mq7a-scope
+                                     :tags  #{[:user "u-1"]}
+                                     :matched []})
+    (is (= 1 (:count (runtime/list-resource-invalidations
+                       {:tag [:article "welcome"]})))
+        "tag filter matches exactly the one invalidation touching the tag")
+    (is (= 2 (:count (runtime/list-resource-invalidations)))
+        "both invalidations surface with no filter")))


### PR DESCRIPTION
Implements **rf2-e0mq7a** (P2, tools/xray senior review). Two findings, both in `tools/xray`.

## Finding 1 — Module-view preserves zero-module constructed apps

The core app-value contract (`implementation/core/src/re_frame/app_value.cljc:123-127`) distinguishes a **projected / load-order** app (no `:modules` slot) from an app **CONSTRUCTED from zero modules** (an explicit `:modules {}` map — pinned by `app_value_compose_cljs_test.cljc:141-147`). The Module-view helper `project-app-modules` used `(when (seq modules) …)`, which collapsed `{}` to `nil`, so a genuinely-installed zero-module app fell into the no-provenance branch and rendered the false load-order caption.

- `project-app-modules` now keys provenance off the **presence** of the `:modules` key (`some? modules`): `:modules {}` → empty **vector** `[]` (constructed, zero modules); absent/nil → `nil` (no provenance).
- New `any-provenance?` predicate (some realm's `:modules` is a vector) separates the zero-module-app case from the no-provenance case; `any-modules?` still gates the module list.
- New `zero-module-app-caption`; `modules-section-body` is now a **three-way** decision: module list / zero-module-app caption / no-provenance caption. A zero-module constructed app no longer renders the load-order caption.

## Finding 2 — off-box egress for resource history/invalidation value-bearing trace fields

`get-resource-history` / `list-resource-invalidations` dropped whole `:sensitive?` envelopes but passed raw trace values (the scoped key's scope/params, `:cause`, the `:matched` keys) straight to `lifecycle-timeline` / `invalidation-graph`, unlike `list-resource-instances` / `get-resource-state` which route payloads through `resource-egress-fn`.

- `lifecycle-timeline` / `invalidation-graph` / `scoped-key-summary` now take an optional `egress-fn` applied to the value-bearing fields **before** `summarize`.
- The runtime threads `egress-value` (off-box `:sensitive?`/`:large?` defaults) via the new `resource-trace-egress-fn` — the trace-buffer peer of `resource-egress-fn`. These are **trace** values (not runtime-db `:entries` payloads), so the walker is `egress-value`, not `egress-runtime-db-value`; there is no runtime-db partition to gate. Both accessors now accept `:include-large?`. Declared `:sensitive?`/`:large?` values redact/elide **by default** and reveal under the trusted-local `:include-sensitive?`/`:include-large?` opt-ins, while the non-PII metadata (`:tags`, counts, lifecycle shape) stays useful and the `:tag` filter axis still works on the default-redacted path.

## Tests

- Helper (`module_view_helpers_cljs_test.cljc`): adversarial `project-app-modules` on an explicit `:modules {}` constructed app (`[]`, not nil); `any-provenance?` / `any-modules?`; the three-way empty-state decision; the two distinct captions.
- Runtime (`runtime_cljs_test.cljs`): the scope/params/cause/matched value-bearing fields redact (raw secret absent, `:rf/redacted` present) / elide (`:rf.size/large-elided`) by default and reveal under `:include-sensitive?`/`:include-large?`, while `:tags`/`:match-count`/`:refetched` metadata and the `:tag` filter still project.

Specs `024-Resources-Panel.md` (§Privacy — trace-borne egress) and `026-Module-View-Panel.md` (§4 three-way empty-state) updated in the same PR.

## Quality gates

- `clojure -M:test` (tools/xray JVM): **1192 tests, 5299 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **7086 tests, 29150 assertions, 0 failures, 0 errors**
- `npm run test:xray-feature-gate`: **15 scenarios, 0 failures, 13 matrix rows** (exit 0)