### PR TITLE
refactor(flows): prune stale conformance skips (rf2-lrf1se)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -432,12 +432,10 @@
   the pending frame-state, dirty-check each one, recompute and assoc-in the
   result into a transformed APP-DB. Returns the flow-augmented APP-DB value.
 
-  Two arities:
-    `[frame-id db]`            — app-db-only pending state (runtime-db is
-                                 nil; only bare app-db inputs resolve).
-    `[frame-id db runtime-db]` — the full pending frame-state. `db` is the
-                                 pending app-db partition; `runtime-db` the
-                                 pending runtime-db partition.
+  Signature `[frame-id db runtime-db]` — the full pending frame-state. `db`
+  is the pending app-db partition; `runtime-db` the pending runtime-db
+  partition (pass `nil` to resolve only bare app-db inputs). The router's
+  flows-after-interceptor always supplies both partitions.
 
   EP-0001 §535-551 (Mike RULED (b) 2026-06-09): a flow reads app-db by
   default (bare `:inputs` paths) and runtime-db only through EXPLICIT
@@ -494,8 +492,7 @@
   so this rollback cannot clobber its just-advanced dirty-check rows. The
   per-frame-independence invariant (Spec 002 rule 1 / Spec 013
   §Frame-scoping) holds by construction, not by careful keying."
-  ([frame-id db] (run-flows-on-db frame-id db nil))
-  ([frame-id db runtime-db]
+  [frame-id db runtime-db]
   (let [flow-map (get (registry/flows-snapshot) frame-id)]
     (if-not (seq flow-map)
       db
@@ -560,7 +557,7 @@
             ;; untouched. The throw (carrying `:rf.flow/failed-id` from
             ;; `evaluate-flow!`) propagates unchanged for router attribution.
             (registry/reset-frame-last-inputs-to! frame-id last-inputs-before)
-            (throw e))))))))
+            (throw e)))))))
 
 ;; ---- late-bind hook registration ----------------------------------------
 ;;

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -84,9 +84,26 @@
   ## Capability claim
 
   Per `spec/conformance/README.md` §Capability tagging, the runner
-  declares the surface its host implements. A fixture whose
-  `:fixture/capabilities` are NOT a subset of `claimed-capabilities`
-  is reported as out-of-claim and does not block the suite.
+  declares the surface its host implements via `claimed-capabilities` /
+  `claimed-spec-versions`.
+
+  Unlike the corpus-wide machines / ssr / core runners — which iterate
+  the WHOLE fixture set and legitimately skip fixtures targeting another
+  surface — this runner pre-filters to `flow-*.edn` ONLY (see
+  `all-flow-fixtures`). Every fixture it sees is a flow fixture the flows
+  artefact is the reference gate for. So an out-of-claim capability (or an
+  unclaimed spec-version) on a flow fixture is never \"another surface's
+  concern\": it is a newly-added flow capability this runner has not yet
+  implemented, or a typo. Either way it must FAIL the gate loudly, not be
+  silently skipped — a silent skip would let a new flow fixture's
+  contract go entirely unchecked while the gate stayed green.
+
+  Concretely (rf2-lrf1se): out-of-claim / unclaimed-spec-version flow
+  fixtures are recorded as FAILURES (not non-blocking skips), so the
+  suite's `(is (zero? failed))` assertion catches them. The fix is to
+  extend `claimed-capabilities` (and implement the matcher) — a reviewed
+  edit to this file — never to let the fixture skip. There is no
+  known-skips list because the correct number of known skips is zero.
 
   The claim here covers the `:flow/*` capabilities every flow fixture
   exercises plus the bare `:core/*` capabilities every flow fixture
@@ -708,52 +725,58 @@
       (reset-runtime
         (fn []
           (cond
+            ;; A flow fixture that will not parse, declares a spec-version
+            ;; this runner does not claim, or declares a capability outside
+            ;; the claim is NOT a benign skip — this runner is the reference
+            ;; gate for every `flow-*.edn` fixture (rf2-lrf1se). Record it as
+            ;; a FAILURE so `(is (zero? failed))` catches it; the fix is to
+            ;; fix the fixture or extend `claimed-*` + implement the matcher
+            ;; (a reviewed edit to this file), never to let it skip.
             (:fixture/load-error fixture)
             (swap! results conj {:fixture-id fname
-                                 :skipped?   true
+                                 :fname      fname
+                                 :passed?    false
                                  :reason     "load error"
                                  :error      (:fixture/load-error fixture)})
 
             (not (spec-version-claimed? fixture))
             (swap! results conj {:fixture-id   (:fixture/id fixture)
                                  :fname        fname
-                                 :skipped?     true
+                                 :passed?      false
                                  :reason       "spec-version not in claimed set"
                                  :spec-version (:fixture/spec-version fixture)})
 
             (not (runnable-capability-set? fixture))
             (swap! results conj {:fixture-id   (:fixture/id fixture)
                                  :fname        fname
-                                 :skipped?     true
+                                 :passed?      false
                                  :reason       "capabilities outside flows-runner claim"
                                  :capabilities (:fixture/capabilities fixture)})
 
             :else
             (swap! results conj (assoc (run-fixture fixture) :fname fname))))))
     (let [all     @results
-          run     (remove :skipped? all)
-          passed  (filter :passed? run)
-          failed  (remove :passed? run)
-          skipped (filter :skipped? all)]
+          passed  (filter :passed? all)
+          failed  (remove :passed? all)]
       ;; Silent-on-success (rf2-try1x): summary prints only on failure.
+      ;; No skip bucket (rf2-lrf1se): a flow fixture this runner cannot run —
+      ;; load error, unclaimed spec-version, out-of-claim capability — is a
+      ;; FAILURE, not a non-blocking skip.
       (when (seq failed)
         (println)
         (println "Flows conformance corpus (flow-*.edn fixtures):")
         (println "  total fixtures:" (count all))
-        (println "  runnable:      " (count run))
         (println "  passed:        " (count passed))
         (println "  failed:        " (count failed))
-        (println "  skipped:       " (count skipped))
-        (when (seq skipped)
-          (println)
-          (println "Skipped:")
-          (doseq [s skipped]
-            (println "  " (:fixture-id s) "—" (:reason s)
-                     (or (:capabilities s) (:spec-version s) (:error s)))))
         (println)
         (println "Failures:")
         (doseq [f failed]
           (println "  " (:fixture-id f))
+          ;; Out-of-claim / load-error failures carry a `:reason` instead of
+          ;; matcher diffs — surface it (plus the offending caps / version).
+          (when-let [reason (:reason f)]
+            (println "    reason:" reason
+                     (or (:capabilities f) (:spec-version f) "")))
           (when (:error f)
             (println "    error:" (:error f)))
           (when-let [td (:expected-db f)]
@@ -800,5 +823,7 @@
           (doseq [ef (:err-failures f)]
             (println "    error-emit:" ef))))
       (is (zero? (count failed))
-          (str "All claim-runnable flow-*.edn conformance fixtures must pass; "
+          (str "Every flow-*.edn conformance fixture must pass (an out-of-claim "
+               "capability or unclaimed spec-version is itself a failure — extend "
+               "the claim + matcher, don't skip); "
                (count failed) " failed.")))))

--- a/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
+++ b/implementation/flows/test/re_frame/flows_per_frame_last_inputs_test.clj
@@ -106,7 +106,7 @@
     ;; Drive frame A's drain directly. A's flow throws, so run-flows-on-db
     ;; rolls back A's OWN container. The throw propagates — catch it.
     (is (thrown? Throwable
-                 (flows/run-flows-on-db :a {:n 7}))
+                 (flows/run-flows-on-db :a {:n 7} nil))
         "A's flow throw propagates out of run-flows-on-db")
 
     ;; THE ASSERTION: B's row is untouched by A's rollback.
@@ -143,7 +143,7 @@
                     :output (fn [_] (throw (ex-info "boom-B" {})))
                     :path   [:b-out]}
                    {:frame :solo})
-      (is (thrown? Throwable (flows/run-flows-on-db :solo {:n 5})))
+      (is (thrown? Throwable (flows/run-flows-on-db :solo {:n 5} nil)))
       (reset! a-row-before (registry/get-frame-flow-last-inputs :solo :A))
       (is (nil? @a-row-before)
           ":A's last-inputs advance was rolled back (single-frame atomicity intact)")

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -2,11 +2,13 @@
   "JVM smoke coverage for Spec 013 — Flows.
 
   This file backstops the conformance fixtures in
-  spec/conformance/fixtures/flow-*.edn. Where the fixtures
-  describe canonical flow shapes as data (skipped by the reference
-  harness until the :flow/* capability set is wired into the conformance
-  runner), the tests here exercise the same paths against the JVM
-  reference implementation directly:
+  spec/conformance/fixtures/flow-*.edn. Those fixtures describe canonical
+  flow shapes as data and are driven against the live runtime by
+  `re-frame.flows-conformance-test` (the flows artefact's own conformance
+  gate, which claims the `:flow/*` capability set). The tests here exercise
+  the same paths against the JVM reference implementation directly — a
+  focused, debuggable companion to the data-driven gate so a regression in
+  any of these shapes surfaces as a plain unit-test failure:
 
     - reg-flow / clear-flow round-trip
     - dirty-check (=-equal inputs do NOT recompute)

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -2,12 +2,11 @@
   "JVM coverage for Spec 009 §Flow trace events / Spec 013 §Flow tracing
   — verifies the five `:rf.flow/*` lifecycle events fire with the
   documented payloads. The conformance fixture
-  `flow-lifecycle-emits-traces.edn` describes the same shapes as data;
+  `flow-lifecycle-emits-traces.edn` describes the same shapes as data and
+  is driven against the live runtime by `re-frame.flows-conformance-test`;
   this file exercises them against the JVM reference implementation
-  directly so a regression surfaces as a unit-test failure even when the
-  conformance harness is skipping the fixture (the reference harness
-  skips `:flow/basic` capability fixtures until the runner wires the
-  flow-body realiser through).
+  directly so a regression surfaces as a plain unit-test failure rather
+  than only through the data-driven gate.
 
   Per rf2-2s1o: `:flow` op-type and `:rf.flow/*` operation vocabulary
   added for re-frame-10x v2's flow panel."


### PR DESCRIPTION
Prunes three vestigial skip-era items in `implementation/flows` (rf2-lrf1se, pre-alpha). Each premise was verified dead before deleting.

## What changed

**1. Stale skip-era docstrings (finding 1).** `flows_test.clj` and `flows_trace_test.clj` claimed the flow fixtures were "skipped by the reference harness until the `:flow/*` capability set is wired into the conformance runner". That is no longer true: `flows_conformance_test` is the flows artefact's own live conformance gate — it claims the full `:flow/*` capability set (`claimed-capabilities`) and drives every `flow-*.edn` fixture against the live runtime. Both docstrings reframed to describe the JVM smoke as a focused, debuggable companion to that live gate.

**2. Silent out-of-claim skip is now a loud failure (finding 2).** The flows conformance runner pre-filters to `flow-*.edn` ONLY — unlike the corpus-wide machines/ssr/core runners that iterate the whole fixture set and legitimately skip another surface's fixtures. So an out-of-claim capability (or unclaimed spec-version) on a flow fixture is never "another surface's concern": it is a newly-added flow capability this runner has not yet implemented, or a typo. Either is now recorded as a **failure** (`:passed? false`) instead of a non-blocking skip, so `(is (zero? failed))` catches it. No known-skips list — the correct number of known skips is zero. Verified: all 9 current `flow-*.edn` fixtures are in-claim at spec-version `"1.0"`, so the gate stays green; the dead skip-reporting bucket was removed from the summary.

**3. Removed test-only two-arg `run-flows-on-db` arity (finding 3).** The `[frame-id db]` arity merely delegated to the three-arg form with `nil` runtime-db. Verified the sole production caller — the router's `flows-after-interceptor` (`router.cljc:1181`) — always uses the three-arg form `(run-on-db frame pending-db pending-runtime-db)`. The only two-arg callers were two sites in `flows_per_frame_last_inputs_test.clj`. Removed the arity; both tests now pass an explicit `nil`. Decision recorded: the two-arg arity was not a current internal API, so it is removed per the bead's acceptance.

Nothing rejected — all three findings' premises held.

## Quality gates

- `clojure -M:test` (flows artefact): **203 tests / 4836 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **7073 tests / 29103 assertions, 0 failures, 0 errors**

Closes rf2-lrf1se.