### PR TITLE
refactor(routing): prune vestigial docs+tests (rf2-6qclsc)

### DIFF
--- a/implementation/routing/deps.edn
+++ b/implementation/routing/deps.edn
@@ -7,10 +7,14 @@
 ;; `:rf.route/cancel`, the `:rf.nav/push-url` / `:rf.nav/replace-url` /
 ;; `:rf.nav/scroll` fxs, `match-url` / `route-url`, the `:rf/route` /
 ;; `:rf.route/{id,params,query,transition,error}` framework subs, and
-;; the per-frame routing-runtime sub-keys
-;; (`:scroll-positions` / `:scroll-positions-order` /
-;; `:nav-token-counter` / `:pending-nav-counter`) sitting as siblings
-;; under `[:rf.runtime/routing ...]` in runtime-db (rf2-3ib8h, rf2-eguy4)) ships as a separate Maven
+;; and the per-frame routing runtime-db keys — the durable route slice
+;; `:current` (subscribable via `:rf/route`) and the
+;; local-subscribable `:pending-navigation` (via `:rf/pending-navigation`),
+;; both under `[:rf.runtime/routing ...]`. (Scroll positions and the
+;; nav-token / pending-nav allocator counters are NOT runtime-db state —
+;; they live in module-level host-side transient caches keyed by frame-id;
+;; see `re-frame.routing.nav-counters/routing-state-classification`,
+;; rf2-1hncp2 / rf2-oosjmh.) (rf2-3ib8h, rf2-eguy4)) ships as a separate Maven
 ;; artefact so apps that don't register any routes don't drag the
 ;; namespace, the route-rank / pattern-compile / nav-token machinery,
 ;; or any of the `:rf.route/*` and `:rf.nav/*` trace strings onto the

--- a/implementation/routing/test/re_frame/route_link_test.clj
+++ b/implementation/routing/test/re_frame/route_link_test.clj
@@ -24,32 +24,16 @@
   `route-link` row."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.routing :as routing]
-            [re-frame.schemas :as schemas]
-            [re-frame.flows :as flows]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.routing-test-support :as rts]))
 
-(defn reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
-  ;; routing/nav fxs require a carried frame stamp. Register `:rf/default`
-  ;; explicitly as the conventional app frame; URL ownership is now an
-  ;; explicit declaration, so opt in via `{:url-bound? true}`. Pin it as the
-  ;; ambient scope for the body.
-  (rf/reg-frame :rf/default {:url-bound? true
-                             :doc "route-link suite default app frame (explicit URL owner)."})
-  (require 're-frame.routing :reload)
-  (routing/reset-counters!)
-  (rf/with-frame :rf/default
-    (test-fn)))
-
-(use-fixtures :each reset-runtime)
+;; rf2-6qclsc: use the shared `reset-runtime` fixture directly rather than a
+;; drifting local copy. The route-link suite has no suite-specific reset
+;; extras, so the shared fixture (which additionally reloads ssr /
+;; test-support and drops the host-side scroll / nav-counter caches) applies
+;; verbatim.
+(use-fixtures :each rts/reset-runtime)
 
 ;; ---- registry registration ----------------------------------------------
 

--- a/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
+++ b/implementation/routing/test/re_frame/routing_concurrency_stress_test.clj
@@ -53,8 +53,6 @@
   is tight."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.flows :as flows]
-            [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             ;; rf2-k682: this test lives in the routing artefact's test
             ;; classpath, so requiring re-frame.routing here is the
@@ -63,33 +61,19 @@
             ;; reg-sub installations, and registers the framework
             ;; `:rf.nav/*` fxs. Without this require the rf/reg-route
             ;; calls below would throw :rf.error/routing-artefact-missing.
-            [re-frame.routing :as routing]
-            [re-frame.schemas :as schemas]
-            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.routing]
+            [re-frame.routing-test-support :as rts]
             [re-frame.trace :as trace])
   (:import [java.util.concurrent CountDownLatch]
            [java.util.concurrent.atomic AtomicLong]))
 
+;; rf2-6qclsc: wrap the shared `reset-runtime` fixture rather than keeping a
+;; drifting local copy. This suite's only extra is clearing trace listeners
+;; (the stress invariants register/deref listeners), so layer that on top of
+;; the shared registrar/runtime/cache reset.
 (defn- reset-runtime [test-fn]
-  (registrar/clear-all!)
-  (reset! frame/frames {})
-  (flows/reset-flows!)
-  (schemas/clear-schemas-by-frame!)
   (trace/clear-listeners!)
-  (rf/init! plain-atom/adapter)
-  ;; EP-0002 (rf2-nn0jqa): `init!` no longer synthesises `:rf/default`, and
-  ;; routing/nav fxs require a carried frame stamp. Register `:rf/default`
-  ;; explicitly as the conventional app frame; URL ownership is now an
-  ;; explicit declaration, so opt in via `{:url-bound? true}`. Pin it as the
-  ;; ambient scope for the body.
-  (rf/reg-frame :rf/default {:url-bound? true
-                             :doc "concurrency-stress suite default app frame (explicit URL owner)."})
-  ;; Framework events / fx (routing.cljc) are registered at ns-load;
-  ;; clear-all! wiped them. Reload to resurrect.
-  (require 're-frame.routing :reload)
-  (routing/reset-counters!)
-  (rf/with-frame :rf/default
-    (test-fn)))
+  (rts/reset-runtime test-fn))
 
 (use-fixtures :each reset-runtime)
 
@@ -113,7 +97,7 @@
 
 ;; ---- Scenario 1: N concurrent :rf.route/transitioned from N frames -------------
 
-(deftest ^:stress url-changed-cross-frame-stress
+(deftest ^:stress transitioned-cross-frame-stress
   ;; rf2-ksbur scenario 1.
   ;;
   ;; Each thread owns its own frame and fires `stress-iters` `:rf.route/transitioned`
@@ -266,7 +250,7 @@
   ;; ID drove it, with no popstate-vs-push reordering visible at the
   ;; counter level.
   (testing (str n-threads " threads × " stress-iters
-                " iters mixed url-changed/handle-url-change "
+                " iters mixed transitioned/handle-url-change "
                 "— exact on-match count, no double-process")
     (let [global-counter      (AtomicLong. 0)
           per-thread-counters (vec (repeatedly n-threads #(atom 0)))
@@ -324,7 +308,7 @@
                    ". Per-thread breakdown: " per-thread-totals))
           (is (every? #(= stress-iters %) per-thread-totals)
               (str "Each thread must have processed exactly "
-                   stress-iters " on-match events (mixed url-changed "
+                   stress-iters " on-match events (mixed transitioned "
                    "+ handle-url-change); got " per-thread-totals)))
 
         ;; --- Invariant 2: global atomic exact ---------------------

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -186,30 +186,25 @@
 
 (def ^:dynamic *history-state* nil)
 
-;; Real-browser detection. node-runtime starts with no `js/window`; the
-;; stub's `install-window-stub!` builds one on `js/globalThis`. In a
-;; real browser (shadow-cljs `:browser-test` headless Chromium runner)
-;; `js/window` IS the actual `Window` object — its `History` API can't
-;; be js-deleted + replaced, so the in-memory `*history-state*` atom
-;; can't observe real-browser pushState calls. Defer browser-runtime
-;; coverage to a future real-history-wrapping harness; for now scope
-;; this ns to node-runtime via fixture-level skip.
-(def ^:private real-browser?
-  (and (exists? js/window)
-       (some? (.-history js/window))
-       (identical? js/window js/globalThis)))
-
+;; Node-runtime only by design (rf2-6qclsc). This ns ends in `-cljs-test`,
+;; so shadow-cljs discovers it under the `:node-test` build (`:ns-regexp
+;; "cljs-test$"`) ONLY — the `:browser-test` build is narrowed to
+;; `-dom-cljs-test$` namespaces (rf2-2hrj8, implementation/shadow-cljs.edn).
+;; The fixture installs an in-memory `js/window` / history stub on
+;; `js/globalThis` (a real browser's `Window` / `History` cannot be
+;; replaced, so the in-memory `*history-state*` atom could not observe
+;; real pushState calls there anyway). A real-browser harness would be a
+;; separate `*_dom_cljs_test.cljs` namespace; until one exists there is no
+;; silent browser no-op to guard against — the gates never run this ns in
+;; a browser.
 (defn- with-window-stub-fixture
   [f]
-  (if real-browser?
-    ;; Real browser — fixture skips body; tests run as no-ops.
-    nil
-    (let [state (install-window-stub!)]
-      (try
-        (binding [*history-state* state]
-          (f))
-        (finally
-          (uninstall-window-stub!))))))
+  (let [state (install-window-stub!)]
+    (try
+      (binding [*history-state* state]
+        (f))
+      (finally
+        (uninstall-window-stub!)))))
 
 (use-fixtures :each
   with-window-stub-fixture
@@ -732,7 +727,7 @@
 ;; handler — when only the URL fragment changes (the route-id,
 ;; :params, and :query are unchanged) the runtime updates
 ;; [:rf.runtime/routing :current :fragment] and emits :rf.route/fragment-changed (rf2-cj9fn,
-;; pre-rename: `:rf.route/fragment-changed`) instead of re-firing :on-match.
+;; pre-rename: `:rf.route/url-changed`) instead of re-firing :on-match.
 ;; That's the framework's hashchange surface.
 
 (deftest hashchange-fragment-only-cljs

--- a/implementation/routing/test/re_frame/routing_navigation_test.clj
+++ b/implementation/routing/test/re_frame/routing_navigation_test.clj
@@ -147,7 +147,7 @@
 ;; `navigate-url-form-preserves-fragment` (above) only covers the MATCHING
 ;; URL-string case; the not-found fallback through the programmatic
 ;; URL-string entry point (distinct from the URL-driven
-;; `:rf.route/transitioned` path that `url-changed-unmatched-url-routes-to-
+;; `:rf.route/transitioned` path that `transitioned-unmatched-url-routes-to-
 ;; not-found` covers) was unpinned.
 
 (deftest navigate-url-form-unmatched-routes-to-not-found
@@ -266,7 +266,7 @@
            link/popstate, so the address bar already shows the requested url
            (this path is unchanged by rf2-0zr2o)"))))
 
-(deftest url-changed-validation-fail-routes-to-not-found-with-reason
+(deftest transitioned-validation-fail-routes-to-not-found-with-reason
   (testing ":rf.route/transitioned for a structurally-matched URL whose params
             fail schema validation routes to :rf.route/not-found with
             `:reason :validation` in :params (Spec 012 §Param validation)"
@@ -409,7 +409,7 @@
 ;; page; leaving the previous slice intact (pre-fix) showed the previous
 ;; route's UI through a navigation to a nonexistent URL.
 
-(deftest url-changed-unmatched-url-routes-to-not-found
+(deftest transitioned-unmatched-url-routes-to-not-found
   (testing ":rf.route/transitioned for an unmatched URL writes the
             :rf.route/not-found slice with {:url url} in :params"
     (rf/reg-route :route/home {:path "/"})
@@ -433,7 +433,7 @@
       (is (some? (:nav-token slice))
           "a fresh nav-token is allocated even for not-found navigation"))))
 
-(deftest url-changed-not-found-without-route-registered-warns
+(deftest transitioned-not-found-without-route-registered-warns
   (testing "when :rf.route/not-found is NOT registered, an unmatched URL
             still rewrites the slice AND emits :rf.warning/no-not-found-route"
     (rf/reg-route :route/home {:path "/"})
@@ -464,7 +464,7 @@
 ;; URLs from bare misses ({:url url}) and validation failures
 ;; ({:url url :reason :validation}).
 
-(deftest url-changed-malformed-url-routes-to-not-found-with-reason
+(deftest transitioned-malformed-url-routes-to-not-found-with-reason
   (testing ":rf.route/transitioned for a malformed-%-encoded URL writes the
             :rf.route/not-found slice with `:reason :malformed-url`"
     (rf/reg-route :route/home    {:path "/"})
@@ -497,7 +497,7 @@
       (is (= :rf.route/not-found (:id slice)) "malformed fragment → not-found")
       (is (= :malformed-url (get-in slice [:params :reason]))))))
 
-(deftest url-changed-malformed-url-emits-structured-trace
+(deftest transitioned-malformed-url-emits-structured-trace
   (testing ":rf.route/transitioned emits :rf.warning/malformed-url alongside the
             standard :rf.error/no-such-handler when the URL is malformed"
     (rf/reg-route :route/home {:path "/"})
@@ -522,7 +522,7 @@
                 @traces)
           ":rf.error/no-such-handler carries `:reason :malformed-url`"))))
 
-(deftest url-changed-forward-nav-traces-carry-frame-rf2-w3qgc
+(deftest transitioned-forward-nav-traces-carry-frame-rf2-w3qgc
   (testing "rf2-w3qgc: forward URL-driven nav (`:rf.route/transitioned`)
             threads the active `frame` through `url-change-fx`, so the
             route-miss / malformed-url / no-not-found diagnostics carry
@@ -590,7 +590,7 @@
             "default-frame dispatch tags :rf/default (not nil) — matches the
              popstate/SSR sibling and the programmatic path")))))
 
-(deftest url-changed-well-formed-url-does-not-emit-malformed-trace
+(deftest transitioned-well-formed-url-does-not-emit-malformed-trace
   (testing "the regular happy path emits NO :rf.warning/malformed-url"
     (rf/reg-route :route/home    {:path "/"})
     (rf/reg-route :route/search  {:path "/search"})
@@ -613,7 +613,7 @@
 ;; Pre-fix the URL-driven handler hardcoded :idle, so URL-driven loaders
 ;; never observed the :loading state.
 
-(deftest url-changed-transition-loading-when-on-match-fires
+(deftest transitioned-transition-loading-when-on-match-fires
   (testing ":rf.route/transitioned sets :transition :loading when the route
             declares :on-match events"
     (rf/reg-event-db :prefs/loaded (fn [db _] (assoc db :prefs/loaded? true)))
@@ -716,7 +716,7 @@
           ":rf.nav/push-url pushed the REQUESTED (over-cap) url VERBATIM —
            NOT the not-found route's /404 (rf2-0zr2o address-bar parity)")
       ;; rf2-2zyvj: the SAME hostile-URL signal the URL-driven path emits
-      ;; (url-changed-over-cap → :rf.warning/malformed-url) MUST also fire on
+      ;; (`:rf.route/transitioned` over-cap → :rf.warning/malformed-url) MUST also fire on
       ;; the programmatic `{:url ...}` fail-closed path, or the over-cap
       ;; navigate attack is invisible to the security dashboards / SSR
       ;; error-projections the DoS cap feeds (spec/012 §Keyword-interning


### PR DESCRIPTION
Prunes four stale/vestigial residues in the routing artefact (pre-alpha, no back-compat). Implements **rf2-6qclsc**. Each removal target was verified genuinely stale before editing; no item was forced.

## What changed

1. **`deps.edn` stale runtime-db doc.** The per-feature-split comment claimed `:scroll-positions` / `:scroll-positions-order` / `:nav-token-counter` / `:pending-nav-counter` sit as runtime-db siblings under `[:rf.runtime/routing ...]`. They moved host-side (rf2-1hncp2 / rf2-oosjmh); only the durable `:current` slice and the local-subscribable `:pending-navigation` are runtime-db. Rewrote the comment to match `nav-counters/routing-state-classification` (the canonical source of truth). The source comments, the `:rf/route` sub doc (`routing.cljc:307`), and `spec/012-Routing.md` were already correct — no change there.

2. **Stale `url-changed` test vocabulary.** The URL-driven event is `:rf.route/transitioned`; there is no `:rf.route/url-changed` event in src. Renamed the `url-changed-*` deftests + comment references in `routing_navigation_test.clj` (9 sites) and `routing_concurrency_stress_test.clj` (3 sites) to `transitioned-*`. Corrected the self-referential pre-rename parenthetical in `routing_history_cljs_test.cljs` (a blanket audit rename, cb0a7e420, had collapsed `pre-rename: :rf.route/url-changed` into the post-rename name) — the deliberate historical migration note is retained per the acceptance criteria.

3. **Two drifting `reset-runtime` fixture copies.** `route_link_test.clj` now uses `re-frame.routing-test-support/reset-runtime` directly (no suite-specific extras). `routing_concurrency_stress_test.clj` wraps it with its suite-specific `(trace/clear-listeners!)` layer. Both local copies had silently dropped the ssr / test-support `:reload` and the host-side scroll / nav-counter cache resets — exactly the drift risk the bead flagged.

4. **Silent browser no-op.** Removed the dead `real-browser?` fixture skip in `routing_history_cljs_test.cljs`. A `-cljs-test` ns is discovered only by the `:node-test` build (`:ns-regexp "cljs-test$"`); `:browser-test` is narrowed to `-dom-cljs-test$` (rf2-2hrj8), so the skip guarded an impossible path. The replacement comment documents the node-only, stub-based intent. `shadow-cljs.edn` unchanged (already correct).

No spec, `shadow-cljs.edn`, or `docs/` files touched — all changes are within `implementation/routing`.

## Rejected items

None. All four findings' premises verified true.

## Quality gates

- `clojure -M:test` (routing JVM): **251 tests, 1240 assertions, 0 failures, 0 errors** ✓
- `clojure -M:test -i :stress` (routing stress, RF2_KSBUR_STRESS_ITERS=50): **3 tests, 73 assertions, 0 failures, 0 errors** ✓ (confirms the wrapped shared fixture works under contention)
- `npm run test:cljs` (node-runtime CLJS, incl. `routing-history-cljs-test`): **7073 tests, 29103 assertions, 0 failures, 0 errors** ✓
- Docs gate: not applicable (no `docs/` touched).

Closes rf2-6qclsc.
